### PR TITLE
write: Layer B unit C (C1) — per-create result-script binding + .pex presence check

### DIFF
--- a/src/housecarl-core/DialogueScriptCheck.cs
+++ b/src/housecarl-core/DialogueScriptCheck.cs
@@ -1,0 +1,194 @@
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+
+namespace HousecarlCore;
+
+// ======================================================================
+//  DialogueScriptCheck — the per-create RESULT-SCRIPT binding check for created dialogue lines
+//  (nested-dialogue plan §3.6, Layer B unit C / "per-create structural checks"; sibling of VoiceCheck).
+//  A dialogue line (INFO) can carry a RESULT SCRIPT — a Papyrus fragment that runs when the line plays
+//  (start a quest stage, give an item). It lives on the INFO's VirtualMachineAdapter (a DialogResponsesAdapter):
+//  a ScriptFragments fragment ("End"/"Begin" box, keyed by a FileName script class) and/or attached Scripts.
+//  A byte-valid INFO whose script binding is HALF-BUILT or points at an UNCOMPILED script runs NOTHING — the
+//  same silent-failure class houseCARL refuses (Q3, plan §3 job 3). This runs as a POST-WRITE step on a
+//  successful create: for every CREATED INFO that carries a VMAD it
+//    • verifies the binding is structurally usable (a real fragment, or a named attached script), and
+//    • checks each bound script class has a compiled `Scripts\<class>.pex` on disk (the VFS — loose + BSA),
+//  reporting a loud "WILL NOT FIRE" when the binding is incomplete or its `.pex` is missing, an "OK" for ones
+//  fully wired + compiled, or a NAMED undetermined reason when the created INFO can't be located in the patch.
+//
+//  CORNERSTONE-CLEAN: this is a DIAGNOSTIC over records the engine already wrote — it adds NO per-record write
+//  logic and is deliberately SEPARATE from the proven WritePatchBuilder.CreateRecords path (which is untouched).
+//  It is driven by BOTH the service (post-create, with the live AssetResolver) and the nested-create CI guard
+//  (with a temp AssetResolver over a planted .pex), so the bound/incomplete/not-compiled verdict is end-to-end
+//  testable in CI.
+//
+//  WHY IT NEEDS NO GRAPH RESOLUTION (unlike VoiceCheck): the result-script binding lives ENTIRELY on the INFO
+//  itself (VMAD → FileName / OnEnd / Scripts) and the only external fact is the on-disk `.pex`. There is no
+//  speaker/voice-type/quest chain to resolve, so this needs the written patch + the AssetResolver only — no
+//  LoadOrderResolver, no session.
+//
+//  KEYED ON VMAD-PRESENT (= the §3.6 "when a result-script op was requested" filter, realized off the written
+//  record): a created line with NO VirtualMachineAdapter intends no script and is NOT checked — never nagged.
+//  An adapter that exists is validated for completeness; for a freshly-created record the adapter is non-null
+//  only because the create spec set it, so VMAD-present and "a result-script was requested" coincide here.
+// ======================================================================
+
+/// <summary>The result-script binding verdict for one created dialogue line (INFO) that carries a VMAD.</summary>
+public enum ScriptBindingStatus
+{
+    /// <summary>A fragment or attached script is bound AND every bound class has a compiled `.pex` on disk — it will fire.</summary>
+    BoundAndCompiled,
+    /// <summary>A VMAD is present but binds no usable fragment/script (no real Begin/End fragment, no named attached
+    /// script) — byte-valid, runs NOTHING.</summary>
+    BindingIncomplete,
+    /// <summary>A script class is bound but its compiled `Scripts\&lt;class&gt;.pex` is absent on disk — runs NOTHING
+    /// until compiled.</summary>
+    ScriptNotCompiled,
+    /// <summary>The created INFO couldn't be located in the written patch to check — surfaced, never silently skipped (Q3).</summary>
+    Undetermined,
+}
+
+/// <summary>One created INFO's result-script verdict: the <see cref="Status"/>, the bound script class name(s)
+/// (<see cref="Scripts"/>), the `Scripts\&lt;class&gt;.pex` path(s) found missing on disk (<see cref="MissingPex"/>,
+/// for <see cref="ScriptBindingStatus.ScriptNotCompiled"/>), the <see cref="ReadIncomplete"/> caveat (a BSA failed to
+/// read, so a "missing" may merely be unscanned — Q3), and a human-readable <see cref="Detail"/>.</summary>
+public sealed record ScriptBindingFinding(
+    FormKey Info, string TopicEditorId, ScriptBindingStatus Status,
+    IReadOnlyList<string> Scripts, IReadOnlyList<string> MissingPex,
+    bool ReadIncomplete, string Detail);
+
+/// <summary>The result-script-coverage report for one create call: a per-INFO binding verdict for each created
+/// dialogue line that carries a VMAD. <see cref="IsEmpty"/> when the call created no scripted dialogue lines.</summary>
+public sealed record ScriptBindingReport(IReadOnlyList<ScriptBindingFinding> Findings)
+{
+    /// <summary>The check itself could not run (the patch wouldn't re-open, the walk threw) — surfaced, never a silent
+    /// skip (Q3). The create ALREADY SUCCEEDED when this is set; it just means "I couldn't verify the script binding",
+    /// not "the write failed". Null on a clean run.</summary>
+    public string? CheckError { get; init; }
+
+    public bool IsEmpty => Findings.Count == 0 && CheckError is null;
+    public static readonly ScriptBindingReport Empty = new(Array.Empty<ScriptBindingFinding>());
+}
+
+public static class DialogueScriptCheck
+{
+    /// <summary>Run the result-script binding check over the INFOs created by ONE create call. <paramref name="patchPath"/>
+    /// is the just-written patch file (re-opened read-only here, then disposed — the overlay lifetime lives in core, so
+    /// the service needs no Mutagen.Skyrim dependency); <paramref name="created"/> is the call's CreatedRecord list
+    /// (filtered here to INFOs); <paramref name="assets"/> answers on-disk `.pex` presence (loose + BSA). Returns
+    /// <see cref="ScriptBindingReport.Empty"/> when the call created no INFOs. A created INFO not located in the patch is
+    /// a NAMED undetermined (Q3); a whole-check failure (the patch won't re-open, the walk throws) is surfaced on
+    /// <see cref="ScriptBindingReport.CheckError"/> — NEVER thrown (the create already succeeded; this is a verify step).</summary>
+    public static ScriptBindingReport Run(string patchPath, IReadOnlyList<WritePatchBuilder.CreatedRecord> created,
+                                          AssetResolver assets)
+    {
+        // Which created records are dialogue lines (INFOs) — only these get a script-binding check.
+        var infoKeys = new HashSet<FormKey>();
+        foreach (var c in created)
+            if (string.Equals(c.RecordType, VoiceCheck.InfoCatalogName, StringComparison.Ordinal))
+                infoKeys.Add(c.FormKey);
+        if (infoKeys.Count == 0) return ScriptBindingReport.Empty;
+
+        ISkyrimModGetter? patch = null;
+        try
+        {
+            patch = SkyrimMod.CreateFromBinaryOverlay(patchPath, SkyrimRelease.SkyrimSE);
+            return RunOver(patch, infoKeys, assets);
+        }
+        catch (Exception ex)
+        {
+            return ScriptBindingReport.Empty with { CheckError = $"{ex.GetType().Name}: {ex.Message}" };
+        }
+        finally { (patch as IDisposable)?.Dispose(); }
+    }
+
+    /// <summary>The walk over the re-opened patch (split out so <see cref="Run"/> can wrap the overlay open + any
+    /// walk-level throw into <see cref="ScriptBindingReport.CheckError"/>, while a per-INFO not-found stays a NAMED
+    /// undetermined). Mirrors <see cref="VoiceCheck"/>'s topic walk: each created INFO lives in exactly one topic's
+    /// Responses (its structural parent), which also yields the topic EditorID for a friendly label.</summary>
+    static ScriptBindingReport RunOver(ISkyrimModGetter writtenPatch, HashSet<FormKey> infoKeys, AssetResolver assets)
+    {
+        var findings = new List<ScriptBindingFinding>();
+        var av = assets.Capture();                           // ONE asset build, so presence + ReadIncomplete agree
+
+        var found = new HashSet<FormKey>();
+        foreach (var topic in writtenPatch.DialogTopics)
+        {
+            foreach (var info in topic.Responses)
+            {
+                if (!infoKeys.Contains(info.FormKey)) continue;   // a pre-existing INFO the patch carried, or not ours
+                found.Add(info.FormKey);
+                CheckInfo(info, topic.EditorID ?? "", av, findings);
+            }
+        }
+
+        // A created INFO not found under any topic is a real inconsistency — surfaced, never silently dropped (Q3).
+        foreach (var fk in infoKeys)
+            if (!found.Contains(fk))
+                findings.Add(new ScriptBindingFinding(fk, "", ScriptBindingStatus.Undetermined,
+                    Array.Empty<string>(), Array.Empty<string>(), false,
+                    "created but not found under any topic in the written patch — can't check its result-script binding; inspect the patch in xEdit."));
+
+        return new ScriptBindingReport(findings);
+    }
+
+    /// <summary>Verdict one created INFO. A line with NO VirtualMachineAdapter intends no script and yields nothing
+    /// (correct — never nag a script-free line). An adapter that IS present is validated: collect every bound script
+    /// CLASS that must have a compiled `.pex` to run (a ScriptFragments fragment's FileName, counted only when a real
+    /// Begin/End fragment is wired; each attached Scripts[] entry's class name), then either flag the hollow binding,
+    /// or check each class's `Scripts\&lt;class&gt;.pex` on disk.</summary>
+    static void CheckInfo(IDialogResponsesGetter info, string topicEdid, AssetResolver.AssetView av,
+                          List<ScriptBindingFinding> findings)
+    {
+        var vmad = info.VirtualMachineAdapter;
+        if (vmad is null) return;   // no result script intended — nothing to check
+
+        // The bound script CLASS names that must each have a compiled .pex to actually fire.
+        var names = new List<string>();
+        var frag = vmad.ScriptFragments;
+        if (frag is not null && !string.IsNullOrWhiteSpace(frag.FileName) && HasRealFragment(frag))
+            names.Add(frag.FileName.Trim());
+        foreach (var entry in vmad.Scripts)
+            if (!string.IsNullOrWhiteSpace(entry.Name)) names.Add(entry.Name.Trim());
+
+        // A VMAD that binds nothing usable (no real fragment, no named attached script) is byte-valid but inert — a
+        // FileName WITHOUT a Begin/End fragment is a hollow declaration, not a binding, and is caught here (Q3).
+        if (names.Count == 0)
+        {
+            findings.Add(new ScriptBindingFinding(info.FormKey, topicEdid, ScriptBindingStatus.BindingIncomplete,
+                Array.Empty<string>(), Array.Empty<string>(), false,
+                "a script adapter (VMAD) is present but binds no usable result-script fragment or attached script — " +
+                "byte-valid but it runs NOTHING. Wire the result-script fragment (a FileName AND a Begin/End fragment) " +
+                "or remove the empty adapter."));
+            return;
+        }
+
+        // Each bound class needs Scripts\<class>.pex on disk to fire. Distinct (case-insensitive) so two contributors
+        // naming the same class don't double-report.
+        var distinct = names.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        var missing = new List<string>();
+        foreach (var name in distinct)
+            if (!av.Resolve($@"Scripts\{name}.pex").Exists)
+                missing.Add($@"Scripts\{name}.pex");
+
+        if (missing.Count == 0)
+            findings.Add(new ScriptBindingFinding(info.FormKey, topicEdid, ScriptBindingStatus.BoundAndCompiled,
+                distinct, Array.Empty<string>(), av.ReadIncomplete,
+                $"result script bound + compiled ({string.Join(", ", distinct)})."));
+        else
+            findings.Add(new ScriptBindingFinding(info.FormKey, topicEdid, ScriptBindingStatus.ScriptNotCompiled,
+                distinct, missing, av.ReadIncomplete,
+                $"result script bound ({string.Join(", ", distinct)}) but the compiled .pex is missing on disk — " +
+                "it runs NOTHING until compiled (housecarl_compile_script)."));
+    }
+
+    /// <summary>A ScriptFragments carries a REAL fragment when its Begin or End fragment names a script/fragment — a
+    /// FileName alone (no Begin/End) is a hollow declaration that binds nothing.</summary>
+    static bool HasRealFragment(IScriptFragmentsGetter frag)
+        => IsReal(frag.OnBegin) || IsReal(frag.OnEnd);
+
+    static bool IsReal(IScriptFragmentGetter? f)
+        => f is not null && (!string.IsNullOrWhiteSpace(f.ScriptName) || !string.IsNullOrWhiteSpace(f.FragmentName));
+}

