### PR TITLE
Service layer: one captured snapshot view per logical operation (HCBR-2026-06-11-02)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,3 +92,10 @@ jobs:
       # (never the SDK's generic text), and the published schema stays a declared array (HCBR-2026-06-11-01).
       - name: Probe — tool-argument binding shim (drives the real server over stdio)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- binding-shim-guard
+
+      # Self-contained (synthesizes a master + override, then rewrites the override and rebuilds the index mid-test
+      # — no external files), runs fully here: a regression guard locking in the snapshot-view capture discipline —
+      # ONE captured view answers a whole logical operation (winner/touching/counters from the SAME build), pinned
+      # across a real index rebuild; the real service layer rides it (HCBR-2026-06-11-02).
+      - name: Probe — snapshot-view capture (self-contained regression guard)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- snapshot-view-guard

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -81,7 +81,7 @@ public sealed class LoadOrderResolver : IDisposable
     /// opaque transport error pre-Guard). Bundling the build into one immutable snapshot, captured ONCE per operation
     /// (iterators capture at enumeration start), makes a torn view impossible by construction (HCBR-2026-06-11-01
     /// hardening). The volatile field gives the swap release/acquire visibility.</summary>
-    sealed class IndexSnapshot
+    internal sealed class IndexSnapshot   // internal (not private) so IndexView's ctor can take it; never leaves the assembly
     {
         public readonly Dictionary<FormKey, (int winner, int count)> Index;   // ALL keys — winner + depth, O(1)
         public readonly Dictionary<FormKey, int[]> Overriders;                // MULTI keys only — ordered touching overlay indices
@@ -356,24 +356,78 @@ public sealed class LoadOrderResolver : IDisposable
         return head.Length > 300 ? head.Substring(0, 300) + "…" : head;
     }
 
+    // ---- Snapshot-scoped reads (HCBR-2026-06-11-02: one build per logical operation) --------------------
+
+    /// <summary>Capture the CURRENT build as a pinned read view. The snapshot swap (HCBR-2026-06-11-01 hardening)
+    /// made each individual read internally consistent; this is the cross-VALUE companion: a service method that
+    /// issues SEVERAL resolver reads in one logical operation could still observe TWO adjacent builds if a
+    /// freshness rebuild landed between them — a status line mixing counters from different builds, a record's
+    /// winner disagreeing with its own touching-plugin list, a scan row's winner= reflecting a newer build than
+    /// the scan that produced it. Capture ONCE per logical operation (one service method / one tool call) and
+    /// answer every question in that operation off the SAME view; a rebuild mid-operation then changes nothing
+    /// the operation reports. Pure data over the immutable snapshot — no handles, safe to hold for a call.</summary>
+    public IndexView Capture() => new(this, _snap);
+
+    /// <summary>A read view pinned to ONE captured index build (see <see cref="Capture"/>). Every member answers
+    /// from the SAME build — winner, touching list, counters, and the scan streams can never disagree about which
+    /// build they describe. Bodies are still fetched from the files on disk (Option B holds no bodies), so a
+    /// mid-operation file edit surfaces as the existing named staleness errors, never as torn index values.</summary>
+    public readonly struct IndexView
+    {
+        readonly LoadOrderResolver _r;
+        readonly IndexSnapshot _s;
+        internal IndexView(LoadOrderResolver r, IndexSnapshot s) { _r = r; _s = s; }   // only Capture() constructs
+
+        public int PluginCount => _r._paths.Length;
+        public int RecordCount => _s.Index.Count;               // distinct FormKeys across the order
+        public int ConflictCount => _s.Overriders.Count;        // FormKeys overridden by >1 plugin
+        public int MaxDepth => _s.MaxDepth;
+        public IReadOnlyList<string> LoadFailures => _s.LoadFailures;
+        public IReadOnlyDictionary<string, string> ExcludedPlugins => _s.ExcludedPlugins;
+
+        /// <summary>O(1): the winning plugin + override depth for a FormKey. null if the FormKey isn't in the order.</summary>
+        public WinnerInfo? ResolveWinner(FormKey fk)
+            => _s.Index.TryGetValue(fk, out var e) ? new WinnerInfo(fk, _r._names[e.winner], e.count) : null;
+
+        /// <summary>Every FormKey overridden by more than one plugin (the whole-order conflict set).</summary>
+        public IEnumerable<FormKey> ConflictKeys() => _s.Overriders.Keys;
+
+        /// <summary>The ordered touching-plugin names for a FormKey (priority order, winner last) — no body fetched.
+        /// The atom behind every conflict-status question.</summary>
+        public IReadOnlyList<string>? TouchingPlugins(FormKey fk)
+        {
+            if (!_s.Index.TryGetValue(fk, out var e)) return null;
+            if (e.count == 1) return new[] { _r._names[e.winner] };    // singleton: sole overrider = winner
+            var names = _r._names;                                     // local copy — a struct's lambda can't capture 'this'
+            return Array.ConvertAll(_s.Overriders[fk], i => names[i]);
+        }
+
+        /// <summary>The winner-body scan stream (<see cref="LoadOrderResolver.WinnerRecordsOfType(IReadOnlyList{Type})"/>),
+        /// pinned to THIS view's build — so a caller's per-match winner/depth fills agree with the scan by construction.</summary>
+        public IEnumerable<(FormKey fk, int depth, IMajorRecordGetter body)> WinnerRecordsOfType(IReadOnlyList<Type> getterTypes)
+            => _r.WinnerRecordsOfType(getterTypes, _s);
+
+        /// <summary>The plugin-scoped scan stream (<see cref="LoadOrderResolver.RecordsIn(IReadOnlyList{string}, IReadOnlyList{Type})"/>),
+        /// pinned to THIS view's build.</summary>
+        public IEnumerable<(FormKey fk, int depth, IMajorRecordGetter body, string source)> RecordsIn(
+            IReadOnlyList<string> plugins, IReadOnlyList<Type>? getterTypes)
+            => _r.RecordsIn(plugins, getterTypes, _s);
+    }
+
     // ---- Queries -------------------------------------------------------
