### PR TITLE
Freshness + write-capture hardening (hunt F5-F8 + PR #51 review note)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,3 +158,12 @@ jobs:
       # Self-contained: a synthetic MO2 instance + a synthesized master in temp.
       - name: Probe — write-path mutex (concurrent writes serialize; refusals leave no orphan)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- write-mutex-guard
+
+      # Freshness + write-capture (2026-06-12 hunt F5-F8 + the PR #51 review note): a restored-backup profile or
+      # ModOrganizer.ini (newer content, OLDER mtimes) is seen — baselines compare last-seen mtimes by value, never
+      # wall-clock order; one status line and one multi-op write each compose from ONE index build (no torn status,
+      # no patch silently mixing two builds' winners); and a concurrent read's freshness refresh DEFERS while a
+      # write is in flight (never rebuilds/swaps the index under a serialize). Self-contained: synthetic MO2
+      # instances + synthesized plugins in temp.
+      - name: Probe — freshness + write-capture (restored backups seen; one build per answer)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- freshness-capture-guard

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -420,6 +420,13 @@ public sealed class LoadOrderResolver : IDisposable
         public IEnumerable<(FormKey fk, int depth, IMajorRecordGetter body, string source)> RecordsIn(
             IReadOnlyList<string> plugins, IReadOnlyList<Type>? getterTypes)
             => _r.RecordsIn(plugins, getterTypes, _s);
+
+        /// <summary>One record's body from a named plugin (<see cref="LoadOrderResolver.GetRecord"/>), with the
+        /// excluded-plugin check judged against THIS view's build — so a winner this view resolved and the body
+        /// fetched for it can never be vetted by two different builds (2026-06-12 hunt F5: the write path resolves
+        /// every edit of one call off ONE view; reads pin their fetch to the same view they resolved with).</summary>
+        public IMajorRecordGetter? GetRecord(OverlaySession session, string pluginName, FormKey fk)
+            => _r.GetRecord(session, pluginName, fk, _s);
     }
 
     // ---- Queries -------------------------------------------------------
@@ -490,9 +497,12 @@ public sealed class LoadOrderResolver : IDisposable
     /// for an explicit-plugin read, and for the winner's body off <see cref="ResolveWinner"/>. The returned body is
     /// backed by the session's overlay — read it before the session disposes.</summary>
     public IMajorRecordGetter? GetRecord(OverlaySession session, string pluginName, FormKey fk)
