### PR TITLE
Pre-1.3.0 cosmetic sweep (render NOTEs + hunter-1 leftovers + F9-followups)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,3 +182,11 @@ jobs:
       # a synthetic MO2 instance with real synthesized plugins for the end-to-end arms.
       - name: Probe — MO2 overwrite-folder resolution (tool outputs resolve, on top)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- overwrite-resolve-guard
+
+      # MO2 instance derivation (launch-arc item 3 + hunt H1): one instance path derives the load-order roots + the
+      # active profile from ModOrganizer.ini, with the Qt @ByteArray/doubled-backslash quirks handled and every missing
+      # piece NAMED in the problem list (Q3) — including a base_directory that is SET but points at a missing folder
+      # (still usable via the instance-dir fallback, but the discarded base_directory is named, not silently dropped).
+      # The real-instance arms (E5/E6) self-skip when Aaron's C:\MO2\Instance is absent; the synthetic edges run fully.
+      - name: Probe — MO2 instance derivation (roots + profile + base_directory honesty)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- mo2instance-probe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,13 @@ jobs:
       - name: Probe — compile-tool import order (import_dirs outrank vanilla)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- import-order-guard
 
+      # Render-clamp guard (2026-06-13 cosmetic sweep, render NOTEs N2+N3): the Nexus description renderer
+      # truncates surrogate-safe (an emoji/astral char at the truncation boundary is never split into a lone
+      # half-glyph) and decodes the &amp; entity LAST, so a double-encoded "&amp;lt;" renders the literal text
+      # "&lt;" rather than double-decoding to "<". Pure string transforms — runs fully here, no game data.
+      - name: Probe — render clamp (surrogate-safe truncation + &amp;-last entity decode)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- render-clamp-guard
+
       # Committed-fixture contract for housecarl_decompile_script (fixtures are our OWN compiled probe sources):
       # construct fidelity vs a reviewed golden, unreadable-pex fails loud, an existing .psc is never overwritten,
       # and a missing class-hierarchy degrades to explicit casts (correct source) — runs fully here. What CI proves

--- a/src/housecarl-core/BsaArchive.cs
+++ b/src/housecarl-core/BsaArchive.cs
@@ -187,6 +187,7 @@ public static class BsaArchive
         try { p = Process.Start(psi)!; }
         catch (Exception ex) { return (false, -1, "", "", $"could not run BSArch at '{exe}': {ex.Message}"); }
 
+        const int StreamDrainMs = 5000;
         var o = p.StandardOutput.ReadToEndAsync();
         var e = p.StandardError.ReadToEndAsync();
         if (!p.WaitForExit(timeoutMs))
@@ -194,6 +195,17 @@ public static class BsaArchive
             try { p.Kill(entireProcessTree: true); } catch { /* already gone */ }
             return (false, -1, "", "", $"BSArch did not finish within {timeoutMs / 1000}s (killed).");
         }
-        return (true, p.ExitCode, o.GetAwaiter().GetResult(), e.GetAwaiter().GetResult(), null);
+        // The PROCESS exited, but a grandchild that inherited the stdout/stderr pipe could keep it open and hang the
+        // stream reads forever (WaitForExit(int) does NOT flush async readers, unlike the parameterless overload).
+        // Bound the post-exit drain: on a stuck pipe kill the tree to force the inherited handles closed and report
+        // what was captured rather than blocking indefinitely (Q3 — a bounded, named degradation, never a hang).
+        bool drained; try { drained = Task.WaitAll(new Task[] { o, e }, StreamDrainMs); } catch { drained = false; }
+        if (!drained) { try { p.Kill(entireProcessTree: true); } catch { /* already gone */ } }
+        var stdout = o.IsCompletedSuccessfully ? o.Result : "";
+        var stderr = e.IsCompletedSuccessfully ? e.Result : "";
+        return drained
+            ? (true, p.ExitCode, stdout, stderr, null)
+            : (true, p.ExitCode, stdout, stderr,
+               $"BSArch exited but its output did not drain within {StreamDrainMs / 1000}s (a child process may still hold the pipe) — captured output may be truncated.");
     }
 }

--- a/src/housecarl-core/BsaArchive.cs
+++ b/src/housecarl-core/BsaArchive.cs
@@ -35,8 +35,13 @@ public static class BsaArchive
     static readonly Regex FilesCount = new(@"^\s*Files:\s*(\d+)\s*$", RegexOptions.Multiline | RegexOptions.Compiled);
     static readonly Regex FormatLine = new(@"^\s*Format:\s*(.+?)\s*$", RegexOptions.Multiline | RegexOptions.Compiled);
 
-    /// <summary>List an archive's contents. Robust parse: BSArch prints "Files: N" in the info block, then the N paths as
-    /// the final block — so the file list is the LAST N non-empty lines (immune to banner/info-block variation).</summary>
+    /// <summary>List an archive's contents. BSArch prints "Files: N" in the info block, then the N paths as the final
+    /// block, so the file list is taken as the LAST N non-empty lines. NOTE (hunt H4 — parse fix DEFERRED, needs real
+    /// BSArch output to fix safely): this is immune to LEADING banner/info-block growth, but NOT to the path block
+    /// UNDER-producing — if BSArch prints fewer than N path lines, the last-N window slides UP into the info block and
+    /// absorbs banner/"Files:" lines AS paths (files.Count still == declared, so it reads as success). The real fix is
+    /// a delimiter-anchored parse (the paths after the last blank line) + a LOUD count-mismatch, landed against a
+    /// captured real-BSArch fixture; it is intentionally not attempted blind here.</summary>
     public static BsaListResult List(string bsarchExe, string archive, int timeoutMs = 60_000)
     {
         var run = Run(bsarchExe, new[] { archive, "-list" }, timeoutMs);

--- a/src/housecarl-core/Mo2Instance.cs
+++ b/src/housecarl-core/Mo2Instance.cs
@@ -125,6 +125,13 @@ public static class Mo2Instance
         if (string.IsNullOrWhiteSpace(profile))  problems?.Add($"{IniFileName} has no selected_profile (open a profile in MO2 once)");
         if (string.IsNullOrWhiteSpace(gamePath)) problems?.Add($"{IniFileName} has no gamePath (MO2 doesn't know where the game is)");
 
+        // base_directory SET but pointing at a missing folder is its own problem: we still fall back to the instance dir
+        // (below), but silently doing so would point every downstream "mods/profiles missing" message at the WRONG root
+        // (Q3 — never a silently-degraded mode). Absent base_directory (the common portable case) stays quiet: it's the
+        // documented default, not a misconfiguration.
+        if (!string.IsNullOrWhiteSpace(baseDir) && !Directory.Exists(baseDir))
+            problems?.Add($"{IniFileName} sets base_directory='{baseDir}' but that folder doesn't exist — falling back to the instance dir for mods/ + profiles/");
+
         // base_directory overrides where mods/ + profiles/ live; absent (the common portable case) ⇒ the instance dir.
         var basePath = (!string.IsNullOrWhiteSpace(baseDir) && Directory.Exists(baseDir)) ? baseDir! : instanceDir;
         var modsDir    = Path.Combine(basePath, "mods");

--- a/src/housecarl-core/Mo2Instance.cs
+++ b/src/housecarl-core/Mo2Instance.cs
@@ -1,7 +1,7 @@
 namespace HousecarlCore;
 
 // ======================================================================
-//  Mo2Instance — derive the three load-order roots from ONE path: the MO2
+//  Mo2Instance — derive the four load-order roots from ONE path: the MO2
 //  instance folder, read out of its ModOrganizer.ini (launch-arc item 3,
 //  2026-06-02). The user configures a single "where is your MO2?" path;
 //  ProfileDir / ModsDir / DataDir are derived, and the ACTIVE profile is
@@ -35,8 +35,8 @@ namespace HousecarlCore;
 //  FAILS — never a silently-empty or half-derived path set.
 // ======================================================================
 
-/// <summary>The three load-order roots derived from an MO2 instance folder, plus the active profile name + game root.
-/// Feed ProfileDir/ModsDir/DataDir straight to <see cref="Mo2LoadOrder.Build"/>.</summary>
+/// <summary>The four load-order roots derived from an MO2 instance folder, plus the active profile name + game root.
+/// Feed ProfileDir/ModsDir/DataDir/OverwriteDir straight to <see cref="Mo2LoadOrder.Build"/>.</summary>
 /// <param name="InstanceDir">The MO2 instance folder (contains ModOrganizer.ini).</param>
 /// <param name="ProfileName">The ACTIVE profile (ModOrganizer.ini selected_profile) — auto-detected.</param>
 /// <param name="ProfileDir">base\profiles\&lt;ProfileName&gt; — holds loadorder.txt + modlist.txt + plugins.txt.</param>

--- a/src/housecarl-core/Mo2LoadOrder.cs
+++ b/src/housecarl-core/Mo2LoadOrder.cs
@@ -82,6 +82,13 @@ public static class Mo2LoadOrder
         var winningPath = BuildFilenameMap(comp.EnabledMods, modsDir, dataDir, overwriteDir);
         var inactive = new HashSet<string>(comp.InactivePluginNames, StringComparer.OrdinalIgnoreCase);
 
+        // The can't-resolve warning names the places actually searched. The overwrite folder is only one of them in
+        // MO2-instance mode; explicit-paths mode passes overwriteDir="" (no overwrite layer), so naming it there would
+        // overstate the search (Q3 — honest about what was checked).
+        var searchedPlaces = string.IsNullOrWhiteSpace(overwriteDir)
+            ? "no enabled mod or the game Data folder"
+            : "no enabled mod, the overwrite folder, or the game Data folder";
+
         // loadorder.txt order → drop unchecked plugins; resolve the rest to their winning path (winner last).
         var orderedPaths = new List<string>(comp.OrderedPluginNames.Count);
         int active = 0;
@@ -93,8 +100,8 @@ public static class Mo2LoadOrder
                 orderedPaths.Add(path);
             else
                 warnings.Add(
-                    $"load order lists '{name}' but no enabled mod, the overwrite folder, or the game Data folder " +
-                    "provides it (stale loadorder.txt? trigger an MO2 refresh / re-sort so it re-writes the profile files).");
+                    $"load order lists '{name}' but {searchedPlaces} provides it (stale loadorder.txt? " +
+                    "trigger an MO2 refresh / re-sort so it re-writes the profile files).");
         }
 
         return new Mo2OrderResult(orderedPaths, warnings, active);

