### PR TITLE
write: render expected apply rejections (the whole live-state class) cleanly, not as inconsistencies (gap-audit Finding 3)

### DIFF
--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1783,13 +1783,28 @@ public static class WriteEngine
                     new[] { req.Struct is not null ? BuildStruct(req.Struct) : Coerce(req.Value!, elem) });
                 break;
             case "SetAtIndex":
-                Indexer(lt).GetSetMethod()!.Invoke(list,
-                    new[] { (object)int.Parse(req.Key!, CultureInfo.InvariantCulture), Coerce(req.Value!, elem) });
+            {
+                // EXPECTED apply rejection (live length): pre-flight gates the index SHAPE (parseable non-negative int)
+                // but leaves the in-range bound to apply — it has no live collection to know the length (KEYSHAPE / gap-
+                // audit Finding 3). Pre-check it so an out-of-range index surfaces as clean guidance, not a reflection-
+                // wrapped ArgumentOutOfRangeException under the "real inconsistency" wrapper.
+                int idx = int.Parse(req.Key!, CultureInfo.InvariantCulture);
+                int count = CollectionCount(list);
+                if (idx < 0 || idx >= count)
+                    throw new ExpectedApplyRejectionException(IndexRangeMessage(prop.Name, idx, count, append: true));
+                Indexer(lt).GetSetMethod()!.Invoke(list, new[] { (object)idx, Coerce(req.Value!, elem) });
                 break;
+            }
             case "Remove":
                 if (req.Key is not null)
-                    lt.GetMethod("RemoveAt", new[] { typeof(int) })!
-                        .Invoke(list, new object[] { int.Parse(req.Key, CultureInfo.InvariantCulture) });
+                {
+                    // Same EXPECTED out-of-range rejection for Remove-by-index (RemoveAt) — clean, not the wrapper.
+                    int idx = int.Parse(req.Key, CultureInfo.InvariantCulture);
+                    int count = CollectionCount(list);
+                    if (idx < 0 || idx >= count)
+                        throw new ExpectedApplyRejectionException(IndexRangeMessage(prop.Name, idx, count, append: false));
+                    lt.GetMethod("RemoveAt", new[] { typeof(int) })!.Invoke(list, new object[] { idx });
+                }
                 else
                     lt.GetMethod("Remove", new[] { elem })!.Invoke(list, new[] { Coerce(req.Value!, elem) });
                 break;
@@ -1802,6 +1817,27 @@ public static class WriteEngine
                 throw new InvalidOperationException($"Verb '{req.Verb}' is not valid on list '{prop.Name}'.");
         }
     }
+
+    /// <summary>Element count of a (possibly Mutagen <c>ExtendedList&lt;T&gt;</c>) collection WITHOUT assuming the
+    /// non-generic <c>ICollection</c> — enumerate, mirroring <see cref="StepIntoElement"/>'s index walk. Used to
+    /// pre-check a list index against live length so an out-of-range SetAtIndex/Remove-by-index surfaces as an
+    /// <see cref="ExpectedApplyRejectionException"/> (clean, live-state user error) rather than a reflection-wrapped
+    /// <c>ArgumentOutOfRangeException</c> under the gate/apply-inconsistency wrapper.</summary>
+    static int CollectionCount(object coll)
+    {
+        int n = 0;
+        foreach (var _ in (System.Collections.IEnumerable)coll) n++;
+        return n;
+    }
+
+    /// <summary>The clean out-of-range message for a list index op. <paramref name="append"/> adds the "or Add to
+    /// append" hint for SetAtIndex (Remove can't append); the empty-list case names the right next step for each.</summary>
+    static string IndexRangeMessage(string field, int idx, int count, bool append) =>
+        count == 0
+            ? $"Index {idx} out of range for '{field}' — the list is empty"
+              + (append ? "; Add an element first." : "; nothing to remove.")
+            : $"Index {idx} out of range for '{field}' (it has {count} element(s)) — use an index in 0..{count - 1}"
+              + (append ? ", or Add to append a new element." : ".");
 
     /// <summary>Materialize an absent (null) optional collection so a first element/entry can be added. Instantiates
     /// the property's declared concrete collection type (Mutagen's settable ExtendedList&lt;T&gt; / dictionary) and
@@ -1856,7 +1892,7 @@ public static class WriteEngine
             return StepIntoGenderedArm(parent, prop, name, key, materialize);
 
         var coll = prop.GetValue(parent)
