### PR TITLE
fix(write): author AssetLink list elements (SoundDescriptor.SoundFiles) — Heisen bug + 2 findings

### DIFF
--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -626,8 +626,9 @@ public static class ReadEngine
         // AssetLink<T> family — the stored path string. Recognised by generic-definition NAME (the mutable
         // AssetLink<T> Coerce builds, the getter overlay's AssetLinkGetter<T>, or the IAssetLink(Getter)<T>
         // interfaces) so the value READ off a getter is handled, not only the mutable type — the same
-        // by-name recognition the engine uses for the FLOI family.
-        if (IsAssetLinkFamily(rt2))
+        // by-name recognition the engine uses for the FLOI family. Shares ONE predicate with the write
+        // coercion (WriteEngine.IsAssetLinkFamily) so read and write can't drift on what an asset link is.
+        if (WriteEngine.IsAssetLinkFamily(rt2))
         { token = ReflectString(val, "GivenPath", "RawPath", "DataRelativePath") ?? val.ToString() ?? ""; return true; }
 
         return false;
@@ -737,12 +738,8 @@ public static class ReadEngine
            && (t.GetGenericTypeDefinition() == typeof(Noggog.MemorySlice<>) || t.GetGenericTypeDefinition() == typeof(Noggog.ReadOnlyMemorySlice<>))
            && t.GetGenericArguments()[0] == typeof(byte);
 
-    static bool IsAssetLinkFamily(Type t)
-    {
-        if (!t.IsGenericType) return false;
-        var n = t.GetGenericTypeDefinition().Name;
-        return n.StartsWith("AssetLink", StringComparison.Ordinal) || n.StartsWith("IAssetLink", StringComparison.Ordinal);
-    }
+    // AssetLink-family recognition lives in WriteEngine.IsAssetLinkFamily (ONE predicate, shared with write
+    // coercion — read emits the path, write builds the link from it; they must agree on the family).
 
     /// <summary>True if <paramref name="t"/> is a VMAD script-property arm (ScriptObjectProperty, the scalar
     /// ScriptInt/Float/Bool/StringProperty arms, and the *ListProperty arms) — recognised by the shared getter

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1872,6 +1872,21 @@ public static class WriteEngine
         return elementRef is not null && elementRef.StartsWith("AssetLink", StringComparison.Ordinal);
     }
 
+    /// <summary>True iff <paramref name="t"/> is a Mutagen <c>AssetLink&lt;T&gt;</c> family type — the mutable
+    /// concrete <c>AssetLink&lt;T&gt;</c>, its getter overlay <c>AssetLinkGetter&lt;T&gt;</c>, or the
+    /// <c>IAssetLink(Getter)&lt;T&gt;</c> interfaces a collection element exposes. Recognised by generic-definition
+    /// NAME (the same shape the FLOI family uses, and the cross-assembly nested-generic getter interface does not
+    /// always resolve by AQ), so the recogniser is robust to which interface arm a list/dict element happens to
+    /// surface. SHARED by the read path (<see cref="ReadEngine"/> emits the stored path) and the write coercion
+    /// (<see cref="TryValueType"/> builds a new AssetLink from a path) so the two can't drift on what an asset link
+    /// is — the same one-recogniser discipline the FormLink family uses.</summary>
+    internal static bool IsAssetLinkFamily(Type t)
+    {
+        if (!t.IsGenericType) return false;
+        var n = t.GetGenericTypeDefinition().Name;
+        return n.StartsWith("AssetLink", StringComparison.Ordinal) || n.StartsWith("IAssetLink", StringComparison.Ordinal);
+    }
+
     static void ApplyDictVerb(object parent, PropertyInfo prop, Type dictIface, WriteRequest req)
     {
         // Writable-by-construction: an ABSENT optional dict (null) is materialized so a first entry can be set.
@@ -2519,10 +2534,22 @@ public static class WriteEngine
             return true;
         }
 
