### PR TITLE
feat(compact): facegen carry + external-overrider detection — xEdit parity on compaction

### DIFF
--- a/src/housecarl-core/AssetRenameService.cs
+++ b/src/housecarl-core/AssetRenameService.cs
@@ -87,12 +87,19 @@ public static class AssetRenameService
 
         if (npcs.Count == 0) return AssetRenameOutcome.None(assets.ReadIncomplete);
 
-        // 2. Carry each NPC's mesh + tint from the old path's WINNING copy to the new path.
+        // 2. Carry each NPC's mesh + tint from the old path's WINNING copy to the new path — in TWO PHASES so that ALL
+        //    reads complete before ANY commit. The renumber packs the new IDs into the same 0x800–0xFFF window the source
+        //    already used, so in the IN-PLACE lane (outDir == the target's OWN folder) a new-FormID write would otherwise
+        //    CLOBBER a not-yet-read old-FormID facegen of a DIFFERENT NPC — handing that NPC another's face, a Q3 silent
+        //    wrong answer (PR #123 review). Phase 1 stages each new file to a '.houseCARL-tmp' SIBLING (a name that never
+        //    collides with an old '00<hex>.nif' read path), so every read sees the original bytes; phase 2 commits the
+        //    temps via AtomicFile.Commit once all reads are done. O(1) memory per file (staged to disk, not buffered).
+        //    The new-file lane (fresh folder, no old facegen to clobber) is already safe but rides the same correct path.
         var failures = new List<string>();
-        int npcsCarried = 0, files = 0;
+        var pending = new List<(string Staged, string Final, FormKey NewKey)>();
+
+        // ---- phase 1: read every old facegen + stage it to a temp (writes ONLY '.houseCARL-tmp', never an old '00<hex>.nif') ----
         foreach (var (oldKey, newKey) in npcs)
-        {
-            int carriedForNpc = 0;
             foreach (var (slot, oldPath) in FaceGenPath.Both(oldKey))      // (Mesh, …), (Tint, …) — the dark-face pair
             {
                 var res = assets.ResolveForPlacement(oldPath);
@@ -101,22 +108,44 @@ public static class AssetRenameService
                 var (bytes, err) = ReadWinner(res.Sources[0]);             // the copy that currently displays in-game
                 if (err is not null) { failures.Add($"{oldKey.ID:X6} {slot}: {err}"); continue; }
 
-                var dest = Path.Combine(outDir, FaceGenPath.For(newKey, slot));
+                var rel = FaceGenPath.For(newKey, slot);
+                var final = Path.Combine(outDir, rel);
+                var staged = final + ".houseCARL-tmp";                     // sibling temp — distinct from every '00<hex>.nif' read path
                 try
                 {
-                    Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
-                    AtomicFile.WriteAllBytes(dest, bytes!);
-                    // Belt-and-braces truncation guard (the PlaceOne idiom): a size mismatch means a short write.
-                    long size; try { size = new FileInfo(dest).Length; } catch { size = -1; }
+                    Directory.CreateDirectory(Path.GetDirectoryName(final)!);
+                    try { if (File.Exists(staged)) File.Delete(staged); } catch { /* a stuck temp surfaces on the write below */ }
+                    File.WriteAllBytes(staged, bytes!);
+                    // Truncation guard on the TEMP (the commit is an atomic rename, which can't truncate): a short stage is caught here.
+                    long size; try { size = new FileInfo(staged).Length; } catch { size = -1; }
                     if (size != bytes!.Length)
-                    { failures.Add($"{newKey.ID:X6} {slot}: wrote {size} byte(s), expected {bytes.Length} — verify."); continue; }
-                    files++; carriedForNpc++;
+                    {
+                        failures.Add($"{newKey.ID:X6} {slot}: staged {size} byte(s), expected {bytes.Length} — verify.");
+                        try { File.Delete(staged); } catch { }
+                        continue;
+                    }
+                    pending.Add((staged, final, newKey));
                 }
-                catch (Exception ex) { failures.Add($"{newKey.ID:X6} {slot}: could not write '{FaceGenPath.For(newKey, slot)}' — {ex.Message}"); }
+                catch (Exception ex)
+                {
+                    failures.Add($"{newKey.ID:X6} {slot}: could not stage '{rel}' — {ex.Message}");
+                    try { if (File.Exists(staged)) File.Delete(staged); } catch { }
+                }
             }
-            if (carriedForNpc > 0) npcsCarried++;
+
+        // ---- phase 2: commit every staged temp (all reads done → overwriting an old facegen at a now-reused name is safe) ----
+        int files = 0;
+        var carriedKeys = new HashSet<FormKey>();
+        foreach (var (staged, final, newKey) in pending)
+        {
+            try { AtomicFile.Commit(staged, final); files++; carriedKeys.Add(newKey); }
+            catch (Exception ex)
+            {
+                failures.Add($"{newKey.ID:X6}: could not commit '{Path.GetFileName(final)}' — {ex.Message}");
+                try { if (File.Exists(staged)) File.Delete(staged); } catch { }
+            }
         }
-        return new AssetRenameOutcome(npcs.Count, npcsCarried, files, failures, assets.ReadIncomplete);
+        return new AssetRenameOutcome(npcs.Count, carriedKeys.Count, files, failures, assets.ReadIncomplete);
     }
 
     /// <summary>Read the bytes of a resolved WINNING provider — a loose file off disk, or a single BSA entry via native

