### PR TITLE
feat(remap): RemapEngine — compact/merge Wave 1 foundation

### DIFF
--- a/src/housecarl-core/RemapEngine.cs
+++ b/src/housecarl-core/RemapEngine.cs
@@ -1,0 +1,352 @@
+using System.Reflection;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+
+namespace HousecarlCore;
+
+/// <summary>
+/// The shared foundation under the plugin-surgery cluster — compact (renumber a plugin into the ESL range), merge
+/// (combine plugins into a new one), and their ride-alongs (COMPACT_MERGE_PLAN_2026-06-26 §3). All four operations
+/// reduce to the SAME three primitives this engine exposes; the compact/merge MCP tools (later waves) are thin policy
+/// layers over them. Built index-free on Mutagen's forward <c>RemapLinks</c> pass (the reverse-ref index is deferred,
+/// for its own value — pre-check 2026-06-26: speed/feature fix, NOT a dependency).
+///
+/// THE MECHANISM, pinned empirically (remap-wave1-mech, this session) — the plan's §4 "assign new FormIDs in place"
+/// was a TRAP and is NOT what we do:
+///   • <c>mod.RemapLinks(old→new dict)</c> repoints a record's OUTGOING references ONLY — it does NOT move a record's
+///     own identity. (Wave-0 proved this half; the mechanism probe re-confirmed it.)
+///   • A record's own <c>FormKey</c> setter IS reachable but is NON-PUBLIC, and setting it leaves the FormKey-keyed
+///     group cache STALE (ContainsKey(new)=false, ContainsKey(old)=true) — a silent-corruption trap. REJECTED.
+///   • The CORRECT renumber is the PUBLIC <c>record.Duplicate(newFormKey)</c> (Mutagen's blessed deep-copy under a new
+///     identity) into a FRESH mod, then <c>RemapLinks(dict)</c> to repoint the internal references. The fresh target
+///     starts empty, so renumbering never collides with an as-yet-unmoved record. Group state stays consistent.
+///
+/// COVERAGE BOUNDARY (Q3, honest — never a silent drop):
+///   • <see cref="IdentifyExternalReferencers"/> and <see cref="RepointInPlace"/> handle EVERY record type — they only
+///     read/mutate a record's outgoing links (Mutagen's by-construction <see cref="IFormLinkContainerGetter"/> surface),
+///     which is nesting-agnostic. Full coverage.
+///   • <see cref="RenumberRecordsInto"/> places duplicated records via the FLAT top-level groups
+///     (<see cref="WriteEngine.EnumerateFlatGroups"/>). Records that live ONLY in NESTED groups (Cell, the Placed*
+///     family, INFO under a topic, navmesh, landscape) have no flat group and are REFUSED LOUD here — the nested
+///     duplicate-into placement is the next wave's work, not silently skipped.
+///
+/// At-rest discipline (Option B / CLAUDE.md §1): every method opens at most ONE plugin mutable at a time
+/// (<c>CreateFromBinary</c>, the anti-trap single-plugin lane) and disposes master overlays after the write — the
+/// load order is never held parsed.
+/// </summary>
+public static class RemapEngine
+{
+    /// <summary>The light-master object-ID window, pinned empirically by EslFormIdProbe against Mutagen 0.53.1:
+    /// an object ID &lt; <see cref="EslFloor"/> throws <c>LowerFormKeyRangeDisallowedException</c> (the general lower
+    /// floor) and one &gt; <see cref="EslCeiling"/> throws <c>FormIDCompactionOutOfBoundsException</c> (the ESL-specific
+    /// ceiling, only when the mod is flagged light). The usable window is therefore 0x800–0xFFF INCLUSIVE = 2048 IDs —
+    /// NOT the 4096 the build plan's draft refuse-threshold assumed; that reconciliation lands when the compact tool
+    /// ships (Wave 2). Compact assigns into this window; the capacity check in <see cref="BuildSequentialRemap"/> enforces it.</summary>
+    public const uint EslFloor = 0x800;
+    public const uint EslCeiling = 0xFFF;
+
+    // ======================================================================
+    //  1. IDENTIFY-PASS  — the per-operation reverse-walk (plan §2 / §3)
+    // ======================================================================
+
+    /// <summary>One external reference into the transform set: a record in a plugin OUTSIDE the set whose outgoing link
+    /// points at a FormKey being remapped. After the transform that link resolves wrong / dangles unless the referencer
+    /// is repointed too (<see cref="RepointInPlace"/>).</summary>
+    public sealed record ExternalRef(string Plugin, FormKey Source, string SourceType, FormKey Target);
+
+    /// <summary>The identify-pass result: every external reference found, the DISTINCT referencing plugins (load order,
+    /// the opt-in-rewrite set), how many plugins were scanned, and the per-record fault-isolation accounting (a record
+    /// whose link walk threw is counted + sampled, never a silent skip — Q3).</summary>
+    public sealed record IdentifyResult(
+        IReadOnlyList<ExternalRef> Refs,
+        IReadOnlyList<string> ExternalPlugins,
+        int PluginsScanned,
+        int UnscannableRecords,
+        IReadOnlyList<string> UnscannableSamples)
+    {
+        /// <summary>True when at least one plugin OUTSIDE the transform set references a remapped FormKey — the
+        /// signal the default new-plugin path must NOT take silently (plan §2: fail loud + offer opt-in rewrite).</summary>
+        public bool HasExternalReferencers => ExternalPlugins.Count > 0;
+    }
+
+    /// <summary>
+    /// Walk the whole active order and find which plugins OUTSIDE <paramref name="transformSet"/> reference any FormKey
+    /// in <paramref name="targets"/> (the keys about to be remapped). This is the per-operation safety enumeration the
+    /// plan keeps the reverse-walk for (NOT a held index): ~25 s at 3520-plugin scale (one whole-order link walk).
+    ///
+    /// The exact inverse of <see cref="ErrorCheck"/>'s loop: there, a link is a finding if it does NOT resolve; here, a
+    /// link is a finding if its target is in the remap set. Per-record fault isolation is identical (Q3 — one record
+    /// Mutagen can't parse is counted + sampled, never an opaque whole-call abort and never a silent skip). One
+    /// <see cref="LoadOrderResolver.Capture"/> pins the whole pass; the resolver streams one plugin at a time (Option B).
+    /// </summary>
+    public static IdentifyResult IdentifyExternalReferencers(
+        LoadOrderResolver resolver, IReadOnlySet<FormKey> targets, IReadOnlySet<string> transformSet)
+    {
+        var view = resolver.Capture();
+        var refs = new List<ExternalRef>();
+        var externalPlugins = new List<string>();        // load-order order, distinct
+        int scanned = 0, unscannable = 0;
+        var unscannableSamples = new List<string>();
+
+        foreach (var plugin in resolver.PluginNames)
+        {
+            if (transformSet.Contains(plugin)) continue;                 // inside the set → its refs are INTERNAL (RemapLinks handles them)
+            if (view.ExcludedPlugins.ContainsKey(plugin)) continue;      // unparseable at build — already surfaced by the resolver
+            scanned++;
+            bool pluginListed = false;
+
+            try
+            {
+                foreach (var (fk, _, body, _) in view.RecordsIn(new[] { plugin }, null))
+                {
+                    // PER-RECORD fault isolation (twin of cross_plugin_query / ErrorCheck): EnumerateFormLinks lazily
+                    // parses subrecord content, so ONE record Mutagen can't parse is counted + sampled, never an opaque
+                    // whole-call abort and never a silent skip (Q3).
+                    try
+                    {
+                        if (body is not IFormLinkContainerGetter flc) continue;
+                        foreach (var link in flc.EnumerateFormLinks())
+                        {
+                            var t = link.FormKey;
+                            if (t.IsNull || !targets.Contains(t)) continue;
+                            refs.Add(new ExternalRef(plugin, fk, RecordNaming.StripOverlay(body.GetType().Name), t));
+                            if (!pluginListed) { externalPlugins.Add(plugin); pluginListed = true; }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        unscannable++;
+                        if (unscannableSamples.Count < 5) unscannableSamples.Add($"{plugin} {fk} — {ex.GetType().Name}: {ex.Message}");
+                    }
+                }
+            }
+            // The plugin enumeration itself faulting (a record that throws on top-level enumeration rather than on a
+            // link walk) is counted per-plugin and the pass continues — never an opaque whole-pass abort (Q3).
+            catch (Exception ex)
+            {
+                unscannable++;
+                if (unscannableSamples.Count < 5) unscannableSamples.Add($"{plugin} — record enumeration aborted: {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+
+        return new IdentifyResult(refs, externalPlugins, scanned, unscannable, unscannableSamples);
+    }
+
+    // ======================================================================
+    //  2. BUILD-REMAP-DICT — collision-free new-FormID allocation (plan §3)
+    // ======================================================================
+
+    /// <summary>A planned remap: the old→new FormKey map, or a loud Q3 refusal (e.g. the source overflows the target
+    /// window) with no map.</summary>
+    public sealed record RemapPlan(IReadOnlyDictionary<FormKey, FormKey> Dict, string? Error)
+    {
+        public bool Success => Error is null;
+        public static RemapPlan Fail(string error) => new(new Dictionary<FormKey, FormKey>(), error);
+    }
+
+    /// <summary>
+    /// Assign each FormKey in <paramref name="sourceKeys"/> a NEW FormKey under <paramref name="targetModKey"/>, object
+    /// IDs running sequentially from <paramref name="floor"/> through <paramref name="ceiling"/> INCLUSIVE, in the
+    /// given order. Collision-free by construction (sequential, distinct). REFUSES LOUD (Q3) if the source count
+    /// exceeds the window capacity — for an ESL compaction that is the real "> 2048 records can't be light-compacted"
+    /// limit (floor/ceiling = <see cref="EslFloor"/>/<see cref="EslCeiling"/>); it is NAMED, never a truncation.
+    /// Duplicate source keys collapse to one mapping (deterministic — first occurrence wins the next ID).
+    /// </summary>
+    public static RemapPlan BuildSequentialRemap(
+        IReadOnlyList<FormKey> sourceKeys, ModKey targetModKey, uint floor, uint ceiling)
+    {
+        if (ceiling < floor) return RemapPlan.Fail($"invalid remap window: ceiling 0x{ceiling:X} < floor 0x{floor:X}.");
+        var dict = new Dictionary<FormKey, FormKey>();
+        uint next = floor;
+        long capacity = (long)ceiling - floor + 1;
+        foreach (var key in sourceKeys)
+        {
+            if (dict.ContainsKey(key)) continue;                          // de-dupe: one mapping per source key
+            if (dict.Count >= capacity)
+                return RemapPlan.Fail(
+                    $"cannot remap {sourceKeys.Distinct().Count()} records into the window 0x{floor:X}–0x{ceiling:X} " +
+                    $"({capacity} IDs): the source overflows it. For an ESL compaction this is the hard light-master " +
+                    "ceiling — the plugin has too many records to fit the light range; it cannot be compacted to light. Named, not truncated (Q3).");
+            dict[key] = new FormKey(targetModKey, next);
+            next++;
+        }
+        return new RemapPlan(dict, null);
+    }
+
+    // ======================================================================
+    //  3a. RENUMBER INTO A FRESH MOD — build P′ / M (plan §4 / §5)
+    // ======================================================================
+
+    /// <summary>The result of building a renumbered mod: how many source records were copied in and how many of those
+    /// were actually renumbered (in the dict), or a loud Q3 refusal (a nested-group record with no flat placement;
+    /// a duplicate/add engine fault) with NOTHING half-built that the caller would ship.</summary>
+    public sealed record RenumberResult(bool Success, string? Error, int RecordsCopied, int RecordsRenumbered)
+    {
+        public static RenumberResult Fail(string error) => new(false, error, 0, 0);
+    }
+
+    /// <summary>
+    /// Copy <paramref name="sources"/> into the (typically fresh) mod <paramref name="target"/>, each under its new
+    /// FormKey from <paramref name="dict"/> (a source NOT in the dict — e.g. an override the compaction leaves at its
+    /// master's FormID — is copied at its OWN key), then <c>RemapLinks(dict)</c> over the whole target so every INTERNAL
+    /// reference among the copied records resolves to the new keys. This is the shared core of compact (one plugin's
+    /// records → P′) and merge (several donors' records → M).
+    ///
+    /// Uses the PUBLIC <c>record.Duplicate(newKey)</c> (Mutagen's deep-copy under a new identity) — NOT the non-public
+    /// FormKey setter (that corrupts the group cache; see the class remark). Placement is via the flat top-level groups;
+    /// a record that has no flat group (a nested-only family — Cell, Placed*, INFO, navmesh, landscape) is REFUSED LOUD
+    /// (Q3): the nested duplicate-into path is a later wave, and a silent skip would ship a plugin missing records.
+    /// </summary>
+    public static RenumberResult RenumberRecordsInto(
+        SkyrimMod target, IEnumerable<IMajorRecordGetter> sources, IReadOnlyDictionary<FormKey, FormKey> dict)
+    {
+        int copied = 0, renumbered = 0;
+        foreach (var rec in sources)
+        {
+            bool isRenumber = dict.TryGetValue(rec.FormKey, out var newKey);
+            if (!isRenumber) newKey = rec.FormKey;                        // unmapped (e.g. an override) — copy at its own key
+
+            IMajorRecord dup;
+            try { dup = rec.Duplicate(newKey); }
+            catch (Exception ex)
+            {
+                return RenumberResult.Fail(
+                    $"could not duplicate {RecordNaming.StripOverlay(rec.GetType().Name)} {rec.FormKey} under {newKey} " +
+                    $"({WriteEngine.Describe(ex)}) — the renumber is abandoned with nothing shippable (Q3).");
+            }
+
+            if (!TryAddToFlatGroup(target, dup))
+                return RenumberResult.Fail(
+                    $"{RecordNaming.StripOverlay(rec.GetType().Name)} {rec.FormKey} lives only in a NESTED group (Cell / placed " +
+                    "ref / INFO / navmesh / landscape), which has no flat top-level group to place the duplicate into. The nested " +
+                    "duplicate-into placement is a later wave — refusing rather than silently dropping the record (Q3).");
+
+            copied++;
+            if (isRenumber) renumbered++;
+        }
+
+        // Repoint every internal reference among the copied records to the new keys. Flat AND nested links are remapped
+        // (RemapLinks walks all outgoing links); the nested-group limit above is about PLACING records, not repointing.
+        target.RemapLinks(dict);
+        return new RenumberResult(true, null, copied, renumbered);
+    }
+
+    /// <summary>Place an already-constructed record into the target mod's matching flat top-level group via the group's
+    /// own <c>Add</c>, reusing the single <see cref="WriteEngine.EnumerateFlatGroups"/> enumeration the create/override
+    /// surface derives from (no drift). An abstract group (e.g. <c>SkyrimGroup&lt;Global&gt;</c>) matches its concrete arm
+    /// (<c>GlobalFloat</c>) because <c>tMajor.IsInstanceOfType(dup)</c> holds and <c>Add(Global)</c> accepts the subtype.
+    /// Returns false when no flat group fits (a nested-only record) — the caller fails loud.</summary>
+    static bool TryAddToFlatGroup(SkyrimMod target, IMajorRecord dup)
+    {
+        foreach (var (prop, tMajor, _) in WriteEngine.EnumerateFlatGroups(target.GetType()))
+        {
+            if (!tMajor.IsInstanceOfType(dup)) continue;
+            var group = prop.GetValue(target)
+                ?? throw new InvalidOperationException($"flat group '{prop.Name}' was null on the target mod (engine inconsistency, Q3).");
+            var add = group.GetType().GetMethod("Add", new[] { tMajor })
+                      ?? group.GetType().GetMethods()
+                          .FirstOrDefault(m => m.Name == "Add" && m.GetParameters().Length == 1
+                                               && m.GetParameters()[0].ParameterType.IsInstanceOfType(dup));
+            if (add is null)
+                throw new InvalidOperationException(
+                    $"flat group '{prop.Name}' ({group.GetType().Name}) exposes no Add accepting {dup.GetType().Name} (Q3).");
+            add.Invoke(group, new object[] { dup });
+            return true;
+        }
+        return false;
+    }
+
+    // ======================================================================
+    //  3b. STREAMING APPLIER — repoint an existing plugin's refs IN PLACE (plan §2/§3)
+    // ======================================================================
+
+    /// <summary>The result of an in-place repoint: success + the on-disk byte size, or a loud Q3 refusal (target not
+    /// active / excluded / not on disk / a declared master absent / a sub-0x800 originating record / a serialize fault)
+    /// with the file UNTOUCHED.</summary>
+    public sealed record RepointResult(bool Success, string? Error, long Bytes, int LinksConsidered)
+    {
+        public static RepointResult Fail(string error) => new(false, error, 0, 0);
+    }
+
+    /// <summary>
+    /// Repoint plugin <paramref name="pluginName"/>'s outgoing references against <paramref name="dict"/> IN PLACE — the
+    /// streaming applier for an EXTERNAL referencer (a plugin outside the transform set that the identify-pass found
+    /// pointing at a remapped record). This rides the existing in-place write lane (the modder's opt-in: explicit flag
+    /// + per-plugin consent + no backup, enforced by the service before this is reached). The default new-plugin path
+    /// NEVER calls this — only the explicit external-referencer rewrite does.
+    ///
+    /// EAGER-loads the SINGLE plugin mutable (<c>CreateFromBinary</c> — never the order; the legacy RAM trap), applies
+    /// <c>RemapLinks(dict)</c> (every outgoing link, flat AND nested), resolves the target's OWN declared masters to
+    /// overlays, and re-serializes over itself via <see cref="WriteEngine.WriteInPlace"/> (own masters, counter verbatim,
+    /// no baseline force-include — the xEdit-parity re-emit, staged + crash-atomically swapped). All-or-nothing: any
+    /// refusal or serialize fault leaves the original file byte-intact. A sub-0x800 originating record (a vanilla master)
+    /// makes the write throw <c>LowerFormKeyRangeDisallowed</c> — surfaced LOUD here, never a silent partial write (Q3).
+    /// </summary>
+    public static RepointResult RepointInPlace(
+        LoadOrderResolver resolver, string pluginName, IReadOnlyDictionary<FormKey, FormKey> dict)
+    {
+        if (dict.Count == 0) return RepointResult.Fail("no remap entries supplied — nothing to repoint.");
+        var view = resolver.Capture();
+        if (!view.ContainsPlugin(pluginName))
+            return RepointResult.Fail($"repoint target '{pluginName}' is not an active plugin in the load order.");
+        if (view.ExcludedPlugins.TryGetValue(pluginName, out var excluded))
+            return RepointResult.Fail(
+                $"cannot repoint '{pluginName}' in place: it was EXCLUDED from this session ({excluded}) — houseCARL won't " +
+                "re-serialize a plugin it can't fully parse (it would risk dropping the record it couldn't read, Q3). The file is UNTOUCHED.");
+
+        var path = view.PluginPath(pluginName);
+        if (path is null || !File.Exists(path))
+            return RepointResult.Fail($"repoint target '{pluginName}' not found on disk at {path ?? "<unresolved>"} — the file is untouched.");
+
+        SkyrimMod targetMod;
+        try { targetMod = SkyrimMod.CreateFromBinary(path, SkyrimRelease.SkyrimSE); }
+        catch (Exception ex)
+        {
+            return RepointResult.Fail(
+                $"cannot open '{pluginName}' to repoint in place ({WriteEngine.Describe(ex)}) — a plugin Mutagen can't parse is " +
+                "refused, not re-emitted minus what it couldn't read (Q3). The file is UNTOUCHED.");
+        }
+
+        try { targetMod.RemapLinks(dict); }
+        catch (Exception ex)
+        {
+            return RepointResult.Fail($"RemapLinks failed on '{pluginName}' ({WriteEngine.Describe(ex)}) — the file is untouched.");
+        }
+
+        // Resolve the target's OWN declared masters to overlays in load order — the faithful re-serialize set
+        // WriteInPlace hands Mutagen (mirrors WritePatchBuilder.ResolveOwnMasters). A declared master ABSENT from the
+        // active order is a loud Q3 refusal (a re-serialize couldn't resolve the references into it), file untouched.
+        var overlays = new List<IDisposable>();
+        try
+        {
+            var resolved = new List<ISkyrimModGetter>();
+            foreach (var mr in targetMod.ModHeader.MasterReferences)
+            {
+                var mfn = mr.Master.FileName.String;
+                var mpath = view.PluginPath(mfn);
+                if (mpath is null)
+                    return RepointResult.Fail(
+                        $"cannot re-serialize '{pluginName}' in place: its declared master '{mfn}' is not active in the load order, " +
+                        "so a faithful re-serialize can't resolve the references into it. Enable that master (or fix the masters in xEdit) first. The file is UNTOUCHED.");
+                var ov = SkyrimMod.CreateFromBinaryOverlay(mpath, SkyrimRelease.SkyrimSE);
+                overlays.Add((IDisposable)ov);
+                resolved.Add(ov);
+            }
+
+            try { WriteEngine.WriteInPlace(targetMod, resolved, path); }
+            catch (Exception ex)
+            {
+                return RepointResult.Fail(
+                    $"writing '{pluginName}' in place failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}" +
+                    " — note: a sub-0x800 originating record (e.g. a vanilla master) is rejected by the light-/master-aware floor here, not silently written.");
+            }
+        }
+        finally { foreach (var d in overlays) { try { d.Dispose(); } catch { /* best-effort; never mask the write result */ } } }
+
+        long bytes = 0;
+        try { bytes = new FileInfo(path).Length; } catch { }
+        return new RepointResult(true, null, bytes, dict.Count);
+    }
+}

--- a/src/housecarl-core/RemapEngine.cs
+++ b/src/housecarl-core/RemapEngine.cs
@@ -89,11 +89,16 @@ public static class RemapEngine
         var externalPlugins = new List<string>();        // load-order order, distinct
         int scanned = 0, unscannable = 0;
         var unscannableSamples = new List<string>();
+        // PluginNames CAN list a filename more than once in a degenerate order; scanning a name twice would
+        // double-count + double-list it. A real MO2 VFS yields unique filenames, so this is belt-and-braces — but
+        // it keeps the result correct regardless (the listing is, by contract, DISTINCT).
+        var scannedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var plugin in resolver.PluginNames)
         {
             if (transformSet.Contains(plugin)) continue;                 // inside the set → its refs are INTERNAL (RemapLinks handles them)
             if (view.ExcludedPlugins.ContainsKey(plugin)) continue;      // unparseable at build — already surfaced by the resolver
+            if (!scannedNames.Add(plugin)) continue;                     // a duplicate name in the order — scan/list it once (Q3: no double-count)
             scanned++;
             bool pluginListed = false;
 
@@ -265,7 +270,9 @@ public static class RemapEngine
     /// <summary>The result of an in-place repoint: success + the on-disk byte size, or a loud Q3 refusal (target not
     /// active / excluded / not on disk / a declared master absent / a sub-0x800 originating record / a serialize fault)
     /// with the file UNTOUCHED.</summary>
-    public sealed record RepointResult(bool Success, string? Error, long Bytes, int LinksConsidered)
+    /// <summary><paramref name="RemapEntries"/> is the size of the remap dict applied — NOT the count of links actually
+    /// rewritten in the file (Mutagen's RemapLinks does not report that); a caller must not read it as "links changed".</summary>
+    public sealed record RepointResult(bool Success, string? Error, long Bytes, int RemapEntries)
     {
         public static RepointResult Fail(string error) => new(false, error, 0, 0);
     }
@@ -316,8 +323,11 @@ public static class RemapEngine
         }
 
         // Resolve the target's OWN declared masters to overlays in load order — the faithful re-serialize set
-        // WriteInPlace hands Mutagen (mirrors WritePatchBuilder.ResolveOwnMasters). A declared master ABSENT from the
-        // active order is a loud Q3 refusal (a re-serialize couldn't resolve the references into it), file untouched.
+        // WriteInPlace hands Mutagen (mirrors WritePatchBuilder.ResolveOwnMasters, which opens them the same way). A
+        // declared master ABSENT from the active order is a loud Q3 refusal (a re-serialize couldn't resolve the
+        // references into it), file untouched. These overlays exist ONLY to resolve FormID/master-table references on
+        // re-serialize — they are not read for localized strings — so the bare CreateFromBinaryOverlay is correct here
+        // and the resolver's strings-wiring OpenOverlay choke point is deliberately not needed (matches the in-place lane).
         var overlays = new List<IDisposable>();
         try
         {

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -99,6 +99,10 @@ public static class CiAll
         // args here → it uses that path). Each returns 0/1 like any guard.
         ("coerce-selftest", WriteEngine.RunCoerceSelftest),
         ("coerce-audit", WriteEngine.RunCoerceAudit),
+        // Compact/merge foundation (RemapEngine, Wave 1): a self-contained multi-plugin compact end-to-end (renumber
+        // into the ESL window + identify external referencers + in-place repoint) plus the two loud-refusal boundaries
+        // (ESL capacity overflow, nested-only record). Pins the foundation the compact/merge tools (later waves) ride on.
+        ("remap-wave1-guard", RemapWave1Probe.RunGuard),
     };
 
     /// <summary>Dispatch a single CI guard by name through the registry — the ONE place a CI probe is listed, so

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -205,6 +205,18 @@ if (args.Length > 0 && args[0] == "esl-real-scan") return EslFormIdProbe.RunReal
 // synthetic fixture round-trips clean and would reveal nothing). Writes only to temp; read-only on the load order.
 if (args.Length > 0 && args[0] == "roundtrip-probe") return RoundTripProbe.RunProbe(args[1..]);
 
+// COMPACT/MERGE Wave 1 (COMPACT_MERGE_PLAN §3/§4): EXPLORATORY mechanism pin — settle, self-contained, whether
+// RemapLinks changes a record's OWN identity or only its references, whether MajorRecord.FormKey is settable, and
+// which Mutagen affordance compact must use to renumber a record into the ESL range. Run before building RemapEngine.
+if (args.Length > 0 && args[0] == "remap-wave1-mech") return RemapWave1Probe.RunMechanism(args[1..]);
+
+// COMPACT/MERGE Wave 1 GATE (self-contained, CI-able) lives in the CiAll.Probes registry as `remap-wave1-guard` —
+// it dispatches through CiAll.TryDispatch above (the ONE CI source of truth), so it is NOT listed here.
+
+// COMPACT/MERGE Wave 1 real-data run (MANUAL): ESL-compact a real plugin to a NEW P′ for Aaron to xEdit-verify, and
+// time the identify-pass over the live order. Needs --mo2 <inst> --plugin <Name.esp>; SKIPs without.
+if (args.Length > 0 && args[0] == "remap-wave1-real") return RemapWave1Probe.RunReal(args[1..]);
+
 var outputDir = Path.GetFullPath(args.Length > 0 ? args[0] : "generated");
 // The slim reference tree ships INSIDE the skill (tracked); corpus.json + summary stay in generated/.
 // Default assumes the generator is run from the repo root (as `dotnet run --project src/housecarl-generator`).

--- a/src/housecarl-generator/RemapWave1Probe.cs
+++ b/src/housecarl-generator/RemapWave1Probe.cs
@@ -321,8 +321,74 @@ public static class RemapWave1Probe
             Console.WriteLine($"   NESTED  nested-only record refused: {(nestedOk ? "PASS" : "FAIL")}  ({(ren.Success ? "did NOT refuse" : ren.Error)})");
         }
 
+        // --- ABSTRACT: a Global (abstract SkyrimGroup<Global>) renumbers + places via TryAddToFlatGroup's abstract-group
+        //     arm — Global.IsInstanceOfType(GlobalFloat) matches and Add(Global) accepts the concrete arm. Globals/GMSTs
+        //     are real compaction targets and this is the most novel reflection in the engine, so it gets its own arm. ---
+        bool abstractOk;
+        {
+            var gOld = new FormKey(donorKey, 0xBBB);
+            var gNew = new FormKey(donorKey, 0x800);
+            var gf = new GlobalFloat(gOld, SkyrimRelease.SkyrimSE) { EditorID = "HcGlobalF", Data = 2.5f };
+            var target = new SkyrimMod(donorKey, SkyrimRelease.SkyrimSE);
+            var ren = RemapEngine.RenumberRecordsInto(target, new IMajorRecordGetter[] { gf }, new Dictionary<FormKey, FormKey> { [gOld] = gNew });
+            bool placed = target.Globals.ContainsKey(gNew) && !target.Globals.ContainsKey(gOld) && target.Globals.FirstOrDefault() is GlobalFloat;
+            abstractOk = ren.Success && ren.RecordsRenumbered == 1 && placed;
+            Console.WriteLine($"   ABSTRACT global placed via abstract-group arm: {(abstractOk ? "PASS" : "FAIL")}  (globals=[{string.Join(",", target.Globals.Select(g => g.FormKey))}], renum {ren.RecordsRenumbered}{(ren.Success ? "" : "; " + ren.Error)})");
+        }
+
+        // --- OVERRIDE: a compaction renumbers a plugin's ORIGINATING records but leaves an OVERRIDE at its master's key
+        //     (the override isn't in the remap dict → RenumberRecordsInto copies it at its OWN key). Base.esp {WB@0x801};
+        //     Over.esp overrides WB + originates WO@0xAAA; compacting Over must yield WO@0x800 AND WB@0x801:Base intact. ---
+        bool overrideOk;
+        {
+            var baseKey = new ModKey("HcRemapBase", ModType.Master);
+            var wbKey = new FormKey(baseKey, 0x801);
+            string basePath = Path.Combine(tmpDir, baseKey.FileName.String);
+            {
+                var b = new SkyrimMod(baseKey, SkyrimRelease.SkyrimSE);
+                b.Weapons.Add(new Weapon(wbKey, SkyrimRelease.SkyrimSE) { EditorID = "HcWeapB", BasicStats = new WeaponBasicStats { Damage = 7 } });
+                b.ModHeader.Stats.NextFormID = 0x802;
+                b.BeginWrite.ToPath(basePath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).NoNextFormIDProcessing().Write();
+            }
+            var overKey = new ModKey("HcRemapOver", ModType.Plugin);
+            var woOld = new FormKey(overKey, 0xAAA);
+            string overPath = Path.Combine(tmpDir, overKey.FileName.String);
+            using (var baseOv = SkyrimMod.CreateFromBinaryOverlay(basePath, SkyrimRelease.SkyrimSE))
+            {
+                var o = new SkyrimMod(overKey, SkyrimRelease.SkyrimSE);
+                o.Weapons.GetOrAddAsOverride(baseOv.Weapons.First(w => w.FormKey == wbKey));
+                o.Weapons.Add(new Weapon(woOld, SkyrimRelease.SkyrimSE) { EditorID = "HcWeapO", BasicStats = new WeaponBasicStats { Damage = 9 } });
+                o.ModHeader.Stats.NextFormID = 0xAAB;
+                o.BeginWrite.ToPath(overPath).WithLoadOrder(new[] { baseOv }).NoNextFormIDProcessing().Write();
+            }
+            using (var overOv = SkyrimMod.CreateFromBinaryOverlay(overPath, SkyrimRelease.SkyrimSE))
+            {
+                var origKeys = overOv.EnumerateMajorRecords().Where(r => r.FormKey.ModKey == overKey).Select(r => r.FormKey).ToList();
+                var plan = RemapEngine.BuildSequentialRemap(origKeys, overKey, RemapEngine.EslFloor, RemapEngine.EslCeiling);
+                var pPrime = new SkyrimMod(overKey, SkyrimRelease.SkyrimSE);
+                var ren = RemapEngine.RenumberRecordsInto(pPrime, overOv.EnumerateMajorRecords(), plan.Dict);
+                bool woRenum = plan.Success && pPrime.Weapons.ContainsKey(plan.Dict[woOld]);   // originating WO -> 0x800:Over
+                bool wbPreserved = pPrime.Weapons.ContainsKey(wbKey);                          // override WB stays at 0x801:Base
+                overrideOk = ren.Success && ren.RecordsCopied == 2 && ren.RecordsRenumbered == 1 && woRenum && wbPreserved;
+                Console.WriteLine($"   OVERRIDE override copied at master key: {(overrideOk ? "PASS" : "FAIL")}  (P′ weapons=[{string.Join(",", pPrime.Weapons.Select(w => w.FormKey))}], copied {ren.RecordsCopied}/renum {ren.RecordsRenumbered}{(ren.Success ? "" : "; " + ren.Error)})");
+            }
+        }
+
+        // --- REFUSAL: RepointInPlace fails LOUD on bad input — a name not in the order, and an empty remap dict — with
+        //     the file untouched (Q3). The opt-in rewrite's guardrails, pinned. ---
+        bool refusalOk;
+        {
+            using var resolver = LoadOrderResolver.Build(new[] { donorPath, extPath });
+            var someDict = new Dictionary<FormKey, FormKey> { [waOld] = new FormKey(donorKey, 0x800) };
+            var notActive = RemapEngine.RepointInPlace(resolver, "HcDoesNotExist.esp", someDict);
+            var emptyDict = RemapEngine.RepointInPlace(resolver, extKey.FileName.String, new Dictionary<FormKey, FormKey>());
+            refusalOk = !notActive.Success && (notActive.Error?.Contains("not an active plugin", StringComparison.OrdinalIgnoreCase) ?? false)
+                     && !emptyDict.Success && (emptyDict.Error?.Contains("no remap", StringComparison.OrdinalIgnoreCase) ?? false);
+            Console.WriteLine($"   REFUSAL RepointInPlace loud on bad input  : {(refusalOk ? "PASS" : "FAIL")}  (not-active: {notActive.Error?.Split('.')[0]}; empty-dict: {emptyDict.Error})");
+        }
+
         Console.WriteLine();
-        bool pass = happyOk && capacityOk && nestedOk;
+        bool pass = happyOk && capacityOk && nestedOk && abstractOk && overrideOk && refusalOk;
         Console.WriteLine($"=== remap-wave1-guard: {(pass ? "PASS" : "FAIL")} ===");
         try { Directory.Delete(tmpDir, true); } catch { }
         return pass ? 0 : 1;

--- a/src/housecarl-generator/RemapWave1Probe.cs
+++ b/src/housecarl-generator/RemapWave1Probe.cs
@@ -1,0 +1,478 @@
+using System.Diagnostics;
+using System.Reflection;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// COMPACT/MERGE — WAVE 1 mechanism pin (the FIRST, load-bearing unknown the build plan rests on).
+///
+/// Wave-0 proved <c>mod.RemapLinks(dict)</c> repoints OUTGOING FormLinks (a record's references). The compact build
+/// plan §4 step 1 ALSO assumes a way to RENUMBER a record's OWN FormID (move it into the ESL 0x800–0xFFF range) — and
+/// that half was NEVER tested. This probe settles, self-contained (synthetic, TEMP, no MO2/Skyrim.esm), exactly:
+///   1. Does <c>RemapLinks(dict)</c> change a record's OWN identity, or ONLY its outgoing references?
+///   2. Is <c>MajorRecord.FormKey</c> settable (so we can renumber identity directly)? — reflection, no compile dep.
+///   3. What mod-/record-level renumber affordances does Mutagen actually expose? — reflect "Remap"/"Duplicate"/"Compact".
+///
+/// Then it RUNS the candidate that the reflection says exists and reports the on-disk truth after a write+reread:
+/// a Weapon A and a FormList L→[A]; renumber A; re-read; report (a) where A's identity landed and (b) where L's entry
+/// points. That four-way truth table (identity moved? link moved?) tells us EXACTLY which mechanism compact must use.
+///
+/// Run: dotnet run --project src/housecarl-generator remap-wave1-mech
+/// </summary>
+public static class RemapWave1Probe
+{
+    public static int RunMechanism(string[] args)
+    {
+        Console.WriteLine("################  COMPACT/MERGE WAVE 1 — renumber-identity mechanism pin  ################");
+        Console.WriteLine();
+
+        // ---- 2 + 3: reflection — what does Mutagen expose for renumbering, without a compile dependency? ----
+        var weapT = typeof(Weapon);
+        var fkProp = weapT.GetProperty("FormKey");
+        Console.WriteLine("REFLECTION:");
+        Console.WriteLine($"   Weapon.FormKey  CanRead={fkProp?.CanRead} CanWrite={fkProp?.CanWrite} setter={(fkProp?.SetMethod is { } sm ? (sm.IsPublic ? "public" : "non-public") : "<none>")}");
+
+        var modT = typeof(SkyrimMod);
+        foreach (var needle in new[] { "Remap", "Duplicate", "Compact", "FormID", "FormKey" })
+        {
+            var ms = modT.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                .Where(m => m.Name.Contains(needle, StringComparison.OrdinalIgnoreCase))
+                .Select(m => $"{m.Name}({string.Join(", ", m.GetParameters().Select(p => p.ParameterType.Name))})")
+                .Distinct().ToList();
+            if (ms.Count > 0) Console.WriteLine($"   SkyrimMod methods ~ '{needle}': {string.Join("; ", ms)}");
+        }
+        foreach (var needle in new[] { "Remap", "Duplicate" })
+        {
+            var ms = weapT.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                .Where(m => m.Name.Contains(needle, StringComparison.OrdinalIgnoreCase))
+                .Select(m => $"{m.Name}({string.Join(", ", m.GetParameters().Select(p => p.ParameterType.Name))})")
+                .Distinct().ToList();
+            if (ms.Count > 0) Console.WriteLine($"   Weapon methods ~ '{needle}': {string.Join("; ", ms)}");
+        }
+        Console.WriteLine();
+
+        var tmpDir = Path.Combine(Path.GetTempPath(), "hc-remap-wave1-mech");
+        if (Directory.Exists(tmpDir)) { try { Directory.Delete(tmpDir, true); } catch { } }
+        Directory.CreateDirectory(tmpDir);
+
+        var donorKey = new ModKey("HcRemapDonor", ModType.Plugin);
+        var aOld = new FormKey(donorKey, 0x800);
+        var aNew = new FormKey(donorKey, 0x900);
+        var lKey = new FormKey(donorKey, 0x801);
+
+        // ---- Experiment 1: RemapLinks alone — does it touch identity, or only the FormList's outgoing link? ----
+        Console.WriteLine("EXPERIMENT 1 — mod.RemapLinks({A_old -> A_new}) ALONE:");
+        RunRenumberExperiment(tmpDir, "remaplinks", donorKey, aOld, aNew, lKey,
+            mod => mod.RemapLinks(new Dictionary<FormKey, FormKey> { [aOld] = aNew }));
+
+        // ---- Experiment 2: set the record's FormKey directly (if reflection said it's writable). ----
+        if (fkProp?.CanWrite == true)
+        {
+            Console.WriteLine("EXPERIMENT 2 — set A.FormKey = A_new directly (no RemapLinks):");
+            RunRenumberExperiment(tmpDir, "setformkey", donorKey, aOld, aNew, lKey,
+                mod => { foreach (var w in mod.Weapons.Where(w => w.FormKey == aOld)) fkProp.SetValue(w, aNew); });
+
+            Console.WriteLine("EXPERIMENT 3 — set A.FormKey = A_new  AND  RemapLinks (the plan §4 step1+step2 combo):");
+            RunRenumberExperiment(tmpDir, "both", donorKey, aOld, aNew, lKey,
+                mod =>
+                {
+                    foreach (var w in mod.Weapons.Where(w => w.FormKey == aOld)) fkProp.SetValue(w, aNew);
+                    mod.RemapLinks(new Dictionary<FormKey, FormKey> { [aOld] = aNew });
+                });
+        }
+        else Console.WriteLine("EXPERIMENT 2/3 — SKIPPED: Weapon.FormKey is not writable (compact must renumber some other way).");
+
+        Console.WriteLine();
+
+        // ---- 4: in-memory GROUP CONSISTENCY after a FormKey-set. The group is a FormKey-keyed cache; if setting the
+        //         record's FormKey does NOT re-key the cache, the group is internally inconsistent (record says new,
+        //         cache still keyed by old) — a silent-corruption risk RemapEngine must not build on. ----
+        if (fkProp?.CanWrite == true)
+        {
+            Console.WriteLine("GROUP CONSISTENCY — after setting A.FormKey = A_new in memory (no write):");
+            var mod = new SkyrimMod(donorKey, SkyrimRelease.SkyrimSE);
+            mod.Weapons.Add(new Weapon(aOld, SkyrimRelease.SkyrimSE) { EditorID = "HcRemapWeapA" });
+            var grp = mod.Weapons;
+            bool hadOld = grp.ContainsKey(aOld);
+            fkProp.SetValue(grp.First(), aNew);
+            bool hasOldKey = grp.ContainsKey(aOld), hasNewKey = grp.ContainsKey(aNew);
+            FormKey? lookupOld = grp.TryGetValue(aOld, out var ro) ? ro.FormKey : (FormKey?)null;
+            FormKey? lookupNew = grp.TryGetValue(aNew, out var rn) ? rn.FormKey : (FormKey?)null;
+            var enumKeys = grp.Select(w => w.FormKey).ToList();
+            Console.WriteLine($"   before: ContainsKey(old)={hadOld}");
+            Console.WriteLine($"   after : ContainsKey(old)={hasOldKey}  ContainsKey(new)={hasNewKey}  enumerated record FormKeys=[{string.Join(",", enumKeys)}]");
+            Console.WriteLine($"   after : TryGetValue(old)->{lookupOld?.ToString() ?? "<none>"}   TryGetValue(new)->{lookupNew?.ToString() ?? "<none>"}");
+            bool consistent = !hasOldKey && hasNewKey && lookupNew == aNew && lookupOld is null;
+            Console.WriteLine($"   => group re-keyed consistently to A_new? {consistent}  {(consistent ? "" : "(!!) cache key did NOT follow the record — RemapEngine must re-key explicitly")}");
+        }
+        Console.WriteLine();
+
+        // ---- 5: is there a PUBLIC Mutagen renumber/duplicate affordance (vs the non-public FormKey setter)? Scan the
+        //         Mutagen assemblies' static classes for Duplicate/DeepCopy extensions taking a record (the OverrideMethod
+        //         finder pattern), and check the record interfaces' own members. ----
+        Console.WriteLine("PUBLIC RENUMBER/DUPLICATE AFFORDANCES (Mutagen static extensions + interface members):");
+        var hits = new List<string>();
+        foreach (var asm in AppDomain.CurrentDomain.GetAssemblies().Where(a => (a.GetName().Name ?? "").StartsWith("Mutagen")))
+        {
+            Type[] types; try { types = asm.GetTypes(); } catch { continue; }
+            foreach (var t in types.Where(t => t is { IsAbstract: true, IsSealed: true, IsPublic: true })) // static classes
+                foreach (var m in t.GetMethods(BindingFlags.Public | BindingFlags.Static))
+                    if ((m.Name is "Duplicate" or "DeepCopy" || m.Name.StartsWith("Duplicate"))
+                        && m.GetParameters().Length >= 1
+                        && typeof(IMajorRecordGetter).IsAssignableFrom(m.GetParameters()[0].ParameterType))
+                        hits.Add($"{t.Name}.{m.Name}({string.Join(",", m.GetParameters().Select(p => p.ParameterType.Name))})");
+        }
+        foreach (var h in hits.Distinct().Take(20)) Console.WriteLine($"   {h}");
+        if (hits.Count == 0) Console.WriteLine("   (none found — no public Duplicate(record,...) extension; renumber-in-place via the FormKey setter is the path)");
+        Console.WriteLine();
+
+        // ---- 6: THE CHOSEN MECHANISM — copy records into a FRESH mod under chosen keys via the PUBLIC Duplicate(key),
+        //         then RemapLinks. This is what RemapEngine will do (no non-public setter, no group corruption, no
+        //         collisions since the target starts empty). Renumber A 0x800->0x900 AND L 0x801->0x901; L->[A] must
+        //         repoint to 0x900. Assert: identities at new keys, group consistent (ContainsKey new / not old), link repointed. ----
+        Console.WriteLine("CHOSEN MECHANISM — Duplicate(record, newKey) into a fresh mod + RemapLinks:");
+        try
+        {
+            string path = Path.Combine(tmpDir, "chosen", donorKey.FileName.String);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            var lOld = lKey;                       // 0x801
+            var lNew = new FormKey(donorKey, 0x901);
+            var dict = new Dictionary<FormKey, FormKey> { [aOld] = aNew, [lOld] = lNew };
+
+            // source
+            var src = new SkyrimMod(donorKey, SkyrimRelease.SkyrimSE);
+            src.Weapons.Add(new Weapon(aOld, SkyrimRelease.SkyrimSE) { EditorID = "HcRemapWeapA" });
+            var srcL = new FormList(lOld, SkyrimRelease.SkyrimSE) { EditorID = "HcRemapList" };
+            srcL.Items.Add(new FormLink<ISkyrimMajorRecordGetter>(aOld));
+            src.FormLists.Add(srcL);
+
+            // fresh target, same ModKey; Duplicate each originating record under its NEW key, place in its group.
+            var tgt = new SkyrimMod(donorKey, SkyrimRelease.SkyrimSE);
+            tgt.Weapons.Add((Weapon)src.Weapons.First().Duplicate(aNew));
+            tgt.FormLists.Add((FormList)src.FormLists.First().Duplicate(lNew));
+            if (tgt.ModHeader.Stats.NextFormID < 0x800) tgt.ModHeader.Stats.NextFormID = 0x800;
+            tgt.RemapLinks(dict);
+
+            bool memOk = tgt.Weapons.ContainsKey(aNew) && !tgt.Weapons.ContainsKey(aOld)
+                       && tgt.FormLists.ContainsKey(lNew) && !tgt.FormLists.ContainsKey(lOld);
+
+            tgt.BeginWrite.ToPath(path).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).NoNextFormIDProcessing().Write();
+            using var rb = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE);
+            var weapKeys = rb.Weapons.Select(w => w.FormKey).ToList();
+            var listKeys = rb.FormLists.Select(l => l.FormKey).ToList();
+            var listEntry = rb.FormLists.First().Items.FirstOrDefault()?.FormKey;
+            bool diskOk = weapKeys.SequenceEqual(new[] { aNew }) && listKeys.SequenceEqual(new[] { lNew }) && listEntry == aNew;
+            Console.WriteLine($"   in-memory group consistent (new keys, not old)? {memOk}");
+            Console.WriteLine($"   on-disk weapons=[{string.Join(",", weapKeys)}] formlists=[{string.Join(",", listKeys)}] list entry -> {listEntry}");
+            Console.WriteLine($"   => CHOSEN MECHANISM correct? {memOk && diskOk}");
+        }
+        catch (Exception ex) { Console.WriteLine($"   THREW {ex.GetType().Name}: {ex.Message}"); }
+        Console.WriteLine();
+
+        Console.WriteLine("=== remap-wave1-mech: DONE — read the identity/link truth table above ===");
+        try { Directory.Delete(tmpDir, true); } catch { }
+        return 0;
+    }
+
+    // ======================================================================
+    //  GUARD — the Wave 1 gate: a self-contained, CI-able end-to-end compact of a
+    //  synthetic MULTI-plugin fixture, exercising every RemapEngine primitive (plan §9).
+    // ======================================================================
+
+    /// <summary>
+    /// Self-contained regression guard for the compact/merge foundation (RemapEngine). Synthesizes a multi-plugin
+    /// fixture in TEMP (no MO2, no Skyrim.esm) and drives the FULL cycle through the REAL engine, then asserts the
+    /// on-disk truth. Arms (ALL required — a GREEN must mean "the foundation compacts end-to-end correctly"):
+    ///   HAPPY    — Donor.esp {Weapon WA@0xAAA, FormList FL@0xCCC->[WA]} compacts into a NEW P′ (records renumbered to
+    ///              the ESL window 0x800,0x801; FL's INTERNAL ref to WA repointed); the identify-pass over the order
+    ///              finds External.esp (which references WA) as an EXTERNAL referencer and NOT Donor itself; the in-place
+    ///              repoint rewrites External's reference to the new key. The whole compact, proven on disk.
+    ///   CAPACITY — BuildSequentialRemap refuses LOUD when the record count overflows the target window (the ESL
+    ///              "too many records to fit the light range" ceiling) — named, never truncated (Q3).
+    ///   NESTED   — RenumberRecordsInto refuses LOUD on a nested-only record (a Cell has no flat group to place the
+    ///              duplicate) — the honest coverage boundary, never a silent drop (Q3).
+    /// Run: dotnet run --project src/housecarl-generator remap-wave1-guard
+    /// </summary>
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  COMPACT/MERGE WAVE 1 — RemapEngine end-to-end guard  ################");
+        Console.WriteLine();
+
+        var tmpDir = Path.Combine(Path.GetTempPath(), "hc-remap-wave1-guard");
+        if (Directory.Exists(tmpDir)) { try { Directory.Delete(tmpDir, true); } catch { } }
+        Directory.CreateDirectory(tmpDir);
+
+        var donorKey = new ModKey("HcRemapDonor", ModType.Plugin);
+        var extKey = new ModKey("HcRemapExternal", ModType.Plugin);
+        var waOld = new FormKey(donorKey, 0xAAA);     // weapon, will renumber -> 0x800
+        var flOld = new FormKey(donorKey, 0xCCC);     // formlist -> [WA] (internal), will renumber -> 0x801
+        var exlKey = new FormKey(extKey, 0x800);      // External's formlist -> [WA] (EXTERNAL ref into Donor)
+
+        string donorPath = Path.Combine(tmpDir, donorKey.FileName.String);
+        string extPath = Path.Combine(tmpDir, extKey.FileName.String);
+
+        // --- synthesize Donor.esp {WA@0xAAA, FL@0xCCC -> [WA]} ---
+        {
+            var d = new SkyrimMod(donorKey, SkyrimRelease.SkyrimSE);
+            d.Weapons.Add(new Weapon(waOld, SkyrimRelease.SkyrimSE) { EditorID = "HcWeapA", BasicStats = new WeaponBasicStats { Damage = 10 } });
+            var fl = new FormList(flOld, SkyrimRelease.SkyrimSE) { EditorID = "HcList" };
+            fl.Items.Add(new FormLink<ISkyrimMajorRecordGetter>(waOld));
+            d.FormLists.Add(fl);
+            d.ModHeader.Stats.NextFormID = 0xCCD;
+            d.BeginWrite.ToPath(donorPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).NoNextFormIDProcessing().Write();
+        }
+        // --- synthesize External.esp {EXL@0x800 -> [WA(donor)]}, master = Donor ---
+        {
+            using var donorOv = SkyrimMod.CreateFromBinaryOverlay(donorPath, SkyrimRelease.SkyrimSE);
+            var e = new SkyrimMod(extKey, SkyrimRelease.SkyrimSE);
+            var exl = new FormList(exlKey, SkyrimRelease.SkyrimSE) { EditorID = "HcExtList" };
+            exl.Items.Add(new FormLink<ISkyrimMajorRecordGetter>(waOld));
+            e.FormLists.Add(exl);
+            e.ModHeader.Stats.NextFormID = 0x801;
+            e.BeginWrite.ToPath(extPath).WithLoadOrder(new[] { donorOv }).NoNextFormIDProcessing().Write();
+        }
+
+        bool happyOk;
+        string happyDetail;
+        {
+            // 1. collect Donor's originating records (doc order) + build the remap into the ESL window.
+            RemapEngine.RemapPlan plan;
+            string pPrimePath = Path.Combine(tmpDir, "pprime", donorKey.FileName.String);
+            Directory.CreateDirectory(Path.GetDirectoryName(pPrimePath)!);
+            RemapEngine.RenumberResult ren;
+            using (var donorOv = SkyrimMod.CreateFromBinaryOverlay(donorPath, SkyrimRelease.SkyrimSE))
+            {
+                var srcKeys = donorOv.EnumerateMajorRecords().Where(r => r.FormKey.ModKey == donorKey).Select(r => r.FormKey).ToList();
+                plan = RemapEngine.BuildSequentialRemap(srcKeys, donorKey, RemapEngine.EslFloor, RemapEngine.EslCeiling);
+                var pPrime = new SkyrimMod(donorKey, SkyrimRelease.SkyrimSE);
+                ren = RemapEngine.RenumberRecordsInto(pPrime, donorOv.EnumerateMajorRecords().Where(r => r.FormKey.ModKey == donorKey), plan.Dict);
+                pPrime.ModHeader.Stats.NextFormID = 0x802;
+                if (ren.Success) WriteEngine.WriteInPlace(pPrime, Array.Empty<ISkyrimModGetter>(), pPrimePath);
+            }
+
+            // 2. re-read P′: weapons at 0x800, formlists at 0x801, the FL's internal ref repointed to 0x800.
+            FormKey waNew = plan.Success ? plan.Dict[waOld] : default;
+            FormKey flNew = plan.Success ? plan.Dict[flOld] : default;
+            List<FormKey> pWeap = new(), pList = new(); FormKey? pInternal = null;
+            if (ren.Success)
+            {
+                using var pp = SkyrimMod.CreateFromBinaryOverlay(pPrimePath, SkyrimRelease.SkyrimSE);
+                pWeap = pp.Weapons.Select(w => w.FormKey).ToList();
+                pList = pp.FormLists.Select(l => l.FormKey).ToList();
+                pInternal = pp.FormLists.First().Items.FirstOrDefault()?.FormKey;
+            }
+            bool pPrimeOk = ren.Success && pWeap.SequenceEqual(new[] { waNew }) && pList.SequenceEqual(new[] { flNew }) && pInternal == waNew;
+
+            // 3. identify-pass over the ORIGINAL order {Donor, External}: External references WA, Donor is in the set.
+            bool identifyOk; bool repointOk; FormKey? extAfter = null;
+            using (var resolver = LoadOrderResolver.Build(new[] { donorPath, extPath }))
+            {
+                var targets = plan.Success ? plan.Dict.Keys.ToHashSet() : new HashSet<FormKey>();
+                var transformSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { donorKey.FileName.String };
+                var id = RemapEngine.IdentifyExternalReferencers(resolver, targets, transformSet);
+                identifyOk = id.HasExternalReferencers
+                             && id.ExternalPlugins.Contains(extKey.FileName.String, StringComparer.OrdinalIgnoreCase)
+                             && !id.ExternalPlugins.Contains(donorKey.FileName.String, StringComparer.OrdinalIgnoreCase)
+                             && id.Refs.Any(r => r.Target == waOld && string.Equals(r.Plugin, extKey.FileName.String, StringComparison.OrdinalIgnoreCase))
+                             && id.UnscannableRecords == 0;
+
+                // 4. opt-in in-place repoint of the external referencer; its ref to WA rewrites to the new key.
+                var rep = RemapEngine.RepointInPlace(resolver, extKey.FileName.String, plan.Success ? plan.Dict : new Dictionary<FormKey, FormKey>());
+                repointOk = rep.Success;
+            }
+            if (repointOk)
+            {
+                using var ee = SkyrimMod.CreateFromBinaryOverlay(extPath, SkyrimRelease.SkyrimSE);
+                extAfter = ee.FormLists.First().Items.FirstOrDefault()?.FormKey;
+            }
+            bool extRepointOk = repointOk && extAfter == waNew;
+
+            happyOk = plan.Success && ren.Success && pPrimeOk && identifyOk && extRepointOk;
+            happyDetail = $"plan={plan.Success}(err:{plan.Error}), renumber={ren.Success}(copied {ren.RecordsCopied}, renum {ren.RecordsRenumbered}; err:{ren.Error}), " +
+                          $"P′ weap=[{string.Join(",", pWeap)}] list=[{string.Join(",", pList)}] internal->{pInternal}, " +
+                          $"identify={identifyOk}, external repointed {extAfter}->expect {waNew} = {extRepointOk}";
+        }
+        Console.WriteLine($"   HAPPY  full compact end-to-end : {(happyOk ? "PASS" : "FAIL")}");
+        Console.WriteLine($"          {happyDetail}");
+
+        // --- CAPACITY: overflow the window (3 distinct keys into a 2-ID window) → loud refusal. ---
+        bool capacityOk;
+        {
+            var keys = new[] { new FormKey(donorKey, 1), new FormKey(donorKey, 2), new FormKey(donorKey, 3) };
+            var plan = RemapEngine.BuildSequentialRemap(keys, donorKey, 0x800, 0x801);   // window holds 2
+            capacityOk = !plan.Success && plan.Error is not null && plan.Error.Contains("overflow", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   CAPACITY window overflow refused: {(capacityOk ? "PASS" : "FAIL")}  ({(plan.Success ? "did NOT refuse" : plan.Error)})");
+        }
+
+        // --- NESTED: a Cell (nested-only family) has no flat group → RenumberRecordsInto refuses loud. ---
+        bool nestedOk;
+        {
+            var cellKey = new FormKey(donorKey, 0xD00);
+            var cell = new Cell(cellKey, SkyrimRelease.SkyrimSE) { EditorID = "HcCell" };
+            var target = new SkyrimMod(donorKey, SkyrimRelease.SkyrimSE);
+            var dict = new Dictionary<FormKey, FormKey> { [cellKey] = new FormKey(donorKey, 0x800) };
+            var ren = RemapEngine.RenumberRecordsInto(target, new IMajorRecordGetter[] { cell }, dict);
+            nestedOk = !ren.Success && ren.Error is not null && ren.Error.Contains("NESTED", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   NESTED  nested-only record refused: {(nestedOk ? "PASS" : "FAIL")}  ({(ren.Success ? "did NOT refuse" : ren.Error)})");
+        }
+
+        Console.WriteLine();
+        bool pass = happyOk && capacityOk && nestedOk;
+        Console.WriteLine($"=== remap-wave1-guard: {(pass ? "PASS" : "FAIL")} ===");
+        try { Directory.Delete(tmpDir, true); } catch { }
+        return pass ? 0 : 1;
+    }
+
+    // ======================================================================
+    //  REAL — manual --mo2 run: ESL-compact a real plugin to a NEW P′ for Aaron to xEdit-verify,
+    //  and measure the identify-pass over the live order (plan §9 Wave 1 real-data gate).
+    // ======================================================================
+
+    /// <summary>
+    /// MANUAL real-data run (needs <c>--mo2 &lt;instanceDir&gt; --plugin &lt;Name.esp&gt;</c>; SKIPs without). ESL-compacts a
+    /// REAL plugin's originating records into the 0x800–0xFFF window, emits a NEW P′ (originals untouched — written to
+    /// <c>--out</c> or a temp dir) for Aaron to load in xEdit, and runs + TIMES the identify-pass over the whole live
+    /// order, REPORTING (not rewriting) any external referencers. Read-only on the load order except the P′ it writes
+    /// into its own output dir. Refuses LOUD on the real boundaries (too many records for the light range; a nested-only
+    /// record; an unparseable plugin) — the same honest limits the guard pins, now against real data.
+    /// Run: dotnet run --project src/housecarl-generator remap-wave1-real -- --mo2 &lt;inst&gt; --plugin &lt;Name.esp&gt; [--out &lt;dir&gt;]
+    /// </summary>
+    public static int RunReal(string[] args)
+    {
+        var f = WriteEngine.ParseFlags(args);
+        var instanceDir = f.GetValueOrDefault("mo2");
+        var pluginName = f.GetValueOrDefault("plugin");
+        if (instanceDir is null || !Directory.Exists(instanceDir) || string.IsNullOrWhiteSpace(pluginName))
+        {
+            Console.WriteLine("SKIP: needs --mo2 <instanceDir> --plugin <Name.esp>. A real ESL-compaction + identify-pass can only");
+            Console.WriteLine("      be measured/verified against a real load order (a synthetic fixture is the guard's job).");
+            return 0;
+        }
+        string outDir = f.GetValueOrDefault("out") ?? Path.Combine(Path.GetTempPath(), "hc-remap-wave1-real");
+        Directory.CreateDirectory(outDir);
+
+        Console.WriteLine("################  COMPACT/MERGE WAVE 1 — real ESL-compact + identify-pass  ################");
+        Console.WriteLine($"   instance: {instanceDir}");
+        Console.WriteLine($"   plugin  : {pluginName}");
+        Console.WriteLine($"   out     : {outDir}");
+        Console.WriteLine();
+
+        var p = Mo2Instance.Resolve(instanceDir);
+        var order = Mo2LoadOrder.Build(p.ProfileDir, p.ModsDir, p.DataDir, p.OverwriteDir);
+        var orderedPaths = order.OrderedPaths.ToList();
+        var srcPath = orderedPaths.FirstOrDefault(op => string.Equals(Path.GetFileName(op), pluginName, StringComparison.OrdinalIgnoreCase));
+        if (srcPath is null) { Console.WriteLine($"ABORT: '{pluginName}' is not in the active order."); return 1; }
+
+        var modKey = ModKey.FromFileName(pluginName);
+
+        // Collect the plugin's ORIGINATING record keys (doc order) + build the ESL remap.
+        List<FormKey> srcKeys;
+        try
+        {
+            using var ov = SkyrimMod.CreateFromBinaryOverlay(srcPath, SkyrimRelease.SkyrimSE);
+            srcKeys = ov.EnumerateMajorRecords().Where(r => r.FormKey.ModKey == modKey).Select(r => r.FormKey).ToList();
+        }
+        catch (Exception ex) { Console.WriteLine($"ABORT: cannot parse '{pluginName}' ({WriteEngine.Describe(ex)})."); return 1; }
+        Console.WriteLine($"   originating records: {srcKeys.Count}  (ESL window capacity = {RemapEngine.EslCeiling - RemapEngine.EslFloor + 1})");
+
+        var plan = RemapEngine.BuildSequentialRemap(srcKeys, modKey, RemapEngine.EslFloor, RemapEngine.EslCeiling);
+        if (!plan.Success) { Console.WriteLine($"   REFUSE (Q3): {plan.Error}"); /* still measure identify below */ }
+
+        // Build P′ (compacted, light-flagged) and write it to the out dir — originals untouched.
+        string pPrimePath = Path.Combine(outDir, pluginName);
+        bool wroteP = false;
+        if (plan.Success)
+        {
+            var masterOverlays = new List<IDisposable>();
+            try
+            {
+                using var ov = SkyrimMod.CreateFromBinaryOverlay(srcPath, SkyrimRelease.SkyrimSE);
+                var pPrime = new SkyrimMod(modKey, SkyrimRelease.SkyrimSE) { IsSmallMaster = true };
+                var ren = RemapEngine.RenumberRecordsInto(pPrime, ov.EnumerateMajorRecords(), plan.Dict);
+                if (!ren.Success) { Console.WriteLine($"   REFUSE (Q3): {ren.Error}"); }
+                else
+                {
+                    pPrime.ModHeader.Stats.NextFormID = Math.Max(0x800u, (uint)plan.Dict.Count + 0x800u);
+                    // resolve the plugin's own declared masters (in load order) for a faithful write.
+                    var byName = orderedPaths.ToDictionary(Path.GetFileName, x => x, StringComparer.OrdinalIgnoreCase);
+                    var resolved = new List<ISkyrimModGetter>();
+                    bool missing = false;
+                    foreach (var mr in ov.ModHeader.MasterReferences)
+                    {
+                        if (!byName.TryGetValue(mr.Master.FileName.String, out var mp)) { missing = true; Console.WriteLine($"   REFUSE: declared master '{mr.Master.FileName}' not in the order."); break; }
+                        var mov = SkyrimMod.CreateFromBinaryOverlay(mp, SkyrimRelease.SkyrimSE); masterOverlays.Add((IDisposable)mov); resolved.Add(mov);
+                    }
+                    if (!missing)
+                    {
+                        try { WriteEngine.WriteInPlace(pPrime, resolved, pPrimePath); wroteP = true; Console.WriteLine($"   WROTE compacted P′ → {pPrimePath}  ({ren.RecordsCopied} records, {ren.RecordsRenumbered} renumbered into 0x800+)"); }
+                        catch (Exception ex) { Console.WriteLine($"   WRITE FAILED ({WriteEngine.Describe(ex)}) — note a sub-0x800 originating record is rejected by the light floor."); }
+                    }
+                }
+            }
+            finally { foreach (var d in masterOverlays) { try { d.Dispose(); } catch { } } }
+        }
+
+        // Identify-pass over the WHOLE live order — time it (the ~25s number the plan composes from).
+        Console.WriteLine();
+        Console.WriteLine("   identify-pass (external referencers of the compacted records) over the whole order…");
+        using (var resolver = LoadOrderResolver.Build(orderedPaths))
+        {
+            var targets = (plan.Success ? plan.Dict.Keys : (IEnumerable<FormKey>)srcKeys).ToHashSet();
+            var transformSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { pluginName };
+            var sw = Stopwatch.StartNew();
+            var id = RemapEngine.IdentifyExternalReferencers(resolver, targets, transformSet);
+            sw.Stop();
+            Console.WriteLine($"   scanned {id.PluginsScanned} plugins in {sw.Elapsed.TotalSeconds:N1}s; unscannable records: {id.UnscannableRecords}");
+            Console.WriteLine($"   EXTERNAL referencers: {id.ExternalPlugins.Count} plugin(s){(id.ExternalPlugins.Count == 0 ? " — the clean default path (emit P′, originals untouched, done)." : ":")}");
+            foreach (var pl in id.ExternalPlugins.Take(25)) Console.WriteLine($"      - {pl}  ({id.Refs.Count(r => string.Equals(r.Plugin, pl, StringComparison.OrdinalIgnoreCase))} ref(s))");
+            if (id.UnscannableRecords > 0) foreach (var s in id.UnscannableSamples) Console.WriteLine($"      [unscannable] {s}");
+            if (id.HasExternalReferencers)
+                Console.WriteLine("   (these would each need the opt-in in-place repoint — REPORTED here, NOT rewritten, in this read-only run.)");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine(wroteP
+            ? $"=== remap-wave1-real: DONE — load {pPrimePath} in xEdit to verify (FormIDs in 0x800–0xFFF, light flag, refs intact). ==="
+            : "=== remap-wave1-real: DONE (P′ not written — see the refusal above) ===");
+        return 0;
+    }
+
+    /// <summary>Build Donor.esp = {Weapon A@aOld, FormList L@lKey -> [A]}, apply <paramref name="renumber"/>, write,
+    /// re-read, and print the on-disk truth: where A's identity landed + where L's entry points.</summary>
+    static void RunRenumberExperiment(string tmpDir, string tag, ModKey donorKey, FormKey aOld, FormKey aNew, FormKey lKey,
+        Action<SkyrimMod> renumber)
+    {
+        string path = Path.Combine(tmpDir, tag, donorKey.FileName.String);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        try
+        {
+            var mod = new SkyrimMod(donorKey, SkyrimRelease.SkyrimSE);
+            mod.Weapons.Add(new Weapon(aOld, SkyrimRelease.SkyrimSE) { EditorID = "HcRemapWeapA" });
+            var flst = new FormList(lKey, SkyrimRelease.SkyrimSE) { EditorID = "HcRemapList" };
+            flst.Items.Add(new FormLink<ISkyrimMajorRecordGetter>(aOld));
+            mod.FormLists.Add(flst);
+            if (mod.ModHeader.Stats.NextFormID < 0x800) mod.ModHeader.Stats.NextFormID = 0x800;
+
+            renumber(mod);
+
+            mod.BeginWrite.ToPath(path).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).NoNextFormIDProcessing().Write();
+
+            using var rb = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE);
+            var weapKeys = rb.Weapons.Select(w => w.FormKey).ToList();
+            var listEntry = rb.FormLists.First().Items.FirstOrDefault()?.FormKey;
+            bool identityMoved = weapKeys.Contains(aNew) && !weapKeys.Contains(aOld);
+            bool linkMoved = listEntry == aNew;
+            Console.WriteLine($"   [{tag}] weapon identities=[{string.Join(",", weapKeys)}]  list entry -> {listEntry}");
+            Console.WriteLine($"   [{tag}] => identity moved to A_new? {identityMoved}   link moved to A_new? {linkMoved}");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"   [{tag}] THREW {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+}


### PR DESCRIPTION
**Compact/merge Wave 1** — the shared foundation under the plugin-surgery cluster (`COMPACT_MERGE_PLAN_2026-06-26` §3), built index-free on Mutagen's forward `RemapLinks` pass. Both compact and merge (later waves) are thin policy layers over the primitives here.

## What this adds
`RemapEngine` (core) — four primitives:
- **`IdentifyExternalReferencers`** — the per-operation reverse-walk (inverse of `ErrorCheck`'s loop): which plugins *outside* the transform set reference a FormKey being remapped. Per-record fault-isolated (Q3). Reads links only → full coverage.
- **`BuildSequentialRemap`** — collision-free new-FormID allocation into a window; refuses LOUD on overflow (the real ESL light-range ceiling), named not truncated.
- **`RenumberRecordsInto`** — copy records into a fresh mod under new keys via the public `Duplicate`, then `RemapLinks` to repoint internal refs. Fails LOUD on a nested-only record (no flat group to place the duplicate).
- **`RepointInPlace`** — the streaming applier: eager-load one plugin (anti-trap), `RemapLinks`, `WriteInPlace` over itself — the opt-in external-referencer rewrite. Full coverage.

Probe `RemapWave1Probe`: `remap-wave1-mech` (empirical mechanism record), `remap-wave1-guard` (self-contained end-to-end gate, now in **ci-all**), `remap-wave1-real` (`--mo2` real-data run for xEdit verification).

## Mechanism findings (deviations from the plan, surfaced)
1. **Renumber = public `Duplicate(newKey)` into a fresh mod**, NOT the plan §4 literal "assign new FormIDs in place" — the non-public `FormKey` setter leaves Mutagen's FormKey-keyed group cache **stale** (silent-corruption trap), so it's rejected. This also unifies compact + merge and fits the "new plugin, originals untouched" lock.
2. **ESL window is `0x800–0xFFF` = 2048 IDs**, not the plan draft's 4096 — a Wave-2 reconciliation for the compact tool's refuse-threshold (the guard already enforces the right number).
3. **Nested-only records** (Cells, placed refs, INFO, navmesh, landscape) refuse LOUD in the renumber half (no flat group) — the honest coverage boundary; identify-pass and in-place repoint handle all types. Nested placement is Wave 2/3.

None challenge the plan's goal — mechanism refinements within it.

## Verification
- `ci-all` **60/60** (the new `remap-wave1-guard` co-hosts cleanly; HAPPY + CAPACITY + NESTED arms green).
- **Empirical xEdit gate deferred** (Aaron): `remap-wave1-real` will ESL-compact a real plugin to a new P′ + time the identify-pass — to run later.

## Scope
Foundation only. No MCP tool surface yet — `housecarl_compact_plugin` (Wave 2) and `housecarl_merge_plugins` (Wave 3) ride these primitives in follow-up sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)