### PR TITLE
write pre-flight: gate malformed FormLink ELEMENTS in collection values

### DIFF
--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -351,6 +351,29 @@ public sealed class CorpusRulebook
             return CheckValue(leaf.Type, req.Value, $"value for '{leaf.Name}'",
                 leaf.MutableTypeAssemblyQualified ?? leaf.GetterTypeAssemblyQualified);
         }
+        // (step 4a) FormLink-ELEMENT collection value-shape — the collection twin of the singular formlink Set check
+        // immediately above. A list/dict whose ELEMENT is a FormLink (corpus FormLinkTarget set — emitted BY
+        // CONSTRUCTION by the SAME generator IsFormLink branch that flags a singular formlink) coerces each element
+        // through FormKey.Factory at apply (ApplyListVerb / ApplyDictVerb -> Coerce -> TryFormLink -> ToFormKey). A
+        // malformed element ("notaformkey"; "0"/"00000000"/"Null"/"000000:Null" stay legal null-clears) used to pass
+        // pre-flight here and throw "Malformed FormKey string" at apply — a Q3 accept-then-throw, the GENERAL gap the
+        // Layer-B sibling-ref collection gate (above) named as the broader pre-existing hole. Validate every supplied
+        // element VALUE with the SAME recognizer the singular path uses (IsValidFormLinkValue — one predicate, no
+        // drift between gate and apply): req.Value (list Add / SetAtIndex / Remove-by-value; dict Add — dict Set
+        // returned at its own block above), req.Values (list ReplaceAll), and req.Entries' VALUES (dict Merge /
+        // ReplaceAll). The dict KEY is deliberately NOT checked — keys are the deferred surface the sibling-ref note
+        // drew. NOTE: every formlink collection in the current corpus is a LIST (85 fields); a formlink-VALUED dict is
+        // not modeled by Mutagen today (0 fields) and the generator's dict branch does not stamp FormLinkTarget for
+        // one, so the req.Entries arm is dormant-by-construction — named here (Q3), and lit the moment such a field
+        // (carrying its FormLinkTarget stamp) exists. The dict KEY-shape edge stays as the sibling-ref note left it.
+        if (leaf.Cardinality is "list" or "dict" && leaf.FormLinkTarget is not null)
+        {
+            if (req.Value is { } ev && !WriteEngine.IsValidFormLinkValue(ev)) return FormLinkElementReject(ev, leaf);
+            foreach (var v in req.Values ?? Array.Empty<string>())
+                if (!WriteEngine.IsValidFormLinkValue(v)) return FormLinkElementReject(v, leaf);
+            foreach (var kv in req.Entries ?? new())
+                if (!WriteEngine.IsValidFormLinkValue(kv.Value)) return FormLinkElementReject(kv.Value, leaf);
+        }
         // (step 4) collection-verb value legality. A struct-element OR arm-element list takes a build-from-parts
         // StructSpec on Add — NOT a plain value — which is wave-1 half B composition (an ARM element composes by its
         // concrete arm type, validated against that arm's own schema — the VMAD shape, #35; before this, arm-element
@@ -442,6 +465,14 @@ public sealed class CorpusRulebook
         return $"'{leaf.Name}' ({leaf.Type}) needs a typed-value spec, not a plain value (e.g. a condition " +
                "FormLinkOrIndex target). Known deferred surface — surfaced, never silently accepted.";
     }
+
+    /// <summary>The loud per-element rejection for a malformed FormLink collection ELEMENT — the SAME legal-set copy
+    /// as the singular formlink Set reject, with "target" reading "element" so the two are visibly the one check at
+    /// two cardinalities. The offending value is named (per-element, Q3): the gate says exactly which element it
+    /// refused and what shape is legal, never a bare "internal inconsistency" surfaced from an apply-time throw.</summary>
+    static string FormLinkElementReject(string value, FieldSchema leaf) =>
+        $"Illegal FormLink element '{value}' for '{leaf.Name}': expected a FormID (XXXXXX:Plugin.esp) " +
+        "or a null-clear ('0', '00000000', 'Null', '000000:Null').";
 
     /// <summary>Validate a polymorphic Set: the arm must be a legal arm of the field, and its contents (flat fields +
     /// nested sets) must validate against the arm type — the same composition-contents check a struct-element Add uses.</summary>

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -49,6 +49,20 @@ namespace HousecarlGenerator;
 ///   REJ-SIBDICT   — the dict half of that gate: an @ref inside a dict Merge's Entries values refuses loud the same way.
 ///   REJ-SIBAPPLY  — an @ref validated with a NULL sibling set (the Apply/set_field context) refuses at the rulebook —
 ///                   create-only scoping, so @editorid never becomes an accept-then-substitute-nothing hole (Q3).
