### PR TITLE
Install pre-reqs: fix the wrong ASP.NET-includes-base-runtime claim; setup preflight-checks both runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,17 @@ models — by construction, not a hand-maintained subset.
 ## Requirements
 
 - **Windows.**
-- **.NET 9 — the [ASP.NET Core Runtime 9.0](https://dotnet.microsoft.com/download/dotnet/9.0).** houseCARL
-  ships framework-dependent (the runtime is not bundled), and the server needs the ASP.NET Core shared
-  framework — the plain ".NET Runtime" or "Desktop Runtime" is **not** sufficient. Install the
-  **ASP.NET Core Runtime** (it includes the base .NET runtime).
+- **.NET 9 — both the .NET Runtime 9.0 *and* the ASP.NET Core Runtime 9.0**, from the same
+  [download page](https://dotnet.microsoft.com/download/dotnet/9.0). houseCARL ships framework-dependent
+  (the runtime is not bundled), and the server needs the ASP.NET Core shared framework *on top of* the
+  base .NET runtime. On Windows these are **two separate installers** — the ASP.NET Core Runtime
+  installer does **not** include the base .NET Runtime — so install both. The setup utility checks for
+  both and tells you exactly which is missing.
 - **[Mod Organizer 2](https://www.modorganizer.org/)** with a modlist. houseCARL reads the instance's
   profile files statically — **MO2 does not need to be running.**
-- **An AI host:** [Claude Code](https://claude.com/claude-code) (v2.1.143 or newer) **or** OpenAI Codex.
+- **An AI host:** [Claude Code](https://claude.com/claude-code) (v2.1.143 or newer) — either the terminal
+  CLI or the Claude desktop app, which has Claude Code built in (houseCARL runs in Claude Code sessions,
+  not the plain chat) — **or** OpenAI Codex.
 
 ## Install
 

--- a/packaging/START-HERE.txt
+++ b/packaging/START-HERE.txt
@@ -39,12 +39,20 @@ INSTALL  (about 30 seconds, no command line)
 REQUIREMENTS
 ------------------------------------------------------------------------
   - Windows (x64).
-  - .NET 9 -- the ASP.NET Core Runtime 9.0 (NOT just the base ".NET
-    Runtime" or "Desktop Runtime"; the server needs the ASP.NET Core
-    one, which includes the base runtime). The runtime, not the SDK.
+  - .NET 9 -- BOTH of these runtimes, from the same download page:
+        1)  .NET Runtime 9.0
+        2)  ASP.NET Core Runtime 9.0
+    They are two separate installers, and the ASP.NET Core one does
+    NOT include the base .NET Runtime -- install both. (The runtimes,
+    not the SDK.)
         https://dotnet.microsoft.com/download/dotnet/9.0
-        or:  winget install Microsoft.DotNet.AspNetCore.9
-  - A recent Claude Code / Claude desktop app  (v2.1.143 or newer).
+        or:  winget install Microsoft.DotNet.Runtime.9
+             winget install Microsoft.DotNet.AspNetCore.9
+    houseCARL-Setup.exe checks for both and tells you which one is
+    missing, so when in doubt just run it.
+  - A recent Claude Code  (v2.1.143 or newer) -- the terminal CLI, or
+    the Claude desktop app (Claude Code is built in; houseCARL runs in
+    Claude Code sessions, not the plain chat).
   - Mod Organizer 2 with a modlist.  MO2 does NOT need to be running.
 
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -32,10 +32,11 @@ models, by construction — not a hand-maintained subset.
 ## Requirements
 
 - **Windows.**
-- **.NET 9 — the [ASP.NET Core Runtime 9.0](https://dotnet.microsoft.com/download/dotnet/9.0)** installed.
-  houseCARL ships framework-dependent (the runtime is not bundled), and the server needs the ASP.NET Core
-  shared framework, so the plain ".NET Runtime" or "Desktop Runtime" is not sufficient — install the
-  **ASP.NET Core Runtime** (it includes the base .NET runtime).
+- **.NET 9 — both the .NET Runtime 9.0 *and* the ASP.NET Core Runtime 9.0**, from the same
+  [download page](https://dotnet.microsoft.com/download/dotnet/9.0). houseCARL ships framework-dependent
+  (the runtime is not bundled), and the server needs the ASP.NET Core shared framework *on top of* the
+  base .NET runtime. On Windows these are **two separate installers** — the ASP.NET Core Runtime
+  installer does **not** include the base .NET Runtime — so install both.
 - **[Mod Organizer 2](https://www.modorganizer.org/)** with a modlist. houseCARL reads the instance's
   profile files statically — **MO2 does not need to be running.**
 - **Claude Code v2.1.143 or newer.** (Earlier builds ignore the plugin's `displayName`; loading a zipped

--- a/scripts/build-plugin.ps1
+++ b/scripts/build-plugin.ps1
@@ -59,8 +59,11 @@ if (-not $Version) { throw "could not read 'version' from $PluginManifest" }
 Write-Host ("Building houseCARL v{0}" -f $Version) -ForegroundColor Green
 
 # ---- 0. clean --------------------------------------------------------------
-Step '0/10' 'Clean dist/housecarl'
-if (Test-Path $DistRoot) { Remove-Item $DistRoot -Recurse -Force }
+# Clean the WHOLE package root, not just dist/housecarl: stale package-root extras (codex/,
+# START-HERE.txt, a previous setup exe) would otherwise survive into the zip - a stale nested
+# codex/codex/ subtree did exactly that at the 1.2.2 build.
+Step '0/10' 'Clean dist/ (package root)'
+if (Test-Path $PkgRoot) { Remove-Item $PkgRoot -Recurse -Force }
 New-Item -ItemType Directory -Path $DistRoot -Force | Out-Null
 
 # ---- 1. regenerate the rulebook (corpus.json + mutagen-reference shards, in sync by construction)

--- a/scripts/build-plugin.ps1
+++ b/scripts/build-plugin.ps1
@@ -129,9 +129,13 @@ if (Test-Path $CodexSrc) { Copy-Item $CodexSrc (Join-Path $PkgRoot 'codex') -Rec
 # ~/.claude/skills/housecarl/ (desktop auto-loads the skills) and registers the MCP server in
 # ~/.claude.json (desktop spawns it per session). It ships in the PACKAGE ROOT (dist\), beside - not
 # inside - the housecarl/ plugin tree, so the leak-check (which scans dist\housecarl only) correctly
-# leaves it out of scope. Single-file, framework-dependent (matches the server's runtime requirement).
+# leaves it out of scope. Single-file, SELF-CONTAINED (trimmed + compressed): setup must run on a
+# machine with no .NET installed at all, so it can preflight-check the two runtimes the
+# framework-dependent SERVER needs (.NET Runtime + ASP.NET Core Runtime - separate installers on
+# Windows) and say exactly which is missing. Trimming is safe HERE (setup uses only the
+# System.Text.Json DOM, no reflection serialization) - the server's trimming ban is untouched.
 Step '7/10' 'Publish the setup utility (houseCARL-Setup.exe) into dist/'
-dotnet publish $SetupProj -c Release -r win-x64 --self-contained false -p:PublishSingleFile=true -p:DebugType=None -p:DebugSymbols=false -o $PkgRoot
+dotnet publish $SetupProj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=true -p:EnableCompressionInSingleFile=true -p:DebugType=None -p:DebugSymbols=false -o $PkgRoot
 if ($LASTEXITCODE -ne 0) { throw "setup-utility publish failed (exit $LASTEXITCODE)" }
 $SetupExe = Join-Path $PkgRoot 'houseCARL-Setup.exe'
 if (-not (Test-Path $SetupExe)) { throw "setup utility not produced at $SetupExe" }

--- a/src/housecarl-setup/Program.cs
+++ b/src/housecarl-setup/Program.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
@@ -31,6 +32,11 @@ internal static class Program
     private const string PluginFolderName = "housecarl"; // plugin dir shipped beside this exe
     private const string McpServerName    = "housecarl"; // server key under mcpServers / [mcp_servers.*]
 
+    // Major version of the runtimes the bundled SERVER needs (keep in sync with housecarl-mcp's
+    // TargetFramework). The default roll-forward policy stays within a major, so "10.x installed"
+    // does not satisfy a net9.0 framework-dependent server.
+    private const string ServerRuntimeMajor = "9";
+
     private enum Target { Claude, Codex, Both }
 
     private static int Main(string[] args)
@@ -44,6 +50,7 @@ internal static class Program
             Console.WriteLine("    --claude   install for Claude Code only");
             Console.WriteLine("    --codex    install for Codex only");
             Console.WriteLine("    --both     install for both");
+            Console.WriteLine("    --skip-runtime-check   skip the .NET runtime preflight (custom DOTNET_ROOT etc.)");
             return 0;
         }
 
@@ -64,6 +71,42 @@ internal static class Program
                 Console.Error.WriteLine("  Looked in: " + pluginSrc);
                 Console.Error.WriteLine("  Keep this program in the same folder as the unzipped 'housecarl' folder, then run it again.");
                 return Finish(1);
+            }
+
+            // ---- server runtime preflight ------------------------------------
+            // The bundled server is framework-dependent net9.0 + ASP.NET Core: it needs BOTH the
+            // base .NET Runtime (Microsoft.NETCore.App) and the ASP.NET Core Runtime
+            // (Microsoft.AspNetCore.App). On Windows those are TWO separate installers, and the
+            // ASP.NET Core one does NOT include the base runtime -- a real-world install trap.
+            // This exe ships self-contained precisely so it still runs on a machine with neither
+            // and can say exactly what's missing, instead of the install "succeeding" into a
+            // server that never starts.
+            if (!args.Contains("--skip-runtime-check"))
+            {
+                List<string> missing = MissingServerRuntimes();
+                if (missing.Count > 0)
+                {
+                    Console.Error.WriteLine("ERROR: the houseCARL server needs .NET runtime(s) that are not installed:");
+                    if (missing.Contains("Microsoft.NETCore.App"))
+                        Console.Error.WriteLine("    - .NET Runtime " + ServerRuntimeMajor + ".x           (Microsoft.NETCore.App)");
+                    if (missing.Contains("Microsoft.AspNetCore.App"))
+                        Console.Error.WriteLine("    - ASP.NET Core Runtime " + ServerRuntimeMajor + ".x   (Microsoft.AspNetCore.App)");
+                    Console.Error.WriteLine();
+                    Console.Error.WriteLine("  Both come from the same page:");
+                    Console.Error.WriteLine("    https://dotnet.microsoft.com/download/dotnet/" + ServerRuntimeMajor + ".0");
+                    Console.Error.WriteLine("  NOTE: they are two separate installers, and the ASP.NET Core Runtime");
+                    Console.Error.WriteLine("  installer does NOT include the base .NET Runtime -- you need both.");
+                    Console.Error.WriteLine("  Or via winget:");
+                    Console.Error.WriteLine("    winget install Microsoft.DotNet.Runtime." + ServerRuntimeMajor);
+                    Console.Error.WriteLine("    winget install Microsoft.DotNet.AspNetCore." + ServerRuntimeMajor);
+                    Console.Error.WriteLine();
+                    Console.Error.WriteLine("  Install the missing runtime(s), then run this setup again. (If you're sure");
+                    Console.Error.WriteLine("  your setup is fine -- e.g. a custom dotnet location -- re-run this setup");
+                    Console.Error.WriteLine("  with --skip-runtime-check.)");
+                    return Finish(1);
+                }
+                Console.WriteLine("[check] .NET Runtime " + ServerRuntimeMajor + " + ASP.NET Core Runtime " + ServerRuntimeMajor + ": found.");
+                Console.WriteLine();
             }
 
             // HOUSECARL_SETUP_HOME overrides the home dir (testing / unusual setups).
@@ -93,6 +136,57 @@ internal static class Program
             Console.Error.WriteLine("  " + ex.Message);
             return Finish(1);
         }
+    }
+
+    // ---- server runtime preflight ------------------------------------------
+
+    /// <summary>
+    /// Which of the server's required shared frameworks are missing at the required major version.
+    /// Asks `dotnet --list-runtimes` first (covers custom install locations on PATH); falls back to
+    /// scanning the default machine-wide install dir, which also covers a console whose PATH predates
+    /// a just-finished runtime install.
+    /// </summary>
+    private static List<string> MissingServerRuntimes()
+    {
+        string[] required = { "Microsoft.NETCore.App", "Microsoft.AspNetCore.App" };
+        HashSet<string> found = new(StringComparer.Ordinal);
+
+        try
+        {
+            ProcessStartInfo psi = new("dotnet", "--list-runtimes")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError  = true,
+                UseShellExecute        = false,
+                CreateNoWindow         = true,
+            };
+            using Process? p = Process.Start(psi);
+            if (p is not null)
+            {
+                string output = p.StandardOutput.ReadToEnd();
+                p.WaitForExit(15000);
+                foreach (string line in output.Split('\n'))
+                {
+                    string t = line.Trim();
+                    foreach (string fx in required)
+                        if (t.StartsWith(fx + " " + ServerRuntimeMajor + ".", StringComparison.Ordinal))
+                            found.Add(fx);
+                }
+            }
+        }
+        catch { /* dotnet not on PATH -- the folder scan below still gets a say */ }
+
+        string sharedDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "dotnet", "shared");
+        foreach (string fx in required)
+        {
+            if (found.Contains(fx)) continue;
+            string fxDir = Path.Combine(sharedDir, fx);
+            if (Directory.Exists(fxDir) && Directory.GetDirectories(fxDir, ServerRuntimeMajor + ".*").Length > 0)
+                found.Add(fx);
+        }
+
+        return required.Where(fx => !found.Contains(fx)).ToList();
     }
 
     // ---- target selection (flag or interactive prompt) --------------------

--- a/src/housecarl-setup/Program.cs
+++ b/src/housecarl-setup/Program.cs
@@ -97,8 +97,10 @@ internal static class Program
                     Console.Error.WriteLine("  NOTE: they are two separate installers, and the ASP.NET Core Runtime");
                     Console.Error.WriteLine("  installer does NOT include the base .NET Runtime -- you need both.");
                     Console.Error.WriteLine("  Or via winget:");
-                    Console.Error.WriteLine("    winget install Microsoft.DotNet.Runtime." + ServerRuntimeMajor);
-                    Console.Error.WriteLine("    winget install Microsoft.DotNet.AspNetCore." + ServerRuntimeMajor);
+                    if (missing.Contains("Microsoft.NETCore.App"))
+                        Console.Error.WriteLine("    winget install Microsoft.DotNet.Runtime." + ServerRuntimeMajor);
+                    if (missing.Contains("Microsoft.AspNetCore.App"))
+                        Console.Error.WriteLine("    winget install Microsoft.DotNet.AspNetCore." + ServerRuntimeMajor);
                     Console.Error.WriteLine();
                     Console.Error.WriteLine("  Install the missing runtime(s), then run this setup again. (If you're sure");
                     Console.Error.WriteLine("  your setup is fine -- e.g. a custom dotnet location -- re-run this setup");
@@ -163,14 +165,25 @@ internal static class Program
             using Process? p = Process.Start(psi);
             if (p is not null)
             {
-                string output = p.StandardOutput.ReadToEnd();
-                p.WaitForExit(15000);
-                foreach (string line in output.Split('\n'))
+                // Drain stderr asynchronously so a broken dotnet host writing errors can't fill the
+                // pipe and deadlock the stdout read, and bound the whole interaction so a wedged host
+                // can't hang the preflight - on timeout we kill it and fall through to the folder scan.
+                p.ErrorDataReceived += (_, _) => { };
+                p.BeginErrorReadLine();
+                Task<string> stdoutTask = p.StandardOutput.ReadToEndAsync();
+                if (!p.WaitForExit(15000))
                 {
-                    string t = line.Trim();
-                    foreach (string fx in required)
-                        if (t.StartsWith(fx + " " + ServerRuntimeMajor + ".", StringComparison.Ordinal))
-                            found.Add(fx);
+                    try { p.Kill(entireProcessTree: true); } catch { /* already exited */ }
+                }
+                if (stdoutTask.Wait(2000))
+                {
+                    foreach (string line in stdoutTask.Result.Split('\n'))
+                    {
+                        string t = line.Trim();
+                        foreach (string fx in required)
+                            if (t.StartsWith(fx + " " + ServerRuntimeMajor + ".", StringComparison.Ordinal))
+                                found.Add(fx);
+                    }
                 }
             }
         }
@@ -182,7 +195,11 @@ internal static class Program
         {
             if (found.Contains(fx)) continue;
             string fxDir = Path.Combine(sharedDir, fx);
-            if (Directory.Exists(fxDir) && Directory.GetDirectories(fxDir, ServerRuntimeMajor + ".*").Length > 0)
+            // A version folder must actually contain assemblies - an empty 9.x dir left behind by an
+            // aborted install/uninstall must not count as "installed".
+            if (Directory.Exists(fxDir) &&
+                Directory.GetDirectories(fxDir, ServerRuntimeMajor + ".*")
+                    .Any(d => Directory.EnumerateFiles(d, "*.dll").Any()))
                 found.Add(fx);
         }
 


### PR DESCRIPTION
## Origin

A user bug report: install took *a long while* because (1) installing the ASP.NET Core Runtime per our docs left the machine without the base .NET runtime, and (2) they downloaded the Claude desktop app and wired houseCARL into the plain chat side by hand.

Verified against Microsoft's install matrix ([Install .NET on Windows](https://learn.microsoft.com/en-us/dotnet/core/install/windows)): the standalone ASP.NET Core Runtime installer for Windows includes the base .NET Runtime: **No**. All three of our shipped docs claimed the opposite - a user who followed them exactly got a machine where neither the server nor the (framework-dependent) setup exe could launch.

## Changes (3 commits)

1. **Docs** (`README.md`, `plugin/README.md`, `packaging/START-HERE.txt`): require **both** the .NET Runtime 9.0 and the ASP.NET Core Runtime 9.0, say they are two separate installers, fix the winget line to install both, and clarify the host (Claude Code = terminal CLI or built into the Claude desktop app; houseCARL runs in Claude Code sessions, not the plain chat).
2. **Setup preflight** (`Program.cs` + build step 7): `houseCARL-Setup.exe` now ships **self-contained** (trimmed + compressed single file, 10.60 MB) so it runs on a machine with no .NET at all, and before installing anything it checks for both `Microsoft.NETCore.App 9.x` and `Microsoft.AspNetCore.App 9.x` (`dotnet --list-runtimes`, then a default-install-dir scan). Missing -> names exactly what to install with the download page + winget commands, exit 1. `--skip-runtime-check` escape hatch. Trimming is safe for setup (DOM JSON only); the server publish and its trimming ban are untouched.
3. **Build script step 0**: clean the whole `dist/` package root, not just `dist/housecarl` - the latent fix flagged at the 1.2.2 ship (stale `codex/codex/` subtree surviving rebuilds).

## Proof

- Happy path: built exe reports `[check] .NET Runtime 9 + ASP.NET Core Runtime 9: found.` and proceeds.
- Missing path: a scratch build requiring runtime major **42** reported both runtimes missing, printed the full fix-it message, exited 1, installed nothing.
- Skip flag: goes straight to the host prompt.
- Full `build-plugin.ps1`: green, leak-check clean, **305 entries** (clean-root fix holding), zip 15.64 MB (+5.5 MB for the self-contained setup).
- `claude plugin validate dist/housecarl --strict`: passed.

Zip-size trade-off (10.12 -> 15.64 MB) was accepted by Aaron before implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)