### PR TITLE
feat: biped-slot filtering via new has predicate + biped-slot-reference skill (HCBR 2026-06-24)

### DIFF
--- a/.claude/skills/biped-slot-reference/SKILL.md
+++ b/.claude/skills/biped-slot-reference/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: biped-slot-reference
+description: Find armor, clothing, or any equippable record that sits on a given Skyrim biped slot via houseCARL — translate a slot number, vanilla name, or community label into its `BodyTemplate.FirstPersonFlags` bit value and filter the load order with `housecarl_cross_plugin_query` `where ... has`, matching multi-slot pieces an exact-match misses. Use when the user wants to find or list every armor on a biped slot, tag or patch items by equip slot (slot 52 / SOS / pelvis, back or cape slots, a mask or fur-clip slot), audit biped-slot conflicts between mods, find what occupies slot 32 / 52 / a modder slot, or asks which slot a piece uses or what slot number maps to which FirstPersonFlags value. This finds and filters records BY slot — distributing keywords to those items is `kid-authoring`, editing a record's own fields is `skypatcher-authoring`. Load this before composing any "armor on slot X" query — the slot↔bit mapping is non-obvious (slot N = bit N−30; named vanilla slots render as text while modder slots render as raw numbers), so a hand-guessed mask silently filters the wrong slot.
+---
+
+# Biped Slot Reference
+
+## Overview
+
+Skyrim armor and clothing occupy **biped slots** numbered 30–61, stored as a bitmask in a record's
+`BodyTemplate.FirstPersonFlags`. This skill turns a slot — given as a number (52), a vanilla name (Body),
+or a community label (SOS, pelvis, a back/cape slot) — into the right `housecarl_cross_plugin_query`
+filter, so "find every armor on slot X" is one query instead of a guess. It is a reference-lookup skill
+with a short query procedure on top (the same look-it-up-never-guess discipline as `mutagen-reference`).
+The full slot↔bit↔value mapping lives in `references/biped-slots.md`.
+
+The mapping is easy to get wrong by hand, which is why this skill exists: slot N is bit (N − 30) with
+value 2^(N − 30), and the field renders inconsistently (named slots as text, modder slots as raw numbers).
+A hand-guessed mask silently filters the wrong slot and looks like a clean answer.
+
+## First step — open the slot table
+
+Read `references/biped-slots.md` for the verified slot 30–61 table (number, bit, the value to pass, hex,
+Mutagen name, note) plus the naming gotcha and community conventions. Pull the value for the slot your
+task names — don't compute 2^(N−30) in your head.
+
+## The query — `has`, not `=`
+
+Use the `where ... has` predicate (a bitwise set-test) so a multi-slot item still matches the one slot you
+asked for:
+
+```
+housecarl_cross_plugin_query(
+    type="Armor",
+    where=["BodyTemplate.FirstPersonFlags has 4194304"])   # slot 52
+```
+
+`has <value>` is true when that bit is set **regardless of other slots** — so a body+slot-52 piece
+matches. Reach for it whenever an item might occupy more than one slot (most armor does).
+
+- **Modder slots (44–49, 52–60):** pass the **number** from the table — `has 4194304` or `has 0x400000`.
+- **Named slots (30–43, 50, 51, 61):** the flag name works too — `has Body`, `has Feet`,
+  `has DecapitateHead`.
+- **Exact, single-slot only:** `= 4194304` matches a record on slot 52 *and nothing else* — use it only
+  when you specifically want single-slot pieces. It silently skips every combo, which is the trap that
+  makes a slot look empty when it isn't.
+
+`has` also works on a plain integer field, and a numeric range now works on the flags field too
+(`FirstPersonFlags >= 65536` no longer errors) — but for "is this slot occupied", `has` is the tool.
+
+## Why a query can mislead — the rendering split
+
+`FirstPersonFlags` is a `[Flags]` enum: it shows slot **names** when every set bit is named, but a raw
+**decimal** the moment any set bit is a modder slot. Two consequences worth holding:
+
+- `= 16` once 0-matched the slot-34 item that renders "Forearms" — flags `=` now compares by bit, so
+  `= 16` and `= Forearms` both find it. Prefer `has` regardless, so combos aren't excluded.
+- Two **named** slots hide in the modder range: 50 `DecapitateHead` and 51 `Decapitate`. An item there
+  renders as that name, not a number — don't assume everything 44–60 is numeric.
+
+## Be sure, don't assume (Q3)
+
+Community slot conventions (SOS = 52, a back slot ≈ 46–48, …) are **hints, not guarantees** — modder slots
+carry no engine-enforced meaning, so a mod can use any free slot. When it matters which slot an item really
+uses, read its `BodyTemplate.FirstPersonFlags` (houseCARL returns it) or query the bit with `has` and
+inspect the hits. The bit is ground truth; the convention is a guess. If you can't confirm a slot, say so
+rather than asserting from the convention.
+
+## Scope — finding records BY slot
+
+This skill **locates and filters** records by their biped slot. It does not distribute or edit:
+
+- distribute a **keyword** to the items you found → `kid-authoring`.
+- distribute a spell / perk / item to **NPCs** → `spid-authoring`.
+- change a record's **own fields** (including its FirstPersonFlags) → `skypatcher-authoring`, or a
+  houseCARL write into a new plugin.

