### PR TITLE
feat: forward a named plugin's version of a record as an override (HCBR-2026-06-21)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,17 @@ jobs:
       - name: "Probe — condition FLOI via compose fields shorthand (self-contained regression guard)"
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- floi-fields-guard
 
+      # Self-contained (synthesizes a master + earlier-override + winner-override + a non-toucher in temp — no Skyrim.esm),
+      # runs fully here: a regression guard for FORWARD-FROM-PLUGIN (HCBR-2026-06-21 — housecarl_forward_record). The write
+      # tools override the load-order WINNER; forwarding copies a NAMED earlier plugin's whole record verbatim as the
+      # override (xEdit's "copy as override into") to re-assert it over a later override, or names a master to revert to
+      # vanilla. Drives the REAL WritePatchBuilder.ForwardRecords: pins that the EARLIER plugin's version (not the winner)
+      # is copied, the header carries ONLY the origin master (content copied, source not mastered), revert-to-vanilla +
+      # already-winner-flagged + multi-record + into= extend all work, the source plugins stay byte-identical, and the four
+      # Q3 rejects (source not-in-order / doesn't-define / the patch itself / same target twice) refuse loud with no file.
+      - name: Probe — forward-from-plugin (self-contained regression guard)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- forward-from-plugin-guard
+
       # Self-contained (synthesizes records with known field values — no external files), runs fully here: a regression
       # guard for the field-value query predicate (cross_plugin_query where=) — matched set == brute-force + the Q3 teeth.
       - name: Probe — field-value query predicate (self-contained regression guard)

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -435,6 +435,167 @@ public static class WritePatchBuilder
         return new RemovalOutcome(true, null, outPath, toRemove, masters, remaining, bytes);
     }
 
