### PR TITLE
conflict-diff: distinguish present-==-winner from absent (HCBR-2026-06-15-01 / PR-G)

### DIFF
--- a/src/housecarl-core/FieldsDiff.cs
+++ b/src/housecarl-core/FieldsDiff.cs
@@ -48,19 +48,12 @@ public static class FieldsDiff
     public sealed record Result(IReadOnlyList<string> Deltas, bool Complete,
         int AgreedCount, IReadOnlyList<string> AgreedSample);
 
-    /// <summary>The read-engine note for a modeled-but-empty optional (absent substruct/optional). Kept in sync
-    /// with <c>ReadEngine.AbsentNote</c> — duplicated (not referenced) to keep core's diff decoupled from the
-    /// read walk's internals; the GuardProbe's real on-disk read proves they still match.</summary>
-    internal const string AbsentNote = "(absent)";
-    /// <summary>The read-engine note for a present-but-null FormLink (FormKey.Null) — distinct from a wholly
-    /// absent field, but for the diff both mean "this contributor carries no value here".</summary>
-    internal const string NullLinkNote = "(null link)";
-
     /// <summary>True when a CleanLines value is a read-engine "no value here" note sentinel — the field is
     /// modeled but the contributor carries nothing (absent optional, or a present-but-null link). Treated as a
-    /// first-class state, never compared as if it were a real token value.</summary>
+    /// first-class state, never compared as if it were a real token value. References the <see cref="ReadEngine"/>
+    /// constants directly (same assembly) — single source of truth, compile-time coupling, no drift.</summary>
     static bool IsAbsentSentinel(string val) =>
-        val == AbsentNote || val == NullLinkNote;
+        val == ReadEngine.AbsentNote || val == ReadEngine.NullLinkNote;
 
     /// <summary>Compare one plugin's deep-read fields against the winner's. Both sides should be read by the
     /// same <see cref="ReadEngine.ReadFields"/> call shape (same paths, same depth) so line sets correspond.</summary>