--- a/.claude/skills/biped-slot-reference/evals/eval_set.json
+++ b/.claude/skills/biped-slot-reference/evals/eval_set.json
@@ -1,0 +1,23 @@
+[
+  {"query": "i need to find every armor in my load order thats on biped slot 52 so i can sort out the SOS pelvis stuff", "should_trigger": true},
+  {"query": "what biped slot is FirstPersonFlags value 8388608, and how do i query for it", "should_trigger": true},
+  {"query": "find every record on slot 32 in the whole load order", "should_trigger": true},
+  {"query": "before i tag the pelvis-slot gear with a keyword i need to figure out which armors are actually sitting on slot 52", "should_trigger": true},
+  {"query": "does this circlet use slot 42 or one of the modder slots? how do i check what biped slot a piece occupies", "should_trigger": true},
+  {"query": "whats the bit value i pass to filter for armor on slot 49", "should_trigger": true},
+  {"query": "show me everything in my load order thats sitting on the SOS slot", "should_trigger": true},
+  {"query": "is this helmet on slot 30 or slot 31, how can i tell", "should_trigger": true},
+  {"query": "list all the armor records on biped slot 44 across my plugins", "should_trigger": true},
+  {"query": "i have FirstPersonFlags = 4194304 on a piece, which biped slot is that", "should_trigger": true},
+
+  {"query": "add the SOS pelvis keyword to all my body armors at runtime, no esp", "should_trigger": false},
+  {"query": "change the armor rating on every iron armor piece in the load order to 30", "should_trigger": false},
+  {"query": "distribute a cloak item to all bandits and forsworn", "should_trigger": false},
+  {"query": "my SOS schlong is invisible in game, the genital mesh just isnt showing up — whats wrong", "should_trigger": false},
+  {"query": "whats the difference between First Person Flags and Biped Object Flags in xEdit, conceptually", "should_trigger": false},
+  {"query": "patch this new armor set for Requiem — set its armor rating, material keywords and a tempering recipe", "should_trigger": false},
+  {"query": "the player has a neck seam and a gap at the wrists after installing this body mod, how do i fix the discoloration", "should_trigger": false},
+  {"query": "convert this cuirass from slot 32 to slot 52 so it stops clipping with my body — edit the FirstPersonFlags on the record", "should_trigger": false},
+  {"query": "find all the iron weapons in my load order so i can rebalance their damage", "should_trigger": false},
+  {"query": "how many armor addon (ARMA) records does Immersive Armors actually contain", "should_trigger": false}
+]