+    /// <summary>One record to FORWARD: take plugin <see cref="FromPlugin"/>'s version of <see cref="Target"/> and carry
+    /// it INTO the patch as an override (xEdit's "copy as override into"). Unlike <see cref="PatchEdit"/> there is no
+    /// path/verb — the WHOLE source record is deep-copied verbatim, so the SOURCE plugin (not the load-order winner)
+    /// decides the content.</summary>
+    public sealed record ForwardSpec
+    {
+        public required FormKey Target { get; init; }
+        public required string FromPlugin { get; init; }
+    }
+
+    /// <summary>One record forwarded by <see cref="ForwardRecords"/> — its FormKey + type + editorid, the source plugin
+    /// whose version was copied, and the load-order winner it will out-rank once the patch is enabled (so the caller
+    /// sees what the forward CHANGES). <see cref="WasAlreadyWinner"/>=true ⇒ the forwarded version WAS already the
+    /// winner, so this override is a redundant no-op copy — surfaced, never silent (Q3).</summary>
+    public sealed record ForwardedRecord(
+        FormKey Target, string RecordType, string? EditorId, string FromPlugin, string PriorWinner, bool WasAlreadyWinner);
+
+    /// <summary>The outcome of a <see cref="ForwardRecords"/> call. <see cref="Error"/> non-null ⇒ the whole call was
+    /// refused (no file written) with a named, recoverable reason (Q3 — a source plugin not in the order / excluded /
+    /// the output itself / one that doesn't define the target). Otherwise the patch at <see cref="OutputPath"/> carries
+    /// each forwarded record; <see cref="Masters"/> is its lean header (the forwarded content's ORIGIN master + whatever
+    /// it references — NOT the source plugin, which is copied FROM, never mastered ON). <see cref="ReadBack"/> is the
+    /// opt-in full read-back of every forwarded record (null unless requested).</summary>
+    public sealed record ForwardOutcome(
+        bool Success, string? Error, string OutputPath, bool Extended,
+        IReadOnlyList<ForwardedRecord> Forwarded, IReadOnlyList<string> Masters, long Bytes)
+    {
+        public IReadOnlyList<FullReadback>? ReadBack { get; init; }
+
+        public static ForwardOutcome Fail(string error) =>
+            new(false, error, "", false, Array.Empty<ForwardedRecord>(), Array.Empty<string>(), 0);
+    }
+
+    /// <summary>
+    /// FORWARD a NAMED plugin's version of each record INTO the patch as an override — xEdit's "copy as override into",
+    /// the inverse of <see cref="Apply"/>'s winner-override. Where Apply/Create author NEW content, this re-asserts an
+    /// EARLIER plugin's already-authored version over a later override (the HCBR-2026-06-21 case: restore ATweaks'
+    /// Searing-Sun spell over Sacrilege's). The whole source record is DEEP-COPIED via
+    /// <see cref="WriteEngine.GenericGetOrAddAsOverride"/> — the SAME override primitive <see cref="Apply"/> uses, so
+    /// it's generic over EVERY record type by construction (the nested Cell/Placed*/INFO/Navmesh/Landscape families
+    /// included, via the source link cache). There is NO field edit, so NO rulebook pre-flight: a complete, valid source
+    /// record copied verbatim is legal by definition (the rulebook validates field EDITS, of which this has none).
+    ///
+    /// <para>Forwarding copies CONTENT, it does not add a master: the patch overrides the target's ORIGIN FormKey with
+    /// the source's body, so the source plugin is read FROM, never recorded as a master — the resulting header carries
+    /// the origin master + whatever the forwarded content references (exactly what xEdit's "copy as override into a new
+    /// patch" produces). Forwarding the ORIGIN master's own version reverts the record to vanilla.</para>
+    ///
+    /// <para>Q3 — every refusal is named and the WHOLE call is all-or-nothing (no partial patch): a source plugin not in
+    /// the order, EXCLUDED (unparseable), the OUTPUT patch itself (a no-op self-forward), the SAME target twice, or one
+    /// that simply doesn't DEFINE the target — the distinct null shapes
+    /// <see cref="LoadOrderResolver.IndexView.GetRecord"/> returns, told apart here so the caller gets the real reason.
+    /// A forwarded version that WAS already the winner is reported (<see cref="ForwardedRecord.WasAlreadyWinner"/>), not
+    /// silently dropped. <paramref name="extend"/>=false writes a fresh patch; =true adds to an existing one (into=).
+    /// <paramref name="fullReadback"/> reads every forwarded record back IN FULL off the written file (the pre-enable
+    /// verify loop — see <see cref="FullReadback"/>).</para>
+    /// </summary>
+    public static ForwardOutcome ForwardRecords(
+        LoadOrderResolver resolver, IReadOnlyList<ForwardSpec> specs, string outPath, bool extend, bool fullReadback = false)
+    {
+        if (specs.Count == 0) return ForwardOutcome.Fail("no records to forward supplied.");
+
+        // Per-call overlay session (Option B): every source plugin this forward reads is opened THROUGH it and disposed
+        // when the method returns — no handle held at rest (the same model Apply / RemoveRecords / CreateRecords use).
+        using var session = resolver.OpenSession();
+        var fileName = Path.GetFileName(outPath);
+
+        // --- Phase 1: resolve each source body from its NAMED plugin (NOT the load-order winner) + classify any miss
+        //     (Q3 — collect ALL problems, then refuse the whole call if any). ONE captured build answers every spec (the
+        //     hunt-F5 one-view discipline Apply follows: a freshness rebuild mid-loop can't mix two builds' resolutions). ---
+        var view = resolver.Capture();
+        var resolved = new List<(ForwardSpec spec, IMajorRecordGetter body, string priorWinner, bool wasWinner)>(specs.Count);
+        var problems = new List<string>();
+        var seen = new HashSet<FormKey>();
+        foreach (var s in specs)
+        {
+            if (!seen.Add(s.Target))
+            { problems.Add($"{s.Target}: forwarded more than once in this call — name each target once (one source per record)."); continue; }
+            if (string.Equals(s.FromPlugin, fileName, StringComparison.OrdinalIgnoreCase))
+            { problems.Add($"{s.Target}: from_plugin '{s.FromPlugin}' is the output patch itself — forwarding a patch's own version into itself is a no-op; name the EARLIER plugin whose version you want to re-assert."); continue; }
+            if (!view.ContainsPlugin(s.FromPlugin))
+            { problems.Add($"{s.Target}: source plugin '{s.FromPlugin}' is not in the load order — name an active plugin that defines or overrides this record."); continue; }
+            if (view.ExcludedPlugins.TryGetValue(s.FromPlugin, out var why))
+            { problems.Add($"{s.Target}: source plugin '{s.FromPlugin}' was excluded from this session ({why}) — its records aren't resolvable."); continue; }
+            var body = view.GetRecord(session, s.FromPlugin, s.Target);
+            if (body is null)
+            { problems.Add($"{s.Target}: source plugin '{s.FromPlugin}' is in the load order but does NOT define or override this record (it doesn't touch it) — there is no version of it there to forward."); continue; }
+            var w = view.ResolveWinner(s.Target);
+            resolved.Add((s, body, w?.WinnerPlugin ?? "(none)",
+                w is { } wi && string.Equals(wi.WinnerPlugin, s.FromPlugin, StringComparison.OrdinalIgnoreCase)));
+        }
+        if (problems.Count > 0)
+            return ForwardOutcome.Fail(
+                $"refused — {problems.Count} of {specs.Count} forward(s) rejected; NO patch written:\n  - "
+                + string.Join("\n  - ", problems));
+
+        // --- Phase 2: open (extend) or create the patch mod (identical to Apply Phase 2). ---
+        SkyrimMod patchMod;
+        if (extend)
+        {
+            if (!File.Exists(outPath))
+                return ForwardOutcome.Fail($"cannot extend: no existing patch at {outPath}. Omit into= to create it fresh.");
+            try { patchMod = SkyrimMod.CreateFromBinary(outPath, SkyrimRelease.SkyrimSE); }
+            catch (Exception ex) { return ForwardOutcome.Fail($"cannot open patch to extend ({fileName}): {ex.GetType().Name}: {ex.Message}"); }
+        }
+        else
+        {
+            patchMod = new SkyrimMod(new ModKey(Path.GetFileNameWithoutExtension(outPath), ModType.Plugin), SkyrimRelease.SkyrimSE);
+        }
+        if (!string.Equals(patchMod.ModKey.FileName.String, fileName, StringComparison.OrdinalIgnoreCase))
+            return ForwardOutcome.Fail($"patch ModKey '{patchMod.ModKey.FileName}' must match output filename '{fileName}'.");
+
+        // --- Phase 3: deep-copy each source body INTO the patch as an override. NO ApplyVerb — the copy IS the forward
+        //     (GenericGetOrAddAsOverride duplicates the source's whole content; a nested record gets the source overlay's
+        //     link cache on demand, the SAME session.LinkCacheFor path Apply uses + guards). A throw here is a real
+        //     engine inconsistency — fail the WHOLE call (no partial patch), surfaced not swallowed (Q3). ---
+        var forwarded = new List<ForwardedRecord>(resolved.Count);
+        foreach (var (spec, body, priorWinner, wasWinner) in resolved)
+        {
+            try
+            {
+                ILinkCache? cache = WriteEngine.RecordNeedsSourceCache(body) ? session.LinkCacheFor(spec.FromPlugin) : null;
+                WriteEngine.GenericGetOrAddAsOverride(patchMod, body, cache);
+                forwarded.Add(new ForwardedRecord(
+                    spec.Target, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID, spec.FromPlugin, priorWinner, wasWinner));
+            }
+            catch (Exception ex)
+            {
+                return ForwardOutcome.Fail(
+                    $"engine error forwarding {spec.Target} from '{spec.FromPlugin}': the source resolved but the " +
+                    $"override-copy threw — a real inconsistency, surfaced not swallowed (Q3): {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+
+        // --- Phase 4: serialize ONCE with the FULL known-master set (identical to Apply Phase 4 — release any overlay
+        //     on the target before the serialize + keep the target out of the master set; the two-part self-lock guard). ---
+        session.ReleaseOverlay(patchMod.ModKey.FileName.String);
+        try { WriteEngine.WritePatch(patchMod, session.AllMastersExcept(patchMod.ModKey.FileName.String), outPath); }
+        catch (Exception ex)
+            { return ForwardOutcome.Fail($"writing the patch failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}"); }
+
+        // --- Phase 5: re-open + report the (lean, derived) master header + bytes — and, on request, each forwarded
+        //     record's FULL read-back off that same re-opened file (see Apply's Phase 5). Dispose the overlay after. ---
+        IReadOnlyList<string> masters = Array.Empty<string>();
+        IReadOnlyList<FullReadback>? readBack = null;
+        long bytes = 0;
+        ISkyrimModGetter? back = null;
+        try
+        {
+            back = SkyrimMod.CreateFromBinaryOverlay(outPath, SkyrimRelease.SkyrimSE);
+            masters = back.ModHeader.MasterReferences.Select(m => m.Master.FileName.ToString()).ToList();
+            bytes = new FileInfo(outPath).Length;
+            if (fullReadback) readBack = ReadBackInFull(back, resolved.Select(r => r.spec.Target));
+        }
+        catch (Exception ex)
+            { return ForwardOutcome.Fail($"patch written but could not be re-opened to confirm masters: {ex.Message}"); }
+        finally { (back as IDisposable)?.Dispose(); }
+
+        return new ForwardOutcome(true, null, outPath, extend, forwarded, masters, bytes) { ReadBack = readBack };
+    }
+
     /// <summary>
     /// Create BRAND-NEW records (new FormIDs) in a patch — the net-new authoring capability, the sibling of
     /// <see cref="Apply"/> (which overrides an EXISTING record). A FLAT top-level <see cref="CreateSpec"/> (no

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -504,7 +504,12 @@ public static class WritePatchBuilder
 
         // --- Phase 1: resolve each source body from its NAMED plugin (NOT the load-order winner) + classify any miss
         //     (Q3 — collect ALL problems, then refuse the whole call if any). ONE captured build answers every spec (the
-        //     hunt-F5 one-view discipline Apply follows: a freshness rebuild mid-loop can't mix two builds' resolutions). ---
+        //     hunt-F5 one-view discipline Apply follows: a freshness rebuild mid-loop can't mix two builds' resolutions).
+        //     PERF (accuracy-over-perf, not a blocker): each GetRecord re-enumerates from_plugin's overlay, so N targets
+        //     from ONE source = N in-memory walks of that overlay (the file is opened ONCE — the session caches it). Fine
+        //     for realistic use (re-assert a few of a mod's records); if a "forward 100 records out of a huge overhaul"
+        //     case ever bites, the clean fix is a single-pass batch fetch keyed by from_plugin (group specs by source,
+        //     enumerate the overlay once collecting all wanted FormKeys) — deferred until measured. ---
         var view = resolver.Capture();
         var resolved = new List<(ForwardSpec spec, IMajorRecordGetter body, string priorWinner, bool wasWinner)>(specs.Count);
         var problems = new List<string>();

--- a/src/housecarl-generator/ForwardFromPluginProbe.cs
+++ b/src/housecarl-generator/ForwardFromPluginProbe.cs
@@ -33,6 +33,9 @@ namespace HousecarlGenerator;
 ///                       header carries ONLY the origin master (NOT ModA — content is copied, not mastered); the prior
 ///                       winner (ModB) is reported and WasAlreadyWinner is false. THE core proof.
 ///   FORWARD-MASTER    — forward the ORIGIN master's X: Dmg 10 lands (revert-to-vanilla by naming a master as source).
+///   NESTED            — forward a PlacedObject (lives in a cell -> the link-cache NESTED override branch, NOT the flat
+///                       WEAP path): ModA's Scale 2.0 copied, NOT winner ModB's 3.0. Demonstrates the "every record
+///                       type, nested families included" generality for the forward path itself, not just by reuse.
 ///   ALREADY-WINNER    — forward ModB's X (already winning): succeeds, Dmg 30, flagged WasAlreadyWinner (redundant — surfaced, not silent Q3).
 ///   MULTI             — forward [X,Y] from ModA in ONE call: both land (20, 200).
 ///   EXTEND            — forward X (fresh) then Y into the SAME patch (into=): both present (20, 200).
@@ -41,6 +44,13 @@ namespace HousecarlGenerator;
 ///   REJ-DOESNTDEFINE  — forwarding X from Other (which defines only W) refuses loud ('does NOT define'), NO file.
 ///   REJ-INTOSELF      — from_plugin == the output patch itself refuses loud ('output patch itself'), NO file.
 ///   REJ-DUP           — the SAME target twice in one call refuses loud ('more than once'), NO file.
+///
+/// COVERAGE NOTE (Q3 — surface the gap, don't imply completeness): four of GetRecord's five null/refusal shapes are
+/// armed above (not-in-order, doesn't-define, the-patch-itself, dup). The FIFTH — a source plugin EXCLUDED from the
+/// index because Mutagen can't parse it — is the deliberately-uncovered branch: synthesizing an unparseable plugin here
+/// would duplicate pkcu-regression's malformed-record machinery for one reject path. The branch is a plain
+/// ExcludedPlugins lookup sharing the same OrdinalIgnoreCase table as the armed checks; if it ever earns a test, model
+/// it on pkcu-regression's synthetic malformed plugin.
 ///
 /// Run: dotnet run --project src/housecarl-generator -- forward-from-plugin-guard
 /// </summary>
@@ -77,23 +87,39 @@ public static class ForwardFromPluginProbe
         string aPath = Path.Combine(tmpDir, ModAName);
         string bPath = Path.Combine(tmpDir, ModBName);
         string oPath = Path.Combine(tmpDir, OtherName);
-        FormKey xFk, yFk;
+        FormKey xFk, yFk, pFk;
         try
         {
             var m = new SkyrimMod(new ModKey("HcFwdMaster", ModType.Master), SkyrimRelease.SkyrimSE);
             var x = m.Weapons.AddNew(); x.EditorID = "HcFwdWeapX"; x.BasicStats = new WeaponBasicStats { Damage = 10 };
             var y = m.Weapons.AddNew(); y.EditorID = "HcFwdWeapY"; y.BasicStats = new WeaponBasicStats { Damage = 100 };
             xFk = x.FormKey; yFk = y.FormKey;
+            // A NESTED fixture (the by-construction generality, SHOWN not just asserted): a PlacedObject lives in a cell,
+            // so RecordNeedsSourceCache(it)==true and forwarding it exercises the link-cache NESTED override branch — a
+            // DIFFERENT code path than the flat WEAP arms. Distinct Scale per version (master 1, ModA 2, ModB 3) is the
+            // discriminator, exactly as Damage is for X/Y (a placed ref's parent chain reconstructs from the source overlay).
+            var cell = new Cell(m.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "HcFwdCell" };
+            var placed = new PlacedObject(m.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "HcFwdRef", Scale = 1.0f };
+            cell.Persistent.Add(placed);
+            var subBlock = new CellSubBlock { BlockNumber = 0, GroupType = GroupTypeEnum.InteriorCellSubBlock };
+            subBlock.Cells.Add(cell);
+            var cblock = new CellBlock { BlockNumber = 0, GroupType = GroupTypeEnum.InteriorCellBlock };
+            cblock.SubBlocks.Add(subBlock);
+            m.Cells.Records.Add(cblock);
+            pFk = placed.FormKey;
             m.BeginWrite.ToPath(mPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            var mCache = m.ToImmutableLinkCache();   // the nested PlacedObject override (below) reconstructs its parent chain from it
 
             var a = new SkyrimMod(new ModKey("HcFwdModA", ModType.Plugin), SkyrimRelease.SkyrimSE);
             ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(a, x)).BasicStats!.Damage = 20;
             ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(a, y)).BasicStats!.Damage = 200;
+            ((IPlacedObject)WriteEngine.GenericGetOrAddAsOverride(a, placed, mCache)).Scale = 2.0f;
             a.BeginWrite.ToPath(aPath).WithLoadOrder(new ISkyrimModGetter[] { m }).Write();
 
             var b = new SkyrimMod(new ModKey("HcFwdModB", ModType.Plugin), SkyrimRelease.SkyrimSE);
             ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(b, x)).BasicStats!.Damage = 30;
             ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(b, y)).BasicStats!.Damage = 300;
+            ((IPlacedObject)WriteEngine.GenericGetOrAddAsOverride(b, placed, mCache)).Scale = 3.0f;
             b.BeginWrite.ToPath(bPath).WithLoadOrder(new ISkyrimModGetter[] { m }).Write();
 
             var o = new SkyrimMod(new ModKey("HcFwdOther", ModType.Plugin), SkyrimRelease.SkyrimSE);
@@ -141,6 +167,19 @@ public static class ForwardFromPluginProbe
             var dmg = o.Success ? ReadWeaponDamage(pPath, xFk) : null;
             Check("FORWARD-MASTER: forwarding the origin master's version reverts X to vanilla (Dmg 10)",
                 o.Success && dmg == 10, $"success={o.Success} dmg={dmg} (want 10) err=[{Trim(o.Error)}]");
+        }
+
+        // ---- NESTED: forward a PlacedObject (the link-cache NESTED override path, a different branch than the flat WEAP
+        //      arms) -> ModA's Scale 2.0 lands, NOT winner ModB's 3.0. Converts "every record type, nested families
+        //      included" from by-construction to SHOWN for the forward path itself. ----
+        {
+            string pPath = Path.Combine(tmpDir, "HcFwdNested.esp");
+            using var r = LoadOrderResolver.Build(orderPaths);
+            var o = WritePatchBuilder.ForwardRecords(r,
+                new[] { new WritePatchBuilder.ForwardSpec { Target = pFk, FromPlugin = ModAName } }, pPath, extend: false);
+            var scale = o.Success ? ReadPlacedScale(pPath, pFk) : null;
+            Check("NESTED: forwarding a PlacedObject (nested link-cache path) copies ModA's version (Scale 2.0), NOT the winner's (3.0)",
+                o.Success && scale == 2.0f, $"success={o.Success} scale={scale} (want 2) err=[{Trim(o.Error)}]");
         }
 
         // ---- ALREADY-WINNER: forward ModB's X (already the winner) -> succeeds, Dmg 30, flagged redundant. ----
