### PR TITLE
Static condition (CTDA) lints in validate_dialogue (1.3.1 item 4)

### DIFF
--- a/.claude/skills/dialogue-authoring/SKILL.md
+++ b/.claude/skills/dialogue-authoring/SKILL.md
@@ -154,7 +154,8 @@ this skill's job.
    `into=` edit if you want it, though `Branch` is usually left unset. (Adding a line to an *existing* topic
    needs none of this — its entry point already exists.)
 
-3. **Author the conditions deliberately** — they are the gate the validator cannot check. A line with no
+3. **Author the conditions deliberately** — the validator can check them for *malformedness* but never
+   *evaluate* whether a well-formed one passes. A line with no
    conditions fires whenever its topic is reached; gate it with `GetStage` (quest progress) and a speaker
    check (`GetIsID`/alias) as the flow model describes. Compose each `Condition` per `mutagen-reference`
    (it is a polymorphic list); [`references/condition-functions.md`](references/condition-functions.md) has

--- a/.claude/skills/dialogue-authoring/SKILL.md
+++ b/.claude/skills/dialogue-authoring/SKILL.md
@@ -28,12 +28,15 @@ tools.
   (`housecarl_validate_dialogue`, `housecarl_read_record`, `housecarl_cross_plugin_query`).
 
 **What houseCARL CANNOT do — say it, never paper over it:**
-- **Evaluate `Conditions` (CTDA).** Conditions decide *when* a line fires; only the running game evaluates
-  them, so a wrong or missing condition silently stops a line forever and is **unverifiable at the data
-  layer**. This is the single most common silent-dead-dialogue cause and it is on the author to get right.
-  houseCARL *can* read a condition back and **decode** it — the function, its parameters, and its Run On
-  scope ([`references/condition-functions.md`](references/condition-functions.md)) — so you can check it by
-  eye; it cannot tell you whether it *passes*.
+- **Evaluate `Conditions` (CTDA).** Conditions decide *when* a line fires. houseCARL **can** statically catch a
+  meaningful subset of **malformed** conditions — `housecarl_validate_dialogue` flags a dangling form reference,
+  a dead quest-alias index, an unset Run On reference, and a `GetIsID` pointed at a placed instance — and it can
+  read a condition back and **decode** it (the function, its parameters, its Run On scope —
+  [`references/condition-functions.md`](references/condition-functions.md)) so you can check it by eye. What it
+  **cannot** do is **evaluate** whether a *well-formed* condition passes — only the running game can. So a
+  well-formed but *wrong* condition (the wrong stage number, the wrong Run On for the intent) still silently
+  stops a line forever — that remains the single most common silent-dead-dialogue cause and on the author to get
+  right.
 - **Record voice audio or verify lip-sync.** Voice presence is an on-disk file check; the audio content and
   voice *acting* are out of scope.
 - **Promise "this will play" from a clean structural pass.** A green validate means the wiring resolves —
@@ -244,8 +247,9 @@ has no `Subtype` field. Copy the exact value from a known-good ForceGreet topic 
   "fix" a topic, and never report its absence as a defect.
 - **Forgetting the SEQ.** A Start-Game-Enabled quest with no `.seq` never starts, and neither does its
   dialogue. Ticking the flag is half the job — write the `.seq`.
-- **Reading a clean validate as "it'll play."** Conditions are unverified by definition. A green graph with
-  wrong `GetStage` conditions is silent in game. Always carry the standing-limits footer to the user.
+- **Reading a clean validate as "it'll play."** A green validate catches *malformed* conditions but never
+  proves a *well-formed* one is *correct* — a wrong `GetStage` value passes validation and is silent in game.
+  Always carry the standing-limits footer to the user.
 - **Computing the voice folder from the conflict winner.** It is the plugin that *defines* the INFO. For a
   new plugin that's yours (clean); for an override it's the original's folder, where the audio lives.
 - **Overriding a topic and dropping its other lines** (the DIAL-wins-wholesale trap above).

--- a/.claude/skills/dialogue-authoring/references/_CORPUS_STATUS.md
+++ b/.claude/skills/dialogue-authoring/references/_CORPUS_STATUS.md
@@ -9,7 +9,7 @@ empirically grounded through houseCARL reads — see their own headers.)
 
 Hand-curated references that let houseCARL **decode** a condition (CTDA) and read the quest layer dialogue
 gates on — turning a read-back `Conditions`/`Stages`/`Objectives` array into meaning, instead of echoing raw
-bytes. They are the **keystone for the planned static condition-lint** (1.3.1 roadmap item 4): you cannot
+bytes. They are the **keystone for the static condition-lint** (shipped 1.3.1, roadmap item 4): you cannot
 lint a condition you cannot decode.
 
 **These are curated, not generated.** Like the bundled SkyPatcher/SPID/KID grammar references, they ship as

--- a/src/housecarl-core/DialogueValidate.cs
+++ b/src/housecarl-core/DialogueValidate.cs
@@ -437,10 +437,11 @@ public static class DialogueValidate
     ///   1. Run On a specific Reference with NO reference set — the gate evaluates against nothing.
     ///   2. A DEAD ALIAS INDEX — Run On:QuestAlias, or a GetIsAliasRef / GetInCurrentLocAlias param, naming an alias
     ///      ID the OWNING quest does not define. SKIPPED (never guessed) when the owning quest is unknown (ownerAliasIds null).
-    ///   3. A DANGLING form parameter — any condition-function FormLink param pointing at a form not in the active
-    ///      load order. GENERIC, BY CONSTRUCTION via EnumerateFormLinks, so it covers EVERY function Mutagen models,
-    ///      not a hand-listed subset (cornerstone-consistent). The Run On Reference slot is excluded (lint 1 owns it),
-    ///      so an unused/parked Reference is never mis-flagged.
+    ///   3. A DANGLING form parameter — any condition-function form target (a plain FormLink, or a FORM-mode
+    ///      FormLinkOrIndex) pointing at a form not in the active load order. GENERIC, BY CONSTRUCTION (reflection over
+    ///      the Data arm's properties), so it covers EVERY function Mutagen models, not a hand-listed subset
+    ///      (cornerstone-consistent). The Run On Reference slot is excluded (lint 1 owns it), so an unused/parked
+    ///      Reference is never mis-flagged; alias/package-data-mode FLOIs are gated out (see the per-condition note).
     ///   4. A DANGLING global comparison value — a ConditionGlobal compared against a GLOB not in the load order.
     ///   5. GetIsID pointed at a PLACED reference instead of a base object — GetIsID compares the run-on actor's BASE
     ///      form, so a placed-instance FormID can never match as intended.
@@ -460,6 +461,15 @@ public static class DialogueValidate
             var data = cond.Data;
             var fn = data.Function.ToString();
             var refKey = data.Reference.FormKey;   // the Run On reference slot — owned by lint 1, excluded from the param sweep
+
+            // FLOI MODE GATE (the load-bearing one). A condition form-parameter is a FormLinkOrIndex (Quest, Object,
+            // Perk, …): a FORM only when the arm is in form mode; in alias / package-data mode the SAME slot is an
+            // INDEX. On the binary OVERLAY the validator reads (CreateFromBinaryOverlay), an index-mode FLOI's .Link
+            // is a BOGUS low FormKey synthesised from the index bytes — NOT null — so reading it as a form would
+            // false-flag a perfectly well-formed alias-mode gate (e.g. "run-on actor has the perk held by quest-alias
+            // N"), the A-iii / Q3 worst case. Mirror the proven write-side gate (WriteEngine's condition scan +
+            // ReadEngine.EmitFloi): treat an FLOI as a form ONLY when UseAliases AND UsePackageData are both false.
+            bool floiIsForm = !data.UseAliases && !data.UsePackageData;
 
             // 1. Run On a specific Reference but none / a missing one is set — the function runs against nothing.
             if (data.RunOnType == Condition.RunOnType.Reference)
