### PR TITLE
feat(compact): carry voice (.fuz/.lip) to new FormIDs on compact (asset-rename spine A2)

### DIFF
--- a/src/housecarl-core/AssetRenameService.cs
+++ b/src/housecarl-core/AssetRenameService.cs
@@ -18,19 +18,31 @@ namespace HousecarlCore;
 //  This is the shared SPINE both compact and merge ride: given the renumber's old→new FormKey map
 //  and the written P′, carry each renumbered record's FormID-keyed assets to their NEW-FormID
 //  paths under the P′ mod folder. A1 covers FACEGEN (the dominant break — the dark-face bug);
-//  voice (A2), SEQ + strings (A3) extend the same service.
+//  A2 covers VOICE (.fuz/.lip — a compacted voiced mod otherwise goes mute); SEQ + strings (A3)
+//  extend the same service. Both categories ride ONE shared two-phase carry (CarryItems) — the
+//  in-place aliasing fix (PR #123) lives in exactly one place, never two diverging copies.
 //
 //  COMPOSES existing, Aaron-locked primitives — NO new path logic:
-//    • FaceGenPath.For (the pure FormKey→path transform; folder = the FormKey's defining master,
-//      so For(oldKey) and For(newKey) give the correct OLD and NEW paths automatically).
-//    • AssetResolver (resolve the OLD path to its load-order WINNING on-disk bytes, loose or BSA).
-//    • AtomicFile.WriteAllBytes (the same crash-atomic place_asset uses).
+//    • FaceGenPath.For / VoicePath (the pure FormKey→path transforms; folder = the FormKey's
+//      defining master, so For(oldKey) and For(newKey) give the correct OLD and NEW paths).
+//    • AssetResolver (resolve the OLD path to its load-order WINNING on-disk bytes, loose or BSA;
+//      EnumerateUnder lists what voice files actually exist under the plugin's voice prefix).
+//    • AtomicFile.WriteAllBytes / Commit (the same crash-atomic place_asset uses).
 //
 //  Q3 — NEVER throws and NEVER fails the compact: the RECORDS are already written correctly by the
-//  time this runs; a facegen it can't carry is a NAMED warning in the outcome, not a crash. An NPC
-//  with NO own facegen is NORMAL (vanilla/inherited head), not a failure — only a facegen that was
+//  time this runs; an asset it can't carry is a NAMED warning in the outcome, not a crash. An NPC
+//  with NO own facegen is NORMAL (vanilla/inherited head), not a failure — only an asset that was
 //  FOUND but couldn't be written is a warning. A BSA that failed to read is surfaced (ReadIncomplete)
-//  so "no facegen" is never silently trusted.
+//  so "no facegen"/"no voice" is never silently trusted.
+//
+//  WHY VOICE SCANS DISK (A2 discovery, strategy b): a facegen path is a PURE FormKey transform, but a
+//  voice filename embeds the parent quest/topic EditorIDs, the voice type, AND a response number —
+//  none of which a renumber changes. On a compact the plugin keeps its basename, so ONLY the
+//  '00<6hex>' id segment differs old→new. So instead of re-deriving the dialogue graph per INFO
+//  (which silently misses radiant/quest-alias lines whose graph won't resolve), CarryVoice ENUMERATES
+//  the voice files actually present under Sound\Voice\<plugin>\ and rewrites the id segment of each
+//  whose embedded FormID was renumbered — catching every file the engine would lose, the way
+//  zMerge/xEdit do it. Matching is purely by the on-disk filename, so it needs no record readback.
 //
 //  NON-DESTRUCTIVE: writes only the NEW-FormID copies under the P′ mod folder (the fresh folder in
 //  the new-file lane; the target's own folder in the in-place lane). The OLD-FormID files are left
