### PR TITLE
Release v1.1.2 — papyrus-reference index lookup fix + corrected credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ models — by construction, not a hand-maintained subset.
 
 ### Download — recommended (modders)
 
-1. Download **`houseCARL-1.1.1.zip`** from the [latest release](https://github.com/Avick3110/houseCARL/releases).
+1. Download **`houseCARL-1.1.2.zip`** from the [latest release](https://github.com/Avick3110/houseCARL/releases).
 2. Unzip it and run **`houseCARL-Setup.exe`**.
 3. Pick your host — **`[1] Claude Code`**, **`[2] Codex`**, or **`[3] Both`**. The installer wires
    everything up:
@@ -67,7 +67,7 @@ cd houseCARL
 
 The script regenerates the reflection rulebook, publishes the server framework-dependent (trimming **off**
 — houseCARL is reflection-driven, so trimming would strip types and silently lose coverage), bundles the
-skills, builds the setup utility, and packs `release/houseCARL-1.1.1.zip`. Install the output with
+skills, builds the setup utility, and packs `release/houseCARL-1.1.2.zip`. Install the output with
 `houseCARL-Setup.exe`, `claude --plugin-dir ./dist/housecarl`, or the bundled local-marketplace
 descriptor — see the script header for details.
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "housecarl",
   "displayName": "houseCARL",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Comprehensive data-layer access to your Skyrim SE load order — read any record, author patches into a new plugin, and look up record schemas, Papyrus signatures, and distributor grammars — in plain English.",
   "author": { "name": "Avick3110" },
   "homepage": "https://github.com/Avick3110/houseCARL",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to houseCARL are documented here. Versioning is [semantic](h
 the `version` in `.claude-plugin/plugin.json` is bumped on each release, so installed users update only
 when it changes.
 
+## 1.1.2 — 2026-06-06
+
+Fixes a silent lookup failure in the Papyrus reference skill, and ships the corrected third-party credits.
+
+- **Papyrus reference lookup fix:** the `papyrus-reference` skill documented its function-index grep with a
+  format that no longer matched the shipped index, so a lookup written from the docs matched zero lines even
+  for functions that are present — silently reporting a real function as "not in the corpus", the exact
+  failure the skill exists to prevent. The doc now matches the compact index, uses a full-quoted-token match,
+  and adds a self-check that validates the search against a known-present token before trusting an empty result.
+- **Corrected attribution:** the bundled third-party notices now credit the distributor-grammar authors by
+  name — Zzyxzz (SkyPatcher) and powerofthree (SPID + KID) — and list the KID-authoring skill.
+
 ## 1.1.1 — 2026-06-06
 
 houseCARL now points you at your logs — completing the external-tool bridge.


### PR DESCRIPTION
Cuts **houseCARL 1.1.2**. Patch release — bug fix, no new tools/capabilities.

## Ships (changes on `main` since the v1.1.1 tag)

- **papyrus-reference index-lookup fix** (`bba1c12` / #10): the skill's documented function-index grep drifted from the compact shipped `index.jsonl`, so a lookup written from the docs matched **zero lines** even for present functions — a silent false-negative that defeated the skill's "never invent a signature" guarantee. Now matches the compact index, uses a full-quoted-token match, and adds a silent-miss self-check.
- **Corrected attribution** (`f58072f` / #7): the bundled third-party notices now credit the distributor-grammar authors by name — Zzyxzz (SkyPatcher), powerofthree (SPID + KID) — and list the kid-authoring skill. Merged after v1.1.1, so this is its first appearance in a released zip.

## Release mechanics

- Version single-sourced from `plugin/.claude-plugin/plugin.json` → 1.1.2; root `README.md` zip refs bumped.
- Built with `scripts/build-plugin.ps1`: `release/houseCARL-1.1.2.zip` (10.07 MB, 303 entries, 5 skills).
- `claude plugin validate ./dist/housecarl --strict` → passed. Leak-check clean. Corpus: no anomalies.

Tag `v1.1.2` + GitHub Release follow the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)