### PR TITLE
write pre-flight: gate missing (null) element value on coercible-collection Add/SetAtIndex

### DIFF
--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -353,20 +353,24 @@ public sealed class CorpusRulebook
         }
         // (step 4-pre) ELEMENT-VALUE PRESENCE — the collection twin of the singular Set "requires a value" reject
         // above (line ~328). Add / SetAtIndex on a COERCIBLE-element collection set the new element by coercing the
-        // singular req.Value (ApplyListVerb / ApplyDictVerb -> Coerce(req.Value!, elem)); a MISSING value (req.Value
-        // null, and no req.Struct compose) does NOT fail loud at the gate — at apply Coerce(null) yields a null
-        // element that then throws a NullReferenceException at SERIALIZE (surfaced as the misleading "compose the Data
-        // arm" NullArmSerializeException, nothing to do with the real cause). That is the SAME accept-then-throw shape
-        // PR #76 closed for a MALFORMED (non-null) element, but for the absent-value case: the step-4a formlink check
-        // below uses `is { } ev`, which SKIPS a null slot. Gate it here for EVERY coercible element (formlink +
-        // non-formlink), by construction. Verb-scoped to the verbs that consume the singular req.Value — ReplaceAll
-        // (req.Values) / Merge (req.Entries) carry their elements elsewhere (a null ENTRY inside those is the step-4a
-        // formlink check's job, or the parked non-formlink value-shape surface), and Remove is by-key-OR-value (a
-        // distinct identify-the-element concern, not a "requires a value" mirror). Coercible-element-only: Struct/Arm
-        // elements take req.Struct (StructElementLegality below gives the right "build-from-parts spec" message), and
-        // Record / uncoercible elements have no plain-value Add path at all — both correctly left exactly as today.
+        // singular req.Value (ApplyListVerb / ApplyDictVerb -> Coerce(req.Value!, elem)); a MISSING value does NOT
+        // fail loud at the gate — at apply Coerce(null) yields a null element that then throws a NullReferenceException
+        // at SERIALIZE (surfaced as the misleading "compose the Data arm" NullArmSerializeException, nothing to do with
+        // the real cause). That is the SAME accept-then-throw shape PR #76 closed for a MALFORMED (non-null) element,
+        // but for the absent-value case: the step-4a formlink check below uses `is { } ev`, which SKIPS a null slot.
+        // Gate it here for EVERY coercible element (formlink + non-formlink), by construction. NO req.Struct guard, by
+        // design (PR #77 review finding 1): a coercible element is NEVER built from a StructSpec, so a struct supplied
+        // with a null value is itself malformed — SetAtIndex ignores req.Struct entirely (ApplyListVerb is
+        // unconditionally Coerce(req.Value!)), and an Add's BuildStruct on a coercible element throws too; firing on a
+        // null value REGARDLESS of req.Struct closes both, and "requires an element value" is the right guidance either
+        // way (this also matches the singular Set mirror, which carries no struct guard). Verb-scoped to the verbs that
+        // consume the singular req.Value — ReplaceAll (req.Values) / Merge (req.Entries) carry their elements elsewhere
+        // (a null ENTRY inside those is the step-4a formlink check's job, or the parked non-formlink value-shape
+        // surface), and Remove is by-key-OR-value (a distinct identify-the-element concern, not a "requires a value"
+        // mirror). Coercible-element-only: Struct/Arm elements compose via the composable block below (which DOES
+        // require the spec), and Record / uncoercible elements have no plain-value Add path — both left as today.
         if (leaf.Cardinality is "list" or "dict" && req.Verb is "Add" or "SetAtIndex"
-            && req.Value is null && req.Struct is null && IsValueCoercibleElement(leaf))
+            && req.Value is null && IsValueCoercibleElement(leaf))
             return $"{req.Verb} on '{leaf.Name}' requires an element value.";
         // (step 4a) FormLink-ELEMENT collection value-shape — the collection twin of the singular formlink Set check
         // immediately above. A list/dict whose ELEMENT is a FormLink (corpus FormLinkTarget set — emitted BY

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -351,6 +351,23 @@ public sealed class CorpusRulebook
             return CheckValue(leaf.Type, req.Value, $"value for '{leaf.Name}'",
                 leaf.MutableTypeAssemblyQualified ?? leaf.GetterTypeAssemblyQualified);
         }
