### PR TITLE
MO2 overwrite-folder resolution (hunt F9, full fix): tool outputs resolve, on top

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,3 +167,11 @@ jobs:
       # instances + synthesized plugins in temp.
       - name: Probe — freshness + write-capture (restored backups seen; one build per answer)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- freshness-capture-guard
+
+      # MO2 overwrite-folder resolution (2026-06-12 hunt F9, Aaron-picked full fix): plugins living in MO2's
+      # overwrite layer — where tool outputs (Synthesis, xEdit "new file") land, listed in the profile files by
+      # MO2 — resolve at HIGHEST priority (top of the VFS, a copy there beats every mod), and the can't-resolve
+      # warning names overwrite among the places searched. Self-contained: dummy files for the path-map arms +
+      # a synthetic MO2 instance with real synthesized plugins for the end-to-end arms.
+      - name: Probe — MO2 overwrite-folder resolution (tool outputs resolve, on top)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- overwrite-resolve-guard

--- a/src/housecarl-core/Mo2Instance.cs
+++ b/src/housecarl-core/Mo2Instance.cs
@@ -26,9 +26,10 @@ namespace HousecarlCore;
 //      carries \\, and anything exotic just fails the existence check loud (Q3).
 //
 //  Derivation (base = base_directory if set+real, else the instance dir):
-//      ModsDir    = base\mods
-//      ProfileDir = base\profiles\<selected_profile>
-//      DataDir    = <gamePath>\Data
+//      ModsDir      = base\mods
+//      ProfileDir   = base\profiles\<selected_profile>
+//      DataDir      = <gamePath>\Data
+//      OverwriteDir = base\overwrite   (MO2's overwrite layer — tool outputs land here; NOT required to exist)
 //
 //  Q3: a missing/empty piece is NAMED in the problem list and the resolve
 //  FAILS — never a silently-empty or half-derived path set.
@@ -42,8 +43,11 @@ namespace HousecarlCore;
 /// <param name="ModsDir">base\mods — each enabled mod is a subfolder.</param>
 /// <param name="DataDir">gamePath\Data — the base-game Data folder (vanilla masters).</param>
 /// <param name="GamePath">The game root (ModOrganizer.ini gamePath); DataDir = this + \Data.</param>
+/// <param name="OverwriteDir">base\overwrite — MO2's overwrite layer, the HIGHEST-priority file source (tool outputs:
+/// Synthesis, xEdit "new file", Wrye Bash land plugins here, and MO2 lists them in the profile files). Derived but NOT
+/// required to exist (a fresh instance may lack it; resolution just skips a missing folder).</param>
 public sealed record Mo2InstancePaths(
-    string InstanceDir, string ProfileName, string ProfileDir, string ModsDir, string DataDir, string GamePath);
+    string InstanceDir, string ProfileName, string ProfileDir, string ModsDir, string DataDir, string GamePath, string OverwriteDir);
 
 public static class Mo2Instance
 {
@@ -141,7 +145,9 @@ public static class Mo2Instance
                   && Directory.Exists(modsDir) && Directory.Exists(dataDir);
         if (!ok) return null;
 
-        return new Mo2InstancePaths(instanceDir, profile!, profileDir, modsDir, dataDir, gamePath!);
+        // Overwrite is derived like mods/profiles (base-relative, the portable default measured on Aaron's real ini)
+        // but never gates validity — a missing folder just means no overwrite-provided plugins.
+        return new Mo2InstancePaths(instanceDir, profile!, profileDir, modsDir, dataDir, gamePath!, Path.Combine(basePath, "overwrite"));
     }
 
     /// <summary>First <c>key=</c> line's raw value (the key matched case-insensitively, ignoring section headers — the keys

--- a/src/housecarl-core/Mo2LoadOrder.cs
+++ b/src/housecarl-core/Mo2LoadOrder.cs
@@ -67,18 +67,19 @@ public static class Mo2LoadOrder
     static readonly string[] PluginExts = { ".esp", ".esm", ".esl" };
 
     /// <summary>Read the active order from <paramref name="profileDir"/>'s loadorder.txt + modlist.txt + plugins.txt,
