### PR TITLE
seq: Layer B unit D — housecarl_write_seq (start-game-enabled-quest .seq writer)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,14 @@ jobs:
       - name: Probe — dialogue-graph validator (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- dialogue-validate-guard
 
+      # Self-contained (synthesizes masters + a patch with own/override/non-SGE/deleted quests + a real MO2 instance), runs
+      # fully here: a regression guard for the SEQ writer (nested-dialogue plan Layer B unit D — housecarl_write_seq). Pins
+      # the master-INDEX on-disk FormID encoding against the plugin's ACTUAL record bytes (own=master count, override=master
+      # index, NEVER 0xFE — load-order-independent, no runtime-FormID bridge), SGE-only + deleted-skip inclusion, the
+      # little-endian serialization, and the REAL LoadOrderService.WriteSeq wire (same-folder default, empty no-op, refusal).
+      - name: Probe — SEQ writer (self-contained regression guard)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- seq-write-guard
+
       # Self-contained (synthesizes a real MO2 instance + a master with a dialogue topic) and drives the REAL
       # LoadOrderService.CreateRecords / CreateRecordsBatch: locks in the create-tool WIRE (nested/dialogue plan,
       # Layer A) — create_record's parent/collection passthrough, the new bulk_create batch tool (the same-call

--- a/src/housecarl-core/SeqFile.cs
+++ b/src/housecarl-core/SeqFile.cs
@@ -1,0 +1,79 @@
+using System.Buffers.Binary;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+
+namespace HousecarlCore;
+
+/// <summary>
+/// SEQ-file builder — the start-game-enabled-quest "sequence" file (<c>Data\SEQ\&lt;plugin&gt;.seq</c>) the engine reads to
+/// actually START a plugin's Start-Game-Enabled quests. Ticking the SGE flag alone does NOTHING: without the .seq the quest
+/// — and any dialogue or world change gated on it — silently never runs (the exact silent-failure class houseCARL refuses,
+/// Q3). The CK writes this file on save; xEdit's "Create SEQ file" does the same; this is houseCARL's data-layer equivalent.
+///
+/// Format (empirically pinned against 145 real .seq files in a live load order): a FLAT array of 4-byte LITTLE-ENDIAN
+/// FormIDs, no header or footer, one per SGE quest. Each FormID is the plugin-LOCAL, master-relative ON-DISK form: high
+/// byte = the quest's slot in the plugin's master list (a plugin's OWN/new records sit at the slot AFTER its last master,
+/// i.e. high byte = master count), low 3 bytes = the object id. That is the SAME master-INDEX encoding Mutagen writes into
+/// the record header on disk — NEVER the runtime 0xFE light-space / load-order address (the ESL ground-truth work pinned
+/// "master-index on disk, never 0xFE" over 1.55M real records). So the file is LOAD-ORDER-INDEPENDENT: computable wholly at
+/// author time with no runtime-FormID bridge, and it ships with the mod. houseCARL writes the plugin and its .seq together,
+/// so the encoding is never stale — the one way real .seq files DO go wrong (a master added/removed, or an ESL compaction/
+/// merge, after the .seq was generated, which shifts the slot) cannot happen when both are emitted in the same act.
+/// </summary>
+public static class SeqFile
+{
+    /// <summary>The plugin-local, master-relative ON-DISK FormID for <paramref name="fk"/> given the defining plugin's
+    /// ORDERED master list (the order they appear in the file header). The high byte is the master's index in that list,
+    /// or the master COUNT when the FormKey belongs to the plugin ITSELF (an own/new record — the plugin's own ModKey is
+    /// never among its own masters, so it sits at the slot after the last master). This is exactly the value Mutagen
+    /// writes into the record header on disk; it is NOT the runtime 0xFE light-space / load-order address (those are
+    /// computed by the engine at load time from each master's header flag + position and are never stored on disk).</summary>
+    public static uint OnDiskFormId(FormKey fk, IReadOnlyList<ModKey> masters)
+    {
+        int slot = -1;
+        for (int i = 0; i < masters.Count; i++)
+            if (masters[i] == fk.ModKey) { slot = i; break; }
+        if (slot < 0) slot = masters.Count;                 // own/new record: its ModKey is the plugin's, never in its masters
+        return ((uint)slot << 24) | (fk.ID & 0x00FFFFFFu);
+    }
+
+    /// <summary>Serialize SEQ FormIDs to the on-disk byte layout: each as a 4-byte LITTLE-ENDIAN uint, concatenated, with
+    /// NO header or footer. An empty sequence yields zero bytes (the caller decides whether an empty .seq is worth
+    /// writing — for SEQ the answer is no: a plugin with no SGE quests needs no .seq at all).</summary>
+    public static byte[] Serialize(IReadOnlyList<uint> formIds)
+    {
+        var bytes = new byte[formIds.Count * 4];
+        for (int i = 0; i < formIds.Count; i++)
+            BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(i * 4), formIds[i]);
+        return bytes;
+    }
+
+    /// <summary>One Start-Game-Enabled quest destined for the .seq: its identity (<paramref name="FormKey"/>), its EditorID
+    /// for the human-readable report, and the <paramref name="OnDiskFormId"/> actually written into the file.</summary>
+    public readonly record struct SeqQuest(FormKey FormKey, string? EditorId, uint OnDiskFormId);
+
+    /// <summary>The built .seq: the bytes to write, the SGE quests it covers (for the report), and the defining plugin's
+    /// filename (e.g. <c>MyMod.esp</c>) — the .seq is named after it (<c>MyMod.seq</c>).</summary>
+    public readonly record struct SeqBuild(byte[] Bytes, IReadOnlyList<SeqQuest> Quests, string PluginFileName);
+
+    /// <summary>Open <paramref name="pluginPath"/> as a binary overlay, find every Start-Game-Enabled quest it contains
+    /// (DELETED quests excluded — a removed record never starts, the same skip the dialogue validator applies to deleted
+    /// lines), and build the .seq bytes from their on-disk FormIDs in the plugin's own record order. Read-only; holds NO
+    /// handle past the <c>using</c> (the at-rest discipline every houseCARL overlay open follows). THROWS on an unreadable
+    /// plugin — the caller surfaces it (Q3); never a silent empty .seq for a plugin that didn't open.</summary>
+    public static SeqBuild Build(string pluginPath)
+    {
+        using var mod = SkyrimMod.CreateFromBinaryOverlay(pluginPath, SkyrimRelease.SkyrimSE);
+        var masters = mod.ModHeader.MasterReferences.Select(m => m.Master).ToList();
+        var quests = new List<SeqQuest>();
+        foreach (var q in mod.Quests)
+        {
+            if (q.IsDeleted) continue;                                       // a deleted quest never starts → never in the .seq
+            if (!q.Flags.HasFlag(Quest.Flag.StartGameEnabled)) continue;    // SGE flag is the sole inclusion test (CK/xEdit rule)
+            quests.Add(new SeqQuest(q.FormKey, q.EditorID, OnDiskFormId(q.FormKey, masters)));
+        }
+        var bytes = Serialize(quests.Select(x => x.OnDiskFormId).ToList());
+        return new SeqBuild(bytes, quests, mod.ModKey.FileName);
+    }
+}

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -357,6 +357,12 @@ if (args.Length > 0 && args[0] == "nested-create-guard") return NestedCreateGuar
 // teeth over EXISTING lines, the quest fan-out, and the named not-found / wrong-type rejects (NO Skyrim.esm).
 if (args.Length > 0 && args[0] == "dialogue-validate-guard") return DialogueValidateGuardProbe.RunGuard(args[1..]);
 
