### PR TITLE
AtomicFile.Commit: crash-atomic File.Replace swap on every houseCARL final-swap write

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,9 +224,10 @@ jobs:
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- mo2instance-probe
 
       # Crash-atomic final-swap primitive (in-place-write-lane fix): AtomicFile.Commit — the File.Replace-over-existing /
-      # rename-onto-fresh swap that every houseCARL write now funnels through (the .esp commit, the BSA repack, the config
-      # save), replacing the product-wide File.Move(overwrite:true) named as not crash-atomic. Self-contained (temp files,
-      # no game data, no BSArch). The overwrite arm is RED-sensitive to a File.Move(overwrite) regression via the
-      # destination's preserved creation time, and self-skips that one check with a note on a file-system-tunneling host.
+      # rename-onto-fresh swap every houseCARL FINAL-SWAP write (commit of a staged temp over the target) now funnels
+      # through (the .esp commit, the BSA repack, the config save), replacing the product-wide File.Move(overwrite:true)
+      # named as not crash-atomic. Self-contained (temp files, no game data, no BSArch). The overwrite arm is RED-sensitive
+      # to a File.Move(overwrite) regression via the destination's preserved creation time, and self-skips that one check
+      # with a note on a file-system-tunneling host; arm C2 proves the locked-target mid-swap fails loud + non-destructive.
       - name: Probe — atomic-commit (crash-atomic File.Replace swap primitive)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- atomic-commit-guard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,3 +222,11 @@ jobs:
       # The real-instance arms (E5/E6) self-skip when Aaron's C:\MO2\Instance is absent; the synthetic edges run fully.
       - name: Probe — MO2 instance derivation (roots + profile + base_directory honesty)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- mo2instance-probe
+
+      # Crash-atomic final-swap primitive (in-place-write-lane fix): AtomicFile.Commit — the File.Replace-over-existing /
+      # rename-onto-fresh swap that every houseCARL write now funnels through (the .esp commit, the BSA repack, the config
+      # save), replacing the product-wide File.Move(overwrite:true) named as not crash-atomic. Self-contained (temp files,
+      # no game data, no BSArch). The overwrite arm is RED-sensitive to a File.Move(overwrite) regression via the
+      # destination's preserved creation time, and self-skips that one check with a note on a file-system-tunneling host.
+      - name: Probe — atomic-commit (crash-atomic File.Replace swap primitive)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- atomic-commit-guard

