### PR TITLE
Binding shim: parse a string-encoded JSON array as the array it spells (#36)

### DIFF
--- a/src/housecarl-generator/BindingShimProbe.cs
+++ b/src/housecarl-generator/BindingShimProbe.cs
@@ -102,6 +102,21 @@ public static class BindingShimProbe
             failures += Check("B coerce: plugins as bare string binds and runs the tool body",
                 !b.text.Contains(GenericError) && b.text.Contains(ConfigPrompt), b.Describe());
 
+            // -- B2: the VERIFIED live Claude Code shape (#36) — the whole array serialized as a JSON STRING.
+            //    Must parse as the array it spells, bind, and reach the tool body — never the generic error,
+            //    and never a one-element array holding the unparsed text (which would fail later, misleadingly).
+            var b2 = Call(stdin, stdout, 30, "housecarl_cross_plugin_query",
+                """{"type":"CELL","plugins":"[\"Synthetic.esp\",\"Other.esp\"]"}""");
+            failures += Check("B2 coerce: plugins as string-encoded JSON array binds and runs the tool body",
+                !b2.text.Contains(GenericError) && b2.text.Contains(ConfigPrompt), b2.Describe());
+
+            // -- B3: a bare string that merely STARTS with '[' but isn't JSON — must keep the one-element
+            //    wrap (the fall-through), not be rejected by a failed parse.
+            var b3 = Call(stdin, stdout, 31, "housecarl_cross_plugin_query",
+                """{"type":"CELL","plugins":"[Bracketed Name.esp"}""");
+            failures += Check("B3 fall-through: a non-JSON bracket-leading string still wraps and runs",
+                !b3.text.Contains(GenericError) && b3.text.Contains(ConfigPrompt), b3.Describe());
+
             // -- C: control — the documented array shape, unchanged behavior.
             var c = Call(stdin, stdout, 4, "housecarl_cross_plugin_query",
                 """{"type":"CELL","plugins":["Synthetic.esp"]}""");

--- a/src/housecarl-mcp/ToolCallShim.cs
+++ b/src/housecarl-mcp/ToolCallShim.cs
@@ -102,7 +102,20 @@ internal static class ToolCallShim
         {
             var s = value.GetString() ?? "";
             if (declared.Contains("array"))
-                return Parse("[" + JsonSerializer.Serialize(s) + "]");          // "A.esp" → ["A.esp"] — THE live failing shape
+            {
+                // A string-ENCODED JSON array first — the verified live Claude Code shape (#36): the client
+                // serializes array arguments into a JSON STRING ("[\"a\",\"b\"]") even though the published
+                // schema correctly declares the array. Parse it as the array it spells; only an unambiguous
+                // parse is taken — anything else (including a bare string that merely starts with '[') falls
+                // through to the one-element wrap below, so no previously-working shape changes meaning.
+                var t = s.TrimStart();
+                if (t.StartsWith('['))
+                {
+                    try { var el = Parse(s); if (el.ValueKind == JsonValueKind.Array) return el; }
+                    catch (JsonException) { /* not a JSON array after all — fall through to the wrap */ }
+                }
+                return Parse("[" + JsonSerializer.Serialize(s) + "]");          // "A.esp" → ["A.esp"] — the bare-string shape
+            }
             if (declared.Contains("boolean") && bool.TryParse(s, out var b))
                 return Parse(b ? "true" : "false");                             // "true" → true
             if (declared.Contains("integer") || declared.Contains("number"))


### PR DESCRIPTION
Closes #36 — together with the already-merged #34 shim this covers every argument shape we've observed on the wire.

## What

The verification matrix posted on #36 (shipped v1.2.2, tested over raw stdio AND through Claude Code) pinned the live failing shape: **the Claude Code client serializes array arguments into a JSON string** (`plugins="[\"A.esp\",\"B.esp\"]"`) even though the server's published schema correctly declares `"type": ["array","null"]`. The #34 shim's bare-string wrap would coerce that into a *one-element* array holding the unparsed text — which binds, then fails lookup with a misleading not-found.

`Coerce` now tries an unambiguous JSON-array parse first when the schema declares an array and the string starts with `[`; anything that doesn't cleanly parse to an array (including a bare string that merely starts with `[`, e.g. a hypothetical `[Bracketed Name.esp`) falls through to the existing one-element wrap — no previously-working shape changes meaning.

## Proof

`binding-shim-guard` gains two cases, both driving the real server over stdio like the existing ones:
- **B2**: the stringified JSON array binds and reaches the tool body (was: generic error)
- **B3**: a non-JSON bracket-leading bare string still wraps to a one-element array (the fall-through is locked in)

Locally verified all four shapes (stringified array / bare string / bracket-leading non-JSON / real array) bind and reach the tool body against the rebuilt server.

One line of context for the wire shape evidence: https://github.com/Avick3110/houseCARL/issues/36#issuecomment-4676704022

🤖 Generated with [Claude Code](https://claude.com/claude-code)
