### PR TITLE
Add papyrus-optimization skill (Papyrus performance reviewer)

### DIFF
--- a/.claude/skills/papyrus-optimization/SKILL.md
+++ b/.claude/skills/papyrus-optimization/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: papyrus-optimization
+description: Review and optimize Papyrus (`.psc`) scripts — classify each part as broken, suboptimal, or clean, explain what makes it heavy, and give the fix (event-driven, caching, states, native offload). Use when the user shares or points at a `.psc`, asks why a mod causes script lag, stack dumps, or Papyrus log spam, wants to know if a script in the load order is heavy, asks to review, optimize, or speed up a script, or questions a `RegisterForUpdate`/`OnUpdate` loop, a cloak scan, `Utility.Wait` chains, uncached `Game.GetPlayer()`/`GetFormFromFile`, persistence or save-bloat, or whether an update interval is acceptable. Load this before judging any `.psc`, even if it looks like a trivial one-liner — Papyrus cost is latency, not line count, and the heavy patterns hide in scripts that look simple.
+---
+
+# Papyrus Optimization
+
+## Overview
+
+This skill is a read-and-assess investigation flow for Papyrus (`.psc`) source. It lets you read a
+script and classify each part as **🔴 broken**, **🟡 suboptimal**, or **🟢 clean**, name *what* makes
+a part heavy, and give the specific fix — so you catch performance problems a signature lookup can't
+see. It is the cost-and-habits complement to the `papyrus-reference` skill (which gives function
+signatures): that one tells you *what a call is*; this one tells you *what it costs and whether to
+make it*. The deep cost model, exact numbers, full technique catalogue, and citations live in
+[`references/papyrus-performance-reference.md`](references/papyrus-performance-reference.md) — load it
+when you need the *why* behind a verdict; the workflow below is enough for most reviews.
+
+It reads script *text* rather than houseCARL's record/conflict surfaces, so it composes with normal
+file reading (or `housecarl_bsa_extract` + the decompiler when the script is packed) — no L2 query
+surface is required.
+
+## First step: establish the trigger before judging anything
+
+The whole review hinges on one formula:
+
+> **cost = how often the code runs × how much latent/native work each run does.**
+
+So before classifying any line, find **what wakes this code** — a one-shot event (`OnInit`,
+`OnEffectStart`), a real engine event (`OnHit`, `OnActivate`), or a periodic update
+(`RegisterForUpdate`/`OnUpdate` chain). The same line is 🟢 in a one-shot and 🔴 in a 0.1 s loop.
+Why this comes first: it sets the cost multiplier for everything else, and it stops you from
+red-flagging a long-but-rare init script or acquitting a short-but-constant poller. Read the triggers,
+then read the body.
+
+## The three tiers
+
+- **🔴 Broken** — incorrect, leaks, will saturate/freeze the VM, or violates an engine contract. Fix
+  before shipping. (Silent no-ops, persistence/registration leaks, polling that can freeze the game,
+  missing cleanup that corrupts state, event signatures the engine never calls.)
+- **🟡 Suboptimal** — correct, but a strictly-better idiom exists. Fix if it's on a hot path or the
+  fix is cheap; otherwise note and move on. (Uncached lookups, bare `RegisterForUpdate`, polling where
+  an event exists, wrong data structure, hot-path logging, off-the-shelf micro-misses.)
+- **🟢 Clean** — idiomatic and as optimized as it usefully gets. Leave it. (Event-driven, early-out
+  guards, cached refs, single-update chains with an exit, states for gating, native offload, symmetric
+  cleanup.)
+
+Judge against frequency × latency, not line count — a finding's tier rises with how often its trigger
+fires.
+
+## Review checklist
+
+Walk these top-to-bottom. The early questions catch 🔴; the later ones catch 🟡. For the mechanism
+behind any item, see the reference file's matching section.
+
+1. **Trigger?** One-shot, event, or periodic update? (Sets the multiplier for everything below.)
+2. **Event contracts valid?** Does every `Event` block match a real engine event's name and signature?
+   A misspelled/invented event silently never fires → 🔴. Is it expecting `OnUpdate` during menus
+   (won't fire)?
+3. **Polling safe?** Any `RegisterForUpdate`? Small interval (freeze risk) → 🔴. No
+   `UnregisterForUpdate` / no `OnPlayerLoadGame` re-arm / handler possibly longer than its interval
+   (save-bloat) → 🔴/🟡. Could it be a `RegisterForSingleUpdate` chain, or fully event-driven?
+4. **Latent loops?** A `Utility.Wait` chain inside an event holding the thread → 🟡/🔴 by duration and
+   frequency. Prefer a single-update chain.
+5. **Cached?** Repeated `Game.GetPlayer()` / `GetFormFromFile` / `GetWornForm`-style native chains
+   resolving unchanging values each run → 🟡 (🔴 in a tight loop).
+6. **Persistence clean?** Property pointed at a placed reference (permanent persistence)? Ref variables
+   never cleared to `None`? Registrations never undone? → 🔴 (leak) / 🟡.
+7. **Cleanup symmetric?** Every `Add*`/`Register*` matched by a `Remove*`/`Unregister*`? Does a chain
+   have an exit and a state machine a `GoToState("")` back? Missing → 🔴.
+8. **Hot-path weight?** In a frequently-firing handler (`OnHit`, `OnAnimationEvent`, cloak): is there a
+   cheap early-out before the expensive work? Many native calls on the path? No guard / many calls →
+   🟡.
+9. **Right tool?** Container-as-counter, 128-cap array bookkeeping, or a cloak scan where a native
+   (`StorageUtil`, `MiscUtil.ScanCellNPCs`, PO3 filtered events) does it in one call → 🟡.
+10. **States vs flags?** Re-entrancy/do-once handled by a boolean guard where an empty-state handler
+    would gate at the engine level → 🟡.
+11. **Logging gated?** `Debug.Trace`/`Notification` on a hot path in a release build → 🟡.
+12. **Micro (hot path only):** abbreviated AV wrappers, `== true`, int-literal-to-float, `Math.Floor`
+    vs `as int`, non-`Global` stateless helpers — inside a loop/frequent event → 🟡; elsewhere → 🟢
+    (don't-care).
+
+## Symptom → tier → fix
+
+| Symptom in the script | Tier | Why | Fix |
+|---|---|---|---|
+| `Event` name/signature matches no engine event | 🔴 | Never called — silent no-op | Correct to the real event signature |
+| `RegisterForUpdate(0.1)`-style small interval | 🔴 | Can freeze the VM; bloats saves | `RegisterForSingleUpdate` chain, longest tolerable interval |
+| Update handler longer than its interval | 🔴 | Calls queue faster than they drain → 1 GB saves | Single-update chain (next tick waits for previous) |
+| `RegisterForUpdate` with no unregister / survives uninstall | 🔴 | Registration baked into save, fires forever, errors each tick | Single-update chain + `OnPlayerLoadGame` re-arm; alias script |
+| Property pointed at a placed reference | 🔴 | Reference permanently persistent — never unloads | Point at base form; resolve ref at runtime, clear when done |
+| `Add*` with no matching `Remove*` on effect end | 🔴 | Spell/perk leak when effect expires/dispels | Symmetric `OnEffectFinish` cleanup |
+| `Utility.Wait` chain in an event for a timed sequence | 🟡/🔴 | Blocks/pins the thread for the duration | Convert to a `RegisterForSingleUpdate` tick chain |
+| Polling for a condition that has an event | 🟡 | Idle ticks doing nothing | Register for the event (`OnHit`, `OnAnimationEvent`, PO3 `OnHitEx`…) |
+| `Game.GetPlayer()` / `GetFormFromFile` re-called every run | 🟡 | External call each time (~1000× a cached read) | Cache in an auto property / `OnInit` |
+| Cloak spell scanning nearby actors | 🟡 | Re-applies to everyone in range each cycle | SPID for distribution, or `MiscUtil.ScanCellNPCs` |
+| Container `GetItemCount` used as a counter | 🟡 | Native inventory serialisation per access | `StorageUtil.AdjustIntValue`/`GetIntValue` |
+| Cross-script property read in a hot loop | 🟡 | External call (~2× local) per read | Cache to a local variable once |
+| Boolean guard for do-once / re-entrancy | 🟡 | Event still fires, enters function, checks flag | Empty-state handler gates at engine level |
+| `Debug.Trace` on a hot path (release) | 🟡 | External call + disk I/O every fire | Gate behind a debug flag / remove |
+| `GetAV`, `== true`, `Wait(1)`, `Math.Floor` *in a loop* | 🟡 | Extra bytecode/cast/call layer per iteration | Native names, `If(b)`, `1.0`, `as int` |
+| Event-driven, early-out guard, cached refs, single-update chain w/ exit, symmetric cleanup | 🟢 | Minimal frequency × latency | Leave it |
+
+**Red flags at a glance:** `RegisterForUpdate(` with a small literal · an `OnUpdate` with no exit
+condition · `Utility.Wait` inside a loop · a property whose value is a placed reference ·
+`Game.GetPlayer()` inside a loop or frequent event · a cloak/scan distribution · `GetItemCount` as a
+number · `Add*`/`Register*` with no matching `Remove*`/`Unregister*` · `Debug.Trace` in
+`OnHit`/`OnUpdate`.
+
+## Common review mistakes
+
+- **Judging a line before its trigger.** A 7-second `Utility.Wait` chain is alarming in a 0.1 s loop
+  and fine in a once-per-game flourish. Always resolve step 1 first — otherwise you flag rare code and
+  miss constant code.
+- **Chasing micro-opts off the hot path.** `b == true` or `Wait(1)` in a one-shot is 🟢, not 🟡. The
+  micro-optimizations only pay inside loops that run hundreds/thousands of times; spending the review
+  there on rare code is wasted, and rewriting it adds risk for no gain.
+- **Only hunting for bad patterns.** Recognise and *credit* the good ones — a cached `PlayerRef`, an
+  early-out guard, an `OnPlayerLoadGame` re-arm. A review that calls everything 🟡 is as useless as one
+  that calls everything 🟢.
+- **Repeating INI folklore.** "Raise the Papyrus budget / memory page size to fix lag" is debunked
+  (reference §5.3). Don't recommend INI edits as a script fix; fix the script, or point at an engine
+  mod (Papyrus Tweaks NG) for genuine engine limits.
+- **Inventing a signature to justify a verdict.** If a verdict depends on a function's exact behavior,
+  confirm it via `papyrus-reference` or the read source — don't assert a signature from memory.
+
+## Make a defensible verdict (no silent wrong answers)
+
+A script review must land on one of two honest outcomes, never a confident guess:
+
+1. **A classification with a reason and a fix** — "🟡: `Game.GetPlayer()` on lines 81/94/204 re-resolves
+   the player each call; cache it in an auto `PlayerREF` property. Low severity here because the
+   trigger is a one-shot init." Tie the tier to the trigger and name the concrete fix.
+2. **An explicit "I can't tell yet — here's what I checked and what to look at next"** — e.g. when the
+   trigger frequency depends on how an effect is applied (a magic effect's delivery, a quest alias's
+   fill), or when behavior hinges on a function whose semantics you haven't confirmed. Say what you'd
+   need (the effect setup, the calling script, a `papyrus-reference` lookup).
+
+A confidently wrong "this is fine" or "this is broken" is worse than a clear non-answer — it sends the
+user to fix the wrong thing or ship a real problem. Prefer the honest gap.
+
+## Worked example
+
+Two real decompiled snippets, classified.
+
+🟢 **Event-driven with an early-out** — fires only on a blocked hit; guards before the expensive cast:
+```papyrus
+Event OnHit(ObjectReference akAggressor, Form akSource, Projectile akProjectile, \
+            bool abPowerAttack, bool abSneakAttack, bool abBashAttack, bool abHitBlocked)
+    If abHitBlocked
+        GrimyAbCounterStrikeSpell.Cast(spellTarget, spellTarget)
+    EndIf
+EndEvent
+```
+Why 🟢: the engine wakes it only on a hit (no idle cost), and the `abHitBlocked` guard means the cast
+runs only on the rare blocked hit. Trigger is event-driven; hot-path work is gated. Nothing to fix.
+
+🔴 **`Utility.Wait` bleed chain** — blocks the thread ~3 s, pinning the object:
+```papyrus
+Event OnEffectStart(Actor akTarget, Actor akCaster)
+    akTarget.DamageActorValue("Health", dmg)
+    Utility.Wait(0.6)
+    akTarget.DamageActorValue("Health", dmg)
+    Utility.Wait(0.6)
+    ; …×5
+EndEvent
+```
+Why 🔴 (in context): the `Wait` chain holds this script's thread for the full bleed, pinning the actor
+and blocking other events on the script. Fix: drive the ticks with a `RegisterForSingleUpdate` chain
+that re-arms until the bleed count is spent, so the thread is free between ticks.
+
+## Notes
+
+- **Severity is contextual.** Every tier in the tables assumes a hot-path trigger; down-weight on rare
+  triggers per step 1. State the trigger in the verdict so the severity is auditable.
+- **Official vs community, contested claims.** The cost mechanics are official (Creation Kit wiki);
+  benchmark magnitudes ("~1000× faster cached") are single community measurements — directionally
+  right, not exact. "States gate at zero engine cost" and "scripted cloaks are always bad" are
+  community consensus with contested edges. The reference file flags each; carry the flag into the
+  verdict rather than overstating.
+- **Signatures:** confirm any function's parameters/flags via `papyrus-reference` before relying on
+  them in a fix.
+- **Packed scripts:** when only a `.pex` is shipped, extract with `housecarl_bsa_extract` and decompile
+  before reviewing — you can only classify source you can read.

--- a/.claude/skills/papyrus-optimization/evals/eval_set.json
+++ b/.claude/skills/papyrus-optimization/evals/eval_set.json
@@ -1,0 +1,152 @@
+{
+  "skill_name": "papyrus-optimization",
+  "_validation_method": "Manual prediction per HOUSECARL_SKILL_AUTHORING.md §6.5 at authoring time (empirical run_loop.py unavailable: absent from this repo and no non-Windows env). `manual_predicted_trigger` is the author's cold-read prediction. VALIDATED 2026-06-07 via houseCARL's native cold-read fan-out (fresh agents shown the full skill menu, judging blind): 10/10 recall + 10/10 specificity, satisfying the §6.3 gate and the §6.5 independent cold-read check. Outcome correctness (§6.6) signed off by Aaron + Heisen on 11 real load-order scripts. Detailed run-records kept in the private dev corpus.",
+  "_predicted_recall": "10/10 should-trigger predicted to fire (100%)",
+  "_predicted_specificity": "10/10 should-not-trigger predicted to abstain (100%) — optimistic; author prediction trends high, see flagged near-miss risks",
+  "_specificity_risks_to_watch": [
+    "snt-new-script-authoring", "snt-compile-psc", "snt-fps-enb", "snt-keyword-function", "snt-spid-authoring"
+  ],
+  "evals": [
+    {
+      "id": "st-onupdate-framerate",
+      "query": "can you look at this OnUpdate script and tell me if it's gonna tank my framerate",
+      "should_trigger": true,
+      "manual_predicted_trigger": true,
+      "rationale": "Review of an OnUpdate script for performance — core use case."
+    },
+    {
+      "id": "st-stackdumps-which-script",
+      "query": "my papyrus log is full of stack dumps after i added that follower mod, which script is the problem",
+      "should_trigger": true,
+      "manual_predicted_trigger": true,
+      "rationale": "Modder-vocabulary symptom (stack dumps, papyrus log) — the rubric is what identifies the heavy script. Description lists 'stack dumps' and 'Papyrus log spam'."
+    },
+    {
+      "id": "st-review-named-psc",
+      "query": "review _lp_bardplayhornscript.psc for me — is it written well?",
+      "should_trigger": true,
+      "manual_predicted_trigger": true,
+      "rationale": "Explicit .psc review request with a real filename."
+    },
+    {
+      "id": "st-tight-registerforupdate",
+      "query": "I've got a RegisterForUpdate(0.1) in my ability script, is that bad?",
+      "should_trigger": true,
+      "manual_predicted_trigger": true,
+      "rationale": "Questions a tight RegisterForUpdate — named in the description."
+    },
+    {
+      "id": "st-cloak-scan-lag",
+      "query": "how do i make this cloak spell that scans nearby actors less laggy",
+      "should_trigger": true,
+      "manual_predicted_trigger": true,
+      "rationale": "Cloak-scan performance — named in the description."
+    },
+    {
+      "id": "st-getplayer-every-frame",
+      "query": "is calling Game.GetPlayer() every frame in my OnUpdate a problem?",
+      "should_trigger": true,
+      "manual_predicted_trigger": true,
+      "rationale": "Uncached Game.GetPlayer() in a loop — named in the description."
+    },
+    {
+      "id": "st-wait-save-bloat",
+      "query": "this mod's script keeps Utility.Wait looping and i think it's causing save bloat, can you check",
+      "should_trigger": true,
+      "manual_predicted_trigger": true,
+      "rationale": "Utility.Wait chains + save-bloat — both named in the description."
+    },
+    {
+      "id": "st-acceptable-interval",
+      "query": "what's a safe update interval for a hunger/thirst needs script, every second too aggressive?",
+      "should_trigger": true,
+      "manual_predicted_trigger": true,
+      "rationale": "Whether an update interval is acceptable — named in the description."
+    },
+    {
+      "id": "st-optimize-survival-script",
+      "query": "optimize this papyrus script, it's part of my survival mod and feels heavy",
+      "should_trigger": true,
+      "manual_predicted_trigger": true,
+      "rationale": "Optimize a .psc that feels heavy — core action-first use case."
+    },
+    {
+      "id": "st-flag-broken-or-tighter",
+      "query": "can you go through my quest script and flag anything broken or that could be tighter",
+      "should_trigger": true,
+      "manual_predicted_trigger": true,
+      "rationale": "Classify broken vs optimizable — the rubric's whole purpose."
+    },
+
+    {
+      "id": "snt-getplayer-signature",
+      "query": "what does Game.GetPlayer() return and what are its parameters?",
+      "should_trigger": false,
+      "manual_predicted_trigger": false,
+      "rationale": "Near-miss: mentions Game.GetPlayer() but wants a signature → papyrus-reference, not optimization."
+    },
+    {
+      "id": "snt-new-script-authoring",
+      "query": "write me a brand-new papyrus script that gives the player a sword on game start",
+      "should_trigger": false,
+      "manual_predicted_trigger": false,
+      "rationale": "Near-miss / RISK: greenfield authoring, no review/optimize ask. Description is review-and-optimize-shaped; trivial enough Claude handles directly. Watch — could mis-fire on 'papyrus script'."
+    },
+    {
+      "id": "snt-ctd-crashlog",
+      "query": "my game crashes to desktop when i enter Whiterun, here's my crash log",
+      "should_trigger": false,
+      "manual_predicted_trigger": false,
+      "rationale": "Near-miss: crash diagnosis → crash-diagnostics, not script optimization."
+    },
+    {
+      "id": "snt-kid-keyword-distribution",
+      "query": "add the keyword WeapMaterialEbony to all the iron daggers in my load order",
+      "should_trigger": false,
+      "manual_predicted_trigger": false,
+      "rationale": "Near-miss: 'load order' + keywords, but it's KID/SkyPatcher authoring, not a script review."
+    },
+    {
+      "id": "snt-compile-psc",
+      "query": "how do i compile this .psc into a .pex? what's the import path?",
+      "should_trigger": false,
+      "manual_predicted_trigger": false,
+      "rationale": "Near-miss / RISK: mentions .psc but it's compilation/tooling, not review/optimize. Watch the .psc keyword."
+    },
+    {
+      "id": "snt-esl-esp-flag",
+      "query": "what's the difference between an ESL and an ESP flag for my plugin?",
+      "should_trigger": false,
+      "manual_predicted_trigger": false,
+      "rationale": "Plugin flags, unrelated to scripts."
+    },
+    {
+      "id": "snt-skypatcher-not-applying",
+      "query": "this SkyPatcher ini i wrote isn't applying, can you see why",
+      "should_trigger": false,
+      "manual_predicted_trigger": false,
+      "rationale": "Near-miss: 'review my file that isn't working', but it's a SkyPatcher INI → skypatcher-authoring, not .psc."
+    },
+    {
+      "id": "snt-fps-enb",
+      "query": "my fps drops to 20 in cities, what enb settings or mods should i change?",
+      "should_trigger": false,
+      "manual_predicted_trigger": false,
+      "rationale": "Near-miss / RISK: performance/fps complaint, but graphics/ENB, not Papyrus. Watch the 'fps drops' overlap with script-lag vocabulary."
+    },
+    {
+      "id": "snt-keyword-function",
+      "query": "is there a function to check if an actor has a specific keyword in papyrus?",
+      "should_trigger": false,
+      "manual_predicted_trigger": false,
+      "rationale": "Near-miss / RISK: papyrus + function lookup → papyrus-reference. Watch the papyrus overlap."
+    },
+    {
+      "id": "snt-spid-authoring",
+      "query": "explain how SPID distribution works, i want to give all bandits a spell",
+      "should_trigger": false,
+      "manual_predicted_trigger": false,
+      "rationale": "Near-miss / RISK: optimization skill names SPID as a cloak alternative, but user wants to author SPID → spid-authoring."
+    }
+  ]
+}

--- a/.claude/skills/papyrus-optimization/references/papyrus-performance-reference.md
+++ b/.claude/skills/papyrus-optimization/references/papyrus-performance-reference.md
@@ -1,0 +1,366 @@
+# Papyrus Performance Reference (the "why" behind the rubric)
+
+This is the depth layer for the `papyrus-optimization` skill. `SKILL.md` carries the review
+workflow and the rubric; this file carries the cost model, the mechanics, the full technique
+catalogue, the thresholds, and the myth table that justify each rubric verdict. Load it when you
+need the *reason* behind a classification, an exact number, or a citation — not on every review.
+
+Sourcing is **official-first**. "Official" = the Bethesda Creation Kit wiki, canonical live mirror
+**`ck.uesp.net`** (the `creationkit.com` domain is frequently down; a second open mirror is
+`fallout.wiki`). Community sources (forum benchmarks, modder writeups, decompiled source) are
+secondary and tagged `[community]`. Benchmark *magnitudes* are single-source where noted; the
+*mechanisms* are corroborated by official docs.
+
+For function signatures, parameters, and flags, use the `papyrus-reference` skill — this file is
+about cost and habits, not call shapes.
+
+## Contents
+
+1. The one formula — cost = frequency × latency
+2. The execution model (threaded, latency-bound VM; the budget; persistence; saves)
+3. What makes a script heavy (the cost drivers)
+4. Optimization techniques (the fixes, with before→after)
+5. What is "acceptable" — thresholds and the myths
+6. Sources
+
+---
+
+## 1. The one formula — cost = frequency × latency
+
+> **A script's cost ≈ (how often its code runs) × (how much latent/native work each run does).**
+
+Every rule below is a corollary. A 200-line script that runs once at quest start is free. A
+three-line `OnUpdate` firing every 0.1 s with two native calls can saturate the VM. When you read a
+script, look first at **what triggers it** and **how many engine calls live on the hot path** — not
+at the line count. Two consequences that cut against intuition:
+
+- **Pure computation is nearly free; engine calls are not.** Arithmetic, string assignment,
+  branches, and array element access cost almost nothing. The expensive thing is *talking to the
+  game* (any native/external call). Optimizing almost always means **fewer engine calls, less
+  often** — not tighter arithmetic.
+- **Micro-optimizations only matter on the hot path.** The canonical benchmark explicitly cautions
+  the differences "only matter [if] you are creating a loop that will run hundreds or thousands of
+  times" ([gamesas: Performance characteristics](https://www.gamesas.com/performance-characteristics-papyrus-functions-and-operati-t260999.html), `[community]`).
+  A `b == true` that runs once is not worth touching; the same line in a 0.1 s loop is.
+
+---
+
+## 2. The execution model
+
+### 2.1 Event-driven, not autonomous
+
+Papyrus code runs **only in response to the game or another script** — inside an `Event` block or a
+fragment. There is no main loop you write; the only "run repeatedly" is *registering* for an update
+event ([Papyrus Introduction](https://ck.uesp.net/wiki/Papyrus_Introduction)). The cheapest script
+is one the engine only wakes when something it cares about happens.
+
+### 2.2 Threaded, lock-per-instance VM
+
+"Papyrus is a threaded scripting language… the game can run multiple scripts in parallel." Only
+**one thread at a time** may touch a script instance; the first thread locks it and others queue, in
+**unpredictable** order. A script that hogs CPU is suspended so others run ([Threading Notes](https://ck.uesp.net/wiki/Threading_Notes_(Papyrus))).
+
+### 2.3 Any external call suspends your thread — the source of latency
+
+The most important mechanical fact:
+
+> "Any time a thread makes an external call (to a function on a different object, to a global
+> function, or to a function in a script with a different self), its execution is suspended… The
+> nature of the function does not matter: it can be native or non-native, latent or not… Even
+> native non-delayed functions (like Debug.Trace) are external calls." ([Threading Notes](https://ck.uesp.net/wiki/Threading_Notes_(Papyrus)))
+
+**Not** external: reading/writing a property **defined in the same script** (lowered to a variable
+access) and **all array operations** (read, write, length, find, rfind) (ibid.). And:
+
+> "native functions all return after at least one frame (the non-delayed functions excepted)… the
+> VM can process about a few thousands of calls per frame." (ibid.)
+
+So a **delayed native call costs ~one frame of latency.** Community quantifies it: ~90% of a
+script's wall-time is "simply waiting for delayed native functions," and "if you call 30 native
+functions and the game is running at 30 fps, it will take (roughly) 1 second to get through them
+all" ([gamesas: Game engine vs Papyrus efficiency](https://www.gamesas.com/game-engine-papyrus-efficiency-questions-t373162.html), `[community]`, corroborating the official "≥1 frame" statement).
+
+> **Papyrus is latency-bound, not compute-bound.** A "heavy" script usually issues many delayed
+> native calls on a frequent trigger — each parks the script for a frame. Reduce the *count* and
+> *frequency* of engine calls and you have done most of the optimization.
+
+### 2.4 The per-frame budget is tiny
+
+`Skyrim.ini` `[Papyrus]` defaults, verbatim ([INI Settings (Papyrus)](https://ck.uesp.net/wiki/INI_Settings_(Papyrus))):
+
+| Setting | Default | What it does |
+|---|---|---|
+| `fUpdateBudgetMS` | **1.2** | Time/frame for the main Papyrus update loop (function dispatch). |
+| `fExtraTaskletBudgetMS` | **1.2** | Extra/frame for running script tasklets (byte-code), borrowed from another thread. |
+| `fPostLoadUpdateTimeMS` | **500.0** (2000 old consoles) | Extra script time on the load screen for cell/quest setup. |
+| `iMinMemoryPageSize` | **128** | Smallest VM stack-page allocation (bytes). |
+| `iMaxMemoryPageSize` | **512** | Largest VM stack-page allocation (bytes). |
+| `iMaxAllocatedMemoryBytes` | **76800** (~75 kB) | Total VM **stack-frame** memory cap. |
+| `bEnableLogging`/`bEnableTrace` | **0** | Papyrus log + trace; off by default ("may improve performance due to less disk activity"). |
+
+At 60 fps a frame is ~16.67 ms, of which Papyrus gets ~**1.2 ms** by default — the rest is rendering
+and the engine ([Thallassa](https://thallassathoughts.wordpress.com/2016/09/16/myths-and-legends-papyrus-ini-settings/),
+[STEP](https://stepmodifications.org/wiki/Guide:Skyrim_INI/Papyrus), `[community]`). The official
+note on `fUpdateBudgetMS` is explicit: raising it buys script time **"at the cost of reduced game
+framerate,"** and "most of the time the VM won't take this entire time slice." This is a description
+of how little time scripts get — not a dial to turn (see §5 myths).
+
+### 2.5 Stacks, suspension, stack dumps
+
+A stack is **suspended** by a latent call — `Utility.Wait(n)` parks it for `n` real seconds
+([Persistence](https://ck.uesp.net/wiki/Persistence_(Papyrus))). When too many suspended stacks pile
+up, the VM logs the canonical **stack dump** (`Suspended stack count is over our warning threshold…
+VM is freezing… VM is frozen`) ([INI Settings](https://ck.uesp.net/wiki/INI_Settings_(Papyrus))). A
+stack dump is a **read-only diagnostic, not a crash** — it cannot damage a save; it is a symptom that
+the VM was overstressed (~5 s by default) ([Stack Dumps are harmless](https://www.nexusmods.com/skyrimspecialedition/articles/4625), `[community]`). Fix the cause; never silence the log.
+
+### 2.6 Persistence — the quiet cost
+
+Persistence keeps an `ObjectReference` loaded so it "consume[s] processor time and memory when other
+references in the same area will have disappeared and unloaded" ([Persistence](https://ck.uesp.net/wiki/Persistence_(Papyrus))). Official causes + checklist:
+
+- A **running function** (incl. long latent ones) pins its object until it returns.
+- A **property pointed at a placed reference** flags that reference **permanently persistent** —
+  *"nothing you do during runtime will unload the object,"* even reassigning. **"If possible, you
+  should not use properties to point at references directly."**
+- A **variable** holding a reference pins it only until no variable points at it; clear with `None`.
+- **Registering for an event** (`OnUpdate`, `OnLOS`, `OnSleep`, `OnAnimationEvent`…) pins until
+  unregister.
+
+Official checklist (verbatim): *avoid long-running functions; avoid properties to references if
+possible; ref variables should point only as long as needed; only register for updates as long as
+you need them.*
+
+### 2.7 The save game bakes script state
+
+The game can save at any instant — between or mid-line — and resumes scripts on load *"assuming you
+don't change anything"* ([Save File Notes](https://ck.uesp.net/wiki/Save_File_Notes_(Papyrus))).
+Consequences that drive bloat and corruption:
+
+- Remove a script after a save and it **still exists on load** (orphaned script); deleting one
+  entirely "may result in oddities."
+- Removed properties/variables **linger in the save** until the next save.
+- **Auto** properties restore from the master; **non-auto** properties and uninitialized variables
+  come back blank/zeroed.
+- A variable pointing at a form from a **removed plugin** becomes a permanent "missing" placeholder
+  (ID #0) — restoring the plugin **does not** recover it once re-saved.
+- This is why a leftover `RegisterForUpdate` from an uninstalled mod **keeps firing forever**, baked
+  into the save, erroring each tick (§3.1).
+
+---
+
+## 3. What makes a script heavy
+
+Roughly ordered by damage.
+
+1. **Polling.** `RegisterForUpdate` with a small interval **can freeze the game**; if the handler
+   runs longer than its interval, calls "are queued faster than they are processed… can lead to
+   savegames as large as one gigabyte!"; a removed mod's handler "still… registered… periodic errors
+   on every tick" ([RegisterForUpdate](https://ck.uesp.net/wiki/RegisterForUpdate_-_Form)). `OnUpdate`
+   doesn't fire in menus and "can start piling up on itself," increasing save size ([OnUpdate](https://ck.uesp.net/wiki/OnUpdate_-_Form)).
+2. **Many latent/native calls per run.** Each delayed native ≈ one frame; loops calling natives per
+   iteration are the usual culprit.
+3. **High-frequency events with heavy bodies.** `OnHit`, `OnAnimationEvent`, cloak
+   `OnMagicEffectApply`/`OnEffectStart` fire often; heavy work with no cheap early-out runs every fire.
+4. **Repeated uncached lookups.** `Game.GetPlayer()` every event, `GetFormFromFile` in logic,
+   `GetWornForm() as Armor` chains. A cached `PlayerRef` property is **~1000×** faster than
+   `Game.GetPlayer()` (`[community]` benchmark; mechanism is the §2.3 external-call rule).
+5. **Cross-script reads on the hot path.** A property on **another** object is an external call (~2×
+   a local read).
+6. **Cloak/scan distribution.** Cloaks re-apply to every actor in range each cycle — cost scales with
+   range (the cloak effect's *magnitude* encodes range), cycle rate, handler weight. Community
+   consensus: distribute via **SPID** instead. *Contested as a universal ban* — a single well-scoped
+   cloak with a cheap handler is not catastrophic ([gamesas](https://www.gamesas.com/will-scripts-work-cloak-spell-t259235.html), `[community]`).
+7. **Wrong data structure.** Container `GetItemCount` as a counter forces native inventory serialisation
+   per access; arrays cap at **128**, sized by a compile-time literal, reallocate on resize ([Arrays](https://ck.uesp.net/wiki/Arrays_(Papyrus))).
+8. **Persistence leaks.** Never-unregistered updates, properties pinning refs, ref vars never cleared
+   to `None` (§2.6).
+9. **`Utility.Wait` loops** holding a thread for their whole duration.
+10. **Logging in hot paths.** Every `Debug.Trace`/`Notification` is an external call + disk I/O.
+
+---
+
+## 4. Optimization techniques
+
+### 4.1 Cache anything that doesn't change
+```papyrus
+; ✗ external call every time
+Actor player = Game.GetPlayer()
+; ✓ fill once in the CK; thereafter a free same-script property access
+Actor Property PlayerREF Auto
+```
+Same for a target actor inside a frequent handler — store `akTarget` in a variable in
+`OnEffectStart`, reuse it, instead of re-calling `GetTargetActor()` each event.
+
+### 4.2 Prefer properties to runtime form lookups
+Fill a `Form`/`Spell`/`Keyword` property in the CK rather than `Game.GetFormFromFile(...)` in logic
+(`GetFormFromFile` is for *optional* cross-mod soft deps). `[community]`; the CK wiki makes no cost
+claim here, so treat as best-practice, not an official number.
+
+### 4.3 Replace polling with events — highest leverage
+If an engine event already signals the condition, register for it instead of polling.
+
+| Instead of polling for… | Use |
+|---|---|
+| player got hit | `OnHit` (or PO3 `OnHitEx`, filters in C++) |
+| started/stopped sneaking/attacking | `OnAnimationEvent` / `RegisterForActorAction` |
+| a specific magic effect landed | PO3 `OnMagicEffectApplyEx` |
+| inventory/equip changed | `OnItemAdded` / `OnObjectEquipped` |
+| distribute to many NPCs | **SPID** (no per-frame scan) instead of a cloak |
+
+Re-register listeners in `OnPlayerLoadGame` so they survive save/load.
+
+### 4.4 If you must poll, poll correctly
+```papyrus
+Event OnInit()
+    RegisterForSingleUpdate(5.0)
+EndEvent
+Event OnUpdate()
+    ; …work…
+    If bKeepGoing                      ; explicit exit
+        RegisterForSingleUpdate(5.0)   ; re-arm only if still needed
+    EndIf
+EndEvent
+```
+Why this beats `RegisterForUpdate`: the next tick can't start before the previous finished (no
+pile-up); an error stops it instead of erroring every tick forever; you control the exit
+([RegisterForUpdate](https://ck.uesp.net/wiki/RegisterForUpdate_-_Form)). Pick the **longest interval
+the feature tolerates**. Bare `RegisterForUpdate` is legitimate only for a script guaranteed not to
+live long, or millisecond-critical timing. An `OnPlayerLoadGame` re-arm is cheap insurance, but not strictly required for a
+single-update chain — a pending `RegisterForSingleUpdate` is itself serialized and generally
+re-fires after load, so the chain usually survives on its own.
+
+### 4.5 Use states to gate events at the engine level
+Defining an event **empty inside a state** switches it off — *"simply define that event or function
+in the state and leave it empty"* ([States](https://ck.uesp.net/wiki/States_(Papyrus))). Community
+holds this is cheaper than a boolean guard because the engine skips dispatching an empty-state handler
+rather than entering the function to check a flag ([cipscis: States](http://www.cipscis.com/skyrim/tutorials/states.aspx), `[community]`).
+```papyrus
+Event OnHit(...)
+    DoThing()
+    GoToState("Done")
+EndEvent
+State Done
+    Event OnHit(...)
+    EndEvent           ; empty — engine stops calling it
+EndState
+```
+Switch state **before** any external call in the handler (an external call can let another thread in
+first). Return to default with `GoToState("")`.
+
+### 4.6 Offload to native (SKSE) instead of looping in Papyrus
+SKSE natives are **not** slower than vanilla natives (`[community]`). High-value offloads (confirm
+signatures via `papyrus-reference`):
+
+| Papyrus pattern | Native replacement | Source |
+|---|---|---|
+| Cloak → iterate hit actors | `MiscUtil.ScanCellNPCs(center, radius, keyword, ignoreDead)` | PapyrusUtil |
+| Container-count counter | `StorageUtil.AdjustIntValue` / `GetIntValue` | PapyrusUtil |
+| Hand-rolled array list | `StorageUtil.FormListAdd/Get/Count/Has` (dynamic, persistent) | PapyrusUtil |
+| Loop testing for an active spell/effect | `PO3_SKSEFunctions.HasActiveSpell` / `HasActiveMagicEffect` | PapyrusExtender |
+| `OnHit` + Papyrus `If` filters | `PO3_Events_AME.RegisterForHitEventEx` → `OnHitEx` | PapyrusExtender |
+| Poll for "did effect X apply" | `PO3_Events_AME.RegisterForMagicEffectApplyEx` → `OnMagicEffectApplyEx` | PapyrusExtender |
+| Script-maintained behaviour override | `ActorUtil.AddPackageOverride` | PapyrusUtil |
+
+### 4.7 Persistence & cleanup hygiene
+Symmetric add/remove (`AddSpell`/`AddPerk` in `OnEffectStart` ↔ `RemoveSpell`/`RemovePerk` in
+`OnEffectFinish`); `UnregisterForUpdate` when a chain ends; clear ref variables to `None`; prefer a
+**`ReferenceAlias`**-extending script over directly scripting an `ObjectReference`/`Actor` (aliases
+sever cleanly when the quest stops, avoiding orphaned registrations after uninstall); don't point
+properties at placed references.
+
+### 4.8 Minimize cross-script overhead
+Cache a remote property into a local once; use `Import ScriptName` to call its globals without a
+wrapper; make stateless helpers **`Global`** (call cost fastest→slowest: inline → native global →
+user global → local function).
+
+### 4.9 Micro-optimizations — hot path only
+Bytecode-demonstrated ([Dennis Soemers: 11 micro-optimisations](https://dennissoemers.github.io/skyrim/papyrus/programming/optimisations/microoptimisations-skyrim/), `[community]`):
+- Call the native, not its wrapper: `GetActorValue("Health")` not `GetAV`; `GetReference() as Actor`
+  not `GetActorReference()`; `GetValue() as int` not `GetValueInt()`.
+- `If (b)` not `If (b == true)`; `If (!b)`/`If (b == false)` not `If (b != true)`.
+- Assign booleans directly: `bool a = someExpr`.
+- Match literal types: `Utility.Wait(1.0)` not `Wait(1)`; `If (f > 1.0)` not `> 1`.
+- `x as int` not `Math.Floor(x)` (~14× the conversion).
+- Factor offsets: `x + Utility.RandomInt(5, 20)` not `RandomInt(x+5, x+20)`.
+- Prefer **auto** properties (VM optimizes them slightly; [Variables and Properties](https://ck.uesp.net/wiki/Variables_and_Properties)).
+
+### 4.10 Tooling
+External editor + compiler; `Debug.Trace` freely in testing, gated/removed for release; profile with
+[PapyrusProfiler](https://github.com/DennisSoemers/PapyrusProfiler) (counts call *frequency*, not
+time) or `Debug.StartStackProfiling` + speedscope.
+
+---
+
+## 5. What is "acceptable" — thresholds and the myths
+
+### 5.1 Honest thresholds
+No single enforced "max ms per script"; "acceptable" is the **frequency × latency** product against
+~1.2 ms/frame.
+- **One-shot / event-driven work is always acceptable**, however long — it runs rarely.
+- **Update intervals:** the longest the feature tolerates. Sub-second polling, *multiplied across
+  many scripts*, is where saturation builds. Under "a few seconds," use a `RegisterForSingleUpdate`
+  chain, never bare `RegisterForUpdate`.
+- **Native calls per hot-path run:** keep them low. "30 native calls at 30 fps ≈ 1 second."
+- **Polling is acceptable only when** no event exists, the interval is as long as tolerable, and the
+  chain has an exit.
+- **Micro-opts are don't-care off the hot path.**
+
+### 5.2 Symptoms of crossing the line
+Saturation shows as **deferred, not lost** work — "Papyrus does not arbitrarily discard things, you
+just get lag": late doors/containers, slow MCM, late dialogue/quest stages ([Nexus: Script Heavy Mods](https://www.nexusmods.com/skyrim/articles/52598), `[community]`). **Stack dumps** in the log are the
+explicit warning (harmless symptom; trace to cause).
+
+### 5.3 Myths — do not propagate these
+
+| Myth | Reality | Source |
+|---|---|---|
+| "Raise `fUpdateBudgetMS`/tasklet budget to fix lag." | Stolen from frame-draw time — trades FPS for dispatch, creates no capacity; the VM usually doesn't use the whole slice. Narrow exception: a small bump (1.2→1.6) on an FPS-capped system with headroom. | [INI Settings](https://ck.uesp.net/wiki/INI_Settings_(Papyrus)) `[official]`; [Thallassa](https://thallassathoughts.wordpress.com/2016/09/16/myths-and-legends-papyrus-ini-settings/), [STEP](https://stepmodifications.org/wiki/Guide:Skyrim_INI/Papyrus) `[community]` |
+| "Enlarge `iMin/iMaxMemoryPageSize` to stop stack dumps." | VM allocates new stacks on demand; needs more, not bigger. **"DON'T TOUCH THESE."** | [Thallassa](https://thallassathoughts.wordpress.com/2016/09/16/myths-and-legends-papyrus-ini-settings/) `[community]` |
+| "Multiply `iMaxAllocatedMemoryBytes` massively." | It's a **stack** cap; exceeding it makes the VM *wait*, not crash. Inflating causes "stack thrashing… intermittent game stuttering, erratic game behavior and CTDs." | [INI Settings](https://ck.uesp.net/wiki/INI_Settings_(Papyrus)) `[official]` + [Thallassa](https://thallassathoughts.wordpress.com/2016/09/16/myths-and-legends-papyrus-ini-settings/) `[community]` |
+| "Papyrus is just a slow interpreter." | The slowness is architectural **latency** (one frame per delayed native), not weak compute. | [Threading Notes](https://ck.uesp.net/wiki/Threading_Notes_(Papyrus)) `[official]`; [gamesas](https://www.gamesas.com/game-engine-papyrus-efficiency-questions-t373162.html) `[community]` |
+| "A stack dump corrupts your save." | Read-only diagnostic; fix the cause, don't silence the log. | [Stack Dumps are harmless](https://www.nexusmods.com/skyrimspecialedition/articles/4625) `[community]` |
+| "`fPostLoadUpdateTimeMS` is unsafe." | Safe; only lengthens the load screen (keep < 1000). | [Thallassa](https://thallassathoughts.wordpress.com/2016/09/16/myths-and-legends-papyrus-ini-settings/) `[community]` |
+
+The legitimate "make Papyrus faster" is an **engine mod**, not an INI edit:
+[Papyrus Tweaks NG](https://www.nexusmods.com/skyrimspecialedition/mods/77779) raises the antique
+"100 operations per tasklet" throughput cap (untouched since 2011), adds **SpeedUpNativeCalls** (syncs
+read-only getter natives to a spinlock instead of the framerate — attacking the latency bottleneck
+directly), caches `GetFormFromFile`, and makes the stack-dump timeout configurable (`[community]`).
+
+---
+
+## 6. Sources
+
+**Official — Creation Kit wiki (`ck.uesp.net`):**
+[Papyrus Introduction](https://ck.uesp.net/wiki/Papyrus_Introduction) ·
+[Threading Notes](https://ck.uesp.net/wiki/Threading_Notes_(Papyrus)) ·
+[Persistence](https://ck.uesp.net/wiki/Persistence_(Papyrus)) ·
+[Save File Notes](https://ck.uesp.net/wiki/Save_File_Notes_(Papyrus)) ·
+[INI Settings](https://ck.uesp.net/wiki/INI_Settings_(Papyrus)) ·
+[OnUpdate](https://ck.uesp.net/wiki/OnUpdate_-_Form) /
+[RegisterForUpdate](https://ck.uesp.net/wiki/RegisterForUpdate_-_Form) /
+[RegisterForSingleUpdate](https://ck.uesp.net/wiki/RegisterForSingleUpdate_-_Form) ·
+[States](https://ck.uesp.net/wiki/States_(Papyrus)) ·
+[Arrays](https://ck.uesp.net/wiki/Arrays_(Papyrus)) ·
+[Variables and Properties](https://ck.uesp.net/wiki/Variables_and_Properties).
+
+**Community — benchmarks, guides, tools:**
+[gamesas: Performance characteristics](https://www.gamesas.com/performance-characteristics-papyrus-functions-and-operati-t260999.html) (canonical micro-benchmark; single source for magnitudes) ·
+[gamesas: Game engine vs Papyrus efficiency](https://www.gamesas.com/game-engine-papyrus-efficiency-questions-t373162.html) ·
+[Dennis Soemers: 11 micro-optimisations](https://dennissoemers.github.io/skyrim/papyrus/programming/optimisations/microoptimisations-skyrim/) + [PapyrusProfiler](https://github.com/DennisSoemers/PapyrusProfiler) ·
+[Thallassa: Papyrus INI myths](https://thallassathoughts.wordpress.com/2016/09/16/myths-and-legends-papyrus-ini-settings/) ·
+[STEP: Skyrim INI/Papyrus](https://stepmodifications.org/wiki/Guide:Skyrim_INI/Papyrus) ·
+[Beyond Skyrim — Arcane University: Scripting Best Practices](https://wiki.beyondskyrim.org/wiki/Arcane_University:Scripting_Best_Practices) ·
+[cipscis tutorials](http://www.cipscis.com/skyrim/tutorials/) ·
+[Nexus: On Script Heavy Mods and Engine Overload](https://www.nexusmods.com/skyrim/articles/52598) /
+[Stack Dumps are harmless](https://www.nexusmods.com/skyrimspecialedition/articles/4625) ·
+[Papyrus Tweaks NG](https://www.nexusmods.com/skyrimspecialedition/mods/77779) ·
+source: [Grimy decomp](https://github.com/Rukan/Grimy-Skyrim-Papyrus-Source), [PapyrusUtil](https://github.com/noxsidereum/PapyrusUtil), [PapyrusExtenderSSE](https://github.com/powerof3/PapyrusExtenderSSE).
+
+> **Certainty note.** Official mechanics (threading/latency model, budget defaults, persistence, save
+> baking, update behavior, the memory-inflation warning) are fact. Benchmark *magnitudes* ("~1000×",
+> "~13× batching") are individual community measurements — directionally reliable, consistent with the
+> official mechanism, not precise constants. "States gate at zero engine cost" and "scripted cloaks
+> are always bad" are community consensus with an official basis but contested edges; flag them as
+> such when you cite them.

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,11 @@ release/
 ## Transient, never source-of-truth; like the worktrees above, it must never enter a commit.
 .claude/scheduled_tasks.lock
 
+## Skill eval RUN-RECORDS — per-run validation outputs (trigger / outcome results) under a skill's
+## evals/. The eval SET (eval_set.json) is committed; run-records are dev-local, and the detailed
+## ones can carry a tester's private load-order data, so they live in dev/ (private), never here.
+.claude/skills/*/evals/*-RESULTS.md
+
 ## Internal dev workspace — PRFAQ corpus, plans, session handoffs, review audits, references, and
 ## spike code. houseCARL's private working area, carved from the public repo at GitHub go-live
 ## (Aaron 2026-06-04); it never publishes. This whole-dir rule subsumes the former

--- a/scripts/build-plugin.ps1
+++ b/scripts/build-plugin.ps1
@@ -47,8 +47,8 @@ $PackagingSrc = Join-Path $RepoRoot 'packaging'        # tracked source for pack
 $ReleaseDir   = Join-Path $RepoRoot 'release'          # output dir for the shippable zip (gitignored)
 $PluginManifest = Join-Path $PluginSrc '.claude-plugin\plugin.json'   # single source of truth for the version
 
-# the 5 shipped skills (the modlist-authoring cluster was removed; tool-surface skills wait)
-$Skills = @('mutagen-reference','papyrus-reference','skypatcher-authoring','spid-authoring','kid-authoring')
+# the 6 shipped skills (the modlist-authoring cluster was removed; tool-surface skills wait)
+$Skills = @('mutagen-reference','papyrus-reference','skypatcher-authoring','spid-authoring','kid-authoring','papyrus-optimization')
 
 function Step($n,$msg) { Write-Host "`n=== [$n] $msg ===" -ForegroundColor Cyan }
 
@@ -86,7 +86,7 @@ Get-ChildItem $ServerDir -Filter 'appsettings*.json' -ErrorAction SilentlyContin
 Step '3/10' 'Copy corpus.json beside the exe'
 Copy-Item $CorpusSrc (Join-Path $ServerDir 'corpus.json') -Force
 
-# ---- 4. bundle the 5 skills (exclude evals/ + _CORPUS_STATUS.md; KEEP all .jsonl) ----
+# ---- 4. bundle the 6 skills (exclude evals/ + _CORPUS_STATUS.md; KEEP all .jsonl) ----
 Step '4/10' 'Bundle skills'
 New-Item -ItemType Directory -Path $SkillsDir -Force | Out-Null
 foreach ($s in $Skills) {


### PR DESCRIPTION
Community skill submission by **DrHeisen** — a read-and-assess reviewer that grades a `.psc` broken / suboptimal / clean, names what makes each part heavy, and gives the concrete fix (event-driven, caching, states, native offload). The cost/performance complement to the signature-only `papyrus-reference`.

## Validation (per `HOUSECARL_SKILL_AUTHORING.md`)
- **Trigger (6.3):** 10/10 recall + 10/10 specificity via cold-read fan-out (the 6.1 `run_eval.py` is absent from the repo and there's no WSL, so the native fan-out method was used). All five author-flagged mis-fire risks held.
- **Outcome (6.6):** 11 real scripts from the live ARR 2.0 load order, reviewed cold by the skill -> **5 green / 5 yellow / 1 red**, all three tiers, spot-verified against the source. RED-detection exercised: `_wetCheckSeason` caught with an honest dead-code caveat. **Signed off by Aaron + Heisen.**
- Validation records live under `.claude/skills/papyrus-optimization/evals/` (stripped from the shipped plugin by `build-plugin.ps1`).

## Changes
- New skill `.claude/skills/papyrus-optimization/` — `SKILL.md` + `references/` + `evals/`.
- Registered in `$Skills` (`scripts/build-plugin.ps1`) so it bundles to both Claude Code and Codex.

Generated with Claude Code
