### PR TITLE
Coordinate-keyed cell create (§4-(b)) — exterior/interior cells + placed, with the structural-shell report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,14 @@ jobs:
       - name: Probe — nested-record create (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- nested-create-guard
 
+      # Self-contained (synthesizes a master with a Worldspace + Weapon — no Skyrim.esm, unlike the manual coord-cell-probe
+      # scout) and drives the REAL CreateRecords: locks in COORDINATE-KEYED cell create (the §4-(b) seam, dev/plans/
+      # COORD_KEYED_CELL_CREATE_BUILD_2026-06-20.md) — exterior cell by grid (block=floor(grid/32), subblock=floor(grid/8)),
+      # interior cell by FormID digits (block=id%10, subblock=(id/10)%10), placed-into-not-yet-present-cell, and the four
+      # malformed rejects (grid+no-parent, parent+no-grid, bad-grid, grid+non-Worldspace-parent — all no file written).
+      - name: Probe — coordinate-keyed cell create (self-contained regression guard)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- coord-cell-guard
+
       # Self-contained (synthesizes a master with one dialogue topic per validation shape — no external files), runs
       # fully here: a regression guard locking in the on-demand dialogue-graph validator (nested-dialogue plan §3.6,
       # Layer B unit C2 — housecarl_validate_dialogue): the graph checks (PNAM chain, quest + branch wiring), the reused

--- a/src/housecarl-core/CellShellCheck.cs
+++ b/src/housecarl-core/CellShellCheck.cs
@@ -1,0 +1,86 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+
+namespace HousecarlCore;
+
+/// <summary>One created Cell's STRUCTURAL-SHELL note: its kind (interior vs exterior) and the world content houseCARL
+/// does NOT author for it (lighting / terrain / water / navmesh — Creation-Kit work). The cell RECORD is valid and
+/// correctly placed (block math proven); this carries the Q3 honesty that "created" ≠ "looks right in game" — the same
+/// shape as the dialogue voice report's "this line will be SILENT" surface.</summary>
+public sealed record CellShell(FormKey Cell, string EditorId, bool Interior, IReadOnlyList<string> MustProvide);
+
+/// <summary>The structural-shell report for one create call: one entry per created Cell. <see cref="IsEmpty"/> when the
+/// call created no cells. Mirrors <see cref="VoiceReport"/> — a post-write enrichment that NEVER fails the create
+/// (the cell IS written; this only says what the author must still provide).</summary>
+public sealed record CellShellReport(IReadOnlyList<CellShell> Cells)
+{
+    /// <summary>The shell check itself could not run (the patch wouldn't re-open) — surfaced, never a silent skip (Q3).
+    /// The create ALREADY SUCCEEDED when this is set; it means "I couldn't enumerate the created cells", not "the write
+    /// failed". Null on a clean run.</summary>
+    public string? CheckError { get; init; }
+
+    public bool IsEmpty => Cells.Count == 0 && CheckError is null;
+    public static readonly CellShellReport Empty = new(Array.Empty<CellShell>());
+}
+
+/// <summary>Post-write structural-shell report for created cells (the coordinate-keyed §4-(b) create teeth — Aaron
+/// 2026-06-20: a created cell is a structural SHELL; houseCARL does NOT author world content). Sibling to
+/// <see cref="VoiceCheck"/>: the overlay re-open lives in core so the service needs no Mutagen.Skyrim dependency.</summary>
+public static class CellShellCheck
+{
+    /// <summary>The catalog name (RecordNaming.StripGetterInterface of ICellGetter) the create flow stamps on a created
+    /// cell — the filter for "which created records are cells".</summary>
+    public const string CellCatalogName = "Cell";
+
+    /// <summary>Run the structural-shell report over the cells created by ONE create call. Re-opens the just-written
+    /// <paramref name="patchPath"/> read-only, reads each created cell's <c>IsInteriorCell</c> flag, and lists the world
+    /// content houseCARL does NOT author (fixed by kind). Returns <see cref="CellShellReport.Empty"/> when the call
+    /// created no cells. A whole-check failure (the patch won't re-open) is surfaced on
+    /// <see cref="CellShellReport.CheckError"/> — NEVER thrown (the create already succeeded; this is a verify step).</summary>
+    public static CellShellReport Run(string patchPath, IReadOnlyList<WritePatchBuilder.CreatedRecord> created)
+    {
+        var cellEdids = new Dictionary<FormKey, string>();
+        foreach (var c in created)
+            if (string.Equals(c.RecordType, CellCatalogName, StringComparison.Ordinal))
+                cellEdids[c.FormKey] = c.EditorId;
+        if (cellEdids.Count == 0) return CellShellReport.Empty;
+
+        ISkyrimModGetter? patch = null;
+        try
+        {
+            patch = SkyrimMod.CreateFromBinaryOverlay(patchPath, SkyrimRelease.SkyrimSE);
+            var shells = new List<CellShell>();
+            // EnumerateMajorRecords<ICellGetter> finds cells in BOTH the interior Cells group AND worldspace blocks.
+            foreach (var cell in patch.EnumerateMajorRecords<ICellGetter>())
+            {
+                if (!cellEdids.TryGetValue(cell.FormKey, out var edid)) continue;
+                bool interior = cell.Flags.HasFlag(Cell.Flag.IsInteriorCell);
+                shells.Add(new CellShell(cell.FormKey, edid, interior, MustProvide(interior)));
+            }
+            return shells.Count == 0 ? CellShellReport.Empty : new CellShellReport(shells);
+        }
+        catch (Exception ex)
+        {
+            return CellShellReport.Empty with { CheckError = $"{ex.GetType().Name}: {ex.Message}" };
+        }
+        finally { (patch as IDisposable)?.Dispose(); }
+    }
+
+    /// <summary>The world content houseCARL does NOT author for a freshly-created cell — fixed by kind. A STANDING list
+    /// (the dialogue "declare the un-done set as a standing warning" pattern), NOT a field-state check: setting a
+    /// LightingTemplate FormLink is not authoring the lit scene, so the caveat holds regardless of which cell fields the
+    /// same call set — keeping the boundary honest without crying wolf about specific fields.</summary>
+    static IReadOnlyList<string> MustProvide(bool interior) => interior
+        ? new[]
+        {
+            "lighting — a Lighting Template and/or lighting settings (else the cell renders pitch black)",
+            "navmesh (else NPCs cannot path or spawn)",
+        }
+        : new[]
+        {
+            "terrain — a LAND record (else the cell is an empty void)",
+            "water height + a region/location",
+            "navmesh (else NPCs cannot path)",
+        };
+}

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -887,8 +887,8 @@ public static class WriteEngine
                  "(a placed object/NPC, a dialogue line, navmesh or terrain) that needs a parent. Create it WITH its parent: " +
                  "pass parent= (the parent record's FormID, or the editorid of a record created EARLIER in the same call) and, " +
                  "if the parent holds more than one child-collection, collection= — or use housecarl_bulk_create to make a parent " +
-                 "and its children (a dialogue topic + its lines, a cell + its placed refs) in ONE call. (An EXTERIOR cell nests " +
-                 "under FormKey-less worldspace block structs — a separate capability, still unsupported.) If instead it's a subtype " +
+                 "and its children (a dialogue topic + its lines, a cell + its placed refs) in ONE call. (A CELL is coordinate-keyed: " +
+                 "create an EXTERIOR cell with parent=<Worldspace FormID> + grid=<X,Y>, or an INTERIOR cell with no parent.) If instead it's a subtype " +
                  "of an abstract group (like Global → GlobalFloat), create the concrete subtype. Flat top-level records — keywords, " +
                  "spells, perks, magic effects, factions, armor, weapons, leveled lists, … — create fine.";
         return false;
@@ -1190,8 +1190,10 @@ public static class WriteEngine
         if (hits.Count == 0)
         {
             error = $"'{childName}' cannot be created under a '{parentName}' — that parent models no child-collection that " +
-                    "holds it. (A real containment boundary — e.g. exterior cells nest under FormKey-less worldspace block " +
-                    "structs, a separate capability — surfaced not guessed, Q3.)";
+                    "holds it (a real containment boundary, surfaced not guessed, Q3)." +
+                    (childType == typeof(Cell)
+                        ? " A Cell is coordinate-keyed, not collection-nested: create an EXTERIOR cell with parent=<Worldspace> + grid=<X,Y>, or an INTERIOR cell with no parent."
+                        : "");
             return false;
         }
         if (collectionName is not null)
@@ -1273,6 +1275,87 @@ public static class WriteEngine
         if (editorId is not null) child.EditorID = editorId;
         list.Add(child);
         return child;
+    }
+
+    // ======================================================================
+    //  COORDINATE-KEYED CREATE (the §4-(b) seam) — cells, the one family whose
+    //  structural parents are FormKey-LESS block structs the FormKey locator
+    //  (NestedAddNew) cannot address: exterior cells under WorldspaceBlock/
+    //  WorldspaceSubBlock, interior cells under CellBlock/CellSubBlock. Placed
+    //  by DERIVED block arithmetic, not a parent FormKey. STEP-0 proven
+    //  (CoordCellProbe, round-tripped vs vanilla): exterior block=floor(grid/32)
+    //  subblock=floor(grid/8) (4000/4000); interior block=id%10 subblock=(id/10)%10
+    //  (590/590); thin Worldspace override (a 1-cell delta, not all of Tamriel).
+    //  ONE generic algorithm per cell-kind — NOT a per-type shim (dev/plans/
+    //  COORD_KEYED_CELL_CREATE_BUILD_2026-06-20.md). Mutagen DROPS the OFST
+    //  seek-cache on write (Aaron-accepted 2026-06-20); the engine rebuilds it
+    //  from the block tree at load. A created cell is a STRUCTURAL SHELL —
+    //  lighting/land/navmesh stay the author's (the shell report surfaces this
+    //  loudly; the engine stays policy-free, Q3).
+    // ======================================================================
+
+    /// <summary>Signed integer floor division (toward -∞) — the exterior block/subblock index from a (possibly
+    /// negative) cell grid coordinate. C# truncates toward zero (<c>-1/8 == 0</c>), but the cell at grid -1 sits in
+    /// subblock -1; this floors so negative coordinates key correctly (the scout confirmed floor vs 4000 vanilla cells).</summary>
+    internal static int FloorDiv(int a, int b) => (int)Math.Floor((double)a / b);
+
+    /// <summary>CREATE an EXTERIOR cell at grid (<paramref name="gridX"/>,<paramref name="gridY"/>) under
+    /// <paramref name="worldspaceInPatch"/> (already settable in the patch — the caller overrides it in, thin). Computes
+    /// the block (floor(grid/32)) + subblock (floor(grid/8)) indices, FINDS-OR-CONSTRUCTS the FormKey-less
+    /// <see cref="WorldspaceBlock"/> + <see cref="WorldspaceSubBlock"/> structs (the add-target is the model's block tree,
+    /// not a FormKey lookup), constructs the <see cref="Cell"/> with its Grid set and <c>IsInteriorCell</c> OFF, allocates
+    /// a fresh local 0x800+ FormKey from the SAME floored counter as flat/nested create, and adds it. Returns the new cell
+    /// (settable, fed into the same <see cref="ApplyVerb"/> path). STEP-0 proven (CoordCellProbe).</summary>
+    public static Cell AddExteriorCell(SkyrimMod patchMod, Worldspace worldspaceInPatch, int gridX, int gridY, string? editorId)
+    {
+        int bx = FloorDiv(gridX, 32), by = FloorDiv(gridY, 32), sx = FloorDiv(gridX, 8), sy = FloorDiv(gridY, 8);
+        var block = worldspaceInPatch.SubCells.FirstOrDefault(b => b.BlockNumberX == bx && b.BlockNumberY == by);
+        if (block is null)
+        {
+            block = new WorldspaceBlock { BlockNumberX = (short)bx, BlockNumberY = (short)by, GroupType = GroupTypeEnum.ExteriorCellBlock };
+            worldspaceInPatch.SubCells.Add(block);
+        }
+        var sub = block.Items.FirstOrDefault(s => s.BlockNumberX == sx && s.BlockNumberY == sy);
+        if (sub is null)
+        {
+            sub = new WorldspaceSubBlock { BlockNumberX = (short)sx, BlockNumberY = (short)sy, GroupType = GroupTypeEnum.ExteriorCellSubBlock };
+            block.Items.Add(sub);
+        }
+        EnsureFormIdFloor(patchMod);   // 0x800 floor, exactly like flat/nested create (HCBR-2026-06-09-04)
+        if (patchMod.ModHeader.Stats.NextFormID > 0xFFFFFF)
+            throw new InvalidOperationException(
+                $"cannot allocate a new FormID: the patch's NextObjectID counter is 0x{patchMod.ModHeader.Stats.NextFormID:X} — " +
+                "past the 24-bit object-ID ceiling (0xFFFFFF). The plugin is full or its header counter is corrupt.");
+        var cell = new Cell(AllocateNextFormKey(patchMod), SkyrimRelease.SkyrimSE) { Grid = new CellGrid { Point = new P2Int(gridX, gridY) } };
+        if (editorId is not null) cell.EditorID = editorId;
+        sub.Items.Add(cell);
+        return cell;
+    }
+
+    /// <summary>CREATE an INTERIOR cell — files into the patch's top-level <see cref="SkyrimMod.Cells"/> group by the
+    /// cell's OWN FormID digits (block = id%10, subblock = (id/10)%10 — STEP-0 proven 590/590 vanilla). The FormKey is
+    /// allocated FIRST (the digits key off it), then the <see cref="CellBlock"/>/<see cref="CellSubBlock"/> are
+    /// found-or-constructed. <c>IsInteriorCell</c> ON. Returns the new cell (settable, fed into the same
+    /// <see cref="ApplyVerb"/> path).</summary>
+    public static Cell AddInteriorCell(SkyrimMod patchMod, string? editorId)
+    {
+        EnsureFormIdFloor(patchMod);
+        if (patchMod.ModHeader.Stats.NextFormID > 0xFFFFFF)
+            throw new InvalidOperationException(
+                $"cannot allocate a new FormID: the patch's NextObjectID counter is 0x{patchMod.ModHeader.Stats.NextFormID:X} — " +
+                "past the 24-bit object-ID ceiling (0xFFFFFF). The plugin is full or its header counter is corrupt.");
+        var fk = AllocateNextFormKey(patchMod);
+        uint id = fk.ID;
+        int blockN = (int)(id % 10), subN = (int)((id / 10) % 10);
+        var records = patchMod.Cells.Records;
+        var block = records.FirstOrDefault(b => b.BlockNumber == blockN);
+        if (block is null) { block = new CellBlock { BlockNumber = blockN, GroupType = GroupTypeEnum.InteriorCellBlock }; records.Add(block); }
+        var sub = block.SubBlocks.FirstOrDefault(s => s.BlockNumber == subN);
+        if (sub is null) { sub = new CellSubBlock { BlockNumber = subN, GroupType = GroupTypeEnum.InteriorCellSubBlock }; block.SubBlocks.Add(sub); }
+        var cell = new Cell(fk, SkyrimRelease.SkyrimSE) { Flags = Cell.Flag.IsInteriorCell };
+        if (editorId is not null) cell.EditorID = editorId;
+        sub.Cells.Add(cell);
+        return cell;
     }
 
     static MethodInfo? _overrideMethod;

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1308,6 +1308,14 @@ public static class WriteEngine
     /// (settable, fed into the same <see cref="ApplyVerb"/> path). STEP-0 proven (CoordCellProbe).</summary>
     public static Cell AddExteriorCell(SkyrimMod patchMod, Worldspace worldspaceInPatch, int gridX, int gridY, string? editorId)
     {
+        // Floor + dedup BEFORE mutating the block tree (a failed call discards the patch, but ordering it like
+        // AddInteriorCell keeps the no-mutation-before-validation property clean — PR #94 review nit).
+        EnsureNoDuplicateCellEditorId(patchMod, editorId);   // no silent duplicate on an into= re-run (cells have a stable EditorID)
+        EnsureFormIdFloor(patchMod);   // 0x800 floor, exactly like flat/nested create (HCBR-2026-06-09-04)
+        if (patchMod.ModHeader.Stats.NextFormID > 0xFFFFFF)
+            throw new InvalidOperationException(
+                $"cannot allocate a new FormID: the patch's NextObjectID counter is 0x{patchMod.ModHeader.Stats.NextFormID:X} — " +
+                "past the 24-bit object-ID ceiling (0xFFFFFF). The plugin is full or its header counter is corrupt.");
         int bx = FloorDiv(gridX, 32), by = FloorDiv(gridY, 32), sx = FloorDiv(gridX, 8), sy = FloorDiv(gridY, 8);
         var block = worldspaceInPatch.SubCells.FirstOrDefault(b => b.BlockNumberX == bx && b.BlockNumberY == by);
         if (block is null)
@@ -1321,11 +1329,6 @@ public static class WriteEngine
             sub = new WorldspaceSubBlock { BlockNumberX = (short)sx, BlockNumberY = (short)sy, GroupType = GroupTypeEnum.ExteriorCellSubBlock };
             block.Items.Add(sub);
         }