--- a/src/housecarl-core/DialogueScriptCheck.cs
+++ b/src/housecarl-core/DialogueScriptCheck.cs
@@ -1,5 +1,4 @@
 using Mutagen.Bethesda.Plugins;
-using Mutagen.Bethesda.Plugins.Records;
 using Mutagen.Bethesda.Skyrim;
 
 namespace HousecarlCore;
@@ -170,8 +169,14 @@ public static class DialogueScriptCheck
         var distinct = names.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
         var missing = new List<string>();
         foreach (var name in distinct)
-            if (!av.Resolve($@"Scripts\{name}.pex").Exists)
-                missing.Add($@"Scripts\{name}.pex");
+        {
+            // A NAMESPACED Papyrus class (Namespace:Script) compiles to Scripts\Namespace\Script.pex — the ':' is a
+            // folder separator on disk (and not a legal filename char), so map it before probing the VFS. Without this a
+            // valid namespaced script reads as a false "not compiled" (Q3 — a loud-wrong answer; the check must not cry
+            // wolf). CK-generated fragments (TIF__/QF_) are always flat, so this only bites namespaced attached Scripts[].
+            var relPex = $@"Scripts\{name.Replace(':', '\\')}.pex";
+            if (!av.Resolve(relPex).Exists) missing.Add(relPex);
+        }
 
         if (missing.Count == 0)
             findings.Add(new ScriptBindingFinding(info.FormKey, topicEdid, ScriptBindingStatus.BoundAndCompiled,

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -139,6 +139,12 @@ public static class WritePatchBuilder
         /// pure record-write and the asset-layer dependency lives in the service. See <see cref="VoiceCheck"/>.</summary>
         public VoiceReport? Voice { get; init; }
 
+        /// <summary>The result-script binding report for the INFOs this call created (Layer B unit C / per-create
+        /// structural check) — null unless the call created ≥1 scripted dialogue line. Filled by the SERVICE post-write
+        /// the SAME way as <see cref="Voice"/> (it owns the live AssetResolver), so <see cref="CreateRecords"/> stays a
+        /// pure record-write. See <see cref="DialogueScriptCheck"/>.</summary>
+        public ScriptBindingReport? ScriptBinding { get; init; }
+
         public static CreateOutcome Fail(string error) =>
             new(false, error, "", false, Array.Empty<CreatedRecord>(), Array.Empty<string>(), 0);
     }

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -2082,6 +2082,32 @@ public static class NestedCreateGuardProbe
             Console.WriteLine($"   SCRIPT-ATTACHED Scripts[] entry    : {(scriptAttachedOk ? "PASS — attached Scripts[] class + .pex -> BoundAndCompiled" : $"FAIL — ok={f.ok} findings={report.Findings.Count} status={find?.Status} scripts=[{(find is null ? "" : string.Join(",", find.Scripts))}] err=[{report.CheckError}]")}");
         }
 
