### PR TITLE
feat(compact): housecarl_compact_plugin — compact/merge Wave 2 (ESL-compact, flat + nested)

### DIFF
--- a/src/housecarl-core/RemapEngine.cs
+++ b/src/housecarl-core/RemapEngine.cs
@@ -329,6 +329,11 @@ public static class RemapEngine
                             var renCell = (Cell)RenumberOne(cell, dict, stats);
                             FileInteriorCellByNewId(target, renCell);
                         }
+
+            // 3. Repoint every internal reference among the copied records (flat AND nested links) to the new keys.
+            //    Inside the try so a RemapLinks throw is the SAME structured Q3 refusal as steps 1–2 — a direct engine
+            //    caller (e.g. the guard) gets a FAIL result, not a raw crash (PR #122 review #4).
+            target.RemapLinks(dict);
         }
         catch (Exception ex)
         {
@@ -336,8 +341,6 @@ public static class RemapEngine
                 $"the structural renumber failed ({WriteEngine.Describe(ex)}) — abandoned with nothing shippable (Q3).");
         }
 
-        // 3. Repoint every internal reference among the copied records (flat AND nested links) to the new keys.
-        target.RemapLinks(dict);
         return new RenumberResult(true, null, stats.Copied, stats.Renumbered);
     }
 
@@ -363,7 +366,15 @@ public static class RemapEngine
     /// records (<see cref="IMajorRecordGetterEnumerable"/> but not a record itself — the FormKey-less block-tree structs
     /// WorldspaceBlock/SubBlock, CellBlock/SubBlock) is recursed THROUGH. Everything else (scalars, FormLinks, value
     /// structs) is skipped — <c>RemapLinks</c> repoints outgoing links separately. By construction: no hand-coded family
-    /// list; the discriminator is Mutagen's own enumerable marker (remap-wave2-nested-mech).</summary>
+    /// list; the discriminator is Mutagen's own enumerable marker (remap-wave2-nested-mech).
+    ///
+    /// <para>Two load-bearing Mutagen assumptions (PR #122 review #5), both confirmed for the tested shapes by
+    /// remap-wave2-nested-mech and stable across the corpus by construction: (1) record-container list/property values are
+    /// REFERENCE types, so reflective <c>list[i] = …</c> / <c>prop.SetValue</c> writes the renumbered duplicate back into
+    /// the parent (never into a boxed struct copy); (2) the child collections implement the non-generic
+    /// <see cref="IList"/> (<c>ExtendedList&lt;T&gt;</c> does), so the <c>val is IList</c> gate reaches them. If Mutagen
+    /// ever broke either, the affected records would be SKIPPED (left at old keys) rather than fail loud — which is why the
+    /// guard pins every nesting shape on disk.</para></summary>
     static void RenumberDescendants(object container, IReadOnlyDictionary<FormKey, FormKey> dict, RenumberStats stats)
     {
         foreach (var prop in container.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))

--- a/src/housecarl-core/RemapEngine.cs
+++ b/src/housecarl-core/RemapEngine.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Reflection;
 using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
@@ -261,6 +262,151 @@ public static class RemapEngine
             return true;
         }
         return false;
+    }
+
+    // ======================================================================
+    //  3a-NESTED. WHOLE-MOD STRUCTURAL RENUMBER — build P′ incl. nested records
+    //  (Wave 2: the gap RenumberRecordsInto refuses loud on). Walks the source mod's
+    //  STRUCTURE (not a flat record stream, which loses parentage): each flat-group
+    //  record AND its nested children (a worldspace's exterior cells + placed refs,
+    //  a dialog topic's INFOs), plus the interior-cell block tree. Renumber mechanism
+    //  pinned by remap-wave2-nested-mech: record.Duplicate(newKey) DEEP-COPIES a
+    //  record's nested children (at their OLD keys), so we Duplicate the container
+    //  then recursively REPLACE each originating child with its own renumbered
+    //  Duplicate; IMajorRecordGetterEnumerable is the by-construction discriminator
+    //  for "contains records but isn't one" (the FormKey-less block-tree structs we
+    //  recurse THROUGH). RemapLinks at the end repoints every internal reference.
+    // ======================================================================
+
+    /// <summary>Per-call accounting for the structural renumber: total records placed (flat + nested) and how many of
+    /// those were actually renumbered (their key was in the dict — i.e. originating, vs an override copied at its own key).</summary>
+    sealed class RenumberStats { public int Copied; public int Renumbered; }
+
+    /// <summary>
+    /// Copy EVERY record of <paramref name="source"/> into the (fresh) mod <paramref name="target"/> under its remapped
+    /// FormKey from <paramref name="dict"/> (a record NOT in the dict — an override the compaction leaves at its master's
+    /// FormID — is copied at its OWN key), reconstructing the FULL nesting: flat top-level records + their nested children
+    /// (worldspace→exterior cells→placed refs, dialog topic→INFOs) AND the interior-cell block tree. Then
+    /// <c>RemapLinks(dict)</c> over the whole target so every INTERNAL reference resolves to the new keys. This is the
+    /// compact tool's core — the structural superset of the flat <see cref="RenumberRecordsInto"/> (which has no parentage
+    /// and so refuses nested-only records); both share the <c>Duplicate(newKey)</c> mechanism and <see cref="TryAddToFlatGroup"/>.
+    ///
+    /// Coverage (Q3): handles every record type — flat groups via <see cref="WriteEngine.EnumerateFlatGroups"/>, interior
+    /// cells via the block tree, and any nested child via the generic <see cref="RenumberDescendants"/> walk (no hand-coded
+    /// per-family list). A flat record whose group can't be resolved on the target (an engine inconsistency that should be
+    /// impossible by construction) is REFUSED LOUD with nothing half-shippable, never a silent drop.
+    /// </summary>
+    public static RenumberResult RenumberModInto(
+        SkyrimMod target, ISkyrimModGetter source, IReadOnlyDictionary<FormKey, FormKey> dict)
+    {
+        var stats = new RenumberStats();
+        try
+        {
+            // 1. FLAT top-level groups (weapons … AND worldspaces, dialog topics — each carries its nested children).
+            foreach (var (prop, _, _) in WriteEngine.EnumerateFlatGroups(typeof(SkyrimMod)))
+            {
+                var srcProp = source.GetType().GetProperty(prop.Name);
+                if (srcProp?.GetValue(source) is not IEnumerable srcGroup) continue;      // group absent on the getter — nothing to copy
+                foreach (var item in srcGroup)
+                {
+                    if (item is not IMajorRecordGetter rec) continue;
+                    var dup = RenumberOne(rec, dict, stats);
+                    if (!TryAddToFlatGroup(target, dup))
+                        return RenumberResult.Fail(
+                            $"{RecordNaming.StripOverlay(rec.GetType().Name)} {rec.FormKey} is a flat top-level record but no matching " +
+                            $"group was found on the target mod to place its renumbered copy (engine inconsistency, Q3) — the renumber is abandoned with nothing shippable.");
+                }
+            }
+
+            // 2. INTERIOR cells (mod.Cells block tree — the nested-only family that has no flat group). Each cell carries
+            //    its own placed refs / navmesh / landscape; re-file the renumbered cell by its NEW FormID digits (the
+            //    vanilla interior block convention, mirroring WriteEngine.AddInteriorCell).
+            if (source.Cells is { } cellsGroup)
+                foreach (var block in cellsGroup.Records)
+                    foreach (var sub in block.SubBlocks)
+                        foreach (var cell in sub.Cells)
+                        {
+                            var renCell = (Cell)RenumberOne(cell, dict, stats);
+                            FileInteriorCellByNewId(target, renCell);
+                        }
+        }
+        catch (Exception ex)
+        {
+            return RenumberResult.Fail(
+                $"the structural renumber failed ({WriteEngine.Describe(ex)}) — abandoned with nothing shippable (Q3).");
+        }
+
+        // 3. Repoint every internal reference among the copied records (flat AND nested links) to the new keys.
+        target.RemapLinks(dict);
+        return new RenumberResult(true, null, stats.Copied, stats.Renumbered);
+    }
+
+    /// <summary>Renumber ONE record: <c>Duplicate(newKey)</c> it under its new-or-same FormKey (Mutagen's deep-copy under
+    /// a new identity — its nested children come along at their OLD keys), then recursively renumber those descendants in
+    /// place. Counted once per record (itself, before its descendants) into <paramref name="stats"/>. Mechanism pinned by
+    /// remap-wave2-nested-mech.</summary>
+    static IMajorRecord RenumberOne(IMajorRecordGetter rec, IReadOnlyDictionary<FormKey, FormKey> dict, RenumberStats stats)
+    {
+        bool isRenumber = dict.TryGetValue(rec.FormKey, out var newKey);
+        if (!isRenumber) newKey = rec.FormKey;                                            // unmapped (an override) — copy at its own key
+        var dup = rec.Duplicate(newKey);
+        stats.Copied++;
+        if (isRenumber) stats.Renumbered++;
+        // Only records that actually CONTAIN nested records pay the property-walk cost (Any() short-circuits flat records).
+        if (dup is IMajorRecordGetterEnumerable e && e.EnumerateMajorRecords().Any())
+            RenumberDescendants(dup, dict, stats);
+        return dup;
+    }
+
+    /// <summary>Walk a container's child records and renumber each in place. A list/property element that IS a record
+    /// (<see cref="IMajorRecordGetter"/>) is REPLACED by its renumbered <see cref="RenumberOne"/>; one that merely CONTAINS
+    /// records (<see cref="IMajorRecordGetterEnumerable"/> but not a record itself — the FormKey-less block-tree structs
+    /// WorldspaceBlock/SubBlock, CellBlock/SubBlock) is recursed THROUGH. Everything else (scalars, FormLinks, value
+    /// structs) is skipped — <c>RemapLinks</c> repoints outgoing links separately. By construction: no hand-coded family
+    /// list; the discriminator is Mutagen's own enumerable marker (remap-wave2-nested-mech).</summary>
+    static void RenumberDescendants(object container, IReadOnlyDictionary<FormKey, FormKey> dict, RenumberStats stats)
+    {
+        foreach (var prop in container.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (prop.GetIndexParameters().Length != 0 || prop.GetGetMethod() is null) continue;
+            object? val;
+            try { val = prop.GetValue(container); } catch { continue; }
+            if (val is null) continue;
+
+            if (val is IList list && val is not string)
+            {
+                for (int i = 0; i < list.Count; i++)
+                {
+                    var el = list[i];
+                    if (el is IMajorRecordGetter childRec) list[i] = RenumberOne(childRec, dict, stats);
+                    else if (el is IMajorRecordGetterEnumerable) RenumberDescendants(el, dict, stats);
+                }
+            }
+            else if (val is IMajorRecordGetter singleRec)
+            {
+                if (prop.CanWrite) prop.SetValue(container, RenumberOne(singleRec, dict, stats));
+            }
+            else if (val is IMajorRecordGetterEnumerable nestedContainer)
+            {
+                RenumberDescendants(nestedContainer, dict, stats);
+            }
+        }
+    }
+
+    /// <summary>File an already-renumbered INTERIOR cell into <paramref name="target"/>'s top-level Cells block tree by
+    /// its NEW FormID digits (block = id%10, subblock = (id/10)%10 — the vanilla interior convention, mirroring
+    /// <see cref="WriteEngine.AddInteriorCell"/>'s STEP-0-proven math). The renumber re-files by the new id, so a cell
+    /// moved into the ESL window lands in the block its new id keys — what the CK expects on re-save.</summary>
+    static void FileInteriorCellByNewId(SkyrimMod target, Cell cell)
+    {
+        uint id = cell.FormKey.ID;
+        int blockN = (int)(id % 10), subN = (int)((id / 10) % 10);
+        var records = target.Cells.Records;
+        var block = records.FirstOrDefault(b => b.BlockNumber == blockN);
+        if (block is null) { block = new CellBlock { BlockNumber = blockN, GroupType = GroupTypeEnum.InteriorCellBlock }; records.Add(block); }
+        var sub = block.SubBlocks.FirstOrDefault(s => s.BlockNumber == subN);
+        if (sub is null) { sub = new CellSubBlock { BlockNumber = subN, GroupType = GroupTypeEnum.InteriorCellSubBlock }; block.SubBlocks.Add(sub); }
+        sub.Cells.Add(cell);
     }
 
     // ======================================================================

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -899,7 +899,7 @@ public static class WritePatchBuilder
         bool Success, string? Error, bool NeedsAcknowledge, string OutputPath, string PluginName, bool InPlace, bool Esl,
         IReadOnlyList<string> Masters, int RecordsCopied, int RecordsRenumbered, long Bytes,
         IReadOnlyList<string> ExternalPlugins, IReadOnlyList<RepointReport> Repointed,