--- a/src/housecarl-core/PapyrusCompile.cs
+++ b/src/housecarl-core/PapyrusCompile.cs
@@ -99,6 +99,7 @@ public static class PapyrusCompile
                 $"could not run the Papyrus compiler at '{compilerExe}': {ex.Message}");
         }
 
+        const int StreamDrainMs = 5000;
         var outTask = proc.StandardOutput.ReadToEndAsync();
         var errTask = proc.StandardError.ReadToEndAsync();
         if (!proc.WaitForExit(timeoutMs))
@@ -107,8 +108,14 @@ public static class PapyrusCompile
             return new CompileResult(false, objectName, null, Array.Empty<PapyrusDiagnostic>(), "", "", -1,
                 $"the Papyrus compiler did not finish within {timeoutMs / 1000}s (killed).");
         }
-        var stdout = outTask.GetAwaiter().GetResult();
-        var stderr = errTask.GetAwaiter().GetResult();
+        // The PROCESS exited, but a grandchild inheriting the stdout/stderr pipe could keep it open and hang the stream
+        // reads forever (WaitForExit(int) does NOT flush async readers, unlike the parameterless overload). Bound the
+        // post-exit drain: on a stuck pipe kill the tree to force the handles closed and use what was captured rather
+        // than blocking indefinitely (Q3). producedNow is decided on the .pex's mtime, independent of the streams.
+        bool drained; try { drained = Task.WaitAll(new Task[] { outTask, errTask }, StreamDrainMs); } catch { drained = false; }
+        if (!drained) { try { proc.Kill(entireProcessTree: true); } catch { /* already gone */ } }
+        var stdout = outTask.IsCompletedSuccessfully ? outTask.Result : "";
+        var stderr = errTask.IsCompletedSuccessfully ? errTask.Result : "";
 
         var diags = ParseDiagnostics(stderr);
         // Success = THIS run WROTE the .pex. Warnings are NON-FATAL: if the compiler still emitted a .pex it's "good

--- a/src/housecarl-core/PapyrusCompile.cs
+++ b/src/housecarl-core/PapyrusCompile.cs
@@ -88,7 +88,10 @@ public static class PapyrusCompile
         };
         psi.ArgumentList.Add(objectName);
         psi.ArgumentList.Add($"-f={flagsFile}");
-        psi.ArgumentList.Add($"-i={string.Join(";", importDirs)}");   // one arg; .NET quotes it, so spaces/semicolons in paths survive
+        // One arg: ';' is the CK compiler's import-dir LIST separator, not a path char. .NET quotes the whole value so
+        // paths-with-spaces survive; a literal ';' INSIDE a path is the one thing that does NOT (it would split that
+        // path at the separator) — but import directories effectively never contain one, so it's not a real concern.
+        psi.ArgumentList.Add($"-i={string.Join(";", importDirs)}");
         psi.ArgumentList.Add($"-o={outputDir}");
 
         Process proc;

--- a/src/housecarl-generator/ConflictDiffProbe.cs
+++ b/src/housecarl-generator/ConflictDiffProbe.cs
@@ -215,7 +215,7 @@ public static class ConflictDiffProbe
         Console.WriteLine($"################  REAL-DATA PROOF — conflict-tree content diff on {Path.GetFileName(instanceDir)}  ################");
         Console.WriteLine();
         var p = Mo2Instance.Resolve(instanceDir);
-        var order = Mo2LoadOrder.Build(p.ProfileDir, p.ModsDir, p.DataDir);
+        var order = Mo2LoadOrder.Build(p.ProfileDir, p.ModsDir, p.DataDir, p.OverwriteDir);
         using var resolver = LoadOrderResolver.Build(order.OrderedPaths.ToList());
         Console.WriteLine($"   resolver: {resolver.PluginCount} plugins, {resolver.RecordCount:N0} records");
         var svc = LoadOrderService.ForGuard(resolver, new UserConfigStore(Path.Combine(Path.GetTempPath(), "hc-conflictdiff-proof.user.json")));

--- a/src/housecarl-generator/HierarchyCacheProbe.cs
+++ b/src/housecarl-generator/HierarchyCacheProbe.cs
@@ -55,7 +55,7 @@ internal static class HierarchyCacheProbe
                 var (edges, _) = svc.ClassParentsForDecompile();
                 Check(edges.TryGetValue("HcGuardChild", out var p1) && p1 == "HcGuardParent",
                       "FIRST call already sees the mods-tree edge (paths derive before the build)");
-                var outDir = svc.ResolveDecompiledSourceFolder(null, null);
+                var outDir = svc.ResolveDecompiledSourceFolder(null, null).OutputDir;
                 Check(outDir.StartsWith(mods, StringComparison.OrdinalIgnoreCase), "output folder resolves under the instance's mods dir");
                 var (edges2, _) = svc.ClassParentsForDecompile();
                 Check(edges2.ContainsKey("HcGuardChild"), "the cache stays correct after derivation (no poisoned survivor)");

--- a/src/housecarl-generator/Mo2InstanceProbe.cs
+++ b/src/housecarl-generator/Mo2InstanceProbe.cs
@@ -12,9 +12,10 @@ namespace HousecarlGenerator;
 ///       profile. This is the load-bearing assertion: the derivation == the old hardcoding, by construction.
 ///   E6 (cheap profile detect) — ReadSelectedProfile() returns the active profile name alone (what the freshness check
 ///       reads after the ini's mtime moves, to learn a profile was switched).
-///   E1–E4 (Qt quirks + edges, synthetic) — a temp instance exercises the @ByteArray(...) unwrap, the doubled-backslash
-///       unescape, a profile name with spaces, the base_directory override, and the loud-fail paths (missing ini,
-///       missing/unset selected_profile) — each NAMED in the problem list (Q3), never a silent half-derivation.
+///   E1–E4, E7 (Qt quirks + edges, synthetic) — a temp instance exercises the @ByteArray(...) unwrap, the doubled-
+///       backslash unescape, a profile name with spaces, the base_directory override, a base_directory set-but-MISSING
+///       (still usable via fallback, but NAMED — hunt H1), and the loud-fail paths (missing ini, missing/unset
+///       selected_profile) — each NAMED in the problem list (Q3), never a silent half-derivation or silent fallback.
 /// </summary>
 public static class Mo2InstanceProbe
 {
@@ -131,6 +132,24 @@ public static class Mo2InstanceProbe
                 Pass(ref allPass, "E4c DataDir still under gamePath", SamePath(p.DataDir, Path.Combine(game, "Data")));
             }
             catch (Exception ex) { Console.WriteLine($"   !! Resolve threw: {ex.Message}"); allPass = false; }
