### PR TITLE
HCBR PR-B (item 1.2): loosen SameShape to write-legality equivalence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,16 @@ jobs:
       - name: Probe — standalone-polymorphic-field descend (pre-flight + in-CI apply)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- poly-field-descend-guard
 
+      # SameShape write-legality equivalence (HCBR 1.2 / PR-B): when a field is shared across a polymorphic base's
+      # arms, FindField admits the path only if the arms AGREE in shape. The one corpus field that differs ONLY by
+      # the Nullable<T> wrapper (APerkEffect.Value: float vs float?) used to over-reject ("CONFLICTING shapes"),
+      # though the engine unwraps Nullable<T> when it coerces; it now agrees. Genuine conflicts on BOTH axes the AQ
+      # check defends stay rejected AT the SameShape gate (cardinality: Condition.ComparisonValue; underlying type:
+      # APackageData.Data), and Apply-1 drives the now-admitted request on an in-memory Perk arm.
+      # Self-contained — generates the corpus into a temp dir on a fresh checkout, no game data.
+      - name: Probe — SameShape write-legality equivalence (self-contained regression guard)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- sameshape-agree-guard
+
       # The compile tool's import ORDER is semantics (the CK compiler takes the FIRST matching .psc), so caller
       # import_dirs must outrank the auto-added vanilla folder — else SKSE-extended copies of vanilla scripts lose
       # to vanilla and extended calls fail despite the right folder being passed (spike findings §5.12, hit twice).

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -463,12 +463,36 @@ public sealed class CorpusRulebook
     /// CLR types (two arms can share a display name like 'Flags' while binding DIFFERENT enum types; ValueLegality
     /// validates against the AQ-resolved type, so AQ disagreement means the value would be checked against the
     /// wrong arm's legal set — PR review). Identity by what the validator USES, so "agrees" can never silently
-    /// mean "close enough".</summary>
+    /// mean "close enough".
+    ///
+    /// The CLR-type facets compare write-legal EQUIVALENCE, not raw-string identity (HCBR 1.2 / PR-B): a type and
+    /// its <c>Nullable&lt;T&gt;</c> wrapper admit the identical value set, because <see cref="WriteEngine"/>'s
+    /// Coerce/CanCoerce unwrap <c>Nullable&lt;T&gt;</c> before checking. So a field declared <c>float</c> on one
+    /// arm and <c>float?</c> on another (the one such corpus field — <c>APerkEffect.Value</c>) AGREES: the
+    /// over-arms search admits the path and the engine resolves on the live arm. The raw <c>Nullable</c> flag is
+    /// therefore NOT compared — it is exactly the wrapper distinction the unwrap erases — while every GENUINE
+    /// difference (cardinality, display type, or a different underlying CLR type) still rejects.</summary>
     static bool SameShape(FieldSchema a, FieldSchema b) =>
         a.Cardinality == b.Cardinality && a.Type == b.Type && a.TypeRef == b.TypeRef
         && a.ElementType == b.ElementType && a.ElementTypeRef == b.ElementTypeRef
-        && a.Writable == b.Writable && a.Nullable == b.Nullable && a.IsIdentity == b.IsIdentity
-        && a.GetterTypeAssemblyQualified == b.GetterTypeAssemblyQualified
-        && a.MutableTypeAssemblyQualified == b.MutableTypeAssemblyQualified
-        && a.ElementTypeAssemblyQualified == b.ElementTypeAssemblyQualified;
+        && a.Writable == b.Writable && a.IsIdentity == b.IsIdentity
+        && SameWriteLegalType(a.GetterTypeAssemblyQualified, b.GetterTypeAssemblyQualified)
+        && SameWriteLegalType(a.MutableTypeAssemblyQualified, b.MutableTypeAssemblyQualified)
+        && SameWriteLegalType(a.ElementTypeAssemblyQualified, b.ElementTypeAssemblyQualified);
+
+    /// <summary>Two assembly-qualified CLR-type names are write-legal-equivalent iff they resolve to the same
+    /// runtime type after unwrapping <c>Nullable&lt;T&gt;</c> — mirroring <see cref="WriteEngine"/>'s own
+    /// Coerce/CanCoerce, which unwrap <c>Nullable&lt;T&gt;</c> before validating, so <c>float</c> and <c>float?</c>
+    /// admit the identical value set. A name that will not resolve to a runtime Type falls back to RAW-string
+    /// identity, so a genuinely unknown type can never be silently widened (Q3 — fail loud, never "close enough").
+    /// Null matches only null (one arm declaring the facet and the other not is a real difference).</summary>
+    static bool SameWriteLegalType(string? a, string? b)
+    {
+        if (a == b) return true;                      // identical strings (incl. both-null) — the common case
+        if (a is null || b is null) return false;     // one present, one absent → genuinely different
+        var ta = WriteEngine.ResolveType(a);
+        var tb = WriteEngine.ResolveType(b);
+        if (ta is null || tb is null) return a == b;  // unresolvable → raw-string fallback (false here → stay rejected, Q3)
+        return (Nullable.GetUnderlyingType(ta) ?? ta) == (Nullable.GetUnderlyingType(tb) ?? tb);
+    }
 }

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -472,7 +472,7 @@ public sealed class CorpusRulebook
     /// over-arms search admits the path and the engine resolves on the live arm. The raw <c>Nullable</c> flag is
     /// therefore NOT compared — it is exactly the wrapper distinction the unwrap erases — while every GENUINE
     /// difference (cardinality, display type, or a different underlying CLR type) still rejects.</summary>
