### PR TITLE
PR-I (HCBR 9.2): surface MO2 instance path + read any profile without switching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,14 @@ jobs:
       - name: Probe — gendered-item [0]/[1] navigable alias, read+write (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- gendered-nav-guard
 
+      # Instance-describe + named-profile read (HCBR-2026-06-15-01 item 9.2 / PR-I): load_order_status surfaces the resolved
+      # MO2 instance PATH (same gated snapshot as the rest of the status line) and inspects any sibling profile's composition
+      # WITHOUT switching to it — cheap text parse (no record-index build), explicit-paths mode refuses loud (no profiles
+      # root), an unknown name lists the available ones (Q3). Asserts both the service data AND the rendered text the user
+      # sees. Self-contained — synthetic MO2 instances + one synthesized master plugin in temp, no game data / no corpus.
+      - name: Probe — load-order-status instance path + named-profile read (self-contained regression guard)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- loadorder-status-guard
+
       # The compile tool's import ORDER is semantics (the CK compiler takes the FIRST matching .psc), so caller
       # import_dirs must outrank the auto-added vanilla folder — else SKSE-extended copies of vanilla scripts lose
       # to vanilla and extended calls fail despite the right folder being passed (spike findings §5.12, hit twice).

--- a/src/housecarl-generator/LoadOrderStatusProbe.cs
+++ b/src/housecarl-generator/LoadOrderStatusProbe.cs
@@ -29,6 +29,8 @@ namespace HousecarlGenerator;
 ///      so the redirect is honored BY CONSTRUCTION — guards against a future re-derivation from the instance dir).
 ///   H  stray-folder filter — a folder under profiles/ with no loadorder.txt (never-opened profile / backup dir) is NOT
 ///      listed or matched, so it can't be offered or read back as an all-zero phantom profile (Q3 — pre-push review fold).
+///   I  inspected-read warnings — a profile with loadorder.txt but no modlist.txt surfaces the read warning under the
+///      inspection block, so a 0-enabled-mods render is never silently mistaken for a genuinely-empty profile (review fold).
 ///
 /// Self-contained: synthetic MO2 instances + one synthesized master plugin in temp; no game data, no corpus (reads only).
 /// </summary>
@@ -201,6 +203,25 @@ internal static class LoadOrderStatusProbe
                 var miss = svc.NamedProfileComposition("_NotAProfile");
                 Check(miss.InstanceMode && miss.Composition is null,
                       "requesting the stray folder is a clean not-found, not an all-zero composition");
+            }
+
+            // ---- I: an inspected profile missing modlist.txt surfaces a read warning, not a silent 0-mods (review-fold note 1) ----
+            Console.WriteLine();
+            Console.WriteLine("--- I: a profile with loadorder.txt but no modlist.txt surfaces a warning (not silently 0-mods) ---");
+            string instI = MakeInstance("inst-i");
+            WriteProfile(Path.Combine(instI, "profiles", "Default"), new[] { masterName }, new[] { "*" + masterName }, new[] { "+MasterMod" });
+            string profI = Path.Combine(instI, "profiles", "Partial");   // loadorder.txt + plugins.txt present, modlist.txt deliberately ABSENT
+            Directory.CreateDirectory(profI);
+            File.WriteAllText(Path.Combine(profI, "loadorder.txt"), "# header\r\n" + masterName + "\r\n");
+            File.WriteAllText(Path.Combine(profI, "plugins.txt"), "*" + masterName + "\r\n");
+            using (var svc = LoadOrderService.WithInstance(instI, 0, store))
+            {
+                var partial = svc.NamedProfileComposition("Partial");
+                Check(partial.Composition is not null, "the partial profile still reads (loadorder.txt present → listed + matched)");
+                Check(partial.Warnings.Any(w => w.Contains("modlist.txt", StringComparison.OrdinalIgnoreCase)),
+                      "the missing modlist.txt is surfaced as a read warning (not a silent 0-mods composition)");
+                var text = Render(svc, partial, "Partial");
+                Check(text.Contains("[!]") && text.Contains("modlist.txt"), "render shows the warning under the inspection block");
             }
         }
         finally { try { Directory.Delete(root, recursive: true); } catch { /* temp scratch */ } }

--- a/src/housecarl-generator/LoadOrderStatusProbe.cs
+++ b/src/housecarl-generator/LoadOrderStatusProbe.cs
@@ -27,6 +27,8 @@ namespace HousecarlGenerator;
 ///   F  discovery — no name in instance mode lists the available profiles; the default status renders the discovery line.
 ///   G  base_directory redirect — profiles under a redirected base are still found (root = parent of the derived ProfileDir,
 ///      so the redirect is honored BY CONSTRUCTION — guards against a future re-derivation from the instance dir).
+///   H  stray-folder filter — a folder under profiles/ with no loadorder.txt (never-opened profile / backup dir) is NOT
+///      listed or matched, so it can't be offered or read back as an all-zero phantom profile (Q3 — pre-push review fold).
 ///
 /// Self-contained: synthetic MO2 instances + one synthesized master plugin in temp; no game data, no corpus (reads only).
 /// </summary>
@@ -183,6 +185,22 @@ internal static class LoadOrderStatusProbe
                       "a profile under the redirected base_directory is found and read correctly");
                 Check(second.AvailableProfiles.Contains("Default") && second.AvailableProfiles.Contains("Second"),
                       "the profiles root resolved through base_directory (both siblings enumerated)");
