### PR TITLE
feat: in-place write lane Wave 1 — edit an existing plugin in place

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,18 @@ jobs:
       - name: Probe — active-patch write self-lock (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- writelock-guard
 
+      # Self-contained (synthesizes a master + a user override + a higher override in temp — no game data), runs fully
+      # here: the in-place write lane Wave 1 (set_field/bulk_apply target=+in_place=true edits the user's ORIGINAL file).
+      # Drives the REAL WritePatchBuilder.ApplyInPlace + LoadOrderService in-place branch and RED-proves every safety
+      # property: content sourced from the TARGET not the load-order winner (no foreign-content injection) + refuse-if-
+      # undefined, the author's NextObjectID + master list preserved verbatim (WriteInPlace ≠ the patch-lane floor/baseline),
+      # the flat self-lock (winner==target, ReleaseOverlay before the swap), the persistent first-touch consent handshake
+      # (RED refuse → acknowledge writes → no re-prompt → persists cross-session via UserConfig), the resolver refusing a
+      # non-load-order target, the in_place⇔target / ⊥ into= contract, and opt-in-by-construction (params default OFF).
+      # The NESTED-record lock arm needs a real master, so it's the manual inplace-nested-proof (self-skips here).
+      - name: Probe — in-place write lane Wave 1 (self-contained regression guard)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- inplace-guard
+
       # Self-contained (synthesizes a corrupted-EPFT perk — no external files), runs fully here AND drives the REAL
       # service-layer scan (the first CI coverage of the mcp layer): a regression guard locking in the references=
       # per-record fault isolation + unscannable accounting (HCBR-2026-06-09-03).

--- a/src/housecarl-core/UserConfig.cs
+++ b/src/housecarl-core/UserConfig.cs
@@ -20,6 +20,15 @@ public sealed class UserConfig
     /// <summary>External-tool paths the bridge saved, keyed by tool wire-name (papyrus_compiler, bsarch, papyrus_logs,
     /// crash_logs) → an absolute file/dir path. Null/absent until housecarl_set_tool_path is first called.</summary>
     public Dictionary<string, string>? ToolPaths { get; set; }
+
+    /// <summary>Resolved on-disk plugin paths (normalized, lower-cased full paths) the user has acknowledged for
+    /// IN-PLACE editing — the PERSISTENT, cross-session first-touch handshake of the in-place write lane. A path present
+    /// here means the user accepted that houseCARL writes that ORIGINAL file in place (it will no longer be untouched);
+    /// it waives the CONSENT axis ONLY, never the touched-record verify (a tool-capability fact no acknowledgement can
+    /// override). Null/absent until the first in-place acknowledgement. The third independent concern in this file —
+    /// like the other two it is read-modify-written ONLY through <see cref="UserConfigStore.Update"/> so it can never
+    /// clobber (or be clobbered by) the MO2 instance / tool paths.</summary>
+    public List<string>? InPlaceAcknowledged { get; set; }
 }
 
 /// <summary>
@@ -114,6 +123,43 @@ public sealed class UserConfigStore
             }
             catch (Exception ex) { return (false, ex.Message, note); }
         });
+    }
+
+    /// <summary>True iff <paramref name="pluginPath"/> already carries a PERSISTED in-place acknowledgement — the
+    /// cross-session first-touch handshake (in-place write lane). Normalized full-path compare, so a file is identified
+    /// the same way it was recorded regardless of the caller's path spelling. FAIL-SAFE (Q3): a missing / unreadable /
+    /// corrupt config reads as NOT acknowledged, so the handshake re-prompts rather than silently proceeding to write a
+    /// user's original. Waives the CONSENT axis only — the touched-record verify still runs.</summary>
+    public bool IsInPlaceAcknowledged(string pluginPath)
+    {
+        var key = NormalizePath(pluginPath);
+        var ack = Load().InPlaceAcknowledged;
+        return ack is not null && ack.Any(p => string.Equals(NormalizePath(p), key, StringComparison.Ordinal));
+    }
+
+    /// <summary>PERSIST an in-place acknowledgement for <paramref name="pluginPath"/> (idempotent — never duplicated),
+    /// through the same atomic read-modify-write as every other field so it can never clobber the MO2 instance / tool
+    /// paths sharing this file. Returns (ok, error): a write failure is RETURNED, not thrown (Q3 — the caller can tell
+    /// the user the edit proceeded but the acknowledgement won't survive a restart, so the next session re-prompts).</summary>
+    public (bool ok, string? error) RecordInPlaceAcknowledged(string pluginPath)
+    {
+        var key = NormalizePath(pluginPath);
+        var (ok, error, _) = Update(cfg =>
+        {
+            cfg.InPlaceAcknowledged ??= new List<string>();
+            if (!cfg.InPlaceAcknowledged.Any(p => string.Equals(NormalizePath(p), key, StringComparison.Ordinal)))
+                cfg.InPlaceAcknowledged.Add(key);
+        });
+        return (ok, error);
+    }
+
+    /// <summary>Canonical identity for an in-place acknowledgement: the full, lower-cased path, so the same on-disk file
+    /// matches whatever path spelling reaches the check. Best-effort — an un-rootable string falls back to a trimmed
+    /// lower-case compare rather than throwing (the worst case is a redundant re-prompt, never a wrong waiver).</summary>
+    static string NormalizePath(string p)
+    {
+        try { return Path.GetFullPath(p).ToLowerInvariant(); }
+        catch { return p.Trim().ToLowerInvariant(); }
     }
 
     /// <summary>The tolerant-but-LOUD read (hunt F3): missing ⇒ blank, parseable ⇒ as saved, CORRUPT ⇒ back the file up

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1535,6 +1535,63 @@ public static class WriteEngine
         catch (IOException) { } catch (UnauthorizedAccessException) { }
     }
 