+///
+/// GENERAL FormLink-ELEMENT collection value-shape — the BROADER pre-existing gap REJ-SIBLIST/REJ-SIBDICT named: ANY
+/// malformed FormLink ELEMENT (not just an @editorid sibling token) in a collection value was accepted at pre-flight
+/// then threw "Malformed FormKey string" at apply (a Q3 accept-then-throw). The gate now validates each element with
+/// the SAME recognizer the singular formlink Set uses (DialogResponses.LinkTo = List&lt;FormLink&lt;DialogTopic&gt;&gt;):
+///   FLELEM-REJ-GATE    — a malformed element in a ReplaceAll (req.Values), PAST a valid one, refuses at PRE-FLIGHT and
+///                        NAMES the bad element ('Illegal FormLink element …' — per-element, the rulebook driven directly).
+///   FLELEM-REJ-ADD     — the req.Value slot too: a malformed Add value refuses (Add/SetAtIndex carry the element there).
+///   FLELEM-NULLCLEAR-OK— a null-clear synonym ('00000000') is a LEGAL element (shares IsValidFormLinkValue with the
+///                        singular path) — the gate doesn't over-reject the clear shape.
+///   FLELEM-OK-E2E      — a VALID FormID element round-trips through the REAL create+apply (accepted AND written to disk).
+///   FLELEM-REJ-E2E     — a malformed element refuses end-to-end with NO file written; the PRE-FLIGHT message (not the
+///                        apply throw) proves it was the gate. (The dict half — Merge/ReplaceAll on a formlink-VALUED
+///                        dict — is dormant-by-construction: no such field is modeled in the corpus today, see ValueLegality.)
 /// </summary>
 public static class NestedCreateGuardProbe
 {
@@ -343,10 +357,86 @@ public static class NestedCreateGuardProbe
             Console.WriteLine($"   REJ-SIBAPPLY @ref on set_field path  : {(sibRejApplyOk ? "PASS — rejected at the gate (no same-call siblings when editing an existing record)" : $"FAIL — reject=[{reject}]")}");
         }
 
