### PR TITLE
write pre-flight: close the remaining gate/apply drift class (PR-A: Gap 1/2 + G4/G6/G7)

### DIFF
--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -472,6 +472,25 @@ public sealed class CorpusRulebook
                 foreach (var kv in req.Entries ?? new())
                     if (ElemShape(kv.Value) is { } entErr) return entErr;
         }
+        // (step 4-rec) RECORD-ELEMENT collection verb — a list/dict whose ELEMENT is an owned child RECORD
+        // (SchemaClassifier classifies record-families ElementKind.Record: DialogTopic.Responses -> DialogResponses;
+        // Cell.Persistent/Temporary -> the all-record Placed arms; the typed record groups). A record element is neither
+        // IsComposableElement (Record is excluded from Struct/Arm) nor IsValueCoercibleElement nor formlink, so an
+        // Add/SetAtIndex/ReplaceAll fell through to `return null` (ACCEPT) and then THREW at apply: with a compose,
+        // BuildStruct -> Instantiate -> CompositionRequiredException (the record class has no public parameterless ctor);
+        // with a plain value, Coerce(value, <record getter>) -> "No coercion rule" — both Q3 accept-then-throw (the
+        // second NAMED-but-misleading: it points at composition/coercion, not at "use create_record"). A child record is
+        // allocated on the record axis, never built into a parent's collection by the verb engine; the supported path is
+        // housecarl_create_record / housecarl_bulk_create with parent=. Redirect by construction (one classifier
+        // predicate, no per-record-type list). Verb-scoped to the create-oriented verbs (Add/SetAtIndex/ReplaceAll); a
+        // record Remove BY INDEX (RemoveAt) is throw-free and stays accepted, and a record Remove BY VALUE is the
+        // non-plain-value Remove surface closed by the unified Remove-by-value reject in the composable block below.
+        if (leaf.Cardinality is "list" or "dict" && req.Verb is "Add" or "SetAtIndex" or "ReplaceAll"
+            && SchemaClassifier.ClassifyElement(leaf, _corpus) == ElementKind.Record)
+            return $"'{leaf.Name}' holds owned child records ({leaf.ElementTypeRef}); a child record is created on its " +
+                   "own (the record axis), not added into a parent's collection by a write verb. Use housecarl_create_record " +
+                   "/ housecarl_bulk_create with parent= the parent's FormID (and collection= when the parent holds more " +
+                   "than one fitting list) — surfaced here, never accepted and thrown at apply.";
         // (step 4) collection-verb value legality. A struct-element OR arm-element list takes a build-from-parts
         // StructSpec on Add — NOT a plain value — which is wave-1 half B composition (an ARM element composes by its
         // concrete arm type, validated against that arm's own schema — the VMAD shape, #35; before this, arm-element

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -442,6 +442,36 @@ public sealed class CorpusRulebook
             foreach (var kv in req.Entries ?? new())
                 if (!WriteEngine.IsValidFormLinkValue(kv.Value)) return FormLinkElementReject(kv.Value, leaf);
         }
+        // (step 4b) NON-FORMLINK coercible-element collection value-SHAPE — the value twin of step-4a (which handles
+        // FORMLINK elements via IsValidFormLinkValue) and of the dict-Set value block above (which gates dict Set's value
+        // but not the other collection verbs). A list Add/SetAtIndex/ReplaceAll/Remove-by-value and a dict Add/Merge/
+        // ReplaceAll coerce each supplied element value at apply (ApplyListVerb/ApplyDictVerb -> Coerce(req.Value!/v,
+        // elem/vType)); a malformed value (e.g. "notafloat" into a List<Single>, "notabyte" into a Dictionary<Skill,Byte>)
+        // used to pass pre-flight then throw UNNAMED (float.Parse/byte.Parse) at apply — the Q3 accept-then-throw this
+        // closes. Scoped to IsValueCoercibleElement(leaf) && FormLinkTarget is null so formlink elements keep step-4a's
+        // per-element message and the two together cover EVERY coercible element with no double-check and no gap. Uses the
+        // SAME CheckValue recognizer (with the element AQ) the dict-Set value block uses — gate and apply can't drift.
+        // Verb/key-FAITHFUL to which slot apply actually coerces: the singular req.Value is checked for list Add/SetAtIndex
+        // and dict Add (always coerced), and for a list Remove-by-VALUE (Key null) only — a list Remove BY INDEX / a dict
+        // Remove coerce only the key, so their value is apply-irrelevant and must NOT be over-rejected. req.Values is the
+        // list ReplaceAll contents; req.Entries' VALUES are dict Merge/ReplaceAll (their keys are the step-4-key block's
+        // job). Null PRESENCE on Add/SetAtIndex stays step-4-pre's; a null inside Values/Entries yields CheckValue's
+        // "Missing element value …" (correct for those verbs, which have no presence mirror).
+        if (leaf.Cardinality is "list" or "dict" && IsValueCoercibleElement(leaf) && leaf.FormLinkTarget is null)
+        {
+            string? ElemShape(string? v) =>
+                CheckValue(leaf.ElementType, v, $"element value for '{leaf.Name}'", leaf.ElementTypeAssemblyQualified);
+            if (req.Value is { } ev
+                && (req.Verb is "Add" or "SetAtIndex" || (req.Verb is "Remove" && req.Key is null))
+                && ElemShape(ev) is { } evErr)
+                return evErr;
+            if (req.Verb is "ReplaceAll")
+                foreach (var v in req.Values ?? Array.Empty<string>())
+                    if (ElemShape(v) is { } valsErr) return valsErr;
+            if (req.Verb is "Merge" or "ReplaceAll")
+                foreach (var kv in req.Entries ?? new())
+                    if (ElemShape(kv.Value) is { } entErr) return entErr;
+        }
         // (step 4) collection-verb value legality. A struct-element OR arm-element list takes a build-from-parts
         // StructSpec on Add — NOT a plain value — which is wave-1 half B composition (an ARM element composes by its
         // concrete arm type, validated against that arm's own schema — the VMAD shape, #35; before this, arm-element

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -506,10 +506,26 @@ public sealed class CorpusRulebook
                     ? $"'{leaf.Name}' is a dict of modeled elements ({leaf.ElementTypeRef}); dict-element " +
                       "composition is a later surface — surfaced here, never accepted and thrown at apply time."
                     : StructElementLegality(leaf, req.Struct);
-            if (req.Verb is "ReplaceAll" or "SetAtIndex")
-                return $"'{leaf.Name}' holds modeled-struct elements ({leaf.ElementTypeRef}); only Add " +
-                       "(build-from-parts) composes struct elements — ReplaceAll/SetAtIndex of structs is a later surface.";
+            // ReplaceAll/SetAtIndex/Merge of modeled elements are all deferred (only Add composes). Merge is dict-only
+            // and was previously OMITTED here, so a Package.Data Merge fell through to ACCEPT then threw 'No coercion
+            // rule' at apply (matrix-critic finding) — folding it in closes that. Verb named in the message so it reads
+            // accurately for each.
+            if (req.Verb is "ReplaceAll" or "SetAtIndex" or "Merge")
+                return $"'{leaf.Name}' holds modeled elements ({leaf.ElementTypeRef}); only Add (build-from-parts) " +
+                       $"composes them — {req.Verb} of modeled elements is a later surface.";
         }
+        // (step 4-rmv) Remove-BY-VALUE on a NON-PLAIN-VALUE element — a list Remove with NO key is by-value
+        // (ApplyListVerb -> Coerce(req.Value!, elem)); an element that is neither coercible (step-4b) nor formlink
+        // (step-4a) has NO plain-value form, so the coerce throws 'No coercion rule' at apply (or an NRE if the value is
+        // also null). ONE by-construction predicate covers composable (struct/arm), record, AND the dormant uncoercible
+        // case — the value twin none of the other branches catch for Remove. A Remove BY INDEX (Key present -> RemoveAt,
+        // no coercion) stays accepted, and a dict Remove (by key only, key-gated) is excluded (list-only). Redirect to
+        // remove-by-index; value-based removal of a modeled/record element is a later surface.
+        if (req.Verb == "Remove" && leaf.Cardinality == "list" && req.Key is null
+            && leaf.FormLinkTarget is null && !IsValueCoercibleElement(leaf))
+            return $"'{leaf.Name}' holds modeled/record elements ({leaf.ElementTypeRef ?? leaf.ElementType}); remove one " +
+                   "BY INDEX (Remove with a Key = its position), not by value — a modeled or record element has no " +
+                   "plain-value form to match. (Value-based removal of such an element is a later surface.)";
         return null;
     }
 

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -181,7 +181,14 @@ public sealed class CorpusRulebook
                            "not reached by stepping into a parent (nested-group wave).";
                 if (field.Cardinality == "list" && !int.TryParse(segKey, out _))
                     return $"List '{segName}' on '{current.Name}' must be indexed by an integer; got '{segKey}'.";
-                if (field.Cardinality == "dict" && CheckValue(field.KeyType, segKey, $"dict key for '{segName}'") is { } ke)
+                // dict mid-path key SHAPE — reconcile onto the SAME recognizer pair (DictKeyType + CheckValue's AQ
+                // branch) the PR #79 LEAF step-4-key block uses, so the mid-path hop and the leaf can't drift. Without
+                // the key's real CLR type (DictKeyType -> the dict AQ's args[0], the type apply keys on via
+                // StepIntoElement/ApplyDictVerb) CheckValue falls to the enum-catalog-by-name fallback and MISSES a
+                // non-enum key — e.g. Package.Data's sbyte key ('Data[notasbyte]') was accepted then threw
+                // FormatException at apply (StepIntoElement -> Coerce(key, sbyte)).
+                if (field.Cardinality == "dict"
+                    && CheckValue(field.KeyType, segKey, $"dict key for '{segName}'", DictKeyType(field)?.AssemblyQualifiedName) is { } ke)
                     return ke;
                 current = elem;
             }

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -465,10 +465,14 @@ public sealed class CorpusRulebook
                 && (req.Verb is "Add" or "SetAtIndex" || (req.Verb is "Remove" && req.Key is null))
                 && ElemShape(ev) is { } evErr)
                 return evErr;