-    static bool SameShape(FieldSchema a, FieldSchema b) =>
+    internal static bool SameShape(FieldSchema a, FieldSchema b) =>
         a.Cardinality == b.Cardinality && a.Type == b.Type && a.TypeRef == b.TypeRef
         && a.ElementType == b.ElementType && a.ElementTypeRef == b.ElementTypeRef
         && a.Writable == b.Writable && a.IsIdentity == b.IsIdentity

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -62,6 +62,13 @@ if (args.Length > 0 && args[0] == "vmad-poly-guard") return VmadPolyProbe.RunGua
 // end-to-end through a live arm (asserted IN CI on an in-memory NPC, not behind --source).
 if (args.Length > 0 && args[0] == "poly-field-descend-guard") return PolyFieldDescendProbe.RunGuard(args[1..]);
 
+// SameShape write-legality equivalence (HCBR 1.2 / PR-B): a field shared across a poly base's arms that differs
+// ONLY by the Nullable<T> wrapper (APerkEffect.Value: float vs float?) now AGREES at pre-flight (the engine
+// unwraps Nullable<T> when it coerces); genuine conflicts on either axis the AQ check defends stay rejected
+// (cardinality: Condition.ComparisonValue; underlying type: APackageData.Data). Apply-1 drives the now-admitted
+// request end-to-end on an in-memory Perk. Self-contained (generated corpus + in-memory Mutagen).
+if (args.Length > 0 && args[0] == "sameshape-agree-guard") return SameShapeAgreeProbe.RunGuard(args[1..]);
+
 // BSA bridge contract guard (2026-06-12 adversarial hunt): unpack success = entries THIS RUN (the pre-seeded
 // meta.ini no longer reads as success), pack provenance (stuck stale scratch refuses), unknown format= refuses.
 if (args.Length > 0 && args[0] == "bsa-contract-guard") return BsaContractProbe.RunGuard(args[1..]);

--- a/src/housecarl-generator/SameShapeAgreeProbe.cs
+++ b/src/housecarl-generator/SameShapeAgreeProbe.cs
@@ -24,11 +24,17 @@ namespace HousecarlGenerator;
 /// rejects.
 ///
 /// RED→GREEN: check A (the one over-reject — <c>APerkEffect.Value</c> reached through <c>Perk.Effects[0].Value</c>)
