### PR TITLE
nested-create Layer B unit A: same-call sibling-ref as a FormLink field value

### DIFF
--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -284,9 +284,12 @@ public sealed class CorpusRulebook
         // Same-call sibling reference ("@editorid", create-context forward-ref — HCBR Layer B unit A). Gate it BEFORE
         // any verb/cardinality dispatch: it is a Set VALUE naming a record created earlier in this same create call,
         // substituted with that record's real FormKey AFTER allocation (WritePatchBuilder.CreateRecords). It is ONLY
-        // legal as a Set on a FormLink leaf, and ONLY in create context (siblingEditorIds non-null) — everywhere else
-        // it rejects loud (the Apply/set_field path has no siblings, so never an accept-then-substitute-nothing, Q3).
-        // One central gate (here, not per-arm) so a sibling token can never slip through a cardinality branch below.
+        // legal as a singular Set Value on a FormLink leaf, and ONLY in create context (siblingEditorIds non-null) —
+        // everywhere else it rejects loud (the Apply/set_field path has no siblings, so never an
+        // accept-then-substitute-nothing, Q3). The create path resolves ONLY the singular req.Value; a sibling token
+        // in a COLLECTION value (a list ReplaceAll's req.Values, or dict req.Entries) is therefore caught here too and
+        // refused loud — otherwise it would slip past pre-flight and throw FormKey.Factory at apply (a Q3
+        // accept-then-throw). Both gates sit ahead of the cardinality branches so no sibling token reaches them.
         if (WriteEngine.IsSameCallSiblingRef(req.Value, out var sibEdid))
         {
             if (siblingEditorIds is null)
@@ -301,6 +304,13 @@ public sealed class CorpusRulebook
                 : $"Same-call reference '{req.Value}' for '{leaf.Name}': no record with editorid '{sibEdid}' is created " +
                   "EARLIER in this call — declare it before the record that references it (in spec order).";
         }
+        // A sibling token inside a COLLECTION value (list ReplaceAll Values, dict Entries) is NOT substituted (only the
+        // singular Set Value is) — refuse loud rather than accept-then-throw at apply (Q3). Unconditional: it is never
+        // supported, on either the create or the edit-existing path. List/dict sibling-refs are a deliberate later surface.
+        if ((req.Values is { } vals && vals.Any(v => WriteEngine.IsSameCallSiblingRef(v, out _)))
+            || (req.Entries is { } ents && ents.Values.Any(v => WriteEngine.IsSameCallSiblingRef(v, out _))))
+            return $"a '@editorid' same-call reference for '{leaf.Name}' is only supported as a single Set value on a " +
+                   "FormLink field, not inside a list/dict value — list/dict sibling-refs are a later surface.";
         if (req.Verb is "Set" && leaf.Cardinality == "dict")
         {
             if (CheckValue(leaf.KeyType, req.Key, $"dict key for '{leaf.Name}'") is { } ke) return ke;

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -304,9 +304,13 @@ public sealed class CorpusRulebook
                 : $"Same-call reference '{req.Value}' for '{leaf.Name}': no record with editorid '{sibEdid}' is created " +
                   "EARLIER in this call — declare it before the record that references it (in spec order).";
         }
-        // A sibling token inside a COLLECTION value (list ReplaceAll Values, dict Entries) is NOT substituted (only the
-        // singular Set Value is) — refuse loud rather than accept-then-throw at apply (Q3). Unconditional: it is never
-        // supported, on either the create or the edit-existing path. List/dict sibling-refs are a deliberate later surface.
+        // A sibling token inside a COLLECTION value (a list ReplaceAll's Values, or a dict Entries' VALUES) is NOT
+        // substituted (only the singular Set Value is) — refuse loud rather than accept-then-throw at apply (Q3).
+        // Unconditional: never supported, on either the create or the edit-existing path. List/dict sibling-refs are a
+        // deliberate later surface. NOTE: dict KEYS are deliberately NOT scanned here — a '@' in a (rare) FormLink-keyed
+        // dict key would still reach apply, where it fails LOUD (a coerce throw caught as a named Q3 inconsistency), not
+        // silently; that edge rides the parked general "list/dict element value-shape isn't gate-checked" task, which
+        // owns collection element-shape validation (gating keys here without it would be an inconsistent half-measure).
         if ((req.Values is { } vals && vals.Any(v => WriteEngine.IsSameCallSiblingRef(v, out _)))
             || (req.Entries is { } ents && ents.Values.Any(v => WriteEngine.IsSameCallSiblingRef(v, out _))))
             return $"a '@editorid' same-call reference for '{leaf.Name}' is only supported as a single Set value on a " +

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -84,8 +84,12 @@ public sealed class CorpusRulebook
             ?? throw new InvalidOperationException("corpus.json deserialised to null.");
     }
 
