### PR TITLE
Layer B unit C2 — housecarl_validate_dialogue (on-demand dialogue-graph validator)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,13 @@ jobs:
       - name: Probe — nested-record create (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- nested-create-guard
 
+      # Self-contained (synthesizes a master with one dialogue topic per validation shape — no external files), runs
+      # fully here: a regression guard locking in the on-demand dialogue-graph validator (nested-dialogue plan §3.6,
+      # Layer B unit C2 — housecarl_validate_dialogue): the graph checks (PNAM chain, quest + branch wiring), the reused
+      # voice/script per-INFO teeth over EXISTING lines, the quest fan-out, and the named not-found/wrong-type rejects.
+      - name: Probe — dialogue-graph validator (self-contained regression guard)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- dialogue-validate-guard
+
       # Self-contained (synthesizes a real MO2 instance + a master with a dialogue topic) and drives the REAL
       # LoadOrderService.CreateRecords / CreateRecordsBatch: locks in the create-tool WIRE (nested/dialogue plan,
       # Layer A) — create_record's parent/collection passthrough, the new bulk_create batch tool (the same-call

--- a/src/housecarl-core/DialogueScriptCheck.cs
+++ b/src/housecarl-core/DialogueScriptCheck.cs
@@ -138,7 +138,9 @@ public static class DialogueScriptCheck
     /// CLASS that must have a compiled `.pex` to run (a ScriptFragments fragment's FileName, counted only when a real
     /// Begin/End fragment is wired; each attached Scripts[] entry's class name), then either flag the hollow binding,
     /// or check each class's `Scripts\&lt;class&gt;.pex` on disk.</summary>
-    static void CheckInfo(IDialogResponsesGetter info, string topicEdid, AssetResolver.AssetView av,
+    // internal (not private): DialogueValidate (unit C2) reuses this exact per-INFO binding check over EVERY INFO
+    // in a topic, so the per-create result-script teeth and the on-demand validator can never drift.
+    internal static void CheckInfo(IDialogResponsesGetter info, string topicEdid, AssetResolver.AssetView av,
                           List<ScriptBindingFinding> findings)
     {
         var vmad = info.VirtualMachineAdapter;

--- a/src/housecarl-core/DialogueValidate.cs
+++ b/src/housecarl-core/DialogueValidate.cs
@@ -12,15 +12,24 @@ namespace HousecarlCore;
 //   what the game actually sees — and audits EVERY existing INFO in the topic, not just freshly-created ones.
 //   That closes unit B's deferred edit-path voice/script audit gap (the WriteTools edit-path note repoints here).
 //
-//  WHAT IT CHECKS (per topic, all on the RESOLVED WINNING DialogTopic record — a plugin that overrides any INFO
-//  must carry its parent topic, so the winning topic's authored Responses ARE the in-game response set + order):
-//    • PNAM previous-link chain — each INFO's PreviousDialog should chain to the line before it in response
-//      order; the first line should have none. A disagreement means the playback order and the chain conflict.
+//  WHAT IT CHECKS (per topic, all on the RESOLVED WINNING DialogTopic record). The in-game INFO set IS the winning
+//  topic's Responses: an INFO cannot exist without its parent DIAL, and overriding an INFO pulls the DIAL in with it,
+//  so INFO+DIAL travel together and the winning DIAL's child list is authoritative (the "DIAL-wins-wholesale" model —
+//  exactly why two mods touching one topic cause the classic dropped-line conflict; Aaron-confirmed 2026-06-19):
 //    • Quest wiring — DialogTopic.Quest set and resolving to a real QUST (an unowned topic may never present).
-//    • Branch wiring — if DialogTopic.Branch is set, it must resolve to a real DLBR.
+//    • Branch wiring — if DialogTopic.Branch is set, it must resolve to a real DLBR (an unset Branch is normal).
+//    • INFO.LinkTo conversation chain — the REAL topic→next-topic hand-off; a set link to a missing DIAL is a broken chain.
+//    • Dangling PNAM — a SET PreviousDialog that resolves to no INFO. ABSENCE is NOT flagged: vanilla leaves PNAM empty
+//      and selects intra-topic by Conditions, not by a previous-link chain (empirically confirmed; the §3.6 "PNAM chain
+//      in response order" model was wrong for the existing corpus, so that check was dropped — review fold 2026-06-19).
 //    • Category / Subtype — surfaced as facts (what the game will use), not judged.
-//    • Voice + result-script — the existing per-INFO VoiceCheck.CheckInfo + DialogueScriptCheck.CheckInfo run
-//      over every INFO (reused verbatim, so the create-path and the validator can never drift).
+//    • Voice + result-script — the existing per-INFO VoiceCheck.CheckInfo + DialogueScriptCheck.CheckInfo run over every
+//      LIVE INFO (reused verbatim, so the create-path and the validator can never drift). DELETED INFOs (a removed line)
+//      are skipped, not validated.
+//
+//  BOUNDARY (Q3): an INFO another plugin contributes but the WINNING topic override does not re-list is dropped in game
+//  (the conflict above) and is likewise not seen here — a clean pass is over the winning topic's INFO set, which IS what
+//  plays. The standing-limits footer names this.
 //
 //  WHAT IT DELIBERATELY CANNOT CHECK (grill-rev C2 — the validator is the ONLY non-advisory enforcement, so it
 //  must NAME the gaps, never let "checks passed" read as "this will play"): the CTDA conditions that gate when a
@@ -36,11 +45,10 @@ namespace HousecarlCore;
 //  resolve/asset failure rides DialogueValidationReport.CheckError, surfaced never silently swallowed (Q3).
 // ======================================================================
 
-/// <summary>How serious a graph finding is. <see cref="Problem"/> = a broken link (a Quest/Branch pointing at a
-/// missing record) the game cannot honour; <see cref="Warning"/> = a suspicious-but-not-fatal shape (a PNAM chain
-/// that disagrees with response order, an unowned topic) the author should verify. There is deliberately no "info"
-/// level — Category/Subtype facts ride <see cref="TopicValidation"/> fields, so the issue list is only ever things
-/// worth a second look.</summary>
+/// <summary>How serious a graph finding is. <see cref="Problem"/> = a broken link (a Quest/Branch/LinkTo/PNAM pointing
+/// at a missing record) the game cannot honour; <see cref="Warning"/> = a suspicious-but-not-fatal shape (e.g. an
+/// unowned topic) the author should verify. There is deliberately no "info" level — Category/Subtype facts ride
+/// <see cref="TopicValidation"/> fields, so the issue list is only ever things worth a second look.</summary>
 public enum DialogueIssueSeverity { Problem, Warning }
 
 /// <summary>One whole-topic graph finding: its <see cref="Severity"/> and a human-readable <see cref="Message"/>
@@ -48,13 +56,14 @@ public enum DialogueIssueSeverity { Problem, Warning }
 public sealed record DialogueIssue(DialogueIssueSeverity Severity, string Message);
 
 /// <summary>One topic's whole-graph validation: identity (<see cref="Topic"/>, <see cref="TopicEditorId"/>,
-/// <see cref="WinnerPlugin"/>), the surfaced Category/Subtype facts, the graph <see cref="Issues"/> (PNAM/quest/
-/// branch), and the reused per-INFO voice (<see cref="VoiceLines"/> / <see cref="VoiceUndetermined"/>) + result-
-/// script (<see cref="ScriptFindings"/>) verdicts over EVERY INFO. <see cref="ConditionedInfoCount"/> feeds the
-/// standing CTDA limit (grill-rev C2).</summary>
+/// <see cref="WinnerPlugin"/>), the surfaced Category/Subtype facts, the graph <see cref="Issues"/> (quest/branch/
+/// LinkTo/dangling-PNAM), and the reused per-INFO voice (<see cref="VoiceLines"/> / <see cref="VoiceUndetermined"/>) +
+/// result-script (<see cref="ScriptFindings"/>) verdicts over every LIVE INFO. <see cref="InfoCount"/> counts INFO
+/// records (one INFO may carry several spoken rows, or none) — NOT spoken lines. <see cref="ConditionedInfoCount"/>
+/// feeds the standing CTDA limit (grill-rev C2). <see cref="DeletedInfoCount"/> = INFOs skipped as removed (deleted).</summary>
 public sealed record TopicValidation(
     FormKey Topic, string TopicEditorId, string WinnerPlugin,
-    int InfoCount, int ConditionedInfoCount,
+    int InfoCount, int ConditionedInfoCount, int DeletedInfoCount,
     string Category, string Subtype, string SubtypeName,
     IReadOnlyList<DialogueIssue> Issues,
     IReadOnlyList<VoiceLine> VoiceLines,
@@ -163,12 +172,17 @@ public static class DialogueValidate
         }
     }
 
-    /// <summary>Validate ONE already-resolved winning <paramref name="topic"/> against the load order: the PNAM
-    /// chain in response order, Quest/Branch wiring (resolved via <paramref name="resolve"/> — the load-order
-    /// winner resolver), and the reused per-INFO voice + result-script checks over EVERY INFO (against
-    /// <paramref name="assetView"/>). Pure walk over the in-memory topic getter — the only external calls are
-    /// <paramref name="resolve"/> (the service's session) and the asset view; the service owns the never-throw
-    /// boundary.</summary>
+    /// <summary>Validate ONE already-resolved winning <paramref name="topic"/> against the load order: Quest/Branch
+    /// wiring, the INFO.LinkTo conversation chain, dangling PNAM links, and the reused per-INFO voice + result-script
+    /// checks over every LIVE INFO (all resolved via <paramref name="resolve"/> — the load-order winner resolver —
+    /// against <paramref name="assetView"/>). Deleted INFOs are skipped, not validated. Pure walk over the in-memory
+    /// topic getter; the service owns the never-throw boundary.
+    ///
+    /// NOTE on PNAM (DialogResponses.PreviousDialog): vanilla Skyrim leaves it EMPTY and selects among a topic's INFOs
+    /// by their Conditions, NOT by a previous-link chain — so absence is the universal norm and is never flagged; only
+    /// a SET-but-unresolvable PNAM is reported. The real conversation chain is INFO.LinkTo (topic → next topic), checked
+    /// here for dangling targets. (Empirically confirmed 2026-06-19 against the live load order — the §3.6 "PNAM chain
+    /// in response order" model was wrong for the existing corpus, so that check was dropped.)</summary>
     public static TopicValidation ValidateTopic(IDialogTopicGetter topic, string winnerPlugin,
         Func<FormKey, IMajorRecordGetter?> resolve, AssetResolver.AssetView assetView)
     {
@@ -193,46 +207,42 @@ public static class DialogueValidate
             issues.Add(new(DialogueIssueSeverity.Problem,
                 $"DialogTopic.Branch points at {branchFk.Value}, which does not resolve to a dialogue branch (DLBR) in the active load order — the branch wiring is broken."));
 
-        // --- PNAM previous-link chain, walked in response order. Well-formed: line[0] has no PNAM; line[k] chains
-        //     to line[k-1]'s FormKey. A disagreement means the authored order and the PNAM chain conflict (the
-        //     game plays by the chain, so the lines may run out of order or not at all). Surfaced as warnings —
-        //     unusual-but-not-provably-fatal — never silently (Q3).
-        var responses = topic.Responses;
-        var topicKeys = new HashSet<FormKey>();
-        foreach (var info in responses) topicKeys.Add(info.FormKey);
-
-        int conditioned = 0;
-        FormKey? prevKey = null;
-        for (int i = 0; i < responses.Count; i++)
+        // --- Per-INFO walk over the topic's LIVE INFOs. A deleted INFO is a REMOVED line — skip it entirely (don't
+        //     count it, chain it, or voice/script-check it; tally it for an honest "N skipped" note, Q3). InfoCount is
+        //     INFO RECORDS, not spoken rows (one INFO can carry several DialogResponse rows, or none).
+        int infoCount = 0, conditioned = 0, deleted = 0;
+        foreach (var info in topic.Responses)
         {
-            var info = responses[i];
+            if (info.IsDeleted) { deleted++; continue; }
+            infoCount++;
+
+            // PNAM (PreviousDialog): vanilla leaves it empty and orders intra-topic by Conditions, so ABSENCE is the
+            // norm and is NEVER flagged. Only a SET previous-link that resolves to no INFO is a real dangling reference.
             var pnam = NonNull(info.PreviousDialog.FormKeyNullable);
-            if (i == 0)
+            if (pnam is not null && resolve(pnam.Value) is not IDialogResponsesGetter)
+                issues.Add(new(DialogueIssueSeverity.Problem,
+                    $"INFO {info.FormKey} has a previous-link (PNAM -> {pnam.Value}) that resolves to no dialogue line (INFO) in the active load order — a dangling reference."));
+
+            // LinkTo: the REAL conversation chain — this line hands off to the next topic(s). A set link to a missing
+            // DialogTopic is a broken chain; an empty LinkTo is a normal terminal line (never flagged).
+            foreach (var link in info.LinkTo)
             {
-                if (pnam is not null)
-                    issues.Add(new(DialogueIssueSeverity.Warning,
-                        $"the first response line ({info.FormKey}) has a previous-link (PNAM -> {pnam.Value}); the first line in a topic normally has none — the playback chain may be malformed."));
+                var lk = link.FormKey;
+                if (!lk.IsNull && resolve(lk) is not IDialogTopicGetter)
+                    issues.Add(new(DialogueIssueSeverity.Problem,
+                        $"INFO {info.FormKey} links (LinkTo) to {lk}, which resolves to no dialogue topic (DIAL) in the active load order — the conversation chain is broken."));
             }
-            else if (pnam is null)
-                issues.Add(new(DialogueIssueSeverity.Warning,
-                    $"response line #{i + 1} ({info.FormKey}) has no previous-link (PNAM) but is not first; it should chain to the line before it ({prevKey!.Value}) — the playback order may break."));
-            else if (pnam.Value != prevKey!.Value)
-                issues.Add(new(DialogueIssueSeverity.Warning,
-                    topicKeys.Contains(pnam.Value)
-                        ? $"response line #{i + 1} ({info.FormKey}) chains (PNAM) to {pnam.Value}, not the line before it in response order ({prevKey!.Value}) — the order and the chain disagree."
-                        : $"response line #{i + 1} ({info.FormKey}) chains (PNAM) to {pnam.Value}, which is not a line in this topic — the chain leaves the topic."));
-            prevKey = info.FormKey;
 
             if (info.Conditions.Count > 0) conditioned++;
 
-            // Reuse the per-INFO voice + result-script checks over EVERY INFO (resolved-winner view). These are the
+            // Reuse the per-INFO voice + result-script checks over every LIVE INFO (resolved-winner view). These are the
             // exact methods the per-create teeth run, so the create path and the validator can never drift.
             VoiceCheck.CheckInfo(info, topic, resolve, assetView, voiceLines, voiceUndet);
             DialogueScriptCheck.CheckInfo(info, edid, assetView, scriptFindings);
         }
 
         return new TopicValidation(
-            topic.FormKey, edid, winnerPlugin, responses.Count, conditioned,
+            topic.FormKey, edid, winnerPlugin, infoCount, conditioned, deleted,
             topic.Category.ToString(), topic.Subtype.ToString(), DescribeSubtypeName(topic.SubtypeName),
             issues, voiceLines, voiceUndet, scriptFindings);
     }

--- a/src/housecarl-core/DialogueValidate.cs
+++ b/src/housecarl-core/DialogueValidate.cs
@@ -127,6 +127,11 @@ public static class DialogueValidate
                 return g;
             }
 
+            // Cheap O(1) existence check (the index dict, no body fetch): a dangling/missing reference — the common
+            // breakage — is caught here, so only a PRESENT link pays Resolve's body fetch (to name a wrong type). See
+            // ValidateTopic.BadRef.
+            bool InOrder(FormKey k) => !k.IsNull && view.ResolveWinner(k) is not null;
+
             var win = view.ResolveWinner(fk);
             if (win is null)
                 return DialogueValidationReport.ForError(fk,
@@ -139,7 +144,7 @@ public static class DialogueValidate
 
             if (body is IDialogTopicGetter topic)
             {
-                var tv = ValidateTopic(topic, win.Value.WinnerPlugin, Resolve, av);
+                var tv = ValidateTopic(topic, win.Value.WinnerPlugin, InOrder, Resolve, av);
                 return new DialogueValidationReport(fk, "topic", topic.EditorID ?? "", win.Value.WinnerPlugin, new[] { tv })
                     { ReadIncomplete = av.ReadIncomplete };
             }
@@ -157,7 +162,7 @@ public static class DialogueValidate
                     if (tbody is not IDialogTopicGetter dt) continue;
                     if (NonNull(dt.Quest.FormKeyNullable) is not { } qk || qk != fk) continue;
                     var wp = view.ResolveWinner(tfk)?.WinnerPlugin ?? win.Value.WinnerPlugin;
-                    topics.Add(ValidateTopic(dt, wp, Resolve, av));
+                    topics.Add(ValidateTopic(dt, wp, InOrder, Resolve, av));
                 }
                 return new DialogueValidationReport(fk, "quest", quest.EditorID ?? "", win.Value.WinnerPlugin, topics)
                     { ReadIncomplete = av.ReadIncomplete };
@@ -182,9 +187,13 @@ public static class DialogueValidate
     /// by their Conditions, NOT by a previous-link chain — so absence is the universal norm and is never flagged; only
     /// a SET-but-unresolvable PNAM is reported. The real conversation chain is INFO.LinkTo (topic → next topic), checked
     /// here for dangling targets. (Empirically confirmed 2026-06-19 against the live load order — the §3.6 "PNAM chain
-    /// in response order" model was wrong for the existing corpus, so that check was dropped.)</summary>
-    public static TopicValidation ValidateTopic(IDialogTopicGetter topic, string winnerPlugin,
-        Func<FormKey, IMajorRecordGetter?> resolve, AssetResolver.AssetView assetView)
+    /// in response order" model was wrong for the existing corpus, so that check was dropped.)
+    ///
+    /// References are vetted by <paramref name="inOrder"/> first (a cheap O(1) index lookup — a dangling/missing target,
+    /// the common breakage, costs no body fetch); only a PRESENT target pays <paramref name="resolve"/> to name a wrong
+    /// type. The voice/script reuse still uses <paramref name="resolve"/> for the speaker/quest bodies it must read.</summary>
+    internal static TopicValidation ValidateTopic(IDialogTopicGetter topic, string winnerPlugin,
+        Func<FormKey, bool> inOrder, Func<FormKey, IMajorRecordGetter?> resolve, AssetResolver.AssetView assetView)
     {
         var edid = topic.EditorID ?? "";
         var issues = new List<DialogueIssue>();
@@ -192,20 +201,32 @@ public static class DialogueValidate
         var voiceUndet = new List<VoiceUndetermined>();
         var scriptFindings = new List<ScriptBindingFinding>();
 
+        // Classify a SET reference: cheap-existence first (a dangling/missing target needs no body fetch), then a body
+        // fetch ONLY for the rarer present-but-wrong-type case (so the message names what it actually is). Returns null
+        // when the reference is fine, else the clause describing what's wrong — sharper than one "doesn't resolve":
+        // "missing or disabled" vs "resolves to a Weapon" (Q3), and it skips most full-plugin enumerations.
+        string? BadRef(FormKey target, string expects, Func<IMajorRecordGetter, bool> isExpected)
+        {
+            if (!inOrder(target)) return $"is not in the active load order ({expects} missing or disabled)";
+            var body = resolve(target);
+            return body is not null && isExpected(body) ? null
+                : $"resolves to {(body is null ? "an unreadable record" : "a " + RecordNaming.StripOverlay(body.GetType().Name))}, not {expects}";
+        }
+
         // --- Quest wiring: most functional topics are owned by a quest; an unowned one may never present its lines.
         var questFk = NonNull(topic.Quest.FormKeyNullable);
         if (questFk is null)
             issues.Add(new(DialogueIssueSeverity.Warning,
                 "DialogTopic.Quest is unset — this topic is not owned by a quest. Most dialogue topics are; an unowned topic may never present its lines in game. Verify this is intentional."));
-        else if (resolve(questFk.Value) is not IQuestGetter)
+        else if (BadRef(questFk.Value, "a quest (QUST)", b => b is IQuestGetter) is { } qwhy)
             issues.Add(new(DialogueIssueSeverity.Problem,
-                $"DialogTopic.Quest points at {questFk.Value}, which does not resolve to a quest (QUST) in the active load order — the owning quest is missing/disabled."));
+                $"DialogTopic.Quest points at {questFk.Value}, which {qwhy} — the owning quest is unresolved."));
 
         // --- Branch wiring: optional (many topics have none), but if set it must resolve to a real DLBR.
         var branchFk = NonNull(topic.Branch.FormKeyNullable);
