### PR TITLE
feat: author an empty header-only (trigger) plugin (HCBR-2026-06-19-02)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,16 @@ jobs:
       - name: Probe — forward-from-plugin (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- forward-from-plugin-guard
 
+      # Self-contained (core arms write to temp; service arms synthesize an MO2 instance — no Skyrim.esm), runs fully
+      # here: a regression guard for CREATE-PLUGIN (HCBR-2026-06-19-02 — housecarl_create_plugin). houseCARL's write
+      # model was record-centric, so a basename-bound SKSE config trigger (CraftingCategories-style) had to carry a junk
+      # filler record; create_plugin authors a valid TES4 header with ZERO records instead. Drives the REAL
+      # WritePatchBuilder.CreatePlugin (0 records, 0 masters, the ESL flag round-trip, sig TES4, author/desc) AND the
+      # REAL LoadOrderService.CreatePlugin (exact name — never auto-suffixed — plus the two collision refusals: an
+      # already-active basename, and an existing houseCARL folder, each loud with no orphan).
+      - name: Probe — create-plugin (self-contained regression guard)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- create-plugin-guard
+
       # Self-contained (synthesizes records with known field values — no external files), runs fully here: a regression
       # guard for the field-value query predicate (cross_plugin_query where=) — matched set == brute-force + the Q3 teeth.
       - name: Probe — field-value query predicate (self-contained regression guard)

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -468,6 +468,20 @@ public static class WritePatchBuilder
             new(false, error, "", false, Array.Empty<ForwardedRecord>(), Array.Empty<string>(), 0);
     }
 
+    /// <summary>The outcome of a <see cref="CreatePlugin"/> call. <see cref="Error"/> non-null ⇒ the call was refused
+    /// (no file written) with a named reason (Q3). Otherwise the empty plugin lives at <see cref="OutputPath"/> with the
+    /// exact <see cref="PluginName"/> the caller asked for (never auto-suffixed — a header-only plugin's basename is
+    /// load-bearing). <see cref="RecordCount"/> is 0 by definition (re-read off the written file to confirm, not
+    /// assumed); <see cref="Masters"/> is empty (an empty plugin references nothing — exactly what the CK stamps on one);
+    /// <see cref="Esl"/> echoes the light-master flag as it round-tripped through the write.</summary>
+    public sealed record CreatePluginOutcome(
+        bool Success, string? Error, string OutputPath, string PluginName, bool Esl,
+        IReadOnlyList<string> Masters, int RecordCount, long Bytes)
+    {
+        public static CreatePluginOutcome Fail(string error) =>
+            new(false, error, "", "", false, Array.Empty<string>(), 0, 0);
+    }
+
     /// <summary>
     /// FORWARD a NAMED plugin's version of each record INTO the patch as an override — xEdit's "copy as override into",
     /// the inverse of <see cref="Apply"/>'s winner-override. Where Apply/Create author NEW content, this re-asserts an
@@ -599,6 +613,74 @@ public static class WritePatchBuilder
         finally { (back as IDisposable)?.Dispose(); }
 
         return new ForwardOutcome(true, null, outPath, extend, forwarded, masters, bytes) { ReadBack = readBack };