+        }
+        Console.WriteLine();
+
+        // ---------------------------------------------------------- E7: base_directory SET but its folder is MISSING (hunt H1)
+        Console.WriteLine("--- E7: base_directory set but the folder doesn't exist → still usable (falls back), but the discarded base_directory is NAMED (Q3) ---");
+        {
+            var inst = Path.Combine(tmp, "e7");
+            var game = Path.Combine(inst, "Stock Game");
+            const string prof = "Default";
+            MakeInstance(inst, game, prof, baseDirOverride: null);          // a VALID instance: mods/ + profiles/ under the instance dir
+            var ghostBase = Path.Combine(tmp, "e7-ghost-base");            // named by the ini but never created on disk
+            File.AppendAllLines(Mo2Instance.IniPath(inst),
+                new[] { "[Settings]", $"base_directory=@ByteArray({ghostBase.Replace(@"\", @"\\")})" });   // MO2's doubled-backslash form
+            var (ok, paths, problems) = Mo2Instance.Validate(inst);
+            Console.WriteLine($"   ok={ok}  problems=[{string.Join(" | ", problems)}]");
+            Pass(ref allPass, "E7a still usable — silently falls back to the instance dir", ok && paths is not null);
+            Pass(ref allPass, "E7b the discarded base_directory is NAMED, not silently dropped (Q3)",
+                problems.Any(s => s.Contains("base_directory")));
         }
         Console.WriteLine();
 

--- a/src/housecarl-generator/Mo2InstanceProbe.cs
+++ b/src/housecarl-generator/Mo2InstanceProbe.cs
@@ -3,9 +3,10 @@ using HousecarlCore;
 namespace HousecarlGenerator;
 
 /// <summary>
-/// Launch-arc item 3 proof — <see cref="Mo2Instance"/> derives the three load-order roots (ProfileDir / ModsDir /
-/// DataDir) + the ACTIVE profile from ONE path (the MO2 instance folder), by reading ModOrganizer.ini. Deterministic,
-/// solo, touches no tracked file:
+/// Launch-arc item 3 proof — <see cref="Mo2Instance"/> derives the load-order roots + the ACTIVE profile from ONE path
+/// (the MO2 instance folder), by reading ModOrganizer.ini. This probe proves the three that reproduce the old hardcoding
+/// (ProfileDir / ModsDir / DataDir); OverwriteDir (the fourth root, hunt F9) is covered by overwrite-resolve-guard.
+/// Deterministic, solo, touches no tracked file:
 ///
 ///   E5 (the real instance) — Resolve(Aaron's real `C:\MO2\Instance`) must reproduce EXACTLY the three paths
 ///       that were hand-typed into appsettings.json (the ground truth this replaces), and auto-detect the selected
@@ -155,7 +156,7 @@ public static class Mo2InstanceProbe
 
         Directory.Delete(tmp, recursive: true);
         Console.WriteLine(allPass
-            ? "=== PASS: one instance path → the three roots + active profile, by construction (real == old hardcoding); Qt quirks + loud-fail edges proven. ==="
+            ? "=== PASS: one instance path → the load-order roots + active profile, by construction (real == old hardcoding); Qt quirks + loud-fail edges proven. ==="
             : "=== read the per-E lines above (a !! marks the thing to fix). ===");
         return allPass ? 0 : 1;
 

--- a/src/housecarl-generator/OverwriteResolveProbe.cs
+++ b/src/housecarl-generator/OverwriteResolveProbe.cs
@@ -24,6 +24,8 @@ namespace HousecarlGenerator;
 ///      reads a record out of the overwrite plugin, and reports no warnings.
 ///   5  service/freshness — the overwrite plugin enters the profile files mid-session (the MO2-refresh flow after
 ///      a tool writes there); the next call picks it up.
+///   6  service/setup-confirm — the housecarl_set_mo2_instance confirmation lists the overwrite root among the
+///      derived roots, not silently omitted (hunt F9-4).
 ///
 /// Arms 1–3 drive Mo2LoadOrder.Build directly with dummy plugin FILES (Build maps paths; it never opens plugin
 /// content). Arms 4–5 drive the REAL service against a synthetic MO2 instance with real plugin bytes. Self-contained.
@@ -140,6 +142,12 @@ internal static class OverwriteResolveProbe
                 var read = svc.ResolveRead(toolFk, null, null, conflictTree: false);
                 Check(read.Error is null && read.Record is not null && read.WinnerPlugin == tKey.FileName,
                       $"a record inside the overwrite plugin reads end-to-end — winner={read.WinnerPlugin ?? "?"}, err={read.Error ?? "none"}");
+
+                // F9-4: the setup confirmation (housecarl_set_mo2_instance) lists the overwrite root among the derived
+                // roots, not silently omitted — it's a real load-order root the user should see.
+                var confirm = SetupTools.Render(Mo2Instance.Resolve(instance), persisted: true, persistError: null, persistNote: null);
+                Check(confirm.Contains(ovw, StringComparison.OrdinalIgnoreCase),
+                      "the setup confirmation lists the overwrite root among the derived roots (hunt F9-4)");
             }
         }
         finally { try { Directory.Delete(root, recursive: true); } catch { /* temp scratch */ } }

--- a/src/housecarl-generator/OverwriteResolveProbe.cs
+++ b/src/housecarl-generator/OverwriteResolveProbe.cs
@@ -18,7 +18,8 @@ namespace HousecarlGenerator;
 ///   1  core/resolve — an overwrite-only plugin listed in the profile resolves to its overwrite path, no warning.
 ///   2  core/priority — a filename present in overwrite AND an enabled mod resolves to the OVERWRITE copy.
 ///   3  core/warning — a genuinely-missing plugin still warns, and the warning names the overwrite folder among
-///      the places searched (the message is honest about what was checked).
+///      the places searched (the message is honest about what was checked) — but in explicit-paths mode
+///      (overwriteDir="") the SAME warning omits overwrite, since it was never searched (hunt F9-3).
 ///   4  service/end-to-end — a real (synthesized) plugin only in overwrite: the service resolves the full order,
 ///      reads a record out of the overwrite plugin, and reports no warnings.
 ///   5  service/freshness — the overwrite plugin enters the profile files mid-session (the MO2-refresh flow after
@@ -77,6 +78,14 @@ internal static class OverwriteResolveProbe
                 Check(goneWarn is not null, "a genuinely-missing plugin still warns");
                 Check(goneWarn is not null && goneWarn.Contains("overwrite", StringComparison.OrdinalIgnoreCase),
                       "…and the warning names the overwrite folder among the places searched");
+
+                // F9-3: explicit-paths mode passes overwriteDir="" (there IS no overwrite layer), so the same warning
+                // must NOT claim the overwrite folder was searched — that would overstate what was checked (Q3).
+                var rExplicit = Mo2LoadOrder.Build(prof, mods, data, "");
+                var goneWarnExplicit = rExplicit.Warnings.FirstOrDefault(w => w.Contains("Gone.esp", StringComparison.OrdinalIgnoreCase));
+                Check(goneWarnExplicit is not null, "explicit mode (overwriteDir=\"\"): a missing plugin still warns");
+                Check(goneWarnExplicit is not null && !goneWarnExplicit.Contains("overwrite", StringComparison.OrdinalIgnoreCase),
+                      "…and the warning does NOT name the overwrite folder (it was never searched in explicit mode)");
             }
 
             // ---- arms 4-5: the real service against a synthetic instance with real plugin bytes ----

--- a/src/housecarl-generator/PerkRefsProbe.cs
+++ b/src/housecarl-generator/PerkRefsProbe.cs
@@ -130,7 +130,7 @@ public static class PerkRefsProbe
         Console.WriteLine($"################  REAL-DATA PROOF — cross_plugin_query type=Perk references={refRaw} on {Path.GetFileName(instanceDir)}  ################");
         Console.WriteLine();
         var p = Mo2Instance.Resolve(instanceDir);
-        var order = Mo2LoadOrder.Build(p.ProfileDir, p.ModsDir, p.DataDir);
+        var order = Mo2LoadOrder.Build(p.ProfileDir, p.ModsDir, p.DataDir, p.OverwriteDir);
         using var resolver = LoadOrderResolver.Build(order.OrderedPaths.ToList());
         Console.WriteLine($"   resolver: {resolver.PluginCount} plugins, {resolver.RecordCount:N0} records, {resolver.ExcludedPlugins.Count} excluded");
         var svc = LoadOrderService.ForGuard(resolver, new UserConfigStore(Path.Combine(Path.GetTempPath(), "hc-perkrefs-proof.user.json")));
