### PR TITLE
Compile-tool import order: caller import_dirs outrank the vanilla auto-import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,3 +120,10 @@ jobs:
       # checkout; the end-to-end engine half (--source) needs game data and runs locally, not here.
       - name: Probe — polymorphic-element validator (VMAD arm fields + composes)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- vmad-poly-guard
+
+      # The compile tool's import ORDER is semantics (the CK compiler takes the FIRST matching .psc), so caller
+      # import_dirs must outrank the auto-added vanilla folder — else SKSE-extended copies of vanilla scripts lose
+      # to vanilla and extended calls fail despite the right folder being passed (spike findings §5.12, hit twice).
+      # The pure order arm fabricates its game layout (runs fully here); the real-compile shadow arm self-skips.
+      - name: Probe — compile-tool import order (import_dirs outrank vanilla)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- import-order-guard

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,8 @@ dev/
 ## match *.user.json, so this safety net keeps a dev run's local config out of the repo.
 *.user.json
 houseCARL.user.json
+
+## Probe scratch dirs (compile-probe / import-order-guard end-to-end arms create + delete these in
+## the repo root; a swallowed delete failure must not litter the tree as untracked noise).
+.compile-probe-gen/
+.import-order-probe-gen/

--- a/src/housecarl-generator/ImportOrderProbe.cs
+++ b/src/housecarl-generator/ImportOrderProbe.cs
@@ -1,0 +1,125 @@
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// Import-order guard — locks in the rule that caller-passed import_dirs OUTRANK the auto-added
+/// vanilla source folder in housecarl_compile_script's import list.
+///
+/// Why it matters: the CK compiler resolves every referenced script to the FIRST matching .psc
+/// across the import dirs, and mods routinely ship EXTENDED copies of vanilla sources (SKSE's
+/// Actor.psc/Game.psc/Form.psc above all). With vanilla ranked above the user's folders, the
+/// vanilla copy wins and any call to an extended function fails "not a function or does not exist"
+/// even though the user explicitly passed the right folder (measured twice during the PEX bulk
+/// gate, spike findings §5.12).
+///
+/// Two arms:
+///   1. PURE (always runs, CI-safe) — fabricates a fake game layout in temp (compiler path + a
+///      Data\Source\Scripts dir), drives the REAL <see cref="CompileTools.BuildImports"/>, and
+///      asserts the order contract: script's own folder FIRST, caller dirs NEXT, vanilla LAST,
+///      case-insensitive dedup, quote-trim.
+///   2. END-TO-END (self-skips without the real CK compiler) — the SKSE-shadow proof: an import
+///      dir carries a copy of vanilla Form.psc extended with a marker global function; a target
+///      script calls it. Compiled with the EXACT list BuildImports produced, the compile succeeds
+///      only if the user's dir outranks vanilla. A control compile WITHOUT the import dir must
+///      fail (proves the marker really resolves from the user's copy, not from vanilla).
+///
+/// Run: dotnet run --project src/housecarl-generator import-order-guard ["&lt;PapyrusCompiler.exe&gt;"]
+/// </summary>
+internal static class ImportOrderProbe
+{
+    // Aaron's known Steam compiler (same default as CompileProbe). Override via arg.
+    const string DefaultCompiler = @"E:\SteamLibrary\steamapps\common\Skyrim Special Edition\Papyrus Compiler\PapyrusCompiler.exe";
+
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" import-order guard — import_dirs outrank the vanilla auto-import");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        // ---- 1) PURE: order contract on the real BuildImports, fabricated game layout ----
+        Console.WriteLine("--- 1: BuildImports order contract (fabricated layout; always runs) ---");
+        var fake = Path.Combine(Path.GetTempPath(), "hc-import-order-guard-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var fakeCompiler = Path.Combine(fake, "game", "Papyrus Compiler", "PapyrusCompiler.exe");
+            var fakeVanilla = Path.Combine(fake, "game", "Data", "Source", "Scripts");
+            var scriptDir = Path.Combine(fake, "work");
+            var userA = Path.Combine(fake, "skse src");      // spaced path on purpose
+            var userB = Path.Combine(fake, "other");
+            foreach (var d in new[] { Path.GetDirectoryName(fakeCompiler)!, fakeVanilla, scriptDir, userA, userB })
+                Directory.CreateDirectory(d);
+
+            var got = CompileTools.BuildImports(scriptDir, fakeCompiler, $"\"{userA}\";{userB}");
+            Check(got.Count == 4, $"4 dirs assembled (got {got.Count}: {string.Join(" | ", got)})");
+            Check(got.Count > 0 && got[0].Equals(scriptDir, StringComparison.OrdinalIgnoreCase),
+                  "the script's own folder is FIRST");
+            var iVan = got.FindIndex(d => d.Equals(fakeVanilla, StringComparison.OrdinalIgnoreCase));
+            var iA = got.FindIndex(d => d.Equals(userA, StringComparison.OrdinalIgnoreCase));
+            var iB = got.FindIndex(d => d.Equals(userB, StringComparison.OrdinalIgnoreCase));
+            Check(iA >= 0, "quoted spaced import dir survives (quote-trim)");
+            Check(iVan == got.Count - 1, $"vanilla auto-import is LAST (index {iVan} of {got.Count - 1})");
+            Check(iA >= 0 && iB >= 0 && iVan > iA && iVan > iB,
+                  "every caller dir outranks the vanilla auto-import");
+
+            var dedup = CompileTools.BuildImports(scriptDir, fakeCompiler, scriptDir.ToUpperInvariant() + ";" + fakeVanilla);
+            Check(dedup.Count == 2, $"case-insensitive dedup holds (got {dedup.Count})");
+            // a caller re-passing the vanilla dir explicitly must not DEMOTE their other intent — it
+            // simply dedups; first occurrence wins positionally, which is the caller's slot.
+            var none = CompileTools.BuildImports(scriptDir, fakeCompiler, null);
+            Check(none.Count == 2 && none[^1].Equals(fakeVanilla, StringComparison.OrdinalIgnoreCase),
+                  "no import_dirs → own folder + vanilla, vanilla last");
+        }
+        finally { try { Directory.Delete(fake, recursive: true); } catch { /* temp scratch; non-fatal */ } }
+
+        // ---- 2) END-TO-END: the SKSE-shadow proof against the real compiler ----
+        Console.WriteLine();
+        Console.WriteLine("--- 2: real compile — extended vanilla copy in import_dirs must win ---");
+        var compiler = args.Length > 0 ? args[0] : DefaultCompiler;
+        var realVanilla = File.Exists(compiler)
+            ? Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(compiler))!, "Data", "Source", "Scripts")
+            : null;
+        if (realVanilla is null || !Directory.Exists(realVanilla) || !File.Exists(Path.Combine(realVanilla, "Form.psc")))
+        {
+            Console.WriteLine($"  SKIP  no compiler/vanilla sources at '{compiler}' (pass the PapyrusCompiler.exe path as an arg to run this layer)");
+        }
+        else
+        {
+            var work = Path.Combine(Environment.CurrentDirectory, ".import-order-probe-gen");
+            var extDir = Path.Combine(work, "ext");
+            var outDir = Path.Combine(work, "out");
+            Directory.CreateDirectory(extDir); Directory.CreateDirectory(outDir);
+            try
+            {
+                // the shadow: vanilla Form.psc + a marker global only OUR copy has
+                File.WriteAllText(Path.Combine(extDir, "Form.psc"),
+                    File.ReadAllText(Path.Combine(realVanilla, "Form.psc")) +
+                    "\nint Function HC_ImportOrderProbeExt() global\n    return 1\nEndFunction\n");
+                File.WriteAllText(Path.Combine(work, "HCImportOrderTarget.psc"),
+                    "Scriptname HCImportOrderTarget extends Quest\n\nint Function UseExt()\n    return Form.HC_ImportOrderProbeExt()\nEndFunction\n");
+
+                // the EXACT list the tool would assemble, ext dir passed as import_dirs
+                var imports = CompileTools.BuildImports(work, compiler, extDir);
+                var r = HousecarlCore.PapyrusCompile.CompileObject(compiler, "HCImportOrderTarget", imports, outDir);
+                Check(r.Ran, "compiler ran");
+                Check(r.Success && r.PexPath is not null,
+                      "extended copy WINS: target calling the marker function compiles" +
+                      (r.Success ? "" : $" (first error: {(r.Diagnostics.Count > 0 ? r.Diagnostics[0].ToString() : r.Stderr.Trim())})"));
+
+                // control: WITHOUT the ext dir the marker must be unknown (it is not in real vanilla)
+                var ctlImports = CompileTools.BuildImports(work, compiler, null);
+                var ctl = HousecarlCore.PapyrusCompile.CompileObject(compiler, "HCImportOrderTarget", ctlImports, outDir);
+                Check(ctl.Ran && !ctl.Success,
+                      "control without import_dirs FAILS (the marker resolves only from the caller's copy)");
+            }
+            finally { try { Directory.Delete(work, recursive: true); } catch { /* in-dir scratch; non-fatal */ } }
+        }
+
+        Console.WriteLine();
+        Console.WriteLine(fail == 0 ? "================ ALL PASS ================" : $"================ {fail} CHECK(S) FAILED ================");
+        return fail == 0 ? 0 : 1;
+    }
+}

