### PR TITLE
Diff conflict-tree CONTENT, not depth-1 count summaries (HCBR-2026-06-09-01)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,9 @@ jobs:
       # per-record fault isolation + unscannable accounting (HCBR-2026-06-09-03).
       - name: Probe — references= scan fault isolation (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- perk-refs-guard
+
+      # Self-contained (synthesizes a master + override with list-content arms — no external files), runs fully here
+      # and drives the REAL ResolveTree (deep) + FieldsDiff: a regression guard locking in the conflict-tree CONTENT
+      # diff — equal-count list deltas reported, reorder ignored, truncation honest (HCBR-2026-06-09-01).
+      - name: Probe — conflict-tree content diff (self-contained regression guard)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- conflict-diff-guard

--- a/src/housecarl-core/FieldsDiff.cs
+++ b/src/housecarl-core/FieldsDiff.cs
@@ -1,0 +1,195 @@
+using System.Text;
+
+namespace HousecarlCore;
+
+/// <summary>
+/// The winner-relative CONTENT comparison behind the conflict-tree diff (HCBR-2026-06-09-01).
+///
+/// The old diff compared depth-1 rendered lines, where a list collapses to a "[List: N item(s)]" count
+/// token — so two lists with EQUAL counts but DIFFERENT contents compared identical, and a whole override
+/// could be reported "(identical to winner)" while carrying the very edit that motivated it (the report's
+/// masked USSEP PlayerFaction regression). This module compares DEEP reads (every modeled leaf):
+///
+///   • scalar / substruct / dict leaves — exact-path token comparison (the old behavior, at full depth;
+///     dict keys like Skills[OneHanded] are semantic identities, so exact-path is correct for them);
+///   • positional LIST contents — order-INSENSITIVE multiset comparison of whole elements keyed on their
+///     content (the report's case: USSEP and the winner store the same relations in different orders, so
+///     an index-wise comparison would over-report; element identity is content-based). Elements present
+///     on only one side are reported with identifying leaf values. Numeric brackets ([0]) mark positional
+///     elements; nested list reordering INSIDE an element is not canonicalised (v1) — it can over-report
+///     as a content delta, never under-report;
+///   • honesty (Q3) — if either side's deep read hit the expansion cap, <see cref="Result.Complete"/> is
+///     false and the caller must not claim identity beyond what was actually compared.
+/// </summary>
+public static class FieldsDiff
+{
+    /// <summary>Field-level deltas, preformatted for the conflict-tree render. <see cref="Complete"/> false ⇒
+    /// at least one side's read was truncated at the expansion cap, so an empty <see cref="Deltas"/> must NOT
+    /// be rendered as "identical to winner" (Q3 — never claim knowledge the comparison doesn't have).</summary>
+    public sealed record Result(IReadOnlyList<string> Deltas, bool Complete);
+
+    /// <summary>Compare one plugin's deep-read fields against the winner's. Both sides should be read by the
+    /// same <see cref="ReadEngine.ReadFields"/> call shape (same paths, same depth) so line sets correspond.</summary>
+    public static Result Compare(RecordFields theirs, RecordFields winner)
+    {
+        var (tLines, tComplete) = CleanLines(theirs);
+        var (wLines, wComplete) = CleanLines(winner);
+
+        // Outermost positional-list roots seen on EITHER side (the union, so a 0-item-vs-N-item list is
+        // still compared as elements rather than as its summary token).
+        var roots = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var (p, _) in tLines) if (ListRoot(p) is { } r) roots.Add(r);
+        foreach (var (p, _) in wLines) if (ListRoot(p) is { } r) roots.Add(r);
+
+        var deltas = new List<string>();
+
+        // ---- scalar / substruct / dict leaves: exact-path comparison ------------------------------------
+        var tScalar = ScalarLines(tLines, roots);
+        var wScalar = ScalarLines(wLines, roots);
+        foreach (var (path, val) in tScalar)
+        {
+            if (wScalar.TryGetValue(path, out var wv))
+            {
+                if (!string.Equals(NormalizeForCompare(val), NormalizeForCompare(wv), StringComparison.Ordinal))
+                    deltas.Add($"{path}={val} (winner {wv})");
+            }
+            else deltas.Add($"{path}={val} (winner has no {path})");   // shape difference (e.g. another ConditionData arm)
+        }
+        foreach (var (path, wv) in wScalar)
+            if (!tScalar.ContainsKey(path)) deltas.Add($"{path} only in winner: {wv}");
+
+        // ---- positional lists: order-insensitive whole-element multiset comparison ----------------------
+        foreach (var root in roots.OrderBy(r => r, StringComparer.Ordinal))
+        {
+            var tElems = ElementsOf(tLines, root);
+            var wElems = ElementsOf(wLines, root);
+            var (onlyT, onlyW) = MultisetDiff(tElems, wElems);
+            if (onlyT.Count == 0 && onlyW.Count == 0) continue;        // same contents (possibly reordered) — no delta
+            deltas.Add(DescribeListDelta(root, tElems.Count, wElems.Count, onlyT, onlyW));
+        }
+
+        return new Result(deltas, tComplete && wComplete);
+    }
+
+    /// <summary>The read's lines minus the expansion-cap sentinel; each value is the round-trippable token or,
+    /// for a non-leaf/absent line, its note. Complete=false iff the sentinel was present.</summary>
+    static (List<(string path, string val)> lines, bool complete) CleanLines(RecordFields rf)
+    {
+        var lines = new List<(string, string)>(rf.Fields.Count);
+        bool complete = true;
+        foreach (var f in rf.Fields)
+        {
+            if (f.Path == "…") { complete = false; continue; }         // ReadEngine's expansion-cap sentinel (Q3)
+            lines.Add((f.Path, f.HasValue ? f.Token ?? "" : f.Note ?? ""));
+        }
+        return (lines, complete);
+    }
+
+    /// <summary>The path's OUTERMOST positional-list root — the prefix before its first NUMERIC bracket — or
+    /// null when it has none (scalars, substructs, and dict keys like Skills[OneHanded], which are semantic
+    /// identities and belong in exact-path comparison).</summary>
+    internal static string? ListRoot(string path)
+    {
+        int from = 0;
+        while (true)
+        {
+            int lb = path.IndexOf('[', from);
+            if (lb < 0) return null;
+            int rb = path.IndexOf(']', lb + 1);
+            if (rb < 0) return null;
+            bool numeric = rb > lb + 1;
+            for (int i = lb + 1; i < rb && numeric; i++) numeric = char.IsAsciiDigit(path[i]);
+            if (numeric) return path[..lb];
+            from = rb + 1;                                              // a dict key — keep scanning for a later list
+        }
+    }
+
+    /// <summary>Exact-path map of every line OUTSIDE positional-list content: no numeric bracket in the path,
+    /// and not itself a compared list's root summary line (those are subsumed by the element comparison —
+    /// including the 0-item side, whose only trace IS its summary line).</summary>
+    static Dictionary<string, string> ScalarLines(List<(string path, string val)> lines, HashSet<string> roots)
+    {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var (path, val) in lines)
+            if (ListRoot(path) is null && !roots.Contains(path))
+                map[path] = val;
+        return map;
+    }
+
+    sealed record Element(int Index, List<(string rel, string val)> Content, string Fingerprint);
+
+    /// <summary>Group a root's bracketed lines into whole elements: positional index + (relative path, value)
+    /// content + an order-insensitive content fingerprint (nested content included verbatim).</summary>
+    static List<Element> ElementsOf(List<(string path, string val)> lines, string root)
+    {
+        var byIndex = new SortedDictionary<int, List<(string rel, string val)>>();
+        var prefix = root + "[";
+        foreach (var (path, val) in lines)
+        {
+            if (!path.StartsWith(prefix, StringComparison.Ordinal)) continue;
+            int rb = path.IndexOf(']', prefix.Length);
+            if (rb < 0 || !int.TryParse(path.AsSpan(prefix.Length, rb - prefix.Length), out var idx)) continue;
+            var rel = rb + 1 < path.Length && path[rb + 1] == '.' ? path[(rb + 2)..] : path[(rb + 1)..];
+            if (!byIndex.TryGetValue(idx, out var content)) byIndex[idx] = content = new();
+            content.Add((rel, val));
+        }
+        return byIndex.Select(kv => new Element(kv.Key, kv.Value,
+            string.Join("\u0001", kv.Value.Select(c => c.rel + "=" + NormalizeForCompare(c.val)).OrderBy(s => s, StringComparer.Ordinal)))).ToList();
+    }
+
+    /// <summary>Case-normalise a value for COMPARISON when it is a FormKey token ("XXXXXX:Plugin.esp").
+    /// ModKeys are case-insensitive and each plugin stores a master's filename as written in ITS OWN master
+    /// list, so the same link can render "17DDC4:ccBGSSSE001-Fish.esm" in one version and
+    /// "17ddc4:ccbgssse001-fish.esm" in another (seen live on the report's PlayerFaction record) — an ordinal
+    /// comparison would report a false content delta. Display keeps each side's original token; only equality
+    /// checks and element fingerprints use this form. Non-FormKey values pass through untouched (string
+    /// content stays case-SENSITIVE).</summary>
+    static string NormalizeForCompare(string val)
+    {
+        if (val.Length < 8 || val[6] != ':') return val;
+        for (int i = 0; i < 6; i++) if (!Uri.IsHexDigit(val[i])) return val;
+        return string.Concat(val[..6].ToUpperInvariant(), ":", val[7..].ToLowerInvariant());
+    }
+
+    /// <summary>Content-keyed multiset difference: elements (with multiplicity) present on one side only.
+    /// Equal multisets ⇒ the lists hold the same contents, merely (possibly) reordered ⇒ no delta.</summary>
+    static (List<Element> onlyT, List<Element> onlyW) MultisetDiff(List<Element> t, List<Element> w)
+    {
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var e in w) counts[e.Fingerprint] = counts.GetValueOrDefault(e.Fingerprint) + 1;
+        var onlyT = new List<Element>();
+        foreach (var e in t)
+        {
+            if (counts.TryGetValue(e.Fingerprint, out var n) && n > 0) counts[e.Fingerprint] = n - 1;
+            else onlyT.Add(e);
+        }
+        var onlyW = new List<Element>();
+        foreach (var e in w)
+            if (counts.TryGetValue(e.Fingerprint, out var n) && n > 0) { onlyW.Add(e); counts[e.Fingerprint] = n - 1; }
+        return (onlyT, onlyW);
+    }
+
+    static string DescribeListDelta(string root, int tCount, int wCount, List<Element> onlyT, List<Element> onlyW)
+    {
+        var sb = new StringBuilder();
+        sb.Append(root).Append(": ").Append(tCount).Append(" vs winner ").Append(wCount).Append(" item(s)");
+        if (tCount == wCount) sb.Append(", contents differ");
+        if (onlyT.Count > 0) sb.Append(" — only here: ").Append(DescribeElements(onlyT));
+        if (onlyW.Count > 0) sb.Append(onlyT.Count > 0 ? "; " : " — ").Append("only in winner: ").Append(DescribeElements(onlyW));
+        return sb.ToString();
+    }
+
+    /// <summary>Up to 2 elements, each as its index plus up to 3 identifying leaf values (emit order — the
+    /// model's field order — with the bare element-summary line used only when no real leaves exist).</summary>
+    static string DescribeElements(List<Element> elems)
+    {
+        var parts = elems.Take(2).Select(e =>
+        {
+            var fields = e.Content.Where(c => c.rel.Length > 0).Take(3).Select(c => $"{c.rel}={c.val}").ToList();
+            if (fields.Count == 0) fields = e.Content.Take(1).Select(c => c.val).ToList();
+            int more = Math.Max(0, e.Content.Count(c => c.rel.Length > 0) - 3);
+            return $"[{e.Index}] {string.Join(", ", fields)}{(more > 0 ? $" (+{more} more field(s))" : "")}";
+        });
+        return string.Join("; ", parts) + (elems.Count > 2 ? $" (+{elems.Count - 2} more element(s))" : "");
+    }
+}

