### PR TITLE
skill: bundle CK CTDA-decode + quest reference pages into dialogue-authoring (1.3.1 item 3)

### DIFF
--- a/.claude/skills/dialogue-authoring/SKILL.md
+++ b/.claude/skills/dialogue-authoring/SKILL.md
@@ -58,7 +58,7 @@ The Skyrim-specific knowledge lives in the `references/` files — read the one 
 
 The condition / branch / quest references are **hand-curated** (sourced from the CK wiki + Mutagen's record
 model, not the by-construction generator), so they carry a staleness duty — provenance and the re-check
-checklist live in [`references/_CORPUS_STATUS.md`](references/_CORPUS_STATUS.md).
+checklist live in `references/_CORPUS_STATUS.md` (dev-side; not shipped in the plugin).
 
 ## Read the flow model first
 

--- a/.claude/skills/dialogue-authoring/SKILL.md
+++ b/.claude/skills/dialogue-authoring/SKILL.md
@@ -31,19 +31,34 @@ tools.
 - **Evaluate `Conditions` (CTDA).** Conditions decide *when* a line fires; only the running game evaluates
   them, so a wrong or missing condition silently stops a line forever and is **unverifiable at the data
   layer**. This is the single most common silent-dead-dialogue cause and it is on the author to get right.
+  houseCARL *can* read a condition back and **decode** it — the function, its parameters, and its Run On
+  scope ([`references/condition-functions.md`](references/condition-functions.md)) — so you can check it by
+  eye; it cannot tell you whether it *passes*.
 - **Record voice audio or verify lip-sync.** Voice presence is an on-disk file check; the audio content and
   voice *acting* are out of scope.
 - **Promise "this will play" from a clean structural pass.** A green validate means the wiring resolves —
   not that the conditions are correct, the audio exists, or the conversation reads well.
 
-The Skyrim-specific knowledge lives in three references — read the one your task touches:
+The Skyrim-specific knowledge lives in the `references/` files — read the one your task touches:
 - [`references/dialogue-flow-model.md`](references/dialogue-flow-model.md) — how DLVW/DLBR/DIAL/INFO connect
   and what drives the flow (conditions, LinkTo, quest stage, PNAM, DIAL-wins-wholesale). **Read this before
   authoring or auditing anything.**
+- [`references/condition-functions.md`](references/condition-functions.md) — how to **decode** a condition
+  (CTDA): function + params + Run On (Subject vs Target), the operators and the `OR` flag, a curated table of
+  the dialogue/quest condition functions, and CTDA-vs-Papyrus-only. Read before reading or composing any
+  `Conditions`.
+- [`references/dialogue-branch.md`](references/dialogue-branch.md) — the DLBR entry point: its fields and the
+  `TopLevel`/`Blocking`/`Exclusive` flags (one of which can silently lock an NPC out of all dialogue).
+- [`references/quest-objectives-tab.md`](references/quest-objectives-tab.md) — stages vs objectives vs log
+  entries, and why a line gates on the stage while the journal is driven by objectives.
 - [`references/seq-file-format.md`](references/seq-file-format.md) — why a start-game-enabled quest needs a
   `.seq` and what the file is.
 - [`references/voice-file-naming.md`](references/voice-file-naming.md) — the `.fuz`/`.lip` path template and
   the override folder trap.
+
+The condition / branch / quest references are **hand-curated** (sourced from the CK wiki + Mutagen's record
+model, not the by-construction generator), so they carry a staleness duty — provenance and the re-check
+checklist live in [`references/_CORPUS_STATUS.md`](references/_CORPUS_STATUS.md).
 
 ## Read the flow model first
 
@@ -139,8 +154,9 @@ this skill's job.
 3. **Author the conditions deliberately** — they are the gate the validator cannot check. A line with no
    conditions fires whenever its topic is reached; gate it with `GetStage` (quest progress) and a speaker
    check (`GetIsID`/alias) as the flow model describes. Compose each `Condition` per `mutagen-reference`
