### PR TITLE
Binding shim + named-error hardening: malformed tool arguments coerce or fail named (HCBR-2026-06-11-01)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,10 @@ jobs:
       # object IDs >= 0x800 and a floored persisted counter from every entry path (HCBR-2026-06-09-04).
       - name: Probe — FormID allocation floor (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- formid-floor-guard
+
+      # Drives the REAL housecarl-mcp.exe over stdio — the exact wire path of the live failure; needs no game data
+      # (argument binding resolves before configuration is consulted): a regression guard locking in the tool-argument
+      # binding shim — string-for-array coerces, missing-required refuses by name, an uncoercible shape fails NAMED
+      # (never the SDK's generic text), and the published schema stays a declared array (HCBR-2026-06-11-01).
+      - name: Probe — tool-argument binding shim (drives the real server over stdio)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- binding-shim-guard

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -74,26 +74,43 @@ public sealed class LoadOrderResolver : IDisposable
     readonly Dictionary<string, int> _nameToIdx;       // plugin filename → index (last copy of a duplicate name wins = priority)
     DateTime[] _mtimes;                                // last-write at the last index build, per path (freshness baseline)
 
-    Dictionary<FormKey, (int winner, int count)> _index;   // ALL keys — winner + depth, O(1)
-    Dictionary<FormKey, int[]> _overriders;                // MULTI keys only — ordered touching overlay indices
-    List<string> _loadFailures = new();                    // per-plugin index-build failures (open OR parse), surfaced (Q3)
-    HashSet<int> _excluded = new();                        // overlay indices excluded this build — never re-touched by any path
-    Dictionary<string, string> _excludedPlugins = new(StringComparer.OrdinalIgnoreCase); // excluded plugin name → reason (Q3)
+    /// <summary>One index build's ENTIRE output, swapped in as a SINGLE reference write. The service refreshes the
+    /// index under its own gate, but READERS run outside that gate (concurrent tool calls hold the resolver while a
+    /// sibling call's freshness check may rebuild) — when the per-build state lived in five separate fields, a reader
+    /// could observe a NEW index next to OLD overriders mid-swap (a KeyNotFound on a freshly-multi key, surfaced as an
+    /// opaque transport error pre-Guard). Bundling the build into one immutable snapshot, captured ONCE per operation
+    /// (iterators capture at enumeration start), makes a torn view impossible by construction (HCBR-2026-06-11-01
+    /// hardening). The volatile field gives the swap release/acquire visibility.</summary>
+    sealed class IndexSnapshot
+    {
+        public readonly Dictionary<FormKey, (int winner, int count)> Index;   // ALL keys — winner + depth, O(1)
+        public readonly Dictionary<FormKey, int[]> Overriders;                // MULTI keys only — ordered touching overlay indices
+        public readonly List<string> LoadFailures;                            // per-plugin index-build failures (open OR parse), surfaced (Q3)
+        public readonly HashSet<int> Excluded;                                // overlay indices excluded this build — never re-touched by any path
+        public readonly Dictionary<string, string> ExcludedPlugins;           // excluded plugin name → reason (Q3)
+        public readonly int MaxDepth;
+
+        public IndexSnapshot(Dictionary<FormKey, (int winner, int count)> index, Dictionary<FormKey, int[]> overriders,
+                             List<string> loadFailures, HashSet<int> excluded, Dictionary<string, string> excludedPlugins, int maxDepth)
+        { Index = index; Overriders = overriders; LoadFailures = loadFailures; Excluded = excluded; ExcludedPlugins = excludedPlugins; MaxDepth = maxDepth; }
+    }
+
+    volatile IndexSnapshot _snap;
 
     /// <summary>Per-plugin index-build failures (couldn't open, or contains a record Mutagen can't parse) — each
     /// excluded plugin named with its reason, surfaced never silently skipped (Q3). Same content as
     /// <see cref="ExcludedPlugins"/>, formatted "name: reason" for log/harness display.</summary>
-    public IReadOnlyList<string> LoadFailures => _loadFailures;
+    public IReadOnlyList<string> LoadFailures => _snap.LoadFailures;
 
     /// <summary>Plugins EXCLUDED from this build (name → why): unopenable, or carrying a record Mutagen can't parse.
     /// Their records are not in the index and no path will re-touch them; load_order_status reports them so the user
     /// can fix/remove the upstream plugin (Q3 — the exclusion is visible, not silent).</summary>
-    public IReadOnlyDictionary<string, string> ExcludedPlugins => _excludedPlugins;
+    public IReadOnlyDictionary<string, string> ExcludedPlugins => _snap.ExcludedPlugins;
 
     public int PluginCount => _paths.Length;
-    public int RecordCount => _index.Count;            // distinct FormKeys across the order
-    public int ConflictCount => _overriders.Count;     // FormKeys overridden by >1 plugin
-    public int MaxDepth { get; private set; }
+    public int RecordCount => _snap.Index.Count;            // distinct FormKeys across the order
+    public int ConflictCount => _snap.Overriders.Count;     // FormKeys overridden by >1 plugin
+    public int MaxDepth => _snap.MaxDepth;
 
     /// <summary>Every plugin's filename, in priority order (PURE DATA — no handles). The known-name list the write
     /// harnesses scan to decide which masters are in the order; replaces the old held-overlay ModKey enumeration.</summary>
@@ -214,8 +231,7 @@ public sealed class LoadOrderResolver : IDisposable
     LoadOrderResolver(string[] paths, string[] names, Dictionary<string, int> nameToIdx, DateTime[] mtimes)
     {
         _paths = paths; _names = names; _nameToIdx = nameToIdx; _mtimes = mtimes;
-        _index = new(); _overriders = new();
-        BuildIndex();
+        _snap = BuildIndex();
     }
 
     /// <summary>Take the plugin paths already in priority order and build the index — WITHOUT holding any plugin open
@@ -253,8 +269,10 @@ public sealed class LoadOrderResolver : IDisposable
     /// enumerates, so a malformed subrecord throws here, NOT lazily on field access), is EXCLUDED wholesale and the
     /// reason recorded — it no longer takes the whole index down with it. Per plugin it's ATOMIC: records go into a
     /// per-plugin buffer and fold into the shared index only if the WHOLE plugin enumerated, so a plugin that throws
-    /// part-way never leaves a half-set behind (which would mis-resolve winners for its un-enumerated records).</summary>
-    void BuildIndex()
+    /// part-way never leaves a half-set behind (which would mis-resolve winners for its un-enumerated records).
+    /// Returns the build as ONE immutable <see cref="IndexSnapshot"/> — the caller swaps it in with a single
+    /// reference write, so a concurrent reader only ever sees a complete, internally-consistent build.</summary>
+    IndexSnapshot BuildIndex()
     {
         var index = new Dictionary<FormKey, (int winner, int count)>();
         var overriders = new Dictionary<FormKey, List<int>>();        // multi keys only
@@ -308,12 +326,10 @@ public sealed class LoadOrderResolver : IDisposable
             }
         }
 
-        _index = index;
-        _overriders = overriders.ToDictionary(kv => kv.Key, kv => kv.Value.ToArray());  // trim List overhead → int[]
-        MaxDepth = maxDepth;
-        _loadFailures = failures;
-        _excluded = excluded;
-        _excludedPlugins = excludedPlugins;
+        return new IndexSnapshot(
+            index,
+            overriders.ToDictionary(kv => kv.Key, kv => kv.Value.ToArray()),  // trim List overhead → int[]
+            failures, excluded, excludedPlugins, maxDepth);
     }
 
     /// <summary>Record one plugin's exclusion from the index build (Q3): into the human-readable failure list, the
@@ -344,18 +360,19 @@ public sealed class LoadOrderResolver : IDisposable
 
     /// <summary>O(1): the winning plugin + override depth for a FormKey. null if the FormKey isn't in the order.</summary>
     public WinnerInfo? ResolveWinner(FormKey fk)
-        => _index.TryGetValue(fk, out var e) ? new WinnerInfo(fk, _names[e.winner], e.count) : null;
+        => _snap.Index.TryGetValue(fk, out var e) ? new WinnerInfo(fk, _names[e.winner], e.count) : null;
 
     /// <summary>Every FormKey overridden by more than one plugin (the whole-order conflict set).</summary>
-    public IEnumerable<FormKey> ConflictKeys() => _overriders.Keys;
+    public IEnumerable<FormKey> ConflictKeys() => _snap.Overriders.Keys;
 
     /// <summary>The ordered touching-plugin names for a FormKey (priority order, winner last) — no body fetched.
     /// The atom behind every conflict-status question.</summary>
     public IReadOnlyList<string>? TouchingPlugins(FormKey fk)
     {
-        if (!_index.TryGetValue(fk, out var e)) return null;
+        var s = _snap;                                                 // ONE build — Index and Overriders can't disagree
+        if (!s.Index.TryGetValue(fk, out var e)) return null;
         if (e.count == 1) return new[] { _names[e.winner] };           // singleton: sole overrider = winner
-        return Array.ConvertAll(_overriders[fk], i => _names[i]);
+        return Array.ConvertAll(s.Overriders[fk], i => _names[i]);
     }
 
     /// <summary>The full conflict tree: every touching plugin's body, in priority order (winner last). Bodies are
