### PR TITLE
Release v1.2.2 - four bug fixes from the Requiem-audit wave

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ models — by construction, not a hand-maintained subset.
 
 ### Download — recommended (modders)
 
-1. Download **`houseCARL-1.2.1.zip`** from the [latest release](https://github.com/Avick3110/houseCARL/releases).
+1. Download **`houseCARL-1.2.2.zip`** from the [latest release](https://github.com/Avick3110/houseCARL/releases).
 2. Unzip it and run **`houseCARL-Setup.exe`**.
 3. Pick your host — **`[1] Claude Code`**, **`[2] Codex`**, or **`[3] Both`**. The installer wires
    everything up:
@@ -70,7 +70,7 @@ cd houseCARL
 
 The script regenerates the reflection rulebook, publishes the server framework-dependent (trimming **off**
 — houseCARL is reflection-driven, so trimming would strip types and silently lose coverage), bundles the
-skills, builds the setup utility, and packs `release/houseCARL-1.2.1.zip`. Install the output with
+skills, builds the setup utility, and packs `release/houseCARL-1.2.2.zip`. Install the output with
 `houseCARL-Setup.exe`, `claude --plugin-dir ./dist/housecarl`, or the bundled local-marketplace
 descriptor — see the script header for details.
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "housecarl",
   "displayName": "houseCARL",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Comprehensive data-layer access to your Skyrim SE load order — read any record, author patches into a new plugin, look mods up on Nexus, and look up record schemas, Papyrus signatures, performance reviews, and distributor grammars — in plain English.",
   "author": { "name": "Avick3110" },
   "homepage": "https://github.com/Avick3110/houseCARL",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to houseCARL are documented here. Versioning is [semantic](h
 the `version` in `.claude-plugin/plugin.json` is bumped on each release, so installed users update only
 when it changes.
 
+## 1.2.2 — 2026-06-10
+
+Fixes four issues surfaced auditing a Requiem load order — all in reads and writes, no change to the tool
+set.
+
+- **New records get valid FormIDs:** creating a record in a patch that was first written by a bulk apply
+  could allocate FormIDs starting at `000000` — the null range the game and other tools reject. houseCARL
+  now floors every new-record allocation at `0x800` (the user range Bethesda reserves) from every write
+  path, and persists a floored high-water mark into the patch so later edits and removals never regress it.
+  Patches that already carry a `000000` record stay readable and editable — nothing is auto-renumbered,
+  which would break references.
+- **Conflict diffs compare real content:** the conflict tree's "what differs between these overrides"
+  comparison looked only at top-level field counts, so two overrides that changed the *contents* of a list
+  or struct without changing its length could be reported as identical. The diff now walks the record's
+  full depth — list elements compared order-insensitively, sub-structs and nested values compared by value
+  — so a genuine deep difference is no longer missed, and the output stays honest when a record is too
+  large to fully expand.
+- **One unreadable record no longer breaks a whole query:** a single record Mutagen can't parse — for
+  example a malformed perk an upstream ESP ships — used to abort an *entire* `housecarl_cross_plugin_query`
+  that scans references, returning nothing. houseCARL now isolates the offending record, scans past it, and
+  reports how many records were skipped and why, so the rest of the results come through.
+- **Form-targeted conditions read correctly:** a condition that points at a form — `HasPerk`,
+  `HasMagicEffect`, `GetInFaction`, and the like — used to render a placeholder instead of the form's
+  FormID when read. houseCARL now resolves the target through its link, so those condition payloads show
+  their real FormID.
+
 ## 1.2.1 — 2026-06-08
 
 Adds value-based record querying and a fuller Nexus lookup, and fixes several read and write rough edges.


### PR DESCRIPTION
## Release v1.2.2

Doc-only release bump that ships the four bug fixes already merged to `main` from the 2026-06-09 Requiem-audit wave (HCBR-2026-06-09-01..04). **No code changes in this PR** — version + changelog + README only. PATCH bump (fixes only, no new tools; tool surface stays 16).

### What ships (already on `main`)
- **New records get valid FormIDs** ([#30](https://github.com/Avick3110/houseCARL/pull/30)) — `create_record` into a `bulk_apply`-born patch no longer allocates from `0x000000`; floored at `0x800` from every write path, high-water mark persisted so removes don't regress it.
- **Conflict diffs compare real content** ([#29](https://github.com/Avick3110/houseCARL/pull/29)) — the conflict-tree diff walks full depth (`FieldsDiff`) instead of depth-1 count summaries, so equal-length content changes are no longer reported as identical.
- **One unreadable record no longer breaks a whole query** ([#27](https://github.com/Avick3110/houseCARL/pull/27)) — per-record fault isolation on `cross_plugin_query references=`, with skipped-count accounting.
- **Form-targeted conditions read correctly** ([#26](https://github.com/Avick3110/houseCARL/pull/26)) — `HasPerk` / `HasMagicEffect` / `GetInFaction`-style condition payloads resolve through the FLOI's `.Link` and show the real FormID.

(CI Node-24 action bumps ([#31](https://github.com/Avick3110/houseCARL/pull/31)) are internal infrastructure — intentionally omitted from the user-facing changelog.)

### This PR's diff
- `plugin/.claude-plugin/plugin.json` — `1.2.1` → `1.2.2` (single source of truth)
- `plugin/CHANGELOG.md` — new `1.2.2 — 2026-06-10` entry (modder-facing, four bullets)
- `README.md` — `houseCARL-1.2.1.zip` → `houseCARL-1.2.2.zip` (download + build refs)

### Verification
- `scripts/build-plugin.ps1` → `houseCARL-1.2.2.zip` (10.12 MB, 305 entries), leak-check clean, version stamped 1.2.2.
- `claude plugin validate ./dist/housecarl --strict` → **passed**.
- Docs staleness pass: both READMEs already current (all 6 skills incl. `papyrus-optimization`, Nexus tools, full credits); only the version strings were stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)