-        if (branchFk is not null && resolve(branchFk.Value) is not IDialogBranchGetter)
+        if (branchFk is not null && BadRef(branchFk.Value, "a dialogue branch (DLBR)", b => b is IDialogBranchGetter) is { } bwhy)
             issues.Add(new(DialogueIssueSeverity.Problem,
-                $"DialogTopic.Branch points at {branchFk.Value}, which does not resolve to a dialogue branch (DLBR) in the active load order — the branch wiring is broken."));
+                $"DialogTopic.Branch points at {branchFk.Value}, which {bwhy} — the branch wiring is broken."));
 
         // --- Per-INFO walk over the topic's LIVE INFOs. A deleted INFO is a REMOVED line — skip it entirely (don't
         //     count it, chain it, or voice/script-check it; tally it for an honest "N skipped" note, Q3). InfoCount is
@@ -217,20 +238,20 @@ public static class DialogueValidate
             infoCount++;
 
             // PNAM (PreviousDialog): vanilla leaves it empty and orders intra-topic by Conditions, so ABSENCE is the
-            // norm and is NEVER flagged. Only a SET previous-link that resolves to no INFO is a real dangling reference.
+            // norm and is NEVER flagged. Only a SET previous-link that doesn't resolve to an INFO is a real defect.
             var pnam = NonNull(info.PreviousDialog.FormKeyNullable);
-            if (pnam is not null && resolve(pnam.Value) is not IDialogResponsesGetter)
+            if (pnam is not null && BadRef(pnam.Value, "a dialogue line (INFO)", b => b is IDialogResponsesGetter) is { } pwhy)
                 issues.Add(new(DialogueIssueSeverity.Problem,
-                    $"INFO {info.FormKey} has a previous-link (PNAM -> {pnam.Value}) that resolves to no dialogue line (INFO) in the active load order — a dangling reference."));
+                    $"INFO {info.FormKey} has a previous-link (PNAM -> {pnam.Value}) that {pwhy}."));
 
             // LinkTo: the REAL conversation chain — this line hands off to the next topic(s). A set link to a missing
             // DialogTopic is a broken chain; an empty LinkTo is a normal terminal line (never flagged).
             foreach (var link in info.LinkTo)
             {
                 var lk = link.FormKey;
-                if (!lk.IsNull && resolve(lk) is not IDialogTopicGetter)
+                if (!lk.IsNull && BadRef(lk, "a dialogue topic (DIAL)", b => b is IDialogTopicGetter) is { } lwhy)
                     issues.Add(new(DialogueIssueSeverity.Problem,
-                        $"INFO {info.FormKey} links (LinkTo) to {lk}, which resolves to no dialogue topic (DIAL) in the active load order — the conversation chain is broken."));
+                        $"INFO {info.FormKey} links (LinkTo) to {lk}, which {lwhy} — the conversation chain is broken."));
             }
 
             if (info.Conditions.Count > 0) conditioned++;

