### PR TITLE
write pre-flight: gate the VALUE-SHAPE of a present dict key / list index

### DIFF
--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -250,7 +250,7 @@ public sealed class CorpusRulebook
             case "Add":
                 // A dict Add coerces req.Key into the new entry's key (ApplyDictVerb -> Coerce(req.Key!, kType)); a
                 // MISSING key reaches apply and throws UNNAMED (Coerce(null)). A list Add appends — no key. Gate dict-Add
-                // key PRESENCE here, the structural twin of Set-on-dict above (key VALUE-shape stays ValueLegality's job).
+                // key PRESENCE here, the structural twin of Set-on-dict above (key VALUE-shape is ValueLegality's step-4-key).
                 if (c == "dict") return hasKey ? null : $"Add on dict field '{leaf.Name}' requires a key.";
                 return c == "list" ? null : $"Add is only valid on list/dict; '{leaf.Name}' is {c}.";
             case "Remove":
@@ -264,7 +264,8 @@ public sealed class CorpusRulebook
                 return c is "list" or "dict" ? null : $"ReplaceAll is only valid on list/dict; '{leaf.Name}' is {c}.";
             case "SetAtIndex":
                 // A list SetAtIndex parses req.Key as the index (ApplyListVerb -> int.Parse(req.Key!)); a MISSING index
-                // throws ArgumentNullException at apply. Require it up front (PRESENCE; parseable-as-int stays deferred).
+                // throws ArgumentNullException at apply. Require it up front (PRESENCE; the parseable-as-int / non-negative
+                // VALUE-shape is gated in ValueLegality's step-4-key block).
                 if (c != "list") return $"SetAtIndex is only valid on list; '{leaf.Name}' is {c}.";
                 return hasKey ? null : $"SetAtIndex on list '{leaf.Name}' requires an index.";
             case "Merge":
@@ -318,17 +319,43 @@ public sealed class CorpusRulebook
         // A sibling token inside a COLLECTION value (a list ReplaceAll's Values, or a dict Entries' VALUES) is NOT
         // substituted (only the singular Set Value is) — refuse loud rather than accept-then-throw at apply (Q3).
         // Unconditional: never supported, on either the create or the edit-existing path. List/dict sibling-refs are a
-        // deliberate later surface. NOTE: dict KEYS are deliberately NOT scanned here — a '@' in a (rare) FormLink-keyed
-        // dict key would still reach apply, where it fails LOUD (a coerce throw caught as a named Q3 inconsistency), not
-        // silently; that edge rides the parked general "list/dict element value-shape isn't gate-checked" task, which
-        // owns collection element-shape validation (gating keys here without it would be an inconsistent half-measure).
+        // deliberate later surface. (A '@editorid' in a dict KEY — Set/Add/Remove req.Key, or a Merge/ReplaceAll Entries
+        // key — is now caught by the step-4-key key-shape gate below: '@…' won't coerce to any modeled key type, so it
+        // rejects there by construction, never reaching apply. The "parked key value-shape" task this note once pointed
+        // at IS that gate.)
         if ((req.Values is { } vals && vals.Any(v => WriteEngine.IsSameCallSiblingRef(v, out _)))
             || (req.Entries is { } ents && ents.Values.Any(v => WriteEngine.IsSameCallSiblingRef(v, out _))))
             return $"a '@editorid' same-call reference for '{leaf.Name}' is only supported as a single Set value on a " +
                    "FormLink field, not inside a list/dict value — list/dict sibling-refs are a later surface.";