-        EnsureFormIdFloor(patchMod);   // 0x800 floor, exactly like flat/nested create (HCBR-2026-06-09-04)
-        if (patchMod.ModHeader.Stats.NextFormID > 0xFFFFFF)
-            throw new InvalidOperationException(
-                $"cannot allocate a new FormID: the patch's NextObjectID counter is 0x{patchMod.ModHeader.Stats.NextFormID:X} — " +
-                "past the 24-bit object-ID ceiling (0xFFFFFF). The plugin is full or its header counter is corrupt.");
         var cell = new Cell(AllocateNextFormKey(patchMod), SkyrimRelease.SkyrimSE) { Grid = new CellGrid { Point = new P2Int(gridX, gridY) } };
         if (editorId is not null) cell.EditorID = editorId;
         sub.Items.Add(cell);
@@ -1339,6 +1342,7 @@ public static class WriteEngine
     /// <see cref="ApplyVerb"/> path).</summary>
     public static Cell AddInteriorCell(SkyrimMod patchMod, string? editorId)
     {
+        EnsureNoDuplicateCellEditorId(patchMod, editorId);   // no silent duplicate on an into= re-run (cells have a stable EditorID)
         EnsureFormIdFloor(patchMod);
         if (patchMod.ModHeader.Stats.NextFormID > 0xFFFFFF)
             throw new InvalidOperationException(
@@ -1356,6 +1360,22 @@ public static class WriteEngine
         if (editorId is not null) cell.EditorID = editorId;
         sub.Cells.Add(cell);
         return cell;
+    }
+
+    /// <summary>Refuse loud (Q3) if <paramref name="patchMod"/> ALREADY defines a cell with <paramref name="editorId"/>.
+    /// Coordinate-keyed cell create does NOT upsert (unlike flat <see cref="GenericUpsertNew"/>), so an into= re-run would
+    /// otherwise silently APPEND a second cell at the same identity — and a cell DOES carry a stable EditorID (the flat
+    /// nested-children carve-out's "no stable handle to de-dup on" rationale, WritePatchBuilder, does not transfer to
+    /// cells; PR #94 review). A no-op on a fresh patch (no prior cells). Within a single bulk_create, same-editorid specs
+    /// are already caught by the pre-flight's per-call editorid set; this closes the cross-call into= gap.</summary>
+    static void EnsureNoDuplicateCellEditorId(SkyrimMod patchMod, string? editorId)
+    {
+        if (string.IsNullOrEmpty(editorId)) return;
+        foreach (var existing in patchMod.EnumerateMajorRecords<ICellGetter>())
+            if (string.Equals(existing.EditorID, editorId, StringComparison.Ordinal))
+                throw new InvalidOperationException(
+                    $"a cell with editorid '{editorId}' already exists in this patch ({existing.FormKey}); creating it again " +
+                    "would duplicate it. Cell create does not upsert — edit the existing cell, or use a different editorid.");
     }
 
     static MethodInfo? _overrideMethod;

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -111,6 +111,13 @@ public static class WritePatchBuilder
         /// this child type (outcome (i), e.g. a DialogTopic's one <c>Responses</c> list). Ignored when
         /// <see cref="ParentRef"/> is null.</summary>
         public string? IntoCollection { get; init; }
+
+        /// <summary>Optional — the exterior-cell GRID as "X,Y" (the coordinate-keyed §4-(b) create path). Set on a
+        /// <c>Cell</c> create, it places the new cell into a Worldspace's block tree by block=floor(grid/32),
+        /// subblock=floor(grid/8) (STEP-0 proven vs 4000 vanilla cells); <see cref="ParentRef"/> must then resolve to a
+        /// Worldspace. A <c>Cell</c> create with NO <see cref="Grid"/> and NO <see cref="ParentRef"/> ⇒ an INTERIOR cell
+        /// (self-files into the top-level Cells group by its own FormID). Ignored for non-Cell types.</summary>
+        public string? Grid { get; init; }
     }
 
     /// <summary>One record created by <see cref="CreateRecords"/> — its freshly-allocated <see cref="FormKey"/> (the
@@ -154,6 +161,24 @@ public static class WritePatchBuilder
     /// unverifiable perk gate), bounded by the modeled-corpus boundary + ReadEngine's expansion cap, whose
     /// truncation sentinel stays an explicit note (Q3).</summary>
     public const int FullReadbackDepth = 16;
