### PR TITLE
Stop write self-locking a patch that's active in the load order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,8 @@ jobs:
       # its OWN source plugin (the body the scan filtered), the winner stream with the winner. Locks wishlist #8.
       - name: Probe — winner-vs-source display (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- source-display-guard
+
+      # Self-contained (synthesizes a patch active in its own load order — no external files), runs fully here: a
+      # regression guard locking in the active-patch write self-lock fix (Heisen 2026-06-08, AllMastersExcept).
+      - name: Probe — active-patch write self-lock (self-contained regression guard)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- writelock-guard

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -164,7 +164,12 @@ public sealed class LoadOrderResolver : IDisposable
         /// open handle, not the argument membership, that locks, so the index must be skipped (Overlay never called),
         /// NOT merely filtered from the returned list. Master derivation is unaffected: only the target itself is dropped,
         /// and a patch never links to itself, so every master its records DO reference is still opened + ordered. Excluded
-        /// (unparseable) plugins are retained for the same reason <see cref="AllMasters"/> retains them (see above).</para></summary>
+        /// (unparseable) plugins are retained for the same reason <see cref="AllMasters"/> retains them (see above).</para>
+        ///
+        /// <para>This closes the MASTER-SET source of a target overlay. A write path can hold one from ANOTHER source —
+        /// <see cref="WritePatchBuilder.Apply"/>'s Phase-1 winner fetch, when re-editing a record the active patch itself
+        /// overrides (there the resolved winner IS the target) — which this can't reach; <see cref="ReleaseOverlay"/>
+        /// closes that one before the serialize. Both together = no mapped handle on the target survives the write.</para></summary>
         public IReadOnlyList<ISkyrimModGetter> AllMastersExcept(string excludeFileName)
         {
             var list = new List<ISkyrimModGetter>(_r._paths.Length);
@@ -172,6 +177,24 @@ public sealed class LoadOrderResolver : IDisposable
                 if (!string.Equals(_r._names[i], excludeFileName, StringComparison.OrdinalIgnoreCase))
                     list.Add(Overlay(i));   // SKIP the target's index — never map the file we're about to overwrite
             return list;
+        }
+
+        /// <summary>Dispose and forget any overlay this session holds on <paramref name="fileName"/> — the file the caller
+        /// is about to serialize to. The SECOND half of the active-patch write fix (with <see cref="AllMastersExcept"/>):
+        /// it closes a target overlay opened from a source AllMastersExcept can't reach — notably
+        /// <see cref="WritePatchBuilder.Apply"/>'s Phase-1 winner fetch (<see cref="GetRecord"/> → <see cref="Overlay"/>),
+        /// which, when you re-edit a record the active patch itself overrides, opens an overlay on the target (the winner
+        /// IS the target) that would otherwise still be mapped at serialize and refuse the overwrite (writelock-apply-probe).
+        ///
+        /// <para>SAFE to call before the write: the only consumer of a fetched winner body is
+        /// <see cref="WriteEngine.GenericGetOrAddAsOverride"/>, which DEEP-COPIES it into the patch mod, so releasing the
+        /// source overlay cannot strip content from the patch about to be written (proven: the edited override reads back
+        /// intact after the release). A no-op when no overlay is open on the file — the common case, and Create/Remove,
+        /// which never winner-fetch the target.</para></summary>
+        public void ReleaseOverlay(string fileName)
+        {
+            var hits = _open.Keys.Where(i => string.Equals(_r._names[i], fileName, StringComparison.OrdinalIgnoreCase)).ToList();
+            foreach (var i in hits) { (_open[i] as IDisposable)?.Dispose(); _open.Remove(i); }
         }
 
         /// <summary>An immutable link cache over ONE named plugin (opened in this session) — built ON DEMAND for the

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -132,7 +132,10 @@ public sealed class LoadOrderResolver : IDisposable
         /// with every master resolvable + ordered, a cross-master patch serializes with a lean only-referenced header.
         /// Opened for THIS write only and disposed with the session (Option B). [Tier-1: the full set — byte-identical to
         /// the xEdit-proven write path. A future Tier-2 could open only the patch-referenced masters so even a write stays
-        /// near-handle-free; a tracked optimization, not done here.]</summary>
+        /// near-handle-free; a tracked optimization, not done here.] To write INTO a patch that is itself ACTIVE in the
+        /// order, the write path uses <see cref="AllMastersExcept"/> instead — mapping the write TARGET would lock it
+        /// against its own overwrite (the active-patch self-lock); that exclusion is a CORRECTNESS fix, separate from the
+        /// Tier-2 perf idea above.</summary>
         public IReadOnlyList<ISkyrimModGetter> AllMasters()
         {
             // Excluded plugins (BuildIndex couldn't fully parse) are INTENTIONALLY retained here — NOT filtered by
@@ -146,6 +149,29 @@ public sealed class LoadOrderResolver : IDisposable
             var arr = new ISkyrimModGetter[_r._paths.Length];
             for (int i = 0; i < arr.Length; i++) arr[i] = Overlay(i);
             return arr;
+        }
+
+        /// <summary>Like <see cref="AllMasters"/>, but NEVER opens an overlay on <paramref name="excludeFileName"/> — the
+        /// file the caller is about to serialize to. THE ACTIVE-PATCH WRITE FIX (Heisen bug 2026-06-08): when the write
+        /// target is itself active in the load order (the normal case once a patch is enabled in MO2), opening a
+        /// memory-mapped overlay on it — as <see cref="AllMasters"/> does for EVERY plugin — LOCKS the file against the
+        /// very overwrite that follows. Windows refuses to replace a mapped file (IOException "used by another process"),
+        /// so the all-or-nothing write writes nothing, and the message misdirects diagnosis at MO2/xEdit.
+        ///
+        /// <para>The fix is to never OPEN that overlay: a patch is never its own master, so the target is never NEEDED in
+        /// the resolve set, and SKIPPING its index leaves no handle to collide with the serialize. Proven (writelock-probe
+        /// 2026-06-08): a held overlay locks the target even when it is excluded from the load-order ARGUMENT — it is the
+        /// open handle, not the argument membership, that locks, so the index must be skipped (Overlay never called),
+        /// NOT merely filtered from the returned list. Master derivation is unaffected: only the target itself is dropped,
+        /// and a patch never links to itself, so every master its records DO reference is still opened + ordered. Excluded
+        /// (unparseable) plugins are retained for the same reason <see cref="AllMasters"/> retains them (see above).</para></summary>
+        public IReadOnlyList<ISkyrimModGetter> AllMastersExcept(string excludeFileName)
+        {
+            var list = new List<ISkyrimModGetter>(_r._paths.Length);
+            for (int i = 0; i < _r._paths.Length; i++)
+                if (!string.Equals(_r._names[i], excludeFileName, StringComparison.OrdinalIgnoreCase))
+                    list.Add(Overlay(i));   // SKIP the target's index — never map the file we're about to overwrite
+            return list;
         }
 
         /// <summary>An immutable link cache over ONE named plugin (opened in this session) — built ON DEMAND for the

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -187,7 +187,9 @@ public static class WritePatchBuilder
 
         // --- Phase 4: serialize ONCE with the FULL known-master set (multi-master). Mutagen keeps the header lean
         //     (only-referenced); a referenced master genuinely absent from the order still fails loud (Q3). ---
-        try { WriteEngine.WritePatch(patchMod, session.AllMasters(), outPath); }
+        // AllMastersExcept (not AllMasters): never map the file we're about to write — were the patch active in the
+        // order, mapping it would lock it against its own overwrite (active-patch self-lock; writelock-probe 2026-06-08).
+        try { WriteEngine.WritePatch(patchMod, session.AllMastersExcept(patchMod.ModKey.FileName.String), outPath); }
         catch (Exception ex)
             { return PatchOutcome.Fail($"serialize failed: {ex.GetType().Name}: {ex.Message}"); }
 
@@ -292,7 +294,9 @@ public static class WritePatchBuilder
 
         // Serialize ONCE with the full known-master set; Mutagen keeps the header lean (only-referenced), so a master
         // orphaned by the removal drops here automatically. A referenced master genuinely absent still fails loud (Q3).
-        try { WriteEngine.WritePatch(patchMod, session.AllMasters(), outPath); }
+        // AllMastersExcept (not AllMasters): never map the file we're about to write — were the patch active in the
+        // order, mapping it would lock it against its own overwrite (active-patch self-lock; writelock-probe 2026-06-08).
+        try { WriteEngine.WritePatch(patchMod, session.AllMastersExcept(patchMod.ModKey.FileName.String), outPath); }
         catch (Exception ex) { return RemovalOutcome.Fail($"serialize after removal failed: {ex.GetType().Name}: {ex.Message}"); }
 
         // Re-open: report the (possibly shrunk) master header + how many records remain (0 ⇒ the patch is now an inert
@@ -396,7 +400,9 @@ public static class WritePatchBuilder
         // --- Phase 4: serialize ONCE with the full known-master set. A created record referencing existing content pulls
         //     its master into the (lean, derived) header; a self-contained one yields a masterless plugin. A referenced
         //     master genuinely absent still fails loud (Q3). ---
-        try { WriteEngine.WritePatch(patchMod, session.AllMasters(), outPath); }
+        // AllMastersExcept (not AllMasters): never map the file we're about to write — were the patch active in the
+        // order, mapping it would lock it against its own overwrite (active-patch self-lock; writelock-probe 2026-06-08).
+        try { WriteEngine.WritePatch(patchMod, session.AllMastersExcept(patchMod.ModKey.FileName.String), outPath); }
         catch (Exception ex) { return CreateOutcome.Fail($"serialize after create failed: {ex.GetType().Name}: {ex.Message}"); }
 
         // --- Phase 5: re-open + report the (derived) master header + bytes. Dispose the overlay so the file isn't left

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -187,8 +187,11 @@ public static class WritePatchBuilder
 
         // --- Phase 4: serialize ONCE with the FULL known-master set (multi-master). Mutagen keeps the header lean
         //     (only-referenced); a referenced master genuinely absent from the order still fails loud (Q3). ---
-        // AllMastersExcept (not AllMasters): never map the file we're about to write — were the patch active in the
-        // order, mapping it would lock it against its own overwrite (active-patch self-lock; writelock-probe 2026-06-08).
+        // Two-part active-patch self-lock guard (Heisen 2026-06-08 + PR #24 review): no mapped handle on the file we're
+        // about to write may survive to the serialize, from ANY source. ReleaseOverlay closes one we already hold (Apply's
+        // Phase-1 winner fetch, when re-editing the patch's OWN override — there the winner IS the target); AllMastersExcept
+        // keeps the target out of the master set. (writelock-probe / writelock-apply-probe; both halves guarded.)
+        session.ReleaseOverlay(patchMod.ModKey.FileName.String);
         try { WriteEngine.WritePatch(patchMod, session.AllMastersExcept(patchMod.ModKey.FileName.String), outPath); }
         catch (Exception ex)
             { return PatchOutcome.Fail($"serialize failed: {ex.GetType().Name}: {ex.Message}"); }
@@ -294,8 +297,11 @@ public static class WritePatchBuilder
 
         // Serialize ONCE with the full known-master set; Mutagen keeps the header lean (only-referenced), so a master
         // orphaned by the removal drops here automatically. A referenced master genuinely absent still fails loud (Q3).
-        // AllMastersExcept (not AllMasters): never map the file we're about to write — were the patch active in the
-        // order, mapping it would lock it against its own overwrite (active-patch self-lock; writelock-probe 2026-06-08).
+        // Two-part active-patch self-lock guard (Heisen 2026-06-08 + PR #24 review): no mapped handle on the file we're
+        // about to write may survive to the serialize, from ANY source. ReleaseOverlay closes one we already hold (Apply's
+        // Phase-1 winner fetch, when re-editing the patch's OWN override — there the winner IS the target); AllMastersExcept
+        // keeps the target out of the master set. (writelock-probe / writelock-apply-probe; both halves guarded.)
+        session.ReleaseOverlay(patchMod.ModKey.FileName.String);
         try { WriteEngine.WritePatch(patchMod, session.AllMastersExcept(patchMod.ModKey.FileName.String), outPath); }
         catch (Exception ex) { return RemovalOutcome.Fail($"serialize after removal failed: {ex.GetType().Name}: {ex.Message}"); }
 
@@ -400,8 +406,11 @@ public static class WritePatchBuilder
         // --- Phase 4: serialize ONCE with the full known-master set. A created record referencing existing content pulls
         //     its master into the (lean, derived) header; a self-contained one yields a masterless plugin. A referenced
         //     master genuinely absent still fails loud (Q3). ---
-        // AllMastersExcept (not AllMasters): never map the file we're about to write — were the patch active in the
-        // order, mapping it would lock it against its own overwrite (active-patch self-lock; writelock-probe 2026-06-08).
+        // Two-part active-patch self-lock guard (Heisen 2026-06-08 + PR #24 review): no mapped handle on the file we're
+        // about to write may survive to the serialize, from ANY source. ReleaseOverlay closes one we already hold (Apply's
+        // Phase-1 winner fetch, when re-editing the patch's OWN override — there the winner IS the target); AllMastersExcept
+        // keeps the target out of the master set. (writelock-probe / writelock-apply-probe; both halves guarded.)
+        session.ReleaseOverlay(patchMod.ModKey.FileName.String);
         try { WriteEngine.WritePatch(patchMod, session.AllMastersExcept(patchMod.ModKey.FileName.String), outPath); }
         catch (Exception ex) { return CreateOutcome.Fail($"serialize after create failed: {ex.GetType().Name}: {ex.Message}"); }
 

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -149,6 +149,10 @@ if (args.Length > 0 && args[0] == "writelock-guard") return WriteLockProbe.RunGu
 // overlay on the target (when re-editing an own override) that survives AllMastersExcept and still self-locks the serialize.
 if (args.Length > 0 && args[0] == "writelock-apply-probe") return WriteLockProbe.RunApplyResidualProbe(args[1..]);
 
+// Active-patch write self-lock follow-up (PR #24 review #2): REAL-DATA proof that a NESTED record (PlacedObject, via the
+// link-cache context path) survives the re-edit-own-override case under the new "release overlay before serialize" invariant.
+if (args.Length > 0 && args[0] == "writelock-nested-proof") return WriteLockProbe.RunNestedProof(args[1..]);
+
 // External-tool bridge (step 1) proof: the pure core pieces housecarl_set_tool_path + the riders ride — shared-config
 // clobber-safety, path validation, the missing-dependency forcing prompt, and canonical-home auto-detect.
 if (args.Length > 0 && args[0] == "tool-bridge") return ToolBridgeProbe.Run(args[1..]);

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -141,9 +141,13 @@ if (args.Length > 0 && args[0] == "atrest-probe") return AtRestProbe.RunProbe(ar
 // into a patch whose own overlay is held by AllMasters() (direct vs temp+Replace vs release-then-write). Decides the fix.
 if (args.Length > 0 && args[0] == "writelock-probe") return WriteLockProbe.RunProbe(args[1..]);
 
-// Active-patch write self-lock (Heisen bug 2026-06-08): SELF-CONTAINED CI regression guard — drives CreateRecords into an
-// ACTIVE patch + asserts the write succeeds (a control proves the lock still reproduces). RED before the AllMastersExcept fix.
+// Active-patch write self-lock (Heisen bug 2026-06-08): SELF-CONTAINED CI regression guard — drives a real product write
+// (RemoveRecords + the Apply winner-fetch path) into an ACTIVE patch, asserts success (a control proves the lock reproduces).
 if (args.Length > 0 && args[0] == "writelock-guard") return WriteLockProbe.RunGuard(args[1..]);
+
+// Active-patch write self-lock follow-up (PR #24 review): EXPLORATORY — prove Apply's Phase-1 winner-fetch opens a SECOND
+// overlay on the target (when re-editing an own override) that survives AllMastersExcept and still self-locks the serialize.
+if (args.Length > 0 && args[0] == "writelock-apply-probe") return WriteLockProbe.RunApplyResidualProbe(args[1..]);
 
 // External-tool bridge (step 1) proof: the pure core pieces housecarl_set_tool_path + the riders ride — shared-config
 // clobber-safety, path validation, the missing-dependency forcing prompt, and canonical-home auto-detect.

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -137,6 +137,14 @@ if (args.Length > 0 && args[0] == "handle-probe") return HandleProbe.RunProbe(ar
 // Cleanup-gotcha / Option-B AT-REST proof: drive the REAL product code (resolver Build -> read via session -> create via write path) on temp copies and assert files are renamable at rest (zero handles held).
 if (args.Length > 0 && args[0] == "atrest-probe") return AtRestProbe.RunProbe(args[1..]);
 
+// Active-patch write self-lock (Heisen bug 2026-06-08): EXPLORATORY — map the Windows file-sharing semantics of writing
+// into a patch whose own overlay is held by AllMasters() (direct vs temp+Replace vs release-then-write). Decides the fix.
+if (args.Length > 0 && args[0] == "writelock-probe") return WriteLockProbe.RunProbe(args[1..]);
+
+// Active-patch write self-lock (Heisen bug 2026-06-08): SELF-CONTAINED CI regression guard — drives CreateRecords into an
+// ACTIVE patch + asserts the write succeeds (a control proves the lock still reproduces). RED before the AllMastersExcept fix.
+if (args.Length > 0 && args[0] == "writelock-guard") return WriteLockProbe.RunGuard(args[1..]);
+
 // External-tool bridge (step 1) proof: the pure core pieces housecarl_set_tool_path + the riders ride — shared-config
 // clobber-safety, path validation, the missing-dependency forcing prompt, and canonical-home auto-detect.
 if (args.Length > 0 && args[0] == "tool-bridge") return ToolBridgeProbe.Run(args[1..]);

--- a/src/housecarl-generator/WriteLockProbe.cs
+++ b/src/housecarl-generator/WriteLockProbe.cs
@@ -279,6 +279,82 @@ public static class WriteLockProbe
     }
 
     /// <summary>
+    /// REAL-DATA proof (PR #24 review residual): the writelock-guard's Apply arm uses a FLAT record (Weapon). This proves
+    /// the same re-edit-own-override case for a NESTED record (a PlacedObject — lives in a Cell, so its override goes
+    /// through Apply's link-cache CONTEXT path, where the parent chain is reconstructed). That is the one place the new
+    /// "ReleaseOverlay disposes the target overlay BEFORE serialize" invariant is least obviously safe: the context path
+    /// builds its link cache OVER the target overlay, then the fix disposes it. If the nested override weren't fully
+    /// deep-copied into the patch mod first, releasing the overlay would break the write.
+    ///
+    /// Needs a real master (Skyrim.esm) for a genuine nested record + parent chain — NOT a CI guard (no game data on the
+    /// runner), the same posture as apply-proof / the nested proofs. Step 1 overrides a real PlacedObject into a fresh Q
+    /// (winner = Skyrim.esm); step 2 re-edits it with Q ACTIVE (winner = Q = target → the nested winner-fetch). GREEN =
+    /// the re-edit succeeds and the new Scale reads back. Revert ReleaseOverlay → step 2 goes RED (teeth on the nested path).
+    /// Run: dotnet run --project src/housecarl-generator writelock-nested-proof ["&lt;Data dir with Skyrim.esm&gt;"]
+    /// </summary>
+    public static int RunNestedProof(string[] args)
+    {
+        Console.WriteLine("=== writelock-nested-proof — Apply re-edit of a NESTED own-override into an active patch (real data) ===");
+        string dataDir = args.Length > 0 ? args[0] : @"E:\Skyrim Modding\ARR 2.0\Stock Game\Data";
+        string skyrim = Path.Combine(dataDir, "Skyrim.esm");
+        if (!File.Exists(skyrim)) { Console.Error.WriteLine($"need Skyrim.esm; not found at {skyrim} (pass the Data dir as arg 1)"); return 1; }
+
+        var tmpDir = Path.Combine(Path.GetTempPath(), "hc-writelock-nested");
+        if (Directory.Exists(tmpDir)) Directory.Delete(tmpDir, recursive: true);
+        Directory.CreateDirectory(tmpDir);
+        var rulebook = CorpusRulebook.Load(GenerateCorpus(tmpDir));
+
+        // a REAL nested record: the first PlacedObject (REFR) in Skyrim.esm — lives in a Cell, so overriding it takes
+        // Apply's source-cache CONTEXT path (RecordNeedsSourceCache == true), the path the review flagged.
+        FormKey refrFk;
+        using (var r0 = LoadOrderResolver.Build(new[] { skyrim }))
+        {
+            refrFk = r0.WinnerRecordsOfType(new[] { typeof(IPlacedObjectGetter) }).Select(x => x.fk).FirstOrDefault();
+            if (refrFk.IsNull) { Console.Error.WriteLine("no PlacedObject found in Skyrim.esm"); return 1; }
+        }
+        Console.WriteLine($"-- real nested record: PlacedObject {refrFk} --");
+        string qPath = Path.Combine(tmpDir, "HcNestedProof.esp");
+
+        // STEP 1 — override it into a FRESH patch Q (winner == Skyrim.esm; the normal nested-override path, Q not yet active)
+        using (var r1 = LoadOrderResolver.Build(new[] { skyrim }))
+        {
+            var o = WritePatchBuilder.Apply(r1, rulebook,
+                new[] { new WritePatchBuilder.PatchEdit { Target = refrFk, Path = new[] { "Scale" }, Verb = "Set", Value = "1.5" } },
+                qPath, extend: false);
+            Console.WriteLine($"   step 1  override into fresh Q (winner=Skyrim.esm) : {(o.Success ? "OK" : "FAIL — " + o.Error)}");
+            if (!o.Success) return 1;
+        }
+
+        // STEP 2 — THE TEST: re-edit the SAME nested record now that Q is ACTIVE (winner == Q == target → nested winner-fetch)
+        bool ok; string err;
+        using (var r2 = LoadOrderResolver.Build(new[] { skyrim, qPath }))
+        {
+            var winner = r2.ResolveWinner(refrFk);
+            var o = WritePatchBuilder.Apply(r2, rulebook,
+                new[] { new WritePatchBuilder.PatchEdit { Target = refrFk, Path = new[] { "Scale" }, Verb = "Set", Value = "2.5" } },
+                qPath, extend: true);
+            ok = o.Success; err = o.Error ?? "ok";
+            Console.WriteLine($"   step 2  re-edit own NESTED override (winner={winner?.WinnerPlugin}) : {(ok ? "OK" : "FAIL — " + err)}");
+        }
+        float? scaleBack = ReadPlacedScale(qPath, refrFk);
+        bool landed = scaleBack.HasValue && Math.Abs(scaleBack.Value - 2.5f) < 0.001f;
+        Console.WriteLine($"   nested edit landed (Scale==2.5) : {(landed ? "PASS" : $"FAIL (scale={scaleBack?.ToString() ?? "null"})")}");
+
+        bool pass = ok && landed;
+        Console.WriteLine($"=== writelock-nested-proof: {(pass ? "PASS — nested re-edit survives ReleaseOverlay-before-serialize" : "FAIL")} ===");
+        try { Directory.Delete(tmpDir, recursive: true); } catch { }
+        return pass ? 0 : 1;
+    }
+
+    static float? ReadPlacedScale(string path, FormKey fk)
+    {
+        ISkyrimModGetter? ov = null;
+        try { ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE); return ov.EnumerateMajorRecords<IPlacedObjectGetter>().FirstOrDefault(r => r.FormKey == fk)?.Scale; }
+        catch { return null; }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    /// <summary>
     /// EXPLORATORY follow-up (PR #24 review, 2026-06-08): the AllMastersExcept fix closes the master-set overlay on the
     /// target, but <see cref="WritePatchBuilder.Apply"/> has a SECOND overlay source — its Phase-1 winner fetch
     /// (<see cref="LoadOrderResolver.GetRecord"/> → <c>session.Overlay(idx)</c> on the WINNER plugin). When you re-edit a

--- a/src/housecarl-generator/WriteLockProbe.cs
+++ b/src/housecarl-generator/WriteLockProbe.cs
@@ -1,0 +1,277 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// Exploratory probe for the active-patch write self-lock (Heisen bug report 2026-06-08): houseCARL fails to write
+/// into a patch that is ACTIVE in the resolved load order, because <c>OverlaySession.AllMasters()</c> opens a
+/// memory-mapped overlay on EVERY active plugin — INCLUDING the write target — and Mutagen then serializes directly
+/// onto that same path while the map is still alive. Windows refuses the overwrite (IOException "used by another
+/// process"), so the all-or-nothing write writes nothing.
+///
+/// This maps the Windows file-sharing semantics precisely, to decide the fix. The honest open question from the
+/// triage: the report recommends "serialize to a temp + File.Replace" as a COMPLETE fix on its own — but on Windows
+/// the final swap must still rename/delete the original, which the same non-shareable map may ALSO block. So we test:
+///
+///   A  direct overwrite while an overlay on the target is HELD          (= the current bug)            → expect FAIL
+///   B  temp write + File.Replace  while the overlay is HELD             (report's "#1 alone")          → ?
+///   B2 temp write + File.Move(overwrite) while the overlay is HELD      (the Move variant)             → ?
+///   C  Dispose the overlay, THEN direct overwrite                       (release-then-write)           → expect OK
+///   D  temp write (overlay HELD) → Dispose overlay → File.Replace       (temp + release-then-swap)     → expect OK
+///   E  CreateFromBinary(target) [the extend read] → direct overwrite    (does the extend read lock?)   → expect OK
+///   F  overlay HELD but EXCLUDED from WithLoadOrder, direct overwrite   (is the HANDLE the lock, not   → expect FAIL
+///                                                                        merely its presence in WLO?)
+///
+/// F is the load-bearing distinction for the fix: if a held-but-excluded handle still blocks the write, the fix must
+/// NOT OPEN an overlay on the target at all (skip its index in AllMasters), not merely drop it from the returned set.
+///
+/// Self-contained — synthesizes its own .esp in TEMP; no game data. Run: dotnet run --project src/housecarl-generator writelock-probe
+/// </summary>
+public static class WriteLockProbe
+{
+    public static int RunProbe(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" houseCARL writelock-probe — active-patch write self-lock semantics");
+        Console.WriteLine("================================================================");
+
+        var tmpDir = Path.Combine(Path.GetTempPath(), "hc-writelock-probe");
+        if (Directory.Exists(tmpDir)) Directory.Delete(tmpDir, recursive: true);
+        Directory.CreateDirectory(tmpDir);
+
+        var modKey = new ModKey("HcWriteLockProbe", ModType.Plugin);
+        string target = Path.Combine(tmpDir, modKey.FileName.String);
+
+        // Establish an existing patch on disk (no overlay held afterward — a clean baseline file to overwrite).
+        Serialize(BuildPatch(modKey, "Init"), Array.Empty<ISkyrimModGetter>(), target);
+        Console.WriteLine($"baseline patch on disk: {target} ({new FileInfo(target).Length} bytes)");
+        Console.WriteLine();
+
+        // ---- A: direct overwrite while an overlay on the target is HELD (the real AllMasters() situation) ----
+        Console.WriteLine("A  direct overwrite, overlay on target HELD (= the bug):");
+        {
+            var ov = OpenAndFault(target);
+            bool ok = Try(() => Serialize(BuildPatch(modKey, "A"), new[] { ov }, target), out var err);
+            Dispose(ov);
+            Report(ok, err, expectFail: true);
+        }
+
+        // ---- B: temp write + File.Replace while the overlay is HELD (report's "#1 alone") ----
+        Console.WriteLine("B  temp write + File.Replace, overlay on target HELD (report's #1 alone):");
+        {
+            var ov = OpenAndFault(target);
+            string tmp = SwapPath(tmpDir, modKey, "B");   // same .esp filename in a sub-dir (keeps ModKey==filename)
+            bool ok = Try(() =>
+            {
+                Serialize(BuildPatch(modKey, "B"), new[] { ov }, tmp);
+                File.Replace(tmp, target, null);
+            }, out var err);
+            Dispose(ov);
+            CleanTmp(tmp);
+            Report(ok, err, expectFail: false);   // unknown — measuring
+        }
+
+        // ---- B2: temp write + File.Move(overwrite:true) while the overlay is HELD ----
+        Console.WriteLine("B2 temp write + File.Move(overwrite), overlay on target HELD:");
+        {
+            var ov = OpenAndFault(target);
+            string tmp = SwapPath(tmpDir, modKey, "B2");
+            bool ok = Try(() =>
+            {
+                Serialize(BuildPatch(modKey, "B2"), new[] { ov }, tmp);
+                File.Move(tmp, target, overwrite: true);
+            }, out var err);
+            Dispose(ov);
+            CleanTmp(tmp);
+            Report(ok, err, expectFail: false);   // unknown — measuring
+        }
+
+        // ---- C: Dispose the overlay, THEN direct overwrite (release-then-write = the "don't hold the map" fix) ----
+        Console.WriteLine("C  Dispose overlay, THEN direct overwrite (release-then-write):");
+        {
+            var ov = OpenAndFault(target);
+            Dispose(ov);
+            bool ok = Try(() => Serialize(BuildPatch(modKey, "C"), Array.Empty<ISkyrimModGetter>(), target), out var err);
+            Report(ok, err, expectFail: false);
+        }
+
+        // ---- D: temp write (overlay HELD) → Dispose overlay → File.Replace (temp + release-then-swap, crash-safe) ----
+        Console.WriteLine("D  temp write (overlay HELD) → Dispose overlay → File.Replace:");
+        {
+            var ov = OpenAndFault(target);
+            string tmp = SwapPath(tmpDir, modKey, "D");
+            bool ok = Try(() =>
+            {
+                Serialize(BuildPatch(modKey, "D"), new[] { ov }, tmp);
+                Dispose(ov);
+                File.Replace(tmp, target, null);
+            }, out var err);
+            Dispose(ov);   // idempotent if already disposed
+            CleanTmp(tmp);
+            Report(ok, err, expectFail: false);
+        }
+
+        // ---- E: CreateFromBinary(target) [the extend read], then direct overwrite (does the extend read lock?) ----
+        Console.WriteLine("E  CreateFromBinary(target) [extend read] → direct overwrite (no overlay held):");
+        {
+            var loaded = SkyrimMod.CreateFromBinary(target, SkyrimRelease.SkyrimSE);   // eager full parse (the extend path)
+            int n = loaded.EnumerateMajorRecords().Count();
+            bool ok = Try(() => Serialize(BuildPatch(modKey, "E"), Array.Empty<ISkyrimModGetter>(), target), out var err);
+            Report(ok, err, expectFail: false, note: $"(extend read saw {n} record(s))");
+        }
+
+        // ---- F: overlay HELD but EXCLUDED from WithLoadOrder, direct overwrite (is the open HANDLE the lock?) ----
+        Console.WriteLine("F  overlay on target HELD but EXCLUDED from the write's master set, direct overwrite:");
+        {
+            var ov = OpenAndFault(target);
+            bool ok = Try(() => Serialize(BuildPatch(modKey, "F"), Array.Empty<ISkyrimModGetter>(), target), out var err);
+            Dispose(ov);
+            Report(ok, err, expectFail: true,
+                   note: "(if FAIL: the OPEN HANDLE locks regardless of WLO → fix must not OPEN the target overlay)");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine("(see A vs F for the lock mechanism; B/B2 vs D for whether temp-swap needs the map released first)");
+        try { Directory.Delete(tmpDir, recursive: true); } catch { /* a lingering lock would itself be telling */ }
+        return 0;
+    }
+
+    /// <summary>
+    /// SELF-CONTAINED CI REGRESSION GUARD for the active-patch write self-lock (Heisen bug 2026-06-08), in the pattern of
+    /// pkcu-regression / depth-leak-guard. Drives a REAL product write path (<see cref="WritePatchBuilder.RemoveRecords"/>)
+    /// writing INTO a patch that is ACTIVE in the resolver's load order — the exact scenario that locks — and asserts the
+    /// write SUCCEEDS. RemoveRecords is used because it is the one product write method that needs NO CorpusRulebook, so the
+    /// guard stays corpus-free (CI never generates corpus.json); Apply / CreateRecords share the SAME serialize seam
+    /// (AllMastersExcept), so proving the seam here covers all three.
+    ///
+    /// Two assertions, both required (a GREEN must mean "the fix works", never "the lock just doesn't happen here"):
+    ///   CONTROL — hold an overlay on a throwaway COPY of the patch and attempt the OLD full-master-set serialize over it;
+    ///             assert it FAILS with the lock. Proves the environment still reproduces the bug (Mutagen still maps
+    ///             without FILE_SHARE_DELETE). If this stops failing, the guard says so — the fix may be moot / Mutagen changed.
+    ///   FIX     — RemoveRecords drops one record from the ACTIVE patch (the serialize now routes through AllMastersExcept,
+    ///             so the target is never mapped); assert Success + the patch is rewritten carrying the remaining record.
+    ///
+    /// RED before the fix (the serialize throws the IOException, Success=false), GREEN after. Self-contained: synthesizes
+    /// its own masterless .esp in TEMP; no game data. Run: dotnet run --project src/housecarl-generator writelock-guard
+    /// </summary>
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  REGRESSION GUARD — active-patch write self-lock (Heisen 2026-06-08)  ################");
+        Console.WriteLine();
+
+        var tmpDir = Path.Combine(Path.GetTempPath(), "hc-writelock-guard");
+        if (Directory.Exists(tmpDir)) Directory.Delete(tmpDir, recursive: true);
+        Directory.CreateDirectory(tmpDir);
+
+        var modKey = new ModKey("HcWriteLockGuard", ModType.Plugin);
+        string target = Path.Combine(tmpDir, modKey.FileName.String);
+
+        // --- Setup: write a patch carrying TWO records straight through Mutagen (no rulebook/corpus — keeps the guard
+        //     self-contained for CI). Masterless, which is irrelevant to the lock (the lock is purely about the target path). ---
+        FormKey removeFk;
+        {
+            var mod = new SkyrimMod(modKey, SkyrimRelease.SkyrimSE);
+            var kwA = mod.Keywords.AddNew(); kwA.EditorID = "HcWriteLockGuard_A";
+            var kwB = mod.Keywords.AddNew(); kwB.EditorID = "HcWriteLockGuard_B";
+            removeFk = kwB.FormKey;
+            mod.BeginWrite.ToPath(target).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+        }
+        Console.WriteLine($"-- setup: wrote {modKey.FileName} with {CountRecords(target)} record(s) --");
+
+        // --- CONTROL: prove the lock reproduces here — overlay a COPY of the patch, attempt the OLD direct serialize over
+        //     the SAME path with that overlay in the master set, assert it FAILS (so a GREEN below is meaningful). ---
+        bool controlLocked; string controlErr;
+        {
+            var ctlDir = Path.Combine(tmpDir, "control");
+            Directory.CreateDirectory(ctlDir);
+            string ctlTarget = Path.Combine(ctlDir, modKey.FileName.String);   // same filename (== ModKey) in a sub-dir
+            File.Copy(target, ctlTarget);
+            var ov = SkyrimMod.CreateFromBinaryOverlay(ctlTarget, SkyrimRelease.SkyrimSE);
+            _ = ov.EnumerateMajorRecords().FirstOrDefault();                    // force the mmap to fault in
+            var ctlPatch = new SkyrimMod(modKey, SkyrimRelease.SkyrimSE);
+            ctlPatch.Keywords.AddNew().EditorID = "HcWriteLockGuard_Ctrl";
+            controlLocked = !Try(() => ctlPatch.BeginWrite.ToPath(ctlTarget)
+                                               .WithLoadOrder(new ISkyrimModGetter[] { ov }).Write(), out controlErr);
+            Dispose(ov);
+        }
+        Console.WriteLine($"   CONTROL (bug reproduces here)   : {(controlLocked ? "PASS — direct serialize onto a mapped target FAILED as expected" : "FAIL — NO lock; can't prove the fix on this platform")}  [{controlErr}]");
+
+        // --- FIX: the product path — RemoveRecords writes INTO a patch that is ACTIVE in the resolver's order (target is in
+        //     the order), routing the serialize through AllMastersExcept so the target is never mapped. Assert it SUCCEEDS. ---
+        bool fixWrote; int remaining; string fixErr;
+        using (var r1 = LoadOrderResolver.Build(new[] { target }))            // the patch is ACTIVE in the order now
+        {
+            var o1 = WritePatchBuilder.RemoveRecords(r1, new[] { removeFk }, target);
+            fixWrote = o1.Success; remaining = o1.RemainingRecords; fixErr = o1.Error ?? "ok";
+        }
+        int afterFix = CountRecords(target);
+        Console.WriteLine($"   FIX (write into active patch)   : {(fixWrote ? "PASS — RemoveRecords wrote into the active patch" : "FAIL — write into the active patch was refused")}  [{fixErr}]");
+        Console.WriteLine($"   patch rewritten on disk (==1)   : {(afterFix == 1 ? "PASS" : $"FAIL (count={afterFix})")}");
+        Console.WriteLine();
+
+        bool pass = controlLocked && fixWrote && remaining == 1 && afterFix == 1;
+        Console.WriteLine($"=== writelock-guard: {(pass ? "PASS" : "FAIL")} ===");
+        try { Directory.Delete(tmpDir, recursive: true); } catch { /* a lingering lock would itself be telling */ }
+        return pass ? 0 : 1;
+    }
+
+    static int CountRecords(string path)
+    {
+        ISkyrimModGetter? ov = null;
+        try { ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE); return ov.EnumerateMajorRecords().Count(); }
+        catch { return -1; }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    // Build a fresh in-memory patch carrying one MGEF (self-contained, references nothing → masterless, like a created record).
+    static SkyrimMod BuildPatch(ModKey mk, string tag)
+    {
+        var mod = new SkyrimMod(mk, SkyrimRelease.SkyrimSE);
+        var mgef = mod.MagicEffects.AddNew();
+        mgef.EditorID = $"HcWriteLock_{tag}";
+        return mod;
+    }
+
+    // The exact serialize incantation WriteEngine.WritePatch uses (BeginWrite → ToPath → WithLoadOrder → Write).
+    static void Serialize(SkyrimMod mod, ISkyrimModGetter[] masters, string outPath)
+        => mod.BeginWrite.ToPath(outPath).WithLoadOrder(masters).Write();
+
+    // A temp swap target that KEEPS the .esp filename (== the ModKey) so a temp serialize doesn't trip Mutagen's
+    // filename↔ModKey coupling — only the directory differs, so it's a clean stand-in for the real swap target.
+    static string SwapPath(string tmpDir, ModKey mk, string tag)
+    {
+        var dir = Path.Combine(tmpDir, "swap-" + tag);
+        Directory.CreateDirectory(dir);
+        return Path.Combine(dir, mk.FileName.String);
+    }
+
+    static ISkyrimModGetter OpenAndFault(string path)
+    {
+        var ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE);
+        _ = ov.EnumerateMajorRecords().FirstOrDefault();   // force the mmap to fault in (a header-only open may not map)
+        return ov;
+    }
+
+    static void Dispose(ISkyrimModGetter ov) => (ov as IDisposable)?.Dispose();
+    static void CleanTmp(string p) { try { if (File.Exists(p)) File.Delete(p); } catch { } }
+
+    static bool Try(Action op, out string err)
+    {
+        try { op(); err = "ok"; return true; }
+        catch (Exception ex) { err = $"{ex.GetType().Name}: {Flatten(ex.Message)}"; return false; }
+    }
+
+    static string Flatten(string s) => s.Replace("\r", " ").Replace("\n", " ").Trim();
+
+    static void Report(bool ok, string err, bool expectFail, string? note = null)
+    {
+        string verdict = ok
+            ? (expectFail ? "WROTE  (UNEXPECTED — expected a lock)" : "WROTE")
+            : (expectFail ? "FAILED (as expected)" : "FAILED (UNEXPECTED)");
+        Console.WriteLine($"     → {verdict}   [{err}]{(note is null ? "" : "  " + note)}");
+        Console.WriteLine();
+    }
+}

--- a/src/housecarl-generator/WriteLockProbe.cs
+++ b/src/housecarl-generator/WriteLockProbe.cs
@@ -140,22 +140,26 @@ public static class WriteLockProbe
     }
 
     /// <summary>
