### PR TITLE
write pre-flight: reject composing a polymorphic base by its own name (G8)

### DIFF
--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -660,7 +660,17 @@ public sealed class CorpusRulebook
     string? ArmLegality(FieldSchema leaf, StructSpec? arm)
     {
         if (arm is null) return $"Set on polymorphic field '{leaf.Name}' requires an arm (which arm + its data).";
-        var legal = leaf.Arms ?? (leaf.TypeRef is { } tr ? Type(tr)?.Arms : null) ?? new();
+        // (G8) The standalone-poly-FIELD twin of the StructElementLegality base-reject. A CONCRETE poly-base (e.g.
+        // ScriptFragments on DialogResponsesAdapter.ScriptFragments) lists ITSELF among its arms, so legal.Contains(base)
+        // would otherwise admit a Set composing the base by its OWN name, and apply then SILENTLY writes a degenerate
+        // base instance. Filter the base (leaf.TypeRef — this method is only reached for a polymorphic field) out of the
+        // legal set, and reject composing the base itself. Symmetric with StructElementLegality; closes the SECOND
+        // composition entry point so the poly-base-by-own-name class is shut at both, by construction.
+        var baseName = leaf.TypeRef;
+        var legal = (leaf.Arms ?? (baseName is { } tr ? Type(tr)?.Arms : null) ?? new()).Where(a => a != baseName).ToList();
+        if (baseName is not null && arm.Type == baseName)
+            return $"'{arm.Type}' is the polymorphic base of '{leaf.Name}' — the base itself cannot be composed; " +
+                   $"choose a concrete arm. Legal arms: {string.Join(", ", legal)}.";
         if (!legal.Contains(arm.Type))
             return $"Illegal arm '{arm.Type}' for '{leaf.Name}'. Legal arms: {string.Join(", ", legal)}.";
         var armSchema = Type(arm.Type);

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -572,15 +572,34 @@ public sealed class CorpusRulebook
         var elemSchema = Type(er);
         if (elemSchema is null) return $"Element type '{er}' for '{leaf.Name}' absent from corpus.";
 
+        // (G8) A polymorphic BASE is composed by choosing a concrete ARM, never the base itself. Naming the base
+        // ({Type:"APackageData"} on the Package.Data dict, {Type:"Condition"} on a *.Conditions list) is a gate/apply
+        // drift the validator must reject: the spec.Type==er short-circuit below would validate it against the base's
+        // OWN fields and ACCEPT, then apply either SILENTLY writes a degenerate base instance (a CONCRETE base like
+        // APackageData — Instantiate finds its public parameterless ctor: a Q3 silent-wrong-write) or THROWS at Invoke
+        // ("cannot create an abstract class" — an ABSTRACT base like Condition). The recognizer is the corpus poly-base
+        // KIND, NOT Type.IsAbstract: APackageData is concrete (IsAbstract=false), so an IsAbstract check would miss the
+        // silent-write case — the worse one. A concrete poly-base also lists ITSELF among its arms (FindUnionArms keeps
+        // a non-abstract base), so the base is filtered out of the legal-arms set everywhere it is used (the arm-match
+        // check AND every message) — neither path can admit or advertise it. Generic over every poly-base; no per-type wiring.
+        bool isPolyBase = elemSchema is { Kind: "polymorphic-base" };
+        var legalArms = (elemSchema.Arms ?? new()).Where(a => a != er).ToList();
+
         TypeSchema specSchema;
-        if (spec.Type == er) specSchema = elemSchema;
-        else if (elemSchema is { Kind: "polymorphic-base", Arms: { Count: > 0 } arms } && arms.Contains(spec.Type))
+        if (spec.Type == er)
+        {
+            if (isPolyBase)
+                return $"'{spec.Type}' is the polymorphic base of '{leaf.Name}' — the base itself cannot be composed; " +
+                       $"choose a concrete arm. Legal element types: {string.Join(", ", legalArms)}.";
+            specSchema = elemSchema;   // a concrete (non-poly-base) struct element composed by its own name — the normal case
+        }
+        else if (isPolyBase && legalArms.Contains(spec.Type))
             specSchema = Type(spec.Type)
                 ?? throw new InvalidOperationException($"Arm '{spec.Type}' of '{er}' is listed but absent from the corpus — regenerate corpus.json.");
         else
         {
-            var legal = elemSchema is { Kind: "polymorphic-base", Arms: { Count: > 0 } a }
-                ? $" Legal element types: {string.Join(", ", a)}." : "";
+            var legal = isPolyBase && legalArms.Count > 0
+                ? $" Legal element types: {string.Join(", ", legalArms)}." : "";
             return $"Element spec type '{spec.Type}' does not match '{leaf.Name}' element type '{er}'.{legal}";
         }
         return StructSpecContents(spec, specSchema);

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -223,18 +223,25 @@ namespace HousecarlGenerator;
 /// Instantiate()s a degenerate empty base and SILENTLY WRITES IT (a Q3 silent-wrong-write, WORSE than a throw); an
 /// ABSTRACT base (Condition) throws MemberAccessException at Invoke. A CONCRETE poly-base also lists ITSELF among its arms
 /// (FindUnionArms keeps it; only an ABSTRACT base like Condition is filtered by !IsAbstract), so the arms.Contains branch
-/// would admit it too and GAP3-REJ-BADARM's message advertised it. The fix rejects spec.Type==er when er is a poly-base
-/// (recognizer = corpus KIND, NOT Type.IsAbstract — APackageData is concrete, so IsAbstract would miss the silent-write
-/// case) and filters the base out of the legal-arms set everywhere (Contains + every message). By construction over every
-/// poly-base family, no per-type wiring; concrete non-poly-base structs composed by their own name still accept:
+/// would admit it too and GAP3-REJ-BADARM's message advertised it. The fix rejects composing the base by its own name and
+/// filters the base out of the legal-arms set everywhere (Contains + every message) at BOTH composition entry points —
+/// StructElementLegality (collection elements: the 4 self-listing bases APackageData/BaseLayer/CellBlock/ScriptProperty)
+/// AND its sibling ArmLegality (standalone polymorphic FIELDS: DialogResponsesAdapter.ScriptFragments,
+/// GenderedItem&lt;SimpleModel&gt; — the twin found in a completeness sweep, folded in Aaron 2026-06-18). Recognizer = corpus
+/// poly-base KIND, NOT Type.IsAbstract (APackageData is concrete, so IsAbstract would miss the silent-write case). By
+/// construction over every poly-base family, no per-type wiring, no generator/corpus change; a concrete non-poly-base
+/// struct composed by its own name still accepts:
 ///   GAP3-REJ-BASEARM         — a Package.Data Add composing the base 'APackageData' itself refuses, offering the concrete
 ///                              arms (RED before: accepted via the spec.Type==er short-circuit).
 ///   GAP3-REJ-BASEARM-LIST    — the LIST twin (Faction.Conditions Add {Type:"Condition"}) refuses too — proves the fix is
 ///                              in the SHARED validator and catches an ABSTRACT base by the same check. RED before: accepted.
 ///   GAP3-OK-BASE-NOOVERREJECT— a CONCRETE struct element composed by its own name (Faction.Ranks element 'Rank', Kind=struct)
 ///                              STILL accepts — only poly-bases are rejected, not every spec.Type==er. Accepted before AND after.
-///   GAP3-REJ-BASEARM-E2E     — composing the base refuses end-to-end with NO file written; the PRE-FLIGHT 'polymorphic base'
-///                              message (not the apply CompositionRequiredException) proves the gate fired before BuildStruct.
+///   GAP3-REJ-BASEARM-E2E     — composing the base refuses end-to-end with NO file written; RED here was the WORST case (the
+///                              concrete base is instantiable, so it SILENTLY wrote a degenerate entry) — GREEN: gate rejects, no file.
+///   GAP3-REJ-BASEARM-FIELD   — the ArmLegality twin: a standalone poly-FIELD Set composing the base
+///                              (DialogResponses.VirtualMachineAdapter.ScriptFragments {Type:"ScriptFragments"}) refuses. RED before: accepted.
+///   GAP3-OK-ARMFIELD-UNCHANGED— a REAL arm ('SceneScriptFragments') on that poly field still accepts (no over-reject). Before AND after.
 ///   (GAP3-REJ-BADARM strengthened: its 'Legal element types' list no longer names the un-composable base 'APackageData'.)
 /// </summary>
 public static class NestedCreateGuardProbe
@@ -1371,6 +1378,34 @@ public static class NestedCreateGuardProbe
             },
             msg => msg.Contains("polymorphic base", StringComparison.OrdinalIgnoreCase));
 