+    /// <summary>Serialize a plugin edited IN PLACE back over ITSELF — the model-C, xEdit-parity re-emit the Wave 0
+    /// round-trip probe validated (in-place write lane, <c>WritePatchBuilder.ApplyInPlace</c>). DELIBERATELY NOT
+    /// <see cref="WritePatch"/>: in-place re-emits an EXISTING authored plugin, so it must NOT apply WritePatch's
+    /// NEW-patch conventions — no Skyrim.esm/Update.esm baseline force-include (<see cref="WritePatch"/>'s
+    /// <c>WithExtraIncludedMasters</c> would ADD masters the author never declared, reindexing the file) and no
+    /// <see cref="EnsureFormIdFloor"/> (<c>NoNextFormIDProcessing</c> persists the author's <c>HEDR.NextObjectID</c>
+    /// verbatim). This is EXACTLY the probe's incantation (<c>RoundTripProbe</c>: <c>.WithLoadOrder(&lt;own declared
+    /// masters&gt;).NoNextFormIDProcessing().Write()</c>) — the surface against which model C ("verify the touched
+    /// records, trust Mutagen for the rest") was measured (~80% benign reorder, ZERO record drops), so routing in-place
+    /// through it (not WritePatch) is what makes that result actually transfer. <paramref name="ownMasters"/> is the
+    /// target's OWN declared masters, resolved to overlays in load order (Mutagen orders + lean-derives the list exactly
+    /// as it did for the probe). Stage + crash-atomic swap (<see cref="AtomicFile.Commit"/>) is shared with the patch
+    /// lane, so the original only ever holds the OLD or the NEW complete file. The caller MUST already hold the PR #24
+    /// self-lock discipline (every overlay it holds on the target released) — here on a FOREIGN target.</summary>
+    public static void WriteInPlace(SkyrimMod targetMod, IReadOnlyList<ISkyrimModGetter> ownMasters, string outputPath)
+    {
+        var expected = targetMod.ModKey.FileName.String;
+        var actual = Path.GetFileName(outputPath);
+        if (!string.Equals(expected, actual, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException(
+                $"In-place output filename '{actual}' must match the target's ModKey filename '{expected}'.");
+        Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+        var ordered = ownMasters as ISkyrimModGetter[] ?? ownMasters.ToArray();
+        // Same composed-null-arm serialize guard as WritePatch (an in-place edit can compose a record too): a required
+        // polymorphic sub-field left null surfaces as a bare NRE at the writer deref — re-stamp ONLY that as a NAMED
+        // refusal; the staged temp is already discarded on any throw (nothing on disk), original byte-intact.
+        string staged;
+        try { staged = WriteInPlaceStaged(targetMod, ordered, outputPath); }
+        catch (NullReferenceException ex) { throw new NullArmSerializeException(ex); }
+        CommitStagedPatch(staged, outputPath);
+    }
+
+    /// <summary>Stage 1 of the in-place write — the probe-faithful re-serialize: own declared masters as the load order,
+    /// the counter persisted verbatim (<c>NoNextFormIDProcessing</c>, NO floor), NO baseline force-include. Stages into
+    /// the <c>.housecarl-tmp</c> sibling of the target (same parent ⇒ same NTFS volume ⇒ the stage-2 swap is atomic),
+    /// and cleans its temp on a serialize failure (Q3 — a failed stage leaves no residue, the original untouched).</summary>
+    static string WriteInPlaceStaged(SkyrimMod targetMod, ISkyrimModGetter[] ordered, string outputPath)
+    {
+        var tmpDir = Path.Combine(Path.GetDirectoryName(outputPath)!, ".housecarl-tmp");
+        var tmpPath = Path.Combine(tmpDir, Path.GetFileName(outputPath));
+        Directory.CreateDirectory(tmpDir);
+        try
+        {
+            targetMod.BeginWrite
+                .ToPath(tmpPath)
+                .WithLoadOrder(ordered)            // the target's OWN masters (no whole-order, no baseline) — the probe's set
+                .NoNextFormIDProcessing()          // persist the author's NextObjectID verbatim (no EnsureFormIdFloor)
+                .Write();
+            return tmpPath;
+        }
+        catch
+        {
+            CleanupStaged(tmpPath);
+            throw;
+        }
+    }
+
     /// <summary>The base-game masters EVERY Skyrim plugin must carry — Skyrim.esm + Update.esm, exactly what the Creation
     /// Kit stamps on every plugin (Aaron 2026-06-02: "if ck stamps both then we should too"). Force-included on every
     /// <see cref="WritePatch(SkyrimMod, IReadOnlyList{ISkyrimModGetter},string)"/> via WithExtraIncludedMasters so even a

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -70,8 +70,30 @@ public static class WritePatchBuilder
     {
         public IReadOnlyList<FullReadback>? ReadBack { get; init; }
 
+        /// <summary>True ⇒ this outcome came from the IN-PLACE lane (<see cref="Apply"/>'s sibling
+        /// <see cref="ApplyInPlace"/>) — the edits landed in the USER's own file at <see cref="OutputPath"/>, not a new
+        /// patch. Drives the distinct "edited in place" confirmation (and the "no undo; keep your own backup" note).</summary>
+        public bool InPlace { get; init; }
+
+        /// <summary>True ⇒ NOT a write and NOT an error: the server-enforced first-touch in-place CONSENT handshake. The
+        /// in-place lane refused to write this plugin until the user acknowledges the trade-off; <see cref="Error"/>
+        /// carries the prompt verbatim (re-call with acknowledge=true). Rendered as a confirmation prompt, never "error:"
+        /// (Q3 — a required confirmation is not a failure). Nothing was written; the original is untouched.</summary>
+        public bool NeedsAcknowledge { get; init; }
+
+        /// <summary>An optional Q3 honesty note appended to a SUCCESSFUL outcome — a side effect that didn't land cleanly
+        /// even though the write did (e.g. the in-place acknowledgement couldn't be persisted, or the editedInPlace audit
+        /// marker couldn't be written). Null when there's nothing to add.</summary>
+        public string? Note { get; init; }
+
         public static PatchOutcome Fail(string error) =>
             new(false, error, "", false, Array.Empty<string>(), Array.Empty<OpResult>(), 0);
+
+        /// <summary>The first-touch in-place consent handshake: no write, no error — a required confirmation carrying the
+        /// trade-off <paramref name="prompt"/> (the caller re-calls with acknowledge=true). Success=false so no
+        /// downstream success path runs; <see cref="NeedsAcknowledge"/> tells the renderer to show it as a prompt.</summary>
+        public static PatchOutcome NeedsAck(string prompt) =>
+            new(false, prompt, "", false, Array.Empty<string>(), Array.Empty<OpResult>(), 0) { NeedsAcknowledge = true };
     }
 
     /// <summary>One record dropped by <see cref="RemoveRecords"/> — its FormKey, the catalog type, and the editorid (if
@@ -324,6 +346,187 @@ public static class WritePatchBuilder
         finally { (back as IDisposable)?.Dispose(); }
 
         return new PatchOutcome(true, null, outPath, extend, masters, ops, bytes) { ReadBack = readBack };
+    }
+
+    /// <summary>
+    /// EDIT records IN PLACE inside an EXISTING plugin the user owns — the opt-in second write lane (in-place write
+    /// lane, Wave 1), the sibling of <see cref="Apply"/>. Where <see cref="Apply"/> overrides the load-order WINNER into
+    /// a NEW patch (originals untouched), this opens the TARGET plugin itself mutably, edits the TARGET's OWN record, and
+    /// re-serializes the whole plugin back over itself — the user's original file IS the output. Three deliberate
+    /// divergences from <see cref="Apply"/>, each load-bearing:
+    /// <list type="bullet">
+    /// <item>CONTENT SOURCE (§4.1 winner-injection fix): the body is the TARGET's own record
+    /// (<c>view.GetRecord(session, target, fk)</c>), NEVER the load-order winner — and the call REFUSES loud if the
+    /// target doesn't itself define/override the FormKey ("in-place edits only what the file OWNS"). So pre-flight
+    /// validates the body actually mutated, and another mod's content can never be injected into the user's file.</item>
+    /// <item>DESTINATION: <paramref name="targetPath"/> IS the target's real on-disk path (the caller resolved it via
+    /// the load order, dropping the houseCARL-owned gate); the mutable mod IS the target (CreateFromBinary), so
+    /// <see cref="WriteEngine.GenericGetOrAddAsOverride"/> returns the target's OWN record (get-semantics).</item>
+    /// <item>SERIALIZE (model C — what the Wave 0 probe validated, NOT <see cref="WriteEngine.WritePatch"/>):
+    /// <see cref="WriteEngine.WriteInPlace"/> re-emits with the target's OWN declared masters, no baseline force-include,
+    /// no FormID floor — preserving the author's master list + NextObjectID as xEdit/CK do on save.</item>
+    /// </list>
+    /// The reused full read-back (<paramref name="fullReadback"/>, default ON here) VERIFIES the records actually touched
+    /// landed; Mutagen is trusted for the rest (the xEdit-parity bar). CONSENT + the persistent acknowledge handshake are
+    /// enforced by the SERVICE before this is reached — this is the mechanism. All-or-nothing (Q3): any resolve/pre-flight
+    /// reject, or a serialize failure, leaves the original file UNTOUCHED (staged temp + atomic swap).
+    /// </summary>
+    public static PatchOutcome ApplyInPlace(
+        LoadOrderResolver resolver, CorpusRulebook rulebook,
+        IReadOnlyList<PatchEdit> edits, string targetPath, string targetName, bool fullReadback = true)
+    {
+        if (edits.Count == 0) return PatchOutcome.Fail("no edits supplied.");
+
+        // Per-call overlay session (Option B), same as Apply: every read (the target's own bodies, the nested link
+        // cache) is opened THROUGH it and disposed when the method returns — no handle held at rest.
+        using var session = resolver.OpenSession();
+        var fileName = Path.GetFileName(targetPath);
+
+        // --- Phase 1: resolve each edit's body FROM THE TARGET (not the winner) + derive type + pre-flight. The §4.1
+        //     content-source guard. ONE captured view answers every edit (the hunt-F5 one-view discipline). ---
+        var view = resolver.Capture();
+        if (!view.ContainsPlugin(targetName))
+            return PatchOutcome.Fail($"in-place target '{targetName}' is not an active plugin in the load order.");
+        if (view.ExcludedPlugins.TryGetValue(targetName, out var excluded))
+            return PatchOutcome.Fail(
+                $"cannot edit '{targetName}' in place: it was EXCLUDED from this session ({excluded}) — houseCARL won't " +
+                "re-serialize a plugin it can't fully parse (that would risk dropping the record it couldn't read, Q3). The file is UNTOUCHED.");
+
+        var resolved = new List<(PatchEdit edit, IMajorRecordGetter body, WriteRequest req, string label)>(edits.Count);
+        var problems = new List<string>();
+        foreach (var e in edits)
+        {
+            var body = view.GetRecord(session, targetName, e.Target);
+            if (body is null)
+            {
+                problems.Add($"{e.Target}: '{targetName}' does not define or override this record — in-place edits only what the " +
+                             "file OWNS. To change a record defined in another plugin, use the default patch lane (a new override) instead.");
+                continue;
+            }
+            var recType = RecordNaming.StripOverlay(body.GetType().Name);
+            var req = new WriteRequest
+            {
+                RecordType = recType, Path = e.Path, Verb = e.Verb,
+                Key = e.Key, Value = e.Value, Values = e.Values, Entries = e.Entries, Struct = e.Struct,
+            };
+            var label = Label(req);
+            if (rulebook.Validate(req) is { } reject) { problems.Add($"{recType} {e.Target} [{label}]: {reject}"); continue; }
+            resolved.Add((e, body, req, label));
+        }
+        if (problems.Count > 0)
+            return PatchOutcome.Fail(
+                $"refused — {problems.Count} of {edits.Count} edit(s) rejected by resolve/pre-flight; '{fileName}' is UNTOUCHED:\n  - "
+                + string.Join("\n  - ", problems));
+
+        // --- Phase 2: open the TARGET mutably. EAGER, the SINGLE plugin only — NEVER the load order (the legacy 12–14 GB
+        //     RAM trap; CLAUDE.md §1). CreateFromBinary is the same call Apply's extend path uses; an unparseable plugin
+        //     throws here and is REFUSED, never silently re-emitted minus the record Mutagen couldn't read (Q3). ---
+        if (!File.Exists(targetPath))
+            return PatchOutcome.Fail($"in-place target '{fileName}' not found on disk at {targetPath} — the file is untouched.");
+        SkyrimMod targetMod;
+        try { targetMod = SkyrimMod.CreateFromBinary(targetPath, SkyrimRelease.SkyrimSE); }
+        catch (Exception ex)
+            { return PatchOutcome.Fail($"cannot open '{fileName}' to edit in place ({WriteEngine.Describe(ex)}) — a plugin Mutagen can't parse is refused, not re-emitted minus what it couldn't read (Q3). The file is UNTOUCHED."); }
+        if (!string.Equals(targetMod.ModKey.FileName.String, fileName, StringComparison.OrdinalIgnoreCase))
+            return PatchOutcome.Fail($"in-place ModKey '{targetMod.ModKey.FileName}' must match the target filename '{fileName}'.");
+
+        // --- Phase 3: apply each verb to the TARGET's OWN record. GenericGetOrAddAsOverride on the target's own body
+        //     (already present in targetMod) returns THAT record (get-semantics) — the verb edits the file's own body,
+        //     never a foreign override's. A nested record gets the target overlay's link cache on demand (released in
+        //     Phase 4). A throw after pre-flight passed is a real engine inconsistency — fail the WHOLE call (Q3). ---
+        var ops = new List<OpResult>(resolved.Count);
+        foreach (var (e, body, req, label) in resolved)
+        {
+            try
+            {
+                ILinkCache? cache = WriteEngine.RecordNeedsSourceCache(body) ? session.LinkCacheFor(targetName) : null;
+                var ov = WriteEngine.GenericGetOrAddAsOverride(targetMod, body, cache);
+                WriteEngine.ApplyVerb(ov, req);
+                ops.Add(new OpResult(e.Target, req.RecordType, label, true, null, TryReadAfter(ov, req)));
+            }
+            catch (ExpectedApplyRejectionException ex)
+            {
+                return PatchOutcome.Fail(
+                    $"refused applying [{label}] to {req.RecordType} {e.Target} — {ex.Message} (the file is untouched)");
+            }
+            catch (MalformedTargetDataException ex)
+            {
+                return PatchOutcome.Fail(
+                    $"refused applying [{label}] to {req.RecordType} {e.Target} — {ex.Message} (the file is untouched)");
+            }
+            catch (Exception ex)
+            {
+                return PatchOutcome.Fail(
+                    $"engine error applying [{label}] to {req.RecordType} {e.Target}: pre-flight ACCEPTED it but the apply " +
+                    $"threw — a real inconsistency, surfaced not swallowed (Q3): {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+
+        // --- Phase 4: re-serialize the WHOLE target back over itself (model C — the probe's incantation via WriteInPlace,
+        //     NOT WritePatch). Release the target overlay first (the winner-IS-the-target common case made common — the
+        //     two-part self-lock guard, here on a FOREIGN target: ReleaseOverlay disposes every session overlay on the
+        //     target, flat via GetRecord and nested via LinkCacheFor, before the File.Replace). Resolve the target's own
+        //     declared masters to overlays for a faithful re-emit; dispose them after the write. ---
+        session.ReleaseOverlay(fileName);
+        var masterOverlays = new List<IDisposable>();
+        try
+        {
+            ISkyrimModGetter[] ownMasters = ResolveOwnMasters(view, targetMod, masterOverlays, out var missing);
+            if (missing is not null) return PatchOutcome.Fail(missing);
+            try { WriteEngine.WriteInPlace(targetMod, ownMasters, targetPath); }
+            catch (Exception ex)
+                { return PatchOutcome.Fail($"writing '{fileName}' in place failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}"); }
+        }
+        finally { foreach (var d in masterOverlays) { try { d.Dispose(); } catch { /* best-effort; never mask the write result */ } } }
+
+        // --- Phase 5: re-open the now-edited file and report its master header — and the touched-record verify (default
+        //     ON for in-place): each edited record read back IN FULL off the on-disk bytes (the model-C substitute for
+        //     the dropped whole-plugin floor — confirm what you TOUCHED landed; Mutagen is trusted for the rest). ---
+        IReadOnlyList<string> masters = Array.Empty<string>();
+        IReadOnlyList<FullReadback>? readBack = null;
+        long bytes = 0;
+        ISkyrimModGetter? back = null;
+        try
+        {
+            back = SkyrimMod.CreateFromBinaryOverlay(targetPath, SkyrimRelease.SkyrimSE);
+            masters = back.ModHeader.MasterReferences.Select(m => m.Master.FileName.ToString()).ToList();
+            bytes = new FileInfo(targetPath).Length;
+            if (fullReadback) readBack = ReadBackInFull(back, resolved.Select(r => r.edit.Target));
+        }
+        catch (Exception ex)
+            { return PatchOutcome.Fail($"'{fileName}' was edited in place but could not be re-opened to verify: {ex.Message}"); }
+        finally { (back as IDisposable)?.Dispose(); }
+
+        return new PatchOutcome(true, null, targetPath, false, masters, ops, bytes) { ReadBack = readBack, InPlace = true };
+    }
+
+    /// <summary>Resolve the target's OWN declared masters to on-disk overlays in declared order — the load order
+    /// <see cref="WriteEngine.WriteInPlace"/> hands Mutagen (the probe's faithful set). Each master filename resolves to
+    /// its WINNING on-disk path via the order (<see cref="LoadOrderResolver.IndexView.PluginPath"/>); a declared master
+    /// ABSENT from the active order makes <paramref name="missing"/> a loud Q3 refusal (re-serializing would leave the
+    /// target's references unresolvable) rather than emit a broken plugin. Opened overlays are added to
+    /// <paramref name="overlays"/> for the caller to dispose after the write.</summary>
+    static ISkyrimModGetter[] ResolveOwnMasters(
+        LoadOrderResolver.IndexView view, SkyrimMod targetMod, List<IDisposable> overlays, out string? missing)
+    {
+        missing = null;
+        var resolved = new List<ISkyrimModGetter>();
+        foreach (var mr in targetMod.ModHeader.MasterReferences)
+        {
+            var mfn = mr.Master.FileName.String;
+            var mpath = view.PluginPath(mfn);
+            if (mpath is null)
+            {
+                missing = $"cannot edit '{targetMod.ModKey.FileName}' in place: its declared master '{mfn}' is not active in the " +
+                          "load order, so a faithful re-serialize can't resolve the references into it. Enable that master (or fix " +
+                          "the target's masters in xEdit) first. The file is UNTOUCHED.";
+                return Array.Empty<ISkyrimModGetter>();
+            }
+            var ov = SkyrimMod.CreateFromBinaryOverlay(mpath, SkyrimRelease.SkyrimSE);
+            overlays.Add((IDisposable)ov);
+            resolved.Add(ov);
+        }
+        return resolved.ToArray();
     }
 
     /// <summary>

--- a/src/housecarl-generator/InPlaceProbe.cs
+++ b/src/housecarl-generator/InPlaceProbe.cs
@@ -1,0 +1,354 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SELF-CONTAINED CI REGRESSION GUARD for the IN-PLACE WRITE LANE, Wave 1 (dev/plans/IN_PLACE_WRITE_LANE_PLAN_2026-06-13.md
+/// §10 CI teeth). The in-place lane (set_field/bulk_apply with target=+in_place=true) edits an EXISTING plugin the user
+/// owns — incl. one houseCARL didn't author — back over itself, instead of writing a new patch. It is the one write lane
+/// that touches the user's ORIGINAL file, so the safety properties are load-bearing and each is RED-provable here:
+///
+///   CONTENT-SOURCE (§4.1)  — the edit's body is the TARGET's OWN record, NEVER the load-order winner; a record the
+///                            target doesn't define is REFUSED (no foreign content injected). RED if sourced from winner.
+///   COUNTER PRESERVED      — the author's HEDR.NextObjectID survives verbatim (WriteInPlace skips EnsureFormIdFloor). RED
+///                            if the patch-lane floor ran (a sub-0x800 author counter would jump to 0x800).
+///   MASTERS PRESERVED      — no Skyrim.esm/Update.esm baseline force-include (WriteInPlace ≠ WritePatch). RED if baseline added.
+///   FLAT LOCK (winner==target) — re-editing a record the ACTIVE target itself owns: Phase-1 fetch opens the target
+///                            overlay, ReleaseOverlay must close it before the File.Replace swap. RED if it stays mapped.
+///   CONSENT HANDSHAKE      — first in-place touch of a plugin REFUSES-and-explains (writes nothing); acknowledge=true
+///                            proceeds; a second edit does NOT re-prompt (persisted, cross-session via UserConfig).
+///   RESOLVER / CONTRACT    — target= resolves the REAL active-plugin path (a non-load-order name REFUSES, never
+///                            retargets); in_place needs target=, is mutually exclusive with into=; opt-in defaults OFF.
+///
+/// Self-contained: synthesizes a master + a user override + a higher override in TEMP and generates the validator corpus
+/// BY CONSTRUCTION in-process (no game data, no checked-in corpus.json). Drives the REAL WritePatchBuilder.ApplyInPlace
+/// (builder arms) and the REAL LoadOrderService.ApplyEdits in-place branch (service arms, via the ForGuard seam).
+/// Run: dotnet run --project src/housecarl-generator inplace-guard
+///
+/// The NESTED lock arm (the LinkCacheFor-on-a-foreign-target path) needs a real nested record + master, so it lives in
+/// <see cref="RunNestedProof"/> (real Skyrim.esm; self-skips on the CI runner), the same posture as writelock-nested-proof.
+/// </summary>
+public static class InPlaceProbe
+{
+    const string MasterName = "HcInPlaceMaster.esm";
+    const string UserName = "HcInPlaceUser.esp";
+    const string HighName = "HcInPlaceHigh.esp";
+
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  REGRESSION GUARD — in-place write lane, Wave 1  ################");
+        Console.WriteLine();
+
+        var tmpDir = Path.Combine(Path.GetTempPath(), "hc-inplace-guard");
+        if (Directory.Exists(tmpDir)) Directory.Delete(tmpDir, recursive: true);
+        Directory.CreateDirectory(tmpDir);
+
+        // Corpus BY CONSTRUCTION (the edits pre-flight through the CorpusRulebook); point the SERVICE's lazy Load() at it too.
+        var corpusPath = GenerateCorpus(tmpDir);
+        CorpusRulebook.CorpusPath = corpusPath;
+        var rulebook = CorpusRulebook.Load(corpusPath);
+
+        // ---- Setup: a master weapon, a USER override (Damage=20, Name="UserSword", a deliberately sub-0x800 author
+        //      counter 0x123), and a HIGHER override (Damage=99, Name="HighSword"). A SECOND master-only weapon the user
+        //      never overrides feeds the refuse-if-undefined arm. ----
+        string masterPath = Path.Combine(tmpDir, MasterName);
+        string userPristine = Path.Combine(tmpDir, "pristine", UserName);
+        string highPath = Path.Combine(tmpDir, HighName);
+        Directory.CreateDirectory(Path.GetDirectoryName(userPristine)!);
+
+        var masterKey = new ModKey("HcInPlaceMaster", ModType.Master);
+        FormKey wfk, w2fk;
+        {
+            var m = new SkyrimMod(masterKey, SkyrimRelease.SkyrimSE);
+            var w = m.Weapons.AddNew(); w.EditorID = "HcIP_Weap"; w.BasicStats = new WeaponBasicStats { Damage = 10 }; w.Name = "MasterSword";
+            var w2 = m.Weapons.AddNew(); w2.EditorID = "HcIP_Weap2"; w2.BasicStats = new WeaponBasicStats { Damage = 5 };
+            wfk = w.FormKey; w2fk = w2.FormKey;
+            m.BeginWrite.ToPath(masterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+        }
+        using (var mOv = SkyrimMod.CreateFromBinaryOverlay(masterPath, SkyrimRelease.SkyrimSE))
+        {
+            var u = new SkyrimMod(new ModKey("HcInPlaceUser", ModType.Plugin), SkyrimRelease.SkyrimSE);
+            var uw = u.Weapons.GetOrAddAsOverride(mOv.Weapons.First(x => x.FormKey == wfk));
+            uw.BasicStats!.Damage = 20; uw.Name = "UserSword";
+            u.ModHeader.Stats.NextFormID = 0x123;                       // a distinctive, deliberately sub-0x800 author counter
+            u.BeginWrite.ToPath(userPristine).WithLoadOrder(new ISkyrimModGetter[] { mOv }).NoNextFormIDProcessing().Write();
+
+            var h = new SkyrimMod(new ModKey("HcInPlaceHigh", ModType.Plugin), SkyrimRelease.SkyrimSE);
+            var hw = h.Weapons.GetOrAddAsOverride(mOv.Weapons.First(x => x.FormKey == wfk));
+            hw.BasicStats!.Damage = 99; hw.Name = "HighSword";
+            h.BeginWrite.ToPath(highPath).WithLoadOrder(new ISkyrimModGetter[] { mOv }).Write();
+        }
+        Console.WriteLine($"-- setup: master {MasterName} (weapon {wfk}), user override (dmg 20, 'UserSword', counter 0x123), higher override (dmg 99, 'HighSword') --");
+        Console.WriteLine();
+
+        string fmtWfk = $"{wfk.ID:X6}:{MasterName}";       // the FormID the tools take (6 hex : defining master)
+        string fmtW2fk = $"{w2fk.ID:X6}:{MasterName}";
+        var results = new List<(string name, bool pass, string detail)>();
+
+        // ===== A — CONTENT-SOURCE / winner-injection: edit the USER's body, NOT the winner's =====
+        // Order [master, user(20/UserSword), high(99/HighSword)]; winner of the weapon is HIGH. Edit ONLY Damage on the
+        // user. A correct in-place sources from the TARGET, so the user's Name stays "UserSword"; if it wrongly sourced
+        // from the winner, Name would become "HighSword". The high override must stay byte-untouched.
+        {
+            var userA = FreshUser(tmpDir, "A", userPristine);
+            using var r = LoadOrderResolver.Build(new[] { masterPath, userA, highPath });
+            var o = WritePatchBuilder.ApplyInPlace(r, rulebook,
+                new[] { new WritePatchBuilder.PatchEdit { Target = wfk, Path = new[] { "BasicStats", "Damage" }, Verb = "Set", Value = "55" } },
+                userA, UserName);
+            int dmg = ReadDamage(userA, wfk); string nm = ReadName(userA, wfk);
+            int highDmg = ReadDamage(highPath, wfk);
+            bool pass = o.Success && o.InPlace && dmg == 55 && nm == "UserSword" && highDmg == 99;
+            results.Add(("A content-source (edit user body, not winner)", pass,
+                $"success={o.Success} inPlace={o.InPlace} userDmg={dmg}(want 55) userName='{nm}'(want UserSword — NOT HighSword) highDmg={highDmg}(want 99 untouched)  [{o.Error ?? "ok"}]"));
+
+            // C rides on A's written file — COUNTER + MASTERS preserved (no floor, no baseline).
+            uint nextId = ReadNextFormId(userA);
+            var masters = ReadMasters(userA);
+            bool cPass = nextId == 0x123 && masters.Count == 1 && masters[0].Equals(MasterName, StringComparison.OrdinalIgnoreCase);
+            results.Add(("C counter+masters preserved (no floor, no baseline)", cPass,
+                $"NextObjectID=0x{nextId:X}(want 0x123 — a patch-lane floor would force 0x800) masters=[{string.Join(",", masters)}](want only {MasterName})"));
+        }
+
+        // ===== B — CONTENT-SOURCE GUARD: refuse a FormKey the target doesn't define =====
+        // W2 lives only in the master; the user never overrides it. In-place must REFUSE (it edits only what the file owns).
+        {
+            var userB = FreshUser(tmpDir, "B", userPristine);
+            var before = File.ReadAllBytes(userB);
+            using var r = LoadOrderResolver.Build(new[] { masterPath, userB, highPath });
+            var o = WritePatchBuilder.ApplyInPlace(r, rulebook,
+                new[] { new WritePatchBuilder.PatchEdit { Target = w2fk, Path = new[] { "BasicStats", "Damage" }, Verb = "Set", Value = "7" } },
+                userB, UserName);
+            bool untouched = File.ReadAllBytes(userB).AsSpan().SequenceEqual(before);
+            bool pass = !o.Success && (o.Error?.Contains("does not define") ?? false) && untouched;
+            results.Add(("B refuse-if-undefined (edit only what the file owns)", pass,
+                $"refused={!o.Success} untouched={untouched}  [{o.Error ?? "(wrote — WRONG)"}]"));
+        }
+
+        // ===== D — FLAT LOCK: re-edit a record the ACTIVE target itself owns (winner == target) =====
+        // Order [master, user]; the user IS the weapon's winner. Phase-1 fetch opens the target overlay; ReleaseOverlay
+        // must close it before File.Replace. Success + value-landed proves the self-lock discipline on a foreign target.
+        {
+            var userD = FreshUser(tmpDir, "D", userPristine);
+            using var r = LoadOrderResolver.Build(new[] { masterPath, userD });   // no higher override → winner == target
+            var winner = r.ResolveWinner(wfk);
+            var o = WritePatchBuilder.ApplyInPlace(r, rulebook,
+                new[] { new WritePatchBuilder.PatchEdit { Target = wfk, Path = new[] { "BasicStats", "Damage" }, Verb = "Set", Value = "42" } },
+                userD, UserName);
+            int dmg = ReadDamage(userD, wfk);
+            bool pass = o.Success && dmg == 42;
+            results.Add(("D flat lock (winner==target; ReleaseOverlay before swap)", pass,
+                $"winner={winner?.WinnerPlugin}(==target) success={o.Success} dmg={dmg}(want 42)  [{o.Error ?? "ok"}]"));
+        }
+
+        // ===== E — CONTRACT validation (refusals that fire BEFORE any resolve/rulebook) =====
+        {
+            var userE = FreshUser(tmpDir, "E", userPristine);
+            using var r = LoadOrderResolver.Build(new[] { masterPath, userE, highPath });
+            var svc = LoadOrderService.ForGuard(r, new UserConfigStore(Path.Combine(tmpDir, "E.user.json")));
+            var op = new[] { new BulkOp { Formid = fmtWfk, FieldPath = "BasicStats.Damage", Verb = "Set", Value = "1" } };
+
+            var noTarget = svc.ApplyEdits(op, null, null, inPlace: true);                                   // in_place w/o target
+            var withInto = svc.ApplyEdits(op, null, "somepatch", fullReadback: false, target: UserName, inPlace: true); // in_place + into=
+            var targetNoFlag = svc.ApplyEdits(op, null, null, fullReadback: false, target: UserName, inPlace: false);   // target w/o in_place
+            bool pass = !noTarget.Success && (noTarget.Error?.Contains("requires target=") ?? false)
+                     && !withInto.Success && (withInto.Error?.Contains("mutually exclusive") ?? false)
+                     && !targetNoFlag.Success && (targetNoFlag.Error?.Contains("only meaningful with in_place") ?? false);
+            results.Add(("E contract (in_place⇔target, ⊥ into=)", pass,
+                $"noTarget={Trim(noTarget.Error)} | into={Trim(withInto.Error)} | noFlag={Trim(targetNoFlag.Error)}"));
+        }
+
+        // ===== F — RESOLVER: a non-load-order target REFUSES (never retargets) =====
+        {
+            var userF = FreshUser(tmpDir, "F", userPristine);
+            using var r = LoadOrderResolver.Build(new[] { masterPath, userF, highPath });
+            var svc = LoadOrderService.ForGuard(r, new UserConfigStore(Path.Combine(tmpDir, "F.user.json")));
+            var o = svc.ApplyEdits(new[] { new BulkOp { Formid = fmtWfk, FieldPath = "BasicStats.Damage", Verb = "Set", Value = "1" } },
+                null, null, fullReadback: false, target: "NotAReal.esp", inPlace: true, acknowledge: true);
+            bool pass = !o.Success && (o.Error?.Contains("not an active plugin") ?? false);
+            results.Add(("F resolver refuses a non-load-order target", pass, Trim(o.Error)));
+        }
+
+        // ===== G — CONSENT HANDSHAKE: RED (first touch refuses) → GREEN (acknowledge writes) → no re-prompt → persists =====
+        {
+            var userG = FreshUser(tmpDir, "G", userPristine);
+            string storePath = Path.Combine(tmpDir, "G.user.json");
+            string userGPath = userG;
+            BulkOp[] Edit(string v) => new[] { new BulkOp { Formid = fmtWfk, FieldPath = "BasicStats.Damage", Verb = "Set", Value = v } };
+
+            byte[] before = File.ReadAllBytes(userGPath);
+            bool red, untouched, green, greenLanded, noReprompt, reLanded, persisted;
+            using (var r = LoadOrderResolver.Build(new[] { masterPath, userGPath }))
+            {
+                var svc = LoadOrderService.ForGuard(r, new UserConfigStore(storePath));
+                var first = svc.ApplyEdits(Edit("31"), null, null, fullReadback: false, target: UserName, inPlace: true, acknowledge: false);
+                red = first.NeedsAcknowledge && !first.Success;
+                untouched = File.ReadAllBytes(userGPath).AsSpan().SequenceEqual(before);
+
+                var ack = svc.ApplyEdits(Edit("31"), null, null, fullReadback: false, target: UserName, inPlace: true, acknowledge: true);
+                green = ack.Success && ack.InPlace; greenLanded = ReadDamage(userGPath, wfk) == 31;
+
+                var again = svc.ApplyEdits(Edit("32"), null, null, fullReadback: false, target: UserName, inPlace: true, acknowledge: false);
+                noReprompt = again.Success && !again.NeedsAcknowledge; reLanded = ReadDamage(userGPath, wfk) == 32;
+            }
+            // PERSISTS cross-session: a brand-new store on the SAME json already knows this plugin is acknowledged.
+            persisted = new UserConfigStore(storePath).IsInPlaceAcknowledged(userGPath);
+            bool pass = red && untouched && green && greenLanded && noReprompt && reLanded && persisted;
+            results.Add(("G handshake RED→GREEN→no-reprompt→persists", pass,
+                $"firstRefused={red} untouched={untouched} ackWrote={green} landed31={greenLanded} secondNoPrompt={noReprompt} landed32={reLanded} persistedAcrossStores={persisted}"));
+        }
+
+        // ===== H — OPT-IN BY CONSTRUCTION: the tool params default OFF (assert the schema, not by omission) =====
+        {
+            var sf = typeof(WriteTools).GetMethod(nameof(WriteTools.SetField))!;
+            var ba = typeof(WriteTools).GetMethod(nameof(WriteTools.BulkApply))!;
+            bool DefOff(System.Reflection.MethodInfo m) =>
+                m.GetParameters().First(p => p.Name == "in_place").DefaultValue is false
+                && m.GetParameters().First(p => p.Name == "target").DefaultValue is null
+                && m.GetParameters().First(p => p.Name == "acknowledge").DefaultValue is false;
+            bool pass = DefOff(sf) && DefOff(ba);
+            results.Add(("H opt-in by construction (in_place/target/acknowledge default OFF)", pass,
+                $"set_field={DefOff(sf)} bulk_apply={DefOff(ba)}"));
+        }
+
+        Console.WriteLine("── ARMS ──");
+        bool all = true;
+        foreach (var (name, pass, detail) in results)
+        {
+            Console.WriteLine($"   {(pass ? "PASS" : "FAIL")}  {name}");
+            Console.WriteLine($"         {detail}");
+            all &= pass;
+        }
+        Console.WriteLine();
+        Console.WriteLine($"=== inplace-guard: {(all ? "PASS" : "FAIL")} ===");
+        try { Directory.Delete(tmpDir, recursive: true); } catch { }
+        return all ? 0 : 1;
+    }
+
+    /// <summary>
+    /// REAL-DATA proof (the one arm the self-contained guard can't cover): the in-place re-edit of a NESTED own-override
+    /// (a PlacedObject — lives in a Cell, so Phase-3 builds the source LinkCacheFor OVER the target overlay). The
+    /// ReleaseOverlay-before-swap discipline must dispose BOTH the flat (GetRecord) AND the nested (LinkCacheFor) session
+    /// overlays on the FOREIGN target before File.Replace. Mirrors writelock-nested-proof but through ApplyInPlace.
+    /// Needs a real master (Skyrim.esm) for a genuine nested record — self-SKIPs on the CI runner (no game data).
+    /// Run: dotnet run --project src/housecarl-generator inplace-nested-proof ["&lt;Data dir with Skyrim.esm&gt;"]
+    /// </summary>
+    public static int RunNestedProof(string[] args)
+    {
+        Console.WriteLine("=== inplace-nested-proof — in-place re-edit of a NESTED own-override (real data) ===");
+        string dataDir = args.Length > 0 ? args[0] : @"E:\Skyrim Modding\ARR 2.0\Stock Game\Data";
+        string skyrim = Path.Combine(dataDir, "Skyrim.esm");
+        if (!File.Exists(skyrim))
+        {
+            Console.WriteLine($"SKIP: need Skyrim.esm; not found at {skyrim} (pass the Data dir as arg 1). A real nested record + master");
+            Console.WriteLine("      can't be synthesized for the LinkCacheFor-on-a-foreign-target arm — the same posture as writelock-nested-proof.");
+            return 0;
+        }
+
+        var tmpDir = Path.Combine(Path.GetTempPath(), "hc-inplace-nested");
+        if (Directory.Exists(tmpDir)) Directory.Delete(tmpDir, recursive: true);
+        Directory.CreateDirectory(tmpDir);
+        var rulebook = CorpusRulebook.Load(GenerateCorpus(tmpDir));
+
+        FormKey refrFk;
+        using (var r0 = LoadOrderResolver.Build(new[] { skyrim }))
+        {
+            refrFk = r0.WinnerRecordsOfType(new[] { typeof(IPlacedObjectGetter) }).Select(x => x.fk).FirstOrDefault();
+            if (refrFk.IsNull) { Console.Error.WriteLine("no PlacedObject in Skyrim.esm"); return 1; }
+        }
+        Console.WriteLine($"-- real nested record: PlacedObject {refrFk} --");
+        string userPath = Path.Combine(tmpDir, "HcInPlaceNested.esp");
+
+        // STEP 1 — author a foreign-style user mod that OVERRIDES the nested record (winner=Skyrim.esm; the patch lane).
+        using (var r1 = LoadOrderResolver.Build(new[] { skyrim }))
+        {
+            var o = WritePatchBuilder.Apply(r1, rulebook,
+                new[] { new WritePatchBuilder.PatchEdit { Target = refrFk, Path = new[] { "Scale" }, Verb = "Set", Value = "1.5" } },
+                userPath, extend: false);
+            Console.WriteLine($"   step 1  author the nested override (winner=Skyrim.esm) : {(o.Success ? "OK" : "FAIL — " + o.Error)}");
+            if (!o.Success) return 1;
+        }
+
+        // STEP 2 — THE TEST: edit that nested record IN PLACE (winner == the user mod == target → flat + nested overlay on it).
+        bool ok; string err;
+        using (var r2 = LoadOrderResolver.Build(new[] { skyrim, userPath }))
+        {
+            var o = WritePatchBuilder.ApplyInPlace(r2, rulebook,
+                new[] { new WritePatchBuilder.PatchEdit { Target = refrFk, Path = new[] { "Scale" }, Verb = "Set", Value = "2.5" } },
+                userPath, Path.GetFileName(userPath));
+            ok = o.Success; err = o.Error ?? "ok";
+            Console.WriteLine($"   step 2  re-edit the NESTED record IN PLACE : {(ok ? "OK" : "FAIL — " + err)}");
+        }
+        float? scale = ReadPlacedScale(userPath, refrFk);
+        bool landed = scale.HasValue && Math.Abs(scale.Value - 2.5f) < 0.001f;
+        Console.WriteLine($"   nested in-place edit landed (Scale==2.5) : {(landed ? "PASS" : $"FAIL (scale={scale?.ToString() ?? "null"})")}");
+
+        bool pass = ok && landed;
+        Console.WriteLine($"=== inplace-nested-proof: {(pass ? "PASS — nested in-place survives ReleaseOverlay-before-serialize on a foreign target" : "FAIL")} ===");
+        try { Directory.Delete(tmpDir, recursive: true); } catch { }
+        return pass ? 0 : 1;
+    }
+
+    // ---- helpers -------------------------------------------------------------------------------------------
+
+    static string FreshUser(string tmpDir, string arm, string pristine)
+    {
+        var dir = Path.Combine(tmpDir, "arm-" + arm);
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, UserName);   // KEEP the filename (== ModKey); only the dir differs
+        File.Copy(pristine, path, overwrite: true);
+        return path;
+    }
+
+    static string GenerateCorpus(string tmpDir)
+    {
+        var genDir = Path.Combine(tmpDir, "corpus-gen");
+        CorpusGenerator.GenerateAll(genDir, Path.Combine(tmpDir, "corpus-ref"));
+        return Path.Combine(genDir, "corpus.json");
+    }
+
+    static int ReadDamage(string path, FormKey fk)
+    {
+        ISkyrimModGetter? ov = null;
+        try { ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE); return ov.Weapons.FirstOrDefault(x => x.FormKey == fk)?.BasicStats?.Damage ?? -1; }
+        catch { return -1; }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    static string ReadName(string path, FormKey fk)
+    {
+        ISkyrimModGetter? ov = null;
+        try { ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE); return ov.Weapons.FirstOrDefault(x => x.FormKey == fk)?.Name?.String ?? "(none)"; }
+        catch { return "(read failed)"; }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    static uint ReadNextFormId(string path)
+    {
+        ISkyrimModGetter? ov = null;
+        try { ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE); return ov.ModHeader.Stats.NextFormID; }
+        catch { return 0xDEAD; }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    static List<string> ReadMasters(string path)
+    {
+        ISkyrimModGetter? ov = null;
+        try { ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE); return ov.ModHeader.MasterReferences.Select(m => m.Master.FileName.String).ToList(); }
+        catch { return new List<string> { "(read failed)" }; }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    static float? ReadPlacedScale(string path, FormKey fk)
+    {
+        ISkyrimModGetter? ov = null;
+        try { ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE); return ov.EnumerateMajorRecords<IPlacedObjectGetter>().FirstOrDefault(r => r.FormKey == fk)?.Scale; }
+        catch { return null; }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    static string Trim(string? s) => (s ?? "(null)").Replace("\r", " ").Replace("\n", " ").Trim();
+}

--- a/src/housecarl-generator/InPlaceProbe.cs
+++ b/src/housecarl-generator/InPlaceProbe.cs
@@ -214,6 +214,52 @@ public static class InPlaceProbe
                 $"set_field={DefOff(sf)} bulk_apply={DefOff(ba)}"));
         }
 
+        // ===== I — MARKER + into= BOUNDARY: the editedInPlace marker is stamped but NEVER generated=true, so the user
+        // mod keeps failing IsHouseCarlOwned and a later into= can't blind-overwrite it. The marker only fires for a
+        // target under ModsDir (IsUnderModsDir), so this arm drives the REAL service over a synthetic MO2 instance with
+        // the user mod as a NON-houseCARL mod folder. The discriminating check: into= STILL refuses the edited user mod
+        // — it would SUCCEED (extend it) if the marker had wrongly written generated=true. =====
+        {
+            string inst = Path.Combine(tmpDir, "instance");
+            string profiles = Path.Combine(inst, "profiles", "Default");
+            string mods = Path.Combine(inst, "mods");
+            Directory.CreateDirectory(profiles); Directory.CreateDirectory(mods);
+            Directory.CreateDirectory(Path.Combine(tmpDir, "game", "Data"));
+            File.WriteAllText(Path.Combine(inst, "ModOrganizer.ini"),
+                "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+                + Path.Combine(tmpDir, "game").Replace(@"\", @"\\") + ")\r\n");
+
+            var mMod = Path.Combine(mods, "MasterMod"); Directory.CreateDirectory(mMod);
+            File.Copy(masterPath, Path.Combine(mMod, MasterName));
+            var uMod = Path.Combine(mods, "UserMod"); Directory.CreateDirectory(uMod);
+            File.Copy(userPristine, Path.Combine(uMod, UserName));
+            string userMeta = Path.Combine(uMod, "meta.ini");
+            File.WriteAllText(userMeta, "[General]\r\ngameName=skyrimse\r\ncomments=USER SENTINEL\r\n");   // a NON-houseCARL meta.ini
+
+            File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + MasterName + "\r\n" + UserName + "\r\n");
+            File.WriteAllText(Path.Combine(profiles, "plugins.txt"), "*" + MasterName + "\r\n*" + UserName + "\r\n");
+            File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+UserMod\r\n+MasterMod\r\n");
+
+            var store = new UserConfigStore(Path.Combine(tmpDir, "I.user.json"));
+            using var svc = LoadOrderService.WithInstance(inst, 0, store);
+            svc.Stats();   // warm the lazy index once
+
+            var edit = new[] { new BulkOp { Formid = fmtWfk, FieldPath = "BasicStats.Damage", Verb = "Set", Value = "61" } };
+            var wrote = svc.ApplyEdits(edit, null, null, fullReadback: false, target: UserName, inPlace: true, acknowledge: true);
+            string meta = File.Exists(userMeta) ? File.ReadAllText(userMeta) : "";
+            bool markerWritten = meta.Contains("editedInPlace=");
+            bool noGenerated = !meta.Replace(" ", "").Contains("generated=true", StringComparison.OrdinalIgnoreCase);
+            bool sentinelKept = meta.Contains("USER SENTINEL");
+            // The boundary, end-to-end: an into= extend of the now-edited user mod STILL refuses it (un-owned). With the
+            // bug (marker writes generated=true) this would instead SUCCEED — so a refusal is the discriminating proof.
+            var intoTry = svc.ApplyEdits(edit, null, UserName, fullReadback: false);
+            bool ownedStaysFalse = !intoTry.Success;
+            bool landed = ReadDamage(Path.Combine(uMod, UserName), wfk) == 61;
+            bool pass = wrote.Success && wrote.InPlace && landed && markerWritten && noGenerated && sentinelKept && ownedStaysFalse;
+            results.Add(("I editedInPlace marker + into= boundary (never generated=true)", pass,
+                $"wrote={wrote.Success} landed61={landed} marker={markerWritten} noGenerated={noGenerated} userSentinelKept={sentinelKept} into=StillRefusesUnowned={ownedStaysFalse}  [{Trim(wrote.Error)}]"));
+        }
+
         Console.WriteLine("── ARMS ──");
         bool all = true;
         foreach (var (name, pass, detail) in results)

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -342,6 +342,15 @@ if (args.Length > 0 && args[0] == "writelock-apply-probe") return WriteLockProbe
 // link-cache context path) survives the re-edit-own-override case under the new "release overlay before serialize" invariant.
 if (args.Length > 0 && args[0] == "writelock-nested-proof") return WriteLockProbe.RunNestedProof(args[1..]);
 