--- a/src/housecarl-core/FieldsDiff.cs
+++ b/src/housecarl-core/FieldsDiff.cs
@@ -49,13 +49,28 @@ public static class FieldsDiff
         foreach (var (p, _) in wLines) if (ListRoot(p) is { } r) candidates.Add(r);
         var listRoots = new HashSet<string>(StringComparer.Ordinal);
         foreach (var root in candidates)
-            if (!IsDictSummary(tLines, root) && !IsDictSummary(wLines, root)) listRoots.Add(root);
+        {
+            var tSum = RootSummary(tLines, root);
+            var wSum = RootSummary(wLines, root);
+            // No root-summary line on EITHER side ⇒ a fields=-bracketed read (e.g. fields=["Data[3].Name"]):
+            // the dict marker is structurally absent there, so positional handling could absorb a dict key
+            // rebinding — and the user named specific indices/keys anyway, so EXACT-PATH is the natural
+            // semantics. The failure direction flips to over-report (a reordered list under bracketed
+            // fields= shows index-wise deltas), never under-report (PR #28 review #2).
+            bool seen = tSum is not null || wSum is not null;
+            bool dict = (tSum?.Contains(" pair(s)]", StringComparison.Ordinal) ?? false)
+                     || (wSum?.Contains(" pair(s)]", StringComparison.Ordinal) ?? false);
+            if (seen && !dict) listRoots.Add(root);
+        }
 
         var deltas = new List<string>();
 
         // ---- exact-path comparison: scalars, substructs, dict children (bracket = a semantic key) --------
-        var tScalar = ExactPathLines(tLines, listRoots);
-        var wScalar = ExactPathLines(wLines, listRoots);
+        // On a TRUNCATED comparison the list roots' own summary lines join the exact-path set: a root count
+        // token read on BOTH sides is a real, cap-independent read, so a count delta still surfaces even
+        // though element comparison is suppressed (PR #28 review #2, non-blocking note).
+        var tScalar = ExactPathLines(tLines, listRoots, includeListRootSummaries: !complete);
+        var wScalar = ExactPathLines(wLines, listRoots, includeListRootSummaries: !complete);
         foreach (var (path, val) in tScalar)
         {
             if (wScalar.TryGetValue(path, out var wv))
@@ -90,14 +105,13 @@ public static class FieldsDiff
         return new Result(deltas, complete);
     }
 
-    /// <summary>True when the root's own summary line carries the read engine's dict marker ("N pair(s)") —
-    /// the in-band signal that the root's brackets hold semantic KEYS, not positional indices.</summary>
-    static bool IsDictSummary(List<(string path, string val)> lines, string root)
+    /// <summary>The root's own container-summary line ("[Type: N item(s)/pair(s)]"), or null when the read
+    /// never emitted one (a fields=-bracketed read names element paths directly, skipping the root).</summary>
+    static string? RootSummary(List<(string path, string val)> lines, string root)
     {
         foreach (var (path, val) in lines)
-            if (path == root)
-                return val.Contains(" pair(s)]", StringComparison.Ordinal);
-        return false;
+            if (path == root) return val;
+        return null;
     }
 
     /// <summary>The read's lines minus the expansion-cap sentinel; each value is the round-trippable token or,
@@ -137,14 +151,15 @@ public static class FieldsDiff
     /// children and dict-root summaries (a dict bracket is a semantic key — numeric or not — so exact-path is
     /// the correct comparison), excluding only positional-list content and the list roots' own summary lines
     /// (subsumed by the element comparison — including the 0-item side, whose only trace IS its summary).</summary>