@@ -199,7 +199,7 @@ public static class PerkRefsProbe
         Console.WriteLine($"################  DIAGNOSIS — EnumerateFormLinks over ALL winner PERKs in the {Path.GetFileName(instanceDir)} order  ################");
         Console.WriteLine();
         var p = HousecarlCore.Mo2Instance.Resolve(instanceDir);
-        var order = HousecarlCore.Mo2LoadOrder.Build(p.ProfileDir, p.ModsDir, p.DataDir);
+        var order = HousecarlCore.Mo2LoadOrder.Build(p.ProfileDir, p.ModsDir, p.DataDir, p.OverwriteDir);
         Console.WriteLine($"   order: {order.OrderedPaths.Count} plugins (profile '{p.ProfileName}')");
         using var resolver = HousecarlCore.LoadOrderResolver.Build(order.OrderedPaths.ToList());
         Console.WriteLine($"   resolver: {resolver.PluginCount} plugins, {resolver.RecordCount:N0} records, {resolver.ExcludedPlugins.Count} excluded");

--- a/src/housecarl-generator/PkcuProbe.cs
+++ b/src/housecarl-generator/PkcuProbe.cs
@@ -158,7 +158,7 @@ public static class PkcuProbe
 
         Console.WriteLine("== SCALE PROOF: real MO2 order + 1 malformed plugin ==");
         var p = Mo2Instance.Resolve(instanceDir);
-        var order = Mo2LoadOrder.Build(p.ProfileDir, p.ModsDir, p.DataDir);
+        var order = Mo2LoadOrder.Build(p.ProfileDir, p.ModsDir, p.DataDir, p.OverwriteDir);
         var real = order.OrderedPaths.ToList();
         Console.WriteLine($"   real order: {real.Count} plugins (profile '{p.ProfileName}')");
         real.Add(mal);                                                     // append the malformed plugin at highest priority

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -188,7 +188,7 @@ if (args.Length > 0 && args[0] == "create-proof") return CreateProof.RunCreatePr
 // Master-baseline scout: how to FORCE Skyrim.esm onto every written plugin (Mutagen strips unreferenced masters) — Aaron-flagged bug.
 if (args.Length > 0 && args[0] == "master-probe") return MasterProbe.RunProbe(args[1..]);
 
-// Launch-arc item 3 proof: derive the three load-order roots + active profile from ONE MO2 instance path (ModOrganizer.ini).
+// Launch-arc item 3 proof: derive the load-order roots + active profile from ONE MO2 instance path (ModOrganizer.ini).
 if (args.Length > 0 && args[0] == "mo2instance-probe") return Mo2InstanceProbe.RunProbe(args[1..]);
 
 // Cleanup-gotcha / Option-B viability: prove a plain overlay LOCKS a plugin, Dispose() RELEASES it promptly, and open->read->dispose latency is invisible (de-risks the LOCKED Option-B fix).

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -82,6 +82,11 @@ if (args.Length > 0 && args[0] == "overwrite-resolve-guard") return OverwriteRes
 // SKSE-extended copies of vanilla sources must win). Pure order arm always runs; real-compile arm self-skips.
 if (args.Length > 0 && args[0] == "import-order-guard") return ImportOrderProbe.RunGuard(args[1..]);
 
+// Render-clamp guard (2026-06-13 cosmetic sweep, render NOTEs N2+N3): the Nexus description renderer
+// truncates surrogate-safe (an emoji at the clamp boundary is never split into a lone half-glyph) and
+// decodes &amp; LAST so a double-encoded "&amp;lt;" renders the literal "&lt;", not "<". Pure strings.
+if (args.Length > 0 && args[0] == "render-clamp-guard") return RenderClampProbe.RunGuard(args[1..]);
+
 // Decompiler baseline hierarchy: emit vanilla-class-parents.json from the CK vanilla sources' own
 // ScriptName-extends headers (committed asset — vanilla sources don't exist on CI; regenerate on game updates).
 if (args.Length > 0 && args[0] == "class-parents") return ClassParentsEmitter.Run(args[1..]);

--- a/src/housecarl-generator/RenderClampProbe.cs
+++ b/src/housecarl-generator/RenderClampProbe.cs
@@ -1,0 +1,79 @@
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// Render-clamp guard (2026-06-13 cosmetic sweep, render NOTEs N2 + N3) — locks two correctness
+/// properties of the Nexus description renderer (HousecarlMcp.Render.StripMarkup / OneLine), fully
+/// self-contained (pure string transforms, no game data, no network).
+///
+/// Arms:
+///   1. SURROGATE-SAFE CLAMP (OneLine) — an astral char (emoji) straddling the clamp boundary must
+///      not be split into a lone half-surrogate. OneLine clamps via ClampChars, so its output carries
+///      no unpaired surrogate.
+///   2. SURROGATE-SAFE CLAMP (StripMarkup cap path) — same property through the description-body
+///      truncation, with no space in the last 200 chars so the word-boundary backup is skipped and the
+///      raw char clamp is what runs.
+///   3. ENTITY DECODE ORDER (&amp; LAST) — a double-encoded "&amp;lt;" (author wanted the visible text
+///      "&lt;") must decode to "&lt;", not "<": &amp; is undone after every other entity so a decoded
+///      entity's '&' can never re-trigger another replacement.
+///   4. ENTITY REGRESSION — the common single-encoded "Mod A &amp; Mod B" still renders "Mod A & Mod B"
+///      (passes under both orders; proves the reorder didn't regress the ordinary case).
+///
+/// Teeth (mutation-RED, verified at authoring): revert ClampChars to a naive s[..n] → arms 1+2 FAIL;
+/// move ".Replace(\"&amp;\", \"&\")" back to the FRONT of the entity chain → arm 3 FAILS.
+/// </summary>
+internal static class RenderClampProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" render-clamp guard — surrogate-safe truncation + &amp;-last decode");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        const string Emoji = "😀"; // U+1F600 GRINNING FACE — one astral char, two UTF-16 code units
+
+        // Arm 1 — OneLine clamps directly via ClampChars. Put the emoji's high half at index n-1 so a naive
+        // clamp would orphan it. n=40, input is 39 'a' + emoji (length 41) → clamp at 40 splits the pair.
+        var oneLineIn = new string('a', 39) + Emoji;
+        var oneLineOut = Render.OneLine(oneLineIn, 40);
+        Check(!HasLoneSurrogate(oneLineOut), "1. OneLine: emoji at the clamp boundary leaves no lone surrogate");
+
+        // Arm 2 — StripMarkup's body cap. cap=400, input is 399 'a' + emoji (cleaned length 401 > 400), no space
+        // in the last 200 chars so the word-boundary backup is skipped and the char clamp is what truncates.
+        var stripIn = new string('a', 399) + Emoji;
+        var stripOut = Render.StripMarkup(stripIn, 400);
+        Check(!HasLoneSurrogate(stripOut), "2. StripMarkup cap path: astral char at the cut leaves no lone surrogate");
+
+        // Arm 3 — double-encoded "&amp;lt;" must decode to the literal text "&lt;", not "<".
+        var doubleEnc = Render.StripMarkup("&amp;lt;", 400);
+        Check(doubleEnc == "&lt;", $"3. entity order: \"&amp;lt;\" decodes to \"&lt;\" (got \"{doubleEnc}\")");
+
+        // Arm 4 — ordinary single-encoded ampersand still renders correctly (regression-safety, both orders).
+        var single = Render.StripMarkup("Mod A &amp; Mod B", 400);
+        Check(single == "Mod A & Mod B", $"4. entity regression: single \"&amp;\" still renders \"&\" (got \"{single}\")");
+
+        Console.WriteLine();
+        Console.WriteLine(fail == 0 ? "ALL PASS" : $"{fail} FAILED");
+        return fail;
+    }
+
+    /// <summary>True if the string contains an unpaired surrogate (a high surrogate not followed by a low,
+    /// or a stray low surrogate) — i.e. a broken half-glyph.</summary>
+    static bool HasLoneSurrogate(string s)
+    {
+        for (int i = 0; i < s.Length; i++)
+        {
+            if (char.IsHighSurrogate(s[i]))
+            {
+                if (i + 1 >= s.Length || !char.IsLowSurrogate(s[i + 1])) return true;
+                i++; // valid pair — skip its low half
+            }
+            else if (char.IsLowSurrogate(s[i])) return true; // a low surrogate with no high before it
+        }
+        return false;
+    }
+}