--- a/src/housecarl-core/AtomicFile.cs
+++ b/src/housecarl-core/AtomicFile.cs
@@ -1,0 +1,47 @@
+namespace HousecarlCore;
+
+/// <summary>
+/// Crash-atomic file commit — the one primitive every houseCARL write funnels its FINAL swap through.
+///
+/// A complete file is first STAGED into a temp on the SAME volume as its final path (the caller's job), then handed
+/// here. <see cref="Commit"/> swaps it into place with NO unlink-then-rename window:
+///
+///  • target EXISTS  → <c>File.Replace</c> (the Win32 <c>ReplaceFile</c> primitive): an atomic content swap that
+///    keeps the destination's on-disk IDENTITY (its NTFS file record). A crash mid-commit leaves either the OLD
+///    complete file or the NEW complete file — never a missing or half-written one. This is the crash-ATOMIC
+///    guarantee, stronger than the crash-TEAR safety a staged write already buys.
+///  • target ABSENT  → <c>File.Move</c> (an atomic rename onto a free name): <c>File.Replace</c> cannot create — it
+///    requires an existing target — so the fresh-file case it throws on is served by a rename, itself atomic.
+///
+/// This REPLACES the product-wide <c>File.Move(overwrite: true)</c> (MoveFileEx MOVEFILE_REPLACE_EXISTING), which the
+/// in-place-write-lane review named as not crash-atomic: it can unlink the destination BEFORE the rename commits, and
+/// it discards the destination's identity (the result becomes the SOURCE file). Same-volume staging is the caller's
+/// invariant — <c>File.Replace</c> THROWS across volumes (a loud, correct refusal) rather than silently degrading to a
+/// non-atomic copy (Q3).
+///
+/// Holds NO handle at rest: it opens nothing it keeps. Proven by the atomic-commit guard, whose overwrite arm is
+/// RED-sensitive to a <c>File.Move(overwrite)</c> regression via the destination's PRESERVED creation time
+/// (<c>File.Replace</c> keeps the replaced file's creation time; <c>File.Move</c> resets it). The guard self-calibrates:
+/// on a host where file-system tunneling would restore the creation time under <c>File.Move</c> too, that one check
+/// self-skips with a loud note rather than false-pass (the distinction is unprovable in-process there).
+/// </summary>
+internal static class AtomicFile
+{
+    /// <summary>Commit a fully-written <paramref name="stagedPath"/> onto <paramref name="finalPath"/> crash-atomically.
+    /// Both MUST be on the same volume. THROWS (never a silent no-op) if the staged file is missing or the swap fails —
+    /// the caller reports it (Q3); on any throw the prior <paramref name="finalPath"/>, if it existed, is byte-intact.</summary>
+    public static void Commit(string stagedPath, string finalPath)
+    {
+        try
+        {
+            File.Replace(stagedPath, finalPath, destinationBackupFileName: null);
+        }
+        catch (FileNotFoundException)
+        {
+            // File.Replace requires an existing destination; the fresh-file case (no prior output) it throws on is
+            // served by an atomic rename instead. A MISSING SOURCE also surfaces here — File.Move then re-throws,
+            // surfacing the real fault loud rather than masking it as a silent no-op.
+            File.Move(stagedPath, finalPath);
+        }
+    }
+}

--- a/src/housecarl-core/AtomicFile.cs
+++ b/src/housecarl-core/AtomicFile.cs
@@ -17,7 +17,9 @@ namespace HousecarlCore;
 /// in-place-write-lane review named as not crash-atomic: it can unlink the destination BEFORE the rename commits, and
 /// it discards the destination's identity (the result becomes the SOURCE file). Same-volume staging is the caller's
 /// invariant — <c>File.Replace</c> THROWS across volumes (a loud, correct refusal) rather than silently degrading to a
-/// non-atomic copy (Q3).
+/// non-atomic copy (Q3). An EFS-encrypted or specially-ACL'd target can likewise make <c>File.Replace</c> throw a
+/// metadata-merge error where <c>File.Move</c> would not — also surfaced loud, original byte-intact; the 3-arg overload
+/// is deliberate (the 4-arg <c>ignoreMetadataErrors: true</c> would silently swallow that failure, violating Q3).
 ///
 /// Holds NO handle at rest: it opens nothing it keeps. Proven by the atomic-commit guard, whose overwrite arm is
 /// RED-sensitive to a <c>File.Move(overwrite)</c> regression via the destination's PRESERVED creation time
@@ -36,12 +38,18 @@ internal static class AtomicFile
         {
             File.Replace(stagedPath, finalPath, destinationBackupFileName: null);
         }
+        // Catch FileNotFoundException ONLY, and deliberately: a cross-volume swap surfaces here as IOException
+        // (ERROR_UNABLE_TO_MOVE_REPLACEMENT_2) and, given the same-volume invariant, that's a caller bug we WANT loud
+        // with the original retained — widening this catch to IOException would silently degrade it into a non-atomic
+        // cross-volume copy (Q3). An EFS/special-ACL merge error likewise surfaces loud here, original byte-intact.
         catch (FileNotFoundException)
         {
             // File.Replace requires an existing destination; the fresh-file case (no prior output) it throws on is
-            // served by an atomic rename instead. A MISSING SOURCE also surfaces here — File.Move then re-throws,
-            // surfacing the real fault loud rather than masking it as a silent no-op.
-            File.Move(stagedPath, finalPath);
+            // served by a rename instead. overwrite:true keeps that branch idempotent against the (mutex-guarded,
+            // houseCARL-owned-path) sub-millisecond TOCTOU where the target appears between the probe and here — there
+            // is no original to lose on a path just judged fresh. A MISSING SOURCE still throws FileNotFoundException
+            // here, so File.Move re-throws it loud rather than masking it as a silent no-op.
+            File.Move(stagedPath, finalPath, overwrite: true);
         }
     }
 }