@@ -485,19 +495,20 @@ public static class DialogueValidate
 
             // 3. Dangling form-link PARAMETER — generic, BY CONSTRUCTION: reflect over the Data arm's properties and
             //    take every form TARGET it carries — a plain FormLink (Faction, Spell, Keyword, FormList, …) AND a
-            //    form-mode FormLinkOrIndex (the condition union — Quest, GetIsID's Object, …; read via the write-side
-            //    ReadFloiFormKey, the oracle-proven accessor, so an alias/index-mode FLOI returns null here and is
-            //    lint 2's job). The Run On Reference slot is skipped by name (lint 1 owns it). A param pointing at a
-            //    form not in the active order is a dead reference. This mirrors the write engine's own FLOI handling
-            //    (a plain EnumerateFormLinks does NOT cleanly surface the FLOI union), so it covers EVERY function
-            //    Mutagen models — never a hand-listed subset.
+            //    FORM-MODE FormLinkOrIndex (the condition union — Quest, GetIsID's Object, …; read via the write-side
+            //    ReadFloiFormKey). An alias/package-data-mode FLOI is GATED OUT by floiIsForm (its index is not a form,
+            //    and its overlay .Link is a bogus low key — see the mode-gate note above); the alias-INDEX paths it
+            //    leaves are lint 2's int-property domain, and an alias-mode FLOI *parameter* is deliberately out of
+            //    scope (a future extension, not a dangling-form case). The Run On Reference slot is skipped by name
+            //    (lint 1 owns it). A param pointing at a form not in the active order is a dead reference. Mirrors the
+            //    write engine's own FLOI handling, so it covers EVERY function Mutagen models — never a hand-listed subset.
             foreach (var p in data.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
             {
                 if (p.Name == "Reference" || p.GetIndexParameters().Length != 0) continue;   // run-on ref → lint 1
                 object? v; try { v = p.GetValue(data); } catch { continue; }
                 FormKey? paramFk =
                     v is IFormLinkGetter fl && !fl.IsNull ? fl.FormKey
-                    : WriteEngine.IsFormLinkOrIndex(p.PropertyType) ? WriteEngine.ReadFloiFormKey(v) : null;
+                    : floiIsForm && WriteEngine.IsFormLinkOrIndex(p.PropertyType) ? WriteEngine.ReadFloiFormKey(v) : null;
                 if (paramFk is { } pk && !inOrder(pk))
                     issues.Add(new(DialogueIssueSeverity.Warning,
                         $"INFO {info.FormKey} condition #{n} ({fn}) references {pk}, which is not in the active load order — a deleted/disabled form or a wrong FormID, so the condition can't evaluate as intended."));
@@ -511,7 +522,9 @@ public static class DialogueValidate
 
             // 5. GetIsID pointed at a PLACED reference — the wrong KIND of form (a dangling one is already caught by
             //    lint 3). GetIsID compares the run-on actor's BASE form, so a placed-instance FormID can never match.
-            if (data is IGetIsIDConditionDataGetter gid && WriteEngine.ReadFloiFormKey(gid.Object) is { } objFk
+            //    Gated on floiIsForm too: an alias-mode GetIsID.Object is an index, not a form to resolve (without the
+            //    gate its bogus overlay .Link could trip resolve()); a form-mode Object is the real base-vs-placed case.
+            if (data is IGetIsIDConditionDataGetter gid && floiIsForm && WriteEngine.ReadFloiFormKey(gid.Object) is { } objFk
                 && inOrder(objFk) && resolve(objFk) is IPlacedGetter)
                 issues.Add(new(DialogueIssueSeverity.Warning,
                     $"INFO {info.FormKey} condition #{n} (GetIsID) points at the placed reference {objFk}, but GetIsID compares the run-on actor's BASE form — pass the base NPC_/object, not a placed instance."));

--- a/src/housecarl-core/DialogueValidate.cs
+++ b/src/housecarl-core/DialogueValidate.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Records;
 using Mutagen.Bethesda.Skyrim;
@@ -260,6 +261,20 @@ public static class DialogueValidate
             issues.Add(new(DialogueIssueSeverity.Problem,
                 $"DialogTopic.Branch points at {branchFk.Value}, which {bwhy} — the branch wiring is broken."));
 
+        // Static condition lints (item 4) need the owning quest's reference-alias IDs — resolved ONCE here off the
+        // load-order WINNER quest (an alias index in a condition is quest-relative, so it's the owning quest's set
+        // that decides whether the index is live). NULL when the quest is unset or unresolvable (already surfaced
+        // above): when we can't read the alias set we SKIP the alias-index lints rather than guess (Q3 — never a
+        // false "dead alias" against a quest we couldn't read). Non-alias condition lints don't need this and run
+        // regardless.
+        HashSet<uint>? ownerAliasIds = null;
+        string ownerQuestLabel = "the owning quest";
+        if (questFk is { } ownerFk && resolve(ownerFk) is IQuestGetter ownerQuest)
+        {
+            ownerAliasIds = ownerQuest.Aliases.Select(a => a.ID).ToHashSet();
+            ownerQuestLabel = $"the owning quest {ownerQuest.EditorID ?? ownerFk.ToString()}";
+        }
+
         // --- Per-INFO walk over the topic's LIVE INFOs. A deleted INFO is a REMOVED line — skip it entirely (don't
         //     count it, chain it, or voice/script-check it; tally it for an honest "N skipped" note, Q3). InfoCount is
         //     INFO RECORDS, not spoken rows (one INFO can carry several DialogResponse rows, or none).
@@ -297,7 +312,14 @@ public static class DialogueValidate
                         $"INFO {info.FormKey} links (LinkTo) to {lk}, which {lwhy} — the conversation chain is broken."));
             }
 
-            if (info.Conditions.Count > 0) conditioned++;
+            if (info.Conditions.Count > 0)
+            {
+                conditioned++;
+                // Static condition (CTDA) well-formedness lints (item 4) — the data-layer-decidable, true-positive
+                // subset. They catch MALFORMED conditions; they do NOT (and cannot) evaluate whether a well-formed
+                // one passes — that stays the running game's job (the standing CTDA limit, restated in the render).
+                CheckConditions(info, ownerAliasIds, ownerQuestLabel, inOrder, resolve, issues);
+            }
 
             // Reuse the per-INFO voice + result-script checks over every LIVE INFO (resolved-winner view). These are the
             // exact methods the per-create teeth run, so the create path and the validator can never drift.
@@ -403,4 +425,106 @@ public static class DialogueValidate
         issues.Add(new(DialogueIssueSeverity.Warning,
             $"{locus} contains non-ASCII char(s) {desc} — the CK/Papyrus user-facing text surface is Windows-1252/ASCII, so these usually render as in-game mojibake.{sug}"));
     }