+
+    /// <summary>The coordinate-keyed cell-create kind for a spec (the §4-(b) path): <see cref="None"/> = the flat or
+    /// FormKey-nested path (unchanged); <see cref="Exterior"/> = a Cell placed under a Worldspace by grid
+    /// (<c>block=floor(grid/32)</c>, <c>subblock=floor(grid/8)</c>); <see cref="Interior"/> = a parentless Cell self-filed
+    /// into the top-level Cells group by its own FormID digits. See <c>WriteEngine.AddExteriorCell</c>/<c>AddInteriorCell</c>.</summary>
+    enum CellCreate { None, Exterior, Interior }
+
+    /// <summary>Is <paramref name="recordType"/> the <c>Cell</c> record type (case-insensitive — the system's catalog convention)?</summary>
+    static bool IsCellType(string recordType) => string.Equals(recordType, nameof(Cell), StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Parse an exterior-cell grid "X,Y" into two ints (whitespace-tolerant). False ⇒ malformed (the call refuses loud, Q3).</summary>
+    static bool TryParseGrid(string? grid, out int x, out int y)
+    {
+        x = y = 0;
+        if (string.IsNullOrWhiteSpace(grid)) return false;
+        var parts = grid.Split(',');
+        return parts.Length == 2 && int.TryParse(parts[0].Trim(), out x) && int.TryParse(parts[1].Trim(), out y);
+    }
 
     /// <summary>Build/extend a patch from <paramref name="edits"/> and serialize it to <paramref name="outPath"/>.
     /// <paramref name="extend"/>=false writes a fresh patch (the ModKey = the output filename); =true opens the existing
@@ -465,6 +490,7 @@ public static class WritePatchBuilder
         // validation it holds {0..i-1}: a self-ref (@its-own-editorid) and a forward-ref (a later sibling) both reject.
         var priorEditorIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var parentPlans = new List<(IMajorRecordGetter? body, string? winnerPlugin, string? sibling, IMajorRecord? patchParent)?>(specs.Count);
+        var cellKinds = new CellCreate[specs.Count];   // coordinate-keyed §4-(b) routing per spec (None / Exterior / Interior)
         for (int i = 0; i < specs.Count; i++)
         {
             var s = specs[i];
@@ -475,7 +501,14 @@ public static class WritePatchBuilder
 
             if (s.ParentRef is null)
             {
-                if (!WriteEngine.CanCreateType(s.RecordType, out var why)) { problems.Add($"{s.RecordType} '{s.EditorId}': {why}"); continue; }
+                if (IsCellType(s.RecordType))
+                {
+                    // A parentless Cell (coordinate-keyed §4-(b)): NO grid ⇒ an INTERIOR cell (self-files by FormID —
+                    // CanCreateType would refuse a bare Cell, so bypass it). A grid here is malformed (exterior needs a Worldspace).
+                    if (s.Grid is not null) { problems.Add($"Cell '{s.EditorId}': an exterior cell (grid=) needs parent= a Worldspace; an interior cell takes no parent and no grid."); continue; }
+                    cellKinds[i] = CellCreate.Interior;
+                }
+                else if (!WriteEngine.CanCreateType(s.RecordType, out var why)) { problems.Add($"{s.RecordType} '{s.EditorId}': {why}"); continue; }
             }
             else
             {
@@ -517,7 +550,17 @@ public static class WritePatchBuilder
                     parentPlans[i] = (null, null, s.ParentRef, null);
                 }
                 if (parentType is null) { problems.Add($"{s.RecordType} '{s.EditorId}': could not resolve the parent's record type."); continue; }
-                if (!WriteEngine.CanCreateNested(s.RecordType, parentType, s.IntoCollection, out var nestedWhy)) { problems.Add($"{s.RecordType} '{s.EditorId}': {nestedWhy}"); continue; }
+                if (IsCellType(s.RecordType))
+                {
+                    // A Cell WITH a parent (coordinate-keyed §4-(b)): a grid ⇒ an EXTERIOR cell placed into the
+                    // Worldspace's block tree (NOT a child-collection nest). No grid ⇒ ambiguous — refuse loud (Q3).
+                    // (Parent resolution above already populated parentPlans[i] so Phase 3 can make the Worldspace settable.)
+                    if (s.Grid is null) { problems.Add($"Cell '{s.EditorId}': a Cell with parent= but no grid= is ambiguous — an exterior cell needs grid=<X,Y> under a Worldspace; an interior cell takes no parent."); continue; }
+                    if (parentType != typeof(Worldspace)) { problems.Add($"Cell '{s.EditorId}': an exterior cell nests under a Worldspace, but parent '{s.ParentRef}' resolved to a {parentType.Name}."); continue; }
+                    if (!TryParseGrid(s.Grid, out _, out _)) { problems.Add($"Cell '{s.EditorId}': grid '{s.Grid}' must be two integers \"X,Y\" (e.g. \"5,-12\")."); continue; }
+                    cellKinds[i] = CellCreate.Exterior;
+                }
+                else if (!WriteEngine.CanCreateNested(s.RecordType, parentType, s.IntoCollection, out var nestedWhy)) { problems.Add($"{s.RecordType} '{s.EditorId}': {nestedWhy}"); continue; }
             }
 
             foreach (var req in s.Edits)
@@ -552,43 +595,59 @@ public static class WritePatchBuilder
         var created = new List<CreatedRecord>(specs.Count);
         var createdByEditorId = new Dictionary<string, IMajorRecord>(StringComparer.OrdinalIgnoreCase);
         var linkCacheByPlugin = new Dictionary<string, Mutagen.Bethesda.Plugins.Cache.ILinkCache>(StringComparer.OrdinalIgnoreCase);
+
+        // Resolve a spec's parent to a SETTABLE record IN the patch — shared by nested-create AND exterior-cell create
+        // (both make the parent settable identically: a prior-into= patch record used directly; an existing load-order
+        // parent overridden in, with its source link cache only when the override needs one; or a same-call sibling
+        // created earlier in this loop). Returns (parent, null) on success, (null, error) to fail the WHOLE call (Q3).
+        (IMajorRecord? parent, string? error) MakeSettableParent(int idx)
+        {
+            var plan = parentPlans[idx]!.Value;
+            if (plan.patchParent is not null) return (plan.patchParent, null);   // a prior-into= patch-local record
+            if (plan.body is not null)
+            {
+                Mutagen.Bethesda.Plugins.Cache.ILinkCache? cache = null;
+                if (WriteEngine.RecordNeedsSourceCache(plan.body))
+                {
+                    if (!linkCacheByPlugin.TryGetValue(plan.winnerPlugin!, out cache))
+                        linkCacheByPlugin[plan.winnerPlugin!] = (cache = session.LinkCacheFor(plan.winnerPlugin!))!;
+                }
+                return (WriteEngine.GenericGetOrAddAsOverride(patchMod, plan.body, cache), null);
+            }
+            if (!createdByEditorId.TryGetValue(plan.sibling!, out var sib))
+                return (null, $"internal: same-call parent '{plan.sibling}' for '{specs[idx].EditorId}' was not created before it — surfaced, not swallowed (Q3).");
+            return (sib, null);
+        }
+
         for (int i = 0; i < specs.Count; i++)
         {
             var s = specs[i];
             IMajorRecord rec; bool replaced = false;
             try
             {
-                if (s.ParentRef is null)
+                if (cellKinds[i] == CellCreate.Interior)
+                {
+                    // INTERIOR cell (coordinate-keyed §4-(b)): self-files into the patch's Cells group by FormID digits.
+                    rec = WriteEngine.AddInteriorCell(patchMod, s.EditorId);
+                }
+                else if (cellKinds[i] == CellCreate.Exterior)
+                {
+                    // EXTERIOR cell (coordinate-keyed §4-(b)): make the Worldspace settable (thin override), then place
+                    // the cell into its block tree by grid. Pre-flight (Phase 1) guaranteed a Worldspace parent + a grid that parses.
+                    var (wsParent, perr) = MakeSettableParent(i);
+                    if (perr is not null) return CreateOutcome.Fail(perr);
+                    TryParseGrid(s.Grid!, out var gx, out var gy);
+                    rec = WriteEngine.AddExteriorCell(patchMod, (Worldspace)wsParent!, gx, gy, s.EditorId);
+                }
+                else if (s.ParentRef is null)
                 {
                     (rec, replaced) = WriteEngine.GenericUpsertNew(patchMod, s.RecordType, s.EditorId);
                 }
                 else
                 {
-                    var plan = parentPlans[i]!.Value;
-                    IMajorRecord settableParent;
-                    if (plan.patchParent is not null)
-                    {
-                        // A parent created in a PRIOR into= call — already a settable patch-local record (Phase 0 opened
-                        // the patch); use it directly, no override.
-                        settableParent = plan.patchParent;
-                    }
-                    else if (plan.body is not null)
-                    {
-                        Mutagen.Bethesda.Plugins.Cache.ILinkCache? cache = null;
-                        if (WriteEngine.RecordNeedsSourceCache(plan.body))
-                        {
-                            if (!linkCacheByPlugin.TryGetValue(plan.winnerPlugin!, out cache))
-                                linkCacheByPlugin[plan.winnerPlugin!] = cache = session.LinkCacheFor(plan.winnerPlugin!);
-                        }
-                        settableParent = WriteEngine.GenericGetOrAddAsOverride(patchMod, plan.body, cache);
-                    }
-                    else
-                    {
-                        if (!createdByEditorId.TryGetValue(plan.sibling!, out var sib))
-                            return CreateOutcome.Fail($"internal: same-call parent '{plan.sibling}' for '{s.EditorId}' was not created before it — surfaced, not swallowed (Q3).");
-                        settableParent = sib;
-                    }
-                    rec = WriteEngine.NestedAddNew(patchMod, settableParent, s.RecordType, s.IntoCollection, s.EditorId);
+                    var (settableParent, perr) = MakeSettableParent(i);
+                    if (perr is not null) return CreateOutcome.Fail(perr);
+                    rec = WriteEngine.NestedAddNew(patchMod, settableParent!, s.RecordType, s.IntoCollection, s.EditorId);
                 }
             }
             catch (Exception ex) { return CreateOutcome.Fail($"could not create {s.RecordType} '{s.EditorId}': {ex.Message}"); }

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -152,6 +152,12 @@ public static class WritePatchBuilder
         /// pure record-write. See <see cref="DialogueScriptCheck"/>.</summary>
         public ScriptBindingReport? ScriptBinding { get; init; }
 
+        /// <summary>The structural-shell report for the cells this call created (the coordinate-keyed §4-(b) teeth —
+        /// what world content the author must still provide; Aaron 2026-06-20: no CK work) — null unless the call created
+        /// ≥1 Cell. Filled by the SERVICE post-write the SAME way as <see cref="Voice"/>, so <see cref="CreateRecords"/>
+        /// stays a pure record-write. See <see cref="CellShellCheck"/>.</summary>
+        public CellShellReport? CellShell { get; init; }
+
         public static CreateOutcome Fail(string error) =>
             new(false, error, "", false, Array.Empty<CreatedRecord>(), Array.Empty<string>(), 0);
     }

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Cache;
@@ -183,7 +184,9 @@ public static class WritePatchBuilder
         x = y = 0;
         if (string.IsNullOrWhiteSpace(grid)) return false;
         var parts = grid.Split(',');
-        return parts.Length == 2 && int.TryParse(parts[0].Trim(), out x) && int.TryParse(parts[1].Trim(), out y);
+        return parts.Length == 2
+            && int.TryParse(parts[0].Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out x)
+            && int.TryParse(parts[1].Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out y);
     }
 
     /// <summary>Build/extend a patch from <paramref name="edits"/> and serialize it to <paramref name="outPath"/>.

--- a/src/housecarl-generator/BulkCreateGuardProbe.cs
+++ b/src/housecarl-generator/BulkCreateGuardProbe.cs
@@ -31,6 +31,7 @@ namespace HousecarlGenerator;
 ///                report rides back (the §4-(b) coordinate-keyed wire: grid= threads service→core; the "you must still
 ///                provide lighting/terrain/navmesh" teeth fire).
 ///   INTERIOR-WIRE — create_record 'Cell' with NO parent + NO grid creates an interior cell with its INTERIOR shell report.
+///   MULTI        — bulk_create of an exterior + an interior cell lists BOTH in one shell report (the >1-cell path).
 /// </summary>
 internal static class BulkCreateGuardProbe
 {
@@ -149,6 +150,21 @@ internal static class BulkCreateGuardProbe
                 bool inter = shell is not null && shell.Cells.Count == 1 && shell.Cells[0].Interior && shell.Cells[0].MustProvide.Count > 0;
                 Check(o.Success && o.Created.Count == 1 && o.Created[0].FormKey.ID >= 0x800 && inter,
                     $"INTERIOR-WIRE Cell with no parent → created + INTERIOR shell report — {(o.Success ? (inter ? "interior shell w/ must-provide" : "shell missing/wrong") : "err=[" + o.Error + "]")}");
+            }
+
+            // ---- MULTI: bulk_create an exterior + an interior cell in ONE call → the shell report lists BOTH (the >1-cell
+            //      report path, untested by the single-cell arms; PR #94 review nit). ----
+            {
+                var records = new[]
+                {
+                    new CreateOp { RecordType = "Cell", Editorid = "HcBcMExt", Parent = worldFk.ToString(), Grid = "200,200" },
+                    new CreateOp { RecordType = "Cell", Editorid = "HcBcMInt" },
+                };
+                var o = svc.CreateRecordsBatch(records, "HcBcMulti", null);
+                var shell = o.CellShell;
+                bool two = shell is not null && shell.Cells.Count == 2 && shell.Cells.Any(c => c.Interior) && shell.Cells.Any(c => !c.Interior);
+                Check(o.Success && o.Created.Count == 2 && two,
+                    $"MULTI bulk_create exterior + interior → shell lists BOTH — {(o.Success ? (two ? "2 cells (1 ext, 1 int)" : "shell wrong: count=" + (shell?.Cells.Count.ToString() ?? "null")) : "err=[" + o.Error + "]")}");
             }
         }
         catch (Exception ex)

--- a/src/housecarl-generator/BulkCreateGuardProbe.cs
+++ b/src/housecarl-generator/BulkCreateGuardProbe.cs
@@ -27,6 +27,10 @@ namespace HousecarlGenerator;
 ///                naming the problem, with the valid 1st spec NOT written and no orphan folder (all-or-nothing, Q3).
 ///   GUIDANCE   — a single nested create with no parent refuses loud and the message guides to parent= / bulk_create
 ///                (the refreshed CanCreateType copy reaches the user).
