### PR TITLE
fix: into= extend resolves a renamed houseCARL patch (by .esp basename or folder name) — HCBR-2026-06-23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,16 @@ jobs:
       - name: Probe — forward-from-plugin (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- forward-from-plugin-guard
 
+      # Self-contained (synthesizes an MO2 instance + master in temp — no Skyrim.esm), runs fully here: a regression
+      # guard for the into=-EXTEND RESOLVER (HCBR-2026-06-23 — "in-place into= can't find a houseCARL patch once its mod
+      # folder is renamed"). The folder-per-patch model coupled into= to a 3-way name match (into== folder suffix == .esp
+      # basename); a user renaming the MO2 folder (the .esp basename is fixed by SPID/CSF/masters) could no longer extend
+      # their OWN patch. Pins: a renamed folder is found by the .esp it holds AND by the folder name (names need not match),
+      # two owned folders sharing an .esp refuse loud + disambiguate by folder, an UN-OWNED folder stays refused (originals
+      # untouched — no foreign-plugin door), and the master is byte-untouched. Still behind the ownership marker.
+      - name: Probe — into=-extend resolver (renamed-folder resolution; self-contained)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- extend-resolve-guard
+
       # Self-contained (core arms write to temp; service arms synthesize an MO2 instance — no Skyrim.esm), runs fully
       # here: a regression guard for CREATE-PLUGIN (HCBR-2026-06-19-02 — housecarl_create_plugin). houseCARL's write
       # model was record-centric, so a basename-bound SKSE config trigger (CraftingCategories-style) had to carry a junk

--- a/src/housecarl-generator/ExtendResolveProbe.cs
+++ b/src/housecarl-generator/ExtendResolveProbe.cs
@@ -1,0 +1,205 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// into=-extend RESOLVER guard (HCBR-2026-06-23: "in-place into= extend can't find a houseCARL-built plugin once its
+/// mod folder is renamed"). The folder-per-patch model created each patch as "houseCARL - &lt;stem&gt;\&lt;stem&gt;.esp",
+/// and the old ResolveOutputPath into= branch demanded a 3-way name match: into= == mod-folder suffix == .esp basename.
+/// A user who renamed the MO2 mod folder for organization (the .esp basename is FIXED — SPID _DISTR / the CSF JSON /
+/// masters bind it) could no longer extend their OWN patch in place. The fix decouples the folder name from the .esp
+/// basename WITHOUT relaxing the ownership marker (this is houseCARL's OWN output — "originals untouched" is not in play;
+/// the marker still gates every touch, so it opens NO foreign-plugin door — that's the separate, unbuilt in-place lane).
+///
+/// Drives the REAL service write path (LoadOrderService.ApplyEdits) against a synthetic MO2 instance in temp (the
+/// WriteMutexProbe synth pattern). Arms:
+///   CANONICAL   — into="SeedA" still resolves the unchanged "houseCARL - SeedA\SeedA.esp" (zero regression, no scan).
+///   BY-ESP      — after the folder is RENAMED (esp basename unchanged), into=&lt;esp basename&gt; finds the patch by the
+///                 plugin it holds, whatever the folder is now called. RED pre-fix (old: "mod folder not found").
+///   BY-FOLDER   — into=&lt;the renamed folder's name&gt; edits the single .esp inside it, names NEED NOT match. RED pre-fix
+///                 (old: "folder has no '&lt;folder&gt;.esp' to extend").
+///   ACCUMULATED — both resolution paths extended the SAME patch file (the edits accumulate; not a fresh patch).
+///   AMBIGUOUS   — two OWNED folders carry the same &lt;esp&gt; → refuse loud, name BOTH folders + the into="&lt;folder&gt;"
+///                 disambiguator (Q3 — never guess which). Then into=&lt;a folder name&gt; picks one unambiguously.
+///   NOT-FOUND   — into= a name no owned folder holds/answers to → refuse, naming both places searched + "create it fresh".
+///   FOREIGN     — a "houseCARL - X" folder with NO marker is still REFUSED (originals untouched, Q3) and left byte-intact.
+///   ORIGINALS   — the master plugin is byte-untouched throughout (extends only ever wrote the patch folder).
+/// </summary>
+internal static class ExtendResolveProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" into=-extend resolver guard — find a renamed houseCARL patch");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        var root = Path.Combine(Path.GetTempPath(), "hc-extend-resolve-guard-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            // ---- synthetic MO2 instance with ONE real master plugin (the established synth-instance pattern) ----
+            string instance = Path.Combine(root, "instance");
+            string profiles = Path.Combine(instance, "profiles", "Default");
+            string mods = Path.Combine(instance, "mods");
+            Directory.CreateDirectory(profiles); Directory.CreateDirectory(mods);
+            Directory.CreateDirectory(Path.Combine(root, "game", "Data"));
+            File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+                "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+                + Path.Combine(root, "game").Replace(@"\", @"\\") + ")\r\n");
+
+            var mKey = new ModKey("HcExtMaster", ModType.Master);
+            var masterPath = Path.Combine(mods, "MasterMod", mKey.FileName.String);
+            Directory.CreateDirectory(Path.GetDirectoryName(masterPath)!);
+            FormKey weapFk;
+            {
+                var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
+                var w = m.Weapons.AddNew(); w.EditorID = "HcExtWeap"; w.BasicStats = new WeaponBasicStats { Damage = 10, Weight = 1 };
+                weapFk = w.FormKey;
+                m.BeginWrite.ToPath(masterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            }
+            File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + mKey.FileName + "\r\n");
+            File.WriteAllText(Path.Combine(profiles, "plugins.txt"), "*" + mKey.FileName + "\r\n");
+            File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+MasterMod\r\n");
+            byte[] masterBytesAtStart = File.ReadAllBytes(masterPath);
+
+            var genDir = Path.Combine(root, "corpus-gen");
+            CorpusGenerator.GenerateAll(genDir, Path.Combine(root, "corpus-ref"));
+            CorpusRulebook.CorpusPath = Path.Combine(genDir, "corpus.json");
+
+            string fid = $"{weapFk.ID:X6}:{weapFk.ModKey.FileName}";
+            var store = new UserConfigStore(Path.Combine(root, "houseCARL.user.json"));
+            using var svc = LoadOrderService.WithInstance(instance, 0, store);
+            svc.Stats();                                                       // warm the lazy index once, off the clock
+
+            static BulkOp Set(string fid, string path, string val) =>
+                new() { Formid = fid, FieldPath = path, Verb = "Set", Value = val };
+            BulkOp Dmg(int v) => Set(fid, "BasicStats.Damage", v.ToString());
+            BulkOp Wgt(int v) => Set(fid, "BasicStats.Weight", v.ToString());
+
+            (ushort? dmg, float? wgt) ReadWeap(string espPath)
+            {
+                ISkyrimModGetter? ov = null;
+                try { ov = SkyrimMod.CreateFromBinaryOverlay(espPath, SkyrimRelease.SkyrimSE);
+                      var w = ov.Weapons.FirstOrDefault(x => x.FormKey == weapFk); return (w?.BasicStats?.Damage, w?.BasicStats?.Weight); }
+                catch { return (null, null); }
+                finally { (ov as IDisposable)?.Dispose(); }
+            }
+            static bool Ends(string path, params string[] parts) =>
+                path.EndsWith(Path.Combine(parts), StringComparison.OrdinalIgnoreCase);
+
+            // ---- SEED: create the patch fresh — "houseCARL - SeedA\SeedA.esp" carrying a Damage=50 override ----
+            var seed = svc.ApplyEdits(new[] { Dmg(50) }, "SeedA", null);
+            Check(seed.Success && Ends(seed.OutputPath, "houseCARL - SeedA", "SeedA.esp"), "seed patch created at houseCARL - SeedA\\SeedA.esp");
+
+            // ---- 1: CANONICAL — into= still resolves the unchanged folder (no scan, zero regression) ----
+            Console.WriteLine("--- 1: canonical into= (unchanged folder) ---");
+            {
+                var r = svc.ApplyEdits(new[] { Wgt(5) }, null, "SeedA");
+                Check(r.Success && Ends(r.OutputPath, "houseCARL - SeedA", "SeedA.esp"),
+                      $"into=\"SeedA\" resolves the canonical folder ({Path.GetFileName(Path.GetDirectoryName(r.OutputPath) ?? "")})");
+            }
+
+            // ---- RENAME the MO2 mod folder; the .esp basename stays SeedA.esp (SPID/CSF/masters bind it) ----
+            string seedFolder = Path.Combine(mods, "houseCARL - SeedA");
+            string renamedFolder = Path.Combine(mods, "houseCARL - SeedA Renamed");
+            Directory.Move(seedFolder, renamedFolder);
+
+            // ---- 2: BY-ESP — find the renamed patch by the plugin it holds (RED pre-fix) ----
+            Console.WriteLine();
+            Console.WriteLine("--- 2: into=<esp basename> after the folder was renamed ---");
+            {
+                var r = svc.ApplyEdits(new[] { Wgt(7) }, null, "SeedA");
+                Check(r.Success && Ends(r.OutputPath, "houseCARL - SeedA Renamed", "SeedA.esp"),
+                      $"into=\"SeedA\" finds the RENAMED folder by the .esp it holds (wrote into {Path.GetFileName(Path.GetDirectoryName(r.OutputPath) ?? "")})");
+            }
+
+            // ---- 3: BY-FOLDER — name the renamed folder; the .esp inside need not match (RED pre-fix) ----
+            Console.WriteLine();
+            Console.WriteLine("--- 3: into=<the renamed folder's name> (folder & esp names differ) ---");
+            {
+                var r = svc.ApplyEdits(new[] { Dmg(88) }, null, "SeedA Renamed");
+                Check(r.Success && Ends(r.OutputPath, "houseCARL - SeedA Renamed", "SeedA.esp"),
+                      $"into=\"SeedA Renamed\" (folder name) edits the single .esp inside it ({Path.GetFileName(r.OutputPath)})");
+            }
+
+            // ---- 4: ACCUMULATED — both paths grew the SAME patch (not a fresh one) ----
+            Console.WriteLine();
+            Console.WriteLine("--- 4: both resolutions extended the same patch ---");
+            {
+                var (dmg, wgt) = ReadWeap(Path.Combine(renamedFolder, "SeedA.esp"));
+                Check(dmg == 88 && wgt == 7, $"the renamed patch carries BOTH extends — Damage={dmg} (by-folder), Weight={wgt} (by-esp)");
+            }
+
+            // ---- 5: AMBIGUOUS — a second OWNED folder carrying the same esp → refuse loud + name both ----
+            Console.WriteLine();
+            Console.WriteLine("--- 5: two owned folders carry the same .esp → ambiguous refusal ---");
+            string dupFolder = Path.Combine(mods, "houseCARL - DupHome");
+            {
+                Directory.CreateDirectory(dupFolder);
+                File.WriteAllText(Path.Combine(dupFolder, "meta.ini"), "[houseCARL]\r\ngenerated=true\r\nplugin=SeedA.esp\r\n");
+                File.Copy(Path.Combine(renamedFolder, "SeedA.esp"), Path.Combine(dupFolder, "SeedA.esp"));
+
+                var r = svc.ApplyEdits(new[] { Wgt(1) }, null, "SeedA");
+                bool named = r.Error is not null
+                    && r.Error.Contains("ambiguous", StringComparison.OrdinalIgnoreCase)
+                    && r.Error.Contains("houseCARL - SeedA Renamed", StringComparison.Ordinal)
+                    && r.Error.Contains("houseCARL - DupHome", StringComparison.Ordinal)
+                    && r.Error.Contains("into=", StringComparison.Ordinal);
+                Check(!r.Success && named, "into=\"SeedA\" refuses (ambiguous), naming BOTH folders + the into=<folder> disambiguator");
+
+                // the disambiguator: name a folder → resolves to its single .esp unambiguously (names differ)
+                var pick = svc.ApplyEdits(new[] { Wgt(3) }, null, "DupHome");
+                Check(pick.Success && Ends(pick.OutputPath, "houseCARL - DupHome", "SeedA.esp"),
+                      "into=\"DupHome\" (folder name) picks ONE despite the shared .esp basename");
+            }
+
+            // ---- 6: NOT-FOUND — refuse, naming both places searched + the fresh-write escape ----
+            Console.WriteLine();
+            Console.WriteLine("--- 6: into= a name nothing answers to → named refusal ---");
+            {
+                var r = svc.ApplyEdits(new[] { Wgt(1) }, null, "GhostPatch");
+                bool named = r.Error is not null
+                    && r.Error.Contains("GhostPatch.esp", StringComparison.Ordinal)
+                    && r.Error.Contains("houseCARL - GhostPatch", StringComparison.Ordinal)
+                    && r.Error.Contains("create it fresh", StringComparison.OrdinalIgnoreCase);
+                Check(!r.Success && named, "into=\"GhostPatch\" refuses, naming the .esp + the folder searched + 'create it fresh'");
+            }
+
+            // ---- 7: FOREIGN — an un-owned "houseCARL - X" folder stays REFUSED + byte-untouched (Q3) ----
+            Console.WriteLine();
+            Console.WriteLine("--- 7: an un-owned folder is still refused (originals untouched) ---");
+            {
+                string foreignFolder = Path.Combine(mods, "houseCARL - Foreign");
+                Directory.CreateDirectory(foreignFolder);                                  // NO meta.ini marker → not owned
+                string foreignEsp = Path.Combine(foreignFolder, "Foreign.esp");
+                File.WriteAllText(foreignEsp, "not a real plugin — a user file houseCARL must never touch");
+                byte[] foreignBefore = File.ReadAllBytes(foreignEsp);
+
+                var r = svc.ApplyEdits(new[] { Wgt(1) }, null, "Foreign");
+                bool refused = r.Error is not null
+                    && r.Error.Contains("NOT created by houseCARL", StringComparison.Ordinal)
+                    && r.Error.Contains("originals untouched", StringComparison.OrdinalIgnoreCase);
+                Check(!r.Success && refused, "into=\"Foreign\" (un-owned folder) is REFUSED — houseCARL won't edit a folder it doesn't own");
+                Check(File.ReadAllBytes(foreignEsp).SequenceEqual(foreignBefore), "the un-owned plugin is byte-untouched after the refusal");
+            }
+
+            // ---- 8: ORIGINALS — the master plugin never moved a byte (extends only wrote the patch folder) ----
+            Console.WriteLine();
+            Console.WriteLine("--- 8: the master plugin is byte-untouched throughout ---");
+            Check(File.ReadAllBytes(masterPath).SequenceEqual(masterBytesAtStart),
+                  "the master plugin is byte-identical to its pre-write state (every extend wrote only the patch)");
+        }
+        finally { try { Directory.Delete(root, recursive: true); } catch { /* temp scratch */ } }
+
+        Console.WriteLine();
+        Console.WriteLine(fail == 0 ? "================ ALL PASS ================" : $"================ {fail} CHECK(S) FAILED ================");
+        return fail == 0 ? 0 : 1;
+    }
+}

