### PR TITLE
facegen Phase 3 PR-B: housecarl_place_asset + housecarl_bulk_place_asset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,3 +231,15 @@ jobs:
       # with a note on a file-system-tunneling host; arm C2 proves the locked-target mid-swap fails loud + non-destructive.
       - name: Probe — atomic-commit (crash-atomic File.Replace swap primitive)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- atomic-commit-guard
+
+      # Place asset (facegen-diagnostics Phase 3 — housecarl_place_asset / housecarl_bulk_place_asset): the WRITE side of
+      # dark-face repair. Locks in the FormKey->FaceGen-path keystone (defining-master folder + masked id, matched against
+      # the committed fixture's entry name), native BSA single-entry extraction with ZERO handles at rest (the .bsa stays
+      # renamable/deletable after — the cornerstone), the crash-atomic non-destructive place (routes through
+      # AtomicFile.WriteAllBytes -> Commit; the creation-time arm is RED to a File.Move regression, self-skipping on a
+      # tunneling host), the precise placer (explicit + auto-resolved source; ambiguity REFUSED, never guessed), the
+      # wins-VFS end-to-end story through the REAL service (place over a wrong winner, enable on top -> it wins
+      # svc.AssetStatus), and the Q3 refusals (drive-rooted/'..', malformed tool specs). Self-contained: synthetic
+      # folders/instances + the committed FixtureA.bsa (fixtures/asset-resolver/), so it runs here with NO BSArch.
+      - name: Probe — place asset (FaceGen-path keystone + precise placer + BSA extract + wins-VFS)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- place-asset-guard

--- a/src/housecarl-core/AssetResolver.cs
+++ b/src/housecarl-core/AssetResolver.cs
@@ -69,6 +69,20 @@ public sealed record AssetProvider(string Source, AssetKind Kind);
 /// VERIFY, not a confirmed desync.</summary>
 public sealed record AssetHit(string RelPath, bool Exists, AssetProvider? Winner, IReadOnlyList<AssetProvider> Providers, bool Ambiguous);
 
+/// <summary>A CONCRETE, on-disk source one provider supplies an asset from — enough to READ its bytes (the place-asset
+/// auto-resolve, facegen-diagnostics Phase 3). For a LOOSE provider, <see cref="LooseFilePath"/> is the file on disk and
+/// <see cref="ArchivePath"/>/<see cref="EntryPath"/> describe nothing. For a BSA provider, <see cref="ArchivePath"/> is the
+/// .bsa on disk and <see cref="EntryPath"/> is the file inside it (read via <see cref="AssetResolver.TryReadArchiveEntry"/>);
+/// <see cref="LooseFilePath"/> is null. <see cref="ProviderName"/>/<see cref="Kind"/> mirror <see cref="AssetProvider"/>.</summary>
+public sealed record PlacementSource(string ProviderName, AssetKind Kind, string? LooseFilePath, string? ArchivePath, string EntryPath);
+
+/// <summary>Concrete-source resolution of one asset path for PLACEMENT (place_asset's auto-resolve when no explicit
+/// source= is given): every provider with its on-disk descriptor, winner FIRST (the same precedence
+/// <see cref="AssetHit"/> reports — they share one code path), an <see cref="Ambiguous"/> flag (&gt;1 provider), and the
+/// build-level <see cref="ReadIncomplete"/> caveat (a BSA failed to read this build, so a missing source may merely be
+/// unscanned — Q3). <see cref="Sources"/> empty ⇒ nothing active provides this path.</summary>
+public sealed record PlacementResolution(string RelPath, IReadOnlyList<PlacementSource> Sources, bool Ambiguous, bool ReadIncomplete);
+
 /// <summary>An active BSA the resolver should consider: its full path, the plugin it loads with, and that plugin's
 /// load-order rank (higher = later in load order = wins among BSAs). The service derives these; the probe injects them.</summary>
 public sealed record ActiveArchive(string Path, string OwningPlugin, int PluginRank);
@@ -213,6 +227,31 @@ public sealed class AssetResolver : IDisposable
         return set;
     }
 
+    /// <summary>Read ONE entry's bytes out of a BSA with Mutagen's NATIVE archive surface (no BSArch) — the single-entry
+    /// extraction place_asset uses for a source inside a BSA (a CC NPC's facegen, base-game assets). Returns a FRESH
+    /// byte[] (<c>IArchiveFile.GetBytes</c> allocates a new array — nothing to dispose), and holds ZERO handle at rest:
+    /// the reader isn't IDisposable in 0.53.1 and nothing keeps the archive mapped after this returns, so the .bsa stays
+    /// renamable/deletable (the cornerstone the place guard's at-rest arm proves on the EXTRACTION path, not just the
+    /// table read). <paramref name="entryPath"/> is matched <see cref="Normalize"/>'d (backslash, OrdinalIgnoreCase)
+    /// against the archive table. Returns null if the entry isn't in the archive; lets an archive that can't be opened/read
+    /// THROW (loud, Q3) so the caller reports it — never a silent empty result.</summary>
+    public static byte[]? TryReadArchiveEntry(string archivePath, string entryPath)
+    {
+        var want = Normalize(entryPath);
+        var reader = Archive.CreateReader(GameRelease.SkyrimSE, archivePath);
+        try
+        {
+            foreach (var file in reader.Files)
+                // OrdinalIgnoreCase — BSA tables store paths lowercased, so an ordinal (case-sensitive) compare against a
+                // mixed-case query (e.g. "Dawnguard.esm\0001A51A.nif") would MISS the entry; matches ReadArchiveTable's
+                // case-insensitive table (Q3: a case mismatch must never read as "entry absent").
+                if (string.Equals(Normalize(file.Path), want, StringComparison.OrdinalIgnoreCase))
+                    return file.GetBytes();                        // fresh array; no held handle (see the summary)
+            return null;                                           // archive read fine, entry simply not present
+        }
+        finally { (reader as IDisposable)?.Dispose(); }           // INERT in 0.53.1 — belt-and-braces, see ReadArchiveTable
+    }
+
     /// <summary>Resolve one Data-relative asset path: where it lives and which copy wins. See <see cref="AssetHit"/>.
     /// Single-shot — this call captures its own build; a caller making MANY reads in one logical operation should
     /// <see cref="Capture"/> once and read off the view so the scan and its failure list share one build.</summary>
@@ -221,38 +260,62 @@ public sealed class AssetResolver : IDisposable
     AssetHit Resolve(string relPath, Snapshot snap)
     {
         var rel = NormalizeQueryPath(relPath);
+        var sources = ResolveProviders(rel, snap);                 // ONE precedence path, winner first (shared with placement)
+        if (sources.Count == 0)
+            return new AssetHit(rel, false, null, Array.Empty<AssetProvider>(), false);
+        // Project the concrete sources down to the display providers — the on-disk paths are placement-only.
+        var providers = sources.Select(s => new AssetProvider(s.ProviderName, s.Kind)).ToList();
+        // Ambiguous when >1 source provides it (contention), or a loose copy coexists with a BSA copy (the edge the
+        // common-rule model can't promise exactly under MO2 managed archives).
+        return new AssetHit(rel, true, providers[0], providers, providers.Count > 1);
+    }
 
+    /// <summary>The ONE precedence resolution both the display answer (<see cref="Resolve"/>) and the placement answer
+    /// (<see cref="ResolveForPlacement"/>) ride, so the two can never drift: loose (overwrite &gt; mod-priority &gt; Data,
+    /// first sighting wins) BEATS BSA (higher plugin rank wins; archive filename a deterministic tie-break). Returns each
+    /// provider with its CONCRETE on-disk descriptor (loose file path; or .bsa path + the entry inside it), WINNER FIRST.
+    /// <paramref name="rel"/> is already <see cref="NormalizeQueryPath"/>'d by the caller. Pure read over the snapshot.</summary>
+    List<PlacementSource> ResolveProviders(string rel, Snapshot snap)
+    {
         // ---- loose, in MO2 precedence order — via the per-subtree cache (warmed on first touch) ----
         var subtreeDir = Normalize(Path.GetDirectoryName(rel) ?? "");
         var fname = Path.GetFileName(rel);
         var st = snap.LooseCache.GetOrAdd(subtreeDir, WarmSubtree);
-        var loose = new List<AssetProvider>();
+        var loose = new List<PlacementSource>();
         foreach (var (rootIndex, files) in st.Present)               // Present is already in precedence order
             if (files.Contains(fname))
-                loose.Add(new AssetProvider(_looseRoots[rootIndex].Name, AssetKind.Loose));
+                loose.Add(new PlacementSource(_looseRoots[rootIndex].Name, AssetKind.Loose,
+                    LooseFilePath: Path.Combine(_looseRoots[rootIndex].Dir, rel), ArchivePath: null, EntryPath: rel));
 
         // ---- BSA, highest plugin rank first ----
-        var bsa = new List<(AssetProvider provider, int rank)>();
+        var bsa = new List<(PlacementSource source, int rank)>();
         foreach (var a in _archives)
             if (snap.Tables.TryGetValue(a.Path, out var t) && t.Contains(rel))
-                bsa.Add((new AssetProvider(Path.GetFileName(a.Path), AssetKind.Bsa), a.PluginRank));
+                bsa.Add((new PlacementSource(Path.GetFileName(a.Path), AssetKind.Bsa,
+                    LooseFilePath: null, ArchivePath: a.Path, EntryPath: rel), a.PluginRank));
         // Higher plugin rank wins; the archive filename is a DETERMINISTIC tie-break so equal-rank BSAs (a plugin can
         // ship more than one) order stably across runs rather than by hash/enumeration order.
         var bsaOrdered = bsa.OrderByDescending(b => b.rank)
-                            .ThenBy(b => b.provider.Source, StringComparer.OrdinalIgnoreCase)
-                            .Select(b => b.provider).ToList();
+                            .ThenBy(b => b.source.ProviderName, StringComparer.OrdinalIgnoreCase)
+                            .Select(b => b.source);
 
-        // ---- winner: loose beats BSA; providers = winner first, then the rest in precedence ----
-        var providers = new List<AssetProvider>(loose);
+        // winner: loose beats BSA; the list is winner first, then the rest in precedence.
+        var providers = new List<PlacementSource>(loose);
         providers.AddRange(bsaOrdered);
-        if (providers.Count == 0)
-            return new AssetHit(rel, false, null, providers, false);
+        return providers;
+    }
 
-        var winner = providers[0];                                 // loose[0] if any loose, else bsaOrdered[0]
-        // Ambiguous when >1 source provides it (contention), or a loose copy coexists with a BSA copy (the edge the
-        // common-rule model can't promise exactly under MO2 managed archives).
-        bool ambiguous = providers.Count > 1;
-        return new AssetHit(rel, true, winner, providers, ambiguous);
+    /// <summary>Resolve one Data-relative asset path to its CONCRETE on-disk sources for PLACEMENT (place_asset): every
+    /// provider winner-first with the file/archive path needed to read its bytes, plus the ambiguity + read-incomplete
+    /// caveats. The auto-resolve half of the precise placer — exactly ONE source means an unambiguous copy to re-assert;
+    /// &gt;1 (ambiguous) means the caller must pick a source= (Q3). Rejects a drive-rooted / '..' path loud, like
+    /// <see cref="Resolve"/>. Single-shot against the current build; holds nothing.</summary>
+    public PlacementResolution ResolveForPlacement(string relPath)
+    {
+        var snap = _snap;                                          // pin one build for this resolution
+        var rel = NormalizeQueryPath(relPath);
+        var sources = ResolveProviders(rel, snap);
+        return new PlacementResolution(rel, sources, sources.Count > 1, snap.Failures.Count > 0);
     }
 
     /// <summary>Resolve many paths in one call (the facegen bulk scan), all against ONE pinned build so the whole scan