+    //  Single-shot conveniences: each delegates to a fresh Capture(), so one call = one build (the pre-existing
+    //  contract). A caller making SEVERAL reads in one logical operation should Capture() once and read off the
+    //  view instead — that's the HCBR-2026-06-11-02 discipline the service layer follows.
 
     /// <summary>O(1): the winning plugin + override depth for a FormKey. null if the FormKey isn't in the order.</summary>
-    public WinnerInfo? ResolveWinner(FormKey fk)
-        => _snap.Index.TryGetValue(fk, out var e) ? new WinnerInfo(fk, _names[e.winner], e.count) : null;
+    public WinnerInfo? ResolveWinner(FormKey fk) => Capture().ResolveWinner(fk);
 
     /// <summary>Every FormKey overridden by more than one plugin (the whole-order conflict set).</summary>
-    public IEnumerable<FormKey> ConflictKeys() => _snap.Overriders.Keys;
+    public IEnumerable<FormKey> ConflictKeys() => Capture().ConflictKeys();
 
     /// <summary>The ordered touching-plugin names for a FormKey (priority order, winner last) — no body fetched.
     /// The atom behind every conflict-status question.</summary>
-    public IReadOnlyList<string>? TouchingPlugins(FormKey fk)
-    {
-        var s = _snap;                                                 // ONE build — Index and Overriders can't disagree
-        if (!s.Index.TryGetValue(fk, out var e)) return null;
-        if (e.count == 1) return new[] { _names[e.winner] };           // singleton: sole overrider = winner
-        return Array.ConvertAll(s.Overriders[fk], i => _names[i]);
-    }
+    public IReadOnlyList<string>? TouchingPlugins(FormKey fk) => Capture().TouchingPlugins(fk);
 
     /// <summary>The full conflict tree: every touching plugin's body, in priority order (winner last). Bodies are
     /// fetched on demand into <paramref name="session"/> (which keeps the touched plugins open until the caller has
@@ -460,8 +514,10 @@ public sealed class LoadOrderResolver : IDisposable
     /// (FormKey, override-depth, winner body). The throw-if-unknown guard is Q3 belt-and-braces (corpus-resolved
     /// types are always real).</summary>
     public IEnumerable<(FormKey fk, int depth, IMajorRecordGetter body)> WinnerRecordsOfType(IReadOnlyList<Type> getterTypes)