--- a/src/housecarl-generator/ExtendResolveProbe.cs
+++ b/src/housecarl-generator/ExtendResolveProbe.cs
@@ -10,25 +10,29 @@ namespace HousecarlGenerator;
 /// <summary>
 /// into=-extend RESOLVER guard (HCBR-2026-06-23: "in-place into= extend can't find a houseCARL-built plugin once its
 /// mod folder is renamed"). The folder-per-patch model created each patch as "houseCARL - &lt;stem&gt;\&lt;stem&gt;.esp",
-/// and the old ResolveOutputPath into= branch demanded a 3-way name match: into= == mod-folder suffix == .esp basename.
-/// A user who renamed the MO2 mod folder for organization (the .esp basename is FIXED — SPID _DISTR / the CSF JSON /
-/// masters bind it) could no longer extend their OWN patch in place. The fix decouples the folder name from the .esp
-/// basename WITHOUT relaxing the ownership marker (this is houseCARL's OWN output — "originals untouched" is not in play;
-/// the marker still gates every touch, so it opens NO foreign-plugin door — that's the separate, unbuilt in-place lane).
+/// and the old into= branch demanded a 3-way name match: into= == mod-folder suffix == .esp basename. A user who renamed
+/// the MO2 mod folder for organization (the .esp basename is FIXED — SPID _DISTR / the CSF JSON / masters bind it) could
+/// no longer extend their OWN patch in place. The fix routes BOTH write lanes — the .esp path (ResolveOutputPath) AND the
+/// rider/asset path (ResolvePatchModFolder: compile / decompile / bsa_repack / place_asset) — through ONE shared 4-step
+/// resolver (ResolveOwnedPatchFolder), decoupling the folder name from the .esp basename WITHOUT relaxing the ownership
+/// marker (this is houseCARL's OWN output; the marker still gates every touch, so it opens NO foreign-plugin door — that's
+/// the separate, unbuilt in-place lane).
 ///
