### PR TITLE
fix: resolve localized strings for cleaned/DLC masters (HCBR 2026-06-24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,3 +455,15 @@ jobs:
       # folders/instances + the committed FixtureA.bsa (fixtures/asset-resolver/), so it runs here with NO BSArch.
       - name: Probe — place asset (FaceGen-path keystone + precise placer + BSA extract + wins-VFS)
         run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- place-asset-guard
+
+      # Localized-strings redirect DECISION (HCBR 2026-06-24): SELF-CONTAINED CI regression guard — the pure path
+      # logic the localized-strings read fix turns on, with NO game files. A localized master MO2 resolves to a
+      # strings-less mod folder (the "Cleaned Base Game Masters" pattern) read its FULL/Name EMPTY because Mutagen's
+      # per-plugin strings lookup only scans the plugin's OWN folder; OpenOverlay redirects the lookup to the real
+      # game-Data folder ONLY when the plugin's own folder carries no strings source. Locks the two decision pieces
+      # most likely to silently regress: FolderHasOwnStrings (loose Strings\ OR a .bsa ⇒ keep the default; bare ⇒
+      # redirect; a bad read ⇒ defensive keep-default) and ComputeDataDir (the fallback target = the resolved
+      # Skyrim.esm's dir, case-insensitive, null when absent). Temp dirs only. The end-to-end string RESOLUTION
+      # (Mutagen finding the DLC strings in the game-Data BSA) is the manual strings-resolve-probe (needs real DLC + BSA).
+      - name: Probe — localized-strings redirect decision (self-contained regression guard)
+        run: dotnet run --project src/housecarl-generator --configuration Release --no-build -- strings-decision-guard

--- a/src/housecarl-core/FieldsDiff.cs
+++ b/src/housecarl-core/FieldsDiff.cs
@@ -53,7 +53,7 @@ public static class FieldsDiff
     /// first-class state, never compared as if it were a real token value. References the <see cref="ReadEngine"/>
     /// constants directly (same assembly) — single source of truth, compile-time coupling, no drift.</summary>
     static bool IsAbsentSentinel(string val) =>
-        val == ReadEngine.AbsentNote || val == ReadEngine.NullLinkNote;
+        val == ReadEngine.AbsentNote || val == ReadEngine.NullLinkNote || val == ReadEngine.UnresolvedStringNote;
 
     /// <summary>Compare one plugin's deep-read fields against the winner's. Both sides should be read by the
     /// same <see cref="ReadEngine.ReadFields"/> call shape (same paths, same depth) so line sets correspond.</summary>

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -244,7 +244,7 @@ public sealed class LoadOrderResolver : IDisposable
     /// master is never cleaned/relocated, so it resolves to the true game-Data root in both MO2 and explicit-paths modes.
     /// The localized-strings fallback target in <see cref="OpenOverlay"/>; null (→ unchanged folder-adjacent opens
     /// everywhere) only if the order somehow lacks Skyrim.esm.</summary>
-    static string? ComputeDataDir(Dictionary<string, int> nameToIdx, string[] paths)
+    internal static string? ComputeDataDir(Dictionary<string, int> nameToIdx, string[] paths)
         => nameToIdx.TryGetValue("Skyrim.esm", out var i) ? Path.GetDirectoryName(paths[i]) : null;
 
     /// <summary>Open one plugin as a lazy binary overlay — THE single overlay-open choke point (every read/scan/index
@@ -279,7 +279,7 @@ public sealed class LoadOrderResolver : IDisposable
     /// a loose <c>Strings\</c> subfolder or any <c>.bsa</c> (which may embed strings). Cheap (one dir stat + a lazy,
     /// short-circuited <c>.bsa</c> scan; negligible beside the per-plugin overlay open it precedes). Defensive: any IO
     /// fault answers "has its own", keeping the unchanged default open — we only ever REDIRECT on a clean, empty read.</summary>
-    static bool FolderHasOwnStrings(string path)
+    internal static bool FolderHasOwnStrings(string path)
     {
         try
         {

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -1,8 +1,10 @@
 using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Binary.Parameters;
 using Mutagen.Bethesda.Plugins.Cache;
 using Mutagen.Bethesda.Plugins.Records;
 using Mutagen.Bethesda.Skyrim;
+using Mutagen.Bethesda.Strings;
 
 namespace HousecarlCore;
 
@@ -73,6 +75,7 @@ public sealed class LoadOrderResolver : IDisposable
     readonly string[] _names;                          // index → plugin filename (e.g. "Skyrim.esm"); == Path.GetFileName(path)
     readonly Dictionary<string, int> _nameToIdx;       // plugin filename → index (last copy of a duplicate name wins = priority)
     DateTime[] _mtimes;                                // last-write at the last index build, per path (freshness baseline)
+    readonly string? _dataDir;                         // real game-Data folder (Skyrim.esm's dir) — localized-strings fallback source (OpenOverlay)
 
     /// <summary>One index build's ENTIRE output, swapped in as a SINGLE reference write. The service refreshes the
     /// index under its own gate, but READERS run outside that gate (concurrent tool calls hold the resolver while a
@@ -141,7 +144,7 @@ public sealed class LoadOrderResolver : IDisposable
         internal ISkyrimModGetter Overlay(int idx)
         {
             if (!_open.TryGetValue(idx, out var ov))
-                _open[idx] = ov = SkyrimMod.CreateFromBinaryOverlay(_r._paths[idx], SkyrimRelease.SkyrimSE);
+                _open[idx] = ov = OpenOverlay(_r._paths[idx], _r._dataDir);
             return ov;
         }
 
@@ -232,7 +235,60 @@ public sealed class LoadOrderResolver : IDisposable
     LoadOrderResolver(string[] paths, string[] names, Dictionary<string, int> nameToIdx, DateTime[] mtimes)
     {
         _paths = paths; _names = names; _nameToIdx = nameToIdx; _mtimes = mtimes;
+        _dataDir = ComputeDataDir(nameToIdx, paths);
         _snap = BuildIndex();
+    }
+
+    /// <summary>The real game-Data directory — the folder holding the vanilla BSAs (<c>Skyrim - Interface.bsa</c> et al.,
+    /// which carry the base AND DLC <c>.STRINGS</c>). Derived as the folder of the resolved <c>Skyrim.esm</c>: the base
+    /// master is never cleaned/relocated, so it resolves to the true game-Data root in both MO2 and explicit-paths modes.
+    /// The localized-strings fallback target in <see cref="OpenOverlay"/>; null (→ unchanged folder-adjacent opens
+    /// everywhere) only if the order somehow lacks Skyrim.esm.</summary>
+    static string? ComputeDataDir(Dictionary<string, int> nameToIdx, string[] paths)
+        => nameToIdx.TryGetValue("Skyrim.esm", out var i) ? Path.GetDirectoryName(paths[i]) : null;
+
+    /// <summary>Open one plugin as a lazy binary overlay — THE single overlay-open choke point (every read/scan/index
+    /// path routes through here) — wiring localized-string (FULL/DESC/…) resolution so a plugin resolved to a folder
+    /// WITHOUT its own strings still reads its names. Mutagen's bare overload only scans the plugin's OWN folder for
+    /// strings (loose <c>Strings\</c> + BSAs there); a localized master that MO2 resolves to a strings-less mod folder
+    /// — the near-universal "Cleaned Base Game Masters" pattern, whose <c>.STRINGS</c> live in the game-Data BSAs beside
+    /// Skyrim.esm — otherwise reads every localized field EMPTY (HCBR-2026-06-24: <c>where Name contains</c> silently
+    /// 0-matched the DLC masters; <see cref="ReadEngine.EmitToken"/> turned the unresolved <c>TranslatedString</c> into
+    /// a blank token). When the plugin's own folder carries NO strings source, point the lookup at the real game-Data
+    /// folder so those archived strings resolve; otherwise leave the folder-adjacent default UNTOUCHED, so a mod whose
+    /// strings sit in its own folder (loose OR in its own BSA) is never redirected away from them — no regression. A
+    /// non-localized plugin needs no strings at all, so the override is simply never consulted.</summary>
+    internal static ISkyrimModGetter OpenOverlay(string path, string? dataDir)
+    {
+        if (dataDir is not null && !FolderHasOwnStrings(path))
+        {
+            var prm = BinaryReadParameters.Default with
+            {
+                StringsParam = new StringsReadParameters
+                {
+                    BsaFolderOverride = dataDir,
+                    StringsFolderOverride = Path.Combine(dataDir, "Strings"),
+                },
+            };
+            return SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE, prm);
+        }
+        return SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE);
+    }
+
+    /// <summary>True if the plugin's OWN folder carries a strings source Mutagen's folder-adjacent default would find —
+    /// a loose <c>Strings\</c> subfolder or any <c>.bsa</c> (which may embed strings). Cheap (one dir stat + a lazy,
+    /// short-circuited <c>.bsa</c> scan; negligible beside the per-plugin overlay open it precedes). Defensive: any IO
+    /// fault answers "has its own", keeping the unchanged default open — we only ever REDIRECT on a clean, empty read.</summary>
+    static bool FolderHasOwnStrings(string path)
+    {
+        try
+        {
+            var folder = Path.GetDirectoryName(path);
+            if (folder is null) return true;
+            if (Directory.Exists(Path.Combine(folder, "Strings"))) return true;
+            return Directory.EnumerateFiles(folder, "*.bsa").Any();
+        }
+        catch { return true; }
     }
 
     /// <summary>Take the plugin paths already in priority order and build the index — WITHOUT holding any plugin open
@@ -285,7 +341,7 @@ public sealed class LoadOrderResolver : IDisposable
         for (int i = 0; i < _paths.Length; i++)
         {
             ISkyrimModGetter ov;
-            try { ov = SkyrimMod.CreateFromBinaryOverlay(_paths[i], SkyrimRelease.SkyrimSE); }
+            try { ov = OpenOverlay(_paths[i], _dataDir); }
             catch (Exception ex)
             {
                 Exclude(i, $"could not be opened — {Concise(ex)}", failures, excluded, excludedPlugins);
@@ -481,7 +537,7 @@ public sealed class LoadOrderResolver : IDisposable
             throw new ArgumentException($"plugin not in the load order: {pluginName}");
         if (s.Excluded.Contains(idx))
             throw new ArgumentException($"plugin '{pluginName}' was excluded from this session: {s.ExcludedPlugins[pluginName]}");
-        var ov = SkyrimMod.CreateFromBinaryOverlay(_paths[idx], SkyrimRelease.SkyrimSE);
+        var ov = OpenOverlay(_paths[idx], _dataDir);
         try
         {
             foreach (var rec in ov.EnumerateMajorRecords())
@@ -547,7 +603,7 @@ public sealed class LoadOrderResolver : IDisposable
         {
             if (s.Excluded.Contains(i)) continue;                          // excluded at build (unparseable/unopenable) — wins nothing; never re-touch (would re-throw)
             ISkyrimModGetter ov;
-            try { ov = SkyrimMod.CreateFromBinaryOverlay(_paths[i], SkyrimRelease.SkyrimSE); }
+            try { ov = OpenOverlay(_paths[i], _dataDir); }
             catch { continue; }                                            // an unopenable plugin wins nothing (surfaced at build)
             try
             {
@@ -575,7 +631,7 @@ public sealed class LoadOrderResolver : IDisposable
         foreach (int i in ScopeIndices(plugins, s))
         {
             ISkyrimModGetter ov;
-            try { ov = SkyrimMod.CreateFromBinaryOverlay(_paths[i], SkyrimRelease.SkyrimSE); }
+            try { ov = OpenOverlay(_paths[i], _dataDir); }
             catch { continue; }
             try
             {

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -66,6 +66,16 @@ public static class ReadEngine
     /// both as "no value here" (see <c>FieldsDiff.IsAbsentSentinel</c>).</summary>
     internal const string NullLinkNote = "(null link)";
 
+    /// <summary>A present <c>TranslatedString</c> (FULL/DESC/…) whose <c>.String</c> resolves to null — a localized
+    /// string whose <c>.STRINGS</c> entry for the target language is not in the workspace. After the
+    /// <see cref="LoadOrderResolver.OpenOverlay"/> strings-source fix this is the genuinely-absent residue (no
+    /// strings anywhere for it), NOT the cleaned-masters case that fix resolves. Surfaced as a no-value NOTE — never
+    /// a blank token — so a value predicate's Q3 accounting fires on it (a `where Name contains …` can't silently
+    /// treat it as a real non-matching value → false "0 matches") and a read renders it loud, not as an empty Name
+    /// indistinguishable from a record that truly has none (HCBR-2026-06-24). Like <see cref="AbsentNote"/> /
+    /// <see cref="NullLinkNote"/>, the conflict diff treats it as "no value here" (<c>FieldsDiff.IsAbsentSentinel</c>).</summary>
+    internal const string UnresolvedStringNote = "(unresolved localized string)";
+
     // ======================================================================
     //  `read` MODE — resolve a record in one plugin and emit its fields.
     //    dotnet run --project src/housecarl-generator read \
@@ -481,6 +491,17 @@ public static class ReadEngine
         // FormKey, never "Null"), so surface it as no-value — consistent with what Coerce accepts.
         if (val is IFormLinkGetter fl)
             return fl.FormKey.IsNull ? LeafRead.None(NullLinkNote) : LeafRead.Value(fl.FormKey.ToString());
+        // TranslatedString (FULL/DESC) — emit the resolved .String (the inverse of Coerce's implicit
+        // `record.Name = "x"`). A genuinely-empty "" still round-trips as a value; a NULL .String is an
+        // UNRESOLVED localized string (no .STRINGS entry for the target language in the workspace) and is
+        // surfaced LOUD as no-value, never a blank token — so the Q3 accounting fires instead of a silent
+        // non-match (HCBR-2026-06-24). Checked before TryEmitValueType, which previously folded the null
+        // into "" here.
+        if (val.GetType().FullName == "Mutagen.Bethesda.Strings.TranslatedString")
+        {
+            var s = ReflectString(val, "String");
+            return s is null ? LeafRead.None(UnresolvedStringNote) : LeafRead.Value(s);
+        }
         // value types (inverse of TryValueType)
         if (TryEmitValueType(val, out var vt)) return LeafRead.Value(vt);
 
@@ -528,9 +549,8 @@ public static class ReadEngine
         var rt2 = val.GetType();
         var fn = rt2.FullName;
 
-        // TranslatedString — emit the plain .String the implicit `record.Name = "x"` conversion stored.
-        if (fn == "Mutagen.Bethesda.Strings.TranslatedString")
-        { token = ReflectString(val, "String") ?? ""; return true; }
+        // (TranslatedString is handled earlier in EmitToken — a null .String surfaces as a loud no-value note,
+        //  not the blank token this branch used to fold it into; see UnresolvedStringNote.)
 
         // Noggog.Percent — emit the [0..1] fraction its single-arg ctor takes. Find the underlying
         // numeric member BY TYPE, not a guessed name: Percent stores exactly one double (its ToString

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -198,6 +198,9 @@ if (args.Length > 0 && args[0] == "class-parents") return ClassParentsEmitter.Ru
 // unreadable-pex loud, never-overwrite, soft hierarchy degradation. Self-contained (fixtures are ours, committed).
 if (args.Length > 0 && args[0] == "decompile-guard") return DecompileGuardProbe.RunGuard(args[1..]);
 
+// Localized-strings read fix (Heisen 2026-06-24): DLC master resolved to a strings-less mod folder reads Name EMPTY.
+if (args.Length > 0 && args[0] == "strings-resolve-probe") return StringsResolveProbe.Run(args[1..]);
+
 // One-shot verify (decision #1): confirm the xEdit 4-char signature reflection path.
 if (args.Length > 0 && args[0] == "sig") return Probe.RunSig();
 

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -201,6 +201,9 @@ if (args.Length > 0 && args[0] == "decompile-guard") return DecompileGuardProbe.
 // Localized-strings read fix (Heisen 2026-06-24): DLC master resolved to a strings-less mod folder reads Name EMPTY.
 if (args.Length > 0 && args[0] == "strings-resolve-probe") return StringsResolveProbe.Run(args[1..]);
 
+// Localized-strings redirect DECISION (HCBR 2026-06-24): SELF-CONTAINED CI guard — FolderHasOwnStrings + ComputeDataDir over temp dirs.
+if (args.Length > 0 && args[0] == "strings-decision-guard") return StringsDecisionProbe.RunGuard(args[1..]);
+
 // One-shot verify (decision #1): confirm the xEdit 4-char signature reflection path.
 if (args.Length > 0 && args[0] == "sig") return Probe.RunSig();
 

--- a/src/housecarl-generator/StringsDecisionProbe.cs
+++ b/src/housecarl-generator/StringsDecisionProbe.cs
@@ -1,0 +1,105 @@
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SELF-CONTAINED CI regression guard for the localized-strings redirect DECISION (HCBR 2026-06-24) — the pure
+/// path logic the bug turned on, with ZERO game files. The end-to-end string RESOLUTION (does Mutagen find the
+/// DLC strings in the game-Data BSA once redirected) is exercised by the manual strings-resolve-probe against
+/// real DLC + Skyrim - Interface.bsa; THIS guard locks the two decision pieces most likely to silently regress
+/// under a refactor:
+///   FolderHasOwnStrings(path) — does the plugin's OWN folder carry a strings source (loose Strings\ or a .bsa)?
+///                              true ⇒ keep the unchanged folder-adjacent default open; false ⇒ redirect to game-Data.
+///   ComputeDataDir(nameToIdx, paths) — the game-Data fallback target = the resolved Skyrim.esm's directory.
+///
+/// Each assertion is its own RED-proof: a regression (e.g. dropping the .bsa check, or a case-sensitive Skyrim
+/// lookup) flips a specific bool and fails the named case. Builds throwaway temp dirs; deletes them on exit.
+///
+/// Run: dotnet run --project src/housecarl-generator strings-decision-guard
+/// </summary>
+public static class StringsDecisionProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("== strings redirect decision (FolderHasOwnStrings + ComputeDataDir), self-contained ==");
+        var root = Path.Combine(Path.GetTempPath(), "hc-strings-decision-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        int fails = 0;
+        try
+        {
+            // ---- FolderHasOwnStrings: the redirect decision ----
+            // (a) bare folder (the .esm only — the "Cleaned Base Game Masters" shape) ⇒ NO own strings ⇒ redirect.
+            var bare = MkFolder(root, "bare", esp: "Cleaned.esm");
+            fails += Check("bare folder (.esm only) → no own strings (redirect)",
+                LoadOrderResolver.FolderHasOwnStrings(Path.Combine(bare, "Cleaned.esm")) == false);
+
+            // (b) folder WITH a loose Strings\ ⇒ has own strings ⇒ keep default.
+            var loose = MkFolder(root, "loose", esp: "Mod.esp");
+            Directory.CreateDirectory(Path.Combine(loose, "Strings"));
+            fails += Check("loose Strings\\ → has own strings (no redirect)",
+                LoadOrderResolver.FolderHasOwnStrings(Path.Combine(loose, "Mod.esp")) == true);
+
+            // (c) folder WITH a .bsa (may embed strings) ⇒ has own strings ⇒ keep default. The check the bug needs
+            //     most: a localized mod whose strings live in its OWN bsa must NOT be redirected away from them.
+            var bsa = MkFolder(root, "bsa", esp: "Mod.esp");
+            File.WriteAllText(Path.Combine(bsa, "Mod.bsa"), "x");
+            fails += Check(".bsa present → has own strings (no redirect)",
+                LoadOrderResolver.FolderHasOwnStrings(Path.Combine(bsa, "Mod.esp")) == true);
+
+            // (d) BOTH ⇒ has own strings.
+            var both = MkFolder(root, "both", esp: "M.esp");
+            Directory.CreateDirectory(Path.Combine(both, "Strings"));
+            File.WriteAllText(Path.Combine(both, "M.bsa"), "x");
+            fails += Check("Strings\\ + .bsa → has own strings (no redirect)",
+                LoadOrderResolver.FolderHasOwnStrings(Path.Combine(both, "M.esp")) == true);
+
+            // (e) DEFENSIVE: a path whose folder doesn't exist ⇒ "has own" (true) so OpenOverlay keeps the
+            //     unchanged default — we only ever REDIRECT on a clean, empty read, never on a bad one.
+            fails += Check("nonexistent folder → defensive 'has own' (no redirect on a bad read)",
+                LoadOrderResolver.FolderHasOwnStrings(Path.Combine(root, "does-not-exist", "X.esp")) == true);
+
+            // ---- ComputeDataDir: the game-Data fallback target = Skyrim.esm's directory ----
+            var dataDir = Path.Combine(root, "Data");
+            Directory.CreateDirectory(dataDir);
+            var skyrim = Path.Combine(dataDir, "Skyrim.esm");
+
+            // (f) Skyrim.esm present ⇒ its directory.
+            var withSky = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase) { ["Update.esm"] = 0, ["Skyrim.esm"] = 1 };
+            var withSkyPaths = new[] { Path.Combine(root, "x", "Update.esm"), skyrim };
+            fails += Check("ComputeDataDir → resolved Skyrim.esm's dir",
+                SamePath(LoadOrderResolver.ComputeDataDir(withSky, withSkyPaths), dataDir));
+
+            // (g) case-insensitive lookup (the nameToIdx Build uses is OrdinalIgnoreCase) ⇒ still found.
+            var lcSky = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase) { ["skyrim.esm"] = 0 };
+            fails += Check("ComputeDataDir → case-insensitive Skyrim.esm key",
+                SamePath(LoadOrderResolver.ComputeDataDir(lcSky, new[] { skyrim }), dataDir));
+
+            // (h) no Skyrim.esm ⇒ null ⇒ OpenOverlay leaves the default open everywhere (no fallback target).
+            var noSky = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase) { ["Dragonborn.esm"] = 0 };
+            fails += Check("ComputeDataDir → null when no Skyrim.esm",
+                LoadOrderResolver.ComputeDataDir(noSky, new[] { Path.Combine(dataDir, "Dragonborn.esm") }) is null);
+        }
+        finally { try { Directory.Delete(root, recursive: true); } catch { /* best-effort temp cleanup */ } }
+
+        Console.WriteLine(fails == 0
+            ? "GUARD PASS — strings redirect decision + game-Data derivation locked."
+            : $"GUARD FAIL — {fails} assertion(s) wrong.");
+        return fails == 0 ? 0 : 1;
+    }
+
+    static string MkFolder(string root, string name, string esp)
+    {
+        var dir = Path.Combine(root, name);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, esp), "x");   // dummy — the decision helpers never OPEN it (path ops only)
+        return dir;
+    }
+
+    static bool SamePath(string? a, string b) => a is not null && string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
+
+    static int Check(string label, bool ok)
+    {
+        Console.WriteLine($"   [{(ok ? "PASS" : "FAIL")}] {label}");
+        return ok ? 0 : 1;
+    }
+}

--- a/src/housecarl-generator/StringsResolveProbe.cs
+++ b/src/housecarl-generator/StringsResolveProbe.cs
@@ -115,9 +115,39 @@ public static class StringsResolveProbe
         else
             Console.WriteLine($"   (skip NO-REGRESSION: {skyrim} not present)");
 
+        // Q3 arm: a genuinely-unresolved localized string (bare overlay, no strings source) must surface LOUD —
+        // a no-value note + the predicate's "no readable value" accounting — NEVER a silent blank-token non-match.
+        ok &= Q3Check(plugin, edidSub);
+
         Console.WriteLine();
-        Console.WriteLine(ok ? "PROBE PASS — product path resolves localized names + predicate matches." : "PROBE FAIL — see above.");
+        Console.WriteLine(ok ? "PROBE PASS — resolves localized names, predicate matches, unresolved fails loud." : "PROBE FAIL — see above.");
         return ok ? 0 : 1;
+    }
+
+    /// <summary>With NO strings source (the bare overlay), the cleaned DLC master's Name is an UNRESOLVED localized
+    /// string. ReadEngine must surface it as a no-value note (<see cref="ReadEngine.UnresolvedStringNote"/>), the
+    /// predicate must NOT match it, and the predicate's Q3 accounting must FIRE — never a silent "0 matches".</summary>
+    static bool Q3Check(string plugin, string edidSub)
+    {
+        Console.WriteLine();
+        Console.WriteLine("== Q3: unresolved localized string surfaces LOUD (bare overlay, no strings) ==");
+        var ov = SkyrimMod.CreateFromBinaryOverlay(plugin, SkyrimRelease.SkyrimSE);   // deliberately strings-less
+        var (set, perr) = HousecarlCore.FieldPredicateSet.Parse(new[] { $"Name contains {edidSub}" });
+        if (perr is not null) { Console.WriteLine($"   predicate parse error: {perr}"); return false; }
+        foreach (var rec in ov.EnumerateMajorRecords(typeof(IArmorGetter), throwIfUnknown: true))
+        {
+            if (rec.EditorID is null || rec.EditorID.IndexOf(edidSub, StringComparison.OrdinalIgnoreCase) < 0) continue;
+            var fv = HousecarlCore.ReadEngine.ReadFields(rec, new[] { "Name" }).Fields[0];
+            bool loud = !fv.HasValue && fv.Note == HousecarlCore.ReadEngine.UnresolvedStringNote;
+            bool noMatch = !set!.Matches(rec);
+            var note = set.AccountingNote();
+            bool pass = loud && noMatch && note is not null;
+            Console.WriteLine($"   {rec.FormKey} Name.HasValue={fv.HasValue} Note='{fv.Note}' predicateMatch={!noMatch} accounting={(note is null ? "<SILENT>" : "FIRED")} => {(pass ? "PASS" : "FAIL")}");
+            if (note is not null) Console.WriteLine($"      accounting: {Trunc(note)}");
+            return pass;
+        }
+        Console.WriteLine("   (no matching armor) => FAIL");
+        return false;
     }
 
     /// <summary>Open <paramref name="plugin"/> through the REAL product helper, read the first edid~<paramref

--- a/src/housecarl-generator/StringsResolveProbe.cs
+++ b/src/housecarl-generator/StringsResolveProbe.cs
@@ -1,0 +1,176 @@
+using System.Reflection;
+using HousecarlCore;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Binary.Parameters;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using Mutagen.Bethesda.Strings;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// Probe for the localized-strings read fix (Heisen 2026-06-24): a localized DLC master resolved to an MO2
+/// mod folder with no adjacent Strings/BSA (the "Cleaned Base Game Masters" pattern) reads its FULL/Name EMPTY
+/// through the bare <c>CreateFromBinaryOverlay(path, release)</c> overlay — Mutagen's per-plugin strings lookup
+/// only scans the plugin's own folder, so cross-plugin strings (dragonborn strings live in Skyrim - Interface.bsa
+/// beside Skyrim.esm) are never found.
+///
+/// v1 = API DISCOVERY + baseline repro:
+///   - dump BinaryReadParameters public properties (find the strings knob)
+///   - dump the strings-param type's properties (one level deeper)
+///   - dump CreateFromBinaryOverlay overload signatures
+///   - baseline: open the cleaned plugin with the BARE overload, read the first matching armor's Name (expect empty)
+///
+/// Run: dotnet run --project src/housecarl-generator strings-resolve-probe &lt;cleaned-plugin.esm&gt; &lt;stockgame-data-dir&gt; [nameSubstr]
+/// </summary>
+public static class StringsResolveProbe
+{
+    public static int Run(string[] args)
+    {
+        if (args.Length < 2)
+        {
+            Console.Error.WriteLine("usage: strings-resolve-probe <cleaned-plugin.esm> <stockgame-data-dir> [editoridSubstr]");
+            return 1;
+        }
+        var plugin = args[0];
+        var dataDir = args[1];
+        var edidSub = args.Length > 2 ? args[2] : "Bonemold";
+        if (!File.Exists(plugin)) { Console.Error.WriteLine($"not found: {plugin}"); return 1; }
+        if (!Directory.Exists(dataDir)) { Console.Error.WriteLine($"not a dir: {dataDir}"); return 1; }
+        Console.WriteLine($"plugin:   {plugin}");
+        Console.WriteLine($"data dir: {dataDir}");
+        Console.WriteLine($"edid ~:   {edidSub}");
+
+        // ---- API 1: BinaryReadParameters surface ----
+        Console.WriteLine();
+        Console.WriteLine("== API 1: BinaryReadParameters public instance properties ==");
+        var brp = typeof(BinaryReadParameters);
+        foreach (var p in brp.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            Console.WriteLine($"   {p.PropertyType.FullName} {p.Name}");
+
+        // ---- API 2: the strings-ish property types, one level deeper ----
+        Console.WriteLine();
+        Console.WriteLine("== API 2: strings-ish param type members ==");
+        foreach (var p in brp.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            var pt = p.PropertyType;
+            var u = Nullable.GetUnderlyingType(pt) ?? pt;
+            if (!u.Name.Contains("String") && !u.Name.Contains("Strings")) continue;
+            Console.WriteLine($"   -- {u.FullName} (via {p.Name}) --");
+            foreach (var sp in u.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+                Console.WriteLine($"        {sp.PropertyType.FullName} {sp.Name}");
+            foreach (var ci in u.GetConstructors(BindingFlags.Public | BindingFlags.Instance))
+                Console.WriteLine($"        .ctor(" + string.Join(", ", ci.GetParameters().Select(x => $"{x.ParameterType.Name} {x.Name}")) + ")");
+            foreach (var sm in u.GetMethods(BindingFlags.Public | BindingFlags.Static))
+                if (sm.Name.Contains("Factory") || sm.Name.Contains("From") || sm.Name == "Create")
+                    Console.WriteLine($"        static {sm.ReturnType.Name} {sm.Name}(" + string.Join(", ", sm.GetParameters().Select(x => $"{x.ParameterType.Name} {x.Name}")) + ")");
+        }
+
+        // ---- API 3: CreateFromBinaryOverlay overloads ----
+        Console.WriteLine();
+        Console.WriteLine("== API 3: SkyrimMod.CreateFromBinaryOverlay overloads ==");
+        foreach (var m in typeof(SkyrimMod).GetMethods(BindingFlags.Public | BindingFlags.Static).Where(m => m.Name == "CreateFromBinaryOverlay"))
+            Console.WriteLine("   (" + string.Join(", ", m.GetParameters().Select(x => $"{x.ParameterType.Name} {x.Name}" + (x.HasDefaultValue ? " = …" : ""))) + ")");
+
+        // ---- API 4: any StringsReadParameters / StringsFolderLookup* types in the loaded Mutagen assemblies ----
+        Console.WriteLine();
+        Console.WriteLine("== API 4: Strings* types in Mutagen assemblies ==");
+        foreach (var asm in AppDomain.CurrentDomain.GetAssemblies().Where(a => (a.GetName().Name ?? "").StartsWith("Mutagen")))
+        {
+            Type[] types; try { types = asm.GetTypes(); } catch { continue; }
+            foreach (var t in types.Where(t => t.IsPublic && (t.Name.StartsWith("StringsReadParameters") || t.Name.StartsWith("StringsFolderLookup") || t.Name == "StringsSource" || t.Name == "StringsLanguageFormat")))
+            {
+                Console.WriteLine($"   {t.FullName}");
+                foreach (var sm in t.GetMethods(BindingFlags.Public | BindingFlags.Static).Where(x => !x.IsSpecialName))
+                    Console.WriteLine($"        static {sm.ReturnType.Name} {sm.Name}(" + string.Join(", ", sm.GetParameters().Select(x => $"{x.ParameterType.Name} {x.Name}")) + ")");
+                foreach (var ci in t.GetConstructors())
+                    Console.WriteLine($"        .ctor(" + string.Join(", ", ci.GetParameters().Select(x => $"{x.ParameterType.Name} {x.Name}")) + ")");
+            }
+        }
+
+        // ---- CANDIDATES: open with various StringsParam, read first matching armor names ----
+        var strings = Path.Combine(dataDir, "Strings");
+        Test("BASELINE bare overload", () => SkyrimMod.CreateFromBinaryOverlay(plugin, SkyrimRelease.SkyrimSE), plugin, edidSub);
+        Test("FIX-A BsaFolderOverride=dataDir", () => SkyrimMod.CreateFromBinaryOverlay(plugin, SkyrimRelease.SkyrimSE,
+            BinaryReadParameters.Default with { StringsParam = new StringsReadParameters { BsaFolderOverride = dataDir } }), plugin, edidSub);
+        Test("FIX-B Bsa+Strings override, lang=English", () => SkyrimMod.CreateFromBinaryOverlay(plugin, SkyrimRelease.SkyrimSE,
+            BinaryReadParameters.Default with { StringsParam = new StringsReadParameters {
+                BsaFolderOverride = dataDir, StringsFolderOverride = strings, TargetLanguage = Language.English } }), plugin, edidSub);
+
+        // ---- PRODUCT: drive the REAL fix (LoadOrderResolver.OpenOverlay) + the REAL read (ReadEngine) + Heisen's
+        //      EXACT predicate (FieldPredicateSet "Name contains <stem>"). This is the guard the bug demands. ----
+        Console.WriteLine();
+        Console.WriteLine("== PRODUCT: OpenOverlay + ReadEngine + FieldPredicate ==");
+        bool ok = true;
+
+        // FIX arm: the cleaned DLC master (no own strings) MUST now resolve Name + match the predicate.
+        ok &= ProductCheck("cleaned DLC master (FIX)", plugin, dataDir, edidSub, mustResolve: true);
+
+        // NO-REGRESSION arm: a folder-adjacent localized master (Skyrim.esm beside its BSA) must STILL resolve —
+        // OpenOverlay's gate keeps the unchanged default open for it (its folder has a .bsa).
+        var skyrim = Path.Combine(dataDir, "Skyrim.esm");
+        if (File.Exists(skyrim))
+            ok &= ProductCheck("folder-adjacent master (NO-REGRESSION)", skyrim, dataDir, "Hide", mustResolve: true);
+        else
+            Console.WriteLine($"   (skip NO-REGRESSION: {skyrim} not present)");
+
+        Console.WriteLine();
+        Console.WriteLine(ok ? "PROBE PASS — product path resolves localized names + predicate matches." : "PROBE FAIL — see above.");
+        return ok ? 0 : 1;
+    }
+
+    /// <summary>Open <paramref name="plugin"/> through the REAL product helper, read the first edid~<paramref
+    /// name="edidSub"/> armor's Name via ReadEngine, and run Heisen's exact "Name contains &lt;edidSub-stem&gt;"
+    /// predicate. When <paramref name="mustResolve"/>, a non-empty token AND a predicate match are required.</summary>
+    static bool ProductCheck(string label, string plugin, string dataDir, string edidSub, bool mustResolve)
+    {
+        var ov = HousecarlCore.LoadOrderResolver.OpenOverlay(plugin, dataDir);
+        var (set, perr) = HousecarlCore.FieldPredicateSet.Parse(new[] { $"Name contains {edidSub}" });
+        if (perr is not null) { Console.WriteLine($"   {label}: predicate parse error: {perr}"); return false; }
+        foreach (var rec in ov.EnumerateMajorRecords(typeof(IArmorGetter), throwIfUnknown: true))
+        {
+            if (rec.EditorID is null || rec.EditorID.IndexOf(edidSub, StringComparison.OrdinalIgnoreCase) < 0) continue;
+            var rf = HousecarlCore.ReadEngine.ReadFields(rec, new[] { "Name" });
+            var fv = rf.Fields.Count > 0 ? rf.Fields[0] : null;
+            var token = fv is { HasValue: true } ? fv.Token : null;
+            bool matched = set!.Matches(rec);
+            bool resolved = !string.IsNullOrEmpty(token);
+            bool pass = !mustResolve || (resolved && matched);
+            Console.WriteLine($"   {label}: {rec.FormKey} edid={rec.EditorID} ReadEngine Name={(token is null ? "<none>" : $"'{token}'")} predicateMatch={matched} => {(pass ? "PASS" : "FAIL")}");
+            return pass;
+        }
+        Console.WriteLine($"   {label}: (no armor matched edid~'{edidSub}') => {(mustResolve ? "FAIL" : "PASS")}");
+        return !mustResolve;
+    }
+
+    static void Test(string label, Func<ISkyrimModGetter> open, string plugin, string edidSub)
+    {
+        Console.WriteLine();
+        Console.WriteLine($"== {label} ==");
+        ISkyrimModGetter ov;
+        try { ov = open(); }
+        catch (Exception ex) { Console.WriteLine($"   open THREW: {ex.GetType().Name}: {Trunc(ex.Message)}"); return; }
+        int shown = 0;
+        var en = ov.EnumerateMajorRecords(typeof(IArmorGetter), throwIfUnknown: true).GetEnumerator();
+        while (shown < 3)
+        {
+            IMajorRecordGetter armo;
+            try { if (!en.MoveNext()) break; armo = en.Current; }
+            catch (Exception ex) { Console.WriteLine($"   enum THREW: {ex.GetType().Name}: {Trunc(ex.Message)}"); break; }
+            if (armo.EditorID is null || armo.EditorID.IndexOf(edidSub, StringComparison.OrdinalIgnoreCase) < 0) continue;
+            string? str;
+            try
+            {
+                var nameVal = armo.GetType().GetProperty("Name", BindingFlags.Public | BindingFlags.Instance)?.GetValue(armo);
+                str = nameVal?.GetType().GetProperty("String", BindingFlags.Public | BindingFlags.Instance)?.GetValue(nameVal) as string;
+            }
+            catch (Exception ex) { str = $"<read threw: {ex.GetType().Name}>"; }
+            Console.WriteLine($"   {armo.FormKey}  edid={armo.EditorID}  Name.String={(str is null ? "<null>" : $"'{str}'")}");
+            shown++;
+        }
+        if (shown == 0) Console.WriteLine($"   (no armor matched edid~'{edidSub}')");
+    }
+
+    static string Trunc(string s) => s.Length > 140 ? s.Substring(0, 140) + "…" : s;
+}


### PR DESCRIPTION
Fixes Heisen's HCBR 2026-06-24: `cross_plugin_query where=["Name contains …"]` (and any plugin-scoped read of a localized field) silently returns 0 / a blank for records defined in the DLC masters, while `editorid_contains` and Skyrim.esm work.

## Root cause (confirmed on the live ARR 2.0 order)
houseCARL opened every plugin with the bare `CreateFromBinaryOverlay(path, release)`, whose strings lookup only scans the plugin's **own** folder. MO2 resolves the DLC/Update masters to the **Cleaned Base Game Masters** mod folder — `.esm` files only, **no `Strings\`, no `.bsa`** — so their localized `FULL`/`Name` read **empty**, even though the `.STRINGS` exist in `Skyrim - Interface.bsa` beside `Skyrim.esm`. The predicate then treated the blank as a real non-matching value → silent `0 matches` (a Q3 wrong-answer). Skyrim.esm worked only because it resolves next to that BSA.

## Fix
- **`OpenOverlay` (single choke point).** Every load-order overlay open routes through it. When the plugin's own folder carries no strings source, it points Mutagen's strings lookup at the real game-Data folder (derived as `Skyrim.esm`'s dir). Folder-adjacent plugins (loose strings **or** their own BSA) keep the unchanged default open — no redirect, no regression. Non-localized plugins never consult it.
- **Q3 hardening.** A *genuinely* unresolved localized string now surfaces as `(unresolved localized string)` (a no-value note), so a predicate's accounting fires instead of a silent `0 matches`; `FieldsDiff` treats it as a no-value sentinel.

## Verification
- `strings-resolve-probe` drives the **real** product path (`OpenOverlay` → `ReadEngine` → `FieldPredicateSet`) on the live order: cleaned `Dragonborn.esm` now reads `Name='Bonemold Boots'` and `Name contains Bonemold` **matches**; folder-adjacent `Skyrim.esm` still resolves; the bare-overlay (unresolved) case fails **loud**.
- All 55 self-contained CI guards green in Release.

## Note
The end-to-end probe is **manual** (needs the real DLC `.esm` + `Skyrim - Interface.bsa`), so it isn't wired into CI. A self-contained guard for the redirect decision — or a committed-fixture guard mirroring `fixtures/asset-resolver/` — can follow if we want CI coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)