### PR TITLE
BSA bridge contract: unpack/pack provenance, list guard, path + format refusals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,3 +134,11 @@ jobs:
       # is the DECOMPILE side; the recompile round-trip proof is the dev-side bulk gate (no CK compiler on runners).
       - name: Probe — decompile tool (fixture fidelity + output contract)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- decompile-guard
+
+      # BSA bridge contract guard (2026-06-12 adversarial hunt) — self-contained, BSArch NOT needed: the failing-
+      # BSArch stand-in is a copy of the runner's own where.exe (runs, errors, writes nothing). Locks in: unpack
+      # success = entries created/changed THIS RUN (the managed flow's pre-seeded meta.ini no longer reads as a
+      # successful extract — the false-success both hunters proved), pack provenance (a stuck stale scratch refuses
+      # loud; a fresh-run mtime gates the move; the prior archive always survives), and format-token refusal.
+      - name: Probe — BSA bridge contract (unpack/pack provenance, self-contained)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- bsa-contract-guard

--- a/src/housecarl-core/BsaArchive.cs
+++ b/src/housecarl-core/BsaArchive.cs
@@ -11,8 +11,10 @@ public sealed record BsaListResult(
     public bool Ran => RunError is null;
 }
 
-/// <summary>The result of a BSArch unpack/pack. <see cref="RunError"/> non-null ⇒ BSArch couldn't be run; otherwise
-/// <see cref="Success"/> is decided by the ARTIFACT (dest has files / the .bsa exists), not the exit code.</summary>
+/// <summary>The result of a BSArch unpack/pack. <see cref="RunError"/> non-null ⇒ the operation never ran BSArch
+/// (bad path / timeout / a stuck stale scratch refused up front); otherwise <see cref="Success"/> is decided by
+/// THIS-RUN artifact provenance (unpack: entries added or changed since the pre-run snapshot; pack: a fresh,
+/// non-empty scratch written at/after the run baseline), never by the exit code alone.</summary>
 public sealed record BsaResult(bool Success, string Raw, string? RunError)
 {
     public bool Ran => RunError is null;
@@ -105,9 +107,12 @@ public static class BsaArchive
     /// <summary>Pack <paramref name="srcFolder"/> into a .bsa at <paramref name="archive"/> with the given format flag
     /// (e.g. "-sse") and optional compression. NON-DESTRUCTIVE (Aaron 2026-06-06): an existing archive at the target is
     /// NEVER overwritten unless this run successfully packs a new one — BSArch writes to a houseCARL-internal temp beside
-    /// the target, and only a clean pack (temp exists, non-empty) is moved over the target; any failure (BSArch error,
-    /// timeout, empty output) deletes the temp and leaves the prior .bsa untouched. NOTE the caller must surface BSArch's
-    /// caveat: a COMPRESSED archive breaks any sounds/voices it contains.</summary>
+    /// the target, and only a clean pack THIS RUN (temp exists, non-empty, AND written at/after the run's mtime baseline)
+    /// is moved over the target; a stale scratch from a previous run that cannot be removed REFUSES up front (nothing
+    /// runs, the prior .bsa untouched), and any failure (BSArch error, timeout, empty output, stale-mtime scratch)
+    /// deletes the temp and leaves the prior .bsa untouched. The mtime gate assumes an NTFS-class timestamp resolution —
+    /// on a FAT-class target a same-second pack could read as stale and fail LOUD (never falsely succeed). NOTE the
+    /// caller must surface BSArch's caveat: a COMPRESSED archive breaks any sounds/voices it contains.</summary>
     public static BsaResult Pack(string bsarchExe, string srcFolder, string archive, string formatFlag, bool compress, int timeoutMs = 600_000)
     {
         // Pack to a scratch sibling (keeps the .bsa extension so BSArch is happy); the real target is touched only on success.

--- a/src/housecarl-core/BsaArchive.cs
+++ b/src/housecarl-core/BsaArchive.cs
@@ -54,15 +54,52 @@ public static class BsaArchive
         return new BsaListResult(files.Count == declared, format, declared, files, run.stdout, null);
     }
 
-    /// <summary>Unpack the WHOLE archive into <paramref name="destFolder"/> (created if absent). Success = the folder has
-    /// at least one entry afterwards (BSArch's exit code isn't relied on). "Read a file inside" = unpack, then read it.</summary>
+    /// <summary>Unpack the WHOLE archive into <paramref name="destFolder"/> (created if absent). Success = THIS RUN
+    /// added or changed entries, not "the folder is non-empty afterwards": the managed flow PRE-SEEDS the folder (the
+    /// meta.ini ownership marker is written before BSArch runs) and a caller-supplied dest may hold anything, so the
+    /// old test was satisfiable with zero extracted files and reported every BSArch failure as a successful extract
+    /// (2026-06-12 adversarial hunt, MUST-FIX). New entries are detected by PATH (robust to extractors that restore
+    /// archived timestamps); changed ones by size/mtime. Honest residual edge: re-extracting byte-identical content
+    /// over an existing dest with restored timestamps can read as "nothing new" — that direction fails LOUD with
+    /// BSArch's raw output attached, never falsely succeeds. "Read a file inside" = unpack, then read it.</summary>
     public static BsaResult Unpack(string bsarchExe, string archive, string destFolder, int timeoutMs = 300_000)
     {
         Directory.CreateDirectory(destFolder);
+        var before = SnapshotEntries(destFolder);
         var run = Run(bsarchExe, new[] { "unpack", archive, destFolder, "-mt" }, timeoutMs);
         if (run.runError is not null) return new BsaResult(false, (run.stdout + run.stderr).Trim(), run.runError);
-        bool ok = Directory.Exists(destFolder) && Directory.EnumerateFileSystemEntries(destFolder).Any();
+        bool ok = AnyNewOrChangedEntries(destFolder, before);
         return new BsaResult(ok, (run.stdout + "\n" + run.stderr).Trim(), null);
+    }
+
+    /// <summary>Snapshot a folder's files (recursive): relative path → (size, mtimeUtc). The Unpack provenance
+    /// baseline — and the bsa-contract-guard probe's seam.</summary>
+    public static Dictionary<string, (long Size, DateTime MtimeUtc)> SnapshotEntries(string folder)
+    {
+        var map = new Dictionary<string, (long, DateTime)>(StringComparer.OrdinalIgnoreCase);
+        if (!Directory.Exists(folder)) return map;
+        foreach (var f in Directory.EnumerateFiles(folder, "*", SearchOption.AllDirectories))
+        {
+            var fi = new FileInfo(f);
+            map[Path.GetRelativePath(folder, f)] = (fi.Length, fi.LastWriteTimeUtc);
+        }
+        return map;
+    }
+
+    /// <summary>Did anything appear or change under <paramref name="folder"/> since <paramref name="before"/>?
+    /// A path absent from the baseline = new (timestamp-independent); a present path with a different size or
+    /// mtime = changed.</summary>
+    public static bool AnyNewOrChangedEntries(string folder, Dictionary<string, (long Size, DateTime MtimeUtc)> before)
+    {
+        if (!Directory.Exists(folder)) return false;
+        foreach (var f in Directory.EnumerateFiles(folder, "*", SearchOption.AllDirectories))
+        {
+            var rel = Path.GetRelativePath(folder, f);
+            if (!before.TryGetValue(rel, out var b)) return true;
+            var fi = new FileInfo(f);
+            if (fi.Length != b.Size || fi.LastWriteTimeUtc != b.MtimeUtc) return true;
+        }
+        return false;
     }
 
     /// <summary>Pack <paramref name="srcFolder"/> into a .bsa at <paramref name="archive"/> with the given format flag
@@ -76,13 +113,25 @@ public static class BsaArchive
         // Pack to a scratch sibling (keeps the .bsa extension so BSArch is happy); the real target is touched only on success.
         var dir = Path.GetDirectoryName(archive) ?? Environment.CurrentDirectory;
         var tmp = Path.Combine(dir, Path.GetFileNameWithoutExtension(archive) + ".houseCARL-tmp.bsa");
-        try { if (File.Exists(tmp)) File.Delete(tmp); } catch { /* stale internal scratch; best-effort */ }
+        try { if (File.Exists(tmp)) File.Delete(tmp); } catch { /* checked next — a stuck scratch refuses loud */ }
+        if (File.Exists(tmp))
+            // A stale scratch from a previous run that we cannot remove: packing over it would let
+            // "tmp exists and is non-empty" pass on the PREVIOUS run's bytes when BSArch fails this
+            // run — a false success that ships wrong content over the target (2026-06-12 adversarial
+            // hunt). Refuse loud instead; nothing is packed, the prior archive is untouched.
+            return new BsaResult(false, "",
+                $"a stale houseCARL scratch from a previous run is stuck at '{tmp}' and could not be removed " +
+                "(another process may hold it). Delete it and retry — this run packed nothing; the existing archive, if any, is untouched.");
+        var baselineUtc = DateTime.UtcNow;
 
         var args = new List<string> { "pack", srcFolder, tmp, formatFlag, "-mt" };
         if (compress) args.Add("-z");
         var run = Run(bsarchExe, args, timeoutMs);
 
-        bool packed = run.runError is null && File.Exists(tmp) && new FileInfo(tmp).Length > 0;
+        // Provenance: THIS run must have written the scratch (mtime at/after the pre-run baseline) —
+        // existence alone proved nothing about who made it.
+        bool packed = run.runError is null && File.Exists(tmp) && new FileInfo(tmp).Length > 0
+                      && File.GetLastWriteTimeUtc(tmp) >= baselineUtc;
         if (!packed)   // BSArch couldn't run, or produced no/empty output — leave any prior archive untouched
         {
             try { if (File.Exists(tmp)) File.Delete(tmp); } catch { /* best-effort */ }
@@ -98,20 +147,26 @@ public static class BsaArchive
         return new BsaResult(File.Exists(archive) && new FileInfo(archive).Length > 0, (run.stdout + "\n" + run.stderr).Trim(), null);
     }
 
-    /// <summary>Map a houseCARL format token to a BSArch flag. Default/unknown → -sse (Skyrim Special Edition, the target).</summary>
-    public static string FormatFlag(string? format) => "-" + ((format?.Trim().ToLowerInvariant()) switch
+    /// <summary>The legal format tokens, for refusal messages.</summary>
+    public const string FormatTokens = "sse (default), tes3/morrowind, tes4/oblivion, fo3, fnv, tes5/le/skyrimle, fo4, fo4dds, sf1/starfield, sf1dds";
+
+    /// <summary>Map a houseCARL format token to a BSArch flag. Null/empty/sse-family = the -sse default (Skyrim SE,
+    /// the target). An UNKNOWN token returns null — the caller refuses loud naming <see cref="FormatTokens"/> —
+    /// instead of silently packing -sse from a typo (Q3: a silently degraded mode; 2026-06-12 adversarial hunt).</summary>
+    public static string? TryFormatFlag(string? format) => (format?.Trim().ToLowerInvariant()) switch
     {
-        "tes3" or "morrowind" => "tes3",
-        "tes4" or "oblivion" => "tes4",
-        "fo3" => "fo3",
-        "fnv" => "fnv",
-        "tes5" or "le" or "skyrimle" => "tes5",
-        "fo4" => "fo4",
-        "fo4dds" => "fo4dds",
-        "sf1" or "starfield" => "sf1",
-        "sf1dds" => "sf1dds",
-        _ => "sse",   // sse / ae / skyrimse / null / unknown → Skyrim SE
-    });
+        null or "" or "sse" or "ae" or "skyrimse" => "-sse",
+        "tes3" or "morrowind" => "-tes3",
+        "tes4" or "oblivion" => "-tes4",
+        "fo3" => "-fo3",
+        "fnv" => "-fnv",
+        "tes5" or "le" or "skyrimle" => "-tes5",
+        "fo4" => "-fo4",
+        "fo4dds" => "-fo4dds",
+        "sf1" or "starfield" => "-sf1",
+        "sf1dds" => "-sf1dds",
+        _ => null,
+    };
 
     static (bool ran, int exit, string stdout, string stderr, string? runError) Run(string exe, IReadOnlyList<string> args, int timeoutMs)
     {

--- a/src/housecarl-generator/BsaContractProbe.cs
+++ b/src/housecarl-generator/BsaContractProbe.cs
@@ -1,0 +1,113 @@
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// BSA bridge CONTRACT guard — self-contained (no BSArch needed): locks in the success/provenance
+/// contracts the 2026-06-12 adversarial hunt proved broken. The stand-in for a failing BSArch is a
+/// copy of Windows' own where.exe (present on every runner): it runs, errors, exits non-zero, and
+/// extracts/packs NOTHING — exactly the failure shape the old success tests mistook for success.
+///
+/// What it locks (each was a real finding):
+///   1. UNPACK PROVENANCE — the managed flow pre-seeds the dest folder (meta.ini ownership marker
+///      is written BEFORE BSArch runs), and the old success test was "folder non-empty afterwards":
+///      the marker alone satisfied it, so EVERY BSArch failure rendered as a successful extract
+///      (MUST-FIX; independently proven by two hunters). Success now = THIS RUN added or changed
+///      entries. Arms: pre-seeded dest must FAIL; non-empty caller dest must FAIL; the snapshot
+///      seam answers new-path / changed-mtime / changed-size / no-change correctly.
+///   2. PACK PROVENANCE — "tmp exists and is non-empty" proved nothing about WHO made it: a stale
+///      scratch from a previous run could ship as this run's archive. A stuck (undeletable) stale
+///      scratch now REFUSES loud before running; a fresh-run mtime baseline gates the move.
+///   3. FORMAT REFUSAL — an unknown format token used to coerce silently to -sse; TryFormatFlag
+///      now returns null for refusal (legal tokens keep their flags; the sse family defaults).
+///
+/// The real-BSArch behaviors (actual extraction, list output shapes) stay covered by bsa-probe,
+/// which self-skips without BSArch — THIS guard needs none.
+/// </summary>
+internal static class BsaContractProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" bsa contract guard — unpack/pack provenance + format refusal");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        var work = Path.Combine(Path.GetTempPath(), "hc-bsa-contract-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(work);
+        try
+        {
+            // the failing-BSArch stand-in: runs, errors to stderr, exits non-zero, writes nothing
+            var stub = Path.Combine(work, "bsarch.exe");
+            File.Copy(Path.Combine(Environment.SystemDirectory, "where.exe"), stub);
+            var fakeArchive = Path.Combine(work, "fake.bsa");
+            File.WriteAllBytes(fakeArchive, new byte[] { 0x42, 0x53, 0x41, 0x00 });
+
+            // ---- 1a) managed-flow shape: dest pre-seeded with the ownership marker ----
+            Console.WriteLine("--- 1: unpack provenance ---");
+            var seeded = Path.Combine(work, "seeded");
+            Directory.CreateDirectory(seeded);
+            File.WriteAllText(Path.Combine(seeded, "meta.ini"), "[houseCARL]\ngenerated=true\n");
+            var r1 = BsaArchive.Unpack(stub, fakeArchive, seeded, timeoutMs: 30_000);
+            Check(r1.Ran, "stub ran (the failure is BSArch's, not a run error)");
+            Check(!r1.Success, "pre-seeded dest + failing BSArch = FAILURE (the marker alone no longer reads as success)");
+
+            // ---- 1b) caller-dest shape: any non-empty folder ----
+            var lived = Path.Combine(work, "lived-in");
+            Directory.CreateDirectory(lived);
+            File.WriteAllText(Path.Combine(lived, "existing.txt"), "user content");
+            var r2 = BsaArchive.Unpack(stub, fakeArchive, lived, timeoutMs: 30_000);
+            Check(r2.Ran && !r2.Success, "non-empty caller dest + failing BSArch = FAILURE");
+
+            // ---- 1c) the snapshot seam: new / changed / unchanged ----
+            var seam = Path.Combine(work, "seam");
+            Directory.CreateDirectory(seam);
+            File.WriteAllText(Path.Combine(seam, "a.txt"), "one");
+            var snap = BsaArchive.SnapshotEntries(seam);
+            Check(!BsaArchive.AnyNewOrChangedEntries(seam, snap), "no change → no entries this run");
+            File.WriteAllText(Path.Combine(seam, "b.txt"), "two");
+            Check(BsaArchive.AnyNewOrChangedEntries(seam, snap), "a NEW path counts (timestamp-independent)");
+            File.Delete(Path.Combine(seam, "b.txt"));
+            File.WriteAllText(Path.Combine(seam, "a.txt"), "ONE+");
+            Check(BsaArchive.AnyNewOrChangedEntries(seam, snap), "a CHANGED existing file counts (size/mtime)");
+
+            // ---- 2) pack: stuck stale scratch refuses; target untouched ----
+            Console.WriteLine();
+            Console.WriteLine("--- 2: pack provenance ---");
+            var packDir = Path.Combine(work, "pack");
+            Directory.CreateDirectory(packDir);
+            var target = Path.Combine(packDir, "Out.bsa");
+            File.WriteAllText(target, "PRIOR ARCHIVE — must survive");
+            var stale = Path.Combine(packDir, "Out.houseCARL-tmp.bsa");
+            File.WriteAllText(stale, "STALE PREVIOUS-RUN BYTES");
+            using (File.Open(stale, FileMode.Open, FileAccess.Read, FileShare.None))   // lock it: the delete must fail
+            {
+                var rp = BsaArchive.Pack(stub, packDir, target, "-sse", compress: false, timeoutMs: 30_000);
+                Check(!rp.Success && !rp.Ran && (rp.RunError?.Contains("stale", StringComparison.OrdinalIgnoreCase) ?? false),
+                      "stuck stale scratch → loud refusal naming it (nothing packed)");
+            }
+            Check(File.ReadAllText(target) == "PRIOR ARCHIVE — must survive", "the prior archive is byte-untouched");
+            // unlocked stale: delete succeeds, stub packs nothing → honest failure, stale gone, target untouched
+            var rp2 = BsaArchive.Pack(stub, packDir, target, "-sse", compress: false, timeoutMs: 30_000);
+            Check(rp2.Ran && !rp2.Success, "deletable stale + failing BSArch = honest failure (no stale shipped)");
+            Check(File.ReadAllText(target) == "PRIOR ARCHIVE — must survive", "the prior archive survives that path too");
+
+            // ---- 3) format refusal ----
+            Console.WriteLine();
+            Console.WriteLine("--- 3: format tokens ---");
+            Check(BsaArchive.TryFormatFlag(null) == "-sse" && BsaArchive.TryFormatFlag("sse") == "-sse"
+                  && BsaArchive.TryFormatFlag("AE") == "-sse", "sse family + empty default to -sse");
+            Check(BsaArchive.TryFormatFlag("tes5") == "-tes5" && BsaArchive.TryFormatFlag("fo4dds") == "-fo4dds",
+                  "legal tokens map to their flags");
+            Check(BsaArchive.TryFormatFlag("fo4dd") is null && BsaArchive.TryFormatFlag("garbage") is null,
+                  "unknown tokens REFUSE (null) — no silent -sse from a typo");
+        }
+        finally { try { Directory.Delete(work, recursive: true); } catch { /* temp scratch */ } }
+
+        Console.WriteLine();
+        Console.WriteLine(fail == 0 ? "================ ALL PASS ================" : $"================ {fail} CHECK(S) FAILED ================");
+        return fail == 0 ? 0 : 1;
+    }
+}

