### PR TITLE
compiler/BSA ergonomics: auto-detect (game-dir + Steam install) + output_dir= (HCBR-2026-06-15-01 / PR-J)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,14 @@ jobs:
       - name: Probe — load-order-status instance path + named-profile read (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- loadorder-status-guard
 
+      # Compile-rider ergonomics (HCBR-2026-06-15-01 / PR-J, items 6.2 + 6.3): the service-layer half. GameDirOrNull (the
+      # compiler auto-detect hint) is NULL-SAFE — unconfigured / unusable-instance → null, never a throw that aborts the
+      # compile; and the output_dir= contract appends Scripts\ with a double-Scripts guard + a Q3 deployability warning,
+      # WITHOUT cutting a houseCARL mod folder. Pure synthetic paths (no MO2, no game data). The pure-core ToolBridge half
+      # (auto-detect candidates, the looked-here prompt, cross-instance sharing) is exercised by the tool-bridge probe.
+      - name: Probe — compile-rider ergonomics (GameDirOrNull null-safety + output_dir= contract)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- compile-ergonomics-guard
+
       # The compile tool's import ORDER is semantics (the CK compiler takes the FIRST matching .psc), so caller
       # import_dirs must outrank the auto-added vanilla folder — else SKSE-extended copies of vanilla scripts lose
       # to vanilla and extended calls fail despite the right folder being passed (spike findings §5.12, hit twice).

--- a/src/housecarl-core/ToolBridge.cs
+++ b/src/housecarl-core/ToolBridge.cs
@@ -39,7 +39,8 @@ public static class ToolBridge
     {
         new(ToolDependency.PapyrusCompiler, "papyrus_compiler", "the Papyrus compiler (PapyrusCompiler.exe)", false, "papyruscompiler",
             "compiling .psc scripts to .pex",
-            "it ships with the Creation Kit (Bethesda's free modding tool, on Steam); it's typically at <Skyrim>\\Papyrus Compiler\\PapyrusCompiler.exe"),
+            "it ships with the Creation Kit (Bethesda's free modding tool, on Steam); it lives in your REAL Steam Skyrim SE install " +
+            "at <Skyrim SE>\\Papyrus Compiler\\PapyrusCompiler.exe — NOT a Wabbajack/MO2 'Stock Game' copy (that's the data dir; the CK and the vanilla script sources are in the Steam install)"),
         new(ToolDependency.Bsarch, "bsarch", "BSArch (BSArch.exe)", false, "bsarch",
             "listing, extracting, and repacking .bsa archives",
             "BSArch is a standalone tool on Nexus Mods (also bundled with 'Cathedral Assets Optimizer' / 'BSA Browser')"),
@@ -93,14 +94,14 @@ public static class ToolBridge
     /// asks the user and is handed the exact resolving call (the forcing function). Mirrors the MO2 not-configured prompt
     /// idiom: a RETURNED string reaches the client, whereas a thrown one is genericized to "An error occurred invoking…"
     /// (measured 2026-06-02), so the guidance must be a return value, never an exception. When auto-detect had canonical
-    /// candidates to check (the compiler with a <paramref name="gameDirHint"/>, the log folders), the prompt NAMES them —
-    /// so a miss says WHERE houseCARL already looked (6.2: "better message"), telling a Wabbajack/Stock-Game user why the
-    /// game-dir anchor missed and that they must supply the real CK path. The tool-key + resolving-call contract is kept
-    /// intact regardless (the AI still gets the exact housecarl_set_tool_path call).</summary>
-    public static string RenderMissingPrompt(ToolDependency dep, string? gameDirHint = null)
+    /// candidates to check (the compiler under each <paramref name="gameDirHints"/> dir, the log folders), the prompt NAMES
+    /// them — so a miss says WHERE houseCARL already looked (6.2: "better message"), telling a Wabbajack/Stock-Game user why
+    /// every game-dir anchor missed and that they must supply the real CK path. The tool-key + resolving-call contract is
+    /// kept intact regardless (the AI still gets the exact housecarl_set_tool_path call).</summary>
+    public static string RenderMissingPrompt(ToolDependency dep, IReadOnlyList<string>? gameDirHints = null)
     {
         var info = Info(dep);
-        var tried = Candidates(dep, gameDirHint).ToList();
+        var tried = Candidates(dep, gameDirHints).ToList();
         var lookedNote = tried.Count == 0 ? "" :
             $" houseCARL already looked for it automatically at {string.Join(" and ", tried.Select(c => $"'{c}'"))} " +
             "and didn't find it there.";
@@ -115,20 +116,22 @@ public static class ToolBridge
 
     /// <summary>The canonical candidate paths houseCARL auto-detects for a dependency, in priority order — the SINGLE
     /// source of truth shared by <see cref="Probe"/> (returns the first that EXISTS) and <see cref="RenderMissingPrompt"/>
-    /// (lists them, so a miss can say WHERE houseCARL looked). The Papyrus compiler is anchored on the active instance's
-    /// game dir (<paramref name="gameDirHint"/> = the load order's gamePath; the CK installs its compiler at
-    /// &lt;game&gt;\Papyrus Compiler\PapyrusCompiler.exe). That hits a NORMAL Steam+CK install (the game dir IS the Steam
-    /// game), and MISSES a Wabbajack "Stock Game" copy (the CK lives in the separate real Steam install, on any drive) —
-    /// a BEST-EFFORT anchor, so a miss falls through to the forcing prompt, never a wrong guess. A future enhancement is
-    /// Steam-library discovery (registry + libraryfolders.vdf) for the Stock-Game case. The log folders live under the
-    /// user's Documents; BSArch is user-downloaded with no canonical home — both yield zero candidates (always prompt).</summary>
-    static IEnumerable<string> Candidates(ToolDependency dep, string? gameDirHint)
+    /// (lists them, so a miss can say WHERE houseCARL looked). The Papyrus compiler is checked under EACH game dir in
+    /// <paramref name="gameDirHints"/>, in order — the CK installs its compiler at &lt;game&gt;\Papyrus
+    /// Compiler\PapyrusCompiler.exe. The caller supplies the hints (LoadOrderService.CompilerGameDirHints): [0] the load
+    /// order's own game dir (correct when MO2 points straight at a CK-equipped install), then the GameFinder-located real
+    /// Steam SE install — because the common MO2 "Stock Game" setup points the load order at a COPY with no CK (the
+    /// Creation Kit + sources live in the Steam install). Whichever has the compiler wins; a total miss falls through to
+    /// the forcing prompt, never a wrong guess. The log folders live under the user's Documents; BSArch is user-downloaded
+    /// with no canonical home — both yield zero compiler-style candidates (BSArch always prompts).</summary>
+    static IEnumerable<string> Candidates(ToolDependency dep, IReadOnlyList<string>? gameDirHints)
     {
         switch (dep)
         {
             case ToolDependency.PapyrusCompiler:
-                if (!string.IsNullOrWhiteSpace(gameDirHint))
-                    yield return Path.Combine(gameDirHint!, "Papyrus Compiler", "PapyrusCompiler.exe");
+                foreach (var g in gameDirHints ?? Array.Empty<string>())
+                    if (!string.IsNullOrWhiteSpace(g))
+                        yield return Path.Combine(g, "Papyrus Compiler", "PapyrusCompiler.exe");
                 break;
             case ToolDependency.PapyrusLogs:
                 yield return Path.Combine(MyGames, "Logs", "Script");
@@ -146,10 +149,10 @@ public static class ToolBridge
     /// an existing folder; an exe dep (the compiler) needs an existing file — its candidate is built as the literal
     /// PapyrusCompiler.exe, so File.Exists is sufficient (the name carries the right stem by construction, and
     /// <see cref="ToolPathResolver.Resolve"/> re-Validates before persisting it anyway).</summary>
-    public static string? Probe(ToolDependency dep, string? gameDirHint = null)
+    public static string? Probe(ToolDependency dep, IReadOnlyList<string>? gameDirHints = null)
     {
         bool isDir = Info(dep).IsDirectory;
-        foreach (var c in Candidates(dep, gameDirHint))
+        foreach (var c in Candidates(dep, gameDirHints))
             if (isDir ? Directory.Exists(c) : File.Exists(c)) return c;
         return null;
     }
@@ -161,12 +164,12 @@ public static class ToolBridge
     /// else none (Unset — a rider would fire the forcing prompt). PURE (no file write), so a ReadOnly status read never
     /// mutates config, and it mirrors what a rider's resolve would find — so "where the logs are" in status is the truth a
     /// Read would hit. A saved path that no longer validates falls through (tool moved / folder deleted), same as the
-    /// runtime resolver. The optional <paramref name="gameDirHint"/> feeds the compiler's game-dir-anchored auto-detect
-    /// (the log deps that use this surface ignore it).</summary>
-    public static (string? path, ToolPathSource source) Inspect(ToolDependency dep, string? savedPath, string? gameDirHint = null)
+    /// runtime resolver. The optional <paramref name="gameDirHints"/> feed the compiler's game-dir-anchored auto-detect
+    /// (the log deps that use this surface ignore them).</summary>
+    public static (string? path, ToolPathSource source) Inspect(ToolDependency dep, string? savedPath, IReadOnlyList<string>? gameDirHints = null)
     {
         if (savedPath is not null && Validate(dep, savedPath).ok) return (savedPath, ToolPathSource.Saved);
-        var found = Probe(dep, gameDirHint);
+        var found = Probe(dep, gameDirHints);
         return found is not null ? (found, ToolPathSource.AutoDetected) : (null, ToolPathSource.Unset);
     }
 

--- a/src/housecarl-core/ToolBridge.cs
+++ b/src/housecarl-core/ToolBridge.cs
@@ -92,12 +92,20 @@ public static class ToolBridge
     /// <summary>The trained missing-dependency prompt — RETURNED by a rider tool when its path is unset, so the AI reliably
     /// asks the user and is handed the exact resolving call (the forcing function). Mirrors the MO2 not-configured prompt
     /// idiom: a RETURNED string reaches the client, whereas a thrown one is genericized to "An error occurred invoking…"
-    /// (measured 2026-06-02), so the guidance must be a return value, never an exception.</summary>
-    public static string RenderMissingPrompt(ToolDependency dep)
+    /// (measured 2026-06-02), so the guidance must be a return value, never an exception. When auto-detect had canonical
+    /// candidates to check (the compiler with a <paramref name="gameDirHint"/>, the log folders), the prompt NAMES them —
+    /// so a miss says WHERE houseCARL already looked (6.2: "better message"), telling a Wabbajack/Stock-Game user why the
+    /// game-dir anchor missed and that they must supply the real CK path. The tool-key + resolving-call contract is kept
+    /// intact regardless (the AI still gets the exact housecarl_set_tool_path call).</summary>
+    public static string RenderMissingPrompt(ToolDependency dep, string? gameDirHint = null)
     {
         var info = Info(dep);
+        var tried = Candidates(dep, gameDirHint).ToList();
+        var lookedNote = tried.Count == 0 ? "" :
+            $" houseCARL already looked for it automatically at {string.Join(" and ", tried.Select(c => $"'{c}'"))} " +
+            "and didn't find it there.";
         return
-            $"houseCARL needs {info.Display} for {info.Need}, but no path is set yet. " +
+            $"houseCARL needs {info.Display} for {info.Need}, but no path is set yet.{lookedNote} " +
             $"Ask the user for the {(info.IsDirectory ? "folder" : "full path to the .exe")}, then call " +
             $"housecarl_set_tool_path(tool='{info.Key}', path='<the path they give>'). " +
             $"If they don't have it: {info.WhereToGet}. " +
@@ -105,28 +113,45 @@ public static class ToolBridge
             "is refused loud.";
     }
 
-    /// <summary>Auto-detect a canonical home for a dependency, so the user is only asked when houseCARL genuinely can't find
-    /// it. Returns the first EXISTING canonical path, or null (→ the forcing prompt). The log folders live under the user's
-    /// Documents (probed here); the compiler and BSArch have no reliable cheap home, so they prompt — see the per-arm notes.</summary>
-    public static string? Probe(ToolDependency dep)
+    /// <summary>The canonical candidate paths houseCARL auto-detects for a dependency, in priority order — the SINGLE
+    /// source of truth shared by <see cref="Probe"/> (returns the first that EXISTS) and <see cref="RenderMissingPrompt"/>
+    /// (lists them, so a miss can say WHERE houseCARL looked). The Papyrus compiler is anchored on the active instance's
+    /// game dir (<paramref name="gameDirHint"/> = the load order's gamePath; the CK installs its compiler at
+    /// &lt;game&gt;\Papyrus Compiler\PapyrusCompiler.exe). That hits a NORMAL Steam+CK install (the game dir IS the Steam
+    /// game), and MISSES a Wabbajack "Stock Game" copy (the CK lives in the separate real Steam install, on any drive) —
+    /// a BEST-EFFORT anchor, so a miss falls through to the forcing prompt, never a wrong guess. A future enhancement is
+    /// Steam-library discovery (registry + libraryfolders.vdf) for the Stock-Game case. The log folders live under the
+    /// user's Documents; BSArch is user-downloaded with no canonical home — both yield zero candidates (always prompt).</summary>
+    static IEnumerable<string> Candidates(ToolDependency dep, string? gameDirHint)
     {
         switch (dep)
         {
+            case ToolDependency.PapyrusCompiler:
+                if (!string.IsNullOrWhiteSpace(gameDirHint))
+                    yield return Path.Combine(gameDirHint!, "Papyrus Compiler", "PapyrusCompiler.exe");
+                break;
             case ToolDependency.PapyrusLogs:
-                return FirstExistingDir(Path.Combine(MyGames, "Logs", "Script"));
+                yield return Path.Combine(MyGames, "Logs", "Script");
+                break;
             case ToolDependency.CrashLogs:
-                return FirstExistingDir(
-                    Path.Combine(MyGames, "SKSE", "Crashlogs"),          // Crash Logger SSE
-                    Path.Combine(MyGames, "NetScriptFramework", "Crash")); // .NET Script Framework
-            // PapyrusCompiler: NO reliable canonical home to probe. The CK's compiler ships ONLY with the vanilla Steam
-            // install — NOT the MO2/Wabbajack "Stock Game" copy the load order points at (confirmed 2026-06-05) — and the
-            // Steam library can sit on any drive. Auto-detecting it = Steam registry + libraryfolders.vdf discovery (a noted
-            // future enhancement); until then the forcing prompt is the reliable path, and once the user supplies the .exe
-            // the compile rider derives the matching vanilla sources + flags from the compiler's own game dir.
-            // Bsarch: user-downloaded, no canonical home either.
-            default:
-                return null;
+                yield return Path.Combine(MyGames, "SKSE", "Crashlogs");          // Crash Logger SSE
+                yield return Path.Combine(MyGames, "NetScriptFramework", "Crash"); // .NET Script Framework
+                break;
+            // Bsarch: user-downloaded, no canonical home — no candidates.
         }
+    }
+
+    /// <summary>Auto-detect a canonical home for a dependency, so the user is only asked when houseCARL genuinely can't find
+    /// it. Returns the first EXISTING <see cref="Candidates"/> path, or null (→ the forcing prompt). A directory dep needs
+    /// an existing folder; an exe dep (the compiler) needs an existing file — its candidate is built as the literal
+    /// PapyrusCompiler.exe, so File.Exists is sufficient (the name carries the right stem by construction, and
+    /// <see cref="ToolPathResolver.Resolve"/> re-Validates before persisting it anyway).</summary>
+    public static string? Probe(ToolDependency dep, string? gameDirHint = null)
+    {
+        bool isDir = Info(dep).IsDirectory;
+        foreach (var c in Candidates(dep, gameDirHint))
+            if (isDir ? Directory.Exists(c) : File.Exists(c)) return c;
+        return null;
     }
 
     /// <summary>For a status / "what's configured" surface: where a dependency RESOLVES right now, WITHOUT the persist
@@ -136,20 +161,15 @@ public static class ToolBridge
     /// else none (Unset — a rider would fire the forcing prompt). PURE (no file write), so a ReadOnly status read never
     /// mutates config, and it mirrors what a rider's resolve would find — so "where the logs are" in status is the truth a
     /// Read would hit. A saved path that no longer validates falls through (tool moved / folder deleted), same as the
-    /// runtime resolver.</summary>
-    public static (string? path, ToolPathSource source) Inspect(ToolDependency dep, string? savedPath)
+    /// runtime resolver. The optional <paramref name="gameDirHint"/> feeds the compiler's game-dir-anchored auto-detect
+    /// (the log deps that use this surface ignore it).</summary>
+    public static (string? path, ToolPathSource source) Inspect(ToolDependency dep, string? savedPath, string? gameDirHint = null)
     {
         if (savedPath is not null && Validate(dep, savedPath).ok) return (savedPath, ToolPathSource.Saved);
-        var found = Probe(dep);
+        var found = Probe(dep, gameDirHint);
         return found is not null ? (found, ToolPathSource.AutoDetected) : (null, ToolPathSource.Unset);
     }
 
     static string MyGames => Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "My Games", "Skyrim Special Edition");
-
-    static string? FirstExistingDir(params string[] candidates)
-    {
-        foreach (var c in candidates) if (Directory.Exists(c)) return c;
-        return null;
-    }
 }

--- a/src/housecarl-generator/CompileErgonomicsProbe.cs
+++ b/src/housecarl-generator/CompileErgonomicsProbe.cs
@@ -97,10 +97,18 @@ internal static class CompileErgonomicsProbe
         Console.WriteLine();
         Console.WriteLine("--- B2: ScriptOutputContract — deployability warning (Q3: never a clean done for a .pex that won't load) ---");
         Check(bare.deployWarning is not null, "a path under NEITHER mods nor Data carries the Q3 deploy warning");
+        // DEPLOYABLE (no warning): exactly <mods>\<modFolder>\Scripts, or <data>\Scripts.
         Check(LoadOrderService.ScriptOutputContract(@"C:\MO2\mods\MyPatch", mods, data).deployWarning is null,
-              "a path under the MO2 mods folder is deployable (no warning)");
+              "a real mod folder (<mods>\\MyPatch) is deployable (no warning)");
         Check(LoadOrderService.ScriptOutputContract(data, mods, data).deployWarning is null,
-              "a path under the game's Data folder is deployable (no warning)");
+              "the game's Data folder (-> <data>\\Scripts) is deployable (no warning)");
+        // NON-deployable (warns) — the tightened rule (review nit): "under mods" alone is not enough.
+        Check(LoadOrderService.ScriptOutputContract(@"C:\MO2\mods", mods, data).deployWarning is not null,
+              "the mods ROOT itself (-> <mods>\\Scripts, no mod folder) WARNS — MO2 won't deploy it (tightened nit)");
+        Check(LoadOrderService.ScriptOutputContract(@"C:\MO2\mods\X\Sub", mods, data).deployWarning is not null,
+              "a NESTED path (<mods>\\X\\Sub\\Scripts -> Data\\Sub\\Scripts) WARNS — not Data\\Scripts (tightened nit)");
+        Check(LoadOrderService.ScriptOutputContract(@"C:\Game\Skyrim Special Edition\Data\Sub", mods, data).deployWarning is not null,
+              "a nested Data path (<data>\\Sub\\Scripts) WARNS — the game loads only <data>\\Scripts");
         Check(LoadOrderService.ScriptOutputContract(@"C:\MO2\modsX\Foo", mods, data).deployWarning is not null,
               "segment-boundary safe: C:\\MO2\\modsX is NOT 'under' C:\\MO2\\mods (still warns)");
 