--- a/src/housecarl-core/DialogueValidate.cs
+++ b/src/housecarl-core/DialogueValidate.cs
@@ -1,0 +1,252 @@
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+
+namespace HousecarlCore;
+
+// ======================================================================
+//  DialogueValidate — the ON-DEMAND whole-topic dialogue-graph validator
+//  (nested-dialogue plan §3.6, Layer B unit C part C2; the on-demand counterpart of the per-create
+//   VoiceCheck (unit B) + DialogueScriptCheck (unit C1)). Where those run at CREATE time over the lines a
+//   single call just wrote, THIS runs on demand over a WHOLE topic resolved against the LOAD-ORDER WINNERS —
+//   what the game actually sees — and audits EVERY existing INFO in the topic, not just freshly-created ones.
+//   That closes unit B's deferred edit-path voice/script audit gap (the WriteTools edit-path note repoints here).
+//
+//  WHAT IT CHECKS (per topic, all on the RESOLVED WINNING DialogTopic record — a plugin that overrides any INFO
+//  must carry its parent topic, so the winning topic's authored Responses ARE the in-game response set + order):
+//    • PNAM previous-link chain — each INFO's PreviousDialog should chain to the line before it in response
+//      order; the first line should have none. A disagreement means the playback order and the chain conflict.
+//    • Quest wiring — DialogTopic.Quest set and resolving to a real QUST (an unowned topic may never present).
+//    • Branch wiring — if DialogTopic.Branch is set, it must resolve to a real DLBR.
+//    • Category / Subtype — surfaced as facts (what the game will use), not judged.
+//    • Voice + result-script — the existing per-INFO VoiceCheck.CheckInfo + DialogueScriptCheck.CheckInfo run
+//      over every INFO (reused verbatim, so the create-path and the validator can never drift).
+//
+//  WHAT IT DELIBERATELY CANNOT CHECK (grill-rev C2 — the validator is the ONLY non-advisory enforcement, so it
+//  must NAME the gaps, never let "checks passed" read as "this will play"): the CTDA conditions that gate when a
+//  line fires are semantic and only the game evaluates them; lip-sync accuracy + audio content are out of the
+//  data layer. Both are declared as standing limits the render surfaces loudly (Q3).
+//
+//  RESOLUTION SCOPE (Aaron 2026-06-19): LOAD-ORDER-AWARE, like every other houseCARL read — it validates what
+//  the active load order resolves (the modlist-author's "does this play in THIS list" view). An isolated
+//  mod-author "master-closure" scope (validate within {plugin + its masters} only) is a recognised, deliberately
+//  DEFERRED cross-tool capability (post-1.3), not a C2 knob — see memory project_parked_and_planned_work.
+//
+//  NEVER THROWS over a verify step: a per-topic walk is defensive, and the service wraps the whole run so a
+//  resolve/asset failure rides DialogueValidationReport.CheckError, surfaced never silently swallowed (Q3).
+// ======================================================================
+
+/// <summary>How serious a graph finding is. <see cref="Problem"/> = a broken link (a Quest/Branch pointing at a
+/// missing record) the game cannot honour; <see cref="Warning"/> = a suspicious-but-not-fatal shape (a PNAM chain
+/// that disagrees with response order, an unowned topic) the author should verify. There is deliberately no "info"
+/// level — Category/Subtype facts ride <see cref="TopicValidation"/> fields, so the issue list is only ever things
+/// worth a second look.</summary>
+public enum DialogueIssueSeverity { Problem, Warning }
+
+/// <summary>One whole-topic graph finding: its <see cref="Severity"/> and a human-readable <see cref="Message"/>
+/// that names the offending FormKey + what is wrong (Q3 — never a bare "invalid").</summary>
+public sealed record DialogueIssue(DialogueIssueSeverity Severity, string Message);
+
+/// <summary>One topic's whole-graph validation: identity (<see cref="Topic"/>, <see cref="TopicEditorId"/>,
+/// <see cref="WinnerPlugin"/>), the surfaced Category/Subtype facts, the graph <see cref="Issues"/> (PNAM/quest/
+/// branch), and the reused per-INFO voice (<see cref="VoiceLines"/> / <see cref="VoiceUndetermined"/>) + result-
+/// script (<see cref="ScriptFindings"/>) verdicts over EVERY INFO. <see cref="ConditionedInfoCount"/> feeds the
+/// standing CTDA limit (grill-rev C2).</summary>
+public sealed record TopicValidation(
+    FormKey Topic, string TopicEditorId, string WinnerPlugin,
+    int InfoCount, int ConditionedInfoCount,
+    string Category, string Subtype, string SubtypeName,
+    IReadOnlyList<DialogueIssue> Issues,
+    IReadOnlyList<VoiceLine> VoiceLines,
+    IReadOnlyList<VoiceUndetermined> VoiceUndetermined,
+    IReadOnlyList<ScriptBindingFinding> ScriptFindings);
+
+/// <summary>The whole-validation report for one <c>housecarl_validate_dialogue</c> call: the resolved input
+/// (<see cref="Input"/>, <see cref="InputKind"/> = "topic"/"quest"/"error", <see cref="InputEditorId"/>) and the
+/// per-topic validations. A top-level recoverable miss (the FormID isn't in the order, or resolves to neither a
+/// DIAL nor a QUST) is a NAMED <see cref="Error"/>; a mid-run throw is surfaced on <see cref="CheckError"/> — both
+/// honest, never a silent empty pass (Q3). <see cref="ReadIncomplete"/> carries the asset-layer caveat (a BSA that
+/// failed to read, so an "absent" voice/.pex may merely be unscanned).</summary>
+public sealed record DialogueValidationReport(
+    FormKey Input, string InputKind, string? InputEditorId, string? InputWinnerPlugin,
+    IReadOnlyList<TopicValidation> Topics)
+{
+    public string? Error { get; init; }
+    public string? CheckError { get; init; }
+    public bool ReadIncomplete { get; init; }
+
+    /// <summary>The FormID isn't in the active order, or resolves to neither a DIAL nor a QUST — a recoverable,
+    /// named error the tool renders as guidance (Q3), not a thrown failure.</summary>
+    public static DialogueValidationReport ForError(FormKey fk, string error) =>
+        new(fk, "error", null, null, Array.Empty<TopicValidation>()) { Error = error };
+
+    /// <summary>The validate threw mid-run (a resolve/asset failure) — surfaced, never silently swallowed (Q3).</summary>
+    public static DialogueValidationReport ForCheckError(FormKey fk, string err) =>
+        new(fk, "error", null, null, Array.Empty<TopicValidation>()) { CheckError = err };
+}
+
+public static class DialogueValidate
+{
+    /// <summary>The type filter for the quest fan-out scan — every winning DialogTopic (DIAL) in the order.</summary>
+    static readonly Type[] DialTypes = { typeof(IDialogTopicGetter) };
+
+    /// <summary>Resolve <paramref name="fk"/> to its load-order winner and validate the dialogue graph: a DIAL →
+    /// validate that one topic; a QUST → fan out to EVERY topic the quest owns (a whole-order DIAL winner scan,
+    /// filtered by DialogTopic.Quest, because a topic points UP at its quest — the quest holds no topic list).
+    /// Builds the load-order winner <c>Resolve</c> closure (each INFO's Speaker → NPC → VoiceType, and the topic's
+    /// Quest) + the asset view off the live resolvers, and opens ONE overlay session for the run. NEVER throws: a
+    /// recoverable miss (not in the order, or neither a DIAL nor a QUST) is a NAMED
+    /// <see cref="DialogueValidationReport.Error"/>; a mid-run throw rides
+    /// <see cref="DialogueValidationReport.CheckError"/> (Q3 — surfaced, never a silent empty pass).</summary>
+    public static DialogueValidationReport Run(LoadOrderResolver resolver, AssetResolver assets, FormKey fk)
+    {
+        try
+        {
+            var view = resolver.Capture();                       // pin ONE index build for the whole validation
+            using var session = resolver.OpenSession();          // one set of overlays, disposed at run end (Option B)
+            var av = assets.Capture();                           // …and ONE asset build, so presence + ReadIncomplete agree
+
+            // Load-order winner resolver for each INFO's Speaker → NPC → VoiceType and the topic's Quest. Cached for
+            // the run so a topic full of lines sharing a speaker doesn't re-enumerate a master per line.
+            var loCache = new Dictionary<FormKey, IMajorRecordGetter?>();
+            IMajorRecordGetter? Resolve(FormKey k)
+            {
+                if (k.IsNull) return null;
+                if (loCache.TryGetValue(k, out var c)) return c;
+                IMajorRecordGetter? g = view.ResolveWinner(k) is { } w ? view.GetRecord(session, w.WinnerPlugin, k) : null;
+                loCache[k] = g;
+                return g;
+            }
+
+            var win = view.ResolveWinner(fk);
+            if (win is null)
+                return DialogueValidationReport.ForError(fk,
+                    $"{fk} is not in the active load order — nothing to validate. Pass a dialogue topic (DIAL) FormID to validate one topic, or a quest (QUST) FormID to validate all of a quest's topics.");
+
+            var body = view.GetRecord(session, win.Value.WinnerPlugin, fk);
+            if (body is null)
+                return DialogueValidationReport.ForError(fk,
+                    $"{fk} resolves to a winner in {win.Value.WinnerPlugin} but its body could not be fetched (the plugin may have changed since the index was built) — re-run to rebuild and try again.");
+
+            if (body is IDialogTopicGetter topic)
+            {
+                var tv = ValidateTopic(topic, win.Value.WinnerPlugin, Resolve, av);
+                return new DialogueValidationReport(fk, "topic", topic.EditorID ?? "", win.Value.WinnerPlugin, new[] { tv })
+                    { ReadIncomplete = av.ReadIncomplete };
+            }
+
+            if (body is IQuestGetter quest)
+            {
+                // Fan out: a topic points UP at its quest, so scan every winning DialogTopic in the order and keep
+                // the ones whose Quest is this quest. A whole-order DIAL winner scan (accuracy over perf — an
+                // on-demand validate, not a hot path). Each scanned body is FULLY walked by ValidateTopic before the
+                // scan iterator advances (and disposes that overlay) — the WinnerRecordsOfType consume-before-advance
+                // contract.
+                var topics = new List<TopicValidation>();
+                foreach (var (tfk, _, tbody) in view.WinnerRecordsOfType(DialTypes))
+                {
+                    if (tbody is not IDialogTopicGetter dt) continue;
+                    if (NonNull(dt.Quest.FormKeyNullable) is not { } qk || qk != fk) continue;
+                    var wp = view.ResolveWinner(tfk)?.WinnerPlugin ?? win.Value.WinnerPlugin;
+                    topics.Add(ValidateTopic(dt, wp, Resolve, av));
+                }
+                return new DialogueValidationReport(fk, "quest", quest.EditorID ?? "", win.Value.WinnerPlugin, topics)
+                    { ReadIncomplete = av.ReadIncomplete };
+            }
+
+            return DialogueValidationReport.ForError(fk,
+                $"{fk} resolves to a {RecordNaming.StripOverlay(body.GetType().Name)} in {win.Value.WinnerPlugin}, not a dialogue topic (DIAL) or quest (QUST). Pass a DIAL FormID to validate one topic, or a QUST FormID to validate every topic a quest owns.");
+        }
+        catch (Exception ex)
+        {
+            return DialogueValidationReport.ForCheckError(fk, $"{ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>Validate ONE already-resolved winning <paramref name="topic"/> against the load order: the PNAM
+    /// chain in response order, Quest/Branch wiring (resolved via <paramref name="resolve"/> — the load-order
+    /// winner resolver), and the reused per-INFO voice + result-script checks over EVERY INFO (against
+    /// <paramref name="assetView"/>). Pure walk over the in-memory topic getter — the only external calls are
+    /// <paramref name="resolve"/> (the service's session) and the asset view; the service owns the never-throw
+    /// boundary.</summary>
+    public static TopicValidation ValidateTopic(IDialogTopicGetter topic, string winnerPlugin,
+        Func<FormKey, IMajorRecordGetter?> resolve, AssetResolver.AssetView assetView)
+    {
+        var edid = topic.EditorID ?? "";
+        var issues = new List<DialogueIssue>();
+        var voiceLines = new List<VoiceLine>();
+        var voiceUndet = new List<VoiceUndetermined>();
+        var scriptFindings = new List<ScriptBindingFinding>();
+
+        // --- Quest wiring: most functional topics are owned by a quest; an unowned one may never present its lines.
+        var questFk = NonNull(topic.Quest.FormKeyNullable);
+        if (questFk is null)
+            issues.Add(new(DialogueIssueSeverity.Warning,
+                "DialogTopic.Quest is unset — this topic is not owned by a quest. Most dialogue topics are; an unowned topic may never present its lines in game. Verify this is intentional."));
+        else if (resolve(questFk.Value) is not IQuestGetter)
+            issues.Add(new(DialogueIssueSeverity.Problem,
+                $"DialogTopic.Quest points at {questFk.Value}, which does not resolve to a quest (QUST) in the active load order — the owning quest is missing/disabled."));
+
+        // --- Branch wiring: optional (many topics have none), but if set it must resolve to a real DLBR.
+        var branchFk = NonNull(topic.Branch.FormKeyNullable);
+        if (branchFk is not null && resolve(branchFk.Value) is not IDialogBranchGetter)
+            issues.Add(new(DialogueIssueSeverity.Problem,
+                $"DialogTopic.Branch points at {branchFk.Value}, which does not resolve to a dialogue branch (DLBR) in the active load order — the branch wiring is broken."));
+
+        // --- PNAM previous-link chain, walked in response order. Well-formed: line[0] has no PNAM; line[k] chains
+        //     to line[k-1]'s FormKey. A disagreement means the authored order and the PNAM chain conflict (the
+        //     game plays by the chain, so the lines may run out of order or not at all). Surfaced as warnings —
+        //     unusual-but-not-provably-fatal — never silently (Q3).
+        var responses = topic.Responses;
+        var topicKeys = new HashSet<FormKey>();
+        foreach (var info in responses) topicKeys.Add(info.FormKey);
+
+        int conditioned = 0;
+        FormKey? prevKey = null;
+        for (int i = 0; i < responses.Count; i++)
+        {
+            var info = responses[i];
+            var pnam = NonNull(info.PreviousDialog.FormKeyNullable);
+            if (i == 0)
+            {
+                if (pnam is not null)
+                    issues.Add(new(DialogueIssueSeverity.Warning,
+                        $"the first response line ({info.FormKey}) has a previous-link (PNAM -> {pnam.Value}); the first line in a topic normally has none — the playback chain may be malformed."));
+            }
+            else if (pnam is null)
+                issues.Add(new(DialogueIssueSeverity.Warning,
+                    $"response line #{i + 1} ({info.FormKey}) has no previous-link (PNAM) but is not first; it should chain to the line before it ({prevKey!.Value}) — the playback order may break."));
+            else if (pnam.Value != prevKey!.Value)
+                issues.Add(new(DialogueIssueSeverity.Warning,
+                    topicKeys.Contains(pnam.Value)
+                        ? $"response line #{i + 1} ({info.FormKey}) chains (PNAM) to {pnam.Value}, not the line before it in response order ({prevKey!.Value}) — the order and the chain disagree."
+                        : $"response line #{i + 1} ({info.FormKey}) chains (PNAM) to {pnam.Value}, which is not a line in this topic — the chain leaves the topic."));
+            prevKey = info.FormKey;
+
+            if (info.Conditions.Count > 0) conditioned++;
+
+            // Reuse the per-INFO voice + result-script checks over EVERY INFO (resolved-winner view). These are the
+            // exact methods the per-create teeth run, so the create path and the validator can never drift.
+            VoiceCheck.CheckInfo(info, topic, resolve, assetView, voiceLines, voiceUndet);
+            DialogueScriptCheck.CheckInfo(info, edid, assetView, scriptFindings);
+        }
+
+        return new TopicValidation(
+            topic.FormKey, edid, winnerPlugin, responses.Count, conditioned,
+            topic.Category.ToString(), topic.Subtype.ToString(), DescribeSubtypeName(topic.SubtypeName),
+            issues, voiceLines, voiceUndet, scriptFindings);
+    }
+
+    /// <summary>A 4-char SubtypeName marker as text, or "&lt;none&gt;" for the empty/default RecordType — so a
+    /// missing marker reads as a fact, never as a blank (Q3).</summary>
+    static string DescribeSubtypeName(RecordType rt)
+    {
+        var s = rt.ToString();
+        return string.IsNullOrWhiteSpace(s) || s.All(c => c == '\0') ? "<none>" : s;
+    }
+
+    /// <summary>A nullable FormLink's target as a real FormKey, or null when the link is unset OR explicitly Null
+    /// (00000000) — both mean "no target". Mirrors <see cref="VoiceCheck"/>'s sibling so the two read links the
+    /// same way.</summary>
+    static FormKey? NonNull(FormKey? fk) => fk is { } v && !v.IsNull ? v : null;
+}

--- a/src/housecarl-core/VoiceCheck.cs
+++ b/src/housecarl-core/VoiceCheck.cs
@@ -152,7 +152,9 @@ public static class VoiceCheck
     /// <summary>Resolve one INFO's voice graph (topic+quest EDIDs, speaker voice type) and emit either a per-line
     /// presence verdict for each spoken response, or ONE named undetermined reason (Q3) when the voice folder can't
     /// be computed. An INFO with no spoken response lines (a link/branch node) yields nothing — there is no voice to check.</summary>
-    static void CheckInfo(IDialogResponsesGetter info, IDialogTopicGetter topic,
+    // internal (not private): DialogueValidate (unit C2) reuses this exact per-INFO walk over EVERY INFO in a
+    // topic, so the per-create voice teeth and the on-demand validator can never drift on what "silent" means.
+    internal static void CheckInfo(IDialogResponsesGetter info, IDialogTopicGetter topic,
                           Func<FormKey, IMajorRecordGetter?> resolve, AssetResolver.AssetView av,
                           List<VoiceLine> lines, List<VoiceUndetermined> undetermined)
     {

--- a/src/housecarl-generator/DialogueValidateGuardProbe.cs
+++ b/src/housecarl-generator/DialogueValidateGuardProbe.cs
@@ -12,20 +12,26 @@ namespace HousecarlGenerator;
 /// owns two topics (the fan-out), a weapon (the wrong-type reject) + a not-in-order FormKey (the absent reject).
 /// Run: dotnet run --project src/housecarl-generator -- dialogue-validate-guard
 ///
-/// Arms (ALL required — a GREEN must mean "the contract holds", never "the scenario doesn't arise here"):
-///   CLEAN        — a well-formed topic (quest + branch resolve, PNAM chain correct) reports ZERO graph issues — the
-///                  no-FALSE-POSITIVE keystone (a validator that cries wolf is as bad as one that misses, Q3).
-///   PNAM-BROKEN  — a 2nd line with NO previous-link (PNAM) warns 'previous-link'/'order' — the chain teeth. RED if dropped: no warning.
+/// CHECK MODEL (review fold 2026-06-19, empirically confirmed against the live load order): vanilla topics leave PNAM
+/// EMPTY and select intra-topic by Conditions, so PNAM absence is the NORM and is never flagged — the §3.6 "PNAM chain
+/// in response order" check was DROPPED (it false-flagged ~every real topic). The real conversation chain is INFO.LinkTo
+/// (topic → next topic). So the graph checks are: quest + branch wiring, LinkTo targets resolve, and a SET-but-dangling
+/// PNAM. Deleted INFOs are skipped. Arms (ALL required — a GREEN must mean "the contract holds"):
+///   CLEAN        — a well-formed topic (quest + branch resolve; INFOs with EMPTY PNAM, the vanilla norm; a valid
+///                  LinkTo to a real topic) reports ZERO issues — the no-FALSE-POSITIVE keystone, and the direct proof
+///                  that empty PNAM is NOT flagged (the regression the review caught).
+///   LINKTO-DANGLE— an INFO.LinkTo to a missing topic is a PROBLEM naming 'LinkTo' — the real broken-chain teeth.
+///   PNAM-DANGLE  — a SET PreviousDialog resolving to no INFO is a PROBLEM naming 'PNAM'/'previous-link'. (Absence is
+///                  NOT flagged — proven by CLEAN.)
+///   DELETED-SKIP — a deleted INFO (a removed line) is skipped: not counted live (InfoCount excludes it), tallied as
+///                  deleted, and never voice/script-checked or graph-flagged.
 ///   NO-QUEST     — a topic with DialogTopic.Quest unset warns 'Quest' — the unowned-topic teeth.
-///   BAD-BRANCH   — DialogTopic.Branch pointing at a non-DLBR is a PROBLEM naming 'Branch' — the broken-wiring teeth.
-///   VOICE-WIRED  — a voiced line with no .fuz on disk surfaces as a SILENT VoiceLine IN THE VALIDATOR (the create-time
-///                  VoiceCheck reused over an EXISTING info) — proves the reuse is wired, not just that VoiceCheck exists.
-///   SCRIPT-WIRED — a bound result-script with no .pex surfaces as a ScriptNotCompiled finding IN THE VALIDATOR (the
-///                  reused DialogueScriptCheck over an existing info).
+///   BAD-BRANCH   — DialogTopic.Branch pointing at a non-DLBR is a PROBLEM naming 'Branch'.
+///   VOICE-WIRED  — a voiced line with no .fuz surfaces as a SILENT VoiceLine IN THE VALIDATOR (reused VoiceCheck).
+///   SCRIPT-WIRED — a bound result-script with no .pex surfaces as a ScriptNotCompiled finding (reused DialogueScriptCheck).
 ///   CTDA-COUNT   — a line carrying a Condition is counted (ConditionedInfoCount >= 1) — the standing-CTDA-limit teeth.
-///   QUEST-FANOUT — validating a QUEST fans out to EXACTLY the topics it owns (2 here), kind="quest". RED if the filter
-///                  breaks: 0 or every topic.
-///   REJ-NOTFOUND — a FormID not in the active order is a NAMED error ('not in the active load order'), never an empty pass.
+///   QUEST-FANOUT — validating a QUEST fans out to EXACTLY the topics it owns (2 here), kind="quest".
+///   REJ-NOTFOUND — a FormID not in the active order is a NAMED error ('not in the active load order').
 ///   REJ-WRONGTYPE— a FormID resolving to neither a DIAL nor a QUST (a Weapon) is a NAMED error ('not a dialogue topic').
 /// </summary>
 public static class DialogueValidateGuardProbe
@@ -41,7 +47,7 @@ public static class DialogueValidateGuardProbe
 
         var mKey = new ModKey("HcDvGuardMaster", ModType.Master);
         string mPath = Path.Combine(tmpDir, mKey.FileName.String);
-        FormKey cleanFk, pnamFk, noQuestFk, badBranchFk, voicedFk, scriptedFk, condFk, qFanFk, weapFk;
+        FormKey cleanFk, linkBadFk, pnamBadFk, deletedFk, noQuestFk, badBranchFk, voicedFk, scriptedFk, condFk, qFanFk, weapFk;
         try
         {
             var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
@@ -57,15 +63,32 @@ public static class DialogueValidateGuardProbe
 
             DialogResponses Info(string edid) => new(m.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = edid };
 
-            // CLEAN: quest + branch wired, two lines with a correct PNAM chain (line0 has none; line1 -> line0).
+            // A plain target topic so CLEAN's LinkTo resolves to a real DIAL.
+            var tTarget = m.DialogTopics.AddNew(); tTarget.EditorID = "HcDvLinkTarget"; tTarget.Quest.SetTo(qMain.FormKey);
+            tTarget.Responses.Add(Info("HcDvLinkTargetI"));
+
+            // CLEAN: quest + branch wired; two INFOs with EMPTY PNAM (the vanilla norm); the 2nd hands off to a real
+            // topic via LinkTo. The no-false-positive keystone — empty PNAM and a valid LinkTo must NOT be flagged.
             var tClean = m.DialogTopics.AddNew(); tClean.EditorID = "HcDvClean";
             tClean.Quest.SetTo(qMain.FormKey); tClean.Branch.SetTo(branch.FormKey);
-            var c0 = Info("HcDvCleanI0"); var c1 = Info("HcDvCleanI1"); c1.PreviousDialog.SetTo(c0.FormKey);
-            tClean.Responses.Add(c0); tClean.Responses.Add(c1); cleanFk = tClean.FormKey;
+            var c1 = Info("HcDvCleanI1"); c1.LinkTo.Add(new FormLink<IDialogTopicGetter>(tTarget.FormKey));
+            tClean.Responses.Add(Info("HcDvCleanI0")); tClean.Responses.Add(c1); cleanFk = tClean.FormKey;
 
-            // PNAM-BROKEN: a 2nd line whose PNAM is left unset (should chain to line0).
-            var tPnam = m.DialogTopics.AddNew(); tPnam.EditorID = "HcDvBadPnam"; tPnam.Quest.SetTo(qMain.FormKey);
-            tPnam.Responses.Add(Info("HcDvBpI0")); tPnam.Responses.Add(Info("HcDvBpI1")); pnamFk = tPnam.FormKey;
+            // LINKTO-DANGLE: an INFO links to a topic that is not in the order.
+            var tLinkBad = m.DialogTopics.AddNew(); tLinkBad.EditorID = "HcDvLinkBad"; tLinkBad.Quest.SetTo(qMain.FormKey);
+            var lb = Info("HcDvLinkBadI"); lb.LinkTo.Add(new FormLink<IDialogTopicGetter>(new FormKey(mKey, 0x00BBBBBB)));
+            tLinkBad.Responses.Add(lb); linkBadFk = tLinkBad.FormKey;
+
+            // PNAM-DANGLE: an INFO's previous-link points at an INFO that is not in the order.
+            var tPnamBad = m.DialogTopics.AddNew(); tPnamBad.EditorID = "HcDvPnamBad"; tPnamBad.Quest.SetTo(qMain.FormKey);
+            var pb = Info("HcDvPnamBadI"); pb.PreviousDialog.SetTo(new FormKey(mKey, 0x00CCCCCC));
+            tPnamBad.Responses.Add(pb); pnamBadFk = tPnamBad.FormKey;
+
+            // DELETED-SKIP: a live INFO + a deleted INFO (a removed line) — the deleted one must be skipped.
+            var tDeleted = m.DialogTopics.AddNew(); tDeleted.EditorID = "HcDvDeleted"; tDeleted.Quest.SetTo(qMain.FormKey);
+            tDeleted.Responses.Add(Info("HcDvDeletedLive"));
+            var del = Info("HcDvDeletedGone"); del.IsDeleted = true; tDeleted.Responses.Add(del);
+            deletedFk = tDeleted.FormKey;
 
             // NO-QUEST: Quest deliberately left unset.
             var tNoQ = m.DialogTopics.AddNew(); tNoQ.EditorID = "HcDvNoQuest";
@@ -111,24 +134,39 @@ public static class DialogueValidateGuardProbe
         var dataDir = Path.Combine(tmpDir, "data"); Directory.CreateDirectory(dataDir);   // EMPTY — nothing planted; voiced/scripted lines read as absent
         using var resolver = LoadOrderResolver.Build(new[] { mPath });
         using var assets = AssetResolver.Build("", "", dataDir, Array.Empty<string>(), Array.Empty<ActiveArchive>());
-        Console.WriteLine($"-- setup: master {mKey.FileName}; topics clean/pnam/noquest/badbranch/voiced/scripted/cond + 2 fan-out; quest {qFanFk}; weapon {weapFk} --");
+        Console.WriteLine($"-- setup: master {mKey.FileName}; topics clean/linkbad/pnambad/deleted/noquest/badbranch/voiced/scripted/cond + 2 fan-out; quest {qFanFk}; weapon {weapFk} --");
         Console.WriteLine();
 
         bool all = true;
 
-        // ---------- CLEAN: a well-formed topic reports ZERO graph issues (no false positives) ----------
+        // ---------- CLEAN: a well-formed topic (EMPTY PNAM + valid LinkTo) reports ZERO issues — empty PNAM is NOT flagged ----------
         {
             var t = One(DialogueValidate.Run(resolver, assets, cleanFk));
-            bool ok = t is not null && t.Issues.Count == 0;
-            all &= Pass("CLEAN no false issues", ok, t is null ? "no topic returned" : $"{t.Issues.Count} issue(s): {Issues(t)}");
+            bool ok = t is not null && t.Issues.Count == 0 && t.InfoCount == 2;
+            all &= Pass("CLEAN no false issues", ok, t is null ? "no topic returned" : $"infos={t.InfoCount} issues={t.Issues.Count}: {Issues(t)}");
         }
 
-        // ---------- PNAM-BROKEN: a 2nd line missing its previous-link warns ----------
+        // ---------- LINKTO-DANGLE: a LinkTo to a missing topic is a PROBLEM ----------
         {
-            var t = One(DialogueValidate.Run(resolver, assets, pnamFk));
-            bool ok = t is not null && t.Issues.Any(i => i.Severity == DialogueIssueSeverity.Warning
-                && (i.Message.Contains("previous-link", StringComparison.OrdinalIgnoreCase) || i.Message.Contains("PNAM", StringComparison.Ordinal)));
-            all &= Pass("PNAM-BROKEN warns chain", ok, t is null ? "no topic" : Issues(t));
+            var t = One(DialogueValidate.Run(resolver, assets, linkBadFk));
+            bool ok = t is not null && t.Issues.Any(i => i.Severity == DialogueIssueSeverity.Problem && i.Message.Contains("LinkTo", StringComparison.Ordinal));
+            all &= Pass("LINKTO-DANGLE problem", ok, t is null ? "no topic" : Issues(t));
+        }
+
+        // ---------- PNAM-DANGLE: a SET-but-unresolvable previous-link is a PROBLEM (absence is NOT flagged — see CLEAN) ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, pnamBadFk));
+            bool ok = t is not null && t.Issues.Any(i => i.Severity == DialogueIssueSeverity.Problem
+                && (i.Message.Contains("PNAM", StringComparison.Ordinal) || i.Message.Contains("previous-link", StringComparison.OrdinalIgnoreCase)));
+            all &= Pass("PNAM-DANGLE problem", ok, t is null ? "no topic" : Issues(t));
+        }
+
+        // ---------- DELETED-SKIP: a deleted INFO is skipped (not counted live, tallied deleted, no findings) ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, deletedFk));
+            bool ok = t is not null && t.InfoCount == 1 && t.DeletedInfoCount == 1
+                && t.ScriptFindings.Count == 0 && t.VoiceLines.Count == 0 && t.Issues.Count == 0;
+            all &= Pass("DELETED-SKIP not validated", ok, t is null ? "no topic" : $"live={t.InfoCount} deleted={t.DeletedInfoCount} issues={t.Issues.Count} script={t.ScriptFindings.Count}");
         }
 
         // ---------- NO-QUEST: an unowned topic warns 'Quest' ----------
@@ -190,14 +228,14 @@ public static class DialogueValidateGuardProbe
 
         Console.WriteLine();
         Console.WriteLine(all
-            ? "RESULT: PASS — the dialogue-graph validator holds (graph checks, voice/script reuse, fan-out, named rejects)."
+            ? "RESULT: PASS — the dialogue-graph validator holds (no false PNAM-absence flag, LinkTo + dangling-PNAM teeth, deleted-skip, voice/script reuse, fan-out, named rejects)."
             : "RESULT: FAIL — at least one arm regressed (see above).");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return all ? 0 : 1;
     }
 
-    /// <summary>The single topic of a topic-kind report (null on an error / a 0-topic result), so the single-topic arms
-    /// read its one TopicValidation directly.</summary>
+    /// <summary>The single topic of a topic-kind report (null on an error / a non-single-topic result), so the
+    /// single-topic arms read its one TopicValidation directly.</summary>
     static TopicValidation? One(DialogueValidationReport r) => r.Topics.Count == 1 ? r.Topics[0] : null;
 
     static string Issues(TopicValidation t) => t.Issues.Count == 0 ? "<none>" : string.Join(" | ", t.Issues.Select(i => $"[{i.Severity}] {i.Message}"));

--- a/src/housecarl-generator/DialogueValidateGuardProbe.cs
+++ b/src/housecarl-generator/DialogueValidateGuardProbe.cs
@@ -23,6 +23,8 @@ namespace HousecarlGenerator;
 ///   LINKTO-DANGLE— an INFO.LinkTo to a missing topic is a PROBLEM naming 'LinkTo' — the real broken-chain teeth.
 ///   PNAM-DANGLE  — a SET PreviousDialog resolving to no INFO is a PROBLEM naming 'PNAM'/'previous-link'. (Absence is
 ///                  NOT flagged — proven by CLEAN.)
+///   PNAM-RESOLVES— a SET previous-link to a REAL sibling INFO is NOT flagged — the positive lock that dangling-only is
+///                  resolve-aware, not blanket (guards against an INFO index-scoping regression). PR #90 review finding 4.
 ///   DELETED-SKIP — a deleted INFO (a removed line) is skipped: not counted live (InfoCount excludes it), tallied as
 ///                  deleted, and never voice/script-checked or graph-flagged.
 ///   NO-QUEST     — a topic with DialogTopic.Quest unset warns 'Quest' — the unowned-topic teeth.
@@ -47,7 +49,7 @@ public static class DialogueValidateGuardProbe
 
         var mKey = new ModKey("HcDvGuardMaster", ModType.Master);
         string mPath = Path.Combine(tmpDir, mKey.FileName.String);
-        FormKey cleanFk, linkBadFk, pnamBadFk, deletedFk, noQuestFk, badBranchFk, voicedFk, scriptedFk, condFk, qFanFk, weapFk;
+        FormKey cleanFk, linkBadFk, pnamBadFk, pnamOkFk, deletedFk, noQuestFk, badBranchFk, voicedFk, scriptedFk, condFk, qFanFk, weapFk;
         try
         {
             var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
@@ -83,6 +85,13 @@ public static class DialogueValidateGuardProbe
             var tPnamBad = m.DialogTopics.AddNew(); tPnamBad.EditorID = "HcDvPnamBad"; tPnamBad.Quest.SetTo(qMain.FormKey);
             var pb = Info("HcDvPnamBadI"); pb.PreviousDialog.SetTo(new FormKey(mKey, 0x00CCCCCC));
             tPnamBad.Responses.Add(pb); pnamBadFk = tPnamBad.FormKey;
+
+            // PNAM-RESOLVES: an INFO whose previous-link points at a REAL sibling INFO must NOT be flagged — the
+            // positive lock that the dangling-ONLY PNAM check is resolve-aware, not blanket (PR #90 review finding 4).
+            var tPnamOk = m.DialogTopics.AddNew(); tPnamOk.EditorID = "HcDvPnamOk"; tPnamOk.Quest.SetTo(qMain.FormKey);
+            var pa = Info("HcDvPnamOkA");
+            var pbk = Info("HcDvPnamOkB"); pbk.PreviousDialog.SetTo(pa.FormKey);
+            tPnamOk.Responses.Add(pa); tPnamOk.Responses.Add(pbk); pnamOkFk = tPnamOk.FormKey;
 
             // DELETED-SKIP: a live INFO + a deleted INFO (a removed line) — the deleted one must be skipped.
             var tDeleted = m.DialogTopics.AddNew(); tDeleted.EditorID = "HcDvDeleted"; tDeleted.Quest.SetTo(qMain.FormKey);
@@ -134,7 +143,7 @@ public static class DialogueValidateGuardProbe
         var dataDir = Path.Combine(tmpDir, "data"); Directory.CreateDirectory(dataDir);   // EMPTY — nothing planted; voiced/scripted lines read as absent
         using var resolver = LoadOrderResolver.Build(new[] { mPath });
         using var assets = AssetResolver.Build("", "", dataDir, Array.Empty<string>(), Array.Empty<ActiveArchive>());
-        Console.WriteLine($"-- setup: master {mKey.FileName}; topics clean/linkbad/pnambad/deleted/noquest/badbranch/voiced/scripted/cond + 2 fan-out; quest {qFanFk}; weapon {weapFk} --");
+        Console.WriteLine($"-- setup: master {mKey.FileName}; topics clean/linkbad/pnambad/pnamok/deleted/noquest/badbranch/voiced/scripted/cond + 2 fan-out; quest {qFanFk}; weapon {weapFk} --");
         Console.WriteLine();
 
         bool all = true;
@@ -159,6 +168,13 @@ public static class DialogueValidateGuardProbe
             bool ok = t is not null && t.Issues.Any(i => i.Severity == DialogueIssueSeverity.Problem
                 && (i.Message.Contains("PNAM", StringComparison.Ordinal) || i.Message.Contains("previous-link", StringComparison.OrdinalIgnoreCase)));
             all &= Pass("PNAM-DANGLE problem", ok, t is null ? "no topic" : Issues(t));
+        }
+
+        // ---------- PNAM-RESOLVES: a SET previous-link to a REAL sibling INFO is NOT flagged (dangling-only is resolve-aware) ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, pnamOkFk));
+            bool ok = t is not null && t.InfoCount == 2 && t.Issues.Count == 0;
+            all &= Pass("PNAM-RESOLVES not flagged", ok, t is null ? "no topic" : $"infos={t.InfoCount} issues={t.Issues.Count}: {Issues(t)}");
         }
 
         // ---------- DELETED-SKIP: a deleted INFO is skipped (not counted live, tallied deleted, no findings) ----------

--- a/src/housecarl-generator/DialogueValidateGuardProbe.cs
+++ b/src/housecarl-generator/DialogueValidateGuardProbe.cs
@@ -1,0 +1,210 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SELF-CONTAINED CI REGRESSION GUARD for the on-demand dialogue-graph validator (nested-dialogue plan §3.6, Layer B
+/// unit C part C2 — housecarl_validate_dialogue). Drives the REAL core path (DialogueValidate.Run) against a SYNTHESIZED
+/// master in TEMP — NO Skyrim.esm, so it runs in CI. The master carries one topic per validation shape, a quest that
+/// owns two topics (the fan-out), a weapon (the wrong-type reject) + a not-in-order FormKey (the absent reject).
+/// Run: dotnet run --project src/housecarl-generator -- dialogue-validate-guard
+///
+/// Arms (ALL required — a GREEN must mean "the contract holds", never "the scenario doesn't arise here"):
+///   CLEAN        — a well-formed topic (quest + branch resolve, PNAM chain correct) reports ZERO graph issues — the
+///                  no-FALSE-POSITIVE keystone (a validator that cries wolf is as bad as one that misses, Q3).
+///   PNAM-BROKEN  — a 2nd line with NO previous-link (PNAM) warns 'previous-link'/'order' — the chain teeth. RED if dropped: no warning.
+///   NO-QUEST     — a topic with DialogTopic.Quest unset warns 'Quest' — the unowned-topic teeth.
+///   BAD-BRANCH   — DialogTopic.Branch pointing at a non-DLBR is a PROBLEM naming 'Branch' — the broken-wiring teeth.
+///   VOICE-WIRED  — a voiced line with no .fuz on disk surfaces as a SILENT VoiceLine IN THE VALIDATOR (the create-time
+///                  VoiceCheck reused over an EXISTING info) — proves the reuse is wired, not just that VoiceCheck exists.
+///   SCRIPT-WIRED — a bound result-script with no .pex surfaces as a ScriptNotCompiled finding IN THE VALIDATOR (the
+///                  reused DialogueScriptCheck over an existing info).
+///   CTDA-COUNT   — a line carrying a Condition is counted (ConditionedInfoCount >= 1) — the standing-CTDA-limit teeth.
+///   QUEST-FANOUT — validating a QUEST fans out to EXACTLY the topics it owns (2 here), kind="quest". RED if the filter
+///                  breaks: 0 or every topic.
+///   REJ-NOTFOUND — a FormID not in the active order is a NAMED error ('not in the active load order'), never an empty pass.
+///   REJ-WRONGTYPE— a FormID resolving to neither a DIAL nor a QUST (a Weapon) is a NAMED error ('not a dialogue topic').
+/// </summary>
+public static class DialogueValidateGuardProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  REGRESSION GUARD — dialogue-graph validator (nested-dialogue plan §3.6, Layer B unit C2)  ################");
+        Console.WriteLine();
+
+        var tmpDir = Path.Combine(Path.GetTempPath(), "hc-dialogue-validate-guard");
+        if (Directory.Exists(tmpDir)) Directory.Delete(tmpDir, recursive: true);
+        Directory.CreateDirectory(tmpDir);
+
+        var mKey = new ModKey("HcDvGuardMaster", ModType.Master);
+        string mPath = Path.Combine(tmpDir, mKey.FileName.String);
+        FormKey cleanFk, pnamFk, noQuestFk, badBranchFk, voicedFk, scriptedFk, condFk, qFanFk, weapFk;
+        try
+        {
+            var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
+
+            // Shared wiring the topics point at: two quests (main + the fan-out owner), a branch, a speaker chain.
+            var qMain = m.Quests.AddNew(); qMain.EditorID = "HcDvQuestMain";
+            var qFan = m.Quests.AddNew(); qFan.EditorID = "HcDvQuestFan"; qFanFk = qFan.FormKey;
+            var branch = m.DialogBranches.AddNew(); branch.EditorID = "HcDvBranch";
+            var voice = m.VoiceTypes.AddNew(); voice.EditorID = "HcDvVoice";
+            var npc = m.Npcs.AddNew(); npc.EditorID = "HcDvNpc"; npc.Voice.SetTo(voice.FormKey);
+            var weap = m.Weapons.AddNew(); weap.EditorID = "HcDvWeap"; weap.BasicStats = new WeaponBasicStats { Damage = 10 };
+            weapFk = weap.FormKey;
+
+            DialogResponses Info(string edid) => new(m.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = edid };
+
+            // CLEAN: quest + branch wired, two lines with a correct PNAM chain (line0 has none; line1 -> line0).
+            var tClean = m.DialogTopics.AddNew(); tClean.EditorID = "HcDvClean";
+            tClean.Quest.SetTo(qMain.FormKey); tClean.Branch.SetTo(branch.FormKey);
+            var c0 = Info("HcDvCleanI0"); var c1 = Info("HcDvCleanI1"); c1.PreviousDialog.SetTo(c0.FormKey);
+            tClean.Responses.Add(c0); tClean.Responses.Add(c1); cleanFk = tClean.FormKey;
+
+            // PNAM-BROKEN: a 2nd line whose PNAM is left unset (should chain to line0).
+            var tPnam = m.DialogTopics.AddNew(); tPnam.EditorID = "HcDvBadPnam"; tPnam.Quest.SetTo(qMain.FormKey);
+            tPnam.Responses.Add(Info("HcDvBpI0")); tPnam.Responses.Add(Info("HcDvBpI1")); pnamFk = tPnam.FormKey;
+
+            // NO-QUEST: Quest deliberately left unset.
+            var tNoQ = m.DialogTopics.AddNew(); tNoQ.EditorID = "HcDvNoQuest";
+            tNoQ.Responses.Add(Info("HcDvNqI0")); noQuestFk = tNoQ.FormKey;
+
+            // BAD-BRANCH: Branch points at a FormID that is no record (so it resolves to no DialogBranch).
+            var tBadB = m.DialogTopics.AddNew(); tBadB.EditorID = "HcDvBadBranch"; tBadB.Quest.SetTo(qMain.FormKey);
+            tBadB.Branch.SetTo(new FormKey(mKey, 0x00ABCDEF));
+            tBadB.Responses.Add(Info("HcDvBbI0")); badBranchFk = tBadB.FormKey;
+
+            // VOICE-WIRED: a voiced line (Speaker + one response) — no .fuz planted -> SILENT in the validator.
+            var tVoice = m.DialogTopics.AddNew(); tVoice.EditorID = "HcDvVoiced"; tVoice.Quest.SetTo(qMain.FormKey);
+            var vi = Info("HcDvVoicedI"); vi.Speaker.SetTo(npc.FormKey); vi.Responses.Add(new DialogResponse { ResponseNumber = 1 });
+            tVoice.Responses.Add(vi); voicedFk = tVoice.FormKey;
+
+            // SCRIPT-WIRED: a bound result-script fragment — no .pex planted -> ScriptNotCompiled in the validator.
+            var tScript = m.DialogTopics.AddNew(); tScript.EditorID = "HcDvScripted"; tScript.Quest.SetTo(qMain.FormKey);
+            var si = Info("HcDvScriptedI");
+            si.VirtualMachineAdapter = new DialogResponsesAdapter { ScriptFragments = new ScriptFragments {
+                FileName = "HcDvScriptClass", OnEnd = new ScriptFragment { ScriptName = "HcDvScriptClass", FragmentName = "Fragment_0" } } };
+            tScript.Responses.Add(si); scriptedFk = tScript.FormKey;
+
+            // CTDA-COUNT: a line carrying one Condition.
+            var tCond = m.DialogTopics.AddNew(); tCond.EditorID = "HcDvCond"; tCond.Quest.SetTo(qMain.FormKey);
+            var ci = Info("HcDvCondI");
+            ci.Conditions.Add(new ConditionFloat { CompareOperator = CompareOperator.EqualTo, ComparisonValue = 1f,
+                Data = new GetActorValueConditionData { ActorValue = ActorValue.Conjuration } });
+            tCond.Responses.Add(ci); condFk = tCond.FormKey;
+
+            // QUEST-FANOUT: two topics owned by qFan (and nothing else points at it).
+            var tf1 = m.DialogTopics.AddNew(); tf1.EditorID = "HcDvFan1"; tf1.Quest.SetTo(qFan.FormKey); tf1.Responses.Add(Info("HcDvFan1I"));
+            var tf2 = m.DialogTopics.AddNew(); tf2.EditorID = "HcDvFan2"; tf2.Quest.SetTo(qFan.FormKey); tf2.Responses.Add(Info("HcDvFan2I"));
+
+            m.BeginWrite.ToPath(mPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"error: could not synthesize the fixture master: {ex.GetType().Name}: {(ex.InnerException ?? ex).Message}");
+            try { Directory.Delete(tmpDir, recursive: true); } catch { }
+            return 1;
+        }
+
+        var dataDir = Path.Combine(tmpDir, "data"); Directory.CreateDirectory(dataDir);   // EMPTY — nothing planted; voiced/scripted lines read as absent
+        using var resolver = LoadOrderResolver.Build(new[] { mPath });
+        using var assets = AssetResolver.Build("", "", dataDir, Array.Empty<string>(), Array.Empty<ActiveArchive>());
+        Console.WriteLine($"-- setup: master {mKey.FileName}; topics clean/pnam/noquest/badbranch/voiced/scripted/cond + 2 fan-out; quest {qFanFk}; weapon {weapFk} --");
+        Console.WriteLine();
+
+        bool all = true;
+
+        // ---------- CLEAN: a well-formed topic reports ZERO graph issues (no false positives) ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, cleanFk));
+            bool ok = t is not null && t.Issues.Count == 0;
+            all &= Pass("CLEAN no false issues", ok, t is null ? "no topic returned" : $"{t.Issues.Count} issue(s): {Issues(t)}");
+        }
+
+        // ---------- PNAM-BROKEN: a 2nd line missing its previous-link warns ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, pnamFk));
+            bool ok = t is not null && t.Issues.Any(i => i.Severity == DialogueIssueSeverity.Warning
+                && (i.Message.Contains("previous-link", StringComparison.OrdinalIgnoreCase) || i.Message.Contains("PNAM", StringComparison.Ordinal)));
+            all &= Pass("PNAM-BROKEN warns chain", ok, t is null ? "no topic" : Issues(t));
+        }
+
+        // ---------- NO-QUEST: an unowned topic warns 'Quest' ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, noQuestFk));
+            bool ok = t is not null && t.Issues.Any(i => i.Message.Contains("Quest", StringComparison.Ordinal));
+            all &= Pass("NO-QUEST warns unowned", ok, t is null ? "no topic" : Issues(t));
+        }
+
+        // ---------- BAD-BRANCH: a Branch resolving to no DLBR is a PROBLEM ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, badBranchFk));
+            bool ok = t is not null && t.Issues.Any(i => i.Severity == DialogueIssueSeverity.Problem && i.Message.Contains("Branch", StringComparison.Ordinal));
+            all &= Pass("BAD-BRANCH problem", ok, t is null ? "no topic" : Issues(t));
+        }
+
+        // ---------- VOICE-WIRED: a voiced line with no .fuz surfaces as a SILENT VoiceLine in the validator ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, voicedFk));
+            bool ok = t is not null && t.VoiceLines.Count == 1 && !t.VoiceLines[0].FuzPresent;
+            all &= Pass("VOICE-WIRED silent line", ok, t is null ? "no topic" : $"lines={t.VoiceLines.Count} present={(t.VoiceLines.Count == 1 ? t.VoiceLines[0].FuzPresent.ToString() : "?")}");
+        }
+
+        // ---------- SCRIPT-WIRED: a bound script with no .pex surfaces as ScriptNotCompiled in the validator ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, scriptedFk));
+            bool ok = t is not null && t.ScriptFindings.Count == 1 && t.ScriptFindings[0].Status == ScriptBindingStatus.ScriptNotCompiled;
+            all &= Pass("SCRIPT-WIRED not-compiled", ok, t is null ? "no topic" : $"findings={t.ScriptFindings.Count} status={(t.ScriptFindings.Count == 1 ? t.ScriptFindings[0].Status.ToString() : "?")}");
+        }
+
+        // ---------- CTDA-COUNT: a conditioned line is counted (the standing-limit teeth) ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, condFk));
+            bool ok = t is not null && t.ConditionedInfoCount >= 1;
+            all &= Pass("CTDA-COUNT counts conditions", ok, t is null ? "no topic" : $"conditioned={t?.ConditionedInfoCount}");
+        }
+
+        // ---------- QUEST-FANOUT: validating a quest fans out to EXACTLY its 2 topics ----------
+        {
+            var r = DialogueValidate.Run(resolver, assets, qFanFk);
+            bool ok = r.InputKind == "quest" && r.Error is null && r.CheckError is null && r.Topics.Count == 2;
+            all &= Pass("QUEST-FANOUT 2 topics", ok, $"kind={r.InputKind} topics={r.Topics.Count} err=[{r.Error}] ckerr=[{r.CheckError}]");
+        }
+
+        // ---------- REJ-NOTFOUND: a FormID not in the order is a NAMED error ----------
+        {
+            var ghost = new FormKey(new ModKey("HcDvGhost", ModType.Plugin), 0x000800);
+            var r = DialogueValidate.Run(resolver, assets, ghost);
+            bool ok = r.InputKind == "error" && r.Error is not null && r.Error.Contains("not in the active load order", StringComparison.OrdinalIgnoreCase) && r.Topics.Count == 0;
+            all &= Pass("REJ-NOTFOUND named error", ok, $"kind={r.InputKind} err=[{r.Error}]");
+        }
+
+        // ---------- REJ-WRONGTYPE: a Weapon FormID is a NAMED 'not a dialogue topic or quest' error ----------
+        {
+            var r = DialogueValidate.Run(resolver, assets, weapFk);
+            bool ok = r.InputKind == "error" && r.Error is not null && r.Error.Contains("not a dialogue topic", StringComparison.OrdinalIgnoreCase) && r.Topics.Count == 0;
+            all &= Pass("REJ-WRONGTYPE named error", ok, $"kind={r.InputKind} err=[{r.Error}]");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine(all
+            ? "RESULT: PASS — the dialogue-graph validator holds (graph checks, voice/script reuse, fan-out, named rejects)."
+            : "RESULT: FAIL — at least one arm regressed (see above).");
+        try { Directory.Delete(tmpDir, recursive: true); } catch { }
+        return all ? 0 : 1;
+    }
+
+    /// <summary>The single topic of a topic-kind report (null on an error / a 0-topic result), so the single-topic arms
+    /// read its one TopicValidation directly.</summary>
+    static TopicValidation? One(DialogueValidationReport r) => r.Topics.Count == 1 ? r.Topics[0] : null;
+
+    static string Issues(TopicValidation t) => t.Issues.Count == 0 ? "<none>" : string.Join(" | ", t.Issues.Select(i => $"[{i.Severity}] {i.Message}"));
+
+    static bool Pass(string label, bool ok, string detail)
+    {
+        Console.WriteLine($"   {label,-28}: {(ok ? "PASS" : "FAIL")} — {detail}");
+        return ok;
+    }
+}

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -351,6 +351,12 @@ if (args.Length > 0 && args[0] == "upsert-guard") return UpsertGuardProbe.RunGua
 // happy paths + the 4 Q3 rejects + the patch-carried-parent extend (the former N9 gap) (NO Skyrim.esm, unlike nested-create-proof).
 if (args.Length > 0 && args[0] == "nested-create-guard") return NestedCreateGuardProbe.RunGuard(args[1..]);
 