-/// is RED before the fix ("CONFLICTING shapes") and GREEN after. The genuine-conflict guards are GREEN before AND
-/// after, proving the loosen is NARROW on BOTH axes the AQ check defends: C = <c>Condition.ComparisonValue</c>
-/// (formlink vs scalar — the CARDINALITY axis), D = <c>APackageData.Data</c> (bool vs uint vs float — the
-/// underlying-TYPE axis); each must still reject AT the SameShape gate (asserted on the "CONFLICTING shapes"
-/// message, not just any refusal — no green-for-the-wrong-reason). Apply-1 drives the SAME request A through
+/// is RED before the fix ("CONFLICTING shapes") and GREEN after. Real-corpus genuine conflicts stay rejected (net
+/// regression guards), each firing AT the SameShape gate ("CONFLICTING shapes" message — no
+/// green-for-the-wrong-reason): C = <c>Condition.ComparisonValue</c> (formlink vs scalar, rejected at the
+/// <c>a.Cardinality</c> clause), D = <c>APackageData.Data</c> (bool/uint/float, rejected at the display
+/// <c>a.Type</c> clause). NOTE neither C nor D reaches the NEW <c>SameWriteLegalType</c> branch — they reject on a
+/// clause this PR did not touch — and no corpus field has arms agreeing on every display facet yet differing only
+/// by underlying CLR type. So E exercises that branch DIRECTLY on two synthetic FieldSchemas equal on every facet
+/// SameShape checks before the AQ comparison: E1 (float vs int) must REJECT — the "different type bound under a
+/// shared display name" defense the original docstring cites, RED-able if <c>SameWriteLegalType</c> were ever
+/// neutered to always-agree; E2 (float vs float?) must AGREE — the loosen isolated at the AQ axis (RED under the
+/// old raw-AQ-string equality). Apply-1 drives the SAME request A through
 /// <see cref="WriteEngine"/>.ApplyVerb on an in-memory Perk carrying a live arm, locking the invariant "pre-flight
 /// admits exactly what the runtime coerces" (GREEN before and after — apply was never the gate; pre-flight was).
 ///
@@ -103,10 +109,11 @@ public static class SameShapeAgreeProbe
         Check("C: Condition.ComparisonValue (formlink vs scalar — cardinality conflict) stays rejected at the SameShape gate",
             cErr is not null && cErr.Contains("CONFLICTING shapes", StringComparison.Ordinal), cErr);
 
-        // ---- D: GENUINE conflict on the underlying-TYPE axis — APackageData.Data is scalar bool / uint / float
-        //         across arms (SAME cardinality + display facets differ only by the real CLR type). Reached through
-        //         Package.Data[0] (dict of the poly base). Proves the AQ comparison still distinguishes
-        //         Boolean/UInt32/Single AFTER the Nullable-unwrap — the loosen did NOT collapse different scalars. ----
+        // ---- D: GENUINE real-corpus conflict — APackageData.Data is scalar bool / uint / float across arms,
+        //         reached through Package.Data[0] (dict of the poly base). The display Type strings DIFFER
+        //         (bool/uint/float), so SameShape rejects at the UNCHANGED `a.Type == b.Type` clause — it never
+        //         reaches SameWriteLegalType. Kept as a net regression guard that a genuine multi-arm conflict
+        //         stays rejected; the AQ-discrimination branch the loosen actually changed is exercised by E. ----
         var d = new WriteRequest
         {
             RecordType = "Package",
@@ -114,8 +121,30 @@ public static class SameShapeAgreeProbe
             Verb = "Set", Value = "1",
         };
         var dErr = rb.Validate(d);
