### PR TITLE
Isolate per-record scan faults so one bad record can't kill a query (HCBR-2026-06-09-03)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,9 @@ jobs:
       # regression guard locking in the active-patch write self-lock fix (Heisen 2026-06-08, AllMastersExcept).
       - name: Probe — active-patch write self-lock (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- writelock-guard
+
+      # Self-contained (synthesizes a corrupted-EPFT perk — no external files), runs fully here AND drives the REAL
+      # service-layer scan (the first CI coverage of the mcp layer): a regression guard locking in the references=
+      # per-record fault isolation + unscannable accounting (HCBR-2026-06-09-03).
+      - name: Probe — references= scan fault isolation (self-contained regression guard)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- perk-refs-guard

--- a/src/housecarl-generator/PerkRefsProbe.cs
+++ b/src/housecarl-generator/PerkRefsProbe.cs
@@ -1,0 +1,255 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// HCBR-2026-06-09-03 — `cross_plugin_query type=Perk references=` hard-errored (opaquely) on the whole call.
+///
+/// DIAGNOSIS (<c>perk-refs-diagnose</c>): the scan's per-record test is Mutagen's own <c>EnumerateFormLinks()</c>,
+/// which LAZILY parses subrecord content (a perk's Effects); run it over every PERK in a plugin / the whole MO2
+/// order and report which records throw, with full exception detail. The ARR sweep found exactly ONE offender in
+/// 1,822 winner perks — 00080E:Requiem - Special Feats.esp, whose PerkEntryPointModifyActorValue carries a
+/// parameter-type flag Mutagen's model rejects (MalformedDataException) — and that single record aborted the
+/// whole call, because the scan loop only caught ArgumentException.
+///
+/// REGRESSION GUARD (<c>perk-refs-guard</c>, standing CI instrument, self-contained): synthesizes the failure —
+/// a plugin with a target perk, a good perk that references it (NextPerk), and a perk whose written EPFT
+/// (entry-point parameter-type flag) byte is then corrupted so Mutagen's ParseEffect throws — and drives the REAL
+/// service-layer scan (<see cref="LoadOrderService.CrossQuery"/> via the ForGuard seam; the first CI coverage of
+/// the mcp layer). Asserts: the call SUCCEEDS, the good match is found, and the unscannable record is ACCOUNTED
+/// by FormKey in the ScanNote (Q3 — excluded, never silent). A control proves the corrupted perk really does
+/// throw from EnumerateFormLinks (so a GREEN is meaningful). RED before the fix, GREEN after.
+///
+/// Run: <c>dotnet run --project src/housecarl-generator perk-refs-guard</c>
+///      <c>dotnet run --project src/housecarl-generator perk-refs-diagnose [-- --source &lt;path&gt; | --mo2 &lt;instanceDir&gt;]</c>
+/// </summary>
+public static class PerkRefsProbe
+{
+    const string DefaultSource = @"E:\SteamLibrary\steamapps\common\Skyrim Special Edition\Data\Skyrim.esm";
+
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  REGRESSION GUARD — references= scan fault isolation (HCBR-2026-06-09-03)  ################");
+        Console.WriteLine();
+
+        var tmpDir = Path.Combine(Path.GetTempPath(), "hc-perkrefs-guard");
+        if (Directory.Exists(tmpDir)) Directory.Delete(tmpDir, recursive: true);
+        Directory.CreateDirectory(tmpDir);
+        var modKey = new ModKey("HcPerkRefsGuard", ModType.Plugin);
+        string espPath = Path.Combine(tmpDir, modKey.FileName.String);
+
+        // --- Setup: target perk + a GOOD perk referencing it (NextPerk) + a BAD perk with one entry-point effect,
+        //     whose EPFT (parameter-type flag) byte we corrupt after writing — the exact malformation class the ARR
+        //     sweep found (ParseEffect: "did not have expected parameter type flag"). Single mod, masterless. ---
+        FormKey targetFk, goodFk, badFk;
+        {
+            var mod = new SkyrimMod(modKey, SkyrimRelease.SkyrimSE);
+            var target = mod.Perks.AddNew(); target.EditorID = "HcPerkRefsGuard_Target"; targetFk = target.FormKey;
+            var good = mod.Perks.AddNew(); good.EditorID = "HcPerkRefsGuard_Good"; goodFk = good.FormKey;
+            good.NextPerk.SetTo(targetFk);
+            var bad = mod.Perks.AddNew(); bad.EditorID = "HcPerkRefsGuard_Bad"; badFk = bad.FormKey;
+            bad.Effects.Add(new PerkEntryPointModifyActorValue
+            {
+                EntryPoint = APerkEntryPointEffect.EntryType.CalculateWeaponDamage,
+                ActorValue = ActorValue.OneHanded,
+                Value = 1f,
+                Modification = PerkEntryPointModifyActorValue.ModificationType.AddAVMult,
+            });
+            mod.BeginWrite.ToPath(espPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+        }
+        int corrupted = CorruptEpftBytes(espPath);
+        Console.WriteLine($"-- setup: wrote {modKey.FileName} (target + referencing + entry-point perks); corrupted {corrupted} EPFT flag byte(s) --");
+        if (corrupted != 1) { Console.WriteLine($"=== perk-refs-guard: FAIL (expected exactly 1 EPFT subrecord to corrupt, found {corrupted}) ==="); return 1; }
+
+        // --- CONTROL: the corruption must reproduce the crash class — EnumerateFormLinks on the bad perk THROWS. ---
+        bool controlThrew = false; string controlMsg = "(no throw)";
+        using (var ov = SkyrimMod.CreateFromBinaryOverlay(espPath, SkyrimRelease.SkyrimSE))
+        {
+            var badOv = ov.Perks.First(p => p.FormKey == badFk);
+            try { _ = ((IFormLinkContainerGetter)badOv).EnumerateFormLinks().Count(); }
+            catch (Exception ex) { controlThrew = true; controlMsg = $"{ex.GetType().Name}: {ex.Message}"; }
+        }
+        Console.WriteLine($"   CONTROL (bad perk throws from EnumerateFormLinks) : {(controlThrew ? "PASS" : "FAIL")}  [{controlMsg}]");
+
+        // --- FIX: drive the REAL service-layer scan over the order containing the bad perk. Scoped by plugins=
+        //     (the same scan loop type= runs; no corpus needed). Before the fix this whole call THREW. ---
+        using var resolver = LoadOrderResolver.Build(new[] { espPath });
+        var svc = LoadOrderService.ForGuard(resolver, new UserConfigStore(Path.Combine(tmpDir, "houseCARL.user.json")));
+        CrossQueryOutcome q;
+        try { q = svc.CrossQuery(type: null, references: targetFk, editoridContains: null, conflictsOnly: false,
+                                 plugins: new[] { modKey.FileName.String }, where: null, limit: 500); }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"   scan call completed (no escape)                    : FAIL — the call still THREW: {ex.GetType().Name}: {ex.Message}");
+            Console.WriteLine();
+            Console.WriteLine("=== perk-refs-guard: FAIL ===");
+            return 1;
+        }
+
+        bool noError = q.Error is null;
+        bool foundGood = q.Total == 1 && q.Keys.Count == 1 && q.Keys[0] == goodFk;
+        bool accounted = q.ScanNote is not null
+                         && q.ScanNote.Contains(badFk.ToString(), StringComparison.OrdinalIgnoreCase)
+                         && q.ScanNote.Contains("1 record(s)", StringComparison.Ordinal);
+
+        Console.WriteLine($"   scan call completed (no escape, no error)          : {(noError ? "PASS" : $"FAIL [{q.Error}]")}");
+        Console.WriteLine($"   good referencing perk matched                      : {(foundGood ? "PASS" : $"FAIL (total={q.Total})")}");
+        Console.WriteLine($"   unscannable perk ACCOUNTED by FormKey (ScanNote)   : {(accounted ? "PASS" : $"FAIL [{q.ScanNote ?? "(no note)"}]")}");
+        if (accounted) Console.WriteLine($"      {q.ScanNote}");
+        Console.WriteLine();
+
+        bool pass = controlThrew && noError && foundGood && accounted;
+        Console.WriteLine($"=== perk-refs-guard: {(pass ? "PASS" : "FAIL")} ===");
+        return pass ? 0 : 1;
+    }
+
+    /// <summary>REAL-DATA proof (manual; needs an MO2 instance + a generated corpus.json): drive the SERVICE-layer
+    /// scan with the report's exact failing call — <c>type=Perk references=01CEAD:Skyrim.esm</c> (KYWD
+    /// MagicDamageFire) — over the live order. Before the fix the whole call threw; after, it must return with no
+    /// error and account any unscannable perk(s) by FormKey in the ScanNote. Match count is data-dependent and
+    /// reported, not asserted.
+    /// Run: <c>dotnet run --project src/housecarl-generator perk-refs-proof -- --mo2 &lt;instanceDir&gt; --corpus &lt;corpus.json&gt; [--references XXXXXX:Plugin.esp]</c></summary>
+    public static int RunProof(string[] args)
+    {
+        var f = WriteEngine.ParseFlags(args);
+        var instanceDir = f.GetValueOrDefault("mo2");
+        var corpus = f.GetValueOrDefault("corpus");
+        if (instanceDir is null || corpus is null) { Console.WriteLine("SKIP: needs --mo2 <instanceDir> and --corpus <corpus.json>"); return 0; }
+        if (!Directory.Exists(instanceDir) || !File.Exists(corpus)) { Console.WriteLine($"SKIP: --mo2 or --corpus path not found"); return 0; }
+        CorpusRulebook.CorpusPath = corpus;                                   // ResolveTypeFilter("Perk") reads the type catalog
+        var refRaw = f.GetValueOrDefault("references") ?? "01CEAD:Skyrim.esm";   // the report's row-1 repro (KYWD MagicDamageFire)
+        var refFk = FormKey.Factory(refRaw);
+
+        Console.WriteLine($"################  REAL-DATA PROOF — cross_plugin_query type=Perk references={refRaw} on {Path.GetFileName(instanceDir)}  ################");
+        Console.WriteLine();
+        var p = Mo2Instance.Resolve(instanceDir);
+        var order = Mo2LoadOrder.Build(p.ProfileDir, p.ModsDir, p.DataDir);
+        using var resolver = LoadOrderResolver.Build(order.OrderedPaths.ToList());
+        Console.WriteLine($"   resolver: {resolver.PluginCount} plugins, {resolver.RecordCount:N0} records, {resolver.ExcludedPlugins.Count} excluded");
+        var svc = LoadOrderService.ForGuard(resolver, new UserConfigStore(Path.Combine(Path.GetTempPath(), "hc-perkrefs-proof.user.json")));
+
+        CrossQueryOutcome q;
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        try { q = svc.CrossQuery(type: "Perk", references: refFk, editoridContains: null, conflictsOnly: false,
+                                 plugins: null, where: null, limit: 500); }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"   FAIL — the call still THREW: {ex.GetType().Name}: {ex.Message}");
+            return 1;
+        }
+        sw.Stop();
+
+        Console.WriteLine($"   call completed in {sw.Elapsed.TotalSeconds:N1}s");
+        Console.WriteLine($"   error    : {q.Error ?? "(none)"}");
+        Console.WriteLine($"   matches  : {q.Total}");
+        Console.WriteLine($"   scan note: {q.ScanNote ?? "(none — every record scanned clean)"}");
+        foreach (var s in (q.Prefilled ?? Array.Empty<RecordSummary>()).Take(5))
+            Console.WriteLine($"      {s.FormKey}  {s.EditorId ?? "<no editorid>"}  (winner {s.Winner})");
+        Console.WriteLine();
+        bool pass = q.Error is null;
+        Console.WriteLine($"=== perk-refs-proof: {(pass ? "PASS" : "FAIL")} ===");
+        return pass ? 0 : 1;
+    }
+
+    /// <summary>Corrupt every EPFT subrecord's parameter-type flag byte in the written plugin (sig + len(2) + 1-byte
+    /// payload → payload at +6), returning how many were hit. The guard writes exactly one entry-point effect, so
+    /// exactly one EPFT is expected — asserted by the caller.</summary>
+    static int CorruptEpftBytes(string espPath)
+    {
+        var bytes = File.ReadAllBytes(espPath);
+        int hits = 0;
+        for (int i = 0; i + 6 < bytes.Length; i++)
+        {
+            if (bytes[i] != (byte)'E' || bytes[i + 1] != (byte)'P' || bytes[i + 2] != (byte)'F' || bytes[i + 3] != (byte)'T') continue;
+            bytes[i + 6] = 0x63;   // not a legal parameter-type flag → ParseEffect throws on lazy Effects parse
+            hits++;
+        }
+        if (hits > 0) File.WriteAllBytes(espPath, bytes);
+        return hits;
+    }
+
+    public static int RunDiagnose(string[] args)
+    {
+        // --mo2 <instanceDir>: sweep the WHOLE load order through the PRODUCT stream (WinnerRecordsOfType),
+        // the exact loop cross_plugin_query runs. Without it: a quick single-plugin sweep of Skyrim.esm.
+        var f = HousecarlCore.WriteEngine.ParseFlags(args);
+        if (f.GetValueOrDefault("mo2") is { } instanceDir) return DiagnoseFullOrder(instanceDir);
+
+        var src = f.GetValueOrDefault("source") ?? DefaultSource;
+        if (!File.Exists(src)) { Console.WriteLine($"SKIP: source plugin not found: {src}"); return 0; }
+
+        Console.WriteLine($"################  DIAGNOSIS — EnumerateFormLinks over PERK records in {Path.GetFileName(src)}  ################");
+        Console.WriteLine();
+
+        using var mod = SkyrimMod.CreateFromBinaryOverlay(src, SkyrimRelease.SkyrimSE);
+        var (ok, links, failures) = Sweep(mod.Perks.Select(p => ((IMajorRecordGetter)p, "Skyrim.esm")));
+        Report(ok, links, failures);
+        return 0;
+    }
+
+    static int DiagnoseFullOrder(string instanceDir)
+    {
+        Console.WriteLine($"################  DIAGNOSIS — EnumerateFormLinks over ALL winner PERKs in the {Path.GetFileName(instanceDir)} order  ################");
+        Console.WriteLine();
+        var p = HousecarlCore.Mo2Instance.Resolve(instanceDir);
+        var order = HousecarlCore.Mo2LoadOrder.Build(p.ProfileDir, p.ModsDir, p.DataDir);
+        Console.WriteLine($"   order: {order.OrderedPaths.Count} plugins (profile '{p.ProfileName}')");
+        using var resolver = HousecarlCore.LoadOrderResolver.Build(order.OrderedPaths.ToList());
+        Console.WriteLine($"   resolver: {resolver.PluginCount} plugins, {resolver.RecordCount:N0} records, {resolver.ExcludedPlugins.Count} excluded");
+        Console.WriteLine();
+
+        var (ok, links, failures) = Sweep(resolver.WinnerRecordsOfType(new[] { typeof(IPerkGetter) })
+                                                  .Select(x => (x.body, x.fk.ModKey.FileName.ToString())));
+        Report(ok, links, failures);
+        return 0;
+    }
+
+    static (int ok, int links, List<(FormKey fk, string? edid, string src, Exception ex)> failures)
+        Sweep(IEnumerable<(IMajorRecordGetter rec, string src)> stream)
+    {
+        int ok = 0, links = 0;
+        var failures = new List<(FormKey, string?, string, Exception)>();
+        foreach (var (rec, src) in stream)
+        {
+            try
+            {
+                if (rec is IFormLinkContainerGetter flc)
+                    links += flc.EnumerateFormLinks().Count();
+                ok++;
+            }
+            catch (Exception ex)
+            {
+                if (failures.Count < 8) failures.Add((rec.FormKey, rec.EditorID, src, ex));
+                else failures.Add((rec.FormKey, null, src, ex));
+            }
+        }
+        return (ok, links, failures);
+    }
+
+    static void Report(int ok, int links, List<(FormKey fk, string? edid, string src, Exception ex)> failures)
+    {
+        Console.WriteLine($"   perks scanned : {ok + failures.Count}");
+        Console.WriteLine($"   enumerated OK : {ok}  (total links seen: {links})");
+        Console.WriteLine($"   THREW         : {failures.Count}");
+        Console.WriteLine();
+        foreach (var (fk, edid, src, ex) in failures.Take(8))
+        {
+            Console.WriteLine($"-- {fk} ({edid ?? "<no editorid>"}) defined in {src} --");
+            Console.WriteLine($"   {ex.GetType().FullName}: {ex.Message}");
+            var st = ex.StackTrace?.Split('\n').Take(12) ?? Array.Empty<string>();
+            foreach (var line in st) Console.WriteLine($"   {line.TrimEnd()}");
+            if (ex.InnerException is { } inner)
+                Console.WriteLine($"   INNER {inner.GetType().FullName}: {inner.Message}");
+            Console.WriteLine();
+        }
+        if (failures.Count > 8)
+        {
+            Console.WriteLine($"   ... and {failures.Count - 8} more failing perk(s); distinct exception types: " +
+                string.Join(", ", failures.Select(x => x.ex.GetType().Name).Distinct()));
+        }
+    }
+}