--- a/src/housecarl-generator/WriteMutexProbe.cs
+++ b/src/housecarl-generator/WriteMutexProbe.cs
@@ -28,6 +28,9 @@ namespace HousecarlGenerator;
 ///   DOTTED     — a dotted patch name ("My.Cool.Patch") keeps every segment in the folder + plugin, and an
 ///                into= naming the .esp-suffixed form strips ONLY the extension, resolving the SAME folder.
 ///                RED pre-fix (Path.GetFileNameWithoutExtension clipped at the last dot -> "My.Cool"). NOTE N1.
+///   RIDER RESIDUE — the F4 "a refusal leaves no orphan folder" principle, generalised to the non-.esp riders
+///                (hunt H2): a failed rider DELETES a genuinely-empty fresh folder (only meta.ini), KEEPS + names one
+///                holding real output, and NEVER touches a reused into= folder. Drives RemoveOrNameRiderResidue.
 /// </summary>
 internal static class WriteMutexProbe
 {
@@ -178,6 +181,33 @@ internal static class WriteMutexProbe
                     null, "My.Cool.Patch.esp");
                 Check(ext.Success && dot.Success && string.Equals(ext.OutputPath, dot.OutputPath, StringComparison.OrdinalIgnoreCase),
                       $"into='My.Cool.Patch.esp' resolves the SAME folder — extension stripped, inner dots kept (into {Path.GetFileName(ext.OutputPath)})");
+            }
+
+            // ---- RIDER RESIDUE: a non-.esp rider that fails cleans up — delete if empty, name if real output, into= untouched (hunt H2) ----
+            Console.WriteLine();
+            Console.WriteLine("--- 5: rider residue — fresh empty folder deleted, partial named, into= reuse untouched (hunt H2) ---");
+            {
+                // (a) fresh + genuinely empty (only our meta.ini) → DELETED, nothing to name
+                var rfEmpty = svc.ResolvePatchModFolder("HcRiderEmpty", null, "houseCARL_Archive");
+                Check(rfEmpty.CreatedFresh && Directory.Exists(rfEmpty.ModFolder), "a fresh rider folder is created (only meta.ini)");
+                var leftEmpty = svc.RemoveOrNameRiderResidue(rfEmpty);
+                Check(leftEmpty is null && !Directory.Exists(rfEmpty.ModFolder),
+                      "a genuinely-empty fresh rider folder is DELETED on failure (no orphan, nothing to name)");
+
+                // (b) fresh + a real artifact landed → KEPT and its path NAMED
+                var rfFull = svc.ResolvePatchModFolder("HcRiderFull", null, "houseCARL_Archive");
+                File.WriteAllText(Path.Combine(rfFull.OutputDir, "Output.bsa"), "data");        // real output before the failure
+                var leftFull = svc.RemoveOrNameRiderResidue(rfFull);
+                Check(leftFull == rfFull.ModFolder && Directory.Exists(rfFull.ModFolder),
+                      "a fresh rider folder holding REAL output is KEPT and its path named (never delete tool output)");
+
+                // (c) into= reuse → NEVER touched (the user owns it)
+                svc.ResolvePatchModFolder("HcRiderInto", null, "houseCARL_Archive");             // create it fresh first
+                var reuse = svc.ResolvePatchModFolder(null, "HcRiderInto", "houseCARL_Archive");  // then reuse it via into=
+                Check(!reuse.CreatedFresh, "an into= reuse is not flagged fresh");
+                var leftReuse = svc.RemoveOrNameRiderResidue(reuse);
+                Check(leftReuse is null && Directory.Exists(reuse.ModFolder),
+                      "an into= reused folder is NEVER deleted or named (the user owns it)");
             }
         }
         finally { try { Directory.Delete(root, recursive: true); } catch { /* temp scratch */ } }

--- a/src/housecarl-generator/WriteMutexProbe.cs
+++ b/src/housecarl-generator/WriteMutexProbe.cs
@@ -25,6 +25,9 @@ namespace HousecarlGenerator;
 ///                gate means the second opens what the first committed — no lost update). RED pre-fix.
 ///   ORPHAN     — a pre-flight-refused fresh write leaves NO folder behind, twice over (no _001 accretion), and
 ///                a later successful write under that name gets the BASE stem. RED pre-fix (deterministic).
+///   DOTTED     — a dotted patch name ("My.Cool.Patch") keeps every segment in the folder + plugin, and an
+///                into= naming the .esp-suffixed form strips ONLY the extension, resolving the SAME folder.
+///                RED pre-fix (Path.GetFileNameWithoutExtension clipped at the last dot -> "My.Cool"). NOTE N1.
 /// </summary>
 internal static class WriteMutexProbe
 {
@@ -159,6 +162,22 @@ internal static class WriteMutexProbe
                 var good = svc.ApplyEdits(new[] { DamageOp(fid, 75) }, "HcWmxOrphan", null);
                 Check(good.Success && good.OutputPath.EndsWith(Path.Combine("houseCARL - HcWmxOrphan", "HcWmxOrphan.esp"), StringComparison.OrdinalIgnoreCase),
                       $"a later good write gets the BASE stem, not an accreted _NNN — wrote {Path.GetFileName(good.OutputPath)}");
+            }
+
+            // ---- DOTTED: a dotted patch name survives intact; into= strips only the extension (render NOTE N1) ----
+            Console.WriteLine();
+            Console.WriteLine("--- 4: dotted patch name not clipped at a dot (render NOTE N1) ---");
+            {
+                var dot = svc.ApplyEdits(new[] { DamageOp(fid, 80) }, "My.Cool.Patch", null);
+                Check(dot.Success && dot.OutputPath.EndsWith(
+                          Path.Combine("houseCARL - My.Cool.Patch", "My.Cool.Patch.esp"), StringComparison.OrdinalIgnoreCase),
+                      $"the dotted stem survives — folder + plugin keep every segment (wrote {Path.GetFileName(dot.OutputPath)})");
+                // into= naming the .esp-suffixed form strips ONLY the extension and resolves the SAME dotted folder.
+                var ext = svc.ApplyEdits(
+                    new[] { new BulkOp { Formid = fid, FieldPath = "BasicStats.Weight", Verb = "Set", Value = "9" } },
+                    null, "My.Cool.Patch.esp");
+                Check(ext.Success && dot.Success && string.Equals(ext.OutputPath, dot.OutputPath, StringComparison.OrdinalIgnoreCase),
+                      $"into='My.Cool.Patch.esp' resolves the SAME folder — extension stripped, inner dots kept (into {Path.GetFileName(ext.OutputPath)})");
             }
         }
         finally { try { Directory.Delete(root, recursive: true); } catch { /* temp scratch */ } }

--- a/src/housecarl-mcp/BsaTools.cs
+++ b/src/housecarl-mcp/BsaTools.cs
@@ -84,7 +84,9 @@ public static class BsaTools
         if (managed)
         {
             if (svc.ConfigPromptOrNull() is { } cfg) return cfg;   // need ModsDir for the default managed folder
-            try { target = svc.ResolvePatchModFolder(Path.GetFileNameWithoutExtension(archive) + " (extracted)", into: null, "houseCARL_Extract"); }
+            // Extract keeps its own #49 residue contract (snapshot-provenance + the "left at X" message below) — out
+            // of H2's delete-if-empty scope, which Aaron set to repack/compile/decompile. Just take the output dir.
+            try { target = svc.ResolvePatchModFolder(Path.GetFileNameWithoutExtension(archive) + " (extracted)", into: null, "houseCARL_Extract").OutputDir; }
             catch (InvalidOperationException ex) { return "error: " + ex.Message; }
         }
         else
@@ -141,19 +143,29 @@ public static class BsaTools
             : Path.GetFileName(archive_name!.Trim().Trim('"'));
         if (!name.EndsWith(".bsa", StringComparison.OrdinalIgnoreCase)) name += ".bsa";
 
-        string folder;
-        try { folder = svc.ResolvePatchModFolder(patch_name, into, "houseCARL_Archive"); }
+        LoadOrderService.RiderFolder rf;
+        try { rf = svc.ResolvePatchModFolder(patch_name, into, "houseCARL_Archive"); }
         catch (InvalidOperationException ex) { return "error: " + ex.Message; }
+        var folder = rf.OutputDir;
+
+        // On any post-allocation failure: a genuinely-empty fresh folder is deleted (no orphan), a partial .bsa is
+        // kept and named, a reused into= folder is left alone — hunt H2 (Aaron's delete-if-empty).
+        string Refuse(string msg)
+        {
+            var left = svc.RemoveOrNameRiderResidue(rf);
+            return left is null ? msg
+                : msg + $"\nThe freshly created mod folder at '{left}' still holds a partial archive — delete it or retry with into=.";
+        }
 
         var archive = Path.Combine(folder, name);
         // Unknown format tokens REFUSE (Q3): a typo like 'fo4dd' must not silently pack -sse.
         var fmtFlag = HousecarlCore.BsaArchive.TryFormatFlag(format);
         if (fmtFlag is null)