--- a/.claude/skills/biped-slot-reference/references/biped-slots.md
+++ b/.claude/skills/biped-slot-reference/references/biped-slots.md
@@ -1,0 +1,86 @@
+# Skyrim biped slots — number ↔ bit ↔ FirstPersonFlags value
+
+Skyrim armor/clothing "biped slots" are numbered **30–61**. The slots a record occupies live in
+`BodyTemplate.FirstPersonFlags` (xEdit: "First Person Flags") — a 32-bit mask where **each bit is one
+slot**. houseCARL reads that field, and the `housecarl_cross_plugin_query` `where ... has` predicate
+bit-tests it.
+
+## The mapping (exact)
+
+- **Slot N occupies bit (N − 30).**
+- **Its value is 2^(N − 30)** — the decimal number you pass to `has`.
+- Example: slot 52 → bit 22 → `2^22` = **4194304** (`0x400000`).
+
+Don't compute the power of two in your head — read it off the table. A wrong exponent queries the wrong
+slot and looks like a clean result.
+
+## Slot table (verified against Mutagen's `BipedObjectFlag`)
+
+| Slot | Bit | Value (pass to `has`) | Hex | Mutagen name | Note |
+|------|-----|------|-----|------|------|
+| 30 | 0 | 1 | 0x1 | Head | vanilla — head/face |
+| 31 | 1 | 2 | 0x2 | Hair | vanilla — hair |
+| 32 | 2 | 4 | 0x4 | Body | vanilla — body / main torso armor |
+| 33 | 3 | 8 | 0x8 | Hands | vanilla — hands |
+| 34 | 4 | 16 | 0x10 | Forearms | vanilla — forearms / gauntlets |
+| 35 | 5 | 32 | 0x20 | Amulet | vanilla — amulet |
+| 36 | 6 | 64 | 0x40 | Ring | vanilla — ring |
+| 37 | 7 | 128 | 0x80 | Feet | vanilla — feet / boots |
+| 38 | 8 | 256 | 0x100 | Calves | vanilla — calves |
+| 39 | 9 | 512 | 0x200 | Shield | vanilla — shield |
+| 40 | 10 | 1024 | 0x400 | Tail | vanilla — tail |
+| 41 | 11 | 2048 | 0x800 | LongHair | vanilla — long hair |
+| 42 | 12 | 4096 | 0x1000 | Circlet | vanilla — circlet |
+| 43 | 13 | 8192 | 0x2000 | Ears | vanilla — ears |
+| 44 | 14 | 16384 | 0x4000 | — | modder |
+| 45 | 15 | 32768 | 0x8000 | — | modder |
+| 46 | 16 | 65536 | 0x10000 | — | modder |
+| 47 | 17 | 131072 | 0x20000 | — | modder |
+| 48 | 18 | 262144 | 0x40000 | — | modder |
+| 49 | 19 | 524288 | 0x80000 | — | modder |
+| 50 | 20 | 1048576 | 0x100000 | DecapitateHead | vanilla — decapitation (head) |
+| 51 | 21 | 2097152 | 0x200000 | Decapitate | vanilla — decapitation (body) |
+| 52 | 22 | 4194304 | 0x400000 | — | modder — **SOS** pelvis / the de-facto "pelvis" slot |
+| 53 | 23 | 8388608 | 0x800000 | — | modder |
+| 54 | 24 | 16777216 | 0x1000000 | — | modder |
+| 55 | 25 | 33554432 | 0x2000000 | — | modder |
+| 56 | 26 | 67108864 | 0x4000000 | — | modder |
+| 57 | 27 | 134217728 | 0x8000000 | — | modder |
+| 58 | 28 | 268435456 | 0x10000000 | — | modder |
+| 59 | 29 | 536870912 | 0x20000000 | — | modder |
+| 60 | 30 | 1073741824 | 0x40000000 | — | modder |
+| 61 | 31 | 2147483648 | 0x80000000 | FX01 | vanilla — special-effect slot |
+
+The **named** bits are not contiguous: 30–43 (bits 0–13), then 50/51 (`DecapitateHead`/`Decapitate`), then
+61 (`FX01`). Everything else (44–49, 52–60) is an unnamed modder slot. This non-contiguity is the trap —
+the names you'd guess sit at 44/45/46 actually live at 50/51/61.
+
+## Naming gotcha — why some slots filter by name and some by number
+
+`FirstPersonFlags` renders through .NET's `[Flags]` enum: when **every** set bit is a Mutagen-named slot
+it shows the **name(s)** ("Body", "Body, Hands"); the moment **any** set bit is unnamed it shows the whole
+value as a **raw decimal** ("8388608"). So in a `where`:
+
+- **Named slots** (30–43, 50, 51, 61) — `has Body`, `has Feet`, `has DecapitateHead` work by name, and
+  `= Body` works too.
+- **Modder slots** (44–49, 52–60) — no name exists; use the **number** from the table: `has 4194304`
+  (or `has 0x400000`).
+- A combo of named slots renders "Body, Hands" — `has Body` still finds it. A combo that includes any
+  modder slot renders as one number — `has <bit>` is the only reliable way to find it.
+- Watch the two **named** slots inside the modder range: an item on 50/51 renders `DecapitateHead` /
+  `Decapitate`, not a number — don't assume everything 44–60 is numeric.
+
+## Community slot conventions (vary by mod — verify, don't assume)
+
+Modder slots carry **no engine-enforced meaning** — a mod may use any free slot however it likes. A couple
+of conventions are widespread enough to name, but treat them as hints:
+
+- **52 = SOS / pelvis** — Schlongs of Skyrim and most pelvis-aware bodies/armors. The strongest convention.
+- **A "back" slot** (capes, cloaks, backpacks, wings, quivers) — commonly somewhere in **46–48**, but
+  mod-specific; don't assume one number.
+- **44–49, 53–60** — general modder slots (masks, shoulders, scarves, leg add-ons, fur clips, …); usage
+  is whatever the mod chose.
+
+To know for **certain** which slot an item uses, don't rely on the convention — read the record's
+`BodyTemplate.FirstPersonFlags` (houseCARL returns it), or query the bit with `has` and inspect the hits.
+The bit is ground truth; the convention is a guess.

--- a/scripts/build-plugin.ps1
+++ b/scripts/build-plugin.ps1
@@ -47,8 +47,8 @@ $PackagingSrc = Join-Path $RepoRoot 'packaging'        # tracked source for pack
 $ReleaseDir   = Join-Path $RepoRoot 'release'          # output dir for the shippable zip (gitignored)
 $PluginManifest = Join-Path $PluginSrc '.claude-plugin\plugin.json'   # single source of truth for the version
 
-# the 10 shipped skills (the modlist-authoring cluster was removed; tool-surface skills wait)
-$Skills = @('mutagen-reference','papyrus-reference','skypatcher-authoring','spid-authoring','kid-authoring','papyrus-optimization','facegen-diagnostics','dialogue-authoring','oar-authoring','tool-output-awareness')
+# the 11 shipped skills (the modlist-authoring cluster was removed; tool-surface skills wait)
+$Skills = @('mutagen-reference','papyrus-reference','skypatcher-authoring','spid-authoring','kid-authoring','papyrus-optimization','facegen-diagnostics','dialogue-authoring','oar-authoring','tool-output-awareness','biped-slot-reference')
 
 function Step($n,$msg) { Write-Host "`n=== [$n] $msg ===" -ForegroundColor Cyan }
 