-            ?? throw new InvalidOperationException(
+            ?? throw new ExpectedApplyRejectionException(   // live-state: empty/absent collection — clean, not the inconsistency wrapper
                 $"Cannot navigate into '{name}[{key}]': the collection is absent (null). Add an element first " +
                 "(element composition — wave 1 half B), then navigate into it.");
 
@@ -1871,7 +1907,7 @@ public static class WriteEngine
             var dt = coll.GetType();
             var contains = dt.GetMethod("ContainsKey", new[] { kType });
             if (contains is not null && contains.Invoke(coll, new[] { keyObj }) is false)
-                throw new InvalidOperationException($"No entry with key '{key}' in dict '{name}'.");
+                throw new ExpectedApplyRejectionException($"No entry with key '{key}' in dict '{name}'.");  // live-state: absent key
             var idxer = dt.GetProperties(BindingFlags.Public | BindingFlags.Instance)
                 .FirstOrDefault(p => p.GetIndexParameters().Length == 1 && p.CanRead)
                 ?? throw new InvalidOperationException($"No readable indexer on dict '{name}' ({dt.Name}).");
@@ -1888,8 +1924,8 @@ public static class WriteEngine
             int j = 0;
             foreach (var item in (System.Collections.IEnumerable)coll)
                 if (j++ == idx)
-                    return item ?? throw new InvalidOperationException($"Element '{name}[{idx}]' is null.");
-            throw new InvalidOperationException($"Index {idx} out of bounds for list '{name}' (has {j} element(s)).");
+                    return item ?? throw new InvalidOperationException($"Element '{name}[{idx}]' is null.");  // present-but-null: NOT reclassified (data anomaly, stays loud)
+            throw new ExpectedApplyRejectionException($"Index {idx} out of bounds for list '{name}' (has {j} element(s)).");  // live-state: out of range
         }
 
         throw new InvalidOperationException($"'{name}' is not a navigable collection (no [read-only] IList/IDictionary).");
@@ -2850,17 +2886,26 @@ public sealed class NullArmSerializeException : InvalidOperationException
     }
 }
 
