### PR TITLE
feat: in-place write lane Wave 1b — create new records into an existing plugin in place (create_record/bulk_create)

### DIFF
--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -163,6 +163,24 @@ public static class WritePatchBuilder
     {
         public IReadOnlyList<FullReadback>? ReadBack { get; init; }
 
+        /// <summary>True ⇒ this outcome came from the IN-PLACE create lane (<see cref="CreateRecords"/>'s sibling
+        /// <see cref="CreateRecordsInPlace"/>) — the new records were allocated into the USER's own file at
+        /// <see cref="OutputPath"/>, not a new patch. Drives the distinct "created in place" confirmation (and the
+        /// "no undo; keep your own backup" note). Mirrors <see cref="PatchOutcome.InPlace"/>.</summary>
+        public bool InPlace { get; init; }
+
+        /// <summary>True ⇒ NOT a write and NOT an error: the server-enforced first-touch in-place CONSENT handshake.
+        /// The in-place create lane refused to write this plugin until the user acknowledges the trade-off;
+        /// <see cref="Error"/> carries the prompt verbatim (re-call with acknowledge=true). Rendered as a confirmation
+        /// prompt, never "error:" (Q3). Nothing was written; the original is untouched. Mirrors
+        /// <see cref="PatchOutcome.NeedsAcknowledge"/>.</summary>
+        public bool NeedsAcknowledge { get; init; }
+
+        /// <summary>An optional Q3 honesty note appended to a SUCCESSFUL outcome — a side effect that didn't land cleanly
+        /// even though the write did (e.g. the in-place acknowledgement couldn't be persisted, or the editedInPlace audit
+        /// marker couldn't be written). Null when there's nothing to add. Mirrors <see cref="PatchOutcome.Note"/>.</summary>
+        public string? Note { get; init; }
+
         /// <summary>The voice-coverage report for the INFOs this call created (Layer B unit B) — null unless the call
         /// created ≥1 dialogue line. Filled by the SERVICE post-write (it owns the live AssetResolver), NOT by the core
         /// create path: a `with { Voice = … }` enrich on the returned outcome, so <see cref="CreateRecords"/> stays a
@@ -183,6 +201,13 @@ public static class WritePatchBuilder
 
         public static CreateOutcome Fail(string error) =>
             new(false, error, "", false, Array.Empty<CreatedRecord>(), Array.Empty<string>(), 0);
+
+        /// <summary>The first-touch in-place consent handshake: no write, no error — a required confirmation carrying the
+        /// trade-off <paramref name="prompt"/> (the caller re-calls with acknowledge=true). Success=false so no downstream
+        /// success path runs; <see cref="NeedsAcknowledge"/> tells the renderer to show it as a prompt. Mirrors
+        /// <see cref="PatchOutcome.NeedsAck"/>.</summary>
+        public static CreateOutcome NeedsAck(string prompt) =>
+            new(false, prompt, "", false, Array.Empty<CreatedRecord>(), Array.Empty<string>(), 0) { NeedsAcknowledge = true };
     }
 
     /// <summary>How deep the full read-back reads each written record — the same rationale as the conflict diff's
@@ -911,25 +936,51 @@ public static class WritePatchBuilder
     /// <see cref="WriteEngine.CanCreateNested"/>. <paramref name="extend"/>=false writes a fresh patch (ModKey = filename);
     /// =true adds to an existing one (the into= path). ALL-OR-NOTHING (Q3): any pre-flight problem — missing editorid, an
     /// un-createable type, an unresolvable parent, a rejected edit — refuses the WHOLE call with no file written.
+    ///
+    /// <paramref name="inPlaceTarget"/> (non-null) switches to the IN-PLACE lane (Wave 1b): <paramref name="outPath"/> IS
+    /// the target plugin's real on-disk path and the records are allocated INTO it + the whole plugin re-serialized over
+    /// itself (model C, <see cref="WriteEngine.WriteInPlace"/>) instead of a new patch — full create parity, incl. nesting
+    /// under a parent the target doesn't itself own (the parent is overridden IN, exactly as the patch lane does into a new
+    /// patch; a parent the target DOES own is sourced from the target so its content is preserved). Every in-place fork is
+    /// additive + gated on this param: the patch lane (inPlaceTarget null) is behaviourally unchanged.
     /// </summary>
     public static CreateOutcome CreateRecords(
         LoadOrderResolver resolver, CorpusRulebook rulebook,
-        IReadOnlyList<CreateSpec> specs, string outPath, bool extend, bool fullReadback = false)
+        IReadOnlyList<CreateSpec> specs, string outPath, bool extend, bool fullReadback = false, string? inPlaceTarget = null)
     {
         if (specs.Count == 0) return CreateOutcome.Fail("no records to create supplied.");
+        bool inPlace = inPlaceTarget is not null;
 
         // Per-call overlay session (Option B): the known-master set for the serialize is opened through it and disposed
-        // when the method returns — no handle held at rest.
+        // when the method returns — no handle held at rest. The view is captured up front (the in-place Phase-0 guard needs
+        // it; the patch lane uses it identically in Phase 1).
         using var session = resolver.OpenSession();
+        var view = resolver.Capture();
 
-        // --- Phase 0: open (extend) or create the patch mod FIRST — moved AHEAD of pre-flight so a FormKey parent can
-        //     resolve from the PATCH being extended (a parent created in a PRIOR into= call), not the load order alone
-        //     (the former N9 gap). CreateFromBinary reads the file fully into memory and holds NO handle at rest (the
-        //     active-patch self-lock invariant is untouched — Phase 4's ReleaseOverlay + AllMastersExcept still guard the
-        //     serialize); nothing is mutated until Phase 3 and nothing serialized until Phase 4, so all-or-nothing holds. ---
+        // --- Phase 0: open the destination FIRST — moved AHEAD of pre-flight so a FormKey parent can resolve from it (a
+        //     parent created in a PRIOR into= call, or — in place — a parent the target itself owns). CreateFromBinary reads
+        //     the file fully into memory and holds NO handle at rest (the active-patch self-lock invariant is untouched —
+        //     Phase 4's ReleaseOverlay + AllMastersExcept still guard the serialize); nothing is mutated until Phase 3 and
+        //     nothing serialized until Phase 4, so all-or-nothing holds. IN-PLACE: the destination IS the target plugin. ---
         var fileName = Path.GetFileName(outPath);
         SkyrimMod patchMod;
-        if (extend)
+        if (inPlace)
+        {
+            // The target must be an active, fully-parseable plugin (the excluded-plugin guard, same as ApplyInPlace):
+            // houseCARL won't re-serialize a plugin it can't fully parse — that would risk DROPPING a record it couldn't read (Q3).
+            if (!view.ContainsPlugin(inPlaceTarget!))
+                return CreateOutcome.Fail($"in-place target '{inPlaceTarget}' is not an active plugin in the load order.");
+            if (view.ExcludedPlugins.TryGetValue(inPlaceTarget!, out var excluded))
+                return CreateOutcome.Fail(
+                    $"cannot create into '{inPlaceTarget}' in place: it was EXCLUDED from this session ({excluded}) — houseCARL won't " +
+                    "re-serialize a plugin it can't fully parse (that would risk dropping a record it couldn't read, Q3). The file is UNTOUCHED.");
+            if (!File.Exists(outPath))
+                return CreateOutcome.Fail($"in-place target '{fileName}' not found on disk at {outPath} — the file is untouched.");
+            try { patchMod = SkyrimMod.CreateFromBinary(outPath, SkyrimRelease.SkyrimSE); }
+            catch (Exception ex)
+                { return CreateOutcome.Fail($"cannot open '{fileName}' to create into it in place ({WriteEngine.Describe(ex)}) — a plugin Mutagen can't parse is refused, not re-emitted minus what it couldn't read (Q3). The file is UNTOUCHED."); }
+        }
+        else if (extend)
         {
             if (!File.Exists(outPath))
                 return CreateOutcome.Fail($"cannot extend: no existing patch at {outPath}. Omit into= to create it fresh.");
@@ -941,7 +992,7 @@ public static class WritePatchBuilder
             patchMod = new SkyrimMod(new ModKey(Path.GetFileNameWithoutExtension(outPath), ModType.Plugin), SkyrimRelease.SkyrimSE);
         }
         if (!string.Equals(patchMod.ModKey.FileName.String, fileName, StringComparison.OrdinalIgnoreCase))
-            return CreateOutcome.Fail($"patch ModKey '{patchMod.ModKey.FileName}' must match output filename '{fileName}'.");
+            return CreateOutcome.Fail($"{(inPlace ? "in-place" : "patch")} ModKey '{patchMod.ModKey.FileName}' must match {(inPlace ? "the target filename" : "output filename")} '{fileName}'.");
 
         // --- Phase 1: pre-flight EVERY spec before any mutation (Q3, all-or-nothing). editorid required + unique; the
         //     type must be createable — a FLAT top-level type (CanCreateType), OR a NESTED child given a valid parent
@@ -951,7 +1002,6 @@ public static class WritePatchBuilder
         //     edit is validated by the rulebook rooted at the create type. The new FormID isn't known until allocation
         //     (Phase 3), so creatability is STRUCTURAL; a FormKey parent is resolved here only to learn its TYPE + stash
         //     the route to make it settable in Phase 3. ONE captured build answers every parent resolve (hunt-F5). ---
-        var view = resolver.Capture();
         var problems = new List<string>();
         var seenEdid = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var declaredEdidType = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);   // editorid -> RecordType (same-call sibling parents)
