### PR TITLE
.gitignore: drop "parallel sessions" residue from worktrees comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,7 @@ dist/
 ## Build artifact, reproducible on demand; never source-of-truth.
 release/
 
-## Agent worktrees — transient git worktrees created under .claude/worktrees/ by parallel sessions.
+## Agent worktrees — transient git worktrees created under .claude/worktrees/ by Claude sessions (solo or parallel).
 ## Each is an isolated checkout of a claude/<name> branch; never source-of-truth, removed once merged.
 .claude/worktrees/
 


### PR DESCRIPTION
Companion to #8. The agent-worktrees comment in `.gitignore` still framed worktrees as a parallel-session tool -- the same residue behind the convention drift. Now reads "by Claude sessions (solo or parallel)".

Comment-only; the `.claude/worktrees/` ignore behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