@@ -240,6 +279,18 @@ public static class ForwardFromPluginProbe
         {
             back = SkyrimMod.CreateFromBinaryOverlay(patchPath, SkyrimRelease.SkyrimSE);
             return back.EnumerateMajorRecords<IWeaponGetter>().FirstOrDefault(r => r.FormKey == fk)?.BasicStats?.Damage;
+        }
+        catch { return null; }
+        finally { (back as IDisposable)?.Dispose(); }
+    }
+
+    static float? ReadPlacedScale(string patchPath, FormKey fk)
+    {
+        ISkyrimModGetter? back = null;
+        try
+        {
+            back = SkyrimMod.CreateFromBinaryOverlay(patchPath, SkyrimRelease.SkyrimSE);
+            return back.EnumerateMajorRecords<IPlacedObjectGetter>().FirstOrDefault(r => r.FormKey == fk)?.Scale;
         }
         catch { return null; }
         finally { (back as IDisposable)?.Dispose(); }

--- a/src/housecarl-generator/ForwardFromPluginProbe.cs
+++ b/src/housecarl-generator/ForwardFromPluginProbe.cs
@@ -1,0 +1,256 @@
+using System.Security.Cryptography;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SELF-CONTAINED CI REGRESSION GUARD for FORWARD-FROM-PLUGIN (HCBR-2026-06-21 — "no convenient 'forward an earlier
+/// plugin's version as my override'"). Drives the REAL product path (WritePatchBuilder.ForwardRecords — what
+/// housecarl_forward_record calls) against a SYNTHESIZED 4-plugin order in TEMP — NO Skyrim.esm, so it runs in CI.
+///
+/// THE GAP (reproduced by construction): the write tools (set_field / bulk_apply) override the load-order WINNER. To
+/// re-assert an EARLIER plugin's version over a later override (the report case: restore ATweaks' Searing-Sun spell over
+/// Sacrilege's), there was no primitive — you had to hand-reconstruct the earlier record field-by-field. forward_record
+/// copies the earlier plugin's WHOLE record verbatim as the override.
+///
+/// THE FIX (generic by construction): ForwardRecords resolves the source body from a NAMED plugin (not the winner) via
+/// the resolver's GetRecord, then DEEP-COPIES it into the patch through WriteEngine.GenericGetOrAddAsOverride — the SAME
+/// override primitive Apply uses, so it covers every record type (nested families included) with no per-type wiring and
+/// no field pre-flight (a whole valid source record is legal by definition).
+///
+/// FIXTURE (priority master -> ModA -> ModB -> Other): master defines weapon X(Dmg 10), Y(Dmg 100); ModA overrides
+/// X->20, Y->200 (the EARLIER override to re-assert); ModB overrides X->30, Y->300 (the WINNER); Other defines its OWN
+/// weapon W and touches NEITHER X nor Y (the "source doesn't define it" Q3 fixture). Distinct Damage per version is the
+/// by-construction discriminator: the read-back Damage proves WHICH plugin's version landed.
+///
+/// Arms (ALL required — a GREEN must mean "the contract holds"):
+///   SETUP             — the order resolves X's winner to ModB (else the forward beats nothing — Q3).
+///   FORWARD-NONWINNER — forward ModA's X: the patch carries Dmg 20 (ModA's), NOT 30 (winner ModB) NOR 10 (master); the
+///                       header carries ONLY the origin master (NOT ModA — content is copied, not mastered); the prior
+///                       winner (ModB) is reported and WasAlreadyWinner is false. THE core proof.
+///   FORWARD-MASTER    — forward the ORIGIN master's X: Dmg 10 lands (revert-to-vanilla by naming a master as source).
+///   ALREADY-WINNER    — forward ModB's X (already winning): succeeds, Dmg 30, flagged WasAlreadyWinner (redundant — surfaced, not silent Q3).
+///   MULTI             — forward [X,Y] from ModA in ONE call: both land (20, 200).
+///   EXTEND            — forward X (fresh) then Y into the SAME patch (into=): both present (20, 200).
+///   ORIGINALS         — the 4 source plugins are SHA-identical across the whole run (only the patch is ever written).
+///   REJ-NOTINORDER    — a source plugin not in the order refuses loud ('not in the load order'), NO file.
+///   REJ-DOESNTDEFINE  — forwarding X from Other (which defines only W) refuses loud ('does NOT define'), NO file.
+///   REJ-INTOSELF      — from_plugin == the output patch itself refuses loud ('output patch itself'), NO file.
+///   REJ-DUP           — the SAME target twice in one call refuses loud ('more than once'), NO file.
+///
+/// Run: dotnet run --project src/housecarl-generator -- forward-from-plugin-guard
+/// </summary>
+public static class ForwardFromPluginProbe
+{
+    const string MasterName = "HcFwdMaster.esm";
+    const string ModAName = "HcFwdModA.esp";
+    const string ModBName = "HcFwdModB.esp";
+    const string OtherName = "HcFwdOther.esp";
+
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("forward-from-plugin-guard — copy a NAMED plugin's version of a record as an override (HCBR-2026-06-21)");
+        Console.WriteLine();
+
+        var tmpDir = Path.Combine(Path.GetTempPath(), "hc-forward-from-plugin-guard");
+        if (Directory.Exists(tmpDir)) Directory.Delete(tmpDir, recursive: true);
+        Directory.CreateDirectory(tmpDir);
+        try { return RunChecks(tmpDir); }
+        finally { try { Directory.Delete(tmpDir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    static int RunChecks(string tmpDir)
+    {
+        int failures = 0;
+        void Check(string label, bool ok, string? detail = null)
+        {
+            Console.WriteLine($"  {(ok ? "PASS" : "FAIL")}  {label}{(ok || detail is null ? "" : $"\n        -> {detail}")}");
+            if (!ok) failures++;
+        }
+
+        // ---- synthesize the 4-plugin order (see class doc). ----
+        string mPath = Path.Combine(tmpDir, MasterName);
+        string aPath = Path.Combine(tmpDir, ModAName);
+        string bPath = Path.Combine(tmpDir, ModBName);
+        string oPath = Path.Combine(tmpDir, OtherName);
+        FormKey xFk, yFk;
+        try
+        {
+            var m = new SkyrimMod(new ModKey("HcFwdMaster", ModType.Master), SkyrimRelease.SkyrimSE);
+            var x = m.Weapons.AddNew(); x.EditorID = "HcFwdWeapX"; x.BasicStats = new WeaponBasicStats { Damage = 10 };
+            var y = m.Weapons.AddNew(); y.EditorID = "HcFwdWeapY"; y.BasicStats = new WeaponBasicStats { Damage = 100 };
+            xFk = x.FormKey; yFk = y.FormKey;
+            m.BeginWrite.ToPath(mPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+            var a = new SkyrimMod(new ModKey("HcFwdModA", ModType.Plugin), SkyrimRelease.SkyrimSE);
+            ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(a, x)).BasicStats!.Damage = 20;
+            ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(a, y)).BasicStats!.Damage = 200;
+            a.BeginWrite.ToPath(aPath).WithLoadOrder(new ISkyrimModGetter[] { m }).Write();
+
+            var b = new SkyrimMod(new ModKey("HcFwdModB", ModType.Plugin), SkyrimRelease.SkyrimSE);
+            ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(b, x)).BasicStats!.Damage = 30;
+            ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(b, y)).BasicStats!.Damage = 300;
+            b.BeginWrite.ToPath(bPath).WithLoadOrder(new ISkyrimModGetter[] { m }).Write();
+
+            var o = new SkyrimMod(new ModKey("HcFwdOther", ModType.Plugin), SkyrimRelease.SkyrimSE);
+            var w = o.Weapons.AddNew(); w.EditorID = "HcFwdWeapW"; w.BasicStats = new WeaponBasicStats { Damage = 5 };
+            o.BeginWrite.ToPath(oPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"error: could not synthesize fixtures: {ex.GetType().Name}: {(ex.InnerException ?? ex).Message}");
+            return 1;
+        }
+
+        var orderPaths = new[] { mPath, aPath, bPath, oPath };   // priority: master -> ModA -> ModB -> Other
+        // SHA the sources up front; assert untouched at the end (only the patch is ever written).
+        var shaBefore = orderPaths.ToDictionary(p => p, ShaOf, StringComparer.Ordinal);
+
+        // ---- SETUP: the order resolves X's winner to ModB (else the forward below beats nothing). ----
+        using (var r = LoadOrderResolver.Build(orderPaths))
+        {
+            var v = r.Capture();
+            Check("SETUP: winner of X resolves to ModB (the override the forward must beat)",
+                v.ResolveWinner(xFk)?.WinnerPlugin == ModBName, $"winner={v.ResolveWinner(xFk)?.WinnerPlugin}");
+        }
+
+        // ---- FORWARD-NONWINNER (the core proof): forward ModA's X -> Dmg 20, masters=[origin], winner reported. ----
+        {
+            string pPath = Path.Combine(tmpDir, "HcFwdNonWinner.esp");
+            using var r = LoadOrderResolver.Build(orderPaths);
+            var o = WritePatchBuilder.ForwardRecords(r,
+                new[] { new WritePatchBuilder.ForwardSpec { Target = xFk, FromPlugin = ModAName } }, pPath, extend: false);
+            var dmg = o.Success ? ReadWeaponDamage(pPath, xFk) : null;
+            bool mastersOk = o.Success && o.Masters.Count == 1 && o.Masters[0].Equals(MasterName, StringComparison.OrdinalIgnoreCase);
+            bool winnerRep = o.Success && o.Forwarded.Count == 1 && o.Forwarded[0].PriorWinner == ModBName && !o.Forwarded[0].WasAlreadyWinner;
+            Check("FORWARD-NONWINNER: ModA's X (Dmg 20) copied, NOT winner ModB's (30); header=[origin master only]; winner reported",
+                o.Success && dmg == 20 && mastersOk && winnerRep,
+                $"success={o.Success} dmg={dmg} (want 20) masters=[{(o.Success ? string.Join(",", o.Masters) : "")}] winnerRep={winnerRep} err=[{Trim(o.Error)}]");
+        }
+
+        // ---- FORWARD-MASTER (revert to vanilla): forward the ORIGIN master's X -> Dmg 10. ----
+        {
+            string pPath = Path.Combine(tmpDir, "HcFwdMasterVer.esp");
+            using var r = LoadOrderResolver.Build(orderPaths);
+            var o = WritePatchBuilder.ForwardRecords(r,
+                new[] { new WritePatchBuilder.ForwardSpec { Target = xFk, FromPlugin = MasterName } }, pPath, extend: false);
+            var dmg = o.Success ? ReadWeaponDamage(pPath, xFk) : null;
+            Check("FORWARD-MASTER: forwarding the origin master's version reverts X to vanilla (Dmg 10)",
+                o.Success && dmg == 10, $"success={o.Success} dmg={dmg} (want 10) err=[{Trim(o.Error)}]");
+        }
+
+        // ---- ALREADY-WINNER: forward ModB's X (already the winner) -> succeeds, Dmg 30, flagged redundant. ----
+        {
+            string pPath = Path.Combine(tmpDir, "HcFwdAlreadyWin.esp");
+            using var r = LoadOrderResolver.Build(orderPaths);
+            var o = WritePatchBuilder.ForwardRecords(r,
+                new[] { new WritePatchBuilder.ForwardSpec { Target = xFk, FromPlugin = ModBName } }, pPath, extend: false);
+            var dmg = o.Success ? ReadWeaponDamage(pPath, xFk) : null;
+            bool flagged = o.Success && o.Forwarded.Count == 1 && o.Forwarded[0].WasAlreadyWinner;
+            Check("ALREADY-WINNER: forwarding the current winner succeeds (Dmg 30) and is flagged redundant (Q3, not silent)",
+                o.Success && dmg == 30 && flagged, $"success={o.Success} dmg={dmg} (want 30) flagged={flagged} err=[{Trim(o.Error)}]");
+        }
+
+        // ---- MULTI: forward [X,Y] from ModA in ONE call -> both land (20, 200). ----
+        {
+            string pPath = Path.Combine(tmpDir, "HcFwdMulti.esp");
+            using var r = LoadOrderResolver.Build(orderPaths);
+            var o = WritePatchBuilder.ForwardRecords(r, new[]
+            {
+                new WritePatchBuilder.ForwardSpec { Target = xFk, FromPlugin = ModAName },
+                new WritePatchBuilder.ForwardSpec { Target = yFk, FromPlugin = ModAName },
+            }, pPath, extend: false);
+            var dx = o.Success ? ReadWeaponDamage(pPath, xFk) : null;
+            var dy = o.Success ? ReadWeaponDamage(pPath, yFk) : null;
+            Check("MULTI: two records forwarded from ModA in one call both land (X=20, Y=200)",
+                o.Success && o.Forwarded.Count == 2 && dx == 20 && dy == 200,
+                $"success={o.Success} count={(o.Success ? o.Forwarded.Count : 0)} dx={dx} dy={dy} err=[{Trim(o.Error)}]");
+        }
+
+        // ---- EXTEND (into=): forward X (fresh) then Y into the SAME patch -> both present (20, 200). ----
+        {
+            string pPath = Path.Combine(tmpDir, "HcFwdExtend.esp");
+            bool firstOk, secondOk; ushort? dx = null, dy = null;
+            using (var r = LoadOrderResolver.Build(orderPaths))
+                firstOk = WritePatchBuilder.ForwardRecords(r,
+                    new[] { new WritePatchBuilder.ForwardSpec { Target = xFk, FromPlugin = ModAName } }, pPath, extend: false).Success;
+            using (var r = LoadOrderResolver.Build(orderPaths))
+            {
+                var o2 = WritePatchBuilder.ForwardRecords(r,
+                    new[] { new WritePatchBuilder.ForwardSpec { Target = yFk, FromPlugin = ModAName } }, pPath, extend: true);
+                secondOk = o2.Success && o2.Extended;
+            }
+            if (firstOk && secondOk) { dx = ReadWeaponDamage(pPath, xFk); dy = ReadWeaponDamage(pPath, yFk); }
+            Check("EXTEND: forward X fresh, then Y into the same patch (into=) — both survive (X=20, Y=200)",
+                firstOk && secondOk && dx == 20 && dy == 200, $"first={firstOk} second={secondOk} dx={dx} dy={dy}");
+        }
+
+        // ---- Q3 rejects (whole call refused, NO file written, named reason). ----
+        void RejectArm(string label, string stem, WritePatchBuilder.ForwardSpec[] specs, Func<string, bool> msgOk)
+        {
+            string pPath = Path.Combine(tmpDir, stem + ".esp");
+            using var r = LoadOrderResolver.Build(orderPaths);
+            var o = WritePatchBuilder.ForwardRecords(r, specs, pPath, extend: false);
+            bool refused = !o.Success, noFile = !File.Exists(pPath), named = o.Error is not null && msgOk(o.Error);
+            Check(label, refused && noFile && named, $"refused={refused} noFile={noFile} named={named} err=[{Trim(o.Error)}]");
+        }
+
+        RejectArm("REJ-NOTINORDER: source plugin not in the order refuses loud, no file", "HcFwdNotInOrder",
+            new[] { new WritePatchBuilder.ForwardSpec { Target = xFk, FromPlugin = "NotReal.esp" } },
+            msg => msg.Contains("not in the load order", StringComparison.OrdinalIgnoreCase));
+
+        RejectArm("REJ-DOESNTDEFINE: source in the order but doesn't define the record refuses loud, no file", "HcFwdNoDef",
+            new[] { new WritePatchBuilder.ForwardSpec { Target = xFk, FromPlugin = OtherName } },
+            msg => msg.Contains("does NOT define", StringComparison.OrdinalIgnoreCase) || msg.Contains("does not define", StringComparison.OrdinalIgnoreCase));
+
+        // INTOSELF: from_plugin == the output patch's own filename (HcFwdSelf.esp). The self-check fires before the
+        // in-order check, so it's reported as the self-forward no-op, not a misleading "not in the load order".
+        RejectArm("REJ-INTOSELF: from_plugin == the output patch itself refuses loud, no file", "HcFwdSelf",
+            new[] { new WritePatchBuilder.ForwardSpec { Target = xFk, FromPlugin = "HcFwdSelf.esp" } },
+            msg => msg.Contains("output patch itself", StringComparison.OrdinalIgnoreCase));
+
+        RejectArm("REJ-DUP: the same target twice in one call refuses loud, no file", "HcFwdDup",
+            new[]
+            {
+                new WritePatchBuilder.ForwardSpec { Target = xFk, FromPlugin = ModAName },
+                new WritePatchBuilder.ForwardSpec { Target = xFk, FromPlugin = ModBName },
+            },
+            msg => msg.Contains("more than once", StringComparison.OrdinalIgnoreCase));
+
+        // ---- ORIGINALS: every source plugin SHA-identical across the whole run (only patches were ever written). ----
+        bool untouched = shaBefore.All(kv => string.Equals(kv.Value, ShaOf(kv.Key), StringComparison.Ordinal));
+        Check("ORIGINALS: the 4 source plugins are byte-identical after the run (only the patch is written)", untouched,
+            untouched ? null : "a source plugin's bytes changed — forwarding must never write a source");
+
+        Console.WriteLine();
+        Console.WriteLine(failures == 0 ? "forward-from-plugin-guard: ALL PASS" : $"forward-from-plugin-guard: {failures} FAILURE(S)");
+        return failures == 0 ? 0 : 1;
+    }
+
+    // ---- helpers ----
+
+    static ushort? ReadWeaponDamage(string patchPath, FormKey fk)
+    {
+        ISkyrimModGetter? back = null;
+        try
+        {
+            back = SkyrimMod.CreateFromBinaryOverlay(patchPath, SkyrimRelease.SkyrimSE);
+            return back.EnumerateMajorRecords<IWeaponGetter>().FirstOrDefault(r => r.FormKey == fk)?.BasicStats?.Damage;
+        }
+        catch { return null; }
+        finally { (back as IDisposable)?.Dispose(); }
+    }
+
+    static string ShaOf(string path)
+    {
+        using var sha = SHA256.Create();
+        using var fs = File.OpenRead(path);
+        return Convert.ToHexString(sha.ComputeHash(fs));
+    }
+
+    static string Trim(string? s) => s is null ? "" : (s.Length <= 160 ? s.Replace("\n", " ") : s[..160].Replace("\n", " ") + "…");
+}

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -41,6 +41,12 @@ if (args.Length > 0 && args[0] == "floi-read-guard") return FloiReadProbe.RunGua
 // composes a GetEquipped.ItemOrList via fields: AND sets:, asserts both land (form + index mode) and are byte-identical.
 if (args.Length > 0 && args[0] == "floi-fields-guard") return FloiFieldsProbe.RunGuard(args[1..]);
 
+// Forward a NAMED plugin's version of a record as an override (HCBR-2026-06-21): SELF-CONTAINED CI regression guard —
+// synthesizes a master + earlier-override + winner-override + a non-toucher, drives the REAL WritePatchBuilder.ForwardRecords,
+// asserts the EARLIER plugin's version (not the winner) is copied, the header carries only the origin master, revert-to-vanilla
+// (forward a master) + already-winner + multi + into= work, originals untouched, and the 4 Q3 rejects.
+if (args.Length > 0 && args[0] == "forward-from-plugin-guard") return ForwardFromPluginProbe.RunGuard(args[1..]);
+
 // Field-value query predicate (cross_plugin_query where=): SELF-CONTAINED CI regression guard — synthesizes records
 // with known field values, asserts the evaluator's matched set == a brute-force reference + the Q3 teeth.
 if (args.Length > 0 && args[0] == "value-predicate-guard") return ValuePredicateProbe.RunGuard(args[1..]);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1101,6 +1101,50 @@ public sealed class LoadOrderService : IDisposable
         }
     }
 