@@ -363,8 +380,9 @@ public sealed class LoadOrderResolver : IDisposable
     /// materialised them, then disposes them). null if the FormKey isn't in the order.</summary>
     public ConflictTree? ResolveTree(OverlaySession session, FormKey fk)
     {
-        if (!_index.TryGetValue(fk, out var e)) return null;
-        var overlayIdxs = e.count == 1 ? new[] { e.winner } : _overriders[fk];
+        var s = _snap;                                                 // ONE build — Index and Overriders can't disagree
+        if (!s.Index.TryGetValue(fk, out var e)) return null;
+        var overlayIdxs = e.count == 1 ? new[] { e.winner } : s.Overriders[fk];
         var nodes = new ConflictNode[overlayIdxs.Length];
         string? recType = null;
         for (int n = 0; n < overlayIdxs.Length; n++)
@@ -382,18 +400,21 @@ public sealed class LoadOrderResolver : IDisposable
     /// disposes it when the enumeration ends (Option B — self-scoped, one handle); the yielded status is pure data.</summary>
     public IEnumerable<RecordStatus> PluginRecordStatus(string pluginName)
     {
+        var s = _snap;                                                 // ONE build, captured for the whole enumeration
         if (!_nameToIdx.TryGetValue(pluginName, out int idx))
             throw new ArgumentException($"plugin not in the load order: {pluginName}");
-        if (_excluded.Contains(idx))
-            throw new ArgumentException($"plugin '{pluginName}' was excluded from this session: {_excludedPlugins[pluginName]}");
+        if (s.Excluded.Contains(idx))
+            throw new ArgumentException($"plugin '{pluginName}' was excluded from this session: {s.ExcludedPlugins[pluginName]}");
         var ov = SkyrimMod.CreateFromBinaryOverlay(_paths[idx], SkyrimRelease.SkyrimSE);
         try
         {
             foreach (var rec in ov.EnumerateMajorRecords())
             {
                 var fk = rec.FormKey;
-                var e = _index[fk];                                        // present by construction (we enumerated it)
-                var touching = e.count == 1 ? new[] { _names[e.winner] } : Array.ConvertAll(_overriders[fk], i => _names[i]);
+                if (!s.Index.TryGetValue(fk, out var e))               // the FILE outran the snapshot (edited after the build) — name it (Q3)
+                    throw new InvalidOperationException(
+                        $"index staleness: '{pluginName}' yields {fk} which the current index build does not contain — the plugin changed since the index was built; re-run (the next call's freshness check rebuilds).");
+                var touching = e.count == 1 ? new[] { _names[e.winner] } : Array.ConvertAll(s.Overriders[fk], i => _names[i]);
                 yield return new RecordStatus(fk, RecordNaming.StripOverlay(rec.GetType().Name),
                                               PluginWins: e.winner == idx, OverrideDepth: e.count, TouchingPlugins: touching);
             }
@@ -409,7 +430,7 @@ public sealed class LoadOrderResolver : IDisposable
     public IMajorRecordGetter? GetRecord(OverlaySession session, string pluginName, FormKey fk)
     {
         if (!_nameToIdx.TryGetValue(pluginName, out int idx)) return null;
-        if (_excluded.Contains(idx)) return null;                          // excluded plugin — never re-enumerate it (would re-throw); the service reports the reason via ExcludedPlugins
+        if (_snap.Excluded.Contains(idx)) return null;                     // excluded plugin — never re-enumerate it (would re-throw); the service reports the reason via ExcludedPlugins
         foreach (var rec in session.Overlay(idx).EnumerateMajorRecords())
             if (rec.FormKey == fk) return rec;
         return null;
@@ -440,9 +461,10 @@ public sealed class LoadOrderResolver : IDisposable
     /// types are always real).</summary>
     public IEnumerable<(FormKey fk, int depth, IMajorRecordGetter body)> WinnerRecordsOfType(IReadOnlyList<Type> getterTypes)
     {
+        var s = _snap;                                                     // ONE build, captured for the whole scan
         for (int i = 0; i < _paths.Length; i++)
         {
-            if (_excluded.Contains(i)) continue;                           // excluded at build (unparseable/unopenable) — wins nothing; never re-touch (would re-throw)
+            if (s.Excluded.Contains(i)) continue;                          // excluded at build (unparseable/unopenable) — wins nothing; never re-touch (would re-throw)
             ISkyrimModGetter ov;
             try { ov = SkyrimMod.CreateFromBinaryOverlay(_paths[i], SkyrimRelease.SkyrimSE); }
             catch { continue; }                                            // an unopenable plugin wins nothing (surfaced at build)
@@ -450,7 +472,7 @@ public sealed class LoadOrderResolver : IDisposable
             {
                 foreach (var t in getterTypes)
                     foreach (var rec in ov.EnumerateMajorRecords(t, throwIfUnknown: true))
-                        if (_index.TryGetValue(rec.FormKey, out var e) && e.winner == i)   // this overlay's instance wins
+                        if (s.Index.TryGetValue(rec.FormKey, out var e) && e.winner == i)   // this overlay's instance wins
                             yield return (rec.FormKey, e.count, rec);
             }
             finally { (ov as IDisposable)?.Dispose(); }
@@ -465,7 +487,8 @@ public sealed class LoadOrderResolver : IDisposable
     public IEnumerable<(FormKey fk, int depth, IMajorRecordGetter body, string source)> RecordsIn(
         IReadOnlyList<string> plugins, IReadOnlyList<Type>? getterTypes)
     {
-        foreach (int i in ScopeIndices(plugins))
+        var s = _snap;                                                     // ONE build, captured for the whole scan
+        foreach (int i in ScopeIndices(plugins, s))
         {
             ISkyrimModGetter ov;
             try { ov = SkyrimMod.CreateFromBinaryOverlay(_paths[i], SkyrimRelease.SkyrimSE); }
@@ -476,7 +499,7 @@ public sealed class LoadOrderResolver : IDisposable
                     ? ov.EnumerateMajorRecords()
                     : getterTypes.SelectMany(t => ov.EnumerateMajorRecords(t, throwIfUnknown: true));
                 foreach (var rec in recs)
-                    if (_index.TryGetValue(rec.FormKey, out var e))
+                    if (s.Index.TryGetValue(rec.FormKey, out var e))
                         yield return (rec.FormKey, e.count, rec, _names[i]);   // _names[i] = this scoped plugin's filename (the source body)
             }
             finally { (ov as IDisposable)?.Dispose(); }
@@ -484,18 +507,19 @@ public sealed class LoadOrderResolver : IDisposable
     }
 
     /// <summary>Resolve a scope (plugin filenames) to overlay indices; null/empty = the whole order. Throws
-    /// (Q3) on a name not in the order, naming it — never silently scans an empty/partial scope.</summary>
-    IReadOnlyList<int> ScopeIndices(IReadOnlyList<string>? scopePlugins)
+    /// (Q3) on a name not in the order, naming it — never silently scans an empty/partial scope. Works off the
+    /// caller's captured snapshot so scope and scan judge exclusion against the SAME build.</summary>
+    IReadOnlyList<int> ScopeIndices(IReadOnlyList<string>? scopePlugins, IndexSnapshot s)
     {
         if (scopePlugins is null || scopePlugins.Count == 0)
-            return Enumerable.Range(0, _paths.Length).Where(i => !_excluded.Contains(i)).ToArray();  // whole order, minus excluded
+            return Enumerable.Range(0, _paths.Length).Where(i => !s.Excluded.Contains(i)).ToArray();  // whole order, minus excluded
         var idxs = new List<int>(scopePlugins.Count);
         foreach (var name in scopePlugins)
         {
             if (!_nameToIdx.TryGetValue(name, out int i))
                 throw new ArgumentException($"plugin not in the load order: {name}");
-            if (_excluded.Contains(i))                                     // explicitly scoped to an excluded plugin → fail loud with the reason (Q3), don't silently scan nothing
-                throw new ArgumentException($"plugin '{name}' was excluded from this session: {_excludedPlugins[name]}");
+            if (s.Excluded.Contains(i))                                    // explicitly scoped to an excluded plugin → fail loud with the reason (Q3), don't silently scan nothing
+                throw new ArgumentException($"plugin '{name}' was excluded from this session: {s.ExcludedPlugins[name]}");
             idxs.Add(i);
         }
         return idxs;
@@ -515,7 +539,7 @@ public sealed class LoadOrderResolver : IDisposable
         if (!stale) return false;
 
         for (int i = 0; i < _paths.Length; i++) _mtimes[i] = SafeMtime(_paths[i]);
-        BuildIndex();
+        _snap = BuildIndex();                                              // ONE reference write — in-flight readers keep their captured build
         return true;
     }
 

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -16,8 +16,8 @@ namespace HousecarlCore;
 //  SHAPE (Aaron-confirmed 2026-06-01 off the body-fetch probe; handle model proven by handle-probe 2026-06-04):
 //    • Held index — PURE DATA, ZERO file handles — built by enumerating every plugin ONE AT A TIME (low→high
 //      priority: open i → enumerate → DISPOSE → i+1, never all-open-at-once):
-//        - _index    : FormKey → (winnerOverlay, overrideCount)  — ALL keys, the O(1) "what wins" fast path (§8.1).
-//        - _overriders: FormKey → ordered overlay indices         — MULTI-override keys ONLY (the "list of touching
+//        - Index     : FormKey → (winnerOverlay, overrideCount)  — ALL keys, the O(1) "what wins" fast path (§8.1).
+//        - Overriders: FormKey → ordered overlay indices          — MULTI-override keys ONLY (the "list of touching
 //                        plugins" §5.2 calls for; singletons' sole overrider IS the winner, so they need no list).
 //      ~125–185 MB at full-modlist scale (within §5.2's "few hundred MB"); NO record bodies, NO mmap handles held.
 //    • On-demand body fetch = open the plugin, re-enumerate + match the FormKey, then DISPOSE when the work ends.
@@ -156,13 +156,13 @@ public sealed class LoadOrderResolver : IDisposable
         public IReadOnlyList<ISkyrimModGetter> AllMasters()
         {
             // Excluded plugins (BuildIndex couldn't fully parse) are INTENTIONALLY retained here — NOT filtered by
-            // _excluded. A clean plugin can override a record whose ORIGIN master is an excluded one, and that master
+            // the snapshot's Excluded set. A clean plugin can override a record whose ORIGIN master is an excluded one, and that master
             // must still appear in the patch's output header for FormID resolution; dropping it would corrupt the
             // header. Safe: Overlay() opens lazily (no parse, no enumeration → no throw), and the serializer parses a
             // master's bodies ONLY when the patch references them — and an excluded plugin's OWN records can't be
             // referenced (they're unreadable). So this is the one read-path that touches excluded plugins on purpose,
             // and it cannot re-throw. (If a future change enumerates or link-caches over this full set, it must
-            // re-introduce the _excluded skip — the per-read "single choke point" is BuildIndex, not this method.)
+            // re-introduce the Excluded skip — the per-read "single choke point" is BuildIndex, not this method.)
             var arr = new ISkyrimModGetter[_r._paths.Length];
             for (int i = 0; i < arr.Length; i++) arr[i] = Overlay(i);
             return arr;

--- a/src/housecarl-generator/BindingShimProbe.cs
+++ b/src/housecarl-generator/BindingShimProbe.cs
@@ -1,0 +1,209 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+
+namespace HousecarlGenerator;
+
+// ======================================================================
+//  BindingShimProbe — SELF-CONTAINED CI regression guard for the tool-argument
+//  binding shim (HCBR-2026-06-11-01).
+//
+//  THE BUG: the MCP SDK deserializes a call's JSON arguments into the tool
+//  method's parameters BEFORE any houseCARL code runs. An argument whose
+//  SHAPE doesn't match the declared parameter — the live case was plugins=
+//  sent as a bare string where string[] is declared — threw inside that
+//  binding layer, and the SDK genericizes any such throw to
+//  "An error occurred invoking '<tool>'." — an opaque dead end the calling
+//  agent can't self-correct from (it abandoned the documented query path).
+//
+//  THE FIX (ToolCallShim in housecarl-mcp): a call-tool filter that
+//    (1) coerces obvious-intent shapes against the tool's own input schema
+//        (string → [string] where an array is declared; quoted numbers/bools),
+//    (2) refuses missing REQUIRED parameters with a named error, and
+//    (3) rewrites the SDK's generic binding-failure text into a named,
+//        actionable message when binding still fails.
+//
+//  THE GUARD: drives the REAL housecarl-mcp.exe over stdio (the exact wire
+//  path the live failure took) with the exact argument shapes from the bug
+//  report. Needs NO game data and NO MO2 instance: argument binding resolves
+//  before configuration is consulted, and a deliberately-unconfigured server
+//  answers every successfully-bound call with the trained config prompt —
+//  which is precisely the "our code RAN" signal the asserts key on.
+// ======================================================================
+public static class BindingShimProbe
+{
+    const string GenericError = "An error occurred invoking";          // the SDK's opaque text (measured live, HCBR-2026-06-11-01)
+    const string ConfigPrompt = "no Mod Organizer 2 instance configured"; // the unconfigured server's trained prompt = "the tool body ran"
+
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("[binding-shim-guard] tool-argument binding shim (HCBR-2026-06-11-01)");
+
+        // The mcp exe built alongside this generator (same configuration, sibling project).
+        var exe = Path.GetFullPath(AppContext.BaseDirectory.Replace(
+            Path.DirectorySeparatorChar + "housecarl-generator" + Path.DirectorySeparatorChar,
+            Path.DirectorySeparatorChar + "housecarl-mcp" + Path.DirectorySeparatorChar));
+        exe = Path.Combine(exe, "housecarl-mcp.exe");
+        if (!File.Exists(exe))
+        {
+            Console.WriteLine($"FAIL  housecarl-mcp.exe not found at '{exe}' — build the whole solution first.");
+            return 1;
+        }
+
+        // A fresh, EMPTY data dir ⇒ no houseCARL.user.json ⇒ the server boots unconfigured, deterministically —
+        // on a dev box too, where a real user config may sit beside the exe.
+        var dataDir = Path.Combine(Path.GetTempPath(), "housecarl-binding-shim-guard-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dataDir);
+
+        int failures = 0;
+        var psi = new ProcessStartInfo(exe)
+        {
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            StandardOutputEncoding = Encoding.UTF8,
+        };
+        psi.Environment["HOUSECARL_DATA_DIR"] = dataDir;
+
+        using var proc = Process.Start(psi)!;
+        proc.ErrorDataReceived += (_, _) => { };                        // server logs ride stderr — drain, ignore
+        proc.BeginErrorReadLine();
+        var stdin = proc.StandardInput;
+        var stdout = proc.StandardOutput;
+
+        try
+        {
+            // -- handshake ------------------------------------------------------------------
+            Rpc(stdin, stdout, 1, "initialize", new
+            {
+                protocolVersion = "2025-06-18",
+                capabilities = new { },
+                clientInfo = new { name = "binding-shim-guard", version = "0" },
+            });
+            Notify(stdin, "notifications/initialized");
+
+            // -- A: the fix must NOT degrade the published schema — plugins stays a declared array.
+            //    (Guards against ever "fixing" this via serializer-options converters, which would
+            //    collapse the generated schema and remove the model's shape hint.)
+            var tools = Rpc(stdin, stdout, 2, "tools/list", new { });
+            string? pluginsSchema = null;
+            foreach (var t in tools.GetProperty("tools").EnumerateArray())
+                if (t.GetProperty("name").GetString() == "housecarl_cross_plugin_query")
+                    pluginsSchema = t.GetProperty("inputSchema").GetProperty("properties").GetProperty("plugins").GetRawText();
+            failures += Check("A schema: cross_plugin_query plugins= still declares an array",
+                pluginsSchema is not null && pluginsSchema.Contains("array"),
+                $"plugins schema = {pluginsSchema ?? "<tool or property not found>"}");
+
+            // -- B: THE live failing shape — plugins as a bare string. Must bind (coerced to a
+            //    one-element array) and reach the tool body (⇒ the config prompt), never the generic error.
+            var b = Call(stdin, stdout, 3, "housecarl_cross_plugin_query",
+                """{"type":"CELL","plugins":"Synthetic.esp"}""");
+            failures += Check("B coerce: plugins as bare string binds and runs the tool body",
+                !b.text.Contains(GenericError) && b.text.Contains(ConfigPrompt), b.Describe());
+
+            // -- C: control — the documented array shape, unchanged behavior.
+            var c = Call(stdin, stdout, 4, "housecarl_cross_plugin_query",
+                """{"type":"CELL","plugins":["Synthetic.esp"]}""");
+            failures += Check("C control: plugins as array still binds and runs the tool body",
+                !c.text.Contains(GenericError) && c.text.Contains(ConfigPrompt), c.Describe());
+
+            // -- D: the audit's other failing call — {} with a REQUIRED parameter missing. Must be a
+            //    NAMED refusal naming the parameter, never the generic error.
+            var d = Call(stdin, stdout, 5, "housecarl_batch_record_detail", "{}");
+            failures += Check("D required: missing required parameter is refused by NAME",
+                !d.text.Contains(GenericError) && d.text.Contains("required parameter") && d.text.Contains("formids"),
+                d.Describe());
+
+            // -- E: quoted number — same obvious-intent class as B. Must bind and run.
+            var e = Call(stdin, stdout, 6, "housecarl_cross_plugin_query",
+                """{"type":"CELL","plugins":["Synthetic.esp"],"limit":"100"}""");
+            failures += Check("E coerce: quoted number limit binds and runs the tool body",
+                !e.text.Contains(GenericError) && e.text.Contains(ConfigPrompt), e.Describe());
+
+            // -- F: quoted bool — same class.
+            var f = Call(stdin, stdout, 7, "housecarl_cross_plugin_query",
+                """{"type":"CELL","plugins":["Synthetic.esp"],"conflicts_only":"true"}""");
+            failures += Check("F coerce: quoted bool conflicts_only binds and runs the tool body",
+                !f.text.Contains(GenericError) && f.text.Contains(ConfigPrompt), f.Describe());
+
+            // -- G: an UNCOERCIBLE shape (an object where a number is declared) must still fail — but
+            //    NAMED, telling the caller it's an argument-shape problem, never the bare generic text.
+            var g = Call(stdin, stdout, 8, "housecarl_cross_plugin_query",
+                """{"type":"CELL","plugins":["Synthetic.esp"],"limit":{"oops":1}}""");
+            failures += Check("G rewrite: an uncoercible argument fails NAMED, not generic",
+                !g.text.Contains(GenericError) && g.text.Contains("could not be bound"), g.Describe());
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"FAIL  probe infrastructure: {ex.GetType().Name}: {ex.Message}");
+            failures++;
+        }
+        finally
+        {
+            try { if (!proc.HasExited) proc.Kill(entireProcessTree: true); } catch { }
+            try { Directory.Delete(dataDir, recursive: true); } catch { }
+        }
+
+        Console.WriteLine(failures == 0
+            ? "[binding-shim-guard] PASS — all argument-shape cases bind or fail with a named reason."
+            : $"[binding-shim-guard] FAIL — {failures} case(s) regressed.");
+        return failures == 0 ? 0 : 1;
+    }
+
+    static int Check(string what, bool ok, string detail)
+    {
+        Console.WriteLine($"{(ok ? "PASS" : "FAIL")}  {what}");
+        if (!ok) Console.WriteLine($"      got: {detail}");
+        return ok ? 0 : 1;
+    }
+
+    // ---- minimal JSON-RPC-over-stdio plumbing -----------------------------------------------
+
+    /// <summary>One tools/call; returns (isError, first text block) for the asserts.</summary>
+    static (bool isError, string text) Call(StreamWriter stdin, StreamReader stdout, int id, string tool, string argumentsJson)
+    {
+        using var argsDoc = JsonDocument.Parse(argumentsJson);
+        var result = Rpc(stdin, stdout, id, "tools/call", new { name = tool, arguments = argsDoc.RootElement });
+        bool isError = result.TryGetProperty("isError", out var ie) && ie.ValueKind == JsonValueKind.True;
+        string text = "";
+        if (result.TryGetProperty("content", out var content) && content.ValueKind == JsonValueKind.Array)
+            foreach (var block in content.EnumerateArray())
+                if (block.TryGetProperty("text", out var tx)) { text = tx.GetString() ?? ""; break; }
+        return (isError, text);
+    }
+
+    /// <summary>Send a request and block (bounded) for the response with the same id; returns its `result`.</summary>
+    static JsonElement Rpc(StreamWriter stdin, StreamReader stdout, int id, string method, object @params)
+    {
+        Send(stdin, new { jsonrpc = "2.0", id, method, @params });
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+        while (DateTime.UtcNow < deadline)
+        {
+            var read = Task.Run(stdout.ReadLine);
+            if (!read.Wait(TimeSpan.FromSeconds(30)) || read.Result is not { } line)
+                break;
+            if (line.Length == 0) continue;
+            using var doc = JsonDocument.Parse(line);
+            if (doc.RootElement.TryGetProperty("id", out var rid) && rid.ValueKind == JsonValueKind.Number && rid.GetInt32() == id)
+            {
+                if (doc.RootElement.TryGetProperty("error", out var err))
+                    throw new InvalidOperationException($"JSON-RPC error for {method}: {err.GetRawText()}");
+                return doc.RootElement.GetProperty("result").Clone();
+            }
+            // a notification or another id — keep reading
+        }
+        throw new TimeoutException($"no response to {method} (id {id}) within 30s.");
+    }
+
+    static void Notify(StreamWriter stdin, string method) => Send(stdin, new { jsonrpc = "2.0", method });
+
+    static void Send(StreamWriter stdin, object msg)
+    {
+        stdin.WriteLine(JsonSerializer.Serialize(msg));
+        stdin.Flush();
+    }
+
+    static string Describe(this (bool isError, string text) r)
+        => $"isError={r.isError} text=\"{(r.text.Length > 160 ? r.text[..160] + "…" : r.text)}\"";
+}

--- a/src/housecarl-generator/BindingShimProbe.cs
+++ b/src/housecarl-generator/BindingShimProbe.cs
@@ -142,6 +142,7 @@ public static class BindingShimProbe
         finally
         {
             try { if (!proc.HasExited) proc.Kill(entireProcessTree: true); } catch { }
+            try { proc.WaitForExit(5000); } catch { }                   // let the kill land before the delete, or the dir cleanup loses the race
             try { Directory.Delete(dataDir, recursive: true); } catch { }
         }
 
@@ -181,7 +182,8 @@ public static class BindingShimProbe
         while (DateTime.UtcNow < deadline)
         {
             var read = Task.Run(stdout.ReadLine);
-            if (!read.Wait(TimeSpan.FromSeconds(30)) || read.Result is not { } line)
+            var remaining = deadline - DateTime.UtcNow;                 // ONE shared 30s budget — the per-line wait never extends it
+            if (remaining <= TimeSpan.Zero || !read.Wait(remaining) || read.Result is not { } line)
                 break;
             if (line.Length == 0) continue;
             using var doc = JsonDocument.Parse(line);

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -39,6 +39,10 @@ if (args.Length > 0 && args[0] == "value-predicate-guard") return ValuePredicate
 // (B wins) and asserts RecordsIn pairs each yielded body with its OWN source plugin, the winner stream with the winner.
 if (args.Length > 0 && args[0] == "source-display-guard") return SourceDisplayProbe.RunGuard(args[1..]);
 
+// Tool-argument binding shim (HCBR-2026-06-11-01): drives the REAL housecarl-mcp.exe over stdio with the report's
+// exact malformed argument shapes — string-for-array coerces, missing-required refuses by name, uncoercible fails named.
+if (args.Length > 0 && args[0] == "binding-shim-guard") return BindingShimProbe.RunGuard(args[1..]);
+
 // One-shot verify (decision #1): confirm the xEdit 4-char signature reflection path.
 if (args.Length > 0 && args[0] == "sig") return Probe.RunSig();
 

--- a/src/housecarl-mcp/BsaTools.cs
+++ b/src/housecarl-mcp/BsaTools.cs
@@ -25,7 +25,7 @@ public static class BsaTools
         [Description("Full path to the .bsa archive to list.")]
             string archive,
         [Description("Optional. Max characters before the file list is cut with an explicit notice. 0 = the server default (~80k).")]
-            int max_chars = 0)
+            int max_chars = 0) => Guard.Tool("housecarl_bsa_list", () =>
     {
         if (string.IsNullOrWhiteSpace(archive)) return "error: no archive given. Pass the full path to the .bsa.";
         archive = archive.Trim().Trim('"');
@@ -48,7 +48,7 @@ public static class BsaTools
             sb.Append("  ").Append(f).Append('\n'); shown++;
         }
         return sb.ToString().TrimEnd('\n');
-    }
+    });
 
     [McpServerTool(Name = "housecarl_bsa_extract", Title = "Extract a .bsa archive to a folder"),
      Description(
@@ -62,7 +62,7 @@ public static class BsaTools
         [Description("Full path to the .bsa archive to extract.")]
             string archive,
         [Description("Optional. Folder to unpack into. If omitted, houseCARL creates a NEW mod folder under your mods directory and reports its path.")]
-            string? dest = null)
+            string? dest = null) => Guard.Tool("housecarl_bsa_extract", () =>
     {
         if (string.IsNullOrWhiteSpace(archive)) return "error: no archive given. Pass the full path to the .bsa.";
         archive = archive.Trim().Trim('"');
@@ -93,7 +93,7 @@ public static class BsaTools
             ? "(a new houseCARL mod folder — read the files you need from it; enable it in MO2 only if you want the loose files in your load order.)"
             : "(read the files you need from that folder.)");
         return sb.ToString();
-    }
+    });
 
     [McpServerTool(Name = "housecarl_bsa_repack", Title = "Pack a folder into a .bsa archive"),
      Description(
@@ -116,7 +116,7 @@ public static class BsaTools
         [Description("Optional. Base name for the NEW mod folder the .bsa lands in (default 'houseCARL_Archive'); auto-suffixed if taken.")]
             string? patch_name = null,
         [Description("Optional. Filename of an existing houseCARL patch mod to place the .bsa into instead of a fresh folder.")]
-            string? into = null)
+            string? into = null) => Guard.Tool("housecarl_bsa_repack", () =>
     {
         if (string.IsNullOrWhiteSpace(source_folder)) return "error: no source_folder given.";
         source_folder = Path.GetFullPath(source_folder.Trim().Trim('"'));
@@ -145,5 +145,5 @@ public static class BsaTools
         sb.Append("(a new houseCARL mod folder — enable it in MO2 to use the archive.)");
         if (compress) sb.Append("\nNOTE: compressed — any sounds/voices in it will not work in-game (BSArch limitation).");
         return sb.ToString();
-    }
+    });
 }

