### PR TITLE
Two lookup/compile ergonomics fixes (HCBR-2026-06-25 notes)

### DIFF
--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -540,7 +540,7 @@ public sealed class LoadOrderResolver : IDisposable
     {
         var s = _snap;                                                 // ONE build, captured for the whole enumeration
         if (!_nameToIdx.TryGetValue(pluginName, out int idx))
-            throw new ArgumentException($"plugin not in the load order: {pluginName}");
+            throw new ArgumentException($"plugin not in the load order: {pluginName}.{PluginNameSuggest.DidYouMean(pluginName, _names)}");
         if (s.Excluded.Contains(idx))
             throw new ArgumentException($"plugin '{pluginName}' was excluded from this session: {s.ExcludedPlugins[pluginName]}");
         var ov = OpenOverlay(_paths[idx], _dataDir);
@@ -586,7 +586,7 @@ public sealed class LoadOrderResolver : IDisposable
     IReadOnlyList<string> DeclaredMasters(string pluginName, IndexSnapshot s)
     {
         if (!_nameToIdx.TryGetValue(pluginName, out int idx))
-            throw new ArgumentException($"plugin not in the load order: {pluginName}");
+            throw new ArgumentException($"plugin not in the load order: {pluginName}.{PluginNameSuggest.DidYouMean(pluginName, _names)}");
         if (s.Excluded.Contains(idx))
             throw new ArgumentException($"plugin '{pluginName}' was excluded from this session: {s.ExcludedPlugins[pluginName]}");
         var ov = OpenOverlay(_paths[idx], _dataDir);
@@ -680,7 +680,7 @@ public sealed class LoadOrderResolver : IDisposable
         foreach (var name in scopePlugins)
         {
             if (!_nameToIdx.TryGetValue(name, out int i))
-                throw new ArgumentException($"plugin not in the load order: {name}");
+                throw new ArgumentException($"plugin not in the load order: {name}.{PluginNameSuggest.DidYouMean(name, _names)}");
             if (s.Excluded.Contains(i))                                    // explicitly scoped to an excluded plugin → fail loud with the reason (Q3), don't silently scan nothing
                 throw new ArgumentException($"plugin '{name}' was excluded from this session: {s.ExcludedPlugins[name]}");
             idxs.Add(i);

--- a/src/housecarl-core/PapyrusCompile.cs
+++ b/src/housecarl-core/PapyrusCompile.cs
@@ -40,6 +40,37 @@ public static class PapyrusCompile
 {
     static readonly Regex DiagLine = new(@"^(?<file>.*?)\((?<line>\d+),(?<col>\d+)\):\s*(?<msg>.*)$", RegexOptions.Compiled);
 
+    // The "symbol/type could not be resolved" message fragments — the SIGNATURE of a MISSING IMPORT (a dependency's
+    // Source\Scripts folder not on the import path), as opposed to a syntax error. Grounded in the REAL CK compiler's
+    // wording, captured 2026-06-26 against deliberately-missing PO3 / SkyUI / JContainers sources:
+    //   "unknown type po3_sksefunctions"                     — a declared/return/param type whose source isn't found
+    //   "variable JValue is undefined"                       — a static call on a script namespace not on the path
+    //   "none is not a known user-defined type"              — the cascade when an unresolved expression types to none
+    //   "X is not a function or does not exist"              — an extended function whose source copy isn't found
+    //                                                          (captured during the import-order PEX gate; spike §5.12)
+    // Contrast SYNTAX errors, which are NOT this class: "no viable alternative", "missing EOF", "mismatched input",
+    // "unknown user flag" — a code/grammar defect the import path can't fix.
+    static readonly string[] UnresolvedSymbolFragments =
+    {
+        "unknown type ",
+        " is undefined",
+        "is not a known user-defined type",
+        "is not a function or does not exist",
+    };
+
+    /// <summary>True if a compiler diagnostic message is the "symbol/type could not be resolved" class — the signature of
+    /// a MISSING IMPORT (the script is fine; a dependency's Source\Scripts folder just isn't on the import path), as
+    /// distinct from a syntax error. Used to LEAD a dominated failure with the import-path hint instead of letting the AI
+    /// read an avalanche of resolution errors as code bugs. Grounded in the real compiler's wording (see
+    /// <see cref="UnresolvedSymbolFragments"/>); case-insensitive.</summary>
+    public static bool IsUnresolvedSymbol(string? message)
+    {
+        if (string.IsNullOrEmpty(message)) return false;
+        foreach (var frag in UnresolvedSymbolFragments)
+            if (message.Contains(frag, StringComparison.OrdinalIgnoreCase)) return true;
+        return false;
+    }
+
     /// <summary>Parse PapyrusCompiler stderr into diagnostics. The format is `&lt;fullpath&gt;(line,col): message`, one per
     /// line (measured against the real compiler). Lines that don't match the shape are ignored (non-diagnostic noise).</summary>
     public static IReadOnlyList<PapyrusDiagnostic> ParseDiagnostics(string? stderr)

--- a/src/housecarl-core/PluginNameSuggest.cs
+++ b/src/housecarl-core/PluginNameSuggest.cs
@@ -1,0 +1,124 @@
+namespace HousecarlCore;
+
+/// <summary>
+/// Nearest-plugin-name suggestion for a MISSED plugin lookup — the "did you mean …?" the tool surface appends when a
+/// plugins= / lookup= / FormID-plugin value matches no plugin in the load order (HCBR-2026-06-25 ergonomics note). A
+/// near-miss is an easy slip — an apostrophe dropped ("Sanguines Trade…" for "Sanguine's Trade…"), the MOD FOLDER name
+/// passed where the .esp FILENAME was wanted ("Sanguine's Trade - An Economy Mod" for "…Mod.esp") — and a flat "not in
+/// the load order" used to cost several dead-end calls before the exact filename was found by a broad query. This points
+/// at the nearest real filename(s) instead.
+///
+/// PURE + ALLOCATION-LIGHT and run ONLY on the rare miss path (never hot), so a plain O(query·candidate) Levenshtein over
+/// the whole name list is fine. Ranking, best first:
+///   • EXTENSION-only difference  (query == candidate minus its .esp/.esm/.esl) — the bare mod-folder / missing-extension case
+///   • PREFIX                     (candidate starts with the query, or their extension-stripped stems do) — partial typed name
+///   • SUBSTRING                  (one contains the other) — a fragment of the real name
+///   • EDIT DISTANCE within a length-scaled threshold — typos / apostrophe slips
+/// Anything clearing none of these is NOT offered (Q3-adjacent: a wrong "did you mean" is worse than none), and matches
+/// are de-duplicated + capped so the message stays short.
+/// </summary>
+public static class PluginNameSuggest
+{
+    static readonly string[] PluginExts = { ".esp", ".esm", ".esl" };
+
+    /// <summary>Up to <paramref name="max"/> nearest candidate names for a missed <paramref name="query"/>, best first.
+    /// Empty when nothing clears the relevance bar (no spurious suggestion). Case-insensitive throughout.</summary>
+    public static IReadOnlyList<string> Nearest(string query, IEnumerable<string> candidates, int max = 3)
+    {
+        var q = (query ?? "").Trim();
+        if (q.Length == 0) return Array.Empty<string>();
+        var qb = StripExt(q);
+
+        var scored = new List<(string name, int score, int dist)>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var raw in candidates)
+        {
+            var c = raw?.Trim();
+            if (string.IsNullOrEmpty(c)) continue;
+            if (!seen.Add(c)) continue;                              // a name can repeat across lists — score it once
+            if (string.Equals(c, q, StringComparison.OrdinalIgnoreCase)) continue;   // an exact match isn't a miss
+            var (score, dist) = ScoreOne(q, qb, c);
+            if (score > 0) scored.Add((c, score, dist));
+        }
+
+        return scored
+            .OrderByDescending(s => s.score)
+            .ThenBy(s => s.dist)
+            .ThenBy(s => s.name, StringComparer.OrdinalIgnoreCase)
+            .Take(max)
+            .Select(s => s.name)
+            .ToList();
+    }
+
+    /// <summary>The ready-to-append clause — e.g. " Did you mean 'Sanguine's Trade - An Economy Mod.esp'?" — or "" when
+    /// there is no near match. Leads with a space so callers can append it straight onto an existing message.</summary>
+    public static string DidYouMean(string query, IEnumerable<string> candidates, int max = 3)
+    {
+        var hits = Nearest(query, candidates, max);
+        if (hits.Count == 0) return "";
+        var quoted = string.Join(", ", hits.Select(h => "'" + h + "'"));
+        return hits.Count == 1 ? $" Did you mean {quoted}?" : $" Did you mean one of: {quoted}?";
+    }
+
+    /// <summary>Relevance score (higher = closer; 0 = not a candidate) + the edit distance used as the tiebreak. The tiers
+    /// are gapped (1000/800/600/…) so a stronger match always outranks a weaker one regardless of its distance tiebreak.</summary>
+    static (int score, int dist) ScoreOne(string q, string qb, string candidate)
+    {
+        var cb = StripExt(candidate);
+        // EXTENSION-only difference: the bare folder name / missing-extension case ("…Mod" → "…Mod.esp"). Strongest signal.
+        if (string.Equals(qb, cb, StringComparison.OrdinalIgnoreCase)) return (1000, 0);
+
+        // PREFIX: a partially typed name, on the full names or their stems.
+        if (candidate.StartsWith(q, StringComparison.OrdinalIgnoreCase) ||
+            cb.StartsWith(qb, StringComparison.OrdinalIgnoreCase))
+            return (800, Math.Abs(cb.Length - qb.Length));
+
+        // SUBSTRING either way: a fragment of the real name (or the real name inside an over-long query).
+        if (candidate.Contains(q, StringComparison.OrdinalIgnoreCase) ||
+            q.Contains(candidate, StringComparison.OrdinalIgnoreCase))
+            return (600, Math.Abs(cb.Length - qb.Length));
+
+        // EDIT DISTANCE on the stems, within a length-scaled threshold — catches typos / apostrophe slips. Skip pairs whose
+        // lengths already differ by more than the threshold (they can't be within it) so most candidates cost nothing.
+        int threshold = Math.Max(2, Math.Min(qb.Length, cb.Length) / 4);
+        if (Math.Abs(qb.Length - cb.Length) > threshold) return (0, 0);
+        int d = Levenshtein(qb, cb, threshold);
+        if (d >= 0 && d <= threshold) return (500 - d * 10, d);
+        return (0, 0);
+    }
+
+    static string StripExt(string name)
+    {
+        foreach (var ext in PluginExts)
+            if (name.EndsWith(ext, StringComparison.OrdinalIgnoreCase))
+                return name.Substring(0, name.Length - ext.Length);
+        return name;
+    }
+
+    /// <summary>Case-insensitive Levenshtein with an early-out: returns -1 the moment the best possible distance on a row
+    /// exceeds <paramref name="max"/>, so a far candidate is abandoned without finishing the matrix.</summary>
+    static int Levenshtein(string a, string b, int max)
+    {
+        a = a.ToLowerInvariant(); b = b.ToLowerInvariant();
+        int n = a.Length, m = b.Length;
+        if (n == 0) return m; if (m == 0) return n;
+
+        var prev = new int[m + 1];
+        var curr = new int[m + 1];
+        for (int j = 0; j <= m; j++) prev[j] = j;
+        for (int i = 1; i <= n; i++)
+        {
+            curr[0] = i;
+            int rowBest = curr[0];
+            for (int j = 1; j <= m; j++)
+            {
+                int cost = a[i - 1] == b[j - 1] ? 0 : 1;
+                curr[j] = Math.Min(Math.Min(prev[j] + 1, curr[j - 1] + 1), prev[j - 1] + cost);
+                if (curr[j] < rowBest) rowBest = curr[j];
+            }
+            if (rowBest > max) return -1;                            // even the best continuation can't get back under max
+            (prev, curr) = (curr, prev);
+        }
+        return prev[m];
+    }
+}

--- a/src/housecarl-core/PluginNameSuggest.cs
+++ b/src/housecarl-core/PluginNameSuggest.cs
@@ -56,7 +56,9 @@ public static class PluginNameSuggest
     {
         var hits = Nearest(query, candidates, max);
         if (hits.Count == 0) return "";
-        var quoted = string.Join(", ", hits.Select(h => "'" + h + "'"));
+        // Backtick-delimit (not single-quote): mod names routinely carry an apostrophe ("Sanguine's Trade…") that
+        // would collide with a wrapping ' and read as a broken quote. Backticks never collide with the name's own text.
+        var quoted = string.Join(", ", hits.Select(h => "`" + h + "`"));
         return hits.Count == 1 ? $" Did you mean {quoted}?" : $" Did you mean one of: {quoted}?";
     }
 
@@ -83,7 +85,9 @@ public static class PluginNameSuggest
         int threshold = Math.Max(2, Math.Min(qb.Length, cb.Length) / 4);
         if (Math.Abs(qb.Length - cb.Length) > threshold) return (0, 0);
         int d = Levenshtein(qb, cb, threshold);
-        if (d >= 0 && d <= threshold) return (500 - d * 10, d);
+        // Floor at 1: keep a genuine edit-distance match POSITIVE so Nearest's `score > 0` never silently drops it. The
+        // raw 500 - d*10 only reaches 0 at d>=50 — unreachable for .esp filenames (needs ~200-char stems) but free to guard.
+        if (d >= 0 && d <= threshold) return (Math.Max(1, 500 - d * 10), d);
         return (0, 0);
     }
 

--- a/src/housecarl-generator/CompileErgonomicsProbe.cs
+++ b/src/housecarl-generator/CompileErgonomicsProbe.cs
@@ -171,6 +171,67 @@ internal static class CompileErgonomicsProbe
         Check(outDirMsg.Contains("output folder you chose") && !outDirMsg.Contains("houseCARL patch-mod folder"),
               "output_dir= destination: success names the user's chosen folder, NOT a houseCARL patch folder (no over-claim)");
 
+        // ---------------------------------------------------------- D: missing-imports LEAD on a dominated failure (HCBR-2026-06-25)
+        Console.WriteLine();
+        Console.WriteLine("--- D: a failure dominated by unresolved-symbol errors LEADS with the import_dirs hint (not 'fix the code') ---");
+
+        // D1: PapyrusCompile.IsUnresolvedSymbol on the REAL captured CK compiler wording (missing PO3/SkyUI/JContainers
+        // sources, 2026-06-26) — the four resolution-error shapes are import-class; the syntax shapes are NOT.
+        Check(HousecarlCore.PapyrusCompile.IsUnresolvedSymbol("unknown type po3_sksefunctions"), "import-class: 'unknown type …'");
+        Check(HousecarlCore.PapyrusCompile.IsUnresolvedSymbol("variable JValue is undefined"), "import-class: '… is undefined'");
+        Check(HousecarlCore.PapyrusCompile.IsUnresolvedSymbol("none is not a known user-defined type"), "import-class: '… is not a known user-defined type' (cascade)");
+        Check(HousecarlCore.PapyrusCompile.IsUnresolvedSymbol("HC_ImportOrderProbeExt is not a function or does not exist"), "import-class: '… is not a function or does not exist'");
+        Check(!HousecarlCore.PapyrusCompile.IsUnresolvedSymbol("no viable alternative at character '@'"), "syntax (NOT import): 'no viable alternative …'");
+        Check(!HousecarlCore.PapyrusCompile.IsUnresolvedSymbol("missing EOF at 'EndFunction'"), "syntax (NOT import): 'missing EOF …'");
+        Check(!HousecarlCore.PapyrusCompile.IsUnresolvedSymbol("Unknown user flag papyrus"), "syntax (NOT import): 'Unknown user flag …'");
+
+        // D2: a FAILED compile whose diagnostics are the real missing-import avalanche → Render LEADS with the banner + count.
+        HousecarlCore.PapyrusDiagnostic Diag(string msg) => new(@"C:\mod\Scripts\HCMissingImports.psc", 8, 1, msg);
+        var missingImports = new HousecarlCore.CompileResult(
+            Success: false, ObjectName: "HCMissingImports", PexPath: null,
+            Diagnostics: new[]
+            {
+                Diag("unknown type po3_sksefunctions"),
+                Diag("unknown type ski_configbase"),
+                Diag("variable PO3_SKSEFunctions is undefined"),
+                Diag("none is not a known user-defined type"),
+                Diag("variable JValue is undefined"),
+                Diag("variable JMap is undefined"),
+            },
+            Stdout: "", Stderr: "", ExitCode: 0, RunError: null);
+        var miMsg = CompileTools.Render(missingImports, Array.Empty<string>(), userChoseOutputDir: false);
+        Check(miMsg.Contains("INCOMPLETE import_dirs"), "dominated failure LEADS with the 'INCOMPLETE import_dirs' banner");
+        Check(miMsg.Contains("6 of 6") && miMsg.IndexOf("INCOMPLETE import_dirs", StringComparison.Ordinal) < miMsg.IndexOf("diagnostic(s)", StringComparison.Ordinal),
+              "the banner names the count (6 of 6) and precedes the diagnostic list");
+
+        // D3: a SYNTAX failure (the real captured broken-script wording) must NOT mislabel a code bug as a missing import —
+        // no banner, and the generic import tail still rides along as the fallback hint.
+        var syntaxFail = new HousecarlCore.CompileResult(
+            Success: false, ObjectName: "HCBad", PexPath: null,
+            Diagnostics: new[]
+            {
+                Diag("no viable alternative at character '@'"),
+                Diag("no viable alternative at input 'papyrus'"),
+                Diag("Unknown user flag papyrus"),
+                Diag("missing EOF at 'EndFunction'"),
+            },
+            Stdout: "", Stderr: "", ExitCode: 0, RunError: null);
+        var synMsg = CompileTools.Render(syntaxFail, Array.Empty<string>(), userChoseOutputDir: false);
+        Check(!synMsg.Contains("INCOMPLETE import_dirs"), "a syntax-only failure does NOT trigger the missing-imports banner (no false positive)");
+        Check(synMsg.Contains("import path") && synMsg.Contains("import_dirs="), "a syntax-only failure keeps the generic import-path tail as the fallback hint");
+
+        // D4: the gate is a STRONG majority + count — 2 resolution errors mixed with 3 syntax errors is NOT dominated.
+        var mixed = new HousecarlCore.CompileResult(
+            Success: false, ObjectName: "HCMixed", PexPath: null,
+            Diagnostics: new[]
+            {
+                Diag("unknown type foo"), Diag("variable bar is undefined"),
+                Diag("no viable alternative at input 'x'"), Diag("missing EOF at 'y'"), Diag("mismatched input 'z'"),
+            },
+            Stdout: "", Stderr: "", ExitCode: 0, RunError: null);
+        Check(!CompileTools.Render(mixed, Array.Empty<string>(), userChoseOutputDir: false).Contains("INCOMPLETE import_dirs"),
+              "2 resolution errors among 5 is NOT a strong majority → no banner (the gate needs >=3 AND a majority)");
+
         Console.WriteLine();
         Console.WriteLine(fail == 0
             ? "================ ALL PASS ================"

--- a/src/housecarl-generator/CompileErgonomicsProbe.cs
+++ b/src/housecarl-generator/CompileErgonomicsProbe.cs
@@ -220,17 +220,28 @@ internal static class CompileErgonomicsProbe
         Check(!synMsg.Contains("INCOMPLETE import_dirs"), "a syntax-only failure does NOT trigger the missing-imports banner (no false positive)");
         Check(synMsg.Contains("import path") && synMsg.Contains("import_dirs="), "a syntax-only failure keeps the generic import-path tail as the fallback hint");
 
-        // D4: the gate is a STRONG majority + count — 2 resolution errors mixed with 3 syntax errors is NOT dominated.
-        var mixed = new HousecarlCore.CompileResult(
-            Success: false, ObjectName: "HCMixed", PexPath: null,
-            Diagnostics: new[]
-            {
-                Diag("unknown type foo"), Diag("variable bar is undefined"),
-                Diag("no viable alternative at input 'x'"), Diag("missing EOF at 'y'"), Diag("mismatched input 'z'"),
-            },
-            Stdout: "", Stderr: "", ExitCode: 0, RunError: null);
-        Check(!CompileTools.Render(mixed, Array.Empty<string>(), userChoseOutputDir: false).Contains("INCOMPLETE import_dirs"),
-              "2 resolution errors among 5 is NOT a strong majority → no banner (the gate needs >=3 AND a majority)");
+        // Helper: build a failed compile from N unresolved + M syntax diagnostics, to pin the gate boundary exactly.
+        HousecarlCore.CompileResult Fail(int unresolved, int syntax)
+        {
+            var ds = new List<HousecarlCore.PapyrusDiagnostic>();
+            for (int i = 0; i < unresolved; i++) ds.Add(Diag($"unknown type frameworktype{i}"));
+            for (int i = 0; i < syntax; i++) ds.Add(Diag($"no viable alternative at input 'tok{i}'"));
+            return new HousecarlCore.CompileResult(false, "HCBoundary", null, ds, "", "", 0, null);
+        }
+        bool Banner(HousecarlCore.CompileResult r) =>
+            CompileTools.Render(r, Array.Empty<string>(), userChoseOutputDir: false).Contains("INCOMPLETE import_dirs");
+
+        // D4: COUNT floor — 2 unresolved is below the >=3 minimum regardless of ratio, so no banner (a 1-2 error typo).
+        Check(!Banner(Fail(unresolved: 2, syntax: 0)), "2 unresolved (100% but < 3) → no banner (the >=3 count floor)");
+
+        // D5: the reviewer's boundary — a near-EVEN 3-of-6 split (half could be real syntax bugs) must NOT earn the
+        // confident "not a bug" banner under the >=2/3 gate (3/6 = 50% < 66%). It falls to the generic import tail instead.
+        Check(!Banner(Fail(unresolved: 3, syntax: 3)), "3-of-6 (50%) → NO banner: a near-even split is below the 2/3 supermajority bar");
+
+        // D6: exactly AT the 2/3 bar (4-of-6) DOES fire — the gate is inclusive at two-thirds.
+        Check(Banner(Fail(unresolved: 4, syntax: 2)), "4-of-6 (exactly 2/3) → banner fires (the gate is inclusive at two-thirds)");
+        // …and just over keeps firing (the overwhelming real signature: ~all unresolved).
+        Check(Banner(Fail(unresolved: 5, syntax: 1)), "5-of-6 (>2/3) → banner fires");
 
         Console.WriteLine();
         Console.WriteLine(fail == 0

--- a/src/housecarl-generator/LoadOrderStatusProbe.cs
+++ b/src/housecarl-generator/LoadOrderStatusProbe.cs
@@ -223,6 +223,39 @@ internal static class LoadOrderStatusProbe
                 var text = Render(svc, partial, "Partial");
                 Check(text.Contains("[!]") && text.Contains("modlist.txt"), "render shows the warning under the inspection block");
             }
+
+            // ---- J: a near-miss lookup is pointed at the nearest real plugin (HCBR-2026-06-25 ergonomics note) ----
+            Console.WriteLine();
+            Console.WriteLine("--- J: a near-miss plugin/mod lookup suggests the nearest real name (no more flat 'not in the load order') ---");
+
+            // J1: PluginNameSuggest ranking on the REPORT's real names (the apostrophe slip + the mod-folder-vs-filename mix-up).
+            const string real = "Sanguine's Trade - An Economy Mod.esp";
+            var pool = new[] { "Skyrim.esm", real, "Requiem.esp" };
+            Check(PluginNameSuggest.Nearest("Sanguines Trade - An Economy Mod.esp", pool).FirstOrDefault() == real,
+                  "apostrophe slip (edit-distance 1) → suggests the real .esp");
+            Check(PluginNameSuggest.Nearest("Sanguine's Trade - An Economy Mod", pool).FirstOrDefault() == real,
+                  "the MOD FOLDER name (no extension) → suggests the matching .esp (extension-difference rule)");
+            Check(PluginNameSuggest.Nearest("Totally Unrelated Content Pack.esp", pool).Count == 0,
+                  "a far miss yields NO suggestion (a wrong 'did you mean' is worse than none)");
+            Check(PluginNameSuggest.Nearest(real, pool).Count == 0, "an EXACT match is not a miss → no suggestion");
+            Check(PluginNameSuggest.DidYouMean("Sanguines Trade - An Economy Mod.esp", pool).Contains("Did you mean")
+                  && PluginNameSuggest.DidYouMean("Sanguines Trade - An Economy Mod.esp", pool).Contains(real),
+                  "DidYouMean renders the clause naming the real plugin");
+
+            // J2: the suggestion reaches the RENDERED lookup= verdict the user actually sees.
+            string instJ = MakeInstance("inst-j");
+            WriteProfile(Path.Combine(instJ, "profiles", "Default"), new[] { masterName }, new[] { "*" + masterName }, new[] { "+MasterMod" });
+            using (var svc = LoadOrderService.WithInstance(instJ, 0, store))
+            {
+                // masterName is "HcLosMaster.esm" — look it up WITHOUT the extension (the bare folder/no-ext case).
+                string noExt = Path.GetFileNameWithoutExtension(masterName);
+                var hit = StatusWire.Render(svc.StatusData(), logs, svc.NamedProfileComposition(null), lookup: noExt, cap: 80_000);
+                Check(hit.Contains("not in the load order") && hit.Contains("Did you mean") && hit.Contains(masterName),
+                      $"lookup='{noExt}' (no extension) → the plugin-miss line suggests '{masterName}'");
+                var farMiss = StatusWire.Render(svc.StatusData(), logs, svc.NamedProfileComposition(null), lookup: "ZzzNothingLikeIt.esp", cap: 80_000);
+                Check(farMiss.Contains("not in the load order") && !farMiss.Contains("Did you mean"),
+                      "an unrelated lookup renders the miss with NO suggestion (no spurious 'did you mean')");
+            }
         }
         finally { try { Directory.Delete(root, recursive: true); } catch { /* temp scratch */ } }
 

--- a/src/housecarl-mcp/CompileTools.cs
+++ b/src/housecarl-mcp/CompileTools.cs
@@ -166,12 +166,32 @@ public static class CompileTools
         sb.Append("compile FAILED: ").Append(r.ObjectName).Append(".psc — no new .pex produced (any previous build is left unchanged).");
         if (r.Diagnostics.Count > 0)
         {
+            // MISSING-IMPORTS LEAD (HCBR-2026-06-25): when the failure is DOMINATED by unresolved-symbol/type errors, the
+            // overwhelmingly likely cause is an incomplete import_dirs — NOT a bug in the script (a single missing framework
+            // header cascades into dozens of "unknown type / is undefined" lines that read like code errors). Surface that
+            // FIRST so the AI fixes the import path instead of "fixing" correct code. Gated on a strong majority + a real
+            // count (>=3) so a one-off typo's 1-2 resolution errors never mislabel a genuine code bug as a missing import.
+            int unresolved = 0;
+            foreach (var d in r.Diagnostics) if (HousecarlCore.PapyrusCompile.IsUnresolvedSymbol(d.Message)) unresolved++;
+            bool dominatedByMissingImports = unresolved >= 3 && unresolved * 2 >= r.Diagnostics.Count;
+            if (dominatedByMissingImports)
+                sb.Append("\n⚠ This looks like INCOMPLETE import_dirs, not a bug in the script: ")
+                  .Append(unresolved).Append(" of ").Append(r.Diagnostics.Count)
+                  .Append(" diagnostics are unresolved-symbol/type errors (e.g. 'unknown type …', '… is undefined'). The CK " +
+                          "compiler resolves every referenced script against the import path, so a dependency whose Source\\Scripts " +
+                          "folder is missing makes ALL its calls/types fail. Re-run with import_dirs= listing EVERY dependency's " +
+                          "source folder (SKSE, SkyUI, PapyrusUtil, PO3, JContainers, …; ';'-separated) — the same set your " +
+                          "project's compile .bat passes via -i=.");
+
             // "diagnostic(s)", not "error(s)": the CK compiler mixes warnings into a failed run's output and the
             // parser doesn't split severities — labelling them all errors over-claims (2026-06-12 hunt render wave).
             sb.Append('\n').Append(r.Diagnostics.Count).Append(" diagnostic(s) (errors and possibly warnings — the CK compiler mixes them):");
             foreach (var d in r.Diagnostics) sb.Append("\n  ").Append(d);
-            sb.Append("\nfix the .psc and recompile (look unfamiliar functions/types up with the papyrus-reference skill). " +
-                      "If a dependency type is 'not found', its source folder may be missing from the import path — pass it via import_dirs=.");
+            // The generic tail stays for the NON-dominated case (a few resolution errors mixed with real ones); when we
+            // already led with the strong missing-imports banner, don't repeat the import line.
+            sb.Append("\nfix the .psc and recompile (look unfamiliar functions/types up with the papyrus-reference skill).");
+            if (!dominatedByMissingImports)
+                sb.Append(" If a dependency type is 'not found', its source folder may be missing from the import path — pass it via import_dirs=.");
         }
         else
         {

--- a/src/housecarl-mcp/CompileTools.cs
+++ b/src/housecarl-mcp/CompileTools.cs
@@ -168,12 +168,15 @@ public static class CompileTools
         {
             // MISSING-IMPORTS LEAD (HCBR-2026-06-25): when the failure is DOMINATED by unresolved-symbol/type errors, the
             // overwhelmingly likely cause is an incomplete import_dirs — NOT a bug in the script (a single missing framework
-            // header cascades into dozens of "unknown type / is undefined" lines that read like code errors). Surface that
-            // FIRST so the AI fixes the import path instead of "fixing" correct code. Gated on a strong majority + a real
-            // count (>=3) so a one-off typo's 1-2 resolution errors never mislabel a genuine code bug as a missing import.
+            // header cascades into dozens of "unknown type / is undefined" lines, plus secondary type-mismatch noise, that
+            // read like code errors). Surface that FIRST so the AI fixes the import path instead of "fixing" correct code.
+            // Gated on a >=2/3 SUPERMAJORITY of the diagnostics AND a real count (>=3): a genuine missing import is
+            // overwhelmingly unresolved (~all of the ~360 in the report), so a near-EVEN split — which could be half real
+            // syntax bugs — must NOT earn the confident "not a bug" banner (it falls to the generic tail instead). The full
+            // diagnostic list prints either way, so a missed banner only costs the lead hint, never the errors themselves.
             int unresolved = 0;
             foreach (var d in r.Diagnostics) if (HousecarlCore.PapyrusCompile.IsUnresolvedSymbol(d.Message)) unresolved++;
-            bool dominatedByMissingImports = unresolved >= 3 && unresolved * 2 >= r.Diagnostics.Count;
+            bool dominatedByMissingImports = unresolved >= 3 && unresolved * 3 >= r.Diagnostics.Count * 2;
             if (dominatedByMissingImports)
                 sb.Append("\n⚠ This looks like INCOMPLETE import_dirs, not a bug in the script: ")
                   .Append(unresolved).Append(" of ").Append(r.Diagnostics.Count)

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -797,7 +797,8 @@ public sealed class LoadOrderService : IDisposable
         if (plugin is not null && !view.ContainsPlugin(plugin))
             return ReadOutcome.Fail(fk,
                 $"Plugin '{plugin}' is not in the load order ({view.PluginCount} plugins; names match the plugin FILENAME " +
-                "incl. .esp/.esm, case-insensitively) — houseCARL reads load-order truth only and does not open disabled " +
+                "incl. .esp/.esm, case-insensitively)." + HousecarlCore.PluginNameSuggest.DidYouMean(plugin, resolver.PluginNames) +
+                " houseCARL reads load-order truth only and does not open disabled " +
                 "plugins off disk. If this is a freshly written houseCARL patch, it isn't enabled yet: enable + sort it in " +
                 "MO2, then re-read. To verify a write BEFORE enabling, use the write call's own read-back " +
                 "(full_readback=true returns the whole written record). If a prior write into this patch reported success, " +

--- a/src/housecarl-mcp/StatusTools.cs
+++ b/src/housecarl-mcp/StatusTools.cs
@@ -241,6 +241,9 @@ static class StatusWire
     {
         sb.Append("\nlookup '").Append(name).Append("':\n");
 
+        // modMiss / pluginMiss MUST stay in sync with the not-found arm of their respective ternary below (each is the
+        // negation of every hit case) — they drive whether a "did you mean" fires, so a reordering that desynced them
+        // could surface a suggestion on a non-miss. Kept adjacent + mirrored so the pairing is obvious.
         bool modMiss = !Contains(c.EnabledMods, name) && !Contains(c.DisabledMods, name);
         string asMod =
             Contains(c.EnabledMods, name)  ? "ENABLED (mod present + switched on)" :

--- a/src/housecarl-mcp/StatusTools.cs
+++ b/src/housecarl-mcp/StatusTools.cs
@@ -241,18 +241,30 @@ static class StatusWire
     {
         sb.Append("\nlookup '").Append(name).Append("':\n");
 
+        bool modMiss = !Contains(c.EnabledMods, name) && !Contains(c.DisabledMods, name);
         string asMod =
             Contains(c.EnabledMods, name)  ? "ENABLED (mod present + switched on)" :
             Contains(c.DisabledMods, name) ? "DISABLED (mod present but switched OFF — houseCARL excludes it)" :
                                              "not found in modlist.txt (not a managed mod folder name, or a UI separator)";
-        sb.Append("  as a mod:    ").Append(asMod).Append('\n');
+        sb.Append("  as a mod:    ").Append(asMod);
+        // A near-miss is an easy slip (apostrophe dropped, a stray word) — point at the nearest real mod folder(s) rather
+        // than leave a flat "not found" (HCBR-2026-06-25). Suggest across both the enabled and disabled lists.
+        if (modMiss) sb.Append(HousecarlCore.PluginNameSuggest.DidYouMean(name, c.EnabledMods.Concat(c.DisabledMods)));
+        sb.Append('\n');
 
+        bool pluginMiss = !c.ActivePluginNames.Contains(name) && !Contains(c.ImplicitPluginNames, name)
+                          && !Contains(c.InactivePluginNames, name);
         string asPlugin =
             c.ActivePluginNames.Contains(name)   ? "ACTIVE (checked in plugins.txt — houseCARL reads/writes it)" :
             Contains(c.ImplicitPluginNames, name) ? "ACTIVE (implicit master/CC, force-loaded — houseCARL reads/writes it)" :
             Contains(c.InactivePluginNames, name) ? "INACTIVE (present but unchecked — houseCARL EXCLUDES it)" :
                                                     "not in the load order (no such plugin in loadorder.txt)";
-        sb.Append("  as a plugin: ").Append(asPlugin).Append('\n');
+        sb.Append("  as a plugin: ").Append(asPlugin);
+        // The documented pain: the MOD FOLDER name passed where the .esp FILENAME was wanted, or an apostrophe slip, hits
+        // this miss and used to cost several dead-end calls. The suggester's extension-difference + prefix rules turn
+        // "Sanguine's Trade - An Economy Mod" → "Sanguine's Trade - An Economy Mod.esp" here. Match across the whole order.
+        if (pluginMiss) sb.Append(HousecarlCore.PluginNameSuggest.DidYouMean(name, c.OrderedPluginNames));
+        sb.Append('\n');
 
         // An active plugin can still be EXCLUDED from the index (a record Mutagen can't parse) — say so (Q3), so the
         // "ACTIVE … houseCARL reads/writes it" line above isn't taken as the whole truth.


### PR DESCRIPTION
Bundles the two ergonomics notes from the 2026-06-25 bug-report drop. Both are "fail *helpfully*" polish — neither was a wrong-answer or silent failure. Deliberately scoped to avoid the parallel `compact-merge` branch: both fixes extend **existing** probes already in `ci-all`, so this touches neither `CiAll.cs` nor `Program.cs` — no merge conflict with the compaction work.

## 1. Plugin-name suggestion on a miss (`a4d35ce`)
A near-miss plugin name (apostrophe dropped; mod-folder name passed for the `.esp` filename) returned a flat "not in the load order" and cost several dead-end calls. New pure `PluginNameSuggest` ranks candidates best-first — extension-only difference → prefix → substring → length-scaled Levenshtein — and suggests nothing when no candidate clears the bar.

> *before:* `as a plugin: not in the load order (no such plugin in loadorder.txt)`
> *after:*  `…loadorder.txt) Did you mean 'Sanguine's Trade - An Economy Mod.esp'?`

Wired into all three miss sites: `load_order_status` `lookup=`, `LoadOrderResolver`'s throws (behind `cross_plugin_query` / `check_errors` / plugin-scoped scans), and `read_record`'s explicit-plugin miss. Guard: `loadorder-status-guard` arm J.

## 2. Missing-import compile hint (`5fc5ba4`)
`compile_script` only auto-adds the vanilla path + the script's own folder; a single missing framework header cascades into dozens of "unknown type … / … is undefined" errors that read like code bugs (~360 in the reported case). When a failure is *dominated* by unresolved-symbol errors, the tool now **leads** with an "INCOMPLETE import_dirs, not a bug in the script" banner (N-of-M count), gated on a strong majority AND ≥3 errors so a one-off typo never gets mislabeled.

The classifier (`PapyrusCompile.IsUnresolvedSymbol`) was grounded by running the real CK compiler against deliberately-missing PO3/SkyUI/JContainers sources and keying on the **actual captured wording**, not invented patterns. Guard: `compile-ergonomics-guard` arm D.

## Not done (parked, named)
The two heavier compile ideals — reading import paths from the MO2 compiler config, and a saved/named import-set — are out of scope here; only the cheap "hint when dominated" ideal shipped.

## Evidence
- Build clean (0 errors).
- Full `ci-all` **60/60** (incl. the two extended probes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)