+// SEQ writer (nested-dialogue plan Layer B unit D — housecarl_write_seq): SELF-CONTAINED CI regression guard — synthesizes
+// masters + a patch (own/override/non-SGE/deleted quests), drives core SeqFile.Build + the REAL LoadOrderService.WriteSeq
+// over a synthetic MO2 instance, and verifies the master-index on-disk FormID encoding against the plugin's ACTUAL record
+// bytes (own=master count, override=master index, never 0xFE) — load-order-independent, no runtime-FormID bridge.
+if (args.Length > 0 && args[0] == "seq-write-guard") return SeqWriteGuardProbe.RunGuard(args[1..]);
+
 // create-tool WIRE (nested/dialogue plan, Layer A): SELF-CONTAINED CI regression guard — drives the REAL
 // LoadOrderService.CreateRecords (single, parent/collection) + CreateRecordsBatch (the bulk_create array) over a
 // synthetic MO2 instance: flat-still-works, parent passthrough, the same-call one-shot, batch all-or-nothing, the

--- a/src/housecarl-generator/SeqWriteGuardProbe.cs
+++ b/src/housecarl-generator/SeqWriteGuardProbe.cs
@@ -26,9 +26,11 @@ namespace HousecarlGenerator;
 ///   ENCODE-OWN     — OnDiskFormId(own FormKey, [m]) == (1&lt;&lt;24)|id (own record sits at master COUNT, not a constant 0).
 ///   ENCODE-OVERRIDE— OnDiskFormId(master FormKey, [m]) == (0&lt;&lt;24)|id (an override carries the overridden master's index).
 ///   SGE-ONLY       — Build lists exactly the non-deleted Start-Game-Enabled quests (a RunOnce-only quest is EXCLUDED).
+///   OVERRIDE-SGE   — an override that NEWLY flags SGE is included, at the overridden master's index (high byte != 0xFE).
 ///   DELETED-SKIP   — a deleted SGE quest is NOT in the .seq (the same skip the dialogue validator applies to deleted lines).
 ///   HIGH-BYTE-COUNT— the own SGE quest's high byte == the plugin's master count (1 here, 2 in the 2-master setup — tracks
 ///                    the count, never a fixed value or a global load-order index).
+///   ESL-NEVER-FE   — an ESL (light) patch's own SGE quest ALSO encodes master-index (high byte == master count, never 0xFE).
 ///   ON-DISK-MATCH  — every built FormID is present among the QUST records' ACTUAL on-disk FormIDs (raw byte parse) — the
 ///                    computed master-index encoding == what Mutagen wrote; RED to an FE-space / wrong-index regression.
 ///   SERVICE-WRITE  — LoadOrderService.WriteSeq lands &lt;ModFolder&gt;\SEQ\&lt;plugin&gt;.seq with the expected bytes.
@@ -103,8 +105,8 @@ internal static class SeqWriteGuardProbe
             Check(!aFks.Contains(plainFk), $"SGE-ONLY RunOnce-only quest EXCLUDED — {plainFk} absent");
             Check(!aFks.Contains(delFk), $"DELETED-SKIP deleted SGE quest EXCLUDED — {delFk} absent");
 
-            var ownSeq = builtA.Quests.FirstOrDefault(q => q.FormKey == ownFk);
-            var ovSeq = builtA.Quests.FirstOrDefault(q => q.FormKey == mQuestFk);
+            var ownSeq = builtA.Quests.Single(q => q.FormKey == ownFk);    // present (asserted above) — Single fails loud if a reorder ever breaks that
+            var ovSeq = builtA.Quests.Single(q => q.FormKey == mQuestFk);
             byte ownHi = (byte)((ownSeq.OnDiskFormId >> 24) & 0xFF);
             byte ovHi = (byte)((ovSeq.OnDiskFormId >> 24) & 0xFF);
             Check(ownHi == aMasters.Count, $"HIGH-BYTE-COUNT own quest high byte == master count — 0x{ownHi:X2} (masters={aMasters.Count})");
@@ -138,13 +140,41 @@ internal static class SeqWriteGuardProbe
                 p.BeginWrite.ToPath(bPatch).WithLoadOrder(new[] { (ISkyrimModGetter)m1, (ISkyrimModGetter)m2 }).NoNextFormIDProcessing().Write();
             }
             var builtB = SeqFile.Build(bPatch);
-            var bOwn = builtB.Quests.FirstOrDefault(q => q.FormKey == bOwnFk);
+            var bOwn = builtB.Quests.Single(q => q.FormKey == bOwnFk);
             byte bOwnHi = (byte)((bOwn.OnDiskFormId >> 24) & 0xFF);
             List<ModKey> bMasters;
             using (var pOv = SkyrimMod.CreateFromBinaryOverlay(bPatch, SkyrimRelease.SkyrimSE))
                 bMasters = pOv.ModHeader.MasterReferences.Select(mr => mr.Master).ToList();
             Check(bMasters.Count == 2 && bOwnHi == 2,
                 $"HIGH-BYTE-COUNT(2 masters) own high byte == 2 — 0x{bOwnHi:X2} (masters={bMasters.Count}) — proves it tracks the count");
