### PR TITLE
Nested-path surface: bracket-grammar discoverability + descendable reads

### DIFF
--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -210,13 +210,21 @@ public static class ReadEngine
     static readonly string[] IdentityFieldNames = { "Name", "EditorID", "Title" };
 
     /// <summary>Emit one target path, expanding container/substruct contents up to <paramref name="depth"/>
-    /// levels. A miss surfaces the same bracket-aware note the leaf read uses.</summary>
+    /// levels. A miss surfaces the same bracket-aware note the leaf read uses. The body is wrapped in the same
+    /// per-field fault isolation depth-1 <see cref="ReadLeaf"/> gives (Q3): a throw while navigating OR expanding
+    /// this one target (an unparseable nested getter, an enumerator that faults mid-list, an ambiguous identity
+    /// reflection) names itself "(unreadable …)" and never escapes the record read — so one bad field can't crash
+    /// a whole-record depth dump. Lines already emitted before a mid-expansion fault are real reads and are kept.</summary>
     static void EmitWithDepth(object record, string path, int depth, List<FieldValue> sink, ref int budget)
     {
-        var seg = path.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        var nav = NavigateValue(record, seg);
-        if (!nav.ok) { Emit(sink, ref budget, new FieldValue(path, false, null, nav.note)); return; }
-        Expand(nav.val, nav.type, nav.parent, path, depth, sink, ref budget);
+        try
+        {
+            var seg = path.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            var nav = NavigateValue(record, seg);
+            if (!nav.ok) { Emit(sink, ref budget, new FieldValue(path, false, null, nav.note)); return; }
+            Expand(nav.val, nav.type, nav.parent, path, depth, sink, ref budget);
+        }
+        catch (Exception ex) { Emit(sink, ref budget, new FieldValue(path, false, null, $"(unreadable: {ex.Message})")); }
     }
 
     /// <summary>Recursively emit <paramref name="val"/> at <paramref name="path"/>: a value leaf → its token;

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -98,21 +98,13 @@ public static class ReadEngine
         var typeName = RecordNaming.StripGetterInterface(WriteEngine.PrimaryGetter(target.GetType())?.Name ?? "I?Getter");
         Console.WriteLine($"{typeName}  {target.FormKey}  ({target.EditorID ?? "<no editorid>"})");
 
-        if (paths.Count > 0)
-        {
-            foreach (var p in paths)
-            {
-                var seg = p.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-                Console.WriteLine($"  {p} = {ReadLeaf(target, seg)}");
-            }
-            return 0;
-        }
-
-        // Whole-record dump (one level): every modeled field, fault-isolated per field. The CORPUS is the
-        // authoritative modeled-field set (infra-free by construction — it's what the read-proof drives); fall
-        // back to reflection (Loqui-filtered) only when the corpus isn't built.
-        foreach (var name in ModeledFieldNames(typeName, target.GetType()))
-            Console.WriteLine($"  {name} = {ReadLeaf(target, new[] { name })}");
+        // --depth N (default 1): depth>=2 expands list/dict/substruct contents (descendable reads). With
+        // --path it expands those targets; without, the whole-record dump. Routes through the SAME ReadFields
+        // the MCP read tools call, so the harness and the product stay in lockstep.
+        var depth = int.TryParse(f.GetValueOrDefault("depth"), out var dN) && dN > 0 ? dN : 1;
+        var rf = ReadFields(target, paths.Count > 0 ? paths : null, depth);
+        foreach (var fv in rf.Fields)
+            Console.WriteLine($"  {fv.Path} = {(fv.HasValue ? fv.Token : fv.Note)}");
         return 0;
     }
 
@@ -122,16 +114,27 @@ public static class ReadEngine
     /// proven internal <see cref="ReadLeaf"/> (the round-trip oracle drives it), so the server's reads inherit the
     /// read-proof by construction. Per-leaf fault isolation (Q3): an unreadable field names itself in its
     /// <see cref="FieldValue.Note"/>, never throws out of the record read.</summary>