--- a/src/housecarl-core/BsaArchive.cs
+++ b/src/housecarl-core/BsaArchive.cs
@@ -148,7 +148,7 @@ public static class BsaArchive
             return new BsaResult(false, (run.stdout + "\n" + run.stderr).Trim(), run.runError);
         }
 
-        try { File.Move(tmp, archive, overwrite: true); }   // success → atomically replace the target (same volume = rename)
+        try { AtomicFile.Commit(tmp, archive); }   // success → crash-atomically swap the target (File.Replace / rename, same volume)
         catch (Exception ex)
         {
             try { if (File.Exists(tmp)) File.Delete(tmp); } catch { /* best-effort */ }

--- a/src/housecarl-core/UserConfig.cs
+++ b/src/housecarl-core/UserConfig.cs
@@ -109,7 +109,7 @@ public sealed class UserConfigStore
                 if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
                 var tmp = _path + ".tmp";
                 File.WriteAllText(tmp, JsonSerializer.Serialize(cfg, Json));
-                File.Move(tmp, _path, overwrite: true);   // atomic on the same volume — a reader never sees a torn file
+                AtomicFile.Commit(tmp, _path);   // crash-atomic swap (File.Replace / rename) — a reader never sees a torn or vanished file
                 return (true, null, note);
             }
             catch (Exception ex) { return (false, ex.Message, note); }

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1236,9 +1236,11 @@ public static class WriteEngine
         // ATOMIC WRITE (Q3): stage + commit. Serializing IN PLACE has two failure shapes once a patch lives in an
         // MO2 mods folder: a crash mid-serialize leaves a truncated .esp (a torn original), and an external folder
         // watcher (MO2 refreshing its plugin list) can open a half-written file. Staging into a sibling temp dir and
-        // committing via an atomic same-volume rename means the target path only ever holds the OLD complete file or
-        // the NEW complete file — never a partial one. NOTE: this does NOT relax the PR #24 self-lock guard
-        // (ReleaseOverlay + AllMastersExcept before the serialize): a rename onto a still-mapped target fails exactly
+        // committing via AtomicFile.Commit (File.Replace over an existing target — the Win32 atomic-replace primitive —
+        // or a rename onto a fresh one) means the target path only ever holds the OLD complete file or the NEW complete
+        // file, never a missing or partial one: true crash-ATOMIC replacement, not merely crash-TEAR safety. NOTE: this
+        // does NOT relax the PR #24 self-lock guard
+        // (ReleaseOverlay + AllMastersExcept before the serialize): a swap onto a still-mapped target fails exactly
         // like an in-place write would, so callers must still release every handle they hold on the target first.
         // Staging buys crash-tear safety and shrinks the external-watcher window; the handle discipline stays
         // load-bearing.
@@ -1272,12 +1274,13 @@ public static class WriteEngine
         }
     }
 
-    /// <summary>Stage 2 of the atomic write: rename the staged temp over the target — atomic on the same volume
-    /// (stage 1 guaranteed same-volume placement). Requires the PR #24 handle discipline to already hold (no handle
-    /// of ours on the target). Temp is removed afterward; a cleanup failure never masks the result (Q3).</summary>
+    /// <summary>Stage 2 of the atomic write: swap the staged temp over the target via AtomicFile.Commit — crash-atomic
+    /// File.Replace when the target exists, a rename when it does not (stage 1 guaranteed same-volume placement).
+    /// Requires the PR #24 handle discipline to already hold (no handle of ours on the target). Temp is removed
+    /// afterward; a cleanup failure never masks the result (Q3).</summary>
     static void CommitStagedPatch(string tmpPath, string outputPath)
     {
-        try { File.Move(tmpPath, outputPath, overwrite: true); }
+        try { AtomicFile.Commit(tmpPath, outputPath); }
         finally { CleanupStaged(tmpPath); }
     }
 