-    static Dictionary<string, string> ExactPathLines(List<(string path, string val)> lines, HashSet<string> listRoots)
+    static Dictionary<string, string> ExactPathLines(List<(string path, string val)> lines,
+        HashSet<string> listRoots, bool includeListRootSummaries = false)
     {
         var map = new Dictionary<string, string>(StringComparer.Ordinal);
         foreach (var (path, val) in lines)
         {
             var root = ListRoot(path);
             bool positionalContent = root is not null && listRoots.Contains(root);
-            if (!positionalContent && !listRoots.Contains(path))
+            if (!positionalContent && (includeListRootSummaries || !listRoots.Contains(path)))
                 map[path] = val;
         }
         return map;

--- a/src/housecarl-core/FieldsDiff.cs
+++ b/src/housecarl-core/FieldsDiff.cs
@@ -10,16 +10,19 @@ namespace HousecarlCore;
 /// could be reported "(identical to winner)" while carrying the very edit that motivated it (the report's
 /// masked USSEP PlayerFaction regression). This module compares DEEP reads (every modeled leaf):
 ///
-///   • scalar / substruct / dict leaves — exact-path token comparison (the old behavior, at full depth;
-///     dict keys like Skills[OneHanded] are semantic identities, so exact-path is correct for them);
+///   • scalar / substruct / dict leaves — exact-path token comparison (the old behavior, at full depth).
+///     Dict brackets are semantic KEYS — non-numeric (Skills[OneHanded]) by spelling, numeric-keyed dicts
+///     (Package.Data) by the read engine's in-band "N pair(s)" container marker — so a key rebinding is a
+///     real delta, never absorbed by positional handling;
 ///   • positional LIST contents — order-INSENSITIVE multiset comparison of whole elements keyed on their
 ///     content (the report's case: USSEP and the winner store the same relations in different orders, so
 ///     an index-wise comparison would over-report; element identity is content-based). Elements present
-///     on only one side are reported with identifying leaf values. Numeric brackets ([0]) mark positional
-///     elements; nested list reordering INSIDE an element is not canonicalised (v1) — it can over-report
-///     as a content delta, never under-report;
+///     on only one side are reported with identifying leaf values. Nested list reordering INSIDE an
+///     element is not canonicalised (v1) — it can over-report as a content delta, never under-report;
 ///   • honesty (Q3) — if either side's deep read hit the expansion cap, <see cref="Result.Complete"/> is
-///     false and the caller must not claim identity beyond what was actually compared.
+///     false: list comparison and one-sided-presence deltas are SUPPRESSED (where the two caps fell would
+///     otherwise fabricate differences), only value mismatches observed on both sides are reported, and
+///     the caller must not claim identity beyond what was actually compared.
 /// </summary>
 public static class FieldsDiff
 {
@@ -34,18 +37,25 @@ public static class FieldsDiff
     {
         var (tLines, tComplete) = CleanLines(theirs);
         var (wLines, wComplete) = CleanLines(winner);
+        bool complete = tComplete && wComplete;
 
-        // Outermost positional-list roots seen on EITHER side (the union, so a 0-item-vs-N-item list is
-        // still compared as elements rather than as its summary token).
-        var roots = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var (p, _) in tLines) if (ListRoot(p) is { } r) roots.Add(r);
-        foreach (var (p, _) in wLines) if (ListRoot(p) is { } r) roots.Add(r);
+        // Numeric-bracket roots seen on EITHER side (the union, so a 0-item-vs-N-item list is still compared
+        // as elements), then split DICT-vs-LIST by the read engine's in-band container marker: a numeric-KEYED
+        // dict (Package.Data) renders "N pair(s)" and is compared by EXACT PATH — its bracket content is a
+        // semantic KEY, so the same values rebound to different keys is a real delta — while a positional
+        // list is compared by element content (PR #28 review finding 2).
+        var candidates = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var (p, _) in tLines) if (ListRoot(p) is { } r) candidates.Add(r);
+        foreach (var (p, _) in wLines) if (ListRoot(p) is { } r) candidates.Add(r);
+        var listRoots = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var root in candidates)
+            if (!IsDictSummary(tLines, root) && !IsDictSummary(wLines, root)) listRoots.Add(root);
 
         var deltas = new List<string>();
 
-        // ---- scalar / substruct / dict leaves: exact-path comparison ------------------------------------
-        var tScalar = ScalarLines(tLines, roots);
-        var wScalar = ScalarLines(wLines, roots);
+        // ---- exact-path comparison: scalars, substructs, dict children (bracket = a semantic key) --------
+        var tScalar = ExactPathLines(tLines, listRoots);
+        var wScalar = ExactPathLines(wLines, listRoots);
         foreach (var (path, val) in tScalar)
         {
             if (wScalar.TryGetValue(path, out var wv))
@@ -53,22 +63,41 @@ public static class FieldsDiff
                 if (!string.Equals(NormalizeForCompare(val), NormalizeForCompare(wv), StringComparison.Ordinal))
                     deltas.Add($"{path}={val} (winner {wv})");
             }
-            else deltas.Add($"{path}={val} (winner has no {path})");   // shape difference (e.g. another ConditionData arm)
+            // One-sided presence is only a delta when BOTH sides were fully read: on a truncated side a
+            // missing line is an artifact of WHERE its cap fell, not of content — reporting it would
+            // FABRICATE a difference (PR #28 review finding 1).
+            else if (complete) deltas.Add($"{path}={val} (winner has no {path})");   // shape difference (e.g. another ConditionData arm)
         }
-        foreach (var (path, wv) in wScalar)
-            if (!tScalar.ContainsKey(path)) deltas.Add($"{path} only in winner: {wv}");
+        if (complete)
+            foreach (var (path, wv) in wScalar)
+                if (!tScalar.ContainsKey(path)) deltas.Add($"{path} only in winner: {wv}");
 
-        // ---- positional lists: order-insensitive whole-element multiset comparison ----------------------
-        foreach (var root in roots.OrderBy(r => r, StringComparer.Ordinal))
+        // ---- positional lists: order-insensitive whole-element multiset comparison. SKIPPED entirely on a
+        //      truncated comparison — a cap landing mid-list fabricates one-sided elements and wrong counts;
+        //      the renderer surfaces the truncation instead (PR #28 review finding 1). --------------------
+        if (complete)
         {
-            var tElems = ElementsOf(tLines, root);
-            var wElems = ElementsOf(wLines, root);
-            var (onlyT, onlyW) = MultisetDiff(tElems, wElems);
-            if (onlyT.Count == 0 && onlyW.Count == 0) continue;        // same contents (possibly reordered) — no delta
-            deltas.Add(DescribeListDelta(root, tElems.Count, wElems.Count, onlyT, onlyW));
+            foreach (var root in listRoots.OrderBy(r => r, StringComparer.Ordinal))
+            {
+                var tElems = ElementsOf(tLines, root);
+                var wElems = ElementsOf(wLines, root);
+                var (onlyT, onlyW) = MultisetDiff(tElems, wElems);
+                if (onlyT.Count == 0 && onlyW.Count == 0) continue;    // same contents (possibly reordered) — no delta
+                deltas.Add(DescribeListDelta(root, tElems.Count, wElems.Count, onlyT, onlyW));
+            }
         }
 
-        return new Result(deltas, tComplete && wComplete);
+        return new Result(deltas, complete);
+    }
+
+    /// <summary>True when the root's own summary line carries the read engine's dict marker ("N pair(s)") —
+    /// the in-band signal that the root's brackets hold semantic KEYS, not positional indices.</summary>
+    static bool IsDictSummary(List<(string path, string val)> lines, string root)
+    {
+        foreach (var (path, val) in lines)
+            if (path == root)
+                return val.Contains(" pair(s)]", StringComparison.Ordinal);
+        return false;
     }
 
     /// <summary>The read's lines minus the expansion-cap sentinel; each value is the round-trippable token or,