+///   EXTERIOR-WIRE — create_record 'Cell' with parent=<worldspace> + grid= creates an exterior cell AND the CellShell
+///                report rides back (the §4-(b) coordinate-keyed wire: grid= threads service→core; the "you must still
+///                provide lighting/terrain/navmesh" teeth fire).
+///   INTERIOR-WIRE — create_record 'Cell' with NO parent + NO grid creates an interior cell with its INTERIOR shell report.
 /// </summary>
 internal static class BulkCreateGuardProbe
 {
@@ -53,11 +57,13 @@ internal static class BulkCreateGuardProbe
             var mKey = new ModKey("HcBcGdMaster", ModType.Master);
             var modDir = Path.Combine(mods, "MasterMod");
             Directory.CreateDirectory(modDir);
-            FormKey topicFk;
+            FormKey topicFk, worldFk;
             {
                 var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
                 var topic = m.DialogTopics.AddNew(); topic.EditorID = "HcBcGdTopic";
                 topicFk = topic.FormKey;
+                var world = m.Worldspaces.AddNew(); world.EditorID = "HcBcGdWorld";   // the exterior-cell parent fixture (coord-keyed wire)
+                worldFk = world.FormKey;
                 m.BeginWrite.ToPath(Path.Combine(modDir, mKey.FileName.String)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
             }
             File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + mKey.FileName + "\r\n");
@@ -124,6 +130,25 @@ internal static class BulkCreateGuardProbe
                     && o.Error.Contains("parent", StringComparison.OrdinalIgnoreCase)
                     && o.Error.Contains("bulk_create", StringComparison.OrdinalIgnoreCase);
                 Check(guided, $"GUIDANCE nested-with-no-parent refused + guides to parent=/bulk_create — guided={guided} err=[{o.Error}]");
+            }
+
+            // ---- EXTERIOR-WIRE: create_record Cell with parent=<worldspace> + grid= → exterior cell + shell report ----
+            //      Proves the grid= param threads service→core AND the CellShell teeth fire (Aaron's "you must fill" report).
+            {
+                var o = svc.CreateRecords("Cell", "HcBcExtCell", Array.Empty<BulkOp>(), "HcBcExt", null, parent: worldFk.ToString(), grid: "1000,-1000");
+                var shell = o.CellShell;
+                bool ext = shell is not null && shell.Cells.Count == 1 && !shell.Cells[0].Interior && shell.Cells[0].MustProvide.Count > 0;
+                Check(o.Success && o.Created.Count == 1 && o.Created[0].FormKey.ID >= 0x800 && ext,
+                    $"EXTERIOR-WIRE Cell via parent=worldspace + grid → created + EXTERIOR shell report — {(o.Success ? (ext ? "exterior shell w/ must-provide" : "shell missing/wrong") : "err=[" + o.Error + "]")}");
+            }
+
+            // ---- INTERIOR-WIRE: create_record Cell with NO parent + NO grid → interior cell + shell report ----
+            {
+                var o = svc.CreateRecords("Cell", "HcBcIntCell", Array.Empty<BulkOp>(), "HcBcInt", null);
+                var shell = o.CellShell;
+                bool inter = shell is not null && shell.Cells.Count == 1 && shell.Cells[0].Interior && shell.Cells[0].MustProvide.Count > 0;
+                Check(o.Success && o.Created.Count == 1 && o.Created[0].FormKey.ID >= 0x800 && inter,
+                    $"INTERIOR-WIRE Cell with no parent → created + INTERIOR shell report — {(o.Success ? (inter ? "interior shell w/ must-provide" : "shell missing/wrong") : "err=[" + o.Error + "]")}");
             }
         }
         catch (Exception ex)

--- a/src/housecarl-generator/CoordCellGuardProbe.cs
+++ b/src/housecarl-generator/CoordCellGuardProbe.cs
@@ -28,6 +28,8 @@ namespace HousecarlGenerator;
 ///   REJ-NOGRID  — a Cell + a Worldspace parent but NO grid refuses loud (ambiguous), NO file written.
 ///   REJ-BADGRID — a Cell + a Worldspace parent + a non-numeric grid refuses loud (the "X,Y" format), NO file written.
 ///   REJ-NONWS   — a Cell + grid with a NON-Worldspace (Weapon) parent refuses loud, NO file written.
+///   DUP-REJECT  — an into= re-run of the SAME cell editorid refuses loud (no silent duplicate — cells carry a stable
+///                 EditorID, so the flat nested-children append carve-out does NOT transfer; PR #94 review).
 /// </summary>
 public static class CoordCellGuardProbe
 {
@@ -149,6 +151,20 @@ public static class CoordCellGuardProbe
         results.Add(RejectArm("REJ-NONWS  grid + Weapon parent", tmpDir, "RejNonWs", mPath, rulebook,
             new[] { new WritePatchBuilder.CreateSpec { RecordType = "Cell", EditorId = "HcCcRej4", ParentRef = masterWeapFk.ToString(), Grid = "1,2", Edits = Array.Empty<WriteRequest>() } },
             msg => msg.Contains("Worldspace", StringComparison.OrdinalIgnoreCase)));
+
+        // ---- DUP-REJECT: an into= re-run of the SAME cell editorid refuses loud (no silent duplicate — cells carry a
+        //      stable EditorID, so the flat nested-children append carve-out does not transfer; PR #94 review). ----
+        {
+            string pPath = Path.Combine(tmpDir, "HcCcDup.esp");
+            using var r = LoadOrderResolver.Build(new[] { mPath });
+            var spec = new[] { new WritePatchBuilder.CreateSpec { RecordType = "Cell", EditorId = "HcCcDupCell", Edits = Array.Empty<WriteRequest>() } };
+            var o1 = WritePatchBuilder.CreateRecords(r, rulebook, spec, pPath, extend: false);
+            var o2 = WritePatchBuilder.CreateRecords(r, rulebook, spec, pPath, extend: true);   // into= the same patch, same editorid
+            bool firstOk = o1.Success && o1.Created.Count == 1;
+            bool refused = !o2.Success && (o2.Error ?? "").Contains("already exists", StringComparison.OrdinalIgnoreCase);
+            results.Add(("DUP-REJECT into= duplicate cell editorid", firstOk && refused,
+                $"first-created={YN(firstOk)} re-run-refused={YN(refused)} err=[{(o2.Error ?? "").Replace('\n', ' ')}]"));
+        }
 
         bool srcOk = shaBefore == Sha(mPath);
 

--- a/src/housecarl-generator/CoordCellGuardProbe.cs
+++ b/src/housecarl-generator/CoordCellGuardProbe.cs
@@ -1,0 +1,245 @@
+using System.Security.Cryptography;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SELF-CONTAINED CI REGRESSION GUARD for COORDINATE-KEYED cell CREATE (the §4-(b) seam —
+/// <c>dev/plans/COORD_KEYED_CELL_CREATE_BUILD_2026-06-20.md</c>), in the pattern of nested-create-guard. Drives the REAL
+/// product path (<see cref="WritePatchBuilder.CreateRecords"/>) against a SYNTHESIZED master in TEMP — NO Skyrim.esm, so
+/// it runs in CI (the manual <see cref="CoordCellProbe"/> scout samples vanilla). The master carries a Worldspace (the
+/// exterior-cell parent) + a Weapon (the non-Worldspace-parent reject target). Where the scout proved the Mutagen block
+/// math in isolation, this proves the mechanism THROUGH the production cleave — parent override → AddExteriorCell /
+/// AddInteriorCell → multi-master serialize → re-open from disk.
+/// Run: dotnet run --project src/housecarl-generator -- coord-cell-guard
+///
+/// Arms (ALL required — a GREEN must mean "the contract holds", never "the scenario doesn't arise here"):
+///   EXTERIOR    — a Cell created with parent=&lt;Worldspace FormKey&gt; + grid="1000,-1000" lands under
+///                 block(31,-32)/subblock(125,-125) on disk, grid (1000,-1000), local 0x800+ (block math, real path).
+///   INTERIOR    — a Cell created with NO parent + NO grid self-files into the Cells group at block=id%10/
+///                 subblock=(id/10)%10, IsInteriorCell ON, local 0x800+.
+///   PLACED      — a one-shot exterior Cell + a PlacedObject parent=&lt;that cell's editorid&gt; collection=Temporary:
+///                 the ref lands in the new cell's Temporary (Placed-into-not-yet-present-cell rides the sibling path).
+///   REJ-NOWS    — a Cell + grid with NO parent refuses loud (an exterior cell needs a Worldspace), NO file written.
+///   REJ-NOGRID  — a Cell + a Worldspace parent but NO grid refuses loud (ambiguous), NO file written.
+///   REJ-BADGRID — a Cell + a Worldspace parent + a non-numeric grid refuses loud (the "X,Y" format), NO file written.
+///   REJ-NONWS   — a Cell + grid with a NON-Worldspace (Weapon) parent refuses loud, NO file written.
+/// </summary>
+public static class CoordCellGuardProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  REGRESSION GUARD — COORDINATE-KEYED cell CREATE (§4-(b))  ################");
+        Console.WriteLine();
+
+        var tmpDir = Path.Combine(Path.GetTempPath(), "hc-coord-cell-guard");
+        if (Directory.Exists(tmpDir)) Directory.Delete(tmpDir, recursive: true);
+        Directory.CreateDirectory(tmpDir);
+
+        // --- Setup: a master carrying a Worldspace (the exterior-cell parent) + a Weapon (the non-Worldspace reject). ---
+        var mKey = new ModKey("HcCcGdMaster", ModType.Master);
+        string mPath = Path.Combine(tmpDir, mKey.FileName.String);
+        FormKey masterWsFk, masterWeapFk;
+        try
+        {
+            var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
+            var ws = m.Worldspaces.AddNew(); ws.EditorID = "HcCcWorld";
+            masterWsFk = ws.FormKey;
+            var w = m.Weapons.AddNew(); w.EditorID = "HcCcWeap"; w.BasicStats = new WeaponBasicStats { Damage = 10 };
+            masterWeapFk = w.FormKey;
+            m.BeginWrite.ToPath(mPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"error: could not synthesize the fixture master: {ex.GetType().Name}: {(ex.InnerException ?? ex).Message}");
+            try { Directory.Delete(tmpDir, recursive: true); } catch { }
+            return 1;
+        }
+
+        bool fixturesOk;
+        using (var r = LoadOrderResolver.Build(new[] { mPath }))
+        {
+            var view = r.Capture();
+            fixturesOk = view.ResolveWinner(masterWsFk) is not null && view.ResolveWinner(masterWeapFk) is not null;
+        }
+        var genDir = Path.Combine(tmpDir, "corpus-gen");
+        CorpusGenerator.GenerateAll(genDir, Path.Combine(tmpDir, "corpus-ref"));
+        var rulebook = CorpusRulebook.Load(Path.Combine(genDir, "corpus.json"));
+        var shaBefore = Sha(mPath);
+        Console.WriteLine($"-- setup: master {mKey.FileName} with worldspace {masterWsFk}, weapon {masterWeapFk}; fixtures-resolve={fixturesOk}; corpus generated --");
+        Console.WriteLine();
+
+        var results = new List<(string name, bool pass, string detail)>();
+
+        // ---------- EXTERIOR: a Cell placed by grid under the Worldspace ----------
+        {
+            string pPath = Path.Combine(tmpDir, "HcCcExterior.esp");
+            int gx = 1000, gy = -1000;
+            int bx = FloorDiv(gx, 32), by = FloorDiv(gy, 32), sx = FloorDiv(gx, 8), sy = FloorDiv(gy, 8);
+            var specs = new[] { new WritePatchBuilder.CreateSpec { RecordType = "Cell", EditorId = "HcCcExtCell", ParentRef = masterWsFk.ToString(), Grid = $"{gx},{gy}", Edits = Array.Empty<WriteRequest>() } };
+            using var r = LoadOrderResolver.Build(new[] { mPath });
+            var o = WritePatchBuilder.CreateRecords(r, rulebook, specs, pPath, extend: false);
+            bool ok = o.Success && o.Created.Count == 1;
+            var cellFk = ok ? o.Created[0].FormKey : default;
+            var loc = ok ? LocateExterior(pPath, masterWsFk, cellFk) : null;
+            bool present = loc.HasValue;
+            bool placedRight = loc is { } l && l.bx == bx && l.by == by && l.sx == sx && l.sy == sy;
+            bool gridOk = loc is { } g && g.gx == gx && g.gy == gy;
+            bool floored = ok && cellFk.ID >= 0x800 && cellFk.ModKey.FileName.String == "HcCcExterior.esp";
+            bool pass = ok && present && placedRight && gridOk && floored;
+            results.Add(("EXTERIOR cell by grid", pass,
+                $"created={YN(ok)} present={YN(present)} block/sub-correct={YN(placedRight)} grid-correct={YN(gridOk)} local>=0x800={YN(floored)}{Err(o)}"));
+        }
+
+        // ---------- INTERIOR: a parentless Cell self-files by FormID digits ----------
+        {
+            string pPath = Path.Combine(tmpDir, "HcCcInterior.esp");
+            var specs = new[] { new WritePatchBuilder.CreateSpec { RecordType = "Cell", EditorId = "HcCcIntCell", Edits = Array.Empty<WriteRequest>() } };
+            using var r = LoadOrderResolver.Build(new[] { mPath });
+            var o = WritePatchBuilder.CreateRecords(r, rulebook, specs, pPath, extend: false);
+            bool ok = o.Success && o.Created.Count == 1;
+            var cellFk = ok ? o.Created[0].FormKey : default;
+            var loc = ok ? LocateInterior(pPath, cellFk) : null;
+            bool present = loc.HasValue;
+            bool placedRight = loc is { } l && l.block == (int)(cellFk.ID % 10) && l.sub == (int)((cellFk.ID / 10) % 10);
+            bool interior = loc is { } l2 && l2.interior;
+            bool floored = ok && cellFk.ID >= 0x800 && cellFk.ModKey.FileName.String == "HcCcInterior.esp";
+            bool pass = ok && present && placedRight && interior && floored;
+            results.Add(("INTERIOR cell by FormID digits", pass,
+                $"created={YN(ok)} present={YN(present)} block/sub-correct={YN(placedRight)} interior-flag={YN(interior)} local>=0x800={YN(floored)}{Err(o)}"));
+        }
+
+        // ---------- PLACED: one-shot exterior cell + a PlacedObject into its Temporary (sibling nested path) ----------
+        {
+            string pPath = Path.Combine(tmpDir, "HcCcPlaced.esp");
+            var specs = new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "Cell", EditorId = "HcCcPCell", ParentRef = masterWsFk.ToString(), Grid = "1500,1500", Edits = Array.Empty<WriteRequest>() },
+                new WritePatchBuilder.CreateSpec { RecordType = "PlacedObject", EditorId = "HcCcPRef", ParentRef = "HcCcPCell", IntoCollection = "Temporary", Edits = Array.Empty<WriteRequest>() },
+            };
+            using var r = LoadOrderResolver.Build(new[] { mPath });
+            var o = WritePatchBuilder.CreateRecords(r, rulebook, specs, pPath, extend: false);
+            bool ok = o.Success && o.Created.Count == 2;
+            var cellFk = ok ? o.Created[0].FormKey : default;
+            var refFk = ok ? o.Created[1].FormKey : default;
+            var temp = ok ? CellTemporary(pPath, masterWsFk, cellFk) : null;
+            bool refUnder = temp is not null && temp.Contains(refFk);
+            bool pass = ok && refUnder;
+            results.Add(("PLACED into new exterior cell", pass,
+                $"created={(o.Success ? o.Created.Count : 0)} ref-in-temporary={YN(refUnder)}{Err(o)}"));
+        }
+
+        // ---------- REJECT arms (all-or-nothing, no file written, message named) ----------
+        results.Add(RejectArm("REJ-NOWS   grid, no parent", tmpDir, "RejNoWs", mPath, rulebook,
+            new[] { new WritePatchBuilder.CreateSpec { RecordType = "Cell", EditorId = "HcCcRej1", Grid = "1,2", Edits = Array.Empty<WriteRequest>() } },
+            msg => msg.Contains("Worldspace", StringComparison.OrdinalIgnoreCase)));
+
+        results.Add(RejectArm("REJ-NOGRID parent, no grid", tmpDir, "RejNoGrid", mPath, rulebook,
+            new[] { new WritePatchBuilder.CreateSpec { RecordType = "Cell", EditorId = "HcCcRej2", ParentRef = masterWsFk.ToString(), Edits = Array.Empty<WriteRequest>() } },
+            msg => msg.Contains("grid", StringComparison.OrdinalIgnoreCase)));
+
+        results.Add(RejectArm("REJ-BADGRID non-numeric grid", tmpDir, "RejBadGrid", mPath, rulebook,
+            new[] { new WritePatchBuilder.CreateSpec { RecordType = "Cell", EditorId = "HcCcRej3", ParentRef = masterWsFk.ToString(), Grid = "abc", Edits = Array.Empty<WriteRequest>() } },
+            msg => msg.Contains("X,Y", StringComparison.OrdinalIgnoreCase) || msg.Contains("two integers", StringComparison.OrdinalIgnoreCase)));
+
+        results.Add(RejectArm("REJ-NONWS  grid + Weapon parent", tmpDir, "RejNonWs", mPath, rulebook,
+            new[] { new WritePatchBuilder.CreateSpec { RecordType = "Cell", EditorId = "HcCcRej4", ParentRef = masterWeapFk.ToString(), Grid = "1,2", Edits = Array.Empty<WriteRequest>() } },
+            msg => msg.Contains("Worldspace", StringComparison.OrdinalIgnoreCase)));
+
+        bool srcOk = shaBefore == Sha(mPath);
+
+        // ---- VERDICT ----
+        Console.WriteLine("Results:");
+        foreach (var (name, pass, detail) in results)
+            Console.WriteLine($"  [{(pass ? "PASS" : "FAIL")}] {name,-32} {detail}");
+        Console.WriteLine($"  [{(srcOk ? "PASS" : "FAIL")}] {"master byte-untouched",-32}");
+        Console.WriteLine();
+        bool allPass = results.All(r => r.pass) && srcOk;
+        Console.WriteLine(allPass
+            ? "=== ALL CHECKS PASS — coordinate-keyed cell create proven through the production create cleave\n" +
+              "    (exterior by grid, interior by FormID digits, placed-into-new-cell, + the malformed rejects). ==="
+            : "=== FAIL — see the checks above (a !! is the thing to resolve). ===");
+        try { Directory.Delete(tmpDir, recursive: true); } catch { }
+        return allPass ? 0 : 1;
+    }
+
+    /// <summary>A REJECT arm: drive CreateRecords expecting refusal, assert NO file written + the message matches.</summary>
+    static (string, bool, string) RejectArm(string name, string tmpDir, string tag, string mPath, CorpusRulebook rulebook,
+        WritePatchBuilder.CreateSpec[] specs, Func<string, bool> msgOk)
+    {
+        string outPath = Path.Combine(tmpDir, $"HcCc_{tag}.esp");
+        using var r = LoadOrderResolver.Build(new[] { mPath });
+        var o = WritePatchBuilder.CreateRecords(r, rulebook, specs, outPath, extend: false);
+        bool refused = !o.Success;
+        bool named = refused && msgOk(o.Error ?? "");
+        bool noFile = !File.Exists(outPath);
+        bool pass = refused && named && noFile;
+        return (name, pass, $"refused={YN(refused)} msg-named={YN(named)} no-file={YN(noFile)}" + (refused ? "" : $"  (unexpectedly wrote; created={o.Created.Count})"));
+    }
+
+    // ---- re-open helpers ----
+
+    static (int bx, int by, int sx, int sy, int gx, int gy)? LocateExterior(string path, FormKey wsFk, FormKey cellFk)
+    {
+        ISkyrimModGetter? back = null;
+        try
+        {
+            back = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE);
+            var ws = back.Worldspaces.FirstOrDefault(w => w.FormKey == wsFk);
+            if (ws is null) return null;
+            foreach (var b in ws.SubCells ?? Enumerable.Empty<IWorldspaceBlockGetter>())
+                foreach (var s in b.Items ?? Enumerable.Empty<IWorldspaceSubBlockGetter>())
+                    foreach (var c in s.Items ?? Enumerable.Empty<ICellGetter>())
+                        if (c.FormKey == cellFk && c.Grid is not null)
+                            return (b.BlockNumberX, b.BlockNumberY, s.BlockNumberX, s.BlockNumberY, c.Grid.Point.X, c.Grid.Point.Y);
+            return null;
+        }
+        catch { return null; }
+        finally { (back as IDisposable)?.Dispose(); }
+    }
+
+    static List<FormKey>? CellTemporary(string path, FormKey wsFk, FormKey cellFk)
+    {
+        ISkyrimModGetter? back = null;
+        try
+        {
+            back = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE);
+            var ws = back.Worldspaces.FirstOrDefault(w => w.FormKey == wsFk);
+            if (ws is null) return null;
+            foreach (var b in ws.SubCells ?? Enumerable.Empty<IWorldspaceBlockGetter>())
+                foreach (var s in b.Items ?? Enumerable.Empty<IWorldspaceSubBlockGetter>())
+                    foreach (var c in s.Items ?? Enumerable.Empty<ICellGetter>())
+                        if (c.FormKey == cellFk)
+                            return c.Temporary?.Select(x => x.FormKey).ToList() ?? new List<FormKey>();
+            return null;
+        }
+        catch { return null; }
+        finally { (back as IDisposable)?.Dispose(); }
+    }
+
+    static (int block, int sub, bool interior)? LocateInterior(string path, FormKey cellFk)
+    {
+        ISkyrimModGetter? back = null;
+        try
+        {
+            back = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE);
+            foreach (var b in back.Cells.Records)
+                foreach (var s in b.SubBlocks ?? Enumerable.Empty<ICellSubBlockGetter>())
+                    foreach (var c in s.Cells ?? Enumerable.Empty<ICellGetter>())
+                        if (c.FormKey == cellFk)
+                            return (b.BlockNumber, s.BlockNumber, c.Flags.HasFlag(Cell.Flag.IsInteriorCell));
+            return null;
+        }
+        catch { return null; }
+        finally { (back as IDisposable)?.Dispose(); }
+    }
+
+    static int FloorDiv(int a, int b) => (int)Math.Floor((double)a / b);
+    static string Err(WritePatchBuilder.CreateOutcome o) => o.Success ? "" : "  err=" + (o.Error ?? "").Replace('\n', ' ');
+    static string YN(bool b) => b ? "Y" : "N";
+    static string Sha(string p) { using var s = File.OpenRead(p); using var h = SHA256.Create(); return Convert.ToHexString(h.ComputeHash(s)); }
+}

