### PR TITLE
docs(claude.md): route fresh sessions to a sub-project STATUS over the main handoff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,8 @@ A session picking up work reads:
 2. **The latest handoff** in `dev/session-handoffs/` — what the last session did and what to pick up. The most important transition read; start here for "where are we."
 3. **The PRFAQ corpus** (`dev/PRFAQ/`) — read once when new to the project, then consult on demand (it's ~60k tokens — not a per-session read). Product: P1 + P2. Direction: P7 + rebuild plan v1. Proof: spike findings (code at `dev/references/spike/`). Deeper, on demand: FAQs (P3/P4), Housecarl-HEAD eval (P5), pivot doc (§5's source).
 
+**Sub-project sessions.** Some work runs as a self-contained sub-project under `dev/projects/<name>/` (its own tracking, walled off from the main gap/bug/release lane — see `dev/projects/README.md`). If a session is for one, the user will name it ("the follower skill", "the `<name>` project"); then read `dev/projects/<name>/STATUS.md` **instead of** the latest `dev/session-handoffs/` handoff (item 2), and stay in that lane. Absent that, boot normally — the default is unchanged.
+
 The cornerstone (§3) and revalidation protocol (§4) are restated in this file, so you operate correctly from CLAUDE.md alone — the corpus is the authority you re-read when the protocol sends you there, not a tax every session pays.
 
 ---


### PR DESCRIPTION
## What

Adds a **"Sub-project sessions"** note to `CLAUDE.md` §2 (the read-order section). When a fresh session is for a self-contained sub-project under `dev/projects/<name>/`, it reads that project's `STATUS.md` **instead of** the latest main handoff and stays in that lane. Absent that, boot is unchanged.

## Why

We just stood up the first sub-project inside houseCARL (`dev/projects/follower-skill/`, the from-scratch follower-authoring skill — private, gitignored). Its tracking is deliberately walled off from the main gap/bug/release lane. This one line gives a clean, deterministic routing fork at session start so the maintainer can say "let's work on the follower skill" and the session enters the right lane, while normal sessions are entirely unaffected.

Generic across any future nested project — `<name>` is a placeholder; the convention lives in `dev/projects/README.md` (private).

## Scope

- One file, two inserted lines (`CLAUDE.md` only). No code, no behavior change to tools or build.
- Default session boot (read the latest `dev/session-handoffs/` handoff) is preserved verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)