--- a/src/housecarl-generator/BsaProbe.cs
+++ b/src/housecarl-generator/BsaProbe.cs
@@ -54,7 +54,7 @@ internal static class BsaProbe
             Check(onDisk == orig.DeclaredCount, $"unpack: files on disk == declared ({onDisk}/{orig.DeclaredCount})");
 
             // 3) PACK back (Skyrim SE, uncompressed)
-            var pk = BsaArchive.Pack(bsarch, unpacked, repacked, BsaArchive.FormatFlag("sse"), compress: false);
+            var pk = BsaArchive.Pack(bsarch, unpacked, repacked, BsaArchive.TryFormatFlag("sse")!, compress: false);
             Check(pk.Ran && pk.Success, "pack: ran + .bsa written");
             Check(File.Exists(repacked) && new FileInfo(repacked).Length > 0, "pack: output .bsa exists, non-empty");
 
@@ -68,7 +68,7 @@ internal static class BsaProbe
             //    good `repacked` from the round-trip; attempt a pack from a non-existent source to the SAME path and assert
             //    the prior archive survives byte-for-byte (the original is touched only by a clean, successful compaction).
             var beforeLen = new FileInfo(repacked).Length;
-            var failPack = BsaArchive.Pack(bsarch, Path.Combine(work, "no-such-source"), repacked, BsaArchive.FormatFlag("sse"), compress: false);
+            var failPack = BsaArchive.Pack(bsarch, Path.Combine(work, "no-such-source"), repacked, BsaArchive.TryFormatFlag("sse")!, compress: false);
             Check(!failPack.Success, "non-destructive: a pack from a missing source reports failure");
             Check(File.Exists(repacked) && new FileInfo(repacked).Length == beforeLen,
                   "non-destructive: the PRIOR archive is left intact after a failed pack");

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -56,6 +56,10 @@ if (args.Length > 0 && args[0] == "verify-loop-guard") return VerifyLoopProbe.Ru
 // pass pre-flight; non-arm fields/specs still reject named. --source <Skyrim.esm> adds the end-to-end engine proof.
 if (args.Length > 0 && args[0] == "vmad-poly-guard") return VmadPolyProbe.RunGuard(args[1..]);
 