-/// <summary>An apply-time refusal that pre-flight LEGITIMATELY CANNOT pre-empt because it depends on LIVE STATE the
-/// schema-only gate has no visibility into — distinct from a gate/apply <i>inconsistency</i>. The canonical case is a
-/// dict <c>Add</c> of a key that is ALREADY PRESENT (Gap 3 / Package.Data composition): occupancy is runtime state, not
-/// schema, so the gate accepts the shape and the duplicate is correctly caught here at apply with a clear, actionable
-/// message. The all-or-nothing catch in <see cref="WritePatchBuilder"/> renders this kind's message VERBATIM — still
-/// refusing the whole call with no file written (Q3 all-or-nothing holds) — WITHOUT the generic "pre-flight ACCEPTED it
-/// but the apply threw — a real inconsistency" wrapper, which would mislabel an expected, fixable user error as an
-/// internal bug. Genuinely-unexpected apply throws (a real gate/apply drift) keep that wrapper. Use this ONLY where the
-/// throw is a known, live-state user error with self-explanatory guidance — never to quiet a throw whose cause is
-/// unclear, which would re-introduce the silent-failure this project exists to avoid. It is an
-/// <see cref="InvalidOperationException"/> so any plain fail-loud handler still catches it.</summary>
+/// <summary>A refusal whose cause is LIVE COLLECTION/RECORD STATE the schema-only pre-flight provably CANNOT see —
+/// distinct from a gate/apply <i>inconsistency</i>. This is the whole class of "expected, user-fixable apply rejections":
+/// <list type="bullet">
+///   <item>a dict <c>Add</c> of an ALREADY-PRESENT key (occupancy — Gap 3 / Package.Data);</item>
+///   <item>a list <c>SetAtIndex</c> / <c>Remove</c>-by-index at an OUT-OF-RANGE index (length — pre-flight gates the
+///         index shape but leaves the in-range bound to apply, having no live collection);</item>
+///   <item>a mid-path navigation into an ABSENT collection, an ABSENT dict key, or an OUT-OF-BOUNDS list index
+///         (<see cref="WriteEngine.StepIntoElement"/>).</item>
+/// </list>
+/// Each is correctly caught at the boundary it manifests, with a clear, actionable message. The all-or-nothing catch in
+/// <see cref="WritePatchBuilder"/> renders this kind's message VERBATIM — still refusing the whole call with no file
+/// written (Q3 all-or-nothing holds) — WITHOUT the generic "pre-flight ACCEPTED it but the apply threw — a real
+/// inconsistency" wrapper, which would mislabel an expected, fixable user error as an internal bug. Genuinely-unexpected
+/// throws (a real gate/apply drift) keep that wrapper. <see cref="WriteEngine.StepIntoElement"/> is shared with the READ
+/// path; a read has no inconsistency wrapper, so it simply renders this message exactly as it did when these were plain
+/// <see cref="InvalidOperationException"/>s — no read behavior changes. Use this ONLY where the throw is a known,
+/// live-state user error with self-explanatory guidance — never to quiet a throw whose cause is unclear, which would
+/// re-introduce the silent-failure this project exists to avoid (the present-but-null element and bad-shape index throws
+/// deliberately stay un-reclassified for that reason). It is an <see cref="InvalidOperationException"/> so any plain
+/// fail-loud handler still catches it.</summary>
 public sealed class ExpectedApplyRejectionException : InvalidOperationException
 {
     public ExpectedApplyRejectionException(string message) : base(message) { }

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1738,7 +1738,10 @@ public static class WriteEngine
                 var addKey = Coerce(req.Key!, kType);
                 var contains = dt.GetMethod("ContainsKey", new[] { kType });
                 if (contains is not null && contains.Invoke(dict, new[] { addKey }) is true)
-                    throw new InvalidOperationException(
+                    // EXPECTED apply rejection (live occupancy — pre-flight is schema-only, can't see it): thrown as the
+                    // distinct kind so WritePatchBuilder renders this guidance cleanly, NOT under the "real inconsistency"
+                    // wrapper reserved for genuine gate/apply drift (gap-audit Finding 3).
+                    throw new ExpectedApplyRejectionException(
                         $"Key '{req.Key}' already present in '{prop.Name}' — use Set to overwrite that entry, or choose a free key/index.");
                 dt.GetMethod("Add", new[] { kType, vType })!.Invoke(dict, new[] { addKey, BuildValue() });
                 break;
@@ -2845,4 +2848,20 @@ public sealed class NullArmSerializeException : InvalidOperationException
                "inconsistency — surface it, don't work around it.", inner)
     {
     }
+}
+
+/// <summary>An apply-time refusal that pre-flight LEGITIMATELY CANNOT pre-empt because it depends on LIVE STATE the
+/// schema-only gate has no visibility into — distinct from a gate/apply <i>inconsistency</i>. The canonical case is a
+/// dict <c>Add</c> of a key that is ALREADY PRESENT (Gap 3 / Package.Data composition): occupancy is runtime state, not
+/// schema, so the gate accepts the shape and the duplicate is correctly caught here at apply with a clear, actionable
+/// message. The all-or-nothing catch in <see cref="WritePatchBuilder"/> renders this kind's message VERBATIM — still
+/// refusing the whole call with no file written (Q3 all-or-nothing holds) — WITHOUT the generic "pre-flight ACCEPTED it
+/// but the apply threw — a real inconsistency" wrapper, which would mislabel an expected, fixable user error as an
+/// internal bug. Genuinely-unexpected apply throws (a real gate/apply drift) keep that wrapper. Use this ONLY where the
+/// throw is a known, live-state user error with self-explanatory guidance — never to quiet a throw whose cause is
+/// unclear, which would re-introduce the silent-failure this project exists to avoid. It is an
+/// <see cref="InvalidOperationException"/> so any plain fail-loud handler still catches it.</summary>
+public sealed class ExpectedApplyRejectionException : InvalidOperationException
+{
+    public ExpectedApplyRejectionException(string message) : base(message) { }
 }

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -222,6 +222,14 @@ public static class WritePatchBuilder
                 WriteEngine.ApplyVerb(ov, req);
                 ops.Add(new OpResult(e.Target, req.RecordType, label, true, null, TryReadAfter(ov, req)));
             }