@@ -364,6 +427,13 @@ public sealed class AssetResolver : IDisposable
     /// OrdinalIgnoreCase (Windows + BSA tables are case-insensitive), so case is left as-is and compared case-insensitively.
     /// Lenient — applied to BSA-table entries (already archive-relative), so it never throws.</summary>
     static string Normalize(string p) => (p ?? "").Replace('/', '\\').TrimStart('\\');
+
+    /// <summary>Public, reusable gate: normalize + VALIDATE a Data-relative path, REJECTING a drive-rooted or
+    /// parent-escaping one — the SAME check <see cref="Resolve"/> applies (it delegates to <see cref="NormalizeQueryPath"/>),
+    /// exposed so the place path validates a destination through this ONE validator rather than a divergent copy
+    /// (place_asset writes to Path.Combine(modRoot, rel), so the same escape would write OUTSIDE the owned folder — Q3).
+    /// Throws ArgumentException naming the bad input; returns the normalized (backslash, no leading sep) path.</summary>
+    public static string ValidateRelPath(string relPath) => NormalizeQueryPath(relPath);
 
     /// <summary>Normalize AND validate a Data-relative QUERY path. After the lenient <see cref="Normalize"/>, REJECT a
     /// drive-rooted path ("C:\…") or one carrying a ".." segment — both make <c>Path.Combine(root, rel)</c> ESCAPE the

--- a/src/housecarl-core/AtomicFile.cs
+++ b/src/housecarl-core/AtomicFile.cs
@@ -27,8 +27,33 @@ namespace HousecarlCore;
 /// on a host where file-system tunneling would restore the creation time under <c>File.Move</c> too, that one check
 /// self-skips with a loud note rather than false-pass (the distinction is unprovable in-process there).
 /// </summary>
