### PR TITLE
write pre-flight: close the PR #83 follow-up gap batch (Gaps 1-3)

### DIFF
--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -179,8 +179,14 @@ public sealed class CorpusRulebook
                 if (elem.Kind == "record")
                     return $"'{segName}' on '{current.Name}' holds records ({er}); a record is resolved on its own, " +
                            "not reached by stepping into a parent (nested-group wave).";
-                if (field.Cardinality == "list" && !int.TryParse(segKey, out _))
-                    return $"List '{segName}' on '{current.Name}' must be indexed by an integer; got '{segKey}'.";
+                // list mid-path index SHAPE — reconcile onto the SAME recognizer the LEAF step-4-key block uses
+                // (WriteEngine.IsValidListIndexValue: a parseable NON-NEGATIVE int32), so the mid-path hop and the leaf
+                // can't drift. A bare int.TryParse ACCEPTS a negative ('-1' parses), but apply's StepIntoElement list
+                // branch requires idx >= 0 and throws a PLAIN InvalidOperationException (a SHAPE error, deliberately not
+                // an ExpectedApplyRejection) → the misleading "real inconsistency" wrapper. Gating >= 0 here closes that
+                // accept-then-throw, exactly as the leaf index was reconciled (the in-range bound stays apply's job, Q3).
+                if (field.Cardinality == "list" && !WriteEngine.IsValidListIndexValue(segKey))
+                    return $"List '{segName}' on '{current.Name}' must be indexed by a non-negative integer; got '{segKey}'.";
                 // dict mid-path key SHAPE — reconcile onto the SAME recognizer pair (DictKeyType + CheckValue's AQ
                 // branch) the PR #79 LEAF step-4-key block uses, so the mid-path hop and the leaf can't drift. Without
                 // the key's real CLR type (DictKeyType -> the dict AQ's args[0], the type apply keys on via

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1710,11 +1710,15 @@ public static class WriteEngine
     static void ApplyDictVerb(object parent, PropertyInfo prop, Type dictIface, WriteRequest req)
     {
         // Writable-by-construction: an ABSENT optional dict (null) is materialized so a first entry can be set.
-        // Remove on an absent dict is a no-op (nothing to remove) — it must NOT create an empty dict.
+        // Remove on an absent dict SURFACES "nothing to remove" (Gap 3 — a Remove that removes nothing is no longer a
+        // silent no-op; the key is trivially not present when the whole dict is absent) — thrown as the EXPECTED kind
+        // BEFORE materializing, so it still must NOT create an empty dict.
         var dict = prop.GetValue(parent);
         if (dict is null)
         {
-            if (req.Verb == "Remove") return;
+            if (req.Verb == "Remove")
+                throw new ExpectedApplyRejectionException(
+                    $"Remove on dict '{prop.Name}': the collection is absent (no entries) — nothing to remove.");
             dict = MaterializeCollection(parent, prop);
         }
         var kType = dictIface.GetGenericArguments()[0];
@@ -1747,7 +1751,11 @@ public static class WriteEngine
                 break;
             }
             case "Remove":
-                dt.GetMethod("Remove", new[] { kType })!.Invoke(dict, new[] { Coerce(req.Key!, kType) });
+                // SURFACE a no-op Remove (Gap 3): the runtime Remove returns false when the key is not present — refuse it
+                // as the EXPECTED kind (the symmetric twin of Add's duplicate-key refusal), clean, not a silent success.
+                if (dt.GetMethod("Remove", new[] { kType })!.Invoke(dict, new[] { Coerce(req.Key!, kType) }) is false)
+                    throw new ExpectedApplyRejectionException(
+                        $"Key '{req.Key}' is not present in '{prop.Name}' — nothing to remove.");
                 break;
             case "ReplaceAll":
                 dt.GetMethod("Clear")!.Invoke(dict, null);
@@ -1764,12 +1772,15 @@ public static class WriteEngine
     static void ApplyListVerb(object parent, PropertyInfo prop, Type listIface, WriteRequest req)
     {
         // Writable-by-construction: an ABSENT optional list (null) is materialized so a first element can be
-        // added — "add a keyword to a record that has none" must work, not throw. Remove on an absent list is a
-        // no-op (nothing to remove) — it must NOT create an empty list (which would alter the serialized bytes).
+        // added — "add a keyword to a record that has none" must work, not throw. Remove on an absent list SURFACES
+        // "nothing to remove" (Gap 3 — no silent no-op; the value/index is trivially not present when the whole list is
+        // absent) — thrown as the EXPECTED kind BEFORE materializing, so it still must NOT create an empty list.
         var list = prop.GetValue(parent);
         if (list is null)
         {
-            if (req.Verb == "Remove") return;
+            if (req.Verb == "Remove")
+                throw new ExpectedApplyRejectionException(
+                    $"Remove on list '{prop.Name}': the collection is absent (no elements) — nothing to remove.");
             list = MaterializeCollection(parent, prop);
         }
         var elem = listIface.GetGenericArguments()[0];
@@ -1806,7 +1817,13 @@ public static class WriteEngine
                     lt.GetMethod("RemoveAt", new[] { typeof(int) })!.Invoke(list, new object[] { idx });
                 }
                 else