+        // (step 4-key) KEY / INDEX VALUE-SHAPE — the shape twin of the key/index PRESENCE gate (VerbLegality's
+        // missing-key rejects). A PRESENT-but-malformed dict key / list index passes presence but throws UNNAMED at
+        // apply: a dict Set/Add/Remove coerces req.Key into the entry (ApplyDictVerb -> Coerce(req.Key!, KeyType)) and
+        // Merge/ReplaceAll coerce each Entries key the same way; a list SetAtIndex/Remove parses req.Key as the index
+        // (ApplyListVerb -> int.Parse(req.Key!)). Gate both LOUD here, by construction, with the SAME recognizers the
+        // apply path uses so gate and apply can't drift: the dict key's real CLR type is resolved from the field's own
+        // dictionary AQ (DictKeyType — the identical type apply keys on, dictIface.GetGenericArguments()[0]), so
+        // coercibility is checked for EVERY key kind (enum AND the one sbyte-keyed dict), not just enums by catalog-
+        // name; the list index via WriteEngine.IsValidListIndexValue (parseable non-negative int32). This EXTENDS the
+        // gate to Add/Remove/Merge/ReplaceAll keys AND reconciles the dict Set key check (below, now value-only) onto
+        // the same recognizer — closing the prior enum-only gaps (a non-enum key slipped; a numeric enum key like '3',
+        // which apply accepts, was over-rejected). PRESENCE stays VerbLegality's job; this is purely SHAPE.
+        if (leaf.Cardinality == "dict")
+        {
+            var keyAq = DictKeyType(leaf)?.AssemblyQualifiedName;
+            string? KeyShape(string? k) => CheckValue(leaf.KeyType, k, $"dict key for '{leaf.Name}'", keyAq);
+            if (req.Verb is "Set" or "Add" or "Remove" && req.Key is { } dKey && KeyShape(dKey) is { } dKeyErr)
+                return dKeyErr;
+            if (req.Verb is "Merge" or "ReplaceAll" && req.Entries is { } keyEnts)
+                foreach (var k in keyEnts.Keys)
+                    if (KeyShape(k) is { } entKeyErr) return entKeyErr;
+        }
+        if (leaf.Cardinality == "list" && req.Verb is "SetAtIndex" or "Remove" && req.Key is { } lIdx
+            && !WriteEngine.IsValidListIndexValue(lIdx))
+            return $"Illegal list index '{lIdx}' for '{leaf.Name}': expected a non-negative integer. " +
+                   "(Whether the index is in range is checked at apply, against the live list.)";
         if (req.Verb is "Set" && leaf.Cardinality == "dict")
         {
-            if (CheckValue(leaf.KeyType, req.Key, $"dict key for '{leaf.Name}'") is { } ke) return ke;
+            // Key shape gated by the step-4-key block above (Set/Add/Remove share one recognizer); validate the VALUE here.
             if (req.Value is null) return $"Set on dict '{leaf.Name}' requires a value.";
             return CheckValue(leaf.ElementType, req.Value, $"dict value for '{leaf.Name}'", leaf.ElementTypeAssemblyQualified);
         }
@@ -393,13 +420,13 @@ public sealed class CorpusRulebook
         // element VALUE with the SAME recognizer the singular path uses (IsValidFormLinkValue — one predicate, no
         // drift between gate and apply): req.Value (list Add / SetAtIndex / Remove-by-value; dict Add — dict Set
         // returned at its own block above), req.Values (list ReplaceAll), and req.Entries' VALUES (dict Merge /
-        // ReplaceAll). The dict KEY VALUE-SHAPE is deliberately NOT checked here — key shape is the deferred surface the
-        // sibling-ref note drew. (Key/index PRESENCE is a DISTINCT concern and IS gated up front, by construction, in
-        // VerbLegality's Add/Remove/SetAtIndex arms — the missing-key twin of the missing-value gate above.) NOTE: every
+        // ReplaceAll). The dict KEY VALUE-SHAPE is gated up front by the step-4-key block above (coercible-to-KeyType
+        // via the key's real CLR type, EVERY key kind) — this block validates element VALUES only. (Key/index PRESENCE
+        // is a DISTINCT concern, gated by construction in VerbLegality's Add/Remove/SetAtIndex arms.) NOTE: every
         // formlink collection in the current corpus is a LIST (85 fields); a formlink-VALUED dict is
         // not modeled by Mutagen today (0 fields) and the generator's dict branch does not stamp FormLinkTarget for
         // one, so the req.Entries arm is dormant-by-construction — named here (Q3), and lit the moment such a field