@@ -985,14 +1035,26 @@ public static class WritePatchBuilder
                 Type? parentType = null;
                 if (FormKey.TryFactory(s.ParentRef, out var parentFk))
                 {
-                    var w = view.ResolveWinner(parentFk);
-                    if (w is not null)
+                    // IN-PLACE target-owned parent (the create-side of the edit lane's content-source guard): if the TARGET
+                    // itself carries the parent (defines or overrides it), use ITS OWN copy directly — preserve the user's
+                    // parent content + just add the child. The winner-source path below would instead override the load-order
+                    // WINNER in, clobbering the user's content for a parent they own but don't win. (Patch lane: inPlace false
+                    // => skips this; the prior-into= patchMod-carries branch still serves it, unchanged.)
+                    if (inPlace && patchMod.EnumerateMajorRecords().FirstOrDefault(r => r.FormKey == parentFk) is { } ownParent)
                     {
-                        // An EXISTING load-order parent (a topic/cell from a master or mod): override it INTO the patch in Phase 3.
-                        var parentBody = view.GetRecord(session, w.Value.WinnerPlugin, parentFk);
-                        if (parentBody is null) { problems.Add($"{s.RecordType} '{s.EditorId}': parent {parentFk} winner '{w.Value.WinnerPlugin}' did not yield it on fetch (a load-order inconsistency)."); continue; }
+                        parentType = WriteEngine.ResolveConcreteRecordType(RecordNaming.StripOverlay(ownParent.GetType().Name));
+                        parentPlans[i] = (null, null, null, ownParent);
+                    }
+                    else if (view.ResolveWinner(parentFk) is { } w)
+                    {
+                        // An EXISTING load-order parent (a topic/cell from a master or mod): override it INTO the destination
+                        // in Phase 3. In place, this is the FOREIGN-parent case — the parent the target doesn't own — and
+                        // overriding it in to host the child is exactly what the patch lane does into a new patch (correct,
+                        // necessary nesting, NOT injection: the user explicitly named the parent; the override is reported).
+                        var parentBody = view.GetRecord(session, w.WinnerPlugin, parentFk);
+                        if (parentBody is null) { problems.Add($"{s.RecordType} '{s.EditorId}': parent {parentFk} winner '{w.WinnerPlugin}' did not yield it on fetch (a load-order inconsistency)."); continue; }
                         parentType = WriteEngine.ResolveConcreteRecordType(RecordNaming.StripOverlay(parentBody.GetType().Name));
-                        parentPlans[i] = (parentBody, w.Value.WinnerPlugin, null, null);
+                        parentPlans[i] = (parentBody, w.WinnerPlugin, null, null);
                     }
                     else if (patchMod.EnumerateMajorRecords().FirstOrDefault(r => r.FormKey == parentFk) is { } patchParent)
                     {
@@ -1004,10 +1066,10 @@ public static class WritePatchBuilder
                     }
                     else
                     {
-                        // Genuinely absent from BOTH the load order and the patch — the surviving loud refusal (Q3, never a
+                        // Genuinely absent from the load order AND the destination — the surviving loud refusal (Q3, never a
                         // misleading "wrong FormID"). Name the one-call workaround for the common new-topic case.
                         problems.Add($"{s.RecordType} '{s.EditorId}': parent {parentFk} is not present in the load order"
-                            + (extend ? " or this patch" : "") + " — name an existing parent, or create the parent and this "
+                            + (extend ? " or this patch" : "") + (inPlace ? " or the target plugin" : "") + " — name an existing parent, or create the parent and this "
                             + "child in ONE call (a same-call sibling parent, by the parent's editorid).");
                         continue;
                     }
@@ -1174,8 +1236,18 @@ public static class WritePatchBuilder
         // Phase-1 winner fetch, when re-editing the patch's OWN override — there the winner IS the target); AllMastersExcept
         // keeps the target out of the master set. (writelock-probe / writelock-apply-probe; both halves guarded.)
         session.ReleaseOverlay(patchMod.ModKey.FileName.String);
-        try { WriteEngine.WritePatch(patchMod, session.AllMastersExcept(patchMod.ModKey.FileName.String), outPath); }
-        catch (Exception ex) { return CreateOutcome.Fail($"writing the patch after create failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}"); }
+        try
+        {
+            if (inPlace)
+                // Model C (the Wave 0 probe's incantation): re-emit the WHOLE target over itself — the author's counter
+                // preserved (NoNextFormIDProcessing, no re-floor; the allocation already floored+advanced it), no baseline
+                // force-include. Handed the SAME whole-master set as WritePatch, so a new record's cross-mod reference (incl.
+                // an overridden-in foreign parent) resolves + pulls its master into the lean derived header — xEdit-parity.
+                WriteEngine.WriteInPlace(patchMod, session.AllMastersExcept(patchMod.ModKey.FileName.String), outPath);
+            else
+                WriteEngine.WritePatch(patchMod, session.AllMastersExcept(patchMod.ModKey.FileName.String), outPath);
+        }
+        catch (Exception ex) { return CreateOutcome.Fail($"writing {(inPlace ? $"'{fileName}' in place" : "the patch")} after create failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}"); }
 
         // --- Phase 5: re-open + report the (derived) master header + bytes — and, on request, each created record's
         //     FULL read-back off that same re-opened file (see Apply's Phase 5). Dispose the overlay so the file isn't
@@ -1194,8 +1266,21 @@ public static class WritePatchBuilder
         catch (Exception ex) { return CreateOutcome.Fail($"records created + written but the patch could not be re-opened to confirm: {ex.Message}"); }
         finally { (back as IDisposable)?.Dispose(); }
 
-        return new CreateOutcome(true, null, outPath, extend, created, masters, bytes) { ReadBack = readBack };
+        return new CreateOutcome(true, null, outPath, extend, created, masters, bytes) { ReadBack = readBack, InPlace = inPlace };
     }
+
+    /// <summary>Create BRAND-NEW records IN PLACE inside an EXISTING plugin the user owns (in-place write lane, Wave 1b) —
+    /// the create sibling of <see cref="ApplyInPlace"/>, and the in-place ENTRY POINT into the shared
+    /// <see cref="CreateRecords"/> core: it forwards with <paramref name="targetName"/> as the in-place target, so the FULL
+    /// create capability — flat, nested (incl. under a parent the target doesn't own, overridden in to host the child), and
+    /// cells — runs the SAME proven path as the patch lane, pointed at <paramref name="targetPath"/> and serialized model-C
+    /// over the file itself (<see cref="WriteEngine.WriteInPlace"/>). The created-record verify
+    /// (<paramref name="fullReadback"/>) defaults ON. CONSENT + the persistent acknowledge handshake are enforced by the
+    /// SERVICE before this is reached.</summary>
+    public static CreateOutcome CreateRecordsInPlace(
+        LoadOrderResolver resolver, CorpusRulebook rulebook,
+        IReadOnlyList<CreateSpec> specs, string targetPath, string targetName, bool fullReadback = true)
+        => CreateRecords(resolver, rulebook, specs, targetPath, extend: false, fullReadback, inPlaceTarget: targetName);
 
     /// <summary>Read each just-written record IN FULL off the re-opened written file — the overlay Phase 5 already
     /// opens to confirm masters, so no new handle class (opened AFTER the serialize, disposed with Phase 5; the

--- a/src/housecarl-generator/InPlaceProbe.cs
+++ b/src/housecarl-generator/InPlaceProbe.cs
@@ -7,26 +7,36 @@ using HousecarlMcp;
 namespace HousecarlGenerator;
 
 /// <summary>
-/// SELF-CONTAINED CI REGRESSION GUARD for the IN-PLACE WRITE LANE, Wave 1 (dev/plans/IN_PLACE_WRITE_LANE_PLAN_2026-06-13.md
-/// §10 CI teeth). The in-place lane (set_field/bulk_apply with target=+in_place=true) edits an EXISTING plugin the user
-/// owns — incl. one houseCARL didn't author — back over itself, instead of writing a new patch. It is the one write lane
-/// that touches the user's ORIGINAL file, so the safety properties are load-bearing and each is RED-provable here:
+/// SELF-CONTAINED CI REGRESSION GUARD for the IN-PLACE WRITE LANE, Waves 1 + 1b (dev/plans/IN_PLACE_WRITE_LANE_PLAN_2026-06-13.md
+/// §10 CI teeth). The in-place EDIT lane (set_field/bulk_apply, Wave 1) edits an EXISTING plugin the user owns — incl. one
+/// houseCARL didn't author — back over itself; the in-place CREATE lane (create_record/bulk_create, Wave 1b) allocates
+/// BRAND-NEW records into it the same way. Both touch the user's ORIGINAL file, so the safety properties are load-bearing
+/// and each is RED-provable here:
 ///
-///   CONTENT-SOURCE (§4.1)  — the edit's body is the TARGET's OWN record, NEVER the load-order winner; a record the
+///   CONTENT-SOURCE (§4.1)  — the EDIT's body is the TARGET's OWN record, NEVER the load-order winner; a record the
 ///                            target doesn't define is REFUSED (no foreign content injected). RED if sourced from winner.