-    /// <summary>Pre-flight (P-VALIDATE order). Returns null if the write is legal, else a fail-loud message.</summary>
-    public string? Validate(WriteRequest req)
+    /// <summary>Pre-flight (P-VALIDATE order). Returns null if the write is legal, else a fail-loud message.
+    /// <paramref name="siblingEditorIds"/> (non-null only on the CREATE-batch path) is the set of editorids created
+    /// EARLIER in the same call: a FormLink value of the form <c>@editorid</c> in that set is accepted as a forward-ref
+    /// the create path resolves post-allocation (HCBR Layer B unit A). Null (the override/set_field path) ⇒ an
+    /// <c>@editorid</c> value is rejected loud — it has no meaning when there are no same-call siblings.</summary>
+    public string? Validate(WriteRequest req, IReadOnlyCollection<string>? siblingEditorIds = null)
     {
         // (1) resolve the record, then validate rooted at it. ValidateFromType is shared with StructSpec validation
         // (a build-from-parts spec's nested writes) so the record path and the composition path can never disagree.
@@ -93,12 +97,12 @@ public sealed class CorpusRulebook
         if (recType is null)
             return $"Unknown record type '{req.RecordType}': absent from the Mutagen corpus ({TypeCount} types). " +
                    "If Mutagen models it, that's a real coverage gap to surface — never a value to guess.";
-        return ValidateFromType(recType, req);
+        return ValidateFromType(recType, req, siblingEditorIds);
     }
 
     /// <summary>Validate a write rooted at an arbitrary type — a record OR a struct being built from parts (so a
     /// <see cref="StructSpec"/>'s nested writes validate by the identical leaf/path rules, recursively).</summary>
-    string? ValidateFromType(TypeSchema root, WriteRequest req)
+    string? ValidateFromType(TypeSchema root, WriteRequest req, IReadOnlyCollection<string>? siblingEditorIds = null)
     {
         if (req.Path.Length == 0)
             return "Empty path: a write must target at least one field.";
@@ -215,7 +219,7 @@ public sealed class CorpusRulebook
         if (!leaf.Writable) return WritabilityRejection(leafOwner, leaf);
 
         // (4) value / key coercion + enum/legal-set legality
-        return ValueLegality(leaf, req);
+        return ValueLegality(leaf, req, siblingEditorIds);
     }
 
     /// <summary>Extract the arm type T from a gendered field's <c>GenderedItem&lt;T&gt;</c> TypeRef — e.g.
@@ -275,8 +279,28 @@ public sealed class CorpusRulebook
     }
 
     // ---- value / key legality ----
-    string? ValueLegality(FieldSchema leaf, WriteRequest req)
+    string? ValueLegality(FieldSchema leaf, WriteRequest req, IReadOnlyCollection<string>? siblingEditorIds = null)
     {
+        // Same-call sibling reference ("@editorid", create-context forward-ref — HCBR Layer B unit A). Gate it BEFORE
+        // any verb/cardinality dispatch: it is a Set VALUE naming a record created earlier in this same create call,
+        // substituted with that record's real FormKey AFTER allocation (WritePatchBuilder.CreateRecords). It is ONLY
+        // legal as a Set on a FormLink leaf, and ONLY in create context (siblingEditorIds non-null) — everywhere else
+        // it rejects loud (the Apply/set_field path has no siblings, so never an accept-then-substitute-nothing, Q3).
+        // One central gate (here, not per-arm) so a sibling token can never slip through a cardinality branch below.
+        if (WriteEngine.IsSameCallSiblingRef(req.Value, out var sibEdid))
+        {
+            if (siblingEditorIds is null)
+                return $"'{req.Value}' for '{leaf.Name}': a '@editorid' same-call reference is only valid when creating " +
+                       "records in ONE call (housecarl_bulk_create) — it has no meaning when editing an existing record.";
+            if (req.Verb != "Set")
+                return $"Same-call reference '{req.Value}' for '{leaf.Name}' is only valid as a Set value (the verb was '{req.Verb}').";
+            if (leaf.Cardinality != "formlink")
+                return $"Same-call reference '{req.Value}' for '{leaf.Name}' is only valid on a FormLink field, but " +
+                       $"'{leaf.Name}' is a {leaf.Cardinality}.";
+            return siblingEditorIds.Contains(sibEdid) ? null
+                : $"Same-call reference '{req.Value}' for '{leaf.Name}': no record with editorid '{sibEdid}' is created " +
+                  "EARLIER in this call — declare it before the record that references it (in spec order).";
+        }
         if (req.Verb is "Set" && leaf.Cardinality == "dict")
         {
             if (CheckValue(leaf.KeyType, req.Key, $"dict key for '{leaf.Name}'") is { } ke) return ke;
@@ -385,7 +409,9 @@ public sealed class CorpusRulebook
                     af.MutableTypeAssemblyQualified ?? af.GetterTypeAssemblyQualified) is { } e) return e;
         }
         foreach (var s in spec.Sets ?? new())
