### PR TITLE
write: Layer B unit B — on-disk voice (.fuz/.lip) presence check on dialogue-line create

### DIFF
--- a/src/housecarl-core/VoiceCheck.cs
+++ b/src/housecarl-core/VoiceCheck.cs
@@ -158,6 +158,18 @@ public static class VoiceCheck
     {
         var topicEdid = topic.EditorID ?? "";
 
+        // No own response lines: either a link/branch node (no spoken audio — skip silently) or one that BORROWS
+        // another INFO's audio via ResponseData (it IS voiced, but under the OTHER INFO's path, not computable here).
+        // The borrowed case must be NAMED, not silently produce nothing (Q3 — a "false nothing").
+        if (info.Responses.Count == 0)
+        {
+            var sharedFk = NonNull(info.ResponseData.FormKeyNullable);
+            if (sharedFk is { } sfk)
+                undetermined.Add(new VoiceUndetermined(info.FormKey, topicEdid,
+                    $"no own response lines — this line draws its audio from shared response data ({sfk}); voice is not checked here, verify that INFO's .fuz."));
+            return;   // ResponseData null ⇒ a genuine link/branch node: no spoken audio to check
+        }
+
         // Speaker -> the voice type (folder). Null Speaker is the runtime quest-alias case: no computable path (Q3).
         var speakerFk = NonNull(info.Speaker.FormKeyNullable);
         if (speakerFk is null)
@@ -167,10 +179,20 @@ public static class VoiceCheck
                 "Set Speaker on this line to make it checkable, or verify the audio yourself."));
             return;
         }
-        if (resolve(speakerFk.Value) is not INpcGetter npc)
+        // Two distinct misses, two distinct messages (Q3 — don't say "not found" for a record that WAS found): the
+        // FormKey resolves to nothing, vs it resolves to a record that isn't an NPC (Speaker is typed as a FormLink to
+        // an NPC, but real/odd data can point it elsewhere, and the voice type is derived only from an NPC's Voice).
+        var speaker = resolve(speakerFk.Value);
+        if (speaker is null)
         {
             undetermined.Add(new VoiceUndetermined(info.FormKey, topicEdid,
-                $"Speaker NPC {speakerFk.Value} not found in the patch or load order — can't resolve the voice type."));
+                $"Speaker {speakerFk.Value} not found in the patch or load order — can't resolve the voice type."));
+            return;
+        }
+        if (speaker is not INpcGetter npc)
+        {
+            undetermined.Add(new VoiceUndetermined(info.FormKey, topicEdid,
+                $"Speaker {speakerFk.Value} resolves to a non-NPC record — houseCARL derives the voice type from an NPC's Voice, so it can't compute a voice path here; verify the audio yourself."));
             return;
         }
         var voiceFk = NonNull(npc.Voice.FormKeyNullable);

