### PR TITLE
feat: in-place write lane Wave 2 — remove a record from an existing plugin in place (remove_record)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,15 +120,18 @@ jobs:
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- writelock-guard
 
       # Self-contained (synthesizes a master + a user override + a higher override in temp — no game data), runs fully
-      # here: the in-place write lane Wave 1 (set_field/bulk_apply target=+in_place=true edits the user's ORIGINAL file).
-      # Drives the REAL WritePatchBuilder.ApplyInPlace + LoadOrderService in-place branch and RED-proves every safety
-      # property: content sourced from the TARGET not the load-order winner (no foreign-content injection) + refuse-if-
-      # undefined, the author's NextObjectID + master list preserved verbatim (WriteInPlace ≠ the patch-lane floor/baseline),
-      # the flat self-lock (winner==target, ReleaseOverlay before the swap), the persistent first-touch consent handshake
-      # (RED refuse → acknowledge writes → no re-prompt → persists cross-session via UserConfig), the resolver refusing a
-      # non-load-order target, the in_place⇔target / ⊥ into= contract, and opt-in-by-construction (params default OFF).
-      # The NESTED-record lock arm needs a real master, so it's the manual inplace-nested-proof (self-skips here).
-      - name: Probe — in-place write lane Wave 1 (self-contained regression guard)
+      # here: the in-place write lane Waves 1 + 1b + 2 — set_field/bulk_apply EDIT, create_record/bulk_create CREATE, and
+      # remove_record REMOVE, all with target=+in_place=true against the user's ORIGINAL file. Drives the REAL
+      # WritePatchBuilder.ApplyInPlace / CreateRecordsInPlace / RemoveRecordsInPlace + the LoadOrderService in-place
+      # branches and RED-proves every safety property: content sourced from the TARGET not the load-order winner (no
+      # foreign-content injection) + refuse-if-undefined, the author's NextObjectID + master list preserved verbatim on an
+      # edit (WriteInPlace ≠ the patch-lane floor/baseline) and orphaned masters pruned on a remove, the flat self-lock
+      # (winner==target, ReleaseOverlay before the swap), the persistent first-touch consent handshake SHARED across all
+      # three lanes (RED refuse → acknowledge writes → no re-prompt → persists cross-session via UserConfig), the resolver
+      # refusing a non-load-order target, the in_place⇔target / ⊥ into=/patch= contract, and opt-in-by-construction (params
+      # default OFF). The NESTED-record arms need a real master, so they're the manual inplace-nested-proof +
+      # inplace-remove-nested-proof (self-skip here).
+      - name: Probe — in-place write lane Waves 1+1b+2 (self-contained regression guard)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- inplace-guard
 
       # Self-contained (synthesizes a corrupted-EPFT perk — no external files), runs fully here AND drives the REAL

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -565,9 +565,9 @@ public static class WritePatchBuilder
             var mpath = view.PluginPath(mfn);
             if (mpath is null)
             {
-                missing = $"cannot edit '{targetMod.ModKey.FileName}' in place: its declared master '{mfn}' is not active in the " +
-                          "load order, so a faithful re-serialize can't resolve the references into it. Enable that master (or fix " +
-                          "the target's masters in xEdit) first. The file is UNTOUCHED.";
+                missing = $"cannot re-serialize '{targetMod.ModKey.FileName}' in place: its declared master '{mfn}' is not active " +
+                          "in the load order, so a faithful re-serialize can't resolve the references into it. Enable that master " +
+                          "(or fix the target's masters in xEdit) first. The file is UNTOUCHED.";
                 return Array.Empty<ISkyrimModGetter>();
             }
             var ov = SkyrimMod.CreateFromBinaryOverlay(mpath, SkyrimRelease.SkyrimSE);

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -108,8 +108,31 @@ public static class WritePatchBuilder
         bool Success, string? Error, string OutputPath,
         IReadOnlyList<RemovedRecord> Removed, IReadOnlyList<string> Masters, int RemainingRecords, long Bytes)
     {
+        /// <summary>True ⇒ this outcome came from the IN-PLACE remove lane (<see cref="RemoveRecords"/>'s sibling
+        /// <see cref="RemoveRecordsInPlace"/>) — the records were dropped from the USER's own file at
+        /// <see cref="OutputPath"/>, not a houseCARL patch. Drives the distinct "removed in place" confirmation (and the
+        /// "no undo; keep your own backup" note). Mirrors <see cref="PatchOutcome.InPlace"/>.</summary>
+        public bool InPlace { get; init; }
+
+        /// <summary>True ⇒ NOT a write and NOT an error: the server-enforced first-touch in-place CONSENT handshake. The
+        /// in-place lane refused to write this plugin until the user acknowledges the trade-off; <see cref="Error"/>
+        /// carries the prompt verbatim (re-call with acknowledge=true). Rendered as a confirmation prompt, never "error:"
+        /// (Q3 — a required confirmation is not a failure). Nothing was written; the original is untouched.</summary>
+        public bool NeedsAcknowledge { get; init; }
+
+        /// <summary>An optional Q3 honesty note appended to a SUCCESSFUL outcome — a side effect that didn't land cleanly
+        /// even though the removal did (e.g. the in-place acknowledgement couldn't be persisted, or the editedInPlace
+        /// audit marker couldn't be written). Null when there's nothing to add.</summary>
+        public string? Note { get; init; }
+
         public static RemovalOutcome Fail(string error) =>
             new(false, error, "", Array.Empty<RemovedRecord>(), Array.Empty<string>(), 0, 0);
+
+        /// <summary>The first-touch in-place consent handshake: no write, no error — a required confirmation carrying the
+        /// trade-off <paramref name="prompt"/> (the caller re-calls with acknowledge=true). Success=false so no
+        /// downstream success path runs; <see cref="NeedsAcknowledge"/> tells the renderer to show it as a prompt.</summary>
+        public static RemovalOutcome NeedsAck(string prompt) =>
+            new(false, prompt, "", Array.Empty<RemovedRecord>(), Array.Empty<string>(), 0, 0) { NeedsAcknowledge = true };
     }
 
     /// <summary>One brand-new record to create: its (caller-DECLARED) <see cref="RecordType"/> catalog name, the required
@@ -661,6 +684,152 @@ public static class WritePatchBuilder
         finally { (back as IDisposable)?.Dispose(); }
 
         return new RemovalOutcome(true, null, outPath, toRemove, masters, remaining, bytes);