-            if (ValidateFromType(structSchema, s) is { } e) return e;
+            // siblingEditorIds: null — a same-call @editorid forward-ref inside a COMPOSED struct (e.g. a VMAD
+            // property) is out of unit-A scope; it rejects loud here rather than being silently accepted (Q3).
+            if (ValidateFromType(structSchema, s, siblingEditorIds: null) is { } e) return e;
         return null;
     }
 

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -2036,6 +2036,33 @@ public static class WriteEngine
     /// caller can't trip an NRE in FormKey.TryFactory.</summary>
     internal static bool IsValidFormLinkValue(string? text) => IsFormKeyNullSynonym(text) || (text is not null && FormKey.TryFactory(text, out _));
 
+    // ---- Same-call sibling reference (HCBR-2026-06-15-01 Layer B / unit A) -------------------------------------
+    //  A create's field VALUE can forward-reference a record created EARLIER in the SAME create call, by its
+    //  editorid, written "@<editorid>". The referenced record's local 0x800+ FormKey is not allocated until the
+    //  apply phase, so the caller cannot write a literal FormID — this is how the INFO PNAM order-chain
+    //  (PreviousDialog -> the prior line) and the Topic back-link (-> the same-call DialogTopic) are authored in
+    //  ONE housecarl_bulk_create. WritePatchBuilder.CreateRecords substitutes the token with the sibling's real
+    //  FormKey AFTER allocation (single-pass: the prior sibling is already allocated, in spec order). CREATE-CONTEXT
+    //  ONLY — the override/set_field (Apply) path has no siblings, so pre-flight there (CorpusRulebook called with a
+    //  null sibling set) rejects the token LOUD rather than letting it through to a substitute-nothing apply (Q3, no
+    //  accept-then-throw). The recognizer is SHARED by pre-flight (CorpusRulebook) and the apply-side substitution
+    //  (CreateRecords) so the gate and the engine cannot drift on the token shape — the same shared-predicate
+    //  discipline as IsFormKeyNullSynonym / IsFormLinkOrIndex.
+    internal const char SiblingRefSigil = '@';
+
+    /// <summary>True iff <paramref name="text"/> is a same-call sibling reference (<c>@editorid</c>, trimmed); emits
+    /// the referenced editorid (also trimmed). The sigil '@' begins neither a Skyrim EditorID nor a FormID, so the
+    /// token can't collide with a real FormLink value. Shared by pre-flight (<see cref="CorpusRulebook"/>) and the
+    /// create-time substitution (<see cref="WritePatchBuilder.CreateRecords"/>).</summary>
+    internal static bool IsSameCallSiblingRef(string? text, out string editorId)
+    {
+        editorId = "";
+        var v = (text ?? "").Trim();
+        if (v.Length < 2 || v[0] != SiblingRefSigil) return false;
+        editorId = v[1..].Trim();
+        return editorId.Length > 0;
+    }
+
     /// <summary>FormLink families — build the matching concrete (nullable vs not) from a "FORMID:ModName.esp" key.
     /// Mutagen distinguishes IFormLink&lt;T&gt; (required) from IFormLinkNullable&lt;T&gt; (optional); the wrong
     /// concrete won't assign to the property, so the target type decides which we construct. A null-synonym value

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -431,6 +431,10 @@ public static class WritePatchBuilder
         var problems = new List<string>();
         var seenEdid = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var declaredEdidType = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);   // editorid -> RecordType (same-call sibling parents)
+        // editorids declared in EARLIER specs (NOT the current one) — the legal targets of a "@editorid" same-call
+        // field forward-ref (HCBR Layer B unit A). Grown at the END of each spec's iteration, so during spec i's edit
+        // validation it holds {0..i-1}: a self-ref (@its-own-editorid) and a forward-ref (a later sibling) both reject.
+        var priorEditorIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var parentPlans = new List<(IMajorRecordGetter? body, string? winnerPlugin, string? sibling, IMajorRecord? patchParent)?>(specs.Count);
         for (int i = 0; i < specs.Count; i++)
         {
@@ -488,7 +492,11 @@ public static class WritePatchBuilder
             }
 
             foreach (var req in s.Edits)
