### PR TITLE
Add field-value predicate to cross_plugin_query (where=, by construction)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,8 @@ jobs:
       # files), runs fully here: a regression guard locking in the depth-walker reflection-leak fix (HCBR-2026-06-08-01).
       - name: Probe — depth-walker reflection leak (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- depth-leak-guard
+
+      # Self-contained (synthesizes records with known field values — no external files), runs fully here: a regression
+      # guard for the field-value query predicate (cross_plugin_query where=) — matched set == brute-force + the Q3 teeth.
+      - name: Probe — field-value query predicate (self-contained regression guard)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- value-predicate-guard

--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -1,0 +1,263 @@
+using System.Globalization;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+
+namespace HousecarlCore;
+
+/// <summary>
+/// A field-VALUE predicate over a record body — the query-side complement to <see cref="ReadEngine"/>.
+///
+/// <para>Where <c>cross_plugin_query</c> can already scope and shape results by a record's IDENTITY and LINKS
+/// (type / editorid_contains / references), a <see cref="FieldPredicateSet"/> filters by a field's VALUE:
+/// <c>"MagicSkill = Destruction"</c>, <c>"BasicStats.Damage &gt;= 50"</c>, <c>"Archetype.ActorValue = Infamy"</c>.
+/// Multiple predicates are ANDed (the wire is <c>where: string[]</c>).</para>
+///
+/// <para><b>By construction (cornerstone §3).</b> The extraction is NOT a per-field table — it is the read
+/// engine's own proven path-walk: each predicate pulls its candidate's value through the internal
+/// <see cref="ReadEngine.ReadLeaf"/> (the same <c>ParseSegment</c>/<c>ResolveProperty</c>/<c>StepIntoElement</c>
+/// navigation the read tools and the round-trip oracle drive), then compares the round-trippable token. So the
+/// set of fields you can FILTER on IS the set of fields houseCARL can READ — every type, every depth, no
+/// hand-kept list. The comparison vocabulary is fixed by the token forms <see cref="ReadEngine"/> emits (the
+/// faithful inverse of the write engine's Coerce): enum NAME, invariant numeric round-trip, <c>True</c>/<c>False</c>,
+/// <c>XXXXXX:Plugin.esp</c> FormKey.</para>
+///
+/// <para><b>Q3 — no silent wrong answer.</b> A value predicate's natural failure mode is a wrong field path that
+/// reads no value on every candidate and looks like a true "0 matches." This type ACCOUNTS for why each
+/// candidate didn't match (per-predicate value-read vs no-value counts) so the scan can fail LOUD when a path
+/// is read-blind everywhere (<see cref="AccountingNote"/>), and a numeric operator pointed at a non-numeric
+/// field is a fast, named <see cref="FatalError"/> on the first value-bearing candidate — never a whole-scan
+/// silent skip.</para>
+///
+/// <para>Scope (v1): scalar-leaf paths only (incl. a concrete bracketed element like <c>Keywords[0]</c>). A whole
+/// LIST leaf (<c>Keywords</c>, <c>Effects</c>) reads as a no-value container summary, so a list path is surfaced
+/// by the Q3 accounting, never silently matched — list→FormID membership is <c>references=</c>'s job. A wildcard
+/// over a list (<c>Effects[*].Magnitude &gt; 50</c>) is a deliberate future extension, not v1.</para>
+/// </summary>
+public sealed class FieldPredicateSet
+{
+    /// <summary>The seven v1 operators. <see cref="Gt"/>/<see cref="Ge"/>/<see cref="Lt"/>/<see cref="Le"/> are
+    /// numeric-only; <see cref="Contains"/> is a case-insensitive substring; <see cref="Eq"/>/<see cref="Ne"/>
+    /// compare across the whole token vocabulary (FormKey-canonical, else numeric, else case-insensitive string).</summary>
+    enum Op { Eq, Ne, Gt, Ge, Lt, Le, Contains }
+
+    /// <summary>One parsed predicate: the split path segments (fed straight to <see cref="ReadEngine.ReadLeaf"/>),
+    /// the operator, the raw operand, and — for a numeric operator — the operand pre-parsed to a double (validated
+    /// at parse, so a non-numeric operand under <c>&gt;</c>/<c>&lt;</c> fails the whole call before any scan).</summary>
+    sealed record Predicate(string Text, string[] PathSegments, string PathDisplay, Op Op, string Operand, double NumericOperand);
+
+    readonly IReadOnlyList<Predicate> _predicates;
+    readonly long[] _valueRead;   // per-predicate: candidates whose path read SOME value
+    readonly long[] _noValue;     // per-predicate: candidates whose path read NO value (absent / no-such-field / container / fault)
+    long _scanned;
+    string? _fatal;
+
+    FieldPredicateSet(IReadOnlyList<Predicate> predicates)
+    {
+        _predicates = predicates;
+        _valueRead = new long[predicates.Count];
+        _noValue = new long[predicates.Count];
+    }
+
+    /// <summary>Set once when a numeric operator meets a non-numeric field value on the first value-bearing
+    /// candidate — a typed predicate error. The scan checks this and aborts, surfacing it as a recoverable error
+    /// (never a silent skip). Null while the predicate is well-typed.</summary>
+    public string? FatalError => _fatal;
+
+    /// <summary>Candidate bodies tested so far — the denominator the Q3 accounting reports against.</summary>
+    public long Scanned => _scanned;
+
+    // ======================================================================
+    //  PARSE — "<path> <op> <value>", longest-match the operator.
+    //  The path is dotted/bracketed identifiers (no whitespace, no operator
+    //  char), so it ends at the first space or operator char; the operand is
+    //  the remainder. 'contains' is a whitespace-delimited word operator.
+    // ======================================================================
+
+    /// <summary>Parse the wire <c>where</c> list into an evaluable set, or return the FIRST parse error (so a
+    /// malformed predicate refuses the whole call before scanning — Q3). An empty list is a parse error: a
+    /// caller passing <c>where</c> at all means to filter.</summary>
+    public static (FieldPredicateSet? Set, string? Error) Parse(IReadOnlyList<string> where)
+    {
+        var list = new List<Predicate>(where.Count);
+        foreach (var raw in where)
+        {
+            var (p, err) = ParseOne(raw);
+            if (err is not null) return (null, err);
+            list.Add(p!);
+        }
+        if (list.Count == 0) return (null, "where= was empty — give at least one predicate like \"MagicSkill = Destruction\".");
+        return (new FieldPredicateSet(list), null);
+    }
+
+    static (Predicate?, string?) ParseOne(string raw)
+    {
+        var text = (raw ?? "").Trim();
+        if (text.Length == 0) return (null, "empty predicate in where= (expected \"<path> <op> <value>\").");
+
+        // 1. path — the leading run of non-whitespace, non-operator-char characters.
+        int i = 0;
+        while (i < text.Length && !char.IsWhiteSpace(text[i]) && !IsOpChar(text[i])) i++;
+        var path = text.Substring(0, i);
+        if (path.Length == 0)
+            return (null, $"predicate '{raw}': no field path before the operator (expected \"<path> <op> <value>\").");
+
+        // 2. skip whitespace to the operator.
+        while (i < text.Length && char.IsWhiteSpace(text[i])) i++;
+        if (i >= text.Length)
+            return (null, $"predicate '{raw}': no operator. Use one of = != > >= < <= contains, e.g. \"{path} = <value>\".");
+
+        // 3. operator — symbolic (longest match) or the 'contains' word.
+        Op op;
+        int after;
+        if (IsOpChar(text[i]))
+        {
+            if (StartsWith(text, i, "!=")) { op = Op.Ne; after = i + 2; }
+            else if (StartsWith(text, i, ">=")) { op = Op.Ge; after = i + 2; }
+            else if (StartsWith(text, i, "<=")) { op = Op.Le; after = i + 2; }
+            else if (text[i] == '=') { op = Op.Eq; after = i + 1; }
+            else if (text[i] == '>') { op = Op.Gt; after = i + 1; }
+            else if (text[i] == '<') { op = Op.Lt; after = i + 1; }
+            else return (null, $"predicate '{raw}': unrecognized operator at '{text.Substring(i)}'. Use = != > >= < <= contains.");
+        }
+        else
+        {
+            int w = i;
+            while (w < text.Length && !char.IsWhiteSpace(text[w])) w++;
+            var word = text.Substring(i, w - i);
+            if (!word.Equals("contains", StringComparison.OrdinalIgnoreCase))
+                return (null, $"predicate '{raw}': unrecognized operator '{word}'. Use = != > >= < <= or contains.");
+            op = Op.Contains;
+            after = w;
+        }
+
+        // 4. operand — the remainder, trimmed. (For 'contains' the operand may contain operator chars; we already
+        //    consumed the operator positionally, so that's fine.)
+        var operand = text.Substring(after).Trim();
+        if (operand.Length == 0)
+            return (null, $"predicate '{raw}': no value after '{OpStr(op)}'.");
+
+        // 5. a numeric operator demands a numeric operand — fail fast at parse (before any scan).
+        double num = 0;
+        if (IsNumericOp(op) && !TryNum(operand, out num))
+            return (null, $"predicate '{raw}': operator '{OpStr(op)}' needs a numeric value, got '{operand}'.");
+
+        var segs = path.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (segs.Length == 0)
+            return (null, $"predicate '{raw}': '{path}' is not a usable field path.");
+        return (new Predicate(text, segs, path, op, operand, num), null);
+    }
+
+    static bool IsOpChar(char c) => c is '=' or '!' or '<' or '>';
+    static bool IsNumericOp(Op op) => op is Op.Gt or Op.Ge or Op.Lt or Op.Le;
+    static bool StartsWith(string s, int i, string op)
+        => i + op.Length <= s.Length && string.CompareOrdinal(s, i, op, 0, op.Length) == 0;
+
+    // ======================================================================
+    //  EVALUATE — test one in-hand body against ALL predicates (ANDed).
+    // ======================================================================
+
+    /// <summary>Test one candidate body against every predicate (ANDed), updating the per-predicate accounting.
+    /// Returns true iff all predicates are satisfied. Reuses <see cref="ReadEngine.ReadLeaf"/> for the value —
+    /// so a filterable path is exactly a readable path. On a numeric-operator-vs-non-numeric-field mismatch sets
+    /// <see cref="FatalError"/> and returns false (the scan aborts and surfaces it on the first value-bearing
+    /// candidate). All predicates are read for their accounting even when an earlier one already disqualifies the
+    /// AND, so the Q3 no-value signal is correct per predicate.</summary>
+    public bool Matches(IMajorRecordGetter body)
+    {
+        if (_fatal is not null) return false;
+        _scanned++;
+        bool all = true;
+        for (int k = 0; k < _predicates.Count; k++)
+        {
+            var p = _predicates[k];
+            var leaf = ReadEngine.ReadLeaf(body, p.PathSegments);   // internal, same assembly — the by-construction read walk
+            if (!leaf.HasValue) { _noValue[k]++; all = false; continue; }
+            _valueRead[k]++;
+            var (satisfied, err) = Compare(p, leaf.Token);
+            if (err is not null) { _fatal ??= err; return false; }
+            if (!satisfied) all = false;
+        }
+        return all;
+    }
+
+    static (bool satisfied, string? error) Compare(Predicate p, string token)
+    {
+        switch (p.Op)
+        {
+            case Op.Gt or Op.Ge or Op.Lt or Op.Le:
+                if (!TryNum(token, out var tv))
+                    return (false, $"predicate '{p.Text}': operator '{OpStr(p.Op)}' needs a numeric field, but '{p.PathDisplay}' read '{Trunc(token)}', not a number.");
+                double ov = p.NumericOperand;
+                bool num = p.Op switch { Op.Gt => tv > ov, Op.Ge => tv >= ov, Op.Lt => tv < ov, Op.Le => tv <= ov, _ => false };
+                return (num, null);
+
+            case Op.Contains:
+                return (token.Contains(p.Operand, StringComparison.OrdinalIgnoreCase), null);
+
+            default: // Eq / Ne
+                bool eq = ValueEquals(token, p.Operand);
+                return (p.Op == Op.Eq ? eq : !eq, null);
+        }
+    }
+
+    /// <summary>Equality across the token vocabulary: FormKey-canonical if BOTH sides are FormKeys (so a link
+    /// compares as a FormKey, not a string), else numeric if both parse as numbers (so <c>0.50</c> matches a
+    /// stored <c>0.5</c>), else case-insensitive string (enum names, <c>True</c>/<c>False</c>, plain strings).</summary>
+    static bool ValueEquals(string token, string operand)
+    {
+        if (TryFormKey(token, out var a) && TryFormKey(operand, out var b)) return a == b;
+        if (TryNum(token, out var x) && TryNum(operand, out var y)) return x.Equals(y);
+        return string.Equals(token, operand, StringComparison.OrdinalIgnoreCase);
+    }
+
+    static bool TryNum(string s, out double d)
+        => double.TryParse(s, NumberStyles.Float | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out d);
+
+    /// <summary>True only for a real FormKey string (<c>XXXXXX:Plugin.esp</c>). A plain number or enum name has no
+    /// <c>:Plugin</c> tail, so it never parses here — the FormKey branch can't swallow a numeric/string compare.</summary>
+    static bool TryFormKey(string s, out FormKey fk)
+    {
+        try { fk = FormKey.Factory(s.Trim()); return true; }
+        catch { fk = default; return false; }
+    }
+
+    // ======================================================================
+    //  Q3 ACCOUNTING — the loud "wrong path ≠ true zero" surface.
+    // ======================================================================
+
+    /// <summary>The line(s) appended to the result header so a value predicate's natural failure mode (a wrong
+    /// path that reads nothing everywhere → false "0 matches") can never read as a confirmed true negative.
+    /// Null when every predicate read values on a healthy fraction of candidates.
+    /// <list type="bullet">
+    /// <item>A predicate that read NO value on ANY candidate ⇒ a LOUD line (it necessarily produced 0 matches —
+    /// likely a mistyped or container/list path).</item>
+    /// <item>A predicate that read no value on MORE THAN HALF the candidates ⇒ a SOFT note (a path wrong for some
+    /// scanned types in a mixed scan reads as a non-match there, not an error).</item>
+    /// </list></summary>
+    public string? AccountingNote()
+    {
+        if (_scanned == 0) return null;   // nothing reached the predicate (e.g. an empty type group) — no health signal to give
+        List<string>? notes = null;
+        for (int k = 0; k < _predicates.Count; k++)
+        {
+            var path = _predicates[k].PathDisplay;
+            if (_valueRead[k] == 0)
+                (notes ??= new()).Add(
+                    $"predicate field '{path}' yielded no readable value on any of {_scanned:N0} scanned record(s) — likely a mistyped path, " +
+                    $"or a container/list path (use a scalar leaf like 'Archetype.ActorValue', or references= for list→FormID membership). " +
+                    $"0 matches on that basis is NOT a confirmed 'nothing matches'.");
+            else if (_noValue[k] * 2 > _scanned)
+                (notes ??= new()).Add(
+                    $"note: '{path}' had no readable value on {_noValue[k]:N0} of {_scanned:N0} scanned record(s) " +
+                    $"(absent or not a field on those types) — counted as non-matches there, not errors.");
+        }
+        return notes is null ? null : string.Join("\n", notes);
+    }
+
+    static string OpStr(Op op) => op switch
+    {
+        Op.Eq => "=", Op.Ne => "!=", Op.Gt => ">", Op.Ge => ">=", Op.Lt => "<", Op.Le => "<=", Op.Contains => "contains", _ => "?",
+    };
+
+    static string Trunc(string s) => s.Length > 60 ? s.Substring(0, 60) + "…" : s;
+}

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -27,6 +27,10 @@ if (args.Length > 0 && args[0] == "pkcu-regression") return PkcuProbe.RunRegress
 // condition whose arm carries a System.Type Parameter1Type, asserts a deep read renders it as one opaque token.
 if (args.Length > 0 && args[0] == "depth-leak-guard") return DepthLeakProbe.RunGuard(args[1..]);
 
+// Field-value query predicate (cross_plugin_query where=): SELF-CONTAINED CI regression guard — synthesizes records
+// with known field values, asserts the evaluator's matched set == a brute-force reference + the Q3 teeth.
+if (args.Length > 0 && args[0] == "value-predicate-guard") return ValuePredicateProbe.RunGuard(args[1..]);
+
 // One-shot verify (decision #1): confirm the xEdit 4-char signature reflection path.
 if (args.Length > 0 && args[0] == "sig") return Probe.RunSig();
 

--- a/src/housecarl-generator/ValuePredicateProbe.cs
+++ b/src/housecarl-generator/ValuePredicateProbe.cs
@@ -1,0 +1,228 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// REGRESSION GUARD (standing CI instrument) for the field-value query predicate (cross_plugin_query where=).
+///
+/// Self-contained, in the pattern of <c>depth-leak-guard</c> / <c>pkcu-regression</c>: synthesizes records IN
+/// MEMORY with KNOWN field values, runs the product evaluator (<see cref="FieldPredicateSet"/>), and asserts the
+/// matched set EQUALS a brute-force reference computed independently from those known literals (plain C#
+/// comparisons over the stored values — NOT the read walk), so a drift in the path-walk, the token comparison,
+/// or the operator parse fails loud.
+///
+/// It locks in the load-bearing Q3 teeth: a wrong path reads no value EVERYWHERE and is surfaced LOUD (never a
+/// silent "0 matches"); a numeric operator on a non-numeric field is a fast typed error; <c>=</c> on a float
+/// matches across <c>0.5</c>/<c>0.50</c>; a FormLink compares as a FormKey; <c>!=</c> negates; an AND-list
+/// intersects; and malformed predicates are refused at parse. RED if any of those is absent.
+///
+/// Run: <c>dotnet run --project src/housecarl-generator value-predicate-guard</c>
+/// </summary>
+public static class ValuePredicateProbe
+{
+    /// <summary>One synthesized MagicEffect plus the literals it was BUILT with — the independent ground truth the
+    /// evaluator must reproduce (the brute-force oracle reads these fields, never the record).</summary>
+    sealed record Mgef(IMagicEffectGetter Rec, ActorValue MagicSkill, float BaseCost, ActorValue ArchActorValue, FormKey Projectile)
+    {
+        public FormKey Fk => Rec.FormKey;
+    }
+
+    /// <summary>One synthesized Weapon plus its known BasicStats.Damage.</summary>
+    sealed record Weap(IWeaponGetter Rec, ushort Damage)
+    {
+        public FormKey Fk => Rec.FormKey;
+    }
+
+    static int _pass, _fail;
+
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  REGRESSION GUARD — field-value query predicate (cross_plugin_query where=)  ################");
+        Console.WriteLine();
+
+        var mod = new SkyrimMod(new ModKey("hcvalguard", ModType.Plugin), SkyrimRelease.SkyrimSE);
+
+        // ---- MGEF cohort: known (MagicSkill, BaseCost, Archetype.ActorValue, Projectile) ---------------------
+        var projX = FormKey.Factory("0ABCDE:hcvalguard.esp");
+        var projY = FormKey.Factory("0FEDCB:hcvalguard.esp");
+        var mgefs = new List<Mgef>
+        {
+            MakeMgef(mod, ActorValue.Destruction, 0.5f,  ActorValue.Infamy,      projX),
+            MakeMgef(mod, ActorValue.Conjuration, 1.0f,  ActorValue.Conjuration, projY),
+            MakeMgef(mod, ActorValue.Destruction, 2.0f,  ActorValue.Infamy,      projX),
+            MakeMgef(mod, ActorValue.Restoration, 0.5f,  ActorValue.Destruction, projY),
+        };
+        var mgefBodies = mgefs.Select(m => (IMajorRecordGetter)m.Rec).ToList();
+
+        // ---- WEAP cohort: known BasicStats.Damage ------------------------------------------------------------
+        var weaps = new List<Weap>
+        {
+            MakeWeap(mod, 10),
+            MakeWeap(mod, 50),
+            MakeWeap(mod, 100),
+        };
+        var weapBodies = weaps.Select(w => (IMajorRecordGetter)w.Rec).ToList();
+
+        Console.WriteLine($"-- synthesized {mgefs.Count} MagicEffect + {weaps.Count} Weapon records --");
+        Console.WriteLine();
+
+        // ============================ FILTER-CORRECTNESS (matched set == brute force) ============================
+
+        // 1. enum equality (top-level scalar enum) — case-insensitive on the enum NAME.
+        CheckSet("MagicSkill = Destruction",
+            Run(new[] { "MagicSkill = Destruction" }, mgefBodies),
+            Expect(mgefs, m => m.MagicSkill == ActorValue.Destruction));
+        CheckSet("MagicSkill = destruction  (case-insensitive)",
+            Run(new[] { "MagicSkill = destruction" }, mgefBodies),
+            Expect(mgefs, m => m.MagicSkill == ActorValue.Destruction));
+
+        // 2. inequality.
+        CheckSet("MagicSkill != Destruction",
+            Run(new[] { "MagicSkill != Destruction" }, mgefBodies),
+            Expect(mgefs, m => m.MagicSkill != ActorValue.Destruction));
+
+        // 3. NESTED enum path (the plan's headline — substruct → field, by construction the same walk as reads).
+        CheckSet("Archetype.ActorValue = Infamy",
+            Run(new[] { "Archetype.ActorValue = Infamy" }, mgefBodies),
+            Expect(mgefs, m => m.ArchActorValue == ActorValue.Infamy));
+
+        // 4. numeric operators on a NESTED numeric leaf (ushort) — parse both sides to a number.
+        CheckSet("BasicStats.Damage >= 50",
+            Run(new[] { "BasicStats.Damage >= 50" }, weapBodies),
+            Expect(weaps, w => w.Damage >= 50));
+        CheckSet("BasicStats.Damage < 50",
+            Run(new[] { "BasicStats.Damage < 50" }, weapBodies),
+            Expect(weaps, w => w.Damage < 50));
+        CheckSet("BasicStats.Damage = 50",
+            Run(new[] { "BasicStats.Damage = 50" }, weapBodies),
+            Expect(weaps, w => w.Damage == 50));
+
+        // 5. float equality across 0.5 / 0.50 — numeric compare, not string (a raw string compare would miss it).
+        CheckSet("BaseCost = 0.50  (matches stored 0.5)",
+            Run(new[] { "BaseCost = 0.50" }, mgefBodies),
+            Expect(mgefs, m => Math.Abs(m.BaseCost - 0.5f) < 1e-6));
+
+        // 6. FormLink equality — compares as a FormKey (broader 0x/leading-zero leniency is deferred per plan).
+        CheckSet($"Projectile = {projX}",
+            Run(new[] { $"Projectile = {projX}" }, mgefBodies),
+            Expect(mgefs, m => m.Projectile == projX));
+
+        // 7. AND-list — every predicate must hold (intersection).
+        CheckSet("[MagicSkill = Destruction] AND [BaseCost >= 1.0]",
+            Run(new[] { "MagicSkill = Destruction", "BaseCost >= 1.0" }, mgefBodies),
+            Expect(mgefs, m => m.MagicSkill == ActorValue.Destruction && m.BaseCost >= 1.0f));
+
+        // ============================ Q3 TEETH (no silent wrong answer) ============================
+        Console.WriteLine();
+        Console.WriteLine("-- Q3 teeth --");
+
+        // 8. WRONG PATH → no readable value on ANY candidate → LOUD accounting (NOT a silent zero).
+        {
+            var (matched, set) = RunWithSet(new[] { "Archetyp.ActorValue = Infamy" }, mgefBodies);  // typo'd 'Archetyp'
+            var note = set.AccountingNote();
+            bool loud = note is not null && note.Contains("no readable value", StringComparison.Ordinal);
+            Check("wrong path: 0 matches", matched.Count == 0);
+            Check("wrong path: LOUD note (not silent zero)", loud);
+            Console.WriteLine($"     note: {Trunc(note)}");
+        }
+
+        // 9. LIST path (Keywords) reads as a container → no value → surfaced, never silently matched.
+        {
+            var (matched, set) = RunWithSet(new[] { "Keywords = 0ABCDE:hcvalguard.esp" }, mgefBodies);
+            var note = set.AccountingNote();
+            Check("list path: 0 matches", matched.Count == 0);
+            Check("list path: surfaced (note mentions list/container)",
+                  note is not null && note.Contains("container/list", StringComparison.Ordinal));
+        }
+
+        // 10. NUMERIC operator on a NON-numeric field → fast typed FatalError (not a whole-scan silent skip).
+        {
+            var (matched, set) = RunWithSet(new[] { "MagicSkill > 5" }, mgefBodies);
+            Check("numeric op on enum: FatalError set", set.FatalError is not null);
+            Check("numeric op on enum: 0 matches", matched.Count == 0);
+            Console.WriteLine($"     fatal: {Trunc(set.FatalError)}");
+        }
+
+        // 11. PARSE errors refuse the whole call (before any scan).
+        Check("parse: numeric op needs numeric operand ('>= abc')", FieldPredicateSet.Parse(new[] { "BasicStats.Damage >= abc" }).Error is not null);
+        Check("parse: missing operator ('MagicSkill')", FieldPredicateSet.Parse(new[] { "MagicSkill" }).Error is not null);
+        Check("parse: missing path ('= Infamy')", FieldPredicateSet.Parse(new[] { "= Infamy" }).Error is not null);
+        Check("parse: missing value ('MagicSkill =')", FieldPredicateSet.Parse(new[] { "MagicSkill =" }).Error is not null);
+        Check("parse: unknown operator ('MagicSkill ~ x')", FieldPredicateSet.Parse(new[] { "MagicSkill ~ x" }).Error is not null);
+        Check("parse: empty where= refused", FieldPredicateSet.Parse(Array.Empty<string>()).Error is not null);
+        // a VALID predicate parses clean.
+        Check("parse: valid predicate accepted", FieldPredicateSet.Parse(new[] { "MagicSkill = Destruction" }).Error is null);
+
+        // 12. healthy scan emits NO accounting note (no false alarms).
+        {
+            var (_, set) = RunWithSet(new[] { "MagicSkill = Destruction" }, mgefBodies);
+            Check("healthy scan: no spurious accounting note", set.AccountingNote() is null);
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"=== value-predicate-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
+        return _fail == 0 ? 0 : 1;
+    }
+
+    // ---- helpers ---------------------------------------------------------------------------------------------
+
+    static Mgef MakeMgef(SkyrimMod mod, ActorValue skill, float baseCost, ActorValue archAv, FormKey projectile)
+    {
+        var m = mod.MagicEffects.AddNew();
+        m.MagicSkill = skill;
+        m.BaseCost = baseCost;
+        m.Archetype = new MagicEffectLightArchetype { ActorValue = archAv };
+        m.Projectile.SetTo(projectile);
+        return new Mgef(m, skill, baseCost, archAv, projectile);
+    }
+
+    static Weap MakeWeap(SkyrimMod mod, ushort damage)
+    {
+        var w = mod.Weapons.AddNew();
+        w.BasicStats = new WeaponBasicStats { Damage = damage };
+        return new Weap(w, damage);
+    }
+
+    /// <summary>Parse + evaluate the predicate set over a cohort; return the matched FormKey set. Throws if the
+    /// predicates don't parse (these call sites pass well-formed predicates — a parse failure is a real bug).</summary>
+    static HashSet<FormKey> Run(string[] where, IEnumerable<IMajorRecordGetter> cohort) => RunWithSet(where, cohort).matched;
+
+    static (HashSet<FormKey> matched, FieldPredicateSet set) RunWithSet(string[] where, IEnumerable<IMajorRecordGetter> cohort)
+    {
+        var (set, err) = FieldPredicateSet.Parse(where);
+        if (err is not null) throw new InvalidOperationException($"unexpected parse error for [{string.Join(", ", where)}]: {err}");
+        var matched = new HashSet<FormKey>();
+        foreach (var body in cohort) if (set!.Matches(body)) matched.Add(body.FormKey);
+        return (matched, set!);
+    }
+
+    static HashSet<FormKey> Expect(IEnumerable<Mgef> cohort, Func<Mgef, bool> pred)
+        => cohort.Where(pred).Select(m => m.Fk).ToHashSet();
+
+    static HashSet<FormKey> Expect(IEnumerable<Weap> cohort, Func<Weap, bool> pred)
+        => cohort.Where(pred).Select(w => w.Fk).ToHashSet();
+
+    static void CheckSet(string label, HashSet<FormKey> actual, HashSet<FormKey> expected)
+    {
+        bool ok = actual.SetEquals(expected);
+        Console.WriteLine($"   [{(ok ? "PASS" : "FAIL")}] {label}   matched={actual.Count} expected={expected.Count}");
+        if (!ok)
+        {
+            Console.WriteLine($"           actual  : {string.Join(", ", actual)}");
+            Console.WriteLine($"           expected: {string.Join(", ", expected)}");
+        }
+        if (ok) _pass++; else _fail++;
+    }
+
+    static void Check(string label, bool ok)
+    {
+        Console.WriteLine($"   [{(ok ? "PASS" : "FAIL")}] {label}");
+        if (ok) _pass++; else _fail++;
+    }
+
+    static string Trunc(string? s) => s is null ? "(null)" : s.Length > 160 ? s.Substring(0, 160) + "…" : s;
+}

--- a/src/housecarl-generator/ValuePredicateProbe.cs
+++ b/src/housecarl-generator/ValuePredicateProbe.cs
@@ -26,7 +26,7 @@ public static class ValuePredicateProbe
 {
     /// <summary>One synthesized MagicEffect plus the literals it was BUILT with — the independent ground truth the
     /// evaluator must reproduce (the brute-force oracle reads these fields, never the record).</summary>
-    sealed record Mgef(IMagicEffectGetter Rec, ActorValue MagicSkill, float BaseCost, ActorValue ArchActorValue, FormKey Projectile)
+    sealed record Mgef(IMagicEffectGetter Rec, string Eid, ActorValue MagicSkill, float BaseCost, ActorValue ArchActorValue, FormKey Projectile)
     {
         public FormKey Fk => Rec.FormKey;
     }
@@ -51,10 +51,10 @@ public static class ValuePredicateProbe
         var projY = FormKey.Factory("0FEDCB:hcvalguard.esp");
         var mgefs = new List<Mgef>
         {
-            MakeMgef(mod, ActorValue.Destruction, 0.5f,  ActorValue.Infamy,      projX),
-            MakeMgef(mod, ActorValue.Conjuration, 1.0f,  ActorValue.Conjuration, projY),
-            MakeMgef(mod, ActorValue.Destruction, 2.0f,  ActorValue.Infamy,      projX),
-            MakeMgef(mod, ActorValue.Restoration, 0.5f,  ActorValue.Destruction, projY),
+            MakeMgef(mod, "hcFireDamage",    ActorValue.Destruction, 0.5f,  ActorValue.Infamy,      projX),
+            MakeMgef(mod, "hcConjureFlame",  ActorValue.Conjuration, 1.0f,  ActorValue.Conjuration, projY),
+            MakeMgef(mod, "hcFrostDamage",   ActorValue.Destruction, 2.0f,  ActorValue.Infamy,      projX),
+            MakeMgef(mod, "hcRestoreHealth", ActorValue.Restoration, 0.5f,  ActorValue.Destruction, projY),
         };
         var mgefBodies = mgefs.Select(m => (IMajorRecordGetter)m.Rec).ToList();
 
@@ -116,6 +116,25 @@ public static class ValuePredicateProbe
             Run(new[] { "MagicSkill = Destruction", "BaseCost >= 1.0" }, mgefBodies),
             Expect(mgefs, m => m.MagicSkill == ActorValue.Destruction && m.BaseCost >= 1.0f));
 
+        // 8. contains — case-insensitive substring on a string leaf (EditorID).
+        CheckSet("EditorID contains Frost",
+            Run(new[] { "EditorID contains Frost" }, mgefBodies),
+            Expect(mgefs, m => m.Eid.IndexOf("Frost", StringComparison.OrdinalIgnoreCase) >= 0));
+        CheckSet("EditorID contains frost  (case-insensitive)",
+            Run(new[] { "EditorID contains frost" }, mgefBodies),
+            Expect(mgefs, m => m.Eid.IndexOf("Frost", StringComparison.OrdinalIgnoreCase) >= 0));
+        CheckSet("EditorID contains hc  (all)",
+            Run(new[] { "EditorID contains hc" }, mgefBodies),
+            Expect(mgefs, m => m.Eid.IndexOf("hc", StringComparison.OrdinalIgnoreCase) >= 0));
+
+        // 9. the remaining numeric operators (> and <=), completing the set.
+        CheckSet("BasicStats.Damage > 50",
+            Run(new[] { "BasicStats.Damage > 50" }, weapBodies),
+            Expect(weaps, w => w.Damage > 50));
+        CheckSet("BasicStats.Damage <= 50",
+            Run(new[] { "BasicStats.Damage <= 50" }, weapBodies),
+            Expect(weaps, w => w.Damage <= 50));
+
         // ============================ Q3 TEETH (no silent wrong answer) ============================
         Console.WriteLine();
         Console.WriteLine("-- Q3 teeth --");
@@ -147,6 +166,19 @@ public static class ValuePredicateProbe
             Console.WriteLine($"     fatal: {Trunc(set.FatalError)}");
         }
 