+        // ---------- SCRIPT-NAMESPACED: a namespaced class (Namespace:Script) maps to Scripts\Namespace\Script.pex ----------
+        // The ':' is a folder separator on disk (not a legal filename char), so a literal Scripts\<name>.pex probe would
+        // FALSE-alarm "not compiled" on a valid namespaced script. Plant the .pex at the MAPPED subfolder path and assert
+        // BoundAndCompiled — a regression dropping the ':'->'\' mapping turns this RED.
+        bool scriptNamespacedOk = false;
+        {
+            var f = BuildScriptFixture("HcScNs", info =>
+            {
+                var a = new DialogResponsesAdapter();
+                a.Scripts.Add(new ScriptEntry { Name = "HcScNsSpace:HcScNsClass" });
+                info.VirtualMachineAdapter = a;
+            });
+            var dataDir = Path.Combine(tmpDir, "script-ns-data");
+            if (f.ok)
+            {
+                var planted = Path.Combine(dataDir, @"Scripts\HcScNsSpace\HcScNsClass.pex");   // namespace -> subfolder
+                Directory.CreateDirectory(Path.GetDirectoryName(planted)!); File.WriteAllBytes(planted, new byte[] { 0, 1, 2 });
+            }
+            else Directory.CreateDirectory(dataDir);
+            using var assets = AssetResolver.Build("", "", dataDir, Array.Empty<string>(), Array.Empty<ActiveArchive>());
+            var report = f.ok ? DialogueScriptCheck.Run(f.path, AsCreated("HcScNs", f.infoFk), assets) : ScriptBindingReport.Empty;
+            var find = report.Findings.Count == 1 ? report.Findings[0] : null;
+            scriptNamespacedOk = f.ok && find is not null && find.Status == ScriptBindingStatus.BoundAndCompiled && find.MissingPex.Count == 0;
+            Console.WriteLine($@"   SCRIPT-NAMESPACED ns -> subfolder  : {(scriptNamespacedOk ? @"PASS — Namespace:Script -> Scripts\Namespace\Script.pex resolves -> BoundAndCompiled" : $"FAIL — ok={f.ok} findings={report.Findings.Count} status={find?.Status} missing=[{(find is null ? "" : string.Join(",", find.MissingPex))}] err=[{report.CheckError}]")}");
+        }
+
         // ---------- SCRIPT-NOVMAD: a created line with NO result script is NOT checked (no false-positive nag) ----------
         bool scriptNoVmadOk = false;
         {
@@ -2137,7 +2163,7 @@ public static class NestedCreateGuardProbe
                     && voicePathOk && voiceSilentOk && voicePresentOk && voiceNoSpeakerOk && voiceMultiOk
                     && voiceSameCallOk && voiceCheckErrorOk
                     && scriptIncompleteOk && scriptNoFragOk && scriptNotCompiledOk && scriptBoundOk
-                    && scriptAttachedOk && scriptNoVmadOk && scriptCheckErrorOk;
+                    && scriptAttachedOk && scriptNamespacedOk && scriptNoVmadOk && scriptCheckErrorOk;
         Console.WriteLine($"=== nested-create-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return pass ? 0 : 1;

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -1968,6 +1968,146 @@ public static class NestedCreateGuardProbe
             Console.WriteLine($"   VOICE-CHECKERROR surfaced not thrown: {(voiceCheckErrorOk ? "PASS — corrupt patch -> CheckError set, no throw, no lines" : $"FAIL — success={o.Success} threw={threw} checkError=[{report.CheckError}] lines={report.Lines.Count} err=[{o.Error}]")}");
         }
 
+        // ==================  RESULT-SCRIPT (Layer B unit C) — per-create VMAD binding + .pex presence check  ==================
+        // A dialogue line can carry a RESULT SCRIPT (a Papyrus fragment run when the line plays) on its VMAD: a
+        // ScriptFragments fragment (FileName + a Begin/End fragment) and/or attached Scripts. A byte-valid INFO whose
+        // binding is half-built, or names a script with no compiled Scripts\<class>.pex on disk, runs NOTHING in game
+        // (the Q3 class this closes; plan §3 job 3). DialogueScriptCheck verdicts each CREATED scripted INFO. A temp
+        // Data root (planted / absent .pex) makes the bound / incomplete / not-compiled verdict CI-testable. Fixtures
+        // are built directly (a topic + an INFO with a configured VMAD), then serialized + re-opened the way the check
+        // sees a real written patch.
+        (bool ok, string path, FormKey infoFk) BuildScriptFixture(string name, Action<DialogResponses> configure)
+        {
+            try
+            {
+                var key = new ModKey(name, ModType.Plugin);
+                var path = Path.Combine(tmpDir, key.FileName.String);
+                var fm = new SkyrimMod(key, SkyrimRelease.SkyrimSE);
+                var topic = fm.DialogTopics.AddNew(); topic.EditorID = name + "Topic";
+                var info = new DialogResponses(fm.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = name + "Info" };
+                configure(info);
+                topic.Responses.Add(info);
+                fm.BeginWrite.ToPath(path).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+                return (true, path, info.FormKey);
+            }
+            catch (Exception ex) { Console.WriteLine($"   (script fixture '{name}' failed: {ex.GetType().Name}: {(ex.InnerException ?? ex).Message})"); return (false, "", default); }
+        }
+        WritePatchBuilder.CreatedRecord[] AsCreated(string name, FormKey fk)
+            => new[] { new WritePatchBuilder.CreatedRecord(fk, "DialogResponses", name + "Info", Array.Empty<WritePatchBuilder.OpResult>()) };
+
+        // ---------- SCRIPT-INCOMPLETE: a VMAD present but binding nothing usable -> BindingIncomplete (won't fire) ----------
+        bool scriptIncompleteOk = false;
+        {
+            var f = BuildScriptFixture("HcScIncomplete", info => info.VirtualMachineAdapter = new DialogResponsesAdapter());
+            var dataDir = Path.Combine(tmpDir, "script-incomplete-data"); Directory.CreateDirectory(dataDir);
+            using var assets = AssetResolver.Build("", "", dataDir, Array.Empty<string>(), Array.Empty<ActiveArchive>());
+            var report = f.ok ? DialogueScriptCheck.Run(f.path, AsCreated("HcScIncomplete", f.infoFk), assets) : ScriptBindingReport.Empty;
+            var find = report.Findings.Count == 1 ? report.Findings[0] : null;
+            scriptIncompleteOk = f.ok && find is not null && find.Status == ScriptBindingStatus.BindingIncomplete && find.Info == f.infoFk;
+            Console.WriteLine($"   SCRIPT-INCOMPLETE empty VMAD       : {(scriptIncompleteOk ? "PASS — VMAD present, binds nothing -> BindingIncomplete" : $"FAIL — ok={f.ok} findings={report.Findings.Count} status={find?.Status} err=[{report.CheckError}]")}");
+        }
+
+        // ---------- SCRIPT-NOFRAG: a ScriptFragments FileName with NO Begin/End fragment is hollow -> BindingIncomplete ----------
+        // The .pex IS planted, so a "FileName alone counts as bound" regression would mis-read this as BoundAndCompiled
+        // (not NotCompiled) — the planted .pex is what makes that regression visible here.
+        bool scriptNoFragOk = false;
+        {
+            var f = BuildScriptFixture("HcScNoFrag", info =>
+                info.VirtualMachineAdapter = new DialogResponsesAdapter { ScriptFragments = new ScriptFragments { FileName = "HcScNoFragClass" } });
+            var dataDir = Path.Combine(tmpDir, "script-nofrag-data"); Directory.CreateDirectory(dataDir);
+            var planted = Path.Combine(dataDir, @"Scripts\HcScNoFragClass.pex");
+            Directory.CreateDirectory(Path.GetDirectoryName(planted)!); File.WriteAllBytes(planted, new byte[] { 0, 1, 2 });
+            using var assets = AssetResolver.Build("", "", dataDir, Array.Empty<string>(), Array.Empty<ActiveArchive>());
+            var report = f.ok ? DialogueScriptCheck.Run(f.path, AsCreated("HcScNoFrag", f.infoFk), assets) : ScriptBindingReport.Empty;
+            var find = report.Findings.Count == 1 ? report.Findings[0] : null;
+            scriptNoFragOk = f.ok && find is not null && find.Status == ScriptBindingStatus.BindingIncomplete;
+            Console.WriteLine($"   SCRIPT-NOFRAG FileName, no fragment: {(scriptNoFragOk ? "PASS — FileName alone (no Begin/End) -> BindingIncomplete even with a .pex on disk" : $"FAIL — ok={f.ok} findings={report.Findings.Count} status={find?.Status} err=[{report.CheckError}]")}");
+        }
+
+        // ---------- SCRIPT-NOTCOMPILED: a bound fragment whose Scripts\<class>.pex is absent -> ScriptNotCompiled ----------
+        bool scriptNotCompiledOk = false;
+        {
+            var f = BuildScriptFixture("HcScNotComp", info =>
+                info.VirtualMachineAdapter = new DialogResponsesAdapter { ScriptFragments = new ScriptFragments {
+                    FileName = "HcScNotCompClass", OnEnd = new ScriptFragment { ScriptName = "HcScNotCompClass", FragmentName = "Fragment_0" } } });
+            var dataDir = Path.Combine(tmpDir, "script-notcomp-data"); Directory.CreateDirectory(dataDir);   // EMPTY — no .pex planted
+            using var assets = AssetResolver.Build("", "", dataDir, Array.Empty<string>(), Array.Empty<ActiveArchive>());
+            var report = f.ok ? DialogueScriptCheck.Run(f.path, AsCreated("HcScNotComp", f.infoFk), assets) : ScriptBindingReport.Empty;
+            var find = report.Findings.Count == 1 ? report.Findings[0] : null;
+            scriptNotCompiledOk = f.ok && find is not null && find.Status == ScriptBindingStatus.ScriptNotCompiled
+                && find.MissingPex.Count == 1 && find.MissingPex[0] == @"Scripts\HcScNotCompClass.pex";
+            Console.WriteLine($"   SCRIPT-NOTCOMPILED no .pex         : {(scriptNotCompiledOk ? @"PASS — bound fragment, no Scripts\<class>.pex -> ScriptNotCompiled" : $"FAIL — ok={f.ok} findings={report.Findings.Count} status={find?.Status} missing=[{(find is null ? "" : string.Join(",", find.MissingPex))}] err=[{report.CheckError}]")}");
+        }
+
+        // ---------- SCRIPT-BOUND: a bound fragment WITH its compiled .pex on disk -> BoundAndCompiled ----------
+        bool scriptBoundOk = false;
+        {
+            var f = BuildScriptFixture("HcScBound", info =>
+                info.VirtualMachineAdapter = new DialogResponsesAdapter { ScriptFragments = new ScriptFragments {
+                    FileName = "HcScBoundClass", OnEnd = new ScriptFragment { ScriptName = "HcScBoundClass", FragmentName = "Fragment_0" } } });
+            var dataDir = Path.Combine(tmpDir, "script-bound-data");
+            if (f.ok)
+            {
+                var planted = Path.Combine(dataDir, @"Scripts\HcScBoundClass.pex");
+                Directory.CreateDirectory(Path.GetDirectoryName(planted)!); File.WriteAllBytes(planted, new byte[] { 0, 1, 2 });
+            }
+            else Directory.CreateDirectory(dataDir);
+            using var assets = AssetResolver.Build("", "", dataDir, Array.Empty<string>(), Array.Empty<ActiveArchive>());
+            var report = f.ok ? DialogueScriptCheck.Run(f.path, AsCreated("HcScBound", f.infoFk), assets) : ScriptBindingReport.Empty;
+            var find = report.Findings.Count == 1 ? report.Findings[0] : null;
+            scriptBoundOk = f.ok && find is not null && find.Status == ScriptBindingStatus.BoundAndCompiled && find.MissingPex.Count == 0;
+            Console.WriteLine($"   SCRIPT-BOUND planted .pex          : {(scriptBoundOk ? "PASS — bound fragment + compiled .pex -> BoundAndCompiled" : $"FAIL — ok={f.ok} findings={report.Findings.Count} status={find?.Status} err=[{report.CheckError}]")}");
+        }
+
+        // ---------- SCRIPT-ATTACHED: an attached Scripts[] entry (not a fragment) is a bound class too -> checked for .pex ----------
+        bool scriptAttachedOk = false;
+        {
+            var f = BuildScriptFixture("HcScAttached", info =>
+            {
+                var a = new DialogResponsesAdapter();
+                a.Scripts.Add(new ScriptEntry { Name = "HcScAttachedClass" });
+                info.VirtualMachineAdapter = a;
+            });
+            var dataDir = Path.Combine(tmpDir, "script-attached-data");
+            if (f.ok)
+            {
+                var planted = Path.Combine(dataDir, @"Scripts\HcScAttachedClass.pex");
+                Directory.CreateDirectory(Path.GetDirectoryName(planted)!); File.WriteAllBytes(planted, new byte[] { 0, 1, 2 });
+            }
+            else Directory.CreateDirectory(dataDir);
+            using var assets = AssetResolver.Build("", "", dataDir, Array.Empty<string>(), Array.Empty<ActiveArchive>());
+            var report = f.ok ? DialogueScriptCheck.Run(f.path, AsCreated("HcScAttached", f.infoFk), assets) : ScriptBindingReport.Empty;
+            var find = report.Findings.Count == 1 ? report.Findings[0] : null;
+            scriptAttachedOk = f.ok && find is not null && find.Status == ScriptBindingStatus.BoundAndCompiled && find.Scripts.Contains("HcScAttachedClass");
+            Console.WriteLine($"   SCRIPT-ATTACHED Scripts[] entry    : {(scriptAttachedOk ? "PASS — attached Scripts[] class + .pex -> BoundAndCompiled" : $"FAIL — ok={f.ok} findings={report.Findings.Count} status={find?.Status} scripts=[{(find is null ? "" : string.Join(",", find.Scripts))}] err=[{report.CheckError}]")}");
+        }
+
+        // ---------- SCRIPT-NOVMAD: a created line with NO result script is NOT checked (no false-positive nag) ----------
+        bool scriptNoVmadOk = false;
+        {
+            var f = BuildScriptFixture("HcScNoVmad", info => { });   // no VMAD configured
+            var dataDir = Path.Combine(tmpDir, "script-novmad-data"); Directory.CreateDirectory(dataDir);
+            using var assets = AssetResolver.Build("", "", dataDir, Array.Empty<string>(), Array.Empty<ActiveArchive>());
+            var report = f.ok ? DialogueScriptCheck.Run(f.path, AsCreated("HcScNoVmad", f.infoFk), assets) : new ScriptBindingReport(Array.Empty<ScriptBindingFinding>()) { CheckError = "fixture failed" };
+            scriptNoVmadOk = f.ok && report.IsEmpty;
+            Console.WriteLine($"   SCRIPT-NOVMAD no script -> no nag   : {(scriptNoVmadOk ? "PASS — a line with no VMAD yields no finding (not nagged)" : $"FAIL — ok={f.ok} findings={report.Findings.Count} err=[{report.CheckError}]")}");
+        }
+
+        // ---------- SCRIPT-CHECKERROR: a check failure SURFACES on CheckError, never throws / never demotes the create ----------
+        bool scriptCheckErrorOk = false;
+        {
+            var corruptPath = Path.Combine(tmpDir, "HcScCorrupt.esp");
+            File.WriteAllText(corruptPath, "this is not a valid Skyrim plugin");
+            var dataDir = Path.Combine(tmpDir, "script-ckerr-data"); Directory.CreateDirectory(dataDir);
+            using var assets = AssetResolver.Build("", "", dataDir, Array.Empty<string>(), Array.Empty<ActiveArchive>());
+            var created = new[] { new WritePatchBuilder.CreatedRecord(new FormKey(new ModKey("HcScCk", ModType.Plugin), 0x800), "DialogResponses", "HcScCkInfo", Array.Empty<WritePatchBuilder.OpResult>()) };
+            ScriptBindingReport report = ScriptBindingReport.Empty; bool threw = false;
+            try { report = DialogueScriptCheck.Run(corruptPath, created, assets); }
+            catch { threw = true; }
+            scriptCheckErrorOk = !threw && report.CheckError is not null && report.Findings.Count == 0;
+            Console.WriteLine($"   SCRIPT-CHECKERROR surfaced not thrown:{(scriptCheckErrorOk ? "PASS — corrupt patch -> CheckError set, no throw, no findings" : $"FAIL — threw={threw} checkError=[{report.CheckError}] findings={report.Findings.Count}")}");
+        }
+
         Console.WriteLine();
         bool pass = fixturesOk && oneshotOk && multiOk && intoTopicOk && intoCellOk
                     && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendOk
@@ -1995,7 +2135,9 @@ public static class NestedCreateGuardProbe
                     && removeRejDictKeyAbsentOk && removeRejNullCollOk && removeRejListValAbsentOk
                     && removeOkPresentDictOk && removeOkPresentListOk
                     && voicePathOk && voiceSilentOk && voicePresentOk && voiceNoSpeakerOk && voiceMultiOk
-                    && voiceSameCallOk && voiceCheckErrorOk;
+                    && voiceSameCallOk && voiceCheckErrorOk
+                    && scriptIncompleteOk && scriptNoFragOk && scriptNotCompiledOk && scriptBoundOk
+                    && scriptAttachedOk && scriptNoVmadOk && scriptCheckErrorOk;
         Console.WriteLine($"=== nested-create-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return pass ? 0 : 1;

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1199,7 +1199,10 @@ public sealed class LoadOrderService : IDisposable
 
             var outcome = WritePatchBuilder.CreateRecords(resolver, rulebook, specs, outPath, extend, fullReadback);
             if (!outcome.Success && created) RemoveFolderCreatedThisCall(outPath);   // hunt F4: a refused create leaves no orphan
-            return outcome.Success ? EnrichWithVoiceCheck(outcome, resolver) : outcome;
+            // Layer B dialogue teeth, both post-write verify steps (the proven CreateRecords path stays untouched):
+            // unit B voice (.fuz/.lip) coverage, then unit C the result-script binding. Each is a no-op unless the call
+            // created a dialogue line; neither can fail the create (the write already succeeded).
+            return outcome.Success ? EnrichWithScriptCheck(EnrichWithVoiceCheck(outcome, resolver)) : outcome;
         }
     }
 