--- a/src/housecarl-generator/AtomicCommitProbe.cs
+++ b/src/housecarl-generator/AtomicCommitProbe.cs
@@ -1,0 +1,112 @@
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// atomic-commit guard — locks in AtomicFile.Commit, the crash-atomic final-swap primitive every houseCARL write now
+/// funnels through (the .esp commit WriteEngine.CommitStagedPatch, the BSA repack BsaArchive.Pack, the config save
+/// UserConfig.Update), replacing the product-wide File.Move(overwrite:true) the in-place-write-lane review named as not
+/// crash-atomic (MoveFileEx can unlink the destination before the rename commits, and resets its metadata).
+///
+/// A single process cannot power-cut mid-write, so this proves what IS observable, honestly (Q3):
+///   A  fresh file (target absent) — Commit lands the bytes via the rename branch; also guards that a File.Replace-ONLY
+///      regression (which throws on a missing target) is NOT what shipped.
+///   B  overwrite (target exists) — Commit replaces content BYTE-EXACT and the staged temp is consumed; AND, where the
+///      host's file-system tunneling does not mask it, the destination's CREATION TIME is PRESERVED → File.Replace, not
+///      File.Move(overwrite) which resets it. A self-calibrating CONTROL detects a tunneling host and SELF-SKIPS that
+///      one sub-check with a loud note rather than false-pass (the distinction is unprovable in-process there).
+///   C  failure is loud + non-destructive (Q3) — a Commit with a MISSING staged source THROWS (never a silent no-op)
+///      and the prior target survives byte-for-byte.
+///
+/// The crash-atomicity itself (no missing-file window on a power cut) is NOT demonstrable in-process and is NOT claimed
+/// here — only that the code takes File.Replace's atomic-replace path, not File.Move's. Self-contained: temp files
+/// only, no game data, no BSArch. Run: dotnet run --project src/housecarl-generator atomic-commit-guard
+/// </summary>
+internal static class AtomicCommitProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" atomic-commit guard — crash-atomic File.Replace swap primitive");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        var oldCreate = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var root = Path.Combine(Path.GetTempPath(), "hc-atomic-commit-guard-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            // ---- A: fresh file (target absent) — Commit renames the staged file into place ----
+            Console.WriteLine("--- A: fresh file (target absent) ---");
+            {
+                var staged = Path.Combine(root, "a.tmp");
+                var final = Path.Combine(root, "a.dat");
+                var bytes = new byte[] { 1, 2, 3, 4, 5 };
+                File.WriteAllBytes(staged, bytes);
+                AtomicFile.Commit(staged, final);
+                Check(File.Exists(final) && File.ReadAllBytes(final).SequenceEqual(bytes),
+                      "fresh target written byte-exact (rename branch; a File.Replace-only regression would throw here)");
+                Check(!File.Exists(staged), "staged temp consumed (fresh case)");
+            }
+
+            // ---- CONTROL: is file-system tunneling masking the creation-time signal on THIS host? A File.Move(overwrite)
+            //      with a distinctive OLD destination creation time: if the result KEEPS it, tunneling is active and the
+            //      creation-time arm cannot tell File.Replace from File.Move here. ----
+            bool tunnelingMasks;
+            {
+                var staged = Path.Combine(root, "ctl.tmp");
+                var final = Path.Combine(root, "ctl.dat");
+                File.WriteAllBytes(final, new byte[] { 0 });
+                File.SetCreationTimeUtc(final, oldCreate);
+                File.WriteAllBytes(staged, new byte[] { 1 });
+                File.Move(staged, final, overwrite: true);
+                tunnelingMasks = File.GetCreationTimeUtc(final) == oldCreate;
+                Console.WriteLine($"--- control: file-system tunneling {(tunnelingMasks ? "ACTIVE — creation-time arm self-skips (Q3)" : "off — creation-time arm has teeth")} ---");
+            }
+
+            // ---- B: overwrite (target exists) — byte-exact replace, staged consumed, creation time preserved (= File.Replace) ----
+            Console.WriteLine("--- B: overwrite (target exists) ---");
+            {
+                var staged = Path.Combine(root, "b.tmp");
+                var final = Path.Combine(root, "b.dat");
+                File.WriteAllBytes(final, new byte[] { 9, 9, 9 });
+                File.SetCreationTimeUtc(final, oldCreate);
+                var newBytes = new byte[] { 7, 7, 7, 7 };
+                File.WriteAllBytes(staged, newBytes);
+                AtomicFile.Commit(staged, final);
+                Check(File.ReadAllBytes(final).SequenceEqual(newBytes), "overwrite content is byte-exact the new staged bytes");
+                Check(!File.Exists(staged), "staged temp consumed (overwrite case)");
+                if (tunnelingMasks)
+                    Console.WriteLine("  SKIP  destination creation-time preserved — UNPROVABLE on a tunneling host (Q3, not a pass)");
+                else
+                    Check(File.GetCreationTimeUtc(final) == oldCreate,
+                          "destination creation time preserved — File.Replace, not File.Move(overwrite)  [RED arm]");
+            }
+
+            // ---- C: failure is loud + non-destructive (Q3) — missing staged source throws; prior target byte-intact ----
+            Console.WriteLine("--- C: failure is loud + non-destructive (Q3) ---");
+            {
+                var staged = Path.Combine(root, "does-not-exist.tmp");
+                var final = Path.Combine(root, "c.dat");
+                var prior = new byte[] { 4, 2 };
+                File.WriteAllBytes(final, prior);
+                bool threw = false;
+                try { AtomicFile.Commit(staged, final); } catch { threw = true; }
+                Check(threw, "a missing staged source THROWS (never a silent no-op)");
+                Check(File.Exists(final) && File.ReadAllBytes(final).SequenceEqual(prior),
+                      "prior target survives the failed commit byte-for-byte");
+            }
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { /* a lingering lock would itself be telling */ }
+        }
+
+        Console.WriteLine();
+        if (fail == 0) Console.WriteLine("================ ALL CHECKS PASSED ================");
+        else Console.WriteLine($"================ {fail} CHECK(S) FAILED ================");
+        return fail == 0 ? 0 : 1;
+    }
+}

