### PR TITLE
CI: bump checkout/setup-dotnet to Node 24 majors; verify the windows-2025-vs2026 image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,7 @@ on:
 jobs:
   build-and-probe:
     name: build + probes
-    # TEMPORARY explicit pin: windows-latest redirects to this image on 2026-06-15 — one green
-    # run here proves the job on it ahead of the switch, then this reverts to windows-latest.
-    runs-on: windows-2025-vs2026   # houseCARL is a Windows-only (Skyrim SE) product — match that
+    runs-on: windows-latest   # houseCARL is a Windows-only (Skyrim SE) product — match that
     steps:
       - name: Check out the code
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,15 @@ on:
 jobs:
   build-and-probe:
     name: build + probes
-    runs-on: windows-latest   # houseCARL is a Windows-only (Skyrim SE) product — match that
+    # TEMPORARY explicit pin: windows-latest redirects to this image on 2026-06-15 — one green
+    # run here proves the job on it ahead of the switch, then this reverts to windows-latest.
+    runs-on: windows-2025-vs2026   # houseCARL is a Windows-only (Skyrim SE) product — match that
     steps:
       - name: Check out the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up .NET 9
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '9.0.x'
 


### PR DESCRIPTION
## Why

GitHub Actions annotations on recent runs carry two deprecation warnings:

1. **`actions/checkout@v4` and `actions/setup-dotnet@v4` run on Node.js 20** — actions are forced to Node 24 starting **2026-06-16**, and Node 20 is removed from runners **2026-09-16**.
2. **`windows-latest` is being redirected to `windows-2025-vs2026`** by **2026-06-15**.

## What

- **`actions/checkout@v4` → `@v6`** (latest major, v6.0.3). Verified `runs.using: node24` at the tag. The only behavior change beyond the runtime bump is that credentials persist to a separate file instead of `.git/config` — this workflow does no git operations after checkout, so it is inert here.
- **`actions/setup-dotnet@v4` → `@v5`** (latest major, v5.3.0). Verified `runs.using: node24` at the tag. Its only other breaking change drops installs of *old* .NET versions; we pin `9.0.x`.
- Both majors require runner ≥ v2.327.1 — GitHub-hosted runners are always current.
- **Image verification, empirically:** the first commit temporarily pins `runs-on: windows-2025-vs2026` (the label is already live in actions/runner-images) so one green run proves build + probes on the exact image `windows-latest` will become. A follow-up commit on this branch reverts to `windows-latest` so the alias keeps tracking GitHub's redirect — and that run proves the new actions on the current image too. Nothing in the job depends on image contents: the .NET 9 SDK comes from setup-dotnet, and the probes self-skip external tools (CK compiler, BSArch).

## Proof

- CI run on commit 1 = new actions + new image, green.
- CI run on commit 2 = new actions + current image (`windows-latest`), green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)