+
+    /// <summary>Static condition-lint suite (item 4) over one INFO's <c>Conditions</c> (CTDA rows) — the
+    /// data-layer-decidable subset the §4 design decision (A-iii) authorises. Every lint here is a TRUE-positive
+    /// STRUCTURAL defect (a malformed condition), never a behavioural guess: houseCARL still cannot EVALUATE whether
+    /// a well-formed condition passes — only the running game can (the standing CTDA limit, restated in the render).
+    /// All emit WARNING, never block: a dead gate misfires that one line, it doesn't break the topic's chain, and a
+    /// few load-order shapes are legitimately edge-y, so it's an advisory the author confirms (roadmap §3 item 4).
+    ///
+    /// The lints (each decidable from the record + the form index alone):
+    ///   1. Run On a specific Reference with NO reference set — the gate evaluates against nothing.
+    ///   2. A DEAD ALIAS INDEX — Run On:QuestAlias, or a GetIsAliasRef / GetInCurrentLocAlias param, naming an alias
+    ///      ID the OWNING quest does not define. SKIPPED (never guessed) when the owning quest is unknown (ownerAliasIds null).
+    ///   3. A DANGLING form parameter — any condition-function FormLink param pointing at a form not in the active
+    ///      load order. GENERIC, BY CONSTRUCTION via EnumerateFormLinks, so it covers EVERY function Mutagen models,
+    ///      not a hand-listed subset (cornerstone-consistent). The Run On Reference slot is excluded (lint 1 owns it),
+    ///      so an unused/parked Reference is never mis-flagged.
+    ///   4. A DANGLING global comparison value — a ConditionGlobal compared against a GLOB not in the load order.
+    ///   5. GetIsID pointed at a PLACED reference instead of a base object — GetIsID compares the run-on actor's BASE
+    ///      form, so a placed-instance FormID can never match as intended.
+    ///
+    /// DELIBERATELY NOT LINTED (semantic, not structural — flagging them would be a behavioural guess that risks the
+    /// false positives A-iii's honesty forbids, so they stay the author's call / the standing limit): Run On
+    /// Subject-vs-Target INTENT (a player-shaped function left on Subject), the faction-rank gate VALUE (&lt; 0 vs == 0),
+    /// and intra-topic Info-variant ORDERING (a specific line shadowed by a generic sibling). Scope is INFO conditions
+    /// (the dialogue surface); a quest's own DialogConditions/alias conditions are out of this pass.</summary>
+    internal static void CheckConditions(IDialogResponsesGetter info, HashSet<uint>? ownerAliasIds, string ownerQuestLabel,
+        Func<FormKey, bool> inOrder, Func<FormKey, IMajorRecordGetter?> resolve, List<DialogueIssue> issues)
+    {
+        int n = 0;
+        foreach (var cond in info.Conditions)
+        {
+            n++;
+            var data = cond.Data;
+            var fn = data.Function.ToString();
+            var refKey = data.Reference.FormKey;   // the Run On reference slot — owned by lint 1, excluded from the param sweep
+
+            // 1. Run On a specific Reference but none / a missing one is set — the function runs against nothing.
+            if (data.RunOnType == Condition.RunOnType.Reference)
+            {
+                if (data.Reference.IsNull)
+                    issues.Add(new(DialogueIssueSeverity.Warning,
+                        $"INFO {info.FormKey} condition #{n} ({fn}) is set to Run On a specific reference, but no reference is set — it evaluates against nothing, so the gate never behaves as intended."));
+                else if (!inOrder(refKey))
+                    issues.Add(new(DialogueIssueSeverity.Warning,
+                        $"INFO {info.FormKey} condition #{n} ({fn}) Run On reference {refKey} is not in the active load order — the gate evaluates against nothing."));
+            }
+
+            // 2. Dead alias index — only when the owning quest's alias set is known (else skip, never guess, Q3).
+            if (ownerAliasIds is not null)
+            {
+                if (data.RunOnType == Condition.RunOnType.QuestAlias && BadAlias(data.RunOnTypeIndex, ownerAliasIds))
+                    issues.Add(AliasIssue(info.FormKey, n, fn, data.RunOnTypeIndex, "is set to Run On", "reference-alias", ownerQuestLabel));
+                if (data is IGetIsAliasRefConditionDataGetter gar && BadAlias(gar.ReferenceAliasIndex, ownerAliasIds))
+                    issues.Add(AliasIssue(info.FormKey, n, fn, gar.ReferenceAliasIndex, "references", "reference-alias", ownerQuestLabel));
+                if (data is IGetInCurrentLocAliasConditionDataGetter gla && BadAlias(gla.LocationAliasIndex, ownerAliasIds))
+                    issues.Add(AliasIssue(info.FormKey, n, fn, gla.LocationAliasIndex, "references", "location-alias", ownerQuestLabel));
+            }
+
+            // 3. Dangling form-link PARAMETER — generic, BY CONSTRUCTION: reflect over the Data arm's properties and
+            //    take every form TARGET it carries — a plain FormLink (Faction, Spell, Keyword, FormList, …) AND a
+            //    form-mode FormLinkOrIndex (the condition union — Quest, GetIsID's Object, …; read via the write-side
+            //    ReadFloiFormKey, the oracle-proven accessor, so an alias/index-mode FLOI returns null here and is
+            //    lint 2's job). The Run On Reference slot is skipped by name (lint 1 owns it). A param pointing at a
+            //    form not in the active order is a dead reference. This mirrors the write engine's own FLOI handling
+            //    (a plain EnumerateFormLinks does NOT cleanly surface the FLOI union), so it covers EVERY function
+            //    Mutagen models — never a hand-listed subset.
+            foreach (var p in data.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (p.Name == "Reference" || p.GetIndexParameters().Length != 0) continue;   // run-on ref → lint 1
+                object? v; try { v = p.GetValue(data); } catch { continue; }
+                FormKey? paramFk =
+                    v is IFormLinkGetter fl && !fl.IsNull ? fl.FormKey
+                    : WriteEngine.IsFormLinkOrIndex(p.PropertyType) ? WriteEngine.ReadFloiFormKey(v) : null;
+                if (paramFk is { } pk && !inOrder(pk))
+                    issues.Add(new(DialogueIssueSeverity.Warning,
+                        $"INFO {info.FormKey} condition #{n} ({fn}) references {pk}, which is not in the active load order — a deleted/disabled form or a wrong FormID, so the condition can't evaluate as intended."));
+            }
+
+            // 4. Dangling global comparison value — a ConditionGlobal compared against a GLOB not in the order. The
+            //    comparison value lives on the Condition, not the Data arm, so it's outside the param sweep above.
+            if (cond is IConditionGlobalGetter cg && !cg.ComparisonValue.IsNull && !inOrder(cg.ComparisonValue.FormKey))
+                issues.Add(new(DialogueIssueSeverity.Warning,
+                    $"INFO {info.FormKey} condition #{n} ({fn}) compares against global {cg.ComparisonValue.FormKey}, which is not in the active load order."));
+
+            // 5. GetIsID pointed at a PLACED reference — the wrong KIND of form (a dangling one is already caught by
+            //    lint 3). GetIsID compares the run-on actor's BASE form, so a placed-instance FormID can never match.
+            if (data is IGetIsIDConditionDataGetter gid && WriteEngine.ReadFloiFormKey(gid.Object) is { } objFk
+                && inOrder(objFk) && resolve(objFk) is IPlacedGetter)
+                issues.Add(new(DialogueIssueSeverity.Warning,
+                    $"INFO {info.FormKey} condition #{n} (GetIsID) points at the placed reference {objFk}, but GetIsID compares the run-on actor's BASE form — pass the base NPC_/object, not a placed instance."));
+        }
+    }
+
+    /// <summary>An alias index is dead when it's negative or not one of the owning quest's reference-alias IDs (the
+    /// alias <c>ID</c> is a <c>uint</c>; a negative condition index can never be a real ID).</summary>
+    static bool BadAlias(int idx, HashSet<uint> ownerAliasIds) => idx < 0 || !ownerAliasIds.Contains((uint)idx);
+
+    /// <summary>The dead-alias-index warning (lint 2), worded so it names the function, the offending index, and the
+    /// owning quest — never a bare "invalid" (Q3).</summary>
+    static DialogueIssue AliasIssue(FormKey infoFk, int n, string fn, int idx, string verb, string aliasKind, string ownerQuestLabel) =>
+        new(DialogueIssueSeverity.Warning,
+            $"INFO {infoFk} condition #{n} ({fn}) {verb} {ownerQuestLabel}'s {aliasKind} #{idx}, but that quest defines no alias with that ID — the gate evaluates against nothing.");
 }