+        // 10b. SOFT no-value note — a path wrong for >half the candidates in a MIXED scan is surfaced softly, even
+        //      though matches are still returned (distinct from the LOUD "no value on ANY" note in test 8/9 above).
+        {
+            var mixed = mgefBodies.Concat(weapBodies).ToList();   // 4 MGEF (no BasicStats) + 3 WEAP
+            var (matched, set) = RunWithSet(new[] { "BasicStats.Damage >= 0" }, mixed);
+            var note = set.AccountingNote();
+            Check("soft note: matched only the weapons (3)", matched.Count == 3);
+            Check("soft note: SOFT (>half no-value), not the loud 'no value on any' note",
+                  note is not null && note.Contains("had no readable value on", StringComparison.Ordinal)
+                  && !note.Contains("yielded no readable value", StringComparison.Ordinal));
+            Console.WriteLine($"     note: {Trunc(note)}");
+        }
+
         // 11. PARSE errors refuse the whole call (before any scan).
         Check("parse: numeric op needs numeric operand ('>= abc')", FieldPredicateSet.Parse(new[] { "BasicStats.Damage >= abc" }).Error is not null);
         Check("parse: missing operator ('MagicSkill')", FieldPredicateSet.Parse(new[] { "MagicSkill" }).Error is not null);