-            if (req.Verb is "ReplaceAll")
+            // Slot-faithful to apply: a LIST ReplaceAll coerces req.Values (ApplyListVerb); a DICT Merge/ReplaceAll
+            // coerces req.Entries' values (ApplyDictVerb). Scope each loop to its slot's cardinality so a stray
+            // off-cardinality slot apply IGNORES (e.g. req.Entries supplied on a list ReplaceAll) is not over-rejected —
+            // mirrors the singular-value verb/key-faithfulness above (review polish).
+            if (leaf.Cardinality == "list" && req.Verb is "ReplaceAll")
                 foreach (var v in req.Values ?? Array.Empty<string>())
                     if (ElemShape(v) is { } valsErr) return valsErr;
-            if (req.Verb is "Merge" or "ReplaceAll")
+            if (leaf.Cardinality == "dict" && req.Verb is "Merge" or "ReplaceAll")
                 foreach (var kv in req.Entries ?? new())
                     if (ElemShape(kv.Value) is { } entErr) return entErr;
         }
@@ -484,7 +488,7 @@ public sealed class CorpusRulebook
         // housecarl_create_record / housecarl_bulk_create with parent=. Redirect by construction (one classifier
         // predicate, no per-record-type list). Verb-scoped to the create-oriented verbs (Add/SetAtIndex/ReplaceAll); a
         // record Remove BY INDEX (RemoveAt) is throw-free and stays accepted, and a record Remove BY VALUE is the
-        // non-plain-value Remove surface closed by the unified Remove-by-value reject in the composable block below.
+        // non-plain-value Remove surface closed by the unified Remove-by-value reject in the step-4-rmv block below.
         if (leaf.Cardinality is "list" or "dict" && req.Verb is "Add" or "SetAtIndex" or "ReplaceAll"
             && SchemaClassifier.ClassifyElement(leaf, _corpus) == ElementKind.Record)
             return $"'{leaf.Name}' holds owned child records ({leaf.ElementTypeRef}); a child record is created on its " +

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -567,6 +567,14 @@ public sealed class CorpusRulebook
     /// composition entry points can never disagree.</summary>
     string? StructSpecContents(StructSpec spec, TypeSchema structSchema)
     {
+        // (G4) positional ctor_args value-SHAPE + ARITY — the one compose part the gate never checked. A malformed arg
+        // or a wrong arity passed pre-flight then threw at apply (Instantiate: Coerce(arg, paramType) / "no constructor
+        // taking N arg(s)"). WriteEngine.TryRecognizeCtorArgs mirrors Instantiate EXACTLY (same ResolveStructType + ctor
+        // selector + TryCoerce), so gate and apply can't drift. Checked at the TOP so it runs for BOTH StructSpecContents
+        // call sites (ArmLegality + StructElementLegality) and reports before the per-field checks. Skipped when CtorArgs
+        // is null (the common compose path — parameterless/fields only, unchanged).
+        if (spec.CtorArgs is { } ctorArgs && WriteEngine.TryRecognizeCtorArgs(spec.Type, ctorArgs) is { } ctorErr)
+            return ctorErr;
         foreach (var f in spec.Fields ?? new())
         {
             var af = structSchema.Fields.FirstOrDefault(x => x.Name == f.Key);

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1608,6 +1608,33 @@ public static class WriteEngine
         return InstantiateComposition(t);
     }
 
+    /// <summary>Recognition-only mirror of <see cref="Instantiate"/>'s ctor-args path — the write pre-flight gate's twin
+    /// of the apply-time ctor build (G4). Does this struct type have a constructor of the supplied arity, and does each
+    /// supplied arg COERCE to its parameter type? Resolves the type the SAME way <see cref="BuildStruct"/> feeds
+    /// Instantiate (<see cref="ResolveStructType"/>), selects the ctor the SAME way Instantiate does
+    /// (<c>GetConstructors().FirstOrDefault(len==N)</c>), and checks each arg with <see cref="TryCoerce"/> — the
+    /// non-throwing twin of the very same <c>Coerce</c> Instantiate calls per arg — so the gate and apply cannot drift on
+    /// arity OR value-shape. Returns null = legal; else a fail-loud message: the arity mismatch (mirroring Instantiate's
+    /// own throw text, incl. <see cref="CtorList"/>) or the first arg that won't coerce, NAMED (Q3). The corpus models no
+    /// ctor signatures (it is schema-driven; apply is reflection-driven), so this is the ONE gap whose recognizer is new
+    /// — but it composes entirely from existing engine primitives, by construction, no generator change. Called only when
+    /// <c>spec.CtorArgs</c> is non-null; an empty array means "the 0-arg ctor" and is checked like any other arity.</summary>
+    internal static string? TryRecognizeCtorArgs(string structTypeName, string[] ctorArgs)
+    {
+        Type t;
+        try { t = ResolveStructType(structTypeName); }
+        catch (Exception ex) { return ex.Message; }   // unknown struct type — surface ResolveStructType's own loud message
+        var ctor = t.GetConstructors().FirstOrDefault(c => c.GetParameters().Length == ctorArgs.Length);
+        if (ctor is null)
+            return $"{t.Name}: no constructor taking {ctorArgs.Length} arg(s). Ctors: {CtorList(t)}";
+        var ps = ctor.GetParameters();
+        for (int i = 0; i < ps.Length; i++)
+            if (!TryCoerce(ctorArgs[i], ps[i].ParameterType, out _))
+                return $"ctor arg #{i} ('{ctorArgs[i]}') for '{structTypeName}' does not coerce to " +
+                       $"{Pretty(ps[i].ParameterType)} (parameter '{ps[i].Name}').";
+        return null;
+    }
+
     /// <summary>A composition type has NO parameterless ctor — it is built only from its parts. Recognised by its
     /// generic definition (the engine's normal type-recognition, like IList&lt;&gt;/FormLink&lt;&gt; — NOT a hand-listed
     /// set of record types, which the cornerstone forbids):

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -144,6 +144,8 @@ namespace HousecarlGenerator;
 ///   GAP2-FORMLINK-ROUTE        — a formlink list (Weapon.Keywords) stays on step-4a: a valid FormID accepted, a malformed
 ///                                one refuses 'Illegal FormLink element' (NOT 'does not coerce') — the two blocks partition
 ///                                coercible elements with no overlap.
+///   GAP2-OK-OFFCARD-SLOT       — a stray off-cardinality slot apply ignores (req.Entries on a list ReplaceAll) is NOT
+///                                over-rejected — step-4b's loops are slot-faithful (Values->list, Entries->dict), review polish.
 ///   GAP2-REJ-E2E               — a malformed list value refuses end-to-end with NO file written; the PRE-FLIGHT message
 ///                                ('does not coerce to Single'), not the apply float.Parse throw, proves the gate.
 ///
@@ -927,6 +929,19 @@ public static class NestedCreateGuardProbe
             Console.WriteLine($"   GAP2-FORMLINK-ROUTE step-4a intact  : {(gap2FormlinkRouteOk ? "PASS — formlink elements still route through step-4a, not step-4b" : $"FAIL — ok=[{ok}] bad=[{bad}]")}");
         }
 
+        // ---------- GAP2-OK-OFFCARD-SLOT: a stray off-cardinality slot apply IGNORES is NOT over-rejected (review polish) ----------
+        // ApplyListVerb ReplaceAll consumes req.Values only and ignores req.Entries; step-4b is slot-faithful (Values only
+        // for a list, Entries only for a dict), so a malformed stray Entries on a LIST ReplaceAll does not over-reject.
+        // RED before the slot-scoping fix: the cardinality-blind Entries loop scanned it -> rejected (gate stricter than apply).
+        bool gap2OkOffcardSlotOk;
+        {
+            var req = new WriteRequest { RecordType = "MusicTrack", Path = new[] { "CuePoints" }, Verb = "ReplaceAll",
+                Values = new[] { "1.5" }, Entries = new Dictionary<string, string> { ["x"] = "notafloat" } };
+            var reject = rulebook.Validate(req);
+            gap2OkOffcardSlotOk = reject is null;
+            Console.WriteLine($"   GAP2-OK-OFFCARD-SLOT stray entries  : {(gap2OkOffcardSlotOk ? "PASS — a stray off-cardinality slot (Entries on a list ReplaceAll) apply ignores is NOT over-rejected" : $"FAIL — reject=[{reject}]")}");
+        }
+
         // ---------- GAP2-REJ-E2E: a malformed list value refuses end-to-end with NO file written (gate, not apply throw) ----------
         // MusicTrack is a flat (Kind=record) createable record — no parent needed. The PRE-FLIGHT message ('does not
         // coerce to Single'), not the apply float.Parse throw, proves the gate; RejectArm proves no file written.
