### PR TITLE
Nested-record create (dialogue) — Layer A: mechanism + public tool + N9 extend fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,13 @@ jobs:
       - name: Probe — nested-record create (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- nested-create-guard
 
+      # Self-contained (synthesizes a real MO2 instance + a master with a dialogue topic) and drives the REAL
+      # LoadOrderService.CreateRecords / CreateRecordsBatch: locks in the create-tool WIRE (nested/dialogue plan,
+      # Layer A) — create_record's parent/collection passthrough, the new bulk_create batch tool (the same-call
+      # topic + line one-shot), batch all-or-nothing, and the nested-with-no-parent guidance copy.
+      - name: Probe — create-tool wire create_record parent + bulk_create (self-contained regression guard)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- bulk-create-guard
+
       # Drives the REAL housecarl-mcp.exe over stdio — the exact wire path of the live failure; needs no game data
       # (argument binding resolves before configuration is consulted): a regression guard locking in the tool-argument
       # binding shim — string-for-array coerces, missing-required refuses by name, an uncoercible shape fails NAMED

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
       # manual nested-create-proof) and drives the REAL CreateRecords: locks in nested-record create (nested/dialogue
       # plan, Layer A) — the one-shot topic+INFO, multi-child + field edit, INFO-into-existing-topic and
       # placed-into-cell happy paths; the four Q3 rejects (no parent, can't-contain, ambiguous collection, forward
-      # sibling); and the patch-carried-parent extend gap refusing loud.
+      # sibling); and the patch-carried-parent extend WORKING (a prior-into= topic resolves; a truly-absent parent refuses loud).
       - name: Probe — nested-record create (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- nested-create-guard
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,14 @@ jobs:
       - name: Probe — create into= upsert + staged write (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- upsert-guard
 
+      # Self-contained (synthesizes a master with a weapon + dialogue topic + interior cell — no Skyrim.esm, unlike the
+      # manual nested-create-proof) and drives the REAL CreateRecords: locks in nested-record create (nested/dialogue
+      # plan, Layer A) — the one-shot topic+INFO, multi-child + field edit, INFO-into-existing-topic and
+      # placed-into-cell happy paths; the four Q3 rejects (no parent, can't-contain, ambiguous collection, forward
+      # sibling); and the patch-carried-parent extend gap refusing loud.
+      - name: Probe — nested-record create (self-contained regression guard)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- nested-create-guard
+
       # Drives the REAL housecarl-mcp.exe over stdio — the exact wire path of the live failure; needs no game data
       # (argument binding resolves before configuration is consulted): a regression guard locking in the tool-argument
       # binding shim — string-for-array coerces, missing-required refuses by name, an uncoercible shape fails NAMED

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1008,6 +1008,154 @@ public static class WriteEngine
             $"Could not locate an AddNew({(withEdid ? "string" : "")}) extension accepting {group.GetType().Name} in the Mutagen assemblies.");
     }
 
+    // ======================================================================
+    //  NESTED CREATE front-end (nested/dialogue plan, Layer A — STEP 0 proven).
+    //  The sibling of NestedGetOrAddAsOverride: where that OVERRIDES an existing
+    //  nested record into the patch, this ALLOCATES a brand-new child INTO a
+    //  parent's modeled child-collection. By construction for the FormKey-
+    //  parented families (an INFO under a DialogTopic; a Placed* into a Cell):
+    //  the add-target collection is found REFLECTIVELY — the child type alone
+    //  picks it (outcome i) or the caller names one of the parent's enumerable
+    //  child-collections (outcome ii) — never a hand-coded per-family selector.
+    //  The parent must already be settable IN the patch (the caller overrides or
+    //  creates it first). Coordinate-keyed parents (an exterior Cell under the
+    //  FormKey-LESS WorldspaceBlock/SubBlock structs) are a SEPARATE §4-(b) seam,
+    //  not reachable here — TryFindNestedCollection fails loud for them (Q3).
+    // ======================================================================
+
+    /// <summary>Resolve a catalog/record-type name to its concrete Mutagen record <see cref="Type"/>. The namespace
+    /// is <c>Mutagen.Bethesda.Skyrim</c> by construction (the Loqui convention). Null ⇒ absent from the modeled set,
+    /// a real coverage gap to surface (Q3), never a value to guess.</summary>
+    public static Type? ResolveConcreteRecordType(string catalogName)
+        => typeof(IArmorGetter).Assembly.GetType("Mutagen.Bethesda.Skyrim." + catalogName);
+
+    /// <summary>Can a brand-new <paramref name="childCatalogName"/> record be created as a nested child of a parent of
+    /// <paramref name="parentType"/>, into <paramref name="collectionName"/> (null = the unique collection that accepts
+    /// the child)? The by-construction add-target test (nested plan §1.4 Q2): the parent's settable child-collections are
+    /// found reflectively, so "createable-under" is defined by the model, not a hand-coded per-family list. Every false
+    /// (no such containment, an ambiguous unnamed target, an unknown collection name) names what it checked (Q3).</summary>
+    public static bool CanCreateNested(string childCatalogName, Type parentType, string? collectionName, out string? reason)
+    {
+        var childType = ResolveConcreteRecordType(childCatalogName);
+        if (childType is null)
+        {
+            reason = $"'{childCatalogName}' is absent from the Mutagen corpus — a real coverage gap to surface, not a value to guess.";
+            return false;
+        }
+        return TryFindNestedCollection(parentType, childType, collectionName, out _, out _, out reason);
+    }
+
+    /// <summary>Find the parent type's SETTABLE child-collection to allocate a <paramref name="childType"/> into — the
+    /// generic add-target resolver. Reflects the parent's list/ExtendedList properties whose element type the child
+    /// satisfies. Outcomes: exactly one match ⇒ derivable by type (i), returned; several ⇒ the caller must NAME one
+    /// (<paramref name="collectionName"/> picks it) (ii); zero ⇒ the child cannot nest under this parent (a real
+    /// containment boundary, Q3). <paramref name="error"/> names the unnamed-ambiguous / no-containment / bad-name cases;
+    /// null on success.</summary>
+    static bool TryFindNestedCollection(Type parentType, Type childType, string? collectionName,
+        out PropertyInfo? prop, out List<string> matches, out string? error)
+    {
+        prop = null; error = null;
+        matches = new List<string>();
+        var hits = new List<PropertyInfo>();
+        foreach (var p in parentType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (p.GetGetMethod() is null) continue;                          // need a readable list instance to Add to
+            var elem = ListElementType(p.PropertyType);
+            if (elem is null) continue;
+            if (!elem.IsAssignableFrom(childType)) continue;                 // the child fits this list's element type
+            if (!typeof(System.Collections.IList).IsAssignableFrom(p.PropertyType)) continue;  // addable (ExtendedList<T> is an IList)
+            hits.Add(p); matches.Add(p.Name);
+        }
+        var parentName = parentType.Name;   // concrete class name, already clean (never an I…Getter here)
+        var childName = childType.Name;
+        if (hits.Count == 0)
+        {
+            error = $"'{childName}' cannot be created under a '{parentName}' — that parent models no child-collection that " +
+                    "holds it. (A real containment boundary — e.g. exterior cells nest under FormKey-less worldspace block " +
+                    "structs, a separate capability — surfaced not guessed, Q3.)";
+            return false;
+        }
+        if (collectionName is not null)
+        {
+            var named = hits.FirstOrDefault(h => string.Equals(h.Name, collectionName, StringComparison.OrdinalIgnoreCase));
+            if (named is null)
+            {
+                error = $"'{parentName}' has no child-collection named '{collectionName}' that holds '{childName}'. Available: {string.Join(", ", matches)}.";
+                return false;
+            }
+            prop = named; return true;
+        }
+        if (hits.Count > 1)
+        {
+            error = $"'{childName}' can be added to more than one collection on '{parentName}' ({string.Join(", ", matches)}) — " +
+                    "name which one (the collection= discriminator). (Q3 — never a silent default.)";
+            return false;
+        }
+        prop = hits[0]; return true;
+    }
+
+    /// <summary>The element type of an <c>IList&lt;T&gt;</c>/<c>ExtendedList&lt;T&gt;</c>-shaped property, else null
+    /// (a scalar, a string, a read-only sequence). Used to match a parent's child-collections to a child type.</summary>
+    static Type? ListElementType(Type t)
+    {
+        if (t == typeof(string) || !typeof(System.Collections.IEnumerable).IsAssignableFrom(t)) return null;
+        if (t.IsGenericType && t.GetGenericArguments() is { Length: 1 } ga) return ga[0];
+        return t.GetInterfaces().FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IList<>))
+                ?.GetGenericArguments()[0];
+    }
+
+    /// <summary>Construct a concrete Mutagen record via its <c>(FormKey, &lt;release enum&gt;)</c> constructor — the
+    /// net-new nested child. The ctor shape is discovered reflectively (measure, don't assume); throws loud if absent.</summary>
+    static IMajorRecord ConstructRecord(Type concrete, FormKey fk)
+    {
+        var ctor = concrete.GetConstructors()
+            .FirstOrDefault(c => c.GetParameters().Length == 2
+                && c.GetParameters()[0].ParameterType == typeof(FormKey) && c.GetParameters()[1].ParameterType.IsEnum);
+        if (ctor is null)
+            throw new InvalidOperationException($"nested create: no (FormKey, release) constructor on {concrete.Name} — surfaced, not guessed (Q3).");
+        var release = Enum.Parse(ctor.GetParameters()[1].ParameterType, "SkyrimSE");
+        return (IMajorRecord)ctor.Invoke(new object[] { fk, release });
+    }
+
+    /// <summary>Allocate the next LOCAL FormKey from the patch's own allocator (<c>GetNextFormKey</c>), discovered
+    /// reflectively. The caller floors the counter first (<see cref="EnsureFormIdFloor"/>), so the returned id is in
+    /// the 0x800+ ESP-local range and shares the SAME incrementing counter flat <c>AddNew</c> draws from (STEP 0).</summary>
+    static FormKey AllocateNextFormKey(SkyrimMod patchMod)
+    {
+        var m = patchMod.GetType().GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(x => x.Name == "GetNextFormKey" && x.GetParameters().Length == 0)
+            ?? throw new InvalidOperationException("nested create: no GetNextFormKey() on the patch mod — surfaced, not guessed (Q3).");
+        return (FormKey)m.Invoke(patchMod, null)!;
+    }
+
+    /// <summary>The CREATE front-end for a NESTED record: allocate a brand-new <paramref name="childCatalogName"/> child
+    /// into <paramref name="parentInPatch"/>'s modeled child-collection (named, or the unique one), returning a settable
+    /// root fed into the SAME <see cref="ApplyVerb"/> path as a flat create or an override. The new record gets a fresh
+    /// local 0x800+ FormKey from the SAME floor/counter as flat <see cref="GenericAddNew"/> (the nested plan §1.5 inherited
+    /// item — proven sharing in STEP 0). The parent MUST already be settable in the patch (overridden or created by the
+    /// caller). Throws loud (Q3) via <see cref="TryFindNestedCollection"/> on a containment/ambiguity the pre-flight
+    /// (<see cref="CanCreateNested"/>) should have caught — a throw here means the surface changed under us.</summary>
+    public static IMajorRecord NestedAddNew(SkyrimMod patchMod, IMajorRecord parentInPatch,
+        string childCatalogName, string? collectionName, string? editorId)
+    {
+        var childType = ResolveConcreteRecordType(childCatalogName)
+            ?? throw new InvalidOperationException($"nested create: '{childCatalogName}' is absent from the Mutagen corpus.");
+        if (!TryFindNestedCollection(parentInPatch.GetType(), childType, collectionName, out var prop, out _, out var error))
+            throw new InvalidOperationException(error);
+        if (prop!.GetValue(parentInPatch) is not System.Collections.IList list)
+            throw new InvalidOperationException($"nested create: collection '{prop.Name}' on '{parentInPatch.GetType().Name}' is not an addable list.");
+
+        EnsureFormIdFloor(patchMod);   // a rehydrated (into=) counter below 0x800 would hand engine-reserved IDs (HCBR-2026-06-09-04)
+        if (patchMod.ModHeader.Stats.NextFormID > 0xFFFFFF)
+            throw new InvalidOperationException(
+                $"cannot allocate a new FormID: the patch's NextObjectID counter is 0x{patchMod.ModHeader.Stats.NextFormID:X} — " +
+                "past the 24-bit object-ID ceiling (0xFFFFFF). The plugin is full or its header counter is corrupt.");
+        var child = ConstructRecord(childType, AllocateNextFormKey(patchMod));
+        if (editorId is not null) child.EditorID = editorId;
+        list.Add(child);
+        return child;
+    }
+
     static MethodInfo? _overrideMethod;
     /// <summary>The 2-arg <c>GetOrAddAsOverride&lt;TMajor,TMajorGetter&gt;(IGroup&lt;TMajor&gt;, TMajorGetter)</c> extension.</summary>
     static MethodInfo OverrideMethod()

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -810,10 +810,14 @@ public static class WriteEngine
                 reason = null;
                 return true;
             }
-        reason = $"'{typeName}' has no top-level group, so it can't be created directly — it's a nested/placed record " +
-                 "(a cell, a placed object/NPC, a dialogue line, navmesh or terrain, which needs parent context like which " +
-                 "cell it goes in), or a subtype of an abstract group (like Global → GlobalFloat). Both are named follow-ups. " +
-                 "Flat top-level records — keywords, spells, perks, magic effects, factions, armor, weapons, leveled lists, … — create fine.";
+        reason = $"'{typeName}' has no top-level group, so it can't be created on its own — it's a nested/placed record " +
+                 "(a placed object/NPC, a dialogue line, navmesh or terrain) that needs a parent. Create it WITH its parent: " +
+                 "pass parent= (the parent record's FormID, or the editorid of a record created EARLIER in the same call) and, " +
+                 "if the parent holds more than one child-collection, collection= — or use housecarl_bulk_create to make a parent " +
+                 "and its children (a dialogue topic + its lines, a cell + its placed refs) in ONE call. (An EXTERIOR cell nests " +
+                 "under FormKey-less worldspace block structs — a separate capability, still unsupported.) If instead it's a subtype " +
+                 "of an abstract group (like Global → GlobalFloat), create the concrete subtype. Flat top-level records — keywords, " +
+                 "spells, perks, magic effects, factions, armor, weapons, leveled lists, … — create fine.";
         return false;
     }
 

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -489,8 +489,10 @@ public static class WritePatchBuilder
         //     parent is overridden in (a flat parent needs no link cache; a nested parent — a Cell — gets the winner
         //     overlay's cache, the SAME session.LinkCacheFor path Apply uses + guards), a same-call sibling parent is
         //     the record created earlier in this loop — then WriteEngine.NestedAddNew allocates the child into the
-        //     parent's modeled collection (named, or the unique one). Idempotency note: nested create APPENDS (no
-        //     upsert-replace yet — a re-run into= re-adds; a follow-up surface). ---
+        //     parent's modeled collection (named, or the unique one). Idempotency: nested create APPENDS (no
+        //     upsert-replace) — Aaron-accepted for Layer A (2026-06-14): nested children carry no stable EditorID
+        //     handle to de-dup on (unlike flat GenericUpsertNew), so a re-run into= re-adds. Watch in real use;
+        //     revisit only if it bites. ---
         var created = new List<CreatedRecord>(specs.Count);
         var createdByEditorId = new Dictionary<string, IMajorRecord>(StringComparer.OrdinalIgnoreCase);
         var linkCacheByPlugin = new Dictionary<string, Mutagen.Bethesda.Plugins.Cache.ILinkCache>(StringComparer.OrdinalIgnoreCase);

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -98,6 +98,19 @@ public static class WritePatchBuilder
         public required string RecordType { get; init; }
         public required string EditorId { get; init; }
         public required IReadOnlyList<WriteRequest> Edits { get; init; }
+
+        /// <summary>Optional — the PARENT this record nests UNDER (nested-create, Layer A). Either an EXISTING parent's
+        /// FormKey (<c>XXXXXX:Plugin.esp</c> — add a line to an existing topic, a ref to an existing cell) OR the
+        /// <see cref="EditorId"/> of a record created EARLIER in this same call (the one-shot "topic + its lines" unit).
+        /// A FormKey is recognised by parsing; anything else is a same-call sibling EditorId. Null ⇒ a flat top-level
+        /// record (the existing create path, unchanged).</summary>
+        public string? ParentRef { get; init; }
+
+        /// <summary>Optional — which of the parent's child-collections to add into, BY NAME (the outcome-(ii)
+        /// discriminator, e.g. a Cell's <c>Persistent</c>/<c>Temporary</c>). Null ⇒ the unique collection that accepts
+        /// this child type (outcome (i), e.g. a DialogTopic's one <c>Responses</c> list). Ignored when
+        /// <see cref="ParentRef"/> is null.</summary>
+        public string? IntoCollection { get; init; }
     }
 
     /// <summary>One record created by <see cref="CreateRecords"/> — its freshly-allocated <see cref="FormKey"/> (the
@@ -380,17 +393,54 @@ public static class WritePatchBuilder
         // when the method returns — no handle held at rest.
         using var session = resolver.OpenSession();
 
-        // --- Phase 1: pre-flight EVERY spec before any mutation (Q3, all-or-nothing). editorid required; the type must be
-        //     createable (a concrete flat group — else the named nested/abstract boundary message); every edit validated by
-        //     the rulebook rooted at the create type. The new FormID isn't known until AddNew (Phase 3), so creatability is
-        //     a STRUCTURAL check (no resolve, no winner). ---
+        // --- Phase 1: pre-flight EVERY spec before any mutation (Q3, all-or-nothing). editorid required + unique; the
+        //     type must be createable — a FLAT top-level type (CanCreateType), OR a NESTED child given a valid parent
+        //     (CanCreateNested): the parent is resolved to its TYPE (an existing parent FormKey's load-order winner, or a
+        //     record created EARLIER in this same call — the one-shot order rule), and the child must nest under it by
+        //     construction (§1.4 Q2). Every edit is validated by the rulebook rooted at the create type. The new FormID
+        //     isn't known until allocation (Phase 3), so creatability is STRUCTURAL; a FormKey parent is resolved here only
+        //     to learn its TYPE + stash its winner body for the Phase-3 override. ONE captured build answers every parent
+        //     resolve (the hunt-F5 discipline the edit path follows). ---
+        var view = resolver.Capture();
         var problems = new List<string>();
         var seenEdid = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var s in specs)
+        var declaredEdidType = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);   // editorid -> RecordType (same-call sibling parents)
+        var parentPlans = new List<(IMajorRecordGetter? body, string? winnerPlugin, string? sibling)?>(specs.Count);
+        for (int i = 0; i < specs.Count; i++)
         {
+            var s = specs[i];
+            parentPlans.Add(null);   // flat default; overwritten on the nested path
             if (string.IsNullOrWhiteSpace(s.EditorId)) { problems.Add($"{s.RecordType}: an editorid is required to create a record (it's how the record is referenced)."); continue; }
             if (!seenEdid.Add(s.EditorId)) { problems.Add($"editorid '{s.EditorId}' is used by more than one record in this call — each created record needs a distinct editorid."); continue; }
-            if (!WriteEngine.CanCreateType(s.RecordType, out var why)) { problems.Add($"{s.RecordType} '{s.EditorId}': {why}"); continue; }
+            declaredEdidType[s.EditorId] = s.RecordType;
+
+            if (s.ParentRef is null)
+            {
+                if (!WriteEngine.CanCreateType(s.RecordType, out var why)) { problems.Add($"{s.RecordType} '{s.EditorId}': {why}"); continue; }
+            }
+            else
+            {
+                Type? parentType = null;
+                if (FormKey.TryFactory(s.ParentRef, out var parentFk))
+                {
+                    var w = view.ResolveWinner(parentFk);
+                    if (w is null) { problems.Add($"{s.RecordType} '{s.EditorId}': parent {parentFk} is not present in the load order — name an existing parent or create it first."); continue; }
+                    var parentBody = view.GetRecord(session, w.Value.WinnerPlugin, parentFk);
+                    if (parentBody is null) { problems.Add($"{s.RecordType} '{s.EditorId}': parent {parentFk} winner '{w.Value.WinnerPlugin}' did not yield it on fetch (a load-order inconsistency)."); continue; }
+                    parentType = WriteEngine.ResolveConcreteRecordType(RecordNaming.StripOverlay(parentBody.GetType().Name));
+                    parentPlans[i] = (parentBody, w.Value.WinnerPlugin, null);
+                }
+                else   // a same-call sibling parent — must be DECLARED EARLIER in this call (topic before its lines)
+                {
+                    if (s.ParentRef.Equals(s.EditorId, StringComparison.OrdinalIgnoreCase) || !declaredEdidType.TryGetValue(s.ParentRef, out var parentCatalog))
+                    { problems.Add($"{s.RecordType} '{s.EditorId}': parent '{s.ParentRef}' is neither an existing FormID nor a record created EARLIER in this call — create the parent (e.g. the topic) before its children, in spec order."); continue; }
+                    parentType = WriteEngine.ResolveConcreteRecordType(parentCatalog);
+                    parentPlans[i] = (null, null, s.ParentRef);
+                }
+                if (parentType is null) { problems.Add($"{s.RecordType} '{s.EditorId}': could not resolve the parent's record type."); continue; }
+                if (!WriteEngine.CanCreateNested(s.RecordType, parentType, s.IntoCollection, out var nestedWhy)) { problems.Add($"{s.RecordType} '{s.EditorId}': {nestedWhy}"); continue; }
+            }
+
             foreach (var req in s.Edits)
                 if (rulebook.Validate(req) is { } reject) problems.Add($"{s.RecordType} '{s.EditorId}' [{Label(req)}]: {reject}");
         }
