### PR TITLE
create-abstract-group: create a concrete arm of an abstract record group (HCBR 2.2 / PR-D)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,16 @@ jobs:
       - name: Probe — create-tool wire create_record parent + bulk_create (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- bulk-create-guard
 
+      # Self-contained (synthesizes a master + corpus — no external files), drives the REAL CreateRecords: locks in
+      # creating a CONCRETE SUBTYPE of an ABSTRACT record group (HCBR-2026-06-15-01 item 2.2 / PR-D). The two abstract
+      # groups are SkyrimGroup<Global> / SkyrimGroup<GameSetting>; a Global is stored as a GlobalFloat/Int/Short, never
+      # a bare Global. The fix is keyed off the runtime hierarchy (abstract group -> its concrete arms, discovered not
+      # hand-listed), so 'GlobalFloat' AND 'GameSettingFloat' create off the SAME branch (the by-construction generality
+      # proof — never a GLOB special-case), Data round-trips, re-runs upsert-replace in place, and the bare base
+      # ('Global') refuses loud naming the arms. RED before the fix (CanCreateType refused the concrete arm).
+      - name: Probe — create concrete subtype of an abstract record group (self-contained regression guard)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- create-abstract-group-guard
+
       # Drives the REAL housecarl-mcp.exe over stdio — the exact wire path of the live failure; needs no game data
       # (argument binding resolves before configuration is consulted): a regression guard locking in the tool-argument
       # binding shim — string-for-array coerces, missing-required refuses by name, an uncoercible shape fails NAMED

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,9 @@ jobs:
       # a bare Global. The fix is keyed off the runtime hierarchy (abstract group -> its concrete arms, discovered not
       # hand-listed), so 'GlobalFloat' AND 'GameSettingFloat' create off the SAME branch (the by-construction generality
       # proof — never a GLOB special-case), Data round-trips, re-runs upsert-replace in place, and the bare base
-      # ('Global') refuses loud naming the arms. RED before the fix (CanCreateType refused the concrete arm).
+      # ('Global') refuses loud naming the arms. Also pins the READ-SIDE base->arm mapping (BuildTypeLookup, driven via a
+      # real cross_plugin_query): type='Global' unions its concrete arms (GlobalFloat+GlobalInt). RED before the fix
+      # (CanCreateType refused the concrete arm; BuildTypeLookup returned "unknown record type" for the base name).
       - name: Probe — create concrete subtype of an abstract record group (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- create-abstract-group-guard
 

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -787,27 +787,89 @@ public static class WriteEngine
     //  the SAME EnumerateFlatGroups enumeration, so the create surface IS the
     //  flat-group surface BY CONSTRUCTION — every concrete flat record type is
     //  createable, nothing else is silently treated as covered (CLAUDE.md §3).
+    //
+    //  A small minority of flat groups are typed by an ABSTRACT base — exactly two
+    //  by construction (SkyrimGroup<Global>, SkyrimGroup<GameSetting>); a Global is
+    //  stored as a GlobalFloat / GlobalInt / GlobalShort, never a bare Global. The
+    //  generic AddNew path can't close Mutagen's AddNew<T> with an abstract T (it
+    //  throws), so abstract-group create takes a distinct branch keyed off the
+    //  runtime hierarchy (T.IsAssignableFrom(concrete) && !concrete.IsAbstract):
+    //  the caller names the CONCRETE arm ('GlobalFloat'), which is constructed via
+    //  the same ConstructRecord/AllocateNextFormKey helpers the nested create uses
+    //  and Add()-ed to the group's own instance Add(T) (a SkyrimGroup<T> is NOT an
+    //  IList). Naming the bare abstract base ('Global') stays a loud refusal that
+    //  lists the arms (Q3 — never a guessed default). The arm set is discovered, not
+    //  hand-listed, so the branch serves GMST and any future abstract group equally.
     // ======================================================================
 
+    /// <summary>Every flat group whose T is ABSTRACT, paired with its concrete-arm record Types — discovered by walking
+    /// the SAME <see cref="EnumerateFlatGroups"/> enumeration that defines the create surface, testing <c>T.IsAbstract</c>,
+    /// then collecting every non-abstract record class the base is assignable from (the runtime hierarchy, exactly as
+    /// <see cref="GenericAddNew"/> keys off it). By construction: the abstract-group set IS Mutagen's (two today —
+    /// Global, GameSetting), and each base's arm set IS its concrete subtype set — neither is hand-listed. Mod-instance-
+    /// free (walks <c>typeof(SkyrimMod)</c>), so it serves the pre-flight before any patch exists.</summary>
+    internal static IEnumerable<(PropertyInfo prop, Type baseType, IReadOnlyList<Type> arms)> EnumerateAbstractGroups()
+    {
+        var skyrimAsm = typeof(IArmorGetter).Assembly;
+        foreach (var (prop, tMajor, _) in EnumerateFlatGroups(typeof(SkyrimMod)))
+        {
+            if (!tMajor.IsAbstract) continue;
+            var arms = skyrimAsm.GetTypes()
+                .Where(t => t.IsClass && !t.IsAbstract && tMajor.IsAssignableFrom(t) && typeof(IMajorRecord).IsAssignableFrom(t))
+                .OrderBy(t => t.Name, StringComparer.Ordinal)
+                .ToList();
+            yield return (prop, tMajor, arms);
+        }
+    }
+
+    /// <summary>If <paramref name="typeName"/> is the CONCRETE arm of an abstract record group (e.g. "GlobalFloat" under
+    /// SkyrimGroup&lt;Global&gt;), resolve the live group + the arm's Type; else false. The single point both the
+    /// pre-flight (<see cref="CanCreateType"/>) and the allocation (<see cref="GenericAddNew"/> / <see cref="GenericUpsertNew"/>)
+    /// key off, so they can't drift. <paramref name="patchMod"/> null ⇒ the group instance isn't resolved (pre-flight,
+    /// no patch yet) — only the arm Type is returned.</summary>
+    static bool TryResolveAbstractGroupArm(SkyrimMod? patchMod, string typeName, out object? group, out Type? arm)
+    {
+        group = null; arm = null;
+        foreach (var (prop, _, arms) in EnumerateAbstractGroups())
+        {
+            var hit = arms.FirstOrDefault(a => string.Equals(a.Name, typeName, StringComparison.OrdinalIgnoreCase));
+            if (hit is null) continue;
+            arm = hit;
+            group = patchMod is null ? null : prop.GetValue(patchMod);
+            return true;
+        }
+        return false;
+    }
+
     /// <summary>Can a brand-new record of <paramref name="typeName"/> (a catalog name, e.g. "Keyword") be created by the
-    /// generic flat-group dispatch? True iff a flat <c>SkyrimGroup&lt;T&gt;</c> models it AND its T is concrete. The two
-    /// false cases are the named loud-fail boundaries (Q3 — surfaced, never a silent wrong create): NO flat group ⇒ a
-    /// nested/placed record (Cell/Placed*/INFO/Navmesh/Landscape) that needs parent context, OR an abstract-group subtype;
-    /// an ABSTRACT T (Global) ⇒ needs a concrete subtype. <paramref name="reason"/> carries the user-facing explanation
-    /// when false. Mod-instance-free (walks <c>typeof(SkyrimMod)</c>), so it serves the pre-flight before any patch exists.</summary>
+    /// generic create dispatch? True iff a flat <c>SkyrimGroup&lt;T&gt;</c> models it with a CONCRETE T, OR
+    /// <paramref name="typeName"/> is a concrete ARM of an abstract group (e.g. "GlobalFloat" under SkyrimGroup&lt;Global&gt;).
+    /// The two false cases are the named loud-fail boundaries (Q3 — surfaced, never a silent wrong create): NO flat group ⇒ a
+    /// nested/placed record (Cell/Placed*/INFO/Navmesh/Landscape) that needs parent context; the bare ABSTRACT base
+    /// ('Global'/'GameSetting') ⇒ name a concrete arm (the message lists the DISCOVERED arms — never a guessed default).
+    /// <paramref name="reason"/> carries the user-facing explanation when false. Mod-instance-free (walks
+    /// <c>typeof(SkyrimMod)</c>), so it serves the pre-flight before any patch exists.</summary>
     public static bool CanCreateType(string typeName, out string? reason)
     {
+        // A concrete arm of an abstract group ('GlobalFloat', 'GameSettingFloat', …) — createable via the abstract-group
+        // branch in GenericAddNew. Checked FIRST so a concrete arm always wins over the abstract-base refusal below.
+        if (TryResolveAbstractGroupArm(null, typeName, out _, out _)) { reason = null; return true; }
+
+        foreach (var (_, tm, _) in EnumerateAbstractGroups())
+            if (string.Equals(tm.Name, typeName, StringComparison.OrdinalIgnoreCase))
+            {
+                // The bare abstract base ('Global'/'GameSetting'). The record is always stored as one of its concrete
+                // arms — name which (Q3, no guessed default). Arms are DISCOVERED, not hand-listed (cornerstone §3).
+                var arms = EnumerateAbstractGroups().First(g => g.baseType == tm).arms.Select(a => a.Name);
+                reason = $"'{typeName}' is an abstract record group — a {typeName} is always stored as one of its concrete " +
+                         $"subtypes ({string.Join(" / ", arms)}). Name the concrete subtype to create (e.g. {tm.Name}Float).";
+                return false;
+            }
+
         foreach (var (_, tm, _) in EnumerateFlatGroups(typeof(SkyrimMod)))
             if (string.Equals(tm.Name, typeName, StringComparison.OrdinalIgnoreCase))
             {
-                if (tm.IsAbstract)
-                {
-                    reason = $"'{typeName}' is an abstract record type (e.g. Global, whose concrete subtypes are " +
-                             "GlobalFloat / GlobalInt / GlobalShort) — create a concrete subtype instead. Abstract-type " +
-                             "create is a named follow-up, not yet supported.";
-                    return false;
-                }
-                reason = null;
+                reason = null;   // a concrete flat T (abstract T's were handled by the EnumerateAbstractGroups loop above)
                 return true;
             }
         reason = $"'{typeName}' has no top-level group, so it can't be created on its own — it's a nested/placed record " +
@@ -821,13 +883,16 @@ public static class WriteEngine
         return false;
     }
 
-    /// <summary>The CREATE front-end: allocate a brand-new record of <paramref name="typeName"/> in <paramref name="patchMod"/>
-    /// via the flat group's <c>AddNew</c>, returning a settable root fed into the SAME <see cref="ApplyVerb"/> path as an
-    /// override. AddNew allocates a fresh LOCAL FormID (the new plugin's own 0x800+ ESP range, incrementing — measured by
-    /// create-probe C2, with the floor guaranteed by <see cref="EnsureFormIdFloor"/>); the new record's master is the patch
-    /// itself. <paramref name="editorId"/> sets the EditorID via the <c>AddNew(string)</c> overload (null uses the no-arg,
-    /// engine-assigned one). Throws loud (Q3) on the two boundaries via <see cref="CanCreateType"/> — callers pre-flight
-    /// with that, so a throw here means the surface changed under us.</summary>
+    /// <summary>The CREATE front-end: allocate a brand-new record of <paramref name="typeName"/> in <paramref name="patchMod"/>,
+    /// returning a settable root fed into the SAME <see cref="ApplyVerb"/> path as an override. For a concrete flat type the
+    /// flat group's <c>AddNew</c> allocates a fresh LOCAL FormID (the new plugin's own 0x800+ ESP range, incrementing — measured
+    /// by create-probe C2, with the floor guaranteed by <see cref="EnsureFormIdFloor"/>); for a concrete ARM of an abstract group
+    /// ('GlobalFloat' / 'GameSettingFloat'), the arm is constructed via <see cref="ConstructRecord"/> + <see cref="AllocateNextFormKey"/>
+    /// (the same allocator the nested create draws from, so the floor + counter are shared) and added through the group's own
+    /// instance <c>Add(T)</c> — a <c>SkyrimGroup&lt;T&gt;</c> is NOT an IList, and Mutagen's generic AddNew&lt;T&gt; can't be
+    /// closed with the abstract base. The new record's master is the patch itself. <paramref name="editorId"/> sets the EditorID
+    /// (null uses the engine-assigned one). Throws loud (Q3) on the boundaries via <see cref="CanCreateType"/> — callers
+    /// pre-flight with that, so a throw here means the surface changed under us.</summary>
     public static IMajorRecord GenericAddNew(SkyrimMod patchMod, string typeName, string? editorId)
     {
         if (!CanCreateType(typeName, out var reason)) throw new InvalidOperationException(reason);
@@ -839,10 +904,33 @@ public static class WriteEngine
             throw new InvalidOperationException(
                 $"cannot allocate a new FormID: the patch's NextObjectID counter is 0x{patchMod.ModHeader.Stats.NextFormID:X} — " +
                 "past the 24-bit object-ID ceiling (0xFFFFFF). The plugin is full or its header counter is corrupt.");
+
+        // Abstract-group arm (GlobalFloat / GameSettingFloat / …): construct the concrete arm + Add(T) it (the abstract T
+        // can't go through InvokeAddNew). CanCreateType admitted the arm, so resolution here can't fail benignly.
+        if (TryResolveAbstractGroupArm(patchMod, typeName, out var armGroup, out var armType))
+            return AddConcreteArmToGroup(armGroup!, armType!, AllocateNextFormKey(patchMod), editorId);
+
         object? group = null; Type? tMajor = null;
         foreach (var (prop, tm, _) in EnumerateFlatGroups(patchMod.GetType()))
             if (string.Equals(tm.Name, typeName, StringComparison.OrdinalIgnoreCase)) { group = prop.GetValue(patchMod); tMajor = tm; break; }
         return InvokeAddNew(group!, tMajor!, editorId);   // CanCreateType guaranteed a concrete flat group exists
+    }
+
+    /// <summary>Construct a concrete abstract-group arm (<paramref name="armType"/>, e.g. <c>GlobalFloat</c>) at
+    /// <paramref name="formKey"/> and add it to its group via the group's own instance <c>Add(T)</c> method (reflected —
+    /// a <c>SkyrimGroup&lt;T&gt;</c> is NOT an IList, so the nested-create IList.Add path would crash). The same
+    /// <see cref="ConstructRecord"/> idiom the nested create uses. Throws loud (Q3) if the expected <c>Add(T)</c> shape
+    /// is absent — never a silent no-op.</summary>
+    static IMajorRecord AddConcreteArmToGroup(object group, Type armType, FormKey formKey, string? editorId)
+    {
+        var rec = ConstructRecord(armType, formKey);
+        if (editorId is not null) rec.EditorID = editorId;
+        var baseType = group.GetType().IsGenericType ? group.GetType().GetGenericArguments()[0] : armType;
+        var add = group.GetType().GetMethod("Add", new[] { baseType })
+            ?? throw new InvalidOperationException(
+                $"abstract-group create: no Add({baseType.Name}) on {group.GetType().Name} — surfaced, not guessed (Q3).");
+        add.Invoke(group, new object[] { rec });
+        return rec;
     }
 
     /// <summary>UPSERT front-end for the extend path: like <see cref="GenericAddNew"/>, but if the patch already
@@ -888,6 +976,22 @@ public static class WriteEngine
                 var existing = matches[0];
                 if (!CanCreateType(typeName, out var reason)) throw new InvalidOperationException(reason);
                 var formKey = existing.FormKey;
+
+                // Abstract-group arm (GlobalFloat / GameSettingFloat / …): the cross-type guard compares the existing
+                // record's CONCRETE type to the requested arm (re-running a GlobalFloat create over a stored GlobalInt
+                // of the same editorid IS a cross-type collision — different concrete records), and the re-add goes
+                // through Add(T), not the abstract-base InvokeAddNewWithFormKey (which can't close AddNew<T>).
+                if (TryResolveAbstractGroupArm(patchMod, typeName, out var armGroup, out var armType))
+                {
+                    if (!armType!.IsInstanceOfType(existing))
+                        throw new InvalidOperationException(
+                            $"upsert refused: existing record '{editorId}' ({formKey}) is a {existing.GetType().Name}, not a {typeName} — " +
+                            "an EditorID collision across record types is a real authoring error, surfaced not swallowed (Q3).");
+                    InvokeRemove(armGroup!, formKey);
+                    var freshArm = AddConcreteArmToGroup(armGroup!, armType, formKey, editorId);
+                    return (freshArm, true);
+                }
+
                 object? group = null; Type? tMajor = null;
                 foreach (var (prop, tm, _) in EnumerateFlatGroups(patchMod.GetType()))
                     if (string.Equals(tm.Name, typeName, StringComparison.OrdinalIgnoreCase)) { group = prop.GetValue(patchMod); tMajor = tm; break; }

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -806,21 +806,32 @@ public static class WriteEngine
     /// the SAME <see cref="EnumerateFlatGroups"/> enumeration that defines the create surface, testing <c>T.IsAbstract</c>,
     /// then collecting every non-abstract record class the base is assignable from (the runtime hierarchy, exactly as
     /// <see cref="GenericAddNew"/> keys off it). By construction: the abstract-group set IS Mutagen's (two today —
-    /// Global, GameSetting), and each base's arm set IS its concrete subtype set — neither is hand-listed. Mod-instance-
-    /// free (walks <c>typeof(SkyrimMod)</c>), so it serves the pre-flight before any patch exists.</summary>
-    internal static IEnumerable<(PropertyInfo prop, Type baseType, IReadOnlyList<Type> arms)> EnumerateAbstractGroups()
-    {
-        var skyrimAsm = typeof(IArmorGetter).Assembly;
-        foreach (var (prop, tMajor, _) in EnumerateFlatGroups(typeof(SkyrimMod)))
+    /// Global, GameSetting), and each base's arm set IS its concrete subtype set — neither is hand-listed.
+    ///
+    /// MEMOIZED (the <see cref="OverrideMethod"/> precedent): the result is pure reflection METADATA (<c>PropertyInfo</c>
+    /// + <c>Type</c>s), constant for the process lifetime and PATCH-INDEPENDENT, so the ~10k-type <c>GetTypes()</c> walk
+    /// runs once. <see cref="CanCreateType"/> calls this ≥2× on EVERY create (incl. common Keyword/Spell creates and every
+    /// record of a bulk_create), so the cache is a pure win. The per-patch group INSTANCE is NOT cached — callers resolve
+    /// it live via <c>prop.GetValue(patchMod)</c> against the tuple's (patch-independent) <c>PropertyInfo</c>.</summary>
+    static readonly Lazy<IReadOnlyList<(PropertyInfo prop, Type baseType, IReadOnlyList<Type> arms)>> _abstractGroups =
+        new(() =>
         {
-            if (!tMajor.IsAbstract) continue;
-            var arms = skyrimAsm.GetTypes()
-                .Where(t => t.IsClass && !t.IsAbstract && tMajor.IsAssignableFrom(t) && typeof(IMajorRecord).IsAssignableFrom(t))
-                .OrderBy(t => t.Name, StringComparer.Ordinal)
-                .ToList();
-            yield return (prop, tMajor, arms);
-        }
-    }
+            var skyrimAsm = typeof(IArmorGetter).Assembly;
+            var list = new List<(PropertyInfo, Type, IReadOnlyList<Type>)>();
+            foreach (var (prop, tMajor, _) in EnumerateFlatGroups(typeof(SkyrimMod)))
+            {
+                if (!tMajor.IsAbstract) continue;
+                var arms = skyrimAsm.GetTypes()
+                    .Where(t => t.IsClass && !t.IsAbstract && tMajor.IsAssignableFrom(t) && typeof(IMajorRecord).IsAssignableFrom(t))
+                    .OrderBy(t => t.Name, StringComparer.Ordinal)
+                    .ToList();
+                list.Add((prop, tMajor, arms));
+            }
+            return list;
+        });
+
+    internal static IReadOnlyList<(PropertyInfo prop, Type baseType, IReadOnlyList<Type> arms)> EnumerateAbstractGroups()
+        => _abstractGroups.Value;
 
     /// <summary>If <paramref name="typeName"/> is the CONCRETE arm of an abstract record group (e.g. "GlobalFloat" under
     /// SkyrimGroup&lt;Global&gt;), resolve the live group + the arm's Type; else false. The single point both the

--- a/src/housecarl-generator/CreateGlobalProbe.cs
+++ b/src/housecarl-generator/CreateGlobalProbe.cs
@@ -3,6 +3,7 @@ using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Records;
 using Mutagen.Bethesda.Skyrim;
 using HousecarlCore;
+using HousecarlMcp;
 
 namespace HousecarlGenerator;
 
@@ -34,6 +35,12 @@ namespace HousecarlGenerator;
 ///   G6  BASEREFUSE   — create RecordType='Global' (the bare abstract base) is REFUSED loud, the message NAMES the
 ///                      concrete arms, NOTHING written. (Green today as a regression guard, not a fix-proof — it keeps
 ///                      the loud-fail boundary loud after the fix opened the concrete-arm path beside it.)
+///   G7  READMAP      — the READ-SIDE base→arm mapping (LoadOrderService.BuildTypeLookup): a cross_plugin_query
+///                      type='Global' over an order holding a GlobalFloat AND a GlobalInt resolves (no "unknown type")
+///                      and returns BOTH — proving the abstract base NAME unions its concrete arms (the read-side twin
+///                      of the create branch). The union spanning two DISTINCT arms is the observable form of the
+///                      "4 arms" by-construction claim. type='GameSetting' returns its GameSettingFloat (generality).
+///                      RED before the fix (BuildTypeLookup skipped polymorphic-base names → "unknown record type").
 /// </summary>
 public static class CreateGlobalProbe
 {
@@ -189,8 +196,74 @@ public static class CreateGlobalProbe
             Console.WriteLine($"   G6 bare abstract base 'Global' refused, arms named : {(g6 ? "PASS — refused loud, arms named, no file" : $"FAIL — refused={refused} namesArms={namesArms} noFile={noFile} error=[{error}]")}");
         }
 
+        // --- G7: the READ-SIDE base→arm mapping (LoadOrderService.BuildTypeLookup, driven through the real CrossQuery).
+        //     A synthetic MO2 instance (the bulk-create-guard synth pattern) holding a master with a GlobalFloat, a
+        //     GlobalInt, and a GameSettingFloat. type='Global' must RESOLVE (not "unknown record type") and return BOTH
+        //     globals — proving the abstract base NAME unions its concrete arms (two distinct arms = the observable form
+        //     of the "4 arms" claim); type='GameSetting' returns its GameSettingFloat (the generality, second group). ---
+        bool g7 = false;
+        {
+            var g7Root = Path.Combine(tmpDir, "readmap");
+            string instance = Path.Combine(g7Root, "instance");
+            string profiles = Path.Combine(instance, "profiles", "Default");
+            string mods = Path.Combine(instance, "mods");
+            Directory.CreateDirectory(profiles); Directory.CreateDirectory(mods);
+            Directory.CreateDirectory(Path.Combine(g7Root, "game", "Data"));
+            File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+                "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+                + Path.Combine(g7Root, "game").Replace(@"\", @"\\") + ")\r\n");
+
+            var mapKey = new ModKey("HcAbsGrpReadMap", ModType.Master);
+            var modDir = Path.Combine(mods, "ReadMapMod");
+            Directory.CreateDirectory(modDir);
+            FormKey globFloatFk, globIntFk, gmstFloatFk;
+            {
+                // Build the fixture records through the product's own abstract-group create (the only path that can
+                // populate these groups — the bare Mutagen AddNew<T> extension can't, which is the whole reason for PR-D).
+                var m = new SkyrimMod(mapKey, SkyrimRelease.SkyrimSE);
+                globFloatFk = WriteEngine.GenericAddNew(m, "GlobalFloat", "HcRmGlobalFloat").FormKey;
+                globIntFk = WriteEngine.GenericAddNew(m, "GlobalInt", "HcRmGlobalInt").FormKey;
+                gmstFloatFk = WriteEngine.GenericAddNew(m, "GameSettingFloat", "fHcRmGmstFloat").FormKey;
+                m.BeginWrite.ToPath(Path.Combine(modDir, mapKey.FileName.String)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            }
+            File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + mapKey.FileName + "\r\n");
+            File.WriteAllText(Path.Combine(profiles, "plugins.txt"), "*" + mapKey.FileName + "\r\n");
+            File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+ReadMapMod\r\n");
+
+            // BuildTypeLookup reads the corpus via CorpusRulebook.CorpusPath (the same one the rulebook loaded from).
+            CorpusRulebook.CorpusPath = Path.Combine(genDir, "corpus.json");
+            var store = new UserConfigStore(Path.Combine(g7Root, "houseCARL.user.json"));
+
+            bool globResolved = false, globBothArms = false, gmstResolved = false, gmstArm = false;
+            string? globErr = null, gmstErr = null;
+            try
+            {
+                using var svc = LoadOrderService.WithInstance(instance, 0, store);
+                svc.Stats();   // warm the lazy index once
+
+                var glob = svc.CrossQuery("Global", null, null, false, null, null, 50);
+                globErr = glob.Error;
+                globResolved = glob.Error is null;
+                if (globResolved)
+                {
+                    var keys = glob.Keys.ToHashSet();
+                    // BOTH distinct arms surface under the single base-name query (the union spans >1 arm).
+                    globBothArms = keys.Contains(globFloatFk) && keys.Contains(globIntFk);
+                }
+
+                var gmst = svc.CrossQuery("GameSetting", null, null, false, null, null, 50);
+                gmstErr = gmst.Error;
+                gmstResolved = gmst.Error is null;
+                if (gmstResolved) gmstArm = gmst.Keys.Contains(gmstFloatFk);
+            }
+            catch (Exception ex) { globErr ??= $"{ex.GetType().Name}: {ex.Message}"; }
+
+            g7 = globResolved && globBothArms && gmstResolved && gmstArm;
+            Console.WriteLine($"   G7 read-side base→arm mapping (cross_plugin_query): {(g7 ? "PASS — type='Global' unions GlobalFloat+GlobalInt; type='GameSetting' returns its arm" : $"FAIL — globResolved={globResolved} bothArms={globBothArms} gmstResolved={gmstResolved} gmstArm={gmstArm} globErr=[{globErr}] gmstErr=[{gmstErr}]")}");
+        }
+
         Console.WriteLine();
