### PR TITLE
External-tool bridge: set_tool_path + compile + BSA riders (3 of 4)

### DIFF
--- a/src/housecarl-core/BsaArchive.cs
+++ b/src/housecarl-core/BsaArchive.cs
@@ -1,0 +1,120 @@
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+
+namespace HousecarlCore;
+
+/// <summary>The parsed result of a BSArch -list. <see cref="RunError"/> non-null ⇒ BSArch couldn't be RUN (bad path /
+/// timeout). <see cref="Success"/> means the archive was read and the file list matched its declared count.</summary>
+public sealed record BsaListResult(
+    bool Success, string? Format, int DeclaredCount, IReadOnlyList<string> Files, string Raw, string? RunError)
+{
+    public bool Ran => RunError is null;
+}
+
+/// <summary>The result of a BSArch unpack/pack. <see cref="RunError"/> non-null ⇒ BSArch couldn't be run; otherwise
+/// <see cref="Success"/> is decided by the ARTIFACT (dest has files / the .bsa exists), not the exit code.</summary>
+public sealed record BsaResult(bool Success, string Raw, string? RunError)
+{
+    public bool Ran => RunError is null;
+}
+
+/// <summary>
+/// Drives BSArch (zilav/ElminsterAU/Sheson; ships with xEdit) to list / unpack / pack Bethesda .bsa archives — the engine
+/// behind the housecarl_bsa_* tools. Mutagen has no archive surface, so this wraps the external exe (a bounded
+/// ProcessStartInfo + parser). Grounded against the real BSArch v0.9c CLI (measured 2026-06-05):
+///   • list  : `BSArch &lt;archive&gt; -list`  → banner + info block (incl. "Files: N"), a blank line, then N file paths.
+///   • unpack: `BSArch unpack &lt;archive&gt; &lt;folder&gt; -mt`  (WHOLE archive — BSArch has no per-file extract).
+///   • pack  : `BSArch pack &lt;folder&gt; &lt;archive&gt; -sse [-z] -mt`  (-sse = Skyrim SE; -z compresses but BREAKS
+///             sounds/voices, so uncompressed is the safe default).
+/// Pure (no DI): the build-time probe drives this exact code against real BSArch + real .bsa.
+/// </summary>
+public static class BsaArchive
+{
+    static readonly Regex FilesCount = new(@"^\s*Files:\s*(\d+)\s*$", RegexOptions.Multiline | RegexOptions.Compiled);
+    static readonly Regex FormatLine = new(@"^\s*Format:\s*(.+?)\s*$", RegexOptions.Multiline | RegexOptions.Compiled);
+
+    /// <summary>List an archive's contents. Robust parse: BSArch prints "Files: N" in the info block, then the N paths as
+    /// the final block — so the file list is the LAST N non-empty lines (immune to banner/info-block variation).</summary>
+    public static BsaListResult List(string bsarchExe, string archive, int timeoutMs = 60_000)
+    {
+        var run = Run(bsarchExe, new[] { archive, "-list" }, timeoutMs);
+        if (run.runError is not null)
+            return new BsaListResult(false, null, 0, Array.Empty<string>(), run.stdout + run.stderr, run.runError);
+
+        var format = FormatLine.Match(run.stdout) is { Success: true } fm2 ? fm2.Groups[1].Value.Trim() : null;
+        var fm = FilesCount.Match(run.stdout);
+        if (!fm.Success)   // no "Files: N" ⇒ not a readable archive (BSArch printed an error / usage)
+            return new BsaListResult(false, format, 0, Array.Empty<string>(), (run.stdout + "\n" + run.stderr).Trim(), null);
+
+        int declared = int.Parse(fm.Groups[1].Value);
+        var nonEmpty = run.stdout.Replace("\r", "").Split('\n').Where(l => l.Trim().Length > 0).ToList();
+        var files = declared > 0 && declared <= nonEmpty.Count
+            ? nonEmpty.Skip(nonEmpty.Count - declared).ToList()
+            : new List<string>();
+        return new BsaListResult(files.Count == declared, format, declared, files, run.stdout, null);
+    }
+
+    /// <summary>Unpack the WHOLE archive into <paramref name="destFolder"/> (created if absent). Success = the folder has
+    /// at least one entry afterwards (BSArch's exit code isn't relied on). "Read a file inside" = unpack, then read it.</summary>
+    public static BsaResult Unpack(string bsarchExe, string archive, string destFolder, int timeoutMs = 300_000)
+    {
+        Directory.CreateDirectory(destFolder);
+        var run = Run(bsarchExe, new[] { "unpack", archive, destFolder, "-mt" }, timeoutMs);
+        if (run.runError is not null) return new BsaResult(false, (run.stdout + run.stderr).Trim(), run.runError);
+        bool ok = Directory.Exists(destFolder) && Directory.EnumerateFileSystemEntries(destFolder).Any();
+        return new BsaResult(ok, (run.stdout + "\n" + run.stderr).Trim(), null);
+    }
+
+    /// <summary>Pack <paramref name="srcFolder"/> into a .bsa at <paramref name="archive"/> with the given format flag
+    /// (e.g. "-sse") and optional compression. Deletes a stale target first so the success check (the .bsa exists, non-empty)
+    /// is honest. NOTE the caller must surface BSArch's caveat: a COMPRESSED archive breaks any sounds/voices it contains.</summary>
+    public static BsaResult Pack(string bsarchExe, string srcFolder, string archive, string formatFlag, bool compress, int timeoutMs = 600_000)
+    {
+        try { if (File.Exists(archive)) File.Delete(archive); } catch { /* best-effort so the success check is honest */ }
+        var args = new List<string> { "pack", srcFolder, archive, formatFlag, "-mt" };
+        if (compress) args.Add("-z");
+        var run = Run(bsarchExe, args, timeoutMs);
+        if (run.runError is not null) return new BsaResult(false, (run.stdout + run.stderr).Trim(), run.runError);
+        bool ok = File.Exists(archive) && new FileInfo(archive).Length > 0;
+        return new BsaResult(ok, (run.stdout + "\n" + run.stderr).Trim(), null);
+    }
+
+    /// <summary>Map a houseCARL format token to a BSArch flag. Default/unknown → -sse (Skyrim Special Edition, the target).</summary>
+    public static string FormatFlag(string? format) => "-" + ((format?.Trim().ToLowerInvariant()) switch
+    {
+        "tes3" or "morrowind" => "tes3",
+        "tes4" or "oblivion" => "tes4",
+        "fo3" => "fo3",
+        "fnv" => "fnv",
+        "tes5" or "le" or "skyrimle" => "tes5",
+        "fo4" => "fo4",
+        "fo4dds" => "fo4dds",
+        "sf1" or "starfield" => "sf1",
+        "sf1dds" => "sf1dds",
+        _ => "sse",   // sse / ae / skyrimse / null / unknown → Skyrim SE
+    });
+
+    static (bool ran, int exit, string stdout, string stderr, string? runError) Run(string exe, IReadOnlyList<string> args, int timeoutMs)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = exe,
+            WorkingDirectory = Path.GetDirectoryName(exe) ?? Environment.CurrentDirectory,
+            RedirectStandardOutput = true, RedirectStandardError = true, UseShellExecute = false, CreateNoWindow = true,
+        };
+        foreach (var a in args) psi.ArgumentList.Add(a);   // one arg each; .NET quotes spaces/semicolons
+
+        Process p;
+        try { p = Process.Start(psi)!; }
+        catch (Exception ex) { return (false, -1, "", "", $"could not run BSArch at '{exe}': {ex.Message}"); }
+
+        var o = p.StandardOutput.ReadToEndAsync();
+        var e = p.StandardError.ReadToEndAsync();
+        if (!p.WaitForExit(timeoutMs))
+        {
+            try { p.Kill(entireProcessTree: true); } catch { /* already gone */ }
+            return (false, -1, "", "", $"BSArch did not finish within {timeoutMs / 1000}s (killed).");
+        }
+        return (true, p.ExitCode, o.GetAwaiter().GetResult(), e.GetAwaiter().GetResult(), null);
+    }
+}

--- a/src/housecarl-core/BsaArchive.cs
+++ b/src/housecarl-core/BsaArchive.cs
@@ -66,17 +66,36 @@ public static class BsaArchive
     }
 
     /// <summary>Pack <paramref name="srcFolder"/> into a .bsa at <paramref name="archive"/> with the given format flag
-    /// (e.g. "-sse") and optional compression. Deletes a stale target first so the success check (the .bsa exists, non-empty)
-    /// is honest. NOTE the caller must surface BSArch's caveat: a COMPRESSED archive breaks any sounds/voices it contains.</summary>
+    /// (e.g. "-sse") and optional compression. NON-DESTRUCTIVE (Aaron 2026-06-06): an existing archive at the target is
+    /// NEVER overwritten unless this run successfully packs a new one — BSArch writes to a houseCARL-internal temp beside
+    /// the target, and only a clean pack (temp exists, non-empty) is moved over the target; any failure (BSArch error,
+    /// timeout, empty output) deletes the temp and leaves the prior .bsa untouched. NOTE the caller must surface BSArch's
+    /// caveat: a COMPRESSED archive breaks any sounds/voices it contains.</summary>
     public static BsaResult Pack(string bsarchExe, string srcFolder, string archive, string formatFlag, bool compress, int timeoutMs = 600_000)
     {
-        try { if (File.Exists(archive)) File.Delete(archive); } catch { /* best-effort so the success check is honest */ }
-        var args = new List<string> { "pack", srcFolder, archive, formatFlag, "-mt" };
+        // Pack to a scratch sibling (keeps the .bsa extension so BSArch is happy); the real target is touched only on success.
+        var dir = Path.GetDirectoryName(archive) ?? Environment.CurrentDirectory;
+        var tmp = Path.Combine(dir, Path.GetFileNameWithoutExtension(archive) + ".houseCARL-tmp.bsa");
+        try { if (File.Exists(tmp)) File.Delete(tmp); } catch { /* stale internal scratch; best-effort */ }
+
+        var args = new List<string> { "pack", srcFolder, tmp, formatFlag, "-mt" };
         if (compress) args.Add("-z");
         var run = Run(bsarchExe, args, timeoutMs);
-        if (run.runError is not null) return new BsaResult(false, (run.stdout + run.stderr).Trim(), run.runError);
-        bool ok = File.Exists(archive) && new FileInfo(archive).Length > 0;
-        return new BsaResult(ok, (run.stdout + "\n" + run.stderr).Trim(), null);
+
+        bool packed = run.runError is null && File.Exists(tmp) && new FileInfo(tmp).Length > 0;
+        if (!packed)   // BSArch couldn't run, or produced no/empty output — leave any prior archive untouched
+        {
+            try { if (File.Exists(tmp)) File.Delete(tmp); } catch { /* best-effort */ }
+            return new BsaResult(false, (run.stdout + "\n" + run.stderr).Trim(), run.runError);
+        }
+
+        try { File.Move(tmp, archive, overwrite: true); }   // success → atomically replace the target (same volume = rename)
+        catch (Exception ex)
+        {
+            try { if (File.Exists(tmp)) File.Delete(tmp); } catch { /* best-effort */ }
+            return new BsaResult(false, (run.stdout + "\n" + run.stderr + $"\ncould not place the packed archive at '{archive}': {ex.Message}").Trim(), null);
+        }
+        return new BsaResult(File.Exists(archive) && new FileInfo(archive).Length > 0, (run.stdout + "\n" + run.stderr).Trim(), null);
     }
 
     /// <summary>Map a houseCARL format token to a BSArch flag. Default/unknown → -sse (Skyrim Special Edition, the target).</summary>