-        // (carrying its FormLinkTarget stamp) exists. The dict KEY-shape edge stays as the sibling-ref note left it.
+        // (carrying its FormLinkTarget stamp) exists. The dict KEY-shape edge is now closed by the step-4-key block above.
         if (leaf.Cardinality is "list" or "dict" && leaf.FormLinkTarget is not null)
         {
             if (req.Value is { } ev && !WriteEngine.IsValidFormLinkValue(ev)) return FormLinkElementReject(ev, leaf);
@@ -531,6 +558,21 @@ public sealed class CorpusRulebook
         var armSchema = Type(arm.Type);
         if (armSchema is null) return $"Arm '{arm.Type}' absent from corpus.";
         return StructSpecContents(arm, armSchema);
+    }
+
+    /// <summary>Resolve a dict leaf's KEY clr type from its own dictionary AQ — the SAME type the apply path keys on
+    /// (<c>ApplyDictVerb</c>: <c>dictIface.GetGenericArguments()[0]</c>), so the key-shape gate and the engine agree on
+    /// the key type by construction. The corpus carries the whole <c>IDictionary&lt;K,V&gt;</c> /
+    /// <c>IReadOnlyDictionary&lt;K,V&gt;</c> AQ with BOTH type args fully qualified, so no separate key-AQ schema field
+    /// is needed. Returns null if it can't be resolved (the caller's <see cref="CheckValue"/> then degrades to the
+    /// catalog-by-name enum check — still loud for enum keys, never a silent accept). Mutable AQ preferred over getter,
+    /// matching <see cref="CoercibilityReject"/>.</summary>
+    static System.Type? DictKeyType(FieldSchema leaf)
+    {
+        var aq = leaf.MutableTypeAssemblyQualified ?? leaf.GetterTypeAssemblyQualified;
+        if (aq is null || WriteEngine.ResolveType(aq) is not { IsGenericType: true } dt) return null;
+        var args = dt.GetGenericArguments();
+        return args.Length == 2 ? args[0] : null;
     }
 
     /// <summary>Enum → must be a legal value of the field's REAL enum type; primitive → must coerce to the

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -2036,6 +2036,20 @@ public static class WriteEngine
     /// caller can't trip an NRE in FormKey.TryFactory.</summary>
     internal static bool IsValidFormLinkValue(string? text) => IsFormKeyNullSynonym(text) || (text is not null && FormKey.TryFactory(text, out _));
 
+    // ---- List INDEX value-shape (write pre-flight: key/index value-shape gate) ---------------------------------
+    //  A list SetAtIndex / Remove(with a key) parses req.Key as the index at apply (ApplyListVerb:
+    //  int.Parse(req.Key!, CultureInfo.InvariantCulture)). A non-integer threw FormatException; a NEGATIVE value
+    //  parsed but then threw ArgumentOutOfRangeException at the indexer — both UNNAMED accept-then-throws. This
+    //  recognizer mirrors that parse EXACTLY (int32, NumberStyles.Integer, InvariantCulture — int.Parse(s, provider)'s
+    //  own default style) so the gate and apply can't drift on what counts as a legal index, plus the non-negative
+    //  pre-check the indexer would otherwise enforce by throwing. The UPPER bound (index < the live element count) is
+    //  NOT checked here — pre-flight has no live collection; an in-range-shaped but too-large index is left to apply,
+    //  where it fails named (Q3). Same shared-recognizer discipline as IsValidFormLinkValue / IsFormKeyNullSynonym.
+    /// <summary>True iff <paramref name="text"/> is a legal list INDEX SHAPE: a non-negative int32 under the same
+    /// parse the apply path uses (<see cref="ApplyListVerb"/>). Shape only — the in-range check is apply's.</summary>
+    internal static bool IsValidListIndexValue(string? text) =>
+        text is not null && int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var i) && i >= 0;
+
     // ---- Same-call sibling reference (HCBR-2026-06-15-01 Layer B / unit A) -------------------------------------
     //  A create's field VALUE can forward-reference a record created EARLIER in the SAME create call, by its
     //  editorid, written "@<editorid>". The referenced record's local 0x800+ FormKey is not allocated until the

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -87,7 +87,34 @@ namespace HousecarlGenerator;
 ///   KEYIDX-OK-LISTREMOVE  — a keyless list Remove + value is STILL accepted: list Remove is by-index-OR-by-value, so the
 ///                           DICT-only scope does not over-reach to lists (no-over-reject, like FLELEM-NULLCLEAR-OK).
 ///   KEYIDX-REJ-SETIDX-E2E — a keyless SetAtIndex refuses end-to-end with NO file written; the PRE-FLIGHT message (not the
