### PR TITLE
formlink-null-guard: FormLink null-clear + value-shape pre-flight (HCBR-2026-06-15-01 / PR-F)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,15 @@ jobs:
       - name: Probe — nested compose + serialize-boundary null-arm refusal (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- nullarm-guard
 
+      # FormLink null-clear (HCBR 1.6 / PR-F): clearing a FormLink with a null-synonym ("00000000"/"0") threw at apply
+      # (FormKey.Factory) while pre-flight ACCEPTED it (type-only CoercibilityReject) — a Q3 accept-then-throw hole, and
+      # a REQUIRED link ("Set Race = null") had no clear path. ONE shared recognizer routes a synonym to FormKey.Null on
+      # apply and validates the formlink value shape at pre-flight; a real 6-hex FormID is never swallowed as a clear.
+      # Teeth: C1 (pre-flight now rejects a malformed value), D (apply clears a nullable link), E (apply clears a
+      # required link). Apply/serialize arms are pure in-memory Mutagen; pre-flight arms generate the corpus into a temp dir.
+      - name: Probe — FormLink null-clear + value-shape pre-flight (self-contained regression guard)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- formlink-null-guard
+
       # The compile tool's import ORDER is semantics (the CK compiler takes the FIRST matching .psc), so caller
       # import_dirs must outrank the auto-added vanilla folder — else SKSE-extended copies of vanilla scripts lose
       # to vanilla and extended calls fail despite the right folder being passed (spike findings §5.12, hit twice).

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -253,6 +253,15 @@ public sealed class CorpusRulebook
                     return WriteEngine.TryClassifyFloiValue(req.Value) ? null
                         : $"Illegal condition target '{req.Value}' for '{leaf.Name}': expected a FormID " +
                           "(XXXXXX:Plugin.esp → form mode), a bare index, or 'alias N' / 'packdata N' (→ index mode).";
+                // A NORMAL FormLink Set — validate the FormKey VALUE shape at the gate (the FORMLINK arm ONLY; a
+                // substruct still falls to the type-shape CoercibilityReject below). CoercibilityReject is type-only
+                // and never inspected the string, so "00000000"/"0" were accepted then threw at FormKey.Factory on
+                // apply — a Q3 accept-then-throw hole. A null-synonym clears the link; otherwise it must parse as a
+                // FormKey. The recognizer is SHARED with the engine apply path (no drift). (HCBR-2026-06-15-01 PR-F.)
+                if (leaf.Cardinality == "formlink")
+                    return WriteEngine.IsValidFormLinkValue(req.Value) ? null
+                        : $"Illegal FormLink target '{req.Value}' for '{leaf.Name}': expected a FormID " +
+                          "(XXXXXX:Plugin.esp) or a null-clear ('0', '00000000', 'Null', '000000:Null').";
                 return CoercibilityReject(leaf);
             }
             return CheckValue(leaf.Type, req.Value, $"value for '{leaf.Name}'",

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1950,8 +1950,10 @@ public static class WriteEngine
     /// <summary>Pre-flight value-shape check for a NORMAL FormLink Set: a null-clear synonym, or a value that parses
     /// as a FormKey. The type-only <c>CoercibilityReject</c> never inspected the value, so "00000000"/"0" were
     /// accepted then threw at FormKey.Factory on apply; this closes that hole at the gate. Shares the synonym
-    /// recognizer with the apply path so the gate and the engine agree on a legal value.</summary>
-    internal static bool IsValidFormLinkValue(string text) => IsFormKeyNullSynonym(text) || FormKey.TryFactory(text, out _);
+    /// recognizer with the apply path so the gate and the engine agree on a legal value. Null-tolerant for symmetry
+    /// with the FLOI sibling (<see cref="TryClassifyFloiValue"/>): all current callers guard non-null, but a future
+    /// caller can't trip an NRE in FormKey.TryFactory.</summary>
+    internal static bool IsValidFormLinkValue(string? text) => IsFormKeyNullSynonym(text) || (text is not null && FormKey.TryFactory(text, out _));
 
     /// <summary>FormLink families — build the matching concrete (nullable vs not) from a "FORMID:ModName.esp" key.
     /// Mutagen distinguishes IFormLink&lt;T&gt; (required) from IFormLinkNullable&lt;T&gt; (optional); the wrong

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1921,9 +1921,42 @@ public static class WriteEngine
         return true;
     }
 
