### PR TITLE
setup-update-lock: pre-flight the locked-server overwrite (HCBR-2026-06-15-01 / PR-M)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,17 @@ jobs:
       - name: Probe — compile-rider ergonomics (GameDirOrNull null-safety + output_dir= contract)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- compile-ergonomics-guard
 
+      # Setup update-lock pre-flight (HCBR-2026-06-15-01 item 9.1 / PR-M): re-running houseCARL-Setup.exe over a LIVE
+      # install used to overwrite the running housecarl-mcp.exe (CopyDirectory's File.Copy overwrite:true), throw
+      # mid-copy, and leave a half-updated tree behind a generic "did not complete". The fix pre-flights the lock at
+      # EVERY destination before any copy and refuses with actionable "quit Claude/Codex" guidance, with a mid-copy
+      # sharing-violation catch as defense in depth. Drives the real (now-probeable) Program.TryInstall over a
+      # synthetic package + temp home: a clean install succeeds, a held server exe refuses at PRE-FLIGHT for BOTH
+      # Claude and Codex (no copy ran, held exe byte-intact), and a held sibling DLL is caught mid-copy. Self-
+      # contained — synthetic files in temp, no game data / no real host config.
+      - name: Probe — setup update-lock pre-flight (self-contained regression guard)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- setup-update-lock-guard
+
       # The compile tool's import ORDER is semantics (the CK compiler takes the FIRST matching .psc), so caller
       # import_dirs must outrank the auto-added vanilla folder — else SKSE-extended copies of vanilla scripts lose
       # to vanilla and extended calls fail despite the right folder being passed (spike findings §5.12, hit twice).

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ models — by construction, not a hand-maintained subset.
    tell houseCARL your **MO2 instance folder** — the one containing `ModOrganizer.ini`. It prompts you on
    first use; you can switch instances anytime by asking it to set a new one.
 
+> **Updating an existing install?** Fully quit Claude Code (and Codex) before re-running
+> `houseCARL-Setup.exe` — it can't replace the server while a session is running it. If one is, it stops and
+> tells you to quit and re-run.
+
 ### Build from source (developers / verifiers)
 
 Requires the **.NET 9 SDK** (not just the runtime), Windows, and PowerShell.

--- a/packaging/START-HERE.txt
+++ b/packaging/START-HERE.txt
@@ -36,6 +36,13 @@ INSTALL  (about 30 seconds, no command line)
           "which plugins override the IronSword record, and who wins?"
 
 
+UPDATING  (installing a newer houseCARL over an older one)
+------------------------------------------------------------------------
+  Same as installing -- but FULLY QUIT Claude (and Codex) FIRST. The
+  setup can't replace the houseCARL server while a session is running
+  it; if one is, it stops and tells you to quit and re-run.
+
+
 REQUIREMENTS
 ------------------------------------------------------------------------
   - Windows (x64).

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -117,6 +117,13 @@ if (args.Length > 0 && args[0] == "loadorder-status-guard") return LoadOrderStat
 // folder. Pure synthetic paths; the pure-core ToolBridge half is in the tool-bridge probe.
 if (args.Length > 0 && args[0] == "compile-ergonomics-guard") return CompileErgonomicsProbe.RunGuard(args[1..]);
 
+// Setup update-lock pre-flight (HCBR-2026-06-15-01 item 9.1 / PR-M): re-running houseCARL-Setup over a LIVE
+// install used to overwrite the running housecarl-mcp.exe (CopyDirectory's File.Copy overwrite:true), throw
+// mid-copy, and leave a half-updated tree. Drives the now-probeable Program.TryInstall: a clean install
+// succeeds, a held server exe refuses at PRE-FLIGHT before any copy (both Claude + Codex), and a held sibling
+// DLL is caught mid-copy as defense in depth. Self-contained: synthetic package + temp home, no game data.
+if (args.Length > 0 && args[0] == "setup-update-lock-guard") return SetupUpdateLockProbe.RunGuard(args[1..]);
+
 // MO2 overwrite-folder resolution (2026-06-12 hunt F9): plugins living in MO2's overwrite layer resolve at
 // HIGHEST priority (top of the VFS — where Synthesis/xEdit tool outputs land), and the can't-resolve warning
 // names overwrite among the places searched.