+    /// <summary>Forward a NAMED plugin's version of one-or-more records into a patch as an override (housecarl_forward_record)
+    /// — xEdit's "copy as override into", the inverse of <see cref="ApplyEdits"/>'s winner-override. Parses every formid
+    /// (all-or-nothing on a malformed one), resolves the folder-per-patch output (fresh, or <paramref name="into"/> an
+    /// existing houseCARL-owned patch), then drives <see cref="WritePatchBuilder.ForwardRecords"/> (resolve each source
+    /// body from <paramref name="fromPlugin"/> → deep-copy as override → multi-master serialize). The whole source record
+    /// is copied verbatim, so the SOURCE plugin (not the load-order winner) decides the content — and forwarding the
+    /// ORIGIN master reverts a record to vanilla. Originals are never touched (only the patch folder is written).</summary>
+    public WritePatchBuilder.ForwardOutcome ForwardRecords(IReadOnlyList<string> formids, string fromPlugin, string? patchName, string? into, bool fullReadback = false)
+    {
+        if (string.IsNullOrWhiteSpace(fromPlugin))
+            return WritePatchBuilder.ForwardOutcome.Fail(
+                "from_plugin is required — name the plugin whose version of the record(s) to forward (the earlier override, or a master to revert to vanilla).");
+        if (formids is null || formids.Count == 0)
+            return WritePatchBuilder.ForwardOutcome.Fail("no formids supplied — pass the FormID(s) to forward from the source plugin.");
+
+        // Parse every formid first, collecting ALL problems (all-or-nothing, like the edit/remove paths). Pure — outside the gate.
+        var fp = fromPlugin.Trim();
+        var specs = new List<WritePatchBuilder.ForwardSpec>(formids.Count);
+        var problems = new List<string>();
+        for (int i = 0; i < formids.Count; i++)
+        {
+            var raw = formids[i];
+            if (string.IsNullOrWhiteSpace(raw)) { problems.Add($"formid[{i}]: empty."); continue; }
+            try { specs.Add(new WritePatchBuilder.ForwardSpec { Target = FormKey.Factory(raw.Trim()), FromPlugin = fp }); }
+            catch (Exception ex) { problems.Add($"formid[{i}] '{raw}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."); }
+        }
+        if (problems.Count > 0)
+            return WritePatchBuilder.ForwardOutcome.Fail(
+                $"refused — {problems.Count} of {formids.Count} formid(s) malformed; NOTHING forwarded:\n  - " + string.Join("\n  - ", problems));
+
+        lock (_writeGate)                                                 // hunt F2: one write at a time, resolve→commit
+        {
+            var resolver = Resolver;                                      // builds/refreshes the index (Overlays for the source fetch + serialize)
+
+            string outPath; bool extend, created;
+            try { outPath = ResolveOutputPath(patchName, into, out extend, out created); }
+            catch (Exception ex) { return WritePatchBuilder.ForwardOutcome.Fail(ex.Message); }
+
+            var outcome = WritePatchBuilder.ForwardRecords(resolver, specs, outPath, extend, fullReadback);
+            if (!outcome.Success && created) RemoveFolderCreatedThisCall(outPath);   // hunt F4: a refused forward leaves no orphan
+            return outcome;
+        }
+    }
+
     /// <summary>Create a BRAND-NEW record (housecarl_create_record) — the net-new authoring capability, the sibling of
     /// <see cref="ApplyEdits"/>. Resolves <paramref name="recordType"/> (catalog name or 4-char signature) to ONE concrete
     /// catalog name (unknown/ambiguous → Q3), maps the field <paramref name="operations"/> to core <see cref="WriteRequest"/>s

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -358,7 +358,7 @@ public static class WriteTools
             sb.Append("  ").Append(f.RecordType).Append(' ').Append(f.Target).Append("  ").Append(f.EditorId ?? "<no editorid>")
               .Append("  — copied from ").Append(f.FromPlugin);
             if (f.WasAlreadyWinner)