--- a/src/housecarl-mcp/CompileTools.cs
+++ b/src/housecarl-mcp/CompileTools.cs
@@ -36,7 +36,7 @@ public static class CompileTools
         [Description("Optional. Base name for the NEW patch-mod folder the .pex lands in (default 'houseCARL_Scripts'); auto-suffixed if taken.")]
             string? patch_name = null,
         [Description("Optional. Filename of an existing houseCARL patch mod to add the .pex into instead of creating a fresh folder (accumulate compiled scripts).")]
-            string? into = null)
+            string? into = null) => Guard.Tool("housecarl_compile_script", () =>
     {
         // 1) MO2 must be configured — the .pex lands under the instance's mods folder.
         if (svc.ConfigPromptOrNull() is { } cfgPrompt) return cfgPrompt;
@@ -78,7 +78,7 @@ public static class CompileTools
         // 6) compile + render.
         var result = HousecarlCore.PapyrusCompile.CompileObject(compilerExe!, objectName, imports, outDir);
         return Render(result, imports);
-    }
+    });
 
     static string Render(HousecarlCore.CompileResult r, IReadOnlyList<string> imports)
     {

--- a/src/housecarl-mcp/Guard.cs
+++ b/src/housecarl-mcp/Guard.cs
@@ -1,0 +1,49 @@
+namespace HousecarlMcp;
+
+/// <summary>
+/// The last-line tool-body guard (Q3 hardening, HCBR-2026-06-11-01 follow-through). Every MCP tool body runs
+/// inside <see cref="Tool(string,System.Func{string})"/>: an exception the body's own handling didn't convert to
+/// a named error — the unguarded residue was the <see cref="LoadOrderService"/> resolver getter (freshness/IO
+/// throws during a mid-call profile re-read) and the render layer's per-match reads — returns a NAMED error
+/// string instead of escaping to the SDK, whose own catch genericizes to "An error occurred invoking '…'."
+/// (the opaque dead end the binding shim exists to kill; see <see cref="ToolCallShim"/>).
+///
+/// Division of honesty with the shim: with every body wrapped HERE, the only exceptions still reaching the
+/// shim's catch are pre-body (argument binding), so its "could not be bound" wording stays accurate — and this
+/// guard's "the arguments bound fine" wording is accurate in turn, because a body only runs after binding
+/// succeeded. Cancellation is rethrown — a cancelled request is the SDK's to finish, not a tool failure.
+/// </summary>
+internal static class Guard
+{
+    public static string Tool(string tool, Func<string> body)
+    {
+        try { return body(); }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex) { return Named(tool, ex); }
+    }
+
+    /// <summary>The async twin (the Nexus tools).</summary>
+    public static async Task<string> Tool(string tool, Func<Task<string>> body)
+    {
+        try { return await body(); }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex) { return Named(tool, ex); }
+    }
+
+    static string Named(string tool, Exception ex)
+    {
+        Console.Error.WriteLine($"[houseCARL] {tool} unhandled exception: {ex}");   // full stack → stderr (the MCP log), never stdout (the protocol channel)
+        return $"error: {tool} failed unexpectedly — {ex.GetType().Name}: {Flatten(ex.Message)} This is an " +
+               "internal houseCARL failure (the arguments bound fine), not bad input. Retry once — a transient " +
+               "mid-refresh hiccup self-heals on the next call; if it persists, capture this exact message in a bug report.";
+    }
+
+    /// <summary>One-line, bounded essence of an exception message for the wire (System.Text.Json and IO messages
+    /// span lines); the full exception, stack included, already went to stderr.</summary>
+    internal static string Flatten(string message)
+    {
+        var s = message.Replace("\r", "").Replace("\n", " | ").Trim();
+        if (s.Length > 0 && !s.EndsWith('.')) s += ".";
+        return s.Length > 300 ? s[..300] + "…" : s;
+    }
+}