+        // (step 4-pre) ELEMENT-VALUE PRESENCE — the collection twin of the singular Set "requires a value" reject
+        // above (line ~328). Add / SetAtIndex on a COERCIBLE-element collection set the new element by coercing the
+        // singular req.Value (ApplyListVerb / ApplyDictVerb -> Coerce(req.Value!, elem)); a MISSING value (req.Value
+        // null, and no req.Struct compose) does NOT fail loud at the gate — at apply Coerce(null) yields a null
+        // element that then throws a NullReferenceException at SERIALIZE (surfaced as the misleading "compose the Data
+        // arm" NullArmSerializeException, nothing to do with the real cause). That is the SAME accept-then-throw shape
+        // PR #76 closed for a MALFORMED (non-null) element, but for the absent-value case: the step-4a formlink check
+        // below uses `is { } ev`, which SKIPS a null slot. Gate it here for EVERY coercible element (formlink +
+        // non-formlink), by construction. Verb-scoped to the verbs that consume the singular req.Value — ReplaceAll
+        // (req.Values) / Merge (req.Entries) carry their elements elsewhere (a null ENTRY inside those is the step-4a
+        // formlink check's job, or the parked non-formlink value-shape surface), and Remove is by-key-OR-value (a
+        // distinct identify-the-element concern, not a "requires a value" mirror). Coercible-element-only: Struct/Arm
+        // elements take req.Struct (StructElementLegality below gives the right "build-from-parts spec" message), and
+        // Record / uncoercible elements have no plain-value Add path at all — both correctly left exactly as today.
+        if (leaf.Cardinality is "list" or "dict" && req.Verb is "Add" or "SetAtIndex"
+            && req.Value is null && req.Struct is null && IsValueCoercibleElement(leaf))
+            return $"{req.Verb} on '{leaf.Name}' requires an element value.";
         // (step 4a) FormLink-ELEMENT collection value-shape — the collection twin of the singular formlink Set check
         // immediately above. A list/dict whose ELEMENT is a FormLink (corpus FormLinkTarget set — emitted BY
         // CONSTRUCTION by the SAME generator IsFormLink branch that flags a singular formlink) coerces each element
@@ -403,6 +420,18 @@ public sealed class CorpusRulebook
     /// a spec. Derived via the shared <see cref="SchemaClassifier"/> so the partition cannot be defined twice.</summary>
     bool IsComposableElement(FieldSchema leaf)
         => SchemaClassifier.ClassifyElement(leaf, _corpus) is ElementKind.Struct or ElementKind.Arm;
+
+    /// <summary>True iff the leaf is a collection whose ELEMENT the engine sets by COERCING a single plain value
+    /// (req.Value): a scalar/enum/formlink element (<see cref="ElementKind.ScalarCoercible"/>) or a whole-coercible
+    /// AssetLink-path element (<see cref="ElementKind.WholeCoercible"/>). These are exactly the kinds an Add /
+    /// SetAtIndex writes via <c>Coerce(req.Value!, elem)</c> at apply, so a null req.Value yields a null element that
+    /// throws at serialize — the value-presence gate keys off this. Struct/Arm elements compose via req.Struct
+    /// (<see cref="IsComposableElement"/>), and Record / uncoercible elements have no plain-value Add path at all; both
+    /// are correctly EXCLUDED so the gate can't mis-diagnose them. Derived via the shared <see cref="SchemaClassifier"/>
+    /// so the partition isn't redefined. (Broader than <see cref="SchemaClassifier.CoercibleElement"/>, which is
+    /// ScalarCoercible only — a WholeCoercible element is ALSO set by one coerced value, so it shares the null hazard.)</summary>
+    bool IsValueCoercibleElement(FieldSchema leaf)
+        => SchemaClassifier.ClassifyElement(leaf, _corpus) is ElementKind.ScalarCoercible or ElementKind.WholeCoercible;
 
     /// <summary>Validate a struct-element Add: the spec must be present, its type must match the list's element
     /// type — or, when the element type is a <b>polymorphic-base</b>, be one of its ARMS (the VMAD shape, #35:

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -63,6 +63,16 @@ namespace HousecarlGenerator;
 ///   FLELEM-REJ-E2E     — a malformed element refuses end-to-end with NO file written; the PRE-FLIGHT message (not the
 ///                        apply throw) proves it was the gate. (The dict half — Merge/ReplaceAll on a formlink-VALUED
 ///                        dict — is dormant-by-construction: no such field is modeled in the corpus today, see ValueLegality.)