+// In-place write lane Wave 1: SELF-CONTAINED CI regression guard — drives the REAL WritePatchBuilder.ApplyInPlace + the
+// REAL LoadOrderService in-place branch (content-source/winner-injection, counter+master preservation, flat lock, the
+// persistent consent handshake, the resolver/contract refusals, opt-in-by-construction). No game data.
+if (args.Length > 0 && args[0] == "inplace-guard") return InPlaceProbe.RunGuard(args[1..]);
+
+// In-place write lane Wave 1: REAL-DATA proof of the NESTED own-override re-edit IN PLACE (the LinkCacheFor-on-a-foreign-
+// target overlay path), the one arm the self-contained guard can't synthesize. Needs Skyrim.esm; self-skips on the runner.
+if (args.Length > 0 && args[0] == "inplace-nested-proof") return InPlaceProbe.RunNestedProof(args[1..]);
+
 // Perk references= crash (HCBR-2026-06-09-03): DIAGNOSIS — run Mutagen's EnumerateFormLinks over every PERK in a
 // real plugin, report which records throw and with what (the evidence the fix is designed from). Skips without Skyrim.esm.
 if (args.Length > 0 && args[0] == "perk-refs-diagnose") return PerkRefsProbe.RunDiagnose(args[1..]);

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -425,6 +425,13 @@ if (args.Length > 0 && args[0] == "bulk-create-guard") return BulkCreateGuardPro
 // file-system-tunneling host; arm C2 proves the locked-target mid-swap fails loud + non-destructive.
 if (args.Length > 0 && args[0] == "atomic-commit-guard") return AtomicCommitProbe.RunGuard(args[1..]);
 