+// on-demand dialogue-graph VALIDATOR (nested-dialogue plan §3.6, Layer B unit C2 — housecarl_validate_dialogue):
+// SELF-CONTAINED CI regression guard — synthesizes a master with one topic per validation shape, drives the REAL
+// DialogueValidate.Run for the graph checks (PNAM chain, quest + branch wiring), the reused voice/script per-INFO
+// teeth over EXISTING lines, the quest fan-out, and the named not-found / wrong-type rejects (NO Skyrim.esm).
+if (args.Length > 0 && args[0] == "dialogue-validate-guard") return DialogueValidateGuardProbe.RunGuard(args[1..]);
+
 // create-tool WIRE (nested/dialogue plan, Layer A): SELF-CONTAINED CI regression guard — drives the REAL
 // LoadOrderService.CreateRecords (single, parent/collection) + CreateRecordsBatch (the bulk_create array) over a
 // synthetic MO2 instance: flat-still-works, parent passthrough, the same-call one-shot, batch all-or-nothing, the

--- a/src/housecarl-mcp/DialogueTools.cs
+++ b/src/housecarl-mcp/DialogueTools.cs
@@ -97,8 +97,9 @@ static class DialogueWire
         string pad = indent ? "  " : "";
         sb.Append(pad).Append("topic ").Append(Edid(t.TopicEditorId)).Append(" (").Append(t.Topic).Append(')')
           .Append(" — winner ").Append(t.WinnerPlugin).Append('\n');
