### PR TITLE
write pre-flight: gate missing dict key / list index on Add/SetAtIndex/Remove (PR #77 follow-up)

### DIFF
--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -248,14 +248,25 @@ public sealed class CorpusRulebook
                 if (c == "list") return $"Set is not valid on list '{leaf.Name}' — use SetAtIndex (with an index) or ReplaceAll.";
                 return hasKey ? $"Set on {c} field '{leaf.Name}' does not take a key." : null;
             case "Add":
-                return c is "list" or "dict" ? null : $"Add is only valid on list/dict; '{leaf.Name}' is {c}.";
+                // A dict Add coerces req.Key into the new entry's key (ApplyDictVerb -> Coerce(req.Key!, kType)); a
+                // MISSING key reaches apply and throws UNNAMED (Coerce(null)). A list Add appends — no key. Gate dict-Add
+                // key PRESENCE here, the structural twin of Set-on-dict above (key VALUE-shape stays ValueLegality's job).
+                if (c == "dict") return hasKey ? null : $"Add on dict field '{leaf.Name}' requires a key.";
+                return c == "list" ? null : $"Add is only valid on list/dict; '{leaf.Name}' is {c}.";
             case "Remove":
-                if (c is "list" or "dict") return null;
+                // A dict Remove identifies the entry to drop BY KEY (ApplyDictVerb -> Coerce(req.Key!, kType)); a MISSING
+                // key throws UNNAMED at apply. A list Remove is by-index-OR-by-value (ApplyListVerb): a null key legally
+                // falls back to remove-by-value, so list Remove needs NO key — gate dict-Remove key PRESENCE only.
+                if (c == "dict") return hasKey ? null : $"Remove on dict field '{leaf.Name}' requires a key.";
+                if (c == "list") return null;
                 return leaf.Nullable ? null : $"Remove on non-nullable {c} field '{leaf.Name}' is not valid.";
             case "ReplaceAll":
                 return c is "list" or "dict" ? null : $"ReplaceAll is only valid on list/dict; '{leaf.Name}' is {c}.";
             case "SetAtIndex":
-                return c == "list" ? null : $"SetAtIndex is only valid on list; '{leaf.Name}' is {c}.";
+                // A list SetAtIndex parses req.Key as the index (ApplyListVerb -> int.Parse(req.Key!)); a MISSING index
+                // throws ArgumentNullException at apply. Require it up front (PRESENCE; parseable-as-int stays deferred).
+                if (c != "list") return $"SetAtIndex is only valid on list; '{leaf.Name}' is {c}.";
+                return hasKey ? null : $"SetAtIndex on list '{leaf.Name}' requires an index.";
             case "Merge":
                 return c == "dict" ? null : $"Merge is only valid on dict; '{leaf.Name}' is {c}.";
             default:
@@ -382,8 +393,10 @@ public sealed class CorpusRulebook
         // element VALUE with the SAME recognizer the singular path uses (IsValidFormLinkValue — one predicate, no
         // drift between gate and apply): req.Value (list Add / SetAtIndex / Remove-by-value; dict Add — dict Set
         // returned at its own block above), req.Values (list ReplaceAll), and req.Entries' VALUES (dict Merge /
-        // ReplaceAll). The dict KEY is deliberately NOT checked — keys are the deferred surface the sibling-ref note
-        // drew. NOTE: every formlink collection in the current corpus is a LIST (85 fields); a formlink-VALUED dict is
+        // ReplaceAll). The dict KEY VALUE-SHAPE is deliberately NOT checked here — key shape is the deferred surface the
+        // sibling-ref note drew. (Key/index PRESENCE is a DISTINCT concern and IS gated up front, by construction, in
+        // VerbLegality's Add/Remove/SetAtIndex arms — the missing-key twin of the missing-value gate above.) NOTE: every
+        // formlink collection in the current corpus is a LIST (85 fields); a formlink-VALUED dict is
         // not modeled by Mutagen today (0 fields) and the generator's dict branch does not stamp FormLinkTarget for
         // one, so the req.Entries arm is dormant-by-construction — named here (Q3), and lit the moment such a field
         // (carrying its FormLinkTarget stamp) exists. The dict KEY-shape edge stays as the sibling-ref note left it.

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -75,6 +75,19 @@ namespace HousecarlGenerator;
 ///   FLELEM-REJ-NULLSETIDX    — a compose supplied with NO value on a coercible SetAtIndex still refuses (PR #77 review
 ///                              finding 1): SetAtIndex ignores req.Struct, so the gate carries NO req.Struct guard.
 ///   FLELEM-REJ-NULLADD-E2E   — a null-value Add refuses end-to-end with NO file written (the gate, not the serialize NRE).
+///
+/// KEY / INDEX PRESENCE — the missing-addressing-key twin of the value-presence gap above (PR #77 follow-up). A dict
+/// Add/Remove coerces req.Key into / against the entry; a list SetAtIndex parses req.Key as the index. A MISSING
+/// key/index slipped pre-flight (VerbLegality required a key only for Set-on-dict) and threw UNNAMED at apply
+/// (Coerce(null) / int.Parse(null)). VerbLegality now requires it up front, by construction:
+///   KEYIDX-REJ-DICTADD    — a dict Add with no key refuses at PRE-FLIGHT (Class.SkillWeights=Dictionary&lt;Skill,Byte&gt;;
+///                           a valid value is supplied so ONLY the missing key differs). RED before: accepted (null).
+///   KEYIDX-REJ-DICTREMOVE — a dict Remove with no key refuses (it identifies the entry BY key). RED before: accepted.
+///   KEYIDX-REJ-SETIDX     — a list SetAtIndex with no index refuses (Race.MovementTypeNames=List&lt;String&gt;). RED before: accepted.
+///   KEYIDX-OK-LISTREMOVE  — a keyless list Remove + value is STILL accepted: list Remove is by-index-OR-by-value, so the
+///                           DICT-only scope does not over-reach to lists (no-over-reject, like FLELEM-NULLCLEAR-OK).
+///   KEYIDX-REJ-SETIDX-E2E — a keyless SetAtIndex refuses end-to-end with NO file written; the PRE-FLIGHT message (not the
+///                           apply int.Parse(null) throw) proves the gate. (Key VALUE-shape stays the deferred surface.)
 /// </summary>
 public static class NestedCreateGuardProbe
 {
@@ -501,12 +514,79 @@ public static class NestedCreateGuardProbe
             },
             msg => msg.Contains("requires an element value", StringComparison.OrdinalIgnoreCase));
 