--- a/src/housecarl-core/AssetRenameService.cs
+++ b/src/housecarl-core/AssetRenameService.cs
@@ -1,0 +1,142 @@
+using System.Linq;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+
+namespace HousecarlCore;
+
+// ======================================================================
+//  AssetRenameService — carry FormID-KEYED assets across a renumber (compact/merge Wave A1).
+//
+//  THE PROBLEM (research MERGE_REFERENCE_RESEARCH_2026-06-26 §3 / §8): renumbering a plugin's
+//  records (compact's RenumberModInto) moves every record to a NEW FormID, but the asset FILES
+//  the engine looks up BY that FormID — FaceGen head meshes/tints, voice .fuz/.lip — keep their
+//  OLD-FormID names. The engine then can't find them at the new FormID, so a compacted NPC mod
+//  silently dark-faces and a voiced mod goes mute. xEdit/zMerge/Merge Plugins all rename these
+//  along the same old→new map; houseCARL must too, or compact is a Q3 "silently degraded mode".
+//
+//  This is the shared SPINE both compact and merge ride: given the renumber's old→new FormKey map
+//  and the written P′, carry each renumbered record's FormID-keyed assets to their NEW-FormID
+//  paths under the P′ mod folder. A1 covers FACEGEN (the dominant break — the dark-face bug);
+//  voice (A2), SEQ + strings (A3) extend the same service.
+//
+//  COMPOSES existing, Aaron-locked primitives — NO new path logic:
+//    • FaceGenPath.For (the pure FormKey→path transform; folder = the FormKey's defining master,
+//      so For(oldKey) and For(newKey) give the correct OLD and NEW paths automatically).
+//    • AssetResolver (resolve the OLD path to its load-order WINNING on-disk bytes, loose or BSA).
+//    • AtomicFile.WriteAllBytes (the same crash-atomic place_asset uses).
+//
+//  Q3 — NEVER throws and NEVER fails the compact: the RECORDS are already written correctly by the
+//  time this runs; a facegen it can't carry is a NAMED warning in the outcome, not a crash. An NPC
+//  with NO own facegen is NORMAL (vanilla/inherited head), not a failure — only a facegen that was
+//  FOUND but couldn't be written is a warning. A BSA that failed to read is surfaced (ReadIncomplete)
+//  so "no facegen" is never silently trusted.
+//
+//  NON-DESTRUCTIVE: writes only the NEW-FormID copies under the P′ mod folder (the fresh folder in
+//  the new-file lane; the target's own folder in the in-place lane). The OLD-FormID files are left
+//  untouched — harmless orphans the engine no longer looks up (project_nondestructive_output_policy).
+// ======================================================================
+
+/// <summary>The accounting of one asset-rename pass (A1: facegen). <see cref="NpcCount"/> = renumbered NPCs considered
+/// (the denominator). <see cref="FacegenNpcsCarried"/> = those for which ≥1 facegen file was carried; <see cref="FacegenFilesCarried"/>
+/// = total files written (mesh + tint). <see cref="Failures"/> = facegen that was FOUND but could not be written (Q3 — real
+/// problems, named; an NPC simply WITHOUT facegen is not a failure). <see cref="ReadIncomplete"/> = a BSA failed to read this
+/// scan, so a "no facegen" answer may be incomplete (a facegen present only in an unreadable archive looks absent).</summary>
+public sealed record AssetRenameOutcome(
+    int NpcCount, int FacegenNpcsCarried, int FacegenFilesCarried,
+    IReadOnlyList<string> Failures, bool ReadIncomplete)
+{
+    /// <summary>Nothing carried (no renumbered NPCs, or the carry was not run) — a clean zero, ReadIncomplete propagated.</summary>
+    public static AssetRenameOutcome None(bool readIncomplete = false) =>
+        new(0, 0, 0, Array.Empty<string>(), readIncomplete);
+}
+
+public static class AssetRenameService
+{
+    /// <summary>Carry the FaceGen assets (head mesh + face tint) of every RENUMBERED NPC in <paramref name="pPrimePath"/>
+    /// from their OLD-FormID path to their NEW-FormID path, writing the new copies under <paramref name="outDir"/> (the
+    /// P′ mod-folder root — pass <c>Path.GetDirectoryName(outPath)</c>, which is that root in BOTH the new-file and
+    /// in-place lanes). <paramref name="map"/> is the renumber's old→new FormKey map; only NPCs whose new key is a map
+    /// VALUE (i.e. were renumbered) are carried — override NPCs kept at a master key are left alone. <paramref name="assets"/>
+    /// is a pinned resolver view (its winner is the copy that currently displays in-game). Best-effort + reported (Q3):
+    /// records are already written, so this never throws and never fails the compact.</summary>
+    public static AssetRenameOutcome CarryFaceGen(
+        string pPrimePath, IReadOnlyDictionary<FormKey, FormKey> map, AssetResolver.AssetView assets, string outDir)
+    {
+        // 1. Which renumbered records are NPCs? Read P′ back and intersect its NPCs with the map's NEW keys (the values).
+        //    Reverse the map ONCE (new→old) so each renumbered NPC yields its old key (for the old asset path). Reading the
+        //    just-written P′ is a transient overlay (disposed immediately — zero handle at rest, the codebase idiom).
+        List<(FormKey Old, FormKey New)> npcs;
+        try
+        {
+            using var pp = SkyrimMod.CreateFromBinaryOverlay(pPrimePath, SkyrimRelease.SkyrimSE);
+            var reverse = new Dictionary<FormKey, FormKey>(map.Count);
+            foreach (var kv in map) reverse[kv.Value] = kv.Key;            // new → old
+            npcs = pp.Npcs.Where(n => reverse.ContainsKey(n.FormKey))
+                          .Select(n => (Old: reverse[n.FormKey], New: n.FormKey))
+                          .ToList();
+        }
+        catch (Exception ex)
+        {
+            // Can't read P′ back ⇒ can't find which NPCs to carry. The compact SUCCEEDED; this is a degraded asset pass,
+            // surfaced as a named warning (Q3) rather than a silent skip.
+            return new AssetRenameOutcome(0, 0, 0,
+                new[] { $"could not read '{Path.GetFileName(pPrimePath)}' back to find its NPCs for facegen carry ({ex.Message}) — verify NPC faces in-game." },
+                assets.ReadIncomplete);
+        }
+
+        if (npcs.Count == 0) return AssetRenameOutcome.None(assets.ReadIncomplete);
+
+        // 2. Carry each NPC's mesh + tint from the old path's WINNING copy to the new path.
+        var failures = new List<string>();
+        int npcsCarried = 0, files = 0;
+        foreach (var (oldKey, newKey) in npcs)
+        {
+            int carriedForNpc = 0;
+            foreach (var (slot, oldPath) in FaceGenPath.Both(oldKey))      // (Mesh, …), (Tint, …) — the dark-face pair
+            {
+                var res = assets.ResolveForPlacement(oldPath);
+                if (res.Sources.Count == 0) continue;                      // no facegen for this slot — NORMAL (vanilla/inherited head)
+
+                var (bytes, err) = ReadWinner(res.Sources[0]);             // the copy that currently displays in-game
+                if (err is not null) { failures.Add($"{oldKey.ID:X6} {slot}: {err}"); continue; }
+
+                var dest = Path.Combine(outDir, FaceGenPath.For(newKey, slot));
+                try
+                {
+                    Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
+                    AtomicFile.WriteAllBytes(dest, bytes!);
+                    // Belt-and-braces truncation guard (the PlaceOne idiom): a size mismatch means a short write.
+                    long size; try { size = new FileInfo(dest).Length; } catch { size = -1; }
+                    if (size != bytes!.Length)
+                    { failures.Add($"{newKey.ID:X6} {slot}: wrote {size} byte(s), expected {bytes.Length} — verify."); continue; }
+                    files++; carriedForNpc++;
+                }
+                catch (Exception ex) { failures.Add($"{newKey.ID:X6} {slot}: could not write '{FaceGenPath.For(newKey, slot)}' — {ex.Message}"); }
+            }
+            if (carriedForNpc > 0) npcsCarried++;
+        }
+        return new AssetRenameOutcome(npcs.Count, npcsCarried, files, failures, assets.ReadIncomplete);
+    }
+
+    /// <summary>Read the bytes of a resolved WINNING provider — a loose file off disk, or a single BSA entry via native
+    /// Mutagen (zero handle at rest, the AssetResolver.TryReadArchiveEntry cornerstone). Mirrors LoadOrderService.ReadResolvedSource
+    /// but lives in core (the service's home) so the spine has no mcp dependency. A named error (Q3) if the resolved copy
+    /// vanished between resolve and read, or the archive can't be read.</summary>
+    static (byte[]? bytes, string? error) ReadWinner(PlacementSource s)
+    {
+        if (s.Kind == AssetKind.Loose)
+        {
+            var p = s.LooseFilePath!;
+            if (!File.Exists(p)) return (null, $"the resolved loose source '{p}' is no longer on disk");
+            try { return (File.ReadAllBytes(p), null); }
+            catch (Exception ex) { return (null, $"could not read resolved source '{p}': {ex.Message}"); }
+        }
+        try
+        {
+            var b = AssetResolver.TryReadArchiveEntry(s.ArchivePath!, s.EntryPath);
+            return b is null ? (null, $"entry '{s.EntryPath}' not found inside '{Path.GetFileName(s.ArchivePath!)}'") : (b, null);
+        }
+        catch (Exception ex) { return (null, $"could not read archive '{Path.GetFileName(s.ArchivePath!)}': {ex.Message}"); }
+    }
+}

--- a/src/housecarl-core/RemapEngine.cs
+++ b/src/housecarl-core/RemapEngine.cs
@@ -57,19 +57,35 @@ public static class RemapEngine
     /// is repointed too (<see cref="RepointInPlace"/>).</summary>
     public sealed record ExternalRef(string Plugin, FormKey Source, string SourceType, FormKey Target);
 