--- a/src/housecarl-mcp/Guard.cs
+++ b/src/housecarl-mcp/Guard.cs
@@ -15,18 +15,22 @@ namespace HousecarlMcp;
 /// </summary>
 internal static class Guard
 {
-    public static string Tool(string tool, Func<string> body)
+    /// <summary>Rethrow ONLY a real request cancellation (the SDK's to finish), mirroring the SDK's own test —
+    /// an OperationCanceledException whose REQUEST token is live (e.g. a TaskCanceledException from an internal
+    /// HttpClient timeout) is a body FAILURE and must be named, or it lands in the SDK generic (review #1
+    /// finding 1). Tools without a CancellationToken parameter pass none, so every body OCE there is named.</summary>
+    public static string Tool(string tool, Func<string> body, CancellationToken ct = default)
     {
         try { return body(); }
-        catch (OperationCanceledException) { throw; }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
         catch (Exception ex) { return Named(tool, ex); }
     }
 
     /// <summary>The async twin (the Nexus tools).</summary>
-    public static async Task<string> Tool(string tool, Func<Task<string>> body)
+    public static async Task<string> Tool(string tool, Func<Task<string>> body, CancellationToken ct = default)
     {
         try { return await body(); }
-        catch (OperationCanceledException) { throw; }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
         catch (Exception ex) { return Named(tool, ex); }
     }
 

--- a/src/housecarl-mcp/NexusTools.cs
+++ b/src/housecarl-mcp/NexusTools.cs
@@ -51,7 +51,7 @@ public static class NexusTools
         var (ok, error, result) = await nexus.SearchAsync(query.Trim(), category, sortField, limit, ct);
         if (!ok) return "error: " + error;
         return Render.Search(query.Trim(), category, sort, result!);
-    });
+    }, ct);
 
     [McpServerTool(Name = "housecarl_nexus_mod", ReadOnly = true, Title = "Look up a Nexus mod"),
      Description(
@@ -82,7 +82,7 @@ public static class NexusTools
         var (ok, error, detail) = await nexus.GetModAsync(modId, ct);
         if (!ok) return "error: " + error;
         return Render.Mod(detail!, description);
-    });
+    }, ct);
 
     /// <summary>Map a friendly sort word to a ModsSort field name; null if unrecognised (the tool reports it — Q3).</summary>
     static string? MapSort(string s) => s.Trim().ToLowerInvariant() switch

