### PR TITLE
Credit distributor authors by name (Zzyxzz, powerofthree)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,5 +112,5 @@ pointers.
   houseCARL is built on.
 - **[papyrus-index](https://github.com/BellCubeDev/papyrus-index)** by **BellCube** — the source corpus
   for the bundled `papyrus-reference` skill. Thank you.
-- The **SkyPatcher** author, **powerof3** (SPID), and the **KID** author — whose public documentation the
+- **Zzyxzz** (SkyPatcher) and **powerofthree** (SPID and KID) — whose public documentation the
   distributor-authoring grammar facts were drawn from.

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -138,11 +138,11 @@ Bundled skill reference content
       the same GPL-3.0-only terms as the rest of the Mutagen surface above. (The
       server's corpus.json rulebook is the same generated derivative.)
 
-  skypatcher-authoring / spid-authoring
+  skypatcher-authoring / spid-authoring / kid-authoring
       Original grammar-reference prose describing the (uncopyrightable)
-      SkyPatcher and SPID configuration grammars; no upstream source is vendored.
-      With thanks to the SkyPatcher author and to powerof3 (SPID, MIT), whose
-      public documentation the grammar facts were drawn from.
+      SkyPatcher, SPID, and KID configuration grammars; no upstream source is
+      vendored. With thanks to Zzyxzz (SkyPatcher) and to powerofthree (SPID and
+      KID, MIT), whose public documentation the grammar facts were drawn from.
 
 
 ===============================================================================

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -70,5 +70,5 @@ no linking exception), which houseCARL bundles. Every third-party component and 
   houseCARL is built on.
 - **[papyrus-index](https://github.com/BellCubeDev/papyrus-index)** by **BellCube** — the source corpus for
   the bundled `papyrus-reference` skill. Thank you.
-- The **SkyPatcher** author and **powerof3** (SPID) — the public documentation behind the
+- **Zzyxzz** (SkyPatcher) and **powerofthree** (SPID and KID) — the public documentation behind the
   distributor-authoring skills.

--- a/plugin/THIRD-PARTY-NOTICES.txt
+++ b/plugin/THIRD-PARTY-NOTICES.txt
@@ -138,11 +138,11 @@ Bundled skill reference content
       the same GPL-3.0-only terms as the rest of the Mutagen surface above. (The
       server's corpus.json rulebook is the same generated derivative.)
 
-  skypatcher-authoring / spid-authoring
+  skypatcher-authoring / spid-authoring / kid-authoring
       Original grammar-reference prose describing the (uncopyrightable)
-      SkyPatcher and SPID configuration grammars; no upstream source is vendored.
-      With thanks to the SkyPatcher author and to powerof3 (SPID, MIT), whose
-      public documentation the grammar facts were drawn from.
+      SkyPatcher, SPID, and KID configuration grammars; no upstream source is
+      vendored. With thanks to Zzyxzz (SkyPatcher) and to powerofthree (SPID and
+      KID, MIT), whose public documentation the grammar facts were drawn from.
 
 
 ===============================================================================


### PR DESCRIPTION
Fixes the top-level author credits, which left the **SkyPatcher** author unnamed and **omitted KID's author entirely**.

## What changed
- Name **Zzyxzz** (SkyPatcher) and **powerofthree** (SPID and KID) in `README.md` and `plugin/README.md` Credits.
- Same fix in `THIRD-PARTY-NOTICES.txt` and `plugin/THIRD-PARTY-NOTICES.txt`, and add **kid-authoring** to the bundled-skill notices section (the skill ships but was missing from the notices header/prose/thanks).

## Why
The bundled skill reference files already credited `powerofthree` correctly; only the top-level credits were stale. The new Nexus mod page credits both authors correctly, so this brings the repo in line. Docs-only — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)