### PR TITLE
asset tools: generalize tool descriptions (de-anchor from facegen)

### DIFF
--- a/src/housecarl-mcp/AssetTools.cs
+++ b/src/housecarl-mcp/AssetTools.cs
@@ -5,12 +5,12 @@ using ModelContextProtocol.Server;
 namespace HousecarlMcp;
 
 /// <summary>
-/// houseCARL asset tool (facegen-diagnostics Phase 2). Read-only. Resolves Data-relative asset paths through MO2's
-/// virtual file system — which mod or BSA provides each asset, and which copy actually WINS in game (loose files beat
-/// BSA-packed; among BSAs the latest-loaded plugin's wins) — the file-side answer the dark-face ("grey/black face")
-/// skill rides. The asset resolver discovers the active BSAs by construction from the same static MO2 profile read the
-/// load order uses (per-plugin "X.bsa"/"X - Textures.bsa" + Skyrim.ini base archives), holds ZERO archive handles at
-/// rest (arch #3), and refreshes by mtime — no daemon, no live tracking.
+/// houseCARL asset tool. Read-only. Resolves Data-relative asset paths through MO2's virtual file system — which mod or
+/// BSA provides each asset, and which copy actually WINS in game (loose files beat BSA-packed; among BSAs the
+/// latest-loaded plugin's wins) — the file-layer counterpart to a record's load-order winner. General asset-layer; the
+/// FaceGen / dark-face skill is one consumer. The asset resolver discovers the active BSAs by construction from the same
+/// static MO2 profile read the load order uses (per-plugin "X.bsa"/"X - Textures.bsa" + Skyrim.ini base archives), holds
+/// ZERO archive handles at rest (arch #3), and refreshes by mtime — no daemon, no live tracking.
 /// </summary>
 [McpServerToolType]
 public static class AssetTools
@@ -22,11 +22,9 @@ public static class AssetTools
          "overwrite folder, the game Data folder, and active BSAs), whether more than one source contends, and whether " +
          "the asset is absent. Precedence is the real engine/MO2 rule — loose files beat BSA-packed, among loose the " +
          "higher-priority mod (then overwrite) wins, among BSAs the later-loaded plugin's archive wins. This is the " +
-         "file-side half of dark-face / grey-face ('black face', 'ashen face') NPC diagnosis: pass an NPC's FaceGen " +
-         "mesh/texture path (meshes\\actors\\character\\facegendata\\... .nif or textures\\actors\\character\\facegendata\\... .dds) " +
-         "to see which mod's facegen wins versus which plugin wins the NPC record — a mismatch is the dark-face bug. " +
-         "Also answers general 'which mod provides this file / who is this asset coming from / is this texture loose or " +
-         "in a BSA / is this asset even present' questions for any mesh, texture, script, sound, or other path. Pass " +
+         "file-layer counterpart to the load-order winner of a record: use it to answer 'which mod provides this file / " +
+         "who is this asset coming from / is this texture loose or in a BSA / is this asset even present / why isn't my " +
+         "override applying' for ANY mesh, texture, script, sound, interface, or other Data-relative path. Pass " +
          "asset_paths = one or more paths RELATIVE to the Data folder (forward or back slashes both fine; a drive-rooted " +
          "or '..'-escaping path is rejected per-path). An archive that cannot be read, or a Skyrim.ini base-archive list " +
          "that cannot be found, is reported LOUD — so an 'absent' answer is never silently trusted when the scan was " +