--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -35,10 +35,14 @@ namespace HousecarlCore;
 /// </summary>
 public sealed class FieldPredicateSet
 {
-    /// <summary>The seven v1 operators. <see cref="Gt"/>/<see cref="Ge"/>/<see cref="Lt"/>/<see cref="Le"/> are
+    /// <summary>The eight v1 operators. <see cref="Gt"/>/<see cref="Ge"/>/<see cref="Lt"/>/<see cref="Le"/> are
     /// numeric-only; <see cref="Contains"/> is a case-insensitive substring; <see cref="Eq"/>/<see cref="Ne"/>
-    /// compare across the whole token vocabulary (FormKey-canonical, else numeric, else case-insensitive string).</summary>
-    enum Op { Eq, Ne, Gt, Ge, Lt, Le, Contains }
+    /// compare across the whole token vocabulary (FormKey-canonical, else numeric, else case-insensitive string).
+    /// <see cref="Has"/> is a BITWISE set-test for a <c>[Flags]</c> enum (or plain integer) leaf — true iff every
+    /// bit of the operand is set on the field, regardless of other bits — so a multi-slot BodyTemplate still
+    /// matches the one slot asked for, which <see cref="Eq"/> (exact value) and the range ops cannot express. Its
+    /// operand is a bit value (decimal or <c>0x</c> hex) or a flag NAME.</summary>
+    enum Op { Eq, Ne, Gt, Ge, Lt, Le, Contains, Has }
 
     /// <summary>One parsed predicate: the split path segments (fed straight to <see cref="ReadEngine.ReadLeaf"/>),
     /// the operator, the raw operand, and — for a numeric operator — the operand pre-parsed to a double (validated
@@ -104,7 +108,7 @@ public sealed class FieldPredicateSet
         // 2. skip whitespace to the operator.
         while (i < text.Length && char.IsWhiteSpace(text[i])) i++;
         if (i >= text.Length)
-            return (null, $"predicate '{raw}': no operator. Use one of = != > >= < <= contains, e.g. \"{path} = <value>\".");
+            return (null, $"predicate '{raw}': no operator. Use one of = != > >= < <= contains has, e.g. \"{path} = <value>\".");
 
         // 3. operator — symbolic (longest match) or the 'contains' word.
         Op op;
@@ -117,16 +121,17 @@ public sealed class FieldPredicateSet
             else if (text[i] == '=') { op = Op.Eq; after = i + 1; }
             else if (text[i] == '>') { op = Op.Gt; after = i + 1; }
             else if (text[i] == '<') { op = Op.Lt; after = i + 1; }
-            else return (null, $"predicate '{raw}': unrecognized operator at '{text.Substring(i)}'. Use = != > >= < <= contains.");
+            else return (null, $"predicate '{raw}': unrecognized operator at '{text.Substring(i)}'. Use = != > >= < <= contains has.");
         }
         else
         {
             int w = i;
             while (w < text.Length && !char.IsWhiteSpace(text[w])) w++;
             var word = text.Substring(i, w - i);
-            if (!word.Equals("contains", StringComparison.OrdinalIgnoreCase))
-                return (null, $"predicate '{raw}': unrecognized operator '{word}'. Use = != > >= < <= or contains.");
-            op = Op.Contains;
+            if (word.Equals("contains", StringComparison.OrdinalIgnoreCase)) op = Op.Contains;
+            else if (word.Equals("has", StringComparison.OrdinalIgnoreCase)) op = Op.Has;
+            else
+                return (null, $"predicate '{raw}': unrecognized operator '{word}'. Use = != > >= < <= contains or has.");
             after = w;
         }
 
@@ -173,19 +178,29 @@ public sealed class FieldPredicateSet
             var leaf = ReadEngine.ReadLeaf(body, p.PathSegments);   // internal, same assembly — the by-construction read walk
             if (!leaf.HasValue) { _noValue[k]++; all = false; continue; }
             _valueRead[k]++;
-            var (satisfied, err) = Compare(p, leaf.Token);
+            var (satisfied, err) = Compare(p, leaf);
             if (err is not null) { _fatal ??= err; return false; }
             if (!satisfied) all = false;
         }
         return all;
     }
 