--- a/src/housecarl-generator/CompileErgonomicsProbe.cs
+++ b/src/housecarl-generator/CompileErgonomicsProbe.cs
@@ -62,6 +62,18 @@ internal static class CompileErgonomicsProbe
             try { badResult = badInstance.GameDirOrNull(); } catch { badThrew = true; }
             Check(!badThrew && badResult is null,
                   "unusable instance: GameDirOrNull returns null, does NOT throw (best-effort hint — the rider's config gate reports the real problem)");
+
+            // CompilerGameDirHints: the ordered auto-detect hint list. [0] = the load-order game dir; then the located real
+            // Steam install (environment-dependent — absent on a CI runner with no Skyrim, verified on Aaron's rig). NULL-SAFE
+            // end to end: the GameFinder/registry call is wrapped, so a hiccup yields fewer hints, never throws.
+            bool hintsThrew = false; IReadOnlyList<string>? hints = null;
+            try { hints = explicitSvc.CompilerGameDirHints(); } catch { hintsThrew = true; }
+            Check(!hintsThrew && hints is not null && hints.Contains(@"C:\Game\Skyrim Special Edition"),
+                  "CompilerGameDirHints includes the load-order game dir as the first hint, and never throws (locator is best-effort)");
+            bool unconfHintsThrew = false; IReadOnlyList<string>? unconfHints = null;
+            try { unconfHints = unconfigured.CompilerGameDirHints(); } catch { unconfHintsThrew = true; }
+            Check(!unconfHintsThrew && unconfHints is not null,
+                  "CompilerGameDirHints on an unconfigured service returns a list (no load-order hint; locator-only), never throws");
         }
         finally { try { File.Delete(tmpStore); } catch { /* non-fatal */ } }
 

--- a/src/housecarl-generator/CompileErgonomicsProbe.cs
+++ b/src/housecarl-generator/CompileErgonomicsProbe.cs
@@ -65,6 +65,67 @@ internal static class CompileErgonomicsProbe
         }
         finally { try { File.Delete(tmpStore); } catch { /* non-fatal */ } }
 