@@ -48,6 +60,21 @@ public sealed record AssetRenameOutcome(
 {
     /// <summary>Nothing carried (no renumbered NPCs, or the carry was not run) — a clean zero, ReadIncomplete propagated.</summary>
     public static AssetRenameOutcome None(bool readIncomplete = false) =>
+        new(0, 0, 0, Array.Empty<string>(), readIncomplete);
+}
+
+/// <summary>The accounting of the voice-carry pass (A2). <see cref="FilesScanned"/> = voice files found under the
+/// plugin's <c>Sound\Voice\&lt;plugin&gt;\</c> prefix (the denominator). <see cref="FilesCarried"/> = those whose
+/// embedded FormID was renumbered and that were written to the new id; <see cref="LinesCarried"/> = the distinct
+/// dialogue lines (INFOs) those files belong to. <see cref="Failures"/> = a voice file FOUND but not writable (Q3 —
+/// a file simply NOT keyed to a renumbered line is not a failure). <see cref="ReadIncomplete"/> = a BSA failed to
+/// read this scan, so a "no voice" answer may be incomplete (audio present only in an unreadable archive looks absent).</summary>
+public sealed record VoiceCarryOutcome(
+    int FilesScanned, int FilesCarried, int LinesCarried,
+    IReadOnlyList<string> Failures, bool ReadIncomplete)
+{
+    /// <summary>Nothing carried (no renumbered records, or no voice files) — a clean zero, ReadIncomplete propagated.</summary>
+    public static VoiceCarryOutcome None(bool readIncomplete = false) =>
         new(0, 0, 0, Array.Empty<string>(), readIncomplete);
 }
 
@@ -87,66 +114,158 @@ public static class AssetRenameService
 
         if (npcs.Count == 0) return AssetRenameOutcome.None(assets.ReadIncomplete);
 
-        // 2. Carry each NPC's mesh + tint from the old path's WINNING copy to the new path — in TWO PHASES so that ALL
-        //    reads complete before ANY commit. The renumber packs the new IDs into the same 0x800–0xFFF window the source
-        //    already used, so in the IN-PLACE lane (outDir == the target's OWN folder) a new-FormID write would otherwise
-        //    CLOBBER a not-yet-read old-FormID facegen of a DIFFERENT NPC — handing that NPC another's face, a Q3 silent
-        //    wrong answer (PR #123 review). Phase 1 stages each new file to a '.houseCARL-tmp' SIBLING (a name that never
-        //    collides with an old '00<hex>.nif' read path), so every read sees the original bytes; phase 2 commits the
-        //    temps via AtomicFile.Commit once all reads are done. O(1) memory per file (staged to disk, not buffered).
-        //    The new-file lane (fresh folder, no old facegen to clobber) is already safe but rides the same correct path.
-        var failures = new List<string>();
-        var pending = new List<(string Staged, string Final, FormKey NewKey)>();
-
-        // ---- phase 1: read every old facegen + stage it to a temp (writes ONLY '.houseCARL-tmp', never an old '00<hex>.nif') ----
+        // 2. Build the carry list — each renumbered NPC's mesh + tint, OLD path → NEW path — and run it through the shared
+        //    two-phase carry (CarryItems): all reads stage to temps before ANY commit, so the in-place lane can't read-after
+        //    -write alias one NPC's facegen over another's not-yet-read file (PR #123). The dark-face pair is placed together.
+        var items = new List<CarryItem>();
         foreach (var (oldKey, newKey) in npcs)
             foreach (var (slot, oldPath) in FaceGenPath.Both(oldKey))      // (Mesh, …), (Tint, …) — the dark-face pair
-            {
-                var res = assets.ResolveForPlacement(oldPath);
-                if (res.Sources.Count == 0) continue;                      // no facegen for this slot — NORMAL (vanilla/inherited head)
+                items.Add(new CarryItem(oldPath, FaceGenPath.For(newKey, slot), newKey, $"{oldKey.ID:X6}→{newKey.ID:X6} {slot}"));
 
-                var (bytes, err) = ReadWinner(res.Sources[0]);             // the copy that currently displays in-game
-                if (err is not null) { failures.Add($"{oldKey.ID:X6} {slot}: {err}"); continue; }
+        var failures = new List<string>();
+        var (files, carried) = CarryItems(items, assets, outDir, failures);
+        return new AssetRenameOutcome(npcs.Count, carried.Count, files, failures, assets.ReadIncomplete);
+    }
 
-                var rel = FaceGenPath.For(newKey, slot);
-                var final = Path.Combine(outDir, rel);
-                var staged = final + ".houseCARL-tmp";                     // sibling temp — distinct from every '00<hex>.nif' read path
-                try
-                {
-                    Directory.CreateDirectory(Path.GetDirectoryName(final)!);
-                    try { if (File.Exists(staged)) File.Delete(staged); } catch { /* a stuck temp surfaces on the write below */ }
-                    File.WriteAllBytes(staged, bytes!);
-                    // Truncation guard on the TEMP (the commit is an atomic rename, which can't truncate): a short stage is caught here.
-                    long size; try { size = new FileInfo(staged).Length; } catch { size = -1; }
-                    if (size != bytes!.Length)
-                    {
-                        failures.Add($"{newKey.ID:X6} {slot}: staged {size} byte(s), expected {bytes.Length} — verify.");
-                        try { File.Delete(staged); } catch { }
-                        continue;
-                    }
-                    pending.Add((staged, final, newKey));
-                }
-                catch (Exception ex)
-                {
-                    failures.Add($"{newKey.ID:X6} {slot}: could not stage '{rel}' — {ex.Message}");
-                    try { if (File.Exists(staged)) File.Delete(staged); } catch { }
-                }
-            }
+    /// <summary>Carry the VOICE files (.fuz/.lip/…) of every RENUMBERED dialogue line (INFO) in <paramref name="pPrimePath"/>
+    /// from their OLD-FormID name to their NEW-FormID name, writing the new copies under <paramref name="outDir"/> (the P′
+    /// mod-folder root, as <see cref="CarryFaceGen"/>). DISCOVERS by SCANNING the plugin's voice prefix rather than re-deriving
+    /// the dialogue graph (see the file header): every file under <c>Sound\Voice\&lt;basename&gt;\</c> whose embedded local
+    /// FormID is a renumbered key in <paramref name="map"/> gets its id segment rewritten to the new id. On a compact the
+    /// plugin keeps its basename, so the folder + voice-type + quest/topic + response-number segments are unchanged — ONLY the
+    /// id moves. Rides the same two-phase <see cref="CarryItems"/> as facegen (same in-place aliasing guard). Best-effort +
+    /// reported (Q3): records are already written, so this never throws and never fails the compact.</summary>
+    public static VoiceCarryOutcome CarryVoice(
+        string pPrimePath, IReadOnlyDictionary<FormKey, FormKey> map, AssetResolver.AssetView assets, string outDir)
+    {
+        var basename = Path.GetFileName(pPrimePath);                        // P′ keeps the source basename → the voice folder name (with ext)
 
-        // ---- phase 2: commit every staged temp (all reads done → overwriting an old facegen at a now-reused name is safe) ----
-        int files = 0;
-        var carriedKeys = new HashSet<FormKey>();
-        foreach (var (staged, final, newKey) in pending)
+        // local-id → new-local-id for THIS plugin's renumbered records — the only ones whose voice lives under
+        // Sound\Voice\<basename>\ (an override kept at a master key has its voice under the MASTER's folder, untouched).
+        var idMap = new Dictionary<uint, uint>();
+        foreach (var kv in map)
+            if (string.Equals(kv.Key.ModKey.FileName.ToString(), basename, StringComparison.OrdinalIgnoreCase))
+                idMap[kv.Key.ID] = kv.Value.ID;
+        if (idMap.Count == 0) return VoiceCarryOutcome.None(assets.ReadIncomplete);
+
+        // The new INFO FormKeys need a ModKey for the distinct-line accounting; basename came from a real plugin path, so
+        // this is valid (a malformed name is surfaced rather than silently producing a zero pass — Q3).
+        ModKey modKey;
+        try { modKey = ModKey.FromFileName(basename); }
+        catch (Exception ex)
         {
-            try { AtomicFile.Commit(staged, final); files++; carriedKeys.Add(newKey); }
+            return new VoiceCarryOutcome(0, 0, 0,
+                new[] { $"'{basename}' is not a valid plugin filename for voice carry ({ex.Message}) — verify voiced lines in-game." },
+                assets.ReadIncomplete);
+        }
+
+        IReadOnlyCollection<string> files;
+        try { files = assets.EnumerateUnder($@"Sound\Voice\{basename}"); }
+        catch (Exception ex)
+        {
+            return new VoiceCarryOutcome(0, 0, 0,
+                new[] { $@"could not scan 'Sound\Voice\{basename}' for voice files ({ex.Message}) — verify voiced lines in-game." },
+                assets.ReadIncomplete);
+        }
+        if (files.Count == 0) return VoiceCarryOutcome.None(assets.ReadIncomplete);
+
+        // Build the carry list: each voice file whose embedded id was renumbered → its new-id name (ONLY the id segment
+        // changes — see the header). A file with no '_<8hex>_<num>.<ext>' tail, or whose id wasn't renumbered, is left alone.
+        var items = new List<CarryItem>();
+        foreach (var oldRel in files)
+        {
+            var fname = Path.GetFileName(oldRel);
+            var m = VoiceIdRx.Match(fname);
+            if (!m.Success) continue;                                      // not an INFO-keyed voice file — nothing to remap
+            uint full;
+            try { full = Convert.ToUInt32(m.Groups[1].Value, 16); } catch { continue; }
+            uint oldLocal = full & 0xFFFFFFu;                              // mask the index byte, exactly like VoicePath emits "00"+6hex
+            if (!idMap.TryGetValue(oldLocal, out var newLocal)) continue;  // id not renumbered → filename unchanged → no carry
+
+            var newId = "00" + newLocal.ToString("X6");
+            var newFname = fname.Substring(0, m.Groups[1].Index) + newId + fname.Substring(m.Groups[1].Index + m.Groups[1].Length);
+            var dir = Path.GetDirectoryName(oldRel) ?? "";                 // same voice-type folder — only the filename's id moves
+            var newRel = dir.Length == 0 ? newFname : Path.Combine(dir, newFname);
+            items.Add(new CarryItem(oldRel, newRel, new FormKey(modKey, newLocal), $"{oldLocal:X6}→{newLocal:X6} {fname}"));
+        }
+
+        var failures = new List<string>();
+        var (carriedFiles, carriedLines) = CarryItems(items, assets, outDir, failures);
+        return new VoiceCarryOutcome(files.Count, carriedFiles, carriedLines.Count, failures, assets.ReadIncomplete);
+    }
+
+    /// <summary>One asset to carry: read <see cref="OldPath"/>'s winning on-disk copy and place its bytes at
+    /// <see cref="NewPath"/> under the output dir. <see cref="Owner"/> is the renumbered record the asset belongs to (the
+    /// distinct-owner count = NPCs-carried for facegen, lines-carried for voice); <see cref="Label"/> prefixes any failure.</summary>
+    readonly record struct CarryItem(string OldPath, string NewPath, FormKey Owner, string Label);
+
+    /// <summary>The shared TWO-PHASE carry both facegen (A1) and voice (A2) ride. Phase 1: resolve each item's OLD path to
+    /// its WINNING on-disk bytes and stage them to a '.houseCARL-tmp' SIBLING of the final new path (a name that never
+    /// collides with an old '00&lt;hex&gt;.ext' read path). Phase 2: once EVERY read is done, commit the temps via
+    /// <see cref="AtomicFile.Commit"/>. Staging-before-committing is the in-place-aliasing fix (PR #123): the renumber packs
+    /// the new ids into the same window the source used, so in the in-place lane (outDir == the donor's own folder) a direct
+    /// new-id write could clobber a DIFFERENT record's not-yet-read old-id file — handing it the wrong face/voice (a Q3 silent
+    /// wrong answer). O(1) memory per file (staged to disk, not buffered). A resolve MISS is skipped silently (the caller
+    /// decides whether "absent" is normal); a FOUND-but-unwritable file is a NAMED failure. Returns (files committed, the set
+    /// of distinct owners that had ≥1 file committed). Never throws — the records are already written.</summary>
+    static (int Files, HashSet<FormKey> Owners) CarryItems(
+        IReadOnlyList<CarryItem> items, AssetResolver.AssetView assets, string outDir, List<string> failures)
+    {
+        var pending = new List<(string Staged, string Final, FormKey Owner)>();
+
+        // ---- phase 1: read every old asset + stage it to a temp (writes ONLY '.houseCARL-tmp', never an old read path) ----
+        foreach (var it in items)
+        {
+            var res = assets.ResolveForPlacement(it.OldPath);
+            if (res.Sources.Count == 0) continue;                          // not on disk — the caller decides if that's normal
+
+            var (bytes, err) = ReadWinner(res.Sources[0]);                 // the copy that currently displays/plays in-game
+            if (err is not null) { failures.Add($"{it.Label}: {err}"); continue; }
+
+            var final = Path.Combine(outDir, it.NewPath);
+            var staged = final + ".houseCARL-tmp";                         // sibling temp — distinct from every old read path
+            try
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(final)!);
+                try { if (File.Exists(staged)) File.Delete(staged); } catch { /* a stuck temp surfaces on the write below */ }
+                File.WriteAllBytes(staged, bytes!);
+                // Truncation guard on the TEMP (the commit is an atomic rename, which can't truncate): a short stage is caught here.
+                long size; try { size = new FileInfo(staged).Length; } catch { size = -1; }
+                if (size != bytes!.Length)
+                {
+                    failures.Add($"{it.Label}: staged {size} byte(s), expected {bytes.Length} — verify.");
+                    try { File.Delete(staged); } catch { }
+                    continue;
+                }
+                pending.Add((staged, final, it.Owner));
+            }
             catch (Exception ex)
             {
-                failures.Add($"{newKey.ID:X6}: could not commit '{Path.GetFileName(final)}' — {ex.Message}");
+                failures.Add($"{it.Label}: could not stage '{it.NewPath}' — {ex.Message}");
                 try { if (File.Exists(staged)) File.Delete(staged); } catch { }
             }
         }