-/// Drives the REAL service write path (LoadOrderService.ApplyEdits) against a synthetic MO2 instance in temp (the
-/// WriteMutexProbe synth pattern). Arms:
-///   CANONICAL   — into="SeedA" still resolves the unchanged "houseCARL - SeedA\SeedA.esp" (zero regression, no scan).
-///   BY-ESP      — after the folder is RENAMED (esp basename unchanged), into=&lt;esp basename&gt; finds the patch by the
-///                 plugin it holds, whatever the folder is now called. RED pre-fix (old: "mod folder not found").
-///   BY-FOLDER   — into=&lt;the renamed folder's name&gt; edits the single .esp inside it, names NEED NOT match. RED pre-fix
-///                 (old: "folder has no '&lt;folder&gt;.esp' to extend").
-///   ACCUMULATED — both resolution paths extended the SAME patch file (the edits accumulate; not a fresh patch).
-///   AMBIGUOUS   — two OWNED folders carry the same &lt;esp&gt; → refuse loud, name BOTH folders + the into="&lt;folder&gt;"
-///                 disambiguator (Q3 — never guess which). Then into=&lt;a folder name&gt; picks one unambiguously.
-///   NOT-FOUND   — into= a name no owned folder holds/answers to → refuse, naming both places searched + "create it fresh".
-///   FOREIGN     — a "houseCARL - X" folder with NO marker is still REFUSED (originals untouched, Q3) and left byte-intact.
-///   ORIGINALS   — the master plugin is byte-untouched throughout (extends only ever wrote the patch folder).
+/// Drives the REAL service write paths against a synthetic MO2 instance in temp (the WriteMutexProbe synth pattern). Arms:
+///   CANONICAL    — into="SeedA" still resolves the unchanged "houseCARL - SeedA\SeedA.esp" (zero regression, no scan).
+///   BY-ESP       — after the folder is RENAMED, into=&lt;esp basename&gt; finds the patch by the plugin it holds. RED pre-fix.
+///   BY-ESP-EXT   — into="SeedA.esp" (with extension) strips the ext and resolves the same renamed patch.
+///   BY-FOLDER    — into=&lt;the renamed folder's name&gt; edits the single .esp inside it, names NEED NOT match. RED pre-fix.
+///   ACCUMULATED  — both .esp resolution paths extended the SAME patch file (the edits accumulate; not a fresh patch).
+///   RIDER        — the SIBLING lane (ResolvePatchModFolder, used by compile/decompile/bsa/place_asset): a renamed patch
+///                  folder resolves by the .esp it holds AND by its new name, returning the reused folder. RED pre-fix
+///                  (the rider branch carried the same untouched 3-way "folder not found" coupling).
+///   AMBIGUOUS    — two OWNED folders carry the same &lt;esp&gt; → refuse loud, name BOTH + the into="&lt;folder&gt;"
+///                  disambiguator (Q3 — never guess). Then into=&lt;a folder name&gt; picks one unambiguously.
+///   MULTI-PLUGIN — into=&lt;a folder holding 2+ plugins&gt; (no &lt;stem&gt;.esp to single out) refuses, naming each plugin.
+///   NOT-FOUND    — into= a name nothing holds/answers to → refuse, naming both places searched + "create it fresh".
+///   FOREIGN      — a "houseCARL - X" folder with NO marker is still REFUSED (originals untouched, Q3) and left byte-intact.
+///   ORIGINALS    — the master plugin is byte-untouched throughout (extends only ever wrote the patch folder).
 /// </summary>
 internal static class ExtendResolveProbe
 {
@@ -93,6 +97,8 @@ internal static class ExtendResolveProbe
             }
             static bool Ends(string path, params string[] parts) =>
                 path.EndsWith(Path.Combine(parts), StringComparison.OrdinalIgnoreCase);
+            void MarkOwned(string folder, string plugin) =>
+                File.WriteAllText(Path.Combine(folder, "meta.ini"), $"[houseCARL]\r\ngenerated=true\r\nplugin={plugin}\r\n");
 
             // ---- SEED: create the patch fresh — "houseCARL - SeedA\SeedA.esp" carrying a Damage=50 override ----
             var seed = svc.ApplyEdits(new[] { Dmg(50) }, "SeedA", null);
@@ -118,6 +124,11 @@ internal static class ExtendResolveProbe
                 var r = svc.ApplyEdits(new[] { Wgt(7) }, null, "SeedA");
                 Check(r.Success && Ends(r.OutputPath, "houseCARL - SeedA Renamed", "SeedA.esp"),
                       $"into=\"SeedA\" finds the RENAMED folder by the .esp it holds (wrote into {Path.GetFileName(Path.GetDirectoryName(r.OutputPath) ?? "")})");
+
+                // into="SeedA.esp" — the .esp extension is stripped and resolves the SAME renamed patch
+                var ext = svc.ApplyEdits(new[] { Wgt(7) }, null, "SeedA.esp");
+                Check(ext.Success && Ends(ext.OutputPath, "houseCARL - SeedA Renamed", "SeedA.esp"),
+                      "into=\"SeedA.esp\" (with extension) strips the ext and resolves the same renamed patch");
             }
 
             // ---- 3: BY-FOLDER — name the renamed folder; the .esp inside need not match (RED pre-fix) ----
@@ -137,13 +148,25 @@ internal static class ExtendResolveProbe
                 Check(dmg == 88 && wgt == 7, $"the renamed patch carries BOTH extends — Damage={dmg} (by-folder), Weight={wgt} (by-esp)");
             }
 
-            // ---- 5: AMBIGUOUS — a second OWNED folder carrying the same esp → refuse loud + name both ----
+            // ---- 5: RIDER lane — the SAME shared resolver serves compile/decompile/bsa/place_asset (RED pre-fix) ----
             Console.WriteLine();