--- a/src/housecarl-core/PapyrusCompile.cs
+++ b/src/housecarl-core/PapyrusCompile.cs
@@ -1,0 +1,111 @@
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+
+namespace HousecarlCore;
+
+/// <summary>One compiler diagnostic — a file/line/col + message parsed off PapyrusCompiler's stderr. Its
+/// <see cref="ToString"/> is the compact "name(line,col): message" the AI fix-loop reads (file basename, since the
+/// full path is long and the AI already knows which script it compiled).</summary>
+public sealed record PapyrusDiagnostic(string File, int Line, int Col, string Message)
+{
+    public override string ToString() => $"{System.IO.Path.GetFileName(File)}({Line},{Col}): {Message}";
+}
+
+/// <summary>The outcome of one compile. <see cref="RunError"/> non-null ⇒ the compiler could NOT be run at all (bad
+/// path / timeout) — distinct from <see cref="Success"/>=false, which is a compile that RAN and reported errors.
+/// <see cref="Success"/> is decided by the .pex existing AND no error diagnostics — NOT the exit code (the CK
+/// compiler returns 0 even on a usage error; measured 2026-06-05).</summary>
+public sealed record CompileResult(
+    bool Success, string ObjectName, string? PexPath, IReadOnlyList<PapyrusDiagnostic> Diagnostics,
+    string Stdout, string Stderr, int ExitCode, string? RunError)
+{
+    public bool Ran => RunError is null;
+}
+
+/// <summary>
+/// Drives the Creation Kit's PapyrusCompiler.exe as a subprocess to compile a .psc → .pex (the engine behind
+/// housecarl_compile_script). NOT Mutagen — Mutagen cannot compile Papyrus (verified 2026-06-05), so this is a bounded
+/// ProcessStartInfo + an output parser, nothing more.
+///
+/// Everything here is grounded in the REAL compiler's behaviour, measured 2026-06-05 against the shipped CK compiler:
+///   • Invocation (Bethesda's own ScriptCompile.bat): `PapyrusCompiler &lt;object&gt; -f="flags.flg" -i="dir;dir" -o="out"`.
+///   • Errors print to STDERR, one per line, as `&lt;fullpath&gt;(line,col): message`.
+///   • A success prints `Batch compile … N succeeded, M failed.` to stdout and writes &lt;object&gt;.pex to -o.
+///   • The EXIT CODE is unreliable (0 on a usage error), so success = the .pex exists AND no error diagnostics.
+/// Pure (no DI): the build-time probe drives this exact code against the real compiler.
+/// </summary>
+public static class PapyrusCompile
+{
+    static readonly Regex DiagLine = new(@"^(?<file>.*?)\((?<line>\d+),(?<col>\d+)\):\s*(?<msg>.*)$", RegexOptions.Compiled);
+
+    /// <summary>Parse PapyrusCompiler stderr into diagnostics. The format is `&lt;fullpath&gt;(line,col): message`, one per
+    /// line (measured against the real compiler). Lines that don't match the shape are ignored (non-diagnostic noise).</summary>
+    public static IReadOnlyList<PapyrusDiagnostic> ParseDiagnostics(string? stderr)
+    {
+        var list = new List<PapyrusDiagnostic>();
+        if (string.IsNullOrEmpty(stderr)) return list;
+        foreach (var raw in stderr.Split('\n'))
+        {
+            var line = raw.TrimEnd('\r');
+            if (line.Length == 0) continue;
+            var m = DiagLine.Match(line);
+            if (!m.Success) continue;
+            list.Add(new PapyrusDiagnostic(
+                m.Groups["file"].Value.Trim(),
+                int.Parse(m.Groups["line"].Value),
+                int.Parse(m.Groups["col"].Value),
+                m.Groups["msg"].Value.Trim()));
+        }
+        return list;
+    }
+
+    /// <summary>Compile ONE object (a script name, no extension — its .psc must be findable in <paramref name="importDirs"/>)
+    /// to a .pex in <paramref name="outputDir"/>. Deletes any stale &lt;object&gt;.pex first so the success check (the .pex
+    /// exists) reflects THIS run honestly (Q3). Reads both output streams asynchronously to avoid the classic pipe
+    /// deadlock. A start failure or a timeout returns a RunError (the compiler couldn't run), never a thrown exception.</summary>
+    public static CompileResult CompileObject(
+        string compilerExe, string objectName, IReadOnlyList<string> importDirs, string outputDir,
+        string flagsFile = "TESV_Papyrus_Flags.flg", int timeoutMs = 120_000)
+    {
+        var pexPath = Path.Combine(outputDir, objectName + ".pex");
+        try { if (File.Exists(pexPath)) File.Delete(pexPath); } catch { /* best-effort: a locked stale pex just means the success check is conservative */ }
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = compilerExe,
+            WorkingDirectory = Path.GetDirectoryName(compilerExe) ?? Environment.CurrentDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        psi.ArgumentList.Add(objectName);
+        psi.ArgumentList.Add($"-f={flagsFile}");
+        psi.ArgumentList.Add($"-i={string.Join(";", importDirs)}");   // one arg; .NET quotes it, so spaces/semicolons in paths survive
+        psi.ArgumentList.Add($"-o={outputDir}");
+
+        Process proc;
+        try { proc = Process.Start(psi)!; }
+        catch (Exception ex)
+        {
+            return new CompileResult(false, objectName, null, Array.Empty<PapyrusDiagnostic>(), "", "", -1,
+                $"could not run the Papyrus compiler at '{compilerExe}': {ex.Message}");
+        }
+
+        var outTask = proc.StandardOutput.ReadToEndAsync();
+        var errTask = proc.StandardError.ReadToEndAsync();
+        if (!proc.WaitForExit(timeoutMs))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { /* already gone */ }
+            return new CompileResult(false, objectName, null, Array.Empty<PapyrusDiagnostic>(), "", "", -1,
+                $"the Papyrus compiler did not finish within {timeoutMs / 1000}s (killed).");
+        }
+        var stdout = outTask.GetAwaiter().GetResult();
+        var stderr = errTask.GetAwaiter().GetResult();
+
+        var diags = ParseDiagnostics(stderr);
+        bool pex = File.Exists(pexPath);
+        bool success = pex && diags.Count == 0;   // NOT proc.ExitCode — unreliable (measured)
+        return new CompileResult(success, objectName, success ? pexPath : null, diags, stdout, stderr, proc.ExitCode, null);
+    }
+}

--- a/src/housecarl-core/PapyrusCompile.cs
+++ b/src/housecarl-core/PapyrusCompile.cs
@@ -12,9 +12,11 @@ public sealed record PapyrusDiagnostic(string File, int Line, int Col, string Me
 }
 
 /// <summary>The outcome of one compile. <see cref="RunError"/> non-null ⇒ the compiler could NOT be run at all (bad
-/// path / timeout) — distinct from <see cref="Success"/>=false, which is a compile that RAN and reported errors.
-/// <see cref="Success"/> is decided by the .pex existing AND no error diagnostics — NOT the exit code (the CK
-/// compiler returns 0 even on a usage error; measured 2026-06-05).</summary>
+/// path / timeout) — distinct from <see cref="Success"/>=false, which is a compile that RAN but produced no .pex.
+/// <see cref="Success"/> is decided by THIS run WRITING the .pex — NOT the exit code (the CK compiler returns 0 even on
+/// a usage error; measured 2026-06-05), and NOT the absence of diagnostics: a .pex that compiled WITH warnings is a
+/// success and the warnings ride along in <see cref="Diagnostics"/> ("if the compiler lets it compile with warnings,
+/// it's good enough" — Aaron 2026-06-06).</summary>
 public sealed record CompileResult(
     bool Success, string ObjectName, string? PexPath, IReadOnlyList<PapyrusDiagnostic> Diagnostics,
     string Stdout, string Stderr, int ExitCode, string? RunError)
@@ -31,7 +33,7 @@ public sealed record CompileResult(
 ///   • Invocation (Bethesda's own ScriptCompile.bat): `PapyrusCompiler &lt;object&gt; -f="flags.flg" -i="dir;dir" -o="out"`.
 ///   • Errors print to STDERR, one per line, as `&lt;fullpath&gt;(line,col): message`.
 ///   • A success prints `Batch compile … N succeeded, M failed.` to stdout and writes &lt;object&gt;.pex to -o.
-///   • The EXIT CODE is unreliable (0 on a usage error), so success = the .pex exists AND no error diagnostics.
+///   • The EXIT CODE is unreliable (0 on a usage error), so success = THIS run WROTE the .pex (warnings are fine).
 /// Pure (no DI): the build-time probe drives this exact code against the real compiler.
 /// </summary>
 public static class PapyrusCompile
@@ -60,15 +62,20 @@ public static class PapyrusCompile
     }
 
     /// <summary>Compile ONE object (a script name, no extension — its .psc must be findable in <paramref name="importDirs"/>)
-    /// to a .pex in <paramref name="outputDir"/>. Deletes any stale &lt;object&gt;.pex first so the success check (the .pex
-    /// exists) reflects THIS run honestly (Q3). Reads both output streams asynchronously to avoid the classic pipe
-    /// deadlock. A start failure or a timeout returns a RunError (the compiler couldn't run), never a thrown exception.</summary>
+    /// to a .pex in <paramref name="outputDir"/>. NON-DESTRUCTIVE (Aaron 2026-06-06): a prior &lt;object&gt;.pex is LEFT in
+    /// place — the user deletes outputs at their convenience, and a failed recompile must never destroy the last good
+    /// build. So instead of deleting it first, success = the .pex was WRITTEN by this run (it newly appeared, or its
+    /// write-time advanced) — an honest signal (Q3) that never touches the file: a successful compile rewrites it, a
+    /// failure leaves it untouched. Reads both output streams asynchronously to avoid the classic pipe deadlock. A start
+    /// failure or a timeout returns a RunError (the compiler couldn't run), never a thrown exception.</summary>
     public static CompileResult CompileObject(
         string compilerExe, string objectName, IReadOnlyList<string> importDirs, string outputDir,
         string flagsFile = "TESV_Papyrus_Flags.flg", int timeoutMs = 120_000)
     {
         var pexPath = Path.Combine(outputDir, objectName + ".pex");
-        try { if (File.Exists(pexPath)) File.Delete(pexPath); } catch { /* best-effort: a locked stale pex just means the success check is conservative */ }
+        // Note the prior .pex's write-time (null ⇒ none) so we can tell "this run wrote it" from "a stale one was already
+        // here" — WITHOUT deleting it. A multi-second compile always advances the write-time past this baseline.
+        DateTime? pexBeforeUtc = File.Exists(pexPath) ? File.GetLastWriteTimeUtc(pexPath) : null;
 
         var psi = new ProcessStartInfo
         {
@@ -104,8 +111,11 @@ public static class PapyrusCompile
         var stderr = errTask.GetAwaiter().GetResult();
 
         var diags = ParseDiagnostics(stderr);
-        bool pex = File.Exists(pexPath);
-        bool success = pex && diags.Count == 0;   // NOT proc.ExitCode — unreliable (measured)
-        return new CompileResult(success, objectName, success ? pexPath : null, diags, stdout, stderr, proc.ExitCode, null);
+        // Success = THIS run WROTE the .pex. Warnings are NON-FATAL: if the compiler still emitted a .pex it's "good
+        // enough" and the diagnostics ride along as warnings. NOT proc.ExitCode (unreliable, measured) and NOT
+        // "no diagnostics" (that wrongly failed a compiled-with-warnings build).
+        bool producedNow = File.Exists(pexPath)
+            && (pexBeforeUtc is null || File.GetLastWriteTimeUtc(pexPath) > pexBeforeUtc.Value);
+        return new CompileResult(producedNow, objectName, producedNow ? pexPath : null, diags, stdout, stderr, proc.ExitCode, null);
     }
 }

--- a/src/housecarl-core/ToolBridge.cs
+++ b/src/housecarl-core/ToolBridge.cs
@@ -1,0 +1,137 @@
+namespace HousecarlCore;
+
+/// <summary>The external tools houseCARL can drive once the user supplies a path — the bridge's dependency set. Each is an
+/// .exe houseCARL shells out to, or a log DIRECTORY it reads. Extensible: a new rider adds an arm here + a catalog row in
+/// <see cref="ToolBridge"/>. Verified 2026-06-05 (source, not memory): Mutagen cannot compile/decompile Papyrus and has no
+/// archive surface, so these are EXTERNAL exes, not engine work.</summary>
+public enum ToolDependency
+{
+    /// <summary>The Creation Kit's PapyrusCompiler.exe — compiles .psc → .pex (housecarl_compile_script). NOT Mutagen.</summary>
+    PapyrusCompiler,
+    /// <summary>BSArch.exe — list / extract / repack .bsa archives (the BSA riders). No canonical home; always prompts.</summary>
+    Bsarch,
+    /// <summary>The Papyrus script-log DIRECTORY (…\My Games\Skyrim Special Edition\Logs\Script) — read for Papyrus triage.</summary>
+    PapyrusLogs,
+    /// <summary>The SKSE crash-log DIRECTORY (Crash Logger SSE / .NET Script Framework) — read for crash diagnosis.</summary>
+    CrashLogs,
+}
+
+/// <summary>Per-dependency metadata: the wire key the user/tool names it by, a human display, whether the path is a
+/// DIRECTORY (a log root) or an .exe FILE, the expected exe stem (a sanity-check the path is the right tool), the one-line
+/// "what it's for", and where to get it (shown in the missing-dependency prompt).</summary>
+public sealed record ToolInfo(
+    ToolDependency Dep, string Key, string Display, bool IsDirectory, string? ExeStem, string Need, string WhereToGet);
+
+/// <summary>
+/// The external-tool catalog + the bridge's pure logic: parse a wire name, VALIDATE a candidate path (Q3 — never silently
+/// accept a wrong one), render the trained MISSING-DEPENDENCY prompt (the forcing function), and AUTO-DETECT canonical
+/// homes. All pure (no DI, no file mutation beyond existence checks), so the build-time probe can exercise it directly;
+/// the runtime wrapper (<see cref="ToolPathResolver"/>) adds saved-path lookup + persistence on top.
+/// </summary>
+public static class ToolBridge
+{
+    static readonly ToolInfo[] All =
+    {
+        new(ToolDependency.PapyrusCompiler, "papyrus_compiler", "the Papyrus compiler (PapyrusCompiler.exe)", false, "papyruscompiler",
+            "compiling .psc scripts to .pex",
+            "it ships with the Creation Kit (Bethesda's free modding tool, on Steam); it's typically at <Skyrim>\\Papyrus Compiler\\PapyrusCompiler.exe"),
+        new(ToolDependency.Bsarch, "bsarch", "BSArch (BSArch.exe)", false, "bsarch",
+            "listing, extracting, and repacking .bsa archives",
+            "BSArch is a standalone tool on Nexus Mods (also bundled with 'Cathedral Assets Optimizer' / 'BSA Browser')"),
+        new(ToolDependency.PapyrusLogs, "papyrus_logs", "the Papyrus script-log folder", true, null,
+            "reading Papyrus script logs for triage",
+            "they're under Documents\\My Games\\Skyrim Special Edition\\Logs\\Script (set bEnableLogging=1 in the ini if the folder is absent)"),
+        new(ToolDependency.CrashLogs, "crash_logs", "the SKSE crash-log folder", true, null,
+            "reading crash logs for diagnosis",
+            "Crash Logger SSE (Nexus) writes them under Documents\\My Games\\Skyrim Special Edition\\SKSE\\Crashlogs"),
+    };
+
+    static readonly Dictionary<ToolDependency, ToolInfo> ByDep = All.ToDictionary(i => i.Dep);
+    static readonly Dictionary<string, ToolDependency> ByKey =
+        All.ToDictionary(i => i.Key, i => i.Dep, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>The catalog entry for a dependency.</summary>
+    public static ToolInfo Info(ToolDependency dep) => ByDep[dep];
+
+    /// <summary>The comma-joined wire keys, for an error listing the valid tools.</summary>
+    public static string WireKeys => string.Join(", ", All.Select(i => i.Key));
+
+    /// <summary>Parse a wire name (case-insensitive) to a dependency; false if it isn't one we know.</summary>
+    public static bool TryParse(string? wire, out ToolDependency dep)
+    {
+        if (!string.IsNullOrWhiteSpace(wire) && ByKey.TryGetValue(wire.Trim(), out dep)) return true;
+        dep = default; return false;
+    }
+
+    /// <summary>Validate a candidate path for a dependency (Q3 — never silently accept a wrong path): a directory tool
+    /// needs an existing folder; an exe tool needs an existing .exe whose name carries the expected stem (so a path to the
+    /// wrong program is caught). Returns (ok, error) — error names what's wrong, for the tool to surface to the user.</summary>
+    public static (bool ok, string? error) Validate(ToolDependency dep, string path)
+    {
+        var info = Info(dep);
+        if (string.IsNullOrWhiteSpace(path)) return (false, "no path given.");
+        if (info.IsDirectory)
+            return Directory.Exists(path) ? (true, null)
+                 : (false, $"no such folder: '{path}'. Give the {info.Display} (a directory).");
+        if (!File.Exists(path))
+            return (false, $"no such file: '{path}'. Give the full path to {info.Display}.");
+        var name = Path.GetFileName(path);
+        if (!name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+            return (false, $"'{name}' is not an .exe — give the {info.Display}.");
+        if (info.ExeStem is not null && name.IndexOf(info.ExeStem, StringComparison.OrdinalIgnoreCase) < 0)
+            return (false, $"'{name}' doesn't look like {info.Display} (expected a filename containing '{info.ExeStem}'). " +
+                           "Double-check you pointed at the right .exe.");
+        return (true, null);
+    }
+
+    /// <summary>The trained missing-dependency prompt — RETURNED by a rider tool when its path is unset, so the AI reliably
+    /// asks the user and is handed the exact resolving call (the forcing function). Mirrors the MO2 not-configured prompt
+    /// idiom: a RETURNED string reaches the client, whereas a thrown one is genericized to "An error occurred invoking…"
+    /// (measured 2026-06-02), so the guidance must be a return value, never an exception.</summary>
+    public static string RenderMissingPrompt(ToolDependency dep)
+    {
+        var info = Info(dep);
+        return
+            $"houseCARL needs {info.Display} for {info.Need}, but no path is set yet. " +
+            $"Ask the user for the {(info.IsDirectory ? "folder" : "full path to the .exe")}, then call " +
+            $"housecarl_set_tool_path(tool='{info.Key}', path='<the path they give>'). " +
+            $"If they don't have it: {info.WhereToGet}. " +
+            "Do NOT guess the path, invent one, or skip the step — the operation cannot run without it, and a wrong path " +
+            "is refused loud.";
+    }
+
+    /// <summary>Auto-detect a canonical home for a dependency, so the user is only asked when houseCARL genuinely can't find
+    /// it. <paramref name="skyrimGamePath"/> is the resolved MO2 instance's game root, when known (for the compiler under
+    /// &lt;game&gt;\Papyrus Compiler). Returns the first EXISTING canonical path, or null (→ the prompt). BSArch has no
+    /// canonical home, so it's always null. (GOG/other game-dir variants are a later refinement — flagged in the plan.)</summary>
+    public static string? Probe(ToolDependency dep, string? skyrimGamePath)
+    {
+        switch (dep)
+        {
+            case ToolDependency.PapyrusCompiler:
+                if (!string.IsNullOrWhiteSpace(skyrimGamePath))
+                {
+                    var exe = Path.Combine(skyrimGamePath!, "Papyrus Compiler", "PapyrusCompiler.exe");
+                    if (File.Exists(exe)) return exe;
+                }
+                return null;
+            case ToolDependency.PapyrusLogs:
+                return FirstExistingDir(Path.Combine(MyGames, "Logs", "Script"));
+            case ToolDependency.CrashLogs:
+                return FirstExistingDir(
+                    Path.Combine(MyGames, "SKSE", "Crashlogs"),         // Crash Logger SSE
+                    Path.Combine(MyGames, "NetScriptFramework", "Crash")); // .NET Script Framework
+            default:
+                return null;   // bsarch — user-downloaded, no canonical home
+        }
+    }
+
+    static string MyGames => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "My Games", "Skyrim Special Edition");
+
+    static string? FirstExistingDir(params string[] candidates)
+    {
+        foreach (var c in candidates) if (Directory.Exists(c)) return c;
+        return null;
+    }
+}

--- a/src/housecarl-core/ToolBridge.cs
+++ b/src/housecarl-core/ToolBridge.cs
@@ -101,28 +101,26 @@ public static class ToolBridge
     }
 
     /// <summary>Auto-detect a canonical home for a dependency, so the user is only asked when houseCARL genuinely can't find