-    /// SELF-CONTAINED CI REGRESSION GUARD for the active-patch write self-lock (Heisen bug 2026-06-08), in the pattern of
-    /// pkcu-regression / depth-leak-guard. Drives a REAL product write path (<see cref="WritePatchBuilder.RemoveRecords"/>)
-    /// writing INTO a patch that is ACTIVE in the resolver's load order — the exact scenario that locks — and asserts the
-    /// write SUCCEEDS. RemoveRecords is used because it is the one product write method that needs NO CorpusRulebook, so the
-    /// guard stays corpus-free (CI never generates corpus.json); Apply / CreateRecords share the SAME serialize seam
-    /// (AllMastersExcept), so proving the seam here covers all three.
+    /// SELF-CONTAINED CI REGRESSION GUARD for the active-patch write self-lock (Heisen bug 2026-06-08 + PR #24 review), in
+    /// the pattern of pkcu-regression / depth-leak-guard. Drives REAL product write paths INTO a patch that is ACTIVE in
+    /// the resolver's load order — the exact scenario that locks — and asserts the writes SUCCEED. Self-contained (synthesizes
+    /// its own .esp in TEMP, and generates the validator corpus BY CONSTRUCTION in-process for the Apply arm; no game data,
+    /// no checked-in corpus.json). Run: dotnet run --project src/housecarl-generator writelock-guard
     ///