-        int PluginsScanned, int UnscannableRecords, IReadOnlyList<string> UnscannableSamples)
+        int PluginsScanned, int UnscannableRecords, IReadOnlyList<string> UnscannableSamples, string? Note = null)
     {
         public static CompactOutcome Fail(string error) =>
             new(false, error, false, "", "", false, false, Array.Empty<string>(), 0, 0, 0,
@@ -1197,7 +1197,9 @@ public static class WritePatchBuilder
         if (!ren.Success) return CompactBuildResult.Fail(ren.Error!);
 
         // NextObjectID = the next free originating id above the renumbered run (floor + #originating). WriteInPlace
-        // persists it verbatim (NoNextFormIDProcessing) — the CK reads it on the next save.
+        // persists it verbatim (NoNextFormIDProcessing) — the CK reads it on the next save. Note (PR #122 review #6): for
+        // an exactly-full light master (2048 records) this lands at 0x1000, one past the ESL ceiling — INTENTIONAL and
+        // harmless: it's only header metadata for the NEXT new record, and compact creates none (it renumbers existing ones).
         pPrime.ModHeader.Stats.NextFormID = Math.Max(floor, (uint)(floor + dict.Count));
 
         // 2. Resolve P's OWN declared masters to overlays (the faithful re-serialize set). A declared master absent from

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -879,6 +879,36 @@ public static class WritePatchBuilder
             new(false, error, "", "", false, Array.Empty<string>(), 0, 0);
     }
 
+    /// <summary>One external referencer's in-place repoint result (the opt-in compact rewrite): the plugin, whether its
+    /// references were successfully rewritten to the new keys, and the named reason if not (Q3 — a per-plugin failure is
+    /// reported, never silent; the file is left untouched on failure by <see cref="RemapEngine.RepointInPlace"/>).</summary>
+    public sealed record RepointReport(string Plugin, bool Success, string? Error);
+
+    /// <summary>The outcome of a <see cref="LoadOrderService.CompactPlugin"/> call (the compact/ESL-renumber tool).
+    /// <see cref="NeedsAcknowledge"/> ⇒ a required first-time in-place CONSENT prompt (the operation will overwrite an
+    /// existing file — the target in the in-place lane, and/or each external referencer being repointed — so the caller
+    /// must re-call with acknowledge=true); it is NOT an error (Q3). <see cref="Error"/> non-null (with NeedsAcknowledge
+    /// false) ⇒ refused, nothing written, named reason. On success the compacted P′ is at <see cref="OutputPath"/>
+    /// (<see cref="InPlace"/> ⇒ the original file was overwritten; else a NEW file keeping the source's basename in a fresh
+    /// mod folder). <see cref="RecordsRenumbered"/> originating records moved into the (light if <see cref="Esl"/>) window;
+    /// <see cref="RecordsCopied"/> total (originating + overrides copied at their master keys). <see cref="ExternalPlugins"/>
+    /// lists plugins outside the target that reference a renumbered record — empty on the clean path; on the refused path
+    /// (externals present, no opt-in) the list IS the refusal detail; with opt-in repoint, <see cref="Repointed"/> reports
+    /// each. <see cref="PluginsScanned"/>/<see cref="UnscannableRecords"/> are the identify-pass coverage accounting.</summary>
+    public sealed record CompactOutcome(
+        bool Success, string? Error, bool NeedsAcknowledge, string OutputPath, string PluginName, bool InPlace, bool Esl,
+        IReadOnlyList<string> Masters, int RecordsCopied, int RecordsRenumbered, long Bytes,
+        IReadOnlyList<string> ExternalPlugins, IReadOnlyList<RepointReport> Repointed,
+        int PluginsScanned, int UnscannableRecords, IReadOnlyList<string> UnscannableSamples)
+    {
+        public static CompactOutcome Fail(string error) =>
+            new(false, error, false, "", "", false, false, Array.Empty<string>(), 0, 0, 0,
+                Array.Empty<string>(), Array.Empty<RepointReport>(), 0, 0, Array.Empty<string>());
+        public static CompactOutcome Confirm(string prompt) =>
+            new(false, prompt, true, "", "", false, false, Array.Empty<string>(), 0, 0, 0,
+                Array.Empty<string>(), Array.Empty<RepointReport>(), 0, 0, Array.Empty<string>());
+    }
+
     /// <summary>
     /// FORWARD a NAMED plugin's version of each record INTO the patch as an override — xEdit's "copy as override into",
     /// the inverse of <see cref="Apply"/>'s winner-override. Where Apply/Create author NEW content, this re-asserts an
@@ -1088,6 +1118,116 @@ public static class WritePatchBuilder
         }
 
         return new CreatePluginOutcome(true, null, outPath, fileName, esl, masters, recordCount, bytes);
+    }
+
+    // ======================================================================
+    //  COMPACT (A2) — the core build half of housecarl_compact_plugin (the
+    //  service does the policy half: resolve P, identify externals, consent,
+    //  folder allocation, opt-in external repoint). Renumber-mechanism + nested
+    //  coverage live in RemapEngine (remap-wave1/2). Output model = a NEW P′ or
+    //  an in-place overwrite (Aaron 2026-06-26: new-file default, in-place opt-in).
+    // ======================================================================
+
+    /// <summary>Read a plugin's ORIGINATING record FormKeys (<c>FormKey.ModKey == modKey</c>) in document order — the set
+    /// a compaction renumbers (overrides, which reference a master's record, are NOT renumbered). Opens the plugin as a
+    /// binary overlay (the lazy read path) and disposes it before returning, so no handle is held at rest (Option B).
+    /// Returns false with a named reason (Q3) if the plugin can't be parsed — the same honesty the in-place lane uses
+    /// (houseCARL won't renumber a plugin it can't fully read, lest it drop a record it couldn't parse).</summary>
+    public static bool TryReadOriginatingKeys(string srcPath, ModKey modKey, out IReadOnlyList<FormKey> keys, out string? error)
+    {
+        keys = Array.Empty<FormKey>(); error = null;
+        ISkyrimModGetter? ov = null;
+        try
+        {
+            ov = SkyrimMod.CreateFromBinaryOverlay(srcPath, SkyrimRelease.SkyrimSE);
+            keys = ov.EnumerateMajorRecords().Where(r => r.FormKey.ModKey == modKey).Select(r => r.FormKey).ToList();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            error = $"cannot parse '{modKey.FileName}' to compact it ({WriteEngine.Describe(ex)}) — houseCARL won't renumber a " +
+                    "plugin it can't fully read (it would risk dropping a record it couldn't parse, Q3).";
+            return false;
+        }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    /// <summary>The result of the core compact build: success + the written file's masters / record accounting / byte
+    /// size, or a loud Q3 refusal with the file UNTOUCHED (a missing master, a renumber fault, a serialize fault).</summary>
+    public sealed record CompactBuildResult(
+        bool Success, string? Error, IReadOnlyList<string> Masters, int RecordsCopied, int RecordsRenumbered, long Bytes)
+    {
+        public static CompactBuildResult Fail(string error) => new(false, error, Array.Empty<string>(), 0, 0, 0);
+    }
+
+    /// <summary>
+    /// Build the compacted plugin P′ from <paramref name="srcPath"/> and write it to <paramref name="outPath"/> (a NEW
+    /// file, or — in the in-place lane — <paramref name="srcPath"/> itself). EAGER-loads the source mutable overlay,
+    /// renumbers EVERY record (flat + nested) into a fresh <see cref="SkyrimMod"/> via
+    /// <see cref="RemapEngine.RenumberModInto"/> under <paramref name="dict"/> (originating records → the window; overrides
+    /// copied at their master keys), sets the light flag (<paramref name="esl"/>) and the NextObjectID, resolves P's OWN
+    /// declared masters to overlays via <paramref name="resolveMasterPath"/>, and re-serializes through
+    /// <see cref="WriteEngine.WriteInPlace"/> (own masters, no baseline force, crash-atomic staged swap — the faithful
+    /// re-emit). The source overlay is DISPOSED before the write so the in-place lane (outPath == srcPath) can swap over
+    /// it. All-or-nothing (Q3): any refusal or fault leaves <paramref name="outPath"/> untouched.
+    /// </summary>
+    public static CompactBuildResult CompactBuild(
+        string srcPath, ModKey modKey, IReadOnlyDictionary<FormKey, FormKey> dict,
+        Func<string, string?> resolveMasterPath, string outPath, bool esl, uint floor)
+    {
+        // 1. Build P′ in memory, then DISPOSE the source overlay (the in-place lane overwrites srcPath — its handle must
+        //    be released before the atomic swap).
+        SkyrimMod pPrime;
+        RemapEngine.RenumberResult ren;
+        List<string> declaredMasters;
+        ISkyrimModGetter? srcOv = null;
+        try
+        {
+            srcOv = SkyrimMod.CreateFromBinaryOverlay(srcPath, SkyrimRelease.SkyrimSE);
+            declaredMasters = srcOv.ModHeader.MasterReferences.Select(m => m.Master.FileName.String).ToList();
+            pPrime = new SkyrimMod(modKey, SkyrimRelease.SkyrimSE) { IsSmallMaster = esl };
+            ren = RemapEngine.RenumberModInto(pPrime, srcOv, dict);
+        }
+        catch (Exception ex)
+        {
+            return CompactBuildResult.Fail($"cannot open/renumber '{modKey.FileName}' to compact it ({WriteEngine.Describe(ex)}) — nothing written.");
+        }
+        finally { (srcOv as IDisposable)?.Dispose(); }
+
+        if (!ren.Success) return CompactBuildResult.Fail(ren.Error!);
+
+        // NextObjectID = the next free originating id above the renumbered run (floor + #originating). WriteInPlace
+        // persists it verbatim (NoNextFormIDProcessing) — the CK reads it on the next save.
+        pPrime.ModHeader.Stats.NextFormID = Math.Max(floor, (uint)(floor + dict.Count));
+
+        // 2. Resolve P's OWN declared masters to overlays (the faithful re-serialize set). A declared master absent from
+        //    the active order is a loud refusal (the refs into it can't resolve), file untouched.
+        var overlays = new List<IDisposable>();
+        try
+        {
+            var resolved = new List<ISkyrimModGetter>();
+            foreach (var mfn in declaredMasters)
+            {
+                var mp = resolveMasterPath(mfn);
+                if (mp is null)
+                    return CompactBuildResult.Fail(
+                        $"cannot compact '{modKey.FileName}': its declared master '{mfn}' is not active in the load order, so a " +
+                        "faithful re-serialize can't resolve the references into it. Enable that master (or fix the masters in xEdit) first. Nothing was written.");
+                var mov = SkyrimMod.CreateFromBinaryOverlay(mp, SkyrimRelease.SkyrimSE);
+                overlays.Add((IDisposable)mov); resolved.Add(mov);
+            }
+            try { WriteEngine.WriteInPlace(pPrime, resolved, outPath); }
+            catch (Exception ex)
+            {
+                return CompactBuildResult.Fail(
+                    $"writing the compacted plugin failed (serialize or commit; nothing partial left): {WriteEngine.Describe(ex)} — " +
+                    $"note: a sub-0x{RemapEngine.EslFloor:X} originating record, or (for the light range) one above 0x{RemapEngine.EslCeiling:X}, is rejected by the light-/master-aware write here.");
+            }
+        }
+        finally { foreach (var d in overlays) { try { d.Dispose(); } catch { /* best-effort; never mask the write result */ } } }
+
+        long bytes = 0; try { bytes = new FileInfo(outPath).Length; } catch { }
+        return new CompactBuildResult(true, null, declaredMasters, ren.RecordsCopied, ren.RecordsRenumbered, bytes);
     }
 
     /// <summary>

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -108,6 +108,10 @@ public static class CiAll
         // dialog topic + INFO is compacted into the ESL window (nesting preserved, internal refs repointed), then its
         // external referencer is found + repointed in place. Pins the housecarl_compact_plugin tool's cell-bearing path.
         ("remap-wave2-compact-guard", RemapWave2NestedMechProbe.RunCompactGuard),
+        // COMPACT Wave 2 SERVICE-POLICY gate (PR #122 review #3): drives LoadOrderService.CompactPlugin over a synthetic
+        // MO2 instance — the clean new-file lane, esl=false, override-of-master-cell-with-new-child, external refusal, the
+        // repoint→in_place gate, not-active, and the in_place+repoint consent handshake. Covers the policy the engine guard bypasses.
+        ("compact-service-guard", CompactServiceGuardProbe.RunGuard),
     };
 
     /// <summary>Dispatch a single CI guard by name through the registry — the ONE place a CI probe is listed, so

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -103,6 +103,11 @@ public static class CiAll
         // into the ESL window + identify external referencers + in-place repoint) plus the two loud-refusal boundaries
         // (ESL capacity overflow, nested-only record). Pins the foundation the compact/merge tools (later waves) ride on.
         ("remap-wave1-guard", RemapWave1Probe.RunGuard),
+        // COMPACT/MERGE Wave 2 GATE: the NESTED compact end-to-end (RemapEngine.RenumberModInto) — a synthetic mod with
+        // a flat record, a FormList internal ref, an interior cell + placed, a worldspace + exterior cell + placed, and a
+        // dialog topic + INFO is compacted into the ESL window (nesting preserved, internal refs repointed), then its
+        // external referencer is found + repointed in place. Pins the housecarl_compact_plugin tool's cell-bearing path.
+        ("remap-wave2-compact-guard", RemapWave2NestedMechProbe.RunCompactGuard),
     };
 
     /// <summary>Dispatch a single CI guard by name through the registry — the ONE place a CI probe is listed, so

