### PR TITLE
Release v1.1.3 — load-order index-build resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ models — by construction, not a hand-maintained subset.
 
 ### Download — recommended (modders)
 
-1. Download **`houseCARL-1.1.2.zip`** from the [latest release](https://github.com/Avick3110/houseCARL/releases).
+1. Download **`houseCARL-1.1.3.zip`** from the [latest release](https://github.com/Avick3110/houseCARL/releases).
 2. Unzip it and run **`houseCARL-Setup.exe`**.
 3. Pick your host — **`[1] Claude Code`**, **`[2] Codex`**, or **`[3] Both`**. The installer wires
    everything up:
@@ -67,7 +67,7 @@ cd houseCARL
 
 The script regenerates the reflection rulebook, publishes the server framework-dependent (trimming **off**
 — houseCARL is reflection-driven, so trimming would strip types and silently lose coverage), bundles the
-skills, builds the setup utility, and packs `release/houseCARL-1.1.2.zip`. Install the output with
+skills, builds the setup utility, and packs `release/houseCARL-1.1.3.zip`. Install the output with
 `houseCARL-Setup.exe`, `claude --plugin-dir ./dist/housecarl`, or the bundled local-marketplace
 descriptor — see the script header for details.
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "housecarl",
   "displayName": "houseCARL",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Comprehensive data-layer access to your Skyrim SE load order — read any record, author patches into a new plugin, and look up record schemas, Papyrus signatures, and distributor grammars — in plain English.",
   "author": { "name": "Avick3110" },
   "homepage": "https://github.com/Avick3110/houseCARL",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to houseCARL are documented here. Versioning is [semantic](h
 the `version` in `.claude-plugin/plugin.json` is bumped on each release, so installed users update only
 when it changes.
 
+## 1.1.3 — 2026-06-07
+
+Hardens houseCARL against a malformed plugin that could otherwise make every command fail.
+
+- **Resilient load-order indexing:** a single record Mutagen can't parse — for example a malformed package
+  data-input count that an upstream ESP ships and the game engine ignores — used to make *every* houseCARL
+  command fail with a Mutagen error, because the whole-load-order index is built up front and one bad record
+  threw the entire build. houseCARL now isolates the offending plugin: it is excluded from the session and
+  reported in `housecarl_load_order_status` (with the reason why), while every other plugin stays fully
+  readable. Fix or remove the upstream plugin to restore access to it.
+
 ## 1.1.2 — 2026-06-06
 
 Fixes a silent lookup failure in the Papyrus reference skill, and ships the corrected third-party credits.


### PR DESCRIPTION
## houseCARL 1.1.3 — load-order index-build resilience

Packages the index-build resilience fix (already merged to `main` in [#12](https://github.com/Avick3110/houseCARL/pull/12)) into a shippable release.

### What ships
- **The fix:** a record Mutagen can't parse mid-enumeration — e.g. a malformed package data-input count an upstream ESP carries (the game ignores it; Mutagen validates strictly) — used to brick **every** houseCARL command. It now excludes only the offending plugin (reported in `housecarl_load_order_status` with the reason), while every other plugin stays fully readable. The "Taste of Death" Nexus report.

### Version bump (the only tracked changes)
- `plugin/.claude-plugin/plugin.json` → `1.1.3` (single source of truth)
- `plugin/CHANGELOG.md` → 1.1.3 entry
- `README.md` → download/build zip references → `houseCARL-1.1.3.zip`

### Built + verified
- `scripts/build-plugin.ps1` → `release/houseCARL-1.1.3.zip` (**10.08 MB, 303 entries**), leak-check clean, all components present (server + corpus.json, 5 skills, `houseCARL-Setup.exe`, package extras).
- `claude plugin validate ./dist/housecarl --strict` → **passed**.
- The shipped server DLL is compiled from this branch (which includes the fix), and the new self-contained `pkcu-regression` CI guard is on `main`.

### Publish plan (after merge, on your go)
1. FF-merge this PR.
2. Annotated tag `v1.1.3` on the release commit.
3. GitHub Release `v1.1.3` (Latest), attaching `houseCARL-1.1.3.zip`.
4. Nexus upload stays manual (yours) — GitHub will lead Nexus by one patch until you upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