@@ -170,14 +202,15 @@ public static class ValuePredicateProbe
 
     // ---- helpers ---------------------------------------------------------------------------------------------
 
-    static Mgef MakeMgef(SkyrimMod mod, ActorValue skill, float baseCost, ActorValue archAv, FormKey projectile)
+    static Mgef MakeMgef(SkyrimMod mod, string eid, ActorValue skill, float baseCost, ActorValue archAv, FormKey projectile)
     {
         var m = mod.MagicEffects.AddNew();
+        m.EditorID = eid;
         m.MagicSkill = skill;
         m.BaseCost = baseCost;
         m.Archetype = new MagicEffectLightArchetype { ActorValue = archAv };
         m.Projectile.SetTo(projectile);
-        return new Mgef(m, skill, baseCost, archAv, projectile);
+        return new Mgef(m, eid, skill, baseCost, archAv, projectile);
     }
 
     static Weap MakeWeap(SkyrimMod mod, ushort damage)

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -378,17 +378,28 @@ public sealed class LoadOrderService : IDisposable
     /// in-hand body and so require type= or plugins= to bound them. Returns pre-built match summaries (capped at
     /// <paramref name="limit"/>, with the true total) or a recoverable Q3 error. Holds nothing.</summary>
     public CrossQueryOutcome CrossQuery(string? type, FormKey? references, string? editoridContains,
-                                        bool conflictsOnly, IReadOnlyList<string>? plugins, int limit)
+                                        bool conflictsOnly, IReadOnlyList<string>? plugins, IReadOnlyList<string>? where, int limit)
     {
         var resolver = Resolver;
         bool hasPlugins = plugins is { Count: > 0 };
         bool hasType = type is not null;
-        bool bodyFilter = references is not null || !string.IsNullOrEmpty(editoridContains);
+        bool hasWhere = where is { Count: > 0 };
+        bool bodyFilter = references is not null || !string.IsNullOrEmpty(editoridContains) || hasWhere;
 
         if (!hasType && !conflictsOnly && !hasPlugins && !bodyFilter)
-            return CrossQueryOutcome.Fail("cross_plugin_query needs at least one of: type=, conflicts_only=true, editorid_contains=, references=, or plugins=.");
+            return CrossQueryOutcome.Fail("cross_plugin_query needs at least one of: type=, conflicts_only=true, editorid_contains=, references=, where=, or plugins=.");
         if (bodyFilter && !hasType && !hasPlugins)
-            return CrossQueryOutcome.Fail("editorid_contains/references is a body scan and must be combined with type= or plugins= to bound it (conflicts_only= alone is not enough — an unbounded body scan over the whole order is refused). A global reverse-reference index is a future capability.");
+            return CrossQueryOutcome.Fail("editorid_contains/references/where is a body scan and must be combined with type= or plugins= to bound it (conflicts_only= alone is not enough — an unbounded body scan over the whole order is refused). A global reverse-reference index is a future capability.");
+
+        // where= → the field-value predicate set. Parsed up front so a malformed predicate refuses the call BEFORE
+        // any scan (Q3). The predicate reuses the read engine's path-walk, so its reach == the read surface's reach.
+        FieldPredicateSet? predicate = null;
+        if (hasWhere)
+        {
+            var (set, perr) = FieldPredicateSet.Parse(where!);
+            if (perr is not null) return CrossQueryOutcome.Fail(perr);
+            predicate = set;
+        }
 
         IReadOnlyList<Type>? types;
         try { types = hasType ? ResolveTypeFilter(type!) : null; }
@@ -417,6 +428,11 @@ public sealed class LoadOrderService : IDisposable
                     if (references is { } target
                         && !(body is IFormLinkContainerGetter flc && flc.EnumerateFormLinks().Any(l => l.FormKey == target)))
                         continue;
+                    if (predicate is not null && !predicate.Matches(body))    // value filter — same in-hand body, no extra fetch
+                    {
+                        if (predicate.FatalError is not null) break;          // numeric op vs non-numeric field — abort + surface (Q3)
+                        continue;
+                    }
                     if (!seen.Add(fk)) continue;                              // de-dup (a FK can recur across scoped plugins)
                     total++;
                     if (keys.Count < limit)                                   // in-hand body → fill the summary for free
@@ -428,6 +444,7 @@ public sealed class LoadOrderService : IDisposable
                 }
             }
             catch (ArgumentException ex) { return CrossQueryOutcome.Fail(ex.Message); } // plugin not in order / unknown type