+    }
+
+    /// <summary>
+    /// Remove WHOLE records IN PLACE — the in-place write lane's Wave-2 sibling of <see cref="RemoveRecords"/> and the
+    /// remove counterpart of <see cref="ApplyInPlace"/>. Drops a record the TARGET's own file carries (one it DEFINES, or
+    /// an override it HOLDS) back over the user's ORIGINAL file, instead of dropping it from a houseCARL patch. REUSES
+    /// every in-place mechanic <see cref="ApplyInPlace"/> proved: a per-call overlay session, the ContainsPlugin/
+    /// ExcludedPlugins refusal (never re-serialize a plugin Mutagen can't fully parse — that would risk dropping the
+    /// record it couldn't read, Q3), an EAGER CreateFromBinary of the SINGLE target (NEVER the order — the legacy
+    /// 12–14 GB RAM trap), <see cref="LoadOrderResolver.OverlaySession.ReleaseOverlay"/> before the swap (the self-lock
+    /// guard, here on a FOREIGN target), own-declared-masters re-emit via <see cref="WriteEngine.WriteInPlace"/> (NOT
+    /// WritePatch — no Skyrim.esm/Update.esm baseline force-include, the author's HEDR.NextObjectID preserved), and the
+    /// crash-atomic swap.
+    ///
+    /// <para>REMOVAL SEMANTICS are <see cref="RemoveRecords"/>'s, unchanged: PRESENT-CHECK FIRST against what the TARGET
+    /// carries (Q3 — a key the file doesn't carry is REFUSED, the whole call, nothing written; <c>Remove</c> is a silent
+    /// no-op otherwise), then the typed <c>Remove(FormKey, Type, throwIfUnknown)</c> that reaches every group (flat AND
+    /// nested). MASTER-PRUNE rides along for free exactly as the patch lane gets it: <see cref="WriteEngine.WriteInPlace"/>
+    /// hands Mutagen the target's own masters as the resolution context and lean-derives the emitted header from the
+    /// SURVIVING records' links, so a master the removal orphaned drops from the header automatically. The model-C
+    /// touched-record verify is applied to a removal as ABSENCE — every removed FormKey is confirmed GONE on the
+    /// re-opened on-disk file (confirm what you DROPPED actually went; Mutagen is trusted for the untouched rest).</para>
+    ///
+    /// <para>The caller (the service in-place branch) has already resolved <paramref name="targetPath"/> to the real
+    /// active-plugin path, run the consent handshake, and checked the writable parent — exactly as it does for
+    /// <see cref="ApplyInPlace"/>. Returns <see cref="RemovalOutcome.InPlace"/>=true on success.</para>
+    /// </summary>
+    public static RemovalOutcome RemoveRecordsInPlace(
+        LoadOrderResolver resolver, IReadOnlyList<FormKey> targets, string targetPath, string targetName)
+    {
+        if (targets.Count == 0) return RemovalOutcome.Fail("no records to remove supplied.");
+
+        // Per-call overlay session (Option B), same as ApplyInPlace: every read (the master set for the re-serialize) is
+        // opened THROUGH it and disposed when the method returns — no handle held at rest.
+        using var session = resolver.OpenSession();
+        var fileName = Path.GetFileName(targetPath);
+
+        // --- Phase 1: the target must be an active, FULLY-PARSEABLE plugin (the ApplyInPlace guard — never re-serialize a
+        //     plugin Mutagen excluded, which would risk dropping the record it couldn't read on the rewrite, Q3). ---
+        var view = resolver.Capture();
+        if (!view.ContainsPlugin(targetName))
+            return RemovalOutcome.Fail($"in-place target '{targetName}' is not an active plugin in the load order.");
+        if (view.ExcludedPlugins.TryGetValue(targetName, out var excluded))
+            return RemovalOutcome.Fail(
+                $"cannot remove from '{targetName}' in place: it was EXCLUDED from this session ({excluded}) — houseCARL won't " +
+                "re-serialize a plugin it can't fully parse (that would risk dropping a record it couldn't read, Q3). The file is UNTOUCHED.");
+
+        // --- Phase 2: open the TARGET mutably. EAGER, the SINGLE plugin only — NEVER the load order. CreateFromBinary is
+        //     the same call ApplyInPlace uses; an unparseable plugin throws here and is REFUSED, never silently
+        //     re-emitted minus the record Mutagen couldn't read (Q3). ---
+        if (!File.Exists(targetPath))
+            return RemovalOutcome.Fail($"in-place target '{fileName}' not found on disk at {targetPath} — the file is untouched.");
+        SkyrimMod targetMod;
+        try { targetMod = SkyrimMod.CreateFromBinary(targetPath, SkyrimRelease.SkyrimSE); }
+        catch (Exception ex)
+            { return RemovalOutcome.Fail($"cannot open '{fileName}' to remove from in place ({WriteEngine.Describe(ex)}) — a plugin Mutagen can't parse is refused, not re-emitted minus what it couldn't read (Q3). The file is UNTOUCHED."); }
+        if (!string.Equals(targetMod.ModKey.FileName.String, fileName, StringComparison.OrdinalIgnoreCase))
+            return RemovalOutcome.Fail($"in-place ModKey '{targetMod.ModKey.FileName}' must match the target filename '{fileName}'.");
+
+        // --- Phase 3: present-check against what the TARGET carries (RemoveRecords' contract, unchanged). One enumeration
+        //     (flat + nested) captures type+editorid for the report AND the runtime type that routes the typed Remove. A
+        //     key the file doesn't define/override is REFUSED loud — in-place removes only what the file OWNS. ---
+        var carried = new Dictionary<FormKey, (string type, string? edid, Type runtime)>();
+        foreach (var r in targetMod.EnumerateMajorRecords())
+            carried[r.FormKey] = (RecordNaming.StripOverlay(r.GetType().Name), r.EditorID, r.GetType());
+
+        var problems = new List<string>();
+        var toRemove = new List<RemovedRecord>(targets.Count);
+        var seen = new HashSet<FormKey>();
+        foreach (var fk in targets)
+        {
+            if (!seen.Add(fk)) continue;   // de-dup repeated targets in one call
+            if (!carried.TryGetValue(fk, out var info))
+            {
+                problems.Add(
+                    $"{fk}: not carried by '{fileName}' — in-place removes only a record the file ITSELF defines or " +
+                    "overrides. To stop ANOTHER plugin's record from winning, use the default patch lane (forward the " +
+                    "master version, or override it) instead.");
+                continue;
+            }
+            toRemove.Add(new RemovedRecord(fk, info.type, info.edid));
+        }
+        if (problems.Count > 0)
+            return RemovalOutcome.Fail(
+                $"refused — {problems.Count} of {targets.Count} target(s) not carried by '{fileName}'; NOTHING removed:\n  - "
+                + string.Join("\n  - ", problems));
+
+        // --- Phase 4: literal drop-from-group (NOT flag-as-deleted), the typed overload RemoveRecords proved reaches
+        //     nested groups (Cell/Placed*/INFO/Navmesh/Landscape) too. throwIfUnknown:true keeps an unrecognized type
+        //     loud (Q3). A throw AFTER the present-check passed is a real engine inconsistency — surfaced, not swallowed. ---
+        try
+        {
+            foreach (var rr in toRemove)
+                ((IMajorRecordEnumerable)targetMod).Remove(rr.Target, carried[rr.Target].runtime, throwIfUnknown: true);
+        }
+        catch (Exception ex)
+        {
+            return RemovalOutcome.Fail(
+                $"present-check passed but Remove threw — a real engine inconsistency, surfaced not swallowed (Q3): "
+                + $"{ex.GetType().Name}: {ex.Message}");
+        }
+
+        // --- Phase 5: re-serialize the WHOLE target back over itself (model C — WriteInPlace, NOT WritePatch). Release
+        //     the target overlay first (the self-lock guard on a FOREIGN target: ReleaseOverlay disposes every session
+        //     overlay on the target — none here, since the present-check read targetMod directly, not via an overlay, but
+        //     the discipline is kept identical to ApplyInPlace). Resolve the target's OWN declared masters; Mutagen orders
+        //     against them and lean-derives the emitted header from the SURVIVING records, so an orphaned master drops. ---
+        session.ReleaseOverlay(fileName);
+        var masterOverlays = new List<IDisposable>();
+        try
+        {
+            ISkyrimModGetter[] ownMasters = ResolveOwnMasters(view, targetMod, masterOverlays, out var missing);
+            if (missing is not null) return RemovalOutcome.Fail(missing);
+            try { WriteEngine.WriteInPlace(targetMod, ownMasters, targetPath); }
+            catch (Exception ex)
+                { return RemovalOutcome.Fail($"writing '{fileName}' in place after removal failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}"); }
+        }
+        finally { foreach (var d in masterOverlays) { try { d.Dispose(); } catch { /* best-effort; never mask the write result */ } } }
+
+        // --- Phase 6: re-open the now-rewritten file; report its (possibly shrunk) master header + how many records
+        //     remain, and VERIFY each removed FormKey is ABSENT (the model-C touched-record verify applied to a removal
+        //     as absence). One enumeration counts survivors AND catches any removed key that wrongly survived. ---
+        IReadOnlyList<string> masters = Array.Empty<string>();
+        int remaining = 0; long bytes = 0;
+        ISkyrimModGetter? back = null;
+        try
+        {
+            back = SkyrimMod.CreateFromBinaryOverlay(targetPath, SkyrimRelease.SkyrimSE);
+            var removedKeys = toRemove.Select(rr => rr.Target).ToHashSet();
+            var stillThere = new List<FormKey>();
+            foreach (var r in back.EnumerateMajorRecords())
+            {
+                remaining++;
+                if (removedKeys.Contains(r.FormKey)) stillThere.Add(r.FormKey);
+            }
+            if (stillThere.Count > 0)
+                return RemovalOutcome.Fail(
+                    $"'{fileName}' was rewritten but the verify found {stillThere.Count} record(s) that should have been removed still present " +
+                    $"({string.Join(", ", stillThere)}) — a real inconsistency surfaced, not swallowed (Q3). The on-disk file may differ from intent; re-check in xEdit.");
+            masters = back.ModHeader.MasterReferences.Select(m => m.Master.FileName.ToString()).ToList();
+            bytes = new FileInfo(targetPath).Length;
+        }
+        catch (Exception ex) { return RemovalOutcome.Fail($"records removed + written but '{fileName}' could not be re-opened to verify: {ex.Message}"); }
+        finally { (back as IDisposable)?.Dispose(); }
+
+        return new RemovalOutcome(true, null, targetPath, toRemove, masters, remaining, bytes) { InPlace = true };
     }
 
     /// <summary>One record to FORWARD: take plugin <see cref="FromPlugin"/>'s version of <see cref="Target"/> and carry