+
+            // ====================== CORE BUILD: SETUP E (ESL / light patch) — the most-doubted "never 0xFE" case ======================
+            // An ESL-flagged plugin's OWN records STILL use master-INDEX encoding on disk (high byte = master count), NOT the
+            // runtime 0xFE light-space (that's computed at load time). master M (a quest); a LIGHT patch overrides it (forces M)
+            // + an own SGE quest at 0x800 (legal ESL object-id) → own high byte == 1, never 0xFE.
+            string eMaster = Path.Combine(root, "E", "HcSeqEMaster.esm");
+            string ePatch = Path.Combine(root, "E", "HcSeqEPatch.esp");
+            Directory.CreateDirectory(Path.GetDirectoryName(eMaster)!);
+            FormKey emQuestFk;
+            { var m = new SkyrimMod(new ModKey("HcSeqEMaster", ModType.Master), SkyrimRelease.SkyrimSE); var q = m.Quests.AddNew(); q.EditorID = "EMQ"; q.Flags = Quest.Flag.RunOnce; emQuestFk = q.FormKey; m.BeginWrite.ToPath(eMaster).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).NoNextFormIDProcessing().Write(); }
+            FormKey eOwnFk;
+            {
+                using var mOv = SkyrimMod.CreateFromBinaryOverlay(eMaster, SkyrimRelease.SkyrimSE);
+                var p = new SkyrimMod(new ModKey("HcSeqEPatch", ModType.Plugin), SkyrimRelease.SkyrimSE) { IsSmallMaster = true }; // ESL-flagged patch
+                if (p.ModHeader.Stats.NextFormID < 0x800) p.ModHeader.Stats.NextFormID = 0x800;
+                p.Quests.GetOrAddAsOverride(mOv.Quests.First(x => x.FormKey == emQuestFk));   // forces M as a master
+                var own = p.Quests.AddNew(); own.EditorID = "EOwn"; own.Flags = Quest.Flag.StartGameEnabled; eOwnFk = own.FormKey;
+                p.BeginWrite.ToPath(ePatch).WithLoadOrder(new[] { (ISkyrimModGetter)mOv }).NoNextFormIDProcessing().Write();
+            }
+            var builtE = SeqFile.Build(ePatch);
+            var eOwn = builtE.Quests.Single(q => q.FormKey == eOwnFk);
+            byte eOwnHi = (byte)((eOwn.OnDiskFormId >> 24) & 0xFF);
+            var eRaw = AllRecordFormIds(ePatch, "QUST").ToHashSet();
+            bool eslOk = eOwnHi == 1
+                         && builtE.Quests.All(q => ((q.OnDiskFormId >> 24) & 0xFF) != 0xFE)
+                         && builtE.Quests.All(q => eRaw.Contains(q.OnDiskFormId));
+            Check(eslOk,
+                $"ESL-NEVER-FE light patch's SGE quest encodes master-index (own high 0x{eOwnHi:X2}==1, never 0xFE), ON-DISK-MATCH holds — built [{string.Join(",", builtE.Quests.Select(q => $"0x{q.OnDiskFormId:X8}"))}]");
 
             // ====================== SERVICE WIRE over a synthetic MO2 instance ======================
             string instance = Path.Combine(root, "instance");