+            if (predicate?.FatalError is not null) return CrossQueryOutcome.Fail(predicate.FatalError); // typed predicate error — fail fast, named (Q3)
         }
         else                                                                  // conflicts_only alone — index keys only; NO body fetch
         {
@@ -439,7 +456,7 @@ public sealed class LoadOrderService : IDisposable
                 if (keys.Count < limit) keys.Add(fk);
             }
         }
-        return new CrossQueryOutcome(keys, prefilled, total, total > keys.Count, null);
+        return new CrossQueryOutcome(keys, prefilled, total, total > keys.Count, null, predicate?.AccountingNote());
     }
 
     // ---- writes (§8.4 Beat C: housecarl_set_field / housecarl_bulk_apply) -------------------------------
@@ -878,7 +895,8 @@ public sealed record ReadOutcome(
 /// lazily, bounded by max_chars). <see cref="Total"/> is the true match count; <see cref="Capped"/> is true when
 /// Total exceeded what was returned.</summary>
 public sealed record CrossQueryOutcome(
-    IReadOnlyList<FormKey> Keys, IReadOnlyList<RecordSummary>? Prefilled, int Total, bool Capped, string? Error)
+    IReadOnlyList<FormKey> Keys, IReadOnlyList<RecordSummary>? Prefilled, int Total, bool Capped, string? Error,
+    string? PredicateNote = null)
 {
     public static CrossQueryOutcome Fail(string error) => new(Array.Empty<FormKey>(), null, 0, false, error);
 }

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -81,8 +81,10 @@ public static class ReadTools
          "summary line (FormID, type, editorid, winner, override depth). Filters (combine freely): type= a record " +
          "signature ('WEAP') or catalog name ('Weapon'); conflicts_only=true for records >1 plugin touches; " +
          "editorid_contains= a substring of the EditorID; references= a FormID the record points at (reverse lookup, " +
