### PR TITLE
Logs rider (external-tool bridge, step 4 of 4): log folders in load_order_status

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# houseCARL line-ending policy.
+#
+# The repo is developed on Windows (git's core.autocrlf default is `true`), but several files are
+# GENERATED with Unix (LF) endings — notably the by-construction skill reference corpora under
+# .claude/skills/*/references/*.jsonl. With no rule, autocrlf flags those LF files as "modified" on
+# every checkout (it expects CRLF on disk, finds LF) even though their content is byte-identical —
+# cosmetic churn that clutters `git status` and invites accidental re-commits of nothing.
+#
+# Pin the generated data formats to LF so git stops trying to convert them. This matches how the
+# generator emits them and keeps them stable across platforms. We deliberately do NOT add a global
+# `* text=auto` rule — that would renormalize unrelated files in one noisy pass; this targeted rule
+# fixes the demonstrated churn with no side effects. Source files keep git's normal handling.
+
+# Generated reference corpora (mutagen-reference / papyrus-reference) — emitted LF, kept LF.
+*.jsonl text eol=lf

--- a/src/housecarl-core/ToolBridge.cs
+++ b/src/housecarl-core/ToolBridge.cs
@@ -16,6 +16,11 @@ public enum ToolDependency
     CrashLogs,
 }
 
+/// <summary>How a tool path resolved for a status / diagnostic surface (<see cref="ToolBridge.Inspect"/>): the user SAVED it
+/// (and it still validates), houseCARL AUTO-DETECTED a canonical home, or it's UNSET — no save and no probe hit, so a rider
+/// would fire the trained missing-dependency prompt.</summary>
+public enum ToolPathSource { Saved, AutoDetected, Unset }
+
 /// <summary>Per-dependency metadata: the wire key the user/tool names it by, a human display, whether the path is a
 /// DIRECTORY (a log root) or an .exe FILE, the expected exe stem (a sanity-check the path is the right tool), the one-line
 /// "what it's for", and where to get it (shown in the missing-dependency prompt).</summary>
@@ -122,6 +127,21 @@ public static class ToolBridge
             default:
                 return null;
         }