--- a/src/housecarl-generator/CoordCellProbe.cs
+++ b/src/housecarl-generator/CoordCellProbe.cs
@@ -1,0 +1,329 @@
+using System.Collections;
+using System.Reflection;
+using System.Security.Cryptography;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using Noggog;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// STEP 0 SCOUT — COORDINATE-KEYED nested CREATE (the §4-(b) seam the nested/dialogue plan deferred).
+/// Throwaway recon, not a standing instrument. Writes to a temp dir; touches no tracked file; SHA-guards the source.
+///
+/// <see cref="NestedCreateProbe"/> proved the FormKey-parented families (INFO under a DialogTopic; Placed into an
+/// already-overridden Cell) and CHARACTERIZED — but never round-tripped — the coordinate-keyed seam: exterior Cell,
+/// interior Cell, and Placed-into-a-not-yet-present-cell, whose structural parents are the FormKey-LESS
+/// WorldspaceBlock/WorldspaceSubBlock (exterior) and CellBlock/CellSubBlock (interior) structs. Aaron's call (2026-06-20):
+/// CLOSE THE GAP — so this scout answers the BUILD questions, fail-loud per shape (Q3):
+///
+///   B  OVERRIDE SHAPE — does GetOrAddAsOverride(Worldspace) come back THIN (empty SubCells, so adding one cell costs
+///      one block path) or DEEP (carries all of Tamriel's cells, so a one-cell add would override the whole worldspace)?
+///      Decides the whole build approach.
+///   C  BLOCK MATH — does the exterior 32-cell-block / 8-cell-subblock division (floored, incl. negatives) and the
+///      interior FormID-digit keying MATCH vanilla? Confirms the arithmetic against real data, never assumed.
+///   D  EXTERIOR ROUND-TRIP — construct a new exterior Cell with a Grid, compute its block/subblock, find-or-CONSTRUCT
+///      the WorldspaceBlock + WorldspaceSubBlock, add the cell, serialize, RE-OPEN clean: cell present under the right
+///      block/subblock, FormKey local 0x800+, OFST regenerated, source byte-unchanged. + a Placed ref into the new cell.
+///   E  INTERIOR ROUND-TRIP — same, into the top-level Cells group (CellBlock/CellSubBlock by FormID digits).
+///
+/// If a round-trip won't serialize/reopen, or OFST drops the cell, or the override is unavoidably DEEP: STOP and surface
+/// to Aaron (§4-(b) stays a declared loud-fail boundary), never a per-type shim.
+///
+/// Run: <c>dotnet run --project src/housecarl-generator -- coord-cell-probe [sourcePlugin]</c>
+/// </summary>
+public static class CoordCellProbe
+{
+    const string DefaultSource = @"E:\Skyrim Modding\ARR 2.0\Stock Game\Data\Skyrim.esm";
+    static readonly FormKey Tamriel = FormKey.Factory("00003C:Skyrim.esm");
+
+    public static int RunProbe(string[] args)
+    {
+        var src = args.Length > 0 && !args[0].StartsWith("--") ? args[0] : DefaultSource;
+        var asm = typeof(IArmorGetter).Assembly;
+
+        Console.WriteLine("################  STEP 0 SCOUT — COORDINATE-KEYED nested CREATE (exterior/interior Cell, Placed-into-new-cell)  ################");
+        Console.WriteLine($"source: {src}");
+        Console.WriteLine();
+        if (!File.Exists(src)) { Console.Error.WriteLine($"error: source plugin not found: {src}"); return 1; }
+
+        var shaBefore = Sha(src);
+        var sourceMod = SkyrimMod.CreateFromBinaryOverlay(src, SkyrimRelease.SkyrimSE);
+        var cache = sourceMod.ToImmutableLinkCache();
+
+        var outDir = Path.Combine(Path.GetTempPath(), "hc-coord-cell-probe");
+        if (Directory.Exists(outDir)) Directory.Delete(outDir, recursive: true);
+        Directory.CreateDirectory(outDir);
+
+        bool extOk = true, intOk = true, placedOk = true;
+
+        // ============================================================ PHASE A : structure discovery ============================================================
+        Console.WriteLine("===== PHASE A : exact shapes (reflection — measure, don't assume) =====");
+        DumpType("Worldspace", typeof(Worldspace), "SubCells", "OffsetData");
+        DumpType("WorldspaceBlock", typeof(WorldspaceBlock), "BlockNumberX", "BlockNumberY", "GroupType", "Items");
+        DumpType("WorldspaceSubBlock", typeof(WorldspaceSubBlock), "BlockNumberX", "BlockNumberY", "GroupType", "Items");
+        DumpType("Cell", typeof(Cell), "Grid", "Flags");
+        DumpType("CellGrid", typeof(CellGrid), "Point", "Flags");
+        DumpType("Cells (interior top-level group)", typeof(SkyrimMod).GetProperty("Cells")!.PropertyType, "Records");
+        DumpType("CellBlock", typeof(CellBlock), "BlockNumber", "GroupType", "SubBlocks");
+        DumpType("CellSubBlock", typeof(CellSubBlock), "BlockNumber", "GroupType", "Cells");
+        Console.WriteLine($"   GroupTypeEnum values: {string.Join(", ", Enum.GetNames(typeof(GroupTypeEnum)))}");
+        Console.WriteLine($"   Cell.Flag values (interior bit): {(Enum.GetNames(typeof(Cell.Flag)).FirstOrDefault(n => n.Contains("Interior")) ?? "(none named *Interior*)")}");
+        Console.WriteLine();
+
+        // ============================================================ PHASE B : override shape (thin vs deep) ============================================================
+        Console.WriteLine("===== PHASE B : GetOrAddAsOverride(Worldspace Tamriel) — THIN or DEEP? =====");
+        var wsGetter = cache.Resolve<IWorldspaceGetter>(Tamriel);
+        int srcBlocks = wsGetter.SubCells?.Count ?? 0;
+        int srcCells = CountWsCells(wsGetter.SubCells);
+        Console.WriteLine($"   SOURCE Tamriel: SubCells blocks={srcBlocks}  total exterior cells (overlay, lazy)≈{srcCells}");
+        Console.WriteLine($"   SOURCE Tamriel OffsetData (OFST seek-cache): {(wsGetter.OffsetData.HasValue ? wsGetter.OffsetData.Value.Length + " bytes present" : "absent")}  (Mutagen drops it on write — see PHASE D OFST=)");
+        {
+            var patch = new SkyrimMod(new ModKey("hc_ws_shape", ModType.Plugin), SkyrimRelease.SkyrimSE);
+            var wsOv = (Worldspace)WriteEngine.GenericGetOrAddAsOverride(patch, wsGetter, cache);
+            int ovBlocks = wsOv.SubCells?.Count ?? 0;
+            int ovCells = CountWsCellsSettable(wsOv.SubCells);
+            Console.WriteLine($"   OVERRIDE: SubCells blocks={ovBlocks}  cells={ovCells}  ==>  {(ovCells == 0 ? "THIN (empty SubCells — add the one new block path, clean)" : ovCells >= srcCells && srcCells > 0 ? "DEEP (carries the whole worldspace — a one-cell add would override everything; build must thin it)" : $"PARTIAL ({ovCells} cells carried)")}");
+        }
+        Console.WriteLine();
+
+        // ============================================================ PHASE C : block math vs vanilla ============================================================
+        Console.WriteLine("===== PHASE C : block arithmetic vs vanilla (exterior /32 block, /8 subblock, floored) =====");
+        {
+            int chec99 = 0, ext = 0, extMatch = 0;
+            foreach (var block in wsGetter.SubCells ?? Enumerable.Empty<IWorldspaceBlockGetter>())
+            {
+                foreach (var sub in block.Items ?? Enumerable.Empty<IWorldspaceSubBlockGetter>())
+                foreach (var c in sub.Items ?? Enumerable.Empty<ICellGetter>())
+                {
+                    if (c.Grid is null) continue;
+                    int gx = c.Grid.Point.X, gy = c.Grid.Point.Y;
+                    bool bm = block.BlockNumberX == FloorDiv(gx, 32) && block.BlockNumberY == FloorDiv(gy, 32);
+                    bool sm = sub.BlockNumberX == FloorDiv(gx, 8) && sub.BlockNumberY == FloorDiv(gy, 8);
+                    ext++; if (bm && sm) extMatch++;
+                    else if (chec99 < 6) { Console.WriteLine($"     MISMATCH grid=({gx},{gy}) block=({block.BlockNumberX},{block.BlockNumberY}) exp=({FloorDiv(gx,32)},{FloorDiv(gy,32)}) sub=({sub.BlockNumberX},{sub.BlockNumberY}) exp=({FloorDiv(gx,8)},{FloorDiv(gy,8)})"); chec99++; }
+                    if (ext >= 4000) goto doneExt;
+                }
+            }
+            doneExt:
+            Console.WriteLine($"   EXTERIOR: {extMatch}/{ext} sampled cells match block=floor(grid/32), subblock=floor(grid/8)  => {(ext > 0 && extMatch == ext ? "CONFIRMED" : "!! divisor/floor wrong — read mismatches")}");
+        }
+        {
+            // interior keying: derive from vanilla — block & subblock vs FormID decimal digits.
+            int interior = 0, match = 0, shown = 0;
+            foreach (var cb in sourceMod.Cells.Records)
+            {
+                foreach (var sb in cb.SubBlocks ?? Enumerable.Empty<ICellSubBlockGetter>())
+                foreach (var c in sb.Cells ?? Enumerable.Empty<ICellGetter>())
+                {
+                    uint id = c.FormKey.ID;
+                    bool m = cb.BlockNumber == (int)(id % 10) && sb.BlockNumber == (int)((id / 10) % 10);
+                    interior++; if (m) match++;
+                    else if (shown < 6) { Console.WriteLine($"     INT MISMATCH id=0x{id:X6}({id}) block={cb.BlockNumber} exp={id%10} sub={sb.BlockNumber} exp={(id/10)%10}"); shown++; }
+                    if (interior >= 2000) goto doneInt;
+                }
+            }
+            doneInt:
+            Console.WriteLine($"   INTERIOR: {match}/{interior} sampled cells match block=id%10, subblock=(id/10)%10  => {(interior > 0 && match == interior ? "CONFIRMED" : "!! interior keying differs — read mismatches")}");
+        }
+        Console.WriteLine();
+
+        // ============================================================ PHASE D : EXTERIOR round-trip ============================================================
+        Console.WriteLine("===== PHASE D : EXTERIOR cell create (construct block+subblock from Grid) + Placed-into-it =====");
+        try
+        {
+            var patch = new SkyrimMod(new ModKey("hc_ext_cell", ModType.Plugin), SkyrimRelease.SkyrimSE);
+            WriteEngine.EnsureFormIdFloor(patch);
+            var wsOv = (Worldspace)WriteEngine.GenericGetOrAddAsOverride(patch, wsGetter, cache);
+
+            // a deliberately far-flung empty grid → guarantees a NEW block + NEW subblock (exercises the construct path).
+            int gx = 1000, gy = -1000;
+            int bx = FloorDiv(gx, 32), by = FloorDiv(gy, 32), sx = FloorDiv(gx, 8), sy = FloorDiv(gy, 8);
+            var cellFk = patch.GetNextFormKey("HC_S0_ExtCell");
+            var cell = new Cell(cellFk, SkyrimRelease.SkyrimSE)
+            {
+                Grid = new CellGrid { Point = new P2Int(gx, gy) },
+                Flags = default,   // exterior: IsInteriorCell OFF
+            };
+            var (block, sub) = FindOrAddExteriorBlock(wsOv, bx, by, sx, sy);
+            sub.Items.Add(cell);
+
+            // Placed ref into the new cell's Temporary.
+            var refFk = patch.GetNextFormKey("HC_S0_ExtRef");
+            var placed = new PlacedObject(refFk, SkyrimRelease.SkyrimSE);
+            cell.Temporary.Add(placed);
+
+            var outPath = Path.Combine(outDir, patch.ModKey.FileName);
+            WriteEngine.WritePatch(patch, sourceMod, outPath);
+            using var back = SkyrimMod.CreateFromBinaryOverlay(outPath, SkyrimRelease.SkyrimSE);
+            var backWs = back.Worldspaces.FirstOrDefault(w => w.FormKey == Tamriel);
+            var (reBlock, reSub, reCell) = LocateExteriorCell(backWs?.SubCells, cellFk);
+            bool present = reCell is not null;
+            bool gridOk = reCell?.Grid is { } g && g.Point.X == gx && g.Point.Y == gy;
+            bool blockOk = reBlock is not null && reBlock.BlockNumberX == bx && reBlock.BlockNumberY == by
+                           && reSub is not null && reSub.BlockNumberX == sx && reSub.BlockNumberY == sy;
+            bool floored = cellFk.ID >= 0x800 && cellFk.ModKey == patch.ModKey;
+            bool refPresent = reCell is not null && (reCell.Temporary?.Any(r => r.FormKey == refFk) ?? false);
+            int patchCells = backWs is null ? -1 : CountWsCells(backWs.SubCells);
+            var ofst = backWs?.OffsetData;
+            int ofstLen = ofst.HasValue ? ofst.Value.Length : -1;
+
+            extOk = present && gridOk && blockOk && floored;
+            placedOk = refPresent;
+            Console.WriteLine($"[{(extOk ? "PASS" : "FAIL")}] exterior cell {cellFk} grid=({gx},{gy}) -> block=({bx},{by}) subblock=({sx},{sy})");
+            Console.WriteLine($"         reopened-present={present} grid-correct={gridOk} block/subblock-correct={blockOk} local>=0x800={floored}");
+            Console.WriteLine($"         patch carries {patchCells} exterior cell(s) (expect 1 — a THIN override delta, not all of Tamriel)  OFST regenerated bytes={ofstLen}");
+            Console.WriteLine($"[{(refPresent ? "PASS" : "FAIL")}] Placed ref {refFk} into the new cell's Temporary  reopened-present={refPresent}");
+        }
+        catch (Exception ex) { Console.WriteLine($"[FAIL] exterior round-trip — {ex.GetType().Name}: {(ex.InnerException ?? ex).Message}"); extOk = false; }
+        Console.WriteLine();
+
+        // ============================================================ PHASE E : INTERIOR round-trip ============================================================
+        Console.WriteLine("===== PHASE E : INTERIOR cell create (CellBlock/CellSubBlock by FormID digits) =====");
+        try
+        {
+            var patch = new SkyrimMod(new ModKey("hc_int_cell", ModType.Plugin), SkyrimRelease.SkyrimSE);
+            WriteEngine.EnsureFormIdFloor(patch);
+            var cellFk = patch.GetNextFormKey("HC_S0_IntCell");
+            uint id = cellFk.ID;
+            int blockN = (int)(id % 10), subN = (int)((id / 10) % 10);
+            var cell = new Cell(cellFk, SkyrimRelease.SkyrimSE) { Flags = ParseInteriorFlag() };
+            AddInteriorCell(patch, blockN, subN, cell);
+
+            var outPath = Path.Combine(outDir, patch.ModKey.FileName);
+            WriteEngine.WritePatch(patch, sourceMod, outPath);
+            using var back = SkyrimMod.CreateFromBinaryOverlay(outPath, SkyrimRelease.SkyrimSE);
+            var (reBlock, reSub, reCell) = LocateInteriorCell(back, cellFk);
+            bool present = reCell is not null;
+            bool placedRight = reBlock == blockN && reSub == subN;
+            bool floored = cellFk.ID >= 0x800 && cellFk.ModKey == patch.ModKey;
+            bool interiorFlag = reCell is not null && reCell.Flags.HasFlag(ParseInteriorFlag());
+            intOk = present && placedRight && floored && interiorFlag;
+            Console.WriteLine($"[{(intOk ? "PASS" : "FAIL")}] interior cell {cellFk} (id={id}) -> block={blockN} subblock={subN}");
+            Console.WriteLine($"         reopened-present={present} block/subblock-correct={placedRight} (got block={reBlock} sub={reSub}) local>=0x800={floored} interior-flag={interiorFlag}");
+        }
+        catch (Exception ex) { Console.WriteLine($"[FAIL] interior round-trip — {ex.GetType().Name}: {(ex.InnerException ?? ex).Message}"); intOk = false; }
+        Console.WriteLine();
+
+        // ============================================================ VERDICT ============================================================
+        var sourceUnchanged = shaBefore == Sha(src);
+        Console.WriteLine("===== COORDINATE-KEYED STEP 0 VERDICT =====");
+        Console.WriteLine($"   Exterior cell create (block math + thin override + reopen) : {(extOk ? "HOLDS" : "!! FAILED — read [FAIL] above")}");
+        Console.WriteLine($"   Placed-into-new-cell                                       : {(placedOk ? "HOLDS" : "!! FAILED")}");
+        Console.WriteLine($"   Interior cell create (FormID-digit blocks + reopen)        : {(intOk ? "HOLDS" : "!! FAILED")}");
+        Console.WriteLine($"   source byte-unchanged                                      : {(sourceUnchanged ? "YES" : "!! NO — CHANGED")}");
+        Console.WriteLine();
+        var pass = extOk && intOk && placedOk && sourceUnchanged;
+        Console.WriteLine(pass
+            ? "=== STEP 0 PASS: coordinate-keyed create is TRACTABLE — a single block-math algorithm (floor(grid/32|8) exterior, FormID digits interior) places a constructed cell into find-or-built block structs; round-trips clean; OFST regenerates. Build is §4-(b) DELIBERATE-BUILD, not a per-type shim. Report to Aaron. ==="
+            : "=== STEP 0: a coordinate-keyed shape did NOT round-trip — read the [FAIL] lines. Per §1.4: STOP and surface to Aaron; the loud-fail boundary stays until resolved. ===");
+        return pass ? 0 : 1;
+    }
+
+    // ---------- exterior block tree: find-or-construct ----------
+
+    static (WorldspaceBlock block, WorldspaceSubBlock sub) FindOrAddExteriorBlock(Worldspace ws, int bx, int by, int sx, int sy)
+    {
+        var block = ws.SubCells.FirstOrDefault(b => b.BlockNumberX == bx && b.BlockNumberY == by);
+        if (block is null)
+        {
+            block = new WorldspaceBlock { BlockNumberX = (short)bx, BlockNumberY = (short)by, GroupType = GroupTypeEnum.ExteriorCellBlock };
+            ws.SubCells.Add(block);
+        }
+        var sub = block.Items.FirstOrDefault(s => s.BlockNumberX == sx && s.BlockNumberY == sy);
+        if (sub is null)
+        {
+            sub = new WorldspaceSubBlock { BlockNumberX = (short)sx, BlockNumberY = (short)sy, GroupType = GroupTypeEnum.ExteriorCellSubBlock };
+            block.Items.Add(sub);
+        }
+        return (block, sub);
+    }
+
+    static (IWorldspaceBlockGetter? block, IWorldspaceSubBlockGetter? sub, ICellGetter? cell) LocateExteriorCell(
+        IReadOnlyList<IWorldspaceBlockGetter>? blocks, FormKey fk)
+    {
+        foreach (var b in blocks ?? (IReadOnlyList<IWorldspaceBlockGetter>)Array.Empty<IWorldspaceBlockGetter>())
+            foreach (var s in b.Items ?? Enumerable.Empty<IWorldspaceSubBlockGetter>())
+                foreach (var c in s.Items ?? Enumerable.Empty<ICellGetter>())
+                    if (c.FormKey == fk) return (b, s, c);
+        return (null, null, null);
+    }
+
+    // ---------- interior block tree: find-or-construct ----------
+
+    static void AddInteriorCell(SkyrimMod patch, int blockN, int subN, Cell cell)
+    {
+        var records = patch.Cells.Records;
+        var block = records.FirstOrDefault(b => b.BlockNumber == blockN);
+        if (block is null) { block = new CellBlock { BlockNumber = blockN, GroupType = GroupTypeEnum.InteriorCellBlock }; records.Add(block); }
+        var sub = block.SubBlocks.FirstOrDefault(s => s.BlockNumber == subN);
+        if (sub is null) { sub = new CellSubBlock { BlockNumber = subN, GroupType = GroupTypeEnum.InteriorCellSubBlock }; block.SubBlocks.Add(sub); }
+        sub.Cells.Add(cell);
+    }
+
+    static (int block, int sub, ICellGetter? cell) LocateInteriorCell(ISkyrimModGetter back, FormKey fk)
+    {
+        foreach (var b in back.Cells.Records)
+            foreach (var s in b.SubBlocks ?? Enumerable.Empty<ICellSubBlockGetter>())
+                foreach (var c in s.Cells ?? Enumerable.Empty<ICellGetter>())
+                    if (c.FormKey == fk) return (b.BlockNumber, s.BlockNumber, c);
+        return (-99, -99, null);
+    }
+
+    static Cell.Flag ParseInteriorFlag()
+        => (Cell.Flag)Enum.Parse(typeof(Cell.Flag), Enum.GetNames(typeof(Cell.Flag)).First(n => n.Contains("Interior")));
+
+    // ---------- helpers ----------
+
+    static int FloorDiv(int a, int b) => (int)Math.Floor((double)a / b);
+
+    static int CountWsCells(IReadOnlyList<IWorldspaceBlockGetter>? blocks)
+    {
+        int n = 0;
+        foreach (var b in blocks ?? (IReadOnlyList<IWorldspaceBlockGetter>)Array.Empty<IWorldspaceBlockGetter>())
+            foreach (var s in b.Items ?? Enumerable.Empty<IWorldspaceSubBlockGetter>())
+                n += s.Items?.Count ?? 0;
+        return n;
+    }
+
+    static int CountWsCellsSettable(IList<WorldspaceBlock>? blocks)
+    {
+        int n = 0;
+        foreach (var b in blocks ?? (IList<WorldspaceBlock>)Array.Empty<WorldspaceBlock>())
+            foreach (var s in b.Items)
+                n += s.Items.Count;
+        return n;
+    }
+
+    static void DumpType(string label, Type t, params string[] props)
+    {
+        Console.WriteLine($"   {label} ({t.Name}):");
+        foreach (var name in props)
+        {
+            var p = t.GetProperty(name);
+            Console.WriteLine(p is null
+                ? $"      {name,-12} : (ABSENT — surface, don't guess)"
+                : $"      {name,-12} : {Pretty(p.PropertyType)}");
+        }
+    }
+
+    static string Sha(string path)
+    {
+        using var sha = SHA256.Create();
+        using var stream = File.OpenRead(path);
+        return Convert.ToHexString(sha.ComputeHash(stream));
+    }
+
+    static string Pretty(Type t)
+    {
+        if (t.IsGenericType)
+        {
+            var name = t.Name; var tick = name.IndexOf('`');
+            if (tick > 0) name = name[..tick];
+            return $"{name}<{string.Join(", ", t.GetGenericArguments().Select(Pretty))}>";
+        }
+        return Nullable.GetUnderlyingType(t)?.Name is { } u ? u + "?" : t.Name;
+    }
+}

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -196,6 +196,11 @@ if (args.Length > 0 && args[0] == "nested-create-probe") return NestedCreateProb
 // bad parent, ambiguous collection, forward sibling). Re-opens each patch from disk; Skyrim.esm byte-checked.
 if (args.Length > 0 && args[0] == "nested-create-proof") return NestedCreateProof.RunProof(args[1..]);
 