+        => GetRecord(session, pluginName, fk, _snap);                      // single-shot: this call = its own build (the IndexView overload pins a whole operation)
+
+    IMajorRecordGetter? GetRecord(OverlaySession session, string pluginName, FormKey fk, IndexSnapshot s)
     {
         if (!_nameToIdx.TryGetValue(pluginName, out int idx)) return null;
-        if (_snap.Excluded.Contains(idx)) return null;                     // excluded plugin — never re-enumerate it (would re-throw); the service reports the reason via ExcludedPlugins
+        if (s.Excluded.Contains(idx)) return null;                         // excluded plugin — never re-enumerate it (would re-throw); the service reports the reason via ExcludedPlugins
         foreach (var rec in session.Overlay(idx).EnumerateMajorRecords())
             if (rec.FormKey == fk) return rec;
         return null;

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -147,14 +147,20 @@ public static class WritePatchBuilder
         using var session = resolver.OpenSession();
 
         // --- Phase 1: resolve winner + derive RecordType + pre-flight EVERY edit. Collect ALL problems (so the caller
-        //     sees every fix at once), then refuse the whole call if any (Q3 — never a silently-partial patch). ---
+        //     sees every fix at once), then refuse the whole call if any (Q3 — never a silently-partial patch).
+        //     ONE captured view answers EVERY edit (2026-06-12 hunt F5): the per-edit single-shot resolves each took
+        //     a fresh capture, so a freshness rebuild landing mid-loop (a concurrent read's refresh) could resolve
+        //     two edits of ONE call against two different builds' winners — a silently MIXED patch
+        //     (freshness-capture-guard arm 4, RED pre-fix: 2 of 12 hammered multi-op writes mixed). The write is one
+        //     logical operation; it reads one build — the same HCBR-2026-06-11-02 discipline the read service follows. ---
+        var view = resolver.Capture();
         var resolved = new List<(PatchEdit edit, IMajorRecordGetter body, string winnerPlugin, WriteRequest req, string label)>(edits.Count);
         var problems = new List<string>();
         foreach (var e in edits)
         {
-            var w = resolver.ResolveWinner(e.Target);
-            if (w is null) { problems.Add($"{e.Target}: not present in the load order ({resolver.PluginCount} plugins)."); continue; }
-            var body = resolver.GetRecord(session, w.Value.WinnerPlugin, e.Target);
+            var w = view.ResolveWinner(e.Target);
+            if (w is null) { problems.Add($"{e.Target}: not present in the load order ({view.PluginCount} plugins)."); continue; }
+            var body = view.GetRecord(session, w.Value.WinnerPlugin, e.Target);
             if (body is null) { problems.Add($"{e.Target}: winner '{w.Value.WinnerPlugin}' did not yield it on fetch (a load-order inconsistency)."); continue; }
 
             var recType = RecordNaming.StripOverlay(body.GetType().Name);

--- a/src/housecarl-generator/FreshnessCaptureProbe.cs
+++ b/src/housecarl-generator/FreshnessCaptureProbe.cs
@@ -1,0 +1,335 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// Freshness + write-capture guard (2026-06-12 adversarial hunt F5–F8 + the PR #51 review note): the freshness
+/// machinery is what lets houseCARL promise "the answer reflects the CURRENT MO2 state" without a daemon — so a
+/// freshness check that misses a change (F7/F8), or an answer composed from TWO adjacent builds (F5/F6), is a
+/// silent wrong answer (Q3), not a perf nit. Arms:
+///
+///   1  F8/profile — MO2 "Restore Backup" rewrites the profile files with OLDER mtimes; the wall-clock
+///      `mtime &gt; builtUtc` check is blind to a regression, so the restored order stays invisible for the
+///      process lifetime. The fix compares last-SEEN mtimes by VALUE (!=), like the resolver always has.
+///      Deterministic RED.
+///   2  F7+F8/ini — SetInstance stamped its ini baseline AFTER reading the instance (the one stamp-after in
+///      the file), and the profile-switch check used `&lt;=`; a backdated/restored ModOrganizer.ini profile
+///      switch is invisible forever. Deterministic RED.
+///   3  F6/status — housecarl_load_order_status read the resolver's view and then the per-build fields
+///      (warnings / staleness / profile dir) OUTSIDE the gate, with file I/O in between — a concurrent
+///      freshness rebuild lands in that gap and the one status line mixes two builds. Hammer: concurrent
+///      readers + an atomic loadorder flipper; ANY (count, warning) pair that no single build produces = torn.
+///   4  F5/write — WritePatchBuilder.Apply Phase 1 resolved winner + body PER EDIT (a fresh capture each), so
+///      a freshness rebuild landing mid-loop resolved two edits of ONE call against two builds' winners — a
+///      silently MIXED patch. Hammer at the core layer: a flipper rewrites the override plugin + refreshes
+///      mid-Apply; every SUCCESSFUL patch must carry ONE build's bodies (uniform marker values).
+///   5  Deferral (PR #51 review note) — a concurrent read's freshness refresh used to rebuild/swap the index
+///      UNDER an in-flight write (transiently mmap-opening every plugin INCLUDING the file the write is
+///      serializing — the #24 "no mapped handle on the target survives the serialize" invariant, breached
+///      from the read path). The fix defers the read-path refresh while a write holds the write gate: a
+///      mid-write read serves the last good snapshot; the NEXT call refreshes. Deterministic given a write
+///      long enough to straddle the read (retried; judged only when the read provably finished mid-write).
+///
+/// Self-contained: synthetic MO2 instances + synthesized plugins in temp; generates its own corpus. No game data.
+/// </summary>
+internal static class FreshnessCaptureProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" freshness-capture guard — one build per answer; no missed change");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        var root = Path.Combine(Path.GetTempPath(), "hc-freshness-guard-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root, "game", "Data"));   // the ini's gamePath target
+
+            // ---- synthesized plugin bytes, built once and copied into per-arm fixtures ----
+            var masterKey = new ModKey("HcFcgMaster", ModType.Master);
+            var ovKey = new ModKey("HcFcgOverride", ModType.Plugin);
+            var extraKey = new ModKey("HcFcgExtra", ModType.Plugin);
+            string masterName = masterKey.FileName.String, ovName = ovKey.FileName.String, extraName = extraKey.FileName.String;
+            const int Pad = 1500;   // master record count — pads per-edit body fetches so arms 4/5 have a real time window
+            const int OvN = 150;    // the overridden/edited subset arm 4 judges
+
+            var bytes = Path.Combine(root, "plugin-bytes");
+            Directory.CreateDirectory(Path.Combine(bytes, "full"));
+            Directory.CreateDirectory(Path.Combine(bytes, "empty"));
+
+            var master = new SkyrimMod(masterKey, SkyrimRelease.SkyrimSE);
+            var fks = new List<FormKey>(Pad);
+            for (int i = 0; i < Pad; i++)
+            {
+                var w = master.Weapons.AddNew(); w.EditorID = $"HcFcgW{i:D3}";
+                w.BasicStats = new WeaponBasicStats { Damage = 10, Weight = 1 };
+                fks.Add(w.FormKey);
+            }
+            var masterFile = Path.Combine(bytes, masterName);
+            master.BeginWrite.ToPath(masterFile).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+            // override variant FULL: the first OvN weapons re-declared with Damage=20 (the build marker arm 4 reads)
+            var fullMod = new SkyrimMod(ovKey, SkyrimRelease.SkyrimSE);
+            foreach (var w in master.Weapons.Take(OvN))
+                ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(fullMod, w)).BasicStats = new WeaponBasicStats { Damage = 20, Weight = 1 };
+            var fullFile = Path.Combine(bytes, "full", ovName);
+            fullMod.BeginWrite.ToPath(fullFile).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
+
+            // override variant EMPTY: same ModKey, no records — the master wins everything
+            var emptyMod = new SkyrimMod(ovKey, SkyrimRelease.SkyrimSE);
+            var emptyFile = Path.Combine(bytes, "empty", ovName);
+            emptyMod.BeginWrite.ToPath(emptyFile).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+            var extraMod = new SkyrimMod(extraKey, SkyrimRelease.SkyrimSE);
+            var xw = extraMod.Weapons.AddNew(); xw.EditorID = "HcFcgExtraW"; xw.BasicStats = new WeaponBasicStats { Damage = 5 };
+            var extraFile = Path.Combine(bytes, extraName);
+            extraMod.BeginWrite.ToPath(extraFile).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+            // The service's pre-flight rulebook loads from the static CorpusPath — generate one fresh (CI has no repo state).
+            var genDir = Path.Combine(root, "corpus-gen");
+            CorpusGenerator.GenerateAll(genDir, Path.Combine(root, "corpus-ref"));
+            CorpusRulebook.CorpusPath = Path.Combine(genDir, "corpus.json");
+
+            // ---- per-arm fixture helpers ----
+            string NewInstance(string name)
+            {
+                var inst = Path.Combine(root, name);
+                var mods = Path.Combine(inst, "mods");
+                Directory.CreateDirectory(Path.Combine(mods, "MasterMod"));
+                File.Copy(masterFile, Path.Combine(mods, "MasterMod", masterName));
+                Directory.CreateDirectory(Path.Combine(mods, "ExtraMod"));
+                File.Copy(extraFile, Path.Combine(mods, "ExtraMod", extraName));
+                WriteIni(inst, "Default");
+                return inst;
+            }
+            void WriteIni(string inst, string profile) =>
+                File.WriteAllText(Path.Combine(inst, "ModOrganizer.ini"),
+                    "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(" + profile + ")\r\ngamePath=@ByteArray("
+                    + Path.Combine(root, "game").Replace(@"\", @"\\") + ")\r\n");
+            void WriteProfile(string profDir, string[] loadorder, string[] plugins, string[] modlist)
+            {
+                Directory.CreateDirectory(profDir);
+                File.WriteAllText(Path.Combine(profDir, "loadorder.txt"), "# header\r\n" + string.Join("\r\n", loadorder) + "\r\n");
+                File.WriteAllText(Path.Combine(profDir, "plugins.txt"), string.Join("\r\n", plugins) + "\r\n");
+                File.WriteAllText(Path.Combine(profDir, "modlist.txt"), "# header\r\n" + string.Join("\r\n", modlist) + "\r\n");
+            }
+            string Fid(FormKey fk) => $"{fk.ID:X6}:{fk.ModKey.FileName}";
+
+            // ---- 1: F8/profile — a restored-backup profile (newer content, OLDER mtimes) must be seen ----
+            Console.WriteLine("--- 1: MO2 'Restore Backup' on the profile files (older mtimes) is picked up (hunt F8) ---");
+            {
+                var inst = NewInstance("inst-f8");
+                var prof = Path.Combine(inst, "profiles", "Default");
+                WriteProfile(prof, new[] { masterName }, new[] { "*" + masterName }, new[] { "+MasterMod" });
+                var store = new UserConfigStore(Path.Combine(root, "user-f8.json"));
+                using var svc = LoadOrderService.WithInstance(inst, 0, store);
+                var before = svc.Stats().plugins;
+                Check(before == 1, $"baseline order resolved — {before}/1 plugin");
+
+                var backdate = DateTime.UtcNow.AddHours(-2);          // the restored backup pre-dates the build baseline
+                WriteProfile(prof, new[] { masterName, extraName },
+                             new[] { "*" + masterName, "*" + extraName }, new[] { "+ExtraMod", "+MasterMod" });
+                foreach (var f in new[] { "loadorder.txt", "plugins.txt", "modlist.txt" })
+                    File.SetLastWriteTimeUtc(Path.Combine(prof, f), backdate);
+                var after = svc.Stats().plugins;
+                Check(after == 2, $"the restored profile (different content, older mtimes) was re-resolved — {after}/2 plugins");
+            }
+
+            // ---- 2: F7+F8/ini — a backdated ModOrganizer.ini profile switch after SetInstance must be seen ----
+            Console.WriteLine();
+            Console.WriteLine("--- 2: restored-backup ModOrganizer.ini profile switch after SetInstance is followed (hunt F7+F8) ---");
+            {
+                var inst = NewInstance("inst-f7");
+                WriteProfile(Path.Combine(inst, "profiles", "Default"),
+                             new[] { masterName }, new[] { "*" + masterName }, new[] { "+MasterMod" });
+                WriteProfile(Path.Combine(inst, "profiles", "Second"), new[] { masterName, extraName },
+                             new[] { "*" + masterName, "*" + extraName }, new[] { "+MasterMod", "+ExtraMod" });
+                var store = new UserConfigStore(Path.Combine(root, "user-f7.json"));
+                using var svc = LoadOrderService.WithInstance(inst, 0, store);
+                svc.SetInstance(inst);                                // the F7 path: THIS stamps the ini baseline
+                var before = svc.Stats().plugins;
+                Check(before == 1 && svc.ProfileName == "Default", $"baseline on profile 'Default' — {before}/1 plugin, profile={svc.ProfileName}");
+
+                WriteIni(inst, "Second");                             // the switch arrives via a restored/backdated ini
+                File.SetLastWriteTimeUtc(Path.Combine(inst, "ModOrganizer.ini"), DateTime.UtcNow.AddHours(-2));
+                var after = svc.Stats().plugins;
+                Check(svc.ProfileName == "Second" && after == 2,
+                      $"the backdated ini's profile switch was followed — profile={svc.ProfileName}, {after}/2 plugins");
+            }
+
+            // ---- 3: F6/status — concurrent flips never tear one status line across two builds ----
+            Console.WriteLine();
+            Console.WriteLine("--- 3: status line composes ONE build under concurrent profile flips (hunt F6) ---");
+            {
+                var inst = NewInstance("inst-f6");
+                var prof = Path.Combine(inst, "profiles", "Default");
+                // plugins.txt + modlist.txt constant; loadorder.txt flips ATOMICALLY (temp+move) between
+                //   X: [master, Ghost.esp] → 1 resolved + the "no enabled mod provides Ghost.esp" warning
+                //   Y: [master, extra]     → 2 resolved + no warning
+                // so EVERY complete build is (1, ghost-warning) or (2, none) — any other pair is a torn line.
+                WriteProfile(prof, new[] { masterName, extraName },
+                             new[] { "*" + masterName, "*" + extraName }, new[] { "+MasterMod", "+ExtraMod" });
+                var store = new UserConfigStore(Path.Combine(root, "user-f6.json"));
+                using var svc = LoadOrderService.WithInstance(inst, 0, store);
+                svc.Stats();                                          // warm the lazy index off the clock
+                string lo = Path.Combine(prof, "loadorder.txt");
+                string stateX = "# header\r\n" + masterName + "\r\nGhost.esp\r\n";
+                string stateY = "# header\r\n" + masterName + "\r\n" + extraName + "\r\n";
+                int torn = 0; long reads = 0; long contended = 0;
+                using var stop = new CancellationTokenSource(TimeSpan.FromSeconds(4));
+                var flipper = Task.Run(() =>
+                {
+                    bool x = true;
+                    while (!stop.IsCancellationRequested)
+                    {
+                        try
+                        {
+                            var tmp = lo + ".tmp";
+                            File.WriteAllText(tmp, x ? stateX : stateY);
+                            File.Move(tmp, lo, overwrite: true);      // atomic: a reader sees old or new, never partial
+                        }
+                        catch (IOException) { }                       // reader had it open — flip again next tick
+                        catch (UnauthorizedAccessException) { }       // same race, surfaced as access-denied on Windows
+                        x = !x;
+                        Thread.Sleep(2);
+                    }
+                });
+                var readers = Enumerable.Range(0, 3).Select(_ => Task.Run(() =>
+                {
+                    while (!stop.IsCancellationRequested)
+                    {
+                        LoadOrderStatusData s;
+                        // A read colliding with the flipper's in-progress replace fails LOUD (an IOException out of the
+                        // profile-file read) — the honest MO2-mid-write transient, not a torn answer; skip and re-read.
+                        try { s = svc.StatusData(); }
+                        catch (IOException) { Interlocked.Increment(ref contended); continue; }
+                        catch (UnauthorizedAccessException) { Interlocked.Increment(ref contended); continue; }
+                        bool ghost = s.Warnings.Any(w => w.Contains("Ghost.esp", StringComparison.OrdinalIgnoreCase));
+                        if ((s.ResolvedPluginCount == 2 && ghost) || (s.ResolvedPluginCount == 1 && !ghost))
+                            Interlocked.Increment(ref torn);
+                        Interlocked.Increment(ref reads);
+                    }
+                })).ToList();
+                readers.Add(flipper);
+                Task.WaitAll(readers.ToArray());
+                Check(torn == 0,
+                      $"no torn status line across {Interlocked.Read(ref reads)} concurrent reads (torn={torn}, loud transients={Interlocked.Read(ref contended)})");
+            }
+
+            // ---- 4: F5/write — every successful multi-op patch carries ONE build's winners ----
+            Console.WriteLine();
+            Console.WriteLine("--- 4: one multi-op write resolves EVERY edit against ONE build (hunt F5) ---");
+            {
+                var dir = Path.Combine(root, "core-f5");
+                Directory.CreateDirectory(dir);
+                var mPath = Path.Combine(dir, masterName); File.Copy(masterFile, mPath);
+                var oPath = Path.Combine(dir, ovName); File.Copy(emptyFile, oPath);
+                using var resolver = LoadOrderResolver.Build(new[] { mPath, oPath });
+                var rulebook = CorpusRulebook.Load();
+                var edits = fks.Take(OvN).Select(fk => new WritePatchBuilder.PatchEdit
+                {
+                    Target = fk, Path = new[] { "BasicStats", "Weight" }, Verb = "Set", Value = "7",
+                }).ToList();
+
+                static bool TryCopy(string src, string dst)
+                {
+                    for (int i = 0; i < 40; i++)
+                    {
+                        try { File.Copy(src, dst, overwrite: true); return true; }
+                        catch (IOException) { Thread.Sleep(5); }
+                    }
+                    return false;
+                }
+
+                int mixed = 0, successes = 0, refusals = 0;
+                const int Rounds = 12;
+                for (int r = 0; r < Rounds; r++)
+                {
+                    TryCopy(emptyFile, oPath);                        // reset: master wins everything (Damage=10)
+                    resolver.RefreshIfStale();
+                    int delay = 5 + r * 17 % 130;                     // sweep the flip across the Phase-1 loop
+                    var flip = Task.Run(() =>
+                    {
+                        Thread.Sleep(delay);
+                        if (TryCopy(fullFile, oPath))                 // the override now wins the OvN subset (Damage=20)
+                            resolver.RefreshIfStale();                // the concurrent read's freshness path, mid-Apply
+                    });
+                    var outDir = Path.Combine(dir, $"out_{r:D3}");
+                    Directory.CreateDirectory(outDir);
+                    var o = WritePatchBuilder.Apply(resolver, rulebook, edits, Path.Combine(outDir, "HcFcgOut.esp"), extend: false);
+                    flip.Wait();
+                    if (!o.Success) { refusals++; continue; }         // an honest named refusal is fine — mixing silently is not
+                    successes++;
+                    ISkyrimModGetter? back = null;
+                    HashSet<ushort> marks;
+                    try
+                    {
+                        back = SkyrimMod.CreateFromBinaryOverlay(o.OutputPath, SkyrimRelease.SkyrimSE);
+                        var want = fks.Take(OvN).ToHashSet();
+                        marks = back.Weapons.Where(w => want.Contains(w.FormKey)).Select(w => w.BasicStats?.Damage ?? 0).ToHashSet();
+                    }
+                    finally { (back as IDisposable)?.Dispose(); }
+                    if (marks.Count > 1) mixed++;
+                }
+                Check(mixed == 0,
+                      $"no successful patch mixed two builds' winners — {successes} success(es), {refusals} honest refusal(s), mixed={mixed}");
+            }
+
+            // ---- 5: deferral — a read's freshness refresh waits out an in-flight write ----
+            Console.WriteLine();
+            Console.WriteLine("--- 5: a concurrent read defers its freshness refresh while a write is in flight (PR #51 review note) ---");
+            {
+                var inst = NewInstance("inst-defer");
+                var prof = Path.Combine(inst, "profiles", "Default");
+                WriteProfile(prof, new[] { masterName }, new[] { "*" + masterName }, new[] { "+MasterMod" });
+                var store = new UserConfigStore(Path.Combine(root, "user-defer.json"));
+                using var svc = LoadOrderService.WithInstance(inst, 0, store);
+                Check(svc.Stats().plugins == 1, "baseline order resolved — 1 plugin");
+
+                var ops = fks.Skip(OvN).Take(250).Select(fk => new BulkOp
+                {
+                    Formid = Fid(fk), FieldPath = "BasicStats.Weight", Verb = "Set", Value = "9",
+                }).ToList();
+
+                int duringCount = -1; bool judged = false;
+                WritePatchBuilder.PatchOutcome? outcome = null;
+                for (int attempt = 0; attempt < 5 && !judged; attempt++)
+                {
+                    WriteProfile(prof, new[] { masterName }, new[] { "*" + masterName }, new[] { "+MasterMod" });
+                    svc.Stats();                                      // settle back on the 1-plugin order
+                    var started = new ManualResetEventSlim();
+                    var wt = Task.Run(() => { started.Set(); return svc.ApplyEdits(ops, $"HcFcgDefer{attempt}", null); });
+                    started.Wait();
+                    Thread.Sleep(100);                                // let the write get into its resolve/serialize body
+                    if (wt.IsCompleted) { outcome = wt.Result; continue; }   // write finished too fast to straddle — retry
+                    WriteProfile(prof, new[] { masterName, extraName },     // a real MO2 toggle arrives MID-write
+                                 new[] { "*" + masterName, "*" + extraName }, new[] { "+MasterMod", "+ExtraMod" });
+                    var dc = svc.Stats().plugins;                     // the concurrent read
+                    bool midFlight = !wt.IsCompleted;                 // judge only a read that provably finished mid-write
+                    outcome = wt.Result;
+                    if (!midFlight) continue;
+                    duringCount = dc; judged = true;
+                }
+                Check(judged, "landed a read that completed while the write was still in flight");
+                Check(outcome is { Success: true }, $"the in-flight write succeeded — {outcome?.Error ?? "ok"}");
+                Check(duringCount == 1,
+                      $"the mid-write read served the last good snapshot (refresh deferred, no mid-write rebuild) — saw {duringCount} plugin(s)");
+                var afterCount = svc.Stats().plugins;
+                Check(afterCount == 2, $"the deferred refresh ran on the NEXT call — {afterCount}/2 plugins (freshness deferred, never lost)");
+            }
+        }
+        finally { try { Directory.Delete(root, recursive: true); } catch { /* temp scratch */ } }
+
+        Console.WriteLine();
+        Console.WriteLine(fail == 0 ? "================ ALL PASS ================" : $"================ {fail} CHECK(S) FAILED ================");
+        return fail == 0 ? 0 : 1;
+    }
+}

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -68,6 +68,11 @@ if (args.Length > 0 && args[0] == "hierarchy-cache-guard") return HierarchyCache
 // bytes, no lost extend), and a pre-flight-refused fresh write removes the folder it created (no _NNN accretion).
 if (args.Length > 0 && args[0] == "write-mutex-guard") return WriteMutexProbe.RunGuard(args[1..]);
 