--- a/src/housecarl-core/VoiceCheck.cs
+++ b/src/housecarl-core/VoiceCheck.cs
@@ -1,0 +1,214 @@
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+
+namespace HousecarlCore;
+
+// ======================================================================
+//  VoiceCheck — the on-disk voice (.fuz/.lip) PRESENCE check for created dialogue lines
+//  (nested-dialogue plan §3.5, Layer B unit B). A byte-valid INFO with no .fuz on disk plays
+//  NOTHING — the exact silent-failure class houseCARL refuses (Q3). This runs as a POST-WRITE
+//  step on a successful create: for every CREATED voiced INFO it computes each response line's
+//  expected voice path (VoicePath), checks it against the live VFS (AssetResolver — loose + BSA),
+//  and reports a loud "WILL BE SILENT" line when the audio is absent, OR a loud, NAMED reason
+//  when the path can't even be computed (no Speaker, etc.) — never a false "fine".
+//
+//  CORNERSTONE-CLEAN: this is a DIAGNOSTIC over records the engine already wrote — it adds NO
+//  per-record write logic and is deliberately SEPARATE from the proven WritePatchBuilder.CreateRecords
+//  path (which is untouched). It is driven by BOTH the service (post-create, with the live
+//  AssetResolver) and the nested-create CI guard (with a temp AssetResolver over a planted .fuz),
+//  so the present/silent/undeterminable verdict is end-to-end testable in CI.
+//
+//  HOW IT RESOLVES THE GRAPH (the voice path needs more than the FormKey — see VoicePath):
+//    • parent topic — found by WALKING the written patch's DialogTopics: the created INFO lives in
+//      some topic's Responses (for an existing parent the patch carries its OVERRIDE, deep-copied
+//      with EditorID + Quest intact; for a same-call parent it's the new topic). So topic EDID + the
+//      Quest link come straight off the patch — no spec threading, works for same-call AND existing parents.
+//    • voice type — INFO.Speaker -> Npc.Voice -> VoiceType.EditorID, each resolved patch-first then
+//      load-order (a same-call NPC/quest lives in the patch; an existing one in the order). Speaker
+//      null -> the runtime quest-alias case -> NO computable path (a NAMED undetermined reason, Q3).
+//    • quest EDID — the topic's Quest -> Quest.EditorID (empty when the topic has no quest).
+//
+//  Resolution reuses the read idiom (ResolveWinner -> GetRecord re-enumerates the winner overlay),
+//  cached per FormKey for the run — a create post-step, not a hot bulk scan; a handful of resolves.
+// ======================================================================
+
+/// <summary>One created INFO response line's voice verdict: the expected <see cref="FuzPath"/> (the spoken
+/// audio — absence ⇒ the line is SILENT) and <see cref="LipPath"/> (lip-sync — absence ⇒ no mouth movement,
+/// audio still plays), each with its on-disk presence + the winning provider, plus the
+/// <see cref="ReadIncomplete"/> caveat (a BSA failed to read, so an "absent" may merely be unscanned — Q3).</summary>
+public sealed record VoiceLine(
+    FormKey Info, string TopicEditorId, int ResponseNumber,
+    string FuzPath, bool FuzPresent, string? FuzWinner, bool FuzAmbiguous,
+    string LipPath, bool LipPresent,
+    bool ReadIncomplete);
+
+/// <summary>A created INFO whose voice path could NOT be computed, with the NAMED reason (Q3 — never a
+/// silent "fine"): no Speaker (voice type assigned at runtime from a quest alias), an unresolvable
+/// speaker/voice-type, etc. The whole INFO is reported once; its lines are not checked.</summary>
+public sealed record VoiceUndetermined(FormKey Info, string TopicEditorId, string Reason);
+
+/// <summary>The voice-coverage report for one create call: per-line presence verdicts and per-INFO
+/// undeterminable reasons. <see cref="IsEmpty"/> when the call created no voiced INFO lines.</summary>
+public sealed record VoiceReport(IReadOnlyList<VoiceLine> Lines, IReadOnlyList<VoiceUndetermined> Undetermined)
+{
+    /// <summary>The voice check itself could not run (the patch wouldn't re-open, the walk threw) — surfaced, never a
+    /// silent skip (Q3). The create ALREADY SUCCEEDED when this is set; it just means "I couldn't verify voice
+    /// coverage", not "the write failed". Null on a clean run.</summary>
+    public string? CheckError { get; init; }
+
+    public bool IsEmpty => Lines.Count == 0 && Undetermined.Count == 0 && CheckError is null;
+    public static readonly VoiceReport Empty = new(Array.Empty<VoiceLine>(), Array.Empty<VoiceUndetermined>());
+}
+
+public static class VoiceCheck
+{
+    /// <summary>The catalog name (RecordNaming.StripGetterInterface of IDialogResponsesGetter) the create flow
+    /// stamps on a created INFO — the filter for "which created records are dialogue lines".</summary>
+    public const string InfoCatalogName = "DialogResponses";
+
+    /// <summary>Run the voice-presence check over the INFOs created by ONE create call. <paramref name="patchPath"/> is
+    /// the just-written patch file (re-opened here read-only, then disposed — the overlay lifetime lives in core, so the
+    /// service needs no Mutagen.Skyrim dependency); <paramref name="created"/> is the call's CreatedRecord list (filtered
+    /// here to INFOs); <paramref name="resolver"/> resolves existing speaker/voice-type/quest records from the load order;
+    /// <paramref name="assets"/> answers on-disk presence (loose + BSA). Returns <see cref="VoiceReport.Empty"/> when the
+    /// call created no INFOs. A resolve MISS is a NAMED undetermined reason (Q3); a whole-check failure (the patch won't
+    /// re-open, the walk throws) is surfaced on <see cref="VoiceReport.CheckError"/> — NEVER thrown (the create already
+    /// succeeded; this is a verify step, not the write).</summary>
+    public static VoiceReport Run(string patchPath, IReadOnlyList<WritePatchBuilder.CreatedRecord> created,
+                                  LoadOrderResolver resolver, AssetResolver assets)
+    {
+        // Which created records are dialogue lines (INFOs) — only these get a voice check.
+        var infoKeys = new HashSet<FormKey>();
+        foreach (var c in created)
+            if (string.Equals(c.RecordType, InfoCatalogName, StringComparison.Ordinal))
+                infoKeys.Add(c.FormKey);
+        if (infoKeys.Count == 0) return VoiceReport.Empty;
+
+        ISkyrimModGetter? patch = null;
+        try
+        {
+            patch = SkyrimMod.CreateFromBinaryOverlay(patchPath, SkyrimRelease.SkyrimSE);
+            return RunOver(patch, infoKeys, resolver, assets);
+        }
+        catch (Exception ex)
+        {
+            return VoiceReport.Empty with { CheckError = $"{ex.GetType().Name}: {ex.Message}" };
+        }
+        finally { (patch as IDisposable)?.Dispose(); }
+    }
+
+    /// <summary>The walk over the re-opened patch (split out so <see cref="Run"/> can wrap the overlay open + any
+    /// walk-level throw into <see cref="VoiceReport.CheckError"/>, while per-INFO resolve misses stay NAMED undetermined).</summary>
+    static VoiceReport RunOver(ISkyrimModGetter writtenPatch, HashSet<FormKey> infoKeys,
+                               LoadOrderResolver resolver, AssetResolver assets)
+    {
+        var lines = new List<VoiceLine>();
+        var undetermined = new List<VoiceUndetermined>();
+
+        // Same-call record lookup off the patch (an NPC / quest / topic created in THIS call lives here, not the
+        // load order). One pass; FormKeys are unique within a mod.
+        var patchByKey = new Dictionary<FormKey, IMajorRecordGetter>();
+        foreach (var rec in writtenPatch.EnumerateMajorRecords())
+            patchByKey[rec.FormKey] = rec;
+
+        using var session = resolver.OpenSession();
+        var view = resolver.Capture();                       // pin ONE index build for every resolve in this run
+        var av = assets.Capture();                           // …and ONE asset build, so presence + ReadIncomplete agree
+        var loCache = new Dictionary<FormKey, IMajorRecordGetter?>();
+
+        // Resolve a FormKey to its record getter: the patch first (same-call records), else the load-order winner
+        // (existing records). Cached so a bulk_create sharing a speaker doesn't re-enumerate a master per line.
+        IMajorRecordGetter? Resolve(FormKey fk)
+        {
+            if (patchByKey.TryGetValue(fk, out var p)) return p;
+            if (loCache.TryGetValue(fk, out var c)) return c;
+            IMajorRecordGetter? g = view.ResolveWinner(fk) is { } w ? view.GetRecord(session, w.WinnerPlugin, fk) : null;
+            loCache[fk] = g;
+            return g;
+        }
+
+        // Walk the patch's topics; each created INFO is in exactly one topic's Responses (its structural parent).
+        var foundInfos = new HashSet<FormKey>();
+        foreach (var topic in writtenPatch.DialogTopics)
+        {
+            foreach (var info in topic.Responses)
+            {
+                if (!infoKeys.Contains(info.FormKey)) continue;   // a pre-existing INFO the patch carried, or not ours
+                foundInfos.Add(info.FormKey);
+                CheckInfo(info, topic, Resolve, av, lines, undetermined);
+            }
+        }
+
+        // A created INFO not found under any topic is a real inconsistency — surfaced, never silently dropped (Q3).
+        foreach (var fk in infoKeys)
+            if (!foundInfos.Contains(fk))
+                undetermined.Add(new VoiceUndetermined(fk, "",
+                    "created but not found under any topic in the written patch — can't determine its voice path; inspect the patch in xEdit."));
+
+        return new VoiceReport(lines, undetermined);
+    }
+
+    /// <summary>Resolve one INFO's voice graph (topic+quest EDIDs, speaker voice type) and emit either a per-line
+    /// presence verdict for each spoken response, or ONE named undetermined reason (Q3) when the voice folder can't
+    /// be computed. An INFO with no spoken response lines (a link/branch node) yields nothing — there is no voice to check.</summary>
+    static void CheckInfo(IDialogResponsesGetter info, IDialogTopicGetter topic,
+                          Func<FormKey, IMajorRecordGetter?> resolve, AssetResolver.AssetView av,
+                          List<VoiceLine> lines, List<VoiceUndetermined> undetermined)
+    {
+        var topicEdid = topic.EditorID ?? "";
+
+        // Speaker -> the voice type (folder). Null Speaker is the runtime quest-alias case: no computable path (Q3).
+        var speakerFk = NonNull(info.Speaker.FormKeyNullable);
+        if (speakerFk is null)
+        {
+            undetermined.Add(new VoiceUndetermined(info.FormKey, topicEdid,
+                "no Speaker set — the voice type (folder) is assigned at runtime from the quest alias, so the .fuz path can't be computed. " +
+                "Set Speaker on this line to make it checkable, or verify the audio yourself."));
+            return;
+        }
+        if (resolve(speakerFk.Value) is not INpcGetter npc)
+        {
+            undetermined.Add(new VoiceUndetermined(info.FormKey, topicEdid,
+                $"Speaker NPC {speakerFk.Value} not found in the patch or load order — can't resolve the voice type."));
+            return;
+        }
+        var voiceFk = NonNull(npc.Voice.FormKeyNullable);
+        if (voiceFk is null)
+        {
+            undetermined.Add(new VoiceUndetermined(info.FormKey, topicEdid,
+                $"Speaker NPC {speakerFk.Value} has no Voice type set — can't compute the voice folder."));
+            return;
+        }
+        var voiceType = (resolve(voiceFk.Value) as IVoiceTypeGetter)?.EditorID;
+        if (string.IsNullOrEmpty(voiceType))
+        {
+            undetermined.Add(new VoiceUndetermined(info.FormKey, topicEdid,
+                $"the speaker's Voice type {voiceFk.Value} has no resolvable EditorID — can't name the voice folder."));
+            return;
+        }
+
+        // Quest EDID — the topic's quest's EditorID (empty when the topic has no quest; that's a real on-disk shape).
+        var questFk = NonNull(topic.Quest.FormKeyNullable);
+        var questEdid = questFk is { } qfk ? (resolve(qfk) as IQuestGetter)?.EditorID ?? "" : "";
+
+        // One .fuz/.lip check per spoken response line (its ResponseNumber names the file — used as-authored, Q3).
+        foreach (var resp in info.Responses)
+        {
+            int num = resp.ResponseNumber;
+            var fuz = VoicePath.For(info.FormKey, voiceType, questEdid, topicEdid, num, VoiceFile.Fuz);
+            var lip = VoicePath.For(info.FormKey, voiceType, questEdid, topicEdid, num, VoiceFile.Lip);
+            var fhit = av.Resolve(fuz);
+            var lhit = av.Resolve(lip);
+            lines.Add(new VoiceLine(
+                info.FormKey, topicEdid, num,
+                fuz, fhit.Exists, fhit.Winner?.Source, fhit.Ambiguous,
+                lip, lhit.Exists,
+                av.ReadIncomplete));
+        }
+    }
+
+    /// <summary>A nullable FormLink's target as a real FormKey, or null when the link is unset OR explicitly Null
+    /// (00000000) — both mean "no target", and a Null-FormKey segment would resolve nothing.</summary>
+    static FormKey? NonNull(FormKey? fk) => fk is { } v && !v.IsNull ? v : null;
+}