--- a/src/housecarl-generator/SetupUpdateLockProbe.cs
+++ b/src/housecarl-generator/SetupUpdateLockProbe.cs
@@ -1,0 +1,136 @@
+using SetupProgram = HousecarlSetup.Program; // alias: the generator's own top-level Program shadows it otherwise
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// Setup update-lock guard (HCBR-2026-06-15-01 item 9.1 / PR-M). Re-running houseCARL-Setup over a LIVE
+/// install used to copy over the running housecarl-mcp.exe (CopyDirectory's File.Copy overwrite:true), throw
+/// mid-copy, and leave a half-updated tree behind a generic "setup did not complete". The fix pre-flights the
+/// lock at every destination BEFORE any copy and refuses with actionable guidance, with a mid-copy
+/// sharing-violation catch as defense in depth. This drives the REAL, now-probeable
+/// <see cref="HousecarlSetup.Program.TryInstall"/> over a synthetic package + a temp home (no real ~/.claude,
+/// ~/.codex, or %LOCALAPPDATA% touched):
+///
+///   T1 (control)  a clean first install (no destination exe yet) SUCCEEDS for Claude AND Codex — the
+///                 pre-flight never false-blocks a fresh machine.
+///   T2 (Claude)   with the installed server exe held open like a running session, the re-install refuses:
+///                 ServerInUse, RefusedBeforeAnyCopy (the PRE-FLIGHT path, not the catch), a deleted sentinel
+///                 file is STILL absent (no copy ran), and the held exe is byte-intact.
+///   T3 (Codex)    the same pre-flight refusal at the Codex destination (both destinations covered).
+///   T4 (catch)    a held sibling DLL (exe FREE, so the pre-flight passes) makes the copy hit a sharing
+///                 violation, which the defense-in-depth catch turns into ServerInUse (NOT before-copy, and
+///                 NOT a raw throw).
+///
+/// Self-contained: synthetic files in temp, no game data / no MO2 / no real host config. RED before the fix:
+/// remove the pre-flight and T2/T3's RefusedBeforeAnyCopy flips false (the request reaches the mid-copy catch)
+/// or the call throws; remove the catch and T4 throws (uncaught IOException) instead of a clean ServerInUse.
+///
+/// Run: dotnet run --project src/housecarl-generator setup-update-lock-guard
+/// </summary>
+internal static class SetupUpdateLockProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" setup update-lock guard — pre-flight the locked-server overwrite (PR-M)");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        // Keep the Codex destination hermetic: TryInstall honours CODEX_HOME for config.toml, so a dev box
+        // that happens to set it would otherwise write into the real ~/.codex. We pass an explicit temp home,
+        // and clear CODEX_HOME for this short-lived probe process so config.toml lands under the temp home too.
+        Environment.SetEnvironmentVariable("CODEX_HOME", null);
+
+        string root = Path.Combine(Path.GetTempPath(), "hc-setup-lock-" + Guid.NewGuid().ToString("N"));
+        string pkg  = Path.Combine(root, "package");   // the unzipped package dir
+        string src  = Path.Combine(pkg, "housecarl");  // pluginSrc (beside it lives codex/housecarl)
+        string home = Path.Combine(root, "home");      // stand-in for the user profile
+
+        // The destinations TryInstall computes (mirrored here for the lock-holding + assertions).
+        string claudeExe = Path.Combine(home, ".claude", "skills", "housecarl", "server", "housecarl-mcp.exe");
+        string claudeDll = Path.Combine(home, ".claude", "skills", "housecarl", "server", "Mutagen.Bethesda.dll");
+        string codexExe  = Path.Combine(home, "houseCARL", "server", "housecarl-mcp.exe");
+        string sentinel  = Path.Combine(home, ".claude", "skills", "housecarl", "skills", "demo-skill", "SKILL.md");
+
+        byte[] exeV1 = { 1, 1, 1, 1 };
+        byte[] exeV2 = { 2, 2, 2, 2 }; // a different "version", so a copy that ran WOULD change the on-disk bytes
+
+        try
+        {
+            // ---- a synthetic package the installer can copy from ----
+            WriteFile(Path.Combine(src, ".claude-plugin", "plugin.json"), "{}");
+            WriteFile(Path.Combine(src, "server", "housecarl-mcp.exe"), exeV1);
+            WriteFile(Path.Combine(src, "server", "Mutagen.Bethesda.dll"), new byte[] { 9 }); // a sibling DLL (T4)
+            WriteFile(Path.Combine(src, "skills", "demo-skill", "SKILL.md"), "demo");
+            WriteFile(Path.Combine(pkg, "codex", "housecarl", "SKILL.md"), "umbrella");
+
+            // ===================================================== T1: a clean first install succeeds
+            Console.WriteLine("--- T1: a clean first install succeeds (pre-flight never false-blocks a fresh machine) ---");
+            var clean = SetupProgram.TryInstall(SetupProgram.Target.Both, src, home, home);
+            Check(clean.Outcome == SetupProgram.InstallOutcome.Installed, "clean install (Both) => Installed");
+            Check(File.Exists(claudeExe), "Claude server exe landed at ~/.claude/skills/housecarl/server");
+            Check(File.Exists(codexExe),  "Codex server exe landed under the (test) data dir");
+
+            // ===================================================== T2: locked Claude exe => pre-flight refuses, before any copy
+            Console.WriteLine();
+            Console.WriteLine("--- T2: re-install with the Claude server exe HELD (a running session) refuses BEFORE any copy ---");
+            WriteFile(Path.Combine(src, "server", "housecarl-mcp.exe"), exeV2); // a newer "version" waiting to land
+            File.Delete(sentinel);                                              // gone unless a copy re-creates it
+            SetupProgram.InstallResult lockedClaude;
+            using (HoldLikeRunning(claudeExe))
+                lockedClaude = SetupProgram.TryInstall(SetupProgram.Target.Claude, src, home, home);
+            Check(lockedClaude.Outcome == SetupProgram.InstallOutcome.ServerInUse, "locked Claude exe => ServerInUse (refused, not thrown)");
+            Check(lockedClaude.RefusedBeforeAnyCopy, "refused at PRE-FLIGHT (RefusedBeforeAnyCopy) — not the mid-copy catch");
+            Check(!File.Exists(sentinel), "no copy ran: the deleted sentinel file is still absent");
+            Check(File.ReadAllBytes(claudeExe).AsSpan().SequenceEqual(exeV1),
+                  "the held server exe is byte-intact (still the installed bytes, not the newer source)");
+            WriteFile(sentinel, "demo");                                        // restore for the later targets
+            WriteFile(Path.Combine(src, "server", "housecarl-mcp.exe"), exeV1);
+
+            // ===================================================== T3: locked Codex exe => same pre-flight refusal
+            Console.WriteLine();
+            Console.WriteLine("--- T3: the same pre-flight refusal at the Codex destination (both destinations covered) ---");
+            SetupProgram.InstallResult lockedCodex;
+            using (HoldLikeRunning(codexExe))
+                lockedCodex = SetupProgram.TryInstall(SetupProgram.Target.Codex, src, home, home);
+            Check(lockedCodex.Outcome == SetupProgram.InstallOutcome.ServerInUse, "locked Codex exe => ServerInUse");
+            Check(lockedCodex.RefusedBeforeAnyCopy, "Codex refusal is at pre-flight too");
+
+            // ===================================================== T4: held sibling DLL => defense-in-depth mid-copy catch
+            Console.WriteLine();
+            Console.WriteLine("--- T4: a held sibling DLL (exe FREE) is caught mid-copy as ServerInUse (defense in depth) ---");
+            SetupProgram.InstallResult lockedDll;
+            using (HoldLikeRunning(claudeDll))
+                lockedDll = SetupProgram.TryInstall(SetupProgram.Target.Claude, src, home, home);
+            Check(lockedDll.Outcome == SetupProgram.InstallOutcome.ServerInUse,
+                  "held DLL (exe free) => ServerInUse (the copy's sharing violation is caught, not a raw throw)");
+            Check(!lockedDll.RefusedBeforeAnyCopy, "this is the MID-COPY catch, NOT the pre-flight (the two paths stay distinct)");
+        }
+        finally { try { Directory.Delete(root, recursive: true); } catch { /* non-fatal */ } }
+
+        Console.WriteLine();
+        Console.WriteLine(fail == 0
+            ? "================ ALL PASS ================"
+            : $"================ {fail} CHECK(S) FAILED ================");
+        return fail == 0 ? 0 : 1;
+    }
+
+    /// <summary>Open a file the way a running image holds it: readable + share-read, write DENIED — so the
+    /// installer's write-open / File.Copy overwrite fails with a sharing violation, exactly as for a live exe.</summary>
+    private static FileStream HoldLikeRunning(string path)
+        => new(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+
+    private static void WriteFile(string path, string text)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, text);
+    }
+
+    private static void WriteFile(string path, byte[] bytes)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllBytes(path, bytes);
+    }
+}