+            }
+
+            // ---- H: a stray / never-opened folder under profiles/ (no loadorder.txt) is NOT offered or matched ----
+            Console.WriteLine();
+            Console.WriteLine("--- H: a folder under profiles/ with no loadorder.txt is skipped (Q3 — never an all-zero phantom profile) ---");
+            string instH = MakeInstance("inst-h");
+            WriteProfile(Path.Combine(instH, "profiles", "Default"), new[] { masterName }, new[] { "*" + masterName }, new[] { "+MasterMod" });
+            Directory.CreateDirectory(Path.Combine(instH, "profiles", "_NotAProfile"));   // a stray dir — no loadorder.txt (e.g. a backup or never-opened profile)
+            using (var svc = LoadOrderService.WithInstance(instH, 0, store))
+            {
+                var disc = svc.NamedProfileComposition(null);
+                Check(disc.AvailableProfiles.Contains("Default") && !disc.AvailableProfiles.Contains("_NotAProfile"),
+                      "the stray folder is excluded from the available profiles (only loadorder.txt-bearing dirs)");
+                var miss = svc.NamedProfileComposition("_NotAProfile");
+                Check(miss.InstanceMode && miss.Composition is null,
+                      "requesting the stray folder is a clean not-found, not an all-zero composition");
             }
         }
         finally { try { Directory.Delete(root, recursive: true); } catch { /* temp scratch */ } }