@@ -104,15 +133,20 @@ public static class FieldsDiff
         }
     }
 
-    /// <summary>Exact-path map of every line OUTSIDE positional-list content: no numeric bracket in the path,
-    /// and not itself a compared list's root summary line (those are subsumed by the element comparison —
-    /// including the 0-item side, whose only trace IS its summary line).</summary>
-    static Dictionary<string, string> ScalarLines(List<(string path, string val)> lines, HashSet<string> roots)
+    /// <summary>Exact-path map of every line OUTSIDE positional-list content: scalars, substructs, dict
+    /// children and dict-root summaries (a dict bracket is a semantic key — numeric or not — so exact-path is
+    /// the correct comparison), excluding only positional-list content and the list roots' own summary lines
+    /// (subsumed by the element comparison — including the 0-item side, whose only trace IS its summary).</summary>
+    static Dictionary<string, string> ExactPathLines(List<(string path, string val)> lines, HashSet<string> listRoots)
     {
         var map = new Dictionary<string, string>(StringComparer.Ordinal);
         foreach (var (path, val) in lines)
-            if (ListRoot(path) is null && !roots.Contains(path))
+        {
+            var root = ListRoot(path);
+            bool positionalContent = root is not null && listRoots.Contains(root);
+            if (!positionalContent && !listRoots.Contains(path))
                 map[path] = val;
+        }
         return map;
     }
 

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -240,16 +240,21 @@ public static class ReadEngine
         if (val is IFormLinkGetter || WriteEngine.IsFormLinkOrIndex(Nullable.GetUnderlyingType(declaredType) ?? declaredType))
         { Emit(sink, ref budget, new FieldValue(path, false, null, leaf.Note)); return; }
 
-        // a container or substruct — summarise (with an element identity where we can), then maybe open it.
-        if (!Emit(sink, ref budget, new FieldValue(path, false, null, ElementSummary(val)))) return;
-        if (depth <= 1) return;
-
         // Classify dict-vs-list the SAME way the navigation does (StepIntoElement) — by the GENERIC dictionary
         // interfaces via ClosedInterface, not a separate non-generic System.Collections.IDictionary cast — so the
         // browse view and the read/write path can't drift (a getter dict need not expose the non-generic interface).