+    // ---- FormLink null-clear (HCBR-2026-06-15-01 / PR-F) -------------------------------------------------------
+    //  A Set that CLEARS a FormLink (points it at no target) is expressed by a null-synonym value. The canonical
+    //  set is fixed (Aaron 2026-06-16): "0", "00000000", "Null", "000000:Null" — trimmed, case-insensitive,
+    //  FULL-STRING, so a real FormID ("012345:Skyrim.esm") is never mistaken for a clear. A synonym routes to
+    //  FormKey.Null; anything else parses through FormKey.Factory (which throws fail-loud on a malformed id — that
+    //  throw is caught at the gate by the pre-flight value-shape check, never reached as an accept-then-throw). This
+    //  ONE recognizer is shared by the apply path (ToFormKey, via TryFormLink) and pre-flight (CorpusRulebook ->
+    //  IsValidFormLinkValue) so the two can't drift on what counts as a clear — the same shared-predicate shape the
+    //  engine already uses for IsFormLinkOrIndex. (Without it, "00000000"/"0" was ACCEPTED by pre-flight then threw
+    //  "Malformed FormKey string" at apply — a Q3 accept-then-throw hole; and a required link had no clear path.)
+    static readonly string[] FormKeyNullSynonyms = { "0", "00000000", "Null", "000000:Null" };
+
+    /// <summary>True iff <paramref name="text"/> is a canonical FormKey null-clear synonym (trimmed, case-insensitive,
+    /// full-string). Shared by apply (<see cref="ToFormKey"/>) and pre-flight (<see cref="IsValidFormLinkValue"/>).</summary>
+    internal static bool IsFormKeyNullSynonym(string? text)
+    {
+        var v = (text ?? "").Trim();
+        foreach (var s in FormKeyNullSynonyms)
+            if (v.Equals(s, StringComparison.OrdinalIgnoreCase)) return true;
+        return false;
+    }
+
+    /// <summary>A null-synonym clears to <see cref="FormKey.Null"/>; anything else parses via FormKey.Factory
+    /// (fail-loud on a malformed id — pre-flight's value-shape check rejects that string before apply is reached).</summary>
+    static FormKey ToFormKey(string text) => IsFormKeyNullSynonym(text) ? FormKey.Null : FormKey.Factory(text);
+
+    /// <summary>Pre-flight value-shape check for a NORMAL FormLink Set: a null-clear synonym, or a value that parses
+    /// as a FormKey. The type-only <c>CoercibilityReject</c> never inspected the value, so "00000000"/"0" were
+    /// accepted then threw at FormKey.Factory on apply; this closes that hole at the gate. Shares the synonym
+    /// recognizer with the apply path so the gate and the engine agree on a legal value.</summary>
+    internal static bool IsValidFormLinkValue(string text) => IsFormKeyNullSynonym(text) || FormKey.TryFactory(text, out _);
+
     /// <summary>FormLink families — build the matching concrete (nullable vs not) from a "FORMID:ModName.esp" key.
     /// Mutagen distinguishes IFormLink&lt;T&gt; (required) from IFormLinkNullable&lt;T&gt; (optional); the wrong