-internal static class AtomicFile
+// PUBLIC (facegen-diagnostics Phase 3): place_asset writes from the MCP layer (not a core friend), so the primitive is
+// public. <see cref="Commit"/> is the low-level swap (caller stages same-volume); <see cref="WriteAllBytes"/> is the
+// high-level convenience that does the same-volume staging for you (it materializes the bytes into a sibling temp, so a
+// cross-volume SOURCE never reaches Commit). The .esp/BSA/config writers keep calling Commit directly with their own staging.
+public static class AtomicFile
 {
+    /// <summary>Crash-atomically write <paramref name="bytes"/> to <paramref name="finalPath"/>: stage them into a SIBLING
+    /// temp (same volume as the target, so the swap is never cross-volume — the place tool may read its source from another
+    /// volume or a BSA, but the bytes are in hand by here) and <see cref="Commit"/> it into place. The caller must have
+    /// created the destination directory. THROWS (Q3, never a silent partial write) on any failure, deleting the temp first
+    /// so no scratch is left; on a throw the prior <paramref name="finalPath"/>, if any, is byte-intact (Commit's guarantee).</summary>
+    public static void WriteAllBytes(string finalPath, byte[] bytes)
+    {
+        var staged = finalPath + ".houseCARL-tmp";                 // sibling of the target ⇒ same volume ⇒ Commit's invariant holds
+        try { if (File.Exists(staged)) File.Delete(staged); } catch { /* a stuck temp surfaces on the write below */ }
+        try
+        {
+            File.WriteAllBytes(staged, bytes);
+            Commit(staged, finalPath);
+        }
+        catch
+        {
+            try { if (File.Exists(staged)) File.Delete(staged); } catch { /* best-effort: never mask the real failure */ }
+            throw;
+        }
+    }
+
     /// <summary>Commit a fully-written <paramref name="stagedPath"/> onto <paramref name="finalPath"/> crash-atomically.
     /// Both MUST be on the same volume. THROWS (never a silent no-op) if the staged file is missing or the swap fails —
     /// the caller reports it (Q3); on any throw the prior <paramref name="finalPath"/>, if it existed, is byte-intact.</summary>

--- a/src/housecarl-core/FaceGenPath.cs
+++ b/src/housecarl-core/FaceGenPath.cs
@@ -1,0 +1,58 @@
+using Mutagen.Bethesda.Plugins;
+
+namespace HousecarlCore;
+
+// ======================================================================
+//  FaceGenPath — the FaceGen asset path is a PURE TRANSFORM of an NPC's FormKey
+//  (facegen-diagnostics; Aaron-locked keystone 2026-06-14). NO load order, NO runtime
+//  FormID, NO file read: just the FormKey → the two Data-relative paths the game looks
+//  the NPC's generated head geometry + tint up under.
+//
+//  THE RULE (the keystone the whole dark-face feature rests on — get it wrong and you
+//  resolve/place a DIFFERENT NPC's asset, a Q3 silent-wrong answer):
+//    • FOLDER  = the DEFINING MASTER — the plugin in the FormKey 'XXXXXX:Plugin.esp'
+//      (fk.ModKey.FileName), NOT the conflict winner. The CK writes an NPC's facegen under
+//      the folder named for the plugin that DEFINES the record, so the path is stable across
+//      load order (the record winner can change; the defining plugin in the FormKey cannot).
+//    • FILE    = the load-order index byte MASKED to "00", then the 6-hex local FormID:
+//      "00" + fk.ID("X6"). The index byte is masked because the file lives in the defining
+//      plugin's OWN named folder — the index is redundant there, so the on-disk convention
+//      normalizes it to 00 (the same masking xEdit applies to voice/InfoFileName paths; see
+//      memory reference_skyrim_voice_file_naming). fk.ID is Mutagen's 24-bit local id, so
+//      "00" + the 6 hex == the 8-hex filename the CK/loose mods/CC BSAs use.
+//      e.g. 01A51A:Dawnguard.esm → "0001A51A" (matches the committed fixtures/asset-resolver
+//      facegen entry facegeom\Dawnguard.esm\0001A51A.nif).
+//
+//    • MESH (.nif): meshes\actors\character\facegendata\facegeom\<Master>\00<6hex>.nif
+//    • TINT (.dds): textures\actors\character\facegendata\facetint\<Master>\00<6hex>.dds
+//
+//  Built in core (not in the place tool) so the read side (housecarl_asset_status / a future
+//  read-tool consumer) can reuse the EXACT same transform — one home for the keystone, never
+//  two subtly-different copies. Backslash-separated (the AssetResolver match form is
+//  backslash, OrdinalIgnoreCase). Hex is UPPERCASE to match the CK's on-disk convention;
+//  resolution is case-insensitive regardless.
+// ======================================================================
+
+/// <summary>Which FaceGen file: the head MESH geometry (.nif under facegeom) or the face TINT texture
+/// (.dds under facetint). An NPC's appearance needs BOTH in sync — a dark/grey face is usually the tint
+/// (facetint .dds) desynced from the geometry, but both are placed together to fully resolve it.</summary>
+public enum FaceGenSlot { Mesh, Tint }
+
+public static class FaceGenPath
+{
+    /// <summary>The Data-relative FaceGen path for one NPC FormKey + slot — the pure transform (see the file header).
+    /// Folder = the defining master (fk.ModKey.FileName); file = "00" + the 6-hex local FormID. Backslash-separated.</summary>
+    public static string For(FormKey fk, FaceGenSlot slot)
+    {
+        var master = fk.ModKey.FileName.ToString();          // the DEFINING plugin in the FormKey — never the winner
+        var name = "00" + fk.ID.ToString("X6");              // index byte masked to 00, then the 6-hex local id
+        return slot == FaceGenSlot.Mesh
+            ? $@"meshes\actors\character\facegendata\facegeom\{master}\{name}.nif"
+            : $@"textures\actors\character\facegendata\facetint\{master}\{name}.dds";
+    }
+
+    /// <summary>Both FaceGen paths for one NPC, mesh first — the dark-face pair placed together. Each entry is the
+    /// slot and its Data-relative path.</summary>
+    public static IReadOnlyList<(FaceGenSlot Slot, string RelPath)> Both(FormKey fk)
+        => new[] { (FaceGenSlot.Mesh, For(fk, FaceGenSlot.Mesh)), (FaceGenSlot.Tint, For(fk, FaceGenSlot.Tint)) };
+}

--- a/src/housecarl-generator/PlaceAssetProbe.cs
+++ b/src/housecarl-generator/PlaceAssetProbe.cs
@@ -1,0 +1,355 @@
+using HousecarlCore;
+using HousecarlMcp;
+using Mutagen.Bethesda.Plugins;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// place-asset guard (facegen-diagnostics Phase 3 — housecarl_place_asset / housecarl_bulk_place_asset). Proves the
+/// WRITE side of dark-face repair: the FormKey→FaceGen-path keystone, the precise placer (explicit + auto-resolved
+/// source), in-process BSA single-entry extraction with ZERO handles at rest (the cornerstone), the crash-atomic
+/// non-destructive write, the wins-VFS end-to-end story through the REAL service, and the Q3 refusals.
+///
+/// PURE / CORE arms (no MO2 instance):
+///   A  FaceGen-path transform — folder = the DEFINING master (NOT a winner), file = "00" + the 6-hex local id
+///      (index masked), mesh under facegeom/.nif, tint under facetint/.dds; matches the committed fixture name. [RED:
+///      the keystone — a wrong mask/folder places a DIFFERENT NPC's asset.]
+///   B  native BSA single-entry extraction — TryReadArchiveEntry pulls the right bytes out of the committed FixtureA.bsa,
+///      returns null for an absent entry, AND holds ZERO handle at rest (the .bsa stays renamable/deletable after). [RED:
+///      the cornerstone — a held handle would block MO2/xEdit.]
+///   C  crash-atomic routing — AtomicFile.WriteAllBytes overwrites byte-exact AND preserves the destination's creation
+///      time (File.Replace, not File.Move), self-calibrating off a tunneling control; a fresh write lands byte-exact and
+///      leaves no temp. [RED: a non-atomic File.Move regression flips the creation-time arm.]
+///
+/// SERVICE arms (the REAL LoadOrderService over a synthetic MO2 instance, AssetStatusProbe style):
+///   D  explicit-source place + wins-VFS end-to-end — a loose source placed over a different current winner writes the
+///      right bytes into a fresh houseCARL mod; after ENABLING that mod on top, the REAL svc.AssetStatus reports IT as the
+///      VFS winner (the placed copy actually wins once sorted). Originals untouched; the placed file == the source bytes.
+///   E  BSA-source place end-to-end — source = a .bsa path (entry derived from the destination) places the extracted bytes.
+///   F  auto-resolve — sole provider used with no source=; >1 provider REFUSED ambiguous (per-asset, no guess); 0 providers
+///      REFUSED with guidance. [RED: an auto-guess on ambiguity is the Q3 hazard this arm forbids.]
+///   G  non-destructive / provenance / Q3 — an all-failed FRESH batch leaves NO orphan folder; a partial batch KEEPS the
+///      folder (the good file present); a drive-rooted / '..' destination is a per-asset named error; the tool layer
+///      refuses malformed specs (no kind, both/neither of formid+asset_path, bad formid/kind, both-expansion + loose source).
+///
+/// Self-contained: synthetic folders/instances in temp + the committed fixtures/asset-resolver/FixtureA.bsa, NO BSArch.
+/// Run: dotnet run --project src/housecarl-generator place-asset-guard
+/// </summary>
+internal static class PlaceAssetProbe
+{
+    // A facegen path that EXISTS inside the committed FixtureA.bsa (the dark-face shape) — the extraction + e2e source.
+    const string FacegenRel = @"meshes\actors\character\facegendata\facegeom\Dawnguard.esm\0001A51A.nif";
+
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" place-asset guard — FaceGen-path keystone + precise placer + BSA extract + wins-VFS");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        var fixDir = Path.GetFullPath(@"src/housecarl-generator/fixtures/asset-resolver");
+        var fixA = Path.Combine(fixDir, "FixtureA.bsa");
+        if (!File.Exists(fixA))
+        {
+            Console.WriteLine($"  FAIL  committed BSA fixture present at {fixA} (run from the repo root)");
+            Console.WriteLine("================ 1 CHECK(S) FAILED ================");
+            return 1;
+        }
+
+        var root = Path.Combine(Path.GetTempPath(), "hc-place-asset-guard-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            // ================= A: the FaceGen-path transform (the keystone) =================
+            Console.WriteLine("--- A: FaceGen path = pure transform of the FormKey (defining master + masked id) ---");
+            {
+                var fk = FormKey.Factory("01A51A:Dawnguard.esm");        // houseCARL 6-hex form of the fixture NPC
+                var mesh = FaceGenPath.For(fk, FaceGenSlot.Mesh);
+                var tint = FaceGenPath.For(fk, FaceGenSlot.Tint);
+                Check(mesh == @"meshes\actors\character\facegendata\facegeom\Dawnguard.esm\0001A51A.nif",
+                      $"mesh path is folder=defining-master + '00'+6hex .nif — got {mesh}");
+                Check(tint == @"textures\actors\character\facegendata\facetint\Dawnguard.esm\0001A51A.dds",
+                      $"tint path is facetint + .dds — got {tint}");
+                Check(mesh == FacegenRel, "the computed mesh path matches the committed fixture's facegen entry name exactly");
+
+                // the FOLDER is the DEFINING master in the FormKey, NEVER substituted — a different master ⇒ a different folder.
+                var fk2 = FormKey.Factory("000ABC:Skyrim.esm");
+                Check(FaceGenPath.For(fk2, FaceGenSlot.Mesh) == @"meshes\actors\character\facegendata\facegeom\Skyrim.esm\00000ABC.nif",
+                      "the folder is the FormKey's defining master and the id is masked to 8 hex ('00'+6) — Skyrim.esm/00000ABC.nif");
+                var both = FaceGenPath.Both(fk);
+                Check(both.Count == 2 && both[0].Slot == FaceGenSlot.Mesh && both[1].Slot == FaceGenSlot.Tint,
+                      "Both() returns mesh first, then tint");
+            }
+
+            // ================= B: native BSA single-entry extraction + zero handles at rest =================
+            Console.WriteLine();
+            Console.WriteLine("--- B: TryReadArchiveEntry — right bytes, null for absent, ZERO handle at rest (cornerstone) ---");
+            {
+                var bsaCopy = Path.Combine(root, "extract-probe.bsa");
+                File.Copy(fixA, bsaCopy);
+                var bytes = AssetResolver.TryReadArchiveEntry(bsaCopy, FacegenRel);
+                Check(bytes is { Length: > 0 }, $"the facegen entry's bytes are extracted from the BSA — {(bytes?.Length ?? 0)} bytes");
+                Check(AssetResolver.TryReadArchiveEntry(bsaCopy, @"meshes\nope\not-in-archive.nif") is null,
+                      "an entry not in the archive returns null (not a throw, not empty bytes)");
+
+                // The cornerstone: after extraction returns, NOTHING keeps the .bsa mapped — rename + delete must succeed.
+                bool renamable = true;
+                var renamed = bsaCopy + ".moved";
+                try { File.Move(bsaCopy, renamed); File.Move(renamed, bsaCopy); File.Delete(bsaCopy); }
+                catch { renamable = false; }
+                Check(renamable, "the .bsa stays renamable AND deletable after extraction — zero handles held at rest");
+            }
+
+            // ================= C: crash-atomic routing (AtomicFile.WriteAllBytes → File.Replace) =================
+            Console.WriteLine();
+            Console.WriteLine("--- C: place write is crash-atomic (File.Replace path), fresh + overwrite ---");
+            {
+                var oldCreate = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+                // self-calibrating control: does file-system tunneling mask the creation-time signal on THIS host?
+                bool tunnelingMasks;
+                {
+                    var f = Path.Combine(root, "ctl.dat");
+                    File.WriteAllBytes(f, new byte[] { 0 });
+                    File.SetCreationTimeUtc(f, oldCreate);
+                    var s = f + ".s"; File.WriteAllBytes(s, new byte[] { 1 });
+                    File.Move(s, f, overwrite: true);
+                    tunnelingMasks = File.GetCreationTimeUtc(f) == oldCreate;
+                }
+
+                var fresh = Path.Combine(root, "sub", "fresh.nif");
+                Directory.CreateDirectory(Path.GetDirectoryName(fresh)!);
+                var fb = new byte[] { 1, 2, 3, 4 };
+                AtomicFile.WriteAllBytes(fresh, fb);
+                Check(File.Exists(fresh) && File.ReadAllBytes(fresh).SequenceEqual(fb), "a fresh place writes byte-exact");
+                Check(!File.Exists(fresh + ".houseCARL-tmp"), "no staging temp is left after a fresh place");
+
+                var over = Path.Combine(root, "over.dds");
+                File.WriteAllBytes(over, new byte[] { 9, 9, 9 });
+                File.SetCreationTimeUtc(over, oldCreate);
+                var nb = new byte[] { 7, 7, 7, 7, 7 };
+                AtomicFile.WriteAllBytes(over, nb);
+                Check(File.ReadAllBytes(over).SequenceEqual(nb), "an overwrite place writes the NEW bytes byte-exact");
+                Check(!File.Exists(over + ".houseCARL-tmp"), "no staging temp is left after an overwrite place");
+                if (tunnelingMasks)
+                    Console.WriteLine("  SKIP  creation-time preserved — UNPROVABLE on a tunneling host (Q3, not a pass)");
+                else
+                    Check(File.GetCreationTimeUtc(over) == oldCreate,
+                          "overwrite preserves the destination's creation time — File.Replace, not File.Move  [RED arm]");
+            }
+
+            // ================= D: explicit-source place + wins-VFS end-to-end (REAL service) =================
+            Console.WriteLine();
+            Console.WriteLine("--- D: place a loose source over a wrong winner, then ENABLE → it wins the VFS (REAL svc.AssetStatus) ---");
+            {
+                var inst = Path.Combine(root, "svc-d");
+                var (mods, _, prof) = MakeInstance(inst);
+                var wrong = Path.Combine(mods, "WrongFace");
+                Directory.CreateDirectory(wrong);
+                WriteLoose(wrong, FacegenRel, new byte[] { 0xBA, 0xD0 });    // the current (wrong) winner
+                var correctSrc = Path.Combine(root, "correct-face.nif");
+                var correctBytes = new byte[] { 0x60, 0x0D, 0x60, 0x0D };
+                File.WriteAllBytes(correctSrc, correctBytes);
+                WriteProfile(prof, new[] { "Dummy.esp" }, new[] { "*Dummy.esp" }, new[] { "+WrongFace" });
+                WriteSkyrimIni(prof, "");
+                File.WriteAllText(Path.Combine(wrong, "Dummy.esp"), "x");    // a resolvable plugin path; never parsed
+
+                var store = new UserConfigStore(Path.Combine(root, "user-d.json"));
+                using var svc = LoadOrderService.WithInstance(inst, 0, store);
+
+                // before: the wrong copy wins
+                Check(svc.AssetStatus(new[] { FacegenRel }).Results[0].Hit?.Winner?.Source == "WrongFace",
+                      "before placing, the wrong loose copy wins the VFS");
+
+                var outcome = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, correctSrc) }, patchName: null, into: null);
+                var r0 = outcome.Results[0];
+                Check(r0.Placed && outcome.ModFolder is not null, $"the asset placed into a fresh houseCARL mod folder — {(r0.Placed ? Path.GetFileName(outcome.ModFolder!) : r0.Error)}");
+                Check(r0.CurrentWinner == "WrongFace (loose)", $"the placement reports the CURRENT winner to sort above — {r0.CurrentWinner}");
+                var placedFile = outcome.ModFolder is null ? null : Path.Combine(outcome.ModFolder, FacegenRel);
+                Check(placedFile is not null && File.Exists(placedFile) && File.ReadAllBytes(placedFile).SequenceEqual(correctBytes),
+                      "the placed file holds the SOURCE bytes byte-exact");
+                Check(File.ReadAllBytes(correctSrc).SequenceEqual(correctBytes) && File.ReadAllBytes(Path.Combine(wrong, FacegenRel)).SequenceEqual(new byte[] { 0xBA, 0xD0 }),
+                      "originals untouched — the source AND the prior winner are unchanged");
+
+                // enable the placed mod ON TOP, then re-resolve: it must WIN (the end-to-end fix)
+                if (outcome.ModFolder is { } mf)
+                {
+                    var placedMod = Path.GetFileName(mf);
+                    WriteProfile(prof, new[] { "Dummy.esp" }, new[] { "*Dummy.esp" }, new[] { "+" + placedMod, "+WrongFace" });
+                    File.SetLastWriteTimeUtc(Path.Combine(prof, "modlist.txt"), DateTime.UtcNow.AddHours(1));
+                    var after = svc.AssetStatus(new[] { FacegenRel }).Results[0];
+                    Check(after.Hit?.Winner?.Source == placedMod && after.Hit.Winner.Kind == AssetKind.Loose,
+                          $"after enabling the placed mod on top, IT wins the VFS — winner={after.Hit?.Winner?.Source}");
+                }
+                else Check(false, "wins-VFS end-to-end skipped — nothing was placed");
+            }
+
+            // ================= E: BSA-source place end-to-end =================
+            Console.WriteLine();
+            Console.WriteLine("--- E: source = a .bsa path → the extracted entry is placed (CC-NPC case) ---");
+            {
+                var inst = Path.Combine(root, "svc-e");
+                var (mods, _, prof) = MakeInstance(inst);
+                WriteProfile(prof, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>());
+                WriteSkyrimIni(prof, "");
+                var store = new UserConfigStore(Path.Combine(root, "user-e.json"));
+                using var svc = LoadOrderService.WithInstance(inst, 0, store);
+
+                var expect = AssetResolver.TryReadArchiveEntry(fixA, FacegenRel)!;
+                var outcome = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, fixA) }, patchName: null, into: null);
+                var r0 = outcome.Results[0];
+                Check(r0.Placed, $"a .bsa source places (entry derived from the destination) — {(r0.Placed ? "ok" : r0.Error)}");
+                var placedFile = outcome.ModFolder is null ? null : Path.Combine(outcome.ModFolder, FacegenRel);
+                Check(placedFile is not null && File.Exists(placedFile) && File.ReadAllBytes(placedFile).SequenceEqual(expect),
+                      "the placed bytes equal the natively-extracted BSA entry, byte-exact");
+            }
+
+            // ================= F: auto-resolve (sole / ambiguous / absent) =================
+            Console.WriteLine();
+            Console.WriteLine("--- F: auto-resolve — sole provider used; ambiguous refused (no guess); absent refused ---");
+            {
+                // sole provider
+                {
+                    var inst = Path.Combine(root, "svc-f1");
+                    var (mods, _, prof) = MakeInstance(inst);
+                    var only = Path.Combine(mods, "OnlyMod");
+                    Directory.CreateDirectory(only);
+                    var b = new byte[] { 1, 1, 1 };
+                    WriteLoose(only, FacegenRel, b);
+                    File.WriteAllText(Path.Combine(only, "Dummy.esp"), "x");
+                    WriteProfile(prof, new[] { "Dummy.esp" }, new[] { "*Dummy.esp" }, new[] { "+OnlyMod" });
+                    WriteSkyrimIni(prof, "");
+                    var store = new UserConfigStore(Path.Combine(root, "user-f1.json"));
+                    using var svc = LoadOrderService.WithInstance(inst, 0, store);
+                    var r = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, null) }, null, null).Results[0];
+                    Check(r.Placed, $"a SOLE provider auto-resolves with no source= — {(r.Placed ? "ok" : r.Error)}");
+                }
+                // ambiguous → refuse, no guess
+                {
+                    var inst = Path.Combine(root, "svc-f2");
+                    var (mods, _, prof) = MakeInstance(inst);
+                    foreach (var m in new[] { "ModA", "ModB" }) { var d = Path.Combine(mods, m); Directory.CreateDirectory(d); WriteLoose(d, FacegenRel, new byte[] { 2 }); }
+                    File.WriteAllText(Path.Combine(mods, "ModA", "Dummy.esp"), "x");
+                    WriteProfile(prof, new[] { "Dummy.esp" }, new[] { "*Dummy.esp" }, new[] { "+ModA", "+ModB" });
+                    WriteSkyrimIni(prof, "");
+                    var store = new UserConfigStore(Path.Combine(root, "user-f2.json"));
+                    using var svc = LoadOrderService.WithInstance(inst, 0, store);
+                    var r = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, null) }, null, null).Results[0];
+                    Check(!r.Placed && r.Error!.Contains("ambiguous"), $"TWO providers + no source= is REFUSED (no guess) — {r.Error}");
+                }
+                // absent → refuse
+                {
+                    var inst = Path.Combine(root, "svc-f3");
+                    var (mods, _, prof) = MakeInstance(inst);
+                    WriteProfile(prof, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>());
+                    WriteSkyrimIni(prof, "");
+                    var store = new UserConfigStore(Path.Combine(root, "user-f3.json"));
+                    using var svc = LoadOrderService.WithInstance(inst, 0, store);
+                    var r = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, null) }, null, null).Results[0];
+                    Check(!r.Placed && r.Error!.Contains("nothing"), $"NO provider + no source= is REFUSED with guidance — {r.Error}");
+                }
+            }
+
+            // ================= G: non-destructive / provenance / Q3 refusals =================
+            Console.WriteLine();
+            Console.WriteLine("--- G: no-orphan on all-fail, keep-on-partial, drive-rooted reject, tool-layer spec refusals ---");
+            {
+                var inst = Path.Combine(root, "svc-g");
+                var (mods, _, prof) = MakeInstance(inst);
+                var only = Path.Combine(mods, "GMod");
+                Directory.CreateDirectory(only);
+                WriteLoose(only, FacegenRel, new byte[] { 5, 5 });
+                File.WriteAllText(Path.Combine(only, "Dummy.esp"), "x");
+                WriteProfile(prof, new[] { "Dummy.esp" }, new[] { "*Dummy.esp" }, new[] { "+GMod" });
+                WriteSkyrimIni(prof, "");
+                var store = new UserConfigStore(Path.Combine(root, "user-g.json"));
+                using var svc = LoadOrderService.WithInstance(inst, 0, store);
+
+                // all-failed FRESH batch → NO orphan folder left
+                var allFail = svc.PlaceAssets(new[] { new PlaceRequest(@"meshes\absent\x.nif", null) }, "GHostFolder", null);
+                Check(allFail.ModFolder is null, "an all-failed batch reports no mod folder");
+                Check(!Directory.Exists(Path.Combine(mods, "houseCARL - GHostFolder")), "a fresh folder with NOTHING placed is removed — no orphan (F4/H2)");
+
+                // partial FRESH batch → folder KEPT, good file present
+                var partial = svc.PlaceAssets(new[]
+                {
+                    new PlaceRequest(FacegenRel, null),                  // ok (sole provider)
+                    new PlaceRequest(@"meshes\absent\y.nif", null),      // fails (absent)
+                }, "GKeepFolder", null);
+                Check(partial.ModFolder is not null && File.Exists(Path.Combine(partial.ModFolder!, FacegenRel)),
+                      "a PARTIAL batch keeps the folder with the good file present");
+
+                // drive-rooted / '..' destination → per-asset named error (Q3)
+                var bad = svc.PlaceAssets(new[] { new PlaceRequest(@"C:\Windows\evil.nif", @"C:\x") }, null, null).Results[0];
+                Check(!bad.Placed && bad.Error!.Contains("drive-rooted"), $"a drive-rooted destination is a per-asset named error — {bad.Error}");
+                var esc = svc.PlaceAssets(new[] { new PlaceRequest(@"meshes\..\..\evil.nif", FacegenRel) }, null, null).Results[0];
+                Check(!esc.Placed && esc.Error!.Contains("parent-escaping"), $"a '..'-escaping destination is rejected — {esc.Error}");
+
+                // tool-layer spec refusals (the REAL tool entrypoints, config-gated svc)
+                Check(PlaceAssetTools.PlaceAsset(svc, formid: "01A51A:Dawnguard.esm", kind: null).Contains("kind is required"),
+                      "single tool: formid with no kind is refused (it places ONE file)");
+                Check(PlaceAssetTools.PlaceAsset(svc, formid: "01A51A:Dawnguard.esm", asset_path: "meshes/x.nif", kind: "mesh").Contains("exactly one"),
+                      "single tool: BOTH formid and asset_path is refused");
+                Check(PlaceAssetTools.PlaceAsset(svc).Contains("exactly one"),
+                      "single tool: NEITHER formid nor asset_path is refused");
+                Check(PlaceAssetTools.PlaceAsset(svc, formid: "not-a-formid", kind: "mesh").Contains("bad formid"),
+                      "single tool: a malformed formid is refused named");
+                Check(PlaceAssetTools.PlaceAsset(svc, formid: "01A51A:Dawnguard.esm", kind: "bogus").Contains("not valid"),
+                      "single tool: a bad kind token is refused named");
+                Check(PlaceAssetTools.BulkPlaceAsset(svc, new[] { new PlaceAssetSpec { Formid = "01A51A:Dawnguard.esm", Source = @"C:\loose.nif" } })
+                        .Contains(".bsa"),
+                      "bulk tool: a both-expansion (formid, no kind) with a non-.bsa source is refused");
+                Check(PlaceAssetTools.BulkPlaceAsset(svc, Array.Empty<PlaceAssetSpec>()).Contains("empty"),
+                      "bulk tool: an empty assets array is rejected");
+            }
+        }
+        finally { try { Directory.Delete(root, recursive: true); } catch { /* temp scratch */ } }
+
+        Console.WriteLine();
+        Console.WriteLine(fail == 0 ? "================ ALL PASS ================" : $"================ {fail} CHECK(S) FAILED ================");
+        return fail == 0 ? 0 : 1;
+    }
+
+    // ---- synthetic MO2 layout helpers (the AssetStatusProbe / FreshnessCaptureProbe pattern) ----
+
+    /// <summary>Create a synthetic MO2 instance skeleton (mods/, game/Data/, profiles/Default/, ModOrganizer.ini) and
+    /// return (modsDir, dataDir, profileDir). The caller writes the profile + any mods.</summary>
+    static (string mods, string data, string prof) MakeInstance(string inst)
+    {
+        var mods = Path.Combine(inst, "mods");
+        var data = Path.Combine(inst, "game", "Data");
+        var prof = Path.Combine(inst, "profiles", "Default");
+        foreach (var d in new[] { mods, data, prof }) Directory.CreateDirectory(d);
+        WriteIni(inst, "Default", Path.Combine(inst, "game"));
+        return (mods, data, prof);
+    }
+
+    static void WriteProfile(string profDir, string[] loadorder, string[] plugins, string[] modlist)
+    {
+        Directory.CreateDirectory(profDir);
+        File.WriteAllText(Path.Combine(profDir, "loadorder.txt"), "# header\r\n" + string.Join("\r\n", loadorder) + "\r\n");
+        File.WriteAllText(Path.Combine(profDir, "plugins.txt"), string.Join("\r\n", plugins) + "\r\n");
+        File.WriteAllText(Path.Combine(profDir, "modlist.txt"), "# header\r\n" + string.Join("\r\n", modlist) + "\r\n");
+    }
+
+    static void WriteSkyrimIni(string profDir, string resourceArchiveList)
+    {
+        Directory.CreateDirectory(profDir);
+        File.WriteAllText(Path.Combine(profDir, "Skyrim.ini"),
+            "[Archive]\r\nsResourceArchiveList=" + resourceArchiveList + "\r\n");
+    }
+
+    static void WriteIni(string inst, string profile, string gameDir) =>
+        File.WriteAllText(Path.Combine(inst, "ModOrganizer.ini"),
+            "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(" + profile + ")\r\ngamePath=@ByteArray("
+            + gameDir.Replace(@"\", @"\\") + ")\r\n");
+
+    static void WriteLoose(string baseDir, string rel, byte[] bytes)
+    {
+        var p = Path.Combine(baseDir, rel);
+        Directory.CreateDirectory(Path.GetDirectoryName(p)!);
+        File.WriteAllBytes(p, bytes);
+    }
+}