-        Check("D: APackageData.Data (bool vs uint vs float — underlying-type conflict) stays rejected at the SameShape gate",
+        Check("D: APackageData.Data (bool/uint/float — genuine conflict, rejects at the unchanged display-Type clause) stays rejected",
             dErr is not null && dErr.Contains("CONFLICTING shapes", StringComparison.Ordinal), dErr);
+
+        // ---- E: the SameWriteLegalType discrimination branch ITSELF, driven DIRECTLY — because no corpus field
+        //         has arms agreeing on every display facet yet differing only by underlying CLR type, C/D both
+        //         reject at earlier, UNCHANGED clauses and never reach it. Two synthetic FieldSchemas, identical on
+        //         every facet SameShape checks before the AQ comparison (same Cardinality/Type/refs/Writable/
+        //         IsIdentity), differing ONLY in a resolvable AQ type:
+        //           E1 (float vs int) must REJECT — the "two arms share a display name but bind different types"
+        //              defense; RED if SameWriteLegalType were ever neutered to always-agree past its a==b fast path.
+        //           E2 (float vs float?) must AGREE — the loosen, isolated at the AQ axis (RED under the old raw-AQ
+        //              equality, which compared the wrapper string literally). Together they pin the branch both ways. ----
+        FieldSchema Leaf(string aq) => new FieldSchema
+        {
+            Name = "X", Cardinality = "scalar", Type = "float", Writable = true, IsIdentity = false,
+            GetterTypeAssemblyQualified = aq, MutableTypeAssemblyQualified = aq,
+        };
+        var floatLeaf = Leaf(typeof(float).AssemblyQualifiedName!);
+        var intLeaf = Leaf(typeof(int).AssemblyQualifiedName!);
+        var nullableFloatLeaf = Leaf(typeof(float?).AssemblyQualifiedName!);
+        Check("E1: arms equal on every display facet but binding float vs int REJECT (SameWriteLegalType discriminates underlying type)",
+            !CorpusRulebook.SameShape(floatLeaf, intLeaf));
+        Check("E2: the same two facets binding float vs float? AGREE (the Nullable<T> unwrap, isolated at the AQ axis)",
+            CorpusRulebook.SameShape(floatLeaf, nullableFloatLeaf));
 
         // ============================================================================================
         // PART 2 — apply: the same request A the loosen now admits actually applies through the engine, asserted

--- a/src/housecarl-generator/SameShapeAgreeProbe.cs
+++ b/src/housecarl-generator/SameShapeAgreeProbe.cs
@@ -1,0 +1,139 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// REGRESSION GUARD (standing CI instrument) for HCBR-2026-06-15-01 item 1.2 (PR-B) — the SameShape over-reject.
+///
+/// THE GAP: when a field exists on several ARMS of a polymorphic base, <see cref="CorpusRulebook"/>'s FindField
+/// admits the path only if those arms AGREE in shape (<c>SameShape</c>) — one shape validates for whichever arm the
+/// live element turns out to be. SameShape compared the raw <c>Nullable</c> flag and three raw assembly-qualified
+/// CLR-type strings, so two arms that are WRITE-LEGAL-IDENTICAL but differ only by the <c>Nullable&lt;T&gt;</c>
+/// wrapper over-rejected with "CONFLICTING shapes" — even though <see cref="WriteEngine"/>.Coerce unwraps
+/// <c>Nullable&lt;T&gt;</c> and admits the identical value set on either arm. Re-walking the corpus, EXACTLY ONE
+/// field is affected: <c>APerkEffect.Value</c> — <c>float</c> on <c>PerkEntryPointModifyActorValue</c>, <c>float?</c>
+/// on <c>PerkEntryPointModifyValue</c>/<c>…ModifyValues</c>.
+///
+/// THE FIX (by construction): SameShape now compares the AQ types after unwrapping <c>Nullable&lt;T&gt;</c>
+/// (mirroring the engine's own Coerce/CanCoerce) and drops the raw Nullable-bool equality; an AQ name that won't
+/// resolve to a runtime Type falls back to raw-string equality, so a genuinely unknown type is never silently
+/// widened (Q3). Every GENUINE difference — cardinality, display type, or a different underlying CLR type — still
+/// rejects.
+///
+/// RED→GREEN: check A (the one over-reject — <c>APerkEffect.Value</c> reached through <c>Perk.Effects[0].Value</c>)
+/// is RED before the fix ("CONFLICTING shapes") and GREEN after. The genuine-conflict guards are GREEN before AND
+/// after, proving the loosen is NARROW on BOTH axes the AQ check defends: C = <c>Condition.ComparisonValue</c>
+/// (formlink vs scalar — the CARDINALITY axis), D = <c>APackageData.Data</c> (bool vs uint vs float — the
+/// underlying-TYPE axis); each must still reject AT the SameShape gate (asserted on the "CONFLICTING shapes"
+/// message, not just any refusal — no green-for-the-wrong-reason). Apply-1 drives the SAME request A through
+/// <see cref="WriteEngine"/>.ApplyVerb on an in-memory Perk carrying a live arm, locking the invariant "pre-flight
+/// admits exactly what the runtime coerces" (GREEN before and after — apply was never the gate; pre-flight was).
+///
+/// Self-contained: the corpus checks use the GENERATED corpus.json (built into a unique temp dir on a fresh
+/// checkout, exactly as <c>poly-field-descend-guard</c> does); the apply check is pure in-memory Mutagen — no
+/// plugin file, no Skyrim.esm.
+///
+/// Run: <c>dotnet run --project src/housecarl-generator sameshape-agree-guard</c>
+/// </summary>
+public static class SameShapeAgreeProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        // CI-safe: corpus.json is GENERATED, not tracked — on a fresh checkout (the CI runner) build it into a
+        // UNIQUE temp dir (no cross-run sharing/races) and point the rulebook there, leaving the working tree
+        // untouched; cleaned up on exit. A repo with generated/ already present (local dev) is used as-is.
+        string? tmp = null;
+        if (!File.Exists(CorpusRulebook.CorpusPath))
+        {
+            tmp = Path.Combine(Path.GetTempPath(), "housecarl-sameshape-agree-guard-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tmp);
+            Console.WriteLine($"corpus.json absent — generating into {tmp} (CI / fresh checkout)…");
+            var rc = CorpusGenerator.GenerateAll(Path.Combine(tmp, "generated"), Path.Combine(tmp, "refs"));
+            if (rc != 0) { Console.Error.WriteLine("error: corpus generation failed"); return rc; }
+            CorpusRulebook.CorpusPath = Path.Combine(tmp, "generated", "corpus.json");
+        }
+        try { return RunChecks(); }
+        finally { if (tmp is not null) { try { Directory.Delete(tmp, recursive: true); } catch { /* best-effort */ } } }
+    }
+
+    static int RunChecks()
+    {
+        var rb = CorpusRulebook.Load();
+        int failures = 0;
+
+        void Check(string label, bool ok, string? detail = null)
+        {
+            Console.WriteLine($"  {(ok ? "PASS" : "FAIL")}  {label}{(ok || detail is null ? "" : $"\n        -> {detail}")}");
+            if (!ok) failures++;
+        }
+
+        Console.WriteLine("sameshape-agree-guard — SameShape write-legality equivalence (HCBR 1.2 / PR-B)");
+        Console.WriteLine();
+
+        // ============================================================================================
+        // PART 1 — pre-flight: the ONE over-reject now agrees; both axes of genuine conflict stay rejected.
+        // ============================================================================================
+
+        // ---- A: THE over-reject — APerkEffect.Value lives on three arms, all scalar float, differing ONLY on
+        //         Nullable (float vs float?). Reached through Perk.Effects[0] (the list element type is the base
+        //         APerkEffect, so FindField's over-arms loop is entered). RED today = "CONFLICTING shapes". ----
+        var a = new WriteRequest
+        {
+            RecordType = "Perk",
+            Path = new[] { "Effects[0]", "Value" },
+            Verb = "Set", Value = "5",
+        };
+        var aErr = rb.Validate(a);
+        Check("A: Set Perk.Effects[0].Value (float vs float? across arms — write-legal-identical) passes pre-flight",
+            aErr is null, aErr);
+
+        // ---- C: GENUINE conflict on the CARDINALITY axis — Condition.ComparisonValue is a formlink on
+        //         ConditionGlobal and a scalar float on ConditionFloat. Reached through MagicEffect.Conditions[0].
+        //         Stays rejected (the loosen never touches Cardinality), and rejects AT the SameShape gate. ----
+        var c = new WriteRequest
+        {
+            RecordType = "MagicEffect",
+            Path = new[] { "Conditions[0]", "ComparisonValue" },
+            Verb = "Set", Value = "000800:Skyrim.esm",
+        };
+        var cErr = rb.Validate(c);
+        Check("C: Condition.ComparisonValue (formlink vs scalar — cardinality conflict) stays rejected at the SameShape gate",
+            cErr is not null && cErr.Contains("CONFLICTING shapes", StringComparison.Ordinal), cErr);
+
+        // ---- D: GENUINE conflict on the underlying-TYPE axis — APackageData.Data is scalar bool / uint / float
+        //         across arms (SAME cardinality + display facets differ only by the real CLR type). Reached through
+        //         Package.Data[0] (dict of the poly base). Proves the AQ comparison still distinguishes
+        //         Boolean/UInt32/Single AFTER the Nullable-unwrap — the loosen did NOT collapse different scalars. ----
+        var d = new WriteRequest
+        {
+            RecordType = "Package",
+            Path = new[] { "Data[0]", "Data" },
+            Verb = "Set", Value = "1",
+        };
+        var dErr = rb.Validate(d);
+        Check("D: APackageData.Data (bool vs uint vs float — underlying-type conflict) stays rejected at the SameShape gate",
+            dErr is not null && dErr.Contains("CONFLICTING shapes", StringComparison.Ordinal), dErr);
+
+        // ============================================================================================
+        // PART 2 — apply: the same request A the loosen now admits actually applies through the engine, asserted
+        // IN CI on an in-memory Perk with a live nullable-float arm — "pre-flight admits exactly what apply does".
+        // (GREEN before and after the fix: apply already coerced "5" onto the live arm; pre-flight was the gate.)
+        // ============================================================================================
+
+        var perk = new SkyrimMod(new ModKey("hc_sameshape", ModType.Plugin), SkyrimRelease.SkyrimSE).Perks.AddNew();
+        perk.Effects.Add(new PerkEntryPointModifyValue());   // a live arm carrying the nullable-float Value
+        WriteEngine.ApplyVerb(perk, a);
+        Check("Apply-1: ApplyVerb resolves Effects[0] to the live PerkEntryPointModifyValue arm and sets Value=5 (in-memory, in CI)",
+            perk.Effects[0] is PerkEntryPointModifyValue { Value: 5f },
+            perk.Effects[0] is PerkEntryPointModifyValue pe
+                ? $"Value={pe.Value?.ToString() ?? "null"}"
+                : $"arm is {perk.Effects[0].GetType().Name}");
+
+        Console.WriteLine();
+        Console.WriteLine(failures == 0 ? "sameshape-agree-guard: ALL PASS" : $"sameshape-agree-guard: {failures} FAILURE(S)");
+        return failures == 0 ? 0 : 1;
+    }
+}