-        // Mutagen AssetLink<T> — a path string (texture / model / behavior / …).
-        if (u.IsGenericType && u.GetGenericTypeDefinition() == typeof(Mutagen.Bethesda.Plugins.Assets.AssetLink<>))
+        // Mutagen AssetLink<T> family — a path string (texture / model / sound / …). Recognises the mutable concrete
+        // AssetLink<T>, its getter overlay AssetLinkGetter<T>, AND the IAssetLink(Getter)<T> INTERFACES — because a
+        // COLLECTION element's runtime type is the interface, not the concrete (List<IAssetLinkGetter<T>> /
+        // ExtendedList<IAssetLink<T>>), so the concrete-only check missed every asset-link LIST element (Heisen
+        // 2026-06-26: SoundDescriptor.SoundFiles). Every arm maps to the MUTABLE AssetLink<T> we construct — the same
+        // getter-interface→concrete map TryFormLink does for IFormLinkGetter<T>→FormLink<T> — and AssetLink<T>
+        // implements both interfaces, so the built element assigns into either list. Recognised by the SAME by-name
+        // family predicate the read path uses (IsAssetLinkFamily), so the two surfaces can't drift on what an asset
+        // link is.
+        if (u.IsGenericType && IsAssetLinkFamily(u))
         {
-            if (text != null) result = ConstructFromString(u, text);
+            if (text != null)
+            {
+                var concrete = typeof(Mutagen.Bethesda.Plugins.Assets.AssetLink<>).MakeGenericType(u.GetGenericArguments()[0]);
+                result = ConstructFromString(concrete, text);
+            }
             return true;
         }
 
@@ -2696,8 +2723,19 @@ public static class WriteEngine
                     break;
                 case "list":
                 case "dict":
-                    // scalar/enum/formlink elements are coercion targets; struct elements (ElementTypeRef) are build-cases.
+                    // scalar/enum/formlink elements are coercion targets; modeled-struct/arm/record elements
+                    // (ElementTypeRef) are build-cases — EXCEPT a WHOLE-COERCIBLE element (an AssetLink path), which
+                    // carries an ElementTypeRef yet is SET as one coerced value, not built from parts. The bare
+                    // `ElementTypeRef is null` test mis-skipped those (SoundDescriptor.SoundFiles,
+                    // Weather.CloudTextures) into navOrBuild, hiding them from the audit denominator — the blind spot
+                    // that let the asset-link LIST element ship uncoercible (Heisen 2026-06-26). Route a whole-
+                    // coercible element to the SAME resolve+CanCoerce path the scalar elements take, recognised by the
+                    // SAME predicate the rulebook/classifier use (no drift on what a whole-coercible element is); its
+                    // getter-interface AQ resolves at runtime (verified), so it lands on CanCoerce, not the
+                    // unresolved bucket.
                     if (f.ElementTypeRef is null && f.ElementTypeAssemblyQualified is { } eaq) aq = eaq;
+                    else if (IsWholeCoercibleElement(f.ElementTypeRef, f.ElementTypeAssemblyQualified)
+                             && f.ElementTypeAssemblyQualified is { } weaq) aq = weaq;
                     else { navOrBuild++; continue; }
                     break;
                 case "substruct":
@@ -2811,6 +2849,23 @@ public static class WriteEngine
         };
         if (texAsset is not null)
             samples.Add(("AssetLink<Texture>", typeof(Mutagen.Bethesda.Plugins.Assets.AssetLink<>).MakeGenericType(texAsset), @"textures\hc\test.dds"));