-        return new AssetRenameOutcome(npcs.Count, carriedKeys.Count, files, failures, assets.ReadIncomplete);
+
+        // ---- phase 2: commit every staged temp (all reads done → overwriting an old file at a now-reused name is safe) ----
+        int files = 0;
+        var owners = new HashSet<FormKey>();
+        foreach (var (staged, final, owner) in pending)
+        {
+            try { AtomicFile.Commit(staged, final); files++; owners.Add(owner); }
+            catch (Exception ex)
+            {
+                failures.Add($"could not commit '{Path.GetFileName(final)}' — {ex.Message}");
+                try { if (File.Exists(staged)) File.Delete(staged); } catch { }
+            }
+        }
+        return (files, owners);
     }
+
+    /// <summary>Matches a voice file's '_&lt;8hex&gt;_&lt;response&gt;.&lt;ext&gt;' tail (anchored to the end, so quest/topic
+    /// EditorID segments that themselves contain underscores or hex don't confuse it). Group 1 is the 8-hex FormID segment —
+    /// the only part a renumber moves. Compiled: CarryVoice runs it once per discovered file.</summary>
+    static readonly System.Text.RegularExpressions.Regex VoiceIdRx =
+        new(@"_([0-9A-Fa-f]{8})_\d+\.[A-Za-z0-9]+$", System.Text.RegularExpressions.RegexOptions.Compiled);
 
     /// <summary>Read the bytes of a resolved WINNING provider — a loose file off disk, or a single BSA entry via native
     /// Mutagen (zero handle at rest, the AssetResolver.TryReadArchiveEntry cornerstone). Mirrors LoadOrderService.ReadResolvedSource

--- a/src/housecarl-core/AssetResolver.cs
+++ b/src/housecarl-core/AssetResolver.cs
@@ -331,6 +331,42 @@ public sealed class AssetResolver : IDisposable
         return relPaths.Select(p => Resolve(p, snap)).ToList();
     }
 