-    public static RecordFields ReadFields(IMajorRecordGetter record, IReadOnlyList<string>? paths = null)
+    public static RecordFields ReadFields(IMajorRecordGetter record, IReadOnlyList<string>? paths = null, int depth = 1)
     {
         var typeName = RecordNaming.StripGetterInterface(WriteEngine.PrimaryGetter(record.GetType())?.Name ?? "I?Getter");
         var targets = paths is { Count: > 0 } ? (IEnumerable<string>)paths : ModeledFieldNames(typeName, record.GetType());
         var fields = new List<FieldValue>();
-        foreach (var p in targets)
+        if (depth <= 1)
         {
-            var seg = p.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            var r = ReadLeaf(record, seg);
-            fields.Add(new FieldValue(p, r.HasValue, r.HasValue ? r.Token : null, r.HasValue ? null : r.Note));
+            // depth 1 (default) — UNCHANGED one-level read: the proven get_field/dump path the round-trip
+            // oracle drives (ReadLeaf). Descendable expansion (depth>=2) is an additive sibling below, so
+            // the oracle-critical leaf path is never touched.
+            foreach (var p in targets)
+            {
+                var seg = p.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                var r = ReadLeaf(record, seg);
+                fields.Add(new FieldValue(p, r.HasValue, r.HasValue ? r.Token : null, r.HasValue ? null : r.Note));
+            }
+        }
+        else
+        {
+            int budget = MaxExpandNodes;
+            foreach (var p in targets) EmitWithDepth(record, p, depth, fields, ref budget);
         }
         return new RecordFields(typeName, record.FormKey.ToString(), record.EditorID, fields);
     }
