### PR TITLE
Release v1.1.1 — version bump + CHANGELOG (logs rider)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ models — by construction, not a hand-maintained subset.
 
 ### Download — recommended (modders)
 
-1. Download **`houseCARL-1.1.0.zip`** from the [latest release](https://github.com/Avick3110/houseCARL/releases).
+1. Download **`houseCARL-1.1.1.zip`** from the [latest release](https://github.com/Avick3110/houseCARL/releases).
 2. Unzip it and run **`houseCARL-Setup.exe`**.
 3. Pick your host — **`[1] Claude Code`**, **`[2] Codex`**, or **`[3] Both`**. The installer wires
    everything up:
@@ -67,7 +67,7 @@ cd houseCARL
 
 The script regenerates the reflection rulebook, publishes the server framework-dependent (trimming **off**
 — houseCARL is reflection-driven, so trimming would strip types and silently lose coverage), bundles the
-skills, builds the setup utility, and packs `release/houseCARL-1.1.0.zip`. Install the output with
+skills, builds the setup utility, and packs `release/houseCARL-1.1.1.zip`. Install the output with
 `houseCARL-Setup.exe`, `claude --plugin-dir ./dist/housecarl`, or the bundled local-marketplace
 descriptor — see the script header for details.
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "housecarl",
   "displayName": "houseCARL",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Comprehensive data-layer access to your Skyrim SE load order — read any record, author patches into a new plugin, and look up record schemas, Papyrus signatures, and distributor grammars — in plain English.",
   "author": { "name": "Avick3110" },
   "homepage": "https://github.com/Avick3110/houseCARL",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to houseCARL are documented here. Versioning is [semantic](h
 the `version` in `.claude-plugin/plugin.json` is bumped on each release, so installed users update only
 when it changes.
 
+## 1.1.1 — 2026-06-06
+
+houseCARL now points you at your logs — completing the external-tool bridge.
+
+- **Log folders in status:** `housecarl_load_order_status` now surfaces the resolved Papyrus script-log and
+  SKSE crash-log folders, so houseCARL knows where to read them when you ask about a Papyrus error or a
+  crash. Set a folder explicitly with `housecarl_set_tool_path` (`papyrus_logs` / `crash_logs`); when one is
+  unset, houseCARL auto-detects the default location and says so, or tells you exactly how to point it at
+  yours. Logs are the one bridge dependency with no wrapping tool — you Read the `.log` files directly.
+
 ## 1.1.0 — 2026-06-06
 
 houseCARL now drives the external modding toolchain, not just the data layer.


### PR DESCRIPTION
Release prep for **houseCARL 1.1.1**, the logs rider.

The logs-rider *code* already merged in #5 (`load_order_status` surfaces the resolved Papyrus/crash log folders) and is on `main`. This PR is the version/release metadata so a 1.1.1 desktop release can be cut:

- `plugin/.claude-plugin/plugin.json` → `1.1.1` (the build's version source of truth + the installed-user update signal).
- `plugin/CHANGELOG.md` → 1.1.1 entry.
- `README.md` → bump the two `houseCARL-1.1.x.zip` references.

No code change. After merge: rebuild `release/houseCARL-1.1.1.zip` via `build-plugin.ps1`, move the `v1.1.1` tag onto the release commit, and publish the GitHub release.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