+        // AssetLink INTERFACE forms — the runtime type a COLLECTION element exposes, NOT the concrete: a
+        // List<IAssetLinkGetter<T>> / ExtendedList<IAssetLink<T>> element coerces to the getter/setter INTERFACE,
+        // which the concrete-only rule missed (Heisen 2026-06-26: SoundDescriptor.SoundFiles). Each must build the
+        // mutable AssetLink<T> and be assignable to its interface (what list .Add demands). Both asset TYPES (sound +
+        // texture) and both interface arms (setter + getter) are covered, so the family fix is proven generic, not
+        // sound-special.
+        var sndAsset = typeof(SkyrimMod).Assembly.GetType("Mutagen.Bethesda.Skyrim.Assets.SkyrimSoundAssetType");
+        if (sndAsset is not null)
+        {
+            samples.Add(("IAssetLink<Sound> (setter iface)", typeof(Mutagen.Bethesda.Plugins.Assets.IAssetLink<>).MakeGenericType(sndAsset), @"Sound\fx\hc\test.wav"));
+            samples.Add(("IAssetLinkGetter<Sound> (getter iface)", typeof(Mutagen.Bethesda.Plugins.Assets.IAssetLinkGetter<>).MakeGenericType(sndAsset), @"Sound\fx\hc\test.wav"));
+        }
+        if (texAsset is not null)
+        {
+            samples.Add(("IAssetLink<Texture> (setter iface)", typeof(Mutagen.Bethesda.Plugins.Assets.IAssetLink<>).MakeGenericType(texAsset), @"textures\hc\test2.dds"));
+            samples.Add(("IAssetLinkGetter<Texture> (getter iface)", typeof(Mutagen.Bethesda.Plugins.Assets.IAssetLinkGetter<>).MakeGenericType(texAsset), @"textures\hc\test2.dds"));
+        }
 
         int ok = 0;
         foreach (var (label, type, text) in samples)

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -2748,8 +2748,14 @@ public static class WriteEngine
                     // that let the asset-link LIST element ship uncoercible (Heisen 2026-06-26). Route a whole-
                     // coercible element to the SAME resolve+CanCoerce path the scalar elements take, recognised by the
                     // SAME predicate the rulebook/classifier use (no drift on what a whole-coercible element is); its
-                    // getter-interface AQ resolves at runtime (verified), so it lands on CanCoerce, not the
-                    // unresolved bucket.
+                    // getter-interface AQ resolves at runtime (verified — ci-all green on Linux too), so it lands on
+                    // CanCoerce, not the unresolved bucket.
+                    // COUPLING NOTE: this routes the getter AQ through the shared ResolveType, so the audit here is
+                    // STRICTER than IsWholeCoercibleElement itself — that predicate carries a by-NAME fallback for when
+                    // the cross-assembly nested-generic getter AQ does NOT resolve via Type.GetType, which this branch
+                    // does not. Today every asset-link element's AQ resolves; if a future Mutagen shape stops resolving,
+                    // it lands in `unresolved` → audit RED (loud, Q3-fine — never a silent skip), which is the cue to
+                    // mirror the name-fallback here.
                     if (f.ElementTypeRef is null && f.ElementTypeAssemblyQualified is { } eaq) aq = eaq;
                     else if (IsWholeCoercibleElement(f.ElementTypeRef, f.ElementTypeAssemblyQualified)
                              && f.ElementTypeAssemblyQualified is { } weaq) aq = weaq;

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1951,6 +1951,23 @@ public static class WriteEngine
 
     static void ApplyListVerb(object parent, PropertyInfo prop, Type listIface, WriteRequest req)
     {
+        // ARRAY-backed collection (a C# T[], e.g. Weather.CloudTextures / Weather.Clouds — fixed-size game
+        // structures Mutagen models as a plain array, not a growable ExtendedList). The list verbs assume
+        // ExtendedList semantics (Clear / Add / RemoveAt); an array has none, so without this guard Add / ReplaceAll /
+        // Remove NRE at apply on the missing method, and even materialize of an absent array throws (arrays need a
+        // length) — an UNNAMED accept-then-throw (the schema-only gate accepts the verb). Refuse LOUD and NAMED (Q3):
+        // array-collection mutation is a distinct write mechanism not yet built (some, like Weather clouds, are a
+        // fixed 29-layer format, so an arbitrary-length write may not even serialize validly — it needs its own
+        // investigation). SetAtIndex is refused too: the array may be absent (can't index a null) and a set-only
+        // surface would surprise. Element COERCION is unaffected — this is the collection-shape gap, not the value
+        // gap (an asset-link element coerces fine; see IsAssetLinkFamily). The gate could pre-check IsArray later
+        // (array-ness is schema-visible) to move this to pre-flight — tracked.
+        if (prop.PropertyType.IsArray)
+            throw new ExpectedApplyRejectionException(
+                $"'{prop.Name}' is an array-backed collection ({Pretty(prop.PropertyType)}); Add / ReplaceAll / Remove / " +
+                "SetAtIndex are not yet supported on arrays (some, like Weather clouds, are fixed-size game structures). " +
+                "Tracked gap — array-collection mutation is a distinct write mechanism not yet built.");
+
         // Writable-by-construction: an ABSENT optional list (null) is materialized so a first element can be
         // added — "add a keyword to a record that has none" must work, not throw. Remove on an absent list SURFACES
         // "nothing to remove" (Gap 3 — no silent no-op; the value/index is trivially not present when the whole list is

--- a/src/housecarl-generator/AssetLinkWriteProbe.cs
+++ b/src/housecarl-generator/AssetLinkWriteProbe.cs
@@ -59,6 +59,11 @@ public static class AssetLinkWriteProbe
             replaceAll: new[] { @"Sound\fx\hc\bardsong\one.wav", @"Sound\fx\hc\bardsong\two.wav", @"Sound\fx\hc\bardsong\three.wav" },
             add: @"Sound\fx\hc\bardsong\four.wav");
 
