### PR TITLE
Pre-1.3.0 hardening: write-path mutex (F2), user.json atomicity (F3), orphan folders (F4), render wave

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,3 +149,12 @@ jobs:
       # a synthetic MO2 instance in temp, no game data.
       - name: Probe — hierarchy-cache lifecycle (decompile-first sees the mods tree)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- hierarchy-cache-guard
+
+      # Write-path mutex + orphan folders (2026-06-12 adversarial hunt F2+F4): the MCP SDK dispatches tool calls
+      # concurrently, so the whole resolve-stage-commit of every .esp write serializes on one service-level gate —
+      # concurrent writes get distinct outputs carrying their own bytes (no UniqueStem TOCTOU, no cross-commit
+      # through the fixed .housecarl-tmp staging path, no lost into= extend) — and a pre-flight-refused fresh
+      # write removes the folder it created ("NO patch written" is true of the disk; no _NNN accretion on retry).
+      # Self-contained: a synthetic MO2 instance + a synthesized master in temp.
+      - name: Probe — write-path mutex (concurrent writes serialize; refusals leave no orphan)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- write-mutex-guard

--- a/scripts/build-plugin.ps1
+++ b/scripts/build-plugin.ps1
@@ -75,8 +75,10 @@ if (-not (Test-Path $CorpusSrc)) { throw "corpus not produced at $CorpusSrc" }
 Write-Host ("corpus.json: {0:N1} MB" -f ((Get-Item $CorpusSrc).Length / 1MB))
 
 # ---- 2. publish the server (framework-dependent; trimming OFF) -------------
+# -p:Version stamps the plugin.json version into the exe, which ServerInfo reports over MCP
+# (one version home; an unstamped dev build says 0.0.0-dev).
 Step '2/10' 'Publish server (Release, win-x64, framework-dependent)'
-dotnet publish $McpProj -c Release -r win-x64 --self-contained false -o $ServerDir
+dotnet publish $McpProj -c Release -r win-x64 --self-contained false -p:Version=$Version -o $ServerDir
 if ($LASTEXITCODE -ne 0) { throw "publish failed (exit $LASTEXITCODE)" }
 $Exe = Join-Path $ServerDir 'housecarl-mcp.exe'
 if (-not (Test-Path $Exe)) { throw "server exe not produced at $Exe" }

--- a/src/housecarl-core/UserConfig.cs
+++ b/src/housecarl-core/UserConfig.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 
 namespace HousecarlCore;
@@ -22,54 +24,129 @@ public sealed class UserConfig
 
 /// <summary>
 /// The single OWNER of houseCARL.user.json — every read and write of that file goes through here, so the two independent
-/// writers (housecarl_set_mo2_instance, housecarl_set_tool_path) can never clobber each other's field. <see cref="Update"/>
-/// is read-modify-write under a process-wide lock on this store; <see cref="Load"/> is a TOLERANT read (a missing or
-/// corrupt file yields a blank config, never a crash — Q3). Best-effort + HONEST: a write failure (e.g. a read-only data
-/// dir) is RETURNED, not thrown or swallowed, so the calling tool can tell the user the choice won't survive a restart.
-/// One instance is registered as a singleton and shared by <see cref="LoadOrderService"/> + the tool bridge.
+/// writers (housecarl_set_mo2_instance, housecarl_set_tool_path) can never clobber each other's field. Hardened per the
+/// 2026-06-12 adversarial hunt (F3, hunter-PROVEN silent clobbers):
+///   • ATOMIC — <see cref="Update"/> serializes to a sibling temp file and renames it over the target (same volume),
+///     so a reader never sees a half-written file and a crash mid-write never corrupts the saved config.
+///   • CROSS-PROCESS — the read-modify-write runs under a NAMED mutex derived from the file path, so two server
+///     processes sharing the file (CLI plugin + desktop app) serialize instead of clobbering each other's field
+///     (the old gate was process-local only).
+///   • CORRUPT = LOUD — an unparseable file is BACKED UP beside itself (.corrupt.bak) and REPORTED via the returned
+///     note, never silently treated as blank (the old path silently wiped every saved setting on the next Update).
+/// Best-effort + HONEST: a write failure (e.g. a read-only data dir) is RETURNED, not thrown or swallowed, so the
+/// calling tool can tell the user the choice won't survive a restart. One instance is registered as a singleton and
+/// shared by <see cref="LoadOrderService"/> + the tool bridge.
 /// </summary>
 public sealed class UserConfigStore
 {
     readonly string _path;
-    readonly object _gate = new();
+    readonly object _gate = new();      // process-local fast path; the named mutex below adds the cross-process half
+    readonly Mutex _mutex;              // named per-file: CLI + desktop server processes serialize on the same config
     static readonly JsonSerializerOptions Json = new() { WriteIndented = true };
 
-    public UserConfigStore(string path) => _path = path;
+    public UserConfigStore(string path)
+    {
+        _path = path;
+        _mutex = new Mutex(initiallyOwned: false, MutexName(path));
+    }
 
     /// <summary>The file this store owns (for the tool confirmation / diagnostics).</summary>
     public string FilePath => _path;
 
-    /// <summary>Read the current config — a missing file or unparseable JSON yields a fresh blank <see cref="UserConfig"/>
-    /// (Q3: a corrupt user file never crashes boot or a tool; it reads as "nothing saved yet").</summary>
-    public UserConfig Load()
+    /// <summary>A stable, legal mutex name for the config file: same file (case-insensitively) ⇒ same mutex in any
+    /// process of this session. Local\ scope — both server hosts (CLI plugin, desktop app) run in the user's session.</summary>
+    static string MutexName(string path)
     {
-        lock (_gate) { return ReadOrBlank(); }
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(Path.GetFullPath(path).ToLowerInvariant()));
+        return "Local\\houseCARL-user-config-" + Convert.ToHexString(hash, 0, 12);
     }
 
-    /// <summary>Apply <paramref name="mutate"/> to the CURRENT on-disk config and write it back — the ONLY way the file is
-    /// written, so the two concerns merge instead of overwriting. Returns (ok, error): a write failure is reported, not
-    /// thrown, so the tool can surface "works this session, won't persist" (Q3). The mutate runs under the lock.</summary>
-    public (bool ok, string? error) Update(Action<UserConfig> mutate)
+    /// <summary>Run <paramref name="body"/> holding BOTH locks. An abandoned mutex (the other process died holding it)
+    /// counts as acquired — the file itself stays consistent because writes are atomic renames. A timeout proceeds
+    /// WITHOUT the cross-process half rather than deadlocking a tool call forever; the process-local gate still holds,
+    /// and the atomic rename bounds the damage to last-write-wins (never a torn file).</summary>
+    T WithLocks<T>(Func<T> body)
     {
         lock (_gate)
         {
-            try
-            {
-                var cfg = ReadOrBlank();
-                mutate(cfg);
-                var dir = Path.GetDirectoryName(_path);   // the data dir (${CLAUDE_PLUGIN_DATA}) may not exist on the first save
-                if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
-                File.WriteAllText(_path, JsonSerializer.Serialize(cfg, Json));
-                return (true, null);
-            }
-            catch (Exception ex) { return (false, ex.Message); }
+            bool taken = false;
+            try { taken = _mutex.WaitOne(TimeSpan.FromSeconds(10)); }
+            catch (AbandonedMutexException) { taken = true; }
+            try { return body(); }
+            finally { if (taken) _mutex.ReleaseMutex(); }
         }
     }
 