--- a/src/housecarl-generator/PerkRefsProbe.cs
+++ b/src/housecarl-generator/PerkRefsProbe.cs
@@ -42,15 +42,16 @@ public static class PerkRefsProbe
         var modKey = new ModKey("HcPerkRefsGuard", ModType.Plugin);
         string espPath = Path.Combine(tmpDir, modKey.FileName.String);
 
-        // --- Setup: target perk + a GOOD perk referencing it (NextPerk) + a BAD perk with one entry-point effect,
-        //     whose EPFT (parameter-type flag) byte we corrupt after writing — the exact malformation class the ARR
-        //     sweep found (ParseEffect: "did not have expected parameter type flag"). Single mod, masterless. ---
+        // --- Setup: target perk + a BAD perk with one entry-point effect (whose EPFT parameter-type flag byte we
+        //     corrupt after writing — the exact malformation class the ARR sweep found), THEN a GOOD perk
+        //     referencing the target. Order is load-bearing (PR #27 review): the bad perk gets the LOWER FormID,
+        //     so it enumerates BEFORE the good match — the guard then pins not just "one bad record doesn't kill
+        //     the call" but "the scan CONTINUES past the fault" (a stop-at-first-fault regression silently drops
+        //     every later match — the Q3 class this fix closes; RED re-proven against that simulation). ---
         FormKey targetFk, goodFk, badFk;
         {
             var mod = new SkyrimMod(modKey, SkyrimRelease.SkyrimSE);
             var target = mod.Perks.AddNew(); target.EditorID = "HcPerkRefsGuard_Target"; targetFk = target.FormKey;
-            var good = mod.Perks.AddNew(); good.EditorID = "HcPerkRefsGuard_Good"; goodFk = good.FormKey;
-            good.NextPerk.SetTo(targetFk);
             var bad = mod.Perks.AddNew(); bad.EditorID = "HcPerkRefsGuard_Bad"; badFk = bad.FormKey;
             bad.Effects.Add(new PerkEntryPointModifyActorValue
             {
@@ -59,6 +60,8 @@ public static class PerkRefsProbe
                 Value = 1f,
                 Modification = PerkEntryPointModifyActorValue.ModificationType.AddAVMult,
             });
+            var good = mod.Perks.AddNew(); good.EditorID = "HcPerkRefsGuard_Good"; goodFk = good.FormKey;
+            good.NextPerk.SetTo(targetFk);
             mod.BeginWrite.ToPath(espPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
         }
         int corrupted = CorruptEpftBytes(espPath);
@@ -94,7 +97,7 @@ public static class PerkRefsProbe
         bool foundGood = q.Total == 1 && q.Keys.Count == 1 && q.Keys[0] == goodFk;
         bool accounted = q.ScanNote is not null
                          && q.ScanNote.Contains(badFk.ToString(), StringComparison.OrdinalIgnoreCase)
-                         && q.ScanNote.Contains("1 record(s)", StringComparison.Ordinal);
+                         && q.ScanNote.Contains("1 record instance(s)", StringComparison.Ordinal);
 
         Console.WriteLine($"   scan call completed (no escape, no error)          : {(noError ? "PASS" : $"FAIL [{q.Error}]")}");
         Console.WriteLine($"   good referencing perk matched                      : {(foundGood ? "PASS" : $"FAIL (total={q.Total})")}");

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -153,6 +153,18 @@ if (args.Length > 0 && args[0] == "writelock-apply-probe") return WriteLockProbe
 // link-cache context path) survives the re-edit-own-override case under the new "release overlay before serialize" invariant.
 if (args.Length > 0 && args[0] == "writelock-nested-proof") return WriteLockProbe.RunNestedProof(args[1..]);
 
+// Perk references= crash (HCBR-2026-06-09-03): DIAGNOSIS — run Mutagen's EnumerateFormLinks over every PERK in a
+// real plugin, report which records throw and with what (the evidence the fix is designed from). Skips without Skyrim.esm.
+if (args.Length > 0 && args[0] == "perk-refs-diagnose") return PerkRefsProbe.RunDiagnose(args[1..]);
+
+// Perk references= crash (HCBR-2026-06-09-03): SELF-CONTAINED CI regression guard — synthesizes a corrupted-EPFT perk,
+// drives the REAL service-layer scan (CrossQuery via ForGuard), asserts matches + the unscannable record's accounting.
+if (args.Length > 0 && args[0] == "perk-refs-guard") return PerkRefsProbe.RunGuard(args[1..]);
+
+// Perk references= crash (HCBR-2026-06-09-03): REAL-DATA proof — the report's exact failing call (type=Perk references=)
+// over a live MO2 order through the service layer. Manual; needs --mo2 + --corpus (skips without).
+if (args.Length > 0 && args[0] == "perk-refs-proof") return PerkRefsProbe.RunProof(args[1..]);
+
 // External-tool bridge (step 1) proof: the pure core pieces housecarl_set_tool_path + the riders ride — shared-config
 // clobber-safety, path validation, the missing-dependency forcing prompt, and canonical-home auto-detect.
 if (args.Length > 0 && args[0] == "tool-bridge") return ToolBridgeProbe.Run(args[1..]);

--- a/src/housecarl-generator/housecarl-generator.csproj
+++ b/src/housecarl-generator/housecarl-generator.csproj
@@ -17,6 +17,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\housecarl-core\housecarl-core.csproj" />
+    <!-- The CI regression guards drive the SERVICE-layer scan logic (LoadOrderService.CrossQuery, via the
+         ForGuard seam) — the first CI coverage of the mcp layer (PR #23 follow-up). -->
+    <ProjectReference Include="..\housecarl-mcp\housecarl-mcp.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/housecarl-mcp/InternalsVisibleTo.cs
+++ b/src/housecarl-mcp/InternalsVisibleTo.cs
@@ -1,0 +1,7 @@
+using System.Runtime.CompilerServices;
+
+// The proof harness (housecarl-generator) drives the SERVICE-layer scan logic (LoadOrderService.CrossQuery
+// via the ForGuard seam) in its CI regression guards — the first CI coverage of the mcp layer (the follow-up
+// logged at PR #23: the winner-vs-source guard could only reach the core's RecordsIn, not the service loop).
+// Declaring the harness a friend keeps the guard on the REAL product path without widening the public surface.
+[assembly: InternalsVisibleTo("housecarl-generator")]

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -497,8 +497,10 @@ public sealed class LoadOrderService : IDisposable
         }
         // Unscannable accounting (Q3): name the count, the first few offenders with Mutagen's reason, and what
         // a caller can still do — these records are invisible to the body filters, not "0 matches" silence.
+        // "instance(s) … where they threw" because under plugins= a FormKey is tested once per scoped plugin:
+        // a copy that throws is skipped while another plugin's copy of the same FK can still match (PR #27 review).
         string? scanNote = unscannable == 0 ? null
-            : $"note: {unscannable} record(s) could not be scanned (Mutagen could not parse their content) and are excluded from the matches: "
+            : $"note: {unscannable} record instance(s) could not be scanned (Mutagen could not parse their content) and were skipped where they threw: "
               + string.Join("; ", unscannableSamples)
               + (unscannable > unscannableSamples.Count ? $"; and {unscannable - unscannableSamples.Count} more" : "")
               + ". Inspect one with read_record (per-field fault isolation applies).";

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -67,6 +67,18 @@ public sealed class LoadOrderService : IDisposable
     public static LoadOrderService WithExplicitPaths(string dataDir, string modsDir, string profileDir, int maxPlugins, UserConfigStore store)
         => new(null, dataDir, modsDir, profileDir, configured: true, maxPlugins, store);
 
+    /// <summary>TEST SEAM (the harness' CI regression guards only): wrap a PREBUILT resolver so a guard can drive
+    /// the service-layer query logic (CrossQuery's scan loop) on synthetic plugins — no MO2 profile, no user config
+    /// on disk. Explicit-mode freshness checks no-op (no ini, empty profile dir); the caller owns the resolver's
+    /// lifetime. Never used by the product.</summary>
+    internal static LoadOrderService ForGuard(LoadOrderResolver resolver, UserConfigStore store)
+    {
+        var svc = new LoadOrderService(null, "", "", "", configured: true, maxPlugins: 0, store);
+        svc._resolver = resolver;
+        svc._orderBuiltUtc = DateTime.UtcNow;
+        return svc;
+    }
+
     /// <summary>Non-fatal warnings from the last order build (Q3) — e.g. a plugin the load order lists that no enabled
     /// mod provides (stale profile files). Surfaced, never swallowed. Empty until the resolver first builds.</summary>
     public IReadOnlyList<string> OrderWarnings => _orderWarnings;
@@ -409,6 +421,8 @@ public sealed class LoadOrderService : IDisposable
         var sources = new List<string?>();                                    // parallel to keys: the plugin whose body matched (null ⇒ winner), so the render displays the SAME body it filtered
         List<RecordSummary>? prefilled = (hasType || hasPlugins) ? new() : null;   // parallel to keys; null = renderer fills lazily
         int total = 0;
+        int unscannable = 0;                                                  // records whose body tests THREW (Mutagen-unparseable content) — excluded + accounted, never silent (Q3)
+        var unscannableSamples = new List<string>();
 
         if (hasType || hasPlugins)                                            // a body-bearing scope: stream + filter in hand
         {
@@ -426,32 +440,49 @@ public sealed class LoadOrderService : IDisposable
                 foreach (var (fk, depth, body, source) in stream)
                 {
                     if (conflictsOnly && depth <= 1) continue;
-                    if (!string.IsNullOrEmpty(editoridContains)
-                        && (body.EditorID is null || body.EditorID.IndexOf(editoridContains, StringComparison.OrdinalIgnoreCase) < 0))
-                        continue;
-                    if (references is { } target
-                        && !(body is IFormLinkContainerGetter flc && flc.EnumerateFormLinks().Any(l => l.FormKey == target)))
-                        continue;
-                    if (predicate is not null && !predicate.Matches(body))    // value filter — same in-hand body, no extra fetch
+                    // PER-RECORD FAULT ISOLATION (HCBR-2026-06-09-03): the body tests lazily parse subrecord
+                    // content (references= walks Effects etc. via Mutagen's EnumerateFormLinks), so ONE record
+                    // Mutagen can't parse used to abort the WHOLE call as an opaque transport error — the
+                    // scan-level twin of the PKCU index-build fix. Such a record is excluded and ACCOUNTED in
+                    // the response (never a silent skip, never a guessed match — Q3).
+                    try
                     {
-                        if (predicate.FatalError is not null) break;          // numeric op vs non-numeric field — abort + surface (Q3)
-                        continue;
+                        if (!string.IsNullOrEmpty(editoridContains)
+                            && (body.EditorID is null || body.EditorID.IndexOf(editoridContains, StringComparison.OrdinalIgnoreCase) < 0))
+                            continue;
+                        if (references is { } target
+                            && !(body is IFormLinkContainerGetter flc && flc.EnumerateFormLinks().Any(l => l.FormKey == target)))
+                            continue;
+                        if (predicate is not null && !predicate.Matches(body))    // value filter — same in-hand body, no extra fetch
+                        {
+                            if (predicate.FatalError is not null) break;          // numeric op vs non-numeric field — abort + surface (Q3)
+                            continue;
+                        }
+                        // De-dup (a FK can recur across scoped plugins). This runs AFTER the filters, so under
+                        // plugins=[A,B] the source recorded for a shared FK is the FIRST scoped plugin (in plugins=
+                        // array order) whose body PASSED the filters — deterministic, and it's the body we'll display.
+                        if (!seen.Add(fk)) continue;
+                        total++;
+                        if (keys.Count < limit)                                   // in-hand body → fill the summary for free
+                        {
+                            keys.Add(fk);
+                            sources.Add(source);                                  // the body we filtered IS the body we'll display (null ⇒ winner)
+                            prefilled!.Add(new RecordSummary(fk, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID,
+                                                             resolver.ResolveWinner(fk)?.WinnerPlugin ?? "?", depth, null));
+                        }
                     }
-                    // De-dup (a FK can recur across scoped plugins). This runs AFTER the filters, so under
-                    // plugins=[A,B] the source recorded for a shared FK is the FIRST scoped plugin (in plugins=
-                    // array order) whose body PASSED the filters — deterministic, and it's the body we'll display.
-                    if (!seen.Add(fk)) continue;
-                    total++;
-                    if (keys.Count < limit)                                   // in-hand body → fill the summary for free
+                    catch (Exception ex)
                     {
-                        keys.Add(fk);
-                        sources.Add(source);                                  // the body we filtered IS the body we'll display (null ⇒ winner)
-                        prefilled!.Add(new RecordSummary(fk, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID,
-                                                         resolver.ResolveWinner(fk)?.WinnerPlugin ?? "?", depth, null));
+                        unscannable++;
+                        if (unscannableSamples.Count < 3)
+                            unscannableSamples.Add($"{fk}{(source is null ? "" : $" in {source}")} — {ex.GetType().Name}: {ex.Message}");
                     }
                 }
             }
             catch (ArgumentException ex) { return CrossQueryOutcome.Fail(ex.Message); } // plugin not in order / unknown type
+            // Anything else escaping the stream itself still gets a NAMED failure — the MCP layer's generic
+            // "An error occurred invoking …" must never be the terminal diagnostic for a data failure (Q3).
+            catch (Exception ex) { return CrossQueryOutcome.Fail($"scan aborted: {ex.GetType().Name}: {ex.Message}"); }
             if (predicate?.FatalError is not null) return CrossQueryOutcome.Fail(predicate.FatalError); // typed predicate error — fail fast, named (Q3)
         }
         else                                                                  // conflicts_only alone — index keys only; NO body fetch