--- a/src/housecarl-generator/housecarl-generator.csproj
+++ b/src/housecarl-generator/housecarl-generator.csproj
@@ -20,6 +20,9 @@
     <!-- The CI regression guards drive the SERVICE-layer scan logic (LoadOrderService.CrossQuery, via the
          ForGuard seam) — the first CI coverage of the mcp layer (PR #23 follow-up). -->
     <ProjectReference Include="..\housecarl-mcp\housecarl-mcp.csproj" />
+    <!-- The setup update-lock guard (HCBR item 9.1 / PR-M) drives the real installer's now-public
+         Program.TryInstall seam — the only way to regression-test the locked-server pre-flight in CI. -->
+    <ProjectReference Include="..\housecarl-setup\housecarl-setup.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/housecarl-setup/Program.cs
+++ b/src/housecarl-setup/Program.cs
@@ -196,7 +196,8 @@ public static class Program
 
         foreach (string destExe in destExes)
             if (ServerExeInUse(destExe))
-                return new InstallResult(InstallOutcome.ServerInUse, "Looks like the server is running here: " + destExe)
+                return new InstallResult(InstallOutcome.ServerInUse,
+                        "Can't update the server here — it looks like it's running (or the file is locked/read-only): " + destExe)
                     { RefusedBeforeAnyCopy = true };
 
         try
@@ -206,8 +207,10 @@ public static class Program
         }
         catch (IOException ex) when (IsSharingViolation(ex))
         {
+            // The try wraps the copy AND the host-config registration, so the locked file may be the server
+            // exe/DLL or a config file (e.g. ~/.codex/config.toml open in an editor) — name both honestly.
             return new InstallResult(InstallOutcome.ServerInUse,
-                "A houseCARL server file was in use during the update.");
+                "A houseCARL file was in use during the update (the server, or a config file it writes).");
         }
 
         return new InstallResult(InstallOutcome.Installed, null);