--- a/src/housecarl-generator/LoadOrderStatusProbe.cs
+++ b/src/housecarl-generator/LoadOrderStatusProbe.cs
@@ -1,0 +1,194 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// Instance-describe + named-profile read guard (HCBR-2026-06-15-01 item 9.2 / PR-I). housecarl_load_order_status used to
+/// report the profile NAME but never the resolved INSTANCE PATH (which MO2 instance houseCARL is pointed at — easy to lose
+/// track of), and it could not inspect an INACTIVE profile. The fix surfaces the instance path and adds a profile= read
+/// that reports any sibling profile's composition WITHOUT switching to it. The Q3 hazards this guards:
+///   • the instance path must come from the SAME gated snapshot as the rest of the status line (never re-derived);
+///   • inspecting an inactive profile must NOT switch the active profile and must NOT build the record index (cheap text
+///     parse only);
+///   • an unknown profile name must NAME the available options, never render a silently-empty composition;
+///   • explicit-paths mode has no profiles root, so a named read must refuse LOUD there, never enumerate an arbitrary dir.
+///
+/// Arms (each asserts the service DATA and the RENDERED text the user actually sees):
+///   A  instance path surfaced — instance mode: StatusData().InstanceDir == the configured folder; header renders "instance: &lt;path&gt;".
+///   B  explicit-paths mode — a REAL WithExplicitPaths service (not ForGuard): InstanceDir == null; header renders "explicit-paths mode".
+///   C  named/inactive read — a two-profile instance (Default active, Second inactive, DISTINCT comps): profile='Second'
+///      returns Second's composition (≠ Default's), the active profile stays 'Default' (no switch), match is case-insensitive.
+///   D  not found — an unknown name yields no composition but NAMES the available profiles (Q3); the render says so.
+///   E  explicit refusal — WithExplicitPaths + a named read refuses loud (InstanceMode false); the render explains why.
+///   F  discovery — no name in instance mode lists the available profiles; the default status renders the discovery line.
+///   G  base_directory redirect — profiles under a redirected base are still found (root = parent of the derived ProfileDir,
+///      so the redirect is honored BY CONSTRUCTION — guards against a future re-derivation from the instance dir).
+///
+/// Self-contained: synthetic MO2 instances + one synthesized master plugin in temp; no game data, no corpus (reads only).
+/// </summary>
+internal static class LoadOrderStatusProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" load-order-status guard — instance path + named/inactive-profile read (9.2)");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        var root = Path.Combine(Path.GetTempPath(), "hc-losstatus-guard-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root, "game", "Data"));   // the ini's gamePath target (shared)
+
+            // ---- one synthesized master plugin (so the active order resolves to real bytes for StatusData) ----
+            var masterKey = new ModKey("HcLosMaster", ModType.Master);
+            var extraKey = new ModKey("HcLosExtra", ModType.Plugin);
+            string masterName = masterKey.FileName.String, extraName = extraKey.FileName.String;
+            var masterFile = Path.Combine(root, masterName);
+            var master = new SkyrimMod(masterKey, SkyrimRelease.SkyrimSE);
+            var w = master.Weapons.AddNew(); w.EditorID = "HcLosW0"; w.BasicStats = new WeaponBasicStats { Damage = 10, Weight = 1 };
+            master.BeginWrite.ToPath(masterFile).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+            var logs = Array.Empty<LogFolderView>();   // render needs a log list; the log surface is out of scope here
+            string Render(LoadOrderService svc, NamedProfileResult profiles, string? profileReq) =>
+                StatusWire.Render(svc.StatusData(), logs, profiles, lookup: null, cap: 80_000);
+
+            void WriteIni(string inst, string profile, string? baseDir = null)
+            {
+                var b = baseDir is null ? "" : "base_directory=@ByteArray(" + baseDir.Replace(@"\", @"\\") + ")\r\n";
+                File.WriteAllText(Path.Combine(inst, Mo2Instance.IniFileName),
+                    "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(" + profile + ")\r\ngamePath=@ByteArray("
+                    + Path.Combine(root, "game").Replace(@"\", @"\\") + ")\r\n" + (baseDir is null ? "" : "[Settings]\r\n" + b));
+            }
+            void WriteProfile(string profDir, string[] loadorder, string[] plugins, string[] modlist)
+            {
+                Directory.CreateDirectory(profDir);
+                File.WriteAllText(Path.Combine(profDir, "loadorder.txt"), "# header\r\n" + string.Join("\r\n", loadorder) + "\r\n");
+                File.WriteAllText(Path.Combine(profDir, "plugins.txt"), string.Join("\r\n", plugins) + "\r\n");
+                File.WriteAllText(Path.Combine(profDir, "modlist.txt"), "# header\r\n" + string.Join("\r\n", modlist) + "\r\n");
+            }
+            // A usable instance under baseRoot (mods/ + profiles/ live there): mods/MasterMod has the master bytes.
+            string MakeInstance(string name, string? baseDir = null)
+            {
+                var inst = Path.Combine(root, name);
+                var b = baseDir ?? inst;
+                Directory.CreateDirectory(Path.Combine(b, "mods", "MasterMod"));
+                File.Copy(masterFile, Path.Combine(b, "mods", "MasterMod", masterName));
+                Directory.CreateDirectory(inst);
+                WriteIni(inst, "Default", baseDir);
+                return inst;
+            }
+
+            // ---- A: instance mode surfaces the resolved instance path ----
+            Console.WriteLine("--- A: instance path surfaced (instance mode) ---");
+            string instA = MakeInstance("inst-a");
+            WriteProfile(Path.Combine(instA, "profiles", "Default"), new[] { masterName }, new[] { "*" + masterName }, new[] { "+MasterMod" });
+            // One store, shared by every arm: nothing here calls SetInstance / set_tool_path, so houseCARL.user.json is
+            // never written — each arm points a fresh service at its own synthetic instance.
+            var store = new UserConfigStore(Path.Combine(root, "user.json"));
+            using (var svc = LoadOrderService.WithInstance(instA, 0, store))
+            {
+                var data = svc.StatusData();
+                Check(data.InstanceDir == instA, $"InstanceDir == the configured instance folder (got '{data.InstanceDir}')");
+                Check(data.ProfileName == "Default", $"ProfileName == 'Default' (got '{data.ProfileName}')");
+                var text = Render(svc, svc.NamedProfileComposition(null), null);
+                Check(text.Contains("instance: " + instA), "rendered header carries the 'instance: <path>' line");
+            }
+
+            // ---- B: explicit-paths mode renders "explicit-paths mode" (REAL WithExplicitPaths, not ForGuard) ----
+            Console.WriteLine();
+            Console.WriteLine("--- B: explicit-paths mode (InstanceDir null) — real WithExplicitPaths over synthesized plugins ---");
+            string instB = MakeInstance("inst-b");
+            string profB = Path.Combine(instB, "profiles", "Default");
+            WriteProfile(profB, new[] { masterName }, new[] { "*" + masterName }, new[] { "+MasterMod" });
+            using (var svc = LoadOrderService.WithExplicitPaths(Path.Combine(root, "game", "Data"), Path.Combine(instB, "mods"), profB, 0, store))
+            {
+                var data = svc.StatusData();
+                Check(data.InstanceDir is null, "explicit-paths mode → InstanceDir is null");
+                var text = Render(svc, svc.NamedProfileComposition(null), null);
+                Check(text.Contains("explicit-paths mode"), "rendered header shows 'explicit-paths mode' (not a bogus path)");
+            }
+
+            // ---- C: named/inactive read — Second's composition, active profile unchanged ----
+            Console.WriteLine();
+            Console.WriteLine("--- C: inspect an INACTIVE profile without switching to it ---");
+            string instC = MakeInstance("inst-c");
+            WriteProfile(Path.Combine(instC, "profiles", "Default"), new[] { masterName }, new[] { "*" + masterName }, new[] { "+MasterMod" });
+            WriteProfile(Path.Combine(instC, "profiles", "Second"), new[] { masterName, extraName },
+                         new[] { "*" + masterName, "*" + extraName }, new[] { "+MasterMod", "+ExtraMod" });
+            using (var svc = LoadOrderService.WithInstance(instC, 0, store))
+            {
+                var second = svc.NamedProfileComposition("Second");
+                Check(second.InstanceMode && second.Composition is not null, "Second resolved (instance mode, composition present)");
+                Check(second.Composition!.EnabledMods.Count == 2, $"Second sees 2 enabled mods (got {second.Composition.EnabledMods.Count})");
+                Check(second.Composition.ActivePluginNames.Contains(extraName), "Second's active plugins include the extra plugin");
+                Check(svc.ProfileName == "Default", $"the active profile is STILL 'Default' — the named read did not switch (got '{svc.ProfileName}')");
+
+                var def = svc.NamedProfileComposition("Default");
+                Check(def.Composition!.EnabledMods.Count == 1, $"Default sees 1 enabled mod — the two profiles are genuinely DISTINCT (got {def.Composition.EnabledMods.Count})");
+                Check(svc.NamedProfileComposition("second").Composition is not null, "name match is case-insensitive ('second' finds 'Second')");
+
+                var text = Render(svc, second, "Second");
+                Check(text.Contains("inspecting profile 'Second'") && text.Contains("active profile is unchanged"),
+                      "render shows the named inspection and states the active profile is unchanged");
+
+                // ---- D: not-found names the available profiles (Q3), never a silent empty composition ----
+                Console.WriteLine();
+                Console.WriteLine("--- D: an unknown profile name lists the available ones (Q3) ---");
+                var nf = svc.NamedProfileComposition("Nope");
+                Check(nf.InstanceMode && nf.Composition is null, "unknown name → no composition (not a silent empty)");
+                Check(nf.AvailableProfiles.Contains("Default") && nf.AvailableProfiles.Contains("Second"), "not-found result NAMES the available profiles");
+                var nfText = Render(svc, nf, "Nope");
+                Check(nfText.Contains("not found") && nfText.Contains("Default") && nfText.Contains("Second"),
+                      "render says 'not found' and lists the real options");
+
+                // ---- F: discovery line in the default status ----
+                Console.WriteLine();
+                Console.WriteLine("--- F: the default status lists the available profiles (discovery) ---");
+                var disc = svc.NamedProfileComposition(null);
+                Check(disc.InstanceMode && disc.RequestedName is null && disc.AvailableProfiles.Count == 2, "no name → discovery list of both profiles");
+                var discText = Render(svc, disc, null);
+                Check(discText.Contains("profiles available"), "default status renders the 'profiles available' discovery line");
+            }
+
+            // ---- E: explicit-paths mode refuses a named read LOUD (no profiles root) ----
+            Console.WriteLine();
+            Console.WriteLine("--- E: explicit-paths mode refuses a named-profile read (no profiles root) ---");
+            using (var svc = LoadOrderService.WithExplicitPaths(Path.Combine(root, "game", "Data"), Path.Combine(instB, "mods"), profB, 0, store))
+            {
+                var r = svc.NamedProfileComposition("whatever");
+                Check(!r.InstanceMode && r.Composition is null, "explicit mode → named read refused (InstanceMode false, no composition)");
+                var text = Render(svc, r, "whatever");
+                Check(text.Contains("MO2-instance mode"), "render explains the named read needs instance mode");
+            }
+
+            // ---- G: base_directory redirect — profiles under the redirected base are still found (by construction) ----
+            Console.WriteLine();
+            Console.WriteLine("--- G: base_directory redirect — root = parent of the derived ProfileDir (honored by construction) ---");
+            string baseG = Path.Combine(root, "base-g");
+            string instG = MakeInstance("inst-g", baseDir: baseG);   // mods/ + profiles/ live under baseG, ini points there
+            WriteProfile(Path.Combine(baseG, "profiles", "Default"), new[] { masterName }, new[] { "*" + masterName }, new[] { "+MasterMod" });
+            WriteProfile(Path.Combine(baseG, "profiles", "Second"), new[] { masterName, extraName },
+                         new[] { "*" + masterName, "*" + extraName }, new[] { "+MasterMod", "+ExtraMod" });
+            using (var svc = LoadOrderService.WithInstance(instG, 0, store))
+            {
+                var second = svc.NamedProfileComposition("Second");
+                Check(second.InstanceMode && second.Composition is not null && second.Composition.EnabledMods.Count == 2,
+                      "a profile under the redirected base_directory is found and read correctly");
+                Check(second.AvailableProfiles.Contains("Default") && second.AvailableProfiles.Contains("Second"),
+                      "the profiles root resolved through base_directory (both siblings enumerated)");
+            }
+        }
+        finally { try { Directory.Delete(root, recursive: true); } catch { /* temp scratch */ } }
+
+        Console.WriteLine();
+        Console.WriteLine(fail == 0 ? "================ ALL PASS ================" : $"================ {fail} CHECK(S) FAILED ================");
+        return fail == 0 ? 0 : 1;
+    }
+}

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -105,6 +105,12 @@ if (args.Length > 0 && args[0] == "write-mutex-guard") return WriteMutexProbe.Ru
 // read's freshness refresh defers while a write is in flight (never rebuilds under a serialize).
 if (args.Length > 0 && args[0] == "freshness-capture-guard") return FreshnessCaptureProbe.RunGuard(args[1..]);
 