@@ -464,7 +495,14 @@ public sealed class LoadOrderService : IDisposable
                 if (keys.Count < limit) { keys.Add(fk); sources.Add(null); }   // no scoped plugin → display the winner
             }
         }
-        return new CrossQueryOutcome(keys, prefilled, total, total > keys.Count, null, predicate?.AccountingNote(), sources);
+        // Unscannable accounting (Q3): name the count, the first few offenders with Mutagen's reason, and what
+        // a caller can still do — these records are invisible to the body filters, not "0 matches" silence.
+        string? scanNote = unscannable == 0 ? null
+            : $"note: {unscannable} record(s) could not be scanned (Mutagen could not parse their content) and are excluded from the matches: "
+              + string.Join("; ", unscannableSamples)
+              + (unscannable > unscannableSamples.Count ? $"; and {unscannable - unscannableSamples.Count} more" : "")
+              + ". Inspect one with read_record (per-field fault isolation applies).";
+        return new CrossQueryOutcome(keys, prefilled, total, total > keys.Count, null, predicate?.AccountingNote(), sources, scanNote);
     }
 
     // ---- writes (§8.4 Beat C: housecarl_set_field / housecarl_bulk_apply) -------------------------------
@@ -906,7 +944,7 @@ public sealed record ReadOutcome(
 /// <see cref="Total"/> is the true match count; <see cref="Capped"/> is true when Total exceeded what was returned.</summary>
 public sealed record CrossQueryOutcome(
     IReadOnlyList<FormKey> Keys, IReadOnlyList<RecordSummary>? Prefilled, int Total, bool Capped, string? Error,
-    string? PredicateNote = null, IReadOnlyList<string?>? Sources = null)
+    string? PredicateNote = null, IReadOnlyList<string?>? Sources = null, string? ScanNote = null)
 {
     public static CrossQueryOutcome Fail(string error) => new(Array.Empty<FormKey>(), null, 0, false, error);
 }

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -177,6 +177,7 @@ static class Wire
         if (q.Capped) sb.Append(" (showing first ").Append(q.Keys.Count).Append("; raise limit= or narrow to see more)");
         sb.Append('\n');
         if (q.PredicateNote is not null) sb.Append(q.PredicateNote).Append('\n');   // where= Q3 accounting (wrong-path/no-value surface)
