### PR TITLE
Validate paths + composes through a polymorphic-base's arms — the VMAD write surface (#35)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,3 +106,10 @@ jobs:
       # define"), and the write tools' opt-in full read-back returns every touched record IN FULL off the written file.
       - name: Probe — verify-loop wave, plugin= taxonomy + write-time full read-back (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- verify-loop-guard
+
+      # Corpus-only validator checks for the polymorphic-element surface (#35 — the VMAD write gap): paths through
+      # an arm-only field validate, an arm-element compose validates against the ARM's own schema, and non-arm
+      # fields / non-arm specs still reject NAMED. Self-contained — generates the corpus into a temp dir on a fresh
+      # checkout; the end-to-end engine half (--source) needs game data and runs locally, not here.
+      - name: Probe — polymorphic-element validator (VMAD arm fields + composes)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- vmad-poly-guard

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -109,7 +109,8 @@ public sealed class CorpusRulebook
         for (int i = 0; i < req.Path.Length - 1; i++)
         {
             if (!TrySeg(req.Path[i], out var segName, out var segKey, out var segErr)) return segErr;
-            var field = current.Fields.FirstOrDefault(f => f.Name == segName);
+            var field = FindField(current, segName, out _, out var polyErr);
+            if (polyErr is not null) return polyErr;
             if (field is null) return FieldNotFound(current, segName);
 
             if (segKey is null)
@@ -154,7 +155,8 @@ public sealed class CorpusRulebook
         if (leafKey is not null)
             return $"Path '{req.Path[^1]}' brackets a collection element at the LEAF; brackets navigate mid-path only. " +
                    "To edit a list/dict element, target the collection field and use the verb + Key (SetAtIndex/Set/Remove).";
-        var leaf = current.Fields.FirstOrDefault(f => f.Name == leafName);
+        var leaf = FindField(current, leafName, out var leafOwner, out var leafPolyErr);
+        if (leafPolyErr is not null) return leafPolyErr;
         if (leaf is null) return FieldNotFound(current, leafName);
 
         // (3a) verb legal for this cardinality?
@@ -162,10 +164,10 @@ public sealed class CorpusRulebook
 
         // (3b) record identity (FormKey/ModKey) is a flat, honest reject regardless of Mutagen's setter (plan §3 P-DISC).
         if (leaf.IsIdentity)
-            return $"'{leaf.Name}' on '{current.Name}' is record identity (FormKey/ModKey), not an editable content field.";
+            return $"'{leaf.Name}' on '{leafOwner.Name}' is record identity (FormKey/ModKey), not an editable content field.";
 
         // (3c) writable? (P-DISC routing for discriminators)
-        if (!leaf.Writable) return WritabilityRejection(current, leaf);
+        if (!leaf.Writable) return WritabilityRejection(leafOwner, leaf);
 
         // (4) value / key coercion + enum/legal-set legality
         return ValueLegality(leaf, req);
@@ -243,10 +245,12 @@ public sealed class CorpusRulebook
             return CheckValue(leaf.Type, req.Value, $"value for '{leaf.Name}'",
                 leaf.MutableTypeAssemblyQualified ?? leaf.GetterTypeAssemblyQualified);
         }
-        // (step 4) collection-verb value legality. A struct-element list (modeled-struct elements) takes a
-        // build-from-parts StructSpec on Add — NOT a plain value — which is wave-1 half B composition; a
+        // (step 4) collection-verb value legality. A struct-element OR arm-element list takes a build-from-parts
+        // StructSpec on Add — NOT a plain value — which is wave-1 half B composition (an ARM element composes by its
+        // concrete arm type, validated against that arm's own schema — the VMAD shape, #35; before this, arm-element
+        // Adds fell through pre-flight UNVALIDATED and only failed at runtime — an accept-then-throw Q3 hole). A
         // coercible-element list takes a plain value the engine coerces (proven by the collection waves).
-        if (leaf.Cardinality is "list" or "dict" && IsStructElement(leaf))
+        if (leaf.Cardinality is "list" or "dict" && IsComposableElement(leaf))
         {
             if (req.Verb == "Add") return StructElementLegality(leaf, req.Struct);
             if (req.Verb is "ReplaceAll" or "SetAtIndex")
@@ -256,24 +260,40 @@ public sealed class CorpusRulebook
         return null;
     }
 
-    /// <summary>True iff the leaf is a collection whose ELEMENT is a BUILD-FROM-PARTS modeled struct (so Add takes a
-    /// StructSpec). Record-elements (nested-group wave) and arm-elements (arm wave) are NOT structs; and a
-    /// WHOLE-COERCIBLE element (an AssetLink path) is set as one value, not composed — so it falls through to the
-    /// plain-value Add path, never demanding a spec.</summary>
-    bool IsStructElement(FieldSchema leaf) => SchemaClassifier.IsStructElement(leaf, _corpus);
+    /// <summary>True iff the leaf is a collection whose ELEMENT is built FROM PARTS on Add (so Add takes a
+    /// StructSpec): a modeled-struct element, or a polymorphic-union (arm) element composed by its concrete arm
+    /// type. Record-elements (nested-group wave) are resolved on their own axis, and a WHOLE-COERCIBLE element
+    /// (an AssetLink path) is set as one value — both fall through to the plain-value Add path, never demanding
+    /// a spec. Derived via the shared <see cref="SchemaClassifier"/> so the partition cannot be defined twice.</summary>
+    bool IsComposableElement(FieldSchema leaf)
+        => SchemaClassifier.ClassifyElement(leaf, _corpus) is ElementKind.Struct or ElementKind.Arm;
 
     /// <summary>Validate a struct-element Add: the spec must be present, its type must match the list's element
-    /// type, and its contents must validate against that element type (recursively, via the shared validator).</summary>
+    /// type — or, when the element type is a <b>polymorphic-base</b>, be one of its ARMS (the VMAD shape, #35:
+    /// <c>ScriptEntry.Properties</c> is a list of the base <c>ScriptProperty</c>, but a real new element is a
+    /// concrete arm like <c>ScriptObjectProperty</c>) — and its contents must validate against the SPEC's own
+    /// schema (the arm's fields, not the base's), recursively via the shared validator. Generic over every
+    /// polymorphic-base element family — no per-type wiring (cornerstone).</summary>
     string? StructElementLegality(FieldSchema leaf, StructSpec? spec)
     {
         if (spec is null)
             return $"Add to struct-element collection '{leaf.Name}' requires a build-from-parts spec (the new element).";
         var er = leaf.ElementTypeRef!;
-        if (spec.Type != er)
-            return $"Element spec type '{spec.Type}' does not match '{leaf.Name}' element type '{er}'.";
         var elemSchema = Type(er);
         if (elemSchema is null) return $"Element type '{er}' for '{leaf.Name}' absent from corpus.";
-        return StructSpecContents(spec, elemSchema);
+
+        TypeSchema specSchema;
+        if (spec.Type == er) specSchema = elemSchema;
+        else if (elemSchema is { Kind: "polymorphic-base", Arms: { Count: > 0 } arms } && arms.Contains(spec.Type))
+            specSchema = Type(spec.Type)
+                ?? throw new InvalidOperationException($"Arm '{spec.Type}' of '{er}' is listed but absent from the corpus — regenerate corpus.json.");
+        else
+        {
+            var legal = elemSchema is { Kind: "polymorphic-base", Arms: { Count: > 0 } a }
+                ? $" Legal element types: {string.Join(", ", a)}." : "";
+            return $"Element spec type '{spec.Type}' does not match '{leaf.Name}' element type '{er}'.{legal}";
+        }
+        return StructSpecContents(spec, specSchema);
     }
 
     /// <summary>Validate a build-from-parts spec's CONTENTS against its declared struct type: flat <see cref="StructSpec.Fields"/>
@@ -361,10 +381,60 @@ public sealed class CorpusRulebook
         catch (Exception ex) { name = segment; key = null; error = ex.Message; return false; }
     }
 