--- a/src/housecarl-mcp/NexusTools.cs
+++ b/src/housecarl-mcp/NexusTools.cs
@@ -27,7 +27,7 @@ public static class NexusTools
          "open its page and use Nexus's 'Mod Manager Download' button as usual — houseCARL reads Nexus, your mod manager " +
          "does the download. For full details (requirements and the newest MAIN file — the accurate latest version) of " +
          "one result, pass its id to housecarl_nexus_mod.")]
-    public static async Task<string> NexusSearch(
+    public static Task<string> NexusSearch(
         NexusClient nexus,
         [Description("Words to search for in mod names, e.g. 'archery overhaul' or 'true storms'. Matched as a wildcard against Skyrim SE mod names.")]
             string query,
@@ -37,7 +37,7 @@ public static class NexusTools
             string sort = "endorsements",
         [Description("Optional. Max results to return (default 10, max 50).")]
             int limit = 10,
-        CancellationToken ct = default)
+        CancellationToken ct = default) => Guard.Tool("housecarl_nexus_search", async () =>
     {
         if (string.IsNullOrWhiteSpace(query))
             return "error: no search term. Pass query= some words to look for in mod names (e.g. 'archery overhaul').";
@@ -51,7 +51,7 @@ public static class NexusTools
         var (ok, error, result) = await nexus.SearchAsync(query.Trim(), category, sortField, limit, ct);
         if (!ok) return "error: " + error;
         return Render.Search(query.Trim(), category, sort, result!);
-    }
+    });
 
     [McpServerTool(Name = "housecarl_nexus_mod", ReadOnly = true, Title = "Look up a Nexus mod"),
      Description(
@@ -64,7 +64,7 @@ public static class NexusTools
          "compatibility/conflict notes), cleaned of Nexus markup to plain text — off by default because it can run " +
          "several KB. READ-ONLY and needs an internet connection (local tools unaffected offline). Does NOT download or install — " +
          "use your mod manager's 'Mod Manager Download' for that. To find a mod by name first, use housecarl_nexus_search.")]
-    public static async Task<string> NexusMod(
+    public static Task<string> NexusMod(
         NexusClient nexus,
         [Description("The mod to look up: a numeric Nexus mod id (e.g. 12604) or a full mod URL (e.g. https://www.nexusmods.com/skyrimspecialedition/mods/12604).")]
             string mod,
@@ -74,7 +74,7 @@ public static class NexusTools
             "requirements, and latest version only, because the full description can run several KB. Set true when you " +
             "need the detail, e.g. comparing two mods or understanding how one works.")]
             bool description = false,
-        CancellationToken ct = default)
+        CancellationToken ct = default) => Guard.Tool("housecarl_nexus_mod", async () =>
     {
         var (modId, parseError) = ResolveModId(mod);
         if (parseError is not null) return "error: " + parseError;
@@ -82,7 +82,7 @@ public static class NexusTools
         var (ok, error, detail) = await nexus.GetModAsync(modId, ct);
         if (!ok) return "error: " + error;
         return Render.Mod(detail!, description);
-    }
+    });
 
     /// <summary>Map a friendly sort word to a ModsSort field name; null if unrecognised (the tool reports it — Q3).</summary>
     static string? MapSort(string s) => s.Trim().ToLowerInvariant() switch