-    UserConfig ReadOrBlank()
+    /// <summary>Read the current config. A missing file yields a fresh blank <see cref="UserConfig"/>; a CORRUPT file is
+    /// backed up beside itself and reported via <paramref name="note"/> (Q3 — never silently "nothing saved yet"), then
+    /// also yields blank so a tool call still proceeds.</summary>
+    public UserConfig Load(out string? note)
     {
+        var (cfg, n) = WithLocks(() => { var c = ReadOrRecover(out var rn); return (c, rn); });
+        note = n;
+        return cfg;
+    }
+
+    /// <summary>Read the current config, discarding any recovery note — for callers that only need the values and a
+    /// later <see cref="Update"/> (which re-reports) or the boot path's noted Load owns the loudness.</summary>
+    public UserConfig Load() => Load(out _);
+
+    /// <summary>Apply <paramref name="mutate"/> to the CURRENT on-disk config and write it back ATOMICALLY (temp +
+    /// rename) — the ONLY way the file is written, so the two concerns merge instead of overwriting. Returns (ok, error,
+    /// note): a write failure is reported in <c>error</c>, not thrown (Q3 — "works this session, won't persist"); a
+    /// corrupt prior file is backed up and named in <c>note</c> even when the write itself succeeds, so a recovery is
+    /// never silent. The whole read-modify-write runs under the cross-process lock.</summary>
+    public (bool ok, string? error, string? note) Update(Action<UserConfig> mutate)
+    {
+        return WithLocks<(bool, string?, string?)>(() =>
+        {
+            string? note = null;
+            try
+            {
+                var cfg = ReadOrRecover(out note);
+                mutate(cfg);
+                var dir = Path.GetDirectoryName(_path);   // the data dir (${CLAUDE_PLUGIN_DATA}) may not exist on the first save
+                if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+                var tmp = _path + ".tmp";
+                File.WriteAllText(tmp, JsonSerializer.Serialize(cfg, Json));
+                File.Move(tmp, _path, overwrite: true);   // atomic on the same volume — a reader never sees a torn file
+                return (true, null, note);
+            }
+            catch (Exception ex) { return (false, ex.Message, note); }
+        });
+    }
+
+    /// <summary>The tolerant-but-LOUD read (hunt F3): missing ⇒ blank, parseable ⇒ as saved, CORRUPT ⇒ back the file up
+    /// beside itself (.corrupt.bak — kept until the user deletes it; re-copied while the corrupt file persists) and
+    /// return blank with a note naming the backup and what was lost. The corrupt original is COPIED, not moved, so a
+    /// read never destroys evidence; the next successful <see cref="Update"/> replaces it with a clean file.</summary>
+    UserConfig ReadOrRecover(out string? note)
+    {
+        note = null;
         if (!File.Exists(_path)) return new UserConfig();
-        try { return JsonSerializer.Deserialize<UserConfig>(File.ReadAllText(_path)) ?? new UserConfig(); }
-        catch { return new UserConfig(); }   // corrupt → treat as blank (Q3); a tool write then rewrites it clean
+        string text;
+        try { text = File.ReadAllText(_path); }
+        catch (Exception ex)
+        {
+            note = $"could not read '{_path}' ({ex.Message}) — proceeding as if nothing were saved; the file was left untouched.";
+            return new UserConfig();
+        }
+        try { return JsonSerializer.Deserialize<UserConfig>(text) ?? new UserConfig(); }
+        catch (Exception ex)
+        {
+            var backup = _path + ".corrupt.bak";
+            try
+            {
+                File.Copy(_path, backup, overwrite: true);
+                note = $"houseCARL.user.json was unreadable (corrupt JSON: {ex.Message}). The corrupt file was backed up to " +
+                       $"'{backup}'; previously saved settings (MO2 instance / tool paths) are NOT loaded and need re-saving.";
+            }
+            catch (Exception bex)
+            {
+                note = $"houseCARL.user.json is unreadable (corrupt JSON: {ex.Message}) AND backing it up failed ({bex.Message}). " +
+                       $"The corrupt file remains at '{_path}'; previously saved settings are NOT loaded.";
+            }
+            return new UserConfig();
+        }
     }
 }

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -178,7 +178,7 @@ public static class WritePatchBuilder
         if (extend)
         {
             if (!File.Exists(outPath))
-                return PatchOutcome.Fail($"cannot extend: no existing patch at {outPath}. Omit extend to create it fresh.");
+                return PatchOutcome.Fail($"cannot extend: no existing patch at {outPath}. Omit into= to create it fresh.");
             try { patchMod = SkyrimMod.CreateFromBinary(outPath, SkyrimRelease.SkyrimSE); }
             catch (Exception ex) { return PatchOutcome.Fail($"cannot open patch to extend ({fileName}): {ex.GetType().Name}: {ex.Message}"); }
         }
@@ -398,7 +398,7 @@ public static class WritePatchBuilder
         if (extend)
         {
             if (!File.Exists(outPath))
-                return CreateOutcome.Fail($"cannot extend: no existing patch at {outPath}. Omit extend to create it fresh.");
+                return CreateOutcome.Fail($"cannot extend: no existing patch at {outPath}. Omit into= to create it fresh.");
             try { patchMod = SkyrimMod.CreateFromBinary(outPath, SkyrimRelease.SkyrimSE); }
             catch (Exception ex) { return CreateOutcome.Fail($"cannot open patch to extend ({fileName}): {ex.GetType().Name}: {ex.Message}"); }
         }

--- a/src/housecarl-generator/BindingShimProbe.cs
+++ b/src/housecarl-generator/BindingShimProbe.cs
@@ -148,6 +148,16 @@ public static class BindingShimProbe
                 """{"type":"CELL","plugins":["Synthetic.esp"],"limit":{"oops":1}}""");
             failures += Check("G rewrite: an uncoercible argument fails NAMED, not generic",
                 !g.text.Contains(GenericError) && g.text.Contains("could not be bound"), g.Describe());