--- a/src/housecarl-generator/ImportOrderProbe.cs
+++ b/src/housecarl-generator/ImportOrderProbe.cs
@@ -67,11 +67,20 @@ internal static class ImportOrderProbe
 
             var dedup = CompileTools.BuildImports(scriptDir, fakeCompiler, scriptDir.ToUpperInvariant() + ";" + fakeVanilla);
             Check(dedup.Count == 2, $"case-insensitive dedup holds (got {dedup.Count})");
-            // a caller re-passing the vanilla dir explicitly must not DEMOTE their other intent — it
-            // simply dedups; first occurrence wins positionally, which is the caller's slot.
+            // PR #46 review pin: a caller re-passing the auto-added vanilla dir (defensively, ahead of
+            // their real dirs) must NOT pin vanilla into the caller slot and resurrect the shadowing —
+            // the auto-vanilla is authoritative-LAST regardless of where the caller listed it.
+            var repass = CompileTools.BuildImports(scriptDir, fakeCompiler, fakeVanilla + ";" + userB);
+            Check(repass.Count == 3 && repass[^1].Equals(fakeVanilla, StringComparison.OrdinalIgnoreCase)
+                  && repass[1].Equals(userB, StringComparison.OrdinalIgnoreCase),
+                  "re-passed vanilla stays LAST; the caller's real dir keeps the caller slot");
             var none = CompileTools.BuildImports(scriptDir, fakeCompiler, null);
             Check(none.Count == 2 && none[^1].Equals(fakeVanilla, StringComparison.OrdinalIgnoreCase),
                   "no import_dirs → own folder + vanilla, vanilla last");