+    /// <summary>Every DISTINCT Data-relative file path that exists anywhere under <paramref name="prefix"/> (recursively),
+    /// across all loose roots and all active BSAs — the directory ENUMERATION the voice carry needs (Resolve answers ONE
+    /// path; this lists what's there). The winner per path is left to <see cref="ResolveForPlacement"/>; here we only need
+    /// the set of paths that exist in ANY source. Reuses the <see cref="NormalizeQueryPath"/> escape guard. Pure read of the
+    /// snapshot's BSA tables + a bounded recursive loose walk under the prefix; holds nothing. A loose root that won't
+    /// enumerate contributes nothing (its absence flows through <see cref="ReadIncomplete"/>, never a silent half-answer).</summary>
+    public IReadOnlyCollection<string> EnumerateUnder(string prefix) => EnumerateUnder(prefix, _snap);
+
+    IReadOnlyCollection<string> EnumerateUnder(string prefix, Snapshot snap)
+    {
+        var pre = NormalizeQueryPath(prefix);                    // drive-root / '..' rejected loud (Q3), backslash-normalized
+        var withSep = pre + "\\";                                // match a SUBTREE, not a sibling whose name starts with 'pre'
+        var found = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // loose: recurse each root's copy of the prefix dir (set-UNION across roots — the per-path winner is decided later).
+        foreach (var (_, rootDir) in _looseRoots)
+        {
+            var baseDir = Path.Combine(rootDir, pre);
+            if (!Directory.Exists(baseDir)) continue;
+            try
+            {
+                foreach (var f in Directory.EnumerateFiles(baseDir, "*", SearchOption.AllDirectories))
+                    found.Add(Normalize(f.Substring(rootDir.Length)));       // f starts with rootDir → the remainder is Data-relative
+            }
+            catch { /* a root that won't enumerate contributes nothing; not silently trusted (see the summary) */ }
+        }
+
+        // BSA: every table entry under the prefix (the cached tables ARE the authoritative archive listing, zero handle at rest).
+        foreach (var t in snap.Tables.Values)
+            foreach (var entry in t)
+                if (entry.StartsWith(withSep, StringComparison.OrdinalIgnoreCase))
+                    found.Add(entry);
+
+        return found;
+    }
+
     /// <summary>Capture the CURRENT build as a pinned read view (the LoadOrderResolver.Capture discipline): a bulk
     /// facegen scan and its read-failure list answer from ONE build, so a RefreshIfStale landing mid-scan cannot make
     /// the scan's hits and <see cref="BsaFailures"/> describe two different builds. Pure data over the immutable snapshot.</summary>
@@ -363,6 +399,11 @@ public sealed class AssetResolver : IDisposable
             var r = _r; var s = _s;                              // locals — a struct's lambda can't capture 'this'
             return relPaths.Select(p => r.Resolve(p, s)).ToList();
         }
+
+        /// <summary>Enumerate every Data-relative path under <paramref name="prefix"/> pinned to THIS view's build — see
+        /// <see cref="AssetResolver.EnumerateUnder(string)"/>. The voice carry lists the plugin's voice files off the same
+        /// capture it resolves their winners from, so the scan and its <see cref="ReadIncomplete"/> caveat agree.</summary>
+        public IReadOnlyCollection<string> EnumerateUnder(string prefix) => _r.EnumerateUnder(prefix, _s);
     }
 
     /// <summary>Re-stat the inputs; if any changed, rebuild the snapshot and return true. Inputs = the active archives

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -896,7 +896,9 @@ public static class WritePatchBuilder
     /// (externals present, no opt-in) the list IS the refusal detail; with opt-in repoint, <see cref="Repointed"/> reports
     /// each. <see cref="PluginsScanned"/>/<see cref="UnscannableRecords"/> are the identify-pass coverage accounting.
     /// <see cref="AssetRename"/> (null until the asset-carry runs) is the FormID-keyed-asset accounting — A1: facegen