-    /// resolving each active plugin to its WINNING real path under <paramref name="modsDir"/> (highest-priority enabled
-    /// mod that provides the filename), falling back to <paramref name="dataDir"/> for vanilla/base plugins. The returned
-    /// paths are in load order (winner last) — feed straight to <see cref="LoadOrderResolver.Build"/>.</summary>
-    public static Mo2OrderResult Build(string profileDir, string modsDir, string dataDir)
+    /// resolving each active plugin to its WINNING real path: MO2's <paramref name="overwriteDir"/> first (the overwrite
+    /// layer beats every mod — it's where tool outputs land), then the highest-priority enabled mod under
+    /// <paramref name="modsDir"/> that provides the filename, falling back to <paramref name="dataDir"/> for vanilla/base
+    /// plugins. The returned paths are in load order (winner last) — feed straight to <see cref="LoadOrderResolver.Build"/>.</summary>
+    public static Mo2OrderResult Build(string profileDir, string modsDir, string dataDir, string overwriteDir = "")
     {
         var warnings = new List<string>();
 
         // The enabled/disabled COMPOSITION (text files only — cheap). The diagnostic re-reads this same parse fresh.
         var comp = ReadComposition(profileDir, warnings);
 
-        // filename → WINNING real path: highest-priority enabled mod first (first-seen wins), data folder as base.
-        var winningPath = BuildFilenameMap(comp.EnabledMods, modsDir, dataDir);
+        // filename → WINNING real path: overwrite first, then highest-priority enabled mod (first-seen wins), data folder as base.
+        var winningPath = BuildFilenameMap(comp.EnabledMods, modsDir, dataDir, overwriteDir);
         var inactive = new HashSet<string>(comp.InactivePluginNames, StringComparer.OrdinalIgnoreCase);
 
         // loadorder.txt order → drop unchecked plugins; resolve the rest to their winning path (winner last).
@@ -92,8 +93,8 @@ public static class Mo2LoadOrder
                 orderedPaths.Add(path);
             else
                 warnings.Add(
-                    $"load order lists '{name}' but no enabled mod or the data folder provides it " +
-                    "(stale loadorder.txt? trigger an MO2 refresh / re-sort so it re-writes the profile files).");
+                    $"load order lists '{name}' but no enabled mod, the overwrite folder, or the game Data folder " +
+                    "provides it (stale loadorder.txt? trigger an MO2 refresh / re-sort so it re-writes the profile files).");
         }
 
         return new Mo2OrderResult(orderedPaths, warnings, active);
@@ -145,12 +146,18 @@ public static class Mo2LoadOrder
         }
     }
 
-    /// <summary>Build filename → winning real path. Enabled mods are scanned highest-priority FIRST and the first sighting
-    /// of a filename wins (so a higher-priority mod's copy beats a lower one's — MO2's own overwrite rule). The data
-    /// folder is scanned LAST and only fills names no mod provided (vanilla masters / base game = lowest priority).</summary>
-    static Dictionary<string, string> BuildFilenameMap(IReadOnlyList<string> enabledModsByPriority, string modsDir, string dataDir)
+    /// <summary>Build filename → winning real path. MO2's OVERWRITE folder is scanned first — it is the top of MO2's
+    /// VFS (a copy there beats every mod; tool outputs like Synthesis patches and xEdit "new file" plugins live there,
+    /// and MO2 lists them in the profile files — 2026-06-12 hunt F9: these were unresolvable and the warning
+    /// misdiagnosed them as a stale-profile problem a re-sort can't fix). Then enabled mods, highest-priority FIRST,
+    /// first sighting of a filename wins (a higher-priority mod's copy beats a lower one's — MO2's own overwrite rule).
+    /// The data folder is scanned LAST and only fills names no mod provided (vanilla masters / base game = lowest priority).</summary>
+    static Dictionary<string, string> BuildFilenameMap(IReadOnlyList<string> enabledModsByPriority, string modsDir, string dataDir, string overwriteDir)
     {
         var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (fn, full) in EnumeratePlugins(overwriteDir))  // MO2's overwrite layer — beats every mod