+// IN-PLACE WRITE LANE, Wave 0 (design-gating, IN_PLACE_WRITE_LANE_PLAN §5.3/§9 STEP-2): MANUAL/REAL-DATA probe —
+// no-op re-serialize a sample of REAL plugins (counter-preserving, the §5.1-correct in-place shape) and measure the
+// whole-plugin byte divergence surface (identical / header-only / body / records-changed / unloadable), so fork #1's
+// round-trip accept/refuse threshold is calibrated on measured reality. Needs --mo2 <instance>; SKIPs without (a
+// synthetic fixture round-trips clean and would reveal nothing). Writes only to temp; read-only on the load order.
+if (args.Length > 0 && args[0] == "roundtrip-probe") return RoundTripProbe.RunProbe(args[1..]);
+
 // External-tool bridge (step 1) proof: the pure core pieces housecarl_set_tool_path + the riders ride — shared-config
 // clobber-safety, path validation, the missing-dependency forcing prompt, and canonical-home auto-detect.
 if (args.Length > 0 && args[0] == "tool-bridge") return ToolBridgeProbe.Run(args[1..]);

--- a/src/housecarl-generator/RoundTripProbe.cs
+++ b/src/housecarl-generator/RoundTripProbe.cs
@@ -1,0 +1,306 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// EXPLORATORY / REAL-DATA probe for the IN-PLACE WRITE LANE, Wave 0 (the design-gating measurement —
+/// dev/plans/IN_PLACE_WRITE_LANE_PLAN_2026-06-13.md §5.3 / §9 STEP-2). It answers the one fork the planning
+/// chair CANNOT decide (fork #1, the round-trip baseline): when houseCARL re-serializes a WHOLE existing
+/// plugin (the in-place lane re-emits every record, not a thin override), does it come back BYTE-IDENTICAL,
+/// and if not, WHAT diverges?
+///
+/// Why this is the first build action. The entire houseCARL write path to date emits thin OVERRIDE patches,
+/// and the standing byte-faithfulness proof (WriteOracle) is "engine override == hand-typed Mutagen override"
+/// — NOT "Mutagen round-trips a whole plugin". So houseCARL has ZERO empirical evidence of Mutagen's
+/// whole-plugin divergence surface beyond the named residuals (Worldspace OFST regen, Array2d/terrain grids,
+/// the ~8 unparseable records). The round-trip floor (§5) is the SUBSTITUTE for the ownership marker the
+/// patch lane relies on; calibrating its accept/refuse threshold (byte-strict vs semantic-tolerant) needs
+/// the real divergence surface measured, not guessed.
+///
+/// THE MEASUREMENT (per sampled plugin):
+///   1. EAGER load — SkyrimMod.CreateFromBinary(path) (the SAME call the extend write path uses;
+///      WritePatchBuilder.cs:247). The SINGLE target plugin only — NEVER the load order (the legacy 12–14 GB
+///      RAM trap; CLAUDE.md §1). Masters are opened LAZILY as overlays.
+///   2. NO-OP RE-SERIALIZE — write the loaded mod straight back out with the product incantation MINUS the
+///      FormID floor: .WithLoadOrder(<the plugin's own masters, as overlays>).NoNextFormIDProcessing().Write().
+///      NoNextFormIDProcessing persists the IN-MEMORY counter verbatim, and we deliberately DO NOT call
+///      EnsureFormIdFloor — so the written HEDR.NextObjectID equals the ORIGINAL. That is EXACTLY the
+///      §5.1-correct in-place serialize (preserve the author's counter), so any divergence the probe sees is
+///      the TRUE residual surface the floor must handle, not floor-induced noise.
+///   3. BYTE-COMPARE the re-serialized temp against the original on disk; categorize any divergence.
+///   4. NextObjectID, measured SEPARATELY (§5.1): report how many plugins carry a stored counter the CURRENT
+///      product floor (EnsureFormIdFloor) WOULD have raised — quantifying why in-place must preserve, not floor.
+///
+/// CATEGORIES reported for a divergent plugin:
+///   • UNLOADABLE       — CreateFromBinary threw (the read-parse residual class, incl. the 2 known unparseable
+///                        PERKs). In-place would REFUSE this plugin rather than silently re-emit it minus the
+///                        record Mutagen couldn't parse. Counted, never silently skipped.
+///   • RECORDS-CHANGED  — the on-disk record-header SEQUENCE (sig+FormID, GRUP-recursive) differs between
+///                        original and re-serialized: a dropped / added / reordered record. The dangerous class.
+///   • HEADER-ONLY      — record sequence identical; first byte divergence falls inside the TES4 header region
+///                        (master list / ONAM / flags / counter churn) — body records intact.
+///   • BODY-DIVERGENT   — record sequence identical; divergence is in record bodies (compression re-emit,
+///                        subrecord ordering, OFST regen, terrain/Array2d) — the §5.2 blind-spot territory.
+///
+/// This is a MANUAL/real-data probe (like esl-real-scan / conflict-diff-proof / perk-refs-proof): it needs real
+/// CK-/xEdit-/Wrye-Bash-authored plugins, which a self-contained CI fixture cannot stand in for (a synthetic
+/// plugin round-trips clean by construction and would reveal nothing). It writes ONLY to the system temp dir
+/// and never mutates the real load order (read-only). SKIPs cleanly without --mo2.
+///
+/// Run: dotnet run --project src/housecarl-generator roundtrip-probe -- --mo2 &lt;instanceDir&gt; [--max N] [--plugins A.esp,B.esp]
+/// </summary>
+public static class RoundTripProbe
+{
+    public static int RunProbe(string[] args)
+    {
+        var f = WriteEngine.ParseFlags(args);
+        var instanceDir = f.GetValueOrDefault("mo2");
+        if (instanceDir is null || !Directory.Exists(instanceDir))
+        {
+            Console.WriteLine("SKIP: needs --mo2 <instanceDir>. The whole-plugin round-trip divergence surface can only be");
+            Console.WriteLine("      measured against REAL CK-/xEdit-/Wrye-Bash-authored plugins — a synthetic fixture round-trips");
+            Console.WriteLine("      clean by construction and would reveal nothing. (This is why Wave 0 is a manual probe, not a CI guard.)");
+            return 0;
+        }
+        int max = f.TryGetValue("max", out var ms) && int.TryParse(ms, out var mm) ? mm : 60;
+        var only = f.GetValueOrDefault("plugins")?
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        Console.WriteLine("################  IN-PLACE WAVE 0 — whole-plugin round-trip divergence surface  ################");
+        Console.WriteLine($"   instance: {instanceDir}");
+        Console.WriteLine();
+
+        var p = Mo2Instance.Resolve(instanceDir);
+        var order = Mo2LoadOrder.Build(p.ProfileDir, p.ModsDir, p.DataDir, p.OverwriteDir);
+        var orderedPaths = order.OrderedPaths.ToList();
+        // filename -> winning on-disk path (a plugin filename is unique in a load order; OrderedPaths is the
+        // resolved winner per plugin). The master-resolution map for step 2's .WithLoadOrder.
+        var byName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var op in orderedPaths) byName[Path.GetFileName(op)] = op;
+
+        // Sample: explicit --plugins if given; else an even spread across the whole order (a mix of vanilla
+        // masters, big overhauls, small patches — varied provenance), with the vanilla masters force-included.
+        List<string> targets;
+        if (only is not null)
+            targets = orderedPaths.Where(op => only.Contains(Path.GetFileName(op))).ToList();
+        else
+        {
+            var forced = new[] { "Skyrim.esm", "Update.esm", "Dawnguard.esm", "HearthFires.esm", "Dragonborn.esm" };
+            var picked = new List<string>();
+            foreach (var fn in forced) if (byName.TryGetValue(fn, out var pp)) picked.Add(pp);
+            int remaining = Math.Max(0, max - picked.Count);
+            if (remaining > 0 && orderedPaths.Count > 0)
+            {
+                var pool = orderedPaths.Where(op => !picked.Contains(op)).ToList();
+                int step = Math.Max(1, pool.Count / remaining);
+                for (int i = 0; i < pool.Count && picked.Count < max; i += step) picked.Add(pool[i]);
+            }
+            targets = picked.Distinct().ToList();
+        }
+
+        Console.WriteLine($"   load order: {orderedPaths.Count} plugins; sampling {targets.Count}{(only is null ? $" (cap --max {max})" : " (explicit --plugins)")}.");
+        Console.WriteLine();
+
+        var tmpRoot = Path.Combine(Path.GetTempPath(), "hc-roundtrip-probe");
+        if (Directory.Exists(tmpRoot)) { try { Directory.Delete(tmpRoot, recursive: true); } catch { } }
+        Directory.CreateDirectory(tmpRoot);
+
+        int identical = 0, headerOnly = 0, bodyDiverge = 0, recordsChanged = 0, unloadable = 0, mastersMissing = 0, writeFailed = 0;
+        int counterWouldFloor = 0;
+        var notable = new List<string>();   // divergent plugins, for the per-plugin detail table
+
+        foreach (var path in targets)
+        {
+            string name = Path.GetFileName(path);
+            byte[] origBytes;
+            try { origBytes = File.ReadAllBytes(path); }
+            catch (Exception ex) { unloadable++; notable.Add($"   {name,-48} READ-FAILED  {ex.GetType().Name}"); continue; }
+
+            SkyrimMod mod;
+            try { mod = SkyrimMod.CreateFromBinary(path, SkyrimRelease.SkyrimSE); }
+            catch (Exception ex)
+            {
+                unloadable++;
+                notable.Add($"   {name,-48} UNLOADABLE   {WriteEngine.Describe(ex)}  → in-place would REFUSE (read-parse residual)");
+                continue;
+            }
+
+            // §5.1 — the header counter, measured analytically (no write needed): would the CURRENT product
+            // floor have raised this plugin's stored NextObjectID? (If yes, a floor-applying re-serialize would
+            // diverge here — which is why in-place PRESERVES the counter instead.)
+            uint storedNext = mod.ModHeader.Stats.NextFormID;
+            uint floor = 0x800;
+            foreach (var r in mod.EnumerateMajorRecords())
+                if (r.FormKey.ModKey == mod.ModKey && r.FormKey.ID >= floor) floor = r.FormKey.ID + 1;
+            bool floorWouldRaise = storedNext < floor;
+            if (floorWouldRaise) counterWouldFloor++;
+
+            // Resolve this plugin's own declared masters to on-disk overlays for a faithful re-serialize.
+            var masterOverlays = new List<IDisposable>();
+            ISkyrimModGetter[] orderedMasters;
+            try
+            {
+                var resolved = new List<ISkyrimModGetter>();
+                bool missing = false;
+                foreach (var mr in mod.ModHeader.MasterReferences)
+                {
+                    var mfn = mr.Master.FileName.String;
+                    if (!byName.TryGetValue(mfn, out var mpath)) { missing = true; break; }
+                    var ov = SkyrimMod.CreateFromBinaryOverlay(mpath, SkyrimRelease.SkyrimSE);
+                    masterOverlays.Add((IDisposable)ov);
+                    resolved.Add(ov);
+                }
+                if (missing)
+                {
+                    mastersMissing++;
+                    notable.Add($"   {name,-48} MASTERS-MISSING  (a declared master is absent from the order — unmeasurable here)");
+                    foreach (var d in masterOverlays) d.Dispose();
+                    continue;
+                }
+                orderedMasters = resolved.ToArray();
+            }
+            catch (Exception ex)
+            {
+                mastersMissing++;
+                notable.Add($"   {name,-48} MASTER-OPEN-FAILED  {ex.GetType().Name}");
+                foreach (var d in masterOverlays) d.Dispose();
+                continue;
+            }
+
+            // Step 2 — the faithful, counter-preserving no-op re-serialize (the §5.1-correct in-place shape).
+            string tmpPath = Path.Combine(tmpRoot, name);
+            try
+            {
+                mod.BeginWrite
+                    .ToPath(tmpPath)
+                    .WithLoadOrder(orderedMasters)
+                    .NoNextFormIDProcessing()
+                    .Write();
+            }
+            catch (Exception ex)
+            {
+                writeFailed++;
+                notable.Add($"   {name,-48} WRITE-FAILED  {WriteEngine.Describe(ex)}");
+                foreach (var d in masterOverlays) d.Dispose();
+                continue;
+            }
+            finally { foreach (var d in masterOverlays) d.Dispose(); }
+
+            byte[] newBytes;
+            try { newBytes = File.ReadAllBytes(tmpPath); }
+            catch (Exception ex) { writeFailed++; notable.Add($"   {name,-48} REREAD-FAILED  {ex.GetType().Name}"); continue; }
+            finally { try { File.Delete(tmpPath); } catch { } }
+
+            if (origBytes.AsSpan().SequenceEqual(newBytes))
+            {
+                identical++;
+                continue;
+            }
+
+            // Divergent — categorize. Walk record headers on both sides (GRUP-recursive).
+            var origRecs = WalkRecords(origBytes);
+            var newRecs = WalkRecords(newBytes);
+            bool seqSame = origRecs.Count == newRecs.Count && origRecs.SequenceEqual(newRecs);
+            int firstDiff = FirstDivergence(origBytes, newBytes);
+            int tes4End = 24 + (origBytes.Length >= 8 ? (int)BitConverter.ToUInt32(origBytes, 4) : 0);
+            int sizeDelta = newBytes.Length - origBytes.Length;
+            string counterTag = floorWouldRaise ? $", counter 0x{storedNext:X}→floor 0x{floor:X}" : "";
+
+            if (!seqSame)
+            {
+                recordsChanged++;
+                int dropped = origRecs.Count - newRecs.Count;
+                notable.Add($"   {name,-48} RECORDS-CHANGED  recs {origRecs.Count}→{newRecs.Count} ({(dropped > 0 ? $"-{dropped}" : dropped < 0 ? $"+{-dropped}" : "reordered")}), Δsize {sizeDelta:+#;-#;0}b{counterTag}");
+            }
+            else if (firstDiff >= 0 && firstDiff < tes4End)
+            {
+                headerOnly++;
+                notable.Add($"   {name,-48} HEADER-ONLY      first Δ @0x{firstDiff:X} (TES4 hdr, ends 0x{tes4End:X}), Δsize {sizeDelta:+#;-#;0}b{counterTag}");
+            }
+            else
+            {
+                bodyDiverge++;
+                notable.Add($"   {name,-48} BODY-DIVERGENT   first Δ @0x{firstDiff:X} (past TES4 hdr 0x{tes4End:X}), Δsize {sizeDelta:+#;-#;0}b{counterTag}");
+            }
+        }
+
+        Console.WriteLine("── PER-PLUGIN (divergent / unmeasurable only; byte-identical omitted) ──");
+        if (notable.Count == 0) Console.WriteLine("   (every sampled plugin round-tripped byte-identical)");
+        else foreach (var line in notable) Console.WriteLine(line);
+        Console.WriteLine();
+
+        int measured = identical + headerOnly + bodyDiverge + recordsChanged;
+        Console.WriteLine("── AGGREGATE ──");
+        Console.WriteLine($"   sampled            : {targets.Count}");
+        Console.WriteLine($"   BYTE-IDENTICAL     : {identical}");
+        Console.WriteLine($"   HEADER-ONLY diverge: {headerOnly}   (master list / ONAM / flags — body records intact)");
+        Console.WriteLine($"   BODY-DIVERGENT     : {bodyDiverge}   (compression / subrecord order / OFST / terrain — §5.2 territory)");
+        Console.WriteLine($"   RECORDS-CHANGED    : {recordsChanged}   (dropped/added/reordered record — the dangerous class)");
+        Console.WriteLine($"   UNLOADABLE         : {unloadable}   (CreateFromBinary threw — in-place REFUSES, never silently re-emits minus a record)");
+        Console.WriteLine($"   masters-missing    : {mastersMissing}   (a declared master absent from the order — unmeasurable, not a divergence)");
+        Console.WriteLine($"   write-failed       : {writeFailed}");
+        Console.WriteLine();
+        Console.WriteLine($"   §5.1 NextObjectID  : {counterWouldFloor}/{measured} loadable plugins carry a stored counter the CURRENT product");
+        Console.WriteLine($"                        floor (EnsureFormIdFloor) WOULD raise — i.e. a floor-applying re-serialize would");
+        Console.WriteLine($"                        diverge on the header counter for these. In-place PRESERVES the counter, so this");
+        Console.WriteLine($"                        probe's no-op writes did NOT floor it (the §5.1-correct behavior, measured clean above).");
+        Console.WriteLine();
+        Console.WriteLine("── READING THIS (fork #1, the round-trip baseline) ──");
+        Console.WriteLine("   • BYTE-IDENTICAL high  → a byte-strict floor is viable for those plugins; refuse on any miss (strict-first).");
+        Console.WriteLine("   • BODY-DIVERGENT / HEADER-ONLY present → byte-strict would refuse safe plugins en masse; the surface here is");
+        Console.WriteLine("     the exact set the two-tier semantic threshold (or a targeted byte-check on terrain/OFST families) must tolerate.");
+        Console.WriteLine("   • RECORDS-CHANGED / UNLOADABLE are NON-NEGOTIABLE refusals regardless of threshold (a record vanished or wouldn't parse).");
+
+        try { Directory.Delete(tmpRoot, recursive: true); } catch { }
+        return 0;
+    }
+
+    /// <summary>Walk an .esp/.esm/.esl and return the (signature, raw on-disk FormID) of every major record
+    /// header in document order (GRUP-recursive). Reads only the fixed 24-byte record header, never field data,
+    /// so record compression is irrelevant. The structural fingerprint a re-serialize must preserve exactly.</summary>
+    static List<(string sig, uint formId)> WalkRecords(byte[] buf)
+    {
+        var outp = new List<(string, uint)>();
+        if (buf.Length < 24) return outp;
+        uint tes4Size = BitConverter.ToUInt32(buf, 4);
+        Scan(buf, 24 + (int)tes4Size, buf.Length, outp);
+        return outp;
+    }
+
+    static void Scan(byte[] buf, int start, int end, List<(string, uint)> outp)
+    {
+        int pos = start;
+        while (pos + 24 <= end)
+        {
+            string sig = System.Text.Encoding.ASCII.GetString(buf, pos, 4);
+            uint size = BitConverter.ToUInt32(buf, pos + 4);
+            long next;
+            if (sig == "GRUP")
+            {
+                next = (long)pos + size;                       // GRUP size INCLUDES its 24-byte header
+                Scan(buf, pos + 24, (int)Math.Min(next, end), outp);
+            }
+            else
+            {
+                outp.Add((sig, BitConverter.ToUInt32(buf, pos + 12)));
+                next = (long)pos + 24 + size;                  // major record: 24-byte header + dataSize
+            }
+            if (next <= pos) break;                            // forward-progress guard (malformed size)
+            pos = (int)Math.Min(next, (long)end);
+        }
+    }
+
+    /// <summary>Index of the first differing byte between two buffers, or -1 if one is a strict prefix of the
+    /// other (length-only divergence). Length differences alone still register via the size-delta report.</summary>
+    static int FirstDivergence(byte[] a, byte[] b)
+    {
+        int n = Math.Min(a.Length, b.Length);
+        for (int i = 0; i < n; i++) if (a[i] != b[i]) return i;
+        return a.Length == b.Length ? -1 : n;
+    }
+}

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1204,7 +1204,10 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>Writable-parent pre-flight for the in-place swap (§6 layer 3): the staged temp is a sibling of the
     /// target, so prove the parent is writable NOW, loud, rather than degrade to a non-atomic write later. True (with a