-    static string FieldNotFound(TypeSchema owner, string name)
+    string FieldNotFound(TypeSchema owner, string name)
     {
         var sample = owner.Fields.Select(f => f.Name).Take(12).ToList();
         var more = owner.Fields.Count > sample.Count ? $", … (+{owner.Fields.Count - sample.Count} more)" : "";
-        return $"No field '{name}' on '{owner.Name}'. Fields: {string.Join(", ", sample)}{more}.";
+        var arms = owner is { Kind: "polymorphic-base", Arms.Count: > 0 }
+            ? $" Also searched its arms ({string.Join(", ", owner.Arms!.Where(a => a != owner.Name))})."
+            : "";
+        return $"No field '{name}' on '{owner.Name}'. Fields: {string.Join(", ", sample)}{more}.{arms}";
     }
+
+    /// <summary>Find <paramref name="name"/> on <paramref name="owner"/>, looking through a <b>polymorphic-base</b>'s
+    /// ARMS when the base itself lacks it — the VMAD shape (#35): <c>ScriptEntry.Properties</c> is modeled as a list
+    /// of the base <c>ScriptProperty</c> (Name/Flags only), but every REAL element is a concrete arm
+    /// (<c>ScriptObjectProperty</c> carries Object/Alias), so a path like <c>Properties[0].Object</c> is legal even
+    /// though the BASE schema lacks 'Object'. Generic over every polymorphic-base family — no per-type wiring
+    /// (cornerstone). The static validator cannot know WHICH arm sits at a given index, so: a name found on arms
+    /// must AGREE in shape across all the arms that declare it (one shape validates for whichever arm the element
+    /// turns out to be — the engine then resolves on the element's RUNTIME type and fails loud on a real mismatch);
+    /// arms that DISAGREE reject named (Q3), never guess. <paramref name="effectiveOwner"/> is the schema the found
+    /// field belongs to (the arm for an arm-found field), so downstream messages name the real owner.</summary>
+    FieldSchema? FindField(TypeSchema owner, string name, out TypeSchema effectiveOwner, out string? error)
+    {
+        effectiveOwner = owner; error = null;
+        if (owner.Fields.FirstOrDefault(f => f.Name == name) is { } direct) return direct;
+        if (owner is not { Kind: "polymorphic-base", Arms.Count: > 0 }) return null;
+
+        var hits = new List<(TypeSchema arm, FieldSchema field)>();
+        foreach (var armName in owner.Arms!)
+        {
+            if (armName == owner.Name) continue;                       // the base lists itself as an arm; already checked
+            if (Type(armName) is not { } arm) continue;                 // absent arm entry → other arms still searched
+            if (arm.Fields.FirstOrDefault(f => f.Name == name) is { } af) hits.Add((arm, af));
+        }
+        if (hits.Count == 0) return null;
+
+        var (firstArm, firstField) = hits[0];
+        foreach (var (arm, f) in hits.Skip(1))
+            if (!SameShape(firstField, f))
+            {
+                error = $"Field '{name}' exists on several arms of '{owner.Name}' with CONFLICTING shapes " +
+                        $"('{firstArm.Name}': {firstField.Cardinality} {firstField.Type} vs '{arm.Name}': {f.Cardinality} {f.Type}) — " +
+                        "the validator cannot pick one statically. Read the element first to learn its concrete arm, " +
+                        "then target a field whose shape is unambiguous.";
+                return null;
+            }
+        effectiveOwner = firstArm;
+        return firstField;
+    }
+
+    /// <summary>Two arm declarations of the same field name agree iff every navigation/validation-relevant facet
+    /// matches — cardinality, display + referenced types, element type, and writability. Identity by what the
+    /// validator USES, so "agrees" can never silently mean "close enough".</summary>
+    static bool SameShape(FieldSchema a, FieldSchema b) =>
+        a.Cardinality == b.Cardinality && a.Type == b.Type && a.TypeRef == b.TypeRef
+        && a.ElementType == b.ElementType && a.ElementTypeRef == b.ElementTypeRef
+        && a.Writable == b.Writable && a.Nullable == b.Nullable && a.IsIdentity == b.IsIdentity;
 }

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -252,7 +252,14 @@ public sealed class CorpusRulebook
         // coercible-element list takes a plain value the engine coerces (proven by the collection waves).
         if (leaf.Cardinality is "list" or "dict" && IsComposableElement(leaf))
         {
-            if (req.Verb == "Add") return StructElementLegality(leaf, req.Struct);
+            // Composition lands through the LIST Add only — the engine's dict Add takes a coercible key + value
+            // and ignores a spec (ApplyDictVerb), so admitting a dict compose here would be accept-then-throw
+            // (PR review). Named deferred surface instead, never a runtime surprise.
+            if (req.Verb == "Add")
+                return leaf.Cardinality == "dict"
+                    ? $"'{leaf.Name}' is a dict of modeled elements ({leaf.ElementTypeRef}); dict-element " +
+                      "composition is a later surface — surfaced here, never accepted and thrown at apply time."
+                    : StructElementLegality(leaf, req.Struct);
             if (req.Verb is "ReplaceAll" or "SetAtIndex")
                 return $"'{leaf.Name}' holds modeled-struct elements ({leaf.ElementTypeRef}); only Add " +
                        "(build-from-parts) composes struct elements — ReplaceAll/SetAtIndex of structs is a later surface.";
@@ -411,7 +418,15 @@ public sealed class CorpusRulebook
         foreach (var armName in owner.Arms!)
         {
             if (armName == owner.Name) continue;                       // the base lists itself as an arm; already checked
-            if (Type(armName) is not { } arm) continue;                 // absent arm entry → other arms still searched
+            if (Type(armName) is not { } arm)
+            {
+                // Arms and the catalog come out of the same reflection walk, so a listed-but-absent arm is a real
+                // corpus defect — surfaced loud (Q3), never skipped: skipping could fake shape-agreement over an
+                // incomplete arm set, or fake "no such field" for a field the missing arm exclusively declares.
+                error = $"Arm '{armName}' of polymorphic-base '{owner.Name}' is listed but ABSENT from the corpus — " +
+                        "corpus.json is stale or incompletely generated; regenerate it (dotnet run --project src/housecarl-generator).";
+                return null;
+            }
             if (arm.Fields.FirstOrDefault(f => f.Name == name) is { } af) hits.Add((arm, af));
         }
         if (hits.Count == 0) return null;
@@ -431,10 +446,16 @@ public sealed class CorpusRulebook
     }
 
     /// <summary>Two arm declarations of the same field name agree iff every navigation/validation-relevant facet