-                sb.Append("  [NOTE: this version was ALREADY the load-order winner — the override is a redundant no-op copy]");
+                sb.Append("  [NOTE: this source IS already the load-order winner — the override just re-asserts the content that already wins (a no-op in effect)]");
             else
                 sb.Append("  (out-ranks the current winner ").Append(f.PriorWinner).Append(" once this patch is enabled + sorted above it)");
             sb.Append('\n');

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -207,6 +207,47 @@ public static class WriteTools
         return RenderCreate(svc.CreateRecordsBatch(records, patch_name, into, full_readback), max_chars);
     });
 
+    [McpServerTool(Name = "housecarl_forward_record", Title = "Forward a plugin's version of a record as an override"),
+     Description(
+         "Forward a SPECIFIC plugin's version of one-or-more records into a NEW patch as an override (originals untouched) " +
+         "— xEdit's \"copy as override into\", the INVERSE of set_field/bulk_apply. Those edit the load-order WINNER; this " +
+         "copies from_plugin's whole record VERBATIM, so from_plugin's version (NOT the winner) becomes the patch's content " +
+         "— the way to RE-ASSERT an earlier mod's version over a later override (e.g. a late total-overhaul re-architected a " +
+         "record an earlier list patch had balanced — forward the earlier plugin's version back on top), or to REVERT a " +
+         "record to vanilla (name a master — Skyrim.esm/Update.esm/… — as from_plugin). formids are 'XXXXXX:Plugin.esp' " +
+         "(one or more, ALL copied from the SAME from_plugin); call again with into= to forward from a different source into " +
+         "the same patch. This copies the record WHOLE — it does NOT edit fields (use set_field/bulk_apply for that) and " +
+         "needs no field pre-flight (a complete source record is legal by construction). Forwarding does NOT add from_plugin " +
+         "as a master: the patch overrides the record's ORIGIN FormKey with the copied body, so the header carries the origin " +
+         "master + whatever the body references (exactly xEdit's copy-as-override-into-a-new-patch). ALL-OR-NOTHING (Q3): the " +
+         "whole call is refused with a named reason and NOTHING is written if from_plugin isn't in the load order, was " +
+         "excluded (unparseable), is the output patch itself, names a target twice, or simply doesn't DEFINE/override a given " +
+         "record (nothing there to forward). By default writes a fresh patch named patch_name; into= EXTENDS an existing " +
+         "houseCARL patch (accumulate across calls/sessions). Returns the patch path, masters, and per-record what was " +
+         "copied + the current winner it will out-rank (a forward whose version is ALREADY winning is flagged redundant).")]
+    public static string ForwardRecord(
+        LoadOrderService svc,
+        [Description("The record(s) to forward, each as 'XXXXXX:Plugin.esp' (6 hex digits, the defining master's filename). All are copied from the SAME from_plugin.")]
+            string[] formids,
+        [Description("The plugin filename whose version of the record(s) to copy (e.g. 'Authoria - ATweaks.esp', or a master like 'Skyrim.esm' to revert to vanilla). Must be an active plugin that DEFINES or overrides each formid.")]
+            string from_plugin,
+        [Description("Optional. Base filename for the new patch (default 'houseCARL_Patch'); auto-suffixed if taken so a prior patch is never overwritten. Ignored if into= is given.")]
+            string patch_name = "houseCARL_Patch",
+        [Description("Optional. Filename of an existing houseCARL patch to ADD these forwards to instead of writing a fresh one (accumulate across calls — e.g. forward from a different source plugin into the same patch).")]
+            string? into = null,
+        [Description("When true, the response ALSO returns each forwarded record IN FULL, read back from the written patch file on disk (every field, deep). The pre-enable verification: confirm the copied version is exactly the source's, WITHOUT enabling the patch in MO2 (the written file's content, not load-order truth).")]
+            bool full_readback = false,
+        [Description("Optional. Max characters for the whole response; past it the full read-back section is cut with an explicit notice (never silent). 0 = the server default (~80k). Only matters with full_readback=true.")]
+            int max_chars = 0) => Guard.Tool("housecarl_forward_record", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        if (formids is null || formids.Length == 0)
+            return "error: formids is empty. Pass one or more 'XXXXXX:Plugin.esp' FormIDs to forward from from_plugin.";
+        if (string.IsNullOrWhiteSpace(from_plugin))
+            return "error: from_plugin is empty. Name the plugin whose version of the record(s) to forward.";
+        return RenderForward(svc.ForwardRecords(formids, from_plugin, patch_name, into, full_readback), max_chars);
+    });
+
     /// <summary>Compact, parseable confirmation (rulebook: short mutation confirmation + the IDs needed for follow-up).
     /// On refusal, the full reason (every malformed/rejected op) so the caller can fix and retry.</summary>
     static string Render(WritePatchBuilder.PatchOutcome o, int maxChars = 0)