@@ -154,7 +157,7 @@ public static class ReadEngine
             {
                 var (segName, segKey) = WriteEngine.ParseSegment(path[i]);
                 var p = WriteEngine.ResolveProperty(current!.GetType(), segName);
-                if (p is null) return LeafRead.None($"(no field {segName})");
+                if (p is null) return LeafRead.None(NoFieldNote(current, segName, i > 0 ? WriteEngine.ParseSegment(path[i - 1]).name : null));
                 current = segKey is null
                     ? p.GetValue(current)                                  // descend a substruct (read-only)
                     : WriteEngine.StepIntoElement(current, p, segName, segKey); // collnav (handles IReadOnly*)
@@ -163,7 +166,7 @@ public static class ReadEngine
 
             var (leafName, leafKey) = WriteEngine.ParseSegment(path[^1]);
             var leaf = WriteEngine.ResolveProperty(current!.GetType(), leafName);
-            if (leaf is null) return LeafRead.None($"(no field {leafName})");
+            if (leaf is null) return LeafRead.None(NoFieldNote(current, leafName, path.Length >= 2 ? WriteEngine.ParseSegment(path[^2]).name : null));
             if (leafKey is not null)
             {
                 // The leaf brackets a collection element (Keywords[0]) — step in and emit the element.
@@ -173,6 +176,194 @@ public static class ReadEngine
             return EmitToken(leaf.GetValue(current), leaf.PropertyType, current);
         }
         catch (Exception ex) { return LeafRead.None($"(unreadable: {ex.Message})"); }
+    }
+
+    /// <summary>A "no such field" note that, when the owner is a collection, points the caller at bracket
+    /// indexing — the common <c>.0</c>-vs-<c>[0]</c> confusion (the read analog of the write pre-flight's
+    /// bracket hint in <c>CorpusRulebook</c>). Brackets are how you step into a list/dict element mid-path;
+    /// a bare dotted <c>.0</c> is parsed as a field name and dead-ends here.</summary>
+    static string NoFieldNote(object owner, string segName, string? precedingField)
+    {
+        bool ownerIsCollection = owner is System.Collections.IDictionary
+            || (owner is System.Collections.IEnumerable && owner is not string);
+        if (ownerIsCollection)
+        {
+            var pf = precedingField ?? "<field>";
+            return $"(no field '{segName}': '{pf}' is a list/dict — index an element with brackets, " +
+                   $"e.g. '{pf}[{segName}]', not '{pf}.{segName}')";
+        }
+        return $"(no field {segName})";
+    }
+
+    // ======================================================================
+    //  DESCENDABLE READS (depth>=2) — enumerate list/dict/substruct CONTENTS so element indices and
+    //  sub-fields are discoverable without hand-probing each [i]. Additive: navigation reuses the same
+    //  engine walk (ParseSegment/ResolveProperty/StepIntoElement) and EmitToken as the leaf path, but the
+    //  proven depth-1 ReadLeaf is untouched. Bounded by MaxExpandNodes (Q3 — explicit truncation note).
+    // ======================================================================
+
+    /// <summary>Max FieldValue lines one descendable read will GENERATE (separate from the renderer's char
+    /// cap) — a guard so depth-expanding a huge container can't build a runaway result. Over it, a single
+    /// truncation note is emitted (Q3 — bounded, never silent).</summary>
+    internal const int MaxExpandNodes = 2000;
+
+    static readonly string[] IdentityFieldNames = { "Name", "EditorID", "Title" };
+
+    /// <summary>Emit one target path, expanding container/substruct contents up to <paramref name="depth"/>
+    /// levels. A miss surfaces the same bracket-aware note the leaf read uses.</summary>
+    static void EmitWithDepth(object record, string path, int depth, List<FieldValue> sink, ref int budget)
+    {
+        var seg = path.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var nav = NavigateValue(record, seg);
+        if (!nav.ok) { Emit(sink, ref budget, new FieldValue(path, false, null, nav.note)); return; }
+        Expand(nav.val, nav.type, nav.parent, path, depth, sink, ref budget);
+    }
+
+    /// <summary>Recursively emit <paramref name="val"/> at <paramref name="path"/>: a value leaf → its token;
+    /// a link → its note (not opened); a container/substruct → an identity-enriched summary line, then (while
+    /// depth allows) one child line per element (bracketed) or sub-field (dotted), each recursed at depth-1.</summary>
+    static void Expand(object? val, Type declaredType, object parent, string path, int depth, List<FieldValue> sink, ref int budget)
+    {
+        if (budget < 0) return;
+        var leaf = EmitToken(val, declaredType, parent);
+        if (leaf.HasValue) { Emit(sink, ref budget, new FieldValue(path, true, leaf.Token, null)); return; }
+        if (val is null) { Emit(sink, ref budget, new FieldValue(path, false, null, leaf.Note)); return; }
+        // a link (incl. a null FormKey, or an FLOI) is a note, not an openable container/substruct.
+        if (val is IFormLinkGetter || WriteEngine.IsFormLinkOrIndex(Nullable.GetUnderlyingType(declaredType) ?? declaredType))
+        { Emit(sink, ref budget, new FieldValue(path, false, null, leaf.Note)); return; }
+
+        // a container or substruct — summarise (with an element identity where we can), then maybe open it.
+        if (!Emit(sink, ref budget, new FieldValue(path, false, null, ElementSummary(val)))) return;
+        if (depth <= 1) return;
+
+        if (val is System.Collections.IDictionary dict)
+        {
+            foreach (System.Collections.DictionaryEntry e in dict)
+            {
+                if (budget < 0) return;
+                Expand(e.Value, e.Value?.GetType() ?? typeof(object), dict, $"{path}[{e.Key}]", depth - 1, sink, ref budget);
+            }
+        }
+        else if (val is System.Collections.IEnumerable seq and not string)
+        {
+            int i = 0;
+            foreach (var item in seq)
+            {
+                if (budget < 0) return;
+                Expand(item, item?.GetType() ?? typeof(object), val, $"{path}[{i}]", depth - 1, sink, ref budget);
+                i++;
+            }
+        }
+        else
+        {
+            // substruct — open its modeled (Loqui-filtered) fields. Reflection, not the corpus: display-only,
+            // and substructs aren't corpus-keyed by a name we hold here.
+            foreach (var fname in ReflectedFieldNames(val.GetType()))
+            {
+                if (budget < 0) return;
+                var prop = WriteEngine.ResolveProperty(val.GetType(), fname);
+                object? fv; try { fv = prop?.GetValue(val); } catch { continue; }
+                Expand(fv, prop?.PropertyType ?? typeof(object), val, $"{path}.{fname}", depth - 1, sink, ref budget);
+            }
+        }
+    }
+
+    /// <summary>Append a line, decrementing the generation budget; at exhaustion emit ONE truncation note and
+    /// stop (returns false thereafter so callers unwind). Q3: the cut is named, never silent.</summary>
+    static bool Emit(List<FieldValue> sink, ref int budget, FieldValue fv)
+    {
+        if (budget < 0) return false;
+        if (budget == 0)
+        {
+            sink.Add(new FieldValue("…", false, null,
+                $"(expansion truncated at {MaxExpandNodes} lines — narrow with a field path or a lower depth)"));
+            budget = -1;
+            return false;
+        }
+        sink.Add(fv); budget--; return true;
+    }
+
+    /// <summary>Navigate a path READ-ONLY to its target, returning the live value object (+ declared type +
+    /// owning parent) for recursion, or a miss note. Same walk as <see cref="ReadLeaf"/> but yields the object
+    /// instead of a token, so the expander can descend into it. Fault-isolated (Q3).</summary>
+    static (bool ok, object? val, Type type, object parent, string? note) NavigateValue(object record, string[] path)
+    {
+        try
+        {
+            object current = record;
+            for (int i = 0; i < path.Length - 1; i++)
+            {
+                var (segName, segKey) = WriteEngine.ParseSegment(path[i]);
+                var p = WriteEngine.ResolveProperty(current.GetType(), segName);
+                if (p is null) return (false, null, typeof(object), current,
+                    NoFieldNote(current, segName, i > 0 ? WriteEngine.ParseSegment(path[i - 1]).name : null));
+                var next = segKey is null ? p.GetValue(current) : WriteEngine.StepIntoElement(current, p, segName, segKey);
+                if (next is null) return (false, null, typeof(object), record, AbsentNote);
+                current = next;
+            }
+            var (leafName, leafKey) = WriteEngine.ParseSegment(path[^1]);
+            var leaf = WriteEngine.ResolveProperty(current.GetType(), leafName);
+            if (leaf is null) return (false, null, typeof(object), current,
+                NoFieldNote(current, leafName, path.Length >= 2 ? WriteEngine.ParseSegment(path[^2]).name : null));
+            if (leafKey is not null)
+            {
+                var elem = WriteEngine.StepIntoElement(current, leaf, leafName, leafKey);
+                return (true, elem, elem.GetType(), current, null);
+            }
+            return (true, leaf.GetValue(current), leaf.PropertyType, current, null);
+        }
+        catch (Exception ex) { return (false, null, typeof(object), record, $"(unreadable: {ex.Message})"); }
+    }
+
+    /// <summary>A compact summary for a container/struct value: for a collection, the count form
+    /// (<see cref="SummariseContainer"/>); for a struct, <c>[TypeName]</c> plus a representative identity
+    /// field (Name/EditorID/Title) where present — so a list line like
+    /// <c>Properties[5] = [ScriptObjectProperty] Name=DAK_HorseBuyPerk</c> reveals which element is which.</summary>
+    static string ElementSummary(object val)
+    {
+        if (val is System.Collections.IEnumerable && val is not string) return SummariseContainer(val);
+        var t = val.GetType();
+        var typeName = RecordNaming.StripGetterInterface(RecordNaming.StripOverlay(t.Name));
+        foreach (var idName in IdentityFieldNames)
+        {
+            var p = t.GetProperty(idName, BindingFlags.Public | BindingFlags.Instance);
+            if (p is null || p.GetIndexParameters().Length != 0) continue;
+            object? iv; try { iv = p.GetValue(val); } catch { continue; }
+            var s = iv switch { null => null, string str => str, IFormLinkGetter fl => fl.FormKey.ToString(), _ => iv.ToString() };
+            if (!string.IsNullOrEmpty(s)) return $"[{typeName}] {idName}={s}";
+        }
+        return $"[{typeName}]";
+    }
+
+    /// <summary>Public-instance modeled field names off a runtime type (Loqui infra filtered) — the reflection
+    /// sibling of <see cref="ModeledFieldNames"/> for substructs (which aren't corpus-keyed by a name we hold
+    /// here). Best-effort, display-only.</summary>
+    static IEnumerable<string> ReflectedFieldNames(Type runtimeType)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var primary = WriteEngine.PrimaryGetter(runtimeType);
+        var ifaces = new List<Type>();
+        if (primary is not null) { ifaces.Add(primary); ifaces.AddRange(primary.GetInterfaces()); }
+        else { ifaces.Add(runtimeType); ifaces.AddRange(runtimeType.GetInterfaces()); }
+        foreach (var iface in ifaces)
+            foreach (var p in iface.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+                if (p.GetIndexParameters().Length == 0
+                    && p.DeclaringType?.Namespace?.StartsWith("Loqui", StringComparison.Ordinal) != true
+                    && !IsInfrastructure(p)
+                    && seen.Add(p.Name))
+                    yield return p.Name;
+    }
+
+    /// <summary>Drop Loqui/Mutagen plumbing members that aren't real data fields — the translation/registration
+    /// properties the corpus omits but raw reflection surfaces (e.g. a substruct's <c>BinaryWriteTranslator</c>).
+    /// Keeps reflective substruct expansion as clean as the corpus-driven whole-record dump.</summary>
+    static bool IsInfrastructure(PropertyInfo p)
+    {
+        if (p.Name is "BinaryWriteTranslator" or "Registration" or "StaticRegistration"
+            or "CommonInstance" or "CommonSetterInstance" or "CommonSetterTranslationInstance") return true;
+        var tn = p.PropertyType.Name;
+        return tn.Contains("BinaryWriteTranslat", StringComparison.Ordinal)
+            || tn.EndsWith("BinaryTranslation", StringComparison.Ordinal);
     }
 
     // ======================================================================

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -244,12 +244,21 @@ public static class ReadEngine
         if (!Emit(sink, ref budget, new FieldValue(path, false, null, ElementSummary(val)))) return;
         if (depth <= 1) return;
 