-    /// carried to the new FormIDs (so a compacted NPC mod no longer silently dark-faces). <see cref="ExternalOverriders"/>
+    /// carried to the new FormIDs (so a compacted NPC mod no longer silently dark-faces). <see cref="VoiceRename"/>
+    /// (A2, null until the carry runs) is the same for voice (.fuz/.lip), so a compacted voiced mod no longer goes mute.
+    /// <see cref="ExternalOverriders"/>
     /// (gap #2) are plugins OUTSIDE the target that OVERRIDE a renumbered record — surfaced as a WARN (they orphan after
     /// the renumber and houseCARL can't auto-repoint an override's identity); they never gate the compaction.</summary>
     public sealed record CompactOutcome(
@@ -904,7 +906,8 @@ public static class WritePatchBuilder
         IReadOnlyList<string> Masters, int RecordsCopied, int RecordsRenumbered, long Bytes,
         IReadOnlyList<string> ExternalPlugins, IReadOnlyList<RepointReport> Repointed,
         int PluginsScanned, int UnscannableRecords, IReadOnlyList<string> UnscannableSamples, string? Note = null,
-        AssetRenameOutcome? AssetRename = null, IReadOnlyList<string>? ExternalOverriders = null)
+        AssetRenameOutcome? AssetRename = null, IReadOnlyList<string>? ExternalOverriders = null,
+        VoiceCarryOutcome? VoiceRename = null)
     {
         public static CompactOutcome Fail(string error) =>
             new(false, error, false, "", "", false, false, Array.Empty<string>(), 0, 0, 0,

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -116,6 +116,10 @@ public static class CiAll
         // FaceGen (head mesh + face tint) to the new FormID, end-to-end through the real service, so it no longer silently
         // dark-faces (the gap MERGE_REFERENCE_RESEARCH §3/§8 exposed in the shipped tool). New-file + in-place + no-facegen.
         ("facegen-carry-guard", FacegenCarryProbe.RunGuard),
+        // COMPACT/MERGE Wave A2 — the asset-rename spine's SECOND category: compacting a VOICED mod carries its FormID-keyed
+        // voice (.fuz spoken audio + .lip lip-sync) to the new INFO FormID, end-to-end through the real service, so it no
+        // longer silently goes mute. New-file + in-place + multi-line + no-voice; rides the same two-phase carry as facegen.
+        ("voice-carry-guard", VoiceCarryProbe.RunGuard),
         // COMPACT gap #2 — the identify-pass now detects external OVERRIDERS (a plugin that overrides a renumbered record,
         // not just one that FormLinks to it), surfaced as a WARN (warn-and-proceed, xEdit parity) distinct from the
         // referencer refuse/repoint. Proves overrider→success+named and referencer→refused stay separate.

--- a/src/housecarl-generator/VoiceCarryProbe.cs
+++ b/src/housecarl-generator/VoiceCarryProbe.cs
@@ -1,0 +1,239 @@
+using System.Linq;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// COMPACT/MERGE Wave A2 — VOICE-CARRY guard for housecarl_compact_plugin (the asset-rename spine, second category).
+/// Proves the OTHER half of the gap the merge research (MERGE_REFERENCE_RESEARCH_2026-06-26 §3/§8) exposed in the
+/// SHIPPED compact tool is CLOSED: compacting a VOICED mod renumbers its dialogue lines (INFOs) AND carries the
+/// FormID-keyed voice files (.fuz spoken audio + .lip lip-sync) to the NEW INFO FormID, so the mod no longer SILENTLY
+/// goes mute (a Q3 degraded mode — the pre-A2 tool renumbered the INFO but left the voice at the old FormID the engine
+/// no longer looks up, and only PRINTED a "verify voice yourself" reminder). CarryVoice DISCOVERS by scanning the
+/// plugin's Sound\Voice\&lt;plugin&gt;\ prefix and rewriting the embedded id segment of every file whose FormID was
+/// renumbered (strategy b — catches radiant/quest-alias lines a graph re-derivation would miss). Drives the REAL
+/// <see cref="LoadOrderService.CompactPlugin"/> over a synthetic MO2 instance (the FacegenCarry / CompactServiceGuard
+/// pattern), so it pins the END-TO-END wiring, not the service in isolation.
+///   NEW-FILE   — compact to a new file carries an INFO's .fuz + .lip to the new FormID under the FRESH mod folder,
+///                byte-exact; the outcome reports 2 files / 1 line; the OLD-FormID voice is left untouched.
+///   IN-PLACE   — compact in place carries the voice into the target's OWN folder at the new FormID (old left orphan).
+///   MULTI-LINE — two INFOs with distinct audio each keep their OWN .fuz across the renumber (the shared two-phase
+///                carry; the dedicated OVERLAPPING-window aliasing torture test lives in facegen-carry-guard, which
+///                rides the SAME CarryItems helper, so the aliasing fix is proven once where it's cleanest to build).
+///   NO-VOICE   — a voiced-free plugin carries nothing and is NOT a failure (FilesScanned 0, carried 0, zero WARN).
+/// Run: dotnet run --project src/housecarl-generator voice-carry-guard
+/// </summary>
+public static class VoiceCarryProbe
+{
+    // The voice-path coordinates the fixture's audio is filed under — only the id segment moves on a compact, so old
+    // and new paths share these (CarryVoice rewrites the id, nothing else). VoiceType is the on-disk folder name.
+    const string VoiceType = "FemaleEventoned";
+    const int RespNum = 1;
+
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  COMPACT Wave A2 — voice-carry guard (housecarl_compact_plugin)  ################");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        var root = Path.Combine(Path.GetTempPath(), "hc-voice-carry-guard-" + Guid.NewGuid().ToString("N"));
+        var fuzBytes = new byte[] { 0x46, 0x55, 0x5A, 0x01, 0x02, 0x03 };   // distinctive "spoken audio" bytes
+        var lipBytes = new byte[] { 0x4C, 0x49, 0x50, 0x10, 0x11 };         // distinctive "lip-sync" bytes
+        try
+        {
+            // ================= NEW-FILE: carry .fuz + .lip to the new INFO FormID in a fresh folder, byte-exact =================
+            {
+                var (mods, prof) = MakeInstance(Path.Combine(root, "newfile"));
+                var key = new ModKey("VoiceNf", ModType.Plugin);
+                var topicOld = new FormKey(key, 0x810);
+                var infoOld = new FormKey(key, 0x811);
+                WriteMod(mods, "VoiceNf", key, m => AddTopic(m, topicOld, infoOld, "HcVoiceTopic"));
+                WriteLoose(Path.Combine(mods, "VoiceNf"), VoicePath.For(infoOld, VoiceType, "", "HcVoiceTopic", RespNum, VoiceFile.Fuz), fuzBytes);
+                WriteLoose(Path.Combine(mods, "VoiceNf"), VoicePath.For(infoOld, VoiceType, "", "HcVoiceTopic", RespNum, VoiceFile.Lip), lipBytes);
+                WriteProfile(prof, new[] { key.FileName.String }, new[] { "*" + key.FileName }, new[] { "+VoiceNf" });
+                WriteSkyrimIni(prof);
+
+                using var svc = LoadOrderService.WithInstance(Path.Combine(root, "newfile"), 0, new UserConfigStore(Path.Combine(root, "user-nf.json")));
+                svc.Stats();
+
+                var o = svc.CompactPlugin("VoiceNf.esp");
+                FormKey? infoNew = null; bool fuzOk = false, lipOk = false, oldUntouched = false;
+                if (o.Success && File.Exists(o.OutputPath))
+                {
+                    infoNew = ReadInfoKey(o.OutputPath, "HcVoiceTopic");
+                    var modRoot = Path.GetDirectoryName(o.OutputPath)!;
+                    if (infoNew is { } ik)
+                    {
+                        var newFuz = Path.Combine(modRoot, VoicePath.For(ik, VoiceType, "", "HcVoiceTopic", RespNum, VoiceFile.Fuz));
+                        var newLip = Path.Combine(modRoot, VoicePath.For(ik, VoiceType, "", "HcVoiceTopic", RespNum, VoiceFile.Lip));
+                        fuzOk = File.Exists(newFuz) && File.ReadAllBytes(newFuz).SequenceEqual(fuzBytes);
+                        lipOk = File.Exists(newLip) && File.ReadAllBytes(newLip).SequenceEqual(lipBytes);
+                    }
+                    var oldFuz = Path.Combine(mods, "VoiceNf", VoicePath.For(infoOld, VoiceType, "", "HcVoiceTopic", RespNum, VoiceFile.Fuz));
+                    oldUntouched = File.Exists(oldFuz) && File.ReadAllBytes(oldFuz).SequenceEqual(fuzBytes);
+                }
+                var vr = o.VoiceRename;
+                Check(o.Success && infoNew is { } k && k.ID >= RemapEngine.EslFloor && k.ID <= RemapEngine.EslCeiling
+                      && fuzOk && lipOk
+                      && vr is { FilesScanned: 2, FilesCarried: 2, LinesCarried: 1 } && vr.Failures.Count == 0,
+                      $"NEW-FILE voice carried to new FormID {infoNew?.ID:X6} (fuz {fuzOk}, lip {lipOk}, report {vr?.FilesCarried}f/{vr?.LinesCarried}line/{vr?.FilesScanned}scanned{(o.Success ? "" : "; ERR " + o.Error)})");
+                Check(oldUntouched, "NEW-FILE the OLD-FormID voice is left untouched (non-destructive)");
+            }
+
+            // ================= IN-PLACE: carry the voice into the target's OWN folder at the new FormID =================
+            {
+                var (mods, prof) = MakeInstance(Path.Combine(root, "inplace"));
+                var key = new ModKey("VoiceIp", ModType.Plugin);
+                var topicOld = new FormKey(key, 0x820);
+                var infoOld = new FormKey(key, 0x821);
+                WriteMod(mods, "VoiceIp", key, m => AddTopic(m, topicOld, infoOld, "HcVoiceTopic"));
+                WriteLoose(Path.Combine(mods, "VoiceIp"), VoicePath.For(infoOld, VoiceType, "", "HcVoiceTopic", RespNum, VoiceFile.Fuz), fuzBytes);
+                WriteProfile(prof, new[] { key.FileName.String }, new[] { "*" + key.FileName }, new[] { "+VoiceIp" });
+                WriteSkyrimIni(prof);
+
+                using var svc = LoadOrderService.WithInstance(Path.Combine(root, "inplace"), 0, new UserConfigStore(Path.Combine(root, "user-ip.json")));
+                svc.Stats();
+
+                var o = svc.CompactPlugin("VoiceIp.esp", inPlace: true, acknowledge: true);
+                FormKey? infoNew = null; bool fuzOk = false, oldOrphan = false;
+                if (o.Success)
+                {
+                    infoNew = ReadInfoKey(o.OutputPath, "HcVoiceTopic");
+                    if (infoNew is { } ik)
+                    {
+                        var newFuz = Path.Combine(mods, "VoiceIp", VoicePath.For(ik, VoiceType, "", "HcVoiceTopic", RespNum, VoiceFile.Fuz));
+                        fuzOk = File.Exists(newFuz) && File.ReadAllBytes(newFuz).SequenceEqual(fuzBytes);
+                    }
+                    // the OLD-FormID voice remains as a harmless orphan (non-destructive — never auto-deleted)
+                    oldOrphan = File.Exists(Path.Combine(mods, "VoiceIp", VoicePath.For(infoOld, VoiceType, "", "HcVoiceTopic", RespNum, VoiceFile.Fuz)));
+                }
+                var vr = o.VoiceRename;
+                Check(o.Success && o.InPlace && fuzOk && vr is { FilesCarried: 1, LinesCarried: 1 },
+                      $"IN-PLACE voice carried into the target folder at new FormID {infoNew?.ID:X6} (fuz {fuzOk}, report {vr?.FilesCarried}f{(o.Success ? "" : "; ERR " + o.Error)})");
+                Check(oldOrphan, "IN-PLACE the OLD-FormID voice is left as a harmless orphan (non-destructive)");
+            }
+
+            // ===== MULTI-LINE: two INFOs with DISTINCT audio each keep their OWN .fuz across the renumber (shared two-phase) =====
+            // The OVERLAPPING old/new-id aliasing torture test is facegen-carry-guard's (it rides the SAME CarryItems helper),
+            // so here we pin the per-line correctness of a multi-file voice carry: line A must not inherit line B's audio.
+            {
+                var (mods, prof) = MakeInstance(Path.Combine(root, "multi"));
+                var key = new ModKey("VoiceMl", ModType.Plugin);
+                var tA = new FormKey(key, 0x830); var iA = new FormKey(key, 0x831);
+                var tB = new FormKey(key, 0x832); var iB = new FormKey(key, 0x833);
+                var fuzA = new byte[] { 0xA0, 0x01, 0x02 };
+                var fuzB = new byte[] { 0xB0, 0x01, 0x02 };
+                WriteMod(mods, "VoiceMl", key, m => { AddTopic(m, tA, iA, "HcTopicA"); AddTopic(m, tB, iB, "HcTopicB"); });
+                WriteLoose(Path.Combine(mods, "VoiceMl"), VoicePath.For(iA, VoiceType, "", "HcTopicA", RespNum, VoiceFile.Fuz), fuzA);
+                WriteLoose(Path.Combine(mods, "VoiceMl"), VoicePath.For(iB, VoiceType, "", "HcTopicB", RespNum, VoiceFile.Fuz), fuzB);
+                WriteProfile(prof, new[] { key.FileName.String }, new[] { "*" + key.FileName }, new[] { "+VoiceMl" });
+                WriteSkyrimIni(prof);
+
+                using var svc = LoadOrderService.WithInstance(Path.Combine(root, "multi"), 0, new UserConfigStore(Path.Combine(root, "user-ml.json")));
+                svc.Stats();
+
+                var o = svc.CompactPlugin("VoiceMl.esp", inPlace: true, acknowledge: true);
+                bool aOk = false, bOk = false;
+                if (o.Success)
+                {
+                    var iaNew = ReadInfoKey(o.OutputPath, "HcTopicA");
+                    var ibNew = ReadInfoKey(o.OutputPath, "HcTopicB");
+                    if (iaNew is { } ak) aOk = File.ReadAllBytes(Path.Combine(mods, "VoiceMl", VoicePath.For(ak, VoiceType, "", "HcTopicA", RespNum, VoiceFile.Fuz))).SequenceEqual(fuzA);
+                    if (ibNew is { } bk) bOk = File.ReadAllBytes(Path.Combine(mods, "VoiceMl", VoicePath.For(bk, VoiceType, "", "HcTopicB", RespNum, VoiceFile.Fuz))).SequenceEqual(fuzB);
+                }
+                var vr = o.VoiceRename;
+                Check(o.Success && aOk && bOk && vr is { FilesCarried: 2, LinesCarried: 2 },
+                      $"MULTI-LINE each dialogue line keeps its OWN audio (A {aOk}, B {bOk}, report {vr?.FilesCarried}f/{vr?.LinesCarried}lines{(o.Success ? "" : "; ERR " + o.Error)})");
+            }
+
+            // ================= NO-VOICE: a plugin with no voice files carries nothing and is NOT a failure =================
+            {
+                var (mods, prof) = MakeInstance(Path.Combine(root, "novoice"));
+                var key = new ModKey("VoiceNone", ModType.Plugin);
+                var topicOld = new FormKey(key, 0x840);
+                var infoOld = new FormKey(key, 0x841);
+                WriteMod(mods, "VoiceNone", key, m => AddTopic(m, topicOld, infoOld, "HcVoiceTopic"));
+                WriteProfile(prof, new[] { key.FileName.String }, new[] { "*" + key.FileName }, new[] { "+VoiceNone" });
+                WriteSkyrimIni(prof);
+
+                using var svc = LoadOrderService.WithInstance(Path.Combine(root, "novoice"), 0, new UserConfigStore(Path.Combine(root, "user-nv.json")));
+                svc.Stats();
+
+                var o = svc.CompactPlugin("VoiceNone.esp");
+                var vr = o.VoiceRename;
+                Check(o.Success && vr is { FilesScanned: 0, FilesCarried: 0, LinesCarried: 0 } && vr.Failures.Count == 0,
+                      $"NO-VOICE a voiced-free plugin carries nothing and is NOT a failure (report {vr?.FilesCarried}f/{vr?.FilesScanned}scanned, warns {vr?.Failures.Count}{(o.Success ? "" : "; ERR " + o.Error)})");
+            }
+        }
+        finally { try { Directory.Delete(root, true); } catch { } }
+
+        Console.WriteLine();
+        Console.WriteLine($"=== voice-carry-guard: {(fail == 0 ? "PASS" : $"FAIL ({fail})")} ===");
+        return fail == 0 ? 0 : 1;
+    }
+
+    // ---- fixture builders ----
+
+    /// <summary>Add a DialogTopic (with EditorID, so the readback can find it) holding ONE INFO line — the minimal voiced
+    /// dialogue shape compact renumbers (topic→INFO nesting via RenumberModInto).</summary>
+    static void AddTopic(SkyrimMod m, FormKey topicKey, FormKey infoKey, string topicEdid)
+    {
+        var topic = new DialogTopic(topicKey, SkyrimRelease.SkyrimSE) { EditorID = topicEdid };
+        topic.Responses.Add(new DialogResponses(infoKey, SkyrimRelease.SkyrimSE));
+        m.DialogTopics.Add(topic);
+    }
+
+    /// <summary>Read P′ back and return the (renumbered) FormKey of the single INFO under the topic with <paramref name="topicEdid"/>.</summary>
+    static FormKey? ReadInfoKey(string pPrimePath, string topicEdid)
+    {
+        using var pp = SkyrimMod.CreateFromBinaryOverlay(pPrimePath, SkyrimRelease.SkyrimSE);
+        var topic = pp.DialogTopics.FirstOrDefault(t => t.EditorID == topicEdid);
+        return topic?.Responses.FirstOrDefault()?.FormKey;
+    }
+
+    // ---- synthetic MO2 layout helpers (the FacegenCarry / CompactServiceGuard probe pattern) ----
+
+    static (string mods, string prof) MakeInstance(string inst)
+    {
+        var mods = Path.Combine(inst, "mods");
+        var data = Path.Combine(inst, "game", "Data");
+        var prof = Path.Combine(inst, "profiles", "Default");
+        foreach (var d in new[] { mods, data, prof }) Directory.CreateDirectory(d);
+        File.WriteAllText(Path.Combine(inst, "ModOrganizer.ini"),
+            "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+            + Path.Combine(inst, "game").Replace(@"\", @"\\") + ")\r\n");
+        return (mods, prof);
+    }
+
+    static void WriteMod(string mods, string folder, ModKey key, Action<SkyrimMod> build)
+    {
+        var dir = Path.Combine(mods, folder);
+        Directory.CreateDirectory(dir);
+        var m = new SkyrimMod(key, SkyrimRelease.SkyrimSE);
+        build(m);
+        m.BeginWrite.ToPath(Path.Combine(dir, key.FileName.String)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+    }
+
+    static void WriteProfile(string prof, string[] loadorder, string[] plugins, string[] modlist)
+    {
+        Directory.CreateDirectory(prof);
+        File.WriteAllText(Path.Combine(prof, "loadorder.txt"), "# header\r\n" + string.Join("\r\n", loadorder) + "\r\n");
+        File.WriteAllText(Path.Combine(prof, "plugins.txt"), string.Join("\r\n", plugins) + "\r\n");
+        File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n" + string.Join("\r\n", modlist) + "\r\n");
+    }
+
+    static void WriteSkyrimIni(string prof) =>
+        File.WriteAllText(Path.Combine(prof, "Skyrim.ini"), "[Archive]\r\nsResourceArchiveList=\r\n");
+
+    static void WriteLoose(string baseDir, string rel, byte[] bytes)
+    {
+        var p = Path.Combine(baseDir, rel);
+        Directory.CreateDirectory(Path.GetDirectoryName(p)!);
+        File.WriteAllBytes(p, bytes);
+    }
+}

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1663,23 +1663,31 @@ public sealed class LoadOrderService : IDisposable
                     repointed.Add(new WritePatchBuilder.RepointReport(ext, rep.Success, rep.Error));
                 }
 
-            // 7b. carry FormID-keyed assets (compact/merge Wave A1: facegen). The records renumbered, so the asset FILES the
-            //     engine looks up BY FormID — FaceGen head mesh/tint — must follow, or a compacted NPC mod silently dark-faces
-            //     (the gap this research exposed in the shipped tool). Best-effort + REPORTED (Q3): the records are already
-            //     written, so a facegen we can't carry is a NAMED warning in the outcome, never a failure of the compaction —
-            //     and the asset layer failing to build never fails the compact either. outDir = the P′ mod-folder root (the
-            //     directory holding the plugin) in BOTH lanes (new-file: the fresh folder; in-place: the target's own folder).
+            // 7b. carry the FormID-keyed assets a renumber moves — FaceGen head mesh/tint (A1) + voice .fuz/.lip (A2). The
+            //     records renumbered, so the asset FILES the engine looks up BY FormID must follow, or a compacted NPC mod
+            //     silently dark-faces and a voiced mod goes mute (the gap this research exposed in the shipped tool). ONE
+            //     captured asset view feeds both carries (so the scan and its read-failure caveat agree). Best-effort +
+            //     REPORTED (Q3): the records are already written, so an asset we can't carry is a NAMED warning in the
+            //     outcome, never a failure of the compaction — and the asset layer failing to build never fails the compact
+            //     either. outDir = the P′ mod-folder root (the directory holding the plugin) in BOTH lanes (new-file: the
+            //     fresh folder; in-place: the target's own folder).
             AssetRenameOutcome assetRename;
+            VoiceCarryOutcome voiceRename;
             try
             {
                 AssetResolver assetResolver;
                 lock (_gate) { assetResolver = Assets; }                  // reentrant under the held _writeGate (the PlaceAssets idiom)
-                assetRename = AssetRenameService.CarryFaceGen(outPath, plan.Dict, assetResolver.Capture(), Path.GetDirectoryName(outPath)!);
+                var assetView = assetResolver.Capture();
+                var outDir = Path.GetDirectoryName(outPath)!;
+                assetRename = AssetRenameService.CarryFaceGen(outPath, plan.Dict, assetView, outDir);
+                voiceRename = AssetRenameService.CarryVoice(outPath, plan.Dict, assetView, outDir);
             }
             catch (Exception ex)
             {
                 assetRename = new AssetRenameOutcome(0, 0, 0,
                     new[] { $"facegen carry skipped — the asset layer could not be built ({ex.Message}); verify NPC faces in-game." }, false);
+                voiceRename = new VoiceCarryOutcome(0, 0, 0,
+                    new[] { $"voice carry skipped — the asset layer could not be built ({ex.Message}); verify voiced lines in-game." }, false);
             }
 
             // 8. audit markers (PR #122 review #2): stamp the distinct editedInPlace= breadcrumb into the meta.ini of EVERY
@@ -1700,7 +1708,7 @@ public sealed class LoadOrderService : IDisposable
             return new WritePatchBuilder.CompactOutcome(
                 true, null, false, outPath, name, inPlace, esl, build.Masters, build.RecordsCopied, build.RecordsRenumbered,
                 build.Bytes, id.ExternalPlugins, repointed, id.PluginsScanned, id.UnscannableRecords, id.UnscannableSamples,
-                markerNotes.Count > 0 ? string.Join(" ", markerNotes) : null, assetRename, id.ExternalOverriders);
+                markerNotes.Count > 0 ? string.Join(" ", markerNotes) : null, assetRename, id.ExternalOverriders, voiceRename);
         }
     }
 

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -612,10 +612,27 @@ public static class WriteTools
                 sb.Append("  note: a BSA failed to read this scan, so a 'no facegen' result may be incomplete — verify NPC faces in-game.\n");
         }
 