--- a/src/housecarl-core/DialogueValidate.cs
+++ b/src/housecarl-core/DialogueValidate.cs
@@ -506,6 +506,11 @@ public static class DialogueValidate
             {
                 if (p.Name == "Reference" || p.GetIndexParameters().Length != 0) continue;   // run-on ref → lint 1
                 object? v; try { v = p.GetValue(data); } catch { continue; }
+                // Branch 1 (plain FormLink) is defensive: on a ConditionData arm the ONLY plain FormLink is the
+                // (skipped) run-on Reference — every function TARGET is the FormLinkOrIndex union (branch 2). A FLOI
+                // is read via its .Link, not as an IFormLinkGetter, so it never falls into branch 1 and bypasses the
+                // mode gate (proven by COND-ALIAS-FLOI: green with the gate on). Branch 1 has no index mode anyway,
+                // so it needs no gate; it correctly handles a plain-FormLink param should any arm ever carry one.
                 FormKey? paramFk =
                     v is IFormLinkGetter fl && !fl.IsNull ? fl.FormKey
                     : floiIsForm && WriteEngine.IsFormLinkOrIndex(p.PropertyType) ? WriteEngine.ReadFloiFormKey(v) : null;

--- a/src/housecarl-generator/DialogueValidateGuardProbe.cs
+++ b/src/housecarl-generator/DialogueValidateGuardProbe.cs
@@ -34,6 +34,15 @@ namespace HousecarlGenerator;
 ///   FRAGMENT-PRESENCE— a line carrying a real result-script FRAGMENT is reported HasFragment + FragmentInfoCount>=1 (item 8).
 ///   FRAGMENT-FREE— a plain voiced line is fragment-free (FragmentInfoCount 0), COUNTED not omitted (item 8).
 ///   CTDA-COUNT   — a line carrying a Condition is counted (ConditionedInfoCount >= 1) — the standing-CTDA-limit teeth.
+///   COND-CLEAN   — two WELL-FORMED conditions (GetStage on the owning quest + GetIsID on a base npc) report ZERO
+///                  condition issues — the no-false-positive keystone (incl. the GetIsID-on-a-base-form lock) (item 4).
+///   COND-REF-UNSET— Run On a specific Reference with no reference set WARNs ('Run On a specific reference') (item 4).
+///   COND-DEAD-ALIAS— GetIsAliasRef at an alias index the owning quest doesn't define WARNs ('no alias with that ID') (item 4).
+///   COND-ALIAS-OK — GetIsAliasRef at a REAL alias index is NOT flagged — the resolve-aware positive lock (item 4).
+///   COND-DANGLING-PARAM— a condition form param (GetStage's Quest) not in the order WARNs ('not in the active load order') (item 4).
+///   COND-DANGLING-GLOBAL— a ConditionGlobal vs a GLOB not in the order WARNs ('compares against global') (item 4).
+///   COND-GETISID-OK— GetIsID pointed at a BASE object is NOT flagged — the lint-5 no-false-positive lock (item 4).
+///   COND-GETISID-PLACED— GetIsID pointed at a PLACED reference WARNs ('placed reference'), NOT the dangling-param lint (item 4).
 ///   TEXT-MOJIBAKE— a line whose player-facing text carries non-ASCII chars (ellipsis/em-dash) WARNs, naming them (item 1).
 ///   TEXT-CLEAN   — pure-ASCII player-facing text is NOT flagged — the lint keys on >0x7F, not "has text" (item 1).
 ///   QUEST-FANOUT — validating a QUEST fans out to EXACTLY the topics it owns (2 here), kind="quest".
@@ -54,12 +63,14 @@ public static class DialogueValidateGuardProbe
         var mKey = new ModKey("HcDvGuardMaster", ModType.Master);
         string mPath = Path.Combine(tmpDir, mKey.FileName.String);
         FormKey cleanFk, linkBadFk, pnamBadFk, pnamOkFk, deletedFk, noQuestFk, badBranchFk, voicedFk, scriptedFk, condFk, qFanFk, weapFk, encBadFk, encOkFk;
+        FormKey condCleanFk, condRefUnsetFk, condDeadAliasFk, condAliasOkFk, condDanglingFk, condGlobalFk, condGetIsIdOkFk, condGetIsIdFk;
         try
         {
             var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
 
             // Shared wiring the topics point at: two quests (main + the fan-out owner), a branch, a speaker chain.
             var qMain = m.Quests.AddNew(); qMain.EditorID = "HcDvQuestMain";
+            qMain.Aliases.Add(new QuestAlias { ID = 0, Name = "HcDvAlias0" });   // ONE reference-alias (ID 0) — the alias-index lints key on this set
             var qFan = m.Quests.AddNew(); qFan.EditorID = "HcDvQuestFan"; qFanFk = qFan.FormKey;
             var branch = m.DialogBranches.AddNew(); branch.EditorID = "HcDvBranch";
             var voice = m.VoiceTypes.AddNew(); voice.EditorID = "HcDvVoice";
@@ -143,6 +154,98 @@ public static class DialogueValidateGuardProbe
             var eoi = Info("HcDvEncOkI"); eoi.Prompt = "Wait...";
             eoi.Responses.Add(new DialogResponse { ResponseNumber = 1, Text = "Take it - or leave it" });
             tEncOk.Responses.Add(eoi); encOkFk = tEncOk.FormKey;
+
+            // CONDITION LINTS (item 4) — topics owned by qMain (which carries ONE reference-alias, ID 0). Each
+            // condition below is STRUCTURALLY malformed in exactly one decidable way; a well-formed control proves
+            // no false positive. Conditions are built from real Mutagen ConditionData arms (the same shapes
+            // read_record surfaces), never hand-encoded bytes.
+
+            // COND-CLEAN: two WELL-FORMED conditions (GetStage on the owning quest + GetActorValue, both Run On
+            // Subject) -> ZERO condition issues. The no-false-positive keystone (a present quest param + a
+            // param-free function both pass clean).
+            var tCondClean = m.DialogTopics.AddNew(); tCondClean.EditorID = "HcDvCondClean"; tCondClean.Quest.SetTo(qMain.FormKey);
+            {
+                var i = Info("HcDvCondCleanI");
+                var d1 = new GetStageConditionData { RunOnType = Condition.RunOnType.Subject }; SetFloiForm(d1, "Quest", qMain.FormKey);
+                i.Conditions.Add(new ConditionFloat { CompareOperator = CompareOperator.GreaterThanOrEqualTo, ComparisonValue = 10f, Data = d1 });
+                var d2 = new GetActorValueConditionData { ActorValue = ActorValue.Health, RunOnType = Condition.RunOnType.Subject };
+                i.Conditions.Add(new ConditionFloat { CompareOperator = CompareOperator.GreaterThan, ComparisonValue = 0f, Data = d2 });
+                tCondClean.Responses.Add(i); condCleanFk = tCondClean.FormKey;
+            }
+
+            // COND-REF-UNSET: Run On a specific Reference but NO reference set -> WARN (the gate runs on nothing).
+            var tCondRef = m.DialogTopics.AddNew(); tCondRef.EditorID = "HcDvCondRefUnset"; tCondRef.Quest.SetTo(qMain.FormKey);
+            {
+                var i = Info("HcDvCondRefUnsetI");
+                var d = new GetActorValueConditionData { ActorValue = ActorValue.Health, RunOnType = Condition.RunOnType.Reference };
+                i.Conditions.Add(new ConditionFloat { CompareOperator = CompareOperator.GreaterThan, ComparisonValue = 0f, Data = d });
+                tCondRef.Responses.Add(i); condRefUnsetFk = tCondRef.FormKey;
+            }
+
+            // COND-DEAD-ALIAS: GetIsAliasRef naming alias #99 (qMain defines only #0) -> WARN dead alias.
+            var tCondAliasBad = m.DialogTopics.AddNew(); tCondAliasBad.EditorID = "HcDvCondDeadAlias"; tCondAliasBad.Quest.SetTo(qMain.FormKey);
+            {
+                var i = Info("HcDvCondDeadAliasI");
+                var d = new GetIsAliasRefConditionData { ReferenceAliasIndex = 99, RunOnType = Condition.RunOnType.Subject };
+                i.Conditions.Add(new ConditionFloat { CompareOperator = CompareOperator.EqualTo, ComparisonValue = 1f, Data = d });
+                tCondAliasBad.Responses.Add(i); condDeadAliasFk = tCondAliasBad.FormKey;
+            }
+
+            // COND-ALIAS-OK: GetIsAliasRef naming alias #0 (a REAL alias of qMain) -> NOT flagged (resolve-aware lock).
+            var tCondAliasOk = m.DialogTopics.AddNew(); tCondAliasOk.EditorID = "HcDvCondAliasOk"; tCondAliasOk.Quest.SetTo(qMain.FormKey);
+            {
+                var i = Info("HcDvCondAliasOkI");
+                var d = new GetIsAliasRefConditionData { ReferenceAliasIndex = 0, RunOnType = Condition.RunOnType.Subject };
+                i.Conditions.Add(new ConditionFloat { CompareOperator = CompareOperator.EqualTo, ComparisonValue = 1f, Data = d });
+                tCondAliasOk.Responses.Add(i); condAliasOkFk = tCondAliasOk.FormKey;
+            }
+
+            // COND-DANGLING-PARAM: GetStage whose Quest param is NOT in the load order -> WARN dangling param.
+            var tCondDangling = m.DialogTopics.AddNew(); tCondDangling.EditorID = "HcDvCondDangling"; tCondDangling.Quest.SetTo(qMain.FormKey);
+            {
+                var i = Info("HcDvCondDanglingI");
+                var d = new GetStageConditionData { RunOnType = Condition.RunOnType.Subject }; SetFloiForm(d, "Quest", new FormKey(mKey, 0x00DDDDDD));
+                i.Conditions.Add(new ConditionFloat { CompareOperator = CompareOperator.GreaterThanOrEqualTo, ComparisonValue = 10f, Data = d });
+                tCondDangling.Responses.Add(i); condDanglingFk = tCondDangling.FormKey;
+            }
+
+            // COND-DANGLING-GLOBAL: a ConditionGlobal compared against a GLOB not in the load order -> WARN.
+            var tCondGlobal = m.DialogTopics.AddNew(); tCondGlobal.EditorID = "HcDvCondGlobal"; tCondGlobal.Quest.SetTo(qMain.FormKey);
+            {
+                var i = Info("HcDvCondGlobalI");
+                var d = new GetActorValueConditionData { ActorValue = ActorValue.Health, RunOnType = Condition.RunOnType.Subject };
+                var cg = new ConditionGlobal { CompareOperator = CompareOperator.EqualTo, Data = d };
+                cg.ComparisonValue.SetTo(new FormKey(mKey, 0x00EEEEEE));
+                i.Conditions.Add(cg);
+                tCondGlobal.Responses.Add(i); condGlobalFk = tCondGlobal.FormKey;
+            }
+
+            // COND-GETISID-PLACED: GetIsID pointed at a PLACED reference (an interior-cell PlacedObject) -> WARN
+            // wrong-kind. The placed ref must EXIST + resolve (so lint 3 doesn't fire instead) and resolve to an
+            // IPlacedGetter (so lint 5 does) — proving the validator resolves a placed ref's record type.
+            var condCell = new Cell(m.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "HcDvCondCell", Flags = Cell.Flag.IsInteriorCell };
+            var condPlaced = new PlacedObject(m.GetNextFormKey(), SkyrimRelease.SkyrimSE); condPlaced.Base.SetTo(weap.FormKey);
+            condCell.Persistent.Add(condPlaced);
+            var condSub = new CellSubBlock { BlockNumber = 0, GroupType = GroupTypeEnum.InteriorCellSubBlock }; condSub.Cells.Add(condCell);
+            var condBlock = new CellBlock { BlockNumber = 0, GroupType = GroupTypeEnum.InteriorCellBlock }; condBlock.SubBlocks.Add(condSub);
+            m.Cells.Records.Add(condBlock);
+            // COND-GETISID-OK: GetIsID pointed at a BASE npc -> NOT flagged. The lint-5 no-false-positive lock
+            // (a base object is exactly what GetIsID wants), proving lint 5 fires ONLY for a placed reference.
+            var tCondGetIsIdOk = m.DialogTopics.AddNew(); tCondGetIsIdOk.EditorID = "HcDvCondGetIsIdOk"; tCondGetIsIdOk.Quest.SetTo(qMain.FormKey);
+            {
+                var i = Info("HcDvCondGetIsIdOkI");
+                var d = new GetIsIDConditionData { RunOnType = Condition.RunOnType.Subject }; SetFloiForm(d, "Object", npc.FormKey);
+                i.Conditions.Add(new ConditionFloat { CompareOperator = CompareOperator.EqualTo, ComparisonValue = 1f, Data = d });
+                tCondGetIsIdOk.Responses.Add(i); condGetIsIdOkFk = tCondGetIsIdOk.FormKey;
+            }
+
+            var tCondGetIsId = m.DialogTopics.AddNew(); tCondGetIsId.EditorID = "HcDvCondGetIsId"; tCondGetIsId.Quest.SetTo(qMain.FormKey);
+            {
+                var i = Info("HcDvCondGetIsIdI");
+                var d = new GetIsIDConditionData { RunOnType = Condition.RunOnType.Subject }; SetFloiForm(d, "Object", condPlaced.FormKey);
+                i.Conditions.Add(new ConditionFloat { CompareOperator = CompareOperator.EqualTo, ComparisonValue = 1f, Data = d });
+                tCondGetIsId.Responses.Add(i); condGetIsIdFk = tCondGetIsId.FormKey;
+            }
 
             // QUEST-FANOUT: two topics owned by qFan (and nothing else points at it).
             var tf1 = m.DialogTopics.AddNew(); tf1.EditorID = "HcDvFan1"; tf1.Quest.SetTo(qFan.FormKey); tf1.Responses.Add(Info("HcDvFan1I"));
@@ -251,6 +354,63 @@ public static class DialogueValidateGuardProbe
             all &= Pass("CTDA-COUNT counts conditions", ok, t is null ? "no topic" : $"conditioned={t?.ConditionedInfoCount}");
         }
 
+        // ---------- COND-CLEAN (item 4): two well-formed conditions report ZERO condition issues — the no-false-positive keystone ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, condCleanFk));
+            bool ok = t is not null && t.ConditionedInfoCount == 1 && t.Issues.Count == 0;
+            all &= Pass("COND-CLEAN no false issues", ok, t is null ? "no topic" : $"cond={t.ConditionedInfoCount} issues={t.Issues.Count}: {Issues(t)}");
+        }
+
+        // ---------- COND-REF-UNSET (item 4): Run On a specific Reference with none set is a WARN ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, condRefUnsetFk));
+            bool ok = t is not null && t.Issues.Any(i => i.Severity == DialogueIssueSeverity.Warning && i.Message.Contains("Run On a specific reference", StringComparison.Ordinal));
+            all &= Pass("COND-REF-UNSET warns", ok, t is null ? "no topic" : Issues(t));
+        }
+
+        // ---------- COND-DEAD-ALIAS (item 4): an alias index the owning quest doesn't define is a WARN ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, condDeadAliasFk));
+            bool ok = t is not null && t.Issues.Any(i => i.Severity == DialogueIssueSeverity.Warning && i.Message.Contains("no alias with that ID", StringComparison.Ordinal));
+            all &= Pass("COND-DEAD-ALIAS warns", ok, t is null ? "no topic" : Issues(t));
+        }
+
+        // ---------- COND-ALIAS-OK (item 4): a REAL alias index is NOT flagged — the resolve-aware positive lock ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, condAliasOkFk));
+            bool ok = t is not null && t.ConditionedInfoCount == 1 && t.Issues.Count == 0;
+            all &= Pass("COND-ALIAS-OK not flagged", ok, t is null ? "no topic" : $"issues={t.Issues.Count}: {Issues(t)}");
+        }
+
+        // ---------- COND-DANGLING-PARAM (item 4): a condition form param not in the order is a WARN ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, condDanglingFk));
+            bool ok = t is not null && t.Issues.Any(i => i.Severity == DialogueIssueSeverity.Warning
+                && i.Message.Contains("condition", StringComparison.Ordinal) && i.Message.Contains("not in the active load order", StringComparison.Ordinal));
+            all &= Pass("COND-DANGLING-PARAM warns", ok, t is null ? "no topic" : Issues(t));
+        }
+
+        // ---------- COND-DANGLING-GLOBAL (item 4): a ConditionGlobal vs a missing GLOB is a WARN ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, condGlobalFk));
+            bool ok = t is not null && t.Issues.Any(i => i.Severity == DialogueIssueSeverity.Warning && i.Message.Contains("compares against global", StringComparison.Ordinal));
+            all &= Pass("COND-DANGLING-GLOBAL warns", ok, t is null ? "no topic" : Issues(t));
+        }
+
+        // ---------- COND-GETISID-OK (item 4): GetIsID at a BASE object is NOT flagged — lint-5 no-false-positive lock ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, condGetIsIdOkFk));
+            bool ok = t is not null && t.ConditionedInfoCount == 1 && t.Issues.Count == 0;
+            all &= Pass("COND-GETISID-OK not flagged", ok, t is null ? "no topic" : $"issues={t.Issues.Count}: {Issues(t)}");
+        }
+
+        // ---------- COND-GETISID-PLACED (item 4): GetIsID pointed at a placed reference is a WARN (not the dangling-param one) ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, condGetIsIdFk));
+            bool ok = t is not null && t.Issues.Any(i => i.Severity == DialogueIssueSeverity.Warning && i.Message.Contains("placed reference", StringComparison.Ordinal));
+            all &= Pass("COND-GETISID-PLACED warns", ok, t is null ? "no topic" : Issues(t));
+        }
+
         // ---------- TEXT-MOJIBAKE (item 1): non-ASCII player-facing text WARNs, naming the offending chars ----------
         {
             var t = One(DialogueValidate.Run(resolver, assets, encBadFk));
@@ -290,10 +450,20 @@ public static class DialogueValidateGuardProbe
 
         Console.WriteLine();
         Console.WriteLine(all
-            ? "RESULT: PASS — the dialogue-graph validator holds (no false PNAM-absence flag, LinkTo + dangling-PNAM teeth, deleted-skip, voice/script reuse, encoding lint, fan-out, named rejects)."
+            ? "RESULT: PASS — the dialogue-graph validator holds (no false PNAM-absence flag, LinkTo + dangling-PNAM teeth, deleted-skip, voice/script reuse, encoding lint, condition lints (item 4), fan-out, named rejects)."
             : "RESULT: FAIL — at least one arm regressed (see above).");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return all ? 0 : 1;
+    }
+
+    /// <summary>Set a condition FormLinkOrIndex (e.g. GetIsID.Object) to a FORM-mode target via its <c>.Link</c> —
+    /// the inverse of WriteEngine.ReadFloiFormKey, by reflection (the union's typed setter isn't on the public getter
+    /// interface). UseAliases/UsePackageData stay false (form mode) so ReadFloiFormKey reads the link back.</summary>
+    static void SetFloiForm(object data, string prop, FormKey fk)
+    {
+        var floi = data.GetType().GetProperty(prop)!.GetValue(data)!;
+        var link = floi.GetType().GetProperty("Link")!.GetValue(floi)!;
+        link.GetType().GetMethod("SetTo", new[] { typeof(FormKey) })!.Invoke(link, new object[] { fk });
     }
 
     /// <summary>The single topic of a topic-kind report (null on an error / a non-single-topic result), so the