-        if (val is System.Collections.IDictionary dict)
+        // Classify dict-vs-list the SAME way the navigation does (StepIntoElement) — by the GENERIC dictionary
+        // interfaces via ClosedInterface, not a separate non-generic System.Collections.IDictionary cast — so the
+        // browse view and the read/write path can't drift (a getter dict need not expose the non-generic interface).
+        // A generic dict enumerates as KeyValuePair<,>; Key/Value come off each pair.
+        if (WriteEngine.ClosedInterface(val.GetType(), typeof(IDictionary<,>)) is not null
+            || WriteEngine.ClosedInterface(val.GetType(), typeof(IReadOnlyDictionary<,>)) is not null)
         {
-            foreach (System.Collections.DictionaryEntry e in dict)
+            foreach (var entry in (System.Collections.IEnumerable)val)
             {
                 if (budget < 0) return;
-                Expand(e.Value, e.Value?.GetType() ?? typeof(object), dict, $"{path}[{e.Key}]", depth - 1, sink, ref budget);
+                if (entry is null) continue;
+                var et = entry.GetType();
+                var key = et.GetProperty("Key", BindingFlags.Public | BindingFlags.Instance)?.GetValue(entry);
+                var ev = et.GetProperty("Value", BindingFlags.Public | BindingFlags.Instance)?.GetValue(entry);
+                Expand(ev, ev?.GetType() ?? typeof(object), val, $"{path}[{key}]", depth - 1, sink, ref budget);
             }
         }
         else if (val is System.Collections.IEnumerable seq and not string)

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -302,7 +302,7 @@ public sealed class LoadOrderService : IDisposable
     /// named <paramref name="plugin"/>'s version; with <paramref name="conflictTree"/> also returns the ordered
     /// touching-plugin list. Honest, recoverable errors (Q3): not-in-order, plugin-doesn't-touch, fetch
     /// inconsistency — never a silent empty result.</summary>