+        // Voice (.fuz/.lip) carried WITH the renumber (compact/merge Wave A2) — the renumber moved every INFO to a new
+        // FormID, and a voice filename is keyed by the OLD FormID, so carrying it is what stops a compacted voiced mod
+        // going mute. Reported, not silent (Q3) — and the old "voice NOT carried, verify yourself" reminder is now retired.
+        if (o.VoiceRename is { } vr)
+        {
+            if (vr.FilesCarried > 0)
+                sb.Append("voice: carried ").Append(vr.FilesCarried).Append(vr.FilesCarried == 1 ? " file for " : " files for ")
+                  .Append(vr.LinesCarried).Append(vr.LinesCarried == 1 ? " dialogue line to the new FormIDs" : " dialogue lines to the new FormIDs")
+                  .Append(o.InPlace ? " (old-FormID voice left as harmless orphans).\n" : " (in the new mod folder — enabling it carries the voice).\n");
+            else if (vr.FilesScanned > 0 && vr.Failures.Count == 0)
+                sb.Append("voice: ").Append(vr.FilesScanned).Append(vr.FilesScanned == 1 ? " voice file found, none keyed to a renumbered line" : " voice files found, none keyed to a renumbered line")
+                  .Append(" — nothing to carry.\n");
+            foreach (var f in vr.Failures.Take(25)) sb.Append("  voice WARN: ").Append(f).Append('\n');
+            if (vr.Failures.Count > 25) sb.Append("  voice WARN: … (+").Append(vr.Failures.Count - 25).Append(" more)\n");
+            if (vr.ReadIncomplete)
+                sb.Append("  note: a BSA failed to read this scan, so a 'no voice' result may be incomplete — verify voiced lines in-game.\n");
+        }
+
         if (o.Note is { } note) sb.Append("note: ").Append(note).Append('\n');