--- a/src/housecarl-generator/DialogueValidateGuardProbe.cs
+++ b/src/housecarl-generator/DialogueValidateGuardProbe.cs
@@ -39,6 +39,8 @@ namespace HousecarlGenerator;
 ///   COND-REF-UNSET— Run On a specific Reference with no reference set WARNs ('Run On a specific reference') (item 4).
 ///   COND-DEAD-ALIAS— GetIsAliasRef at an alias index the owning quest doesn't define WARNs ('no alias with that ID') (item 4).
 ///   COND-ALIAS-OK — GetIsAliasRef at a REAL alias index is NOT flagged — the resolve-aware positive lock (item 4).
+///   COND-ALIAS-FLOI— an ALIAS-mode form-param FLOI (HasPerk.Perk=alias 7) is NOT flagged — the binary-overlay
+///                  false-positive lock (an index-mode FLOI's .Link is a bogus low key on the overlay; lint 3/5 gate on form mode) (item 4).
 ///   COND-DANGLING-PARAM— a condition form param (GetStage's Quest) not in the order WARNs ('not in the active load order') (item 4).
 ///   COND-DANGLING-GLOBAL— a ConditionGlobal vs a GLOB not in the order WARNs ('compares against global') (item 4).
 ///   COND-GETISID-OK— GetIsID pointed at a BASE object is NOT flagged — the lint-5 no-false-positive lock (item 4).