-        sb.Append(pad).Append("  ").Append(t.InfoCount).Append(t.InfoCount == 1 ? " response line" : " response lines");
+        sb.Append(pad).Append("  ").Append(t.InfoCount).Append(t.InfoCount == 1 ? " INFO record" : " INFO records");
         if (t.ConditionedInfoCount > 0) sb.Append("; ").Append(t.ConditionedInfoCount).Append(" carry conditions (CTDA)");
+        if (t.DeletedInfoCount > 0) sb.Append("; ").Append(t.DeletedInfoCount).Append(" deleted line(s) skipped");
         sb.Append('\n');
         sb.Append(pad).Append("  category=").Append(t.Category).Append("  subtype=").Append(t.Subtype)
           .Append("  subtype_marker=").Append(t.SubtypeName).Append('\n');
@@ -185,6 +186,7 @@ static class DialogueWire
         if (conditioned > 0) sb.Append(" — ").Append(conditioned).Append(" line(s) here carry conditions, unverified");
         sb.Append(".\n");
         sb.Append("  • voice presence is an on-disk file check only — lip-sync accuracy and the audio content itself are not verified (voice acting is out of scope).\n");
+        sb.Append("  • this validates the WINNING topic's INFO list (what the game plays); a line another plugin adds but this topic override does not re-list is dropped in game and is not seen here — resolve dialogue conflicts so the winning topic carries every line.\n");
         if (readIncomplete)
             sb.Append("  • a BSA failed to read this build, so an \"absent\" voice/.pex above may merely be unscanned — see housecarl_load_order_status.\n");
     }