-    /// matches — cardinality, display + referenced types, element type, and writability. Identity by what the
-    /// validator USES, so "agrees" can never silently mean "close enough".</summary>
+    /// matches — cardinality, display + referenced types, element type, writability, AND the assembly-qualified
+    /// CLR types (two arms can share a display name like 'Flags' while binding DIFFERENT enum types; ValueLegality
+    /// validates against the AQ-resolved type, so AQ disagreement means the value would be checked against the
+    /// wrong arm's legal set — PR review). Identity by what the validator USES, so "agrees" can never silently
+    /// mean "close enough".</summary>
     static bool SameShape(FieldSchema a, FieldSchema b) =>
         a.Cardinality == b.Cardinality && a.Type == b.Type && a.TypeRef == b.TypeRef
         && a.ElementType == b.ElementType && a.ElementTypeRef == b.ElementTypeRef
-        && a.Writable == b.Writable && a.Nullable == b.Nullable && a.IsIdentity == b.IsIdentity;
+        && a.Writable == b.Writable && a.Nullable == b.Nullable && a.IsIdentity == b.IsIdentity
+        && a.GetterTypeAssemblyQualified == b.GetterTypeAssemblyQualified
+        && a.MutableTypeAssemblyQualified == b.MutableTypeAssemblyQualified
+        && a.ElementTypeAssemblyQualified == b.ElementTypeAssemblyQualified;
 }