+        // The OTHER asset-link list, Weather.CloudTextures, is ARRAY-backed (IAssetLink<T>[]) — a separate, not-yet-built
+        // write mechanism. It must refuse LOUD and NAMED at apply (an "array-backed" ExpectedApplyRejection), NOT the
+        // silent NRE it threw before this guard. Asserts the honest boundary, so a future array-write build flips it green.
+        RunArrayRefusalCase(results, rulebook);
+
         Console.WriteLine();
         bool allPass = true;
         foreach (var (name, pass, detail) in results)
@@ -69,8 +74,8 @@ public static class AssetLinkWriteProbe
         }
         Console.WriteLine();
         Console.WriteLine(allPass
-            ? "=== PASS: asset-link list elements author end-to-end (gate accepts, apply coerces, paths round-trip) ==="
-            : "=== FAIL: an asset-link list element did not author cleanly (read the !! lines) ===");
+            ? "=== PASS: ExtendedList asset-link element authors end-to-end (round-trips); array-backed one refuses LOUD ==="
+            : "=== FAIL: an asset-link list element did not behave as required (read the !! lines) ===");
         return allPass ? 0 : 1;
     }
 
@@ -124,6 +129,42 @@ public static class AssetLinkWriteProbe
         {
             var e = ex.InnerException ?? ex;
             results.Add((label, false, $"threw {e.GetType().Name}: {e.Message}"));
+        }
+    }
+
+    /// <summary>The honest-boundary arm: an ARRAY-backed asset-link list (Weather.CloudTextures, IAssetLink&lt;T&gt;[])
+    /// must refuse a list verb with a clean, NAMED <see cref="ExpectedApplyRejectionException"/> ("array-backed"), NOT
+    /// the silent NullReferenceException it threw before the guard. Drives the REAL ApplyVerb and asserts the refusal
+    /// kind + wording (RED if it NREs again, or wrongly succeeds — which is the signal a future array-write build is in).</summary>
+    static void RunArrayRefusalCase(List<(string, bool, string)> results, CorpusRulebook rulebook)
+    {
+        const string label = "Weather.CloudTextures (array-backed) — refuses LOUD, not NRE";
+        try
+        {
+            var pc = new SkyrimMod(new ModKey("HcAssetLinkWthr", ModType.Plugin), SkyrimRelease.SkyrimSE);
+            var wthr = pc.Weathers.AddNew("HC_WTHR_AssetLink");
+            var op = new WriteRequest { RecordType = "Weather", Path = new[] { "CloudTextures" }, Verb = "ReplaceAll",
+                                        Values = new[] { @"textures\hc\sky\cloud0.dds", @"textures\hc\sky\cloud1.dds" } };
+            try
+            {
+                WriteEngine.ApplyVerb(wthr, op);
+                results.Add((label, false, "ApplyVerb SUCCEEDED on an array-backed list — array-write may now be implemented; update this guard."));
+            }
+            catch (ExpectedApplyRejectionException ex)
+            {
+                bool named = ex.Message.Contains("array-backed", StringComparison.OrdinalIgnoreCase);
+                results.Add((label, named, $"refused as {nameof(ExpectedApplyRejectionException)}: \"{ex.Message}\""));
+            }
+            catch (Exception ex)
+            {
+                var e = ex.InnerException ?? ex;
+                results.Add((label, false, $"threw {e.GetType().Name} (want a NAMED ExpectedApplyRejectionException, not this): {e.Message}"));
+            }
+        }
+        catch (Exception ex)
+        {
+            var e = ex.InnerException ?? ex;
+            results.Add((label, false, $"setup threw {e.GetType().Name}: {e.Message}"));
         }
     }
 }