-                if (rulebook.Validate(req) is { } reject) problems.Add($"{s.RecordType} '{s.EditorId}' [{Label(req)}]: {reject}");
+                // siblingEditorIds = priorEditorIds: a "@editorid" FormLink value is accepted iff that editorid was
+                // created in an EARLIER spec of THIS call (resolved to its real FormKey in Phase 3); else rejected loud.
+                if (rulebook.Validate(req, priorEditorIds) is { } reject) problems.Add($"{s.RecordType} '{s.EditorId}' [{Label(req)}]: {reject}");
+
+            priorEditorIds.Add(s.EditorId);   // now available as a same-call sibling target for LATER specs (not its own)
         }
         if (problems.Count > 0)
             return CreateOutcome.Fail(
@@ -558,8 +566,23 @@ public static class WritePatchBuilder
 
             createdByEditorId[s.EditorId] = rec;
             var ops = new List<OpResult>(s.Edits.Count);
-            foreach (var req in s.Edits)
+            foreach (var rawReq in s.Edits)
             {
+                // Resolve a same-call sibling reference (@editorid) in a FormLink value to the sibling's now-allocated
+                // FormKey (HCBR Layer B unit A — the INFO PNAM chain + Topic back-link in one bulk_create). Pre-flight
+                // (Phase 1) already guaranteed any surviving @-token is on a FormLink leaf AND names a record created
+                // EARLIER in this call — so it is already in createdByEditorId; a miss here is a real engine
+                // inconsistency, surfaced not swallowed (Q3). The substituted value is a normal intra-patch FormKey
+                // that ApplyVerb coerces exactly as a literal FormID would (no apply-path change).
+                var req = rawReq;
+                if (WriteEngine.IsSameCallSiblingRef(rawReq.Value, out var sibEdid))
+                {
+                    if (!createdByEditorId.TryGetValue(sibEdid, out var sibRec))
+                        return CreateOutcome.Fail(
+                            $"internal: same-call reference '@{sibEdid}' on new {s.RecordType} '{s.EditorId}' resolved to no " +
+                            "record created in this call — pre-flight should have caught it; surfaced, not swallowed (Q3).");
+                    req = CopyWithValue(rawReq, sibRec.FormKey.ToString());
+                }
                 try { WriteEngine.ApplyVerb(rec, req); ops.Add(new OpResult(rec.FormKey, s.RecordType, Label(req), true, null, TryReadAfter(rec, req))); }
                 catch (Exception ex)
                 {
@@ -639,6 +662,15 @@ public static class WritePatchBuilder
     /// <summary>The xEdit-style edit label: <c>Verb path[key] = value</c> (matches <see cref="WriteEngine.RunPatch"/>).</summary>
     static string Label(WriteRequest r) =>
         $"{r.Verb} {string.Join('.', r.Path)}{(r.Key is not null ? "[" + r.Key + "]" : "")}{(r.Value is not null ? " = " + r.Value : "")}";
+
+    /// <summary>Clone a <see cref="WriteRequest"/> changing ONLY its <see cref="WriteRequest.Value"/> — it's an
+    /// init-only class (no <c>with</c>). Used to substitute a resolved same-call sibling FormKey for the
+    /// <c>@editorid</c> token before apply (HCBR Layer B unit A); every other field is carried verbatim.</summary>
+    static WriteRequest CopyWithValue(WriteRequest r, string value) => new()
+    {
+        RecordType = r.RecordType, Path = r.Path, Verb = r.Verb, Key = r.Key,
+        Value = value, Values = r.Values, Entries = r.Entries, Struct = r.Struct,
+    };
 
     /// <summary>Best-effort read-back of the edited leaf off the override (so the caller sees the value landed without a
     /// follow-up read). Reads the leaf PATH (not the keyed element — that's xEdit's job); null on any difficulty — never

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -46,6 +46,7 @@ namespace HousecarlGenerator;
 ///   REJ-SIBLIST   — an @ref inside a COLLECTION value (a list ReplaceAll's Values) refuses loud ('only supported as a
 ///                   single Set value') — the create path resolves only the singular Value, so a list/dict token must
 ///                   fail at the gate, not accept-then-throw at apply (Q3).
+///   REJ-SIBDICT   — the dict half of that gate: an @ref inside a dict Merge's Entries values refuses loud the same way.
 ///   REJ-SIBAPPLY  — an @ref validated with a NULL sibling set (the Apply/set_field context) refuses at the rulebook —
 ///                   create-only scoping, so @editorid never becomes an accept-then-substitute-nothing hole (Q3).
 /// </summary>
@@ -318,6 +319,19 @@ public static class NestedCreateGuardProbe
             },
             msg => msg.Contains("only supported as a single Set value", StringComparison.OrdinalIgnoreCase));
 
+        // ---------- REJ-SIBDICT: an @ref inside a DICT value (Merge Entries) refuses loud — the dict half of the gate ----------
+        // Sibling tokens in a dict Entries' VALUES are caught by the same collection gate as the list case (the |
+        // req.Entries branch). Class.SkillWeights (Dictionary<Skill,Byte>) is a flat dict leaf; the gate fires on the
+        // '@' in the Entries value before any key/value coercion, so the dict key need not be a valid Skill.
+        bool sibRejDictOk = RejectArm("REJ-SIBDICT @ref in dict value     ", tmpDir, "SibDict", mPath, rulebook,
+            new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "Class", EditorId = "HcNcSdClass",
+                    Edits = new[] { new WriteRequest { RecordType = "Class", Path = new[] { "SkillWeights" }, Verb = "Merge",
+                        Entries = new Dictionary<string, string> { ["OneHanded"] = "@HcNcSdClass" } } } },
+            },
+            msg => msg.Contains("only supported as a single Set value", StringComparison.OrdinalIgnoreCase));
+
         // ---------- REJ-SIBAPPLY: an @ref on the Apply/set_field path (no siblings) refuses at the rulebook ----------
         // Drives the rulebook DIRECTLY with a null sibling set (the override/set_field context) — proves the create-only
         // scoping that keeps @editorid from becoming an accept-then-substitute-nothing hole on the edit-existing path (Q3).