+// STEP 0 scout for the COORDINATE-KEYED §4-(b) seam (exterior/interior Cell + Placed-into-new-cell): round-trips a
+// constructed cell into find-or-built WorldspaceBlock/SubBlock (exterior, floor(grid/32|8)) and CellBlock/SubBlock
+// (interior, FormID digits), checks override is thin, block math vs vanilla, OFST regen, source byte-unchanged.
+if (args.Length > 0 && args[0] == "coord-cell-probe") return CoordCellProbe.RunProbe(args[1..]);
+
 // Wave 4 scout: recon Mutagen's IFormLinkOrIndex condition-target API — the form-vs-index discriminator (condition oracle), the wave-4 unknown.
 if (args.Length > 0 && args[0] == "condition-probe") return ConditionProbe.RunConditionProbe(args[1..]);
 

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -201,6 +201,11 @@ if (args.Length > 0 && args[0] == "nested-create-proof") return NestedCreateProo
 // (interior, FormID digits), checks override is thin, block math vs vanilla, OFST regen, source byte-unchanged.
 if (args.Length > 0 && args[0] == "coord-cell-probe") return CoordCellProbe.RunProbe(args[1..]);
 
+// CI regression guard for coordinate-keyed cell create (§4-(b)): drives the REAL CreateRecords path against a
+// synthesized Worldspace+Weapon master in TEMP (no Skyrim.esm) — exterior by grid, interior by FormID digits,
+// placed-into-new-cell, + the malformed rejects (no-worldspace / no-grid / bad-grid / non-worldspace-parent).
+if (args.Length > 0 && args[0] == "coord-cell-guard") return CoordCellGuardProbe.RunGuard(args[1..]);
+
 // Wave 4 scout: recon Mutagen's IFormLinkOrIndex condition-target API — the form-vs-index discriminator (condition oracle), the wave-4 unknown.
 if (args.Length > 0 && args[0] == "condition-probe") return ConditionProbe.RunConditionProbe(args[1..]);
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1113,10 +1113,10 @@ public sealed class LoadOrderService : IDisposable
     /// fitting child-list, <paramref name="collection"/>. For a parent + its children in ONE call (a topic + its lines, a
     /// child's parent= naming a same-call sibling), see <see cref="CreateRecordsBatch"/>.</summary>
     public WritePatchBuilder.CreateOutcome CreateRecords(string recordType, string editorid, IReadOnlyList<BulkOp> operations,
-        string? patchName, string? into, bool fullReadback = false, string? parent = null, string? collection = null)
+        string? patchName, string? into, bool fullReadback = false, string? parent = null, string? collection = null, string? grid = null)
     {
         var problems = new List<string>();
-        var spec = BuildCreateSpec(recordType, editorid, operations, parent, collection, where: null, problems);
+        var spec = BuildCreateSpec(recordType, editorid, operations, parent, collection, grid, where: null, problems);
         if (spec is null)
             return WritePatchBuilder.CreateOutcome.Fail(
                 $"refused — {problems.Count} problem(s) creating the record; NOTHING created:\n  - " + string.Join("\n  - ", problems));
@@ -1139,7 +1139,7 @@ public sealed class LoadOrderService : IDisposable
         for (int r = 0; r < records.Count; r++)
         {
             var rec = records[r];
-            var spec = BuildCreateSpec(rec.RecordType, rec.Editorid, rec.Operations ?? Array.Empty<BulkOp>(), rec.Parent, rec.Collection, $"record[{r}]", problems);
+            var spec = BuildCreateSpec(rec.RecordType, rec.Editorid, rec.Operations ?? Array.Empty<BulkOp>(), rec.Parent, rec.Collection, rec.Grid, $"record[{r}]", problems);
             if (spec is not null) specs.Add(spec);
         }
         if (problems.Count > 0)
@@ -1155,7 +1155,7 @@ public sealed class LoadOrderService : IDisposable
     /// through (a nested child) — null ⇒ a flat top-level record. Every problem (with the optional <paramref name="where"/>
     /// label) is APPENDED to <paramref name="problems"/>; returns null iff this record contributed any (all-or-nothing).</summary>
     WritePatchBuilder.CreateSpec? BuildCreateSpec(string? recordType, string? editorid, IReadOnlyList<BulkOp> operations,
-        string? parent, string? collection, string? where, List<string> problems)
+        string? parent, string? collection, string? grid, string? where, List<string> problems)
     {
         var prefix = where is null ? "" : where + ": ";
         int before = problems.Count;
@@ -1192,6 +1192,7 @@ public sealed class LoadOrderService : IDisposable
             RecordType = catalogName!, EditorId = editorid!.Trim(), Edits = edits,
             ParentRef = string.IsNullOrWhiteSpace(parent) ? null : parent.Trim(),
             IntoCollection = string.IsNullOrWhiteSpace(collection) ? null : collection.Trim(),
+            Grid = string.IsNullOrWhiteSpace(grid) ? null : grid.Trim(),
         };
     }
 