+    /// <summary>One external OVERRIDE of a record being remapped: a record in a plugin OUTSIDE the set whose OWN FormKey
+    /// is in the remap set — it OVERRIDES a record about to be renumbered (gap #2). After the renumber that override points
+    /// at a base FormID that no longer exists → orphaned override + missing master. Unlike <see cref="ExternalRef"/> it
+    /// CANNOT be auto-repointed: fixing it means changing the override's OWN identity, not rewriting an outgoing link
+    /// (<see cref="RepointInPlace"/>/RemapLinks only do links), so it is surfaced as a WARN, never routed through the
+    /// repoint path (Q3 — that would report a false success). <paramref name="Record"/> is the overridden FormKey.</summary>
+    public sealed record ExternalOverride(string Plugin, FormKey Record, string RecordType);
+
     /// <summary>The identify-pass result: every external reference found, the DISTINCT referencing plugins (load order,
-    /// the opt-in-rewrite set), how many plugins were scanned, and the per-record fault-isolation accounting (a record
-    /// whose link walk threw is counted + sampled, never a silent skip — Q3).</summary>
+    /// the opt-in-rewrite set), the external OVERRIDERS (gap #2 — detect + warn, NOT repointable), how many plugins were
+    /// scanned, and the per-record fault-isolation accounting (a record whose link walk threw is counted + sampled, never
+    /// a silent skip — Q3).</summary>
     public sealed record IdentifyResult(
         IReadOnlyList<ExternalRef> Refs,
         IReadOnlyList<string> ExternalPlugins,
         int PluginsScanned,
         int UnscannableRecords,
-        IReadOnlyList<string> UnscannableSamples)
+        IReadOnlyList<string> UnscannableSamples,
+        IReadOnlyList<ExternalOverride> Overrides,
+        IReadOnlyList<string> ExternalOverriders)
     {
         /// <summary>True when at least one plugin OUTSIDE the transform set references a remapped FormKey — the
         /// signal the default new-plugin path must NOT take silently (plan §2: fail loud + offer opt-in rewrite).</summary>
         public bool HasExternalReferencers => ExternalPlugins.Count > 0;
+
+        /// <summary>True when at least one plugin OUTSIDE the transform set OVERRIDES a remapped record (gap #2). Unlike
+        /// <see cref="HasExternalReferencers"/> this does NOT gate the operation — an override can't be auto-fixed, so the
+        /// posture is warn-and-proceed (xEdit parity), never refuse.</summary>
+        public bool HasExternalOverriders => ExternalOverriders.Count > 0;
     }
 
     /// <summary>
@@ -88,6 +104,8 @@ public static class RemapEngine
         var view = resolver.Capture();
         var refs = new List<ExternalRef>();
         var externalPlugins = new List<string>();        // load-order order, distinct
+        var overrides = new List<ExternalOverride>();     // gap #2: external plugins that OVERRIDE a remapped record
+        var externalOverriders = new List<string>();      // distinct overriding plugins, load-order order
         int scanned = 0, unscannable = 0;
         var unscannableSamples = new List<string>();
         // PluginNames CAN list a filename more than once in a degenerate order; scanning a name twice would
@@ -102,6 +120,7 @@ public static class RemapEngine
             if (!scannedNames.Add(plugin)) continue;                     // a duplicate name in the order — scan/list it once (Q3: no double-count)
             scanned++;
             bool pluginListed = false;
+            bool pluginListedOverride = false;
 
             try
             {
@@ -112,6 +131,17 @@ public static class RemapEngine
                     // whole-call abort and never a silent skip (Q3).
                     try
                     {
+                        // OVERRIDER (gap #2): this external plugin's record shares a FormKey being remapped → it OVERRIDES
+                        // a record about to be renumbered. Detected by IDENTITY (fk), independent of outgoing links, so it
+                        // is checked BEFORE the FormLinkContainer guard (an override with no outgoing ref into the set is
+                        // still a dependent the old link-only walk missed). It CANNOT be auto-repointed (identity change,
+                        // not a link rewrite) → collected for a WARN, never routed through the referencer repoint (Q3).
+                        if (targets.Contains(fk))
+                        {
+                            overrides.Add(new ExternalOverride(plugin, fk, RecordNaming.StripOverlay(body.GetType().Name)));
+                            if (!pluginListedOverride) { externalOverriders.Add(plugin); pluginListedOverride = true; }
+                        }
+                        // REFERENCER: an outgoing link whose target is being remapped (after the transform it dangles).
                         if (body is not IFormLinkContainerGetter flc) continue;
                         foreach (var link in flc.EnumerateFormLinks())
                         {
@@ -137,7 +167,7 @@ public static class RemapEngine
             }
         }
 
-        return new IdentifyResult(refs, externalPlugins, scanned, unscannable, unscannableSamples);
+        return new IdentifyResult(refs, externalPlugins, scanned, unscannable, unscannableSamples, overrides, externalOverriders);
     }
 
     // ======================================================================

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -896,13 +896,15 @@ public static class WritePatchBuilder
     /// (externals present, no opt-in) the list IS the refusal detail; with opt-in repoint, <see cref="Repointed"/> reports
     /// each. <see cref="PluginsScanned"/>/<see cref="UnscannableRecords"/> are the identify-pass coverage accounting.
     /// <see cref="AssetRename"/> (null until the asset-carry runs) is the FormID-keyed-asset accounting — A1: facegen