@@ -1120,7 +1135,7 @@ public static class NestedCreateGuardProbe
                     && keyShapeOkDictAddOk && keyShapeOkSetIdxOk && keyShapeOkNumEnumSetOk && keyShapeRejE2eOk
                     && gap1RejMidKeySbyteOk && gap1OkMidKeyOk
                     && gap2RejDictAddOk && gap2RejListAddOk && gap2RejListReplaceAllOk && gap2RejListRemoveOk && gap2RejDictMergeOk
-                    && gap2OkValidOk && gap2OkRemoveByIndexOk && gap2FormlinkRouteOk && gap2RejE2eOk
+                    && gap2OkValidOk && gap2OkRemoveByIndexOk && gap2FormlinkRouteOk && gap2OkOffcardSlotOk && gap2RejE2eOk
                     && g6RejRecordAddOk && g6RejRecordReplaceAllOk && g6OkRemoveByIndexOk && g6OkStructUnchangedOk && g6RejE2eOk
                     && g4RejCtorArgShapeOk && g4RejCtorArgArityOk && g4OkCtorArgOk && g4OkNoCtorArgsOk
                     && g7RejDictMergeOk && g7RejComposableRemoveOk && g7RejRecordRemoveOk && g7OkComposableRemoveIdxOk && g7OkDictRemoveKeyOk;

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -161,6 +161,21 @@ namespace HousecarlGenerator;
 ///   G6-REJ-E2E                 — a record-element Add refuses end-to-end with NO file written; the PRE-FLIGHT message
 ///                                (not the apply CompositionRequiredException) proves the gate. (A FLAT create whose own op
 ///                                does the bad Add — NOT a parent= nested create, which is a disjoint, legitimate path.)
+///
+/// G4 — StructSpec CtorArgs VALUE-SHAPE + ARITY. A compose (polymorphic Set arm OR struct-element Add) can carry
+/// positional ctor_args (StructInput.CtorArgs -> StructSpec.CtorArgs); StructSpecContents validated Fields + Sets but
+/// NEVER CtorArgs. At apply, Instantiate selects GetConstructors().FirstOrDefault(len==N) then Coerce(arg, paramType) — a
+/// wrong ARITY threw 'no constructor taking N arg(s)' (named-but-at-apply) and a malformed arg threw UNNAMED. The new
+/// WriteEngine.TryRecognizeCtorArgs mirrors Instantiate EXACTLY (ResolveStructType + same ctor selector + TryCoerce per
+/// arg), called from StructSpecContents — the ONE gap whose recognizer is new, but composed from existing engine
+/// primitives, by construction:
+///   G4-REJ-CTORARG-SHAPE       — a malformed ctor arg ('notatypeenum' for MagicEffectArchetype's TypeEnum) of the right
+///                                arity refuses at PRE-FLIGHT, naming the bad arg (RED before: accepted then Enum.Parse
+///                                threw unnamed at apply).
+///   G4-REJ-CTORARG-ARITY       — a wrong ctor-arg COUNT refuses (mirrors Instantiate's 'no constructor taking 3 arg(s)').
+///                                RED before: accepted.
+///   G4-OK-CTORARG              — valid ctor args ('ValueModifier') of the right arity stay accepted (no over-reject).
+///   G4-OK-NOCTORARGS          — a compose WITHOUT ctor_args (the common case) is untouched (the spec.CtorArgs guard skips).
 /// </summary>
 public static class NestedCreateGuardProbe
 {
@@ -966,6 +981,58 @@ public static class NestedCreateGuardProbe
             },
             msg => msg.Contains("created on its own (the record axis)", StringComparison.OrdinalIgnoreCase));
 
