### PR TITLE
Render cross_plugin_query plugins= matches from the scoped plugin's own body

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,9 @@ jobs:
       # guard for the field-value query predicate (cross_plugin_query where=) — matched set == brute-force + the Q3 teeth.
       - name: Probe — field-value query predicate (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- value-predicate-guard
+
+      # Self-contained (synthesizes a master + two overrides on disk — no external files), runs fully here: a regression
+      # guard for the winner-vs-source display fix (cross_plugin_query plugins= scope) — RecordsIn pairs each body with
+      # its OWN source plugin (the body the scan filtered), the winner stream with the winner. Locks wishlist #8.
+      - name: Probe — winner-vs-source display (self-contained regression guard)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- source-display-guard

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -411,8 +411,9 @@ public sealed class LoadOrderResolver : IDisposable
     /// <summary>Stream every record contained in the given plugins (optionally only of the given type(s)), each
     /// with that PLUGIN'S body in hand — the plugin-scoped path (the Q4.9 plugin_dump fold + a plugin-content
     /// audit). A FormKey touched by more than one scoped plugin is yielded once per scoped plugin (the SERVICE
-    /// de-dupes). Yields (FormKey, whole-order override-depth, the scoped plugin's body). Holds nothing.</summary>
-    public IEnumerable<(FormKey fk, int depth, IMajorRecordGetter body)> RecordsIn(
+    /// de-dupes). Yields (FormKey, whole-order override-depth, the scoped plugin's body, the scoped plugin's
+    /// filename — so a caller can DISPLAY from the same body it filtered, not the winner). Holds nothing.</summary>
+    public IEnumerable<(FormKey fk, int depth, IMajorRecordGetter body, string source)> RecordsIn(
         IReadOnlyList<string> plugins, IReadOnlyList<Type>? getterTypes)
     {
         foreach (int i in ScopeIndices(plugins))
@@ -427,7 +428,7 @@ public sealed class LoadOrderResolver : IDisposable
                     : getterTypes.SelectMany(t => ov.EnumerateMajorRecords(t, throwIfUnknown: true));
                 foreach (var rec in recs)
                     if (_index.TryGetValue(rec.FormKey, out var e))
-                        yield return (rec.FormKey, e.count, rec);
+                        yield return (rec.FormKey, e.count, rec, _names[i]);   // _names[i] = this scoped plugin's filename (the source body)
             }
             finally { (ov as IDisposable)?.Dispose(); }
         }

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -31,6 +31,10 @@ if (args.Length > 0 && args[0] == "depth-leak-guard") return DepthLeakProbe.RunG
 // with known field values, asserts the evaluator's matched set == a brute-force reference + the Q3 teeth.
 if (args.Length > 0 && args[0] == "value-predicate-guard") return ValuePredicateProbe.RunGuard(args[1..]);
 
+// Winner-vs-source display (wishlist #8): SELF-CONTAINED CI regression guard — synthesizes a master + two overrides
+// (B wins) and asserts RecordsIn pairs each yielded body with its OWN source plugin, the winner stream with the winner.
+if (args.Length > 0 && args[0] == "source-display-guard") return SourceDisplayProbe.RunGuard(args[1..]);
+
 // One-shot verify (decision #1): confirm the xEdit 4-char signature reflection path.
 if (args.Length > 0 && args[0] == "sig") return Probe.RunSig();
 

--- a/src/housecarl-generator/SourceDisplayProbe.cs
+++ b/src/housecarl-generator/SourceDisplayProbe.cs
@@ -1,0 +1,135 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// REGRESSION GUARD (standing CI instrument) for the winner-vs-source DISPLAY fix (session-review wishlist #8):
+/// <c>cross_plugin_query</c>'s per-match render must show the body the scan FILTERED — under <c>plugins=[X]</c> the
+/// scoped plugin's OWN override, under <c>type=</c> the load-order winner — and never silently the winner under a
+/// <c>plugins=</c> scope (the pre-existing bug: filter on X's value, display the winner's, which can CONTRADICT the
+/// filter you typed).
+///
+/// Self-contained, in the pattern of <c>pkcu-regression</c> / <c>value-predicate-guard</c> / <c>depth-leak-guard</c>:
+/// synthesizes a 3-plugin order ON DISK — a master plus two overrides of ONE weapon with DIFFERENT Damage, the
+/// higher-priority override winning — then drives the product CORE primitives the render rests on:
+/// <see cref="LoadOrderResolver.RecordsIn"/> (the scoped-plugin stream, which now carries the source plugin) and
+/// <see cref="LoadOrderResolver.WinnerRecordsOfType"/> (the winner stream). It asserts every yielded record is
+/// paired with the CORRECT source plugin name AND that plugin's OWN body value (A⇒50, B⇒99), that a single-plugin
+/// scope yields only that plugin's body, that a multi-plugin scope yields each plugin's own body once, and that the
+/// winner stream yields the WINNER's body (99). RED if <c>RecordsIn</c> ever yields a body whose value doesn't match
+/// its source plugin — the exact mispairing that would make the render display a value contradicting the filter.
+///
+/// SCOPE NOTE: the mcp render wiring itself (<c>CrossQueryOutcome.Sources</c> → <c>ResolveRead(fk, source)</c> in
+/// housecarl-mcp) is NOT reachable from this harness — the generator references housecarl-core only (the same
+/// project boundary that makes the bsa/compile probes skip external tools). That last hop is proven end-to-end by
+/// the re-runnable LIVE stdio round-trip on the ARR order (recorded in the plan + handoff). This guard locks the
+/// by-construction CORE contract that wiring merely threads: source plugin ↔ its own body, never the winner's.
+///
+/// Run: <c>dotnet run --project src/housecarl-generator -- source-display-guard</c>
+/// </summary>
+public static class SourceDisplayProbe
+{
+    static int _pass, _fail;
+
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  REGRESSION GUARD — winner-vs-source display (cross_plugin_query plugins= scope)  ################");
+        Console.WriteLine();
+
+        var dir = Path.Combine(Path.GetTempPath(), "hc_source_display_guard");
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); } catch { }
+        Directory.CreateDirectory(dir);
+
+        const string masterName = "hcSrcMaster.esp", aName = "hcSrcA.esp", bName = "hcSrcB.esp";
+        const ushort dmgMaster = 10, dmgA = 50, dmgB = 99;       // distinct per plugin so a mispaired body is provable
+        var masterPath = Path.Combine(dir, masterName);
+        var aPath = Path.Combine(dir, aName);
+        var bPath = Path.Combine(dir, bName);
+
+        try
+        {
+            // ---- 1. MASTER: one weapon, Damage=10. Masterless (CI has no game files — it references nothing). ----
+            var master = new SkyrimMod(ModKey.FromNameAndExtension(masterName), SkyrimRelease.SkyrimSE);
+            var mw = master.Weapons.AddNew();
+            mw.EditorID = "hcSrcSword";
+            mw.BasicStats = new WeaponBasicStats { Damage = dmgMaster };
+            var fk = mw.FormKey;                                  // <id>:hcSrcMaster.esp — the one FormKey all three touch
+            master.BeginWrite.ToPath(masterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+            // ---- 2. OVERRIDE A: the SAME weapon, Damage=50. Masters [master]. (raw BeginWrite writes only the
+            //         actually-referenced master — no Skyrim/Update baseline injection, so the order stays self-contained). ----
+            var aMod = new SkyrimMod(ModKey.FromNameAndExtension(aName), SkyrimRelease.SkyrimSE);
+            ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(aMod, mw)).BasicStats = new WeaponBasicStats { Damage = dmgA };
+            aMod.BeginWrite.ToPath(aPath).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
+
+            // ---- 3. OVERRIDE B: the SAME weapon, Damage=99 — highest priority, so it WINS. Masters [master]. ----
+            var bMod = new SkyrimMod(ModKey.FromNameAndExtension(bName), SkyrimRelease.SkyrimSE);
+            ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(bMod, mw)).BasicStats = new WeaponBasicStats { Damage = dmgB };
+            bMod.BeginWrite.ToPath(bPath).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
+
+            Console.WriteLine($"-- synthesized {masterName} (dmg {dmgMaster}) < {aName} (dmg {dmgA}) < {bName} (dmg {dmgB}); {bName} WINS --");
+            Console.WriteLine();
+
+            // ---- 4. BUILD the order (master < A < B) and drive the product primitives. ----
+            using var resolver = LoadOrderResolver.Build(new[] { masterPath, aPath, bPath });
+            var weap = new[] { typeof(IWeaponGetter) };
+
+            var w = resolver.ResolveWinner(fk);
+            Check($"winner is {bName} (highest override wins)",
+                  w is not null && string.Equals(w.Value.WinnerPlugin, bName, StringComparison.OrdinalIgnoreCase));
+
+            // (a) plugins=[A] → the weapon ONCE, source=A, A's OWN body (dmg 50) — NOT the winner's 99.
+            CheckScope("plugins=[A]", resolver.RecordsIn(new[] { aName }, weap).ToList(), fk, aName, dmgA);
+
+            // (b) plugins=[B] → source=B, dmg 99 (here B's own == the winner, but it's reached as the SOURCE, not the winner fetch).
+            CheckScope("plugins=[B]", resolver.RecordsIn(new[] { bName }, weap).ToList(), fk, bName, dmgB);
+
+            // (c) plugins=[A,B] → the weapon yielded ONCE PER scoped plugin, each paired with its OWN body (A/50, B/99).
+            var ab = resolver.RecordsIn(new[] { aName, bName }, weap).Where(x => x.fk == fk).ToList();
+            Check("plugins=[A,B]: weapon yielded once per scoped plugin (2)", ab.Count == 2);
+            Check($"plugins=[A,B]: A's yield → source={aName} & dmg={dmgA}", ab.Any(x => Eq(x.source, aName) && DmgOf(x.body) == dmgA));
+            Check($"plugins=[A,B]: B's yield → source={bName} & dmg={dmgB}", ab.Any(x => Eq(x.source, bName) && DmgOf(x.body) == dmgB));
+            Check("plugins=[A,B]: EVERY yield's body matches its source plugin (no mispairing — the heart of the fix)",
+                  ab.All(x => (Eq(x.source, aName) && DmgOf(x.body) == dmgA) || (Eq(x.source, bName) && DmgOf(x.body) == dmgB)));
+
+            // (d) type= (winner scope) → the weapon ONCE, the WINNER's body (dmg 99). type= display stays the winner, UNCHANGED.
+            var winners = resolver.WinnerRecordsOfType(weap).Where(x => x.fk == fk).ToList();
+            Check("type=: weapon yielded once (the winner only)", winners.Count == 1);
+            Check($"type=: winner body is B's (dmg {dmgB}) — type= scope displays the winner, unchanged",
+                  winners.Count == 1 && DmgOf(winners[0].body) == dmgB);
+
+            Console.WriteLine();
+            Console.WriteLine($"=== source-display-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
+            return _fail == 0 ? 0 : 1;
+        }
+        catch (Exception ex) { Console.WriteLine($"   FAIL (unexpected): {ex.GetType().Name}: {ex.Message}"); return 1; }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
+
+    // ---- helpers ---------------------------------------------------------------------------------------------
+
+    static ushort? DmgOf(IMajorRecordGetter body) => (body as IWeaponGetter)?.BasicStats?.Damage;
+    static bool Eq(string? a, string b) => string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>A single-plugin scope must yield the FormKey exactly once, with that plugin as the source and that
+    /// plugin's OWN body value — not the winner's.</summary>
+    static void CheckScope(string label, List<(FormKey fk, int depth, IMajorRecordGetter body, string source)> yields,
+                           FormKey fk, string expectSource, ushort expectDmg)
+    {
+        var hit = yields.Where(x => x.fk == fk).ToList();
+        Check($"{label}: weapon yielded once", hit.Count == 1);
+        if (hit.Count != 1) return;
+        Check($"{label}: source = {expectSource}", Eq(hit[0].source, expectSource));
+        Check($"{label}: body is {expectSource}'s OWN (dmg {expectDmg}, not the winner)", DmgOf(hit[0].body) == expectDmg);
+    }
+
+    static void Check(string label, bool ok)
+    {
+        Console.WriteLine($"   [{(ok ? "PASS" : "FAIL")}] {label}");
+        if (ok) _pass++; else _fail++;
+    }
+}

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -437,7 +437,10 @@ public sealed class LoadOrderService : IDisposable
                         if (predicate.FatalError is not null) break;          // numeric op vs non-numeric field — abort + surface (Q3)
                         continue;
                     }