-    /// it. <paramref name="skyrimGamePath"/> is the resolved MO2 instance's game root, when known (for the compiler under
-    /// &lt;game&gt;\Papyrus Compiler). Returns the first EXISTING canonical path, or null (→ the prompt). BSArch has no
-    /// canonical home, so it's always null. (GOG/other game-dir variants are a later refinement — flagged in the plan.)</summary>
-    public static string? Probe(ToolDependency dep, string? skyrimGamePath)
+    /// it. Returns the first EXISTING canonical path, or null (→ the forcing prompt). The log folders live under the user's
+    /// Documents (probed here); the compiler and BSArch have no reliable cheap home, so they prompt — see the per-arm notes.</summary>
+    public static string? Probe(ToolDependency dep)
     {
         switch (dep)
         {
-            case ToolDependency.PapyrusCompiler:
-                if (!string.IsNullOrWhiteSpace(skyrimGamePath))
-                {
-                    var exe = Path.Combine(skyrimGamePath!, "Papyrus Compiler", "PapyrusCompiler.exe");
-                    if (File.Exists(exe)) return exe;
-                }
-                return null;
             case ToolDependency.PapyrusLogs:
                 return FirstExistingDir(Path.Combine(MyGames, "Logs", "Script"));
             case ToolDependency.CrashLogs:
                 return FirstExistingDir(
-                    Path.Combine(MyGames, "SKSE", "Crashlogs"),         // Crash Logger SSE
+                    Path.Combine(MyGames, "SKSE", "Crashlogs"),          // Crash Logger SSE
                     Path.Combine(MyGames, "NetScriptFramework", "Crash")); // .NET Script Framework
+            // PapyrusCompiler: NO reliable canonical home to probe. The CK's compiler ships ONLY with the vanilla Steam
+            // install — NOT the MO2/Wabbajack "Stock Game" copy the load order points at (confirmed 2026-06-05) — and the
+            // Steam library can sit on any drive. Auto-detecting it = Steam registry + libraryfolders.vdf discovery (a noted
+            // future enhancement); until then the forcing prompt is the reliable path, and once the user supplies the .exe
+            // the compile rider derives the matching vanilla sources + flags from the compiler's own game dir.
+            // Bsarch: user-downloaded, no canonical home either.
             default:
-                return null;   // bsarch — user-downloaded, no canonical home
+                return null;
         }
     }
 

--- a/src/housecarl-core/UserConfig.cs
+++ b/src/housecarl-core/UserConfig.cs
@@ -1,0 +1,75 @@
+using System.Text.Json;
+
+namespace HousecarlCore;
+
+/// <summary>
+/// The on-disk user config shape (houseCARL.user.json) — the values houseCARL persists for ITSELF at runtime, separate
+/// from the shipped appsettings.json. TWO independent concerns share this one file: the MO2 instance folder (written by
+/// housecarl_set_mo2_instance) and the external-TOOL paths (written by housecarl_set_tool_path — the bridge for compile /
+/// BSA / log access). They MUST coexist — a write of one must never clobber the other — which is why the only writer is
+/// <see cref="UserConfigStore.Update"/> (read-modify-write under a lock), never a whole-object overwrite.
+/// </summary>
+public sealed class UserConfig
+{
+    /// <summary>The MO2 instance folder housecarl_set_mo2_instance saved (precedence §6d: this beats appsettings'
+    /// Mo2InstanceDir). Null/absent ⇒ fall through to explicit paths / unconfigured.</summary>
+    public string? Mo2InstanceDir { get; set; }
+
+    /// <summary>External-tool paths the bridge saved, keyed by tool wire-name (papyrus_compiler, bsarch, papyrus_logs,
+    /// crash_logs) → an absolute file/dir path. Null/absent until housecarl_set_tool_path is first called.</summary>
+    public Dictionary<string, string>? ToolPaths { get; set; }
+}
+
+/// <summary>
+/// The single OWNER of houseCARL.user.json — every read and write of that file goes through here, so the two independent
+/// writers (housecarl_set_mo2_instance, housecarl_set_tool_path) can never clobber each other's field. <see cref="Update"/>
+/// is read-modify-write under a process-wide lock on this store; <see cref="Load"/> is a TOLERANT read (a missing or
+/// corrupt file yields a blank config, never a crash — Q3). Best-effort + HONEST: a write failure (e.g. a read-only data
+/// dir) is RETURNED, not thrown or swallowed, so the calling tool can tell the user the choice won't survive a restart.
+/// One instance is registered as a singleton and shared by <see cref="LoadOrderService"/> + the tool bridge.
+/// </summary>
+public sealed class UserConfigStore
+{
+    readonly string _path;
+    readonly object _gate = new();
+    static readonly JsonSerializerOptions Json = new() { WriteIndented = true };
+
+    public UserConfigStore(string path) => _path = path;
+
+    /// <summary>The file this store owns (for the tool confirmation / diagnostics).</summary>
+    public string FilePath => _path;
+
+    /// <summary>Read the current config — a missing file or unparseable JSON yields a fresh blank <see cref="UserConfig"/>
+    /// (Q3: a corrupt user file never crashes boot or a tool; it reads as "nothing saved yet").</summary>
+    public UserConfig Load()
+    {
+        lock (_gate) { return ReadOrBlank(); }
+    }
+
+    /// <summary>Apply <paramref name="mutate"/> to the CURRENT on-disk config and write it back — the ONLY way the file is
+    /// written, so the two concerns merge instead of overwriting. Returns (ok, error): a write failure is reported, not
+    /// thrown, so the tool can surface "works this session, won't persist" (Q3). The mutate runs under the lock.</summary>
+    public (bool ok, string? error) Update(Action<UserConfig> mutate)
+    {
+        lock (_gate)
+        {
+            try
+            {
+                var cfg = ReadOrBlank();
+                mutate(cfg);
+                var dir = Path.GetDirectoryName(_path);   // the data dir (${CLAUDE_PLUGIN_DATA}) may not exist on the first save
+                if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+                File.WriteAllText(_path, JsonSerializer.Serialize(cfg, Json));
+                return (true, null);
+            }
+            catch (Exception ex) { return (false, ex.Message); }
+        }
+    }
+
+    UserConfig ReadOrBlank()
+    {
+        if (!File.Exists(_path)) return new UserConfig();
+        try { return JsonSerializer.Deserialize<UserConfig>(File.ReadAllText(_path)) ?? new UserConfig(); }
+        catch { return new UserConfig(); }   // corrupt → treat as blank (Q3); a tool write then rewrites it clean
+    }
+}

--- a/src/housecarl-generator/BsaProbe.cs
+++ b/src/housecarl-generator/BsaProbe.cs
@@ -1,0 +1,71 @@
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// BSA-rider proof (EXTERNAL_TOOL_BRIDGE_PLAN step 3). Drives the shipped <see cref="BsaArchive"/> against the REAL BSArch
+/// on a REAL archive: list → unpack → pack → re-list, asserting the round-trip preserves the file count (the plan's proof
+/// gate). The list step also exercises the "Files: N + last-N-lines" parser against real output. Skipped (not failed) if
+/// BSArch or the test archive isn't present; override both via args.
+///
+/// Run: dotnet run --project src/housecarl-generator bsa-probe ["&lt;BSArch.exe&gt;"] ["&lt;test.bsa&gt;"]
+/// </summary>
+internal static class BsaProbe
+{
+    const string DefaultBsarch = @"E:\Skyrim Modding\Tools\xEdit.4.1.5f\BSArch.exe";
+    const string DefaultBsa = @"E:\Skyrim Modding\ARR 2.0\Stock Game\Data\MarketplaceTextures.bsa";
+
+    public static int Run(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" BSA riders — step 3: list → unpack → pack → re-list round-trip (real BSArch)");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        var bsarch = args.Length > 0 ? args[0] : DefaultBsarch;
+        var bsa = args.Length > 1 ? args[1] : DefaultBsa;
+        if (!File.Exists(bsarch)) { Console.WriteLine($"  SKIP  no BSArch at '{bsarch}' (pass its path as arg 1)"); return 0; }
+        if (!File.Exists(bsa)) { Console.WriteLine($"  SKIP  no test archive at '{bsa}' (pass one as arg 2)"); return 0; }
+
+        var work = Path.Combine(Environment.CurrentDirectory, ".bsa-probe");
+        var unpacked = Path.Combine(work, "unpacked");
+        var repacked = Path.Combine(work, "repacked.bsa");
+        try
+        {
+            Directory.CreateDirectory(work);
+
+            // 1) LIST the original (exercises the parser on real output)
+            var orig = BsaArchive.List(bsarch, bsa);
+            Check(orig.Ran && orig.Success, "list: ran + Success");
+            Check(orig.DeclaredCount > 0 && orig.Files.Count == orig.DeclaredCount,
+                  $"list: file count matches declared ({orig.Files.Count}/{orig.DeclaredCount})");
+            Check(orig.Format is not null && orig.Format.Contains("Skyrim", StringComparison.OrdinalIgnoreCase),
+                  $"list: format parsed ('{orig.Format}')");
+            if (orig.Files.Count > 0) Console.WriteLine("         e.g. " + orig.Files[0]);
+
+            // 2) UNPACK
+            var up = BsaArchive.Unpack(bsarch, bsa, unpacked);
+            Check(up.Ran && up.Success, "unpack: ran + dest has files");
+            int onDisk = Directory.Exists(unpacked) ? Directory.GetFiles(unpacked, "*", SearchOption.AllDirectories).Length : 0;
+            Check(onDisk == orig.DeclaredCount, $"unpack: files on disk == declared ({onDisk}/{orig.DeclaredCount})");
+
+            // 3) PACK back (Skyrim SE, uncompressed)
+            var pk = BsaArchive.Pack(bsarch, unpacked, repacked, BsaArchive.FormatFlag("sse"), compress: false);
+            Check(pk.Ran && pk.Success, "pack: ran + .bsa written");
+            Check(File.Exists(repacked) && new FileInfo(repacked).Length > 0, "pack: output .bsa exists, non-empty");
+
+            // 4) RE-LIST the repacked archive — round-trip preserves the file count
+            var round = BsaArchive.List(bsarch, repacked);
+            Check(round.Ran && round.Success, "re-list: ran + Success");
+            Check(round.DeclaredCount == orig.DeclaredCount,
+                  $"round-trip preserves file count ({round.DeclaredCount} == {orig.DeclaredCount})");
+        }
+        finally { try { Directory.Delete(work, recursive: true); } catch { /* in-dir scratch; non-fatal */ } }
+
+        Console.WriteLine();
+        Console.WriteLine(fail == 0 ? "================ ALL PASS ================" : $"================ {fail} CHECK(S) FAILED ================");
+        return fail == 0 ? 0 : 1;
+    }
+}

--- a/src/housecarl-generator/BsaProbe.cs
+++ b/src/housecarl-generator/BsaProbe.cs
@@ -61,6 +61,15 @@ internal static class BsaProbe
             Check(round.Ran && round.Success, "re-list: ran + Success");
             Check(round.DeclaredCount == orig.DeclaredCount,
                   $"round-trip preserves file count ({round.DeclaredCount} == {orig.DeclaredCount})");
+
+            // 5) NON-DESTRUCTIVE PACK (Aaron 2026-06-06): a FAILED pack must NOT overwrite an existing archive. We have a
+            //    good `repacked` from the round-trip; attempt a pack from a non-existent source to the SAME path and assert
+            //    the prior archive survives byte-for-byte (the original is touched only by a clean, successful compaction).
+            var beforeLen = new FileInfo(repacked).Length;
+            var failPack = BsaArchive.Pack(bsarch, Path.Combine(work, "no-such-source"), repacked, BsaArchive.FormatFlag("sse"), compress: false);
+            Check(!failPack.Success, "non-destructive: a pack from a missing source reports failure");
+            Check(File.Exists(repacked) && new FileInfo(repacked).Length == beforeLen,
+                  "non-destructive: the PRIOR archive is left intact after a failed pack");
         }
         finally { try { Directory.Delete(work, recursive: true); } catch { /* in-dir scratch; non-fatal */ } }
 