-                    lt.GetMethod("Remove", new[] { elem })!.Invoke(list, new[] { Coerce(req.Value!, elem) });
+                {
+                    // SURFACE a no-op Remove-by-value (Gap 3): List<T>.Remove returns false when the value is not present —
+                    // refuse it as the EXPECTED kind (Remove-by-INDEX is range-checked above), clean, not a silent success.
+                    if (lt.GetMethod("Remove", new[] { elem })!.Invoke(list, new[] { Coerce(req.Value!, elem) }) is false)
+                        throw new ExpectedApplyRejectionException(
+                            $"Value '{req.Value}' is not present in '{prop.Name}' — nothing to remove.");
+                }
                 break;
             case "ReplaceAll":
                 lt.GetMethod("Clear")!.Invoke(list, null);
@@ -2892,6 +2909,10 @@ public sealed class NullArmSerializeException : InvalidOperationException
 ///   <item>a dict <c>Add</c> of an ALREADY-PRESENT key (occupancy — Gap 3 / Package.Data);</item>
 ///   <item>a list <c>SetAtIndex</c> / <c>Remove</c>-by-index at an OUT-OF-RANGE index (length — pre-flight gates the
 ///         index shape but leaves the in-range bound to apply, having no live collection);</item>
+///   <item>a <c>Remove</c> that removes NOTHING — a dict <c>Remove</c> of a key not present, a list
+///         <c>Remove</c>-by-value of a value not present, or a <c>Remove</c> on an absent (null) collection
+///         (occupancy — Gap 3 / PR #83 follow-up; the symmetric twin of the duplicate-key <c>Add</c> refusal, so a
+///         Remove that thought it removed something but didn't surfaces instead of silently succeeding);</item>
 ///   <item>a mid-path navigation into an ABSENT collection, an ABSENT dict key, or an OUT-OF-BOUNDS list index
 ///         (<see cref="WriteEngine.StepIntoElement"/>).</item>
 /// </list>

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1929,7 +1929,8 @@ public static class WriteEngine
                 .FirstOrDefault(p => p.GetIndexParameters().Length == 1 && p.CanRead)
                 ?? throw new InvalidOperationException($"No readable indexer on dict '{name}' ({dt.Name}).");
             return idxer.GetValue(coll, new object[] { keyObj! })
-                ?? throw new InvalidOperationException($"Entry '{name}[{key}]' is null.");
+                ?? throw new MalformedTargetDataException(   // present-but-null entry: a SOURCE-data anomaly (its own third category), not gate/apply drift
+                    $"Entry '{name}[{key}]' is present but null — the target record's data is malformed here (a source-data anomaly, not an engine fault).");
         }
 
         var listIface = ClosedInterface(prop.PropertyType, typeof(IList<>))
@@ -1941,7 +1942,8 @@ public static class WriteEngine
             int j = 0;
             foreach (var item in (System.Collections.IEnumerable)coll)
                 if (j++ == idx)
-                    return item ?? throw new InvalidOperationException($"Element '{name}[{idx}]' is null.");  // present-but-null: NOT reclassified (data anomaly, stays loud)
+                    return item ?? throw new MalformedTargetDataException(   // present-but-null element: a SOURCE-data anomaly (its own third category), not gate/apply drift
+                        $"Element '{name}[{idx}]' is present but null — the target record's data is malformed here (a source-data anomaly, not an engine fault).");
             throw new ExpectedApplyRejectionException($"Index {idx} out of bounds for list '{name}' (has {j} element(s)).");  // live-state: out of range
         }
 
@@ -2924,10 +2926,29 @@ public sealed class NullArmSerializeException : InvalidOperationException
 /// path; a read has no inconsistency wrapper, so it simply renders this message exactly as it did when these were plain
 /// <see cref="InvalidOperationException"/>s — no read behavior changes. Use this ONLY where the throw is a known,
 /// live-state user error with self-explanatory guidance — never to quiet a throw whose cause is unclear, which would
-/// re-introduce the silent-failure this project exists to avoid (the present-but-null element and bad-shape index throws
-/// deliberately stay un-reclassified for that reason). It is an <see cref="InvalidOperationException"/> so any plain
+/// re-introduce the silent-failure this project exists to avoid (a bad-SHAPE index throw deliberately stays
+/// un-reclassified for that reason; a present-but-null element/entry is its own <see cref="MalformedTargetDataException"/>
+/// — a distinct THIRD category — rather than this kind). It is an <see cref="InvalidOperationException"/> so any plain
 /// fail-loud handler still catches it.</summary>
 public sealed class ExpectedApplyRejectionException : InvalidOperationException
 {
     public ExpectedApplyRejectionException(string message) : base(message) { }
+}
+
+/// <summary>A refusal whose cause is the TARGET record's own data being malformed/unexpected — a present-but-null
+/// collection element or dict entry that <see cref="WriteEngine.StepIntoElement"/> cannot navigate into. This is the
+/// THIRD apply-rejection category, deliberately distinct from both siblings: it is NOT an
+/// <see cref="ExpectedApplyRejectionException"/> (the user did nothing wrong — there's no input to fix; a null element is
+/// a data anomaly, not a routine occupancy/length/presence rejection), and it is NOT a gate/apply <i>inconsistency</i>
+/// (the schema-only pre-flight provably cannot see live data, so it is not a "pre-flight ACCEPTED it but apply threw"
+/// engine bug). The honest middle: surfaced LOUD and accurately as malformed SOURCE data — houseCARL reads it but never
+/// wrote it, so the present-but-null state arises only from pre-existing malformed plugins, never from houseCARL's own
+/// write path (the null gates forbid writing one). The all-or-nothing catch in <see cref="WritePatchBuilder"/> renders
+/// this kind's message cleanly (no inconsistency wrapper), still refusing the whole call with no file written (Q3).
+/// <see cref="WriteEngine.StepIntoElement"/> is shared with the READ path, which has no wrapper, so a read renders this
+/// message exactly as it did when these were plain <see cref="InvalidOperationException"/>s — no read behavior change. It
+/// is an <see cref="InvalidOperationException"/> so any plain fail-loud handler still catches it.</summary>
+public sealed class MalformedTargetDataException : InvalidOperationException
+{
+    public MalformedTargetDataException(string message) : base(message) { }
 }

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -230,6 +230,15 @@ public static class WritePatchBuilder
                 return PatchOutcome.Fail(
                     $"refused applying [{label}] to {req.RecordType} {e.Target} — {ex.Message} (no patch written)");
             }