--- a/src/housecarl-mcp/Program.cs
+++ b/src/housecarl-mcp/Program.cs
@@ -132,4 +132,8 @@ static void AddMcp(IServiceCollection services, bool stdio)
     if (stdio) mcp.WithStdioServerTransport();
     else mcp.WithHttpTransport(o => o.Stateless = true);
     mcp.WithToolsFromAssembly();
+    // The argument-binding shim (HCBR-2026-06-11-01): schema-driven coercion of obvious-intent argument shapes
+    // (a bare string where an array is declared, quoted bools/numbers), named refusal of missing required
+    // parameters, and a named rewrite of the SDK's generic binding-failure text. See ToolCallShim.
+    mcp.WithRequestFilters(f => f.AddCallToolFilter(ToolCallShim.LenientArguments));
 }

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -37,7 +37,7 @@ public static class ReadTools
         [Description("When true, also return the ordered list of every plugin that touches this record (winner last) and the winner-relative field diff for each.")]
             bool conflict_tree = false,
         [Description("Optional. Max characters before the diff is cut with an explicit notice (never silent). 0 = the server default (~80k). Raise to see a very deep conflict tree in full.")]
-            int max_chars = 0)
+            int max_chars = 0) => Guard.Tool("housecarl_read_record", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         FormKey fk;
@@ -46,7 +46,7 @@ public static class ReadTools
 
         var outcome = svc.ResolveRead(fk, plugin, fields, conflict_tree, depth <= 0 ? 1 : depth);
         return Wire.RenderRecord(svc, outcome, fields, conflict_tree, max_chars);
-    }
+    });
 
     [McpServerTool(Name = "housecarl_batch_record_detail", ReadOnly = true, Title = "Read many records"),
      Description(
@@ -67,13 +67,13 @@ public static class ReadTools
         [Description("When true, include each record's touching-plugin list (winner last) + winner-relative field diff.")]
             bool conflict_tree = false,
         [Description("Optional. Max characters before the response stops with an explicit 'rendered X of N' notice. 0 = the server default (~80k).")]
-            int max_chars = 0)
+            int max_chars = 0) => Guard.Tool("housecarl_batch_record_detail", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         if (formids is null || formids.Length == 0) return "error: formids is empty. Pass one or more 'XXXXXX:Plugin.esp' FormIDs.";
         var outcomes = svc.ResolveBatch(formids, fields, conflict_tree, depth <= 0 ? 1 : depth);
         return Wire.RenderBatch(svc, outcomes, fields, conflict_tree, max_chars);
-    }
+    });
 
     [McpServerTool(Name = "housecarl_cross_plugin_query", ReadOnly = true, Title = "Query records across the load order"),
      Description(
@@ -109,7 +109,7 @@ public static class ReadTools
         [Description("Optional. Max matches to return (default 500). The TRUE total is always reported; over the cap it says 'showing first N'.")]
             int limit = 500,
         [Description("Optional. Max characters before the response stops with an explicit notice. 0 = the server default (~80k).")]
-            int max_chars = 0)
+            int max_chars = 0) => Guard.Tool("housecarl_cross_plugin_query", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         FormKey? refFk = null;
@@ -120,7 +120,7 @@ public static class ReadTools
         }
         var outcome = svc.CrossQuery(type, refFk, editorid_contains, conflicts_only, plugins, where, limit <= 0 ? 500 : limit);
         return Wire.RenderCrossQuery(svc, outcome, fields, conflict_tree, max_chars);
-    }
+    });
 }
 
 /// <summary>Compact, parseable `key = value` rendering (Q4.8 lever 1) + the winner-relative conflict diff

--- a/src/housecarl-mcp/SetupTools.cs
+++ b/src/housecarl-mcp/SetupTools.cs
@@ -31,7 +31,7 @@ public static class SetupTools
     public static string SetMo2Instance(
         LoadOrderService svc,
         [Description("Full path to the MO2 instance folder — the one containing ModOrganizer.ini (e.g. a Wabbajack list's install folder).")]
-            string path)
+            string path) => Guard.Tool("housecarl_set_mo2_instance", () =>
     {
         if (string.IsNullOrWhiteSpace(path))
             return "error: no path given. Pass the full path to your MO2 instance folder (the one containing ModOrganizer.ini).";
@@ -41,7 +41,7 @@ public static class SetupTools
         catch (InvalidOperationException ex) { return "error: " + ex.Message; }   // not a usable instance — Q3 reason, nothing changed
 
         return Render(paths, persisted, persistError);
-    }
+    });
 
     [McpServerTool(Name = "housecarl_set_tool_path", Title = "Tell houseCARL where an external tool is"),
      Description(
@@ -59,7 +59,7 @@ public static class SetupTools
         [Description("Which tool: 'papyrus_compiler' (CK PapyrusCompiler.exe), 'bsarch' (BSArch.exe), 'papyrus_logs' (script-log folder), or 'crash_logs' (SKSE crash-log folder).")]
             string tool,
         [Description("Full path to the tool: the .exe FILE for papyrus_compiler/bsarch, or the log DIRECTORY for papyrus_logs/crash_logs.")]
-            string path)
+            string path) => Guard.Tool("housecarl_set_tool_path", () =>
     {
         if (string.IsNullOrWhiteSpace(tool))
             return "error: no tool named. Pass tool= one of: " + ToolBridge.WireKeys + ".";
@@ -79,7 +79,7 @@ public static class SetupTools
             ? "saved to houseCARL.user.json — persists across restarts (coexists with your MO2 instance)."
             : $"NOTE: could not save ({persistError}) — works this session, but you'll need to set it again after a restart.");
         return sb.ToString();
-    }
+    });
 
     /// <summary>Confirmation: the instance + the DERIVED roots + the AUTO-DETECTED profile, a cheap enabled/active summary
     /// (text-file read, no deep index — proof houseCARL found the order), and whether the choice was persisted (Q3: a

--- a/src/housecarl-mcp/StatusTools.cs
+++ b/src/housecarl-mcp/StatusTools.cs
@@ -33,13 +33,13 @@ public static class StatusTools
         [Description("Optional. A mod folder name or plugin filename to look up. Omit for the whole-profile summary.")]
             string? lookup = null,
         [Description("Optional. Max characters before name lists are cut with an explicit notice. 0 = the server default (~80k).")]
-            int max_chars = 0)
+            int max_chars = 0) => Guard.Tool("housecarl_load_order_status", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         var data = svc.StatusData();
         var logs = StatusWire.LogFolders(tools);                 // resolved Papyrus/crash log dirs (pure — no persist)
         return StatusWire.Render(data, logs, lookup, max_chars > 0 ? max_chars : 80_000);
-    }
+    });
 }
 
 /// <summary>Renders <see cref="LoadOrderStatusData"/> as compact, scannable text: a header line per category, then the

--- a/src/housecarl-mcp/ToolCallShim.cs
+++ b/src/housecarl-mcp/ToolCallShim.cs
@@ -56,7 +56,7 @@ internal static class ToolCallShim
             Console.Error.WriteLine($"[houseCARL] {p?.Name}: exception during tool invocation: {ex}");   // full stack → stderr (the MCP log), never stdout (the protocol channel)
             return NamedError(
                 $"error: {p?.Name}: an argument most likely could not be bound to its declared parameter — " +
-                $"{ex.GetType().Name}: {Flatten(ex.Message)} Received {DescribeArgs(p?.Arguments)}. Check each " +
+                $"{ex.GetType().Name}: {Guard.Flatten(ex.Message)} Received {DescribeArgs(p?.Arguments)}. Check each " +
                 "argument's TYPE against the tool's schema: array parameters take JSON arrays (a single bare " +
                 "string is auto-wrapped), numbers take numbers, booleans take true/false. Fix the mismatched " +
                 "argument and retry.");
@@ -175,14 +175,5 @@ internal static class ToolCallShim
     {
         using var doc = JsonDocument.Parse(json);
         return doc.RootElement.Clone();
-    }
-
-    /// <summary>One-line, bounded essence of an exception message for the wire (System.Text.Json messages span
-    /// lines); the full exception, stack included, already went to stderr.</summary>
-    static string Flatten(string message)
-    {
-        var s = message.Replace("\r", "").Replace("\n", " | ").Trim();
-        if (s.Length > 0 && !s.EndsWith('.')) s += ".";
-        return s.Length > 300 ? s[..300] + "…" : s;
     }
 }

