### PR TITLE
feat: resolve a MagicEffect's carriers + magnitudes (housecarl_effect_chain)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,12 @@ jobs:
       - name: Probe — field-value query predicate (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- value-predicate-guard
 
+      # Self-contained (synthesizes MGEFs + the five effect-bearing records on disk — no external files), runs fully
+      # here: a regression guard for the effect-chain resolver (housecarl_effect_chain) — Resolve's carrier rows ==
+      # a brute-force oracle, multi-entry + null-base + types-narrow + the Q3 gate (non-MGEF / absent → loud, unused → clean zero).
+      - name: Probe — effect-chain resolver (self-contained regression guard)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- effect-chain-guard
+
       # Self-contained (synthesizes a master + two overrides on disk — no external files), runs fully here: a regression
       # guard for the winner-vs-source display fix (cross_plugin_query plugins= scope) — RecordsIn pairs each body with
       # its OWN source plugin (the body the scan filtered), the winner stream with the winner. Locks wishlist #8.

--- a/src/housecarl-core/EffectChain.cs
+++ b/src/housecarl-core/EffectChain.cs
@@ -1,0 +1,169 @@
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+
+namespace HousecarlCore;
+
+/// <summary>
+/// The effect-chain resolver (housecarl_effect_chain — gap 2026-06-08): given a MagicEffect (MGEF), find every
+/// record that APPLIES it and the magnitude/area/duration of the matching effect entry. It collapses the hand-trace
+/// "cross_plugin_query references=&lt;MGEF&gt; type=SPEL → read each hit's Effects[].Data → keep the entry whose
+/// BaseEffect is the MGEF, then repeat for ENCH/ALCH/SCRL/INGR" into one call. The inverse-by-magnitude of
+/// references=: that says WHICH carriers reference the effect; this says which entry, and at what strength.
+///
+/// Two seams, mirroring the where= predicate (<see cref="FieldPredicate"/> ← <c>ValuePredicateProbe</c>):
+///   • <see cref="Match"/> — PURE over an in-hand body (no resolver, no I/O), so the regression guard tests the real
+///     matcher directly against a known-magnitude fixture.
+///   • <see cref="Resolve"/> — the end-to-end service path (Q3 typed-match gate → winner-body scan → assemble),
+///     drivable from a <see cref="LoadOrderResolver"/> built over synthetic plugins, so the guard covers the gate too.
+///
+/// Scope is the five records the library models with an <c>Effects</c> list — Spell/ObjectEffect/Ingestible/
+/// Scroll/Ingredient (SPEL/ENCH/ALCH/SCRL/INGR). That is EVERY effect-bearing record by construction, not a chosen
+/// subset (cornerstone §3): the element type is the SAME <see cref="IEffectGetter"/> across all five, so once
+/// <see cref="EffectsOf"/> hands back the list, extraction is uniform and the only per-type code is the switch that
+/// reaches the list.
+/// </summary>
+public static class EffectChain
+{
+    /// <summary>One matching effect entry on a carrier: its index in the carrier's Effects list and the list size
+    /// (so a caller can render "[effect i/n]"), and the magnitude/area/duration of THAT entry — the trace's payload.</summary>
+    public readonly record struct EffectHit(int Index, int Count, float Magnitude, int Area, int Duration);
+
+    /// <summary>The effect-bearing getter Types — the scan scope. Every Skyrim record the library models with an
+    /// Effects list; a query type-narrow is validated against this exact set (a non-member is refused, never a
+    /// silent empty scan). Listed once here so both the scan default and the narrow-validation share one source.</summary>
+    public static readonly IReadOnlyList<Type> CarrierTypes = new[]
+    {
+        typeof(ISpellGetter), typeof(IObjectEffectGetter), typeof(IIngestibleGetter),
+        typeof(IScrollGetter), typeof(IIngredientGetter),
+    };
+
+    /// <summary>The carrier's Effects list if <paramref name="body"/> is one of the five effect-bearing records, else
+    /// null. An explicit switch over the known set — NOT reflection: type-safe, and a sixth effect-bearing record in a
+    /// future library version is then a deliberate, surfaced boundary (the guard's MATCH-ALL arm would catch the
+    /// new type's absence) rather than a silent reflective guess that might mis-read an unrelated "Effects" member.</summary>
+    public static IReadOnlyList<IEffectGetter>? EffectsOf(IMajorRecordGetter body) => body switch
+    {
+        ISpellGetter s => s.Effects,
+        IObjectEffectGetter e => e.Effects,
+        IIngestibleGetter i => i.Effects,
+        IScrollGetter c => c.Effects,
+        IIngredientGetter g => g.Effects,
+        _ => null,
+    };
+
+    /// <summary>The effect entries of <paramref name="body"/> whose BaseEffect is <paramref name="mgef"/>, each with
+    /// its magnitude/area/duration. Empty if the body carries no effects or none reference the MGEF. An effect with an
+    /// unset BaseEffect (FormKey.Null) is skipped — never matched, never throws. Pure: the guard's ground truth.</summary>
+    public static IReadOnlyList<EffectHit> Match(IMajorRecordGetter body, FormKey mgef)
+    {
+        var effects = EffectsOf(body);
+        if (effects is null || effects.Count == 0) return Array.Empty<EffectHit>();
+        List<EffectHit>? hits = null;
+        for (int i = 0; i < effects.Count; i++)
+        {
+            var eff = effects[i];
+            if (eff.BaseEffect.FormKey != mgef) continue;   // FormKey.Null (an unset base) never equals a real MGEF
+            // Data (the EFIT magnitude/area/duration) is required in practice but modeled nullable; a matching effect
+            // with absent data is still a carrier — report it at zero (honest "no magnitude data"), never an NRE that
+            // the scan's fault-isolation would then mis-count as an unparseable record.
+            var d = eff.Data;
+            (hits ??= new List<EffectHit>()).Add(new EffectHit(i, effects.Count, d?.Magnitude ?? 0f, d?.Area ?? 0, d?.Duration ?? 0));
+        }
+        return hits ?? (IReadOnlyList<EffectHit>)Array.Empty<EffectHit>();
+    }
+
+    /// <summary>Resolve the effect chain for <paramref name="mgef"/> over the order <paramref name="resolver"/> holds,
+    /// scanning the winner bodies of <paramref name="scope"/> (a subset of <see cref="CarrierTypes"/>). One
+    /// <see cref="LoadOrderResolver.Capture"/>; per-record fault isolation (one Mutagen-unparseable body is excluded +
+    /// accounted, never aborts the call, never a silent skip); holds nothing.
+    ///
+    /// Q3 GATE FIRST (the gap's explicit ask — never a silent "0 carriers" on a bad target): the FormID must resolve
+    /// to a MagicEffect. An absent FormID or a non-MGEF (a WEAP, an NPC_, …) fails loud with the actual type named; a
+    /// VALID-but-unused MGEF returns a clean zero result (Error null) so the caller can tell "no carriers" from "bad
+    /// id" by the absence of an error and the resolved <see cref="EffectChainResult.MgefEditorId"/> in the header.</summary>
+    public static EffectChainResult Resolve(LoadOrderResolver resolver, FormKey mgef, IReadOnlyList<Type> scope, int limit)
+    {
+        var view = resolver.Capture();
+
+        // --- Q3 typed-match gate: the target must be an MGEF. Cheap — one winner-body fetch off this view. ---
+        var w = view.ResolveWinner(mgef);
+        if (w is null)
+            return EffectChainResult.Fail(
+                $"no record with FormID {mgef} in the load order. effect_chain needs a MagicEffect (MGEF) the active order defines.");
+        string mgefEid;
+        using (var session = resolver.OpenSession())
+        {
+            var mbody = view.GetRecord(session, w.Value.WinnerPlugin, mgef);
+            if (mbody is null)
+                return EffectChainResult.Fail(
+                    $"winner '{w.Value.WinnerPlugin}' did not yield {mgef} on fetch — cannot confirm it is a MagicEffect.");
+            if (mbody is not IMagicEffectGetter mr)
+                return EffectChainResult.Fail(
+                    $"{mgef} resolves to a {RecordNaming.StripOverlay(mbody.GetType().Name)}, not a MagicEffect — effect_chain " +
+                    "needs an MGEF. (To find what references an arbitrary record, use cross_plugin_query references=.)");
+            mgefEid = mr.EditorID ?? "<none>";
+        }
+
+        // --- scan the winner bodies of the scope; collect every matching effect entry. ---
+        var rows = new List<EffectChainRow>();
+        int total = 0, unscannable = 0;
+        var samples = new List<string>();
+        try
+        {
+            foreach (var (fk, _, body) in view.WinnerRecordsOfType(scope))
+            {
+                // PER-RECORD FAULT ISOLATION (twin of the cross_plugin_query scan): Match lazily parses subrecord
+                // content, so ONE record Mutagen can't parse is excluded + accounted, not an opaque whole-call abort.
+                try
+                {
+                    var hits = Match(body, mgef);
+                    if (hits.Count == 0) continue;
+                    string type = RecordNaming.StripOverlay(body.GetType().Name);
+                    string winner = view.ResolveWinner(fk)?.WinnerPlugin ?? "?";
+                    foreach (var h in hits)
+                    {
+                        total++;
+                        if (rows.Count < limit)
+                            rows.Add(new EffectChainRow(fk, type, body.EditorID, winner, h.Index, h.Count, h.Magnitude, h.Area, h.Duration));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    unscannable++;
+                    if (samples.Count < 3) samples.Add($"{fk} — {ex.GetType().Name}: {ex.Message}");
+                }
+            }
+        }
+        // Anything escaping the stream itself (a bad scope type, a build fault) gets a NAMED failure — never the
+        // MCP layer's generic "An error occurred invoking …" as the terminal diagnostic for a data failure (Q3).
+        catch (Exception ex) { return EffectChainResult.Fail($"scan aborted: {ex.GetType().Name}: {ex.Message}"); }
+
+        string? scanNote = unscannable == 0 ? null
+            : $"note: {unscannable} record instance(s) could not be scanned (Mutagen could not parse their content) and were skipped: "
+              + string.Join("; ", samples)
+              + (unscannable > samples.Count ? $"; and {unscannable - samples.Count} more" : "")
+              + ". Inspect one with read_record (per-field fault isolation applies).";
+
+        return new EffectChainResult(mgef, mgefEid, rows, total, total > rows.Count, null, scanNote);
+    }
+}
+
+/// <summary>One carrier-row of an effect chain: the carrier record, its catalog type + editorid + load-order winner,
+/// and the matching effect entry's position (<paramref name="EffectIndex"/>/<paramref name="EffectCount"/>) and
+/// magnitude/area/duration. A carrier that applies the MGEF in more than one entry yields one row per entry.</summary>
+public sealed record EffectChainRow(
+    FormKey Carrier, string Type, string? EditorId, string Winner,
+    int EffectIndex, int EffectCount, float Magnitude, int Area, int Duration);
+
+/// <summary>The result of <see cref="EffectChain.Resolve"/>: the resolved MGEF (+ its editorid, the typed-match proof
+/// for the header), the carrier rows (capped at the caller's limit), the TRUE total, the capped flag, an optional Q3
+/// scan note, and — on the Q3 gate — a recoverable <see cref="Error"/> with no rows.</summary>
+public sealed record EffectChainResult(
+    FormKey Mgef, string MgefEditorId, IReadOnlyList<EffectChainRow> Rows,
+    int Total, bool Capped, string? Error, string? ScanNote)
+{
+    public bool Success => Error is null;
+    public static EffectChainResult Fail(string error) =>
+        new(default, "", Array.Empty<EffectChainRow>(), 0, false, error, null);
+}

--- a/src/housecarl-generator/EffectChainProbe.cs
+++ b/src/housecarl-generator/EffectChainProbe.cs
@@ -40,6 +40,12 @@ namespace HousecarlGenerator;
 ///                    distinguishable from the bad-id errors above, so "0 carriers" is never a silent wrong answer.
 ///   CAP            — limit=3 returns 3 rows but reports the TRUE total (7) and Capped (the explicit-overrun teeth).
 ///
+/// COVERAGE NOTE (Q3 — name what this guard LEANS ON rather than re-proves; PR #107 review): the fixture is ONE
+/// plugin, so the winner-only scan (WinnerRecordsOfType) and the per-row winner= are exercised only at depth 0. Both
+/// are the SAME shared primitive cross_plugin_query uses, multi-plugin-proven in source-display-guard +
+/// snapshot-view-guard — so override/winner behavior is covered transitively, not re-proven here. The MATCH-ALL-FIVE
+/// arm is the canary for a sixth effect-bearing record (it would simply not be scanned).
+///
 /// Run: dotnet run --project src/housecarl-generator -- effect-chain-guard
 /// </summary>
 public static class EffectChainProbe
@@ -78,11 +84,13 @@ public static class EffectChainProbe
             var v = m.MagicEffects.AddNew(); v.EditorID = "HcEcUnused";
             tFk = t.FormKey; uFk = u.FormKey; vFk = v.FormKey;
 
-            var s1 = m.Spells.AddNew();      s1.EditorID = "HcEcSpell1";  s1.Effects.Add(Eff(t.FormKey, 11f));
-            var e1 = m.ObjectEffects.AddNew(); e1.EditorID = "HcEcEnch1"; e1.Effects.Add(Eff(t.FormKey, 22f));
-            var a1 = m.Ingestibles.AddNew(); a1.EditorID = "HcEcAlch1";   a1.Effects.Add(Eff(t.FormKey, 33f));
-            var c1 = m.Scrolls.AddNew();     c1.EditorID = "HcEcScroll1"; c1.Effects.Add(Eff(t.FormKey, 44f));
-            var i1 = m.Ingredients.AddNew(); i1.EditorID = "HcEcIngr1";   i1.Effects.Add(Eff(t.FormKey, 55f));
+            // distinct (mag, area, dur) per carrier — all three differ WITHIN a row, so an Area/Duration/Magnitude
+            // field transposition in the extraction is caught, not just a magnitude bug (PR #107 review).
+            var s1 = m.Spells.AddNew();      s1.EditorID = "HcEcSpell1";  s1.Effects.Add(Eff(t.FormKey, 11f, 1, 101));
+            var e1 = m.ObjectEffects.AddNew(); e1.EditorID = "HcEcEnch1"; e1.Effects.Add(Eff(t.FormKey, 22f, 2, 102));
+            var a1 = m.Ingestibles.AddNew(); a1.EditorID = "HcEcAlch1";   a1.Effects.Add(Eff(t.FormKey, 33f, 3, 103));
+            var c1 = m.Scrolls.AddNew();     c1.EditorID = "HcEcScroll1"; c1.Effects.Add(Eff(t.FormKey, 44f, 4, 104));
+            var i1 = m.Ingredients.AddNew(); i1.EditorID = "HcEcIngr1";   i1.Effects.Add(Eff(t.FormKey, 55f, 5, 105));
             s1Fk = s1.FormKey; e1Fk = e1.FormKey; a1Fk = a1.FormKey; c1Fk = c1.FormKey; i1Fk = i1.FormKey;
 
             // multi-entry: T at index 1 AND 2; the U-entry at index 0 must NOT match.
@@ -119,12 +127,12 @@ public static class EffectChainProbe
             $"success={all.Success} eid={all.MgefEditorId} err=[{Trim(all.Error)}]");
 
         bool five =
-            RowMag(all, s1Fk, 0) == 11f && RowCount(all, s1Fk, 0) == 1 && RowType(all, s1Fk) == "Spell" &&
-            RowMag(all, e1Fk, 0) == 22f && RowType(all, e1Fk) == "ObjectEffect" &&
-            RowMag(all, a1Fk, 0) == 33f && RowType(all, a1Fk) == "Ingestible" &&
-            RowMag(all, c1Fk, 0) == 44f && RowType(all, c1Fk) == "Scroll" &&
-            RowMag(all, i1Fk, 0) == 55f && RowType(all, i1Fk) == "Ingredient";
-        Check("MATCH-ALL-FIVE: SPEL/ENCH/ALCH/SCRL/INGR each return with the authored magnitude + catalog type", five,
+            RowMag(all, s1Fk, 0) == 11f && RowArea(all, s1Fk, 0) == 1 && RowDur(all, s1Fk, 0) == 101 && RowCount(all, s1Fk, 0) == 1 && RowType(all, s1Fk) == "Spell" &&
+            RowMag(all, e1Fk, 0) == 22f && RowArea(all, e1Fk, 0) == 2 && RowDur(all, e1Fk, 0) == 102 && RowType(all, e1Fk) == "ObjectEffect" &&
+            RowMag(all, a1Fk, 0) == 33f && RowArea(all, a1Fk, 0) == 3 && RowDur(all, a1Fk, 0) == 103 && RowType(all, a1Fk) == "Ingestible" &&
+            RowMag(all, c1Fk, 0) == 44f && RowArea(all, c1Fk, 0) == 4 && RowDur(all, c1Fk, 0) == 104 && RowType(all, c1Fk) == "Scroll" &&
+            RowMag(all, i1Fk, 0) == 55f && RowArea(all, i1Fk, 0) == 5 && RowDur(all, i1Fk, 0) == 105 && RowType(all, i1Fk) == "Ingredient";
+        Check("MATCH-ALL-FIVE: SPEL/ENCH/ALCH/SCRL/INGR each return the authored magnitude/area/duration (distinct, so a field transposition is caught) + catalog type", five,
             $"S1={RowMag(all, s1Fk, 0)}/{RowType(all, s1Fk)} E1={RowMag(all, e1Fk, 0)}/{RowType(all, e1Fk)} A1={RowMag(all, a1Fk, 0)}/{RowType(all, a1Fk)} C1={RowMag(all, c1Fk, 0)}/{RowType(all, c1Fk)} I1={RowMag(all, i1Fk, 0)}/{RowType(all, i1Fk)}");
 
         bool multi =
@@ -205,6 +213,12 @@ public static class EffectChainProbe
 
     static float? RowMag(EffectChainResult res, FormKey carrier, int effIndex) =>
         res.Rows.FirstOrDefault(x => x.Carrier == carrier && x.EffectIndex == effIndex)?.Magnitude;
+
+    static int? RowArea(EffectChainResult res, FormKey carrier, int effIndex) =>
+        res.Rows.FirstOrDefault(x => x.Carrier == carrier && x.EffectIndex == effIndex)?.Area;
+
+    static int? RowDur(EffectChainResult res, FormKey carrier, int effIndex) =>
+        res.Rows.FirstOrDefault(x => x.Carrier == carrier && x.EffectIndex == effIndex)?.Duration;
 
     static int? RowCount(EffectChainResult res, FormKey carrier, int effIndex) =>
         res.Rows.FirstOrDefault(x => x.Carrier == carrier && x.EffectIndex == effIndex)?.EffectCount;

--- a/src/housecarl-generator/EffectChainProbe.cs
+++ b/src/housecarl-generator/EffectChainProbe.cs
@@ -1,0 +1,216 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SELF-CONTAINED CI REGRESSION GUARD for the EFFECT-CHAIN RESOLVER (housecarl_effect_chain — gap 2026-06-08: "given
+/// an MGEF, what SPEL/ENCH/ALCH apply it, at what magnitude?"). Drives the REAL product path
+/// (<see cref="EffectChain.Resolve"/> — what housecarl_effect_chain calls through the thin service wrapper) against a
+/// SYNTHESIZED 1-plugin order in TEMP — NO Skyrim.esm, so it runs in CI.
+///
+/// THE GAP (reproduced by construction): there was no one call from a MagicEffect to "applied by these records, at
+/// these magnitudes" — you re-ran cross_plugin_query references=&lt;MGEF&gt; for SPEL, then ENCH, ALCH, SCRL, INGR, and
+/// hand-read each hit's matching Effects[].Data. Resolve collapses that into one verb.
+///
+/// THE FIX (generic by construction): the five effect-bearing records share ONE element type (IEffectGetter), so
+/// EffectsOf() reaches the list with a five-arm switch and Match() extracts the matching entries uniformly — every
+/// effect-bearing record, no per-type magnitude wiring.
+///
+/// FIXTURE (one master; distinct magnitude per carrier is the by-construction discriminator — the read-back mag proves
+/// WHICH entry landed): MGEFs Target(T)/Other(U)/Unused(V); one carrier of each type applying T — Spell(11), ENCH(22),
+/// ALCH(33), Scroll(44), INGR(55); a multi-entry Spell [U@100, T@66, T@77] (T at index 1 AND 2); a non-match Spell
+/// [U@88]; a null-base Spell [unset@99]; and a Weapon (the non-MGEF Q3 fixture).
+///
+/// Arms (ALL required — a GREEN must mean "the contract holds"):
+///   GATE-OK        — Resolve(T) succeeds and the header carries T's editorid (the typed-match proof).
+///   MATCH-ALL-FIVE — SPEL/ENCH/ALCH/SCRL/INGR each return once with the authored magnitude + the right catalog type.
+///   MULTI-ENTRY    — the multi Spell yields one row PER matching entry (mag 66 @1/3, mag 77 @2/3); its U-entry @0 is excluded.
+///   TOTAL          — exactly 7 rows (5 single + 2 multi), not capped.
+///   NON-MATCH      — a carrier of a DIFFERENT MGEF (and the multi's U-entry) is never returned.
+///   NULL-BASE      — an effect with an unset BaseEffect is skipped — not matched, no throw, no scan note.
+///   TYPES-NARROW   — scope=[Spell] returns only spell carriers (S1 + multi×2 = 3); ENCH/ALCH/SCRL/INGR excluded.
+///   PURE           — Match/EffectsOf on the in-MEMORY bodies (the pure seam, independent of the scan): list for a
+///                    Spell, null for a Weapon; the single hit on the spell, empty on the weapon.
+///   Q3-NONMGEF     — a WEAP FormID fails LOUD ("not a MagicEffect"), no rows (the headline typed-mismatch case).
+///   Q3-ABSENT      — a FormID no plugin defines fails LOUD ("not in the load order"), no rows.
+///   Q3-UNUSED      — a valid-but-unreferenced MGEF returns a CLEAN zero (Success, 0 rows, no error, eid in header) —
+///                    distinguishable from the bad-id errors above, so "0 carriers" is never a silent wrong answer.
+///   CAP            — limit=3 returns 3 rows but reports the TRUE total (7) and Capped (the explicit-overrun teeth).
+///
+/// Run: dotnet run --project src/housecarl-generator -- effect-chain-guard
+/// </summary>
+public static class EffectChainProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("effect-chain-guard — resolve a MagicEffect's carriers + magnitudes (housecarl_effect_chain, gap 2026-06-08)");
+        Console.WriteLine();
+
+        var tmpDir = Path.Combine(Path.GetTempPath(), "hc-effect-chain-guard");
+        if (Directory.Exists(tmpDir)) Directory.Delete(tmpDir, recursive: true);
+        Directory.CreateDirectory(tmpDir);
+        try { return RunChecks(tmpDir); }
+        finally { try { Directory.Delete(tmpDir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    static int RunChecks(string tmpDir)
+    {
+        int failures = 0;
+        void Check(string label, bool ok, string? detail = null)
+        {
+            Console.WriteLine($"  {(ok ? "PASS" : "FAIL")}  {label}{(ok || detail is null ? "" : $"\n        -> {detail}")}");
+            if (!ok) failures++;
+        }
+
+        // ---- synthesize the 1-plugin order (see class doc). ----
+        string mPath = Path.Combine(tmpDir, "HcEcMaster.esm");
+        FormKey tFk, uFk, vFk, s1Fk, e1Fk, a1Fk, c1Fk, i1Fk, s2Fk, s3Fk, s4Fk, wFk;
+        ISpellGetter s1Mem, s4Mem; IWeaponGetter wMem;   // in-memory bodies for the PURE arm
+        try
+        {
+            var m = new SkyrimMod(new ModKey("HcEcMaster", ModType.Master), SkyrimRelease.SkyrimSE);
+
+            var t = m.MagicEffects.AddNew(); t.EditorID = "HcEcTarget";
+            var u = m.MagicEffects.AddNew(); u.EditorID = "HcEcOther";
+            var v = m.MagicEffects.AddNew(); v.EditorID = "HcEcUnused";
+            tFk = t.FormKey; uFk = u.FormKey; vFk = v.FormKey;
+
+            var s1 = m.Spells.AddNew();      s1.EditorID = "HcEcSpell1";  s1.Effects.Add(Eff(t.FormKey, 11f));
+            var e1 = m.ObjectEffects.AddNew(); e1.EditorID = "HcEcEnch1"; e1.Effects.Add(Eff(t.FormKey, 22f));
+            var a1 = m.Ingestibles.AddNew(); a1.EditorID = "HcEcAlch1";   a1.Effects.Add(Eff(t.FormKey, 33f));
+            var c1 = m.Scrolls.AddNew();     c1.EditorID = "HcEcScroll1"; c1.Effects.Add(Eff(t.FormKey, 44f));
+            var i1 = m.Ingredients.AddNew(); i1.EditorID = "HcEcIngr1";   i1.Effects.Add(Eff(t.FormKey, 55f));
+            s1Fk = s1.FormKey; e1Fk = e1.FormKey; a1Fk = a1.FormKey; c1Fk = c1.FormKey; i1Fk = i1.FormKey;
+
+            // multi-entry: T at index 1 AND 2; the U-entry at index 0 must NOT match.
+            var s2 = m.Spells.AddNew(); s2.EditorID = "HcEcMulti";
+            s2.Effects.Add(Eff(u.FormKey, 100f));
+            s2.Effects.Add(Eff(t.FormKey, 66f));
+            s2.Effects.Add(Eff(t.FormKey, 77f));
+            s2Fk = s2.FormKey;
+
+            var s3 = m.Spells.AddNew(); s3.EditorID = "HcEcNonMatch"; s3.Effects.Add(Eff(u.FormKey, 88f));   // a DIFFERENT MGEF
+            var s4 = m.Spells.AddNew(); s4.EditorID = "HcEcNullBase"; s4.Effects.Add(Eff(null, 99f));        // unset BaseEffect
+            s3Fk = s3.FormKey; s4Fk = s4.FormKey;
+
+            var w = m.Weapons.AddNew(); w.EditorID = "HcEcWeap"; w.BasicStats = new WeaponBasicStats { Damage = 10 };
+            wFk = w.FormKey;
+
+            s1Mem = s1; s4Mem = s4; wMem = w;   // capture before write (the write does not invalidate them)
+
+            m.BeginWrite.ToPath(mPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"error: could not synthesize fixtures: {ex.GetType().Name}: {(ex.InnerException ?? ex).Message}");
+            return 1;
+        }
+
+        using var r = LoadOrderResolver.Build(new[] { mPath });
+
+        // ---- the main resolve over all five types. ----
+        var all = EffectChain.Resolve(r, tFk, EffectChain.CarrierTypes, 500);
+
+        Check("GATE-OK: Resolve(target) succeeds and the header carries the MGEF's editorid (typed-match proof)",
+            all.Success && all.MgefEditorId == "HcEcTarget",
+            $"success={all.Success} eid={all.MgefEditorId} err=[{Trim(all.Error)}]");
+
+        bool five =
+            RowMag(all, s1Fk, 0) == 11f && RowCount(all, s1Fk, 0) == 1 && RowType(all, s1Fk) == "Spell" &&
+            RowMag(all, e1Fk, 0) == 22f && RowType(all, e1Fk) == "ObjectEffect" &&
+            RowMag(all, a1Fk, 0) == 33f && RowType(all, a1Fk) == "Ingestible" &&
+            RowMag(all, c1Fk, 0) == 44f && RowType(all, c1Fk) == "Scroll" &&
+            RowMag(all, i1Fk, 0) == 55f && RowType(all, i1Fk) == "Ingredient";
+        Check("MATCH-ALL-FIVE: SPEL/ENCH/ALCH/SCRL/INGR each return with the authored magnitude + catalog type", five,
+            $"S1={RowMag(all, s1Fk, 0)}/{RowType(all, s1Fk)} E1={RowMag(all, e1Fk, 0)}/{RowType(all, e1Fk)} A1={RowMag(all, a1Fk, 0)}/{RowType(all, a1Fk)} C1={RowMag(all, c1Fk, 0)}/{RowType(all, c1Fk)} I1={RowMag(all, i1Fk, 0)}/{RowType(all, i1Fk)}");
+
+        bool multi =
+            RowMag(all, s2Fk, 1) == 66f && RowCount(all, s2Fk, 1) == 3 &&
+            RowMag(all, s2Fk, 2) == 77f && RowCount(all, s2Fk, 2) == 3 &&
+            all.Rows.Count(x => x.Carrier == s2Fk) == 2;
+        Check("MULTI-ENTRY: a carrier applying the MGEF twice yields one row per entry (66 @1/3, 77 @2/3); its U-entry @0 excluded", multi,
+            $"rows@s2={all.Rows.Count(x => x.Carrier == s2Fk)} mag@1={RowMag(all, s2Fk, 1)} mag@2={RowMag(all, s2Fk, 2)} cnt@1={RowCount(all, s2Fk, 1)}");
+
+        Check("TOTAL: exactly 7 carrier rows (5 single + 2 multi), not capped",
+            all.Total == 7 && all.Rows.Count == 7 && !all.Capped,
+            $"total={all.Total} rows={all.Rows.Count} capped={all.Capped}");
+
+        bool nonMatch = !all.Rows.Any(x => x.Carrier == s3Fk) && !all.Rows.Any(x => x.Magnitude == 88f || x.Magnitude == 100f);
+        Check("NON-MATCH: a carrier of a DIFFERENT MGEF (and the multi's U-entry) is never returned", nonMatch,
+            $"s3 present={all.Rows.Any(x => x.Carrier == s3Fk)} stray-mags={all.Rows.Any(x => x.Magnitude == 88f || x.Magnitude == 100f)}");
+
+        bool nullBase = !all.Rows.Any(x => x.Carrier == s4Fk) && all.ScanNote is null && all.Success;
+        Check("NULL-BASE: an effect with an unset BaseEffect is skipped (not matched, no throw / no scan note)", nullBase,
+            $"s4 present={all.Rows.Any(x => x.Carrier == s4Fk)} scanNote=[{Trim(all.ScanNote)}]");
+
+        // ---- TYPES-NARROW: scope=[Spell] only. ----
+        var spellsOnly = EffectChain.Resolve(r, tFk, new[] { typeof(ISpellGetter) }, 500);
+        bool narrow = spellsOnly.Success && spellsOnly.Total == 3 &&
+            spellsOnly.Rows.All(x => x.Type == "Spell") &&
+            spellsOnly.Rows.Any(x => x.Carrier == s1Fk) && spellsOnly.Rows.Count(x => x.Carrier == s2Fk) == 2 &&
+            !spellsOnly.Rows.Any(x => x.Carrier == e1Fk);
+        Check("TYPES-NARROW: scope=[Spell] returns only spell carriers (S1 + multi×2 = 3); ENCH/ALCH/SCRL/INGR excluded", narrow,
+            $"total={spellsOnly.Total} allSpell={spellsOnly.Rows.All(x => x.Type == "Spell")} e1present={spellsOnly.Rows.Any(x => x.Carrier == e1Fk)}");
+
+        // ---- PURE: Match / EffectsOf on the in-MEMORY bodies (independent of the resolver scan). ----
+        bool pureEffectsOf = EffectChain.EffectsOf(s1Mem)?.Count == 1 && EffectChain.EffectsOf(wMem) is null;
+        Check("PURE: EffectsOf returns the list for a Spell, null for a Weapon", pureEffectsOf,
+            $"spell={EffectChain.EffectsOf(s1Mem)?.Count} weapon={(EffectChain.EffectsOf(wMem) is null ? "null" : "non-null")}");
+        var s1Hits = EffectChain.Match(s1Mem, tFk);
+        bool pureMatch = s1Hits.Count == 1 && s1Hits[0].Magnitude == 11f && s1Hits[0].Index == 0
+                         && EffectChain.Match(wMem, tFk).Count == 0 && EffectChain.Match(s4Mem, tFk).Count == 0;
+        Check("PURE: Match returns the single hit (mag 11 @0) on the spell, empty on the weapon + the null-base spell", pureMatch,
+            $"s1Hits={s1Hits.Count} mag={(s1Hits.Count > 0 ? s1Hits[0].Magnitude : -1)} weapHits={EffectChain.Match(wMem, tFk).Count} nullHits={EffectChain.Match(s4Mem, tFk).Count}");
+
+        // ---- Q3 teeth (the gap's explicit ask — never a silent wrong answer). ----
+        var wRes = EffectChain.Resolve(r, wFk, EffectChain.CarrierTypes, 500);
+        Check("Q3-NONMGEF: a WEAP FormID fails LOUD ('not a MagicEffect'), no rows",
+            !wRes.Success && wRes.Rows.Count == 0 && wRes.Error is not null && wRes.Error.Contains("not a MagicEffect", StringComparison.Ordinal),
+            $"success={wRes.Success} rows={wRes.Rows.Count} err=[{Trim(wRes.Error)}]");
+
+        var absentFk = FormKey.Factory("ABCDEF:HcEcNotReal.esp");
+        var absRes = EffectChain.Resolve(r, absentFk, EffectChain.CarrierTypes, 500);
+        Check("Q3-ABSENT: a FormID no plugin defines fails LOUD ('no record … in the load order'), no rows",
+            !absRes.Success && absRes.Rows.Count == 0 && absRes.Error is not null && absRes.Error.Contains("in the load order", StringComparison.Ordinal),
+            $"success={absRes.Success} rows={absRes.Rows.Count} err=[{Trim(absRes.Error)}]");
+
+        var unusedRes = EffectChain.Resolve(r, vFk, EffectChain.CarrierTypes, 500);
+        Check("Q3-UNUSED: a valid-but-unreferenced MGEF returns a CLEAN zero (Success, 0 rows, no error, eid in header)",
+            unusedRes.Success && unusedRes.Total == 0 && unusedRes.Rows.Count == 0 && unusedRes.Error is null && unusedRes.MgefEditorId == "HcEcUnused",
+            $"success={unusedRes.Success} total={unusedRes.Total} err=[{Trim(unusedRes.Error)}] eid={unusedRes.MgefEditorId}");
+
+        // ---- CAP: limit=3 over the 7-row set. ----
+        var capped = EffectChain.Resolve(r, tFk, EffectChain.CarrierTypes, 3);
+        Check("CAP: limit=3 returns 3 rows but reports the TRUE total (7) and Capped",
+            capped.Rows.Count == 3 && capped.Total == 7 && capped.Capped,
+            $"rows={capped.Rows.Count} total={capped.Total} capped={capped.Capped}");
+
+        Console.WriteLine();
+        Console.WriteLine(failures == 0 ? "effect-chain-guard: ALL PASS" : $"effect-chain-guard: {failures} FAILURE(S)");
+        return failures == 0 ? 0 : 1;
+    }
+
+    // ---- helpers ----
+
+    static Effect Eff(FormKey? baseEffect, float magnitude, int area = 0, int duration = 0)
+    {
+        var e = new Effect();
+        if (baseEffect is { } bf) e.BaseEffect.SetTo(bf);     // unset (null) leaves BaseEffect at FormKey.Null — the null-base fixture
+        e.Data = new EffectData { Magnitude = magnitude, Area = area, Duration = duration };
+        return e;
+    }
+
+    static float? RowMag(EffectChainResult res, FormKey carrier, int effIndex) =>
+        res.Rows.FirstOrDefault(x => x.Carrier == carrier && x.EffectIndex == effIndex)?.Magnitude;
+
+    static int? RowCount(EffectChainResult res, FormKey carrier, int effIndex) =>
+        res.Rows.FirstOrDefault(x => x.Carrier == carrier && x.EffectIndex == effIndex)?.EffectCount;
+
+    static string? RowType(EffectChainResult res, FormKey carrier) =>
+        res.Rows.FirstOrDefault(x => x.Carrier == carrier)?.Type;
+
+    static string Trim(string? s) => s is null ? "" : (s.Length <= 160 ? s.Replace("\n", " ") : s[..160].Replace("\n", " ") + "…");
+}

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -57,6 +57,12 @@ if (args.Length > 0 && args[0] == "create-plugin-guard") return CreatePluginGuar
 // with known field values, asserts the evaluator's matched set == a brute-force reference + the Q3 teeth.
 if (args.Length > 0 && args[0] == "value-predicate-guard") return ValuePredicateProbe.RunGuard(args[1..]);
 
+// Effect-chain resolver (housecarl_effect_chain, gap 2026-06-08): SELF-CONTAINED CI regression guard — synthesizes
+// MGEFs + the five effect-bearing records (SPEL/ENCH/ALCH/SCRL/INGR) with KNOWN magnitudes referencing them, asserts
+// Resolve's carrier rows == a brute-force oracle, multi-entry + null-base + types-narrow + the Q3 gate (non-MGEF /
+// absent → loud, unused → clean zero).
+if (args.Length > 0 && args[0] == "effect-chain-guard") return EffectChainProbe.RunGuard(args[1..]);
+
 // Winner-vs-source display (wishlist #8): SELF-CONTAINED CI regression guard — synthesizes a master + two overrides
 // (B wins) and asserts RecordsIn pairs each yielded body with its OWN source plugin, the winner stream with the winner.
 if (args.Length > 0 && args[0] == "source-display-guard") return SourceDisplayProbe.RunGuard(args[1..]);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1016,6 +1016,40 @@ public sealed class LoadOrderService : IDisposable
         return new CrossQueryOutcome(keys, prefilled, total, total > keys.Count, null, predicate?.AccountingNote(), sources, scanNote);
     }
 
+    // ---- effect-chain resolver (housecarl_effect_chain — gap 2026-06-08) --------------------------------
+
+    /// <summary>Resolve which SPEL/ENCH/ALCH/SCRL/INGR apply a MagicEffect, each with the magnitude/area/duration from
+    /// the MATCHING effect entry (housecarl_effect_chain). Thin wiring over the core: resolve the optional type-narrow
+    /// (each must be one of the five effect-bearing records — a non-member is refused loud, never a silent empty scan),
+    /// then drive <see cref="EffectChain.Resolve"/> (Q3 typed-match gate → winner-body scan). All the logic + the Q3
+    /// teeth live in core so the self-contained guard drives this same path on synthetic plugins.</summary>
+    public EffectChainResult ResolveEffectChain(FormKey mgef, IReadOnlyList<string>? typesNarrow, int limit)
+    {
+        IReadOnlyList<Type> scope;
+        if (typesNarrow is { Count: > 0 })
+        {
+            var picked = new List<Type>();
+            foreach (var ts in typesNarrow)
+            {
+                IReadOnlyList<Type> resolved;
+                try { resolved = ResolveTypeFilter(ts.Trim()); }              // unknown type → named Q3 error (same as cross_plugin_query)
+                catch (ArgumentException ex) { return EffectChainResult.Fail(ex.Message); }
+                foreach (var t in resolved)
+                {
+                    if (!EffectChain.CarrierTypes.Contains(t))
+                        return EffectChainResult.Fail(
+                            $"type '{ts}' is not effect-bearing — effect_chain scans only Spell/ObjectEffect/Ingestible/Scroll/Ingredient " +
+                            "(SPEL/ENCH/ALCH/SCRL/INGR), the records that carry an Effects list. Drop it or pass one of those.");
+                    if (!picked.Contains(t)) picked.Add(t);
+                }
+            }
+            scope = picked;
+        }
+        else scope = EffectChain.CarrierTypes;
+
+        return EffectChain.Resolve(Resolver, mgef, scope, limit);
+    }
+
     // ---- writes (§8.4 Beat C: housecarl_set_field / housecarl_bulk_apply) -------------------------------
 
     /// <summary>Apply one-or-more edits as a single patch (housecarl_set_field = one op; housecarl_bulk_apply = many).

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -122,6 +122,37 @@ public static class ReadTools
         var outcome = svc.CrossQuery(type, refFk, editorid_contains, conflicts_only, plugins, where, limit <= 0 ? 500 : limit);
         return Wire.RenderCrossQuery(svc, outcome, fields, conflict_tree, max_chars);
     });
+
+    [McpServerTool(Name = "housecarl_effect_chain", ReadOnly = true, Title = "Resolve an effect's carriers + magnitudes"),
+     Description(
+         "Given a MagicEffect (MGEF), return every Spell/Enchantment/Potion/Scroll/Ingredient (SPEL/ENCH/ALCH/SCRL/INGR) " +
+         "that APPLIES it, each with the magnitude/area/duration from the MATCHING effect entry — collapsing the " +
+         "'cross_plugin_query references=<MGEF> then read each hit's effect' trace (repeated across five record types) " +
+         "into one call. The FormID MUST resolve to a MagicEffect: a non-MGEF or absent FormID fails LOUD (never a " +
+         "silent '0 carriers') — to find what references an arbitrary record, use housecarl_cross_plugin_query " +
+         "references=. A carrier that applies the effect in more than one entry yields one row per entry. Magnitude is " +
+         "reported AS AUTHORED: this does NOT evaluate the effect's Conditions, so a row means 'this carrier defines the " +
+         "effect at this strength', not 'it will fire'. Winners only (the load-order-effective version). Results cap at " +
+         "limit= and max_chars (both overruns explicit, never silent). Does NOT modify anything.")]
+    public static string EffectChainTool(
+        LoadOrderService svc,
+        [Description("The MagicEffect's FormID as 'XXXXXX:Plugin.esp' — 6 hex digits, a colon, then the defining master's filename. Must resolve to an MGEF in the active order.")]
+            string mgef_formid,
+        [Description("Optional. Narrow the scan to a subset of the effect-bearing types — any of 'SPEL','ENCH','ALCH','SCRL','INGR' (or the catalog names 'Spell','ObjectEffect','Ingestible','Scroll','Ingredient'). A non-effect-bearing type is refused. Omit to scan all five.")]
+            string[]? types = null,
+        [Description("Optional. Max rows (default 500). The TRUE total is always reported; over the cap it says 'showing first N'.")]
+            int limit = 500,
+        [Description("Optional. Max characters before the response stops with an explicit notice. 0 = the server default (~80k).")]
+            int max_chars = 0) => Guard.Tool("housecarl_effect_chain", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        FormKey fk;
+        try { fk = FormKey.Factory(mgef_formid.Trim()); }
+        catch (Exception ex) { return $"error: bad FormID '{mgef_formid}': {ex.Message}. Expected 'XXXXXX:Plugin.esp', e.g. '0F1AC1:Skyrim.esm'."; }
+
+        var result = svc.ResolveEffectChain(fk, types, limit <= 0 ? 500 : limit);
+        return Wire.RenderEffectChain(result, max_chars);
+    });
 }
 
 /// <summary>Compact, parseable `key = value` rendering (Q4.8 lever 1) + the winner-relative conflict diff