-    /// carried to the new FormIDs (so a compacted NPC mod no longer silently dark-faces).</summary>
+    /// carried to the new FormIDs (so a compacted NPC mod no longer silently dark-faces). <see cref="ExternalOverriders"/>
+    /// (gap #2) are plugins OUTSIDE the target that OVERRIDE a renumbered record — surfaced as a WARN (they orphan after
+    /// the renumber and houseCARL can't auto-repoint an override's identity); they never gate the compaction.</summary>
     public sealed record CompactOutcome(
         bool Success, string? Error, bool NeedsAcknowledge, string OutputPath, string PluginName, bool InPlace, bool Esl,
         IReadOnlyList<string> Masters, int RecordsCopied, int RecordsRenumbered, long Bytes,
         IReadOnlyList<string> ExternalPlugins, IReadOnlyList<RepointReport> Repointed,
         int PluginsScanned, int UnscannableRecords, IReadOnlyList<string> UnscannableSamples, string? Note = null,
-        AssetRenameOutcome? AssetRename = null)
+        AssetRenameOutcome? AssetRename = null, IReadOnlyList<string>? ExternalOverriders = null)
     {
         public static CompactOutcome Fail(string error) =>
             new(false, error, false, "", "", false, false, Array.Empty<string>(), 0, 0, 0,

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -894,12 +894,15 @@ public static class WritePatchBuilder
     /// <see cref="RecordsCopied"/> total (originating + overrides copied at their master keys). <see cref="ExternalPlugins"/>
     /// lists plugins outside the target that reference a renumbered record — empty on the clean path; on the refused path
     /// (externals present, no opt-in) the list IS the refusal detail; with opt-in repoint, <see cref="Repointed"/> reports
-    /// each. <see cref="PluginsScanned"/>/<see cref="UnscannableRecords"/> are the identify-pass coverage accounting.</summary>
+    /// each. <see cref="PluginsScanned"/>/<see cref="UnscannableRecords"/> are the identify-pass coverage accounting.
+    /// <see cref="AssetRename"/> (null until the asset-carry runs) is the FormID-keyed-asset accounting — A1: facegen
+    /// carried to the new FormIDs (so a compacted NPC mod no longer silently dark-faces).</summary>
     public sealed record CompactOutcome(
         bool Success, string? Error, bool NeedsAcknowledge, string OutputPath, string PluginName, bool InPlace, bool Esl,
         IReadOnlyList<string> Masters, int RecordsCopied, int RecordsRenumbered, long Bytes,
         IReadOnlyList<string> ExternalPlugins, IReadOnlyList<RepointReport> Repointed,
-        int PluginsScanned, int UnscannableRecords, IReadOnlyList<string> UnscannableSamples, string? Note = null)
+        int PluginsScanned, int UnscannableRecords, IReadOnlyList<string> UnscannableSamples, string? Note = null,
+        AssetRenameOutcome? AssetRename = null)
     {
         public static CompactOutcome Fail(string error) =>
             new(false, error, false, "", "", false, false, Array.Empty<string>(), 0, 0, 0,

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -116,6 +116,10 @@ public static class CiAll
         // FaceGen (head mesh + face tint) to the new FormID, end-to-end through the real service, so it no longer silently
         // dark-faces (the gap MERGE_REFERENCE_RESEARCH §3/§8 exposed in the shipped tool). New-file + in-place + no-facegen.
         ("facegen-carry-guard", FacegenCarryProbe.RunGuard),
+        // COMPACT gap #2 — the identify-pass now detects external OVERRIDERS (a plugin that overrides a renumbered record,
+        // not just one that FormLinks to it), surfaced as a WARN (warn-and-proceed, xEdit parity) distinct from the
+        // referencer refuse/repoint. Proves overrider→success+named and referencer→refused stay separate.
+        ("overrider-detect-guard", OverriderDetectProbe.RunGuard),
     };
 
     /// <summary>Dispatch a single CI guard by name through the registry — the ONE place a CI probe is listed, so

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -112,6 +112,10 @@ public static class CiAll
         // MO2 instance — the clean new-file lane, esl=false, override-of-master-cell-with-new-child, external refusal, the
         // repoint→in_place gate, not-active, and the in_place+repoint consent handshake. Covers the policy the engine guard bypasses.
         ("compact-service-guard", CompactServiceGuardProbe.RunGuard),
+        // COMPACT/MERGE Wave A1 — the asset-rename SPINE's first category: compacting an NPC mod carries its FormID-keyed
+        // FaceGen (head mesh + face tint) to the new FormID, end-to-end through the real service, so it no longer silently
+        // dark-faces (the gap MERGE_REFERENCE_RESEARCH §3/§8 exposed in the shipped tool). New-file + in-place + no-facegen.
+        ("facegen-carry-guard", FacegenCarryProbe.RunGuard),
     };
 
     /// <summary>Dispatch a single CI guard by name through the registry — the ONE place a CI probe is listed, so

--- a/src/housecarl-generator/FacegenCarryProbe.cs
+++ b/src/housecarl-generator/FacegenCarryProbe.cs
@@ -1,0 +1,176 @@
+using System.Linq;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// COMPACT/MERGE Wave A1 — FACEGEN-CARRY guard for housecarl_compact_plugin (the asset-rename spine).
+/// Proves the gap the merge research (dev/plans/MERGE_REFERENCE_RESEARCH_2026-06-26 §3/§8) exposed in the SHIPPED
+/// compact tool is CLOSED: compacting an NPC mod renumbers its records AND carries the FormID-keyed FaceGen files
+/// (head mesh + face tint) to the NEW FormID, so the mod no longer SILENTLY dark-faces (a Q3 degraded mode in the
+/// pre-A1 tool, which renumbered the record but left the facegen at the old FormID the engine no longer looks up).
+/// Drives the REAL <see cref="LoadOrderService.CompactPlugin"/> over a synthetic MO2 instance (the CompactServiceGuard
+/// + PlaceAsset probe pattern), so it pins the END-TO-END wiring, not just the service in isolation.
+///   NEW-FILE   — compact to a new file carries the NPC's facegen (mesh+tint) to the new FormID under the FRESH mod
+///                folder, byte-exact; the outcome reports 2 files / 1 NPC; the OLD-FormID facegen is left untouched.
+///   IN-PLACE   — compact in place carries the facegen into the target's OWN folder at the new FormID (old left orphan).
+///   NO-FACEGEN — an NPC with no facegen carries nothing and is NOT a failure (NpcCount &gt; 0, files 0, zero WARN).
+/// Run: dotnet run --project src/housecarl-generator facegen-carry-guard
+/// </summary>
+public static class FacegenCarryProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  COMPACT Wave A1 — facegen-carry guard (housecarl_compact_plugin)  ################");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        var root = Path.Combine(Path.GetTempPath(), "hc-facegen-carry-guard-" + Guid.NewGuid().ToString("N"));
+        var meshBytes = new byte[] { 0x4E, 0x49, 0x46, 0x01, 0x02, 0x03 };   // distinctive "head mesh" bytes
+        var tintBytes = new byte[] { 0xDD, 0x5B, 0xEE, 0xFF, 0x10 };         // distinctive "face tint" bytes
+        try
+        {
+            // ================= NEW-FILE: carry facegen to the new FormID in a fresh folder, byte-exact =================
+            {
+                var (mods, prof) = MakeInstance(Path.Combine(root, "newfile"));
+                var faceKey = new ModKey("FaceMod", ModType.Plugin);
+                var npcOld = new FormKey(faceKey, 0xA10);
+                WriteMod(mods, "FaceMod", faceKey, m => m.Npcs.Add(new Npc(npcOld, SkyrimRelease.SkyrimSE) { EditorID = "HcFaceNpc" }));
+                WriteLoose(Path.Combine(mods, "FaceMod"), FaceGenPath.For(npcOld, FaceGenSlot.Mesh), meshBytes);
+                WriteLoose(Path.Combine(mods, "FaceMod"), FaceGenPath.For(npcOld, FaceGenSlot.Tint), tintBytes);
+                WriteProfile(prof, new[] { faceKey.FileName.String }, new[] { "*" + faceKey.FileName }, new[] { "+FaceMod" });
+                WriteSkyrimIni(prof);
+
+                using var svc = LoadOrderService.WithInstance(Path.Combine(root, "newfile"), 0, new UserConfigStore(Path.Combine(root, "user-nf.json")));
+                svc.Stats();
+
+                var o = svc.CompactPlugin("FaceMod.esp");
+                FormKey? npcNew = null; bool meshOk = false, tintOk = false, oldUntouched = false;
+                if (o.Success && File.Exists(o.OutputPath))
+                {
+                    using (var pp = SkyrimMod.CreateFromBinaryOverlay(o.OutputPath, SkyrimRelease.SkyrimSE))
+                        npcNew = pp.Npcs.FirstOrDefault(n => n.EditorID == "HcFaceNpc")?.FormKey;
+                    var modRoot = Path.GetDirectoryName(o.OutputPath)!;
+                    if (npcNew is { } nk)
+                    {
+                        var newMesh = Path.Combine(modRoot, FaceGenPath.For(nk, FaceGenSlot.Mesh));
+                        var newTint = Path.Combine(modRoot, FaceGenPath.For(nk, FaceGenSlot.Tint));
+                        meshOk = File.Exists(newMesh) && File.ReadAllBytes(newMesh).SequenceEqual(meshBytes);
+                        tintOk = File.Exists(newTint) && File.ReadAllBytes(newTint).SequenceEqual(tintBytes);
+                    }
+                    var oldMesh = Path.Combine(mods, "FaceMod", FaceGenPath.For(npcOld, FaceGenSlot.Mesh));
+                    oldUntouched = File.Exists(oldMesh) && File.ReadAllBytes(oldMesh).SequenceEqual(meshBytes);
+                }
+                var ar = o.AssetRename;
+                Check(o.Success && npcNew is { } k && k.ID >= RemapEngine.EslFloor && k.ID <= RemapEngine.EslCeiling
+                      && meshOk && tintOk
+                      && ar is { NpcCount: 1, FacegenNpcsCarried: 1, FacegenFilesCarried: 2 } && ar.Failures.Count == 0,
+                      $"NEW-FILE facegen carried to new FormID {npcNew?.ID:X6} (mesh {meshOk}, tint {tintOk}, report {ar?.FacegenFilesCarried}f/{ar?.FacegenNpcsCarried}npc/{ar?.NpcCount}total{(o.Success ? "" : "; ERR " + o.Error)})");
+                Check(oldUntouched, "NEW-FILE the OLD-FormID facegen is left untouched (non-destructive)");
+            }
+
+            // ================= IN-PLACE: carry facegen into the target's OWN folder at the new FormID =================
+            {
+                var (mods, prof) = MakeInstance(Path.Combine(root, "inplace"));
+                var faceKey = new ModKey("FaceIp", ModType.Plugin);
+                var npcOld = new FormKey(faceKey, 0xB20);
+                WriteMod(mods, "FaceIp", faceKey, m => m.Npcs.Add(new Npc(npcOld, SkyrimRelease.SkyrimSE) { EditorID = "HcIpNpc" }));
+                WriteLoose(Path.Combine(mods, "FaceIp"), FaceGenPath.For(npcOld, FaceGenSlot.Mesh), meshBytes);
+                WriteLoose(Path.Combine(mods, "FaceIp"), FaceGenPath.For(npcOld, FaceGenSlot.Tint), tintBytes);
+                WriteProfile(prof, new[] { faceKey.FileName.String }, new[] { "*" + faceKey.FileName }, new[] { "+FaceIp" });
+                WriteSkyrimIni(prof);
+
+                using var svc = LoadOrderService.WithInstance(Path.Combine(root, "inplace"), 0, new UserConfigStore(Path.Combine(root, "user-ip.json")));
+                svc.Stats();
+
+                var o = svc.CompactPlugin("FaceIp.esp", inPlace: true, acknowledge: true);
+                FormKey? npcNew = null; bool meshOk = false, oldOrphan = false;
+                if (o.Success)
+                {
+                    using (var pp = SkyrimMod.CreateFromBinaryOverlay(o.OutputPath, SkyrimRelease.SkyrimSE))
+                        npcNew = pp.Npcs.FirstOrDefault(n => n.EditorID == "HcIpNpc")?.FormKey;
+                    if (npcNew is { } nk)
+                    {
+                        var newMesh = Path.Combine(mods, "FaceIp", FaceGenPath.For(nk, FaceGenSlot.Mesh));
+                        meshOk = File.Exists(newMesh) && File.ReadAllBytes(newMesh).SequenceEqual(meshBytes);
+                    }
+                    // the OLD-FormID facegen remains as a harmless orphan (non-destructive — never auto-deleted)
+                    oldOrphan = File.Exists(Path.Combine(mods, "FaceIp", FaceGenPath.For(npcOld, FaceGenSlot.Mesh)));
+                }
+                var ar = o.AssetRename;
+                Check(o.Success && o.InPlace && meshOk && ar is { FacegenFilesCarried: 2, FacegenNpcsCarried: 1 },
+                      $"IN-PLACE facegen carried into the target folder at new FormID {npcNew?.ID:X6} (mesh {meshOk}, report {ar?.FacegenFilesCarried}f{(o.Success ? "" : "; ERR " + o.Error)})");
+                Check(oldOrphan, "IN-PLACE the OLD-FormID facegen is left as a harmless orphan (non-destructive)");
+            }
+
+            // ================= NO-FACEGEN: an NPC with no facegen carries nothing and is NOT a failure =================
+            {
+                var (mods, prof) = MakeInstance(Path.Combine(root, "nofg"));
+                var faceKey = new ModKey("NoFg", ModType.Plugin);
+                var npcOld = new FormKey(faceKey, 0xC30);
+                WriteMod(mods, "NoFg", faceKey, m => m.Npcs.Add(new Npc(npcOld, SkyrimRelease.SkyrimSE) { EditorID = "HcNoFgNpc" }));
+                WriteProfile(prof, new[] { faceKey.FileName.String }, new[] { "*" + faceKey.FileName }, new[] { "+NoFg" });
+                WriteSkyrimIni(prof);
+
+                using var svc = LoadOrderService.WithInstance(Path.Combine(root, "nofg"), 0, new UserConfigStore(Path.Combine(root, "user-no.json")));
+                svc.Stats();
+
+                var o = svc.CompactPlugin("NoFg.esp");
+                var ar = o.AssetRename;
+                Check(o.Success && ar is { NpcCount: 1, FacegenFilesCarried: 0, FacegenNpcsCarried: 0 } && ar.Failures.Count == 0,
+                      $"NO-FACEGEN an NPC without facegen carries nothing and is NOT a failure (report {ar?.FacegenFilesCarried}f/{ar?.NpcCount}npc, warns {ar?.Failures.Count}{(o.Success ? "" : "; ERR " + o.Error)})");
+            }
+        }
+        finally { try { Directory.Delete(root, true); } catch { } }
+
+        Console.WriteLine();
+        Console.WriteLine($"=== facegen-carry-guard: {(fail == 0 ? "PASS" : $"FAIL ({fail})")} ===");
+        return fail == 0 ? 0 : 1;
+    }
+
+    // ---- synthetic MO2 layout helpers (the CompactServiceGuard / PlaceAsset probe pattern) ----
+
+    static (string mods, string prof) MakeInstance(string inst)
+    {
+        var mods = Path.Combine(inst, "mods");
+        var data = Path.Combine(inst, "game", "Data");
+        var prof = Path.Combine(inst, "profiles", "Default");
+        foreach (var d in new[] { mods, data, prof }) Directory.CreateDirectory(d);
+        File.WriteAllText(Path.Combine(inst, "ModOrganizer.ini"),
+            "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+            + Path.Combine(inst, "game").Replace(@"\", @"\\") + ")\r\n");
+        return (mods, prof);
+    }
+
+    static void WriteMod(string mods, string folder, ModKey key, Action<SkyrimMod> build)
+    {
+        var dir = Path.Combine(mods, folder);
+        Directory.CreateDirectory(dir);
+        var m = new SkyrimMod(key, SkyrimRelease.SkyrimSE);
+        build(m);
+        m.BeginWrite.ToPath(Path.Combine(dir, key.FileName.String)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+    }
+
+    static void WriteProfile(string prof, string[] loadorder, string[] plugins, string[] modlist)
+    {
+        Directory.CreateDirectory(prof);
+        File.WriteAllText(Path.Combine(prof, "loadorder.txt"), "# header\r\n" + string.Join("\r\n", loadorder) + "\r\n");
+        File.WriteAllText(Path.Combine(prof, "plugins.txt"), string.Join("\r\n", plugins) + "\r\n");
+        File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n" + string.Join("\r\n", modlist) + "\r\n");
+    }
+
+    static void WriteSkyrimIni(string prof) =>
+        File.WriteAllText(Path.Combine(prof, "Skyrim.ini"), "[Archive]\r\nsResourceArchiveList=\r\n");
+
+    static void WriteLoose(string baseDir, string rel, byte[] bytes)
+    {
+        var p = Path.Combine(baseDir, rel);
+        Directory.CreateDirectory(Path.GetDirectoryName(p)!);
+        File.WriteAllBytes(p, bytes);
+    }
+}