--- a/src/housecarl-generator/InPlaceProbe.cs
+++ b/src/housecarl-generator/InPlaceProbe.cs
@@ -287,10 +287,19 @@ public static class InPlaceProbe
             string meta2 = File.Exists(userMeta) ? File.ReadAllText(userMeta) : "";
             bool createNoGenerated = !meta2.Replace(" ", "").Contains("generated=true", StringComparison.OrdinalIgnoreCase) && meta2.Contains("editedInPlace=");
 
+            // The REMOVE lane (Wave 2) likewise shares this user mod's acknowledgement AND stamps the SAME marker via the
+            // SAME helper: a remove-in-place here must NOT re-prompt (the edit's ack covers it) and must keep generated=true
+            // absent — the remove half of the cross-lane share + marker safety, end-to-end through the REAL service over a
+            // ModsDir instance. (Drops the weapon override; the created keyword above keeps the mod non-empty.)
+            var removeIP = svc.RemoveRecords(new[] { fmtWfk }, null, target: UserName, inPlace: true, acknowledge: false);
+            bool removeShared = removeIP.Success && removeIP.InPlace && !removeIP.NeedsAcknowledge;
+            string meta3 = File.Exists(userMeta) ? File.ReadAllText(userMeta) : "";
+            bool removeNoGenerated = !meta3.Replace(" ", "").Contains("generated=true", StringComparison.OrdinalIgnoreCase) && meta3.Contains("editedInPlace=");
+
             bool pass = wrote.Success && wrote.InPlace && landed && markerWritten && noGenerated && sentinelKept && ownedStaysFalse
-                     && createShared && createNoGenerated;
-            results.Add(("I editedInPlace marker + into= boundary + create-lane share (never generated=true)", pass,
-                $"wrote={wrote.Success} landed61={landed} marker={markerWritten} noGenerated={noGenerated} userSentinelKept={sentinelKept} into=StillRefusesUnowned={ownedStaysFalse} createSharesAck={createShared} createKeepsMarkerSafe={createNoGenerated}  [{Trim(wrote.Error)}]"));
+                     && createShared && createNoGenerated && removeShared && removeNoGenerated;
+            results.Add(("I editedInPlace marker + into= boundary + create+remove-lane share (never generated=true)", pass,
+                $"wrote={wrote.Success} landed61={landed} marker={markerWritten} noGenerated={noGenerated} userSentinelKept={sentinelKept} into=StillRefusesUnowned={ownedStaysFalse} createSharesAck={createShared} createKeepsMarkerSafe={createNoGenerated} removeSharesAck={removeShared} removeKeepsMarkerSafe={removeNoGenerated}  [{Trim(wrote.Error)}]"));
         }
 
         // ===== J — CREATE-INTO-TARGET: a new flat record allocates a fresh FormID IN THE TARGET; the counter ADVANCES =====

--- a/src/housecarl-generator/InPlaceProbe.cs
+++ b/src/housecarl-generator/InPlaceProbe.cs
@@ -7,11 +7,12 @@ using HousecarlMcp;
 namespace HousecarlGenerator;
 
 /// <summary>
-/// SELF-CONTAINED CI REGRESSION GUARD for the IN-PLACE WRITE LANE, Waves 1 + 1b (dev/plans/IN_PLACE_WRITE_LANE_PLAN_2026-06-13.md
+/// SELF-CONTAINED CI REGRESSION GUARD for the IN-PLACE WRITE LANE, Waves 1 + 1b + 2 (dev/plans/IN_PLACE_WRITE_LANE_PLAN_2026-06-13.md
 /// §10 CI teeth). The in-place EDIT lane (set_field/bulk_apply, Wave 1) edits an EXISTING plugin the user owns — incl. one
 /// houseCARL didn't author — back over itself; the in-place CREATE lane (create_record/bulk_create, Wave 1b) allocates
-/// BRAND-NEW records into it the same way. Both touch the user's ORIGINAL file, so the safety properties are load-bearing
-/// and each is RED-provable here:
+/// BRAND-NEW records into it the same way; the in-place REMOVE lane (remove_record, Wave 2) drops a record the file carries
+/// back out of it. All three touch the user's ORIGINAL file, so the safety properties are load-bearing and each is
+/// RED-provable here:
 ///
 ///   CONTENT-SOURCE (§4.1)  — the EDIT's body is the TARGET's OWN record, NEVER the load-order winner; a record the
 ///                            target doesn't define is REFUSED (no foreign content injected). RED if sourced from winner.
@@ -31,13 +32,20 @@ namespace HousecarlGenerator;
 ///                            sourced from the target; a FOREIGN parent is overridden IN to host the child, as xEdit/the patch lane do.
 ///   RESOLVER / CONTRACT    — target= resolves the REAL active-plugin path (a non-load-order name REFUSES, never
 ///                            retargets); in_place needs target=, is mutually exclusive with into=; opt-in defaults OFF.
+///   REMOVE (Wave 2)        — drop a record the target CARRIES back out of its own file: an override removed PRUNES the
+///                            master it orphaned (R), a record the file doesn't carry is REFUSED (S), a surgical drop keeps
+///                            the rest + a still-referenced master (T), and the consent handshake is SHARED with the edit
+///                            lane (one ack covers edit+create+remove — W). RED if it removed from a winner not the target,
+///                            kept an orphaned master, over-pruned a referenced one, or skipped the handshake.
 ///
 /// Self-contained: synthesizes a master + a user override + a higher override in TEMP and generates the validator corpus
 /// BY CONSTRUCTION in-process (no game data, no checked-in corpus.json). Drives the REAL WritePatchBuilder.ApplyInPlace /
-/// CreateRecordsInPlace (builder arms) and the REAL LoadOrderService in-place branches (service arms, via the ForGuard seam).
+/// CreateRecordsInPlace / RemoveRecordsInPlace (builder arms) and the REAL LoadOrderService in-place branches (service
+/// arms, via the ForGuard seam).
 /// Arms A–I cover the EDIT lane; J–Q cover the CREATE lane (J create+counter, O cross-master, M nested-under-a-foreign-parent,
 /// P same-call nested unit, Q exterior-cell-under-a-foreign-worldspace, K handshake, L contract, N opt-in) and arm I also