+        // ---------- GAP3-REJ-BASEARM-FIELD: the STANDALONE poly-FIELD twin (ArmLegality, NOT StructElementLegality) ----
+        // A Set on a polymorphic FIELD (not a collection element) composing the base by name hits the SIBLING validator
+        // ArmLegality, which had the IDENTICAL hole: a concrete poly-base (ScriptFragments on
+        // DialogResponsesAdapter.ScriptFragments) self-lists, so legal.Contains(base) admitted it then apply silently
+        // wrote a degenerate base. Found in a completeness sweep, folded in (Aaron 2026-06-18) so the poly-base-by-own-name
+        // class is closed at BOTH composition entry points by construction. Path: DialogResponses -> VirtualMachineAdapter
+        // (the VMAD substruct) -> ScriptFragments (polymorphic leaf).
+        bool gap3RejBaseArmFieldOk;
+        {
+            var req = new WriteRequest { RecordType = "DialogResponses", Path = new[] { "VirtualMachineAdapter", "ScriptFragments" },
+                Verb = "Set", Struct = new StructSpec { Type = "ScriptFragments" } };
+            var reject = rulebook.Validate(req);
+            gap3RejBaseArmFieldOk = reject is not null
+                && reject.Contains("polymorphic base", StringComparison.OrdinalIgnoreCase)
+                && reject.Contains("SceneScriptFragments", StringComparison.Ordinal);   // a real arm is offered instead
+            Console.WriteLine($"   GAP3-REJ-BASEARM-FIELD poly field  : {(gap3RejBaseArmFieldOk ? "PASS — a standalone poly-FIELD Set composing the base 'ScriptFragments' refuses via ArmLegality (RED before: accepted, then silent-write)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- GAP3-OK-ARMFIELD-UNCHANGED: a REAL arm on the same poly field still accepts (no over-reject) ----------
+        bool gap3OkArmFieldUnchangedOk;
+        {
+            var req = new WriteRequest { RecordType = "DialogResponses", Path = new[] { "VirtualMachineAdapter", "ScriptFragments" },
+                Verb = "Set", Struct = new StructSpec { Type = "SceneScriptFragments" } };
+            var reject = rulebook.Validate(req);
+            gap3OkArmFieldUnchangedOk = reject is null;
+            Console.WriteLine($"   GAP3-OK-ARMFIELD-UNCHANGED real arm: {(gap3OkArmFieldUnchangedOk ? "PASS — a real arm ('SceneScriptFragments') on the poly field still accepts (filtering the base didn't break real arms)" : $"FAIL — reject=[{reject}]")}");
+        }
+
         Console.WriteLine();
         bool pass = fixturesOk && oneshotOk && multiOk && intoTopicOk && intoCellOk
                     && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendOk
@@ -1389,7 +1424,8 @@ public static class NestedCreateGuardProbe
                     && g7RejDictMergeOk && g7RejComposableRemoveOk && g7RejRecordRemoveOk && g7OkComposableRemoveIdxOk && g7OkDictRemoveKeyOk
                     && gap3OkDictAddComposeOk && gap3OkDictSetComposeOk && gap3RejBadArmOk && gap3OkListUnchangedOk
                     && gap3OkE2eOk && gap3OkE2eSetOk && gap3RejDupOk
-                    && gap3RejBaseArmOk && gap3RejBaseArmListOk && gap3OkBaseNoOverRejectOk && gap3RejBaseArmE2eOk;
+                    && gap3RejBaseArmOk && gap3RejBaseArmListOk && gap3OkBaseNoOverRejectOk && gap3RejBaseArmE2eOk
+                    && gap3RejBaseArmFieldOk && gap3OkArmFieldUnchangedOk;
         Console.WriteLine($"=== nested-create-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return pass ? 0 : 1;

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -214,6 +214,28 @@ namespace HousecarlGenerator;
 ///   GAP3-E2E                 — a composed PackageDataBool(Data=true) round-trips through the real create+apply path onto Package.Data[0] on disk.
 ///   GAP3-E2E-SET             — the Set-OVERWRITE apply branch round-trips: Add Data[0]=false then Set Data[0]=true reads Data==true on disk (the dup escape hatch).
 ///   GAP3-REJ-DUP             — an Add of an already-present key refuses (apply-time) end-to-end, NO file written, naming Set as the overwrite path.
+///
+/// G8 — the polymorphic BASE composed by its OWN name (PR-B review finding; PRE-EXISTING, shared list+dict). A compose
+/// naming the base itself ({Type:"APackageData"} on Package.Data, {Type:"Condition"} on a *.Conditions list) hit
+/// StructElementLegality's `if (spec.Type == er) specSchema = elemSchema` short-circuit, validated against the base's OWN
+/// fields, and ACCEPTED — then apply DIVERGED by base kind (verified by reflection, correcting the PR-B note's
+/// 'CompositionRequiredException' guess): a CONCRETE base (APackageData, IsAbstract=false, public parameterless ctor)
+/// Instantiate()s a degenerate empty base and SILENTLY WRITES IT (a Q3 silent-wrong-write, WORSE than a throw); an
+/// ABSTRACT base (Condition) throws MemberAccessException at Invoke. A CONCRETE poly-base also lists ITSELF among its arms
+/// (FindUnionArms keeps it; only an ABSTRACT base like Condition is filtered by !IsAbstract), so the arms.Contains branch
+/// would admit it too and GAP3-REJ-BADARM's message advertised it. The fix rejects spec.Type==er when er is a poly-base
+/// (recognizer = corpus KIND, NOT Type.IsAbstract — APackageData is concrete, so IsAbstract would miss the silent-write
+/// case) and filters the base out of the legal-arms set everywhere (Contains + every message). By construction over every
+/// poly-base family, no per-type wiring; concrete non-poly-base structs composed by their own name still accept:
+///   GAP3-REJ-BASEARM         — a Package.Data Add composing the base 'APackageData' itself refuses, offering the concrete
+///                              arms (RED before: accepted via the spec.Type==er short-circuit).
+///   GAP3-REJ-BASEARM-LIST    — the LIST twin (Faction.Conditions Add {Type:"Condition"}) refuses too — proves the fix is
+///                              in the SHARED validator and catches an ABSTRACT base by the same check. RED before: accepted.
+///   GAP3-OK-BASE-NOOVERREJECT— a CONCRETE struct element composed by its own name (Faction.Ranks element 'Rank', Kind=struct)
+///                              STILL accepts — only poly-bases are rejected, not every spec.Type==er. Accepted before AND after.
+///   GAP3-REJ-BASEARM-E2E     — composing the base refuses end-to-end with NO file written; the PRE-FLIGHT 'polymorphic base'
+///                              message (not the apply CompositionRequiredException) proves the gate fired before BuildStruct.
+///   (GAP3-REJ-BADARM strengthened: its 'Legal element types' list no longer names the un-composable base 'APackageData'.)
 /// </summary>
 public static class NestedCreateGuardProbe
 {
@@ -1206,9 +1228,13 @@ public static class NestedCreateGuardProbe
             var req = new WriteRequest { RecordType = "Package", Path = new[] { "Data" }, Verb = "Add", Key = "0",
                 Struct = new StructSpec { Type = "Weapon" } };
             var reject = rulebook.Validate(req);
+            // (G8) the un-composable base must NOT appear in the 'Legal element types:' list it names — scoped to the
+            // list portion, since 'APackageData' legitimately appears earlier as the element-type context of the mismatch.
+            int g3LegalAt = reject?.IndexOf("Legal element types:", StringComparison.Ordinal) ?? -1;
+            string g3LegalList = g3LegalAt >= 0 ? reject![g3LegalAt..] : "";
             gap3RejBadArmOk = reject is not null && reject.Contains("does not match", StringComparison.OrdinalIgnoreCase)
-                && reject.Contains("Legal element types", StringComparison.OrdinalIgnoreCase);
-            Console.WriteLine($"   GAP3-REJ-BADARM bad compose arm    : {(gap3RejBadArmOk ? "PASS — a non-APackageData compose type is refused, naming the legal arms (RED before: rejected 'later surface', wrong reason)" : $"FAIL — reject=[{reject}]")}");
+                && g3LegalAt >= 0 && !g3LegalList.Contains("APackageData", StringComparison.Ordinal);
+            Console.WriteLine($"   GAP3-REJ-BADARM bad compose arm    : {(gap3RejBadArmOk ? "PASS — a non-APackageData compose type is refused, naming the legal arms but NOT the base 'APackageData' in the legal list (G8 filter; RED before G8: the base was advertised)" : $"FAIL — reject=[{reject}]")}");
         }
 
         // ---------- GAP3-OK-LIST-UNCHANGED: an ARM-element LIST compose (Faction.Conditions) still composes (no regression) ----------
@@ -1282,6 +1308,69 @@ public static class NestedCreateGuardProbe
             },
             msg => msg.Contains("already present", StringComparison.OrdinalIgnoreCase) && msg.Contains("use Set", StringComparison.OrdinalIgnoreCase));
 
+        // ====== G8 — the polymorphic BASE composed by its OWN name (the gate/apply drift this batch exists to kill) ======
+        // StructElementLegality short-circuits `if (spec.Type == er) specSchema = elemSchema` — so composing the poly-BASE
+        // itself ({Type:"APackageData"} on the Package.Data dict, {Type:"Condition"} on a *.Conditions list) validated
+        // against the base's OWN fields and ACCEPTED, then apply DIVERGED by base kind (verified by reflection): a CONCRETE
+        // base (APackageData, IsAbstract=false, has a public parameterless ctor) Instantiate()s a degenerate empty base and
+        // SILENTLY WRITES IT — a Q3 silent-wrong-write, WORSE than a throw; an ABSTRACT base (Condition) throws
+        // MemberAccessException ("cannot create an abstract class") at Invoke. A CONCRETE poly-base ALSO lists itself among
+        // its arms (FindUnionArms keeps a non-abstract base — only an abstract one is filtered by !IsAbstract), so the
+        // arms.Contains branch would admit it too and the bad-arm message advertised it. The recognizer is the corpus
+        // poly-base KIND, NOT Type.IsAbstract — APackageData is concrete, so IsAbstract would miss the silent-write (worse)
+        // case. The base is rejected when named, and filtered out of the legal-arms set everywhere (Contains + message).
+
+        // ---------- GAP3-REJ-BASEARM: a Package.Data Add composing the BASE 'APackageData' itself refuses ----------
+        bool gap3RejBaseArmOk;
+        {
+            var req = new WriteRequest { RecordType = "Package", Path = new[] { "Data" }, Verb = "Add", Key = "0",
+                Struct = new StructSpec { Type = "APackageData" } };
+            var reject = rulebook.Validate(req);
+            gap3RejBaseArmOk = reject is not null
+                && reject.Contains("polymorphic base", StringComparison.OrdinalIgnoreCase)
+                && reject.Contains("PackageDataBool", StringComparison.Ordinal);   // a real arm is offered instead
+            Console.WriteLine($"   GAP3-REJ-BASEARM compose the base  : {(gap3RejBaseArmOk ? "PASS — composing the poly-base 'APackageData' itself refuses, offering the concrete arms (RED before: accepted via the spec.Type==er short-circuit)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- GAP3-REJ-BASEARM-LIST: the LIST twin — Faction.Conditions Add {Type:"Condition"} refuses ----------
+        // Proves the fix lives in the SHARED StructElementLegality (list + dict), and catches an ABSTRACT base (Condition,
+        // NOT in its own arms) by the same spec.Type==er + poly-base check the concrete APackageData hits.
+        bool gap3RejBaseArmListOk;
+        {
+            var req = new WriteRequest { RecordType = "Faction", Path = new[] { "Conditions" }, Verb = "Add",
+                Struct = new StructSpec { Type = "Condition" } };
+            var reject = rulebook.Validate(req);
+            gap3RejBaseArmListOk = reject is not null
+                && reject.Contains("polymorphic base", StringComparison.OrdinalIgnoreCase)
+                && reject.Contains("ConditionFloat", StringComparison.Ordinal);
+            Console.WriteLine($"   GAP3-REJ-BASEARM-LIST list base    : {(gap3RejBaseArmListOk ? "PASS — composing the poly-base 'Condition' on a list refuses too (shared validator; RED before: accepted)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- GAP3-OK-BASE-NOOVERREJECT: a CONCRETE (non-poly-base) struct composed by its own name STILL accepts ----
+        // The no-over-reject guard: the fix rejects spec.Type==er ONLY when er is a poly-base. A plain struct element
+        // (Faction.Ranks element 'Rank', Kind=struct) composed by its own name is the NORMAL case and must stay accepted.
+        bool gap3OkBaseNoOverRejectOk;
+        {
+            var req = new WriteRequest { RecordType = "Faction", Path = new[] { "Ranks" }, Verb = "Add",
+                Struct = new StructSpec { Type = "Rank" } };
+            var reject = rulebook.Validate(req);
+            gap3OkBaseNoOverRejectOk = reject is null;
+            Console.WriteLine($"   GAP3-OK-BASE-NOOVERREJECT struct   : {(gap3OkBaseNoOverRejectOk ? "PASS — a concrete struct element composed by its own name ('Rank') still accepts (only poly-bases rejected)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- GAP3-REJ-BASEARM-E2E: composing the base end-to-end refuses with NO file written (gate, not apply) ----
+        // The silent-wrong-write closed end-to-end: APackageData is concrete + instantiable, so RED here was the WORST case
+        // — the create SUCCEEDED and a degenerate empty-base entry was WRITTEN with no error (refused=False, noFile=False).
+        // GREEN: the gate rejects pre-flight ('polymorphic base'), so NO file is written and BuildStruct never runs.
+        bool gap3RejBaseArmE2eOk = RejectArm("GAP3-REJ-BASEARM-E2E compose base  ", tmpDir, "Gap3Base", mPath, rulebook,
+            new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "Package", EditorId = "HcNcGap3Base",
+                    Edits = new[] { new WriteRequest { RecordType = "Package", Path = new[] { "Data" }, Verb = "Add", Key = "0",
+                        Struct = new StructSpec { Type = "APackageData" } } } },
+            },
+            msg => msg.Contains("polymorphic base", StringComparison.OrdinalIgnoreCase));
+
         Console.WriteLine();
         bool pass = fixturesOk && oneshotOk && multiOk && intoTopicOk && intoCellOk
                     && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendOk
@@ -1299,7 +1388,8 @@ public static class NestedCreateGuardProbe
                     && g4RejCtorArgShapeOk && g4RejCtorArgArityOk && g4OkCtorArgOk && g4OkNoCtorArgsOk && g4RejCtorArgE2eOk
                     && g7RejDictMergeOk && g7RejComposableRemoveOk && g7RejRecordRemoveOk && g7OkComposableRemoveIdxOk && g7OkDictRemoveKeyOk
                     && gap3OkDictAddComposeOk && gap3OkDictSetComposeOk && gap3RejBadArmOk && gap3OkListUnchangedOk
-                    && gap3OkE2eOk && gap3OkE2eSetOk && gap3RejDupOk;
+                    && gap3OkE2eOk && gap3OkE2eSetOk && gap3RejDupOk
+                    && gap3RejBaseArmOk && gap3RejBaseArmListOk && gap3OkBaseNoOverRejectOk && gap3RejBaseArmE2eOk;
         Console.WriteLine($"=== nested-create-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return pass ? 0 : 1;


### PR DESCRIPTION
Closes **G8** from the write pre-flight gap audit (`dev/plans/WRITE_PREFLIGHT_GAP_AUDIT_2026-06-18.md` §8) — composing a polymorphic **base** by its own name (`{Type:"APackageData"}` on the `Package.Data` dict, `{Type:"Condition"}` on a `*.Conditions` list). PR-B (#81) made it newly reachable for the dict; the hole pre-dated it on the list path.

## §4 correction — the bug is *worse* than the ledger said (verified by reflection)
The PR-B review note called G8 "accept-then-**throw**, fails loud." Reflection shows that's only true for an **abstract** base (`Condition` → `MemberAccessException`). For the **concrete** base `APackageData` (the headline `Package.Data`/AI-package case): `IsAbstract=false` + a public parameterless ctor, so apply **silently writes a degenerate empty base instance, no error** — a Q3 silent-wrong-write, the worst class. This *vindicates* the recognizer choice (corpus poly-base **Kind**, not `Type.IsAbstract`, which would have missed the concrete/silent case).

## The fix (by construction, both composition entry points)
Reject composing the base by its own name + filter the base out of the legal-arms set everywhere (the arm-match check **and** every message), in:
- **`StructElementLegality`** (commit 1) — collection elements. Covers the 4 self-listing element bases: `APackageData` (dict), `BaseLayer`, `CellBlock`, `ScriptProperty` (lists; `ScriptProperty` = the VMAD shape).
- **`ArmLegality`** (commit 2) — standalone polymorphic *fields*. A completeness sweep found the identical hole here, live for `DialogResponsesAdapter.ScriptFragments` and `GenderedItem<SimpleModel>.Male/Female`. Folded in (Aaron-approved) so the whole class lands in one PR.

Generic over every poly-base family; **no per-type wiring, no generator/corpus change**. A concrete non-poly-base struct composed by its own name still accepts. §4-(a).

## Why not the generator
The "clean" generator fix (stop self-listing the base in `FindUnionArms`) **changes coverage semantics** and is rejected per the audit's STOP condition: `ScriptFragments` and `SimpleModel` have only **one real arm** besides the self-listed base, so removing the base drops them below the generator's `arms.Count > 1` poly-base threshold → reclassified poly-base→plain-struct, losing `SceneScriptFragments`/`Model` as composable arms. The gate fix neutralizes the cosmetic corpus wart with zero corpus blast radius.

## Guard
`nested-create-guard` **75 → 81** arms (RED-proven then green; no new CI step): `GAP3-REJ-BASEARM`, `GAP3-REJ-BASEARM-LIST`, `GAP3-OK-BASE-NOOVERREJECT`, `GAP3-REJ-BASEARM-E2E`, `GAP3-REJ-BASEARM-FIELD`, `GAP3-OK-ARMFIELD-UNCHANGED`, plus `GAP3-REJ-BADARM` strengthened to prove the base is filtered from the legal-arms message. Full local suite green (`vmad-poly-guard`, `value-predicate-guard`, `poly-field-descend-guard`, `nullarm-guard`, `sameshape-agree-guard`, `coerce-audit`); clean build, 0 warnings. Tool surface stays 21; no new tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)