@@ -236,6 +239,12 @@ public static class Program
     /// Claude/Codex session is running it (a running image denies write sharing). A missing file (a clean
     /// first install) returns false, so it's never falsely blocked. The handle is opened then immediately
     /// closed and never written, so a held server's exe stays byte-intact.
+    ///
+    /// CONSERVATIVE BY DESIGN: FileShare.None reports "in use" if ANYTHING else holds the file (an AV
+    /// on-demand scan, the Search indexer, a backup tool with full sharing) — a possible false positive
+    /// that self-resolves on retry. That is the SAFE direction: a false positive is an annoying "quit and
+    /// re-run"; a false negative is the exact mid-copy corruption this exists to prevent. Do NOT "tighten"
+    /// this (e.g. to FileShare.Read) into a false-negative.
     /// </summary>
     private static bool ServerExeInUse(string destExe)
     {
@@ -246,7 +255,7 @@ public static class Program
             return false; // got exclusive write access -> nothing holds it -> safe to overwrite
         }
         catch (IOException)                 { return true; } // in use by a running session
-        catch (UnauthorizedAccessException) { return true; } // locked / not writable -> can't overwrite either
+        catch (UnauthorizedAccessException) { return true; } // locked / read-only -> can't overwrite either
     }
 
     // ERROR_SHARING_VIOLATION (32) / ERROR_LOCK_VIOLATION (33): the file-in-use cases. We re-stamp ONLY these

--- a/src/housecarl-setup/Program.cs
+++ b/src/housecarl-setup/Program.cs
@@ -27,7 +27,7 @@ namespace HousecarlSetup;
 /// For a Both install each host runs its own server copy (so MO2 is set once per host); unifying to a
 /// single shared server is a deferred clean-up that would re-touch the proven Claude path.
 /// </summary>