-///   COUNTER PRESERVED      — the author's HEDR.NextObjectID survives verbatim (WriteInPlace skips EnsureFormIdFloor). RED
+///   COUNTER (edit)         — the author's HEDR.NextObjectID survives verbatim (WriteInPlace skips EnsureFormIdFloor). RED
 ///                            if the patch-lane floor ran (a sub-0x800 author counter would jump to 0x800).
-///   MASTERS PRESERVED      — no Skyrim.esm/Update.esm baseline force-include (WriteInPlace ≠ WritePatch). RED if baseline added.
+///   COUNTER (create)       — a new record allocates a fresh FormID in the TARGET's OWN range; the allocation path floors
+///                            the target's counter and ADVANCES it (the opposite of edit's preserve). RED if it kept 0x123.
+///   MASTERS (edit)         — no Skyrim.esm/Update.esm baseline force-include (WriteInPlace ≠ WritePatch). RED if baseline added.
+///   MASTERS (create)       — a new record's cross-mod reference resolves + pulls its origin into the lean derived header
+///                            (the WHOLE known-master set is the serialize's resolution context). RED if own-masters-only.
 ///   FLAT LOCK (winner==target) — re-editing a record the ACTIVE target itself owns: Phase-1 fetch opens the target
 ///                            overlay, ReleaseOverlay must close it before the File.Replace swap. RED if it stays mapped.
 ///   CONSENT HANDSHAKE      — first in-place touch of a plugin REFUSES-and-explains (writes nothing); acknowledge=true
-///                            proceeds; a second edit does NOT re-prompt (persisted, cross-session via UserConfig).
+///                            proceeds; a second touch does NOT re-prompt (persisted, cross-session via UserConfig). The
+///                            acknowledgement is SHARED across the edit + create lanes (keyed off the resolved path).
+///   NESTED (create)        — a new child under ANY parent works in place (full create parity): a parent the target OWNS is
+///                            sourced from the target; a FOREIGN parent is overridden IN to host the child, as xEdit/the patch lane do.
 ///   RESOLVER / CONTRACT    — target= resolves the REAL active-plugin path (a non-load-order name REFUSES, never
 ///                            retargets); in_place needs target=, is mutually exclusive with into=; opt-in defaults OFF.
 ///
 /// Self-contained: synthesizes a master + a user override + a higher override in TEMP and generates the validator corpus
-/// BY CONSTRUCTION in-process (no game data, no checked-in corpus.json). Drives the REAL WritePatchBuilder.ApplyInPlace
-/// (builder arms) and the REAL LoadOrderService.ApplyEdits in-place branch (service arms, via the ForGuard seam).
+/// BY CONSTRUCTION in-process (no game data, no checked-in corpus.json). Drives the REAL WritePatchBuilder.ApplyInPlace /
+/// CreateRecordsInPlace (builder arms) and the REAL LoadOrderService in-place branches (service arms, via the ForGuard seam).
+/// Arms A–I cover the EDIT lane; J–P cover the CREATE lane (J create+counter, O cross-master, M nested-under-a-foreign-parent,
+/// P same-call nested unit, K handshake, L contract, N opt-in) and arm I also proves the create lane shares the marker + handshake.
 /// Run: dotnet run --project src/housecarl-generator inplace-guard
 ///
 /// The NESTED lock arm (the LinkCacheFor-on-a-foreign-target path) needs a real nested record + master, so it lives in