+        // ---------------------------------------------------------- B) output_dir= contract (6.3): pure double-Scripts guard
+        Console.WriteLine();
+        Console.WriteLine("--- B1: ScriptOutputContract (pure) — append Scripts\\ with the double-Scripts guard + deployability ---");
+        const string mods = @"C:\MO2\mods", data = @"C:\Game\Skyrim Special Edition\Data";
+
+        var bare = LoadOrderService.ScriptOutputContract(@"C:\MyMod", mods, data);
+        Check(bare.scriptsDir == @"C:\MyMod\Scripts" && bare.appendedScripts, "a bare mod-folder root gets Scripts\\ appended");
+
+        var already = LoadOrderService.ScriptOutputContract(@"C:\MyMod\Scripts", mods, data);
+        Check(already.scriptsDir == @"C:\MyMod\Scripts" && !already.appendedScripts, "double-Scripts guard: a root already ending in Scripts is NOT doubled");
+
+        var lower = LoadOrderService.ScriptOutputContract(@"C:\MyMod\scripts", mods, data);
+        Check(lower.scriptsDir == @"C:\MyMod\scripts" && !lower.appendedScripts, "double-Scripts guard is case-insensitive (…\\scripts not doubled)");
+
+        var trailing = LoadOrderService.ScriptOutputContract(@"C:\MyMod\Scripts\", mods, data);
+        Check(trailing.scriptsDir == @"C:\MyMod\Scripts" && !trailing.appendedScripts, "double-Scripts guard tolerates a trailing separator");
+
+        Console.WriteLine();
+        Console.WriteLine("--- B2: ScriptOutputContract — deployability warning (Q3: never a clean done for a .pex that won't load) ---");
+        Check(bare.deployWarning is not null, "a path under NEITHER mods nor Data carries the Q3 deploy warning");
+        Check(LoadOrderService.ScriptOutputContract(@"C:\MO2\mods\MyPatch", mods, data).deployWarning is null,
+              "a path under the MO2 mods folder is deployable (no warning)");
+        Check(LoadOrderService.ScriptOutputContract(data, mods, data).deployWarning is null,
+              "a path under the game's Data folder is deployable (no warning)");
+        Check(LoadOrderService.ScriptOutputContract(@"C:\MO2\modsX\Foo", mods, data).deployWarning is not null,
+              "segment-boundary safe: C:\\MO2\\modsX is NOT 'under' C:\\MO2\\mods (still warns)");
+
+        // ---------------------------------------------------------- B3: ResolveExplicitScriptFolder — no patch folder cut
+        Console.WriteLine();
+        Console.WriteLine("--- B3: ResolveExplicitScriptFolder — user-owned, ResolvePatchModFolder NOT called, cleanup bypassed ---");
+        var bRoot = Path.Combine(Path.GetTempPath(), "hc-comperg-b-" + Guid.NewGuid().ToString("N"));
+        var tStore = Path.Combine(bRoot, "user.json");
+        var tMods = Path.Combine(bRoot, "mods");
+        var tData = Path.Combine(bRoot, "game", "Data");
+        var tOut = Path.Combine(bRoot, "elsewhere", "MyMod");           // OUTSIDE the mods tree
+        try
+        {
+            Directory.CreateDirectory(tMods); Directory.CreateDirectory(tData);
+            var svc = LoadOrderService.WithExplicitPaths(tData, tMods, "", 0, new UserConfigStore(tStore));
+
+            var rf = svc.ResolveExplicitScriptFolder(tOut, out var warn);
+            Check(rf.OutputDir == Path.Combine(tOut, "Scripts"), "output path = output_dir\\Scripts (the chosen contract)");
+            Check(!rf.CreatedFresh, "the folder is USER-OWNED (CreatedFresh=false), so residue cleanup never deletes it");
+            Check(Directory.Exists(rf.OutputDir), "the Scripts\\ folder is created under output_dir");
+            Check(!Directory.EnumerateFileSystemEntries(tMods).Any(),
+                  "ResolvePatchModFolder was NOT called — no houseCARL patch folder cut under ModsDir");
+            Check(warn is not null, "output_dir outside the mods tree carries the deploy warning");
+            // The load-bearing bypass: on a failed compile RemoveOrNameRiderResidue must NOT delete the user's folder.
+            // (Asserting it returns null alone is too weak — an EMPTY fresh folder also returns null because it gets
+            // deleted; the real tooth is that a user-owned folder SURVIVES.)
+            var residue = svc.RemoveOrNameRiderResidue(rf);
+            Check(residue is null && Directory.Exists(rf.OutputDir),
+                  "residue cleanup never deletes a user-owned output_dir folder (CreatedFresh=false: returns null, folder survives)");
+
+            // A path UNDER the mods tree is deployable → no warning.
+            var rfIn = svc.ResolveExplicitScriptFolder(Path.Combine(tMods, "MyPatch"), out var warnIn);
+            Check(rfIn.OutputDir == Path.Combine(tMods, "MyPatch", "Scripts") && warnIn is null,
+                  "an output_dir under the MO2 mods folder deploys cleanly (no warning)");
+        }
+        finally { try { Directory.Delete(bRoot, recursive: true); } catch { /* non-fatal */ } }
+
         Console.WriteLine();
         Console.WriteLine(fail == 0
             ? "================ ALL PASS ================"

--- a/src/housecarl-generator/CompileErgonomicsProbe.cs
+++ b/src/housecarl-generator/CompileErgonomicsProbe.cs
@@ -143,8 +143,33 @@ internal static class CompileErgonomicsProbe
             var rfIn = svc.ResolveExplicitScriptFolder(Path.Combine(tMods, "MyPatch"), out var warnIn);
             Check(rfIn.OutputDir == Path.Combine(tMods, "MyPatch", "Scripts") && warnIn is null,
                   "an output_dir under the MO2 mods folder deploys cleanly (no warning)");
+
+            // review nit #4: if <output_dir>\Scripts already exists AS A FILE, the create throws IOException — it must be
+            // re-stamped as a friendly InvalidOperationException (which the rider renders as a clean "error: ...") rather
+            // than escaping to Guard.Tool's generic "internal failure" wording.
+            var tColl = Path.Combine(bRoot, "collision");
+            Directory.CreateDirectory(tColl);
+            File.WriteAllText(Path.Combine(tColl, "Scripts"), "a file where the Scripts folder should go");
+            bool friendly = false;
+            try { svc.ResolveExplicitScriptFolder(tColl, out _); }
+            catch (InvalidOperationException) { friendly = true; }
+            catch { /* any other exception type → not friendly */ }
+            Check(friendly, "a file at <output_dir>\\Scripts yields a friendly InvalidOperationException, not a raw IOException");
         }
         finally { try { Directory.Delete(bRoot, recursive: true); } catch { /* non-fatal */ } }
+
+        // ---------------------------------------------------------- C: success message matches the actual destination (Q3)
+        Console.WriteLine();
+        Console.WriteLine("--- C: CompileTools.Render — the success line names the RIGHT destination (review nit #1) ---");
+        var ok = new HousecarlCore.CompileResult(
+            Success: true, ObjectName: "MyScript", PexPath: @"C:\out\Scripts\MyScript.pex",
+            Diagnostics: Array.Empty<HousecarlCore.PapyrusDiagnostic>(), Stdout: "", Stderr: "", ExitCode: 0, RunError: null);
+        var defaultMsg = CompileTools.Render(ok, Array.Empty<string>(), userChoseOutputDir: false);
+        var outDirMsg = CompileTools.Render(ok, Array.Empty<string>(), userChoseOutputDir: true);
+        Check(defaultMsg.Contains("houseCARL patch-mod folder") && defaultMsg.Contains("enable it in MO2"),
+              "default destination: success names the houseCARL patch-mod folder + the MO2-enable step");
+        Check(outDirMsg.Contains("output folder you chose") && !outDirMsg.Contains("houseCARL patch-mod folder"),
+              "output_dir= destination: success names the user's chosen folder, NOT a houseCARL patch folder (no over-claim)");
 
         Console.WriteLine();
         Console.WriteLine(fail == 0

--- a/src/housecarl-generator/CompileErgonomicsProbe.cs
+++ b/src/housecarl-generator/CompileErgonomicsProbe.cs
@@ -1,0 +1,74 @@
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// Compile-rider ergonomics guard (HCBR-2026-06-15-01 / PR-J, items 6.2 + 6.3). The service-layer (housecarl-mcp) half of
+/// the compiler/BSA ergonomics work — the pure-core ToolBridge half (auto-detect candidates, the looked-here prompt, the
+/// cross-instance sharing lock) lives in <see cref="ToolBridgeProbe"/>. Two LoadOrderService seams, both asserted on
+/// SYNTHETIC paths — no MO2 instance, no game data, no record index:
+///
+///   A  <see cref="LoadOrderService.GameDirOrNull"/> (6.2 auto-detect hint) — NULL-SAFE by contract: it feeds the compiler
+///      auto-detect, so a failure must fall through to the forcing prompt, never throw and abort the compile.
+///        • explicit-paths mode → DataDir's parent (the game dir), derived without an ini read;
+///        • unconfigured → null (no _configured guard would otherwise hit EnsurePathsDerived's NotConfigured throw);
+///        • an UNUSABLE instance dir → null, NOT a thrown exception (the rider's own config gate names the real problem).
+///   B  <see cref="LoadOrderService.ScriptOutputContract"/> (6.3 output_dir=) — the DECIDED contract (Aaron 2026-06-16):
+///      output_dir is a mod-folder ROOT and houseCARL appends Scripts\ (so the .pex deploys), with a double-Scripts guard
+///      and a Q3 deployability warning. PURE (no I/O) so the riskiest change's only proof isn't punted:
+///        • a bare root gets Scripts\ appended; a root already ending in Scripts\ does NOT get a second one (any case);
+///        • a path under the MO2 mods dir or a game Data\Scripts is deployable (no warning); one outside any deploy root
+///          still lands but carries the Q3 note (never a clean "done" for a .pex MO2 won't deploy);
+///        • the output path is the chosen contract WITHOUT calling ResolvePatchModFolder (no houseCARL mod folder cut),
+///          and the rider's RiderFolder is user-owned (CreatedFresh=false) so residue cleanup never deletes it.
+///
+/// Run: dotnet run --project src/housecarl-generator compile-ergonomics-guard
+/// </summary>
+internal static class CompileErgonomicsProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" compile-ergonomics guard — GameDirOrNull null-safety + output_dir= contract (PR-J)");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        var tmpStore = Path.Combine(Path.GetTempPath(), "hc-comperg-store-" + Guid.NewGuid().ToString("N") + ".json");
+        try
+        {
+            var store = new UserConfigStore(tmpStore);
+
+            // ---------------------------------------------------------- A) GameDirOrNull — the compiler auto-detect hint
+            Console.WriteLine("--- A: LoadOrderService.GameDirOrNull — game dir derived; null-safe when it can't be ---");
+
+            // explicit-paths mode: DataDir is set directly, so the game dir = DataDir's parent (no ini read, no instance).
+            var explicitSvc = LoadOrderService.WithExplicitPaths(@"C:\Game\Skyrim Special Edition\Data", @"C:\Mods", @"C:\Profile", 0, store);
+            Check(explicitSvc.GameDirOrNull() == @"C:\Game\Skyrim Special Edition",
+                  "explicit mode: GameDirOrNull = DataDir's parent (the game install dir)");
+
+            // unconfigured: no instance, not configured → null (not a throw).
+            var unconfigured = LoadOrderService.WithInstance(null, 0, store);
+            bool unconfThrew = false; string? unconfResult = null;
+            try { unconfResult = unconfigured.GameDirOrNull(); } catch { unconfThrew = true; }
+            Check(!unconfThrew && unconfResult is null, "unconfigured: GameDirOrNull returns null (never throws)");
+
+            // an UNUSABLE instance dir: configured (non-blank), but EnsurePathsDerived throws on Resolve → caught → null.
+            var badInstance = LoadOrderService.WithInstance(
+                Path.Combine(Path.GetTempPath(), "hc-no-such-instance-" + Guid.NewGuid().ToString("N")), 0, store);
+            bool badThrew = false; string? badResult = null;
+            try { badResult = badInstance.GameDirOrNull(); } catch { badThrew = true; }
+            Check(!badThrew && badResult is null,
+                  "unusable instance: GameDirOrNull returns null, does NOT throw (best-effort hint — the rider's config gate reports the real problem)");
+        }
+        finally { try { File.Delete(tmpStore); } catch { /* non-fatal */ } }
+
+        Console.WriteLine();
+        Console.WriteLine(fail == 0
+            ? "================ ALL PASS ================"
+            : $"================ {fail} CHECK(S) FAILED ================");
+        return fail == 0 ? 0 : 1;
+    }
+}

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -111,6 +111,12 @@ if (args.Length > 0 && args[0] == "freshness-capture-guard") return FreshnessCap
 // names the available ones (Q3). Self-contained: synthetic instances + one synthesized master, no game data / no corpus.
 if (args.Length > 0 && args[0] == "loadorder-status-guard") return LoadOrderStatusProbe.RunGuard(args[1..]);
 