--- a/src/housecarl-generator/CompactServiceGuardProbe.cs
+++ b/src/housecarl-generator/CompactServiceGuardProbe.cs
@@ -1,0 +1,227 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// COMPACT/MERGE Wave 2 — SERVICE-POLICY guard for housecarl_compact_plugin (PR #122 review #3). Where
+/// remap-wave2-compact-guard drives the ENGINE (RenumberModInto) directly, this drives the SERVICE
+/// (<see cref="LoadOrderService.CompactPlugin"/>) over a synthetic MO2 instance, exercising the policy branches the
+/// engine guard bypasses — the paths most likely to regress silently:
+///   CLEAN     — a self-contained nested mod compacts to a NEW file (default lane): success, !InPlace, P′ in a fresh
+///               folder with every originating record in the ESL window and the light flag set.
+///   ESL-OFF   — esl=false renumbers without the light flag.
+///   OVERRIDE  — compacting a mod that OVERRIDES a master's interior cell and adds a NEW placed ref keeps the override
+///               cell at its master FormID while the new child renumbers (the realistic patch case; copied 2 / renum 1).
+///   REFUSE-EXT— a mod another plugin references is REFUSED (the external referencer named), nothing written.
+///   GATE      — repoint_externals without in_place is REFUSED (the coherence gate; review #1).
+///   NOT-ACTIVE— an unknown plugin is refused.
+///   CONSENT   — in_place + repoint without acknowledge returns the CONFIRM prompt (no write); WITH acknowledge it
+///               compacts the target IN PLACE and repoints the external referencer to the new key (the full opt-in path).
+/// Run: dotnet run --project src/housecarl-generator compact-service-guard
+/// </summary>
+public static class CompactServiceGuardProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  COMPACT Wave 2 — service-policy guard (housecarl_compact_plugin)  ################");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        var root = Path.Combine(Path.GetTempPath(), "hc-compact-service-guard-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            string instance = Path.Combine(root, "instance");
+            string profiles = Path.Combine(instance, "profiles", "Default");
+            string mods = Path.Combine(instance, "mods");
+            string data = Path.Combine(root, "game", "Data");
+            Directory.CreateDirectory(profiles); Directory.CreateDirectory(mods); Directory.CreateDirectory(data);
+            File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+                "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+                + Path.Combine(root, "game").Replace(@"\", @"\\") + ")\r\n");
+
+            // ---- fixture mods (each in its own MO2 mod folder) ----
+            var selfKey = new ModKey("HcCsSelf", ModType.Plugin);
+            var swOld = new FormKey(selfKey, 0xA01); var scOld = new FormKey(selfKey, 0xA02); var spOld = new FormKey(selfKey, 0xA03);
+            WriteMod(mods, "SelfMod", selfKey, Array.Empty<string>(), m =>
+            {
+                m.Weapons.Add(new Weapon(swOld, SkyrimRelease.SkyrimSE) { EditorID = "HcCsWeap", BasicStats = new WeaponBasicStats { Damage = 5 } });
+                var c = new Cell(scOld, SkyrimRelease.SkyrimSE) { EditorID = "HcCsCell", Flags = Cell.Flag.IsInteriorCell };
+                c.Temporary.Add(new PlacedObject(spOld, SkyrimRelease.SkyrimSE) { EditorID = "HcCsRef" });
+                FileInterior(m, c);
+            });
+
+            var baseKey = new ModKey("HcCsBase", ModType.Master);
+            var bcOld = new FormKey(baseKey, 0xA01);
+            WriteMod(mods, "BaseMod", baseKey, Array.Empty<string>(), m =>
+            {
+                var c = new Cell(bcOld, SkyrimRelease.SkyrimSE) { EditorID = "HcCsBaseCell", Flags = Cell.Flag.IsInteriorCell };
+                FileInterior(m, c);
+            });
+
+            var overKey = new ModKey("HcCsOver", ModType.Plugin);
+            var opOld = new FormKey(overKey, 0xA01);
+            {
+                using var baseOv = SkyrimMod.CreateFromBinaryOverlay(Path.Combine(mods, "BaseMod", baseKey.FileName.String), SkyrimRelease.SkyrimSE);
+                var baseCache = baseOv.ToImmutableLinkCache();
+                var baseCell = baseOv.EnumerateMajorRecords<ICellGetter>().First(c => c.EditorID == "HcCsBaseCell");
+                var modDir = Path.Combine(mods, "OverMod"); Directory.CreateDirectory(modDir);
+                var o = new SkyrimMod(overKey, SkyrimRelease.SkyrimSE);
+                var ovCell = (ICell)WriteEngine.GenericGetOrAddAsOverride(o, baseCell, baseCache);
+                ovCell.Temporary.Add(new PlacedObject(opOld, SkyrimRelease.SkyrimSE) { EditorID = "HcCsOverRef" });
+                o.ModHeader.Stats.NextFormID = 0xA02;
+                o.BeginWrite.ToPath(Path.Combine(modDir, overKey.FileName.String)).WithLoadOrder(new[] { baseOv }).NoNextFormIDProcessing().Write();
+            }
+
+            var libKey = new ModKey("HcCsLib", ModType.Plugin);
+            var lwOld = new FormKey(libKey, 0xA01);
+            WriteMod(mods, "LibMod", libKey, Array.Empty<string>(), m =>
+                m.Weapons.Add(new Weapon(lwOld, SkyrimRelease.SkyrimSE) { EditorID = "HcCsLibWeap", BasicStats = new WeaponBasicStats { Damage = 8 } }));
+
+            var depKey = new ModKey("HcCsDep", ModType.Plugin);
+            var dlOld = new FormKey(depKey, 0xA01);
+            {
+                using var libOv = SkyrimMod.CreateFromBinaryOverlay(Path.Combine(mods, "LibMod", libKey.FileName.String), SkyrimRelease.SkyrimSE);
+                var modDir = Path.Combine(mods, "DepMod"); Directory.CreateDirectory(modDir);
+                var d = new SkyrimMod(depKey, SkyrimRelease.SkyrimSE);
+                var fl = new FormList(dlOld, SkyrimRelease.SkyrimSE) { EditorID = "HcCsDepList" };
+                fl.Items.Add(new FormLink<ISkyrimMajorRecordGetter>(lwOld));
+                d.FormLists.Add(fl);
+                d.ModHeader.Stats.NextFormID = 0xA02;
+                d.BeginWrite.ToPath(Path.Combine(modDir, depKey.FileName.String)).WithLoadOrder(new[] { libOv }).NoNextFormIDProcessing().Write();
+            }
+
+            // ---- profile files (masters first, then plugins; one mod folder per plugin) ----
+            File.WriteAllText(Path.Combine(profiles, "loadorder.txt"),
+                "# header\r\n" + string.Join("\r\n", baseKey.FileName, selfKey.FileName, libKey.FileName, overKey.FileName, depKey.FileName) + "\r\n");
+            File.WriteAllText(Path.Combine(profiles, "plugins.txt"),
+                string.Join("\r\n", "*" + baseKey.FileName, "*" + selfKey.FileName, "*" + libKey.FileName, "*" + overKey.FileName, "*" + depKey.FileName) + "\r\n");
+            File.WriteAllText(Path.Combine(profiles, "modlist.txt"),
+                "# header\r\n" + string.Join("\r\n", "+DepMod", "+OverMod", "+LibMod", "+SelfMod", "+BaseMod") + "\r\n");
+
+            var store = new UserConfigStore(Path.Combine(root, "houseCARL.user.json"));
+            using var svc = LoadOrderService.WithInstance(instance, 0, store);
+            svc.Stats();   // warm the lazy index once
+
+            // ---- CLEAN: self-contained nested mod -> NEW-file compact, every record in the ESL window, light-flagged ----
+            {
+                var o = svc.CompactPlugin("HcCsSelf.esp");
+                bool windowOk = false, lightOk = false;
+                if (o.Success && File.Exists(o.OutputPath))
+                {
+                    using var pp = SkyrimMod.CreateFromBinaryOverlay(o.OutputPath, SkyrimRelease.SkyrimSE);
+                    windowOk = pp.EnumerateMajorRecords().Where(r => r.FormKey.ModKey == selfKey)
+                        .All(r => r.FormKey.ID >= RemapEngine.EslFloor && r.FormKey.ID <= RemapEngine.EslCeiling);
+                    lightOk = pp.IsSmallMaster;
+                }
+                Check(o.Success && !o.InPlace && o.Esl && o.RecordsRenumbered == 3 && o.ExternalPlugins.Count == 0 && windowOk && lightOk,
+                    $"CLEAN new-file compact (renum {o.RecordsRenumbered}, inWindow {windowOk}, light {lightOk}, ext {o.ExternalPlugins.Count}{(o.Success ? "" : "; ERR " + o.Error)})");
+            }
+
+            // ---- ESL-OFF: esl=false -> renumbered, NOT light-flagged ----
+            {
+                var o = svc.CompactPlugin("HcCsSelf.esp", esl: false);
+                bool notLight = o.Success && File.Exists(o.OutputPath) && !SkyrimMod.CreateFromBinaryOverlay(o.OutputPath, SkyrimRelease.SkyrimSE).IsSmallMaster;
+                Check(o.Success && !o.Esl && notLight, $"ESL-OFF contiguous renumber, no light flag (esl {o.Esl}, notLight {notLight})");
+            }
+
+            // ---- OVERRIDE: compacting OverMod keeps the override cell at its master key, renumbers the new placed ----
+            {
+                var o = svc.CompactPlugin("HcCsOver.esp");
+                bool ok = false;
+                if (o.Success && File.Exists(o.OutputPath))
+                {
+                    using var pp = SkyrimMod.CreateFromBinaryOverlay(o.OutputPath, SkyrimRelease.SkyrimSE);
+                    var cell = pp.EnumerateMajorRecords<ICellGetter>().FirstOrDefault(c => c.EditorID == "HcCsBaseCell");
+                    var placed = cell?.Temporary.FirstOrDefault(p => p.EditorID == "HcCsOverRef");
+                    ok = cell?.FormKey == bcOld                                        // override cell stays at the master FormID
+                         && placed is not null && placed.FormKey.ModKey == overKey      // the new placed renumbered into Over's own window
+                         && placed.FormKey.ID >= RemapEngine.EslFloor && placed.FormKey.ID <= RemapEngine.EslCeiling;
+                }
+                Check(o.Success && o.RecordsCopied == 2 && o.RecordsRenumbered == 1 && ok,
+                    $"OVERRIDE master-cell preserved + new child renumbered (copied {o.RecordsCopied}, renum {o.RecordsRenumbered}, struct {ok}{(o.Success ? "" : "; ERR " + o.Error)})");
+            }
+
+            // ---- REFUSE-EXT: LibMod is referenced by DepMod -> refused, DepMod named, nothing written ----
+            {
+                var o = svc.CompactPlugin("HcCsLib.esp");
+                Check(!o.Success && !o.NeedsAcknowledge && (o.Error?.Contains("HcCsDep.esp", StringComparison.OrdinalIgnoreCase) ?? false),
+                    $"REFUSE-EXT external referencer named ({o.Error?.Split('.')[0]})");
+            }
+
+            // ---- GATE: repoint_externals without in_place -> refused (review #1 coherence gate) ----
+            {
+                var o = svc.CompactPlugin("HcCsLib.esp", repointExternals: true, inPlace: false);
+                Check(!o.Success && (o.Error?.Contains("requires in_place", StringComparison.OrdinalIgnoreCase) ?? false),
+                    $"GATE repoint_externals requires in_place ({o.Error?.Split('.')[0]})");
+            }
+
+            // ---- NOT-ACTIVE: unknown plugin -> refused ----
+            {
+                var o = svc.CompactPlugin("HcCsNope.esp");
+                Check(!o.Success && (o.Error?.Contains("not an active plugin", StringComparison.OrdinalIgnoreCase) ?? false),
+                    $"NOT-ACTIVE unknown plugin refused ({o.Error?.Split('—')[0].Trim()})");
+            }
+
+            // ---- CONSENT: in_place + repoint WITHOUT acknowledge -> confirm prompt (no write); WITH it -> in-place compact + repoint ----
+            {
+                var pre = svc.CompactPlugin("HcCsLib.esp", repointExternals: true, inPlace: true, acknowledge: false);
+                bool confirm = pre.NeedsAcknowledge && !pre.Success
+                               && (pre.Error?.Contains("HcCsLib.esp", StringComparison.OrdinalIgnoreCase) ?? false)
+                               && (pre.Error?.Contains("HcCsDep.esp", StringComparison.OrdinalIgnoreCase) ?? false);
+                Check(confirm, $"CONSENT in_place+repoint without ack returns CONFIRM listing target+external (needsAck {pre.NeedsAcknowledge})");
+
+                var o = svc.CompactPlugin("HcCsLib.esp", repointExternals: true, inPlace: true, acknowledge: true);
+                FormKey? libWeapAfter = null, depRefAfter = null;
+                var libPath = Path.Combine(mods, "LibMod", libKey.FileName.String);
+                var depPath = Path.Combine(mods, "DepMod", depKey.FileName.String);
+                if (o.Success)
+                {
+                    using (var lb = SkyrimMod.CreateFromBinaryOverlay(libPath, SkyrimRelease.SkyrimSE))
+                        libWeapAfter = lb.Weapons.FirstOrDefault(w => w.EditorID == "HcCsLibWeap")?.FormKey;
+                    using (var db = SkyrimMod.CreateFromBinaryOverlay(depPath, SkyrimRelease.SkyrimSE))
+                        depRefAfter = db.FormLists.First().Items.FirstOrDefault()?.FormKey;
+                }
+                bool repointOk = o.Success && o.InPlace
+                                 && libWeapAfter is { } lw && lw.ModKey == libKey && lw.ID >= RemapEngine.EslFloor && lw.ID <= RemapEngine.EslCeiling
+                                 && depRefAfter == libWeapAfter
+                                 && o.Repointed.Count == 1 && o.Repointed[0].Success;
+                Check(repointOk, $"CONSENT in_place+repoint with ack: Lib weapon -> {libWeapAfter}, Dep ref -> {depRefAfter}, repointed {o.Repointed.Count(r => r.Success)}/{o.Repointed.Count}{(o.Success ? "" : "; ERR " + o.Error)}");
+            }
+        }
+        finally { try { Directory.Delete(root, true); } catch { } }
+
+        Console.WriteLine();
+        Console.WriteLine($"=== compact-service-guard: {(fail == 0 ? "PASS" : $"FAIL ({fail})")} ===");
+        return fail == 0 ? 0 : 1;
+    }
+
+    /// <summary>Build a plugin via <paramref name="build"/> and write it to its own MO2 mod folder under
+    /// <paramref name="mods"/> (no masters unless the build adds referenced records).</summary>
+    static void WriteMod(string mods, string folder, ModKey key, IReadOnlyList<string> masters, Action<SkyrimMod> build)
+    {
+        var dir = Path.Combine(mods, folder);
+        Directory.CreateDirectory(dir);
+        var m = new SkyrimMod(key, SkyrimRelease.SkyrimSE);
+        build(m);
+        m.BeginWrite.ToPath(Path.Combine(dir, key.FileName.String)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+    }
+
+    /// <summary>File an interior cell into a mod's Cells block tree by its FormID digits (mirrors WriteEngine.AddInteriorCell).</summary>
+    static void FileInterior(SkyrimMod mod, Cell cell)
+    {
+        uint id = cell.FormKey.ID;
+        int blockN = (int)(id % 10), subN = (int)((id / 10) % 10);
+        var records = mod.Cells.Records;
+        var block = records.FirstOrDefault(b => b.BlockNumber == blockN);
+        if (block is null) { block = new CellBlock { BlockNumber = blockN, GroupType = GroupTypeEnum.InteriorCellBlock }; records.Add(block); }
+        var sub = block.SubBlocks.FirstOrDefault(s => s.BlockNumber == subN);
+        if (sub is null) { sub = new CellSubBlock { BlockNumber = subN, GroupType = GroupTypeEnum.InteriorCellSubBlock }; block.SubBlocks.Add(sub); }
+        sub.Cells.Add(cell);
+    }
+}

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -217,6 +217,11 @@ if (args.Length > 0 && args[0] == "remap-wave1-mech") return RemapWave1Probe.Run
 // time the identify-pass over the live order. Needs --mo2 <inst> --plugin <Name.esp>; SKIPs without.
 if (args.Length > 0 && args[0] == "remap-wave1-real") return RemapWave1Probe.RunReal(args[1..]);
 
