### PR TITLE
write-surface: nested compose + serialize-boundary null-arm refusal (HCBR PR-C)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,18 @@ jobs:
       - name: Probe — SameShape write-legality equivalence (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- sameshape-agree-guard
 
+      # Nested compose + serialize-boundary null-arm refusal (HCBR 1.1 null-arm half + serialize-NRE / PR-C). PART A:
+      # a compose's nested set carried no `compose`, so a sets[] entry could only set a scalar, never SELECT a
+      # polymorphic sub-arm (a Condition's Data). NestedSet gained an optional Compose and MapStruct propagates it into
+      # WriteRequest.Struct — which the core already applies + validates end-to-end (BuildStruct recurses; ArmLegality
+      # validates the arm). PART B: a COMPOSED record left with a required polymorphic sub-field null is a bare NRE in
+      # Mutagen's writer (no field name); pre-flight can't reject it (every poly field is corpus-Nullable=false, so no
+      # required/optional signal — empirically a bare NPC with Sound/Level null serializes fine), so WritePatch
+      # re-stamps the serialize-boundary NRE as a NAMED NullArmSerializeException (all-or-nothing, target untouched).
+      # A1/A2/A5/B1/B2 are pure in-memory Mutagen; A3/A4 generate the corpus into a temp dir. No game data.
+      - name: Probe — nested compose + serialize-boundary null-arm refusal (self-contained regression guard)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- nullarm-guard
+
       # The compile tool's import ORDER is semantics (the CK compiler takes the FIRST matching .psc), so caller
       # import_dirs must outrank the auto-added vanilla folder — else SKSE-extended copies of vanilla scripts lose
       # to vanilla and extended calls fail despite the right folder being passed (spike findings §5.12, hit twice).

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1244,9 +1244,30 @@ public static class WriteEngine
         // like an in-place write would, so callers must still release every handle they hold on the target first.
         // Staging buys crash-tear safety and shrinks the external-watcher window; the handle discipline stays
         // load-bearing.
-        var staged = WritePatchStaged(patchMod, ordered, baseline, outputPath);
+        // SERIALIZE-BOUNDARY NULL-ARM CATCH (HCBR-2026-06-15-01 PR-C, PART B): Mutagen's binary writer dereferences a
+        // record's modeled sub-fields as it writes; a COMPOSED record that left a REQUIRED polymorphic sub-field unset
+        // (the canonical case: a Condition composed without its Data arm) is null at that deref → a bare
+        // NullReferenceException carrying NO field name. Pre-flight can't reject it: the corpus models every polymorphic
+        // field as Nullable=false, so there is no required/optional signal to gate on (that predicate would over-reject
+        // EVERY legitimately-optional null poly field — empirically a bare NPC with Sound/Level null serializes fine).
+        // The serialize boundary is the honest place to fail it (Q3). WritePatchStaged already discards its temp on any
+        // throw, so nothing is on disk; re-stamp ONLY the opaque NRE as a NAMED refusal (other serialize errors keep
+        // their own type/message). The existing WritePatchBuilder serialize catches render it loud + all-or-nothing.
+        string staged;
+        try { staged = WritePatchStaged(patchMod, ordered, baseline, outputPath); }
+        catch (NullReferenceException ex) { throw new NullArmSerializeException(ex); }
         CommitStagedPatch(staged, outputPath);
     }
+
+    /// <summary>Render an exception as <c>Type: message</c>, APPENDING its inner exception's type+message when present.
+    /// A re-stamped wrapper (e.g. <see cref="NullArmSerializeException"/> over the raw writer NRE) otherwise hides the
+    /// discriminating inner signal at the user surface — so the serialize-failure render sites use this to keep the
+    /// loud NAMED outer message AND the inner that distinguishes a genuine engine NRE from a composed-null-arm one
+    /// (the codebase's InnerException-unwrap idiom). Q3 — no opaque, no signal-stripping error.</summary>
+    internal static string Describe(Exception ex)
+        => ex.InnerException is { } inner
+            ? $"{ex.GetType().Name}: {ex.Message} [inner: {inner.GetType().Name}: {inner.Message}]"
+            : $"{ex.GetType().Name}: {ex.Message}";
 
     /// <summary>Stage 1 of the atomic write: serialize the patch into a temp SUBDIRECTORY beside the target —
     /// same filename (Mutagen's writer ties filename to ModKey), same parent directory (guarantees same NTFS
