### PR TITLE
facegen-diagnostics: author the dark-face investigation-flow skill (Phase 4 / B3)

### DIFF
--- a/.claude/skills/facegen-diagnostics/SKILL.md
+++ b/.claude/skills/facegen-diagnostics/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: facegen-diagnostics
+description: Diagnose and (where houseCARL can) repair the dark / grey / black-face NPC bug in Skyrim SE — resolve the NPC to a FormKey, compare the load-order record winner against the VFS facegen file winner, then place the correct facegen as a winning override (`housecarl_place_asset` / `housecarl_bulk_place_asset`) or forward the matching appearance into an override, instructing the CK / NifSkope / RaceMenu fixes houseCARL cannot perform. Use when an NPC has a dark, grey, black, brown, or discolored face, a head darker than its body or a neck seam, a face "fine in xEdit but wrong in game", a whole mod's NPCs gone dark after an ESL-compaction or merge, a missing or headless face, or the player's own face turned grey — or when the user mentions FaceGen, facegeom/facetint, the dark face bug, or Face Discoloration Fix. Load this before judging any face bug, even one that looks like a simple missing file — the fix hinges on which of two independent precedence systems (record vs file) wins, and a wrong call places facegen where the engine never looks.
+---
+
+# Facegen Diagnostics
+
+## Overview
+
+This is an investigation flow for the dark/grey/black-face family of NPC bugs in Skyrim SE. A baked NPC
+face is two preprocessed per-NPC files (a head `.nif` and a face tint `.dds`); "dark face" is a **desync**
+between the plugin that wins the NPC **record** and the mod/BSA that wins the **facegen file** for that
+same NPC. This skill resolves the NPC, computes its facegen path, compares the two winners, and decides
+whether to make the right **file** win or forward the right **appearance** into a record — then verifies.
+
+**What houseCARL CAN do:** report the VFS/file winner of a Data-relative path (`housecarl_asset_status`),
+place a correct copy as a winning loose override including single-entry in-process BSA extract
+(`housecarl_place_asset` / `housecarl_bulk_place_asset`), and read the load-order-winning record + write
+appearance edits into a new override plugin (`housecarl_read_record`, `housecarl_set_field`,
+`housecarl_create_record`, `housecarl_cross_plugin_query`, `housecarl_batch_record_detail`).
+
+**What houseCARL CANNOT do — instruct, never claim:** bake/regenerate facegen geometry (that is Creation
+Kit Ctrl+F4), and read or edit the internal bytes of a `.nif` or `.dds` (it moves whole files; it does not
+edit their contents). Anything needing NifSkope, a texture tool, the CK, or a runtime SKSE mod is
+**instructed**. Saying this limit out loud is the Q3-honest move, not a failure.
+
+The full cause taxonomy (A–X), fix taxonomy, symptom table, community-tool routing, and path mechanics
+live in [`references/facegen-causes-and-fixes.md`](references/facegen-causes-and-fixes.md) — read it to
+pin a specific cause or pick a fix; the flow below is enough to drive most diagnoses.
+
+## The two-precedence model (read before judging anything)
+
+Dark face exists because **two independent precedence systems** decide different things:
+
+- **Plugin load order** decides which mod's **NPC record** wins → `housecarl_read_record`.
+- **The MO2 VFS / asset order** decides which mod's **facegen FILE** wins → `housecarl_asset_status`.
+  **Loose always beats BSA**; among loose, MO2 priority (then overwrite) wins; among BSAs, the later-loaded
+  plugin's wins.
+
+The face goes dark whenever, for one NPC, the **file winner's source ≠ the record winner's appearance
+source**, or nothing wins the computed path — the engine then regenerates the head from the record and
+drops the tint. This is why **xEdit can show no record conflict yet the face is dark**: the desync is
+between a record and a *file*. Checking both winners is houseCARL's structural advantage — and the reason a
+record-only tool can't solve this.
+
+**The path is a pure function of the FormKey** (no path is stored in the record): folder =
+`FormKey.ModKey.FileName` (the **defining master**, NOT the conflict winner); filename = `"00"` + the 6-hex
+local id. There is **no cross-folder fallback** — the engine reads one keyed path and regenerates if
+nothing wins there. So always ask *"what wins this exact path, and does it match the record?"* — never
+*"does it fall back?"* (Mechanics, ESL, and injected-record detail: reference §1.)
+
+## Step 0 — Scope and exclusions first (avoid false positives)
+
+Rule these out before any tool call — each is out of houseCARL's lane and the desync flow would mislead:
+
+- **Player-only grey, NPCs fine** (appeared after a reload / game update / crash) → almost certainly
+  RaceMenu/SKEE co-save state, **not** facegen (Causes U/V). If **all** RaceMenu sliders/overlays are also
+  gone game-wide, skee64.dll didn't load (V) — suspect first if it followed a Skyrim/Steam update. houseCARL
+  is a **no-op**: instruct re-apply preset / OverlayFix / SKEE cosave fix (U), or SKSE↔runtime↔RaceMenu
+  version match + read `skse64.log` (V). Stop. (Phrase as "strongly suggests," not "proves.")
+- **Brown face** matching nothing → weight/scale baked into the save (Cause Q). Re-issue `setnpcweight`;
+  if save-baked, new game or ReSaver. Runtime, not a file fix.
+- **Purple / bright-white face** → a missing *texture* file, not facegen desync. Different lane.
+- **Shiny/oily face, ash-pile** → specular/ENB or script state. Not facegen.
+- **`FFxxxxxx` base id** (runtime-spawned) or **SPID/SkyPatcher-distributed appearance** → houseCARL reads
+  *plugin* records, so the winner it sees may not be the in-game face (Cause T). Warn; route to FDF or
+  matching the distributed head parts, not `place_asset`. (DynDOLOD is object-LOD, not NPC appearance.)
+- **NPC built from a RaceMenu `.jslot` preset, facegen comes up missing** (Cause W) → the preset is not
+  facegen; instruct Sculpt→Export Head / Ctrl+F4. Once the `.nif`/`.dds` exist, `place_asset` can win them.
+
+## The front door — resolve the NPC to a FormKey
+
+Users name an NPC by display name, EditorID, or a FormID they read somewhere — rarely as
+`XXXXXX:DefiningMaster.esp`. Resolve carefully; one path is a trap:
+
+1. **Prefer EditorID, then name.** Resolve via `housecarl_cross_plugin_query` over `NPC_` (a `where=`
+   predicate on the EditorID or the display-name field). On **more than one** hit ("Guard", "Bandit"),
+   list the candidates and have the user pick — **never auto-pick the first**.
+2. **An xEdit-style FormID** the user already read: drop the high byte (it's that person's load-order
+   index), keep the 6-hex local, and let houseCARL attach the defining master from its own load order.
+3. **A console-clicked FormID — STOP.** It is a RefID (the placed instance, not the base NPC_) and/or a
+   live runtime-indexed id; houseCARL's runtime-FormID↔FormKey bridge is **unshipped**, so the high byte
+   (and the ESL `FExxx` slot) can't be mechanically resolved. Route to name/EditorID (have the user run
+   `help "<name>" 4` or Skyrim Search SE), or treat the 6-hex local as a *hypothesis* and confirm by
+   reading the candidate record back and matching the name. Never silently trust the console high byte — a
+   wrong high byte → wrong defining master → wrong facegen folder, exactly the trap.
+
+Once you hold the FormKey, `housecarl_read_record` it and check the **Template + "Use Traits"** exclusion:
+if `Template` is set **and** `Configuration.TemplateFlags` includes `Traits` (Cause S), the NPC has no
+facegen of its own — recompute the path against the **template's** FormKey, not this one.
+
+## Diagnosis decision tree
+
+**Step 1 — Record winner.** `housecarl_read_record` → which plugin's NPC record wins, and (from the
+FormKey) the **defining master**. Confirm the record resolves and its masters are present (a dark/missing
+actor where the *correct* file wins points at a missing master, Cause L — not a file fix). houseCARL exposes
+FormIDs as `XXXXXX:Plugin.esp`, so folder + filename are computable from the FormKey alone.
+
+**Step 2 — Compute the facegen path (both files, always a pair):**
+- `meshes\actors\character\facegendata\facegeom\<DefiningMaster>\<00…ID>.nif`
+- `textures\actors\character\facegendata\facetint\<DefiningMaster>\<00…ID>.dds`
+
+**Step 3 — File winner.** `housecarl_asset_status` on **both** paths (it takes raw `asset_paths` with no
+FormID/kind, so **you compute and pass both** the `.nif` and the `.dds`). Branch on the result:
+- **No winner / absent everywhere** → the engine regenerates and drops tint → dark face. Does the **winning
+  record actually change appearance** vs the defining master? Compare **`FaceMorph` / `TintLayers` /
+  `HeadTexture`**, not `HeadParts` alone (a winner can change morph/tint while keeping the head-parts list,
+  via `housecarl_cross_plugin_query` / `housecarl_batch_record_detail`). Unchanged → it's riding the
+  master's facegen at the same keyed path (benign) — confirm the master's file resolves. Changed and no
+  facegen exists anywhere → **Cause B/N: nothing correct to place → instruct CK Ctrl+F4** (FDF as a
+  color-only band-aid). Recently **ESL-compacted or merged**? A stale old-name file may exist while the new
+  path is empty (Cause F/G) — rename/place to the new name **plus** instruct the embedded-`.nif`-path edit.
+- **A file wins, but from the wrong source** → Cause A/C/D/E. Is it a **loose file from a different/disabled
+  mod or MO2 overwrite** masking the correct copy (E; loose beats BSA even from a disabled mod)? The correct
+  copy **trapped in a losing/double BSA** (D)? A **non-appearance edit** that won the record while an
+  overhaul's file still wins (C)?
+- **A file wins from the right source, record looks right, still dark** → "file present" is necessary but
+  not sufficient: the `.nif`'s internal head-part block names may not match the record (mode ii), which
+  houseCARL **cannot inspect** — instruct CK re-bake / FDF, and confirm masters (Cause L) before concluding.
+
+**Step 4 — Decide which copy is correct (the judgment this skill owns).** The invariant: **the winning
+record's appearance and the winning facegen files must come from the SAME source.** The place tools are
+deliberately dumb about which copy is correct — *this skill decides*, then drives them with an **explicit
+`source=`** for a real desync fix (auto-resolve is a re-assert convenience, useful for sole-BSA→loose or to
+own the copy):
+- **Record winner is the intended appearance, wrong file wins** → **Fix B**: `place_asset` the correct
+  facegen as a winning loose override.
+- **The file is the intended appearance, a non-appearance plugin won the record** → **Fix C**: forward the
+  appearance fields into a new override (houseCARL's editorial minimal set — `HeadParts, FaceMorph,
+  FaceParts, TintLayers, HairColor, HeadTexture, TextureLighting`, + optional `WornArmor`).
+- Often **both** (Fix B + Fix C together).
+
+Placing both files of an NPC at once: `housecarl_bulk_place_asset` with `formid` and **no `kind`** expands
+to mesh+tint via the pure path transform (an explicit `source=` for that both-case must be a **bare `.bsa`**
+path — for a loose file or a `<bsa>|<entry>` source, set `kind=` and place the two separately). The single
+`housecarl_place_asset` **requires** `kind` (`mesh`/`tint`) with a `formid`. **Place both halves from the
+SAME source mod** — a same-FormKey forward is safe by construction (the `.nif`'s embedded `.dds` path
+already resolves at the destination); only cross-FormKey / renumber / re-folder cases need the
+NifSkope/FaceGenEslify escalation (reference Fix B/E).
+
+**Step 5 — Verify ("wrote it" ≠ "it wins" ≠ "it renders correctly").** This is the Q3 backbone — houseCARL
+confirms **provenance, not appearance** (it cannot read mesh/texture bytes or render):
+- **5a — VFS check (houseCARL).** Re-run `housecarl_asset_status` to confirm the placed copy actually wins,
+  and tell the user to **enable + sort** the new mod above the current winner (the tool reports the winner
+  to sort above; trust its reported winner over the abstract rule — a "Manage Archives"-on user can rank a
+  BSA above loose). This is necessary but **not sufficient** — a green status survives (1) winning-but-wrong
+  content (houseCARL never validated the head inside the file), (2) a geometry/tint split, and (3) the save
+  cache (Skyrim bakes facegen into the save for any already-loaded actor).
+- **5b — In-game correctness handoff (the user's eyes, by design).** Hand the user this:
+  1. `` ` `` (console) → **click the NPC** → `setnpcweight 50` → `` ` ``. This reloads the actor's 3D head
+     in place, defeating the save cache. It is a *verification probe*, not the fix (temporary; reverts on
+     cell change).
+  2. `prid <RefID>` then `moveto player` (or `player.moveto <RefID>`) to reach them. **Never put `coc` in a
+     `.bat` — it CTDs.** `prid`/`moveto`/`setnpcweight` need the in-world **RefID**, not the NPC_ base id.
+  3. Look at the face. Correct → done. Still wrong → wrong file content (re-pick the source — houseCARL
+     can't see inside the `.nif`/`.dds`) or a baked save (→ 5d).
+- **5c — FDF-off litmus.** A genuinely-correct fix renders right with **FDF disabled**. If it looks right
+  only with FDF installed, FDF is *masking* a desync the placed file didn't fix — still report and fix the
+  underlying desync.
+- **5d — True clean check.** Because facegen is baked into the save, the only fully-authoritative check is a
+  **new game or a save where the NPC never loaded**. If `setnpcweight` + visual still shows wrong, the
+  residue is in the save → hand off to Fallrim Tools (ReSaver) to delete the NPC's baked ChangeForm by base
+  id (also resets faction ranks). houseCARL does not perform save edits.
+
+## Batch flow ("a bunch of NPCs went dark after I installed X")
+
+Mirror Dark Face Issue Reporter at the VFS layer — **enumerate → compute-all → asset_status-all →
+bulk_place**:
+1. `housecarl_cross_plugin_query` the suspect plugin's `NPC_` records (or query across the load order and
+   filter to records whose **load-order winner** is X). **Dedupe to winners only.**
+2. `housecarl_batch_record_detail` for FormKey + defining master per NPC in one batch.
+3. Compute both facegen paths per NPC.
+4. `housecarl_asset_status` each path. Three batch signatures: (i) *every* path resolves to nothing/vanilla
+   → ESLify/merge FormID desync (Cause F/G, the "universal" case); (ii) record winner ≠ file winner
+   consistently → record-vs-asset desync; (iii) only a subset dark → per-NPC missing/incompatible facegen.
+5. `housecarl_bulk_place_asset` the correct copies into one fresh reviewable mod.
+
+**Boundary:** houseCARL can batch-detect and batch-relocate/rename existing correct facegen (covers Cause
+F/G — pure file-name/folder desyncs). If the batch reveals the facegen **exists nowhere** (true
+missing/regenerate), the fix is **CK Ctrl+F4** — houseCARL cannot bake and must instruct.
+
+## Common mistakes
+
+- **Anchoring the facegen folder to the conflict winner.** The folder is the **defining master**
+  (`FormKey.ModKey.FileName`) — for a vanilla-NPC overhaul that's `Skyrim.esm\`, not the overhaul's folder.
+  Using the winner computes a path the engine never reads. The single highest-stakes mechanical error.
+- **Trusting a console-clicked FormID.** It's a RefID and/or runtime-indexed; the bridge is unshipped.
+  Route to name/EditorID — a wrong high byte points at the wrong defining master.
+- **Calling "a file wins" the all-clear.** "File present at the path" is necessary, not sufficient — mode ii
+  (`.nif` head-part block names ≠ record) dark-faces with a file present, and houseCARL can't see `.nif`
+  internals. Always hand off the in-game check.
+- **Declaring victory on a green `asset_status`.** That's provenance, not appearance — never skip Step 5b.
+  Skipping it is a Q3 violation (a victory you provenance-checked but never appearance-checked).
+- **Placing only one of the pair.** `.nif` and `.dds` go together, from the same source — one alone
+  re-creates a mismatch.
+- **Treating multi-provider / "Ambiguous" as a problem.** At a large modlist's scale, more than one source
+  providing a path is the **common, healthy** case — present it neutrally; it's a "verify if unexpected"
+  signal, not a detected fault.
+- **Reaching for `place_asset` on an out-of-lane cause.** Player-only grey (U/V), `.jslot` presets (W),
+  NiOverride overlays (X), `FFxxxxxx`/SPID-distributed (T), brown/save-baked (Q) — name the real tool, don't
+  place a file that does nothing.
+
+## Make a defensible verdict (no silent wrong answers)
+
+A face-bug diagnosis lands on one of two honest outcomes, never a confident guess:
+
+1. **A diagnosis with the cause, the fix, and its capability class** — "Cause A: `read_record` winner is
+   Bijin, but `asset_status` shows the `.nif`/`.dds` won by a stale loose copy from a disabled mod. Fix B:
+   `place_asset` Bijin's pair as a winning override; then enable+sort and run the in-game `setnpcweight`
+   check." Name which winner is wrong and which fix moves which half.
+2. **An explicit "I can't fully resolve this — here's what I checked and what to do next"** — when the cause
+   is out of lane (the file wins and the record looks right, so it's likely mode ii inside the `.nif`, which
+   I can't inspect → CK re-bake / in-game check), or houseCARL is structurally a no-op (RaceMenu/SKEE,
+   save-baked, runtime-distributed). Say what you confirmed, why houseCARL can't finish it, and the exact
+   external tool that can.
+
+A confidently wrong "place this file and you're done" sends the user to enable a mod that changes nothing —
+worse than a clear non-answer. Prefer the honest gap and the right external tool.
+
+## Notes
+
+- **Pair everything.** Query, place, extract, and forward both the `.nif` (FaceGeom) and the `.dds`
+  (FaceTint) for a FormKey — fixing one without the other still dark-faces.
+- **Two embedded `.nif` references are both invisible to houseCARL** — the FaceTint `.dds` path (NifSkope
+  slot 7) and the skin diffuse/normal paths (slots 1/2). Route by symptom: stale FaceTint → FaceGenEslify;
+  wrong skin path → NPC Facegen Patcher; general missing tint → FDF. Never claim to know which slot is
+  broken (reference §6).
+- **FaceGenEslify renames files; it does NOT auto-edit the embedded `.nif` path** (that's a manual NifSkope
+  step). houseCARL's conclusion is unchanged — it can rename/place files but must *instruct* the embedded
+  edit on cross-FormKey/renumber cases.
+- **Field names:** confirm any NPC_ field path/spelling via the `mutagen-reference` skill before composing a
+  `set_field`/`create_record` — the appearance set uses Mutagen spellings (`TextureLighting` = the QNAM
+  Color field; `TintLayers` is one token).
+- **The place tools report the required enable+sort and never claim the fix took effect on write** — carry
+  that honesty through to the user.

--- a/.claude/skills/facegen-diagnostics/evals/eval_set.json
+++ b/.claude/skills/facegen-diagnostics/evals/eval_set.json
@@ -1,0 +1,155 @@
+{
+  "skill_name": "facegen-diagnostics",
+  "_validation_method": "Manual prediction per HOUSECARL_SKILL_AUTHORING.md §6.5 at authoring time (empirical run_loop.py unavailable: absent from this repo and no non-Windows env), THEN validated via houseCARL's native cold-read fan-out (anonymized, relevance-framed; fresh agents shown a neutral skill catalog with the candidate description unlabeled among the real shipped skills, queries shuffled into mixed batches so no agent saw the trigger cluster, judging blind — per feedback_skill_trigger_eval_fanout). The candidate skill lived only in the worktree (not installed), so it could not contaminate its own eval. Reasoning was read, not just the verdict. Outcome correctness (§6.6) covered by the _q3_outcome notes below + Aaron empirical sign-off on the live order before the 1.3 release (PRE_RELEASE_1.3_LOCAL_TEST_CHECKLIST.md).",
+  "_fanout_note_post_trim": "After the fan-out, the description was trimmed from 190→179 words to meet the §3.5 soft target. The trim removed only redundant phrasings ('a face that's'→'a face', 'into a new plugin'→'into an override', dropped 'or a baked face that doesn't match the record'); NO validated trigger noun was removed, so the shipped trigger surface is a strict subset of the fanned-out one and the 10/10 recall holds a fortiori.",
+  "_fanout_result": "2026-06-16, 5 router agents × 4 mixed queries (20 total). RECALL 10/10 (100%) — every should-trigger query routed to facegen-diagnostics, each citing the correct symptom (dark/grey/black/brown face, neck seam, fine-in-xEdit, ESL-batch, FDF, player-grey, which-copy-wins). SPECIFICITY 10/10 (100%) — every should-not-trigger near-miss routed elsewhere (skypatcher ×2, spid, papyrus-reference, none ×6). Both far exceed the §6.3 gates (≥80% / ≥50%). Notable: the CBBE body neck-seam near-miss was correctly distinguished — the agent keyed on 'tone breaks BELOW the neck → body-texture, not facegen' and explicitly noted 'head darker than body would flip it to facegen', i.e. the skill's intended discriminator held. The asset_status-only and purple-armor cases resisted the VFS/texture-vocabulary overlap. No near-miss false-fire.",
+  "_predicted_recall": "10/10 should-trigger predicted to fire (100%) — CONFIRMED 10/10 by fan-out",
+  "_predicted_specificity": "10/10 should-not-trigger predicted to abstain — CONFIRMED 10/10 by fan-out (the four flagged risks all held)",
+  "_specificity_risks_to_watch": [
+    "snt-skypatcher-npc-face", "snt-asset-status-only", "snt-shiny-enb-face", "snt-npc-outfit-edit"
+  ],
+  "_q3_outcome": "Investigation-flow + procedural-write archetype → §6.6 Q3 conformance applies. Pass = emit a correct cause+fix+capability-class diagnosis OR an explicit 'houseCARL cannot finish this — here's what I checked + the external tool that can' (CK/NifSkope/RaceMenu/ReSaver). Silent wrong answer (e.g. 'place this file and you're done' when the real cause is out of lane, or anchoring the facegen folder to the conflict winner) fails outright. The out-of-lane should-trigger cases (brown face, player-only grey) are deliberate Q3 probes: the correct outcome is the honest 'houseCARL is a no-op, here's the runtime fix', not a place_asset.",
+  "evals": [
+    {
+      "id": "st-dark-follower-overhaul",
+      "query": "i installed Bijin and now Lydia's face is way darker than her body with a visible neck seam, how do i fix it",
+      "should_trigger": true,
+      "manual_predicted_trigger": true,
+      "rationale": "Canonical dark-face desync on an overhauled NPC (Cause A). Named symptom (darker face + neck seam) + named NPC. Core use case."
+    },
+    {
+      "id": "st-fine-in-xedit-dark-in-game",
+      "query": "this NPC looks fine in xedit, no conflicts, but in game her face is black. what am i missing",
+      "should_trigger": true,
+      "manual_predicted_trigger": true,
+      "rationale": "The record-vs-file desync tell verbatim — the exact case a record-only tool misses and asset_status catches."
+    },
+    {
+      "id": "st-esl-batch-dark",
+      "query": "i compacted my follower mod to ESL and now every single NPC in it has a grey face. did i break the facegen?",
+      "should_trigger": true,
+      "manual_predicted_trigger": true,
+      "rationale": "Whole-mod ESL-compaction FormID renumber (Cause F), the batch 'universal' signature. Mentions facegen explicitly."
+    },
+    {
+      "id": "st-generic-greyface-bug",
+      "query": "how do i fix the grey face bug on npcs in skyrim se",
+      "should_trigger": true,
+      "manual_predicted_trigger": true,
+      "rationale": "Generic dark/grey face bug request — the skill's headline topic."
+    },
+    {
+      "id": "st-modder-baked-still-black",
+      "query": "i made a custom npc and baked the facegen with ctrl+f4 in the CK but her head is still pitch black in game",
+      "should_trigger": true,
+      "manual_predicted_trigger": true,
+      "rationale": "Baked-but-still-black → mode ii head-parts/nif mismatch or a path/winner problem; the skill triages record-vs-file and the .nif-internals boundary."
+    },
+    {
+      "id": "st-fdf-mention",
+      "query": "should i just install Face Discoloration Fix for my black face npcs or is there a real fix",
+      "should_trigger": true,
+      "manual_predicted_trigger": true,
+      "rationale": "Names FDF + black-face NPCs. The skill owns the FDF-is-a-color-mask-not-a-fix framing and the FDF-off litmus."
+    },
+    {
+      "id": "st-dark-after-installing-mod",
+      "query": "a bunch of my npcs went dark in the face after i added that big npc overhaul pack, how do i track down which ones and fix them",
+      "should_trigger": true,
+      "manual_predicted_trigger": true,
+      "rationale": "Batch 'after I installed X' flow — enumerate winners → compute paths → asset_status-all → bulk_place."
+    },
+    {
+      "id": "st-brown-face",
+      "query": "one of my followers has a brown face that doesn't match her body, the rest look fine",
+      "should_trigger": true,
+      "manual_predicted_trigger": true,
+      "rationale": "Brown face (Cause Q). Q3 probe: the skill should TRIGGER and triage correctly to weight/save-baked + setnpcweight/ReSaver — an out-of-lane-for-place_asset outcome, not a file fix."
+    },
+    {
+      "id": "st-player-grey-after-update",
+      "query": "after the latest skyrim update my character's face is grey in the inventory menu but npcs are all fine",
+      "should_trigger": true,
+      "manual_predicted_trigger": true,
+      "rationale": "Player-only grey (Cause U/V). Q3 probe: the skill should TRIGGER and correctly exclude it as RaceMenu/SKEE runtime state — houseCARL is a no-op; route to version match / OverlayFix / skse64.log. The strongest exclusion rule is the skill's to own."
+    },
+    {
+      "id": "st-which-facegen-wins",
+      "query": "two of my npc mods both ship facegen for the same character and i think the wrong one is winning, can you tell which copy the game actually uses",
+      "should_trigger": true,
+      "manual_predicted_trigger": true,
+      "rationale": "Record-vs-file winner / VFS facegen precedence — exactly asset_status + the decide-which-copy-is-correct judgment the skill owns."
+    },
+
+    {
+      "id": "snt-skypatcher-npc-face",
+      "query": "my skypatcher ini that changes an npc's head parts and skin tone isn't applying, can you see why",
+      "should_trigger": false,
+      "manual_predicted_trigger": false,
+      "rationale": "Near-miss / RISK: mentions npc head parts + skin tone (face vocabulary) but it's a SkyPatcher INI authoring/debug task → skypatcher-authoring, not a dark-face bug. Watch the 'head parts'/'skin tone' overlap."
+    },
+    {
+      "id": "snt-spid-distribute-appearance",
+      "query": "i want to give all the bandits in my game a new menacing look, how do i set that up with SPID",
+      "should_trigger": false,
+      "manual_predicted_trigger": false,
+      "rationale": "Near-miss: distributing appearance to NPCs, but it's SPID authoring → spid-authoring, not diagnosing a baked-face bug."
+    },
+    {
+      "id": "snt-ctd-on-npc",
+      "query": "my game crashes to desktop every time a specific npc loads in whiterun, here's the crash log",
+      "should_trigger": false,
+      "manual_predicted_trigger": false,
+      "rationale": "Near-miss: NPC + 'after loads' + an artifact, but it's a CTD diagnosis → crash-diagnostics, not a face-rendering bug."
+    },
+    {
+      "id": "snt-shiny-enb-face",
+      "query": "my follower's face looks really shiny and oily in direct sunlight, the rest of the skin is fine",
+      "should_trigger": false,
+      "manual_predicted_trigger": false,
+      "rationale": "Near-miss / RISK: a 'face' problem, but it's specular/ENB, not facegen (the skill itself lists shiny face as not-facegen). Watch the 'face' overlap."
+    },
+    {
+      "id": "snt-asset-status-only",
+      "query": "which mod is providing femalehead.dds in my load order right now?",
+      "should_trigger": false,
+      "manual_predicted_trigger": false,
+      "rationale": "Near-miss / RISK: a head-texture VFS-winner question Claude answers directly with housecarl_asset_status — no dark-face diagnosis, no facegen skill needed. Watch the asset/VFS vocabulary overlap."
+    },
+    {
+      "id": "snt-npc-outfit-edit",
+      "query": "can you change this npc's default outfit and add a steel sword to her inventory in a patch",
+      "should_trigger": false,
+      "manual_predicted_trigger": false,
+      "rationale": "Near-miss / RISK: an NPC record edit, but outfit/inventory, nothing to do with a face bug. Watch the 'NPC + patch' overlap (it's esp-patching territory, not facegen)."
+    },
+    {
+      "id": "snt-create-follower-mod",
+      "query": "i want to make my own custom follower from scratch, what's the process for setting up the npc record and her face",
+      "should_trigger": false,
+      "manual_predicted_trigger": false,
+      "rationale": "Near-miss: mentions 'her face' + NPC record, but it's greenfield follower authoring, not diagnosing a dark/grey face — no symptom to investigate."
+    },
+    {
+      "id": "snt-purple-armor-texture",
+      "query": "the steel armor on my new mod shows up bright purple in game, what did i do wrong",
+      "should_trigger": false,
+      "manual_predicted_trigger": false,
+      "rationale": "Near-miss: a purple/missing-texture problem (which the skill mentions for FACES), but it's armor, not a face — tests that the skill keys on the face-bug family, not on 'purple/missing texture' generally."
+    },
+    {
+      "id": "snt-body-neck-seam-cbbe",
+      "query": "i'm getting a neck seam between the body and the head on my CBBE setup, different skin tone below the neck",
+      "should_trigger": false,
+      "manual_predicted_trigger": false,
+      "rationale": "Hard near-miss: 'neck seam' is a dark-face symptom too, BUT a CBBE body/skin-texture-set mismatch across the whole body is a body-texture install problem, not a per-NPC facegen desync. Genuinely tricky — flagged as a watch item; a body-wide seam ≠ a single NPC's baked-face seam."
+    },
+    {
+      "id": "snt-compile-papyrus",
+      "query": "how do i compile this quest script into a pex, i keep getting an unknown identifier error",
+      "should_trigger": false,
+      "manual_predicted_trigger": false,
+      "rationale": "Clean negative in an adjacent modding domain (Papyrus compile) — shares no facegen vocabulary; confirms the skill doesn't fire on generic 'skyrim modding help'."
+    }
+  ]
+}

--- a/.claude/skills/facegen-diagnostics/references/facegen-causes-and-fixes.md
+++ b/.claude/skills/facegen-diagnostics/references/facegen-causes-and-fixes.md
@@ -1,0 +1,370 @@
+# FaceGen causes, fixes, and mechanics — deep reference
+
+Load this when the SKILL.md decision tree points here: to identify a specific cause, pick the matching
+fix and its capability class, read the path/keystone mechanics, or look up which community tool owns a
+case houseCARL cannot. The decision tree in `SKILL.md` is enough for most diagnoses; this file is the
+*why* and the long tail.
+
+## Contents
+- [1. The keystone — facegen path is a pure function of the FormKey](#1-the-keystone)
+- [2. The desync model — record winner vs file winner](#2-the-desync-model)
+- [3. Cause taxonomy A–X](#3-cause-taxonomy)
+- [4. Fix taxonomy A–I (with capability class)](#4-fix-taxonomy)
+- [5. Symptom → likely cause](#5-symptom--likely-cause)
+- [6. The two embedded `.nif` references houseCARL cannot read](#6-embedded-nif-references)
+- [7. Edge cases and gotchas](#7-edge-cases-and-gotchas)
+- [8. Community tools reference](#8-community-tools)
+- [9. Residual uncertainty — what to route AROUND, not assert](#9-residual-uncertainty)
+
+---
+
+## 1. The keystone
+
+A baked NPC face is **two preprocessed per-NPC files** the Creation Kit exports on Ctrl+F4:
+
+```
+Head mesh ("FaceGeom"):  meshes\actors\character\facegendata\facegeom\<DefiningMaster>\<file>.nif
+Face tint ("FaceTint"):  textures\actors\character\facegendata\facetint\<DefiningMaster>\<file>.dds
+```
+
+The two trees diverge only at `meshes`↔`textures` and `facegeom`↔`facetint`; the `<DefiningMaster>\<file>`
+tail is identical. Paths are case-insensitive (the MO2 VFS already is). Both files are **opaque binary to
+houseCARL** — it places/moves them as whole files and reports which copy wins, but cannot read or edit
+their internal bytes.
+
+**The path is a pure function of the FormKey** — the engine links facegen to the NPC's FormID, not to any
+path stored in the record. There is no path field in the NPC record. So houseCARL derives the exact
+expected path from the FormKey alone, exactly as `housecarl-core`'s `FaceGenPath.For` does:
+
+> **folder = `FormKey.ModKey.FileName`** (the defining master's filename, including extension —
+> `Skyrim.esm`, `Dragonborn.esm`, `diverse skyrim.esp`)
+> **filename = `"00" + FormKey.ID.ToString("X6")`** (the masked 24-bit local id) + `.nif` / `.dds`
+
+Worked examples (confirmed across the CK wiki, Nexus articles 2090 / 52817, FaceGenEslify, SkyLady):
+`000012C4` in `ExampleMod.esp` → `…\facegeom\ExampleMod.esp\000012C4.nif`; Dragonborn NPC Elmus
+`0001A51A` → `…\Dragonborn.esm\0001A51A.nif`; non-zero high byte `14004085` in `test.esp` →
+`…\test.esp\00004085.nif` (the index byte is zeroed regardless of value).
+
+**Use this `FormKey.ModKey.FileName` + `"00"+ID.X6` framing — not "render the full 8-hex FormID and zero
+the index region."** The two are equivalent in result, but the second phrasing invites a reimplementation
+that slices a *runtime* FormID and introduces a load-order-index bug. Mutagen's `FormKey.ID` is already
+the bare local id, so the simple form is ESL-safe by construction (Mutagen 0.53.1 confirmed: an `.esl`
+FormKey → `…\MyLight.esl\000001FF.nif`).
+
+**Folder = the defining master, never the conflict winner.** The subfolder is the plugin the record's
+FormID is *prefixed to* — for an injected/override NPC, the master it is injected INTO (where the FormID
+high byte points), NOT the plugin that authors the record, and NOT the load-order winner. An override mod
+that merely edits an existing vanilla NPC ships its facegen under `Skyrim.esm\`, not its own folder. This
+is the single highest-stakes mechanical point: anchoring the folder to the conflict winner computes a path
+the engine never reads and places facegen where it does nothing. (`FaceGenPath.For` is correct by
+construction here — it uses `FormKey.ModKey`, which is the prefix master.)
+
+**There is NO cross-folder fallback.** The engine computes ONE path and uses whatever loose/BSA file wins
+there. If nothing valid resolves, it does NOT look in the master's folder or `Skyrim.esm` — it falls into
+runtime head *regeneration* from the record's morph/head-part data and drops the tint (dark face). So the
+diagnostic question is always *"what wins this exact path, and does it match the record?"* — never *"does
+it fall back?"*
+
+**ESL / ESPFE:** the on-disk filename never contains "FE". `FaceGenPath` renders the current (post-
+compaction) local id from Mutagen's FormKey, so it stays correct by construction — the folder is unchanged
+on eslification (same plugin file), only the filename tracks the renumbered local id. A freshly-eslified
+mod's loose facegen sits at the OLD names until renamed/regenerated; `place_asset` must target the NEW
+(current-FormKey) name. (`<0x800` "hardcoded" injected records, which xEdit issue #848 can mislabel as
+"new": compute the path AND flag the condition rather than assert silently. Rare for NPC_.)
+
+---
+
+## 2. The desync model
+
+Dark/grey/black face is a **desync between two independent precedence systems**:
+
+- **Plugin load order** decides which mod's **NPC record** wins — what `housecarl_read_record` returns.
+- **The MO2 VFS / asset order** decides which mod's **facegen FILE** wins — what `housecarl_asset_status`
+  returns. **Loose always beats BSA**; among loose, MO2 mod priority (then the overwrite folder) decides;
+  among BSAs, the BSA whose plugin loads later wins.
+
+Dark/wrong face occurs whenever, for the same NPC, the **file winner's source ≠ the record winner's
+appearance source**, or no file resolves at the computed path. The engine then regenerates the head from
+the record and drops the preprocessed tint → untinted (dark/grey/black) head with a sharp neck seam
+against the correctly-tinted body. This is why **xEdit can show NO record conflict yet the face is dark** —
+the desync is between a record and a *file*, not between two records. Checking the file winner
+(`asset_status`) alongside the record winner (`read_record`) is houseCARL's structural advantage.
+
+Two trigger conditions both land in this same path, so "a file is present" is **necessary but not
+sufficient**: (i) no valid head mesh at the computed path; or (ii) a file IS present but its internal
+head-part block names don't match the winning record's head-parts list (mode ii — "Dawnguard vampires are
+notorious for this"; houseCARL cannot inspect the `.nif` internals, so this needs CK re-bake / the in-game
+check).
+
+**"Rides the master's facegen" is the SAME keyed path, not a fallback.** A pure stat/AI override of a
+vanilla NPC (no appearance change, ships no facegen) renders fine because the vanilla file already wins
+that exact `Skyrim.esm\…` path. It dark-faces only if no file wins there or the record's head parts no
+longer match. So a no-facegen override does NOT "always dark-face."
+
+A **separate, non-desync dark class** comes from broken/missing **skin-texture path** references (a mod
+overwrote/renamed the `.dds` a head `.nif` or record points to). FDF does **not** fix this. Keep it
+distinct: head-parts/facegen mismatch → tint-dropped-on-regen (FDF/`asset_status`/`place_asset`/CK domain);
+broken skin texture → a texture-path problem (Cause R).
+
+---
+
+## 3. Cause taxonomy
+
+Fix layers: **houseCARL-file** (`asset_status`/`place_asset`) · **houseCARL-record**
+(`read_record`/`set_field`/`create_record`) · **CK-instructed** (Ctrl+F4 bake — houseCARL cannot) ·
+**nif-dds-instructed** (NifSkope/texture tool — houseCARL cannot edit internal bytes) · **runtime-mod**.
+
+| # | Cause | Mechanism | houseCARL tell | Fix class |
+|---|---|---|---|---|
+| **A** | **Record-winner vs file-winner desync** (dominant) | Load order picks record B; VFS picks mod A's facegen file → file built from a different mod's appearance than the winning record | `read_record` winner ≠ `asset_status` winner on the `.nif`/`.dds` pair | houseCARL-file and/or -record |
+| **B** | **Winner ships NO facegen** | Override changed appearance but author shipped only the plugin → record points at facegen that exists nowhere | record appearance changed (compare below) + `asset_status` = no winner at the path | CK-instructed; or houseCARL if a correct source exists |
+| **C** | **Non-appearance edit reverts head parts** | A later non-facegen plugin (USSEP-style) wins the record and reverts head parts toward vanilla while overhaul A's file still wins | `cross_plugin_query` shows the non-appearance plugin winning head parts; `asset_status` shows A's file still winning | houseCARL-record (often + -file) |
+| **D** | **Facegen trapped in a losing/double BSA** | Correct facegen is in a BSA that loses the VFS race, or buried in a RAR-in-BSA the game can't read | `asset_status` shows a wrong loose/BSA copy winning, or the expected BSA losing | houseCARL-file (extract the entry to loose) |
+| **E** | **Stale loose facegen masks correct BSA** | A leftover loose file (old/disabled/uninstalled mod, leftover extraction, wrong priority) wins because **loose beats BSA even from a disabled mod** | `asset_status` shows a loose file winning over the expected BSA | houseCARL-file |
+| **F** | **ESL / compaction FormID renumber** | `Compact FormIDs for ESL` renumbers local IDs but does NOT rename facegen files → engine looks up the new id, finds nothing. (a) filename mismatch; (b) FaceTint path embedded in each `.nif` | universal dark face for the whole eslified mod; `asset_status` on the new path = no winner | (a) houseCARL-file; (b) nif-dds-instructed |
+| **G** | **Merge / renumber (zMerge, Merge Plugins)** | New defining master AND new local id → both folder and filename change; facegen not carried | dark face for merged NPCs; new computed path absent | houseCARL-file (+ nif-dds if embedded path changed) |
+| **H** | **Head-part / hair / brow conflict or missing HDPT** | Record references an HDPT whose mesh is absent/replaced, or whose internal block names don't match | partial dark/clipping; `read_record` head-parts list; mesh winner ≠ expected | split: houseCARL-record / nif-dds / CK |
+| **I** | **Face-vs-body texture mismatch** (unique-bodies-by-race) | Head `.nif` hardcodes the vanilla skin path; a per-race body framework gives a unique body but the head still loads vanilla → head/body color mismatch. **NOT the dark-face bug.** | detect the *scenario*; the broken path is in the `.nif` skin slots houseCARL CANNOT read | nif-dds-instructed (NPC Facegen Patcher) |
+| **J** | **Skin-tone / TextureLighting / HeadTexture record mismatch** | Winner's TintLayers / TextureLighting (QNAM) / HeadTexture / HairColor inconsistent with body race/skin | wrong-colored but correct-shaped head; `read_record` these fields vs intended source | houseCARL-record (pair with re-bake/FDF) |
+| **K** | **CK baked against the wrong load order/masters** | Facegen baked while the wrong override resolved (missing master) → right filename, wrong content | wrong (not dark) face; `read_record` shows the true winner to bake against | CK-instructed |
+| **L** | **Missing master / orphan override** | Override copied without its master (or master disabled) → record can't resolve | dark/missing actor, but `asset_status` shows the correct file winning; `read_record` masters | houseCARL-record (masters-by-construction) / report |
+| **M** | **Missing appearance dependency** (High Poly Head, KS Hairdos) | A required resource mod is disabled while the record still references it | headless/floating parts; `read_record` head-parts links unresolved, or asset absent | runtime-mod / report (install) |
+| **N** | **Custom/beast race, no baseline facegen ever baked** | Never exported facegen (or for the wrong race) | guaranteed black face; `asset_status` = no winner anywhere | CK-instructed |
+| **O** | **LE/Oldrim facegen `.nif` ported to SE without re-bake** | SE will not read Oldrim facegen `.nif` format | dark face for an LE-ported NPC mod; a file may win that the engine still can't use | CK-instructed |
+| **P** | **Texture-memory grey/black face** (rare) | Face/body textures too large/uncompressed (8k, non-BC `.dds`) → tint fails to apply though record+file match. **Tell: not permanent — save+reload temporarily clears it.** | `asset_status`/BSA listing flags oversized/uncompressed `.dds` | nif-dds-instructed (Cathedral Assets Optimizer / Ordenator) |
+| **Q** | **Weight/scale-induced brown face** (runtime) | In-game weight ≠ the weight the tint was baked at (commonly from `setnpcweight`/`setscale`, baked into the save) | plain brown face matching nothing; `read_record` Weight | runtime/console (re-issue `setnpcweight`); save-baked → ReSaver |
+| **R** | **Broken/missing skin-texture path** (distinct dark class) | A mod overwrote/renamed the skin `.dds` a head `.nif`/record points to. If the broken ref is INSIDE the `.nif`, houseCARL CANNOT read or fix it | black face; **FDF does NOT fix it**; `asset_status` on the texture path / `read_record` HeadTexture (TXST) | houseCARL-file (if a correct `.dds` exists) / nif-dds |
+| **S** | **Template + "Use Traits" actor** (exclusion, not a defect) | NPC inherits appearance from a template ActorBase → has NO facegen of its own; facegen lives under the **template's** FormKey | `read_record` Template set AND `Configuration.TemplateFlags` includes `Traits` → recompute against the template's FormKey | n/a — redirect diagnosis |
+| **T** | **Runtime-distributed appearance (SPID/SkyPatcher) / `FFxxxxxx` NPCs** | Appearance applied at runtime, or on a dynamically-spawned actor → no pre-baked facegen; the plugin-winner record houseCARL sees ≠ the in-game face | recognize the scenario (SPID/SkyPatcher present; `FF` base id); houseCARL reads *plugin* records, can't see the distributed result | runtime-mod / report (not `place_asset`) |
+| **U** | **RaceMenu/SKEE co-save state dropped — player-only grey** | SKEE skipped the actor's co-save → NiOverride sculpt/tint held only at runtime is dropped | **player** (+ a few RaceMenu-touched NPCs) grey, ordinary NPCs fine; appears after reload/update/crash | runtime-mod / report — houseCARL **no-op** |
+| **V** | **skee64.dll didn't load** (version mismatch / fatal error) | No runtime overlay/tint application runs (often after a Skyrim/Steam auto-update) | grey **player** face **plus all RaceMenu sliders/overlays gone game-wide** | runtime-mod / report — houseCARL **no-op** |
+| **W** | **Sculpt in `.jslot`/preset, never exported to facegen** | A `.jslot`/runtime sculpt holds the geometry/tint but no `.nif`/`.dds` was ever exported for the FormKey | an NPC built from a preset is grey though the modder "has the preset"; `asset_status` = facegen missing | partial: CK/RaceMenu-instructed to bake, then houseCARL-file |
+| **X** | **NiOverride runtime overlays expected on an NPC** | SKEE warpaint/body/face overlays are runtime-applied, not in the exported `.dds` unless baked | NPC missing warpaint/makeup, or wrong/grey in that region | runtime-mod / report (no-op for the overlay; tintmask `.dds` itself → `place_asset`) |
+
+---
+
+## 4. Fix taxonomy
+
+Each fix: procedure + capability class. **Always handle facegen as a PAIR** — query/place/forward both
+the `.nif` (FaceGeom) and the `.dds` (FaceTint); fixing one without the other still dark-faces.
+
+### Fix A — Regenerate facegen in the Creation Kit (Ctrl+F4) — **CK-instructed**
+The only correct fix when no correct facegen exists anywhere and the record content is what you want
+(Cause B/N), or after ESL/merge renumber. Hand the user verbatim: open CK; load the plugin and **"Set as
+Active File"** (this keys output to that plugin's name); ensure required masters are loaded; in the Object
+Window go to the **Actors tree directly** (Ctrl+F4 does NOT fire if actors were found via the `*All`
+search); select the actors; press **Ctrl+F4**, confirm, wait for "Done." Pitfalls: do NOT select
+child/RaceChild actors (unique child TRI → "shiny potatoes"); some unique faces (Astrid) corrupt others on
+regen; large batches need RAM/VRAM (batch by race if <32 GB). **houseCARL has zero CK automation — hand
+over the procedure, never claim to do it.**
+
+### Fix B — Place the correct existing facegen as a winning loose override — **houseCARL-file**
+When a correct copy exists somewhere (mod or BSA) but loses VFS precedence (Cause D/E, and the file side of
+A/C/F/G). `asset_status` the two paths to see the current winner, then `place_asset`/`bulk_place_asset` to
+extract the correct entry (single-entry in-process BSA extract) and write it as a winning loose override
+into a fresh enable+sort MO2 mod. **Place BOTH `.nif` and `.dds` as a pair, from the SAME source mod.**
+
+> **Same-FormKey forward is SAFE by construction — do not over-refuse.** The `.nif` embeds the FaceTint
+> `.dds` path as a pure function of `(defining-master, local FormID)`. A same-FormKey, same-defining-master
+> forward (the normal "make Mod A's appearance win for this NPC" case) changes neither — so the copied
+> `.nif` already embeds exactly the path that resolves to the destination's `.dds`. No NifSkope edit is
+> needed; this is why EasyNPC copies facegen as exact copies. Place the pair together so another mod's
+> `.dds` can't win the tint slot (a softer "looks strange" mismatch).
+>
+> **Fix B is UNSAFE (escalate to NifSkope / FaceGenEslify) ONLY in cross-FormKey / renumber / re-folder
+> cases** — where the destination FormID or defining plugin differs from what's baked into the source
+> `.nif` (ESLify/compaction changed the FormID; re-homing changed the `<Plugin>` segment; a merge
+> renumbers/re-masters). The engine DOES honor the embedded path, and houseCARL cannot edit `.nif` bytes,
+> so those route to the instructed tool.
+
+Then re-run `asset_status` and tell the user to enable + sort, and run the in-game verification (SKILL.md
+Step 5).
+
+### Fix C — Forward NPC appearance into a winning override record — **houseCARL-record**
+When a behavior/other plugin won the record while the intended appearance mod's facegen files are present
+(Cause C/J; record side of A). `read_record` the winner and the appearance source, then
+`create_record`/`set_field` to write an override copying the appearance set.
+
+> **The face-determining minimal set is houseCARL's OWN editorial set** (all real, writable NPC_ fields,
+> Mutagen spellings): **`HeadParts, FaceMorph, FaceParts, TintLayers, HairColor, HeadTexture,
+> TextureLighting`** (+ optionally **`WornArmor`** for body/skin-tone consistency). `TextureLighting` is
+> the `Color` field xEdit shows as **QNAM**; `TintLayers` is one token. Do NOT describe this as "what
+> facefixer does" — facefixer copies a 14-field mask with **NO `Race`**; FacegenBaseline *does* forward
+> `Race`. `Race` is a real writable NPC_ field houseCARL may forward, but don't claim facefixer fixes a
+> wrong-`Race` NPC.
+
+**Pairing rule:** Fix C only cures dark face if the matching facegen FILES also win the VFS — so Fix C and
+Fix B are siblings, often applied together. Forwarding TintLayers/WornArmor without the matching body skin
+causes a neck seam. For an existing-NPC override the defining master (and facegen folder) does NOT change;
+houseCARL cannot bake new geometry, so Fix C still needs a matching facegen file to exist somewhere.
+
+### Fix D — Correct skin-tone via record edits — **houseCARL-record (with a nif-dds boundary)**
+For head/body color mismatch that is a *record* problem (Cause J): `set_field` TextureLighting (QNAM
+Color), re-forward TintLayers/WornArmor/HeadTexture to a consistent source. If the mismatch is baked into
+the `.nif` texture paths or the `.dds` pixels, that's internal file content houseCARL cannot read —
+instruct NifSkope or a CK re-bake. Editing TintLayers/morph WITHOUT regenerating facegen can itself
+reintroduce discoloration until Ctrl+F4 or FDF applies — pair record appearance edits with a re-bake/FDF.
+
+### Fix E — ESLify / compaction repair — **partial houseCARL-file + nif-dds-instructed**
+For Cause F/G. (a) rename/place the `.nif`/`.dds` to the new (post-compaction) FormID — **houseCARL-file**
+(computable from the current FormKey); (b) rewrite the FaceTint `.dds` path embedded in each `.nif`'s
+`BSShaderTextureSet` to the new FormID — **houseCARL CANNOT** (internal `.nif` bytes) → **instruct**.
+**FaceGenEslify automates only the rename — its embedded-path edit is a MANUAL NifSkope step (its own
+README step 9); do NOT credit it with automating the embedded rewrite.** (ESLifyEverything/ESLifier may
+automate both; unverified.) Or CK re-bake (Fix A) writes correct files for the new IDs. Best practice to
+state: **don't compact facegen-carrying plugins** unless running a fixer.
+
+### Fix F — Face Discoloration Fix (FDF, runtime) — **runtime-mod (instructed)**
+An SKSE plugin that prevents the engine from discarding tint during the regen fallback, so a
+missing/mismatched facegen renders with correct **color** instead of black — a runtime equivalent of
+Ctrl+F4 **for tint only**. Hard limits to state: (1) fixes **discoloration only** — NOT the intended custom
+sculpt (a conflict that broke the look yields a colored-but-wrong face); (2) regenerates from the record's
+morph data, so a custom sculpt that lived only in the baked `.nif` is lost; (3) ~30–70 ms/NPC vs ~0.2 ms to
+load a preprocessed file; (4) does NOT fix Cause R, Cause M, or the RaceMenu/SKEE classes (U–X).
+**Diagnostic consequence:** with FDF installed, dark faces may be suppressed in-game even though the
+on-disk desync is still present — "looks fine in game" does not mean the diagnosis is clean (the FDF-off
+litmus). Recommend FDF as a safety net; still report and fix the underlying desync.
+
+### Fix G — Add missing master / remove orphan override — **houseCARL-record**
+For Cause L. houseCARL writes **masters-by-construction**, so any override it authors carries correct
+masters — it structurally avoids the bug a hand-edited plugin causes. Diagnostically: a dark face where
+`asset_status` shows the **correct** file winning AND the record looks right points away from VFS desync
+toward a master/resolution problem — confirm via `read_record` before reaching for a file fix (Fix B will
+not cure a missing-master dark face).
+
+### Fix H — Instruct NPC Facegen Patcher / texture compression — **nif-dds-instructed**
+For Cause I (NPC Facegen Patcher edits the **skin** texture slots inside each head `.nif`, leaving the
+FaceTint slot untouched) and Cause P (oversized textures → Cathedral Assets Optimizer/Ordenator). houseCARL
+detects the *scenario* (and reads the source TXST record) but cannot read/edit the `.nif` slots.
+**Routing rule:** wrong/stale **FaceTint** path → FaceGenEslify (FaceTint slot); wrong **skin
+diffuse/normal** path → NPC Facegen Patcher (skin slots); general missing-tint regeneration → FDF.
+
+### Fix I — RaceMenu/SKEE runtime repair — **runtime-mod / report (houseCARL no-op, except W's file half)**
+For Causes U–X. **U:** re-open `showracemenu`/`showlooksmenu player 1`, re-apply/re-load the preset; install
+OverlayFix or the SKEE cosave Load Crash Fix; read `skse64.log`. **V:** match SKSE↔Skyrim runtime↔RaceMenu
+versions; delete stray loose `CharGen.pex`/`NiOverride.pex`/`RaceMenu*.pex`; read `skse64.log`. **W:**
+instruct Sculpt→Export Head (writes to `Data\SKSE\Plugins\CharGen\`, **distinct** from the facegen VFS
+paths) or CK Ctrl+F4 — once the `.nif`/`.dds` exist, `place_asset` them. **X:** instruct the re-applying
+overlay framework; if the *tintmask `.dds`* itself is the problem, that's the normal facegen-tint path
+(`place_asset` covers it). houseCARL has **no read or write** into the SKSE co-save / SKEE runtime state —
+surfacing that limit IS the Q3-honest move.
+
+---
+
+## 5. Symptom → likely cause
+
+| Symptom | Most likely | Notes |
+|---|---|---|
+| **Only the PLAYER is grey; NPCs fine** (after reload/update/crash) | U/V (RaceMenu/SKEE runtime) | **The single strongest exclusion — OUT of lane.** The desync family hits NPCs; the player's face is runtime/co-save state. Phrase "strongly suggests," not "proves." |
+| **Player grey AND all RaceMenu sliders/overlays missing** game-wide | V (skee64.dll disabled) | Out of lane; suspect first if it appeared right after a Skyrim/Steam update. |
+| **Dark/grey/black face, sharp neck seam** (head darker than body) | A–H, N (record↔facegen desync) | The canonical dark-face bug. FDF masks the *color*; the real fix is matching record↔file or re-baking. |
+| **Brown face** matching nothing | Q (weight/scale, save-baked) | Re-issue `setnpcweight`; if save-baked, new game or ReSaver. Runtime, not a file fix. |
+| **Grey/black with matched record+file**, clears on save+reload | P (texture memory) | Oversized/uncompressed `.dds` → compress. (R = broken skin path — FDF will NOT fix R.) |
+| **Purple or bright-white face** | missing **texture file/path** | A referenced texture isn't found — a texture-asset problem, not facegen (dark face *has* a file, the wrong one). |
+| **Neck seam, face correctly colored but ≠ body** | I or J | I = `.nif` hardcodes vanilla skin (NPC Facegen Patcher; houseCARL can't see the slot). J = record QNAM/TintLayers inconsistent (houseCARL-record). |
+| **Headless / floating parts / missing geometry** | M or H | Required head-part/hair mod disabled, or a HDPT doesn't resolve — report/install, or forward correct HeadParts. |
+| **NPC built from a RaceMenu preset is grey** | W (sculpt in `.jslot`, never exported) | The preset alone is not facegen. Instruct Export Head / Ctrl+F4; then `place_asset`. |
+| **NPC missing warpaint/makeup overlay** specifically | X (NiOverride runtime overlay) | Overlays are runtime SKEE state, not facegen tint — out of lane for the overlay portion. |
+| **Shiny/oily face** | specular/ENB | **Not facegen.** Out of lane. |
+| **Ash-pile / disintegration** | death/disintegration script state | **Not facegen.** Out of lane. |
+| **"Shiny potato" child head** after a re-bake | child re-baked in CK (unique TRI) | A CK-bake hazard — do NOT blanket-recommend Ctrl+F4 for children/special actors. |
+
+---
+
+## 6. Embedded `.nif` references
+
+The head `.nif`'s `BSShaderTextureSet` carries TWO logically distinct texture references in ONE block, and
+houseCARL can read **neither** (they live inside `.nif` bytes it does not parse):
+
+1. **The per-NPC FaceTint `.dds`** — at binary index 6 / NifSkope slot 7 (the subsurface/tint slot). This
+   is the FaceGenEslify target.
+2. **The base SKIN texture set** — race/body diffuse, normal, etc. at slots 1/2 (binary 0/1). This is the
+   NPC Facegen Patcher target (it rewrites skin slots `fti-6, fti-5, fti-4, fti-3, fti+1` and deliberately
+   leaves the FaceTint slot untouched).
+
+Consequence: **Cause I, Cause R's in-`.nif` form, and the FaceTint-path half of Fix E are non-diagnosable
+inside the file.** Say plainly "this requires NifSkope / an external tool; I cannot inspect or edit the
+embedded texture paths," and route by symptom: wrong/stale FaceTint → FaceGenEslify; wrong skin
+diffuse/normal → NPC Facegen Patcher; general missing tint → FDF. Never claim to know which embedded slot
+is broken.
+
+---
+
+## 7. Edge cases and gotchas
+
+- **The front door is the first failure point.** Resolve via EditorID (best) or name (disambiguate). A
+  **console-clicked FormID is a RefID and/or a runtime-indexed base id** — houseCARL's FormID↔FormKey
+  bridge is unshipped, so the high byte (and the ESL `FExxx` slot) can't be mechanically resolved. Route to
+  name/EditorID, or confirm the 6-hex local as a hypothesis. Never trust the console high byte as identity.
+- **No cross-folder fallback** (§1). Step 3 asks "what wins this exact path, and does it match the record?"
+- **"Rides the master's facegen" is the same keyed path, not a fallback** (§2).
+- **ESL/FE prefix:** filename never contains "FE"; compute from the current FormKey. Folder unchanged on
+  eslification. A freshly-eslified mod's loose facegen sits at the OLD names until renamed.
+- **Beast/custom races:** identical path scheme. Common failure is a custom-race mod that never exported
+  facegen (Cause N) → `asset_status` no winner → CK bake, not `place_asset`.
+- **Male/female:** NO separate folder or filename rule — sex affects which head parts/tint the CK bakes.
+  Risk: `asset_status` "file wins" ≠ "file is the right sex"; houseCARL confirms provenance, not content.
+- **SPID/SkyPatcher-distributed appearance:** houseCARL reads *plugin* records, so the plugin-winner it
+  sees may not be the in-game face. Warn; route to FDF or matching the distributed head parts. (DynDOLOD
+  does object-LOD, **not** NPC appearance — do not group it with SPID/SkyPatcher.)
+- **RaceMenu/SKEE is a whole out-of-lane class** (U–X). Player-only grey is the strongest exclusion. A
+  `.jslot` is not facegen (W); NiOverride overlays are runtime state (X). Don't conflate the CharGen working
+  folder (`Data\SKSE\Plugins\CharGen\`) with the facegen VFS paths.
+- **BSA-vs-loose stale facegen:** loose always beats BSA — including from a **disabled** mod or MO2
+  overwrite (Cause E). The classic "fine in xEdit/CK but dark in game." Trust `asset_status`'s reported
+  winner (a "Manage Archives"-on user can invert the rule). Drop "archive-invalidation /
+  bInvalidateOlderFiles" language for SE — that's LE-era; SE honors BSAs natively.
+- **Vanilla/CC baseline:** vanilla NPCs ship matching facegen in the base-game BSAs under
+  `Skyrim.esm`/`<DLC>.esm`; record↔file are in sync out of the box. The baseline file lives under the
+  **defining-master** folder, not an overhaul's — anchoring to the conflict winner points at the wrong
+  subfolder (keep the defining-master rule).
+- **Pair invariant:** always query/place/extract BOTH `.nif` and `.dds` for a FormKey. For a same-FormKey
+  forward the embedded path is valid by construction (Fix B) — place the pair together, don't over-refuse.
+- **Verification ≠ provenance:** a green `asset_status` proves the right file wins, not that it renders
+  correctly. Hand off the in-game `setnpcweight`/`prid`/`moveto` check; never put `coc` in a `.bat`;
+  facegen is baked into the save (a true clean check is a new game or ReSaver removal).
+- **Children/special actors:** never blanket-recommend a CK re-bake (unique child TRI → "shiny potatoes";
+  Astrid-type faces corrupt others).
+- **LE→SE ports:** SE will not read Oldrim facegen `.nif` format — re-bake in SE CK (Cause O).
+
+---
+
+## 8. Community tools
+
+houseCARL drives the *file* and *record* halves itself; the rest it names and instructs.
+
+| Tool | What it does | When it's the right tool |
+|---|---|---|
+| **Face Discoloration Fix (FDF)** (Nexus 42441) | Runtime SKSE; NOPs the tint-discard on regen so a missing/mismatched facegen renders with correct **color** | Universal **color** safety net; when only CK can bake but the user wants a quick mask. Fixes color, not the sculpt, not skin textures, not RaceMenu state. Its presence can mask on-disk desync. |
+| **EasyNPC** (Nexus 52313) | Consolidates many NPC overhauls into one standalone mod, copying BOTH the chosen face mod's record edits AND its facegen (to BSA); uses `FormKey.ModKey.FileName` + `"00"`+local-id (same stack as houseCARL) | Whole-load-order NPC consolidation; eliminating desync by co-locating record+facegen |
+| **NPC Plugin Chooser** (GitHub Piranha91) | Per-NPC GUI patcher; copies chosen records AND forwards matching facegen; names the two winners explicitly — **LoadOrder winner** (plugin) vs **FaceGenOrder winner** (file) | Per-NPC choice across overlapping overhauls, doing both halves |
+| **facefixer** (Synthesis-Collective) | Synthesis/Mutagen; `DeepCopyIn`s a 14-field appearance mask (**no `Race`**) onto each load-order-winning NPC | Record-side appearance forward (assumes the matching facegen already wins). The list houseCARL Fix C is modeled on — but the editorial minimal set is houseCARL's own. |
+| **FacegenBaseline** (GitHub SteveTownsend) | Synthesis; for NPCs whose winner did NOT change HeadParts vs the master, forwards a baseline mod's appearance (records only, no files). Forward set DOES include `Race`. | Backfilling baseline appearance for NPCs a non-appearance edit reverted (Cause C). Its `HeadParts.SetEquals` gate is **necessary-not-sufficient** — see §9. |
+| **FaceGenEslify** (Nexus 46208) / ESLifyEverything / ESLifier | xEdit pre/post-compaction FormID dump + EXE that batch-**renames** facegen to the new compacted FormIDs. **The embedded `.nif` FaceTint-path edit is a MANUAL NifSkope step (README step 9), NOT automated by FaceGenEslify.** | After `Compact FormIDs for ESL` / merges renumber an NPC mod (Cause F/G) |
+| **NPC Facegen Patcher** (Nexus 41008) | xEdit script; rewrites the **skin** texture slots inside head `.nif`s (leaves the FaceTint slot untouched) so face textures match race-specific body textures. "Not used to fix grey/black/brown face bugs." | Face-vs-body color mismatch under unique-bodies-by-race (Cause I) — NOT the desync dark-face bug |
+| **Dark Face Issue Reporter** (Nexus 42133) | xEdit script; enumerates every NPC from a chosen master, checks each record's HeadParts against the resolvable NIF, flags `DarkFaceIssue`; emits in-game `prid`/`moveto` batch files. Does NOT auto-fix. | Whole-mod / load-order batch diagnosis. The batch model the SKILL.md batch flow mirrors at the VFS layer. |
+| **RaceMenu / SKEE + fixers** (RaceMenu 19080; cosave Load Crash Fix 173617; OverlayFix 138586; CharGen Export SE 29954) | Runtime sculpt/tint/overlay via skee64.dll, persisted in the SKSE co-save; Export Head writes `.nif`/`.dds` to `Data\SKSE\Plugins\CharGen\` | The out-of-lane grey-face class (U–X). houseCARL no-op except placing an already-exported head. |
+
+---
+
+## 9. Residual uncertainty
+
+Route AROUND these — do not assert them. The reliable tell is the **file-winner-vs-record-winner mismatch**,
+not predicting dark face from field deltas.
+
+- **Exact engine field(s) that invalidate a cached facegen.** Sources agree a HeadParts-list mismatch
+  triggers the regen (mode ii), but no source enumerates every field. Don't predict dark face from
+  record-field deltas alone — use the file-vs-record-winner mismatch.
+- **FacegenBaseline's `HeadParts.SetEquals` proxy is necessary-not-sufficient.** A winner that changed only
+  morph/tint/HeadTexture but NOT HeadParts is misclassified as "no appearance change." So houseCARL's own
+  Cause-B / Step-3 "did the winner change appearance" check must compare **`FaceMorph` / `TintLayers` /
+  `HeadTexture`** in addition to `HeadParts`, not `HeadParts` alone.
+- **Mode ii (`.nif` head-parts block-name mismatch) is undetectable by houseCARL** — a file can win the
+  correct path yet still dark-face because its internal head-part block names don't match the record. This
+  is the residual that keeps "file wins" necessary-but-not-sufficient and forces the in-game handoff.
+- **SE vs LE `.nif` rejection (Cause O):** hard format rejection vs partial render is unconfirmed at the
+  binary level — affects how absolute the "must re-bake LE ports" instruction should be.
+- **ESL facegen filename** is correct by construction (`FaceGenPath` renders the current FormKey's local
+  id); an on-rig eyeball against a known ESPFE follower is a confidence-raiser, not a gate.
+- **Console-clicked-FormID resolution** is blocked until the runtime-FormID bridge ships — route around it
+  via name/EditorID.

--- a/scripts/build-plugin.ps1
+++ b/scripts/build-plugin.ps1
@@ -47,8 +47,8 @@ $PackagingSrc = Join-Path $RepoRoot 'packaging'        # tracked source for pack
 $ReleaseDir   = Join-Path $RepoRoot 'release'          # output dir for the shippable zip (gitignored)
 $PluginManifest = Join-Path $PluginSrc '.claude-plugin\plugin.json'   # single source of truth for the version
 
-# the 6 shipped skills (the modlist-authoring cluster was removed; tool-surface skills wait)
-$Skills = @('mutagen-reference','papyrus-reference','skypatcher-authoring','spid-authoring','kid-authoring','papyrus-optimization')
+# the 7 shipped skills (the modlist-authoring cluster was removed; tool-surface skills wait)
+$Skills = @('mutagen-reference','papyrus-reference','skypatcher-authoring','spid-authoring','kid-authoring','papyrus-optimization','facegen-diagnostics')
 
 function Step($n,$msg) { Write-Host "`n=== [$n] $msg ===" -ForegroundColor Cyan }
 

--- a/scripts/build-plugin.ps1
+++ b/scripts/build-plugin.ps1
@@ -91,7 +91,7 @@ Get-ChildItem $ServerDir -Filter 'appsettings*.json' -ErrorAction SilentlyContin
 Step '3/10' 'Copy corpus.json beside the exe'
 Copy-Item $CorpusSrc (Join-Path $ServerDir 'corpus.json') -Force
 
-# ---- 4. bundle the 6 skills (exclude evals/ + _CORPUS_STATUS.md; KEEP all .jsonl) ----
+# ---- 4. bundle the 7 skills (exclude evals/ + _CORPUS_STATUS.md; KEEP all .jsonl) ----
 Step '4/10' 'Bundle skills'
 New-Item -ItemType Directory -Path $SkillsDir -Force | Out-Null
 foreach ($s in $Skills) {


### PR DESCRIPTION
## Phase 4 / B3 — author the `facegen-diagnostics` skill

houseCARL's 7th shipped skill: the dark / grey / black-face NPC diagnosis flow that drives the Phase 1–3 asset tools (`housecarl_asset_status` #18, `housecarl_place_asset` #20, `housecarl_bulk_place_asset` #21). It resolves the NPC to a FormKey, compares the **record winner** (which plugin wins the `NPC_` record) against the **file winner** (which mod/BSA wins the facegen `.nif`/`.dds`), and either places the correct facegen as a winning override or forwards the matching appearance into a new plugin — and **instructs** (never fakes) the CK / NifSkope / RaceMenu fixes houseCARL can't perform.

### What's in it
- `.claude/skills/facegen-diagnostics/SKILL.md` — investigation-flow + procedural-write body (`crash-diagnostics` shape): Step 0 exclusions → front door → record winner → compute path → file winner → decide-which-copy → verify. 235 lines, 179-word description.
- `.claude/skills/facegen-diagnostics/references/facegen-causes-and-fixes.md` — deep tail: 24-cause taxonomy (A–X), fix taxonomy, symptom table, embedded-`.nif` slot mechanics, community-tool routing, path keystone.
- `.claude/skills/facegen-diagnostics/evals/eval_set.json` — 10 should-trigger + 10 should-not-trigger (genuine near-misses) + Q3 outcome-correctness notes.
- `scripts/build-plugin.ps1` — registered in `$Skills` (6 → 7; the count is computed from the dir, auto-bumps).

### Source & corrections
Built from `dev/references/facegen/FACEGEN_DARKFACE_RESEARCH_2026-06-15.md` including its §11 (B1 gap-fill, primary sources read via Claude-in-Chrome) and §12 (source/schema verification). The three §12.1 corrections are baked and contradicted nowhere:
1. **facefixer copies NO `Race`** — the face-determining minimal set (`HeadParts, FaceMorph, FaceParts, TintLayers, HairColor, HeadTexture, TextureLighting` + optional `WornArmor`) is framed as houseCARL's own editorial set, not "what facefixer does."
2. **FaceGenEslify only renames files** — the embedded `.nif` FaceTint-path edit is a manual NifSkope step; the skill instructs it, doesn't credit the tool with automating it.
3. **Keystone** = folder `FormKey.ModKey.FileName`, filename `"00" + FormKey.ID.ToString("X6")` (the masked local id) — not "render 8-hex, zero the index" (which invites a runtime-FormID-slicing bug).

Tool-call account verified line-by-line against `AssetTools.cs` / `PlaceAssetTools.cs`, including the asymmetric FaceGeom/FaceTint pairing (`asset_status` takes raw paths → skill computes both; `place_asset` requires `kind`; `bulk_place_asset` with `formid`+no-`kind` places both, and a both-case explicit `source=` accepts only a bare `.bsa`).

### Q3 backbone
"Wrote it" ≠ "wins" ≠ "renders correctly": every place-then-done path is gated behind the in-game `setnpcweight`/`prid`/`moveto` verification handoff with the "provenance, not appearance" caveat. Out-of-lane causes (player-only grey U/V, `FFxxxxxx`/SPID-distributed T, brown/save-baked Q, mode-ii `.nif`-internals) route to instruct-not-do.

### Validation
- **Trigger fan-out: 10/10 recall, 10/10 specificity** — anonymized blind cold-read (candidate unlabeled among the real shipped skills, queries shuffled), per `feedback_skill_trigger_eval_fanout`. Far above the §6.3 gates (≥80% / ≥50%). The candidate lived only in the worktree, so it couldn't contaminate its own eval.
- **Two independent adversarial pre-merge reviews:** correctness = SHIP (zero blockers/should-fixes; all tool-call claims + the §12.1 corrections + the defining-master-folder rule verified against source), standard = 19/19 CONFORMS-WITH-FIXES (both should-fix items resolved in-branch).

### Not gating authoring (per handoff §A.3)
The ESL-filename on-rig eyeball needs the current MCP build on the rig — it's parked in `dev/PRE_RELEASE_1.3_LOCAL_TEST_CHECKLIST.md` for the pre-1.3 pass. The skill ships on by-construction correctness and does not assert it.

Unreleased → rides the held 1.3.0 batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