@@ -207,6 +238,54 @@ static class Wire
                        .Append("  winner=").Append(m.Winner).Append("  override_depth=").Append(m.OverrideDepth).Append('\n');
             }
             rendered++;
+        }
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    // ---- housecarl_effect_chain ---------------------------------------------------------------------
+    /// <summary>Render the effect chain: a header that RESOLVES the MGEF (its editorid + the confirmed MagicEffect
+    /// type — the Q3 typed-match proof), then carrier rows grouped by record type. A valid-but-unused MGEF renders a
+    /// clean "none" line, NOT an error (the error path is the bad/mistyped FormID, handled in core). Over max_chars it
+    /// stops with the same explicit notice the other read renders use (Q3 — never silent).</summary>
+    public static string RenderEffectChain(EffectChainResult r, int maxChars)
+    {
+        if (r.Error is not null) return "error: " + r.Error;
+        int cap = Cap(maxChars);
+        var sb = new StringBuilder();
+        sb.Append("effect_chain for ").Append(r.Mgef).Append(" (").Append(r.MgefEditorId).Append(", MagicEffect): ")
+          .Append(r.Total).Append(r.Total == 1 ? " carrier row" : " carrier rows");
+        if (r.Capped) sb.Append(" (showing first ").Append(r.Rows.Count).Append("; raise limit= or narrow to see more)");
+        sb.Append('\n');
+        if (r.Total == 0)
+            sb.Append("  none — ").Append(r.MgefEditorId)
+              .Append(" is a valid MagicEffect but is applied by no SPEL/ENCH/ALCH/SCRL/INGR in the active order.\n");
+        if (r.ScanNote is not null) sb.Append(r.ScanNote).Append('\n');
+
+        int rendered = 0;
+        bool truncated = false;
+        // Group rows by carrier type (stable, ordinal) so a multi-type result reads grouped — like cross_plugin_query's type=.
+        foreach (var grp in r.Rows.GroupBy(x => x.Type).OrderBy(g => g.Key, StringComparer.Ordinal))
+        {
+            if (truncated) break;
+            sb.Append(grp.Key).Append(" (").Append(grp.Count()).Append("):\n");
+            foreach (var row in grp)
+            {
+                if (sb.Length >= cap)
+                {
+                    sb.Append("  ... [truncated: rendered ").Append(rendered).Append(" of ").Append(r.Rows.Count)
+                      .Append(" rows before hitting max_chars=").Append(cap).Append("; lower limit= or raise max_chars]\n");
+                    truncated = true;
+                    break;
+                }
+                sb.Append("  ").Append(row.Carrier)
+                  .Append("  ").Append(row.EditorId ?? "<none>")
+                  .Append("  winner=").Append(row.Winner)
+                  .Append("  mag=").Append(row.Magnitude.ToString(System.Globalization.CultureInfo.InvariantCulture))
+                  .Append("  area=").Append(row.Area)
+                  .Append("  dur=").Append(row.Duration)
+                  .Append("  [effect ").Append(row.EffectIndex + 1).Append('/').Append(row.EffectCount).Append("]\n");
+                rendered++;
+            }
         }
         return sb.ToString().TrimEnd('\n');
     }