-   (it is a polymorphic list). Wrong conditions are the #1 silent-dead-dialogue cause — there is no tool
-   that will catch them, so reason them through.
+   (it is a polymorphic list); [`references/condition-functions.md`](references/condition-functions.md) has
+   the function param shapes and the Run On (Subject vs Target) scoping. Wrong conditions are the #1
+   silent-dead-dialogue cause — there is no tool that will catch them, so reason them through.
 
 4. **Result scripts, if the line does something.** Compose the line's `VirtualMachineAdapter` script binding
    (the `TIF_`-style fragment), author the `.psc`, and compile it with `housecarl_compile_script` (never

--- a/.claude/skills/dialogue-authoring/references/_CORPUS_STATUS.md
+++ b/.claude/skills/dialogue-authoring/references/_CORPUS_STATUS.md
@@ -1,0 +1,55 @@
+# dialogue-authoring CTDA / quest reference — status & provenance
+
+Provenance and staleness record for the **condition-decode and quest-structure** references added in 1.3.1:
+`condition-functions.md`, `dialogue-branch.md`, `quest-objectives-tab.md`. (The older
+`dialogue-flow-model.md`, `seq-file-format.md`, and `voice-file-naming.md` predate this file and were
+empirically grounded through houseCARL reads — see their own headers.)
+
+## What these are
+
+Hand-curated references that let houseCARL **decode** a condition (CTDA) and read the quest layer dialogue
+gates on — turning a read-back `Conditions`/`Stages`/`Objectives` array into meaning, instead of echoing raw
+bytes. They are the **keystone for the planned static condition-lint** (1.3.1 roadmap item 4): you cannot
+lint a condition you cannot decode.
+
+**These are curated, not generated.** Like the bundled SkyPatcher/SPID/KID grammar references, they ship as
+static prose and carry a **hand-maintained-staleness duty** — they are deliberately kept **out of** the
+by-construction generator (which targets `mutagen-reference` only), so authoring them never contaminates the
+generated corpus.
+
+## Two-layer sourcing (read this before trusting a fact)
+
+| Layer | Source | Confidence |
+|---|---|---|
+| **Structure** — which condition functions exist, each one's parameter shape, the Run On enum, the compare operators, the DLBR/Quest/QuestStage/QuestObjective record fields | **By construction from Mutagen**, via houseCARL's own `mutagen-reference` (`arms.jsonl` / `records.jsonl` / `structs.jsonl` / `enums.jsonl`), read at the 1.3.1 dev head. This is exactly what `housecarl_read_record` surfaces and what the write tools compose. | **High** — it *is* the model houseCARL decodes. Re-derivable any time from `mutagen-reference`. |
+| **Semantics** — what each function tests, Run On scoping rules (Subject = speaker, Target = player), DLBR flag behavior, objective/stage display behavior | **Creation Kit wiki** (UESP-hosted, `ck.uesp.net`: *Condition Functions*, *Conditions*, *Dialogue Speech Checks*, *Dialogue Branch*, *Quest Objectives Tab*, *SetObjectiveDisplayed/Completed*) **+ modding-domain knowledge.** | **High** for the well-established facts; domain-authored where noted. |
+
+### Why the wiki wasn't fetched directly (the source-substitution, stated plainly)
+
+At authoring time (**2026-06-22**) the canonical **creationkit.com** wiki was **down for maintenance** (every
+page 302-redirected to a Bethesda maintenance page), and direct automated fetches of both the Internet
+Archive and the UESP mirror were unavailable in the build environment. So the **structural backbone was taken
+by construction from Mutagen** (a *better* source for what houseCARL actually decodes than the wiki would be),
+and the **semantics were sourced from the UESP-hosted CK wiki via web search + domain knowledge**, rather
+than by bundling the wiki pages verbatim. This was a deliberate, surfaced call (Aaron-approved 2026-06-22),
+not a silent workaround — but it means the prose carries the staleness duty below.
+
+## Coverage
+
+- **Condition functions:** a **curated dialogue/quest subset** (~40 functions) documented with full param
+  shapes + semantics. Mutagen models **every** condition function (hundreds — all combat/VATS/weather/AI
+  ones too); to decode one outside the subset, read its `ConditionData` arm directly and look it up in
+  `mutagen-reference`. The CTDA-vs-Papyrus-only distinction is covered as a section in `condition-functions.md`.
+- **Dialogue Branch:** all fields + the three flags (`TopLevel`/`Blocking`/`Exclusive`) + Category.
+- **Quest stages & objectives:** stages, log entries, objectives, targets, and the index convention.
+
+## Staleness duty
+
+- **Structure** — re-derive from `mutagen-reference` whenever Mutagen updates; if a function's param shape
+  here ever disagrees with `mutagen-reference`, **`mutagen-reference` wins** (it's by construction).
+- **Semantics** — when **creationkit.com is back**, cross-check the curated descriptions, the DLBR flag
+  behavior, and the objective/stage notes against the canonical pages, and correct any drift. Known soft
+  spots flagged in-text: the objective-index/stage-number relationship is a **convention, not a rule**
+  (corrected here vs. looser shorthand); a few param-less functions (`GetIsCreatureType`, `GetSitting`)
+  return coded values whose exact codes are not enumerated here.
+- This file is the place to record any future correction.

--- a/.claude/skills/dialogue-authoring/references/condition-functions.md
+++ b/.claude/skills/dialogue-authoring/references/condition-functions.md
@@ -47,7 +47,8 @@ each row:
 
 `OR` only chains **adjacent** rows — there are **no parentheses**. So a list can express a flat
 AND-of-ORs run, but **not** `(A AND B) OR (C AND D)`; to gate on a real sum-of-products you must duplicate
-the whole INFO, one copy per AND-clause (see the flow-model reference's "non-lint traps"). Reading a list,
+the whole INFO, one copy per AND-clause (see the flow-model reference's *Authoring traps the model implies
+(non-lint)* section). Reading a list,
 walk it row by row and group consecutive `OR` rows.
 
 ### `SwapSubjectAndTarget`

--- a/.claude/skills/dialogue-authoring/references/condition-functions.md
+++ b/.claude/skills/dialogue-authoring/references/condition-functions.md
@@ -1,0 +1,210 @@
+# Condition functions (CTDA) — decode reference
+
+How to **decode** a condition you read back from a record (`Conditions` on an INFO, a quest's
+`DialogConditions`/`EventConditions`, an alias, a magic effect, a perk, …) — and how to compose one
+correctly. A condition is the gate the running game evaluates to decide *when* a line fires or an alias
+fills; houseCARL cannot evaluate it (only the game can), but it **can** read it back in full, and this
+reference is how you turn the bytes into meaning.
+
+**Two layers, two sources.** The *structure* below — which functions exist, each one's parameter shape, the
+Run On options, the operators — is taken **by construction from Mutagen** (houseCARL's `mutagen-reference`),
+so it is exactly what `housecarl_read_record` surfaces and what `housecarl_bulk_apply`/`housecarl_set_field`
+compose. The *semantics* — what each function tests, the Run On scoping rules — are from the Creation Kit
+wiki + modding practice (see `_CORPUS_STATUS.md` for provenance and the staleness duty). Confirm any exact
+field path or arm name against `mutagen-reference` before composing a write.
+
+## The shape of a condition (CTDA)
+
+A `Condition` is a polymorphic struct with **two concrete arms** — which one is used depends only on what the
+comparison value is:
+
+| Arm (Mutagen) | `ComparisonValue` is… | Use |
+|---|---|---|
+| `ConditionFloat` | a `float` literal | the common case — compare against a number (`GetStage >= 20`) |
+| `ConditionGlobal` | a `FormLink<Global>` | compare against a global variable's runtime value |
+
+Both arms carry the same four pieces:
+
+- **`CompareOperator`** — one of `EqualTo`, `NotEqualTo`, `GreaterThan`, `GreaterThanOrEqualTo`,
+  `LessThan`, `LessThanOrEqualTo` (xEdit shows these as `=`, `!=`, `>`, `>=`, `<`, `<=`).
+- **`ComparisonValue`** — the number (Float) or global (Global) the function's result is compared to.
+- **`Data`** — the function and its parameters (the polymorphic `ConditionData`, below). This is the part
+  that says *which* function and *what* it is pointed at.
+- **`Flags`** — `OR` and `SwapSubjectAndTarget` (below).
+
+**The function result is always compared to the value.** A condition is read as
+`<function>(<params>) <operator> <value>`. `GetStage(MyQuest) >= 20` is `Data=GetStage(Quest=MyQuest)`,
+`CompareOperator=GreaterThanOrEqualTo`, `ComparisonValue=20`. There is no "boolean" type — a yes/no
+function like `GetIsID` is written `GetIsID(X) = 1` / `= 0`.
+
+### AND / OR between rows — the `OR` flag
+
+A condition *list* is rows evaluated top to bottom. The join is **per-row**, carried by the `OR` flag on
+each row:
+
+- **Flag clear (default) = AND** with the *next* row.
+- **Flag set (`OR`) = OR** with the *next* row.
+
+`OR` only chains **adjacent** rows — there are **no parentheses**. So a list can express a flat
+AND-of-ORs run, but **not** `(A AND B) OR (C AND D)`; to gate on a real sum-of-products you must duplicate
+the whole INFO, one copy per AND-clause (see the flow-model reference's "non-lint traps"). Reading a list,
+walk it row by row and group consecutive `OR` rows.
+
+### `SwapSubjectAndTarget`
+
+The other `Condition.Flag`. When set on a row, that row's Run On **Subject** and **Target** are swapped for
+that single evaluation — a way to ask a Subject-shaped function about the Target without changing the Run On
+selector. Rare; note it when you see it because it inverts who the row is really testing.
+
+## Run On — *which* object the function is evaluated against
+
+The parameter says *what to compare to*; **Run On** says *who the function runs on*. They are independent,
+and getting Run On wrong is the classic "correctly-wired line still plays wrong" bug — the condition passes
+or fails against the wrong actor, silently. Mutagen's `RunOnType` enum has exactly these eight values:
+
+| Run On (`RunOnType`) | The function is evaluated on… |
+|---|---|
+| `Subject` | **the line's speaker** (the NPC saying the dialogue). The default. |
+| `Target` | **who the speaker is talking to** — in dialogue, normally the **player**. |
+| `Reference` | a specific placed reference you pick — the `Reference` FormLink field on the Data. |
+| `CombatTarget` | the Subject's current combat target. |
+| `LinkedReference` | the reference linked from the Subject (optionally by a keyword). |
+| `QuestAlias` | a reference alias of the owning quest — which alias is the `RunOnTypeIndex`. |
+| `PackageData` | a reference supplied by the running package's data. |
+| `EventData` | a reference supplied by the triggering event (story-manager / scene). |
+
+**The dialogue lint this enables:** a function that asks about the *player* (e.g. "is the player wearing
+X", "does the player have keyword Y") left on **Subject** silently tests the **NPC** instead — it should be
+on **Target**. Conversely a check about the speaker (`IsSneaking`, the NPC's own faction) belongs on
+**Subject**. (Confirmed: in dialogue "Target = who the NPC is talking to", "Subject = the NPC speaking" —
+UESP CK wiki, *Dialogue Speech Checks*.) Run On `Reference`/`QuestAlias` carry an index/link (`Reference`,
+`RunOnTypeIndex`) — a `QuestAlias` Run On whose index isn't a real alias of the owning quest is a dead
+condition.
+
+## Reading a function's parameters
+
+Every `ConditionData` arm exposes its **function-specific parameter(s) first**, then a common block:
+`Function` (the read-only selector), `RunOnType` + `RunOnTypeIndex`, `Reference` (used when
+`RunOnType=Reference`), `UseAliases`, `UsePackageData`, and unused int/string parameter slots. When you read
+a condition back, the arm's **name *is* the function** (e.g. Data type `GetStageConditionData` ⇒ function
+`GetStage`), and the named non-common fields are the parameters.
+
+A parameter is one of: a **FormLink** to a specific record type (so `GetIsID`'s `Object` must be a *base
+object*, `GetStage`'s `Quest` must be a *QUST*, etc. — a link of the wrong type is malformed), an **enum**
+(`GetActorValue`'s `ActorValue`, `GetIsSex`'s gender), or a **raw int/string** (`GetStageDone`'s stage
+number, `GetIsAliasRef`'s alias index, `GetVMQuestVariable`'s variable name). A few functions take **no**
+parameter and read state off the Run On object alone (`GetLevel`, `GetDead`, `GetRandomPercent`, …).
+
+## Dialogue / quest condition functions (curated)
+
+The functions that show up in quest and dialogue gating, with their **Mutagen parameter shape** (authoritative)
+and what they test. The `…ConditionData` Data-arm name is `<Function>ConditionData`. Compare each with an
+operator + value as shown in the "Reads as" notes.
+
+### Quest progress & state
+| Function | Parameter(s) | What it tests |
+|---|---|---|
+| `GetStage` | `Quest` → QUST | the quest's **current** highest-set stage. Window gate = **two rows**: `>= N` AND `<= M`. |
+| `GetStageDone` | `Quest` → QUST, `Stage` → int | whether a **specific** stage index has **ever** been set (1/0) — true even after the quest moved past it. **Not** `GetStage`. |
+| `GetQuestRunning` | `Quest` → QUST | 1 if the quest is currently running. |
+| `GetQuestCompleted` | `Quest` → QUST | 1 if the quest is completed. |
+| `GetVMQuestVariable` | `Quest` → QUST, `VariableName` → string | value of a script variable on the quest's VM (the variable must exist on the quest's script). |
+
+### Speaker / actor identity
+| Function | Parameter(s) | What it tests |
+|---|---|---|
+| `GetIsID` | `Object` → **base** form (NPC_/etc.) | 1 if the Run On reference's **base form** equals `Object`. Pass the **base NPC_**, not a placed REFR. For a leveled actor it compares the spawned ActorBase. |
+| `GetIsAliasRef` | `ReferenceAliasIndex` → int | 1 if the Run On reference fills that **reference alias of the owning quest**. Index is quest-relative — wrong index = dead. |
+| `GetIsRace` | `Race` → RACE | 1 if the Run On actor's race matches. |
+| `GetIsSex` | `MaleFemaleGender` → enum (`Male`/`Female`) | 1 if the Run On actor's sex matches. |
+| `GetIsVoiceType` | `VoiceTypeOrList` → VTYP or FormList | 1 if the Run On actor's voice type is (in) the form. |
+| `GetIsObjectType` | `FormType` → enum | 1 if the Run On object is of that record/form type. |
+| `GetIsCurrentPackage` | `Package` → PACK | 1 if the Run On actor's running package matches. |
+| `GetDead` | *(none)* | 1 if the Run On actor is dead. |
+| `GetTalkedToPC` | *(none)* | 1 if the Run On actor has talked to the player before. |
+
+### Faction & relationship
+| Function | Parameter(s) | What it tests |
+|---|---|---|
+| `GetInFaction` | `Faction` → FACT | 1 if the Run On actor is in the faction. |
+| `GetFactionRank` | `Faction` → FACT | the Run On actor's **rank** in the faction. **Gate on `< 0`**, not `== 0` (rank −1 = not in faction; 0 is a real rank). |
+| `GetRelationshipRank` | `TargetNpc` → actor ref | relationship rank between the Run On actor and the other actor. |
+
+### Location
+| Function | Parameter(s) | What it tests |
+|---|---|---|
+| `GetInCurrentLoc` | `Location` → LCTN | 1 if the Run On actor's current location is / is within `Location`. |
+| `GetInCurrentLocAlias` | `LocationAliasIndex` → int | same, against a **location alias** of the owning quest. |
+
+### Inventory & equipment
+| Function | Parameter(s) | What it tests |
+|---|---|---|
+| `GetItemCount` | `ItemOrList` → item or FormList | count of the item (or any in the list) in the Run On actor's inventory. |
+| `GetEquipped` | `ItemOrList` → item or FormList | 1 if the Run On actor has it equipped. |
+| `GetGold` | *(none)* | the Run On actor's gold. |
+| `HasKeyword` | `Keyword` → KYWD | 1 if the Run On **object** has the keyword. |
+
+### Stats, magic & misc state
+| Function | Parameter(s) | What it tests |
+|---|---|---|
+| `GetActorValue` | `ActorValue` → enum | the Run On actor's current value of that actor value. |
+| `GetLevel` | *(none)* | the Run On actor's level. |
+| `GetGlobalValue` | `Global` → GLOB | the value of a global (Run On is irrelevant — it's a global). |
+| `GetRandomPercent` | *(none)* | a fresh random 0–99 **each evaluation** — for chance gates; never stable across re-checks. |
+| `GetDeadCount` | `Npc` → base NPC_ | how many instances of that base actor are dead. |
+| `GetSitting` | *(none)* | the Run On actor's sit/furniture state (a code, not a plain bool). |
+| `GetIsAlerted` | *(none)* | 1 if the Run On actor is alerted. |
+| `HasSpell` | `Spell` → SPEL | 1 if the Run On actor knows the spell (also abilities/diseases). |
+| `HasPerk` | `Perk` → PERK | 1 if the Run On actor has the perk. |
+| `HasMagicEffect` | `MagicEffect` → MGEF | 1 if the effect is active on the Run On actor. |
+| `HasMagicEffectKeyword` | `Keyword` → KYWD | 1 if an active effect on the Run On actor has the keyword. |
+| `IsInList` | `FormList` → FLST | 1 if the Run On object is in the form list. |
+
+This is a **curated dialogue/quest subset**, not the full set — Mutagen models **every** condition function
+(hundreds, including all the combat/VATS/weather/AI ones). To decode a function not in this table, read the
+`ConditionData` arm name and its named fields directly, and look the function up in `mutagen-reference`
+(the arm `<Function>ConditionData`) or the CK wiki.
+
+## CTDA conditions vs Papyrus-only functions
+
+A common authoring trap: reaching for a **Papyrus** function name as a condition. The two namespaces overlap
+but are **not** the same set — a function being callable in a `.psc` does **not** make it a condition
+function, and vice-versa. The condition-function set is **fixed and complete** (Mutagen models all of it by
+construction), so the test is simple: **if a name is not a condition function, it cannot go in a CTDA.**
+
+The frequent confusions are the `Is…` Papyrus methods vs the `Get…` condition functions:
+
+| You want (Papyrus habit) | The **condition** function is | Note |
+|---|---|---|
+| `Actor.IsPlayerTeammate()` | **`GetPlayerTeammate`** | `IsPlayerTeammate` is **not** a condition — using it in a CTDA is impossible. |
+| `Actor.IsInFaction(f)` | **`GetInFaction`** | the condition is `Get…`, not `Is…`. |
+| `Actor.IsEquipped(x)` / `IsEquippedWeapon` | **`GetEquipped`** | |
+| `Actor.IsDead()` | **`GetDead`** | |
+| `ObjectReference.GetItemCount(x)` | **`GetItemCount`** | same name here — but confirm, don't assume. |
+
+Many `Is…` names **do** exist as conditions (`IsSneaking`, `IsInCombat`, `IsHostileToActor`, `IsWeaponOut`,
+…), so the rule isn't "Is = Papyrus, Get = condition" — it's **"only a name in the condition-function set is
+a condition."** When unsure: check the arm exists in `mutagen-reference` (as `<Name>ConditionData`), or read
+a known-good CTDA back and copy its function. Never hand-write a function the CK's own dropdown wouldn't
+offer.
+
+## Decoding a condition you read back — worked example
+
+`housecarl_read_record` on an INFO with `Conditions` deep returns, per row, the arm + operator + value +
+the Data arm + its params. Read this row:
+
+```
+ConditionFloat
+  CompareOperator = GreaterThanOrEqualTo
+  ComparisonValue = 20
+  Data = GetStageConditionData { Quest = 001234:MyMod.esp, RunOnType = Subject }
+  Flags = (none)
+```
+
+→ **"`GetStage(MyMod quest 001234) >= 20`, evaluated on the speaker."** Because `GetStage` reads the quest in
+its parameter, the `Subject` Run On is harmless here (the result doesn't depend on the speaker). Contrast a
+row whose function *does* depend on the Run On — `GetItemCount` on `Subject` counts the **NPC's** items, on
+`Target` the **player's** — there the Run On is the whole meaning.
+
+To **write** conditions, never hand-synthesize the encoded operator/comparison bytes — read a verified gate
+back and replay its rows verbatim (the `bulk_apply` clone recipe in `SKILL.md`).

--- a/.claude/skills/dialogue-authoring/references/dialogue-branch.md
+++ b/.claude/skills/dialogue-authoring/references/dialogue-branch.md
@@ -1,0 +1,69 @@
+# Dialogue Branch (DLBR) reference
+
+A **Dialogue Branch** is a conversation entry point — the record that makes a `Custom`-subtype topic
+*reachable*. The flow-model reference introduces it; this one is the field-and-flag detail, because the three
+branch flags change in-game behavior in ways a record-only glance won't reveal, and one of them
+(`Exclusive`) can silently lock an NPC out of all dialogue.
+
+Field names are Mutagen spellings (by construction from the record model — see `_CORPUS_STATUS.md`); flag
+**semantics** are from the Creation Kit wiki. Confirm exact paths against `mutagen-reference`.
+
+## Fields (Mutagen `DialogBranch`)
+
+| Field | Type | Meaning |
+|---|---|---|
+| `Quest` | `FormLink<Quest>` | the quest that owns the branch (its topics' `Conditions` typically gate on this quest's stage). |
+| `StartingTopic` | `FormLink<DialogTopic>?` | **the branch's entry point** — the first DIAL the game shows when the branch is entered. A branch with no `StartingTopic` is inert. |
+| `Category` | `DialogBranch.CategoryType` enum | `Player` or `Command` (below). |
+| `Flags` | `DialogBranch.Flag` enum | `TopLevel`, `Blocking`, `Exclusive` (below) — combinable. |
+
+The reverse link `DialogTopic.Branch` (BNAM) points a topic back at its DLBR; it is **often unset** — generic
+topics have no branch, and a `Custom` topic is reached via the branch's `StartingTopic`, not via its own
+`Branch` field. Don't read a missing `DialogTopic.Branch` as a defect.
+
+## Category — `Player` vs `Command`
+
+- **`Player`** — a player-initiated conversation branch: the topics are choices the player picks from a menu.
+  This is what you author for "add a dialogue option to an NPC."
+- **`Command`** — a command/forced branch (used by the game's command and AI-driven dialogue), not a
+  player-choice menu. You rarely author these by hand.
+
+## Flags — the behavior that isn't in the bytes
+
+(Creation Kit wiki, *Dialogue Branch*.) The flags decide how the branch's topics surface against the NPC's
+other dialogue.
+
+- **`TopLevel`** — the branch's topics appear as **separate options in the dialogue menu** when the player
+  starts a conversation. Top-level branches **begin with a player line** (a choice), not an NPC line, so many
+  branches from many sources sit **side by side** without any one of them pushing the conversation. This is
+  the usual flag for "a new player-choice topic on an NPC."
+- **`Blocking`** — **overrides the NPC's normal topic list.** When the NPC has a *valid* info in a blocking
+  branch's `StartingTopic`, the NPC uses it as the **greeting**, and if that info has a choice list, those
+  choices replace the normal topic list. Use it to force the player through a specific exchange (e.g. a quest
+  beat that must happen before normal chatter resumes).
+- **`Exclusive`** — like `Blocking`, but it **takes over the topic list once the branch is "entered"** (the
+  NPC speaks a line from any of the branch's topics). The NPC stays "in" the exclusive branch — acting as if
+  it were a valid blocking branch — **until it speaks a line from a different, non-exclusive branch.** So if
+  you exit and re-open dialogue, the greeting is the exclusive branch's `StartingTopic` again.
+  - ⚠️ **The deadlock:** if the exclusive branch has **no topic the NPC can currently speak** (e.g. all its
+    infos' conditions fail), the NPC is stuck "in" the branch with nothing valid to say — which can **block
+    all of that NPC's dialogue.** An exclusive branch must always have an exit: a valid info under the current
+    conditions, or a line from another branch that releases it.
+
+## Reachability — why a `Custom` topic needs a branch
+
+A `Custom`-subtype topic is **not** matched by the generic subtype system (Hello/Goodbye/… are matched
+automatically; `Custom` is not). It becomes reachable only by being a branch's `StartingTopic` **or** the
+`LinkTo` target of another reachable topic. A byte-valid `Custom` topic with neither is **never entered** in
+game — the most common "I added a topic and nothing happens" cause. When you author a new player-choice menu,
+author the DLBR in the **same** `housecarl_bulk_create` call (declared *after* the topic) with
+`StartingTopic` set to the topic's `@editorid`, `Category = Player`, and `Flags = TopLevel` for an ordinary
+side-by-side option. (See the `SKILL.md` reachability note.)
+
+## Quick decode
+
+Reading a branch back: `Category` tells you player-menu vs command; the `Flags` tell you whether it sits
+beside other options (`TopLevel`), hijacks the greeting/topic list (`Blocking`), or latches the NPC into
+itself until released (`Exclusive`); `StartingTopic` is where it begins. A `Blocking`/`Exclusive` branch
+whose starting topic has no currently-valid info is the thing to flag — it's how an NPC goes silent or
+gets stuck.

--- a/.claude/skills/dialogue-authoring/references/quest-objectives-tab.md
+++ b/.claude/skills/dialogue-authoring/references/quest-objectives-tab.md
@@ -1,0 +1,74 @@
+# Quest stages & objectives reference
+
+The quest layer dialogue gates on. Dialogue conditions read the quest **stage** (`GetStage`/`GetStageDone`);
+the **journal** the player sees is driven by **objectives** and stage **log entries**. These are three
+distinct things people conflate — stage number, objective index, and log entry — and conflating them is how
+a journal goes wrong while the dialogue is fine.
+
+Field names are Mutagen spellings (by construction — see `_CORPUS_STATUS.md`); the display/script behavior is
+from the Creation Kit wiki + practice. Confirm exact paths against `mutagen-reference`.
+
+## The three things, kept separate
+
+| Thing | Mutagen | What it is |
+|---|---|---|
+| **Stage** | `Quest.Stages[]` → `QuestStage` | a numbered progress point. `Index` (ushort), `Flags`, and `LogEntries`. Advancing the quest = setting a stage. |
+| **Log entry** | `QuestStage.LogEntries[]` → `QuestLogEntry` | the **journal text** shown for a stage (`Entry`), optionally `Conditions`-gated, plus the stage's script bytes. A stage can have zero log entries (a silent/controller stage). |
+| **Objective** | `Quest.Objectives[]` → `QuestObjective` | a **tracked goal**: `Index` (ushort), `DisplayText`, `Flags`, and `Targets`. What shows under the quest with a map marker. |
+
+A **stage** moves the quest forward and (via its log entry) can write a journal line. An **objective** is the
+"current goal" with a quest-marker. They are **independent numbering systems** — see the convention note.
+
+## Stages (`QuestStage`)
+
+- **`Index`** — the stage number (the value `GetStage` returns / `SetStage` sets).
+- **`Flags`** (`QuestStage.Flag`): `StartUpStage` (the stage the quest enters when it starts),
+  `ShutDownStage` (running it stops/completes the quest), `KeepInstanceDataFromHereOn`.
+- **`LogEntries`** — the journal text candidates for the stage. Each `QuestLogEntry` has `Entry` (the text),
+  optional `Conditions` (so a stage can show different journal text by condition), a `Flags`
+  (`CompleteQuest`/etc.), `NextQuest`, and the stage **script fragment** bytes (`SCHR`/`SCTX`) — the Papyrus
+  that runs **when the stage is set**.
+
+The stage fragment is where most authors put `SetObjectiveDisplayed`/`SetObjectiveCompleted` calls and other
+beats — so "what happens at stage N" usually lives in stage N's fragment, not in a condition. (Fragment
+indices are not obviously tied to stage numbers; the CK wiki recommends comments for clarity.)
+
+## Objectives (`QuestObjective`)
+
+- **`Index`** — the objective number. This is the index `SetObjectiveDisplayed(index)` /
+  `SetObjectiveCompleted(index)` take; **they only accept indices defined on the Objectives tab.**
+- **`DisplayText`** — the goal text shown in the journal/HUD.
+- **`Flags`** (`QuestObjective.Flag`): `OrWithPrevious` — groups this objective's display with the previous
+  one (an "A **or** B" goal).
+- **`Targets`** (`QuestObjectiveTarget`): where the quest marker points. Each target is an **`AliasID`** (an
+  alias of *this* quest), with optional `Conditions` and `Flags` (`Quest.TargetFlag`). The marker resolves at
+  runtime to whatever reference fills that alias — so a target whose alias never fills shows **no marker**.
+
+## The index convention — a practice, not a rule
+
+A widespread habit is to make an objective's index **match the stage number** that displays it (objective 10
+shown at stage 10), because it reads cleanly. **It is not enforced** — objective indices and stage numbers
+are independent numeric spaces, and `SetObjectiveDisplayed`/`SetObjectiveCompleted` reference the **objective
+index**, wherever it's called from (UESP CK wiki). Don't assume "stage N ⇒ objective N exists"; read the
+Objectives tab for the real indices. (This corrects the looser "objective-index = stage-number" shorthand —
+treat aligned numbering as a convention authors *choose*, and verify it per quest.)
+
+## How they drive the journal (the part that bites)
+
+- `SetStage(n)` runs stage n's fragment and shows its (condition-passing) log entry. Advancing the quest is
+  stage work.
+- `SetObjectiveDisplayed(index, true)` shows an objective + its marker; `SetObjectiveCompleted(index, true)`
+  ticks it done; `SetObjectiveDisplayed(index, false)` hides it.
+- These are usually called **from stage fragments** — so the journal you see is the *combination* of which
+  stage set what objective state. A common bug: setting a stage but never displaying/completing the matching
+  objective (no goal shown), or completing the quest stage but leaving an objective still "displayed"
+  (lingering goal).
+
+## Relevance to dialogue
+
+Dialogue lines gate on **stage** (`GetStage`/`GetStageDone`), almost never on objectives — objectives are a
+display concern. So when "a line won't fire," check the **stage** condition against the quest's real stage
+indices here; when "the journal looks wrong," check **objectives** and **log entries**. They fail
+independently, and houseCARL can read all of them back (`housecarl_read_record` on the QUST,
+`housecarl_validate_dialogue` on the quest for the dialogue side). Remember `Stop()` resets the stage to 0 —
+never gate post-completion dialogue on a stopping quest's stage (see the flow-model reference).


### PR DESCRIPTION
## Item 3 — bundle the CK CTDA-decode + quest reference pages (1.3.1 roadmap §3 item 3)

Four hand-curated references under `dialogue-authoring/references/` — the **keystone for item 4** (you can't lint a CTDA you can't decode). Doc-only, no tool, no new skill → PATCH.

### Files
- **condition-functions.md** — decode a condition (CTDA): the two arms (`ConditionFloat`/`ConditionGlobal`), `CompareOperator`, the `OR` + `SwapSubjectAndTarget` flags, the 8 Run On types (**Subject = speaker, Target = player**), a curated ~40-function dialogue/quest param table, and a **CTDA-condition vs Papyrus-only** section.
- **dialogue-branch.md** — DLBR fields + `TopLevel`/`Blocking`/`Exclusive` flags, incl. the **Exclusive-branch deadlock** that can mute an NPC entirely.
- **quest-objectives-tab.md** — stages vs objectives vs log entries; **objective index is a convention, not a rule** (corrects the roadmap shorthand).
- **_CORPUS_STATUS.md** — provenance + staleness duty.

### Sourcing (creationkit.com was down — approved substitution)
- **Structure** (which functions exist, param shapes, Run On / operator / flag enums, DLBR/Quest/QuestStage/QuestObjective fields) is **by construction from Mutagen** (`mutagen-reference`) — exactly what `read_record` surfaces and the write tools compose. More authoritative for decode than the wiki itself.
- **Semantics** from the CK wiki (UESP-hosted `ck.uesp.net`, via web search) + modding-domain knowledge. Marked honestly in `_CORPUS_STATUS.md`. Approved 2026-06-22, surfaced not silent.

### A-iii preserved
SKILL.md is wired **additively**. The "**conditions are unverifiable at the data layer**" CANNOT claim is **kept verbatim** — item 3 only adds "houseCARL can *decode* a condition," consistent with "can't *evaluate* it." Item 4's A-iii reword remains a separate, pending decision.

### Verification
Frontmatter intact; internal links resolve; references ship via `build-plugin.ps1`'s recursive copy (no packaging edit). CI `plugin-validate-guard` is the formal gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