-         "e.g. 'what uses this keyword'); plugins= limits the scan to records those plugins touch (a bare plugins= is " +
-         "'everything this plugin touches'). At least one filter or plugins= is required. editorid_contains/references " +
+         "e.g. 'what uses this keyword'); where= filters by a field's VALUE (e.g. 'MagicSkill = Destruction', " +
+         "'BasicStats.Damage >= 50' — any scalar field, ANDed); plugins= limits the scan to records those plugins " +
+         "touch (a bare plugins= is 'everything this plugin touches'). At least one filter or plugins= is required. " +
+         "editorid_contains/references/where " +
          "are body scans and MUST be combined with type=, plugins=, or conflicts_only= to bound the work. Pass fields= " +
          "or conflict_tree=true to expand each match from a summary line to full detail. Results cap at limit= matches " +
          "and max_chars; both overruns are reported explicitly (never silent). Does NOT modify anything.")]
@@ -98,6 +100,8 @@ public static class ReadTools
             bool conflicts_only = false,
         [Description("Optional. Plugin filenames to scope the scan to (records those plugins touch). A name not in the load order is an error. Omit to scan the whole order.")]
             string[]? plugins = null,
+        [Description("Optional. Field-VALUE predicates, each \"<path> <op> <value>\" — e.g. 'MagicSkill = Destruction', 'BasicStats.Damage >= 50', 'Archetype.ActorValue = Infamy'. Operators: = != > >= < <= (>/< numeric) and contains (case-insensitive substring); multiple are ANDed. Filters on ANY scalar field the read tools can read (any type, any depth). A body scan — MUST be combined with type= or plugins=. A wrong or container/list path is reported, never a silent '0 matches'.")]
+            string[]? where = null,
         [Description("Optional. Dotted field paths to show for each match (e.g. 'BasicStats.Damage'). Omit for a one-line summary per match.")]
             string[]? fields = null,
         [Description("When true, include each match's touching-plugin list (winner last) + winner-relative field diff.")]