--- a/src/housecarl-core/VoicePath.cs
+++ b/src/housecarl-core/VoicePath.cs
@@ -1,0 +1,80 @@
+using Mutagen.Bethesda.Plugins;
+
+namespace HousecarlCore;
+
+// ======================================================================
+//  VoicePath — a dialogue line's voice .fuz/.lip path is a PURE TRANSFORM of
+//  {the INFO's FormKey, the speaker's voice type, the parent quest + topic EditorIDs,
+//  the response number} (nested-dialogue plan §3.5; sibling of FaceGenPath). NO load
+//  order, NO runtime FormID, NO file read: Skyrim resolves the spoken audio by
+//  FILESYSTEM CONVENTION (there is no Voice/Wav/Lip/FileName field on INFO/DialogResponse
+//  anywhere in the Mutagen corpus — see memory reference_skyrim_voice_file_naming), so a
+//  byte-valid INFO with no .fuz on disk plays NOTHING. This computes the path that audio
+//  must live at, so the create flow can check it and warn loud (Q3 — never a silent dead line).
+//
+//  THE RULE (the keystone — get it wrong and the "place audio here" path is wrong, a Q3
+//  silent-wrong answer; authoritative source is xEdit's InfoFileName, Export dialogues.pas,
+//  verified empirically 2026-06-19 against real loose .fuz files — e.g.
+//  Walks-Distant-Sands: WDSMainQue_WDSMainQuest1Co_00000013_1.fuz):
+//    Sound\Voice\<DefiningPlugin>\<VoiceType>\<QuestEDID[..10]>_<TopicEDID[..15]>_<00+6hexLocalID>_<ResponseNum>.fuz
+//
+//    • FOLDER1 = the DEFINING PLUGIN — the plugin in the INFO's FormKey (fk.ModKey.FileName),
+//      WITH extension, NOT the conflict winner. For create-into-a-new-patch that's the new
+//      patch (clean). For an override/in-place edit it would be the WINNER's plugin and the
+//      audio lives with the original (the override trap — out of scope for the create path,
+//      which assigns fresh patch-local 0x800+ ids).
+//    • FOLDER2 = the speaker's VoiceType EditorID (INFO.Speaker -> Npc.Voice -> VoiceType.EditorID),
+//      empirically the on-disk folder name (e.g. "FemaleArgonian"). Resolved by the caller — when
+//      it can't be (no Speaker; the runtime quest-alias case), there is NO path to compute (Q3).
+//    • QUEST seg = the parent topic's Quest's EditorID, truncated to 10 chars (empirically
+//      "WDSMainQue" = 10). Empty when the topic has no quest (the segment is just empty).
+//    • TOPIC seg = the parent DialogTopic's EditorID, truncated to 15 chars (empirically
+//      "WDSMainQuest1Co" = 15). Often EMPTY (a topic with no EditorID) -> the "__" double underscore.
+//    • ID    = the load-order index byte MASKED to "00", then the 6-hex local id: "00" + fk.ID("X6")
+//      (xEdit IntToHex(InfoFormID and $FFFFFF, 8)) — load-order-INDEPENDENT, exactly the
+//      FaceGenPath masking. e.g. local 0x13 -> "00000013".
+//    • NUM   = the DialogResponse's ResponseNumber (one .fuz per spoken line: _1, _2, …).
+//
+//  Built in core (not in the create tool) so the read side (a future voice-coverage diagnostic /
+//  the Unit C completeness validator) reuses the EXACT same transform — one home for the keystone.
+//  Backslash-separated to match the AssetResolver match form (backslash, OrdinalIgnoreCase);
+//  resolution is case-insensitive, so EDID case is preserved as-authored and the hex is upper.
+// ======================================================================
+
+/// <summary>Which voice file: the spoken audio (.fuz — absence = the line is SILENT) or the
+/// lip-sync (.lip — absence = no mouth movement, audio still plays). The "will be silent" verdict
+/// keys on the .fuz; the .lip is reported as a secondary caveat.</summary>
+public enum VoiceFile { Fuz, Lip }
+
+public static class VoicePath
+{
+    /// <summary>xEdit InfoFileName truncates the Quest EditorID to its first 10 chars (Copy(QuestEDID, 1, 10)),
+    /// verified empirically ("WDSMainQue" = 10).</summary>
+    public const int QuestEdidMax = 10;
+
+    /// <summary>…and the Topic/DIAL EditorID to its first 15 chars (Copy(TopicEDID, 1, 15)), verified
+    /// empirically ("WDSMainQuest1Co" = 15).</summary>
+    public const int TopicEdidMax = 15;
+
+    /// <summary>The Data-relative voice path for one created INFO line + slot — the pure transform (see the
+    /// file header). <paramref name="info"/> supplies BOTH the defining-plugin folder (info.ModKey.FileName)
+    /// and the 8-hex id ("00" + info.ID:X6); <paramref name="voiceType"/> is the speaker's VoiceType EditorID
+    /// folder; <paramref name="questEdid"/>/<paramref name="topicEdid"/> are the parent topic's quest+topic
+    /// EditorIDs (each truncated; null/empty -> an empty segment, a real on-disk shape); <paramref name="responseNumber"/>
+    /// is the spoken line's ResponseNumber. Backslash-separated.</summary>
+    public static string For(FormKey info, string voiceType, string? questEdid, string? topicEdid,
+                             int responseNumber, VoiceFile kind)
+    {
+        var plugin = info.ModKey.FileName.ToString();        // the DEFINING plugin in the FormKey, WITH extension
+        var id = "00" + info.ID.ToString("X6");              // index byte masked to 00, then the 6-hex local id
+        var q = Trunc(questEdid, QuestEdidMax);
+        var t = Trunc(topicEdid, TopicEdidMax);
+        var ext = kind == VoiceFile.Fuz ? "fuz" : "lip";
+        return $@"Sound\Voice\{plugin}\{voiceType}\{q}_{t}_{id}_{responseNumber}.{ext}";
+    }
+
+    /// <summary>First <paramref name="max"/> chars of an EditorID (xEdit's Copy(edid, 1, max)); empty stays empty
+    /// (the legitimate "__" double-underscore shape for a topic with no EditorID).</summary>
+    static string Trunc(string? s, int max)
+        => string.IsNullOrEmpty(s) ? "" : (s.Length <= max ? s : s.Substring(0, max));
+}

--- a/src/housecarl-core/VoicePath.cs
+++ b/src/housecarl-core/VoicePath.cs
@@ -26,6 +26,10 @@ namespace HousecarlCore;
 //    • FOLDER2 = the speaker's VoiceType EditorID (INFO.Speaker -> Npc.Voice -> VoiceType.EditorID),
 //      empirically the on-disk folder name (e.g. "FemaleArgonian"). Resolved by the caller — when
 //      it can't be (no Speaker; the runtime quest-alias case), there is NO path to compute (Q3).
+//      ASSUMPTION (the one unverified leg of the keystone): the on-disk folder == the VoiceType's
+//      EditorID. True for vanilla + the empirically-checked mods; a mod whose VoiceType EditorID
+//      diverges from the folder its audio actually ships under would get a wrong "place audio here"
+//      path. No counter-example seen, but it's the assumption to revisit first if a path is ever wrong.
 //    • QUEST seg = the parent topic's Quest's EditorID, truncated to 10 chars (empirically
 //      "WDSMainQue" = 10). Empty when the topic has no quest (the segment is just empty).
 //    • TOPIC seg = the parent DialogTopic's EditorID, truncated to 15 chars (empirically

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -133,6 +133,12 @@ public static class WritePatchBuilder
     {
         public IReadOnlyList<FullReadback>? ReadBack { get; init; }
 
+        /// <summary>The voice-coverage report for the INFOs this call created (Layer B unit B) — null unless the call
+        /// created ≥1 dialogue line. Filled by the SERVICE post-write (it owns the live AssetResolver), NOT by the core
+        /// create path: a `with { Voice = … }` enrich on the returned outcome, so <see cref="CreateRecords"/> stays a
+        /// pure record-write and the asset-layer dependency lives in the service. See <see cref="VoiceCheck"/>.</summary>
+        public VoiceReport? Voice { get; init; }
+
         public static CreateOutcome Fail(string error) =>
             new(false, error, "", false, Array.Empty<CreatedRecord>(), Array.Empty<string>(), 0);
     }

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -294,6 +294,24 @@ namespace HousecarlGenerator;
 ///   REMOVE-REJ-LISTVAL-ABSENT  — a list Remove-by-value of a value not present throws the EXPECTED kind (in-memory). RED before: no throw.
 ///   REMOVE-OK-PRESENT-DICT     — a dict Remove of a PRESENT key still succeeds (no over-reject of a real removal).
 ///   REMOVE-OK-PRESENT-LIST     — a list Remove-by-value of a PRESENT value still succeeds (no over-reject).
