### PR TITLE
Harden load-order index build against records Mutagen can't parse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,8 @@ jobs:
 
       - name: Probe — BSA riders (skips without BSArch)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- bsa-probe
+
+      # Self-contained (synthesizes a malformed-PKCU plugin in code — no external files), so unlike the manual
+      # pkcu-* proofs it runs fully here: a regression guard locking in the "Taste of Death" index-build fix.
+      - name: Probe — PKCU index-build resilience (self-contained regression guard)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- pkcu-regression

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -135,6 +135,14 @@ public sealed class LoadOrderResolver : IDisposable
         /// near-handle-free; a tracked optimization, not done here.]</summary>
         public IReadOnlyList<ISkyrimModGetter> AllMasters()
         {
+            // Excluded plugins (BuildIndex couldn't fully parse) are INTENTIONALLY retained here — NOT filtered by
+            // _excluded. A clean plugin can override a record whose ORIGIN master is an excluded one, and that master
+            // must still appear in the patch's output header for FormID resolution; dropping it would corrupt the
+            // header. Safe: Overlay() opens lazily (no parse, no enumeration → no throw), and the serializer parses a
+            // master's bodies ONLY when the patch references them — and an excluded plugin's OWN records can't be
+            // referenced (they're unreadable). So this is the one read-path that touches excluded plugins on purpose,
+            // and it cannot re-throw. (If a future change enumerates or link-caches over this full set, it must
+            // re-introduce the _excluded skip — the per-read "single choke point" is BuildIndex, not this method.)
             var arr = new ISkyrimModGetter[_r._paths.Length];
             for (int i = 0; i < arr.Length; i++) arr[i] = Overlay(i);
             return arr;
@@ -274,6 +282,10 @@ public sealed class LoadOrderResolver : IDisposable
     static string Concise(Exception ex)
     {
         var s = ex.ToString();
+        // "\n   at " is the en-US stack-frame prefix; on a localized runtime it won't match and the whole ToString()
+        // (stack included) gets flattened + capped instead — noisier, never WRONG, and the RecordException "which
+        // record" context is front-loaded in ToString() so it survives the 300-char cap either way. (Windows/en-US
+        // product → acceptable; reading the exception's record-identity properties would be the locale-proof upgrade.)
         int at = s.IndexOf("\n   at ", StringComparison.Ordinal);
         var head = (at >= 0 ? s.Substring(0, at) : s).Replace("\r", "").Replace("\n", " | ").Trim();
         return head.Length > 300 ? head.Substring(0, 300) + "…" : head;

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -39,8 +39,15 @@ namespace HousecarlCore;
 //  MEMBERSHIP are order-independent and correct now; winner IDENTITY is only as correct as the injected order
 //  — pinning the true active order (plugins.txt / MO2 USVFS) + xEdit-verifying it is the §8.5 gate, not this class.
 //
-//  Q3 (no silent failure): per-plugin open failures during the index build are COLLECTED and surfaced
-//  (LoadFailures), never skipped silently; a body the index says exists but the plugin can't yield throws.
+//  Q3 (no silent failure): a plugin the index build cannot fully read — it won't OPEN, or it contains a
+//  record Mutagen cannot PARSE (a strict-validation throw mid-enumeration; the common real case is a
+//  malformed subrecord an upstream ESP ships and the game engine ignores) — is EXCLUDED wholesale and the
+//  reason is COLLECTED + surfaced (LoadFailures / ExcludedPlugins → load_order_status), never skipped
+//  silently. ONE such record used to kill the whole build (bricking EVERY tool call, since all resolve
+//  through this index); now it costs only its own plugin. The throw is non-resumable, so we can't skip just
+//  the bad record (Mutagen 0.53.1: the group enumerator can't advance past it) — exclusion is per-PLUGIN,
+//  and atomic (a partially-read plugin never half-populates the index). A body the index says exists but the
+//  plugin can't yield still throws (a real inconsistency, named).
 // ======================================================================
 
 /// <summary>One plugin's version of a record in a conflict tree (the body is fetched on demand, not held).</summary>
@@ -69,10 +76,19 @@ public sealed class LoadOrderResolver : IDisposable
 
     Dictionary<FormKey, (int winner, int count)> _index;   // ALL keys — winner + depth, O(1)
     Dictionary<FormKey, int[]> _overriders;                // MULTI keys only — ordered touching overlay indices
-    List<string> _loadFailures = new();                    // per-plugin open failures from the last index build (Q3)
+    List<string> _loadFailures = new();                    // per-plugin index-build failures (open OR parse), surfaced (Q3)
+    HashSet<int> _excluded = new();                        // overlay indices excluded this build — never re-touched by any path
+    Dictionary<string, string> _excludedPlugins = new(StringComparer.OrdinalIgnoreCase); // excluded plugin name → reason (Q3)
 
-    /// <summary>Overlay-open failures from the last index build — surfaced, never silently skipped (Q3).</summary>
+    /// <summary>Per-plugin index-build failures (couldn't open, or contains a record Mutagen can't parse) — each
+    /// excluded plugin named with its reason, surfaced never silently skipped (Q3). Same content as
+    /// <see cref="ExcludedPlugins"/>, formatted "name: reason" for log/harness display.</summary>
     public IReadOnlyList<string> LoadFailures => _loadFailures;
+
+    /// <summary>Plugins EXCLUDED from this build (name → why): unopenable, or carrying a record Mutagen can't parse.
+    /// Their records are not in the index and no path will re-touch them; load_order_status reports them so the user
+    /// can fix/remove the upstream plugin (Q3 — the exclusion is visible, not silent).</summary>
+    public IReadOnlyDictionary<string, string> ExcludedPlugins => _excludedPlugins;
 
     public int PluginCount => _paths.Length;
     public int RecordCount => _index.Count;            // distinct FormKeys across the order
@@ -174,47 +190,93 @@ public sealed class LoadOrderResolver : IDisposable
     }
 
     /// <summary>Enumerate every plugin once (low→high), ONE AT A TIME (open → enumerate → dispose), building the
-    /// winner/count index for all keys and the ordered overrider list for multi-override keys only. Single pass, no
-    /// all-keys list ever materialized, and at most ONE plugin handle open at any instant (Option B — never the floor).
-    /// A plugin that won't open is recorded in <see cref="LoadFailures"/> and contributes no records (Q3).</summary>
+    /// winner/count index for all keys and the ordered overrider list for multi-override keys only. At most ONE plugin
+    /// handle open at any instant (Option B — never the floor). RESILIENT (Q3): a plugin that won't OPEN, or that
+    /// contains a record Mutagen can't PARSE (a throw mid-enumeration — Mutagen constructs each record's body as it
+    /// enumerates, so a malformed subrecord throws here, NOT lazily on field access), is EXCLUDED wholesale and the
+    /// reason recorded — it no longer takes the whole index down with it. Per plugin it's ATOMIC: records go into a
+    /// per-plugin buffer and fold into the shared index only if the WHOLE plugin enumerated, so a plugin that throws
+    /// part-way never leaves a half-set behind (which would mis-resolve winners for its un-enumerated records).</summary>
     void BuildIndex()
     {
         var index = new Dictionary<FormKey, (int winner, int count)>();
         var overriders = new Dictionary<FormKey, List<int>>();        // multi keys only
         var failures = new List<string>();
+        var excluded = new HashSet<int>();
+        var excludedPlugins = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         int maxDepth = 0;
 
         for (int i = 0; i < _paths.Length; i++)
         {
             ISkyrimModGetter ov;
             try { ov = SkyrimMod.CreateFromBinaryOverlay(_paths[i], SkyrimRelease.SkyrimSE); }
-            catch (Exception ex) { failures.Add($"{_names[i]}: {ex.GetType().Name} {ex.Message}"); continue; }
-            try
+            catch (Exception ex)
             {
-                foreach (var rec in ov.EnumerateMajorRecords())
-                {
-                    var fk = rec.FormKey;
-                    if (!index.TryGetValue(fk, out var e))
-                    {
-                        index[fk] = (i, 1);                                // first sighting — singleton so far, no list
-                    }
-                    else
-                    {
-                        int newCount = e.count + 1;
-                        index[fk] = (i, newCount);                          // higher overlay = new winner
-                        if (newCount == 2) overriders[fk] = new List<int> { e.winner, i };  // 2nd sighting promotes to multi
-                        else overriders[fk].Add(i);                         // 3rd+ extends the list
-                        if (newCount > maxDepth) maxDepth = newCount;
-                    }
-                }
+                Exclude(i, $"could not be opened — {Concise(ex)}", failures, excluded, excludedPlugins);
+                continue;
+            }
+
+            // Buffer the WHOLE plugin's keys first (plugin-atomic). EnumerateMajorRecords() constructs each record
+            // body as it advances, so a record Mutagen rejects (e.g. a malformed PKCU data-count) throws HERE. The
+            // throw is non-resumable, so we can't skip just that record — but catching it lets us EXCLUDE this one
+            // plugin and carry on with every other (vs. the old try/finally, where the throw escaped and killed the
+            // entire index → every tool call failed). The buffer means a partial enumeration is discarded, not merged.
+            var keys = new List<FormKey>();
+            try { foreach (var rec in ov.EnumerateMajorRecords()) keys.Add(rec.FormKey); }
+            catch (Exception ex)
+            {
+                Exclude(i, $"contains a record Mutagen cannot parse, so the whole plugin is excluded from this " +
+                           $"session (its records are not resolvable; every other plugin is unaffected) — read " +
+                           $"{keys.Count} record(s) before the failure: {Concise(ex)}. Fix or remove the upstream " +
+                           "plugin to restore access to it.",
+                        failures, excluded, excludedPlugins);
+                continue;
             }
             finally { (ov as IDisposable)?.Dispose(); }                    // one plugin open at a time — never the whole floor
+
+            foreach (var fk in keys)                                       // fold the COMPLETE plugin into the index
+            {
+                if (!index.TryGetValue(fk, out var e))
+                {
+                    index[fk] = (i, 1);                                    // first sighting — singleton so far, no list
+                }
+                else
+                {
+                    int newCount = e.count + 1;
+                    index[fk] = (i, newCount);                              // higher overlay = new winner
+                    if (newCount == 2) overriders[fk] = new List<int> { e.winner, i };  // 2nd sighting promotes to multi
+                    else overriders[fk].Add(i);                            // 3rd+ extends the list
+                    if (newCount > maxDepth) maxDepth = newCount;
+                }
+            }
         }
 
         _index = index;
         _overriders = overriders.ToDictionary(kv => kv.Key, kv => kv.Value.ToArray());  // trim List overhead → int[]
         MaxDepth = maxDepth;
         _loadFailures = failures;
+        _excluded = excluded;
+        _excludedPlugins = excludedPlugins;
+    }
+
+    /// <summary>Record one plugin's exclusion from the index build (Q3): into the human-readable failure list, the
+    /// fast-skip index set, and the name→reason map the server surfaces in load_order_status.</summary>
+    void Exclude(int i, string reason, List<string> failures, HashSet<int> excluded, Dictionary<string, string> excludedPlugins)
+    {
+        failures.Add($"{_names[i]}: {reason}");
+        excluded.Add(i);
+        excludedPlugins[_names[i]] = reason;
+    }
+
+    /// <summary>One-line essence of an exception for a user-facing reason: the message lines (the Mutagen
+    /// RecordException/SubrecordException family names the offending record + subrecord in its display text) up to the
+    /// stack trace, newlines flattened, bounded. Keeps the WHICH-record context without dumping the whole trace.</summary>
+    static string Concise(Exception ex)
+    {
+        var s = ex.ToString();
+        int at = s.IndexOf("\n   at ", StringComparison.Ordinal);
+        var head = (at >= 0 ? s.Substring(0, at) : s).Replace("\r", "").Replace("\n", " | ").Trim();
+        return head.Length > 300 ? head.Substring(0, 300) + "…" : head;
     }
 
     // ---- Queries -------------------------------------------------------
@@ -261,6 +323,8 @@ public sealed class LoadOrderResolver : IDisposable
     {
         if (!_nameToIdx.TryGetValue(pluginName, out int idx))
             throw new ArgumentException($"plugin not in the load order: {pluginName}");
+        if (_excluded.Contains(idx))
+            throw new ArgumentException($"plugin '{pluginName}' was excluded from this session: {_excludedPlugins[pluginName]}");
         var ov = SkyrimMod.CreateFromBinaryOverlay(_paths[idx], SkyrimRelease.SkyrimSE);
         try
         {
@@ -284,6 +348,7 @@ public sealed class LoadOrderResolver : IDisposable
     public IMajorRecordGetter? GetRecord(OverlaySession session, string pluginName, FormKey fk)
     {
         if (!_nameToIdx.TryGetValue(pluginName, out int idx)) return null;
+        if (_excluded.Contains(idx)) return null;                          // excluded plugin — never re-enumerate it (would re-throw); the service reports the reason via ExcludedPlugins
         foreach (var rec in session.Overlay(idx).EnumerateMajorRecords())
             if (rec.FormKey == fk) return rec;
         return null;
@@ -316,6 +381,7 @@ public sealed class LoadOrderResolver : IDisposable
     {
         for (int i = 0; i < _paths.Length; i++)
         {
+            if (_excluded.Contains(i)) continue;                           // excluded at build (unparseable/unopenable) — wins nothing; never re-touch (would re-throw)
             ISkyrimModGetter ov;
             try { ov = SkyrimMod.CreateFromBinaryOverlay(_paths[i], SkyrimRelease.SkyrimSE); }
             catch { continue; }                                            // an unopenable plugin wins nothing (surfaced at build)
@@ -360,12 +426,14 @@ public sealed class LoadOrderResolver : IDisposable
     IReadOnlyList<int> ScopeIndices(IReadOnlyList<string>? scopePlugins)
     {
         if (scopePlugins is null || scopePlugins.Count == 0)
-            return Enumerable.Range(0, _paths.Length).ToArray();
+            return Enumerable.Range(0, _paths.Length).Where(i => !_excluded.Contains(i)).ToArray();  // whole order, minus excluded
         var idxs = new List<int>(scopePlugins.Count);
         foreach (var name in scopePlugins)
         {
             if (!_nameToIdx.TryGetValue(name, out int i))
                 throw new ArgumentException($"plugin not in the load order: {name}");
+            if (_excluded.Contains(i))                                     // explicitly scoped to an excluded plugin → fail loud with the reason (Q3), don't silently scan nothing
+                throw new ArgumentException($"plugin '{name}' was excluded from this session: {_excludedPlugins[name]}");
             idxs.Add(i);
         }
         return idxs;

--- a/src/housecarl-generator/Mo2OrderHarness.cs
+++ b/src/housecarl-generator/Mo2OrderHarness.cs
@@ -66,7 +66,7 @@ static class Mo2OrderHarness
         Console.WriteLine($"  plugins={resolver.PluginCount}  records={resolver.RecordCount}  conflicts={resolver.ConflictCount}  maxDepth={resolver.MaxDepth}");
         if (resolver.LoadFailures.Count > 0)
         {
-            Console.WriteLine($"  overlay-open failures: {resolver.LoadFailures.Count} (first 5):");
+            Console.WriteLine($"  excluded plugins (open OR parse failure): {resolver.LoadFailures.Count} (first 5):");
             foreach (var f in resolver.LoadFailures.Take(5)) Console.WriteLine($"    - {f}");
         }
 

--- a/src/housecarl-generator/PkcuProbe.cs
+++ b/src/housecarl-generator/PkcuProbe.cs
@@ -186,6 +186,88 @@ public static class PkcuProbe
         return pass ? 0 : 1;
     }
 
+    /// <summary>CI REGRESSION GUARD (self-contained — no external file/MO2 deps, unlike the manual proofs above, so it
+    /// runs on the CI runner). SYNTHESIZES the malformed-PKCU case in code: writes a clean plugin (a keyword) + a plugin
+    /// with an empty PACK, both masterless (CI has no game files), then flips the PACK's PKCU data-input count from 0 to
+    /// a non-zero value so count≠inputs — the exact mismatch Mutagen throws on mid-enumeration. Asserts the resolver
+    /// EXCLUDES the bad plugin (not fatal) while the clean plugin still resolves. Locks in the "Taste of Death" fix.
+    /// Returns 0 = pass / 1 = fail (the CI gate). Run: dotnet run --project src/housecarl-generator -- pkcu-regression</summary>
+    public static int RunRegression(string[] args)
+    {
+        Console.WriteLine("== PKCU REGRESSION GUARD (self-contained) ==");
+        var dir = Path.Combine(Path.GetTempPath(), "hc_pkcu_regression");
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); } catch { }
+        Directory.CreateDirectory(dir);
+        var cleanPath = Path.Combine(dir, "hcRegClean.esp");
+        var badPath = Path.Combine(dir, "hcRegBad.esp");
+        try
+        {
+            // 1. CLEAN plugin — a keyword we can resolve (masterless: references nothing, so CI needs no game files).
+            var cleanMod = new SkyrimMod(ModKey.FromNameAndExtension("hcRegClean.esp"), SkyrimRelease.SkyrimSE);
+            var kw = cleanMod.Keywords.AddNew();
+            kw.EditorID = "hcRegKeyword";
+            var cleanKwFk = kw.FormKey;
+            cleanMod.BeginWrite.ToPath(cleanPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+            // 2. BAD plugin — an empty PACK. Mutagen writes a PKCU counter (count=0) for it; flip count→6 so it claims
+            //    6 data inputs but carries 0 → "Unexpected data count mismatch" thrown when Mutagen constructs the
+            //    overlay during enumeration (the exact bug).
+            var badMod = new SkyrimMod(ModKey.FromNameAndExtension("hcRegBad.esp"), SkyrimRelease.SkyrimSE);
+            var pkg = badMod.Packages.AddNew();
+            pkg.EditorID = "hcRegBadPackage";
+            var pkgFk = pkg.FormKey;
+            badMod.BeginWrite.ToPath(badPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+            if (!FlipPkcuCount(badPath, 0x06, out var synthNote)) { Console.WriteLine($"   FAIL (synth): {synthNote}"); return 1; }
+            Console.WriteLine($"   synth: {synthNote}");
+
+            // Sanity: the synthesized bad plugin really does throw on raw enumeration (else the test proves nothing).
+            bool rawThrows = false;
+            try { foreach (var _ in SkyrimMod.CreateFromBinaryOverlay(badPath, SkyrimRelease.SkyrimSE).EnumerateMajorRecords()) { } }
+            catch { rawThrows = true; }
+            if (!rawThrows) { Console.WriteLine("   FAIL (synth): the corrupted plugin did NOT throw on raw enumeration — synthesis is stale, test would be a false PASS."); return 1; }
+
+            // 3. The fix: Build over [clean, bad] must NOT throw; bad excluded; clean still resolves.
+            LoadOrderResolver resolver;
+            try { resolver = LoadOrderResolver.Build(new[] { cleanPath, badPath }); }
+            catch (Exception ex) { Console.WriteLine($"   FAIL (regression!): LoadOrderResolver.Build threw: {ex.GetType().Name}: {Trunc(ex.Message)}"); return 1; }
+
+            bool excluded = resolver.ExcludedPlugins.ContainsKey("hcRegBad.esp");
+            var cleanWin = resolver.ResolveWinner(cleanKwFk);
+            var badWin = resolver.ResolveWinner(pkgFk);
+            Console.WriteLine($"   build OK — {resolver.RecordCount} record(s), {resolver.ExcludedPlugins.Count} excluded");
+            foreach (var kv in resolver.ExcludedPlugins) Console.WriteLine($"   excluded[{kv.Key}]: {Trunc(kv.Value)}");
+            Console.WriteLine($"   clean keyword resolves : {(cleanWin is not null ? "yes -> " + cleanWin.Value.WinnerPlugin : "NO")}");
+            Console.WriteLine($"   bad package resolves   : {(badWin is null ? "no (correct — excluded)" : "YES (wrong)")}");
+            resolver.Dispose();
+
+            bool pass = excluded && cleanWin is not null && badWin is null && resolver.RecordCount > 0;
+            Console.WriteLine(pass ? "   ==> PASS: malformed plugin isolated, clean plugin resolves." : "   ==> FAIL");
+            return pass ? 0 : 1;
+        }
+        catch (Exception ex) { Console.WriteLine($"   FAIL (unexpected): {ex.GetType().Name}: {Trunc(ex.Message)}"); return 1; }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
+
+    /// <summary>Flip the PKCU data-input count (first DWORD's low byte) in a written plugin to <paramref name="newCount"/>,
+    /// creating a count≠actual-inputs mismatch. Returns false if no PKCU subrecord is present (synthesis assumption broken).</summary>
+    static bool FlipPkcuCount(string path, byte newCount, out string note)
+    {
+        var b = File.ReadAllBytes(path);
+        for (int i = 0; i < b.Length - 6; i++)
+            if (b[i] == 0x50 && b[i + 1] == 0x4B && b[i + 2] == 0x43 && b[i + 3] == 0x55)   // "PKCU"
+            {
+                int dataStart = i + 6;                                                        // 4 tag + 2 length
+                byte old = b[dataStart];
+                b[dataStart] = newCount;
+                File.WriteAllBytes(path, b);
+                note = $"PKCU @ {i}: data-input count {old} -> {newCount} (now claims {newCount} inputs, carries 0)";
+                return true;
+            }
+        note = "no PKCU subrecord found in the synthesized PACK (Mutagen did not emit one for an empty package)";
+        return false;
+    }
+
     static string Sig(MethodInfo m) =>
         $"{m.Name}({string.Join(", ", m.GetParameters().Select(p => $"{p.ParameterType.Name} {p.Name}{(p.IsOptional ? "=opt" : "")}"))})";
 

--- a/src/housecarl-generator/PkcuProbe.cs
+++ b/src/housecarl-generator/PkcuProbe.cs
@@ -1,0 +1,193 @@
+using System.Reflection;
+using HousecarlCore;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Binary.Parameters;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// Throwaway feasibility probe for the index-build resilience fix (Nexus bug: a malformed PKCU in
+/// TasteOfDeath_Addon_Dialogue.esp throws DURING EnumerateMajorRecords(), bricking the whole index build).
+///
+/// Decides record-level vs plugin/type-level isolation:
+///   TEST 1 — is the group enumeration RESUMABLE past a parse throw? (manual MoveNext + catch-continue)
+///   TEST 2 — what EnumerateMajorRecords / CreateFromBinaryOverlay overloads exist (any resilience knob?)
+///
+/// Run: dotnet run --project src/housecarl-generator pkcu-probe &lt;malformed.esp&gt;
+/// </summary>
+public static class PkcuProbe
+{
+    public static int Run(string[] args)
+    {
+        if (args.Length < 1) { Console.Error.WriteLine("usage: pkcu-probe <malformed.esp>"); return 1; }
+        var path = args[0];
+        if (!File.Exists(path)) { Console.Error.WriteLine($"not found: {path}"); return 1; }
+        Console.WriteLine($"probe target: {path}");
+
+        // ---- TEST 1: is all-types group enumeration RESUMABLE past a parse throw? ----
+        Console.WriteLine();
+        Console.WriteLine("== TEST 1: manual MoveNext loop, catch-and-continue (record-level feasibility) ==");
+        var ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE);
+        var en = ov.EnumerateMajorRecords().GetEnumerator();
+        int good = 0, errors = 0, afterFirstError = 0; bool errored = false;
+        while (true)
+        {
+            IMajorRecordGetter? cur;
+            try
+            {
+                if (!en.MoveNext()) break;
+                cur = en.Current;
+            }
+            catch (Exception ex)
+            {
+                errors++;
+                Console.WriteLine($"   [throw #{errors}] {ex.GetType().Name}: {Trunc(ex.Message)}");
+                errored = true;
+                continue;   // attempt to resume past the bad record
+            }
+            good++;
+            if (errored) afterFirstError++;
+        }
+        Console.WriteLine($"   good={good}  errors={errors}  recordsYieldedAfterFirstError={afterFirstError}");
+        Console.WriteLine(afterFirstError > 0
+            ? "   => RESUMABLE: record-level isolation FEASIBLE via catch-continue."
+            : "   => NOT resumable: record-level via this API NOT feasible — use plugin/type-level.");
+
+        // ---- TEST 2: API surface for resilience options ----
+        Console.WriteLine();
+        Console.WriteLine("== TEST 2: EnumerateMajorRecords overloads (SkyrimModMixIn) ==");
+        var mixin = typeof(SkyrimMod).Assembly.GetType("Mutagen.Bethesda.Skyrim.SkyrimModMixIn");
+        if (mixin != null)
+            foreach (var m in mixin.GetMethods(BindingFlags.Public | BindingFlags.Static)
+                                   .Where(m => m.Name == "EnumerateMajorRecords"))
+                Console.WriteLine("   " + Sig(m));
+
+        Console.WriteLine();
+        Console.WriteLine("== TEST 2b: SkyrimMod.CreateFromBinaryOverlay overloads ==");
+        var createOverloads = typeof(SkyrimMod).GetMethods(BindingFlags.Public | BindingFlags.Static)
+                                               .Where(m => m.Name == "CreateFromBinaryOverlay").ToList();
+        foreach (var m in createOverloads) Console.WriteLine("   " + Sig(m));
+
+        // ---- TEST 3: BinaryReadParameters surface — any parse-error tolerance knob? ----
+        Console.WriteLine();
+        Console.WriteLine("== TEST 3: BinaryReadParameters public properties ==");
+        var brpType = createOverloads.SelectMany(m => m.GetParameters())
+            .Select(p => p.ParameterType).FirstOrDefault(t => t.Name == "BinaryReadParameters");
+        if (brpType is null) Console.WriteLine("   (BinaryReadParameters type not found)");
+        else
+            foreach (var p in brpType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+                Console.WriteLine($"   {p.PropertyType.Name} {p.Name}");
+
+        // ---- TEST 4: does relaxing ThrowOnUnknownSubrecord rescue the malformed PKCU? ----
+        Console.WriteLine();
+        Console.WriteLine("== TEST 4: open with ThrowOnUnknownSubrecord=false, enumerate ==");
+        try
+        {
+            var prm = BinaryReadParameters.Default with { ThrowOnUnknownSubrecord = false };
+            var ov3 = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE, prm);
+            int n = 0; bool threw = false;
+            var e3 = ov3.EnumerateMajorRecords().GetEnumerator();
+            while (true)
+            {
+                try { if (!e3.MoveNext()) break; _ = e3.Current; }
+                catch (Exception ex) { threw = true; Console.WriteLine($"   still THREW: {ex.GetType().Name}: {Trunc(ex.Message)}"); break; }
+                n++;
+            }
+            Console.WriteLine(threw
+                ? $"   => flag does NOT help (count-mismatch is a known-subrecord validation, not unknown-subrecord). enumerated {n} before throw."
+                : $"   => flag RESCUES it! enumerated all {n} records clean — record-level feasible via BinaryReadParameters.");
+        }
+        catch (Exception ex) { Console.WriteLine($"   construction/open failed: {ex.GetType().Name}: {Trunc(ex.Message)}"); }
+
+        return 0;
+    }
+
+    /// <summary>End-to-end proof of the fix: drive the REAL product code (LoadOrderResolver.Build) over a load order
+    /// that contains the malformed plugin, and assert it (a) does NOT throw, (b) excludes + reports the bad plugin,
+    /// (c) still fully indexes the OTHER plugin, (d) resolves + reads a good record. args: &lt;clean.esp&gt; &lt;mal.esp&gt;</summary>
+    public static int RunFixProof(string[] args)
+    {
+        if (args.Length < 2) { Console.Error.WriteLine("usage: pkcu-fix-proof <clean.esp> <mal.esp>"); return 1; }
+        var clean = args[0]; var mal = args[1];
+        var cleanName = Path.GetFileName(clean); var malName = Path.GetFileName(mal);
+
+        Console.WriteLine("== FIX PROOF: LoadOrderResolver.Build([clean, malformed]) ==");
+        LoadOrderResolver resolver;
+        try { resolver = LoadOrderResolver.Build(new[] { clean, mal }); }   // the throw used to escape HERE and brick everything
+        catch (Exception ex) { Console.WriteLine($"   FAIL — build threw (fix not working): {ex.GetType().Name}: {Trunc(ex.Message)}"); return 1; }
+
+        Console.WriteLine($"   build OK — {resolver.PluginCount} plugins, {resolver.RecordCount} records indexed, {resolver.ExcludedPlugins.Count} excluded");
+        foreach (var kv in resolver.ExcludedPlugins) Console.WriteLine($"   excluded[{kv.Key}]: {Trunc(kv.Value)}");
+
+        // (c) the OTHER plugin's records survived — index is non-empty and the clean plugin won its records.
+        var goodFk = FormKey.Factory($"000668:{cleanName}");               // madAttackPlayer, defined in the clean plugin
+        var w = resolver.ResolveWinner(goodFk);
+        Console.WriteLine($"   ResolveWinner({goodFk}) -> {(w is null ? "NULL" : w.Value.WinnerPlugin)}   (expect {cleanName})");
+
+        // (d) we can actually fetch + read that good record.
+        using (var s = resolver.OpenSession())
+        {
+            var body = resolver.GetRecord(s, cleanName, goodFk);
+            Console.WriteLine($"   GetRecord(clean, goodFk) -> {(body is null ? "NULL" : body.EditorID + " / Type=" + RecordNaming.StripOverlay(body.GetType().Name))}   (expect madAttackPlayer)");
+        }
+
+        // (b) the malformed plugin's own record is NOT resolvable, and exclusion is reported (Q3).
+        var badFk = FormKey.Factory($"000668:{malName}");
+        Console.WriteLine($"   ResolveWinner({badFk}) -> {(resolver.ResolveWinner(badFk) is null ? "NULL (correct — plugin excluded)" : "RESOLVED (WRONG)")}");
+        Console.WriteLine($"   ExcludedPlugins.ContainsKey({malName}) -> {resolver.ExcludedPlugins.ContainsKey(malName)}");
+
+        // verdict
+        bool pass = resolver.ExcludedPlugins.ContainsKey(malName)
+                    && w is not null && string.Equals(w.Value.WinnerPlugin, cleanName, StringComparison.OrdinalIgnoreCase)
+                    && resolver.ResolveWinner(badFk) is null
+                    && resolver.RecordCount > 0;
+        Console.WriteLine(pass ? "   ==> PASS: malformed plugin isolated, clean plugin fully accessible." : "   ==> FAIL");
+        return pass ? 0 : 1;
+    }
+
+    /// <summary>Real-scale proof: build the ACTUAL MO2 order (the product path Mo2LoadOrder.Build → LoadOrderResolver.Build)
+    /// with the malformed plugin appended, and assert the whole order resolves with ONLY that one plugin excluded — i.e.
+    /// no regression at full scale + isolation works in the real world. args: &lt;mo2InstanceDir&gt; &lt;mal.esp&gt;</summary>
+    public static int RunScaleProof(string[] args)
+    {
+        if (args.Length < 2) { Console.Error.WriteLine("usage: pkcu-scale-proof <mo2InstanceDir> <mal.esp>"); return 1; }
+        var instanceDir = args[0]; var mal = args[1]; var malName = Path.GetFileName(mal);
+
+        Console.WriteLine("== SCALE PROOF: real MO2 order + 1 malformed plugin ==");
+        var p = Mo2Instance.Resolve(instanceDir);
+        var order = Mo2LoadOrder.Build(p.ProfileDir, p.ModsDir, p.DataDir);
+        var real = order.OrderedPaths.ToList();
+        Console.WriteLine($"   real order: {real.Count} plugins (profile '{p.ProfileName}')");
+        real.Add(mal);                                                     // append the malformed plugin at highest priority
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        LoadOrderResolver resolver;
+        try { resolver = LoadOrderResolver.Build(real); }                  // the OLD code threw HERE → every tool call dead
+        catch (Exception ex) { Console.WriteLine($"   FAIL — build threw: {ex.GetType().Name}: {Trunc(ex.Message)}"); return 1; }
+        sw.Stop();
+
+        Console.WriteLine($"   build OK in {sw.Elapsed.TotalSeconds:N1}s — {resolver.PluginCount} plugins, {resolver.RecordCount:N0} records, {resolver.ExcludedPlugins.Count} excluded");
+        foreach (var kv in resolver.ExcludedPlugins) Console.WriteLine($"   excluded[{kv.Key}]: {Trunc(kv.Value)}");
+
+        var iron = FormKey.Factory("012EB7:Skyrim.esm");                   // a real vanilla record must still resolve
+        var w = resolver.ResolveWinner(iron);
+        Console.WriteLine($"   ResolveWinner(012EB7:Skyrim.esm) -> {(w is null ? "NULL" : w.Value.WinnerPlugin)} (override depth {(w?.OverrideDepth ?? 0)})");
+
+        bool pass = resolver.ExcludedPlugins.ContainsKey(malName) && resolver.RecordCount > 100_000 && w is not null;
+        Console.WriteLine(pass
+            ? $"   ==> PASS: full order built; only '{malName}' excluded; {resolver.RecordCount:N0} records resolve."
+            : "   ==> FAIL");
+        if (resolver.ExcludedPlugins.Count > 1)
+            Console.WriteLine($"   NOTE: {resolver.ExcludedPlugins.Count - 1} OTHER plugin(s) in the real order were also excluded — surfaced above (would previously have bricked houseCARL too).");
+        resolver.Dispose();
+        return pass ? 0 : 1;
+    }
+
+    static string Sig(MethodInfo m) =>
+        $"{m.Name}({string.Join(", ", m.GetParameters().Select(p => $"{p.ParameterType.Name} {p.Name}{(p.IsOptional ? "=opt" : "")}"))})";
+
+    static string Trunc(string s) => s.Length > 110 ? s.Substring(0, 110) + "…" : s;
+}

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -11,6 +11,15 @@ using HousecarlGenerator;
 // Maintenance diagnostic: re-verify the mutable-collection whitelist on a Mutagen bump.
 if (args.Length > 0 && args[0] == "vocab") return Probe.RunVocab();
 
+// Index-build resilience (Nexus bug): feasibility probe — is group enumeration resumable past a parse throw?
+if (args.Length > 0 && args[0] == "pkcu-probe") return PkcuProbe.Run(args[1..]);
+
+// Index-build resilience (Nexus bug): end-to-end proof the malformed plugin is isolated, not fatal.
+if (args.Length > 0 && args[0] == "pkcu-fix-proof") return PkcuProbe.RunFixProof(args[1..]);
+
+// Index-build resilience (Nexus bug): real-scale proof — full MO2 order + 1 malformed plugin, only it excluded.
+if (args.Length > 0 && args[0] == "pkcu-scale-proof") return PkcuProbe.RunScaleProof(args[1..]);
+
 // One-shot verify (decision #1): confirm the xEdit 4-char signature reflection path.
 if (args.Length > 0 && args[0] == "sig") return Probe.RunSig();
 

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -20,6 +20,9 @@ if (args.Length > 0 && args[0] == "pkcu-fix-proof") return PkcuProbe.RunFixProof
 // Index-build resilience (Nexus bug): real-scale proof — full MO2 order + 1 malformed plugin, only it excluded.
 if (args.Length > 0 && args[0] == "pkcu-scale-proof") return PkcuProbe.RunScaleProof(args[1..]);
 
+// Index-build resilience (Nexus bug): SELF-CONTAINED CI regression guard — synthesizes the malformed PKCU, asserts isolation.
+if (args.Length > 0 && args[0] == "pkcu-regression") return PkcuProbe.RunRegression(args[1..]);
+
 // One-shot verify (decision #1): confirm the xEdit 4-char signature reflection path.
 if (args.Length > 0 && args[0] == "sig") return Probe.RunSig();
 

--- a/src/housecarl-generator/ResolveHarness.cs
+++ b/src/housecarl-generator/ResolveHarness.cs
@@ -44,7 +44,7 @@ public static class ResolveHarness
         Console.WriteLine($"   (§8.1 floor was ~28 MB managed → index alone ≈ held managed − floor; target was ~165–185 MB total)");
         if (resolver.LoadFailures.Count > 0)
         {
-            Console.WriteLine($"   !! {resolver.LoadFailures.Count} overlay(s) FAILED to open (surfaced, not skipped — Q3):");
+            Console.WriteLine($"   !! {resolver.LoadFailures.Count} plugin(s) EXCLUDED — open OR parse failure (surfaced, not skipped — Q3):");
             foreach (var f in resolver.LoadFailures.Take(10)) Console.WriteLine($"        {f}");
         }
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -127,10 +127,10 @@ public sealed class LoadOrderService : IDisposable
     /// changed since that build (Q3 — never present a stale picture as current). Forces the lazy resolver build.</summary>
     public LoadOrderStatusData StatusData()
     {
-        var r = Resolver;                                          // force build/refresh → resolved count + warnings
+        var r = Resolver;                                          // force build/refresh → resolved count + warnings + exclusions
         var comp = Mo2LoadOrder.ReadComposition(_profileDir);      // FRESH composition (always current)
         return new LoadOrderStatusData(
-            comp, _orderWarnings, r.PluginCount, _maxPlugins, ProfileNewerThan(_orderBuiltUtc), _profileDir);
+            comp, _orderWarnings, r.PluginCount, _maxPlugins, ProfileNewerThan(_orderBuiltUtc), _profileDir, r.ExcludedPlugins);
     }
 
     /// <summary>True if any of the three MO2 profile files has a newer mtime than the resolver's last build — i.e. the
@@ -290,9 +290,21 @@ public sealed class LoadOrderService : IDisposable
     public ReadOutcome ResolveRead(FormKey fk, string? plugin, IReadOnlyList<string>? fields, bool conflictTree, int depth = 1)
     {
         var resolver = Resolver;
+
+        // An explicitly-requested plugin that was EXCLUDED this session (unparseable/unopenable) → say so (Q3),
+        // rather than fall through to a misleading "does not define this record".
+        if (plugin is not null && resolver.ExcludedPlugins.TryGetValue(plugin, out var pWhy))
+            return ReadOutcome.Fail(fk, $"Plugin '{plugin}' was excluded from this session: {pWhy}");
+
         var winner = resolver.ResolveWinner(fk);
         if (winner is null)
+        {
+            // If the record's defining plugin was excluded, that's WHY it's missing — name it (Q3), not a bare "not present".
+            var defining = fk.ModKey.FileName.ToString();
+            if (resolver.ExcludedPlugins.TryGetValue(defining, out var dWhy))
+                return ReadOutcome.Fail(fk, $"FormID {fk} is not resolvable: its plugin '{defining}' was excluded from this session: {dWhy}");
             return ReadOutcome.Fail(fk, $"FormID {fk} is not present in the load order ({resolver.PluginCount} plugins).");
+        }
 
         var source = plugin ?? winner.Value.WinnerPlugin;
         using var session = resolver.OpenSession();                       // opens the source plugin; disposed at return (Option B)
@@ -889,11 +901,14 @@ public sealed record ConflictNodeView(string Plugin, RecordFields Record);
 /// <summary>The data behind housecarl_load_order_status. <see cref="Composition"/> is the fresh enabled/disabled picture;
 /// <see cref="ResolvedPluginCount"/> + <see cref="Warnings"/> are the resolver's actual last-build state;
 /// <see cref="ProfileChanged"/> is true only when a refresh was attempted but is still pending (e.g. MO2 was mid-write) —
-/// houseCARL re-reads automatically on the next tool call; no restart.</summary>
+/// houseCARL re-reads automatically on the next tool call; no restart. <see cref="ExcludedPlugins"/> (name → reason) are
+/// plugins dropped from the index this build (unopenable, or carrying a record Mutagen can't parse) — surfaced so the
+/// user can fix/remove them (Q3).</summary>
 public sealed record LoadOrderStatusData(
     Mo2Composition Composition,
     IReadOnlyList<string> Warnings,
     int ResolvedPluginCount,
     int MaxPlugins,
     bool ProfileChanged,
-    string ProfileDir);
+    string ProfileDir,
+    IReadOnlyDictionary<string, string> ExcludedPlugins);

--- a/src/housecarl-mcp/StatusTools.cs
+++ b/src/housecarl-mcp/StatusTools.cs
@@ -70,10 +70,11 @@ static class StatusWire
 
         if (lookup is { Length: > 0 })
         {
-            AppendLookup(sb, c, lookup.Trim());
+            AppendLookup(sb, c, d.ExcludedPlugins, lookup.Trim());
             return sb.ToString().TrimEnd('\n');
         }
 
+        AppendExcluded(sb, d.ExcludedPlugins, cap);   // Q3 health alarm — prominent, before the routine name lists
         AppendLogs(sb, logs);   // fixed-tiny — before the cap-bounded name lists, so a long modlist can't truncate it away
 
         AppendList(sb, "disabled mods", c.DisabledMods, cap);
@@ -126,6 +127,24 @@ static class StatusWire
         }
     }
 
+    /// <summary>The EXCLUDED-plugins alarm (Q3): plugins dropped from the index this build — unopenable, or carrying a
+    /// record Mutagen can't parse (a malformed subrecord the game ignores but Mutagen rejects). houseCARL reads NONE of
+    /// an excluded plugin, but EVERY other plugin works — surfaced loud so the user can fix/remove the upstream plugin
+    /// (before this fix, ONE such record bricked every call). Rendered before the routine name lists so a long modlist
+    /// can't truncate it away.</summary>
+    static void AppendExcluded(StringBuilder sb, IReadOnlyDictionary<string, string> excluded, int cap)
+    {
+        if (excluded.Count == 0) return;
+        sb.Append("\n[!] EXCLUDED plugins (").Append(excluded.Count)
+          .Append(") — dropped from the index this session; houseCARL does NOT read these, every OTHER plugin works:\n");
+        int shown = 0;
+        foreach (var kv in excluded)
+        {
+            if (sb.Length >= cap) { sb.Append("  ... [").Append(excluded.Count - shown).Append(" more omitted at max_chars=").Append(cap).Append("]\n"); break; }
+            sb.Append("  - ").Append(kv.Key).Append(": ").Append(kv.Value).Append('\n'); shown++;
+        }
+    }
+
     static void AppendList(StringBuilder sb, string label, IReadOnlyList<string> names, int cap)
     {
         sb.Append('\n').Append(label).Append(" (").Append(names.Count).Append("):");
@@ -139,7 +158,8 @@ static class StatusWire
         }
     }
 
-    static void AppendLookup(StringBuilder sb, HousecarlCore.Mo2Composition c, string name)
+    static void AppendLookup(StringBuilder sb, HousecarlCore.Mo2Composition c,
+                             IReadOnlyDictionary<string, string> excluded, string name)
     {
         sb.Append("\nlookup '").Append(name).Append("':\n");
 
@@ -155,6 +175,11 @@ static class StatusWire
             Contains(c.InactivePluginNames, name) ? "INACTIVE (present but unchecked — houseCARL EXCLUDES it)" :
                                                     "not in the load order (no such plugin in loadorder.txt)";
         sb.Append("  as a plugin: ").Append(asPlugin).Append('\n');
+
+        // An active plugin can still be EXCLUDED from the index (a record Mutagen can't parse) — say so (Q3), so the
+        // "ACTIVE … houseCARL reads/writes it" line above isn't taken as the whole truth.
+        if (excluded.TryGetValue(name, out var why))
+            sb.Append("  [!] EXCLUDED this session: ").Append(why).Append("\n      → houseCARL does NOT read this plugin (every other plugin is unaffected).\n");
     }
 
     static string ProfileName(string profileDir)


### PR DESCRIPTION
## The bug (Nexus "Taste of Death" report)

A single record Mutagen rejects on parse — a malformed `PKCU` data-input count in `TasteOfDeath_Addon_Dialogue.esp` (`madAttackPlayer`, count=6 but only 3 pairs; the game engine ignores it, Mutagen validates strictly) — **bricked every houseCARL call** when that plugin was in the load order.

**Root cause:** the held FormKey→winner index is built once (lazily, on the first record-touching call) by enumerating every plugin. Mutagen 0.53.1 **constructs each record body during enumeration**, so the malformed record threw mid-enumeration. `BuildIndex`'s loop was `try/finally`, not `try/catch`, so the throw escaped → the index never built → every call (including `load_order_status`, which forces the build) failed. Exactly the reporter's "initializes on first call regardless of query target."

It does **not** reproduce on our own load order only because our copy of that ESP is a different, clean version (PKCU count=0). The flaw is real for any user with the malformed copy — or any plugin carrying any enumeration-time-unparseable record.

## The fix — per-plugin isolation

Record-level isolation was checked and is **infeasible in Mutagen 0.53.1** (proven): the group enumerator can't resume past a bad record, no overload skips one, and `ThrowOnUnknownSubrecord=false` doesn't touch the count-mismatch path. So isolation is per-**plugin**:

- **`BuildIndex` is the gatekeeper** — buffers each plugin's keys and folds them into the index only if the *whole* plugin enumerated (atomic; never a half-populated plugin). A plugin that won't open **or** can't fully parse is **excluded**, with its reason recorded (`ExcludedPlugins` name→reason + `LoadFailures`).
- **Every other enumeration path** (`GetRecord`, `WinnerRecordsOfType`, `RecordsIn` via `ScopeIndices`, `PluginRecordStatus`) skips excluded plugins — once a plugin passes `BuildIndex` it's construction-safe, so the gatekeeper is the single choke point.
- **`load_order_status` surfaces excluded plugins** (name + reason). This also fixes a pre-existing Q3 gap: `LoadFailures` were collected but never shown to the user.
- **`read_record`** returns a precise "excluded" message for an explicit/defining excluded plugin instead of a misleading "not present" / "does not define".

This keeps the comprehensive-access cornerstone (§3): a genuine Mutagen-delta record fails loud about *itself*, not the whole load order.

## Proof (re-runnable via `PkcuProbe` in housecarl-generator)

- Feasibility: recreated the reporter's exact bytes → raw Mutagen still throws (we isolate around it, don't change Mutagen); record-level infeasibility confirmed.
- `pkcu-fix-proof`: `LoadOrderResolver.Build([clean, malformed])` → bad plugin excluded + reported, clean plugin fully readable.
- `pkcu-scale-proof`: the **full 3,443-plugin Authoria order + the malformed plugin builds clean in ~11s, only that one plugin excluded, all 2,757,243 records resolve** (also confirms the real order has no other unparseable plugins).

Clean build across the solution; no changes to the read/write engines or any record logic — defensive hardening around index construction only.

## Reviewer notes

- Happy path is unchanged *by construction* — clean plugins run the identical winner/override fold, just via a transient per-plugin buffer.
- Main risk surface to scrutinize: `BuildIndex` atomic buffer/fold, and the `_excluded` skip in the streaming iterators (`ScopeIndices` / `WinnerRecordsOfType` / `GetRecord`).
- `PkcuProbe.cs` is a committed proof harness (takes paths as args; not run in CI).

Not landed — opening for an independent review session before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