-    public ReadOutcome ResolveRead(FormKey fk, string? plugin, IReadOnlyList<string>? fields, bool conflictTree)
+    public ReadOutcome ResolveRead(FormKey fk, string? plugin, IReadOnlyList<string>? fields, bool conflictTree, int depth = 1)
     {
         var resolver = Resolver;
         var winner = resolver.ResolveWinner(fk);
@@ -317,7 +317,7 @@ public sealed class LoadOrderService : IDisposable
                 ? $"Winner '{winner.Value.WinnerPlugin}' did not yield {fk} on fetch — a load-order inconsistency."
                 : $"Plugin '{plugin}' does not define {fk} (it does not touch this record). The winner is '{winner.Value.WinnerPlugin}'.");
 
-        var record = ReadEngine.ReadFields(rec, fields);                  // materialise while the session (overlay) is open
+        var record = ReadEngine.ReadFields(rec, fields, depth);           // materialise while the session (overlay) is open
         var touching = conflictTree ? resolver.TouchingPlugins(fk) : null;
         return new ReadOutcome(fk, record, source, winner.Value.WinnerPlugin, winner.Value.OverrideDepth, touching, null);
     }
@@ -359,7 +359,7 @@ public sealed class LoadOrderService : IDisposable
     /// <summary>Resolve+read many records in one call (housecarl_batch_record_detail). Each formid runs the same
     /// <see cref="ResolveRead"/> path, so a bad/absent formid yields a per-item recoverable error (Q3) without
     /// failing the batch. Returns one <see cref="ReadOutcome"/> per input, in order.</summary>