+// Freshness + write-capture guard (2026-06-12 hunt F5–F8 + PR #51 review note): restored-backup profile/ini
+// changes (older mtimes) are seen; one status line / one multi-op write composes from ONE build; a concurrent
+// read's freshness refresh defers while a write is in flight (never rebuilds under a serialize).
+if (args.Length > 0 && args[0] == "freshness-capture-guard") return FreshnessCaptureProbe.RunGuard(args[1..]);
+
 // Compile-tool import order: caller import_dirs OUTRANK the vanilla auto-import (first match wins, so
 // SKSE-extended copies of vanilla sources must win). Pure order arm always runs; real-compile arm self-skips.
 if (args.Length > 0 && args[0] == "import-order-guard") return ImportOrderProbe.RunGuard(args[1..]);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -45,9 +45,16 @@ public sealed class LoadOrderService : IDisposable
     LoadOrderResolver? _resolver;
     CorpusRulebook? _rulebook;
     IReadOnlyList<string> _orderWarnings = Array.Empty<string>();
-    DateTime _orderBuiltUtc = DateTime.MinValue;   // when the resolver last read the profile (the staleness baseline)
-    DateTime _iniReadUtc = DateTime.MinValue;      // when ModOrganizer.ini was last read (instance-mode profile-switch baseline)
+    // Freshness baselines are the files' LAST-SEEN MTIMES compared by VALUE (!=), the same model the resolver itself
+    // uses — NOT wall-clock stamps compared by ORDER (2026-06-12 hunt F8: `mtime > builtUtc` was blind to an mtime
+    // REGRESSION, so MO2's "Restore Backup" — which restores a profile file with an OLDER mtime — stayed invisible
+    // for the process lifetime). Each baseline is statted BEFORE the read it baselines (TOCTOU: a write landing
+    // during/after the read shows as a changed mtime on the next check, never absorbed).
+    DateTime[] _profileMtimes = new DateTime[ProfileFileNames.Length];   // per ProfileFileNames, recorded at each order build
+    DateTime _iniMtime = DateTime.MinValue;                              // ModOrganizer.ini (instance-mode profile-switch baseline)
     IReadOnlyList<string> _resolvedPaths = Array.Empty<string>();   // ordered paths the current snapshot was built from (the cheap "did the order actually change?" check)