--- a/src/housecarl-generator/PlaceAssetProbe.cs
+++ b/src/housecarl-generator/PlaceAssetProbe.cs
@@ -204,6 +204,15 @@ internal static class PlaceAssetProbe
                 var placedFile = outcome.ModFolder is null ? null : Path.Combine(outcome.ModFolder, FacegenRel);
                 Check(placedFile is not null && File.Exists(placedFile) && File.ReadAllBytes(placedFile).SequenceEqual(expect),
                       "the placed bytes equal the natively-extracted BSA entry, byte-exact");
+
+                // a QUOTED .bsa source must still route to BSA EXTRACTION, not be read WHOLE as a loose file (the Q3
+                // silent-wrong mis-route the independent pre-merge review caught). RED if routing decides .bsa-vs-loose
+                // on the un-trimmed string: the loose branch would place File.ReadAllBytes(wholeArchive) != the entry.
+                var outcomeQ = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, "\"" + fixA + "\"") }, patchName: null, into: null);
+                var rQ = outcomeQ.Results[0];
+                var placedQ = outcomeQ.ModFolder is null ? null : Path.Combine(outcomeQ.ModFolder, FacegenRel);
+                Check(rQ.Placed && placedQ is not null && File.ReadAllBytes(placedQ).SequenceEqual(expect),
+                      "a QUOTED .bsa source extracts the ENTRY (placed bytes == the entry, NOT the whole archive read as loose)  [RED arm]");
             }
 
             // ================= F: auto-resolve (sole / ambiguous / absent) =================

--- a/src/housecarl-generator/PlaceAssetProbe.cs
+++ b/src/housecarl-generator/PlaceAssetProbe.cs
@@ -248,7 +248,7 @@ internal static class PlaceAssetProbe
                     var store = new UserConfigStore(Path.Combine(root, "user-f3.json"));
                     using var svc = LoadOrderService.WithInstance(inst, 0, store);
                     var r = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, null) }, null, null).Results[0];
-                    Check(!r.Placed && r.Error!.Contains("nothing"), $"NO provider + no source= is REFUSED with guidance — {r.Error}");
+                    Check(!r.Placed && r.Error!.Contains("no copy to auto-place"), $"NO provider + no source= is REFUSED with guidance — {r.Error}");
                 }
             }
 
@@ -301,8 +301,63 @@ internal static class PlaceAssetProbe
                 Check(PlaceAssetTools.BulkPlaceAsset(svc, new[] { new PlaceAssetSpec { Formid = "01A51A:Dawnguard.esm", Source = @"C:\loose.nif" } })
                         .Contains(".bsa"),
                       "bulk tool: a both-expansion (formid, no kind) with a non-.bsa source is refused");