+        if (q.ScanNote is not null) sb.Append(q.ScanNote).Append('\n');             // unscannable-record Q3 accounting (Mutagen-unparseable content)
 
         int rendered = 0;
         for (int i = 0; i < q.Keys.Count; i++)


### PR DESCRIPTION
Fixes **HCBR-2026-06-09-03** — `cross_plugin_query` hard-errors (opaquely) whenever `type=Perk` is combined with `references=`.

## Diagnosis (empirical, on the live ARR order)

A full sweep of all 1,822 winner PERKs across the 3,508-plugin ARR order found **exactly one offender**: `00080E:Requiem - Special Feats.esp` (`Feat_Perk_Skill_HeavyArmor_DevastatingTackle`). Its `PerkEntryPointModifyActorValue` carries a parameter-type flag Mutagen's model rejects, so Mutagen's `EnumerateFormLinks()` — which the `references=` test calls, and which lazily parses the perk's Effects — throws `MalformedDataException` mid-scan. The scan loop only caught `ArgumentException`, so that single record aborted the **whole call**, surfacing as the generic `An error occurred invoking 'housecarl_cross_plugin_query'`. The scan-level twin of the PKCU index-build bug ("one record bricks everything"), one layer up.

(The report hypothesized the crash was on vanilla data — it wasn't: Skyrim.esm's 375 perks all enumerate clean. The scanned set is the whole order regardless of target, which is why all four report repros failed identically.)