+            // script ITSELF in the vanilla folder: the own-folder slot survives (vanilla == scriptDir).
+            var inVan = CompileTools.BuildImports(fakeVanilla, fakeCompiler, userB);
+            Check(inVan.Count == 2 && inVan[0].Equals(fakeVanilla, StringComparison.OrdinalIgnoreCase),
+                  "script inside the vanilla folder keeps its own-folder slot first");
         }
         finally { try { Directory.Delete(fake, recursive: true); } catch { /* temp scratch; non-fatal */ } }
 

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -56,6 +56,10 @@ if (args.Length > 0 && args[0] == "verify-loop-guard") return VerifyLoopProbe.Ru
 // pass pre-flight; non-arm fields/specs still reject named. --source <Skyrim.esm> adds the end-to-end engine proof.
 if (args.Length > 0 && args[0] == "vmad-poly-guard") return VmadPolyProbe.RunGuard(args[1..]);
 
+// Compile-tool import order: caller import_dirs OUTRANK the vanilla auto-import (first match wins, so
+// SKSE-extended copies of vanilla sources must win). Pure order arm always runs; real-compile arm self-skips.
+if (args.Length > 0 && args[0] == "import-order-guard") return ImportOrderProbe.RunGuard(args[1..]);
+
 // One-shot verify (decision #1): confirm the xEdit 4-char signature reflection path.
 if (args.Length > 0 && args[0] == "sig") return Probe.RunSig();
 