--- a/src/housecarl-core/FieldsDiff.cs
+++ b/src/housecarl-core/FieldsDiff.cs
@@ -28,15 +28,48 @@ public static class FieldsDiff
 {
     /// <summary>Field-level deltas, preformatted for the conflict-tree render. <see cref="Complete"/> false ⇒
     /// at least one side's read was truncated at the expansion cap, so an empty <see cref="Deltas"/> must NOT
-    /// be rendered as "identical to winner" (Q3 — never claim knowledge the comparison doesn't have).</summary>
-    public sealed record Result(IReadOnlyList<string> Deltas, bool Complete);
+    /// be rendered as "identical to winner" (Q3 — never claim knowledge the comparison doesn't have).
+    ///
+    /// <para><see cref="AgreedCount"/> + <see cref="AgreedSample"/> are the present-==-winner signal (PR-G, item
+    /// 4.3): how many VALUE LEAVES the node carries that exactly equal the winner's — i.e. ITM-restated fields,
+    /// the deltas of which are (by design) OMITTED, so without this count a contributor that restates a field
+    /// identically (an ITM override) was indistinguishable from one that simply doesn't carry it. Counts only
+    /// exact-path value leaves read on BOTH sides (never container summaries, never a side's <c>(absent)</c> /
+    /// <c>(null link)</c> sentinel — an absent field is NOT an agreement). <see cref="AgreedSample"/> is up to a
+    /// few of those paths for the render. Both are 0/empty on a truncated comparison (the agreed set, like the
+    /// one-sided deltas, would be a where-the-cap-fell artifact — Q3).</para>
+    ///
+    /// <para><b>Honest limit (Q3):</b> per-field presence is reliable only for NULLABLE fields, whose absence the
+    /// read engine surfaces as a distinct <c>(absent)</c> / <c>(null link)</c> note. Non-nullable scalars grouped
+    /// in a binary subrecord (Armor <c>DATA</c> → rating/value/weight) read as <c>0</c>/default with no carried
+    /// presence bit, so a leaf that EQUALS the winner is counted as agreement (it IS the same modeled value) but
+    /// the render never claims the contributor "carries" it as a distinct subrecord — there is no bit to prove
+    /// that. The ABSENT render fires only on the explicit sentinels, which only nullable fields produce.</para></summary>
+    public sealed record Result(IReadOnlyList<string> Deltas, bool Complete,
+        int AgreedCount, IReadOnlyList<string> AgreedSample);
+
+    /// <summary>The read-engine note for a modeled-but-empty optional (absent substruct/optional). Kept in sync
+    /// with <c>ReadEngine.AbsentNote</c> — duplicated (not referenced) to keep core's diff decoupled from the
+    /// read walk's internals; the GuardProbe's real on-disk read proves they still match.</summary>
+    internal const string AbsentNote = "(absent)";
+    /// <summary>The read-engine note for a present-but-null FormLink (FormKey.Null) — distinct from a wholly
+    /// absent field, but for the diff both mean "this contributor carries no value here".</summary>
+    internal const string NullLinkNote = "(null link)";
+
+    /// <summary>True when a CleanLines value is a read-engine "no value here" note sentinel — the field is
+    /// modeled but the contributor carries nothing (absent optional, or a present-but-null link). Treated as a
+    /// first-class state, never compared as if it were a real token value.</summary>
+    static bool IsAbsentSentinel(string val) =>
+        val == AbsentNote || val == NullLinkNote;
 
     /// <summary>Compare one plugin's deep-read fields against the winner's. Both sides should be read by the
     /// same <see cref="ReadEngine.ReadFields"/> call shape (same paths, same depth) so line sets correspond.</summary>
     public static Result Compare(RecordFields theirs, RecordFields winner)
     {
-        var (tLines, tComplete) = CleanLines(theirs);
-        var (wLines, wComplete) = CleanLines(winner);
+        var tValueLeaves = new HashSet<string>(StringComparer.Ordinal);
+        var wValueLeaves = new HashSet<string>(StringComparer.Ordinal);
+        var (tLines, tComplete) = CleanLines(theirs, tValueLeaves);
+        var (wLines, wComplete) = CleanLines(winner, wValueLeaves);
         bool complete = tComplete && wComplete;
 
         // Numeric-bracket roots seen on EITHER side (the union, so a 0-item-vs-N-item list is still compared
@@ -71,12 +104,43 @@ public static class FieldsDiff
         // though element comparison is suppressed (PR #28 review #2, non-blocking note).
         var tScalar = ExactPathLines(tLines, listRoots, includeListRootSummaries: !complete);
         var wScalar = ExactPathLines(wLines, listRoots, includeListRootSummaries: !complete);
+        int agreedCount = 0;
+        var agreedSample = new List<string>();
         foreach (var (path, val) in tScalar)
         {
             if (wScalar.TryGetValue(path, out var wv))
             {
-                if (!string.Equals(NormalizeForCompare(val), NormalizeForCompare(wv), StringComparison.Ordinal))
+                bool tAbsent = IsAbsentSentinel(val), wAbsent = IsAbsentSentinel(wv);
+                if (tAbsent && wAbsent)
+                {
+                    // Both carry nothing here (a nullable field neither side sets) — same state, no delta and
+                    // not an agreement (there is no value to agree ON).
+                }
+                else if (tAbsent)
+                {
+                    // FIRST-CLASS absent state (item 4.3): the contributor doesn't carry this field but the
+                    // winner does. Rendered as ABSENT, not as a "=(absent)" phantom value delta. Only nullable
+                    // fields reach here — the read engine emits the sentinel only for them.
+                    deltas.Add($"{path}: ABSENT here (winner has {wv})");
+                }
+                else if (wAbsent)
+                {
+                    // The contributor carries a value the WINNER doesn't — the field is absent on the winner.
+                    deltas.Add($"{path}={val} (winner has {path} ABSENT)");
+                }
+                else if (!string.Equals(NormalizeForCompare(val), NormalizeForCompare(wv), StringComparison.Ordinal))
+                {
                     deltas.Add($"{path}={val} (winner {wv})");
+                }
+                else if (tValueLeaves.Contains(path) && wValueLeaves.Contains(path))
+                {
+                    // present-==-winner: a VALUE leaf the contributor restates identically (an ITM override).
+                    // Counted (not a delta) so the render can distinguish an ITM-restating override from a
+                    // fields-narrow one. Container summary lines ("[3 item(s)]") that happen to match are NOT
+                    // value leaves and so never inflate this count.
+                    agreedCount++;
+                    if (agreedSample.Count < AgreedSampleCap) agreedSample.Add(path);
+                }
             }
             // One-sided presence is only a delta when BOTH sides were fully read: on a truncated side a
             // missing line is an artifact of WHERE its cap fell, not of content — reporting it would
@@ -102,8 +166,15 @@ public static class FieldsDiff
             }
         }
 
-        return new Result(deltas, complete);
+        // On a truncated comparison the agreed set, like the one-sided deltas, would be a where-the-cap-fell
+        // artifact — suppress it (Q3): a partial read must not claim "N fields match the winner".
+        if (!complete) { agreedCount = 0; agreedSample.Clear(); }
+        return new Result(deltas, complete, agreedCount, agreedSample);
     }