+// Instance-describe + named-profile read (HCBR-2026-06-15-01 item 9.2 / PR-I): load_order_status now surfaces the
+// resolved MO2 instance PATH (captured in the same gated snapshot) and reads any sibling profile's composition WITHOUT
+// switching (cheap text parse, no index build) — explicit-paths mode refuses loud (no profiles root), an unknown name
+// names the available ones (Q3). Self-contained: synthetic instances + one synthesized master, no game data / no corpus.
+if (args.Length > 0 && args[0] == "loadorder-status-guard") return LoadOrderStatusProbe.RunGuard(args[1..]);
+
 // MO2 overwrite-folder resolution (2026-06-12 hunt F9): plugins living in MO2's overwrite layer resolve at
 // HIGHEST priority (top of the VFS — where Synthesis/xEdit tool outputs land), and the can't-resolve warning
 // names overwrite among the places searched.

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -435,17 +435,19 @@ public sealed class LoadOrderService : IDisposable
         // concurrent freshness rebuild landing in that gap could compose one status line from TWO adjacent builds —
         // the count from one, the warnings beside it from another. The fresh composition stays OUTSIDE the gate by
         // design (it is documented as always-current and is not judged against the resolver's build).
-        LoadOrderResolver.IndexView view; IReadOnlyList<string> warnings; bool profileChanged; string profileDir;
+        LoadOrderResolver.IndexView view; IReadOnlyList<string> warnings; bool profileChanged; string profileDir; string profileName; string? instanceDir;
         lock (_gate)
         {
             view = Resolver.Capture();                             // force build/refresh; ONE build for count + exclusions (HCBR-2026-06-11-02)
             warnings = _orderWarnings;
             profileChanged = ProfileFilesChanged();
             profileDir = _profileDir;
+            profileName = _profileName;                            // captured under the SAME gate (hunt F6) — one snapshot, never re-derived at render
+            instanceDir = _instanceDir;                            // the configured MO2 instance folder; null ⇒ explicit-paths / unconfigured mode
         }
         var comp = Mo2LoadOrder.ReadComposition(profileDir);       // FRESH composition (always current)
         return new LoadOrderStatusData(
-            comp, warnings, view.PluginCount, _maxPlugins, profileChanged, profileDir, view.ExcludedPlugins);
+            comp, warnings, view.PluginCount, _maxPlugins, profileChanged, profileDir, profileName, instanceDir, view.ExcludedPlugins);
     }
 
     /// <summary>True if any of the three MO2 profile files' mtimes DIFFERS from the last build's baseline — the user
@@ -1590,6 +1592,8 @@ public sealed record LoadOrderStatusData(
     int MaxPlugins,
     bool ProfileChanged,
     string ProfileDir,
+    string ProfileName,         // the ACTIVE profile (instance mode: MO2's selected_profile; explicit: the dir name) — captured under the gate, not re-derived at render
+    string? InstanceDir,        // the resolved MO2 instance folder houseCARL is pointed at; null ⇒ explicit-paths / unconfigured mode
     IReadOnlyDictionary<string, string> ExcludedPlugins);
 
 /// <summary>One queried asset path's resolution behind housecarl_asset_status: the resolver's <see cref="AssetHit"/>

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -450,6 +450,61 @@ public sealed class LoadOrderService : IDisposable
             comp, warnings, view.PluginCount, _maxPlugins, profileChanged, profileDir, profileName, instanceDir, view.ExcludedPlugins);
     }
 