## The fix (service scan loop)

1. **Per-record fault isolation** — a record whose body tests throw is excluded and **accounted**: the response carries a note naming the count and the first offenders with FormKey + Mutagen's reason. Never a silent skip, never the whole-call death (Q3).
2. **Named failure for anything else** — a catch-all on the stream maps residual exceptions to an explicit `CrossQueryOutcome` failure, so the MCP transport's generic error is never the terminal diagnostic for a data failure (report ask #3).

## Proof

- **`perk-refs-guard`** (new self-contained CI guard): synthesizes a plugin with a target perk, a referencing perk, and a perk whose written EPFT flag byte is corrupted — the **control** proves it reproduces the exact ARR exception. Then drives the **real service-layer scan** (`LoadOrderService.CrossQuery`, via a new internal `ForGuard` seam — `housecarl-generator` now references `housecarl-mcp`, giving the mcp layer its first CI coverage, the follow-up logged at [PR #23](https://github.com/Avick3110/houseCARL/pull/23)). **RED** with isolation disabled (the exception escapes the product call), **GREEN** with the fix: call succeeds, the good match is found, the bad perk is accounted by FormKey.
- **`perk-refs-proof`** (real data): the report's exact failing call — `type=Perk references=01CEAD:Skyrim.esm` — over the live ARR order now returns **42 matches in 1.0s**, with the scan note naming the one Requiem perk and Mutagen's reason:

```
matches  : 42
scan note: note: 1 record(s) could not be scanned (Mutagen could not parse their content) and are
excluded from the matches: 00080E:Requiem - Special Feats.esp — MalformedDataException:
PerkEntryPointModifyActorValue did not have expected parameter type flag: Float. Inspect one with
read_record (per-field fault isolation applies).
```

The unscannable record itself is the known Mutagen-delta class (model vs file disagreement) — failed loud per record, per house policy; the other 1,821 perks now scan normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