+
+    /// <summary>How many agreed-field paths to keep for the render — a small sample, not the full set (a deep
+    /// ITM override agrees on dozens of leaves; the count carries the weight, the sample is illustrative).</summary>
+    const int AgreedSampleCap = 3;
 
     /// <summary>The root's own container-summary line ("[Type: N item(s)/pair(s)]"), or null when the read
     /// never emitted one (a fields=-bracketed read names element paths directly, skipping the root).</summary>
@@ -115,14 +186,18 @@ public static class FieldsDiff
     }
 
     /// <summary>The read's lines minus the expansion-cap sentinel; each value is the round-trippable token or,
-    /// for a non-leaf/absent line, its note. Complete=false iff the sentinel was present.</summary>
-    static (List<(string path, string val)> lines, bool complete) CleanLines(RecordFields rf)
+    /// for a non-leaf/absent line, its note. <paramref name="valueLeaves"/> collects the paths that carry a real
+    /// VALUE (<c>HasValue</c>) — the only lines an agreement count may consider, so a container summary line
+    /// ("[3 item(s)]") or an absent/null-link note is never miscounted as a present field. Complete=false iff the
+    /// expansion-cap sentinel was present.</summary>
+    static (List<(string path, string val)> lines, bool complete) CleanLines(RecordFields rf, HashSet<string> valueLeaves)
     {
         var lines = new List<(string, string)>(rf.Fields.Count);
         bool complete = true;
         foreach (var f in rf.Fields)
         {
             if (f.Path == "…") { complete = false; continue; }         // ReadEngine's expansion-cap sentinel (Q3)
+            if (f.HasValue) valueLeaves.Add(f.Path);
             lines.Add((f.Path, f.HasValue ? f.Token ?? "" : f.Note ?? ""));
         }
         return (lines, complete);

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -60,6 +60,12 @@ public static class ReadEngine
     /// surface.</summary>
     internal const string AbsentNote = "(absent)";
 
+    /// <summary>A present-but-null FormLink (FormKey.Null) — modeled, but carrying no target. Not a
+    /// round-trippable token (the write surface sets links to a real FormKey, never "Null"), so surfaced as
+    /// a note. Distinct from <see cref="AbsentNote"/> (a wholly absent optional); the conflict diff treats
+    /// both as "no value here" (see <c>FieldsDiff.IsAbsentSentinel</c>).</summary>
+    internal const string NullLinkNote = "(null link)";
+
     // ======================================================================
     //  `read` MODE — resolve a record in one plugin and emit its fields.
     //    dotnet run --project src/housecarl-generator read \
@@ -446,7 +452,7 @@ public static class ReadEngine
         // link (FormKey.Null) is NOT a round-trippable token (the write surface sets links to a real
         // FormKey, never "Null"), so surface it as no-value — consistent with what Coerce accepts.
         if (val is IFormLinkGetter fl)
-            return fl.FormKey.IsNull ? LeafRead.None("(null link)") : LeafRead.Value(fl.FormKey.ToString());
+            return fl.FormKey.IsNull ? LeafRead.None(NullLinkNote) : LeafRead.Value(fl.FormKey.ToString());
         // value types (inverse of TryValueType)
         if (TryEmitValueType(val, out var vt)) return LeafRead.Value(vt);
 

--- a/src/housecarl-generator/ConflictDiffProbe.cs
+++ b/src/housecarl-generator/ConflictDiffProbe.cs
@@ -25,7 +25,9 @@ namespace HousecarlGenerator;
 ///   I. a NULLABLE FORMLINK the contributor doesn't carry but the winner does → a FIRST-CLASS "ABSENT here"
 ///      state, not the pre-fix phantom "=(absent) (winner …)" value delta (RED before the fix);
 ///   J. the contributor RESTATES a field == winner (an ITM override) → no delta, but a positive AgreedCount
-///      makes it distinguishable from a contributor that simply doesn't carry the field (RED before the fix).
+///      makes it distinguishable from a contributor that simply doesn't carry the field (RED before the fix);
+///   K. the SYMMETRIC absent case — the contributor carries the link, the WINNER cleared it → the distinct
+///      "<path>=<val> (winner has <path> ABSENT)" render (review finding #3).
 ///
 /// Run: <c>dotnet run --project src/housecarl-generator conflict-diff-guard</c>
 /// </summary>
@@ -70,6 +72,8 @@ public static class ConflictDiffProbe
         // (SharedCrimeFactionList deliberately LEFT NULL on the master)
         var fJ = master.Factions.AddNew(); fJ.EditorID = "hcDiffITM";        // arm J: contributor restates the field == winner (an ITM override)
         fJ.SharedCrimeFactionList.SetTo(fl.FormKey);
+        var fK = master.Factions.AddNew(); fK.EditorID = "hcDiffWinnerCleared"; // arm K: contributor CARRIES the link, the winner CLEARS it (symmetric absent)
+        fK.SharedCrimeFactionList.SetTo(fl.FormKey);
         master.BeginWrite.ToPath(masterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
 
         // ---- OVERRIDE (the winner): the four subjects re-shaped per arm. ----
@@ -88,6 +92,8 @@ public static class ConflictDiffProbe
         oI.SharedCrimeFactionList.SetTo(fl.FormKey);                          // winner CARRIES the link the contributor (master) left null
         var oJ = (IFaction)WriteEngine.GenericGetOrAddAsOverride(over, fJ);
         oJ.SharedCrimeFactionList.SetTo(fl.FormKey);                          // winner == contributor (ITM restate)
+        var oK = (IFaction)WriteEngine.GenericGetOrAddAsOverride(over, fK);
+        oK.SharedCrimeFactionList.SetToNull();                                // winner CLEARS the link the contributor carries (symmetric absent)
         over.BeginWrite.ToPath(overPath).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
 
         Console.WriteLine($"-- synthesized {masterName} < {overName} (winner); subject factions, one comparison arm each --");
@@ -143,6 +149,26 @@ public static class ConflictDiffProbe
               dJ.Complete && dJ.Deltas.Count == 0);
         Check("J: the ITM override is detectable — AgreedCount > arm-I (it restates the formlink arm I omits)",
               dJ.AgreedCount > dI.AgreedCount && dJ.AgreedSample.Count > 0);
+
+        // (Review finding #1's node-neutral render WORDING — IdenticalWholeRecord/IdenticalAcrossFields in
+        // ReadTools — is human-reviewed, not pinned here: a cross-assembly call into the mcp render helper
+        // could not be compiled in this worktree (a build-server metadata-cache pathology, see the PR summary),
+        // and the reviewer explicitly authorised skipping the render-string pin when it needs an awkward
+        // harness. The data-layer signal the wording rests on — AgreedCount distinguishing an ITM restate from
+        // a no-op — IS pinned by arm J above.)
+
+        // ---- K (review finding #3): the SYMMETRIC absent branch — the contributor CARRIES the link, the WINNER
+        //      cleared it. Distinct render string "<path>=<val> (winner has <path> ABSENT)", previously
+        //      unexercised. The winner's null formlink reads through the "(absent)" sentinel. ----
+        var dK = DiffOf(svc, fK.FormKey);
+        Check("K: a field the winner CLEARED renders as the contributor's value + 'winner has … ABSENT'",
+              dK.Complete
+              && dK.Deltas.Any(d => d.StartsWith("SharedCrimeFactionList=", StringComparison.Ordinal)
+                                 && d.Contains("(winner has SharedCrimeFactionList ABSENT)", StringComparison.Ordinal)
+                                 && d.Contains(fl.FormKey.ToString(), StringComparison.Ordinal)));
+        Check("K: the cleared-on-winner field is NOT rendered as a phantom value delta",
+              !dK.Deltas.Any(d => d.Contains("(winner (absent))", StringComparison.Ordinal)
+                               || d.Contains("(winner (null link))", StringComparison.Ordinal)));
 
         // ---- E: truncation honesty (in-memory; the expansion cap fires well below 900 relations). ----
         var big = new SkyrimMod(new ModKey("hcDiffBig", ModType.Plugin), SkyrimRelease.SkyrimSE);

--- a/src/housecarl-generator/ConflictDiffProbe.cs
+++ b/src/housecarl-generator/ConflictDiffProbe.cs
@@ -21,6 +21,12 @@ namespace HousecarlGenerator;
 ///   D. a scalar field delta → still reported (the old behavior, preserved at depth);
 ///   E. a read that hits the expansion cap → Complete=false (the render must NOT claim "identical"; Q3).
 ///
+/// Extended for PR-G (HCBR-2026-06-15-01 item 4.3) — distinguish present-==-winner from absent:
+///   I. a NULLABLE FORMLINK the contributor doesn't carry but the winner does → a FIRST-CLASS "ABSENT here"
+///      state, not the pre-fix phantom "=(absent) (winner …)" value delta (RED before the fix);
+///   J. the contributor RESTATES a field == winner (an ITM override) → no delta, but a positive AgreedCount
+///      makes it distinguishable from a contributor that simply doesn't carry the field (RED before the fix).
+///
 /// Run: <c>dotnet run --project src/housecarl-generator conflict-diff-guard</c>
 /// </summary>
 public static class ConflictDiffProbe
@@ -41,7 +47,8 @@ public static class ConflictDiffProbe
         var masterPath = Path.Combine(dir, masterName);
         var overPath = Path.Combine(dir, overName);
 
-        // ---- MASTER: four target factions (relation targets) + four subject factions, one per arm. ----
+        // ---- MASTER: four target factions (relation targets) + the subject factions, one per arm (A–D the
+        //      list/scalar arms; I/J the nullable-formlink absent / ITM-restate arms added for PR-G). ----
         var master = new SkyrimMod(ModKey.FromNameAndExtension(masterName), SkyrimRelease.SkyrimSE);
         var t = new FormKey[4];
         for (int i = 0; i < 4; i++) { var tf = master.Factions.AddNew(); tf.EditorID = $"hcDiffTarget{i + 1}"; t[i] = tf.FormKey; }
@@ -54,6 +61,15 @@ public static class ConflictDiffProbe
         fC.Relations.AddRange(new[] { Rel(t[0]), Rel(t[1]) });
         var fD = master.Factions.AddNew(); fD.EditorID = "hcDiffScalar";     // arm D: scalar delta
         fD.Flags = Faction.FactionFlag.HiddenFromPC;
+
+        // A FormList for the nullable-formlink arms (I/J) to point at — a real link target so the
+        // present-side renders a round-trippable FormKey, the absent-side a note sentinel.
+        var fl = master.FormLists.AddNew(); fl.EditorID = "hcDiffCrimeList";
+
+        var fI = master.Factions.AddNew(); fI.EditorID = "hcDiffAbsent";     // arm I: nullable formlink absent on the contributor, set on the winner
+        // (SharedCrimeFactionList deliberately LEFT NULL on the master)
+        var fJ = master.Factions.AddNew(); fJ.EditorID = "hcDiffITM";        // arm J: contributor restates the field == winner (an ITM override)
+        fJ.SharedCrimeFactionList.SetTo(fl.FormKey);
         master.BeginWrite.ToPath(masterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
 
         // ---- OVERRIDE (the winner): the four subjects re-shaped per arm. ----
@@ -68,9 +84,13 @@ public static class ConflictDiffProbe
         oC.Relations.Add(Rel(t[2]));                                          // 2 -> 3 items
         var oD = (IFaction)WriteEngine.GenericGetOrAddAsOverride(over, fD);
         oD.Flags = Faction.FactionFlag.SpecialCombat;                         // scalar enum delta
+        var oI = (IFaction)WriteEngine.GenericGetOrAddAsOverride(over, fI);
+        oI.SharedCrimeFactionList.SetTo(fl.FormKey);                          // winner CARRIES the link the contributor (master) left null
+        var oJ = (IFaction)WriteEngine.GenericGetOrAddAsOverride(over, fJ);
+        oJ.SharedCrimeFactionList.SetTo(fl.FormKey);                          // winner == contributor (ITM restate)
         over.BeginWrite.ToPath(overPath).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
 
-        Console.WriteLine($"-- synthesized {masterName} < {overName} (winner); four factions, one comparison arm each --");
+        Console.WriteLine($"-- synthesized {masterName} < {overName} (winner); subject factions, one comparison arm each --");
         Console.WriteLine();
 
         // ---- Drive the PRODUCT path: service ResolveTree (deep) + FieldsDiff per node-vs-winner. ----
@@ -96,6 +116,33 @@ public static class ConflictDiffProbe
         var dD = DiffOf(svc, fD.FormKey);
         Check("D: scalar delta still reported",
               dD.Deltas.Any(d => d.StartsWith("Flags=", StringComparison.Ordinal) && d.Contains("winner")));
+
+        // ---- I (PR-G, item 4.3): a NULLABLE FORMLINK the contributor (master) doesn't carry but the winner
+        //      does. The empirically-confirmed render is "SharedCrimeFactionList: ABSENT here (winner has …)" —
+        //      a FIRST-CLASS absent state, NOT the pre-fix phantom "=(absent) (winner …)" value delta. The null
+        //      formlink reads through the read engine's "(absent)" sentinel; the symmetric "(null link)"
+        //      sentinel (a present-but-FormKey.Null link) is handled identically by construction
+        //      (IsAbsentSentinel covers both). ----
+        var dI = DiffOf(svc, fI.FormKey);
+        Check("I: an absent nullable formlink renders as a FIRST-CLASS ABSENT state, not a phantom value delta",
+              dI.Complete
+              && dI.Deltas.Any(d => d.StartsWith("SharedCrimeFactionList: ABSENT here (winner has ", StringComparison.Ordinal))
+              && !dI.Deltas.Any(d => d.Contains("=(absent)", StringComparison.Ordinal)));
+        Check("I: the ABSENT delta names the value the winner carries",
+              dI.Deltas.Any(d => d.Contains(fl.FormKey.ToString(), StringComparison.Ordinal)));
+        // The agreement signal is alive even alongside a delta: the shared scalar leaves (EditorID/Flags/…)
+        // are restated identical, and the absent formlink is NOT miscounted as an agreement.
+        Check("I: AgreedCount counts the restated VALUE leaves but NOT the absent field",
+              dI.AgreedCount > 0 && !dI.AgreedSample.Contains("SharedCrimeFactionList"));
+
+        // ---- J (PR-G, item 4.3): the contributor RESTATES the formlink == winner (an ITM override). No delta,
+        //      but AgreedCount must be STRICTLY HIGHER than arm I's (it agrees on the formlink that arm I left
+        //      absent) — the signal that distinguishes a deliberate same-as-winner override from a no-op. ----
+        var dJ = DiffOf(svc, fJ.FormKey);
+        Check("J: a present-==-winner (ITM) override carries NO delta",
+              dJ.Complete && dJ.Deltas.Count == 0);
+        Check("J: the ITM override is detectable — AgreedCount > arm-I (it restates the formlink arm I omits)",
+              dJ.AgreedCount > dI.AgreedCount && dJ.AgreedSample.Count > 0);
 
         // ---- E: truncation honesty (in-memory; the expansion cap fires well below 900 relations). ----
         var big = new SkyrimMod(new ModKey("hcDiffBig", ModType.Plugin), SkyrimRelease.SkyrimSE);

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -284,11 +284,12 @@ static class Wire
                 ? string.Join("; ", diff.Deltas)
                   + (diff.Complete ? "" : " [comparison TRUNCATED at the expansion cap — only value mismatches observed on both sides are shown; list contents and one-sided fields were NOT compared; narrow with fields= to fully compare]")
                 : diff.Complete
-                    // The identity claim must not outrun the comparison's scope: a fields=-narrowed diff
-                    // compared ONLY those paths, never the whole record (PR #28 review #2).
+                    // No deltas. Distinguish an ITM-RESTATING override (carries fields set EQUAL to the winner —
+                    // a real, deliberate identical override) from one that simply doesn't carry the differing
+                    // fields. AgreedCount counts only value leaves read identical on both sides (item 4.3).
                     ? (fields is { Count: > 0 }
-                        ? "(identical to winner across the requested fields, list order ignored — other fields NOT compared)"
-                        : "(identical to winner — full modeled content compared, list order ignored)")
+                        ? IdenticalAcrossFields(diff)
+                        : IdenticalWholeRecord(diff))
                     : "(no differences found, but the comparison was TRUNCATED at the expansion cap — NOT a verified ITM; narrow with fields= to fully compare)";
             // One node's joined deltas are unbounded (two divergent deep reads can carry thousands); slice
             // against the remaining char budget with the same explicit notice the other cuts use (Q3).
@@ -298,5 +299,28 @@ static class Wire
                     " ... [delta line truncated at max_chars; narrow with fields= or raise max_chars]");
             sb.Append("  ").Append(node.Plugin).Append(": ").Append(line).Append('\n');
         }