-    /// named <paramref name="why"/>) ⇒ refuse. Probes by writing + deleting an empty sibling temp.</summary>
+    /// named <paramref name="why"/>) ⇒ refuse. Probes by writing + deleting an empty sibling temp. This checks the PARENT
+    /// is writable — NOT that the target file isn't EXTERNALLY locked (MO2/xEdit mid-operation); that case isn't
+    /// pre-empted here but surfaces LOUD at the <c>File.Replace</c> swap with the original byte-intact (the correct Q3
+    /// outcome, not a corruption path), so it needs no separate pre-flight.</summary>
     static bool InPlaceParentUnwritable(string targetPath, out string why)
     {
         why = "";

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1061,10 +1061,25 @@ public sealed class LoadOrderService : IDisposable
     /// existing houseCARL-owned patch (the multi-session accumulation lever). Returns null-Error outcome on success.
     /// <paramref name="fullReadback"/> additionally reads every touched record back IN FULL off the written file
     /// (the pre-enable verify loop — wishlist #3 re-scoped / HCBR-2026-06-11-02 wave (b)).</summary>
-    public WritePatchBuilder.PatchOutcome ApplyEdits(IReadOnlyList<BulkOp> ops, string? patchName, string? into, bool fullReadback = false)
+    public WritePatchBuilder.PatchOutcome ApplyEdits(IReadOnlyList<BulkOp> ops, string? patchName, string? into,
+        bool fullReadback = false, string? target = null, bool inPlace = false, bool acknowledge = false)
     {
         if (ops.Count == 0)
             return WritePatchBuilder.PatchOutcome.Fail("no operations supplied.");
+
+        // In-place is the explicit, named-file opt-in (the SECOND write lane — edit an existing plugin, incl. one
+        // houseCARL didn't author, instead of writing a new patch). Validate the contract up front (Q3): it REQUIRES a
+        // target=, and it is mutually exclusive with into= (which EXTENDS a houseCARL patch — a different lane). target=
+        // without in_place is a no-op the caller likely didn't mean — name it rather than silently ignore it.
+        if (inPlace && string.IsNullOrWhiteSpace(target))
+            return WritePatchBuilder.PatchOutcome.Fail(
+                "in_place=true requires target=<plugin filename> — name the existing plugin to edit in place. (Omit in_place to write a new patch instead — the default, originals untouched.)");
+        if (inPlace && !string.IsNullOrWhiteSpace(into))
+            return WritePatchBuilder.PatchOutcome.Fail(
+                "in_place=true and into= are mutually exclusive: into= EXTENDS a houseCARL patch, while in_place edits an existing plugin in place. Use one lane or the other.");
+        if (!inPlace && !string.IsNullOrWhiteSpace(target))
+            return WritePatchBuilder.PatchOutcome.Fail(
+                "target= is only meaningful with in_place=true (it names the plugin to edit in place). For the default patch lane omit target=; use into= to extend an existing houseCARL patch.");
 
         // Map every op to a core PatchEdit, collecting ALL parse problems first (all-or-nothing, like the cleave).
         // Pure parsing — runs outside the write gate so a malformed call never queues behind a real write.
@@ -1084,6 +1099,9 @@ public sealed class LoadOrderService : IDisposable
             var resolver = Resolver;                                      // builds/refreshes the index
             var rulebook = Rulebook;
 
+            if (inPlace)
+                return ApplyEditsInPlace(resolver, rulebook, edits, target!.Trim(), acknowledge);
+
             string outPath; bool extend, created;
             try { outPath = ResolveOutputPath(patchName, into, out extend, out created); }
             catch (Exception ex) { return WritePatchBuilder.PatchOutcome.Fail(ex.Message); }
@@ -1093,6 +1111,184 @@ public sealed class LoadOrderService : IDisposable
             return outcome;
         }
     }