-    public IReadOnlyList<ReadOutcome> ResolveBatch(IReadOnlyList<string> formids, IReadOnlyList<string>? fields, bool conflictTree)
+    public IReadOnlyList<ReadOutcome> ResolveBatch(IReadOnlyList<string> formids, IReadOnlyList<string>? fields, bool conflictTree, int depth = 1)
     {
         var outcomes = new List<ReadOutcome>(formids.Count);
         foreach (var raw in formids)
@@ -367,7 +367,7 @@ public sealed class LoadOrderService : IDisposable
             FormKey fk;
             try { fk = FormKey.Factory(raw.Trim()); }
             catch (Exception ex) { outcomes.Add(ReadOutcome.Fail(default, $"bad FormID '{raw}': {ex.Message}")); continue; }
-            outcomes.Add(ResolveRead(fk, null, fields, conflictTree));
+            outcomes.Add(ResolveRead(fk, null, fields, conflictTree, depth));
         }
         return outcomes;
     }

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -30,8 +30,10 @@ public static class ReadTools
             string formid,
         [Description("Optional. Read THIS plugin's version of the record instead of the load-order winner (a filename, e.g. 'Requiem.esp'). Useful to inspect a specific override.")]
             string? plugin = null,
-        [Description("Optional. Dotted field paths to read (e.g. 'BasicStats.Damage', 'Name', 'Keywords'). Omit to dump every modeled field one level deep.")]
+        [Description("Optional. Dotted field paths to read (e.g. 'BasicStats.Damage', 'Name', 'Keywords'). Index into a list/dict element with BRACKETS, e.g. 'Effects[0].Data.Magnitude' or 'VirtualMachineAdapter.Aliases[0].Scripts[0].Properties[5].Name' — a bare '.0' is read as a field name, not an index. Omit to dump every modeled field one level deep (pass depth= to expand list/dict contents).")]
             string[]? fields = null,
+        [Description("Optional. Expansion depth for list/dict/substruct CONTENTS (default 1 = one level, a container shown as just a count like '[List: 22 item(s)]'). depth=2 enumerates each element with its index + an identity, e.g. 'VirtualMachineAdapter.Aliases[0].Scripts[0].Properties[5] = [ScriptObjectProperty] Name=DAK_HorseBuyPerk' — so you can SEE indices/contents without probing each [i]. Higher depth opens deeper. Pair with a fields= path to expand only that subtree; on a whole-record dump it expands every container (bounded, with an explicit truncation note).")]
+            int depth = 1,
         [Description("When true, also return the ordered list of every plugin that touches this record (winner last) and the winner-relative field diff for each.")]
             bool conflict_tree = false,
         [Description("Optional. Max characters before the diff is cut with an explicit notice (never silent). 0 = the server default (~80k). Raise to see a very deep conflict tree in full.")]
@@ -42,7 +44,7 @@ public static class ReadTools
         try { fk = FormKey.Factory(formid.Trim()); }
         catch (Exception ex) { return $"error: bad FormID '{formid}': {ex.Message}. Expected 'XXXXXX:Plugin.esp', e.g. '0F1AC1:Skyrim.esm'."; }
 
-        var outcome = svc.ResolveRead(fk, plugin, fields, conflict_tree);
+        var outcome = svc.ResolveRead(fk, plugin, fields, conflict_tree, depth <= 0 ? 1 : depth);
         return Wire.RenderRecord(svc, outcome, fields, conflict_tree, max_chars);
     }
 
@@ -58,8 +60,10 @@ public static class ReadTools
         LoadOrderService svc,
         [Description("The FormIDs to read, each 'XXXXXX:Plugin.esp'. Resolved in order; results are returned in the same order.")]
             string[] formids,
-        [Description("Optional. Dotted field paths to read for EVERY record (e.g. 'Name', 'BasicStats.Damage'). Omit to dump every modeled field one level deep per record.")]
+        [Description("Optional. Dotted field paths to read for EVERY record (e.g. 'Name', 'BasicStats.Damage'); index a list/dict element with BRACKETS, e.g. 'Effects[0].Data.Magnitude'. Omit to dump every modeled field one level deep per record.")]
             string[]? fields = null,