+
+    static readonly string[] ProfileFileNames = { "loadorder.txt", "modlist.txt", "plugins.txt" };
 
     LoadOrderService(string? instanceDir, string dataDir, string modsDir, string profileDir, bool configured, int maxPlugins, UserConfigStore store)
     {
@@ -81,7 +88,6 @@ public sealed class LoadOrderService : IDisposable
     {
         var svc = new LoadOrderService(null, "", "", "", configured: true, maxPlugins: 0, store);
         svc._resolver = resolver;
-        svc._orderBuiltUtc = DateTime.UtcNow;
         return svc;
     }
 
@@ -108,7 +114,7 @@ public sealed class LoadOrderService : IDisposable
                     // §8.5: the TRUE active order, read statically from the MO2 profile (loadorder.txt + modlist.txt +
                     // plugins.txt) — no VFS, no live MO2 state. See HousecarlCore.Mo2LoadOrder + memory
                     // project_mo2_load_order_resolution.
-                    var builtUtc = DateTime.UtcNow;              // stamp BEFORE the read (TOCTOU): a profile write during the build is caught next call, not missed
+                    var profileMtimes = StatProfileFiles();      // stat BEFORE the read (TOCTOU): a profile write during the build is caught next call, not missed
                     var order = Mo2LoadOrder.Build(_profileDir, _modsDir, _dataDir);
                     _orderWarnings = order.Warnings;
                     var paths = order.OrderedPaths;
@@ -120,12 +126,26 @@ public sealed class LoadOrderService : IDisposable
                             "HouseCarl config and that MO2 has written loadorder.txt/modlist.txt (a refresh/re-sort in MO2).");
                     _resolver = LoadOrderResolver.Build(paths);
                     _resolvedPaths = paths;