-        sb.Append("reminder: voiced dialogue files (.fuz/.lip, named by the OLD FormID) are NOT yet carried by compact — ")
-          .Append("verify voiced lines after compacting. FormIDs compiled into Papyrus (.pex hardcoded / GetFormFromFile) and ")
-          .Append("any Mutagen-delta residual are NOT remappable — verify scripted records too.");
+        sb.Append("reminder: FormIDs compiled into Papyrus (.pex hardcoded / GetFormFromFile) and any Mutagen-delta ")
+          .Append("residual are NOT remappable — verify scripted records after compacting.");
         return sb.ToString();
     }
 


### PR DESCRIPTION
## What & why

Compacting a **voiced** mod renumbered its dialogue lines (INFOs) but left the voice files at the OLD FormID the engine no longer looks up — so a compacted voiced mod went **silently mute**, and the shipped tool only printed a "verify voice yourself" reminder (a Q3 degraded mode). This is the gap `MERGE_REFERENCE_RESEARCH_2026-06-26.md` §3/§8 exposed; A1 closed it for facegen, **A2 closes it for voice** — the `.fuz`/`.lip` files follow the renumber.

Compaction was already at xEdit parity (past it on facegen); A2 brings voice to parity too.

## The design call (the plan left discovery "pick in-build")