--- a/src/housecarl-mcp/DialogueTools.cs
+++ b/src/housecarl-mcp/DialogueTools.cs
@@ -18,11 +18,13 @@ public static class DialogueTools
      Description(
          "Validate a dialogue topic's whole graph against the load order — what the game actually sees. Pass a " +
          "dialogue topic (DIAL) FormID to validate that one topic, or a quest (QUST) FormID to validate EVERY topic " +
-         "the quest owns. Checks the things houseCARL CAN verify at the data layer: the INFO previous-link (PNAM) " +
-         "chain is well-formed in response order, the topic is wired to a quest, the dialogue branch resolves, and " +
-         "(reusing the create-time teeth over every existing line) each voiced line has its .fuz on disk and each " +
-         "result script is bound + compiled. It LOUDLY declares what it cannot verify — the CTDA conditions that " +
-         "gate when a line fires (semantic, only the game evaluates them) and lip-sync/audio content — so 'checks " +
+         "the quest owns. Checks the things houseCARL CAN verify at the data layer: the topic is wired to a quest, " +
+         "the dialogue branch resolves, the INFO.LinkTo conversation chain (topic -> next topic) has no dangling " +
+         "targets, and no previous-link (PNAM) is dangling — an EMPTY PNAM is normal (vanilla selects among a " +
+         "topic's lines by their conditions, not a previous-link chain), so absence is never flagged; plus (reusing " +
+         "the create-time teeth over every existing line) each voiced line has its .fuz on disk and each result " +
+         "script is bound + compiled. It LOUDLY declares what it cannot verify — the CTDA conditions that gate WHEN " +
+         "a line fires (semantic, only the game evaluates them) and lip-sync/audio content — so 'checks " +
          "passed' never reads as 'this will play'. Resolves against the load-order WINNERS like every other read. " +
          "A FormID is 'XXXXXX:Plugin.esp'. Does NOT modify anything. To create dialogue lines use " +
          "housecarl_create_record; to inspect a single record use housecarl_read_record.")]