+    }
+
+    /// <summary>
+    /// Create an EMPTY, HEADER-ONLY plugin — a valid <c>TES4</c> header and ZERO records (HCBR-2026-06-19-02). The
+    /// whole point is a plugin that exists purely so its BASENAME resolves: the artifact SKSE configs that bind by
+    /// plugin name need (a CraftingCategories-style trigger that must ship <c>Foo.esp</c> so <c>Foo.json</c> loads), a
+    /// placeholder ESL for FormID reservation, a deliberate empty master, a dummy plugin to satisfy a dependency check.
+    /// It is the clean primitive behind those: where the record-centric create/forward paths can only materialise a
+    /// plugin by giving it a record (forcing an unwanted conflict-tree participant — the report's redundant backpack
+    /// override), this authors NO record at all.
+    ///
+    /// <para>CORNERSTONE-CLEAN: a <see cref="SkyrimMod"/> with no records added IS a header-only plugin — there is no
+    /// per-type anything here, so it is trivially generic. ZERO MASTERS (Aaron 2026-06-23): an empty plugin references
+    /// nothing, so it carries no masters — passing an EMPTY known-master set means <see cref="WriteEngine.WritePatch"/>
+    /// forces no baseline masters either (its baseline force-include filters to masters present in the set; the empty
+    /// set yields none). That is exactly what the Creation Kit stamps on a truly empty plugin, so it honours the same
+    /// "match the CK" convention the baseline-master rule is built on. The atomic staged write + FormID floor still
+    /// apply (every product write funnels through that one chokepoint).</para>
+    ///
+    /// <para>Q3 — the written file is RE-READ to confirm it is what was promised (0 records, the ESL flag as requested)
+    /// before reporting success; a mismatch refuses loud rather than return a wrong artifact. Caller resolves
+    /// <paramref name="outPath"/> (the service uses an EXACT, never-suffixed name with a loud collision refusal — the
+    /// basename must be precise for the trigger to bind).</para>
+    /// </summary>
+    public static CreatePluginOutcome CreatePlugin(string outPath, bool esl, string? author, string? description)
+    {
+        var fileName = Path.GetFileName(outPath);
+
+        SkyrimMod mod;
+        try
+        {
+            mod = new SkyrimMod(new ModKey(Path.GetFileNameWithoutExtension(outPath), ModType.Plugin), SkyrimRelease.SkyrimSE)
+                { IsSmallMaster = esl };
+            if (!string.IsNullOrWhiteSpace(author)) mod.ModHeader.Author = author.Trim();
+            if (!string.IsNullOrWhiteSpace(description)) mod.ModHeader.Description = description.Trim();
+        }
+        catch (Exception ex) { return CreatePluginOutcome.Fail($"could not build the plugin in memory: {ex.GetType().Name}: {ex.Message}"); }
+
+        // Serialize through the single WriteEngine.WritePatch chokepoint with an EMPTY known-master set → zero masters,
+        // plus the crash-atomic staged write + the FormID floor every product write gets. Nothing is on disk on a throw.
+        try { WriteEngine.WritePatch(mod, Array.Empty<ISkyrimModGetter>(), outPath); }
+        catch (Exception ex)
+            { return CreatePluginOutcome.Fail($"writing the plugin failed (serialize or commit; nothing left on disk): {WriteEngine.Describe(ex)}"); }
+
+        // Re-open + CONFIRM the artifact (Q3 — never report success on an unverified file): zero records, the master
+        // header (empty), the ESL flag as written, the byte size.
+        IReadOnlyList<string> masters; int recordCount; bool eslBack; long bytes;
+        ISkyrimModGetter? back = null;
+        try
+        {
+            back = SkyrimMod.CreateFromBinaryOverlay(outPath, SkyrimRelease.SkyrimSE);
+            masters = back.ModHeader.MasterReferences.Select(m => m.Master.FileName.ToString()).ToList();
+            recordCount = back.EnumerateMajorRecords().Count();
+            eslBack = back.IsSmallMaster;
+            bytes = new FileInfo(outPath).Length;
+        }
+        catch (Exception ex)
+            { return CreatePluginOutcome.Fail($"plugin written but could not be re-opened to confirm it: {ex.Message}"); }
+        finally { (back as IDisposable)?.Dispose(); }
+
+        if (recordCount != 0)
+            return CreatePluginOutcome.Fail(
+                $"internal error: the created plugin carries {recordCount} record(s), expected 0 (a header-only plugin) — refusing to report success on a wrong artifact (Q3).");
+        if (eslBack != esl)
+            return CreatePluginOutcome.Fail(
+                $"internal error: the created plugin's light-master (ESL) flag is {eslBack}, expected {esl} — refusing to report success on a wrong artifact (Q3).");
+
+        return new CreatePluginOutcome(true, null, outPath, fileName, esl, masters, recordCount, bytes);
     }
 
     /// <summary>

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -619,7 +619,7 @@ public static class WritePatchBuilder
     /// Create an EMPTY, HEADER-ONLY plugin — a valid <c>TES4</c> header and ZERO records (HCBR-2026-06-19-02). The
     /// whole point is a plugin that exists purely so its BASENAME resolves: the artifact SKSE configs that bind by
     /// plugin name need (a CraftingCategories-style trigger that must ship <c>Foo.esp</c> so <c>Foo.json</c> loads), a
-    /// placeholder ESL for FormID reservation, a deliberate empty master, a dummy plugin to satisfy a dependency check.
+    /// placeholder ESL for FormID reservation, a dummy plugin another mod can list as a master to satisfy a dependency.
     /// It is the clean primitive behind those: where the record-centric create/forward paths can only materialise a
     /// plugin by giving it a record (forcing an unwanted conflict-tree participant — the report's redundant backpack
     /// override), this authors NO record at all.
@@ -676,6 +676,8 @@ public static class WritePatchBuilder
 
         if (confirmFail is null && recordCount != 0)
             confirmFail = $"internal error: the created plugin carries {recordCount} record(s), expected 0 (a header-only plugin) — refusing to report success on a wrong artifact (Q3).";
+        if (confirmFail is null && masters.Count != 0)
+            confirmFail = $"internal error: the created plugin carries {masters.Count} master(s) ({string.Join(", ", masters)}), expected 0 (a header-only plugin references nothing) — refusing to report success on a wrong artifact (Q3).";
         if (confirmFail is null && eslBack != esl)
             confirmFail = $"internal error: the created plugin's light-master (ESL) flag is {eslBack}, expected {esl} — refusing to report success on a wrong artifact (Q3).";
 

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -659,7 +659,9 @@ public static class WritePatchBuilder
 
         // Re-open + CONFIRM the artifact (Q3 — never report success on an unverified file): zero records, the master
         // header (empty), the ESL flag as written, the byte size.
-        IReadOnlyList<string> masters; int recordCount; bool eslBack; long bytes;
+        IReadOnlyList<string> masters = Array.Empty<string>();
+        int recordCount = -1; bool eslBack = false; long bytes = 0;
+        string? confirmFail = null;
         ISkyrimModGetter? back = null;
         try
         {
@@ -669,16 +671,22 @@ public static class WritePatchBuilder
             eslBack = back.IsSmallMaster;
             bytes = new FileInfo(outPath).Length;
         }