-            return $"error: unknown format '{format}'. Legal tokens: {HousecarlCore.BsaArchive.FormatTokens}.";
+            return Refuse($"error: unknown format '{format}'. Legal tokens: {HousecarlCore.BsaArchive.FormatTokens}.");
         var r = HousecarlCore.BsaArchive.Pack(bsarch!, source_folder, archive, fmtFlag, compress);
-        if (!r.Ran) return "error: " + r.RunError;
+        if (!r.Ran) return Refuse("error: " + r.RunError);
         if (!r.Success)
-            return $"repack FAILED: no .bsa written at '{archive}'. Raw BSArch output:\n" + r.Raw;
+            return Refuse($"repack FAILED: no .bsa written at '{archive}'. Raw BSArch output:\n" + r.Raw);
 
         var sb = new StringBuilder();
         sb.Append("packed ").Append(name).Append(" (").Append(fmtFlag.TrimStart('-')).Append(compress ? ", compressed" : ", uncompressed").Append(") → ").Append(archive).Append('\n');

--- a/src/housecarl-mcp/CompileTools.cs
+++ b/src/housecarl-mcp/CompileTools.cs
@@ -61,13 +61,22 @@ public static class CompileTools
         var imports = BuildImports(scriptDir, compilerExe!, import_dirs);
 
         // 5) output folder (folder-per-patch, Scripts\ subdir).
-        string outDir;
-        try { outDir = svc.ResolveCompiledScriptFolder(patch_name, into); }
+        LoadOrderService.RiderFolder rf;
+        try { rf = svc.ResolveCompiledScriptFolder(patch_name, into); }
         catch (InvalidOperationException ex) { return "error: " + ex.Message; }
 
         // 6) compile + render.
-        var result = HousecarlCore.PapyrusCompile.CompileObject(compilerExe!, objectName, imports, outDir);
-        return Render(result, imports);
+        var result = HousecarlCore.PapyrusCompile.CompileObject(compilerExe!, objectName, imports, rf.OutputDir);
+        var rendered = Render(result, imports);
+        // A failed compile produced no .pex — clean up a genuinely-empty fresh folder, name a partial one, leave an
+        // into= reuse alone (hunt H2, Aaron's delete-if-empty).
+        if (!result.Success)
+        {
+            var left = svc.RemoveOrNameRiderResidue(rf);
+            if (left is not null)
+                rendered += $"\nThe freshly created mod folder at '{left}' still holds partial output — delete it or retry with into=.";
+        }
+        return rendered;
     });
 
     /// <summary>

--- a/src/housecarl-mcp/DecompileTools.cs
+++ b/src/housecarl-mcp/DecompileTools.cs
@@ -71,8 +71,8 @@ public static class DecompileTools
         // 4) output folder (folder-per-patch, Source\Scripts subdir) — resolved BEFORE the hierarchy build so a
         //    folder-resolution error costs nothing, and the instance paths are derived before the cached walk
         //    (defense in depth for hunt F1; the service also self-derives now).
-        string outDir;
-        try { outDir = svc.ResolveDecompiledSourceFolder(patch_name, into); }
+        LoadOrderService.RiderFolder rf;
+        try { rf = svc.ResolveDecompiledSourceFolder(patch_name, into); }
         catch (InvalidOperationException ex) { return "error: " + ex.Message; }
 
         // 5) class hierarchy: cached vanilla baseline + mods-tree sources, topped up with the input pex itself
@@ -85,15 +85,24 @@ public static class DecompileTools
         try { HousecarlCore.PapyrusClassParents.AddFromPexFolder(edges, Path.GetDirectoryName(pex)!); }
         catch { /* fewer edges, never fatal */ }
 
+        // A refused decompile leaves no orphan: a genuinely-empty fresh folder is deleted, one holding partial .psc
+        // output is kept and named, an into= reuse is left alone (hunt H2, Aaron's delete-if-empty).
+        string Refuse(string msg)
+        {
+            var left = svc.RemoveOrNameRiderResidue(rf);
+            return left is null ? msg
+                : msg + $" The freshly created mod folder at '{left}' still holds partial output — delete it or retry with into=.";
+        }
+
         // 6) decompile + write (the guard-probed seam).
-        var o = WriteObjects(pexFile, edges, outDir);
+        var o = WriteObjects(pexFile, edges, rf.OutputDir);
         if (o.UnnamedObject)
-            return $"error: '{Path.GetFileName(pex)}' carries an unnamed script object. " +
-                   (o.Written.Count > 0 ? $"Already written this call: {string.Join(", ", o.Written)}." : "Nothing was written.");
+            return Refuse($"error: '{Path.GetFileName(pex)}' carries an unnamed script object. " +
+                   (o.Written.Count > 0 ? $"Already written this call: {string.Join(", ", o.Written)}." : "Nothing was written."));
         if (o.ExistingTarget is not null)
-            return $"error: '{o.ExistingTarget}' already exists — houseCARL never overwrites a source file. " +
+            return Refuse($"error: '{o.ExistingTarget}' already exists — houseCARL never overwrites a source file. " +
                    "Move/delete it, or pass a different patch_name= (or into= another patch folder). " +
-                   (o.Written.Count > 0 ? $"Already written this call: {string.Join(", ", o.Written)}." : "Nothing was written.");
+                   (o.Written.Count > 0 ? $"Already written this call: {string.Join(", ", o.Written)}." : "Nothing was written."));
 
         // 7) render — Q3: totals, failures, and every degraded mode named.
         var outSb = new StringBuilder();

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1025,13 +1025,21 @@ public sealed class LoadOrderService : IDisposable
     /// pane and is the human-visible ownership signal (the meta.ini marker is the structural one).</summary>
     static string ModFolderName(string stem) => "houseCARL - " + stem;
 
-    /// <summary>Reduce a caller name to a safe bare STEM — no extension, no directory parts (so "../x" / "C:\y" can't
-    /// escape ModsDir). The plugin is always <c>&lt;stem&gt;.esp</c>; the mod folder is <c>houseCARL - &lt;stem&gt;</c>.</summary>
+    /// <summary>Plugin extensions stripped from a caller-supplied patch name (case-insensitive). NOT every dot — see
+    /// <see cref="PatchStem"/>.</summary>
+    static readonly string[] PluginExts = { ".esp", ".esm", ".esl" };
+
+    /// <summary>Reduce a caller name to a safe bare STEM — no directory parts (so "../x" / "C:\y" can't escape ModsDir),
+    /// stripping ONLY a trailing plugin extension (.esp/.esm/.esl), not every dot. A dotted patch name like
+    /// "My.Cool.Patch" must survive intact: Path.GetFileNameWithoutExtension would clip it to "My.Cool" — and then an
+    /// into="My.Cool.Patch" extend would look for the wrong folder, a silent name divergence. The plugin is always
+    /// <c>&lt;stem&gt;.esp</c>; the mod folder is <c>houseCARL - &lt;stem&gt;</c>.</summary>
     static string PatchStem(string raw)
     {
         var name = Path.GetFileName(raw.Trim());
-        var stem = Path.GetFileNameWithoutExtension(name);
-        return string.IsNullOrEmpty(stem) ? "houseCARL_Patch" : stem;
+        foreach (var ext in PluginExts)
+            if (name.EndsWith(ext, StringComparison.OrdinalIgnoreCase)) { name = name[..^ext.Length]; break; }
+        return string.IsNullOrEmpty(name) ? "houseCARL_Patch" : name;
     }
 
     /// <summary>The given stem if its mod folder is free, else the first free "<c>&lt;stem&gt;_NNN</c>" — never clobbers

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -918,13 +918,20 @@ public sealed class LoadOrderService : IDisposable
         catch (IOException) { } catch (UnauthorizedAccessException) { }
     }
 