+///
+/// VOICE (Layer B unit B) — the on-disk voice (.fuz/.lip) PRESENCE check for created dialogue lines (nested-dialogue
+/// plan §3.5). A byte-valid INFO with no .fuz on disk plays NOTHING — the silent-failure class houseCARL refuses (Q3).
+/// VoiceCheck runs as a post-create step: it walks the written patch to map each created INFO to its parent topic,
+/// resolves the speaker chain (INFO.Speaker -> Npc.Voice -> VoiceType.EditorID) + the topic's quest, computes each
+/// response line's expected path (VoicePath, the xEdit InfoFileName transform), and checks the VFS (AssetResolver).
+/// The master carries a VoiceType + an NPC (Voice -> it) + a Quest the topic points at; an AssetResolver over a TEMP
+/// Data root (planted / absent .fuz) makes the present/silent verdict CI-testable with no real load order:
+///   VOICE-PATH        — the PURE transform locks the keystone format: Quest EDID[..10] _ Topic EDID[..15] _ "00"+6hex
+///                       local id _ ResponseNumber . fuz/.lip (verified empirically against real loose .fuz files).
+///   VOICE-SILENT      — a created voiced line (Speaker set, one response) with NO .fuz planted reports 1 line, NOT
+///                       present, at exactly the computed path (the "WILL BE SILENT" path the create surfaces).
+///   VOICE-PRESENT     — planting the .fuz at that computed path flips the SAME line to present (winner = the Data root)
+///                       — proves the path the check builds is the path the engine looks under (no silent-wrong path).
+///   VOICE-NOSPEAKER   — a created line with NO Speaker can't resolve a voice folder (the runtime quest-alias case): a
+///                       NAMED undetermined reason naming Speaker, and NO line — never a false "fine" (Q3).
+///   VOICE-MULTIRESP   — an INFO with two response lines yields two lines, ResponseNumbers {1,2}, distinct paths (_1/_2)
+///                       — one presence check PER spoken response, keyed by ResponseNumber (not a positional guess).
 /// </summary>
 public static class NestedCreateGuardProbe
 {
@@ -311,7 +329,7 @@ public static class NestedCreateGuardProbe
         //     interior Cell → the named-collection happy path (N3) + the ambiguous-collection reject (N6). ---
         var mKey = new ModKey("HcNcGdMaster", ModType.Master);
         string mPath = Path.Combine(tmpDir, mKey.FileName.String);
-        FormKey masterWeapFk, masterTopicFk, masterCellFk;
+        FormKey masterWeapFk, masterTopicFk, masterCellFk, masterVoiceFk, masterNpcFk, masterQuestFk;
         try
         {
             var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
@@ -321,6 +339,17 @@ public static class NestedCreateGuardProbe
 
             var topic = m.DialogTopics.AddNew(); topic.EditorID = "HcNcGdTopic";
             masterTopicFk = topic.FormKey;
+
+            // Voice-check fixtures (Layer B unit B): the speaker chain INFO.Speaker -> Npc.Voice -> VoiceType.EditorID,
+            // and a Quest the topic points at (the path's quest segment). A line created under this topic with this
+            // speaker has a fully-resolvable voice path.
+            var voice = m.VoiceTypes.AddNew(); voice.EditorID = "HcNcGdVoice";
+            masterVoiceFk = voice.FormKey;
+            var quest = m.Quests.AddNew(); quest.EditorID = "HcNcGdQuest";
+            masterQuestFk = quest.FormKey;
+            var npc = m.Npcs.AddNew(); npc.EditorID = "HcNcGdNpc"; npc.Voice.SetTo(voice.FormKey);
+            masterNpcFk = npc.FormKey;
+            topic.Quest.SetTo(quest.FormKey);
 
             // An interior cell lives under a CellBlock/CellSubBlock structure (FormKey-LESS group structs); build it by
             // hand — there's no flat AddNew for a cell. The cell itself is a normal (FormKey, release) record.
@@ -349,12 +378,15 @@ public static class NestedCreateGuardProbe
             var view = r.Capture();
             fixturesOk = view.ResolveWinner(masterWeapFk) is not null
                       && view.ResolveWinner(masterTopicFk) is not null
-                      && view.ResolveWinner(masterCellFk) is not null;
+                      && view.ResolveWinner(masterCellFk) is not null
+                      && view.ResolveWinner(masterVoiceFk) is not null
+                      && view.ResolveWinner(masterNpcFk) is not null
+                      && view.ResolveWinner(masterQuestFk) is not null;
         }
         var genDir = Path.Combine(tmpDir, "corpus-gen");
         CorpusGenerator.GenerateAll(genDir, Path.Combine(tmpDir, "corpus-ref"));
         var rulebook = CorpusRulebook.Load(Path.Combine(genDir, "corpus.json"));
-        Console.WriteLine($"-- setup: master {mKey.FileName} with weapon {masterWeapFk}, topic {masterTopicFk}, cell {masterCellFk}; fixtures-resolve={fixturesOk}; corpus generated --");
+        Console.WriteLine($"-- setup: master {mKey.FileName} with weapon {masterWeapFk}, topic {masterTopicFk}, cell {masterCellFk}, voice {masterVoiceFk}, npc {masterNpcFk}, quest {masterQuestFk}; fixtures-resolve={fixturesOk}; corpus generated --");
         Console.WriteLine();
 
         // ---------- ONESHOT (N1): topic + its first INFO in ONE call ----------
@@ -1726,6 +1758,134 @@ public static class NestedCreateGuardProbe
             Console.WriteLine($"   REMOVE-OK-PRESENT-LIST present val  : {(removeOkPresentListOk ? "PASS — a list Remove-by-value of a PRESENT value still succeeds (no over-reject)" : $"FAIL — threw={threw} count={race.MovementTypeNames?.Count}")}");
         }
 