@@ -114,7 +118,7 @@ public static class ReadTools
             try { refFk = FormKey.Factory(references.Trim()); }
             catch (Exception ex) { return $"error: bad references FormID '{references}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."; }
         }
-        var outcome = svc.CrossQuery(type, refFk, editorid_contains, conflicts_only, plugins, limit <= 0 ? 500 : limit);
+        var outcome = svc.CrossQuery(type, refFk, editorid_contains, conflicts_only, plugins, where, limit <= 0 ? 500 : limit);
         return Wire.RenderCrossQuery(svc, outcome, fields, conflict_tree, max_chars);
     }
 }
@@ -172,6 +176,7 @@ static class Wire
         sb.Append("cross_plugin_query: ").Append(q.Total).Append(q.Total == 1 ? " match" : " matches");
         if (q.Capped) sb.Append(" (showing first ").Append(q.Keys.Count).Append("; raise limit= or narrow to see more)");
         sb.Append('\n');
+        if (q.PredicateNote is not null) sb.Append(q.PredicateNote).Append('\n');   // where= Q3 accounting (wrong-path/no-value surface)
 
         int rendered = 0;
         for (int i = 0; i < q.Keys.Count; i++)


### PR DESCRIPTION
## What

Adds a **field-value filter** to `housecarl_cross_plugin_query`: a new `where=` parameter that filters records by a field's VALUE — the axis the tool lacked (it had `type` / `editorid_contains` / `references` / `conflicts_only` / `plugins` only).