-        bool pass = g1 && g2 && g3 && g4 && g5 && g6;
+        bool pass = g1 && g2 && g3 && g4 && g5 && g6 && g7;
         Console.WriteLine($"=== create-abstract-group-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return pass ? 0 : 1;

--- a/src/housecarl-generator/CreateGlobalProbe.cs
+++ b/src/housecarl-generator/CreateGlobalProbe.cs
@@ -1,0 +1,198 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SELF-CONTAINED CI REGRESSION GUARD for creating a CONCRETE SUBTYPE of an ABSTRACT record group (HCBR-2026-06-15-01
+/// item 2.2 / PR-D), in the pattern of upsert-guard / nested-create-guard. Drives the REAL product paths
+/// (WritePatchBuilder.CreateRecords / WriteEngine.GenericAddNew / GenericUpsertNew / ApplyVerb) against a synthesized
+/// master in TEMP. The two abstract record groups are SkyrimGroup&lt;Global&gt; and SkyrimGroup&lt;GameSetting&gt;; a
+/// Global is stored as a GlobalFloat/Int/Short, a GameSetting as a GameSettingBool/Float/Int/String — the bare base is
+/// never instantiable. Mutagen's generic AddNew&lt;T&gt; cannot be closed with the abstract base (it throws), and a
+/// SkyrimGroup&lt;T&gt; is NOT an IList, so the fix constructs the concrete arm + Add(T)s it via the group's own
+/// instance method.  Run: dotnet run --project src/housecarl-generator -- create-abstract-group-guard
+///
+/// Arms (ALL required — a GREEN must mean "the contract holds", never "the scenario doesn't arise here"):
+///   G1  GLOBALFLOAT  — create_record RecordType='GlobalFloat' succeeds: a GlobalFloat, FormKey id >= 0x800, master ==
+///                      the patch itself (a local new record). RED before the fix (CanCreateType refused the arm:
+///                      "no top-level group … subtype of an abstract group").
+///   G2  GAMESETTING  — the SAME for RecordType='GameSettingFloat'. The BY-CONSTRUCTION generality proof: the fix is
+///                      keyed off the runtime hierarchy (abstract group → its concrete arms), NOT a per-type GLOB
+///                      special-case, so GMST — a DIFFERENT abstract group discovered the same way — must work
+///                      identically off the same branch. RED before the fix for the same reason as G1.
+///   G3  FIELD        — set Data=12.5 on the created GlobalFloat through the proven ApplyVerb path, read it back off
+///                      the live record (create→edit reuses the write surface).
+///   G4  ROUNDTRIP    — serialize the patch, re-open from disk: the GlobalFloat persists with its FormKey + EditorID +
+///                      Data, as a GlobalFloat (the group.Add path is otherwise unproven through WritePatch).
+///   G5  UPSERT       — re-run the same create with extend=true: the record is REPLACED in place (1 copy, stable
+///                      FormKey, surfaced as ReplacedExisting), not appended — the abstract-group upsert path
+///                      (InvokeRemove + re-construct + Add(T), not InvokeAddNewWithFormKey).
+///   G6  BASEREFUSE   — create RecordType='Global' (the bare abstract base) is REFUSED loud, the message NAMES the
+///                      concrete arms, NOTHING written. (Green today as a regression guard, not a fix-proof — it keeps
+///                      the loud-fail boundary loud after the fix opened the concrete-arm path beside it.)
+/// </summary>
+public static class CreateGlobalProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  REGRESSION GUARD — create concrete subtype of an abstract record group (GLOB / GMST, PR-D)  ################");
+        Console.WriteLine();
+
+        var tmpDir = Path.Combine(Path.GetTempPath(), "hc-create-abstract-group-guard");
+        if (Directory.Exists(tmpDir)) Directory.Delete(tmpDir, recursive: true);
+        Directory.CreateDirectory(tmpDir);
+
+        // --- Setup: an empty master + the validator corpus. The created records reference nothing external. ---
+        var mKey = new ModKey("HcAbsGrpMaster", ModType.Master);
+        string mPath = Path.Combine(tmpDir, mKey.FileName.String);
+        {
+            var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
+            var k = m.Keywords.AddNew(); k.EditorID = "HcAbsGrpMasterKw";   // a record so the master isn't empty-bytes
+            m.BeginWrite.ToPath(mPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+        }
+        var genDir = Path.Combine(tmpDir, "corpus-gen");
+        CorpusGenerator.GenerateAll(genDir, Path.Combine(tmpDir, "corpus-ref"));
+        var rulebook = CorpusRulebook.Load(Path.Combine(genDir, "corpus.json"));
+        Console.WriteLine($"-- setup: master {mKey.FileName}; corpus generated --");
+
+        string pPath = Path.Combine(tmpDir, "HcAbsGrpGuard.esp");
+
+        // --- G1 + G2 + G3 + G4: create a GlobalFloat (with a Data edit) and a GameSettingFloat in one call, serialize,
+        //     re-read. The two arms in one spec set prove the create branch + the generality in one serialize pass. ---
+        bool g1 = false, g2 = false, g3 = false, g4 = false;
+        FormKey globFk = default, gmstFk = default;
+        {
+            var specs = new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "GlobalFloat", EditorId = "HcAbsGrpGlobal", Edits = new[]
+                {
+                    new WriteRequest { RecordType = "GlobalFloat", Path = new[] { "Data" }, Verb = "Set", Value = "12.5" },
+                } },
+                new WritePatchBuilder.CreateSpec { RecordType = "GameSettingFloat", EditorId = "fHcAbsGrpGmst", Edits = Array.Empty<WriteRequest>() },
+            };
+
+            bool createOk = false; string? createErr = null;
+            string? globType = null, gmstType = null;
+            using (var r = LoadOrderResolver.Build(new[] { mPath }))
+            {
+                var o = WritePatchBuilder.CreateRecords(r, rulebook, specs, pPath, extend: false);
+                createOk = o.Success; createErr = o.Error;
+                if (o.Success)
+                {
+                    var glob = o.Created.FirstOrDefault(c => c.EditorId == "HcAbsGrpGlobal");
+                    var gmst = o.Created.FirstOrDefault(c => c.EditorId == "fHcAbsGrpGmst");
+                    if (glob is not null) globFk = glob.FormKey;
+                    if (gmst is not null) gmstFk = gmst.FormKey;
+                }
+            }
+
+            // Re-open from disk and confirm concrete type + fields + master.
+            float? globData = null; string? globEdid = null, gmstEdid = null;
+            bool globLocal = false, gmstLocal = false;
+            if (createOk)
+            {
+                ISkyrimModGetter? ov = null;
+                try
+                {
+                    ov = SkyrimMod.CreateFromBinaryOverlay(pPath, SkyrimRelease.SkyrimSE);
+                    var g = ov.Globals.FirstOrDefault(x => x.FormKey == globFk);
+                    if (g is not null)
+                    {
+                        // The overlay reader returns concrete-arm subclasses (GlobalFloatBinaryOverlay); the load-bearing
+                        // assertion is the getter-interface (the arm's identity), not the class name.
+                        globType = g is IGlobalFloatGetter ? "GlobalFloat" : g.GetType().Name;
+                        globEdid = g.EditorID;
+                        globData = (g as IGlobalFloatGetter)?.Data;
+                        globLocal = g.FormKey.ModKey == ov.ModKey;
+                    }
+                    var s = ov.GameSettings.FirstOrDefault(x => x.FormKey == gmstFk);
+                    if (s is not null)
+                    {
+                        gmstType = s is IGameSettingFloatGetter ? "GameSettingFloat" : s.GetType().Name;
+                        gmstEdid = s.EditorID;
+                        gmstLocal = s.FormKey.ModKey == ov.ModKey;
+                    }
+                }
+                finally { (ov as IDisposable)?.Dispose(); }
+            }
+
+            g1 = createOk && globType == "GlobalFloat" && globFk.ID >= 0x800 && globLocal;
+            g2 = createOk && gmstType == "GameSettingFloat" && gmstFk.ID >= 0x800 && gmstLocal;
+            g3 = globData.HasValue && Math.Abs(globData.Value - 12.5f) < 0.001f;
+            g4 = createOk && globType == "GlobalFloat" && globEdid == "HcAbsGrpGlobal"
+                 && gmstType == "GameSettingFloat" && gmstEdid is not null;   // GMST editorid is engine-prefixed ('f…')
+
+            Console.WriteLine($"   G1 create GlobalFloat (arm of abstract Global)     : {(g1 ? $"PASS — {globType} {globFk} (id 0x{globFk.ID:X6}, local)" : $"FAIL — ok={createOk} type={globType} id=0x{globFk.ID:X6} local={globLocal} err=[{createErr}]")}");
+            Console.WriteLine($"   G2 create GameSettingFloat (generality, NOT GLOB)  : {(g2 ? $"PASS — {gmstType} {gmstFk} (id 0x{gmstFk.ID:X6}, local)" : $"FAIL — ok={createOk} type={gmstType} id=0x{gmstFk.ID:X6} local={gmstLocal} err=[{createErr}]")}");
+            Console.WriteLine($"   G3 set Data=12.5 via ApplyVerb, read back          : {(g3 ? $"PASS — Data={globData}" : $"FAIL — Data={globData}")}");
+            Console.WriteLine($"   G4 serialize + re-read round-trip (FormKey/edid)   : {(g4 ? $"PASS — GlobalFloat '{globEdid}', GameSettingFloat '{gmstEdid}'" : $"FAIL — globType={globType} globEdid={globEdid} gmstType={gmstType} gmstEdid={gmstEdid}")}");
+        }
+
+        // --- G5: re-run the SAME create with extend=true → REPLACE in place (1 copy, stable FormKey, surfaced). ---
+        bool g5 = false;
+        {
+            bool rerunOk = false, flaggedReplaced = false; FormKey globFk2 = default;
+            var specs = new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "GlobalFloat", EditorId = "HcAbsGrpGlobal", Edits = new[]
+                {
+                    new WriteRequest { RecordType = "GlobalFloat", Path = new[] { "Data" }, Verb = "Set", Value = "99.0" },
+                } },
+            };
+            using (var r = LoadOrderResolver.Build(new[] { mPath }))
+            {
+                var o = WritePatchBuilder.CreateRecords(r, rulebook, specs, pPath, extend: true);
+                rerunOk = o.Success;
+                if (o.Success)
+                {
+                    var glob = o.Created.FirstOrDefault(c => c.EditorId == "HcAbsGrpGlobal");
+                    if (glob is not null) { globFk2 = glob.FormKey; flaggedReplaced = glob.ReplacedExisting; }
+                }
+            }
+            int globCount = 0; float? data2 = null;
+            if (rerunOk)
+            {
+                ISkyrimModGetter? ov = null;
+                try
+                {
+                    ov = SkyrimMod.CreateFromBinaryOverlay(pPath, SkyrimRelease.SkyrimSE);
+                    foreach (var g in ov.Globals) if (g.EditorID == "HcAbsGrpGlobal") { globCount++; data2 = (g as IGlobalFloatGetter)?.Data; }
+                }
+                finally { (ov as IDisposable)?.Dispose(); }
+            }
+            g5 = rerunOk && flaggedReplaced && globCount == 1 && globFk2 == globFk
+                 && data2.HasValue && Math.Abs(data2.Value - 99.0f) < 0.001f;
+            Console.WriteLine($"   G5 re-run replaces in place (stable, surfaced)     : {(g5 ? $"PASS — 1 copy, FormKey {globFk2} stable, REPLACED flagged, Data={data2}" : $"FAIL — ok={rerunOk} flagged={flaggedReplaced} count={globCount} stable={globFk2 == globFk} data={data2}")}");
+        }
+
+        // --- G6: the bare abstract base 'Global' refuses loud naming the arms; nothing written. ---
+        bool g6 = false;
+        {
+            string basePath = Path.Combine(tmpDir, "HcAbsGrpBaseRefuse.esp");
+            bool refused; string? error;
+            using (var r = LoadOrderResolver.Build(new[] { mPath }))
+            {
+                var spec = new[] { new WritePatchBuilder.CreateSpec { RecordType = "Global", EditorId = "HcAbsGrpBase", Edits = Array.Empty<WriteRequest>() } };
+                var o = WritePatchBuilder.CreateRecords(r, rulebook, spec, basePath, extend: false);
+                refused = !o.Success; error = o.Error;
+            }
+            bool namesArms = error is not null
+                && error.Contains("GlobalFloat", StringComparison.OrdinalIgnoreCase)
+                && error.Contains("GlobalInt", StringComparison.OrdinalIgnoreCase)
+                && error.Contains("GlobalShort", StringComparison.OrdinalIgnoreCase);
+            bool noFile = !File.Exists(basePath);
+            g6 = refused && namesArms && noFile;
+            Console.WriteLine($"   G6 bare abstract base 'Global' refused, arms named : {(g6 ? "PASS — refused loud, arms named, no file" : $"FAIL — refused={refused} namesArms={namesArms} noFile={noFile} error=[{error}]")}");
+        }
+
+        Console.WriteLine();
+        bool pass = g1 && g2 && g3 && g4 && g5 && g6;
+        Console.WriteLine($"=== create-abstract-group-guard: {(pass ? "PASS" : "FAIL")} ===");
+        try { Directory.Delete(tmpDir, recursive: true); } catch { }
+        return pass ? 0 : 1;
+    }
+}

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -234,6 +234,12 @@ if (args.Length > 0 && args[0] == "create-probe") return CreateProbe.RunProbe(ar
 // Capability arc create proof: drive WritePatchBuilder.CreateRecords (the core housecarl_create_record calls) vs a real, large load order.
 if (args.Length > 0 && args[0] == "create-proof") return CreateProof.RunCreateProof(args[1..]);
 
+// Create a CONCRETE SUBTYPE of an ABSTRACT record group (HCBR 2.2 / PR-D): SELF-CONTAINED CI regression guard —
+// create_record 'GlobalFloat' + 'GameSettingFloat' succeed (the by-construction generality: two distinct abstract
+// groups off ONE branch, never a GLOB special-case), set Data + round-trip, upsert-replace in place, and the bare
+// abstract base ('Global') refuses loud naming the arms.
+if (args.Length > 0 && args[0] == "create-abstract-group-guard") return CreateGlobalProbe.RunGuard(args[1..]);
+
 // Master-baseline scout: how to FORCE Skyrim.esm onto every written plugin (Mutagen strips unreferenced masters) — Aaron-flagged bug.
 if (args.Length > 0 && args[0] == "master-probe") return MasterProbe.RunProbe(args[1..]);
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1482,8 +1482,11 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>Build the type-string → getter-Type(s) map from the corpus (the authoritative type catalog).
     /// Keyed by BOTH catalog name and 4-char signature; the 2 many-to-one signatures (GMST/GLOB) accumulate
-    /// their variants so a signature query unions them. A corpus AQ name that won't load is skipped here and
-    /// surfaces as "unknown type" at query time — never a silent wrong type.</summary>
+    /// their variants so a signature query unions them. The 2 abstract-group BASE names (Global / GameSetting,
+    /// kind="polymorphic-base") map to their concrete arms' getter Types BY CONSTRUCTION — the same arm union the
+    /// GMST/GLOB signature already yields — so a query by the base name unions them too and the ambiguity branch at
+    /// ResolveTypeFilter's callers names the variants. A corpus AQ name that won't load is skipped here and surfaces
+    /// as "unknown type" at query time — never a silent wrong type.</summary>
     static Dictionary<string, List<Type>> BuildTypeLookup()
     {
         var lookup = new Dictionary<string, List<Type>>(StringComparer.OrdinalIgnoreCase);
@@ -1493,13 +1496,25 @@ public sealed class LoadOrderService : IDisposable
             if (!lookup.TryGetValue(key, out var list)) lookup[key] = list = new List<Type>();
             if (!list.Contains(t)) list.Add(t);
         }
-        foreach (var ts in CorpusRulebook.LoadCorpus().Types.Values)
+        var corpus = CorpusRulebook.LoadCorpus();
+        foreach (var ts in corpus.Types.Values)
         {
             if (ts.Kind != "record") continue;
             var t = Type.GetType(ts.GetterInterfaceAssemblyQualified);
             if (t is null) continue;
             Add(ts.Name, t);
             Add(ts.Signature, t);
+        }
+        // Abstract-group base names (Global / GameSetting) → their concrete arms' getter Types. The arms are listed
+        // on the polymorphic-base's own corpus entry, so the union is derived, not hand-wired (cornerstone §3): a query
+        // type='Global' resolves to the same set GLOB does, and the existing many-match guidance names the variants.
+        foreach (var ts in corpus.Types.Values)
+        {
+            if (ts.Kind != "polymorphic-base" || ts.Arms is not { Count: > 0 } arms) continue;
+            foreach (var armName in arms)
+                if (corpus.Types.TryGetValue(armName, out var arm) && arm.Kind == "record"
+                    && Type.GetType(arm.GetterInterfaceAssemblyQualified) is { } at)
+                    Add(ts.Name, at);
         }
         return lookup;
     }

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -131,11 +131,13 @@ public static class WriteTools
          "operations=[{field_path:'Name', value:'My Spell'}, {field_path:'EffectList', verb:'Add', compose:{...}}]. To create a " +
          "NESTED record (a dialogue line under a topic, a placed ref in a cell), pass parent= (the parent record's FormID) and, " +
          "if the parent holds more than one child-list that fits, collection= (e.g. 'Persistent'); for a parent AND its children " +