@@ -1211,10 +1212,11 @@ public sealed class LoadOrderService : IDisposable
 
             var outcome = WritePatchBuilder.CreateRecords(resolver, rulebook, specs, outPath, extend, fullReadback);
             if (!outcome.Success && created) RemoveFolderCreatedThisCall(outPath);   // hunt F4: a refused create leaves no orphan
-            // Layer B dialogue teeth, both post-write verify steps (the proven CreateRecords path stays untouched):
-            // unit B voice (.fuz/.lip) coverage, then unit C the result-script binding. Each is a no-op unless the call
-            // created a dialogue line; neither can fail the create (the write already succeeded).
-            return outcome.Success ? EnrichWithScriptCheck(EnrichWithVoiceCheck(outcome, resolver)) : outcome;
+            // Layer B dialogue teeth + the coordinate-keyed cell teeth — all post-write verify steps (the proven
+            // CreateRecords path stays untouched): unit B voice (.fuz/.lip) coverage, unit C the result-script binding,
+            // then the §4-(b) structural-shell report. Each is a no-op unless the call created the relevant record kind
+            // (a dialogue line / a cell); none can fail the create (the write already succeeded).
+            return outcome.Success ? EnrichWithCellShell(EnrichWithScriptCheck(EnrichWithVoiceCheck(outcome, resolver))) : outcome;
         }
     }
 