--- a/src/housecarl-mcp/ToolCallShim.cs
+++ b/src/housecarl-mcp/ToolCallShim.cs
@@ -1,0 +1,188 @@
+using System.Text.Json;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace HousecarlMcp;
+
+/// <summary>
+/// The tool-argument binding shim (HCBR-2026-06-11-01) — a call-tool filter that runs BEFORE the SDK binds a
+/// call's JSON arguments to the tool method's parameters, closing the one layer where houseCARL's named-error
+/// (Q3) discipline could not reach: a malformed argument SHAPE used to throw inside SDK binding, which the SDK
+/// genericizes to "An error occurred invoking '&lt;tool&gt;'." — an opaque dead end the live audit agent could not
+/// self-correct from (it abandoned the documented query path; see the bug report's transcripts).
+///
+/// Three moves, all schema-driven off the tool's own published InputSchema (so every current and future tool
+/// parameter is covered by construction — no per-tool wiring):
+/// <list type="number">
+/// <item><b>Coerce obvious intent</b> — a bare string where an array is declared becomes a one-element array
+/// (the live failing shape: <c>plugins="A.esp"</c>); quoted numbers/booleans become numbers/booleans; a bare
+/// number where a string is declared becomes its text. Anything else is left for binding to judge.</item>
+/// <item><b>Refuse missing REQUIRED parameters by name</b> — the audit's <c>{}</c> call gets
+/// "required parameter missing: formids", not the generic text.</item>
+/// <item><b>Name what still fails</b> — if binding still throws (an uncoercible shape), the exception passes
+/// through this filter on its way to the SDK's catch (which sits ABOVE the filter pipeline and would genericize
+/// it — measured: AIFunctionMcpServerTool.InvokeAsync doesn't catch; McpServerImpl's outermost wrapper does).
+/// Catching it HERE instead returns a named error carrying the real exception text plus each received
+/// argument's JSON kind, so the caller can fix and retry. (With every tool body wrapped in <see cref="Guard"/>,
+/// what reaches this catch is the pre-body machinery — argument binding — which is what makes the
+/// "could not be bound" wording honest.)</item>
+/// </list>
+/// </summary>
+internal static class ToolCallShim
+{
+    /// <summary>The filter. Registered on the server in Program.cs via WithRequestFilters → AddCallToolFilter.</summary>
+    public static McpRequestFilter<CallToolRequestParams, CallToolResult> LenientArguments => next => async (request, cancellationToken) =>
+    {
+        // MatchedPrimitive is resolved by the SDK BEFORE filters run; unknown tool names pass through untouched
+        // (the SDK's own unknown-tool error is already specific).
+        var p = request.Params;
+        if (p is not null && request.MatchedPrimitive is McpServerTool tool)
+        {
+            var schema = tool.ProtocolTool.InputSchema;
+            CoerceObviousShapes(p, schema);
+            if (MissingRequired(p, schema) is { } refusal) return refusal;
+        }
+
+        try
+        {
+            return await next(request, cancellationToken);
+        }
+        // Cancellation belongs to the SDK's own special-casing; McpException is the protocol surface (e.g. the
+        // unknown-tool path) whose handling must stay the SDK's. Everything else below this filter would otherwise
+        // surface as the opaque generic text (Q3's dead end) — name it instead.
+        catch (Exception ex) when (ex is not OperationCanceledException and not McpException)
+        {
+            Console.Error.WriteLine($"[houseCARL] {p?.Name}: exception during tool invocation: {ex}");   // full stack → stderr (the MCP log), never stdout (the protocol channel)
+            return NamedError(
+                $"error: {p?.Name}: an argument most likely could not be bound to its declared parameter — " +
+                $"{ex.GetType().Name}: {Flatten(ex.Message)} Received {DescribeArgs(p?.Arguments)}. Check each " +
+                "argument's TYPE against the tool's schema: array parameters take JSON arrays (a single bare " +
+                "string is auto-wrapped), numbers take numbers, booleans take true/false. Fix the mismatched " +
+                "argument and retry.");
+        }
+    };
+
+    /// <summary>Rewrite arguments whose JSON kind mismatches the declared schema type but whose intent is
+    /// unambiguous. Only ever REPLACES values for keys the schema declares — unknown keys and already-correct
+    /// shapes pass through untouched, so a well-formed call is byte-identical to today.</summary>
+    static void CoerceObviousShapes(CallToolRequestParams p, JsonElement schema)
+    {
+        if (p.Arguments is not { Count: > 0 } args) return;
+        if (schema.ValueKind != JsonValueKind.Object ||
+            !schema.TryGetProperty("properties", out var props) || props.ValueKind != JsonValueKind.Object) return;
+
+        Dictionary<string, JsonElement>? rewritten = null;
+        foreach (var kv in args)
+        {
+            if (!props.TryGetProperty(kv.Key, out var propSchema)) continue;
+            if (Coerce(kv.Value, propSchema) is { } coerced)
+            {
+                rewritten ??= new Dictionary<string, JsonElement>(args);
+                rewritten[kv.Key] = coerced;
+            }
+        }
+        if (rewritten is not null) p.Arguments = rewritten;
+    }
+
+    /// <summary>One value against one property schema: the coerced element, or null to leave it alone.</summary>
+    static JsonElement? Coerce(JsonElement value, JsonElement propSchema)
+    {
+        var declared = DeclaredTypes(propSchema);
+        if (declared.Count == 0) return null;
+
+        if (value.ValueKind == JsonValueKind.String)
+        {
+            var s = value.GetString() ?? "";
+            if (declared.Contains("array"))
+                return Parse("[" + JsonSerializer.Serialize(s) + "]");          // "A.esp" → ["A.esp"] — THE live failing shape
+            if (declared.Contains("boolean") && bool.TryParse(s, out var b))
+                return Parse(b ? "true" : "false");                             // "true" → true
+            if (declared.Contains("integer") || declared.Contains("number"))
+            {
+                // "100" → 100. Parse validates it's a standalone JSON number; anything else stays for binding to name.
+                try { var el = Parse(s); if (el.ValueKind == JsonValueKind.Number) return el; }
+                catch (JsonException) { }
+            }
+        }
+        else if (value.ValueKind == JsonValueKind.Number &&
+                 declared.Contains("string") && !declared.Contains("number") && !declared.Contains("integer"))
+        {
+            return Parse(JsonSerializer.Serialize(value.GetRawText()));         // 123456 → "123456" (e.g. an unquoted hex-free FormID)
+        }
+        return null;
+    }
+
+    /// <summary>The schema's declared type name(s) for a property — handles both <c>"type":"array"</c> and the
+    /// nullable-parameter form <c>"type":["array","null"]</c> the schema exporter emits.</summary>
+    static HashSet<string> DeclaredTypes(JsonElement propSchema)
+    {
+        var set = new HashSet<string>(StringComparer.Ordinal);
+        if (propSchema.ValueKind == JsonValueKind.Object && propSchema.TryGetProperty("type", out var t))
+        {
+            if (t.ValueKind == JsonValueKind.String) set.Add(t.GetString()!);
+            else if (t.ValueKind == JsonValueKind.Array)
+                foreach (var e in t.EnumerateArray())
+                    if (e.ValueKind == JsonValueKind.String) set.Add(e.GetString()!);
+        }
+        return set;
+    }
+
+    /// <summary>Schema-required parameters absent from the call → a named refusal (Q3), or null to proceed.</summary>
+    static CallToolResult? MissingRequired(CallToolRequestParams p, JsonElement schema)
+    {
+        if (schema.ValueKind != JsonValueKind.Object ||
+            !schema.TryGetProperty("required", out var req) || req.ValueKind != JsonValueKind.Array) return null;
+
+        List<string>? missing = null;
+        foreach (var r in req.EnumerateArray())
+            if (r.GetString() is { } name && (p.Arguments is null || !p.Arguments.ContainsKey(name)))
+                (missing ??= new List<string>()).Add(name);
+        if (missing is null) return null;
+
+        string plural = missing.Count == 1 ? "" : "s";
+        return NamedError(
+            $"error: {p.Name}: required parameter{plural} missing: {string.Join(", ", missing)}. Supplied: " +
+            $"{(p.Arguments is { Count: > 0 } a ? string.Join(", ", a.Keys) : "(none)")}. Add the missing argument{plural} and retry.");
+    }
+
+    static CallToolResult NamedError(string text) => new()
+    {
+        IsError = true,
+        Content = [new TextContentBlock { Text = text }],
+    };
+
+    /// <summary>Each received argument's name + JSON kind ("plugins=string, limit=object") — exactly the view a
+    /// caller needs to spot which argument's shape disagrees with the schema.</summary>
+    static string DescribeArgs(IDictionary<string, JsonElement>? args)
+        => args is not { Count: > 0 }
+            ? "(no arguments)"
+            : string.Join(", ", args.Select(kv => $"{kv.Key}={KindName(kv.Value.ValueKind)}"));
+
+    static string KindName(JsonValueKind k) => k switch
+    {
+        JsonValueKind.String => "string",
+        JsonValueKind.Number => "number",
+        JsonValueKind.True or JsonValueKind.False => "boolean",
+        JsonValueKind.Array => "array",
+        JsonValueKind.Object => "object",
+        JsonValueKind.Null => "null",
+        _ => k.ToString().ToLowerInvariant(),
+    };
+
+    /// <summary>A detached element from raw JSON text (no serializer reflection; valid past the document's lifetime).</summary>
+    static JsonElement Parse(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.Clone();
+    }
+
+    /// <summary>One-line, bounded essence of an exception message for the wire (System.Text.Json messages span
+    /// lines); the full exception, stack included, already went to stderr.</summary>
+    static string Flatten(string message)
+    {
+        var s = message.Replace("\r", "").Replace("\n", " | ").Trim();
+        if (s.Length > 0 && !s.EndsWith('.')) s += ".";
+        return s.Length > 300 ? s[..300] + "…" : s;
+    }
+}