+    /// <summary>The resolved output location for a NON-.esp rider: the directory to WRITE into, the mod-folder ROOT
+    /// (what residue cleanup operates on), and whether THIS call created the folder fresh (vs reused an into= folder,
+    /// which the user owns and cleanup never touches). For the .bsa/extract riders OutputDir == ModFolder; for the
+    /// compile/decompile riders OutputDir is a subfolder (<c>Scripts\</c> / <c>Source\Scripts\</c>) under ModFolder.</summary>
+    public readonly record struct RiderFolder(string OutputDir, string ModFolder, bool CreatedFresh);
+
     /// <summary>Resolve a houseCARL-owned MOD FOLDER under ModsDir for a NON-.esp output (compiled scripts, a packed .bsa,
     /// extracted loose files) — the folder-per-patch model generalised beyond the .esp write path. A fresh marker-stamped
     /// folder (<paramref name="defaultStem"/> names it when patchName is blank; auto-suffixed so a prior one is never
     /// clobbered) or <paramref name="into"/> an existing houseCARL-owned one. ORIGINALS UNTOUCHED (Q3): refuses a folder
     /// houseCARL didn't create. Derives ModsDir CHEAPLY (reads ModOrganizer.ini; NO ~10s index build). Throws the trained
-    /// prompt when unconfigured. Reuses the same ownership/marker helpers as the .esp write path.</summary>
-    public string ResolvePatchModFolder(string? patchName, string? into, string defaultStem)
+    /// prompt when unconfigured. Reuses the same ownership/marker helpers as the .esp write path. The returned
+    /// <see cref="RiderFolder.CreatedFresh"/> flag drives <see cref="RemoveOrNameRiderResidue"/> on a rider failure.</summary>
+    public RiderFolder ResolvePatchModFolder(string? patchName, string? into, string defaultStem)
     {
         lock (_gate)
         {
@@ -943,37 +950,61 @@ public sealed class LoadOrderService : IDisposable
                 if (!IsHouseCarlOwned(folder))
                     throw new InvalidOperationException(
                         $"cannot extend: mod folder '{ModFolderName(stem)}' was NOT created by houseCARL (no marker) — refusing to write into a folder houseCARL doesn't own (Q3).");
-                return folder;
+                return new RiderFolder(folder, folder, CreatedFresh: false);   // reused — the user owns it; cleanup leaves it
             }
 
             var newStem = UniqueStem(PatchStem(string.IsNullOrWhiteSpace(patchName) ? defaultStem : patchName!));
             var newFolder = Path.Combine(_modsDir, ModFolderName(newStem));
             Directory.CreateDirectory(newFolder);
             WriteOwnerMeta(newFolder, "(houseCARL output)");   // ownership marker; this folder may hold scripts / a .bsa / loose files, not an .esp
-            return newFolder;
+            return new RiderFolder(newFolder, newFolder, CreatedFresh: true);
         }
     }
 
     /// <summary>The <c>Scripts\</c> output folder for a COMPILED .pex (the compile rider) — a houseCARL mod folder via
     /// <see cref="ResolvePatchModFolder"/> plus its <c>Scripts\</c> subfolder, where MO2 deploys compiled Papyrus into the
-    /// game's Data\Scripts.</summary>
-    public string ResolveCompiledScriptFolder(string? patchName, string? into)
+    /// game's Data\Scripts. Carries the mod-folder root + fresh flag through for residue cleanup.</summary>
+    public RiderFolder ResolveCompiledScriptFolder(string? patchName, string? into)
     {
-        var folder = ResolvePatchModFolder(patchName, into, "houseCARL_Scripts");
-        var scripts = Path.Combine(folder, "Scripts");
+        var f = ResolvePatchModFolder(patchName, into, "houseCARL_Scripts");
+        var scripts = Path.Combine(f.ModFolder, "Scripts");
         Directory.CreateDirectory(scripts);
-        return scripts;
+        return f with { OutputDir = scripts };
     }
 
     /// <summary>The <c>Source\Scripts\</c> output folder for a DECOMPILED .psc (the decompile rider) — the SE-canonical
     /// source layout, and the same default patch stem as the compile rider so decompile → edit → compile naturally
-    /// accumulates in one houseCARL patch folder via <c>into=</c>.</summary>
-    public string ResolveDecompiledSourceFolder(string? patchName, string? into)
+    /// accumulates in one houseCARL patch folder via <c>into=</c>. Carries the root + fresh flag through for cleanup.</summary>
+    public RiderFolder ResolveDecompiledSourceFolder(string? patchName, string? into)
     {
-        var folder = ResolvePatchModFolder(patchName, into, "houseCARL_Scripts");
-        var src = Path.Combine(folder, "Source", "Scripts");
+        var f = ResolvePatchModFolder(patchName, into, "houseCARL_Scripts");
+        var src = Path.Combine(f.ModFolder, "Source", "Scripts");
         Directory.CreateDirectory(src);
-        return src;
+        return f with { OutputDir = src };
+    }
+
+    /// <summary>Hunt H2 (Aaron 2026-06-13): a NON-.esp rider (compile / decompile / repack) that FAILED after creating a
+    /// fresh houseCARL mod folder cleans up after itself — the .esp F4 "a refusal leaves no orphan folder" principle,
+    /// generalised to the riders. If the fresh folder is GENUINELY EMPTY (holds NOTHING but our own meta.ini marker
+    /// anywhere in its tree) it is DELETED, so "no output written" is true of the disk; if real output DID land (a
+    /// partial .bsa, some written .psc/.pex), the folder STAYS and its path is RETURNED so the rider can NAME it —
+    /// houseCARL never deletes content it didn't recognise as its own marker. A REUSED into= folder
+    /// (<see cref="RiderFolder.CreatedFresh"/> = false) is never touched: the user owns it. Returns the leftover path to
+    /// name, or null (deleted, or nothing to do). Best-effort: a cleanup hiccup never masks the rider's own outcome.</summary>
+    internal string? RemoveOrNameRiderResidue(RiderFolder folder)
+    {
+        if (!folder.CreatedFresh) return null;             // into= reuse — the user owns it, never deleted or named
+        var root = folder.ModFolder;
+        try
+        {
+            if (!Directory.Exists(root)) return null;
+            bool onlyMarker = Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories)
+                .All(f => Path.GetFileName(f).Equals("meta.ini", StringComparison.OrdinalIgnoreCase));
+            if (onlyMarker) { Directory.Delete(root, recursive: true); return null; }   // genuinely empty → gone, nothing to name
+            return root;                                   // real output landed → keep it, hand back the path to NAME
+        }
+        catch (IOException) { return Directory.Exists(root) ? root : null; }
+        catch (UnauthorizedAccessException) { return Directory.Exists(root) ? root : null; }
     }
 
     // ---- decompiler class hierarchy (lazy, cached for process lifetime) ----------------------------------------

--- a/src/housecarl-mcp/NexusTools.cs
+++ b/src/housecarl-mcp/NexusTools.cs
@@ -226,12 +226,23 @@ static class Render
         return sb.ToString();
     }
 
+    /// <summary>Substring(0, n) that never splits a surrogate pair: an astral char (emoji, CJK extension B+, …) is two
+    /// UTF-16 chars, so a raw clamp can leave a LONE high surrogate at the cut = a broken half-glyph. If the char just
+    /// before the cut is a high surrogate (its low half sits at/after n), back up one so the orphaned half is dropped
+    /// (Q3 — an explicit cut, never a silent garble).</summary>
+    static string ClampChars(string s, int n)
+    {
+        if (s.Length <= n) return s;
+        if (n > 0 && char.IsHighSurrogate(s[n - 1])) n--;
+        return s[..n];
+    }
+
     /// <summary>Collapse whitespace and cap a blurb to n chars with an ellipsis (Q3: explicit cut, never silent garble).</summary>
-    static string OneLine(string s, int n)
+    internal static string OneLine(string s, int n)
     {
         s = s.Replace('\r', ' ').Replace('\n', ' ').Trim();
         while (s.Contains("  ")) s = s.Replace("  ", " ");
-        return s.Length <= n ? s : s[..n].TrimEnd() + "…";
+        return s.Length <= n ? s : ClampChars(s, n).TrimEnd() + "…";
     }
 
     /// <summary>Turn a Nexus description (BBCode interleaved with HTML — e.g. "[size=5][b]…[/b][/size]&lt;br /&gt;") into
@@ -239,7 +250,7 @@ static class Render
     /// [url=…]label[/url] to its label, turn list markers and HTML block/break tags into newlines, strip every remaining
     /// BBCode and HTML tag (keeping inner text), decode the handful of HTML entities that actually appear, collapse
     /// runaway whitespace, and cap the result with an explicit truncation marker (Q3 — never a silent cut).</summary>