+        [Description("Optional. Expansion depth for list/dict/substruct CONTENTS per record (default 1). depth=2 enumerates each container's elements with index + identity (see housecarl_read_record). Bounded per record with an explicit truncation note.")]
+            int depth = 1,
         [Description("When true, include each record's touching-plugin list (winner last) + winner-relative field diff.")]
             bool conflict_tree = false,
         [Description("Optional. Max characters before the response stops with an explicit 'rendered X of N' notice. 0 = the server default (~80k).")]
@@ -67,7 +71,7 @@ public static class ReadTools
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         if (formids is null || formids.Length == 0) return "error: formids is empty. Pass one or more 'XXXXXX:Plugin.esp' FormIDs.";
-        var outcomes = svc.ResolveBatch(formids, fields, conflict_tree);
+        var outcomes = svc.ResolveBatch(formids, fields, conflict_tree, depth <= 0 ? 1 : depth);
         return Wire.RenderBatch(svc, outcomes, fields, conflict_tree, max_chars);
     }
 
@@ -129,7 +133,7 @@ static class Wire
     {
         if (o.Error is not null) return "error: " + o.Error;
         var sb = new StringBuilder();
-        AppendRecord(sb, o);
+        AppendRecord(sb, o, Cap(maxChars));
         if (conflictTree) AppendConflictTree(sb, svc, o, fields, Cap(maxChars));
         return sb.ToString().TrimEnd('\n');
     }
@@ -152,7 +156,7 @@ static class Wire
             }
             sb.Append('\n');
             if (o.Error is not null) sb.Append("error: ").Append(o.Error).Append('\n');
-            else { AppendRecord(sb, o); if (conflictTree) AppendConflictTree(sb, svc, o, fields, cap); }
+            else { AppendRecord(sb, o, cap); if (conflictTree) AppendConflictTree(sb, svc, o, fields, cap); }
             rendered++;
         }
         return sb.ToString().TrimEnd('\n');
@@ -185,7 +189,7 @@ static class Wire
                 var o = svc.ResolveRead(fk, null, fields, conflictTree);
                 sb.Append('\n');
                 if (o.Error is not null) sb.Append(fk).Append(": error: ").Append(o.Error).Append('\n');