--- a/src/housecarl-mcp/CompileTools.cs
+++ b/src/housecarl-mcp/CompileTools.cs
@@ -21,7 +21,8 @@ public static class CompileTools
          "houseCARL patch-mod folder you review and enable in MO2 (originals untouched). Pass script= the full path to the " +
          ".psc to compile; houseCARL adds the script's own folder and the vanilla source folder (derived from the compiler's " +
          "game dir) to the import path automatically — pass import_dirs= (';'-separated) for any extra dependency sources " +
-         "(SKSE, other mods). On a compile FAILURE it returns the per-line errors as 'name(line,col): message' so you can fix " +
+         "(SKSE, other mods); your folders are searched BEFORE the vanilla sources, so mod-extended copies of vanilla " +
+         "scripts (SKSE's Actor.psc etc.) win. On a compile FAILURE it returns the per-line errors as 'name(line,col): message' so you can fix " +
          "the .psc and recompile (look unfamiliar functions up with the papyrus-reference skill); on SUCCESS it returns the " +
          ".pex path. Needs houseCARL pointed at your MO2 instance (for the output folder) and the Papyrus compiler path — if " +
          "the compiler isn't set yet, houseCARL tells you exactly what to ask for and how to set it. The CK compiler ships " +
@@ -31,7 +32,7 @@ public static class CompileTools
         ToolPathResolver bridge,
         [Description("Full path to the .psc source file to compile.")]
             string script,
-        [Description("Optional. Extra import directories where dependency sources (.psc) live — SKSE, other mods — separated by ';'. The script's own folder and the vanilla source folder are added automatically.")]
+        [Description("Optional. Extra import directories where dependency sources (.psc) live — SKSE, other mods — separated by ';'. The script's own folder and the vanilla source folder are added automatically; your directories are searched before vanilla (first match wins), so extended copies of vanilla scripts take precedence.")]
             string? import_dirs = null,
         [Description("Optional. Base name for the NEW patch-mod folder the .pex lands in (default 'houseCARL_Scripts'); auto-suffixed if taken.")]
             string? patch_name = null,
@@ -56,19 +57,8 @@ public static class CompileTools
         // 3) the compiler — bridge forcing function if unset (returns the trained prompt to surface).
         if (bridge.RequireOrPrompt(ToolDependency.PapyrusCompiler, out var compilerExe) is { } toolPrompt) return toolPrompt;
 
-        // 4) import dirs: the script's own folder + the vanilla sources (derived from the compiler's game dir:
-        //    <game>\Papyrus Compiler\PapyrusCompiler.exe → <game>\Data\Source\Scripts, which also holds the flags file) + caller extras.
-        var imports = new List<string> { scriptDir };
-        var gameRoot = Path.GetDirectoryName(Path.GetDirectoryName(compilerExe!));
-        if (gameRoot is not null)
-        {
-            var vanilla = Path.Combine(gameRoot, "Data", "Source", "Scripts");
-            if (Directory.Exists(vanilla)) imports.Add(vanilla);
-        }
-        if (!string.IsNullOrWhiteSpace(import_dirs))
-            foreach (var d in import_dirs.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-                imports.Add(d.Trim('"'));
-        imports = imports.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        // 4) import dirs — assembled by BuildImports (the guard-probed seam).
+        var imports = BuildImports(scriptDir, compilerExe!, import_dirs);
 
         // 5) output folder (folder-per-patch, Scripts\ subdir).
         string outDir;
@@ -79,6 +69,32 @@ public static class CompileTools
         var result = HousecarlCore.PapyrusCompile.CompileObject(compilerExe!, objectName, imports, outDir);
         return Render(result, imports);
     });
