### PR TITLE
Write-safety pair (PR #44 takeover): hardened upsert + atomic staged write + upsert-guard CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,13 @@ jobs:
       - name: Probe — FormID allocation floor (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- formid-floor-guard
 
+      # Self-contained (synthesizes its own master — no external files), drives the REAL create/apply paths: locks
+      # in the create_record into= upsert + atomic staged write (PR #44, outside contribution, hardened in review) —
+      # re-runs replace loudly in place (stable FormKeys, byte-identical, REPLACED surfaced); override / duplicate /
+      # cross-type editorid collisions refuse loud; a commit blocked by a foreign handle leaves the old file intact.
+      - name: Probe — create into= upsert + staged write (self-contained regression guard)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- upsert-guard
+
       # Drives the REAL housecarl-mcp.exe over stdio — the exact wire path of the live failure; needs no game data
       # (argument binding resolves before configuration is consulted): a regression guard locking in the tool-argument
       # binding shim — string-for-array coerces, missing-required refuses by name, an uncoercible shape fails NAMED

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -842,22 +842,46 @@ public static class WriteEngine
     }
 
     /// <summary>UPSERT front-end for the extend path: like <see cref="GenericAddNew"/>, but if the patch already
-    /// carries a record with the same EditorID (a re-run of the same create against the same <c>into=</c> target),
-    /// the stale copy is REPLACED — removed from its group and re-created FRESH at the SAME FormKey — instead of a
-    /// duplicate being appended. This makes create calls IDEMPOTENT: re-running neither appends a second copy (the
-    /// dup-append failure) nor accumulates list items inside a reused record (re-applying edits to a live record
-    /// would re-Add keyword/effect list entries), and the stable FormKey keeps cross-record links and external
-    /// references (script properties, SKSE framework configs) valid across re-runs. An EditorID collision across
-    /// record TYPES is refused loud (Q3) — that is a real authoring error, not an upsert.
-    /// Returns the record plus whether an existing one was replaced (for caller logging).</summary>
+    /// carries a record IT ITSELF DEFINES with the same EditorID (a re-run of the same create against the same
+    /// <c>into=</c> target), the stale copy is REPLACED — removed from its group and re-created FRESH at the SAME
+    /// FormKey — instead of a duplicate being appended. This makes create calls IDEMPOTENT: re-running neither
+    /// appends a second copy (the dup-append failure) nor accumulates list items inside a reused record (re-applying
+    /// edits to a live record would re-Add keyword/effect list entries), and the stable FormKey keeps cross-record
+    /// links and external references (script properties, SKSE framework configs) valid across re-runs.
+    ///
+    /// Three collisions are refused LOUD (Q3), never absorbed into a replace:
+    ///   - an OVERRIDE the patch carries (another plugin's record, matched by its carried EditorID): replacing it
+    ///     would serialize a blank override that GUTS the original plugin's record — the opposite of
+    ///     originals-untouched. Overrides are edited with set_field/bulk_apply, never re-created.
+    ///   - DUPLICATE residue (2+ same-EditorID records, the pre-fix dup-append bug's own product): which FormKey
+    ///     survives is the caller's call — external references may point at either copy. Named, not guessed.
+    ///   - a cross-TYPE EditorID collision: a real authoring error, surfaced not swallowed.
+    /// Returns the record plus whether an existing one was replaced — the caller MUST surface a replace to the user
+    /// (a replace discards the prior record state, including any set_field edits made since the original create).</summary>
     public static (IMajorRecord Record, bool Replaced) GenericUpsertNew(SkyrimMod patchMod, string typeName, string? editorId)
     {
         if (editorId is not null)
         {
-            var existing = patchMod.EnumerateMajorRecords()
-                .FirstOrDefault(r => string.Equals(r.EditorID, editorId, StringComparison.OrdinalIgnoreCase));
-            if (existing is not null)
+            var matches = patchMod.EnumerateMajorRecords()
+                .Where(r => string.Equals(r.EditorID, editorId, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            if (matches.Count > 0)
             {
+                // Replace-eligibility guard: ONLY a record this patch itself defines (its own ModKey) may be
+                // replaced. A match on a carried OVERRIDE keeps the foreign FormKey — re-creating "at the same
+                // FormKey" there would emit a field-wiping override of the ORIGINAL plugin's record.
+                var foreign = matches.FirstOrDefault(r => r.FormKey.ModKey != patchMod.ModKey);
+                if (foreign is not null)
+                    throw new InvalidOperationException(
+                        $"create refused: this patch already carries an OVERRIDE of {foreign.FormKey} whose editorid is '{editorId}' — " +
+                        $"re-creating over an override would blank the original plugin's record. Pick a different editorid for the new record, " +
+                        "or edit the override's fields with housecarl_set_field / housecarl_bulk_apply.");
+                if (matches.Count > 1)
+                    throw new InvalidOperationException(
+                        $"create refused: this patch carries {matches.Count} records with editorid '{editorId}' " +
+                        $"({string.Join(", ", matches.Select(m => m.FormKey))}) — duplicate residue from re-running creates on a pre-fix houseCARL. " +
+                        "External references may point at either copy, so which survives is your call: remove the extra(s) with housecarl_remove_record, then re-run.");
+                var existing = matches[0];
                 if (!CanCreateType(typeName, out var reason)) throw new InvalidOperationException(reason);
                 var formKey = existing.FormKey;
                 object? group = null; Type? tMajor = null;
@@ -884,7 +908,15 @@ public static class WriteEngine
     static void InvokeRemove(object group, FormKey formKey)
     {
         var instance = group.GetType().GetMethod("Remove", new[] { typeof(FormKey) });
-        if (instance is not null) { instance.Invoke(group, new object[] { formKey }); return; }
+        if (instance is not null)
+        {
+            var result = instance.Invoke(group, new object[] { formKey });
+            if (result is false)
+                throw new InvalidOperationException(
+                    $"Remove({formKey}) reported nothing removed — the matched record vanished between match and replace " +
+                    "(engine inconsistency, surfaced not swallowed).");
+            return;
+        }
         foreach (var asm in AppDomain.CurrentDomain.GetAssemblies().Where(a => (a.GetName().Name ?? "").StartsWith("Mutagen")))
             foreach (var t in SafeTypes(asm).Where(t => t is { IsAbstract: true, IsSealed: true }))
                 foreach (var m in t.GetMethods(BindingFlags.Public | BindingFlags.Static).Where(m => m.Name == "Remove"))
@@ -1049,38 +1081,23 @@ public static class WriteEngine
         // so a freed ID is never re-allocated). Every product write funnels through here, so every houseCARL-written
         // plugin carries a conventional counter regardless of which tool created it.
         EnsureFormIdFloor(patchMod);
-        // ATOMIC WRITE (Q3): stage + commit. Serializing IN PLACE can tear the plugin (a crash mid-write leaves a
-        // truncated .esp) and loses two races once the patch is enabled in MO2: (a) MO2's folder watcher opens the
-        // half-written file to refresh its plugin list (sharing violation), and (b) on an EXTEND, the caller's own
-        // overlay session may have memory-mapped the target (a winner read against a last-in-order patch opens its
-        // overlay; AllMastersExcept keeps the SERIALIZER from mapping it but cannot un-map a phase-3 read) — and a
-        // memory-mapped file cannot be replaced (deterministic AccessDenied, measured against a live MO2 instance).
-        // Callers that hold a session stage INSIDE it and commit AFTER disposing it; this one-shot overload serves
-        // session-free callers (the standalone harness).
+        // ATOMIC WRITE (Q3): stage + commit. Serializing IN PLACE has two failure shapes once a patch lives in an
+        // MO2 mods folder: a crash mid-serialize leaves a truncated .esp (a torn original), and an external folder
+        // watcher (MO2 refreshing its plugin list) can open a half-written file. Staging into a sibling temp dir and
+        // committing via an atomic same-volume rename means the target path only ever holds the OLD complete file or
+        // the NEW complete file — never a partial one. NOTE: this does NOT relax the PR #24 self-lock guard
+        // (ReleaseOverlay + AllMastersExcept before the serialize): a rename onto a still-mapped target fails exactly
+        // like an in-place write would, so callers must still release every handle they hold on the target first.
+        // Staging buys crash-tear safety and shrinks the external-watcher window; the handle discipline stays
+        // load-bearing.
         var staged = WritePatchStaged(patchMod, ordered, baseline, outputPath);
         CommitStagedPatch(staged, outputPath);
     }
 
     /// <summary>Stage 1 of the atomic write: serialize the patch into a temp SUBDIRECTORY beside the target —
     /// same filename (Mutagen's writer ties filename to ModKey), same parent directory (guarantees same NTFS
-    /// volume so the stage-2 rename is atomic). Read-only with respect to the target file, so it is safe while
-    /// an overlay session still has the target memory-mapped (the extend path). Cleans its temp on serialize
-    /// failure (Q3 — a failed stage leaves no residue). Same filename-check / floor / counter-persistence
-    /// semantics as <see cref="WritePatch(SkyrimMod,IReadOnlyList{ISkyrimModGetter},string)"/>.</summary>
-    internal static string WritePatchStaged(SkyrimMod patchMod, IReadOnlyList<ISkyrimModGetter> knownMasters, string outputPath)
-    {
-        var expected = patchMod.ModKey.FileName.String;
-        var actual = Path.GetFileName(outputPath);
-        if (!string.Equals(expected, actual, StringComparison.OrdinalIgnoreCase))
-            throw new InvalidOperationException(
-                $"Output filename '{actual}' must match patch ModKey filename '{expected}'.");
-        Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
-        var ordered = knownMasters as ISkyrimModGetter[] ?? knownMasters.ToArray();
-        var baseline = BaselineMasters.Where(bm => ordered.Any(km => km.ModKey == bm)).ToArray();
-        EnsureFormIdFloor(patchMod);
-        return WritePatchStaged(patchMod, ordered, baseline, outputPath);
-    }
-
+    /// volume so the stage-2 rename is atomic). Does not open the target file itself. Cleans its temp on serialize
+    /// failure (Q3 — a failed stage leaves no residue).</summary>
     static string WritePatchStaged(SkyrimMod patchMod, ISkyrimModGetter[] ordered, ModKey[] baseline, string outputPath)
     {
         var tmpDir = Path.Combine(Path.GetDirectoryName(outputPath)!, ".housecarl-tmp");
@@ -1104,9 +1121,9 @@ public static class WriteEngine
     }
 
     /// <summary>Stage 2 of the atomic write: rename the staged temp over the target — atomic on the same volume
-    /// (stage 1 guaranteed same-volume placement). Call AFTER disposing any overlay session that may have the
-    /// target mapped. Temp is removed afterward; a cleanup failure never masks the result (Q3).</summary>
-    internal static void CommitStagedPatch(string tmpPath, string outputPath)
+    /// (stage 1 guaranteed same-volume placement). Requires the PR #24 handle discipline to already hold (no handle
+    /// of ours on the target). Temp is removed afterward; a cleanup failure never masks the result (Q3).</summary>
+    static void CommitStagedPatch(string tmpPath, string outputPath)
     {
         try { File.Move(tmpPath, outputPath, overwrite: true); }
         finally { CleanupStaged(tmpPath); }

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -841,6 +841,91 @@ public static class WriteEngine
         return InvokeAddNew(group!, tMajor!, editorId);   // CanCreateType guaranteed a concrete flat group exists
     }
 
+    /// <summary>UPSERT front-end for the extend path: like <see cref="GenericAddNew"/>, but if the patch already
+    /// carries a record with the same EditorID (a re-run of the same create against the same <c>into=</c> target),
+    /// the stale copy is REPLACED — removed from its group and re-created FRESH at the SAME FormKey — instead of a
+    /// duplicate being appended. This makes create calls IDEMPOTENT: re-running neither appends a second copy (the
+    /// dup-append failure) nor accumulates list items inside a reused record (re-applying edits to a live record
+    /// would re-Add keyword/effect list entries), and the stable FormKey keeps cross-record links and external
+    /// references (script properties, SKSE framework configs) valid across re-runs. An EditorID collision across
+    /// record TYPES is refused loud (Q3) — that is a real authoring error, not an upsert.
+    /// Returns the record plus whether an existing one was replaced (for caller logging).</summary>
+    public static (IMajorRecord Record, bool Replaced) GenericUpsertNew(SkyrimMod patchMod, string typeName, string? editorId)
+    {
+        if (editorId is not null)
+        {
+            var existing = patchMod.EnumerateMajorRecords()
+                .FirstOrDefault(r => string.Equals(r.EditorID, editorId, StringComparison.OrdinalIgnoreCase));
+            if (existing is not null)
+            {
+                if (!CanCreateType(typeName, out var reason)) throw new InvalidOperationException(reason);
+                var formKey = existing.FormKey;
+                object? group = null; Type? tMajor = null;
+                foreach (var (prop, tm, _) in EnumerateFlatGroups(patchMod.GetType()))
+                    if (string.Equals(tm.Name, typeName, StringComparison.OrdinalIgnoreCase)) { group = prop.GetValue(patchMod); tMajor = tm; break; }
+                if (group is null || tMajor is null)
+                    throw new InvalidOperationException($"upsert: no flat group found for type '{typeName}'.");
+                if (!tMajor.IsInstanceOfType(existing))
+                    throw new InvalidOperationException(
+                        $"upsert refused: existing record '{editorId}' ({formKey}) is a {existing.GetType().Name}, not a {typeName} — " +
+                        "an EditorID collision across record types is a real authoring error, surfaced not swallowed (Q3).");
+                InvokeRemove(group, formKey);
+                var fresh = InvokeAddNewWithFormKey(group, tMajor, formKey);
+                fresh.EditorID = editorId;
+                return (fresh, true);
+            }
+        }
+        return (GenericAddNew(patchMod, typeName, editorId), false);
+    }
+
+    /// <summary>Remove a record from a flat group by FormKey. Tries the group's own instance <c>Remove(FormKey)</c>
+    /// first, then falls back to the same Mutagen static-extension scan <see cref="InvokeAddNew"/> uses (Q3 —
+    /// fails loud if neither shape exists, never a silent no-op).</summary>
+    static void InvokeRemove(object group, FormKey formKey)
+    {
+        var instance = group.GetType().GetMethod("Remove", new[] { typeof(FormKey) });
+        if (instance is not null) { instance.Invoke(group, new object[] { formKey }); return; }
+        foreach (var asm in AppDomain.CurrentDomain.GetAssemblies().Where(a => (a.GetName().Name ?? "").StartsWith("Mutagen")))
+            foreach (var t in SafeTypes(asm).Where(t => t is { IsAbstract: true, IsSealed: true }))
+                foreach (var m in t.GetMethods(BindingFlags.Public | BindingFlags.Static).Where(m => m.Name == "Remove"))
+                {
+                    var ps = m.GetParameters();
+                    if (ps.Length != 2 || ps[1].ParameterType != typeof(FormKey)) continue;
+                    var closed = m;
+                    if (m.IsGenericMethodDefinition)
+                    {
+                        if (m.GetGenericArguments().Length != 1) continue;
+                        var tArg = group.GetType().IsGenericType ? group.GetType().GetGenericArguments()[0] : null;
+                        if (tArg is null) continue;
+                        try { closed = m.MakeGenericMethod(tArg); } catch { continue; }
+                    }
+                    if (!closed.GetParameters()[0].ParameterType.IsInstanceOfType(group)) continue;
+                    closed.Invoke(null, new object[] { group, formKey });
+                    return;
+                }
+        throw new InvalidOperationException($"Could not locate a Remove(FormKey) accepting {group.GetType().Name}.");
+    }
+
+    /// <summary>The FormKey-preserving sibling of <see cref="InvokeAddNew"/>: Mutagen's <c>AddNew(IGroup&lt;T&gt;, FormKey)</c>
+    /// extension, located by the same proven candidate scan. Used by upsert so a replaced record keeps its FormID
+    /// (the allocator is untouched — no new ID is consumed by a replace).</summary>
+    static IMajorRecord InvokeAddNewWithFormKey(object group, Type tMajor, FormKey formKey)
+    {
+        foreach (var asm in AppDomain.CurrentDomain.GetAssemblies().Where(a => (a.GetName().Name ?? "").StartsWith("Mutagen")))
+            foreach (var t in SafeTypes(asm).Where(t => t is { IsAbstract: true, IsSealed: true }))
+                foreach (var open in t.GetMethods(BindingFlags.Public | BindingFlags.Static)
+                             .Where(m => m.Name == "AddNew" && m.IsGenericMethodDefinition && m.GetGenericArguments().Length == 1))
+                {
+                    var ps = open.GetParameters();
+                    if (ps.Length != 2 || ps[1].ParameterType != typeof(FormKey)) continue;
+                    MethodInfo closed;
+                    try { closed = open.MakeGenericMethod(tMajor); } catch { continue; }
+                    if (!closed.GetParameters()[0].ParameterType.IsInstanceOfType(group)) continue;
+                    return (IMajorRecord)closed.Invoke(null, new object[] { group, formKey })!;
+                }
+        throw new InvalidOperationException($"Could not locate an AddNew(FormKey) extension accepting {group.GetType().Name}.");
+    }
+
     /// <summary>
     /// Raise the patch's FormID allocator counter (<c>HEDR.NextObjectID</c>, in memory <c>ModHeader.Stats.NextFormID</c>)
     /// to its safe floor: at least 0x800 (object IDs below 0x800 are engine-reserved — and 0x000000 is the NULL-reference
@@ -964,12 +1049,79 @@ public static class WriteEngine
         // so a freed ID is never re-allocated). Every product write funnels through here, so every houseCARL-written
         // plugin carries a conventional counter regardless of which tool created it.
         EnsureFormIdFloor(patchMod);
-        patchMod.BeginWrite
-            .ToPath(outputPath)
-            .WithLoadOrder(ordered)
-            .WithExtraIncludedMasters(baseline)
-            .NoNextFormIDProcessing()
-            .Write();
+        // ATOMIC WRITE (Q3): stage + commit. Serializing IN PLACE can tear the plugin (a crash mid-write leaves a
+        // truncated .esp) and loses two races once the patch is enabled in MO2: (a) MO2's folder watcher opens the
+        // half-written file to refresh its plugin list (sharing violation), and (b) on an EXTEND, the caller's own
+        // overlay session may have memory-mapped the target (a winner read against a last-in-order patch opens its
+        // overlay; AllMastersExcept keeps the SERIALIZER from mapping it but cannot un-map a phase-3 read) — and a
+        // memory-mapped file cannot be replaced (deterministic AccessDenied, measured against a live MO2 instance).
+        // Callers that hold a session stage INSIDE it and commit AFTER disposing it; this one-shot overload serves
+        // session-free callers (the standalone harness).
+        var staged = WritePatchStaged(patchMod, ordered, baseline, outputPath);
+        CommitStagedPatch(staged, outputPath);
+    }
+
+    /// <summary>Stage 1 of the atomic write: serialize the patch into a temp SUBDIRECTORY beside the target —
+    /// same filename (Mutagen's writer ties filename to ModKey), same parent directory (guarantees same NTFS
+    /// volume so the stage-2 rename is atomic). Read-only with respect to the target file, so it is safe while
+    /// an overlay session still has the target memory-mapped (the extend path). Cleans its temp on serialize
+    /// failure (Q3 — a failed stage leaves no residue). Same filename-check / floor / counter-persistence
+    /// semantics as <see cref="WritePatch(SkyrimMod,IReadOnlyList{ISkyrimModGetter},string)"/>.</summary>
+    internal static string WritePatchStaged(SkyrimMod patchMod, IReadOnlyList<ISkyrimModGetter> knownMasters, string outputPath)
+    {
+        var expected = patchMod.ModKey.FileName.String;
+        var actual = Path.GetFileName(outputPath);
+        if (!string.Equals(expected, actual, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException(
+                $"Output filename '{actual}' must match patch ModKey filename '{expected}'.");
+        Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+        var ordered = knownMasters as ISkyrimModGetter[] ?? knownMasters.ToArray();
+        var baseline = BaselineMasters.Where(bm => ordered.Any(km => km.ModKey == bm)).ToArray();
+        EnsureFormIdFloor(patchMod);
+        return WritePatchStaged(patchMod, ordered, baseline, outputPath);
+    }
+
+    static string WritePatchStaged(SkyrimMod patchMod, ISkyrimModGetter[] ordered, ModKey[] baseline, string outputPath)
+    {
+        var tmpDir = Path.Combine(Path.GetDirectoryName(outputPath)!, ".housecarl-tmp");
+        var tmpPath = Path.Combine(tmpDir, Path.GetFileName(outputPath));
+        Directory.CreateDirectory(tmpDir);
+        try
+        {
+            patchMod.BeginWrite
+                .ToPath(tmpPath)
+                .WithLoadOrder(ordered)
+                .WithExtraIncludedMasters(baseline)
+                .NoNextFormIDProcessing()
+                .Write();
+            return tmpPath;
+        }
+        catch
+        {
+            CleanupStaged(tmpPath);
+            throw;
+        }
+    }
+
+    /// <summary>Stage 2 of the atomic write: rename the staged temp over the target — atomic on the same volume
+    /// (stage 1 guaranteed same-volume placement). Call AFTER disposing any overlay session that may have the
+    /// target mapped. Temp is removed afterward; a cleanup failure never masks the result (Q3).</summary>
+    internal static void CommitStagedPatch(string tmpPath, string outputPath)
+    {
+        try { File.Move(tmpPath, outputPath, overwrite: true); }
+        finally { CleanupStaged(tmpPath); }
+    }
+
+    static void CleanupStaged(string tmpPath)
+    {
+        try
+        {
+            if (File.Exists(tmpPath)) File.Delete(tmpPath);
+            var dir = Path.GetDirectoryName(tmpPath);
+            if (dir is not null && Directory.Exists(dir) && !Directory.EnumerateFileSystemEntries(dir).Any())
+                Directory.Delete(dir, recursive: false);
+        }
+        catch (IOException) { } catch (UnauthorizedAccessException) { }
     }
 
     /// <summary>The base-game masters EVERY Skyrim plugin must carry — Skyrim.esm + Update.esm, exactly what the Creation

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -404,14 +404,18 @@ public static class WritePatchBuilder
         if (!string.Equals(patchMod.ModKey.FileName.String, fileName, StringComparison.OrdinalIgnoreCase))
             return CreateOutcome.Fail($"patch ModKey '{patchMod.ModKey.FileName}' must match output filename '{fileName}'.");
 
-        // --- Phase 3: AddNew each record, then apply its edits. A throw here AFTER pre-flight passed is a real engine
+        // --- Phase 3: UPSERT each record, then apply its edits. A throw here AFTER pre-flight passed is a real engine
         //     inconsistency — fail the WHOLE call (the in-memory patch is discarded; nothing serialized), surfaced not
-        //     swallowed (Q3). All AddNews are in-memory until the single WritePatch, so all-or-nothing holds even mid-loop. ---
+        //     swallowed (Q3). All upserts are in-memory until the single WritePatch, so all-or-nothing holds even mid-loop.
+        //     UPSERT (idempotency): on the into=/extend path, a re-run of the same create used to APPEND a duplicate of
+        //     every record (nothing checked whether the EditorID already existed in the opened patch). GenericUpsertNew
+        //     replaces an existing same-EditorID record FRESH at its same FormKey instead — re-runs are idempotent, list
+        //     fields can't accumulate, and stable FormKeys keep cross-record links + external references valid. ---
         var created = new List<CreatedRecord>(specs.Count);
         foreach (var s in specs)
         {
             IMajorRecord rec;
-            try { rec = WriteEngine.GenericAddNew(patchMod, s.RecordType, s.EditorId); }
+            try { (rec, _) = WriteEngine.GenericUpsertNew(patchMod, s.RecordType, s.EditorId); }
             catch (Exception ex) { return CreateOutcome.Fail($"could not create {s.RecordType} '{s.EditorId}': {ex.Message}"); }
 
             var ops = new List<OpResult>(s.Edits.Count);

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -101,8 +101,13 @@ public static class WritePatchBuilder
     }
 
     /// <summary>One record created by <see cref="CreateRecords"/> — its freshly-allocated <see cref="FormKey"/> (the
-    /// caller can't predict it; it's the local 0x800+ id), its type + editorid, and the per-field op results.</summary>
-    public sealed record CreatedRecord(FormKey FormKey, string RecordType, string EditorId, IReadOnlyList<OpResult> Ops);
+    /// caller can't predict it; it's the local 0x800+ id), its type + editorid, and the per-field op results.
+    /// <see cref="ReplacedExisting"/> = this create REPLACED a record the patch already defined with the same
+    /// editorid (an into= re-run): same FormKey, prior contents — including any set_field edits made since the
+    /// original create — discarded and rebuilt from this call's spec. MUST be surfaced to the user (Q3 — a replace
+    /// is never silent).</summary>
+    public sealed record CreatedRecord(FormKey FormKey, string RecordType, string EditorId, IReadOnlyList<OpResult> Ops,
+        bool ReplacedExisting = false);
 
     /// <summary>The outcome of a <see cref="CreateRecords"/> call. <see cref="Error"/> non-null ⇒ the whole call was
     /// refused (no file written) with a named, recoverable reason (Q3 — missing editorid, an un-createable type, a rejected
@@ -409,13 +414,15 @@ public static class WritePatchBuilder
         //     swallowed (Q3). All upserts are in-memory until the single WritePatch, so all-or-nothing holds even mid-loop.
         //     UPSERT (idempotency): on the into=/extend path, a re-run of the same create used to APPEND a duplicate of
         //     every record (nothing checked whether the EditorID already existed in the opened patch). GenericUpsertNew
-        //     replaces an existing same-EditorID record FRESH at its same FormKey instead — re-runs are idempotent, list
-        //     fields can't accumulate, and stable FormKeys keep cross-record links + external references valid. ---
+        //     replaces a same-EditorID record THE PATCH ITSELF DEFINES fresh at its same FormKey instead — re-runs are
+        //     idempotent, list fields can't accumulate, and stable FormKeys keep cross-record links + external references
+        //     valid. Collisions it will NOT absorb (carried overrides, duplicate residue, cross-type) refuse loud there;
+        //     every replace that DOES happen is carried on CreatedRecord.ReplacedExisting and rendered to the user. ---
         var created = new List<CreatedRecord>(specs.Count);
         foreach (var s in specs)
         {
-            IMajorRecord rec;
-            try { (rec, _) = WriteEngine.GenericUpsertNew(patchMod, s.RecordType, s.EditorId); }
+            IMajorRecord rec; bool replaced;
+            try { (rec, replaced) = WriteEngine.GenericUpsertNew(patchMod, s.RecordType, s.EditorId); }
             catch (Exception ex) { return CreateOutcome.Fail($"could not create {s.RecordType} '{s.EditorId}': {ex.Message}"); }
 
             var ops = new List<OpResult>(s.Edits.Count);
@@ -429,7 +436,7 @@ public static class WritePatchBuilder
                         $"pre-flight ACCEPTED it but the apply threw — a real inconsistency, surfaced not swallowed (Q3): {ex.GetType().Name}: {ex.Message}");
                 }
             }
-            created.Add(new CreatedRecord(rec.FormKey, s.RecordType, s.EditorId, ops));
+            created.Add(new CreatedRecord(rec.FormKey, s.RecordType, s.EditorId, ops, replaced));
         }
 
         // --- Phase 4: serialize ONCE with the full known-master set. A created record referencing existing content pulls
@@ -441,7 +448,7 @@ public static class WritePatchBuilder
         // keeps the target out of the master set. (writelock-probe / writelock-apply-probe; both halves guarded.)
         session.ReleaseOverlay(patchMod.ModKey.FileName.String);
         try { WriteEngine.WritePatch(patchMod, session.AllMastersExcept(patchMod.ModKey.FileName.String), outPath); }
-        catch (Exception ex) { return CreateOutcome.Fail($"serialize after create failed: {ex.GetType().Name}: {ex.Message}"); }
+        catch (Exception ex) { return CreateOutcome.Fail($"writing the patch after create failed (serialize or commit; the existing file is untouched): {ex.GetType().Name}: {ex.Message}"); }
 
         // --- Phase 5: re-open + report the (derived) master header + bytes — and, on request, each created record's
         //     FULL read-back off that same re-opened file (see Apply's Phase 5). Dispose the overlay so the file isn't

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -220,7 +220,7 @@ public static class WritePatchBuilder
         session.ReleaseOverlay(patchMod.ModKey.FileName.String);
         try { WriteEngine.WritePatch(patchMod, session.AllMastersExcept(patchMod.ModKey.FileName.String), outPath); }
         catch (Exception ex)
-            { return PatchOutcome.Fail($"serialize failed: {ex.GetType().Name}: {ex.Message}"); }
+            { return PatchOutcome.Fail($"writing the patch failed (serialize or commit; the existing file is untouched): {ex.GetType().Name}: {ex.Message}"); }
 
         // --- Phase 5: re-open the written patch and report its master header — and, on request, each touched
         //     record's FULL read-back off that same re-opened file (the on-disk bytes, not the in-memory mod — the
@@ -333,7 +333,7 @@ public static class WritePatchBuilder
         // keeps the target out of the master set. (writelock-probe / writelock-apply-probe; both halves guarded.)
         session.ReleaseOverlay(patchMod.ModKey.FileName.String);
         try { WriteEngine.WritePatch(patchMod, session.AllMastersExcept(patchMod.ModKey.FileName.String), outPath); }
-        catch (Exception ex) { return RemovalOutcome.Fail($"serialize after removal failed: {ex.GetType().Name}: {ex.Message}"); }
+        catch (Exception ex) { return RemovalOutcome.Fail($"writing the patch after removal failed (serialize or commit; the existing file is untouched): {ex.GetType().Name}: {ex.Message}"); }
 
         // Re-open: report the (possibly shrunk) master header + how many records remain (0 ⇒ the patch is now an inert
         // header-only plugin the user can disable/delete). Dispose the overlay so the file isn't left mmap'd for a later call.

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -202,6 +202,11 @@ if (args.Length > 0 && args[0] == "formid-floor-probe") return FormIdFloorProbe.
 // workflow (Apply-born patch → CreateRecords into=) through the real product paths, asserts the 0x800+ contract.
 if (args.Length > 0 && args[0] == "formid-floor-guard") return FormIdFloorProbe.RunGuard(args[1..]);
 
+// create_record into= upsert + atomic staged write (PR #44, hardened in review): SELF-CONTAINED CI regression
+// guard — re-runs replace loudly in place; override/duplicate/cross-type collisions refuse loud; a blocked commit
+// leaves the old file intact with no temp residue.
+if (args.Length > 0 && args[0] == "upsert-guard") return UpsertGuardProbe.RunGuard(args[1..]);
+
 // External-tool bridge (step 1) proof: the pure core pieces housecarl_set_tool_path + the riders ride — shared-config
 // clobber-safety, path validation, the missing-dependency forcing prompt, and canonical-home auto-detect.
 if (args.Length > 0 && args[0] == "tool-bridge") return ToolBridgeProbe.Run(args[1..]);

--- a/src/housecarl-generator/UpsertGuardProbe.cs
+++ b/src/housecarl-generator/UpsertGuardProbe.cs
@@ -1,0 +1,230 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SELF-CONTAINED CI REGRESSION GUARD for the create_record into= UPSERT + atomic staged write (PR #44, outside
+/// contribution by AlmightyChan, hardened in review), in the pattern of writelock-guard / formid-floor-guard.
+/// Drives the REAL product paths (WritePatchBuilder.CreateRecords / Apply) against a synthesized master in TEMP.
+/// Run: dotnet run --project src/housecarl-generator -- upsert-guard
+///
+/// Arms (ALL required — a GREEN must mean "the contract holds", never "the scenario doesn't arise here"):
+///   RERUN     — re-running the same create against the same into= target REPLACES instead of appending: 1 copy of
+///               each record, FormKeys stable, output byte-identical, list edits applied once, the persisted counter
+///               unmoved, and EVERY replace surfaced on CreatedRecord.ReplacedExisting (a replace is never silent).
+///               RED pre-PR-44 (dup-append: 2 copies, shifted FormKeys, growing file).
+///   OVERRIDE  — a create whose editorid collides with an OVERRIDE the patch carries (another plugin's record) is
+///               REFUSED loud, the file untouched, and the override's edited fields survive. RED on unhardened
+///               PR #44 (the upsert matched overrides too and silently emitted a field-wiping override of the
+///               original plugin's record — the master-blanking path).
+///   CROSS-TYPE— an editorid collision across record types refuses loud (carried over from the contribution).
+///   DUP       — duplicate same-editorid residue (the pre-fix bug's own product) refuses LOUD naming every copy,
+///               replacing none — which FormKey survives is the caller's call (external references may point at
+///               either). RED on unhardened PR #44 (FirstOrDefault replaced one copy silently, leaving the rest).
+///   LOCKED    — a commit blocked by a foreign handle on the target (no FILE_SHARE_DELETE) fails LOUD with the
+///               target's old bytes fully intact and no .housecarl-tmp residue — the staged write's failure
+///               contract (the old in-place serialize had no such guarantee shape to test).
+/// </summary>
+public static class UpsertGuardProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  REGRESSION GUARD — create_record into= upsert + staged write (PR #44)  ################");
+        Console.WriteLine();
+
+        var tmpDir = Path.Combine(Path.GetTempPath(), "hc-upsert-guard");
+        if (Directory.Exists(tmpDir)) Directory.Delete(tmpDir, recursive: true);
+        Directory.CreateDirectory(tmpDir);
+
+        // --- Setup: a master carrying a weapon (the override target) + a keyword (the created weapon's list edit),
+        //     + the validator corpus. ---
+        var mKey = new ModKey("HcUpsGdMaster", ModType.Master);
+        string mPath = Path.Combine(tmpDir, mKey.FileName.String);
+        FormKey masterWeapFk, masterKwFk;
+        {
+            var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
+            var w = m.Weapons.AddNew(); w.EditorID = "HcUpsGdMasterWeap"; w.BasicStats = new WeaponBasicStats { Damage = 10 };
+            masterWeapFk = w.FormKey;
+            var k = m.Keywords.AddNew(); k.EditorID = "HcUpsGdMasterKw";
+            masterKwFk = k.FormKey;
+            m.BeginWrite.ToPath(mPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+        }
+        var genDir = Path.Combine(tmpDir, "corpus-gen");
+        CorpusGenerator.GenerateAll(genDir, Path.Combine(tmpDir, "corpus-ref"));
+        var rulebook = CorpusRulebook.Load(Path.Combine(genDir, "corpus.json"));
+        string masterKwRef = $"{masterKwFk.ID:X6}:{masterKwFk.ModKey.FileName}";
+        Console.WriteLine($"-- setup: master {mKey.FileName} with weapon {masterWeapFk} + keyword {masterKwFk}; corpus generated --");
+
+        string pPath = Path.Combine(tmpDir, "HcUpsGuard.esp");
+        WritePatchBuilder.CreateSpec[] Specs() => new[]
+        {
+            new WritePatchBuilder.CreateSpec { RecordType = "Keyword", EditorId = "HcUpsGdKw", Edits = Array.Empty<WriteRequest>() },
+            new WritePatchBuilder.CreateSpec { RecordType = "Weapon", EditorId = "HcUpsGdWeap", Edits = new[]
+            {
+                new WriteRequest { RecordType = "Weapon", Path = new[] { "BasicStats", "Damage" }, Verb = "Set", Value = "25" },
+                new WriteRequest { RecordType = "Weapon", Path = new[] { "Keywords" }, Verb = "Add", Value = masterKwRef },
+            } },
+        };
+
+        // --- RERUN: fresh create, then the identical create with extend=true. ---
+        bool rerunOk = false;
+        {
+            FormKey kwFk1 = default, weapFk1 = default;
+            bool freshOk = false, freshNotReplaced = false;
+            using (var r = LoadOrderResolver.Build(new[] { mPath }))
+            {
+                var o = WritePatchBuilder.CreateRecords(r, rulebook, Specs(), pPath, extend: false);
+                freshOk = o.Success;
+                if (o.Success)
+                {
+                    kwFk1 = o.Created[0].FormKey; weapFk1 = o.Created[1].FormKey;
+                    freshNotReplaced = o.Created.All(c => !c.ReplacedExisting);
+                }
+            }
+            byte[] bytes1 = freshOk ? File.ReadAllBytes(pPath) : Array.Empty<byte>();
+
+            bool rerunSuccess = false, flagsOk = false;
+            using (var r = LoadOrderResolver.Build(new[] { mPath }))
+            {
+                var o = WritePatchBuilder.CreateRecords(r, rulebook, Specs(), pPath, extend: true);
+                rerunSuccess = o.Success;
+                if (o.Success) flagsOk = o.Created.Count == 2 && o.Created.All(c => c.ReplacedExisting);
+            }
+
+            int kwCount = 0, weapCount = 0, weapKwList = -1; FormKey kwFk2 = default, weapFk2 = default;
+            if (rerunSuccess)
+            {
+                ISkyrimModGetter? ov = null;
+                try
+                {
+                    ov = SkyrimMod.CreateFromBinaryOverlay(pPath, SkyrimRelease.SkyrimSE);
+                    foreach (var k in ov.Keywords) if (k.EditorID == "HcUpsGdKw") { kwCount++; kwFk2 = k.FormKey; }
+                    foreach (var w in ov.Weapons) if (w.EditorID == "HcUpsGdWeap") { weapCount++; weapFk2 = w.FormKey; weapKwList = w.Keywords?.Count ?? 0; }
+                }
+                finally { (ov as IDisposable)?.Dispose(); }
+            }
+            byte[] bytes2 = rerunSuccess ? File.ReadAllBytes(pPath) : Array.Empty<byte>();
+            uint counter = rerunSuccess ? ReadDiskNextFormId(pPath) : 0;
+
+            rerunOk = freshOk && freshNotReplaced && rerunSuccess && flagsOk
+                      && kwCount == 1 && weapCount == 1 && weapKwList == 1
+                      && kwFk2 == kwFk1 && weapFk2 == weapFk1
+                      && bytes1.AsSpan().SequenceEqual(bytes2)
+                      && counter == 0x802;
+            Console.WriteLine($"   RERUN replaces, loudly, in place    : {(rerunOk ? $"PASS — 1/1 copies, stable FormKeys ({kwFk2}, {weapFk2}), byte-identical, both flagged REPLACED, counter 0x{counter:X6}" : $"FAIL — fresh={freshOk}/{freshNotReplaced} rerun={rerunSuccess} flags={flagsOk} counts={kwCount}/{weapCount} list={weapKwList} stable={kwFk2 == kwFk1 && weapFk2 == weapFk1} bytes={bytes1.Length}->{bytes2.Length} counter=0x{counter:X6}")}");
+        }
+
+        // --- OVERRIDE: an Apply-born override rides in the patch; a create colliding with ITS editorid must refuse,
+        //     file untouched, override fields intact (the master-blanking guard). ---
+        bool overrideOk = false;
+        {
+            bool applyOk;
+            using (var r = LoadOrderResolver.Build(new[] { mPath }))
+            {
+                var edit = new WritePatchBuilder.PatchEdit { Target = masterWeapFk, Path = new[] { "BasicStats", "Damage" }, Verb = "Set", Value = "20" };
+                applyOk = WritePatchBuilder.Apply(r, rulebook, new[] { edit }, pPath, extend: true).Success;
+            }
+            byte[] before = applyOk ? File.ReadAllBytes(pPath) : Array.Empty<byte>();
+
+            bool refused = false; string? error = null;
+            if (applyOk)
+                using (var r = LoadOrderResolver.Build(new[] { mPath }))
+                {
+                    var clash = new[] { new WritePatchBuilder.CreateSpec { RecordType = "Weapon", EditorId = "HcUpsGdMasterWeap", Edits = Array.Empty<WriteRequest>() } };
+                    var o = WritePatchBuilder.CreateRecords(r, rulebook, clash, pPath, extend: true);
+                    refused = !o.Success; error = o.Error;
+                }
+
+            bool fileUntouched = applyOk && before.AsSpan().SequenceEqual(File.ReadAllBytes(pPath));
+            bool overrideIntact = false;
+            if (applyOk)
+            {
+                ISkyrimModGetter? ov = null;
+                try
+                {
+                    ov = SkyrimMod.CreateFromBinaryOverlay(pPath, SkyrimRelease.SkyrimSE);
+                    var w = ov.Weapons.FirstOrDefault(x => x.FormKey == masterWeapFk);
+                    overrideIntact = w is not null && w.BasicStats?.Damage == 20;
+                }
+                finally { (ov as IDisposable)?.Dispose(); }
+            }
+            bool named = error is not null && error.Contains("override", StringComparison.OrdinalIgnoreCase);
+            overrideOk = applyOk && refused && named && fileUntouched && overrideIntact;
+            Console.WriteLine($"   OVERRIDE collision refused loud     : {(overrideOk ? "PASS — refused by name, file untouched, override Damage=20 intact" : $"FAIL — apply={applyOk} refused={refused} named={named} untouched={fileUntouched} intact={overrideIntact} error=[{error}]")}");
+        }
+
+        // --- CROSS-TYPE: a Keyword create colliding with the patch-defined weapon's editorid refuses loud. ---
+        bool crossTypeOk = false;
+        {
+            using var r = LoadOrderResolver.Build(new[] { mPath });
+            var clash = new[] { new WritePatchBuilder.CreateSpec { RecordType = "Keyword", EditorId = "HcUpsGdWeap", Edits = Array.Empty<WriteRequest>() } };
+            var o = WritePatchBuilder.CreateRecords(r, rulebook, clash, pPath, extend: true);
+            crossTypeOk = !o.Success && o.Error is not null && o.Error.Contains("not a Keyword", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   CROSS-TYPE collision refused loud   : {(crossTypeOk ? "PASS" : $"FAIL — success={o.Success} error=[{o.Error}]")}");
+        }
+
+        // --- DUP: duplicate same-editorid residue (the old bug's product) refuses LOUD naming every copy. ---
+        bool dupOk = false;
+        {
+            string dupPath = Path.Combine(tmpDir, "HcUpsGuardDup.esp");
+            FormKey dup1, dup2;
+            {
+                var p = new SkyrimMod(new ModKey("HcUpsGuardDup", ModType.Plugin), SkyrimRelease.SkyrimSE);
+                var k1 = p.Keywords.AddNew(); k1.EditorID = "HcUpsGdDupKw"; dup1 = k1.FormKey;
+                var k2 = p.Keywords.AddNew(); k2.EditorID = "HcUpsGdDupKw"; dup2 = k2.FormKey;
+                p.BeginWrite.ToPath(dupPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).NoNextFormIDProcessing().Write();
+            }
+            byte[] before = File.ReadAllBytes(dupPath);
+            bool refused; string? error;
+            using (var r = LoadOrderResolver.Build(new[] { mPath }))
+            {
+                var spec = new[] { new WritePatchBuilder.CreateSpec { RecordType = "Keyword", EditorId = "HcUpsGdDupKw", Edits = Array.Empty<WriteRequest>() } };
+                var o = WritePatchBuilder.CreateRecords(r, rulebook, spec, dupPath, extend: true);
+                refused = !o.Success; error = o.Error;
+            }
+            bool namedBoth = error is not null && error.Contains(dup1.ToString()) && error.Contains(dup2.ToString());
+            bool untouched = before.AsSpan().SequenceEqual(File.ReadAllBytes(dupPath));
+            dupOk = refused && namedBoth && untouched;
+            Console.WriteLine($"   DUP residue refused naming copies   : {(dupOk ? $"PASS — both copies named ({dup1}, {dup2}), file untouched" : $"FAIL — refused={refused} namedBoth={namedBoth} untouched={untouched} error=[{error}]")}");
+        }
+
+        // --- LOCKED: a foreign no-delete-share handle on the target blocks the COMMIT; the failure must be loud,
+        //     the old file intact, the temp cleaned. ---
+        bool lockedOk = false;
+        {
+            byte[] before = File.ReadAllBytes(pPath);
+            bool failed; string? error;
+            using (new FileStream(pPath, FileMode.Open, FileAccess.Read, FileShare.Read))   // readers allowed, delete/replace blocked
+            using (var r = LoadOrderResolver.Build(new[] { mPath }))
+            {
+                var spec = new[] { new WritePatchBuilder.CreateSpec { RecordType = "Keyword", EditorId = "HcUpsGdKwLocked", Edits = Array.Empty<WriteRequest>() } };
+                var o = WritePatchBuilder.CreateRecords(r, rulebook, spec, pPath, extend: true);
+                failed = !o.Success; error = o.Error;
+            }
+            bool intact = before.AsSpan().SequenceEqual(File.ReadAllBytes(pPath));
+            bool noResidue = !Directory.EnumerateDirectories(tmpDir, ".housecarl-tmp", SearchOption.AllDirectories).Any();
+            bool named = error is not null && error.Contains("writing the patch after create failed", StringComparison.OrdinalIgnoreCase);
+            lockedOk = failed && named && intact && noResidue;
+            Console.WriteLine($"   LOCKED commit fails loud + intact   : {(lockedOk ? "PASS — loud refusal, old bytes intact, no temp residue" : $"FAIL — failed={failed} named={named} intact={intact} noResidue={noResidue} error=[{error}]")}");
+        }
+
+        Console.WriteLine();
+        bool pass = rerunOk && overrideOk && crossTypeOk && dupOk && lockedOk;
+        Console.WriteLine($"=== upsert-guard: {(pass ? "PASS" : "FAIL")} ===");
+        try { Directory.Delete(tmpDir, recursive: true); } catch { }
+        return pass ? 0 : 1;
+    }
+
+    /// <summary>Read the persisted HEDR.NextObjectID by reopening the file as a binary overlay (same helper shape
+    /// as formid-floor-guard).</summary>
+    static uint ReadDiskNextFormId(string path)
+    {
+        ISkyrimModGetter? ov = null;
+        try { ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE); return ov.ModHeader.Stats.NextFormID; }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+}

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -250,10 +250,17 @@ public static class WriteTools
         sb.Append("mod folder: ").Append(modFolder)
           .Append(o.Extended ? "\n" : "  — enable + sort it in MO2 to use the patch\n");
         sb.Append("masters: ").Append(o.Masters.Count == 0 ? "(none)" : string.Join(", ", o.Masters)).Append('\n');
-        sb.Append("created ").Append(o.Created.Count).Append(o.Created.Count == 1 ? " record:\n" : " records:\n");
+        var replacedCount = o.Created.Count(c => c.ReplacedExisting);
+        sb.Append("created ").Append(o.Created.Count).Append(o.Created.Count == 1 ? " record" : " records");
+        if (replacedCount > 0)
+            sb.Append(" (").Append(replacedCount).Append(replacedCount == 1 ? " REPLACED an existing record" : " REPLACED existing records")
+              .Append(" — same FormID kept, prior contents discarded)");
+        sb.Append(":\n");
         foreach (var c in o.Created)
         {
-            sb.Append("  ").Append(c.RecordType).Append(' ').Append(c.FormKey).Append("  ").Append(c.EditorId).Append('\n');
+            sb.Append("  ").Append(c.RecordType).Append(' ').Append(c.FormKey).Append("  ").Append(c.EditorId);
+            if (c.ReplacedExisting) sb.Append("  [REPLACED: this patch already defined this editorid — re-created fresh at the same FormID; prior contents, including any set_field edits since, were discarded]");
+            sb.Append('\n');
             foreach (var op in c.Ops)
                 sb.Append("      ").Append(op.Label).Append(op.After is not null ? "  -> " + op.After : "  -> applied").Append('\n');
         }


### PR DESCRIPTION
Lands the write-safety pair contributed in #44 (AlmightyChan — both underlying defects are real and verified), hardened to houseCARL's contract per independent adversarial review. Their commit is preserved as the base of this branch with authorship intact.

## What ships

**From #44 (verified, kept):**
- `create_record into=` re-runs now **replace** the patch's own same-EditorID record fresh at the **same FormKey** instead of appending duplicates (pre-fix: every re-run duplicated every record, FormIDs crept, external references went stale).
- `WritePatch` is now **atomic**: serialize into a `.housecarl-tmp` sibling staging dir, commit via same-volume rename — a crash mid-write can no longer tear a plugin, and MO2's folder watcher never sees a half-written file.

**Hardening added in review (3 must-fixes + 2 should-fixes):**
1. **Replace-eligibility guard** — only records the patch *itself defines* are replace-eligible. The contributed version matched carried **overrides** too and silently emitted a field-wiping override of the original plugin's record (demonstrated; reject-grade). An override collision now refuses loud and points at `set_field`/`bulk_apply`.
2. **Replaces are never silent (Q3)** — the upsert's `Replaced` flag was discarded; now carried on `CreatedRecord.ReplacedExisting` and rendered in the tool output (same FormID kept, prior contents discarded — including any interleaved `set_field` edits).
3. **Duplicate residue refuses loud** — 2+ same-EditorID copies (the old bug's own product) refuse naming every copy's FormKey instead of silently replacing the first.
4. **Truthful atomic-write comment** — the staged write does NOT relax the PR #24 handle discipline (a rename onto a mapped target fails like an in-place write); it buys crash-tear safety + a shrunken watcher window. The contributed comment claimed otherwise.
5. **Dead API split removed**, `InvokeRemove` bool-result checked, Phase-4 failure message covers serialize *and* commit.

## Proof
- New self-contained CI guard **`upsert-guard`** (5 arms: RERUN / OVERRIDE / CROSS-TYPE / DUP / LOCKED), teeth-proven: OVERRIDE + DUP go **RED against the unhardened contribution** (the master-blanking path reproduces under the guard), RERUN goes RED against pre-#44 main.
- Adjacent guards locally green: writelock-guard, formid-floor-guard, verify-loop-guard (14/14), snapshot-view-guard (22/22).
- Floor/counter invariants (HCBR-2026-06-09-04) and the PR #24 no-mapped-handle invariant preserved on both staged paths.

Closes #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)