@@ -1222,6 +1225,27 @@ public sealed class LoadOrderService : IDisposable
         try { report = VoiceCheck.Run(outcome.OutputPath, outcome.Created, resolver, Assets); }
         catch (Exception ex) { report = VoiceReport.Empty with { CheckError = $"{ex.GetType().Name}: {ex.Message}" }; }
         return report.IsEmpty ? outcome : outcome with { Voice = report };
+    }
+
+    /// <summary>Layer B unit C — the per-create RESULT-SCRIPT binding check, run as a POST-WRITE step on a SUCCESSFUL
+    /// create (the service owns the live <see cref="Assets"/> resolver; the proven core create path stays asset-free and
+    /// untouched), exactly like <see cref="EnrichWithVoiceCheck"/>. Only fires when the call created ≥1 dialogue line
+    /// (INFO): <see cref="DialogueScriptCheck.Run"/> re-opens the written patch read-only, validates each created INFO's
+    /// VMAD result-script binding and checks its compiled `.pex` on disk — the report rides back on
+    /// <see cref="WritePatchBuilder.CreateOutcome.ScriptBinding"/>. NEVER fails the create (the write already succeeded);
+    /// a check failure is surfaced on the report's CheckError (Q3), and even a thrown Assets-build is caught here. Needs
+    /// no LoadOrderResolver — the binding lives wholly on the INFO + the on-disk `.pex` (no graph resolution).</summary>
+    WritePatchBuilder.CreateOutcome EnrichWithScriptCheck(WritePatchBuilder.CreateOutcome outcome)
+    {
+        bool anyInfo = false;
+        foreach (var c in outcome.Created)
+            if (string.Equals(c.RecordType, VoiceCheck.InfoCatalogName, StringComparison.Ordinal)) { anyInfo = true; break; }
+        if (!anyInfo) return outcome;
+
+        ScriptBindingReport report;
+        try { report = DialogueScriptCheck.Run(outcome.OutputPath, outcome.Created, Assets); }
+        catch (Exception ex) { report = ScriptBindingReport.Empty with { CheckError = $"{ex.GetType().Name}: {ex.Message}" }; }
+        return report.IsEmpty ? outcome : outcome with { ScriptBinding = report };
     }
 
     /// <summary>Map a wire field-op to a core <see cref="WriteRequest"/> for CREATE: RecordType is the create type (not

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -222,12 +222,14 @@ public static class WriteTools
         foreach (var op in o.Ops)
             sb.Append("  ").Append(op.RecordType).Append(' ').Append(op.Target).Append("  ").Append(op.Label)
               .Append(op.After is not null ? "  -> " + op.After : "  -> applied").Append('\n');