+    }
+
+    /// <summary>For a status / "what's configured" surface: where a dependency RESOLVES right now, WITHOUT the persist
+    /// side-effect of the runtime resolver (<see cref="ToolPathResolver.Resolve"/>, which saves an auto-detected home so it
+    /// probes once). Given the user's <paramref name="savedPath"/> (or null), returns the path + HOW it resolved: a saved
+    /// path that still VALIDATES wins (Saved); else an auto-detect <see cref="Probe"/> of the canonical home (AutoDetected);
+    /// else none (Unset — a rider would fire the forcing prompt). PURE (no file write), so a ReadOnly status read never
+    /// mutates config, and it mirrors what a rider's resolve would find — so "where the logs are" in status is the truth a
+    /// Read would hit. A saved path that no longer validates falls through (tool moved / folder deleted), same as the
+    /// runtime resolver.</summary>
+    public static (string? path, ToolPathSource source) Inspect(ToolDependency dep, string? savedPath)
+    {
+        if (savedPath is not null && Validate(dep, savedPath).ok) return (savedPath, ToolPathSource.Saved);
+        var found = Probe(dep);
+        return found is not null ? (found, ToolPathSource.AutoDetected) : (null, ToolPathSource.Unset);
     }
 
     static string MyGames => Path.Combine(

--- a/src/housecarl-generator/ToolBridgeProbe.cs
+++ b/src/housecarl-generator/ToolBridgeProbe.cs
@@ -14,6 +14,9 @@ namespace HousecarlGenerator;
 ///   4. <see cref="ToolBridge.TryParse"/> — wire names round-trip; junk is rejected.
 ///   5. <see cref="ToolBridge.Probe"/> — the compiler probe hits a synthetic &lt;game&gt;\Papyrus Compiler\PapyrusCompiler.exe
 ///      and misses when absent; BSArch has no canonical home (always null).
+///   6. <see cref="ToolBridge.Inspect"/> — the status-surface resolve (housecarl_load_order_status' log-folder section): a
+///      saved+valid path → Saved; an invalid/absent one with no canonical home → Unset; PURE (takes the saved path,
+///      persists nothing — a ReadOnly status read never mutates config).
 ///
 /// The cross-restart persistence + live-server forcing-function proof is the Aaron-empirical follow-up (needs his install).
 /// Run: dotnet run --project src/housecarl-generator tool-bridge
@@ -101,6 +104,32 @@ public static class ToolBridgeProbe
         Check(ToolBridge.Probe(ToolDependency.PapyrusCompiler) is null, "compiler has no probe home (prompts; the CK lives in the separate Steam install)");
         Check(ToolBridge.Probe(ToolDependency.Bsarch) is null, "bsarch has no canonical home (always prompts)");
         // (papyrus_logs / crash_logs probe the user's Documents — environment-dependent, so not asserted here.)
+
+        // ---------------------------------------------------------------- 6) INSPECT (status surface: saved → auto-detect → unset, PURE)
+        Console.WriteLine();
+        Console.WriteLine("--- 6: ToolBridge.Inspect — status-surface resolve (saved/auto-detected/unset), persists NOTHING ---");
+        var realExe = Path.Combine(Path.GetTempPath(), "bsarch.inspect." + Guid.NewGuid().ToString("N") + ".exe");
+        var realDir = Path.Combine(Path.GetTempPath(), "logs.inspect." + Guid.NewGuid().ToString("N"));
+        File.WriteAllText(realExe, "stub"); Directory.CreateDirectory(realDir);
+        try
+        {
+            var savedExe = ToolBridge.Inspect(ToolDependency.Bsarch, realExe);
+            Check(savedExe.source == ToolPathSource.Saved && savedExe.path == realExe, "a saved + valid exe path resolves as Saved");
+
+            var savedDir = ToolBridge.Inspect(ToolDependency.PapyrusLogs, realDir);
+            Check(savedDir.source == ToolPathSource.Saved && savedDir.path == realDir, "a saved + valid log dir resolves as Saved");
+
+            // Bsarch has NO canonical probe home, so an invalid/absent saved path falls through to Unset deterministically
+            // (a LOG dep would probe the user's Documents here — environment-dependent — so Bsarch is used for the assertion).
+            var ghost2 = Path.Combine(Path.GetTempPath(), "ghost-" + Guid.NewGuid().ToString("N") + ".exe");
+            Check(ToolBridge.Inspect(ToolDependency.Bsarch, ghost2).source == ToolPathSource.Unset,
+                  "an invalid saved path + no probe home → Unset (falls through, like the runtime resolver)");
+            Check(ToolBridge.Inspect(ToolDependency.Bsarch, null).source == ToolPathSource.Unset,
+                  "no saved path + no probe home → Unset");
+            // PURE by construction: Inspect is static, takes the saved path as an arg, and has no store to write — the
+            // runtime ToolPathResolver owns persistence, so a ReadOnly status read can never mutate config.
+        }
+        finally { try { File.Delete(realExe); Directory.Delete(realDir); } catch { /* non-fatal */ } }
 
         Console.WriteLine();
         Console.WriteLine(fail == 0

--- a/src/housecarl-mcp/StatusTools.cs
+++ b/src/housecarl-mcp/StatusTools.cs
@@ -24,9 +24,12 @@ public static class StatusTools
          "each call when the profile changed — no restart needed (a 'refresh still pending' note appears only in the rare " +
          "case MO2 was mid-write). Pass lookup= a mod folder name (e.g. 'Requiem " +
          "Lite 2') or a plugin filename (e.g. 'Requiem.esp') to ask whether houseCARL sees that one as enabled/disabled " +
-         "(mod) or active/inactive/implicit (plugin). Does NOT modify anything.")]
+         "(mod) or active/inactive/implicit (plugin). Also reports the resolved Papyrus script-log and SKSE crash-log " +
+         "FOLDERS — where to Read logs for triage/diagnosis (auto-detected, or as set via housecarl_set_tool_path). " +
+         "Does NOT modify anything.")]
     public static string LoadOrderStatus(
         LoadOrderService svc,
+        ToolPathResolver tools,
         [Description("Optional. A mod folder name or plugin filename to look up. Omit for the whole-profile summary.")]
             string? lookup = null,
         [Description("Optional. Max characters before name lists are cut with an explicit notice. 0 = the server default (~80k).")]
@@ -34,7 +37,8 @@ public static class StatusTools
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         var data = svc.StatusData();
-        return StatusWire.Render(data, lookup, max_chars > 0 ? max_chars : 80_000);
+        var logs = StatusWire.LogFolders(tools);                 // resolved Papyrus/crash log dirs (pure — no persist)
+        return StatusWire.Render(data, logs, lookup, max_chars > 0 ? max_chars : 80_000);
     }
 }
 