@@ -1258,6 +1260,26 @@ public sealed class LoadOrderService : IDisposable
         try { report = DialogueScriptCheck.Run(outcome.OutputPath, outcome.Created, Assets); }
         catch (Exception ex) { report = ScriptBindingReport.Empty with { CheckError = $"{ex.GetType().Name}: {ex.Message}" }; }
         return report.IsEmpty ? outcome : outcome with { ScriptBinding = report };
+    }
+
+    /// <summary>The coordinate-keyed §4-(b) teeth — the structural-SHELL report, a POST-WRITE step on a SUCCESSFUL
+    /// create exactly like <see cref="EnrichWithVoiceCheck"/>. Only fires when the call created ≥1 Cell:
+    /// <see cref="CellShellCheck.Run"/> re-opens the written patch read-only, reads each created cell's interior/exterior
+    /// kind, and lists the world content houseCARL does NOT author (lighting / terrain / water / navmesh — Aaron
+    /// 2026-06-20: no CK work) — the report rides back on <see cref="WritePatchBuilder.CreateOutcome.CellShell"/>. NEVER
+    /// fails the create (the cell IS written; this only says what the author must still provide); a check failure is
+    /// surfaced on the report's CheckError (Q3). Needs no resolver/assets — the kind comes off the written cell's flag.</summary>
+    WritePatchBuilder.CreateOutcome EnrichWithCellShell(WritePatchBuilder.CreateOutcome outcome)
+    {
+        bool anyCell = false;
+        foreach (var c in outcome.Created)
+            if (string.Equals(c.RecordType, CellShellCheck.CellCatalogName, StringComparison.Ordinal)) { anyCell = true; break; }
+        if (!anyCell) return outcome;
+
+        CellShellReport report;
+        try { report = CellShellCheck.Run(outcome.OutputPath, outcome.Created); }
+        catch (Exception ex) { report = CellShellReport.Empty with { CheckError = $"{ex.GetType().Name}: {ex.Message}" }; }
+        return report.IsEmpty ? outcome : outcome with { CellShell = report };
     }
 
     /// <summary>Map a wire field-op to a core <see cref="WriteRequest"/> for CREATE: RecordType is the create type (not

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -405,6 +405,10 @@ public static class WriteTools
             foreach (var m in c.MustProvide)
                 sb.Append("      - ").Append(m).Append('\n');
         }
+        // Q3 — declare the un-checked grid-occupancy seam (full load-order occupancy detection is a follow-up; never a
+        // silent omission). Only an EXTERIOR cell collides on a grid; an interior cell has no grid identity.
+        if (report.Cells.Any(c => !c.Interior))
+            sb.Append("  note: houseCARL does NOT check grid-occupancy — a NEW exterior cell at a grid your load order already fills collides (engine behavior undefined). To change an existing cell, OVERRIDE it instead of creating a new one.\n");
         if (report.CheckError is not null)
             sb.Append("  cell-shell check could not run: ").Append(report.CheckError).Append(" — the cell(s) WERE created; review world content manually.\n");
     }

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -152,6 +152,8 @@ public static class WriteTools
             string? parent = null,
         [Description("Optional. Which of the parent's child-collections to add into, BY NAME (e.g. a cell's 'Persistent'/'Temporary') — needed only when the parent holds more than one list that accepts this child type. Omit when the collection is unique (e.g. a topic's responses) or when parent is omitted.")]
             string? collection = null,
+        [Description("Optional. For an EXTERIOR cell (record_type 'Cell' with parent= a Worldspace FormID): the cell's grid as \"X,Y\" (e.g. \"5,-12\") — houseCARL files it into the worldspace's block tree (block=floor(grid/32), subblock=floor(grid/8)). A 'Cell' with NO parent and NO grid is an INTERIOR cell (self-files by FormID). Ignored for non-Cell types.")]
+            string? grid = null,
         [Description("Optional. Base filename for the new patch (default 'houseCARL_Patch'); auto-suffixed if taken. Ignored if into= is given.")]
             string patch_name = "houseCARL_Patch",
         [Description("Optional. Filename of an existing houseCARL patch to add this new record to instead of writing a fresh one (accumulate across calls/sessions).")]
@@ -162,7 +164,7 @@ public static class WriteTools
             int max_chars = 0) => Guard.Tool("housecarl_create_record", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-        return RenderCreate(svc.CreateRecords(record_type, editorid, operations ?? Array.Empty<BulkOp>(), patch_name, into, full_readback, parent, collection), max_chars);
+        return RenderCreate(svc.CreateRecords(record_type, editorid, operations ?? Array.Empty<BulkOp>(), patch_name, into, full_readback, parent, collection, grid), max_chars);
     });
 
     [McpServerTool(Name = "housecarl_bulk_create", Title = "Create many records (incl. a nested one-shot) in one patch"),
@@ -324,6 +326,7 @@ public static class WriteTools
         }
         AppendVoiceReport(sb, o.Voice, maxChars);
         AppendScriptBindingReport(sb, o.ScriptBinding, maxChars);
+        AppendCellShellReport(sb, o.CellShell);
         if (o.ReadBack is { } rb) AppendFullReadback(sb, rb, maxChars);
         sb.Append("the new FormID above is how you reference this record (SkyPatcher/SPID, or a follow-up edit). ")
           .Append("To add more to THIS patch, pass into=\"").Append(file).Append("\".");
@@ -386,6 +389,25 @@ public static class WriteTools
     static void AppendVoiceTrunc(StringBuilder sb, int rendered, int total, int cap)
         => sb.Append("  ... [voice coverage truncated: rendered ").Append(rendered).Append(" of ").Append(total)
              .Append(" line(s) at max_chars=").Append(cap).Append("; raise max_chars to see the rest]\n");
+
+    /// <summary>Render the coordinate-keyed §4-(b) structural-shell report (a cell create). The enforced Q3 teeth against
+    /// a created-but-EMPTY cell: a created cell is a valid, correctly-placed RECORD, but houseCARL does NOT author world
+    /// content — so per created cell this lists, by kind, what the author must still provide in the Creation Kit
+    /// (lighting / terrain / water / navmesh). "Created" must never read as "looks right in game". No-op unless the call
+    /// created cells.</summary>
+    static void AppendCellShellReport(StringBuilder sb, CellShellReport? report)
+    {
+        if (report is null || report.IsEmpty) return;
+        sb.Append("cell shell — created cells are valid, correctly-placed records but EMPTY; houseCARL does not author world content (provide these in the Creation Kit):\n");
+        foreach (var c in report.Cells)
+        {
+            sb.Append("  ").Append(c.Interior ? "INTERIOR " : "EXTERIOR ").Append(c.EditorId).Append(" (").Append(c.Cell).Append("):\n");
+            foreach (var m in c.MustProvide)
+                sb.Append("      - ").Append(m).Append('\n');
+        }
+        if (report.CheckError is not null)
+            sb.Append("  cell-shell check could not run: ").Append(report.CheckError).Append(" — the cell(s) WERE created; review world content manually.\n");
+    }
 
     /// <summary>Render the Layer B unit C result-script coverage report (a dialogue-line create). The enforced Q3 teeth
     /// against a byte-valid-but-INERT result script: a LOUD "WILL NOT FIRE" per created line whose VMAD binds nothing
@@ -488,6 +510,9 @@ public sealed record CreateOp
 
     [JsonPropertyName("collection"), Description("Optional. Which of the parent's child-collections to add into, BY NAME (e.g. a cell's 'Persistent') — needed only when more than one fits. Omit when unique or when parent is omitted.")]
     public string? Collection { get; init; }
+
+    [JsonPropertyName("grid"), Description("Optional. For an EXTERIOR cell only (record_type 'Cell' with parent= a Worldspace): the cell's grid as \"X,Y\" (e.g. \"5,-12\"). houseCARL files it into the worldspace's block tree by block=floor(grid/32), subblock=floor(grid/8). A 'Cell' with NO parent and NO grid is an INTERIOR cell (self-files by FormID). Ignored for non-Cell types.")]
+    public string? Grid { get; init; }
 }
 
 /// <summary>A modeled struct built from parts (wire shape of <see cref="StructSpec"/>): the concrete type, optional


### PR DESCRIPTION
Closes the last nested-create gap: **coordinate-keyed create** — exterior cells, interior cells, and placed refs into not-yet-present cells — the §4-(b) seam the nested/dialogue plan deferred (cells nest under **FormKey-less** `WorldspaceBlock`/`CellBlock` structs the FormKey locator can't address). One generic block-math algorithm per cell-kind, **not** a per-type shim, so it stays cornerstone-clean.

Three commits: a STEP-0 behavior scout (proven vs vanilla), the engine + `CreateRecords` integration, then the tool surface + the Q3 shell report.

### What it does
- **Exterior cell** — `parent=<Worldspace>` + `grid="X,Y"` → filed into the block tree by `block=floor(grid/32)`, `subblock=floor(grid/8)` (matched **4000/4000** vanilla cells). Thin worldspace override (a 1-cell delta, not all of Tamriel).
- **Interior cell** — no parent, no grid → self-files into the Cells group by FormID digits `block=id%10`, `subblock=(id/10)%10` (**590/590** vanilla).
- **Placed-into-new-cell** — rides the existing sibling nested path once the cell exists (no new mechanism).
- **`grid=`** wired into `housecarl_create_record` + `housecarl_bulk_create`.
- **Structural-shell report** (the Q3 teeth, sibling to the dialogue voice report): a created cell is a valid, correctly-placed *record* but **empty** — the report lists, per cell by kind, the world content houseCARL does **not** author (lighting / terrain / water / navmesh). "Created" never reads as "looks right in game".

### Decisions baked in (Aaron, 2026-06-20)
- **OFST** — Mutagen drops the worldspace seek-cache on write; the engine rebuilds it from the block tree at load (Synthesis-style patchers rely on this). **Accepted as-is, no regeneration.** → **in-game verification is the one open check**: create an exterior cell, load the patch, confirm the cell loads in game.
- **Scope** — structural cell + the loud "you must fill" report; **no CK work** (no auto lighting/land/navmesh).

### Proof (CI guards, all green)
- **`coord-cell-guard`** (new) — exterior, interior, placed-into-new-cell, + 4 malformed rejects (grid+no-parent / parent+no-grid / bad-grid / non-worldspace-parent — each refuses the whole call, no file written), through the real `CreateRecords`; synthesized master, no Skyrim.esm.
- **`bulk-create-guard`** (+2 arms) — `grid=` threads service→core and the `CellShell` report rides back, for both kinds.
- **`nested-create-guard`** still green — the `MakeSettableParent` refactor (shared by nested + exterior) didn't regress the existing path.
- Clean full-solution build, no new warnings.

Plan/design: `dev/plans/COORD_KEYED_CELL_CREATE_BUILD_2026-06-20.md` (private). A cell-authoring **skill** is a possible follow-up, decided after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)