--- a/src/housecarl-generator/FacegenCarryProbe.cs
+++ b/src/housecarl-generator/FacegenCarryProbe.cs
@@ -108,6 +108,50 @@ public static class FacegenCarryProbe
                 Check(oldOrphan, "IN-PLACE the OLD-FormID facegen is left as a harmless orphan (non-destructive)");
             }
 
+            // ===== IN-PLACE ALIASING (PR #123 review blocker): 2 NPCs whose NEW-id window overlaps their OLD ids =====
+            // NpcP (old 0x900, enumerated FIRST) renumbers to new 0x800 — which is NpcQ's OLD id. A naive single-phase
+            // carry processes P first and writes P's new-0x800 facegen OVER NpcQ's not-yet-read old-0x800 file, so Q then
+            // reads P's bytes and inherits P's face (a Q3 silent wrong answer). Two-phase staging must keep them distinct.
+            {
+                var (mods, prof) = MakeInstance(Path.Combine(root, "alias"));
+                var faceKey = new ModKey("FaceAlias", ModType.Plugin);
+                var pOld = new FormKey(faceKey, 0x900);                  // enumerated first → renumbers to 0x800
+                var qOld = new FormKey(faceKey, 0x800);                  // enumerated second → its OLD 0x800 == P's NEW id
+                var meshP = new byte[] { 0x50, 0x01 }; var tintP = new byte[] { 0x50, 0x02 };
+                var meshQ = new byte[] { 0x51, 0x01 }; var tintQ = new byte[] { 0x51, 0x02 };
+                WriteMod(mods, "FaceAlias", faceKey, m =>
+                {
+                    m.Npcs.Add(new Npc(pOld, SkyrimRelease.SkyrimSE) { EditorID = "NpcP" });   // added FIRST
+                    m.Npcs.Add(new Npc(qOld, SkyrimRelease.SkyrimSE) { EditorID = "NpcQ" });   // added SECOND
+                });
+                WriteLoose(Path.Combine(mods, "FaceAlias"), FaceGenPath.For(pOld, FaceGenSlot.Mesh), meshP);
+                WriteLoose(Path.Combine(mods, "FaceAlias"), FaceGenPath.For(pOld, FaceGenSlot.Tint), tintP);
+                WriteLoose(Path.Combine(mods, "FaceAlias"), FaceGenPath.For(qOld, FaceGenSlot.Mesh), meshQ);
+                WriteLoose(Path.Combine(mods, "FaceAlias"), FaceGenPath.For(qOld, FaceGenSlot.Tint), tintQ);
+                WriteProfile(prof, new[] { faceKey.FileName.String }, new[] { "*" + faceKey.FileName }, new[] { "+FaceAlias" });
+                WriteSkyrimIni(prof);
+
+                using var svc = LoadOrderService.WithInstance(Path.Combine(root, "alias"), 0, new UserConfigStore(Path.Combine(root, "user-alias.json")));
+                svc.Stats();
+
+                var o = svc.CompactPlugin("FaceAlias.esp", inPlace: true, acknowledge: true);
+                bool pOk = false, qOk = false;
+                if (o.Success)
+                {
+                    FormKey? pNew = null, qNew = null;
+                    using (var pp = SkyrimMod.CreateFromBinaryOverlay(o.OutputPath, SkyrimRelease.SkyrimSE))
+                    {
+                        pNew = pp.Npcs.FirstOrDefault(n => n.EditorID == "NpcP")?.FormKey;
+                        qNew = pp.Npcs.FirstOrDefault(n => n.EditorID == "NpcQ")?.FormKey;
+                    }
+                    var modRoot = Path.GetDirectoryName(o.OutputPath)!;
+                    if (pNew is { } pk) pOk = File.ReadAllBytes(Path.Combine(modRoot, FaceGenPath.For(pk, FaceGenSlot.Mesh))).SequenceEqual(meshP);
+                    if (qNew is { } qk) qOk = File.ReadAllBytes(Path.Combine(modRoot, FaceGenPath.For(qk, FaceGenSlot.Mesh))).SequenceEqual(meshQ);
+                }
+                Check(o.Success && pOk && qOk,
+                      $"IN-PLACE ALIASING each NPC keeps its OWN face across overlapping old/new IDs (P {pOk}, Q {qOk}{(o.Success ? "" : "; ERR " + o.Error)})");
+            }
+
             // ================= NO-FACEGEN: an NPC with no facegen carries nothing and is NOT a failure =================
             {
                 var (mods, prof) = MakeInstance(Path.Combine(root, "nofg"));

--- a/src/housecarl-generator/OverriderDetectProbe.cs
+++ b/src/housecarl-generator/OverriderDetectProbe.cs
@@ -1,0 +1,139 @@
+using System.Linq;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// COMPACT gap #2 — EXTERNAL-OVERRIDER detection guard for housecarl_compact_plugin. The shipped identify-pass walked
+/// only OUTGOING FormLinks, so a plugin that OVERRIDES a record being renumbered (its override shares the FormKey but
+/// need carry no link into the set — e.g. a face-only NPC override) was MISSED and orphaned silently after the renumber.
+/// This proves the fix: the identify-pass now also tests each external record's OWN FormKey against the remap set, and
+/// surfaces overriders as a WARN — warn-and-proceed (xEdit parity), NOT the referencer refuse/repoint (an override can't
+/// be auto-repointed: that's an identity change, not a link rewrite, so routing it through repoint would be a Q3 false
+/// success). Drives the REAL LoadOrderService over synthetic MO2 instances.
+///   OVERRIDER  — plugin Q overrides target P's record (no outgoing ref into P): compacting P SUCCEEDS (warn-and-proceed)
+///                and the outcome NAMES Q as an external overrider, while listing ZERO referencers (the two are distinct).
+///   REFERENCER — plugin R FormLinks into P's record (does not override it): compacting P is still REFUSED + R named
+///                (existing behavior, unchanged) — the contrast that proves overrider≠referencer handling.
+/// Run: dotnet run --project src/housecarl-generator overrider-detect-guard
+/// </summary>
+public static class OverriderDetectProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  COMPACT gap #2 — external-overrider detection guard  ################");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        var root = Path.Combine(Path.GetTempPath(), "hc-overrider-detect-guard-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            // ============ OVERRIDER: Q overrides P's weapon (pure override) → compact P warns + proceeds, names Q ============
+            {
+                var (mods, prof) = MakeInstance(Path.Combine(root, "ovr"));
+                var pKey = new ModKey("OvrTarget", ModType.Plugin);
+                var pWeap = new FormKey(pKey, 0xA01);
+                WriteMod(mods, "OvrTarget", pKey, m =>
+                    m.Weapons.Add(new Weapon(pWeap, SkyrimRelease.SkyrimSE) { EditorID = "OvrWeap", BasicStats = new WeaponBasicStats { Damage = 7 } }));
+                // Q OVERRIDES P's weapon — a deep-copy-as-override, NO added FormLink into P (the link-only walk missed this).
+                var qKey = new ModKey("OvrDependent", ModType.Plugin);
+                {
+                    using var pOv = SkyrimMod.CreateFromBinaryOverlay(Path.Combine(mods, "OvrTarget", pKey.FileName.String), SkyrimRelease.SkyrimSE);
+                    var pCache = pOv.ToImmutableLinkCache();
+                    var pw = pOv.Weapons.First(w => w.EditorID == "OvrWeap");
+                    var dir = Path.Combine(mods, "OvrDependent"); Directory.CreateDirectory(dir);
+                    var q = new SkyrimMod(qKey, SkyrimRelease.SkyrimSE);
+                    WriteEngine.GenericGetOrAddAsOverride(q, pw, pCache);     // q now overrides P:0xA01 (declares P a master)
+                    q.BeginWrite.ToPath(Path.Combine(dir, qKey.FileName.String)).WithLoadOrder(new[] { pOv }).NoNextFormIDProcessing().Write();
+                }
+                WriteProfile(prof, new[] { pKey.FileName.String, qKey.FileName.String },
+                    new[] { "*" + pKey.FileName, "*" + qKey.FileName }, new[] { "+OvrDependent", "+OvrTarget" });
+                WriteSkyrimIni(prof);
+
+                using var svc = LoadOrderService.WithInstance(Path.Combine(root, "ovr"), 0, new UserConfigStore(Path.Combine(root, "user-ovr.json")));
+                svc.Stats();
+
+                var o = svc.CompactPlugin("OvrTarget.esp");
+                bool detected = o.ExternalOverriders is { } ovr && ovr.Contains("OvrDependent.esp", StringComparer.OrdinalIgnoreCase);
+                bool notReferencer = o.ExternalPlugins.Count == 0;            // it's an OVERRIDER, not a referencer
+                Check(o.Success && detected && notReferencer,
+                    $"OVERRIDER detected + warn-and-proceed (success {o.Success}, overriders [{(o.ExternalOverriders is { } x ? string.Join(",", x) : "")}], referencers {o.ExternalPlugins.Count}{(o.Success ? "" : "; ERR " + o.Error)})");
+            }
+
+            // ============ REFERENCER (contrast): R FormLinks into P → still REFUSED + named (distinct path) ============
+            {
+                var (mods, prof) = MakeInstance(Path.Combine(root, "ref"));
+                var pKey = new ModKey("RefTarget", ModType.Plugin);
+                var pWeap = new FormKey(pKey, 0xA01);
+                WriteMod(mods, "RefTarget", pKey, m =>
+                    m.Weapons.Add(new Weapon(pWeap, SkyrimRelease.SkyrimSE) { EditorID = "RefWeap", BasicStats = new WeaponBasicStats { Damage = 7 } }));
+                // R REFERENCES P's weapon via a FormList (outgoing link) — does NOT override it.
+                var rKey = new ModKey("RefDependent", ModType.Plugin);
+                {
+                    using var pOv = SkyrimMod.CreateFromBinaryOverlay(Path.Combine(mods, "RefTarget", pKey.FileName.String), SkyrimRelease.SkyrimSE);
+                    var dir = Path.Combine(mods, "RefDependent"); Directory.CreateDirectory(dir);
+                    var r = new SkyrimMod(rKey, SkyrimRelease.SkyrimSE);
+                    var fl = new FormList(new FormKey(rKey, 0xA01), SkyrimRelease.SkyrimSE) { EditorID = "RefList" };
+                    fl.Items.Add(new FormLink<ISkyrimMajorRecordGetter>(pWeap));
+                    r.FormLists.Add(fl);
+                    r.ModHeader.Stats.NextFormID = 0xA02;
+                    r.BeginWrite.ToPath(Path.Combine(dir, rKey.FileName.String)).WithLoadOrder(new[] { pOv }).NoNextFormIDProcessing().Write();
+                }
+                WriteProfile(prof, new[] { pKey.FileName.String, rKey.FileName.String },
+                    new[] { "*" + pKey.FileName, "*" + rKey.FileName }, new[] { "+RefDependent", "+RefTarget" });
+                WriteSkyrimIni(prof);
+
+                using var svc = LoadOrderService.WithInstance(Path.Combine(root, "ref"), 0, new UserConfigStore(Path.Combine(root, "user-ref.json")));
+                svc.Stats();
+
+                var o = svc.CompactPlugin("RefTarget.esp");
+                Check(!o.Success && !o.NeedsAcknowledge && (o.Error?.Contains("RefDependent.esp", StringComparison.OrdinalIgnoreCase) ?? false),
+                    $"REFERENCER still REFUSED + named — distinct from the overrider warn ({o.Error?.Split('.')[0]})");
+            }
+        }
+        finally { try { Directory.Delete(root, true); } catch { } }
+
+        Console.WriteLine();
+        Console.WriteLine($"=== overrider-detect-guard: {(fail == 0 ? "PASS" : $"FAIL ({fail})")} ===");
+        return fail == 0 ? 0 : 1;
+    }
+
+    // ---- synthetic MO2 layout helpers (the CompactServiceGuard / FacegenCarry probe pattern) ----
+
+    static (string mods, string prof) MakeInstance(string inst)
+    {
+        var mods = Path.Combine(inst, "mods");
+        var data = Path.Combine(inst, "game", "Data");
+        var prof = Path.Combine(inst, "profiles", "Default");
+        foreach (var d in new[] { mods, data, prof }) Directory.CreateDirectory(d);
+        File.WriteAllText(Path.Combine(inst, "ModOrganizer.ini"),
+            "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+            + Path.Combine(inst, "game").Replace(@"\", @"\\") + ")\r\n");
+        return (mods, prof);
+    }
+
+    static void WriteMod(string mods, string folder, ModKey key, Action<SkyrimMod> build)
+    {
+        var dir = Path.Combine(mods, folder);
+        Directory.CreateDirectory(dir);
+        var m = new SkyrimMod(key, SkyrimRelease.SkyrimSE);
+        build(m);
+        m.BeginWrite.ToPath(Path.Combine(dir, key.FileName.String)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+    }
+
+    static void WriteProfile(string prof, string[] loadorder, string[] plugins, string[] modlist)
+    {
+        Directory.CreateDirectory(prof);
+        File.WriteAllText(Path.Combine(prof, "loadorder.txt"), "# header\r\n" + string.Join("\r\n", loadorder) + "\r\n");
+        File.WriteAllText(Path.Combine(prof, "plugins.txt"), string.Join("\r\n", plugins) + "\r\n");
+        File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n" + string.Join("\r\n", modlist) + "\r\n");
+    }
+
+    static void WriteSkyrimIni(string prof) =>
+        File.WriteAllText(Path.Combine(prof, "Skyrim.ini"), "[Archive]\r\nsResourceArchiveList=\r\n");
+}

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1700,7 +1700,7 @@ public sealed class LoadOrderService : IDisposable
             return new WritePatchBuilder.CompactOutcome(
                 true, null, false, outPath, name, inPlace, esl, build.Masters, build.RecordsCopied, build.RecordsRenumbered,
                 build.Bytes, id.ExternalPlugins, repointed, id.PluginsScanned, id.UnscannableRecords, id.UnscannableSamples,
-                markerNotes.Count > 0 ? string.Join(" ", markerNotes) : null, assetRename);
+                markerNotes.Count > 0 ? string.Join(" ", markerNotes) : null, assetRename, id.ExternalOverriders);
         }
     }
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1663,6 +1663,25 @@ public sealed class LoadOrderService : IDisposable
                     repointed.Add(new WritePatchBuilder.RepointReport(ext, rep.Success, rep.Error));
                 }
 