### PR DESCRIPTION
## HCBR-2026-06-15-01 / PR-B — item 1.2: loosen `SameShape` to write-legality equivalence

**The gap.** When a field exists on several arms of a polymorphic base, `CorpusRulebook.FindField` admits the path only if the arms AGREE in shape (`SameShape`) — one shape validates for whichever arm the live element turns out to be. `SameShape` compared the raw `Nullable` flag and three raw assembly-qualified CLR-type strings, so two arms that are **write-legal-identical** but differ only by the `Nullable<T>` wrapper over-rejected with `"CONFLICTING shapes"` — even though `WriteEngine.Coerce`/`CanCoerce` unwrap `Nullable<T>` and admit the identical value set on either arm. Re-walking the corpus, **exactly one** field is affected: `APerkEffect.Value` (`float` on `PerkEntryPointModifyActorValue`, `float?` on `PerkEntryPointModifyValue`/`…ModifyValues`). The reject reads *"scalar float vs scalar float"* — identical to the user, yet refused.

**The fix (by construction).** The CLR-type facets now compare write-legal **equivalence** via a new `SameWriteLegalType` helper — resolve both AQ names and compare after unwrapping `Nullable<T>` (mirroring the engine's own coercion); an unresolvable name falls back to raw-string identity so a genuinely unknown type is never silently widened (Q3). The raw `Nullable`-bool equality is dropped (it is exactly the wrapper distinction the unwrap erases). Every genuine difference — cardinality, display type, or a different underlying CLR type — still rejects.

Per the fix-scoping critic correction, this is a **single Nullable-unwrap edit only**: the scope's proposed "least-writable representative" `FindField` change is **not** made (it guarded a path with zero corpus instances).

**Proof — new guard `sameshape-agree-guard` (CI step #34), RED→GREEN:**
- **A (RED→GREEN):** `Set Perk.Effects[0].Value` (the one over-reject, reached through the base-typed list element so the over-arms loop is entered) now passes pre-flight.
- **C / D (green before *and* after):** genuine conflicts stay rejected on **both** axes the AQ check defends — `Condition.ComparisonValue` (formlink vs scalar, the cardinality axis) and `APackageData.Data` (bool vs uint vs float, the underlying-type axis) — each asserted to reject **at the SameShape gate** (on the `"CONFLICTING shapes"` message; no green-for-the-wrong-reason).
- **Apply-1:** the same request A drives `WriteEngine.ApplyVerb` on an in-memory `Perk` with a live `PerkEntryPointModifyValue` arm, locking *"pre-flight admits exactly what the runtime coerces."*

**No regression:** `poly-field-descend-guard` (PR-A) and `vmad-poly-guard` (the sibling guards over the same `FindField`/`SameShape` path) both ALL PASS; full solution builds clean (0 errors).

**§4:** (a). Restores the by-construction invariant "pre-flight admits exactly what the runtime coerces."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