-        catch (Exception ex)
-            { return CreatePluginOutcome.Fail($"plugin written but could not be re-opened to confirm it: {ex.Message}"); }
-        finally { (back as IDisposable)?.Dispose(); }
+        catch (Exception ex) { confirmFail = $"plugin written but could not be re-opened to confirm it: {ex.Message}"; }
+        finally { (back as IDisposable)?.Dispose(); }   // dispose the overlay BEFORE any delete below (it maps the file)
 
-        if (recordCount != 0)
-            return CreatePluginOutcome.Fail(
-                $"internal error: the created plugin carries {recordCount} record(s), expected 0 (a header-only plugin) — refusing to report success on a wrong artifact (Q3).");
-        if (eslBack != esl)
-            return CreatePluginOutcome.Fail(
-                $"internal error: the created plugin's light-master (ESL) flag is {eslBack}, expected {esl} — refusing to report success on a wrong artifact (Q3).");
+        if (confirmFail is null && recordCount != 0)
+            confirmFail = $"internal error: the created plugin carries {recordCount} record(s), expected 0 (a header-only plugin) — refusing to report success on a wrong artifact (Q3).";
+        if (confirmFail is null && eslBack != esl)
+            confirmFail = $"internal error: the created plugin's light-master (ESL) flag is {eslBack}, expected {esl} — refusing to report success on a wrong artifact (Q3).";
+
+        if (confirmFail is not null)
+        {
+            // The file we just wrote is wrong or unverifiable — remove it so a refusal leaves NO bad artifact behind
+            // (Q3; the service's folder cleanup then finds an empty folder and removes that too). Safe here: create_plugin
+            // always writes a FRESH file in a fresh folder (no extend), so there is never a prior file to lose.
+            try { File.Delete(outPath); } catch { /* best-effort; the loud refusal stands regardless */ }
+            return CreatePluginOutcome.Fail(confirmFail);
+        }
 
         return new CreatePluginOutcome(true, null, outPath, fileName, esl, masters, recordCount, bytes);
     }