@@ -332,7 +346,7 @@ public static class NestedCreateGuardProbe
         Console.WriteLine();
         bool pass = fixturesOk && oneshotOk && multiOk && intoTopicOk && intoCellOk
                     && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendOk
-                    && sibrefOk && sibRejFwdOk && sibRejNonflOk && sibRejListOk && sibRejApplyOk;
+                    && sibrefOk && sibRejFwdOk && sibRejNonflOk && sibRejListOk && sibRejDictOk && sibRejApplyOk;
         Console.WriteLine($"=== nested-create-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return pass ? 0 : 1;

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -43,6 +43,9 @@ namespace HousecarlGenerator;
 ///   REJ-SIBFWD    — a field @ref to a sibling declared LATER refuses loud ('EARLIER in this call' — the declared-earlier rule).
 ///   REJ-SIBNONFL  — an @ref on a NON-FormLink field (FavorLevel) refuses loud ('only valid on a FormLink field' — the
 ///                   string-collision guard that keeps Phase-3 substitution scoped to formlinks).
+///   REJ-SIBLIST   — an @ref inside a COLLECTION value (a list ReplaceAll's Values) refuses loud ('only supported as a
+///                   single Set value') — the create path resolves only the singular Value, so a list/dict token must
+///                   fail at the gate, not accept-then-throw at apply (Q3).
 ///   REJ-SIBAPPLY  — an @ref validated with a NULL sibling set (the Apply/set_field context) refuses at the rulebook —
 ///                   create-only scoping, so @editorid never becomes an accept-then-substitute-nothing hole (Q3).
 /// </summary>
@@ -303,6 +306,18 @@ public static class NestedCreateGuardProbe
             },
             msg => msg.Contains("only valid on a FormLink field", StringComparison.OrdinalIgnoreCase));
 
+        // ---------- REJ-SIBLIST: an @ref inside a COLLECTION value (list ReplaceAll) refuses loud, not accept-then-throw ----------
+        // The create path substitutes only the singular Set Value; a sibling token in req.Values would otherwise slip
+        // past pre-flight and throw FormKey.Factory at apply (a Q3 accept-then-throw). Caught loud at the gate instead.
+        bool sibRejListOk = RejectArm("REJ-SIBLIST @ref in list value     ", tmpDir, "SibList", mPath, rulebook,
+            new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogTopic", EditorId = "HcNcSlTopic", Edits = Array.Empty<WriteRequest>() },
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcSlL1", ParentRef = "HcNcSlTopic",
+                    Edits = new[] { new WriteRequest { RecordType = "DialogResponses", Path = new[] { "LinkTo" }, Verb = "ReplaceAll", Values = new[] { "@HcNcSlTopic" } } } },
+            },
+            msg => msg.Contains("only supported as a single Set value", StringComparison.OrdinalIgnoreCase));
+
         // ---------- REJ-SIBAPPLY: an @ref on the Apply/set_field path (no siblings) refuses at the rulebook ----------
         // Drives the rulebook DIRECTLY with a null sibling set (the override/set_field context) — proves the create-only
         // scoping that keeps @editorid from becoming an accept-then-substitute-nothing hole on the edit-existing path (Q3).
@@ -317,7 +332,7 @@ public static class NestedCreateGuardProbe
         Console.WriteLine();
         bool pass = fixturesOk && oneshotOk && multiOk && intoTopicOk && intoCellOk
                     && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendOk
-                    && sibrefOk && sibRejFwdOk && sibRejNonflOk && sibRejApplyOk;
+                    && sibrefOk && sibRejFwdOk && sibRejNonflOk && sibRejListOk && sibRejApplyOk;
         Console.WriteLine($"=== nested-create-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return pass ? 0 : 1;

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -35,6 +35,16 @@ namespace HousecarlGenerator;
 ///                    (call 1), then in a SECOND into= call add an INFO under it by FormKey — the INFO lands under the
 ///                    patch-carried topic. A GENUINELY-absent parent (in neither the load order nor the patch) still
 ///                    refuses loud, naming both.
+///
+/// Layer B unit A — same-call sibling reference (@editorid) as a FormLink VALUE (the PNAM order-chain + Topic back-link
+/// in ONE bulk_create):
+///   SIBREF        — topic + 2 lines; line 1's Topic=@topic and line 2's PreviousDialog=@line1 BOTH resolve to the
+///                   right same-call 0x800+ FormKeys on disk (the keystone).
+///   REJ-SIBFWD    — a field @ref to a sibling declared LATER refuses loud ('EARLIER in this call' — the declared-earlier rule).
+///   REJ-SIBNONFL  — an @ref on a NON-FormLink field (FavorLevel) refuses loud ('only valid on a FormLink field' — the
+///                   string-collision guard that keeps Phase-3 substitution scoped to formlinks).
+///   REJ-SIBAPPLY  — an @ref validated with a NULL sibling set (the Apply/set_field context) refuses at the rulebook —
+///                   create-only scoping, so @editorid never becomes an accept-then-substitute-nothing hole (Q3).
 /// </summary>
 public static class NestedCreateGuardProbe
 {
@@ -239,9 +249,75 @@ public static class NestedCreateGuardProbe
             Console.WriteLine($"   EXTEND patch-carried parent works    : {(extendOk ? "PASS — prior-call topic resolvable, BOTH lines under it; a truly-absent parent still refuses loud" : $"FAIL — call1={call1Ok} call2={call2Ok} under={under} absentRefused={absentRefused} absentNamed={absentNamed} absentErr=[{absentErr}]")}");
         }
 
+        // ---------- SIBREF (Layer B unit A): @editorid same-call FormLink forward-ref ----------
+        // The keystone: a one-shot topic + two lines where line 1 back-links to the same-call topic (Topic=@topic) and
+        // line 2 chains off line 1 (PreviousDialog=@line1) — BOTH targets are sibling local 0x800+ FormKeys not known
+        // until allocation. Proves the @editorid token resolves to the right allocated FormKey in a FormLink VALUE.
+        bool sibrefOk = false;
+        {
+            string pPath = Path.Combine(tmpDir, "HcNcSibRef.esp");
+            var specs = new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogTopic", EditorId = "HcNcSrTopic", Edits = Array.Empty<WriteRequest>() },
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcSrL1", ParentRef = "HcNcSrTopic",
+                    Edits = new[] { new WriteRequest { RecordType = "DialogResponses", Path = new[] { "Topic" }, Verb = "Set", Value = "@HcNcSrTopic" } } },
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcSrL2", ParentRef = "HcNcSrTopic",
+                    Edits = new[]
+                    {
+                        new WriteRequest { RecordType = "DialogResponses", Path = new[] { "Topic" }, Verb = "Set", Value = "@HcNcSrTopic" },
+                        new WriteRequest { RecordType = "DialogResponses", Path = new[] { "PreviousDialog" }, Verb = "Set", Value = "@HcNcSrL1" },
+                    } },
+            };
+            using var r = LoadOrderResolver.Build(new[] { mPath });
+            var o = WritePatchBuilder.CreateRecords(r, rulebook, specs, pPath, extend: false);
+            FormKey topicFk = o.Success ? o.Created[0].FormKey : default;
+            FormKey l1Fk = o.Success && o.Created.Count > 1 ? o.Created[1].FormKey : default;
+            FormKey l2Fk = o.Success && o.Created.Count > 2 ? o.Created[2].FormKey : default;
+            var l1Topic = o.Success ? InfoTopic(pPath, l1Fk) : null;            // back-link → same-call topic
+            var l2Topic = o.Success ? InfoTopic(pPath, l2Fk) : null;
+            var l2Prev  = o.Success ? InfoPreviousDialog(pPath, l2Fk) : null;   // PNAM chain → prior same-call line
+            bool backLink = l1Topic == topicFk && l2Topic == topicFk;
+            bool pnam = l2Prev == l1Fk;
+            sibrefOk = o.Success && o.Created.Count == 3 && backLink && pnam && topicFk != l1Fk && l1Fk != l2Fk;
+            Console.WriteLine($"   SIBREF @editorid FormLink fwd-ref    : {(sibrefOk ? "PASS — Topic back-link + PreviousDialog chain resolved to same-call FormKeys" : $"FAIL — success={o.Success} backLink={backLink} pnam={pnam} l1Topic=[{l1Topic}] l2Prev=[{l2Prev}] topic=[{topicFk}] l1=[{l1Fk}] err=[{o.Error}]")}");
+        }
+
+        // ---------- REJ-SIBFWD: a field @ref to a sibling declared LATER refuses loud (declared-earlier rule) ----------
+        bool sibRejFwdOk = RejectArm("REJ-SIBFWD @ref to later sibling   ", tmpDir, "SibFwd", mPath, rulebook,
+            new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogTopic", EditorId = "HcNcSfTopic", Edits = Array.Empty<WriteRequest>() },
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcSfL1", ParentRef = "HcNcSfTopic",
+                    Edits = new[] { new WriteRequest { RecordType = "DialogResponses", Path = new[] { "PreviousDialog" }, Verb = "Set", Value = "@HcNcSfL2" } } },
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcSfL2", ParentRef = "HcNcSfTopic", Edits = Array.Empty<WriteRequest>() },
+            },
+            msg => msg.Contains("EARLIER in this call", StringComparison.OrdinalIgnoreCase));
+
+        // ---------- REJ-SIBNONFL: an @ref on a NON-FormLink field refuses loud (the string-collision guard) ----------
+        bool sibRejNonflOk = RejectArm("REJ-SIBNONFL @ref on non-formlink  ", tmpDir, "SibNonFl", mPath, rulebook,
+            new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogTopic", EditorId = "HcNcSnTopic", Edits = Array.Empty<WriteRequest>() },
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcSnL1", ParentRef = "HcNcSnTopic",
+                    Edits = new[] { new WriteRequest { RecordType = "DialogResponses", Path = new[] { "FavorLevel" }, Verb = "Set", Value = "@HcNcSnTopic" } } },
+            },
+            msg => msg.Contains("only valid on a FormLink field", StringComparison.OrdinalIgnoreCase));
+
+        // ---------- REJ-SIBAPPLY: an @ref on the Apply/set_field path (no siblings) refuses at the rulebook ----------
+        // Drives the rulebook DIRECTLY with a null sibling set (the override/set_field context) — proves the create-only
+        // scoping that keeps @editorid from becoming an accept-then-substitute-nothing hole on the edit-existing path (Q3).
+        bool sibRejApplyOk;
+        {
+            var req = new WriteRequest { RecordType = "DialogResponses", Path = new[] { "PreviousDialog" }, Verb = "Set", Value = "@AnySibling" };
+            var reject = rulebook.Validate(req);   // null sibling set == the override/set_field context
+            sibRejApplyOk = reject is not null && reject.Contains("only valid when creating records in ONE call", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   REJ-SIBAPPLY @ref on set_field path  : {(sibRejApplyOk ? "PASS — rejected at the gate (no same-call siblings when editing an existing record)" : $"FAIL — reject=[{reject}]")}");
+        }
+
         Console.WriteLine();
         bool pass = fixturesOk && oneshotOk && multiOk && intoTopicOk && intoCellOk
-                    && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendOk;
+                    && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendOk
+                    && sibrefOk && sibRejFwdOk && sibRejNonflOk && sibRejApplyOk;
         Console.WriteLine($"=== nested-create-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return pass ? 0 : 1;
@@ -321,6 +397,30 @@ public static class NestedCreateGuardProbe
                 foreach (var sub in block.SubBlocks)
                     foreach (var c in sub.Cells)
                         if (c.FormKey == cellFk) return c.Persistent.Select(x => x.FormKey).ToList();
+            return null;
+        }
+        catch { return null; }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    /// <summary>Re-open the written patch and read a created INFO's Topic back-link FormKey (the @editorid sibling-ref
+    /// arm). FormKey.Null if unset.</summary>
+    static FormKey? InfoTopic(string patchPath, FormKey infoFk) => InfoFormLink(patchPath, infoFk, i => i.Topic.FormKey);
+
+    /// <summary>Re-open the written patch and read a created INFO's PreviousDialog (PNAM) FormKey. FormKey.Null if unset.</summary>
+    static FormKey? InfoPreviousDialog(string patchPath, FormKey infoFk) => InfoFormLink(patchPath, infoFk, i => i.PreviousDialog.FormKey);
+
+    /// <summary>Re-open the written patch, find a created INFO by FormKey (under any topic's Responses), and project a
+    /// FormLink field off it — shared by the Topic / PreviousDialog readers.</summary>
+    static FormKey? InfoFormLink(string patchPath, FormKey infoFk, Func<IDialogResponsesGetter, FormKey> select)
+    {
+        ISkyrimModGetter? ov = null;
+        try
+        {
+            ov = SkyrimMod.CreateFromBinaryOverlay(patchPath, SkyrimRelease.SkyrimSE);
+            foreach (var t in ov.DialogTopics)
+                foreach (var info in t.Responses)
+                    if (info.FormKey == infoFk) return select(info);
             return null;
         }
         catch { return null; }

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -173,7 +173,12 @@ public static class WriteTools
          "create_record call. A spec's parent= can be the FormID of an EXISTING record OR the editorid of a record declared " +
          "EARLIER in this same records array (a same-call sibling) — which is how the one-shot 'topic + its lines' is expressed: " +
          "records=[{record_type:'DialogTopic', editorid:'MyTopic'}, {record_type:'DialogResponses', editorid:'MyTopic_L1', " +
-         "parent:'MyTopic', operations:[{field_path:'Prompt', value:'Hello'}]}] (declare the topic BEFORE the lines). collection= " +
+         "parent:'MyTopic', operations:[{field_path:'Prompt', value:'Hello'}]}] (declare the topic BEFORE the lines). A FormLink " +
+         "field VALUE can ALSO reference a same-call sibling, written '@editorid' — so a dialogue line's order-chain and its " +
+         "topic back-link are authored in the SAME call: e.g. on a line, operations:[{field_path:'Topic', value:'@MyTopic'}, " +
+         "{field_path:'PreviousDialog', value:'@MyTopic_L1'}] points it at the same-call topic and the prior line. Each '@editorid' " +
+         "must name a record declared EARLIER in this array; it resolves to that record's auto-allocated FormID. (Only on FormLink " +
+         "fields, only in this batch tool — a single create_record has no siblings.) collection= " +
          "names which child-list when the parent holds more than one that fits (e.g. a cell's 'Persistent'). Each new FormID is " +
          "auto-allocated (the patch's own 0x800+ range) and returned. ALL-OR-NOTHING (Q3): if ANY spec is malformed or fails " +
          "pre-flight (unknown/ambiguous type, missing editorid, illegal field op, a nested child with no resolvable parent, an " +


### PR DESCRIPTION
**Nested-create Layer B, unit A (the keystone).** Lets a `housecarl_bulk_create` call use a field value of the form `@editorid` to forward-reference a record created **earlier in the same call**, resolved to that record's auto-allocated 0x800+ FormKey after allocation. This is what lets a whole dialogue conversation be authored in one command: an INFO line's `PreviousDialog` (the PNAM order-chain) pointing at the prior line, and its `Topic` back-link pointing at the same-call `DialogTopic` — both targets are sibling FormKeys that don't exist until the call runs. (Plan `dev/plans/NESTED_DIALOGUE_AUTHORING_PLAN_2026-06-13.md` §1.5 [grill-rev: B1]; Aaron chose Build-it / Option A, 2026-06-17.)

### By construction, generic (§4-(a) — not per-record-type)
The mechanism is value-agnostic and works for **any FormLink on any created record**; dialogue (INFO/DIAL) appears only in comments and guard fixtures, never in logic.

- **`WriteEngine.IsSameCallSiblingRef`** — the shared `@editorid` recognizer (sigil `@`, which begins neither a FormKey `hex:Plugin.esp` nor any null-synonym, so it can't collide with a real FormLink value). Mirrors `IsFormKeyNullSynonym` — one recognizer shared by the gate and the apply-side substitution, so they can't drift.
- **`CorpusRulebook.ValueLegality`** — one central gate, threaded an optional `siblingEditorIds` via `Validate`. A sibling token is accepted **only** as a singular `Set` on a **FormLink** leaf, **only** in create context (non-null set), **only** if the editorid was declared **earlier** in this call. Everywhere else it rejects loud (Q3): the Apply/`set_field` path passes `null` → `@x` there is refused, never an accept-then-substitute-nothing; a non-FormLink field, a later/self reference, a non-`Set` verb, or a token inside a list/dict value all reject loud with a precise message.
- **`WritePatchBuilder.CreateRecords`** — Phase 1 passes the declared-earlier editorids (grown at each spec's loop end, so spec *i* sees `{0..i-1}`); Phase 3 substitutes the token with the sibling's real FormKey before `ApplyVerb` (single-pass — the prior sibling is already allocated). **The apply/coercion path is untouched** (the substituted value is a normal intra-patch FormKey). All-or-nothing preserved.
- **`housecarl_bulk_create`** description documents the `@editorid` syntax (bulk-only — a single `create_record` has no siblings).

### Guard + RED-proofs
`nested-create-guard` (`NestedCreateGuardProbe`) extended **in place** (no new CI step), 5 new arms — all RED-proven by sabotage→watch-fail→revert:
- **SIBREF** (keystone) — a one-shot topic + 2 lines; line 1's `Topic=@topic` and line 2's `PreviousDialog=@line1` both resolve to the right same-call FormKeys **read back off the written file**. (RED: skip Phase-3 substitution → `@` reaches apply → `Malformed FormKey`.)
- **REJ-SIBFWD** — a `@ref` to a sibling declared **later** refuses loud. (RED: neuter the gate → slips to a Phase-3 internal fail.)
- **REJ-SIBNONFL** — a `@ref` on a non-FormLink field (FavorLevel) refuses loud (the string-collision guard keeping substitution scoped to formlinks). (RED: neuter the gate → reaches apply, enum-coerce throws.)
- **REJ-SIBLIST** — a `@ref` inside a **collection** value (list `ReplaceAll`) refuses loud, not accept-then-throw. (RED: disable the collection check → `@` slips to apply and throws.)
- **REJ-SIBAPPLY** — a `@ref` validated with a null sibling set (the edit-existing path) refuses at the rulebook.

### Review
Independent adversarial review → **APPROVE-WITH-NITS**. Its one real finding — a sibling token inside `req.Values`/`req.Entries` (a collection value) slipped the singular gate and accept-then-threw at apply, which the gate's own comment wrongly denied — is **folded** (commit `4a5d18b`): the gate now refuses a collection-value sibling token loud and unconditionally, comment corrected, `REJ-SIBLIST` arm added + RED-proven. (The reviewer noted a **broader pre-existing** gap — a non-sibling garbage element in a formlink-list `ReplaceAll` also accept-then-throws because list-element value-shape was never gate-checked; that pre-dates this feature, is unrelated to dialogue, and is parked as its own task, not folded here.)

### Test evidence
- `nested-create-guard`: **15/15** arms PASS.
- Full CI suite: **all 42 probes** exit 0 (pass or self-skip); write/validate subset re-run after the fold — green.
- Release build clean (0 errors).

### Scope
Part of the Layer B batch (A → B voice check → C completeness validator → D SEQ writer → E dialogue skill). This is unit **A**; the others land as their own PRs. Tool surface unchanged (no new tool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)