-        // A generic dict enumerates as KeyValuePair<,>; Key/Value come off each pair.
-        if (WriteEngine.ClosedInterface(val.GetType(), typeof(IDictionary<,>)) is not null
-            || WriteEngine.ClosedInterface(val.GetType(), typeof(IReadOnlyDictionary<,>)) is not null)
+        // A generic dict enumerates as KeyValuePair<,>; Key/Value come off each pair. Classified BEFORE the
+        // summary line so the summary can carry the dict marker ("pair(s)" vs "item(s)") — the in-band signal
+        // FieldsDiff uses to keep numeric-KEYED dicts (Package.Data) out of positional-list comparison, where
+        // a key rebinding would wrongly compare "identical" (PR #28 review).
+        bool isDict = WriteEngine.ClosedInterface(val.GetType(), typeof(IDictionary<,>)) is not null
+                   || WriteEngine.ClosedInterface(val.GetType(), typeof(IReadOnlyDictionary<,>)) is not null;
+
+        // a container or substruct — summarise (with an element identity where we can), then maybe open it.
+        if (!Emit(sink, ref budget, new FieldValue(path, false, null, ElementSummary(val, isDict)))) return;
+        if (depth <= 1) return;
+
+        if (isDict)
         {
             foreach (var entry in (System.Collections.IEnumerable)val)
             {
@@ -346,9 +351,9 @@ public static class ReadEngine
     /// (<see cref="SummariseContainer"/>); for a struct, <c>[TypeName]</c> plus a representative identity
     /// field (Name/EditorID/Title) where present — so a list line like
     /// <c>Properties[5] = [ScriptObjectProperty] Name=DAK_HorseBuyPerk</c> reveals which element is which.</summary>
-    static string ElementSummary(object val)
+    static string ElementSummary(object val, bool isDict = false)
     {
-        if (val is System.Collections.IEnumerable && val is not string) return SummariseContainer(val);
+        if (val is System.Collections.IEnumerable && val is not string) return SummariseContainer(val, isDict);
         var t = val.GetType();
         var typeName = RecordNaming.StripGetterInterface(RecordNaming.StripOverlay(t.Name));
         foreach (var idName in IdentityFieldNames)
@@ -447,8 +452,10 @@ public static class ReadEngine
 
         // Not a single-token VALUE leaf: a substruct / collection / arm container. The oracle never
         // drives these AS leaves — their sub-leaves are driven individually (exactly like write-proof).
-        // Summarise for the read display.
-        return LeafRead.None(SummariseContainer(val));
+        // Summarise for the read display, with the same dict-vs-list marker the depth walk renders.
+        return LeafRead.None(SummariseContainer(val,
+            WriteEngine.ClosedInterface(val.GetType(), typeof(IDictionary<,>)) is not null
+            || WriteEngine.ClosedInterface(val.GetType(), typeof(IReadOnlyDictionary<,>)) is not null));
     }
 
     // -- primitive family (mirror TryPrimitive) --------------------------------
@@ -639,14 +646,16 @@ public static class ReadEngine
     }
 
     /// <summary>A short, non-round-trippable description of a container leaf (substruct / list / dict /
-    /// arm) for the read display. Its sub-leaves are the round-trippable surface.</summary>
-    static string SummariseContainer(object val)
+    /// arm) for the read display. Its sub-leaves are the round-trippable surface. A dict renders
+    /// "N pair(s)" (vs a list's "N item(s)") — display-informative, and the in-band marker FieldsDiff
+    /// uses to keep numeric-keyed dicts out of positional-list comparison (PR #28 review).</summary>
+    static string SummariseContainer(object val, bool isDict = false)
     {
         if (val is System.Collections.IEnumerable en and not string)
         {
             int n = 0;
             foreach (var _ in en) n++;
-            return $"[{RecordNaming.StripGetterInterface(val.GetType().Name)}: {n} item(s)]";
+            return $"[{RecordNaming.StripGetterInterface(val.GetType().Name)}: {n} {(isDict ? "pair(s)" : "item(s)")}]";
         }
         return $"[{RecordNaming.StripGetterInterface(val.GetType().Name)}]";
     }

--- a/src/housecarl-generator/ConflictDiffProbe.cs
+++ b/src/housecarl-generator/ConflictDiffProbe.cs
@@ -1,0 +1,200 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// REGRESSION GUARD (standing CI instrument) for HCBR-2026-06-09-01 — the conflict-tree winner-relative diff
+/// reported "(identical to winner)" when lists differed in CONTENT but not COUNT. The old diff compared depth-1
+/// rendered lines, where a list is just a "[List: N item(s)]" count token — an affirmative false ITM verdict
+/// that masked a real override regression (the report's USSEP PlayerFaction case).
+///
+/// Self-contained: synthesizes ON DISK a master + an override of four factions exercising each comparison arm,
+/// then drives the REAL product path — <see cref="LoadOrderService.ResolveTree"/> (now a DEEP read, via the
+/// ForGuard seam) + <see cref="FieldsDiff.Compare"/> (the new content comparison) — and asserts:
+///   A. equal-count, different-content Relations → a DELTA naming the element only in each side (RED before
+///      the fix: depth-1 reads gave the comparator nothing but equal count tokens);
+///   B. same contents merely REORDERED → NO delta (content-keyed comparison; an index-wise diff over-reports);
+///   C. different counts → still a delta (the case the old diff did catch);
+///   D. a scalar field delta → still reported (the old behavior, preserved at depth);
+///   E. a read that hits the expansion cap → Complete=false (the render must NOT claim "identical"; Q3).
+///
+/// Run: <c>dotnet run --project src/housecarl-generator conflict-diff-guard</c>
+/// </summary>
+public static class ConflictDiffProbe
+{
+    static int _pass, _fail;
+
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  REGRESSION GUARD — conflict-tree content diff (HCBR-2026-06-09-01)  ################");
+        Console.WriteLine();
+        _pass = _fail = 0;
+
+        var dir = Path.Combine(Path.GetTempPath(), "hc-conflictdiff-guard");
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); } catch { }
+        Directory.CreateDirectory(dir);
+
+        const string masterName = "hcDiffMaster.esp", overName = "hcDiffOver.esp";
+        var masterPath = Path.Combine(dir, masterName);
+        var overPath = Path.Combine(dir, overName);
+
+        // ---- MASTER: four target factions (relation targets) + four subject factions, one per arm. ----
+        var master = new SkyrimMod(ModKey.FromNameAndExtension(masterName), SkyrimRelease.SkyrimSE);
+        var t = new FormKey[4];
+        for (int i = 0; i < 4; i++) { var tf = master.Factions.AddNew(); tf.EditorID = $"hcDiffTarget{i + 1}"; t[i] = tf.FormKey; }
+
+        var fA = master.Factions.AddNew(); fA.EditorID = "hcDiffContent";    // arm A: equal count, contents differ
+        fA.Relations.AddRange(new[] { Rel(t[0]), Rel(t[1]), Rel(t[2]) });
+        var fB = master.Factions.AddNew(); fB.EditorID = "hcDiffReorder";    // arm B: same contents, reordered
+        fB.Relations.AddRange(new[] { Rel(t[0]), Rel(t[1]), Rel(t[2]) });
+        var fC = master.Factions.AddNew(); fC.EditorID = "hcDiffCount";      // arm C: counts differ
+        fC.Relations.AddRange(new[] { Rel(t[0]), Rel(t[1]) });
+        var fD = master.Factions.AddNew(); fD.EditorID = "hcDiffScalar";     // arm D: scalar delta
+        fD.Flags = Faction.FactionFlag.HiddenFromPC;
+        master.BeginWrite.ToPath(masterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+        // ---- OVERRIDE (the winner): the four subjects re-shaped per arm. ----
+        var over = new SkyrimMod(ModKey.FromNameAndExtension(overName), SkyrimRelease.SkyrimSE);
+        var oA = (IFaction)WriteEngine.GenericGetOrAddAsOverride(over, fA);
+        oA.Relations.Clear();
+        oA.Relations.AddRange(new[] { Rel(t[3]), Rel(t[0]), Rel(t[1]) });    // 3 items: t3 dropped, t4 added, shuffled
+        var oB = (IFaction)WriteEngine.GenericGetOrAddAsOverride(over, fB);
+        oB.Relations.Clear();
+        oB.Relations.AddRange(new[] { Rel(t[2]), Rel(t[0]), Rel(t[1]) });    // same 3, different order
+        var oC = (IFaction)WriteEngine.GenericGetOrAddAsOverride(over, fC);
+        oC.Relations.Add(Rel(t[2]));                                          // 2 -> 3 items
+        var oD = (IFaction)WriteEngine.GenericGetOrAddAsOverride(over, fD);
+        oD.Flags = Faction.FactionFlag.SpecialCombat;                         // scalar enum delta
+        over.BeginWrite.ToPath(overPath).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
+
+        Console.WriteLine($"-- synthesized {masterName} < {overName} (winner); four factions, one comparison arm each --");
+        Console.WriteLine();
+
+        // ---- Drive the PRODUCT path: service ResolveTree (deep) + FieldsDiff per node-vs-winner. ----
+        using var resolver = LoadOrderResolver.Build(new[] { masterPath, overPath });
+        var svc = LoadOrderService.ForGuard(resolver, new UserConfigStore(Path.Combine(dir, "houseCARL.user.json")));
+
+        var dA = DiffOf(svc, fA.FormKey);
+        Check("A: equal-count content delta IS reported (the masked case)",
+              dA.Deltas.Any(d => d.StartsWith("Relations:", StringComparison.Ordinal) && d.Contains("contents differ")));
+        Check("A: the delta names the master-only element (t3)",
+              dA.Deltas.Any(d => d.Contains(t[2].ToString())));
+        Check("A: the delta names the winner-only element (t4)",
+              dA.Deltas.Any(d => d.Contains(t[3].ToString())));
+
+        var dB = DiffOf(svc, fB.FormKey);
+        Check("B: reordered-only list reports NO delta (content-keyed, order-insensitive)",
+              dB.Deltas.Count == 0 && dB.Complete);
+
+        var dC = DiffOf(svc, fC.FormKey);
+        Check("C: count delta still reported",
+              dC.Deltas.Any(d => d.StartsWith("Relations: 2 vs winner 3", StringComparison.Ordinal)));
+
+        var dD = DiffOf(svc, fD.FormKey);
+        Check("D: scalar delta still reported",
+              dD.Deltas.Any(d => d.StartsWith("Flags=", StringComparison.Ordinal) && d.Contains("winner")));
+
+        // ---- E: truncation honesty (in-memory; the expansion cap fires well below 900 relations). ----
+        var big = new SkyrimMod(new ModKey("hcDiffBig", ModType.Plugin), SkyrimRelease.SkyrimSE);
+        var bigF = big.Factions.AddNew();
+        for (int i = 0; i < 900; i++) bigF.Relations.Add(Rel(t[i % 4]));
+        var bigRead = ReadEngine.ReadFields(bigF, new[] { "Relations" }, LoadOrderService.ConflictDiffDepth);
+        var dE = FieldsDiff.Compare(bigRead, bigRead);
+        Check("E: a capped read yields Complete=false (no false 'identical' claim)",
+              dE is { Complete: false, Deltas.Count: 0 });
+
+        // ---- F: FormKey tokens differing only by hex/master-name CASE are the SAME content (ModKeys are
+        //      case-insensitive; each plugin stores a master's filename as written in ITS OWN master list —
+        //      seen live as ccBGSSSE001-Fish.esm vs ccbgssse001-fish.esm on the report's PlayerFaction). ----
+        var caseA = Fields(("Relations", null, "[3 item(s)]"), ("Relations[0]", null, "[Relation]"),
+                           ("Relations[0].Target", "17DDC4:ccBGSSSE001-Fish.esm", null));
+        var caseB = Fields(("Relations", null, "[3 item(s)]"), ("Relations[0]", null, "[Relation]"),
+                           ("Relations[0].Target", "17ddc4:ccbgssse001-fish.esm", null));
+        Check("F: FormKey case drift is NOT a content delta",
+              FieldsDiff.Compare(caseA, caseB) is { Complete: true, Deltas.Count: 0 });
+
+        Console.WriteLine();
+        Console.WriteLine($"=== conflict-diff-guard: {_pass} pass / {_fail} fail — {(_fail == 0 ? "PASS" : "FAIL")} ===");
+        return _fail == 0 ? 0 : 1;
+    }
+
+    static FieldsDiff.Result DiffOf(LoadOrderService svc, FormKey fk)
+    {
+        var tree = svc.ResolveTree(fk, null) ?? throw new InvalidOperationException($"no conflict tree for {fk}");
+        if (tree.Nodes.Count != 2) throw new InvalidOperationException($"expected 2 touching plugins for {fk}, got {tree.Nodes.Count}");
+        return FieldsDiff.Compare(tree.Nodes[0].Record, tree.Winner.Record);   // master node vs the override (winner)
+    }
+
+    static Relation Rel(FormKey target)
+    {
+        var rel = new Relation { Reaction = CombatReaction.Ally };
+        rel.Target.SetTo(target);
+        return rel;
+    }
+
+    static RecordFields Fields(params (string path, string? token, string? note)[] lines) =>
+        new("Faction", "000000:hcDiffGuard.esp", "hcDiffCase",
+            lines.Select(l => new FieldValue(l.path, l.token is not null, l.token, l.note)).ToList());
+
+    static void Check(string what, bool ok)
+    {
+        if (ok) _pass++; else _fail++;
+        Console.WriteLine($"   {what,-72}: {(ok ? "PASS" : "FAIL")}");
+    }
+
+    /// <summary>REAL-DATA proof (manual; needs an MO2 instance with the Ashe plugins): the report's exact repro —
+    /// the whole-record conflict diff of <c>E495A3:Ashe - Fire and Blood.esp</c> (MM_RelentlessFury, SPEL), whose
+    /// origin and winning patch both carry exactly 1 effect but with DIFFERENT BaseEffect. The old diff said
+    /// "(identical to winner)"; the content diff must report the Effects delta. Also prints the PlayerFaction
+    /// (000DB1:Skyrim.esm) tree diff — the masked-regression record — for eyes-on confirmation.
+    /// Run: <c>dotnet run --project src/housecarl-generator conflict-diff-proof -- --mo2 &lt;instanceDir&gt;</c></summary>
+    public static int RunProof(string[] args)
+    {
+        var f = WriteEngine.ParseFlags(args);
+        var instanceDir = f.GetValueOrDefault("mo2");
+        if (instanceDir is null || !Directory.Exists(instanceDir)) { Console.WriteLine("SKIP: needs --mo2 <instanceDir>"); return 0; }
+
+        Console.WriteLine($"################  REAL-DATA PROOF — conflict-tree content diff on {Path.GetFileName(instanceDir)}  ################");
+        Console.WriteLine();
+        var p = Mo2Instance.Resolve(instanceDir);
+        var order = Mo2LoadOrder.Build(p.ProfileDir, p.ModsDir, p.DataDir);
+        using var resolver = LoadOrderResolver.Build(order.OrderedPaths.ToList());
+        Console.WriteLine($"   resolver: {resolver.PluginCount} plugins, {resolver.RecordCount:N0} records");
+        var svc = LoadOrderService.ForGuard(resolver, new UserConfigStore(Path.Combine(Path.GetTempPath(), "hc-conflictdiff-proof.user.json")));
+
+        bool pass = true;
+        foreach (var subject in new[] { "E495A3:Ashe - Fire and Blood.esp", "000DB1:Skyrim.esm" })
+        {
+            Console.WriteLine();
+            Console.WriteLine($"-- {subject} --");
+            FormKey fk;
+            try { fk = FormKey.Factory(subject); } catch { Console.WriteLine("   (bad FormKey)"); continue; }
+            var tree = svc.ResolveTree(fk, null);
+            if (tree is null || tree.Nodes.Count < 2) { Console.WriteLine("   (not in this order, or only one plugin touches it — skipped)"); continue; }
+            var winner = tree.Winner;
+            Console.WriteLine($"   {tree.Nodes.Count} plugins touch it; winner = {winner.Plugin}");
+            for (int n = 0; n < tree.Nodes.Count - 1; n++)
+            {
+                var diff = FieldsDiff.Compare(tree.Nodes[n].Record, winner.Record);
+                var line = diff.Deltas.Count > 0 ? string.Join("; ", diff.Deltas)
+                         : diff.Complete ? "(identical to winner — full modeled content compared, list order ignored)"
+                                         : "(comparison truncated — not a verified ITM)";
+                Console.WriteLine($"   {tree.Nodes[n].Plugin}: {line}");
+            }
+            if (subject.StartsWith("E495A3", StringComparison.Ordinal))
+            {
+                var fnb = tree.Nodes.Take(tree.Nodes.Count - 1).FirstOrDefault(x => x.Plugin.StartsWith("Ashe - Fire and Blood", StringComparison.OrdinalIgnoreCase));
+                bool reported = fnb is not null
+                    && FieldsDiff.Compare(fnb.Record, winner.Record).Deltas.Any(d => d.StartsWith("Effects:", StringComparison.Ordinal) && d.Contains("0E40BF"));
+                Console.WriteLine($"   ASSERT Effects content delta reported for Ashe - Fire and Blood.esp: {(reported ? "PASS" : "FAIL")}");
+                pass &= reported;
+            }
+        }
+        Console.WriteLine();
+        Console.WriteLine($"=== conflict-diff-proof: {(pass ? "PASS" : "FAIL")} ===");
+        return pass ? 0 : 1;
+    }
+}