-            Console.WriteLine("--- 5: two owned folders carry the same .esp → ambiguous refusal ---");
+            Console.WriteLine("--- 5: rider/asset lane (ResolvePatchModFolder) resolves the renamed patch too ---");
+            {
+                var byEsp = svc.ResolvePatchModFolder(null, "SeedA", "houseCARL_Archive");
+                Check(!byEsp.CreatedFresh && Ends(byEsp.ModFolder, "houseCARL - SeedA Renamed"),
+                      $"rider into=\"SeedA\" finds the renamed folder by the .esp it holds ({Path.GetFileName(byEsp.ModFolder)}, reused)");
+                var byFolder = svc.ResolvePatchModFolder(null, "SeedA Renamed", "houseCARL_Archive");
+                Check(!byFolder.CreatedFresh && Ends(byFolder.ModFolder, "houseCARL - SeedA Renamed"),
+                      "rider into=\"SeedA Renamed\" (folder name) resolves the same reused folder");
+            }
+
+            // ---- 6: AMBIGUOUS — a second OWNED folder carrying the same esp → refuse loud + name both ----
+            Console.WriteLine();
+            Console.WriteLine("--- 6: two owned folders carry the same .esp → ambiguous refusal ---");
             string dupFolder = Path.Combine(mods, "houseCARL - DupHome");
             {
                 Directory.CreateDirectory(dupFolder);
-                File.WriteAllText(Path.Combine(dupFolder, "meta.ini"), "[houseCARL]\r\ngenerated=true\r\nplugin=SeedA.esp\r\n");
+                MarkOwned(dupFolder, "SeedA.esp");
                 File.Copy(Path.Combine(renamedFolder, "SeedA.esp"), Path.Combine(dupFolder, "SeedA.esp"));
 
                 var r = svc.ApplyEdits(new[] { Wgt(1) }, null, "SeedA");
@@ -154,15 +177,32 @@ internal static class ExtendResolveProbe
                     && r.Error.Contains("into=", StringComparison.Ordinal);
                 Check(!r.Success && named, "into=\"SeedA\" refuses (ambiguous), naming BOTH folders + the into=<folder> disambiguator");
 
-                // the disambiguator: name a folder → resolves to its single .esp unambiguously (names differ)
                 var pick = svc.ApplyEdits(new[] { Wgt(3) }, null, "DupHome");
                 Check(pick.Success && Ends(pick.OutputPath, "houseCARL - DupHome", "SeedA.esp"),
                       "into=\"DupHome\" (folder name) picks ONE despite the shared .esp basename");
             }
 
-            // ---- 6: NOT-FOUND — refuse, naming both places searched + the fresh-write escape ----
+            // ---- 7: MULTI-PLUGIN — into=<folder holding 2+ plugins, none == stem> refuses, naming each ----
             Console.WriteLine();
-            Console.WriteLine("--- 6: into= a name nothing answers to → named refusal ---");
+            Console.WriteLine("--- 7: into=<folder with several plugins> refuses, naming them ---");
+            {
+                string twoEsp = Path.Combine(mods, "houseCARL - TwoEsp");
+                Directory.CreateDirectory(twoEsp);
+                MarkOwned(twoEsp, "Alpha.esp");
+                File.WriteAllText(Path.Combine(twoEsp, "Alpha.esp"), "x");
+                File.WriteAllText(Path.Combine(twoEsp, "Beta.esp"), "y");
+
+                var r = svc.ApplyEdits(new[] { Wgt(1) }, null, "TwoEsp");
+                bool named = r.Error is not null
+                    && r.Error.Contains("2 plugins", StringComparison.Ordinal)
+                    && r.Error.Contains("Alpha.esp", StringComparison.Ordinal)
+                    && r.Error.Contains("Beta.esp", StringComparison.Ordinal);
+                Check(!r.Success && named, "into=\"TwoEsp\" (folder holds Alpha.esp + Beta.esp) refuses, naming both plugins");
+            }
+
+            // ---- 8: NOT-FOUND — refuse, naming both places searched + the fresh-write escape ----
+            Console.WriteLine();
+            Console.WriteLine("--- 8: into= a name nothing answers to → named refusal ---");
             {
                 var r = svc.ApplyEdits(new[] { Wgt(1) }, null, "GhostPatch");
                 bool named = r.Error is not null
@@ -172,9 +212,9 @@ internal static class ExtendResolveProbe
                 Check(!r.Success && named, "into=\"GhostPatch\" refuses, naming the .esp + the folder searched + 'create it fresh'");
             }
 
-            // ---- 7: FOREIGN — an un-owned "houseCARL - X" folder stays REFUSED + byte-untouched (Q3) ----
+            // ---- 9: FOREIGN — an un-owned "houseCARL - X" folder stays REFUSED + byte-untouched (Q3) ----
             Console.WriteLine();
-            Console.WriteLine("--- 7: an un-owned folder is still refused (originals untouched) ---");
+            Console.WriteLine("--- 9: an un-owned folder is still refused (originals untouched) ---");
             {
                 string foreignFolder = Path.Combine(mods, "houseCARL - Foreign");
                 Directory.CreateDirectory(foreignFolder);                                  // NO meta.ini marker → not owned
@@ -188,11 +228,17 @@ internal static class ExtendResolveProbe
                     && r.Error.Contains("originals untouched", StringComparison.OrdinalIgnoreCase);
                 Check(!r.Success && refused, "into=\"Foreign\" (un-owned folder) is REFUSED — houseCARL won't edit a folder it doesn't own");
                 Check(File.ReadAllBytes(foreignEsp).SequenceEqual(foreignBefore), "the un-owned plugin is byte-untouched after the refusal");
+
+                // the rider lane refuses the un-owned folder too (shared resolver — same gate)
+                bool riderRefused = false;
+                try { svc.ResolvePatchModFolder(null, "Foreign", "houseCARL_Archive"); }
+                catch (InvalidOperationException ex) { riderRefused = ex.Message.Contains("NOT created by houseCARL", StringComparison.Ordinal); }
+                Check(riderRefused, "the RIDER lane also refuses the un-owned folder (same ownership gate, no foreign-plugin door)");
             }
 
-            // ---- 8: ORIGINALS — the master plugin never moved a byte (extends only wrote the patch folder) ----
+            // ---- 10: ORIGINALS — the master plugin never moved a byte (extends only wrote the patch folder) ----
             Console.WriteLine();
-            Console.WriteLine("--- 8: the master plugin is byte-untouched throughout ---");
+            Console.WriteLine("--- 10: the master plugin is byte-untouched throughout ---");
             Check(File.ReadAllBytes(masterPath).SequenceEqual(masterBytesAtStart),
                   "the master plugin is byte-identical to its pre-write state (every extend wrote only the patch)");
         }

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -47,6 +47,11 @@ if (args.Length > 0 && args[0] == "floi-fields-guard") return FloiFieldsProbe.Ru
 // (forward a master) + already-winner + multi + into= work, originals untouched, and the 4 Q3 rejects.
 if (args.Length > 0 && args[0] == "forward-from-plugin-guard") return ForwardFromPluginProbe.RunGuard(args[1..]);
 
+// into=-extend RESOLVER (HCBR-2026-06-23): SELF-CONTAINED CI regression guard — a renamed houseCARL mod folder is still
+// found by the .esp basename it holds (the fixed name) AND by the folder name itself (names need not match); two owned
+// folders sharing an .esp refuse loud + disambiguate by folder; an un-owned folder stays refused (originals untouched); the master is byte-untouched.
+if (args.Length > 0 && args[0] == "extend-resolve-guard") return ExtendResolveProbe.RunGuard(args[1..]);
+
 // Author an EMPTY, header-only (trigger) plugin (HCBR-2026-06-19-02): SELF-CONTAINED CI regression guard — core arms
 // write a header-only plugin straight to temp (0 records, 0 masters, ESL flag round-trip, sig TES4, author/desc), and
 // service arms drive the REAL LoadOrderService.CreatePlugin over a synthetic MO2 instance (exact-name no-suffix +

--- a/src/housecarl-mcp/BsaTools.cs
+++ b/src/housecarl-mcp/BsaTools.cs
@@ -129,7 +129,7 @@ public static class BsaTools
             bool compress = false,
         [Description("Optional. Base name for the NEW mod folder the .bsa lands in (default 'houseCARL_Archive'); auto-suffixed if taken.")]
             string? patch_name = null,