+
+            // -- H: an EXPLICIT JSON null for a REQUIRED parameter (2026-06-12 hunt, proven over stdio on
+            //    nexus_mod): ContainsKey saw it as supplied, the SDK bound null, and the tool body
+            //    NullReferenced into Guard's "internal houseCARL failure… capture a bug report"
+            //    misdirection. Must be the same NAMED missing-parameter refusal as D.
+            var h = Call(stdin, stdout, 9, "housecarl_batch_record_detail", """{"formids":null}""");
+            failures += Check("H required: explicit null for a required parameter is refused by NAME, not an internal failure",
+                !h.text.Contains(GenericError) && !h.text.Contains("internal houseCARL failure")
+                && h.text.Contains("required parameter") && h.text.Contains("formids"),
+                h.Describe());
         }
         catch (Exception ex)
         {

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -64,6 +64,10 @@ if (args.Length > 0 && args[0] == "bsa-contract-guard") return BsaContractProbe.
 // class-parents map for process lifetime — paths derive before the build; the first derivation invalidates.
 if (args.Length > 0 && args[0] == "hierarchy-cache-guard") return HierarchyCacheProbe.RunGuard(args[1..]);
 
+// Write-path mutex + orphan folders (2026-06-12 hunt F2+F4): concurrent writes serialize (distinct outputs, own
+// bytes, no lost extend), and a pre-flight-refused fresh write removes the folder it created (no _NNN accretion).
+if (args.Length > 0 && args[0] == "write-mutex-guard") return WriteMutexProbe.RunGuard(args[1..]);
+
 // Compile-tool import order: caller import_dirs OUTRANK the vanilla auto-import (first match wins, so
 // SKSE-extended copies of vanilla sources must win). Pure order arm always runs; real-compile arm self-skips.
 if (args.Length > 0 && args[0] == "import-order-guard") return ImportOrderProbe.RunGuard(args[1..]);

--- a/src/housecarl-generator/ToolBridgeProbe.cs
+++ b/src/housecarl-generator/ToolBridgeProbe.cs
@@ -7,8 +7,11 @@ namespace HousecarlGenerator;
 /// housecarl_set_tool_path tool + the riders ride, with NO MO2 / NO server, so it's a cheap, deterministic green/red gate:
 ///
 ///   1. <see cref="UserConfigStore"/> CLOBBER-SAFETY (the load-bearing claim) — two independent writers (the MO2 instance
-///      dir + a tool path) share one houseCARL.user.json and must NOT overwrite each other's field, in either order; a
-///      corrupt file reads blank, never throws (Q3).
+///      dir + a tool path) share one houseCARL.user.json and must NOT overwrite each other's field, in either order;
+///      hardened per the 2026-06-12 hunt (F3): a corrupt file is BACKED UP + REPORTED (never silently blank — the old
+///      path wiped every saved setting on the next Update), writes are atomic (temp + rename, no residue), and TWO
+///      STORE INSTANCES on one file (the CLI + desktop two-process shape) serialize on the named cross-process mutex
+///      instead of losing each other's read-modify-write.
 ///   2. <see cref="ToolBridge.Validate"/> — rejects a missing exe / wrong-named exe / missing dir; accepts a real exe + dir.
 ///   3. <see cref="ToolBridge.RenderMissingPrompt"/> — the forcing function names the tool key AND the resolving call.
 ///   4. <see cref="ToolBridge.TryParse"/> — wire names round-trip; junk is rejected.
@@ -60,11 +63,40 @@ public static class ToolBridgeProbe
             store.Update(c => (c.ToolPaths ??= new())["papyrus_compiler"] = @"C:\CK\PapyrusCompiler.exe");
             var c2 = store.Load();
             Check(c2.ToolPaths!.Count == 2 && c2.Mo2InstanceDir == @"D:\Other", "a second tool path merges; MO2 dir intact");
+            Check(!File.Exists(tmp + ".tmp"), "atomic write leaves no .tmp residue");
 
+            // CORRUPT = LOUD (hunt F3, hunter-proven silent clobber): blank-with-note + backup, never silently blank.
             File.WriteAllText(tmp, "{ this is not valid json");
-            Check(store.Load().Mo2InstanceDir is null, "corrupt file loads blank, no throw (Q3)");
+            var blank = store.Load(out var loadNote);
+            Check(blank.Mo2InstanceDir is null, "corrupt file loads blank, no throw (Q3)");
+            Check(loadNote is not null && loadNote.Contains(".corrupt.bak"), "corrupt load is REPORTED, naming the backup");
+            Check(File.Exists(tmp + ".corrupt.bak") && File.ReadAllText(tmp + ".corrupt.bak") == "{ this is not valid json",
+                  "the corrupt original is backed up byte-for-byte beside the file");
+            var (upOk, upErr, upNote) = store.Update(c => c.Mo2InstanceDir = @"E:\Fresh");
+            Check(upOk && upErr is null && upNote is not null, "Update over a corrupt file succeeds AND reports the recovery");
+            var fresh = store.Load(out var freshNote);
+            Check(fresh.Mo2InstanceDir == @"E:\Fresh" && freshNote is null, "the fresh file holds the new setting and reads clean");
+
+            // CROSS-PROCESS shape (hunt F3): TWO store instances on ONE file — each with its own process-local gate, the
+            // way the CLI plugin + desktop app share houseCARL.user.json — hammer different fields concurrently. Without
+            // the named mutex the read-modify-write races and one concern's last value is clobbered (hunter-measured).
+            const int rounds = 200;
+            var s1 = new UserConfigStore(tmp);
+            var s2 = new UserConfigStore(tmp);
+            var t1 = Task.Run(() => { for (int i = 1; i <= rounds; i++) s1.Update(c => c.Mo2InstanceDir = @"C:\Race\" + i); });
+            var t2 = Task.Run(() => { for (int i = 1; i <= rounds; i++) s2.Update(c => (c.ToolPaths ??= new())["bsarch"] = @"C:\Race\bsarch" + i + ".exe"); });
+            Task.WaitAll(t1, t2);
+            var final = s1.Load(out var raceNote);
+            Check(raceNote is null, "no corruption under two-store contention (every write atomic + serialized)");
+            Check(final.Mo2InstanceDir == @"C:\Race\" + rounds
+                  && final.ToolPaths is { } rtp && rtp.TryGetValue("bsarch", out var rb) && rb == @"C:\Race\bsarch" + rounds + ".exe",
+                  "BOTH concerns' LAST values survive two-store concurrent updates (no cross-process clobber)");
         }
-        finally { try { File.Delete(tmp); } catch { /* temp cleanup, non-fatal */ } }
+        finally
+        {
+            try { File.Delete(tmp); } catch { /* temp cleanup, non-fatal */ }
+            try { File.Delete(tmp + ".corrupt.bak"); } catch { /* temp cleanup, non-fatal */ }
+        }
 
         // ---------------------------------------------------------------- 2) VALIDATE
         Console.WriteLine();

--- a/src/housecarl-generator/WriteMutexProbe.cs
+++ b/src/housecarl-generator/WriteMutexProbe.cs
@@ -1,0 +1,170 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// Write-path mutex + orphan-folder guard (2026-06-12 adversarial hunt F2 + F4): the MCP SDK dispatches tool
+/// calls CONCURRENTLY, and the .esp write path had no mutual exclusion — ResolveOutputPath took no gate (its
+/// sibling ResolvePatchModFolder locks), UniqueStem was check-then-create TOCTOU, and the staging path under a
+/// patch folder is FIXED (.housecarl-tmp\&lt;name&gt;.esp), so two same-default-name writes could allocate the
+/// SAME folder and cross-commit (R1's success message shipping R2's bytes). F4 rode the same path: the fresh
+/// folder + meta.ini were created BEFORE pre-flight, so a refused write's "NO patch written" left an orphan
+/// folder accreting _001/_002 on retry.
+///
+/// Drives the REAL service-level write path (LoadOrderService.ApplyEdits) against a synthetic MO2 instance in
+/// temp (the hierarchy-cache-guard synth pattern + the upsert-guard synthesized master). Arms:
+///   CONCURRENT — N pairs of simultaneous fresh default-name writes: every call succeeds, every output path is
+///                distinct, and every written file carries ITS OWN edit (no cross-commit). RED pre-fix (same
+///                folder allocated; cross-committed bytes).
+///   EXTEND     — two simultaneous into= extends of one patch: both edits survive in the final file (the write
+///                gate means the second opens what the first committed — no lost update). RED pre-fix.
+///   ORPHAN     — a pre-flight-refused fresh write leaves NO folder behind, twice over (no _001 accretion), and
+///                a later successful write under that name gets the BASE stem. RED pre-fix (deterministic).
+/// </summary>
+internal static class WriteMutexProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" write-mutex guard — concurrent writes must not cross-commit");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        var root = Path.Combine(Path.GetTempPath(), "hc-write-mutex-guard-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            // ---- synthetic MO2 instance (the established synth-instance pattern) with ONE real master plugin ----
+            string instance = Path.Combine(root, "instance");
+            string profiles = Path.Combine(instance, "profiles", "Default");
+            string mods = Path.Combine(instance, "mods");
+            string data = Path.Combine(root, "game", "Data");
+            Directory.CreateDirectory(profiles); Directory.CreateDirectory(mods); Directory.CreateDirectory(data);
+            File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+                "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+                + Path.Combine(root, "game").Replace(@"\", @"\\") + ")\r\n");
+
+            var mKey = new ModKey("HcWmxMaster", ModType.Master);
+            var modDir = Path.Combine(mods, "MasterMod");
+            Directory.CreateDirectory(modDir);
+            FormKey weapFk;
+            {
+                var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
+                var w = m.Weapons.AddNew(); w.EditorID = "HcWmxWeap"; w.BasicStats = new WeaponBasicStats { Damage = 10 };
+                weapFk = w.FormKey;
+                m.BeginWrite.ToPath(Path.Combine(modDir, mKey.FileName.String)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            }
+            File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + mKey.FileName + "\r\n");
+            File.WriteAllText(Path.Combine(profiles, "plugins.txt"), "*" + mKey.FileName + "\r\n");
+            File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+MasterMod\r\n");
+
+            // The service's Rulebook loads from the static CorpusPath — point it at a freshly generated corpus.
+            var genDir = Path.Combine(root, "corpus-gen");
+            CorpusGenerator.GenerateAll(genDir, Path.Combine(root, "corpus-ref"));
+            CorpusRulebook.CorpusPath = Path.Combine(genDir, "corpus.json");
+
+            string fid = $"{weapFk.ID:X6}:{weapFk.ModKey.FileName}";
+            var store = new UserConfigStore(Path.Combine(root, "houseCARL.user.json"));
+            using var svc = LoadOrderService.WithInstance(instance, 0, store);
+            svc.Stats();                                                       // warm the lazy index once, off the clock
+
+            static BulkOp DamageOp(string fid, int dmg) =>
+                new() { Formid = fid, FieldPath = "BasicStats.Damage", Verb = "Set", Value = dmg.ToString() };
+
+            static ushort? ReadDamage(string path, FormKey fk)
+            {
+                ISkyrimModGetter? ov = null;
+                try
+                {
+                    ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE);
+                    return ov.Weapons.FirstOrDefault(w => w.FormKey == fk)?.BasicStats?.Damage;
+                }
+                catch { return null; }
+                finally { (ov as IDisposable)?.Dispose(); }
+            }
+
+            // ---- CONCURRENT: pairs of simultaneous default-name writes — distinct outputs, own bytes ----
+            Console.WriteLine("--- 1: concurrent fresh writes (default patch name on both) ---");
+            {
+                const int pairs = 6;
+                var all = new List<(int dmg, WritePatchBuilder.PatchOutcome o)>();
+                bool threw = false;
+                for (int i = 0; i < pairs; i++)
+                {
+                    int dmgA = 100 + i * 2, dmgB = 101 + i * 2;
+                    using var barrier = new Barrier(2);
+                    WritePatchBuilder.PatchOutcome? oA = null, oB = null;
+                    var tA = Task.Run(() => { barrier.SignalAndWait(); oA = svc.ApplyEdits(new[] { DamageOp(fid, dmgA) }, null, null); });
+                    var tB = Task.Run(() => { barrier.SignalAndWait(); oB = svc.ApplyEdits(new[] { DamageOp(fid, dmgB) }, null, null); });
+                    try { Task.WaitAll(tA, tB); } catch { threw = true; }
+                    if (oA is null || oB is null) { threw = true; continue; }
+                    all.Add((dmgA, oA)); all.Add((dmgB, oB));
+                }
+                Check(!threw, "no call threw or vanished");
+                Check(all.All(x => x.o.Success), $"every concurrent write succeeded ({all.Count(x => x.o.Success)}/{all.Count})");
+                var paths = all.Select(x => x.o.OutputPath).ToList();
+                Check(paths.Distinct(StringComparer.OrdinalIgnoreCase).Count() == paths.Count,
+                      "every call got its OWN output path (no shared folder from the UniqueStem race)");
+                bool ownBytes = all.All(x => x.o.Success && ReadDamage(x.o.OutputPath, weapFk) == x.dmg);
+                Check(ownBytes, "every written file carries ITS OWN edit (no cross-commit through the shared staging path)");
+            }
+
+            // ---- EXTEND: two simultaneous extends of ONE patch — no lost update ----
+            Console.WriteLine();
+            Console.WriteLine("--- 2: concurrent into= extends of one patch ---");
+            {
+                var seed = svc.ApplyEdits(new[] { DamageOp(fid, 50) }, "HcWmxExtend", null);
+                Check(seed.Success, "seed patch created");
+                using var barrier = new Barrier(2);
+                WritePatchBuilder.PatchOutcome? oA = null, oB = null;
+                var tA = Task.Run(() => { barrier.SignalAndWait(); oA = svc.ApplyEdits(new[] { DamageOp(fid, 60) }, null, "HcWmxExtend"); });
+                var tB = Task.Run(() => { barrier.SignalAndWait(); oB = svc.ApplyEdits(
+                    new[] { new BulkOp { Formid = fid, FieldPath = "BasicStats.Weight", Verb = "Set", Value = "7" } }, null, "HcWmxExtend"); });
+                Task.WaitAll(tA, tB);
+                bool bothOk = oA is { Success: true } && oB is { Success: true };
+                Check(bothOk, "both extends succeeded");
+                ushort? dmg = null; float? weight = null;
+                if (bothOk)
+                {
+                    ISkyrimModGetter? ov = null;
+                    try
+                    {
+                        ov = SkyrimMod.CreateFromBinaryOverlay(seed.OutputPath, SkyrimRelease.SkyrimSE);
+                        var w = ov.Weapons.FirstOrDefault(x => x.FormKey == weapFk);
+                        dmg = w?.BasicStats?.Damage; weight = w?.BasicStats?.Weight;
+                    }
+                    finally { (ov as IDisposable)?.Dispose(); }
+                }
+                Check(dmg == 60 && weight == 7, $"BOTH edits survive in the final file (no lost update) — Damage={dmg}, Weight={weight}");
+            }
+
+            // ---- ORPHAN: a pre-flight-refused fresh write leaves no folder; no _001 accretion on retry ----
+            Console.WriteLine();
+            Console.WriteLine("--- 3: refused write leaves no orphan folder (hunt F4) ---");
+            {
+                var bad = new BulkOp { Formid = fid, FieldPath = "NoSuchFieldAnywhere", Verb = "Set", Value = "1" };
+                var r1 = svc.ApplyEdits(new[] { bad }, "HcWmxOrphan", null);
+                var r2 = svc.ApplyEdits(new[] { bad }, "HcWmxOrphan", null);
+                Check(!r1.Success && !r2.Success, "both bad writes refused");
+                Check(r1.Error is not null && r1.Error.Contains("NO patch written", StringComparison.OrdinalIgnoreCase),
+                      "refusal says NO patch written");
+                bool noOrphans = !Directory.EnumerateDirectories(mods, "houseCARL - HcWmxOrphan*").Any();
+                Check(noOrphans, "no orphan folder remains after either refusal (the message is true of the disk)");
+                var good = svc.ApplyEdits(new[] { DamageOp(fid, 75) }, "HcWmxOrphan", null);
+                Check(good.Success && good.OutputPath.EndsWith(Path.Combine("houseCARL - HcWmxOrphan", "HcWmxOrphan.esp"), StringComparison.OrdinalIgnoreCase),
+                      $"a later good write gets the BASE stem, not an accreted _NNN — wrote {Path.GetFileName(good.OutputPath)}");
+            }
+        }
+        finally { try { Directory.Delete(root, recursive: true); } catch { /* temp scratch */ } }
+
+        Console.WriteLine();
+        Console.WriteLine(fail == 0 ? "================ ALL PASS ================" : $"================ {fail} CHECK(S) FAILED ================");
+        return fail == 0 ? 0 : 1;
+    }
+}