+    }
+
+    /// <summary>No-delta render for a WHOLE-record compare. AgreedCount>0 ⇒ the contributor RESTATES fields
+    /// identically to the winner (an ITM override — it deliberately carries those values), distinct from
+    /// carrying nothing that differs. The sample names a few agreed paths; presence is claimed only for the
+    /// nullable/value leaves the read engine actually surfaced (Q3 — never claim a non-nullable subrecord bit
+    /// the read can't prove).</summary>
+    static string IdenticalWholeRecord(FieldsDiff.Result diff) =>
+        diff.AgreedCount > 0
+            ? $"(no differences — but RESTATES {diff.AgreedCount} field(s) set identical to the winner ({SampleOf(diff)}): a same-as-winner (ITM) override, not merely a no-op. Full modeled content compared, list order ignored)"
+            : "(identical to winner — full modeled content compared, list order ignored)";
+
+    /// <summary>No-delta render for a fields=-narrowed compare — the identity claim must not outrun the
+    /// compared paths (PR #28 review #2).</summary>
+    static string IdenticalAcrossFields(FieldsDiff.Result diff) =>
+        diff.AgreedCount > 0
+            ? $"(no differences across the requested fields — RESTATES {diff.AgreedCount} of them identical to the winner ({SampleOf(diff)}): an ITM override across those fields; other fields NOT compared, list order ignored)"
+            : "(identical to winner across the requested fields, list order ignored — other fields NOT compared)";
+
+    static string SampleOf(FieldsDiff.Result diff)
+    {
+        var s = string.Join(", ", diff.AgreedSample);
+        return diff.AgreedCount > diff.AgreedSample.Count ? $"e.g. {s}, …" : s;
     }
 }

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -284,9 +284,11 @@ static class Wire
                 ? string.Join("; ", diff.Deltas)
                   + (diff.Complete ? "" : " [comparison TRUNCATED at the expansion cap — only value mismatches observed on both sides are shown; list contents and one-sided fields were NOT compared; narrow with fields= to fully compare]")
                 : diff.Complete