--- a/src/housecarl-generator/CompileProbe.cs
+++ b/src/housecarl-generator/CompileProbe.cs
@@ -78,6 +78,21 @@ internal static class CompileProbe
                 Check(!bad.Success && bad.PexPath is null, "bad: Success=false + no .pex");
                 Check(bad.Diagnostics.Count > 0, $"bad: structured diagnostics produced (got {bad.Diagnostics.Count})");
                 if (bad.Diagnostics.Count > 0) Console.WriteLine("         e.g. " + bad.Diagnostics[0]);
+
+                // RECOMPILE behaviour (Aaron 2026-06-06): a prior .pex is LEFT in place — a successful recompile updates
+                // it (success = THIS run wrote it, detected by the write-time advancing, NOT by a pre-delete); a FAILED
+                // recompile must NOT destroy the last good build (non-destructive — the user deletes outputs at will).
+                var pex = good.PexPath!;
+                var firstWriteUtc = File.GetLastWriteTimeUtc(pex);
+                var reGood = PapyrusCompile.CompileObject(compiler, "HCGood", imports, outDir);
+                Check(reGood.Success && File.Exists(pex), "recompile (still valid): Success + .pex present");
+                Check(File.GetLastWriteTimeUtc(pex) > firstWriteUtc, "recompile (still valid): .pex rewritten this run (write-time advanced; no pre-delete)");
+
+                File.WriteAllText(Path.Combine(work, "HCGood.psc"),
+                    "Scriptname HCGood extends Quest\n\nFunction Foo()\n    @@@ broken edit\nEndFunction\n");
+                var reBad = PapyrusCompile.CompileObject(compiler, "HCGood", imports, outDir);
+                Check(!reBad.Success && reBad.PexPath is null, "recompile (now broken): reports failure, no new .pex");
+                Check(File.Exists(pex), "recompile (now broken): the PRIOR .pex is LEFT INTACT (non-destructive)");
             }
             finally { try { Directory.Delete(work, recursive: true); } catch { /* in-dir scratch; non-fatal */ } }
         }