+        // ==================  VOICE (Layer B unit B) — on-disk .fuz/.lip presence check  ==================
+        // The keystone path transform + the present / silent / undeterminable verdict over the REAL create path. The .fuz
+        // path is computed from {defining plugin, speaker voice type, parent quest+topic EDIDs, response number}; a created
+        // INFO with no .fuz on disk plays SILENT in game (the Q3 class this closes). An AssetResolver over a TEMP Data root
+        // (planted / absent .fuz) makes the present/silent verdict CI-testable with no real load order.
+
+        // ---------- VOICE-PATH: the pure transform locks the xEdit InfoFileName format (Quest[..10]_Topic[..15]_00+6hex_num) ----------
+        bool voicePathOk;
+        {
+            var fk = new FormKey(new ModKey("MyPatch", ModType.Plugin), 0x000ABCu);
+            var fuz = VoicePath.For(fk, "MaleNord", "QuestEditorIDLong", "TopicEditorIDLongerThan15", 3, VoiceFile.Fuz);
+            var lip = VoicePath.For(fk, "MaleNord", "QuestEditorIDLong", "TopicEditorIDLongerThan15", 3, VoiceFile.Lip);
+            const string expFuz = @"Sound\Voice\MyPatch.esp\MaleNord\QuestEdito_TopicEditorIDLo_00000ABC_3.fuz";
+            const string expLip = @"Sound\Voice\MyPatch.esp\MaleNord\QuestEdito_TopicEditorIDLo_00000ABC_3.lip";
+            voicePathOk = fuz == expFuz && lip == expLip;
+            Console.WriteLine($"   VOICE-PATH transform format        : {(voicePathOk ? "PASS — quest[..10]_topic[..15]_00+6hex_num, .fuz/.lip" : $"FAIL — fuz=[{fuz}] lip=[{lip}]")}");
+        }
+
+        // ---------- VOICE-SILENT: a created voiced line with NO .fuz on disk reports WILL-BE-SILENT at the right path ----------
+        bool voiceSilentOk = false;
+        {
+            string pPath = Path.Combine(tmpDir, "HcNcVoiceSilent.esp");
+            var specs = new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcVsInfo", ParentRef = masterTopicFk.ToString(),
+                    Edits = new[]
+                    {
+                        new WriteRequest { RecordType = "DialogResponses", Path = new[] { "Speaker" }, Verb = "Set", Value = masterNpcFk.ToString() },
+                        new WriteRequest { RecordType = "DialogResponses", Path = new[] { "Responses" }, Verb = "Add",
+                            Struct = new StructSpec { Type = "DialogResponse", Fields = new Dictionary<string, string> { ["ResponseNumber"] = "1" } } },
+                    } },
+            };
+            using var r = LoadOrderResolver.Build(new[] { mPath });
+            var o = WritePatchBuilder.CreateRecords(r, rulebook, specs, pPath, extend: false);
+            var dataDir = Path.Combine(tmpDir, "voice-silent-data"); Directory.CreateDirectory(dataDir);   // EMPTY — no .fuz planted
+            using var assets = AssetResolver.Build("", "", dataDir, Array.Empty<string>(), Array.Empty<ActiveArchive>());
+            var report = o.Success ? VoiceCheck.Run(pPath, o.Created, r, assets) : VoiceReport.Empty;
+            var exp = o.Success ? VoicePath.For(o.Created[0].FormKey, "HcNcGdVoice", "HcNcGdQuest", "HcNcGdTopic", 1, VoiceFile.Fuz) : "";
+            var line = report.Lines.Count == 1 ? report.Lines[0] : null;
+            voiceSilentOk = o.Success && line is not null && !line.FuzPresent && line.FuzPath == exp && line.ResponseNumber == 1 && report.Undetermined.Count == 0;
+            Console.WriteLine($"   VOICE-SILENT no .fuz -> silent     : {(voiceSilentOk ? $"PASS — 1 line, absent, path={exp}" : $"FAIL — success={o.Success} lines={report.Lines.Count} undet={report.Undetermined.Count} present={line?.FuzPresent} path=[{line?.FuzPath}] exp=[{exp}] err=[{o.Error}]")}");
+        }
+
+        // ---------- VOICE-PRESENT: planting the .fuz at the computed path reports voice present (winner = Data) ----------
+        bool voicePresentOk = false;
+        {
+            string pPath = Path.Combine(tmpDir, "HcNcVoicePresent.esp");
+            var specs = new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcVpInfo", ParentRef = masterTopicFk.ToString(),
+                    Edits = new[]
+                    {
+                        new WriteRequest { RecordType = "DialogResponses", Path = new[] { "Speaker" }, Verb = "Set", Value = masterNpcFk.ToString() },
+                        new WriteRequest { RecordType = "DialogResponses", Path = new[] { "Responses" }, Verb = "Add",
+                            Struct = new StructSpec { Type = "DialogResponse", Fields = new Dictionary<string, string> { ["ResponseNumber"] = "1" } } },
+                    } },
+            };
+            using var r = LoadOrderResolver.Build(new[] { mPath });
+            var o = WritePatchBuilder.CreateRecords(r, rulebook, specs, pPath, extend: false);
+            var dataDir = Path.Combine(tmpDir, "voice-present-data");
+            string? exp = null; bool planted = false;
+            if (o.Success)
+            {
+                exp = VoicePath.For(o.Created[0].FormKey, "HcNcGdVoice", "HcNcGdQuest", "HcNcGdTopic", 1, VoiceFile.Fuz);
+                var full = Path.Combine(dataDir, exp);
+                Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+                File.WriteAllBytes(full, new byte[] { 0, 1, 2 });
+                planted = true;
+            }
+            else Directory.CreateDirectory(dataDir);
+            using var assets = AssetResolver.Build("", "", dataDir, Array.Empty<string>(), Array.Empty<ActiveArchive>());
+            var report = o.Success ? VoiceCheck.Run(pPath, o.Created, r, assets) : VoiceReport.Empty;
+            var line = report.Lines.Count == 1 ? report.Lines[0] : null;
+            voicePresentOk = o.Success && planted && line is not null && line.FuzPresent && line.FuzPath == exp && line.FuzWinner == "Data";
+            Console.WriteLine($"   VOICE-PRESENT planted .fuz -> present: {(voicePresentOk ? $"PASS — 1 line, present (Data), path={exp}" : $"FAIL — success={o.Success} lines={report.Lines.Count} present={line?.FuzPresent} winner=[{line?.FuzWinner}] path=[{line?.FuzPath}] err=[{o.Error}]")}");
+        }
+
+        // ---------- VOICE-NOSPEAKER: a created line with no Speaker can't compute a path -> a NAMED undetermined (Q3) ----------
+        bool voiceNoSpeakerOk = false;
+        {
+            string pPath = Path.Combine(tmpDir, "HcNcVoiceNoSpeaker.esp");
+            var specs = new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcVnsInfo", ParentRef = masterTopicFk.ToString(),
+                    Edits = new[]
+                    {
+                        new WriteRequest { RecordType = "DialogResponses", Path = new[] { "Responses" }, Verb = "Add",
+                            Struct = new StructSpec { Type = "DialogResponse", Fields = new Dictionary<string, string> { ["ResponseNumber"] = "1" } } },
+                    } },
+            };
+            using var r = LoadOrderResolver.Build(new[] { mPath });
+            var o = WritePatchBuilder.CreateRecords(r, rulebook, specs, pPath, extend: false);
+            var dataDir = Path.Combine(tmpDir, "voice-nospk-data"); Directory.CreateDirectory(dataDir);
+            using var assets = AssetResolver.Build("", "", dataDir, Array.Empty<string>(), Array.Empty<ActiveArchive>());
+            var report = o.Success ? VoiceCheck.Run(pPath, o.Created, r, assets) : VoiceReport.Empty;
+            var u = report.Undetermined.Count == 1 ? report.Undetermined[0] : null;
+            voiceNoSpeakerOk = o.Success && report.Lines.Count == 0 && u is not null && u.Info == o.Created[0].FormKey
+                && u.Reason.Contains("Speaker", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   VOICE-NOSPEAKER undeterminable     : {(voiceNoSpeakerOk ? "PASS — no Speaker -> 1 NAMED undetermined, no lines" : $"FAIL — success={o.Success} lines={report.Lines.Count} undet={report.Undetermined.Count} reason=[{u?.Reason}] err=[{o.Error}]")}");
+        }
+
+        // ---------- VOICE-MULTIRESP: two response lines -> two .fuz paths, _1 and _2 (one per ResponseNumber) ----------
+        bool voiceMultiOk = false;
+        {
+            string pPath = Path.Combine(tmpDir, "HcNcVoiceMulti.esp");
+            var specs = new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcVmInfo", ParentRef = masterTopicFk.ToString(),
+                    Edits = new[]
+                    {
+                        new WriteRequest { RecordType = "DialogResponses", Path = new[] { "Speaker" }, Verb = "Set", Value = masterNpcFk.ToString() },
+                        new WriteRequest { RecordType = "DialogResponses", Path = new[] { "Responses" }, Verb = "Add",
+                            Struct = new StructSpec { Type = "DialogResponse", Fields = new Dictionary<string, string> { ["ResponseNumber"] = "1" } } },
+                        new WriteRequest { RecordType = "DialogResponses", Path = new[] { "Responses" }, Verb = "Add",
+                            Struct = new StructSpec { Type = "DialogResponse", Fields = new Dictionary<string, string> { ["ResponseNumber"] = "2" } } },
+                    } },
+            };
+            using var r = LoadOrderResolver.Build(new[] { mPath });
+            var o = WritePatchBuilder.CreateRecords(r, rulebook, specs, pPath, extend: false);
+            var dataDir = Path.Combine(tmpDir, "voice-multi-data"); Directory.CreateDirectory(dataDir);
+            using var assets = AssetResolver.Build("", "", dataDir, Array.Empty<string>(), Array.Empty<ActiveArchive>());
+            var report = o.Success ? VoiceCheck.Run(pPath, o.Created, r, assets) : VoiceReport.Empty;
+            var nums = report.Lines.Select(l => l.ResponseNumber).OrderBy(n => n).ToList();
+            bool distinctPaths = report.Lines.Select(l => l.FuzPath).Distinct().Count() == report.Lines.Count;
+            voiceMultiOk = o.Success && report.Lines.Count == 2 && nums.SequenceEqual(new[] { 1, 2 }) && distinctPaths && report.Undetermined.Count == 0;
+            Console.WriteLine($"   VOICE-MULTIRESP 2 lines _1/_2       : {(voiceMultiOk ? "PASS — 2 lines, ResponseNumbers {1,2}, distinct paths" : $"FAIL — success={o.Success} lines={report.Lines.Count} nums=[{string.Join(",", nums)}] distinct={distinctPaths} err=[{o.Error}]")}");
+        }
+
         Console.WriteLine();
         bool pass = fixturesOk && oneshotOk && multiOk && intoTopicOk && intoCellOk
                     && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendOk
@@ -1751,7 +1911,8 @@ public static class NestedCreateGuardProbe
                     && expectedRejNavE2eOk
                     && malformedNavTypeOk
                     && removeRejDictKeyAbsentOk && removeRejNullCollOk && removeRejListValAbsentOk
