### PR TITLE
feat(mcp): add housecarl_check_errors — load-order integrity sweep (A1)

### DIFF
--- a/src/housecarl-core/ErrorCheck.cs
+++ b/src/housecarl-core/ErrorCheck.cs
@@ -1,0 +1,181 @@
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+
+namespace HousecarlCore;
+
+/// <summary>
+/// The load-order integrity sweep (housecarl_check_errors — audit A1): the data-layer twin of the Creation Kit's
+/// "Check For Errors" / xEdit's error check. For each plugin in scope it walks EVERY record's FormLinks (Mutagen's
+/// own <see cref="IFormLinkContainerGetter.EnumerateFormLinks"/> — the by-construction link surface, the same one
+/// cross_plugin_query references= rides) and reports three error classes:
+///   • DANGLING — a non-null FormLink whose target NO plugin in the active order defines (<see cref="LoadOrderResolver.IndexView.ResolveWinner"/>
+///     is null): a broken reference in the resolvable order.
+///   • MISSING MASTER — a plugin DECLARES a master that is not present in the active order
+///     (<see cref="LoadOrderResolver.IndexView.ContainsPlugin"/> is false): the plugin's dependency is not installed /
+///     enabled, the most common load-order break (and the root cause behind a cluster of that master's refs dangling).
+///   • PARSE failures — per-record (a body whose link walk THROWS is excluded + accounted, never a silent skip — the
+///     fault-isolation twin of the cross_plugin_query scan) and whole-plugin (plugins the index build could not parse,
+///     surfaced via <see cref="LoadOrderResolver.IndexView.ExcludedPlugins"/>).
+///
+/// WHY NOT the master-TABLE diff the CK/xEdit also show (declared-vs-used) — the honest scope boundary, Q3:
+///   • "used-but-undeclared master" is STRUCTURALLY UNDETECTABLE through Mutagen: a FormID's master-index byte is
+///     decoded against the plugin's declared master list, so every FormKey Mutagen yields has a ModKey that is, by
+///     construction, a declared master or the plugin itself — the "references a form from a plugin it does not master"
+///     corruption lives in the RAW master-index byte, below what Mutagen models (adjacent to the mesh-byte residual).
+///     Its OBSERVABLE effect — refs that no longer resolve — is caught as DANGLING. We do not claim to diagnose it.
+///   • "declared-but-unused master" (xEdit's unused-master cleanup) is advisory only and a FormLink scan cannot prove
+///     it (a master used solely by scripts or unmodeled refs would read as unused — a false positive). Deferred as a
+///     named future item rather than shipped as an unprovable claim.
+///
+/// HONEST BOUNDARY (Q3 — the sweep claims exactly this, never more): it covers the FormLink-resolution / missing-master
+/// / parse class. It does NOT verify navmesh or terrain SPATIAL integrity (the CrcHash / NavmeshGrid recompute — a known
+/// Mutagen-delta residual), does NOT flag a REQUIRED field left null (needs per-field requiredness; a null FormLink is a
+/// legal optional here), and does NOT list unused-master cleanup (see above). All named in the rendered footer so a
+/// clean result is never read as byte-for-byte xEdit parity.
+///
+/// Composes existing primitives only — no new dependency (audit A1 "Verified 2026-06-25"): the per-plugin record stream
+/// (<c>RecordsIn</c>), the O(1) resolution test (<c>ResolveWinner</c>), presence (<c>ContainsPlugin</c>), the declared-
+/// master read (<c>DeclaredMasters</c>), and per-record fault isolation. Holds nothing past each yield (Option B).
+/// </summary>
+public static class ErrorCheck
+{
+    /// <summary>Sweep <paramref name="scope"/> (plugin filenames; null/empty = the whole active order minus excluded
+    /// plugins) over the order <paramref name="resolver"/> holds. One <see cref="LoadOrderResolver.Capture"/> pins the
+    /// whole sweep. <paramref name="limit"/> caps the number of dangling refs collected across the sweep (the true
+    /// total is always counted); missing-master findings are few and never capped. A bad/excluded scope name fails
+    /// LOUD (Q3) with no partial result.</summary>
+    public static ErrorCheckResult Run(LoadOrderResolver resolver, IReadOnlyList<string>? scope, int limit)
+    {
+        var view = resolver.Capture();
+
+        // --- resolve the plugin set to scan (Q3: a bad or excluded explicit scope name fails loud, never a silent skip). ---
+        List<string> targets;
+        if (scope is { Count: > 0 })
+        {
+            targets = new List<string>(scope.Count);
+            foreach (var name in scope)
+            {
+                if (!view.ContainsPlugin(name))
+                    return ErrorCheckResult.Fail($"plugin not in the load order: {name}");
+                if (view.ExcludedPlugins.TryGetValue(name, out var why))
+                    return ErrorCheckResult.Fail(
+                        $"plugin '{name}' was excluded from this session because it could not be parsed ({why}) — fix or remove it upstream; it cannot be checked.");
+                targets.Add(name);
+            }
+        }
+        else
+        {
+            targets = new List<string>();
+            foreach (var n in resolver.PluginNames)
+                if (!view.ExcludedPlugins.ContainsKey(n)) targets.Add(n);
+        }
+
+        var reports = new List<PluginErrors>();
+        int totalDangling = 0, totalMissing = 0, totalUnscannable = 0;
+        int danglingBudget = limit;
+        bool capped = false;
+
+        foreach (var plugin in targets)
+        {
+            string? scanError = null;
+
+            // Missing masters: a declared master not present in the active order (the dependency is not installed /
+            // enabled). Read independently of the record walk so a record-walk fault still reports the master state.
+            var missingMasters = new List<string>();
+            try
+            {
+                foreach (var m in view.DeclaredMasters(plugin))
+                    if (!view.ContainsPlugin(m)) missingMasters.Add(m);
+            }
+            catch (Exception ex) { scanError = $"could not read the master list: {ex.GetType().Name}: {ex.Message}"; }
+            missingMasters.Sort(StringComparer.OrdinalIgnoreCase);
+
+            var dangling = new List<DanglingRef>();
+            int unscannable = 0;
+            var unscannableSamples = new List<string>();
+
+            try
+            {
+                foreach (var (fk, _, body, _) in view.RecordsIn(new[] { plugin }, null))
+                {
+                    // PER-RECORD FAULT ISOLATION (twin of the cross_plugin_query scan, HCBR-2026-06-09-03):
+                    // EnumerateFormLinks lazily parses subrecord content, so ONE record Mutagen can't parse is excluded
+                    // + accounted, never an opaque whole-call abort and never a silent skip (Q3).
+                    try
+                    {
+                        if (body is not IFormLinkContainerGetter flc) continue;
+                        foreach (var link in flc.EnumerateFormLinks())
+                        {
+                            var target = link.FormKey;
+                            if (target.IsNull) continue;            // a null FormLink is a legal optional — not an error (see the class-doc boundary)
+                            if (view.ResolveWinner(target) is not null) continue;   // resolves → fine
+                            totalDangling++;
+                            if (danglingBudget > 0)
+                            {
+                                dangling.Add(new DanglingRef(fk, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID, target));
+                                danglingBudget--;
+                            }
+                            else capped = true;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        unscannable++;
+                        if (unscannableSamples.Count < 3) unscannableSamples.Add($"{fk} — {ex.GetType().Name}: {ex.Message}");
+                    }
+                }
+            }
+            // The plugin enumeration itself faulting (a record that throws on top-level enumeration rather than on a
+            // link walk) is NAMED per-plugin and the sweep continues — never the MCP layer's opaque transport error (Q3).
+            catch (Exception ex)
+            {
+                scanError = (scanError is null ? "" : scanError + "; ")
+                          + $"record enumeration aborted partway: {ex.GetType().Name}: {ex.Message}";
+            }
+
+            totalMissing += missingMasters.Count;
+            totalUnscannable += unscannable;
+
+            if (dangling.Count > 0 || missingMasters.Count > 0 || unscannable > 0 || scanError is not null)
+                reports.Add(new PluginErrors(plugin, dangling, missingMasters, unscannable, unscannableSamples, scanError));
+        }
+
+        return new ErrorCheckResult(reports, targets.Count, totalDangling, totalMissing,
+                                    totalUnscannable, capped, view.ExcludedPlugins, null);
+    }
+}
+
+/// <summary>One broken reference: the SOURCE record (FormKey + catalog type + editorid) and the TARGET FormKey no
+/// active plugin defines.</summary>
+public sealed record DanglingRef(FormKey Source, string SourceType, string? SourceEditorId, FormKey Target);
+
+/// <summary>Every error found in one plugin: its dangling references (capped across the sweep), the masters it declares
+/// that are not present in the active order, the count + samples of records that could not be scanned, and — if the
+/// plugin's own enumeration faulted — a <paramref name="ScanError"/>.</summary>
+public sealed record PluginErrors(
+    string Plugin,
+    IReadOnlyList<DanglingRef> Dangling,
+    IReadOnlyList<string> MissingMasters,
+    int UnscannableRecords,
+    IReadOnlyList<string> UnscannableSamples,
+    string? ScanError);
+
+/// <summary>The result of <see cref="ErrorCheck.Run"/>: the per-plugin reports (only plugins WITH findings; clean
+/// plugins are counted in <paramref name="PluginsScanned"/> but omitted), the sweep totals, whether the dangling list
+/// was capped at the caller's limit, the plugins the index build excluded as unparseable, and — on a Q3 scope error —
+/// a recoverable <see cref="Error"/> with no reports.</summary>
+public sealed record ErrorCheckResult(
+    IReadOnlyList<PluginErrors> Reports,
+    int PluginsScanned,
+    int TotalDangling,
+    int TotalMissingMasters,
+    int TotalUnscannableRecords,
+    bool Capped,
+    IReadOnlyDictionary<string, string> ExcludedPlugins,
+    string? Error)
+{
+    public bool Success => Error is null;
+    public static ErrorCheckResult Fail(string error) =>
+        new(Array.Empty<PluginErrors>(), 0, 0, 0, 0, false,
+            new Dictionary<string, string>(), error);
+}

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -490,6 +490,12 @@ public sealed class LoadOrderResolver : IDisposable
         /// every edit of one call off ONE view; reads pin their fetch to the same view they resolved with).</summary>
         public IMajorRecordGetter? GetRecord(OverlaySession session, string pluginName, FormKey fk)
             => _r.GetRecord(session, pluginName, fk, _s);
+
+        /// <summary>The master filenames a plugin DECLARES in its header (the master table), in declared order — opens
+        /// the overlay, reads the header, disposes (Option B; the header parses without enumerating records). Throws
+        /// (Q3) on a name not in the order or excluded this build. The integrity sweep diffs this against the masters a
+        /// plugin's records actually reference; judged against THIS view's build (same exclusion set as the scan).</summary>
+        public IReadOnlyList<string> DeclaredMasters(string pluginName) => _r.DeclaredMasters(pluginName, _s);
     }
 
     // ---- Queries -------------------------------------------------------