--- a/src/housecarl-generator/ConflictDiffProbe.cs
+++ b/src/housecarl-generator/ConflictDiffProbe.cs
@@ -141,6 +141,26 @@ public static class ConflictDiffProbe
         Check("G2: a real numeric-keyed dict renders the 'pair(s)' marker",
               packRead.Fields.Any(fv => fv.Path == "Data" && (fv.Note ?? "").Contains(" pair(s)]", StringComparison.Ordinal)));
 
+        // ---- E3: a root COUNT delta still surfaces under truncation — the root summary lines are real,
+        //      cap-independent reads on both sides (review #2's recovery note). ----
+        var truncC = Fields(("Relations", null, "[ExtendedList`1: 600 item(s)]"),
+                            ("Relations[0]", null, "[Relation]"), ("Relations[0].Target", "AAAAAA:m.esm", null),
+                            ("…", null, "(expansion truncated at 2000 lines — narrow with a field path or a lower depth)"));
+        var truncD = Fields(("Relations", null, "[ExtendedList`1: 601 item(s)]"),
+                            ("Relations[0]", null, "[Relation]"), ("Relations[0].Target", "AAAAAA:m.esm", null),
+                            ("…", null, "(expansion truncated at 2000 lines — narrow with a field path or a lower depth)"));
+        var dE3 = FieldsDiff.Compare(truncC, truncD);
+        Check("E3: truncated comparison still reports a root COUNT delta",
+              dE3 is { Complete: false, Deltas.Count: 1 } && dE3.Deltas[0].StartsWith("Relations=", StringComparison.Ordinal));
+
+        // ---- H: a fields=-BRACKETED read (fields=["Data[3].Name"]) emits no root summary, so the dict
+        //      marker is structurally absent — such roots must fall to EXACT-PATH comparison, not positional
+        //      handling (review #2: a dict key swap compared "identical" through this hole). ----
+        var brackA = Fields(("Data[0].Name", "TopicData", null), ("Data[3].Name", "Repeatable", null));
+        var brackB = Fields(("Data[0].Name", "Repeatable", null), ("Data[3].Name", "TopicData", null));
+        Check("H: bracketed fields= read without a root summary compares exact-path",
+              FieldsDiff.Compare(brackA, brackB) is { Complete: true, Deltas.Count: 2 });
+
         // ---- F: FormKey tokens differing only by hex/master-name CASE are the SAME content (ModKeys are
         //      case-insensitive; each plugin stores a master's filename as written in ITS OWN master list —
         //      seen live as ccBGSSSE001-Fish.esm vs ccbgssse001-fish.esm on the report's PlayerFaction). ----

--- a/src/housecarl-generator/ConflictDiffProbe.cs
+++ b/src/housecarl-generator/ConflictDiffProbe.cs
@@ -106,6 +106,41 @@ public static class ConflictDiffProbe
         Check("E: a capped read yields Complete=false (no false 'identical' claim)",
               dE is { Complete: false, Deltas.Count: 0 });
 