### PR DESCRIPTION
Closes the **#1 gap** of the running order (`2026-06-08_gap_effect-chain-resolver`).

## What
A new read-only tool **`housecarl_effect_chain(mgef_formid, types?, limit?, max_chars?)`**: given a MagicEffect (MGEF), return every Spell/Enchantment/Potion/Scroll/Ingredient (SPEL/ENCH/ALCH/SCRL/INGR) that **applies** it, each with the magnitude/area/duration from the **matching** effect entry. It collapses the hand-trace — `cross_plugin_query references=<MGEF>` repeated across five record types, then read each hit's effect — into one verb. The inverse-by-magnitude of `references=`: that says *which* carriers reference the effect; this says *which entry*, and *at what strength*.

## Design
- **Generic by construction** — the five effect-bearing records share one element type (`IEffectGetter`), so `EffectsOf()` reaches the `Effects` list with a five-arm switch and `Match()` extracts uniformly. No per-type magnitude wiring; the five are *every* record the library models with an `Effects` list (cornerstone-safe, not a subset).
- **Read-only** — no schema/rulebook change.
- **Layering mirrors the `where=` predicate**: pure `EffectChain.Match` (the guard's seam) + `EffectChain.Resolve` (Q3 gate → winner-body scan, per-record fault isolation) in **core**; a thin `LoadOrderService.ResolveEffectChain` (type-narrow validation) + the tool + `Wire.RenderEffectChain` in **mcp**.

## Q3 teeth (the gap's explicit ask — never a silent "0 carriers")
- non-MGEF FormID → fails **loud**, naming the actual type
- absent FormID → fails **loud**
- valid-but-unused MGEF → **clean zero** with the resolved header (distinguishable from the bad-id errors)
- a carrier applying the effect in >1 entry → one row per entry
- magnitude reported **as authored** (Conditions not evaluated — stated in the tool description)

## Evidence (run before commit)
- **`effect-chain-guard` 14/14 PASS** — self-contained (synthesizes MGEFs + the five carriers, no Skyrim.esm), drives the real `EffectChain.Resolve`: match-all-five, multi-entry, non-match, null-base, types-narrow, the pure matcher, cap, and all three Q3 gate paths. Added to CI.
- **No regression** in the shared read path: `value-predicate-guard` 31/31, `source-display-guard` 13/13.
- Build clean (0 errors).

## Review focus
- The `EffectChain.Match` BaseEffect comparison + the nullable-`Data` zero-fill.
- The Q3 gate ordering in `EffectChain.Resolve` (absent vs non-MGEF vs unused).
- The `types=` narrow validation against the effect-bearing set in `ResolveEffectChain`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)