@@ -569,6 +575,23 @@ public sealed class LoadOrderResolver : IDisposable
         foreach (var rec in session.Overlay(idx).EnumerateMajorRecords())
             if (rec.FormKey == fk) return rec;
         return null;
+    }
+
+    /// <summary>The master filenames a plugin declares in its header (the master TABLE). Opens the overlay, reads
+    /// <c>ModHeader.MasterReferences</c>, disposes (Option B — the header parses without enumerating records). Throws
+    /// (Q3) on a name not in the order or excluded this build, mirroring <see cref="PluginRecordStatus"/>. The
+    /// integrity sweep (housecarl_check_errors) diffs this against the masters a plugin's records actually reference.</summary>
+    public IReadOnlyList<string> DeclaredMasters(string pluginName) => DeclaredMasters(pluginName, _snap);
+
+    IReadOnlyList<string> DeclaredMasters(string pluginName, IndexSnapshot s)
+    {
+        if (!_nameToIdx.TryGetValue(pluginName, out int idx))
+            throw new ArgumentException($"plugin not in the load order: {pluginName}");
+        if (s.Excluded.Contains(idx))
+            throw new ArgumentException($"plugin '{pluginName}' was excluded from this session: {s.ExcludedPlugins[pluginName]}");
+        var ov = OpenOverlay(_paths[idx], _dataDir);
+        try { return ov.ModHeader.MasterReferences.Select(m => m.Master.FileName.ToString()).ToList(); }
+        finally { (ov as IDisposable)?.Dispose(); }
     }
 
     /// <summary>Fetch one record body from one overlay by re-enumerating it (primitive B — into the session). Throws if

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -1,0 +1,170 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SELF-CONTAINED CI REGRESSION GUARD for the LOAD-ORDER INTEGRITY SWEEP (housecarl_check_errors — audit A1). Drives the
+/// REAL product path (<see cref="ErrorCheck.Run"/> — what housecarl_check_errors calls through the thin service wrapper)
+/// against a SYNTHESIZED 4-plugin order in TEMP — NO Skyrim.esm, so it runs in CI.
+///
+/// THE GAP (reproduced by construction): no general "validate every record" verb existed — validate_dialogue is
+/// DIAL/QUST-only. The sweep walks every record's FormLinks and reports dangling refs, missing masters, and parse
+/// failures, the data-layer twin of the CK's "Check For Errors".
+///
+/// FIXTURE — four plugins, two of them masters, one omitted from the loaded order ON PURPOSE:
+///   • HcCeMaster.esm  — defines a Race (HcCeMasterRace). Present in the order.
+///   • HcCeGhost.esm   — defines a Race (HcCeGhostRace). DECLARED by HcCeBad as a master, but NOT loaded → the
+///                       missing-master fixture, and every ref into it is therefore also dangling.
+///   • HcCeClean.esp   — masters [HcCeMaster]; one NPC whose Race → HcCeMasterRace (a VALID ref). The clean control:
+///                       a Mutagen-written plugin whose masters all resolve must produce ZERO findings.
+///   • HcCeBad.esp     — masters [HcCeMaster, HcCeGhost]; NPC1 Race → HcCeGhostRace (missing-master + dangling), NPC2
+///                       Race → 0F0F0F:HcCeMaster.esm (dangling, master PRESENT — isolates "dangling" from "missing").
+/// The order built for the resolver is [Master, Clean, Bad] — Ghost on disk but NOT in the order.
+///
+/// Arms (ALL required — a GREEN must mean "the contract holds"):
+///   CLEAN-CONTROL   — HcCeClean.esp produces NO report (valid ref + a fresh NPC's default-null links are not flagged:
+///                     the no-false-positive teeth, and the proof a null FormLink is treated as a legal optional).
+///   DANGLING-GHOST  — HcCeBad's dangling set contains the ref to HcCeGhostRace (a ref into an absent master).
+///   DANGLING-DEAD   — HcCeBad's dangling set contains the ref to 0F0F0F:HcCeMaster.esm (master present, target absent).
+///   DANGLING-TOTAL  — exactly 2 dangling refs across the sweep (no stray links from the fresh NPCs).
+///   SOURCE-ATTRIB   — each dangling ref names its SOURCE record (editorid + "Npc" type), not just the target.
+///   MISSING-MASTER  — HcCeBad lists HcCeGhost.esm as a missing master; HcCeMaster.esm (present) is NOT listed.
+///   MISSING-ISOLATE — no plugin reports HcCeMaster.esm missing (a present master is never a false missing-master).
+///   SCANNED         — the whole-order sweep scanned 3 plugins (Master, Clean, Bad — Ghost is not in the order).
+///   SCOPE           — scope=[HcCeBad.esp] reports only Bad (1 plugin scanned), Clean absent.
+///   SCOPE-Q3        — scope=[a name not in the order] fails LOUD ("not in the load order"), no reports (never a silent skip).
+///   CAP             — limit=1 over Bad's 2 dangling refs returns 1 but reports the TRUE total (2) and Capped.
+///
+/// COVERAGE NOTE (Q3 — name what this guard LEANS ON rather than re-proves): PARSE failures are not synthesized here.
+///   Whole-plugin exclusion rides on the index build's ExcludedPlugins machinery (exercised across the suite), and the
+///   per-record link-walk fault isolation is the SAME try/catch idiom proven by effect-chain-guard + the cross_plugin_query
+///   scan. The sweep surfaces both verbatim (ExcludedPlugins + the unscannable accounting), it does not re-implement them.
+///
+/// Run: dotnet run --project src/housecarl-generator -- check-errors-guard
+/// </summary>
+public static class CheckErrorsProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("check-errors-guard — load-order integrity sweep (housecarl_check_errors, audit A1)");
+        Console.WriteLine();
+        var tmpDir = Path.Combine(Path.GetTempPath(), "hc-check-errors-guard-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tmpDir);
+        try { return RunChecks(tmpDir); }
+        finally { try { Directory.Delete(tmpDir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    static int RunChecks(string tmpDir)
+    {
+        int failures = 0;
+        void Check(string label, bool ok, string? detail = null)
+        {
+            Console.WriteLine($"  {(ok ? "PASS" : "FAIL")}  {label}{(ok || detail is null ? "" : $"\n        -> {detail}")}");
+            if (!ok) failures++;
+        }
+
+        string masterPath = Path.Combine(tmpDir, "HcCeMaster.esm");
+        string ghostPath  = Path.Combine(tmpDir, "HcCeGhost.esm");
+        string cleanPath  = Path.Combine(tmpDir, "HcCeClean.esp");
+        string badPath    = Path.Combine(tmpDir, "HcCeBad.esp");
+        var deadFk = FormKey.Factory("0F0F0F:HcCeMaster.esm");   // an object id HcCeMaster.esm does NOT define (master present, target absent)
+        FormKey masterRaceFk, ghostRaceFk;
+        try
+        {
+            var master = new SkyrimMod(new ModKey("HcCeMaster", ModType.Master), SkyrimRelease.SkyrimSE);
+            var mRace = master.Races.AddNew(); mRace.EditorID = "HcCeMasterRace"; masterRaceFk = mRace.FormKey;
+            master.BeginWrite.ToPath(masterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+            var ghost = new SkyrimMod(new ModKey("HcCeGhost", ModType.Master), SkyrimRelease.SkyrimSE);
+            var gRace = ghost.Races.AddNew(); gRace.EditorID = "HcCeGhostRace"; ghostRaceFk = gRace.FormKey;
+            ghost.BeginWrite.ToPath(ghostPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+            // Clean dependent: one NPC, Race → a VALID master race. WithLoadOrder([master]) declares HcCeMaster only.
+            var clean = new SkyrimMod(new ModKey("HcCeClean", ModType.Plugin), SkyrimRelease.SkyrimSE);
+            var cNpc = clean.Npcs.AddNew(); cNpc.EditorID = "HcCeCleanNpc"; cNpc.Race.SetTo(masterRaceFk);
+            clean.BeginWrite.ToPath(cleanPath).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
+
+            // Broken dependent: NPC1 → Ghost's race (missing master + dangling); NPC2 → a dead id in the present master.
+            // Referencing both masters makes Mutagen declare [HcCeMaster, HcCeGhost] in the header.
+            var bad = new SkyrimMod(new ModKey("HcCeBad", ModType.Plugin), SkyrimRelease.SkyrimSE);
+            var bGhost = bad.Npcs.AddNew(); bGhost.EditorID = "HcCeBadGhostNpc"; bGhost.Race.SetTo(ghostRaceFk);
+            var bDead  = bad.Npcs.AddNew(); bDead.EditorID  = "HcCeBadDeadNpc";  bDead.Race.SetTo(deadFk);
+            bad.BeginWrite.ToPath(badPath).WithLoadOrder(new ISkyrimModGetter[] { master, ghost }).Write();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"error: could not synthesize fixtures: {ex.GetType().Name}: {(ex.InnerException ?? ex).Message}");
+            return 1;
+        }
+
+        // Build the order WITHOUT Ghost — it is the missing master.
+        using var r = LoadOrderResolver.Build(new[] { masterPath, cleanPath, badPath });
+
+        var all = ErrorCheck.Run(r, null, 1000);
+        if (!all.Success) { Console.Error.WriteLine($"error: whole-order sweep failed: {all.Error}"); return 1; }
+
+        PluginErrors? Bad() => all.Reports.FirstOrDefault(p => p.Plugin == "HcCeBad.esp");
+        var bad2 = Bad();
+
+        Check("CLEAN-CONTROL: HcCeClean.esp produces NO report (valid ref + fresh NPC's null links are not flagged)",
+            all.Reports.All(p => p.Plugin != "HcCeClean.esp"),
+            $"clean report present={all.Reports.Any(p => p.Plugin == "HcCeClean.esp")}");
+
+        Check("DANGLING-GHOST: HcCeBad's dangling set contains the ref into the absent master (HcCeGhostRace)",
+            bad2 is not null && bad2.Dangling.Any(d => d.Target == ghostRaceFk),
+            $"bad={(bad2 is null ? "<no report>" : string.Join(",", bad2.Dangling.Select(d => d.Target.ToString())))}");
+
+        Check("DANGLING-DEAD: HcCeBad's dangling set contains the ref to a dead id in the present master (0F0F0F:HcCeMaster.esm)",
+            bad2 is not null && bad2.Dangling.Any(d => d.Target == deadFk),
+            $"bad={(bad2 is null ? "<no report>" : string.Join(",", bad2.Dangling.Select(d => d.Target.ToString())))}");
+
+        Check("DANGLING-TOTAL: exactly 2 dangling refs across the sweep (no stray links from the fresh NPCs)",
+            all.TotalDangling == 2, $"total={all.TotalDangling}");
+
+        Check("SOURCE-ATTRIB: each dangling ref names its SOURCE record (editorid + 'Npc' type)",
+            bad2 is not null
+            && bad2.Dangling.Any(d => d.SourceEditorId == "HcCeBadGhostNpc" && d.SourceType == "Npc")
+            && bad2.Dangling.Any(d => d.SourceEditorId == "HcCeBadDeadNpc"  && d.SourceType == "Npc"),
+            bad2 is null ? "<no report>" : string.Join(",", bad2.Dangling.Select(d => $"{d.SourceEditorId}/{d.SourceType}")));
+
+        Check("MISSING-MASTER: HcCeBad lists HcCeGhost.esm as missing; HcCeMaster.esm (present) is NOT listed",
+            bad2 is not null
+            && bad2.MissingMasters.Contains("HcCeGhost.esm", StringComparer.OrdinalIgnoreCase)
+            && !bad2.MissingMasters.Contains("HcCeMaster.esm", StringComparer.OrdinalIgnoreCase),
+            bad2 is null ? "<no report>" : string.Join(",", bad2.MissingMasters));
+
+        Check("MISSING-ISOLATE: no plugin reports HcCeMaster.esm missing (a present master is never a false missing-master)",
+            all.Reports.All(p => !p.MissingMasters.Contains("HcCeMaster.esm", StringComparer.OrdinalIgnoreCase)),
+            string.Join(" | ", all.Reports.Select(p => $"{p.Plugin}:[{string.Join(",", p.MissingMasters)}]")));
+
+        Check("SCANNED: the whole-order sweep scanned 3 plugins (Master, Clean, Bad — Ghost not in the order)",
+            all.PluginsScanned == 3, $"scanned={all.PluginsScanned}");
+
+        // ---- SCOPE: only the named plugin. ----
+        var scoped = ErrorCheck.Run(r, new[] { "HcCeBad.esp" }, 1000);
+        Check("SCOPE: scope=[HcCeBad.esp] reports only Bad (1 plugin scanned), Clean absent",
+            scoped.Success && scoped.PluginsScanned == 1 && scoped.Reports.Count == 1
+            && scoped.Reports[0].Plugin == "HcCeBad.esp",
+            $"success={scoped.Success} scanned={scoped.PluginsScanned} reports={scoped.Reports.Count}");
+
+        var q3 = ErrorCheck.Run(r, new[] { "HcCeNotReal.esp" }, 1000);
+        Check("SCOPE-Q3: an unknown scope name fails LOUD ('not in the load order'), no reports",
+            !q3.Success && q3.Reports.Count == 0 && q3.Error is not null
+            && q3.Error.Contains("not in the load order", StringComparison.Ordinal),
+            $"success={q3.Success} reports={q3.Reports.Count} err=[{q3.Error}]");
+
+        // ---- CAP: limit=1 over Bad's 2 dangling refs. ----
+        var capped = ErrorCheck.Run(r, new[] { "HcCeBad.esp" }, 1);
+        Check("CAP: limit=1 returns 1 dangling ref but reports the TRUE total (2) and Capped",
+            capped.TotalDangling == 2 && capped.Capped
+            && capped.Reports.Count == 1 && capped.Reports[0].Dangling.Count == 1,
+            $"total={capped.TotalDangling} capped={capped.Capped} collected={(capped.Reports.Count > 0 ? capped.Reports[0].Dangling.Count : -1)}");
+
+        Console.WriteLine();
+        Console.WriteLine(failures == 0 ? "check-errors-guard: ALL PASS" : $"check-errors-guard: {failures} FAILURE(S)");
+        return failures == 0 ? 0 : 1;
+    }
+}

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -45,6 +45,7 @@ public static class CiAll
         ("create-plugin-guard", CreatePluginGuardProbe.RunGuard),
         ("value-predicate-guard", ValuePredicateProbe.RunGuard),
         ("effect-chain-guard", EffectChainProbe.RunGuard),
+        ("check-errors-guard", CheckErrorsProbe.RunGuard),
         ("source-display-guard", SourceDisplayProbe.RunGuard),
         ("writelock-guard", WriteLockProbe.RunGuard),
         ("inplace-guard", InPlaceProbe.RunGuard),

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1050,6 +1050,15 @@ public sealed class LoadOrderService : IDisposable
         return EffectChain.Resolve(Resolver, mgef, scope, limit);
     }
 
+    // ---- integrity sweep (housecarl_check_errors — audit A1) --------------------------------------------
+
+    /// <summary>Sweep the active order (or the given <paramref name="plugins"/> scope) for record integrity errors —
+    /// dangling FormLinks, missing masters, and parse failures (housecarl_check_errors). Thin wiring over the
+    /// core <see cref="ErrorCheck.Run"/>, which holds all the scan logic + Q3 teeth so the self-contained guard drives
+    /// this same path over synthetic plugins. Read-only; composes existing primitives, no new dependency.</summary>
+    public ErrorCheckResult CheckErrors(IReadOnlyList<string>? plugins, int limit)
+        => ErrorCheck.Run(Resolver, plugins, limit);
+
     // ---- writes (§8.4 Beat C: housecarl_set_field / housecarl_bulk_apply) -------------------------------
 
     /// <summary>Apply one-or-more edits as a single patch (housecarl_set_field = one op; housecarl_bulk_apply = many).

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -153,6 +153,32 @@ public static class ReadTools
         var result = svc.ResolveEffectChain(fk, types, limit <= 0 ? 500 : limit);
         return Wire.RenderEffectChain(result, max_chars);
     });
+
+    [McpServerTool(Name = "housecarl_check_errors", ReadOnly = true, Title = "Check the load order for record errors"),
+     Description(
+         "Load-order integrity sweep — the data-layer twin of the Creation Kit's 'Check For Errors' / xEdit's error " +
+         "check. For each plugin in scope it walks every record's FormLinks and reports three error classes: (1) DANGLING " +
+         "references — a non-null link whose target NO plugin in the ACTIVE order defines (a broken reference); (2) " +
+         "MISSING MASTERS — a master a plugin DECLARES that is not present in the active order (its dependency is not " +
+         "installed/enabled — the most common load-order break); (3) PARSE failures — records houseCARL/Mutagen could not " +
+         "read (per record), plus whole plugins the index excluded as unparseable. Read-only — writes nothing. BOUNDARY " +
+         "(never a silent claim of more — Q3): this covers the FormLink-resolution / missing-master / parse class. It does " +
+         "NOT verify navmesh or terrain spatial integrity (CRC/grid — a Mutagen-delta residual), does NOT flag a required " +
+         "field left null (a null FormLink is a legal optional, not an error), and does NOT list unused-master cleanup " +
+         "(a FormLink scan cannot prove a master is unused). Results cap at limit= and max_chars (both overruns explicit).")]
+    public static string CheckErrorsTool(
+        LoadOrderService svc,
+        [Description("Optional. Plugin filenames to check (e.g. 'MyMod.esp'). A name not in the load order is an error. Omit to sweep the WHOLE active order (every non-excluded plugin) — thorough but heavier; scope to one plugin for a fast, focused check like the CK's per-plugin 'Check For Errors'.")]
+            string[]? plugins = null,
+        [Description("Optional. Max dangling references to list across the whole sweep (default 1000). The TRUE total is always reported; over the cap it says so. Master-table findings are always listed in full (they are few).")]
+            int limit = 1000,
+        [Description("Optional. Max characters before the response stops with an explicit notice. 0 = the server default (~80k).")]
+            int max_chars = 0) => Guard.Tool("housecarl_check_errors", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        var result = svc.CheckErrors(plugins, limit <= 0 ? 1000 : limit);
+        return Wire.RenderCheckErrors(result, max_chars);
+    });
 }
 
 /// <summary>Compact, parseable `key = value` rendering (Q4.8 lever 1) + the winner-relative conflict diff