--- a/src/housecarl-generator/CompileProbe.cs
+++ b/src/housecarl-generator/CompileProbe.cs
@@ -1,0 +1,89 @@
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// Compile-rider proof (EXTERNAL_TOOL_BRIDGE_PLAN step 2). Two layers:
+///   1. PARSER regression — <see cref="PapyrusCompile.ParseDiagnostics"/> on the EXACT stderr format the real CK compiler
+///      emits (captured 2026-06-05): "&lt;fullpath&gt;(line,col): message". Pure, always runnable.
+///   2. END-TO-END — drives the shipped <see cref="PapyrusCompile.CompileObject"/> against the REAL PapyrusCompiler.exe on
+///      a good and a deliberately-broken script, asserting good→.pex+Success and bad→no-pex+diagnostics. Skipped (not
+///      failed) if the compiler isn't present; pass its path as the first arg to point elsewhere.
+///
+/// Run: dotnet run --project src/housecarl-generator compile-probe ["&lt;PapyrusCompiler.exe&gt;"]
+/// </summary>
+internal static class CompileProbe
+{
+    // Aaron's known Steam compiler (the CK ships with the vanilla Steam install, not the MO2 game copy). Override via arg.
+    const string DefaultCompiler = @"E:\SteamLibrary\steamapps\common\Skyrim Special Edition\Papyrus Compiler\PapyrusCompiler.exe";
+
+    public static int Run(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" compile rider — step 2: stderr parser + (if compiler present) real .psc → .pex");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        // ---- 1) PARSER on the real captured format ----
+        Console.WriteLine("--- 1: ParseDiagnostics on the real CK stderr format ---");
+        var realStderr = string.Join("\n", new[]
+        {
+            @"C:\mod\Source\Scripts\HCBad.psc(4,4): no viable alternative at character '@'",
+            @"C:\mod\Source\Scripts\HCBad.psc(4,18): no viable alternative at input 'papyrus'",
+            @"C:\mod\Source\Scripts\HCBad.psc(4,12): Unknown user flag papyrus",
+            @"C:\mod\Source\Scripts\HCBad.psc(5,0): missing EOF at 'EndFunction'",
+        });
+        var diags = PapyrusCompile.ParseDiagnostics(realStderr);
+        Check(diags.Count == 4, $"parses 4 diagnostics (got {diags.Count})");
+        Check(diags.Count > 0 && diags[0].Line == 4 && diags[0].Col == 4 && diags[0].Message == "no viable alternative at character '@'",
+              "first diagnostic: line=4 col=4 message intact");
+        Check(diags.Count > 3 && diags[3].Line == 5 && diags[3].Col == 0, "later diagnostic line/col parsed");
+        Check(PapyrusCompile.ParseDiagnostics("").Count == 0, "empty stderr → no diagnostics");
+        Check(PapyrusCompile.ParseDiagnostics("Batch compile of 1 files finished. 1 succeeded, 0 failed.").Count == 0,
+              "a non-diagnostic line is ignored (not mis-parsed)");
+
+        // ---- 2) END-TO-END against the real compiler ----
+        Console.WriteLine();
+        Console.WriteLine("--- 2: real compile via PapyrusCompile.CompileObject ---");
+        var compiler = args.Length > 0 ? args[0] : DefaultCompiler;
+        if (!File.Exists(compiler))
+        {
+            Console.WriteLine($"  SKIP  no compiler at '{compiler}' (pass the PapyrusCompiler.exe path as an arg to run this layer)");
+        }
+        else
+        {
+            var gameRoot = Path.GetDirectoryName(Path.GetDirectoryName(compiler));
+            var vanilla = Path.Combine(gameRoot!, "Data", "Source", "Scripts");
+            Check(Directory.Exists(vanilla), $"vanilla sources derived from compiler dir exist ({vanilla})");
+
+            var work = Path.Combine(Environment.CurrentDirectory, ".compile-probe-gen");
+            var outDir = Path.Combine(work, "out");
+            Directory.CreateDirectory(outDir);
+            File.WriteAllText(Path.Combine(work, "HCGood.psc"),
+                "Scriptname HCGood extends Quest\n\nFunction Foo()\n    Debug.Trace(\"ok from houseCARL\")\nEndFunction\n");
+            File.WriteAllText(Path.Combine(work, "HCBad.psc"),
+                "Scriptname HCBad extends Quest\n\nFunction Foo()\n    @@@ not valid papyrus\nEndFunction\n");
+            var imports = new[] { work, vanilla };
+            try
+            {
+                var good = PapyrusCompile.CompileObject(compiler, "HCGood", imports, outDir);
+                Check(good.Ran, "good: compiler ran");
+                Check(good.Success && good.PexPath is not null && File.Exists(good.PexPath), "good: Success + .pex written");
+                Check(good.Diagnostics.Count == 0, $"good: no diagnostics (got {good.Diagnostics.Count})");
+
+                var bad = PapyrusCompile.CompileObject(compiler, "HCBad", imports, outDir);
+                Check(bad.Ran, "bad: compiler ran");
+                Check(!bad.Success && bad.PexPath is null, "bad: Success=false + no .pex");
+                Check(bad.Diagnostics.Count > 0, $"bad: structured diagnostics produced (got {bad.Diagnostics.Count})");
+                if (bad.Diagnostics.Count > 0) Console.WriteLine("         e.g. " + bad.Diagnostics[0]);
+            }
+            finally { try { Directory.Delete(work, recursive: true); } catch { /* in-dir scratch; non-fatal */ } }
+        }
+
+        Console.WriteLine();
+        Console.WriteLine(fail == 0 ? "================ ALL PASS ================" : $"================ {fail} CHECK(S) FAILED ================");
+        return fail == 0 ? 0 : 1;
+    }
+}

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -117,6 +117,9 @@ if (args.Length > 0 && args[0] == "atrest-probe") return AtRestProbe.RunProbe(ar
 // clobber-safety, path validation, the missing-dependency forcing prompt, and canonical-home auto-detect.
 if (args.Length > 0 && args[0] == "tool-bridge") return ToolBridgeProbe.Run(args[1..]);
 
+// External-tool bridge (step 2) proof: the compile rider's stderr parser + a real .psc → .pex against the CK compiler.
+if (args.Length > 0 && args[0] == "compile-probe") return CompileProbe.Run(args[1..]);
+
 var outputDir = Path.GetFullPath(args.Length > 0 ? args[0] : "generated");
 // The slim reference tree ships INSIDE the skill (tracked); corpus.json + summary stay in generated/.
 // Default assumes the generator is run from the repo root (as `dotnet run --project src/housecarl-generator`).

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -120,6 +120,9 @@ if (args.Length > 0 && args[0] == "tool-bridge") return ToolBridgeProbe.Run(args
 // External-tool bridge (step 2) proof: the compile rider's stderr parser + a real .psc → .pex against the CK compiler.
 if (args.Length > 0 && args[0] == "compile-probe") return CompileProbe.Run(args[1..]);
 
+// External-tool bridge (step 3) proof: the BSA riders' list→unpack→pack→re-list round-trip against real BSArch.
+if (args.Length > 0 && args[0] == "bsa-probe") return BsaProbe.Run(args[1..]);
+
 var outputDir = Path.GetFullPath(args.Length > 0 ? args[0] : "generated");
 // The slim reference tree ships INSIDE the skill (tracked); corpus.json + summary stay in generated/.
 // Default assumes the generator is run from the repo root (as `dotnet run --project src/housecarl-generator`).

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -113,6 +113,10 @@ if (args.Length > 0 && args[0] == "handle-probe") return HandleProbe.RunProbe(ar
 // Cleanup-gotcha / Option-B AT-REST proof: drive the REAL product code (resolver Build -> read via session -> create via write path) on temp copies and assert files are renamable at rest (zero handles held).
 if (args.Length > 0 && args[0] == "atrest-probe") return AtRestProbe.RunProbe(args[1..]);
 
+// External-tool bridge (step 1) proof: the pure core pieces housecarl_set_tool_path + the riders ride — shared-config
+// clobber-safety, path validation, the missing-dependency forcing prompt, and canonical-home auto-detect.
+if (args.Length > 0 && args[0] == "tool-bridge") return ToolBridgeProbe.Run(args[1..]);
+
 var outputDir = Path.GetFullPath(args.Length > 0 ? args[0] : "generated");
 // The slim reference tree ships INSIDE the skill (tracked); corpus.json + summary stay in generated/.
 // Default assumes the generator is run from the repo root (as `dotnet run --project src/housecarl-generator`).

--- a/src/housecarl-generator/ToolBridgeProbe.cs
+++ b/src/housecarl-generator/ToolBridgeProbe.cs
@@ -1,0 +1,120 @@
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// External-tool bridge — step-1 proof (EXTERNAL_TOOL_BRIDGE_PLAN). Exercises the PURE core pieces the
+/// housecarl_set_tool_path tool + the riders ride, with NO MO2 / NO server, so it's a cheap, deterministic green/red gate:
+///
+///   1. <see cref="UserConfigStore"/> CLOBBER-SAFETY (the load-bearing claim) — two independent writers (the MO2 instance
+///      dir + a tool path) share one houseCARL.user.json and must NOT overwrite each other's field, in either order; a
+///      corrupt file reads blank, never throws (Q3).
+///   2. <see cref="ToolBridge.Validate"/> — rejects a missing exe / wrong-named exe / missing dir; accepts a real exe + dir.
+///   3. <see cref="ToolBridge.RenderMissingPrompt"/> — the forcing function names the tool key AND the resolving call.
+///   4. <see cref="ToolBridge.TryParse"/> — wire names round-trip; junk is rejected.
+///   5. <see cref="ToolBridge.Probe"/> — the compiler probe hits a synthetic &lt;game&gt;\Papyrus Compiler\PapyrusCompiler.exe
+///      and misses when absent; BSArch has no canonical home (always null).
+///
+/// The cross-restart persistence + live-server forcing-function proof is the Aaron-empirical follow-up (needs his install).
+/// Run: dotnet run --project src/housecarl-generator tool-bridge
+/// </summary>
+public static class ToolBridgeProbe
+{
+    public static int Run(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" external-tool bridge — step 1: shared-config clobber-safety + validate + prompt + auto-detect");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+
+        int fail = 0;
+        void Check(bool cond, string label)
+        {
+            Console.WriteLine((cond ? "  PASS  " : "  FAIL  ") + label);
+            if (!cond) fail++;
+        }
+
+        // ---------------------------------------------------------------- 1) STORE clobber-safety (the core claim)
+        Console.WriteLine("--- 1: UserConfigStore — two writers share one file without clobbering ---");
+        var tmp = Path.Combine(Path.GetTempPath(), "houseCARL.user.test." + Guid.NewGuid().ToString("N") + ".json");
+        try
+        {
+            var store = new UserConfigStore(tmp);
+            Check(store.Load().Mo2InstanceDir is null && store.Load().ToolPaths is null, "absent file loads blank");
+
+            store.Update(c => c.Mo2InstanceDir = @"C:\MO2\Instance");
+            store.Update(c => (c.ToolPaths ??= new())["bsarch"] = @"C:\Tools\bsarch.exe");
+            var a = store.Load();
+            Check(a.Mo2InstanceDir == @"C:\MO2\Instance", "MO2 dir survives a later tool-path write");
+            Check(a.ToolPaths is { } tp && tp.TryGetValue("bsarch", out var bp) && bp == @"C:\Tools\bsarch.exe",
+                  "tool path persisted alongside the MO2 dir");
+
+            store.Update(c => c.Mo2InstanceDir = @"D:\Other");                 // reverse order
+            var b = store.Load();
+            Check(b.Mo2InstanceDir == @"D:\Other" && b.ToolPaths!["bsarch"] == @"C:\Tools\bsarch.exe",
+                  "tool path survives a later MO2-dir write (no clobber, both directions)");
+
+            store.Update(c => (c.ToolPaths ??= new())["papyrus_compiler"] = @"C:\CK\PapyrusCompiler.exe");
+            var c2 = store.Load();
+            Check(c2.ToolPaths!.Count == 2 && c2.Mo2InstanceDir == @"D:\Other", "a second tool path merges; MO2 dir intact");
+
+            File.WriteAllText(tmp, "{ this is not valid json");
+            Check(store.Load().Mo2InstanceDir is null, "corrupt file loads blank, no throw (Q3)");
+        }
+        finally { try { File.Delete(tmp); } catch { /* temp cleanup, non-fatal */ } }
+
+        // ---------------------------------------------------------------- 2) VALIDATE
+        Console.WriteLine();
+        Console.WriteLine("--- 2: ToolBridge.Validate — loud on a wrong/missing path, accepts the real thing ---");
+        var ghost = Path.Combine(Path.GetTempPath(), "ghost-" + Guid.NewGuid().ToString("N") + ".exe");
+        Check(!ToolBridge.Validate(ToolDependency.Bsarch, ghost).ok, "rejects a non-existent exe");
+
+        var goodExe = Path.Combine(Path.GetTempPath(), "bsarch.test." + Guid.NewGuid().ToString("N") + ".exe");
+        var wrongExe = Path.Combine(Path.GetTempPath(), "notepad.test." + Guid.NewGuid().ToString("N") + ".exe");
+        File.WriteAllText(goodExe, "stub"); File.WriteAllText(wrongExe, "stub");
+        try
+        {
+            Check(ToolBridge.Validate(ToolDependency.Bsarch, goodExe).ok, "accepts an existing bsarch*.exe");
+            Check(!ToolBridge.Validate(ToolDependency.Bsarch, wrongExe).ok, "rejects an exe whose name isn't the expected tool");
+            Check(ToolBridge.Validate(ToolDependency.PapyrusLogs, Path.GetTempPath()).ok, "accepts an existing log directory");
+            Check(!ToolBridge.Validate(ToolDependency.PapyrusLogs, ghost).ok, "rejects a non-existent log directory");
+        }
+        finally { try { File.Delete(goodExe); File.Delete(wrongExe); } catch { /* non-fatal */ } }
+
+        // ---------------------------------------------------------------- 3) MISSING-DEPENDENCY PROMPT (forcing function)
+        Console.WriteLine();
+        Console.WriteLine("--- 3: ToolBridge.RenderMissingPrompt — scripts the ask + the resolving call ---");
+        var prompt = ToolBridge.RenderMissingPrompt(ToolDependency.Bsarch);
+        Check(prompt.Contains("housecarl_set_tool_path"), "prompt names the resolving call");
+        Check(prompt.Contains("bsarch"), "prompt names the tool key");
+
+        // ---------------------------------------------------------------- 4) PARSE
+        Console.WriteLine();
+        Console.WriteLine("--- 4: ToolBridge.TryParse — wire names round-trip; junk rejected ---");
+        Check(ToolBridge.TryParse("papyrus_compiler", out var d1) && d1 == ToolDependency.PapyrusCompiler, "parses papyrus_compiler");
+        Check(ToolBridge.TryParse("CRASH_LOGS", out var d2) && d2 == ToolDependency.CrashLogs, "parses case-insensitively");
+        Check(!ToolBridge.TryParse("nonsense", out _), "rejects an unknown tool");
+
+        // ---------------------------------------------------------------- 5) AUTO-DETECT
+        Console.WriteLine();
+        Console.WriteLine("--- 5: ToolBridge.Probe — compiler hits under a synthetic game root; bsarch has no home ---");
+        var game = Path.Combine(Path.GetTempPath(), "fakegame-" + Guid.NewGuid().ToString("N"));
+        var compDir = Path.Combine(game, "Papyrus Compiler");
+        Directory.CreateDirectory(compDir);
+        var compExe = Path.Combine(compDir, "PapyrusCompiler.exe");
+        File.WriteAllText(compExe, "stub");
+        try
+        {
+            Check(ToolBridge.Probe(ToolDependency.PapyrusCompiler, game) == compExe, "compiler probe finds <game>\\Papyrus Compiler\\PapyrusCompiler.exe");
+            Check(ToolBridge.Probe(ToolDependency.PapyrusCompiler, Path.Combine(game, "nope")) is null, "compiler probe misses when absent");
+            Check(ToolBridge.Probe(ToolDependency.Bsarch, game) is null, "bsarch has no canonical home (always prompts)");
+        }
+        finally { try { Directory.Delete(game, recursive: true); } catch { /* non-fatal */ } }
+
+        Console.WriteLine();
+        Console.WriteLine(fail == 0
+            ? "================ ALL PASS ================"
+            : $"================ {fail} CHECK(S) FAILED ================");
+        return fail == 0 ? 0 : 1;
+    }
+}

--- a/src/housecarl-generator/ToolBridgeProbe.cs
+++ b/src/housecarl-generator/ToolBridgeProbe.cs
@@ -97,19 +97,10 @@ public static class ToolBridgeProbe
 
         // ---------------------------------------------------------------- 5) AUTO-DETECT
         Console.WriteLine();
-        Console.WriteLine("--- 5: ToolBridge.Probe — compiler hits under a synthetic game root; bsarch has no home ---");
-        var game = Path.Combine(Path.GetTempPath(), "fakegame-" + Guid.NewGuid().ToString("N"));
-        var compDir = Path.Combine(game, "Papyrus Compiler");
-        Directory.CreateDirectory(compDir);
-        var compExe = Path.Combine(compDir, "PapyrusCompiler.exe");
-        File.WriteAllText(compExe, "stub");
-        try
-        {
-            Check(ToolBridge.Probe(ToolDependency.PapyrusCompiler, game) == compExe, "compiler probe finds <game>\\Papyrus Compiler\\PapyrusCompiler.exe");
-            Check(ToolBridge.Probe(ToolDependency.PapyrusCompiler, Path.Combine(game, "nope")) is null, "compiler probe misses when absent");
-            Check(ToolBridge.Probe(ToolDependency.Bsarch, game) is null, "bsarch has no canonical home (always prompts)");
-        }
-        finally { try { Directory.Delete(game, recursive: true); } catch { /* non-fatal */ } }
+        Console.WriteLine("--- 5: ToolBridge.Probe — compiler + bsarch have no cheap canonical home (prompt) ---");
+        Check(ToolBridge.Probe(ToolDependency.PapyrusCompiler) is null, "compiler has no probe home (prompts; the CK lives in the separate Steam install)");
+        Check(ToolBridge.Probe(ToolDependency.Bsarch) is null, "bsarch has no canonical home (always prompts)");
+        // (papyrus_logs / crash_logs probe the user's Documents — environment-dependent, so not asserted here.)
 
         Console.WriteLine();
         Console.WriteLine(fail == 0

--- a/src/housecarl-mcp/BsaTools.cs
+++ b/src/housecarl-mcp/BsaTools.cs
@@ -1,0 +1,149 @@
+using System.ComponentModel;
+using System.Text;
+using ModelContextProtocol.Server;
+
+namespace HousecarlMcp;
+
+/// <summary>
+/// houseCARL BSA riders — list / extract / repack Bethesda .bsa archives by driving BSArch (via
+/// <see cref="HousecarlCore.BsaArchive"/>; Mutagen has no archive surface). All three ride the external-tool bridge: the
+/// BSArch path comes from <see cref="ToolPathResolver"/> (auto-prompts via the forcing function if unset — BSArch ships
+/// with xEdit). Reading a file INSIDE an archive = extract it, then read it (BSArch has no per-file extract). Extract +
+/// repack land their output in a reviewable houseCARL mod folder (folder-per-patch; originals untouched).
+/// </summary>
+[McpServerToolType]
+public static class BsaTools
+{
+    [McpServerTool(Name = "housecarl_bsa_list", ReadOnly = true, Title = "List a .bsa archive's contents"),
+     Description(
+         "List the files inside a Bethesda .bsa archive (via BSArch). Returns the archive format + the contained file " +
+         "paths. Read-only — extracts nothing. To read a file's CONTENTS, use housecarl_bsa_extract then read the file. " +
+         "Needs the BSArch path; if it isn't set yet houseCARL tells you exactly what to ask for and how to set it " +
+         "(BSArch ships with xEdit).")]
+    public static string BsaList(
+        ToolPathResolver bridge,
+        [Description("Full path to the .bsa archive to list.")]
+            string archive,
+        [Description("Optional. Max characters before the file list is cut with an explicit notice. 0 = the server default (~80k).")]
+            int max_chars = 0)
+    {
+        if (string.IsNullOrWhiteSpace(archive)) return "error: no archive given. Pass the full path to the .bsa.";
+        archive = archive.Trim().Trim('"');
+        if (!File.Exists(archive)) return $"error: no such file: '{archive}'.";
+        if (bridge.RequireOrPrompt(ToolDependency.Bsarch, out var bsarch) is { } prompt) return prompt;
+
+        var r = HousecarlCore.BsaArchive.List(bsarch!, archive);
+        if (!r.Ran) return "error: " + r.RunError;
+        if (!r.Success && r.DeclaredCount == 0)
+            return $"error: BSArch could not read '{Path.GetFileName(archive)}' as an archive. Raw output:\n" + r.Raw;
+
+        int cap = max_chars > 0 ? max_chars : 80_000;
+        var sb = new StringBuilder();
+        sb.Append(Path.GetFileName(archive)).Append("  [").Append(r.Format ?? "unknown format").Append("]  ")
+          .Append(r.DeclaredCount).Append(" file(s)\n");
+        int shown = 0;
+        foreach (var f in r.Files)
+        {
+            if (sb.Length >= cap) { sb.Append("  ... [").Append(r.Files.Count - shown).Append(" more omitted at max_chars=").Append(cap).Append("]\n"); break; }
+            sb.Append("  ").Append(f).Append('\n'); shown++;
+        }
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    [McpServerTool(Name = "housecarl_bsa_extract", Title = "Extract a .bsa archive to a folder"),
+     Description(
+         "Extract a Bethesda .bsa archive's contents to a folder (via BSArch), so you can read the files. BSArch unpacks " +
+         "the WHOLE archive (it has no per-file extract). Pass dest= a folder to unpack into; OMIT dest to let houseCARL " +
+         "unpack into a NEW reviewable mod folder under your mods directory (reported back) — that needs houseCARL pointed " +
+         "at your MO2 instance. Needs the BSArch path (auto-prompts if unset). Originals are never modified.")]
+    public static string BsaExtract(
+        LoadOrderService svc,
+        ToolPathResolver bridge,
+        [Description("Full path to the .bsa archive to extract.")]
+            string archive,
+        [Description("Optional. Folder to unpack into. If omitted, houseCARL creates a NEW mod folder under your mods directory and reports its path.")]
+            string? dest = null)
+    {
+        if (string.IsNullOrWhiteSpace(archive)) return "error: no archive given. Pass the full path to the .bsa.";
+        archive = archive.Trim().Trim('"');
+        if (!File.Exists(archive)) return $"error: no such file: '{archive}'.";
+        if (bridge.RequireOrPrompt(ToolDependency.Bsarch, out var bsarch) is { } prompt) return prompt;
+
+        string target;
+        bool managed = string.IsNullOrWhiteSpace(dest);
+        if (managed)
+        {
+            if (svc.ConfigPromptOrNull() is { } cfg) return cfg;   // need ModsDir for the default managed folder
+            try { target = svc.ResolvePatchModFolder(Path.GetFileNameWithoutExtension(archive) + " (extracted)", into: null, "houseCARL_Extract"); }
+            catch (InvalidOperationException ex) { return "error: " + ex.Message; }
+        }
+        else
+        {
+            target = Path.GetFullPath(dest!.Trim().Trim('"'));
+        }
+
+        var r = HousecarlCore.BsaArchive.Unpack(bsarch!, archive, target);
+        if (!r.Ran) return "error: " + r.RunError;
+        if (!r.Success)
+            return $"extract FAILED: '{Path.GetFileName(archive)}' produced no files in '{target}'. Raw BSArch output:\n" + r.Raw;
+
+        var sb = new StringBuilder();
+        sb.Append("extracted ").Append(Path.GetFileName(archive)).Append(" → ").Append(target).Append('\n');
+        sb.Append(managed
+            ? "(a new houseCARL mod folder — read the files you need from it; enable it in MO2 only if you want the loose files in your load order.)"
+            : "(read the files you need from that folder.)");
+        return sb.ToString();
+    }
+
+    [McpServerTool(Name = "housecarl_bsa_repack", Title = "Pack a folder into a .bsa archive"),
+     Description(
+         "Pack a folder of loose files into a Bethesda .bsa archive (via BSArch), placed in a NEW reviewable houseCARL mod " +
+         "folder under your mods directory (originals untouched; enable it in MO2 to use). format defaults to 'sse' (Skyrim " +
+         "Special Edition). compress defaults to FALSE — a compressed archive is smaller but BREAKS any sounds/voices it " +
+         "contains (a BSArch limitation), so only compress archives with no audio. Needs the BSArch path (auto-prompts if " +
+         "unset) and houseCARL pointed at your MO2 instance (for the output folder).")]
+    public static string BsaRepack(
+        LoadOrderService svc,
+        ToolPathResolver bridge,
+        [Description("Full path to the source folder of loose files to pack (its tree becomes the archive's contents).")]
+            string source_folder,
+        [Description("Optional. The .bsa filename to create (default: the source folder's name + '.bsa').")]
+            string? archive_name = null,
+        [Description("Optional. Archive format: 'sse' (default, Skyrim SE), 'tes5' (Skyrim LE), 'fo4', 'fo4dds', 'sf1', 'sf1dds', 'tes4', 'fo3', 'fnv', 'tes3'.")]
+            string? format = null,
+        [Description("Optional. Compress the archive (default false). WARNING: compression breaks sounds/voices — leave false if the folder contains any audio.")]
+            bool compress = false,
+        [Description("Optional. Base name for the NEW mod folder the .bsa lands in (default 'houseCARL_Archive'); auto-suffixed if taken.")]
+            string? patch_name = null,
+        [Description("Optional. Filename of an existing houseCARL patch mod to place the .bsa into instead of a fresh folder.")]
+            string? into = null)
+    {
+        if (string.IsNullOrWhiteSpace(source_folder)) return "error: no source_folder given.";
+        source_folder = Path.GetFullPath(source_folder.Trim().Trim('"'));
+        if (!Directory.Exists(source_folder)) return $"error: no such folder: '{source_folder}'.";
+        if (svc.ConfigPromptOrNull() is { } cfg) return cfg;
+        if (bridge.RequireOrPrompt(ToolDependency.Bsarch, out var bsarch) is { } prompt) return prompt;
+
+        var name = string.IsNullOrWhiteSpace(archive_name)
+            ? new DirectoryInfo(source_folder).Name + ".bsa"
+            : Path.GetFileName(archive_name!.Trim().Trim('"'));
+        if (!name.EndsWith(".bsa", StringComparison.OrdinalIgnoreCase)) name += ".bsa";
+
+        string folder;
+        try { folder = svc.ResolvePatchModFolder(patch_name, into, "houseCARL_Archive"); }
+        catch (InvalidOperationException ex) { return "error: " + ex.Message; }
+
+        var archive = Path.Combine(folder, name);
+        var fmtFlag = HousecarlCore.BsaArchive.FormatFlag(format);
+        var r = HousecarlCore.BsaArchive.Pack(bsarch!, source_folder, archive, fmtFlag, compress);
+        if (!r.Ran) return "error: " + r.RunError;
+        if (!r.Success)
+            return $"repack FAILED: no .bsa written at '{archive}'. Raw BSArch output:\n" + r.Raw;
+
+        var sb = new StringBuilder();
+        sb.Append("packed ").Append(name).Append(" (").Append(fmtFlag.TrimStart('-')).Append(compress ? ", compressed" : ", uncompressed").Append(") → ").Append(archive).Append('\n');
+        sb.Append("(a new houseCARL mod folder — enable it in MO2 to use the archive.)");
+        if (compress) sb.Append("\nNOTE: compressed — any sounds/voices in it will not work in-game (BSArch limitation).");
+        return sb.ToString();
+    }
+}

--- a/src/housecarl-mcp/CompileTools.cs
+++ b/src/housecarl-mcp/CompileTools.cs
@@ -89,16 +89,16 @@ public static class CompileTools
         {
             sb.Append("compile OK: ").Append(r.ObjectName).Append(".psc → ").Append(r.PexPath).Append('\n');
             sb.Append("the .pex is in a houseCARL patch-mod folder — enable it in MO2 to use it.");
-            if (r.Diagnostics.Count > 0)   // .pex produced but the compiler still emitted notes → treat as warnings
+            if (r.Diagnostics.Count > 0)   // a .pex WAS produced but the compiler emitted notes → surface them as warnings
             {
-                sb.Append('\n').Append(r.Diagnostics.Count).Append(" warning(s):");
+                sb.Append('\n').Append(r.Diagnostics.Count).Append(" warning(s) (the .pex compiled anyway):");
                 foreach (var d in r.Diagnostics) sb.Append("\n  ").Append(d);
             }
             return sb.ToString();
         }
 
-        // failed — no .pex
-        sb.Append("compile FAILED: ").Append(r.ObjectName).Append(".psc — no .pex written.");
+        // failed — this run wrote no .pex (a previous build, if any, is left untouched for the user to keep or delete)
+        sb.Append("compile FAILED: ").Append(r.ObjectName).Append(".psc — no new .pex produced (any previous build is left unchanged).");
         if (r.Diagnostics.Count > 0)
         {
             sb.Append('\n').Append(r.Diagnostics.Count).Append(" error(s):");

--- a/src/housecarl-mcp/CompileTools.cs
+++ b/src/housecarl-mcp/CompileTools.cs
@@ -1,0 +1,118 @@
+using System.ComponentModel;
+using System.Text;
+using ModelContextProtocol.Server;
+
+namespace HousecarlMcp;
+
+/// <summary>
+/// houseCARL compile rider — housecarl_compile_script. Drives the Creation Kit's PapyrusCompiler.exe (via
+/// <see cref="HousecarlCore.PapyrusCompile"/>; NOT Mutagen) to turn a .psc into a .pex, and lands the .pex in a reviewable
+/// houseCARL patch-mod folder (originals untouched — same folder-per-patch model as every other write). It rides the
+/// external-tool bridge: the compiler path comes from <see cref="ToolPathResolver"/> (auto-prompts via the forcing
+/// function if unset). The structured pass/fail return — per-line {file,line,col,message} diagnostics — is the point: it
+/// feeds the AI fix-loop (compile-fail → look the symbol up with the papyrus-reference skill → fix the .psc → recompile).
+/// </summary>
+[McpServerToolType]
+public static class CompileTools
+{
+    [McpServerTool(Name = "housecarl_compile_script", Title = "Compile a Papyrus script (.psc → .pex)"),
+     Description(
+         "Compile a Papyrus script (.psc) to .pex using the Creation Kit's PapyrusCompiler.exe, landing the .pex in a NEW " +
+         "houseCARL patch-mod folder you review and enable in MO2 (originals untouched). Pass script= the full path to the " +
+         ".psc to compile; houseCARL adds the script's own folder and the vanilla source folder (derived from the compiler's " +
+         "game dir) to the import path automatically — pass import_dirs= (';'-separated) for any extra dependency sources " +
+         "(SKSE, other mods). On a compile FAILURE it returns the per-line errors as 'name(line,col): message' so you can fix " +
+         "the .psc and recompile (look unfamiliar functions up with the papyrus-reference skill); on SUCCESS it returns the " +
+         ".pex path. Needs houseCARL pointed at your MO2 instance (for the output folder) and the Papyrus compiler path — if " +
+         "the compiler isn't set yet, houseCARL tells you exactly what to ask for and how to set it. The CK compiler ships " +
+         "with the vanilla Steam game install, NOT a Wabbajack 'Stock Game' copy.")]
+    public static string CompileScript(
+        LoadOrderService svc,
+        ToolPathResolver bridge,
+        [Description("Full path to the .psc source file to compile.")]
+            string script,
+        [Description("Optional. Extra import directories where dependency sources (.psc) live — SKSE, other mods — separated by ';'. The script's own folder and the vanilla source folder are added automatically.")]
+            string? import_dirs = null,
+        [Description("Optional. Base name for the NEW patch-mod folder the .pex lands in (default 'houseCARL_Scripts'); auto-suffixed if taken.")]
+            string? patch_name = null,
+        [Description("Optional. Filename of an existing houseCARL patch mod to add the .pex into instead of creating a fresh folder (accumulate compiled scripts).")]
+            string? into = null)
+    {
+        // 1) MO2 must be configured — the .pex lands under the instance's mods folder.
+        if (svc.ConfigPromptOrNull() is { } cfgPrompt) return cfgPrompt;
+
+        // 2) validate the script path.
+        if (string.IsNullOrWhiteSpace(script))
+            return "error: no script given. Pass script= the full path to the .psc file to compile.";
+        script = script.Trim().Trim('"');
+        if (!File.Exists(script))
+            return $"error: no such file: '{script}'. Pass the full path to the .psc source.";
+        if (!script.EndsWith(".psc", StringComparison.OrdinalIgnoreCase))
+            return $"error: '{Path.GetFileName(script)}' is not a .psc source file.";
+        script = Path.GetFullPath(script);
+        var objectName = Path.GetFileNameWithoutExtension(script);
+        var scriptDir = Path.GetDirectoryName(script)!;
+
+        // 3) the compiler — bridge forcing function if unset (returns the trained prompt to surface).
+        if (bridge.RequireOrPrompt(ToolDependency.PapyrusCompiler, out var compilerExe) is { } toolPrompt) return toolPrompt;
+
+        // 4) import dirs: the script's own folder + the vanilla sources (derived from the compiler's game dir:
+        //    <game>\Papyrus Compiler\PapyrusCompiler.exe → <game>\Data\Source\Scripts, which also holds the flags file) + caller extras.
+        var imports = new List<string> { scriptDir };
+        var gameRoot = Path.GetDirectoryName(Path.GetDirectoryName(compilerExe!));
+        if (gameRoot is not null)
+        {
+            var vanilla = Path.Combine(gameRoot, "Data", "Source", "Scripts");
+            if (Directory.Exists(vanilla)) imports.Add(vanilla);
+        }
+        if (!string.IsNullOrWhiteSpace(import_dirs))
+            foreach (var d in import_dirs.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                imports.Add(d.Trim('"'));
+        imports = imports.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+
+        // 5) output folder (folder-per-patch, Scripts\ subdir).
+        string outDir;
+        try { outDir = svc.ResolveCompiledScriptFolder(patch_name, into); }
+        catch (InvalidOperationException ex) { return "error: " + ex.Message; }
+
+        // 6) compile + render.
+        var result = HousecarlCore.PapyrusCompile.CompileObject(compilerExe!, objectName, imports, outDir);
+        return Render(result, imports);
+    }
+
+    static string Render(HousecarlCore.CompileResult r, IReadOnlyList<string> imports)
+    {
+        var sb = new StringBuilder();
+        if (!r.Ran) return "error: " + r.RunError;   // the compiler couldn't be run at all
+
+        if (r.Success)
+        {
+            sb.Append("compile OK: ").Append(r.ObjectName).Append(".psc → ").Append(r.PexPath).Append('\n');
+            sb.Append("the .pex is in a houseCARL patch-mod folder — enable it in MO2 to use it.");
+            if (r.Diagnostics.Count > 0)   // .pex produced but the compiler still emitted notes → treat as warnings
+            {
+                sb.Append('\n').Append(r.Diagnostics.Count).Append(" warning(s):");
+                foreach (var d in r.Diagnostics) sb.Append("\n  ").Append(d);
+            }
+            return sb.ToString();
+        }
+
+        // failed — no .pex
+        sb.Append("compile FAILED: ").Append(r.ObjectName).Append(".psc — no .pex written.");
+        if (r.Diagnostics.Count > 0)
+        {
+            sb.Append('\n').Append(r.Diagnostics.Count).Append(" error(s):");
+            foreach (var d in r.Diagnostics) sb.Append("\n  ").Append(d);
+            sb.Append("\nfix the .psc and recompile (look unfamiliar functions/types up with the papyrus-reference skill). " +
+                      "If a dependency type is 'not found', its source folder may be missing from the import path — pass it via import_dirs=.");
+        }
+        else
+        {
+            // no parseable diagnostics — surface the raw compiler output rather than a silent empty failure (Q3)
+            sb.Append("\nthe compiler reported failure but no per-line diagnostics were parsed. Raw output:");
+            if (r.Stderr.Trim().Length > 0) sb.Append("\n[stderr] ").Append(r.Stderr.Trim());
+            if (r.Stdout.Trim().Length > 0) sb.Append("\n[stdout] ").Append(r.Stdout.Trim());
+        }
+        return sb.ToString();
+    }
+}

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -686,44 +686,51 @@ public sealed class LoadOrderService : IDisposable
         return Path.Combine(newFolder, plugin);
     }
 
-    /// <summary>Resolve the <c>Scripts\</c> output folder for a COMPILED .pex under the folder-per-patch model — the compile
-    /// rider's analogue of <see cref="ResolveOutputPath"/>. A fresh houseCARL mod folder (marker-stamped) or
-    /// <paramref name="into"/> an existing houseCARL-owned one; the .pex lands in its <c>Scripts\</c> subfolder (where MO2
-    /// deploys compiled Papyrus into the game's Data\Scripts). ORIGINALS UNTOUCHED (Q3): refuses a folder houseCARL didn't
-    /// create. Derives ModsDir CHEAPLY (reads ModOrganizer.ini; no ~10s index build). Throws the trained prompt when
-    /// unconfigured. Reuses the same ownership/marker helpers as the .esp write path.</summary>
-    public string ResolveCompiledScriptFolder(string? patchName, string? into)
+    /// <summary>Resolve a houseCARL-owned MOD FOLDER under ModsDir for a NON-.esp output (compiled scripts, a packed .bsa,
+    /// extracted loose files) — the folder-per-patch model generalised beyond the .esp write path. A fresh marker-stamped
+    /// folder (<paramref name="defaultStem"/> names it when patchName is blank; auto-suffixed so a prior one is never
+    /// clobbered) or <paramref name="into"/> an existing houseCARL-owned one. ORIGINALS UNTOUCHED (Q3): refuses a folder
+    /// houseCARL didn't create. Derives ModsDir CHEAPLY (reads ModOrganizer.ini; NO ~10s index build). Throws the trained
+    /// prompt when unconfigured. Reuses the same ownership/marker helpers as the .esp write path.</summary>
+    public string ResolvePatchModFolder(string? patchName, string? into, string defaultStem)
     {
         lock (_gate)
         {
             if (!_configured) throw NotConfigured();
             EnsurePathsDerived();                          // cheap: derive ModsDir from the instance, NO resolver build
             if (!Directory.Exists(_modsDir))
-                throw new InvalidOperationException($"cannot write the compiled script: ModsDir '{_modsDir}' does not exist.");
+                throw new InvalidOperationException($"cannot write: ModsDir '{_modsDir}' does not exist.");
 
-            string folder;
             if (!string.IsNullOrWhiteSpace(into))
             {
                 var stem = PatchStem(into);
-                folder = Path.Combine(_modsDir, ModFolderName(stem));
+                var folder = Path.Combine(_modsDir, ModFolderName(stem));
                 if (!Directory.Exists(folder))
                     throw new InvalidOperationException(
                         $"cannot extend: no houseCARL patch named '{stem}' (mod folder '{ModFolderName(stem)}' not found). Omit into= to create it fresh.");
                 if (!IsHouseCarlOwned(folder))
                     throw new InvalidOperationException(
                         $"cannot extend: mod folder '{ModFolderName(stem)}' was NOT created by houseCARL (no marker) — refusing to write into a folder houseCARL doesn't own (Q3).");
+                return folder;
             }
-            else
-            {
-                var stem = UniqueStem(PatchStem(string.IsNullOrWhiteSpace(patchName) ? "houseCARL_Scripts" : patchName!));
-                folder = Path.Combine(_modsDir, ModFolderName(stem));
-                Directory.CreateDirectory(folder);
-                WriteOwnerMeta(folder, "(compiled scripts)");   // ownership marker; a script-only mod has no .esp
-            }
-            var scripts = Path.Combine(folder, "Scripts");
-            Directory.CreateDirectory(scripts);
-            return scripts;
+
+            var newStem = UniqueStem(PatchStem(string.IsNullOrWhiteSpace(patchName) ? defaultStem : patchName!));
+            var newFolder = Path.Combine(_modsDir, ModFolderName(newStem));
+            Directory.CreateDirectory(newFolder);
+            WriteOwnerMeta(newFolder, "(houseCARL output)");   // ownership marker; this folder may hold scripts / a .bsa / loose files, not an .esp
+            return newFolder;
         }
+    }
+
+    /// <summary>The <c>Scripts\</c> output folder for a COMPILED .pex (the compile rider) — a houseCARL mod folder via
+    /// <see cref="ResolvePatchModFolder"/> plus its <c>Scripts\</c> subfolder, where MO2 deploys compiled Papyrus into the
+    /// game's Data\Scripts.</summary>
+    public string ResolveCompiledScriptFolder(string? patchName, string? into)
+    {
+        var folder = ResolvePatchModFolder(patchName, into, "houseCARL_Scripts");
+        var scripts = Path.Combine(folder, "Scripts");
+        Directory.CreateDirectory(scripts);
+        return scripts;
     }
 
     /// <summary>The MO2 mod-folder name for a patch stem. The "houseCARL - " prefix groups our patches in MO2's left

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Records;
 
@@ -34,7 +33,7 @@ public sealed class LoadOrderService : IDisposable
     string _profileDir;
     string _profileName;                           // the active profile (instance mode: from selected_profile)
     bool _configured;                              // false ⇒ tools return the trained prompt instead of resolving
-    readonly string _userConfigPath;               // where housecarl_set_mo2_instance persists the chosen instance dir
+    readonly UserConfigStore _store;               // the sole owner of houseCARL.user.json (MO2 instance dir + tool paths)
     readonly int _maxPlugins;
     readonly object _gate = new();
     LoadOrderResolver? _resolver;
@@ -44,7 +43,7 @@ public sealed class LoadOrderService : IDisposable
     DateTime _iniReadUtc = DateTime.MinValue;      // when ModOrganizer.ini was last read (instance-mode profile-switch baseline)
     IReadOnlyList<string> _resolvedPaths = Array.Empty<string>();   // ordered paths the current snapshot was built from (the cheap "did the order actually change?" check)
 
-    LoadOrderService(string? instanceDir, string dataDir, string modsDir, string profileDir, bool configured, int maxPlugins, string userConfigPath)
+    LoadOrderService(string? instanceDir, string dataDir, string modsDir, string profileDir, bool configured, int maxPlugins, UserConfigStore store)
     {
         _instanceDir = instanceDir;
         _dataDir = dataDir;
@@ -53,20 +52,20 @@ public sealed class LoadOrderService : IDisposable
         _profileName = profileDir.Length > 0 ? Path.GetFileName(profileDir.TrimEnd('\\', '/')) : "";
         _configured = configured;
         _maxPlugins = maxPlugins;
-        _userConfigPath = userConfigPath;
+        _store = store;
     }
 
     /// <summary>INSTANCE mode (product default): derive the load-order roots + active profile from ONE MO2 instance folder
     /// (lazily, on the first build). A null/blank <paramref name="instanceDir"/> ⇒ UNCONFIGURED (boots; tools prompt for the
     /// path). The instance is re-read on a profile switch, so a mid-session switch is followed.</summary>
-    public static LoadOrderService WithInstance(string? instanceDir, int maxPlugins, string userConfigPath)
+    public static LoadOrderService WithInstance(string? instanceDir, int maxPlugins, UserConfigStore store)
         => new(string.IsNullOrWhiteSpace(instanceDir) ? null : instanceDir.Trim(),
-               "", "", "", configured: !string.IsNullOrWhiteSpace(instanceDir), maxPlugins, userConfigPath);
+               "", "", "", configured: !string.IsNullOrWhiteSpace(instanceDir), maxPlugins, store);
 
     /// <summary>EXPLICIT mode (dev / non-portable override): the three roots are configured directly; no ModOrganizer.ini is
     /// read and no profile-switch watch runs (the paths are fixed for the process lifetime).</summary>
-    public static LoadOrderService WithExplicitPaths(string dataDir, string modsDir, string profileDir, int maxPlugins, string userConfigPath)
-        => new(null, dataDir, modsDir, profileDir, configured: true, maxPlugins, userConfigPath);
+    public static LoadOrderService WithExplicitPaths(string dataDir, string modsDir, string profileDir, int maxPlugins, UserConfigStore store)
+        => new(null, dataDir, modsDir, profileDir, configured: true, maxPlugins, store);
 
     /// <summary>Non-fatal warnings from the last order build (Q3) — e.g. a plugin the load order lists that no enabled
     /// mod provides (stale profile files). Surfaced, never swallowed. Empty until the resolver first builds.</summary>
@@ -237,6 +236,19 @@ public sealed class LoadOrderService : IDisposable
     /// name); "" when unconfigured. For the status surface.</summary>
     public string ProfileName { get { lock (_gate) { return _profileName; } } }
 
+    /// <summary>The resolved MO2 instance's Skyrim game root (ModOrganizer.ini gamePath), derived CHEAPLY (reads the ini,
+    /// does NOT force the ~10s load-order index build) — for the tool bridge's compiler auto-detect, which probes
+    /// &lt;game&gt;\Papyrus Compiler\PapyrusCompiler.exe. Null in explicit/unconfigured mode, or if the instance can't be
+    /// read right now (the bridge then just prompts the user for the path). Never throws (Q3).</summary>
+    public string? TryGetGamePath()
+    {
+        lock (_gate)
+        {
+            if (_instanceDir is null) return null;
+            return Mo2Instance.TryResolve(_instanceDir, out var p) && p is not null ? p.GamePath : null;
+        }
+    }
+
     /// <summary>Point houseCARL at an MO2 instance folder — first-run setup AND switching between instances ("jump around").
     /// VALIDATES it (<see cref="Mo2Instance.Resolve"/> throws a clear Q3 message if it isn't usable — nothing is changed or
     /// persisted on failure), then re-points the live service (derives the roots + active profile, drops the cached resolver
@@ -260,26 +272,12 @@ public sealed class LoadOrderService : IDisposable
         return (paths, persisted, persistError);
     }
 
-    /// <summary>Persist the chosen instance dir to the user config JSON so the next boot finds it. Best-effort + HONEST
-    /// (Q3): a write failure (e.g. a read-only install dir) is reported, not swallowed — the session still works, but the
-    /// user is told the choice won't survive a restart.</summary>
+    /// <summary>Persist the chosen instance dir through the shared <see cref="UserConfigStore"/> (read-modify-write), so it
+    /// survives a restart AND coexists with any saved tool paths — the store never clobbers the other concern's field.
+    /// Best-effort + HONEST (Q3): a write failure (e.g. a read-only data dir) is reported, not swallowed — the session
+    /// still works, but the user is told the choice won't survive a restart.</summary>
     (bool ok, string? error) PersistInstanceDir(string instanceDir)
-    {
-        try
-        {
-            var dir = Path.GetDirectoryName(_userConfigPath);   // the data dir (${CLAUDE_PLUGIN_DATA}) may not exist on the first save
-            if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
-            File.WriteAllText(_userConfigPath, JsonSerializer.Serialize(new UserConfig { Mo2InstanceDir = instanceDir }, UserConfigJson));
-            return (true, null);
-        }
-        catch (Exception ex) { return (false, ex.Message); }
-    }
-
-    static readonly JsonSerializerOptions UserConfigJson = new() { WriteIndented = true };
-
-    /// <summary>The on-disk user config shape (houseCARL.user.json) — the one user-set value houseCARL persists itself,
-    /// separate from the shipped appsettings.json. Read at boot (Program.cs), written by <see cref="SetInstance"/>.</summary>
-    public sealed class UserConfig { public string? Mo2InstanceDir { get; set; } }
+        => _store.Update(c => c.Mo2InstanceDir = instanceDir);
 
     /// <summary>The trained prompt shown while unconfigured: tells houseCARL to ask the user which MO2 instance to use (not
     /// silently pick among several) and call the setup tool. Tools RETURN this (so the client SEES it) via <see cref="ConfigPromptOrNull"/>; the <see cref="Resolver"/>

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -236,19 +236,6 @@ public sealed class LoadOrderService : IDisposable
     /// name); "" when unconfigured. For the status surface.</summary>
     public string ProfileName { get { lock (_gate) { return _profileName; } } }
 
-    /// <summary>The resolved MO2 instance's Skyrim game root (ModOrganizer.ini gamePath), derived CHEAPLY (reads the ini,
-    /// does NOT force the ~10s load-order index build) — for the tool bridge's compiler auto-detect, which probes
-    /// &lt;game&gt;\Papyrus Compiler\PapyrusCompiler.exe. Null in explicit/unconfigured mode, or if the instance can't be
-    /// read right now (the bridge then just prompts the user for the path). Never throws (Q3).</summary>
-    public string? TryGetGamePath()
-    {
-        lock (_gate)
-        {
-            if (_instanceDir is null) return null;
-            return Mo2Instance.TryResolve(_instanceDir, out var p) && p is not null ? p.GamePath : null;
-        }
-    }
-
     /// <summary>Point houseCARL at an MO2 instance folder — first-run setup AND switching between instances ("jump around").
     /// VALIDATES it (<see cref="Mo2Instance.Resolve"/> throws a clear Q3 message if it isn't usable — nothing is changed or
     /// persisted on failure), then re-points the live service (derives the roots + active profile, drops the cached resolver
@@ -697,6 +684,46 @@ public sealed class LoadOrderService : IDisposable
         var plugin = freeStem + ".esp";
         WriteOwnerMeta(newFolder, plugin);
         return Path.Combine(newFolder, plugin);
+    }
+
+    /// <summary>Resolve the <c>Scripts\</c> output folder for a COMPILED .pex under the folder-per-patch model — the compile
+    /// rider's analogue of <see cref="ResolveOutputPath"/>. A fresh houseCARL mod folder (marker-stamped) or
+    /// <paramref name="into"/> an existing houseCARL-owned one; the .pex lands in its <c>Scripts\</c> subfolder (where MO2
+    /// deploys compiled Papyrus into the game's Data\Scripts). ORIGINALS UNTOUCHED (Q3): refuses a folder houseCARL didn't
+    /// create. Derives ModsDir CHEAPLY (reads ModOrganizer.ini; no ~10s index build). Throws the trained prompt when
+    /// unconfigured. Reuses the same ownership/marker helpers as the .esp write path.</summary>
+    public string ResolveCompiledScriptFolder(string? patchName, string? into)
+    {
+        lock (_gate)
+        {
+            if (!_configured) throw NotConfigured();
+            EnsurePathsDerived();                          // cheap: derive ModsDir from the instance, NO resolver build
+            if (!Directory.Exists(_modsDir))
+                throw new InvalidOperationException($"cannot write the compiled script: ModsDir '{_modsDir}' does not exist.");
+
+            string folder;
+            if (!string.IsNullOrWhiteSpace(into))
+            {
+                var stem = PatchStem(into);
+                folder = Path.Combine(_modsDir, ModFolderName(stem));
+                if (!Directory.Exists(folder))
+                    throw new InvalidOperationException(
+                        $"cannot extend: no houseCARL patch named '{stem}' (mod folder '{ModFolderName(stem)}' not found). Omit into= to create it fresh.");
+                if (!IsHouseCarlOwned(folder))
+                    throw new InvalidOperationException(
+                        $"cannot extend: mod folder '{ModFolderName(stem)}' was NOT created by houseCARL (no marker) — refusing to write into a folder houseCARL doesn't own (Q3).");
+            }
+            else
+            {
+                var stem = UniqueStem(PatchStem(string.IsNullOrWhiteSpace(patchName) ? "houseCARL_Scripts" : patchName!));
+                folder = Path.Combine(_modsDir, ModFolderName(stem));
+                Directory.CreateDirectory(folder);
+                WriteOwnerMeta(folder, "(compiled scripts)");   // ownership marker; a script-only mod has no .esp
+            }
+            var scripts = Path.Combine(folder, "Scripts");
+            Directory.CreateDirectory(scripts);
+            return scripts;
+        }
     }
 
     /// <summary>The MO2 mod-folder name for a patch stem. The "houseCARL - " prefix groups our patches in MO2's left

--- a/src/housecarl-mcp/Program.cs
+++ b/src/housecarl-mcp/Program.cs
@@ -98,14 +98,13 @@ static (LoadOrderService svc, bool explicitMode, string? instanceDir, string ins
         : LoadOrderService.WithInstance(instanceDir, maxPlugins, store);
     services.AddSingleton(svc);
 
-    // The external-tool bridge (compile / BSA / log access): one resolver over the shared user config, given a cheap
-    // accessor for the MO2 instance's Skyrim game root (the compiler auto-detect probe). Riders inject it as it lands.
-    services.AddSingleton(new ToolPathResolver(store, () => svc.TryGetGamePath()));
+    // The external-tool bridge (compile / BSA / log access): one resolver over the shared user config. Riders inject it.
+    services.AddSingleton(new ToolPathResolver(store));
 
     return (svc, explicitMode, instanceDir, instanceSource);
 }
 
-// The MCP server registration — server identity + instructions + the 10 attribute-registered tools. ONLY the
+// The MCP server registration — server identity + instructions + the 11 attribute-registered tools. ONLY the
 // transport line differs between modes (the whole point of the stdio/http split); everything else is shared.
 static void AddMcp(IServiceCollection services, bool stdio)
 {

--- a/src/housecarl-mcp/Program.cs
+++ b/src/housecarl-mcp/Program.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using HousecarlMcp;
 using ModelContextProtocol.Protocol;
 
@@ -77,12 +76,11 @@ static (LoadOrderService svc, bool explicitMode, string? instanceDir, string ins
     var pluginDataDir = Environment.GetEnvironmentVariable("HOUSECARL_DATA_DIR");
     var userConfigDir = string.IsNullOrWhiteSpace(pluginDataDir) ? AppContext.BaseDirectory : pluginDataDir;
     var userConfigPath = Path.Combine(userConfigDir, "houseCARL.user.json");
-    string? userInstanceDir = null;
-    if (File.Exists(userConfigPath))
-    {
-        try { userInstanceDir = JsonSerializer.Deserialize<LoadOrderService.UserConfig>(File.ReadAllText(userConfigPath))?.Mo2InstanceDir; }
-        catch { /* corrupt user config → ignore; fall through */ }
-    }
+    // ONE owner of houseCARL.user.json (UserConfigStore): the MO2 instance dir AND the external-tool paths share the file,
+    // so neither writer clobbers the other (read-modify-write). Tolerant read (corrupt/missing → blank, never crashes — Q3).
+    var store = new UserConfigStore(userConfigPath);
+    services.AddSingleton(store);
+    string? userInstanceDir = store.Load().Mo2InstanceDir;
 
     // PRECEDENCE (§6d): the saved user config (houseCARL.user.json, written by housecarl_set_mo2_instance at RUNTIME) wins
     // over Mo2InstanceDir (the userConfig install-dialog value / appsettings) — the runtime switch beats the install default.
@@ -96,13 +94,18 @@ static (LoadOrderService svc, bool explicitMode, string? instanceDir, string ins
         && !string.IsNullOrWhiteSpace(dataDir) && !string.IsNullOrWhiteSpace(modsDir) && !string.IsNullOrWhiteSpace(profileDir);
 
     LoadOrderService svc = explicitMode
-        ? LoadOrderService.WithExplicitPaths(dataDir!, modsDir!, profileDir!, maxPlugins, userConfigPath)
-        : LoadOrderService.WithInstance(instanceDir, maxPlugins, userConfigPath);
+        ? LoadOrderService.WithExplicitPaths(dataDir!, modsDir!, profileDir!, maxPlugins, store)
+        : LoadOrderService.WithInstance(instanceDir, maxPlugins, store);
     services.AddSingleton(svc);
+
+    // The external-tool bridge (compile / BSA / log access): one resolver over the shared user config, given a cheap
+    // accessor for the MO2 instance's Skyrim game root (the compiler auto-detect probe). Riders inject it as it lands.
+    services.AddSingleton(new ToolPathResolver(store, () => svc.TryGetGamePath()));
+
     return (svc, explicitMode, instanceDir, instanceSource);
 }
 
-// The MCP server registration — server identity + instructions + the 9 attribute-registered tools. ONLY the
+// The MCP server registration — server identity + instructions + the 10 attribute-registered tools. ONLY the
 // transport line differs between modes (the whole point of the stdio/http split); everything else is shared.
 static void AddMcp(IServiceCollection services, bool stdio)
 {

--- a/src/housecarl-mcp/Program.cs
+++ b/src/housecarl-mcp/Program.cs
@@ -104,7 +104,7 @@ static (LoadOrderService svc, bool explicitMode, string? instanceDir, string ins
     return (svc, explicitMode, instanceDir, instanceSource);
 }
 
-// The MCP server registration — server identity + instructions + the 11 attribute-registered tools. ONLY the
+// The MCP server registration — server identity + instructions + the 14 attribute-registered tools. ONLY the
 // transport line differs between modes (the whole point of the stdio/http split); everything else is shared.
 static void AddMcp(IServiceCollection services, bool stdio)
 {

--- a/src/housecarl-mcp/SetupTools.cs
+++ b/src/housecarl-mcp/SetupTools.cs
@@ -5,12 +5,15 @@ using ModelContextProtocol.Server;
 namespace HousecarlMcp;
 
 /// <summary>
-/// houseCARL setup tool — the one piece of config the USER owns: WHERE Mod Organizer 2 is. houseCARL needs a single path
-/// (the MO2 instance folder); it reads ModOrganizer.ini to derive the mods folder, the ACTIVE profile, and the game Data
-/// folder (<see cref="Mo2Instance"/>), so the user never hand-types those and the profile is always auto-detected.
-/// First-run setup (an unconfigured server's tools return a trained prompt naming this tool) AND switching between MO2
-/// instances both flow through here. Validates loud (Q3 — nothing changes on a bad path) and persists the choice to
-/// houseCARL.user.json so it survives a restart. The 9th MCP tool.
+/// houseCARL setup tools — the config the USER owns, persisted to houseCARL.user.json (validated loud; nothing saved on a
+/// bad value — Q3). Two tools live here:
+///   • housecarl_set_mo2_instance — WHERE Mod Organizer 2 is: one path (the instance folder); ModOrganizer.ini yields the
+///     mods folder, the ACTIVE profile, and the game Data folder (<see cref="Mo2Instance"/>), so nothing is hand-typed.
+///     First-run setup (an unconfigured server's tools return a trained prompt naming this tool) AND switching instances
+///     both flow through here.
+///   • housecarl_set_tool_path — WHERE an external tool is (the Papyrus compiler, BSArch, or a log folder): the bridge the
+///     compile / BSA / log-access riders sit on. Auto-detects canonical homes, so it's usually only needed for BSArch or a
+///     non-standard install (<see cref="ToolPathResolver"/> + <see cref="ToolBridge"/>).
 /// </summary>
 [McpServerToolType]
 public static class SetupTools
@@ -38,6 +41,44 @@ public static class SetupTools
         catch (InvalidOperationException ex) { return "error: " + ex.Message; }   // not a usable instance — Q3 reason, nothing changed
 
         return Render(paths, persisted, persistError);
+    }
+
+    [McpServerTool(Name = "housecarl_set_tool_path", Title = "Tell houseCARL where an external tool is"),
+     Description(
+         "Give houseCARL the path to an external tool it drives: 'papyrus_compiler' (the Creation Kit's " +
+         "PapyrusCompiler.exe, for compiling .psc scripts to .pex), 'bsarch' (BSArch.exe, for .bsa archive " +
+         "list/extract/repack), 'papyrus_logs' (the Papyrus script-log FOLDER), or 'crash_logs' (the SKSE crash-log " +
+         "FOLDER) — the bridge houseCARL's compile / BSA / log-reading capabilities sit on. houseCARL AUTO-DETECTS the " +
+         "canonical homes for the compiler and the log folders, so you usually only need this for BSArch (no fixed home) " +
+         "or a non-standard install. VALIDATES the path — the .exe exists and looks like the right tool; the log folder " +
+         "exists — and reports exactly what's wrong if not, saving NOTHING on failure (Q3). On success it SAVES the choice " +
+         "to houseCARL.user.json so it persists across restarts, coexisting with your MO2 instance setting. tool must be " +
+         "one of: papyrus_compiler, bsarch, papyrus_logs, crash_logs.")]
+    public static string SetToolPath(
+        ToolPathResolver bridge,
+        [Description("Which tool: 'papyrus_compiler' (CK PapyrusCompiler.exe), 'bsarch' (BSArch.exe), 'papyrus_logs' (script-log folder), or 'crash_logs' (SKSE crash-log folder).")]
+            string tool,
+        [Description("Full path to the tool: the .exe FILE for papyrus_compiler/bsarch, or the log DIRECTORY for papyrus_logs/crash_logs.")]
+            string path)
+    {
+        if (string.IsNullOrWhiteSpace(tool))
+            return "error: no tool named. Pass tool= one of: " + ToolBridge.WireKeys + ".";
+        if (!ToolBridge.TryParse(tool, out var dep))
+            return $"error: unknown tool '{tool}'. Expected one of: {ToolBridge.WireKeys}.";
+        if (string.IsNullOrWhiteSpace(path))
+            return $"error: no path given for '{tool}'. Pass the full path to {ToolBridge.Info(dep).Display}.";
+
+        var (ok, error, persisted, persistError, resolved) = bridge.Save(dep, path);
+        if (!ok) return "error: " + error;   // validation failed — nothing saved (Q3)
+
+        var info = ToolBridge.Info(dep);
+        var sb = new StringBuilder();
+        sb.Append("configured houseCARL -> ").Append(info.Display).Append('\n');
+        sb.Append("  path: ").Append(resolved).Append('\n');
+        sb.Append(persisted
+            ? "saved to houseCARL.user.json — persists across restarts (coexists with your MO2 instance)."
+            : $"NOTE: could not save ({persistError}) — works this session, but you'll need to set it again after a restart.");
+        return sb.ToString();
     }
 
     /// <summary>Confirmation: the instance + the DERIVED roots + the AUTO-DETECTED profile, a cheap enabled/active summary

--- a/src/housecarl-mcp/ToolPathResolver.cs
+++ b/src/housecarl-mcp/ToolPathResolver.cs
@@ -16,13 +16,8 @@ namespace HousecarlMcp;
 public sealed class ToolPathResolver
 {
     readonly UserConfigStore _store;
-    readonly Func<string?> _gamePath;   // the resolved MO2 instance's Skyrim game root, when cheaply known (for compiler auto-detect); null otherwise
 
-    public ToolPathResolver(UserConfigStore store, Func<string?> gamePath)
-    {
-        _store = store;
-        _gamePath = gamePath;
-    }
+    public ToolPathResolver(UserConfigStore store) => _store = store;
 
     /// <summary>The path the user SAVED for a dependency, or null if unset. Pure read (no probe, no persist) — for a status
     /// surface or a "what's configured" question.</summary>
@@ -40,7 +35,7 @@ public sealed class ToolPathResolver
         var saved = Saved(dep);
         if (saved is not null && ToolBridge.Validate(dep, saved).ok) return saved;
 
-        var found = ToolBridge.Probe(dep, _gamePath());
+        var found = ToolBridge.Probe(dep);
         if (found is not null) Save(dep, found);   // persist the auto-detected home so we only probe once
         return found;
     }

--- a/src/housecarl-mcp/ToolPathResolver.cs
+++ b/src/housecarl-mcp/ToolPathResolver.cs
@@ -1,0 +1,73 @@
+namespace HousecarlMcp;
+
+/// <summary>
+/// The runtime bridge between houseCARL's external-tool RIDERS (compile, BSA, log access) and the user-supplied paths they
+/// need. Singleton. Sits on <see cref="UserConfigStore"/> (the saved paths, shared with the MO2-instance setting) and
+/// <see cref="ToolBridge"/> (the catalog, validation, auto-detect, and the trained missing-dependency prompt).
+///
+/// Resolution order for a dependency (<see cref="Resolve"/>): (1) a path the user SAVED via housecarl_set_tool_path wins;
+/// (2) else AUTO-DETECT a canonical home and, on a hit, persist it silently so we probe once; (3) else null — the caller
+/// fires the forcing function (<see cref="RequireOrPrompt"/>), which returns the trained prompt so the AI reliably asks the
+/// user and is handed the exact resolving call. This is Q3 pointed at external deps: a RETURNED string reaches the client,
+/// where a throw would be genericized away — the same lesson the MO2 not-configured prompt proved (2026-06-02).
+///
+/// Step 1 builds + proves this bridge; the riders (compile, BSA) call <see cref="RequireOrPrompt"/> as they land.
+/// </summary>
+public sealed class ToolPathResolver
+{
+    readonly UserConfigStore _store;
+    readonly Func<string?> _gamePath;   // the resolved MO2 instance's Skyrim game root, when cheaply known (for compiler auto-detect); null otherwise
+
+    public ToolPathResolver(UserConfigStore store, Func<string?> gamePath)
+    {
+        _store = store;
+        _gamePath = gamePath;
+    }
+
+    /// <summary>The path the user SAVED for a dependency, or null if unset. Pure read (no probe, no persist) — for a status
+    /// surface or a "what's configured" question.</summary>
+    public string? Saved(ToolDependency dep)
+    {
+        var paths = _store.Load().ToolPaths;
+        return paths is not null && paths.TryGetValue(ToolBridge.Info(dep).Key, out var p) ? p : null;
+    }
+
+    /// <summary>Resolve a dependency to a usable path: saved → else auto-detect (persist on hit) → else null. A saved path
+    /// that no longer validates (tool moved/uninstalled) is treated as unset, so it re-detects or re-prompts rather than
+    /// failing opaquely downstream.</summary>
+    public string? Resolve(ToolDependency dep)
+    {
+        var saved = Saved(dep);
+        if (saved is not null && ToolBridge.Validate(dep, saved).ok) return saved;
+
+        var found = ToolBridge.Probe(dep, _gamePath());
+        if (found is not null) Save(dep, found);   // persist the auto-detected home so we only probe once
+        return found;
+    }
+
+    /// <summary>Validate + SAVE a user-supplied path for a dependency (the housecarl_set_tool_path body). The path is
+    /// trimmed of surrounding quotes and made absolute. On a validation failure NOTHING is saved (Q3) and the reason is
+    /// returned; on success it's written to the shared user.json (coexisting with the MO2 instance setting).</summary>
+    public (bool ok, string? error, bool persisted, string? persistError, string resolved) Save(ToolDependency dep, string rawPath)
+    {
+        var path = (rawPath ?? "").Trim().Trim('"');
+        if (path.Length == 0) return (false, "no path given.", false, null, "");
+        try { path = Path.GetFullPath(path); }
+        catch (Exception ex) { return (false, $"'{rawPath}' is not a usable path ({ex.Message}).", false, null, rawPath ?? ""); }
+
+        var (ok, error) = ToolBridge.Validate(dep, path);
+        if (!ok) return (false, error, false, null, path);
+
+        var (persisted, persistError) = _store.Update(c => (c.ToolPaths ??= new())[ToolBridge.Info(dep).Key] = path);
+        return (true, null, persisted, persistError, path);
+    }
+
+    /// <summary>The forcing function a rider calls: out <paramref name="path"/> is the resolved path when available and the
+    /// return is null (proceed); otherwise the return is the trained prompt string for the rider to RETURN to the client
+    /// (so the AI surfaces the ask + the resolving call) and path is null. Exactly one of the two is non-null.</summary>
+    public string? RequireOrPrompt(ToolDependency dep, out string? path)
+    {
+        path = Resolve(dep);
+        return path is null ? ToolBridge.RenderMissingPrompt(dep) : null;
+    }
+}


### PR DESCRIPTION
## External-tool bridge wave (steps 1-3 of the EXTERNAL_TOOL_BRIDGE_PLAN)

Adds houseCARL's external-tool bridge and two rider families, all **additive** — the proven 1.0 record engine (reflection generator, ReadEngine, WriteEngine, LoadOrderResolver) is untouched.

### What's here (3 atomic commits)
1. **Bridge** (`c053d1d`) — `housecarl_set_tool_path` + a fail-loud forcing function (an unset tool dependency returns a trained prompt that scripts the ask + the resolving call) + canonical-home auto-detect. `UserConfigStore` becomes the single, clobber-safe owner of `houseCARL.user.json` so the MO2 setting and tool paths coexist without overwriting each other.
2. **Compile rider** (`b266f0c`) — `housecarl_compile_script` wraps the CK's PapyrusCompiler.exe (NOT Mutagen), with structured `{file,line,col,message}` diagnostics for the AI fix-loop. The `.pex` lands in a folder-per-patch mod folder.
3. **BSA riders** (`80fa07f`) — `housecarl_bsa_list` / `_extract` / `_repack` wrap BSArch.

### Grounded against the real tools (measured 2026-06-05)
- PapyrusCompiler: errors on stderr as `path(line,col): message`; the **exit code is unreliable** (0 on a usage error), so success = the `.pex` exists + no error diagnostics.
- BSArch: `-list` = info block + `Files: N` + the N paths; unpack is whole-archive (no per-file); `-z` breaks sounds/voices, so uncompressed is the default.
- The CK compiler lives in the **vanilla Steam install**, not the MO2 "Stock Game" copy, so it resolves via the forcing prompt (Steam-library auto-detect is a noted follow-up).

### Proofs
- Re-runnable generator probes: `tool-bridge`, `compile-probe` (real `.psc -> .pex`), `bsa-probe` (real list -> unpack -> pack -> re-list round-trip).
- A full **live gate through a real MCP client**: all 14 tools register, both forcing prompts reach the client, `set_tool_path` saves + rejects a bad path, a rider executes live, paths persist across a restart, and a real compile produced a `.pex` — all isolated from the real modlist.

### Deferred (not in this PR)
- Step 4 (logs rider): `papyrus_logs`/`crash_logs` config + auto-detect already exist in the bridge; surfacing resolved log paths in `load_order_status` is a fast follow-up.
- "The `.pex`/`.bsa` loads in-game": a game-launch confirmation (the artifacts come from the canonical CK / BSArch tools driven with the proven invocation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
