### PR TITLE
Parameterize BsaProbe dev paths via env vars (drop private path from source)

### DIFF
--- a/src/housecarl-generator/BsaProbe.cs
+++ b/src/housecarl-generator/BsaProbe.cs
@@ -6,14 +6,16 @@ namespace HousecarlGenerator;
 /// BSA-rider proof (EXTERNAL_TOOL_BRIDGE_PLAN step 3). Drives the shipped <see cref="BsaArchive"/> against the REAL BSArch
 /// on a REAL archive: list → unpack → pack → re-list, asserting the round-trip preserves the file count (the plan's proof
 /// gate). The list step also exercises the "Files: N + last-N-lines" parser against real output. Skipped (not failed) if
-/// BSArch or the test archive isn't present; override both via args.
+/// BSArch or the test archive isn't present; provide both via args or the HOUSECARL_BSARCH / HOUSECARL_TEST_BSA env vars.
 ///
 /// Run: dotnet run --project src/housecarl-generator bsa-probe ["&lt;BSArch.exe&gt;"] ["&lt;test.bsa&gt;"]
 /// </summary>
 internal static class BsaProbe
 {
-    const string DefaultBsarch = @"E:\Skyrim Modding\Tools\xEdit.4.1.5f\BSArch.exe";
-    const string DefaultBsa = @"E:\Skyrim Modding\ARR 2.0\Stock Game\Data\MarketplaceTextures.bsa";
+    // No personal paths baked into source: the no-arg defaults come from env vars, so the probe SKIPs
+    // cleanly when neither is set. Pass a BSArch.exe + test .bsa as args, or set the env vars below.
+    static readonly string DefaultBsarch = Environment.GetEnvironmentVariable("HOUSECARL_BSARCH") ?? "";
+    static readonly string DefaultBsa = Environment.GetEnvironmentVariable("HOUSECARL_TEST_BSA") ?? "";
 
     public static int Run(string[] args)
     {
@@ -26,8 +28,8 @@ internal static class BsaProbe
 
         var bsarch = args.Length > 0 ? args[0] : DefaultBsarch;
         var bsa = args.Length > 1 ? args[1] : DefaultBsa;
-        if (!File.Exists(bsarch)) { Console.WriteLine($"  SKIP  no BSArch at '{bsarch}' (pass its path as arg 1)"); return 0; }
-        if (!File.Exists(bsa)) { Console.WriteLine($"  SKIP  no test archive at '{bsa}' (pass one as arg 2)"); return 0; }
+        if (!File.Exists(bsarch)) { Console.WriteLine($"  SKIP  no BSArch at '{bsarch}' (pass its path as arg 1, or set HOUSECARL_BSARCH)"); return 0; }
+        if (!File.Exists(bsa)) { Console.WriteLine($"  SKIP  no test archive at '{bsa}' (pass one as arg 2, or set HOUSECARL_TEST_BSA)"); return 0; }
 
         var work = Path.Combine(Environment.CurrentDirectory, ".bsa-probe");
         var unpacked = Path.Combine(work, "unpacked");


### PR DESCRIPTION
Drops a real personal path from public source. `BsaProbe.cs` — a dev-only proof harness in `src/housecarl-generator` (not shipped) — hardcoded the author's real load-order path (an absolute path on a personal data drive) as the no-arg default for BSArch + the test archive.

## Change
- `DefaultBsarch` / `DefaultBsa` now read from the `HOUSECARL_BSARCH` / `HOUSECARL_TEST_BSA` env vars (empty fallback).
- The existing `File.Exists` -> `SKIP` path already handles "unset", so behavior is unchanged: the probe SKIPs cleanly when neither args nor env vars are set. Set the env vars (or pass args) to run it.

## Scope / verification
- This was the **only** file leaking a real path. The sibling probes (`Mo2InstanceProbe`, `ResolveProbe`, `Wave5Probe`, `WriteProof`, ...) use a generic `C:\MO2\Instance\Stock Game` placeholder, not a real path -- left as-is.
- Build-verified (generator project: 0 warnings / 0 errors).
- Note: removes the path from the **live source** going forward. It remains in older history (where it has long sat); fully purging it would need a destructive rewrite of public `main`, which this PR deliberately does NOT do. The build's dev-path leak-check is orthogonal (it scans shipped `dist/`; the generator isn't shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