```
type=MGEF where="MagicSkill = Destruction"
type=WEAP where="BasicStats.Damage >= 50"
where=["Archetype.ActorValue = Infamy", "Archetype.Type = ValueModifier"]   # ANDed
```

Operators: `= != > >= < <=` (numeric) and `contains` (substring). Multiple predicates AND together (wire shape A). Closes the ARR review's **L1 / wishlist #1** — *"what writes actor value X?"* had no direct answer and forced a ~103k-token subagent fan-out.

## By construction (cornerstone §3)

The predicate reuses the read engine's own proven path-walk (`ReadEngine.ReadLeaf`) to pull each candidate's value, then compares the round-trippable token — so **the filterable-field set IS the readable-field set**: every type, every depth, no per-field allowlist. It slots in as **one more body-filter** in `CrossQuery`'s existing in-hand-body loop (right after `references`): no extra fetch, no index, the same `type=`/`plugins=` bound as the other body scans. General-walk only for v1 — a fall-through index accelerator stays a possible later perf layer, never a coverage gate.

## Q3 — no silent wrong answer

A value predicate's natural failure mode is a wrong path that reads nothing everywhere and looks like a true "0 matches." Guarded against:

- A path that reads **no value on any candidate** fails **loud** (`predicate field 'Archetyp.ActorValue' yielded no readable value on any of N scanned records — likely a mistyped path… use a scalar leaf, or references= for list membership`), never a bare "0 matches".
- A numeric operator on a **non-numeric field** is a fast, named error on the first value-bearing candidate.
- **Malformed predicates** are refused at parse, before any scan.
- A **list leaf** reads as a no-value container summary → surfaced, never silently matched (list→FormID membership stays `references=`).