-        [Description("Optional. Filename of an existing houseCARL patch mod to place the .bsa into instead of a fresh folder.")]
+        [Description("Optional. Filename of an existing houseCARL patch mod to place the .bsa into instead of a fresh folder. Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead (folder & plugin names need not match).")]
             string? into = null) => Guard.Tool("housecarl_bsa_repack", () =>
     {
         if (string.IsNullOrWhiteSpace(source_folder)) return "error: no source_folder given.";

--- a/src/housecarl-mcp/CompileTools.cs
+++ b/src/housecarl-mcp/CompileTools.cs
@@ -37,7 +37,7 @@ public static class CompileTools
             string? import_dirs = null,
         [Description("Optional. Base name for the NEW patch-mod folder the .pex lands in (default 'houseCARL_Scripts'); auto-suffixed if taken.")]
             string? patch_name = null,
-        [Description("Optional. Filename of an existing houseCARL patch mod to add the .pex into instead of creating a fresh folder (accumulate compiled scripts).")]
+        [Description("Optional. Filename of an existing houseCARL patch mod to add the .pex into instead of creating a fresh folder (accumulate compiled scripts). Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead (folder & plugin names need not match).")]
             string? into = null,
         [Description("Optional. Land the .pex in a folder of YOUR choosing instead of a fresh houseCARL patch folder — pass the mod-folder ROOT; houseCARL appends Scripts\\ (and won't double it if you already point at a ...\\Scripts folder). When set, patch_name=/into= are ignored. If the folder is under neither your MO2 mods folder nor the game's Data, the .pex still compiles but you're warned it won't deploy automatically.")]
             string? output_dir = null) => Guard.Tool("housecarl_compile_script", () =>

--- a/src/housecarl-mcp/DecompileTools.cs
+++ b/src/housecarl-mcp/DecompileTools.cs
@@ -41,7 +41,7 @@ public static class DecompileTools
             string pex,
         [Description("Optional. Base name for the NEW patch-mod folder the .psc lands in (default 'houseCARL_Scripts'); auto-suffixed if taken.")]
             string? patch_name = null,
-        [Description("Optional. Filename of an existing houseCARL patch mod to add the .psc into instead of creating a fresh folder (accumulate sources; pairs with housecarl_compile_script's into=).")]
+        [Description("Optional. Filename of an existing houseCARL patch mod to add the .psc into instead of creating a fresh folder (accumulate sources; pairs with housecarl_compile_script's into=). Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead (folder & plugin names need not match).")]
             string? into = null) => Guard.Tool("housecarl_decompile_script", () =>
     {
         // 1) MO2 must be configured — the .psc lands under the instance's mods folder.

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1539,54 +1539,17 @@ public sealed class LoadOrderService : IDisposable
             if (!string.IsNullOrWhiteSpace(into))
             {
                 extend = true;
-                var stem = PatchStem(into);                         // strips a trailing .esp/.esm/.esl; no directory parts (can't escape ModsDir)
-                var espName = stem + ".esp";
-
-                // (1) CANONICAL fast path — unchanged: the patch still lives in its own "houseCARL - <stem>" folder holding
-                //     <stem>.esp. The common case; no scan, byte-for-byte the prior behavior of every into= call.
-                var canonical = Path.Combine(_modsDir, ModFolderName(stem));
-                if (Directory.Exists(canonical) && IsHouseCarlOwned(canonical) && File.Exists(Path.Combine(canonical, espName)))
-                    return Path.Combine(canonical, espName);
-
-                // (2) Resolve by PLUGIN name — the MO2 mod FOLDER was renamed for organization, but the .esp basename is
-                //     fixed (SPID _DISTR / the CSF JSON / masters all bind the patch by its filename). Find the houseCARL-
-                //     OWNED folder that HOLDS <stem>.esp, whatever the folder is now called. Ownership-gated, so a user mod
-                //     sharing the basename is never touched (originals untouched, Q3 — this opens NO foreign-plugin door).
-                var byEsp = OwnedFoldersHolding(espName);
-                if (byEsp.Count == 1) return byEsp[0];
-                if (byEsp.Count > 1)
-                    throw new InvalidOperationException(
-                        $"cannot extend: {byEsp.Count} houseCARL folders carry '{espName}' — ambiguous, refusing to guess. " +
-                        "Pass the CONTAINING mod-folder name as into= to pick one (folder & plugin names need not match): " +
-                        string.Join("  |  ", byEsp.Select(p => $"into=\"{Path.GetFileName(Path.GetDirectoryName(p)!)}\"")) + ".");
-
-                // (3) FOLDER catch-all — into= NAMES the mod folder itself: the disambiguator for same-named plugins, and the
-                //     way to point at a renamed folder by its new name. Edit the single .esp inside it, whatever it's named.
-                var named = ResolveOwnedFolderByName(into);
-                if (named is not null)
-                {
-                    var sole = SoleEspInFolder(named, out var why);
-                    if (sole is not null) return sole;
-                    throw new InvalidOperationException($"cannot extend: houseCARL folder '{Path.GetFileName(named)}' {why}.");
-                }
-
-                // (4) Nothing matched. Distinguish a FOREIGN (un-owned) name collision — refused for the same reason as ever
-                //     (originals untouched, Q3) — from a genuine miss, and NAME every place searched (the report asked the
-                //     refusal to reveal all the required pieces at once, not one half per failed call).
-                var bareName = Path.GetFileName(into.Trim());
-                foreach (var cand in new[] { ModFolderName(stem), bareName })
-                {
-                    var candPath = string.IsNullOrEmpty(cand) ? null : Path.Combine(_modsDir, cand);
-                    if (candPath is not null && Directory.Exists(candPath) && !IsHouseCarlOwned(candPath))
-                        throw new InvalidOperationException(
-                            $"cannot extend: mod folder '{cand}' exists but was NOT created by houseCARL (no marker) — " +
-                            "refusing to modify a folder houseCARL doesn't own (originals untouched, Q3). Use a different patch name.");
-                }
-                throw new InvalidOperationException(
-                    $"cannot extend: no houseCARL plugin '{espName}' in any houseCARL folder, and no houseCARL folder named " +
-                    $"'{ModFolderName(stem)}'" +
-                    (string.Equals(bareName, ModFolderName(stem), StringComparison.OrdinalIgnoreCase) ? "" : $" or '{bareName}'") +
-                    ". Omit into= to create it fresh, or check the name.");
+                // The .esp write lane shares the 4-step EXTEND resolver with the rider/asset lane (HCBR-2026-06-23) so
+                // "extend my renamed patch" behaves IDENTICALLY across records, scripts, BSAs, and assets. needEsp:true —
+                // the canonical fast path only short-circuits a folder that actually holds <stem>.esp; we then pick the .esp
+                // to extend inside the resolved folder: the <stem>.esp it holds, or — via the by-folder catch-all, where the
+                // folder & plugin names differ — the folder's single plugin (Q3-refuse if it holds none or several).
+                var folder = ResolveOwnedPatchFolder(into, needEsp: true);
+                var direct = Path.Combine(folder, PatchStem(into) + ".esp");
+                if (File.Exists(direct)) return direct;
+                var sole = SoleEspInFolder(folder, out var why);
+                if (sole is not null) return sole;
+                throw new InvalidOperationException($"cannot extend: houseCARL folder '{Path.GetFileName(folder)}' {why}.");
             }
 
             extend = false;
@@ -1649,14 +1612,12 @@ public sealed class LoadOrderService : IDisposable
 
             if (!string.IsNullOrWhiteSpace(into))
             {
-                var stem = PatchStem(into);
-                var folder = Path.Combine(_modsDir, ModFolderName(stem));
-                if (!Directory.Exists(folder))
-                    throw new InvalidOperationException(
-                        $"cannot extend: no houseCARL patch named '{stem}' (mod folder '{ModFolderName(stem)}' not found). Omit into= to create it fresh.");
-                if (!IsHouseCarlOwned(folder))
-                    throw new InvalidOperationException(
-                        $"cannot extend: mod folder '{ModFolderName(stem)}' was NOT created by houseCARL (no marker) — refusing to write into a folder houseCARL doesn't own (Q3).");
+                // The SAME shared 4-step EXTEND resolver as the .esp write path (HCBR-2026-06-23): a renamed houseCARL patch
+                // folder is found by the .esp it holds OR by its new name, so compile / decompile / bsa_repack / place_asset
+                // into= behaves exactly like record into= (before this, a renamed folder fell to a misleading "folder not
+                // found"). needEsp:false — a rider targets the FOLDER itself (it writes scripts / a .bsa / loose files into
+                // it, not an .esp), so it does NOT require a <stem>.esp to be present.
+                var folder = ResolveOwnedPatchFolder(into, needEsp: false);
                 return new RiderFolder(folder, folder, CreatedFresh: false);   // reused — the user owns it; cleanup leaves it
             }
 
@@ -1971,6 +1932,62 @@ public sealed class LoadOrderService : IDisposable
             if (!Directory.Exists(Path.Combine(_modsDir, ModFolderName(cand)))) return cand;
         }
         throw new InvalidOperationException($"too many patches named '{stem}' under ModsDir — clean some out.");
+    }
+
+    /// <summary>The 4-step <c>into=</c> EXTEND resolver, SHARED by the .esp write path (<see cref="ResolveOutputPath"/>)
+    /// and the rider/asset path (<see cref="ResolvePatchModFolder"/>) so "extend my renamed patch" behaves IDENTICALLY
+    /// across records, scripts, BSAs, and assets (HCBR-2026-06-23 — the record lane was fixed first; this closes the
+    /// sibling). Resolves <paramref name="into"/> to the houseCARL-OWNED mod FOLDER it names: (1) the canonical
+    /// "houseCARL - &lt;stem&gt;" fast path; (2) by the &lt;stem&gt;.esp it HOLDS (the folder was renamed — the .esp basename
+    /// is fixed by SPID/CSF/masters); (3) by the folder's OWN name (the catch-all; folder &amp; plugin names need not match);
+    /// (4) loud Q3 refusals naming every place searched, a FOREIGN (un-owned) collision distinguished from a genuine miss.
+    /// Ownership-gated at every step — a plugin houseCARL didn't make stays refused (no foreign-plugin door; that's the
+    /// separate in-place lane). <paramref name="needEsp"/> tightens the canonical fast path for the RECORD lane (the folder
+    /// must actually hold &lt;stem&gt;.esp to short-circuit, else fall through); the rider lane targets the folder itself, so
+    /// it short-circuits on folder-exists+owned. Caller holds <see cref="_gate"/>.</summary>
+    string ResolveOwnedPatchFolder(string into, bool needEsp)
+    {
+        var stem = PatchStem(into);                             // strips a trailing .esp/.esm/.esl; no directory parts (can't escape ModsDir)
+        var espName = stem + ".esp";
+
+        // (1) CANONICAL fast path — "houseCARL - <stem>" still owns the patch (common case; no scan). The record lane also
+        //     requires it to HOLD <stem>.esp (needEsp); the rider lane only needs the owned folder.
+        var canonical = Path.Combine(_modsDir, ModFolderName(stem));
+        if (Directory.Exists(canonical) && IsHouseCarlOwned(canonical) && (!needEsp || File.Exists(Path.Combine(canonical, espName))))
+            return canonical;
+
+        // (2) by PLUGIN name — the owned folder HOLDING <stem>.esp, whatever it's now called (the renamed-folder case).
+        var byEsp = OwnedFoldersHolding(espName)
+            .Select(p => Path.GetDirectoryName(p)!).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        if (byEsp.Count == 1) return byEsp[0];
+        if (byEsp.Count > 1)
+            throw new InvalidOperationException(
+                $"cannot extend: {byEsp.Count} houseCARL folders carry '{espName}' — ambiguous, refusing to guess. " +
+                "Pass the CONTAINING mod-folder name as into= to pick one (folder & plugin names need not match): " +
+                string.Join("  |  ", byEsp.Select(d => $"into=\"{Path.GetFileName(d)}\"")) + ".");
+
+        // (3) FOLDER catch-all — into= NAMES the mod folder itself (the same-named-plugin disambiguator, and the way to
+        //     point at a renamed folder by its new name).
+        var named = ResolveOwnedFolderByName(into);
+        if (named is not null) return named;
+
+        // (4) Nothing matched. Distinguish a FOREIGN (un-owned) name collision — refused for the same reason as ever
+        //     (originals untouched, Q3) — from a genuine miss, NAMING every place searched (the report asked the refusal
+        //     to reveal all the required pieces at once, not one half per failed call).
+        var bareName = Path.GetFileName(into.Trim());
+        foreach (var cand in new[] { ModFolderName(stem), bareName })
+        {
+            var candPath = string.IsNullOrEmpty(cand) ? null : Path.Combine(_modsDir, cand);
+            if (candPath is not null && Directory.Exists(candPath) && !IsHouseCarlOwned(candPath))
+                throw new InvalidOperationException(
+                    $"cannot extend: mod folder '{cand}' exists but was NOT created by houseCARL (no marker) — " +
+                    "refusing to write into a folder houseCARL doesn't own (originals untouched, Q3). Use a different patch name.");
+        }
+        throw new InvalidOperationException(
+            $"cannot extend: no houseCARL plugin '{espName}' in any houseCARL folder, and no houseCARL folder named " +
+            $"'{ModFolderName(stem)}'" +
+            (string.Equals(bareName, ModFolderName(stem), StringComparison.OrdinalIgnoreCase) ? "" : $" or '{bareName}'") +
+            ". Omit into= to create it fresh, or check the name.");
     }
 
     /// <summary>houseCARL-OWNED mod folders under ModsDir holding a plugin file named <paramref name="espFileName"/> at

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1539,21 +1539,54 @@ public sealed class LoadOrderService : IDisposable
             if (!string.IsNullOrWhiteSpace(into))
             {
                 extend = true;
-                var stem = PatchStem(into);
-                var folder = Path.Combine(_modsDir, ModFolderName(stem));
-                if (!Directory.Exists(folder))
+                var stem = PatchStem(into);                         // strips a trailing .esp/.esm/.esl; no directory parts (can't escape ModsDir)
+                var espName = stem + ".esp";
+
+                // (1) CANONICAL fast path — unchanged: the patch still lives in its own "houseCARL - <stem>" folder holding
+                //     <stem>.esp. The common case; no scan, byte-for-byte the prior behavior of every into= call.
+                var canonical = Path.Combine(_modsDir, ModFolderName(stem));
+                if (Directory.Exists(canonical) && IsHouseCarlOwned(canonical) && File.Exists(Path.Combine(canonical, espName)))
+                    return Path.Combine(canonical, espName);
+
+                // (2) Resolve by PLUGIN name — the MO2 mod FOLDER was renamed for organization, but the .esp basename is
+                //     fixed (SPID _DISTR / the CSF JSON / masters all bind the patch by its filename). Find the houseCARL-
+                //     OWNED folder that HOLDS <stem>.esp, whatever the folder is now called. Ownership-gated, so a user mod
+                //     sharing the basename is never touched (originals untouched, Q3 — this opens NO foreign-plugin door).
+                var byEsp = OwnedFoldersHolding(espName);
+                if (byEsp.Count == 1) return byEsp[0];
+                if (byEsp.Count > 1)
                     throw new InvalidOperationException(
-                        $"cannot extend: no houseCARL patch named '{stem}' (mod folder '{ModFolderName(stem)}' not found). " +
-                        "Omit into= to create it fresh, or check the name.");
-                if (!IsHouseCarlOwned(folder))
-                    throw new InvalidOperationException(
-                        $"cannot extend: mod folder '{ModFolderName(stem)}' exists but was NOT created by houseCARL (no marker) — " +
-                        "refusing to modify a folder houseCARL doesn't own (originals untouched, Q3). Use a different patch name.");
-                var existing = Path.Combine(folder, stem + ".esp");
-                if (!File.Exists(existing))
-                    throw new InvalidOperationException(
-                        $"cannot extend: houseCARL folder '{ModFolderName(stem)}' has no '{stem}.esp' to extend.");
-                return existing;
+                        $"cannot extend: {byEsp.Count} houseCARL folders carry '{espName}' — ambiguous, refusing to guess. " +
+                        "Pass the CONTAINING mod-folder name as into= to pick one (folder & plugin names need not match): " +
+                        string.Join("  |  ", byEsp.Select(p => $"into=\"{Path.GetFileName(Path.GetDirectoryName(p)!)}\"")) + ".");
+
+                // (3) FOLDER catch-all — into= NAMES the mod folder itself: the disambiguator for same-named plugins, and the
+                //     way to point at a renamed folder by its new name. Edit the single .esp inside it, whatever it's named.
+                var named = ResolveOwnedFolderByName(into);
+                if (named is not null)
+                {
+                    var sole = SoleEspInFolder(named, out var why);
+                    if (sole is not null) return sole;
+                    throw new InvalidOperationException($"cannot extend: houseCARL folder '{Path.GetFileName(named)}' {why}.");
+                }
+
+                // (4) Nothing matched. Distinguish a FOREIGN (un-owned) name collision — refused for the same reason as ever
+                //     (originals untouched, Q3) — from a genuine miss, and NAME every place searched (the report asked the
+                //     refusal to reveal all the required pieces at once, not one half per failed call).
+                var bareName = Path.GetFileName(into.Trim());
+                foreach (var cand in new[] { ModFolderName(stem), bareName })
+                {
+                    var candPath = string.IsNullOrEmpty(cand) ? null : Path.Combine(_modsDir, cand);
+                    if (candPath is not null && Directory.Exists(candPath) && !IsHouseCarlOwned(candPath))
+                        throw new InvalidOperationException(
+                            $"cannot extend: mod folder '{cand}' exists but was NOT created by houseCARL (no marker) — " +
+                            "refusing to modify a folder houseCARL doesn't own (originals untouched, Q3). Use a different patch name.");
+                }
+                throw new InvalidOperationException(
+                    $"cannot extend: no houseCARL plugin '{espName}' in any houseCARL folder, and no houseCARL folder named " +
+                    $"'{ModFolderName(stem)}'" +
+                    (string.Equals(bareName, ModFolderName(stem), StringComparison.OrdinalIgnoreCase) ? "" : $" or '{bareName}'") +
+                    ". Omit into= to create it fresh, or check the name.");
             }
 
             extend = false;