+        // ---- E2: a TRUNCATED comparison must not FABRICATE deltas from where the cap fell (PR #28 review):
+        //      one side cut mid-list ⇒ no list or one-sided deltas; a value mismatch observed on BOTH sides
+        //      (read before either cap) still reports. ----
+        var truncA = Fields(("Flags", "A", null), ("Relations", null, "[2 item(s)]"),
+                            ("Relations[0]", null, "[Relation]"), ("Relations[0].Target", "AAAAAA:m.esm", null),
+                            ("…", null, "(expansion truncated at 2000 lines — narrow with a field path or a lower depth)"));
+        var fullB = Fields(("Flags", "B", null), ("Relations", null, "[2 item(s)]"),
+                           ("Relations[0]", null, "[Relation]"), ("Relations[0].Target", "AAAAAA:m.esm", null),
+                           ("Relations[1]", null, "[Relation]"), ("Relations[1].Target", "BBBBBB:m.esm", null));
+        var dE2 = FieldsDiff.Compare(truncA, fullB);
+        Check("E2: truncation fabricates NO list/one-sided deltas; both-sides mismatch kept",
+              dE2 is { Complete: false, Deltas.Count: 1 } && dE2.Deltas[0].StartsWith("Flags=A", StringComparison.Ordinal));
+
+        // ---- G: a numeric-KEYED dict (Package.Data) — the bracket is a semantic KEY: the same values bound
+        //      to swapped keys is a REAL delta, and must not vanish into order-insensitive list handling
+        //      (PR #28 review: pre-fix this compared "identical"). Classified by the engine's in-band
+        //      "pair(s)" marker. ----
+        var dictA = Fields(("Data", null, "[Dictionary`2: 2 pair(s)]"),
+                           ("Data[0]", null, "[PackageDataBool]"), ("Data[0].Name", "TopicData", null),
+                           ("Data[3]", null, "[PackageDataBool]"), ("Data[3].Name", "Repeatable", null));
+        var dictB = Fields(("Data", null, "[Dictionary`2: 2 pair(s)]"),
+                           ("Data[0]", null, "[PackageDataBool]"), ("Data[0].Name", "Repeatable", null),
+                           ("Data[3]", null, "[PackageDataBool]"), ("Data[3].Name", "TopicData", null));
+        Check("G: numeric-keyed dict key rebinding IS a delta (exact-path, not positional)",
+              FieldsDiff.Compare(dictA, dictB) is { Complete: true, Deltas.Count: 2 });
+
+        // ---- G2: the dict marker is REAL — the engine renders a numeric-keyed dict (Package.Data) as
+        //      "pair(s)", the in-band signal arm G's classification rests on. ----
+        var packMod = new SkyrimMod(new ModKey("hcDiffPack", ModType.Plugin), SkyrimRelease.SkyrimSE);
+        var pack = packMod.Packages.AddNew();
+        pack.Data.Add(3, new PackageDataBool { Name = "hcDiffPackDatum" });
+        var packRead = ReadEngine.ReadFields(pack, new[] { "Data" }, 4);
+        Check("G2: a real numeric-keyed dict renders the 'pair(s)' marker",
+              packRead.Fields.Any(fv => fv.Path == "Data" && (fv.Note ?? "").Contains(" pair(s)]", StringComparison.Ordinal)));
+
         // ---- F: FormKey tokens differing only by hex/master-name CASE are the SAME content (ModKeys are
         //      case-insensitive; each plugin stores a master's filename as written in ITS OWN master list —
         //      seen live as ccBGSSSE001-Fish.esm vs ccbgssse001-fish.esm on the report's PlayerFaction). ----

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -165,6 +165,14 @@ if (args.Length > 0 && args[0] == "perk-refs-guard") return PerkRefsProbe.RunGua
 // over a live MO2 order through the service layer. Manual; needs --mo2 + --corpus (skips without).
 if (args.Length > 0 && args[0] == "perk-refs-proof") return PerkRefsProbe.RunProof(args[1..]);
 
+// Conflict-tree content diff (HCBR-2026-06-09-01): SELF-CONTAINED CI regression guard — synthesizes a master + override
+// with equal-count/reordered/count/scalar list arms, drives the REAL ResolveTree (deep) + FieldsDiff, asserts each arm.
+if (args.Length > 0 && args[0] == "conflict-diff-guard") return ConflictDiffProbe.RunGuard(args[1..]);
+
+// Conflict-tree content diff (HCBR-2026-06-09-01): REAL-DATA proof — the report's exact repro (MM_RelentlessFury's
+// "(identical to winner)" false ITM) over a live MO2 order. Manual; needs --mo2 (skips without).
+if (args.Length > 0 && args[0] == "conflict-diff-proof") return ConflictDiffProbe.RunProof(args[1..]);
+
 // External-tool bridge (step 1) proof: the pure core pieces housecarl_set_tool_path + the riders ride — shared-config
 // clobber-safety, path validation, the missing-dependency forcing prompt, and canonical-home auto-detect.
 if (args.Length > 0 && args[0] == "tool-bridge") return ToolBridgeProbe.Run(args[1..]);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -331,10 +331,18 @@ public sealed class LoadOrderService : IDisposable
         return new ReadOutcome(fk, record, source, winner.Value.WinnerPlugin, winner.Value.OverrideDepth, touching, null);
     }
 
+    /// <summary>How deep the conflict diff reads each touching body. The diff must compare CONTENT, not the
+    /// depth-1 count summaries that masked equal-count list deltas (HCBR-2026-06-09-01) — deep enough to reach
+    /// every modeled scalar leaf (the walk is bounded by the modeled-corpus boundary + ReadEngine's expansion
+    /// cap, whose truncation sentinel FieldsDiff surfaces as Complete=false).</summary>
+    internal const int ConflictDiffDepth = 16;
+
     /// <summary>The winner's full conflict tree, MATERIALISED — every touching plugin's name + its fields read off its
-    /// own body, in priority order (winner last) — for the field-level diff view. Opens a per-call session, fetches each
-    /// touching body, reads its <paramref name="fields"/> into a plain DTO, then DISPOSES the session (Option B): the
-    /// render layer never touches a live overlay or holds a handle. null if the FormKey isn't in the order.</summary>
+    /// own body, in priority order (winner last) — for the field-level diff view, read DEEP (<see cref="ConflictDiffDepth"/>)
+    /// so the diff compares list/substruct CONTENT, not depth-1 count summaries (HCBR-2026-06-09-01). Opens a per-call
+    /// session, fetches each touching body, reads its <paramref name="fields"/> into a plain DTO, then DISPOSES the
+    /// session (Option B): the render layer never touches a live overlay or holds a handle. null if the FormKey isn't
+    /// in the order.</summary>
     public ConflictTreeView? ResolveTree(FormKey fk, IReadOnlyList<string>? fields)
     {
         var resolver = Resolver;
@@ -343,7 +351,7 @@ public sealed class LoadOrderService : IDisposable
         if (tree is null) return null;
         var nodes = new List<ConflictNodeView>(tree.Nodes.Count);
         foreach (var n in tree.Nodes)
-            nodes.Add(new ConflictNodeView(n.Plugin, ReadEngine.ReadFields(n.Record, fields)));   // materialise while open
+            nodes.Add(new ConflictNodeView(n.Plugin, ReadEngine.ReadFields(n.Record, fields, ConflictDiffDepth)));   // materialise while open
         return new ConflictTreeView(nodes);
     }
 

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -261,11 +261,14 @@ static class Wire
         if (tree is null || tree.Nodes.Count <= 1) return;
 
         var winnerNode = tree.Winner;                                       // Nodes[^1] = highest priority = the winner
-        var winnerFields = new Dictionary<string, string?>(StringComparer.Ordinal);
-        foreach (var f in winnerNode.Record.Fields)
-            winnerFields[f.Path] = f.HasValue ? f.Token : f.Note;
 
-        sb.Append("diff (field deltas vs winner ").Append(winnerNode.Plugin).Append("; identical fields omitted):\n");
+        // CONTENT diff (HCBR-2026-06-09-01): each node's DEEP read vs the winner's, compared by FieldsDiff —
+        // scalar leaves exact-path, list contents order-insensitively by whole element. The old depth-1 token
+        // comparison called equal-count lists with different contents "identical to winner" — an affirmative
+        // false ITM that masked a real override regression. "Identical" is now only claimed when the FULL
+        // modeled content compared clean; a truncated comparison says so instead (Q3).
+        sb.Append("diff (field deltas vs winner ").Append(winnerNode.Plugin)
+          .Append("; identical fields omitted; list contents compared order-insensitively):\n");
         for (int n = 0; n < tree.Nodes.Count - 1; n++)                      // every node except the winner
         {
             if (sb.Length >= cap)
@@ -275,18 +278,14 @@ static class Wire
                 return;
             }
             var node = tree.Nodes[n];