@@ -2491,5 +2512,27 @@ public sealed class CompositionRequiredException : InvalidOperationException
     {
         Segment = segment;
         SubstructType = substructType;
+    }
+}
+
+/// <summary>A serialize-boundary <see cref="NullReferenceException"/> re-stamped as a loud, NAMED refusal
+/// (HCBR-2026-06-15-01 PR-C, PART B). Mutagen's binary writer throws a bare NRE — no field name — when it dereferences
+/// a record's REQUIRED modeled sub-field that was left null; the dominant cause is a COMPOSED record missing a required
+/// polymorphic sub-arm (a Condition without its Data arm, an element missing a required part). The corpus models every
+/// polymorphic field as <c>Nullable=false</c>, so pre-flight has no required/optional signal to reject on (such a
+/// predicate would over-reject every legitimately-optional null poly field), which is why this is caught at the
+/// serialize boundary instead. The staged temp is already discarded by the time this throws (nothing on disk; the
+/// target is untouched), and the caller's serialize catch renders it as an all-or-nothing <c>Fail</c>. The original
+/// NRE is preserved as <see cref="Exception.InnerException"/>. Q3 — no silent failure, no opaque message.</summary>
+public sealed class NullArmSerializeException : InvalidOperationException
+{
+    public NullArmSerializeException(Exception inner)
+        : base("a required modeled sub-field was null when Mutagen serialized the patch (a NullReferenceException in the " +
+               "writer). The most common cause is a COMPOSED record that left a required polymorphic sub-field unset — " +
+               "e.g. a Condition composed without its Data arm, or a leveled-list / effect element missing a required " +
+               "part. Compose that sub-field too (select the arm via compose). Nothing was written — the staged file was " +
+               "discarded and the target is untouched. If no composition was involved, this is an engine/Mutagen " +
+               "inconsistency — surface it, don't work around it.", inner)
+    {
     }
 }

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -239,7 +239,7 @@ public static class WritePatchBuilder
         session.ReleaseOverlay(patchMod.ModKey.FileName.String);
         try { WriteEngine.WritePatch(patchMod, session.AllMastersExcept(patchMod.ModKey.FileName.String), outPath); }
         catch (Exception ex)
-            { return PatchOutcome.Fail($"writing the patch failed (serialize or commit; the existing file is untouched): {ex.GetType().Name}: {ex.Message}"); }
+            { return PatchOutcome.Fail($"writing the patch failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}"); }
 
         // --- Phase 5: re-open the written patch and report its master header — and, on request, each touched
         //     record's FULL read-back off that same re-opened file (the on-disk bytes, not the in-memory mod — the
@@ -352,7 +352,7 @@ public static class WritePatchBuilder
         // keeps the target out of the master set. (writelock-probe / writelock-apply-probe; both halves guarded.)
         session.ReleaseOverlay(patchMod.ModKey.FileName.String);
         try { WriteEngine.WritePatch(patchMod, session.AllMastersExcept(patchMod.ModKey.FileName.String), outPath); }
-        catch (Exception ex) { return RemovalOutcome.Fail($"writing the patch after removal failed (serialize or commit; the existing file is untouched): {ex.GetType().Name}: {ex.Message}"); }
+        catch (Exception ex) { return RemovalOutcome.Fail($"writing the patch after removal failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}"); }
 
         // Re-open: report the (possibly shrunk) master header + how many records remain (0 ⇒ the patch is now an inert
         // header-only plugin the user can disable/delete). Dispose the overlay so the file isn't left mmap'd for a later call.