-internal static class Program
+public static class Program
 {
     private const string PluginFolderName = "housecarl"; // plugin dir shipped beside this exe
     private const string McpServerName    = "housecarl"; // server key under mcpServers / [mcp_servers.*]
@@ -37,7 +37,28 @@ internal static class Program
     // does not satisfy a net9.0 framework-dependent server.
     private const string ServerRuntimeMajor = "9";
 
-    private enum Target { Claude, Codex, Both }
+    public enum Target { Claude, Codex, Both }
+
+    /// <summary>What a non-interactive <see cref="TryInstall"/> did.</summary>
+    public enum InstallOutcome
+    {
+        /// <summary>Skills + server copied and the MCP server registered for the chosen host(s).</summary>
+        Installed,
+        /// <summary>A houseCARL server file at a destination is in use (a live Claude/Codex session is
+        /// running it), so it could not be overwritten. Nothing usable was changed when the refusal was at
+        /// pre-flight (<see cref="InstallResult.RefusedBeforeAnyCopy"/>).</summary>
+        ServerInUse,
+    }
+
+    /// <summary>Result of a non-interactive install attempt — the probeable seam under the interactive prompt.</summary>
+    /// <param name="Outcome">What happened.</param>
+    /// <param name="Message">Caller-facing detail for a non-<see cref="InstallOutcome.Installed"/> outcome (else null).</param>
+    public sealed record InstallResult(InstallOutcome Outcome, string? Message)
+    {
+        /// <summary>True only when a <see cref="InstallOutcome.ServerInUse"/> refusal happened at PRE-FLIGHT,
+        /// before any file was copied (so nothing was changed). False for the mid-copy defense-in-depth catch.</summary>
+        public bool RefusedBeforeAnyCopy { get; init; }
+    }
 
     private static int Main(string[] args)
     {
@@ -125,8 +146,21 @@ internal static class Program
             }
 
             Console.WriteLine();
-            if (target is Target.Claude or Target.Both) InstallForClaude(pluginSrc, home);
-            if (target is Target.Codex  or Target.Both) InstallForCodex(pluginSrc, home, homeOverride);
+            InstallResult result = TryInstall(target.Value, pluginSrc, home, homeOverride);
+            if (result.Outcome == InstallOutcome.ServerInUse)
+            {
+                Console.Error.WriteLine("ERROR: houseCARL is already installed and a server file is in use, so it");
+                Console.Error.WriteLine("       can't be updated right now.");
+                if (result.Message is not null)
+                    Console.Error.WriteLine("  " + result.Message);
+                Console.Error.WriteLine();
+                Console.Error.WriteLine("  Fully quit Claude Code AND Codex -- every desktop window, every terminal");
+                Console.Error.WriteLine("  session, and any background session -- then run this setup again.");
+                Console.Error.WriteLine(result.RefusedBeforeAnyCopy
+                    ? "  Nothing was changed."
+                    : "  The update was stopped partway; re-running after you quit will finish it.");
+                return Finish(1);
+            }
 
             PrintNext(target.Value);
             return Finish(0);
@@ -139,6 +173,90 @@ internal static class Program
             return Finish(1);
         }
     }
