### PR TITLE
Align Nexus tool descriptions with rendered output (newest MAIN file, not files)

### DIFF
--- a/src/housecarl-mcp/NexusClient.cs
+++ b/src/housecarl-mcp/NexusClient.cs
@@ -6,8 +6,8 @@ namespace HousecarlMcp;
 
 /// <summary>
 /// houseCARL's read-only bridge to the Nexus Mods public v2 GraphQL API (the QOL "smooth out Nexus" layer). It exists
-/// so houseCARL can answer Nexus questions — search the catalog, look up a mod's version/requirements/files — DIRECTLY
-/// instead of driving a browser to scrape a rendered page. It is deliberately:
+/// so houseCARL can answer Nexus questions — search the catalog, look up a mod's version/requirements/newest MAIN file
+/// — DIRECTLY instead of driving a browser to scrape a rendered page. It is deliberately:
 ///   • READ-ONLY — search + mod lookup; it never downloads, installs, endorses, or mutates anything. A download stays
 ///     the user's mod manager's job (the nxm "Mod Manager Download" handoff), exactly as before.
 ///   • KEYLESS — the v2 GraphQL read surface (search/mod/modFiles/requirements) is public and anonymous, so there is no

--- a/src/housecarl-mcp/NexusTools.cs
+++ b/src/housecarl-mcp/NexusTools.cs
@@ -8,9 +8,10 @@ namespace HousecarlMcp;
 /// <summary>
 /// houseCARL's Nexus Mods read tools — the QOL layer that lets houseCARL answer Nexus questions DIRECTLY instead of
 /// spinning up a browser to scrape a mod page. Two read-only tools over <see cref="NexusClient"/> (the public v2 GraphQL
-/// read API, keyless): search the catalog, and look up one mod's detail + requirements + files. Neither downloads or
-/// installs — that stays the mod manager's nxm handoff. Both need an internet connection and fail LOUD/clean when there
-/// isn't one (Q3); they do NOT touch the MO2 instance, so they work even when houseCARL has no load order configured.
+/// read API, keyless): search the catalog, and look up one mod's detail + requirements + newest MAIN file (the accurate
+/// latest version). Neither downloads or installs — that stays the mod manager's nxm handoff. Both need an internet
+/// connection and fail LOUD/clean when there isn't one (Q3); they do NOT touch the MO2 instance, so they work even when
+/// houseCARL has no load order configured.
 /// </summary>
 [McpServerToolType]
 public static class NexusTools
@@ -24,8 +25,8 @@ public static class NexusTools
          "category=, capped at limit= (default 10, max 50). READ-ONLY and needs an internet connection — houseCARL's " +
          "local load-order tools are unaffected if offline. Does NOT download or install anything: to install a result, " +
          "open its page and use Nexus's 'Mod Manager Download' button as usual — houseCARL reads Nexus, your mod manager " +
-         "does the download. For full details (requirements, files, accurate latest version) of one result, pass its id " +
-         "to housecarl_nexus_mod.")]
+         "does the download. For full details (requirements and the newest MAIN file — the accurate latest version) of " +
+         "one result, pass its id to housecarl_nexus_mod.")]
     public static async Task<string> NexusSearch(
         NexusClient nexus,
         [Description("Words to search for in mod names, e.g. 'archery overhaul' or 'true storms'. Matched as a wildcard against Skyrim SE mod names.")]
@@ -144,7 +145,7 @@ static class Render
             sb.Append("\n  ").Append(ModUrlBase).Append(h.ModId);
         }
         sb.Append("\n\n(To install one: open its page and use Nexus's \"Mod Manager Download\" — houseCARL reads Nexus, ")
-          .Append("your mod manager does the download. Pass an id to housecarl_nexus_mod for requirements + files.)");
+          .Append("your mod manager does the download. Pass an id to housecarl_nexus_mod for requirements + latest version.)");
         return sb.ToString();
     }
 


### PR DESCRIPTION
**The PR #18 loose end.** v1.2.0 dropped the word "files" from the *user-facing* description of `housecarl_nexus_mod` (README.md, plugin/README.md, plugin/CHANGELOG.md) because the rendered output shows only the **newest MAIN file** — the accurate latest version — not a file listing. That docs-only PR intentionally left the matching wording in the tool's **runtime descriptions** (the text Claude reads to decide when/how to call the tool). PR #18's code review flagged this as the one remaining loose end, correctly out of scope there. This PR closes it.

**What changed** (4 spots, wording only):
- `NexusTools.cs` — class XML summary: `+ files` → `+ newest MAIN file (the accurate latest version)`
- `NexusTools.cs` — `housecarl_nexus_search` `[Description]` pointer to `nexus_mod`: `(requirements, files, accurate latest version)` → `(requirements and the newest MAIN file — the accurate latest version)`
- `NexusTools.cs` — `Render.Search` footer (user-facing): `requirements + files` → `requirements + latest version`
- `NexusClient.cs` — class XML summary: `version/requirements/files` → `version/requirements/newest MAIN file`

**Deliberately NOT touched** — these legitimately reference the file fetch (not a bug):
- The GraphQL surface comment `search/mod/modFiles/requirements` and the `modFiles` query
- `GetModAsync` summary / `NexusFile` / `NexusModDetail.Files` data-model docs — the query genuinely fetches the full file list into the data model; it is simply never rendered
- The `housecarl_nexus_mod` `[Description]`, already accurate ("its newest MAIN file's version — the accurate 'latest version'")

**Not a behavior change** — consistency polish only. No GraphQL/query/render logic changed.

**Gates:** `scripts/build-plugin.ps1` passed (server compiles, leak-check clean, zip packs 305 entries) · `claude plugin validate ./dist/housecarl --strict` passed.

Ships in a patch (1.2.1) or folds into the next code change — no version bump in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)