+// COMPACT/MERGE Wave 2 (COMPACT_MERGE_PLAN §4): EXPLORATORY mechanism pin — settle, self-contained, whether the
+// recursive Duplicate-and-replace renumber closes the nested-record gap (cell/worldspace/topic children renumber +
+// round-trip on disk), and whether IMajorRecordGetterEnumerable is the by-construction recurse discriminator.
+if (args.Length > 0 && args[0] == "remap-wave2-nested-mech") return RemapWave2NestedMechProbe.RunMechanism(args[1..]);
+
 var outputDir = Path.GetFullPath(args.Length > 0 ? args[0] : "generated");
 // The slim reference tree ships INSIDE the skill (tracked); corpus.json + summary stay in generated/.
 // Default assumes the generator is run from the repo root (as `dotnet run --project src/housecarl-generator`).

--- a/src/housecarl-generator/RemapWave1Probe.cs
+++ b/src/housecarl-generator/RemapWave1Probe.cs
@@ -459,7 +459,9 @@ public static class RemapWave1Probe
             {
                 using var ov = SkyrimMod.CreateFromBinaryOverlay(srcPath, SkyrimRelease.SkyrimSE);
                 var pPrime = new SkyrimMod(modKey, SkyrimRelease.SkyrimSE) { IsSmallMaster = true };
-                var ren = RemapEngine.RenumberRecordsInto(pPrime, ov.EnumerateMajorRecords(), plan.Dict);
+                // Wave 2: the STRUCTURAL renumber (flat + nested — cells/placed/INFO), so a cell-bearing real mod compacts
+                // too (the flat RenumberRecordsInto would refuse it loud). Same path the housecarl_compact_plugin tool uses.
+                var ren = RemapEngine.RenumberModInto(pPrime, ov, plan.Dict);
                 if (!ren.Success) { Console.WriteLine($"   REFUSE (Q3): {ren.Error}"); }
                 else
                 {

--- a/src/housecarl-generator/RemapWave2NestedMechProbe.cs
+++ b/src/housecarl-generator/RemapWave2NestedMechProbe.cs
@@ -317,7 +317,7 @@ public static class RemapWave2NestedMechProbe
                                 && intRef?.Base.FormKey == New(waOld);                      // placed.Base -> weapon (nested internal)
             bool inWindow = new[] { weap?.FormKey, list?.FormKey, intCell?.FormKey, intRef?.FormKey, ws?.FormKey, extCell?.FormKey, extRef?.FormKey, topic?.FormKey, info?.FormKey }
                             .All(k => k is { } fk && fk.ID >= RemapEngine.EslFloor && fk.ID <= RemapEngine.EslCeiling);
-            nestedOk = keys && internalRefs && inWindow;
+            nestedOk = keys && internalRefs && inWindow && ren.RecordsCopied == 9 && ren.RecordsRenumbered == 9;   // all 9 originating, none overrides
             nestedDetail = $"copied {ren.RecordsCopied}, renumbered {ren.RecordsRenumbered}; keys={keys} internalRefs={internalRefs} inWindow={inWindow}; " +
                            $"weap={weap?.FormKey} intRef={intRef?.FormKey} extRef={extRef?.FormKey} info={info?.FormKey}";
         }

--- a/src/housecarl-generator/RemapWave2NestedMechProbe.cs
+++ b/src/housecarl-generator/RemapWave2NestedMechProbe.cs
@@ -1,0 +1,430 @@
+using System.Collections;
+using System.Reflection;
+using Noggog;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// COMPACT/MERGE — WAVE 2 nested-renumber mechanism pin (the load-bearing unknown for the compact tool's nested scope).
+///
+/// Wave 1 proved the FLAT renumber: <c>record.Duplicate(newKey)</c> into a fresh mod + <c>RemapLinks</c>, placing each
+/// duplicate via its flat top-level group. <see cref="RemapEngine.RenumberRecordsInto"/> REFUSES LOUD on a record that
+/// lives ONLY in a nested group (a Cell, a Placed* under a cell, an INFO under a topic) — there is no flat group to
+/// place the duplicate into. Wave 2 must CLOSE that gap so a cell-/dialogue-bearing mod compacts. This probe settles,
+/// self-contained (synthetic, TEMP, no MO2/Skyrim.esm), the three facts the closing mechanism rests on:
+///
+///   1. Does <c>Cell.Duplicate(newKey)</c> / <c>Worldspace.Duplicate</c> / <c>DialogTopic.Duplicate</c> DEEP-COPY their
+///      nested child records (placed refs / exterior cells / INFOs), and do those children keep their OLD FormKeys?
+///      (If Duplicate dropped or shared them, the "duplicate the container, then renumber the children in place" plan
+///      would be wrong.)
+///   2. Is <c>IMajorRecordGetterEnumerable</c> the by-construction discriminator for "a sub-object that CONTAINS records
+///      but is not itself a record" (the block-tree structs WorldspaceBlock/SubBlock, CellBlock/SubBlock) — so the
+///      recursive renumber can tell "renumber this element" (an IMajorRecordGetter) from "recurse THROUGH this element"
+///      (a record-container struct) without a hand-coded per-family list?
+///   3. Does the recursive Duplicate-and-replace renumber, applied to (interior cell + placed), (worldspace + exterior
+///      cell + placed), and (topic + INFO), produce the right identities on disk after a write + re-read?
+///
+/// Run: dotnet run --project src/housecarl-generator remap-wave2-nested-mech
+/// </summary>
+public static class RemapWave2NestedMechProbe
+{
+    public static int RunMechanism(string[] args)
+    {
+        Console.WriteLine("################  COMPACT/MERGE WAVE 2 — nested-renumber mechanism pin  ################");
+        Console.WriteLine();
+
+        // ---- 2: is IMajorRecordGetterEnumerable the recurse-discriminator? Report what the block structs implement. ----
+        Console.WriteLine("DISCRIMINATOR — does each block-tree struct implement IMajorRecordGetterEnumerable (the recurse marker)?");
+        foreach (var t in new[] { typeof(WorldspaceBlock), typeof(WorldspaceSubBlock), typeof(CellBlock), typeof(CellSubBlock), typeof(Cell), typeof(Worldspace), typeof(DialogTopic), typeof(Weapon) })
+        {
+            bool enumGetter = typeof(IMajorRecordGetterEnumerable).IsAssignableFrom(t);
+            bool isRec = typeof(IMajorRecordGetter).IsAssignableFrom(t);
+            Console.WriteLine($"   {t.Name,-20} IMajorRecordGetterEnumerable={enumGetter,-5} IMajorRecordGetter={isRec}");
+        }
+        Console.WriteLine();
+
+        var tmpDir = Path.Combine(Path.GetTempPath(), "hc-remap-wave2-nested-mech");
+        if (Directory.Exists(tmpDir)) { try { Directory.Delete(tmpDir, true); } catch { } }
+        Directory.CreateDirectory(tmpDir);
+
+        var key = new ModKey("HcRemapNested", ModType.Plugin);
+
+        // ---- 1 + 3a: INTERIOR CELL + a PlacedObject child. Duplicate deep-copy, then renumber both, place by new id. ----
+        Console.WriteLine("EXPERIMENT A — interior cell {C@0xC00 -> [PlacedObject P@0xD00]} renumber C->0x800, P->0x801:");
+        bool aOk = false;
+        try
+        {
+            var cOld = new FormKey(key, 0xC00);
+            var pOld = new FormKey(key, 0xD00);
+            var cNew = new FormKey(key, 0x800);
+            var pNew = new FormKey(key, 0x801);
+            var dict = new Dictionary<FormKey, FormKey> { [cOld] = cNew, [pOld] = pNew };
+
+            // source mod with one interior cell holding one placed object
+            var src = new SkyrimMod(key, SkyrimRelease.SkyrimSE);
+            var srcCell = new Cell(cOld, SkyrimRelease.SkyrimSE) { EditorID = "HcNestCell", Flags = Cell.Flag.IsInteriorCell };
+            srcCell.Temporary.Add(new PlacedObject(pOld, SkyrimRelease.SkyrimSE) { EditorID = "HcNestRef", Scale = 1.5f });
+            FileInterior(src, srcCell);
+
+            // Duplicate deep-copy check: duplicate the cell, see if Temporary came along at the OLD key.
+            var dupCheck = (Cell)((IMajorRecordGetter)srcCell).Duplicate(cNew);
+            int dupChildCount = dupCheck.Temporary.Count;
+            FormKey? dupChildKey = dupCheck.Temporary.FirstOrDefault()?.FormKey;
+            bool deepCopied = dupChildCount == 1 && dupChildKey == pOld;
+            Console.WriteLine($"   Cell.Duplicate deep-copied Temporary? count={dupChildCount} childKey={dupChildKey} (expect 1 @ {pOld})  => {deepCopied}");
+
+            // Real renumber into a fresh target via the prototype recursion, then write + reread.
+            var tgt = new SkyrimMod(key, SkyrimRelease.SkyrimSE);
+            var renCell = (Cell)RenumberOne(srcCell, dict);
+            FileInterior(tgt, renCell);
+            tgt.ModHeader.Stats.NextFormID = 0x802;
+            tgt.RemapLinks(dict);
+
+            string path = Path.Combine(tmpDir, "A", key.FileName.String);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            tgt.BeginWrite.ToPath(path).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).NoNextFormIDProcessing().Write();
+            using var rb = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE);
+            var cells = rb.EnumerateMajorRecords<ICellGetter>().ToList();
+            var rbCell = cells.FirstOrDefault();
+            var rbChild = rbCell?.Temporary.FirstOrDefault();
+            aOk = deepCopied
+                  && cells.Count == 1 && rbCell!.FormKey == cNew
+                  && rbChild is not null && rbChild.FormKey == pNew;
+            Console.WriteLine($"   on-disk: cell={rbCell?.FormKey} (expect {cNew}); placed={rbChild?.FormKey} (expect {pNew})  => {(aOk ? "PASS" : "FAIL")}");
+        }
+        catch (Exception ex) { Console.WriteLine($"   THREW {ex.GetType().Name}: {ex.Message}"); }
+        Console.WriteLine();
+
+        // ---- 3b: WORLDSPACE + an EXTERIOR cell + a placed child. The exterior cell lives in the worldspace's SubCells
+        //         tree (Duplicate brings the whole tree); the renumber fixes the cell + placed identities IN the tree. ----
+        Console.WriteLine("EXPERIMENT B — worldspace {W@0xE00 -> SubCells -> ext Cell EC@0xE01 -> [P@0xE02]} renumber all into 0x800,0x801,0x802:");
+        bool bOk = false;
+        try
+        {
+            var wOld = new FormKey(key, 0xE00);
+            var ecOld = new FormKey(key, 0xE01);
+            var pOld = new FormKey(key, 0xE02);
+            var wNew = new FormKey(key, 0x800);
+            var ecNew = new FormKey(key, 0x801);
+            var pNew = new FormKey(key, 0x802);
+            var dict = new Dictionary<FormKey, FormKey> { [wOld] = wNew, [ecOld] = ecNew, [pOld] = pNew };
+
+            var src = new SkyrimMod(key, SkyrimRelease.SkyrimSE);
+            var ws = new Worldspace(wOld, SkyrimRelease.SkyrimSE) { EditorID = "HcNestWS" };
+            var extCell = new Cell(ecOld, SkyrimRelease.SkyrimSE) { EditorID = "HcNestExtCell", Grid = new CellGrid { Point = new P2Int(3, -4) } };
+            extCell.Temporary.Add(new PlacedObject(pOld, SkyrimRelease.SkyrimSE) { EditorID = "HcNestExtRef", Scale = 2.0f });
+            FileExterior(ws, extCell, 3, -4);
+            src.Worldspaces.Add(ws);
+
+            // Duplicate deep-copy check on the worldspace.
+            var dupWs = (Worldspace)((IMajorRecordGetter)ws).Duplicate(wNew);
+            int dupCells = dupWs.EnumerateMajorRecords<ICellGetter>().Count();
+            Console.WriteLine($"   Worldspace.Duplicate brought {dupCells} nested cell(s) (expect 1)");
+
+            var tgt = new SkyrimMod(key, SkyrimRelease.SkyrimSE);
+            tgt.Worldspaces.Add((Worldspace)RenumberOne(ws, dict));
+            tgt.ModHeader.Stats.NextFormID = 0x803;
+            tgt.RemapLinks(dict);
+
+            string path = Path.Combine(tmpDir, "B", key.FileName.String);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            tgt.BeginWrite.ToPath(path).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).NoNextFormIDProcessing().Write();
+            using var rb = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE);
+            var rbWs = rb.Worldspaces.FirstOrDefault();
+            var rbCell = rbWs?.EnumerateMajorRecords<ICellGetter>().FirstOrDefault();
+            var rbPlaced = rbCell?.Temporary.FirstOrDefault();
+            bOk = rbWs is not null && rbWs.FormKey == wNew
+                  && rbCell is not null && rbCell.FormKey == ecNew
+                  && rbPlaced is not null && rbPlaced.FormKey == pNew;
+            Console.WriteLine($"   on-disk: ws={rbWs?.FormKey} (expect {wNew}); extCell={rbCell?.FormKey} (expect {ecNew}); placed={rbPlaced?.FormKey} (expect {pNew})  => {(bOk ? "PASS" : "FAIL")}");
+        }
+        catch (Exception ex) { Console.WriteLine($"   THREW {ex.GetType().Name}: {ex.Message}"); }
+        Console.WriteLine();
+
+        // ---- 3c: DIALOG TOPIC + an INFO child. INFO lives in DialogTopic.Responses; Duplicate brings it. ----
+        Console.WriteLine("EXPERIMENT C — topic {T@0xF00 -> Responses -> INFO@0xF01} renumber T->0x800, INFO->0x801:");
+        bool cOk = false;
+        try
+        {
+            var tOld = new FormKey(key, 0xF00);
+            var iOld = new FormKey(key, 0xF01);
+            var tNew = new FormKey(key, 0x800);
+            var iNew = new FormKey(key, 0x801);
+            var dict = new Dictionary<FormKey, FormKey> { [tOld] = tNew, [iOld] = iNew };
+
+            var src = new SkyrimMod(key, SkyrimRelease.SkyrimSE);
+            var topic = new DialogTopic(tOld, SkyrimRelease.SkyrimSE) { EditorID = "HcNestTopic" };
+            topic.Responses.Add(new DialogResponses(iOld, SkyrimRelease.SkyrimSE) { EditorID = "HcNestInfo" });
+            src.DialogTopics.Add(topic);
+
+            var dupTopic = (DialogTopic)((IMajorRecordGetter)topic).Duplicate(tNew);
+            int dupInfos = dupTopic.Responses.Count;
+            Console.WriteLine($"   DialogTopic.Duplicate brought {dupInfos} INFO(s) (expect 1)");
+
+            var tgt = new SkyrimMod(key, SkyrimRelease.SkyrimSE);
+            tgt.DialogTopics.Add((DialogTopic)RenumberOne(topic, dict));
+            tgt.ModHeader.Stats.NextFormID = 0x802;
+            tgt.RemapLinks(dict);
+
+            string path = Path.Combine(tmpDir, "C", key.FileName.String);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            tgt.BeginWrite.ToPath(path).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).NoNextFormIDProcessing().Write();
+            using var rb = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE);
+            var rbTopic = rb.DialogTopics.FirstOrDefault();
+            var rbInfo = rbTopic?.Responses.FirstOrDefault();
+            cOk = rbTopic is not null && rbTopic.FormKey == tNew
+                  && rbInfo is not null && rbInfo.FormKey == iNew;
+            Console.WriteLine($"   on-disk: topic={rbTopic?.FormKey} (expect {tNew}); info={rbInfo?.FormKey} (expect {iNew})  => {(cOk ? "PASS" : "FAIL")}");
+        }
+        catch (Exception ex) { Console.WriteLine($"   THREW {ex.GetType().Name}: {ex.Message}"); }
+        Console.WriteLine();
+
+        bool pass = aOk && bOk && cOk;
+        Console.WriteLine($"=== remap-wave2-nested-mech: {(pass ? "PASS" : "FAIL")} — the recursive Duplicate-and-replace renumber is{(pass ? "" : " NOT")} viable ===");
+        try { Directory.Delete(tmpDir, true); } catch { }
+        return pass ? 0 : 1;
+    }
+
+    // ======================================================================
+    //  GUARD — the Wave 2 gate (CI-able): a self-contained, end-to-end compact of a
+    //  synthetic multi-plugin fixture with NESTED records, through the REAL
+    //  RemapEngine.RenumberModInto + identify + repoint, asserting the on-disk truth.
+    // ======================================================================
+
+    /// <summary>
+    /// Self-contained regression guard for the Wave-2 NESTED compact (RemapEngine.RenumberModInto). Synthesizes a
+    /// Donor.esp carrying one of every nesting shape — a flat weapon, a FormList with an INTERNAL ref, an interior cell
+    /// with a placed object (whose Base is an internal ref), a worldspace with an exterior cell with a placed object,
+    /// and a dialog topic with an INFO — plus an External.esp that references the weapon. Drives the FULL compact through
+    /// the real engine (RenumberModInto → write P′ → identify-pass → RepointInPlace) and asserts the on-disk truth:
+    ///   NESTED   — every originating record (flat AND nested) lands at its remapped key in the ESL window, the nesting is
+    ///              preserved (cell→placed, ws→ext cell→placed, topic→INFO), and INTERNAL refs (FormList→weapon, the
+    ///              placed object's Base→weapon) are repointed to the new keys.
+    ///   EXTERNAL — the identify-pass finds External (not Donor) as an external referencer, and RepointInPlace rewrites
+    ///              External's reference to the new weapon key.
+    /// Run: dotnet run --project src/housecarl-generator remap-wave2-compact-guard
+    /// </summary>
+    public static int RunCompactGuard(string[] args)
+    {
+        Console.WriteLine("################  COMPACT/MERGE WAVE 2 — nested compact end-to-end guard  ################");
+        Console.WriteLine();
+
+        var tmpDir = Path.Combine(Path.GetTempPath(), "hc-remap-wave2-compact-guard");
+        if (Directory.Exists(tmpDir)) { try { Directory.Delete(tmpDir, true); } catch { } }
+        Directory.CreateDirectory(tmpDir);
+
+        var donorKey = new ModKey("HcW2Donor", ModType.Plugin);
+        var extKey = new ModKey("HcW2External", ModType.Plugin);
+
+        // originating fixture keys (deliberately scattered, > 0xFFF, to force a real renumber into the window)
+        var waOld = new FormKey(donorKey, 0xA00);   // weapon
+        var flOld = new FormKey(donorKey, 0xA01);   // formlist -> [WA] (internal)
+        var icOld = new FormKey(donorKey, 0xA02);   // interior cell
+        var ipOld = new FormKey(donorKey, 0xA03);   // placed in the interior cell; Base -> WA (internal)
+        var wsOld = new FormKey(donorKey, 0xA04);   // worldspace
+        var ecOld = new FormKey(donorKey, 0xA05);   // exterior cell under the worldspace
+        var epOld = new FormKey(donorKey, 0xA06);   // placed in the exterior cell
+        var dtOld = new FormKey(donorKey, 0xA07);   // dialog topic
+        var inOld = new FormKey(donorKey, 0xA08);   // INFO under the topic
+        var exlKey = new FormKey(extKey, 0x800);    // External's formlist -> [WA] (EXTERNAL ref)
+
+        string donorPath = Path.Combine(tmpDir, donorKey.FileName.String);
+        string extPath = Path.Combine(tmpDir, extKey.FileName.String);
+
+        // --- synthesize Donor.esp with every nesting shape ---
+        {
+            var d = new SkyrimMod(donorKey, SkyrimRelease.SkyrimSE);
+            d.Weapons.Add(new Weapon(waOld, SkyrimRelease.SkyrimSE) { EditorID = "HcW2Weap", BasicStats = new WeaponBasicStats { Damage = 10 } });
+            var fl = new FormList(flOld, SkyrimRelease.SkyrimSE) { EditorID = "HcW2List" };
+            fl.Items.Add(new FormLink<ISkyrimMajorRecordGetter>(waOld));
+            d.FormLists.Add(fl);
+
+            var ic = new Cell(icOld, SkyrimRelease.SkyrimSE) { EditorID = "HcW2IntCell", Flags = Cell.Flag.IsInteriorCell };
+            var ip = new PlacedObject(ipOld, SkyrimRelease.SkyrimSE) { EditorID = "HcW2IntRef" };
+            ip.Base.SetTo(waOld);                                          // a NESTED internal ref → must repoint to the new weapon key
+            ic.Temporary.Add(ip);
+            FileInterior(d, ic);
+
+            var ws = new Worldspace(wsOld, SkyrimRelease.SkyrimSE) { EditorID = "HcW2WS" };
+            var ec = new Cell(ecOld, SkyrimRelease.SkyrimSE) { EditorID = "HcW2ExtCell", Grid = new CellGrid { Point = new P2Int(3, -4) } };
+            ec.Temporary.Add(new PlacedObject(epOld, SkyrimRelease.SkyrimSE) { EditorID = "HcW2ExtRef" });
+            FileExterior(ws, ec, 3, -4);
+            d.Worldspaces.Add(ws);
+
+            var dt = new DialogTopic(dtOld, SkyrimRelease.SkyrimSE) { EditorID = "HcW2Topic" };
+            dt.Responses.Add(new DialogResponses(inOld, SkyrimRelease.SkyrimSE) { EditorID = "HcW2Info" });
+            d.DialogTopics.Add(dt);
+
+            d.ModHeader.Stats.NextFormID = 0xA09;
+            d.BeginWrite.ToPath(donorPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).NoNextFormIDProcessing().Write();
+        }
+        // --- synthesize External.esp {EXL@0x800 -> [WA(donor)]}, master = Donor ---
+        {
+            using var donorOv = SkyrimMod.CreateFromBinaryOverlay(donorPath, SkyrimRelease.SkyrimSE);
+            var e = new SkyrimMod(extKey, SkyrimRelease.SkyrimSE);
+            var exl = new FormList(exlKey, SkyrimRelease.SkyrimSE) { EditorID = "HcW2ExtList" };
+            exl.Items.Add(new FormLink<ISkyrimMajorRecordGetter>(waOld));
+            e.FormLists.Add(exl);
+            e.ModHeader.Stats.NextFormID = 0x801;
+            e.BeginWrite.ToPath(extPath).WithLoadOrder(new[] { donorOv }).NoNextFormIDProcessing().Write();
+        }
+
+        // --- build the ESL remap over Donor's originating records + structurally renumber into P′ ---
+        RemapEngine.RemapPlan plan;
+        RemapEngine.RenumberResult ren;
+        string pPrimePath = Path.Combine(tmpDir, "pprime", donorKey.FileName.String);
+        Directory.CreateDirectory(Path.GetDirectoryName(pPrimePath)!);
+        using (var donorOv = SkyrimMod.CreateFromBinaryOverlay(donorPath, SkyrimRelease.SkyrimSE))
+        {
+            var srcKeys = donorOv.EnumerateMajorRecords().Where(r => r.FormKey.ModKey == donorKey).Select(r => r.FormKey).ToList();
+            plan = RemapEngine.BuildSequentialRemap(srcKeys, donorKey, RemapEngine.EslFloor, RemapEngine.EslCeiling);
+            var pPrime = new SkyrimMod(donorKey, SkyrimRelease.SkyrimSE) { IsSmallMaster = true };
+            ren = RemapEngine.RenumberModInto(pPrime, donorOv, plan.Dict);
+            pPrime.ModHeader.Stats.NextFormID = (uint)(RemapEngine.EslFloor + plan.Dict.Count);
+            if (ren.Success) WriteEngine.WriteInPlace(pPrime, Array.Empty<ISkyrimModGetter>(), pPrimePath);
+        }
+
+        FormKey New(FormKey old) => plan.Success && plan.Dict.TryGetValue(old, out var nk) ? nk : default;
+
+        bool nestedOk = false; string nestedDetail = ren.Error ?? "";
+        if (ren.Success && plan.Success)
+        {
+            using var pp = SkyrimMod.CreateFromBinaryOverlay(pPrimePath, SkyrimRelease.SkyrimSE);
+            // flat
+            var weap = pp.Weapons.FirstOrDefault(w => w.EditorID == "HcW2Weap");
+            var list = pp.FormLists.FirstOrDefault(l => l.EditorID == "HcW2List");
+            // interior cell + placed (Base internal ref)
+            var intCell = pp.EnumerateMajorRecords<ICellGetter>().FirstOrDefault(c => c.EditorID == "HcW2IntCell");
+            var intRef = intCell?.Temporary.FirstOrDefault(p => p.EditorID == "HcW2IntRef") as IPlacedObjectGetter;
+            // worldspace + exterior cell + placed
+            var ws = pp.Worldspaces.FirstOrDefault(w => w.EditorID == "HcW2WS");
+            var extCell = ws?.EnumerateMajorRecords<ICellGetter>().FirstOrDefault(c => c.EditorID == "HcW2ExtCell");
+            var extRef = extCell?.Temporary.FirstOrDefault(p => p.EditorID == "HcW2ExtRef");
+            // topic + INFO
+            var topic = pp.DialogTopics.FirstOrDefault(t => t.EditorID == "HcW2Topic");
+            var info = topic?.Responses.FirstOrDefault();
+
+            bool keys = weap?.FormKey == New(waOld) && list?.FormKey == New(flOld)
+                        && intCell?.FormKey == New(icOld) && intRef?.FormKey == New(ipOld)
+                        && ws?.FormKey == New(wsOld) && extCell?.FormKey == New(ecOld) && extRef?.FormKey == New(epOld)
+                        && topic?.FormKey == New(dtOld) && info?.FormKey == New(inOld);
+            bool internalRefs = list?.Items.FirstOrDefault()?.FormKey == New(waOld)        // FormList -> weapon
+                                && intRef?.Base.FormKey == New(waOld);                      // placed.Base -> weapon (nested internal)
+            bool inWindow = new[] { weap?.FormKey, list?.FormKey, intCell?.FormKey, intRef?.FormKey, ws?.FormKey, extCell?.FormKey, extRef?.FormKey, topic?.FormKey, info?.FormKey }
+                            .All(k => k is { } fk && fk.ID >= RemapEngine.EslFloor && fk.ID <= RemapEngine.EslCeiling);
+            nestedOk = keys && internalRefs && inWindow;
+            nestedDetail = $"copied {ren.RecordsCopied}, renumbered {ren.RecordsRenumbered}; keys={keys} internalRefs={internalRefs} inWindow={inWindow}; " +
+                           $"weap={weap?.FormKey} intRef={intRef?.FormKey} extRef={extRef?.FormKey} info={info?.FormKey}";
+        }
+        Console.WriteLine($"   NESTED   structural compact (flat+cell+worldspace+topic) : {(nestedOk ? "PASS" : "FAIL")}");
+        Console.WriteLine($"            {nestedDetail}");
+
+        // --- EXTERNAL: identify-pass finds External (not Donor); RepointInPlace rewrites its ref to the new weapon key. ---
+        bool externalOk = false; string extDetail = "";
+        using (var resolver = LoadOrderResolver.Build(new[] { donorPath, extPath }))
+        {
+            var targets = plan.Success ? plan.Dict.Keys.ToHashSet() : new HashSet<FormKey>();
+            var transformSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { donorKey.FileName.String };
+            var id = RemapEngine.IdentifyExternalReferencers(resolver, targets, transformSet);
+            bool identifyOk = id.HasExternalReferencers
+                              && id.ExternalPlugins.Contains(extKey.FileName.String, StringComparer.OrdinalIgnoreCase)
+                              && !id.ExternalPlugins.Contains(donorKey.FileName.String, StringComparer.OrdinalIgnoreCase)
+                              && id.UnscannableRecords == 0;
+            var rep = RemapEngine.RepointInPlace(resolver, extKey.FileName.String, plan.Success ? plan.Dict : new Dictionary<FormKey, FormKey>());
+            FormKey? extAfter = null;
+            if (rep.Success)
+            {
+                using var ee = SkyrimMod.CreateFromBinaryOverlay(extPath, SkyrimRelease.SkyrimSE);
+                extAfter = ee.FormLists.First().Items.FirstOrDefault()?.FormKey;
+            }
+            externalOk = identifyOk && rep.Success && extAfter == New(waOld);
+            extDetail = $"identify={identifyOk} (scanned {id.PluginsScanned}), repoint={rep.Success}, external ref {extAfter} -> expect {New(waOld)}";
+        }
+        Console.WriteLine($"   EXTERNAL identify + in-place repoint                     : {(externalOk ? "PASS" : "FAIL")}");
+        Console.WriteLine($"            {extDetail}");
+
+        Console.WriteLine();
+        bool pass = nestedOk && externalOk;
+        Console.WriteLine($"=== remap-wave2-compact-guard: {(pass ? "PASS" : "FAIL")} ===");
+        try { Directory.Delete(tmpDir, true); } catch { }
+        return pass ? 0 : 1;
+    }
+
+    // ======================================================================
+    //  PROTOTYPE of the recursive renumber the engine will adopt (proven here first).
+    // ======================================================================
+
+    /// <summary>Renumber ONE record: Duplicate it under its new-or-same FormKey (Mutagen's deep-copy under a new
+    /// identity — nested children come along at their OLD keys), then recursively renumber those descendants in place.</summary>
+    static IMajorRecord RenumberOne(IMajorRecordGetter rec, IReadOnlyDictionary<FormKey, FormKey> dict)
+    {
+        var newKey = dict.TryGetValue(rec.FormKey, out var nk) ? nk : rec.FormKey;
+        var dup = rec.Duplicate(newKey);
+        RenumberDescendants(dup, dict);
+        return dup;
+    }
+
+    /// <summary>Walk a container's child records and renumber each in place. A list/property element that IS a record
+    /// (<see cref="IMajorRecordGetter"/>) is REPLACED by its renumbered Duplicate; one that merely CONTAINS records
+    /// (<see cref="IMajorRecordGetterEnumerable"/> but not a record itself — the FormKey-less block-tree structs) is
+    /// recursed THROUGH. Everything else (scalars, FormLinks, value structs) is skipped — RemapLinks handles outgoing
+    /// links separately.</summary>
+    static void RenumberDescendants(object container, IReadOnlyDictionary<FormKey, FormKey> dict)
+    {
+        foreach (var prop in container.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (prop.GetIndexParameters().Length != 0 || prop.GetGetMethod() is null) continue;
+            object? val;
+            try { val = prop.GetValue(container); } catch { continue; }
+            if (val is null) continue;
+
+            if (val is IList list && val is not string)
+            {
+                for (int i = 0; i < list.Count; i++)
+                {
+                    var el = list[i];
+                    if (el is IMajorRecordGetter childRec) list[i] = RenumberOne(childRec, dict);
+                    else if (el is IMajorRecordGetterEnumerable) RenumberDescendants(el, dict);
+                }
+            }
+            else if (val is IMajorRecordGetter singleRec)
+            {
+                if (prop.CanWrite) prop.SetValue(container, RenumberOne(singleRec, dict));
+            }
+            else if (val is IMajorRecordGetterEnumerable nestedContainer)
+            {
+                RenumberDescendants(nestedContainer, dict);
+            }
+        }
+    }
+
+    // ---- minimal block-tree filing helpers (mirror WriteEngine.AddInteriorCell / AddExteriorCell), just enough for the fixtures ----
+
+    static void FileInterior(SkyrimMod mod, Cell cell)
+    {
+        uint id = cell.FormKey.ID;
+        int blockN = (int)(id % 10), subN = (int)((id / 10) % 10);
+        var records = mod.Cells.Records;
+        var block = records.FirstOrDefault(b => b.BlockNumber == blockN);
+        if (block is null) { block = new CellBlock { BlockNumber = blockN, GroupType = GroupTypeEnum.InteriorCellBlock }; records.Add(block); }
+        var sub = block.SubBlocks.FirstOrDefault(s => s.BlockNumber == subN);
+        if (sub is null) { sub = new CellSubBlock { BlockNumber = subN, GroupType = GroupTypeEnum.InteriorCellSubBlock }; block.SubBlocks.Add(sub); }
+        sub.Cells.Add(cell);
+    }
+
+    static void FileExterior(Worldspace ws, Cell cell, int gridX, int gridY)
+    {
+        int bx = (int)Math.Floor(gridX / 32.0), by = (int)Math.Floor(gridY / 32.0);
+        int sx = (int)Math.Floor(gridX / 8.0), sy = (int)Math.Floor(gridY / 8.0);
+        var block = ws.SubCells.FirstOrDefault(b => b.BlockNumberX == bx && b.BlockNumberY == by);
+        if (block is null) { block = new WorldspaceBlock { BlockNumberX = (short)bx, BlockNumberY = (short)by, GroupType = GroupTypeEnum.ExteriorCellBlock }; ws.SubCells.Add(block); }
+        var sub = block.Items.FirstOrDefault(s => s.BlockNumberX == sx && s.BlockNumberY == sy);
+        if (sub is null) { sub = new WorldspaceSubBlock { BlockNumberX = (short)sx, BlockNumberY = (short)sy, GroupType = GroupTypeEnum.ExteriorCellSubBlock }; block.Items.Add(sub); }
+        sub.Items.Add(cell);
+    }
+}

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1589,13 +1589,25 @@ public sealed class LoadOrderService : IDisposable
             var id = RemapEngine.IdentifyExternalReferencers(resolver, targets, transformSet);
 
             // 3. external-referencer policy (Q3 — never silently ship a compaction that dangles an external reference).