--- a/src/housecarl-generator/SeqWriteGuardProbe.cs
+++ b/src/housecarl-generator/SeqWriteGuardProbe.cs
@@ -1,0 +1,252 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SELF-CONTAINED CI REGRESSION GUARD for the SEQ writer (nested/dialogue plan Layer B unit D — housecarl_write_seq).
+/// Pins the start-game-enabled-quest .seq contract end-to-end: the CORE encoding (<see cref="SeqFile"/>) AND the SERVICE
+/// wire (<see cref="LoadOrderService.WriteSeq"/>) over a synthetic MO2 instance. No Skyrim.esm — synthesizes its own
+/// masters + patch.
+///
+/// The load-bearing claim it defends: a .seq lists each SGE quest as its plugin-LOCAL, master-INDEX on-disk FormID
+/// (own/new records at the slot AFTER the last master, i.e. high byte = master count; an override at the overridden
+/// master's index), little-endian, NEVER the runtime 0xFE / load-order address — so the file is load-order-independent
+/// and needs no runtime-FormID bridge. The ON-DISK-MATCH arm proves the computed FormIDs equal what Mutagen ACTUALLY
+/// wrote into the plugin's record headers (a raw byte parse), so a future write-path/Mutagen change that shifted the
+/// encoding to FE-space or a different index would turn this RED.
+///
+/// Run: dotnet run --project src/housecarl-generator -- seq-write-guard
+///
+/// Arms (ALL required):
+///   SERIALIZE-LE   — Serialize([0x0500AA02]) == bytes 02 AA 00 05 (4-byte little-endian, no header).
+///   ENCODE-OWN     — OnDiskFormId(own FormKey, [m]) == (1&lt;&lt;24)|id (own record sits at master COUNT, not a constant 0).
+///   ENCODE-OVERRIDE— OnDiskFormId(master FormKey, [m]) == (0&lt;&lt;24)|id (an override carries the overridden master's index).
+///   SGE-ONLY       — Build lists exactly the non-deleted Start-Game-Enabled quests (a RunOnce-only quest is EXCLUDED).
+///   DELETED-SKIP   — a deleted SGE quest is NOT in the .seq (the same skip the dialogue validator applies to deleted lines).
+///   HIGH-BYTE-COUNT— the own SGE quest's high byte == the plugin's master count (1 here, 2 in the 2-master setup — tracks
+///                    the count, never a fixed value or a global load-order index).
+///   ON-DISK-MATCH  — every built FormID is present among the QUST records' ACTUAL on-disk FormIDs (raw byte parse) — the
+///                    computed master-index encoding == what Mutagen wrote; RED to an FE-space / wrong-index regression.
+///   SERVICE-WRITE  — LoadOrderService.WriteSeq lands &lt;ModFolder&gt;\SEQ\&lt;plugin&gt;.seq with the expected bytes.
+///   SAME-FOLDER    — a plugin inside a houseCARL-owned folder defaults the .seq INTO that folder (WroteIntoPluginFolder).
+///   EMPTY-NOOP     — a plugin with NO SGE quests writes nothing, cuts no folder (no orphan), reports the clean no-op.
+///   REFUSE-NOFILE  — WriteSeq on a missing plugin path refuses, named (Q3).
+/// </summary>
+internal static class SeqWriteGuardProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  REGRESSION GUARD — SEQ writer (housecarl_write_seq, Layer B unit D)  ################");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        var root = Path.Combine(Path.GetTempPath(), "hc-seq-write-guard-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(root);
+
+            // ====================== PURE CORE: serialize + encode ======================
+            {
+                var bytes = SeqFile.Serialize(new uint[] { 0x0500AA02u });
+                Check(bytes.Length == 4 && bytes[0] == 0x02 && bytes[1] == 0xAA && bytes[2] == 0x00 && bytes[3] == 0x05,
+                    $"SERIALIZE-LE 0x0500AA02 → 02 AA 00 05 — got {BitConverter.ToString(bytes)}");
+
+                var pKey = new ModKey("HcSeqEnc", ModType.Plugin);
+                var mKey = new ModKey("HcSeqEncMaster", ModType.Master);
+                var masters = new List<ModKey> { mKey };
+                uint ownEnc = SeqFile.OnDiskFormId(new FormKey(pKey, 0x000800), masters);    // own: ModKey not in masters → slot = count(1)
+                uint ovEnc = SeqFile.OnDiskFormId(new FormKey(mKey, 0x00AA02), masters);     // override of a master → slot = its index(0)
+                Check(ownEnc == 0x01000800u, $"ENCODE-OWN own record at master COUNT — got 0x{ownEnc:X8} (expect 0x01000800)");
+                Check(ovEnc == 0x0000AA02u, $"ENCODE-OVERRIDE override at master index — got 0x{ovEnc:X8} (expect 0x0000AA02)");
+            }
+
+            // ====================== CORE BUILD: SETUP A (1 master) ======================
+            // master M with a (non-SGE) quest; patch P overrides it (→ SGE, forces M as a master) + own SGE + own RunOnce +
+            // own deleted-SGE. Expect the .seq = { own-SGE @ high 0x01, override @ high 0x00 }.
+            string aMaster = Path.Combine(root, "A", "HcSeqAMaster.esm");
+            string aPatch = Path.Combine(root, "A", "HcSeqAPatch.esp");
+            Directory.CreateDirectory(Path.GetDirectoryName(aMaster)!);
+            FormKey mQuestFk;
+            {
+                var m = new SkyrimMod(new ModKey("HcSeqAMaster", ModType.Master), SkyrimRelease.SkyrimSE);
+                var qm = m.Quests.AddNew(); qm.EditorID = "HcSeqAMasterQuest"; qm.Flags = Quest.Flag.RunOnce; // master copy: NOT SGE
+                mQuestFk = qm.FormKey;
+                m.BeginWrite.ToPath(aMaster).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).NoNextFormIDProcessing().Write();
+            }
+            FormKey ownFk, plainFk, delFk;
+            {
+                using var mOv = SkyrimMod.CreateFromBinaryOverlay(aMaster, SkyrimRelease.SkyrimSE);
+                var p = new SkyrimMod(new ModKey("HcSeqAPatch", ModType.Plugin), SkyrimRelease.SkyrimSE);
+                if (p.ModHeader.Stats.NextFormID < 0x800) p.ModHeader.Stats.NextFormID = 0x800;
+                var ov = p.Quests.GetOrAddAsOverride(mOv.Quests.First(x => x.FormKey == mQuestFk));
+                ov.Flags = Quest.Flag.StartGameEnabled;                                   // override NEWLY flags it SGE
+                var own = p.Quests.AddNew(); own.EditorID = "HcSeqAOwn"; own.Flags = Quest.Flag.StartGameEnabled; ownFk = own.FormKey;
+                var plain = p.Quests.AddNew(); plain.EditorID = "HcSeqAPlain"; plain.Flags = Quest.Flag.RunOnce; plainFk = plain.FormKey;
+                var del = p.Quests.AddNew(); del.EditorID = "HcSeqADel"; del.Flags = Quest.Flag.StartGameEnabled; del.IsDeleted = true; delFk = del.FormKey;
+                p.BeginWrite.ToPath(aPatch).WithLoadOrder(new[] { (ISkyrimModGetter)mOv }).NoNextFormIDProcessing().Write();
+            }
+
+            var builtA = SeqFile.Build(aPatch);
+            var aFks = builtA.Quests.Select(q => q.FormKey).ToHashSet();
+            // master list of the written patch (for the high-byte assertions)
+            List<ModKey> aMasters;
+            using (var pOv = SkyrimMod.CreateFromBinaryOverlay(aPatch, SkyrimRelease.SkyrimSE))
+                aMasters = pOv.ModHeader.MasterReferences.Select(mr => mr.Master).ToList();
+
+            Check(aFks.Contains(ownFk), $"SGE-ONLY own SGE quest included — {ownFk} ∈ {{{string.Join(",", aFks)}}}");
+            Check(aFks.Contains(mQuestFk), $"OVERRIDE-SGE override that newly flags SGE included — {mQuestFk} present");
+            Check(!aFks.Contains(plainFk), $"SGE-ONLY RunOnce-only quest EXCLUDED — {plainFk} absent");
+            Check(!aFks.Contains(delFk), $"DELETED-SKIP deleted SGE quest EXCLUDED — {delFk} absent");
+
+            var ownSeq = builtA.Quests.FirstOrDefault(q => q.FormKey == ownFk);
+            var ovSeq = builtA.Quests.FirstOrDefault(q => q.FormKey == mQuestFk);
+            byte ownHi = (byte)((ownSeq.OnDiskFormId >> 24) & 0xFF);
+            byte ovHi = (byte)((ovSeq.OnDiskFormId >> 24) & 0xFF);
+            Check(ownHi == aMasters.Count, $"HIGH-BYTE-COUNT own quest high byte == master count — 0x{ownHi:X2} (masters={aMasters.Count})");
+            Check(ovHi == aMasters.IndexOf(mQuestFk.ModKey) && ovHi != 0xFE,
+                $"OVERRIDE high byte == overridden master index (never 0xFE) — 0x{ovHi:X2} (index={aMasters.IndexOf(mQuestFk.ModKey)})");
+
+            // ON-DISK-MATCH: every built FormID must appear among the patch's ACTUAL on-disk QUST record FormIDs.
+            var rawOnDisk = AllRecordFormIds(aPatch, "QUST").ToHashSet();
+            bool onDiskMatch = builtA.Quests.All(q => rawOnDisk.Contains(q.OnDiskFormId))
+                               && builtA.Quests.All(q => ((q.OnDiskFormId >> 24) & 0xFF) != 0xFE);
+            Check(onDiskMatch,
+                $"ON-DISK-MATCH built FormIDs == actual on-disk record FormIDs (master-index, never FE) — built [{string.Join(",", builtA.Quests.Select(q => $"0x{q.OnDiskFormId:X8}"))}] raw [{string.Join(",", rawOnDisk.Select(x => $"0x{x:X8}"))}]");
+
+            // ====================== CORE BUILD: SETUP B (2 masters) — high byte tracks COUNT ======================
+            string bM1 = Path.Combine(root, "B", "HcSeqBM1.esm");
+            string bM2 = Path.Combine(root, "B", "HcSeqBM2.esm");
+            string bPatch = Path.Combine(root, "B", "HcSeqBPatch.esp");
+            Directory.CreateDirectory(Path.GetDirectoryName(bM1)!);
+            FormKey b1Fk, b2Fk;
+            { var m = new SkyrimMod(new ModKey("HcSeqBM1", ModType.Master), SkyrimRelease.SkyrimSE); var q = m.Quests.AddNew(); q.EditorID = "B1Q"; q.Flags = Quest.Flag.RunOnce; b1Fk = q.FormKey; m.BeginWrite.ToPath(bM1).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).NoNextFormIDProcessing().Write(); }
+            { var m = new SkyrimMod(new ModKey("HcSeqBM2", ModType.Master), SkyrimRelease.SkyrimSE); var q = m.Quests.AddNew(); q.EditorID = "B2Q"; q.Flags = Quest.Flag.RunOnce; b2Fk = q.FormKey; m.BeginWrite.ToPath(bM2).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).NoNextFormIDProcessing().Write(); }
+            FormKey bOwnFk;
+            {
+                using var m1 = SkyrimMod.CreateFromBinaryOverlay(bM1, SkyrimRelease.SkyrimSE);
+                using var m2 = SkyrimMod.CreateFromBinaryOverlay(bM2, SkyrimRelease.SkyrimSE);
+                var p = new SkyrimMod(new ModKey("HcSeqBPatch", ModType.Plugin), SkyrimRelease.SkyrimSE);
+                if (p.ModHeader.Stats.NextFormID < 0x800) p.ModHeader.Stats.NextFormID = 0x800;
+                p.Quests.GetOrAddAsOverride(m1.Quests.First(x => x.FormKey == b1Fk));      // force M1 as a master
+                p.Quests.GetOrAddAsOverride(m2.Quests.First(x => x.FormKey == b2Fk));      // force M2 as a master
+                var own = p.Quests.AddNew(); own.EditorID = "BOwn"; own.Flags = Quest.Flag.StartGameEnabled; bOwnFk = own.FormKey;
+                p.BeginWrite.ToPath(bPatch).WithLoadOrder(new[] { (ISkyrimModGetter)m1, (ISkyrimModGetter)m2 }).NoNextFormIDProcessing().Write();
+            }
+            var builtB = SeqFile.Build(bPatch);
+            var bOwn = builtB.Quests.FirstOrDefault(q => q.FormKey == bOwnFk);
+            byte bOwnHi = (byte)((bOwn.OnDiskFormId >> 24) & 0xFF);
+            List<ModKey> bMasters;
+            using (var pOv = SkyrimMod.CreateFromBinaryOverlay(bPatch, SkyrimRelease.SkyrimSE))
+                bMasters = pOv.ModHeader.MasterReferences.Select(mr => mr.Master).ToList();
+            Check(bMasters.Count == 2 && bOwnHi == 2,
+                $"HIGH-BYTE-COUNT(2 masters) own high byte == 2 — 0x{bOwnHi:X2} (masters={bMasters.Count}) — proves it tracks the count");
+
+            // ====================== SERVICE WIRE over a synthetic MO2 instance ======================
+            string instance = Path.Combine(root, "instance");
+            string profiles = Path.Combine(instance, "profiles", "Default");
+            string mods = Path.Combine(instance, "mods");
+            Directory.CreateDirectory(profiles); Directory.CreateDirectory(mods);
+            Directory.CreateDirectory(Path.Combine(root, "game", "Data"));   // Mo2Instance.Resolve requires <gamePath>\Data
+            File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+                "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+                + Path.Combine(root, "game").Replace(@"\", @"\\") + ")\r\n");
+            File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n");
+            File.WriteAllText(Path.Combine(profiles, "plugins.txt"), "");
+            File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n");
+
+            var store = new UserConfigStore(Path.Combine(root, "houseCARL.user.json"));
+            using var svc = LoadOrderService.WithInstance(instance, 0, store);
+
+            // SERVICE-WRITE + SAME-FOLDER: a houseCARL-OWNED patch folder under mods, holding an SGE-quest plugin.
+            string ownedFolder = Path.Combine(mods, "houseCARL - HcSeqSvc");
+            Directory.CreateDirectory(ownedFolder);
+            File.WriteAllText(Path.Combine(ownedFolder, "meta.ini"), "[General]\r\ngameName=skyrimse\r\n\r\n[houseCARL]\r\ngenerated=true\r\n");
+            string svcPlugin = Path.Combine(ownedFolder, "HcSeqSvc.esp");
+            {
+                var p = new SkyrimMod(new ModKey("HcSeqSvc", ModType.Plugin), SkyrimRelease.SkyrimSE);
+                if (p.ModHeader.Stats.NextFormID < 0x800) p.ModHeader.Stats.NextFormID = 0x800;
+                var q = p.Quests.AddNew(); q.EditorID = "SvcOwn"; q.Flags = Quest.Flag.StartGameEnabled;
+                p.BeginWrite.ToPath(svcPlugin).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).NoNextFormIDProcessing().Write();
+            }
+            var oSvc = svc.WriteSeq(svcPlugin, null, null);
+            string expectedSeq = Path.Combine(ownedFolder, "SEQ", "HcSeqSvc.seq");
+            bool svcOk = oSvc.Success && oSvc.SeqPath is not null
+                         && File.Exists(expectedSeq)
+                         && new FileInfo(expectedSeq).Length == 4
+                         && oSvc.Quests.Count == 1;
+            Check(svcOk, $"SERVICE-WRITE WriteSeq lands SEQ\\<plugin>.seq with the SGE quest — success={oSvc.Success} path=[{oSvc.SeqPath}] err=[{oSvc.Error}]");
+            Check(oSvc.WroteIntoPluginFolder && PathUnder(oSvc.SeqPath, ownedFolder),
+                $"SAME-FOLDER .seq defaults into the plugin's OWN houseCARL folder — intoPlugin={oSvc.WroteIntoPluginFolder} path=[{oSvc.SeqPath}]");
+
+            // EMPTY-NOOP: a plugin with NO SGE quests writes nothing + cuts no folder.
+            string emptyPlugin = Path.Combine(root, "empty", "HcSeqEmpty.esp");
+            Directory.CreateDirectory(Path.GetDirectoryName(emptyPlugin)!);
+            {
+                var p = new SkyrimMod(new ModKey("HcSeqEmpty", ModType.Plugin), SkyrimRelease.SkyrimSE);
+                if (p.ModHeader.Stats.NextFormID < 0x800) p.ModHeader.Stats.NextFormID = 0x800;
+                var q = p.Quests.AddNew(); q.EditorID = "EmptyPlain"; q.Flags = Quest.Flag.RunOnce; // NOT SGE
+                p.BeginWrite.ToPath(emptyPlugin).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).NoNextFormIDProcessing().Write();
+            }
+            int foldersBefore = Directory.GetDirectories(mods).Length;
+            var oEmpty = svc.WriteSeq(emptyPlugin, null, null);
+            int foldersAfter = Directory.GetDirectories(mods).Length;
+            Check(oEmpty.Success && oEmpty.SeqPath is null && oEmpty.Quests.Count == 0 && foldersAfter == foldersBefore,
+                $"EMPTY-NOOP no SGE quests → nothing written, no folder cut — success={oEmpty.Success} path=[{oEmpty.SeqPath}] folders {foldersBefore}->{foldersAfter}");
+
+            // REFUSE-NOFILE: a missing plugin path is refused, named.
+            var oMiss = svc.WriteSeq(Path.Combine(root, "does-not-exist.esp"), null, null);
+            Check(!oMiss.Success && oMiss.Error is not null && oMiss.Error.Contains("no such plugin", StringComparison.OrdinalIgnoreCase),
+                $"REFUSE-NOFILE missing plugin path refused + named — err=[{oMiss.Error}]");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("  FAIL  guard threw: " + ex);
+            fail++;
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { /* best-effort temp cleanup */ }
+        }
+
+        Console.WriteLine();
+        Console.WriteLine(fail == 0 ? "ALL SEQ-WRITE GUARD ARMS PASSED" : $"SEQ-WRITE GUARD: {fail} ARM(S) FAILED");
+        return fail == 0 ? 0 : 1;
+    }
+
+    static bool PathUnder(string? path, string folder)
+        => path is not null && Path.GetFullPath(path).StartsWith(Path.GetFullPath(folder), StringComparison.OrdinalIgnoreCase);
+
+    // ---- raw on-disk FormID parse (independent of Mutagen's overlay decode) — to verify the computed encoding ----
+
+    static List<uint> AllRecordFormIds(string path, string targetSig)
+        => WalkRecords(File.ReadAllBytes(path)).Where(x => x.sig == targetSig).Select(x => x.formId).ToList();
+
+    static List<(string sig, uint formId)> WalkRecords(byte[] buf)
+    {
+        var outp = new List<(string, uint)>();
+        if (buf.Length < 24) return outp;
+        uint tes4Size = BitConverter.ToUInt32(buf, 4);          // skip the TES4 header record (24-byte header + data)
+        Scan(buf, 24 + (int)tes4Size, buf.Length, outp);
+        return outp;
+    }
+
+    static void Scan(byte[] buf, int start, int end, List<(string, uint)> outp)
+    {
+        int p = start;
+        while (p + 24 <= end)
+        {
+            string sig = System.Text.Encoding.ASCII.GetString(buf, p, 4);
+            uint size = BitConverter.ToUInt32(buf, p + 4);
+            long next;
+            if (sig == "GRUP") { next = (long)p + size; Scan(buf, p + 24, (int)Math.Min(next, end), outp); }  // GRUP size INCLUDES its 24-byte header
+            else { outp.Add((sig, BitConverter.ToUInt32(buf, p + 12))); next = (long)p + 24 + size; }          // major record: FormID at +12
+            if (next <= p) break;                                                                              // forward-progress guard (Q3)
+            p = (int)Math.Min(next, (long)end);
+        }
+    }
+}

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1678,7 +1678,7 @@ public sealed class LoadOrderService : IDisposable
 
             // No SGE quests → no .seq needed; write nothing, cut no folder (Q3: a clean, explicit "nothing to do").
             if (built.Quests.Count == 0)