-///                           apply int.Parse(null) throw) proves the gate. (Key VALUE-shape stays the deferred surface.)
+///                           apply int.Parse(null) throw) proves the gate.
+///
+/// KEY / INDEX VALUE-SHAPE — the malformed-addressing-key twin of the PRESENCE gap above (this PR). PRESENCE (above)
+/// catches a MISSING key/index; this catches a PRESENT-but-MALFORMED one. A dict Set/Add/Remove coerces req.Key into the
+/// entry and Merge/ReplaceAll coerce each Entries key (ApplyDictVerb -> Coerce(key, KeyType)); a list SetAtIndex/Remove
+/// parses req.Key as the index (ApplyListVerb -> int.Parse(req.Key!)). A malformed key/index slipped pre-flight (only dict
+/// SET key-shape was gated, and only ENUM keys by catalog-NAME) and threw UNNAMED at apply. ValueLegality now gates the
+/// key/index SHAPE by construction: dict keys via the SAME coercibility the apply path uses (the key's real CLR type
+/// resolved from the field's dict AQ — EVERY key kind, not just enums); list indices via IsValidListIndexValue (parseable
+/// non-negative int, the in-range check left to apply, Q3):
+///   KEYSHAPE-REJ-DICTADD       — a dict Add with a non-coercible enum key refuses at PRE-FLIGHT (Class.SkillWeights; a
+///                                valid value supplied so ONLY the key differs). RED before: accepted (no Add key-shape gate).
+///   KEYSHAPE-REJ-DICTREMOVE    — a dict Remove with a non-coercible key refuses (it identifies the entry BY key). RED: accepted.
+///   KEYSHAPE-REJ-MERGEKEY      — a Merge with a non-coercible Entries KEY refuses (Merge/ReplaceAll keys coerce too). RED: accepted.
+///   KEYSHAPE-REJ-SBYTE         — a Remove on the ONE non-enum-keyed dict (Package.Data = Dictionary&lt;sbyte,APackageData&gt;)
+///                                with a non-numeric key refuses 'does not coerce to sbyte' — proves the gate is by the key's
+///                                real CLR type (every kind), not enum-catalog-name only. RED before: accepted (the sbyte hole).
+///   KEYSHAPE-REJ-SETIDX        — a list SetAtIndex with a non-integer index refuses (Race.MovementTypeNames). RED: accepted.
+///   KEYSHAPE-REJ-NEGIDX        — a list SetAtIndex with a NEGATIVE index refuses too: int.Parse accepts '-1' but the indexer
+///                                throws, so the gate pre-checks &gt;= 0 (the &gt;=0 decision). RED before: accepted.
+///   KEYSHAPE-REJ-LISTREMOVE-IDX— a list Remove with a present non-integer index refuses (the RemoveAt path int.Parse too). RED: accepted.
+///   KEYSHAPE-OK-DICTADD        — a dict Add with a VALID enum key + value is STILL accepted (no over-reject). Accepted before AND after.
+///   KEYSHAPE-OK-SETIDX         — a list SetAtIndex with a VALID index is STILL accepted (no over-reject). Accepted before AND after.
+///   KEYSHAPE-OK-NUMENUM-SET    — a dict Set with a NUMERIC enum key ('3', which apply accepts via Enum.Parse) is accepted: the
+///                                gate matches apply, no longer over-rejecting numeric enum keys (the reconciled Set path).
+///                                RED before: REJECTED by the old enum-catalog-NAME-only check (the gate/apply drift this fixes).
+///   KEYSHAPE-REJ-E2E           — a malformed list index refuses end-to-end with NO file written; the PRE-FLIGHT message
+///                                ('Illegal list index'), not the apply int.Parse throw, proves the gate.
 /// </summary>
 public static class NestedCreateGuardProbe
 {
@@ -580,13 +607,142 @@ public static class NestedCreateGuardProbe
             },
             msg => msg.Contains("requires an index", StringComparison.OrdinalIgnoreCase));
 