-                    _orderBuiltUtc = builtUtc;
+                    _profileMtimes = profileMtimes;
                 }
-                else
+                else if (Monitor.TryEnter(_writeGate))
                 {
-                    RefreshOnProfileChange();     // to-do #6: lazy profile-membership refresh on THIS call (cheap-check first)
-                    _resolver.RefreshIfStale();   // plugin-CONTENT freshness: cheap stat sweep; rebuilds if a plugin's bytes changed
+                    // Lazy freshness, run on each tool call once the snapshot exists — but DEFERRED while a WRITE is
+                    // in flight (PR #51 review note): a refresh here can rebuild the index — transiently mmap-opening
+                    // every plugin INCLUDING the file a concurrent write is serializing (the PR #24 "no mapped handle
+                    // on the target survives the serialize" invariant, breached from the read path) — and dispose-swap
+                    // the resolver that write captured. TryEnter probes the write gate WITHOUT blocking: it cannot
+                    // deadlock (no blocking _gate→_writeGate wait — the established blocking order stays _writeGate
+                    // THEN _gate), and Monitor reentrancy keeps the write's OWN entry refresh working (it holds
+                    // _writeGate, so its TryEnter succeeds). A skipped refresh serves the last good snapshot and
+                    // re-checks on the next call — the freshness contract is per-call lazy, so deferral behind a
+                    // seconds-long write is honest staleness, never wrongness (freshness-capture-guard arm 5).
+                    try
+                    {
+                        RefreshOnProfileChange();     // to-do #6: lazy profile-membership refresh on THIS call (cheap-check first)
+                        _resolver.RefreshIfStale();   // plugin-CONTENT freshness: cheap stat sweep; rebuilds if a plugin's bytes changed
+                    }
+                    finally { Monitor.Exit(_writeGate); }
                 }
                 return _resolver;
             }