-                return new SeqOutcome(true, null, null, null, built.Quests, built.PluginFileName, null, false);
+                return new SeqOutcome(true, null, null, null, built.Quests, built.PluginFileName, false);
 
             // Output folder: default into the plugin's OWN houseCARL folder; else fresh / explicit into=/patch_name.
             string? autoInto = (string.IsNullOrWhiteSpace(into) && string.IsNullOrWhiteSpace(patchName))
@@ -1703,7 +1703,7 @@ public sealed class LoadOrderService : IDisposable
             if (size != built.Bytes.Length)
                 return SeqOutcome.Fail($"wrote '{seqName}' but its on-disk size ({size}) does not match the {built.Bytes.Length} expected byte(s) — verify before relying on it.");
 
-            return new SeqOutcome(true, null, dest, rf.ModFolder, built.Quests, built.PluginFileName, null, autoInto is not null);
+            return new SeqOutcome(true, null, dest, rf.ModFolder, built.Quests, built.PluginFileName, autoInto is not null);
         }
     }
 
@@ -2014,11 +2014,12 @@ public sealed record PlaceOutcome(
 /// plugin, an into= folder houseCARL doesn't own, a failed write). On success: <see cref="Quests"/> is every SGE quest
 /// covered (EMPTY ⇒ the plugin had none, so <see cref="SeqPath"/> is null and nothing was written — a clean no-op, not a
 /// failure); <see cref="SeqPath"/> is the written <c>.seq</c> and <see cref="ModFolder"/> the houseCARL mod it landed in;
-/// <see cref="WroteIntoPluginFolder"/> is true when it defaulted into the plugin's OWN folder (so one mod enables both).</summary>
+/// <see cref="WroteIntoPluginFolder"/> is true when it defaulted into the plugin's OWN folder (so one mod enables both).
+/// A write-failure residue path (a fresh folder kept because the write half-landed) is folded into <see cref="Error"/>.</summary>
 public sealed record SeqOutcome(
     bool Success, string? Error, string? SeqPath, string? ModFolder,
-    IReadOnlyList<HousecarlCore.SeqFile.SeqQuest> Quests, string PluginFileName, string? LeftoverFolder, bool WroteIntoPluginFolder)
+    IReadOnlyList<HousecarlCore.SeqFile.SeqQuest> Quests, string PluginFileName, bool WroteIntoPluginFolder)
 {
     public static SeqOutcome Fail(string error)
-        => new(false, error, null, null, Array.Empty<HousecarlCore.SeqFile.SeqQuest>(), "", null, false);
+        => new(false, error, null, null, Array.Empty<HousecarlCore.SeqFile.SeqQuest>(), "", false);
 }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1618,6 +1618,95 @@ public sealed class LoadOrderService : IDisposable
         catch (UnauthorizedAccessException) { return Directory.Exists(root) ? root : null; }
     }
 