@@ -287,6 +313,77 @@ static class Wire
                 rendered++;
             }
         }
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    // ---- housecarl_check_errors ---------------------------------------------------------------------
+    public static string RenderCheckErrors(ErrorCheckResult r, int maxChars)
+    {
+        if (r.Error is not null) return "error: " + r.Error;
+        int cap = Cap(maxChars);
+        var sb = new StringBuilder();
+
+        sb.Append("check_errors — load-order integrity sweep\n");
+        sb.Append("scanned ").Append(r.PluginsScanned).Append(r.PluginsScanned == 1 ? " plugin · " : " plugins · ")
+          .Append(r.TotalDangling).Append(" dangling ref(s) · ")
+          .Append(r.TotalMissingMasters).Append(" missing master(s) · ")
+          .Append(r.TotalUnscannableRecords).Append(" unscannable record(s)");
+        if (r.ExcludedPlugins.Count > 0)
+            sb.Append(" · ").Append(r.ExcludedPlugins.Count).Append(" plugin(s) excluded (unparseable)");
+        sb.Append('\n');
+
+        if (r.Reports.Count == 0 && r.ExcludedPlugins.Count == 0)
+            sb.Append("\nNo errors found in the scanned scope.\n");
+
+        bool truncated = false;
+        foreach (var p in r.Reports)
+        {
+            if (sb.Length >= cap)
+            {
+                sb.Append("\n... [truncated at max_chars=").Append(cap).Append("; scope plugins= or raise max_chars to see the rest]\n");
+                truncated = true;
+                break;
+            }
+            sb.Append("\n[ERROR] ").Append(p.Plugin).Append('\n');
+            if (p.ScanError is not null)
+                sb.Append("  scan error: ").Append(p.ScanError).Append('\n');
+            if (p.MissingMasters.Count > 0)
+                sb.Append("  missing master(s): ").Append(string.Join(", ", p.MissingMasters))
+                  .Append("   [declared as a dependency but not present in the active order — install/enable it, or this plugin's refs into it dangle]\n");
+            if (p.Dangling.Count > 0)
+            {
+                sb.Append("  dangling reference(s) (").Append(p.Dangling.Count).Append("):\n");
+                foreach (var d in p.Dangling)
+                {
+                    if (sb.Length >= cap) break;
+                    sb.Append("    ").Append(d.Source).Append(" (").Append(d.SourceType);
+                    if (!string.IsNullOrEmpty(d.SourceEditorId)) sb.Append(" '").Append(d.SourceEditorId).Append('\'');
+                    sb.Append(") -> ").Append(d.Target).Append("   [target not defined by any active plugin]\n");
+                }
+            }
+            if (p.UnscannableRecords > 0)
+            {
+                sb.Append("  ").Append(p.UnscannableRecords).Append(" record(s) could not be scanned (Mutagen could not parse their content)");
+                if (p.UnscannableSamples.Count > 0) sb.Append(": ").Append(string.Join("; ", p.UnscannableSamples));
+                sb.Append('\n');
+            }
+        }
+
+        if (r.Capped)
+            sb.Append("\n[dangling list capped at limit; true total = ").Append(r.TotalDangling).Append(" — raise limit= to see all]\n");
+
+        if (!truncated && r.ExcludedPlugins.Count > 0)
+        {
+            sb.Append("\nexcluded plugins (could not be parsed — NOT checked):\n");
+            foreach (var kv in r.ExcludedPlugins)
+            {
+                if (sb.Length >= cap) break;
+                sb.Append("  ").Append(kv.Key).Append(": ").Append(kv.Value).Append('\n');
+            }
+        }
+
+        sb.Append("\nboundary: checks FormLink resolution, missing masters, and parse failures. Does NOT verify navmesh/terrain ")
+          .Append("spatial integrity (CRC/grid), flag required-but-null fields, or list unused-master cleanup; a null FormLink is a legal optional.\n");
         return sb.ToString().TrimEnd('\n');
     }
 