--- a/src/housecarl-generator/CreatePluginGuardProbe.cs
+++ b/src/housecarl-generator/CreatePluginGuardProbe.cs
@@ -1,0 +1,179 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SELF-CONTAINED CI REGRESSION GUARD for CREATE-PLUGIN (HCBR-2026-06-19-02 — "no way to author a placeholder /
+/// header-only trigger plugin"). houseCARL's write model is record-centric: a plugin existed only as a side effect of
+/// containing a record, so a basename-bound SKSE config trigger (CraftingCategories-style) had to be materialised WITH
+/// a junk filler record. housecarl_create_plugin authors a valid TES4 header with ZERO records — the clean primitive.
+///
+/// Two layers, both required for a GREEN to mean "the contract holds":
+///   CORE arms (WritePatchBuilder.CreatePlugin straight to a temp path — no MO2, no Skyrim.esm):
+///     HEADER-ONLY-ESP — esl=false → 0 records, 0 masters (Aaron 2026-06-23: an empty plugin carries none), NOT
+///                       ESL-flagged, first 4 bytes "TES4", author/description survive the write+reopen.
+///     HEADER-ONLY-ESL — esl=true → the light-master (IsSmallMaster) flag survives reopen; still 0 records / 0 masters.
+///   SERVICE arms (the REAL LoadOrderService.CreatePlugin over a synthetic MO2 instance — the bulk-create-guard synth):
+///     WIRE-CREATE    — writes the EXACT-named plugin ('HcCpTrigger.esp', NOT auto-suffixed) in a 'houseCARL - …' folder.
+///     REJ-FOLDER     — re-creating the SAME name refuses loud ('already exists') with no second folder (no auto-suffix:
+///                      the basename is load-bearing for the trigger, so houseCARL refuses rather than rename).
+///     REJ-NAME-ACTIVE— naming a plugin already ACTIVE in the order refuses loud ('already active'), no folder (a second
+///                      plugin of that basename would shadow it — MO2 picks one by mod order).
+///     ESL-WIRE       — esl=true through the service lands a light-flagged plugin on disk.
+///
+/// Run: dotnet run --project src/housecarl-generator -- create-plugin-guard
+/// </summary>
+public static class CreatePluginGuardProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("create-plugin-guard — author an empty, header-only (trigger) plugin (HCBR-2026-06-19-02)");
+        Console.WriteLine();
+
+        int failures = 0;
+        void Check(string label, bool ok, string? detail = null)
+        {
+            Console.WriteLine($"  {(ok ? "PASS" : "FAIL")}  {label}{(ok || detail is null ? "" : $"\n        -> {detail}")}");
+            if (!ok) failures++;
+        }
+
+        var root = Path.Combine(Path.GetTempPath(), "hc-create-plugin-guard-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            // ===== CORE arms (self-contained: WritePatchBuilder.CreatePlugin to a temp path, no MO2) =====
+
+            // HEADER-ONLY-ESP: a full (non-ESL) header-only plugin round-trips clean.
+            {
+                string p = Path.Combine(root, "HcCpEsp.esp");
+                var o = WritePatchBuilder.CreatePlugin(p, esl: false, author: "houseCARL", description: "trigger plugin");
+                bool tes4 = File.Exists(p) && IsTes4(p);
+                var (recs, masters, eslBack, author, desc) = o.Success ? Reopen(p) : (-1, new List<string>(), (bool?)null, null, null);
+                Check("HEADER-ONLY-ESP: 0 records, 0 masters, NOT ESL, sig TES4, author/description round-trip",
+                    o.Success && o.RecordCount == 0 && o.Masters.Count == 0 && !o.Esl && tes4
+                        && recs == 0 && masters.Count == 0 && eslBack == false && author == "houseCARL" && desc == "trigger plugin",
+                    $"success={o.Success} recs={recs} masters=[{string.Join(",", masters)}] esl={eslBack} tes4={tes4} author='{author}' desc='{desc}' err=[{Trim(o.Error)}]");
+            }
+
+            // HEADER-ONLY-ESL: esl=true sets the light-master flag (survives reopen); still empty.
+            {
+                string p = Path.Combine(root, "HcCpEslCore.esp");
+                var o = WritePatchBuilder.CreatePlugin(p, esl: true, author: null, description: null);
+                var (recs, masters, eslBack, _, _) = o.Success ? Reopen(p) : (-1, new List<string>(), (bool?)null, null, null);
+                Check("HEADER-ONLY-ESL: esl=true sets the light-master flag (survives reopen); still 0 records / 0 masters",
+                    o.Success && o.Esl && o.RecordCount == 0 && eslBack == true && recs == 0 && masters.Count == 0,
+                    $"success={o.Success} esl={eslBack} recs={recs} masters=[{string.Join(",", masters)}] err=[{Trim(o.Error)}]");
+            }
+
+            // ===== SERVICE arms (synthetic MO2 instance → the REAL LoadOrderService.CreatePlugin) =====
+            string instance = Path.Combine(root, "instance");
+            string profiles = Path.Combine(instance, "profiles", "Default");
+            string mods = Path.Combine(instance, "mods");
+            Directory.CreateDirectory(profiles); Directory.CreateDirectory(mods);
+            Directory.CreateDirectory(Path.Combine(root, "game", "Data"));
+            File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+                "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+                + Path.Combine(root, "game").Replace(@"\", @"\\") + ")\r\n");
+
+            var mKey = new ModKey("HcCpMaster", ModType.Master);
+            var modDir = Path.Combine(mods, "MasterMod");
+            Directory.CreateDirectory(modDir);
+            {
+                var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
+                var kw = m.Keywords.AddNew(); kw.EditorID = "HcCpKw";   // one record so the master is a real plugin in the order
+                m.BeginWrite.ToPath(Path.Combine(modDir, mKey.FileName.String)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            }
+            File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + mKey.FileName + "\r\n");
+            File.WriteAllText(Path.Combine(profiles, "plugins.txt"), "*" + mKey.FileName + "\r\n");
+            File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+MasterMod\r\n");
+
+            var store = new UserConfigStore(Path.Combine(root, "houseCARL.user.json"));
+            using var svc = LoadOrderService.WithInstance(instance, 0, store);
+            svc.Stats();   // warm the lazy index once
+
+            // WIRE-CREATE + EXACT-NAME: the service writes the EXACT-named header-only plugin in a houseCARL folder.
+            {
+                var o = svc.CreatePlugin("HcCpTrigger");
+                bool exactName = o.Success && Path.GetFileName(o.OutputPath) == "HcCpTrigger.esp";
+                bool folderOk = o.Success && Path.GetFileName(Path.GetDirectoryName(o.OutputPath)!) == "houseCARL - HcCpTrigger";
+                bool onDisk = o.Success && File.Exists(o.OutputPath) && IsTes4(o.OutputPath);
+                Check("WIRE-CREATE: service writes the EXACT-named header-only plugin in a houseCARL folder (no auto-suffix)",
+                    o.Success && exactName && folderOk && onDisk && o.RecordCount == 0,
+                    $"success={o.Success} file={(o.Success ? Path.GetFileName(o.OutputPath) : "")} exactName={exactName} folderOk={folderOk} onDisk={onDisk} err=[{Trim(o.Error)}]");
+            }
+
+            // REJ-FOLDER: a second create of the SAME name refuses loud (no auto-suffix), no second folder.
+            {
+                var o = svc.CreatePlugin("HcCpTrigger");
+                bool refused = !o.Success && o.Error is not null && o.Error.Contains("already exists", StringComparison.OrdinalIgnoreCase);
+                int folderCount = Directory.EnumerateDirectories(mods, "houseCARL - HcCpTrigger*").Count();
+                Check("REJ-FOLDER: re-creating the same name refuses loud (no auto-suffix); exactly one folder remains",
+                    refused && folderCount == 1, $"refused={refused} folderCount={folderCount} err=[{Trim(o.Error)}]");
+            }
+
+            // REJ-NAME-ACTIVE: naming a plugin already ACTIVE in the order refuses loud (would shadow it), no folder.
+            {
+                var o = svc.CreatePlugin("HcCpMaster");   // the synthesized master, active in the order (as HcCpMaster.esm)
+                bool refused = !o.Success && o.Error is not null && o.Error.Contains("already active", StringComparison.OrdinalIgnoreCase);
+                bool noFolder = !Directory.EnumerateDirectories(mods, "houseCARL - HcCpMaster*").Any();
+                Check("REJ-NAME-ACTIVE: naming an already-active plugin refuses loud (no shadow), no folder",
+                    refused && noFolder, $"refused={refused} noFolder={noFolder} err=[{Trim(o.Error)}]");
+            }
+
+            // ESL-WIRE: esl=true through the service → the on-disk plugin is light-flagged.
+            {
+                var o = svc.CreatePlugin("HcCpEslWire", esl: true);
+                var (_, _, eslBack, _, _) = o.Success ? Reopen(o.OutputPath) : (-1, new List<string>(), (bool?)null, null, null);
+                Check("ESL-WIRE: esl=true through the service lands a light-flagged plugin on disk",
+                    o.Success && o.Esl && eslBack == true, $"success={o.Success} esl={eslBack} err=[{Trim(o.Error)}]");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"error: guard infrastructure: {ex.GetType().Name}: {(ex.InnerException ?? ex).Message}");
+            failures++;
+        }
+        finally { try { Directory.Delete(root, recursive: true); } catch { /* best-effort */ } }
+
+        Console.WriteLine();
+        Console.WriteLine(failures == 0 ? "create-plugin-guard: ALL PASS" : $"create-plugin-guard: {failures} FAILURE(S)");
+        return failures == 0 ? 0 : 1;
+    }
+
+    // ---- helpers ----
+
+    /// <summary>First 4 bytes == ASCII "TES4" (the mod header signature — a valid plugin always opens with it).</summary>
+    static bool IsTes4(string path)
+    {
+        try
+        {
+            using var fs = File.OpenRead(path);
+            Span<byte> b = stackalloc byte[4];
+            return fs.Read(b) == 4 && b[0] == (byte)'T' && b[1] == (byte)'E' && b[2] == (byte)'S' && b[3] == (byte)'4';
+        }
+        catch { return false; }
+    }
+
+    /// <summary>Re-open the written plugin as a binary overlay and read back what the contract promises:
+    /// (record count, master filenames, IsSmallMaster, Author, Description).</summary>
+    static (int recs, List<string> masters, bool? esl, string? author, string? desc) Reopen(string path)
+    {
+        ISkyrimModGetter? back = null;
+        try
+        {
+            back = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE);
+            return (back.EnumerateMajorRecords().Count(),
+                back.ModHeader.MasterReferences.Select(m => m.Master.FileName.ToString()).ToList(),
+                back.IsSmallMaster, back.ModHeader.Author, back.ModHeader.Description);
+        }
+        catch { return (-1, new List<string>(), null, null, null); }
+        finally { (back as IDisposable)?.Dispose(); }
+    }
+
+    static string Trim(string? s) => s is null ? "" : (s.Length <= 160 ? s.Replace("\n", " ") : s[..160].Replace("\n", " ") + "…");
+}