@@ -63,7 +65,7 @@ public static class DialogueValidateGuardProbe
         var mKey = new ModKey("HcDvGuardMaster", ModType.Master);
         string mPath = Path.Combine(tmpDir, mKey.FileName.String);
         FormKey cleanFk, linkBadFk, pnamBadFk, pnamOkFk, deletedFk, noQuestFk, badBranchFk, voicedFk, scriptedFk, condFk, qFanFk, weapFk, encBadFk, encOkFk;
-        FormKey condCleanFk, condRefUnsetFk, condDeadAliasFk, condAliasOkFk, condDanglingFk, condGlobalFk, condGetIsIdOkFk, condGetIsIdFk;
+        FormKey condCleanFk, condRefUnsetFk, condDeadAliasFk, condAliasOkFk, condAliasFloiFk, condDanglingFk, condGlobalFk, condGetIsIdOkFk, condGetIsIdFk;
         try
         {
             var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
@@ -198,6 +200,21 @@ public static class DialogueValidateGuardProbe
                 var d = new GetIsAliasRefConditionData { ReferenceAliasIndex = 0, RunOnType = Condition.RunOnType.Subject };
                 i.Conditions.Add(new ConditionFloat { CompareOperator = CompareOperator.EqualTo, ComparisonValue = 1f, Data = d });
                 tCondAliasOk.Responses.Add(i); condAliasOkFk = tCondAliasOk.FormKey;
+            }
+
+            // COND-ALIAS-FLOI: a form-PARAMETER FormLinkOrIndex in ALIAS mode (HasPerk.Perk = alias index 7,
+            // UseAliases=true) -> NOT flagged. The regression lock for the binary-overlay FLOI false positive: on the
+            // overlay the validator reads, an index-mode FLOI's .Link is a bogus low key (000007), so WITHOUT the
+            // form-mode gate lint 3 would WARN "references 000007:... not in the active load order" on a well-formed
+            // alias-mode gate. Round-trips through the on-disk master (the overlay path) like every arm. Index 7 need
+            // not be a real alias — alias-mode FLOI *parameter* indices are deliberately out of the dangling-form scope.
+            var tCondAliasFloi = m.DialogTopics.AddNew(); tCondAliasFloi.EditorID = "HcDvCondAliasFloi"; tCondAliasFloi.Quest.SetTo(qMain.FormKey);
+            {
+                var i = Info("HcDvCondAliasFloiI");
+                var d = new HasPerkConditionData { RunOnType = Condition.RunOnType.Subject, UseAliases = true };
+                d.Perk = new FormLinkOrIndex<IPerkGetter>(d, 7u);   // alias index 7 — index mode, the bogus-overlay-link shape
+                i.Conditions.Add(new ConditionFloat { CompareOperator = CompareOperator.EqualTo, ComparisonValue = 1f, Data = d });
+                tCondAliasFloi.Responses.Add(i); condAliasFloiFk = tCondAliasFloi.FormKey;
             }
 
             // COND-DANGLING-PARAM: GetStage whose Quest param is NOT in the load order -> WARN dangling param.