@@ -424,13 +474,51 @@ public static class WritePatchBuilder
         //     idempotent, list fields can't accumulate, and stable FormKeys keep cross-record links + external references
         //     valid. Collisions it will NOT absorb (carried overrides, duplicate residue, cross-type) refuse loud there;
         //     every replace that DOES happen is carried on CreatedRecord.ReplacedExisting and rendered to the user. ---
+        //     NESTED create (a spec with a ParentRef): the parent is made settable IN the patch first — an existing
+        //     parent is overridden in (a flat parent needs no link cache; a nested parent — a Cell — gets the winner
+        //     overlay's cache, the SAME session.LinkCacheFor path Apply uses + guards), a same-call sibling parent is
+        //     the record created earlier in this loop — then WriteEngine.NestedAddNew allocates the child into the
+        //     parent's modeled collection (named, or the unique one). Idempotency note: nested create APPENDS (no
+        //     upsert-replace yet — a re-run into= re-adds; a follow-up surface). ---
         var created = new List<CreatedRecord>(specs.Count);
-        foreach (var s in specs)
+        var createdByEditorId = new Dictionary<string, IMajorRecord>(StringComparer.OrdinalIgnoreCase);
+        var linkCacheByPlugin = new Dictionary<string, Mutagen.Bethesda.Plugins.Cache.ILinkCache>(StringComparer.OrdinalIgnoreCase);
+        for (int i = 0; i < specs.Count; i++)
         {
-            IMajorRecord rec; bool replaced;
-            try { (rec, replaced) = WriteEngine.GenericUpsertNew(patchMod, s.RecordType, s.EditorId); }
+            var s = specs[i];
+            IMajorRecord rec; bool replaced = false;
+            try
+            {
+                if (s.ParentRef is null)
+                {
+                    (rec, replaced) = WriteEngine.GenericUpsertNew(patchMod, s.RecordType, s.EditorId);
+                }
+                else
+                {
+                    var plan = parentPlans[i]!.Value;
+                    IMajorRecord settableParent;
+                    if (plan.body is not null)
+                    {
+                        Mutagen.Bethesda.Plugins.Cache.ILinkCache? cache = null;
+                        if (WriteEngine.RecordNeedsSourceCache(plan.body))
+                        {
+                            if (!linkCacheByPlugin.TryGetValue(plan.winnerPlugin!, out cache))
+                                linkCacheByPlugin[plan.winnerPlugin!] = cache = session.LinkCacheFor(plan.winnerPlugin!);
+                        }
+                        settableParent = WriteEngine.GenericGetOrAddAsOverride(patchMod, plan.body, cache);
+                    }
+                    else
+                    {
+                        if (!createdByEditorId.TryGetValue(plan.sibling!, out var sib))
+                            return CreateOutcome.Fail($"internal: same-call parent '{plan.sibling}' for '{s.EditorId}' was not created before it — surfaced, not swallowed (Q3).");
+                        settableParent = sib;
+                    }
+                    rec = WriteEngine.NestedAddNew(patchMod, settableParent, s.RecordType, s.IntoCollection, s.EditorId);
+                }
+            }
             catch (Exception ex) { return CreateOutcome.Fail($"could not create {s.RecordType} '{s.EditorId}': {ex.Message}"); }
 
+            createdByEditorId[s.EditorId] = rec;
             var ops = new List<OpResult>(s.Edits.Count);
             foreach (var req in s.Edits)
             {

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -393,19 +393,40 @@ public static class WritePatchBuilder
         // when the method returns — no handle held at rest.
         using var session = resolver.OpenSession();
 
+        // --- Phase 0: open (extend) or create the patch mod FIRST — moved AHEAD of pre-flight so a FormKey parent can
+        //     resolve from the PATCH being extended (a parent created in a PRIOR into= call), not the load order alone
+        //     (the former N9 gap). CreateFromBinary reads the file fully into memory and holds NO handle at rest (the
+        //     active-patch self-lock invariant is untouched — Phase 4's ReleaseOverlay + AllMastersExcept still guard the
+        //     serialize); nothing is mutated until Phase 3 and nothing serialized until Phase 4, so all-or-nothing holds. ---
+        var fileName = Path.GetFileName(outPath);
+        SkyrimMod patchMod;
+        if (extend)
+        {
+            if (!File.Exists(outPath))
+                return CreateOutcome.Fail($"cannot extend: no existing patch at {outPath}. Omit into= to create it fresh.");
+            try { patchMod = SkyrimMod.CreateFromBinary(outPath, SkyrimRelease.SkyrimSE); }
+            catch (Exception ex) { return CreateOutcome.Fail($"cannot open patch to extend ({fileName}): {ex.GetType().Name}: {ex.Message}"); }
+        }
+        else
+        {
+            patchMod = new SkyrimMod(new ModKey(Path.GetFileNameWithoutExtension(outPath), ModType.Plugin), SkyrimRelease.SkyrimSE);
+        }
+        if (!string.Equals(patchMod.ModKey.FileName.String, fileName, StringComparison.OrdinalIgnoreCase))
+            return CreateOutcome.Fail($"patch ModKey '{patchMod.ModKey.FileName}' must match output filename '{fileName}'.");
+
         // --- Phase 1: pre-flight EVERY spec before any mutation (Q3, all-or-nothing). editorid required + unique; the
         //     type must be createable — a FLAT top-level type (CanCreateType), OR a NESTED child given a valid parent
-        //     (CanCreateNested): the parent is resolved to its TYPE (an existing parent FormKey's load-order winner, or a
-        //     record created EARLIER in this same call — the one-shot order rule), and the child must nest under it by
-        //     construction (§1.4 Q2). Every edit is validated by the rulebook rooted at the create type. The new FormID
-        //     isn't known until allocation (Phase 3), so creatability is STRUCTURAL; a FormKey parent is resolved here only
-        //     to learn its TYPE + stash its winner body for the Phase-3 override. ONE captured build answers every parent
-        //     resolve (the hunt-F5 discipline the edit path follows). ---
+        //     (CanCreateNested): the parent is resolved to its TYPE (an existing parent FormKey's load-order winner, a
+        //     record created EARLIER in this same call — the one-shot order rule — or a record the PATCH being extended
+        //     already carries, from a prior into= call), and the child must nest under it by construction (§1.4 Q2). Every
+        //     edit is validated by the rulebook rooted at the create type. The new FormID isn't known until allocation
+        //     (Phase 3), so creatability is STRUCTURAL; a FormKey parent is resolved here only to learn its TYPE + stash
+        //     the route to make it settable in Phase 3. ONE captured build answers every parent resolve (hunt-F5). ---
         var view = resolver.Capture();
         var problems = new List<string>();
         var seenEdid = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var declaredEdidType = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);   // editorid -> RecordType (same-call sibling parents)
-        var parentPlans = new List<(IMajorRecordGetter? body, string? winnerPlugin, string? sibling)?>(specs.Count);
+        var parentPlans = new List<(IMajorRecordGetter? body, string? winnerPlugin, string? sibling, IMajorRecord? patchParent)?>(specs.Count);
         for (int i = 0; i < specs.Count; i++)
         {
             var s = specs[i];
@@ -424,29 +445,38 @@ public static class WritePatchBuilder
                 if (FormKey.TryFactory(s.ParentRef, out var parentFk))
                 {
                     var w = view.ResolveWinner(parentFk);
-                    if (w is null)
+                    if (w is not null)
                     {
-                        // KNOWN GAP (nested-create Layer A): a FormKey parent is resolved against the LOAD ORDER only, not
-                        // the patch being extended — so a parent created in a PRIOR into= call isn't resolvable yet. The
-                        // one-shot path (create the parent + its children in ONE call via a same-call sibling parent)
-                        // covers the common case; the patch-carried-parent extend path is a named follow-up. Refuse LOUD
-                        // and name the workaround (Q3 — never a misleading "wrong FormID" implication).
-                        problems.Add($"{s.RecordType} '{s.EditorId}': parent {parentFk} is not present in the load order — name an existing parent, "
-                            + "or create the parent and this child in ONE call (a same-call sibling parent, by the parent's editorid)."
-                            + (extend ? " (A parent you created in a PRIOR into= call isn't resolvable as a parent yet — for now, create a topic/cell and its children together in one call.)" : ""));
+                        // An EXISTING load-order parent (a topic/cell from a master or mod): override it INTO the patch in Phase 3.
+                        var parentBody = view.GetRecord(session, w.Value.WinnerPlugin, parentFk);
+                        if (parentBody is null) { problems.Add($"{s.RecordType} '{s.EditorId}': parent {parentFk} winner '{w.Value.WinnerPlugin}' did not yield it on fetch (a load-order inconsistency)."); continue; }
+                        parentType = WriteEngine.ResolveConcreteRecordType(RecordNaming.StripOverlay(parentBody.GetType().Name));
+                        parentPlans[i] = (parentBody, w.Value.WinnerPlugin, null, null);
+                    }
+                    else if (patchMod.EnumerateMajorRecords().FirstOrDefault(r => r.FormKey == parentFk) is { } patchParent)
+                    {
+                        // A parent created in a PRIOR into= call — it lives in the patch being extended, not the load order
+                        // (the former N9 gap, now resolvable because Phase 0 opens the patch BEFORE this loop). It's already
+                        // a settable patch-local record, so Phase 3 uses it directly (no override needed).
+                        parentType = WriteEngine.ResolveConcreteRecordType(RecordNaming.StripOverlay(patchParent.GetType().Name));
+                        parentPlans[i] = (null, null, null, patchParent);
+                    }
+                    else
+                    {
+                        // Genuinely absent from BOTH the load order and the patch — the surviving loud refusal (Q3, never a
+                        // misleading "wrong FormID"). Name the one-call workaround for the common new-topic case.
+                        problems.Add($"{s.RecordType} '{s.EditorId}': parent {parentFk} is not present in the load order"
+                            + (extend ? " or this patch" : "") + " — name an existing parent, or create the parent and this "
+                            + "child in ONE call (a same-call sibling parent, by the parent's editorid).");
                         continue;
                     }
-                    var parentBody = view.GetRecord(session, w.Value.WinnerPlugin, parentFk);
-                    if (parentBody is null) { problems.Add($"{s.RecordType} '{s.EditorId}': parent {parentFk} winner '{w.Value.WinnerPlugin}' did not yield it on fetch (a load-order inconsistency)."); continue; }
-                    parentType = WriteEngine.ResolveConcreteRecordType(RecordNaming.StripOverlay(parentBody.GetType().Name));
-                    parentPlans[i] = (parentBody, w.Value.WinnerPlugin, null);
                 }
                 else   // a same-call sibling parent — must be DECLARED EARLIER in this call (topic before its lines)
                 {
                     if (s.ParentRef.Equals(s.EditorId, StringComparison.OrdinalIgnoreCase) || !declaredEdidType.TryGetValue(s.ParentRef, out var parentCatalog))
                     { problems.Add($"{s.RecordType} '{s.EditorId}': parent '{s.ParentRef}' is neither an existing FormID nor a record created EARLIER in this call — create the parent (e.g. the topic) before its children, in spec order."); continue; }
                     parentType = WriteEngine.ResolveConcreteRecordType(parentCatalog);
-                    parentPlans[i] = (null, null, s.ParentRef);
+                    parentPlans[i] = (null, null, s.ParentRef, null);
                 }
                 if (parentType is null) { problems.Add($"{s.RecordType} '{s.EditorId}': could not resolve the parent's record type."); continue; }
                 if (!WriteEngine.CanCreateNested(s.RecordType, parentType, s.IntoCollection, out var nestedWhy)) { problems.Add($"{s.RecordType} '{s.EditorId}': {nestedWhy}"); continue; }
@@ -459,23 +489,6 @@ public static class WritePatchBuilder
             return CreateOutcome.Fail(
                 $"refused — {problems.Count} problem(s) creating {specs.Count} record(s); NOTHING created:\n  - " + string.Join("\n  - ", problems));
 
-        // --- Phase 2: open (extend) or create the patch mod (same as Apply). ---
-        var fileName = Path.GetFileName(outPath);
-        SkyrimMod patchMod;
-        if (extend)
-        {
-            if (!File.Exists(outPath))
-                return CreateOutcome.Fail($"cannot extend: no existing patch at {outPath}. Omit into= to create it fresh.");
-            try { patchMod = SkyrimMod.CreateFromBinary(outPath, SkyrimRelease.SkyrimSE); }
-            catch (Exception ex) { return CreateOutcome.Fail($"cannot open patch to extend ({fileName}): {ex.GetType().Name}: {ex.Message}"); }
-        }
-        else
-        {
-            patchMod = new SkyrimMod(new ModKey(Path.GetFileNameWithoutExtension(outPath), ModType.Plugin), SkyrimRelease.SkyrimSE);
-        }
-        if (!string.Equals(patchMod.ModKey.FileName.String, fileName, StringComparison.OrdinalIgnoreCase))
-            return CreateOutcome.Fail($"patch ModKey '{patchMod.ModKey.FileName}' must match output filename '{fileName}'.");
-
         // --- Phase 3: UPSERT each record, then apply its edits. A throw here AFTER pre-flight passed is a real engine
         //     inconsistency — fail the WHOLE call (the in-memory patch is discarded; nothing serialized), surfaced not
         //     swallowed (Q3). All upserts are in-memory until the single WritePatch, so all-or-nothing holds even mid-loop.
@@ -486,9 +499,10 @@ public static class WritePatchBuilder
         //     valid. Collisions it will NOT absorb (carried overrides, duplicate residue, cross-type) refuse loud there;
         //     every replace that DOES happen is carried on CreatedRecord.ReplacedExisting and rendered to the user. ---
         //     NESTED create (a spec with a ParentRef): the parent is made settable IN the patch first — an existing
-        //     parent is overridden in (a flat parent needs no link cache; a nested parent — a Cell — gets the winner
-        //     overlay's cache, the SAME session.LinkCacheFor path Apply uses + guards), a same-call sibling parent is
-        //     the record created earlier in this loop — then WriteEngine.NestedAddNew allocates the child into the
+        //     load-order parent is overridden in (a flat parent needs no link cache; a nested parent — a Cell — gets the
+        //     winner overlay's cache, the SAME session.LinkCacheFor path Apply uses + guards), a same-call sibling parent
+        //     is the record created earlier in this loop, and a parent the patch ALREADY carries (created in a prior
+        //     into= call — Phase 0) is used directly — then WriteEngine.NestedAddNew allocates the child into the
         //     parent's modeled collection (named, or the unique one). Idempotency: nested create APPENDS (no
         //     upsert-replace) — Aaron-accepted for Layer A (2026-06-14): nested children carry no stable EditorID
         //     handle to de-dup on (unlike flat GenericUpsertNew), so a re-run into= re-adds. Watch in real use;
@@ -510,7 +524,13 @@ public static class WritePatchBuilder
                 {
                     var plan = parentPlans[i]!.Value;
                     IMajorRecord settableParent;
-                    if (plan.body is not null)
+                    if (plan.patchParent is not null)
+                    {
+                        // A parent created in a PRIOR into= call — already a settable patch-local record (Phase 0 opened
+                        // the patch); use it directly, no override.
+                        settableParent = plan.patchParent;
+                    }
+                    else if (plan.body is not null)
                     {
                         Mutagen.Bethesda.Plugins.Cache.ILinkCache? cache = null;
                         if (WriteEngine.RecordNeedsSourceCache(plan.body))

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -374,14 +374,19 @@ public static class WritePatchBuilder
 
     /// <summary>
     /// Create BRAND-NEW records (new FormIDs) in a patch — the net-new authoring capability, the sibling of
-    /// <see cref="Apply"/> (which overrides an EXISTING record). Each <see cref="CreateSpec"/> allocates a fresh record of
-    /// its (caller-declared) type via <see cref="WriteEngine.GenericAddNew"/> — a local 0x800+ ESP-range FormID, the new
-    /// plugin its own master — then drives the SAME <see cref="WriteEngine.ApplyVerb"/> path to set its fields. Unlike Apply,
-    /// the RecordType is DECLARED (there's no existing winner to derive it from). FLAT records only BY CONSTRUCTION (the
-    /// create surface = the flat-group surface); nested/placed records and abstract-group subtypes fail loud via
-    /// <see cref="WriteEngine.CanCreateType"/> (named follow-ups, Q3). <paramref name="extend"/>=false writes a fresh patch
-    /// (ModKey = filename); =true adds to an existing one (the into= path). ALL-OR-NOTHING (Q3): any pre-flight problem —
-    /// missing editorid, an un-createable type, a rejected edit — refuses the WHOLE call with no file written.
+    /// <see cref="Apply"/> (which overrides an EXISTING record). A FLAT top-level <see cref="CreateSpec"/> (no
+    /// <see cref="CreateSpec.ParentRef"/>) allocates a fresh record of its (caller-declared) type via
+    /// <see cref="WriteEngine.GenericUpsertNew"/>; a NESTED spec (a ParentRef — a dialogue line under a topic, a placed
+    /// ref into a cell) resolves its parent (an existing load-order winner, a same-call sibling by editorid, OR a record
+    /// the patch being extended already carries from a prior into= call) and allocates the child into the parent's modeled
+    /// child-collection via <see cref="WriteEngine.NestedAddNew"/> — the add-target found by construction, named via
+    /// <see cref="CreateSpec.IntoCollection"/> when more than one fits. Either way the new record gets a local 0x800+
+    /// ESP-range FormID and the SAME <see cref="WriteEngine.ApplyVerb"/> path sets its fields; RecordType is DECLARED
+    /// (no existing winner to derive it from). Still failed loud (Q3): an abstract-group subtype, and a coordinate-keyed
+    /// EXTERIOR cell (FormKey-less worldspace block parents) — via <see cref="WriteEngine.CanCreateType"/> /
+    /// <see cref="WriteEngine.CanCreateNested"/>. <paramref name="extend"/>=false writes a fresh patch (ModKey = filename);
+    /// =true adds to an existing one (the into= path). ALL-OR-NOTHING (Q3): any pre-flight problem — missing editorid, an
+    /// un-createable type, an unresolvable parent, a rejected edit — refuses the WHOLE call with no file written.
     /// </summary>
     public static CreateOutcome CreateRecords(
         LoadOrderResolver resolver, CorpusRulebook rulebook,

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -424,7 +424,18 @@ public static class WritePatchBuilder
                 if (FormKey.TryFactory(s.ParentRef, out var parentFk))
                 {
                     var w = view.ResolveWinner(parentFk);
-                    if (w is null) { problems.Add($"{s.RecordType} '{s.EditorId}': parent {parentFk} is not present in the load order — name an existing parent or create it first."); continue; }
+                    if (w is null)
+                    {
+                        // KNOWN GAP (nested-create Layer A): a FormKey parent is resolved against the LOAD ORDER only, not
+                        // the patch being extended — so a parent created in a PRIOR into= call isn't resolvable yet. The
+                        // one-shot path (create the parent + its children in ONE call via a same-call sibling parent)
+                        // covers the common case; the patch-carried-parent extend path is a named follow-up. Refuse LOUD
+                        // and name the workaround (Q3 — never a misleading "wrong FormID" implication).
+                        problems.Add($"{s.RecordType} '{s.EditorId}': parent {parentFk} is not present in the load order — name an existing parent, "
+                            + "or create the parent and this child in ONE call (a same-call sibling parent, by the parent's editorid)."
+                            + (extend ? " (A parent you created in a PRIOR into= call isn't resolvable as a parent yet — for now, create a topic/cell and its children together in one call.)" : ""));
+                        continue;
+                    }
                     var parentBody = view.GetRecord(session, w.Value.WinnerPlugin, parentFk);
                     if (parentBody is null) { problems.Add($"{s.RecordType} '{s.EditorId}': parent {parentFk} winner '{w.Value.WinnerPlugin}' did not yield it on fetch (a load-order inconsistency)."); continue; }
                     parentType = WriteEngine.ResolveConcreteRecordType(RecordNaming.StripOverlay(parentBody.GetType().Name));

--- a/src/housecarl-generator/BulkCreateGuardProbe.cs
+++ b/src/housecarl-generator/BulkCreateGuardProbe.cs
@@ -1,0 +1,166 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SELF-CONTAINED CI REGRESSION GUARD for the CREATE-TOOL WIRE (housecarl_create_record's parent/collection +
+/// the new housecarl_bulk_create batch tool, nested/dialogue plan Layer A). Where nested-create-guard pins the
+/// CORE (WritePatchBuilder.CreateRecords) against a bare resolver, this pins the SERVICE LAYER —
+/// LoadOrderService.CreateRecords (single, with parent/collection) + CreateRecordsBatch (the array) — driven over a
+/// synthetic MO2 instance in temp (the write-mutex-guard synth pattern: real ModOrganizer.ini + profile + a master
+/// mod), so the wire's NEW logic (type resolution from a string, parent/collection passthrough, per-record batch
+/// aggregation, MO2 folder-per-patch output) runs end-to-end. (The MCP argument binding above the service is generic
+/// SDK + already covered by binding-shim-guard; this drives the service methods directly, as write-mutex-guard does.)
+/// Run: dotnet run --project src/housecarl-generator -- bulk-create-guard
+///
+/// Arms (ALL required):
+///   FLAT       — a single flat Keyword create still works (the wire didn't break the existing flat path).
+///   SINGLE-PARENT — a single create with parent=<an existing master topic's FormID> nests an INFO under it
+///                (proves parent/collection passthrough through the service to the core).
+///   ONESHOT    — bulk_create of [DialogTopic, DialogResponses parent=<the topic's editorid>] in one call: both
+///                created, the INFO under the NEW topic (the same-call sibling one-shot, through the batch wire).
+///   BATCH-AON  — a batch whose 2nd spec is un-createable (a nested type with no parent) refuses the WHOLE call,
+///                naming the problem, with the valid 1st spec NOT written and no orphan folder (all-or-nothing, Q3).
+///   GUIDANCE   — a single nested create with no parent refuses loud and the message guides to parent= / bulk_create
+///                (the refreshed CanCreateType copy reaches the user).
+/// </summary>
+internal static class BulkCreateGuardProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  REGRESSION GUARD — create-tool wire (create_record parent/collection + bulk_create)  ################");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        var root = Path.Combine(Path.GetTempPath(), "hc-bulk-create-guard-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            // --- synthetic MO2 instance with ONE master mod carrying a dialogue topic (the existing-parent fixture). ---
+            string instance = Path.Combine(root, "instance");
+            string profiles = Path.Combine(instance, "profiles", "Default");
+            string mods = Path.Combine(instance, "mods");
+            string data = Path.Combine(root, "game", "Data");
+            Directory.CreateDirectory(profiles); Directory.CreateDirectory(mods); Directory.CreateDirectory(data);
+            File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+                "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+                + Path.Combine(root, "game").Replace(@"\", @"\\") + ")\r\n");
+
+            var mKey = new ModKey("HcBcGdMaster", ModType.Master);
+            var modDir = Path.Combine(mods, "MasterMod");
+            Directory.CreateDirectory(modDir);
+            FormKey topicFk;
+            {
+                var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
+                var topic = m.DialogTopics.AddNew(); topic.EditorID = "HcBcGdTopic";
+                topicFk = topic.FormKey;
+                m.BeginWrite.ToPath(Path.Combine(modDir, mKey.FileName.String)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            }
+            File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + mKey.FileName + "\r\n");
+            File.WriteAllText(Path.Combine(profiles, "plugins.txt"), "*" + mKey.FileName + "\r\n");
+            File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+MasterMod\r\n");
+
+            var genDir = Path.Combine(root, "corpus-gen");
+            CorpusGenerator.GenerateAll(genDir, Path.Combine(root, "corpus-ref"));
+            CorpusRulebook.CorpusPath = Path.Combine(genDir, "corpus.json");
+
+            var store = new UserConfigStore(Path.Combine(root, "houseCARL.user.json"));
+            using var svc = LoadOrderService.WithInstance(instance, 0, store);
+            svc.Stats();   // warm the lazy index once
+
+            // ---- FLAT: single flat Keyword create, no parent ----
+            {
+                var o = svc.CreateRecords("Keyword", "HcBcGdKw", Array.Empty<BulkOp>(), "HcBcFlat", null);
+                Check(o.Success && o.Created.Count == 1 && o.Created[0].FormKey.ID >= 0x800,
+                    $"FLAT single flat create still works — {(o.Success ? o.Created[0].FormKey.ToString() : "err=[" + o.Error + "]")}");
+            }
+
+            // ---- SINGLE-PARENT: single create_record with parent= an existing master topic ----
+            {
+                var o = svc.CreateRecords("DialogResponses", "HcBcN2Info", Array.Empty<BulkOp>(), "HcBcSingleParent", null, parent: topicFk.ToString());
+                var responses = o.Success ? TopicResponses(o.OutputPath, topicFk) : null;
+                bool under = responses is not null && o.Success && responses.Contains(o.Created[0].FormKey);
+                Check(o.Success && o.Created.Count == 1 && o.Created[0].FormKey.ID >= 0x800 && under,
+                    $"SINGLE-PARENT INFO into existing topic via parent= — {(o.Success ? (under ? "under the topic" : "NOT under topic") : "err=[" + o.Error + "]")}");
+            }
+
+            // ---- ONESHOT: bulk_create topic + its first line, parent = same-call sibling editorid ----
+            {
+                var records = new[]
+                {
+                    new CreateOp { RecordType = "DialogTopic", Editorid = "HcBcOsTopic" },
+                    new CreateOp { RecordType = "DialogResponses", Editorid = "HcBcOsL1", Parent = "HcBcOsTopic",
+                        Operations = new[] { new BulkOp { FieldPath = "Prompt", Verb = "Set", Value = "houseCARL one-shot" } } },
+                };
+                var o = svc.CreateRecordsBatch(records, "HcBcOneShot", null);
+                var responses = o.Success ? TopicResponses(o.OutputPath, "HcBcOsTopic") : null;
+                bool under = responses is not null && o.Success && o.Created.Count == 2 && responses.Contains(o.Created[1].FormKey);
+                Check(o.Success && o.Created.Count == 2 && under,
+                    $"ONESHOT bulk_create topic + line (sibling parent) — {(o.Success ? (under ? "line under the new topic" : "NOT under topic") : "err=[" + o.Error + "]")}");
+            }
+
+            // ---- BATCH-AON: a batch with one un-createable spec refuses the whole call, writes nothing ----
+            {
+                var records = new[]
+                {
+                    new CreateOp { RecordType = "Keyword", Editorid = "HcBcAonKw" },                 // valid
+                    new CreateOp { RecordType = "DialogResponses", Editorid = "HcBcAonBad" },        // nested, NO parent → un-createable
+                };
+                var o = svc.CreateRecordsBatch(records, "HcBcAon", null);
+                bool refused = !o.Success && o.Error is not null;
+                bool noFolder = !Directory.EnumerateDirectories(mods, "houseCARL - HcBcAon*").Any();
+                Check(refused && noFolder,
+                    $"BATCH-AON one bad spec refuses the whole batch, nothing written — refused={refused} noFolder={noFolder} err=[{o.Error}]");
+            }
+
+            // ---- GUIDANCE: a nested create with no parent guides to parent= / bulk_create ----
+            {
+                var o = svc.CreateRecords("DialogResponses", "HcBcNoParent", Array.Empty<BulkOp>(), "HcBcGuidance", null);
+                bool guided = !o.Success && o.Error is not null
+                    && o.Error.Contains("parent", StringComparison.OrdinalIgnoreCase)
+                    && o.Error.Contains("bulk_create", StringComparison.OrdinalIgnoreCase);
+                Check(guided, $"GUIDANCE nested-with-no-parent refused + guides to parent=/bulk_create — guided={guided} err=[{o.Error}]");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"  FAIL  guard infrastructure: {ex.GetType().Name}: {(ex.InnerException ?? ex).Message}");
+            fail++;
+        }
+        finally { try { Directory.Delete(root, recursive: true); } catch { } }
+
+        Console.WriteLine();
+        Console.WriteLine($"=== bulk-create-guard: {(fail == 0 ? "PASS" : "FAIL")} ===");
+        return fail == 0 ? 0 : 1;
+    }
+
+    static List<FormKey>? TopicResponses(string patchPath, FormKey topicFk)
+    {
+        ISkyrimModGetter? ov = null;
+        try
+        {
+            ov = SkyrimMod.CreateFromBinaryOverlay(patchPath, SkyrimRelease.SkyrimSE);
+            var t = ov.DialogTopics.FirstOrDefault(x => x.FormKey == topicFk);
+            return t?.Responses.Select(x => x.FormKey).ToList();
+        }
+        catch { return null; }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    static List<FormKey>? TopicResponses(string patchPath, string topicEditorId)
+    {
+        ISkyrimModGetter? ov = null;
+        try
+        {
+            ov = SkyrimMod.CreateFromBinaryOverlay(patchPath, SkyrimRelease.SkyrimSE);
+            var t = ov.DialogTopics.FirstOrDefault(x => x.EditorID == topicEditorId);
+            return t?.Responses.Select(x => x.FormKey).ToList();
+        }
+        catch { return null; }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+}

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -31,11 +31,10 @@ namespace HousecarlGenerator;
 ///   REJ-AMBIG (N6) — a PlacedObject into a Cell with NO collection named refuses loud naming the candidate lists
 ///                    ('more than one' + 'Persistent') — the outcome-(ii) discriminator is required, never guessed.
 ///   REJ-FWDSIB(N7) — a child whose same-call sibling parent is declared LATER refuses loud ('earlier in this call').
-///   EXTENDGAP (N9) — the patch-carried-parent gap: create a topic (call 1), then in a SECOND into= call try to add an
-///                    INFO under it by FormKey. The parent lives only in the patch, not the load order, so it refuses
-///                    LOUD and names the one-call workaround, no file mutated on the refused call.
-///                    [Unit 2 (the N9 extend-gap fix) FLIPS this arm to assert the extend now SUCCEEDS, keeping a
-///                    genuinely-absent-parent sub-check as the surviving loud refusal.]
+///   EXTEND (was N9) — a parent created in a PRIOR into= call IS now resolvable (the N9 extend-gap fix): create a topic
+///                    (call 1), then in a SECOND into= call add an INFO under it by FormKey — the INFO lands under the
+///                    patch-carried topic. A GENUINELY-absent parent (in neither the load order nor the patch) still
+///                    refuses loud, naming both.
 /// </summary>
 public static class NestedCreateGuardProbe
 {
@@ -191,38 +190,56 @@ public static class NestedCreateGuardProbe
             },
             msg => msg.Contains("earlier in this call", StringComparison.OrdinalIgnoreCase));
 
-        // ---------- EXTENDGAP (N9): patch-carried parent on a second into= call refuses loud ----------
-        bool extendGapOk = false;
+        // ---------- EXTEND (was N9): a parent created in a PRIOR into= call IS now resolvable (the N9 fix) ----------
+        bool extendOk = false;
         {
-            string pPath = Path.Combine(tmpDir, "HcNcExtendGap.esp");
-            FormKey topicFk; bool call1Ok;
+            string pPath = Path.Combine(tmpDir, "HcNcExtend.esp");
+            // call 1: a one-shot topic + its first line (so the topic ALREADY carries a child when call 2 extends it).
+            FormKey topicFk = default, l1Fk = default; bool call1Ok;
             using (var r = LoadOrderResolver.Build(new[] { mPath }))
             {
                 var o1 = WritePatchBuilder.CreateRecords(r, rulebook,
-                    new[] { new WritePatchBuilder.CreateSpec { RecordType = "DialogTopic", EditorId = "HcNcN9Topic", Edits = Array.Empty<WriteRequest>() } },
+                    new[]
+                    {
+                        new WritePatchBuilder.CreateSpec { RecordType = "DialogTopic", EditorId = "HcNcExTopic", Edits = Array.Empty<WriteRequest>() },
+                        new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcExL1", ParentRef = "HcNcExTopic", Edits = Array.Empty<WriteRequest>() },
+                    },
                     pPath, extend: false);
-                call1Ok = o1.Success;
-                topicFk = o1.Success ? o1.Created[0].FormKey : default;
+                call1Ok = o1.Success && o1.Created.Count == 2;
+                if (call1Ok) { topicFk = o1.Created[0].FormKey; l1Fk = o1.Created[1].FormKey; }
             }
-            byte[] before = call1Ok ? File.ReadAllBytes(pPath) : Array.Empty<byte>();
-            bool refused = false; string? error = null;
+            // call 2: add a SECOND line under that topic — the topic lives ONLY in the patch (the N9 case).
+            bool call2Ok = false; FormKey l2Fk = default;
             if (call1Ok)
                 using (var r = LoadOrderResolver.Build(new[] { mPath }))
                 {
                     var o2 = WritePatchBuilder.CreateRecords(r, rulebook,
-                        new[] { new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcN9Info", ParentRef = topicFk.ToString(), Edits = Array.Empty<WriteRequest>() } },
+                        new[] { new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcExL2", ParentRef = topicFk.ToString(), Edits = Array.Empty<WriteRequest>() } },
                         pPath, extend: true);
-                    refused = !o2.Success; error = o2.Error;
+                    call2Ok = o2.Success; l2Fk = o2.Success ? o2.Created[0].FormKey : default;
                 }
-            bool untouched = call1Ok && before.AsSpan().SequenceEqual(File.ReadAllBytes(pPath));
-            bool named = error is not null && error.Contains("one call", StringComparison.OrdinalIgnoreCase) && error.Contains("prior into=", StringComparison.OrdinalIgnoreCase);
-            extendGapOk = call1Ok && refused && named && untouched;
-            Console.WriteLine($"   EXTENDGAP patch-parent refused loud  : {(extendGapOk ? "PASS — refused, names the one-call workaround, file untouched" : $"FAIL — call1={call1Ok} refused={refused} named={named} untouched={untouched} err=[{error}]")}");
+            // BOTH the prior line (L1) and the new line (L2) must be under the topic — the patch-carried parent is used
+            // in full, never an override carrying only the new child (which would silently drop L1).
+            var responses = call2Ok ? TopicResponses(pPath, topicFk) : null;
+            bool under = responses is not null && responses.Contains(l1Fk) && responses.Contains(l2Fk);
+            // and a GENUINELY-absent parent (in neither the load order nor the patch) still refuses loud, naming both.
+            bool absentRefused = false; string? absentErr = null;
+            if (call1Ok)
+                using (var r = LoadOrderResolver.Build(new[] { mPath }))
+                {
+                    var o3 = WritePatchBuilder.CreateRecords(r, rulebook,
+                        new[] { new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcExGhost", ParentRef = "0F0F0F:HcNcGdMaster.esm", Edits = Array.Empty<WriteRequest>() } },
+                        pPath, extend: true);
+                    absentRefused = !o3.Success; absentErr = o3.Error;
+                }
+            bool absentNamed = absentErr is not null && absentErr.Contains("load order", StringComparison.OrdinalIgnoreCase) && absentErr.Contains("patch", StringComparison.OrdinalIgnoreCase);
+            extendOk = call1Ok && call2Ok && under && absentRefused && absentNamed;
+            Console.WriteLine($"   EXTEND patch-carried parent works    : {(extendOk ? "PASS — prior-call topic resolvable, BOTH lines under it; a truly-absent parent still refuses loud" : $"FAIL — call1={call1Ok} call2={call2Ok} under={under} absentRefused={absentRefused} absentNamed={absentNamed} absentErr=[{absentErr}]")}");
         }
 
         Console.WriteLine();
         bool pass = fixturesOk && oneshotOk && multiOk && intoTopicOk && intoCellOk
-                    && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendGapOk;
+                    && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendOk;
         Console.WriteLine($"=== nested-create-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return pass ? 0 : 1;

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -132,10 +132,12 @@ public static class NestedCreateGuardProbe
             var o = WritePatchBuilder.CreateRecords(r, rulebook, specs, pPath, extend: false);
             var responses = o.Success ? TopicResponses(pPath, "HcNcMTopic") : null;
             bool bothUnder = responses is not null && o.Success && responses.Contains(o.Created[1].FormKey) && responses.Contains(o.Created[2].FormKey);
-            string? prompt = o.Success ? InfoPrompt(pPath, o.Created[2].FormKey) : null;
-            bool editLanded = prompt == "houseCARL line two";
-            multiOk = o.Success && o.Created.Count == 3 && bothUnder && editLanded;
-            Console.WriteLine($"   MULTICHILD topic+2 INFO + field edit: {(multiOk ? $"PASS — 3 created, both under topic, L2.Prompt landed" : $"FAIL — success={o.Success} count={(o.Success ? o.Created.Count : 0)} bothUnder={bothUnder} editLanded={editLanded} prompt=[{prompt}] err=[{o.Error}]")}");
+            string? l2Prompt = o.Success ? InfoPrompt(pPath, o.Created[2].FormKey) : null;
+            string? l1Prompt = o.Success ? InfoPrompt(pPath, o.Created[1].FormKey) : null;
+            bool editLanded = l2Prompt == "houseCARL line two";
+            bool editIsolated = l1Prompt != "houseCARL line two";   // the edit landed on L2 ONLY — it did NOT leak to its sibling L1
+            multiOk = o.Success && o.Created.Count == 3 && bothUnder && editLanded && editIsolated;
+            Console.WriteLine($"   MULTICHILD topic+2 INFO + field edit: {(multiOk ? $"PASS — 3 created, both under topic, L2.Prompt landed (only on L2)" : $"FAIL — success={o.Success} count={(o.Success ? o.Created.Count : 0)} bothUnder={bothUnder} editLanded={editLanded} editIsolated={editIsolated} l2=[{l2Prompt}] l1=[{l1Prompt}] err=[{o.Error}]")}");
         }
 
         // ---------- INTOTOPIC (N2): INFO into an EXISTING (master) topic by FormKey ----------

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -1,0 +1,310 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SELF-CONTAINED CI REGRESSION GUARD for nested-record CREATE (nested/dialogue plan, Layer A), in the pattern of
+/// upsert-guard / formid-floor-guard. Drives the REAL product path (WritePatchBuilder.CreateRecords) against a
+/// SYNTHESIZED master in TEMP — NO Skyrim.esm, so it runs in CI (unlike the manual nested-create-proof, which samples
+/// fixtures from vanilla Skyrim.esm). The synthesized master carries the three fixture shapes the mechanism nests
+/// under: a Weapon (the can't-contain-a-child reject target), a DialogTopic (the unique-collection happy path), and an
+/// interior Cell (the named-collection happy path + the ambiguous-collection reject).
+/// Run: dotnet run --project src/housecarl-generator -- nested-create-guard
+///
+/// Arms (ALL required — a GREEN must mean "the contract holds", never "the scenario doesn't arise here"). They mirror
+/// the manual proof's N1-N9:
+///   ONESHOT   (N1) — topic + its first INFO created in ONE call (same-call sibling parent): both records allocated at
+///                    the local 0x800+ floor, the INFO present in the topic's Responses on disk, distinct FormKeys.
+///   MULTICHILD(N8) — topic + TWO INFOs in one call, the second carrying a field edit: all three created, both INFOs
+///                    under the topic, the edited Prompt landed on the second.
+///   INTOTOPIC (N2) — an INFO added to an EXISTING (master) topic by FormKey: the new INFO at the floor, present in
+///                    the topic override's Responses (outcome (i), the unique collection derived by type).
+///   INTOCELL  (N3) — a PlacedObject added to an EXISTING (master) cell, the collection named 'Persistent' (outcome
+///                    (ii)): the new ref at the floor, present in the cell override's Persistent list.
+///   REJ-NOPARENT(N4) — a nested type with NO parent refuses loud (the type isn't flat-createable), no file written.
+///   REJ-BADPARENT(N5)— an INFO under a Weapon refuses loud ('cannot be created under' — the containment boundary),
+///                    no file written.
+///   REJ-AMBIG (N6) — a PlacedObject into a Cell with NO collection named refuses loud naming the candidate lists
+///                    ('more than one' + 'Persistent') — the outcome-(ii) discriminator is required, never guessed.
+///   REJ-FWDSIB(N7) — a child whose same-call sibling parent is declared LATER refuses loud ('earlier in this call').
+///   EXTENDGAP (N9) — the patch-carried-parent gap: create a topic (call 1), then in a SECOND into= call try to add an
+///                    INFO under it by FormKey. The parent lives only in the patch, not the load order, so it refuses
+///                    LOUD and names the one-call workaround, no file mutated on the refused call.
+///                    [Unit 2 (the N9 extend-gap fix) FLIPS this arm to assert the extend now SUCCEEDS, keeping a
+///                    genuinely-absent-parent sub-check as the surviving loud refusal.]
+/// </summary>
+public static class NestedCreateGuardProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  REGRESSION GUARD — nested-record CREATE (nested/dialogue plan, Layer A)  ################");
+        Console.WriteLine();
+
+        var tmpDir = Path.Combine(Path.GetTempPath(), "hc-nested-create-guard");
+        if (Directory.Exists(tmpDir)) Directory.Delete(tmpDir, recursive: true);
+        Directory.CreateDirectory(tmpDir);
+
+        // --- Setup: a master carrying the three nest-under fixtures + the validator corpus.
+        //     Weapon  → the can't-contain reject (N5).  DialogTopic → the unique-collection happy path (N2).
+        //     interior Cell → the named-collection happy path (N3) + the ambiguous-collection reject (N6). ---
+        var mKey = new ModKey("HcNcGdMaster", ModType.Master);
+        string mPath = Path.Combine(tmpDir, mKey.FileName.String);
+        FormKey masterWeapFk, masterTopicFk, masterCellFk;
+        try
+        {
+            var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
+
+            var w = m.Weapons.AddNew(); w.EditorID = "HcNcGdWeap"; w.BasicStats = new WeaponBasicStats { Damage = 10 };
+            masterWeapFk = w.FormKey;
+
+            var topic = m.DialogTopics.AddNew(); topic.EditorID = "HcNcGdTopic";
+            masterTopicFk = topic.FormKey;
+
+            // An interior cell lives under a CellBlock/CellSubBlock structure (FormKey-LESS group structs); build it by
+            // hand — there's no flat AddNew for a cell. The cell itself is a normal (FormKey, release) record.
+            var cell = new Cell(m.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "HcNcGdCell" };
+            masterCellFk = cell.FormKey;
+            var subBlock = new CellSubBlock { BlockNumber = 0, GroupType = GroupTypeEnum.InteriorCellSubBlock };
+            subBlock.Cells.Add(cell);
+            var block = new CellBlock { BlockNumber = 0, GroupType = GroupTypeEnum.InteriorCellBlock };
+            block.SubBlocks.Add(subBlock);
+            m.Cells.Records.Add(block);
+
+            m.BeginWrite.ToPath(mPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"error: could not synthesize the fixture master: {ex.GetType().Name}: {(ex.InnerException ?? ex).Message}");
+            try { Directory.Delete(tmpDir, recursive: true); } catch { }
+            return 1;
+        }
+
+        // Confirm the synthesized fixtures actually round-trip + resolve (a master that doesn't carry them would make
+        // the fixture-dependent arms silently test nothing — Q3).
+        bool fixturesOk;
+        using (var r = LoadOrderResolver.Build(new[] { mPath }))
+        {
+            var view = r.Capture();
+            fixturesOk = view.ResolveWinner(masterWeapFk) is not null
+                      && view.ResolveWinner(masterTopicFk) is not null
+                      && view.ResolveWinner(masterCellFk) is not null;
+        }
+        var genDir = Path.Combine(tmpDir, "corpus-gen");
+        CorpusGenerator.GenerateAll(genDir, Path.Combine(tmpDir, "corpus-ref"));
+        var rulebook = CorpusRulebook.Load(Path.Combine(genDir, "corpus.json"));
+        Console.WriteLine($"-- setup: master {mKey.FileName} with weapon {masterWeapFk}, topic {masterTopicFk}, cell {masterCellFk}; fixtures-resolve={fixturesOk}; corpus generated --");
+        Console.WriteLine();
+
+        // ---------- ONESHOT (N1): topic + its first INFO in ONE call ----------
+        bool oneshotOk = false;
+        {
+            string pPath = Path.Combine(tmpDir, "HcNcOneShot.esp");
+            var specs = new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogTopic", EditorId = "HcNcOsTopic", Edits = Array.Empty<WriteRequest>() },
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcOsInfo", ParentRef = "HcNcOsTopic", Edits = Array.Empty<WriteRequest>() },
+            };
+            using var r = LoadOrderResolver.Build(new[] { mPath });
+            var o = WritePatchBuilder.CreateRecords(r, rulebook, specs, pPath, extend: false);
+            bool floored = o.Success && o.Created.Count == 2 && o.Created.All(c => c.FormKey.ID >= 0x800);
+            var responses = o.Success ? TopicResponses(pPath, "HcNcOsTopic") : null;
+            bool infoUnder = responses is not null && o.Success && responses.Contains(o.Created[1].FormKey);
+            bool distinct = o.Success && o.Created.Count == 2 && o.Created[0].FormKey != o.Created[1].FormKey;
+            oneshotOk = o.Success && floored && infoUnder && distinct;
+            Console.WriteLine($"   ONESHOT  topic+first INFO, one call : {(oneshotOk ? $"PASS — both >=0x800, INFO under topic ({(responses?.Count ?? 0)} response)" : $"FAIL — success={o.Success} floored={floored} infoUnder={infoUnder} distinct={distinct} err=[{o.Error}]")}");
+        }
+
+        // ---------- MULTICHILD (N8): topic + two INFOs (+ a field edit) in one call ----------
+        bool multiOk = false;
+        {
+            string pPath = Path.Combine(tmpDir, "HcNcMulti.esp");
+            var specs = new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogTopic", EditorId = "HcNcMTopic", Edits = Array.Empty<WriteRequest>() },
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcML1", ParentRef = "HcNcMTopic", Edits = Array.Empty<WriteRequest>() },
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcML2", ParentRef = "HcNcMTopic",
+                    Edits = new[] { new WriteRequest { RecordType = "DialogResponses", Path = new[] { "Prompt" }, Verb = "Set", Value = "houseCARL line two" } } },
+            };
+            using var r = LoadOrderResolver.Build(new[] { mPath });
+            var o = WritePatchBuilder.CreateRecords(r, rulebook, specs, pPath, extend: false);
+            var responses = o.Success ? TopicResponses(pPath, "HcNcMTopic") : null;
+            bool bothUnder = responses is not null && o.Success && responses.Contains(o.Created[1].FormKey) && responses.Contains(o.Created[2].FormKey);
+            string? prompt = o.Success ? InfoPrompt(pPath, o.Created[2].FormKey) : null;
+            bool editLanded = prompt == "houseCARL line two";
+            multiOk = o.Success && o.Created.Count == 3 && bothUnder && editLanded;
+            Console.WriteLine($"   MULTICHILD topic+2 INFO + field edit: {(multiOk ? $"PASS — 3 created, both under topic, L2.Prompt landed" : $"FAIL — success={o.Success} count={(o.Success ? o.Created.Count : 0)} bothUnder={bothUnder} editLanded={editLanded} prompt=[{prompt}] err=[{o.Error}]")}");
+        }
+
+        // ---------- INTOTOPIC (N2): INFO into an EXISTING (master) topic by FormKey ----------
+        bool intoTopicOk = false;
+        {
+            string pPath = Path.Combine(tmpDir, "HcNcIntoTopic.esp");
+            var spec = new[] { new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcN2Info", ParentRef = masterTopicFk.ToString(), Edits = Array.Empty<WriteRequest>() } };
+            using var r = LoadOrderResolver.Build(new[] { mPath });
+            var o = WritePatchBuilder.CreateRecords(r, rulebook, spec, pPath, extend: false);
+            bool floored = o.Success && o.Created.Count == 1 && o.Created[0].FormKey.ID >= 0x800 && o.Created[0].FormKey.ModKey.FileName.String == "HcNcIntoTopic.esp";
+            var responses = o.Success ? TopicResponses(pPath, masterTopicFk) : null;
+            bool present = responses is not null && o.Success && responses.Contains(o.Created[0].FormKey);
+            intoTopicOk = o.Success && floored && present;
+            Console.WriteLine($"   INTOTOPIC INFO into existing topic  : {(intoTopicOk ? "PASS — new INFO >=0x800/local, under the topic override" : $"FAIL — success={o.Success} floored={floored} present={present} err=[{o.Error}]")}");
+        }
+
+        // ---------- INTOCELL (N3): PlacedObject into an EXISTING cell, collection named 'Persistent' ----------
+        bool intoCellOk = false;
+        {
+            string pPath = Path.Combine(tmpDir, "HcNcIntoCell.esp");
+            var spec = new[] { new WritePatchBuilder.CreateSpec { RecordType = "PlacedObject", EditorId = "HcNcN3Ref", ParentRef = masterCellFk.ToString(), IntoCollection = "Persistent", Edits = Array.Empty<WriteRequest>() } };
+            using var r = LoadOrderResolver.Build(new[] { mPath });
+            var o = WritePatchBuilder.CreateRecords(r, rulebook, spec, pPath, extend: false);
+            bool floored = o.Success && o.Created.Count == 1 && o.Created[0].FormKey.ID >= 0x800 && o.Created[0].FormKey.ModKey.FileName.String == "HcNcIntoCell.esp";
+            var persistent = o.Success ? CellPersistent(pPath, masterCellFk) : null;
+            bool present = persistent is not null && o.Success && persistent.Contains(o.Created[0].FormKey);
+            intoCellOk = o.Success && floored && present;
+            Console.WriteLine($"   INTOCELL Placed into cell.Persistent: {(intoCellOk ? "PASS — new ref >=0x800/local, in the cell override's Persistent" : $"FAIL — success={o.Success} floored={floored} present={present} err=[{o.Error}]")}");
+        }
+
+        // ---------- REJ-NOPARENT (N4) ----------
+        bool rejNoParentOk = RejectArm("REJ-NOPARENT nested no parent     ", tmpDir, "N4", mPath, rulebook,
+            new[] { new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcN4", Edits = Array.Empty<WriteRequest>() } },
+            msg => msg.Contains("parent", StringComparison.OrdinalIgnoreCase) || msg.Contains("nested", StringComparison.OrdinalIgnoreCase));
+
+        // ---------- REJ-BADPARENT (N5): INFO under a Weapon ----------
+        bool rejBadParentOk = RejectArm("REJ-BADPARENT INFO under Weapon   ", tmpDir, "N5", mPath, rulebook,
+            new[] { new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcN5", ParentRef = masterWeapFk.ToString(), Edits = Array.Empty<WriteRequest>() } },
+            msg => msg.Contains("cannot be created under", StringComparison.OrdinalIgnoreCase));
+
+        // ---------- REJ-AMBIG (N6): Placed into a Cell with no collection named ----------
+        bool rejAmbigOk = RejectArm("REJ-AMBIG Placed, no collection    ", tmpDir, "N6", mPath, rulebook,
+            new[] { new WritePatchBuilder.CreateSpec { RecordType = "PlacedObject", EditorId = "HcNcN6", ParentRef = masterCellFk.ToString(), Edits = Array.Empty<WriteRequest>() } },
+            msg => msg.Contains("more than one", StringComparison.OrdinalIgnoreCase) && msg.Contains("Persistent", StringComparison.OrdinalIgnoreCase));
+
+        // ---------- REJ-FWDSIB (N7): sibling parent declared LATER ----------
+        bool rejFwdSibOk = RejectArm("REJ-FWDSIB forward sibling parent  ", tmpDir, "N7", mPath, rulebook,
+            new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcN7Info", ParentRef = "HcNcN7Topic", Edits = Array.Empty<WriteRequest>() },
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogTopic", EditorId = "HcNcN7Topic", Edits = Array.Empty<WriteRequest>() },
+            },
+            msg => msg.Contains("earlier in this call", StringComparison.OrdinalIgnoreCase));
+
+        // ---------- EXTENDGAP (N9): patch-carried parent on a second into= call refuses loud ----------
+        bool extendGapOk = false;
+        {
+            string pPath = Path.Combine(tmpDir, "HcNcExtendGap.esp");
+            FormKey topicFk; bool call1Ok;
+            using (var r = LoadOrderResolver.Build(new[] { mPath }))
+            {
+                var o1 = WritePatchBuilder.CreateRecords(r, rulebook,
+                    new[] { new WritePatchBuilder.CreateSpec { RecordType = "DialogTopic", EditorId = "HcNcN9Topic", Edits = Array.Empty<WriteRequest>() } },
+                    pPath, extend: false);
+                call1Ok = o1.Success;
+                topicFk = o1.Success ? o1.Created[0].FormKey : default;
+            }
+            byte[] before = call1Ok ? File.ReadAllBytes(pPath) : Array.Empty<byte>();
+            bool refused = false; string? error = null;
+            if (call1Ok)
+                using (var r = LoadOrderResolver.Build(new[] { mPath }))
+                {
+                    var o2 = WritePatchBuilder.CreateRecords(r, rulebook,
+                        new[] { new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcN9Info", ParentRef = topicFk.ToString(), Edits = Array.Empty<WriteRequest>() } },
+                        pPath, extend: true);
+                    refused = !o2.Success; error = o2.Error;
+                }
+            bool untouched = call1Ok && before.AsSpan().SequenceEqual(File.ReadAllBytes(pPath));
+            bool named = error is not null && error.Contains("one call", StringComparison.OrdinalIgnoreCase) && error.Contains("prior into=", StringComparison.OrdinalIgnoreCase);
+            extendGapOk = call1Ok && refused && named && untouched;
+            Console.WriteLine($"   EXTENDGAP patch-parent refused loud  : {(extendGapOk ? "PASS — refused, names the one-call workaround, file untouched" : $"FAIL — call1={call1Ok} refused={refused} named={named} untouched={untouched} err=[{error}]")}");
+        }
+
+        Console.WriteLine();
+        bool pass = fixturesOk && oneshotOk && multiOk && intoTopicOk && intoCellOk
+                    && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendGapOk;
+        Console.WriteLine($"=== nested-create-guard: {(pass ? "PASS" : "FAIL")} ===");
+        try { Directory.Delete(tmpDir, recursive: true); } catch { }
+        return pass ? 0 : 1;
+    }
+
+    /// <summary>Drive a create expected to REFUSE (extend=false, fresh path): assert Success=false, NO file written,
+    /// and the error matches <paramref name="msgOk"/> (the same shape as the manual proof's RejectCheck).</summary>
+    static bool RejectArm(string banner, string tmpDir, string tag, string mPath, CorpusRulebook rulebook,
+        WritePatchBuilder.CreateSpec[] specs, Func<string, bool> msgOk)
+    {
+        string pPath = Path.Combine(tmpDir, $"HcNcRej{tag}.esp");
+        bool refused; string? error;
+        using (var r = LoadOrderResolver.Build(new[] { mPath }))
+        {
+            var o = WritePatchBuilder.CreateRecords(r, rulebook, specs, pPath, extend: false);
+            refused = !o.Success; error = o.Error;
+        }
+        bool noFile = !File.Exists(pPath);
+        bool named = error is not null && msgOk(error);
+        bool ok = refused && noFile && named;
+        Console.WriteLine($"   {banner}: {(ok ? "PASS — refused by name, no file written" : $"FAIL — refused={refused} noFile={noFile} named={named} err=[{error}]")}");
+        return ok;
+    }
+
+    /// <summary>Re-open the written patch and list a new topic's (by EditorID) child INFO FormKeys.</summary>
+    static List<FormKey>? TopicResponses(string patchPath, string topicEditorId)
+    {
+        ISkyrimModGetter? ov = null;
+        try
+        {
+            ov = SkyrimMod.CreateFromBinaryOverlay(patchPath, SkyrimRelease.SkyrimSE);
+            var t = ov.DialogTopics.FirstOrDefault(x => x.EditorID == topicEditorId);
+            return t?.Responses.Select(x => x.FormKey).ToList();
+        }
+        catch { return null; }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    /// <summary>Re-open the written patch and list a topic's (by FormKey) child INFO FormKeys.</summary>
+    static List<FormKey>? TopicResponses(string patchPath, FormKey topicFk)
+    {
+        ISkyrimModGetter? ov = null;
+        try
+        {
+            ov = SkyrimMod.CreateFromBinaryOverlay(patchPath, SkyrimRelease.SkyrimSE);
+            var t = ov.DialogTopics.FirstOrDefault(x => x.FormKey == topicFk);
+            return t?.Responses.Select(x => x.FormKey).ToList();
+        }
+        catch { return null; }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    /// <summary>Re-open the written patch and read a created INFO's Prompt (the field-edit check).</summary>
+    static string? InfoPrompt(string patchPath, FormKey infoFk)
+    {
+        ISkyrimModGetter? ov = null;
+        try
+        {
+            ov = SkyrimMod.CreateFromBinaryOverlay(patchPath, SkyrimRelease.SkyrimSE);
+            foreach (var t in ov.DialogTopics)
+                foreach (var info in t.Responses)
+                    if (info.FormKey == infoFk) return info.Prompt?.String;
+            return null;
+        }
+        catch { return null; }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    /// <summary>Re-open the written patch and list a cell's (by FormKey) Persistent placed-ref FormKeys.</summary>
+    static List<FormKey>? CellPersistent(string patchPath, FormKey cellFk)
+    {
+        ISkyrimModGetter? ov = null;
+        try
+        {
+            ov = SkyrimMod.CreateFromBinaryOverlay(patchPath, SkyrimRelease.SkyrimSE);
+            foreach (var block in ov.Cells)
+                foreach (var sub in block.SubBlocks)
+                    foreach (var c in sub.Cells)
+                        if (c.FormKey == cellFk) return c.Persistent.Select(x => x.FormKey).ToList();
+            return null;
+        }
+        catch { return null; }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+}

--- a/src/housecarl-generator/NestedCreateProbe.cs
+++ b/src/housecarl-generator/NestedCreateProbe.cs
@@ -1,0 +1,416 @@
+using System.Collections;
+using System.Reflection;
+using System.Security.Cryptography;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// STEP 0 SCOUT — nested-record CREATE (throwaway recon, not a standing instrument).
+///
+/// The blocking pre-build scout the nested/dialogue plan (<c>dev/plans/NESTED_DIALOGUE_AUTHORING_PLAN_2026-06-13.md</c>
+/// §1.4 + §6 step 0) gates the whole build on. <see cref="NestedProbe"/> already proved nested OVERRIDE resolution
+/// (resolve a record's <c>IModContext</c> by FormKey → <c>GetOrAddAsOverride(patch)</c> rebuilds the parent chain).
+/// This probe answers the harder, unproven question: can houseCARL ALLOCATE a brand-new record INTO a nested parent
+/// — by construction, across the FormKey-parented families — and what does the add-target / FormID-floor / coordinate
+/// seam actually do? Fails LOUD per shape (Q3). Recon only: writes to a temp dir, touches no tracked file.
+///
+/// THE THREE QUESTIONS (plan §1.4):
+///   Q1  existence/behavior — does a nested-alloc primitive allocate a fresh child with a valid LOCAL 0x800+ FormKey,
+///       serialize, and re-open clean, ACROSS families (not just the easy one)?
+///   Q2  add-target derivability — is the collection to add into (i) derivable from the child type, (ii) chosen by a
+///       caller-supplied NAMED-collection discriminator (both stay by-construction = §4-(a)), or (iii) hand-coded
+///       per family (= §4-(b), STOP)?
+///   Q3  the coordinate-keyed parent — does Mutagen auto-sort an exterior cell into the right WorldspaceBlock/SubBlock
+///       from <c>Cell.Grid</c>, or must houseCARL compute the 32/8 block math? (Characterize; this is the separate
+///       §4-(b) seam, NOT to be folded into the generic Layer-A claim.)
+///
+/// TWO CANDIDATE PRIMITIVES (the plan names DuplicateIntoAsNewRecord prime; recon showed it duplicates into the
+/// SOURCE record's own parent, so it can't, alone, build the PRIMARY dialogue case — a NEW topic with no INFO to
+/// clone). So both are tested:
+///   P1  IModContext.DuplicateIntoAsNewRecord(patch, editorID) — clone an EXISTING child as a fresh record (sibling-add).
+///   P2  construct a child with a patch-allocated FormKey + Add it into the parent's modeled collection (first-child /
+///       new-parent — the actual dialogue entry shape). The by-construction one if the collection is reflectable.
+///
+/// Run: <c>dotnet run --project src/housecarl-generator nested-create-probe [sourcePlugin]</c>
+/// </summary>
+public static class NestedCreateProbe
+{
+    const string DefaultSource =
+        @"E:\Skyrim Modding\ARR 2.0\Stock Game\Data\Skyrim.esm";
+
+    public static int RunProbe(string[] args)
+    {
+        var src = args.Length > 0 && !args[0].StartsWith("--") ? args[0] : DefaultSource;
+        var asm = typeof(IArmorGetter).Assembly;
+
+        Console.WriteLine("################  STEP 0 SCOUT — nested-record CREATE  ################");
+        Console.WriteLine($"source: {src}");
+        Console.WriteLine();
+        if (!File.Exists(src)) { Console.Error.WriteLine($"error: source plugin not found: {src}"); return 1; }
+
+        var shaBefore = Sha(src);
+        var sourceMod = SkyrimMod.CreateFromBinaryOverlay(src, SkyrimRelease.SkyrimSE);
+        var cache = sourceMod.ToImmutableLinkCache();
+
+        var outDir = Path.Combine(Path.GetTempPath(), "hc-nested-create-probe");
+        if (Directory.Exists(outDir)) Directory.Delete(outDir, recursive: true);
+        Directory.CreateDirectory(outDir);
+
+        // Q-verdict accumulators.
+        bool q1ok = true, q2ok = true;
+        var addTarget = new List<(string family, string parent, int matchingColls, string verdict)>();
+
+        // The by-FormKey context resolver off the LIVE cache (re-resolved closed-generic, per NestedProbe §A.3).
+        var resolveCtx = cache.GetType().GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(m => m.Name == "ResolveContext" && m.IsGenericMethodDefinition
+                && m.GetGenericArguments().Length == 2 && m.GetParameters().Length >= 1
+                && m.GetParameters()[0].ParameterType == typeof(FormKey));
+        if (resolveCtx is null) { Console.Error.WriteLine("!! no ResolveContext<T,TG>(FormKey,...) on the live cache — surface, do not guess."); return 1; }
+
+        // ============================================================ PHASE A : API discovery (reflection) ============================================================
+        Console.WriteLine("===== PHASE A : nested-alloc API surface (pinned Mutagen 0.53.1) =====");
+        var ctxIface = asm.GetType("Mutagen.Bethesda.Plugins.Records.IModContext`4")
+            ?? AppDomain.CurrentDomain.GetAssemblies().SelectMany(SafeTypes)
+                 .FirstOrDefault(t => t.IsInterface && t.Name == "IModContext`4");
+        Console.WriteLine("-- IModContext<TMod,TModGetter,TTarget,TTargetGetter> alloc members --");
+        foreach (var m in (ctxIface?.GetMethods() ?? Array.Empty<MethodInfo>())
+                     .Where(m => m.Name is "GetOrAddAsOverride" or "DuplicateIntoAsNewRecord"))
+            Console.WriteLine($"     {Sig(m)}");
+        // The mod-level FormKey allocator (what a direct-construct child must draw from).
+        Console.WriteLine("-- IMod FormKey allocator --");
+        foreach (var m in sourceMod.GetType().GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                     .Where(m => m.Name == "GetNextFormKey"))
+            Console.WriteLine($"     {Sig(m)}");
+        Console.WriteLine();
+
+        // ============================================================ PHASE E : FormID floor (do both primitives respect 0x800?) ============================================================
+        Console.WriteLine("===== PHASE E : FormID floor — fresh-mod allocator start + the 0x800 floor =====");
+        {
+            var fresh = new SkyrimMod(new ModKey("hc_floor", ModType.Plugin), SkyrimRelease.SkyrimSE);
+            uint before = fresh.ModHeader.Stats.NextFormID;
+            var preFloorKey = TryGetNextFormKey(fresh, null);
+            WriteEngine.EnsureFormIdFloor(fresh);
+            uint after = fresh.ModHeader.Stats.NextFormID;
+            var postFloorKey = TryGetNextFormKey(fresh, "HC_floor_edid");
+            Console.WriteLine($"   fresh NextFormID (header default)        = 0x{before:X}");
+            Console.WriteLine($"   GetNextFormKey() BEFORE EnsureFormIdFloor = {Show(preFloorKey)}  {(preFloorKey is { } a && a.ID < 0x800 ? "<< below 0x800 (engine-reserved) — build MUST floor first" : "")}");
+            Console.WriteLine($"   NextFormID AFTER EnsureFormIdFloor       = 0x{after:X}");
+            Console.WriteLine($"   GetNextFormKey() AFTER EnsureFormIdFloor  = {Show(postFloorKey)}  {(postFloorKey is { } b && b.ID >= 0x800 ? "OK >= 0x800" : "!! still below floor")}");
+            Console.WriteLine("   => the nested-create front-end must call EnsureFormIdFloor before allocating, exactly like flat GenericAddNew (HCBR-2026-06-09-04 class).");
+        }
+        Console.WriteLine();
+
+        // ============================================================ PHASE B : P1 — DuplicateIntoAsNewRecord (clone-a-sibling) across families ============================================================
+        Console.WriteLine("===== PHASE B : P1 = DuplicateIntoAsNewRecord (clone an existing child as a fresh record) =====");
+        // One sample child per FormKey-parented family present in vanilla (from the nested-probe inventory).
+        var families = new (string name, FormKey sample)[]
+        {
+            ("DialogResponses", FormKey.Factory("000E3D:Skyrim.esm")),
+            ("PlacedObject",    FormKey.Factory("0EBEBF:Skyrim.esm")),
+            ("PlacedNpc",       FormKey.Factory("029D87:Skyrim.esm")),
+            ("PlacedHazard",    FormKey.Factory("0F49AE:Skyrim.esm")),
+            ("PlacedTrap",      FormKey.Factory("103997:Skyrim.esm")),
+            ("NavigationMesh",  FormKey.Factory("09CB6A:Skyrim.esm")),
+            ("Landscape",       FormKey.Factory("00A0E3:Skyrim.esm")),
+        };
+        foreach (var (name, sample) in families)
+        {
+            try
+            {
+                var getterIface = asm.GetType("Mutagen.Bethesda.Skyrim.I" + name + "Getter")!;
+                var setterIface = asm.GetType("Mutagen.Bethesda.Skyrim.I" + name)!;
+                var ctx = resolveCtx.MakeGenericMethod(setterIface, getterIface).Invoke(cache, BuildResolveArgs(resolveCtx, sample));
+                if (ctx is null) { Console.WriteLine($"[FAIL] {name,-16} — ResolveContext null."); q1ok = false; continue; }
+
+                var srcRec = (IMajorRecordGetter)ctx.GetType().GetProperty("Record")!.GetValue(ctx)!;
+                var parentDesc = DescribeParent(ctx.GetType().GetProperty("Parent")?.GetValue(ctx));
+
+                var patch = new SkyrimMod(new ModKey("hc_dup_" + name, ModType.Plugin), SkyrimRelease.SkyrimSE);
+                // NOT pre-flooring here on purpose — observe whether Duplicate respects 0x800 on a fresh patch.
+                var dup = ctx.GetType().GetMethods(BindingFlags.Public | BindingFlags.Instance).FirstOrDefault(m =>
+                    m.Name == "DuplicateIntoAsNewRecord" && m.GetParameters().Length == 2
+                    && m.GetParameters()[0].ParameterType.IsInstanceOfType(patch)
+                    && m.GetParameters()[1].ParameterType == typeof(string));
+                if (dup is null) { Console.WriteLine($"[FAIL] {name,-16} — no DuplicateIntoAsNewRecord(mod, string)."); q1ok = false; continue; }
+
+                var newRec = (IMajorRecordGetter)dup.Invoke(ctx, new object[] { patch, "HC_S0_DUP_" + name })!;
+                var newFk = newRec.FormKey;
+                var settable = setterIface.IsInstanceOfType(newRec);
+                var isNew = newFk != srcRec.FormKey;
+                var local = newFk.ModKey == patch.ModKey;
+                var floored = newFk.ID >= 0x800;
+
+                var outPath = Path.Combine(outDir, patch.ModKey.FileName);
+                WriteEngine.WritePatch(patch, sourceMod, outPath);
+                using var back = SkyrimMod.CreateFromBinaryOverlay(outPath, SkyrimRelease.SkyrimSE);
+                var all = back.EnumerateMajorRecords().ToList();
+                var present = all.Any(r => r.FormKey == newFk);
+                var masters = back.ModHeader.MasterReferences.Select(m => m.Master.FileName.ToString()).ToList();
+                var carried = string.Join("+", all.Select(r => RecordNaming.StripOverlay(r.GetType().Name)).Distinct().OrderBy(s => s));
+
+                var ok = settable && isNew && local && floored && present;
+                if (!ok) q1ok = false;
+                Console.WriteLine($"[{(ok ? "PASS" : "FAIL")}] {name,-16} new={newFk} (src {srcRec.FormKey})  parent={parentDesc}");
+                Console.WriteLine($"         settable={settable} fresh-fk={isNew} local={local} >=0x800={floored} reopened-present={present} | patch-records={all.Count} ({carried}) masters=[{string.Join(",", masters)}]");
+            }
+            catch (Exception ex)
+            {
+                var inner = ex.InnerException is { } ie ? $" / {ie.GetType().Name}: {ie.Message}" : "";
+                Console.WriteLine($"[FAIL] {name,-16} — {ex.GetType().Name}: {ex.Message}{inner}");
+                q1ok = false;
+            }
+        }
+        Console.WriteLine("   note: P1 duplicates into the SOURCE child's OWN parent — it adds a SIBLING, it cannot target an arbitrary/empty parent. (Phase C covers that.)");
+        Console.WriteLine();
+
+        // ============================================================ PHASE C : P2 — construct + Add into the parent's modeled collection (the new-parent case) ============================================================
+        Console.WriteLine("===== PHASE C : P2 = construct child w/ patch FormKey + Add into the parent's collection =====");
+
+        // C1 — INFO under a BRAND-NEW topic (the primary dialogue case: no sibling to clone). DialogTopic is FLAT
+        // (SkyrimGroup<DialogTopic>) so the topic is created by the proven flat path; the INFO is the net-new seam.
+        try
+        {
+            var patch = new SkyrimMod(new ModKey("hc_newtopic", ModType.Plugin), SkyrimRelease.SkyrimSE);
+            var topic = WriteEngine.GenericAddNew(patch, "DialogTopic", "HC_S0_NewTopic");   // floors the counter
+            var topicFk = topic.FormKey;
+            var childType = asm.GetType("Mutagen.Bethesda.Skyrim.DialogResponses")!;
+            var (coll, matching, names) = FindChildCollections(topic, childType);
+            addTarget.Add(("DialogResponses", "DialogTopic", matching, (matching == 1 ? "(i) derivable by type" : matching > 1 ? "(ii) named discriminator" : "(iii) NONE — hand-coded") + " [" + string.Join("/", names) + "]"));
+            if (coll is null) { Console.WriteLine("[FAIL] INFO/new-topic — no settable collection on DialogTopic accepts DialogResponses."); q2ok = false; }
+            else
+            {
+                WriteEngine.EnsureFormIdFloor(patch);
+                var infoFk = TryGetNextFormKey(patch, "HC_S0_Info1") ?? throw new InvalidOperationException("GetNextFormKey unavailable");
+                var info = ConstructRecord(childType, infoFk);
+                coll.Add(info);
+
+                var outPath = Path.Combine(outDir, patch.ModKey.FileName);
+                WriteEngine.WritePatch(patch, sourceMod, outPath);
+                using var back = SkyrimMod.CreateFromBinaryOverlay(outPath, SkyrimRelease.SkyrimSE);
+                var reTopic = back.DialogTopics.FirstOrDefault(t => t.EditorID == "HC_S0_NewTopic");
+                var responses = reTopic is null ? null : ChildCollectionValue(reTopic, childType);
+                var infoPresent = responses is not null && responses.Cast<object>().Any(r => ((IMajorRecordGetter)r).FormKey == infoFk);
+                var infoFloored = infoFk.ID >= 0x800 && infoFk.ModKey == patch.ModKey;
+                var topicFloored = topicFk.ID >= 0x800;
+                var ok = reTopic is not null && infoPresent && infoFloored && topicFloored;
+                if (!ok) q2ok = false;
+                Console.WriteLine($"[{(ok ? "PASS" : "FAIL")}] INFO under NEW topic   topic={topicFk} info={infoFk}");
+                Console.WriteLine($"         topic>=0x800={topicFloored} info>=0x800/local={infoFloored} topic-reopened={reTopic is not null} info-under-topic={infoPresent} | Responses-collections-matching={matching}");
+            }
+        }
+        catch (Exception ex) { Console.WriteLine($"[FAIL] INFO/new-topic — {ex.GetType().Name}: {(ex.InnerException ?? ex).Message}"); q2ok = false; }
+
+        // C2 — Placed into an EXISTING (overridden) cell, choosing the collection BY NAME (outcome ii: a Cell has 3
+        // placed lists, so the child type alone cannot pick — the caller names Persistent/Temporary/VisibleWhenDistant).
+        try
+        {
+            var patch = new SkyrimMod(new ModKey("hc_placed_in_cell", ModType.Plugin), SkyrimRelease.SkyrimSE);
+            var cellGetter = sourceMod.EnumerateMajorRecords<ICellGetter>().First(c => c.Persistent.Count > 0 || c.Temporary.Count > 0);
+            var cell = (IMajorRecord)WriteEngine.GenericGetOrAddAsOverride(patch, cellGetter, cache);   // override the parent cell into the patch
+            var childType = asm.GetType("Mutagen.Bethesda.Skyrim.PlacedObject")!;
+            var (coll, matching, names) = FindChildCollections(cell, childType, preferName: "Persistent");
+            addTarget.Add(("PlacedObject", "Cell", matching, (matching == 1 ? "(i) derivable by type" : matching > 1 ? "(ii) named discriminator" : "(iii) NONE — hand-coded") + " [" + string.Join("/", names) + "]"));
+            if (coll is null) { Console.WriteLine("[FAIL] Placed/cell — no settable collection on Cell accepts PlacedObject."); q2ok = false; }
+            else
+            {
+                WriteEngine.EnsureFormIdFloor(patch);
+                var refFk = TryGetNextFormKey(patch, "HC_S0_Ref1") ?? throw new InvalidOperationException("GetNextFormKey unavailable");
+                var placed = ConstructRecord(childType, refFk);
+                coll.Add(placed);
+
+                var outPath = Path.Combine(outDir, patch.ModKey.FileName);
+                WriteEngine.WritePatch(patch, sourceMod, outPath);
+                using var back = SkyrimMod.CreateFromBinaryOverlay(outPath, SkyrimRelease.SkyrimSE);
+                var present = back.EnumerateMajorRecords().Any(r => r.FormKey == refFk);
+                var floored = refFk.ID >= 0x800 && refFk.ModKey == patch.ModKey;
+                var ok = present && floored;
+                if (!ok) q2ok = false;
+                Console.WriteLine($"[{(ok ? "PASS" : "FAIL")}] Placed into cell {cellGetter.FormKey}  newRef={refFk}  collection=Persistent (chosen by name; matching-lists={matching})");
+                Console.WriteLine($"         ref>=0x800/local={floored} reopened-present={present}");
+            }
+        }
+        catch (Exception ex) { Console.WriteLine($"[FAIL] Placed/cell — {ex.GetType().Name}: {(ex.InnerException ?? ex).Message}"); q2ok = false; }
+        Console.WriteLine();
+
+        // ============================================================ PHASE D : Q3 — the coordinate-keyed seam (characterize, don't solve) ============================================================
+        Console.WriteLine("===== PHASE D : Q3 = coordinate-keyed parents (exterior Cell / Placed-into-new-cell) — characterize the §4-(b) seam =====");
+        try
+        {
+            // The structural parents of an exterior cell: Worldspace -> WorldspaceBlock -> WorldspaceSubBlock -> Cell.
+            // Report whether those parents are FormKey-LESS structs (so the FormKey locator can't address them) and
+            // whether Cell carries a Grid the placement math would key on.
+            var wsType = asm.GetType("Mutagen.Bethesda.Skyrim.Worldspace")!;
+            var blockProp = wsType.GetProperties().FirstOrDefault(p => p.Name is "SubCells" or "Blocks");
+            var blockElem = blockProp is null ? null : ElementType(blockProp.PropertyType);
+            var blockIsRecord = blockElem is not null && typeof(IMajorRecordGetter).IsAssignableFrom(blockElem);
+            Console.WriteLine($"   Worldspace child-collection: {blockProp?.Name ?? "(none found)"} -> element {blockElem?.Name ?? "?"}  (IMajorRecord? {blockIsRecord})");
+            if (blockElem is not null)
+            {
+                var subProp = blockElem.GetProperties().FirstOrDefault(p => p.Name is "Items" or "SubBlocks" or "Block");
+                var subElem = subProp is null ? null : ElementType(subProp.PropertyType);
+                Console.WriteLine($"     {blockElem.Name}.{subProp?.Name ?? "(?)"} -> element {subElem?.Name ?? "?"}  (FormKey-less struct? {(subElem is not null && !typeof(IMajorRecordGetter).IsAssignableFrom(subElem))})");
+                var blockNum = blockElem.GetProperties().FirstOrDefault(p => p.Name is "BlockNumberX" or "BlockNumberY" or "BlockNumber");
+                Console.WriteLine($"     block carries a numeric coordinate key: {(blockNum is not null ? blockNum.Name + " (placement is index math from Cell.Grid, not a FormKey lookup)" : "no explicit block-number prop found by simple name")}");
+            }
+            var cellType = asm.GetType("Mutagen.Bethesda.Skyrim.Cell")!;
+            var gridProp = cellType.GetProperties().FirstOrDefault(p => p.Name == "Grid");
+            Console.WriteLine($"   Cell.Grid present: {gridProp is not null} (type {gridProp?.PropertyType.Name})  — the X/Y a 32-cell-block / 8-cell-subblock division would compute from.");
+            Console.WriteLine("   VERDICT Q3: exterior-cell create + Placed-into-not-yet-present-cell sit under FormKey-LESS struct parents (WorldspaceBlock/SubBlock)");
+            Console.WriteLine("              and need derived block arithmetic outside the FormKey-locator mechanism — a SEPARATE §4-(b) decision, NOT in this build.");
+        }
+        catch (Exception ex) { Console.WriteLine($"   (could not fully characterize: {ex.GetType().Name}: {ex.Message})"); }
+        Console.WriteLine();
+
+        // ============================================================ VERDICT ============================================================
+        var sourceUnchanged = shaBefore == Sha(src);
+        Console.WriteLine("===== ADD-TARGET CLASSIFICATION (Q2) =====");
+        foreach (var (family, parent, n, v) in addTarget)
+            Console.WriteLine($"   {family,-16} under {parent,-12} matching-collections={n} -> {v}");
+        Console.WriteLine();
+        Console.WriteLine("===== STEP 0 VERDICT =====");
+        Console.WriteLine($"   Q1 (alloc + serialize + reopen, across families)  : {(q1ok ? "HOLDS — P1 clone-a-sibling is generic across the present families" : "!! a family FAILED — read the [FAIL] lines")}");
+        Console.WriteLine($"   Q2 (add-target by construction)                   : {(q2ok ? "HOLDS — P2 construct+Add works; collection is (i)/(ii) reflectable, never hand-coded" : "!! see the [FAIL] lines")}");
+        Console.WriteLine($"   Q3 (coordinate-keyed cells)                       : SEPARATE §4-(b) seam (FormKey-less struct parents + block math) — characterized above, NOT built here");
+        Console.WriteLine($"   source byte-unchanged                             : {(sourceUnchanged ? "YES" : "!! NO — CHANGED")}");
+        Console.WriteLine();
+        var pass = q1ok && q2ok && sourceUnchanged;
+        Console.WriteLine(pass
+            ? "=== STEP 0 PASS: a GENERIC nested-create mechanism holds for the FormKey-parented families (P1 sibling-add + P2 first-child); add-target is (i)/(ii) by construction; the coordinate-keyed seam is a named separate decision. STOP for Aaron's go. ==="
+            : "=== STEP 0: read the [FAIL] lines above — a generic mechanism did NOT hold for some shape. Per §1.4: STOP and surface to Aaron as §4-(b)/(c), never a per-type shim. ===");
+        return pass ? 0 : 1;
+    }
+
+    // ---- the parent's child-collection finder (the by-construction Q2 test) ----
+
+    /// <summary>Find every SETTABLE list property on <paramref name="parent"/> whose element type the child
+    /// <paramref name="childConcrete"/> satisfies, and return (the chosen IList to Add into, how many such lists exist).
+    /// One match → outcome (i) derivable-by-type; &gt;1 → outcome (ii) the caller must NAME which (preferName picks it);
+    /// zero → outcome (iii). Reflection only — so "which collection" is a uniform reflectable question, not per-type code.</summary>
+    static (IList? coll, int matching, List<string> names) FindChildCollections(object parent, Type childConcrete, string? preferName = null)
+    {
+        var hits = new List<(string name, IList list)>();
+        foreach (var p in parent.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            var elem = ElementType(p.PropertyType);
+            if (elem is null) continue;
+            if (!elem.IsAssignableFrom(childConcrete)) continue;        // the child fits this list's element type
+            if (p.GetValue(parent) is IList list) hits.Add((p.Name, list));
+        }
+        var names = hits.Select(h => h.name).ToList();
+        if (hits.Count == 0) return (null, 0, names);
+        var chosen = preferName is not null ? hits.FirstOrDefault(h => h.name == preferName).list ?? hits[0].list : hits[0].list;
+        return (chosen, hits.Count, names);
+    }
+
+    /// <summary>Read back the child collection value on a re-opened (getter) parent, to confirm the child landed.</summary>
+    static IEnumerable? ChildCollectionValue(object parent, Type childConcrete)
+    {
+        var childGetter = childConcrete.GetInterface("I" + childConcrete.Name + "Getter");
+        foreach (var p in parent.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            var elem = ElementType(p.PropertyType);
+            if (elem is null) continue;
+            if (childGetter is not null && elem.IsAssignableFrom(childGetter) && p.GetValue(parent) is IEnumerable e) return e;
+        }
+        return null;
+    }
+
+    /// <summary>The element type of an IList&lt;T&gt;/ExtendedList&lt;T&gt;-shaped property (else null for scalars).</summary>
+    static Type? ElementType(Type t)
+    {
+        if (t == typeof(string) || !typeof(IEnumerable).IsAssignableFrom(t)) return null;
+        if (t.IsGenericType)
+        {
+            var ga = t.GetGenericArguments();
+            if (ga.Length == 1) return ga[0];
+        }
+        var ifaceList = t.GetInterfaces().FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IList<>));
+        return ifaceList?.GetGenericArguments()[0];
+    }
+
+    /// <summary>Construct a concrete Mutagen record via its (FormKey, SkyrimRelease) ctor — the same shape the engine
+    /// would build a net-new nested child with. Discovered reflectively (Q3-style: don't assume the ctor shape).</summary>
+    static IMajorRecord ConstructRecord(Type concrete, FormKey fk)
+    {
+        var ctor = concrete.GetConstructors()
+            .FirstOrDefault(c => c.GetParameters().Length == 2 && c.GetParameters()[0].ParameterType == typeof(FormKey)
+                && c.GetParameters()[1].ParameterType.IsEnum);
+        if (ctor is null)
+            throw new InvalidOperationException($"no (FormKey, <release-enum>) constructor on {concrete.Name} — surface, do not guess.");
+        var releaseType = ctor.GetParameters()[1].ParameterType;
+        var release = Enum.Parse(releaseType, "SkyrimSE");
+        return (IMajorRecord)ctor.Invoke(new object[] { fk, release });
+    }
+
+    /// <summary>Reflectively call <c>IMod.GetNextFormKey()</c> / <c>GetNextFormKey(string)</c> — measure, don't assume.</summary>
+    static FormKey? TryGetNextFormKey(object mod, string? editorId)
+    {
+        var m = mod.GetType().GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .Where(x => x.Name == "GetNextFormKey")
+            .OrderBy(x => x.GetParameters().Length)
+            .FirstOrDefault(x => editorId is null ? x.GetParameters().Length == 0
+                : x.GetParameters().Length == 1 && x.GetParameters()[0].ParameterType == typeof(string));
+        if (m is null) return null;
+        return (FormKey)m.Invoke(mod, editorId is null ? null : new object[] { editorId })!;
+    }
+
+    // -- diagnostic helpers (local copies — the probe touches no shared file) --
+
+    static string Show(FormKey? fk) => fk is { } f ? $"{f} (id=0x{f.ID:X6})" : "(null)";
+
+    static string DescribeParent(object? parent)
+    {
+        if (parent is null) return "(none)";
+        var rec = parent.GetType().GetProperty("Record")?.GetValue(parent) as IMajorRecordGetter;
+        var inner = DescribeParent(parent.GetType().GetProperty("Parent")?.GetValue(parent));
+        var here = rec is null ? parent.GetType().Name : $"{RecordNaming.StripOverlay(rec.GetType().Name)}:{rec.FormKey.ID:X6}";
+        return inner == "(none)" ? here : $"{here}<-{inner}";
+    }
+
+    static object?[] BuildResolveArgs(MethodInfo m, FormKey fk)
+    {
+        var ps = m.GetParameters();
+        var argv = new object?[ps.Length];
+        argv[0] = fk;
+        for (int i = 1; i < ps.Length; i++)
+            argv[i] = ps[i].HasDefaultValue ? ps[i].DefaultValue
+                : ps[i].ParameterType.IsValueType ? System.Activator.CreateInstance(ps[i].ParameterType) : null;
+        return argv;
+    }
+
+    static string Sha(string path)
+    {
+        using var sha = SHA256.Create();
+        using var stream = File.OpenRead(path);
+        return Convert.ToHexString(sha.ComputeHash(stream));
+    }
+
+    static IEnumerable<Type> SafeTypes(Assembly a)
+    {
+        try { return a.GetTypes(); }
+        catch (ReflectionTypeLoadException ex) { return ex.Types.Where(t => t is not null)!; }
+    }
+
+    static string Sig(MethodInfo m)
+    {
+        var gen = m.IsGenericMethodDefinition ? "<" + string.Join(",", m.GetGenericArguments().Select(g => g.Name)) + ">" : "";
+        var ps = string.Join(", ", m.GetParameters().Select(p => $"{Pretty(p.ParameterType)} {p.Name}"));
+        return $"{m.Name}{gen}({ps}) -> {Pretty(m.ReturnType)}";
+    }
+
+    static string Pretty(Type t)
+    {
+        if (t.IsByRef) return Pretty(t.GetElementType()!) + "&";
+        if (t.IsGenericType)
+        {
+            var name = t.Name; var tick = name.IndexOf('`');
+            if (tick > 0) name = name[..tick];
+            return $"{name}<{string.Join(", ", t.GetGenericArguments().Select(Pretty))}>";
+        }
+        return t.Name;
+    }
+}

--- a/src/housecarl-generator/NestedCreateProof.cs
+++ b/src/housecarl-generator/NestedCreateProof.cs
@@ -158,11 +158,11 @@ public static class NestedCreateProof
                 $"created={(o.Success ? o.Created.Count : 0)} both-under-topic={YN(bothUnder)} L2.Prompt=\"{prompt}\" field-landed={YN(fieldLanded)} distinct-ids={YN(distinct)}{Err(o)}"));
         }
 
-        // ===================== N9 — KNOWN GAP: extend= with a parent CARRIED BY THE PATCH (not the load order) =====================
-        //   Create a topic (call 1), then add an INFO under it in a separate into= call (call 2). The parent topic
-        //   lives in the PATCH, not the load order — and nested parent resolution checks the load-order winner only,
-        //   so this is REFUSED. Asserts the gap is communicated LOUD + names the one-call workaround (Q3), NOT that
-        //   the capability works. The capability (resolve a patch-carried parent on extend) is a named follow-up.
+        // ===================== N9 — extend= with a parent CARRIED BY THE PATCH (the former gap, now SUPPORTED) =====================
+        //   Create a topic (call 1), then add an INFO under it in a SEPARATE into= call (call 2). The parent topic lives
+        //   in the PATCH, not the load order — resolved from the patch being extended (Phase 0 opens the patch before
+        //   pre-flight). Asserts the INFO lands under the patch-carried topic; and a GENUINELY-absent parent (in neither
+        //   the load order nor the patch) still refuses LOUD, naming both (Q3).
         {
             var outPath = Path.Combine(outDir, "houseCARL_NestedCreate_N9.esp");
             var s1 = WritePatchBuilder.CreateRecords(resolver, rulebook,
@@ -172,10 +172,17 @@ public static class NestedCreateProof
             var s2 = WritePatchBuilder.CreateRecords(resolver, rulebook,
                 new[] { new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HC_N9_Info", ParentRef = topicFk2.ToString(), Edits = Array.Empty<WriteRequest>() } },
                 outPath, extend: true);
-            bool refusedLoud = s1.Success && !s2.Success && (s2.Error ?? "").Contains("one call", StringComparison.OrdinalIgnoreCase)
-                && (s2.Error ?? "").Contains("prior into=", StringComparison.OrdinalIgnoreCase);
-            results.Add(("N9 extend+patch-parent (KNOWN GAP: refuses loud)", refusedLoud,
-                $"call1-ok={YN(s1.Success)} call2-refused-loud+named={YN(refusedLoud)}{Err(s2)}"));
+            var responses = s2.Success ? TopicResponses(outPath, topicFk2) : null;
+            bool infoUnder = s2.Success && responses is not null && responses.Contains(s2.Created[0].FormKey);
+            // a parent in a non-existent plugin is absent from BOTH the load order and the patch — the surviving refusal.
+            var s3 = WritePatchBuilder.CreateRecords(resolver, rulebook,
+                new[] { new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HC_N9_Ghost", ParentRef = "ABCDEF:HC_GhostPlugin.esp", Edits = Array.Empty<WriteRequest>() } },
+                outPath, extend: true);
+            bool ghostRefused = !s3.Success && (s3.Error ?? "").Contains("load order", StringComparison.OrdinalIgnoreCase)
+                && (s3.Error ?? "").Contains("patch", StringComparison.OrdinalIgnoreCase);
+            bool ok = s1.Success && s2.Success && infoUnder && ghostRefused;
+            results.Add(("N9 extend+patch-carried parent (now works; absent still refuses)", ok,
+                $"call1-ok={YN(s1.Success)} call2-ok={YN(s2.Success)} info-under-topic={YN(infoUnder)} absent-refused-loud={YN(ghostRefused)}{Err(s2)}"));
         }
 
         // ===================== N4 — REJECT nested with no parent =====================

--- a/src/housecarl-generator/NestedCreateProof.cs
+++ b/src/housecarl-generator/NestedCreateProof.cs
@@ -166,13 +166,13 @@ public static class NestedCreateProof
             Console.WriteLine($"  [{(pass ? "PASS" : "FAIL")}] {name,-34} {detail}");
         Console.WriteLine($"  [{(srcOk ? "PASS" : "FAIL")}] {"Skyrim.esm byte-untouched",-34}");
         Console.WriteLine();
-        Console.WriteLine("OPEN QUESTION (Layer-B / domain — surfaced, NOT guessed, evidence-first §4):");
+        Console.WriteLine("NOTE — the surgical-override model (resolved via mutagen-reference, not guessed):");
         Console.WriteLine($"  Adding a child to an EXISTING parent overrides that parent carrying ONLY the new child");
         Console.WriteLine($"  (N2 topic override = {n2OverrideCount} response of {origResponses + 1}; N3 cell override = {n3OverrideCount} persistent of {origPersistent + 1}).");
-        Console.WriteLine($"  This is CORRECT iff Skyrim merges a parent's children across plugins by record (the 28 cell refs /");
-        Console.WriteLine($"  the original topic line still load from Skyrim.esm). If the engine instead REPLACES the child list,");
-        Console.WriteLine($"  the override silently drops the siblings — then the build must deep-copy existing children first.");
-        Console.WriteLine($"  The NEW-parent one-shot (N1) has NO existing siblings, so it is unaffected + complete either way.");
+        Console.WriteLine($"  This is CORRECT, not lossy: INFOs and placed refs are FULL records (own FormKeys; INFO carries a");
+        Console.WriteLine($"  Topic back-link). The engine loads each child record from its defining plugin and merges by FormID,");
+        Console.WriteLine($"  so the cell's other refs / the topic's original line still load from Skyrim.esm. The override is");
+        Console.WriteLine($"  surgical (parent header + the new child) — the standard add-to-an-existing-parent shape.");
         Console.WriteLine();
         bool allPass = results.All(r => r.pass) && srcOk;
         Console.WriteLine("================================================================");

--- a/src/housecarl-generator/NestedCreateProof.cs
+++ b/src/housecarl-generator/NestedCreateProof.cs
@@ -134,6 +134,50 @@ public static class NestedCreateProof
                 $"created={YN(ok)} ref-in-persistent={YN(present)} local-id={YN(local)} | override-carries={(persistent?.Count ?? -1)} of {origPersistent + 1} (orig+new) [merge-semantic: OPEN]{Err(o)}"));
         }
 
+        // ===================== N8 — multi-child under one new topic + a FIELD EDIT on a created INFO =====================
+        {
+            var outPath = Path.Combine(outDir, "houseCARL_NestedCreate_N8.esp");
+            var specs = new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogTopic", EditorId = "HC_N8_Topic", Edits = Array.Empty<WriteRequest>() },
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HC_N8_L1", ParentRef = "HC_N8_Topic", Edits = Array.Empty<WriteRequest>() },
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HC_N8_L2", ParentRef = "HC_N8_Topic",
+                    Edits = new[] { new WriteRequest { RecordType = "DialogResponses", Path = new[] { "Prompt" }, Verb = "Set", Value = "houseCARL line two" } } },
+            };
+            var o = WritePatchBuilder.CreateRecords(resolver, rulebook, specs, outPath, extend: false);
+            bool ok = o.Success && o.Created.Count == 3;
+            var l1 = ok ? o.Created[1].FormKey : default;
+            var l2 = ok ? o.Created[2].FormKey : default;
+            var responses = ok ? TopicResponses(outPath, "HC_N8_Topic") : null;
+            bool bothUnder = responses is not null && responses.Contains(l1) && responses.Contains(l2);
+            var prompt = ok ? InfoPrompt(outPath, l2) : null;
+            bool fieldLanded = prompt == "houseCARL line two";
+            bool distinct = ok && l1 != l2;
+            bool pass = ok && bothUnder && fieldLanded && distinct;
+            results.Add(("N8 multi-INFO + field edit", pass,
+                $"created={(o.Success ? o.Created.Count : 0)} both-under-topic={YN(bothUnder)} L2.Prompt=\"{prompt}\" field-landed={YN(fieldLanded)} distinct-ids={YN(distinct)}{Err(o)}"));
+        }
+
+        // ===================== N9 — KNOWN GAP: extend= with a parent CARRIED BY THE PATCH (not the load order) =====================
+        //   Create a topic (call 1), then add an INFO under it in a separate into= call (call 2). The parent topic
+        //   lives in the PATCH, not the load order — and nested parent resolution checks the load-order winner only,
+        //   so this is REFUSED. Asserts the gap is communicated LOUD + names the one-call workaround (Q3), NOT that
+        //   the capability works. The capability (resolve a patch-carried parent on extend) is a named follow-up.
+        {
+            var outPath = Path.Combine(outDir, "houseCARL_NestedCreate_N9.esp");
+            var s1 = WritePatchBuilder.CreateRecords(resolver, rulebook,
+                new[] { new WritePatchBuilder.CreateSpec { RecordType = "DialogTopic", EditorId = "HC_N9_Topic", Edits = Array.Empty<WriteRequest>() } },
+                outPath, extend: false);
+            var topicFk2 = s1.Success ? s1.Created[0].FormKey : default;
+            var s2 = WritePatchBuilder.CreateRecords(resolver, rulebook,
+                new[] { new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HC_N9_Info", ParentRef = topicFk2.ToString(), Edits = Array.Empty<WriteRequest>() } },
+                outPath, extend: true);
+            bool refusedLoud = s1.Success && !s2.Success && (s2.Error ?? "").Contains("one call", StringComparison.OrdinalIgnoreCase)
+                && (s2.Error ?? "").Contains("prior into=", StringComparison.OrdinalIgnoreCase);
+            results.Add(("N9 extend+patch-parent (KNOWN GAP: refuses loud)", refusedLoud,
+                $"call1-ok={YN(s1.Success)} call2-refused-loud+named={YN(refusedLoud)}{Err(s2)}"));
+        }
+
         // ===================== N4 — REJECT nested with no parent =====================
         results.Add(RejectCheck("N4 reject nested no-parent", outDir, "N4", resolver, rulebook,
             new[] { new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HC_N4", Edits = Array.Empty<WriteRequest>() } },
@@ -213,6 +257,19 @@ public static class NestedCreateProof
             back = SkyrimMod.CreateFromBinaryOverlay(patchPath, SkyrimRelease.SkyrimSE);
             var t = back.DialogTopics.FirstOrDefault(match);
             return t?.Responses.Select(r => r.FormKey).ToList();
+        }
+        catch { return null; }
+        finally { (back as IDisposable)?.Dispose(); }
+    }
+
+    static string? InfoPrompt(string patchPath, FormKey infoFk)
+    {
+        ISkyrimModGetter? back = null;
+        try
+        {
+            back = SkyrimMod.CreateFromBinaryOverlay(patchPath, SkyrimRelease.SkyrimSE);
+            var info = back.EnumerateMajorRecords<IDialogResponsesGetter>().FirstOrDefault(x => x.FormKey == infoFk);
+            return info?.Prompt?.String;
         }
         catch { return null; }
         finally { (back as IDisposable)?.Dispose(); }

--- a/src/housecarl-generator/NestedCreateProof.cs
+++ b/src/housecarl-generator/NestedCreateProof.cs
@@ -1,0 +1,237 @@
+using System.Security.Cryptography;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// NESTED-CREATE build proof (nested/dialogue plan, Layer A) — exercises the REAL
+/// <see cref="WritePatchBuilder.CreateRecords"/> (the core the MCP create tool calls) on its NESTED path, so the
+/// proof transfers to the server by construction (the way <see cref="CreateProof"/> proves flat create). Where
+/// STEP 0's scout proved the Mutagen PRIMITIVE in isolation, this proves the mechanism THROUGH the production cleave —
+/// parent override → NestedAddNew → ApplyVerb → multi-master serialize → re-open from disk.
+///
+///   N1 — ONE-SHOT (the unit Aaron confirmed): a DialogTopic (flat) + a DialogResponses/INFO under it (same-call
+///        sibling parent) in ONE call → re-open: the INFO is in the NEW topic's Responses, both ids local 0x800+.
+///   N2 — INFO into an EXISTING topic (FormKey parent): the topic is overridden into the patch carrying its
+///        original lines, the new INFO appended → re-open: new INFO present AND the original responses survive.
+///   N3 — PlacedObject into an EXISTING Cell, collection='Persistent' (the outcome-(ii) named discriminator) →
+///        re-open: the new ref is in the cell's Persistent list.
+///   N4 — REJECT a nested type with NO parent (Q3): create 'DialogResponses' alone → refused, names the need for a parent.
+///   N5 — REJECT a parent that can't contain the child (Q3): 'DialogResponses' under a WEAPON FormKey → refused loud.
+///   N6 — REJECT an ambiguous add-target (Q3): 'PlacedObject' into a Cell with NO collection= → refused, names the lists.
+///   N7 — REJECT a forward sibling parent (Q3): an INFO whose parent sibling is declared LATER → refused, the order rule.
+///
+/// Vanilla Skyrim.esm is SHA-checked unchanged (create only writes the patch). Patches land in
+/// write-output/nested-create-proof/ for xEdit.  Run: dotnet run --project src/housecarl-generator nested-create-proof [Skyrim.esm]
+/// </summary>
+public static class NestedCreateProof
+{
+    const string DefaultSource = @"E:\Skyrim Modding\ARR 2.0\Stock Game\Data\Skyrim.esm";
+
+    public static int RunProof(string[] args)
+    {
+        var src = args.Length > 0 && !args[0].StartsWith("--") ? args[0] : DefaultSource;
+
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" houseCARL nested-create proof (Layer A — housecarl_create_record nested path)");
+        Console.WriteLine("================================================================");
+        Console.WriteLine($"source: {src}");
+        if (!File.Exists(src)) { Console.Error.WriteLine($"error: source not found: {src}"); return 1; }
+
+        using var resolver = LoadOrderResolver.Build(new[] { src });
+        var rulebook = CorpusRulebook.Load();
+        Console.WriteLine($"Resolver: {resolver.PluginCount:N0} plugin | {resolver.RecordCount:N0} records.");
+
+        // Sample an existing topic WITH responses (N2), a cell WITH persistent refs (N3), a weapon (N5 bad parent).
+        FormKey topicFk = default; int origResponses = 0;
+        foreach (var (fk, _, body) in resolver.WinnerRecordsOfType(new[] { typeof(IDialogTopicGetter) }))
+            if (body is IDialogTopicGetter t && t.Responses.Count > 0) { topicFk = fk; origResponses = t.Responses.Count; break; }
+        FormKey cellFk = default; int origPersistent = 0;
+        foreach (var (fk, _, body) in resolver.WinnerRecordsOfType(new[] { typeof(ICellGetter) }))
+            if (body is ICellGetter c && c.Persistent.Count > 0) { cellFk = fk; origPersistent = c.Persistent.Count; break; }
+        FormKey weaponFk = resolver.WinnerRecordsOfType(new[] { typeof(IWeaponGetter) }).Select(x => x.fk).FirstOrDefault();
+        if (topicFk.IsNull || cellFk.IsNull || weaponFk.IsNull)
+        { Console.Error.WriteLine($"error: could not sample fixtures (topic={topicFk} cell={cellFk} weapon={weaponFk})."); return 1; }
+        Console.WriteLine($"fixtures: topic={topicFk} (responses={origResponses})  cell={cellFk} (persistent={origPersistent})  weapon={weaponFk}");
+        Console.WriteLine();
+
+        var outDir = Path.GetFullPath(Path.Combine("write-output", "nested-create-proof"));
+        if (Directory.Exists(outDir)) Directory.Delete(outDir, recursive: true);
+        Directory.CreateDirectory(outDir);
+        var shaBefore = Sha(src);
+
+        var results = new List<(string name, bool pass, string detail)>();
+
+        // ===================== N1 — ONE-SHOT: new topic + INFO under it, in one call =====================
+        {
+            var outPath = Path.Combine(outDir, "houseCARL_NestedCreate_N1.esp");
+            var specs = new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogTopic", EditorId = "HC_N1_Topic", Edits = Array.Empty<WriteRequest>() },
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HC_N1_Info1", ParentRef = "HC_N1_Topic", Edits = Array.Empty<WriteRequest>() },
+            };
+            var o = WritePatchBuilder.CreateRecords(resolver, rulebook, specs, outPath, extend: false);
+            bool ok2 = o.Success && o.Created.Count == 2;
+            var topic = ok2 ? o.Created[0].FormKey : default;
+            var info = ok2 ? o.Created[1].FormKey : default;
+            bool floored = ok2 && topic.ID >= 0x800 && info.ID >= 0x800 && topic != info
+                && topic.ModKey.FileName.String.Equals(Path.GetFileName(outPath), StringComparison.OrdinalIgnoreCase)
+                && info.ModKey == topic.ModKey;
+            var responses = ok2 ? TopicResponses(outPath, "HC_N1_Topic") : null;
+            bool underTopic = responses is not null && responses.Contains(info);
+            bool pass = ok2 && floored && underTopic;
+            results.Add(("N1 one-shot topic+INFO", pass,
+                $"created={(o.Success ? o.Created.Count : 0)} topic={(ok2 ? "0x" + topic.ID.ToString("X6") : "-")} info={(ok2 ? "0x" + info.ID.ToString("X6") : "-")} floored={YN(floored)} info-under-new-topic={YN(underTopic)}{Err(o)}"));
+        }
+
+        // ===================== N2 — INFO into an EXISTING topic (FormKey parent) =====================
+        //   ASSERTS THE MECHANISM only (the new child is allocated + placed under the overridden parent + local id).
+        //   It does NOT assert "the parent's existing children survive" — overriding the parent yields an override
+        //   carrying ONLY the new child (sibChildren below). Whether that's correct (Skyrim merges children across
+        //   plugins by record) or lossy (the override replaces the child list) is the merge-vs-replace SEMANTIC,
+        //   reported as an OPEN QUESTION below — NOT decided by guessing (evidence-first, §4).
+        int n2OverrideCount = -1;
+        {
+            var outPath = Path.Combine(outDir, "houseCARL_NestedCreate_N2.esp");
+            var specs = new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HC_N2_Info", ParentRef = topicFk.ToString(), Edits = Array.Empty<WriteRequest>() },
+            };
+            var o = WritePatchBuilder.CreateRecords(resolver, rulebook, specs, outPath, extend: false);
+            bool ok = o.Success && o.Created.Count == 1;
+            var info = ok ? o.Created[0].FormKey : default;
+            var responses = ok ? TopicResponses(outPath, topicFk) : null;
+            n2OverrideCount = responses?.Count ?? -1;
+            bool present = responses is not null && responses.Contains(info);
+            bool local = ok && info.ID >= 0x800 && info.ModKey.FileName.String.Equals(Path.GetFileName(outPath), StringComparison.OrdinalIgnoreCase);
+            bool pass = ok && present && local;
+            results.Add(("N2 INFO added to existing topic", pass,
+                $"created={YN(ok)} new-info-present={YN(present)} local-id={YN(local)} | override-carries={(responses?.Count ?? -1)} of {origResponses + 1} (orig+new) [merge-semantic: OPEN]{Err(o)}"));
+        }
+
+        // ===================== N3 — PlacedObject into an existing Cell, collection='Persistent' (outcome ii) =====================
+        //   Same as N2: asserts the MECHANISM (ref allocated + in the cell's Persistent + local id). The override
+        //   carries only the new ref (not the cell's other 28) — the merge-vs-replace OPEN QUESTION, not asserted.
+        int n3OverrideCount = -1;
+        {
+            var outPath = Path.Combine(outDir, "houseCARL_NestedCreate_N3.esp");
+            var specs = new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "PlacedObject", EditorId = "HC_N3_Ref", ParentRef = cellFk.ToString(), IntoCollection = "Persistent", Edits = Array.Empty<WriteRequest>() },
+            };
+            var o = WritePatchBuilder.CreateRecords(resolver, rulebook, specs, outPath, extend: false);
+            bool ok = o.Success && o.Created.Count == 1;
+            var refFk = ok ? o.Created[0].FormKey : default;
+            var persistent = ok ? CellPersistent(outPath, cellFk) : null;
+            n3OverrideCount = persistent?.Count ?? -1;
+            bool present = persistent is not null && persistent.Contains(refFk);
+            bool local = ok && refFk.ID >= 0x800 && refFk.ModKey.FileName.String.Equals(Path.GetFileName(outPath), StringComparison.OrdinalIgnoreCase);
+            bool pass = ok && present && local;
+            results.Add(("N3 Placed added to existing cell", pass,
+                $"created={YN(ok)} ref-in-persistent={YN(present)} local-id={YN(local)} | override-carries={(persistent?.Count ?? -1)} of {origPersistent + 1} (orig+new) [merge-semantic: OPEN]{Err(o)}"));
+        }
+
+        // ===================== N4 — REJECT nested with no parent =====================
+        results.Add(RejectCheck("N4 reject nested no-parent", outDir, "N4", resolver, rulebook,
+            new[] { new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HC_N4", Edits = Array.Empty<WriteRequest>() } },
+            msg => msg.Contains("parent", StringComparison.OrdinalIgnoreCase) || msg.Contains("nested", StringComparison.OrdinalIgnoreCase)));
+
+        // ===================== N5 — REJECT a parent that can't contain the child =====================
+        results.Add(RejectCheck("N5 reject bad parent (INFO<-Weapon)", outDir, "N5", resolver, rulebook,
+            new[] { new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HC_N5", ParentRef = weaponFk.ToString(), Edits = Array.Empty<WriteRequest>() } },
+            msg => msg.Contains("cannot be created under", StringComparison.OrdinalIgnoreCase)));
+
+        // ===================== N6 — REJECT ambiguous add-target (Cell has 2 placed lists) =====================
+        results.Add(RejectCheck("N6 reject ambiguous collection", outDir, "N6", resolver, rulebook,
+            new[] { new WritePatchBuilder.CreateSpec { RecordType = "PlacedObject", EditorId = "HC_N6", ParentRef = cellFk.ToString(), Edits = Array.Empty<WriteRequest>() } },
+            msg => msg.Contains("more than one", StringComparison.OrdinalIgnoreCase) && msg.Contains("Persistent", StringComparison.OrdinalIgnoreCase)));
+
+        // ===================== N7 — REJECT a forward sibling parent (declared LATER) =====================
+        results.Add(RejectCheck("N7 reject forward sibling parent", outDir, "N7", resolver, rulebook,
+            new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HC_N7_Info", ParentRef = "HC_N7_Topic", Edits = Array.Empty<WriteRequest>() },
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogTopic", EditorId = "HC_N7_Topic", Edits = Array.Empty<WriteRequest>() },
+            },
+            msg => msg.Contains("earlier in this call", StringComparison.OrdinalIgnoreCase)));
+
+        bool srcOk = shaBefore == Sha(src);
+
+        // ---- VERDICT ----
+        Console.WriteLine("Results:");
+        foreach (var (name, pass, detail) in results)
+            Console.WriteLine($"  [{(pass ? "PASS" : "FAIL")}] {name,-34} {detail}");
+        Console.WriteLine($"  [{(srcOk ? "PASS" : "FAIL")}] {"Skyrim.esm byte-untouched",-34}");
+        Console.WriteLine();
+        Console.WriteLine("OPEN QUESTION (Layer-B / domain — surfaced, NOT guessed, evidence-first §4):");
+        Console.WriteLine($"  Adding a child to an EXISTING parent overrides that parent carrying ONLY the new child");
+        Console.WriteLine($"  (N2 topic override = {n2OverrideCount} response of {origResponses + 1}; N3 cell override = {n3OverrideCount} persistent of {origPersistent + 1}).");
+        Console.WriteLine($"  This is CORRECT iff Skyrim merges a parent's children across plugins by record (the 28 cell refs /");
+        Console.WriteLine($"  the original topic line still load from Skyrim.esm). If the engine instead REPLACES the child list,");
+        Console.WriteLine($"  the override silently drops the siblings — then the build must deep-copy existing children first.");
+        Console.WriteLine($"  The NEW-parent one-shot (N1) has NO existing siblings, so it is unaffected + complete either way.");
+        Console.WriteLine();
+        bool allPass = results.All(r => r.pass) && srcOk;
+        Console.WriteLine("================================================================");
+        Console.WriteLine(allPass
+            ? "=== ALL CHECKS PASS — nested-record creation is proven through the production create cleave.\n" +
+              "    Open write-output/nested-create-proof/*.esp in xEdit: N1=a new topic + its line, N2=a new line on an\n" +
+              "    existing topic, N3=a new ref in a cell. New local FormIDs, Skyrim.esm byte-untouched. ==="
+            : "=== FAIL — see the checks above (a !! is the thing to resolve). ===");
+        Console.WriteLine("================================================================");
+        return allPass ? 0 : 1;
+    }
+
+    /// <summary>A REJECT check: drive CreateRecords expecting refusal, assert no file written + the message matches.</summary>
+    static (string, bool, string) RejectCheck(string name, string outDir, string tag, LoadOrderResolver resolver,
+        CorpusRulebook rulebook, WritePatchBuilder.CreateSpec[] specs, Func<string, bool> msgOk)
+    {
+        var outPath = Path.Combine(outDir, $"houseCARL_NestedCreate_{tag}.esp");
+        var o = WritePatchBuilder.CreateRecords(resolver, rulebook, specs, outPath, extend: false);
+        bool refused = !o.Success;
+        bool named = refused && msgOk(o.Error ?? "");
+        bool noFile = !File.Exists(outPath);
+        bool pass = refused && named && noFile;
+        return (name, pass, $"refused={YN(refused)} msg-named={YN(named)} no-file={YN(noFile)}" + (refused ? "" : $"  (unexpectedly wrote; created={o.Created.Count})"));
+    }
+
+    // ---- re-open helpers ----
+
+    static List<FormKey>? TopicResponses(string patchPath, string topicEditorId)
+        => TopicResponsesBy(patchPath, t => t.EditorID == topicEditorId);
+    static List<FormKey>? TopicResponses(string patchPath, FormKey topicFk)
+        => TopicResponsesBy(patchPath, t => t.FormKey == topicFk);
+
+    static List<FormKey>? TopicResponsesBy(string patchPath, Func<IDialogTopicGetter, bool> match)
+    {
+        ISkyrimModGetter? back = null;
+        try
+        {
+            back = SkyrimMod.CreateFromBinaryOverlay(patchPath, SkyrimRelease.SkyrimSE);
+            var t = back.DialogTopics.FirstOrDefault(match);
+            return t?.Responses.Select(r => r.FormKey).ToList();
+        }
+        catch { return null; }
+        finally { (back as IDisposable)?.Dispose(); }
+    }
+
+    static List<FormKey>? CellPersistent(string patchPath, FormKey cellFk)
+    {
+        ISkyrimModGetter? back = null;
+        try
+        {
+            back = SkyrimMod.CreateFromBinaryOverlay(patchPath, SkyrimRelease.SkyrimSE);
+            var c = back.EnumerateMajorRecords<ICellGetter>().FirstOrDefault(x => x.FormKey == cellFk);
+            return c?.Persistent.Select(r => r.FormKey).ToList();
+        }
+        catch { return null; }
+        finally { (back as IDisposable)?.Dispose(); }
+    }
+
+    static string Err(WritePatchBuilder.CreateOutcome o) => o.Success ? "" : "  err=" + (o.Error ?? "").Replace('\n', ' ');
+    static string YN(bool b) => b ? "Y" : "N";
+    static string Sha(string p) { using var s = File.OpenRead(p); using var h = SHA256.Create(); return Convert.ToHexString(h.ComputeHash(s)); }
+}

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -133,6 +133,11 @@ if (args.Length > 0 && args[0] == "nested-probe") return NestedProbe.RunNestedPr
 // the FormID floor, and characterizes the coordinate-keyed §4-(b) seam. Throwaway recon, fail-loud per shape (Q3).
 if (args.Length > 0 && args[0] == "nested-create-probe") return NestedCreateProbe.RunProbe(args[1..]);
 
+// Nested-create build proof (Layer A): drive the REAL WritePatchBuilder.CreateRecords nested path — one-shot
+// topic+INFO, INFO into an existing topic, Placed into a cell (named collection), + the Q3 rejects (no-parent,
+// bad parent, ambiguous collection, forward sibling). Re-opens each patch from disk; Skyrim.esm byte-checked.
+if (args.Length > 0 && args[0] == "nested-create-proof") return NestedCreateProof.RunProof(args[1..]);
+
 // Wave 4 scout: recon Mutagen's IFormLinkOrIndex condition-target API — the form-vs-index discriminator (condition oracle), the wave-4 unknown.
 if (args.Length > 0 && args[0] == "condition-probe") return ConditionProbe.RunConditionProbe(args[1..]);
 

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -273,6 +273,12 @@ if (args.Length > 0 && args[0] == "upsert-guard") return UpsertGuardProbe.RunGua
 // happy paths + the 4 Q3 rejects + the patch-carried-parent extend gap (NO Skyrim.esm, unlike nested-create-proof).
 if (args.Length > 0 && args[0] == "nested-create-guard") return NestedCreateGuardProbe.RunGuard(args[1..]);
 
+// create-tool WIRE (nested/dialogue plan, Layer A): SELF-CONTAINED CI regression guard — drives the REAL
+// LoadOrderService.CreateRecords (single, parent/collection) + CreateRecordsBatch (the bulk_create array) over a
+// synthetic MO2 instance: flat-still-works, parent passthrough, the same-call one-shot, batch all-or-nothing, the
+// nested-no-parent guidance copy.
+if (args.Length > 0 && args[0] == "bulk-create-guard") return BulkCreateGuardProbe.RunGuard(args[1..]);
+
 // External-tool bridge (step 1) proof: the pure core pieces housecarl_set_tool_path + the riders ride — shared-config
 // clobber-safety, path validation, the missing-dependency forcing prompt, and canonical-home auto-detect.
 if (args.Length > 0 && args[0] == "tool-bridge") return ToolBridgeProbe.Run(args[1..]);

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -268,6 +268,11 @@ if (args.Length > 0 && args[0] == "formid-floor-guard") return FormIdFloorProbe.
 // leaves the old file intact with no temp residue.
 if (args.Length > 0 && args[0] == "upsert-guard") return UpsertGuardProbe.RunGuard(args[1..]);
 
+// nested-record CREATE (nested/dialogue plan, Layer A): SELF-CONTAINED CI regression guard — synthesizes a master
+// (weapon + topic + interior cell), drives the REAL CreateRecords for the one-shot/multi-child/field-edit/into-existing
+// happy paths + the 4 Q3 rejects + the patch-carried-parent extend gap (NO Skyrim.esm, unlike nested-create-proof).
+if (args.Length > 0 && args[0] == "nested-create-guard") return NestedCreateGuardProbe.RunGuard(args[1..]);
+
 // External-tool bridge (step 1) proof: the pure core pieces housecarl_set_tool_path + the riders ride — shared-config
 // clobber-safety, path validation, the missing-dependency forcing prompt, and canonical-home auto-detect.
 if (args.Length > 0 && args[0] == "tool-bridge") return ToolBridgeProbe.Run(args[1..]);

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -128,6 +128,11 @@ if (args.Length > 0 && args[0] == "substruct-probe") return WriteEngine.RunSubst
 // Wave 3 scout: recon Mutagen's nested-group override API (Cell/Placed*/INFO/Navmesh/Landscape) — the highest-risk unknown.
 if (args.Length > 0 && args[0] == "nested-probe") return NestedProbe.RunNestedProbe(args[1..]);
 
+// STEP 0 scout (nested/dialogue plan §1.4, BLOCKING): can houseCARL ALLOCATE a brand-new record INTO a nested parent
+// by construction? Tests DuplicateIntoAsNewRecord (clone-a-sibling) + construct-and-Add-into-collection (new parent),
+// the FormID floor, and characterizes the coordinate-keyed §4-(b) seam. Throwaway recon, fail-loud per shape (Q3).
+if (args.Length > 0 && args[0] == "nested-create-probe") return NestedCreateProbe.RunProbe(args[1..]);
+
 // Wave 4 scout: recon Mutagen's IFormLinkOrIndex condition-target API — the form-vs-index discriminator (condition oracle), the wave-4 unknown.
 if (args.Length > 0 && args[0] == "condition-probe") return ConditionProbe.RunConditionProbe(args[1..]);
 

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -270,7 +270,7 @@ if (args.Length > 0 && args[0] == "upsert-guard") return UpsertGuardProbe.RunGua
 
 // nested-record CREATE (nested/dialogue plan, Layer A): SELF-CONTAINED CI regression guard — synthesizes a master
 // (weapon + topic + interior cell), drives the REAL CreateRecords for the one-shot/multi-child/field-edit/into-existing
-// happy paths + the 4 Q3 rejects + the patch-carried-parent extend gap (NO Skyrim.esm, unlike nested-create-proof).
+// happy paths + the 4 Q3 rejects + the patch-carried-parent extend (the former N9 gap) (NO Skyrim.esm, unlike nested-create-proof).
 if (args.Length > 0 && args[0] == "nested-create-guard") return NestedCreateGuardProbe.RunGuard(args[1..]);
 
 // create-tool WIRE (nested/dialogue plan, Layer A): SELF-CONTAINED CI regression guard — drives the REAL

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -801,38 +801,94 @@ public sealed class LoadOrderService : IDisposable
     /// <see cref="WritePatchBuilder.CreateRecords"/> (pre-flight ALL → AddNew → ApplyVerb → multi-master serialize). The new
     /// record's FormID is auto-allocated (local 0x800+) and reported; originals are never touched. FLAT records only — a
     /// nested/placed or abstract-group type fails loud with guidance.</summary>
-    public WritePatchBuilder.CreateOutcome CreateRecords(string recordType, string editorid, IReadOnlyList<BulkOp> operations, string? patchName, string? into, bool fullReadback = false)
+    public WritePatchBuilder.CreateOutcome CreateRecords(string recordType, string editorid, IReadOnlyList<BulkOp> operations,
+        string? patchName, string? into, bool fullReadback = false, string? parent = null, string? collection = null)
     {
-        if (string.IsNullOrWhiteSpace(recordType))
-            return WritePatchBuilder.CreateOutcome.Fail("record_type is required (a catalog name like 'Keyword'/'Spell'/'Weapon' or a 4-char signature like 'KYWD').");
-        if (string.IsNullOrWhiteSpace(editorid))
-            return WritePatchBuilder.CreateOutcome.Fail("editorid is required — the EditorID the new record is referenced by (e.g. in SkyPatcher/SPID).");
-
-        // Resolve the type string → ONE concrete catalog name. Signature + name both work; unknown → Q3; an ambiguous
-        // signature (maps to several types) → refuse and ask for the specific name.
-        string catalogName;
-        try
-        {
-            var types = ResolveTypeFilter(recordType.Trim());
-            if (types.Count != 1)
-                return WritePatchBuilder.CreateOutcome.Fail(
-                    $"record_type '{recordType}' is ambiguous ({types.Count} matches) — use a specific catalog name (e.g. one of: {string.Join(", ", types.Select(t => RecordNaming.StripGetterInterface(t.Name)))}).");
-            catalogName = RecordNaming.StripGetterInterface(types[0].Name);
-        }
-        catch (ArgumentException ex) { return WritePatchBuilder.CreateOutcome.Fail(ex.Message); }
-
-        // Map each field op → a core WriteRequest rooted at the create type (all-or-nothing on a malformed one).
-        var edits = new List<WriteRequest>(operations.Count);
         var problems = new List<string>();
-        for (int i = 0; i < operations.Count; i++)
+        var spec = BuildCreateSpec(recordType, editorid, operations, parent, collection, where: null, problems);
+        if (spec is null)
+            return WritePatchBuilder.CreateOutcome.Fail(
+                $"refused — {problems.Count} problem(s) creating the record; NOTHING created:\n  - " + string.Join("\n  - ", problems));
+        return CommitCreate(new[] { spec }, patchName, into, fullReadback);
+    }
+
+    /// <summary>Create MANY new records in ONE patch (housecarl_bulk_create) — the batch sibling of
+    /// <see cref="CreateRecords"/>, and the one-shot lever for a nested unit (a dialogue topic + its lines, a cell + its
+    /// placed refs) where a child's <c>parent</c> names a same-call sibling by editorid. Each spec is mapped exactly as
+    /// the single create (type resolution + field-op mapping + parent/collection); ALL-OR-NOTHING (Q3) — any malformed
+    /// spec refuses the whole call (with per-record reasons) and the core <see cref="WritePatchBuilder.CreateRecords"/>
+    /// likewise refuses the whole batch on any creatability/parent problem. One serialize for the lot.</summary>
+    public WritePatchBuilder.CreateOutcome CreateRecordsBatch(IReadOnlyList<CreateOp> records, string? patchName, string? into, bool fullReadback = false)
+    {
+        if (records is null || records.Count == 0)
+            return WritePatchBuilder.CreateOutcome.Fail("no records to create supplied — pass one or more {record_type, editorid, operations?, parent?, collection?} specs.");
+
+        var problems = new List<string>();
+        var specs = new List<WritePatchBuilder.CreateSpec>(records.Count);
+        for (int r = 0; r < records.Count; r++)
         {
-            var req = MapCreateEdit(operations[i], i, catalogName, out var err);
-            if (err is not null) problems.Add(err); else edits.Add(req!);
+            var rec = records[r];
+            var spec = BuildCreateSpec(rec.RecordType, rec.Editorid, rec.Operations ?? Array.Empty<BulkOp>(), rec.Parent, rec.Collection, $"record[{r}]", problems);
+            if (spec is not null) specs.Add(spec);
         }
         if (problems.Count > 0)
             return WritePatchBuilder.CreateOutcome.Fail(
-                $"refused — {problems.Count} of {operations.Count} operation(s) malformed; NOTHING created:\n  - " + string.Join("\n  - ", problems));
+                $"refused — {problems.Count} problem(s) across {records.Count} record(s); NOTHING created:\n  - " + string.Join("\n  - ", problems));
+        return CommitCreate(specs, patchName, into, fullReadback);
+    }
 
+    /// <summary>Build ONE core <see cref="WritePatchBuilder.CreateSpec"/> from wire parts (shared by the single create and
+    /// the batch): resolve <paramref name="recordType"/> (catalog name or 4-char signature) to ONE concrete catalog name
+    /// (unknown/ambiguous → a problem), require an editorid, map each field <paramref name="operations"/> op to a core
+    /// <see cref="WriteRequest"/> rooted at that type, and carry <paramref name="parent"/>/<paramref name="collection"/>
+    /// through (a nested child) — null ⇒ a flat top-level record. Every problem (with the optional <paramref name="where"/>
+    /// label) is APPENDED to <paramref name="problems"/>; returns null iff this record contributed any (all-or-nothing).</summary>
+    WritePatchBuilder.CreateSpec? BuildCreateSpec(string? recordType, string? editorid, IReadOnlyList<BulkOp> operations,
+        string? parent, string? collection, string? where, List<string> problems)
+    {
+        var prefix = where is null ? "" : where + ": ";
+        int before = problems.Count;
+
+        string? catalogName = null;
+        if (string.IsNullOrWhiteSpace(recordType))
+            problems.Add($"{prefix}record_type is required (a catalog name like 'Keyword'/'Spell'/'Weapon' or a 4-char signature like 'KYWD').");
+        else
+        {
+            try
+            {
+                var types = ResolveTypeFilter(recordType.Trim());
+                if (types.Count != 1)
+                    problems.Add($"{prefix}record_type '{recordType}' is ambiguous ({types.Count} matches) — use a specific catalog name (e.g. one of: {string.Join(", ", types.Select(t => RecordNaming.StripGetterInterface(t.Name)))}).");
+                else catalogName = RecordNaming.StripGetterInterface(types[0].Name);
+            }
+            catch (ArgumentException ex) { problems.Add($"{prefix}{ex.Message}"); }
+        }
+        if (string.IsNullOrWhiteSpace(editorid))
+            problems.Add($"{prefix}editorid is required — the EditorID the new record is referenced by (e.g. in SkyPatcher/SPID).");
+
+        // Map each field op → a core WriteRequest rooted at the create type (only once the type resolved; collect ALL malformed ops).
+        var edits = new List<WriteRequest>(operations.Count);
+        if (catalogName is not null)
+            for (int i = 0; i < operations.Count; i++)
+            {
+                var req = MapCreateEdit(operations[i], i, catalogName, out var err);
+                if (err is not null) problems.Add($"{prefix}{err}"); else edits.Add(req!);
+            }
+
+        if (problems.Count != before) return null;
+        return new WritePatchBuilder.CreateSpec
+        {
+            RecordType = catalogName!, EditorId = editorid!.Trim(), Edits = edits,
+            ParentRef = string.IsNullOrWhiteSpace(parent) ? null : parent.Trim(),
+            IntoCollection = string.IsNullOrWhiteSpace(collection) ? null : collection.Trim(),
+        };
+    }
+
+    /// <summary>Resolve the folder-per-patch output (fresh, or <paramref name="into"/> an existing houseCARL-owned patch),
+    /// then drive the core multi-record create + serialize under the write gate (hunt F2: one write at a time). A refused
+    /// create that just created the output folder leaves no orphan (hunt F4). Shared by the single + batch create.</summary>
+    WritePatchBuilder.CreateOutcome CommitCreate(IReadOnlyList<WritePatchBuilder.CreateSpec> specs, string? patchName, string? into, bool fullReadback)
+    {
         lock (_writeGate)                                                 // hunt F2: one write at a time, resolve→commit
         {
             var resolver = Resolver;
@@ -842,8 +898,7 @@ public sealed class LoadOrderService : IDisposable
             try { outPath = ResolveOutputPath(patchName, into, out extend, out created); }
             catch (Exception ex) { return WritePatchBuilder.CreateOutcome.Fail(ex.Message); }
 
-            var spec = new WritePatchBuilder.CreateSpec { RecordType = catalogName, EditorId = editorid.Trim(), Edits = edits };
-            var outcome = WritePatchBuilder.CreateRecords(resolver, rulebook, new[] { spec }, outPath, extend, fullReadback);
+            var outcome = WritePatchBuilder.CreateRecords(resolver, rulebook, specs, outPath, extend, fullReadback);
             if (!outcome.Success && created) RemoveFolderCreatedThisCall(outPath);   // hunt F4: a refused create leaves no orphan
             return outcome;
         }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -798,9 +798,12 @@ public sealed class LoadOrderService : IDisposable
     /// catalog name (unknown/ambiguous → Q3), maps the field <paramref name="operations"/> to core <see cref="WriteRequest"/>s
     /// rooted at that type (a create op takes NO formid — it sets fields on the new record), resolves the folder-per-patch
     /// output (fresh, or <paramref name="into"/> an existing houseCARL-owned patch), then drives
-    /// <see cref="WritePatchBuilder.CreateRecords"/> (pre-flight ALL → AddNew → ApplyVerb → multi-master serialize). The new
-    /// record's FormID is auto-allocated (local 0x800+) and reported; originals are never touched. FLAT records only — a
-    /// nested/placed or abstract-group type fails loud with guidance.</summary>
+    /// <see cref="WritePatchBuilder.CreateRecords"/> (pre-flight ALL → AddNew/NestedAddNew → ApplyVerb → multi-master serialize).
+    /// The new record's FormID is auto-allocated (local 0x800+) and reported; originals are never touched. A flat top-level
+    /// record needs no <paramref name="parent"/>; a NESTED child (a dialogue line, a placed ref) passes <paramref name="parent"/>
+    /// (an existing parent's FormKey, or a record created in a prior into= call) and, when the parent holds more than one
+    /// fitting child-list, <paramref name="collection"/>. For a parent + its children in ONE call (a topic + its lines, a
+    /// child's parent= naming a same-call sibling), see <see cref="CreateRecordsBatch"/>.</summary>
     public WritePatchBuilder.CreateOutcome CreateRecords(string recordType, string editorid, IReadOnlyList<BulkOp> operations,
         string? patchName, string? into, bool fullReadback = false, string? parent = null, string? collection = null)
     {

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -140,7 +140,7 @@ public static class WriteTools
          "FormID + editorid, the patch path, and its (derived) masters.")]
     public static string CreateRecord(
         LoadOrderService svc,
-        [Description("The kind of record to create: a catalog name ('Keyword', 'Spell', 'Weapon', 'LeveledItem') or a 4-char signature ('KYWD'). Flat top-level records only.")]
+        [Description("The kind of record to create: a catalog name ('Keyword', 'Spell', 'Weapon', 'LeveledItem', 'DialogResponses', 'PlacedObject') or a 4-char signature ('KYWD'). A flat top-level type, or a nested type (a dialogue line, a placed ref) when parent= is given.")]
             string record_type,
         [Description("REQUIRED. The EditorID for the new record — how it's referenced (in SkyPatcher/SPID/xEdit). Choose a clear, prefixed name.")]
             string editorid,

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -128,13 +128,16 @@ public static class WriteTools
          "REQUIRED — the EditorID the record is referenced by (in SkyPatcher/SPID, in xEdit); choose a clear, prefixed name. " +
          "operations set the new record's fields, the SAME shape as bulk_apply ops but WITHOUT a formid (the new record's " +
          "FormID is auto-allocated, in the patch's own 0x800+ range, and returned to you) — e.g. " +
-         "operations=[{field_path:'Name', value:'My Spell'}, {field_path:'EffectList', verb:'Add', compose:{...}}]. The new " +
-         "FormID is reported back; to make ANOTHER record reference it, call this or set_field again with into='<this patch>' " +
-         "using that FormID. By default writes a fresh patch named patch_name; into= extends an existing houseCARL patch " +
-         "(accumulate across calls/sessions). ALL-OR-NOTHING (Q3): the whole call is refused with a reason and nothing is " +
-         "written if the type can't be created (nested/placed records — cells, placed objects, dialogue — need parent " +
-         "context, a follow-up; abstract types like Global need a concrete subtype), if editorid is missing, or if any field " +
-         "op is illegal. Returns the new record's FormID + editorid, the patch path, and its (derived) masters.")]
+         "operations=[{field_path:'Name', value:'My Spell'}, {field_path:'EffectList', verb:'Add', compose:{...}}]. To create a " +
+         "NESTED record (a dialogue line under a topic, a placed ref in a cell), pass parent= (the parent record's FormID) and, " +
+         "if the parent holds more than one child-list that fits, collection= (e.g. 'Persistent'); for a parent AND its children " +
+         "in ONE call (a topic + its lines), use housecarl_bulk_create. The new FormID is reported back; to make ANOTHER record " +
+         "reference it, call this or set_field again with into='<this patch>' using that FormID. By default writes a fresh patch " +
+         "named patch_name; into= extends an existing houseCARL patch (accumulate across calls/sessions). ALL-OR-NOTHING (Q3): " +
+         "the whole call is refused with a reason and nothing is written if the type can't be created (an EXTERIOR cell nests " +
+         "under FormKey-less worldspace structs — a separate capability; abstract types like Global need a concrete subtype), if " +
+         "a nested type is given no parent, if editorid is missing, or if any field op is illegal. Returns the new record's " +
+         "FormID + editorid, the patch path, and its (derived) masters.")]
     public static string CreateRecord(
         LoadOrderService svc,
         [Description("The kind of record to create: a catalog name ('Keyword', 'Spell', 'Weapon', 'LeveledItem') or a 4-char signature ('KYWD'). Flat top-level records only.")]
@@ -143,6 +146,10 @@ public static class WriteTools
             string editorid,
         [Description("Optional. The new record's fields, same shape as bulk_apply ops but with NO formid: {field_path, verb?, value?, key?, values?, entries?, compose?}. Omit to create a bare record (just type + editorid).")]
             BulkOp[]? operations = null,
+        [Description("Optional. For a NESTED record (a dialogue line, a placed ref): the PARENT it nests under, as the parent record's FormID 'XXXXXX:Plugin.esp' (e.g. add a line to an existing topic, a ref to an existing cell). Omit for a flat top-level record. (For a parent + its children in one call — where parent can also be a same-call sibling's editorid — use housecarl_bulk_create.)")]
+            string? parent = null,
+        [Description("Optional. Which of the parent's child-collections to add into, BY NAME (e.g. a cell's 'Persistent'/'Temporary') — needed only when the parent holds more than one list that accepts this child type. Omit when the collection is unique (e.g. a topic's responses) or when parent is omitted.")]
+            string? collection = null,
         [Description("Optional. Base filename for the new patch (default 'houseCARL_Patch'); auto-suffixed if taken. Ignored if into= is given.")]
             string patch_name = "houseCARL_Patch",
         [Description("Optional. Filename of an existing houseCARL patch to add this new record to instead of writing a fresh one (accumulate across calls/sessions).")]
@@ -153,7 +160,42 @@ public static class WriteTools
             int max_chars = 0) => Guard.Tool("housecarl_create_record", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-        return RenderCreate(svc.CreateRecords(record_type, editorid, operations ?? Array.Empty<BulkOp>(), patch_name, into, full_readback), max_chars);
+        return RenderCreate(svc.CreateRecords(record_type, editorid, operations ?? Array.Empty<BulkOp>(), patch_name, into, full_readback, parent, collection), max_chars);
+    });
+
+    [McpServerTool(Name = "housecarl_bulk_create", Title = "Create many records (incl. a nested one-shot) in one patch"),
+     Description(
+         "Create MANY brand-new records in ONE patch plugin (originals untouched) — the batch form of housecarl_create_record, " +
+         "and the way to author a NESTED unit in a single call: a dialogue topic AND its lines, a cell AND its placed refs. " +
+         "records is an array of {record_type, editorid, operations?, parent?, collection?} — each spec is exactly a " +
+         "create_record call. A spec's parent= can be the FormID of an EXISTING record OR the editorid of a record declared " +
+         "EARLIER in this same records array (a same-call sibling) — which is how the one-shot 'topic + its lines' is expressed: " +
+         "records=[{record_type:'DialogTopic', editorid:'MyTopic'}, {record_type:'DialogResponses', editorid:'MyTopic_L1', " +
+         "parent:'MyTopic', operations:[{field_path:'Prompt', value:'Hello'}]}] (declare the topic BEFORE the lines). collection= " +
+         "names which child-list when the parent holds more than one that fits (e.g. a cell's 'Persistent'). Each new FormID is " +
+         "auto-allocated (the patch's own 0x800+ range) and returned. ALL-OR-NOTHING (Q3): if ANY spec is malformed or fails " +
+         "pre-flight (unknown/ambiguous type, missing editorid, illegal field op, a nested child with no resolvable parent, an " +
+         "ambiguous collection), the whole call is refused with per-record reasons and nothing is written — no partial patches. " +
+         "By default writes a fresh patch named patch_name; into= extends an existing houseCARL patch. NOTE: a parent created in " +
+         "a PRIOR into= call isn't resolvable as a parent yet — create a parent and its children together in one call. Returns " +
+         "each new record's FormID + editorid, the patch path, and its (derived) masters.")]
+    public static string BulkCreate(
+        LoadOrderService svc,
+        [Description("The records to create, all into one patch. Each: {record_type, editorid, operations?, parent?, collection?}. For a nested one-shot, declare the parent (e.g. a DialogTopic) BEFORE the children whose parent= names its editorid.")]
+            CreateOp[] records,
+        [Description("Optional. Base filename for the new patch (default 'houseCARL_Patch'); auto-suffixed if taken. Ignored if into= is given.")]
+            string patch_name = "houseCARL_Patch",
+        [Description("Optional. Filename of an existing houseCARL patch to add these new records to instead of writing a fresh one (accumulate across calls/sessions).")]
+            string? into = null,
+        [Description("When true, the response ALSO returns each created record IN FULL, read back from the written patch file on disk (every field, deep). The pre-enable verification, WITHOUT enabling the patch in MO2 (the written file's content, not load-order truth).")]
+            bool full_readback = false,
+        [Description("Optional. Max characters for the whole response; past it the full read-back section is cut with an explicit notice (never silent). 0 = the server default (~80k). Only matters with full_readback=true.")]
+            int max_chars = 0) => Guard.Tool("housecarl_bulk_create", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        if (records is null || records.Length == 0)
+            return "error: records is empty. Pass one or more {record_type, editorid, operations?, parent?, collection?} specs.";
+        return RenderCreate(svc.CreateRecordsBatch(records, patch_name, into, full_readback), max_chars);
     });
 
     /// <summary>Compact, parseable confirmation (rulebook: short mutation confirmation + the IDs needed for follow-up).