@@ -40,7 +50,7 @@ public static class InPlaceProbe
 
     public static int RunGuard(string[] args)
     {
-        Console.WriteLine("################  REGRESSION GUARD — in-place write lane, Wave 1  ################");
+        Console.WriteLine("################  REGRESSION GUARD — in-place write lane, Waves 1 + 1b  ################");
         Console.WriteLine();
 
         var tmpDir = Path.Combine(Path.GetTempPath(), "hc-inplace-guard");
@@ -61,12 +71,13 @@ public static class InPlaceProbe
         Directory.CreateDirectory(Path.GetDirectoryName(userPristine)!);
 
         var masterKey = new ModKey("HcInPlaceMaster", ModType.Master);
-        FormKey wfk, w2fk;
+        FormKey wfk, w2fk, tfk;
         {
             var m = new SkyrimMod(masterKey, SkyrimRelease.SkyrimSE);
             var w = m.Weapons.AddNew(); w.EditorID = "HcIP_Weap"; w.BasicStats = new WeaponBasicStats { Damage = 10 }; w.Name = "MasterSword";
             var w2 = m.Weapons.AddNew(); w2.EditorID = "HcIP_Weap2"; w2.BasicStats = new WeaponBasicStats { Damage = 5 };
-            wfk = w.FormKey; w2fk = w2.FormKey;
+            var t = m.DialogTopics.AddNew(); t.EditorID = "HcIP_Topic";   // a FOREIGN parent for the nested-in-place arm (M)
+            wfk = w.FormKey; w2fk = w2.FormKey; tfk = t.FormKey;
             m.BeginWrite.ToPath(masterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
         }
         using (var mOv = SkyrimMod.CreateFromBinaryOverlay(masterPath, SkyrimRelease.SkyrimSE))
@@ -87,6 +98,7 @@ public static class InPlaceProbe
 
         string fmtWfk = $"{wfk.ID:X6}:{MasterName}";       // the FormID the tools take (6 hex : defining master)
         string fmtW2fk = $"{w2fk.ID:X6}:{MasterName}";
+        string fmtTfk = $"{tfk.ID:X6}:{MasterName}";       // the foreign DialogTopic parent (arm M)
         var results = new List<(string name, bool pass, string detail)>();
 
         // ===== A — CONTENT-SOURCE / winner-injection: edit the USER's body, NOT the winner's =====
@@ -255,9 +267,152 @@ public static class InPlaceProbe
             var intoTry = svc.ApplyEdits(edit, null, UserName, fullReadback: false);
             bool ownedStaysFalse = !intoTry.Success;
             bool landed = ReadDamage(Path.Combine(uMod, UserName), wfk) == 61;
-            bool pass = wrote.Success && wrote.InPlace && landed && markerWritten && noGenerated && sentinelKept && ownedStaysFalse;
-            results.Add(("I editedInPlace marker + into= boundary (never generated=true)", pass,
-                $"wrote={wrote.Success} landed61={landed} marker={markerWritten} noGenerated={noGenerated} userSentinelKept={sentinelKept} into=StillRefusesUnowned={ownedStaysFalse}  [{Trim(wrote.Error)}]"));
+
+            // The CREATE lane shares this user mod's acknowledgement (keyed off the resolved path, recorded by the edit
+            // above) AND stamps the SAME editedInPlace marker via the SAME helper: a create-in-place here must NOT re-prompt
+            // (edit's ack covers it — the cross-lane handshake share, end-to-end) and must keep generated=true absent.
+            var createIP = svc.CreateRecords("Keyword", "HcIP_InstKw", Array.Empty<BulkOp>(), null, null, false, null, null, null, target: UserName, inPlace: true, acknowledge: false);
+            bool createShared = createIP.Success && createIP.InPlace && !createIP.NeedsAcknowledge;
+            string meta2 = File.Exists(userMeta) ? File.ReadAllText(userMeta) : "";
+            bool createNoGenerated = !meta2.Replace(" ", "").Contains("generated=true", StringComparison.OrdinalIgnoreCase) && meta2.Contains("editedInPlace=");
+
+            bool pass = wrote.Success && wrote.InPlace && landed && markerWritten && noGenerated && sentinelKept && ownedStaysFalse
+                     && createShared && createNoGenerated;
+            results.Add(("I editedInPlace marker + into= boundary + create-lane share (never generated=true)", pass,
+                $"wrote={wrote.Success} landed61={landed} marker={markerWritten} noGenerated={noGenerated} userSentinelKept={sentinelKept} into=StillRefusesUnowned={ownedStaysFalse} createSharesAck={createShared} createKeepsMarkerSafe={createNoGenerated}  [{Trim(wrote.Error)}]"));
+        }
+
+        // ===== J — CREATE-INTO-TARGET: a new flat record allocates a fresh FormID IN THE TARGET; the counter ADVANCES =====
+        // The create-side counter behaviour is the OPPOSITE of the edit lane's preserve: the allocation path floors the
+        // target's OWN counter (the author's sub-0x800 0x123 → 0x800) and advances it. A new Keyword lands in the USER
+        // mod's own range (FormKey.ModKey == the user mod), the counter jumps to keywordId+1, and the user's existing
+        // weapon override stays intact. RED if nothing was allocated, it allocated in the wrong plugin, or kept 0x123.
+        {
+            var userJ = FreshUser(tmpDir, "J", userPristine);
+            using var r = LoadOrderResolver.Build(new[] { masterPath, userJ, highPath });
+            var o = WritePatchBuilder.CreateRecordsInPlace(r, rulebook,
+                new[] { new WritePatchBuilder.CreateSpec { RecordType = "Keyword", EditorId = "HcIP_NewKw", Edits = Array.Empty<WriteRequest>() } },
+                userJ, UserName);
+            var newFk = o.Created.Count > 0 ? o.Created[0].FormKey : default;
+            bool inTarget = newFk.ModKey.FileName.String.Equals(UserName, StringComparison.OrdinalIgnoreCase) && newFk.ID >= 0x800;
+            uint nextId = ReadNextFormId(userJ);
+            string newEdid = ReadEditorIdAt(userJ, newFk);
+            int wDmg = ReadDamage(userJ, wfk); string wName = ReadName(userJ, wfk);
+            bool pass = o.Success && o.InPlace && inTarget && nextId == newFk.ID + 1 && newEdid == "HcIP_NewKw" && wDmg == 20 && wName == "UserSword";
+            results.Add(("J create-into-target (fresh FormID in target, counter advances)", pass,
+                $"success={o.Success} inPlace={o.InPlace} newFk={newFk}(want ID>=0x800 in {UserName}) counter=0x{nextId:X}(want 0x{newFk.ID + 1:X}, NOT 0x123) edid='{newEdid}' weaponOverride=dmg{wDmg}/'{wName}'(want 20/UserSword)  [{o.Error ?? "ok"}]"));
+        }
+
+        // ===== O — CROSS-MASTER REFERENCE: a new record referencing another plugin ADDS that plugin as a master =====
+        // The model-C create serialize hands WriteInPlace the WHOLE known-master set (AllMastersExcept the target), exactly
+        // as xEdit/the patch lane do, so a created record's reference resolves and its origin is pulled into the lean
+        // derived header. Into a BARE user mod with NO masters: a new FormList whose Items reference the master weapon must
+        // make HcInPlaceMaster.esm a master. RED if the serialize used own-masters-only (a bare mod has none → the
+        // reference can't resolve → the write throws or the master is absent).
+        {
+            var bareDir = Path.Combine(tmpDir, "arm-O"); Directory.CreateDirectory(bareDir);
+            var bare = Path.Combine(bareDir, "HcInPlaceBare.esp");
+            new SkyrimMod(new ModKey("HcInPlaceBare", ModType.Plugin), SkyrimRelease.SkyrimSE)
+                .BeginWrite.ToPath(bare).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            using var r = LoadOrderResolver.Build(new[] { masterPath, bare });
+            var o = WritePatchBuilder.CreateRecordsInPlace(r, rulebook,
+                new[] { new WritePatchBuilder.CreateSpec { RecordType = "FormList", EditorId = "HcIP_RefFlst",
+                    Edits = new[] { new WriteRequest { RecordType = "FormList", Path = new[] { "Items" }, Verb = "Add", Value = fmtWfk } } } },
+                bare, "HcInPlaceBare.esp");
+            var masters = ReadMasters(bare);
+            bool added = masters.Any(m => m.Equals(MasterName, StringComparison.OrdinalIgnoreCase));
+            bool pass = o.Success && o.InPlace && added;
+            results.Add(("O cross-master reference adds the master (xEdit-parity serialize)", pass,
+                $"success={o.Success} inPlace={o.InPlace} masters=[{string.Join(",", masters)}](want incl. {MasterName})  [{o.Error ?? "ok"}]"));
+        }
+
+        // ===== M — NESTED UNDER A FOREIGN PARENT works in place (full create parity — the corrected scope) =====
+        // Add a NEW dialogue line (DialogResponses/INFO) under the MASTER's topic — a parent the user mod does NOT own —
+        // straight into the user mod in place. This is normal authoring (xEdit/the patch lane do exactly it): the foreign
+        // parent is OVERRIDDEN INTO the user mod to host the child, the child gets a fresh FormID in the user's range, and
+        // the user's existing records stay intact. RED if it refused, or didn't override the parent in / land the child.
+        {
+            var userM = FreshUser(tmpDir, "M", userPristine);
+            using var r = LoadOrderResolver.Build(new[] { masterPath, userM, highPath });
+            var o = WritePatchBuilder.CreateRecordsInPlace(r, rulebook,
+                new[] { new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcIP_NewLine", Edits = Array.Empty<WriteRequest>(), ParentRef = fmtTfk } },
+                userM, UserName);
+            var infoFk = o.Created.Count > 0 ? o.Created[0].FormKey : default;
+            bool childInTarget = infoFk.ModKey.FileName.String.Equals(UserName, StringComparison.OrdinalIgnoreCase) && infoFk.ID >= 0x800;
+            bool parentOverriddenIn = RecordPresent(userM, tfk);   // the foreign topic is now carried (as an override) by the user mod
+            int wDmg = ReadDamage(userM, wfk);                     // the user's existing weapon override stays intact
+            bool pass = o.Success && o.InPlace && childInTarget && parentOverriddenIn && wDmg == 20;
+            results.Add(("M nested under a FOREIGN parent works in place (parent overridden in + child)", pass,
+                $"success={o.Success} inPlace={o.InPlace} childFk={infoFk}(in {UserName}) foreignTopicOverriddenIn={parentOverriddenIn} weaponIntact={wDmg == 20}  [{o.Error ?? "ok"}]"));
+        }
+
+        // ===== K — CONSENT HANDSHAKE for create: RED (first refuses) → GREEN (acknowledge writes) → no re-prompt =====
+        {
+            var userK = FreshUser(tmpDir, "K", userPristine);
+            byte[] before = File.ReadAllBytes(userK);
+            bool red, untouched, green, noReprompt;
+            using (var r = LoadOrderResolver.Build(new[] { masterPath, userK }))
+            {
+                var svc = LoadOrderService.ForGuard(r, new UserConfigStore(Path.Combine(tmpDir, "K.user.json")));
+                var first = svc.CreateRecords("Keyword", "HcIP_KwA", Array.Empty<BulkOp>(), null, null, false, null, null, null, target: UserName, inPlace: true, acknowledge: false);
+                red = first.NeedsAcknowledge && !first.Success;
+                untouched = File.ReadAllBytes(userK).AsSpan().SequenceEqual(before);
+                var ack = svc.CreateRecords("Keyword", "HcIP_KwA", Array.Empty<BulkOp>(), null, null, false, null, null, null, target: UserName, inPlace: true, acknowledge: true);
+                green = ack.Success && ack.InPlace;
+                var again = svc.CreateRecords("Keyword", "HcIP_KwB", Array.Empty<BulkOp>(), null, null, false, null, null, null, target: UserName, inPlace: true, acknowledge: false);
+                noReprompt = again.Success && !again.NeedsAcknowledge;
+            }
+            bool pass = red && untouched && green && noReprompt;
+            results.Add(("K create handshake RED->GREEN->no-reprompt", pass,
+                $"firstRefused={red} untouched={untouched} ackWrote={green} secondNoPrompt={noReprompt}"));
+        }
+
+        // ===== L — CONTRACT validation for create (mirror the edit lane's E) =====
+        {
+            var userL = FreshUser(tmpDir, "L", userPristine);
+            using var r = LoadOrderResolver.Build(new[] { masterPath, userL, highPath });
+            var svc = LoadOrderService.ForGuard(r, new UserConfigStore(Path.Combine(tmpDir, "L.user.json")));
+            var noTarget = svc.CreateRecords("Keyword", "HcIP_K", Array.Empty<BulkOp>(), null, null, false, null, null, null, target: null, inPlace: true, acknowledge: true);
+            var withInto = svc.CreateRecords("Keyword", "HcIP_K", Array.Empty<BulkOp>(), null, "somepatch", false, null, null, null, target: UserName, inPlace: true, acknowledge: true);
+            var targetNoFlag = svc.CreateRecords("Keyword", "HcIP_K", Array.Empty<BulkOp>(), null, null, false, null, null, null, target: UserName, inPlace: false, acknowledge: false);
+            bool pass = !noTarget.Success && (noTarget.Error?.Contains("requires target=") ?? false)
+                     && !withInto.Success && (withInto.Error?.Contains("mutually exclusive") ?? false)
+                     && !targetNoFlag.Success && (targetNoFlag.Error?.Contains("only meaningful with in_place") ?? false);
+            results.Add(("L contract (in_place<->target, _|_ into=) — create", pass,
+                $"noTarget={Trim(noTarget.Error)} | into={Trim(withInto.Error)} | noFlag={Trim(targetNoFlag.Error)}"));
+        }
+
+        // ===== N — OPT-IN BY CONSTRUCTION (create): create_record + bulk_create default the three params OFF =====
+        {
+            var cr = typeof(WriteTools).GetMethod(nameof(WriteTools.CreateRecord))!;
+            var bc = typeof(WriteTools).GetMethod(nameof(WriteTools.BulkCreate))!;
+            bool DefOff(System.Reflection.MethodInfo m) =>
+                m.GetParameters().First(p => p.Name == "in_place").DefaultValue is false
+                && m.GetParameters().First(p => p.Name == "target").DefaultValue is null
+                && m.GetParameters().First(p => p.Name == "acknowledge").DefaultValue is false;
+            bool pass = DefOff(cr) && DefOff(bc);
+            results.Add(("N opt-in by construction (create_record/bulk_create default OFF)", pass,
+                $"create_record={DefOff(cr)} bulk_create={DefOff(bc)}"));
+        }
+
+        // ===== P — SAME-CALL nested unit in place (a NEW topic + its NEW line, both into the user mod) =====
+        // The headline "author a new dialogue unit straight into my mod" case: bulk-create a topic AND a line under it
+        // (a same-call SIBLING parent), both net-new, in place. RED if either didn't land or the sibling-parent wiring
+        // broke under the in-place lane.
+        {
+            var userP = FreshUser(tmpDir, "P", userPristine);
+            using var r = LoadOrderResolver.Build(new[] { masterPath, userP });
+            var o = WritePatchBuilder.CreateRecordsInPlace(r, rulebook, new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogTopic", EditorId = "HcIP_NewTopic", Edits = Array.Empty<WriteRequest>() },
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcIP_TopicLine", Edits = Array.Empty<WriteRequest>(), ParentRef = "HcIP_NewTopic" },
+            }, userP, UserName);
+            bool bothInTarget = o.Created.Count == 2 && o.Created.All(c => c.FormKey.ModKey.FileName.String.Equals(UserName, StringComparison.OrdinalIgnoreCase));
+            bool topicPresent = o.Created.Count > 0 && RecordPresent(userP, o.Created[0].FormKey);
+            bool linePresent = o.Created.Count > 1 && RecordPresent(userP, o.Created[1].FormKey);
+            bool pass = o.Success && o.InPlace && bothInTarget && topicPresent && linePresent;
+            results.Add(("P same-call nested unit (new topic + line) in place", pass,
+                $"success={o.Success} inPlace={o.InPlace} created={o.Created.Count}(want 2) bothInTarget={bothInTarget} topic={topicPresent} line={linePresent}  [{o.Error ?? "ok"}]"));
         }
 
         Console.WriteLine("── ARMS ──");
@@ -369,6 +524,22 @@ public static class InPlaceProbe
         ISkyrimModGetter? ov = null;
         try { ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE); return ov.Weapons.FirstOrDefault(x => x.FormKey == fk)?.Name?.String ?? "(none)"; }
         catch { return "(read failed)"; }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    static string ReadEditorIdAt(string path, FormKey fk)