+
+    /// <summary>The in-place branch of <see cref="ApplyEdits"/> (in-place write lane, Wave 1) — runs under _writeGate.
+    /// (1) resolves <paramref name="target"/> to its REAL on-disk path via the load order (NOT the houseCARL-owned
+    /// folder model — the foreign-plugin resolver, the sibling of <see cref="ResolveOwnedPatchFolder"/> with the
+    /// ownership gate DROPPED); (2) enforces the server-side, PERSISTENT first-touch CONSENT handshake (keyed off the
+    /// resolved path, stored in <see cref="UserConfigStore"/>); (3) checks the writable parent; (4) drives
+    /// <see cref="WritePatchBuilder.ApplyInPlace"/> with the touched-record verify forced ON; (5) on success stamps the
+    /// distinct <c>editedInPlace=</c> marker (NEVER <c>generated=true</c> — the user mod must keep failing
+    /// <see cref="IsHouseCarlOwned"/> so a later into= can't blind-overwrite it). <paramref name="acknowledge"/> waives
+    /// the CONSENT axis ONLY — the verify is a corruption-axis fact no acknowledgement overrides.</summary>
+    WritePatchBuilder.PatchOutcome ApplyEditsInPlace(
+        LoadOrderResolver resolver, CorpusRulebook rulebook, IReadOnlyList<WritePatchBuilder.PatchEdit> edits,
+        string target, bool acknowledge)
+    {
+        // (1) Resolve target -> real on-disk path via the load order (by plugin FILENAME — unique in an order). Refuse
+        //     loud if it isn't a real active plugin (closes the coincidental-folder collision the into= lane can hit).
+        var view = resolver.Capture();
+        var targetPath = ResolveActivePluginPath(view, Path.GetFileName(target.Trim()), out var targetName);
+        if (targetPath is null)
+            return WritePatchBuilder.PatchOutcome.Fail(
+                $"in-place target '{target}' is not an active plugin in the load order — name a plugin enabled in MO2, by its " +
+                "plugin filename (e.g. 'CoolWeapons.esp'). in-place edits the file the game actually loads. Nothing was written.");
+
+        // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path. NOT a
+        //     sticky mode: each in-place write still names its own target=, so this only stops re-explaining the
+        //     trade-off; it never makes an ambiguous request route to in-place.
+        bool already = _store.IsInPlaceAcknowledged(targetPath);
+        if (!already && !acknowledge)
+            return WritePatchBuilder.PatchOutcome.NeedsAck(InPlaceHandshakeText(targetName, targetPath));
+        string? ackNote = null;
+        if (!already && acknowledge)
+        {
+            var (ok, err) = _store.RecordInPlaceAcknowledged(targetPath);
+            if (!ok) ackNote = $"the in-place acknowledgement could not be saved ({err}) — the edit proceeded, but a future session will re-prompt for this plugin.";
+        }
+
+        // (3) Writable, same-volume parent pre-flight — refuse rather than degrade (the swap stages a sibling temp in
+        //     this dir; AtomicFile.Commit already refuses cross-volume loud, this catches a read-only/locked parent up
+        //     front with a clear message before any work).
+        if (InPlaceParentUnwritable(targetPath, out var why))
+            return WritePatchBuilder.PatchOutcome.Fail(why);
+
+        // (4) The write — touched-record verify forced ON (the model-C substitute for the dropped whole-plugin floor).
+        var outcome = WritePatchBuilder.ApplyInPlace(resolver, rulebook, edits, targetPath, targetName, fullReadback: true);
+
+        // (5) On success, stamp the distinct audit marker (best-effort; a marker miss never fails the done edit, Q3-noted).
+        if (outcome.Success)
+        {
+            var markerNote = MergeEditedInPlaceMarker(Path.GetDirectoryName(targetPath));
+            var note = JoinNotes(ackNote, markerNote);
+            if (note is not null) return outcome with { Note = note };
+        }
+        else if (ackNote is not null)
+        {
+            // The acknowledgement was recorded but the write then failed — keep the (now-honest) note alongside the error.
+            return outcome with { Note = ackNote };
+        }
+        return outcome;
+    }
+
+    /// <summary>Resolve an ACTIVE plugin's on-disk path by filename (in-place write lane) — exact match first, then a
+    /// lenient retry appending each plugin extension if the caller dropped it (e.g. 'CoolWeapons' → 'CoolWeapons.esp').
+    /// <paramref name="resolvedName"/> echoes the canonical filename that matched. Null ⇒ no such active plugin (the
+    /// caller refuses loud). The path is the load order's WINNING path for that filename — the file the game loads.</summary>
+    static string? ResolveActivePluginPath(LoadOrderResolver.IndexView view, string raw, out string resolvedName)
+    {
+        resolvedName = raw;
+        var direct = view.PluginPath(raw);
+        if (direct is not null) return direct;
+        if (!PluginExts.Any(e => raw.EndsWith(e, StringComparison.OrdinalIgnoreCase)))
+            foreach (var ext in PluginExts)
+            {
+                var cand = raw + ext;
+                var p = view.PluginPath(cand);
+                if (p is not null) { resolvedName = cand; return p; }
+            }
+        return null;
+    }
+
+    /// <summary>The first-touch in-place CONSENT prompt (server-enforced, shown once per plugin). States the trade-off
+    /// plainly: the original file IS the output, there's no houseCARL undo/backup, the whole plugin is re-laid-out like
+    /// xEdit/CK do on save with the touched records VERIFIED and Mutagen trusted for the rest, and the default new-patch
+    /// lane stays recommended. Waives the CONSENT axis only (re-call with acknowledge=true).</summary>
+    static string InPlaceHandshakeText(string pluginName, string path) =>
+        $"in-place edit of '{pluginName}' — first-time confirmation (shown once for this plugin):\n" +
+        $"  • This writes to your ORIGINAL file ({path}). It will NO LONGER be untouched, and houseCARL keeps NO backup or undo — keep your own.\n" +
+        "  • houseCARL re-lays-out the WHOLE plugin the way xEdit/CK do on save (every record re-serialized), VERIFIES the records you edit, and trusts Mutagen for the rest.\n" +
+        "  • It still refuses if the file can't be parsed, or carries engine-reserved (sub-0x800) records.\n" +
+        "  • The default lane (a NEW patch, originals untouched) stays the recommended way — this is the explicit opt-in.\n" +
+        "Re-call the SAME edit with acknowledge=true to proceed.";
+
+    /// <summary>Writable-parent pre-flight for the in-place swap (§6 layer 3): the staged temp is a sibling of the
+    /// target, so prove the parent is writable NOW, loud, rather than degrade to a non-atomic write later. True (with a
+    /// named <paramref name="why"/>) ⇒ refuse. Probes by writing + deleting an empty sibling temp.</summary>
+    static bool InPlaceParentUnwritable(string targetPath, out string why)
+    {
+        why = "";
+        var dir = Path.GetDirectoryName(targetPath);
+        if (string.IsNullOrEmpty(dir) || !Directory.Exists(dir))
+        {
+            why = $"in-place refused: the target's parent folder '{dir}' does not exist — nothing written.";
+            return true;
+        }
+        try
+        {
+            var probe = Path.Combine(dir, ".housecarl-writeprobe-" + Guid.NewGuid().ToString("N"));
+            File.WriteAllBytes(probe, Array.Empty<byte>());
+            File.Delete(probe);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            why = $"in-place refused: the target's folder '{dir}' is not writable ({ex.GetType().Name}: {ex.Message}) — houseCARL " +
+                  "won't degrade to a non-atomic write. Make the mod folder writable (or move the plugin somewhere writable) and retry. Nothing written.";
+            return true;
+        }
+    }
+
+    /// <summary>Stamp the distinct <c>[houseCARL] editedInPlace=&lt;ISO&gt;</c> audit line into the target mod's
+    /// <c>meta.ini</c> (the MO2-undeployed mod-root file) — a breadcrumb that houseCARL touched this user mod, WITHOUT
+    /// ever writing <c>generated=true</c> (so <see cref="IsHouseCarlOwned"/> still reads FALSE and a later into= can't
+    /// blind-overwrite it — the safety property). PRESERVES every existing line (merges into / creates the
+    /// <c>[houseCARL]</c> section), and only for an MO2 mod folder under ModsDir (never pollutes the game Data dir for a
+    /// loose plugin). Best-effort: returns a Q3 note on failure (the edit already succeeded), null on success or N/A.</summary>
+    string? MergeEditedInPlaceMarker(string? modFolder)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(modFolder) || !IsUnderModsDir(modFolder)) return null;   // N/A for a non-MO2 target
+            var meta = Path.Combine(modFolder, "meta.ini");
+            var stamp = $"editedInPlace={DateTime.UtcNow:o}";
+            var lines = File.Exists(meta) ? File.ReadAllLines(meta).ToList() : new List<string>();
+
+            int sec = lines.FindIndex(l => l.Trim().Equals("[houseCARL]", StringComparison.OrdinalIgnoreCase));
+            if (sec < 0)
+            {
+                if (lines.Count > 0 && lines[^1].Trim().Length > 0) lines.Add("");
+                lines.Add("[houseCARL]");
+                lines.Add(stamp);
+            }
+            else
+            {
+                int edited = -1;
+                for (int i = sec + 1; i < lines.Count; i++)
+                {
+                    var t = lines[i].Trim();
+                    if (t.StartsWith('[') && t.EndsWith(']')) break;                          // next section — stop
+                    if (t.Replace(" ", "").StartsWith("editedInPlace=", StringComparison.OrdinalIgnoreCase)) { edited = i; break; }
+                }
+                if (edited >= 0) lines[edited] = stamp; else lines.Insert(sec + 1, stamp);    // update-or-insert within the section
+            }
+            File.WriteAllText(meta, string.Join("\r\n", lines) + "\r\n");
+            return null;
+        }
+        catch (Exception ex)
+        {
+            return $"the editedInPlace audit marker could not be written to the target's meta.ini ({ex.GetType().Name}) — the edit itself succeeded.";
+        }
+    }
+
+    /// <summary>True iff <paramref name="folder"/> is ModsDir itself or a folder directly/indirectly under it — the gate
+    /// that keeps the editedInPlace marker out of the game Data dir for a loose (non-MO2-managed) in-place target.</summary>
+    bool IsUnderModsDir(string folder)
+    {
+        if (string.IsNullOrEmpty(_modsDir)) return false;
+        try
+        {
+            var full = Path.GetFullPath(folder);
+            var mods = Path.GetFullPath(_modsDir);
+            return full.Equals(mods, StringComparison.OrdinalIgnoreCase)
+                || full.StartsWith(mods + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+        }
+        catch { return false; }
+    }
+
+    /// <summary>Join two optional Q3 notes into one (space-separated), or null when both are absent.</summary>
+    static string? JoinNotes(string? a, string? b)
+        => (a, b) switch { (null, null) => null, (null, _) => b, (_, null) => a, _ => a + " " + b };
 
     /// <summary>Remove WHOLE records a houseCARL patch carries (housecarl_remove_record) — literal drop-from-plugin, the
     /// companion to <see cref="ApplyEdits"/>. <paramref name="patch"/> is REQUIRED and names an existing houseCARL-owned

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -24,7 +24,9 @@ public static class WriteTools
          "defaults to Set; for collections use Add / Remove / SetAtIndex / ReplaceAll (key = a dict key or list index; " +
          "values = the whole new list for ReplaceAll). By default writes a fresh patch named patch_name; pass " +
          "into='<an existing patch's filename>' to ADD this edit to that patch instead (accumulate across calls and " +
-         "sessions). Pre-flight rejects an illegal edit with the reason and writes nothing (Q3). Returns the patch path, " +
+         "sessions). To edit an EXISTING plugin IN PLACE instead — rewriting your ORIGINAL file (incl. a mod houseCARL " +
+         "didn't make), not a patch — pass target=<plugin filename> + in_place=true (opt-in; see those params; the default " +
+         "patch lane leaves originals untouched). Pre-flight rejects an illegal edit with the reason and writes nothing (Q3). Returns the patch path, " +
          "its masters, and the value read back. Does NOT compose modeled structs (leveled-list entries, polymorphic " +
          "fields) or edit a dict via Merge — use housecarl_bulk_apply for those, or for many edits in one patch. Read " +
          "first with housecarl_read_record.")]
