### PR TITLE
Release 1.2.3 — VMAD write surface, verify loop, binding shim, setup hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ models — by construction, not a hand-maintained subset.
 
 ### Download — recommended (modders)
 
-1. Download **`houseCARL-1.2.2.zip`** from the [latest release](https://github.com/Avick3110/houseCARL/releases).
+1. Download **`houseCARL-1.2.3.zip`** from the [latest release](https://github.com/Avick3110/houseCARL/releases).
 2. Unzip it and run **`houseCARL-Setup.exe`**.
 3. Pick your host — **`[1] Claude Code`**, **`[2] Codex`**, or **`[3] Both`**. The installer wires
    everything up:
@@ -74,7 +74,7 @@ cd houseCARL
 
 The script regenerates the reflection rulebook, publishes the server framework-dependent (trimming **off**
 — houseCARL is reflection-driven, so trimming would strip types and silently lose coverage), bundles the
-skills, builds the setup utility, and packs `release/houseCARL-1.2.2.zip`. Install the output with
+skills, builds the setup utility, and packs `release/houseCARL-1.2.3.zip`. Install the output with
 `houseCARL-Setup.exe`, `claude --plugin-dir ./dist/housecarl`, or the bundled local-marketplace
 descriptor — see the script header for details.
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "housecarl",
   "displayName": "houseCARL",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Comprehensive data-layer access to your Skyrim SE load order — read any record, author patches into a new plugin, look mods up on Nexus, and look up record schemas, Papyrus signatures, performance reviews, and distributor grammars — in plain English.",
   "author": { "name": "Avick3110" },
   "homepage": "https://github.com/Avick3110/houseCARL",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to houseCARL are documented here. Versioning is [semantic](h
 the `version` in `.claude-plugin/plugin.json` is bumped on each release, so installed users update only
 when it changes.
 
+## 1.2.3 — 2026-06-11
+
+Opens the script-property write surface, adds a write-and-verify loop, and hardens tool-argument handling
+and setup — carrying houseCARL's first outside code contributions (thanks, **WraithFallen**). No change to
+the tool set.
+
+- **Script-property (VMAD) writes work** *(WraithFallen — #35/#38)*: paths and composes that go through a
+  polymorphic field's arms — setting a script property's target object, editing a quest alias's script
+  fields, adding a `ScriptObjectProperty` to a script's property list — now validate against the arm's own
+  schema and write end-to-end. Before, the write pre-flight couldn't see fields that exist only on one arm
+  of a polymorphic type, so those edits were rejected; reads already worked. The surface is generic over
+  every polymorphic family — no per-type wiring — and the cases an arm can't support still fail with a
+  named reason.
+- **Malformed tool arguments coerce or fail by name** *(#36, string-encoded-array case by WraithFallen)*:
+  Claude Code's client sometimes sends an array argument as a plain string or as a JSON-array-in-a-string
+  (`"[\"A.esp\"]"`); both shapes now bind as the array they spell. A missing required argument refuses by
+  name, an uncoercible shape fails with a named reason, and an unexpected error inside any tool now returns
+  a named error — never the SDK's generic text.
+- **Write-and-verify in one step:** the write tools gain an opt-in `full_readback=` that returns every
+  record the write touched or created — in full, read back off the *written file* — so a patch can be
+  verified before it's ever enabled in MO2.
+- **Honest answer for a plugin that isn't in the load order:** a `plugin=` read naming a plugin that isn't
+  in the current order now gets its own named error saying exactly that, instead of the false "does not
+  define this record".
+- **Consistent answers while the load order changes:** each logical operation now reads from one captured
+  index snapshot, so an MO2 change landing mid-query can no longer tear a result (winner, touching list,
+  and counters always come from the same view).
+- **Setup is self-contained and pre-flights the runtimes:** `houseCARL-Setup.exe` no longer needs .NET
+  installed to run, and it checks for *both* required .NET runtimes up front with a specific fix message.
+  The install docs are corrected accordingly — installing the ASP.NET Core Runtime does **not** include the
+  base .NET runtime.
+- **Authoring skills load for reading, not just writing:** the SkyPatcher / SPID / KID skills now also fire
+  when *interpreting or auditing* an existing INI — "what does this `_DISTR.ini` do", "is this NPC
+  affected", "why isn't this line applying" — so those answers come from the bundled grammar references
+  instead of memory.
+
 ## 1.2.2 — 2026-06-10
 
 Fixes four issues surfaced auditing a Requiem load order — all in reads and writes, no change to the tool


### PR DESCRIPTION
Version bump 1.2.2 → 1.2.3 + the user-facing changelog for everything merged since `v1.2.2` (24 commits). PATCH per precedent: the tool surface stays 16 — existing tools enhanced, no new tools. 1.2.3 is also load-bearing: the authoria-requiem recipe docs already say "houseCARL 1.2.3+".

## In this release (user-facing)

- **#38 VMAD polymorphic write surface** — *WraithFallen's* contribution; closes #35. The release trigger per Aaron's decision.
- **#39 string-encoded JSON-array binding** — *WraithFallen*; with #34's binding shim + named tool errors, closes #36.
- **#40 verify-loop wave** — opt-in `full_readback=` on write tools + honest `plugin=` not-in-order taxonomy.
- **#37 snapshot-view** — one captured index view per logical operation.
- **#33 setup hardening** — self-contained `houseCARL-Setup.exe` + both-runtimes preflight + corrected .NET docs.
- **#42 authoring-skill read triggers** — SkyPatcher/SPID/KID skills fire on interpret/audit tasks too.

Omitted from the user changelog (intentional, per precedent): #41 CONTRIBUTING.md, CI YAML fix, Node-24-era CI internals, build-script dist clean.

## Proof

- `build-plugin.ps1` from this branch: **305 entries, 15.66 MB**, leak-check clean, all summary checks true (exe/corpus/manifest/setup/start-here/marketplace/codex).
- `claude plugin validate --strict` on the assembled `dist/housecarl`: **PASSED**.

After merge: annotated tag `v1.2.3` on the release commit → GitHub Release with the zip → one-line-bullet changelog block reused verbatim for Nexus (Aaron's manual upload). Nexus page reminder: the ASP.NET-runtime wording fix from #33 likely still needs applying there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)