--- a/src/housecarl-generator/AtomicCommitProbe.cs
+++ b/src/housecarl-generator/AtomicCommitProbe.cs
@@ -3,20 +3,25 @@ using HousecarlCore;
 namespace HousecarlGenerator;
 
 /// <summary>
-/// atomic-commit guard — locks in AtomicFile.Commit, the crash-atomic final-swap primitive every houseCARL write now
-/// funnels through (the .esp commit WriteEngine.CommitStagedPatch, the BSA repack BsaArchive.Pack, the config save
-/// UserConfig.Update), replacing the product-wide File.Move(overwrite:true) the in-place-write-lane review named as not
-/// crash-atomic (MoveFileEx can unlink the destination before the rename commits, and resets its metadata).
+/// atomic-commit guard — locks in AtomicFile.Commit, the crash-atomic primitive every houseCARL FINAL-SWAP write (the
+/// commit of a staged temp over the target) now funnels through (the .esp commit WriteEngine.CommitStagedPatch, the BSA
+/// repack BsaArchive.Pack, the config save UserConfig.Update), replacing the product-wide File.Move(overwrite:true) the
+/// in-place-write-lane review named as not crash-atomic (MoveFileEx can unlink the destination before the rename
+/// commits, and resets its metadata). (Fresh-CREATE writes — DecompileTools' FileMode.CreateNew, the meta.ini
+/// File.WriteAllText — do NOT funnel through it, by design: there is no original to lose.)
 ///
 /// A single process cannot power-cut mid-write, so this proves what IS observable, honestly (Q3):