+    {
+        ISkyrimModGetter? ov = null;
+        try { ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE); return ov.EnumerateMajorRecords().FirstOrDefault(r => r.FormKey == fk)?.EditorID ?? "(none)"; }
+        catch { return "(read failed)"; }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    static bool RecordPresent(string path, FormKey fk)
+    {
+        ISkyrimModGetter? ov = null;
+        try { ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE); return ov.EnumerateMajorRecords().Any(r => r.FormKey == fk); }
+        catch { return false; }
         finally { (ov as IDisposable)?.Dispose(); }
     }
 

--- a/src/housecarl-generator/InPlaceProbe.cs
+++ b/src/housecarl-generator/InPlaceProbe.cs
@@ -35,8 +35,9 @@ namespace HousecarlGenerator;
 /// Self-contained: synthesizes a master + a user override + a higher override in TEMP and generates the validator corpus
 /// BY CONSTRUCTION in-process (no game data, no checked-in corpus.json). Drives the REAL WritePatchBuilder.ApplyInPlace /
 /// CreateRecordsInPlace (builder arms) and the REAL LoadOrderService in-place branches (service arms, via the ForGuard seam).
-/// Arms A–I cover the EDIT lane; J–P cover the CREATE lane (J create+counter, O cross-master, M nested-under-a-foreign-parent,
-/// P same-call nested unit, K handshake, L contract, N opt-in) and arm I also proves the create lane shares the marker + handshake.
+/// Arms A–I cover the EDIT lane; J–Q cover the CREATE lane (J create+counter, O cross-master, M nested-under-a-foreign-parent,
+/// P same-call nested unit, Q exterior-cell-under-a-foreign-worldspace, K handshake, L contract, N opt-in) and arm I also
+/// proves the create lane shares the marker + handshake.
 /// Run: dotnet run --project src/housecarl-generator inplace-guard
 ///
 /// The NESTED lock arm (the LinkCacheFor-on-a-foreign-target path) needs a real nested record + master, so it lives in
@@ -71,13 +72,14 @@ public static class InPlaceProbe
         Directory.CreateDirectory(Path.GetDirectoryName(userPristine)!);
 
         var masterKey = new ModKey("HcInPlaceMaster", ModType.Master);
-        FormKey wfk, w2fk, tfk;
+        FormKey wfk, w2fk, tfk, wsfk;
         {
             var m = new SkyrimMod(masterKey, SkyrimRelease.SkyrimSE);
             var w = m.Weapons.AddNew(); w.EditorID = "HcIP_Weap"; w.BasicStats = new WeaponBasicStats { Damage = 10 }; w.Name = "MasterSword";
             var w2 = m.Weapons.AddNew(); w2.EditorID = "HcIP_Weap2"; w2.BasicStats = new WeaponBasicStats { Damage = 5 };
             var t = m.DialogTopics.AddNew(); t.EditorID = "HcIP_Topic";   // a FOREIGN parent for the nested-in-place arm (M)
-            wfk = w.FormKey; w2fk = w2.FormKey; tfk = t.FormKey;
+            var ws = m.Worldspaces.AddNew(); ws.EditorID = "HcIP_World";  // a FOREIGN worldspace for the exterior-cell-in-place arm (Q)
+            wfk = w.FormKey; w2fk = w2.FormKey; tfk = t.FormKey; wsfk = ws.FormKey;
             m.BeginWrite.ToPath(masterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
         }
         using (var mOv = SkyrimMod.CreateFromBinaryOverlay(masterPath, SkyrimRelease.SkyrimSE))
@@ -99,6 +101,7 @@ public static class InPlaceProbe
         string fmtWfk = $"{wfk.ID:X6}:{MasterName}";       // the FormID the tools take (6 hex : defining master)
         string fmtW2fk = $"{w2fk.ID:X6}:{MasterName}";
         string fmtTfk = $"{tfk.ID:X6}:{MasterName}";       // the foreign DialogTopic parent (arm M)
+        string fmtWsfk = $"{wsfk.ID:X6}:{MasterName}";     // the foreign Worldspace parent (arm Q)
         var results = new List<(string name, bool pass, string detail)>();
 
         // ===== A — CONTENT-SOURCE / winner-injection: edit the USER's body, NOT the winner's =====
@@ -413,6 +416,24 @@ public static class InPlaceProbe
             bool pass = o.Success && o.InPlace && bothInTarget && topicPresent && linePresent;
             results.Add(("P same-call nested unit (new topic + line) in place", pass,
                 $"success={o.Success} inPlace={o.InPlace} created={o.Created.Count}(want 2) bothInTarget={bothInTarget} topic={topicPresent} line={linePresent}  [{o.Error ?? "ok"}]"));
+        }
+
+        // ===== Q — EXTERIOR CELL create in place under a FOREIGN worldspace (closes the disclosed cell gap) =====
+        // Create a new EXTERIOR cell (grid=) under the MASTER's worldspace — a foreign parent that NEEDS a source link
+        // cache (LinkCacheFor on the foreign winner, the one nesting path arm M's topic parent doesn't exercise) — straight
+        // into the user mod in place. RED if it refused, didn't place the cell, or didn't override the worldspace in.
+        {
+            var userQ = FreshUser(tmpDir, "Q", userPristine);
+            using var r = LoadOrderResolver.Build(new[] { masterPath, userQ });
+            var o = WritePatchBuilder.CreateRecordsInPlace(r, rulebook,
+                new[] { new WritePatchBuilder.CreateSpec { RecordType = "Cell", EditorId = "HcIP_ExtCell", Edits = Array.Empty<WriteRequest>(), ParentRef = fmtWsfk, Grid = "5,-12" } },
+                userQ, UserName);
+            var cellFk = o.Created.Count > 0 ? o.Created[0].FormKey : default;
+            bool cellInTarget = cellFk.ModKey.FileName.String.Equals(UserName, StringComparison.OrdinalIgnoreCase) && cellFk.ID >= 0x800;
+            bool worldOverriddenIn = RecordPresent(userQ, wsfk);   // the foreign worldspace is now carried (as an override) by the user mod
+            bool pass = o.Success && o.InPlace && cellInTarget && worldOverriddenIn;
+            results.Add(("Q exterior cell in place under a foreign worldspace (LinkCacheFor + placement)", pass,
+                $"success={o.Success} inPlace={o.InPlace} cellFk={cellFk}(in {UserName}) worldOverriddenIn={worldOverriddenIn}  [{o.Error ?? "ok"}]"));
         }
 
         Console.WriteLine("── ARMS ──");

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1577,13 +1577,14 @@ public sealed class LoadOrderService : IDisposable
     /// resolver (<see cref="ResolveActivePluginPath"/>), the same PERSISTENT first-touch CONSENT handshake (keyed off the
     /// resolved path in <see cref="UserConfigStore"/>), the same writable-parent pre-flight, and the same distinct
     /// <c>editedInPlace=</c> marker (NEVER <c>generated=true</c> — the user mod keeps failing