### PR DESCRIPTION
## What

Adds `housecarl_check_errors` (audit A1, the first post-1.4.0 build) — a read-only, per-plugin load-order integrity sweep, the data-layer twin of the CK's "Check For Errors" / xEdit's error check. For each plugin in scope it walks every record's FormLinks and reports three classes:

- **Dangling references** — a non-null link whose target no plugin in the active order defines (`ResolveWinner == null`).
- **Missing masters** — a declared master not present in the active order (`!ContainsPlugin`) — the #1 load-order break.
- **Parse failures** — per-record (fault-isolated link walk, the `cross_plugin_query` idiom) + whole-plugin (`ExcludedPlugins`).

Default scope is the whole active order; `plugins=` scopes to a focused per-plugin check. Caps on `limit=` / `max_chars`, explicit boundary footer (no silent claim of more — Q3). Composes existing primitives (`RecordsIn` / `ResolveWinner` / `ContainsPlugin` + a new `DeclaredMasters`), no new dependency. Directly hardens the 1.4.0 in-place write lane.

## Design note — scope refinement vs the audit

The audit (A1) listed "declared-vs-used master mismatches." Building it surfaced that this splits, and neither half is the right v1 check:

- **used-but-undeclared is structurally undetectable through Mutagen.** A FormID's master-index byte is decoded against the plugin's declared master list, so every `FormKey.ModKey` Mutagen yields is a declared master or self *by construction*. That corruption lives in raw master-index bytes, below Mutagen's model (adjacent to the mesh-byte residual); its observable effect — refs that stop resolving — is caught as **dangling**.
- **declared-but-unused** is advisory only, unprovable by a FormLink scan (a master used solely by scripts reads as a false "unused"), and can't be synthesized through Mutagen's normalizing writer to regression-test.