@@ -293,6 +334,37 @@ public static class WriteTools
         sb.Append(o.RemainingRecords == 0
             ? "this patch now carries no records — it's inert; disable or delete the mod folder in MO2 if you don't need it."
             : "re-sort in MO2 if dropping this override changes a conflict winner.");
+        return sb.ToString();
+    }
+
+    /// <summary>Confirmation for housecarl_forward_record: per record, WHAT was copied (type + FormID + editorid), the
+    /// source it was copied FROM, and the current winner it out-ranks once enabled — with a redundant-forward NOTE when
+    /// the copied version was already winning (Q3 — never silently a no-op). On refusal, the named reason so the caller
+    /// can fix and retry. Optional full read-back rides along (the pre-enable verify that the copy is the source's).</summary>
+    static string RenderForward(WritePatchBuilder.ForwardOutcome o, int maxChars = 0)
+    {
+        if (!o.Success) return "error: " + o.Error;
+        var file = Path.GetFileName(o.OutputPath);
+        var modFolder = Path.GetFileName(Path.GetDirectoryName(o.OutputPath) ?? "");
+        var sb = new StringBuilder();
+        sb.Append(o.Extended ? "extended " : "wrote ").Append(file)
+          .Append(o.Extended ? " (existing patch grown; " : " (new patch; ").Append(o.Bytes).Append(" bytes)\n");
+        sb.Append("mod folder: ").Append(modFolder)
+          .Append(o.Extended ? "\n" : "  — enable + sort it in MO2 to use the patch\n");
+        sb.Append("masters: ").Append(o.Masters.Count == 0 ? "(none)" : string.Join(", ", o.Masters)).Append('\n');
+        sb.Append("forwarded ").Append(o.Forwarded.Count).Append(o.Forwarded.Count == 1 ? " record:\n" : " records:\n");
+        foreach (var f in o.Forwarded)
+        {
+            sb.Append("  ").Append(f.RecordType).Append(' ').Append(f.Target).Append("  ").Append(f.EditorId ?? "<no editorid>")
+              .Append("  — copied from ").Append(f.FromPlugin);
+            if (f.WasAlreadyWinner)
+                sb.Append("  [NOTE: this version was ALREADY the load-order winner — the override is a redundant no-op copy]");
+            else
+                sb.Append("  (out-ranks the current winner ").Append(f.PriorWinner).Append(" once this patch is enabled + sorted above it)");
+            sb.Append('\n');
+        }
+        if (o.ReadBack is { } rb) AppendFullReadback(sb, rb, maxChars);
+        sb.Append("to forward more into THIS patch (incl. from a different source plugin), pass into=\"").Append(file).Append("\".");
         return sb.ToString();
     }
 