+
+    /// <summary>
+    /// Assemble the compiler's import-directory list. The CK compiler resolves each referenced script
+    /// to the FIRST matching .psc across these directories in order, so order is semantics: the
+    /// script's own folder first, then CALLER extras, then the vanilla sources LAST (derived from the
+    /// compiler's game dir: &lt;game&gt;\Papyrus Compiler\PapyrusCompiler.exe → &lt;game&gt;\Data\Source\Scripts,
+    /// which also holds the flags file). Vanilla last is load-bearing: mods ship EXTENDED copies of
+    /// vanilla sources (SKSE's Actor.psc/Game.psc/Form.psc above all) — ranked above the caller's
+    /// dirs, the vanilla copy wins and every call to an extended function fails "not a function or
+    /// does not exist" despite the user passing the right folder (the PEX bulk gate hit this twice;
+    /// spike findings §5.12). Exposed as the import-order-guard probe's seam.
+    /// </summary>
+    public static List<string> BuildImports(string scriptDir, string compilerExe, string? import_dirs)
+    {
+        var imports = new List<string> { scriptDir };
+        if (!string.IsNullOrWhiteSpace(import_dirs))
+            foreach (var d in import_dirs.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                imports.Add(d.Trim('"'));
+        var gameRoot = Path.GetDirectoryName(Path.GetDirectoryName(compilerExe));
+        if (gameRoot is not null)
+        {
+            var vanilla = Path.Combine(gameRoot, "Data", "Source", "Scripts");
+            if (Directory.Exists(vanilla)) imports.Add(vanilla);
+        }
+        return imports.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+    }
 
     static string Render(HousecarlCore.CompileResult r, IReadOnlyList<string> imports)
     {

--- a/src/housecarl-mcp/CompileTools.cs
+++ b/src/housecarl-mcp/CompileTools.cs
@@ -91,7 +91,16 @@ public static class CompileTools
         if (gameRoot is not null)
         {
             var vanilla = Path.Combine(gameRoot, "Data", "Source", "Scripts");
-            if (Directory.Exists(vanilla)) imports.Add(vanilla);
+            if (Directory.Exists(vanilla))
+            {
+                // The auto-added vanilla dir is authoritative-LAST: a caller re-passing it (defensively,
+                // not knowing it's auto-added) must not pin it into the caller slot and resurrect the
+                // shadowing — Distinct keeps the FIRST occurrence. (When the script ITSELF lives in the
+                // vanilla folder, that slot is the own-folder slot and stays.)
+                imports.RemoveAll(d => d.Equals(vanilla, StringComparison.OrdinalIgnoreCase)
+                                       && !d.Equals(scriptDir, StringComparison.OrdinalIgnoreCase));
+                imports.Add(vanilla);
+            }
         }
         return imports.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
     }


### PR DESCRIPTION
## What

`housecarl_compile_script` assembled its import list as **own folder → vanilla → caller `import_dirs`**. The CK compiler takes the FIRST matching `.psc` per referenced script, and mods routinely ship extended copies of vanilla sources (SKSE's `Actor.psc`/`Game.psc`/`Form.psc` above all) — so the vanilla copy shadowed the extended one and any call to an extended function failed `not a function or does not exist`, even though the user explicitly passed the right folder. The PEX bulk gate hit exactly this twice (spike findings §5.12 named it a tool-improvement candidate).

## Fix

The assembly is extracted into `CompileTools.BuildImports` (the guard's seam) and reordered: **own folder → caller `import_dirs` → vanilla LAST**. Explicit beats implicit — and taking the mod's copy over vanilla's matches what the game itself does at runtime. Tool + parameter descriptions now state the precedence.

## Proof — `import-order-guard` (new CI step)

- **Pure arm (runs fully in CI):** fabricates a fake game layout in temp (compiler path + `Data\Source\Scripts`), drives the real `BuildImports`, asserts: own folder first, every caller dir above vanilla, vanilla last, case-insensitive dedup, quoted spaced paths survive.
- **End-to-end arm (self-skips without the CK compiler):** stages a copy of vanilla `Form.psc` extended with a marker global function in an `import_dirs` folder; a target script calls it; compiled through the EXACT list `BuildImports` produced. Plus an inverse control: without the import dir the compile must fail (the marker resolves only from the caller's copy).
- **Teeth (RED on the unfixed order):** pure arm failed both order checks (vanilla at index 1) and the real compiler reproduced the exact failure class — `HC_ImportOrderProbeExt is not a function or does not exist`. After the reorder: ALL PASS on both arms; the existing `compile-probe` regression stays green.

## Behavior change, named

The only observable change is when the SAME script name exists in both a caller dir and vanilla — and in that case the old pick was the wrong one. No-`import_dirs` calls are byte-identical in behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