@@ -34,15 +32,15 @@ public static class AssetTools
     public static string AssetStatus(
         LoadOrderService svc,
         [Description("The Data-relative asset path(s) to resolve, e.g. " +
-                     "'meshes/actors/character/facegendata/facegeom/Skyrim.esm/000ABCDE.nif'. One or many; resolved in " +
-                     "order, results returned in the same order. Paths are relative to the game's Data folder.")]
+                     "'textures/armor/iron/cuirass_1.dds' or 'meshes/clutter/common/tankard01.nif'. One or many; resolved " +
+                     "in order, results returned in the same order. Paths are relative to the game's Data folder.")]
             string[] asset_paths,
         [Description("Optional. Max characters before the per-path list is cut with an explicit notice. 0 = the server default (~80k).")]
             int max_chars = 0) => Guard.Tool("housecarl_asset_status", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         if (asset_paths is null || asset_paths.Length == 0)
-            return "error: asset_paths is empty. Pass one or more Data-relative asset paths (e.g. 'textures/actors/character/facegendata/facetint/Skyrim.esm/000ABCDE.dds').";
+            return "error: asset_paths is empty. Pass one or more Data-relative asset paths (e.g. 'textures/armor/iron/cuirass_1.dds').";
         var data = svc.AssetStatus(asset_paths);
         return AssetWire.Render(data, max_chars > 0 ? max_chars : 80_000);
     });

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -260,7 +260,7 @@ public sealed class LoadOrderService : IDisposable
             // every other writer and instance-switch throughout, so no profile refresh can land between them. Do not call
             // PlaceOne/Assets here outside this _writeGate hold.
             RiderFolder rf;
-            try { rf = ResolvePatchModFolder(patchName, into, "houseCARL_FaceGen"); }
+            try { rf = ResolvePatchModFolder(patchName, into, "houseCARL_Assets"); }   // neutral default stem (general asset placer); the facegen skill passes its own patch_name
             catch (InvalidOperationException ex) { return PlaceOutcome.Fail(ex.Message); }
 
             // ONE asset build for the whole batch (auto-resolve sources + the post-write winner report), reentrant on _gate.

--- a/src/housecarl-mcp/PlaceAssetTools.cs
+++ b/src/housecarl-mcp/PlaceAssetTools.cs
@@ -45,7 +45,7 @@ public static class PlaceAssetTools
             string? asset_path = null,
         [Description("Optional. The correct copy to place: a loose file path; or '<archive.bsa path>|<entry inside>'; or just a '.bsa' path (the entry is taken to be the destination path). If omitted, houseCARL uses the SOLE provider in your load order and refuses if more than one provides it (you choose).")]
             string? source = null,