-/// proves the create lane shares the marker + handshake.
+/// proves the create lane shares the marker + handshake; R–X cover the REMOVE lane (R override-remove+prune, S refuse-if-
+/// not-carried, T surgical-remove+keep-master, U contract, V resolver, W handshake+cross-lane-share, X opt-in).
 /// Run: dotnet run --project src/housecarl-generator inplace-guard
 ///
 /// The NESTED lock arm (the LinkCacheFor-on-a-foreign-target path) needs a real nested record + master, so it lives in
@@ -51,7 +59,7 @@ public static class InPlaceProbe
 
     public static int RunGuard(string[] args)
     {
-        Console.WriteLine("################  REGRESSION GUARD — in-place write lane, Waves 1 + 1b  ################");
+        Console.WriteLine("################  REGRESSION GUARD — in-place write lane, Waves 1 + 1b + 2  ################");
         Console.WriteLine();
 
         var tmpDir = Path.Combine(Path.GetTempPath(), "hc-inplace-guard");
@@ -436,6 +444,136 @@ public static class InPlaceProbe
                 $"success={o.Success} inPlace={o.InPlace} cellFk={cellFk}(in {UserName}) worldOverriddenIn={worldOverriddenIn}  [{o.Error ?? "ok"}]"));
         }
 
+        // ============================ WAVE 2 — REMOVE-IN-PLACE (arms R–X) ============================
+        // remove_record gains target=+in_place=, reusing every Wave-1 seam (resolver + persistent consent handshake +
+        // editedInPlace marker + writable-parent pre-flight). Semantics = the patch lane's RemoveRecords, pointed at the
+        // user's OWN file: drop a record the TARGET carries (defines OR overrides), refuse what it doesn't, prune orphaned
+        // masters on the WriteInPlace rewrite, and VERIFY each removed FormKey is absent on read-back (model-C as absence).
+
+        // ===== R — REMOVE an OVERRIDE the target HOLDS → record gone, orphaned master PRUNED, winner reverts =====
+        // The fresh user mod carries ONE record: its override of the master weapon (its only master ref). Removing it in
+        // place drops the record AND orphans HcInPlaceMaster, which must be PRUNED on the rewrite (the patch-lane prune,
+        // here via WriteInPlace's lean-derive). RemainingRecords→0 (inert shell); the master file stays untouched (dmg 10).
+        {
+            var userR = FreshUser(tmpDir, "R", userPristine);
+            using var r = LoadOrderResolver.Build(new[] { masterPath, userR });   // [master, user] — user IS the winner of wfk
+            var o = WritePatchBuilder.RemoveRecordsInPlace(r, new[] { wfk }, userR, UserName);
+            bool gone = !RecordPresent(userR, wfk);
+            var masters = ReadMasters(userR);
+            bool pruned = !masters.Any(m => m.Equals(MasterName, StringComparison.OrdinalIgnoreCase));
+            bool masterUntouched = ReadDamage(masterPath, wfk) == 10;
+            bool pass = o.Success && o.InPlace && gone && o.Removed.Count == 1 && o.RemainingRecords == 0 && pruned && masterUntouched;
+            results.Add(("R remove an override in place (record gone, orphaned master pruned, inert shell)", pass,
+                $"success={o.Success} inPlace={o.InPlace} recordGone={gone} removed={o.Removed.Count}(want 1) remaining={o.RemainingRecords}(want 0) masterPruned={pruned} masters=[{string.Join(",", masters)}] masterFileUntouched={masterUntouched}  [{o.Error ?? "ok"}]"));
+        }
+
+        // ===== S — REFUSE a FormKey the target doesn't carry (the "only what the file owns" gate) =====
+        // W2 lives only in the master; the user never overrides it. In-place remove must REFUSE, file byte-untouched.
+        {
+            var userS = FreshUser(tmpDir, "S", userPristine);
+            var before = File.ReadAllBytes(userS);
+            using var r = LoadOrderResolver.Build(new[] { masterPath, userS, highPath });
+            var o = WritePatchBuilder.RemoveRecordsInPlace(r, new[] { w2fk }, userS, UserName);
+            bool untouched = File.ReadAllBytes(userS).AsSpan().SequenceEqual(before);
+            bool pass = !o.Success && (o.Error?.Contains("not carried by") ?? false) && untouched;
+            results.Add(("S refuse-if-not-carried (remove only what the file owns)", pass,
+                $"refused={!o.Success} untouched={untouched}  [{o.Error ?? "(wrote — WRONG)"}]"));
+        }
+
+        // ===== T — SURGICAL removal: drop ONE own record, keep the rest + a still-referenced master =====
+        // Set up a user mod with TWO records: the weapon override (refs HcInPlaceMaster) + a NEW own keyword (refs nothing).
+        // Remove ONLY the keyword in place. The weapon override survives (dmg 20), RemainingRecords→1, and HcInPlaceMaster
+        // is KEPT (still referenced by the weapon) — proving the prune is surgical, never over-eager.
+        {
+            var userT = FreshUser(tmpDir, "T", userPristine);
+            FormKey kwFk;
+            using (var rc = LoadOrderResolver.Build(new[] { masterPath, userT, highPath }))
+            {
+                var c = WritePatchBuilder.CreateRecordsInPlace(rc, rulebook,
+                    new[] { new WritePatchBuilder.CreateSpec { RecordType = "Keyword", EditorId = "HcIP_RmKw", Edits = Array.Empty<WriteRequest>() } },
+                    userT, UserName);
+                kwFk = c.Created.Count > 0 ? c.Created[0].FormKey : default;
+            }
+            using var r = LoadOrderResolver.Build(new[] { masterPath, userT, highPath });
+            var o = WritePatchBuilder.RemoveRecordsInPlace(r, new[] { kwFk }, userT, UserName);
+            bool kwGone = !RecordPresent(userT, kwFk);
+            bool weaponKept = ReadDamage(userT, wfk) == 20 && ReadName(userT, wfk) == "UserSword";
+            var masters = ReadMasters(userT);
+            bool masterKept = masters.Any(m => m.Equals(MasterName, StringComparison.OrdinalIgnoreCase));
+            bool pass = o.Success && o.InPlace && o.Removed.Count == 1 && kwGone && weaponKept && o.RemainingRecords == 1 && masterKept;
+            results.Add(("T surgical remove (drop one own record, keep the rest + referenced master)", pass,
+                $"success={o.Success} inPlace={o.InPlace} keywordGone={kwGone} weaponKept={weaponKept} remaining={o.RemainingRecords}(want 1) masterKept={masterKept}  [{o.Error ?? "ok"}]"));
+        }
+
+        // ===== U — CONTRACT validation for remove (mirror the edit lane's E / create's L) =====
+        {
+            var userU = FreshUser(tmpDir, "U", userPristine);
+            using var r = LoadOrderResolver.Build(new[] { masterPath, userU, highPath });
+            var svc = LoadOrderService.ForGuard(r, new UserConfigStore(Path.Combine(tmpDir, "U.user.json")));
+            var noTarget = svc.RemoveRecords(new[] { fmtWfk }, null, target: null, inPlace: true, acknowledge: true);          // in_place w/o target
+            var withPatch = svc.RemoveRecords(new[] { fmtWfk }, "somepatch", target: UserName, inPlace: true, acknowledge: true); // in_place + patch=
+            var targetNoFlag = svc.RemoveRecords(new[] { fmtWfk }, null, target: UserName, inPlace: false);                     // target w/o in_place
+            bool pass = !noTarget.Success && (noTarget.Error?.Contains("requires target=") ?? false)
+                     && !withPatch.Success && (withPatch.Error?.Contains("mutually exclusive") ?? false)
+                     && !targetNoFlag.Success && (targetNoFlag.Error?.Contains("only meaningful with in_place") ?? false);
+            results.Add(("U contract (in_place<->target, _|_ patch=) — remove", pass,
+                $"noTarget={Trim(noTarget.Error)} | patch={Trim(withPatch.Error)} | noFlag={Trim(targetNoFlag.Error)}"));
+        }
+
+        // ===== V — RESOLVER: a non-load-order target REFUSES (never retargets) =====
+        {
+            var userV = FreshUser(tmpDir, "V", userPristine);
+            using var r = LoadOrderResolver.Build(new[] { masterPath, userV, highPath });
+            var svc = LoadOrderService.ForGuard(r, new UserConfigStore(Path.Combine(tmpDir, "V.user.json")));
+            var o = svc.RemoveRecords(new[] { fmtWfk }, null, target: "NotAReal.esp", inPlace: true, acknowledge: true);
+            bool pass = !o.Success && (o.Error?.Contains("not an active plugin") ?? false);
+            results.Add(("V resolver refuses a non-load-order target — remove", pass, Trim(o.Error)));
+        }
+
+        // ===== W — CONSENT HANDSHAKE: remove's own RED→GREEN, AND it SHARES the edit lane's ack (keyed off the path) =====
+        {
+            // W-part-1: remove's own first-touch RED→GREEN.
+            var userW = FreshUser(tmpDir, "W", userPristine);
+            byte[] before = File.ReadAllBytes(userW);
+            bool red, untouched, green, removed;
+            using (var r = LoadOrderResolver.Build(new[] { masterPath, userW }))
+            {
+                var svc = LoadOrderService.ForGuard(r, new UserConfigStore(Path.Combine(tmpDir, "W.user.json")));
+                var first = svc.RemoveRecords(new[] { fmtWfk }, null, target: UserName, inPlace: true, acknowledge: false);
+                red = first.NeedsAcknowledge && !first.Success;
+                untouched = File.ReadAllBytes(userW).AsSpan().SequenceEqual(before);
+                var ack = svc.RemoveRecords(new[] { fmtWfk }, null, target: UserName, inPlace: true, acknowledge: true);
+                green = ack.Success && ack.InPlace; removed = !RecordPresent(userW, wfk);
+            }
+            // W-part-2: SHARED handshake — an EDIT acks the plugin, then a REMOVE in place does NOT re-prompt (one ack
+            // covers edit + create + remove, keyed off the resolved path — the cross-lane share, the remove half of arm I).
+            var userW2 = FreshUser(tmpDir, "W2", userPristine);
+            bool editAck, removeNoPrompt, removeLanded;
+            using (var r = LoadOrderResolver.Build(new[] { masterPath, userW2 }))
+            {
+                var svc = LoadOrderService.ForGuard(r, new UserConfigStore(Path.Combine(tmpDir, "W2.user.json")));
+                var e = svc.ApplyEdits(new[] { new BulkOp { Formid = fmtWfk, FieldPath = "BasicStats.Damage", Verb = "Set", Value = "33" } },
+                    null, null, fullReadback: false, target: UserName, inPlace: true, acknowledge: true);
+                editAck = e.Success && e.InPlace;
+                var rm = svc.RemoveRecords(new[] { fmtWfk }, null, target: UserName, inPlace: true, acknowledge: false);
+                removeNoPrompt = rm.Success && !rm.NeedsAcknowledge; removeLanded = !RecordPresent(userW2, wfk);
+            }
+            bool pass = red && untouched && green && removed && editAck && removeNoPrompt && removeLanded;
+            results.Add(("W remove handshake RED->GREEN + SHARED with edit lane (one ack covers both)", pass,
+                $"firstRefused={red} untouched={untouched} ackRemoved={green && removed} | editAcked={editAck} removeNoReprompt={removeNoPrompt} removeLanded={removeLanded}"));
+        }
+
+        // ===== X — OPT-IN BY CONSTRUCTION (remove): remove_record defaults the three in-place params OFF =====
+        {
+            var rr = typeof(WriteTools).GetMethod(nameof(WriteTools.RemoveRecord))!;
+            bool DefOff(System.Reflection.MethodInfo m) =>
+                m.GetParameters().First(p => p.Name == "in_place").DefaultValue is false
+                && m.GetParameters().First(p => p.Name == "target").DefaultValue is null
+                && m.GetParameters().First(p => p.Name == "acknowledge").DefaultValue is false;
+            bool pass = DefOff(rr);
+            results.Add(("X opt-in by construction (remove_record defaults OFF)", pass, $"remove_record={DefOff(rr)}"));
+        }
+
         Console.WriteLine("── ARMS ──");
         bool all = true;
         foreach (var (name, pass, detail) in results)
