### PR TITLE
Release v1.2.1 - field-value query, Nexus descriptions, read/write fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ models — by construction, not a hand-maintained subset.
 
 ### Download — recommended (modders)
 
-1. Download **`houseCARL-1.2.0.zip`** from the [latest release](https://github.com/Avick3110/houseCARL/releases).
+1. Download **`houseCARL-1.2.1.zip`** from the [latest release](https://github.com/Avick3110/houseCARL/releases).
 2. Unzip it and run **`houseCARL-Setup.exe`**.
 3. Pick your host — **`[1] Claude Code`**, **`[2] Codex`**, or **`[3] Both`**. The installer wires
    everything up:
@@ -70,7 +70,7 @@ cd houseCARL
 
 The script regenerates the reflection rulebook, publishes the server framework-dependent (trimming **off**
 — houseCARL is reflection-driven, so trimming would strip types and silently lose coverage), bundles the
-skills, builds the setup utility, and packs `release/houseCARL-1.2.0.zip`. Install the output with
+skills, builds the setup utility, and packs `release/houseCARL-1.2.1.zip`. Install the output with
 `houseCARL-Setup.exe`, `claude --plugin-dir ./dist/housecarl`, or the bundled local-marketplace
 descriptor — see the script header for details.
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "housecarl",
   "displayName": "houseCARL",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Comprehensive data-layer access to your Skyrim SE load order — read any record, author patches into a new plugin, look mods up on Nexus, and look up record schemas, Papyrus signatures, performance reviews, and distributor grammars — in plain English.",
   "author": { "name": "Avick3110" },
   "homepage": "https://github.com/Avick3110/houseCARL",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to houseCARL are documented here. Versioning is [semantic](h
 the `version` in `.claude-plugin/plugin.json` is bumped on each release, so installed users update only
 when it changes.
 
+## 1.2.1 — 2026-06-08
+
+Adds value-based record querying and a fuller Nexus lookup, and fixes several read and write rough edges.
+
+- **Query by field value:** `housecarl_cross_plugin_query` gains a `where=` filter that matches records
+  by a field's *value*, not just by record type or plugin — e.g. `where="MagicSkill = Destruction"` or
+  `where="BasicStats.Damage >= 50"`. Operators are `=`, `!=`, `>`, `>=`, `<`, `<=`, and `contains`, and
+  multiple `where=` conditions are ANDed. It works on any field you can read (by construction — the
+  filterable set is the readable set); a path that can't resolve fails loud rather than silently matching
+  nothing.
+- **Full Nexus descriptions:** `housecarl_nexus_mod` takes an opt-in `description=true` that returns a
+  mod's full Nexus page write-up — cleaned from the page markup to plain text — instead of only the short
+  catalogue summary.
+- **Write into an active patch:** writing into a patch that is itself active in the load order no longer
+  fails with a file-lock error — houseCARL releases every mapped handle on the target before it saves.
+- **Deep reads of condition-bearing records:** a deep read (`depth` 5+) of a record that carries
+  conditions — a perk, spell, or magic effect — no longer floods the output with .NET reflection
+  internals; the descent now stops at the modeled record content, so the real values stay visible.
+- **Scoped queries show the scoped record:** under a `plugins=` scope, `housecarl_cross_plugin_query`
+  now renders each match from that plugin's own record body rather than the global load-order winner.
+
 ## 1.2.0 — 2026-06-07
 
 houseCARL reads Nexus Mods directly, and gains a community-contributed Papyrus performance reviewer.


### PR DESCRIPTION
## houseCARL 1.2.1

Cuts a release for the batch accumulated on `main` since 1.2.0 (PRs #19–#24). No new tools — enhancements to existing tools plus fixes — so this is a **patch** bump, matching the convention (the `depth` param shipped as 1.0.1, the logs rider as 1.1.1).

### Release notes — same text for the GitHub Release body and the Nexus changelog

- New: cross_plugin_query can now filter records by a field's VALUE, not just by type or plugin — e.g. where="MagicSkill = Destruction" or where="BasicStats.Damage >= 50" (operators: = != > >= < <= contains; multiple where= are ANDed). Works on any field you can read.
- New: housecarl_nexus_mod takes an opt-in description=true that returns a mod's full Nexus page write-up as plain text, not just the short catalogue summary.
- Fix: writing into a patch that's already active in your load order no longer fails with a file-lock error.
- Fix: deep reads (depth 5+) of records with conditions (perks, spells, magic effects) no longer flood the output with .NET internals — the actual values are visible again.
- Fix: under a plugins= scope, cross_plugin_query now shows each match from that plugin's own record, not the global load-order winner.

### Changes in this PR
- `plugin/.claude-plugin/plugin.json`: version 1.2.0 → 1.2.1
- `plugin/CHANGELOG.md`: 1.2.1 section (house style — richer than the terse notes above)
- `README.md`: release-zip name → `houseCARL-1.2.1.zip` (both references)

### Proof
- `scripts/build-plugin.ps1` (from this branch): **green** — `houseCARL-1.2.1.zip`, 10.12 MB, 305 entries, leak-check clean, corpus regenerated (133 record types, no anomalies).
- `claude plugin validate ./dist/housecarl --strict`: **✔ passed**.

### After merge — the actual release cut, on your go
1. FF merge → annotated tag `v1.2.1` on the release commit.
2. `gh release create v1.2.1` with `houseCARL-1.2.1.zip` + the release notes above, marked Latest.
3. Manual Nexus upload (zip + paste the same notes) — Nexus has no upload API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