-    static (bool satisfied, string? error) Compare(Predicate p, string token)
+    static (bool satisfied, string? error) Compare(Predicate p, ReadEngine.LeafRead leaf)
     {
+        var token = leaf.Token;
+        var flags = leaf.Flags;   // non-null iff the leaf is a [Flags] enum — carries (bit pattern, enum type)
         switch (p.Op)
         {
+            case Op.Has:
+                return CompareHas(p, token, flags);
+
             case Op.Gt or Op.Ge or Op.Lt or Op.Le:
-                if (!TryNum(token, out var tv))
+                // A [Flags] enum compares on its underlying numeric value — so `>= 65536` no longer ERRORS on a
+                // field that renders as "Body". Every other leaf compares on its numeric token, exactly as before
+                // (a non-numeric, non-flags field is still the fast typed FatalError — Q3).
+                double tv;
+                if (flags is { } fnum) tv = fnum.Bits;
+                else if (!TryNum(token, out tv))
                     return (false, $"predicate '{p.Text}': operator '{OpStr(p.Op)}' needs a numeric field, but '{p.PathDisplay}' read '{Trunc(token)}', not a number.");
                 double ov = p.NumericOperand;
                 bool num = p.Op switch { Op.Gt => tv > ov, Op.Ge => tv >= ov, Op.Lt => tv < ov, Op.Le => tv <= ov, _ => false };
@@ -195,9 +210,59 @@ public sealed class FieldPredicateSet
                 return (token.Contains(p.Operand, StringComparison.OrdinalIgnoreCase), null);
 
             default: // Eq / Ne
-                bool eq = ValueEquals(token, p.Operand);
+                // On a [Flags] enum, equate by RESOLVED bit pattern so a numeric operand matches a name-rendered
+                // field (`= 16` matches "Forearms"), a name matches a number-rendered one, and order/spacing of a
+                // comma-combo stops mattering. Every other leaf keeps the token-vocabulary equality unchanged.
+                bool eq;
+                if (flags is { } feq && TryResolveBits(p.Operand, feq.EnumType, out var opBits))
+                    eq = feq.Bits == opBits;
+                else
+                    eq = ValueEquals(token, p.Operand);
                 return (p.Op == Op.Eq ? eq : !eq, null);
         }
+    }
+
+    /// <summary>The bitwise set-test (<c>has</c>): true iff EVERY bit of the operand is set on the field, other
+    /// bits free — so a multi-slot BodyTemplate still matches the one slot asked for, the case <c>=</c> (exact
+    /// value) and the range ops miss. On a [Flags] enum the operand is a bit value (decimal or <c>0x</c> hex) or a
+    /// flag NAME; on a plain integer leaf it must be a bit value. A non-bitmask field, an unresolvable operand, or
+    /// a zero mask is a typed error — never a silent non-match (Q3).</summary>
+    static (bool satisfied, string? error) CompareHas(Predicate p, string token, ReadEngine.FlagBits? flags)
+    {
+        ulong leafBits, opBits;
+        if (flags is { } fi)
+        {
+            leafBits = fi.Bits;
+            if (!TryResolveBits(p.Operand, fi.EnumType, out opBits))
+                return (false, $"predicate '{p.Text}': 'has' value '{p.Operand}' is not a bit value or a valid {fi.EnumType.Name} flag name.");
+        }
+        else if (TryBits(token, out leafBits))   // a plain integer leaf — bit-test its numeric value
+        {
+            if (!TryBits(p.Operand, out opBits))
+                return (false, $"predicate '{p.Text}': 'has' value '{p.Operand}' must be a bit value (decimal or 0x hex) for the integer field '{p.PathDisplay}'.");
+        }
+        else
+            return (false, $"predicate '{p.Text}': 'has' needs a flags/bitmask or integer field, but '{p.PathDisplay}' read '{Trunc(token)}', not a number.");
+
+        if (opBits == 0)
+            return (false, $"predicate '{p.Text}': 'has 0' tests no bits — give a non-zero bit value or a flag name.");
+        return ((leafBits & opBits) == opBits, null);
+    }
+
+    /// <summary>Resolve a <c>has</c>/<c>=</c> operand against a [Flags] enum to its bit pattern: a numeric literal
+    /// (decimal or <c>0x</c> hex) is the bits directly; otherwise it is parsed as a flag NAME (or comma-combo)
+    /// against that enum. False if it is neither — the caller turns that into a typed error.</summary>
+    static bool TryResolveBits(string operand, Type enumType, out ulong bits)
+        => TryBits(operand, out bits) || ReadEngine.TryEnumBitsFromName(enumType, operand, out bits);
+
+    /// <summary>Parse a bit value — decimal, or <c>0x</c>-prefixed hex (bitmasks read naturally in hex). Unsigned;
+    /// a sign or a non-integer is rejected (those fall through to the flag-name path).</summary>
+    static bool TryBits(string s, out ulong bits)
+    {
+        s = s.Trim();
+        if (s.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+            return ulong.TryParse(s.AsSpan(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out bits);
+        return ulong.TryParse(s, NumberStyles.None, CultureInfo.InvariantCulture, out bits);
     }
 
     /// <summary>Equality across the token vocabulary: FormKey-canonical if BOTH sides are FormKeys (so a link

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -47,13 +47,25 @@ public static class ReadEngine
     /// <summary>The outcome of reading one leaf. <see cref="HasValue"/> ⇒ <see cref="Token"/> is a
     /// round-trippable value (the inverse of Coerce). Otherwise <see cref="Note"/> explains why there
     /// is no value to round-trip (absent optional, no such field, a non-leaf container, or an
-    /// isolated read fault). The round-trip oracle drives ONLY <see cref="HasValue"/> reads.</summary>
-    internal readonly record struct LeafRead(bool HasValue, string Token, string? Note)
+    /// isolated read fault). The round-trip oracle drives ONLY <see cref="HasValue"/> reads.
+    ///
+    /// <para><see cref="Flags"/> is additive METADATA carried only for a <c>[Flags]</c> enum leaf: the underlying
+    /// bit pattern + enum type, so the query predicate (<c>where=</c>) can bit-test (<c>has</c>) and compare
+    /// numerically WITHOUT tripping over the name/number rendering split that <c>[Flags].ToString()</c> produces
+    /// (named bits → "Body"; an unnamed modder slot → "8388608"). The <see cref="Token"/> is unchanged — the
+    /// round-trip oracle still drives the same display token — so this is invisible to read/write/diff.</para></summary>
+    internal readonly record struct LeafRead(bool HasValue, string Token, string? Note, FlagBits? Flags = null)
     {
         public static LeafRead Value(string token) => new(true, token, null);
+        public static LeafRead FlagsValue(string token, FlagBits bits) => new(true, token, null, bits);
         public static LeafRead None(string note) => new(false, "", note);
         public override string ToString() => HasValue ? Token : Note ?? "(none)";
     }
+
+    /// <summary>The bit-test view of a <c>[Flags]</c> enum leaf — the unsigned bit pattern plus the enum
+    /// <see cref="Type"/> (so a predicate's operand given as a flag NAME, e.g. <c>has Body</c>, resolves against
+    /// the same enum). Populated by <see cref="EmitToken"/> for flags enums only; null for every other leaf.</summary>
+    internal readonly record struct FlagBits(ulong Bits, Type EnumType);
 
     /// <summary>A modeled leaf that exists but holds no value on this record (absent optional substruct,
     /// empty optional). Distinct from a real token; the oracle skips it — write-proof owns the absent
@@ -484,8 +496,17 @@ public static class ReadEngine
         // primitive (inverse of TryPrimitive)
         if (TryEmitPrimitive(val, out var prim)) return LeafRead.Value(prim);
         // enum (inverse of TryEnum) — ToString gives the name(s); Enum.Parse(ignoreCase) re-accepts,
-        // including the comma form for a [Flags] combination.
-        if (u.IsEnum || val.GetType().IsEnum) return LeafRead.Value(val.ToString() ?? "");
+        // including the comma form for a [Flags] combination. For a [Flags] enum we ALSO carry the underlying
+        // bit pattern + type (the display token is unchanged) so the query predicate can bit-test (`has`) and
+        // compare numerically without tripping over the name-vs-number rendering split (HCBR 2026-06-24).
+        if (u.IsEnum || val.GetType().IsEnum)
+        {
+            var token = val.ToString() ?? "";
+            var enumType = u.IsEnum ? u : val.GetType();
+            if (enumType.IsDefined(typeof(FlagsAttribute), false) && TryEnumBits(val, enumType, out var bits))
+                return LeafRead.FlagsValue(token, new FlagBits(bits, enumType));
+            return LeafRead.Value(token);
+        }
         // formlink (inverse of TryFormLink) — FormKey.ToString() ↔ FormKey.Factory. A present-but-null
         // link (FormKey.Null) is NOT a round-trippable token (the write surface sets links to a real
         // FormKey, never "Null"), so surface it as no-value — consistent with what Coerce accepts.
@@ -511,6 +532,43 @@ public static class ReadEngine
         return LeafRead.None(SummariseContainer(val,
             WriteEngine.ClosedInterface(val.GetType(), typeof(IDictionary<,>)) is not null
             || WriteEngine.ClosedInterface(val.GetType(), typeof(IReadOnlyDictionary<,>)) is not null));
+    }
+
+    /// <summary>The unsigned bit pattern of a boxed enum value, robust across every underlying integer type
+    /// (signed or unsigned) — the bits a <c>has</c> predicate ANDs against. Read through the declared underlying
+    /// type so a high-bit-set signed enum yields its two's-complement pattern rather than overflowing.</summary>
+    static bool TryEnumBits(object val, Type enumType, out ulong bits)
+    {
+        bits = 0;
+        try
+        {
+            var prim = Convert.ChangeType(val, Enum.GetUnderlyingType(enumType), CultureInfo.InvariantCulture);
+            bits = prim switch
+            {
+                ulong ul => ul,
+                long l => unchecked((ulong)l),
+                uint ui => ui,
+                int i => unchecked((ulong)(long)i),
+                ushort us => us,
+                short s => unchecked((ulong)(long)s),
+                byte b => b,
+                sbyte sb => unchecked((ulong)(long)sb),
+                _ => Convert.ToUInt64(prim, CultureInfo.InvariantCulture),
+            };
+            return true;
+        }
+        catch { return false; }
+    }
+
+    /// <summary>Resolve a flag NAME (or a comma-combo, case-insensitive) against a <c>[Flags]</c> enum type to its
+    /// bit pattern — the name-operand path for the query predicate's <c>has</c>/<c>=</c> (e.g. <c>has Body</c>).
+    /// False if the text is not a member (or combo of members) of the enum. A numeric string also parses here, but
+    /// the caller resolves numerics first, so this only ever sees names.</summary>
+    internal static bool TryEnumBitsFromName(Type enumType, string name, out ulong bits)
+    {
+        bits = 0;
+        try { return TryEnumBits(Enum.Parse(enumType, name.Trim(), ignoreCase: true), enumType, out bits); }
+        catch { return false; }
     }
 
     // -- primitive family (mirror TryPrimitive) --------------------------------

--- a/src/housecarl-generator/ValuePredicateProbe.cs
+++ b/src/housecarl-generator/ValuePredicateProbe.cs
@@ -37,6 +37,14 @@ public static class ValuePredicateProbe
         public FormKey Fk => Rec.FormKey;
     }
 