+            map[fn] = full;                                         // (map is empty here; plain set keeps the rule obvious)
 
         foreach (var mod in enabledModsByPriority)                  // highest priority first
         {

--- a/src/housecarl-generator/OverwriteResolveProbe.cs
+++ b/src/housecarl-generator/OverwriteResolveProbe.cs
@@ -1,0 +1,142 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// MO2 overwrite-folder resolution guard (2026-06-12 hunt F9, Aaron-picked full fix): plugins living in MO2's
+/// OVERWRITE folder — the top of MO2's VFS, where tool outputs land (Synthesis patches, xEdit "new file",
+/// Wrye Bash) — are listed in the profile files by MO2 but were unresolvable to houseCARL, and the warning
+/// misdiagnosed them as a stale-profile problem ("trigger a re-sort") that a re-sort cannot fix. The fix
+/// includes overwrite in the filename map at HIGHEST priority (a copy there beats every mod, MO2's own rule).
+///
+/// Arms (all deterministic):
+///   1  core/resolve — an overwrite-only plugin listed in the profile resolves to its overwrite path, no warning.
+///   2  core/priority — a filename present in overwrite AND an enabled mod resolves to the OVERWRITE copy.
+///   3  core/warning — a genuinely-missing plugin still warns, and the warning names the overwrite folder among
+///      the places searched (the message is honest about what was checked).
+///   4  service/end-to-end — a real (synthesized) plugin only in overwrite: the service resolves the full order,
+///      reads a record out of the overwrite plugin, and reports no warnings.
+///   5  service/freshness — the overwrite plugin enters the profile files mid-session (the MO2-refresh flow after
+///      a tool writes there); the next call picks it up.
+///
+/// Arms 1–3 drive Mo2LoadOrder.Build directly with dummy plugin FILES (Build maps paths; it never opens plugin
+/// content). Arms 4–5 drive the REAL service against a synthetic MO2 instance with real plugin bytes. Self-contained.
+/// </summary>
+internal static class OverwriteResolveProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" overwrite-resolve guard — MO2's overwrite layer resolves, on top");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        var root = Path.Combine(Path.GetTempPath(), "hc-overwrite-guard-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            // ---- arms 1-3: the core path map, with dummy plugin files ----
+            Console.WriteLine("--- 1-3: core filename map (Mo2LoadOrder.Build) ---");
+            {
+                var prof = Path.Combine(root, "core", "profile");
+                var mods = Path.Combine(root, "core", "mods");
+                var data = Path.Combine(root, "core", "data");
+                var ovw  = Path.Combine(root, "core", "overwrite");
+                Directory.CreateDirectory(prof); Directory.CreateDirectory(Path.Combine(mods, "SomeMod"));
+                Directory.CreateDirectory(data); Directory.CreateDirectory(ovw);
+
+                File.WriteAllText(Path.Combine(data, "Skyrim.esm"), "x");                       // base game
+                File.WriteAllText(Path.Combine(mods, "SomeMod", "Dup.esp"), "x");               // a mod's copy…
+                File.WriteAllText(Path.Combine(ovw, "Dup.esp"), "x");                           // …and overwrite's copy of the SAME name
+                File.WriteAllText(Path.Combine(ovw, "ToolOutput.esp"), "x");                    // only in overwrite
+
+                File.WriteAllText(Path.Combine(prof, "loadorder.txt"),
+                    "# header\r\nSkyrim.esm\r\nDup.esp\r\nToolOutput.esp\r\nGone.esp\r\n");
+                File.WriteAllText(Path.Combine(prof, "plugins.txt"), "*Dup.esp\r\n*ToolOutput.esp\r\n*Gone.esp\r\n");
+                File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n+SomeMod\r\n");
+
+                var r = Mo2LoadOrder.Build(prof, mods, data, ovw);
+
+                var toolPath = r.OrderedPaths.FirstOrDefault(p => Path.GetFileName(p).Equals("ToolOutput.esp", StringComparison.OrdinalIgnoreCase));
+                Check(toolPath is not null && toolPath.StartsWith(ovw, StringComparison.OrdinalIgnoreCase),
+                      $"an overwrite-only plugin resolves to its overwrite path — {toolPath ?? "(unresolved)"}");
+                Check(!r.Warnings.Any(w => w.Contains("ToolOutput.esp", StringComparison.OrdinalIgnoreCase)),
+                      "…and raises no warning (it is not a stale-profile problem)");
+
+                var dupPath = r.OrderedPaths.FirstOrDefault(p => Path.GetFileName(p).Equals("Dup.esp", StringComparison.OrdinalIgnoreCase));
+                Check(dupPath is not null && dupPath.StartsWith(ovw, StringComparison.OrdinalIgnoreCase),
+                      $"a name in overwrite AND an enabled mod resolves to the OVERWRITE copy (top of the VFS) — {dupPath ?? "(unresolved)"}");
+
+                var goneWarn = r.Warnings.FirstOrDefault(w => w.Contains("Gone.esp", StringComparison.OrdinalIgnoreCase));
+                Check(goneWarn is not null, "a genuinely-missing plugin still warns");
+                Check(goneWarn is not null && goneWarn.Contains("overwrite", StringComparison.OrdinalIgnoreCase),
+                      "…and the warning names the overwrite folder among the places searched");
+            }
+
+            // ---- arms 4-5: the real service against a synthetic instance with real plugin bytes ----
+            Console.WriteLine();
+            Console.WriteLine("--- 4-5: service end-to-end (a real plugin living only in overwrite) ---");
+            {
+                string instance = Path.Combine(root, "instance");
+                string profiles = Path.Combine(instance, "profiles", "Default");
+                string mods = Path.Combine(instance, "mods");
+                string ovw = Path.Combine(instance, "overwrite");
+                string data = Path.Combine(root, "game", "Data");
+                Directory.CreateDirectory(profiles); Directory.CreateDirectory(Path.Combine(mods, "MasterMod"));
+                Directory.CreateDirectory(ovw); Directory.CreateDirectory(data);
+                File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+                    "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+                    + Path.Combine(root, "game").Replace(@"\", @"\\") + ")\r\n");
+
+                var mKey = new ModKey("HcOvwMaster", ModType.Master);
+                {
+                    var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
+                    var w = m.Weapons.AddNew(); w.EditorID = "HcOvwBase"; w.BasicStats = new WeaponBasicStats { Damage = 10 };
+                    m.BeginWrite.ToPath(Path.Combine(mods, "MasterMod", mKey.FileName.String)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+                }
+                var tKey = new ModKey("HcOvwTool", ModType.Plugin);
+                FormKey toolFk;
+                {
+                    var t = new SkyrimMod(tKey, SkyrimRelease.SkyrimSE);
+                    var w = t.Weapons.AddNew(); w.EditorID = "HcOvwToolW"; w.BasicStats = new WeaponBasicStats { Damage = 42 };
+                    toolFk = w.FormKey;
+                    t.BeginWrite.ToPath(Path.Combine(ovw, tKey.FileName.String)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+                }
+
+                // arm 5 starts BEFORE the tool plugin is in the profile (the moment a tool just wrote it to overwrite)
+                File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + mKey.FileName + "\r\n");
+                File.WriteAllText(Path.Combine(profiles, "plugins.txt"), "*" + mKey.FileName + "\r\n");
+                File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+MasterMod\r\n");
+
+                var store = new UserConfigStore(Path.Combine(root, "user.json"));
+                using var svc = LoadOrderService.WithInstance(instance, 0, store);
+                Check(svc.Stats().plugins == 1, "baseline order resolved (overwrite plugin not yet in the profile)");
+
+                // MO2 refresh after the tool ran: the profile files now list the overwrite-resident plugin
+                File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + mKey.FileName + "\r\n" + tKey.FileName + "\r\n");
+                File.WriteAllText(Path.Combine(profiles, "plugins.txt"), "*" + mKey.FileName + "\r\n*" + tKey.FileName + "\r\n");
+
+                var status = svc.StatusData();
+                Check(status.ResolvedPluginCount == 2,
+                      $"the overwrite-resident plugin resolves once the profile lists it — {status.ResolvedPluginCount}/2 plugins");
+                Check(status.Warnings.Count == 0,
+                      $"no warning raised for it ({status.Warnings.Count} warning(s): {string.Join(" | ", status.Warnings)})");
+
+                var read = svc.ResolveRead(toolFk, null, null, conflictTree: false);
+                Check(read.Error is null && read.Record is not null && read.WinnerPlugin == tKey.FileName,
+                      $"a record inside the overwrite plugin reads end-to-end — winner={read.WinnerPlugin ?? "?"}, err={read.Error ?? "none"}");
+            }
+        }
+        finally { try { Directory.Delete(root, recursive: true); } catch { /* temp scratch */ } }
+
+        Console.WriteLine();
+        Console.WriteLine(fail == 0 ? "================ ALL PASS ================" : $"================ {fail} CHECK(S) FAILED ================");
+        return fail == 0 ? 0 : 1;
+    }
+}

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -73,6 +73,11 @@ if (args.Length > 0 && args[0] == "write-mutex-guard") return WriteMutexProbe.Ru
 // read's freshness refresh defers while a write is in flight (never rebuilds under a serialize).
 if (args.Length > 0 && args[0] == "freshness-capture-guard") return FreshnessCaptureProbe.RunGuard(args[1..]);
 