@@ -380,6 +397,13 @@ public static class DialogueValidateGuardProbe
             var t = One(DialogueValidate.Run(resolver, assets, condAliasOkFk));
             bool ok = t is not null && t.ConditionedInfoCount == 1 && t.Issues.Count == 0;
             all &= Pass("COND-ALIAS-OK not flagged", ok, t is null ? "no topic" : $"issues={t.Issues.Count}: {Issues(t)}");
+        }
+
+        // ---------- COND-ALIAS-FLOI (item 4): an ALIAS-mode form-param FLOI is NOT flagged — the binary-overlay false-positive lock ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, condAliasFloiFk));
+            bool ok = t is not null && t.ConditionedInfoCount == 1 && t.Issues.Count == 0;
+            all &= Pass("COND-ALIAS-FLOI not flagged", ok, t is null ? "no topic" : $"issues={t.Issues.Count}: {Issues(t)}");
         }
 
         // ---------- COND-DANGLING-PARAM (item 4): a condition form param not in the order is a WARN ----------

--- a/src/housecarl-generator/DialogueValidateGuardProbe.cs
+++ b/src/housecarl-generator/DialogueValidateGuardProbe.cs
@@ -38,6 +38,8 @@ namespace HousecarlGenerator;
 ///                  condition issues — the no-false-positive keystone (incl. the GetIsID-on-a-base-form lock) (item 4).
 ///   COND-REF-UNSET— Run On a specific Reference with no reference set WARNs ('Run On a specific reference') (item 4).
 ///   COND-DEAD-ALIAS— GetIsAliasRef at an alias index the owning quest doesn't define WARNs ('no alias with that ID') (item 4).
+///   COND-DEAD-LOCALIAS— GetInCurrentLocAlias at an undefined location-alias WARNs ('location-alias', 'no alias with that ID') (item 4).
+///   COND-DEAD-QUESTALIAS— Run On:QuestAlias at an undefined alias WARNs ('reference-alias', 'no alias with that ID') (item 4).
 ///   COND-ALIAS-OK — GetIsAliasRef at a REAL alias index is NOT flagged — the resolve-aware positive lock (item 4).
 ///   COND-ALIAS-FLOI— an ALIAS-mode form-param FLOI (HasPerk.Perk=alias 7) is NOT flagged — the binary-overlay
 ///                  false-positive lock (an index-mode FLOI's .Link is a bogus low key on the overlay; lint 3/5 gate on form mode) (item 4).
@@ -65,7 +67,7 @@ public static class DialogueValidateGuardProbe
         var mKey = new ModKey("HcDvGuardMaster", ModType.Master);
         string mPath = Path.Combine(tmpDir, mKey.FileName.String);
         FormKey cleanFk, linkBadFk, pnamBadFk, pnamOkFk, deletedFk, noQuestFk, badBranchFk, voicedFk, scriptedFk, condFk, qFanFk, weapFk, encBadFk, encOkFk;
-        FormKey condCleanFk, condRefUnsetFk, condDeadAliasFk, condAliasOkFk, condAliasFloiFk, condDanglingFk, condGlobalFk, condGetIsIdOkFk, condGetIsIdFk;
+        FormKey condCleanFk, condRefUnsetFk, condDeadAliasFk, condDeadLocAliasFk, condDeadQAliasFk, condAliasOkFk, condAliasFloiFk, condDanglingFk, condGlobalFk, condGetIsIdOkFk, condGetIsIdFk;
         try
         {
             var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
@@ -191,6 +193,26 @@ public static class DialogueValidateGuardProbe
                 var d = new GetIsAliasRefConditionData { ReferenceAliasIndex = 99, RunOnType = Condition.RunOnType.Subject };
                 i.Conditions.Add(new ConditionFloat { CompareOperator = CompareOperator.EqualTo, ComparisonValue = 1f, Data = d });
                 tCondAliasBad.Responses.Add(i); condDeadAliasFk = tCondAliasBad.FormKey;
+            }
+
+            // COND-DEAD-LOCALIAS: GetInCurrentLocAlias naming a location-alias #99 the owning quest doesn't define
+            // -> WARN. Locks lint 2's GetInCurrentLocAlias sub-check (structurally identical to GetIsAliasRef, distinct path).
+            var tCondLocAlias = m.DialogTopics.AddNew(); tCondLocAlias.EditorID = "HcDvCondDeadLocAlias"; tCondLocAlias.Quest.SetTo(qMain.FormKey);
+            {
+                var i = Info("HcDvCondDeadLocAliasI");
+                var d = new GetInCurrentLocAliasConditionData { LocationAliasIndex = 99, RunOnType = Condition.RunOnType.Subject };
+                i.Conditions.Add(new ConditionFloat { CompareOperator = CompareOperator.EqualTo, ComparisonValue = 1f, Data = d });
+                tCondLocAlias.Responses.Add(i); condDeadLocAliasFk = tCondLocAlias.FormKey;
+            }
+
+            // COND-DEAD-QUESTALIAS: Run On:QuestAlias at an alias #99 the owning quest doesn't define -> WARN.
+            // Locks lint 2's RunOnType==QuestAlias sub-check (the run-on path, distinct from the alias-param paths).
+            var tCondQAlias = m.DialogTopics.AddNew(); tCondQAlias.EditorID = "HcDvCondDeadQAlias"; tCondQAlias.Quest.SetTo(qMain.FormKey);
+            {
+                var i = Info("HcDvCondDeadQAliasI");
+                var d = new GetActorValueConditionData { ActorValue = ActorValue.Health, RunOnType = Condition.RunOnType.QuestAlias, RunOnTypeIndex = 99 };
+                i.Conditions.Add(new ConditionFloat { CompareOperator = CompareOperator.GreaterThan, ComparisonValue = 0f, Data = d });
+                tCondQAlias.Responses.Add(i); condDeadQAliasFk = tCondQAlias.FormKey;
             }
 
             // COND-ALIAS-OK: GetIsAliasRef naming alias #0 (a REAL alias of qMain) -> NOT flagged (resolve-aware lock).
@@ -390,6 +412,22 @@ public static class DialogueValidateGuardProbe
             var t = One(DialogueValidate.Run(resolver, assets, condDeadAliasFk));
             bool ok = t is not null && t.Issues.Any(i => i.Severity == DialogueIssueSeverity.Warning && i.Message.Contains("no alias with that ID", StringComparison.Ordinal));
             all &= Pass("COND-DEAD-ALIAS warns", ok, t is null ? "no topic" : Issues(t));
+        }
+
+        // ---------- COND-DEAD-LOCALIAS (item 4): GetInCurrentLocAlias at an undefined location-alias is a WARN ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, condDeadLocAliasFk));
+            bool ok = t is not null && t.Issues.Any(i => i.Severity == DialogueIssueSeverity.Warning
+                && i.Message.Contains("location-alias", StringComparison.Ordinal) && i.Message.Contains("no alias with that ID", StringComparison.Ordinal));
+            all &= Pass("COND-DEAD-LOCALIAS warns", ok, t is null ? "no topic" : Issues(t));
+        }
+
+        // ---------- COND-DEAD-QUESTALIAS (item 4): Run On:QuestAlias at an undefined alias is a WARN ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, condDeadQAliasFk));
+            bool ok = t is not null && t.Issues.Any(i => i.Severity == DialogueIssueSeverity.Warning
+                && i.Message.Contains("reference-alias", StringComparison.Ordinal) && i.Message.Contains("no alias with that ID", StringComparison.Ordinal));
+            all &= Pass("COND-DEAD-QUESTALIAS warns", ok, t is null ? "no topic" : Issues(t));
         }
 
         // ---------- COND-ALIAS-OK (item 4): a REAL alias index is NOT flagged — the resolve-aware positive lock ----------

--- a/src/housecarl-mcp/DialogueTools.cs
+++ b/src/housecarl-mcp/DialogueTools.cs
@@ -121,7 +121,14 @@ static class DialogueWire
 
         // --- graph issues (PNAM chain, quest + branch wiring) ---
         if (t.Issues.Count == 0)