-        // Make the voice-coverage scope boundary VISIBLE, not silent (Q3): the .fuz/.lip presence check runs on
-        // CREATE of dialogue lines, not on EDITS to existing ones (Unit C). An edit that adds a spoken response to an
-        // existing INFO produces the same silent-line hazard with no voice note here, so flag it.
+        // Make the dialogue-coverage scope boundary VISIBLE, not silent (Q3): the .fuz/.lip presence check (unit B) AND
+        // the result-script binding check (unit C) both run on CREATE of dialogue lines, not on EDITS to existing ones.
+        // An edit that adds a spoken response or a result script to an existing INFO produces the same silent-line /
+        // dead-script hazard with no note here, so flag it. (The on-demand whole-topic validator — Unit C2 — will audit
+        // existing INFOs too; this note repoints to it then.)
         if (o.Ops.Any(op => string.Equals(op.RecordType, VoiceCheck.InfoCatalogName, StringComparison.Ordinal)))
-            sb.Append("note: this edit touched a dialogue line (INFO). Voice (.fuz) coverage is checked on CREATE, not on edits yet — ")
-              .Append("if you added a spoken response, verify its voice file on disk (housecarl_create_record reports the expected path).\n");
+            sb.Append("note: this edit touched a dialogue line (INFO). Voice (.fuz) and result-script coverage are checked on CREATE, not on edits yet — ")
+              .Append("if you added a spoken response or a result script, verify its voice file / compiled script on disk (housecarl_create_record reports the expected paths).\n");
         if (o.ReadBack is { } rb) AppendFullReadback(sb, rb, maxChars);
         sb.Append("to add more edits to THIS patch, pass into=\"").Append(file).Append("\".");
         return sb.ToString();