+            // 7b. carry FormID-keyed assets (compact/merge Wave A1: facegen). The records renumbered, so the asset FILES the
+            //     engine looks up BY FormID — FaceGen head mesh/tint — must follow, or a compacted NPC mod silently dark-faces
+            //     (the gap this research exposed in the shipped tool). Best-effort + REPORTED (Q3): the records are already
+            //     written, so a facegen we can't carry is a NAMED warning in the outcome, never a failure of the compaction —
+            //     and the asset layer failing to build never fails the compact either. outDir = the P′ mod-folder root (the
+            //     directory holding the plugin) in BOTH lanes (new-file: the fresh folder; in-place: the target's own folder).
+            AssetRenameOutcome assetRename;
+            try
+            {
+                AssetResolver assetResolver;
+                lock (_gate) { assetResolver = Assets; }                  // reentrant under the held _writeGate (the PlaceAssets idiom)
+                assetRename = AssetRenameService.CarryFaceGen(outPath, plan.Dict, assetResolver.Capture(), Path.GetDirectoryName(outPath)!);
+            }
+            catch (Exception ex)
+            {
+                assetRename = new AssetRenameOutcome(0, 0, 0,
+                    new[] { $"facegen carry skipped — the asset layer could not be built ({ex.Message}); verify NPC faces in-game." }, false);
+            }
+
             // 8. audit markers (PR #122 review #2): stamp the distinct editedInPlace= breadcrumb into the meta.ini of EVERY
             //    file rewritten IN PLACE — the target (in-place lane) + each successfully repointed external — matching the
             //    traceability the in-place EDIT lane gives. The CONSENT model deliberately stays compact's own per-call