+        // ====== G4 — StructSpec CtorArgs VALUE-SHAPE + ARITY (compose ctor_args were never pre-flight-validated) ======
+        // A compose (polymorphic Set arm OR struct-element Add) can carry positional ctor_args (StructInput.CtorArgs ->
+        // StructSpec.CtorArgs). StructSpecContents validated Fields + Sets but NEVER CtorArgs. At apply, Instantiate picks
+        // GetConstructors().FirstOrDefault(len==N) then Coerce(arg, paramType): a wrong ARITY threw "no constructor taking
+        // N arg(s)" (named-but-at-apply) and a malformed arg threw UNNAMED (Enum.Parse/int.Parse). The new
+        // WriteEngine.TryRecognizeCtorArgs mirrors Instantiate EXACTLY (ResolveStructType + same ctor selector + TryCoerce
+        // per arg), called from StructSpecContents — gate and apply can't drift. Fixture: MagicEffect.Archetype
+        // (polymorphic, writable) arm MagicEffectArchetype, whose concrete ctor takes a (MagicEffectArchetype.TypeEnum).
+
+        // ---------- G4-REJ-CTORARG-SHAPE: a malformed ctor arg of the right arity refuses, naming the bad arg ----------
+        bool g4RejCtorArgShapeOk;
+        {
+            var req = new WriteRequest { RecordType = "MagicEffect", Path = new[] { "Archetype" }, Verb = "Set",
+                Struct = new StructSpec { Type = "MagicEffectArchetype", CtorArgs = new[] { "notatypeenum" } } };
+            var reject = rulebook.Validate(req);
+            g4RejCtorArgShapeOk = reject is not null && reject.Contains("ctor arg #0", StringComparison.OrdinalIgnoreCase)
+                && reject.Contains("notatypeenum", StringComparison.Ordinal);
+            Console.WriteLine($"   G4-REJ-CTORARG-SHAPE bad ctor arg   : {(g4RejCtorArgShapeOk ? "PASS — a malformed ctor arg is refused at pre-flight, named (RED before: accepted then Enum.Parse threw unnamed at apply)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- G4-REJ-CTORARG-ARITY: a wrong ctor-arg COUNT refuses (mirrors Instantiate's arity throw) ----------
+        bool g4RejCtorArgArityOk;
+        {
+            var req = new WriteRequest { RecordType = "MagicEffect", Path = new[] { "Archetype" }, Verb = "Set",
+                Struct = new StructSpec { Type = "MagicEffectArchetype", CtorArgs = new[] { "a", "b", "c" } } };
+            var reject = rulebook.Validate(req);
+            g4RejCtorArgArityOk = reject is not null && reject.Contains("no constructor taking 3 arg(s)", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   G4-REJ-CTORARG-ARITY wrong count    : {(g4RejCtorArgArityOk ? "PASS — a wrong ctor-arg count is refused at pre-flight (RED before: accepted then 'no constructor taking 3 arg(s)' at apply)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- G4-OK-CTORARG: valid ctor args of the right arity stay accepted (no over-reject) ----------
+        bool g4OkCtorArgOk;
+        {
+            var req = new WriteRequest { RecordType = "MagicEffect", Path = new[] { "Archetype" }, Verb = "Set",
+                Struct = new StructSpec { Type = "MagicEffectArchetype", CtorArgs = new[] { "ValueModifier" } } };
+            var reject = rulebook.Validate(req);
+            g4OkCtorArgOk = reject is null;
+            Console.WriteLine($"   G4-OK-CTORARG valid ctor arg        : {(g4OkCtorArgOk ? "PASS — a valid ctor arg (MagicEffectArchetype TypeEnum 'ValueModifier') is NOT over-rejected" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- G4-OK-NOCTORARGS: a compose WITHOUT ctor_args (the common case) is untouched ----------
+        // The check is guarded by `spec.CtorArgs is { }` — a null CtorArgs skips it entirely, so the parameterless/field
+        // compose path the engine already proves is unchanged. (No Fields, to avoid an unrelated enum dependency.)
+        bool g4OkNoCtorArgsOk;
+        {
+            var req = new WriteRequest { RecordType = "MagicEffect", Path = new[] { "Archetype" }, Verb = "Set",
+                Struct = new StructSpec { Type = "MagicEffectLightArchetype" } };
+            var reject = rulebook.Validate(req);
+            g4OkNoCtorArgsOk = reject is null;
+            Console.WriteLine($"   G4-OK-NOCTORARGS no ctor_args       : {(g4OkNoCtorArgsOk ? "PASS — a compose without ctor_args (the common case) is untouched" : $"FAIL — reject=[{reject}]")}");
+        }
+
         Console.WriteLine();
         bool pass = fixturesOk && oneshotOk && multiOk && intoTopicOk && intoCellOk
                     && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendOk
@@ -979,7 +1046,8 @@ public static class NestedCreateGuardProbe
                     && gap1RejMidKeySbyteOk && gap1OkMidKeyOk
                     && gap2RejDictAddOk && gap2RejListAddOk && gap2RejListReplaceAllOk && gap2RejListRemoveOk && gap2RejDictMergeOk
                     && gap2OkValidOk && gap2OkRemoveByIndexOk && gap2FormlinkRouteOk && gap2RejE2eOk
-                    && g6RejRecordAddOk && g6RejRecordReplaceAllOk && g6OkRemoveByIndexOk && g6OkStructUnchangedOk && g6RejE2eOk;
+                    && g6RejRecordAddOk && g6RejRecordReplaceAllOk && g6OkRemoveByIndexOk && g6OkStructUnchangedOk && g6RejE2eOk
+                    && g4RejCtorArgShapeOk && g4RejCtorArgArityOk && g4OkCtorArgOk && g4OkNoCtorArgsOk;
         Console.WriteLine($"=== nested-create-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return pass ? 0 : 1;

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -146,6 +146,21 @@ namespace HousecarlGenerator;
 ///                                coercible elements with no overlap.
 ///   GAP2-REJ-E2E               — a malformed list value refuses end-to-end with NO file written; the PRE-FLIGHT message
 ///                                ('does not coerce to Single'), not the apply float.Parse throw, proves the gate.
+///
+/// G6 — RECORD-ELEMENT collection VERBS. A list/dict whose ELEMENT is an owned child RECORD (DialogTopic.Responses ->
+/// DialogResponses) is neither coercible, composable, nor formlink, so a collection verb fell through ValueLegality to
+/// ACCEPT then threw at apply (compose -> CompositionRequiredException, named-but-MISLEADING; or plain value -> Coerce
+/// 'No coercion rule'). The new step-4-rec branch redirects Add/SetAtIndex/ReplaceAll to the record axis
+/// (create_record/bulk_create parent=) by one ClassifyElement==Record predicate; a record Remove BY INDEX stays accepted:
+///   G6-REJ-RECORD-ADD          — a record-element Add (compose) refuses, naming create_record (RED before: accepted then
+///                                CompositionRequiredException at apply).
+///   G6-REJ-RECORD-REPLACEALL   — a record-element ReplaceAll refuses too (verb coverage). RED before: accepted.
+///   G6-OK-REMOVE-BYINDEX       — a record-element Remove BY INDEX (RemoveAt) stays accepted (no over-reject; verb-scoped).
+///   G6-OK-STRUCT-UNCHANGED     — a struct-element Add (Faction.Ranks) still composes — the Record branch is mutually
+///                                exclusive with Struct/Arm, so it doesn't bleed onto the real composition surface.
+///   G6-REJ-E2E                 — a record-element Add refuses end-to-end with NO file written; the PRE-FLIGHT message
+///                                (not the apply CompositionRequiredException) proves the gate. (A FLAT create whose own op
+///                                does the bad Add — NOT a parent= nested create, which is a disjoint, legitimate path.)
 /// </summary>
 public static class NestedCreateGuardProbe
 {
@@ -893,6 +908,64 @@ public static class NestedCreateGuardProbe
             },
             msg => msg.Contains("does not coerce to Single", StringComparison.OrdinalIgnoreCase));
 
+        // ====== G6 — RECORD-ELEMENT collection VERBS (Add/SetAtIndex/ReplaceAll redirect to create_record) ======
+        // A list/dict whose element is an owned child RECORD (DialogTopic.Responses -> DialogResponses) is neither
+        // coercible, composable, nor formlink, so a collection verb fell through ValueLegality to ACCEPT then threw at
+        // apply (BuildStruct -> CompositionRequiredException, or Coerce -> "No coercion rule"). The new step-4-rec branch
+        // redirects to the record axis (create_record/bulk_create parent=). Verb-scoped to Add/SetAtIndex/ReplaceAll; a
+        // record Remove BY INDEX stays throw-free/accepted, and a record Remove BY VALUE is the non-plain-value Remove
+        // surface closed with G7's unified Remove-by-value reject.
+
+        // ---------- G6-REJ-RECORD-ADD: an Add (compose) on a record-element list refuses, naming create_record ----------
+        bool g6RejRecordAddOk;
+        {
+            var req = new WriteRequest { RecordType = "DialogTopic", Path = new[] { "Responses" }, Verb = "Add", Struct = new StructSpec { Type = "DialogResponses" } };
+            var reject = rulebook.Validate(req);
+            g6RejRecordAddOk = reject is not null
+                && reject.Contains("created on its own (the record axis)", StringComparison.OrdinalIgnoreCase)
+                && reject.Contains("housecarl_create_record", StringComparison.OrdinalIgnoreCase)
+                && reject.Contains("Responses", StringComparison.Ordinal);
+            Console.WriteLine($"   G6-REJ-RECORD-ADD record-elem Add   : {(g6RejRecordAddOk ? "PASS — a record-element Add is refused, redirected to create_record (RED before: accepted then CompositionRequiredException at apply)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- G6-REJ-RECORD-REPLACEALL: ReplaceAll on a record-element list refuses too (verb coverage) ----------
+        bool g6RejRecordReplaceAllOk;
+        {
+            var req = new WriteRequest { RecordType = "DialogTopic", Path = new[] { "Responses" }, Verb = "ReplaceAll", Values = new[] { "012345:Skyrim.esm" } };
+            var reject = rulebook.Validate(req);
+            g6RejRecordReplaceAllOk = reject is not null && reject.Contains("created on its own (the record axis)", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   G6-REJ-RECORD-REPLACEALL           : {(g6RejRecordReplaceAllOk ? "PASS — a record-element ReplaceAll is refused too (RED before: accepted)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- G6-OK-REMOVE-BYINDEX: a record-element Remove BY INDEX (RemoveAt) stays accepted (no over-reject) ----------
+        bool g6OkRemoveByIndexOk;
+        {
+            var req = new WriteRequest { RecordType = "DialogTopic", Path = new[] { "Responses" }, Verb = "Remove", Key = "0" };
+            var reject = rulebook.Validate(req);
+            g6OkRemoveByIndexOk = reject is null;
+            Console.WriteLine($"   G6-OK-REMOVE-BYINDEX record rm idx  : {(g6OkRemoveByIndexOk ? "PASS — a record-element Remove by index (RemoveAt) is throw-free and NOT over-rejected" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- G6-OK-STRUCT-UNCHANGED: a struct-element Add still composes (Record branch doesn't bleed onto Struct) ----------
+        bool g6OkStructUnchangedOk;
+        {
+            var req = new WriteRequest { RecordType = "Faction", Path = new[] { "Ranks" }, Verb = "Add", Struct = new StructSpec { Type = "Rank" } };
+            var reject = rulebook.Validate(req);
+            g6OkStructUnchangedOk = reject is null;
+            Console.WriteLine($"   G6-OK-STRUCT-UNCHANGED struct Add   : {(g6OkStructUnchangedOk ? "PASS — a struct-element Add (Faction.Ranks) still composes (Record branch is mutually exclusive)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- G6-REJ-E2E: a record-element Add refuses end-to-end with NO file written (gate, not apply throw) ----------
+        // A FLAT DialogTopic create whose OWN op does the bad record-element Add (NOT a parent= nested create — that path
+        // is disjoint and legitimately works). The PRE-FLIGHT message, not the apply CompositionRequiredException, proves the gate.
+        bool g6RejE2eOk = RejectArm("G6-REJ-E2E record-element Add      ", tmpDir, "G6", mPath, rulebook,
+            new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogTopic", EditorId = "HcNcG6Topic",
+                    Edits = new[] { new WriteRequest { RecordType = "DialogTopic", Path = new[] { "Responses" }, Verb = "Add", Struct = new StructSpec { Type = "DialogResponses" } } } },
+            },
+            msg => msg.Contains("created on its own (the record axis)", StringComparison.OrdinalIgnoreCase));
+
         Console.WriteLine();
         bool pass = fixturesOk && oneshotOk && multiOk && intoTopicOk && intoCellOk
                     && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendOk
@@ -905,7 +978,8 @@ public static class NestedCreateGuardProbe
                     && keyShapeOkDictAddOk && keyShapeOkSetIdxOk && keyShapeOkNumEnumSetOk && keyShapeRejE2eOk
                     && gap1RejMidKeySbyteOk && gap1OkMidKeyOk
                     && gap2RejDictAddOk && gap2RejListAddOk && gap2RejListReplaceAllOk && gap2RejListRemoveOk && gap2RejDictMergeOk
-                    && gap2OkValidOk && gap2OkRemoveByIndexOk && gap2FormlinkRouteOk && gap2RejE2eOk;
+                    && gap2OkValidOk && gap2OkRemoveByIndexOk && gap2FormlinkRouteOk && gap2RejE2eOk
+                    && g6RejRecordAddOk && g6RejRecordReplaceAllOk && g6OkRemoveByIndexOk && g6OkStructUnchangedOk && g6RejE2eOk;
         Console.WriteLine($"=== nested-create-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return pass ? 0 : 1;

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -125,6 +125,27 @@ namespace HousecarlGenerator;
 ///   GAP1-REJ-MIDKEY-SBYTE      — a malformed sbyte key in a mid-path hop ('Data[notasbyte].Name') refuses 'does not coerce
 ///                                to sbyte' at PRE-FLIGHT (RED before: accepted — no AQ, 'sbyte' not a catalog enum).
 ///   GAP1-OK-MIDKEY             — a VALID sbyte mid-path key ('Data[0].Name') + valid leaf Set stays accepted (no over-reject).
+///
+/// GAP 2 — NON-FORMLINK coercible collection ELEMENT VALUE-SHAPE (the value twin of step-4a + the dict-Set value block).
+/// A non-null, non-formlink, MALFORMED coercible element value on list Add/SetAtIndex/ReplaceAll/Remove-by-value and dict
+/// Add/Merge/ReplaceAll passed pre-flight then threw UNNAMED at apply (Coerce -> float.Parse/byte.Parse). dict-Set value
+/// was already gated; the new ValueLegality step-4b block mirrors that CheckValue across those verbs/slots, scoped to
+/// IsValueCoercibleElement && FormLinkTarget is null (formlink elements keep step-4a) and verb/key-faithful to which slot
+/// apply coerces (so a Remove-BY-INDEX with a stray value is not over-rejected):
+///   GAP2-REJ-DICTADD           — a malformed dict Add value ('notabyte' into Dictionary&lt;Skill,Byte&gt;) refuses 'does
+///                                not coerce to Byte' (RED before: accepted — only dict Set value was gated).
+///   GAP2-REJ-LISTADD           — a malformed list Add value ('notafloat' into List&lt;Single&gt;) refuses (RED: accepted).
+///   GAP2-REJ-LISTREPLACEALL    — a bad ReplaceAll value PAST a valid one is caught and NAMED (per-element scan). RED: accepted.
+///   GAP2-REJ-LISTREMOVE        — a malformed Remove-BY-VALUE (Key null) refuses (RED: accepted).
+///   GAP2-REJ-DICTMERGE         — a malformed Merge entries value refuses ('notabyte'). RED: accepted.
+///   GAP2-OK-VALID              — valid list+dict element values stay accepted (no over-reject).
+///   GAP2-OK-REMOVE-BYINDEX     — a list Remove BY INDEX (Key present) carrying a stray value is NOT over-rejected (apply
+///                                ignores the value on a by-index Remove) — proves the verb/key-faithful scoping.
+///   GAP2-FORMLINK-ROUTE        — a formlink list (Weapon.Keywords) stays on step-4a: a valid FormID accepted, a malformed
+///                                one refuses 'Illegal FormLink element' (NOT 'does not coerce') — the two blocks partition
+///                                coercible elements with no overlap.
+///   GAP2-REJ-E2E               — a malformed list value refuses end-to-end with NO file written; the PRE-FLIGHT message
+///                                ('does not coerce to Single'), not the apply float.Parse throw, proves the gate.
 /// </summary>
 public static class NestedCreateGuardProbe
 {
@@ -772,6 +793,106 @@ public static class NestedCreateGuardProbe
             Console.WriteLine($"   GAP1-OK-MIDKEY valid sbyte mid key : {(gap1OkMidKeyOk ? "PASS — a valid sbyte mid-path key (Data[0]) is NOT over-rejected" : $"FAIL — reject=[{reject}]")}");
         }
 
+        // ====== GAP 2 — NON-FORMLINK coercible collection ELEMENT VALUE-SHAPE ======
+        // The value twin of step-4a (formlink elements) and of the dict-Set value block. A non-null, non-formlink,
+        // MALFORMED coercible element value on list Add/SetAtIndex/ReplaceAll/Remove-by-value and dict Add/Merge/ReplaceAll
+        // passed pre-flight then threw UNNAMED at apply (Coerce -> float.Parse/byte.Parse). dict-Set value was already
+        // gated. The new step-4b block mirrors the dict-Set CheckValue across those verbs/slots, scoped to
+        // IsValueCoercibleElement && FormLinkTarget is null (formlink elements keep step-4a), and verb/key-faithful to
+        // which slot apply actually coerces (so a Remove-BY-INDEX carrying a stray value is NOT over-rejected).
+
+        // ---------- GAP2-REJ-DICTADD: dict Add, valid key, malformed value (Class.SkillWeights=Dictionary<Skill,Byte>) ----------
+        bool gap2RejDictAddOk;
+        {
+            var req = new WriteRequest { RecordType = "Class", Path = new[] { "SkillWeights" }, Verb = "Add", Key = "OneHanded", Value = "notabyte" };
+            var reject = rulebook.Validate(req);
+            gap2RejDictAddOk = reject is not null && reject.Contains("does not coerce to Byte", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   GAP2-REJ-DICTADD bad dict value     : {(gap2RejDictAddOk ? "PASS — a malformed dict Add value is refused at pre-flight (only dict Set value was gated before)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- GAP2-REJ-LISTADD: list Add malformed value (MusicTrack.CuePoints=List<Single>) ----------
+        bool gap2RejListAddOk;
+        {
+            var req = new WriteRequest { RecordType = "MusicTrack", Path = new[] { "CuePoints" }, Verb = "Add", Value = "notafloat" };
+            var reject = rulebook.Validate(req);
+            gap2RejListAddOk = reject is not null && reject.Contains("does not coerce to Single", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   GAP2-REJ-LISTADD bad list value     : {(gap2RejListAddOk ? "PASS — a malformed list Add value is refused at pre-flight" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- GAP2-REJ-LISTREPLACEALL: bad value PAST a good one (per-element scan names the bad one) ----------
+        bool gap2RejListReplaceAllOk;
+        {
+            var req = new WriteRequest { RecordType = "MusicTrack", Path = new[] { "CuePoints" }, Verb = "ReplaceAll", Values = new[] { "1.5", "notafloat" } };
+            var reject = rulebook.Validate(req);
+            gap2RejListReplaceAllOk = reject is not null && reject.Contains("does not coerce to Single", StringComparison.OrdinalIgnoreCase)
+                && reject.Contains("notafloat", StringComparison.Ordinal);
+            Console.WriteLine($"   GAP2-REJ-LISTREPLACEALL bad in list : {(gap2RejListReplaceAllOk ? "PASS — a bad ReplaceAll value is caught past a valid one, named" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- GAP2-REJ-LISTREMOVE: Remove-by-value (Key null) malformed value ----------
+        bool gap2RejListRemoveOk;
+        {
+            var req = new WriteRequest { RecordType = "MusicTrack", Path = new[] { "CuePoints" }, Verb = "Remove", Value = "notafloat" };
+            var reject = rulebook.Validate(req);
+            gap2RejListRemoveOk = reject is not null && reject.Contains("does not coerce to Single", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   GAP2-REJ-LISTREMOVE bad remove value: {(gap2RejListRemoveOk ? "PASS — a malformed Remove-by-value is refused at pre-flight" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- GAP2-REJ-DICTMERGE: Merge entries bad value (valid key, non-@ value) ----------
+        bool gap2RejDictMergeOk;
+        {
+            var req = new WriteRequest { RecordType = "Class", Path = new[] { "SkillWeights" }, Verb = "Merge",
+                Entries = new Dictionary<string, string> { ["OneHanded"] = "notabyte" } };
+            var reject = rulebook.Validate(req);
+            gap2RejDictMergeOk = reject is not null && reject.Contains("does not coerce to Byte", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   GAP2-REJ-DICTMERGE bad merge value  : {(gap2RejDictMergeOk ? "PASS — a malformed Merge entries value is refused at pre-flight" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- GAP2-OK-VALID: valid coercible values stay accepted (no over-reject) ----------
+        bool gap2OkValidOk;
+        {
+            var r1 = rulebook.Validate(new WriteRequest { RecordType = "MusicTrack", Path = new[] { "CuePoints" }, Verb = "Add", Value = "1.5" });
+            var r2 = rulebook.Validate(new WriteRequest { RecordType = "Class", Path = new[] { "SkillWeights" }, Verb = "Add", Key = "OneHanded", Value = "5" });
+            gap2OkValidOk = r1 is null && r2 is null;
+            Console.WriteLine($"   GAP2-OK-VALID valid values accepted : {(gap2OkValidOk ? "PASS — valid list+dict element values are NOT over-rejected" : $"FAIL — r1=[{r1}] r2=[{r2}]")}");
+        }
+
+        // ---------- GAP2-OK-REMOVE-BYINDEX: Remove BY INDEX (Key present) ignores its value at apply -> not over-rejected ----------
+        // ApplyListVerb Remove with a Key is RemoveAt(int.Parse(key)) — the value is apply-irrelevant. The step-4b value
+        // check is verb/key-faithful (Remove value only when Key is null), so a stray value here must NOT reject.
+        bool gap2OkRemoveByIndexOk;
+        {
+            var req = new WriteRequest { RecordType = "MusicTrack", Path = new[] { "CuePoints" }, Verb = "Remove", Key = "0", Value = "notafloat" };
+            var reject = rulebook.Validate(req);
+            gap2OkRemoveByIndexOk = reject is null;
+            Console.WriteLine($"   GAP2-OK-REMOVE-BYINDEX stray value  : {(gap2OkRemoveByIndexOk ? "PASS — a by-index Remove with a stray value is NOT over-rejected (apply ignores it)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- GAP2-FORMLINK-ROUTE: formlink elements still take step-4a, not step-4b (the partition holds) ----------
+        // A formlink list (Weapon.Keywords, FormLinkTarget set) is EXCLUDED from step-4b's scope, so a valid FormID stays
+        // accepted and a malformed one rejects with step-4a's "Illegal FormLink element" (NOT "does not coerce") — proving
+        // the two value-shape blocks partition coercible elements with no overlap and no gap.
+        bool gap2FormlinkRouteOk;
+        {
+            var ok = rulebook.Validate(new WriteRequest { RecordType = "Weapon", Path = new[] { "Keywords" }, Verb = "Add", Value = "012345:Skyrim.esm" });
+            var bad = rulebook.Validate(new WriteRequest { RecordType = "Weapon", Path = new[] { "Keywords" }, Verb = "Add", Value = "notaformkey" });
+            gap2FormlinkRouteOk = ok is null && bad is not null
+                && bad.Contains("Illegal FormLink element", StringComparison.OrdinalIgnoreCase)
+                && !bad.Contains("does not coerce", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   GAP2-FORMLINK-ROUTE step-4a intact  : {(gap2FormlinkRouteOk ? "PASS — formlink elements still route through step-4a, not step-4b" : $"FAIL — ok=[{ok}] bad=[{bad}]")}");
+        }
+
+        // ---------- GAP2-REJ-E2E: a malformed list value refuses end-to-end with NO file written (gate, not apply throw) ----------
+        // MusicTrack is a flat (Kind=record) createable record — no parent needed. The PRE-FLIGHT message ('does not
+        // coerce to Single'), not the apply float.Parse throw, proves the gate; RejectArm proves no file written.
+        bool gap2RejE2eOk = RejectArm("GAP2-REJ-E2E bad list value       ", tmpDir, "Gap2", mPath, rulebook,
+            new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "MusicTrack", EditorId = "HcNcG2Mtrk",
+                    Edits = new[] { new WriteRequest { RecordType = "MusicTrack", Path = new[] { "CuePoints" }, Verb = "Add", Value = "notafloat" } } },
+            },
+            msg => msg.Contains("does not coerce to Single", StringComparison.OrdinalIgnoreCase));
+
         Console.WriteLine();
         bool pass = fixturesOk && oneshotOk && multiOk && intoTopicOk && intoCellOk
                     && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendOk
@@ -782,7 +903,9 @@ public static class NestedCreateGuardProbe
                     && keyShapeRejDictAddOk && keyShapeRejDictRemoveOk && keyShapeRejMergeKeyOk && keyShapeRejSbyteOk
                     && keyShapeRejSetIdxOk && keyShapeRejNegIdxOk && keyShapeRejListRemoveIdxOk
                     && keyShapeOkDictAddOk && keyShapeOkSetIdxOk && keyShapeOkNumEnumSetOk && keyShapeRejE2eOk
-                    && gap1RejMidKeySbyteOk && gap1OkMidKeyOk;
+                    && gap1RejMidKeySbyteOk && gap1OkMidKeyOk
+                    && gap2RejDictAddOk && gap2RejListAddOk && gap2RejListReplaceAllOk && gap2RejListRemoveOk && gap2RejDictMergeOk
+                    && gap2OkValidOk && gap2OkRemoveByIndexOk && gap2FormlinkRouteOk && gap2RejE2eOk;
         Console.WriteLine($"=== nested-create-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return pass ? 0 : 1;

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -125,6 +125,8 @@ namespace HousecarlGenerator;
 ///   GAP1-REJ-MIDKEY-SBYTE      — a malformed sbyte key in a mid-path hop ('Data[notasbyte].Name') refuses 'does not coerce
 ///                                to sbyte' at PRE-FLIGHT (RED before: accepted — no AQ, 'sbyte' not a catalog enum).
 ///   GAP1-OK-MIDKEY             — a VALID sbyte mid-path key ('Data[0].Name') + valid leaf Set stays accepted (no over-reject).
+///   GAP1-REJ-E2E               — a malformed mid-path key refuses end-to-end with NO file written (review hardening); the
+///                                PRE-FLIGHT 'does not coerce to sbyte', not the apply sbyte FormatException, proves the gate.
 ///
 /// GAP 2 — NON-FORMLINK coercible collection ELEMENT VALUE-SHAPE (the value twin of step-4a + the dict-Set value block).
 /// A non-null, non-formlink, MALFORMED coercible element value on list Add/SetAtIndex/ReplaceAll/Remove-by-value and dict
@@ -178,6 +180,8 @@ namespace HousecarlGenerator;
 ///                                RED before: accepted.
 ///   G4-OK-CTORARG              — valid ctor args ('ValueModifier') of the right arity stay accepted (no over-reject).
 ///   G4-OK-NOCTORARGS          — a compose WITHOUT ctor_args (the common case) is untouched (the spec.CtorArgs guard skips).
+///   G4-REJ-CTORARG-E2E         — a malformed ctor arg refuses end-to-end with NO file written (review hardening); the
+///                                PRE-FLIGHT 'ctor arg #0', not the apply Enum.Parse throw, proves the gate ran before Instantiate.
 ///
 /// G7 — composable-element MERGE + non-plain-value Remove-BY-VALUE (the deferred-reject completion; matrix-critic finding
 /// + a record twin found while implementing G6). The IsComposableElement deferred-reject covered Add and
@@ -840,6 +844,20 @@ public static class NestedCreateGuardProbe
             Console.WriteLine($"   GAP1-OK-MIDKEY valid sbyte mid key : {(gap1OkMidKeyOk ? "PASS — a valid sbyte mid-path key (Data[0]) is NOT over-rejected" : $"FAIL — reject=[{reject}]")}");
         }
 
+        // ---------- GAP1-REJ-E2E: a malformed mid-path dict key refuses end-to-end with NO file written (review hardening) ----------
+        // Package is a flat (Kind=record) createable record; the create's own op edits Data[notasbyte].Name. A fresh
+        // Package's Data is an empty NON-null dict (Mutagen initializes it), so apply DOES reach the key coerce — WITHOUT
+        // the fix, pre-flight accepts and apply throws the genuine sbyte FormatException at StepIntoElement ->
+        // Coerce('notasbyte', sbyte) (RED-proven verbatim). With the fix, the PRE-FLIGHT message ('does not coerce to
+        // sbyte'), not the apply throw, refuses it with NO file written — the faithful mid-path-key accept-then-throw, end to end.
+        bool gap1RejE2eOk = RejectArm("GAP1-REJ-E2E bad mid-path key      ", tmpDir, "Gap1E2E", mPath, rulebook,
+            new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "Package", EditorId = "HcNcG1Pack",
+                    Edits = new[] { new WriteRequest { RecordType = "Package", Path = new[] { "Data[notasbyte]", "Name" }, Verb = "Set", Value = "houseCARL" } } },
+            },
+            msg => msg.Contains("does not coerce to sbyte", StringComparison.OrdinalIgnoreCase));
+
         // ====== GAP 2 — NON-FORMLINK coercible collection ELEMENT VALUE-SHAPE ======
         // The value twin of step-4a (formlink elements) and of the dict-Set value block. A non-null, non-formlink,
         // MALFORMED coercible element value on list Add/SetAtIndex/ReplaceAll/Remove-by-value and dict Add/Merge/ReplaceAll
@@ -1063,6 +1081,20 @@ public static class NestedCreateGuardProbe
             Console.WriteLine($"   G4-OK-NOCTORARGS no ctor_args       : {(g4OkNoCtorArgsOk ? "PASS — a compose without ctor_args (the common case) is untouched" : $"FAIL — reject=[{reject}]")}");
         }
 
+        // ---------- G4-REJ-CTORARG-E2E: a malformed ctor arg refuses end-to-end with NO file written (review hardening) ----------
+        // MagicEffect is a flat (Kind=record) createable record; the create's own op does the polymorphic Set with a bad
+        // ctor arg. The PRE-FLIGHT message ('ctor arg #0'), not the apply Enum.Parse throw, proves the gate caught it
+        // BEFORE Instantiate ran — self-enforcing against future drift in Instantiate (G4's recognizer is the one
+        // genuinely new one, so this faithfully reproduces the accept-then-throw end to end). RejectArm proves no file.
+        bool g4RejCtorArgE2eOk = RejectArm("G4-REJ-CTORARG-E2E bad ctor arg   ", tmpDir, "G4E2E", mPath, rulebook,
+            new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "MagicEffect", EditorId = "HcNcG4Mgef",
+                    Edits = new[] { new WriteRequest { RecordType = "MagicEffect", Path = new[] { "Archetype" }, Verb = "Set",
+                        Struct = new StructSpec { Type = "MagicEffectArchetype", CtorArgs = new[] { "notatypeenum" } } } } },
+            },
+            msg => msg.Contains("ctor arg #0", StringComparison.OrdinalIgnoreCase));
+
         // ====== G7 — composable-element MERGE + non-plain-value Remove-BY-VALUE (the deferred-reject completion) ======
         // The IsComposableElement deferred-reject block covered Add (compose/deferred) and ReplaceAll/SetAtIndex, but
         // OMITTED Merge — a Package.Data Merge fell through to ACCEPT then threw 'No coercion rule' at apply. And a
@@ -1133,11 +1165,11 @@ public static class NestedCreateGuardProbe
                     && keyShapeRejDictAddOk && keyShapeRejDictRemoveOk && keyShapeRejMergeKeyOk && keyShapeRejSbyteOk
                     && keyShapeRejSetIdxOk && keyShapeRejNegIdxOk && keyShapeRejListRemoveIdxOk
                     && keyShapeOkDictAddOk && keyShapeOkSetIdxOk && keyShapeOkNumEnumSetOk && keyShapeRejE2eOk
-                    && gap1RejMidKeySbyteOk && gap1OkMidKeyOk
+                    && gap1RejMidKeySbyteOk && gap1OkMidKeyOk && gap1RejE2eOk
                     && gap2RejDictAddOk && gap2RejListAddOk && gap2RejListReplaceAllOk && gap2RejListRemoveOk && gap2RejDictMergeOk
                     && gap2OkValidOk && gap2OkRemoveByIndexOk && gap2FormlinkRouteOk && gap2OkOffcardSlotOk && gap2RejE2eOk
                     && g6RejRecordAddOk && g6RejRecordReplaceAllOk && g6OkRemoveByIndexOk && g6OkStructUnchangedOk && g6RejE2eOk
-                    && g4RejCtorArgShapeOk && g4RejCtorArgArityOk && g4OkCtorArgOk && g4OkNoCtorArgsOk
+                    && g4RejCtorArgShapeOk && g4RejCtorArgArityOk && g4OkCtorArgOk && g4OkNoCtorArgsOk && g4RejCtorArgE2eOk
                     && g7RejDictMergeOk && g7RejComposableRemoveOk && g7RejRecordRemoveOk && g7OkComposableRemoveIdxOk && g7OkDictRemoveKeyOk;
         Console.WriteLine($"=== nested-create-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -115,6 +115,16 @@ namespace HousecarlGenerator;
 ///                                RED before: REJECTED by the old enum-catalog-NAME-only check (the gate/apply drift this fixes).
 ///   KEYSHAPE-REJ-E2E           — a malformed list index refuses end-to-end with NO file written; the PRE-FLIGHT message
 ///                                ('Illegal list index'), not the apply int.Parse throw, proves the gate.
+///
+/// GAP 1 — mid-path dict-key VALUE-SHAPE (the one-segment-up twin of the leaf KEYSHAPE-REJ-SBYTE arm). The leaf step-4-key
+/// block (PR #79) gates a dict key at the LEAF; ValidateFromType's bracketed MID-PATH hop ('Data[key].field') checked the
+/// key via CheckValue WITHOUT the key's AQ, so it fell to the enum-catalog-by-name fallback and missed the lone non-enum
+/// key (Package.Data = Dictionary&lt;sbyte,APackageData&gt;, the only mid-path-navigable dict). A malformed mid-path key
+/// was accepted then threw FormatException at apply (StepIntoElement -&gt; Coerce(key, sbyte)). The fix passes
+/// DictKeyType(field)?.AQ — the SAME recognizer pair the leaf block uses — so mid-path and leaf can't drift:
+///   GAP1-REJ-MIDKEY-SBYTE      — a malformed sbyte key in a mid-path hop ('Data[notasbyte].Name') refuses 'does not coerce
+///                                to sbyte' at PRE-FLIGHT (RED before: accepted — no AQ, 'sbyte' not a catalog enum).
+///   GAP1-OK-MIDKEY             — a VALID sbyte mid-path key ('Data[0].Name') + valid leaf Set stays accepted (no over-reject).
 /// </summary>
 public static class NestedCreateGuardProbe
 {
@@ -733,6 +743,35 @@ public static class NestedCreateGuardProbe
             },
             msg => msg.Contains("Illegal list index", StringComparison.OrdinalIgnoreCase));
 
+        // ====== GAP 1 — mid-path dict-key VALUE-SHAPE (the one-segment-up twin of the leaf KEYSHAPE gate above) ======
+        // KEYSHAPE-REJ-SBYTE gates a dict key at the LEAF; this gates a dict key in a MID-PATH hop ('Data[key].field').
+        // ValidateFromType's bracketed mid-path branch checked the key via CheckValue WITHOUT the key's AQ, so it fell to
+        // the enum-catalog-by-name fallback and missed the lone non-enum key type (Package.Data = Dictionary<sbyte,...>).
+        // A malformed mid-path key ('Data[notasbyte].Name') was accepted then threw FormatException at apply
+        // (StepIntoElement -> Coerce(key, sbyte)). The fix passes DictKeyType(field)?.AQ — the SAME recognizer pair the
+        // leaf step-4-key block uses — so mid-path and leaf can't drift.
+
+        // ---------- GAP1-REJ-MIDKEY-SBYTE: a malformed sbyte key in a MID-PATH hop refuses at PRE-FLIGHT ----------
+        // Package.Data = Dictionary<sbyte,APackageData> is the ONLY mid-path-navigable (struct/poly-valued) dict. A valid
+        // APackageData base field ('Name', writable string) as the leaf so ONLY the mid-path key is at fault. RED before:
+        // accepted (the mid-path CheckValue had no AQ -> 'sbyte' is not a catalog enum -> returns null).
+        bool gap1RejMidKeySbyteOk;
+        {
+            var req = new WriteRequest { RecordType = "Package", Path = new[] { "Data[notasbyte]", "Name" }, Verb = "Set", Value = "houseCARL" };
+            var reject = rulebook.Validate(req);
+            gap1RejMidKeySbyteOk = reject is not null && reject.Contains("does not coerce to sbyte", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   GAP1-REJ-MIDKEY-SBYTE bad mid key  : {(gap1RejMidKeySbyteOk ? "PASS — a malformed sbyte mid-path key is refused at pre-flight (real CLR type, not enum-name only)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- GAP1-OK-MIDKEY: a VALID sbyte mid-path key + valid leaf Set stays accepted (no over-reject) ----------
+        bool gap1OkMidKeyOk;
+        {
+            var req = new WriteRequest { RecordType = "Package", Path = new[] { "Data[0]", "Name" }, Verb = "Set", Value = "houseCARL" };
+            var reject = rulebook.Validate(req);
+            gap1OkMidKeyOk = reject is null;
+            Console.WriteLine($"   GAP1-OK-MIDKEY valid sbyte mid key : {(gap1OkMidKeyOk ? "PASS — a valid sbyte mid-path key (Data[0]) is NOT over-rejected" : $"FAIL — reject=[{reject}]")}");
+        }
+
         Console.WriteLine();
         bool pass = fixturesOk && oneshotOk && multiOk && intoTopicOk && intoCellOk
                     && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendOk
@@ -742,7 +781,8 @@ public static class NestedCreateGuardProbe
                     && keyIdxRejDictAddOk && keyIdxRejDictRemoveOk && keyIdxRejSetIdxOk && keyIdxOkListRemoveOk && keyIdxRejSetIdxE2eOk
                     && keyShapeRejDictAddOk && keyShapeRejDictRemoveOk && keyShapeRejMergeKeyOk && keyShapeRejSbyteOk
                     && keyShapeRejSetIdxOk && keyShapeRejNegIdxOk && keyShapeRejListRemoveIdxOk
-                    && keyShapeOkDictAddOk && keyShapeOkSetIdxOk && keyShapeOkNumEnumSetOk && keyShapeRejE2eOk;
+                    && keyShapeOkDictAddOk && keyShapeOkSetIdxOk && keyShapeOkNumEnumSetOk && keyShapeRejE2eOk
+                    && gap1RejMidKeySbyteOk && gap1OkMidKeyOk;
         Console.WriteLine($"=== nested-create-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return pass ? 0 : 1;

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -176,6 +176,21 @@ namespace HousecarlGenerator;
 ///                                RED before: accepted.
 ///   G4-OK-CTORARG              — valid ctor args ('ValueModifier') of the right arity stay accepted (no over-reject).
 ///   G4-OK-NOCTORARGS          — a compose WITHOUT ctor_args (the common case) is untouched (the spec.CtorArgs guard skips).
+///
+/// G7 — composable-element MERGE + non-plain-value Remove-BY-VALUE (the deferred-reject completion; matrix-critic finding
+/// + a record twin found while implementing G6). The IsComposableElement deferred-reject covered Add and
+/// ReplaceAll/SetAtIndex but OMITTED Merge (a Package.Data Merge fell through to ACCEPT then threw 'No coercion rule' at
+/// apply), and a Remove BY VALUE (Key null) on ANY non-plain-value element (composable OR record — neither has a
+/// plain-value form) likewise fell through then threw. The fix folds Merge into the composable deferred-reject and adds
+/// ONE unified Remove-by-value branch (predicate: list Remove, Key null, NOT formlink, NOT coercible) covering
+/// composable + record + the dormant uncoercible case by construction:
+///   G7-REJ-DICTMERGE                 — a Package.Data Merge refuses ('Merge of modeled elements is a later surface')
+///                                      (RED before: accepted then 'No coercion rule' at apply).
+///   G7-REJ-COMPOSABLE-REMOVE-BYVALUE — a struct-element (Faction.Ranks) Remove-by-value refuses, redirected to remove-by-index.
+///   G7-REJ-RECORD-REMOVE-BYVALUE     — a record-element (DialogTopic.Responses) Remove-by-value refuses too — the unified
+///                                      non-plain-value branch covers records (the twin found while implementing G6).
+///   G7-OK-COMPOSABLE-REMOVE-BYINDEX  — a struct-element Remove BY INDEX (RemoveAt) stays accepted (no over-reject).
+///   G7-OK-DICTREMOVE-BYKEY           — a composable-dict (Package.Data) Remove BY KEY stays accepted (the branch is list-only).
 /// </summary>
 public static class NestedCreateGuardProbe
 {
@@ -1033,6 +1048,66 @@ public static class NestedCreateGuardProbe
             Console.WriteLine($"   G4-OK-NOCTORARGS no ctor_args       : {(g4OkNoCtorArgsOk ? "PASS — a compose without ctor_args (the common case) is untouched" : $"FAIL — reject=[{reject}]")}");
         }
 
+        // ====== G7 — composable-element MERGE + non-plain-value Remove-BY-VALUE (the deferred-reject completion) ======
+        // The IsComposableElement deferred-reject block covered Add (compose/deferred) and ReplaceAll/SetAtIndex, but
+        // OMITTED Merge — a Package.Data Merge fell through to ACCEPT then threw 'No coercion rule' at apply. And a
+        // Remove BY VALUE (Key null) on ANY non-plain-value element (composable OR record — both have no plain-value
+        // form) likewise fell through then threw. The fix adds Merge to the composable deferred-reject and adds ONE
+        // unified Remove-by-value branch (predicate: list Remove, Key null, NOT formlink, NOT coercible) covering
+        // composable + record + the dormant uncoercible case by construction. A Remove BY INDEX (Key present) and a dict
+        // Remove BY KEY stay accepted (throw-free RemoveAt / key-gated). Closes the 2 matrix-critic cells + the record
+        // Remove-by-value twin found while implementing G6.
+
+        // ---------- G7-REJ-DICTMERGE: a Package.Data Merge (composable-valued dict) refuses (Merge now in the block) ----------
+        bool g7RejDictMergeOk;
+        {
+            var req = new WriteRequest { RecordType = "Package", Path = new[] { "Data" }, Verb = "Merge",
+                Entries = new Dictionary<string, string> { ["0"] = "x" } };
+            var reject = rulebook.Validate(req);
+            g7RejDictMergeOk = reject is not null && reject.Contains("Merge of modeled elements", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   G7-REJ-DICTMERGE composable merge   : {(g7RejDictMergeOk ? "PASS — a Package.Data Merge is refused (Merge folded into the composable deferred-reject; RED before: accepted then 'No coercion rule' at apply)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- G7-REJ-COMPOSABLE-REMOVE-BYVALUE: a struct-element list Remove-by-value refuses (remove by index) ----------
+        bool g7RejComposableRemoveOk;
+        {
+            var req = new WriteRequest { RecordType = "Faction", Path = new[] { "Ranks" }, Verb = "Remove", Value = "x" };
+            var reject = rulebook.Validate(req);
+            g7RejComposableRemoveOk = reject is not null && reject.Contains("BY INDEX", StringComparison.OrdinalIgnoreCase)
+                && reject.Contains("not by value", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   G7-REJ-COMPOSABLE-REMOVE-BYVALUE   : {(g7RejComposableRemoveOk ? "PASS — a struct-element Remove-by-value is refused, redirected to remove-by-index (RED before: accepted then 'No coercion rule' at apply)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- G7-REJ-RECORD-REMOVE-BYVALUE: a record-element list Remove-by-value refuses too (one unified branch) ----------
+        // The twin found while implementing G6: a record element ALSO has no plain-value form, so the SAME predicate
+        // (not coercible, not formlink) catches it. RED before: accepted then Coerce(value, IDialogResponsesGetter) threw.
+        bool g7RejRecordRemoveOk;
+        {
+            var req = new WriteRequest { RecordType = "DialogTopic", Path = new[] { "Responses" }, Verb = "Remove", Value = "x" };
+            var reject = rulebook.Validate(req);
+            g7RejRecordRemoveOk = reject is not null && reject.Contains("BY INDEX", StringComparison.OrdinalIgnoreCase)
+                && reject.Contains("not by value", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   G7-REJ-RECORD-REMOVE-BYVALUE       : {(g7RejRecordRemoveOk ? "PASS — a record-element Remove-by-value is refused too (the unified non-plain-value branch covers records)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- G7-OK-COMPOSABLE-REMOVE-BYINDEX: a struct-element Remove BY INDEX stays accepted (no over-reject) ----------
+        bool g7OkComposableRemoveIdxOk;
+        {
+            var req = new WriteRequest { RecordType = "Faction", Path = new[] { "Ranks" }, Verb = "Remove", Key = "0" };
+            var reject = rulebook.Validate(req);
+            g7OkComposableRemoveIdxOk = reject is null;
+            Console.WriteLine($"   G7-OK-COMPOSABLE-REMOVE-BYINDEX    : {(g7OkComposableRemoveIdxOk ? "PASS — a struct-element Remove by index (RemoveAt) is throw-free and NOT over-rejected" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- G7-OK-DICTREMOVE-BYKEY: a Package.Data Remove BY KEY stays accepted (the Remove-by-value branch is list-only) ----------
+        bool g7OkDictRemoveKeyOk;
+        {
+            var req = new WriteRequest { RecordType = "Package", Path = new[] { "Data" }, Verb = "Remove", Key = "0" };
+            var reject = rulebook.Validate(req);
+            g7OkDictRemoveKeyOk = reject is null;
+            Console.WriteLine($"   G7-OK-DICTREMOVE-BYKEY composable  : {(g7OkDictRemoveKeyOk ? "PASS — a composable-dict Remove by key (key-gated, throw-free) is NOT over-rejected" : $"FAIL — reject=[{reject}]")}");
+        }
+
         Console.WriteLine();
         bool pass = fixturesOk && oneshotOk && multiOk && intoTopicOk && intoCellOk
                     && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendOk
@@ -1047,7 +1122,8 @@ public static class NestedCreateGuardProbe
                     && gap2RejDictAddOk && gap2RejListAddOk && gap2RejListReplaceAllOk && gap2RejListRemoveOk && gap2RejDictMergeOk
                     && gap2OkValidOk && gap2OkRemoveByIndexOk && gap2FormlinkRouteOk && gap2RejE2eOk
                     && g6RejRecordAddOk && g6RejRecordReplaceAllOk && g6OkRemoveByIndexOk && g6OkStructUnchangedOk && g6RejE2eOk
-                    && g4RejCtorArgShapeOk && g4RejCtorArgArityOk && g4OkCtorArgOk && g4OkNoCtorArgsOk;
+                    && g4RejCtorArgShapeOk && g4RejCtorArgArityOk && g4OkCtorArgOk && g4OkNoCtorArgsOk
+                    && g7RejDictMergeOk && g7RejComposableRemoveOk && g7RejRecordRemoveOk && g7OkComposableRemoveIdxOk && g7OkDictRemoveKeyOk;
         Console.WriteLine($"=== nested-create-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return pass ? 0 : 1;


### PR DESCRIPTION
## What

Closes the **remaining write pre-flight gate/apply drift class** — every place where the pre-flight gate would *accept* a write that the apply path then *throws* on (the Q3 "accept-then-throw" hole), plus a couple of newly-found cells. After this, the gate rejects **exactly** what apply throws on, for every live collection cell.

This is **PR-A** from the gap-audit (`dev/plans/WRITE_PREFLIGHT_GAP_AUDIT_2026-06-18.md`). It is the named follow-on to the PR #76–#79 "presence → shape" series. By-construction throughout — no per-record-type lists, no generator change, no new tool (surface stays **21**), §4-(a) (the PRFAQ holds; clean fix exists).

## Commits (atomic, each RED-proven then green-confirmed)

| Commit | Gap | Closes |
|---|---|---|
| Gap 1 | mid-path dict-key value-shape | `ValidateFromType` dict mid-path hop passed no AQ to `CheckValue` → missed the lone non-enum key (`Package.Data` = `Dictionary<sbyte,…>`); `Data[notasbyte].…` was accepted then threw `FormatException`. Now passes `DictKeyType(field)?.AssemblyQualifiedName` — same recognizer pair as the PR #79 leaf check, so mid-path and leaf can't drift. |
| Gap 2 | non-formlink coercible element value-shape | A malformed coercible element value (e.g. `notafloat` into `List<Single>`, `notabyte` into `Dictionary<Skill,Byte>`) on list Add/SetAtIndex/ReplaceAll/Remove-by-value + dict Add/Merge/ReplaceAll passed then threw unnamed. New `ValueLegality` step-4b mirrors the dict-Set value `CheckValue`, scoped to coercible-non-formlink elements, **verb/key-faithful** to which slot apply actually coerces. |
| G6 | record-element collection verbs | Add/SetAtIndex/ReplaceAll on a record-element list (e.g. `DialogTopic.Responses`) fell through to accept then threw `CompositionRequiredException` (named-but-**misleading**). Now redirects to `housecarl_create_record`/`housecarl_bulk_create` with `parent=`, by one `ClassifyElement==Record` predicate. |
| G4 | compose `ctor_args` shape + arity | `ctor_args` flowed to apply with **zero** validation; a malformed arg threw unnamed (`Enum.Parse`), a wrong arity threw at apply. New `WriteEngine.TryRecognizeCtorArgs` mirrors `Instantiate` exactly (same `ResolveStructType` + ctor selector + `TryCoerce` per arg), called from `StructSpecContents`. The one gap whose recognizer is new — but composed from existing engine primitives. |
| G7 | composable `Merge` + non-plain-value `Remove`-by-value | The composable deferred-reject omitted `Merge` (a `Package.Data` Merge threw "No coercion rule"); and a `Remove`-by-value on any non-plain-value element (composable **or** record) threw the same. Folds `Merge` in + adds ONE unified by-construction Remove-by-value branch. |
| review polish | slot-faithfulness + comment | cardinality-scopes the step-4b ReplaceAll/Merge loops (a stray off-cardinality slot apply ignores was over-rejected) + a comment fix. |

## Scope grew beyond the plan's 4 documented gaps — by design

A pre-implementation **verification sweep** (matrix-completeness critic) found **2 accept-then-throw cells the audit's "authoritative list" had missed** (`Package.Data Merge` — the §2 matrix had even mis-labelled it "both reject"; and composable-list `Remove`-by-value). A **3rd** (record-list `Remove`-by-value) surfaced while implementing G6. All three are the same hardening class (not new capabilities), approved for inclusion, and closed in G7 — so the class is closed more completely than the original plan.

## Review

A post-implementation **adversarial review** (independent lenses + adversarial verification of each finding) returned **6 confirmed findings, 0 blockers**. Its completeness critic independently re-walked the full verb × cardinality × element-kind matrix against the corpus and confirmed the **accept-then-throw class is CLOSED for every live collection cell** (remaining unhandled arms — Unknown/ScalarUncoercible kinds, formlink-valued dicts, record-valued dicts — are dormant-by-construction with zero live corpus fields, and fail loud + named). The two actionable findings are fixed in the review-polish commit.

**Two findings left deliberately** (both are over-rejects — the *safe* direction, never a Q3 hole):
- **substruct `Set`-with-compose** over-reject — **pre-existing** (predates this PR), already documented in plan §3(b). Out of scope.
- **null `String` entry** inside a ReplaceAll/Merge slot is rejected though apply's `Coerce(null,string)` would accept it — degenerate input, and consistent with PR #77's deliberate uniform null-coercible-value rejection. Relaxing it only for text would make the gate inconsistent with the single-value rule.

## Verification

- `nested-create-guard`: **68 arms, all PASS** (was 40; +28 new, each RED-proven before its fix). Arms extend the existing probe in place — **no new CI step**.
- `vmad-poly-guard`, `value-predicate-guard` (31/0), `poly-field-descend-guard`, `nullarm-guard`, `coerce-audit` all re-run green — no regressions.

## Out of scope

**Gap 3** (dict-element COMPOSITION — the lone new *capability*, AI-package data authoring) is **PR-B**, separate, rebased on this after it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