+///
+/// ELEMENT-VALUE PRESENCE — the null-PRESENCE twin of the value-SHAPE gap above (PR #76 follow-up). Add/SetAtIndex on a
+/// coercible-element collection set the new element by coercing the singular req.Value; a MISSING value (req.Value null,
+/// no compose) used to slip pre-flight — the formlink step-4a check uses `is { } ev`, which SKIPS a null slot — then
+/// Coerce(null) yielded a null element that threw a NullReferenceException at SERIALIZE (the misleading "compose the Data
+/// arm" message). The value-presence gate refuses it loud, mirroring the singular Set "requires a value":
+///   FLELEM-REJ-NULLADD       — a null req.Value on a formlink-list Add refuses at PRE-FLIGHT (RED before: accepted, null).
+///   FLELEM-REJ-NULLADD-PLAIN — the SAME gate fires for a NON-formlink coercible list (Race.MovementTypeNames =
+///                              List&lt;String&gt;) — proves it's gated UNIFORMLY by element KIND, not formlink-ness (by construction).
+///   FLELEM-REJ-NULLADD-E2E   — a null-value Add refuses end-to-end with NO file written (the gate, not the serialize NRE).
 /// </summary>
 public static class NestedCreateGuardProbe
 {
@@ -432,11 +442,54 @@ public static class NestedCreateGuardProbe
             },
             msg => msg.Contains("Illegal FormLink element", StringComparison.OrdinalIgnoreCase));
 