@@ -106,7 +108,7 @@ static class DialogueWire
 
         // --- graph issues (PNAM chain, quest + branch wiring) ---
         if (t.Issues.Count == 0)
-            sb.Append(pad).Append("  graph: OK — PNAM chain well-formed, quest + branch wiring resolve.\n");
+            sb.Append(pad).Append("  graph: OK — quest + branch wiring resolve, LinkTo targets resolve, no dangling PNAM.\n");
         else
         {
             sb.Append(pad).Append("  graph: ").Append(t.Issues.Count).Append(" issue(s):\n");

--- a/src/housecarl-mcp/DialogueTools.cs
+++ b/src/housecarl-mcp/DialogueTools.cs
@@ -1,0 +1,193 @@
+using System.ComponentModel;
+using System.Text;
+using ModelContextProtocol.Server;
+using Mutagen.Bethesda.Plugins;
+
+namespace HousecarlMcp;
+
+/// <summary>
+/// houseCARL dialogue tools (Layer B unit C2). The on-demand whole-topic dialogue-graph validator — the counterpart
+/// of the per-create voice (unit B) + result-script (unit C1) teeth, but run over EXISTING dialogue resolved against
+/// the load-order winners. Read-only: it inspects + reports, never mutates. The Skyrim-typed validation lives in
+/// <see cref="HousecarlCore.DialogueValidate"/>; this file is the wire surface + the render.
+/// </summary>
+[McpServerToolType]
+public static class DialogueTools
+{
+    [McpServerTool(Name = "housecarl_validate_dialogue", ReadOnly = true, Title = "Validate a dialogue topic or quest"),
+     Description(
+         "Validate a dialogue topic's whole graph against the load order — what the game actually sees. Pass a " +
+         "dialogue topic (DIAL) FormID to validate that one topic, or a quest (QUST) FormID to validate EVERY topic " +
+         "the quest owns. Checks the things houseCARL CAN verify at the data layer: the INFO previous-link (PNAM) " +
+         "chain is well-formed in response order, the topic is wired to a quest, the dialogue branch resolves, and " +
+         "(reusing the create-time teeth over every existing line) each voiced line has its .fuz on disk and each " +
+         "result script is bound + compiled. It LOUDLY declares what it cannot verify — the CTDA conditions that " +
+         "gate when a line fires (semantic, only the game evaluates them) and lip-sync/audio content — so 'checks " +
+         "passed' never reads as 'this will play'. Resolves against the load-order WINNERS like every other read. " +
+         "A FormID is 'XXXXXX:Plugin.esp'. Does NOT modify anything. To create dialogue lines use " +
+         "housecarl_create_record; to inspect a single record use housecarl_read_record.")]
+    public static string ValidateDialogue(
+        LoadOrderService svc,
+        [Description("The dialogue topic (DIAL) or quest (QUST) FormID as 'XXXXXX:Plugin.esp' — 6 hex digits, a colon, then the defining master's filename. A DIAL validates one topic; a QUST validates every topic that quest owns.")]
+            string formid,
+        [Description("Optional. Max characters before the report is cut with an explicit notice (never silent). 0 = the server default (~80k). Raise for a quest that owns many topics.")]
+            int max_chars = 0) => Guard.Tool("housecarl_validate_dialogue", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        FormKey fk;
+        try { fk = FormKey.Factory(formid.Trim()); }
+        catch (Exception ex) { return $"error: bad FormID '{formid}': {ex.Message}. Expected 'XXXXXX:Plugin.esp', e.g. '0F1AC1:Skyrim.esm'."; }
+
+        return DialogueWire.Render(svc.ValidateDialogue(fk), max_chars);
+    });
+}
+
+/// <summary>Renders a <see cref="HousecarlCore.DialogueValidationReport"/> as a compact, honest text report: a
+/// topic (or per-topic-of-a-quest) block with its graph issues, voice + result-script verdicts, and ALWAYS the
+/// standing-limits footer (grill-rev C2 — the un-checkable CTDA/lip-sync set, so a clean structural pass is never
+/// mistaken for "this will play"). Budget-bounded like the read tools (explicit cut at max_chars, never silent).</summary>
+static class DialogueWire
+{
+    public static string Render(DialogueValidationReport r, int maxChars)
+    {
+        int cap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+
+        // A check that didn't run to completion is NOT a clean pass (Q3) — say so, loudly, never an empty "ok".
+        if (r.CheckError is not null)
+            return $"validate_dialogue: could NOT complete the check for {r.Input} — {r.CheckError}. " +
+                   "Nothing here is a verified pass; the validation did not finish. Try again (the next call rebuilds the index); if it persists, inspect the topic in xEdit.";
+        if (r.Error is not null) return "error: " + r.Error;
+
+        var sb = new StringBuilder();
+        if (r.InputKind == "quest")
+        {
+            sb.Append("validate_dialogue: quest ").Append(Edid(r.InputEditorId)).Append(" (").Append(r.Input).Append(')')
+              .Append(" — ").Append(r.Topics.Count).Append(r.Topics.Count == 1 ? " topic owned" : " topics owned").Append('\n');
+            if (r.Topics.Count == 0)
+                sb.Append("  no dialogue topics in the active load order are owned by this quest — nothing to validate. " +
+                          "If you expected some, check those topics set DialogTopic.Quest to this quest and that their plugin is enabled.\n");
+        }
+
+        for (int i = 0; i < r.Topics.Count; i++)
+        {
+            if (sb.Length >= cap)
+            {
+                sb.Append("... [truncated: rendered ").Append(i).Append(" of ").Append(r.Topics.Count)
+                  .Append(" topics at max_chars=").Append(cap).Append("; raise max_chars to see the rest]\n");
+                break;
+            }
+            AppendTopic(sb, r.Topics[i], indent: r.InputKind == "quest", cap);
+        }
+
+        // The standing CTDA limit sums conditioned lines across ALL topics (a global honesty note), not just the ones
+        // that fit under the render cap.
+        AppendStandingLimits(sb, SumConditioned(r), r.ReadIncomplete);
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    static int SumConditioned(DialogueValidationReport r)
+    {
+        int n = 0;
+        foreach (var t in r.Topics) n += t.ConditionedInfoCount;
+        return n;
+    }
+
+    static void AppendTopic(StringBuilder sb, TopicValidation t, bool indent, int cap)
+    {
+        string pad = indent ? "  " : "";
+        sb.Append(pad).Append("topic ").Append(Edid(t.TopicEditorId)).Append(" (").Append(t.Topic).Append(')')
+          .Append(" — winner ").Append(t.WinnerPlugin).Append('\n');
+        sb.Append(pad).Append("  ").Append(t.InfoCount).Append(t.InfoCount == 1 ? " response line" : " response lines");
+        if (t.ConditionedInfoCount > 0) sb.Append("; ").Append(t.ConditionedInfoCount).Append(" carry conditions (CTDA)");
+        sb.Append('\n');
+        sb.Append(pad).Append("  category=").Append(t.Category).Append("  subtype=").Append(t.Subtype)
+          .Append("  subtype_marker=").Append(t.SubtypeName).Append('\n');
+
+        // --- graph issues (PNAM chain, quest + branch wiring) ---
+        if (t.Issues.Count == 0)
+            sb.Append(pad).Append("  graph: OK — PNAM chain well-formed, quest + branch wiring resolve.\n");
+        else
+        {
+            sb.Append(pad).Append("  graph: ").Append(t.Issues.Count).Append(" issue(s):\n");
+            foreach (var iss in t.Issues)
+            {
+                if (sb.Length >= cap) { sb.Append(pad).Append("    ... [truncated at max_chars]\n"); return; }
+                sb.Append(pad).Append("    ").Append(iss.Severity == DialogueIssueSeverity.Problem ? "[X] " : "[!] ")
+                  .Append(iss.Message).Append('\n');
+            }
+        }
+
+        AppendVoice(sb, t, pad, cap);
+        AppendScripts(sb, t, pad, cap);
+    }
+
+    /// <summary>Voice: a SILENT line is the actionable one (named with its .fuz path), present lines are summarised as
+    /// a count, and not-checkable lines (no Speaker / unresolvable voice type) are grouped by reason — the same Q3
+    /// honesty as the create-time report, but bounded for a whole topic. Skipped entirely when the topic has no voiced
+    /// content (a topic of pure link/branch nodes) — nothing to check, not a hidden pass.</summary>
+    static void AppendVoice(StringBuilder sb, TopicValidation t, string pad, int cap)
+    {
+        if (t.VoiceLines.Count == 0 && t.VoiceUndetermined.Count == 0) return;
+        var silent = t.VoiceLines.Where(l => !l.FuzPresent).ToList();
+        int present = t.VoiceLines.Count - silent.Count;
+        sb.Append(pad).Append("  voice: ").Append(present).Append(" present, ").Append(silent.Count).Append(" SILENT");
+        if (t.VoiceUndetermined.Count > 0) sb.Append(", ").Append(t.VoiceUndetermined.Count).Append(" not checkable");
+        sb.Append('\n');
+        foreach (var l in silent)
+        {
+            if (sb.Length >= cap) { sb.Append(pad).Append("    ... [truncated at max_chars]\n"); return; }
+            sb.Append(pad).Append("    [!] WILL BE SILENT  ").Append(l.Info).Append(" resp ").Append(l.ResponseNumber)
+              .Append(" — no .fuz at ").Append(l.FuzPath).Append("  (place the audio here)");
+            if (!l.LipPresent) sb.Append("; .lip also absent");
+            sb.Append('\n');
+        }
+        foreach (var grp in t.VoiceUndetermined.GroupBy(u => u.Reason))
+        {
+            if (sb.Length >= cap) { sb.Append(pad).Append("    ... [truncated at max_chars]\n"); return; }
+            int n = grp.Count();
+            sb.Append(pad).Append("    [?] ").Append(n).Append(n == 1 ? " line: " : " lines: ").Append(grp.Key).Append('\n');
+        }
+    }
+
+    /// <summary>Result scripts: a WILL NOT FIRE line is the actionable one (named, with any missing .pex), bound +
+    /// compiled lines are a count, and undetermined ones are listed. Skipped when no line carries a result script.</summary>
+    static void AppendScripts(StringBuilder sb, TopicValidation t, string pad, int cap)
+    {
+        if (t.ScriptFindings.Count == 0) return;
+        int ok = t.ScriptFindings.Count(f => f.Status == ScriptBindingStatus.BoundAndCompiled);
+        var bad = t.ScriptFindings.Where(f => f.Status is ScriptBindingStatus.ScriptNotCompiled or ScriptBindingStatus.BindingIncomplete).ToList();
+        var undet = t.ScriptFindings.Where(f => f.Status == ScriptBindingStatus.Undetermined).ToList();
+        sb.Append(pad).Append("  result scripts: ").Append(ok).Append(" bound + compiled, ").Append(bad.Count).Append(" WILL NOT FIRE");
+        if (undet.Count > 0) sb.Append(", ").Append(undet.Count).Append(" undetermined");
+        sb.Append('\n');
+        foreach (var f in bad)
+        {
+            if (sb.Length >= cap) { sb.Append(pad).Append("    ... [truncated at max_chars]\n"); return; }
+            sb.Append(pad).Append("    [!] WILL NOT FIRE  ").Append(f.Info).Append("  — ").Append(f.Detail);
+            if (f.MissingPex.Count > 0) sb.Append("  (missing: ").Append(string.Join(", ", f.MissingPex)).Append(')');
+            sb.Append('\n');
+        }
+        foreach (var f in undet)
+        {
+            if (sb.Length >= cap) { sb.Append(pad).Append("    ... [truncated at max_chars]\n"); return; }
+            sb.Append(pad).Append("    [?] ").Append(f.Info).Append("  — ").Append(f.Detail).Append('\n');
+        }
+    }
+
+    /// <summary>The ALWAYS-printed footer (grill-rev C2): the validator is the only non-advisory enforcement, so it
+    /// must enumerate what it could NOT verify — the CTDA gate (semantic, game-only) and lip-sync/audio — so a clean
+    /// structural pass is never mistaken for "this dialogue will play as intended". The BSA read-incomplete caveat
+    /// rides here too when an archive failed to read (an "absent" above may merely be unscanned, Q3).</summary>
+    static void AppendStandingLimits(StringBuilder sb, int conditioned, bool readIncomplete)
+    {
+        sb.Append("standing limits — what houseCARL could NOT verify (so a clean pass above does NOT mean the dialogue will play as intended):\n");
+        sb.Append("  • CTDA conditions gate WHEN each line fires; they are semantic and only the game evaluates them, so a wrong/missing condition silently stops a line from ever playing");
+        if (conditioned > 0) sb.Append(" — ").Append(conditioned).Append(" line(s) here carry conditions, unverified");
+        sb.Append(".\n");
+        sb.Append("  • voice presence is an on-disk file check only — lip-sync accuracy and the audio content itself are not verified (voice acting is out of scope).\n");
+        if (readIncomplete)
+            sb.Append("  • a BSA failed to read this build, so an \"absent\" voice/.pex above may merely be unscanned — see housecarl_load_order_status.\n");
+    }
+
+    static string Edid(string? e) => string.IsNullOrEmpty(e) ? "<none>" : e;
+}

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -762,6 +762,18 @@ public sealed class LoadOrderService : IDisposable
         return ResolveRead(resolver, resolver.Capture(), fk, plugin, fields, conflictTree, depth);
     }
 