+    /// <summary>Inspect a NAMED profile's enabled/disabled composition WITHOUT switching to it (9.2: "can't inspect an
+    /// inactive profile") — INSTANCE MODE ONLY. The profiles root is the PARENT of the active profile's dir, so MO2's
+    /// base_directory redirect is honored by construction (the active ProfileDir already incorporates it) and a stale
+    /// active-profile dir doesn't matter — every profile is a sibling folder there. Reads with the cheap text-only
+    /// <see cref="Mo2LoadOrder.ReadComposition"/>, NOT <see cref="Mo2LoadOrder.Build"/> (Build walks every enabled mod
+    /// folder — thousands of dir enumerations) — so inspecting an inactive profile never builds the record index and never
+    /// changes the active profile. EXPLICIT-paths mode has no profiles root (the dir is configured arbitrarily), so a named
+    /// read REFUSES LOUD there rather than enumerate a non-profiles folder. A <paramref name="requested"/> name matching no
+    /// profile is reported with the available names (Q3 — never a silently-empty composition); a null/blank name returns
+    /// just the available list (the discovery affordance on the default status). Case-insensitive name match.</summary>
+    public NamedProfileResult NamedProfileComposition(string? requested)
+    {
+        string? instanceDir; string profilesRoot;
+        lock (_gate)
+        {
+            if (!_configured) throw NotConfigured();              // fresh install → the tool returns the trained prompt
+            EnsurePathsDerived();                                 // instance mode: derive the ACTIVE ProfileDir (cheap ini read; throws Q3 if the instance is unusable)
+            instanceDir = _instanceDir;
+            profilesRoot = instanceDir is null ? "" : (Path.GetDirectoryName(_profileDir.TrimEnd('\\', '/')) ?? "");
+        }
+
+        var name = string.IsNullOrWhiteSpace(requested) ? null : requested.Trim();
+        if (instanceDir is null)                                  // explicit-paths mode — no profiles root (refuse loud; the tool renders the named-mode-only message)
+            return new NamedProfileResult(InstanceMode: false, AvailableProfiles: Array.Empty<string>(), RequestedName: name, ResolvedProfileDir: null, Composition: null);
+
+        var available = ListProfiles(profilesRoot);              // directory listing OUTSIDE the gate (like StatusData's ReadComposition) — no lock held over I/O
+        if (name is null)                                        // no name → the discovery list only (default-status affordance)
+            return new NamedProfileResult(true, available, null, null, null);
+
+        var match = available.FirstOrDefault(p => string.Equals(p, name, StringComparison.OrdinalIgnoreCase));
+        if (match is null)                                       // named profile not found → Q3: report it WITH the available names, never an empty composition
+            return new NamedProfileResult(true, available, name, null, null);
+
+        var dir = Path.Combine(profilesRoot, match);
+        var comp = Mo2LoadOrder.ReadComposition(dir);            // cheap text parse of THAT profile's loadorder/modlist/plugins — no index build, no switch
+        return new NamedProfileResult(true, available, match, dir, comp);
+    }
+
+    /// <summary>The profile folder names under <paramref name="profilesRoot"/> (each MO2 profile is one subfolder), sorted
+    /// case-insensitively. Never throws — an unreadable/absent root yields an empty list, so the caller surfaces "no
+    /// profiles" honestly rather than failing the whole status read (Q3).</summary>
+    static IReadOnlyList<string> ListProfiles(string profilesRoot)
+    {
+        if (profilesRoot.Length == 0) return Array.Empty<string>();
+        try
+        {
+            return Directory.EnumerateDirectories(profilesRoot)
+                .Select(d => Path.GetFileName(d.TrimEnd('\\', '/')))
+                .Where(n => !string.IsNullOrEmpty(n))
+                .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+        catch { return Array.Empty<string>(); }                  // root vanished / access denied — empty, not a thrown status read
+    }
+
     /// <summary>True if any of the three MO2 profile files' mtimes DIFFERS from the last build's baseline — the user
     /// toggled mods/plugins, re-sorted, or RESTORED A BACKUP since, so the resolver's resolved set is behind the live
     /// profile. Compared by value (!=), like the resolver's own plugin sweep: a restored backup carries an OLDER
@@ -1595,6 +1650,20 @@ public sealed record LoadOrderStatusData(
     string ProfileName,         // the ACTIVE profile (instance mode: MO2's selected_profile; explicit: the dir name) — captured under the gate, not re-derived at render
     string? InstanceDir,        // the resolved MO2 instance folder houseCARL is pointed at; null ⇒ explicit-paths / unconfigured mode
     IReadOnlyDictionary<string, string> ExcludedPlugins);
+
+/// <summary>The result of <see cref="LoadOrderService.NamedProfileComposition"/> — the profiles affordance behind
+/// housecarl_load_order_status' profile= param. <see cref="InstanceMode"/> is false in explicit-paths mode (no profiles
+/// root — a named read refuses loud). <see cref="AvailableProfiles"/> lists the profile folders (instance mode; empty in
+/// explicit mode), used both for the default-status discovery line and to name the options when a requested profile isn't
+/// found. <see cref="RequestedName"/> echoes the trimmed name asked for (null if none). <see cref="Composition"/> +
+/// <see cref="ResolvedProfileDir"/> are set ONLY when a requested profile was found and read; a non-null RequestedName with
+/// a null Composition is the "not found" case (Q3 — AvailableProfiles names the real options, never a silent empty).</summary>
+public sealed record NamedProfileResult(
+    bool InstanceMode,
+    IReadOnlyList<string> AvailableProfiles,
+    string? RequestedName,
+    string? ResolvedProfileDir,
+    Mo2Composition? Composition);
 
 /// <summary>One queried asset path's resolution behind housecarl_asset_status: the resolver's <see cref="AssetHit"/>
 /// (which sources have it + which wins + an ambiguity flag), or an <see cref="Error"/> when the path was rejected (a

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -473,19 +473,20 @@ public sealed class LoadOrderService : IDisposable
 
         var name = string.IsNullOrWhiteSpace(requested) ? null : requested.Trim();
         if (instanceDir is null)                                  // explicit-paths mode — no profiles root (refuse loud; the tool renders the named-mode-only message)
-            return new NamedProfileResult(InstanceMode: false, AvailableProfiles: Array.Empty<string>(), RequestedName: name, ResolvedProfileDir: null, Composition: null);
+            return new NamedProfileResult(InstanceMode: false, AvailableProfiles: Array.Empty<string>(), RequestedName: name, ResolvedProfileDir: null, Composition: null, Warnings: Array.Empty<string>());
 
         var available = ListProfiles(profilesRoot);              // directory listing OUTSIDE the gate (like StatusData's ReadComposition) — no lock held over I/O
         if (name is null)                                        // no name → the discovery list only (default-status affordance)
-            return new NamedProfileResult(true, available, null, null, null);
+            return new NamedProfileResult(true, available, null, null, null, Array.Empty<string>());
 
         var match = available.FirstOrDefault(p => string.Equals(p, name, StringComparison.OrdinalIgnoreCase));
         if (match is null)                                       // named profile not found → Q3: report it WITH the available names, never an empty composition
-            return new NamedProfileResult(true, available, name, null, null);
+            return new NamedProfileResult(true, available, name, null, null, Array.Empty<string>());
 
         var dir = Path.Combine(profilesRoot, match);
-        var comp = Mo2LoadOrder.ReadComposition(dir);            // cheap text parse of THAT profile's loadorder/modlist/plugins — no index build, no switch
-        return new NamedProfileResult(true, available, match, dir, comp);
+        var warnings = new List<string>();                       // surface read notes (e.g. a missing modlist.txt) — so a 0-mods inspected profile isn't silently mistaken for empty (Q3)
+        var comp = Mo2LoadOrder.ReadComposition(dir, warnings);  // cheap text parse of THAT profile's loadorder/modlist/plugins — no index build, no switch
+        return new NamedProfileResult(true, available, match, dir, comp, warnings);
     }
 
     /// <summary>The USABLE profile names under <paramref name="profilesRoot"/> — each MO2 profile is one subfolder, and a