-///   A  fresh file (target absent) — Commit lands the bytes via the rename branch; also guards that a File.Replace-ONLY
-///      regression (which throws on a missing target) is NOT what shipped.
+///   A  fresh file (target absent) — Commit lands the bytes via the rename branch (and must not throw — a clean FAIL,
+///      not an uncaught crash, if a File.Replace-only regression dropped the fallback).
 ///   B  overwrite (target exists) — Commit replaces content BYTE-EXACT and the staged temp is consumed; AND, where the
 ///      host's file-system tunneling does not mask it, the destination's CREATION TIME is PRESERVED → File.Replace, not
 ///      File.Move(overwrite) which resets it. A self-calibrating CONTROL detects a tunneling host and SELF-SKIPS that
 ///      one sub-check with a loud note rather than false-pass (the distinction is unprovable in-process there).
-///   C  failure is loud + non-destructive (Q3) — a Commit with a MISSING staged source THROWS (never a silent no-op)
-///      and the prior target survives byte-for-byte.
+///   C  PRE-swap failure is loud + non-destructive (Q3) — a Commit with a MISSING staged source THROWS (never a silent
+///      no-op) and the prior target survives byte-for-byte.
+///   C2 MID-swap failure is loud + non-destructive (Q3) — the operationally-relevant case the staging exists to defend:
+///      a valid staged source but the target HELD by an external holder (MO2/xEdit/the running game) → Commit THROWS and
+///      the prior target survives byte-for-byte.
 ///
 /// The crash-atomicity itself (no missing-file window on a power cut) is NOT demonstrable in-process and is NOT claimed
 /// here — only that the code takes File.Replace's atomic-replace path, not File.Move's. Self-contained: temp files
@@ -45,10 +50,19 @@ internal static class AtomicCommitProbe
                 var final = Path.Combine(root, "a.dat");
                 var bytes = new byte[] { 1, 2, 3, 4, 5 };
                 File.WriteAllBytes(staged, bytes);
-                AtomicFile.Commit(staged, final);
-                Check(File.Exists(final) && File.ReadAllBytes(final).SequenceEqual(bytes),
-                      "fresh target written byte-exact (rename branch; a File.Replace-only regression would throw here)");
-                Check(!File.Exists(staged), "staged temp consumed (fresh case)");
+                try
+                {
+                    AtomicFile.Commit(staged, final);
+                    Check(File.Exists(final) && File.ReadAllBytes(final).SequenceEqual(bytes),
+                          "fresh target written byte-exact (rename branch)");
+                    Check(!File.Exists(staged), "staged temp consumed (fresh case)");
+                }
+                catch (Exception ex)
+                {
+                    // A File.Replace-ONLY regression (rename fallback dropped) would throw on the absent target — report
+                    // a clean FAIL so arms B/C/C2 still run, rather than dying with an uncaught stack trace.
+                    Check(false, $"fresh-file Commit must not throw (rename fallback missing?) — {ex.GetType().Name}: {ex.Message}");
+                }
             }
 
             // ---- CONTROL: is file-system tunneling masking the creation-time signal on THIS host? A File.Move(overwrite)
@@ -85,8 +99,8 @@ internal static class AtomicCommitProbe
                           "destination creation time preserved — File.Replace, not File.Move(overwrite)  [RED arm]");
             }
 