-        [Description("Optional. Base name for the NEW houseCARL mod folder the file lands in (default 'houseCARL_FaceGen'); auto-suffixed if taken.")]
+        [Description("Optional. Base name for the NEW houseCARL mod folder the file lands in (default 'houseCARL_Assets'); auto-suffixed if taken.")]
             string? patch_name = null,
         [Description("Optional. Filename of an existing houseCARL patch mod to place into instead of a fresh folder (accumulate across calls).")]
             string? into = null) => Guard.Tool("housecarl_place_asset", () =>
@@ -73,7 +73,7 @@ public static class PlaceAssetTools
         LoadOrderService svc,
         [Description("The assets to place, all into one mod folder. Each: { formid?: 'XXXXXX:Plugin.esp', kind?: 'mesh'|'tint' (omit with formid to place BOTH), asset_path?: 'meshes/...', source?: '<loose path>' | '<archive.bsa>|<entry>' | '<archive.bsa>' }.")]
             PlaceAssetSpec[] assets,
-        [Description("Optional. Base name for the NEW houseCARL mod folder (default 'houseCARL_FaceGen'); auto-suffixed if taken.")]
+        [Description("Optional. Base name for the NEW houseCARL mod folder (default 'houseCARL_Assets'); auto-suffixed if taken.")]
             string? patch_name = null,
         [Description("Optional. Filename of an existing houseCARL patch mod to place into instead of a fresh folder.")]
             string? into = null) => Guard.Tool("housecarl_bulk_place_asset", () =>

--- a/src/housecarl-mcp/PlaceAssetTools.cs
+++ b/src/housecarl-mcp/PlaceAssetTools.cs
@@ -8,39 +8,40 @@ using HousecarlCore;
 namespace HousecarlMcp;
 
 /// <summary>
-/// houseCARL place-asset tools (facegen-diagnostics Phase 3) — the WRITE side of dark-face / grey-face repair. Where
-/// housecarl_asset_status (read-only) tells you WHICH copy of a FaceGen file currently wins MO2's VFS, these place the
-/// CORRECT copy into a NEW houseCARL-owned mod folder so it CAN win once enabled + sorted. A precise placer: it writes a
-/// source it is handed and auto-resolves only when exactly ONE copy exists (the "which copy is correct" judgment is the
-/// caller's / the facegen skill's, not the tool's). Source bytes are read IN PROCESS — a loose file, or a single entry
-/// out of a BSA via native Mutagen (no BSArch). The write is crash-atomic and non-destructive (originals untouched; a
-/// failed fresh placement leaves no orphan). Honest (Q3): "wrote it" is NOT "it wins" — the tool reports the current
-/// winner and the required MO2 enable + sort, and never claims the fix took effect on write.
+/// houseCARL place-asset tools — place a chosen asset file (any Data-relative file) as a winning override in a NEW
+/// houseCARL-owned MO2 mod folder, the WRITE counterpart to housecarl_asset_status (which reports which copy currently
+/// wins the VFS). A precise placer: it writes a source it is handed and auto-resolves only when exactly ONE copy exists
+/// (the "which copy is correct" judgment is the caller's / a skill's, not the tool's). Source bytes are read IN PROCESS —
+/// a loose file, or a single entry out of a BSA via native Mutagen (no BSArch). The write is crash-atomic and
+/// non-destructive (originals untouched; a failed fresh placement leaves no orphan). Honest (Q3): "wrote it" is NOT "it
+/// wins" — the tool reports the current winner and the required MO2 enable + sort, and never claims the fix took effect on
+/// write. General asset-layer; the FaceGen / dark-face case is the headline use case, driven by the facegen skill (the
+/// formid+kind input is its convenience — for any other file use asset_path).
 /// </summary>
 [McpServerToolType]
 public static class PlaceAssetTools
 {
-    [McpServerTool(Name = "housecarl_place_asset", Title = "Place ONE FaceGen/asset file so the correct copy can win MO2's VFS"),
+    [McpServerTool(Name = "housecarl_place_asset", Title = "Place ONE asset file so a chosen copy can win MO2's VFS"),
      Description(
-         "Place ONE asset file (a FaceGen .nif/.dds, or any Data-relative file) into a NEW houseCARL-owned MO2 mod folder " +
-         "so the CORRECT copy can win the virtual file system — the WRITE half of dark-face / grey-face ('black face', " +
-         "'ashen face') NPC repair (housecarl_asset_status is the read half). Give the DESTINATION as either formid (an " +
-         "NPC's FormID 'XXXXXX:Plugin.esp' — houseCARL computes the FaceGen path: folder = the DEFINING plugin in the " +
-         "FormID, file = the FormID with the index masked) plus kind ('mesh' = the head .nif, 'tint' = the face .dds), OR " +
-         "asset_path (a raw Data-relative path for any file). Give the SOURCE (the correct copy) as source= a loose file " +
-         "path, or '<archive.bsa path>|<entry inside>', or just a '.bsa' path (the entry is taken to be the destination " +
-         "path — the Creation-Club-NPC case). If source is OMITTED, houseCARL auto-resolves: it uses the SOLE provider in " +
-         "your load order, and REFUSES (telling you the candidates) if more than one provides it — it will not guess which " +
-         "is correct. The write is crash-atomic; originals are never touched. IMPORTANT (and reported back): the placed " +
-         "copy does NOT win on write — you must ENABLE the new mod in MO2 and SORT it above the current winner. This tool " +
-         "places ONE file; to place an NPC's mesh AND tint together (or many files) use housecarl_bulk_place_asset.")]
+         "Place ONE asset file — ANY Data-relative file (a mesh, texture, script, sound, interface, etc.) — into a NEW " +
+         "houseCARL-owned MO2 mod folder so a CHOSEN copy can win the virtual file system. The WRITE counterpart to " +
+         "housecarl_asset_status (which reports which copy currently wins). Give the DESTINATION as asset_path (a " +
+         "Data-relative path); OR, for an NPC's generated FaceGen file, as formid (the NPC's FormID 'XXXXXX:Plugin.esp') " +
+         "+ kind ('mesh' = the head .nif, 'tint' = the face .dds), which houseCARL computes the path for. Give the SOURCE " +
+         "(the copy to place) as source= a loose file path, or '<archive.bsa path>|<entry inside>', or just a '.bsa' path " +
+         "(the entry is taken to be the destination — a quick way to pull ONE file out of a BSA as a loose override). If " +
+         "source is OMITTED, houseCARL auto-resolves: it uses the SOLE provider in your load order, and REFUSES (telling " +
+         "you the candidates) if more than one provides it — it will not guess which is correct. The write is crash-atomic; " +
+         "originals are never touched. IMPORTANT (and reported back): the placed copy does NOT win on write — you must " +
+         "ENABLE the new mod in MO2 and SORT it above the current winner. This tool places ONE file; to place several (or " +
+         "an NPC's mesh AND tint together) use housecarl_bulk_place_asset.")]
     public static string PlaceAsset(
         LoadOrderService svc,
-        [Description("Optional. The NPC's FormID 'XXXXXX:Plugin.esp' — houseCARL computes the FaceGen path from it. Use for dark-face fixes. Provide this OR asset_path. Requires kind=.")]
+        [Description("Optional. For an NPC's generated FaceGen file: the NPC's FormID 'XXXXXX:Plugin.esp' — houseCARL computes the FaceGen path from it. For any other file, use asset_path instead. Provide this OR asset_path; requires kind=.")]
             string? formid = null,
         [Description("Optional (with formid). Which FaceGen file: 'mesh' (the head .nif) or 'tint' (the face .dds). REQUIRED when formid is given — this tool places one file. Use housecarl_bulk_place_asset to place both at once.")]
             string? kind = null,
-        [Description("Optional. A Data-relative destination path to place to directly (e.g. 'meshes/actors/...'), instead of formid+kind. Provide this OR formid. A drive-rooted or '..'-escaping path is rejected.")]
+        [Description("Optional. The Data-relative destination path to place to (any file — e.g. 'textures/armor/iron/cuirass_1.dds', 'meshes/...', a script, a sound), instead of formid+kind. Provide this OR formid. A drive-rooted or '..'-escaping path is rejected.")]
             string? asset_path = null,
         [Description("Optional. The correct copy to place: a loose file path; or '<archive.bsa path>|<entry inside>'; or just a '.bsa' path (the entry is taken to be the destination path). If omitted, houseCARL uses the SOLE provider in your load order and refuses if more than one provides it (you choose).")]
             string? source = null,
@@ -55,15 +56,15 @@ public static class PlaceAssetTools
         return PlaceWire.Render(svc.PlaceAssets(reqs!, patch_name, into));
     });
 
