### PR TITLE
Hierarchy cache: derive paths before the build; first derivation invalidates (hunt F1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,3 +142,10 @@ jobs:
       # loud; a fresh-run mtime gates the move; the prior archive always survives), and format-token refusal.
       - name: Probe — BSA bridge contract (unpack/pack provenance, self-contained)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- bsa-contract-guard
+
+      # Hierarchy-cache lifecycle (2026-06-12 adversarial hunt F1, proven): a decompile-first session must not
+      # cache a baseline-only class-parents map for process lifetime — instance paths derive before the build
+      # (gate-then-parents lock order) and the first derivation invalidates any earlier cache. Self-contained:
+      # a synthetic MO2 instance in temp, no game data.
+      - name: Probe — hierarchy-cache lifecycle (decompile-first sees the mods tree)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- hierarchy-cache-guard

--- a/src/housecarl-generator/HierarchyCacheProbe.cs
+++ b/src/housecarl-generator/HierarchyCacheProbe.cs
@@ -1,0 +1,82 @@
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// Hierarchy-cache lifecycle guard (2026-06-12 adversarial hunt, F1 — proven): in instance mode the
+/// service derives ModsDir LAZILY, and the decompiler's class-parents cache is built on first use
+/// and held for process lifetime. A decompile-first session used to build the cache BEFORE ModsDir
+/// was derived — the mods-tree harvest (SKSE/PO3/… source headers) was skipped and the baseline-only
+/// map was cached for the whole process, with the degraded mode never named (the note only covers a
+/// missing baseline): a silent Q3 degradation of the tool's quality claim. The PR #47 review fix
+/// invalidated the cache on SetInstance and the ini re-derive, but missed this third
+/// _modsDir-mutation site (EnsurePathsDerived).
+///
+/// Fixed two ways, both locked here: ClassParentsForDecompile derives the instance paths FIRST
+/// (under the service gate, the established gate→parents lock order), and the first derivation
+/// itself invalidates any cache built before it. Self-contained: synthesizes a minimal MO2 instance
+/// (ModOrganizer.ini + profile files + a mod shipping one .psc header) in temp — no game data.
+/// </summary>
+internal static class HierarchyCacheProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" hierarchy-cache guard — decompile-first must see the mods tree");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        var root = Path.Combine(Path.GetTempPath(), "hc-hierarchy-guard-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            // ---- minimal synthetic MO2 instance (the established synth-instance pattern) ----
+            string instance = Path.Combine(root, "instance");
+            string profiles = Path.Combine(instance, "profiles", "Default");
+            string mods = Path.Combine(instance, "mods");
+            string data = Path.Combine(root, "game", "Data");
+            Directory.CreateDirectory(profiles); Directory.CreateDirectory(mods); Directory.CreateDirectory(data);
+            File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+                "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+                + Path.Combine(root, "game").Replace(@"\", @"\\") + ")\r\n");
+            File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n");
+            File.WriteAllText(Path.Combine(profiles, "plugins.txt"), "");
+            File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+SourceMod\r\n");
+            var srcDir = Path.Combine(mods, "SourceMod", "scripts", "source");
+            Directory.CreateDirectory(srcDir);
+            File.WriteAllText(Path.Combine(srcDir, "HcGuardChild.psc"), "ScriptName HcGuardChild extends HcGuardParent\r\n");
+
+            // ---- the decompile-first flow: hierarchy is the FIRST service touch of the process ----
+            Console.WriteLine("--- 1: hierarchy requested before any path derivation ---");
+            {
+                var store = new UserConfigStore(Path.Combine(root, "userA.json"));
+                using var svc = LoadOrderService.WithInstance(instance, 0, store);
+                var (edges, _) = svc.ClassParentsForDecompile();
+                Check(edges.TryGetValue("HcGuardChild", out var p1) && p1 == "HcGuardParent",
+                      "FIRST call already sees the mods-tree edge (paths derive before the build)");
+                var outDir = svc.ResolveDecompiledSourceFolder(null, null);
+                Check(outDir.StartsWith(mods, StringComparison.OrdinalIgnoreCase), "output folder resolves under the instance's mods dir");
+                var (edges2, _) = svc.ClassParentsForDecompile();
+                Check(edges2.ContainsKey("HcGuardChild"), "the cache stays correct after derivation (no poisoned survivor)");
+            }
+
+            // ---- control: derive-first ordering keeps working ----
+            Console.WriteLine();
+            Console.WriteLine("--- 2: derive-first control ---");
+            {
+                var store = new UserConfigStore(Path.Combine(root, "userB.json"));
+                using var svc = LoadOrderService.WithInstance(instance, 0, store);
+                svc.ResolveDecompiledSourceFolder(null, null);
+                var (edges, _) = svc.ClassParentsForDecompile();
+                Check(edges.TryGetValue("HcGuardChild", out var p) && p == "HcGuardParent",
+                      "derive-first still sees the mods-tree edge");
+            }
+        }
+        finally { try { Directory.Delete(root, recursive: true); } catch { /* temp scratch */ } }
+
+        Console.WriteLine();
+        Console.WriteLine(fail == 0 ? "================ ALL PASS ================" : $"================ {fail} CHECK(S) FAILED ================");
+        return fail == 0 ? 0 : 1;
+    }
+}

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -60,6 +60,10 @@ if (args.Length > 0 && args[0] == "vmad-poly-guard") return VmadPolyProbe.RunGua
 // meta.ini no longer reads as success), pack provenance (stuck stale scratch refuses), unknown format= refuses.
 if (args.Length > 0 && args[0] == "bsa-contract-guard") return BsaContractProbe.RunGuard(args[1..]);
 