-         "in ONE call (a topic + its lines), use housecarl_bulk_create. The new FormID is reported back; to make ANOTHER record " +
+         "in ONE call (a topic + its lines), use housecarl_bulk_create. For an abstract record group (Global, GameSetting), name " +
+         "the CONCRETE subtype directly ('GlobalFloat'/'GlobalInt'/'GlobalShort', 'GameSettingFloat'/'GameSettingInt'/'GameSettingString') " +
+         "— that's how a global variable or game setting is created. The new FormID is reported back; to make ANOTHER record " +
          "reference it, call this or set_field again with into='<this patch>' using that FormID. By default writes a fresh patch " +
          "named patch_name; into= extends an existing houseCARL patch (accumulate across calls/sessions). ALL-OR-NOTHING (Q3): " +
          "the whole call is refused with a reason and nothing is written if the type can't be created (an EXTERIOR cell nests " +
-         "under FormKey-less worldspace structs — a separate capability; abstract types like Global need a concrete subtype), if " +
+         "under FormKey-less worldspace structs — a separate capability; the bare abstract base 'Global'/'GameSetting' needs a concrete subtype — the refusal names them), if " +
          "a nested type is given no parent, if editorid is missing, or if any field op is illegal. Returns the new record's " +
          "FormID + editorid, the patch path, and its (derived) masters.")]
     public static string CreateRecord(


### PR DESCRIPTION
**HCBR-2026-06-15-01 fix unit PR-D** (item 2.2): `create_record` couldn't make a `GlobalVariable` — `Global` is a `polymorphic-base` (absent from the record-only type index) and `GlobalFloat` hit `CanCreateType`'s "subtype of an abstract group" refusal (the flat-group walk finds only the abstract `SkyrimGroup<Global>`).

## What
A "concrete arm of an abstract record group" create branch, keyed off the runtime hierarchy:
- `EnumerateAbstractGroups` discovers the abstract groups by walking the **same** `EnumerateFlatGroups` enumeration and testing `T.IsAbstract` (two today: `Global`, `GameSetting`); each base's arms = its non-abstract `IMajorRecord` subclasses. **Nothing hand-listed.**
- `GenericAddNew` constructs the arm via `ConstructRecord` + `AllocateNextFormKey` (shared floor/counter) and adds it through the group's **instance `Add(T)`** — a `SkyrimGroup<T>` is NOT an `IList`, and Mutagen's `AddNew<T>` can't close on the abstract base.
- `GenericUpsertNew` REPLACE path: `InvokeRemove` + re-construct + `Add(T)`, with a **cross-type collision guard** (re-running `GlobalFloat` over a stored `GlobalInt` of the same EditorID is refused loud).
- Bare base (`'Global'`/`'GameSetting'`) stays a loud refusal listing the **discovered** arms (Q3, no guessed default).
- `BuildTypeLookup` maps each base name → its concrete arms' getter Types (derived from the corpus `Arms` list) so a read query `type='Global'` resolves.

By-construction win: discovery found **4** concrete `Global` arms — the old hand-written refusal listed only 3 (Float/Int/Short).

## Validation
`create-abstract-group-guard` (new, **CI probe #36**): G1 `GlobalFloat` creates (id ≥ 0x800, local), G2 `GameSettingFloat` off the **same branch** (the by-construction generality proof — a different abstract group, so green = no GLOB special-casing), G3 `Data` set+read-back, G4 serialize+re-read round-trip, G5 upsert-replace in place, G6 bare `Global` refused naming arms.
- **RED-proven twice:** disabling the `GenericAddNew` arm branch reds G1–G5; disabling the `CanCreateType` arm admission reds G1–G5 (the original 2.2 failure). G6 green both times (regression guard).
- **Regression:** upsert / nested-create / bulk-create / formid-floor / value-predicate + the PR-A/B/C poly guards all pass. Full solution build clean.
- **Conductor re-ran the probe locally: 6/6 PASS.**

## §4
(a). No record type hand-wired — the abstract-group set is Mutagen's (`T.IsAbstract`), arms come from the runtime hierarchy + corpus `Arms`, the refusal names discovered arms. Same branch serves GMST and any future abstract group. Cornerstone §3 strengthened.

## Reviewer focus
1. **`CreateProof.cs` left unchanged (scope deviation, justified).** The scope flagged it "definite," but the requirement was conditional — keep "abstract" in the refusal *or* update the K5 assertion. The new refusal reads "is an abstract record group" (contains "abstract"), so K5's `Contains("abstract")` holds with no edit. K5 is `--source`-gated (needs Skyrim.esm, not runnable in CI/agent); in-CI G6 drives the same refusal path and additionally asserts the arms are named.
2. **`BuildTypeLookup` read-side change has no dedicated probe arm.** `value-predicate-guard` confirms `ResolveTypeFilter` still resolves, but nothing asserts `Global → 4 arms` specifically. Flag if you want a dedicated read-side assertion.
3. **GMST EditorID auto-prefix.** Mutagen prefixes GameSetting EditorIDs by type; G4 asserts the GMST EditorID is non-null (not an exact match) to avoid coupling to that engine behavior. Possible future create-tool doc note; out of PR-D scope.
4. **Arm discovery walks `skyrimAsm.GetTypes()`.** Overlay/getter subclasses are excluded by the `IMajorRecord`-assignable filter + exact arm-name match (verified empirically: exactly the Global/GameSetting arms, no overlays). Minor: `EnumerateAbstractGroups` re-walks per call (and twice on the bare-base refusal path) — creates are infrequent and this mirrors the existing `EnumerateFlatGroups` pattern, but it's memoizable if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)