-                    // No deltas. Distinguish an ITM-RESTATING override (carries fields set EQUAL to the winner —
-                    // a real, deliberate identical override) from one that simply doesn't carry the differing
-                    // fields. AgreedCount counts only value leaves read identical on both sides (item 4.3).
+                    // No deltas. Surface HOW MANY modeled fields read identical to the winner (item 4.3) — node-
+                    // neutral, because this renders for every touching plugin including the master (Nodes[0]),
+                    // which is not an "override". AgreedCount counts only value leaves read identical on both
+                    // sides; it distinguishes an ITM-restate (high N) from a fields-narrow compare, without
+                    // asserting intent the diff can't know.
                     ? (fields is { Count: > 0 }
                         ? IdenticalAcrossFields(diff)
                         : IdenticalWholeRecord(diff))
@@ -301,21 +303,23 @@ static class Wire
         }
     }
 
-    /// <summary>No-delta render for a WHOLE-record compare. AgreedCount>0 ⇒ the contributor RESTATES fields
-    /// identically to the winner (an ITM override — it deliberately carries those values), distinct from
-    /// carrying nothing that differs. The sample names a few agreed paths; presence is claimed only for the
-    /// nullable/value leaves the read engine actually surfaced (Q3 — never claim a non-nullable subrecord bit
-    /// the read can't prove).</summary>
+    /// <summary>No-delta render for a WHOLE-record compare. Node-NEUTRAL: this renders for every touching plugin,
+    /// including the master node (Nodes[0]), which is not an override — so it reports the COUNT of fields read
+    /// identical to the winner (the ITM-restate-vs-no-op signal lives in N) without asserting an "override" or a
+    /// "not a no-op" intent the diff can't know. A whole-record compare always agrees on housekeeping/identity
+    /// leaves, so N is typically >0; that's stated as a plain fact, not a verdict. The sample names a few agreed
+    /// paths; presence is claimed only for the value leaves the read engine actually surfaced (Q3 — never claim a
+    /// non-nullable subrecord bit the read can't prove).</summary>
     static string IdenticalWholeRecord(FieldsDiff.Result diff) =>
         diff.AgreedCount > 0