-            if (id.HasExternalReferencers && !repointExternals)
-                return WritePatchBuilder.CompactOutcome.Fail(
-                    $"refused — {id.ExternalPlugins.Count} plugin(s) outside '{name}' reference records it is about to renumber; compacting it " +
-                    "WOULD BREAK those references (they would point at FormIDs that no longer exist). Referencers: " +
-                    $"{string.Join(", ", id.ExternalPlugins.Take(25))}{(id.ExternalPlugins.Count > 25 ? $", … (+{id.ExternalPlugins.Count - 25} more)" : "")}. " +
-                    "Re-run with repoint_externals=true AND acknowledge=true to ALSO rewrite those plugins in place to follow the renumber, " +
-                    "or handle them yourself first. Nothing was written.");
+            if (id.HasExternalReferencers)
+            {
+                var refList = $"{string.Join(", ", id.ExternalPlugins.Take(25))}{(id.ExternalPlugins.Count > 25 ? $", … (+{id.ExternalPlugins.Count - 25} more)" : "")}";
+                if (!repointExternals)
+                    return WritePatchBuilder.CompactOutcome.Fail(
+                        $"refused — {id.ExternalPlugins.Count} plugin(s) outside '{name}' reference records it is about to renumber; compacting it " +
+                        $"WOULD BREAK those references (they would point at FormIDs that no longer exist). Referencers: {refList}. " +
+                        "Re-run with repoint_externals=true AND in_place=true (+ acknowledge=true) to ALSO rewrite those plugins in place to follow " +
+                        "the renumber, or handle them yourself first. Nothing was written.");
+                // repoint is only COHERENT paired with in_place (PR #122 review #1): in the new-file lane the renumbered
+                // records live ONLY in the not-yet-active P′, so repointing the externals now would leave them dangling
+                // against the still-active original until the MO2 swap — and broken if the user rejects P′. Couple them.
+                if (!inPlace)
+                    return WritePatchBuilder.CompactOutcome.Fail(
+                        $"refused — repoint_externals requires in_place=true. {id.ExternalPlugins.Count} plugin(s) reference records being renumbered " +
+                        $"({refList}); in the new-file lane those records exist ONLY in the not-yet-active P′, so repointing the externals now would leave " +
+                        "them dangling against the still-active original until you complete the MO2 swap (and broken if you reject P′). Either compact IN " +
+                        "PLACE (in_place=true) so the target and its referrers move together, or handle the externals yourself after enabling P′. Nothing was written.");
+            }
 
             // 4. consent gate — any in-place overwrite (the target, and/or the external referencers) needs acknowledge=true.
             bool willOverwriteTarget = inPlace;