@@ -1938,6 +1971,53 @@ public sealed class LoadOrderService : IDisposable
             if (!Directory.Exists(Path.Combine(_modsDir, ModFolderName(cand)))) return cand;
         }
         throw new InvalidOperationException($"too many patches named '{stem}' under ModsDir — clean some out.");
+    }
+
+    /// <summary>houseCARL-OWNED mod folders under ModsDir holding a plugin file named <paramref name="espFileName"/> at
+    /// their root — the decoupled resolver behind <c>into=</c>. The .esp basename is FIXED (SPID <c>_DISTR</c>, the CSF
+    /// JSON, and masters all bind the patch by its filename), while the MO2 mod-FOLDER name is the user's to rename for
+    /// organization; so an extend finds the patch by the plugin it holds, not by the folder's current name. Ownership-gated
+    /// (the marker) so a user mod that merely shares the basename is NEVER returned (originals untouched, Q3). Full .esp paths.</summary>
+    List<string> OwnedFoldersHolding(string espFileName)
+    {
+        var hits = new List<string>();
+        foreach (var dir in Directory.EnumerateDirectories(_modsDir))
+        {
+            var esp = Path.Combine(dir, espFileName);
+            if (File.Exists(esp) && IsHouseCarlOwned(dir)) hits.Add(esp);
+        }
+        return hits;
+    }
+
+    /// <summary>A houseCARL-OWNED mod folder named exactly <paramref name="rawName"/> or "<c>houseCARL - &lt;rawName&gt;</c>"
+    /// — the FOLDER catch-all behind <c>into=</c>: the user NAMES the containing mod folder when the plugin basename is
+    /// ambiguous (or to point at a renamed folder by its new name), and the folder name need NOT match the .esp inside.
+    /// Bare name only (no directory parts — can't escape ModsDir). Null when no such folder is houseCARL-owned.</summary>
+    string? ResolveOwnedFolderByName(string rawName)
+    {
+        var bare = Path.GetFileName(rawName.Trim());
+        foreach (var cand in new[] { bare, ModFolderName(PatchStem(rawName)) })
+        {
+            if (string.IsNullOrEmpty(cand)) continue;
+            var folder = Path.Combine(_modsDir, cand);
+            if (Directory.Exists(folder) && IsHouseCarlOwned(folder)) return folder;
+        }
+        return null;
+    }
+
+    /// <summary>The single top-level plugin (.esp/.esm/.esl) in a houseCARL folder, so <c>into=</c> a folder NAME can edit
+    /// "the plugin in this folder" without re-stating its basename. Null + a named <paramref name="reason"/> when the folder
+    /// holds none or more than one (Q3 — never guess which of several to extend).</summary>
+    static string? SoleEspInFolder(string folder, out string reason)
+    {
+        var plugins = Directory.EnumerateFiles(folder)
+            .Where(f => PluginExts.Any(ext => f.EndsWith(ext, StringComparison.OrdinalIgnoreCase)))
+            .ToList();
+        if (plugins.Count == 1) { reason = ""; return plugins[0]; }
+        reason = plugins.Count == 0
+            ? "holds no plugin (.esp/.esm/.esl) to extend"
+            : $"holds {plugins.Count} plugins ({string.Join(", ", plugins.Select(Path.GetFileName))}) — name the one to extend by passing its filename as into=";
+        return null;
     }
 
     /// <summary>A mod folder is houseCARL-owned iff its <c>meta.ini</c> carries the <c>[houseCARL] generated=true</c>