+                // a QUOTED .bsa source (the natural form for a spaced filename) must NOT be wrongly refused at the spec
+                // level — quotes are trimmed for the test, as ReadExplicitSource does (review fix). It then attempts to
+                // place mesh+tint (per-asset outcomes), never the "must be a bare '.bsa' path" spec refusal.
+                Check(!PlaceAssetTools.BulkPlaceAsset(svc, new[] { new PlaceAssetSpec { Formid = "01A51A:Dawnguard.esm", Source = "\"" + fixA + "\"" } })
+                        .Contains("must be a bare"),
+                      "bulk tool: a QUOTED .bsa source in a both-expansion is ACCEPTED (not refused for the trailing quote)");
                 Check(PlaceAssetTools.BulkPlaceAsset(svc, Array.Empty<PlaceAssetSpec>()).Contains("empty"),
                       "bulk tool: an empty assets array is rejected");
+            }
+
+            // ================= H: provenance + crash-atomic ROUTING through the SERVICE (overwrite via into=) =================
+            // The fresh-folder arms (D/E) never overwrite a pre-existing dest, so this arm places TWICE into the same folder
+            // (into=) to prove: (1) the overwrite yields the NEW bytes, not the stale prior — no false-success on a
+            // pre-existing file (the 2026-06-12 BSArch lesson, on the SERVICE path); (2) the service place routes through
+            // the crash-atomic primitive — the destination's creation time is PRESERVED (File.Replace), RED to a
+            // File.Move(overwrite) regression in PlaceOne (which resets it). HONEST residual: a regression to a plain
+            // File.WriteAllBytes is NOT distinguishable in-process (it also preserves creation time and is also atomic for
+            // non-crash writes) — only the crash window differs, which no in-process probe can observe (the same limit
+            // atomic-commit-guard states). This arm catches the File.Move regression + the stale-bytes false-success.
+            Console.WriteLine();
+            Console.WriteLine("--- H: service overwrite (into=) — NEW bytes, not stale; creation-time preserved (routes through AtomicFile) ---");
+            {
+                var inst = Path.Combine(root, "svc-h");
+                var (_, _, prof) = MakeInstance(inst);
+                WriteProfile(prof, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>());
+                WriteSkyrimIni(prof, "");
+                var store = new UserConfigStore(Path.Combine(root, "user-h.json"));
+                using var svc = LoadOrderService.WithInstance(inst, 0, store);
+
+                var srcV1 = Path.Combine(root, "v1.nif"); File.WriteAllBytes(srcV1, new byte[] { 1, 1, 1 });
+                var srcV2 = Path.Combine(root, "v2.nif"); var v2 = new byte[] { 2, 2, 2, 2, 2, 2 }; File.WriteAllBytes(srcV2, v2);
+
+                var first = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, srcV1) }, "RouteProv", null);
+                Check(first.Results[0].Placed && first.ModFolder is not null, "first place into a fresh folder succeeds");
+                if (first.ModFolder is { } mf)
+                {
+                    var dest = Path.Combine(mf, FacegenRel);
+                    var oldCreate = new DateTime(2019, 6, 6, 0, 0, 0, DateTimeKind.Utc);
+
+                    // tunneling control (same dir, a File.Move on a throwaway): is the creation-time signal valid here?
+                    var ctl = Path.Combine(mf, "ctl.bin"); File.WriteAllBytes(ctl, new byte[] { 0 }); File.SetCreationTimeUtc(ctl, oldCreate);
+                    var cs = ctl + ".s"; File.WriteAllBytes(cs, new byte[] { 1 }); File.Move(cs, ctl, overwrite: true);
+                    bool tunnelingMasks = File.GetCreationTimeUtc(ctl) == oldCreate;
+                    try { File.Delete(ctl); } catch { /* throwaway */ }
+
+                    File.SetCreationTimeUtc(dest, oldCreate);
+                    var second = svc.PlaceAssets(new[] { new PlaceRequest(FacegenRel, srcV2) }, null, "RouteProv");   // into= the SAME folder
+                    Check(second.Results[0].Placed, $"second place into= the existing folder succeeds — {(second.Results[0].Placed ? "ok" : second.Results[0].Error)}");
+                    Check(File.Exists(dest) && File.ReadAllBytes(dest).SequenceEqual(v2),
+                          "overwrite via the SERVICE yields the NEW bytes byte-exact, not the stale prior (provenance — no false success)");
+                    if (tunnelingMasks)
+                        Console.WriteLine("  SKIP  service place creation-time preserved — UNPROVABLE on a tunneling host (Q3, not a pass)");
+                    else
+                        Check(File.GetCreationTimeUtc(dest) == oldCreate,
+                              "the service place preserves the dest creation time — routes through AtomicFile (File.Replace), not File.Move  [RED arm]");
+                }
+                else Check(false, "provenance/routing skipped — first place produced no folder");
             }
         }
         finally { try { Directory.Delete(root, recursive: true); } catch { /* temp scratch */ } }

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -90,6 +90,13 @@ if (args.Length > 0 && args[0] == "asset-resolver-guard") return AssetResolverPr
 // the heavy record index. Self-contained: synthetic folders/instances + the committed .bsa fixtures, NO BSArch.
 if (args.Length > 0 && args[0] == "asset-status-guard") return AssetStatusProbe.RunGuard(args[1..]);
 
+// Place asset (facegen-diagnostics Phase 3 — housecarl_place_asset / housecarl_bulk_place_asset): the FormKey→FaceGen-path
+// keystone (defining-master folder + masked id), native BSA single-entry extraction with ZERO handles at rest, the
+// crash-atomic non-destructive place, the precise placer (explicit + auto-resolved source; ambiguity refused, not
+// guessed), the wins-VFS end-to-end story through the REAL service, and the Q3 refusals. Self-contained: synthetic
+// folders/instances + the committed FixtureA.bsa, NO BSArch.
+if (args.Length > 0 && args[0] == "place-asset-guard") return PlaceAssetProbe.RunGuard(args[1..]);
+
 // Compile-tool import order: caller import_dirs OUTRANK the vanilla auto-import (first match wins, so
 // SKSE-extended copies of vanilla sources must win). Pure order arm always runs; real-compile arm self-skips.
 if (args.Length > 0 && args[0] == "import-order-guard") return ImportOrderProbe.RunGuard(args[1..]);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -238,6 +238,173 @@ public sealed class LoadOrderService : IDisposable
         }
     }
 