@@ -1614,6 +1626,12 @@ public sealed class LoadOrderService : IDisposable
                 c.Append("Re-call with acknowledge=true to proceed.");
                 return WritePatchBuilder.CompactOutcome.Confirm(c.ToString());
             }
+
+            // pre-flight the in-place target's parent is writable BEFORE any work — the in-place edit lane's layer-3 check,
+            // a nicer early refusal than failing deep in the atomic swap (PR #122 review #2). Each external referencer gets
+            // the same guarantee inside RepointInPlace's own all-or-nothing write.
+            if (inPlace && InPlaceParentUnwritable(srcPath, out var unwritable))
+                return WritePatchBuilder.CompactOutcome.Fail(unwritable);
 
             // 5. output location — in-place (overwrite the original) or a NEW file keeping the source's EXACT basename in
             //    a fresh houseCARL mod folder (so its masters still resolve; the user swaps the folder in MO2 to use it).
@@ -1645,9 +1663,25 @@ public sealed class LoadOrderService : IDisposable
                     repointed.Add(new WritePatchBuilder.RepointReport(ext, rep.Success, rep.Error));
                 }
 
+            // 8. audit markers (PR #122 review #2): stamp the distinct editedInPlace= breadcrumb into the meta.ini of EVERY
+            //    file rewritten IN PLACE — the target (in-place lane) + each successfully repointed external — matching the
+            //    traceability the in-place EDIT lane gives. The CONSENT model deliberately stays compact's own per-call
+            //    confirm (NOT the persistent _store ack the edit lane uses): a compaction can rewrite a broad surface (the
+            //    target + N externals), so each one re-confirms with its exact overwrite list rather than letting a stale
+            //    field-edit ack silently authorize a full renumber. Markers are best-effort (a miss never fails the done
+            //    write, Q3) — any miss is surfaced in Note.
+            var markerNotes = new List<string>();
+            if (inPlace) { var n = MergeEditedInPlaceMarker(Path.GetDirectoryName(srcPath)); if (n is not null) markerNotes.Add(n); }
+            foreach (var r in repointed.Where(r => r.Success))
+            {
+                var rp = view.PluginPath(r.Plugin);
+                if (rp is not null) { var n = MergeEditedInPlaceMarker(Path.GetDirectoryName(rp)); if (n is not null) markerNotes.Add(n); }
+            }
+
             return new WritePatchBuilder.CompactOutcome(
                 true, null, false, outPath, name, inPlace, esl, build.Masters, build.RecordsCopied, build.RecordsRenumbered,
-                build.Bytes, id.ExternalPlugins, repointed, id.PluginsScanned, id.UnscannableRecords, id.UnscannableSamples);
+                build.Bytes, id.ExternalPlugins, repointed, id.PluginsScanned, id.UnscannableRecords, id.UnscannableSamples,
+                markerNotes.Count > 0 ? string.Join(" ", markerNotes) : null);
         }
     }
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1520,6 +1520,137 @@ public sealed class LoadOrderService : IDisposable
         }
     }
 