+    // ---- Layer B unit D: write the start-game-enabled-quest .seq file (housecarl_write_seq) ----
+
+    /// <summary>The <c>SEQ\</c> output folder for a generated <c>.seq</c> (the SEQ rider) — a houseCARL mod folder via
+    /// <see cref="ResolvePatchModFolder"/> plus its <c>SEQ\</c> subfolder, where MO2 deploys it into the game's
+    /// <c>Data\SEQ</c>. Sibling of <see cref="ResolveCompiledScriptFolder"/>; carries the mod-folder root + fresh flag
+    /// through for residue cleanup.</summary>
+    public RiderFolder ResolveSeqFolder(string? patchName, string? into)
+    {
+        var f = ResolvePatchModFolder(patchName, into, "houseCARL_SEQ");
+        var seq = Path.Combine(f.ModFolder, "SEQ");
+        Directory.CreateDirectory(seq);
+        return f with { OutputDir = seq };
+    }
+
+    /// <summary>If <paramref name="pluginPath"/> lives in a houseCARL-owned mod folder DIRECTLY under ModsDir, return that
+    /// folder's patch STEM, so the <c>.seq</c> defaults into the SAME folder as the <c>.esp</c> — one mod to enable, and
+    /// no second fresh folder the user might forget to enable (a real Q3 footgun: a .seq in an un-enabled folder leaves the
+    /// quest silently dead). Only when the folder is the canonical <c>houseCARL - &lt;stem&gt;</c> for THIS plugin (so a
+    /// later <c>into=&lt;stem&gt;</c> resolves to exactly this folder); otherwise null → the caller cuts a fresh folder.</summary>
+    string? OwnedPluginFolderStem(string pluginPath)
+    {
+        var dir = Path.GetDirectoryName(pluginPath);
+        if (dir is null || Path.GetDirectoryName(dir) is not { } parent || !PathEquals(parent, _modsDir)) return null;
+        if (!IsHouseCarlOwned(dir)) return null;
+        var stem = PatchStem(Path.GetFileName(pluginPath));
+        return Path.GetFileName(dir).Equals(ModFolderName(stem), StringComparison.OrdinalIgnoreCase) ? stem : null;
+    }
+
+    /// <summary>Write a plugin's start-game-enabled-quest <c>.seq</c> (housecarl_write_seq). Opens <paramref name="plugin"/>
+    /// (a path to an .esp/.esm/.esl), collects every Start-Game-Enabled quest it defines, and writes
+    /// <c>&lt;ModFolder&gt;\SEQ\&lt;plugin&gt;.seq</c> — the file the engine reads to actually START those quests (the flag
+    /// alone does nothing; the same gated, crash-atomic, non-destructive folder-per-patch model as the compile/asset
+    /// riders). Output folder DEFAULTS to the plugin's OWN houseCARL folder when it lives in one (so the .seq deploys with
+    /// the .esp); else a fresh folder, or <paramref name="into"/>/<paramref name="patchName"/> when given. A plugin with NO
+    /// SGE quests writes NOTHING and cuts no folder (a .seq is only needed for SGE quests — Q3, not a silent empty file).
+    /// Serialized on the write gate (one write at a time), like its sibling writers.</summary>
+    public SeqOutcome WriteSeq(string plugin, string? patchName, string? into)
+    {
+        if (string.IsNullOrWhiteSpace(plugin))
+            return SeqOutcome.Fail("no plugin given. Pass plugin= the path to the .esp/.esm/.esl whose start-game-enabled quests need a .seq.");
+        plugin = plugin.Trim().Trim('"');
+        if (!File.Exists(plugin))
+            return SeqOutcome.Fail($"no such plugin file: '{plugin}'. Pass the full path to the plugin (the path housecarl_create_record reported, or any .esp/.esm/.esl).");
+        var pluginPath = Path.GetFullPath(plugin);
+        if (!PluginExts.Contains(Path.GetExtension(pluginPath), StringComparer.OrdinalIgnoreCase))
+            return SeqOutcome.Fail($"'{Path.GetFileName(pluginPath)}' is not a plugin (.esp/.esm/.esl).");
+
+        lock (_writeGate)                                                // one write at a time (hunt F2 sibling): build → resolve → commit
+        {
+            if (ConfigPromptOrNull() is { } cfgPrompt) return SeqOutcome.Fail(cfgPrompt);   // need ModsDir for the output folder
+            lock (_gate) EnsurePathsDerived();                          // derive ModsDir for the owned-folder check (lock order: _writeGate → _gate)
+
+            // Build the .seq from the plugin (read-only overlay, disposed inside — zero handles at rest).
+            SeqFile.SeqBuild built;
+            try { built = SeqFile.Build(pluginPath); }
+            catch (Exception ex)
+            { return SeqOutcome.Fail($"could not read '{Path.GetFileName(pluginPath)}' as a plugin: {ex.Message}"); }
+
+            // No SGE quests → no .seq needed; write nothing, cut no folder (Q3: a clean, explicit "nothing to do").
+            if (built.Quests.Count == 0)
+                return new SeqOutcome(true, null, null, null, built.Quests, built.PluginFileName, null, false);
+
+            // Output folder: default into the plugin's OWN houseCARL folder; else fresh / explicit into=/patch_name.
+            string? autoInto = (string.IsNullOrWhiteSpace(into) && string.IsNullOrWhiteSpace(patchName))
+                ? OwnedPluginFolderStem(pluginPath) : null;
+            RiderFolder rf;
+            try { rf = ResolveSeqFolder(patchName, autoInto ?? into); }
+            catch (InvalidOperationException ex) { return SeqOutcome.Fail(ex.Message); }
+
+            // Crash-atomic write of <plugin>.seq under SEQ\ (originals untouched — a houseCARL-owned folder only).
+            var seqName = Path.GetFileNameWithoutExtension(pluginPath) + ".seq";
+            var dest = Path.Combine(rf.OutputDir, seqName);
+            try { AtomicFile.WriteAllBytes(dest, built.Bytes); }
+            catch (Exception ex)
+            {
+                var residue = RemoveOrNameRiderResidue(rf);             // nothing landed → a fresh folder is an orphan
+                return SeqOutcome.Fail($"could not write '{seqName}': {ex.Message}"
+                    + (residue is null ? "" : $" The freshly created folder was left at '{residue}'."));
+            }
+
+            // Integrity (Q3: THIS run wrote it; on-disk size matches the bytes we built — no false success).
+            long size; try { size = new FileInfo(dest).Length; } catch { size = -1; }
+            if (size != built.Bytes.Length)
+                return SeqOutcome.Fail($"wrote '{seqName}' but its on-disk size ({size}) does not match the {built.Bytes.Length} expected byte(s) — verify before relying on it.");
+
+            return new SeqOutcome(true, null, dest, rf.ModFolder, built.Quests, built.PluginFileName, null, autoInto is not null);
+        }
+    }
+
     // ---- decompiler class hierarchy (lazy, cached for process lifetime) ----------------------------------------
 
     Dictionary<string, string>? _classParents;