-    /// <see cref="IsHouseCarlOwned"/> so a later into= can't blind-overwrite it). The ONLY divergences from
-    /// <see cref="ApplyEditsInPlace"/>: it drives <see cref="WritePatchBuilder.CreateRecordsInPlace"/> (allocate-into-target,
-    /// not edit-own-record) and returns a <see cref="WritePatchBuilder.CreateOutcome"/>. The created-record verify is forced
-    /// ON (the model-C substitute for the dropped whole-plugin floor). <paramref name="acknowledge"/> waives the CONSENT
-    /// axis ONLY — the verify is a corruption-axis fact no acknowledgement overrides. Runs under <c>_writeGate</c> (the
-    /// caller holds it). No post-write dialogue/cell teeth — Wave 1b is flat top-level records only, so no INFO/Cell can be
-    /// created here.</summary>
+    /// <see cref="IsHouseCarlOwned"/> so a later into= can't blind-overwrite it). THREE divergences from
+    /// <see cref="ApplyEditsInPlace"/>: (1) it drives <see cref="WritePatchBuilder.CreateRecordsInPlace"/>
+    /// (allocate-into-target, not edit-own-record); (2) it returns a <see cref="WritePatchBuilder.CreateOutcome"/>; and
+    /// (3) because in-place create has FULL parity — it can author dialogue lines / cells under any parent, unlike
+    /// <c>set_field</c> — it runs the SAME post-write voice/result-script/cell-shell coverage teeth the patch-lane create
+    /// runs (<see cref="ApplyEditsInPlace"/> is marker-only). The created-record verify is forced ON (the model-C
+    /// substitute for the dropped whole-plugin floor). <paramref name="acknowledge"/> waives the CONSENT axis ONLY — the
+    /// verify is a corruption-axis fact no acknowledgement overrides. Runs under <c>_writeGate</c> (the caller holds it).</summary>
     WritePatchBuilder.CreateOutcome CommitCreateInPlace(
         LoadOrderResolver resolver, CorpusRulebook rulebook, IReadOnlyList<WritePatchBuilder.CreateSpec> specs,
         string target, bool acknowledge)

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1444,14 +1444,15 @@ public sealed class LoadOrderService : IDisposable
     /// fitting child-list, <paramref name="collection"/>. For a parent + its children in ONE call (a topic + its lines, a
     /// child's parent= naming a same-call sibling), see <see cref="CreateRecordsBatch"/>.</summary>
     public WritePatchBuilder.CreateOutcome CreateRecords(string recordType, string editorid, IReadOnlyList<BulkOp> operations,
-        string? patchName, string? into, bool fullReadback = false, string? parent = null, string? collection = null, string? grid = null)
+        string? patchName, string? into, bool fullReadback = false, string? parent = null, string? collection = null, string? grid = null,
+        string? target = null, bool inPlace = false, bool acknowledge = false)
     {
         var problems = new List<string>();
         var spec = BuildCreateSpec(recordType, editorid, operations, parent, collection, grid, where: null, problems);
         if (spec is null)
             return WritePatchBuilder.CreateOutcome.Fail(
                 $"refused — {problems.Count} problem(s) creating the record; NOTHING created:\n  - " + string.Join("\n  - ", problems));
-        return CommitCreate(new[] { spec }, patchName, into, fullReadback);
+        return CommitCreate(new[] { spec }, patchName, into, fullReadback, target, inPlace, acknowledge);
     }
 
     /// <summary>Create MANY new records in ONE patch (housecarl_bulk_create) — the batch sibling of
@@ -1460,7 +1461,8 @@ public sealed class LoadOrderService : IDisposable
     /// the single create (type resolution + field-op mapping + parent/collection); ALL-OR-NOTHING (Q3) — any malformed
     /// spec refuses the whole call (with per-record reasons) and the core <see cref="WritePatchBuilder.CreateRecords"/>
     /// likewise refuses the whole batch on any creatability/parent problem. One serialize for the lot.</summary>
-    public WritePatchBuilder.CreateOutcome CreateRecordsBatch(IReadOnlyList<CreateOp> records, string? patchName, string? into, bool fullReadback = false)
+    public WritePatchBuilder.CreateOutcome CreateRecordsBatch(IReadOnlyList<CreateOp> records, string? patchName, string? into, bool fullReadback = false,
+        string? target = null, bool inPlace = false, bool acknowledge = false)
     {
         if (records is null || records.Count == 0)
             return WritePatchBuilder.CreateOutcome.Fail("no records to create supplied — pass one or more {record_type, editorid, operations?, parent?, collection?} specs.");
@@ -1476,7 +1478,7 @@ public sealed class LoadOrderService : IDisposable
         if (problems.Count > 0)
             return WritePatchBuilder.CreateOutcome.Fail(
                 $"refused — {problems.Count} problem(s) across {records.Count} record(s); NOTHING created:\n  - " + string.Join("\n  - ", problems));
-        return CommitCreate(specs, patchName, into, fullReadback);
+        return CommitCreate(specs, patchName, into, fullReadback, target, inPlace, acknowledge);
     }
 
     /// <summary>Build ONE core <see cref="WritePatchBuilder.CreateSpec"/> from wire parts (shared by the single create and
@@ -1530,12 +1532,31 @@ public sealed class LoadOrderService : IDisposable
     /// <summary>Resolve the folder-per-patch output (fresh, or <paramref name="into"/> an existing houseCARL-owned patch),
     /// then drive the core multi-record create + serialize under the write gate (hunt F2: one write at a time). A refused
     /// create that just created the output folder leaves no orphan (hunt F4). Shared by the single + batch create.</summary>
-    WritePatchBuilder.CreateOutcome CommitCreate(IReadOnlyList<WritePatchBuilder.CreateSpec> specs, string? patchName, string? into, bool fullReadback)
+    WritePatchBuilder.CreateOutcome CommitCreate(IReadOnlyList<WritePatchBuilder.CreateSpec> specs, string? patchName, string? into, bool fullReadback,
+        string? target = null, bool inPlace = false, bool acknowledge = false)
     {
+        // In-place is the explicit, named-file opt-in (the SECOND write lane — create into an existing plugin, incl. one
+        // houseCARL didn't author, instead of writing a new patch). Validate the contract up front (Q3): it REQUIRES a
+        // target=, is mutually exclusive with into= (which EXTENDS a houseCARL patch — a different lane), and target=
+        // without in_place is a no-op the caller likely didn't mean — name it rather than silently ignore it. (Mirrors
+        // ApplyEdits' in-place contract exactly.)
+        if (inPlace && string.IsNullOrWhiteSpace(target))
+            return WritePatchBuilder.CreateOutcome.Fail(
+                "in_place=true requires target=<plugin filename> — name the existing plugin to create into in place. (Omit in_place to write a new patch instead — the default, originals untouched.)");
+        if (inPlace && !string.IsNullOrWhiteSpace(into))
+            return WritePatchBuilder.CreateOutcome.Fail(
+                "in_place=true and into= are mutually exclusive: into= EXTENDS a houseCARL patch, while in_place creates into an existing plugin in place. Use one lane or the other.");
+        if (!inPlace && !string.IsNullOrWhiteSpace(target))
+            return WritePatchBuilder.CreateOutcome.Fail(
+                "target= is only meaningful with in_place=true (it names the plugin to create into in place). For the default patch lane omit target=; use into= to extend an existing houseCARL patch.");
+
         lock (_writeGate)                                                 // hunt F2: one write at a time, resolve→commit
         {
             var resolver = Resolver;
             var rulebook = Rulebook;
+
+            if (inPlace)
+                return CommitCreateInPlace(resolver, rulebook, specs, target!.Trim(), acknowledge);
 
             string outPath; bool extend, created;
             try { outPath = ResolveOutputPath(patchName, into, out extend, out created); }
@@ -1549,6 +1570,69 @@ public sealed class LoadOrderService : IDisposable
             // (a dialogue line / a cell); none can fail the create (the write already succeeded).
             return outcome.Success ? EnrichWithCellShell(EnrichWithScriptCheck(EnrichWithVoiceCheck(outcome, resolver))) : outcome;
         }
+    }
+
+    /// <summary>The in-place branch of <see cref="CommitCreate"/> (in-place write lane, Wave 1b) — the create-side
+    /// companion of <see cref="ApplyEditsInPlace"/>, and it REUSES every Wave-1 in-place seam: the same foreign-target
+    /// resolver (<see cref="ResolveActivePluginPath"/>), the same PERSISTENT first-touch CONSENT handshake (keyed off the
+    /// resolved path in <see cref="UserConfigStore"/>), the same writable-parent pre-flight, and the same distinct
+    /// <c>editedInPlace=</c> marker (NEVER <c>generated=true</c> — the user mod keeps failing
+    /// <see cref="IsHouseCarlOwned"/> so a later into= can't blind-overwrite it). The ONLY divergences from
+    /// <see cref="ApplyEditsInPlace"/>: it drives <see cref="WritePatchBuilder.CreateRecordsInPlace"/> (allocate-into-target,
+    /// not edit-own-record) and returns a <see cref="WritePatchBuilder.CreateOutcome"/>. The created-record verify is forced
+    /// ON (the model-C substitute for the dropped whole-plugin floor). <paramref name="acknowledge"/> waives the CONSENT
+    /// axis ONLY — the verify is a corruption-axis fact no acknowledgement overrides. Runs under <c>_writeGate</c> (the
+    /// caller holds it). No post-write dialogue/cell teeth — Wave 1b is flat top-level records only, so no INFO/Cell can be
+    /// created here.</summary>
+    WritePatchBuilder.CreateOutcome CommitCreateInPlace(
+        LoadOrderResolver resolver, CorpusRulebook rulebook, IReadOnlyList<WritePatchBuilder.CreateSpec> specs,
+        string target, bool acknowledge)
+    {
+        // (1) Resolve target -> real on-disk path via the load order (by plugin FILENAME). Refuse loud if it isn't a real
+        //     active plugin (closes the coincidental-folder collision the into= lane can hit). Same resolver as the edit lane.
+        var view = resolver.Capture();
+        var targetPath = ResolveActivePluginPath(view, Path.GetFileName(target.Trim()), out var targetName);
+        if (targetPath is null)
+            return WritePatchBuilder.CreateOutcome.Fail(
+                $"in-place target '{target}' is not an active plugin in the load order — name a plugin enabled in MO2, by its " +
+                "plugin filename (e.g. 'CoolWeapons.esp'). in-place creates into the file the game actually loads. Nothing was written.");
+
+        // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path (shared with
+        //     the edit lane: acknowledging a plugin once covers BOTH editing and creating into it in place — it's the same
+        //     "touch your original" trade-off).
+        bool already = _store.IsInPlaceAcknowledged(targetPath);
+        if (!already && !acknowledge)
+            return WritePatchBuilder.CreateOutcome.NeedsAck(InPlaceHandshakeText(targetName, targetPath));
+        string? ackNote = null;
+        if (!already && acknowledge)
+        {
+            var (ok, err) = _store.RecordInPlaceAcknowledged(targetPath);
+            if (!ok) ackNote = $"the in-place acknowledgement could not be saved ({err}) — the create proceeded, but a future session will re-prompt for this plugin.";
+        }
+
+        // (3) Writable, same-volume parent pre-flight — refuse rather than degrade (the swap stages a sibling temp here).
+        if (InPlaceParentUnwritable(targetPath, out var why))
+            return WritePatchBuilder.CreateOutcome.Fail(why);
+
+        // (4) The write — created-record verify forced ON (the model-C substitute for the dropped whole-plugin floor).
+        var outcome = WritePatchBuilder.CreateRecordsInPlace(resolver, rulebook, specs, targetPath, targetName, fullReadback: true);
+
+        // (5) On success: run the SAME post-write teeth the patch lane runs (the service owns the live AssetResolver) —
+        //     in-place create can now author dialogue lines / cells under any parent, so voice (.fuz) + result-script +
+        //     cell-shell coverage must be checked here too (each a no-op unless that record kind was created; none can
+        //     fail the write, which already succeeded). Then stamp the distinct audit marker (best-effort; a marker miss
+        //     never fails the done create, Q3-noted).
+        if (outcome.Success)
+        {
+            var enriched = EnrichWithCellShell(EnrichWithScriptCheck(EnrichWithVoiceCheck(outcome, resolver)));
+            var markerNote = MergeEditedInPlaceMarker(Path.GetDirectoryName(targetPath));
+            var note = JoinNotes(ackNote, markerNote);
+            return note is not null ? enriched with { Note = note } : enriched;
+        }
+        if (ackNote is not null)
+            // The acknowledgement was recorded but the write then failed — keep the (now-honest) note alongside the error.
+            return outcome with { Note = ackNote };
+        return outcome;
     }
 
     /// <summary>Layer B unit B — the on-disk voice (.fuz/.lip) presence check, run as a POST-WRITE step on a SUCCESSFUL

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -151,7 +151,10 @@ public static class WriteTools
          "the CONCRETE subtype directly ('GlobalFloat'/'GlobalInt'/'GlobalShort', 'GameSettingFloat'/'GameSettingInt'/'GameSettingString') " +
          "— that's how a global variable or game setting is created. The new FormID is reported back; to make ANOTHER record " +
          "reference it, call this or set_field again with into='<this patch>' using that FormID. By default writes a fresh patch " +