--- a/src/housecarl-generator/AssetLinkWriteProbe.cs
+++ b/src/housecarl-generator/AssetLinkWriteProbe.cs
@@ -29,8 +29,10 @@ namespace HousecarlGenerator;
 /// (Clear/Add) at all (a SEPARATE, pre-existing array-backed-collection write gap, shared with <c>Weather.Clouds</c>,
 /// independent of asset-link coercion). It is deliberately NOT tested here; the coercion fix is proven by the sound case.
 ///
-/// Self-contained: synthesises the record in a fresh plugin in TEMP and generates the validator corpus BY CONSTRUCTION
-/// in-process (no game data, no checked-in corpus.json). Run: dotnet run --project src/housecarl-generator assetlink-write-guard
+/// Self-contained: synthesises the record + plugin in a fresh <c>SkyrimMod</c> in TEMP (no game data). The validator
+/// corpus is the SHARED one loaded via <see cref="CorpusRulebook.Load"/> (<c>CorpusRulebook.CorpusPath</c> — the
+/// canonicalCorpus the ci-all runner pre-generates, or <c>generated/corpus.json</c> for a standalone run); this probe
+/// does NOT generate it. Run: dotnet run --project src/housecarl-generator assetlink-write-guard
 /// </summary>
 public static class AssetLinkWriteProbe
 {

--- a/src/housecarl-generator/AssetLinkWriteProbe.cs
+++ b/src/housecarl-generator/AssetLinkWriteProbe.cs
@@ -1,0 +1,129 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SELF-CONTAINED CI REGRESSION GUARD for AUTHORING ASSET-LINK LIST ELEMENTS (Heisen 2026-06-26:
+/// "cannot author SoundDescriptor.SoundFiles (IAssetLink list elements)"). A collection of asset-link paths
+/// (<c>List&lt;IAssetLinkGetter&lt;T&gt;&gt;</c> / <c>ExtendedList&lt;IAssetLink&lt;T&gt;&gt;</c>) exposes its element as the
+/// getter/setter INTERFACE, not the concrete <c>AssetLink&lt;T&gt;</c> — and the coercion layer recognised only the
+/// concrete, so EVERY asset-link list element failed pre-flight ("does not coerce to IAssetLinkGetter`1") and apply.
+/// The fix teaches the coercion family-recogniser (<see cref="WriteEngine.IsAssetLinkFamily"/>) the interface arms and
+/// builds the mutable <c>AssetLink&lt;T&gt;</c> from a path string — the same getter-interface→concrete map FormLink uses.
+///
+/// This guard drives the FULL author chain end-to-end for <c>SoundDescriptor.SoundFiles</c> (Heisen's exact case, an
+/// <c>ExtendedList&lt;IAssetLink&lt;SkyrimSoundAssetType&gt;&gt;</c>):
+///   (G) pre-flight <see cref="CorpusRulebook.Validate"/> ACCEPTS the ReplaceAll + Add the report saw REJECTED
+///       ("does not coerce to IAssetLinkGetter`1") — RED if that rejection returns;
+///   (A) <see cref="WriteEngine.ApplyVerb"/> coerces+adds each element (builds the mutable AssetLink&lt;T&gt; from a path);
+///   (S) the plugin serialises and re-reads with every path round-tripped verbatim in order — proving the built element
+///       assigns into the real ExtendedList and survives the binary round-trip.
+/// The COERCION's genericity over asset TYPE (sound vs texture, getter vs setter interface) is locked separately by
+/// <c>coerce-selftest</c>, and BOTH asset-link list elements are asserted coercible by <c>coerce-audit</c>.
+///
+/// SCOPE NOTE — the corpus models exactly ONE other asset-link list, <c>Weather.CloudTextures</c>, but its mutable type
+/// is a C# ARRAY (<c>IAssetLink&lt;T&gt;[]</c>), not an ExtendedList — so it can't be authored through the list verbs
+/// (Clear/Add) at all (a SEPARATE, pre-existing array-backed-collection write gap, shared with <c>Weather.Clouds</c>,
+/// independent of asset-link coercion). It is deliberately NOT tested here; the coercion fix is proven by the sound case.
+///
+/// Self-contained: synthesises the record in a fresh plugin in TEMP and generates the validator corpus BY CONSTRUCTION
+/// in-process (no game data, no checked-in corpus.json). Run: dotnet run --project src/housecarl-generator assetlink-write-guard
+/// </summary>
+public static class AssetLinkWriteProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" assetlink-write-guard — author an asset-link list element end-to-end (SoundDescriptor.SoundFiles)");
+        Console.WriteLine("================================================================");
+
+        var rulebook = CorpusRulebook.Load();
+        var tmp = Path.Combine(Path.GetTempPath(), "hc-assetlink-write-guard");
+        if (Directory.Exists(tmp)) Directory.Delete(tmp, recursive: true);
+        Directory.CreateDirectory(tmp);
+
+        var results = new List<(string name, bool pass, string detail)>();
+
+        // Heisen's exact paths shape — Sound\fx\... for the SNDR, textures\... for the WTHR. The verbatim round-trip is
+        // the proof, so the values are distinctive.
+        RunCase(results, tmp, rulebook,
+            label: "SoundDescriptor.SoundFiles (AssetLink<SkyrimSoundAssetType>)",
+            outName: "HcAssetLinkSndr.esp",
+            recordType: "SoundDescriptor",
+            field: "SoundFiles",
+            addRecord: m => { var r = m.SoundDescriptors.AddNew("HC_SNDR_AssetLink"); return r.FormKey; },
+            readBack: (back, fk) => back.SoundDescriptors.First(x => x.FormKey == fk).SoundFiles?.Select(a => a.GivenPath).ToList(),
+            replaceAll: new[] { @"Sound\fx\hc\bardsong\one.wav", @"Sound\fx\hc\bardsong\two.wav", @"Sound\fx\hc\bardsong\three.wav" },
+            add: @"Sound\fx\hc\bardsong\four.wav");
+
+        Console.WriteLine();
+        bool allPass = true;
+        foreach (var (name, pass, detail) in results)
+        {
+            Console.WriteLine($"  [{(pass ? "PASS" : "!! FAIL")}] {name}");
+            Console.WriteLine($"            {detail}");
+            if (!pass) allPass = false;
+        }
+        Console.WriteLine();
+        Console.WriteLine(allPass
+            ? "=== PASS: asset-link list elements author end-to-end (gate accepts, apply coerces, paths round-trip) ==="
+            : "=== FAIL: an asset-link list element did not author cleanly (read the !! lines) ===");
+        return allPass ? 0 : 1;
+    }
+
+    /// <summary>Drive one asset-link list element through the full author chain (gate → apply → serialise → re-read),
+    /// asserting the ReplaceAll contents + the appended Add survive verbatim and in order.</summary>
+    static void RunCase(
+        List<(string, bool, string)> results, string tmp, CorpusRulebook rulebook,
+        string label, string outName, string recordType, string field,
+        Func<SkyrimMod, FormKey> addRecord,
+        Func<ISkyrimModGetter, FormKey, List<string?>?> readBack,
+        string[] replaceAll, string add)
+    {
+        var expected = replaceAll.Append(add).ToList();   // ReplaceAll sets the contents; Add appends one more
+        try
+        {
+            var pc = new SkyrimMod(new ModKey(Path.GetFileNameWithoutExtension(outName), ModType.Plugin), SkyrimRelease.SkyrimSE);
+            var fk = addRecord(pc);
+            var rec = pc.EnumerateMajorRecords().First(r => r.FormKey == fk);
+
+            var ops = new[]
+            {
+                new WriteRequest { RecordType = recordType, Path = new[] { field }, Verb = "ReplaceAll", Values = replaceAll },
+                new WriteRequest { RecordType = recordType, Path = new[] { field }, Verb = "Add", Value = add },
+            };
+
+            // (G) the gate must ACCEPT both — the report saw "does not coerce to IAssetLinkGetter`1" here.
+            foreach (var op in ops)
+                if (rulebook.Validate(op) is { } reject)
+                {
+                    results.Add((label, false, $"GATE REJECTED [{op.Verb} {field}]: {reject}"));
+                    return;
+                }
+
+            // (A) apply each through the real verb engine (coerce → build mutable AssetLink<T> → add to the list).
+            foreach (var op in ops)
+                WriteEngine.ApplyVerb(rec, op);
+
+            // (S) serialise the self-contained plugin (no masters — the paths reference no forms) and re-read.
+            var outPath = Path.Combine(tmp, outName);
+            pc.BeginWrite.ToPath(outPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            using var back = SkyrimMod.CreateFromBinaryOverlay(outPath, SkyrimRelease.SkyrimSE);
+            var got = readBack(back, fk);
+
+            bool roundTrips = got is not null && got.Count == expected.Count
+                && got.Zip(expected, (a, b) => string.Equals(a, b, StringComparison.Ordinal)).All(x => x);
+            var gotStr = got is null ? "(null)" : "[" + string.Join(", ", got) + "]";
+            results.Add((label, roundTrips,
+                $"gate accepted; applied ReplaceAll({replaceAll.Length}) + Add(1); re-read {gotStr} (want [{string.Join(", ", expected)}])"));
+        }
+        catch (Exception ex)
+        {
+            var e = ex.InnerException ?? ex;
+            results.Add((label, false, $"threw {e.GetType().Name}: {e.Message}"));
+        }
+    }
+}

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -93,6 +93,12 @@ public static class CiAll
         ("place-asset-guard", PlaceAssetProbe.RunGuard),
         ("strings-decision-guard", StringsDecisionProbe.RunGuard),
         ("assetlink-write-guard", AssetLinkWriteProbe.RunGuard),