Both are replaced by the higher-value, testable **missing-master** check, and both are named in the tool's boundary footer (Q3 — no silent narrowing). Other documented boundaries: required-but-null fields (a null FormLink is a legal optional, deferred — needs per-field requiredness) and navmesh/terrain spatial integrity (the known Mutagen-delta residual).

## Files

- `src/housecarl-core/ErrorCheck.cs` — the scan + result types (the Q3 teeth live here so the guard drives the real path).
- `src/housecarl-core/LoadOrderResolver.cs` — `DeclaredMasters` primitive (Option B: open header, read, dispose).
- `src/housecarl-mcp/LoadOrderService.cs` — `CheckErrors` wrapper.
- `src/housecarl-mcp/ReadTools.cs` — `housecarl_check_errors` tool + `RenderCheckErrors`.
- `src/housecarl-generator/CheckErrorsProbe.cs` + `CiAll.cs` — `check-errors-guard`, a self-contained 4-plugin guard.

## Tests

`check-errors-guard` — 11 arms: clean control / both dangling classes / dangling-total / source attribution / missing-master / missing-isolation / scanned-count / scope / scope-Q3 / cap. Self-contained (synthetic 4-plugin order in temp, no Skyrim.esm). **ci-all 56/56 green** locally.

Out of scope (release-prep, not this PR): changelog + tool-count bump (26 → 27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)