### PR TITLE
gendered-leaf-hint: gendered-aware LEAF-bracket rejection (HCBR-2026-06-15-01 / PR-H follow-up)

### DIFF
--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -186,8 +186,20 @@ public sealed class CorpusRulebook
         // (3) the leaf field — a bracketed LEAF is rejected (brackets navigate mid-path only; the leaf uses Key).
         if (!TrySeg(req.Path[^1], out var leafName, out var leafKey, out var leafErr)) return leafErr;
         if (leafKey is not null)
+        {
+            // A gendered field bracketed at the LEAF (Set Priority[0]) is NOT a list/dict — the renderer SHOWS [0]/[1]
+            // but the halves are reached/set BY NAME, so point at .Male/.Female, not the list-verb message below (which
+            // would mis-route the user to SetAtIndex/Set/Remove + Key on a field that takes none of them). Same corpus-
+            // side "GenderedItem<" recogniser as the mid-path hop above; its engine twin is WriteEngine.GenderedInterface
+            // in ApplyVerb's leaf throw — two recognisers that must agree. (HCBR-2026-06-15-01 PR-H follow-up: the leaf
+            // seam of the mid-path scalar hint.)
+            if (FindField(current, leafName, out _, out _) is { Cardinality: "substruct", TypeRef: { } ltr }
+                && ltr.StartsWith("GenderedItem<", StringComparison.Ordinal))
+                return $"Gendered field '{leafName}' on '{current.Name}' renders as [0]/[1] but is not a list — set its " +
+                       $"halves by name: '{leafName}.Male' (=[0]) / '{leafName}.Female' (=[1]).";
             return $"Path '{req.Path[^1]}' brackets a collection element at the LEAF; brackets navigate mid-path only. " +
                    "To edit a list/dict element, target the collection field and use the verb + Key (SetAtIndex/Set/Remove).";
+        }
         var leaf = FindField(current, leafName, out var leafOwner, out var leafPolyErr);
         if (leafPolyErr is not null) return leafPolyErr;
         if (leaf is null) return FieldNotFound(current, leafName);

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1496,10 +1496,20 @@ public static class WriteEngine
         }
         var (leafName, leafKey) = ParseSegment(req.Path[^1]);
         if (leafKey is not null)
+        {
+            // A gendered field at the LEAF (Set Priority[0]) renders as [0]/[1] but is NOT a list/dict — redirect to the
+            // named halves, not the list-verb message. Runtime twin of CorpusRulebook's "GenderedItem<" leaf recogniser
+            // (two recognisers that must agree). Pre-flight normally gates this first; the engine keeps the message honest
+            // for any direct / CLI --op call that bypasses pre-flight. (HCBR-2026-06-15-01 PR-H follow-up.)
+            if (ResolveProperty(current.GetType(), leafName) is { } gp && GenderedInterface(gp.PropertyType) is not null)
+                throw new InvalidOperationException(
+                    $"Gendered field '{leafName}' on {current.GetType().Name} renders as [0]/[1] but is not a list — set " +
+                    $"its halves by name: '{leafName}.Male' (=[0]) / '{leafName}.Female' (=[1]).");
             throw new InvalidOperationException(
                 $"Path segment '{req.Path[^1]}' brackets a collection element at the LEAF. Brackets navigate mid-path " +
                 "only; to operate on a list/dict element at the leaf, use the verb + Key (SetAtIndex/Remove by index, " +
                 "or Set/Remove by dict key).");
+        }
         var leaf = ResolveProperty(current.GetType(), leafName)
             ?? throw new InvalidOperationException($"No property '{leafName}' on {current.GetType().Name}");
 

--- a/src/housecarl-generator/GenderedNavProbe.cs
+++ b/src/housecarl-generator/GenderedNavProbe.cs
@@ -226,12 +226,16 @@ public static class GenderedNavProbe
 
         // ---- C-LEAF (control): a NON-gendered (real list) field bracketed at the LEAF still gets the GENERIC leaf-bracket
         //      message, NOT the gendered by-name hint — the new leaf branch is gated on the GenderedItem recogniser and
-        //      doesn't leak to list/dict leaves. Green before AND after the fix. ----
+        //      doesn't leak to list/dict leaves. Pre-flight AND the engine (the list-leaf engine fallthrough, symmetric
+        //      with A4-LEAF). Green before AND after the fix. ----
         var listLeafPf = rb.Validate(Set("Armor", "Keywords[0]", "012345:Skyrim.esm"));
