### PR TITLE
Add keyless Nexus Mods read tools (search + mod lookup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ models — by construction, not a hand-maintained subset.
   cleaned automatically.
 - **Drive the external toolchain** — compile Papyrus scripts through the Creation Kit's compiler, and
   list / extract / repack BSA archives via BSArch; each tool's path is auto-detected or set once.
+- **Look mods up on Nexus** — search the Skyrim SE catalogue and pull any mod's version, requirements,
+  files, and *true* latest release straight from Nexus Mods, without opening a browser. Read-only: it finds
+  and informs; downloading stays your mod manager's "Mod Manager Download" handoff.
 - **Look things up and author distributor files** through bundled, namespaced skills: record schemas
   (every type Mutagen models), Papyrus / SKSE signatures, and SkyPatcher / SPID / KID distributor
   grammars.
@@ -86,6 +89,11 @@ into a new plugin. The active load order is read **statically** from your MO2 pr
 `modlist.txt` / `plugins.txt` (no USVFS, no live MO2 hooking) and refreshes automatically on the next tool
 call via cheap mtime checks. No plugin file handles are held at rest, so MO2 and xEdit can move or delete
 plugins freely while houseCARL is running.
+
+The only outbound network use is the read-only **Nexus Mods lookups** (catalogue search + mod detail).
+They're **keyless** — the public Nexus catalogue API needs no account or API key — and offline-tolerant: if
+there's no connection they say so plainly and every local capability keeps working. houseCARL reads Nexus;
+it never downloads or installs (that stays your mod manager's `nxm` "Mod Manager Download" handoff).
 
 ## Bundled skills
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -17,6 +17,8 @@ It can:
   cleaned automatically.
 - **Drive the external toolchain** — compile Papyrus scripts through the Creation Kit's compiler, and
   list / extract / repack BSA archives via BSArch; each tool's path is auto-detected or set once.
+- **Look mods up on Nexus** — search the Skyrim SE catalogue and read any mod's version, requirements, and
+  files straight from Nexus Mods, no browser needed. Read-only; downloading stays your mod manager's job.
 - Look up **record schemas** (every type Mutagen models) and **Papyrus / SKSE signatures**, and author
   **SkyPatcher**, **SPID**, and **KID** distributor files — through bundled, namespaced skills
   (`/housecarl:mutagen-reference`, `/housecarl:papyrus-reference`, `/housecarl:skypatcher-authoring`,
@@ -54,6 +56,7 @@ Talk to it. For example:
 - "Make a patch that gives every iron weapon +5 damage."
 - "Distribute a Frost Resistance ability to all Nords with SPID."
 - "Which plugins override the IronSword record, and who wins?"
+- "Search Nexus for the most-endorsed archery overhauls — what's the top one's latest version and requirements?"
 
 houseCARL writes each patch as its own MO2 mod folder; enable it in MO2 like any other mod, then review it
 in xEdit if you like before playing.

--- a/src/housecarl-mcp/NexusClient.cs
+++ b/src/housecarl-mcp/NexusClient.cs
@@ -1,0 +1,212 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace HousecarlMcp;
+
+/// <summary>
+/// houseCARL's read-only bridge to the Nexus Mods public v2 GraphQL API (the QOL "smooth out Nexus" layer). It exists
+/// so houseCARL can answer Nexus questions — search the catalog, look up a mod's version/requirements/files — DIRECTLY
+/// instead of driving a browser to scrape a rendered page. It is deliberately:
+///   • READ-ONLY — search + mod lookup; it never downloads, installs, endorses, or mutates anything. A download stays
+///     the user's mod manager's job (the nxm "Mod Manager Download" handoff), exactly as before.
+///   • KEYLESS — the v2 GraphQL read surface (search/mod/modFiles/requirements) is public and anonymous, so there is no
+///     API key to configure (and a personal key in a public app is AUP-"unacceptable" anyway). One fewer onboarding step.
+///   • OFFLINE-SAFE (Q3) — every failure mode (no connection, timeout, HTTP error, rate-limit, malformed body, GraphQL
+///     error) is RETURNED as a plain message, never thrown. houseCARL's local (load-order) tools never depend on this and
+///     keep working with no internet.
+/// It lives in housecarl-mcp, NOT housecarl-core: core is the proven, deterministic, OFFLINE Mutagen engine and stays
+/// network-free. This is the server's first and only outbound network dependency, isolated here.
+/// Registered as a typed HttpClient (Program.cs, services.AddHttpClient&lt;NexusClient&gt;) so its lifetime/timeout are managed.
+/// </summary>
+public sealed class NexusClient
+{
+    /// <summary>Skyrim Special Edition's Nexus game id (domainName 'skyrimspecialedition'). houseCARL is SSE-only, so every
+    /// query is scoped to this — the user never types a game id.</summary>
+    public const int SkyrimSeGameId = 1704;
+
+    const string Endpoint = "https://api.nexusmods.com/v2/graphql";
+
+    readonly HttpClient _http;
+
+    // PropertyNamingPolicy=null: GraphQL field/variable names are case-sensitive (gameId, modId, categoryName,
+    // direction). We author them exactly and must NOT let a camelCase policy rewrite them.
+    static readonly JsonSerializerOptions Json = new() { PropertyNamingPolicy = null };
+
+    public NexusClient(HttpClient http) => _http = http;
+
+    // ──────────────────────────────────────────────────────────────────────────────────────────────────────────
+    //  Public API — both return (ok, error, payload). ok==false ⇒ error is a user-facing message and payload is null.
+    // ──────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Search Skyrim SE mods by a wildcard name term, sorted DESC by <paramref name="sortField"/> (a ModsSort
+    /// field name), optionally narrowed to a category name, capped at <paramref name="count"/>.</summary>
+    public async Task<(bool ok, string? error, NexusSearchResult? result)> SearchAsync(
+        string term, string? category, string sortField, int count, CancellationToken ct)
+    {
+        var filter = new Dictionary<string, object>
+        {
+            ["gameId"] = new[] { new { value = SkyrimSeGameId.ToString(), op = "EQUALS" } },
+            ["name"] = new[] { new { value = term, op = "WILDCARD" } },
+        };
+        if (!string.IsNullOrWhiteSpace(category))
+            filter["categoryName"] = new[] { new { value = category!, op = "EQUALS" } };
+
+        // sort is [{ <field>: { direction: DESC } }] — a single-key object, so build it from a dictionary.
+        var sort = new[] { new Dictionary<string, object> { [sortField] = new { direction = "DESC" } } };
+
+        var (ok, error, data) = await PostAsync(SearchQuery, new { filter, sort, count }, ct);
+        if (!ok) return (false, error, null);
+
+        var mods = data.GetProperty("mods");
+        var hits = new List<NexusSearchHit>();
+        foreach (var n in mods.GetProperty("nodes").EnumerateArray())
+            hits.Add(new NexusSearchHit(
+                Int(n, "modId"), Str(n, "name") ?? "", Str(n, "version"), Str(n, "author"),
+                Int(n, "endorsements"), Int(n, "downloads"), Str(n, "updatedAt"),
+                Bool(n, "adultContent"), Str(n, "summary"), Str(n, "category")));
+        return (true, null, new NexusSearchResult(Int(mods, "totalCount"), hits));
+    }
+
+    /// <summary>Fetch one mod's full detail + its files, in a SINGLE request (mod + modFiles are separate root fields
+    /// queried together). A non-existent modId comes back as a GraphQL error (mod is non-null in the schema), surfaced
+    /// via ok==false.</summary>
+    public async Task<(bool ok, string? error, NexusModDetail? mod)> GetModAsync(int modId, CancellationToken ct)
+    {
+        var (ok, error, data) = await PostAsync(
+            ModQuery, new { modId = modId.ToString(), gameId = SkyrimSeGameId.ToString() }, ct);
+        if (!ok) return (false, error, null);
+
+        var m = data.GetProperty("mod");
+
+        var reqs = new List<NexusRequirement>();
+        if (m.TryGetProperty("modRequirements", out var mr) && mr.ValueKind == JsonValueKind.Object
+            && mr.TryGetProperty("nexusRequirements", out var nr) && nr.ValueKind == JsonValueKind.Object
+            && nr.TryGetProperty("nodes", out var nodes) && nodes.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var r in nodes.EnumerateArray())
+                reqs.Add(new NexusRequirement(
+                    Str(r, "modId") ?? "", Str(r, "modName") ?? "", Str(r, "url"),
+                    Str(r, "notes"), Bool(r, "externalRequirement")));
+        }
+
+        var files = new List<NexusFile>();
+        if (data.TryGetProperty("modFiles", out var mf) && mf.ValueKind == JsonValueKind.Array)
+            foreach (var f in mf.EnumerateArray())
+                files.Add(new NexusFile(
+                    Int(f, "fileId"), Str(f, "name") ?? "", Str(f, "version"),
+                    Str(f, "category") ?? "", Long(f, "date"), Str(f, "description")));
+
+        return (true, null, new NexusModDetail(
+            Int(m, "modId"), Str(m, "name") ?? "", Str(m, "version"), Str(m, "summary"), Str(m, "description"),
+            Str(m, "author"), Str(m, "category") ?? "", Int(m, "endorsements"), Int(m, "downloads"),
+            Str(m, "updatedAt"), Str(m, "createdAt"), Bool(m, "adultContent"), Str(m, "status") ?? "",
+            Bool(m, "directDownloadEnabled"), reqs, files));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────────────────────────────────
+    //  Core POST — the ONE place an exception can come from a Nexus call, so the ONE place Q3 turns every failure into
+    //  a returned message. Returns the GraphQL `data` element (cloned to outlive the JsonDocument) on success.
+    // ──────────────────────────────────────────────────────────────────────────────────────────────────────────
+    async Task<(bool ok, string? error, JsonElement data)> PostAsync(string query, object variables, CancellationToken ct)
+    {
+        HttpResponseMessage resp;
+        string body;
+        try
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Post, Endpoint)
+            {
+                Content = JsonContent.Create(new { query, variables }, options: Json),
+            };
+            resp = await _http.SendAsync(req, ct);
+            body = await resp.Content.ReadAsStringAsync(ct);
+        }
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+        {
+            return (false, "the Nexus Mods request timed out. Check your connection and try again — houseCARL's local "
+                + "(load-order) tools are unaffected.", default);
+        }
+        catch (OperationCanceledException) { return (false, "the Nexus Mods request was cancelled.", default); }
+        catch (HttpRequestException ex)
+        {
+            return (false, $"couldn't reach Nexus Mods ({ex.Message}). The Nexus tools need an internet connection; "
+                + "houseCARL's local tools work offline.", default);
+        }
+
+        if ((int)resp.StatusCode == 429)
+            return (false, "Nexus Mods is rate-limiting the connection (HTTP 429). Wait a moment and try again.", default);
+        if (!resp.IsSuccessStatusCode)
+            return (false, $"Nexus Mods returned HTTP {(int)resp.StatusCode} ({resp.ReasonPhrase}).", default);
+
+        JsonDocument doc;
+        try { doc = JsonDocument.Parse(body); }
+        catch (Exception ex) { return (false, $"Nexus Mods returned an unreadable response ({ex.Message}).", default); }
+
+        using (doc)
+        {
+            var root = doc.RootElement;
+            if (root.TryGetProperty("errors", out var errs) && errs.ValueKind == JsonValueKind.Array && errs.GetArrayLength() > 0)
+            {
+                var msgs = errs.EnumerateArray()
+                    .Select(e => e.TryGetProperty("message", out var mm) ? mm.GetString() : null)
+                    .Where(s => !string.IsNullOrWhiteSpace(s));
+                return (false, "Nexus Mods query error: " + string.Join("; ", msgs), default);
+            }
+            if (!root.TryGetProperty("data", out var dataEl) || dataEl.ValueKind != JsonValueKind.Object)
+                return (false, "Nexus Mods returned no data.", default);
+            return (true, null, dataEl.Clone());   // Clone: survive the using-dispose of doc.
+        }
+    }
+
+    // ── tolerant JsonElement readers (a missing/typed-wrong field reads as null/0/false, never throws — Q3) ──
+    static string? Str(JsonElement e, string p) => e.TryGetProperty(p, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
+    static int Int(JsonElement e, string p) => e.TryGetProperty(p, out var v) && v.ValueKind == JsonValueKind.Number && v.TryGetInt32(out var i) ? i : 0;
+    static long Long(JsonElement e, string p) => e.TryGetProperty(p, out var v) && v.ValueKind == JsonValueKind.Number && v.TryGetInt64(out var l) ? l : 0;
+    static bool Bool(JsonElement e, string p) => e.TryGetProperty(p, out var v) && v.ValueKind == JsonValueKind.True;
+
+    // ── GraphQL documents (variable-based ⇒ user input is never string-concatenated into the query) ──
+    const string SearchQuery =
+        @"query Search($filter: ModsFilter!, $sort: [ModsSort!], $count: Int!) {
+            mods(filter: $filter, sort: $sort, count: $count) {
+              totalCount
+              nodes { modId name version author endorsements downloads updatedAt adultContent summary category }
+            }
+          }";
+
+    const string ModQuery =
+        @"query ModDetail($modId: ID!, $gameId: ID!) {
+            mod(modId: $modId, gameId: $gameId) {
+              modId name version summary description author category endorsements downloads
+              updatedAt createdAt adultContent status directDownloadEnabled
+              modRequirements { nexusRequirements { nodes { modId modName url notes externalRequirement } } }
+            }
+            modFiles(modId: $modId, gameId: $gameId) {
+              fileId name version category date description
+            }
+          }";
+}
+
+// ── result shapes (records ⇒ immutable, value-equal; the tools render these to text) ──
+
+/// <summary>One row of a search result.</summary>
+public sealed record NexusSearchHit(
+    int ModId, string Name, string? Version, string? Author, int Endorsements, int Downloads,
+    string? UpdatedAt, bool AdultContent, string? Summary, string? Category);
+
+/// <summary>A search response: the true total match count plus the (capped) page of hits.</summary>
+public sealed record NexusSearchResult(int TotalCount, IReadOnlyList<NexusSearchHit> Hits);
+
+/// <summary>One Nexus requirement of a mod. <paramref name="ExternalRequirement"/> ⇒ an off-Nexus dependency (ModId/Url
+/// point off-site); otherwise ModId is the required mod's numeric id on Nexus.</summary>
+public sealed record NexusRequirement(string ModId, string ModName, string? Url, string? Notes, bool ExternalRequirement);
+
+/// <summary>One uploaded file of a mod. <paramref name="Category"/> is MAIN / OPTIONAL / OLD_VERSION / ARCHIVED / …;
+/// <paramref name="Date"/> is a unix-seconds timestamp.</summary>
+public sealed record NexusFile(int FileId, string Name, string? Version, string Category, long Date, string? Description);
+
+/// <summary>Full detail for one mod plus its files. Note: <paramref name="Version"/> is the mod's version HEADER, which
+/// can lag the newest MAIN file — the accurate "latest version" is the most recent MAIN entry in <paramref name="Files"/>.</summary>
+public sealed record NexusModDetail(
+    int ModId, string Name, string? Version, string? Summary, string? Description, string? Author, string Category,
+    int Endorsements, int Downloads, string? UpdatedAt, string? CreatedAt, bool AdultContent, string Status,
+    bool DirectDownloadEnabled, IReadOnlyList<NexusRequirement> NexusRequirements, IReadOnlyList<NexusFile> Files);