+// Hierarchy-cache lifecycle (2026-06-12 hunt F1): a decompile-first session must NOT cache a baseline-only
+// class-parents map for process lifetime — paths derive before the build; the first derivation invalidates.
+if (args.Length > 0 && args[0] == "hierarchy-cache-guard") return HierarchyCacheProbe.RunGuard(args[1..]);
+
 // Compile-tool import order: caller import_dirs OUTRANK the vanilla auto-import (first match wins, so
 // SKSE-extended copies of vanilla sources must win). Pure order arm always runs; real-compile arm self-skips.
 if (args.Length > 0 && args[0] == "import-order-guard") return ImportOrderProbe.RunGuard(args[1..]);

--- a/src/housecarl-mcp/DecompileTools.cs
+++ b/src/housecarl-mcp/DecompileTools.cs
@@ -68,7 +68,14 @@ public static class DecompileTools
         if (pexFile.Objects.Count == 0)
             return $"error: '{Path.GetFileName(pex)}' contains no script objects — no output was written.";
 
-        // 4) class hierarchy: cached vanilla baseline + mods-tree sources, topped up with the input pex itself
+        // 4) output folder (folder-per-patch, Source\Scripts subdir) — resolved BEFORE the hierarchy build so a
+        //    folder-resolution error costs nothing, and the instance paths are derived before the cached walk
+        //    (defense in depth for hunt F1; the service also self-derives now).
+        string outDir;
+        try { outDir = svc.ResolveDecompiledSourceFolder(patch_name, into); }
+        catch (InvalidOperationException ex) { return "error: " + ex.Message; }
+
+        // 5) class hierarchy: cached vanilla baseline + mods-tree sources, topped up with the input pex itself
         //    and its sibling .pex files (every pex declares its own parent). Soft input — missing pieces mean
         //    explicit casts in the output, never wrong code. A missing/corrupt BASELINE is named in the
         //    result; the runtime top-ups degrade silently to fewer edges (purely cosmetic).