-            // ---- C: failure is loud + non-destructive (Q3) — missing staged source throws; prior target byte-intact ----
-            Console.WriteLine("--- C: failure is loud + non-destructive (Q3) ---");
+            // ---- C: PRE-swap failure is loud + non-destructive (Q3) — missing staged source throws; prior intact ----
+            Console.WriteLine("--- C: pre-swap failure is loud + non-destructive (Q3) ---");
             {
                 var staged = Path.Combine(root, "does-not-exist.tmp");
                 var final = Path.Combine(root, "c.dat");
@@ -96,7 +110,28 @@ internal static class AtomicCommitProbe
                 try { AtomicFile.Commit(staged, final); } catch { threw = true; }
                 Check(threw, "a missing staged source THROWS (never a silent no-op)");
                 Check(File.Exists(final) && File.ReadAllBytes(final).SequenceEqual(prior),
-                      "prior target survives the failed commit byte-for-byte");
+                      "prior target survives the failed pre-swap commit byte-for-byte");
+            }
+
+            // ---- C2: MID-swap failure is loud + non-destructive (Q3) — the threat staging exists to defend: a VALID
+            //      staged source, but the target is HELD by an external holder (MO2/xEdit/the running game). File.Replace
+            //      opens the destination first → can't (FileShare.None) → throws (IOException, NOT FileNotFoundException,
+            //      so Commit does NOT fall through to a rename) → Commit propagates loud, prior target byte-intact. ----
+            Console.WriteLine("--- C2: mid-swap failure on an externally-locked target (Q3) ---");
+            {
+                var staged = Path.Combine(root, "c2.tmp");
+                var final = Path.Combine(root, "c2.dat");
+                var prior = new byte[] { 5, 5, 5, 5, 5 };
+                File.WriteAllBytes(final, prior);
+                File.WriteAllBytes(staged, new byte[] { 8, 8 });
+                bool threw = false;
+                using (new FileStream(final, FileMode.Open, FileAccess.Read, FileShare.None))   // an external holder
+                {
+                    try { AtomicFile.Commit(staged, final); } catch { threw = true; }
+                }
+                Check(threw, "a mid-swap failure on a locked target THROWS (never a silent no-op)");
+                Check(File.Exists(final) && File.ReadAllBytes(final).SequenceEqual(prior),
+                      "prior target survives the failed mid-swap byte-for-byte");
             }
         }
         finally

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -279,6 +279,12 @@ if (args.Length > 0 && args[0] == "nested-create-guard") return NestedCreateGuar
 // nested-no-parent guidance copy.
 if (args.Length > 0 && args[0] == "bulk-create-guard") return BulkCreateGuardProbe.RunGuard(args[1..]);
 
+// crash-atomic final-swap primitive (in-place-write-lane fix): SELF-CONTAINED CI guard for AtomicFile.Commit — the
+// File.Replace-over-existing / rename-onto-fresh swap that every houseCARL write now funnels through, replacing the
+// product-wide File.Move(overwrite:true). Overwrite arm is RED-sensitive to a File.Move regression via the
+// destination's preserved creation time, self-skipping that one check (with a note) on a file-system-tunneling host.
+if (args.Length > 0 && args[0] == "atomic-commit-guard") return AtomicCommitProbe.RunGuard(args[1..]);
+
 // External-tool bridge (step 1) proof: the pure core pieces housecarl_set_tool_path + the riders ride — shared-config
 // clobber-safety, path validation, the missing-dependency forcing prompt, and canonical-home auto-detect.
 if (args.Length > 0 && args[0] == "tool-bridge") return ToolBridgeProbe.Run(args[1..]);

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -280,9 +280,10 @@ if (args.Length > 0 && args[0] == "nested-create-guard") return NestedCreateGuar
 if (args.Length > 0 && args[0] == "bulk-create-guard") return BulkCreateGuardProbe.RunGuard(args[1..]);
 
 // crash-atomic final-swap primitive (in-place-write-lane fix): SELF-CONTAINED CI guard for AtomicFile.Commit — the