+    // ---- facegen-diagnostics Phase 3: place an asset so the correct copy WINS the VFS (housecarl_place_asset) ----
+
+    /// <summary>Place one-or-more assets (FaceGen .nif/.dds, or any Data-relative file) into a NEW houseCARL-owned MO2 mod
+    /// folder so the CORRECT copy can win the VFS (housecarl_place_asset = one; housecarl_bulk_place_asset = many). For
+    /// each request: resolve its current providers (auto-resolve a source when none was named — sole provider used, &gt;1
+    /// refused as ambiguous, 0 refused with guidance), read the source bytes IN PROCESS (a loose file, or a single entry
+    /// out of a BSA via native Mutagen), and write them CRASH-ATOMICALLY (<see cref="AtomicFile.WriteAllBytes"/>) under the
+    /// owned folder. Originals untouched (we only ever write a fresh / houseCARL-owned folder). NON-DESTRUCTIVE on failure:
+    /// a fresh folder that ended up with NOTHING placed is removed (no orphan); a partial one is kept + named. Q3 honesty:
+    /// "wrote it" ≠ "it wins" — the fresh mod must be ENABLED + SORTED above the current winner, which the render reports;
+    /// this never claims the fix took effect on write. Serialized on the write gate (one placement batch at a time).</summary>
+    public PlaceOutcome PlaceAssets(IReadOnlyList<PlaceRequest> requests, string? patchName, string? into)
+    {
+        if (requests is null || requests.Count == 0) return PlaceOutcome.Fail("no assets to place.");
+
+        lock (_writeGate)                                                 // hunt F2 sibling: one placement batch at a time, resolve->stage->commit
+        {
+            RiderFolder rf;
+            try { rf = ResolvePatchModFolder(patchName, into, "houseCARL_FaceGen"); }
+            catch (InvalidOperationException ex) { return PlaceOutcome.Fail(ex.Message); }
+
+            // ONE asset build for the whole batch (auto-resolve sources + the post-write winner report), reentrant on _gate.
+            AssetResolver resolver; IReadOnlyList<string> warnings;
+            try { lock (_gate) { resolver = Assets; warnings = _assetWarnings; } }
+            catch (Exception ex)
+            {
+                var residue = RemoveOrNameRiderResidue(rf);              // nothing placed yet → a fresh folder is an orphan
+                return PlaceOutcome.Fail($"could not resolve the asset layer (the MO2 instance may not be readable): {ex.Message}"
+                    + (residue is null ? "" : $" The freshly created mod folder was left at '{residue}'."));
+            }
+
+            var results = new List<PlaceResult>(requests.Count);
+            int placed = 0;
+            foreach (var req in requests)
+            {
+                var r = PlaceOne(req, resolver, rf.OutputDir);
+                results.Add(r);
+                if (r.Placed) placed++;
+            }
+
+            // Nothing placed into a FRESH folder → remove the orphan (the .esp F4 / rider H2 principle). A reused into=
+            // folder (the user owns it) is never touched. A partial fresh folder is kept and its path surfaced.
+            string? leftover = placed == 0 ? RemoveOrNameRiderResidue(rf) : null;
+            return new PlaceOutcome(results, placed > 0 ? rf.ModFolder : null, warnings, leftover, null);
+        }
+    }
+
+    /// <summary>Place ONE asset: validate the destination rel-path (reject drive-rooted/'..' through the resolver's own
+    /// gate, Q3), get the source bytes (explicit source= or auto-resolve), and write them crash-atomically under
+    /// <paramref name="outDir"/>. Reports the CURRENT VFS winner so the caller knows what to sort the fresh mod above —
+    /// the placed file does NOT win until the mod is enabled + sorted (the fresh folder isn't in the active profile yet).
+    /// A per-asset failure is a recoverable named error, never a thrown batch abort.</summary>
+    PlaceResult PlaceOne(PlaceRequest req, AssetResolver resolver, string outDir)
+    {
+        string rel;
+        try { rel = AssetResolver.ValidateRelPath(req.AssetPath); }
+        catch (ArgumentException ex) { return PlaceResult.Fail(req.AssetPath, ex.Message); }
+
+        var res = resolver.ResolveForPlacement(rel);                     // rel already validated — won't throw
+        var winner = res.Sources.Count > 0 ? DescribeSource(res.Sources[0]) : null;
+
+        // ---- source bytes: explicit source= wins; else auto-resolve the sole provider ----
+        byte[] bytes; string sourceDesc;
+        var explicitSrc = req.Source?.Trim();
+        if (!string.IsNullOrEmpty(explicitSrc))
+        {
+            var (b, desc, err) = ReadExplicitSource(explicitSrc!, rel);
+            if (err is not null) return PlaceResult.Fail(rel, err, winner);
+            bytes = b!; sourceDesc = desc!;
+        }
+        else
+        {
+            if (res.Sources.Count == 0)
+                return PlaceResult.Fail(rel,
+                    $"nothing in the active load order provides '{rel}', so there is no copy to auto-place. Pass source= the correct copy "
+                    + "(a loose file path, or '<archive.bsa>|<entry>', or a '.bsa' path)."
+                    + (res.ReadIncomplete ? " NOTE: a BSA failed to read this build, so a source may merely be unscanned (see the warnings)." : ""),
+                    winner);
+            if (res.Ambiguous)
+                return PlaceResult.Fail(rel,
+                    $"{res.Sources.Count} sources provide '{rel}' — ambiguous, so place_asset will not guess which copy is correct (the skill decides). "
+                    + $"Pass source= one of: {string.Join("; ", res.Sources.Select(SourceHint))}.",
+                    winner);
+            var (b, desc, err) = ReadResolvedSource(res.Sources[0]);
+            if (err is not null) return PlaceResult.Fail(rel, err, winner);
+            bytes = b!; sourceDesc = desc!;
+        }
+
+        // ---- crash-atomic place under the owned folder (originals untouched; same-volume staging done in core) ----
+        var dest = Path.Combine(outDir, rel);
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
+            AtomicFile.WriteAllBytes(dest, bytes);
+        }
+        catch (Exception ex) { return PlaceResult.Fail(rel, $"could not write '{rel}' into the patch folder: {ex.Message}", winner); }
+
+        // ---- integrity (Q3: THIS run wrote it; the on-disk size matches the source bytes — no false success) ----
+        long size; try { size = new FileInfo(dest).Length; } catch { size = -1; }
+        if (size != bytes.Length)
+            return PlaceResult.Fail(rel,
+                $"wrote '{rel}' but its on-disk size ({size}) does not match the {bytes.Length} source byte(s) — verify before relying on it.", winner);
+        return new PlaceResult(rel, true, bytes.Length, sourceDesc, winner, null);
+    }
+
+    /// <summary>Read an EXPLICIT source= the caller named. Forms: "&lt;archive.bsa&gt;|&lt;entry&gt;" (a specific BSA
+    /// entry, split on the FIRST '|'); a path ending ".bsa" (the entry is the destination rel-path — the FaceGen case,
+    /// where the entry inside the BSA IS the Data-relative path); any other path (a loose file on disk). Returns the bytes
+    /// + a human description, or a NAMED error (Q3) for a missing file / missing entry / unreadable archive.</summary>
+    static (byte[]? bytes, string? desc, string? error) ReadExplicitSource(string source, string destRel)
+    {
+        int bar = source.IndexOf('|');
+        if (bar >= 0)
+            return ReadBsaEntry(source[..bar].Trim().Trim('"'), source[(bar + 1)..].Trim());
+        if (source.EndsWith(".bsa", StringComparison.OrdinalIgnoreCase))
+            return ReadBsaEntry(source.Trim('"'), destRel);              // .bsa with no explicit entry → entry := the destination path
+        string path;
+        try { path = Path.GetFullPath(source.Trim('"')); }
+        catch (Exception ex) { return (null, null, $"source '{source}' is not a usable path: {ex.Message}"); }
+        if (!File.Exists(path)) return (null, null, $"source file not found: '{path}'.");
+        try { return (File.ReadAllBytes(path), $"loose file {path}", null); }
+        catch (Exception ex) { return (null, null, $"could not read source file '{path}': {ex.Message}"); }
+    }
+
+    /// <summary>Read the bytes of an AUTO-resolved provider (the sole VFS provider when no source= was named). A loose
+    /// provider reads off disk; a BSA provider extracts its single entry natively. A named error (Q3) if the resolved copy
+    /// vanished between resolve and read, or the archive can't be read.</summary>
+    static (byte[]? bytes, string? desc, string? error) ReadResolvedSource(PlacementSource s)
+    {
+        if (s.Kind == AssetKind.Loose)
+        {
+            var p = s.LooseFilePath!;
+            if (!File.Exists(p)) return (null, null, $"the resolved loose source '{p}' is no longer on disk.");
+            try { return (File.ReadAllBytes(p), $"loose file {p} (from {s.ProviderName})", null); }
+            catch (Exception ex) { return (null, null, $"could not read resolved source '{p}': {ex.Message}"); }
+        }
+        return ReadBsaEntry(s.ArchivePath!, s.EntryPath);
+    }
+
+    /// <summary>Read one entry out of a BSA (native Mutagen, no BSArch, zero handles at rest — see
+    /// <see cref="AssetResolver.TryReadArchiveEntry"/>). Named errors (Q3) for a missing archive, an entry not inside it,
+    /// or an unreadable archive.</summary>
+    static (byte[]? bytes, string? desc, string? error) ReadBsaEntry(string archive, string entry)
+    {
+        string ap;
+        try { ap = Path.GetFullPath(archive.Trim('"')); }
+        catch (Exception ex) { return (null, null, $"source archive '{archive}' is not a usable path: {ex.Message}"); }
+        if (!File.Exists(ap)) return (null, null, $"source archive not found: '{ap}'.");
+        try
+        {
+            var b = AssetResolver.TryReadArchiveEntry(ap, entry);
+            if (b is null) return (null, null, $"entry '{entry}' not found inside archive '{Path.GetFileName(ap)}'.");
+            return (b, $"{Path.GetFileName(ap)}|{entry}", null);
+        }
+        catch (Exception ex) { return (null, null, $"could not read archive '{Path.GetFileName(ap)}': {ex.Message}"); }
+    }
+
+    /// <summary>A human label for the current winner (the sort target). "ModX (loose)" / "Y.bsa (BSA)".</summary>
+    static string DescribeSource(PlacementSource s) => $"{s.ProviderName} ({(s.Kind == AssetKind.Bsa ? "BSA" : "loose")})";
+
+    /// <summary>A copy-pasteable source= hint for an ambiguous-provider refusal: a BSA provider needs its archive PATH (the
+    /// display name is just the filename), so name it as a BSA the caller must give the full path of; a loose provider's
+    /// on-disk path is exact.</summary>
+    static string SourceHint(PlacementSource s) => s.Kind == AssetKind.Bsa
+        ? $"the BSA '{s.ProviderName}' (give its full path, or '<path>|{s.EntryPath}')"
+        : $"'{s.LooseFilePath}'";
+
     /// <summary>Whole-order stats (forces the lazy build). For the server's stand-up / health check.</summary>
     public (int plugins, int records, int conflicts, int maxDepth, IReadOnlyList<string> loadFailures) Stats()
     {
@@ -1401,3 +1568,30 @@ public sealed record AssetStatusData(
     bool ReadIncomplete,
     IReadOnlyList<string> Warnings,
     string ProfileName);
+
+/// <summary>One asset to PLACE (housecarl_place_asset / bulk). <see cref="AssetPath"/> is the resolved Data-relative
+/// DESTINATION (the tool computes it from a FormID+slot for FaceGen, or takes a raw path). <see cref="Source"/> is the
+/// correct copy to place — a loose file path, "&lt;archive.bsa&gt;|&lt;entry&gt;", or a ".bsa" path (entry := AssetPath);
+/// null/blank ⇒ auto-resolve (use the sole VFS provider; &gt;1 ambiguous and 0 absent are per-asset refusals, Q3).</summary>
+public sealed record PlaceRequest(string AssetPath, string? Source);
+
+/// <summary>One placed asset's outcome. <see cref="Placed"/> false ⇒ <see cref="Error"/> names why (recoverable, per-asset
+/// Q3). <see cref="CurrentWinner"/> is the source that currently wins the VFS for this path (the sort target — the placed
+/// copy does NOT win until the fresh mod is enabled + sorted above it), or null if nothing provided it before.</summary>
+public sealed record PlaceResult(string AssetPath, bool Placed, long Bytes, string? SourceDesc, string? CurrentWinner, string? Error)
+{
+    public static PlaceResult Fail(string assetPath, string error, string? currentWinner = null)
+        => new(assetPath, false, 0, null, currentWinner, error);
+}
+
+/// <summary>The outcome of place_asset / bulk_place_asset. <see cref="Error"/> non-null ⇒ the whole call was rejected
+/// before any placement (unconfigured, an into= folder houseCARL doesn't own, the asset layer wouldn't build). Else
+/// <see cref="Results"/> is per-asset; <see cref="ModFolder"/> is the houseCARL mod the placed files landed in (null when
+/// none placed); <see cref="Warnings"/> carries the asset-discovery caveats (Q3); <see cref="LeftoverFolder"/> names a
+/// fresh folder kept because it holds a partial result (no orphan is left for an all-failed fresh batch).</summary>
+public sealed record PlaceOutcome(
+    IReadOnlyList<PlaceResult> Results, string? ModFolder, IReadOnlyList<string> Warnings, string? LeftoverFolder, string? Error)
+{
+    public static PlaceOutcome Fail(string error)
+        => new(Array.Empty<PlaceResult>(), null, Array.Empty<string>(), null, error);
+}

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -356,13 +356,18 @@ public sealed class LoadOrderService : IDisposable
     /// + a human description, or a NAMED error (Q3) for a missing file / missing entry / unreadable archive.</summary>
     static (byte[]? bytes, string? desc, string? error) ReadExplicitSource(string source, string destRel)
     {
+        source = source.Trim();
         int bar = source.IndexOf('|');
         if (bar >= 0)
-            return ReadBsaEntry(source[..bar].Trim().Trim('"'), source[(bar + 1)..].Trim());
+            return ReadBsaEntry(source[..bar].Trim().Trim('"'), source[(bar + 1)..].Trim().Trim('"'));
+        // Strip surrounding quotes BEFORE the .bsa-vs-loose routing decision (NOT inside each branch): a quoted ".bsa"
+        // path ends in '"' not ".bsa", so routing on the raw string would read the WHOLE archive as a loose file and
+        // place it as the asset — a silent-wrong placement that passes the size check (Q3). The ONE trim point.
+        source = source.Trim('"');
         if (source.EndsWith(".bsa", StringComparison.OrdinalIgnoreCase))
-            return ReadBsaEntry(source.Trim('"'), destRel);              // .bsa with no explicit entry → entry := the destination path
+            return ReadBsaEntry(source, destRel);                        // .bsa with no explicit entry → entry := the destination path
         string path;
-        try { path = Path.GetFullPath(source.Trim('"')); }
+        try { path = Path.GetFullPath(source); }
         catch (Exception ex) { return (null, null, $"source '{source}' is not a usable path: {ex.Message}"); }
         if (!File.Exists(path)) return (null, null, $"source file not found: '{path}'.");
         try { return (File.ReadAllBytes(path), $"loose file {path}", null); }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -255,6 +255,10 @@ public sealed class LoadOrderService : IDisposable
 
         lock (_writeGate)                                                 // hunt F2 sibling: one placement batch at a time, resolve->stage->commit
         {
+            // PRECONDITION: _writeGate is held for the WHOLE method. ResolvePatchModFolder and the `Assets` getter each
+            // take-and-release _gate, so this method straddles two _gate sections — safe ONLY because _writeGate excludes
+            // every other writer and instance-switch throughout, so no profile refresh can land between them. Do not call
+            // PlaceOne/Assets here outside this _writeGate hold.
             RiderFolder rf;
             try { rf = ResolvePatchModFolder(patchName, into, "houseCARL_FaceGen"); }
             catch (InvalidOperationException ex) { return PlaceOutcome.Fail(ex.Message); }
@@ -336,6 +340,9 @@ public sealed class LoadOrderService : IDisposable
         catch (Exception ex) { return PlaceResult.Fail(rel, $"could not write '{rel}' into the patch folder: {ex.Message}", winner); }
 
         // ---- integrity (Q3: THIS run wrote it; the on-disk size matches the source bytes — no false success) ----
+        // Belt-and-braces truncation / short-write detection — NOT a content hash (the bytes are in-memory and the swap is
+        // atomic, so a same-length corruption isn't a reachable failure of this path; a size mismatch would mean the OS
+        // wrote fewer bytes than handed). Defensive, not the primary guarantee (that's AtomicFile's crash-atomic swap).
         long size; try { size = new FileInfo(dest).Length; } catch { size = -1; }
         if (size != bytes.Length)
             return PlaceResult.Fail(rel,

--- a/src/housecarl-mcp/PlaceAssetTools.cs
+++ b/src/housecarl-mcp/PlaceAssetTools.cs
@@ -130,7 +130,10 @@ public static class PlaceAssetTools
             error = $"{where}kind is required with formid (mesh or tint — housecarl_place_asset places ONE file). To place both at once, use housecarl_bulk_place_asset.";
             return null;
         }
-        bool srcOkForBoth = src is null || (src.EndsWith(".bsa", StringComparison.OrdinalIgnoreCase) && src.IndexOf('|') < 0);
+        // Trim quotes for the test exactly as ReadExplicitSource does — else a quoted spaced BSA name (the natural form,
+        // "C:\...\X - Textures.bsa") ends in '"' not '.bsa' and would be wrongly refused on the marquee mesh+tint path.
+        var srcProbe = src?.Trim('"');
+        bool srcOkForBoth = srcProbe is null || (srcProbe.EndsWith(".bsa", StringComparison.OrdinalIgnoreCase) && srcProbe.IndexOf('|') < 0);
         if (!srcOkForBoth)
         {
             error = $"{where}with formid and no kind (placing BOTH mesh and tint), an explicit source= must be a bare '.bsa' path — each slot's entry is then derived. For a single loose file or BSA entry, set kind= mesh or tint.";
@@ -202,9 +205,15 @@ static class PlaceWire
               .Append("' holds a partial result — delete it or retry with into=.\n");
 
         if (placed > 0)
+        {
+            bool anyContended = false;
+            foreach (var r in o.Results) if (r.Placed && r.CurrentWinner is not null) { anyContended = true; break; }
             sb.Append("\nIMPORTANT — \"wrote it\" is not \"it wins\": the placed file(s) do NOT win the VFS yet. Enable the mod '")
-              .Append(modFolder ?? "(the new folder)")
-              .Append("' in MO2 and SORT it (left pane) ABOVE the current winner(s) listed above. Only then does the placed copy win.\n");
+              .Append(modFolder ?? "(the new folder)").Append("' in MO2");
+            sb.Append(anyContended
+                ? " and SORT it (left pane) ABOVE the current winner(s) listed above. Only then does the placed copy win.\n"
+                : ". Nothing else provided these path(s), so once enabled the placed copy wins (sort it above any mod you later add that also provides them).\n");
+        }
 
         return sb.ToString().TrimEnd('\n');
     }

--- a/src/housecarl-mcp/PlaceAssetTools.cs
+++ b/src/housecarl-mcp/PlaceAssetTools.cs
@@ -130,8 +130,9 @@ public static class PlaceAssetTools
             error = $"{where}kind is required with formid (mesh or tint — housecarl_place_asset places ONE file). To place both at once, use housecarl_bulk_place_asset.";
             return null;
         }
-        // Trim quotes for the test exactly as ReadExplicitSource does — else a quoted spaced BSA name (the natural form,
-        // "C:\...\X - Textures.bsa") ends in '"' not '.bsa' and would be wrongly refused on the marquee mesh+tint path.
+        // Trim quotes for the both-expansion test the same way ReadExplicitSource trims before it routes — else a quoted
+        // spaced BSA name (the natural form, "C:\...\X - Textures.bsa") ends in '"' not '.bsa' and would be wrongly
+        // refused here on the marquee mesh+tint path. (The actual read also trims-before-routing, so the two agree.)
         var srcProbe = src?.Trim('"');
         bool srcOkForBoth = srcProbe is null || (srcProbe.EndsWith(".bsa", StringComparison.OrdinalIgnoreCase) && srcProbe.IndexOf('|') < 0);
         if (!srcOkForBoth)

--- a/src/housecarl-mcp/PlaceAssetTools.cs
+++ b/src/housecarl-mcp/PlaceAssetTools.cs
@@ -1,0 +1,228 @@
+using System.ComponentModel;
+using System.Text;
+using System.Text.Json.Serialization;
+using ModelContextProtocol.Server;
+using Mutagen.Bethesda.Plugins;
+using HousecarlCore;
+
+namespace HousecarlMcp;
+
+/// <summary>
+/// houseCARL place-asset tools (facegen-diagnostics Phase 3) — the WRITE side of dark-face / grey-face repair. Where
+/// housecarl_asset_status (read-only) tells you WHICH copy of a FaceGen file currently wins MO2's VFS, these place the
+/// CORRECT copy into a NEW houseCARL-owned mod folder so it CAN win once enabled + sorted. A precise placer: it writes a
+/// source it is handed and auto-resolves only when exactly ONE copy exists (the "which copy is correct" judgment is the
+/// caller's / the facegen skill's, not the tool's). Source bytes are read IN PROCESS — a loose file, or a single entry
+/// out of a BSA via native Mutagen (no BSArch). The write is crash-atomic and non-destructive (originals untouched; a
+/// failed fresh placement leaves no orphan). Honest (Q3): "wrote it" is NOT "it wins" — the tool reports the current
+/// winner and the required MO2 enable + sort, and never claims the fix took effect on write.
+/// </summary>
+[McpServerToolType]
+public static class PlaceAssetTools
+{
+    [McpServerTool(Name = "housecarl_place_asset", Title = "Place ONE FaceGen/asset file so the correct copy can win MO2's VFS"),
+     Description(
+         "Place ONE asset file (a FaceGen .nif/.dds, or any Data-relative file) into a NEW houseCARL-owned MO2 mod folder " +
+         "so the CORRECT copy can win the virtual file system — the WRITE half of dark-face / grey-face ('black face', " +
+         "'ashen face') NPC repair (housecarl_asset_status is the read half). Give the DESTINATION as either formid (an " +
+         "NPC's FormID 'XXXXXX:Plugin.esp' — houseCARL computes the FaceGen path: folder = the DEFINING plugin in the " +
+         "FormID, file = the FormID with the index masked) plus kind ('mesh' = the head .nif, 'tint' = the face .dds), OR " +
+         "asset_path (a raw Data-relative path for any file). Give the SOURCE (the correct copy) as source= a loose file " +
+         "path, or '<archive.bsa path>|<entry inside>', or just a '.bsa' path (the entry is taken to be the destination " +
+         "path — the Creation-Club-NPC case). If source is OMITTED, houseCARL auto-resolves: it uses the SOLE provider in " +
+         "your load order, and REFUSES (telling you the candidates) if more than one provides it — it will not guess which " +
+         "is correct. The write is crash-atomic; originals are never touched. IMPORTANT (and reported back): the placed " +
+         "copy does NOT win on write — you must ENABLE the new mod in MO2 and SORT it above the current winner. This tool " +
+         "places ONE file; to place an NPC's mesh AND tint together (or many files) use housecarl_bulk_place_asset.")]
+    public static string PlaceAsset(
+        LoadOrderService svc,
+        [Description("Optional. The NPC's FormID 'XXXXXX:Plugin.esp' — houseCARL computes the FaceGen path from it. Use for dark-face fixes. Provide this OR asset_path. Requires kind=.")]
+            string? formid = null,
+        [Description("Optional (with formid). Which FaceGen file: 'mesh' (the head .nif) or 'tint' (the face .dds). REQUIRED when formid is given — this tool places one file. Use housecarl_bulk_place_asset to place both at once.")]
+            string? kind = null,
+        [Description("Optional. A Data-relative destination path to place to directly (e.g. 'meshes/actors/...'), instead of formid+kind. Provide this OR formid. A drive-rooted or '..'-escaping path is rejected.")]
+            string? asset_path = null,
+        [Description("Optional. The correct copy to place: a loose file path; or '<archive.bsa path>|<entry inside>'; or just a '.bsa' path (the entry is taken to be the destination path). If omitted, houseCARL uses the SOLE provider in your load order and refuses if more than one provides it (you choose).")]
+            string? source = null,
+        [Description("Optional. Base name for the NEW houseCARL mod folder the file lands in (default 'houseCARL_FaceGen'); auto-suffixed if taken.")]
+            string? patch_name = null,
+        [Description("Optional. Filename of an existing houseCARL patch mod to place into instead of a fresh folder (accumulate across calls).")]
+            string? into = null) => Guard.Tool("housecarl_place_asset", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        var reqs = MapSpec(formid, kind, asset_path, source, allowExpand: false, where: "", out var err);
+        if (err is not null) return "error: " + err;
+        return PlaceWire.Render(svc.PlaceAssets(reqs!, patch_name, into));
+    });
+
+    [McpServerTool(Name = "housecarl_bulk_place_asset", Title = "Place MANY FaceGen/asset files in one houseCARL mod"),
+     Description(
+         "Place MANY asset files in ONE houseCARL-owned MO2 mod folder — the batch form of housecarl_place_asset, and the " +
+         "way to fix an NPC's FaceGen mesh AND tint together (or several NPCs at once). assets is an array of " +
+         "{ formid?, kind?, asset_path?, source? }: give EITHER formid (an NPC FormID — omit kind to place BOTH the mesh " +
+         "and the tint; or set kind='mesh'/'tint' for just one) OR asset_path (a raw Data-relative path). source is the " +
+         "correct copy (a loose file path, '<archive.bsa>|<entry>', or a '.bsa' path); omit it to auto-resolve the sole " +
+         "VFS provider (an ambiguous or absent source becomes a per-asset error — the rest still place). When you give a " +
+         "FormID with no kind (placing both files), an explicit source must be a '.bsa' path (each slot's entry is " +
+         "derived) — for a single loose/entry source set kind=. All files land in ONE reviewable mod folder. A malformed " +
+         "spec (bad FormID, bad kind, neither/both of formid+asset_path) refuses the WHOLE call with per-spec reasons and " +
+         "places nothing. As with the single tool, the placed copies do NOT win until you enable + sort the mod in MO2 " +
+         "(reported back).")]
+    public static string BulkPlaceAsset(
+        LoadOrderService svc,
+        [Description("The assets to place, all into one mod folder. Each: { formid?: 'XXXXXX:Plugin.esp', kind?: 'mesh'|'tint' (omit with formid to place BOTH), asset_path?: 'meshes/...', source?: '<loose path>' | '<archive.bsa>|<entry>' | '<archive.bsa>' }.")]
+            PlaceAssetSpec[] assets,
+        [Description("Optional. Base name for the NEW houseCARL mod folder (default 'houseCARL_FaceGen'); auto-suffixed if taken.")]
+            string? patch_name = null,
+        [Description("Optional. Filename of an existing houseCARL patch mod to place into instead of a fresh folder.")]
+            string? into = null) => Guard.Tool("housecarl_bulk_place_asset", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        if (assets is null || assets.Length == 0)
+            return "error: assets is empty. Pass one or more { formid|asset_path, kind?, source? } specs.";
+
+        // Malformed specs refuse the WHOLE call (all-or-nothing, like bulk_create); placement-time issues
+        // (ambiguous/absent/unreadable source) are per-asset (the resolver isn't consulted until the place loop).
+        var all = new List<PlaceRequest>();
+        var problems = new List<string>();
+        for (int i = 0; i < assets.Length; i++)
+        {
+            var a = assets[i];
+            var reqs = MapSpec(a.Formid, a.Kind, a.AssetPath, a.Source, allowExpand: true, where: $"assets[{i}]: ", out var err);
+            if (err is not null) problems.Add(err); else all.AddRange(reqs!);
+        }
+        if (problems.Count > 0)
+            return $"error: refused — {problems.Count} malformed spec(s); nothing placed:\n  - " + string.Join("\n  - ", problems);
+
+        return PlaceWire.Render(svc.PlaceAssets(all, patch_name, into));
+    });
+
+    /// <summary>Map one wire spec to its placement request(s): asset_path → one request; formid+kind → one request (the
+    /// computed FaceGen path); formid with NO kind → BOTH mesh+tint (only when <paramref name="allowExpand"/> — the bulk
+    /// tool). Exactly one of formid/asset_path is required. A both-expansion forbids a single loose/entry source (it can't
+    /// serve two different files) — only a bare '.bsa' source (entry derived per slot) or auto-resolve. Q3: every bad
+    /// input is a NAMED error (returned via <paramref name="error"/>), never a silent skip.</summary>
+    static List<PlaceRequest>? MapSpec(string? formid, string? kind, string? assetPath, string? source, bool allowExpand, string where, out string? error)
+    {
+        error = null;
+        bool hasFormid = !string.IsNullOrWhiteSpace(formid);
+        bool hasPath = !string.IsNullOrWhiteSpace(assetPath);
+        if (hasFormid == hasPath) { error = $"{where}provide exactly one of formid or asset_path."; return null; }
+
+        var src = NullIfBlank(source);
+
+        if (hasPath)
+            return new List<PlaceRequest> { new(assetPath!.Trim(), src) };
+
+        FormKey fk;
+        try { fk = FormKey.Factory(formid!.Trim()); }
+        catch (Exception ex) { error = $"{where}bad formid '{formid}' ({ex.Message}). Expected 'XXXXXX:Plugin.esp'."; return null; }
+
+        var slot = ParseSlot(kind, out var slotErr);
+        if (slotErr is not null) { error = $"{where}{slotErr}"; return null; }
+
+        if (slot is { } s)                                            // explicit mesh|tint → one file
+            return new List<PlaceRequest> { new(FaceGenPath.For(fk, s), src) };
+
+        // kind omitted → both mesh + tint (bulk only)
+        if (!allowExpand)
+        {
+            error = $"{where}kind is required with formid (mesh or tint — housecarl_place_asset places ONE file). To place both at once, use housecarl_bulk_place_asset.";
+            return null;
+        }
+        bool srcOkForBoth = src is null || (src.EndsWith(".bsa", StringComparison.OrdinalIgnoreCase) && src.IndexOf('|') < 0);
+        if (!srcOkForBoth)
+        {
+            error = $"{where}with formid and no kind (placing BOTH mesh and tint), an explicit source= must be a bare '.bsa' path — each slot's entry is then derived. For a single loose file or BSA entry, set kind= mesh or tint.";
+            return null;
+        }
+        var reqs = new List<PlaceRequest>(2);
+        foreach (var (_, rel) in FaceGenPath.Both(fk)) reqs.Add(new PlaceRequest(rel, src));
+        return reqs;
+    }
+
+    /// <summary>Parse the FaceGen slot token. Null/blank ⇒ null (unspecified — the caller decides if that means "both" or
+    /// "required"). A bad token is a named error (Q3). Lenient synonyms for the two file kinds.</summary>
+    static FaceGenSlot? ParseSlot(string? kind, out string? error)
+    {
+        error = null;
+        var k = kind?.Trim().ToLowerInvariant();
+        if (string.IsNullOrEmpty(k)) return null;
+        switch (k)
+        {
+            case "mesh": case "nif": case "geom": case "facegeom": return FaceGenSlot.Mesh;
+            case "tint": case "dds": case "facetint": case "texture": return FaceGenSlot.Tint;
+            default: error = $"kind '{kind}' is not valid — use 'mesh' (the head .nif) or 'tint' (the face .dds)."; return null;
+        }
+    }
+
+    static string? NullIfBlank(string? s) => string.IsNullOrWhiteSpace(s) ? null : s.Trim();
+}
+
+/// <summary>Renders a <see cref="PlaceOutcome"/> as compact, scannable text: the count, the mod folder, the discovery
+/// caveats (Q3), one line per asset (placed with its source + the current VFS winner to sort above, or a per-asset
+/// error), and — the load-bearing honesty — the EXPLICIT "this does not win until you enable + sort the mod in MO2"
+/// instruction whenever anything was placed.</summary>
+static class PlaceWire
+{
+    public static string Render(PlaceOutcome o)
+    {
+        if (o.Error is not null) return "error: " + o.Error;
+
+        var sb = new StringBuilder();
+        int placed = 0;
+        foreach (var r in o.Results) if (r.Placed) placed++;
+        int failed = o.Results.Count - placed;
+        var modFolder = o.ModFolder is null ? null : Path.GetFileName(o.ModFolder);
+
+        sb.Append("placed ").Append(placed).Append(" of ").Append(o.Results.Count).Append(" asset(s)");
+        if (failed > 0) sb.Append(" (").Append(failed).Append(" failed)");
+        sb.Append('\n');
+        if (modFolder is not null) sb.Append("mod folder: ").Append(modFolder).Append('\n');
+
+        foreach (var w in o.Warnings) sb.Append("[!] discovery: ").Append(w).Append('\n');
+
+        foreach (var r in o.Results)
+        {
+            if (r.Placed)
+            {
+                sb.Append("  OK    ").Append(r.AssetPath).Append("  (").Append(r.Bytes).Append(" bytes from ").Append(r.SourceDesc).Append(")\n");
+                sb.Append(r.CurrentWinner is not null
+                    ? $"        currently wins the VFS: {r.CurrentWinner} — sort the new mod ABOVE it\n"
+                    : "        nothing else provides this path — once the mod is enabled, the placed copy wins\n");
+            }
+            else
+            {
+                sb.Append("  FAIL  ").Append(r.AssetPath).Append("  ").Append(r.Error).Append('\n');
+            }
+        }
+
+        if (o.LeftoverFolder is not null)
+            sb.Append("note: the fresh folder at '").Append(o.LeftoverFolder)
+              .Append("' holds a partial result — delete it or retry with into=.\n");
+
+        if (placed > 0)
+            sb.Append("\nIMPORTANT — \"wrote it\" is not \"it wins\": the placed file(s) do NOT win the VFS yet. Enable the mod '")
+              .Append(modFolder ?? "(the new folder)")
+              .Append("' in MO2 and SORT it (left pane) ABOVE the current winner(s) listed above. Only then does the placed copy win.\n");
+
+        return sb.ToString().TrimEnd('\n');
+    }
+}
+
+/// <summary>One asset to place off the wire (housecarl_bulk_place_asset). Mirrors the scalar args of
+/// housecarl_place_asset: a FormID (+ optional slot) or a raw destination path, and the optional source.</summary>
+public sealed record PlaceAssetSpec
+{
+    [JsonPropertyName("formid"), Description("The NPC's FormID 'XXXXXX:Plugin.esp' — houseCARL computes the FaceGen path. Omit kind to place BOTH the mesh and the tint. Provide this OR asset_path.")]
+    public string? Formid { get; init; }
+
+    [JsonPropertyName("kind"), Description("With formid: 'mesh' (head .nif) or 'tint' (face .dds). Omit to place BOTH. Ignored with asset_path.")]
+    public string? Kind { get; init; }
+
+    [JsonPropertyName("asset_path"), Description("A Data-relative destination path (e.g. 'meshes/actors/...'), instead of formid. Provide this OR formid.")]
+    public string? AssetPath { get; init; }
+
+    [JsonPropertyName("source"), Description("The correct copy to place: a loose file path, '<archive.bsa>|<entry>', or a '.bsa' path. Omit to auto-resolve the sole VFS provider. With formid and no kind, an explicit source must be a bare '.bsa' path.")]
+    public string? Source { get; init; }
+}