--- a/src/housecarl-core/SchemaClassifier.cs
+++ b/src/housecarl-core/SchemaClassifier.cs
@@ -78,9 +78,29 @@ public static class SchemaClassifier
         {
             "struct" => ElementKind.Struct,
             "record" => ElementKind.Record,
-            "arm" or "polymorphic-base" => ElementKind.Arm,
+            "arm" => ElementKind.Arm,
+            "polymorphic-base" => PolyBaseElementKind(er, corpus),
             _ => ElementKind.Unknown,
         };
+    }
+
+    /// <summary>A polymorphic-base element family is ARM (composable by concrete arm type) only when its arms are
+    /// modeled STRUCTS — the VMAD shape (ScriptProperty → ScriptObjectProperty…). A base whose arms are RECORDS
+    /// (GameSetting → GameSettingBool/Float/Int/String, the typed record-group families) lives on the FormKey /
+    /// record axis: its elements are allocated as records, never built from a StructSpec — classify
+    /// <see cref="ElementKind.Record"/> so the composition surface can never admit them (PR review: pre-flight
+    /// accepting a record-family compose was an accept-then-throw). A mixed or unresolvable arm set surfaces as
+    /// <see cref="ElementKind.Unknown"/> — never silently bucketed either way.</summary>
+    static ElementKind PolyBaseElementKind(string baseName, Corpus corpus)
+    {
+        var b = corpus.Types.GetValueOrDefault(baseName);
+        var armKinds = (b?.Arms ?? new())
+            .Where(a => a != baseName)
+            .Select(a => corpus.Types.GetValueOrDefault(a)?.Kind)
+            .Distinct().ToList();
+        if (armKinds.Count > 0 && armKinds.All(k => k is "arm" or "struct" or "polymorphic-base")) return ElementKind.Arm;
+        if (armKinds.Count > 0 && armKinds.All(k => k == "record")) return ElementKind.Record;
+        return ElementKind.Unknown;
     }
 
     /// <summary>True iff the field is a collection whose ELEMENT is a BUILD-FROM-PARTS modeled struct (so Add takes a

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -52,6 +52,10 @@ if (args.Length > 0 && args[0] == "snapshot-view-guard") return SnapshotViewProb
 // hands back every touched/created record IN FULL off the written file (the pre-enable verify loop).
 if (args.Length > 0 && args[0] == "verify-loop-guard") return VerifyLoopProbe.RunGuard(args[1..]);
 
+// Polymorphic-element validator surface (#35 — the VMAD write gap): arm-field paths + arm-element composes
+// pass pre-flight; non-arm fields/specs still reject named. --source <Skyrim.esm> adds the end-to-end engine proof.
+if (args.Length > 0 && args[0] == "vmad-poly-guard") return VmadPolyProbe.RunGuard(args[1..]);
+
 // One-shot verify (decision #1): confirm the xEdit 4-char signature reflection path.
 if (args.Length > 0 && args[0] == "sig") return Probe.RunSig();
 

--- a/src/housecarl-generator/VmadPolyProbe.cs
+++ b/src/housecarl-generator/VmadPolyProbe.cs
@@ -26,18 +26,31 @@ public static class VmadPolyProbe
         var f = WriteEngine.ParseFlags(args);
 
         // CI-safe: corpus.json is GENERATED, not tracked — on a fresh checkout (the CI runner) build it into a