@@ -580,7 +580,7 @@ public static class WritePatchBuilder
         // keeps the target out of the master set. (writelock-probe / writelock-apply-probe; both halves guarded.)
         session.ReleaseOverlay(patchMod.ModKey.FileName.String);
         try { WriteEngine.WritePatch(patchMod, session.AllMastersExcept(patchMod.ModKey.FileName.String), outPath); }
-        catch (Exception ex) { return CreateOutcome.Fail($"writing the patch after create failed (serialize or commit; the existing file is untouched): {ex.GetType().Name}: {ex.Message}"); }
+        catch (Exception ex) { return CreateOutcome.Fail($"writing the patch after create failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}"); }
 
         // --- Phase 5: re-open + report the (derived) master header + bytes — and, on request, each created record's
         //     FULL read-back off that same re-opened file (see Apply's Phase 5). Dispose the overlay so the file isn't

--- a/src/housecarl-generator/NullArmGuardProbe.cs
+++ b/src/housecarl-generator/NullArmGuardProbe.cs
@@ -1,0 +1,204 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// REGRESSION GUARD (standing CI instrument) for HCBR-2026-06-15-01 PR-C — two coupled needs.
+///
+/// PART A — the WIRE nested-compose gap. A compose's nested set (<see cref="StructInput"/>.<c>Sets[]</c>)
+/// carried NO <c>compose</c> field, so a <c>sets[]</c> entry could only set a coercible scalar — never SELECT
+/// a polymorphic sub-ARM (e.g. a Condition's <c>Data</c>). The core already applied AND validated a nested
+/// <see cref="WriteRequest.Struct"/> end-to-end (<c>BuildStruct</c> recurses on a Set/Add carrying a Struct;
+/// the rulebook's <c>ArmLegality</c> validates <c>compose.type</c> against the leaf's legal arms); the only
+/// break was the wire→core mapping. THE FIX: <see cref="NestedSet"/> gained an optional <c>Compose</c>
+/// (<see cref="StructInput"/>), and <see cref="LoadOrderService"/>.<c>MapStruct</c> propagates it recursively
+/// into <see cref="WriteRequest.Struct"/>.
+///
+/// PART B — the serialize-boundary NULL-ARM refusal. A COMPOSED record that leaves a REQUIRED polymorphic
+/// sub-field unset (the canonical case: a Condition composed without its <c>Data</c> arm) is null when
+/// Mutagen's binary writer dereferences it → a bare <see cref="NullReferenceException"/> with NO field name.
+/// Pre-flight can't reject it: the corpus models every polymorphic field as <c>Nullable=false</c>, so there is
+/// no required/optional signal to gate on (such a predicate would over-reject every legitimately-OPTIONAL null
+/// poly field — empirically a bare NPC with Sound/Level null serializes fine). THE FIX: <c>WriteEngine.WritePatch</c>
+/// re-stamps the serialize-boundary NRE as a loud, NAMED <see cref="NullArmSerializeException"/> — all-or-nothing
+/// (the staged temp is already discarded; the target is untouched), preserving the NRE as <c>InnerException</c>. Q3.
+///
+/// RED→GREEN: Part A checks A1/A2/A3/A5 are RED if <c>MapStruct</c> drops the nested Struct; Part B check B1 is
+/// RED (a bare <see cref="NullReferenceException"/>, not a <see cref="NullArmSerializeException"/>) without the
+/// <c>WritePatch</c> catch. The FALSE-POSITIVE control (B2) and the illegal-nested-arm reject (A4) are GREEN
+/// before AND after — they prove the fix is NARROW (a valid optional-null poly still serializes; an illegal
+/// nested arm still rejects loud).
+///
+/// Self-contained: A1/A2/A5/B1/B2 are pure in-memory Mutagen (no plugin file, no Skyrim.esm); A3/A4 use the
+/// GENERATED corpus.json (built into a unique temp dir on a fresh checkout, exactly as poly-field-descend-guard does).
+///
+/// Run: <c>dotnet run --project src/housecarl-generator nullarm-guard</c>
+/// </summary>
+public static class NullArmGuardProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        // CI-safe corpus: corpus.json is GENERATED, not tracked — on a fresh checkout build it into a UNIQUE
+        // temp dir and point the rulebook there, leaving the working tree untouched; cleaned up on exit.
+        string? tmp = null;
+        if (!File.Exists(CorpusRulebook.CorpusPath))
+        {
+            tmp = Path.Combine(Path.GetTempPath(), "housecarl-nullarm-guard-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tmp);
+            Console.WriteLine($"corpus.json absent — generating into {tmp} (CI / fresh checkout)…");
+            var rc = CorpusGenerator.GenerateAll(Path.Combine(tmp, "generated"), Path.Combine(tmp, "refs"));
+            if (rc != 0) { Console.Error.WriteLine("error: corpus generation failed"); return rc; }
+            CorpusRulebook.CorpusPath = Path.Combine(tmp, "generated", "corpus.json");
+        }
+        try { return RunChecks(); }
+        finally { if (tmp is not null) { try { Directory.Delete(tmp, recursive: true); } catch { /* best-effort */ } } }
+    }
+
+    static int RunChecks()
+    {
+        int failures = 0;
+        void Check(string label, bool ok, string? detail = null)
+        {
+            Console.WriteLine($"  {(ok ? "PASS" : "FAIL")}  {label}{(ok || detail is null ? "" : $"\n        -> {detail}")}");
+            if (!ok) failures++;
+        }
+
+        Console.WriteLine("nullarm-guard — nested compose (PR-C Part A) + serialize-boundary null-arm refusal (PR-C Part B)");
+        Console.WriteLine();
+
+        // The wire shape a caller would send: Add a Condition element whose polymorphic Data sub-field is SELECTED by
+        // a nested compose. Before PR-C the inner `compose` could not be expressed (NestedSet had no such field) and,
+        // even if it could, MapStruct dropped it.
+        static StructInput ConditionInputWithData(string dataArm) => new()
+        {
+            Type = "ConditionFloat",
+            Sets = new[] { new NestedSet { Path = "Data", Compose = new StructInput { Type = dataArm } } },
+        };
+
+        static WriteRequest AddCondition(StructSpec? spec) =>
+            new() { RecordType = "ConstructibleObject", Path = new[] { "Conditions" }, Verb = "Add", Struct = spec };
+
+        // ============================ PART A — wire→core nested compose ============================
+
+        // ---- A1: MapStruct carries the nested compose into the nested WriteRequest.Struct (RED if dropped). ----
+        var specWithData = LoadOrderService.MapStruct(ConditionInputWithData("GetActorValueConditionData"), "guard", out var mapErr);
+        Check("A1: MapStruct propagates a nested compose into Sets[0].Struct",
+            mapErr is null && specWithData?.Sets is { Count: 1 } && specWithData.Sets[0].Struct?.Type == "GetActorValueConditionData",
+            mapErr ?? $"Sets[0].Struct = {specWithData?.Sets?[0].Struct?.Type ?? "null"}");
+
+        // ---- A2: ApplyVerb of an Add(Conditions) built from that mapping yields a ConditionFloat whose Data IS the
+        //          composed arm (in-memory; RED if Struct not carried → Data stays null / the nested Set throws). ----
+        bool a2ok; string? a2Detail;
+        try
+        {
+            var cobjA = new SkyrimMod(new ModKey("hc_nullarm_a2", ModType.Plugin), SkyrimRelease.SkyrimSE).ConstructibleObjects.AddNew();
+            WriteEngine.ApplyVerb(cobjA, AddCondition(specWithData));
+            a2ok = cobjA.Conditions is { Count: 1 } && cobjA.Conditions[0] is ConditionFloat { Data: GetActorValueConditionData };
+            a2Detail = cobjA.Conditions.Count == 1
+                ? $"Data arm = {(cobjA.Conditions[0] as ConditionFloat)?.Data?.GetType().Name ?? "null"}"
+                : "no condition added";
+        }
+        catch (Exception ex) { a2ok = false; a2Detail = $"{ex.GetType().Name}: {ex.Message}"; }
+        Check("A2: ApplyVerb builds the composed Data arm through the nested compose (in-memory)", a2ok, a2Detail);
+
+        // ---- A3: pre-flight ACCEPTS the same wire-mapped Add (the nested compose validates through ArmLegality). ----
+        var rb = CorpusRulebook.Load();
+        var a3Err = rb.Validate(AddCondition(specWithData));
+        Check("A3: pre-flight accepts the nested-composed Add (validates the sub-arm)", a3Err is null, a3Err);
+
+        // ---- A4: Q3 teeth — an ILLEGAL nested arm rejects LOUD naming the legal arms. GREEN before+after. ----
+        var badSpec = LoadOrderService.MapStruct(ConditionInputWithData("BogusConditionData"), "guard", out _);
+        var a4Err = rb.Validate(AddCondition(badSpec));
+        Check("A4: an illegal nested arm rejects naming the legal arms",
+            a4Err is not null && a4Err.Contains("arm", StringComparison.OrdinalIgnoreCase) && a4Err.Contains("BogusConditionData", StringComparison.Ordinal),
+            a4Err);
+
+        // ---- A5: end-to-end — compose-Add a Condition WITH Data, then SERIALIZE: the record the nested-compose
+        //          grammar builds is a writable plugin (the fix a user applies actually works through the wire path). ----
+        var (a5ok, a5Detail) = TrySerialize("hc_nullarm_a5", mod =>
+        {
+            var cobj = mod.ConstructibleObjects.AddNew();
+            WriteEngine.ApplyVerb(cobj, AddCondition(LoadOrderService.MapStruct(ConditionInputWithData("GetActorValueConditionData"), "guard", out _)));
+        });
+        Check("A5: a nested-composed Condition (Data set) serializes to a valid patch", a5ok, a5Detail);
+
+        // ======================= PART B — serialize-boundary null-arm refusal =======================
+
+        // ---- B1: compose-Add a ConditionFloat WITHOUT Data → serialize throws a NAMED NullArmSerializeException
+        //          (not a bare NRE), names the cause, preserves the NRE as inner, and writes NOTHING. RED before. ----
+        var b1Path = OutPath("hc_nullarm_b1");
+        NullArmSerializeException? caught = null; Exception? wrong = null;
+        try
+        {
+            SerializeTo(b1Path, mod =>
+            {
+                var cobj = mod.ConstructibleObjects.AddNew();
+                WriteEngine.ApplyVerb(cobj, AddCondition(LoadOrderService.MapStruct(new StructInput { Type = "ConditionFloat" }, "guard", out _)));
+            });
+        }
+        catch (NullArmSerializeException ex) { caught = ex; }
+        catch (Exception ex) { wrong = ex; }
+        Check("B1: a Condition composed without its Data arm fails as a NAMED NullArmSerializeException (not a bare NRE)",
+            caught is not null, wrong is null ? "no exception thrown" : $"threw {wrong.GetType().Name} instead");
+        Check("B1b: the refusal names the cause (compose) and preserves the NRE as InnerException",
+            caught is not null && caught.Message.Contains("compose", StringComparison.OrdinalIgnoreCase) && caught.InnerException is NullReferenceException,
+            caught?.Message);
+        Check("B1c: nothing was written — all-or-nothing, the target is untouched", !File.Exists(b1Path));
+        // B1d: the render boundary (WriteEngine.Describe, used by the three WritePatchBuilder serialize catches) keeps
+        //      BOTH the loud NAMED outer AND the discriminating inner NRE — so a masked non-compose NRE never loses
+        //      its only distinguishing signal (review should-fix; RED if Describe drops the inner). The pre-fix bare
+        //      NRE has no inner, so the negative control below proves Describe only appends when an inner is present.
+        var rendered = caught is null ? "" : WriteEngine.Describe(caught);
+        Check("B1d: the render surfaces the named outer AND the inner NRE (no signal-stripping)",
+            rendered.Contains("NullArmSerializeException", StringComparison.Ordinal)
+                && rendered.Contains("[inner: NullReferenceException", StringComparison.Ordinal),
+            rendered);
+        Check("B1e: Describe appends NOTHING for an inner-less exception (the append is conditional, not noise)",
+            WriteEngine.Describe(new InvalidOperationException("bare")) == "InvalidOperationException: bare");
+        CleanOut(b1Path);
+
+        // ---- B2: FALSE-POSITIVE control — records with genuinely-OPTIONAL null poly fields (a bare NPC whose
+        //          Configuration.Level is null; an NPC with Level set but Sound null) serialize FINE. The catch must
+        //          NEVER fire on a valid null poly. GREEN before+after. ----
+        var (b2ok, b2Detail) = TrySerialize("hc_nullarm_b2", mod =>
+        {
+            mod.Npcs.AddNew();                                                            // bare NPC: Level + Sound null
+            var n2 = mod.Npcs.AddNew(); n2.Configuration.Level = new NpcLevel { Level = 1 }; // Sound null, Level set
+        });
+        Check("B2: optional null polymorphic fields (NPC Sound/Level) still serialize fine (no false refusal)", b2ok, b2Detail);
+
+        Console.WriteLine();
+        Console.WriteLine(failures == 0 ? "nullarm-guard: ALL PASS" : $"nullarm-guard: {failures} FAILURE(S)");
+        return failures == 0 ? 0 : 1;
+    }
+
+    // --- serialize helpers: a self-contained patch through the REAL WriteEngine.WritePatch (pure in-memory) ---
+
+    static string OutPath(string stem) =>
+        Path.Combine(Path.GetTempPath(), stem + "-" + Guid.NewGuid().ToString("N"), stem + ".esp");
+
+    static void SerializeTo(string outPath, Action<SkyrimMod> build)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(outPath)!);
+        var mod = new SkyrimMod(new ModKey(Path.GetFileNameWithoutExtension(outPath), ModType.Plugin), SkyrimRelease.SkyrimSE);
+        build(mod);
+        WriteEngine.WritePatch(mod, new ISkyrimModGetter[] { mod }, outPath);
+    }
+
+    static (bool ok, string? detail) TrySerialize(string stem, Action<SkyrimMod> build)
+    {
+        var outPath = OutPath(stem);
+        try { SerializeTo(outPath, build); var ok = File.Exists(outPath); CleanOut(outPath); return (ok, ok ? null : "no file written"); }
+        catch (Exception ex) { CleanOut(outPath); return (false, $"{ex.GetType().Name}: {ex.Message}"); }
+    }
+
+    static void CleanOut(string outPath)
+    {
+        try { var dir = Path.GetDirectoryName(outPath); if (dir is not null && Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+        catch { /* best-effort */ }
+    }
+}

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -69,6 +69,13 @@ if (args.Length > 0 && args[0] == "poly-field-descend-guard") return PolyFieldDe
 // request end-to-end on an in-memory Perk. Self-contained (generated corpus + in-memory Mutagen).
 if (args.Length > 0 && args[0] == "sameshape-agree-guard") return SameShapeAgreeProbe.RunGuard(args[1..]);
 
+// Nested compose + serialize-boundary null-arm refusal (HCBR 1.1 null-arm half + serialize-NRE / PR-C): a compose's
+// nested set can SELECT a polymorphic sub-arm (NestedSet.compose → MapStruct propagates it into WriteRequest.Struct,
+// which the core already applies + validates end-to-end); and a COMPOSED record left with a required polymorphic
+// sub-field null fails serialize as a NAMED NullArmSerializeException (not a bare NRE), all-or-nothing, while a
+// genuinely-optional null poly field still serializes fine. Self-contained (in-memory Mutagen + generated corpus).
+if (args.Length > 0 && args[0] == "nullarm-guard") return NullArmGuardProbe.RunGuard(args[1..]);
+
 // BSA bridge contract guard (2026-06-12 adversarial hunt): unpack success = entries THIS RUN (the pre-seeded
 // meta.ini no longer reads as success), pack provenance (stuck stale scratch refuses), unknown format= refuses.
 if (args.Length > 0 && args[0] == "bsa-contract-guard") return BsaContractProbe.RunGuard(args[1..]);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1149,8 +1149,15 @@ public sealed class LoadOrderService : IDisposable
     /// <summary>Build a core composition <see cref="StructSpec"/> from the wire shape — flat <c>fields</c> (coercible
     /// sub-fields), positional <c>ctor_args</c>, and nested <c>sets</c> (each a path+verb+value applied to the built
     /// struct, e.g. a leveled-list entry's Data.Level / Data.Reference). The nested sets' RecordType carries the struct
-    /// type (the validator roots them at the struct schema, so it's a label). Q3 on a malformed spec.</summary>
-    StructSpec? MapStruct(StructInput s, string where, out string? error)
+    /// type (the validator roots them at the struct schema, so it's a label). A nested set may itself carry a
+    /// <c>compose</c> (HCBR-2026-06-15-01 PR-C) — a recursive <see cref="StructSpec"/> selecting a polymorphic
+    /// sub-ARM (e.g. <c>sets:[{path:'Data', compose:{type:'GetActorValueConditionData', …}}]</c>) — mapped here into
+    /// the nested <see cref="WriteRequest.Struct"/> the core already applies + validates end-to-end (BuildStruct
+    /// recurses on a Set/Add carrying a Struct; the rulebook's ArmLegality validates compose.type against the leaf's
+    /// legal arms). Without this propagation a nested set could only set a coercible scalar, never a sub-arm. Q3 on a
+    /// malformed spec. <c>internal static</c> is the harness seam (the PR-C guard drives the wire→core mapping directly,
+    /// like the other engine helpers; it touches no instance state).</summary>
+    internal static StructSpec? MapStruct(StructInput s, string where, out string? error)
     {
         error = null;
         if (string.IsNullOrWhiteSpace(s.Type)) { error = $"{where}: compose.type is required (the arm / element type, e.g. 'LeveledItemEntry')."; return null; }
@@ -1161,10 +1168,17 @@ public sealed class LoadOrderService : IDisposable
             foreach (var ns in s.Sets)
             {
                 if (string.IsNullOrWhiteSpace(ns.Path)) { error = $"{where}: each compose.sets[] needs a path."; return null; }
+                StructSpec? nestedSpec = null;
+                if (ns.Compose is not null)
+                {
+                    nestedSpec = MapStruct(ns.Compose, where, out error);
+                    if (error is not null) return null;
+                }
                 sets.Add(new WriteRequest
                 {
                     RecordType = s.Type!, Path = SplitPath(ns.Path),
                     Verb = string.IsNullOrWhiteSpace(ns.Verb) ? "Set" : ns.Verb, Key = ns.Key, Value = ns.Value,
+                    Struct = nestedSpec,
                 });
             }
         }

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -397,4 +397,7 @@ public sealed record NestedSet
 
     [JsonPropertyName("key"), Description("Dict key or list index, if the nested target is a collection.")]
     public string? Key { get; init; }
+
+    [JsonPropertyName("compose"), Description("Build a modeled sub-struct for THIS nested target (recursive): the concrete ARM of a polymorphic sub-field (e.g. a Condition's Data → 'GetActorValueConditionData'), or the element for a struct-element Add nested inside the struct. Omit for a coercible scalar (use value=).")]
+    public StructInput? Compose { get; init; }
 }