@@ -1662,13 +1663,16 @@ public sealed record LoadOrderStatusData(
 /// explicit mode), used both for the default-status discovery line and to name the options when a requested profile isn't
 /// found. <see cref="RequestedName"/> echoes the trimmed name asked for (null if none). <see cref="Composition"/> +
 /// <see cref="ResolvedProfileDir"/> are set ONLY when a requested profile was found and read; a non-null RequestedName with
-/// a null Composition is the "not found" case (Q3 — AvailableProfiles names the real options, never a silent empty).</summary>
+/// a null Composition is the "not found" case (Q3 — AvailableProfiles names the real options, never a silent empty).
+/// <see cref="Warnings"/> carries any Q3 notes from reading the inspected profile (e.g. a missing modlist.txt — so a
+/// 0-enabled-mods render is never mistaken for a genuinely-empty profile); empty unless a profile was found and read.</summary>
 public sealed record NamedProfileResult(
     bool InstanceMode,
     IReadOnlyList<string> AvailableProfiles,
     string? RequestedName,
     string? ResolvedProfileDir,
-    Mo2Composition? Composition);
+    Mo2Composition? Composition,
+    IReadOnlyList<string> Warnings);
 
 /// <summary>One queried asset path's resolution behind housecarl_asset_status: the resolver's <see cref="AssetHit"/>
 /// (which sources have it + which wins + an ambiguity flag), or an <see cref="Error"/> when the path was rejected (a

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -488,15 +488,20 @@ public sealed class LoadOrderService : IDisposable
         return new NamedProfileResult(true, available, match, dir, comp);
     }
 
-    /// <summary>The profile folder names under <paramref name="profilesRoot"/> (each MO2 profile is one subfolder), sorted
-    /// case-insensitively. Never throws — an unreadable/absent root yields an empty list, so the caller surfaces "no
-    /// profiles" honestly rather than failing the whole status read (Q3).</summary>
+    /// <summary>The USABLE profile names under <paramref name="profilesRoot"/> — each MO2 profile is one subfolder, and a
+    /// profile that's been opened at least once has a loadorder.txt (the same validity signal <see cref="Mo2Instance"/> uses
+    /// for the ACTIVE profile). Folders WITHOUT one — a never-opened profile, or a stray non-profile dir — are skipped, so
+    /// the list never OFFERS (and a name match never LANDS ON) a folder that would read back as an all-zero composition
+    /// (Q3: don't present an uninitialized folder as an empty profile). Sorted case-insensitively. Never throws — an
+    /// unreadable/absent root yields an empty list, so the caller surfaces "no profiles" honestly rather than failing the
+    /// whole status read.</summary>
     static IReadOnlyList<string> ListProfiles(string profilesRoot)
     {
         if (profilesRoot.Length == 0) return Array.Empty<string>();
         try
         {
             return Directory.EnumerateDirectories(profilesRoot)
+                .Where(d => File.Exists(Path.Combine(d, "loadorder.txt")))   // an opened MO2 profile has loadorder.txt — skip stray/never-opened folders (Q3, accuracy over the per-folder stat)
                 .Select(d => Path.GetFileName(d.TrimEnd('\\', '/')))
                 .Where(n => !string.IsNullOrEmpty(n))
                 .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)

--- a/src/housecarl-mcp/StatusTools.cs
+++ b/src/housecarl-mcp/StatusTools.cs
@@ -56,7 +56,10 @@ static class StatusWire
         int gameLoaded = checkedActive + impl;
 
         var sb = new StringBuilder();
-        sb.Append("load order status — profile '").Append(ProfileName(d.ProfileDir)).Append("'\n");
+        sb.Append("load order status — profile '").Append(d.ProfileName).Append("'\n");
+        // The resolved MO2 instance houseCARL is pointed at (9.2: easy to lose track of which instance is configured);
+        // null ⇒ explicit-paths mode (dev override — the three roots are set directly, there is no MO2 instance folder).
+        sb.Append("instance: ").Append(d.InstanceDir ?? "explicit-paths mode (no MO2 instance configured)").Append('\n');
         sb.Append("mods:    ").Append(c.EnabledMods.Count).Append(" enabled · ").Append(c.DisabledMods.Count).Append(" disabled\n");
         sb.Append("plugins in load order: ").Append(c.OrderedPluginNames.Count).Append('\n');
         sb.Append("  active:   ").Append(gameLoaded).Append("  (").Append(checkedActive).Append(" checked + ").Append(impl).Append(" implicit masters/CC)\n");
@@ -180,13 +183,6 @@ static class StatusWire
         // "ACTIVE … houseCARL reads/writes it" line above isn't taken as the whole truth.
         if (excluded.TryGetValue(name, out var why))
             sb.Append("  [!] EXCLUDED this session: ").Append(why).Append("\n      → houseCARL does NOT read this plugin (every other plugin is unaffected).\n");
-    }
-
-    static string ProfileName(string profileDir)
-    {
-        var trimmed = profileDir.TrimEnd('\\', '/');
-        var name = Path.GetFileName(trimmed);
-        return string.IsNullOrEmpty(name) ? profileDir : name;
     }
 
     static bool Contains(IReadOnlyList<string> list, string name)