-        // temp dir and point the rulebook there, leaving the working tree untouched. A repo with generated/
-        // already present (local dev) is used as-is.
+        // UNIQUE temp dir (no cross-run sharing/races; PR review) and point the rulebook there, leaving the
+        // working tree untouched; cleaned up on exit. A repo with generated/ already present (local dev) is
+        // used as-is.
+        string? tmp = null;
         if (!File.Exists(CorpusRulebook.CorpusPath))
         {
-            var tmp = Path.Combine(Path.GetTempPath(), "housecarl-vmad-poly-guard");
+            tmp = Path.Combine(Path.GetTempPath(), "housecarl-vmad-poly-guard-" + Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(tmp);
             Console.WriteLine($"corpus.json absent — generating into {tmp} (CI / fresh checkout)…");
             var rc = CorpusGenerator.GenerateAll(Path.Combine(tmp, "generated"), Path.Combine(tmp, "refs"));
             if (rc != 0) { Console.Error.WriteLine("error: corpus generation failed"); return rc; }
             CorpusRulebook.CorpusPath = Path.Combine(tmp, "generated", "corpus.json");
         }
+        try
+        {
+            return RunChecks(f);
+        }
+        finally
+        {
+            if (tmp is not null) { try { Directory.Delete(tmp, recursive: true); } catch { /* temp cleanup is best-effort */ } }
+        }
+    }
 
+    static int RunChecks(Dictionary<string, string> f)
+    {
         var rb = CorpusRulebook.Load();
         int failures = 0;
 
@@ -113,6 +126,29 @@ public static class VmadPolyProbe
         };
         var eErr = rb.Validate(questAlias);
         Check("E: QUST alias-script arm-field path passes pre-flight", eErr is null, eErr);
+
+        // ---- G: a DICT of polymorphic elements (Package.Data) refuses a compose-Add NAMED — the engine's
+        //         dict Add takes a coercible key + value, never a spec (accept-then-throw guard, PR review). ----
+        var dictCompose = new WriteRequest
+        {
+            RecordType = "Package", Path = new[] { "Data" }, Verb = "Add", Key = "0",
+            Struct = new StructSpec { Type = "PackageDataBool", Fields = new() },
+        };
+        var gErr = rb.Validate(dictCompose);
+        Check("G: dict arm-element compose-Add rejects", gErr is not null);
+        Check("G2: …named as a deferred surface, not a generic failure",
+            gErr?.Contains("later surface", StringComparison.OrdinalIgnoreCase) == true, gErr);
+
+        // ---- H: a polymorphic-base whose arms are RECORDS (GameSetting → GameSettingBool/Float/Int/String)
+        //         classifies Record, never Arm — the composition surface must not admit record-group families
+        //         (PR review). ----
+        var corpus = CorpusRulebook.LoadCorpus();
+        var modType = corpus.Types.GetValueOrDefault("SkyrimMod");
+        var gsField = modType?.Fields.FirstOrDefault(x => x.Name == "GameSettings");
+        Check("H: record-family polymorphic base classifies Record (not composable)",
+            gsField is not null && SchemaClassifier.ClassifyElement(gsField, corpus) == ElementKind.Record,
+            gsField is null ? "SkyrimMod.GameSettings not found in corpus"
+                : SchemaClassifier.ClassifyElement(gsField, corpus).ToString());
 
         // ---- F (optional, --source): END-TO-END through the engine's own ApplyVerb on a DeepCopy of a real
         //      scripted record — proving the pre-flight now admits exactly what the runtime can already do. ----