### PR DESCRIPTION
## What

`housecarl_forward_record` — copy a **named earlier plugin's** version of one-or-more records into a patch as an override (xEdit's "copy as override into"). The **inverse** of `set_field`/`bulk_apply`, which override the load-order *winner*: this copies `from_plugin`'s whole record verbatim, so the earlier plugin's version (not the winner) becomes the patch's content.

Closes the HCBR-2026-06-21 gap — "no convenient 'forward an earlier plugin's version as my override'." Two real uses:
- **Re-assert** an earlier mod's version over a later override (the report case: restore `Authoria - ATweaks.esp`'s Searing-Sun spell over Sacrilege's).
- **Revert to vanilla** — name a master (`Skyrim.esm`, …) as `from_plugin`.

## Why it's a small, safe change

Generic **by construction**: `WritePatchBuilder.ForwardRecords` resolves the source body from the **named plugin** (`view.GetRecord(session, fromPlugin, fk)` — the same call `Apply` uses for the winner), then deep-copies it via `WriteEngine.GenericGetOrAddAsOverride` — the **same override primitive `Apply` uses**. So it covers every record type, the nested Cell/Placed*/INFO/Navmesh/Landscape families included, with **no per-type wiring** (cornerstone-safe).

- **No field edit → no rulebook pre-flight.** A whole valid source record copied verbatim is legal by definition (the rulebook validates field *edits*, of which forwarding has none).
- **Copies content, not a master.** The patch overrides the target's origin FormKey with the source body, so the header carries the origin master + whatever the body references — never `from_plugin` (exactly xEdit's copy-as-override-into-a-new-patch).
- **Purely additive:** new method + DTOs + tool + guard. No existing write method is touched.