--- a/src/housecarl-mcp/CompileTools.cs
+++ b/src/housecarl-mcp/CompileTools.cs
@@ -126,7 +126,9 @@ public static class CompileTools
         sb.Append("compile FAILED: ").Append(r.ObjectName).Append(".psc — no new .pex produced (any previous build is left unchanged).");
         if (r.Diagnostics.Count > 0)
         {
-            sb.Append('\n').Append(r.Diagnostics.Count).Append(" error(s):");
+            // "diagnostic(s)", not "error(s)": the CK compiler mixes warnings into a failed run's output and the
+            // parser doesn't split severities — labelling them all errors over-claims (2026-06-12 hunt render wave).
+            sb.Append('\n').Append(r.Diagnostics.Count).Append(" diagnostic(s) (errors and possibly warnings — the CK compiler mixes them):");
             foreach (var d in r.Diagnostics) sb.Append("\n  ").Append(d);
             sb.Append("\nfix the .psc and recompile (look unfamiliar functions/types up with the papyrus-reference skill). " +
                       "If a dependency type is 'not found', its source folder may be missing from the import path — pass it via import_dirs=.");

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -36,6 +36,12 @@ public sealed class LoadOrderService : IDisposable
     readonly UserConfigStore _store;               // the sole owner of houseCARL.user.json (MO2 instance dir + tool paths)
     readonly int _maxPlugins;
     readonly object _gate = new();
+    // Serializes the WHOLE resolve→stage→commit of every .esp write (2026-06-12 hunt F2): the MCP SDK dispatches tool
+    // calls CONCURRENTLY, and without this two same-name writes could allocate the same folder (UniqueStem TOCTOU) and
+    // cross-commit through the fixed .housecarl-tmp staging path — R1's success message shipping R2's bytes. Writes are
+    // seconds-long and rare; serializing them is correct (accuracy over perf). SetInstance takes it too, so an instance
+    // switch can never tear a write in flight across instances. Lock order where both are held: _writeGate THEN _gate.
+    readonly object _writeGate = new();
     LoadOrderResolver? _resolver;
     CorpusRulebook? _rulebook;
     IReadOnlyList<string> _orderWarnings = Array.Empty<string>();
@@ -258,6 +264,7 @@ public sealed class LoadOrderService : IDisposable
     public (Mo2InstancePaths paths, bool persisted, string? persistError) SetInstance(string instanceDir)
     {
         var paths = Mo2Instance.Resolve(instanceDir);            // throws (Q3) if not a usable MO2 instance — the tool renders the reason
+        lock (_writeGate)                                        // hunt F2: an instance switch waits for any in-flight write — never tears one across instances
         lock (_gate)
         {
             _instanceDir = paths.InstanceDir;
@@ -565,10 +572,8 @@ public sealed class LoadOrderService : IDisposable
         if (ops.Count == 0)
             return WritePatchBuilder.PatchOutcome.Fail("no operations supplied.");
 
-        var resolver = Resolver;                                          // builds/refreshes the index
-        var rulebook = Rulebook;
-
         // Map every op to a core PatchEdit, collecting ALL parse problems first (all-or-nothing, like the cleave).
+        // Pure parsing — runs outside the write gate so a malformed call never queues behind a real write.
         var edits = new List<WritePatchBuilder.PatchEdit>(ops.Count);
         var problems = new List<string>();
         for (int i = 0; i < ops.Count; i++)
@@ -580,11 +585,19 @@ public sealed class LoadOrderService : IDisposable
             return WritePatchBuilder.PatchOutcome.Fail(
                 $"refused — {problems.Count} of {ops.Count} operation(s) malformed; NO patch written:\n  - " + string.Join("\n  - ", problems));
 
-        string outPath; bool extend;
-        try { outPath = ResolveOutputPath(patchName, into, out extend); }
-        catch (Exception ex) { return WritePatchBuilder.PatchOutcome.Fail(ex.Message); }
+        lock (_writeGate)                                                 // hunt F2: one write at a time, resolve→commit
+        {
+            var resolver = Resolver;                                      // builds/refreshes the index
+            var rulebook = Rulebook;
 
-        return WritePatchBuilder.Apply(resolver, rulebook, edits, outPath, extend, fullReadback);
+            string outPath; bool extend, created;
+            try { outPath = ResolveOutputPath(patchName, into, out extend, out created); }
+            catch (Exception ex) { return WritePatchBuilder.PatchOutcome.Fail(ex.Message); }
+
+            var outcome = WritePatchBuilder.Apply(resolver, rulebook, edits, outPath, extend, fullReadback);
+            if (!outcome.Success && created) RemoveFolderCreatedThisCall(outPath);   // hunt F4: a refused write leaves no orphan
+            return outcome;
+        }
     }
 
     /// <summary>Remove WHOLE records a houseCARL patch carries (housecarl_remove_record) — literal drop-from-plugin, the
@@ -601,9 +614,7 @@ public sealed class LoadOrderService : IDisposable
             return WritePatchBuilder.RemovalOutcome.Fail(
                 "patch is required — name the houseCARL patch to remove the record from (removal only targets a patch that already carries it).");
 
-        var resolver = Resolver;                                          // builds/refreshes the index (Overlays for the re-serialize)
-
-        // Parse every formid first, collecting ALL problems (all-or-nothing, like the edit path).
+        // Parse every formid first, collecting ALL problems (all-or-nothing, like the edit path). Pure — outside the gate.
         var keys = new List<FormKey>(formids.Count);
         var problems = new List<string>();
         for (int i = 0; i < formids.Count; i++)
@@ -617,12 +628,17 @@ public sealed class LoadOrderService : IDisposable
             return WritePatchBuilder.RemovalOutcome.Fail(
                 $"refused — {problems.Count} of {formids.Count} formid(s) malformed; NOTHING removed:\n  - " + string.Join("\n  - ", problems));
 
-        // Resolve + ownership-gate the patch path via the into= (extend) path — must exist + carry the houseCARL marker.
-        string outPath;
-        try { outPath = ResolveOutputPath(patchName: null, into: patch, out _); }
-        catch (Exception ex) { return WritePatchBuilder.RemovalOutcome.Fail(ex.Message); }
+        lock (_writeGate)                                                 // hunt F2: removal re-serializes the patch — same gate
+        {
+            var resolver = Resolver;                                      // builds/refreshes the index (Overlays for the re-serialize)
 
-        return WritePatchBuilder.RemoveRecords(resolver, keys, outPath);
+            // Resolve + ownership-gate the patch path via the into= (extend) path — must exist + carry the houseCARL marker.
+            string outPath;
+            try { outPath = ResolveOutputPath(patchName: null, into: patch, out _, out _); }
+            catch (Exception ex) { return WritePatchBuilder.RemovalOutcome.Fail(ex.Message); }
+
+            return WritePatchBuilder.RemoveRecords(resolver, keys, outPath);
+        }
     }
 
     /// <summary>Create a BRAND-NEW record (housecarl_create_record) — the net-new authoring capability, the sibling of
@@ -639,9 +655,6 @@ public sealed class LoadOrderService : IDisposable
             return WritePatchBuilder.CreateOutcome.Fail("record_type is required (a catalog name like 'Keyword'/'Spell'/'Weapon' or a 4-char signature like 'KYWD').");
         if (string.IsNullOrWhiteSpace(editorid))
             return WritePatchBuilder.CreateOutcome.Fail("editorid is required — the EditorID the new record is referenced by (e.g. in SkyPatcher/SPID).");
-
-        var resolver = Resolver;
-        var rulebook = Rulebook;
 
         // Resolve the type string → ONE concrete catalog name. Signature + name both work; unknown → Q3; an ambiguous
         // signature (maps to several types) → refuse and ask for the specific name.
@@ -668,12 +681,20 @@ public sealed class LoadOrderService : IDisposable
             return WritePatchBuilder.CreateOutcome.Fail(
                 $"refused — {problems.Count} of {operations.Count} operation(s) malformed; NOTHING created:\n  - " + string.Join("\n  - ", problems));
 
-        string outPath; bool extend;
-        try { outPath = ResolveOutputPath(patchName, into, out extend); }
-        catch (Exception ex) { return WritePatchBuilder.CreateOutcome.Fail(ex.Message); }
+        lock (_writeGate)                                                 // hunt F2: one write at a time, resolve→commit
+        {
+            var resolver = Resolver;
+            var rulebook = Rulebook;
 
-        var spec = new WritePatchBuilder.CreateSpec { RecordType = catalogName, EditorId = editorid.Trim(), Edits = edits };
-        return WritePatchBuilder.CreateRecords(resolver, rulebook, new[] { spec }, outPath, extend, fullReadback);
+            string outPath; bool extend, created;
+            try { outPath = ResolveOutputPath(patchName, into, out extend, out created); }
+            catch (Exception ex) { return WritePatchBuilder.CreateOutcome.Fail(ex.Message); }
+
+            var spec = new WritePatchBuilder.CreateSpec { RecordType = catalogName, EditorId = editorid.Trim(), Edits = edits };
+            var outcome = WritePatchBuilder.CreateRecords(resolver, rulebook, new[] { spec }, outPath, extend, fullReadback);
+            if (!outcome.Success && created) RemoveFolderCreatedThisCall(outPath);   // hunt F4: a refused create leaves no orphan
+            return outcome;
+        }
     }
 
     /// <summary>Map a wire field-op to a core <see cref="WriteRequest"/> for CREATE: RecordType is the create type (not