--- a/src/housecarl-generator/VmadPolyProbe.cs
+++ b/src/housecarl-generator/VmadPolyProbe.cs
@@ -1,0 +1,162 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// Guard for the polymorphic-element validator surface (#35 — the VMAD write gap): the corpus models
+/// <c>ScriptEntry.Properties</c> as a list of the base <c>ScriptProperty</c> (Name/Flags only), but every real
+/// element is one of its ARMS (a <c>ScriptObjectProperty</c> carries Object/Alias) — so before this surface the
+/// pre-flight rejected every write that touched an arm-only field ("No field 'Object' on 'ScriptProperty'") and
+/// every compose of a concrete arm ("spec type does not match element type"), even though the runtime engine
+/// (runtime-typed navigation; BuildStruct-by-name; covariant list Add) could already perform them.
+///
+/// Corpus-only checks A–E run with no plugin (CI-safe). With <c>--source &lt;Skyrim.esm path&gt;</c> the guard
+/// also proves the surface END-TO-END (F): DeepCopy a real scripted record, drive the SAME ApplyVerb the patch
+/// cleave uses for an arm-field Set and an arm-element compose Add, and assert the typed results.
+///
+/// Run: dotnet run --project src/housecarl-generator vmad-poly-guard [--source "&lt;path&gt;\Skyrim.esm"]
+/// </summary>
+public static class VmadPolyProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        var f = WriteEngine.ParseFlags(args);
+
+        // CI-safe: corpus.json is GENERATED, not tracked — on a fresh checkout (the CI runner) build it into a
+        // temp dir and point the rulebook there, leaving the working tree untouched. A repo with generated/
+        // already present (local dev) is used as-is.
+        if (!File.Exists(CorpusRulebook.CorpusPath))
+        {
+            var tmp = Path.Combine(Path.GetTempPath(), "housecarl-vmad-poly-guard");
+            Directory.CreateDirectory(tmp);
+            Console.WriteLine($"corpus.json absent — generating into {tmp} (CI / fresh checkout)…");
+            var rc = CorpusGenerator.GenerateAll(Path.Combine(tmp, "generated"), Path.Combine(tmp, "refs"));
+            if (rc != 0) { Console.Error.WriteLine("error: corpus generation failed"); return rc; }
+            CorpusRulebook.CorpusPath = Path.Combine(tmp, "generated", "corpus.json");
+        }
+
+        var rb = CorpusRulebook.Load();
+        int failures = 0;
+
+        void Check(string label, bool ok, string? detail = null)
+        {
+            Console.WriteLine($"  {(ok ? "PASS" : "FAIL")}  {label}{(ok || detail is null ? "" : $"\n        -> {detail}")}");
+            if (!ok) failures++;
+        }
+
+        Console.WriteLine("vmad-poly-guard — polymorphic-element validator surface (#35)");
+        Console.WriteLine();
+
+        // ---- A: a leaf Set through a polymorphic element's ARM field passes pre-flight. (THE filed repro:
+        //         'No field Object on ScriptProperty'.) ----
+        var setArmLeaf = new WriteRequest
+        {
+            RecordType = "Activator",
+            Path = new[] { "VirtualMachineAdapter", "Scripts[0]", "Properties[0]", "Object" },
+            Verb = "Set", Value = "018C91:Skyrim.esm",
+        };
+        var aErr = rb.Validate(setArmLeaf);
+        Check("A: Set …Properties[0].Object (arm-only field) passes pre-flight", aErr is null, aErr);
+
+        // ---- B: composing a concrete ARM element into the base-typed list passes pre-flight. ----
+        var addArm = new WriteRequest
+        {
+            RecordType = "Activator",
+            Path = new[] { "VirtualMachineAdapter", "Scripts[0]", "Properties" },
+            Verb = "Add",
+            Struct = new StructSpec
+            {
+                Type = "ScriptObjectProperty",
+                Fields = new()
+                {
+                    ["Name"] = "VmadGuardProp", ["Flags"] = "Edited",
+                    ["Object"] = "00308D:Update.esm", ["Alias"] = "-1",
+                },
+            },
+        };
+        var bErr = rb.Validate(addArm);
+        Check("B: Add compose ScriptObjectProperty into Properties passes pre-flight", bErr is null, bErr);
+
+        // ---- C: a field on NO arm still rejects — and the message says the arms were searched (Q3). ----
+        var bogus = new WriteRequest
+        {
+            RecordType = "Activator",
+            Path = new[] { "VirtualMachineAdapter", "Scripts[0]", "Properties[0]", "Bogus" },
+            Verb = "Set", Value = "1",
+        };
+        var cErr = rb.Validate(bogus);
+        Check("C: a field on no arm still rejects", cErr is not null);
+        Check("C2: …and the rejection names the searched arms", cErr?.Contains("arms", StringComparison.OrdinalIgnoreCase) == true, cErr);
+
+        // ---- D: a spec type that is NEITHER the element type NOR one of its arms still rejects, and the
+        //         message lists the legal arm set. ----
+        var wrongSpec = new WriteRequest
+        {
+            RecordType = "Activator",
+            Path = new[] { "VirtualMachineAdapter", "Scripts[0]", "Properties" },
+            Verb = "Add",
+            Struct = new StructSpec { Type = "LeveledItemEntry", Fields = new() },
+        };
+        var dErr = rb.Validate(wrongSpec);
+        Check("D: a non-arm spec type still rejects", dErr is not null);
+        Check("D2: …and the rejection lists the legal element types", dErr?.Contains("ScriptObjectProperty", StringComparison.Ordinal) == true, dErr);
+
+        // ---- E: the QUST alias-script path (QuestAdapter) validates through the same surface. ----
+        var questAlias = new WriteRequest
+        {
+            RecordType = "Quest",
+            Path = new[] { "VirtualMachineAdapter", "Aliases[0]", "Scripts[0]", "Properties[0]", "Object" },
+            Verb = "Set", Value = "00308D:Update.esm",
+        };
+        var eErr = rb.Validate(questAlias);
+        Check("E: QUST alias-script arm-field path passes pre-flight", eErr is null, eErr);
+
+        // ---- F (optional, --source): END-TO-END through the engine's own ApplyVerb on a DeepCopy of a real
+        //      scripted record — proving the pre-flight now admits exactly what the runtime can already do. ----
+        var source = f.GetValueOrDefault("source");
+        if (source is not null)
+        {
+            if (!File.Exists(source)) { Console.Error.WriteLine($"error: --source not found: {source}"); return 1; }
+            var mod = SkyrimMod.CreateFromBinaryOverlay(source, SkyrimRelease.SkyrimSE);
+            var fk = FormKey.Factory("10EE3F:Skyrim.esm");      // ACTI MineOreBlackreach04 — the filed repro record
+            var getter = mod.EnumerateMajorRecords().OfType<IActivatorGetter>().FirstOrDefault(r => r.FormKey == fk);
+            if (getter?.VirtualMachineAdapter is null)
+            {
+                Check("F0: repro record 10EE3F with VMAD present in --source", false,
+                    "record absent or unscripted — is --source a Skyrim SE Skyrim.esm?");
+            }
+            else
+            {
+                var copy = getter.DeepCopy();
+                int before = copy.VirtualMachineAdapter!.Scripts[0].Properties.Count;
+
+                WriteEngine.ApplyVerb(copy, setArmLeaf);
+                var p0 = copy.VirtualMachineAdapter.Scripts[0].Properties[0] as ScriptObjectProperty;
+                Check("F1: runtime Set of the arm field landed",
+                    p0 is not null && p0.Object.FormKey.ToString() == "018C91:Skyrim.esm",
+                    p0 is null ? "Properties[0] is not a ScriptObjectProperty" : p0.Object.FormKey.ToString());
+
+                WriteEngine.ApplyVerb(copy, addArm);
+                var added = copy.VirtualMachineAdapter.Scripts[0].Properties.LastOrDefault() as ScriptObjectProperty;
+                Check("F2: runtime compose-Add of the arm element landed",
+                    copy.VirtualMachineAdapter.Scripts[0].Properties.Count == before + 1
+                        && added is { Name: "VmadGuardProp", Alias: -1 }
+                        && added.Object.FormKey.ToString() == "00308D:Update.esm"
+                        && added.Flags == ScriptProperty.Flag.Edited,
+                    added is null ? "last element is not a ScriptObjectProperty"
+                        : $"count {copy.VirtualMachineAdapter.Scripts[0].Properties.Count} (was {before}), Name={added.Name}, Alias={added.Alias}, Object={added.Object.FormKey}, Flags={added.Flags}");
+            }
+        }
+        else
+        {
+            Console.WriteLine("  (skipped F: pass --source <path>\\Skyrim.esm for the end-to-end engine proof)");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine(failures == 0 ? "vmad-poly-guard: ALL PASS" : $"vmad-poly-guard: {failures} FAILURE(S)");
+        return failures == 0 ? 0 : 1;
+    }
+}

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -64,7 +64,10 @@ public static class WriteTools
          "Apply MANY edits in ONE patch plugin (originals untouched) — the batch form of housecarl_set_field, and the way " +
          "to COMPOSE modeled structs. Each operation is {formid, field_path, verb, value?, key?, values?, entries?, " +
          "compose?}: scalar/collection verbs work as in set_field; entries (a key→value map) drives a dict Merge or " +