-    /// Two assertions, both required (a GREEN must mean "the fix works", never "the lock just doesn't happen here"):
-    ///   CONTROL — hold an overlay on a throwaway COPY of the patch and attempt the OLD full-master-set serialize over it;
-    ///             assert it FAILS with the lock. Proves the environment still reproduces the bug (Mutagen still maps
-    ///             without FILE_SHARE_DELETE). If this stops failing, the guard says so — the fix may be moot / Mutagen changed.
-    ///   FIX     — RemoveRecords drops one record from the ACTIVE patch (the serialize now routes through AllMastersExcept,
-    ///             so the target is never mapped); assert Success + the patch is rewritten carrying the remaining record.
+    /// Arms (ALL required — a GREEN must mean "the fix works", never "the lock just doesn't happen here"):
+    ///   CONTROL — hold an overlay on a throwaway COPY and attempt the OLD full-master-set serialize over it; assert it
+    ///             FAILS with the lock. Proves the environment still reproduces the bug (Mutagen still maps without
+    ///             FILE_SHARE_DELETE). If this stops failing, the guard says so — the fix may be moot / Mutagen changed.
+    ///   REMOVE  — <see cref="WritePatchBuilder.RemoveRecords"/> drops a record from the ACTIVE patch; covers the MASTER-SET
+    ///             overlay source (closed by AllMastersExcept). Corpus-free.
+    ///   APPLY   — <see cref="WritePatchBuilder.Apply"/> RE-EDITS a record the active patch itself overrides (the winner IS
+    ///             the target), so Apply's Phase-1 winner fetch opens a SECOND overlay on the target — the source
+    ///             AllMastersExcept can't reach (PR #24 review). Covers the fix's ReleaseOverlay half; assert Success AND
+    ///             the edited value lands. A RemoveRecords-only guard CANNOT catch this (Remove reads eagerly, no winner
+    ///             fetch) — which is exactly why this arm exists.
     ///