--- a/src/housecarl-generator/CreatePluginGuardProbe.cs
+++ b/src/housecarl-generator/CreatePluginGuardProbe.cs
@@ -132,6 +132,18 @@ public static class CreatePluginGuardProbe
                 Check("ESL-WIRE: esl=true through the service lands a light-flagged plugin on disk",
                     o.Success && o.Esl && eslBack == true, $"success={o.Success} esl={eslBack} err=[{Trim(o.Error)}]");
             }
+
+            // COLD-START (PR #105 review #1): create_plugin as the FIRST op on a fresh service (no prior Stats()/read
+            // to warm the lazy index) must derive ModsDir itself and SUCCEED — not misreport "ModsDir '' does not
+            // exist". A separate, un-warmed service over the same instance exercises the cold path the warmed `svc`
+            // above masks. RED before the fix (derive paths before the _modsDir check), GREEN after.
+            {
+                using var cold = LoadOrderService.WithInstance(instance, 0, store);
+                var o = cold.CreatePlugin("HcCpCold");
+                Check("COLD-START: create_plugin as the first op on a fresh service succeeds (derives ModsDir; no false config error)",
+                    o.Success && Path.GetFileName(o.OutputPath) == "HcCpCold.esp",
+                    $"success={o.Success} file={(o.Success ? Path.GetFileName(o.OutputPath) : "")} err=[{Trim(o.Error)}]");
+            }
         }
         catch (Exception ex)
         {

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -47,6 +47,12 @@ if (args.Length > 0 && args[0] == "floi-fields-guard") return FloiFieldsProbe.Ru
 // (forward a master) + already-winner + multi + into= work, originals untouched, and the 4 Q3 rejects.
 if (args.Length > 0 && args[0] == "forward-from-plugin-guard") return ForwardFromPluginProbe.RunGuard(args[1..]);
 
+// Author an EMPTY, header-only (trigger) plugin (HCBR-2026-06-19-02): SELF-CONTAINED CI regression guard — core arms
+// write a header-only plugin straight to temp (0 records, 0 masters, ESL flag round-trip, sig TES4, author/desc), and
+// service arms drive the REAL LoadOrderService.CreatePlugin over a synthetic MO2 instance (exact-name no-suffix +
+// the two collision refusals: an already-active basename, and an existing houseCARL folder).
+if (args.Length > 0 && args[0] == "create-plugin-guard") return CreatePluginGuardProbe.RunGuard(args[1..]);
+
 // Field-value query predicate (cross_plugin_query where=): SELF-CONTAINED CI regression guard — synthesizes records
 // with known field values, asserts the evaluator's matched set == a brute-force reference + the Q3 teeth.
 if (args.Length > 0 && args[0] == "value-predicate-guard") return ValuePredicateProbe.RunGuard(args[1..]);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1167,12 +1167,16 @@ public sealed class LoadOrderService : IDisposable
 
         lock (_writeGate)                                                 // hunt F2: one write at a time, resolve→commit
         {
+            // Touch Resolver FIRST: in instance mode _modsDir is derived LAZILY (EnsurePathsDerived runs inside the
+            // Resolver getter), so a cold first-call (create_plugin before any read warmed the index) would otherwise
+            // see _modsDir="" and misreport "ModsDir '' does not exist" (a Q3-adjacent wrong reason). Capturing the view
+            // here both derives the paths AND is what the collision check below needs.
+            var view = Resolver.Capture();
             if (!Directory.Exists(_modsDir))
                 return WritePatchBuilder.CreatePluginOutcome.Fail($"cannot write: ModsDir '{_modsDir}' does not exist. Check HouseCarl:ModsDir.");
 
             // COLLISION (Q3): the basename is load-bearing for a trigger, so NEVER auto-suffix — refuse loud instead.
             // (a) an active plugin already owns this basename — a second one would shadow it (MO2 picks one by mod order).
-            var view = Resolver.Capture();
             foreach (var ext in PluginExts)                              // .esp / .esm / .esl
                 if (view.ContainsPlugin(stem + ext))
                     return WritePatchBuilder.CreatePluginOutcome.Fail(

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1145,6 +1145,56 @@ public sealed class LoadOrderService : IDisposable
         }
     }
 
+    /// <summary>Create an EMPTY, HEADER-ONLY plugin (housecarl_create_plugin) — a valid TES4 header with ZERO records,
+    /// no masters, optionally ESL-flagged, named EXACTLY <paramref name="pluginName"/>. The clean primitive for "I need
+    /// plugin <c>Foo.esp</c> to exist" (a basename-bound SKSE config trigger, a placeholder ESL, a dummy master) — it
+    /// authors no record, so it adds no conflict footprint (HCBR-2026-06-19-02). UNLIKE the patch-write paths, the name
+    /// is used VERBATIM — never auto-suffixed — because a trigger plugin's whole job is that its basename matches the
+    /// config bound to it; so a name collision REFUSES loud (Q3) rather than rename or overwrite: (a) a plugin of that
+    /// basename already active in the order (creating another would shadow it), or (b) a houseCARL mod folder of that
+    /// name already on disk. The core <see cref="WritePatchBuilder.CreatePlugin"/> builds + serializes + re-reads to
+    /// confirm; a refused create that just made the output folder leaves no orphan (hunt F4).</summary>
+    public WritePatchBuilder.CreatePluginOutcome CreatePlugin(string pluginName, bool esl = false, string? author = null, string? description = null)
+    {
+        if (string.IsNullOrWhiteSpace(pluginName))
+            return WritePatchBuilder.CreatePluginOutcome.Fail(
+                "plugin_name is required — a header-only plugin has no record to derive a name from, so name it explicitly (e.g. 'Authoria - CraftingCategories').");
+
+        var stem = PatchStem(pluginName);
+        if (string.IsNullOrWhiteSpace(stem))
+            return WritePatchBuilder.CreatePluginOutcome.Fail(
+                $"plugin_name '{pluginName}' has no usable name once path parts and the plugin extension are stripped — give a plain name like 'MyTrigger'.");
+
+        lock (_writeGate)                                                 // hunt F2: one write at a time, resolve→commit
+        {
+            if (!Directory.Exists(_modsDir))
+                return WritePatchBuilder.CreatePluginOutcome.Fail($"cannot write: ModsDir '{_modsDir}' does not exist. Check HouseCarl:ModsDir.");
+
+            // COLLISION (Q3): the basename is load-bearing for a trigger, so NEVER auto-suffix — refuse loud instead.
+            // (a) an active plugin already owns this basename — a second one would shadow it (MO2 picks one by mod order).
+            var view = Resolver.Capture();
+            foreach (var ext in PluginExts)                              // .esp / .esm / .esl
+                if (view.ContainsPlugin(stem + ext))
+                    return WritePatchBuilder.CreatePluginOutcome.Fail(
+                        $"a plugin named '{stem + ext}' is already active in your load order — a header-only trigger needs a UNIQUE basename (a second one would shadow it, MO2 picking the winner by mod order). Choose a different name.");
+            // (b) a houseCARL mod folder of this exact name already exists — don't overwrite (could clobber a real patch
+            //     sharing the name) and don't auto-rename (would break the basename trigger): refuse and point at it.
+            var folder = Path.Combine(_modsDir, ModFolderName(stem));
+            if (Directory.Exists(folder))
+                return WritePatchBuilder.CreatePluginOutcome.Fail(
+                    $"a houseCARL output folder '{ModFolderName(stem)}' already exists — houseCARL won't auto-rename a header-only plugin (its exact basename is what makes the trigger resolve). Remove that folder in MO2, or choose a different name.");
+
+            Directory.CreateDirectory(folder);
+            var plugin = stem + ".esp";
+            WriteOwnerMeta(folder, plugin);
+            var outPath = Path.Combine(folder, plugin);
+
+            var outcome = WritePatchBuilder.CreatePlugin(outPath, esl, author, description);
+            if (!outcome.Success) RemoveFolderCreatedThisCall(outPath);   // hunt F4: a refused create leaves no orphan
+            return outcome;
+        }
+    }
+
     /// <summary>Create a BRAND-NEW record (housecarl_create_record) — the net-new authoring capability, the sibling of
     /// <see cref="ApplyEdits"/>. Resolves <paramref name="recordType"/> (catalog name or 4-char signature) to ONE concrete
     /// catalog name (unknown/ambiguous → Q3), maps the field <paramref name="operations"/> to core <see cref="WriteRequest"/>s

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -248,6 +248,37 @@ public static class WriteTools
         return RenderForward(svc.ForwardRecords(formids, from_plugin, patch_name, into, full_readback), max_chars);
     });
 