@@ -301,6 +343,27 @@ public sealed record BulkOp
 
     [JsonPropertyName("compose"), Description("Build a modeled struct: an arm for a polymorphic Set, or the element for a struct-element Add (e.g. a leveled-list entry; for a polymorphic list like VMAD Scripts[i].Properties, the element's CONCRETE arm type, e.g. 'ScriptObjectProperty').")]
     public StructInput? Compose { get; init; }
+}
+
+/// <summary>One brand-new record to create off the wire (housecarl_bulk_create) — the batch element matching the scalar
+/// args of housecarl_create_record: the DECLARED record_type, its editorid, optional field operations, and the optional
+/// nested parent/collection (a child's parent may be an existing FormID or a same-call sibling's editorid).</summary>
+public sealed record CreateOp
+{
+    [JsonPropertyName("record_type"), Description("The kind of record to create: a catalog name ('Keyword', 'Spell', 'DialogTopic', 'DialogResponses', 'PlacedObject') or a 4-char signature.")]
+    public string? RecordType { get; init; }
+
+    [JsonPropertyName("editorid"), Description("REQUIRED. The EditorID the new record is referenced by. A nested child's parent= can name this editorid (a same-call sibling parent).")]
+    public string? Editorid { get; init; }
+
+    [JsonPropertyName("operations"), Description("Optional. The new record's fields, same shape as bulk_apply ops but with NO formid: {field_path, verb?, value?, key?, values?, entries?, compose?}.")]
+    public BulkOp[]? Operations { get; init; }
+
+    [JsonPropertyName("parent"), Description("Optional. For a NESTED record: the parent it nests under — an EXISTING parent's FormID 'XXXXXX:Plugin.esp', OR the editorid of a record declared EARLIER in this same records array (a same-call sibling). Omit for a flat top-level record.")]
+    public string? Parent { get; init; }
+
+    [JsonPropertyName("collection"), Description("Optional. Which of the parent's child-collections to add into, BY NAME (e.g. a cell's 'Persistent') — needed only when more than one fits. Omit when unique or when parent is omitted.")]
+    public string? Collection { get; init; }
 }
 
 /// <summary>A modeled struct built from parts (wire shape of <see cref="StructSpec"/>): the concrete type, optional

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -176,9 +176,9 @@ public static class WriteTools
          "auto-allocated (the patch's own 0x800+ range) and returned. ALL-OR-NOTHING (Q3): if ANY spec is malformed or fails " +
          "pre-flight (unknown/ambiguous type, missing editorid, illegal field op, a nested child with no resolvable parent, an " +
          "ambiguous collection), the whole call is refused with per-record reasons and nothing is written — no partial patches. " +