+        // ====== KEY / INDEX PRESENCE — the missing-addressing-key twin of the element-VALUE-presence gate above ======
+        // The value-presence gate (FLELEM-REJ-NULL*) catches a missing element VALUE; this catches a missing addressing
+        // KEY/INDEX. A dict Add/Remove coerces req.Key into / against the entry (ApplyDictVerb -> Coerce(req.Key!, kType));
+        // a list SetAtIndex parses req.Key as the index (ApplyListVerb -> int.Parse(req.Key!)). A MISSING key/index used
+        // to slip pre-flight — VerbLegality required a key only for Set-on-dict, NOT for Add/SetAtIndex/Remove — and threw
+        // UNNAMED at apply (Coerce(null) / int.Parse(null) -> the generic "internal failure" misdirection, a Q3 accept-
+        // then-throw). VerbLegality now requires the key/index up front, by construction (verb x cardinality, no per-type
+        // list). It is PRESENCE only — the key VALUE-shape (coercible-to-KeyType / parseable-as-int) stays the deferred
+        // surface ValueLegality step-4a names. The reachability is the same the value-presence twin proved: `key` is an
+        // optional string? param (WriteTools set_field / BulkOp), so ToolCallShim's required-param gate never blocks it.
+
+        // ---------- KEYIDX-REJ-DICTADD: a dict Add with NO key refuses at PRE-FLIGHT (Class.SkillWeights=Dictionary<Skill,Byte>) ----------
+        // A VALID value (Byte "5") is supplied so ONLY the missing key differs — isolates key-presence from value-presence.
+        // RED before the gate: VerbLegality's Add arm returned null for any list/dict -> accepted, then Coerce(null,Skill) threw at apply.
+        bool keyIdxRejDictAddOk;
+        {
+            var req = new WriteRequest { RecordType = "Class", Path = new[] { "SkillWeights" }, Verb = "Add", Key = null, Value = "5" };
+            var reject = rulebook.Validate(req);
+            keyIdxRejDictAddOk = reject is not null && reject.Contains("requires a key", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   KEYIDX-REJ-DICTADD missing dict key  : {(keyIdxRejDictAddOk ? "PASS — a dict Add with no key is refused at pre-flight (not accepted-then-thrown at apply)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- KEYIDX-REJ-DICTREMOVE: a dict Remove with NO key refuses at PRE-FLIGHT (it identifies the entry BY key) ----------
+        // RED before the gate: VerbLegality's Remove arm returned null for list/dict -> accepted, then Coerce(null,Skill) threw at apply.
+        bool keyIdxRejDictRemoveOk;
+        {
+            var req = new WriteRequest { RecordType = "Class", Path = new[] { "SkillWeights" }, Verb = "Remove", Key = null };
+            var reject = rulebook.Validate(req);
+            keyIdxRejDictRemoveOk = reject is not null && reject.Contains("requires a key", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   KEYIDX-REJ-DICTREMOVE missing dict key: {(keyIdxRejDictRemoveOk ? "PASS — a dict Remove with no key is refused at pre-flight" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- KEYIDX-REJ-SETIDX: a list SetAtIndex with NO index refuses at PRE-FLIGHT (Race.MovementTypeNames=List<String>) ----------
+        // A VALID value is supplied so ONLY the missing index differs. RED before the gate: VerbLegality's SetAtIndex arm
+        // returned null for any list -> accepted, then int.Parse(null) threw ArgumentNullException at apply.
+        bool keyIdxRejSetIdxOk;
+        {
+            var req = new WriteRequest { RecordType = "Race", Path = new[] { "MovementTypeNames" }, Verb = "SetAtIndex", Key = null, Value = "MT_Walk" };
+            var reject = rulebook.Validate(req);
+            keyIdxRejSetIdxOk = reject is not null && reject.Contains("requires an index", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   KEYIDX-REJ-SETIDX missing list index : {(keyIdxRejSetIdxOk ? "PASS — a list SetAtIndex with no index is refused at pre-flight" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- KEYIDX-OK-LISTREMOVE: a keyless list Remove + a value is STILL accepted (no over-reject) ----------
+        // The gate is DICT-only for Remove: a list Remove is by-index-OR-by-value (ApplyListVerb), so a null key legally
+        // falls back to remove-by-value. Proves the dict-scoping doesn't over-reach to lists. Accepted before AND after.
+        bool keyIdxOkListRemoveOk;
+        {
+            var req = new WriteRequest { RecordType = "Race", Path = new[] { "MovementTypeNames" }, Verb = "Remove", Key = null, Value = "MT_Walk" };
+            var reject = rulebook.Validate(req);
+            keyIdxOkListRemoveOk = reject is null;
+            Console.WriteLine($"   KEYIDX-OK-LISTREMOVE keyless list rm : {(keyIdxOkListRemoveOk ? "PASS — a keyless list Remove (by value) is NOT over-rejected" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- KEYIDX-REJ-SETIDX-E2E: a keyless list SetAtIndex refuses end-to-end with NO file written (gate, not apply throw) ----------
+        // The "no file written" half (RejectArm): the REAL create+apply path refuses a no-index LinkTo SetAtIndex and
+        // leaves no patch — the PRE-FLIGHT message ('requires an index'), not the apply int.Parse(null) throw, proving the gate.
+        bool keyIdxRejSetIdxE2eOk = RejectArm("KEYIDX-REJ-SETIDX-E2E no index    ", tmpDir, "KeyIdxNoIdx", mPath, rulebook,
+            new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogTopic", EditorId = "HcNcKiTopic", Edits = Array.Empty<WriteRequest>() },
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcKiL1", ParentRef = "HcNcKiTopic",
+                    Edits = new[] { new WriteRequest { RecordType = "DialogResponses", Path = new[] { "LinkTo" }, Verb = "SetAtIndex", Key = null, Value = "012345:Skyrim.esm" } } },
+            },
+            msg => msg.Contains("requires an index", StringComparison.OrdinalIgnoreCase));
+
         Console.WriteLine();
         bool pass = fixturesOk && oneshotOk && multiOk && intoTopicOk && intoCellOk
                     && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendOk
                     && sibrefOk && sibRejFwdOk && sibRejNonflOk && sibRejListOk && sibRejDictOk && sibRejApplyOk
                     && flElemRejGateOk && flElemRejAddOk && flElemNullClearOk && flElemOkE2eOk && flElemRejE2eOk
-                    && flElemRejNullAddOk && flElemRejNullAddPlainOk && flElemRejNullSetIdxOk && flElemRejNullAddE2eOk;
+                    && flElemRejNullAddOk && flElemRejNullAddPlainOk && flElemRejNullSetIdxOk && flElemRejNullAddE2eOk
+                    && keyIdxRejDictAddOk && keyIdxRejDictRemoveOk && keyIdxRejSetIdxOk && keyIdxOkListRemoveOk && keyIdxRejSetIdxE2eOk;
         Console.WriteLine($"=== nested-create-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return pass ? 0 : 1;


### PR DESCRIPTION
## What

The missing-**KEY/index** twin of [PR #77](https://github.com/Avick3110/houseCARL/pull/77)'s missing-**VALUE** gate — the analogous follow-up PR #77's reviewer flagged. Write pre-flight now refuses a missing dict key / list index **loud at the gate** instead of letting it throw an unnamed exception at apply (a Q3 accept-then-throw).

## The gap (verified reachable — Q3, not assumed)

`key` is optional on every write tool (`string? key = null` on `set_field`; `string? Key` on `BulkOp`), and `ToolCallShim.RequiredParamsRejection` only refuses missing **top-level required** params — it doesn't descend into `BulkOp[]`. So a key-consuming verb with no key binds fine (`key=null`), reaches `CorpusRulebook.VerbLegality`, and **was accepted**: `VerbLegality` required a key only for `Set`-on-dict, not for `Add`/`SetAtIndex`/`Remove`. At apply it threw **unnamed**:

| verb · cardinality | apply site | throw |
|---|---|---|
| dict `Add` / dict `Remove` | `ApplyDictVerb` → `Coerce(req.Key!, kType)` | NRE / "no coercion rule" on null |
| list `SetAtIndex` | `ApplyListVerb` → `int.Parse(req.Key!)` | `ArgumentNullException` |

The new E2E arm captures the hole verbatim before the fix: *"pre-flight ACCEPTED it but the apply threw — ArgumentNullException: Value cannot be null. (Parameter 's')"*.

## The fix

Fold key/index **presence** into `VerbLegality`'s `Add`/`Remove`/`SetAtIndex` arms, reusing the `hasKey` local already computed for the `Set` arm — verb × cardinality, **by construction**, no per-record-type list:

- **dict `Add`** → requires a key (a list `Add` appends; no key)
- **dict `Remove`** → requires a key (a list `Remove` is by-index-**or**-by-value, so a null key legally falls back to remove-by-value — list correctly **not** gated)
- **list `SetAtIndex`** → requires an index
- **dict `Set`** → already covered (the existing `Set` arm)

Presence only — the key **value-shape** (coercible-to-`KeyType` / parseable-as-`int`) stays the deferred surface `ValueLegality` step-4a names; that comment is reconciled to disambiguate shape (deferred) from presence (now gated).

`§4-(a)`, by-construction, no new tool (surface stays 21).

## Proof — RED→GREEN, 42/42 green

5 RED-proven arms extend `nested-create-guard` in place (no new CI step):

- `KEYIDX-REJ-DICTADD` — dict `Add`, no key (`Class.SkillWeights`, valid value) refused at pre-flight
- `KEYIDX-REJ-DICTREMOVE` — dict `Remove`, no key refused
- `KEYIDX-REJ-SETIDX` — list `SetAtIndex`, no index (`Race.MovementTypeNames`, valid value) refused
- `KEYIDX-OK-LISTREMOVE` — a keyless list `Remove` (by value) is **still accepted** (no over-reject of the dict-only scope)
- `KEYIDX-REJ-SETIDX-E2E` — keyless `SetAtIndex` refuses end-to-end with **no file written** (the gate, not the apply throw)

RED proven by running each REJ arm before the fix (`reject=[]` = accepted) and after (refused). Full **42-probe** suite green in Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