@@ -43,7 +47,7 @@ public static class StatusTools
 /// explicit cut notice (Q3 — never silent truncation). lookup= switches to a single mod/plugin verdict.</summary>
 static class StatusWire
 {
-    public static string Render(LoadOrderStatusData d, string? lookup, int cap)
+    public static string Render(LoadOrderStatusData d, IReadOnlyList<LogFolderView> logs, string? lookup, int cap)
     {
         var c = d.Composition;
         int checkedActive = c.ActivePluginNames.Count;
@@ -70,6 +74,8 @@ static class StatusWire
             return sb.ToString().TrimEnd('\n');
         }
 
+        AppendLogs(sb, logs);   // fixed-tiny — before the cap-bounded name lists, so a long modlist can't truncate it away
+
         AppendList(sb, "disabled mods", c.DisabledMods, cap);
         AppendList(sb, "inactive plugins", c.InactivePluginNames, cap);
         AppendList(sb, "implicit masters / CC", c.ImplicitPluginNames, cap);
@@ -85,6 +91,39 @@ static class StatusWire
             }
         }
         return sb.ToString().TrimEnd('\n');
+    }
+
+    /// <summary>Build the log-folder views for the status surface: where papyrus_logs + crash_logs resolve (saved →
+    /// auto-detected → unset), PURE (no persist — a ReadOnly status read mutates nothing). These two are the only tool deps
+    /// surfaced here because they have NO wrapping tool — the AI must be TOLD where to Read them; the compiler / BSArch deps
+    /// instead surface through their riders' forcing prompts when called.</summary>
+    public static IReadOnlyList<LogFolderView> LogFolders(ToolPathResolver tools)
+    {
+        var views = new List<LogFolderView>(2);
+        foreach (var dep in new[] { ToolDependency.PapyrusLogs, ToolDependency.CrashLogs })
+        {
+            var (path, source) = tools.Inspect(dep);
+            views.Add(new LogFolderView(ToolBridge.Info(dep).Key, path, source));
+        }
+        return views;
+    }
+
+    /// <summary>The external LOG FOLDERS section: where houseCARL resolves the Papyrus script-log + SKSE crash-log dirs.
+    /// Logs have no wrapping tool, so this tells the AI WHERE to Read them; an unset one names the housecarl_set_tool_path
+    /// call to point at it. Fixed-tiny (2 entries) and rendered before the cap-bounded name lists, so a long modlist with a
+    /// small max_chars can never truncate the log paths away (Q3).</summary>
+    static void AppendLogs(StringBuilder sb, IReadOnlyList<LogFolderView> logs)
+    {
+        sb.Append("\nlog folders (Read the .log files directly — logs have no wrapping tool):\n");
+        foreach (var l in logs)
+        {
+            sb.Append("  ").Append(l.Key).Append(": ").Append(l.Source switch
+            {
+                ToolPathSource.Saved        => l.Path + "  (configured)",
+                ToolPathSource.AutoDetected => l.Path + "  (auto-detected)",
+                _                           => $"not set — call housecarl_set_tool_path(tool='{l.Key}', path='<folder>') to point houseCARL at it",
+            }).Append('\n');
+        }
     }
 
     static void AppendList(StringBuilder sb, string label, IReadOnlyList<string> names, int cap)
@@ -131,3 +170,8 @@ static class StatusWire
         return false;
     }
 }
+
+/// <summary>One external LOG FOLDER for the status surface: its wire key (papyrus_logs / crash_logs — the
+/// housecarl_set_tool_path token), where it resolved (null if unset), and HOW (<see cref="ToolPathSource"/>). The AI reads
+/// the .log files at <see cref="Path"/> with its normal Read tool — logs are the one bridge dep with no wrapping tool.</summary>
+public sealed record LogFolderView(string Key, string? Path, ToolPathSource Source);