-         "named patch_name; into= extends an existing houseCARL patch (accumulate across calls/sessions). ALL-OR-NOTHING (Q3): " +
+         "named patch_name; into= extends an existing houseCARL patch (accumulate across calls/sessions). To create the new " +
+         "record straight INTO an EXISTING plugin IN PLACE instead — rewriting your ORIGINAL file (incl. a mod houseCARL didn't " +
+         "make), not a patch — pass target=<plugin filename> + in_place=true (opt-in; the " +
+         "default patch lane leaves originals untouched). ALL-OR-NOTHING (Q3): " +
          "the whole call is refused with a reason and nothing is written if the type can't be created (an EXTERIOR cell nests " +
          "under FormKey-less worldspace structs — a separate capability; the bare abstract base 'Global'/'GameSetting' needs a concrete subtype — the refusal names them), if " +
          "a nested type is given no parent, if editorid is missing, or if any field op is illegal. Returns the new record's " +
@@ -174,13 +177,19 @@ public static class WriteTools
             string patch_name = "houseCARL_Patch",
         [Description("Optional. Filename of an existing houseCARL patch to add this new record to instead of writing a fresh one (accumulate across calls/sessions). Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead (folder & plugin names need not match).")]
             string? into = null,
+        [Description("Optional. IN-PLACE LANE (opt-in): the filename of an EXISTING active plugin to create the new record straight INTO, IN PLACE — including one houseCARL didn't author — instead of writing a new patch (e.g. 'CoolWeapons.esp'). Requires in_place=true; mutually exclusive with into=. Full create parity in place — incl. a nested record (parent=): a parent the target already owns is edited to host the child, a parent from another plugin is overridden in (exactly as the patch lane does). OMIT this (the default) to write a NEW patch and leave every original untouched — the recommended lane.")]
+            string? target = null,
+        [Description("Optional, default false. With target=, create the new record straight INTO that plugin IN PLACE: houseCARL rewrites your ORIGINAL file — no new patch, and NO houseCARL backup or undo (keep your own). The new record gets a fresh FormID in that plugin's OWN range; houseCARL re-lays-out the whole plugin the way xEdit/CK do on save, VERIFIES the record it created, and trusts Mutagen for the untouched rest; it refuses a file it can't parse or that holds engine-reserved (sub-0x800) records. The FIRST in-place write to a given plugin returns a one-time confirmation prompt (re-call with acknowledge=true).")]
+            bool in_place = false,
+        [Description("Optional, default false. Confirms the one-time in-place trade-off for target (see in_place) — needed only on the FIRST in-place write to a given plugin (edit OR create), never again for it. Waives the consent to touch your original ONLY; it NEVER skips the record verify.")]
+            bool acknowledge = false,
         [Description("When true, the response ALSO returns the ENTIRE created record read back from the written patch file on disk (every field, deep — not just the fields you set). The pre-enable verification, WITHOUT enabling the patch in MO2. (The patch wins nothing until enabled + sorted in MO2 — this read-back is the written file's content, not load-order truth.)")]
             bool full_readback = false,
         [Description("Optional. Max characters for the whole response; past it the full read-back section is cut with an explicit notice (never silent). 0 = the server default (~80k). Only matters with full_readback=true.")]
             int max_chars = 0) => Guard.Tool("housecarl_create_record", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-        return RenderCreate(svc.CreateRecords(record_type, editorid, operations ?? Array.Empty<BulkOp>(), patch_name, into, full_readback, parent, collection, grid), max_chars);
+        return RenderCreate(svc.CreateRecords(record_type, editorid, operations ?? Array.Empty<BulkOp>(), patch_name, into, full_readback, parent, collection, grid, target, in_place, acknowledge), max_chars);
     });
 
     [McpServerTool(Name = "housecarl_bulk_create", Title = "Create many records (incl. a nested one-shot) in one patch"),
@@ -203,6 +212,9 @@ public static class WriteTools
          "ambiguous collection), the whole call is refused with per-record reasons and nothing is written — no partial patches. " +
          "By default writes a fresh patch named patch_name; into= extends an existing houseCARL patch — and a parent created in " +
          "a PRIOR into= call CAN be the parent here too (it's resolved from the patch being extended, not only the load order). " +
+         "To create the new records straight INTO an EXISTING plugin IN PLACE instead — rewriting your ORIGINAL file (incl. a mod " +
+         "houseCARL didn't make), not a patch — pass target=<plugin filename> + in_place=true (opt-in; the default patch lane " +
+         "leaves originals untouched). " +
          "Returns each new record's FormID + editorid, the patch path, and its (derived) masters.")]
     public static string BulkCreate(
         LoadOrderService svc,
@@ -212,6 +224,12 @@ public static class WriteTools
             string patch_name = "houseCARL_Patch",
         [Description("Optional. Filename of an existing houseCARL patch to add these new records to instead of writing a fresh one (accumulate across calls/sessions). Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead (folder & plugin names need not match).")]
             string? into = null,
+        [Description("Optional. IN-PLACE LANE (opt-in): the filename of an EXISTING active plugin to create the new records straight INTO, IN PLACE — including one houseCARL didn't author — instead of writing a new patch (e.g. 'CoolWeapons.esp'). Requires in_place=true; mutually exclusive with into=. Full create parity in place — incl. a nested one-shot (a topic AND its lines, a cell AND its refs): a same-call or target-owned parent hosts the child, a parent from another plugin is overridden in (exactly as the patch lane does). OMIT this (the default) to write a NEW patch and leave every original untouched — the recommended lane.")]
+            string? target = null,
+        [Description("Optional, default false. With target=, create the new records straight INTO that plugin IN PLACE: houseCARL rewrites your ORIGINAL file — no new patch, and NO houseCARL backup or undo (keep your own). Each new record gets a fresh FormID in that plugin's OWN range; houseCARL re-lays-out the whole plugin the way xEdit/CK do on save, VERIFIES the records it created, and trusts Mutagen for the untouched rest; it refuses a file it can't parse or that holds engine-reserved (sub-0x800) records. The FIRST in-place write to a given plugin returns a one-time confirmation prompt (re-call with acknowledge=true).")]
+            bool in_place = false,
+        [Description("Optional, default false. Confirms the one-time in-place trade-off for target (see in_place) — needed only on the FIRST in-place write to a given plugin (edit OR create), never again for it. Waives the consent to touch your original ONLY; it NEVER skips the record verify.")]
+            bool acknowledge = false,
         [Description("When true, the response ALSO returns each created record IN FULL, read back from the written patch file on disk (every field, deep). The pre-enable verification, WITHOUT enabling the patch in MO2 (the written file's content, not load-order truth).")]
             bool full_readback = false,
         [Description("Optional. Max characters for the whole response; past it the full read-back section is cut with an explicit notice (never silent). 0 = the server default (~80k). Only matters with full_readback=true.")]
@@ -220,7 +238,7 @@ public static class WriteTools
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         if (records is null || records.Length == 0)
             return "error: records is empty. Pass one or more {record_type, editorid, operations?, parent?, collection?} specs.";
-        return RenderCreate(svc.CreateRecordsBatch(records, patch_name, into, full_readback), max_chars);
+        return RenderCreate(svc.CreateRecordsBatch(records, patch_name, into, full_readback, target, in_place, acknowledge), max_chars);
     });
 
     [McpServerTool(Name = "housecarl_forward_record", Title = "Forward a plugin's version of a record as an override"),
@@ -450,14 +468,22 @@ public static class WriteTools
     /// fields applied. On refusal, the named reason (Q3) so the caller can fix and retry.</summary>
     static string RenderCreate(WritePatchBuilder.CreateOutcome o, int maxChars = 0)
     {
+        if (o.NeedsAcknowledge) return o.Error!;            // the first-touch in-place CONSENT prompt — a required confirmation, NOT an error (Q3)
         if (!o.Success) return "error: " + o.Error;
         var file = Path.GetFileName(o.OutputPath);
         var modFolder = Path.GetFileName(Path.GetDirectoryName(o.OutputPath) ?? "");
         var sb = new StringBuilder();
-        sb.Append(o.Extended ? "extended " : "wrote ").Append(file)
-          .Append(o.Extended ? " (existing patch grown; " : " (new patch; ").Append(o.Bytes).Append(" bytes)\n");
-        sb.Append("mod folder: ").Append(modFolder)
-          .Append(o.Extended ? "\n" : "  — enable + sort it in MO2 to use the patch\n");
+        if (o.InPlace)
+            sb.Append(file).Append(" rewritten IN PLACE (").Append(o.Bytes)
+              .Append(" bytes — your ORIGINAL file; no houseCARL backup or undo)\n")
+              .Append("mod folder: ").Append(modFolder).Append("  — already active in your load order; re-sort only if a winner changed\n");
+        else
+        {
+            sb.Append(o.Extended ? "extended " : "wrote ").Append(file)
+              .Append(o.Extended ? " (existing patch grown; " : " (new patch; ").Append(o.Bytes).Append(" bytes)\n");
+            sb.Append("mod folder: ").Append(modFolder)
+              .Append(o.Extended ? "\n" : "  — enable + sort it in MO2 to use the patch\n");
+        }
         sb.Append("masters: ").Append(o.Masters.Count == 0 ? "(none)" : string.Join(", ", o.Masters)).Append('\n');
         var replacedCount = o.Created.Count(c => c.ReplacedExisting);
         sb.Append("created ").Append(o.Created.Count).Append(o.Created.Count == 1 ? " record" : " records");
@@ -477,8 +503,11 @@ public static class WriteTools
         AppendScriptBindingReport(sb, o.ScriptBinding, maxChars);
         AppendCellShellReport(sb, o.CellShell);
         if (o.ReadBack is { } rb) AppendFullReadback(sb, rb, maxChars);
-        sb.Append("the new FormID above is how you reference this record (SkyPatcher/SPID, or a follow-up edit). ")
-          .Append("To add more to THIS patch, pass into=\"").Append(file).Append("\".");
+        if (o.Note is { } note) sb.Append("note: ").Append(note).Append('\n');
+        sb.Append("the new FormID above is how you reference this record (SkyPatcher/SPID, or a follow-up edit). ");
+        sb.Append(o.InPlace
+            ? $"To create more records in this plugin, pass target=\"{file}\" in_place=true (no further confirmation needed for it)."
+            : $"To add more to THIS patch, pass into=\"{file}\".");
         return sb.ToString();
     }
 


### PR DESCRIPTION
The create-side companion to **Wave 1's edit lane** ([#110](https://github.com/Avick3110/houseCARL/pull/110)): `create_record`/`bulk_create` with `target=<plugin>` + `in_place=true` allocate **brand-new records into the user's ORIGINAL file** (incl. a mod houseCARL didn't author) instead of writing a new patch.

## Scope: FULL create parity in place
Flat top-level records, **nested children** (a dialogue line, a placed ref), and **cells** — under **any** parent.

> **Mid-build scope correction (worth a reviewer's eye).** This started scoped to standalone records only, with nested creates refused. That was wrong: nesting a new child under a parent from another plugin is **normal authoring, not injection** — the parent is overridden in to *host* the child, exactly as xEdit and houseCARL's own patch lane already do. The edit lane's "only touch what you own" guard exists to stop `set_field` silently overriding the *wrong* record; it doesn't transfer to create, where nesting legitimately requires the parent. So: a parent the target **owns** is sourced **from the target** (its content preserved); a **foreign** parent is overridden in; everything is reported and the user's existing records stay intact + verified.

## Implementation — reuse, not re-implement
The proven `WritePatchBuilder.CreateRecords` is **parameterized** with an in-place target, so **both lanes share its full nested/parent/cell/@editorid logic**. Every in-place fork is additive + gated on the param, so **the patch lane is behaviourally unchanged**:
- **Phase 0** opens the TARGET (`CreateFromBinary` + excluded-plugin guard) instead of a fresh/extend patch.
- **Phase 1** sources a target-OWNED parent from the target (the create-side of the §4.1 content-source guard); a foreign parent falls through to the unchanged winner-source (overridden in to host the child).
- **Phase 4** serializes via `WriteEngine.WriteInPlace` (model C — author's counter preserved, no baseline) handed the WHOLE known-master set, so a new cross-mod reference adds its master (xEdit-parity). `CreateRecordsInPlace` collapsed from a 165-line flat-only sibling to a thin forward into the shared core.
- **`LoadOrderService`**: `target=`/`in_place=`/`acknowledge` on `CreateRecords` + `CreateRecordsBatch`; `CommitCreateInPlace` REUSES every Wave-1 in-place seam (foreign-target resolver, the persistent first-touch consent handshake **shared across edit + create**, the writable-parent pre-flight, the `editedInPlace=` marker that never writes `generated=true`) **and** runs the same post-write dialogue voice / result-script / cell-shell coverage teeth the patch lane runs. The created-record verify is forced ON.
- **`WriteTools`**: the 3 params on `create_record`/`bulk_create`; `RenderCreate` shows the in-place confirmation + the handshake prompt (a confirmation, not `error:`) + the Note channel.

## Proof — `inplace-guard` 16/16 (the existing self-contained CI probe)
Create arms J–P, all RED-provable:
- **J** create-into-target (fresh FormID in the target's range + counter **advances**, vs edit's preserve)
- **O** cross-master reference adds the master
- **M** nested under a **foreign** parent (parent overridden in + child landed + masters correct)
- **P** the same-call **new-dialogue-unit** (topic + line) in place
- **K** create handshake (RED→GREEN→no-reprompt) · **L** contract refusals · **N** opt-in-by-construction
- **I** (extended) also proves the create lane shares the marker + handshake end-to-end

**Patch lane unregressed:** the 8 create regression guards (`bulk-create-guard`, `nested-create-guard`, `coord-cell-guard`, `create-abstract-group-guard`, `formid-floor-guard`, `upsert-guard`, `esl-formid-guard`, `create-plugin-guard`) + the real-data `inplace-nested-proof` all pass.

## Known coverage note (honest, for the review)
The self-contained CI guard has **no dedicated worldspace/exterior-cell-create-in-place arm** — the synthetic master has no worldspace to nest one under. That path rides composition of proven parts: patch-lane cell create (`coord-cell-guard`, green) + the in-place serialize (armed by J/O/M/P). Low risk; flagged as the one nested sub-case without a *direct* in-place arm. Easy to add a synthesized-worldspace arm if the review wants it nailed down.

## Test
```
dotnet run --project src/housecarl-generator -- inplace-guard          # 16/16
dotnet run --project src/housecarl-generator -- bulk-create-guard      # patch-lane regression
dotnet run --project src/housecarl-generator -- inplace-nested-proof   # real-data nested lock (needs Skyrim.esm)
```

Tool surface unchanged (no new tools; params added to the existing `create_record`/`bulk_create`). Not on Nexus — ships on the next repackage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)