-                    if (!seen.Add(fk)) continue;                              // de-dup (a FK can recur across scoped plugins)
+                    // De-dup (a FK can recur across scoped plugins). This runs AFTER the filters, so under
+                    // plugins=[A,B] the source recorded for a shared FK is the FIRST scoped plugin (in plugins=
+                    // array order) whose body PASSED the filters — deterministic, and it's the body we'll display.
+                    if (!seen.Add(fk)) continue;
                     total++;
                     if (keys.Count < limit)                                   // in-hand body → fill the summary for free
                     {

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -406,6 +406,7 @@ public sealed class LoadOrderService : IDisposable
         catch (ArgumentException ex) { return CrossQueryOutcome.Fail(ex.Message); }   // unknown type
 
         var keys = new List<FormKey>();
+        var sources = new List<string?>();                                    // parallel to keys: the plugin whose body matched (null ⇒ winner), so the render displays the SAME body it filtered
         List<RecordSummary>? prefilled = (hasType || hasPlugins) ? new() : null;   // parallel to keys; null = renderer fills lazily
         int total = 0;
 
@@ -417,9 +418,12 @@ public sealed class LoadOrderService : IDisposable
             var seen = new HashSet<FormKey>();
             try
             {
-                var stream = hasPlugins ? resolver.RecordsIn(plugins!, types)  // the scoped plugin's own body
-                                        : resolver.WinnerRecordsOfType(types!); // the load-order winner's body
-                foreach (var (fk, depth, body) in stream)
+                // Carry the SOURCE plugin per record so the render shows the body the scan filtered (not the winner):
+                // plugins= → the scoped plugin's filename; type= → null (⇒ the winner, the WinnerRecordsOfType body).
+                IEnumerable<(FormKey fk, int depth, IMajorRecordGetter body, string? source)> stream =
+                    hasPlugins ? resolver.RecordsIn(plugins!, types).Select(x => (fk: x.fk, depth: x.depth, body: x.body, source: (string?)x.source))  // the scoped plugin's own body
+                               : resolver.WinnerRecordsOfType(types!).Select(x => (fk: x.fk, depth: x.depth, body: x.body, source: (string?)null));    // the load-order winner's body
+                foreach (var (fk, depth, body, source) in stream)
                 {
                     if (conflictsOnly && depth <= 1) continue;
                     if (!string.IsNullOrEmpty(editoridContains)
@@ -438,6 +442,7 @@ public sealed class LoadOrderService : IDisposable
                     if (keys.Count < limit)                                   // in-hand body → fill the summary for free
                     {
                         keys.Add(fk);
+                        sources.Add(source);                                  // the body we filtered IS the body we'll display (null ⇒ winner)
                         prefilled!.Add(new RecordSummary(fk, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID,
                                                          resolver.ResolveWinner(fk)?.WinnerPlugin ?? "?", depth, null));
                     }
@@ -453,10 +458,10 @@ public sealed class LoadOrderService : IDisposable
             foreach (var fk in resolver.ConflictKeys())
             {
                 total++;
-                if (keys.Count < limit) keys.Add(fk);
+                if (keys.Count < limit) { keys.Add(fk); sources.Add(null); }   // no scoped plugin → display the winner
             }
         }
-        return new CrossQueryOutcome(keys, prefilled, total, total > keys.Count, null, predicate?.AccountingNote());
+        return new CrossQueryOutcome(keys, prefilled, total, total > keys.Count, null, predicate?.AccountingNote(), sources);
     }
 
     // ---- writes (§8.4 Beat C: housecarl_set_field / housecarl_bulk_apply) -------------------------------
@@ -892,11 +897,13 @@ public sealed record ReadOutcome(
 /// recoverable, named reason — bad filter combo / unknown type / plugin not in order). Otherwise <see cref="Keys"/>
 /// are the matched FormKeys (at most `limit`); <see cref="Prefilled"/> (parallel to Keys) carries the in-hand
 /// summaries for the type/plugins paths, or is null for the conflicts_only-alone path (the renderer fills those
-/// lazily, bounded by max_chars). <see cref="Total"/> is the true match count; <see cref="Capped"/> is true when
-/// Total exceeded what was returned.</summary>
+/// lazily, bounded by max_chars). <see cref="Sources"/> (parallel to Keys) is the plugin whose body produced each
+/// match — the scoped plugin under plugins=, or null under type=/conflicts_only (⇒ the renderer displays the
+/// winner) — so the detail render shows the SAME body the scan filtered and display never contradicts filter.
+/// <see cref="Total"/> is the true match count; <see cref="Capped"/> is true when Total exceeded what was returned.</summary>
 public sealed record CrossQueryOutcome(
     IReadOnlyList<FormKey> Keys, IReadOnlyList<RecordSummary>? Prefilled, int Total, bool Capped, string? Error,
-    string? PredicateNote = null)
+    string? PredicateNote = null, IReadOnlyList<string?>? Sources = null)
 {
     public static CrossQueryOutcome Fail(string error) => new(Array.Empty<FormKey>(), null, 0, false, error);
 }

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -191,7 +191,7 @@ static class Wire
             var fk = q.Keys[i];
             if (detail)
             {
-                var o = svc.ResolveRead(fk, null, fields, conflictTree);
+                var o = svc.ResolveRead(fk, q.Sources is { } src ? src[i] : null, fields, conflictTree);   // display the body the scan filtered: scoped plugin under plugins=, else winner
                 sb.Append('\n');
                 if (o.Error is not null) sb.Append(fk).Append(": error: ").Append(o.Error).Append('\n');
                 else { AppendRecord(sb, o, cap); if (conflictTree) AppendConflictTree(sb, svc, o, fields, cap); }


### PR DESCRIPTION
## What & why

`cross_plugin_query` has two scope modes. `type=` streams each record's **load-order winner**; `plugins=[X]` streams each scoped plugin's **own override**. The body **filters** (`where=`, `editorid_contains=`, `references=`) correctly test whichever body the scope streams — under `plugins=[X]` they test X's own body. But the per-match **display** (`fields=` / the `conflict_tree` header) was rendered via `svc.ResolveRead(fk, null, …)`, and a `null` plugin always resolves the **winner** — so under `plugins=[X]` you could **filter on X's value but be shown the winner's**, a value that can directly contradict the filter you typed. Labeled (`fields (from <winner>)`), so not strictly silent, but misleading — and sharp once `where=` exists (filter `Damage>=50`, see `Damage=9`).

This is **wishlist #8** from the 2026-06-08 ARR session review (`HCSR-2026-06-08-01`) — pre-existing, shared by all body filters under `plugins=`, surfaced by the field-value-predicate build (#22) and deliberately kept out of its scope as a cross-cutting render-layer change.

Design fork was surfaced to the maintainer; **(a) source-follows-scope** chosen: under `plugins=`, display the scoped plugin's own body so filter and display agree.

## The change (by construction)

- `LoadOrderResolver.RecordsIn` now yields the **source plugin's filename** alongside each body (`_names[i]`, already in scope at the yield).
- `LoadOrderService.CrossQuery` carries it **per match** in `CrossQueryOutcome.Sources` (parallel to `Keys`; `null` under `type=`/`conflicts_only` ⇒ the winner). The winner stream is projected to a `null` source, so **`type=` scope is unchanged**.
- `Wire.RenderCrossQuery`'s detail branch passes `Sources[i]` to `ResolveRead` — so **the body displayed is the body the scan filtered**.

No new read machinery: it reuses the existing `ResolveRead(fk, plugin)` path that `read_record plugin=` already drives. The per-match header still prints `winner=` in every case, so "what wins" is never hidden — only the displayed field *values* follow the scope.

`WinnerRecordsOfType` (10 generator-probe callers) is untouched; only `RecordsIn` (single caller) changed signature.

## Proof

**Self-contained CI guard — `source-display-guard` (13/13):** synthesizes a master + two overrides of one weapon (distinct Damage, B wins) and asserts `RecordsIn` pairs each yielded body with its **own** source plugin, and `WinnerRecordsOfType` with the winner. Registered in CI. All prior guards still green (value-predicate 31/31, pkcu, depth-leak).

> Scope note: the guard locks the **core** primitive (`RecordsIn` body↔source pairing) — the most the generator can reach (it references housecarl-core only, the same boundary the bsa/compile probes skip across). The final render hop (`Sources` → `ResolveRead`) is proven by the live run below, not CI. Closing that gap is tracked as separate follow-up work (CI-cover the mcp/render layer).

**Live, on the real ARR 2.0 order** (3443 plugins), freshly-built binary driven over stdio — `01359D:Skyrim.esm` (REQ_Weapon_Iron_Greatsword), Requiem's own Damage `16` vs winner's `96`:

| Query | Result |
|---|---|
| `plugins=[Requiem.esp] type=WEAP fields=[BasicStats.Damage]` | `fields (from Requiem.esp): Damage = 16` ✅ (was `(from winner): 96`) |
| + `where="BasicStats.Damage = 16"` | matches, shows `16` — filter & display agree ✅ |
| `type=WEAP fields=[BasicStats.Damage]` (winner) | `fields (from <winner>): Damage = 96` — unchanged ✅ |
| `read_record 01359D:Skyrim.esm plugin=Requiem.esp` | `Damage = 16` — ground truth ✅ |

## Test plan

- [x] `dotnet build housecarl.sln` (Debug + Release) clean
- [x] `source-display-guard` 13/13; `value-predicate-guard` 31/31; `pkcu-regression`, `depth-leak-guard` pass
- [x] Live stdio round-trip on ARR 2.0 (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