-            ? $"(no differences — but RESTATES {diff.AgreedCount} field(s) set identical to the winner ({SampleOf(diff)}): a same-as-winner (ITM) override, not merely a no-op. Full modeled content compared, list order ignored)"
+            ? $"(no field deltas; {diff.AgreedCount} modeled field(s) read identical to the winner ({SampleOf(diff)}) — list order ignored)"
             : "(identical to winner — full modeled content compared, list order ignored)";
 
-    /// <summary>No-delta render for a fields=-narrowed compare — the identity claim must not outrun the
-    /// compared paths (PR #28 review #2).</summary>
+    /// <summary>No-delta render for a fields=-narrowed compare — node-neutral, and the identity claim must not
+    /// outrun the compared paths (PR #28 review #2).</summary>
     static string IdenticalAcrossFields(FieldsDiff.Result diff) =>
         diff.AgreedCount > 0
-            ? $"(no differences across the requested fields — RESTATES {diff.AgreedCount} of them identical to the winner ({SampleOf(diff)}): an ITM override across those fields; other fields NOT compared, list order ignored)"
+            ? $"(no deltas across the requested fields; {diff.AgreedCount} of them read identical to the winner ({SampleOf(diff)}) — other fields NOT compared, list order ignored)"
             : "(identical to winner across the requested fields, list order ignored — other fields NOT compared)";
 
     static string SampleOf(FieldsDiff.Result diff)