-    [McpServerTool(Name = "housecarl_bulk_place_asset", Title = "Place MANY FaceGen/asset files in one houseCARL mod"),
+    [McpServerTool(Name = "housecarl_bulk_place_asset", Title = "Place MANY asset files in one houseCARL mod"),
      Description(
-         "Place MANY asset files in ONE houseCARL-owned MO2 mod folder — the batch form of housecarl_place_asset, and the " +
-         "way to fix an NPC's FaceGen mesh AND tint together (or several NPCs at once). assets is an array of " +
-         "{ formid?, kind?, asset_path?, source? }: give EITHER formid (an NPC FormID — omit kind to place BOTH the mesh " +
-         "and the tint; or set kind='mesh'/'tint' for just one) OR asset_path (a raw Data-relative path). source is the " +
-         "correct copy (a loose file path, '<archive.bsa>|<entry>', or a '.bsa' path); omit it to auto-resolve the sole " +
-         "VFS provider (an ambiguous or absent source becomes a per-asset error — the rest still place). When you give a " +
-         "FormID with no kind (placing both files), an explicit source must be a '.bsa' path (each slot's entry is " +
+         "Place MANY asset files in ONE houseCARL-owned MO2 mod folder — the batch form of housecarl_place_asset (place " +
+         "several overrides at once; or, for an NPC, its FaceGen mesh AND tint together). assets is an array of " +
+         "{ formid?, kind?, asset_path?, source? }: give EITHER asset_path (any Data-relative path) OR formid (an NPC " +
+         "FormID — omit kind to place BOTH the FaceGen mesh and the tint; or set kind='mesh'/'tint' for just one). source " +
+         "is the copy to place (a loose file path, '<archive.bsa>|<entry>', or a '.bsa' path); omit it to auto-resolve the " +
+         "sole VFS provider (an ambiguous or absent source becomes a per-asset error — the rest still place). When you give " +
+         "a FormID with no kind (placing both files), an explicit source must be a '.bsa' path (each slot's entry is " +
          "derived) — for a single loose/entry source set kind=. All files land in ONE reviewable mod folder. A malformed " +
          "spec (bad FormID, bad kind, neither/both of formid+asset_path) refuses the WHOLE call with per-spec reasons and " +
          "places nothing. As with the single tool, the placed copies do NOT win until you enable + sort the mod in MO2 " +


### PR DESCRIPTION
Follow-up to [#59](https://github.com/Avick3110/houseCARL/pull/59). The asset tools (`housecarl_asset_status` #18, `housecarl_place_asset` #20, `housecarl_bulk_place_asset` #21) are a **general VFS asset layer**, but their model-facing descriptions led with — and `asset_status` was saturated by — the dark-face / grey-face NPC narrative. That actively suppresses the broader, more common use (a "this is the facegen tool" description makes the model less likely to reach for `asset_status` on "which mod's texture wins?"), and cuts against Anthropic's tool-authoring guidance (describe the tool's *actual* general capability; keep tools distinct). The dark-face framing belongs in the Phase-4 facegen skill that drives these tools — clean split: tool = general capability, skill = use-case workflow.

**Description-only — no behavior change, no probe pins description text.**

- **`housecarl_asset_status`** — title already general; description now leads with the general "which copy wins the VFS" capability for ANY mesh/texture/script/sound/interface path (the file-layer counterpart to a record's load-order winner). The dark-face block removed; example paths made neutral.
- **`housecarl_place_asset` / `housecarl_bulk_place_asset`** — titles drop "FaceGen/"; descriptions lead with general asset placement (including pulling one file out of a BSA as a loose override), with `formid`+`kind` demoted to "for an NPC's FaceGen file" — one convenience input, not the framing. Q3 honesty ("wrote it" ≠ "it wins") and the precedence explanation are unchanged.
- Class-summary comments (internal, not model-facing) note FaceGen as the *headline use case* driven by the facegen skill — honest, demoted.

FaceGen stays named only where it's literally accurate: the `formid`/`kind` params, which compute a FaceGen path from an NPC FormKey.

`asset-status-guard` + `place-asset-guard` stay green (no behavior touched); full solution builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Update (folded in from review):** also renames the default mod-folder stem from `houseCARL_FaceGen` to the neutral `houseCARL_Assets` (the one residual facegen anchor — a general override placed with no `patch_name` was landing in a "houseCARL - houseCARL_FaceGen" folder). The two `patch_name` param docs updated to match. Behavior change is the default folder *name* only; `place-asset-guard` stays green (no arm pins the stem). So this PR is no longer strictly description-only.