### PR DESCRIPTION
## HCBR-2026-06-15-01 / PR-C — nested compose + serialize-boundary null-arm refusal

Third fix-unit of the HCBR-2026-06-15-01 track (after PR-A #62, PR-B #63). Closes item **1.1 (null-arm half)** + the cross-cutting **serialize-NRE**. Both halves are PRFAQ §4-(a) (clean solution, cornerstone untouched). Per the scoping doc `dev/review/HCBR-2026-06-15-01-fix-scoping.md` §PR-C.

### Part A — wire nested compose
The compose grammar's nested sets (`StructInput.Sets[]`) carried no `compose` field, so a `sets[]` entry could set a coercible scalar but **never select a polymorphic sub-arm** (e.g. a Condition's `Data`). `NestedSet` gains an optional `Compose` (`StructInput`); `LoadOrderService.MapStruct` propagates it recursively into `WriteRequest.Struct` — which the core **already** applies (`BuildStruct` recurses on a `Set`/`Add` carrying a `Struct`) and validates (`ArmLegality` against the leaf's legal arms) end-to-end. The break was solely the wire→core mapping. `MapStruct` is now `internal static` (it touches no instance state) so the guard drives the mapping directly.

```
compose:{ type:'ConditionFloat', sets:[ {path:'Data', compose:{type:'GetActorValueConditionData', …}} ] }
```

### Part B — serialize-boundary null-arm refusal
A **composed** record left with a required polymorphic sub-field null (canonical case: a Condition without its `Data` arm) NREs in Mutagen's binary writer with no field name. Pre-flight **can't** reject it: the corpus models **every** polymorphic field as `Nullable=false`, so there is no required/optional signal (such a predicate would over-reject every legitimately-optional null poly field — empirically a bare NPC with `Sound`/`Level` null serializes fine). So the scope's proposed pre-flight predicate was dropped as unsound; instead `WriteEngine.WritePatch` re-stamps that NRE as a loud, **named** `NullArmSerializeException`. The staged write already left the target untouched — this restores a useful message in place of an opaque NRE. **Q3.**

### Review honesty refinement (from a pre-push adversarial review)
The three `WritePatchBuilder` serialize-failure render sites printed only `{type}: {message}`, never `InnerException` — so the named wrapper **hid** the inner NRE, dropping the signal that distinguishes a composed-null-arm from an unrelated engine NRE, and breaking the codebase's own `InnerException`-unwrap idiom. Added `WriteEngine.Describe` (appends the inner type+message when present) and used it at all three serialize catches.

### Verification
- **`nullarm-guard`** (`NullArmGuardProbe`) — 11 checks, **all pass**. Both parts **RED-proven** by sabotage→watch-fail→revert (Part A: drop `MapStruct` propagation → A1/A2/A3/A4/A5 RED; Part B: bypass the `WritePatch` catch → B1/B1b RED; render fix: drop the inner append → B1d RED). False-positive control (B2): optional null poly serializes fine.
- Empirical repro confirmed the bare `NullReferenceException` and the staged-write all-or-nothing (file never on disk) before the fix.
- Full self-contained CI suite (31 guards) green locally; **+1 probe → 35**.
- All write/compose/serialize-path regression guards (`upsert`, `nested-create`, `writelock`, `formid-floor`, `vmad-poly`, `poly-field-descend`, `sameshape-agree`) still pass.

### Files
`+85 / −6` across 6 files + 1 new probe:
- `src/housecarl-mcp/WriteTools.cs` — `NestedSet.Compose`
- `src/housecarl-mcp/LoadOrderService.cs` — `MapStruct` propagation (`internal static`)
- `src/housecarl-core/WriteEngine.cs` — serialize catch + `NullArmSerializeException` + `Describe`
- `src/housecarl-core/WritePatchBuilder.cs` — three serialize render sites use `Describe`
- `src/housecarl-generator/NullArmGuardProbe.cs` (new) + `Program.cs` dispatch + `.github/workflows/ci.yml` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)