### PR DESCRIPTION
The WRITE side of dark-face / grey-face repair (facegen-diagnostics Phase 3 PR-B). `housecarl_asset_status` (#18) reads *which* FaceGen copy wins MO2's VFS; these two tools place the *correct* copy into a fresh `houseCARL - FaceGen` mod so it **can** win once enabled + sorted. Builds on the landed `AtomicFile.Commit` (#58).

## Tools (surface → 21)
- **`housecarl_place_asset` (#20)** — place ONE asset. Destination = an NPC `formid`+`kind` (mesh|tint; the FaceGen path is a pure transform of the FormKey) **or** a raw `asset_path`. Source = a loose path, `<archive.bsa>|<entry>`, or a bare `.bsa` (entry := the destination). Omit `source` → auto-use the **sole** provider; **refuse (no guess)** if >1, refuse with guidance if 0.
- **`housecarl_bulk_place_asset` (#21)** — many in one mod folder; a `formid` with no `kind` places **both** mesh + tint.

A *precise placer* (Aaron-locked): it writes a source it's handed and auto-resolves only when exactly one copy is unambiguous — the "which copy is correct" judgment lives in the Phase-4 skill. Source bytes are read **in-process** (a loose file, or one BSA entry via native Mutagen `IArchiveFile.GetBytes` — no BSArch). The write is **crash-atomic** (`AtomicFile.WriteAllBytes` → `File.Replace`, same-volume staging) and **non-destructive** (originals untouched; an all-failed fresh batch leaves no orphan; a reused `into=` folder is never deleted). **Q3-honest:** "wrote it" ≠ "it wins" — the response always reports the current winner and the required MO2 enable + sort, and never implies the fix took effect on write.

## What landed
- `core/FaceGenPath.cs` — the FormKey → FaceGen path **keystone** (folder = the *defining master* in the FormKey, file = `00` + 6-hex local id; mesh under `facegeom/.nif`, tint under `facetint/.dds`). In core so the read side reuses the exact same transform.
- `core/AssetResolver.cs` — `ResolveForPlacement` (concrete on-disk sources, winner-first, via a shared `ResolveProviders` so display + placement can't drift), `TryReadArchiveEntry` (native single-entry BSA extract, **zero handles at rest**, OrdinalIgnoreCase), `ValidateRelPath` (the one drive-rooted/`..` gate, reused).
- `core/AtomicFile.cs` — public + `WriteAllBytes` (same-volume staged write; the place tool's source may be cross-volume/in a BSA, but the bytes are in hand before the swap).
- `mcp/LoadOrderService.cs` — `PlaceAssets` + helpers (resolve owned folder, source bytes, crash-atomic place, integrity check, residue cleanup; serialized on the write gate).
- `mcp/PlaceAssetTools.cs` — the two tools (auto-registered).

## Proof
- **`place-asset-guard`** (CI step wired; 41 checks): keystone matched against the committed fixture; native BSA extract + **zero-handles-at-rest on the extraction path**; precise placer (auto/explicit, ambiguity refused); **wins-VFS end-to-end through the REAL service** (place over a wrong winner, enable on top → it wins `asset_status`); provenance/overwrite via `into=`; non-destructive/orphan; Q3 refusals (drive-rooted/`..`, malformed specs). Self-contained (synthetic instances + committed `FixtureA.bsa`, no BSArch).
- **Mutation-RED-proven:** a non-atomic write flips the crash-atomic arms C + H (service path); dropping the ambiguity guard flips arm F. The BSA-extract case-match bug failed RED organically before the OrdinalIgnoreCase fix.
- `asset-resolver` / `asset-status` / `atomic-commit` siblings stay green (the `Resolve` refactor is behavior-preserving; the `AtomicFile` public change is additive).

## Review (5-dim adversarial, the PR-A process)
Cornerstone **empirically cleared** (Mutagen 0.53.1 reader decompiled — `Func<Stream>`, no mmap; at-rest holds even on a mid-read exception). No concurrency/Q3 bugs. Fixed: a quoted `.bsa` source wrongly refused in the both-expansion (now guarded); the probe's routing gap (arm H now proves the *service* place routes through the crash-atomic primitive). Honest residual: a regression to plain `File.WriteAllBytes` isn't in-process-distinguishable from the crash-atomic write — only a power-cut differs (the same limit `atomic-commit-guard` documents); the guard does catch the meaningful `File.Move` regression.

Notes for follow-up (not blockers): 8-hex FormIDs are rejected (consistent with every other tool's 6-hex convention, fails loud); `bulk_place_asset` owns the "place both mesh+tint" ergonomic by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)