**Strategy (b) — scan-by-embedded-FormID, not graph re-derivation.** A voice filename embeds the parent quest/topic EditorIDs, the voice type, AND a response number — none of which a renumber touches; on a compact the plugin keeps its basename, so **only the `00<6hex>` id segment moves**. So `CarryVoice` enumerates the files actually present under `Sound\Voice\<plugin>\` and rewrites the id segment of each whose FormID was renumbered.

- **Why over forward-compute:** scan-by-disk catches radiant / quest-alias lines whose dialogue graph won't resolve (forward-compute would silently orphan exactly those hard cases), and it matches what zMerge/xEdit do. No record readback needed.

## Shared two-phase staging (one home for the PR #123 fix)

The in-place aliasing fix (stage ALL reads to `.houseCARL-tmp`, then commit — so a new-id write can't clobber a different record's not-yet-read old-id file) is **extracted into one `CarryItems` helper** that both facegen and voice ride. `CarryFaceGen` is refactored onto it with **no behavior change** — `facegen-carry-guard` stays green, including its overlapping-id aliasing arm.

## Changes

- **`AssetRenameService`** — `CarryVoice` + `VoiceCarryOutcome`; `CarryItem`/`CarryItems` shared two-phase carry; `CarryFaceGen` refactored onto it.
- **`AssetResolver`** — `EnumerateUnder` (recursive loose walk + BSA-table prefix scan), pinned on `AssetView` so the scan and its `ReadIncomplete` caveat share one build.
- **`LoadOrderService.CompactPlugin`** — one captured asset view feeds both carries; `VoiceRename` threaded into `CompactOutcome`.
- **`WriteTools.RenderCompact`** — reports the voice accounting; **retires the stale "voice NOT carried" reminder**.
- **`VoiceCarryProbe`** (`voice-carry-guard`) — new-file + in-place + multi-line + no-voice, registered in `ci-all`.

## Q3 / non-destructive

Best-effort + reported: records are already written, so a voice file it can't carry is a **named warning**, never a failure of the compaction. Only NEW-FormID copies are written; OLD-FormID files are left as harmless orphans (never auto-deleted).

## Tests

`ci-all` **65/65** (was 64; +1 `voice-carry-guard`). The dedicated overlapping-id aliasing torture test stays in `facegen-carry-guard` since both categories ride the same `CarryItems` staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)