+        // ====== ELEMENT-VALUE PRESENCE — the null-PRESENCE twin of the FLELEM value-SHAPE gap above ======
+        // FLELEM-REJ-ADD/GATE catch a MALFORMED (non-null) element; this catches a MISSING one. The step-4a formlink
+        // check uses `is { } ev`, which SKIPS a null req.Value — so a formlink-list Add with NO value used to pass
+        // pre-flight (the RED state) and then null-deref/odd-result at apply (the same accept-then-throw shape PR #76
+        // closed, but for the absent-value case). The value-presence gate refuses it loud, mirroring the singular
+        // Set "requires a value". Coercible-element-only + verb-scoped (Add/SetAtIndex consume the singular req.Value).
+
+        // ---------- FLELEM-REJ-NULLADD: a MISSING element value (req.Value null) on an Add refuses at PRE-FLIGHT ----------
+        // Driven parent-free against the rulebook — a non-null reject IS the gate refusal. RED before the gate:
+        // Validate returned null (accepted), because the formlink step-4a `is { } ev` skips the null slot.
+        bool flElemRejNullAddOk;
+        {
+            var req = new WriteRequest { RecordType = "DialogResponses", Path = new[] { "LinkTo" }, Verb = "Add", Value = null };
+            var reject = rulebook.Validate(req);
+            flElemRejNullAddOk = reject is not null && reject.Contains("requires an element value", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   FLELEM-REJ-NULLADD missing Add value : {(flElemRejNullAddOk ? "PASS — a null element value is refused at pre-flight (not accepted-then-null/thrown at apply)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- FLELEM-REJ-NULLADD-PLAIN: the gate fires for a NON-formlink coercible element too (uniform scope) ----------
+        // The gate keys off the element KIND (ScalarCoercible/WholeCoercible via SchemaClassifier), not formlink-ness, so a
+        // plain coercible list shares the same null-presence hazard and the same fix BY CONSTRUCTION. Race.MovementTypeNames
+        // is List<String> (no FormLinkTarget, no ElementTypeRef → ScalarCoercible). RED before the gate: accepted (null).
+        bool flElemRejNullAddPlainOk;
+        {
+            var req = new WriteRequest { RecordType = "Race", Path = new[] { "MovementTypeNames" }, Verb = "Add", Value = null };
+            var reject = rulebook.Validate(req);
+            flElemRejNullAddPlainOk = reject is not null && reject.Contains("requires an element value", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   FLELEM-REJ-NULLADD-PLAIN non-formlink: {(flElemRejNullAddPlainOk ? "PASS — a null value on a plain coercible (List<String>) Add is refused too — gated uniformly" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- FLELEM-REJ-NULLADD-E2E: a missing element value refuses end-to-end with NO file written ----------
+        // The "no file written" half (RejectArm): the REAL create+apply path refuses a null-value LinkTo Add and leaves
+        // no patch — the pre-flight message (not an apply null/throw) proving the gate, all-or-nothing leaving nothing.
+        bool flElemRejNullAddE2eOk = RejectArm("FLELEM-REJ-NULLADD-E2E missing value", tmpDir, "FlElemNull", mPath, rulebook,
+            new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogTopic", EditorId = "HcNcFnTopic", Edits = Array.Empty<WriteRequest>() },
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcFnL1", ParentRef = "HcNcFnTopic",
+                    Edits = new[] { new WriteRequest { RecordType = "DialogResponses", Path = new[] { "LinkTo" }, Verb = "Add", Value = null } } },
+            },
+            msg => msg.Contains("requires an element value", StringComparison.OrdinalIgnoreCase));
+
         Console.WriteLine();
         bool pass = fixturesOk && oneshotOk && multiOk && intoTopicOk && intoCellOk
                     && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendOk
                     && sibrefOk && sibRejFwdOk && sibRejNonflOk && sibRejListOk && sibRejDictOk && sibRejApplyOk
-                    && flElemRejGateOk && flElemRejAddOk && flElemNullClearOk && flElemOkE2eOk && flElemRejE2eOk;
+                    && flElemRejGateOk && flElemRejAddOk && flElemNullClearOk && flElemOkE2eOk && flElemRejE2eOk
+                    && flElemRejNullAddOk && flElemRejNullAddPlainOk && flElemRejNullAddE2eOk;
         Console.WriteLine($"=== nested-create-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return pass ? 0 : 1;

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -72,6 +72,8 @@ namespace HousecarlGenerator;
 ///   FLELEM-REJ-NULLADD       — a null req.Value on a formlink-list Add refuses at PRE-FLIGHT (RED before: accepted, null).
 ///   FLELEM-REJ-NULLADD-PLAIN — the SAME gate fires for a NON-formlink coercible list (Race.MovementTypeNames =
 ///                              List&lt;String&gt;) — proves it's gated UNIFORMLY by element KIND, not formlink-ness (by construction).
+///   FLELEM-REJ-NULLSETIDX    — a compose supplied with NO value on a coercible SetAtIndex still refuses (PR #77 review
+///                              finding 1): SetAtIndex ignores req.Struct, so the gate carries NO req.Struct guard.
 ///   FLELEM-REJ-NULLADD-E2E   — a null-value Add refuses end-to-end with NO file written (the gate, not the serialize NRE).
 /// </summary>
 public static class NestedCreateGuardProbe
@@ -472,6 +474,21 @@ public static class NestedCreateGuardProbe
             Console.WriteLine($"   FLELEM-REJ-NULLADD-PLAIN non-formlink: {(flElemRejNullAddPlainOk ? "PASS — a null value on a plain coercible (List<String>) Add is refused too — gated uniformly" : $"FAIL — reject=[{reject}]")}");
         }
 
+        // ---------- FLELEM-REJ-NULLSETIDX: a compose supplied with NO value on a coercible SetAtIndex still refuses ----------
+        // (PR #77 review finding 1.) SetAtIndex NEVER consumes req.Struct — ApplyListVerb's SetAtIndex is unconditionally
+        // Coerce(req.Value!, elem) — so a compose+no-value must NOT suppress the presence gate, else Coerce(null) hits the
+        // same serialize NRE the gate exists to kill. The gate therefore has NO req.Struct guard (a coercible element is
+        // never built from a struct, so a struct here is itself malformed). RED before the finding-1 fold: the gate's old
+        // `&& req.Struct is null` clause let a non-null Struct skip the gate → accepted. Race.MovementTypeNames = List<String>.
+        bool flElemRejNullSetIdxOk;
+        {
+            var req = new WriteRequest { RecordType = "Race", Path = new[] { "MovementTypeNames" }, Verb = "SetAtIndex",
+                Key = "0", Value = null, Struct = new StructSpec { Type = "Keyword" } };
+            var reject = rulebook.Validate(req);
+            flElemRejNullSetIdxOk = reject is not null && reject.Contains("requires an element value", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   FLELEM-REJ-NULLSETIDX struct+no value: {(flElemRejNullSetIdxOk ? "PASS — a compose can't suppress the gate on SetAtIndex (which ignores req.Struct)" : $"FAIL — reject=[{reject}]")}");
+        }
+
         // ---------- FLELEM-REJ-NULLADD-E2E: a missing element value refuses end-to-end with NO file written ----------
         // The "no file written" half (RejectArm): the REAL create+apply path refuses a null-value LinkTo Add and leaves
         // no patch — the pre-flight message (not an apply null/throw) proving the gate, all-or-nothing leaving nothing.
@@ -489,7 +506,7 @@ public static class NestedCreateGuardProbe
                     && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendOk
                     && sibrefOk && sibRejFwdOk && sibRejNonflOk && sibRejListOk && sibRejDictOk && sibRejApplyOk
                     && flElemRejGateOk && flElemRejAddOk && flElemNullClearOk && flElemOkE2eOk && flElemRejE2eOk
-                    && flElemRejNullAddOk && flElemRejNullAddPlainOk && flElemRejNullAddE2eOk;
+                    && flElemRejNullAddOk && flElemRejNullAddPlainOk && flElemRejNullSetIdxOk && flElemRejNullAddE2eOk;
         Console.WriteLine($"=== nested-create-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return pass ? 0 : 1;


### PR DESCRIPTION
The null-**presence** twin of [#76](https://github.com/Avick3110/houseCARL/pull/76)'s value-**shape** gate — the exact out-of-scope gap #76's reviewer flagged. §4-(a), by-construction, no new tool (surface stays 21), no new CI step.

## The gap (reachable, not just defense-in-depth)
`value` is optional on every write tool (`string?`, not in the schema `required` set), and `ToolCallShim` only refuses missing/null **top-level required** params — it never descends into `BulkOp[]` elements. So `housecarl_set_field` with `verb=Add` on a formlink-list field and **no value** binds (`value=null`), reaches `CorpusRulebook.ValueLegality`, and the step-4a formlink check's `is { } ev` pattern **skips the null slot** → pre-flight accepts it.

At apply, `Coerce(null, elem)` yields a null element that then throws a `NullReferenceException` at **serialize**, surfaced as the misleading *"a required modeled sub-field was null — e.g. a Condition composed without its Data arm"* `NullArmSerializeException`. A Q3 accept-then-throw that signposts the wrong fix.

## The fix
A verb-scoped element-value **presence** gate before the step-4a block, mirroring the singular `Set` "requires a value" reject. Fires for `Add`/`SetAtIndex` (the verbs that consume the singular `req.Value`) on a **coercible-element** collection (`ScalarCoercible`/`WholeCoercible` via `SchemaClassifier`) when `req.Value` and `req.Struct` are both null → *"Add on 'LinkTo' requires an element value."*, nothing written.

Gated **uniformly by element kind, not formlink-ness**, so formlink AND non-formlink coercible lists/dicts are covered by construction (no per-record-type list). Deliberately out of scope (documented inline):
- `ReplaceAll`/`Merge` carry elements in `values`/`entries`, not the single `value` slot; a null *entry inside* those stays the step-4a formlink check's job (formlinks) or the parked non-formlink value-shape surface.
- `Remove` is by-key-**or**-value (a distinct identify-the-element concern, not a "requires a value" mirror).
- Struct/Arm elements (compose via `req.Struct` — `StructElementLegality` gives the right message) and Record/uncoercible elements (no plain-value Add path) are untouched.

## Proof
RED→GREEN demonstrated by disabling the gate (all 3 new arms fail — pre-flight accepts the null on both formlink and `List<String>`; E2E hits the serialize NRE), then restoring it (all green). 3 RED-proven arms fold into `nested-create-guard`:
- `FLELEM-REJ-NULLADD` — null value on a formlink-list Add refused at pre-flight.
- `FLELEM-REJ-NULLADD-PLAIN` — same gate fires for a non-formlink coercible list (`Race.MovementTypeNames` = `List<String>`) — proves the uniform scope.
- `FLELEM-REJ-NULLADD-E2E` — null-value Add refuses end-to-end with **no file written** (the gate, not the serialize NRE).

Full **42-probe suite green in Release**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)