+// MO2 overwrite-folder resolution (2026-06-12 hunt F9): plugins living in MO2's overwrite layer resolve at
+// HIGHEST priority (top of the VFS — where Synthesis/xEdit tool outputs land), and the can't-resolve warning
+// names overwrite among the places searched.
+if (args.Length > 0 && args[0] == "overwrite-resolve-guard") return OverwriteResolveProbe.RunGuard(args[1..]);
+
 // Compile-tool import order: caller import_dirs OUTRANK the vanilla auto-import (first match wins, so
 // SKSE-extended copies of vanilla sources must win). Pure order arm always runs; real-compile arm self-skips.
 if (args.Length > 0 && args[0] == "import-order-guard") return ImportOrderProbe.RunGuard(args[1..]);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -32,6 +32,7 @@ public sealed class LoadOrderService : IDisposable
     string _modsDir;
     string _profileDir;
     string _profileName;                           // the active profile (instance mode: from selected_profile)
+    string _overwriteDir = "";                     // MO2's overwrite layer (instance mode: derived; explicit mode: none) — hunt F9
     bool _configured;                              // false ⇒ tools return the trained prompt instead of resolving
     readonly UserConfigStore _store;               // the sole owner of houseCARL.user.json (MO2 instance dir + tool paths)
     readonly int _maxPlugins;