-        Check("C-LEAF: a list field at the leaf (Keywords[0]) keeps the generic leaf message (gendered branch gated)",
-            listLeafPf is not null && listLeafPf.Contains("LEAF", StringComparison.Ordinal)
-            && !listLeafPf.Contains("by name", StringComparison.OrdinalIgnoreCase),
-            $"preflight={listLeafPf}");
+        string? listLeafEngineMsg = null;
+        try { WriteEngine.ApplyVerb(FreshArmor(), Set("Armor", "Keywords[0]", "012345:Skyrim.esm")); }
+        catch (Exception ex) { listLeafEngineMsg = ex.Message; }
+        Check("C-LEAF: a list field at the leaf (Keywords[0]) keeps the generic leaf message at pre-flight AND the engine (gendered branch gated)",
+            listLeafPf is not null && listLeafPf.Contains("LEAF", StringComparison.Ordinal) && !listLeafPf.Contains("by name", StringComparison.OrdinalIgnoreCase)
+            && listLeafEngineMsg is not null && listLeafEngineMsg.Contains("LEAF", StringComparison.Ordinal) && !listLeafEngineMsg.Contains("by name", StringComparison.OrdinalIgnoreCase),
+            $"preflight={listLeafPf}\n        -> engine={listLeafEngineMsg}");
 
         // ---- VTYPE (by-construction Q3 guard — the orphan trap, corpus-wide): every gendered arm pre-flight ACCEPTS
         //      for descent (a corpus-resolvable arm type) MUST be a REFERENCE type. A VALUE-type arm would be returned

--- a/src/housecarl-generator/GenderedNavProbe.cs
+++ b/src/housecarl-generator/GenderedNavProbe.cs
@@ -32,8 +32,11 @@ namespace HousecarlGenerator;
 /// ACCEPTS the bracket write), A2 (bracket WRITE lands AND the materialized arm is read back via the NAMED arm — the
 /// write-back/orphan tooth), A3 (the rendered [0]/[1] path re-feeds to the SHOWN value — render↔navigate agreement),
 /// A4-IDX (a bad index [2] is refused with the gendered hint), A4-SCALAR (stepping into a scalar/value arm is refused,
-/// naming the by-name fix), SER (a bracket-written arm PERSISTS through serialize→reopen). CONTROLS (green before+after):
-/// A4-SUB (a non-gendered substruct bracket stays refused — the gendered branch is gated, doesn't leak), C-LIST (a real
+/// naming the by-name fix), A4-LEAF (a gendered field bracketed at the LEAF — <c>Priority[0]</c> — is refused naming
+/// .Male/.Female, NOT the generic list-verb message; the leaf seam of A4-SCALAR — PR-H follow-up, Aaron finding #1),
+/// SER (a bracket-written arm PERSISTS through serialize→reopen). CONTROLS (green before+after):
+/// A4-SUB (a non-gendered substruct bracket stays refused — the gendered branch is gated, doesn't leak), C-LEAF (a
+/// list field bracketed at the leaf keeps the generic message — the leaf gendered branch is gated too), C-LIST (a real
 /// list element still navigates — the StepIntoElement refactor didn't break list nav), SET (the settability fact the
 /// materialize-write-back relies on — GenderedItem&lt;T&gt;.Male is settable; the named-from-null path materializes it).
 ///
@@ -79,6 +82,8 @@ public static class GenderedNavProbe
         // ---- helpers --------------------------------------------------------
         static Armor FreshArmor() =>
             new SkyrimMod(new ModKey("hc_gendered_nav", ModType.Plugin), SkyrimRelease.SkyrimSE).Armors.AddNew();
+        static ArmorAddon FreshArmorAddon() =>
+            new SkyrimMod(new ModKey("hc_gendered_nav", ModType.Plugin), SkyrimRelease.SkyrimSE).ArmorAddons.AddNew();
         static WriteRequest Set(string recordType, string dotted, string value) => new()
         {
             RecordType = recordType,
@@ -204,6 +209,29 @@ public static class GenderedNavProbe
             scalPf is not null && scalPf.Contains("by name", StringComparison.OrdinalIgnoreCase)
             && flPf is not null && flPf.Contains("by name", StringComparison.OrdinalIgnoreCase),
             $"Priority[0]={scalPf}\n        -> SkinTexture[0]={flPf}");