+            catch (ExpectedApplyRejectionException ex)
+            {
+                // An EXPECTED apply-time refusal pre-flight legitimately can't pre-empt (live state — e.g. a duplicate dict
+                // key): render its clean guidance, NOT the gate/apply-inconsistency wrapper. All-or-nothing still holds —
+                // the whole call is refused and no file is written (gap-audit Finding 3).
+                return PatchOutcome.Fail(
+                    $"refused applying [{label}] to {req.RecordType} {e.Target} — {ex.Message} (no patch written)");
+            }
             catch (Exception ex)
             {
                 return PatchOutcome.Fail(
@@ -584,6 +592,13 @@ public static class WritePatchBuilder
                     req = CopyWithValue(rawReq, sibRec.FormKey.ToString());
                 }
                 try { WriteEngine.ApplyVerb(rec, req); ops.Add(new OpResult(rec.FormKey, s.RecordType, Label(req), true, null, TryReadAfter(rec, req))); }
+                catch (ExpectedApplyRejectionException ex)
+                {
+                    // EXPECTED apply-time refusal (live state pre-flight can't see — e.g. a duplicate dict key): clean
+                    // guidance, NOT the inconsistency wrapper. Whole call still refused, nothing serialized (gap-audit Finding 3).
+                    return CreateOutcome.Fail(
+                        $"refused applying [{Label(req)}] to new {s.RecordType} '{s.EditorId}' ({rec.FormKey}) — {ex.Message} (nothing created)");
+                }
                 catch (Exception ex)
                 {
                     return CreateOutcome.Fail(

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -213,7 +213,8 @@ namespace HousecarlGenerator;
 ///   GAP3-OK-LIST-UNCHANGED   — an ARM-element LIST compose (Faction.Conditions) still composes (the dict-Add change didn't disturb the list path).
 ///   GAP3-E2E                 — a composed PackageDataBool(Data=true) round-trips through the real create+apply path onto Package.Data[0] on disk.
 ///   GAP3-E2E-SET             — the Set-OVERWRITE apply branch round-trips: Add Data[0]=false then Set Data[0]=true reads Data==true on disk (the dup escape hatch).
-///   GAP3-REJ-DUP             — an Add of an already-present key refuses (apply-time) end-to-end, NO file written, naming Set as the overwrite path.
+///   GAP3-REJ-DUP             — an Add of an already-present key refuses (apply-time) end-to-end, NO file written, naming Set as the overwrite path,
+///                              and renders that EXPECTED rejection cleanly — NO "real inconsistency" wrapper (gap-audit Finding 3).
 ///
 /// G8 — the polymorphic BASE composed by its OWN name (PR-B review finding; PRE-EXISTING, shared list+dict). A compose
 /// naming the base itself ({Type:"APackageData"} on Package.Data, {Type:"Condition"} on a *.Conditions list) hit
@@ -1301,6 +1302,9 @@ public static class NestedCreateGuardProbe
         // ---------- GAP3-REJ-DUP: Add of an already-present key refuses (apply-time) with the improved 'use Set' guidance ----------
         // The duplicate check is apply-time (pre-flight is schema-only, can't see live occupancy): two Adds of Data[0] in one
         // create — the second refuses the WHOLE call, no file written, with the Gap-3 message naming Set as the overwrite path.
+        // ALSO guards gap-audit Finding 3: this EXPECTED apply rejection (an ExpectedApplyRejectionException) must render its
+        // clean guidance WITHOUT the "pre-flight ACCEPTED … a real inconsistency" wrapper reserved for genuine gate/apply
+        // drift. RED-proof: before the fix the envelope embedded that wrapper, so the absence-asserts below would FAIL.
         bool gap3RejDupOk = RejectArm("GAP3-REJ-DUP duplicate key add     ", tmpDir, "Gap3Dup", mPath, rulebook,
             new[]
             {
@@ -1313,7 +1317,10 @@ public static class NestedCreateGuardProbe
                             Struct = new StructSpec { Type = "PackageDataBool", Fields = new Dictionary<string, string> { ["Data"] = "false" } } },
                     } },
             },
-            msg => msg.Contains("already present", StringComparison.OrdinalIgnoreCase) && msg.Contains("use Set", StringComparison.OrdinalIgnoreCase));
+            msg => msg.Contains("already present", StringComparison.OrdinalIgnoreCase)
+                && msg.Contains("use Set", StringComparison.OrdinalIgnoreCase)
+                && !msg.Contains("real inconsistency", StringComparison.OrdinalIgnoreCase)   // Finding 3: no inconsistency wrapper …
+                && !msg.Contains("pre-flight ACCEPTED", StringComparison.OrdinalIgnoreCase)); //            … on an expected rejection
 
         // ====== G8 — the polymorphic BASE composed by its OWN name (the gate/apply drift this batch exists to kill) ======
         // StructElementLegality short-circuits `if (spec.Type == er) specSchema = elemSchema` — so composing the poly-BASE

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -1413,6 +1413,82 @@ public static class NestedCreateGuardProbe
             Console.WriteLine($"   GAP3-OK-ARMFIELD-UNCHANGED real arm: {(gap3OkArmFieldUnchangedOk ? "PASS — a real arm ('SceneScriptFragments') on the poly field still accepts (filtering the base didn't break real arms)" : $"FAIL — reject=[{reject}]")}");
         }
 
+        // ====== EXPECTED apply rejections — the LIVE-STATE collection-addressing class (gap-audit Finding 3, whole class) ======
+        // Finding 3's dup-key (GAP3-REJ-DUP) is ONE member of a class: apply-time refusals whose cause is live collection
+        // state the schema-only pre-flight CANNOT see. They must render CLEANLY (the actionable message), NOT under the
+        // "pre-flight ACCEPTED … a real inconsistency" wrapper reserved for genuine gate/apply drift. The leaf out-of-range
+        // index (SetAtIndex / Remove-by-index) is the sibling Finding 3 named; the mid-path nav twins route through the SAME
+        // WritePatchBuilder catch via the shared StepIntoElement (now throwing the EXPECTED kind too).
+
+        // ---------- EXPECTED-REJ-SETIDX-OOB: a list SetAtIndex past the end refuses CLEANLY end-to-end, NO file ----------
+        // Index 5 is a VALID shape (pre-flight accepts — KEYSHAPE leaves the in-range bound to apply), so the gate passes
+        // and apply's new pre-check fires (Race.MovementTypeNames=List<String> — a String list, so no master to serialize).
+        // RED before: the indexer Invoke threw ArgumentOutOfRangeException → wrapped as a "real inconsistency"; the
+        // absence-asserts below would FAIL.
+        bool expectedRejSetIdxOobOk = RejectArm("EXPECTED-REJ-SETIDX-OOB out-of-range", tmpDir, "ExpSetIdxOob", mPath, rulebook,
+            new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "Race", EditorId = "HcNcExpSetIdx",
+                    Edits = new[] { new WriteRequest { RecordType = "Race", Path = new[] { "MovementTypeNames" }, Verb = "SetAtIndex", Key = "5", Value = "MT_Walk" } } },
+            },
+            msg => msg.Contains("out of range", StringComparison.OrdinalIgnoreCase)
+                && !msg.Contains("real inconsistency", StringComparison.OrdinalIgnoreCase)
+                && !msg.Contains("pre-flight ACCEPTED", StringComparison.OrdinalIgnoreCase));
+
+        // ---------- EXPECTED-REJ-REMOVEIDX-OOB: a list Remove-by-index past the end refuses CLEANLY, NO file ----------
+        // Add one element first so the list is non-null (Remove on an absent list is a deliberate no-op), then Remove[5]
+        // (count 1 → out of range). RED before: RemoveAt Invoke threw ArgumentOutOfRangeException → wrapped.
+        bool expectedRejRemoveIdxOobOk = RejectArm("EXPECTED-REJ-REMOVEIDX-OOB out-range", tmpDir, "ExpRmIdxOob", mPath, rulebook,
+            new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "Race", EditorId = "HcNcExpRmIdx",
+                    Edits = new[]
+                    {
+                        new WriteRequest { RecordType = "Race", Path = new[] { "MovementTypeNames" }, Verb = "Add", Value = "MT_Walk" },
+                        new WriteRequest { RecordType = "Race", Path = new[] { "MovementTypeNames" }, Verb = "Remove", Key = "5" },
+                    } },
+            },
+            msg => msg.Contains("out of range", StringComparison.OrdinalIgnoreCase)
+                && !msg.Contains("real inconsistency", StringComparison.OrdinalIgnoreCase)
+                && !msg.Contains("pre-flight ACCEPTED", StringComparison.OrdinalIgnoreCase));
+
+        // ---------- EXPECTED-OK-SETIDX-INRANGE: an in-range SetAtIndex still applies (the pre-check does NOT over-reject) ----
+        // Direct engine (no serialize/master concern — a String list never references a master): Add then SetAtIndex[0],
+        // assert the value LANDED and nothing threw. Guards against the new pre-check rejecting a legitimate in-range index.
+        bool expectedOkSetIdxInRangeOk;
+        {
+            var race = new Race(new FormKey(mKey, 0x901u), SkyrimRelease.SkyrimSE);
+            bool threw = false;
+            try
+            {
+                WriteEngine.ApplyVerb(race, new WriteRequest { RecordType = "Race", Path = new[] { "MovementTypeNames" }, Verb = "Add", Value = "MT_Walk" });
+                WriteEngine.ApplyVerb(race, new WriteRequest { RecordType = "Race", Path = new[] { "MovementTypeNames" }, Verb = "SetAtIndex", Key = "0", Value = "MT_Run" });
+            }
+            catch { threw = true; }
+            bool landed = race.MovementTypeNames is { Count: 1 } mtn && mtn[0] == "MT_Run";
+            expectedOkSetIdxInRangeOk = !threw && landed;
+            Console.WriteLine($"   EXPECTED-OK-SETIDX-INRANGE valid  : {(expectedOkSetIdxInRangeOk ? "PASS — Add then in-range SetAtIndex[0] applies (value lands; the pre-check does NOT over-reject)" : $"FAIL — threw={threw} landed={landed}")}");
+        }
+
+        // ---------- EXPECTED-NAV-TYPE: the shared StepIntoElement throws the EXPECTED kind for live-state mid-path nav ----
+        // So a mid-path write into an absent dict entry / out-of-bounds list index routes into the clean-render channel,
+        // not the wrapper. Direct engine (deterministic; independent of whether pre-flight admits a mid-path index). RED
+        // before: StepIntoElement threw a PLAIN InvalidOperationException → not caught as EXPECTED → flags stay false → FAIL.
+        bool expectedNavTypeOk;
+        {
+            bool dictEntryAbsentExpected = false, listOobExpected = false;
+            var pkg = new Package(new FormKey(mKey, 0x902u), SkyrimRelease.SkyrimSE);   // Data dict carries no entry at key 0
+            try { WriteEngine.ApplyVerb(pkg, new WriteRequest { RecordType = "Package", Path = new[] { "Data[0]", "Data" }, Verb = "Set", Value = "true" }); }
+            catch (ExpectedApplyRejectionException) { dictEntryAbsentExpected = true; }
+            catch { }
+            var fac = new Faction(new FormKey(mKey, 0x903u), SkyrimRelease.SkyrimSE);    // Conditions list carries no index 5
+            try { WriteEngine.ApplyVerb(fac, new WriteRequest { RecordType = "Faction", Path = new[] { "Conditions[5]", "Flags" }, Verb = "Set", Value = "0" }); }
+            catch (ExpectedApplyRejectionException) { listOobExpected = true; }
+            catch { }
+            expectedNavTypeOk = dictEntryAbsentExpected && listOobExpected;
+            Console.WriteLine($"   EXPECTED-NAV-TYPE live-state nav   : {(expectedNavTypeOk ? "PASS — StepIntoElement throws the EXPECTED kind for an absent dict entry AND an out-of-bounds list index (routes to clean render)" : $"FAIL — dictEntryAbsent={dictEntryAbsentExpected} listOob={listOobExpected}")}");
+        }
+
         Console.WriteLine();
         bool pass = fixturesOk && oneshotOk && multiOk && intoTopicOk && intoCellOk
                     && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendOk
@@ -1432,7 +1508,8 @@ public static class NestedCreateGuardProbe
                     && gap3OkDictAddComposeOk && gap3OkDictSetComposeOk && gap3RejBadArmOk && gap3OkListUnchangedOk
                     && gap3OkE2eOk && gap3OkE2eSetOk && gap3RejDupOk
                     && gap3RejBaseArmOk && gap3RejBaseArmListOk && gap3OkBaseNoOverRejectOk && gap3RejBaseArmE2eOk
-                    && gap3RejBaseArmFieldOk && gap3OkArmFieldUnchangedOk;
+                    && gap3RejBaseArmFieldOk && gap3OkArmFieldUnchangedOk
+                    && expectedRejSetIdxOobOk && expectedRejRemoveIdxOobOk && expectedOkSetIdxInRangeOk && expectedNavTypeOk;
         Console.WriteLine($"=== nested-create-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return pass ? 0 : 1;

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -244,6 +244,18 @@ namespace HousecarlGenerator;
 ///                              (DialogResponses.VirtualMachineAdapter.ScriptFragments {Type:"ScriptFragments"}) refuses. RED before: accepted.
 ///   GAP3-OK-ARMFIELD-UNCHANGED— a REAL arm ('SceneScriptFragments') on that poly field still accepts (no over-reject). Before AND after.
 ///   (GAP3-REJ-BADARM strengthened: its 'Legal element types' list no longer names the un-composable base 'APackageData'.)
+///
+/// EXPECTED apply rejections — the LIVE-STATE collection-addressing class (gap-audit Finding 3, "close the whole class").
+/// Apply-time refusals whose cause is live state the schema-only gate CANNOT see (occupancy / length / presence) must
+/// render CLEANLY via WritePatchBuilder, NOT under the "pre-flight ACCEPTED … a real inconsistency" wrapper (an
+/// ExpectedApplyRejectionException, a subclass of IOE the catch keys off). GAP3-REJ-DUP (above) is the dict-occupancy
+/// member; the rest:
+///   EXPECTED-REJ-SETIDX-OOB    — a list SetAtIndex past the end refuses cleanly E2E, NO file (Race.MovementTypeNames[5]). RED: wrapped.
+///   EXPECTED-REJ-REMOVEIDX-OOB — a list Remove-by-index past the end refuses cleanly E2E, NO file (Add one, then Remove[5]). RED: wrapped.
+///   EXPECTED-OK-SETIDX-INRANGE — an in-range SetAtIndex[0] still APPLIES (value lands; the new pre-check doesn't over-reject).
+///   EXPECTED-NAV-TYPE          — the shared StepIntoElement throws the EXPECTED kind for an absent dict entry AND an out-of-bounds list index. RED: plain IOE.
+///   EXPECTED-REJ-NAV-E2E       — a mid-path nav reject (Package.Data[5].Name, absent key) renders cleanly THROUGH WritePatchBuilder, NO file. RED: wrapped.
+///   (Left LOUD by design: present-but-null element/entry, bad-SHAPE index, structural/reflection failures — not clean live-state addressing.)
 /// </summary>
 public static class NestedCreateGuardProbe
 {
@@ -1489,6 +1501,23 @@ public static class NestedCreateGuardProbe
             Console.WriteLine($"   EXPECTED-NAV-TYPE live-state nav   : {(expectedNavTypeOk ? "PASS — StepIntoElement throws the EXPECTED kind for an absent dict entry AND an out-of-bounds list index (routes to clean render)" : $"FAIL — dictEntryAbsent={dictEntryAbsentExpected} listOob={listOobExpected}")}");
         }
 
+        // ---------- EXPECTED-REJ-NAV-E2E: a mid-path nav reject renders CLEANLY through WritePatchBuilder end-to-end ----------
+        // EXPECTED-NAV-TYPE proves the engine throws the right KIND; this closes the seam by proving the FULL render (the
+        // shared WritePatchBuilder catch → clean message, no wrapper, NO file). Package.Data[5].Name is a VALID mid-path
+        // path (GAP1-OK-MIDKEY: valid sbyte key + the writable APackageData 'Name' leaf) but key 5 is ABSENT in a fresh
+        // Package's (empty, non-null) Data dict — so the gate passes and apply hits StepIntoElement's key-absent throw.
+        // RED before the nav reclassification: that throw was a PLAIN InvalidOperationException → wrapped as a "real
+        // inconsistency"; the absence-asserts below would FAIL.
+        bool expectedRejNavE2eOk = RejectArm("EXPECTED-REJ-NAV-E2E absent key   ", tmpDir, "ExpNavKey", mPath, rulebook,
+            new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "Package", EditorId = "HcNcExpNav",
+                    Edits = new[] { new WriteRequest { RecordType = "Package", Path = new[] { "Data[5]", "Name" }, Verb = "Set", Value = "houseCARL" } } },
+            },
+            msg => msg.Contains("No entry with key", StringComparison.OrdinalIgnoreCase)
+                && !msg.Contains("real inconsistency", StringComparison.OrdinalIgnoreCase)
+                && !msg.Contains("pre-flight ACCEPTED", StringComparison.OrdinalIgnoreCase));
+
         Console.WriteLine();
         bool pass = fixturesOk && oneshotOk && multiOk && intoTopicOk && intoCellOk
                     && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendOk
@@ -1509,7 +1538,8 @@ public static class NestedCreateGuardProbe
                     && gap3OkE2eOk && gap3OkE2eSetOk && gap3RejDupOk
                     && gap3RejBaseArmOk && gap3RejBaseArmListOk && gap3OkBaseNoOverRejectOk && gap3RejBaseArmE2eOk
                     && gap3RejBaseArmFieldOk && gap3OkArmFieldUnchangedOk
-                    && expectedRejSetIdxOobOk && expectedRejRemoveIdxOobOk && expectedOkSetIdxInRangeOk && expectedNavTypeOk;
+                    && expectedRejSetIdxOobOk && expectedRejRemoveIdxOobOk && expectedOkSetIdxInRangeOk && expectedNavTypeOk
+                    && expectedRejNavE2eOk;
         Console.WriteLine($"=== nested-create-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return pass ? 0 : 1;


### PR DESCRIPTION
## What & why

The all-or-nothing `CreateRecords`/`Apply` catch in `WritePatchBuilder` wrapped **every** apply-time throw as *"pre-flight ACCEPTED it but the apply threw — a real inconsistency, surfaced not swallowed (Q3)"*. Correct for genuine gate/apply **drift**, but it **overstates** an *expected* user error pre-flight legitimately cannot catch — making a fixable input error read like an internal bug.

Provenance: `dev/plans/WRITE_PREFLIGHT_GAP_AUDIT_2026-06-18.md` **Finding 3**.

## The whole class (Aaron: "close the whole class at once")

A new `ExpectedApplyRejectionException` (`: InvalidOperationException`, so existing fail-loud handlers still catch it). The two envelopes (`Apply` + `CreateRecords` Phase 3) catch it **before** the general catch and render its message **verbatim** — still all-or-nothing (whole call refused, **no file written**), just without the wrapper. Genuine drift still gets the wrapper.

Members reclassified (all live-state — pre-flight provably can't see them):
- **dict `Add` of an already-present key** (occupancy — Gap 3 / `Package.Data`). *[commit 1]*
- **list `SetAtIndex` / `Remove`-by-index at an out-of-range index** (length). Pre-flight gates the index *shape* but leaves the in-range bound to apply by design (KEYSHAPE); a new pre-check (`CollectionCount` + `IndexRangeMessage`) throws clean guidance instead of a reflection-wrapped `ArgumentOutOfRangeException`. *[commit 2]*
- **mid-path nav into an absent collection / absent dict key / out-of-bounds list index** (`StepIntoElement`) — explicit throws swapped to the clean kind, routing through the same catch. *[commit 2]*

Deliberately **left loud** (not clean live-state addressing): a present-but-`null` element/entry (data anomaly), bad-*shape* index (already gated / a shape gap), and all structural/reflection failures (genuine engine/coverage).

`StepIntoElement` is shared with the **read** path — a read has no inconsistency wrapper, so it renders these messages exactly as before (subclass of IOE → no read behavior change).

## Guard / proof

`nested-create-guard` **81 → 86 arms**:
- `GAP3-REJ-DUP` strengthened to assert no wrapper *[c1]*; `EXPECTED-REJ-SETIDX-OOB`, `EXPECTED-REJ-REMOVEIDX-OOB` (E2E rejects), `EXPECTED-OK-SETIDX-INRANGE` (no-over-reject control), `EXPECTED-NAV-TYPE` (shared nav throws the clean kind) *[c2]*; `EXPECTED-REJ-NAV-E2E` (a mid-path nav reject rendered cleanly **through WritePatchBuilder end-to-end**) *[c3]*.
- **Whole-class RED-proven**: reverting every new throw to `InvalidOperationException` turns all reject arms RED (wrapper re-embedded) while the in-range OK control stays green; restoring → all green.
- Full solution builds clean (Release), 0 errors; full `nested-create-guard` → `PASS`.

§4-(a) — by construction, cornerstone untouched, tool surface stays 21.

## Review

Independent review: **Approve** (3 low notes, none blocking). Note 2 (the `EXPECTED-NAV-TYPE` engine-level arm covered the mid-path-nav *render* only transitively) addressed by **commit 3** (`a5e4da0`) — an explicit E2E nav-reject arm. Note 1 (`CollectionCount` O(n)) is fine per accuracy-over-perf; note 3 (absent-collection-on-nav masking edge) is defensible — the trigger is almost always genuine user error, the message stays actionable, and the loud cases were left loud.

> ⏸️ **Awaiting Aaron's explicit go to merge** (rebase). Not merging automatically.