--- a/src/housecarl-mcp/ToolCallShim.cs
+++ b/src/housecarl-mcp/ToolCallShim.cs
@@ -37,26 +37,33 @@ internal static class ToolCallShim
         // MatchedPrimitive is resolved by the SDK BEFORE filters run; unknown tool names pass through untouched
         // (the SDK's own unknown-tool error is already specific).
         var p = request.Params;
-        if (p is not null && request.MatchedPrimitive is McpServerTool tool)
-        {
-            var schema = tool.ProtocolTool.InputSchema;
-            CoerceObviousShapes(p, schema);
-            if (MissingRequired(p, schema) is { } refusal) return refusal;
-        }
-
+        var received = DescribeArgs(p?.Arguments);   // what the caller ACTUALLY sent — captured before coercion rewrites
+                                                     // the dictionary, so the failure message never shows a coerced shape
+                                                     // as if the caller had sent it (review #1 finding 2)
         try
         {
+            // The shim's own pre-processing runs inside the same safety net as the call (review #1 finding 4):
+            // a throw from coercion/required-check must also come back named, never the SDK generic.
+            if (p is not null && request.MatchedPrimitive is McpServerTool tool)
+            {
+                var schema = tool.ProtocolTool.InputSchema;
+                CoerceObviousShapes(p, schema);
+                if (MissingRequired(p, schema) is { } refusal) return refusal;
+            }
             return await next(request, cancellationToken);
         }
-        // Cancellation belongs to the SDK's own special-casing; McpException is the protocol surface (e.g. the
-        // unknown-tool path) whose handling must stay the SDK's. Everything else below this filter would otherwise
-        // surface as the opaque generic text (Q3's dead end) — name it instead.
-        catch (Exception ex) when (ex is not OperationCanceledException and not McpException)
+        // A REAL request cancellation belongs to the SDK's special-casing — but ONLY a real one (the SDK's own
+        // test): an OperationCanceledException with a live request token (e.g. an internal HttpClient timeout)
+        // would be genericized above, so it gets named here instead (review #1 finding 1). McpException is the
+        // protocol surface (e.g. the unknown-tool path) whose handling must stay the SDK's. Everything else
+        // below this filter would otherwise surface as the opaque generic text (Q3's dead end) — name it.
+        catch (Exception ex) when (ex is not McpException &&
+                                   !(ex is OperationCanceledException && cancellationToken.IsCancellationRequested))
         {
             Console.Error.WriteLine($"[houseCARL] {p?.Name}: exception during tool invocation: {ex}");   // full stack → stderr (the MCP log), never stdout (the protocol channel)
             return NamedError(
                 $"error: {p?.Name}: an argument most likely could not be bound to its declared parameter — " +
-                $"{ex.GetType().Name}: {Guard.Flatten(ex.Message)} Received {DescribeArgs(p?.Arguments)}. Check each " +
+                $"{ex.GetType().Name}: {Guard.Flatten(ex.Message)} Received {received}. Check each " +
                 "argument's TYPE against the tool's schema: array parameters take JSON arrays (a single bare " +
                 "string is auto-wrapped), numbers take numbers, booleans take true/false. Fix the mismatched " +
                 "argument and retry.");

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -45,7 +45,7 @@ public static class WriteTools
         [Description("Optional. Base filename for the new patch (default 'houseCARL_Patch'); auto-suffixed if taken so a prior patch is never overwritten. Ignored if into= is given.")]
             string patch_name = "houseCARL_Patch",
         [Description("Optional. Filename of an existing patch (from a prior call) to EXTEND with this edit instead of writing a fresh one — the way to accumulate edits into one patch across calls/sessions.")]
-            string? into = null)
+            string? into = null) => Guard.Tool("housecarl_set_field", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         var op = new BulkOp
@@ -53,7 +53,7 @@ public static class WriteTools
             Formid = formid, FieldPath = field_path, Verb = verb, Value = value, Key = key, Values = values,
         };
         return Render(svc.ApplyEdits(new[] { op }, patch_name, into));
-    }
+    });
 
     [McpServerTool(Name = "housecarl_bulk_apply", Title = "Apply many edits in one patch"),
      Description(
@@ -75,13 +75,13 @@ public static class WriteTools
         [Description("Optional. Base filename for the new patch (default 'houseCARL_Patch'); auto-suffixed if taken. Ignored if into= is given.")]
             string patch_name = "houseCARL_Patch",
         [Description("Optional. Filename of an existing patch to EXTEND with these edits instead of writing a fresh one (accumulate across calls/sessions).")]
-            string? into = null)
+            string? into = null) => Guard.Tool("housecarl_bulk_apply", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         if (operations is null || operations.Length == 0)
             return "error: operations is empty. Pass one or more {formid, field_path, verb, ...} edits.";
         return Render(svc.ApplyEdits(operations, patch_name, into));
-    }
+    });
 
     [McpServerTool(Name = "housecarl_remove_record", Title = "Remove a whole record from a patch"),
      Description(
@@ -102,11 +102,11 @@ public static class WriteTools
         [Description("The record's FormID as 'XXXXXX:Plugin.esp' — the record to drop from the patch.")]
             string formid,
         [Description("Filename of the houseCARL patch to remove the record from (e.g. 'MyMerge.esp' or 'MyMerge') — must be a patch houseCARL created that carries this record.")]
-            string patch)
+            string patch) => Guard.Tool("housecarl_remove_record", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         return RenderRemoval(svc.RemoveRecords(new[] { formid }, patch));
-    }
+    });
 
     [McpServerTool(Name = "housecarl_create_record", Title = "Create a brand-new record"),
      Description(
@@ -135,11 +135,11 @@ public static class WriteTools
         [Description("Optional. Base filename for the new patch (default 'houseCARL_Patch'); auto-suffixed if taken. Ignored if into= is given.")]
             string patch_name = "houseCARL_Patch",
         [Description("Optional. Filename of an existing houseCARL patch to add this new record to instead of writing a fresh one (accumulate across calls/sessions).")]
-            string? into = null)
+            string? into = null) => Guard.Tool("housecarl_create_record", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         return RenderCreate(svc.CreateRecords(record_type, editorid, operations ?? Array.Empty<BulkOp>(), patch_name, into));
-    }
+    });
 
     /// <summary>Compact, parseable confirmation (rulebook: short mutation confirmation + the IDs needed for follow-up).
     /// On refusal, the full reason (every malformed/rejected op) so the caller can fix and retry.</summary>


### PR DESCRIPTION
## What this fixes

**HCBR-2026-06-11-01** — the "intermittent CELL/PlacedNpc errors under concurrent load" report. Root-caused from the audit agents' transcripts: **not concurrency**. Every failing call passed `plugins` as a bare string (`"plugins": "SexLab-AmorousAdventures.esp"`) where the tool schema declares `string[]`; `NPC_` and a second plugin failed identically. The MCP SDK binds JSON arguments to the tool method's parameters **before any houseCARL code runs**, and its catch sits **above** the filter pipeline, genericizing every binding throw to *"An error occurred invoking '<tool>'."* — an opaque dead end the calling agent couldn't self-correct from, so it abandoned the documented query path.

## The three commits

1. **Tool-argument binding shim** (`ToolCallShim`, a call-tool filter; schema-driven off each tool's own published InputSchema, so every current and future parameter is covered by construction):
   - a bare string where an array is declared coerces to a one-element array (the live failing shape); quoted bools/numbers coerce; a bare number where a string is declared becomes its text
   - missing REQUIRED parameters are refused **by name** (the audit's `{}` call now says `required parameter missing: formids`)
   - anything that still throws below the filter returns a named error carrying the real exception text + each received argument's JSON kind (e.g. `limit=object`)
2. **Tool-body guard** (`Guard.Tool` around all 16 tool bodies): an unhandled body exception returns a named error with honest retry guidance, full stack to stderr (the MCP log). Keeps the shim honest by division of labor — only pre-body (binding) exceptions can reach the shim's catch.
3. **Resolver snapshot atomicity**: each index build now swaps in as ONE immutable `IndexSnapshot` via a single volatile reference write; readers capture once per operation (scans at enumeration start). Kills the mid-rebuild tear window where a reader outside the service gate could see a NEW index next to OLD overriders (a `KeyNotFoundException` → opaque transport error, pre-guard). Spotted while root-causing the report; not its cause, but real.

## Proof

- **`binding-shim-guard`** (new CI step): drives the REAL `housecarl-mcp.exe` over stdio with the report's exact shapes — needs no game data (binding resolves before configuration). **RED on the unfixed build (4/7 generic), GREEN with the fix (7/7)**, including a schema-stability assert (`plugins` still declares an array — the fix must never degrade the model's shape hint).
- **Full local probe suite green**: all 13 CI probes, including the resolver-heavy guards (pkcu-regression, source-display, perk-refs, conflict-diff, writelock, formid-floor).
- **Live round-trip on the real ARR 2.0 load order** (temp data dir, production config untouched): the verbatim failing call `{type:"CELL", plugins:"SexLab-AmorousAdventures.esp", limit:100}` → **30 matches** (matching the report's isolation run). The guard also proved itself live en route: a missing dev-bin corpus.json came back as a named error, not the generic.

Bug report annotated with the confirmed root cause (addendum in the report store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