+            catch (MalformedTargetDataException ex)
+            {
+                // The THIRD category: the TARGET record's own data is malformed (a present-but-null element/entry) — neither
+                // a user input error nor a gate/apply inconsistency. Render it accurately, NOT under the "pre-flight ACCEPTED
+                // … a real inconsistency" wrapper (which would mislabel pre-existing bad source data as an engine bug).
+                // All-or-nothing holds — no file written (PR #83 follow-up Gap 2).
+                return PatchOutcome.Fail(
+                    $"refused applying [{label}] to {req.RecordType} {e.Target} — {ex.Message} (no patch written)");
+            }
             catch (Exception ex)
             {
                 return PatchOutcome.Fail(
@@ -596,6 +605,13 @@ public static class WritePatchBuilder
                 {
                     // EXPECTED apply-time refusal (live state pre-flight can't see — e.g. a duplicate dict key): clean
                     // guidance, NOT the inconsistency wrapper. Whole call still refused, nothing serialized (gap-audit Finding 3).
+                    return CreateOutcome.Fail(
+                        $"refused applying [{Label(req)}] to new {s.RecordType} '{s.EditorId}' ({rec.FormKey}) — {ex.Message} (nothing created)");
+                }
+                catch (MalformedTargetDataException ex)
+                {
+                    // THIRD category: the target record's own data is malformed (present-but-null element/entry) — render it
+                    // accurately, NOT under the inconsistency wrapper. Whole call refused, nothing serialized (PR #83 Gap 2).
                     return CreateOutcome.Fail(
                         $"refused applying [{Label(req)}] to new {s.RecordType} '{s.EditorId}' ({rec.FormKey}) — {ex.Message} (nothing created)");
                 }

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -274,6 +274,16 @@ namespace HousecarlGenerator;
 ///   (Left LOUD by design: bad-SHAPE index, structural/reflection failures — not clean live-state addressing. Present-but-null
 ///    is now its own MalformedTargetDataException third category — see below.)
 ///
+/// Gap 2 (PR #83 follow-up) — a present-but-null element/entry is its own MalformedTargetDataException THIRD category.
+/// Such a throw was a plain InvalidOperationException → the "pre-flight ACCEPTED … a real inconsistency" wrapper, which
+/// mislabels pre-existing malformed SOURCE data (not user input, not an engine bug) as an internal inconsistency. Now its
+/// own exception kind, caught distinctly by WritePatchBuilder and rendered cleanly (Aaron 2026-06-18: dedicated third
+/// category). The state isn't producible via houseCARL's write path (the null gates forbid it) and Mutagen won't
+/// serialize a null element to make a malformed fixture, so this is engine-direct (throw kind + message); the type
+/// deterministically routes to the dedicated catch (a verbatim passthrough mirroring the proven ExpectedApplyRejection catch):
+///   MALFORMED-NAV-TYPE         — a present-but-null dict entry AND list element throw MalformedTargetDataException ('malformed'
+///                                message), not a plain IOE. RED before: plain InvalidOperationException → not caught as the third kind.
+///
 /// Gap 3 (PR #83 follow-up) — surface a Remove that removes NOTHING (close the silent-no-op). list Remove-by-value and
 /// dict Remove-by-key ignored the runtime Remove's bool, so "remove X" when X isn't present SILENTLY succeeded (Q3
 /// degradation). Now all three forms surface as the EXPECTED kind ("nothing to remove") — the symmetric twin of Add's
@@ -1602,6 +1612,39 @@ public static class NestedCreateGuardProbe
                 && !msg.Contains("real inconsistency", StringComparison.OrdinalIgnoreCase)
                 && !msg.Contains("pre-flight ACCEPTED", StringComparison.OrdinalIgnoreCase));
 
+        // ====== Gap 2 (PR #83 follow-up) — present-but-null element/entry = its own MalformedTargetData third category ======
+        // A present-but-null collection element / dict entry threw a PLAIN InvalidOperationException → the generic
+        // "pre-flight ACCEPTED it but the apply threw — a real inconsistency" wrapper, which mislabels pre-existing
+        // malformed SOURCE data (not the user's input, not an engine bug) as an internal inconsistency. It is now its own
+        // MalformedTargetDataException — a distinct THIRD category (neither ExpectedApplyRejection nor the inconsistency
+        // wrapper), rendered cleanly by WritePatchBuilder. Decision: Aaron 2026-06-18 (dedicated third category).
+        // NOTE on coverage: the present-but-null state is NOT producible through houseCARL's own write path (the null gates
+        // forbid writing one) and Mutagen will not serialize a null element to synthesize a malformed fixture — so there is
+        // nothing to drive through the create/Apply pipeline for a full E2E render. This engine-direct arm proves the THROW
+        // KIND + the third-category message; the throw type deterministically routes to WritePatchBuilder's dedicated
+        // MalformedTargetDataException catch (a verbatim-message passthrough mirroring the proven ExpectedApplyRejection catch).
+
+        // ---------- MALFORMED-NAV-TYPE: a present-but-null dict entry AND list element throw MalformedTargetData ----------
+        // Inject a present-but-null entry/element in-memory (the only way to reach the state — see NOTE), then navigate in.
+        // RED before: the throws were plain InvalidOperationException → not caught as MalformedTargetData → flags stay false.
+        bool malformedNavTypeOk;
+        {
+            bool dictOk = false, listOk = false;
+            var pkg = new Package(new FormKey(mKey, 0x913u), SkyrimRelease.SkyrimSE);
+            pkg.Data[(sbyte)0] = null!;   // present-but-null dict entry (Data is non-null/empty on a fresh Package)
+            try { WriteEngine.ApplyVerb(pkg, new WriteRequest { RecordType = "Package", Path = new[] { "Data[0]", "Data" }, Verb = "Set", Value = "true" }); }
+            catch (MalformedTargetDataException ex) { dictOk = ex.Message.Contains("malformed", StringComparison.OrdinalIgnoreCase); }
+            catch { }
+            var fac = new Faction(new FormKey(mKey, 0x914u), SkyrimRelease.SkyrimSE);
+            WriteEngine.ApplyVerb(fac, new WriteRequest { RecordType = "Faction", Path = new[] { "Conditions" }, Verb = "Add", Struct = new StructSpec { Type = "ConditionFloat" } });
+            fac.Conditions![0] = null!;   // present-but-null list element (Conditions materialized with one element by the Add)
+            try { WriteEngine.ApplyVerb(fac, new WriteRequest { RecordType = "Faction", Path = new[] { "Conditions[0]", "CompareOperator" }, Verb = "Set", Value = "EqualTo" }); }
+            catch (MalformedTargetDataException ex) { listOk = ex.Message.Contains("malformed", StringComparison.OrdinalIgnoreCase); }
+            catch { }
+            malformedNavTypeOk = dictOk && listOk;
+            Console.WriteLine($"   MALFORMED-NAV-TYPE present-but-null : {(malformedNavTypeOk ? "PASS — StepIntoElement throws MalformedTargetDataException (the distinct third category, 'malformed' message) for a present-but-null dict entry AND list element" : $"FAIL — dictOk={dictOk} listOk={listOk}")}");
+        }
+
         // ====== Gap 3 (PR #83 follow-up) — surface a Remove that removes NOTHING (close the silent-no-op) ======
         // list Remove-by-value and dict Remove-by-key IGNORED the runtime Remove's bool, so "remove X" when X isn't
         // present SILENTLY succeeded (a Q3 silent degradation — reports success having changed nothing). Now all three
@@ -1706,6 +1749,7 @@ public static class NestedCreateGuardProbe
                     && gap3RejBaseArmFieldOk && gap3OkArmFieldUnchangedOk
                     && expectedRejSetIdxOobOk && expectedRejRemoveIdxOobOk && expectedOkSetIdxInRangeOk && expectedNavTypeOk
                     && expectedRejNavE2eOk
+                    && malformedNavTypeOk
                     && removeRejDictKeyAbsentOk && removeRejNullCollOk && removeRejListValAbsentOk
                     && removeOkPresentDictOk && removeOkPresentListOk;
         Console.WriteLine($"=== nested-create-guard: {(pass ? "PASS" : "FAIL")} ===");

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -271,7 +271,19 @@ namespace HousecarlGenerator;
 ///   EXPECTED-OK-SETIDX-INRANGE — an in-range SetAtIndex[0] still APPLIES (value lands; the new pre-check doesn't over-reject).
 ///   EXPECTED-NAV-TYPE          — the shared StepIntoElement throws the EXPECTED kind for an absent dict entry AND an out-of-bounds list index. RED: plain IOE.
 ///   EXPECTED-REJ-NAV-E2E       — a mid-path nav reject (Package.Data[5].Name, absent key) renders cleanly THROUGH WritePatchBuilder, NO file. RED: wrapped.
-///   (Left LOUD by design: present-but-null element/entry, bad-SHAPE index, structural/reflection failures — not clean live-state addressing.)
+///   (Left LOUD by design: bad-SHAPE index, structural/reflection failures — not clean live-state addressing. Present-but-null
+///    is now its own MalformedTargetDataException third category — see below.)
+///
+/// Gap 3 (PR #83 follow-up) — surface a Remove that removes NOTHING (close the silent-no-op). list Remove-by-value and
+/// dict Remove-by-key ignored the runtime Remove's bool, so "remove X" when X isn't present SILENTLY succeeded (Q3
+/// degradation). Now all three forms surface as the EXPECTED kind ("nothing to remove") — the symmetric twin of Add's
+/// duplicate-key refusal; consistent with Remove-by-INDEX already surfacing out-of-range (Aaron 2026-06-18: surface, not
+/// idempotent). REMOVE-* disambiguates from the GAP3-* dict-element-COMPOSITION arms:
+///   REMOVE-REJ-DICTKEY-ABSENT  — a dict Remove of a key not present refuses cleanly E2E, NO file. RED before: silent success → file written.
+///   REMOVE-REJ-NULLCOLL        — a Remove on an absent (null) collection refuses cleanly E2E, NO file. RED before: silent no-op → file written.
+///   REMOVE-REJ-LISTVAL-ABSENT  — a list Remove-by-value of a value not present throws the EXPECTED kind (in-memory). RED before: no throw.
+///   REMOVE-OK-PRESENT-DICT     — a dict Remove of a PRESENT key still succeeds (no over-reject of a real removal).
+///   REMOVE-OK-PRESENT-LIST     — a list Remove-by-value of a PRESENT value still succeeds (no over-reject).
 /// </summary>
 public static class NestedCreateGuardProbe
 {
@@ -1590,6 +1602,87 @@ public static class NestedCreateGuardProbe
                 && !msg.Contains("real inconsistency", StringComparison.OrdinalIgnoreCase)
                 && !msg.Contains("pre-flight ACCEPTED", StringComparison.OrdinalIgnoreCase));
 
+        // ====== Gap 3 (PR #83 follow-up) — surface a Remove that removes NOTHING (close the silent-no-op) ======
+        // list Remove-by-value and dict Remove-by-key IGNORED the runtime Remove's bool, so "remove X" when X isn't
+        // present SILENTLY succeeded (a Q3 silent degradation — reports success having changed nothing). Now all three
+        // forms — dict key absent, list value absent, and a Remove on an absent (null) collection — SURFACE as the
+        // EXPECTED kind ("nothing to remove"): the symmetric twin of Add's duplicate-key refusal, and consistent with
+        // Remove-by-INDEX already surfacing out-of-range. Decision: Aaron 2026-06-18 (surface, not idempotent). (REMOVE-*
+        // prefix disambiguates from the existing GAP3-* dict-element-COMPOSITION arms.)
+
+        // ---------- REMOVE-REJ-DICTKEY-ABSENT: a dict Remove of a key NOT present refuses cleanly E2E, NO file ----------
+        // A fresh Package's Data is an empty NON-null dict, so apply reaches the runtime Remove (returns false). RED before:
+        // the false was ignored → silent success → a no-op patch was WRITTEN (refused=False, noFile=False).
+        bool removeRejDictKeyAbsentOk = RejectArm("REMOVE-REJ-DICTKEY-ABSENT no key  ", tmpDir, "RmDictKey", mPath, rulebook,
+            new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "Package", EditorId = "HcNcRmDictKey",
+                    Edits = new[] { new WriteRequest { RecordType = "Package", Path = new[] { "Data" }, Verb = "Remove", Key = "0" } } },
+            },
+            msg => msg.Contains("nothing to remove", StringComparison.OrdinalIgnoreCase)
+                && !msg.Contains("real inconsistency", StringComparison.OrdinalIgnoreCase)
+                && !msg.Contains("pre-flight ACCEPTED", StringComparison.OrdinalIgnoreCase));
+
+        // ---------- REMOVE-REJ-NULLCOLL: a Remove on an ABSENT (null) collection refuses cleanly E2E, NO file ----------
+        // A fresh Faction's Conditions is null (the absent-collection case, (a)). RED before: the null-collection
+        // early-return silently no-op'd → a no-op patch was WRITTEN.
+        bool removeRejNullCollOk = RejectArm("REMOVE-REJ-NULLCOLL absent coll   ", tmpDir, "RmNullColl", mPath, rulebook,
+            new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "Faction", EditorId = "HcNcRmNull",
+                    Edits = new[] { new WriteRequest { RecordType = "Faction", Path = new[] { "Conditions" }, Verb = "Remove", Key = "5" } } },
+            },
+            msg => msg.Contains("nothing to remove", StringComparison.OrdinalIgnoreCase)
+                && !msg.Contains("real inconsistency", StringComparison.OrdinalIgnoreCase)
+                && !msg.Contains("pre-flight ACCEPTED", StringComparison.OrdinalIgnoreCase));
+
+        // ---------- REMOVE-REJ-LISTVAL-ABSENT: a list Remove-by-value of a value NOT present throws the EXPECTED kind ----
+        // Direct engine (a String list never references a master): Add "MT_Run" (list non-null, ["MT_Run"]) then Remove
+        // "MT_Walk" (absent). RED before: List<T>.Remove returned false, ignored → no throw → flag stays false.
+        bool removeRejListValAbsentOk;
+        {
+            var race = new Race(new FormKey(mKey, 0x910u), SkyrimRelease.SkyrimSE);
+            WriteEngine.ApplyVerb(race, new WriteRequest { RecordType = "Race", Path = new[] { "MovementTypeNames" }, Verb = "Add", Value = "MT_Run" });
+            bool surfaced = false;
+            try { WriteEngine.ApplyVerb(race, new WriteRequest { RecordType = "Race", Path = new[] { "MovementTypeNames" }, Verb = "Remove", Value = "MT_Walk" }); }
+            catch (ExpectedApplyRejectionException) { surfaced = true; }
+            catch { }
+            removeRejListValAbsentOk = surfaced && race.MovementTypeNames is { Count: 1 };
+            Console.WriteLine($"   REMOVE-REJ-LISTVAL-ABSENT no value : {(removeRejListValAbsentOk ? "PASS — a list Remove-by-value of an absent value surfaces (EXPECTED kind); the present element is untouched" : $"FAIL — surfaced={surfaced}")}");
+        }
+
+        // ---------- REMOVE-OK-PRESENT-DICT: a dict Remove of a PRESENT key still succeeds (no over-reject) ----------
+        // Add a composed PackageDataBool at key 0, then Remove it: the runtime Remove returns true → no throw, dict emptied.
+        bool removeOkPresentDictOk;
+        {
+            var pkg = new Package(new FormKey(mKey, 0x911u), SkyrimRelease.SkyrimSE);
+            bool threw = false;
+            try
+            {
+                WriteEngine.ApplyVerb(pkg, new WriteRequest { RecordType = "Package", Path = new[] { "Data" }, Verb = "Add", Key = "0",
+                    Struct = new StructSpec { Type = "PackageDataBool", Fields = new Dictionary<string, string> { ["Data"] = "true" } } });
+                WriteEngine.ApplyVerb(pkg, new WriteRequest { RecordType = "Package", Path = new[] { "Data" }, Verb = "Remove", Key = "0" });
+            }
+            catch { threw = true; }
+            removeOkPresentDictOk = !threw && pkg.Data is { Count: 0 };
+            Console.WriteLine($"   REMOVE-OK-PRESENT-DICT present key  : {(removeOkPresentDictOk ? "PASS — a dict Remove of a PRESENT key still succeeds (the no-op surface does NOT over-reject a real removal)" : $"FAIL — threw={threw} count={pkg.Data?.Count}")}");
+        }
+
+        // ---------- REMOVE-OK-PRESENT-LIST: a list Remove-by-value of a PRESENT value still succeeds (no over-reject) ----------
+        bool removeOkPresentListOk;
+        {
+            var race = new Race(new FormKey(mKey, 0x912u), SkyrimRelease.SkyrimSE);
+            bool threw = false;
+            try
+            {
+                WriteEngine.ApplyVerb(race, new WriteRequest { RecordType = "Race", Path = new[] { "MovementTypeNames" }, Verb = "Add", Value = "MT_Run" });
+                WriteEngine.ApplyVerb(race, new WriteRequest { RecordType = "Race", Path = new[] { "MovementTypeNames" }, Verb = "Remove", Value = "MT_Run" });
+            }
+            catch { threw = true; }
+            removeOkPresentListOk = !threw && race.MovementTypeNames is { Count: 0 };
+            Console.WriteLine($"   REMOVE-OK-PRESENT-LIST present val  : {(removeOkPresentListOk ? "PASS — a list Remove-by-value of a PRESENT value still succeeds (no over-reject)" : $"FAIL — threw={threw} count={race.MovementTypeNames?.Count}")}");
+        }
+
         Console.WriteLine();
         bool pass = fixturesOk && oneshotOk && multiOk && intoTopicOk && intoCellOk
                     && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendOk
@@ -1612,7 +1705,9 @@ public static class NestedCreateGuardProbe
                     && gap3RejBaseArmOk && gap3RejBaseArmListOk && gap3OkBaseNoOverRejectOk && gap3RejBaseArmE2eOk
                     && gap3RejBaseArmFieldOk && gap3OkArmFieldUnchangedOk
                     && expectedRejSetIdxOobOk && expectedRejRemoveIdxOobOk && expectedOkSetIdxInRangeOk && expectedNavTypeOk
-                    && expectedRejNavE2eOk;
+                    && expectedRejNavE2eOk
+                    && removeRejDictKeyAbsentOk && removeRejNullCollOk && removeRejListValAbsentOk
+                    && removeOkPresentDictOk && removeOkPresentListOk;
         Console.WriteLine($"=== nested-create-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return pass ? 0 : 1;

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -128,6 +128,22 @@ namespace HousecarlGenerator;
 ///   GAP1-REJ-E2E               — a malformed mid-path key refuses end-to-end with NO file written (review hardening); the
 ///                                PRE-FLIGHT 'does not coerce to sbyte', not the apply sbyte FormatException, proves the gate.
 ///
+/// GAP 1 (cont.) — mid-path LIST-index VALUE-SHAPE (the list twin of the dict-key mid-path gate above; the one-segment-up
+/// twin of the leaf KEYSHAPE-REJ-NEGIDX arm). ValidateFromType's bracketed MID-PATH list branch checked the index with a
+/// bare int.TryParse, which ACCEPTS a negative ('-1' parses) — but apply's StepIntoElement list branch requires idx &gt;= 0
+/// and throws a PLAIN InvalidOperationException (a SHAPE error, deliberately not an ExpectedApplyRejection), so a negative
+/// mid-path index ('Conditions[-1].field') was accepted then threw under the "real inconsistency" wrapper. The LEAF index
+/// was already on IsValidListIndexValue; the mid-path hop drifted. The fix points it onto the SAME recognizer, so leaf and
+/// mid-path can't drift (after it, the apply non-negative throw is unreachable on the gated path; it stays as defense-in-depth):
+///   GAP1-REJ-MIDLISTIDX-NEG    — a NEGATIVE mid-path list index ('Conditions[-1].CompareOperator') refuses at PRE-FLIGHT
+///                                (Faction.Conditions = List&lt;Condition&gt;, a struct-element list; a valid enum leaf so ONLY
+///                                the index is at fault). RED before: accepted (bare int.TryParse passed '-1').
+///   GAP1-OK-MIDLISTIDX         — a VALID non-negative mid-path list index ('Conditions[0].CompareOperator') stays accepted (no over-reject).
+///   GAP1-REJ-NEGIDX-E2E        — a negative mid-path list index refuses end-to-end with NO file written; op1 composes a
+///                                ConditionFloat to materialize the list (non-null) so apply truly reaches the negative-index
+///                                throw, then op2 navigates [-1]. RED before: the apply throw under the inconsistency wrapper;
+///                                with the fix the PRE-FLIGHT 'non-negative integer' (anti-wrapper asserts) proves the gate.
+///
 /// GAP 2 — NON-FORMLINK coercible collection ELEMENT VALUE-SHAPE (the value twin of step-4a + the dict-Set value block).
 /// A non-null, non-formlink, MALFORMED coercible element value on list Add/SetAtIndex/ReplaceAll/Remove-by-value and dict
 /// Add/Merge/ReplaceAll passed pre-flight then threw UNNAMED at apply (Coerce -> float.Parse/byte.Parse). dict-Set value
@@ -917,6 +933,62 @@ public static class NestedCreateGuardProbe
             },
             msg => msg.Contains("does not coerce to sbyte", StringComparison.OrdinalIgnoreCase));
 