-                    && removeOkPresentDictOk && removeOkPresentListOk;
+                    && removeOkPresentDictOk && removeOkPresentListOk
+                    && voicePathOk && voiceSilentOk && voicePresentOk && voiceNoSpeakerOk && voiceMultiOk;
         Console.WriteLine($"=== nested-create-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return pass ? 0 : 1;

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -306,12 +306,18 @@ namespace HousecarlGenerator;
 ///                       local id _ ResponseNumber . fuz/.lip (verified empirically against real loose .fuz files).
 ///   VOICE-SILENT      — a created voiced line (Speaker set, one response) with NO .fuz planted reports 1 line, NOT
 ///                       present, at exactly the computed path (the "WILL BE SILENT" path the create surfaces).
-///   VOICE-PRESENT     — planting the .fuz at that computed path flips the SAME line to present (winner = the Data root)
-///                       — proves the path the check builds is the path the engine looks under (no silent-wrong path).
+///   VOICE-PRESENT     — planting BOTH the .fuz and the .lip at the computed paths flips the SAME line to present
+///                       (FuzPresent + LipPresent, winner = the Data root) — proves the path the check builds is the
+///                       path the engine looks under (no silent-wrong path), and exercises both the .fuz and .lip legs.
 ///   VOICE-NOSPEAKER   — a created line with NO Speaker can't resolve a voice folder (the runtime quest-alias case): a
 ///                       NAMED undetermined reason naming Speaker, and NO line — never a false "fine" (Q3).
-///   VOICE-MULTIRESP   — an INFO with two response lines yields two lines, ResponseNumbers {1,2}, distinct paths (_1/_2)
-///                       — one presence check PER spoken response, keyed by ResponseNumber (not a positional guess).
+///   VOICE-MULTIRESP   — an INFO with two response lines numbered NON-sequentially (5, 2) yields two lines whose paths
+///                       carry _5 / _2 — one presence check PER spoken response, keyed by the line's own ResponseNumber
+///                       (a positional i+1 impl would emit {1,2} and fail).
+///   VOICE-SAMECALL    — the speaker NPC and its VoiceType are created in the SAME bulk_create as the voiced INFO, so
+///                       the speaker chain resolves through patchByKey (same-call records), not the load order.
+///   VOICE-CHECKERROR  — the check run against a CORRUPT patch path surfaces on VoiceReport.CheckError and does NOT
+///                       throw / does NOT lose the created records — the Q3 "never demote a successful create" safety net.
 /// </summary>
 public static class NestedCreateGuardProbe
 {
@@ -1822,17 +1828,21 @@ public static class NestedCreateGuardProbe
             if (o.Success)
             {
                 exp = VoicePath.For(o.Created[0].FormKey, "HcNcGdVoice", "HcNcGdQuest", "HcNcGdTopic", 1, VoiceFile.Fuz);
-                var full = Path.Combine(dataDir, exp);
-                Directory.CreateDirectory(Path.GetDirectoryName(full)!);
-                File.WriteAllBytes(full, new byte[] { 0, 1, 2 });
+                var expLip = VoicePath.For(o.Created[0].FormKey, "HcNcGdVoice", "HcNcGdQuest", "HcNcGdTopic", 1, VoiceFile.Lip);
+                foreach (var rel in new[] { exp, expLip })   // plant BOTH the .fuz and the .lip — exercise both legs of CheckInfo
+                {
+                    var full = Path.Combine(dataDir, rel);
+                    Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+                    File.WriteAllBytes(full, new byte[] { 0, 1, 2 });
+                }
                 planted = true;
             }
             else Directory.CreateDirectory(dataDir);
             using var assets = AssetResolver.Build("", "", dataDir, Array.Empty<string>(), Array.Empty<ActiveArchive>());
             var report = o.Success ? VoiceCheck.Run(pPath, o.Created, r, assets) : VoiceReport.Empty;
             var line = report.Lines.Count == 1 ? report.Lines[0] : null;
-            voicePresentOk = o.Success && planted && line is not null && line.FuzPresent && line.FuzPath == exp && line.FuzWinner == "Data";
-            Console.WriteLine($"   VOICE-PRESENT planted .fuz -> present: {(voicePresentOk ? $"PASS — 1 line, present (Data), path={exp}" : $"FAIL — success={o.Success} lines={report.Lines.Count} present={line?.FuzPresent} winner=[{line?.FuzWinner}] path=[{line?.FuzPath}] err=[{o.Error}]")}");
+            voicePresentOk = o.Success && planted && line is not null && line.FuzPresent && line.LipPresent && line.FuzPath == exp && line.FuzWinner == "Data";
+            Console.WriteLine($"   VOICE-PRESENT planted .fuz+.lip     : {(voicePresentOk ? $"PASS — 1 line, .fuz+.lip present (Data), path={exp}" : $"FAIL — success={o.Success} lines={report.Lines.Count} fuz={line?.FuzPresent} lip={line?.LipPresent} winner=[{line?.FuzWinner}] path=[{line?.FuzPath}] err=[{o.Error}]")}");
         }
 
         // ---------- VOICE-NOSPEAKER: a created line with no Speaker can't compute a path -> a NAMED undetermined (Q3) ----------
@@ -1869,8 +1879,10 @@ public static class NestedCreateGuardProbe
                     Edits = new[]
                     {
                         new WriteRequest { RecordType = "DialogResponses", Path = new[] { "Speaker" }, Verb = "Set", Value = masterNpcFk.ToString() },
+                        // NON-SEQUENTIAL ResponseNumbers (5, 2) — so a positional i+1 impl (which would emit 1,2) is
+                        // distinguishable from the real read of resp.ResponseNumber: the path must carry _5 / _2.
                         new WriteRequest { RecordType = "DialogResponses", Path = new[] { "Responses" }, Verb = "Add",
-                            Struct = new StructSpec { Type = "DialogResponse", Fields = new Dictionary<string, string> { ["ResponseNumber"] = "1" } } },
+                            Struct = new StructSpec { Type = "DialogResponse", Fields = new Dictionary<string, string> { ["ResponseNumber"] = "5" } } },
                         new WriteRequest { RecordType = "DialogResponses", Path = new[] { "Responses" }, Verb = "Add",
                             Struct = new StructSpec { Type = "DialogResponse", Fields = new Dictionary<string, string> { ["ResponseNumber"] = "2" } } },
                     } },
@@ -1881,9 +1893,79 @@ public static class NestedCreateGuardProbe
             using var assets = AssetResolver.Build("", "", dataDir, Array.Empty<string>(), Array.Empty<ActiveArchive>());
             var report = o.Success ? VoiceCheck.Run(pPath, o.Created, r, assets) : VoiceReport.Empty;
             var nums = report.Lines.Select(l => l.ResponseNumber).OrderBy(n => n).ToList();