-    /// concrete won't assign to the property, so the target type decides which we construct.</summary>
+    /// concrete won't assign to the property, so the target type decides which we construct. A null-synonym value
+    /// clears the link to <see cref="FormKey.Null"/> (see <see cref="ToFormKey"/>) rather than throwing.</summary>
     static bool TryFormLink(string? text, Type u, out object? result)
     {
         result = null;
@@ -1933,13 +1966,13 @@ public static class WriteEngine
         if (def == typeof(IFormLinkNullable<>) || def == typeof(IFormLinkNullableGetter<>) || def == typeof(FormLinkNullable<>))
         {
             if (text != null)
-                result = System.Activator.CreateInstance(typeof(FormLinkNullable<>).MakeGenericType(targetGetter), FormKey.Factory(text));
+                result = System.Activator.CreateInstance(typeof(FormLinkNullable<>).MakeGenericType(targetGetter), ToFormKey(text));
             return true;
         }
         if (def == typeof(FormLink<>) || def == typeof(IFormLink<>) || def == typeof(IFormLinkGetter<>))
         {
             if (text != null)
-                result = System.Activator.CreateInstance(typeof(FormLink<>).MakeGenericType(targetGetter), FormKey.Factory(text));
+                result = System.Activator.CreateInstance(typeof(FormLink<>).MakeGenericType(targetGetter), ToFormKey(text));
             return true;
         }
         // IFormLinkOrIndex<T> (condition-data targets) is NOT coercible here: its ctor needs the owning arm as a

--- a/src/housecarl-generator/FormLinkNullProbe.cs
+++ b/src/housecarl-generator/FormLinkNullProbe.cs
@@ -1,0 +1,198 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// REGRESSION GUARD (standing CI instrument) for HCBR-2026-06-15-01 PR-F — FormLink null-clear.
+///
+/// THE GAP (both halves confirmed via a live FormKey probe): a <c>Set</c> that CLEARS a FormLink with a
+/// null-synonym ("00000000" / "0") threw <c>ArgumentException: Malformed FormKey string</c> at APPLY
+/// (<c>FormKey.Factory</c>, inside <see cref="WriteEngine"/>.<c>TryFormLink</c>) — and PRE-FLIGHT ACCEPTED it,
+/// because the formlink arm called the TYPE-ONLY <c>CoercibilityReject</c>, which never validated the value
+/// string. A Q3 accept-then-throw hole on every FormLink leaf, plus no way to clear a REQUIRED link at all.
+///
+/// THE FIX (general FormLink family, by construction): one shared recognizer
+/// <see cref="WriteEngine.IsFormKeyNullSynonym"/> ("0" / "00000000" / "Null" / "000000:Null" — trimmed,
+/// case-insensitive, FULL-STRING) used by BOTH apply and pre-flight. On apply, a synonym routes to
+/// <c>FormKey.Null</c> instead of <c>FormKey.Factory</c>; on pre-flight, the FORMLINK arm validates the value
+/// shape (<see cref="WriteEngine.IsValidFormLinkValue"/>: synonym OR <c>FormKey.TryFactory</c> succeeds, else a
+/// loud reject naming the legal forms). The substruct arm is UNTOUCHED (it keeps its own type-shape reject).
+///
+/// RED-&gt;GREEN: the TEETH are C1 (pre-flight now REJECTS a malformed value — RED without the value-shape check),
+/// D for the ALL-ZEROS forms (apply CLEARS a nullable link instead of throwing — RED without ToFormKey), E (apply
+/// CLEARS a REQUIRED link via all-zeros, the genuinely-new "Set Race = null" case — RED without ToFormKey), and F
+/// (the same all-zeros clear, end-to-end through serialize). EMPIRICAL FINDING (proven by sabotage, baked into the
+/// arms): only the ALL-ZEROS spellings ("0"/"00000000") are newly-enabled — <c>FormKey.Factory</c> ALREADY parsed
+/// "Null"/"000000:Null" to FormKey.Null, so those D rows are CONTROLS (GREEN with the fix reverted), confirming the
+/// shared recognizer routes the already-working spellings identically. Other CONTROLS, GREEN before AND after:
+/// A (a real 6-hex FormID is NOT swallowed as a clear — full-string match; the accuracy guard the scope's critic
+/// called for, 6-hex not 8), C2/C3 (pre-flight still accepts a synonym and a real FormID), S0 (field nullability).
+///
+/// Self-contained: A/D/E/F are pure in-memory Mutagen (no plugin file, no Skyrim.esm); C1/C2/C3 use the GENERATED
+/// corpus.json (built into a unique temp dir on a fresh checkout, exactly as nullarm-guard / poly-field-descend do).
+///
+/// Run: <c>dotnet run --project src/housecarl-generator formlink-null-guard</c>
+/// </summary>
+public static class FormLinkNullProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        // CI-safe corpus: corpus.json is GENERATED, not tracked — on a fresh checkout build it into a UNIQUE temp
+        // dir and point the rulebook there (the pre-flight arms need it), leaving the working tree untouched.
+        string? tmp = null;
+        if (!File.Exists(CorpusRulebook.CorpusPath))
+        {
+            tmp = Path.Combine(Path.GetTempPath(), "housecarl-formlink-null-guard-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tmp);
+            Console.WriteLine($"corpus.json absent — generating into {tmp} (CI / fresh checkout)…");
+            var rc = CorpusGenerator.GenerateAll(Path.Combine(tmp, "generated"), Path.Combine(tmp, "refs"));
+            if (rc != 0) { Console.Error.WriteLine("error: corpus generation failed"); return rc; }
+            CorpusRulebook.CorpusPath = Path.Combine(tmp, "generated", "corpus.json");
+        }
+        try { return RunChecks(); }
+        finally { if (tmp is not null) { try { Directory.Delete(tmp, recursive: true); } catch { /* best-effort */ } } }
+    }
+
+    static int RunChecks()
+    {
+        int failures = 0;
+        void Check(string label, bool ok, string? detail = null)
+        {
+            Console.WriteLine($"  {(ok ? "PASS" : "FAIL")}  {label}{(ok || detail is null ? "" : $"\n        -> {detail}")}");
+            if (!ok) failures++;
+        }
+
+        Console.WriteLine("formlink-null-guard — FormLink null-clear (apply) + value-shape pre-flight (HCBR PR-F)");
+        Console.WriteLine();
+
+        // The two NPC formlinks under test, verified against the mutagen-reference schema (NOT assumed):
+        //   Race      — FormLink<IRaceGetter>          (NON-nullable / REQUIRED) -> arm E "required link clear"
+        //   DeathItem — FormLink<ILeveledItemGetter>?  (nullable)                -> arm D "clear via Set" + arm A
+        // Assert that nullability at RUNTIME so a Mutagen reshape that flips either can't pass green silently.
+        Check("S0: test fields have the expected nullability (Race required, DeathItem nullable)",
+            !IsNullableFormLink(typeof(INpc), "Race") && IsNullableFormLink(typeof(INpc), "DeathItem"));
+
+        static Npc FreshNpc() =>
+            new SkyrimMod(new ModKey("hc_formlink_null", ModType.Plugin), SkyrimRelease.SkyrimSE).Npcs.AddNew();
+        static FormKey Fk(object link) => ((IFormLinkGetter)link).FormKey;   // non-generic getter — works for nullable + required
+        static WriteRequest SetReq(string field, string value) =>
+            new() { RecordType = "Npc", Path = new[] { field }, Verb = "Set", Value = value };
+
+        // ---- A (accuracy CONTROL): a REAL 6-hex FormID is NOT swallowed as a null-clear — it round-trips to that
+        //      exact link. Guards against an over-broad recognizer (e.g. a prefix match on "0") that would clear a
+        //      real target. The scope's critic required a 6-hex form here, not the original 8-hex. GREEN before+after.
+        var real = FormKey.Factory("012345:Skyrim.esm");
+        bool aOk; string? aDetail;
+        try
+        {
+            var npc = FreshNpc();
+            WriteEngine.ApplyVerb(npc, SetReq("DeathItem", "012345:Skyrim.esm"));
+            aOk = Fk(npc.DeathItem) == real && !Fk(npc.DeathItem).IsNull;
+            aDetail = $"DeathItem.FormKey = {Fk(npc.DeathItem)} (expected {real})";
+        }
+        catch (Exception ex) { aOk = false; aDetail = $"{ex.GetType().Name}: {ex.Message}"; }
+        Check("A: a real 6-hex FormID round-trips, not swallowed as a null-clear", aOk, aDetail);
+
+        // ---- C (pre-flight): TOOTH C1 — a malformed FormLink value is now REJECTED at the gate (RED before: the
+        //      type-only CoercibilityReject accepted any value, then apply threw). C2/C3 are CONTROLS (a synonym and
+        //      a real FormID are still accepted) — they prove the new check rejects ONLY garbage, not legal values.
+        var rb = CorpusRulebook.Load();
+        var cBadErr = rb.Validate(SetReq("Race", "notaformkey"));
+        Check("C1: pre-flight REJECTS a malformed FormLink value (was accept-then-throw)",
+            cBadErr is not null && cBadErr.Contains("FormLink", StringComparison.OrdinalIgnoreCase),
+            cBadErr ?? "ACCEPTED — hole open");
+        Check("C2: pre-flight accepts a null-clear synonym ('00000000')", rb.Validate(SetReq("Race", "00000000")) is null,
+            rb.Validate(SetReq("Race", "00000000")));
+        Check("C3: pre-flight accepts a real FormID", rb.Validate(SetReq("DeathItem", "012345:Skyrim.esm")) is null,
+            rb.Validate(SetReq("DeathItem", "012345:Skyrim.esm")));
+
+        // ---- D (apply): Set a NULLABLE formlink to each null-synonym -> CLEARS it (FormKey.Null), no throw. The
+        //      ALL-ZEROS forms ("00000000"/"0") are the TEETH — RED before, because FormKey.Factory throws "Malformed
+        //      FormKey string" on them. The "Null"/"000000:Null" forms are CONTROLS: FormKey.Factory ALREADY parsed
+        //      those to FormKey.Null (verified by sabotage — they stay GREEN with the fix reverted), so they confirm
+        //      the recognizer routes the already-working spellings identically. All four are first-class clears now.
+        foreach (var syn in new[] { "00000000", "0", "Null", "000000:Null" })
+        {
+            bool dOk; string? dDetail;
+            try
+            {
+                var npc = FreshNpc();
+                WriteEngine.ApplyVerb(npc, SetReq("DeathItem", syn));
+                dOk = Fk(npc.DeathItem).IsNull;
+                dDetail = $"DeathItem.FormKey = {Fk(npc.DeathItem)}";
+            }
+            catch (Exception ex) { dOk = false; dDetail = $"{ex.GetType().Name}: {ex.Message}"; }
+            Check($"D: Set nullable FormLink = '{syn}' clears it (no throw)", dOk, dDetail);
+        }
+
+        // ---- E (apply TOOTH): the genuinely-NEW case. Set a REQUIRED (non-nullable) formlink to an ALL-ZEROS clear
+        //      ("Set Race = 00000000") -> clears to FormKey.Null. RED before (FormKey.Factory throws on all-zeros).
+        //      Uses an all-zeros form ON PURPOSE: "Null"/"000000:Null" already parsed via Factory, so they would NOT
+        //      prove the fix is load-bearing here. Distinct from Remove, which is invalid on a required link.
+        bool eOk; string? eDetail;
+        try
+        {
+            var npc = FreshNpc();
+            WriteEngine.ApplyVerb(npc, SetReq("Race", "00000000"));
+            eOk = Fk(npc.Race).IsNull;
+            eDetail = $"Race.FormKey = {Fk(npc.Race)}";
+        }
+        catch (Exception ex) { eOk = false; eDetail = $"{ex.GetType().Name}: {ex.Message}"; }
+        Check("E: Set Race = 00000000 clears a REQUIRED FormLink (the new all-zeros required-clear)", eOk, eDetail);
+
+        // ---- F (end-to-end): the real user path — clear a link with an all-zeros synonym, then SERIALIZE to a valid
+        //      patch (the clear actually persists to disk, not just in memory). RED before at the APPLY step (so it
+        //      shares D/E's apply tooth); the serialize half is what makes it end-to-end. Once a link is FormKey.Null
+        //      in memory, serialization is identical regardless of which synonym produced it.
+        var (fOk, fDetail) = TrySerialize("hc_formlink_null_f", mod =>
+        {
+            var npc = mod.Npcs.AddNew();
+            WriteEngine.ApplyVerb(npc, SetReq("Race", "00000000"));
+        });
+        Check("F: an all-zeros-cleared link serializes end-to-end to a valid patch", fOk, fDetail);
+
+        Console.WriteLine();
+        Console.WriteLine(failures == 0 ? "formlink-null-guard: ALL PASS" : $"formlink-null-guard: {failures} FAILURE(S)");
+        return failures == 0 ? 0 : 1;
+    }
+
+    /// <summary>Runtime nullability of a FormLink property: IFormLinkNullable&lt;&gt; vs IFormLink&lt;&gt; — the same
+    /// distinction the engine keys off in <see cref="WriteEngine"/>.<c>TryFormLink</c>. Keeps the probe honest if a
+    /// Mutagen version reshapes a field from required to nullable (or back).</summary>
+    static bool IsNullableFormLink(Type iface, string prop)
+    {
+        var pt = iface.GetProperty(prop)?.PropertyType;
+        if (pt is null || !pt.IsGenericType) return false;
+        return pt.GetGenericTypeDefinition().Name.StartsWith("IFormLinkNullable", StringComparison.Ordinal);
+    }
+
+    // --- serialize helper: a self-contained patch through the REAL WriteEngine.WritePatch (pure in-memory) ---
+
+    static string OutPath(string stem) =>
+        Path.Combine(Path.GetTempPath(), stem + "-" + Guid.NewGuid().ToString("N"), stem + ".esp");
+
+    static (bool ok, string? detail) TrySerialize(string stem, Action<SkyrimMod> build)
+    {
+        var outPath = OutPath(stem);
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(outPath)!);
+            var mod = new SkyrimMod(new ModKey(Path.GetFileNameWithoutExtension(outPath), ModType.Plugin), SkyrimRelease.SkyrimSE);
+            build(mod);
+            WriteEngine.WritePatch(mod, new ISkyrimModGetter[] { mod }, outPath);
+            var ok = File.Exists(outPath);
+            CleanOut(outPath);
+            return (ok, ok ? null : "no file written");
+        }
+        catch (Exception ex) { CleanOut(outPath); return (false, $"{ex.GetType().Name}: {ex.Message}"); }
+    }
+
+    static void CleanOut(string outPath)
+    {
+        try { var dir = Path.GetDirectoryName(outPath); if (dir is not null && Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+        catch { /* best-effort */ }
+    }
+}

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -76,6 +76,13 @@ if (args.Length > 0 && args[0] == "sameshape-agree-guard") return SameShapeAgree
 // genuinely-optional null poly field still serializes fine. Self-contained (in-memory Mutagen + generated corpus).
 if (args.Length > 0 && args[0] == "nullarm-guard") return NullArmGuardProbe.RunGuard(args[1..]);
 
+// FormLink null-clear (HCBR 1.6 / PR-F): a Set clearing a FormLink with a null-synonym ("00000000"/"0") threw at
+// apply (FormKey.Factory) while pre-flight ACCEPTED it (type-only CoercibilityReject) — a Q3 accept-then-throw hole,
+// and a required link had no clear path. ONE shared recognizer (IsFormKeyNullSynonym) routes a synonym to
+// FormKey.Null on apply and validates the formlink value shape at pre-flight; a real 6-hex FormID is never swallowed.
+// Self-contained: apply/serialize arms are pure in-memory Mutagen; pre-flight arms generate the corpus into a temp dir.
+if (args.Length > 0 && args[0] == "formlink-null-guard") return FormLinkNullProbe.RunGuard(args[1..]);
+
 // BSA bridge contract guard (2026-06-12 adversarial hunt): unpack success = entries THIS RUN (the pre-seeded
 // meta.ini no longer reads as success), pack provenance (stuck stale scratch refuses), unknown format= refuses.
 if (args.Length > 0 && args[0] == "bsa-contract-guard") return BsaContractProbe.RunGuard(args[1..]);


### PR DESCRIPTION
**HCBR-2026-06-15-01 item 1.6.** Closes the FormLink null-clear gap.

## The gap
A `Set` clearing a FormLink with a null-synonym (`00000000` / `0`) threw `Malformed FormKey string` at **apply** (`FormKey.Factory`), while **pre-flight accepted it** — the formlink arm's type-only `CoercibilityReject` never inspected the value. A Q3 accept-then-throw hole on every FormLink leaf; and a required link had no clear path at all.

## The fix (general FormLink family, by construction)
- **`WriteEngine`** — one shared recognizer `IsFormKeyNullSynonym` (`0` / `00000000` / `Null` / `000000:Null`; trimmed, case-insensitive, full-string). `ToFormKey` routes a synonym to `FormKey.Null` instead of `FormKey.Factory`; both `TryFormLink` arms (nullable + required) use it. A real 6-hex FormID is never swallowed.
- **`CorpusRulebook`** — the **formlink arm only** validates the value shape at the gate (`IsValidFormLinkValue`: a synonym **or** `FormKey.TryFactory`) — the *same* recognizer, so gate ↔ engine can't drift. The substruct arm keeps its type-shape `CoercibilityReject` (scoped tightening, per the scope's must-fix).