@@ -320,6 +322,7 @@ public static class WriteTools
                 sb.Append("      ").Append(op.Label).Append(op.After is not null ? "  -> " + op.After : "  -> applied").Append('\n');
         }
         AppendVoiceReport(sb, o.Voice, maxChars);
+        AppendScriptBindingReport(sb, o.ScriptBinding, maxChars);
         if (o.ReadBack is { } rb) AppendFullReadback(sb, rb, maxChars);
         sb.Append("the new FormID above is how you reference this record (SkyPatcher/SPID, or a follow-up edit). ")
           .Append("To add more to THIS patch, pass into=\"").Append(file).Append("\".");
@@ -382,6 +385,55 @@ public static class WriteTools
     static void AppendVoiceTrunc(StringBuilder sb, int rendered, int total, int cap)
         => sb.Append("  ... [voice coverage truncated: rendered ").Append(rendered).Append(" of ").Append(total)
              .Append(" line(s) at max_chars=").Append(cap).Append("; raise max_chars to see the rest]\n");
+
+    /// <summary>Render the Layer B unit C result-script coverage report (a dialogue-line create). The enforced Q3 teeth
+    /// against a byte-valid-but-INERT result script: a LOUD "WILL NOT FIRE" per created line whose VMAD binds nothing
+    /// usable (incomplete) or names a script with no compiled `.pex` on disk (naming the missing path), a brief "OK" for
+    /// ones fully wired + compiled, and a NAMED reason for any created INFO that couldn't be located. Script compilation
+    /// itself is housecarl_compile_script's job — this reports the on-disk DATA-layer boundary. No-op unless the call
+    /// created scripted dialogue lines. Budget-bounded like the voice + read-back sections (same max_chars contract).</summary>
+    static void AppendScriptBindingReport(StringBuilder sb, ScriptBindingReport? report, int maxChars)
+    {
+        if (report is null || report.IsEmpty) return;
+        int cap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        int total = report.Findings.Count, rendered = 0;
+        sb.Append("result-script coverage — created dialogue lines (a bound script that's unwired or uncompiled runs NOTHING in game):\n");
+
+        bool anyReadIncomplete = false;
+        foreach (var f in report.Findings)
+        {
+            if (sb.Length >= cap)
+            {
+                sb.Append("  ... [result-script coverage truncated: rendered ").Append(rendered).Append(" of ").Append(total)
+                  .Append(" line(s) at max_chars=").Append(cap).Append("; raise max_chars to see the rest]\n");
+                return;
+            }
+            var who = string.IsNullOrEmpty(f.TopicEditorId) ? f.Info.ToString() : $"{f.TopicEditorId} ({f.Info})";
+            switch (f.Status)
+            {
+                case ScriptBindingStatus.BoundAndCompiled:
+                    sb.Append("  OK   ").Append(who).Append("  — ").Append(f.Detail).Append('\n');
+                    break;
+                case ScriptBindingStatus.ScriptNotCompiled:
+                    sb.Append("  [!] WILL NOT FIRE  ").Append(who).Append("  — ").Append(f.Detail);
+                    if (f.MissingPex.Count > 0) sb.Append("  (missing: ").Append(string.Join(", ", f.MissingPex)).Append(')');
+                    sb.Append('\n');
+                    break;
+                case ScriptBindingStatus.BindingIncomplete:
+                    sb.Append("  [!] WILL NOT FIRE  ").Append(who).Append("  — ").Append(f.Detail).Append('\n');
+                    break;
+                default: // Undetermined
+                    sb.Append("  [?] ").Append(who).Append("  — ").Append(f.Detail).Append('\n');
+                    break;
+            }
+            if (f.ReadIncomplete) anyReadIncomplete = true;
+            rendered++;
+        }
+        if (anyReadIncomplete)
+            sb.Append("  note: a BSA failed to read this scan, so a \"missing .pex\" above may merely be unscanned — verify in MO2.\n");
+        if (report.CheckError is not null)
+            sb.Append("  result-script check could not run: ").Append(report.CheckError).Append(" — the records WERE created; verify the script binding manually.\n");
+    }
 }
 
 // ---- wire DTOs (the operation shape for bulk_apply; set_field builds one internally) ----------------------


