### PR TITLE
ci: build + probe gate (GitHub Actions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+# houseCARL CI — a green/red gate on every push to main and every pull request.
+# What it does, in plain terms: a fresh Windows machine on GitHub's servers compiles
+# houseCARL and runs its re-runnable proof probes. Green = it builds and the core logic
+# passes; red = something broke. The probes self-SKIP the parts that need external tools
+# (the Creation Kit's Papyrus compiler, BSArch) which aren't installed on the runner, so
+# they stay a reliable gate without those tools present.
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-and-probe:
+    name: build + probes
+    runs-on: windows-latest   # houseCARL is a Windows-only (Skyrim SE) product — match that
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
+
+      - name: Set up .NET 9
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Build the whole solution (Release)
+        run: dotnet build housecarl.sln --configuration Release
+
+      # Each probe returns 0 (pass) / non-zero (fail); a failure fails the job.
+      - name: Probe — external-tool bridge (pure logic; runs fully)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- tool-bridge
+
+      - name: Probe — compile rider (stderr parser; compile layer skips without the CK compiler)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- compile-probe
+
+      - name: Probe — BSA riders (skips without BSArch)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- bsa-probe


### PR DESCRIPTION
Adds a CI workflow so every push to `main` and every pull request gets an automatic green/red health check — and so the **CI badge** in the desktop UI actually does something.

**What it runs** (on a `windows-latest` runner, matching the Windows-only product):
1. `dotnet build housecarl.sln` (Release) — does it compile?
2. `tool-bridge` probe — pure config/validation logic, runs fully.
3. `compile-probe` — the Papyrus stderr parser (the compile-against-the-real-CK layer self-skips; no compiler on the runner).
4. `bsa-probe` — self-skips cleanly without BSArch installed.

The probes are designed to skip the external-tool layers gracefully, so they're a reliable gate even though the CK compiler / BSArch aren't on the runner. This PR is itself the first thing CI will check — watch it go green here before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)