+        // The two coercion COMPLETENESS proofs, now CI guards (were manual-only — the coerce-audit blind spot that
+        // shipped the asset-link gap showed a manual proof silently goes stale). Both are self-contained: selftest is
+        // pure; audit reads the shared canonicalCorpus via CorpusRulebook.CorpusPath (set per-probe by RunAll, empty
+        // args here → it uses that path). Each returns 0/1 like any guard.
+        ("coerce-selftest", WriteEngine.RunCoerceSelftest),
+        ("coerce-audit", WriteEngine.RunCoerceAudit),
     };
 
     /// <summary>Dispatch a single CI guard by name through the registry — the ONE place a CI probe is listed, so

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -92,6 +92,7 @@ public static class CiAll
         ("atomic-commit-guard", AtomicCommitProbe.RunGuard),
         ("place-asset-guard", PlaceAssetProbe.RunGuard),
         ("strings-decision-guard", StringsDecisionProbe.RunGuard),
+        ("assetlink-write-guard", AssetLinkWriteProbe.RunGuard),
     };
 
     /// <summary>Dispatch a single CI guard by name through the registry — the ONE place a CI probe is listed, so

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -87,11 +87,8 @@ if (args.Length > 0 && args[0] == "header-probe") return Wave5Probe.RunHeaderPro
 // Wave 5 scout: the PEX read->write round-trip GATE (project_pex_prefer_source_policy) — the wave-5 unknown.
 if (args.Length > 0 && args[0] == "pex-probe") return Wave5Probe.RunPexProbe(args[1..]);
 