@@ -1919,4 +2008,17 @@ public sealed record PlaceOutcome(
 {
     public static PlaceOutcome Fail(string error)
         => new(Array.Empty<PlaceResult>(), null, Array.Empty<string>(), null, error);
+}
+
+/// <summary>The outcome of housecarl_write_seq. <see cref="Error"/> non-null ⇒ the call was rejected (no plugin, unreadable
+/// plugin, an into= folder houseCARL doesn't own, a failed write). On success: <see cref="Quests"/> is every SGE quest
+/// covered (EMPTY ⇒ the plugin had none, so <see cref="SeqPath"/> is null and nothing was written — a clean no-op, not a
+/// failure); <see cref="SeqPath"/> is the written <c>.seq</c> and <see cref="ModFolder"/> the houseCARL mod it landed in;
+/// <see cref="WroteIntoPluginFolder"/> is true when it defaulted into the plugin's OWN folder (so one mod enables both).</summary>
+public sealed record SeqOutcome(
+    bool Success, string? Error, string? SeqPath, string? ModFolder,
+    IReadOnlyList<HousecarlCore.SeqFile.SeqQuest> Quests, string PluginFileName, string? LeftoverFolder, bool WroteIntoPluginFolder)
+{
+    public static SeqOutcome Fail(string error)
+        => new(false, error, null, null, Array.Empty<HousecarlCore.SeqFile.SeqQuest>(), "", null, false);
 }

--- a/src/housecarl-mcp/SeqTools.cs
+++ b/src/housecarl-mcp/SeqTools.cs
@@ -1,0 +1,71 @@
+using System.ComponentModel;
+using System.Text;
+using ModelContextProtocol.Server;
+
+namespace HousecarlMcp;
+
+/// <summary>
+/// houseCARL SEQ rider — housecarl_write_seq. Writes the start-game-enabled-quest "sequence" file
+/// (<c>Data\SEQ\&lt;plugin&gt;.seq</c>) a plugin needs for its Start-Game-Enabled quests to actually run. Ticking the SGE
+/// flag in the CK/xEdit does nothing on its own; without the .seq the quest — and any dialogue or world change gated on it
+/// — silently never starts (the exact silent-failure class houseCARL refuses, Q3). This is the data-layer equivalent of
+/// the CK's on-save SEQ generation / xEdit's "Create SEQ file": it reads the plugin's SGE quests and emits the file into a
+/// reviewable houseCARL mod folder (originals untouched — same folder-per-patch model as every other write). The byte
+/// format and FormID encoding are load-order-independent (see <see cref="HousecarlCore.SeqFile"/>), so the .seq is correct
+/// the moment it's written and travels with the mod.
+/// </summary>
+[McpServerToolType]
+public static class SeqTools
+{
+    [McpServerTool(Name = "housecarl_write_seq", Title = "Write a start-game-enabled-quest .seq file"),
+     Description(
+         "Write the SEQ file (Data\\SEQ\\<plugin>.seq) a plugin needs for its START-GAME-ENABLED quests to actually run. " +
+         "Ticking 'Start Game Enabled' on a quest does NOTHING on its own — without the .seq the quest, and any dialogue or " +
+         "change gated on it, silently never starts. Pass plugin= the path to the .esp/.esm/.esl (e.g. the path " +
+         "housecarl_create_record reported for your patch); houseCARL reads its start-game-enabled quests and writes the " +
+         ".seq into a houseCARL mod folder you enable in MO2. If the plugin is itself in a houseCARL patch folder, the .seq " +
+         "defaults into THAT same folder (so enabling the one mod deploys both .esp and .seq); otherwise it lands in a fresh " +
+         "folder (pass into= an existing houseCARL patch to keep them together). A plugin with no start-game-enabled quests " +
+         "needs no .seq — that's reported, nothing is written. The .seq makes the quest START; it does not verify the quest " +
+         "or its dialogue is otherwise correct. Needs houseCARL pointed at your MO2 instance (for the output folder).")]
+    public static string WriteSeq(
+        LoadOrderService svc,
+        [Description("Full path to the plugin (.esp/.esm/.esl) whose start-game-enabled quests need a .seq.")]
+            string plugin,
+        [Description("Optional. Base name for a NEW patch-mod folder the .seq lands in (default: the plugin's own houseCARL folder if it's in one, else 'houseCARL_SEQ'); auto-suffixed if taken.")]
+            string? patch_name = null,
+        [Description("Optional. Filename of an existing houseCARL patch mod to write the .seq into (e.g. the patch that holds the .esp, so one mod deploys both).")]
+            string? into = null) => Guard.Tool("housecarl_write_seq", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } cfgPrompt) return cfgPrompt;
+
+        var o = svc.WriteSeq(plugin, patch_name, into);
+        if (!o.Success) return "error: " + o.Error;
+        return Render(o);
+    });
+
+    internal static string Render(SeqOutcome o)
+    {
+        // No SGE quests → a clean, explicit no-op (Q3: never a silent empty .seq, never a misleading "done").
+        if (o.Quests.Count == 0)
+            return $"no start-game-enabled quests in {o.PluginFileName} — no .seq is needed (a .seq lists only quests with the " +
+                   "Start Game Enabled flag). Nothing written. If a quest SHOULD start at game start, set its Start Game Enabled " +
+                   "flag first, then write the .seq.";
+
+        var sb = new StringBuilder();
+        var seqName = Path.GetFileName(o.SeqPath);
+        sb.Append("wrote ").Append(seqName).Append(": ").Append(o.Quests.Count)
+          .Append(o.Quests.Count == 1 ? " start-game-enabled quest" : " start-game-enabled quests").Append('\n');
+        foreach (var q in o.Quests)
+            sb.Append("  ").Append(q.EditorId is { Length: > 0 } e ? e : "(no EditorID)")
+              .Append("  →  0x").AppendFormat("{0:X8}", q.OnDiskFormId).Append('\n');
+        sb.Append("path: ").Append(o.SeqPath).Append('\n');
+        sb.Append(o.WroteIntoPluginFolder
+            ? "the .seq is in the plugin's OWN houseCARL folder — enabling that one mod in MO2 deploys both the .esp and its .seq."
+            : "the .seq is in a houseCARL mod folder — enable it in MO2 (AND make sure the plugin itself is enabled) so the game reads Data\\SEQ\\.");
+        // Q3 standing limit: a written .seq makes the quest START; it is not a guarantee the quest/dialogue is otherwise correct.
+        sb.Append("\nnote: this makes the quest(s) START at game start; it does not verify the quest or its dialogue is otherwise " +
+                  "well-formed (use housecarl_validate_dialogue for the dialogue graph).");
+        return sb.ToString();
+    }
+}