@@ -46,6 +48,12 @@ public static class WriteTools
             string patch_name = "houseCARL_Patch",
         [Description("Optional. Filename of an existing patch (from a prior call) to EXTEND with this edit instead of writing a fresh one — the way to accumulate edits into one patch across calls/sessions. Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead (folder & plugin names need not match).")]
             string? into = null,
+        [Description("Optional. IN-PLACE LANE (opt-in): the filename of an EXISTING active plugin to edit IN PLACE — including one houseCARL didn't author — instead of writing a new patch (e.g. 'CoolWeapons.esp'). Requires in_place=true; mutually exclusive with into=. OMIT this (the default) to write a NEW patch and leave every original untouched — the recommended lane.")]
+            string? target = null,
+        [Description("Optional, default false. With target=, edit that plugin IN PLACE: houseCARL rewrites your ORIGINAL file — no new patch, and NO houseCARL backup or undo (keep your own). It re-lays-out the whole plugin the way xEdit/CK do on save, VERIFIES the records you edit, and trusts Mutagen for the untouched rest; it refuses a file it can't parse or that holds engine-reserved (sub-0x800) records. The FIRST in-place edit of a given plugin returns a one-time confirmation prompt (re-call with acknowledge=true).")]
+            bool in_place = false,
+        [Description("Optional, default false. Confirms the one-time in-place trade-off for target (see in_place) — needed only on the FIRST in-place edit of a given plugin, never again for it. Waives the consent to touch your original ONLY; it NEVER skips the record verify.")]
+            bool acknowledge = false,
         [Description("When true, the response ALSO returns the ENTIRE edited record read back from the written patch file on disk (every field, deep — not just the edited leaf). The pre-enable verification: confirm the write landed exactly and nothing else in the record was disturbed, WITHOUT enabling the patch in MO2. (The patch wins nothing until enabled + sorted in MO2 — this read-back is the written file's content, not load-order truth.)")]
             bool full_readback = false,
         [Description("Optional. Max characters for the whole response; past it the full read-back section is cut with an explicit notice (never silent). 0 = the server default (~80k). Only matters with full_readback=true.")]