--- a/src/housecarl-mcp/StatusTools.cs
+++ b/src/housecarl-mcp/StatusTools.cs
@@ -32,13 +32,20 @@ public static class StatusTools
         ToolPathResolver tools,
         [Description("Optional. A mod folder name or plugin filename to look up. Omit for the whole-profile summary.")]
             string? lookup = null,
+        [Description("Optional. A profile NAME to INSPECT without switching to it (e.g. 'Default', 'Modded') — reports that " +
+            "profile's enabled/disabled mods + active/inactive plugins even if it is not the active one, so you can compare " +
+            "load orders across profiles. Omit to describe the ACTIVE profile (which also lists the available profile names). " +
+            "MO2-instance mode only (explicit-paths mode has no profiles folder); if both lookup= and profile= are given, " +
+            "both render.")]
+            string? profile = null,
         [Description("Optional. Max characters before name lists are cut with an explicit notice. 0 = the server default (~80k).")]
             int max_chars = 0) => Guard.Tool("housecarl_load_order_status", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         var data = svc.StatusData();
         var logs = StatusWire.LogFolders(tools);                 // resolved Papyrus/crash log dirs (pure — no persist)
-        return StatusWire.Render(data, logs, lookup, max_chars > 0 ? max_chars : 80_000);
+        var profiles = svc.NamedProfileComposition(profile);     // 9.2: available-profile discovery + inactive-profile inspection (cheap text parse, no index build, no switch)
+        return StatusWire.Render(data, logs, profiles, lookup, max_chars > 0 ? max_chars : 80_000);
     });
 }
 