-    static string StripMarkup(string raw, int cap)
+    internal static string StripMarkup(string raw, int cap)
     {
         const RegexOptions IC = RegexOptions.IgnoreCase;
         // Bound the input BEFORE any regex: the embed/[url] cleaners use a lazy `.*?` that backtracks O(n²) on many
@@ -247,7 +258,7 @@ static class Render
         // mode risk; DescriptionCap runs too late to help, it only trims the cleaned OUTPUT). cap*4 leaves ample
         // headroom (a real description cleans to < cap from far less raw) while capping the worst case to a fraction
         // of a second.
-        var s = raw.Length > cap * 4 ? raw[..(cap * 4)] : raw;
+        var s = ClampChars(raw, cap * 4);
 
         // Embeds: remove tag AND inner content (a URL/id is meaningless as prose). [img]…[/img], [youtube]…[/youtube], …
         s = Regex.Replace(s, @"\[(img|youtube|video|media|embed)\b[^\]]*\].*?\[/\1\]", " ", IC | RegexOptions.Singleline);
@@ -265,9 +276,13 @@ static class Render
         s = Regex.Replace(s, @"<\s*/?\s*(p|div|li|ul|ol|h[1-6]|tr|table)\b[^>]*>", "\n", IC);
         s = Regex.Replace(s, @"<[^>]+>", "", RegexOptions.Singleline);
 
-        // Entities that actually show up in Nexus descriptions.
-        s = s.Replace("&amp;", "&").Replace("&lt;", "<").Replace("&gt;", ">").Replace("&quot;", "\"")
-             .Replace("&#39;", "'").Replace("&apos;", "'").Replace("&nbsp;", " ");
+        // Entities that actually show up in Nexus descriptions. &amp; is decoded LAST (after every other entity):
+        // it produces a literal '&', the entity-introducing char, so undoing it first would let a double-encoded
+        // input like "&amp;lt;" (author wanted the visible text "&lt;") become "&lt;" then "<" — a double-decode.
+        // Keep &amp; at the tail so an already-decoded entity's '&' can never re-trigger another replacement.
+        s = s.Replace("&lt;", "<").Replace("&gt;", ">").Replace("&quot;", "\"")
+             .Replace("&#39;", "'").Replace("&apos;", "'").Replace("&nbsp;", " ")
+             .Replace("&amp;", "&");
 
         // Strip zero-width / BOM characters authors paste in (they render as stray glyphs); normalise no-break spaces.
         s = s.Replace("\uFEFF", "").Replace("\u200B", "").Replace("\u200C", "").Replace("\u200D", "").Replace('\u00A0', ' ');
@@ -282,7 +297,7 @@ static class Render
         // Cap with an explicit marker, backing up to a nearby word boundary so we don't cut mid-word.
         if (s.Length > cap)
         {
-            var cut = s[..cap];
+            var cut = ClampChars(s, cap);
             var sp = cut.LastIndexOf(' ');
             if (sp > cap - 200) cut = cut[..sp];
             s = cut.TrimEnd() + "\n…(description truncated — full text on the mod page.)";

--- a/src/housecarl-mcp/SetupTools.cs
+++ b/src/housecarl-mcp/SetupTools.cs
@@ -86,13 +86,18 @@ public static class SetupTools
     /// <summary>Confirmation: the instance + the DERIVED roots + the AUTO-DETECTED profile, a cheap enabled/active summary
     /// (text-file read, no deep index — proof houseCARL found the order), and whether the choice was persisted (Q3: a
     /// failed save is reported, not hidden; a corrupt-file recovery is named even on success — hunt F3).</summary>
-    static string Render(Mo2InstancePaths p, bool persisted, string? persistError, string? persistNote)
+    internal static string Render(Mo2InstancePaths p, bool persisted, string? persistError, string? persistNote)
     {
         var sb = new StringBuilder();
         sb.Append("configured houseCARL -> MO2 instance '").Append(p.InstanceDir).Append("'\n");
         sb.Append("active profile: ").Append(p.ProfileName).Append("  (auto-detected from ModOrganizer.ini)\n");
         sb.Append("  mods folder: ").Append(p.ModsDir).Append('\n');
         sb.Append("  game Data  : ").Append(p.DataDir).Append('\n');
+        // The overwrite layer is one of the derived roots (MO2's top-of-VFS, where tool outputs resolve from). It is
+        // NOT required to exist on a fresh instance, so annotate an absent one rather than printing a bare path that
+        // looks like a broken root.
+        sb.Append("  overwrite  : ").Append(p.OverwriteDir)
+          .Append(Directory.Exists(p.OverwriteDir) ? "" : "  (none yet — MO2 creates it when a tool writes here)").Append('\n');
 
         // Cheap composition (the three profile text files only — NO deep index): a quick figure so the user sees houseCARL
         // actually found the order. The resolve already confirmed the profile files exist; a read hiccup here is non-fatal


### PR DESCRIPTION
## Pre-1.3.0 cosmetic sweep

The final batch from the pre-1.3.0 hardening hunt — the cosmetic/UX-honesty leftovers after every behavioral item (F1–F9) landed. No correctness behavior changes beyond small render/diagnostic honesty fixes; each item that changes observable output gets its own CI guard arm, **mutation-RED-proven**. **26/26 CI probes pass locally.**

### Render NOTEs
- **N1** — `PatchStem` clipped a dotted patch name at the last dot (`My.Cool.Patch` → `My.Cool`), corrupting the plugin + MO2 folder name. Strip only a trailing plugin extension. Guard: a dotted arm in `write-mutex-guard`.
- **N2** — the Nexus description renderer could split an astral char (emoji/CJK) at the truncation clamp, leaving a broken half-glyph. New surrogate-safe `ClampChars` across all three clamp sites.
- **N3** — `&amp;` was decoded *before* the other HTML entities, so a double-encoded `&amp;lt;` double-decoded to `<`. Decode `&amp;` **last**. (N2+N3 guard: new `render-clamp-guard`.)
- **N4** — *not reproducible*: `RecordsIn` / `PluginRecordStatus` already throw the same named not-in-order error (fixed in 1.2.3, `0822059`). Closed, no code.

### Hunter-1 leftovers
- **H1** — a `base_directory` that is *set but points at a missing folder* silently fell back to the instance dir, then mis-pointed every downstream "missing folder" message. Now named (the absent/portable default stays quiet). Guard: arm E7 in `mo2instance-probe` (also newly added to CI).
- **H2** — a failed rider (`bsa_repack` / `compile_script` / `decompile_script`) left an empty houseCARL mod folder behind, unnamed. **Aaron's call: delete it, but only if genuinely empty.** `RemoveOrNameRiderResidue` deletes a fresh folder holding nothing but our `meta.ini`, keeps + names one with real output, and never touches a reused `into=` folder. (`bsa_extract` keeps its #49 behavior — out of scope.) Guard: a rider-residue arm in `write-mutex-guard`.
- **H3** — the compile rider's `-i` comment wrongly claimed semicolons-in-paths survive (`;` is the separator). Comment-only.
- **H4** — `bsa_list`'s "immune to banner variation" doc claim is overstated (an under-producing path block absorbs banner lines as paths). The real parse fix needs a captured real-BSArch fixture and is **deferred**; the softened note records the hazard in-code. Comment-only.
- **H5** — both external-tool exec helpers bounded only the process wait, not the post-exit stdout/stderr drain — a pipe-inheriting grandchild could hang `.GetResult()` forever. Port the proven 5s-bounded pattern from the setup preflight. Theoretical (never observed); no deterministic RED-proof, but the happy path is byte-identical (the stub-BSArch `bsa-contract-guard` stays green).

### F9 overwrite-folder follow-ups
- **F9-1** — three dev proofs called `Mo2LoadOrder.Build` 3-arg, missing the overwrite root (dev-run only). Fixed 4 call sites.
- **F9-2** — two "three roots" comments → four.
- **F9-3** — the can't-resolve warning unconditionally named the overwrite folder; in explicit-paths mode (no overwrite) that overstated the search. Now conditional. Guard: an explicit-mode arm in `overwrite-resolve-guard`.
- **F9-4** — the `set_mo2_instance` confirmation omitted the overwrite root. Added (annotating an absent one). Guard: a setup-confirm arm in `overwrite-resolve-guard`.
- **F9-5** — *left as-is*: the redundant `OverwriteDir` term in the switched-check is valuable parallel-structure / future-proofing; removing it would couple the method to a cross-file invariant.

### Verification
Every observable-output fix has a CI guard arm, each mutation-RED-proven at authoring (revert the fix → the new arm FAILs). CI suite is now **27 probes**; all 26 runnable on the runner pass locally (`bsa-probe` self-skips without BSArch). New CI steps: `render-clamp-guard`, `mo2instance-probe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