@@ -77,12 +84,6 @@ public static class DecompileTools
         HousecarlCore.PapyrusClassParents.AddFromPex(edges, pexFile);
         try { HousecarlCore.PapyrusClassParents.AddFromPexFolder(edges, Path.GetDirectoryName(pex)!); }
         catch { /* fewer edges, never fatal */ }
-
-        // 5) output folder (folder-per-patch, Source\Scripts subdir) — resolved BEFORE decompiling so a
-        //    folder-resolution error costs nothing.
-        string outDir;
-        try { outDir = svc.ResolveDecompiledSourceFolder(patch_name, into); }
-        catch (InvalidOperationException ex) { return "error: " + ex.Message; }
 
         // 6) decompile + write (the guard-probed seam).
         var o = WriteObjects(pexFile, edges, outDir);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -236,6 +236,7 @@ public sealed class LoadOrderService : IDisposable
         var p = Mo2Instance.Resolve(_instanceDir);               // throws (Q3) naming the missing piece if not a usable instance
         _profileDir = p.ProfileDir; _modsDir = p.ModsDir; _dataDir = p.DataDir; _profileName = p.ProfileName;
         _iniReadUtc = iniReadUtc;
+        InvalidateClassParents();                                // _modsDir just gained a value — a cache built before derivation is baseline-only (hunt F1)
     }
 
     static bool PathEq(string a, string b) =>
@@ -879,9 +880,17 @@ public sealed class LoadOrderService : IDisposable
     /// headers across the MO2 mods tree (mods that ship sources — SKSE, PO3, …). Built on FIRST decompile call,
     /// cached for process lifetime (a SOFT input by construction: missing pieces = explicit casts in the output,
     /// never wrong code — the note names any degraded mode, Q3). The input pex's own folder is topped up per call
-    /// by the tool, not here (it varies per input).</summary>
+    /// by the tool, not here (it varies per input). Paths derive FIRST (under the gate — the established
+    /// gate→parents lock order): in instance mode ModsDir is lazy, and a decompile-first session used to build
+    /// and cache the baseline-only map for process lifetime with the mods-tree harvest silently skipped
+    /// (2026-06-12 adversarial hunt F1, proven — the third _modsDir-mutation site missed by the PR #47 fix).</summary>
     public (Dictionary<string, string> Edges, string? Note) ClassParentsForDecompile()
     {
+        lock (_gate)
+        {
+            try { EnsurePathsDerived(); }
+            catch { /* unusable instance: the tool's config gate reports it; here = fewer edges, never a throw */ }
+        }
         lock (_classParentsLock)
         {
             if (_classParents is null)


### PR DESCRIPTION
The adversarial hunt's proven must-fix in the day-old decompile surface: in
instance mode ModsDir derives LAZILY, and a decompile-first session built
the class-parents cache BEFORE derivation - the mods-tree harvest
(SKSE/PO3/... source headers) was skipped and the baseline-only map was
cached for PROCESS LIFETIME, with the degraded mode never named (the note
only covers a missing baseline). The PR #47 review fix invalidated the
cache on SetInstance and the ini re-derive but missed this third
_modsDir-mutation site (EnsurePathsDerived).

Fix, both layers:
- ClassParentsForDecompile derives the instance paths FIRST, under the
  service gate (gate->parents, the established lock order; an unusable
  instance is swallowed to fewer edges - the tool's config gate reports it
  separately). The cache can no longer be built against underived paths.
- EnsurePathsDerived invalidates the cache at the derivation point - any
  cache that somehow predates derivation dies with it.
- DecompileTools resolves the output folder BEFORE the hierarchy build
  (error ordering + defense in depth).

Guard: hierarchy-cache-guard, new CI step, self-contained (synthesizes a
minimal MO2 instance + one mod shipping a .psc header in temp; no game
data). RED-proven against the unfixed service: the first call missed the
mods-tree edge AND the cache stayed poisoned after derivation - exactly
the hunter's TEST A; fixed: ALL PASS, decompile-guard regression green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