@@ -1681,7 +1700,7 @@ public sealed class LoadOrderService : IDisposable
             return new WritePatchBuilder.CompactOutcome(
                 true, null, false, outPath, name, inPlace, esl, build.Masters, build.RecordsCopied, build.RecordsRenumbered,
                 build.Bytes, id.ExternalPlugins, repointed, id.PluginsScanned, id.UnscannableRecords, id.UnscannableSamples,
-                markerNotes.Count > 0 ? string.Join(" ", markerNotes) : null);
+                markerNotes.Count > 0 ? string.Join(" ", markerNotes) : null, assetRename);
         }
     }
 

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -604,7 +604,7 @@ public static class WriteTools
                 sb.Append("facegen: carried ").Append(ar.FacegenFilesCarried).Append(ar.FacegenFilesCarried == 1 ? " file for " : " files for ")
                   .Append(ar.FacegenNpcsCarried).Append(ar.FacegenNpcsCarried == 1 ? " NPC to the new FormIDs" : " NPCs to the new FormIDs")
                   .Append(o.InPlace ? " (old-FormID facegen left as harmless orphans).\n" : " (in the new mod folder — enabling it carries the faces).\n");
-            else if (ar.NpcCount > 0)
+            else if (ar.NpcCount > 0 && ar.Failures.Count == 0)
                 sb.Append("facegen: none found for this plugin's ").Append(ar.NpcCount).Append(ar.NpcCount == 1 ? " NPC — nothing to carry.\n" : " NPCs — nothing to carry.\n");
             foreach (var f in ar.Failures.Take(25)) sb.Append("  facegen WARN: ").Append(f).Append('\n');
             if (ar.Failures.Count > 25) sb.Append("  facegen WARN: … (+").Append(ar.Failures.Count - 25).Append(" more)\n");

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -575,6 +575,19 @@ public static class WriteTools
             if (o.ExternalPlugins.Count > 25) sb.Append("  - … (+").Append(o.ExternalPlugins.Count - 25).Append(" more)\n");
         }
 