@@ -510,6 +648,70 @@ public static class InPlaceProbe
 
         bool pass = ok && landed;
         Console.WriteLine($"=== inplace-nested-proof: {(pass ? "PASS — nested in-place survives ReleaseOverlay-before-serialize on a foreign target" : "FAIL")} ===");
+        try { Directory.Delete(tmpDir, recursive: true); } catch { }
+        return pass ? 0 : 1;
+    }
+
+    /// <summary>
+    /// REAL-DATA proof for WAVE 2 (remove-in-place): the in-place REMOVE of a NESTED own-override (a PlacedObject — lives
+    /// in a Cell). Confirms the typed nested <c>Remove(FormKey, Type)</c> drops a nested record AND the WriteInPlace
+    /// rewrite re-emits the rest of the foreign target faithfully on REAL data — the remove counterpart of
+    /// <see cref="RunNestedProof"/>. (Remove's present-check reads the mutable mod directly via CreateFromBinary, so it
+    /// opens no LinkCacheFor overlay on the target — the nested-LOCK hazard the edit proof guards is lighter here; what
+    /// this adds is the nested-Remove + real-data re-serialize on a third-party file.) Needs a real master (Skyrim.esm);
+    /// self-SKIPs on the CI runner.
+    /// Run: dotnet run --project src/housecarl-generator inplace-remove-nested-proof ["&lt;Data dir with Skyrim.esm&gt;"]
+    /// </summary>
+    public static int RunRemoveNestedProof(string[] args)
+    {
+        Console.WriteLine("=== inplace-remove-nested-proof — in-place REMOVE of a NESTED own-override (real data) ===");
+        string dataDir = args.Length > 0 ? args[0] : @"E:\Skyrim Modding\ARR 2.0\Stock Game\Data";
+        string skyrim = Path.Combine(dataDir, "Skyrim.esm");
+        if (!File.Exists(skyrim))
+        {
+            Console.WriteLine($"SKIP: need Skyrim.esm; not found at {skyrim} (pass the Data dir as arg 1). A real nested record + master");
+            Console.WriteLine("      can't be synthesized for the nested-remove arm — the same posture as inplace-nested-proof.");
+            return 0;
+        }
+
+        var tmpDir = Path.Combine(Path.GetTempPath(), "hc-inplace-remove-nested");
+        if (Directory.Exists(tmpDir)) Directory.Delete(tmpDir, recursive: true);
+        Directory.CreateDirectory(tmpDir);
+        var rulebook = CorpusRulebook.Load(GenerateCorpus(tmpDir));
+
+        FormKey refrFk;
+        using (var r0 = LoadOrderResolver.Build(new[] { skyrim }))
+        {
+            refrFk = r0.WinnerRecordsOfType(new[] { typeof(IPlacedObjectGetter) }).Select(x => x.fk).FirstOrDefault();
+            if (refrFk.IsNull) { Console.Error.WriteLine("no PlacedObject in Skyrim.esm"); return 1; }
+        }
+        Console.WriteLine($"-- real nested record: PlacedObject {refrFk} --");
+        string userPath = Path.Combine(tmpDir, "HcInPlaceRmNested.esp");
+
+        // STEP 1 — author a foreign-style user mod that OVERRIDES the nested record (winner=Skyrim.esm; the patch lane).
+        using (var r1 = LoadOrderResolver.Build(new[] { skyrim }))
+        {
+            var o = WritePatchBuilder.Apply(r1, rulebook,
+                new[] { new WritePatchBuilder.PatchEdit { Target = refrFk, Path = new[] { "Scale" }, Verb = "Set", Value = "1.5" } },
+                userPath, extend: false);
+            Console.WriteLine($"   step 1  author the nested override (winner=Skyrim.esm) : {(o.Success ? "OK" : "FAIL — " + o.Error)}");
+            if (!o.Success) return 1;
+        }
+        bool present0 = RecordPresent(userPath, refrFk);
+
+        // STEP 2 — THE TEST: REMOVE that nested record IN PLACE (drop the override from the foreign target's own file).
+        bool ok; string err;
+        using (var r2 = LoadOrderResolver.Build(new[] { skyrim, userPath }))
+        {
+            var o = WritePatchBuilder.RemoveRecordsInPlace(r2, new[] { refrFk }, userPath, Path.GetFileName(userPath));
+            ok = o.Success; err = o.Error ?? "ok";
+            Console.WriteLine($"   step 2  REMOVE the NESTED record IN PLACE : {(ok ? "OK" : "FAIL — " + err)}");
+        }
+        bool gone = !RecordPresent(userPath, refrFk);
+        Console.WriteLine($"   nested record present after step 1 : {present0} ;  gone after in-place remove : {gone}");
+
+        bool pass = ok && present0 && gone;
+        Console.WriteLine($"=== inplace-remove-nested-proof: {(pass ? "PASS — nested in-place remove drops the record + re-serializes faithfully on a foreign target" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return pass ? 0 : 1;
     }

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -351,6 +351,10 @@ if (args.Length > 0 && args[0] == "inplace-guard") return InPlaceProbe.RunGuard(
 // target overlay path), the one arm the self-contained guard can't synthesize. Needs Skyrim.esm; self-skips on the runner.
 if (args.Length > 0 && args[0] == "inplace-nested-proof") return InPlaceProbe.RunNestedProof(args[1..]);
 
+// In-place write lane Wave 2: REAL-DATA proof of the NESTED own-override REMOVE IN PLACE (typed nested Remove + a real-data
+// WriteInPlace re-serialize on a foreign target). The remove counterpart of inplace-nested-proof. Needs Skyrim.esm; self-skips.
+if (args.Length > 0 && args[0] == "inplace-remove-nested-proof") return InPlaceProbe.RunRemoveNestedProof(args[1..]);
+
 // Perk references= crash (HCBR-2026-06-09-03): DIAGNOSIS — run Mutagen's EnumerateFormLinks over every PERK in a
 // real plugin, report which records throw and with what (the evidence the fix is designed from). Skips without Skyrim.esm.
 if (args.Length > 0 && args[0] == "perk-refs-diagnose") return PerkRefsProbe.RunDiagnose(args[1..]);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1294,18 +1294,36 @@ public sealed class LoadOrderService : IDisposable
         => (a, b) switch { (null, null) => null, (null, _) => b, (_, null) => a, _ => a + " " + b };
 
     /// <summary>Remove WHOLE records a houseCARL patch carries (housecarl_remove_record) — literal drop-from-plugin, the
-    /// companion to <see cref="ApplyEdits"/>. <paramref name="patch"/> is REQUIRED and names an existing houseCARL-owned
-    /// patch (resolved + ownership-gated via the same <c>into=</c> path as an extend — refuses a folder houseCARL didn't
-    /// create, Q3); removal only makes sense against a patch that already carries the record. Parses every formid (all-or-
-    /// nothing on a malformed one), then drives <see cref="WritePatchBuilder.RemoveRecords"/> (present-check → mod.Remove →
-    /// re-serialize, with clean-masters riding along). Originals are never touched (only the patch folder is written).</summary>
-    public WritePatchBuilder.RemovalOutcome RemoveRecords(IReadOnlyList<string> formids, string? patch)
+    /// companion to <see cref="ApplyEdits"/>. In the DEFAULT lane <paramref name="patch"/> is REQUIRED and names an existing
+    /// houseCARL-owned patch (resolved + ownership-gated via the same <c>into=</c> path as an extend — refuses a folder
+    /// houseCARL didn't create, Q3); removal only makes sense against a patch that already carries the record. In the
+    /// IN-PLACE lane (Wave 2: <paramref name="target"/> + <paramref name="inPlace"/>) it drops the record from an EXISTING
+    /// plugin in place (incl. one houseCARL didn't author) instead — see <see cref="RemoveRecordsInPlace"/>. Parses every
+    /// formid (all-or-nothing on a malformed one), then drives <see cref="WritePatchBuilder.RemoveRecords"/> (present-check
+    /// → mod.Remove → re-serialize, with clean-masters riding along). The default lane never touches originals (only the
+    /// patch folder is written).</summary>
+    public WritePatchBuilder.RemovalOutcome RemoveRecords(IReadOnlyList<string> formids, string? patch,
+        string? target = null, bool inPlace = false, bool acknowledge = false)
     {
         if (formids is null || formids.Count == 0)
             return WritePatchBuilder.RemovalOutcome.Fail("no formids supplied — pass the FormID(s) of the record(s) to remove.");
-        if (string.IsNullOrWhiteSpace(patch))
+
+        // In-place is the explicit, named-file opt-in (the SECOND remove lane — drop a record from an EXISTING plugin, incl.
+        // one houseCARL didn't author, instead of from a houseCARL patch). Validate the contract up front (Q3): it REQUIRES
+        // a target=, and it is mutually exclusive with patch= (the houseCARL-owned lane). target= without in_place is a
+        // no-op the caller likely didn't mean — name it rather than silently ignore it. (Mirrors ApplyEdits' contract.)
+        if (inPlace && string.IsNullOrWhiteSpace(target))
             return WritePatchBuilder.RemovalOutcome.Fail(
-                "patch is required — name the houseCARL patch to remove the record from (removal only targets a patch that already carries it).");
+                "in_place=true requires target=<plugin filename> — name the existing plugin to remove the record from in place. (Omit in_place to drop the record from a houseCARL patch instead — the default.)");
+        if (inPlace && !string.IsNullOrWhiteSpace(patch))
+            return WritePatchBuilder.RemovalOutcome.Fail(
+                "in_place=true and patch= are mutually exclusive: patch= drops a record from a houseCARL patch, while in_place removes it from an existing plugin in place. Use one lane or the other.");
+        if (!inPlace && !string.IsNullOrWhiteSpace(target))
+            return WritePatchBuilder.RemovalOutcome.Fail(
+                "target= is only meaningful with in_place=true (it names the plugin to remove from in place). For the default lane omit target=; use patch= to name the houseCARL patch.");
+        if (!inPlace && string.IsNullOrWhiteSpace(patch))
+            return WritePatchBuilder.RemovalOutcome.Fail(
+                "patch is required — name the houseCARL patch to remove the record from (removal only targets a patch that already carries it). To remove from an existing plugin IN PLACE instead, pass target=<plugin filename> + in_place=true.");
 
         // Parse every formid first, collecting ALL problems (all-or-nothing, like the edit path). Pure — outside the gate.
         var keys = new List<FormKey>(formids.Count);
@@ -1325,6 +1343,9 @@ public sealed class LoadOrderService : IDisposable
         {
             var resolver = Resolver;                                      // builds/refreshes the index (Overlays for the re-serialize)
 
+            if (inPlace)
+                return RemoveRecordsInPlace(resolver, keys, target!.Trim(), acknowledge);
+
             // Resolve + ownership-gate the patch path via the into= (extend) path — must exist + carry the houseCARL marker.
             string outPath;
             try { outPath = ResolveOutputPath(patchName: null, into: patch, out _, out _); }
@@ -1332,6 +1353,63 @@ public sealed class LoadOrderService : IDisposable
 
             return WritePatchBuilder.RemoveRecords(resolver, keys, outPath);
         }
+    }
+
+    /// <summary>The in-place branch of <see cref="RemoveRecords"/> (in-place write lane, Wave 2) — runs under _writeGate.
+    /// The remove counterpart of <see cref="ApplyEditsInPlace"/>, and it REUSES every Wave-1 in-place seam: the same
+    /// foreign-target resolver (<see cref="ResolveActivePluginPath"/>), the same PERSISTENT first-touch CONSENT handshake
+    /// (keyed off the resolved path in <see cref="UserConfigStore"/>, SHARED with the edit + create lanes — acknowledging a
+    /// plugin once covers all three), the same writable-parent pre-flight, and the same distinct <c>editedInPlace=</c>
+    /// marker (NEVER <c>generated=true</c> — the user mod keeps failing <see cref="IsHouseCarlOwned"/> so a later into=
+    /// can't blind-overwrite it). It drives <see cref="WritePatchBuilder.RemoveRecordsInPlace"/> (drop the record from the
+    /// target's OWN file, with the absence verify forced ON). <paramref name="acknowledge"/> waives the CONSENT axis ONLY —
+    /// the verify is a corruption-axis fact no acknowledgement overrides. (No CorpusRulebook: a removal pre-flights nothing
+    /// — the present-check that the target carries the record is the whole gate.)</summary>
+    WritePatchBuilder.RemovalOutcome RemoveRecordsInPlace(
+        LoadOrderResolver resolver, IReadOnlyList<FormKey> keys, string target, bool acknowledge)
+    {
+        // (1) Resolve target -> real on-disk path via the load order (by plugin FILENAME). Refuse loud if it isn't a real
+        //     active plugin (closes the coincidental-folder collision). Same resolver as the edit + create lanes.
+        var view = resolver.Capture();
+        var targetPath = ResolveActivePluginPath(view, Path.GetFileName(target.Trim()), out var targetName);
+        if (targetPath is null)
+            return WritePatchBuilder.RemovalOutcome.Fail(
+                $"in-place target '{target}' is not an active plugin in the load order — name a plugin enabled in MO2, by its " +
+                "plugin filename (e.g. 'CoolWeapons.esp'). in-place removes from the file the game actually loads. Nothing was written.");
+
+        // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path (shared
+        //     with the edit + create lanes: acknowledging a plugin once covers editing, creating into, AND removing from
+        //     it in place — it's the same "touch your original" trade-off).
+        bool already = _store.IsInPlaceAcknowledged(targetPath);
+        if (!already && !acknowledge)
+            return WritePatchBuilder.RemovalOutcome.NeedsAck(InPlaceHandshakeText(targetName, targetPath));
+        string? ackNote = null;
+        if (!already && acknowledge)
+        {
+            var (ok, err) = _store.RecordInPlaceAcknowledged(targetPath);
+            if (!ok) ackNote = $"the in-place acknowledgement could not be saved ({err}) — the removal proceeded, but a future session will re-prompt for this plugin.";
+        }
+
+        // (3) Writable, same-volume parent pre-flight — refuse rather than degrade (the swap stages a sibling temp here).
+        if (InPlaceParentUnwritable(targetPath, out var why))
+            return WritePatchBuilder.RemovalOutcome.Fail(why);
+
+        // (4) The write — absence verify forced ON (the model-C substitute for the dropped whole-plugin floor).
+        var outcome = WritePatchBuilder.RemoveRecordsInPlace(resolver, keys, targetPath, targetName);
+
+        // (5) On success, stamp the distinct audit marker (best-effort; a marker miss never fails the done removal, Q3-noted).
+        if (outcome.Success)
+        {
+            var markerNote = MergeEditedInPlaceMarker(Path.GetDirectoryName(targetPath));
+            var note = JoinNotes(ackNote, markerNote);
+            if (note is not null) return outcome with { Note = note };
+        }
+        else if (ackNote is not null)
+        {
+            // The acknowledgement was recorded but the write then failed — keep the (now-honest) note alongside the error.
+            return outcome with { Note = ackNote };
+        }
+        return outcome;
     }
 
     /// <summary>Forward a NAMED plugin's version of one-or-more records into a patch as an override (housecarl_forward_record)

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -110,29 +110,39 @@ public static class WriteTools
         return Render(svc.ApplyEdits(operations, patch_name, into, full_readback, target, in_place, acknowledge), max_chars);
     });
 