@@ -771,40 +792,73 @@ public sealed class LoadOrderService : IDisposable
     /// <paramref name="into"/> EXTENDS an existing houseCARL-owned patch (replace / modify its own plugins).
     /// ORIGINALS UNTOUCHED is structural (CLAUDE.md §1): houseCARL only ever writes a folder that is brand-NEW or carries
     /// its own <c>meta.ini</c> marker — it REFUSES (Q3) to write a folder it didn't create (a user mod), even on a name
-    /// collision. The caller name is reduced to a bare stem (no directory parts) so it can never escape ModsDir.</summary>
-    string ResolveOutputPath(string? patchName, string? into, out bool extend)
+    /// collision. The caller name is reduced to a bare stem (no directory parts) so it can never escape ModsDir.
+    /// Runs under <see cref="_gate"/> like its sibling <see cref="ResolvePatchModFolder"/> (hunt F2): the UniqueStem
+    /// check-then-create is only race-free when every folder allocation is serialized on the one gate.
+    /// <paramref name="createdFolder"/> reports whether THIS call created the fresh folder, so a refused write can
+    /// remove it again (hunt F4 — "NO patch written" must not leave an orphan folder accreting _001/_002 on retry).</summary>
+    string ResolveOutputPath(string? patchName, string? into, out bool extend, out bool createdFolder)
     {
-        if (!Directory.Exists(_modsDir))
-            throw new InvalidOperationException($"cannot write: ModsDir '{_modsDir}' does not exist. Check HouseCarl:ModsDir.");
-
-        if (!string.IsNullOrWhiteSpace(into))
+        lock (_gate)
         {
-            extend = true;
-            var stem = PatchStem(into);
-            var folder = Path.Combine(_modsDir, ModFolderName(stem));
-            if (!Directory.Exists(folder))
-                throw new InvalidOperationException(
-                    $"cannot extend: no houseCARL patch named '{stem}' (mod folder '{ModFolderName(stem)}' not found). " +
-                    "Omit into= to create it fresh, or check the name.");
-            if (!IsHouseCarlOwned(folder))
-                throw new InvalidOperationException(
-                    $"cannot extend: mod folder '{ModFolderName(stem)}' exists but was NOT created by houseCARL (no marker) — " +
-                    "refusing to modify a folder houseCARL doesn't own (originals untouched, Q3). Use a different patch name.");
-            var existing = Path.Combine(folder, stem + ".esp");
-            if (!File.Exists(existing))
-                throw new InvalidOperationException(
-                    $"cannot extend: houseCARL folder '{ModFolderName(stem)}' has no '{stem}.esp' to extend.");
-            return existing;
-        }
+            createdFolder = false;
+            if (!Directory.Exists(_modsDir))
+                throw new InvalidOperationException($"cannot write: ModsDir '{_modsDir}' does not exist. Check HouseCarl:ModsDir.");
 
-        extend = false;
-        var baseStem = PatchStem(string.IsNullOrWhiteSpace(patchName) ? "houseCARL_Patch" : patchName!);
-        var freeStem = UniqueStem(baseStem);
-        var newFolder = Path.Combine(_modsDir, ModFolderName(freeStem));
-        Directory.CreateDirectory(newFolder);
-        var plugin = freeStem + ".esp";
-        WriteOwnerMeta(newFolder, plugin);
-        return Path.Combine(newFolder, plugin);
+            if (!string.IsNullOrWhiteSpace(into))
+            {
+                extend = true;
+                var stem = PatchStem(into);
+                var folder = Path.Combine(_modsDir, ModFolderName(stem));
+                if (!Directory.Exists(folder))
+                    throw new InvalidOperationException(
+                        $"cannot extend: no houseCARL patch named '{stem}' (mod folder '{ModFolderName(stem)}' not found). " +
+                        "Omit into= to create it fresh, or check the name.");
+                if (!IsHouseCarlOwned(folder))
+                    throw new InvalidOperationException(
+                        $"cannot extend: mod folder '{ModFolderName(stem)}' exists but was NOT created by houseCARL (no marker) — " +
+                        "refusing to modify a folder houseCARL doesn't own (originals untouched, Q3). Use a different patch name.");
+                var existing = Path.Combine(folder, stem + ".esp");
+                if (!File.Exists(existing))
+                    throw new InvalidOperationException(
+                        $"cannot extend: houseCARL folder '{ModFolderName(stem)}' has no '{stem}.esp' to extend.");
+                return existing;
+            }
+
+            extend = false;
+            var baseStem = PatchStem(string.IsNullOrWhiteSpace(patchName) ? "houseCARL_Patch" : patchName!);
+            var freeStem = UniqueStem(baseStem);
+            var newFolder = Path.Combine(_modsDir, ModFolderName(freeStem));
+            Directory.CreateDirectory(newFolder);
+            createdFolder = true;
+            var plugin = freeStem + ".esp";
+            WriteOwnerMeta(newFolder, plugin);
+            return Path.Combine(newFolder, plugin);
+        }
+    }
+
+    /// <summary>Hunt F4: a write that was REFUSED after <see cref="ResolveOutputPath"/> created a fresh folder removes
+    /// that folder again, so "NO patch written" is true of the disk too (no orphan accreting _001/_002 on retry).
+    /// DELETION-SAFE by content check, not trust: only a folder holding NOTHING beyond our own meta.ini (and an empty
+    /// <c>.housecarl-tmp</c> staging leftover) is removed — anything else present means the folder gained real content
+    /// and stays. Best-effort: a cleanup failure never masks the write's own (already-reported) outcome.</summary>
+    static void RemoveFolderCreatedThisCall(string outPath)
+    {
+        try
+        {
+            var folder = Path.GetDirectoryName(outPath);
+            if (folder is null || !Directory.Exists(folder)) return;
+            foreach (var entry in Directory.EnumerateFileSystemEntries(folder))
+            {
+                var name = Path.GetFileName(entry);
+                if (File.Exists(entry) && name.Equals("meta.ini", StringComparison.OrdinalIgnoreCase)) continue;
+                if (Directory.Exists(entry) && name.Equals(".housecarl-tmp", StringComparison.OrdinalIgnoreCase)
+                    && !Directory.EnumerateFileSystemEntries(entry).Any()) continue;
+                return;                                       // real content appeared — leave the folder alone
+            }
+            Directory.Delete(folder, recursive: true);
+        }
+        catch (IOException) { } catch (UnauthorizedAccessException) { }
     }
 
     /// <summary>Resolve a houseCARL-owned MOD FOLDER under ModsDir for a NON-.esp output (compiled scripts, a packed .bsa,

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -261,7 +261,7 @@ public sealed class LoadOrderService : IDisposable
     /// persisted on failure), then re-points the live service (derives the roots + active profile, drops the cached resolver
     /// so the next tool call rebuilds against the new instance) and PERSISTS the choice to the user config file so it
     /// survives a restart. Returns the derived paths + whether the persist succeeded, for the tool's confirmation.</summary>
-    public (Mo2InstancePaths paths, bool persisted, string? persistError) SetInstance(string instanceDir)
+    public (Mo2InstancePaths paths, bool persisted, string? persistError, string? persistNote) SetInstance(string instanceDir)
     {
         var paths = Mo2Instance.Resolve(instanceDir);            // throws (Q3) if not a usable MO2 instance — the tool renders the reason
         lock (_writeGate)                                        // hunt F2: an instance switch waits for any in-flight write — never tears one across instances
@@ -277,15 +277,16 @@ public sealed class LoadOrderService : IDisposable
             _orderWarnings = Array.Empty<string>();
             InvalidateClassParents();                            // every sibling cache drops on a switch — the hierarchy too (PR #47 review)
         }