+        // External OVERRIDERS (gap #2) — plugins that OVERRIDE a renumbered record (not just reference it). They orphan
+        // after the renumber (the override points at a base FormID that no longer exists), and houseCARL CANNOT auto-repoint
+        // an override — that's an identity change, not a link rewrite — so this is a WARN (xEdit parity), not the referencer
+        // refuse/repoint path. Named per-plugin so the user can re-point or rebuild them (better than xEdit's blanket warning).
+        if (o.ExternalOverriders is { Count: > 0 } overriders)
+        {
+            sb.Append("external OVERRIDERS (").Append(overriders.Count).Append("): these plugins OVERRIDE a renumbered record and will ")
+              .Append("ORPHAN after the renumber — houseCARL can't auto-repoint an override (identity change, not a link). ")
+              .Append("Re-point or rebuild them against the new FormIDs, or don't enable the compacted plugin over them:\n");
+            foreach (var pl in overriders.Take(25)) sb.Append("  ! ").Append(pl).Append('\n');
+            if (overriders.Count > 25) sb.Append("  ! … (+").Append(overriders.Count - 25).Append(" more)\n");
+        }
+
         if (o.UnscannableRecords > 0)
         {
             sb.Append("note: ").Append(o.UnscannableRecords).Append(" record(s) couldn't be scanned in the external-reference pass, so an ")

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -581,9 +581,28 @@ public static class WriteTools
               .Append("'external referencers: none' may be incomplete — verify in xEdit. Samples: ").Append(string.Join("; ", o.UnscannableSamples)).Append('\n');
         }
         sb.Append("identify-pass scanned ").Append(o.PluginsScanned).Append(" plugin(s) for external references.\n");
+
+        // FormID-keyed assets carried WITH the renumber (compact/merge Wave A1: facegen) — the renumber moved every record
+        // to a new FormID, so the engine looks the head mesh/tint up under the NEW name; carrying them is what stops a
+        // compacted NPC mod silently dark-facing. Reported, not silent (Q3).
+        if (o.AssetRename is { } ar)
+        {
+            if (ar.FacegenFilesCarried > 0)
+                sb.Append("facegen: carried ").Append(ar.FacegenFilesCarried).Append(ar.FacegenFilesCarried == 1 ? " file for " : " files for ")
+                  .Append(ar.FacegenNpcsCarried).Append(ar.FacegenNpcsCarried == 1 ? " NPC to the new FormIDs" : " NPCs to the new FormIDs")
+                  .Append(o.InPlace ? " (old-FormID facegen left as harmless orphans).\n" : " (in the new mod folder — enabling it carries the faces).\n");
+            else if (ar.NpcCount > 0)
+                sb.Append("facegen: none found for this plugin's ").Append(ar.NpcCount).Append(ar.NpcCount == 1 ? " NPC — nothing to carry.\n" : " NPCs — nothing to carry.\n");
+            foreach (var f in ar.Failures.Take(25)) sb.Append("  facegen WARN: ").Append(f).Append('\n');
+            if (ar.Failures.Count > 25) sb.Append("  facegen WARN: … (+").Append(ar.Failures.Count - 25).Append(" more)\n");
+            if (ar.ReadIncomplete)
+                sb.Append("  note: a BSA failed to read this scan, so a 'no facegen' result may be incomplete — verify NPC faces in-game.\n");
+        }
+
         if (o.Note is { } note) sb.Append("note: ").Append(note).Append('\n');
-        sb.Append("reminder: FormIDs compiled into Papyrus (.pex hardcoded / GetFormFromFile) and any Mutagen-delta residual ")
-          .Append("are NOT remappable — verify scripted records after compacting.");
+        sb.Append("reminder: voiced dialogue files (.fuz/.lip, named by the OLD FormID) are NOT yet carried by compact — ")
+          .Append("verify voiced lines after compacting. FormIDs compiled into Papyrus (.pex hardcoded / GetFormFromFile) and ")
+          .Append("any Mutagen-delta residual are NOT remappable — verify scripted records too.");
         return sb.ToString();
     }
 


### PR DESCRIPTION
Brings `housecarl_compact_plugin` to **parity with xEdit on the renumber/compaction operation** — and past it on faces. Two atomic commits.

## 1. Carry facegen to the new FormIDs (`66c77fc`) — asset-rename spine A1
Compacting an NPC mod renumbered its records but left the FormID-keyed facegen (head mesh + face tint) at the **old** FormID the engine no longer looks up — a **silent dark-face** (the Q3 degraded mode the merge research exposed in the shipped tool; xEdit's compaction punts facegen to the user entirely).

New `AssetRenameService.CarryFaceGen` (core) reads the written plugin back, finds the renumbered NPCs via the remap map, resolves each one's old-FormID facegen to its load-order-winning on-disk copy (loose **or** BSA), and writes the new-FormID copy under the P′ mod folder. It composes what already existed — `FaceGenPath.For` + `AssetResolver` + `AtomicFile` — so no new path logic. Best-effort and **reported**: it never throws and never fails the compaction (the records are already written). This is the shared spine compact and merge both ride; voice (A2) extends the same service.

- Non-destructive both lanes: new-file → fresh folder; in-place → the target's own folder, old facegen left as a harmless orphan.
- `RenderCompact` now reports *"facegen: carried N file(s) for M NPC(s)"* and the reminder is honest that **voice isn't carried yet** (A2) and scripts aren't remappable.

## 2. Detect external overriders (`6a97d6c`) — gap #2, warn-and-proceed
The identify-pass walked only **outgoing FormLinks**, so a plugin that **overrides** a renumbered record (its override shares the FormKey but need carry no link into the set — e.g. a face-only NPC override) was missed and orphaned **silently**. The per-record loop now also tests each external record's **own** FormKey against the remap set.

Posture = **warn-and-proceed (xEdit parity)**: an override can't be auto-repointed (identity change, not a link rewrite), so overriders are surfaced as a **named** warning, never routed through the referencer refuse/repoint path (which would be a Q3 false success). Naming the specific plugin edges past xEdit's blanket dependent warning. This closes the last xEdit-parity gap on compaction.

## Scope / not in this PR
- **Voice / SEQ** carry = A2/A3 (the reminder is honest that voice isn't carried yet).
- **Merge** = A4 (records merge + this spine; explicitly *not* NPC2-style asset-mod consolidation).
- **Auto-repointing** an overrider's identity = A4 (needs duplicate-into-new-key; out of scope here).

## Verification
`ci-all` **64/64** (adds `facegen-carry-guard` — new-file / in-place / no-facegen — and `overrider-detect-guard` — overrider→success+named, referencer→refused, distinct). Build clean.

Plan: `dev/plans/ASSET_RENAME_LAYER_PLAN_2026-06-27.md`. Research: `dev/plans/MERGE_REFERENCE_RESEARCH_2026-06-26.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)