-// Coercion completeness guard: corpus-derived audit of every writable value-leaf's coercibility.
-if (args.Length > 0 && args[0] == "coerce-audit") return WriteEngine.RunCoerceAudit(args[1..]);
-
-// Coercion construction self-test: confirms each value-type rule builds a valid, assignable instance.
-if (args.Length > 0 && args[0] == "coerce-selftest") return WriteEngine.RunCoerceSelftest(args[1..]);
+// NOTE: coerce-audit + coerce-selftest are now CI guards in CiAll.Probes (the ONE CI source of truth, dispatched
+// for single runs via CiAll.TryDispatch at the top of this file) — no separate dispatch here, by design.
 
 // Step 7 write-surface census: corpus-derived reachability map of every writable leaf (the completeness scoreboard).
 if (args.Length > 0 && args[0] == "write-census") return WriteCensus.Run(args[1..]);


### PR DESCRIPTION
Pauses the roadmap to fix Heisen's bug report (`2026-06-26_gap_sounddescriptor-soundfiles-assetlink.md`): **cannot author `SoundDescriptor.SoundFiles` (IAssetLink list elements)**. Three atomic commits.

## The bug
A `SoundFiles` element is `List<IAssetLinkGetter<T>>` / `ExtendedList<IAssetLink<T>>` — its runtime element type is the getter/setter **interface**, not the concrete `AssetLink<T>`. The coercion layer recognised only the concrete, so every asset-link **list** element failed pre-flight (`"does not coerce to IAssetLinkGetter\`1"`) **and** apply. Singular asset-link fields worked; only list elements were unreachable.