+// Compile-rider ergonomics (HCBR-2026-06-15-01 / PR-J, items 6.2 + 6.3): the service-layer half — GameDirOrNull is
+// NULL-SAFE (the compiler auto-detect hint falls through to the forcing prompt, never throws), and the output_dir=
+// contract appends Scripts\ with a double-Scripts guard + a Q3 deployability warning, WITHOUT cutting a houseCARL mod
+// folder. Pure synthetic paths; the pure-core ToolBridge half is in the tool-bridge probe.
+if (args.Length > 0 && args[0] == "compile-ergonomics-guard") return CompileErgonomicsProbe.RunGuard(args[1..]);
+
 // MO2 overwrite-folder resolution (2026-06-12 hunt F9): plugins living in MO2's overwrite layer resolve at
 // HIGHEST priority (top of the VFS — where Synthesis/xEdit tool outputs land), and the can't-resolve warning
 // names overwrite among the places searched.

--- a/src/housecarl-generator/ToolBridgeProbe.cs
+++ b/src/housecarl-generator/ToolBridgeProbe.cs
@@ -17,9 +17,10 @@ namespace HousecarlGenerator;
 ///      (6.2) when auto-detect had a candidate to check, NAMES where it looked — a missed compiler game-dir anchor tells
 ///      the user which path failed, while keeping the tool-key + resolving-call contract intact.
 ///   4. <see cref="ToolBridge.TryParse"/> — wire names round-trip; junk is rejected.
-///   5. <see cref="ToolBridge.Probe"/> (6.2 compiler auto-detect) — WITH a gameDirHint the compiler probe hits a synthetic
-///      &lt;game&gt;\Papyrus Compiler\PapyrusCompiler.exe and misses when that exe is absent (a Stock-Game copy); WITHOUT a
-///      hint it yields no candidate (null), the pre-6.2 behavior; BSArch has no canonical home (always null).
+///   5. <see cref="ToolBridge.Probe"/> (6.2 compiler auto-detect) — the compiler probe checks each game-dir hint in ORDER
+///      for &lt;game&gt;\Papyrus Compiler\PapyrusCompiler.exe: the common Stock-Game case (load-order dir misses, the
+///      located Steam install hits) returns the Steam compiler; a single present/absent hint hits/misses as expected;
+///      NO hints → null (pre-6.2 behavior); BSArch has no canonical home (always null, hints ignored).
 ///   6. <see cref="ToolBridge.Inspect"/> — the status-surface resolve (housecarl_load_order_status' log-folder section): a
 ///      saved+valid path → Saved; an invalid/absent one with no canonical home → Unset; PURE (takes the saved path,
 ///      persists nothing — a ReadOnly status read never mutates config).
@@ -131,16 +132,20 @@ public static class ToolBridgeProbe
         Check(prompt.Contains("bsarch"), "prompt names the tool key");
         Check(!prompt.Contains("looked for it automatically"), "BSArch (no candidates) prompt names NO looked-here location");
 
-        // 6.2 "better message": with a game-dir hint, the compiler prompt NAMES the candidate it checked (so a Stock-Game
-        // miss says WHERE houseCARL looked) — WITHOUT losing the tool-key + resolving-call contract.
-        var hintDir = Path.Combine(Path.GetTempPath(), "hc-no-such-game-" + Guid.NewGuid().ToString("N"));
-        var expectedCandidate = Path.Combine(hintDir, "Papyrus Compiler", "PapyrusCompiler.exe");
-        var compPrompt = ToolBridge.RenderMissingPrompt(ToolDependency.PapyrusCompiler, hintDir);
-        Check(compPrompt.Contains(expectedCandidate), "compiler prompt (hinted) names the exact path it auto-checked");
+        // 6.2 "better message": with game-dir hints, the compiler prompt NAMES every candidate it checked (so a miss says
+        // WHERE houseCARL looked — across BOTH the load-order dir AND the located Steam install) — WITHOUT losing the
+        // tool-key + resolving-call contract.
+        var hintA = Path.Combine(Path.GetTempPath(), "hc-stockgame-" + Guid.NewGuid().ToString("N"));   // load-order game dir
+        var hintB = Path.Combine(Path.GetTempPath(), "hc-steam-" + Guid.NewGuid().ToString("N"));        // located Steam install
+        var candA = Path.Combine(hintA, "Papyrus Compiler", "PapyrusCompiler.exe");
+        var candB = Path.Combine(hintB, "Papyrus Compiler", "PapyrusCompiler.exe");
+        var compPrompt = ToolBridge.RenderMissingPrompt(ToolDependency.PapyrusCompiler, new[] { hintA, hintB });
+        Check(compPrompt.Contains(candA) && compPrompt.Contains(candB),
+              "compiler prompt names EVERY game-dir candidate it auto-checked (load-order dir + Steam install)");
         Check(compPrompt.Contains("housecarl_set_tool_path") && compPrompt.Contains("papyrus_compiler"),
               "compiler prompt keeps the tool-key + resolving-call contract alongside the looked-here note");
         Check(!ToolBridge.RenderMissingPrompt(ToolDependency.PapyrusCompiler).Contains("looked for it automatically"),
-              "compiler prompt with NO hint names no location (nothing was auto-checked)");
+              "compiler prompt with NO hints names no location (nothing was auto-checked)");
 
         // ---------------------------------------------------------------- 4) PARSE
         Console.WriteLine();
@@ -152,24 +157,28 @@ public static class ToolBridgeProbe
         // ---------------------------------------------------------------- 5) AUTO-DETECT (6.2 compiler game-dir anchor)
         Console.WriteLine();
         Console.WriteLine("--- 5: ToolBridge.Probe — compiler auto-detects under the game-dir hint; bsarch never does ---");
-        // A synthetic game dir with the CK's canonical compiler layout: <game>\Papyrus Compiler\PapyrusCompiler.exe.
-        var synthGame = Path.Combine(Path.GetTempPath(), "hc-synthgame-" + Guid.NewGuid().ToString("N"));
-        var synthCompilerDir = Path.Combine(synthGame, "Papyrus Compiler");
-        var synthCompiler = Path.Combine(synthCompilerDir, "PapyrusCompiler.exe");
-        Directory.CreateDirectory(synthCompilerDir);
-        File.WriteAllText(synthCompiler, "stub");
+        // Two synthetic game dirs modelling the common Stock-Game setup: [0] the load order's dir (a COPY, no CK) and
+        // [1] the located Steam install (HAS the CK). The CK layout is <game>\Papyrus Compiler\PapyrusCompiler.exe.
+        var stockGame = Path.Combine(Path.GetTempPath(), "hc-stock-" + Guid.NewGuid().ToString("N"));   // no CK
+        var steamGame = Path.Combine(Path.GetTempPath(), "hc-steam-" + Guid.NewGuid().ToString("N"));   // has CK
+        var steamCompiler = Path.Combine(steamGame, "Papyrus Compiler", "PapyrusCompiler.exe");
+        Directory.CreateDirectory(stockGame);
+        Directory.CreateDirectory(Path.Combine(steamGame, "Papyrus Compiler"));
+        File.WriteAllText(steamCompiler, "stub");
         try
         {
-            Check(ToolBridge.Probe(ToolDependency.PapyrusCompiler, synthGame) == synthCompiler,
-                  "compiler probe (with game-dir hint) hits <game>\\Papyrus Compiler\\PapyrusCompiler.exe");
+            Check(ToolBridge.Probe(ToolDependency.PapyrusCompiler, new[] { steamGame }) == steamCompiler,
+                  "compiler probe (single game-dir hint) hits <game>\\Papyrus Compiler\\PapyrusCompiler.exe");
+            // THE Stock-Game fix: the load-order dir misses, the located Steam install hits — ordered search returns Steam.
+            Check(ToolBridge.Probe(ToolDependency.PapyrusCompiler, new[] { stockGame, steamGame }) == steamCompiler,
+                  "Stock-Game case: load-order dir misses, located Steam install hits (ordered multi-dir search — the fix)");
             Check(ToolBridge.Probe(ToolDependency.PapyrusCompiler) is null,
-                  "compiler probe with NO hint yields no candidate (pre-6.2 behavior — falls through to the prompt)");
-            var emptyGame = Path.Combine(Path.GetTempPath(), "hc-emptygame-" + Guid.NewGuid().ToString("N"));
-            Check(ToolBridge.Probe(ToolDependency.PapyrusCompiler, emptyGame) is null,
-                  "compiler probe misses when the hinted game dir has no Papyrus Compiler\\ (a Stock-Game copy)");
-            Check(ToolBridge.Probe(ToolDependency.Bsarch, synthGame) is null, "bsarch has no canonical home (always prompts, hint ignored)");
+                  "compiler probe with NO hints yields no candidate (pre-6.2 behavior — falls through to the prompt)");
+            Check(ToolBridge.Probe(ToolDependency.PapyrusCompiler, new[] { stockGame }) is null,
+                  "compiler probe misses when the only hinted dir has no Papyrus Compiler\\ (a Stock-Game copy, no CK)");
+            Check(ToolBridge.Probe(ToolDependency.Bsarch, new[] { steamGame }) is null, "bsarch has no canonical home (always prompts, hints ignored)");
         }
-        finally { try { Directory.Delete(synthGame, recursive: true); } catch { /* non-fatal */ } }
+        finally { try { Directory.Delete(stockGame, recursive: true); Directory.Delete(steamGame, recursive: true); } catch { /* non-fatal */ } }
         // (papyrus_logs / crash_logs probe the user's Documents — environment-dependent, so not asserted here.)
 
         // ---------------------------------------------------------------- 6) INSPECT (status surface: saved → auto-detect → unset, PURE)

--- a/src/housecarl-generator/ToolBridgeProbe.cs
+++ b/src/housecarl-generator/ToolBridgeProbe.cs
@@ -13,13 +13,20 @@ namespace HousecarlGenerator;
 ///      STORE INSTANCES on one file (the CLI + desktop two-process shape) serialize on the named cross-process mutex
 ///      instead of losing each other's read-modify-write.
 ///   2. <see cref="ToolBridge.Validate"/> — rejects a missing exe / wrong-named exe / missing dir; accepts a real exe + dir.
-///   3. <see cref="ToolBridge.RenderMissingPrompt"/> — the forcing function names the tool key AND the resolving call.
+///   3. <see cref="ToolBridge.RenderMissingPrompt"/> — the forcing function names the tool key AND the resolving call, AND
+///      (6.2) when auto-detect had a candidate to check, NAMES where it looked — a missed compiler game-dir anchor tells
+///      the user which path failed, while keeping the tool-key + resolving-call contract intact.
 ///   4. <see cref="ToolBridge.TryParse"/> — wire names round-trip; junk is rejected.