-        var (persisted, persistError) = PersistInstanceDir(paths.InstanceDir);
-        return (paths, persisted, persistError);
+        var (persisted, persistError, persistNote) = PersistInstanceDir(paths.InstanceDir);
+        return (paths, persisted, persistError, persistNote);
     }
 
     /// <summary>Persist the chosen instance dir through the shared <see cref="UserConfigStore"/> (read-modify-write), so it
     /// survives a restart AND coexists with any saved tool paths — the store never clobbers the other concern's field.
     /// Best-effort + HONEST (Q3): a write failure (e.g. a read-only data dir) is reported, not swallowed — the session
-    /// still works, but the user is told the choice won't survive a restart.</summary>
-    (bool ok, string? error) PersistInstanceDir(string instanceDir)
+    /// still works, but the user is told the choice won't survive a restart. <c>note</c> carries a corrupt-file recovery
+    /// (hunt F3 — the prior file was backed up; other saved settings were lost), rendered even on success.</summary>
+    (bool ok, string? error, string? note) PersistInstanceDir(string instanceDir)
         => _store.Update(c => c.Mo2InstanceDir = instanceDir);
 
     /// <summary>The trained prompt shown while unconfigured: tells houseCARL to ask the user which MO2 instance to use (not

--- a/src/housecarl-mcp/NexusTools.cs
+++ b/src/housecarl-mcp/NexusTools.cs
@@ -144,7 +144,17 @@ static class Render
         if (!string.IsNullOrWhiteSpace(category)) sb.Append(" in '").Append(category).Append('\'');
         sb.Append(" — ").Append(r.TotalCount.ToString("N0")).Append(" match(es), by ").Append(sort)
           .Append(", showing ").Append(r.Hits.Count).Append(':');