+    /// <summary>Layer B unit C2 — the on-demand whole-topic dialogue-graph validator (housecarl_validate_dialogue):
+    /// resolve <paramref name="fk"/> to its load-order winner and, when it is a dialogue topic (DIAL) validate that
+    /// topic's whole graph, or when a quest (QUST) fan out to EVERY topic the quest owns — all against the resolved
+    /// load-order winners (what the game actually sees). The on-demand counterpart of the per-create voice (unit B)
+    /// + result-script (unit C1) teeth, auditing existing INFOs the create-time checks never re-touch. The whole
+    /// Skyrim-typed walk (winner resolution, the DIAL/QUST branch, the graph + per-INFO checks) lives in CORE
+    /// (<see cref="DialogueValidate"/>), so the service stays Mutagen.Skyrim-free exactly like the voice/script
+    /// enrichers — here it just hands core the live record resolver + the VFS asset resolver. NEVER throws over a
+    /// verify step: a mid-run resolve/asset failure rides <see cref="DialogueValidationReport.CheckError"/>, and a
+    /// not-in-order / not-a-DIAL-or-QUST input is a NAMED <see cref="DialogueValidationReport.Error"/> (Q3).</summary>
+    public DialogueValidationReport ValidateDialogue(FormKey fk) => DialogueValidate.Run(Resolver, Assets, fk);
+
     /// <summary>The read body, answered entirely off ONE captured view (HCBR-2026-06-11-02): excluded-check, winner,
     /// and touching-plugin list all describe the SAME build — a freshness rebuild landing mid-read can no longer make
     /// a record's reported winner disagree with its own TOUCHING LIST. (The body fetch reads the file on disk through

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -223,13 +223,14 @@ public static class WriteTools
             sb.Append("  ").Append(op.RecordType).Append(' ').Append(op.Target).Append("  ").Append(op.Label)
               .Append(op.After is not null ? "  -> " + op.After : "  -> applied").Append('\n');
         // Make the dialogue-coverage scope boundary VISIBLE, not silent (Q3): the .fuz/.lip presence check (unit B) AND
-        // the result-script binding check (unit C) both run on CREATE of dialogue lines, not on EDITS to existing ones.
+        // the result-script binding check (unit C1) both run on CREATE of dialogue lines, not on EDITS to existing ones.
         // An edit that adds a spoken response or a result script to an existing INFO produces the same silent-line /
-        // dead-script hazard with no note here, so flag it. (The on-demand whole-topic validator — Unit C2 — will audit
-        // existing INFOs too; this note repoints to it then.)
+        // dead-script hazard with no note here, so flag it — and point at the on-demand validator (Unit C2 shipped:
+        // housecarl_validate_dialogue), which audits voice + result-script coverage AND the topic graph over the
+        // edited line and every other line in the topic.
         if (o.Ops.Any(op => string.Equals(op.RecordType, VoiceCheck.InfoCatalogName, StringComparison.Ordinal)))
-            sb.Append("note: this edit touched a dialogue line (INFO). Voice (.fuz) and result-script coverage are checked on CREATE, not on edits yet — ")
-              .Append("if you added a spoken response or a result script, verify its voice file / compiled script on disk (housecarl_create_record reports the expected paths).\n");
+            sb.Append("note: this edit touched a dialogue line (INFO). Voice (.fuz) and result-script coverage are checked on CREATE, not on edits — ")
+              .Append("run housecarl_validate_dialogue on the topic (or its owning quest) to audit voice + result-script coverage and the topic graph over the edited line and every other line in the topic.\n");
         if (o.ReadBack is { } rb) AppendFullReadback(sb, rb, maxChars);
         sb.Append("to add more edits to THIS patch, pass into=\"").Append(file).Append("\".");
         return sb.ToString();


### PR DESCRIPTION
Adds the on-demand whole-topic dialogue-graph validator (Layer B unit C2; nested-dialogue plan §3.6). Tool surface 21 → 22. Read-only.

## What it does
`housecarl_validate_dialogue` resolves a DialogTopic (DIAL) or Quest (QUST) FormID against the load-order winners and reports:
- **Quest wiring** — set + resolves (unowned → warning)
- **Branch wiring** — if set, resolves to a real DLBR (unset is normal)
- **INFO.LinkTo chain** — the real topic→next-topic hand-off; a link to a missing topic is a broken chain
- **Dangling PNAM** — only when set-but-unresolvable; absence is never flagged
- **Voice + result-script** reused over every live INFO (closing unit B's deferred edit-path audit gap); deleted INFOs skipped
- Always declares the un-checkable CTDA/lip-sync set + the dropped-INFO conflict boundary (grill-rev C2)

## Two commits
1. **Build** (`391358d`) — core `DialogueValidate` (sibling of VoiceCheck/DialogueScriptCheck), the `ValidateDialogue` service method (stays Mutagen.Skyrim-free), `DialogueTools` (tool + render), the repointed edit-path note, and the `dialogue-validate-guard` probe.
2. **Review-fold** (`64abebf`) — an adversarial review + an empirical check against the live load order found the §3.6 "PNAM chain in response order" model was wrong: vanilla topics leave PNAM empty and select intra-topic by Conditions (2,757/2,757 Skyrim.esm topics would false-flag). Dropped the PNAM-order check; added LinkTo-resolves + dangling-PNAM-only; skip deleted INFOs; relabel "response lines"→"INFO records"; boundary note. Maintainer-confirmed the revision + the DIAL-wins-wholesale resolution model.

## Verification
- Release build clean (the 14 warnings are pre-existing in PapyrusDecompiler/WritePatchBuilder, also on main).
- `dialogue-validate-guard`: 12 RED-proven arms (CLEAN proves empty PNAM isn't flagged; LinkTo-dangle / PNAM-dangle / deleted-skip / fan-out / named rejects).
- `nested-create-guard` unaffected (111 arms green) — the reused voice/script per-INFO checks are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)