-///   5. <see cref="ToolBridge.Probe"/> — the compiler probe hits a synthetic &lt;game&gt;\Papyrus Compiler\PapyrusCompiler.exe
-///      and misses when absent; BSArch has no canonical home (always null).
+///   5. <see cref="ToolBridge.Probe"/> (6.2 compiler auto-detect) — WITH a gameDirHint the compiler probe hits a synthetic
+///      &lt;game&gt;\Papyrus Compiler\PapyrusCompiler.exe and misses when that exe is absent (a Stock-Game copy); WITHOUT a
+///      hint it yields no candidate (null), the pre-6.2 behavior; BSArch has no canonical home (always null).
 ///   6. <see cref="ToolBridge.Inspect"/> — the status-surface resolve (housecarl_load_order_status' log-folder section): a
 ///      saved+valid path → Saved; an invalid/absent one with no canonical home → Unset; PURE (takes the saved path,
 ///      persists nothing — a ReadOnly status read never mutates config).
+///   7. CROSS-INSTANCE SHARING (6.2/7.1 "share across instances") — tool paths live in ONE global houseCARL.user.json keyed
+///      by tool, and an MO2-instance switch (SetInstance) only writes Mo2InstanceDir; so repeated instance-dir rewrites
+///      (the switch shape) leave the saved compiler + bsarch paths untouched. A regression-lock on that by-construction
+///      coexistence (the same store the clobber-safety arm proves), framed in the gap's own "set once, reuse" terms.
 ///
 /// The cross-restart persistence + live-server forcing-function proof is the Aaron-empirical follow-up (needs his install).
 /// Run: dotnet run --project src/housecarl-generator tool-bridge
@@ -118,10 +125,22 @@ public static class ToolBridgeProbe
 
         // ---------------------------------------------------------------- 3) MISSING-DEPENDENCY PROMPT (forcing function)
         Console.WriteLine();
-        Console.WriteLine("--- 3: ToolBridge.RenderMissingPrompt — scripts the ask + the resolving call ---");
+        Console.WriteLine("--- 3: ToolBridge.RenderMissingPrompt — scripts the ask + the resolving call (+ where it looked) ---");
         var prompt = ToolBridge.RenderMissingPrompt(ToolDependency.Bsarch);
         Check(prompt.Contains("housecarl_set_tool_path"), "prompt names the resolving call");
         Check(prompt.Contains("bsarch"), "prompt names the tool key");
+        Check(!prompt.Contains("looked for it automatically"), "BSArch (no candidates) prompt names NO looked-here location");
+
+        // 6.2 "better message": with a game-dir hint, the compiler prompt NAMES the candidate it checked (so a Stock-Game
+        // miss says WHERE houseCARL looked) — WITHOUT losing the tool-key + resolving-call contract.
+        var hintDir = Path.Combine(Path.GetTempPath(), "hc-no-such-game-" + Guid.NewGuid().ToString("N"));
+        var expectedCandidate = Path.Combine(hintDir, "Papyrus Compiler", "PapyrusCompiler.exe");
+        var compPrompt = ToolBridge.RenderMissingPrompt(ToolDependency.PapyrusCompiler, hintDir);
+        Check(compPrompt.Contains(expectedCandidate), "compiler prompt (hinted) names the exact path it auto-checked");
+        Check(compPrompt.Contains("housecarl_set_tool_path") && compPrompt.Contains("papyrus_compiler"),
+              "compiler prompt keeps the tool-key + resolving-call contract alongside the looked-here note");
+        Check(!ToolBridge.RenderMissingPrompt(ToolDependency.PapyrusCompiler).Contains("looked for it automatically"),
+              "compiler prompt with NO hint names no location (nothing was auto-checked)");
 
         // ---------------------------------------------------------------- 4) PARSE
         Console.WriteLine();
@@ -130,11 +149,27 @@ public static class ToolBridgeProbe
         Check(ToolBridge.TryParse("CRASH_LOGS", out var d2) && d2 == ToolDependency.CrashLogs, "parses case-insensitively");
         Check(!ToolBridge.TryParse("nonsense", out _), "rejects an unknown tool");
 
-        // ---------------------------------------------------------------- 5) AUTO-DETECT
+        // ---------------------------------------------------------------- 5) AUTO-DETECT (6.2 compiler game-dir anchor)
         Console.WriteLine();
-        Console.WriteLine("--- 5: ToolBridge.Probe — compiler + bsarch have no cheap canonical home (prompt) ---");
-        Check(ToolBridge.Probe(ToolDependency.PapyrusCompiler) is null, "compiler has no probe home (prompts; the CK lives in the separate Steam install)");
-        Check(ToolBridge.Probe(ToolDependency.Bsarch) is null, "bsarch has no canonical home (always prompts)");
+        Console.WriteLine("--- 5: ToolBridge.Probe — compiler auto-detects under the game-dir hint; bsarch never does ---");
+        // A synthetic game dir with the CK's canonical compiler layout: <game>\Papyrus Compiler\PapyrusCompiler.exe.
+        var synthGame = Path.Combine(Path.GetTempPath(), "hc-synthgame-" + Guid.NewGuid().ToString("N"));
+        var synthCompilerDir = Path.Combine(synthGame, "Papyrus Compiler");
+        var synthCompiler = Path.Combine(synthCompilerDir, "PapyrusCompiler.exe");
+        Directory.CreateDirectory(synthCompilerDir);
+        File.WriteAllText(synthCompiler, "stub");
+        try
+        {
+            Check(ToolBridge.Probe(ToolDependency.PapyrusCompiler, synthGame) == synthCompiler,
+                  "compiler probe (with game-dir hint) hits <game>\\Papyrus Compiler\\PapyrusCompiler.exe");
+            Check(ToolBridge.Probe(ToolDependency.PapyrusCompiler) is null,
+                  "compiler probe with NO hint yields no candidate (pre-6.2 behavior — falls through to the prompt)");
+            var emptyGame = Path.Combine(Path.GetTempPath(), "hc-emptygame-" + Guid.NewGuid().ToString("N"));
+            Check(ToolBridge.Probe(ToolDependency.PapyrusCompiler, emptyGame) is null,
+                  "compiler probe misses when the hinted game dir has no Papyrus Compiler\\ (a Stock-Game copy)");
+            Check(ToolBridge.Probe(ToolDependency.Bsarch, synthGame) is null, "bsarch has no canonical home (always prompts, hint ignored)");
+        }
+        finally { try { Directory.Delete(synthGame, recursive: true); } catch { /* non-fatal */ } }
         // (papyrus_logs / crash_logs probe the user's Documents — environment-dependent, so not asserted here.)
 
         // ---------------------------------------------------------------- 6) INSPECT (status surface: saved → auto-detect → unset, PURE)
@@ -162,6 +197,28 @@ public static class ToolBridgeProbe
             // runtime ToolPathResolver owns persistence, so a ReadOnly status read can never mutate config.
         }
         finally { try { File.Delete(realExe); Directory.Delete(realDir); } catch { /* non-fatal */ } }