+        // ====== KEY / INDEX VALUE-SHAPE — the malformed-key/index twin of the PRESENCE gate above ======
+        // The presence gate (KEYIDX-*) catches a MISSING key/index; this catches a PRESENT-but-MALFORMED one. A dict
+        // Set/Add/Remove coerces req.Key into the entry (ApplyDictVerb -> Coerce(req.Key!, KeyType)) and Merge/ReplaceAll
+        // coerce each Entries key; a list SetAtIndex/Remove parses req.Key as the index (ApplyListVerb -> int.Parse).
+        // ValueLegality now gates the SHAPE: dict keys via the SAME coercibility apply uses (the key's real CLR type from
+        // the field's dict AQ — EVERY kind, not just enum-by-name), list indices via IsValidListIndexValue (non-negative
+        // int; in-range left to apply). Most arms drive the rulebook DIRECTLY (a non-null reject IS the gate refusal).
+
+        // ---------- KEYSHAPE-REJ-DICTADD: a dict Add with a non-coercible ENUM key refuses at PRE-FLIGHT ----------
+        // A VALID value (Byte "5") so ONLY the key differs. RED before: no Add key-shape gate existed -> accepted, then
+        // Coerce("notaskill", Skill) threw at apply.
+        bool keyShapeRejDictAddOk;
+        {
+            var req = new WriteRequest { RecordType = "Class", Path = new[] { "SkillWeights" }, Verb = "Add", Key = "notaskill", Value = "5" };
+            var reject = rulebook.Validate(req);
+            keyShapeRejDictAddOk = reject is not null && reject.Contains("dict key", StringComparison.OrdinalIgnoreCase)
+                && reject.Contains("not a legal Skill", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   KEYSHAPE-REJ-DICTADD bad enum key   : {(keyShapeRejDictAddOk ? "PASS — a non-coercible dict Add key is refused at pre-flight (not accepted-then-thrown at apply)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- KEYSHAPE-REJ-DICTREMOVE: a dict Remove with a non-coercible key refuses (entry identified BY key) ----------
+        bool keyShapeRejDictRemoveOk;
+        {
+            var req = new WriteRequest { RecordType = "Class", Path = new[] { "SkillWeights" }, Verb = "Remove", Key = "notaskill" };
+            var reject = rulebook.Validate(req);
+            keyShapeRejDictRemoveOk = reject is not null && reject.Contains("not a legal Skill", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   KEYSHAPE-REJ-DICTREMOVE bad key     : {(keyShapeRejDictRemoveOk ? "PASS — a non-coercible dict Remove key is refused at pre-flight" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- KEYSHAPE-REJ-MERGEKEY: a Merge with a non-coercible Entries KEY refuses (Merge/ReplaceAll keys coerce too) ----------
+        // Values are valid + carry no @ (so the sibling-collection gate passes through to the entries-key scan). RED before: accepted.
+        bool keyShapeRejMergeKeyOk;
+        {
+            var req = new WriteRequest { RecordType = "Class", Path = new[] { "SkillWeights" }, Verb = "Merge",
+                Entries = new Dictionary<string, string> { ["notaskill"] = "5" } };
+            var reject = rulebook.Validate(req);
+            keyShapeRejMergeKeyOk = reject is not null && reject.Contains("not a legal Skill", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   KEYSHAPE-REJ-MERGEKEY bad entry key : {(keyShapeRejMergeKeyOk ? "PASS — a non-coercible Merge entries key is refused too (Merge/ReplaceAll keys coerce)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- KEYSHAPE-REJ-SBYTE: the ONE non-enum-keyed dict — by-construction, not enum-only ----------
+        // Package.Data = Dictionary<sbyte,APackageData>. A Remove (no value, sidesteps the composable-element value path)
+        // with a non-numeric key refuses 'does not coerce to sbyte' — the gate resolves the key's REAL CLR type (sbyte) from
+        // the dict AQ, so it catches a kind the old enum-catalog-name check NEVER could. RED before: accepted (the sbyte hole).
+        bool keyShapeRejSbyteOk;
+        {
+            var req = new WriteRequest { RecordType = "Package", Path = new[] { "Data" }, Verb = "Remove", Key = "notanumber" };
+            var reject = rulebook.Validate(req);
+            keyShapeRejSbyteOk = reject is not null && reject.Contains("does not coerce to sbyte", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   KEYSHAPE-REJ-SBYTE non-enum key     : {(keyShapeRejSbyteOk ? "PASS — a non-coercible sbyte key is refused by construction (real CLR type, not enum-name only)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- KEYSHAPE-REJ-SETIDX: a list SetAtIndex with a non-integer index refuses ----------
+        // A VALID value so ONLY the index differs. RED before: accepted, then int.Parse("abc") threw FormatException at apply.
+        bool keyShapeRejSetIdxOk;
+        {
+            var req = new WriteRequest { RecordType = "Race", Path = new[] { "MovementTypeNames" }, Verb = "SetAtIndex", Key = "abc", Value = "MT_Walk" };
+            var reject = rulebook.Validate(req);
+            keyShapeRejSetIdxOk = reject is not null && reject.Contains("Illegal list index", StringComparison.OrdinalIgnoreCase)
+                && reject.Contains("non-negative integer", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   KEYSHAPE-REJ-SETIDX non-int index   : {(keyShapeRejSetIdxOk ? "PASS — a non-integer list index is refused at pre-flight" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- KEYSHAPE-REJ-NEGIDX: a list SetAtIndex with a NEGATIVE index refuses (the >=0 decision) ----------
+        // int.Parse accepts "-1" but the indexer throws ArgumentOutOfRangeException — so the gate pre-checks >= 0. RED before: accepted.
+        bool keyShapeRejNegIdxOk;
+        {
+            var req = new WriteRequest { RecordType = "Race", Path = new[] { "MovementTypeNames" }, Verb = "SetAtIndex", Key = "-1", Value = "MT_Walk" };
+            var reject = rulebook.Validate(req);
+            keyShapeRejNegIdxOk = reject is not null && reject.Contains("non-negative integer", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   KEYSHAPE-REJ-NEGIDX negative index  : {(keyShapeRejNegIdxOk ? "PASS — a negative index is refused too (parses but the indexer would throw)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- KEYSHAPE-REJ-LISTREMOVE-IDX: a list Remove with a present non-integer index refuses (the RemoveAt path) ----------
+        // A present key on list Remove is interpreted as the index (ApplyListVerb -> RemoveAt(int.Parse(req.Key))). RED before: accepted.
+        bool keyShapeRejListRemoveIdxOk;
+        {
+            var req = new WriteRequest { RecordType = "Race", Path = new[] { "MovementTypeNames" }, Verb = "Remove", Key = "abc" };
+            var reject = rulebook.Validate(req);
+            keyShapeRejListRemoveIdxOk = reject is not null && reject.Contains("Illegal list index", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   KEYSHAPE-REJ-LISTREMOVE-IDX non-int : {(keyShapeRejListRemoveIdxOk ? "PASS — a non-integer index on list Remove (by-index) is refused too" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- KEYSHAPE-OK-DICTADD: a dict Add with a VALID enum key + value is STILL accepted (no over-reject) ----------
+        bool keyShapeOkDictAddOk;
+        {
+            var req = new WriteRequest { RecordType = "Class", Path = new[] { "SkillWeights" }, Verb = "Add", Key = "OneHanded", Value = "5" };
+            var reject = rulebook.Validate(req);
+            keyShapeOkDictAddOk = reject is null;
+            Console.WriteLine($"   KEYSHAPE-OK-DICTADD valid key+value : {(keyShapeOkDictAddOk ? "PASS — a valid dict Add (key+value) is NOT over-rejected" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- KEYSHAPE-OK-SETIDX: a list SetAtIndex with a VALID index is STILL accepted (no over-reject) ----------
+        bool keyShapeOkSetIdxOk;
+        {
+            var req = new WriteRequest { RecordType = "Race", Path = new[] { "MovementTypeNames" }, Verb = "SetAtIndex", Key = "0", Value = "MT_Walk" };
+            var reject = rulebook.Validate(req);
+            keyShapeOkSetIdxOk = reject is null;
+            Console.WriteLine($"   KEYSHAPE-OK-SETIDX valid index      : {(keyShapeOkSetIdxOk ? "PASS — a valid list index (0) is NOT over-rejected" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- KEYSHAPE-OK-NUMENUM-SET: a dict Set with a NUMERIC enum key ('3') is accepted — gate matches apply ----------
+        // apply's Coerce("3", Skill) = Enum.Parse accepts the underlying-numeric form, so the gate must too. The reconciled
+        // Set path now resolves the key's real enum type (TryCoerce), not the old NAME-only catalog check. RED before:
+        // REJECTED ('3' is not a NAMED Skill) — the gate/apply drift this fix closes by reusing the engine recognizer.
+        bool keyShapeOkNumEnumSetOk;
+        {
+            var req = new WriteRequest { RecordType = "Class", Path = new[] { "SkillWeights" }, Verb = "Set", Key = "3", Value = "5" };
+            var reject = rulebook.Validate(req);
+            keyShapeOkNumEnumSetOk = reject is null;
+            Console.WriteLine($"   KEYSHAPE-OK-NUMENUM-SET numeric key : {(keyShapeOkNumEnumSetOk ? "PASS — a numeric enum key '3' (which apply accepts) is no longer over-rejected" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- KEYSHAPE-REJ-E2E: a malformed list index refuses end-to-end with NO file written (gate, not apply throw) ----------
+        // The "no file written" half (RejectArm): a real create+apply with a non-integer LinkTo SetAtIndex index leaves no
+        // patch — the PRE-FLIGHT message ('Illegal list index'), not the apply int.Parse throw, proving the gate. A valid
+        // value is supplied so ONLY the index is at fault (the index gate runs before the value-presence gate).
+        bool keyShapeRejE2eOk = RejectArm("KEYSHAPE-REJ-E2E bad list index   ", tmpDir, "KeyShapeIdx", mPath, rulebook,
+            new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogTopic", EditorId = "HcNcKsTopic", Edits = Array.Empty<WriteRequest>() },
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcKsL1", ParentRef = "HcNcKsTopic",
+                    Edits = new[] { new WriteRequest { RecordType = "DialogResponses", Path = new[] { "LinkTo" }, Verb = "SetAtIndex", Key = "abc", Value = "012345:Skyrim.esm" } } },
+            },
+            msg => msg.Contains("Illegal list index", StringComparison.OrdinalIgnoreCase));
+
         Console.WriteLine();
         bool pass = fixturesOk && oneshotOk && multiOk && intoTopicOk && intoCellOk
                     && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendOk
                     && sibrefOk && sibRejFwdOk && sibRejNonflOk && sibRejListOk && sibRejDictOk && sibRejApplyOk
                     && flElemRejGateOk && flElemRejAddOk && flElemNullClearOk && flElemOkE2eOk && flElemRejE2eOk
                     && flElemRejNullAddOk && flElemRejNullAddPlainOk && flElemRejNullSetIdxOk && flElemRejNullAddE2eOk
-                    && keyIdxRejDictAddOk && keyIdxRejDictRemoveOk && keyIdxRejSetIdxOk && keyIdxOkListRemoveOk && keyIdxRejSetIdxE2eOk;
+                    && keyIdxRejDictAddOk && keyIdxRejDictRemoveOk && keyIdxRejSetIdxOk && keyIdxOkListRemoveOk && keyIdxRejSetIdxE2eOk
+                    && keyShapeRejDictAddOk && keyShapeRejDictRemoveOk && keyShapeRejMergeKeyOk && keyShapeRejSbyteOk
+                    && keyShapeRejSetIdxOk && keyShapeRejNegIdxOk && keyShapeRejListRemoveIdxOk
+                    && keyShapeOkDictAddOk && keyShapeOkSetIdxOk && keyShapeOkNumEnumSetOk && keyShapeRejE2eOk;
         Console.WriteLine($"=== nested-create-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return pass ? 0 : 1;


### PR DESCRIPTION
## What

The named follow-on to [#78](https://github.com/Avick3110/houseCARL/pull/78) (key/index **PRESENCE**). #78 made a *missing* dict key / list index refuse loud; this gates a **present-but-malformed** one. Same Q3 accept-then-throw shape as #77 (value presence) / #76 (formlink element value-shape) — the project's deliberate "presence then shape" slice.

## The gap (Q3 accept-then-throw — reachability confirmed)

`key` is an optional `string?` on `set_field`/`BulkOp`, and `ToolCallShim` only refuses missing **top-level required** params — so a malformed key/index reaches the engine, exactly as #77/#78 established. It then threw **unnamed** at apply:

- **dict** Set/Add/Remove (and Merge/ReplaceAll entry keys): `ApplyDictVerb → Coerce(req.Key!, KeyType)` throws on a key that won't coerce — e.g. `Class.SkillWeights` `Key="notaskill"`, or the one **`sbyte`**-keyed dict `Package.Data` `Key="notanumber"`.
- **list** SetAtIndex / Remove(with a key): `ApplyListVerb → int.Parse(req.Key!)` throws `FormatException` on a non-integer; a **negative** index parses, then the indexer throws `ArgumentOutOfRangeException`.

The E2E guard arm reproduced the engine's own *"pre-flight ACCEPTED it but the apply threw … FormatException"* inconsistency before the fix.

## The fix — `ValueLegality` step-4-key, by construction (no per-record-type list)

- **dict key shape** = coercible-to-`KeyType`, via `CheckValue` against the key's **real CLR type** resolved from the field's own dictionary AQ (new `DictKeyType` — the *identical* type apply keys on, `dictIface.GetGenericArguments()[0]`). One unified block covers Set/Add/Remove + Merge/ReplaceAll entry keys, and **reconciles** the existing dict-Set key check (now value-only) onto the same recognizer.
- **list index shape** = new shared `WriteEngine.IsValidListIndexValue` (parseable non-negative `int32`, mirroring `ApplyListVerb`'s `int.Parse` exactly). The **upper** bound (index < live count) is left to apply — pre-flight has no live collection (named, Q3).

### Two pre-existing enum-only gaps this also closes (heads-up — a small behavior change)
The old dict-Set key check was `CheckValue(KeyType, …, aq=null)` → enum-catalog-**name** only. Resolving the real key type:
1. **Closes the `sbyte` hole** — `Package.Data` malformed keys were silently accepted then threw.
2. **Stops over-rejecting numeric enum keys** — `Set SkillWeights Key="3"` was *rejected* by the gate but **accepted by apply** (`Enum.Parse("3")`). Now the gate matches apply (a gate/apply drift fix). Guarded by `KEYSHAPE-OK-NUMENUM-SET`.

Both are strict parity-with-apply improvements; no currently-correct behavior changes. Surfaced explicitly per §5 #9.

## Verification
- **+11 RED-proven arms** on `nested-create-guard` (`KEYSHAPE-*`), each run **before** (accepted / over-rejected) and **after** (refused / accepted-to-match-apply). The `sbyte` arm proves it's by the key's real CLR type, **not** enum-only.
- **Full 42-probe CI suite green**; extended in place, **probe count unchanged (42)**.
- Full solution builds clean (0 errors).
- Reconciles the four deferred-surface notes (VerbLegality Add/SetAtIndex; the sibling-ref collection note; the formlink-element note) that pointed at this as the parked task.

By-construction §4-(a); cornerstone untouched; tool surface stays 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)