+        => WinnerRecordsOfType(getterTypes, _snap);                        // ONE build for the whole scan (captured here, at the call)
+
+    IEnumerable<(FormKey fk, int depth, IMajorRecordGetter body)> WinnerRecordsOfType(IReadOnlyList<Type> getterTypes, IndexSnapshot s)
     {
-        var s = _snap;                                                     // ONE build, captured for the whole scan
         for (int i = 0; i < _paths.Length; i++)
         {
             if (s.Excluded.Contains(i)) continue;                          // excluded at build (unparseable/unopenable) — wins nothing; never re-touch (would re-throw)
@@ -486,8 +542,11 @@ public sealed class LoadOrderResolver : IDisposable
     /// filename — so a caller can DISPLAY from the same body it filtered, not the winner). Holds nothing.</summary>
     public IEnumerable<(FormKey fk, int depth, IMajorRecordGetter body, string source)> RecordsIn(
         IReadOnlyList<string> plugins, IReadOnlyList<Type>? getterTypes)
+        => RecordsIn(plugins, getterTypes, _snap);                         // ONE build for the whole scan (captured here, at the call)
+
+    IEnumerable<(FormKey fk, int depth, IMajorRecordGetter body, string source)> RecordsIn(
+        IReadOnlyList<string> plugins, IReadOnlyList<Type>? getterTypes, IndexSnapshot s)
     {
-        var s = _snap;                                                     // ONE build, captured for the whole scan
         foreach (int i in ScopeIndices(plugins, s))
         {
             ISkyrimModGetter ov;

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -79,8 +79,9 @@ public sealed class LoadOrderResolver : IDisposable
     /// sibling call's freshness check may rebuild) — when the per-build state lived in five separate fields, a reader
     /// could observe a NEW index next to OLD overriders mid-swap (a KeyNotFound on a freshly-multi key, surfaced as an
     /// opaque transport error pre-Guard). Bundling the build into one immutable snapshot, captured ONCE per operation
-    /// (iterators capture at enumeration start), makes a torn view impossible by construction (HCBR-2026-06-11-01
-    /// hardening). The volatile field gives the swap release/acquire visibility.</summary>
+    /// (single-shot members and the scan wrappers capture at CALL time; <see cref="Capture"/> pins a whole logical
+    /// operation), makes a torn view impossible by construction (HCBR-2026-06-11-01 hardening, extended by
+    /// HCBR-2026-06-11-02's IndexView). The volatile field gives the swap release/acquire visibility.</summary>
     internal sealed class IndexSnapshot   // internal (not private) so IndexView's ctor can take it; never leaves the assembly
     {
         public readonly Dictionary<FormKey, (int winner, int count)> Index;   // ALL keys — winner + depth, O(1)

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -43,6 +43,10 @@ if (args.Length > 0 && args[0] == "source-display-guard") return SourceDisplayPr
 // exact malformed argument shapes — string-for-array coerces, missing-required refuses by name, uncoercible fails named.
 if (args.Length > 0 && args[0] == "binding-shim-guard") return BindingShimProbe.RunGuard(args[1..]);
 
+// Snapshot-view capture (HCBR-2026-06-11-02): SELF-CONTAINED CI regression guard — a captured IndexView answers
+// winner/touching/counters from ONE build even when the index rebuilds mid-operation; the real service rides it.
+if (args.Length > 0 && args[0] == "snapshot-view-guard") return SnapshotViewProbe.RunGuard(args[1..]);
+
 // One-shot verify (decision #1): confirm the xEdit 4-char signature reflection path.
 if (args.Length > 0 && args[0] == "sig") return Probe.RunSig();
 

--- a/src/housecarl-generator/SnapshotViewProbe.cs
+++ b/src/housecarl-generator/SnapshotViewProbe.cs
@@ -1,0 +1,169 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// REGRESSION GUARD (standing CI instrument) for the snapshot-view capture discipline (HCBR-2026-06-11-02):
+/// ONE logical operation answers EVERY question off ONE captured index build. PR #34 made each individual
+/// resolver read internally consistent (the index swaps in as one immutable snapshot); the residue it left was
+/// CROSS-VALUE: a service method issuing several resolver reads (Stats' four counters; ResolveRead's
+/// excluded-check + winner + touching; CrossQuery's per-match winner fill next to its scan) could still mix TWO
+/// adjacent builds in one response when a freshness rebuild landed mid-operation. The fix pins each operation to
+/// a <see cref="LoadOrderResolver.IndexView"/> captured once at the top.
+///
+/// Self-contained, in the pattern of <c>pkcu-regression</c> / <c>source-display-guard</c>: synthesizes a
+/// 2-plugin order ON DISK — a master with two weapons, an override plugin overriding one of them — then REWRITES
+/// the override plugin (it stops overriding and brings its own new weapon instead) and triggers the REAL rebuild
+/// path (<see cref="LoadOrderResolver.RefreshIfStale"/>). The mutation flips every observable: winner, depth,
+/// touching list, RecordCount, ConflictCount, MaxDepth — so a value from the wrong build is provable.
+///
+/// Arms:
+///   CONTROL — two captures straddling the rebuild DISAGREE about the winner: proves a rebuild really swaps the
+///             build mid-session here, i.e. the hazard class the discipline closes is live in this environment.
+///   PINNED  — the view captured BEFORE the rebuild still answers ALL-OLD after it (winner + depth + touching +
+///             all counters from its own build, internally consistent). RED if any <c>IndexView</c> member ever
+///             re-derefs the live <c>_snap</c> instead of the captured build — the exact regression class.
+///   FRESH   — a capture taken AFTER the rebuild answers ALL-NEW, equally internally consistent (the view must
+///             pin, not freeze: new operations see the new build).
+///   SERVICE — drives the REAL <see cref="LoadOrderService"/> (ForGuard seam) on the post-rebuild order:
+///             Stats() counters are one consistent set; ResolveRead's winner agrees with its OWN touching list
+///             (winner == touching[^1]); CrossQuery's per-match winner/depth agree with the build that scanned
+///             (the plugins= path — the same scan loop type= runs, no corpus needed). Behavioral cover that the
+///             view refactor changed nothing on a stable order.
+///
+/// The mid-operation race itself can't be scheduled deterministically (no injection seam in the product paths —
+/// by design); per the report, the practical gate is this structural one: the pinning mechanism proven across a
+/// REAL rebuild + the service answering off it (code shape reviewed at the call sites).
+///
+/// Run: <c>dotnet run --project src/housecarl-generator -- snapshot-view-guard</c>
+/// </summary>
+public static class SnapshotViewProbe
+{
+    static int _pass, _fail;
+
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  REGRESSION GUARD — snapshot-view capture (one build per logical operation, HCBR-2026-06-11-02)  ################");
+        Console.WriteLine();
+
+        var dir = Path.Combine(Path.GetTempPath(), "hc_snapshot_view_guard");
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); } catch { }
+        Directory.CreateDirectory(dir);
+
+        const string masterName = "hcSnapMaster.esp", ovrName = "hcSnapOvr.esp";
+        var masterPath = Path.Combine(dir, masterName);
+        var ovrPath = Path.Combine(dir, ovrName);
+
+        try
+        {
+            // ---- 1. MASTER: two weapons (W1, W2). Masterless (CI has no game files — it references nothing). ----
+            var master = new SkyrimMod(ModKey.FromNameAndExtension(masterName), SkyrimRelease.SkyrimSE);
+            var w1 = master.Weapons.AddNew(); w1.EditorID = "hcSnapW1";
+            var w2 = master.Weapons.AddNew(); w2.EditorID = "hcSnapW2";
+            var fk1 = w1.FormKey;
+            master.BeginWrite.ToPath(masterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+            // ---- 2. OVERRIDE v1: overrides W1 → the OLD build has winner(W1)=ovr, depth 2, 1 conflict. ----
+            var ovr1 = new SkyrimMod(ModKey.FromNameAndExtension(ovrName), SkyrimRelease.SkyrimSE);
+            WriteEngine.GenericGetOrAddAsOverride(ovr1, w1);
+            ovr1.BeginWrite.ToPath(ovrPath).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
+
+            using var resolver = LoadOrderResolver.Build(new[] { masterPath, ovrPath });
+            Console.WriteLine($"-- built order {masterName} < {ovrName} (v1 overrides W1) --");
+
+            // ---- 3. Capture the view of the OLD build, and pin its expected facts while it is current. ----
+            var viewOld = resolver.Capture();
+            Check("old build: winner(W1) = override, depth 2",
+                  viewOld.ResolveWinner(fk1) is { } wo && Eq(wo.WinnerPlugin, ovrName) && wo.OverrideDepth == 2);
+            Check("old build: touching(W1) = [master, override]",
+                  viewOld.TouchingPlugins(fk1) is { Count: 2 } to && Eq(to[0], masterName) && Eq(to[1], ovrName));
+            Check("old build: counters = 2 records / 1 conflict / maxDepth 2",
+                  viewOld.RecordCount == 2 && viewOld.ConflictCount == 1 && viewOld.MaxDepth == 2);
+
+            // ---- 4. MUTATE the order on disk: override v2 stops overriding W1 and brings its OWN weapon (W3)
+            //         instead — every observable flips — then drive the REAL rebuild path. ----
+            var ovr2 = new SkyrimMod(ModKey.FromNameAndExtension(ovrName), SkyrimRelease.SkyrimSE);
+            var w3 = ovr2.Weapons.AddNew(); w3.EditorID = "hcSnapW3";
+            ovr2.BeginWrite.ToPath(ovrPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            File.SetLastWriteTimeUtc(ovrPath, DateTime.UtcNow.AddSeconds(2));   // belt-and-braces: the mtime sweep MUST see a change
+            Check("RefreshIfStale rebuilt the index (the mutation was seen)", resolver.RefreshIfStale());
+            Console.WriteLine($"-- rewrote {ovrName} (v2: no override, own weapon W3) and rebuilt --");
+            Console.WriteLine();
+
+            // ---- CONTROL: captures straddling the rebuild disagree — the hazard class is real here. ----
+            var fresh = resolver.ResolveWinner(fk1);
+            Check($"CONTROL: a fresh read now answers from the NEW build (winner(W1) = {masterName})",
+                  fresh is { } fw && Eq(fw.WinnerPlugin, masterName) && fw.OverrideDepth == 1);
+            Check("CONTROL: old view vs fresh read DISAGREE — the torn pair a multi-capture operation could emit",
+                  viewOld.ResolveWinner(fk1) is { } ow && !Eq(ow.WinnerPlugin, fresh!.Value.WinnerPlugin));
+
+            // ---- PINNED: the old view, read AFTER the rebuild, answers ALL-OLD — internally consistent. ----
+            Check("PINNED: viewOld.ResolveWinner(W1) still = override, depth 2",
+                  viewOld.ResolveWinner(fk1) is { } pw && Eq(pw.WinnerPlugin, ovrName) && pw.OverrideDepth == 2);
+            Check("PINNED: viewOld.TouchingPlugins(W1) still = [master, override]",
+                  viewOld.TouchingPlugins(fk1) is { Count: 2 } pt && Eq(pt[0], masterName) && Eq(pt[1], ovrName));
+            Check("PINNED: viewOld counters still = 2 records / 1 conflict / maxDepth 2",
+                  viewOld.RecordCount == 2 && viewOld.ConflictCount == 1 && viewOld.MaxDepth == 2);
+            Check("PINNED: viewOld.ConflictKeys() still yields exactly [W1]",
+                  viewOld.ConflictKeys().ToList() is { Count: 1 } ck && ck[0] == fk1);
+
+            // ---- FRESH: a new capture answers ALL-NEW — the view pins, it doesn't freeze the resolver. ----
+            var viewNew = resolver.Capture();
+            Check($"FRESH: viewNew.ResolveWinner(W1) = {masterName}, depth 1",
+                  viewNew.ResolveWinner(fk1) is { } nw && Eq(nw.WinnerPlugin, masterName) && nw.OverrideDepth == 1);
+            Check("FRESH: viewNew.TouchingPlugins(W1) = [master] only",
+                  viewNew.TouchingPlugins(fk1) is { Count: 1 } nt && Eq(nt[0], masterName));
+            Check("FRESH: viewNew counters = 3 records / 0 conflicts / maxDepth 0",
+                  viewNew.RecordCount == 3 && viewNew.ConflictCount == 0 && viewNew.MaxDepth == 0);
+            Console.WriteLine();
+
+            // ---- SERVICE: the REAL service methods, each answering off one capture, on the (stable) new build. ----
+            var svc = LoadOrderService.ForGuard(resolver, new UserConfigStore(Path.Combine(dir, "houseCARL.user.json")));
+
+            var stats = svc.Stats();
+            Check("SERVICE Stats(): one consistent counter set (2 plugins / 3 records / 0 conflicts / maxDepth 0 / 0 failures)",
+                  stats.plugins == 2 && stats.records == 3 && stats.conflicts == 0 && stats.maxDepth == 0 && stats.loadFailures.Count == 0);
+
+            var read = svc.ResolveRead(fk1, null, null, conflictTree: true);
+            Check("SERVICE ResolveRead(W1): no error, winner = master, depth 1",
+                  read.Error is null && Eq(read.WinnerPlugin ?? "", masterName) && read.OverrideDepth == 1);
+            Check("SERVICE ResolveRead(W1): winner agrees with its OWN touching list (winner == touching[^1])",
+                  read.TouchingPlugins is { Count: 1 } rt && Eq(rt[^1], read.WinnerPlugin ?? ""));
+
+            var q = svc.CrossQuery(type: null, references: null, editoridContains: null, conflictsOnly: false,
+                                   plugins: new[] { masterName, ovrName }, where: null, limit: 500);
+            Check("SERVICE CrossQuery(plugins=[master,ovr]): no error, 3 matches (W1, W2, W3)",
+                  q.Error is null && q.Total == 3 && q.Keys.Count == 3 && q.Prefilled is { Count: 3 });
+            Check("SERVICE CrossQuery: every per-match winner/depth agrees with the build that scanned",
+                  q.Error is null && q.Prefilled is not null && Enumerable.Range(0, q.Keys.Count).All(i =>
+                      resolver.ResolveWinner(q.Keys[i]) is { } cw
+                      && Eq(q.Prefilled[i].Winner, cw.WinnerPlugin) && q.Prefilled[i].OverrideDepth == cw.OverrideDepth));
+            Check($"SERVICE CrossQuery: W1's row reads from the NEW build (winner {masterName}, depth 1 — not the old override/2)",
+                  q.Error is null && q.Prefilled is not null && Enumerable.Range(0, q.Keys.Count).Any(i =>
+                      q.Keys[i] == fk1 && Eq(q.Prefilled[i].Winner, masterName) && q.Prefilled[i].OverrideDepth == 1));
+
+            var qc = svc.CrossQuery(type: null, references: null, editoridContains: null, conflictsOnly: true,
+                                    plugins: null, where: null, limit: 500);
+            Check("SERVICE CrossQuery(conflicts_only): 0 matches on the new build (the old build had 1)",
+                  qc.Error is null && qc.Total == 0);
+
+            Console.WriteLine();
+            Console.WriteLine($"=== snapshot-view-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
+            return _fail == 0 ? 0 : 1;
+        }
+        catch (Exception ex) { Console.WriteLine($"   FAIL (unexpected): {ex.GetType().Name}: {ex.Message}"); return 1; }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
+
+    static bool Eq(string a, string b) => string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
+
+    static void Check(string label, bool ok)
+    {
+        Console.WriteLine($"   [{(ok ? "PASS" : "FAIL")}] {label}");
+        if (ok) _pass++; else _fail++;
+    }
+}

--- a/src/housecarl-generator/SnapshotViewProbe.cs
+++ b/src/housecarl-generator/SnapshotViewProbe.cs
@@ -111,6 +111,17 @@ public static class SnapshotViewProbe
             Check("PINNED: viewOld.ConflictKeys() still yields exactly [W1]",
                   viewOld.ConflictKeys().ToList() is { Count: 1 } ck && ck[0] == fk1);
 
+            // ---- PINNED SCANS (review #1, teeth proven missing): the view's SCAN STREAMS must ride the pinned
+            //      build too, not re-deref the live one. Master's file is unchanged on disk, so enumerating it
+            //      under the OLD snapshot is staleness-safe; the discriminators are pure index facts. ----
+            var pinnedIn = viewOld.RecordsIn(new[] { masterName }, null).Where(x => x.fk == fk1).ToList();
+            Check("PINNED SCAN: viewOld.RecordsIn(master) yields W1 at the OLD depth 2 (a live re-deref would say 1)",
+                  pinnedIn.Count == 1 && pinnedIn[0].depth == 2);
+            var pinnedWin = viewOld.WinnerRecordsOfType(new[] { typeof(Mutagen.Bethesda.Skyrim.IWeaponGetter) }).ToList();
+            Check("PINNED SCAN: viewOld.WinnerRecordsOfType yields ONLY W2 (old build: W1's winner is the override; " +
+                  "a live re-deref would also yield W1 from master and W3 from the rewritten override)",
+                  pinnedWin.Count == 1 && pinnedWin[0].fk != fk1);
+
             // ---- FRESH: a new capture answers ALL-NEW — the view pins, it doesn't freeze the resolver. ----
             var viewNew = resolver.Capture();
             Check($"FRESH: viewNew.ResolveWinner(W1) = {masterName}, depth 1",

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -129,8 +129,8 @@ public sealed class LoadOrderService : IDisposable
     /// <summary>Whole-order stats (forces the lazy build). For the server's stand-up / health check.</summary>
     public (int plugins, int records, int conflicts, int maxDepth, IReadOnlyList<string> loadFailures) Stats()
     {
-        var r = Resolver;
-        return (r.PluginCount, r.RecordCount, r.ConflictCount, r.MaxDepth, r.LoadFailures);
+        var view = Resolver.Capture();          // ONE build for every counter in the line (HCBR-2026-06-11-02)
+        return (view.PluginCount, view.RecordCount, view.ConflictCount, view.MaxDepth, view.LoadFailures);
     }
 
     /// <summary>Diagnostic snapshot for housecarl_load_order_status: the CURRENT enabled/disabled composition (read fresh
@@ -139,10 +139,10 @@ public sealed class LoadOrderService : IDisposable
     /// changed since that build (Q3 — never present a stale picture as current). Forces the lazy resolver build.</summary>
     public LoadOrderStatusData StatusData()
     {
-        var r = Resolver;                                          // force build/refresh → resolved count + warnings + exclusions
+        var view = Resolver.Capture();                             // force build/refresh; ONE build for count + exclusions (HCBR-2026-06-11-02)
         var comp = Mo2LoadOrder.ReadComposition(_profileDir);      // FRESH composition (always current)
         return new LoadOrderStatusData(
-            comp, _orderWarnings, r.PluginCount, _maxPlugins, ProfileNewerThan(_orderBuiltUtc), _profileDir, r.ExcludedPlugins);
+            comp, _orderWarnings, view.PluginCount, _maxPlugins, ProfileNewerThan(_orderBuiltUtc), _profileDir, view.ExcludedPlugins);
     }
 
     /// <summary>True if any of the three MO2 profile files has a newer mtime than the resolver's last build — i.e. the
@@ -302,20 +302,29 @@ public sealed class LoadOrderService : IDisposable
     public ReadOutcome ResolveRead(FormKey fk, string? plugin, IReadOnlyList<string>? fields, bool conflictTree, int depth = 1)
     {
         var resolver = Resolver;
+        return ResolveRead(resolver, resolver.Capture(), fk, plugin, fields, conflictTree, depth);
+    }
 
+    /// <summary>The read body, answered entirely off ONE captured view (HCBR-2026-06-11-02): excluded-check, winner,
+    /// and touching-plugin list all describe the SAME build — a freshness rebuild landing mid-read can no longer make
+    /// a record's reported winner disagree with its own conflict tree. (The body fetch reads the file on disk through
+    /// the session; a mid-read file edit surfaces as the existing named fetch-inconsistency error, never torn values.)</summary>
+    ReadOutcome ResolveRead(LoadOrderResolver resolver, LoadOrderResolver.IndexView view,
+                            FormKey fk, string? plugin, IReadOnlyList<string>? fields, bool conflictTree, int depth)
+    {
         // An explicitly-requested plugin that was EXCLUDED this session (unparseable/unopenable) → say so (Q3),
         // rather than fall through to a misleading "does not define this record".
-        if (plugin is not null && resolver.ExcludedPlugins.TryGetValue(plugin, out var pWhy))
+        if (plugin is not null && view.ExcludedPlugins.TryGetValue(plugin, out var pWhy))
             return ReadOutcome.Fail(fk, $"Plugin '{plugin}' was excluded from this session: {pWhy}");
 
-        var winner = resolver.ResolveWinner(fk);
+        var winner = view.ResolveWinner(fk);
         if (winner is null)
         {
             // If the record's defining plugin was excluded, that's WHY it's missing — name it (Q3), not a bare "not present".
             var defining = fk.ModKey.FileName.ToString();
-            if (resolver.ExcludedPlugins.TryGetValue(defining, out var dWhy))
+            if (view.ExcludedPlugins.TryGetValue(defining, out var dWhy))
                 return ReadOutcome.Fail(fk, $"FormID {fk} is not resolvable: its plugin '{defining}' was excluded from this session: {dWhy}");
-            return ReadOutcome.Fail(fk, $"FormID {fk} is not present in the load order ({resolver.PluginCount} plugins).");
+            return ReadOutcome.Fail(fk, $"FormID {fk} is not present in the load order ({view.PluginCount} plugins).");
         }
 
         var source = plugin ?? winner.Value.WinnerPlugin;
@@ -327,7 +336,7 @@ public sealed class LoadOrderService : IDisposable
                 : $"Plugin '{plugin}' does not define {fk} (it does not touch this record). The winner is '{winner.Value.WinnerPlugin}'.");
 
         var record = ReadEngine.ReadFields(rec, fields, depth);           // materialise while the session (overlay) is open
-        var touching = conflictTree ? resolver.TouchingPlugins(fk) : null;
+        var touching = conflictTree ? view.TouchingPlugins(fk) : null;
         return new ReadOutcome(fk, record, source, winner.Value.WinnerPlugin, winner.Value.OverrideDepth, touching, null);
     }
 
@@ -360,7 +369,7 @@ public sealed class LoadOrderService : IDisposable
     public RecordSummary ResolveSummary(FormKey fk)
     {
         var resolver = Resolver;
-        var w = resolver.ResolveWinner(fk);
+        var w = resolver.Capture().ResolveWinner(fk);   // one capture per summary (winner + depth from one build)
         if (w is null) return new RecordSummary(fk, "?", null, "?", 0, $"{fk} not in the load order");
         using var session = resolver.OpenSession();
         var body = resolver.GetRecord(session, w.Value.WinnerPlugin, fk);
@@ -378,13 +387,15 @@ public sealed class LoadOrderService : IDisposable
     /// failing the batch. Returns one <see cref="ReadOutcome"/> per input, in order.</summary>
     public IReadOnlyList<ReadOutcome> ResolveBatch(IReadOnlyList<string> formids, IReadOnlyList<string>? fields, bool conflictTree, int depth = 1)
     {
+        var resolver = Resolver;                // build/refresh ONCE for the batch
+        var view = resolver.Capture();          // ONE build for every item — the whole batch is one logical operation (HCBR-2026-06-11-02)
         var outcomes = new List<ReadOutcome>(formids.Count);
         foreach (var raw in formids)
         {
             FormKey fk;
             try { fk = FormKey.Factory(raw.Trim()); }
             catch (Exception ex) { outcomes.Add(ReadOutcome.Fail(default, $"bad FormID '{raw}': {ex.Message}")); continue; }
-            outcomes.Add(ResolveRead(fk, null, fields, conflictTree, depth));
+            outcomes.Add(ResolveRead(resolver, view, fk, null, fields, conflictTree, depth));
         }
         return outcomes;
     }
@@ -401,6 +412,7 @@ public sealed class LoadOrderService : IDisposable
                                         bool conflictsOnly, IReadOnlyList<string>? plugins, IReadOnlyList<string>? where, int limit)
     {
         var resolver = Resolver;
+        var view = resolver.Capture();          // ONE build for the SCAN and every per-match fill it makes (HCBR-2026-06-11-02)
         bool hasPlugins = plugins is { Count: > 0 };
         bool hasType = type is not null;
         bool hasWhere = where is { Count: > 0 };
@@ -443,8 +455,8 @@ public sealed class LoadOrderService : IDisposable
                 // Carry the SOURCE plugin per record so the render shows the body the scan filtered (not the winner):
                 // plugins= → the scoped plugin's filename; type= → null (⇒ the winner, the WinnerRecordsOfType body).
                 IEnumerable<(FormKey fk, int depth, IMajorRecordGetter body, string? source)> stream =
-                    hasPlugins ? resolver.RecordsIn(plugins!, types).Select(x => (fk: x.fk, depth: x.depth, body: x.body, source: (string?)x.source))  // the scoped plugin's own body
-                               : resolver.WinnerRecordsOfType(types!).Select(x => (fk: x.fk, depth: x.depth, body: x.body, source: (string?)null));    // the load-order winner's body
+                    hasPlugins ? view.RecordsIn(plugins!, types).Select(x => (fk: x.fk, depth: x.depth, body: x.body, source: (string?)x.source))  // the scoped plugin's own body
+                               : view.WinnerRecordsOfType(types!).Select(x => (fk: x.fk, depth: x.depth, body: x.body, source: (string?)null));    // the load-order winner's body
                 foreach (var (fk, depth, body, source) in stream)
                 {
                     if (conflictsOnly && depth <= 1) continue;
@@ -475,8 +487,10 @@ public sealed class LoadOrderService : IDisposable
                         {
                             keys.Add(fk);
                             sources.Add(source);                                  // the body we filtered IS the body we'll display (null ⇒ winner)
+                            // winner= off the SAME view the scan runs on — a rebuild landing mid-scan can no longer
+                            // make a row's winner reflect a newer build than the depth beside it (HCBR-2026-06-11-02).
                             prefilled!.Add(new RecordSummary(fk, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID,
-                                                             resolver.ResolveWinner(fk)?.WinnerPlugin ?? "?", depth, null));
+                                                             view.ResolveWinner(fk)?.WinnerPlugin ?? "?", depth, null));
                         }
                     }
                     catch (Exception ex)
@@ -497,7 +511,7 @@ public sealed class LoadOrderService : IDisposable
         {
             // Summaries here would each need a winner-body fetch; leaving them to the renderer (which stops at
             // max_chars) means a big limit with a small max_chars doesn't fetch bodies it will never show.
-            foreach (var fk in resolver.ConflictKeys())
+            foreach (var fk in view.ConflictKeys())
             {
                 total++;
                 if (keys.Count < limit) { keys.Add(fk); sources.Add(null); }   // no scoped plugin → display the winner

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -307,8 +307,11 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>The read body, answered entirely off ONE captured view (HCBR-2026-06-11-02): excluded-check, winner,
     /// and touching-plugin list all describe the SAME build — a freshness rebuild landing mid-read can no longer make
-    /// a record's reported winner disagree with its own conflict tree. (The body fetch reads the file on disk through
-    /// the session; a mid-read file edit surfaces as the existing named fetch-inconsistency error, never torn values.)</summary>
+    /// a record's reported winner disagree with its own TOUCHING LIST. (The body fetch reads the file on disk through
+    /// the session; a mid-read file edit surfaces as the existing named fetch-inconsistency error, never torn values.
+    /// Known residue, review #1: the conflict-tree DIFF the render layer adds is a separate <see cref="ResolveTree"/>
+    /// call with its own capture, so one rendered response can still pair this read's build with an adjacent build's
+    /// diff — same low-severity class, named for the next wave rather than threaded through the render API here.)</summary>
     ReadOutcome ResolveRead(LoadOrderResolver resolver, LoadOrderResolver.IndexView view,
                             FormKey fk, string? plugin, IReadOnlyList<string>? fields, bool conflictTree, int depth)
     {


### PR DESCRIPTION
## What

Closes the accepted hardening debt from the PR #34 independent review (finding 3), filed as **HCBR-2026-06-11-02** and marked by Aaron for this bug-fix wave.

PR #34 made each individual resolver read internally consistent (each index build swaps in as ONE immutable snapshot). The residue: a **service method issuing several resolver reads** could still observe two adjacent builds within one response when a freshness rebuild landed mid-call:

- `Stats()` — four separate snapshot derefs; counters on one status line could come from adjacent builds.
- `ResolveRead(...)` — excluded-check, winner, and touching-plugin list each captured their own snapshot; a record's reported winner could disagree with its own conflict tree.
- `CrossQuery(...)` — the scan held one snapshot but the per-match summary fill re-resolved the winner from a possibly-newer one; a row's `winner=` could reflect a newer build than the `depth` beside it.

## Fix (the review's agreed shape)

`LoadOrderResolver.Capture()` returns an **`IndexView`** pinned to one build — winner, touching list, counters, exclusions, `ConflictKeys`, and both scan streams (`WinnerRecordsOfType` / `RecordsIn`). The service captures **one view at the top of each logical operation** and answers everything off it: `Stats`, `StatusData`, `ResolveRead`, `ResolveBatch` (one view for the whole batch), `ResolveSummary`, and `CrossQuery` (the scan AND its per-match winner fills — equivalent to threading the winner through the scan tuples, with no tuple-shape churn across the 14 probe call sites).

Single-shot resolver members delegate to a fresh `Capture()` — one implementation, per-call contract unchanged. Bodies still come off the files on disk (Option B holds none); a mid-read **file** edit surfaces as the existing named staleness errors, never as torn index values.

## Proof

`snapshot-view-guard` (self-contained, in CI): synthesizes a master + override on disk, rewrites the override, drives the REAL `RefreshIfStale` rebuild mid-test.

- **CONTROL** — captures straddling the rebuild disagree (the hazard class is live in-environment).
- **PINNED** — the pre-rebuild view answers ALL-OLD afterward, internally consistent. **RED-proven:** re-derefing the live `_snap` inside `IndexView.ResolveWinner` fails the guard (2 FAIL, exit 1) — the exact regression class.
- **FRESH** — a new capture answers ALL-NEW (the view pins, it does not freeze).
- **SERVICE** — the real `LoadOrderService` via the ForGuard seam: `Stats` one consistent counter set; `ResolveRead` winner == its own `touching[^1]`; `CrossQuery` per-match winner/depth agree with the scanning build; `conflicts_only` off the same view.

All 12 existing guards stay green locally (pkcu, depth-leak, floi, value-predicate, source-display, writelock, perk-refs, conflict-diff, formid-floor, tool-bridge, binding-shim).

## Known residue (out of scope, per the report)

The mid-operation race itself has no deterministic injection seam (by design — no test hooks in product paths); per the report, the structural gate above is the practical proof. Two smaller residues observed and deliberately left, same low-severity class: (a) `GetRecord`'s internal excluded-check derefs the live snapshot — worst case is the existing **named** fetch-inconsistency error, not mixed data; (b) one **render-layer** response can span two service calls (`ResolveRead` + `ResolveTree` under `conflict_tree=true`; per-match `ResolveRead` in detail mode) — each call is now internally consistent; pinning across calls would mean threading the view through the render API, which the catalogued fix shape did not ask for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)