### PR DESCRIPTION
**HCBR-2026-06-15-01 fix unit PR-G** (item 4.3): the winner-relative conflict diff emitted only deltas, so an ITM override (sets a field == winner) was indistinguishable from a contributor that doesn't carry it — and a not-carried nullable field rendered as a confusing phantom `Field=(absent)` value delta.

## What
- `FieldsDiff.Result` gains `AgreedCount` + a small `AgreedSample` — value leaves read identical on both sides (the present-==-winner / ITM signal). Counts **only** real value leaves (`HasValue`), never container summaries, never a side's `(absent)`/`(null link)` sentinel.
- The exact-path loop treats the read-engine sentinels as a **first-class state**: a not-carried nullable field whose winner has a value renders `Field: ABSENT here (winner has X)`, not a phantom value delta.
- `ReadTools` rewords the no-delta header so an ITM-restating override reads differently from a fields-narrow one.
- Keyed off the note sentinels + exact-path tokens — covers every record type, no per-type switch. Truncation suppression preserved (a `Complete=false` read zeroes the agreed set too).

## Honest limit (Q3)
Per-field presence is reliable only for **nullable** fields (the read engine emits their absence as a distinct sentinel). A non-nullable scalar in a binary subrecord reads as `0`/default with no carried presence bit, so a matching leaf is counted as agreement but the render never claims a distinct-subrecord presence bit it can't prove.