### PR DESCRIPTION
## What & why

Layer B **Unit C, part C1** (per-create structural checks) of the nested-dialogue plan (`dev/plans/NESTED_DIALOGUE_AUTHORING_PLAN_2026-06-13.md` §3.6 / §3 job 3). The on-demand whole-topic validator is **C2** (separate PR, next).

A dialogue line (INFO) can carry a **result script** — a Papyrus fragment run when the line plays (start a quest stage, give an item) — on its `VirtualMachineAdapter`. A byte-valid INFO whose binding is **half-built**, or names a script with **no compiled `.pex` on disk**, runs NOTHING in game. That's the silent-failure class houseCARL refuses (Q3). C1 adds the enforced, non-advisory check.

## The two checks (per created INFO that carries a VMAD)

1. **Structural binding completeness** — a real Begin/End fragment, or a named attached `Scripts[]` entry. A bare `ScriptFragments.FileName` with no fragment is *hollow* → `BindingIncomplete` ("WILL NOT FIRE").
2. **Compiled `.pex` on disk** — each bound script class must have `Scripts\<class>.pex` in the VFS (loose + BSA, via the existing `AssetResolver`) → else `ScriptNotCompiled` ("WILL NOT FIRE", names the missing path). The direct analog of Unit B's voice `.fuz` check.