@@ -145,22 +165,48 @@ public sealed class LoadOrderService : IDisposable
     /// changed since that build (Q3 — never present a stale picture as current). Forces the lazy resolver build.</summary>
     public LoadOrderStatusData StatusData()
     {
-        var view = Resolver.Capture();                             // force build/refresh; ONE build for count + exclusions (HCBR-2026-06-11-02)
-        var comp = Mo2LoadOrder.ReadComposition(_profileDir);      // FRESH composition (always current)
+        // The view AND the per-build fields beside it (warnings / staleness / profile dir) are snapshotted under ONE
+        // gate hold (2026-06-12 hunt F6): they used to be read outside the gate after Capture() returned, so a
+        // concurrent freshness rebuild landing in that gap could compose one status line from TWO adjacent builds —
+        // the count from one, the warnings beside it from another. The fresh composition stays OUTSIDE the gate by
+        // design (it is documented as always-current and is not judged against the resolver's build).
+        LoadOrderResolver.IndexView view; IReadOnlyList<string> warnings; bool profileChanged; string profileDir;
+        lock (_gate)
+        {
+            view = Resolver.Capture();                             // force build/refresh; ONE build for count + exclusions (HCBR-2026-06-11-02)
+            warnings = _orderWarnings;
+            profileChanged = ProfileFilesChanged();
+            profileDir = _profileDir;
+        }
+        var comp = Mo2LoadOrder.ReadComposition(profileDir);       // FRESH composition (always current)
         return new LoadOrderStatusData(
-            comp, _orderWarnings, view.PluginCount, _maxPlugins, ProfileNewerThan(_orderBuiltUtc), _profileDir, view.ExcludedPlugins);
+            comp, warnings, view.PluginCount, _maxPlugins, profileChanged, profileDir, view.ExcludedPlugins);
     }
 
-    /// <summary>True if any of the three MO2 profile files has a newer mtime than the resolver's last build — i.e. the
-    /// user toggled mods/plugins or re-sorted since, so the resolver's resolved set is behind the live profile.</summary>
-    bool ProfileNewerThan(DateTime builtUtc)
+    /// <summary>True if any of the three MO2 profile files' mtimes DIFFERS from the last build's baseline — the user
+    /// toggled mods/plugins, re-sorted, or RESTORED A BACKUP since, so the resolver's resolved set is behind the live
+    /// profile. Compared by value (!=), like the resolver's own plugin sweep: a restored backup carries an OLDER
+    /// mtime, which an is-newer comparison was blind to (hunt F8). Caller holds <see cref="_gate"/>.</summary>
+    bool ProfileFilesChanged()
     {
-        foreach (var f in new[] { "loadorder.txt", "modlist.txt", "plugins.txt" })
-        {
-            var p = Path.Combine(_profileDir, f);
-            if (File.Exists(p) && File.GetLastWriteTimeUtc(p) > builtUtc) return true;
-        }
+        if (_profileDir.Length == 0) return false;                 // guard seam / not yet derived — nothing to compare against
+        for (int i = 0; i < ProfileFileNames.Length; i++)
+            if (SafeMtime(Path.Combine(_profileDir, ProfileFileNames[i])) != _profileMtimes[i]) return true;
         return false;
+    }
+
+    /// <summary>The three profile files' current mtimes, in <see cref="ProfileFileNames"/> order — the freshness
+    /// baseline a build records. Stat BEFORE the read it baselines (TOCTOU). Caller holds <see cref="_gate"/>.</summary>
+    DateTime[] StatProfileFiles()
+    {
+        var m = new DateTime[ProfileFileNames.Length];
+        for (int i = 0; i < ProfileFileNames.Length; i++) m[i] = SafeMtime(Path.Combine(_profileDir, ProfileFileNames[i]));
+        return m;
+    }
+
+    static DateTime SafeMtime(string path)
+    {
+        try { return File.GetLastWriteTimeUtc(path); } catch { return DateTime.MinValue; }
     }
 
     /// <summary>To-do #6 — LAZY freshness, run on each tool call once the snapshot exists. Two signals, both cheap-mtime:
@@ -173,7 +219,7 @@ public sealed class LoadOrderService : IDisposable
     void RefreshOnProfileChange()
     {
         if (RederiveIfIniChanged()) return;                      // instance mode: a profile SWITCH already re-derived + re-resolved
-        if (!ProfileNewerThan(_orderBuiltUtc)) return;           // nothing touched the active profile → nothing to do
+        if (!ProfileFilesChanged()) return;                      // nothing touched the active profile → nothing to do
         ReResolve();
     }
 