@@ -56,7 +64,7 @@ public static class WriteTools
         {
             Formid = formid, FieldPath = field_path, Verb = verb, Value = value, Key = key, Values = values,
         };
-        return Render(svc.ApplyEdits(new[] { op }, patch_name, into, full_readback), max_chars);
+        return Render(svc.ApplyEdits(new[] { op }, patch_name, into, full_readback, target, in_place, acknowledge), max_chars);
     });
 
     [McpServerTool(Name = "housecarl_bulk_apply", Title = "Apply many edits in one patch"),
@@ -74,7 +82,9 @@ public static class WriteTools
          "masters automatically when edits reference forms across several plugins (cross-master merge). ALL-OR-NOTHING " +
          "(Q3): if ANY operation is malformed or fails pre-flight, the whole call is refused with per-op reasons and " +
          "nothing is written — no partial patches. By default writes a fresh patch named patch_name; pass into= to extend " +
-         "an existing one. Returns the patch path, masters, and per-op read-back.")]
+         "an existing one. To edit an EXISTING plugin IN PLACE instead — rewriting your ORIGINAL file (incl. a mod houseCARL " +
+         "didn't make), not a patch — pass target=<plugin filename> + in_place=true (opt-in; the default lane leaves originals " +
+         "untouched). Returns the patch path, masters, and per-op read-back.")]
     public static string BulkApply(
         LoadOrderService svc,
         [Description("The edits to apply, all into one patch. Each: {formid, field_path, verb, value?, key?, values?, entries?, compose?}.")]
@@ -83,6 +93,12 @@ public static class WriteTools
             string patch_name = "houseCARL_Patch",
         [Description("Optional. Filename of an existing patch to EXTEND with these edits instead of writing a fresh one (accumulate across calls/sessions). Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead (folder & plugin names need not match).")]
             string? into = null,
+        [Description("Optional. IN-PLACE LANE (opt-in): the filename of an EXISTING active plugin to edit IN PLACE — including one houseCARL didn't author — instead of writing a new patch (e.g. 'CoolWeapons.esp'). Requires in_place=true; mutually exclusive with into=. OMIT this (the default) to write a NEW patch and leave every original untouched — the recommended lane.")]
+            string? target = null,
+        [Description("Optional, default false. With target=, edit that plugin IN PLACE: houseCARL rewrites your ORIGINAL file — no new patch, and NO houseCARL backup or undo (keep your own). It re-lays-out the whole plugin the way xEdit/CK do on save, VERIFIES the records you edit, and trusts Mutagen for the untouched rest; it refuses a file it can't parse or that holds engine-reserved (sub-0x800) records. The FIRST in-place edit of a given plugin returns a one-time confirmation prompt (re-call with acknowledge=true).")]
+            bool in_place = false,
+        [Description("Optional, default false. Confirms the one-time in-place trade-off for target (see in_place) — needed only on the FIRST in-place edit of a given plugin, never again for it. Waives the consent to touch your original ONLY; it NEVER skips the record verify.")]
+            bool acknowledge = false,
         [Description("When true, the response ALSO returns the ENTIRE record(s) this call touched, read back from the written patch file on disk (every field, deep — not just the edited leaves). The pre-enable verification: confirm composed structures (conditions, container entries) landed exactly and nothing else in each record was disturbed, WITHOUT enabling the patch in MO2. (The patch wins nothing until enabled + sorted in MO2 — this read-back is the written file's content, not load-order truth.)")]
             bool full_readback = false,
         [Description("Optional. Max characters for the whole response; past it the full read-back section is cut with an explicit notice (never silent). 0 = the server default (~80k). Only matters with full_readback=true.")]
@@ -91,7 +107,7 @@ public static class WriteTools
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         if (operations is null || operations.Length == 0)
             return "error: operations is empty. Pass one or more {formid, field_path, verb, ...} edits.";
-        return Render(svc.ApplyEdits(operations, patch_name, into, full_readback), max_chars);
+        return Render(svc.ApplyEdits(operations, patch_name, into, full_readback, target, in_place, acknowledge), max_chars);
     });
 
     [McpServerTool(Name = "housecarl_remove_record", Title = "Remove a whole record from a patch"),
@@ -283,14 +299,22 @@ public static class WriteTools
     /// On refusal, the full reason (every malformed/rejected op) so the caller can fix and retry.</summary>
     static string Render(WritePatchBuilder.PatchOutcome o, int maxChars = 0)
     {
+        if (o.NeedsAcknowledge) return o.Error!;            // the first-touch in-place CONSENT prompt — a required confirmation, NOT an error (Q3)
         if (!o.Success) return "error: " + o.Error;
         var file = Path.GetFileName(o.OutputPath);
         var modFolder = Path.GetFileName(Path.GetDirectoryName(o.OutputPath) ?? "");
         var sb = new StringBuilder();
-        sb.Append(o.Extended ? "extended " : "wrote ").Append(file)
-          .Append(o.Extended ? " (existing patch grown; " : " (new patch; ").Append(o.Bytes).Append(" bytes)\n");
-        sb.Append("mod folder: ").Append(modFolder)
-          .Append(o.Extended ? "\n" : "  — enable + sort it in MO2 to use the patch\n");
+        if (o.InPlace)
+            sb.Append("edited ").Append(file).Append(" IN PLACE (").Append(o.Bytes)
+              .Append(" bytes — your ORIGINAL file was rewritten; no houseCARL backup or undo)\n")
+              .Append("mod folder: ").Append(modFolder).Append("  — already active in your load order; re-sort only if a winner changed\n");
+        else
+        {
+            sb.Append(o.Extended ? "extended " : "wrote ").Append(file)
+              .Append(o.Extended ? " (existing patch grown; " : " (new patch; ").Append(o.Bytes).Append(" bytes)\n");
+            sb.Append("mod folder: ").Append(modFolder)
+              .Append(o.Extended ? "\n" : "  — enable + sort it in MO2 to use the patch\n");
+        }
         sb.Append("masters: ").Append(o.Masters.Count == 0 ? "(none)" : string.Join(", ", o.Masters)).Append('\n');
         sb.Append(o.Ops.Count).Append(o.Ops.Count == 1 ? " edit:\n" : " edits:\n");
         foreach (var op in o.Ops)
@@ -306,7 +330,10 @@ public static class WriteTools
             sb.Append("note: this edit touched a dialogue line (INFO). Voice (.fuz) and result-script coverage are checked on CREATE, not on edits — ")
               .Append("run housecarl_validate_dialogue on the topic (or its owning quest) to audit voice + result-script coverage and the topic graph over the edited line and every other line in the topic.\n");
         if (o.ReadBack is { } rb) AppendFullReadback(sb, rb, maxChars);
-        sb.Append("to add more edits to THIS patch, pass into=\"").Append(file).Append("\".");
+        if (o.Note is { } note) sb.Append("note: ").Append(note).Append('\n');
+        sb.Append(o.InPlace
+            ? $"to make more in-place edits to this plugin, pass target=\"{file}\" in_place=true (no further confirmation needed for it)."
+            : $"to add more edits to THIS patch, pass into=\"{file}\".");
         return sb.ToString();
     }
 


### PR DESCRIPTION
## In-place write lane — Wave 1 (the edit path)

The opt-in **second write lane**: `set_field` / `bulk_apply` with `target=<plugin>` + `in_place=true` rewrite an **existing** plugin — including one houseCARL didn't author — back over itself, instead of writing a new patch. The default patch lane is unchanged and stays the documented default. PRFAQ §4 outcome (a); the record-type-coverage cornerstone is untouched (in-place is a write-*destination* choice).

This PR folds the **Wave 0 round-trip probe** (`b6b805e`) + the **Wave 1 edit lane** (`8bbc38b`).

### Model C — what the Wave 0 probe decided
Byte-strict round-trip is non-viable (the probe measured ~80% of real plugins re-serialize with benign record **reordering — zero drops**; Mutagen can't even write sub-0x800 vanilla records). So in-place re-serializes the whole plugin **like xEdit/CK do on save**, **verifies the records you touched**, and trusts Mutagen for the rest — the bar every established tool meets. The whole §5 round-trip floor the original plan carried is **dropped**.

### The one design judgment worth a close look
In-place serializes via a dedicated **`WriteEngine.WriteInPlace`** that mirrors the **probe's** incantation — the target's **own declared masters** as the load order, `NoNextFormIDProcessing`, **no** `WithExtraIncludedMasters` baseline, **no** `EnsureFormIdFloor` — **not** `WriteEngine.WritePatch`. `WritePatch`'s new-patch conventions (force-add Skyrim.esm+Update.esm, floor the counter) would change a user mod's master list + counter in ways the probe never measured and xEdit doesn't do. Mirroring the probe is what makes its "zero record drops" result actually transfer to this lane.

### What's here
- **`WriteEngine.WriteInPlace` / `WriteInPlaceStaged`** — the probe-faithful serialize; shares the stage→`AtomicFile.Commit` crash-atomic swap.
- **`WritePatchBuilder.ApplyInPlace`** — a sibling of `Apply` (`Apply` left **untouched**, zero patch-lane regression risk). Sources the body from the **target**, not the load-order winner, and **refuses if the target doesn't define the FormKey** (the §4.1 content-source guard). Reuses `GenericGetOrAddAsOverride` / `ApplyVerb` / the full-readback touched-record verify.
- **`LoadOrderService`** — `target=`/`in_place=`/`acknowledge=` on `ApplyEdits`; the foreign-target resolver (`LoadOrderResolver.PluginPath`, ownership gate **dropped**); the **persistent first-touch consent handshake** (`UserConfig`, keyed off the resolved path; waives the consent axis only, never the verify); writable-parent pre-flight; the `editedInPlace=` marker (**never** `generated=true`, so `IsHouseCarlOwned` stays false and a later `into=` can't blind-overwrite the user mod).
- **Tool surface** — `target`/`in_place`/`acknowledge` on `set_field`/`bulk_apply`; `Render` shows the in-place confirmation + the first-touch handshake prompt (not "error:").

### Proof (RED-provable)
- **`inplace-guard`** (new self-contained CI guard) — content sourced from the target not the winner (the edited record's untouched `Name` stays `UserSword`, never the winner's `HighSword`) + refuse-if-undefined; **counter preserved** (`0x123`, not floored); **masters lean** (no baseline added); flat self-lock; the handshake (refuse → acknowledge → no re-prompt → **persists cross-session**); resolver/contract refusals; opt-in defaults OFF.
- **`inplace-nested-proof`** (real data) — the nested-record (`LinkCacheFor`-on-a-foreign-target) lock; PASS vs `Skyrim.esm`, self-skips on the runner.
- No regression: `writelock` / `verify-loop` / `upsert` / `forward-from-plugin` / `freshness-capture` / `write-mutex` guards still green.

### Scope
The **edit** path only. **create-into-existing** (`create_record`/`bulk_create` in place) is a distinct mechanism (new-FormID allocation — it *advances* the counter, no content-source guard) and lands as **Wave 1b**. Remove-in-place is Wave 2; script/BSA-in-place is Wave 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
