### PR TITLE
Read the form-mode condition target through the FLOI's .Link (HCBR-2026-06-09-02)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,11 @@ jobs:
       - name: Probe — depth-walker reflection leak (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- depth-leak-guard
 
+      # Self-contained (synthesizes a COBJ HasPerk gate + writes/reopens it as a binary overlay — no external files),
+      # runs fully here: a regression guard locking in the floi form-mode FormKey read fix (HCBR-2026-06-09-02).
+      - name: Probe — ConditionData form-link parameter read (self-contained regression guard)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- floi-read-guard
+
       # Self-contained (synthesizes records with known field values — no external files), runs fully here: a regression
       # guard for the field-value query predicate (cross_plugin_query where=) — matched set == brute-force + the Q3 teeth.
       - name: Probe — field-value query predicate (self-contained regression guard)

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -529,8 +529,12 @@ public static class ReadEngine
 
         if (useAliases == false && usePackData == false)
         {
-            if (val is IFormLinkGetter fl) return LeafRead.Value(fl.FormKey.ToString());   // form mode
-            return LeafRead.None("(floi: form mode but no readable FormKey)");
+            // Form mode. The binary overlay's FLOI is NOT itself a link — it carries the link in its
+            // .Link property, the same accessor the write side reads (ReadFloiFormKey, oracle-proven).
+            // A present-but-null link stays a note, matching plain FormLink leaves (HCBR-2026-06-09-02).
+            if (val is IFormLinkGetter fl) return LeafRead.Value(fl.FormKey.ToString());
+            if (WriteEngine.ReadFloiFormKey(val) is { } fk) return LeafRead.Value(fk.ToString());
+            return LeafRead.None($"(floi: form mode, null or unreadable FormKey on {val.GetType().Name})");
         }
 
         // index mode — read the numeric index defensively (FormLinkOrIndex carries it alongside the link).

--- a/src/housecarl-generator/FloiReadProbe.cs
+++ b/src/housecarl-generator/FloiReadProbe.cs
@@ -1,0 +1,104 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// REGRESSION GUARD (standing CI instrument) for HCBR-2026-06-09-02 — ConditionData form-link parameters
+/// unreadable: a form-mode <c>FormLinkOrIndex</c> read off the BINARY OVERLAY rendered the placeholder
+/// <c>(floi: form mode but no readable FormKey)</c> instead of the FormKey, because the renderer tested
+/// the FLOI itself as an IFormLinkGetter while the overlay carries the link in its <c>.Link</c> property
+/// (the accessor the write side already reads — <see cref="WriteEngine.ReadFloiFormKey"/>, oracle-proven).
+///
+/// Self-contained, in the pattern of <c>pkcu-regression</c>: synthesizes a ConstructibleObject carrying the
+/// universal temper-gate shape from the report — a <c>HasPerk</c> condition whose Perk parameter is a
+/// form-mode FLOI — plus an alias-mode sibling, writes it to a temp folder, re-opens it as a binary overlay
+/// (the product read path's view), and asserts BOTH the mutable and overlay reads render:
+///   Conditions[0].Data.Perk = &lt;the perk's FormKey&gt;   (form mode — RED before the fix on the overlay)
+///   Conditions[1].Data.Perk = alias 7                 (index mode — the report's fix #3)
+///
+/// Run: <c>dotnet run --project src/housecarl-generator floi-read-guard</c>
+/// </summary>
+public static class FloiReadProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  REGRESSION GUARD — floi form-mode FormKey read (HCBR-2026-06-09-02)  ################");
+        Console.WriteLine();
+
+        // Synthesize the report's shape: a COBJ whose HasPerk condition gates on a perk (form mode), plus an
+        // alias-mode sibling. The perk lives in the SAME mod, so the plugin is single-master and self-contained.
+        var mod = new SkyrimMod(new ModKey("hc_floiguard", ModType.Plugin), SkyrimRelease.SkyrimSE);
+        var perk = mod.Perks.AddNew();
+        perk.EditorID = "HC_FloiGuard_GatePerk";
+        var cobj = mod.ConstructibleObjects.AddNew();
+        cobj.EditorID = "HC_FloiGuard_TemperRecipe";
+
+        var formArm = new HasPerkConditionData();
+        formArm.Perk = new FormLinkOrIndex<IPerkGetter>(formArm, perk.FormKey);
+        cobj.Conditions.Add(new ConditionFloat { CompareOperator = CompareOperator.EqualTo, ComparisonValue = 1f, Data = formArm });
+
+        var aliasArm = new HasPerkConditionData { UseAliases = true };
+        aliasArm.Perk = new FormLinkOrIndex<IPerkGetter>(aliasArm, 7u);
+        cobj.Conditions.Add(new ConditionFloat { CompareOperator = CompareOperator.EqualTo, ComparisonValue = 1f, Data = aliasArm });
+
+        var expectForm = perk.FormKey.ToString();
+
+        // Arm 1 — the MUTABLE read (the in-memory shape the write path hands back).
+        var (mutForm, mutAlias) = ReadPerkParams(cobj);
+
+        // Arm 2 — the BINARY OVERLAY read (the product read path's view; where the placeholder reproduced).
+        var tmp = Path.Combine(Path.GetTempPath(), "hc_floiguard_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tmp);
+        string? ovForm, ovAlias;
+        try
+        {
+            var espPath = Path.Combine(tmp, mod.ModKey.FileName);
+            mod.BeginWrite.ToPath(espPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            using var back = SkyrimMod.CreateFromBinaryOverlay(espPath, SkyrimRelease.SkyrimSE);
+            (ovForm, ovAlias) = ReadPerkParams(back.ConstructibleObjects.First());
+        }
+        finally
+        {
+            try { Directory.Delete(tmp, recursive: true); } catch { /* best-effort temp cleanup */ }
+        }
+
+        Console.WriteLine($"-- synthesized COBJ: HasPerk(form -> {expectForm}) + HasPerk(alias 7) --");
+        Console.WriteLine($"   mutable  Conditions[0].Data.Perk : {mutForm ?? "(missing)"}");
+        Console.WriteLine($"   mutable  Conditions[1].Data.Perk : {mutAlias ?? "(missing)"}");
+        Console.WriteLine($"   overlay  Conditions[0].Data.Perk : {ovForm ?? "(missing)"}");
+        Console.WriteLine($"   overlay  Conditions[1].Data.Perk : {ovAlias ?? "(missing)"}");
+        Console.WriteLine();
+
+        bool mutFormOk = mutForm == expectForm;
+        bool mutAliasOk = mutAlias == "alias 7";
+        bool ovFormOk = ovForm == expectForm;
+        bool ovAliasOk = ovAlias == "alias 7";
+        bool pass = mutFormOk && mutAliasOk && ovFormOk && ovAliasOk;
+
+        Console.WriteLine($"   mutable form-mode FormKey read  : {(mutFormOk ? "PASS" : "FAIL")}");
+        Console.WriteLine($"   mutable alias-mode index read   : {(mutAliasOk ? "PASS" : "FAIL")}");
+        Console.WriteLine($"   overlay form-mode FormKey read  : {(ovFormOk ? "PASS" : "FAIL")}  (the HCBR-2026-06-09-02 arm)");
+        Console.WriteLine($"   overlay alias-mode index read   : {(ovAliasOk ? "PASS" : "FAIL")}");
+        Console.WriteLine();
+        Console.WriteLine($"=== floi-read-guard: {(pass ? "PASS" : "FAIL")} ===");
+        return pass ? 0 : 1;
+    }
+
+    /// <summary>Read Conditions at depth through the PRODUCT path (ReadEngine.ReadFields) and pull the two
+    /// Perk-parameter leaves; a leaf that rendered as a note (the bug) comes back as its note text, so a
+    /// failure prints WHAT the renderer said instead of the token.</summary>
+    static (string? form, string? alias) ReadPerkParams(IMajorRecordGetter record)
+    {
+        var rf = ReadEngine.ReadFields(record, new[] { "Conditions" }, 6);
+        string? Leaf(string path)
+        {
+            var f = rf.Fields.FirstOrDefault(fld => fld.Path == path);
+            return f is null ? null : (f.HasValue ? f.Token : f.Note);
+        }
+        return (Leaf("Conditions[0].Data.Perk"), Leaf("Conditions[1].Data.Perk"));
+    }
+}

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -27,6 +27,10 @@ if (args.Length > 0 && args[0] == "pkcu-regression") return PkcuProbe.RunRegress
 // condition whose arm carries a System.Type Parameter1Type, asserts a deep read renders it as one opaque token.
 if (args.Length > 0 && args[0] == "depth-leak-guard") return DepthLeakProbe.RunGuard(args[1..]);
 
+// ConditionData form-link parameter read (HCBR-2026-06-09-02): SELF-CONTAINED CI regression guard — synthesizes a
+// COBJ HasPerk gate, asserts the form-mode FLOI renders its FormKey (and alias mode its index) on overlay + mutable.
+if (args.Length > 0 && args[0] == "floi-read-guard") return FloiReadProbe.RunGuard(args[1..]);
+
 // Field-value query predicate (cross_plugin_query where=): SELF-CONTAINED CI regression guard — synthesizes records
 // with known field values, asserts the evaluator's matched set == a brute-force reference + the Q3 teeth.
 if (args.Length > 0 && args[0] == "value-predicate-guard") return ValuePredicateProbe.RunGuard(args[1..]);


### PR DESCRIPTION
Fixes **HCBR-2026-06-09-02** — ConditionData form-link parameters unreadable: `(floi: form mode but no readable FormKey)`.

## What was broken

Reading a condition's typed form parameter (e.g. `Conditions[1].Data.Perk` on a `HasPerkConditionData`) returned a placeholder instead of the FormID. The renderer's `EmitFloi` tested the FormLinkOrIndex value itself as an `IFormLinkGetter` — but no FLOI (mutable or overlay) *is* a link; it *carries* the link in its `.Link` property. That accessor is exactly what the write side already reads (`WriteEngine.ReadFloiFormKey`, oracle-proven by the wave-4 condition-patch demo), so the read side just never adopted the proven path.

Blast radius per the report: every condition whose payload is a form (`HasPerk`, `HasMagicEffect`, `GetInFaction`, `GetEquipped`, perk entry points…) — the "gated on what" half of every condition read, including the Requiem `REQ_NULL` COBJ-gate checklist scan.

## The fix

`EmitFloi`'s form-mode arm falls through to `WriteEngine.ReadFloiFormKey(val)` (the `.Link` read). A present-but-null link stays a note — matching how plain FormLink leaves render — and the residual note now names the runtime type for diagnosis instead of the bare placeholder.

## Proof

- **`floi-read-guard`** — new self-contained CI regression guard (no external files): synthesizes a COBJ carrying the report's universal temper-gate shape (`HasPerk` form-mode FLOI) plus an alias-mode sibling, writes it to a temp folder, reopens it as a **binary overlay**, and asserts the rendered tokens on both the mutable and overlay reads, both modes. **RED before the fix** (both form arms render the placeholder — the mutable read was broken too), **GREEN after** (4/4).
- **Live vanilla data** — `read` CLI against real `Skyrim.esm`, `TemperWeaponIronSword` (0ADB77): `Conditions[1].Data.Perk = 05218E:Skyrim.esm` — the exact expected value the report names (its suggested regression check, run live).

Index mode (`alias N` / `packdata N`) was already correct (the oracle's FLOI phase covers the round-trip); the guard now locks it in CI too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