@@ -186,10 +232,11 @@ public sealed class LoadOrderService : IDisposable
     {
         if (_instanceDir is null) return false;                  // explicit/override mode — no ini to watch
         var ini = Mo2Instance.IniPath(_instanceDir);
-        if (!File.Exists(ini) || File.GetLastWriteTimeUtc(ini) <= _iniReadUtc) return false;
-        var iniReadUtc = DateTime.UtcNow;                        // stamp BEFORE the read (TOCTOU): an ini write during/after TryResolve is caught next call
+        if (!File.Exists(ini)) return false;                     // missing/mid-replace → keep last good, retry next call
+        var iniMtime = SafeMtime(ini);                           // stat BEFORE the read (TOCTOU): an ini write during/after TryResolve is caught next call
+        if (iniMtime == _iniMtime) return false;                 // compared by VALUE — a restored-backup ini (OLDER mtime) is a change too (hunt F8)
         if (!Mo2Instance.TryResolve(_instanceDir, out var p) || p is null) return false;   // mid-write/invalid → keep last good, retry next call
-        _iniReadUtc = iniReadUtc;                                // advance only on a clean read
+        _iniMtime = iniMtime;                                    // advance only on a clean read
         bool switched = !PathEq(p.ProfileDir, _profileDir) || !PathEq(p.ModsDir, _modsDir) || !PathEq(p.DataDir, _dataDir);
         if (!switched) return false;                             // ini touched but nothing we resolve from changed
         _profileDir = p.ProfileDir; _modsDir = p.ModsDir; _dataDir = p.DataDir; _profileName = p.ProfileName;
@@ -203,7 +250,7 @@ public sealed class LoadOrderService : IDisposable
     /// <see cref="_resolver"/> is non-null. Used by both freshness signals (active-profile change + profile switch).</summary>
     void ReResolve()
     {
-        var builtUtc = DateTime.UtcNow;                          // stamp BEFORE the read (TOCTOU): a write during the re-read is caught next call, not missed
+        var profileMtimes = StatProfileFiles();                  // stat BEFORE the read (TOCTOU): a write during the re-read is caught next call, not missed
         var order = Mo2LoadOrder.Build(_profileDir, _modsDir, _dataDir);
         var paths = order.OrderedPaths;
         if (_maxPlugins > 0 && paths.Count > _maxPlugins) paths = paths.Take(_maxPlugins).ToList();
@@ -217,14 +264,14 @@ public sealed class LoadOrderService : IDisposable
             _resolver = rebuilt;
             _resolvedPaths = paths;
             _orderWarnings = order.Warnings;
-            _orderBuiltUtc = builtUtc;
+            _profileMtimes = profileMtimes;
         }
         else if (paths.Count > 0)
         {
             // The profile was touched but the resolved order is identical (e.g. a no-plugin mod toggled) — no deep
             // re-index; just advance the freshness baseline so the staleness flag clears.
             _orderWarnings = order.Warnings;
-            _orderBuiltUtc = builtUtc;
+            _profileMtimes = profileMtimes;
         }
         // paths.Count == 0 → almost certainly a transient mid-write read; keep the last good snapshot and DON'T advance the
         // baseline, so the next tool call re-checks and self-recovers once MO2 finishes writing.
@@ -238,10 +285,10 @@ public sealed class LoadOrderService : IDisposable
     {
         if (_instanceDir is null) return;                        // explicit mode — roots configured directly
         if (_profileDir.Length > 0) return;                      // already derived (a prior build / SetInstance); RederiveIfIniChanged owns later updates
-        var iniReadUtc = DateTime.UtcNow;                        // stamp BEFORE the read (TOCTOU): an ini write during/after Resolve is caught next call
+        var iniMtime = SafeMtime(Mo2Instance.IniPath(_instanceDir));   // stat BEFORE the read (TOCTOU): an ini write during/after Resolve is caught next call
         var p = Mo2Instance.Resolve(_instanceDir);               // throws (Q3) naming the missing piece if not a usable instance
         _profileDir = p.ProfileDir; _modsDir = p.ModsDir; _dataDir = p.DataDir; _profileName = p.ProfileName;
-        _iniReadUtc = iniReadUtc;
+        _iniMtime = iniMtime;
         InvalidateClassParents();                                // _modsDir just gained a value — a cache built before derivation is baseline-only (hunt F1)
     }
 
@@ -263,17 +310,22 @@ public sealed class LoadOrderService : IDisposable
     /// survives a restart. Returns the derived paths + whether the persist succeeded, for the tool's confirmation.</summary>
     public (Mo2InstancePaths paths, bool persisted, string? persistError, string? persistNote) SetInstance(string instanceDir)
     {
+        // The ini baseline is statted BEFORE Resolve reads the instance (hunt F7 — this was the one stamp-AFTER-the-read
+        // in the file: an MO2 ini write landing between Resolve's read and the stamp was absorbed into the baseline and
+        // its profile switch stayed invisible forever). Statting first makes a during/after-read write show as a changed
+        // mtime on the next call — the same TOCTOU discipline every other baseline here follows.
+        var iniMtime = SafeMtime(Mo2Instance.IniPath(instanceDir.Trim()));
         var paths = Mo2Instance.Resolve(instanceDir);            // throws (Q3) if not a usable MO2 instance — the tool renders the reason
         lock (_writeGate)                                        // hunt F2: an instance switch waits for any in-flight write — never tears one across instances
         lock (_gate)
         {
             _instanceDir = paths.InstanceDir;
             _dataDir = paths.DataDir; _modsDir = paths.ModsDir; _profileDir = paths.ProfileDir; _profileName = paths.ProfileName;
-            _iniReadUtc = DateTime.UtcNow;
+            _iniMtime = iniMtime;
             _configured = true;
             _resolver?.Dispose(); _resolver = null;              // force a rebuild against the new instance on the next query
             _resolvedPaths = Array.Empty<string>();
-            _orderBuiltUtc = DateTime.MinValue;
+            _profileMtimes = new DateTime[ProfileFileNames.Length];   // unset — the next build records fresh baselines against the new profile
             _orderWarnings = Array.Empty<string>();
             InvalidateClassParents();                            // every sibling cache drops on a switch — the hierarchy too (PR #47 review)
         }
@@ -357,7 +409,7 @@ public sealed class LoadOrderService : IDisposable
 
         var source = plugin ?? winner.Value.WinnerPlugin;
         using var session = resolver.OpenSession();                       // opens the source plugin; disposed at return (Option B)
-        var rec = resolver.GetRecord(session, source, fk);
+        var rec = view.GetRecord(session, source, fk);                    // excluded-check pinned to the SAME view the winner came from (hunt F5 discipline)
         if (rec is null)
             return ReadOutcome.Fail(fk, plugin is null
                 ? $"Winner '{winner.Value.WinnerPlugin}' did not yield {fk} on fetch — a load-order inconsistency."
@@ -397,10 +449,11 @@ public sealed class LoadOrderService : IDisposable
     public RecordSummary ResolveSummary(FormKey fk)
     {
         var resolver = Resolver;
-        var w = resolver.Capture().ResolveWinner(fk);   // one capture per summary (winner + depth from one build)
+        var view = resolver.Capture();                  // one capture per summary (winner + depth + fetch from one build)
+        var w = view.ResolveWinner(fk);
         if (w is null) return new RecordSummary(fk, "?", null, "?", 0, $"{fk} not in the load order");
         using var session = resolver.OpenSession();
-        var body = resolver.GetRecord(session, w.Value.WinnerPlugin, fk);
+        var body = view.GetRecord(session, w.Value.WinnerPlugin, fk);
         if (body is null)
             return new RecordSummary(fk, "?", null, w.Value.WinnerPlugin, w.Value.OverrideDepth,
                 $"winner '{w.Value.WinnerPlugin}' did not yield {fk} on fetch");


### PR DESCRIPTION
# Freshness + write-capture hardening (hunt F5–F8 + the PR #51 review note)

The remaining freshness half of the 2026-06-12 pre-1.3.0 hunt backlog. The freshness machinery is what lets houseCARL promise "the answer reflects the current MO2 state" without a daemon — so a check that misses a change, or an answer composed from two adjacent index builds, is a silent wrong answer (Q3), not a perf nit.

## What's fixed

**F5 — one-capture write path** (`0b32f1d`). `WritePatchBuilder.Apply` Phase 1 resolved winner + body **per edit** (a fresh capture each), so a freshness rebuild landing mid-loop — a concurrent read's refresh — could resolve two edits of ONE call against two different builds' winners: a silently mixed patch, no error. Apply now captures one `IndexView` up front and answers every edit's resolve, fetch, and excluded-check off it (the HCBR-2026-06-11-02 one-build-per-operation discipline, finally threaded into writes). `IndexView` gains a view-pinned `GetRecord`; `ResolveRead`/`ResolveSummary` ride it so reads' excluded-checks judge the same build as their winner.

**F8 — mtime-regression blindness** (`a871b14`). Profile/ini freshness compared wall-clock (`mtime > builtUtc`, `<= iniReadUtc`) — blind to an mtime REGRESSION, so MO2's "Restore Backup" (restores a file with an OLDER mtime) stayed invisible for the process lifetime. Baselines are now the files' last-seen mtimes compared by value (`!=`), the model the resolver's own plugin sweep always used. Statted BEFORE the read they baseline (TOCTOU discipline preserved).

**F7 — SetInstance stamp-after-the-read** (`a871b14`). The one baseline in the file stamped AFTER its read; an MO2 ini write landing in the gap was absorbed forever. Now statted before `Mo2Instance.Resolve`.

**F6 — torn status line** (`a871b14`). `StatusData` read the view, then the per-build fields beside it (warnings/staleness/profile dir) outside the gate with file I/O in between. Now snapshotted under one gate hold; the fresh composition stays outside by design (documented always-current).

**PR #51 review note — mid-write refresh** (`a871b14`). A concurrent read's freshness refresh could rebuild the index UNDER an in-flight write — transiently mmap-opening every plugin **including the file the write is serializing** (the PR #24 "no mapped handle on the target survives the serialize" invariant, breached from the read path) — and dispose-swap the resolver the write captured. The read-path refresh now probes the write gate with a non-blocking `Monitor.TryEnter`: a write in flight defers the refresh to the next call (honest staleness, never wrongness). No blocking `_gate`→`_writeGate` wait is introduced — TryEnter never blocks — so the established lock order (`_writeGate` THEN `_gate`) stands; the write's own entry refresh keeps working via Monitor reentrancy.

## Guard (`1d17af9`) — `freshness-capture-guard`, new CI step

| Arm | Claim | Pre-fix evidence |
|---|---|---|
| 1 | restored-backup profile (older mtimes) re-resolved | **RED, deterministic** — stayed 1/2 plugins |
| 2 | backdated ini profile switch after SetInstance followed | **RED, deterministic** — stayed on the old profile |
| 3 | no status line mixes two builds | **invariant lock, NOT RED-proven** — 0 torn in ~12k hammered reads pre-fix; the tear window is structurally narrower than the gate-held rebuild that must land inside it. The arm locks the post-fix shape against future widening (e.g. more I/O drifting between capture and field reads). |
| 4 | every successful multi-op write carries ONE build's bodies | **RED** — 2 of 12 hammered writes silently mixed both builds' winners |
| 5 | a mid-write read defers its refresh; the NEXT call picks up the change | **RED, deterministic** — the mid-write read observed the flipped profile pre-fix |

Post-fix: ALL PASS ×3 consecutive runs. Full existing CI probe suite (all 22) green locally on the fixed tree.

## Honest notes

- **Arm 3 is an invariant lock, not a regression proof** — stated in the probe, the commit, and here. The F6 fix is still right: by-construction consistency beats relying on timing arithmetic that a future edit could invalidate.
- **A residue stays open (named, not silent):** a plain read's transient body-fetch overlay on a write's target can still collide with the serialize's atomic move — the write then fails LOUD with the file intact (same class as "xEdit has the file open"), never corrupt. Closing it would need a per-file read/write lock; deferred unless it shows up in practice.
- `LoadOrderResolver.Dispose()` is a no-op today (Option B holds nothing), so the pre-fix dispose-swap didn't break in-flight writes *yet* — the deferral makes that safety structural instead of accidental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