@@ -47,7 +54,7 @@ public static class StatusTools
 /// explicit cut notice (Q3 — never silent truncation). lookup= switches to a single mod/plugin verdict.</summary>
 static class StatusWire
 {
-    public static string Render(LoadOrderStatusData d, IReadOnlyList<LogFolderView> logs, string? lookup, int cap)
+    public static string Render(LoadOrderStatusData d, IReadOnlyList<LogFolderView> logs, NamedProfileResult profiles, string? lookup, int cap)
     {
         var c = d.Composition;
         int checkedActive = c.ActivePluginNames.Count;
@@ -71,6 +78,11 @@ static class StatusWire
             sb.Append("[!] the profile changed mid-call and a refresh is still pending — houseCARL re-reads it " +
                       "automatically on the next tool call (lazy refresh; no restart needed).\n");
 
+        // 9.2 profile= inspection: render whenever a name was asked for, BEFORE the lookup branch — so an explicit profile=
+        // request is never silently dropped by a concurrent lookup= (the two compose: lookup verdicts the ACTIVE profile,
+        // this inspects another, possibly inactive, one WITHOUT switching to it).
+        if (profiles.RequestedName is not null) AppendNamedProfile(sb, profiles, cap);
+
         if (lookup is { Length: > 0 })
         {
             AppendLookup(sb, c, d.ExcludedPlugins, lookup.Trim());
@@ -79,6 +91,7 @@ static class StatusWire
 
         AppendExcluded(sb, d.ExcludedPlugins, cap);   // Q3 health alarm — prominent, before the routine name lists
         AppendLogs(sb, logs);   // fixed-tiny — before the cap-bounded name lists, so a long modlist can't truncate it away
+        AppendAvailableProfiles(sb, profiles, cap);   // 9.2 discovery line (instance mode, no profile= asked) — makes the inactive-profile read discoverable
 
         AppendList(sb, "disabled mods", c.DisabledMods, cap);
         AppendList(sb, "inactive plugins", c.InactivePluginNames, cap);
@@ -159,6 +172,64 @@ static class StatusWire
             if (sb.Length >= cap) { sb.Append("  ... [showing ").Append(shown).Append(" of ").Append(names.Count).Append("; raise max_chars to see all]\n"); break; }
             sb.Append("  - ").Append(n).Append('\n'); shown++;
         }
+    }
+
+    /// <summary>9.2 profile= : render the requested NAMED profile's composition (or a loud refusal / not-found). Called
+    /// whenever a name was asked for. Explicit-paths mode has no profiles folder → refuse loud (Q3, never enumerate an
+    /// arbitrary dir). A name matching no profile lists the real options (Q3 — never a silent empty composition). A match
+    /// renders that profile's counts + its disabled-mods / inactive-plugins lists, stating plainly the active profile is
+    /// unchanged (this is inspection, not a switch).</summary>
+    static void AppendNamedProfile(StringBuilder sb, NamedProfileResult p, int cap)
+    {
+        if (!p.InstanceMode)
+        {
+            sb.Append("\nprofile '").Append(p.RequestedName)
+              .Append("': can't inspect — that needs MO2-instance mode; in explicit-paths mode there is no profiles folder to read from.\n");
+            return;
+        }
+        if (p.Composition is null)                                // not found → name the real options, never a silent empty composition
+        {
+            sb.Append("\nprofile '").Append(p.RequestedName).Append("' not found — ");
+            AppendProfileNames(sb, "available", p.AvailableProfiles, cap);
+            return;
+        }
+        var c = p.Composition;
+        int active = c.ActivePluginNames.Count + c.ImplicitPluginNames.Count;
+        sb.Append("\n— inspecting profile '").Append(p.RequestedName).Append("' (read-only; the active profile is unchanged):\n");
+        sb.Append("  mods:    ").Append(c.EnabledMods.Count).Append(" enabled · ").Append(c.DisabledMods.Count).Append(" disabled\n");
+        sb.Append("  plugins: ").Append(c.OrderedPluginNames.Count).Append(" in order · ").Append(active).Append(" active · ")
+          .Append(c.InactivePluginNames.Count).Append(" inactive\n");
+        AppendList(sb, "  disabled mods", c.DisabledMods, cap);
+        AppendList(sb, "  inactive plugins", c.InactivePluginNames, cap);
+    }
+
+    /// <summary>9.2 discovery line: the available profile names (instance mode), so the inactive-profile read is
+    /// discoverable from the default status. Suppressed in explicit-paths mode (no profiles folder) and when a profile= was
+    /// asked for (the named block already named them on a miss).</summary>
+    static void AppendAvailableProfiles(StringBuilder sb, NamedProfileResult p, int cap)
+    {
+        if (!p.InstanceMode || p.RequestedName is not null) return;
+        sb.Append('\n');
+        AppendProfileNames(sb, "profiles available", p.AvailableProfiles, cap);
+        if (p.AvailableProfiles.Count > 0)
+            sb.Append("  → pass profile='<name>' to inspect any of these WITHOUT switching to it.\n");
+    }
+
+    /// <summary>One-line "label (N): a, b, c" of profile names, comma-joined, cap-bounded with an explicit cut notice
+    /// (Q3 — never silent truncation).</summary>
+    static void AppendProfileNames(StringBuilder sb, string label, IReadOnlyList<string> names, int cap)
+    {
+        sb.Append(label).Append(" (").Append(names.Count).Append(')');
+        if (names.Count == 0) { sb.Append(": none\n"); return; }
+        sb.Append(": ");
+        int shown = 0;
+        foreach (var n in names)
+        {
+            if (sb.Length >= cap) { sb.Append(" ... [").Append(names.Count - shown).Append(" more omitted at max_chars=").Append(cap).Append(']'); break; }
+            if (shown > 0) sb.Append(", ");
+            sb.Append(n); shown++;
+        }
+        sb.Append('\n');
     }
 
     static void AppendLookup(StringBuilder sb, HousecarlCore.Mo2Composition c,

--- a/src/housecarl-mcp/StatusTools.cs
+++ b/src/housecarl-mcp/StatusTools.cs
@@ -199,6 +199,10 @@ static class StatusWire
         sb.Append("  mods:    ").Append(c.EnabledMods.Count).Append(" enabled · ").Append(c.DisabledMods.Count).Append(" disabled\n");
         sb.Append("  plugins: ").Append(c.OrderedPluginNames.Count).Append(" in order · ").Append(active).Append(" active · ")
           .Append(c.InactivePluginNames.Count).Append(" inactive\n");
+        // Q3: any read note (e.g. a missing modlist.txt) — so a 0-enabled-mods inspection is never silently mistaken for a
+        // genuinely-empty profile. Rendered before the lists, like the active status' own warnings block.
+        foreach (var warn in p.Warnings)
+            sb.Append("  [!] ").Append(warn).Append('\n');
         AppendList(sb, "  disabled mods", c.DisabledMods, cap);
         AppendList(sb, "  inactive plugins", c.InactivePluginNames, cap);
     }


### PR DESCRIPTION
**HCBR-2026-06-15-01 / PR-I — item 9.2.** `housecarl_load_order_status` reported the profile *name* but never the resolved **instance path** (easy to lose track of which MO2 instance houseCARL is pointed at), and couldn't **inspect an inactive profile** without switching to it. This closes both. §4 **n/a** — diagnostic ergonomics, no record-type surface, cornerstone untouched.

### What you get

The status header now names the instance, and the default view lists the other profiles:
```
load order status — profile 'Default'
instance: E:\Skyrim Modding\…\MO2 Instance      ← NEW (or "explicit-paths mode" in dev override)
mods:    312 enabled · 45 disabled
…
profiles available (2): Default, Modded          ← NEW
  → pass profile='<name>' to inspect any of these WITHOUT switching to it.
```

`profile=Modded` reads that profile's composition **without touching the active one**:
```
— inspecting profile 'Modded' (read-only; the active profile is unchanged):
  mods:    340 enabled · 17 disabled
  plugins: 1900 in order · 1885 active · 15 inactive
  disabled mods (17): …
  inactive plugins (15): …
```

### How it's built (the must-fixes, all honored)
- **Instance-mode only.** Explicit-paths mode has no profiles root, so a `profile=` read **refuses loud** there — it never enumerates an arbitrary folder.
- **Cheap.** Uses the text-only `Mo2LoadOrder.ReadComposition`, **not** `Build` (which walks every enabled mod folder). Inspecting an inactive profile builds no record index and switches nothing.
- **By construction.** The profiles root is the *parent of the active profile's dir*, so MO2's `base_directory` redirect is honored automatically and a stale active-profile dir can't mislead it.
- **Never a silent empty (Q3).** An unknown name lists the available profiles; a folder under `profiles/` without a `loadorder.txt` (never-opened / stray) is skipped so it can't render as an all-zero phantom.

### Commits
1. `8f24160` — surface the instance path + active profile (captured under the same gated snapshot, hunt-F6 invariant).
2. `3411716` — `profile=` param + `NamedProfileComposition` + the probe.
3. `0619312` — pre-push review fold: filter the profile listing to real (loadorder.txt-bearing) profiles.

### Proof
- New guard **`loadorder-status-guard`** (CI **39 → 40 probes**), **24 checks across 8 arms**, asserting both the service data **and** the rendered text the user sees: instance path (A), explicit-paths mode (B), inactive read w/ active profile unchanged + case-insensitive (C), not-found names available (D), explicit refusal (E), discovery line (F), `base_directory` redirect (G), stray-folder filter (H).
- **RED-proven** against the committed fix by three sabotages (revert clean): dropping the instance line → A/B fail; reading the active dir instead of the named one → C/G fail; a silent non-empty on a miss → D fails. The other arms stay green (specificity).
- **Independent pre-push adversarial review: APPROVE-WITH-NITS** — all 4 must-fixes verified honored, gate discipline clean, no leftover sabotage; both nits folded into commit 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)