--- a/src/housecarl-mcp/NexusClient.cs
+++ b/src/housecarl-mcp/NexusClient.cs
@@ -52,15 +52,22 @@ public sealed class NexusClient
         if (!string.IsNullOrWhiteSpace(category))
             filter["categoryName"] = new[] { new { value = category!, op = "EQUALS" } };
 
-        // sort is [{ <field>: { direction: DESC } }] — a single-key object, so build it from a dictionary.
-        var sort = new[] { new Dictionary<string, object> { [sortField] = new { direction = "DESC" } } };
+        // sort is [{ <field>: { direction } }] — a single-key object, so build it from a dictionary. Name sorts
+        // ASCending (A-Z, what "by name" means); every other field DESCending (most endorsements/downloads/recent first).
+        var direction = sortField == "name" ? "ASC" : "DESC";
+        var sort = new[] { new Dictionary<string, object> { [sortField] = new { direction } } };
 
         var (ok, error, data) = await PostAsync(SearchQuery, new { filter, sort, count }, ct);
         if (!ok) return (false, error, null);
 
-        var mods = data.GetProperty("mods");
+        // Guard the root navigation: a 200 with an unexpected shape must STILL return cleanly, not throw (the class
+        // contract is "every failure mode is returned, never thrown"). GetProperty would throw on a missing field.
+        if (!data.TryGetProperty("mods", out var mods) || mods.ValueKind != JsonValueKind.Object
+            || !mods.TryGetProperty("nodes", out var nodeList) || nodeList.ValueKind != JsonValueKind.Array)
+            return (false, "Nexus Mods returned an unexpected response shape (no 'mods' results).", null);
+
         var hits = new List<NexusSearchHit>();