-         "ReplaceAll; compose builds a modeled struct for an Add (a leveled-list entry, an effect) or a polymorphic Set " +
+         "ReplaceAll; compose builds a modeled struct for an Add (a leveled-list entry, an effect — and a POLYMORPHIC " +
+         "list element composes by its concrete arm type, e.g. a VMAD script property: verb=Add, " +
+         "field_path='VirtualMachineAdapter.Scripts[0].Properties', compose={type:'ScriptObjectProperty', " +
+         "fields:{Name:'MyProp', Flags:'Edited', Object:'XXXXXX:Plugin.esp', Alias:'-1'}}) or a polymorphic Set " +
          "(an arm) — e.g. merge a weapon into a leveled list with verb=Add, field_path='Entries', " +
          "compose={type:'LeveledItemEntry', sets:[{path:'Data.Level',value:'1'},{path:'Data.Count',value:'1'}," +
          "{path:'Data.Reference',value:'<weapon FormID>'}]}. All edits land in ONE reviewable .esp; the patch spans " +
@@ -289,7 +292,7 @@ public sealed record BulkOp
     [JsonPropertyName("entries"), Description("Key→value pairs for a dict Merge or dict ReplaceAll.")]
     public Dictionary<string, string>? Entries { get; init; }
 
-    [JsonPropertyName("compose"), Description("Build a modeled struct: an arm for a polymorphic Set, or the element for a struct-element Add (e.g. a leveled-list entry).")]
+    [JsonPropertyName("compose"), Description("Build a modeled struct: an arm for a polymorphic Set, or the element for a struct-element Add (e.g. a leveled-list entry; for a polymorphic list like VMAD Scripts[i].Properties, the element's CONCRETE arm type, e.g. 'ScriptObjectProperty').")]
     public StructInput? Compose { get; init; }
 }
 