Keyed on **VMAD-present**, so a script-free line is never nagged (no false positives). Needs no graph resolution — the binding lives wholly on the INFO + the on-disk `.pex`.

## Shape (mirrors Unit B exactly)

- **`DialogueScriptCheck.cs`** (new core, sibling of `VoiceCheck`) — post-write walk; never throws (a whole-check failure rides `ScriptBindingReport.CheckError`, Q3).
- **`CreateOutcome.ScriptBinding`** — additive report field, sibling of `Voice`. The proven `WritePatchBuilder.CreateRecords` path is **untouched**.
- **`LoadOrderService.EnrichWithScriptCheck`** — fills it post-success (the service owns the live `AssetResolver`), chained after the voice enrich; never fails the create.
- **`WriteTools.AppendScriptBindingReport`** — renders it, budget-bounded like the voice report.
- The **edit-path note** now names result-script coverage too (the create-only boundary stays visible — Q3); **C2 repoints it** to the on-demand validator.

## Tests

7 RED-proven arms in `nested-create-guard` (all sabotage → watch-fail → revert):
`SCRIPT-INCOMPLETE`, `SCRIPT-NOFRAG` (FileName alone, `.pex` planted, still incomplete — proves a hollow declaration isn't counted), `SCRIPT-NOTCOMPILED`, `SCRIPT-BOUND`, `SCRIPT-ATTACHED`, `SCRIPT-NOVMAD` (no false-positive nag), `SCRIPT-CHECKERROR` (corrupt patch → `CheckError`, never throws). Full `nested-create-guard` PASS; full solution builds clean (no new warnings).

## Cornerstone

Plan §4 classifies Layer B correctness as **§4-(a)** — a legitimate domain-workflow diagnostic, not disguised per-type write wiring. C1 adds no per-record write logic.

## Known scope line (not a gap)

C1 is **create-only**; auditing existing INFOs' script bindings is **C2** (the on-demand whole-topic validator). The edit-path note makes that boundary visible rather than silent. One minor assumption: the bound class name is stored bare (no extension), as CK/xEdit do — `Scripts\<name>.pex`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)