## Validation
`conflict-diff-guard` extended (13 → 18 internal checks): arm I (absent nullable FormLink renders ABSENT, not a phantom delta; absent field not miscounted) + arm J (ITM restate carries no delta but `AgreedCount` makes it detectable). **Absent render confirmed empirically on a real on-disk read** (`Faction.SharedCrimeFactionList`). Sabotage-RED-proven: reverting the absent/agreement handling reds 3 of the 5 new checks. (CI runs the full suite on this PR.)

## Reviewer focus
1. **Render strings not unit-tested** — the probe asserts at the `FieldsDiff.Result` data layer (where discrimination lives); `IdenticalWholeRecord`/`IdenticalAcrossFields` are pure formatting over `Result`. Pinning the exact MCP strings would need an `AppendConflictTree` harness. Low risk; flag if you want them pinned.
2. **`AgreedCount` includes housekeeping leaves** (`FormKey`/`EditorID`/`FormVersion`) → count is inflated on a true ITM. Cosmetic only — the ITM verdict branch fires only on zero deltas, so a real edit is never mislabeled.
3. **Sentinel constants duplicated** in `FieldsDiff` vs `ReadEngine`. `ReadEngine.AbsentNote` is already an `internal const`; `(null link)` is a bare literal (`ReadEngine.cs:449`). Cleaner alternative: promote the null-link literal to a named const and reference both directly (single source of truth, no drift). Agent chose duplicate-and-guard (arm I reds on drift) to avoid touching `ReadEngine`. Reviewer's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)