### PR TITLE
Fix depth-walker reflection leak on ConditionData reads (HCBR-2026-06-08-01)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,8 @@ jobs:
       # pkcu-* proofs it runs fully here: a regression guard locking in the "Taste of Death" index-build fix.
       - name: Probe — PKCU index-build resilience (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- pkcu-regression
+
+      # Self-contained (synthesizes a CTDA condition whose arm carries a System.Type Parameter1Type — no external
+      # files), runs fully here: a regression guard locking in the depth-walker reflection-leak fix (HCBR-2026-06-08-01).
+      - name: Probe — depth-walker reflection leak (self-contained regression guard)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- depth-leak-guard

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -275,6 +275,16 @@ public static class ReadEngine
         {
             // substruct — open its modeled (Loqui-filtered) fields. Reflection, not the corpus: display-only,
             // and substructs aren't corpus-keyed by a name we hold here.
+            //
+            // GATE — the expansion boundary is the modeled corpus (cornerstone). Only DESCEND into Mutagen/
+            // Noggog record content; a value that reaches here but is NOT modeled is .NET plumbing — in
+            // practice a System.Type (RuntimeType): a ConditionData arm's Parameter1Type/Parameter2Type are
+            // typed System.Type, and a naive recurse walks .Assembly.DefinedTypes (the whole ~17,900-type
+            // Mutagen assembly), the BaseType→Enum→ValueType chain, StructLayoutAttribute, Module, the cyclic
+            // UnderlyingSystemType — ~50 KB of reflection internals that is never record data (HCBR-2026-06-08-01).
+            // The summary token was already emitted above (e.g. `Parameter1Type = [RuntimeType] Name=ActorValue`,
+            // exactly the clean depth<=4 rendering); we keep it and STOP, regardless of remaining depth budget.
+            if (!IsModeledContent(val.GetType())) return;
             foreach (var fname in ReflectedFieldNames(val.GetType()))
             {
                 if (budget < 0) return;
@@ -381,6 +391,27 @@ public static class ReadEngine
         var tn = p.PropertyType.Name;
         return tn.Contains("BinaryWriteTranslat", StringComparison.Ordinal)
             || tn.EndsWith("BinaryTranslation", StringComparison.Ordinal);
+    }
+
+    /// <summary>True if <paramref name="t"/> is MODELED record content the depth walker may descend into — a
+    /// Mutagen or Noggog type. Everything else that reaches the substruct branch is .NET plumbing: in practice a
+    /// <see cref="System.Type"/>/RuntimeType (a ConditionData arm's <c>Parameter1Type</c>/<c>Parameter2Type</c>),
+    /// or an <see cref="Assembly"/>/<see cref="System.Reflection.Module"/>/<see cref="MemberInfo"/>/<see
+    /// cref="Attribute"/> reached through one. Those carry no record data — descending them leaks the assembly's
+    /// whole type metadata — so the expander renders only their one-line summary token and stops. The modeled
+    /// corpus IS the boundary (cornerstone): a type outside Mutagen's own universe is not ours to expand.
+    /// Reflection objects are also blocked explicitly so the intent reads clearly and stays robust if a non-
+    /// modeled support namespace ever appears.</summary>
+    static bool IsModeledContent(Type t)
+    {
+        if (typeof(MemberInfo).IsAssignableFrom(t)            // Type : MemberInfo — covers Type/RuntimeType, MethodInfo, …
+            || typeof(Assembly).IsAssignableFrom(t)
+            || typeof(System.Reflection.Module).IsAssignableFrom(t)
+            || typeof(Attribute).IsAssignableFrom(t)) return false;
+        var ns = t.Namespace;
+        return ns is not null
+            && (ns.StartsWith("Mutagen.Bethesda", StringComparison.Ordinal)
+                || ns.StartsWith("Noggog", StringComparison.Ordinal));
     }
 
     // ======================================================================

--- a/src/housecarl-generator/DepthLeakProbe.cs
+++ b/src/housecarl-generator/DepthLeakProbe.cs
@@ -1,0 +1,88 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// REGRESSION GUARD (standing CI instrument) for HCBR-2026-06-08-01 — the depth-walker reflection leak.
+///
+/// Self-contained, in the pattern of <c>pkcu-regression</c>: synthesizes IN MEMORY a record carrying a CTDA
+/// condition whose ConditionData arm (<c>GetActorValueConditionData</c>) exposes a <c>Parameter1Type</c>
+/// typed <see cref="System.Type"/>, then drives the PRODUCT read path (<see cref="ReadEngine.ReadFields"/>)
+/// at high depth and asserts the walker renders that type as a single opaque summary token and NEVER recurses
+/// into its .NET reflection surface (Assembly.DefinedTypes — the whole ~17,900-type Mutagen assembly — the
+/// BaseType→Enum→ValueType chain, StructLayoutAttribute, Module, the cyclic UnderlyingSystemType, …).
+///
+/// RED before the fix (the leak reproduces deterministically — every reflection sub-member is a `Parameter1Type.*`
+/// field line), GREEN after. It ALSO asserts the useful condition content survives (ActorValue=Conjuration) and
+/// the one-line type summary is still shown — so the fix can't "pass" by truncating real record data.
+///
+/// Run: <c>dotnet run --project src/housecarl-generator depth-leak-guard</c>
+/// </summary>
+public static class DepthLeakProbe
+{
+    // Field-path fragments that only appear when the walker descended INTO a .NET reflection object — i.e.
+    // the leak signature. A clean read shows `…Data.Parameter1Type = [RuntimeType] Name=ActorValue` and stops;
+    // any of these means it walked past that token into Type/Assembly/Module/attribute internals.
+    static readonly string[] LeakMarkers =
+    {
+        "Parameter1Type.", "Parameter2Type.",      // descended PAST the opaque type token (the core bug)
+        ".Assembly", "DefinedTypes", "StructLayoutAttribute", "MetadataToken",
+        "TypeHandle", "UnderlyingSystemType", ".BaseType", ".Module",
+    };
+
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  REGRESSION GUARD — depth-walker reflection leak (HCBR-2026-06-08-01)  ################");
+        Console.WriteLine();
+
+        // Synthesize a MagicEffect with one CTDA condition; its Data arm carries a System.Type Parameter1Type
+        // (typeof(ActorValue)) — the exact shape that exploded on the real Apostasy perk read at depth 8.
+        var mod = new SkyrimMod(new ModKey("hc_depthguard", ModType.Plugin), SkyrimRelease.SkyrimSE);
+        var mgef = mod.MagicEffects.AddNew();
+        mgef.Conditions.Add(new ConditionFloat
+        {
+            CompareOperator = CompareOperator.EqualTo,
+            ComparisonValue = 1f,
+            Data = new GetActorValueConditionData { ActorValue = ActorValue.Conjuration },
+        });
+
+        const int depth = 8;
+        var rf = ReadEngine.ReadFields(mgef, new[] { "Conditions" }, depth);
+
+        var leak = rf.Fields.Where(fld => LeakMarkers.Any(m => fld.Path.Contains(m, StringComparison.Ordinal))).ToList();
+        var summary = rf.Fields.FirstOrDefault(fld => fld.Path.EndsWith(".Parameter1Type", StringComparison.Ordinal));
+        var useful = rf.Fields.FirstOrDefault(fld => fld.Path.EndsWith(".Data.ActorValue", StringComparison.Ordinal));
+
+        Console.WriteLine($"-- synthesized MagicEffect; read Conditions at depth={depth} --");
+        Console.WriteLine($"   field lines emitted           : {rf.Fields.Count}");
+        Console.WriteLine($"   leak lines (reflection paths) : {leak.Count}");
+        Console.WriteLine($"   Parameter1Type summary        : {Show(summary)}");
+        Console.WriteLine($"   useful value (Data.ActorValue): {Show(useful)}");
+        Console.WriteLine();
+
+        if (leak.Count > 0)
+        {
+            Console.WriteLine($"   first {Math.Min(8, leak.Count)} of {leak.Count} leak line(s):");
+            foreach (var fld in leak.Take(8)) Console.WriteLine($"      {fld.Path} = {(fld.HasValue ? fld.Token : fld.Note)}");
+            Console.WriteLine();
+        }
+
+        bool noLeak = leak.Count == 0;
+        bool summaryOk = summary is not null && (summary.Token ?? summary.Note ?? "").Contains("RuntimeType", StringComparison.Ordinal);
+        bool usefulOk = useful is { HasValue: true, Token: "Conjuration" };
+        bool pass = noLeak && summaryOk && usefulOk;
+
+        Console.WriteLine($"   no reflection leak             : {(noLeak ? "PASS" : "FAIL")}");
+        Console.WriteLine($"   type kept as one summary token : {(summaryOk ? "PASS" : "FAIL")}");
+        Console.WriteLine($"   useful condition value kept    : {(usefulOk ? "PASS" : "FAIL")}");
+        Console.WriteLine();
+        Console.WriteLine($"=== depth-leak-guard: {(pass ? "PASS" : "FAIL")} ===");
+        return pass ? 0 : 1;
+    }
+
+    static string Show(FieldValue? f) =>
+        f is null ? "(missing)" : $"{f.Path} = {(f.HasValue ? f.Token : f.Note)}";
+}

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -23,6 +23,10 @@ if (args.Length > 0 && args[0] == "pkcu-scale-proof") return PkcuProbe.RunScaleP
 // Index-build resilience (Nexus bug): SELF-CONTAINED CI regression guard — synthesizes the malformed PKCU, asserts isolation.
 if (args.Length > 0 && args[0] == "pkcu-regression") return PkcuProbe.RunRegression(args[1..]);
 
+// Depth-walker reflection leak (HCBR-2026-06-08-01): SELF-CONTAINED CI regression guard — synthesizes a CTDA
+// condition whose arm carries a System.Type Parameter1Type, asserts a deep read renders it as one opaque token.
+if (args.Length > 0 && args[0] == "depth-leak-guard") return DepthLeakProbe.RunGuard(args[1..]);
+
 // One-shot verify (decision #1): confirm the xEdit 4-char signature reflection path.
 if (args.Length > 0 && args[0] == "sig") return Probe.RunSig();
 


### PR DESCRIPTION
## The bug (HCBR-2026-06-08-01)

A deep read (`depth >= 5`) of any condition-bearing record — perk entry points, MGEF / package / quest / scene conditions — exploded to ~50 KB / 500+ lines of **.NET reflection metadata**. The depth walker recursed into a `ConditionData` arm's `Parameter1Type` / `Parameter2Type`, which are typed `System.Type` (`RuntimeType`), and serialized `.Assembly.DefinedTypes` (the whole ~17,900-type Mutagen assembly), the `BaseType → Enum → ValueType` chain, `StructLayoutAttribute`, `Module`, and the cyclic `UnderlyingSystemType`. The one useful line (`ActorValue = Conjuration`) was buried, and the response overflowed to a `tool-results` spill.

Reported during ARR work (Apostasy perk read, `Effects[5].Conditions` at depth 8).

## The fix

Gate the substruct recursion on the **modeled corpus** (cornerstone): descend only into `Mutagen.Bethesda.*` / `Noggog.*` record content; render any other object (a reflection type) as its existing one-line summary token and stop, regardless of remaining depth budget. The summary line is unchanged from the clean `depth <= 4` rendering, so **no real data is lost — only the reflection descent is cut.** This generalizes past `ConditionData`: any accidental reflection leak in a deep read is now boundary-stopped.

Display-only path — the proven `depth == 1` leaf read and the read↔write round-trip oracle are untouched.

## Evidence

| Check | Before | After |
|---|---|---|
| Live shipped server — real Apostasy perk, depth 8 | 200+ lines, full assembly metadata | — |
| Harness read — **same real record**, depth 8 | — | **27 lines**, every condition field intact |
| `depth-leak-guard` (deterministic) | **RED** — 2001 lines, 1982 reflection | **GREEN** — 24 lines, 0 |
| Release build | — | clean, 0 warnings / 0 errors |

## Regression guard

`depth-leak-guard` is **self-contained** (synthesizes a CTDA condition whose arm carries a `System.Type` `Parameter1Type`) and **wired into CI** beside `pkcu-regression`, so it runs on every push/PR. It also asserts the condition's real data survives, so the fix can't "pass" by truncating output. Proven RED without the engine fix and GREEN with it.

## Diff

4 files, +128/−0: the engine gate + helper (`ReadEngine.cs`), the guard (`DepthLeakProbe.cs`), its dispatch wiring (`Program.cs`), and the CI step (`ci.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