+
+    // ---- non-interactive install (the probeable seam under the prompt) -----
+
+    /// <summary>
+    /// Copy the plugin + register the MCP server for the chosen host(s), non-interactively. This is the seam
+    /// <see cref="Main"/> drives after the prompt, and the one the CI guard drives directly.
+    ///
+    /// Re-running setup over a LIVE install would have <see cref="CopyDirectory"/> overwrite the running
+    /// <c>housecarl-mcp.exe</c> (File.Copy overwrite:true), throw mid-copy, and leave a half-updated tree
+    /// behind a generic "did not complete". So we PRE-FLIGHT the lock at EVERY destination this target
+    /// touches, before copying anything, and refuse with actionable guidance (mirrors the runtime preflight
+    /// below). A clean first install (no destination exe yet) is never blocked. As defense in depth, a
+    /// sharing violation that slips past the pre-flight (a held sibling DLL, or a session started between the
+    /// check and the copy) is caught and surfaced with the same guidance instead of the generic failure.
+    /// </summary>
+    public static InstallResult TryInstall(Target target, string pluginSrc, string home, string? homeOverride)
+    {
+        List<string> destExes = new();
+        if (target is Target.Claude or Target.Both) destExes.Add(ClaudeDestExe(home));
+        if (target is Target.Codex  or Target.Both) destExes.Add(CodexDestExe(home, homeOverride));
+
+        foreach (string destExe in destExes)
+            if (ServerExeInUse(destExe))
+                return new InstallResult(InstallOutcome.ServerInUse, "Looks like the server is running here: " + destExe)
+                    { RefusedBeforeAnyCopy = true };
+
+        try
+        {
+            if (target is Target.Claude or Target.Both) InstallForClaude(pluginSrc, home);
+            if (target is Target.Codex  or Target.Both) InstallForCodex(pluginSrc, home, homeOverride);
+        }
+        catch (IOException ex) when (IsSharingViolation(ex))
+        {
+            return new InstallResult(InstallOutcome.ServerInUse,
+                "A houseCARL server file was in use during the update.");
+        }
+
+        return new InstallResult(InstallOutcome.Installed, null);
+    }
+
+    /// <summary>The Claude install's server exe path. Single source of truth so pre-flight == installer.</summary>
+    private static string ClaudeDestExe(string home)
+        => Path.Combine(home, ".claude", "skills", PluginFolderName, "server", "housecarl-mcp.exe");
+
+    /// <summary>The Codex install's server dir. Under a test home (HOUSECARL_SETUP_HOME) it hangs off that
+    /// home so tests never touch the real LOCALAPPDATA; otherwise it lives under %LOCALAPPDATA%.</summary>
+    private static string CodexServerDir(string home, string? homeOverride)
+    {
+        string dataBase = string.IsNullOrWhiteSpace(homeOverride)
+            ? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
+            : home;
+        return Path.Combine(dataBase, "houseCARL", "server");
+    }
+
+    /// <summary>The Codex install's server exe path. Single source of truth so pre-flight == installer.</summary>
+    private static string CodexDestExe(string home, string? homeOverride)
+        => Path.Combine(CodexServerDir(home, homeOverride), "housecarl-mcp.exe");
+
+    /// <summary>
+    /// True if <paramref name="destExe"/> already exists AND can't be opened for writing — i.e. a live
+    /// Claude/Codex session is running it (a running image denies write sharing). A missing file (a clean
+    /// first install) returns false, so it's never falsely blocked. The handle is opened then immediately
+    /// closed and never written, so a held server's exe stays byte-intact.
+    /// </summary>
+    private static bool ServerExeInUse(string destExe)
+    {
+        if (!File.Exists(destExe)) return false;
+        try
+        {
+            using FileStream _ = new(destExe, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            return false; // got exclusive write access -> nothing holds it -> safe to overwrite
+        }
+        catch (IOException)                 { return true; } // in use by a running session
+        catch (UnauthorizedAccessException) { return true; } // locked / not writable -> can't overwrite either
+    }
+
+    // ERROR_SHARING_VIOLATION (32) / ERROR_LOCK_VIOLATION (33): the file-in-use cases. We re-stamp ONLY these
+    // as "server in use" so an unrelated IOException (disk full, path too long) still surfaces as the honest
+    // generic failure rather than a misleading "quit Claude" message (Q3 — no silently wrong diagnosis).
+    private const int HrSharingViolation = unchecked((int)0x80070020);
+    private const int HrLockViolation    = unchecked((int)0x80070021);
+
+    private static bool IsSharingViolation(IOException ex)
+        => ex.HResult == HrSharingViolation || ex.HResult == HrLockViolation;
 
     // ---- server runtime preflight ------------------------------------------
 
@@ -240,7 +358,7 @@ internal static class Program
     private static void InstallForClaude(string pluginSrc, string home)
     {
         string skillsDest = Path.Combine(home, ".claude", "skills", PluginFolderName);
-        string destExe    = Path.Combine(skillsDest, "server", "housecarl-mcp.exe");
+        string destExe    = ClaudeDestExe(home);
         string claudeJson = Path.Combine(home, ".claude.json");
 
         Console.WriteLine("[Claude Code] installing skills + server");
@@ -260,11 +378,8 @@ internal static class Program
         // Server + corpus go to a neutral per-user dir, NOT the skills dir: Codex scans ~/.agents/skills
         // for skill FOLDERS, and the server is not a skill. Under a test home (HOUSECARL_SETUP_HOME) the
         // data dir hangs off that home so tests never touch the real LOCALAPPDATA.
-        string dataBase = string.IsNullOrWhiteSpace(homeOverride)
-            ? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
-            : home;
-        string serverDest = Path.Combine(dataBase, "houseCARL", "server");
-        string destExe    = Path.Combine(serverDest, "housecarl-mcp.exe");
+        string serverDest = CodexServerDir(home, homeOverride);
+        string destExe    = CodexDestExe(home, homeOverride);
 
         // Skills go FLAT under ~/.agents/skills/ (the cross-agent, user-scope skills dir).
         string skillsRoot = Path.Combine(home, ".agents", "skills");


### PR DESCRIPTION
## What & why (HCBR-2026-06-15-01 item 9.1 / PR-M)

Re-running `houseCARL-Setup.exe` over a **live** install made `CopyDirectory`'s `File.Copy(overwrite:true)` try to overwrite the **running** `housecarl-mcp.exe`, throw mid-copy, and leave a half-updated tree behind a generic "setup did not complete" — no detection, no "quit Claude first" guidance.

Minimal fix (Aaron-fork #7 = pre-flight + catch + docs; atomic dir-swap stays deferred):

- **Pre-flight** the server-exe lock at **every** destination the target touches (Claude **and** Codex) **before any copy**, and refuse with actionable "fully quit Claude/Codex, then re-run" guidance. A clean first install (no dest exe yet) is never blocked. The loop checks **all** destinations before any install runs, so even a `Both` install where only one host is locked changes nothing.
- **Defense in depth:** a sharing-violation `IOException` that slips past the pre-flight (a held sibling DLL, or a session started between the check and the copy) is caught and surfaced with the **same** guidance — filtered to `ERROR_SHARING_VIOLATION`/`ERROR_LOCK_VIOLATION` HResults so an unrelated `IOException` (disk full, …) still fails honestly (Q3).
- Dest-exe paths (`ClaudeDestExe`/`CodexDestExe`) are the **single source of truth** shared by the pre-flight and the installers — the gate and the copy can't drift.
- `Main` renders the refusal honestly: "Nothing was changed" only for a pre-flight refusal; a mid-copy catch says re-running will finish the update.

## The probe wiring is the real work

`housecarl-generator` didn't reference `housecarl-setup`, and the install logic was private behind the interactive prompt. So: extract a **public, non-interactive** `Program.TryInstall` (+ public `Target`/`InstallOutcome`/`InstallResult`; `Main` stays private), add a `generator→setup` ProjectReference, and add **`SetupUpdateLockProbe`** (`setup-update-lock-guard`, +1 CI step → 42).

The guard drives the **real** `TryInstall` over a synthetic package + a temp home (no real `~/.claude`, `~/.codex`, or `%LOCALAPPDATA%` touched):
- **T1 (control):** a clean first install succeeds for Claude **and** Codex.
- **T2 (Claude) / T3 (Codex):** a held server exe refuses at **pre-flight** (`ServerInUse`, `RefusedBeforeAnyCopy`) — no copy ran (deleted sentinel stays absent), held exe byte-intact.
- **T4 (catch):** a held sibling DLL (exe free) is caught **mid-copy** as `ServerInUse` (the two paths stay distinct).

**RED-proven** by sabotage→watch-fail→revert: disable the pre-flight → T2/T3 `RefusedBeforeAnyCopy` flip; disable the catch → T4 throws the exact uncaught `IOException` mid-copy.

## Review

Independent adversarial review: **APPROVE-WITH-NITS** (it rebuilt the OS behavior to confirm the HResults, verified every must-fix, found no code bugs / Q3 violations / false-green tests). The one real nit — docs over-promising "nothing is changed" unconditionally vs the honest mid-copy "stopped partway" — is **folded** (docs now state only the actionable instruction).

## Notes

- **§4 n/a** — install ergonomics + Q3; no record-type surface, no new MCP tool (surface stays 21).
- Fully CI-testable (the held-`FileShare` probe reproduces the lock on the runner) — **no rig-gated remainder**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)