+    /// <summary>COMPACT / ESL-renumber a plugin (housecarl_compact_plugin, A2) — the data-layer twin of xEdit's "Compact
+    /// FormIDs for ESL". Renumbers <paramref name="pluginName"/>'s ORIGINATING records (flat AND nested — cells, placed
+    /// refs, dialog INFOs) into the light range 0x800–0xFFF (the 2048-ID window; <paramref name="esl"/>=false renumbers
+    /// contiguously without the light flag / ceiling), repoints every internal reference, keeps overrides at their master
+    /// FormIDs, and emits the result. Output model (Aaron 2026-06-26): a NEW plugin P′ keeping the source's EXACT basename
+    /// (so external masters still resolve) in a fresh houseCARL mod folder by default — original UNTOUCHED, reviewable in
+    /// xEdit before you swap; <paramref name="inPlace"/>=true overwrites the original instead (the xEdit norm; rides the
+    /// in-place consent, no backup).
+    ///
+    /// <para>The load-bearing safety (Q3, plan §2): renumbering breaks any reference from OUTSIDE the plugin (they'd point
+    /// at FormIDs that no longer exist). The identify-pass finds those external referencers across the whole order. NO
+    /// external referencers ⇒ the clean default path (emit P′, done). External referencers present ⇒ REFUSED LOUD with the
+    /// list, UNLESS <paramref name="repointExternals"/>=true, which ALSO rewrites each of them in place to follow the
+    /// renumber. Any in-place overwrite (the target in the in-place lane, and/or the external referencers) requires
+    /// <paramref name="acknowledge"/>=true — a first call without it returns a CONFIRM prompt listing exactly what will be
+    /// rewritten (never a silent original-file edit).</para>
+    ///
+    /// <para>Refuses loud + writes nothing on: the plugin not active / excluded (unparseable) / not on disk; MORE than the
+    /// light window holds (the hard ESL ceiling — named, never truncated); a declared master not active; a serialize fault.
+    /// Renumber mechanism + nested coverage: <see cref="RemapEngine.RenumberModInto"/> (remap-wave1/2). Serialized on the
+    /// write gate; the identify-pass is one whole-order link walk (~25s at full scale — a deliberate, one-shot operation).</para></summary>
+    public WritePatchBuilder.CompactOutcome CompactPlugin(
+        string pluginName, bool esl = true, bool inPlace = false, bool repointExternals = false,
+        bool acknowledge = false, string? patchName = null)
+    {
+        if (string.IsNullOrWhiteSpace(pluginName))
+            return WritePatchBuilder.CompactOutcome.Fail("plugin is required — name the plugin filename to compact (e.g. 'CoolMod.esp').");
+
+        lock (_writeGate)                                                 // one write at a time; the whole resolve→build→repoint runs under it
+        {
+            var resolver = Resolver;                                      // builds/refreshes; reentrant with _writeGate
+            var view = resolver.Capture();
+            if (!Directory.Exists(_modsDir))
+                return WritePatchBuilder.CompactOutcome.Fail($"cannot write: ModsDir '{_modsDir}' does not exist. Check HouseCarl:ModsDir.");
+
+            var name = pluginName.Trim();
+            if (!view.ContainsPlugin(name))
+                return WritePatchBuilder.CompactOutcome.Fail(
+                    $"'{name}' is not an active plugin in your load order — compact targets an active plugin (so its records, and the plugins that reference it, can be read). Pass the exact filename (e.g. 'CoolMod.esp').");
+            if (view.ExcludedPlugins.TryGetValue(name, out var excluded))
+                return WritePatchBuilder.CompactOutcome.Fail(
+                    $"cannot compact '{name}': it was EXCLUDED from this session ({excluded}) — houseCARL won't renumber a plugin it can't fully parse. The file is untouched.");
+
+            var srcPath = view.PluginPath(name);
+            if (srcPath is null || !File.Exists(srcPath))
+                return WritePatchBuilder.CompactOutcome.Fail($"'{name}' not found on disk at {srcPath ?? "<unresolved>"} — nothing to compact.");
+
+            ModKey modKey;
+            try { modKey = ModKey.FromFileName(name); }
+            catch (Exception ex) { return WritePatchBuilder.CompactOutcome.Fail($"'{name}' is not a valid plugin filename ({ex.Message})."); }
+
+            // 1. originating record keys + the remap into the (light, by default) window.
+            if (!WritePatchBuilder.TryReadOriginatingKeys(srcPath, modKey, out var keys, out var keyErr))
+                return WritePatchBuilder.CompactOutcome.Fail(keyErr!);
+            if (keys.Count == 0)
+                return WritePatchBuilder.CompactOutcome.Fail(
+                    $"'{name}' defines no originating records to renumber (it carries only overrides, or is empty) — nothing to compact.");
+
+            uint floor = RemapEngine.EslFloor;
+            uint ceiling = esl ? RemapEngine.EslCeiling : 0xFFFFFFu;      // light window, or the full 24-bit object-ID range
+            var plan = RemapEngine.BuildSequentialRemap(keys, modKey, floor, ceiling);
+            if (!plan.Success) return WritePatchBuilder.CompactOutcome.Fail(plan.Error!);
+
+            // 2. identify-pass — which plugins OUTSIDE the target reference a record being renumbered (the break risk).
+            var targets = plan.Dict.Keys.ToHashSet();
+            var transformSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { name };
+            var id = RemapEngine.IdentifyExternalReferencers(resolver, targets, transformSet);
+
+            // 3. external-referencer policy (Q3 — never silently ship a compaction that dangles an external reference).
+            if (id.HasExternalReferencers && !repointExternals)
+                return WritePatchBuilder.CompactOutcome.Fail(
+                    $"refused — {id.ExternalPlugins.Count} plugin(s) outside '{name}' reference records it is about to renumber; compacting it " +
+                    "WOULD BREAK those references (they would point at FormIDs that no longer exist). Referencers: " +
+                    $"{string.Join(", ", id.ExternalPlugins.Take(25))}{(id.ExternalPlugins.Count > 25 ? $", … (+{id.ExternalPlugins.Count - 25} more)" : "")}. " +
+                    "Re-run with repoint_externals=true AND acknowledge=true to ALSO rewrite those plugins in place to follow the renumber, " +
+                    "or handle them yourself first. Nothing was written.");
+
+            // 4. consent gate — any in-place overwrite (the target, and/or the external referencers) needs acknowledge=true.
+            bool willOverwriteTarget = inPlace;
+            bool willRepoint = id.HasExternalReferencers && repointExternals;
+            if ((willOverwriteTarget || willRepoint) && !acknowledge)
+            {
+                var c = new System.Text.StringBuilder();
+                c.Append("CONFIRM in-place rewrite (your ORIGINAL file(s) will be rewritten — no houseCARL backup or undo; keep your own):\n");
+                if (willOverwriteTarget) c.Append($"  - '{name}' will be OVERWRITTEN in place with its compacted form.\n");
+                if (willRepoint)
+                {
+                    c.Append($"  - {id.ExternalPlugins.Count} external referencer(s) will be REWRITTEN in place to repoint to the new FormIDs:\n");
+                    foreach (var pl in id.ExternalPlugins.Take(25)) c.Append($"      · {pl}\n");
+                    if (id.ExternalPlugins.Count > 25) c.Append($"      · … (+{id.ExternalPlugins.Count - 25} more)\n");
+                }
+                c.Append("Re-call with acknowledge=true to proceed.");
+                return WritePatchBuilder.CompactOutcome.Confirm(c.ToString());
+            }
+
+            // 5. output location — in-place (overwrite the original) or a NEW file keeping the source's EXACT basename in
+            //    a fresh houseCARL mod folder (so its masters still resolve; the user swaps the folder in MO2 to use it).
+            string outPath; bool createdFresh = false; RiderFolder rf = default;
+            if (inPlace) outPath = srcPath;
+            else
+            {
+                try { rf = ResolvePatchModFolder(patchName, null, Path.GetFileNameWithoutExtension(name) + " compacted"); }
+                catch (InvalidOperationException ex) { return WritePatchBuilder.CompactOutcome.Fail(ex.Message); }
+                createdFresh = rf.CreatedFresh;
+                WriteOwnerMeta(rf.ModFolder, name);                       // P′ keeps the source's exact basename
+                outPath = Path.Combine(rf.OutputDir, name);
+            }
+
+            // 6. build + write the compacted plugin.
+            var build = WritePatchBuilder.CompactBuild(srcPath, modKey, plan.Dict, view.PluginPath, outPath, esl, floor);
+            if (!build.Success)
+            {
+                if (!inPlace && createdFresh) RemoveOrNameRiderResidue(rf);   // a refused build leaves no orphan folder
+                return WritePatchBuilder.CompactOutcome.Fail(build.Error!);
+            }
+
+            // 7. opt-in: repoint each external referencer in place (per-plugin all-or-nothing; every result reported, Q3).
+            var repointed = new List<WritePatchBuilder.RepointReport>();
+            if (willRepoint)
+                foreach (var ext in id.ExternalPlugins)
+                {
+                    var rep = RemapEngine.RepointInPlace(resolver, ext, plan.Dict);
+                    repointed.Add(new WritePatchBuilder.RepointReport(ext, rep.Success, rep.Error));
+                }
+
+            return new WritePatchBuilder.CompactOutcome(
+                true, null, false, outPath, name, inPlace, esl, build.Masters, build.RecordsCopied, build.RecordsRenumbered,
+                build.Bytes, id.ExternalPlugins, repointed, id.PluginsScanned, id.UnscannableRecords, id.UnscannableSamples);
+        }
+    }
+
     /// <summary>Create a BRAND-NEW record (housecarl_create_record) — the net-new authoring capability, the sibling of
     /// <see cref="ApplyEdits"/>. Resolves <paramref name="recordType"/> (catalog name or 4-char signature) to ONE concrete
     /// catalog name (unknown/ambiguous → Q3), maps the field <paramref name="operations"/> to core <see cref="WriteRequest"/>s

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -581,6 +581,7 @@ public static class WriteTools
               .Append("'external referencers: none' may be incomplete — verify in xEdit. Samples: ").Append(string.Join("; ", o.UnscannableSamples)).Append('\n');
         }
         sb.Append("identify-pass scanned ").Append(o.PluginsScanned).Append(" plugin(s) for external references.\n");