+        // ====== GAP 1 (cont.) — mid-path LIST-index VALUE-SHAPE (the list twin of the dict-key mid-path gate above) ======
+        // ValidateFromType's bracketed MID-PATH list branch checked the index with a bare int.TryParse, which ACCEPTS a
+        // negative ('-1' parses fine) — but apply's StepIntoElement list branch requires idx >= 0 and throws a PLAIN
+        // InvalidOperationException (NOT an ExpectedApplyRejectionException, by design — it's a SHAPE error, not live
+        // state). So a negative mid-path index ('Conditions[-1].field') was accepted at pre-flight then threw at apply
+        // and got the misleading "real inconsistency" wrapper. The LEAF list index was already reconciled onto
+        // WriteEngine.IsValidListIndexValue (KEYSHAPE-REJ-NEGIDX, parseable non-negative int32); the mid-path hop drifted.
+        // The fix points the mid-path check onto that SAME recognizer, so the leaf and the mid-path hop can't drift —
+        // after it, the apply-side non-negative throw is unreachable on the gated path (both non-integer AND negative are
+        // caught at pre-flight; the apply throw stays as defense-in-depth, shared with the READ path).
+
+        // ---------- GAP1-REJ-MIDLISTIDX-NEG: a NEGATIVE mid-path list index refuses at PRE-FLIGHT ----------
+        // Faction.Conditions = List<Condition> is a struct-element (Condition Kind=polymorphic-base, NOT record) list,
+        // hence mid-path-navigable; 'CompareOperator' (a valid enum 'EqualTo') is the writable leaf so ONLY the index is
+        // at fault. RED before: accepted (the bare int.TryParse passed '-1'), then apply threw the plain non-negative IOE
+        // under the inconsistency wrapper.
+        bool gap1RejMidListIdxNegOk;
+        {
+            var req = new WriteRequest { RecordType = "Faction", Path = new[] { "Conditions[-1]", "CompareOperator" }, Verb = "Set", Value = "EqualTo" };
+            var reject = rulebook.Validate(req);
+            gap1RejMidListIdxNegOk = reject is not null && reject.Contains("non-negative integer", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   GAP1-REJ-MIDLISTIDX-NEG neg index  : {(gap1RejMidListIdxNegOk ? "PASS — a negative mid-path list index is refused at pre-flight (reconciled onto IsValidListIndexValue; no leaf/mid-path drift)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- GAP1-OK-MIDLISTIDX: a VALID (non-negative) mid-path list index + valid leaf Set stays accepted ----------
+        bool gap1OkMidListIdxOk;
+        {
+            var req = new WriteRequest { RecordType = "Faction", Path = new[] { "Conditions[0]", "CompareOperator" }, Verb = "Set", Value = "EqualTo" };
+            var reject = rulebook.Validate(req);
+            gap1OkMidListIdxOk = reject is null;
+            Console.WriteLine($"   GAP1-OK-MIDLISTIDX valid index     : {(gap1OkMidListIdxOk ? "PASS — a valid non-negative mid-path list index (Conditions[0]) is NOT over-rejected" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- GAP1-REJ-NEGIDX-E2E: a negative mid-path list index refuses end-to-end with NO file written ----------
+        // The apply-time negative-index throw only bites a NON-NULL list — on a list that is null (a fresh record's
+        // default), StepIntoElement's absent-collection ExpectedApplyRejection fires FIRST (already clean), masking the
+        // bug. So op1 composes a ConditionFloat to MATERIALIZE Conditions (non-null, 1 element; the proven-good list
+        // compose of GAP3-OK-LIST-UNCHANGED), then op2 navigates Conditions[-1] — faithfully reproducing the bug:
+        // WITHOUT the fix, pre-flight accepts both, apply lands op1 then op2 hits StepIntoElement's list branch and throws
+        // the PLAIN non-negative IOE → the misleading "real inconsistency" wrapper (RED — the anti-wrapper asserts catch
+        // it). WITH the fix, Phase-1 pre-flight rejects op2 (the whole all-or-nothing create is refused, NOTHING created,
+        // op1 never lands) with the clean gate message ('non-negative integer'), NO file written — model: GAP1-REJ-E2E.
+        bool gap1RejNegIdxE2eOk = RejectArm("GAP1-REJ-NEGIDX-E2E neg mid index ", tmpDir, "Gap1NegIdx", mPath, rulebook,
+            new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "Faction", EditorId = "HcNcG1NegIdx",
+                    Edits = new[]
+                    {
+                        new WriteRequest { RecordType = "Faction", Path = new[] { "Conditions" }, Verb = "Add", Struct = new StructSpec { Type = "ConditionFloat" } },
+                        new WriteRequest { RecordType = "Faction", Path = new[] { "Conditions[-1]", "CompareOperator" }, Verb = "Set", Value = "EqualTo" },
+                    } },
+            },
+            msg => msg.Contains("non-negative integer", StringComparison.OrdinalIgnoreCase)
+                && !msg.Contains("real inconsistency", StringComparison.OrdinalIgnoreCase)
+                && !msg.Contains("pre-flight ACCEPTED", StringComparison.OrdinalIgnoreCase));
+
         // ====== GAP 2 — NON-FORMLINK coercible collection ELEMENT VALUE-SHAPE ======
         // The value twin of step-4a (formlink elements) and of the dict-Set value block. A non-null, non-formlink,
         // MALFORMED coercible element value on list Add/SetAtIndex/ReplaceAll/Remove-by-value and dict Add/Merge/ReplaceAll
@@ -1529,6 +1601,7 @@ public static class NestedCreateGuardProbe
                     && keyShapeRejSetIdxOk && keyShapeRejNegIdxOk && keyShapeRejListRemoveIdxOk
                     && keyShapeOkDictAddOk && keyShapeOkSetIdxOk && keyShapeOkNumEnumSetOk && keyShapeRejE2eOk
                     && gap1RejMidKeySbyteOk && gap1OkMidKeyOk && gap1RejE2eOk
+                    && gap1RejMidListIdxNegOk && gap1OkMidListIdxOk && gap1RejNegIdxE2eOk
                     && gap2RejDictAddOk && gap2RejListAddOk && gap2RejListReplaceAllOk && gap2RejListRemoveOk && gap2RejDictMergeOk
                     && gap2OkValidOk && gap2OkRemoveByIndexOk && gap2FormlinkRouteOk && gap2OkOffcardSlotOk && gap2RejE2eOk
                     && g6RejRecordAddOk && g6RejRecordReplaceAllOk && g6OkRemoveByIndexOk && g6OkStructUnchangedOk && g6RejE2eOk


### PR DESCRIPTION
Follow-up to [#83](https://github.com/Avick3110/houseCARL/pull/83) (write-path "expected apply rejection" clean-render). Three items surfaced in that session and were not addressed: one verified bug + two labeling/behavior decisions. Handled as ONE batch, commit-granular, per Aaron's standing preference (ID them all, one branch, don't fragment). Independent adversarial review: **APPROVE** (no correctness bugs, no Q3 holes, no over-rejects, no by-construction violations).

Each gap was verified against current code (`main` @ `01269e0`) before acting; each fix is RED-proven (revert → arm FAILs → restore). `nested-create-guard` 86 → 95 arms, all green; full Release build clean; `gendered-nav` / `poly-field-descend` / `nullarm` / `vmad-poly` ALL PASS, `value-predicate` 31/0, `coerce-audit` PASS. By construction throughout — no generator/corpus change, tool surface stays 21, §4-(a) (cornerstone untouched).

## Gap 1 — negative mid-path list index (VERIFIED BUG · `6f31696`)
`CorpusRulebook` gated the mid-path list index with a bare `int.TryParse` (ACCEPTS `-1`), while apply's `StepIntoElement` requires `idx >= 0` and throws a **plain** `InvalidOperationException` → the misleading *"pre-flight ACCEPTED it but the apply threw — a real inconsistency"* wrapper. The leaf index was already reconciled onto `WriteEngine.IsValidListIndexValue`; only the mid-path hop had drifted. Fix points it onto that same recognizer (gate↔apply can't drift). Arms: `GAP1-REJ-MIDLISTIDX-NEG`, `GAP1-OK-MIDLISTIDX` (no over-reject), `GAP1-REJ-NEGIDX-E2E` (no file).

## Gap 3 — Remove that removes nothing (DECISION: surface · `c430fb2`)
**Aaron-approved 2026-06-18: surface, not idempotent.** List `Remove`-by-value and dict `Remove`-by-key ignored the runtime `Remove`'s bool → removing an absent value/key **silently reported success** (Q3 degradation; asymmetric with Remove-by-index's out-of-range and Add's duplicate-key surfacing). Now all three forms (dict key absent, list value absent, Remove on an absent/null collection) surface as `ExpectedApplyRejectionException` ("nothing to remove"), all-or-nothing, no file. Remove-by-index unchanged; a present-key/value Remove unaffected. Arms: `REMOVE-REJ-DICTKEY-ABSENT`, `REMOVE-REJ-NULLCOLL`, `REMOVE-REJ-LISTVAL-ABSENT`, `REMOVE-OK-PRESENT-DICT/LIST`.

⚠️ **Behavior change (reviewer Finding 1, for 1.3.0 release notes):** a script that relied on "Remove X if present" being a safe no-op now gets the whole call refused when X is absent. Deliberate per the decision; no internal caller depends on the old behavior.

## Gap 2 — present-but-null target data = third category (DECISION: dedicated · `831aeb6`)
**Aaron-approved 2026-06-18: dedicated third category.** A present-but-null collection element / dict entry threw a plain IOE → wrapped as "real inconsistency", mislabeling pre-existing malformed **source** data (not user input, not an engine bug) as an internal inconsistency. New `MalformedTargetDataException` — a distinct third category, sibling to `ExpectedApplyRejectionException` — caught distinctly in both `WritePatchBuilder.Apply` and `CreateRecords`, rendered accurately. Arm: `MALFORMED-NAV-TYPE` (dict entry + list element throw the third kind with a "malformed" message).

> **Honest coverage note:** a full E2E render arm isn't feasible — the present-but-null state can't be produced through houseCARL's write path (the null gates forbid it) and Mutagen won't serialize a null element to synthesize a malformed fixture. The arm proves the throw KIND + message; the type deterministically routes to the dedicated catch (a verbatim passthrough mirroring the proven `ExpectedApplyRejection` catch). The reviewer independently confirmed there's no write-path route to the state.

## Low-confidence note (from the PR #83 session) — confirmed a non-issue
The worry that reclassifying the absent-collection nav-throw could mask a silent compose no-op: `BuildStruct`/`Instantiate`/`Coerce` always return a non-null instance or throw — no silent-no-op compose path — and all-or-nothing Phase 3 stops on the first throw, so the masking scenario can't occur. No code.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)