+    [McpServerTool(Name = "housecarl_create_plugin", Title = "Create an empty header-only (trigger) plugin"),
+     Description(
+         "Create an EMPTY, HEADER-ONLY plugin — a valid TES4 header with ZERO records and no masters, in a NEW mod " +
+         "folder (originals untouched). Its only job is to EXIST so its basename resolves: the artifact that SKSE configs " +
+         "binding by plugin basename need (e.g. a CraftingCategories-style trigger that must ship 'Foo.esp' so 'Foo.json' " +
+         "loads), a placeholder ESL for FormID reservation, a deliberate empty master, or any 'I just need plugin Foo to " +
+         "be present' case. UNLIKE housecarl_create_record, it authors NO record — so it adds no conflict-tree footprint " +
+         "(no filler override needed to make the plugin non-empty). plugin_name is used EXACTLY (the basename is " +
+         "load-bearing — houseCARL will NOT auto-suffix it): if a plugin of that name is already active in the load order, " +
+         "or a houseCARL folder of that name already exists, it REFUSES loud rather than rename or overwrite (Q3). Pass " +
+         "esl=true for the lightest trigger (a header-only light plugin consumes no consequential load-order slot; with " +
+         "zero records the ESL FormID-range rule is trivially satisfied). author/description are optional TES4 header " +
+         "text. Returns the plugin path + mod folder — enable + sort it in MO2 to use it. To author actual records, use " +
+         "housecarl_create_record / housecarl_bulk_create instead.")]
+    public static string CreatePlugin(
+        LoadOrderService svc,
+        [Description("The EXACT plugin name (with or without a trailing .esp/.esm/.esl; e.g. 'Authoria - CraftingCategories'). Used VERBATIM as the basename — houseCARL will not auto-suffix it, because a trigger plugin's whole job is that its basename matches the config bound to it. The written file is '<name>.esp'.")]
+            string plugin_name,
+        [Description("When true, flag the plugin as a light master (ESL) — the lightest possible trigger: a header-only ESL consumes no consequential load-order slot. Default false (a normal full plugin).")]
+            bool esl = false,
+        [Description("Optional. Author text for the TES4 header (the CNAM field). Purely informational.")]
+            string? author = null,
+        [Description("Optional. Description text for the TES4 header (the SNAM field). Purely informational.")]
+            string? description = null) => Guard.Tool("housecarl_create_plugin", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        if (string.IsNullOrWhiteSpace(plugin_name))
+            return "error: plugin_name is empty. Name the plugin to create (a header-only plugin has no record to derive a name from).";
+        return RenderCreatePlugin(svc.CreatePlugin(plugin_name, esl, author, description));
+    });
+
     /// <summary>Compact, parseable confirmation (rulebook: short mutation confirmation + the IDs needed for follow-up).
     /// On refusal, the full reason (every malformed/rejected op) so the caller can fix and retry.</summary>
     static string Render(WritePatchBuilder.PatchOutcome o, int maxChars = 0)