## Q3 (all-or-nothing, no silent failure)

The whole call is refused with a named reason and **no file written** when `from_plugin`: isn't in the load order / was excluded (unparseable) / is the output patch itself / names the same target twice / doesn't define the record. A forward whose source **is already the winner** is flagged (plugin-identity — it re-asserts the content that already wins), surfaced not dropped.

## Tool surface

`housecarl_forward_record(formids: string[], from_plugin, patch_name?, into?, full_readback?, max_chars?)` — one tool, a **list** of formids from **one** `from_plugin` per call (the realistic "re-assert several of a mod's records at once" case); mixed sources via `into=`. Mirrors the established `set_field`/`bulk_apply` ergonomics.

## Testing

New self-contained CI guard **`forward-from-plugin-guard`** (no Skyrim.esm — synthesizes master + earlier-override + winner-override + a non-toucher), **12/12 PASS**:

- **FORWARD-NONWINNER** (core): ModA's Dmg-20 version is copied, **not** winner ModB's 30 nor master's 10; header = origin master only; prior winner reported.
- **NESTED**: forward a **PlacedObject** (the link-cache nested branch — a *different* path than the flat WEAP arms): ModA's Scale 2.0 copied, not winner's 3.0. Demonstrates the nested generality for the forward path itself, not just by reuse.
- FORWARD-MASTER (revert-to-vanilla, Dmg 10), ALREADY-WINNER (flagged), MULTI (2 in one call), EXTEND (`into=`), ORIGINALS (4 sources byte-untouched), + REJ-NOTINORDER / REJ-DOESNTDEFINE / REJ-INTOSELF / REJ-DUP.
- Guard doc names the one deliberately-uncovered null-shape (an excluded/unparseable source) per Q3.

Build clean (0 errors). The existing write-path guards (`nested-create`, `verify-loop`, `floi-fields`, `formid-floor`) still pass — no regression. Wired into CI (`.github/workflows/ci.yml`).

## Files

- `src/housecarl-core/WritePatchBuilder.cs` — `ForwardSpec` / `ForwardedRecord` / `ForwardOutcome` + `ForwardRecords` (mirrors `Apply`'s 5 phases; Phase 3 is the deep-copy, no `ApplyVerb`).
- `src/housecarl-mcp/LoadOrderService.cs` — service wiring (mirrors the proven **`ApplyEdits`/`CommitCreate` create-path**, including the hunt-F4 orphan cleanup on refusal — *not* `RemoveRecords`, which targets an existing patch and creates no fresh folder).
- `src/housecarl-mcp/WriteTools.cs` — the `housecarl_forward_record` tool + `RenderForward`.
- `src/housecarl-generator/ForwardFromPluginProbe.cs` — the guard (new).
- `src/housecarl-generator/Program.cs`, `.github/workflows/ci.yml` — dispatch + CI step.

## Review response (commit d30b59a)

Folded the independent review's non-blocking items: added the NESTED guard arm (shows nested generality), a coverage note for the one uncovered null-shape, precise plugin-identity wording on the already-winner NOTE, a factual perf note on per-target re-enumeration, and corrected this body's service-mirror description (ApplyEdits, not RemoveRecords).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