## Empirical finding (RED-proven by sabotage, baked into the guard)
Only the **all-zeros** spellings are newly-enabled — `FormKey.Factory` *already* parsed `Null` / `000000:Null` to `FormKey.Null`. So the scope's "Set Race = null" required-clear is a genuine tooth only via an all-zeros form (`Set Race = 00000000`); the `Null` rows are controls confirming the recognizer routes the already-working spellings identically. (Same lesson as PR-E — verify the format claim, don't trust the prose.) Distinct from `Remove` (clears a nullable link to C# null, invalid on a required link) — untouched.

## Guard — `formlink-null-guard` (+1 CI probe → 38)
Teeth RED-proven by two targeted sabotages:
- **C1** — pre-flight now rejects a malformed value (apply-independent).
- **D**-allzeros / **E** / **F** — apply clears a nullable link / a REQUIRED link / end-to-end through serialize.

Controls green before+after: **A** (real 6-hex FormID not swallowed — the accuracy guard), **C2/C3**, **S0** (field nullability), **D**-`Null`. Self-contained (in-memory Mutagen + generated corpus). Adjacent `floi-read-guard` + `nullarm-guard` still pass; full Release build clean.

## Files
`WriteEngine.cs`, `CorpusRulebook.cs`, new `FormLinkNullProbe.cs`, `Program.cs` (dispatch), `ci.yml` (step).

§4 = (a) — same shared-predicate shape as the existing FLOI handling; no per-record-type wiring; cornerstone untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
