### PR TITLE
docs: drop CellBlock from the G8 self-listing-bases comment (now a struct)

### DIFF
--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -242,7 +242,7 @@ namespace HousecarlGenerator;
 /// (FindUnionArms keeps it; only an ABSTRACT base like Condition is filtered by !IsAbstract), so the arms.Contains branch
 /// would admit it too and GAP3-REJ-BADARM's message advertised it. The fix rejects composing the base by its own name and
 /// filters the base out of the legal-arms set everywhere (Contains + every message) at BOTH composition entry points —
-/// StructElementLegality (collection elements: the 4 self-listing bases APackageData/BaseLayer/CellBlock/ScriptProperty)
+/// StructElementLegality (collection elements: the 3 self-listing bases APackageData/BaseLayer/ScriptProperty)
 /// AND its sibling ArmLegality (standalone polymorphic FIELDS: DialogResponsesAdapter.ScriptFragments,
 /// GenderedItem&lt;SimpleModel&gt; — the twin found in a completeness sweep, folded in Aaron 2026-06-18). Recognizer = corpus
 /// poly-base KIND, NOT Type.IsAbstract (APackageData is concrete, so IsAbstract would miss the silent-write case). By


### PR DESCRIPTION
One-line doc-comment tidy deferred from #86. PR #86 reclassified `CellBlock` poly-base → struct (the read-only-projection leak fix), so it is no longer one of the self-listing poly-bases the G8 gate filters at `StructElementLegality`. The comment now reads 3 bases (`APackageData`/`BaseLayer`/`ScriptProperty`).

Comment-only, provably inert — the G8 gate keys on corpus `Kind` (data-driven), not this prose list. Held back from #86 to avoid a conflict with #85 (now merged); this is that tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)