### PR DESCRIPTION
**Layer B unit D** of the nested-dialogue batch. Adds `housecarl_write_seq` — the writer for the start-game-enabled-quest `.seq` file (`Data\SEQ\<plugin>.seq`). Without it, a plugin's Start-Game-Enabled quests (and any dialogue gated on them) **silently never start** — the exact Q3 failure class houseCARL refuses. This is the data-layer equivalent of the CK's on-save SEQ generation / xEdit's "Create SEQ file".

## The load-bearing finding (empirically pinned)
A `.seq` is a flat array of 4-byte **little-endian** FormIDs, no header, one per SGE quest. Each FormID is the plugin-local **master-INDEX on-disk form**: high byte = the record's slot in the plugin's master list (own/new records sit at the slot after the last master, i.e. high byte = master count; an override at the overridden master's index), low 3 bytes = object id. It is **never** the runtime `0xFE` / load-order address.

Verified against **all 145 real `.seq` files** in a live load order (120/143 exact master-count match; the rest are *stale* SEQs — a master added/removed or an ESL compaction/merge after generation — not a different encoding) and cross-checked with the ESL ground-truth work (master-index, never 0xFE, over 1.55M records). So the `.seq` is **load-order-independent and computed wholly at author time — no runtime-FormID bridge** (the plan's §4 classification stays **(a)**, like voice files). houseCARL writes the plugin and its `.seq` together, so the encoding is never stale.

## What's here
- **core `SeqFile`** — the master-index encoder + LE serializer + the overlay walk (SGE-only; deleted quests skipped, the dialogue-validator's rule).
- **service `LoadOrderService.WriteSeq` + `ResolveSeqFolder`** — gated, crash-atomic, non-destructive folder-per-patch writer (the asset-placer sibling). Defaults the `.seq` **into the plugin's own houseCARL folder** when it's in one (one mod to enable, no orphan-folder footgun); else fresh / `into=`. A plugin with **0 SGE quests writes nothing and cuts no folder** (a clean no-op, not a silent empty file).
- **tool `housecarl_write_seq`** — tool surface 22 → 23, Q3-honest render ("makes the quest START; does not verify the dialogue is otherwise correct").
- **`seq-write-guard`** — 16 RED-proven arms incl. **ON-DISK-MATCH** (computed FormIDs == the plugin's *actual* on-disk record bytes via an independent raw parse — RED to an FE-space regression) and **ESL-NEVER-FE**, driving both core and the real `WriteSeq` over a synthetic MO2 instance. Wired into CI.

## Verification
- 16/16 guard arms green; RED-proven (a deliberate FE-space encoding fails 6 arms incl. ON-DISK-MATCH).
- Release build clean (0 errors).
- Independent adversarial review: **SHIP** (no blocker/major; encoding, SGE-only, non-destructive/Q3, lock order all verified). Its three guard-only findings folded in the 2nd commit (+ESL arm, `FirstOrDefault`→`Single`, arm-list reconcile).

1.3.0 release note (batch still on hold): new `housecarl_write_seq` — point it at a plugin and it writes the `Data\SEQ\<plugin>.seq` its start-game-enabled quests need to actually run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)