+
+        // ---------------------------------------------------------------- 7) CROSS-INSTANCE SHARING (6.2/7.1: set once, reuse)
+        Console.WriteLine();
+        Console.WriteLine("--- 7: tool paths persist across MO2-instance switches (one global file; SetInstance writes only Mo2InstanceDir) ---");
+        var tmp7 = Path.Combine(Path.GetTempPath(), "houseCARL.user.share." + Guid.NewGuid().ToString("N") + ".json");
+        try
+        {
+            var store = new UserConfigStore(tmp7);
+            // The user sets the compiler + bsarch ONCE (housecarl_set_tool_path writes ToolPaths).
+            store.Update(c => (c.ToolPaths ??= new())["papyrus_compiler"] = @"C:\CK\Papyrus Compiler\PapyrusCompiler.exe");
+            store.Update(c => (c.ToolPaths ??= new())["bsarch"] = @"C:\Tools\bsarch.exe");
+            // Now they "jump around" instances — each SetInstance writes ONLY Mo2InstanceDir (PersistInstanceDir), never
+            // ToolPaths. Replay that shape: repeated instance-dir rewrites must not disturb the saved tool paths.
+            for (int i = 1; i <= 5; i++) store.Update(c => c.Mo2InstanceDir = @"C:\MO2\Instance" + i);
+            var after = store.Load();
+            Check(after.Mo2InstanceDir == @"C:\MO2\Instance5", "the last instance switch is recorded");
+            Check(after.ToolPaths is { } tps
+                  && tps.TryGetValue("papyrus_compiler", out var cp) && cp == @"C:\CK\Papyrus Compiler\PapyrusCompiler.exe"
+                  && tps.TryGetValue("bsarch", out var bs) && bs == @"C:\Tools\bsarch.exe",
+                  "BOTH tool paths survive every instance switch unchanged (set once → shared across instances)");
+        }
+        finally { try { File.Delete(tmp7); } catch { /* non-fatal */ } }
 
         Console.WriteLine();
         Console.WriteLine(fail == 0

--- a/src/housecarl-mcp/CompileTools.cs
+++ b/src/housecarl-mcp/CompileTools.cs
@@ -86,7 +86,7 @@ public static class CompileTools
 
         // 6) compile + render.
         var result = HousecarlCore.PapyrusCompile.CompileObject(compilerExe!, objectName, imports, rf.OutputDir);
-        var rendered = Render(result, imports);
+        var rendered = Render(result, imports, userChoseOutputDir: !string.IsNullOrWhiteSpace(output_dir));
         if (result.Success)
         {
             // Q3: never report a clean "done" for a .pex that won't deploy from where output_dir= put it.
@@ -140,7 +140,7 @@ public static class CompileTools
         return imports.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
     }
 
-    static string Render(HousecarlCore.CompileResult r, IReadOnlyList<string> imports)
+    internal static string Render(HousecarlCore.CompileResult r, IReadOnlyList<string> imports, bool userChoseOutputDir)
     {
         var sb = new StringBuilder();
         if (!r.Ran) return "error: " + r.RunError;   // the compiler couldn't be run at all
@@ -148,7 +148,12 @@ public static class CompileTools
         if (r.Success)
         {
             sb.Append("compile OK: ").Append(r.ObjectName).Append(".psc → ").Append(r.PexPath).Append('\n');
-            sb.Append("the .pex is in a houseCARL patch-mod folder — enable it in MO2 to use it.");
+            // The destination line must match where the .pex actually went (Q3 — don't claim a houseCARL patch folder for a
+            // user-chosen output_dir=, where there may be no "enable in MO2" step at all). Any deployability caveat for an
+            // output_dir= target is appended by the caller as deployWarning.
+            sb.Append(userChoseOutputDir
+                ? "the .pex is in the output folder you chose (path above)."
+                : "the .pex is in a houseCARL patch-mod folder — enable it in MO2 to use it.");
             if (r.Diagnostics.Count > 0)   // a .pex WAS produced but the compiler emitted notes → surface them as warnings
             {
                 sb.Append('\n').Append(r.Diagnostics.Count).Append(" warning(s) (the .pex compiled anyway):");

--- a/src/housecarl-mcp/CompileTools.cs
+++ b/src/housecarl-mcp/CompileTools.cs
@@ -54,8 +54,10 @@ public static class CompileTools
         var objectName = Path.GetFileNameWithoutExtension(script);
         var scriptDir = Path.GetDirectoryName(script)!;
 
-        // 3) the compiler — bridge forcing function if unset (returns the trained prompt to surface).
-        if (bridge.RequireOrPrompt(ToolDependency.PapyrusCompiler, out var compilerExe) is { } toolPrompt) return toolPrompt;
+        // 3) the compiler — bridge forcing function if unset (returns the trained prompt to surface). Pass the active
+        // load order's game dir as the auto-detect HINT (the CK installs its compiler under it): a normal Steam+CK install
+        // resolves with no prompt; a Wabbajack Stock-Game copy misses and the prompt names where houseCARL looked (6.2).
+        if (bridge.RequireOrPrompt(ToolDependency.PapyrusCompiler, out var compilerExe, svc.GameDirOrNull()) is { } toolPrompt) return toolPrompt;
 
         // 4) import dirs — assembled by BuildImports (the guard-probed seam).
         var imports = BuildImports(scriptDir, compilerExe!, import_dirs);

--- a/src/housecarl-mcp/CompileTools.cs
+++ b/src/housecarl-mcp/CompileTools.cs
@@ -18,7 +18,8 @@ public static class CompileTools
     [McpServerTool(Name = "housecarl_compile_script", Title = "Compile a Papyrus script (.psc → .pex)"),
      Description(
          "Compile a Papyrus script (.psc) to .pex using the Creation Kit's PapyrusCompiler.exe, landing the .pex in a NEW " +
-         "houseCARL patch-mod folder you review and enable in MO2 (originals untouched). Pass script= the full path to the " +
+         "houseCARL patch-mod folder you review and enable in MO2 (originals untouched) — or pass output_dir= to land it in a " +
+         "folder you choose (houseCARL appends Scripts\\ so MO2 deploys it). Pass script= the full path to the " +
          ".psc to compile; houseCARL adds the script's own folder and the vanilla source folder (derived from the compiler's " +
          "game dir) to the import path automatically — pass import_dirs= (';'-separated) for any extra dependency sources " +
          "(SKSE, other mods); your folders are searched BEFORE the vanilla sources, so mod-extended copies of vanilla " +
@@ -37,7 +38,9 @@ public static class CompileTools
         [Description("Optional. Base name for the NEW patch-mod folder the .pex lands in (default 'houseCARL_Scripts'); auto-suffixed if taken.")]
             string? patch_name = null,
         [Description("Optional. Filename of an existing houseCARL patch mod to add the .pex into instead of creating a fresh folder (accumulate compiled scripts).")]
-            string? into = null) => Guard.Tool("housecarl_compile_script", () =>
+            string? into = null,
+        [Description("Optional. Land the .pex in a folder of YOUR choosing instead of a fresh houseCARL patch folder — pass the mod-folder ROOT; houseCARL appends Scripts\\ (and won't double it if you already point at a ...\\Scripts folder). When set, patch_name=/into= are ignored. If the folder is under neither your MO2 mods folder nor the game's Data, the .pex still compiles but you're warned it won't deploy automatically.")]
+            string? output_dir = null) => Guard.Tool("housecarl_compile_script", () =>
     {
         // 1) MO2 must be configured — the .pex lands under the instance's mods folder.
         if (svc.ConfigPromptOrNull() is { } cfgPrompt) return cfgPrompt;
@@ -62,22 +65,42 @@ public static class CompileTools
         // 4) import dirs — assembled by BuildImports (the guard-probed seam).
         var imports = BuildImports(scriptDir, compilerExe!, import_dirs);
 
-        // 5) output folder (folder-per-patch, Scripts\ subdir).
+        // 5) output folder — output_dir= names a USER-OWNED location (append Scripts\, never a houseCARL patch folder; 6.3),
+        // else the default folder-per-patch with its Scripts\ subdir. output_dir= wins; patch_name=/into= are then ignored
+        // (surfaced, not silent — Q3).
         LoadOrderService.RiderFolder rf;
-        try { rf = svc.ResolveCompiledScriptFolder(patch_name, into); }
-        catch (InvalidOperationException ex) { return "error: " + ex.Message; }
+        string? deployWarning = null, outputNote = null;
+        if (!string.IsNullOrWhiteSpace(output_dir))
+        {
+            if (!string.IsNullOrWhiteSpace(patch_name) || !string.IsNullOrWhiteSpace(into))
+                outputNote = "note: output_dir= was given, so patch_name=/into= are ignored (the .pex lands in output_dir, not a houseCARL patch folder).";
+            try { rf = svc.ResolveExplicitScriptFolder(output_dir, out deployWarning); }
+            catch (InvalidOperationException ex) { return "error: " + ex.Message; }
+        }
+        else
+        {
+            try { rf = svc.ResolveCompiledScriptFolder(patch_name, into); }
+            catch (InvalidOperationException ex) { return "error: " + ex.Message; }
+        }
 
         // 6) compile + render.
         var result = HousecarlCore.PapyrusCompile.CompileObject(compilerExe!, objectName, imports, rf.OutputDir);
         var rendered = Render(result, imports);
-        // A failed compile produced no .pex — clean up a genuinely-empty fresh folder, name a partial one, leave an
-        // into= reuse alone (hunt H2, Aaron's delete-if-empty).
-        if (!result.Success)
+        if (result.Success)
         {
+            // Q3: never report a clean "done" for a .pex that won't deploy from where output_dir= put it.
+            if (deployWarning is not null) rendered += "\n" + deployWarning;
+        }
+        else
+        {
+            // A failed compile produced no .pex — clean up a genuinely-empty fresh folder, name a partial one, leave an
+            // into= reuse alone (hunt H2, Aaron's delete-if-empty). An output_dir= folder is USER-OWNED (CreatedFresh=false),
+            // so RemoveOrNameRiderResidue returns null for it by construction — never delete-if-empty a user dir.
             var left = svc.RemoveOrNameRiderResidue(rf);
             if (left is not null)
                 rendered += $"\nThe freshly created mod folder at '{left}' still holds partial output — delete it or retry with into=.";
         }
+        if (outputNote is not null) rendered = outputNote + "\n" + rendered;
         return rendered;
     });
 

--- a/src/housecarl-mcp/CompileTools.cs
+++ b/src/housecarl-mcp/CompileTools.cs
@@ -57,10 +57,11 @@ public static class CompileTools
         var objectName = Path.GetFileNameWithoutExtension(script);
         var scriptDir = Path.GetDirectoryName(script)!;
 
-        // 3) the compiler — bridge forcing function if unset (returns the trained prompt to surface). Pass the active
-        // load order's game dir as the auto-detect HINT (the CK installs its compiler under it): a normal Steam+CK install
-        // resolves with no prompt; a Wabbajack Stock-Game copy misses and the prompt names where houseCARL looked (6.2).
-        if (bridge.RequireOrPrompt(ToolDependency.PapyrusCompiler, out var compilerExe, svc.GameDirOrNull()) is { } toolPrompt) return toolPrompt;
+        // 3) the compiler — bridge forcing function if unset (returns the trained prompt to surface). Pass the auto-detect
+        // HINTS (the CK installs its compiler under <game>\Papyrus Compiler\): the load order's own game dir first, then the
+        // located real Steam SE install — so a normal Steam+CK install AND the common Stock-Game setup (CK lives in the Steam
+        // install, not the copy MO2 points at) both resolve with no prompt; a total miss names where houseCARL looked (6.2).
+        if (bridge.RequireOrPrompt(ToolDependency.PapyrusCompiler, out var compilerExe, svc.CompilerGameDirHints()) is { } toolPrompt) return toolPrompt;
 
         // 4) import dirs — assembled by BuildImports (the guard-probed seam).
         var imports = BuildImports(scriptDir, compilerExe!, import_dirs);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1458,7 +1458,13 @@ public sealed class LoadOrderService : IDisposable
                 throw new InvalidOperationException($"output_dir '{root}' is a file, not a folder. Give a mod-folder root — houseCARL appends Scripts\\.");
 
             var (scriptsDir, appended, warn) = ScriptOutputContract(root, _modsDir, _dataDir);
-            Directory.CreateDirectory(scriptsDir);
+            // Friendly Q3 message if the folder can't be created — e.g. <output_dir>\Scripts already exists AS A FILE, or
+            // the path is read-only — instead of letting the IO/access exception reach Guard.Tool's generic "internal
+            // failure" (which would wrongly read as a houseCARL bug, not bad input). The File.Exists(root) guard above
+            // already catches the common "output_dir itself is a file" shape; this rounds out the rest.
+            try { Directory.CreateDirectory(scriptsDir); }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            { throw new InvalidOperationException($"output_dir: couldn't create the output folder '{scriptsDir}' ({ex.Message}). Check the path and that it's writable."); }
             deployWarning = warn;
             // ModFolder = the mod-folder root (inert here — cleanup is bypassed by CreatedFresh=false — but kept honest):
             // when the user pointed AT a Scripts\ dir, the root is its parent; otherwise the path they gave IS the root.

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -641,6 +641,25 @@ public sealed class LoadOrderService : IDisposable
     /// name); "" when unconfigured. For the status surface.</summary>
     public string ProfileName { get { lock (_gate) { return _profileName; } } }
 
+    /// <summary>The game install directory the load order points at — DataDir's PARENT (DataDir = gamePath\Data), the same
+    /// derivation the asset-discovery path uses — or null when it isn't derivable. The compile rider's auto-detect HINT: the
+    /// CK installs its compiler at &lt;gamePath&gt;\Papyrus Compiler\PapyrusCompiler.exe (6.2). NULL-SAFE by contract — it is
+    /// best-effort plumbing, so a failure here must fall through to the forcing prompt, NEVER throw and abort the compile:
+    /// returns null when unconfigured (no _configured guard would otherwise hit EnsurePathsDerived's NotConfigured throw),
+    /// when the instance is unusable (EnsurePathsDerived throws naming the missing piece — the rider's own config gate
+    /// reports that; here it's just "no hint"), or when DataDir hasn't been derived yet. Takes <see cref="_gate"/> like the
+    /// other derived-root reads; works in explicit mode too (DataDir is set directly, EnsurePathsDerived no-ops).</summary>
+    public string? GameDirOrNull()
+    {
+        lock (_gate)
+        {
+            if (!_configured) return null;
+            try { EnsurePathsDerived(); }
+            catch { return null; }                                  // unusable instance → no hint (Q3: the rider's config gate names the real problem)
+            return _dataDir.Length > 0 ? Path.GetDirectoryName(_dataDir.TrimEnd('\\', '/')) : null;
+        }
+    }
+
     /// <summary>Point houseCARL at an MO2 instance folder — first-run setup AND switching between instances ("jump around").
     /// VALIDATES it (<see cref="Mo2Instance.Resolve"/> throws a clear Q3 message if it isn't usable — nothing is changed or
     /// persisted on failure), then re-points the live service (derives the roots + active profile, drops the cached resolver

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1480,23 +1480,44 @@ public sealed class LoadOrderService : IDisposable
         var root = outputDir.TrimEnd('\\', '/');
         bool alreadyScripts = Path.GetFileName(root).Equals("Scripts", StringComparison.OrdinalIgnoreCase);
         var scriptsDir = alreadyScripts ? root : Path.Combine(root, "Scripts");
-        bool deployable = IsUnder(scriptsDir, modsDir) || IsUnder(scriptsDir, dataDir);
+        // Deployable = the .pex will ACTUALLY auto-load. MO2 overlays a mod folder's CONTENTS onto the game Data root, so a
+        // deployable mod Scripts\ is EXACTLY <mods>\<modFolder>\Scripts (mod folder a direct child of mods; Scripts directly
+        // under it). A bare <mods>\Scripts (no mod folder) and a nested <mods>\X\Sub\Scripts (lands at Data\Sub\Scripts, not
+        // Data\Scripts) do NOT load — so they correctly WARN (review nit: "under mods" alone was too loose). A direct game
+        // install loads exactly <data>\Scripts.
+        bool deployable = IsModScriptsFolder(scriptsDir, modsDir) || IsDataScriptsFolder(scriptsDir, dataDir);
         string? warn = deployable ? null :
-            $"note: '{scriptsDir}' is under neither your MO2 mods folder nor the game's Data folder, so MO2 won't deploy " +
-            "the compiled script automatically — it compiled fine, but you must place it where the game loads scripts " +
-            "(a mod's Scripts\\ folder, or <game>\\Data\\Scripts) yourself.";
+            $"note: '{scriptsDir}' isn't a folder MO2 (or the game) auto-loads scripts from, so the compiled .pex won't " +
+            "deploy on its own — it compiled fine, but you must place it where the game loads scripts yourself: a mod's " +
+            "own Scripts\\ folder (<mods>\\<YourMod>\\Scripts) or the game's <Data>\\Scripts.";
         return (scriptsDir, !alreadyScripts, warn);
     }
 
-    /// <summary>Case-insensitive "is <paramref name="child"/> at or below <paramref name="parent"/>" by normalized path
-    /// prefix, segment-boundary safe (so C:\ModsX is NOT "under" C:\Mods). An empty parent (unconfigured root) → false.</summary>
-    static bool IsUnder(string child, string parent)
+    /// <summary>A Scripts\ folder MO2 actually deploys: <c>&lt;modsDir&gt;\&lt;modFolder&gt;\Scripts</c> exactly — the mod
+    /// folder a DIRECT child of the mods root, Scripts directly under it (MO2 maps a mod folder's contents onto the Data
+    /// root, so <c>&lt;mods&gt;\Scripts</c> has no mod and <c>&lt;mods&gt;\X\Sub\Scripts</c> lands at Data\Sub\Scripts). Empty
+    /// mods root (unconfigured) → false. Case-insensitive, normalized.</summary>
+    static bool IsModScriptsFolder(string scriptsDir, string modsDir)
     {
-        if (string.IsNullOrEmpty(parent)) return false;
-        var c = Path.GetFullPath(child).TrimEnd('\\', '/');
-        var p = Path.GetFullPath(parent).TrimEnd('\\', '/');
-        return c.Equals(p, StringComparison.OrdinalIgnoreCase)
-            || c.StartsWith(p + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+        if (string.IsNullOrEmpty(modsDir)) return false;
+        var modFolder = Path.GetDirectoryName(scriptsDir.TrimEnd('\\', '/'));   // expect <mods>\<modFolder>
+        return modFolder is not null && PathEquals(Path.GetDirectoryName(modFolder), modsDir);
+    }
+
+    /// <summary>A direct game install loads exactly <c>&lt;dataDir&gt;\Scripts</c> (not Data\Sub\Scripts). Empty data dir →
+    /// false. Case-insensitive, normalized.</summary>
+    static bool IsDataScriptsFolder(string scriptsDir, string dataDir)
+    {
+        if (string.IsNullOrEmpty(dataDir)) return false;
+        return PathEquals(Path.GetDirectoryName(scriptsDir.TrimEnd('\\', '/')), dataDir);
+    }
+
+    /// <summary>Case-insensitive equality of two paths after full-path normalization + trailing-separator trim (no
+    /// filesystem access). A null left side (no parent — e.g. a drive root) is never equal.</summary>
+    static bool PathEquals(string? a, string b)
+    {
+        if (a is null) return false;
+        return Path.GetFullPath(a).TrimEnd('\\', '/').Equals(Path.GetFullPath(b).TrimEnd('\\', '/'), StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>The <c>Source\Scripts\</c> output folder for a DECOMPILED .psc (the decompile rider) — the SE-canonical

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -660,6 +660,41 @@ public sealed class LoadOrderService : IDisposable
         }
     }
 
+    /// <summary>The game directories to search for the Creation Kit's compiler, in PRIORITY ORDER — the compile rider's
+    /// auto-detect hints (6.2). [0] = the load order's OWN game dir (<see cref="GameDirOrNull"/>): correct when MO2 points
+    /// straight at a real, CK-equipped install. Then the GameFinder/Mutagen-located real Skyrim SE install(s): in the common
+    /// MO2 "Stock Game" setup (Aaron 2026-06-17) the load order points at a COPY that has NEITHER the CK nor the vanilla
+    /// script sources — both live in the Steam install — so the located install is the one that actually hits. De-duplicated,
+    /// nulls dropped. BEST-EFFORT + NULL-SAFE end to end: the locator reads the registry/Steam, so a miss or a throw just
+    /// yields fewer hints (the forcing prompt then names what was checked), it NEVER aborts the compile.
+    /// <para>LOAD-BEARING (do NOT "simplify"): the compile rider derives the vanilla SOURCE folder from the RESOLVED
+    /// COMPILER's own game dir (<see cref="CompileTools.BuildImports"/>), NOT from these hints and NOT from the data dir — so
+    /// once the compiler resolves to the Steam install, its sibling Data\Source\Scripts is used, never the Stock Game copy's
+    /// (which usually has none). Keying sources off the data dir would re-break exactly the Stock-Game case this fixes.</para></summary>
+    public IReadOnlyList<string> CompilerGameDirHints()
+    {
+        var hints = new List<string>();
+        if (GameDirOrNull() is { } loadOrderGameDir) hints.Add(loadOrderGameDir);
+        try
+        {
+            // The bundled GameFinder locator (Steam/GOG/Xbox), via Mutagen — finds the REAL Skyrim SE install (App 489830),
+            // where the Creation Kit + sources live, regardless of where MO2's load order points.
+            if (new Mutagen.Bethesda.Installs.GameLocator().TryGetGameDirectory(
+                    Mutagen.Bethesda.GameRelease.SkyrimSE, out var dir) && !string.IsNullOrWhiteSpace(dir.Path))
+                hints.Add(NormalizeGameDir(dir.Path));
+        }
+        catch { /* GameFinder / registry hiccup → just the load-order hint (best-effort; the prompt still names it) */ }
+        return hints.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    /// <summary>The locator returns the game-install ROOT (the folder holding the exe + Data); defend against a future build
+    /// handing back the Data folder itself by stepping up one level so the &lt;game&gt;\Papyrus Compiler\ join stays correct.</summary>
+    static string NormalizeGameDir(string p)
+    {
+        var t = p.TrimEnd('\\', '/');
+        return Path.GetFileName(t).Equals("Data", StringComparison.OrdinalIgnoreCase) ? (Path.GetDirectoryName(t) ?? t) : t;
+    }
+
     /// <summary>Point houseCARL at an MO2 instance folder — first-run setup AND switching between instances ("jump around").
     /// VALIDATES it (<see cref="Mo2Instance.Resolve"/> throws a clear Q3 message if it isn't usable — nothing is changed or
     /// persisted on failure), then re-points the live service (derives the roots + active profile, drops the cached resolver

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1400,6 +1400,70 @@ public sealed class LoadOrderService : IDisposable
         return f with { OutputDir = scripts };
     }
 
+    /// <summary>output_dir= escape hatch (6.3): the user names WHERE the compiled .pex lands, instead of houseCARL cutting a
+    /// fresh folder-per-patch mod folder. DECIDED contract (Aaron 2026-06-16): output_dir is a mod-folder ROOT and houseCARL
+    /// appends Scripts\ — matching <see cref="ResolveCompiledScriptFolder"/> + MO2's deploy model so the .pex actually loads —
+    /// with a DOUBLE-SCRIPTS guard (don't append a second Scripts\ if it's already there). Does NOT call
+    /// <see cref="ResolvePatchModFolder"/> (no houseCARL mod folder is cut under ModsDir), and the folder is USER-OWNED — the
+    /// returned <see cref="RiderFolder"/> carries CreatedFresh=false, so <see cref="RemoveOrNameRiderResidue"/> never deletes
+    /// it on a failed compile (it early-returns on !CreatedFresh). <paramref name="deployWarning"/> is a Q3 note (non-null)
+    /// when the final Scripts\ path is under neither the MO2 mods tree nor the game's Data — the .pex compiles but the game
+    /// won't auto-load it from there, so a clean "done" is never reported for a .pex that won't deploy. Refuses loud (Q3) on
+    /// an unusable output_dir (a malformed path, or a path that names an existing FILE).</summary>
+    public RiderFolder ResolveExplicitScriptFolder(string outputDir, out string? deployWarning)
+    {
+        lock (_gate)
+        {
+            if (!_configured) throw NotConfigured();
+            EnsurePathsDerived();                          // cheap: derive ModsDir/DataDir for the deployability check, NO resolver build
+            string root;
+            try { root = Path.GetFullPath((outputDir ?? "").Trim().Trim('"')); }
+            catch (Exception ex) { throw new InvalidOperationException($"output_dir '{outputDir}' is not a usable path ({ex.Message})."); }
+            if (File.Exists(root))
+                throw new InvalidOperationException($"output_dir '{root}' is a file, not a folder. Give a mod-folder root — houseCARL appends Scripts\\.");
+
+            var (scriptsDir, appended, warn) = ScriptOutputContract(root, _modsDir, _dataDir);
+            Directory.CreateDirectory(scriptsDir);
+            deployWarning = warn;
+            // ModFolder = the mod-folder root (inert here — cleanup is bypassed by CreatedFresh=false — but kept honest):
+            // when the user pointed AT a Scripts\ dir, the root is its parent; otherwise the path they gave IS the root.
+            var modRoot = appended ? root : (Path.GetDirectoryName(scriptsDir.TrimEnd('\\', '/')) ?? scriptsDir);
+            return new RiderFolder(scriptsDir, modRoot, CreatedFresh: false);   // user-owned: residue cleanup never touches it
+        }
+    }
+
+    /// <summary>PURE (no filesystem access) resolution of the output_dir= contract, so the riskiest 6.3 change is provable in
+    /// CI without an MO2 instance. Appends Scripts\ to a mod-folder root, with the DOUBLE-SCRIPTS GUARD (a root already ending
+    /// in a Scripts segment — any case, trailing separator tolerated — is taken as-is, never doubled). <paramref name="outputDir"/>
+    /// is expected absolute (the caller GetFullPaths it). Returns the final Scripts dir, whether Scripts\ was appended, and a
+    /// Q3 deployWarning when the result is under neither <paramref name="modsDir"/> (a mod's Scripts\ is VFS-deployed) nor
+    /// <paramref name="dataDir"/> (a direct game install) — the one "this won't load" case the contract can't fix by
+    /// construction, so it's surfaced rather than reported as a clean success.</summary>
+    internal static (string scriptsDir, bool appendedScripts, string? deployWarning) ScriptOutputContract(
+        string outputDir, string modsDir, string dataDir)
+    {
+        var root = outputDir.TrimEnd('\\', '/');
+        bool alreadyScripts = Path.GetFileName(root).Equals("Scripts", StringComparison.OrdinalIgnoreCase);
+        var scriptsDir = alreadyScripts ? root : Path.Combine(root, "Scripts");
+        bool deployable = IsUnder(scriptsDir, modsDir) || IsUnder(scriptsDir, dataDir);
+        string? warn = deployable ? null :
+            $"note: '{scriptsDir}' is under neither your MO2 mods folder nor the game's Data folder, so MO2 won't deploy " +
+            "the compiled script automatically — it compiled fine, but you must place it where the game loads scripts " +
+            "(a mod's Scripts\\ folder, or <game>\\Data\\Scripts) yourself.";
+        return (scriptsDir, !alreadyScripts, warn);
+    }
+
+    /// <summary>Case-insensitive "is <paramref name="child"/> at or below <paramref name="parent"/>" by normalized path
+    /// prefix, segment-boundary safe (so C:\ModsX is NOT "under" C:\Mods). An empty parent (unconfigured root) → false.</summary>
+    static bool IsUnder(string child, string parent)
+    {
+        if (string.IsNullOrEmpty(parent)) return false;
+        var c = Path.GetFullPath(child).TrimEnd('\\', '/');
+        var p = Path.GetFullPath(parent).TrimEnd('\\', '/');
+        return c.Equals(p, StringComparison.OrdinalIgnoreCase)
+            || c.StartsWith(p + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+    }
+
     /// <summary>The <c>Source\Scripts\</c> output folder for a DECOMPILED .psc (the decompile rider) — the SE-canonical
     /// source layout, and the same default patch stem as the compile rider so decompile → edit → compile naturally
     /// accumulates in one houseCARL patch folder via <c>into=</c>. Carries the root + fresh flag through for cleanup.</summary>

--- a/src/housecarl-mcp/ToolPathResolver.cs
+++ b/src/housecarl-mcp/ToolPathResolver.cs
@@ -30,22 +30,22 @@ public sealed class ToolPathResolver
     /// <summary>For a status / diagnostic surface (housecarl_load_order_status' log-folder section): where a dependency
     /// resolves right now — saved-and-valid → auto-detected canonical home → unset — WITHOUT persisting (unlike
     /// <see cref="Resolve"/>), so a ReadOnly status read never writes config. Thin wrapper over the pure
-    /// <see cref="ToolBridge.Inspect"/>, supplying the user's saved path. The optional <paramref name="gameDirHint"/>
-    /// feeds the compiler's game-dir-anchored auto-detect (the status log deps that call this pass none).</summary>
-    public (string? path, ToolPathSource source) Inspect(ToolDependency dep, string? gameDirHint = null)
-        => ToolBridge.Inspect(dep, Saved(dep), gameDirHint);
+    /// <see cref="ToolBridge.Inspect"/>, supplying the user's saved path. The optional <paramref name="gameDirHints"/>
+    /// feed the compiler's game-dir-anchored auto-detect (the status log deps that call this pass none).</summary>
+    public (string? path, ToolPathSource source) Inspect(ToolDependency dep, IReadOnlyList<string>? gameDirHints = null)
+        => ToolBridge.Inspect(dep, Saved(dep), gameDirHints);
 
     /// <summary>Resolve a dependency to a usable path: saved → else auto-detect (persist on hit) → else null. A saved path
     /// that no longer validates (tool moved/uninstalled) is treated as unset, so it re-detects or re-prompts rather than
-    /// failing opaquely downstream. The optional <paramref name="gameDirHint"/> (the active load order's game dir) anchors
-    /// the compiler's auto-detect; persisting the hit is what makes "detect once, reuse across instances" work (6.2/7.1) —
-    /// the saved path is checked FIRST on every later call, regardless of which instance is active.</summary>
-    public string? Resolve(ToolDependency dep, string? gameDirHint = null)
+    /// failing opaquely downstream. The optional <paramref name="gameDirHints"/> (the active load order's game dir, then the
+    /// located real Steam install) anchor the compiler's auto-detect; persisting the hit is what makes "detect once, reuse
+    /// across instances" work (6.2/7.1) — the saved path is checked FIRST on every later call, regardless of active instance.</summary>
+    public string? Resolve(ToolDependency dep, IReadOnlyList<string>? gameDirHints = null)
     {
         var saved = Saved(dep);
         if (saved is not null && ToolBridge.Validate(dep, saved).ok) return saved;
 
-        var found = ToolBridge.Probe(dep, gameDirHint);
+        var found = ToolBridge.Probe(dep, gameDirHints);
         if (found is not null)
         {
             // Persist the auto-detected home so we only probe once. This silent persist is the ONE path where a
@@ -79,11 +79,11 @@ public sealed class ToolPathResolver
     /// <summary>The forcing function a rider calls: out <paramref name="path"/> is the resolved path when available and the
     /// return is null (proceed); otherwise the return is the trained prompt string for the rider to RETURN to the client
     /// (so the AI surfaces the ask + the resolving call) and path is null. Exactly one of the two is non-null. The optional
-    /// <paramref name="gameDirHint"/> (trailing, so the BSArch riders that don't have one keep calling with two args) feeds
-    /// the compiler's game-dir-anchored auto-detect AND the prompt's "looked here" note when the anchor missed.</summary>
-    public string? RequireOrPrompt(ToolDependency dep, out string? path, string? gameDirHint = null)
+    /// <paramref name="gameDirHints"/> (trailing, so the BSArch riders that don't have any keep calling with two args) feed
+    /// the compiler's game-dir-anchored auto-detect AND the prompt's "looked here" note when every candidate missed.</summary>
+    public string? RequireOrPrompt(ToolDependency dep, out string? path, IReadOnlyList<string>? gameDirHints = null)
     {
-        path = Resolve(dep, gameDirHint);
-        return path is null ? ToolBridge.RenderMissingPrompt(dep, gameDirHint) : null;
+        path = Resolve(dep, gameDirHints);
+        return path is null ? ToolBridge.RenderMissingPrompt(dep, gameDirHints) : null;
     }
 }

--- a/src/housecarl-mcp/ToolPathResolver.cs
+++ b/src/housecarl-mcp/ToolPathResolver.cs
@@ -30,18 +30,22 @@ public sealed class ToolPathResolver
     /// <summary>For a status / diagnostic surface (housecarl_load_order_status' log-folder section): where a dependency
     /// resolves right now — saved-and-valid → auto-detected canonical home → unset — WITHOUT persisting (unlike
     /// <see cref="Resolve"/>), so a ReadOnly status read never writes config. Thin wrapper over the pure
-    /// <see cref="ToolBridge.Inspect"/>, supplying the user's saved path.</summary>
-    public (string? path, ToolPathSource source) Inspect(ToolDependency dep) => ToolBridge.Inspect(dep, Saved(dep));
+    /// <see cref="ToolBridge.Inspect"/>, supplying the user's saved path. The optional <paramref name="gameDirHint"/>
+    /// feeds the compiler's game-dir-anchored auto-detect (the status log deps that call this pass none).</summary>
+    public (string? path, ToolPathSource source) Inspect(ToolDependency dep, string? gameDirHint = null)
+        => ToolBridge.Inspect(dep, Saved(dep), gameDirHint);
 
     /// <summary>Resolve a dependency to a usable path: saved → else auto-detect (persist on hit) → else null. A saved path
     /// that no longer validates (tool moved/uninstalled) is treated as unset, so it re-detects or re-prompts rather than
-    /// failing opaquely downstream.</summary>
-    public string? Resolve(ToolDependency dep)
+    /// failing opaquely downstream. The optional <paramref name="gameDirHint"/> (the active load order's game dir) anchors
+    /// the compiler's auto-detect; persisting the hit is what makes "detect once, reuse across instances" work (6.2/7.1) —
+    /// the saved path is checked FIRST on every later call, regardless of which instance is active.</summary>
+    public string? Resolve(ToolDependency dep, string? gameDirHint = null)
     {
         var saved = Saved(dep);
         if (saved is not null && ToolBridge.Validate(dep, saved).ok) return saved;
 
-        var found = ToolBridge.Probe(dep);
+        var found = ToolBridge.Probe(dep, gameDirHint);
         if (found is not null)
         {
             // Persist the auto-detected home so we only probe once. This silent persist is the ONE path where a
@@ -74,10 +78,12 @@ public sealed class ToolPathResolver
 
     /// <summary>The forcing function a rider calls: out <paramref name="path"/> is the resolved path when available and the
     /// return is null (proceed); otherwise the return is the trained prompt string for the rider to RETURN to the client
-    /// (so the AI surfaces the ask + the resolving call) and path is null. Exactly one of the two is non-null.</summary>
-    public string? RequireOrPrompt(ToolDependency dep, out string? path)
+    /// (so the AI surfaces the ask + the resolving call) and path is null. Exactly one of the two is non-null. The optional
+    /// <paramref name="gameDirHint"/> (trailing, so the BSArch riders that don't have one keep calling with two args) feeds
+    /// the compiler's game-dir-anchored auto-detect AND the prompt's "looked here" note when the anchor missed.</summary>
+    public string? RequireOrPrompt(ToolDependency dep, out string? path, string? gameDirHint = null)
     {
-        path = Resolve(dep);
-        return path is null ? ToolBridge.RenderMissingPrompt(dep) : null;
+        path = Resolve(dep, gameDirHint);
+        return path is null ? ToolBridge.RenderMissingPrompt(dep, gameDirHint) : null;
     }
 }


### PR DESCRIPTION
**HCBR-2026-06-15-01 / PR-J** — compiler & BSA ergonomics (items 6.2 + 6.3 + 7.1). §4 = n/a (external-tool ergonomics; Mutagen has no Papyrus surface, so this reintroduces no per-record-type mapping). Leaves the HCBR fix-track at **2/13** (L + M, both rig/setup-gated) once merged.

### What lands (4 commits)
1. **`5f8a540` — compiler auto-detect + better refusal + cross-instance sharing (6.2/7.1).** `ToolBridge` checks for `<game>\Papyrus Compiler\PapyrusCompiler.exe`; the missing-dependency prompt now NAMES where it looked; tool paths are locked to survive instance switches; new null-safe `LoadOrderService.GameDirOrNull()`.
2. **`58f8bb1` — `output_dir=` on `housecarl_compile_script` (6.3).** Land the `.pex` in a folder you choose; houseCARL appends `Scripts\` (double-`Scripts` guard); the folder is user-owned (`CreatedFresh:false`, so residue cleanup never deletes it) and `ResolvePatchModFolder` is never called.
3. **`e653e77` — Steam-install discovery for the Stock-Game case.** The common MO2 "Stock Game" layout points the load order at a COPY with no Creation Kit — the CK + vanilla script sources live in the real Steam install. `CompilerGameDirHints()` now also locates that install via the bundled GameFinder/Mutagen `GameLocator` (App 489830) — **zero new dependencies**. Sources stay keyed to the resolved compiler (`BuildImports` untouched), so the Stock-Game split is handled by construction.
4. **`47eea9f` — tighten `output_dir=` deployability (review nit).** "Deployable" is now exactly `<mods>\<modFolder>\Scripts` or `<data>\Scripts` — a bare `<mods>\Scripts` or a nested path now correctly warns instead of falsely reporting a clean "done".

### Verification
- Full solution builds clean; CI probes **40 → 41** (`tool-bridge` extended + new `compile-ergonomics-guard`).
- Every new tooth RED-proven by sabotage (each flips only its own arm), reverted clean.
- **Two independent adversarial reviews APPROVE** — the second fresh on the full 4-commit diff (confirms `BuildImports` unchanged, `GameLocator` null-safe, the `string`→`IReadOnlyList<string>` hint widening broke no BSArch/Setup/Status caller, tightened-deployability edge cases empirically tested).

### Empirical caveat (rig-gated, by design)
The *live* "GameLocator finds the real Steam install on a Stock-Game rig" can't run in CI (no Skyrim on the runner). The discovery logic, ordering, and messaging are unit-tested with synthetic inputs; the real find is verified on the maintainer's rig — added to the pre-release checklist alongside the existing 6.1/6.4 real-compile items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)