@@ -115,7 +116,7 @@ public sealed class LoadOrderService : IDisposable
                     // plugins.txt) — no VFS, no live MO2 state. See HousecarlCore.Mo2LoadOrder + memory
                     // project_mo2_load_order_resolution.
                     var profileMtimes = StatProfileFiles();      // stat BEFORE the read (TOCTOU): a profile write during the build is caught next call, not missed
-                    var order = Mo2LoadOrder.Build(_profileDir, _modsDir, _dataDir);
+                    var order = Mo2LoadOrder.Build(_profileDir, _modsDir, _dataDir, _overwriteDir);
                     _orderWarnings = order.Warnings;
                     var paths = order.OrderedPaths;
                     if (_maxPlugins > 0 && paths.Count > _maxPlugins) paths = paths.Take(_maxPlugins).ToList();
@@ -237,9 +238,10 @@ public sealed class LoadOrderService : IDisposable
         if (iniMtime == _iniMtime) return false;                 // compared by VALUE — a restored-backup ini (OLDER mtime) is a change too (hunt F8)
         if (!Mo2Instance.TryResolve(_instanceDir, out var p) || p is null) return false;   // mid-write/invalid → keep last good, retry next call
         _iniMtime = iniMtime;                                    // advance only on a clean read
-        bool switched = !PathEq(p.ProfileDir, _profileDir) || !PathEq(p.ModsDir, _modsDir) || !PathEq(p.DataDir, _dataDir);
+        bool switched = !PathEq(p.ProfileDir, _profileDir) || !PathEq(p.ModsDir, _modsDir) || !PathEq(p.DataDir, _dataDir)
+                        || !PathEq(p.OverwriteDir, _overwriteDir);
         if (!switched) return false;                             // ini touched but nothing we resolve from changed
-        _profileDir = p.ProfileDir; _modsDir = p.ModsDir; _dataDir = p.DataDir; _profileName = p.ProfileName;
+        _profileDir = p.ProfileDir; _modsDir = p.ModsDir; _dataDir = p.DataDir; _profileName = p.ProfileName; _overwriteDir = p.OverwriteDir;
         InvalidateClassParents();                                // the mods tree may have moved — drop the cached hierarchy with it
         ReResolve();                                             // a new profile ⇒ the order differs ⇒ ReResolve deep-re-indexes
         return true;
@@ -251,7 +253,7 @@ public sealed class LoadOrderService : IDisposable
     void ReResolve()
     {
         var profileMtimes = StatProfileFiles();                  // stat BEFORE the read (TOCTOU): a write during the re-read is caught next call, not missed
-        var order = Mo2LoadOrder.Build(_profileDir, _modsDir, _dataDir);
+        var order = Mo2LoadOrder.Build(_profileDir, _modsDir, _dataDir, _overwriteDir);
         var paths = order.OrderedPaths;
         if (_maxPlugins > 0 && paths.Count > _maxPlugins) paths = paths.Take(_maxPlugins).ToList();
 
@@ -287,7 +289,7 @@ public sealed class LoadOrderService : IDisposable
         if (_profileDir.Length > 0) return;                      // already derived (a prior build / SetInstance); RederiveIfIniChanged owns later updates
         var iniMtime = SafeMtime(Mo2Instance.IniPath(_instanceDir));   // stat BEFORE the read (TOCTOU): an ini write during/after Resolve is caught next call
         var p = Mo2Instance.Resolve(_instanceDir);               // throws (Q3) naming the missing piece if not a usable instance
-        _profileDir = p.ProfileDir; _modsDir = p.ModsDir; _dataDir = p.DataDir; _profileName = p.ProfileName;
+        _profileDir = p.ProfileDir; _modsDir = p.ModsDir; _dataDir = p.DataDir; _profileName = p.ProfileName; _overwriteDir = p.OverwriteDir;
         _iniMtime = iniMtime;
         InvalidateClassParents();                                // _modsDir just gained a value — a cache built before derivation is baseline-only (hunt F1)
     }