-        foreach (var n in mods.GetProperty("nodes").EnumerateArray())
+        foreach (var n in nodeList.EnumerateArray())
             hits.Add(new NexusSearchHit(
                 Int(n, "modId"), Str(n, "name") ?? "", Str(n, "version"), Str(n, "author"),
                 Int(n, "endorsements"), Int(n, "downloads"), Str(n, "updatedAt"),
@@ -77,7 +84,9 @@ public sealed class NexusClient
             ModQuery, new { modId = modId.ToString(), gameId = SkyrimSeGameId.ToString() }, ct);
         if (!ok) return (false, error, null);
 
-        var m = data.GetProperty("mod");
+        // Guard the root navigation (see SearchAsync) — a missing 'mod' on a 200 returns cleanly, never throws.
+        if (!data.TryGetProperty("mod", out var m) || m.ValueKind != JsonValueKind.Object)
+            return (false, "Nexus Mods returned an unexpected response shape (no 'mod').", null);
 
         var reqs = new List<NexusRequirement>();
         if (m.TryGetProperty("modRequirements", out var mr) && mr.ValueKind == JsonValueKind.Object
@@ -110,16 +119,21 @@ public sealed class NexusClient
     // ──────────────────────────────────────────────────────────────────────────────────────────────────────────
     async Task<(bool ok, string? error, JsonElement data)> PostAsync(string query, object variables, CancellationToken ct)
     {
-        HttpResponseMessage resp;
         string body;
+        int status;
+        string? reason;
+        bool success;
         try
         {
             using var req = new HttpRequestMessage(HttpMethod.Post, Endpoint)
             {
                 Content = JsonContent.Create(new { query, variables }, options: Json),
             };
-            resp = await _http.SendAsync(req, ct);
+            using var resp = await _http.SendAsync(req, ct);
             body = await resp.Content.ReadAsStringAsync(ct);
+            status = (int)resp.StatusCode;
+            reason = resp.ReasonPhrase;
+            success = resp.IsSuccessStatusCode;
         }
         catch (TaskCanceledException) when (!ct.IsCancellationRequested)
         {
@@ -133,10 +147,10 @@ public sealed class NexusClient
                 + "houseCARL's local tools work offline.", default);
         }
 
-        if ((int)resp.StatusCode == 429)
+        if (status == 429)
             return (false, "Nexus Mods is rate-limiting the connection (HTTP 429). Wait a moment and try again.", default);
-        if (!resp.IsSuccessStatusCode)
-            return (false, $"Nexus Mods returned HTTP {(int)resp.StatusCode} ({resp.ReasonPhrase}).", default);
+        if (!success)
+            return (false, $"Nexus Mods returned HTTP {status} ({reason}).", default);
 
         JsonDocument doc;
         try { doc = JsonDocument.Parse(body); }
@@ -161,7 +175,13 @@ public sealed class NexusClient
     // ── tolerant JsonElement readers (a missing/typed-wrong field reads as null/0/false, never throws — Q3) ──
     static string? Str(JsonElement e, string p) => e.TryGetProperty(p, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
     static int Int(JsonElement e, string p) => e.TryGetProperty(p, out var v) && v.ValueKind == JsonValueKind.Number && v.TryGetInt32(out var i) ? i : 0;
-    static long Long(JsonElement e, string p) => e.TryGetProperty(p, out var v) && v.ValueKind == JsonValueKind.Number && v.TryGetInt64(out var l) ? l : 0;
+    static long Long(JsonElement e, string p)
+    {
+        if (!e.TryGetProperty(p, out var v)) return 0;
+        if (v.ValueKind == JsonValueKind.Number && v.TryGetInt64(out var l)) return l;
+        if (v.ValueKind == JsonValueKind.String && long.TryParse(v.GetString(), out var s)) return s;   // tolerate date-as-string
+        return 0;
+    }
     static bool Bool(JsonElement e, string p) => e.TryGetProperty(p, out var v) && v.ValueKind == JsonValueKind.True;
 
     // ── GraphQL documents (variable-based ⇒ user input is never string-concatenated into the query) ──

--- a/src/housecarl-mcp/NexusTools.cs
+++ b/src/housecarl-mcp/NexusTools.cs
@@ -67,9 +67,8 @@ public static class NexusTools
             string mod,
         CancellationToken ct = default)
     {
-        if (!TryParseModId(mod, out int modId))
-            return $"error: couldn't read a mod id from '{mod}'. Pass a numeric Nexus mod id (e.g. 12604) or a Skyrim SE "
-                + "mod URL (e.g. https://www.nexusmods.com/skyrimspecialedition/mods/12604).";
+        var (modId, parseError) = ResolveModId(mod);
+        if (parseError is not null) return "error: " + parseError;
 
         var (ok, error, detail) = await nexus.GetModAsync(modId, ct);
         if (!ok) return "error: " + error;
@@ -87,15 +86,33 @@ public static class NexusTools
         _ => null,
     };
 
-    /// <summary>Accept a bare numeric id or any URL containing '/mods/&lt;n&gt;'.</summary>
-    static bool TryParseModId(string s, out int modId)
+    /// <summary>Resolve the user's input to an SSE mod id. Accepts a bare numeric id or a Nexus mod URL. A Nexus URL for a
+    /// DIFFERENT game (fallout4, skyrim, starfield, …) is REJECTED with a clear message rather than silently resolving to a
+    /// same-numbered Skyrim SE mod (Q3: never a confidently-wrong answer). Returns (modId, error) — exactly one is set.</summary>
+    static (int modId, string? error) ResolveModId(string s)
     {
         s = s.Trim();
-        if (int.TryParse(s, out modId) && modId > 0) return true;
-        var m = Regex.Match(s, @"/mods/(\d+)", RegexOptions.IgnoreCase);
-        if (m.Success && int.TryParse(m.Groups[1].Value, out modId) && modId > 0) return true;
-        modId = 0;
-        return false;
+        if (int.TryParse(s, out var id) && id > 0) return (id, null);
+
+        // A Nexus mod URL carries the game domain right before /mods/<n> (optionally behind a 'games/' segment).
+        var url = Regex.Match(s, @"nexusmods\.com/(?:games/)?([^/]+)/mods/(\d+)", RegexOptions.IgnoreCase);
+        if (url.Success)
+        {
+            var game = url.Groups[1].Value.ToLowerInvariant();
+            if (game != "skyrimspecialedition")
+                return (0, $"that's a '{game}' Nexus URL — houseCARL is Skyrim Special Edition only. (Id {url.Groups[2].Value} "
+                    + "on SSE would be a different mod, so I won't guess.) Pass an SSE mod id or a skyrimspecialedition URL.");
+            if (!int.TryParse(url.Groups[2].Value, out var mid) || mid <= 0)
+                return (0, $"'{url.Groups[2].Value}' isn't a valid mod id.");
+            return (mid, null);
+        }
+
+        // Fallback: a bare '/mods/<n>' with no identifiable game (a partial paste) — treat as an SSE id.
+        var loose = Regex.Match(s, @"/mods/(\d+)", RegexOptions.IgnoreCase);
+        if (loose.Success && int.TryParse(loose.Groups[1].Value, out id) && id > 0) return (id, null);
+
+        return (0, $"couldn't read a mod id from '{s}'. Pass a numeric Nexus mod id (e.g. 12604) or a Skyrim SE mod URL "
+            + "(e.g. https://www.nexusmods.com/skyrimspecialedition/mods/12604).");
     }
 }
 

--- a/src/housecarl-mcp/NexusTools.cs
+++ b/src/housecarl-mcp/NexusTools.cs
@@ -1,0 +1,191 @@
+using System.ComponentModel;
+using System.Text;
+using System.Text.RegularExpressions;
+using ModelContextProtocol.Server;
+
+namespace HousecarlMcp;
+
+/// <summary>
+/// houseCARL's Nexus Mods read tools — the QOL layer that lets houseCARL answer Nexus questions DIRECTLY instead of
+/// spinning up a browser to scrape a mod page. Two read-only tools over <see cref="NexusClient"/> (the public v2 GraphQL
+/// read API, keyless): search the catalog, and look up one mod's detail + requirements + files. Neither downloads or
+/// installs — that stays the mod manager's nxm handoff. Both need an internet connection and fail LOUD/clean when there
+/// isn't one (Q3); they do NOT touch the MO2 instance, so they work even when houseCARL has no load order configured.
+/// </summary>
+[McpServerToolType]
+public static class NexusTools
+{
+    [McpServerTool(Name = "housecarl_nexus_search", ReadOnly = true, Title = "Search Nexus Mods"),
+     Description(
+         "Search Nexus Mods for Skyrim Special Edition mods by name/keywords, WITHOUT opening a browser — houseCARL " +
+         "queries the Nexus catalog directly and returns a ranked list. Each hit gives the mod name, Nexus mod id, " +
+         "version, author, endorsement/download counts, category, last-updated date, a one-line summary, and the page " +
+         "URL. Sorted by endorsements by default (sort= downloads | recent | name | relevance), optionally narrowed to a " +
+         "category=, capped at limit= (default 10, max 50). READ-ONLY and needs an internet connection — houseCARL's " +
+         "local load-order tools are unaffected if offline. Does NOT download or install anything: to install a result, " +
+         "open its page and use Nexus's 'Mod Manager Download' button as usual — houseCARL reads Nexus, your mod manager " +
+         "does the download. For full details (requirements, files, accurate latest version) of one result, pass its id " +
+         "to housecarl_nexus_mod.")]
+    public static async Task<string> NexusSearch(
+        NexusClient nexus,
+        [Description("Words to search for in mod names, e.g. 'archery overhaul' or 'true storms'. Matched as a wildcard against Skyrim SE mod names.")]
+            string query,
+        [Description("Optional. Narrow to a Nexus category name, e.g. 'Audio', 'Armour', 'Gameplay', 'Patches'. Omit to search all categories.")]
+            string? category = null,
+        [Description("Optional. Result ordering: 'endorsements' (default, best-regarded first), 'downloads' (most popular), 'recent' (recently updated), 'name' (A-Z), or 'relevance'.")]
+            string sort = "endorsements",
+        [Description("Optional. Max results to return (default 10, max 50).")]
+            int limit = 10,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+            return "error: no search term. Pass query= some words to look for in mod names (e.g. 'archery overhaul').";
+        if (limit <= 0) limit = 10;
+        if (limit > 50) limit = 50;
+
+        var sortField = MapSort(sort);
+        if (sortField is null)
+            return $"error: unknown sort '{sort}'. Use one of: endorsements, downloads, recent, name, relevance.";
+
+        var (ok, error, result) = await nexus.SearchAsync(query.Trim(), category, sortField, limit, ct);
+        if (!ok) return "error: " + error;
+        return Render.Search(query.Trim(), category, sort, result!);
+    }
+
+    [McpServerTool(Name = "housecarl_nexus_mod", ReadOnly = true, Title = "Look up a Nexus mod"),
+     Description(
+         "Look up ONE Skyrim Special Edition mod on Nexus by its numeric mod id (e.g. 12604) OR a pasted mod URL — " +
+         "without opening a browser. Returns the mod's name, version, author, status, endorsement/download counts, " +
+         "category, last-updated date, summary, whether direct download is disabled (manager-only), its Nexus " +
+         "REQUIREMENTS (each required mod's name + id + notes, off-site deps flagged), and its newest MAIN file's " +
+         "version — the accurate 'latest version', because a mod's own version header can lag its newest file. " +
+         "READ-ONLY and needs an internet connection (local tools unaffected offline). Does NOT download or install — " +
+         "use your mod manager's 'Mod Manager Download' for that. To find a mod by name first, use housecarl_nexus_search.")]
+    public static async Task<string> NexusMod(
+        NexusClient nexus,
+        [Description("The mod to look up: a numeric Nexus mod id (e.g. 12604) or a full mod URL (e.g. https://www.nexusmods.com/skyrimspecialedition/mods/12604).")]
+            string mod,
+        CancellationToken ct = default)
+    {
+        if (!TryParseModId(mod, out int modId))
+            return $"error: couldn't read a mod id from '{mod}'. Pass a numeric Nexus mod id (e.g. 12604) or a Skyrim SE "
+                + "mod URL (e.g. https://www.nexusmods.com/skyrimspecialedition/mods/12604).";
+
+        var (ok, error, detail) = await nexus.GetModAsync(modId, ct);
+        if (!ok) return "error: " + error;
+        return Render.Mod(detail!);
+    }
+
+    /// <summary>Map a friendly sort word to a ModsSort field name; null if unrecognised (the tool reports it — Q3).</summary>
+    static string? MapSort(string s) => s.Trim().ToLowerInvariant() switch
+    {
+        "endorsements" or "endorsed" or "best" or "top" => "endorsements",
+        "downloads" or "popular" or "most_downloaded" => "downloads",
+        "recent" or "updated" or "latest" or "newest" => "updatedAt",
+        "name" or "alphabetical" or "az" => "name",
+        "relevance" or "relevant" => "relevance",
+        _ => null,
+    };
+
+    /// <summary>Accept a bare numeric id or any URL containing '/mods/&lt;n&gt;'.</summary>
+    static bool TryParseModId(string s, out int modId)
+    {
+        s = s.Trim();
+        if (int.TryParse(s, out modId) && modId > 0) return true;
+        var m = Regex.Match(s, @"/mods/(\d+)", RegexOptions.IgnoreCase);
+        if (m.Success && int.TryParse(m.Groups[1].Value, out modId) && modId > 0) return true;
+        modId = 0;
+        return false;
+    }
+}
+
+/// <summary>Render the Nexus result records to compact, readable text. Every mod ends with its page URL so the user can
+/// click through to the manager-download button (the install handoff houseCARL deliberately leaves to MO2).</summary>
+static class Render
+{
+    const string ModUrlBase = "https://www.nexusmods.com/skyrimspecialedition/mods/";
+
+    public static string Search(string term, string? category, string sort, NexusSearchResult r)
+    {
+        var sb = new StringBuilder();
+        sb.Append("Nexus search: \"").Append(term).Append('"');
+        if (!string.IsNullOrWhiteSpace(category)) sb.Append(" in '").Append(category).Append('\'');
+        sb.Append(" — ").Append(r.TotalCount.ToString("N0")).Append(" match(es), by ").Append(sort)
+          .Append(", showing ").Append(r.Hits.Count).Append(':');
+        if (r.Hits.Count == 0) return sb.Append("\n(none)").ToString();
+
+        foreach (var h in r.Hits)
+        {
+            sb.Append("\n\n• ").Append(h.Name).Append("  [id ").Append(h.ModId).Append(']');
+            if (h.AdultContent) sb.Append("  (ADULT)");
+            sb.Append("\n  v").Append(h.Version ?? "?").Append(" · by ").Append(h.Author ?? "?")
+              .Append(" · ").Append(h.Endorsements.ToString("N0")).Append(" endorsements · ")
+              .Append(h.Downloads.ToString("N0")).Append(" downloads");
+            if (!string.IsNullOrWhiteSpace(h.Category)) sb.Append(" · ").Append(h.Category);
+            if (!string.IsNullOrWhiteSpace(h.UpdatedAt)) sb.Append(" · upd ").Append(Day(h.UpdatedAt!));
+            if (!string.IsNullOrWhiteSpace(h.Summary)) sb.Append("\n  ").Append(OneLine(h.Summary!, 160));
+            sb.Append("\n  ").Append(ModUrlBase).Append(h.ModId);
+        }
+        sb.Append("\n\n(To install one: open its page and use Nexus's \"Mod Manager Download\" — houseCARL reads Nexus, ")
+          .Append("your mod manager does the download. Pass an id to housecarl_nexus_mod for requirements + files.)");
+        return sb.ToString();
+    }
+
+    public static string Mod(NexusModDetail m)
+    {
+        var sb = new StringBuilder();
+        sb.Append(m.Name).Append("  [id ").Append(m.ModId).Append(']');
+        sb.Append("\nversion ").Append(m.Version ?? "?").Append(" · by ").Append(m.Author ?? "?")
+          .Append(" · ").Append(m.Status);
+        if (m.AdultContent) sb.Append(" · ADULT");
+        sb.Append("\n").Append(m.Endorsements.ToString("N0")).Append(" endorsements · ")
+          .Append(m.Downloads.ToString("N0")).Append(" downloads");
+        if (!string.IsNullOrWhiteSpace(m.Category)) sb.Append(" · ").Append(m.Category);
+        if (!string.IsNullOrWhiteSpace(m.UpdatedAt)) sb.Append(" · updated ").Append(Day(m.UpdatedAt!));
+        if (!m.DirectDownloadEnabled)
+            sb.Append("\nnote: the author disabled direct download — manager (nxm) download only.");
+        if (!string.IsNullOrWhiteSpace(m.Summary)) sb.Append("\n\n").Append(m.Summary);
+
+        // The accurate "latest version" is the newest MAIN file, not the mod's version header (which can lag).
+        NexusFile? main = null;
+        foreach (var f in m.Files)
+            if (f.Category == "MAIN" && (main is null || f.Date > main.Date)) main = f;
+        if (main is not null)
+            sb.Append("\n\nlatest MAIN file: ").Append(main.Name).Append(" v").Append(main.Version ?? "?")
+              .Append(" (").Append(Day(main.Date)).Append(')');
+
+        if (m.NexusRequirements.Count > 0)
+        {
+            sb.Append("\n\nrequires (").Append(m.NexusRequirements.Count).Append("):");
+            foreach (var req in m.NexusRequirements)
+            {
+                sb.Append("\n  - ").Append(req.ModName);
+                if (req.ExternalRequirement) sb.Append("  (off-site)");
+                else if (!string.IsNullOrWhiteSpace(req.ModId)) sb.Append("  [id ").Append(req.ModId).Append(']');
+                if (!string.IsNullOrWhiteSpace(req.Notes)) sb.Append(" — ").Append(OneLine(req.Notes!, 120));
+            }
+        }
+        else sb.Append("\n\nno Nexus requirements listed.");
+
+        sb.Append("\n\n").Append(ModUrlBase).Append(m.ModId);
+        return sb.ToString();
+    }
+
+    /// <summary>Collapse whitespace and cap a blurb to n chars with an ellipsis (Q3: explicit cut, never silent garble).</summary>
+    static string OneLine(string s, int n)
+    {
+        s = s.Replace('\r', ' ').Replace('\n', ' ').Trim();
+        while (s.Contains("  ")) s = s.Replace("  ", " ");
+        return s.Length <= n ? s : s[..n].TrimEnd() + "…";
+    }
+
+    /// <summary>ISO-8601 datetime → just the date (yyyy-MM-dd).</summary>
+    static string Day(string iso) => iso.Length >= 10 ? iso[..10] : iso;
+
+    /// <summary>Unix-seconds → yyyy-MM-dd.</summary>
+    static string Day(long unixSeconds)
+    {
+        try { return DateTimeOffset.FromUnixTimeSeconds(unixSeconds).ToString("yyyy-MM-dd"); }
+        catch { return unixSeconds.ToString(); }
+    }
+}

--- a/src/housecarl-mcp/Program.cs
+++ b/src/housecarl-mcp/Program.cs
@@ -101,10 +101,20 @@ static (LoadOrderService svc, bool explicitMode, string? instanceDir, string ins
     // The external-tool bridge (compile / BSA / log access): one resolver over the shared user config. Riders inject it.
     services.AddSingleton(new ToolPathResolver(store));
 
+    // The Nexus Mods read bridge (QOL: answer Nexus questions directly instead of driving a browser). A typed HttpClient
+    // so its timeout/lifetime are managed; KEYLESS (the public v2 GraphQL read surface needs no API key). This is
+    // houseCARL's ONLY outbound network dependency — every failure is handled inside NexusClient (Q3), and the local
+    // load-order tools never touch it, so they keep working with no internet.
+    services.AddHttpClient<NexusClient>(c =>
+    {
+        c.Timeout = TimeSpan.FromSeconds(20);
+        c.DefaultRequestHeaders.UserAgent.ParseAdd("houseCARL (+https://github.com/Avick3110/houseCARL)");
+    });
+
     return (svc, explicitMode, instanceDir, instanceSource);
 }
 
-// The MCP server registration — server identity + instructions + the 14 attribute-registered tools. ONLY the
+// The MCP server registration — server identity + instructions + the 16 attribute-registered tools. ONLY the
 // transport line differs between modes (the whole point of the stdio/http split); everything else is shared.
 static void AddMcp(IServiceCollection services, bool stdio)
 {


### PR DESCRIPTION
## What

Two read-only MCP tools so houseCARL answers Nexus questions directly instead of driving the Chrome connector:

- **`housecarl_nexus_search`** — search Skyrim SE mods by name, ranked (default endorsements; also downloads / recent / name / relevance), optional category filter. Returns id, version, author, endorsement/download counts, category, summary, and page link.
- **`housecarl_nexus_mod`** — look up one mod by id *or* pasted URL → info, Nexus requirements (each with id + notes, off-site flagged), files, and the accurate latest **MAIN-file** version (a mod's version header can lag its newest file).

## Why

Every Nexus lookup currently forces a browser spin-up to scrape a rendered page — slow, fragile, dependent on the Chrome connector. These hit the public Nexus v2 GraphQL read API directly.

## Design / guardrails

- **Keyless** — the v2 read surface (search / mod / files / requirements) is public and anonymous; no API key to configure (and a personal key in a public app is AUP-"unacceptable" anyway).
- **Isolated** — `NexusClient` lives in `housecarl-mcp`; the proven `housecarl-core` engine stays network-free. This is houseCARL's only outbound network dependency.
- **Q3 fail-loud** — offline / timeout / 429 / HTTP / GraphQL errors are returned as plain messages, never thrown; the local load-order tools never depend on this and keep working offline.
- **Read-only** — neither tool downloads or installs; that stays the mod manager's `nxm` "Mod Manager Download" handoff.

## Proof

- Clean build (0 warnings / 0 errors).
- Live end-to-end run of `NexusClient` against Nexus: sorted search (Archery Gameplay Overhaul SE, 31k endorsements), SkyUI mod+files with the header-6.9-vs-MAIN-6.11 accuracy catch working, requirements parsing (SKSE [30379]), and the not-found error path surfacing cleanly.

## Not yet exercised

The full MCP round-trip (DI + render wrapper) — compile-clean and mirrors the existing proven tool pattern, but not yet called through a live MCP session (validates on rebuilt-server reconnect).

## Out of scope (phase 2, parked)

Install-aware update-check (cross-reference installed `meta.ini` modids against live Nexus versions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