+        // ====== GENERAL FormLink-ELEMENT collection value-shape (the broader gap the sibling-ref collection gate named) ======
+        // The sibling-ref arms above gate a '@editorid' token in a collection value; this is the GENERAL case — ANY
+        // malformed FormLink ELEMENT in a collection (a list/dict whose element is a FormLink). DialogResponses.LinkTo
+        // is List<FormLink<IDialogTopicGetter>> (corpus FormLinkTarget set), the same fixture field REJ-SIBLIST used.
+
+        // ---------- FLELEM-REJ-GATE: a malformed element in a ReplaceAll (req.Values) refuses at PRE-FLIGHT ----------
+        // Drive the rulebook DIRECTLY (parent-free) — a non-null reject IS a gate refusal (apply would instead throw the
+        // misleading "Malformed FormKey string"). A VALID FormID sits first in the list, so the per-element scan must
+        // catch the bad one even past a good one, and the message must NAME the offending element (per-element, Q3).
+        bool flElemRejGateOk;
+        {
+            var req = new WriteRequest { RecordType = "DialogResponses", Path = new[] { "LinkTo" }, Verb = "ReplaceAll",
+                Values = new[] { masterTopicFk.ToString(), "notaformkey" } };
+            var reject = rulebook.Validate(req);
+            flElemRejGateOk = reject is not null
+                && reject.Contains("Illegal FormLink element", StringComparison.OrdinalIgnoreCase)
+                && reject.Contains("notaformkey", StringComparison.Ordinal);
+            Console.WriteLine($"   FLELEM-REJ-GATE malformed list elem  : {(flElemRejGateOk ? "PASS — refused at pre-flight, names the bad element past a valid one" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- FLELEM-REJ-ADD: a malformed element in an Add (req.Value slot) refuses too ----------
+        // Guards the req.Value arm of the gate specifically (Add/SetAtIndex carry the element in req.Value, not req.Values).
+        bool flElemRejAddOk;
+        {
+            var req = new WriteRequest { RecordType = "DialogResponses", Path = new[] { "LinkTo" }, Verb = "Add", Value = "notaformkey" };
+            var reject = rulebook.Validate(req);
+            flElemRejAddOk = reject is not null && reject.Contains("Illegal FormLink element", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   FLELEM-REJ-ADD malformed Add value   : {(flElemRejAddOk ? "PASS — the req.Value slot is gated too" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- FLELEM-NULLCLEAR-OK: a null-clear synonym element is LEGAL (mirrors the singular formlink check) ----------
+        // The gate shares IsValidFormLinkValue with the singular path, so "00000000" (a null-clear) must pass as an
+        // element exactly as it does as a singular Set value — proves the gate doesn't over-reject the legal clear shape.
+        bool flElemNullClearOk;
+        {
+            var req = new WriteRequest { RecordType = "DialogResponses", Path = new[] { "LinkTo" }, Verb = "ReplaceAll",
+                Values = new[] { masterTopicFk.ToString(), "00000000" } };
+            var reject = rulebook.Validate(req);
+            flElemNullClearOk = reject is null;
+            Console.WriteLine($"   FLELEM-NULLCLEAR-OK null-clear elem  : {(flElemNullClearOk ? "PASS — a real FormID and a null-clear synonym both accepted" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- FLELEM-OK-E2E: a VALID element round-trips through the REAL create+apply path ----------
+        // The no-over-reject proof in full: pre-flight accepts AND the engine writes it (the gate guards the apply path,
+        // it does not block it). Create a topic + INFO whose LinkTo ReplaceAll = [a real FormID]; read it back off disk.
+        bool flElemOkE2eOk = false;
+        {
+            string pPath = Path.Combine(tmpDir, "HcNcFlElemOk.esp");
+            var specs = new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogTopic", EditorId = "HcNcFoTopic", Edits = Array.Empty<WriteRequest>() },
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcFoL1", ParentRef = "HcNcFoTopic",
+                    Edits = new[] { new WriteRequest { RecordType = "DialogResponses", Path = new[] { "LinkTo" }, Verb = "ReplaceAll",
+                        Values = new[] { masterTopicFk.ToString() } } } },
+            };
+            using var r = LoadOrderResolver.Build(new[] { mPath });
+            var o = WritePatchBuilder.CreateRecords(r, rulebook, specs, pPath, extend: false);
+            var linkTo = o.Success && o.Created.Count > 1 ? InfoLinkTo(pPath, o.Created[1].FormKey) : null;
+            bool present = linkTo is not null && linkTo.Contains(masterTopicFk);
+            flElemOkE2eOk = o.Success && present;
+            Console.WriteLine($"   FLELEM-OK-E2E valid elem round-trips : {(flElemOkE2eOk ? "PASS — accepted at the gate AND written to LinkTo on disk" : $"FAIL — success={o.Success} present={present} linkTo=[{(linkTo is null ? "null" : string.Join(",", linkTo))}] err=[{o.Error}]")}");
+        }
+
+        // ---------- FLELEM-REJ-E2E: a malformed element refuses end-to-end with NO file written (gate, not apply throw) ----------
+        // The "no file written" half: drive the REAL create path; the message being the PRE-FLIGHT one (not the apply
+        // "Malformed FormKey string") proves the gate caught it, and RejectArm proves the all-or-nothing leaves no file.
+        bool flElemRejE2eOk = RejectArm("FLELEM-REJ-E2E malformed list elem ", tmpDir, "FlElem", mPath, rulebook,
+            new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogTopic", EditorId = "HcNcFeTopic", Edits = Array.Empty<WriteRequest>() },
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcFeL1", ParentRef = "HcNcFeTopic",
+                    Edits = new[] { new WriteRequest { RecordType = "DialogResponses", Path = new[] { "LinkTo" }, Verb = "ReplaceAll", Values = new[] { "notaformkey" } } } },
+            },
+            msg => msg.Contains("Illegal FormLink element", StringComparison.OrdinalIgnoreCase));
+
         Console.WriteLine();
         bool pass = fixturesOk && oneshotOk && multiOk && intoTopicOk && intoCellOk
                     && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendOk
-                    && sibrefOk && sibRejFwdOk && sibRejNonflOk && sibRejListOk && sibRejDictOk && sibRejApplyOk;
+                    && sibrefOk && sibRejFwdOk && sibRejNonflOk && sibRejListOk && sibRejDictOk && sibRejApplyOk
+                    && flElemRejGateOk && flElemRejAddOk && flElemNullClearOk && flElemOkE2eOk && flElemRejE2eOk;
         Console.WriteLine($"=== nested-create-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return pass ? 0 : 1;
@@ -450,6 +540,23 @@ public static class NestedCreateGuardProbe
             foreach (var t in ov.DialogTopics)
                 foreach (var info in t.Responses)
                     if (info.FormKey == infoFk) return select(info);
+            return null;
+        }
+        catch { return null; }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    /// <summary>Re-open the written patch and list a created INFO's LinkTo (TCLT) element FormKeys — the valid
+    /// formlink-ELEMENT round-trip check (FLELEM-OK-E2E). Null if the INFO isn't found.</summary>
+    static List<FormKey>? InfoLinkTo(string patchPath, FormKey infoFk)
+    {
+        ISkyrimModGetter? ov = null;
+        try
+        {
+            ov = SkyrimMod.CreateFromBinaryOverlay(patchPath, SkyrimRelease.SkyrimSE);
+            foreach (var t in ov.DialogTopics)
+                foreach (var info in t.Responses)
+                    if (info.FormKey == infoFk) return info.LinkTo.Select(x => x.FormKey).ToList();
             return null;
         }
         catch { return null; }


### PR DESCRIPTION
## The gap (Q3 accept-then-throw)

`CorpusRulebook.ValueLegality` validated only the **singular** FormLink Set value (`req.Value`) via `WriteEngine.IsValidFormLinkValue` (PR-F). A list/dict whose **element** is a FormLink — `Npc.Keywords`, `DialogResponses.LinkTo`, faction lists (**85 corpus fields**, all lists) — coerces each element through `FormKey.Factory` at apply, but the per-element values in `req.Values` (ReplaceAll), `req.Value` (Add/SetAtIndex), and `req.Entries` (Merge) fell through to `return null`. A malformed element passed pre-flight, then threw `ArgumentException: Malformed FormKey string` at apply — surfaced as a misleading *"pre-flight ACCEPTED it but apply threw — a real inconsistency"* for what is really bad user input. This is the **general gap the Layer-B unit-A sibling-ref collection gate named** as the broader pre-existing hole.

## The fix

A new block in `ValueLegality` (right after the singular formlink check — its twin — and after both sibling-ref gates) validates every supplied element value with the **same `IsValidFormLinkValue` recognizer** the singular path uses (one predicate, no gate/apply drift), rejecting loud per-element: `Illegal FormLink element '<v>' for '<field>': …`.

Detection is **by-construction, no per-record-type list**: `leaf.Cardinality is "list" or "dict" && leaf.FormLinkTarget is not null` — the corpus `FormLinkTarget` the generator stamps in the same `IsFormLink` branch that flags a singular formlink. The dict **key** stays unchecked (the boundary the sibling-ref note drew).

## Verification

- `nested-create-guard` extended with 5 arms (`FLELEM-*`): **3 RED-proven gap-detectors** (`REJ-GATE` / `REJ-ADD` / `REJ-E2E` all fail with the gate reverted; `REJ-E2E` surfaces the exact accept-then-throw) + **2 no-over-reject guards** (`NULLCLEAR-OK`, `OK-E2E` round-trip a valid FormID to disk).
- **Full CI suite 42/42 green.** No new CI step (extended in place). Tool surface unchanged (21).

## Judgment calls (flagged for review)

1. **Also covers `Remove`-by-value**, not only the four enumerated collection verbs — the impl is slot-based (`req.Value`/`req.Values`/`req.Entries`), and Remove-by-value uses the same `req.Value` slot; covering it is simpler (no verb special-case) and closes the identical adjacent hole. Never touches the dict key.
2. **dict/`Merge` path is dormant-by-construction** — zero formlink-*valued* dicts exist in the corpus and the generator's dict branch doesn't stamp `FormLinkTarget`. The `req.Entries` arm is included for verb-completeness + forward-correctness and documented as dormant, rather than shipping untestable speculation or touching the generator for a field that doesn't exist.
3. **Detection via `FormLinkTarget` only** (not element-AQ resolution + a new `WriteEngine.IsFormLink`) — simpler, no untestable branch; tradeoff is a future formlink-valued dict would need the generator's dict branch updated to be detected. Documented inline.

§4-(a) by-construction, cornerstone untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