+// BSA bridge contract guard (2026-06-12 adversarial hunt): unpack success = entries THIS RUN (the pre-seeded
+// meta.ini no longer reads as success), pack provenance (stuck stale scratch refuses), unknown format= refuses.
+if (args.Length > 0 && args[0] == "bsa-contract-guard") return BsaContractProbe.RunGuard(args[1..]);
+
 // Compile-tool import order: caller import_dirs OUTRANK the vanilla auto-import (first match wins, so
 // SKSE-extended copies of vanilla sources must win). Pure order arm always runs; real-compile arm self-skips.
 if (args.Length > 0 && args[0] == "import-order-guard") return ImportOrderProbe.RunGuard(args[1..]);

--- a/src/housecarl-mcp/BsaTools.cs
+++ b/src/housecarl-mcp/BsaTools.cs
@@ -28,14 +28,22 @@ public static class BsaTools
             int max_chars = 0) => Guard.Tool("housecarl_bsa_list", () =>
     {
         if (string.IsNullOrWhiteSpace(archive)) return "error: no archive given. Pass the full path to the .bsa.";
-        archive = archive.Trim().Trim('"');
+        // GetFullPath: BSArch resolves relative paths against ITS OWN folder (the child's working dir),
+        // not the server's — a relative path that passed File.Exists here could list a DIFFERENT
+        // same-named archive sitting beside BSArch (2026-06-12 adversarial hunt).
+        try { archive = Path.GetFullPath(archive.Trim().Trim('"')); }
+        catch (Exception ex) { return $"error: '{archive}' is not a usable path ({ex.Message})."; }
         if (!File.Exists(archive)) return $"error: no such file: '{archive}'.";
         if (bridge.RequireOrPrompt(ToolDependency.Bsarch, out var bsarch) is { } prompt) return prompt;
 
         var r = HousecarlCore.BsaArchive.List(bsarch!, archive);
         if (!r.Ran) return "error: " + r.RunError;
-        if (!r.Success && r.DeclaredCount == 0)
-            return $"error: BSArch could not read '{Path.GetFileName(archive)}' as an archive. Raw output:\n" + r.Raw;
+        if (!r.Success)
+            // Covers BOTH unreadable (no "Files: N" at all) and aborted-mid-list (declared N, listed
+            // fewer) — the old guard only caught the first, rendering "N file(s)" over an empty list.
+            return r.DeclaredCount == 0
+                ? $"error: BSArch could not read '{Path.GetFileName(archive)}' as an archive. Raw output:\n" + r.Raw
+                : $"error: BSArch declared {r.DeclaredCount} file(s) in '{Path.GetFileName(archive)}' but listed {r.Files.Count} — the listing aborted or the archive is damaged. Raw output:\n" + r.Raw;
 
         int cap = max_chars > 0 ? max_chars : 80_000;
         var sb = new StringBuilder();
@@ -65,7 +73,9 @@ public static class BsaTools
             string? dest = null) => Guard.Tool("housecarl_bsa_extract", () =>
     {
         if (string.IsNullOrWhiteSpace(archive)) return "error: no archive given. Pass the full path to the .bsa.";
-        archive = archive.Trim().Trim('"');
+        // GetFullPath: BSArch resolves relative paths against ITS OWN folder, not the server's (see BsaList).
+        try { archive = Path.GetFullPath(archive.Trim().Trim('"')); }
+        catch (Exception ex) { return $"error: '{archive}' is not a usable path ({ex.Message})."; }
         if (!File.Exists(archive)) return $"error: no such file: '{archive}'.";
         if (bridge.RequireOrPrompt(ToolDependency.Bsarch, out var bsarch) is { } prompt) return prompt;
 
@@ -85,7 +95,9 @@ public static class BsaTools
         var r = HousecarlCore.BsaArchive.Unpack(bsarch!, archive, target);
         if (!r.Ran) return "error: " + r.RunError;
         if (!r.Success)
-            return $"extract FAILED: '{Path.GetFileName(archive)}' produced no files in '{target}'. Raw BSArch output:\n" + r.Raw;
+            return $"extract FAILED: '{Path.GetFileName(archive)}' produced no new or changed files in '{target}' this run." +
+                   (managed ? $" The freshly created mod folder (with only houseCARL's meta.ini marker) was left at '{target}' — delete it or retry into it." : "") +
+                   "\nRaw BSArch output:\n" + r.Raw;
 
         var sb = new StringBuilder();
         sb.Append("extracted ").Append(Path.GetFileName(archive)).Append(" → ").Append(target).Append('\n');
@@ -134,7 +146,10 @@ public static class BsaTools
         catch (InvalidOperationException ex) { return "error: " + ex.Message; }
 
         var archive = Path.Combine(folder, name);
-        var fmtFlag = HousecarlCore.BsaArchive.FormatFlag(format);
+        // Unknown format tokens REFUSE (Q3): a typo like 'fo4dd' must not silently pack -sse.
+        var fmtFlag = HousecarlCore.BsaArchive.TryFormatFlag(format);
+        if (fmtFlag is null)
+            return $"error: unknown format '{format}'. Legal tokens: {HousecarlCore.BsaArchive.FormatTokens}.";
         var r = HousecarlCore.BsaArchive.Pack(bsarch!, source_folder, archive, fmtFlag, compress);
         if (!r.Ran) return "error: " + r.RunError;
         if (!r.Success)


### PR DESCRIPTION
## What

Pre-1.3.0 adversarial-hunt fixes for the BSA bridge — the headline proven independently by BOTH hunters:

**MUST-FIX: `housecarl_bsa_extract` could never report failure on the managed flow.** The patch-folder resolver writes the `meta.ini` ownership marker into the fresh folder *before* BSArch runs, and `Unpack`'s success test was "the folder has at least one entry afterwards" — the marker alone satisfied it, so every BSArch failure rendered as a successful extract. A caller-supplied non-empty `dest=` false-succeeded the same way. Success is now **this-run provenance**: a pre-run snapshot, success = a NEW path (timestamp-independent, robust to extractors restoring archived mtimes) or a CHANGED size/mtime. The honest residual edge (byte-identical re-extract over an existing dest with restored timestamps) fails LOUD with BSArch's raw output — never falsely succeeds. The failure message also names the leftover managed folder.

**Pack provenance:** "tmp exists and is non-empty" proved nothing about *who made it* — a stale scratch from a previous run whose re-delete also failed could be moved over the target as this run's archive. A stuck stale scratch now refuses loud before running (prior archive untouched); a fresh-run mtime baseline gates the move.

**Also:** `bsa_list` errors on ANY parse failure (the old guard only caught declared==0, letting "Files: 5" render over an empty list — the mismatch case now reports declared-vs-listed counts); archive paths are `GetFullPath`-normalized on list+extract (BSArch resolves relative paths against ITS OWN folder, so a relative path could silently list a *different* same-named archive sitting beside BSArch); unknown `format=` tokens refuse naming the legal set instead of silently packing `-sse` from a typo.

## Proof

`bsa-contract-guard` (new CI step, fully self-contained — the failing-BSArch stand-in is a copy of the runner's own `where.exe`: runs, errors, writes nothing): 13 checks covering both false-success shapes, the snapshot seam, the stuck-scratch refusal with the prior archive byte-untouched, and format refusals. **Teeth RED-proven:** the old success test restored → exactly the two false-success arms FAIL, exit 1; fix restored → ALL PASS. `bsa-probe` (real BSArch, self-skipping) updated to the new format API, otherwise untouched.

## Known remaining (named, not silent)

The `bsa_list` banner-absorption hazard (BSArch printing fewer paths than declared while ≥ declared non-empty lines exist) needs real-BSArch output shapes to fix safely — parse changes stay off-limits until a BSArch-equipped session can measure them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