+    /// <summary>One synthesized Armor plus the known BodyTemplate.FirstPersonFlags bits it was built with — the
+    /// independent ground truth for the bitwise <c>has</c> / flags-aware compare (the brute force ANDs these bits,
+    /// never the record).</summary>
+    sealed record Armo(IArmorGetter Rec, ulong Bits)
+    {
+        public FormKey Fk => Rec.FormKey;
+    }
+
     static int _pass, _fail;
 
     public static int RunGuard(string[] args)
@@ -67,7 +75,22 @@ public static class ValuePredicateProbe
         };
         var weapBodies = weaps.Select(w => (IMajorRecordGetter)w.Rec).ToList();
 
-        Console.WriteLine($"-- synthesized {mgefs.Count} MagicEffect + {weaps.Count} Weapon records --");
+        // ---- ARMO cohort: known BodyTemplate.FirstPersonFlags (a [Flags] BipedObjectFlag) --------------------
+        // A mix of NAMED vanilla slots (render "Body"/"Forearms"), UNNAMED modder slots (render numeric), and a
+        // body+modder-slot COMBO (renders as one number) — the exact name/number split HCBR 2026-06-24 reported.
+        const uint slot52 = 0x400000;  // bit 22 — unnamed modder slot ("slot 52") -> "4194304"
+        const uint slot53 = 0x800000;  // bit 23 — unnamed modder slot ("slot 53") -> "8388608"
+        var armos = new List<Armo>
+        {
+            MakeArmo(mod, BipedObjectFlag.Body),                             // 4       -> "Body"
+            MakeArmo(mod, BipedObjectFlag.Forearms),                        // 16      -> "Forearms"
+            MakeArmo(mod, (BipedObjectFlag)slot53),                         // 8388608 -> "8388608"
+            MakeArmo(mod, (BipedObjectFlag)slot52),                         // 4194304 -> "4194304"
+            MakeArmo(mod, BipedObjectFlag.Body | (BipedObjectFlag)slot53),  // 8388612 -> "8388612" (combo)
+        };
+        var armoBodies = armos.Select(a => (IMajorRecordGetter)a.Rec).ToList();
+
+        Console.WriteLine($"-- synthesized {mgefs.Count} MagicEffect + {weaps.Count} Weapon + {armos.Count} Armor records --");
         Console.WriteLine();
 
         // ============================ FILTER-CORRECTNESS (matched set == brute force) ============================