@@ -365,6 +396,25 @@ public static class WriteTools
         }
         if (o.ReadBack is { } rb) AppendFullReadback(sb, rb, maxChars);
         sb.Append("to forward more into THIS patch (incl. from a different source plugin), pass into=\"").Append(file).Append("\".");
+        return sb.ToString();
+    }
+
+    /// <summary>Confirmation for housecarl_create_plugin: the empty plugin's path + mod folder, its ESL flag, master
+    /// header (none), record count (0) and byte size, plus the MO2 enable reminder and what the trigger does. On
+    /// refusal, the named reason (Q3) so the caller can fix and retry.</summary>
+    static string RenderCreatePlugin(WritePatchBuilder.CreatePluginOutcome o)
+    {
+        if (!o.Success) return "error: " + o.Error;
+        var file = Path.GetFileName(o.OutputPath);
+        var modFolder = Path.GetFileName(Path.GetDirectoryName(o.OutputPath) ?? "");
+        var sb = new StringBuilder();
+        sb.Append("wrote ").Append(file).Append(o.Esl ? " (header-only, ESL-flagged; " : " (header-only; ")
+          .Append(o.Bytes).Append(" bytes, ").Append(o.RecordCount).Append(o.RecordCount == 1 ? " record)\n" : " records)\n");
+        sb.Append("mod folder: ").Append(modFolder).Append("  — enable + sort it in MO2 to use it\n");
+        sb.Append("masters: ").Append(o.Masters.Count == 0 ? "(none)" : string.Join(", ", o.Masters)).Append('\n');
+        sb.Append("this is a trigger/placeholder plugin: it carries no records, so it changes nothing in game by itself — ")
+          .Append("its only job is to make the basename '").Append(Path.GetFileNameWithoutExtension(file))
+          .Append("' present in the load order (so a basename-bound SKSE config resolves, a FormID range is reserved, etc.).");
         return sb.ToString();
     }
 

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -253,8 +253,8 @@ public static class WriteTools
          "Create an EMPTY, HEADER-ONLY plugin — a valid TES4 header with ZERO records and no masters, in a NEW mod " +
          "folder (originals untouched). Its only job is to EXIST so its basename resolves: the artifact that SKSE configs " +
          "binding by plugin basename need (e.g. a CraftingCategories-style trigger that must ship 'Foo.esp' so 'Foo.json' " +