-            var deltas = new StringBuilder();
-            foreach (var f in node.Record.Fields)
-            {
-                var theirs = f.HasValue ? f.Token : f.Note;
-                if (winnerFields.TryGetValue(f.Path, out var win) && string.Equals(win, theirs, StringComparison.Ordinal))
-                    continue;                                               // identical to winner — omit
-                if (deltas.Length > 0) deltas.Append("; ");
-                deltas.Append(f.Path).Append('=').Append(theirs);
-                if (winnerFields.TryGetValue(f.Path, out var w2)) deltas.Append(" (winner ").Append(w2).Append(')');
-            }
-            sb.Append("  ").Append(node.Plugin).Append(": ")
-              .Append(deltas.Length > 0 ? deltas.ToString() : "(identical to winner)").Append('\n');
+            var diff = FieldsDiff.Compare(node.Record, winnerNode.Record);
+            string line = diff.Deltas.Count > 0
+                ? string.Join("; ", diff.Deltas)
+                  + (diff.Complete ? "" : " [comparison truncated at the expansion cap — the deltas shown are real, but completeness is not guaranteed; narrow with fields=]")
+                : diff.Complete
+                    ? "(identical to winner — full modeled content compared, list order ignored)"
+                    : "(no differences found, but the comparison was TRUNCATED at the expansion cap — NOT a verified ITM; narrow with fields= to fully compare)";
+            sb.Append("  ").Append(node.Plugin).Append(": ").Append(line).Append('\n');
         }
     }
 }

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -281,10 +281,16 @@ static class Wire
             var diff = FieldsDiff.Compare(node.Record, winnerNode.Record);
             string line = diff.Deltas.Count > 0
                 ? string.Join("; ", diff.Deltas)
-                  + (diff.Complete ? "" : " [comparison truncated at the expansion cap — the deltas shown are real, but completeness is not guaranteed; narrow with fields=]")
+                  + (diff.Complete ? "" : " [comparison TRUNCATED at the expansion cap — only value mismatches observed on both sides are shown; list contents and one-sided fields were NOT compared; narrow with fields= to fully compare]")
                 : diff.Complete
                     ? "(identical to winner — full modeled content compared, list order ignored)"
                     : "(no differences found, but the comparison was TRUNCATED at the expansion cap — NOT a verified ITM; narrow with fields= to fully compare)";
+            // One node's joined deltas are unbounded (two divergent deep reads can carry thousands); slice
+            // against the remaining char budget with the same explicit notice the other cuts use (Q3).
+            int room = cap - sb.Length;
+            if (line.Length > room)
+                line = string.Concat(line.AsSpan(0, Math.Max(0, room)),
+                    " ... [delta line truncated at max_chars; narrow with fields= or raise max_chars]");
             sb.Append("  ").Append(node.Plugin).Append(": ").Append(line).Append('\n');
         }
     }

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -283,7 +283,11 @@ static class Wire
                 ? string.Join("; ", diff.Deltas)
                   + (diff.Complete ? "" : " [comparison TRUNCATED at the expansion cap — only value mismatches observed on both sides are shown; list contents and one-sided fields were NOT compared; narrow with fields= to fully compare]")
                 : diff.Complete
-                    ? "(identical to winner — full modeled content compared, list order ignored)"
+                    // The identity claim must not outrun the comparison's scope: a fields=-narrowed diff
+                    // compared ONLY those paths, never the whole record (PR #28 review #2).
+                    ? (fields is { Count: > 0 }
+                        ? "(identical to winner across the requested fields, list order ignored — other fields NOT compared)"
+                        : "(identical to winner — full modeled content compared, list order ignored)")
                     : "(no differences found, but the comparison was TRUNCATED at the expansion cap — NOT a verified ITM; narrow with fields= to fully compare)";
             // One node's joined deltas are unbounded (two divergent deep reads can carry thousands); slice
             // against the remaining char budget with the same explicit notice the other cuts use (Q3).


### PR DESCRIPTION
Fixes **HCBR-2026-06-09-01** (High) — the conflict-tree winner-relative diff reported **"(identical to winner)"** when lists differed in content but not count.

> **Stacked on [#27](https://github.com/Avick3110/houseCARL/pull/27)** — uses its `ForGuard` seam + generator→mcp reference for the service-level CI guard. Merge #27 first; this branch then rebases clean (its own change is the last commit).

## What was broken

The diff compared depth-1 rendered lines, where a list collapses to a `[List: N item(s)]` count token. Equal-count lists with different contents compared identical; when no scalar differed either, the whole override was labeled "(identical to winner)" — an affirmative false ITM verdict. It masked a real USSEP PlayerFaction regression during the Ashe audit (a dropped CC fish-faction relation inside an 86-vs-86 list) and endorsed an unsound ITM cleanup judgment. Worse, count deltas *did* report, so there was no cue that equal-count cases were blind spots.

## The fix

- **`ResolveTree` reads each touching body deep** (`ConflictDiffDepth=16`, bounded by the modeled-corpus boundary and the expansion cap) — the tree is materialized solely for the diff, so display behavior elsewhere is unchanged.
- **New core `FieldsDiff`** compares the deep reads:
  - scalar / substruct / dict leaves — exact-path token comparison (dict keys are semantic identities);
  - positional **list contents — order-insensitive**, as whole-element multisets keyed on content (the report's explicit ask: USSEP and the winner store the same relations in different orders, so index-wise comparison would over-report). One-sided elements are reported with identifying leaf values;
  - **FormKey tokens case-normalized for comparison only** — ModKeys are case-insensitive and each plugin stores a master's filename as written in its own master list (`ccBGSSSE001-Fish.esm` vs `ccbgssse001-fish.esm`, seen live), otherwise a false content delta;
  - **honesty (Q3)** — "identical to winner" is claimed only when the full modeled content compared clean; a capped comparison renders "NOT a verified ITM" instead.

## Proof

**`conflict-diff-guard`** (new self-contained CI guard, drives the real `ResolveTree` + `FieldsDiff` product path): 8/8 —

- equal-count content delta reported, both one-sided elements named (**RED at depth-1** — the masked case, demonstrated by temporarily reverting the deep read);
- reorder-only list → no delta; count delta and scalar delta still report; capped read → `Complete=false`; FormKey case drift → no delta.

**`conflict-diff-proof`** (real data, ARR 2.0, 3,509 plugins) — the report's exact repro:

```
-- E495A3:Ashe - Fire and Blood.esp --  (was "(identical to winner)")
Ashe - Fire and Blood.esp: Effects: 1 vs winner 1 item(s), contents differ —
  only here: [0] BaseEffect=0E40BF:Skyrim.esm, …; only in winner: [0] BaseEffect=000801:…

-- 000DB1:Skyrim.esm (PlayerFaction — the masked regression) --
unofficial skyrim special edition patch.esp: … Relations: 86 vs winner 87 item(s) — only in winner: [0] Target=0008CE:Ashe - Fire and Blood.esp …
Ashe - Fire and Blood.esp: Relations: 86 vs winner 87 item(s) — only in winner: [86] Target=17DDC4:ccBGSSSE001-Fish.esm …
Ashe - Requiem Economy Patch.esp: (identical to winner — full modeled content compared, list order ignored)
```

Fire and Blood's dropped fish relation — the regression the old diff actively endorsed as benign — is now visible at a glance, and the economy-patch re-override (the session's manual fix) verifies as a true ITM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