-            sb.Append(pad).Append("  graph: OK — quest + branch wiring resolve, LinkTo targets resolve, no dangling PNAM, conditions well-formed (their form references + alias indices resolve).\n");
+        {
+            // The conditions clause is asserted ONLY when the topic actually has conditioned INFOs — otherwise a
+            // condition-free topic would read as "conditions checked + well-formed" when there were none to check.
+            sb.Append(pad).Append("  graph: OK — quest + branch wiring resolve, LinkTo targets resolve, no dangling PNAM");
+            sb.Append(t.ConditionedInfoCount > 0
+                ? ", conditions well-formed (their form references + alias indices resolve).\n"
+                : ".\n");
+        }
         else
         {
             sb.Append(pad).Append("  graph: ").Append(t.Issues.Count).Append(" issue(s):\n");

--- a/src/housecarl-mcp/DialogueTools.cs
+++ b/src/housecarl-mcp/DialogueTools.cs
@@ -23,10 +23,12 @@ public static class DialogueTools
          "targets, and no previous-link (PNAM) is dangling — an EMPTY PNAM is normal (vanilla selects among a " +
          "topic's lines by their conditions, not a previous-link chain), so absence is never flagged; plus (reusing " +
          "the create-time teeth over every existing line) each voiced line has its .fuz on disk and each result " +
-         "script is bound + compiled; and non-ASCII characters in the player-facing text (topic name, line prompt, " +
-         "response text) are flagged as likely in-game mojibake (the CK/Papyrus surface is Windows-1252/ASCII). It " +
-         "LOUDLY declares what it cannot verify — the CTDA conditions that gate WHEN " +
-         "a line fires (semantic, only the game evaluates them) and lip-sync/audio content — so 'checks " +
+         "script is bound + compiled; non-ASCII characters in the player-facing text (topic name, line prompt, " +
+         "response text) are flagged as likely in-game mojibake (the CK/Papyrus surface is Windows-1252/ASCII); " +
+         "and each line's CTDA conditions are statically checked for a meaningful subset of MALFORMED shapes (a " +
+         "dangling form reference, a dead quest-alias index, an unset Run On reference, GetIsID pointed at a placed " +
+         "instance). It LOUDLY declares what it still cannot verify — it cannot EVALUATE whether a WELL-FORMED " +
+         "condition passes (only the running game can) nor check lip-sync/audio content — so 'checks " +
          "passed' never reads as 'this will play'. Resolves against the load-order WINNERS like every other read. " +
          "A FormID is 'XXXXXX:Plugin.esp'. Does NOT modify anything. To create dialogue lines use " +
          "housecarl_create_record; to inspect a single record use housecarl_read_record.")]
@@ -119,7 +121,7 @@ static class DialogueWire
 
         // --- graph issues (PNAM chain, quest + branch wiring) ---
         if (t.Issues.Count == 0)
-            sb.Append(pad).Append("  graph: OK — quest + branch wiring resolve, LinkTo targets resolve, no dangling PNAM.\n");
+            sb.Append(pad).Append("  graph: OK — quest + branch wiring resolve, LinkTo targets resolve, no dangling PNAM, conditions well-formed (their form references + alias indices resolve).\n");
         else
         {
             sb.Append(pad).Append("  graph: ").Append(t.Issues.Count).Append(" issue(s):\n");
@@ -244,8 +246,8 @@ static class DialogueWire
     static void AppendStandingLimits(StringBuilder sb, int conditioned, bool readIncomplete)
     {
         sb.Append("standing limits — what houseCARL could NOT verify (so a clean pass above does NOT mean the dialogue will play as intended):\n");
-        sb.Append("  • CTDA conditions gate WHEN each line fires; they are semantic and only the game evaluates them, so a wrong/missing condition silently stops a line from ever playing");
-        if (conditioned > 0) sb.Append(" — ").Append(conditioned).Append(" line(s) here carry conditions, unverified");
+        sb.Append("  • CTDA conditions gate WHEN each line fires. houseCARL statically catches a meaningful subset of MALFORMED conditions (a dangling form reference, a dead quest-alias index, an unset Run On reference — surfaced above as graph issues); it still cannot EVALUATE whether a WELL-FORMED condition passes — only the running game can, so a well-formed but wrong condition can still silently stop a line from ever playing");
+        if (conditioned > 0) sb.Append(" — ").Append(conditioned).Append(" line(s) here carry conditions, checked for malformedness but not evaluated");
         sb.Append(".\n");
         sb.Append("  • voice presence is an on-disk file check only — lip-sync accuracy and the audio content itself are not verified (voice acting is out of scope).\n");
         sb.Append("  • this validates the WINNING topic's INFO list (what the game plays); a line another plugin adds but this topic override does not re-list is dropped in game and is not seen here — resolve dialogue conflicts so the winning topic carries every line.\n");


### PR DESCRIPTION
**1.3.1 item 4 — the static condition-lint suite** (the roadmap's "meat"). Adds the data-layer-decidable, true-positive subset the §4 design decision (**A-iii**, Aaron-approved) authorises to `housecarl_validate_dialogue`, run over every conditioned INFO. All lints **WARN, never block.**

### The five lints (all true-positive well-formedness, decidable from the record + form index)
1. **Unset Run-On reference** — `RunOnType==Reference` with no/missing reference → the gate runs on nothing.
2. **Dead alias index** — `RunOn:QuestAlias` / `GetIsAliasRef` / `GetInCurrentLocAlias` naming an alias ID the **owning quest** doesn't define (skipped, never guessed, when the quest is unresolved).
3. **Dangling form parameter** — *by construction* (reflection over the Data arm): any plain `FormLink` **or** form-mode `FormLinkOrIndex` (Quest, Object, Perk, …) pointing at a form not in the load order.
4. **Dangling `ConditionGlobal`** comparison value.
5. **`GetIsID` at a placed reference** instead of a base object.

**Deliberately NOT linted** (semantic, not structural — flagging them would be a behavioural guess that risks the false positives A-iii's honesty forbids): Run-On Subject/Target *intent*, faction-rank gate *value*, intra-topic Info-variant *ordering*. Scope is INFO conditions.

### A-iii reword (catch malformed; still can't evaluate well-formed)
Applied verbatim across the tool Description, the standing-limits footer, the skill's "Evaluate Conditions (CTDA)" CANNOT bullet, the workflow-step-3 line, and the "graph: OK" line: *"houseCARL can statically catch a meaningful subset of **malformed** conditions; it still cannot **evaluate** whether a well-formed condition passes — only the running game can."* (PRFAQ outcome (a) — strengthens Q3, doesn't walk it back.)

### Adversarial review caught a real false positive (now fixed)
A multi-agent review found a high-severity FP: on the **binary-overlay** path the validator reads, an alias/package-data-mode `FormLinkOrIndex` param (e.g. `HasPerk` against a quest alias) has its `.Link` populated from the index bytes — so the dangling-form sweep flagged a **well-formed** alias-mode condition as a missing reference (the A-iii/Q3 worst case). **Fix:** gate lints 3 & 5 on form mode (`!UseAliases && !UsePackageData`), mirroring the proven write-side / `ReadEngine.EmitFloi` gate. 6 findings folded, 20 rejected.

### Tests
- `DialogueValidateGuardProbe` — **27/27 arms green** (9 new `COND-*`), incl. four no-false-positive locks (COND-CLEAN, COND-ALIAS-OK, COND-GETISID-OK, **COND-ALIAS-FLOI**).
- `COND-ALIAS-FLOI` is **RED-proven**: with the gate disabled it fails with the literal overlay FP (`HasPerk references 000007:… not in the active load order`); green with the gate.
- Build green across all projects.

### Note for reviewers
The `mutagen-reference` shard normalizes a condition param's `FormLinkOrIndex<T>` to `FormLink<T>` in its type field — a real gotcha for anyone composing condition writes (the runtime type is the form-or-alias union). Handled here via the write-side `ReadFloiFormKey` + the form-mode gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)