## Files (+532 / −9)

- `src/housecarl-core/FieldPredicate.cs` — new public `FieldPredicateSet` (parse + evaluate; reuses internal `ReadLeaf`, same assembly).
- `src/housecarl-mcp/LoadOrderService.cs` — `where` threaded through `CrossQuery`; one continue-guard; typed-op abort; Q3 accounting on `CrossQueryOutcome`.
- `src/housecarl-mcp/ReadTools.cs` — `where=` param + tool description; render the accounting note.
- `src/housecarl-generator/ValuePredicateProbe.cs` + `Program.cs` + `.github/workflows/ci.yml` — the `value-predicate-guard` CI probe.

Tool surface stays **16** (the existing tool gained a parameter).

## Proof

- **`value-predicate-guard`** (self-contained, now in CI): matched set == an independent brute-force reference (expected from the constructed literals; actual via the reflection read path — the two share no code) + every Q3 tooth. **24/24 PASS.**
- **Live stdio round-trip** on the real ARR 2.0 order (3,443 plugins): `type=MGEF where="MagicSkill = Destruction"` returned **exactly the 1,547 of 10,381 MGEF winners** an unfiltered field-dump independently confirms (set-equal); the loud no-value note and the typed-op fatal rendered through the real MCP tool.

## Known interaction (pre-existing, not introduced here)

With `plugins=` + `where=` + `fields=`, the predicate matches on the scoped plugin's **own override** body while `fields=` displays the **winner** body — so a shown field can differ from the matched value. Same as today's `editorid_contains` + `plugins=` + `fields=`; matching-on-own-body is the intended "which of this plugin's own overrides set it" semantics. Plain `type=` (winner) scope has no ambiguity. Left as-is to avoid silently widening scope; a display-consistency follow-up is a separate change across all body filters.

Plan: `dev/plans/FIELD_VALUE_QUERY_PREDICATE_PLAN_2026-06-08.md` (§4 outcome (a)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