+
+        // ---- A4-LEAF (tooth — gendered field bracketed at the LEAF): `Set Priority[0]` with NO trailing segment is
+        //      refused naming the by-name fix (.Male/.Female), NOT the generic list-verb (SetAtIndex/Set/Remove + Key)
+        //      message — a gendered field is not a list/dict and takes none of those. RED before: it fell to the generic
+        //      LEAF-bracket message (no by-name hint). The leaf seam of A4-SCALAR (mid-path scalar already named the fix;
+        //      this closes the pure-leaf case — Aaron finding #1, PR-H follow-up). Pre-flight AND the engine must agree. ----
+        var leafPf = rb.Validate(Set("ArmorAddon", "Priority[0]", "1"));
+        string? leafEngineMsg = null;
+        try { WriteEngine.ApplyVerb(FreshArmorAddon(), Set("ArmorAddon", "Priority[0]", "1")); }
+        catch (Exception ex) { leafEngineMsg = ex.Message; }
+        Check("A4-LEAF: a gendered field at the LEAF (Priority[0]) is refused naming .Male/.Female, at pre-flight AND the engine",
+            leafPf is not null && leafPf.Contains("by name", StringComparison.OrdinalIgnoreCase) && leafPf.Contains(".Male", StringComparison.OrdinalIgnoreCase)
+            && leafEngineMsg is not null && leafEngineMsg.Contains("by name", StringComparison.OrdinalIgnoreCase) && leafEngineMsg.Contains(".Male", StringComparison.OrdinalIgnoreCase),
+            $"preflight={leafPf}\n        -> engine={leafEngineMsg}");
+
+        // ---- C-LEAF (control): a NON-gendered (real list) field bracketed at the LEAF still gets the GENERIC leaf-bracket
+        //      message, NOT the gendered by-name hint — the new leaf branch is gated on the GenderedItem recogniser and
+        //      doesn't leak to list/dict leaves. Green before AND after the fix. ----
+        var listLeafPf = rb.Validate(Set("Armor", "Keywords[0]", "012345:Skyrim.esm"));
+        Check("C-LEAF: a list field at the leaf (Keywords[0]) keeps the generic leaf message (gendered branch gated)",
+            listLeafPf is not null && listLeafPf.Contains("LEAF", StringComparison.Ordinal)
+            && !listLeafPf.Contains("by name", StringComparison.OrdinalIgnoreCase),
+            $"preflight={listLeafPf}");
 
         // ---- VTYPE (by-construction Q3 guard — the orphan trap, corpus-wide): every gendered arm pre-flight ACCEPTS
         //      for descent (a corpus-resolvable arm type) MUST be a REFERENCE type. A VALUE-type arm would be returned


### PR DESCRIPTION
## What

Closes the carved-out **PR-H follow-up (Aaron finding #1)**: make the gendered field **leaf**-bracket rejection point at `.Male`/`.Female`, not the generic list-verb message.

`Set Priority[0]` — a `GenderedItem<T>` field bracketed at the **leaf** (no trailing segment) — used to return *"…use the verb + Key (SetAtIndex/Set/Remove)"*, verbs a gendered field takes none of. The mid-path scalar hop (`Priority[0].Anything`, guard tooth **A4-SCALAR**) already named the by-name fix; this closes the pure-leaf seam.

## How

Two recognizers that agree — the established PR-H shape, never one shared schema-blind classifier:

- **Pre-flight** — `CorpusRulebook` leaf check keys off the corpus-side `"GenderedItem<"` TypeRef.
- **Engine** — `WriteEngine.ApplyVerb`'s leaf throw keys off the runtime `GenderedInterface`.

Both now redirect to `'Field.Male' (=[0]) / 'Field.Female' (=[1])`. Non-gendered leaves fall through to the **unchanged** generic message.

## Proof

- **A4-LEAF** (new tooth) — RED-proven against base `d905379`: both pre-flight AND engine emitted the generic `SetAtIndex/Key` message; GREEN after.
- **C-LEAF** (new control) — a real list leaf (`Keywords[0]`) keeps the generic message, proving the gendered branch is gated and doesn't leak.
- `gendered-nav-guard`: **16/16 ALL PASS**. Full solution + MCP project build clean (0 warnings, 0 errors).

## Scope

Message/ergonomics only; recognizer-gated; no public signature change. **Not** one of the 13 HCBR fix units — the count stays **4/13**. §4-(a) (Q3 — "what we show must work"); cornerstone untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)