-    /// RED before the fix (the serialize throws the IOException, Success=false), GREEN after. Self-contained: synthesizes
-    /// its own masterless .esp in TEMP; no game data. Run: dotnet run --project src/housecarl-generator writelock-guard
+    /// RED before the fix (the serialize throws the IOException, Success=false), GREEN after — verified for BOTH the master-set
+    /// (revert AllMastersExcept → REMOVE+APPLY red) and the winner-fetch (revert ReleaseOverlay → APPLY red) halves.
     /// </summary>
     public static int RunGuard(string[] args)
     {
@@ -212,10 +216,140 @@ public static class WriteLockProbe
         Console.WriteLine($"   patch rewritten on disk (==1)   : {(afterFix == 1 ? "PASS" : $"FAIL (count={afterFix})")}");
         Console.WriteLine();
 
-        bool pass = controlLocked && fixWrote && remaining == 1 && afterFix == 1;
+        // --- APPLY ARM (the PR #24 review finding): drive the REAL WritePatchBuilder.Apply re-editing a record the ACTIVE
+        //     patch ITSELF overrides — there the resolved winner IS the target, so Apply's Phase-1 winner fetch opens an
+        //     overlay on the target (a source AllMastersExcept can't reach; ReleaseOverlay must close it before serialize).
+        //     Apply pre-flights the edit through the CorpusRulebook, so we generate the corpus BY CONSTRUCTION in-process
+        //     (no checked-in corpus.json, no game data — the guard stays self-contained, just slower). ---
+        bool applyWrote = false; string applyErr = "ok"; int dmgBack = -1;
+        {
+            var rulebook = CorpusRulebook.Load(GenerateCorpus(tmpDir));
+            var mKey = new ModKey("HcWriteLockGuardMaster", ModType.Master);
+            var qKey = new ModKey("HcWriteLockGuardPatch", ModType.Plugin);
+            string mPath = Path.Combine(tmpDir, mKey.FileName.String);
+            string qPath = Path.Combine(tmpDir, qKey.FileName.String);
+
+            // a master carrying a weapon, then an ACTIVE patch that OVERRIDES it (so re-editing the weapon hits Q's own override)
+            FormKey wfk;
+            {
+                var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
+                var w = m.Weapons.AddNew(); w.EditorID = "HcGuardWeap"; w.BasicStats = new WeaponBasicStats { Damage = 10 };
+                wfk = w.FormKey;
+                m.BeginWrite.ToPath(mPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            }
+            using (var mOv = SkyrimMod.CreateFromBinaryOverlay(mPath, SkyrimRelease.SkyrimSE))
+            {
+                var q = new SkyrimMod(qKey, SkyrimRelease.SkyrimSE);
+                var qW = q.Weapons.GetOrAddAsOverride(mOv.Weapons.First(x => x.FormKey == wfk));
+                qW.BasicStats!.Damage = 20;
+                q.BeginWrite.ToPath(qPath).WithLoadOrder(new ISkyrimModGetter[] { mOv }).Write();
+            }
+
+            using var r2 = LoadOrderResolver.Build(new[] { mPath, qPath });   // Q ACTIVE + highest priority → the weapon's winner is Q (the target)
+            var edit = new WritePatchBuilder.PatchEdit { Target = wfk, Path = new[] { "BasicStats", "Damage" }, Verb = "Set", Value = "777" };
+            var oa = WritePatchBuilder.Apply(r2, rulebook, new[] { edit }, qPath, extend: true);
+            applyWrote = oa.Success; applyErr = oa.Error ?? "ok";
+            dmgBack = ReadWeaponDamage(qPath, wfk);
+        }
+        Console.WriteLine($"   APPLY re-edit own override       : {(applyWrote ? "PASS — Apply wrote into the active patch" : "FAIL — Apply was refused")}  [{applyErr}]");
+        Console.WriteLine($"   edited value landed (damage==777): {(dmgBack == 777 ? "PASS" : $"FAIL (damage={dmgBack})")}");
+        Console.WriteLine();
+
+        bool pass = controlLocked && fixWrote && remaining == 1 && afterFix == 1 && applyWrote && dmgBack == 777;
         Console.WriteLine($"=== writelock-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { /* a lingering lock would itself be telling */ }
         return pass ? 0 : 1;
+    }
+
+    // Generate the validator corpus BY CONSTRUCTION (reflect the linked Mutagen assembly) into a temp dir; return the
+    // corpus.json path — so the Apply arm can pre-flight edits without a checked-in corpus.json (keeps the guard self-contained).
+    static string GenerateCorpus(string tmpDir)
+    {
+        var genDir = Path.Combine(tmpDir, "corpus-gen");
+        CorpusGenerator.GenerateAll(genDir, Path.Combine(tmpDir, "corpus-ref"));
+        return Path.Combine(genDir, "corpus.json");
+    }
+
+    static int ReadWeaponDamage(string path, FormKey fk)
+    {
+        ISkyrimModGetter? ov = null;
+        try { ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE); return ov.Weapons.FirstOrDefault(x => x.FormKey == fk)?.BasicStats?.Damage ?? -1; }
+        catch { return -1; }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    /// <summary>
+    /// EXPLORATORY follow-up (PR #24 review, 2026-06-08): the AllMastersExcept fix closes the master-set overlay on the
+    /// target, but <see cref="WritePatchBuilder.Apply"/> has a SECOND overlay source — its Phase-1 winner fetch
+    /// (<see cref="LoadOrderResolver.GetRecord"/> → <c>session.Overlay(idx)</c> on the WINNER plugin). When you re-edit a
+    /// record an ACTIVE patch already overrides, the winner IS the target patch, so GetRecord opens an overlay on the
+    /// target that survives AllMastersExcept (exp F: it's the open HANDLE, not master-set membership, that locks) and the
+    /// serialize still fails. This reproduces it on the REAL path (resolver.ResolveWinner + resolver.GetRecord +
+    /// WriteEngine.WritePatch + the shipped AllMastersExcept), corpus-free.
+    ///
+    /// RED = the residual is real with the current fix; the second block previews the fix (release the winner-fetch
+    /// overlay before serialize → success). Run: dotnet run --project src/housecarl-generator writelock-apply-probe
+    /// </summary>
+    public static int RunApplyResidualProbe(string[] args)
+    {
+        Console.WriteLine("=== writelock-apply-probe — Apply winner-fetch residual (PR #24 review) ===");
+        var tmpDir = Path.Combine(Path.GetTempPath(), "hc-writelock-apply");
+        if (Directory.Exists(tmpDir)) Directory.Delete(tmpDir, recursive: true);
+        Directory.CreateDirectory(tmpDir);
+
+        var modKey = new ModKey("HcWriteLockApply", ModType.Plugin);
+        string target = Path.Combine(tmpDir, modKey.FileName.String);
+
+        // The active patch carries an override (a self-contained Weapon stands in for "a record the patch overrides").
+        FormKey fk;
+        {
+            var mod = new SkyrimMod(modKey, SkyrimRelease.SkyrimSE);
+            var w = mod.Weapons.AddNew(); w.EditorID = "HcResidual_W";
+            fk = w.FormKey;
+            mod.BeginWrite.ToPath(target).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+        }
+
+        using var resolver = LoadOrderResolver.Build(new[] { target });   // the target is ACTIVE in the order
+        var winner = resolver.ResolveWinner(fk);
+        Console.WriteLine($"-- winner of {fk} = {winner?.WinnerPlugin} (the active target itself — re-editing its own override) --");
+
+        // RED — Apply's winner fetch opens an overlay on the target (Phase 1), still held when AllMastersExcept serializes (Phase 4).
+        {
+            using var session = resolver.OpenSession();
+            _ = resolver.GetRecord(session, winner!.Value.WinnerPlugin, fk);              // opens the TARGET overlay (winner == target)
+            var patchMod = SkyrimMod.CreateFromBinary(target, SkyrimRelease.SkyrimSE);
+            bool ok = Try(() => WriteEngine.WritePatch(patchMod, session.AllMastersExcept(modKey.FileName.String), target), out var err);
+            Console.WriteLine($"   CURRENT fix (AllMastersExcept), winner-fetch overlay HELD : {(ok ? "WROTE — no residual?!" : "FAILED — RESIDUAL CONFIRMED")}");
+            Console.WriteLine($"      [{err}]");
+        }
+
+        // GREEN preview — the FULL Apply mechanism with the fix: winner-fetch → override+edit (Phase 3) → RELEASE the
+        // winner-fetch overlay → serialize. Proves both that the lock clears AND that the deep-copied, edited override
+        // survives releasing its source overlay (so "release before serialize" can't strip content from the patch).
+        {
+            SkyrimMod patchMod;
+            using (var session = resolver.OpenSession())
+            {
+                var body = resolver.GetRecord(session, winner!.Value.WinnerPlugin, fk)!;   // Phase 1: winner fetch (opens TARGET overlay)
+                patchMod = SkyrimMod.CreateFromBinary(target, SkyrimRelease.SkyrimSE);      // Phase 2: extend copy
+                var ov = WriteEngine.GenericGetOrAddAsOverride(patchMod, body, null);       // Phase 3: deep-copy override into the patch
+                ov.EditorID = "HcResidual_W_EDITED";                                        //          ... and edit it
+            }                                                                              // RELEASE the winner-fetch overlay before serialize
+            bool ok = Try(() => WriteEngine.WritePatch(patchMod, Array.Empty<ISkyrimModGetter>(), target), out var err);
+            string edid = ReadEditorId(target, fk);
+            Console.WriteLine($"   FIX PREVIEW (release first; edit survives) : write={(ok ? "OK" : "FAILED " + err)}  edid-read-back=\"{edid}\" (expect HcResidual_W_EDITED)");
+        }
+
+        try { Directory.Delete(tmpDir, recursive: true); } catch { }
+        return 0;
+    }
+
+    static string ReadEditorId(string path, FormKey fk)
+    {
+        ISkyrimModGetter? ov = null;
+        try { ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE); return ov.EnumerateMajorRecords().FirstOrDefault(r => r.FormKey == fk)?.EditorID ?? "(not found)"; }
+        catch (Exception ex) { return "(read failed: " + ex.GetType().Name + ")"; }
+        finally { (ov as IDisposable)?.Dispose(); }
     }
 
     static int CountRecords(string path)


### PR DESCRIPTION
## The bug (reported by DrHeisen + his AI)

Writing into a patch enabled in MO2 (active in the resolved load order) failed with `IOException "used by another process"` and wrote nothing — houseCARL locking the file against itself, not an external lock. The identical write into the **same** patch when it's inactive succeeds.

## Root cause + fix — two overlay sources on the target

When houseCARL serializes a patch it must not hold a memory-mapped overlay on the file it's about to write (Windows refuses to overwrite a mapped file). The write path opened the target from **two** sources — both now closed:

1. **Master-set overlay.** `OverlaySession.AllMasters()` opened an overlay on *every* active plugin to build the serializer's known-master set — including the target. Fixed by `AllMastersExcept(name)`, which skips the target's index (a patch is never its own master, so it's never needed there).
2. **Winner-fetch overlay (found in review).** `Apply` Phase 1 fetches each edit's load-order winner via `resolver.GetRecord` → `session.Overlay`. When you re-edit a record the active patch *already overrides*, the winner **is** the target, so this opens a second overlay on it that `AllMastersExcept` can't reach. Fixed by `OverlaySession.ReleaseOverlay(target)`, called right before each serialize.

Together: no mapped handle on the target survives to the write, from any source. Releasing the winner-fetch overlay is safe because `GenericGetOrAddAsOverride` deep-copies the winner into the patch mod first (the edited override reads back intact after the release).

## Why not "temp file + replace"

The report suggested serialize-to-temp + `File.Replace`. The `writelock-probe` shows that doesn't work alone on Windows: the swap still renames the original, which the same map blocks. It's the open *handle* that locks, not its presence in the master-list argument — so the fix must not *open/hold* the overlay.

## Proof

- **`writelock-guard`** (self-contained CI regression guard) drives real product writes into a patch active in its own order:
  - **CONTROL** — proves the lock still reproduces in-environment (so a green is meaningful).
  - **REMOVE** — `RemoveRecords` into the active patch (the master-set source).
  - **APPLY** — the real `Apply` re-editing the active patch's own override (the winner-fetch source); generates the validator corpus by construction in-process so it stays self-contained.
  - Verified RED→GREEN for **both** halves: revert `AllMastersExcept` → Remove+Apply red; revert `ReleaseOverlay` → Apply red; both in place → green. The earlier Remove-only guard could **not** catch the winner-fetch case — which is exactly why the Apply arm exists.
- **Nested case proven (review #2)** — `writelock-nested-proof` (real-data, like `apply-proof`; not CI): overrides a real `PlacedObject` into a patch, then re-edits it with the patch active (winner == target, through Apply's link-cache *context* path), asserting the write succeeds and the new value reads back. **PASS** — the nested override fully materializes before `ReleaseOverlay` disposes the overlay. Teeth verified: revert `ReleaseOverlay` → the nested re-edit fails with the exact `IOException` and the value stays stuck at the pre-edit one.
- `writelock-probe` / `writelock-apply-probe` are the exploratory probes documenting the Windows file-locking semantics (experiments A–F) and the winner-fetch residual.
- All self-contained CI guards pass; Release build clean (0 warnings). Rebased linear on current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)