@@ -134,6 +157,62 @@ public static class ValuePredicateProbe
         CheckSet("BasicStats.Damage <= 50",
             Run(new[] { "BasicStats.Damage <= 50" }, weapBodies),
             Expect(weaps, w => w.Damage <= 50));
+
+        // ============== BITWISE `has` + flags-aware compare on a [Flags] enum (HCBR 2026-06-24) ==============
+        Console.WriteLine();
+        Console.WriteLine("-- bitwise `has` + flags-aware compare on BodyTemplate.FirstPersonFlags --");
+
+        // `has <bit value>` — matches every record with that slot bit set, INCLUDING combos (what `=` misses).
+        CheckSet("FirstPersonFlags has 8388608  (slot 53, incl. combos)",
+            Run(new[] { "BodyTemplate.FirstPersonFlags has 8388608" }, armoBodies),
+            Expect(armos, a => (a.Bits & slot53) == slot53));
+
+        // the same bit in HEX — bitmasks read naturally in hex.
+        CheckSet("FirstPersonFlags has 0x800000  (hex form of slot 53)",
+            Run(new[] { "BodyTemplate.FirstPersonFlags has 0x800000" }, armoBodies),
+            Expect(armos, a => (a.Bits & slot53) == slot53));
+
+        // `has <flag name>` — a named vanilla slot by name, combo-tolerant (Body = bit 2 = 4).
+        CheckSet("FirstPersonFlags has Body  (named slot, incl. combos)",
+            Run(new[] { "BodyTemplate.FirstPersonFlags has Body" }, armoBodies),
+            Expect(armos, a => (a.Bits & 4UL) == 4UL));
+
+        // the CONTRAST that motivated the op: `=` is exact (excludes the combo); `has` finds it.
+        CheckSet("FirstPersonFlags = 8388608  (exact — slot-53-ONLY, excludes the combo)",
+            Run(new[] { "BodyTemplate.FirstPersonFlags = 8388608" }, armoBodies),
+            Expect(armos, a => a.Bits == slot53));
+
+        // flags `=` against a NUMERIC operand now matches a NAME-rendered field (the report's `= 16` case).
+        CheckSet("FirstPersonFlags = 16  (matches the name-rendered Forearms)",
+            Run(new[] { "BodyTemplate.FirstPersonFlags = 16" }, armoBodies),
+            Expect(armos, a => a.Bits == 16UL));
+        CheckSet("FirstPersonFlags = Forearms  (name still works)",
+            Run(new[] { "BodyTemplate.FirstPersonFlags = Forearms" }, armoBodies),
+            Expect(armos, a => a.Bits == 16UL));
+
+        // numeric RANGE op no longer ERRORS on a flags field that renders as a name (the report's `>= 65536`).
+        {
+            var (matched, set) = RunWithSet(new[] { "BodyTemplate.FirstPersonFlags >= 65536" }, armoBodies);
+            CheckSet("FirstPersonFlags >= 65536  (modder-range slots; no longer a type error)",
+                matched, Expect(armos, a => a.Bits >= 65536UL));
+            Check("FirstPersonFlags >= 65536: no FatalError (flags compare numerically now)", set.FatalError is null);
+        }
+
+        // `has` on a plain INTEGER leaf (ushort Damage) — generalizes beyond enums (50 = ...110010 has bit 4).
+        CheckSet("BasicStats.Damage has 16  (integer bit-test)",
+            Run(new[] { "BasicStats.Damage has 16" }, weapBodies),
+            Expect(weaps, w => (w.Damage & 16) == 16));
+
+        // Q3: `has` on a NON-bitmask field (a non-[Flags] enum) is a fast typed error, not a silent non-match.
+        {
+            var (matched, set) = RunWithSet(new[] { "MagicSkill has 4" }, mgefBodies);
+            Check("has on non-flags enum: FatalError set", set.FatalError is not null);
+            Check("has on non-flags enum: 0 matches", matched.Count == 0);
+            Console.WriteLine($"     fatal: {Trunc(set.FatalError)}");
+        }
+
+        // parse: `has` is a recognized operator.
+        Check("parse: `has` accepted", FieldPredicateSet.Parse(new[] { "BodyTemplate.FirstPersonFlags has 16" }).Error is null);
 
         // ============================ Q3 TEETH (no silent wrong answer) ============================
         Console.WriteLine();