-                else { AppendRecord(sb, o); if (conflictTree) AppendConflictTree(sb, svc, o, fields, cap); }
+                else { AppendRecord(sb, o, cap); if (conflictTree) AppendConflictTree(sb, svc, o, fields, cap); }
             }
             else
             {
@@ -202,7 +206,7 @@ static class Wire
 
     // ---- shared building blocks ---------------------------------------------------------------------
 
-    static void AppendRecord(StringBuilder sb, ReadOutcome o)
+    static void AppendRecord(StringBuilder sb, ReadOutcome o, int cap)
     {
         var r = o.Record!;
         sb.Append("type=").Append(r.Type)
@@ -211,8 +215,18 @@ static class Wire
           .Append("  winner=").Append(o.WinnerPlugin)
           .Append("  override_depth=").Append(o.OverrideDepth).Append('\n');
         sb.Append("fields (from ").Append(o.SourcePlugin).Append("):\n");
-        foreach (var f in r.Fields)
+        for (int i = 0; i < r.Fields.Count; i++)
+        {
+            if (sb.Length >= cap)                                          // depth= can produce many lines — cap them (Q3)
+            {
+                sb.Append("  ... [truncated: showing ").Append(i).Append(" of ").Append(r.Fields.Count)
+                  .Append(" field lines at max_chars=").Append(cap)
+                  .Append("; narrow with fields=, lower depth=, or raise max_chars]\n");
+                break;
+            }
+            var f = r.Fields[i];
             sb.Append("  ").Append(f.Path).Append(" = ").Append(f.HasValue ? f.Token : f.Note).Append('\n');
+        }
     }
 
     /// <summary>The conflict tree: the ordered touching-plugin list, then (when >1 plugin touches) the

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -32,7 +32,7 @@ public static class WriteTools
         LoadOrderService svc,
         [Description("The record's FormID as 'XXXXXX:Plugin.esp' (6 hex digits, the defining master's filename).")]
             string formid,
-        [Description("Dotted field path to edit, e.g. 'BasicStats.Damage', 'Name', 'Keywords'.")]
+        [Description("Dotted field path to edit, e.g. 'BasicStats.Damage', 'Name', 'Keywords'. Step into a list/dict element MID-PATH with brackets, e.g. 'Effects[0].Data.Magnitude' or 'VirtualMachineAdapter.Aliases[0].Scripts[0].Properties'. At the LEAF, edit a collection element with verb + key (SetAtIndex/Remove by index, Set/Remove by dict key) — not brackets.")]
             string field_path,
         [Description("The value, coerced to the field's type: a number, an enum name (e.g. 'OneHanded'), or a FormID 'XXXXXX:Plugin.esp' for a reference. Omit only for Remove.")]
             string? value = null,
@@ -221,7 +221,7 @@ public sealed record BulkOp
     [JsonPropertyName("formid"), Description("The record's FormID 'XXXXXX:Plugin.esp'.")]
     public string? Formid { get; init; }
 
-    [JsonPropertyName("field_path"), Description("Dotted field path, e.g. 'BasicStats.Damage' or 'Entries'.")]
+    [JsonPropertyName("field_path"), Description("Dotted field path, e.g. 'BasicStats.Damage' or 'Entries'. Step into a list/dict element mid-path with brackets, e.g. 'Effects[0].Data.Magnitude'; at the LEAF use verb + key, not brackets.")]
     public string? FieldPath { get; init; }
 
     [JsonPropertyName("verb"), Description("Set (default) | Add | Remove | SetAtIndex | ReplaceAll | Merge.")]


### PR DESCRIPTION
## Summary

The dotted-path engine already traverses deep nested lists for **both read and write** via `[N]` bracket syntax (e.g. `VirtualMachineAdapter.Aliases[0].Scripts[0].Properties`). The gap was that this capability was effectively **unreachable in practice**: the natural `.0` attempt fails opaquely, bracket indexing was undocumented in the tool descriptions, and the read renderer never showed list/dict contents — so a caller couldn't discover element indices without probing each `[i]` by hand.

This PR makes the existing capability discoverable and its contents visible. It does **not** add traversal (that already exists) and does **not** change record coverage.

## Fix 1 — discoverability
- A read that dots into a collection (`Aliases.0`) now returns an actionable note instead of `(no field 0)`:
  `(no field '0': 'Aliases' is a list/dict — index an element with brackets, e.g. 'Aliases[0]', not 'Aliases.0')`. This is the read analog of the bracket hint the write pre-flight (`CorpusRulebook`) already emits.
- Bracket indexing is now documented in the `read_record` / `batch_record_detail` `fields=` and `set_field` / `bulk_apply` `field_path=` tool descriptions.

## Fix 2 — descendable reads (`depth=`)
- `housecarl_read_record` and `housecarl_batch_record_detail` gain a `depth` parameter (default `1` = the existing one-level dump, unchanged).
- `depth >= 2` enumerates list/dict/substruct **contents**, each element shown with its index and a per-element identity, e.g. `Properties[5] = [ScriptObjectProperty] Name=DAK_HorseBuyPerk` — so indices and contents are discoverable in a single call.

### Design notes
- **Additive / oracle-safe.** The `depth <= 1` path still uses the proven `ReadLeaf`; `depth >= 2` is a separate expander that reuses the same navigation (`ParseSegment` / `ResolveProperty` / `StepIntoElement`) and `EmitToken`, so the read↔write round-trip oracle is untouched.
- **Bounded (Q3).** Generation is capped by `MaxExpandNodes`; rendering is capped by the existing `max_chars` budget. Both truncate with an explicit notice, never silently.
- Loqui/Mutagen infrastructure members (e.g. `BinaryWriteTranslator`) are filtered from reflective substruct expansion so nested output stays as clean as the corpus-driven dump.

## Proof
Exercised via the dev-harness `read` against a real load order (a quest VMAD with 22 script properties):
- the `.0` bracket hint fires;
- `depth=2` enumerates all 22 properties with identities in one call;
- `depth=1` output is unchanged (regression);
- the read↔write round-trip oracle (`read-proof`) is **91/91 byte-stable no-ops, 0 defects** — the read leaf path is intact;
- clean build (0 warnings, 0 errors).

## Deferred
Match-by-name addressing (`[Name=…]`) is intentionally deferred — once `depth=` makes indices visible, index addressing covers the real cases, and it is the highest-risk change (the path parser is shared by read, write, and pre-flight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