--- a/src/housecarl-mcp/ToolPathResolver.cs
+++ b/src/housecarl-mcp/ToolPathResolver.cs
@@ -27,6 +27,12 @@ public sealed class ToolPathResolver
         return paths is not null && paths.TryGetValue(ToolBridge.Info(dep).Key, out var p) ? p : null;
     }
 
+    /// <summary>For a status / diagnostic surface (housecarl_load_order_status' log-folder section): where a dependency
+    /// resolves right now — saved-and-valid → auto-detected canonical home → unset — WITHOUT persisting (unlike
+    /// <see cref="Resolve"/>), so a ReadOnly status read never writes config. Thin wrapper over the pure
+    /// <see cref="ToolBridge.Inspect"/>, supplying the user's saved path.</summary>
+    public (string? path, ToolPathSource source) Inspect(ToolDependency dep) => ToolBridge.Inspect(dep, Saved(dep));
+
     /// <summary>Resolve a dependency to a usable path: saved → else auto-detect (persist on hit) → else null. A saved path
     /// that no longer validates (tool moved/uninstalled) is treated as unset, so it re-detects or re-prompts rather than
     /// failing opaquely downstream.</summary>


### PR DESCRIPTION
Closes out the external-tool bridge wave — **step 4, the logs rider** (EXTERNAL_TOOL_BRIDGE_PLAN Rider 3), the light finish after the v1.1.0 bridge + compile + BSA riders. Intended release: **v1.1.1**.

## What this does
`papyrus_logs` / `crash_logs` path-config + auto-detect already shipped in the step-1 bridge. Logs are the one bridge dep with **no wrapping tool** — so the remaining work is telling the AI *where* the logs are; it then reads the `.log` files with its normal Read tool. This surfaces the resolved log folders in `housecarl_load_order_status`.

Example rendered section (on the dev machine — `Logs/Script` exists, no crash logger installed):

```
log folders (Read the .log files directly — logs have no wrapping tool):
  papyrus_logs: C:\Users\...\Documents\My Games\Skyrim Special Edition\Logs\Script  (auto-detected)
  crash_logs: not set — call housecarl_set_tool_path(tool='crash_logs', path='<folder>') to point houseCARL at it
```

## Design
- **`core/ToolBridge.Inspect(dep, savedPath)` → `(path, ToolPathSource{Saved|AutoDetected|Unset})`** — the status-surface resolve: saved-and-valid → auto-detect probe → unset. **Pure** (no persist, unlike the runtime resolver's probe-and-save), so a ReadOnly status read never mutates config, and it mirrors what a rider's `Resolve` would find. Lives in core so the CI probe tests it.
- **`mcp/ToolPathResolver.Inspect(dep)`** — thin wrapper supplying the saved path.
- **`mcp/StatusTools`** — `load_order_status` takes the resolver (DI) and renders a "log folders" section, placed *before* the cap-bounded name lists so a long modlist with a small `max_chars` can't truncate the log paths away (Q3).

Additive: the record engine is untouched, **no new tool, no new singleton** (rides the existing `ToolPathResolver`).

## Plus: a CRLF-churn fix (separate commit)
`.gitattributes` pins generated `*.jsonl` to LF. The skill reference corpora are emitted LF, but Windows `core.autocrlf=true` flagged all six as "modified" on every checkout despite byte-identical content. Targeted rule (not a global `text=auto`, which would renormalize unrelated files). Merging this clears the churn on `main`'s working tree automatically.

## Proof
- `dotnet build housecarl.sln` — clean, **0 warnings / 0 errors**.
- `dotnet run --project src/housecarl-generator tool-bridge` — **23/23** (19 prior + 4 new `Inspect` checks: saved-exe → Saved, saved-dir → Saved, invalid+no-home → Unset, null → Unset).
- Auto-detect validated against the real filesystem: `Logs/Script` present → papyrus_logs auto-detects; crash-log dirs absent → correct not-set prompt.

The rendered section is build-verified + logic-proven; not yet driven through a live MCP client (low-risk pure string-building over proven inputs). Happy to run the throwaway live-client gate before merge if wanted.

**Not merged / not tagged** — awaiting review + Aaron's go on the merge + the v1.1.1 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