## Commits
1. **`88db2a2` fix(write): coerce AssetLink list elements.** `TryValueType` recognises the whole AssetLink family by a shared by-name predicate (`IsAssetLinkFamily` — concrete, overlay, both interface arms) and builds the mutable `AssetLink<T>` from the path string — the same getter-interface→concrete map `TryFormLink` already uses. `ReadEngine` delegates to the one shared predicate (no read/write drift). Also closes a **`coerce-audit` blind spot**: it was skipping whole-coercible elements that carry an `ElementTypeRef` as "build-cases", silently excluding the two asset-link elements from the completeness denominator (hard targets 7409 → 7411).
2. **`4a66df4` fix(write): refuse array-backed collection verbs LOUD.** Finding surfaced during the fix: `Weather.CloudTextures` / `Weather.Clouds` are array-backed (`T[]`), so the list verbs NRE'd at apply (an unnamed accept-then-throw). `ApplyListVerb` now refuses them with a clean NAMED `ExpectedApplyRejectionException`. Array-collection mutation itself is a distinct, **not-yet-built** mechanism (Weather clouds are a fixed 29-layer format) — tracked, surfaced honestly, not silently crashed.
3. **`be4acaf` test(ci): promote coerce-audit + coerce-selftest into ci-all.** They were manual-only; the audit blind spot just showed a manual proof goes stale. Now live CI guards (registry = one source of truth).

## Proof
- `coerce-selftest`: **19/19** (both asset types × both interface arms construct + assignable).
- `coerce-audit`: **PASS**, +2 coverage, no uncoercible / unresolved.
- New `assetlink-write-guard`: SoundFiles authored end-to-end (gate accepts → apply coerces → serialize → re-read, paths round-trip verbatim); CloudTextures refuses LOUD.
- **`ci-all`: 59/59** (no regressions; +1 new guard, +2 promoted).

## Notes
- The shipped plugin (Nexus/GitHub) picks this up on the next **repackage**; no version bump in this PR.
- Both findings (#1 array loud-fail, #2 CI promotion) were Aaron-decided before implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)