-         "loads), a placeholder ESL for FormID reservation, a deliberate empty master, or any 'I just need plugin Foo to " +
-         "be present' case. UNLIKE housecarl_create_record, it authors NO record — so it adds no conflict-tree footprint " +
+         "loads), a placeholder ESL for FormID reservation, a dummy plugin for another mod to list as a master, or any " +
+         "'I just need plugin Foo to be present' case. UNLIKE housecarl_create_record, it authors NO record — so it adds no conflict-tree footprint " +
          "(no filler override needed to make the plugin non-empty). plugin_name is used EXACTLY (the basename is " +
          "load-bearing — houseCARL will NOT auto-suffix it): if a plugin of that name is already active in the load order, " +
          "or a houseCARL folder of that name already exists, it REFUSES loud rather than rename or overwrite (Q3). Pass " +


### PR DESCRIPTION
## What

`housecarl_create_plugin` — emit a valid `TES4` header with **zero records and no masters**, in a new MO2 mod folder (originals untouched). The clean primitive for *"I need plugin `Foo.esp` to exist"*: a basename-bound SKSE config trigger (CraftingCategories-style needs `Foo.esp` so `Foo.json` loads), a placeholder ESL for FormID reservation, a deliberate empty master, a dummy plugin to satisfy a dependency check.

Closes the gap in **HCBR-2026-06-19-02**: houseCARL's write model was record-centric, so a trigger plugin could only be materialised by giving it a record — forcing an unwanted conflict-tree participant (the report's redundant backpack override, hand-slimmed to a 79-byte stub in xEdit). This authors none.

## Design

- **New tool**, not a `header_only:true` flag on `create_record` — that tool is built around a record type + editorid + field ops; a "ignore all of that" mode is a footgun. (The gap note's primary suggestion.)
- **Generic by construction**: a `SkyrimMod` with no records added *is* a header-only plugin — no per-type anything.
- **Zero masters** (Aaron, 2026-06-23): an empty plugin references nothing, so it carries no masters — exactly what the CK stamps on a truly empty plugin, honouring the same *"match the CK"* principle the baseline-master convention (2026-06-02) is built on. Implemented by passing an **empty known-master set** to the one `WriteEngine.WritePatch` chokepoint (its baseline force-include filters to masters present in the set → none). Crash-atomic staged write + FormID floor still apply.
- **Exact name, never auto-suffixed**: a trigger's basename is load-bearing (the config binds to it), so unlike the patch-write paths the name is used verbatim. A collision **refuses loud (Q3)** rather than rename or overwrite — an already-active basename (a second would shadow it, MO2 picking one by mod order) or an existing houseCARL folder of that name. A refused create leaves no orphan folder (hunt F4).
- **Q3 confirm**: the written file is re-read to confirm 0 records + the ESL flag before reporting success.
- `esl=true` flags a light master (lightest trigger; with zero records the ESL FormID-range rule is trivially met). `author`/`description` are optional TES4 header text.

## Test plan

- **New `create-plugin-guard`** (self-contained, no Skyrim.esm) — wired into CI. 6 arms, all PASS:
  - core: header-only ESP (0 records, 0 masters, not ESL, sig `TES4`, author/desc round-trip), header-only ESL (light flag survives reopen).
  - service (real `LoadOrderService.CreatePlugin` over a synthetic MO2 instance): exact name no-suffix, reject-folder-exists, reject-name-active, esl-through-the-wire.
- **No regressions**: re-ran the 5 closest write-path guards — `forward-from-plugin`, `formid-floor`, `bulk-create`, `write-mutex`, `upsert` — all green.
- Build clean (Release, 0 errors).

## Notes

- houseCARL's 24th tool. No CHANGELOG/README change — release-prep concern (matches the forward_record PR scope); reaches users on the next repackage (PATCH bump).
- Documented rough edge: output is always `<name>.esp` with `esl` as the lightness lever (functionally equivalent to a `.esl` extension). `"Foo.esl"` → `Foo.esp` with esl off unless `esl=true` — visible in the output, not silent. Easy follow-up to make `.esl`-in-name imply `esl=true` if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)