-// File.Replace-over-existing / rename-onto-fresh swap that every houseCARL write now funnels through, replacing the
-// product-wide File.Move(overwrite:true). Overwrite arm is RED-sensitive to a File.Move regression via the
-// destination's preserved creation time, self-skipping that one check (with a note) on a file-system-tunneling host.
+// File.Replace-over-existing / rename-onto-fresh swap every houseCARL FINAL-SWAP write (commit of a staged temp over the
+// target) now funnels through, replacing the product-wide File.Move(overwrite:true). Overwrite arm is RED-sensitive to a
+// File.Move regression via the destination's preserved creation time, self-skipping that one check (with a note) on a
+// file-system-tunneling host; arm C2 proves the locked-target mid-swap fails loud + non-destructive.
 if (args.Length > 0 && args[0] == "atomic-commit-guard") return AtomicCommitProbe.RunGuard(args[1..]);
 
 // External-tool bridge (step 1) proof: the pure core pieces housecarl_set_tool_path + the riders ride — shared-config


### PR DESCRIPTION
## What

Replaces the product-wide `File.Move(..., overwrite: true)` final-swap (= `MoveFileEx(MOVEFILE_REPLACE_EXISTING)`, **not** crash-atomic — it can unlink the destination *before* the rename commits, and it resets the destination's metadata) with a single shared primitive, **`AtomicFile.Commit(staged, final)`**:

- target **exists** → `File.Replace` (the Win32 `ReplaceFile` atomic content swap) — a crash leaves either the OLD or the NEW complete file, never a missing/partial one;
- target **absent** → `File.Move(overwrite: true)` (atomic rename) for the fresh-file case `File.Replace` can't serve (it requires an existing target → `FileNotFoundException` → fallback).

Wired into the three sites that committed a staged temp over a target:
- `WriteEngine.CommitStagedPatch` — the `.esp` write (**every** product record write funnels through it)
- `BsaArchive.Pack` — the BSA repack
- `UserConfig.Update` — the config save (under a cross-process lock)

Same-volume staging stays the caller's invariant (all three stage a sibling temp in the target's own parent dir); `File.Replace` throws across volumes (a loud, correct refusal) rather than silently degrading to a non-atomic copy. The `catch` is `FileNotFoundException`-only **by design** — widening it would swallow the cross-volume / EFS-merge refusals.

This is the shared crash-atomic primitive `housecarl_place_asset` (facegen Phase 3, PR-B) builds on; landing it standalone first hardens every existing write now.

## Proof — `atomic-commit-guard` (CI generator-probe steps 30 → 31)

Self-contained (temp files only, no game data, no BSArch). A single process can't power-cut, so it proves what *is* observable, honestly:
- **A** fresh-file rename branch (clean FAIL, not a crash, if the fallback were dropped)
- **B** byte-exact overwrite + staged consumed + **destination creation time preserved** (`File.Replace`, not `File.Move`) — **RED-proven**: reverting `Commit` to `File.Move(overwrite)` fails this arm. A self-calibrating control detects a file-system-**tunneling** host and self-skips that one check with a note rather than false-pass (the distinction is unprovable in-process there).
- **C** pre-swap failure loud + non-destructive (missing source throws; prior intact)
- **C2** mid-swap failure loud + non-destructive — target HELD by an external holder (MO2/xEdit/the running game), the exact threat staging defends; **RED-proven** (swallowing the mid-swap `IOException` fails C2).

Empirical note: a diagnostic this session showed **both** `File.Replace` and `File.Move` give the result the *source's* NTFS file id — so file id can't distinguish them; creation-time is the working signal.

## Review

Adversarial 4-dimension review (API semantics / call-site blast-radius / probe rigor / completeness) + per-finding verification → **APPROVE-WITH-NITS, no blockers**. The migration is complete (the only remaining `File.Move(...,overwrite)` are generator probes, not production) and the stricter-`File.Replace` risk decomposes into three narrow classes — cross-volume (unreachable by construction), EFS/ACL merge, fresh-file TOCTOU — **all loud + non-destructive; the original is never silently lost.** All findings fixed in commits 3–4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)