-        if (r.Hits.Count == 0) return sb.Append("\n(none)").ToString();
+        if (r.Hits.Count == 0)
+        {
+            sb.Append("\n(none)");
+            // category= is a server-side case-sensitive EQUALS (live-proven: 'Armour' 5041 matches vs 'armour' 0),
+            // so a zero WITH a category filter is as likely a casing/name miss as a real zero — say so (Q3).
+            if (!string.IsNullOrWhiteSpace(category))
+                sb.Append("\nnote: category matching is EXACT and case-sensitive on Nexus's side ('Armour', not 'armour') — ")
+                  .Append("0 matches with a category filter may mean the category name didn't match, not that no mods exist. ")
+                  .Append("Retry without category= or with the exact Nexus category name.");
+            return sb.ToString();
+        }
 
         foreach (var h in r.Hits)
         {
@@ -179,12 +189,16 @@ static class Render
         if (!string.IsNullOrWhiteSpace(m.Summary)) sb.Append("\n\n").Append(m.Summary);
 
         // The accurate "latest version" is the newest MAIN file, not the mod's version header (which can lag).
+        // A mod with NO main file (everything filed as optional/misc/old) says so explicitly — otherwise the
+        // section's absence silently leaves the possibly-lagging version header as the only signal (Q3).
         NexusFile? main = null;
         foreach (var f in m.Files)
             if (f.Category == "MAIN" && (main is null || f.Date > main.Date)) main = f;
         if (main is not null)
             sb.Append("\n\nlatest MAIN file: ").Append(main.Name).Append(" v").Append(main.Version ?? "?")
               .Append(" (").Append(Day(main.Date)).Append(')');
+        else
+            sb.Append("\n\nno MAIN file listed (files may all be optional/misc) — the version header above is the only version signal and can lag.");
 
         if (m.NexusRequirements.Count > 0)
         {

--- a/src/housecarl-mcp/Program.cs
+++ b/src/housecarl-mcp/Program.cs
@@ -15,13 +15,15 @@ var hostArgs = args.Where(a => a != "--http").ToArray();   // strip our own flag
 if (useHttp)
 {
     var builder = WebApplication.CreateBuilder(hostArgs);
-    var (svc, explicitMode, instanceDir, instanceSource) = SetupHouseCarl(builder.Configuration, builder.Services);
+    var (svc, explicitMode, instanceDir, instanceSource, configNote) = SetupHouseCarl(builder.Configuration, builder.Services);
     AddMcp(builder.Services, stdio: false);
 
     var app = builder.Build();
     app.MapMcp();
 
     var url = builder.Configuration.GetSection("HouseCarl")["Url"] is { Length: > 0 } u ? u : "http://127.0.0.1:7345";
+    if (configNote is not null)
+        app.Logger.LogWarning("houseCARL user config recovered: {Note}", configNote);   // corrupt file — backed up, never silent (hunt F3)
     if (!svc.IsConfigured)
         app.Logger.LogWarning(
             "houseCARL listening on {Url} — NOT configured yet. The first tool call will ask for your MO2 instance folder (or call housecarl_set_mo2_instance with it).", url);
@@ -37,12 +39,14 @@ else
     // STDIO GOTCHA: stdout IS the JSON-RPC channel — route ALL logs to stderr or they corrupt the protocol stream.
     builder.Logging.AddConsole(o => o.LogToStandardErrorThreshold = LogLevel.Trace);
 
-    var (svc, explicitMode, instanceDir, instanceSource) = SetupHouseCarl(builder.Configuration, builder.Services);
+    var (svc, explicitMode, instanceDir, instanceSource, configNote) = SetupHouseCarl(builder.Configuration, builder.Services);
     AddMcp(builder.Services, stdio: true);
 
     var app = builder.Build();
 
     var logger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger("houseCARL");
+    if (configNote is not null)
+        logger.LogWarning("houseCARL user config recovered: {Note}", configNote);   // corrupt file — backed up, never silent (hunt F3)
     if (!svc.IsConfigured)
         logger.LogWarning(
             "houseCARL stdio server — NOT configured yet. The first tool call will ask for your MO2 instance folder (or call housecarl_set_mo2_instance with it).");
@@ -61,7 +65,7 @@ else
 // RUNTIME) > explicit DataDir+ModsDir+ProfileDir (dev/non-portable) > Mo2InstanceDir (userConfig install dialog / appsettings)
 // > UNCONFIGURED (boots; tools prompt). The runtime user choice beats the install default. A corrupt user file never crashes boot (Q3).
 // Builds + registers the LoadOrderService; returns the bits the boot log needs.
-static (LoadOrderService svc, bool explicitMode, string? instanceDir, string instanceSource) SetupHouseCarl(IConfiguration config, IServiceCollection services)
+static (LoadOrderService svc, bool explicitMode, string? instanceDir, string instanceSource, string? configNote) SetupHouseCarl(IConfiguration config, IServiceCollection services)
 {
     var cfg = config.GetSection("HouseCarl");
 
@@ -77,10 +81,11 @@ static (LoadOrderService svc, bool explicitMode, string? instanceDir, string ins
     var userConfigDir = string.IsNullOrWhiteSpace(pluginDataDir) ? AppContext.BaseDirectory : pluginDataDir;
     var userConfigPath = Path.Combine(userConfigDir, "houseCARL.user.json");
     // ONE owner of houseCARL.user.json (UserConfigStore): the MO2 instance dir AND the external-tool paths share the file,
-    // so neither writer clobbers the other (read-modify-write). Tolerant read (corrupt/missing → blank, never crashes — Q3).
+    // so neither writer clobbers the other (read-modify-write under a cross-process lock; atomic writes). A corrupt file
+    // never crashes boot, but it is NOT silent either (hunt F3): it's backed up and the note rides the boot log.
     var store = new UserConfigStore(userConfigPath);
     services.AddSingleton(store);
-    string? userInstanceDir = store.Load().Mo2InstanceDir;
+    string? userInstanceDir = store.Load(out var configNote).Mo2InstanceDir;
 
     // PRECEDENCE (§6d): the saved user config (houseCARL.user.json, written by housecarl_set_mo2_instance at RUNTIME) wins
     // over Mo2InstanceDir (the userConfig install-dialog value / appsettings) — the runtime switch beats the install default.
@@ -111,7 +116,7 @@ static (LoadOrderService svc, bool explicitMode, string? instanceDir, string ins
         c.DefaultRequestHeaders.UserAgent.ParseAdd("houseCARL (+https://github.com/Avick3110/houseCARL)");
     });
 
-    return (svc, explicitMode, instanceDir, instanceSource);
+    return (svc, explicitMode, instanceDir, instanceSource, configNote);
 }
 
 // The MCP server registration — server identity + instructions + the 16 attribute-registered tools. ONLY the

--- a/src/housecarl-mcp/Program.cs
+++ b/src/housecarl-mcp/Program.cs
@@ -119,14 +119,16 @@ static (LoadOrderService svc, bool explicitMode, string? instanceDir, string ins
     return (svc, explicitMode, instanceDir, instanceSource, configNote);
 }
 
-// The MCP server registration — server identity + instructions + the 16 attribute-registered tools. ONLY the
+// The MCP server registration — server identity + instructions + the attribute-registered tools. ONLY the
 // transport line differs between modes (the whole point of the stdio/http split); everything else is shared.
 static void AddMcp(IServiceCollection services, bool stdio)
 {
     var mcp = services.AddMcpServer(options =>
     {
-        // The houseCARL brand string lives HERE — the one place in code (CLAUDE.md §6).
-        options.ServerInfo = new Implementation { Name = "houseCARL", Version = "0.1.0" };
+        // The houseCARL brand string lives HERE — the one place in code (CLAUDE.md §6). The version is the exe's
+        // stamped InformationalVersion: build-plugin.ps1 passes -p:Version from plugin.json (the single version
+        // home), so ServerInfo reports the REAL release; an unstamped dev build honestly says 0.0.0-dev.
+        options.ServerInfo = new Implementation { Name = "houseCARL", Version = ServerVersion() };
         options.ServerInstructions =
             "houseCARL exposes the Skyrim Special Edition load order at the data layer. Reads return the TRUE " +
             "load-order winner and, on request, the conflict tree; writes go to a NEW plugin, leaving originals " +
@@ -141,4 +143,16 @@ static void AddMcp(IServiceCollection services, bool stdio)
     // (a bare string where an array is declared, quoted bools/numbers), named refusal of missing required
     // parameters, and a named rewrite of the SDK's generic binding-failure text. See ToolCallShim.
     mcp.WithRequestFilters(f => f.AddCallToolFilter(ToolCallShim.LenientArguments));
+}
+
+// The exe's stamped version for ServerInfo: InformationalVersion (set by build-plugin.ps1's -p:Version from
+// plugin.json — ONE version home) with any "+metadata" suffix trimmed; an unstamped build reports 0.0.0-dev.
+static string ServerVersion()
+{
+    var info = System.Reflection.Assembly.GetExecutingAssembly()
+        .GetCustomAttributes(typeof(System.Reflection.AssemblyInformationalVersionAttribute), inherit: false)
+        is [System.Reflection.AssemblyInformationalVersionAttribute a, ..] ? a.InformationalVersion : null;
+    if (string.IsNullOrWhiteSpace(info)) return "0.0.0-dev";
+    var plus = info.IndexOf('+');
+    return plus > 0 ? info[..plus] : info;
 }

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -85,16 +85,17 @@ public static class ReadTools
          "'BasicStats.Damage >= 50' — any scalar field, ANDed); plugins= limits the scan to records those plugins " +
          "touch (a bare plugins= is 'everything this plugin touches'). At least one filter or plugins= is required. " +
          "editorid_contains/references/where " +
-         "are body scans and MUST be combined with type=, plugins=, or conflicts_only= to bound the work. Pass fields= " +
+         "are body scans and MUST be combined with type= or plugins= to bound the work (conflicts_only= alone is not " +
+         "enough). Pass fields= " +
          "or conflict_tree=true to expand each match from a summary line to full detail. Results cap at limit= matches " +
          "and max_chars; both overruns are reported explicitly (never silent). Does NOT modify anything.")]
     public static string CrossPluginQuery(
         LoadOrderService svc,
         [Description("Optional. A record signature ('WEAP', 'NPC_') or catalog name ('Weapon', 'Npc'). Cheap — uses typed group enumeration.")]
             string? type = null,
-        [Description("Optional. A FormID 'XXXXXX:Plugin.esp'; matches records whose winner references it (deep link scan). Must be combined with type=, plugins=, or conflicts_only=.")]
+        [Description("Optional. A FormID 'XXXXXX:Plugin.esp'; matches records whose winner references it (deep link scan). Must be combined with type= or plugins= (conflicts_only= alone is not enough).")]
             string? references = null,
-        [Description("Optional. Case-insensitive substring of the EditorID. Body scan — must be combined with type=, plugins=, or conflicts_only=.")]
+        [Description("Optional. Case-insensitive substring of the EditorID. Body scan — must be combined with type= or plugins= (conflicts_only= alone is not enough).")]
             string? editorid_contains = null,
         [Description("When true, restrict to records more than one plugin touches (the contested set).")]
             bool conflicts_only = false,

--- a/src/housecarl-mcp/SetupTools.cs
+++ b/src/housecarl-mcp/SetupTools.cs
@@ -35,6 +35,7 @@ public static class SetupTools
     {
         if (string.IsNullOrWhiteSpace(path))
             return "error: no path given. Pass the full path to your MO2 instance folder (the one containing ModOrganizer.ini).";
+        path = path.Trim().Trim('"');   // tolerate a copy-pasted quoted path, like every sibling path-taking tool
 
         Mo2InstancePaths paths; bool persisted; string? persistError; string? persistNote;
         try { (paths, persisted, persistError, persistNote) = svc.SetInstance(path); }
@@ -94,7 +95,8 @@ public static class SetupTools
         sb.Append("  game Data  : ").Append(p.DataDir).Append('\n');
 
         // Cheap composition (the three profile text files only — NO deep index): a quick figure so the user sees houseCARL
-        // actually found the order. The resolve already confirmed the profile files exist; a read hiccup here is non-fatal.
+        // actually found the order. The resolve already confirmed the profile files exist; a read hiccup here is non-fatal
+        // but NAMED — the proof line is what tells the user the setup really worked, so its absence must not be silent (Q3).
         try
         {
             var comp = Mo2LoadOrder.ReadComposition(p.ProfileDir);
@@ -102,7 +104,11 @@ public static class SetupTools
             sb.Append("sees: ").Append(comp.EnabledMods.Count).Append(" enabled mods · ")
               .Append(comp.OrderedPluginNames.Count).Append(" plugins in the load order (").Append(active).Append(" active)\n");
         }
-        catch { /* non-fatal — don't fail a good setup over a follow-up read */ }
+        catch (Exception ex)
+        {
+            sb.Append("(couldn't read the enabled-mods summary just now: ").Append(ex.Message)
+              .Append(" — the instance itself validated; the first real read will confirm.)\n");
+        }
 
         sb.Append(persisted
             ? "saved to houseCARL.user.json — persists across restarts."

--- a/src/housecarl-mcp/SetupTools.cs
+++ b/src/housecarl-mcp/SetupTools.cs
@@ -36,11 +36,11 @@ public static class SetupTools
         if (string.IsNullOrWhiteSpace(path))
             return "error: no path given. Pass the full path to your MO2 instance folder (the one containing ModOrganizer.ini).";
 
-        Mo2InstancePaths paths; bool persisted; string? persistError;
-        try { (paths, persisted, persistError) = svc.SetInstance(path); }
+        Mo2InstancePaths paths; bool persisted; string? persistError; string? persistNote;
+        try { (paths, persisted, persistError, persistNote) = svc.SetInstance(path); }
         catch (InvalidOperationException ex) { return "error: " + ex.Message; }   // not a usable instance — Q3 reason, nothing changed
 
-        return Render(paths, persisted, persistError);
+        return Render(paths, persisted, persistError, persistNote);
     });
 
     [McpServerTool(Name = "housecarl_set_tool_path", Title = "Tell houseCARL where an external tool is"),
@@ -68,7 +68,7 @@ public static class SetupTools
         if (string.IsNullOrWhiteSpace(path))
             return $"error: no path given for '{tool}'. Pass the full path to {ToolBridge.Info(dep).Display}.";
 
-        var (ok, error, persisted, persistError, resolved) = bridge.Save(dep, path);
+        var (ok, error, persisted, persistError, persistNote, resolved) = bridge.Save(dep, path);
         if (!ok) return "error: " + error;   // validation failed — nothing saved (Q3)
 
         var info = ToolBridge.Info(dep);
@@ -78,13 +78,14 @@ public static class SetupTools
         sb.Append(persisted
             ? "saved to houseCARL.user.json — persists across restarts (coexists with your MO2 instance)."
             : $"NOTE: could not save ({persistError}) — works this session, but you'll need to set it again after a restart.");
+        if (persistNote is not null) sb.Append("\nRECOVERED: ").Append(persistNote);   // corrupt prior config — never silent (hunt F3)
         return sb.ToString();
     });
 
     /// <summary>Confirmation: the instance + the DERIVED roots + the AUTO-DETECTED profile, a cheap enabled/active summary
     /// (text-file read, no deep index — proof houseCARL found the order), and whether the choice was persisted (Q3: a
-    /// failed save is reported, not hidden).</summary>
-    static string Render(Mo2InstancePaths p, bool persisted, string? persistError)
+    /// failed save is reported, not hidden; a corrupt-file recovery is named even on success — hunt F3).</summary>
+    static string Render(Mo2InstancePaths p, bool persisted, string? persistError, string? persistNote)
     {
         var sb = new StringBuilder();
         sb.Append("configured houseCARL -> MO2 instance '").Append(p.InstanceDir).Append("'\n");
@@ -106,6 +107,7 @@ public static class SetupTools
         sb.Append(persisted
             ? "saved to houseCARL.user.json — persists across restarts."
             : $"NOTE: could not save the choice ({persistError}) — it works this session, but you'll need to set it again after a restart.");
+        if (persistNote is not null) sb.Append("\nRECOVERED: ").Append(persistNote);   // corrupt prior config — never silent (hunt F3)
         sb.Append("\nthe load order resolves on the next read/write (first build ~10s).");
         return sb.ToString();
     }

--- a/src/housecarl-mcp/ToolCallShim.cs
+++ b/src/housecarl-mcp/ToolCallShim.cs
@@ -148,16 +148,27 @@ internal static class ToolCallShim
         return set;
     }
 
-    /// <summary>Schema-required parameters absent from the call → a named refusal (Q3), or null to proceed.</summary>
+    /// <summary>Schema-required parameters absent from the call → a named refusal (Q3), or null to proceed.
+    /// An EXPLICIT JSON <c>null</c> for a required parameter counts as missing too (unless the schema itself declares
+    /// null legal): the SDK binds it and the tool body NullReferences into the generic "internal houseCARL failure"
+    /// misdirection (2026-06-12 hunt, proven over stdio on nexus_mod) — name the parameter instead.</summary>
     static CallToolResult? MissingRequired(CallToolRequestParams p, JsonElement schema)
     {
         if (schema.ValueKind != JsonValueKind.Object ||
             !schema.TryGetProperty("required", out var req) || req.ValueKind != JsonValueKind.Array) return null;
 
+        schema.TryGetProperty("properties", out var props);
+
         List<string>? missing = null;
         foreach (var r in req.EnumerateArray())
-            if (r.GetString() is { } name && (p.Arguments is null || !p.Arguments.ContainsKey(name)))
-                (missing ??= new List<string>()).Add(name);
+        {
+            if (r.GetString() is not { } name) continue;
+            if (p.Arguments is null || !p.Arguments.TryGetValue(name, out var val))
+                { (missing ??= new List<string>()).Add(name); continue; }
+            if (val.ValueKind == JsonValueKind.Null
+                && !(props.ValueKind == JsonValueKind.Object && props.TryGetProperty(name, out var ps) && DeclaredTypes(ps).Contains("null")))
+                (missing ??= new List<string>()).Add(name + " (was explicit null)");
+        }
         if (missing is null) return null;
 
         string plural = missing.Count == 1 ? "" : "s";

--- a/src/housecarl-mcp/ToolPathResolver.cs
+++ b/src/housecarl-mcp/ToolPathResolver.cs
@@ -42,7 +42,14 @@ public sealed class ToolPathResolver
         if (saved is not null && ToolBridge.Validate(dep, saved).ok) return saved;
 
         var found = ToolBridge.Probe(dep);
-        if (found is not null) Save(dep, found);   // persist the auto-detected home so we only probe once
+        if (found is not null)
+        {
+            // Persist the auto-detected home so we only probe once. This silent persist is the ONE path where a
+            // corrupt-config recovery would otherwise vanish for good (the file is rewritten clean, so no later
+            // Update re-reports it) — route the note to stderr, the same channel as the boot log (PR #51 review).
+            var r = Save(dep, found);
+            if (r.persistNote is not null) Console.Error.WriteLine("houseCARL user config recovered: " + r.persistNote);
+        }
         return found;
     }
 

--- a/src/housecarl-mcp/ToolPathResolver.cs
+++ b/src/housecarl-mcp/ToolPathResolver.cs
@@ -48,19 +48,21 @@ public sealed class ToolPathResolver
 
     /// <summary>Validate + SAVE a user-supplied path for a dependency (the housecarl_set_tool_path body). The path is
     /// trimmed of surrounding quotes and made absolute. On a validation failure NOTHING is saved (Q3) and the reason is
-    /// returned; on success it's written to the shared user.json (coexisting with the MO2 instance setting).</summary>
-    public (bool ok, string? error, bool persisted, string? persistError, string resolved) Save(ToolDependency dep, string rawPath)
+    /// returned; on success it's written to the shared user.json (coexisting with the MO2 instance setting).
+    /// <c>persistNote</c> carries a corrupt-file recovery (hunt F3 — the prior file was backed up; other saved settings
+    /// were lost), rendered even on success.</summary>
+    public (bool ok, string? error, bool persisted, string? persistError, string? persistNote, string resolved) Save(ToolDependency dep, string rawPath)
     {
         var path = (rawPath ?? "").Trim().Trim('"');
-        if (path.Length == 0) return (false, "no path given.", false, null, "");
+        if (path.Length == 0) return (false, "no path given.", false, null, null, "");
         try { path = Path.GetFullPath(path); }
-        catch (Exception ex) { return (false, $"'{rawPath}' is not a usable path ({ex.Message}).", false, null, rawPath ?? ""); }
+        catch (Exception ex) { return (false, $"'{rawPath}' is not a usable path ({ex.Message}).", false, null, null, rawPath ?? ""); }
 
         var (ok, error) = ToolBridge.Validate(dep, path);
-        if (!ok) return (false, error, false, null, path);
+        if (!ok) return (false, error, false, null, null, path);
 
-        var (persisted, persistError) = _store.Update(c => (c.ToolPaths ??= new())[ToolBridge.Info(dep).Key] = path);
-        return (true, null, persisted, persistError, path);
+        var (persisted, persistError, persistNote) = _store.Update(c => (c.ToolPaths ??= new())[ToolBridge.Info(dep).Key] = path);
+        return (true, null, persisted, persistError, persistNote, path);
     }
 
     /// <summary>The forcing function a rider calls: out <paramref name="path"/> is the resolved path when available and the

--- a/src/housecarl-mcp/housecarl-mcp.csproj
+++ b/src/housecarl-mcp/housecarl-mcp.csproj
@@ -16,6 +16,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>HousecarlMcp</RootNamespace>
     <AssemblyName>housecarl-mcp</AssemblyName>
+    <!-- ServerInfo.Version truth: build-plugin.ps1 overrides with -p:Version from plugin.json (the single
+         version home), so a release exe reports the real release; an unstamped dev build says 0.0.0-dev. -->
+    <Version>0.0.0-dev</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Pre-1.3.0 hardening batch — hunt F2 + F3 + F4 + render wave

The next slice of the 2026-06-12 adversarial-hunt backlog, after #48/#49/#50 landed. Three commits, each with its guard proven RED first.

### 1. Write-path mutex + orphan folders (F2 + F4) — `9d2642f`

**The bug (F2, the gate item):** the MCP SDK dispatches tool calls concurrently and the .esp write path had no mutual exclusion — `ResolveOutputPath` took no gate, `UniqueStem` was check-then-create TOCTOU, and the staging path under a patch folder is fixed (`.housecarl-tmp\<name>.esp`). Two same-default-name writes could allocate the SAME folder and cross-commit (R1's success message shipping R2's bytes); concurrent `into=` extends silently lost the first call's edits.

**The fix:** a service-level `_writeGate` serializes the whole resolve→stage→commit of `ApplyEdits` / `RemoveRecords` / `CreateRecords` (writes are seconds-long and rare — serializing is correct, accuracy over perf). `ResolveOutputPath` now runs under `_gate` like its sibling, closing the folder-allocation TOCTOU. `SetInstance` takes the write gate too, so an instance switch can't tear a write in flight. Lock order where both are held: `_writeGate` then `_gate`.

**F4 rode the same path:** the fresh folder + meta.ini were created BEFORE pre-flight, so "NO patch written" left an orphan accreting `_001/_002` on retry. Now a refused write removes the folder it created — deletion-safe by content check (only our meta.ini + an empty `.housecarl-tmp`).

**Guard:** `write-mutex-guard` (new CI step) — concurrent default-name pairs, concurrent extends, refused-write orphan checks, all against the REAL `ApplyEdits` on a synthetic MO2 instance. **RED-proven** against pre-fix code: 6/12 concurrent writes failed, paths collided, an extend lost its sibling's edit, orphans accreted to `_002`.

### 2. user.json hardening (F3) — `424161c`

**The bug (hunter-PROVEN with measured silent clobbers):** `WriteAllText` non-atomic; a corrupt file silently parsed as BLANK and the next Update wrote blank+one-field back with ok=true (wiping the saved MO2 instance + tool paths); the store's gate was process-local while two server processes (CLI plugin + desktop app) share the file.

**The fix, all in `UserConfigStore`:** atomic temp+rename writes; the whole read-modify-write under a named cross-process mutex derived from the file path; corrupt = LOUD — backed up to `.corrupt.bak` and reported via a new note channel that `set_mo2_instance` / `set_tool_path` render as a RECOVERED line and the boot log surfaces at startup. Never silently blank.

**Guard:** `tool-bridge` extended — atomic no-residue, corrupt backup byte-for-byte + reported on Load AND Update, fresh file reads clean after recovery, and a two-store 200-round concurrent hammer (the CLI+desktop two-process shape) where both concerns' last values must survive. **Teeth proven by mutation run** (mutex skipped + silent-blank restored): all four new arms FAIL.

### 3. Render wave — `9b6adb5`

Eight truth-in-rendering fixes:
- **ToolCallShim:** explicit JSON `null` for a required param now refuses by name instead of NullReferencing into the "internal houseCARL failure… capture a bug report" misdirection (proven over stdio on nexus_mod). `binding-shim-guard` arm H, **RED-proven** against the pre-fix shim.
- **ServerInfo.Version:** was hardcoded "0.1.0" → now the exe's stamped InformationalVersion; `build-plugin.ps1` passes `-p:Version` from plugin.json (single version home); unstamped dev builds say `0.0.0-dev`. The "16 tools" comment de-numbered.
- **ReadTools:** three descriptions claimed `conflicts_only=` bounds a body scan; the implementation refuses that — descriptions now match reality (type= or plugins= only).
- **NexusTools:** no-MAIN-file mods say so explicitly; 0 search matches WITH `category=` note that category matching is server-side exact + case-sensitive ('Armour' 5041 vs 'armour' 0, live-proven).
- **CompileTools:** failed-compile "error(s)" → "diagnostic(s)" (the CK mixes warnings in).
- **SetupTools:** the swallowed enabled-mods proof-line failure is now named; `set_mo2_instance` trims surrounding quotes like every sibling.
- **WritePatchBuilder:** "Omit extend" → "Omit into=" (extend is not a wire param).

### Verification

- All three new/extended guards GREEN on the final tree; RED/mutation runs recorded per commit.
- Neighboring write guards re-run clean: upsert-guard, writelock-guard, verify-loop-guard, snapshot-view-guard.
- Full solution builds with 0 errors.

Still open from the hunt backlog (deferred per handoff): F5–F9 freshness batch, hunter NOTEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