@@ -220,6 +299,13 @@ public static class ValuePredicateProbe
         return new Weap(w, damage);
     }
 
+    static Armo MakeArmo(SkyrimMod mod, BipedObjectFlag flags)
+    {
+        var a = mod.Armors.AddNew();
+        a.BodyTemplate = new BodyTemplate { FirstPersonFlags = flags };
+        return new Armo(a, (ulong)flags);
+    }
+
     /// <summary>Parse + evaluate the predicate set over a cohort; return the matched FormKey set. Throws if the
     /// predicates don't parse (these call sites pass well-formed predicates — a parse failure is a real bug).</summary>
     static HashSet<FormKey> Run(string[] where, IEnumerable<IMajorRecordGetter> cohort) => RunWithSet(where, cohort).matched;
@@ -238,6 +324,9 @@ public static class ValuePredicateProbe
 
     static HashSet<FormKey> Expect(IEnumerable<Weap> cohort, Func<Weap, bool> pred)
         => cohort.Where(pred).Select(w => w.Fk).ToHashSet();
+
+    static HashSet<FormKey> Expect(IEnumerable<Armo> cohort, Func<Armo, bool> pred)
+        => cohort.Where(pred).Select(a => a.Fk).ToHashSet();
 
     static void CheckSet(string label, HashSet<FormKey> actual, HashSet<FormKey> expected)
     {


### PR DESCRIPTION
## What & why

Closes the HCBR 2026-06-24 GAP `no-bitmask-slot-filter-on-bodytemplate` (Heisen): `housecarl_cross_plugin_query where=` could not filter a record by a biped slot. Two symptoms, one root — there was no bitwise predicate, and `[Flags].ToString()` renders `BodyTemplate.FirstPersonFlags` as **names** when every set bit is named but a **raw decimal** once any bit is a modder slot, which broke numeric comparisons.

## Engine — `b41df2c`

- New **`has`** operator: `(bits & operand) == operand`, true **regardless of other bits**, so a multi-slot BodyTemplate still matches the one slot asked for — the thing `=` (exact value) cannot do. Operand is a bit value (decimal or `0x` hex) or a flag **name** (`has Body`). Generalizes to plain integer leaves.
- `[Flags]` enum leaves now carry their underlying bit pattern, so range ops compare numerically (`>= 65536` no longer errors on a field that reads `"Body"`) and `=`/`!=` equate by resolved bits (`= 16` now matches the name-rendered `Forearms`; the name still works).
- Non-flags enums are unchanged — a numeric op on them is still the fast typed `FatalError` (Q3); `has` on a non-bitmask field is a loud typed error, never a silent miss.
- The read display **Token is byte-identical** (`val.ToString()` as before), so reads / depth-dump / conflict-diff and the read↔write round-trip oracle are untouched — only the predicate engine reads the new metadata.

## Skill — `4462636`

- `biped-slot-reference`: the slot 30–61 table (number, bit, decimal, hex, Mutagen name) **verified against Mutagen's `BipedObjectFlag`** — the named bits are **non-contiguous** (Head..Ears 30–43, `DecapitateHead`/`Decapitate` 50/51, `FX01` 61), the trap a from-memory table gets wrong. Plus the `has`-not-`=` query pattern, the name-vs-number rendering gotcha, and Q3 "verify the bit, don't trust the convention" guidance. Scope routes keyword distribution to `kid-authoring`, field edits to `skypatcher-authoring`.
- Authored per `HOUSECARL_SKILL_AUTHORING`; added to the plugin build manifest.

### Review focus
`references/biped-slots.md` — the **community slot conventions** (SOS = 52, the back-slot range) are hedged modder-knowledge; worth a glance.

## Evidence
- `value-predicate-guard` 43/43 (new ARMO/`FirstPersonFlags` cohort exercising `has`, the flags `=`/range fixes, the integer-`has` path, and the non-bitmask Q3 error); full **`ci-all` ALL PASS**.
- Skill trigger fan-out (the standard's anonymized relevance method, core-scoped eval set): **recall 10/10, specificity 10/10**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