--- a/src/housecarl-mcp/PlaceAssetTools.cs
+++ b/src/housecarl-mcp/PlaceAssetTools.cs
@@ -47,7 +47,7 @@ public static class PlaceAssetTools
             string? source = null,
         [Description("Optional. Base name for the NEW houseCARL mod folder the file lands in (default 'houseCARL_Assets'); auto-suffixed if taken.")]
             string? patch_name = null,
-        [Description("Optional. Filename of an existing houseCARL patch mod to place into instead of a fresh folder (accumulate across calls).")]
+        [Description("Optional. Filename of an existing houseCARL patch mod to place into instead of a fresh folder (accumulate across calls). Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead (folder & plugin names need not match).")]
             string? into = null) => Guard.Tool("housecarl_place_asset", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
@@ -75,7 +75,7 @@ public static class PlaceAssetTools
             PlaceAssetSpec[] assets,
         [Description("Optional. Base name for the NEW houseCARL mod folder (default 'houseCARL_Assets'); auto-suffixed if taken.")]
             string? patch_name = null,
-        [Description("Optional. Filename of an existing houseCARL patch mod to place into instead of a fresh folder.")]
+        [Description("Optional. Filename of an existing houseCARL patch mod to place into instead of a fresh folder. Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead (folder & plugin names need not match).")]
             string? into = null) => Guard.Tool("housecarl_bulk_place_asset", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -44,7 +44,7 @@ public static class WriteTools
             string[]? values = null,
         [Description("Optional. Base filename for the new patch (default 'houseCARL_Patch'); auto-suffixed if taken so a prior patch is never overwritten. Ignored if into= is given.")]
             string patch_name = "houseCARL_Patch",
-        [Description("Optional. Filename of an existing patch (from a prior call) to EXTEND with this edit instead of writing a fresh one — the way to accumulate edits into one patch across calls/sessions.")]
+        [Description("Optional. Filename of an existing patch (from a prior call) to EXTEND with this edit instead of writing a fresh one — the way to accumulate edits into one patch across calls/sessions. Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead (folder & plugin names need not match).")]
             string? into = null,
         [Description("When true, the response ALSO returns the ENTIRE edited record read back from the written patch file on disk (every field, deep — not just the edited leaf). The pre-enable verification: confirm the write landed exactly and nothing else in the record was disturbed, WITHOUT enabling the patch in MO2. (The patch wins nothing until enabled + sorted in MO2 — this read-back is the written file's content, not load-order truth.)")]
             bool full_readback = false,
@@ -81,7 +81,7 @@ public static class WriteTools
             BulkOp[] operations,
         [Description("Optional. Base filename for the new patch (default 'houseCARL_Patch'); auto-suffixed if taken. Ignored if into= is given.")]
             string patch_name = "houseCARL_Patch",
-        [Description("Optional. Filename of an existing patch to EXTEND with these edits instead of writing a fresh one (accumulate across calls/sessions).")]
+        [Description("Optional. Filename of an existing patch to EXTEND with these edits instead of writing a fresh one (accumulate across calls/sessions). Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead (folder & plugin names need not match).")]
             string? into = null,
         [Description("When true, the response ALSO returns the ENTIRE record(s) this call touched, read back from the written patch file on disk (every field, deep — not just the edited leaves). The pre-enable verification: confirm composed structures (conditions, container entries) landed exactly and nothing else in each record was disturbed, WITHOUT enabling the patch in MO2. (The patch wins nothing until enabled + sorted in MO2 — this read-back is the written file's content, not load-order truth.)")]
             bool full_readback = false,
@@ -112,7 +112,7 @@ public static class WriteTools
         LoadOrderService svc,
         [Description("The record's FormID as 'XXXXXX:Plugin.esp' — the record to drop from the patch.")]
             string formid,
-        [Description("Filename of the houseCARL patch to remove the record from (e.g. 'MyMerge.esp' or 'MyMerge') — must be a patch houseCARL created that carries this record.")]
+        [Description("Filename of the houseCARL patch to remove the record from (e.g. 'MyMerge.esp' or 'MyMerge') — must be a patch houseCARL created that carries this record. Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead (folder & plugin names need not match).")]
             string patch) => Guard.Tool("housecarl_remove_record", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
@@ -156,7 +156,7 @@ public static class WriteTools
             string? grid = null,
         [Description("Optional. Base filename for the new patch (default 'houseCARL_Patch'); auto-suffixed if taken. Ignored if into= is given.")]
             string patch_name = "houseCARL_Patch",
-        [Description("Optional. Filename of an existing houseCARL patch to add this new record to instead of writing a fresh one (accumulate across calls/sessions).")]
+        [Description("Optional. Filename of an existing houseCARL patch to add this new record to instead of writing a fresh one (accumulate across calls/sessions). Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead (folder & plugin names need not match).")]
             string? into = null,
         [Description("When true, the response ALSO returns the ENTIRE created record read back from the written patch file on disk (every field, deep — not just the fields you set). The pre-enable verification, WITHOUT enabling the patch in MO2. (The patch wins nothing until enabled + sorted in MO2 — this read-back is the written file's content, not load-order truth.)")]
             bool full_readback = false,
@@ -194,7 +194,7 @@ public static class WriteTools
             CreateOp[] records,
         [Description("Optional. Base filename for the new patch (default 'houseCARL_Patch'); auto-suffixed if taken. Ignored if into= is given.")]
             string patch_name = "houseCARL_Patch",
-        [Description("Optional. Filename of an existing houseCARL patch to add these new records to instead of writing a fresh one (accumulate across calls/sessions).")]
+        [Description("Optional. Filename of an existing houseCARL patch to add these new records to instead of writing a fresh one (accumulate across calls/sessions). Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead (folder & plugin names need not match).")]
             string? into = null,
         [Description("When true, the response ALSO returns each created record IN FULL, read back from the written patch file on disk (every field, deep). The pre-enable verification, WITHOUT enabling the patch in MO2 (the written file's content, not load-order truth).")]
             bool full_readback = false,
@@ -233,7 +233,7 @@ public static class WriteTools
             string from_plugin,
         [Description("Optional. Base filename for the new patch (default 'houseCARL_Patch'); auto-suffixed if taken so a prior patch is never overwritten. Ignored if into= is given.")]
             string patch_name = "houseCARL_Patch",
-        [Description("Optional. Filename of an existing houseCARL patch to ADD these forwards to instead of writing a fresh one (accumulate across calls — e.g. forward from a different source plugin into the same patch).")]
+        [Description("Optional. Filename of an existing houseCARL patch to ADD these forwards to instead of writing a fresh one (accumulate across calls — e.g. forward from a different source plugin into the same patch). Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead (folder & plugin names need not match).")]
             string? into = null,
         [Description("When true, the response ALSO returns each forwarded record IN FULL, read back from the written patch file on disk (every field, deep). The pre-enable verification: confirm the copied version is exactly the source's, WITHOUT enabling the patch in MO2 (the written file's content, not load-order truth).")]
             bool full_readback = false,


### PR DESCRIPTION
## What & why

Closes the gap report `2026-06-23_gap_into-extend-requires-folder-and-esp-name-to-match.md` (HCBR-2026-06-23).

`into=` — on the record lane (`set_field` / `bulk_apply` / `create_record` / `bulk_create` / `forward_record`, `patch=` on `remove_record`) **and** the rider/asset lane (`compile_script` / `decompile_script` / `bsa_repack` / `place_asset` / `bulk_place_asset`) — demanded a **3-way name match**: `into=` == mod-folder suffix after `houseCARL - ` == `.esp` basename. A user who renamed a houseCARL patch's **MO2 mod folder** for organization could no longer extend their **own** patch in place, even though the folder was located and the target `.esp` sat unambiguously inside it. The `.esp` basename is fixed (SPID `_DISTR` / the CSF JSON / masters bind it by name); the folder name is the user's to rename.

## The fix — one shared resolver, both write lanes

There are **two** resolver chokepoints (record `ResolveOutputPath`, rider/asset `ResolvePatchModFolder`). Both now route through one shared `ResolveOwnedPatchFolder(into, needEsp)` that resolves `into=` to the owned mod folder in four steps:
1. **Canonical fast path** — `houseCARL - <stem>`, unchanged (zero regression, no scan).
2. **By plugin name** — the owned folder that *holds* `<stem>.esp`, whatever the folder is now named.
3. **Folder catch-all** — `into=` the mod-folder name (**names need not match**).
4. **Ambiguous** — two owned folders sharing an `.esp` refuse loud, name both, and give the `into="<folder>"` disambiguator (Q3 — never guess).

Records pass `needEsp:true` (canonical only short-circuits a folder holding `<stem>.esp`; the `.esp` inside is then picked); riders pass `needEsp:false` (they target the folder itself). A genuine miss names every place searched.

## Safety — no foreign-plugin door

Every step still requires the `IsHouseCarlOwned` marker, so a plugin houseCARL did **not** make stays refused (originals untouched, Q3) — across **both** lanes. Editing a foreign plugin in place is the separate, sanctioned-but-unbuilt in-place lane (`dev/plans/IN_PLACE_WRITE_LANE_PLAN_2026-06-13.md`), flagged for the next session — untouched here.

## Tests

New self-contained **`extend-resolve-guard`** (14 arms): canonical / by-esp / by-esp-with-extension / by-folder / accumulate-into-one-patch / **rider lane (`ResolvePatchModFolder` by-esp + by-folder, reused-not-fresh)** / ambiguous + disambiguate / **multi-plugin refusal** / not-found / **foreign-folder refused on both lanes (byte-untouched)** / master-untouched. The 6 record + 5 rider `into=`/`patch=` tool descriptions updated.

`write-mutex` (dotted-name, `into=` extend, rider-residue), `forward-from-plugin` (`into=` extend), and `create-plugin` guards stay green — no regression. Rebased cleanly on the `housecarl_effect_chain` merge (#107).

## Review fold (commit 2)

Independent review flagged that the first commit fixed the **record** lane only and over-claimed "one chokepoint" — the rider/asset lane had the same bug (a renamed patch failing `compile_script`/`place_asset` with a misleading "folder not found", on the facegen lane especially). Per Aaron, folded the rider lane in: the shared resolver above, the 5 rider descriptions, and the rider / multi-plugin / extension test arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