-         "By default writes a fresh patch named patch_name; into= extends an existing houseCARL patch. NOTE: a parent created in " +
-         "a PRIOR into= call isn't resolvable as a parent yet — create a parent and its children together in one call. Returns " +
-         "each new record's FormID + editorid, the patch path, and its (derived) masters.")]
+         "By default writes a fresh patch named patch_name; into= extends an existing houseCARL patch — and a parent created in " +
+         "a PRIOR into= call CAN be the parent here too (it's resolved from the patch being extended, not only the load order). " +
+         "Returns each new record's FormID + editorid, the patch path, and its (derived) masters.")]
     public static string BulkCreate(
         LoadOrderService svc,
         [Description("The records to create, all into one patch. Each: {record_type, editorid, operations?, parent?, collection?}. For a nested one-shot, declare the parent (e.g. a DialogTopic) BEFORE the children whose parent= names its editorid.")]


### PR DESCRIPTION
Brings **nested-record create** to the data layer, by construction: allocate a brand-new child record — a dialogue line (`DialogResponses`) under a topic, a placed ref into a cell — into the parent's modeled child-collection, with a fresh local 0x800+ FormKey, the flat create path unchanged and all-or-nothing preserved. This is the full **Layer A** of the nested/dialogue thread (9 commits, none previously landed); STEP 0 + the mechanism were built/proven in a prior session, this PR adds the CI guard, the public tool surface, and the N9 extend-gap fix.

## What it does
- **`housecarl_create_record`** gains optional `parent` / `collection` — create one nested child under an existing parent (an INFO into a topic, a placed ref into a cell); `collection=` names the child-list when more than one fits (e.g. a cell's `Persistent`).
- **`housecarl_bulk_create`** (new) — a records array, each spec exactly a `create_record` call. The **one-shot**: a parent and its children in ONE call, a child's `parent=` naming a same-call sibling by editorid (declare the topic before its lines). All-or-nothing.
- **The add-target is found by construction** (reflection over the parent's modeled collections) — never per-record-type hand-wiring. The add-target outcomes (unique / named / none / ambiguous) all fail loud (Q3).
- **N9 extend fix** — the patch is opened in a new Phase 0 *before* pre-flight, so a FormKey parent resolves from the load-order winner **or the patch being extended** (a parent created in a prior `into=` call). A patch-carried parent is used directly (full record, prior children retained); a genuinely-absent parent still refuses loud, naming both the load order and the patch.

## Coverage boundary (honest, failed-loud)
The FormKey-parented families (INFO / placed / navmesh / landscape) are supported. An **exterior cell** under a worldspace nests under FormKey-less block structs — a separate capability, still unsupported and refused loud. Re-running an extend appends (append-not-upsert, Aaron-accepted 2026-06-14).

## Proof
Two new self-contained CI guards (no Skyrim.esm), each **RED-proven** (the mechanism was broken, the guard observed to fail, then reverted):
- **`nested-create-guard`** — drives the real `CreateRecords` over a synthesized master (incl. a hand-built interior cell): the one-shot, multi-child + field edit (with edit-isolation), into-existing-topic/cell, the four Q3 rejects, and the extend working.
- **`bulk-create-guard`** — drives the real `LoadOrderService` (single + batch) over a synthetic MO2 instance: parent passthrough, the one-shot, batch all-or-nothing, the no-parent guidance copy.

Reviewed by an independent multi-agent adversarial pass (4 dimensions, every finding refuted against the code): **no correctness bugs** in the reorder, the wire, or the guards; the only findings were stale-copy/completeness, all fixed. Rebased onto current `main` (post asset-status #56) — clean, zero conflicts; all guards green in Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)