@@ -297,7 +300,7 @@ public sealed record BulkOp
 /// flat coercible sub-fields, optional positional ctor args, and nested edits applied to the built struct.</summary>
 public sealed record StructInput
 {
-    [JsonPropertyName("type"), Description("The concrete catalog type to build (arm type for a polymorphic Set, or the collection's element type for an Add, e.g. 'LeveledItemEntry').")]
+    [JsonPropertyName("type"), Description("The concrete catalog type to build (arm type for a polymorphic Set; the collection's element type for an Add, e.g. 'LeveledItemEntry'; or a polymorphic element's concrete ARM, e.g. 'ScriptObjectProperty' into VMAD Properties).")]
     public string? Type { get; init; }
 
     [JsonPropertyName("fields"), Description("Flat coercible sub-fields set directly on the struct: name → value.")]


### PR DESCRIPTION
Closes #35 (the write half; the read half is already fixed on current main — verified: `read --path VirtualMachineAdapter --depth 4` renders full VMAD trees including property Objects on the filed repro records).

## What

The corpus models `ScriptEntry.Properties` as a list of the **base** `ScriptProperty` (Name/Flags only), but every real element is one of its **arms** — so pre-flight rejected every write touching an arm-only field (`No field 'Object' on 'ScriptProperty'`) and every compose of a concrete arm (`spec type does not match element type`), even though the runtime engine (runtime-typed navigation, `BuildStruct`-by-name, covariant list `Add`) already performs both. Both filed repros now work end-to-end.

All changes are generic over every polymorphic-base family — no per-type wiring (cornerstone):

- **`FindField`** (CorpusRulebook): a path hop / leaf not on a schema falls through to a polymorphic-base's arms. Arms declaring the name must **agree in shape** — including the assembly-qualified CLR types, so a value can never be validated against the wrong arm's enum set — one static validation then covers whichever arm the element turns out to be (the engine resolves on the RUNTIME type and fails loud on a real mismatch). Conflicting shapes reject named; an arm listed but absent from the corpus rejects loud (Q3), never skipped.
- **`StructElementLegality`**: an `Add` spec may be the element type **or one of its arms**, validated against the **spec's own schema** (the arm's fields, not the base's). A non-arm spec rejects named with the legal arm set.
- **`ValueLegality`** now routes ARM-element collections through composition validation — previously `ElementKind.Arm` fell through pre-flight **unvalidated** and only failed at runtime (accept-then-throw). Composition lands through the **list** `Add` only: a dict of modeled elements (`Package.Data`) refuses a compose-`Add` named (`ApplyDictVerb` takes key+value and ignores a spec).
- **`SchemaClassifier`**: polymorphic-base element families split by arm kind — struct-armed bases (`ScriptProperty`) classify `Arm`/composable; **record**-armed bases (`GameSetting` → `GameSettingBool/Float/Int/String`) classify `Record` so the composition surface can never admit a record-group compose; mixed/unresolvable arm sets surface `Unknown`.

## Proof

New `vmad-poly-guard` (probe + CI step; corpus-only checks self-generate the corpus into a unique temp dir on a fresh checkout, cleaned on exit):

```
PASS  A: Set …Properties[0].Object (arm-only field) passes pre-flight
PASS  B: Add compose ScriptObjectProperty into Properties passes pre-flight
PASS  C/C2: a field on no arm still rejects — naming the searched arms
PASS  D/D2: a non-arm spec still rejects — listing the legal element types
PASS  E: QUST alias-script arm-field path passes pre-flight
PASS  G/G2: dict arm-element compose-Add rejects, named as a deferred surface
PASS  H: record-family polymorphic base classifies Record (not composable)
PASS  F1: runtime Set of the arm field landed            (--source Skyrim.esm)
PASS  F2: runtime compose-Add of the arm element landed   (--source Skyrim.esm)
```

End-to-end on a real 3000+-plugin SE load order: the filed write repro now emits a correct single-master patch (`patch … --path "VirtualMachineAdapter.Scripts[0].Properties[0].Object"` → 880-byte ESP, source SHA-unchanged), and the emitted VMAD was re-read with an independent, non-Mutagen VMAD parser — property payloads byte-agree. Full local regression battery green: depth-leak / floi-read / value-predicate / source-display / pkcu-regression / formid-floor guards + coerce-selftest, plus a classic-path control patch (Weapon `BasicStats.Damage`).

## Notes for review

- `WriteTools` descriptions now document the arm-element compose shape (VMAD example).
- The shape-agreement rule is deliberately conservative; if you'd rather hard-reject any multi-arm ambiguity (even agreeing shapes), that's a two-line change in `FindField` — happy to adjust.
- Implementation offered in #35; an adversarial review pass was run before submission and its six findings are the third commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