-    [McpServerTool(Name = "housecarl_remove_record", Title = "Remove a whole record from a patch"),
+    [McpServerTool(Name = "housecarl_remove_record", Title = "Remove a whole record from a patch (or a plugin in place)"),
      Description(
          "Remove a WHOLE record from a houseCARL patch — a literal drop-from-plugin (NOT a flag-as-deleted stub). The " +
          "companion to the edit tools: where set_field/bulk_apply ADD an override into a patch, this drops one OUT of it. " +
          "Only works on a record the patch ITSELF carries — one houseCARL created, or an override the patch accumulated " +
          "via a prior set_field/bulk_apply into=patch. You CANNOT remove a record that lives in a master/another mod; you " +
          "can only drop THIS patch's override of it, which makes the load-order winner revert (the patch stops touching " +
-         "that record). patch is REQUIRED and names an existing houseCARL-owned patch (the same name you pass to into=); " +
-         "removal targets a patch that already carries the record. Refuses loud and writes nothing (Q3) if the patch does " +
-         "not carry the FormID. Unused masters are pruned automatically — if the removed record held the patch's last " +
-         "reference to a master, that master drops from the header on the re-write. Reaches records in ANY group (incl. " +
-         "cells, placed references, dialog, navmesh). Returns what was removed, the patch's remaining masters, and how " +
-         "many records remain. To remove a list ENTRY (a keyword, an item) rather than a whole record, use set_field with " +
-         "verb=Remove instead.")]
+         "that record). patch names an existing houseCARL-owned patch (the same name you pass to into=) and is REQUIRED in " +
+         "this default lane; removal targets a patch that already carries the record. Refuses loud and writes nothing (Q3) " +
+         "if the patch does not carry the FormID. Unused masters are pruned automatically — if the removed record held the " +
+         "patch's last reference to a master, that master drops from the header on the re-write. Reaches records in ANY " +
+         "group (incl. cells, placed references, dialog, navmesh). Returns what was removed, the patch's remaining masters, " +
+         "and how many records remain. To remove the record straight from an EXISTING plugin IN PLACE instead — dropping it " +
+         "from your ORIGINAL file (incl. a mod houseCARL didn't make), not a patch — pass target=<plugin filename> + " +
+         "in_place=true (opt-in; the default patch lane leaves originals untouched). In place the rule is the same: you can " +
+         "only drop a record the TARGET file itself defines or OVERRIDES (dropping an override it holds reverts that record " +
+         "to the load-order winner underneath); a FormID the target doesn't carry is refused. To remove a list ENTRY (a " +
+         "keyword, an item) rather than a whole record, use set_field with verb=Remove instead.")]
     public static string RemoveRecord(
         LoadOrderService svc,
-        [Description("The record's FormID as 'XXXXXX:Plugin.esp' — the record to drop from the patch.")]
+        [Description("The record's FormID as 'XXXXXX:Plugin.esp' — the record to drop.")]
             string formid,
-        [Description("Filename of the houseCARL patch to remove the record from (e.g. 'MyMerge.esp' or 'MyMerge') — must be a patch houseCARL created that carries this record. Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead (folder & plugin names need not match).")]
-            string patch) => Guard.Tool("housecarl_remove_record", () =>
+        [Description("DEFAULT LANE: filename of the houseCARL patch to remove the record from (e.g. 'MyMerge.esp' or 'MyMerge') — must be a patch houseCARL created that carries this record. Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead (folder & plugin names need not match). REQUIRED unless you use the in-place lane (target + in_place); omit it then.")]
+            string? patch = null,
+        [Description("Optional. IN-PLACE LANE (opt-in): the filename of an EXISTING active plugin to remove the record from IN PLACE — including one houseCARL didn't author — instead of from a houseCARL patch (e.g. 'CoolWeapons.esp'). Requires in_place=true; mutually exclusive with patch. Drops only a record the TARGET itself defines or overrides; a FormID it doesn't carry is refused. OMIT this (the default) to drop the record from a houseCARL patch and leave every original untouched.")]
+            string? target = null,
+        [Description("Optional, default false. With target=, remove the record straight from that plugin IN PLACE: houseCARL rewrites your ORIGINAL file — no patch, and NO houseCARL backup or undo (keep your own). houseCARL re-lays-out the whole plugin the way xEdit/CK do on save, VERIFIES the record is gone, and trusts Mutagen for the untouched rest; it refuses a file it can't parse or that holds engine-reserved (sub-0x800) records. Any master the removal orphans is pruned from the header. The FIRST in-place write to a given plugin returns a one-time confirmation prompt (re-call with acknowledge=true).")]
+            bool in_place = false,
+        [Description("Optional, default false. Confirms the one-time in-place trade-off for target (see in_place) — needed only on the FIRST in-place write to a given plugin (edit, create, OR remove), never again for it. Waives the consent to touch your original ONLY; it NEVER skips the record verify.")]
+            bool acknowledge = false) => Guard.Tool("housecarl_remove_record", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-        return RenderRemoval(svc.RemoveRecords(new[] { formid }, patch));
+        return RenderRemoval(svc.RemoveRecords(new[] { formid }, patch, target, in_place, acknowledge));
     });
 
     [McpServerTool(Name = "housecarl_create_record", Title = "Create a brand-new record"),
@@ -395,21 +405,37 @@ public static class WriteTools
     /// records remain (0 ⇒ inert). On refusal, the named reason (Q3) so the caller can fix and retry.</summary>
     static string RenderRemoval(WritePatchBuilder.RemovalOutcome o)
     {
+        if (o.NeedsAcknowledge) return o.Error!;            // the first-touch in-place CONSENT prompt — a required confirmation, NOT an error (Q3)
         if (!o.Success) return "error: " + o.Error;
         var file = Path.GetFileName(o.OutputPath);
         var modFolder = Path.GetFileName(Path.GetDirectoryName(o.OutputPath) ?? "");
         var sb = new StringBuilder();
         sb.Append("removed ").Append(o.Removed.Count).Append(o.Removed.Count == 1 ? " record from " : " records from ")
-          .Append(file).Append(" (").Append(o.Bytes).Append(" bytes; ")
-          .Append(o.RemainingRecords).Append(o.RemainingRecords == 1 ? " record remains)\n" : " records remain)\n");
-        sb.Append("mod folder: ").Append(modFolder).Append('\n');
+          .Append(file);
+        if (o.InPlace)
+            sb.Append(" IN PLACE (").Append(o.Bytes).Append(" bytes; ")
+              .Append(o.RemainingRecords).Append(o.RemainingRecords == 1 ? " record remains" : " records remain")
+              .Append(" — your ORIGINAL file was rewritten; no houseCARL backup or undo)\n")
+              .Append("mod folder: ").Append(modFolder).Append("  — already active in your load order; re-sort only if a winner changed\n");
+        else
+        {
+            sb.Append(" (").Append(o.Bytes).Append(" bytes; ")
+              .Append(o.RemainingRecords).Append(o.RemainingRecords == 1 ? " record remains)\n" : " records remain)\n");
+            sb.Append("mod folder: ").Append(modFolder).Append('\n');
+        }
         foreach (var r in o.Removed)
             sb.Append("  - ").Append(r.RecordType).Append(' ').Append(r.Target).Append("  ")
               .Append(r.EditorId ?? "<no editorid>").Append('\n');
         sb.Append("masters: ").Append(o.Masters.Count == 0 ? "(none)" : string.Join(", ", o.Masters)).Append('\n');
-        sb.Append(o.RemainingRecords == 0
-            ? "this patch now carries no records — it's inert; disable or delete the mod folder in MO2 if you don't need it."
-            : "re-sort in MO2 if dropping this override changes a conflict winner.");
+        if (o.Note is { } note) sb.Append("note: ").Append(note).Append('\n');
+        if (o.InPlace)
+            sb.Append(o.RemainingRecords == 0
+                ? "this plugin now carries no records — it's an inert shell; disable or delete the mod in MO2 if you don't need it."
+                : $"to remove more records from this plugin in place, pass target=\"{file}\" in_place=true (no further confirmation needed for it).");
+        else
+            sb.Append(o.RemainingRecords == 0
+                ? "this patch now carries no records — it's inert; disable or delete the mod folder in MO2 if you don't need it."
+                : "re-sort in MO2 if dropping this override changes a conflict winner.");
         return sb.ToString();
     }
 


### PR DESCRIPTION
## What this is

Wave 2 of the in-place write lane: `housecarl_remove_record` gains `target=` / `in_place=true` / `acknowledge=`, the **remove** counterpart of the Wave-1 edit and Wave-1b create lanes (both empirically locked via live test). It drops a record from the user's **own** file instead of from a houseCARL patch.

Plan: `dev/plans/IN_PLACE_WRITE_LANE_PLAN_2026-06-13.md` §E (Wave 2). Build-go'd as part of the waved lane.

## Semantics (the patch-lane remove, pointed at the user's own file)

- Drops only a record the **target itself defines or overrides** — a FormID it doesn't carry is **refused loud** (Q3), nothing written. Dropping an override the target holds reverts that record to the load-order winner underneath.
- **Orphaned masters prune** on the `WriteInPlace` rewrite (Mutagen lean-derives the header from surviving records' links — the same prune the patch lane gets via `WritePatch`).
- The **consent handshake is shared** across edit/create/remove (keyed off the resolved path) — acknowledging a plugin once covers all three.
- The model-C touched-record verify is applied to a removal as **absence**: each removed FormKey is confirmed gone on the re-opened on-disk file.

Reuses every Wave-1 seam unchanged: the foreign-target resolver, the persistent first-touch consent handshake, the writable-parent pre-flight, and the distinct `editedInPlace=` marker (never `generated=true`, so the user mod keeps failing `IsHouseCarlOwned` and a later `into=` can't blind-overwrite it).

## Changes

- **core** (`WritePatchBuilder.cs`): `RemovalOutcome` gains `InPlace` / `NeedsAcknowledge` / `Note` + a `NeedsAck` factory; new `RemoveRecordsInPlace` (removal semantics from `RemoveRecords` + in-place write mechanics from `ApplyInPlace`).
- **service** (`LoadOrderService.cs`): `RemoveRecords` gains the in-place contract (`in_place` requires `target`, mutually exclusive with `patch=`) + a private `RemoveRecordsInPlace` branch mirroring `ApplyEditsInPlace`. Default-lane behavior preserved exactly.
- **tool** (`WriteTools.cs`): `remove_record` `target`/`in_place`/`acknowledge` params + descriptions; `RenderRemoval` handles the handshake prompt + the distinct "removed in place" confirmation.
- **CI teeth** (`InPlaceProbe.cs`, `Program.cs`, `ci.yml`): `inplace-guard` arms **R–X** (override-remove+prune, refuse-if-not-carried, surgical-remove+keep-master, contract, resolver, handshake+cross-lane-share, opt-in) + the manual real-data `inplace-remove-nested-proof`.

## Proof

- `inplace-guard` (runs in CI): **all arms A–X PASS**.
- Real-data on Skyrim.esm: new `inplace-remove-nested-proof` **PASS**; existing `inplace-nested-proof` (edit) still **PASS**.
- Build clean (0 warnings). Patch-lane remove core untouched (additive change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)