-            bool distinctPaths = report.Lines.Select(l => l.FuzPath).Distinct().Count() == report.Lines.Count;
-            voiceMultiOk = o.Success && report.Lines.Count == 2 && nums.SequenceEqual(new[] { 1, 2 }) && distinctPaths && report.Undetermined.Count == 0;
-            Console.WriteLine($"   VOICE-MULTIRESP 2 lines _1/_2       : {(voiceMultiOk ? "PASS — 2 lines, ResponseNumbers {1,2}, distinct paths" : $"FAIL — success={o.Success} lines={report.Lines.Count} nums=[{string.Join(",", nums)}] distinct={distinctPaths} err=[{o.Error}]")}");
+            bool pathsKeyed = report.Lines.All(l => l.FuzPath.EndsWith($"_{l.ResponseNumber}.fuz", StringComparison.Ordinal));
+            voiceMultiOk = o.Success && report.Lines.Count == 2 && nums.SequenceEqual(new[] { 2, 5 }) && pathsKeyed && report.Undetermined.Count == 0;
+            Console.WriteLine($"   VOICE-MULTIRESP keyed by RespNum    : {(voiceMultiOk ? "PASS — 2 lines, ResponseNumbers {2,5}, each path carries its own _N (not positional)" : $"FAIL — success={o.Success} lines={report.Lines.Count} nums=[{string.Join(",", nums)}] pathsKeyed={pathsKeyed} err=[{o.Error}]")}");
+        }
+
+        // ---------- VOICE-SAMECALL: speaker NPC + its VoiceType created in the SAME call -> patch-first resolution ----------
+        // The other voice arms resolve speaker/voice/quest from the MASTER (the load-order arm of Resolve). This one
+        // creates the VoiceType + the speaker NPC (Voice=@it) alongside the voiced INFO in ONE bulk_create, so the
+        // speaker chain resolves through patchByKey (same-call records) — a regression dropping that arm would otherwise
+        // pass every other voice arm GREEN.
+        bool voiceSameCallOk = false;
+        {
+            string pPath = Path.Combine(tmpDir, "HcNcVoiceSameCall.esp");
+            var specs = new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "VoiceType", EditorId = "HcScVoice", Edits = Array.Empty<WriteRequest>() },
+                new WritePatchBuilder.CreateSpec { RecordType = "Npc", EditorId = "HcScNpc",
+                    Edits = new[] { new WriteRequest { RecordType = "Npc", Path = new[] { "Voice" }, Verb = "Set", Value = "@HcScVoice" } } },
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcScInfo", ParentRef = masterTopicFk.ToString(),
+                    Edits = new[]
+                    {
+                        new WriteRequest { RecordType = "DialogResponses", Path = new[] { "Speaker" }, Verb = "Set", Value = "@HcScNpc" },
+                        new WriteRequest { RecordType = "DialogResponses", Path = new[] { "Responses" }, Verb = "Add",
+                            Struct = new StructSpec { Type = "DialogResponse", Fields = new Dictionary<string, string> { ["ResponseNumber"] = "1" } } },
+                    } },
+            };
+            using var r = LoadOrderResolver.Build(new[] { mPath });
+            var o = WritePatchBuilder.CreateRecords(r, rulebook, specs, pPath, extend: false);
+            var infoFk = o.Success ? o.Created.First(c => c.RecordType == "DialogResponses").FormKey : default;
+            var dataDir = Path.Combine(tmpDir, "voice-samecall-data");
+            string? exp = null;
+            if (o.Success)
+            {
+                exp = VoicePath.For(infoFk, "HcScVoice", "HcNcGdQuest", "HcNcGdTopic", 1, VoiceFile.Fuz);
+                var full = Path.Combine(dataDir, exp);
+                Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+                File.WriteAllBytes(full, new byte[] { 0, 1, 2 });
+            }
+            else Directory.CreateDirectory(dataDir);
+            using var assets = AssetResolver.Build("", "", dataDir, Array.Empty<string>(), Array.Empty<ActiveArchive>());
+            var report = o.Success ? VoiceCheck.Run(pPath, o.Created, r, assets) : VoiceReport.Empty;
+            var line = report.Lines.Count == 1 ? report.Lines[0] : null;
+            voiceSameCallOk = o.Success && line is not null && line.FuzPresent && line.FuzPath == exp && report.Undetermined.Count == 0;
+            Console.WriteLine($"   VOICE-SAMECALL patch-resolved chain : {(voiceSameCallOk ? $"PASS — speaker+voice from the SAME call (patchByKey), present at {exp}" : $"FAIL — success={o.Success} lines={report.Lines.Count} undet={report.Undetermined.Count} present={line?.FuzPresent} path=[{line?.FuzPath}] exp=[{exp}] err=[{o.Error}]")}");
+        }
+
+        // ---------- VOICE-CHECKERROR: a check failure SURFACES on CheckError, never throws / never demotes the create ----
+        // The create succeeds; the voice check is then run against a CORRUPT patch path so the overlay-open throws.
+        // VoiceCheck must catch it and return CheckError (not rethrow, not lose the created records) — the Q3 safety net.
+        bool voiceCheckErrorOk = false;
+        {
+            string pPath = Path.Combine(tmpDir, "HcNcVoiceCkErr.esp");
+            var specs = new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcCeInfo", ParentRef = masterTopicFk.ToString(),
+                    Edits = new[]
+                    {
+                        new WriteRequest { RecordType = "DialogResponses", Path = new[] { "Speaker" }, Verb = "Set", Value = masterNpcFk.ToString() },
+                        new WriteRequest { RecordType = "DialogResponses", Path = new[] { "Responses" }, Verb = "Add",
+                            Struct = new StructSpec { Type = "DialogResponse", Fields = new Dictionary<string, string> { ["ResponseNumber"] = "1" } } },
+                    } },
+            };
+            using var r = LoadOrderResolver.Build(new[] { mPath });
+            var o = WritePatchBuilder.CreateRecords(r, rulebook, specs, pPath, extend: false);
+            var dataDir = Path.Combine(tmpDir, "voice-ckerr-data"); Directory.CreateDirectory(dataDir);
+            using var assets = AssetResolver.Build("", "", dataDir, Array.Empty<string>(), Array.Empty<ActiveArchive>());
+            var corruptPath = Path.Combine(tmpDir, "HcNcVoiceCorrupt.esp");
+            File.WriteAllText(corruptPath, "this is not a valid Skyrim plugin");
+            VoiceReport report = VoiceReport.Empty; bool threw = false;
+            try { report = o.Success ? VoiceCheck.Run(corruptPath, o.Created, r, assets) : VoiceReport.Empty; }
+            catch { threw = true; }
+            voiceCheckErrorOk = o.Success && !threw && report.CheckError is not null && report.Lines.Count == 0;
+            Console.WriteLine($"   VOICE-CHECKERROR surfaced not thrown: {(voiceCheckErrorOk ? "PASS — corrupt patch -> CheckError set, no throw, no lines" : $"FAIL — success={o.Success} threw={threw} checkError=[{report.CheckError}] lines={report.Lines.Count} err=[{o.Error}]")}");
         }
 
         Console.WriteLine();
@@ -1912,7 +1994,8 @@ public static class NestedCreateGuardProbe
                     && malformedNavTypeOk
                     && removeRejDictKeyAbsentOk && removeRejNullCollOk && removeRejListValAbsentOk
                     && removeOkPresentDictOk && removeOkPresentListOk
-                    && voicePathOk && voiceSilentOk && voicePresentOk && voiceNoSpeakerOk && voiceMultiOk;
+                    && voicePathOk && voiceSilentOk && voicePresentOk && voiceNoSpeakerOk && voiceMultiOk
+                    && voiceSameCallOk && voiceCheckErrorOk;
         Console.WriteLine($"=== nested-create-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return pass ? 0 : 1;

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1199,8 +1199,29 @@ public sealed class LoadOrderService : IDisposable
 
             var outcome = WritePatchBuilder.CreateRecords(resolver, rulebook, specs, outPath, extend, fullReadback);
             if (!outcome.Success && created) RemoveFolderCreatedThisCall(outPath);   // hunt F4: a refused create leaves no orphan
-            return outcome;
+            return outcome.Success ? EnrichWithVoiceCheck(outcome, resolver) : outcome;
         }
+    }
+
+    /// <summary>Layer B unit B — the on-disk voice (.fuz/.lip) presence check, run as a POST-WRITE step on a SUCCESSFUL
+    /// create (the service owns the live <see cref="Assets"/> resolver; the proven core create path stays asset-free and
+    /// untouched). Only fires when the call created ≥1 dialogue line (INFO): <see cref="VoiceCheck.Run"/> re-opens the
+    /// written patch read-only, computes each created voiced line's expected path, and checks the VFS — the report rides
+    /// back on <see cref="WritePatchBuilder.CreateOutcome.Voice"/>. NEVER fails the create (the write already succeeded);
+    /// a check failure is surfaced on the report's CheckError (Q3), and even a thrown Assets-build is caught here so a
+    /// dialogue create never regresses to an error outcome over a verify step. Caller holds <see cref="_writeGate"/>; the
+    /// reentrant Assets getter is safe there (PlaceAssets uses it the same way).</summary>
+    WritePatchBuilder.CreateOutcome EnrichWithVoiceCheck(WritePatchBuilder.CreateOutcome outcome, LoadOrderResolver resolver)
+    {
+        bool anyInfo = false;
+        foreach (var c in outcome.Created)
+            if (string.Equals(c.RecordType, VoiceCheck.InfoCatalogName, StringComparison.Ordinal)) { anyInfo = true; break; }
+        if (!anyInfo) return outcome;
+
+        VoiceReport report;
+        try { report = VoiceCheck.Run(outcome.OutputPath, outcome.Created, resolver, Assets); }
+        catch (Exception ex) { report = VoiceReport.Empty with { CheckError = $"{ex.GetType().Name}: {ex.Message}" }; }
+        return report.IsEmpty ? outcome : outcome with { Voice = report };
     }
 
     /// <summary>Map a wire field-op to a core <see cref="WriteRequest"/> for CREATE: RecordType is the create type (not

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -222,6 +222,12 @@ public static class WriteTools
         foreach (var op in o.Ops)
             sb.Append("  ").Append(op.RecordType).Append(' ').Append(op.Target).Append("  ").Append(op.Label)
               .Append(op.After is not null ? "  -> " + op.After : "  -> applied").Append('\n');
+        // Make the voice-coverage scope boundary VISIBLE, not silent (Q3): the .fuz/.lip presence check runs on
+        // CREATE of dialogue lines, not on EDITS to existing ones (Unit C). An edit that adds a spoken response to an
+        // existing INFO produces the same silent-line hazard with no voice note here, so flag it.
+        if (o.Ops.Any(op => string.Equals(op.RecordType, VoiceCheck.InfoCatalogName, StringComparison.Ordinal)))
+            sb.Append("note: this edit touched a dialogue line (INFO). Voice (.fuz) coverage is checked on CREATE, not on edits yet — ")
+              .Append("if you added a spoken response, verify its voice file on disk (housecarl_create_record reports the expected path).\n");
         if (o.ReadBack is { } rb) AppendFullReadback(sb, rb, maxChars);
         sb.Append("to add more edits to THIS patch, pass into=\"").Append(file).Append("\".");
         return sb.ToString();
@@ -313,7 +319,7 @@ public static class WriteTools
             foreach (var op in c.Ops)
                 sb.Append("      ").Append(op.Label).Append(op.After is not null ? "  -> " + op.After : "  -> applied").Append('\n');
         }
-        AppendVoiceReport(sb, o.Voice);
+        AppendVoiceReport(sb, o.Voice, maxChars);
         if (o.ReadBack is { } rb) AppendFullReadback(sb, rb, maxChars);
         sb.Append("the new FormID above is how you reference this record (SkyPatcher/SPID, or a follow-up edit). ")
           .Append("To add more to THIS patch, pass into=\"").Append(file).Append("\".");