+        if (o.Note is { } note) sb.Append("note: ").Append(note).Append('\n');
         sb.Append("reminder: FormIDs compiled into Papyrus (.pex hardcoded / GetFormFromFile) and any Mutagen-delta residual ")
           .Append("are NOT remappable — verify scripted records after compacting.");
         return sb.ToString();

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -323,6 +323,46 @@ public static class WriteTools
         return RenderCreatePlugin(svc.CreatePlugin(plugin_name, esl, author, description));
     });
 
+    [McpServerTool(Name = "housecarl_compact_plugin", Title = "Compact / ESL-renumber a plugin's FormIDs"),
+     Description(
+         "COMPACT a plugin's FormIDs — the data-layer twin of xEdit's \"Compact FormIDs for ESL\". Renumbers EVERY record " +
+         "the plugin DEFINES (its originating records — flat AND nested: cells, placed references, dialogue lines, navmesh, " +
+         "landscape) into the light/ESL range 0x800–0xFFF (the 2048-ID window), repoints every reference WITHIN the plugin, " +
+         "leaves its overrides of other mods at their master FormIDs, and flags the result a light master (ESPFE) so it " +
+         "frees a load-order slot. esl=false instead renumbers contiguously from 0x800 with NO light flag/ceiling (to close " +
+         "FormID gaps). OUTPUT (default): a NEW plugin keeping the SOURCE'S EXACT basename (so other mods that list it as a " +
+         "master still resolve) in a fresh houseCARL mod folder — your ORIGINAL is untouched; review the new one in xEdit, " +
+         "then in MO2 enable its folder and DISABLE the original mod (same basename — MO2 serves one). in_place=true instead " +
+         "OVERWRITES the original (xEdit's norm; rides the in-place consent, NO backup; needs acknowledge=true). " +
+         "THE SAFETY (Q3): renumbering breaks any reference from OUTSIDE this plugin (they'd point at FormIDs that vanish). " +
+         "houseCARL scans the WHOLE load order for such external referencers (a one-pass walk — can take ~25s on a big order): " +
+         "if NONE, it's a clean compaction; if SOME, the call is REFUSED and lists them, UNLESS repoint_externals=true, which " +
+         "ALSO rewrites each of them in place to follow the renumber (needs acknowledge=true; no backup of them either). " +
+         "Refuses loud + writes nothing on: the plugin not active / unparseable / not on disk; MORE records than the light " +
+         "range holds (the hard 2048 ESL ceiling — named, never truncated); a declared master not active; a serialize fault. " +
+         "Note: references compiled into Papyrus scripts (.pex hardcoded FormIDs / GetFormFromFile) are NOT remappable — " +
+         "verify scripted records after compacting.")]
+    public static string CompactPlugin(
+        LoadOrderService svc,
+        [Description("The plugin's filename to compact (e.g. 'CoolMod.esp') — must be active in your load order. The compacted output keeps this EXACT basename.")]
+            string plugin,
+        [Description("When true (default), renumber into the light/ESL range (0x800–0xFFF, 2048 IDs) and flag the result a light master (ESPFE) — the canonical 'compact for ESL'. false = renumber contiguously from 0x800 with no light flag or 2048 ceiling (just closes FormID gaps).")]
+            bool esl = true,
+        [Description("Optional, default false. IN-PLACE LANE (opt-in): OVERWRITE the original plugin with its compacted form (xEdit's norm) instead of writing a new file — NO houseCARL backup or undo (keep your own). Requires acknowledge=true. OMIT (the default) to write a NEW plugin (same basename, fresh mod folder) and leave the original untouched for review.")]
+            bool in_place = false,
+        [Description("Optional, default false. If OTHER plugins reference records being renumbered, compaction would break them and the call REFUSES (listing them) by default. Set true to ALSO rewrite those external referencers IN PLACE to follow the renumber (requires acknowledge=true; no backup of them either).")]
+            bool repoint_externals = false,
+        [Description("Optional, default false. Confirms the in-place trade-off when in_place=true OR repoint_externals=true (your original file(s) get rewritten, no backup). The FIRST such call without it returns a CONFIRM prompt listing exactly what will be overwritten — re-call with acknowledge=true to proceed.")]
+            bool acknowledge = false,
+        [Description("Optional. Base name for the NEW mod folder (new-file lane only; auto-suffixed if taken). Ignored with in_place=true. The PLUGIN inside ALWAYS keeps the source's exact basename so external masters still resolve.")]
+            string? patch_name = null) => Guard.Tool("housecarl_compact_plugin", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        if (string.IsNullOrWhiteSpace(plugin))
+            return "error: plugin is empty. Name the plugin filename to compact (e.g. 'CoolMod.esp').";
+        return RenderCompact(svc.CompactPlugin(plugin, esl, in_place, repoint_externals, acknowledge, patch_name));
+    });
+
     /// <summary>Compact, parseable confirmation (rulebook: short mutation confirmation + the IDs needed for follow-up).
     /// On refusal, the full reason (every malformed/rejected op) so the caller can fix and retry.</summary>
     static string Render(WritePatchBuilder.PatchOutcome o, int maxChars = 0)
@@ -486,6 +526,63 @@ public static class WriteTools
         sb.Append("this is a trigger/placeholder plugin: it carries no records, so it changes nothing in game by itself — ")
           .Append("its only job is to make the basename '").Append(Path.GetFileNameWithoutExtension(file))
           .Append("' present in the load order (so a basename-bound SKSE config resolves, a FormID range is reserved, etc.).");
+        return sb.ToString();
+    }
+
+    /// <summary>Confirmation for housecarl_compact_plugin: where the compacted P′ landed (new file vs in place), the
+    /// record accounting (originating renumbered / overrides kept), masters, the external-referencer verdict (clean,
+    /// or the per-plugin repoint results), the identify-pass coverage, and the un-remappable-script reminder (Q3). The
+    /// NeedsAcknowledge prompt (a required in-place consent) is returned verbatim, not as an error; on refusal the named
+    /// reason so the caller can fix and retry.</summary>
+    static string RenderCompact(WritePatchBuilder.CompactOutcome o)
+    {
+        if (o.NeedsAcknowledge) return o.Error!;            // the in-place CONSENT prompt — a required confirmation, NOT an error (Q3)
+        if (!o.Success) return "error: " + o.Error;
+        var file = Path.GetFileName(o.OutputPath);
+        var modFolder = Path.GetFileName(Path.GetDirectoryName(o.OutputPath) ?? "");
+        var sb = new StringBuilder();
+        if (o.InPlace)
+            sb.Append("compacted ").Append(file).Append(" IN PLACE (").Append(o.Bytes)
+              .Append(" bytes — your ORIGINAL file was rewritten; no houseCARL backup or undo)\n")
+              .Append("mod folder: ").Append(modFolder).Append("  — already active; re-sort only if a winner changed\n");
+        else
+            sb.Append("wrote compacted ").Append(file).Append(" (new plugin; ").Append(o.Bytes).Append(" bytes)\n")
+              .Append("mod folder: ").Append(modFolder).Append("  — enable it and DISABLE the original '").Append(file)
+              .Append("' mod in MO2 (same basename — MO2 serves one). Review in xEdit first.\n");
+
+        int overrides = o.RecordsCopied - o.RecordsRenumbered;
+        sb.Append(o.Esl ? "light master (ESPFE): yes — " : "renumbered (not light-flagged): ");
+        sb.Append(o.RecordsRenumbered).Append(o.RecordsRenumbered == 1 ? " originating record renumbered " : " originating records renumbered ");
+        sb.Append(o.Esl ? "into the light range 0x800–0xFFF" : "contiguously from 0x800");
+        if (overrides > 0) sb.Append("; ").Append(overrides).Append(overrides == 1 ? " override kept at its master FormID" : " overrides kept at their master FormIDs");
+        sb.Append(".\n");
+        sb.Append("masters: ").Append(o.Masters.Count == 0 ? "(none)" : string.Join(", ", o.Masters)).Append('\n');
+
+        if (o.ExternalPlugins.Count == 0)
+            sb.Append("external referencers: none — clean compaction (nothing outside this plugin pointed at a renumbered record).\n");
+        else if (o.Repointed.Count > 0)
+        {
+            int ok = o.Repointed.Count(r => r.Success);
+            sb.Append("external referencers repointed in place: ").Append(ok).Append('/').Append(o.Repointed.Count).Append(" succeeded\n");
+            foreach (var rep in o.Repointed)
+                sb.Append("  ").Append(rep.Success ? "OK   " : "FAIL ").Append(rep.Plugin)
+                  .Append(rep.Success ? "" : "  — " + rep.Error).Append('\n');
+        }
+        else
+        {
+            sb.Append("external referencers (").Append(o.ExternalPlugins.Count).Append(", NOT repointed):\n");
+            foreach (var pl in o.ExternalPlugins.Take(25)) sb.Append("  - ").Append(pl).Append('\n');
+            if (o.ExternalPlugins.Count > 25) sb.Append("  - … (+").Append(o.ExternalPlugins.Count - 25).Append(" more)\n");
+        }
+
+        if (o.UnscannableRecords > 0)
+        {
+            sb.Append("note: ").Append(o.UnscannableRecords).Append(" record(s) couldn't be scanned in the external-reference pass, so an ")
+              .Append("'external referencers: none' may be incomplete — verify in xEdit. Samples: ").Append(string.Join("; ", o.UnscannableSamples)).Append('\n');
+        }
+        sb.Append("identify-pass scanned ").Append(o.PluginsScanned).Append(" plugin(s) for external references.\n");
+        sb.Append("reminder: FormIDs compiled into Papyrus (.pex hardcoded / GetFormFromFile) and any Mutagen-delta residual ")
+          .Append("are NOT remappable — verify scripted records after compacting.");
         return sb.ToString();
     }
 


### PR DESCRIPTION
## Compact/merge **Wave 2** — the compact tool (A2)

`housecarl_compact_plugin` — the data-layer twin of xEdit's **"Compact FormIDs for ESL"**, over the Wave-1 `RemapEngine`. Renumbers a plugin's originating records (flat **and** nested) into the light range `0x800–0xFFF`, repoints internal refs, keeps overrides at their master FormIDs, flags the result a light master (`esl=false` = contiguous renumber, no light flag).

### Aaron's Wave-2 decisions (honored)
- **Output:** new-file default (P′ keeps the source's exact basename in a fresh folder; original untouched, review then swap) + **in-place opt-in** (`in_place=true` overwrites the original, in-place consent, no backup).
- **Scope:** flat **and** nested in one session — cell / worldspace / dialogue-bearing mods compact, not just flat ones.

### The nested gap, closed (the hard part)
Mechanism pinned empirically first (`remap-wave2-nested-mech`): `record.Duplicate(newKey)` deep-copies a record's nested children at their old keys, so renumber = Duplicate the container then recursively replace each originating child with its own renumbered Duplicate. `IMajorRecordGetterEnumerable` is the by-construction discriminator for the FormKey-less block-tree structs (recurse through). New primitive **`RemapEngine.RenumberModInto`** walks the mod's structure (flat groups + their nested children + the interior-cell tree); the flat `RenumberRecordsInto` is left intact (Wave-1 primitive / merge's per-record path).

### Safety (Q3, plan §2)
Identify-pass scans the whole order for **external referencers** of the renumbered records. None → clean compaction. Some → **refused loud** with the list, unless `repoint_externals=true` (rewrites each in place via `RepointInPlace`). Any in-place overwrite (target and/or externals) needs `acknowledge=true` with a first-call CONFIRM prompt. Over the 2048 light-range cap → refused, never truncated. Un-remappable refs (Papyrus-compiled FormIDs) flagged in the response.

### Tests
- New gate **`remap-wave2-compact-guard`** drives the real engine end-to-end on a synthetic fixture with every nesting shape (flat + FormList internal ref + interior cell+placed(Base→weap) + worldspace+ext cell+placed + topic+INFO) + an external referencer: all originating land in the ESL window, nesting preserved, internal refs repointed, external found + repointed in place.
- **ci-all 61/61** (was 60). Full solution builds clean. `remap-wave1-real` upgraded to the structural path for the manual real-data gate.

### Commits
1. `feat(remap): RenumberModInto — structural whole-mod renumber (flat + nested) + Wave 2 probes`
2. `test(ci): promote remap-wave2-compact-guard into ci-all`
3. `feat(compact): housecarl_compact_plugin — ESL-compact a plugin (new-file default, in-place opt-in)`

### Not yet proven (Aaron's empirical gate, principle #1)
A real compacted P′ in xEdit is the true proof — `remap-wave1-real --mo2 <inst> --plugin <a real mod>` (or the tool once landed + MO2-configured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)