@@ -321,6 +323,7 @@ public sealed class LoadOrderService : IDisposable
         {
             _instanceDir = paths.InstanceDir;
             _dataDir = paths.DataDir; _modsDir = paths.ModsDir; _profileDir = paths.ProfileDir; _profileName = paths.ProfileName;
+            _overwriteDir = paths.OverwriteDir;
             _iniMtime = iniMtime;
             _configured = true;
             _resolver?.Dispose(); _resolver = null;              // force a rebuild against the new instance on the next query


### PR DESCRIPTION
# MO2 overwrite-folder resolution (hunt F9 — Aaron-picked full fix)

The last behavioral item from the 2026-06-12 hunt backlog. Plugins living in MO2's **overwrite** folder — the top of MO2's VFS, where tool outputs land (Synthesis patches, xEdit "new file", Wrye Bash) and which MO2 lists in the profile files — were unresolvable to houseCARL, and the warning misdiagnosed them as a stale-profile problem ("trigger a re-sort") that a re-sort cannot fix. Aaron picked the **full fix** (resolve them) over the honest-message minimum: overwrite is genuinely part of the active VFS, so comprehensive access means resolving it.

## What changes

- **`Mo2InstancePaths` gains `OverwriteDir`** — `base\overwrite`, the same base-relative derivation as `mods`/`profiles` (grounded against Aaron's real portable ModOrganizer.ini: no `base_directory`/`overwrite_directory` overrides — the portable default). Never gates instance validity; a missing folder just means no overwrite plugins.
- **`Mo2LoadOrder.BuildFilenameMap` scans overwrite FIRST** — a copy there beats every mod (MO2's own rule); enabled mods keep priority-order first-seen-wins; the game Data folder stays the lowest fallback. `Build` takes the new root as a defaulted parameter, so every existing caller (probes included) compiles unchanged.
- **The can't-resolve warning is honest** — it now names the overwrite folder among the places searched.
- **`LoadOrderService` carries the new root through every path the other roots travel** — `EnsurePathsDerived`, `RederiveIfIniChanged` (including the switched check), `SetInstance`; explicit-paths mode has no overwrite (unchanged).

## Guard — `overwrite-resolve-guard`, new CI step, all arms deterministic

| Arm | Claim |
|---|---|
| 1 | an overwrite-only plugin resolves to its overwrite path, no warning |
| 2 | a filename in overwrite AND an enabled mod resolves to the OVERWRITE copy (top of the VFS) |
| 3 | a genuinely-missing plugin still warns, and the warning names overwrite among the places searched |
| 4 | end-to-end through the real service: a synthesized plugin living only in overwrite resolves and a record inside it reads (winner = the overwrite plugin) |
| 5 | the overwrite plugin enters the order when the profile files pick it up mid-session (the MO2-refresh flow after a tool writes there) |

**Mutation-RED-proven:** with the overwrite scan disabled and the old warning text restored (the heart of the fix), **7 of 9 checks FAIL** — unresolved plugin, the mod's copy winning, and the misdiagnosing warning back. Restored, ALL PASS. Neighboring guards green on the fixed tree: freshness-capture, hierarchy-cache, write-mutex, snapshot-view, verify-loop, tool-bridge.

## Honest notes

- **Lazy-mtime contract unchanged:** a plugin appearing in overwrite changes the winning path only once the profile files change — which MO2 writes on refresh, the same contract every other path source follows. A file dropped into overwrite *behind MO2's back* without a profile rewrite is invisible until one happens (identical to the pre-existing behavior for a file dropped into a mod folder).
- `overwrite_directory`/`mod_directory` ini relocations are not read — consistent with the existing model (`base\mods` is likewise assumed). If a relocated-dirs instance ever shows up, both go together as one wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