@@ -325,14 +331,20 @@ public static class WriteTools
     /// path to put the audio at), a brief "voice present" for ones already covered, and a NAMED reason per line whose
     /// path couldn't even be computed (no Speaker, unresolvable voice type, …). Voice ACTING stays out of scope — this
     /// reports the on-disk DATA-layer boundary, never generates audio. No-op unless the call created dialogue lines.</summary>
-    static void AppendVoiceReport(StringBuilder sb, VoiceReport? report)
+    static void AppendVoiceReport(StringBuilder sb, VoiceReport? report, int maxChars)
     {
         if (report is null || report.IsEmpty) return;
+        // Budget-bounded like the full read-back (same maxChars contract): a bulk_create authoring hundreds of voiced
+        // lines must NOT silently blow the response size or starve a requested read-back — past the cap the voice
+        // section stops with an explicit notice (Q3), never a silent cut.
+        int cap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        int total = report.Lines.Count + report.Undetermined.Count, rendered = 0;
         sb.Append("voice coverage — created dialogue lines (a response with no .fuz plays SILENT in game; the audio is yours to provide):\n");
 
         bool anyReadIncomplete = false;
         foreach (var l in report.Lines)
         {
+            if (sb.Length >= cap) { AppendVoiceTrunc(sb, rendered, total, cap); return; }
             var who = string.IsNullOrEmpty(l.TopicEditorId) ? l.Info.ToString() : $"{l.TopicEditorId} ({l.Info})";
             if (l.FuzPresent)
             {
@@ -350,17 +362,26 @@ public static class WriteTools
                 sb.Append('\n');
             }
             if (l.ReadIncomplete) anyReadIncomplete = true;
+            rendered++;
         }
         foreach (var u in report.Undetermined)
         {
+            if (sb.Length >= cap) { AppendVoiceTrunc(sb, rendered, total, cap); return; }
             var who = string.IsNullOrEmpty(u.TopicEditorId) ? u.Info.ToString() : $"{u.TopicEditorId} ({u.Info})";
             sb.Append("  [?] ").Append(who).Append("  — ").Append(u.Reason).Append('\n');
+            rendered++;
         }
         if (anyReadIncomplete)
             sb.Append("  note: a BSA failed to read this scan, so an \"absent\" above may merely be unscanned — verify in MO2.\n");
         if (report.CheckError is not null)
             sb.Append("  voice check could not run: ").Append(report.CheckError).Append(" — the records WERE created; verify voice files manually.\n");
     }
+
+    /// <summary>The explicit voice-coverage truncation notice (Q3 — the same convention as the read-back's): how many
+    /// of the total voice entries were rendered before the char budget was hit, and how to see the rest.</summary>
+    static void AppendVoiceTrunc(StringBuilder sb, int rendered, int total, int cap)
+        => sb.Append("  ... [voice coverage truncated: rendered ").Append(rendered).Append(" of ").Append(total)
+             .Append(" line(s) at max_chars=").Append(cap).Append("; raise max_chars to see the rest]\n");
 }
 
 // ---- wire DTOs (the operation shape for bulk_apply; set_field builds one internally) ----------------------

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -313,10 +313,53 @@ public static class WriteTools
             foreach (var op in c.Ops)
                 sb.Append("      ").Append(op.Label).Append(op.After is not null ? "  -> " + op.After : "  -> applied").Append('\n');
         }
+        AppendVoiceReport(sb, o.Voice);
         if (o.ReadBack is { } rb) AppendFullReadback(sb, rb, maxChars);
         sb.Append("the new FormID above is how you reference this record (SkyPatcher/SPID, or a follow-up edit). ")
           .Append("To add more to THIS patch, pass into=\"").Append(file).Append("\".");
         return sb.ToString();
+    }
+
+    /// <summary>Render the Layer B unit B voice-coverage report (a dialogue-line create). The enforced Q3 teeth against a
+    /// byte-valid-but-SILENT line: a LOUD "WILL BE SILENT" per created voiced response with no .fuz on disk (naming the
+    /// path to put the audio at), a brief "voice present" for ones already covered, and a NAMED reason per line whose
+    /// path couldn't even be computed (no Speaker, unresolvable voice type, …). Voice ACTING stays out of scope — this
+    /// reports the on-disk DATA-layer boundary, never generates audio. No-op unless the call created dialogue lines.</summary>
+    static void AppendVoiceReport(StringBuilder sb, VoiceReport? report)
+    {
+        if (report is null || report.IsEmpty) return;
+        sb.Append("voice coverage — created dialogue lines (a response with no .fuz plays SILENT in game; the audio is yours to provide):\n");
+
+        bool anyReadIncomplete = false;
+        foreach (var l in report.Lines)
+        {
+            var who = string.IsNullOrEmpty(l.TopicEditorId) ? l.Info.ToString() : $"{l.TopicEditorId} ({l.Info})";
+            if (l.FuzPresent)
+            {
+                sb.Append("  OK   ").Append(who).Append(" resp ").Append(l.ResponseNumber)
+                  .Append("  — voice present (").Append(l.FuzWinner ?? "?").Append(')');
+                if (l.FuzAmbiguous) sb.Append(" [more than one source provides it — contended]");
+                if (!l.LipPresent) sb.Append("; no .lip (no lip-sync)");
+                sb.Append('\n');
+            }
+            else
+            {
+                sb.Append("  [!] WILL BE SILENT  ").Append(who).Append(" resp ").Append(l.ResponseNumber)
+                  .Append("  — no .fuz at ").Append(l.FuzPath).Append("  (place the audio here)");
+                if (!l.LipPresent) sb.Append("; .lip also absent (").Append(l.LipPath).Append(')');
+                sb.Append('\n');
+            }
+            if (l.ReadIncomplete) anyReadIncomplete = true;
+        }
+        foreach (var u in report.Undetermined)
+        {
+            var who = string.IsNullOrEmpty(u.TopicEditorId) ? u.Info.ToString() : $"{u.TopicEditorId} ({u.Info})";
+            sb.Append("  [?] ").Append(who).Append("  — ").Append(u.Reason).Append('\n');
+        }
+        if (anyReadIncomplete)
+            sb.Append("  note: a BSA failed to read this scan, so an \"absent\" above may merely be unscanned — verify in MO2.\n");
+        if (report.CheckError is not null)
+            sb.Append("  voice check could not run: ").Append(report.CheckError).Append(" — the records WERE created; verify voice files manually.\n");
     }
 }
 


### PR DESCRIPTION
**Nested-dialogue Layer B, unit B** (plan §3.5). A byte-valid INFO with no `.fuz` on disk plays **silent** in game — the silent-failure class houseCARL refuses (Q3). On a successful create of one or more dialogue lines, the service now runs a **post-write voice-coverage check** and folds the result into the `housecarl_create_record` / `housecarl_bulk_create` response.

## What it surfaces
- **`[!] WILL BE SILENT`** + the exact `.fuz` path to place audio at, for each created voiced response with no audio on disk.
- **`OK voice present`** for ones already covered (naming the winning VFS provider).
- **`[?]` a NAMED reason** when the path can't be computed (no `Speaker` → the runtime quest-alias case; unresolvable voice type) — never a false "fine".
- Voice **acting** stays out of scope; this is the on-disk data-layer boundary only.

## Shape
- **`VoicePath`** (core, pure) — the keystone transform, sibling of `FaceGenPath`: `Sound\Voice\<defining plugin>\<voice type>\<QuestEDID[..10]>_<TopicEDID[..15]>_<00+6hex local id>_<ResponseNumber>.fuz|.lip`. Verified empirically against real loose `.fuz` files (Walks-Distant-Sands); load-order-independent (index byte masks to `00`), same masking as FaceGen — no runtime-FormID bridge.
- **`VoiceCheck`** (core) — walks the written patch to map each created INFO to its parent topic (works for same-call **and** existing parents; the override carries the topic's EditorID + Quest), resolves `Speaker→Npc.Voice→VoiceType.EditorID` and `topic.Quest→EditorID` (patch-first then load order), computes each response line's path, checks the VFS via the existing `AssetResolver`. A resolve miss is a NAMED undetermined reason; a whole-check failure rides `VoiceReport.CheckError` — never thrown, never fails the create (the write already succeeded).
- **Folded into create output** via `CreateOutcome.Voice`, filled by the service (it owns the live `AssetResolver`). The proven core `CreateRecords` path is **untouched**. **No new tool — surface stays 21.** Existing-INFO auditing is deferred to unit C.

## Tests
- **`nested-create-guard`: +5 RED-proven arms** — `VOICE-PATH` (the keystone format lock), `-SILENT`, `-PRESENT`, `-NOSPEAKER`, `-MULTIRESP` — over an `AssetResolver` on a temp Data root (planted / absent `.fuz`), making the present/silent/undeterminable verdict CI-testable with no real load order. Each sabotage-proven (watch-fail → revert).
- Full local probe suite (40 probes) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)