### PR TITLE
fix(write): compact-by-default in-place verify read-back (HCBR-2026-06-28-01)

### DIFF
--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -403,6 +403,43 @@ public static class ReadEngine
         catch (Exception ex) { return (false, null, typeof(object), record, $"(unreadable: {ex.Message})"); }
     }
 
+    /// <summary>Best-effort COMPACT identity of the element a list/dict verb just acted on — the write-verify's
+    /// "what landed" line (HCBR-2026-06-28-01, the compact in-place readback). For a list <c>Add</c>, the new last
+    /// element + the new count (<c>now 29 (+1), new [28] = …</c>); for a keyed <c>SetAtIndex</c>/<c>Remove</c>, the
+    /// touched key + new count; else the new count. Names the element as specifically as the model allows — a
+    /// formlink element renders its FormKey, an identity-bearing struct its Name/EditorID, an anonymous struct (a
+    /// condition) its <c>[Type]</c>. Read-only; NEVER throws (null on any difficulty) — a display nicety on an
+    /// ALREADY-succeeded write, never load-bearing. <paramref name="leafPath"/> is the verb's path to the collection
+    /// (the engine's <see cref="WriteRequest.Path"/>); <paramref name="key"/> its list index / dict key, if any.</summary>
+    internal static string? TouchedElement(object record, string[] leafPath, string verb, string? key)
+    {
+        try
+        {
+            var nav = NavigateValue(record, leafPath);
+            if (!nav.ok || nav.val is not System.Collections.IEnumerable en || nav.val is string) return null;
+            int count = 0; object? last = null;
+            foreach (var e in en) { count++; last = e; }
+            return verb switch
+            {
+                "Add"        => last is null ? $"now {count} item(s)" : $"now {count} (+1), new [{count - 1}] = {ElementId(last, record)}",
+                "ReplaceAll" => $"now {count} item(s) (replaced)",
+                "SetAtIndex" => key is not null ? $"now {count} item(s), set [{key}]" : $"now {count} item(s)",
+                "Remove"     => key is not null ? $"now {count} item(s), removed [{key}]" : $"now {count} item(s) (-1)",
+                _            => $"now {count} item(s)",
+            };
+        }
+        catch { return null; }
+    }
+
+    /// <summary>The compact identity of ONE element for <see cref="TouchedElement"/>: a value/formlink element via its
+    /// own round-trip token (a keyword → its FormKey), an identity-bearing or anonymous struct via
+    /// <see cref="ElementSummary"/> (<c>[Type] Name=…</c> / <c>[Type]</c>).</summary>
+    static string ElementId(object elem, object parent)
+    {
+        var lr = EmitToken(elem, elem.GetType(), parent);
+        return lr.HasValue ? lr.Token : ElementSummary(elem);
+    }
+
     /// <summary>A compact summary for a container/struct value: for a collection, the count form
     /// (<see cref="SummariseContainer"/>); for a struct, <c>[TypeName]</c> plus a representative identity
     /// field (Name/EditorID/Title) where present — so a list line like

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -338,7 +338,8 @@ public static class WritePatchBuilder
                 ILinkCache? cache = WriteEngine.RecordNeedsSourceCache(body) ? session.LinkCacheFor(winnerPlugin) : null;
                 var ov = WriteEngine.GenericGetOrAddAsOverride(patchMod, body, cache);
                 WriteEngine.ApplyVerb(ov, req);
-                ops.Add(new OpResult(e.Target, req.RecordType, label, true, null, TryReadAfter(ov, req), DescribeLanded(ov, req)));
+                var (after, landed) = DescribeApplied(ov, req);
+                ops.Add(new OpResult(e.Target, req.RecordType, label, true, null, after, landed));
             }
             catch (ExpectedApplyRejectionException ex)
             {
@@ -492,7 +493,8 @@ public static class WritePatchBuilder
                 ILinkCache? cache = WriteEngine.RecordNeedsSourceCache(body) ? session.LinkCacheFor(targetName) : null;
                 var ov = WriteEngine.GenericGetOrAddAsOverride(targetMod, body, cache);
                 WriteEngine.ApplyVerb(ov, req);
-                ops.Add(new OpResult(e.Target, req.RecordType, label, true, null, TryReadAfter(ov, req), DescribeLanded(ov, req)));
+                var (after, landed) = DescribeApplied(ov, req);
+                ops.Add(new OpResult(e.Target, req.RecordType, label, true, null, after, landed));
             }
             catch (ExpectedApplyRejectionException ex)
             {
@@ -1669,22 +1671,27 @@ public static class WritePatchBuilder
         catch { return null; }
     }
 
-    /// <summary>The compact "what landed" descriptor for the in-place verify's DEFAULT render (HCBR-2026-06-28-01).
-    /// A SCALAR leaf → the new value itself (names exactly what was set); a LIST/DICT leaf → the touched element +
-    /// the new cardinality via <see cref="ReadEngine.TouchedElement"/> (the element you Added/Set, not the whole
-    /// list — the report's "not the whole record"), falling back to the container's count summary. Best-effort and
-    /// read-only like <see cref="TryReadAfter"/>: null on any difficulty, never throws into the write result.</summary>
-    static string? DescribeLanded(IMajorRecord ov, WriteRequest req)
+    /// <summary>Read the edited leaf ONCE and derive BOTH best-effort descriptors an edit-lane <see cref="OpResult"/>
+    /// carries (PR #127 review #1 — previously two identical reflective reads of the same leaf per op, doubling the very
+    /// readback cost on the large-list records the report was about). <c>After</c> = the leaf read-back (xEdit remains
+    /// the authority). <c>Landed</c> = the compact "what landed" line the in-place verify renders by default
+    /// (HCBR-2026-06-28-01): a SCALAR leaf reuses the value just read (names exactly what was set); a LIST/DICT leaf names
+    /// the touched element + new count via <see cref="ReadEngine.TouchedElement"/> (the element you Added/Set, NOT the
+    /// whole list), falling back to the container summary. Read-only; NEVER throws into the write result (both null on any
+    /// difficulty). The create lane keeps <see cref="TryReadAfter"/> (it needs only <c>After</c>, never <c>Landed</c>).</summary>
+    static (string? After, string? Landed) DescribeApplied(IMajorRecord ov, WriteRequest req)
     {
         try
         {
             var leaf = string.Join('.', req.Path);
             var read = ReadEngine.ReadFields(ov, new[] { leaf });
             var f = read.Fields.FirstOrDefault(x => x.Path == leaf) ?? read.Fields.FirstOrDefault();
-            if (f is { HasValue: true }) return f.Token;                          // scalar — the new value names what landed
-            return ReadEngine.TouchedElement(ov, req.Path, req.Verb, req.Key)     // list/dict — touched element + new count
-                   ?? f?.Note;                                                    // fall back to the container summary
+            if (f is null) return (null, null);
+            var after = f.HasValue ? f.Token : f.Note;
+            // Scalar: Landed reuses the token just read. List/dict: name the touched element (+ new count); else the summary.
+            var landed = f.HasValue ? f.Token : (ReadEngine.TouchedElement(ov, req.Path, req.Verb, req.Key) ?? f.Note);
+            return (after, landed);
         }
-        catch { return null; }
+        catch { return (null, null); }
     }
 }

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -50,8 +50,10 @@ public static class WritePatchBuilder
     }
 
     /// <summary>Per-edit result. On a successful call every op has <see cref="Applied"/>=true (all-or-nothing);
-    /// <see cref="After"/> is a best-effort read-back of the edited leaf (xEdit remains the authority).</summary>
-    public sealed record OpResult(FormKey Target, string RecordType, string Label, bool Applied, string? Error, string? After);
+    /// <see cref="After"/> is a best-effort read-back of the edited leaf (xEdit remains the authority).
+    /// <see cref="Landed"/> is the compact "what landed" descriptor the in-place verify renders by default
+    /// (HCBR-2026-06-28-01) — the new scalar value, or the touched list element + new count; null when not derivable.</summary>
+    public sealed record OpResult(FormKey Target, string RecordType, string Label, bool Applied, string? Error, string? After, string? Landed = null);
 
     /// <summary>One record read back IN FULL from the WRITTEN patch file (opt-in — the pre-enable verify loop,
     /// wishlist #3 re-scoped / HCBR-2026-06-11-02 wave (b)): every modeled field, deep, read off the re-opened
@@ -336,7 +338,7 @@ public static class WritePatchBuilder
                 ILinkCache? cache = WriteEngine.RecordNeedsSourceCache(body) ? session.LinkCacheFor(winnerPlugin) : null;
                 var ov = WriteEngine.GenericGetOrAddAsOverride(patchMod, body, cache);
                 WriteEngine.ApplyVerb(ov, req);
-                ops.Add(new OpResult(e.Target, req.RecordType, label, true, null, TryReadAfter(ov, req)));
+                ops.Add(new OpResult(e.Target, req.RecordType, label, true, null, TryReadAfter(ov, req), DescribeLanded(ov, req)));
             }
             catch (ExpectedApplyRejectionException ex)
             {
@@ -490,7 +492,7 @@ public static class WritePatchBuilder
                 ILinkCache? cache = WriteEngine.RecordNeedsSourceCache(body) ? session.LinkCacheFor(targetName) : null;
                 var ov = WriteEngine.GenericGetOrAddAsOverride(targetMod, body, cache);
                 WriteEngine.ApplyVerb(ov, req);
-                ops.Add(new OpResult(e.Target, req.RecordType, label, true, null, TryReadAfter(ov, req)));
+                ops.Add(new OpResult(e.Target, req.RecordType, label, true, null, TryReadAfter(ov, req), DescribeLanded(ov, req)));
             }
             catch (ExpectedApplyRejectionException ex)
             {
@@ -1663,6 +1665,25 @@ public static class WritePatchBuilder
             var read = ReadEngine.ReadFields(ov, new[] { leaf });
             var f = read.Fields.FirstOrDefault(x => x.Path == leaf) ?? read.Fields.FirstOrDefault();
             return f is null ? null : (f.HasValue ? f.Token : f.Note);
+        }
+        catch { return null; }
+    }
+
+    /// <summary>The compact "what landed" descriptor for the in-place verify's DEFAULT render (HCBR-2026-06-28-01).
+    /// A SCALAR leaf → the new value itself (names exactly what was set); a LIST/DICT leaf → the touched element +
+    /// the new cardinality via <see cref="ReadEngine.TouchedElement"/> (the element you Added/Set, not the whole
+    /// list — the report's "not the whole record"), falling back to the container's count summary. Best-effort and
+    /// read-only like <see cref="TryReadAfter"/>: null on any difficulty, never throws into the write result.</summary>
+    static string? DescribeLanded(IMajorRecord ov, WriteRequest req)
+    {
+        try
+        {
+            var leaf = string.Join('.', req.Path);
+            var read = ReadEngine.ReadFields(ov, new[] { leaf });
+            var f = read.Fields.FirstOrDefault(x => x.Path == leaf) ?? read.Fields.FirstOrDefault();
+            if (f is { HasValue: true }) return f.Token;                          // scalar — the new value names what landed
+            return ReadEngine.TouchedElement(ov, req.Path, req.Verb, req.Key)     // list/dict — touched element + new count
+                   ?? f?.Note;                                                    // fall back to the container summary
         }
         catch { return null; }
     }

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -128,6 +128,11 @@ public static class CiAll
         // REGENERATES its .seq from the renumbered plugin (a renumber shifts the on-disk FormIDs a stale .seq lists, so its
         // quests would silently never start). NOT a map-rename — rebuilt from P′. New-file + in-place-stale-replace + multi-quest + no-SGE.
         ("seq-regen-guard", SeqRegenProbe.RunGuard),
+        // COMPACT in-place verify read-back (HCBR-2026-06-28-01) — a multi-op in-place edit's forced touched-record verify
+        // renders COMPACT by default (one re-read-clean line per record, all N, names what landed) instead of a deep
+        // whole-record dump that overflowed the host token cap and spilled to a file (reading as "only some ops applied").
+        // full_readback=true still gives the deep dump, now bounded under the host limit with an explicit truncation note.
+        ("compact-readback-guard", CompactReadbackProbe.RunGuard),
     };
 
     /// <summary>Dispatch a single CI guard by name through the registry — the ONE place a CI probe is listed, so

--- a/src/housecarl-generator/CompactReadbackProbe.cs
+++ b/src/housecarl-generator/CompactReadbackProbe.cs
@@ -97,8 +97,11 @@ public static class CompactReadbackProbe
                   compact.Contains("now ") && compact.Contains(kwAddFk.ToString()));
             Check($"COMPACT: the whole response stays small even with {N} non-trivial records (the headline fix: no 80k spill)",
                   compact.Length < 6_000);
-            Check("COMPACT: stays under the lowered read-back cap (so the host never bounces it to a file)",
-                  compact.Length < Wire_ReadbackMaxChars());
+            // Guard the CAP VALUE itself against the real consts (PR #127 review #2 — the prior check compared against a
+            // hand-copied 24k mirror BELOW a stricter < 6_000 literal, so it could never fail and the cap was unguarded).
+            // This fails if ReadbackMaxChars ever creeps back toward the 80k DefaultMaxChars that caused the host spill.
+            Check("CAP: the read-back default cap is well under the host token ceiling (the 80k-spill regression guard)",
+                  Wire.ReadbackMaxChars < Wire.DefaultMaxChars && Wire.ReadbackMaxChars <= 32_000);
             Console.WriteLine($"   -- compact render: {compact.Length} chars, {CountOccurrences(compact, "\n") + 1} lines --");
             Console.WriteLine();
 
@@ -134,10 +137,6 @@ public static class CompactReadbackProbe
         catch (Exception ex) { Console.WriteLine($"   FAIL (unexpected): {ex.GetType().Name}: {ex.Message}\n{ex.StackTrace}"); return 1; }
         finally { try { Directory.Delete(dir, recursive: true); } catch { } }
     }
-
-    // The read-back cap the fix lowered DefaultMaxChars to — mirrored here so the guard asserts against the real value
-    // without making the const public (it lives in the internal Wire helper).
-    static int Wire_ReadbackMaxChars() => 24_000;
 
     static bool AllWeaponsGainedKeyword(string path, IReadOnlyList<FormKey> weaponFks, FormKey kwFk)
     {

--- a/src/housecarl-generator/CompactReadbackProbe.cs
+++ b/src/housecarl-generator/CompactReadbackProbe.cs
@@ -1,0 +1,180 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// REGRESSION GUARD (standing CI instrument) for the COMPACT in-place verify read-back (HCBR-2026-06-28-01).
+///
+/// The report: a multi-op <c>bulk_apply</c> editing N records IN PLACE force-ran the touched-record verify as a DEEP,
+/// depth-16, whole-record dump (the model-C floor substitute). For records that already hold large list fields the
+/// combined dump blew past the host token cap — at the 80k default, even the "gracefully truncated" 80k string STILL
+/// exceeded the host limit and spilled to a file, reading as "only some of the N ops applied" (a SILENT, Q3-breaking
+/// verification gap, though the writes themselves were correct).
+///
+/// The fix keeps the verify (corruption DETECTION unchanged — the deep re-read still RUNS) but changes its OUTPUT:
+///   - DEFAULT (full_readback=false) renders COMPACT — one line per record (re-read-clean + field count, or a NAMED
+///     failure) plus the "what landed" identity per op — covering ALL N records, never the silent spill.
+///   - full_readback=true still gives the deep field-by-field dump, now bounded at the LOWER Wire.ReadbackMaxChars so
+///     the cut-off output stays under the host limit and its truncation note actually reaches the caller.
+///
+/// Self-contained, in the VerifyLoopProbe pattern: synthesizes a masterless plugin with N weapons ON DISK, drives the
+/// REAL <see cref="WritePatchBuilder.ApplyInPlace"/> (which forces the verify ON) ONCE, then renders that single
+/// outcome THREE ways through the REAL <see cref="WriteTools.Render"/> (compact / full+low-cap / full+default cap).
+///
+/// RED before the fix: the compact arm's "all N re-read-clean lines / not the deep dump" assertions fail on the old
+/// code (in-place always deep-dumped); the low-cap arm's bounded+note assertion fails (old default cap was 80k, above
+/// the host limit). GREEN on the fixed code.
+///
+/// Run: <c>dotnet run --project src/housecarl-generator -- compact-readback-guard</c>
+/// </summary>
+public static class CompactReadbackProbe
+{
+    static int _pass, _fail;
+
+    public static int RunGuard(string[] args)
+    {
+        _pass = 0; _fail = 0;
+        Console.WriteLine("################  REGRESSION GUARD — compact in-place verify read-back (HCBR-2026-06-28-01)  ################");
+        Console.WriteLine();
+
+        var dir = Path.Combine(Path.GetTempPath(), "hc_compact_readback_guard");
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); } catch { }
+        Directory.CreateDirectory(dir);
+
+        const string pluginName = "hcCompact.esp";
+        var pluginPath = Path.Combine(dir, pluginName);
+        const int N = 6;   // the report's 6 recruit-open INFO lines, as 6 records here
+
+        try
+        {
+            // ---- 1. A masterless plugin: one keyword to ADD, and N weapons to edit IN PLACE. Weapons are non-trivial
+            //         records (Name / stats / bounds), so the DEEP dump of all N is large enough to exceed a low cap. ----
+            var mod = new SkyrimMod(ModKey.FromNameAndExtension(pluginName), SkyrimRelease.SkyrimSE);
+            var kwAdd = mod.Keywords.AddNew(); kwAdd.EditorID = "hcCompactKwAdded";
+            FormKey kwAddFk = kwAdd.FormKey;
+            var fks = new List<FormKey>();
+            for (int i = 0; i < N; i++)
+            {
+                var w = mod.Weapons.AddNew();
+                w.EditorID = $"hcCompactW{i}";
+                w.Name = $"Compact Weapon {i}";
+                w.BasicStats = new WeaponBasicStats { Damage = (ushort)(10 + i) };
+                fks.Add(w.FormKey);
+            }
+            mod.BeginWrite.ToPath(pluginPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+            using var resolver = LoadOrderResolver.Build(new[] { pluginPath });
+            var rulebook = CorpusRulebook.Load(GenerateCorpus(dir));
+            Console.WriteLine($"-- built masterless '{pluginName}' with {N} weapons + 1 keyword; editing all {N} IN PLACE --");
+            Console.WriteLine();
+
+            // ---- 2. ONE in-place bulk edit: Add the SAME keyword to all N weapons' (absent) Keywords list — the
+            //         report's "same op across N records" shape. ApplyInPlace forces the touched-record verify ON. ----
+            var edits = fks.Select(fk => new WritePatchBuilder.PatchEdit
+            {
+                Target = fk, Path = new[] { "Keywords" }, Verb = "Add", Value = kwAddFk.ToString(),
+            }).ToArray();
+
+            var outcome = WritePatchBuilder.ApplyInPlace(resolver, rulebook, edits, pluginPath, pluginName, fullReadback: true);
+            Check($"SETUP: in-place ApplyInPlace succeeded over {N} records  [{outcome.Error ?? "ok"}]", outcome.Success);
+            Check($"SETUP: the verify is forced ON — ReadBack carries all {N} touched records, none errored",
+                  outcome.ReadBack is { } rb0 && rb0.Count == N && rb0.All(r => r.Error is null && r.Record is not null));
+            Check("SETUP: every op captured a 'what landed' descriptor naming the added keyword",
+                  outcome.Ops.Count == N && outcome.Ops.All(o => o.Landed is not null && o.Landed.Contains(kwAddFk.ToString())));
+            Console.WriteLine();
+
+            // ============ ARM A — DEFAULT render (full_readback=false): COMPACT, all N, never the deep spill ============
+            var compact = WriteTools.Render(outcome, maxChars: 0, fullDump: false);
+            Check($"COMPACT: every one of the {N} edited records is verified (one 're-read clean' line each) — none silently dropped",
+                  CountOccurrences(compact, "re-read clean") == N);
+            Check("COMPACT: it is NOT the deep field-by-field dump (no full-readback header)",
+                  !compact.Contains("full read-back — the ENTIRE"));
+            Check("COMPACT: it names what landed (the touched element + new count)",
+                  compact.Contains("now ") && compact.Contains(kwAddFk.ToString()));
+            Check($"COMPACT: the whole response stays small even with {N} non-trivial records (the headline fix: no 80k spill)",
+                  compact.Length < 6_000);
+            Check("COMPACT: stays under the lowered read-back cap (so the host never bounces it to a file)",
+                  compact.Length < Wire_ReadbackMaxChars());
+            Console.WriteLine($"   -- compact render: {compact.Length} chars, {CountOccurrences(compact, "\n") + 1} lines --");
+            Console.WriteLine();
+
+            // ============ ARM B — full_readback=true at a LOW cap: bounded + an EXPLICIT note (never a silent spill) ====
+            var fullLowCap = WriteTools.Render(outcome, maxChars: 1_500, fullDump: true);
+            Check("FULL/low-cap: the deep dump is requested (full-readback header present)",
+                  fullLowCap.Contains("full read-back — the ENTIRE"));
+            Check("FULL/low-cap: it is bounded near the cap (NOT the 80k that the host rejected)",
+                  fullLowCap.Length < 4_000);
+            Check("FULL/low-cap: the truncation is EXPLICIT (a '[truncated …]' note reaches the caller, Q3 — never silent)",
+                  fullLowCap.Contains("truncated"));
+            Console.WriteLine($"   -- full/low-cap render: {fullLowCap.Length} chars --");
+            Console.WriteLine();
+
+            // ============ ARM C — full_readback=true at the DEFAULT cap: the deep dump is intact-or-explicitly-bounded ==
+            var fullDefault = WriteTools.Render(outcome, maxChars: 0, fullDump: true);
+            Check("FULL/default: the deep dump is present (full-readback header)",
+                  fullDefault.Contains("full read-back — the ENTIRE"));
+            Check($"FULL/default: it covers all {N} records OR notes its own truncation — never silently partial (Q3)",
+                  CountOccurrences(fullDefault, "editorid=") == N || fullDefault.Contains("truncated"));
+            Check("FULL/default: the deep dump shows real field content (the never-edited Name on a record)",
+                  fullDefault.Contains("Compact Weapon 0"));
+            Console.WriteLine();
+
+            // ============ GROUND TRUTH — the edits themselves are correct (independent of the render) ============
+            Check($"GROUND TRUTH: re-opening the written file, all {N} weapons gained the keyword (the writes were always correct)",
+                  AllWeaponsGainedKeyword(pluginPath, fks, kwAddFk));
+
+            Console.WriteLine();
+            Console.WriteLine($"=== compact-readback-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
+            return _fail == 0 ? 0 : 1;
+        }
+        catch (Exception ex) { Console.WriteLine($"   FAIL (unexpected): {ex.GetType().Name}: {ex.Message}\n{ex.StackTrace}"); return 1; }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
+
+    // The read-back cap the fix lowered DefaultMaxChars to — mirrored here so the guard asserts against the real value
+    // without making the const public (it lives in the internal Wire helper).
+    static int Wire_ReadbackMaxChars() => 24_000;
+
+    static bool AllWeaponsGainedKeyword(string path, IReadOnlyList<FormKey> weaponFks, FormKey kwFk)
+    {
+        ISkyrimModGetter? ov = null;
+        try
+        {
+            ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE);
+            foreach (var fk in weaponFks)
+            {
+                var w = ov.Weapons.FirstOrDefault(x => x.FormKey == fk);
+                if (w?.Keywords is null || !w.Keywords.Any(k => k.FormKey == kwFk)) return false;
+            }
+            return true;
+        }
+        catch { return false; }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    // Generate the validator corpus BY CONSTRUCTION into the temp dir — the self-contained posture of the sibling
+    // guards (no checked-in corpus.json, no game data, just slower).
+    static string GenerateCorpus(string dir)
+    {
+        var genDir = Path.Combine(dir, "corpus-gen");
+        CorpusGenerator.GenerateAll(genDir, Path.Combine(dir, "corpus-ref"));
+        return Path.Combine(genDir, "corpus.json");
+    }
+
+    static int CountOccurrences(string haystack, string needle)
+    {
+        int n = 0, i = 0;
+        while ((i = haystack.IndexOf(needle, i, StringComparison.Ordinal)) >= 0) { n++; i += needle.Length; }
+        return n;
+    }
+
+    static void Check(string label, bool ok)
+    {
+        Console.WriteLine($"   [{(ok ? "PASS" : "FAIL")}] {label}");
+        if (ok) _pass++; else _fail++;
+    }
+}

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -188,6 +188,13 @@ static class Wire
     /// <summary>Server default char budget for one tool response (~20k tokens). A caller raises it per-call via max_chars.</summary>
     public const int DefaultMaxChars = 80_000;
 
+    /// <summary>Default char budget for a write-tool READ-BACK section (HCBR-2026-06-28-01). Deliberately well BELOW
+    /// <see cref="DefaultMaxChars"/> / the host's per-result token ceiling: the forced in-place verify deep-dumped
+    /// every touched record and, at the 80k default, the "gracefully truncated" 80k string STILL exceeded the host
+    /// limit and spilled to a file (silent, Q3-breaking). The compact default render is tiny; this only bounds the
+    /// opt-in full_readback=true dump, whose truncation note now actually reaches the caller. A caller raises it via max_chars.</summary>
+    public const int ReadbackMaxChars = 24_000;
+
     static int Cap(int maxChars) => maxChars > 0 ? maxChars : DefaultMaxChars;
 
     // ---- housecarl_read_record ----------------------------------------------------------------------

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -188,11 +188,14 @@ static class Wire
     /// <summary>Server default char budget for one tool response (~20k tokens). A caller raises it per-call via max_chars.</summary>
     public const int DefaultMaxChars = 80_000;
 
-    /// <summary>Default char budget for a write-tool READ-BACK section (HCBR-2026-06-28-01). Deliberately well BELOW
+    /// <summary>Default char budget for ANY write-tool READ-BACK dump (HCBR-2026-06-28-01). Deliberately well BELOW
     /// <see cref="DefaultMaxChars"/> / the host's per-result token ceiling: the forced in-place verify deep-dumped
     /// every touched record and, at the 80k default, the "gracefully truncated" 80k string STILL exceeded the host
-    /// limit and spilled to a file (silent, Q3-breaking). The compact default render is tiny; this only bounds the
-    /// opt-in full_readback=true dump, whose truncation note now actually reaches the caller. A caller raises it via max_chars.</summary>
+    /// limit and spilled to a file (silent, Q3-breaking). The compact default render is tiny; this bounds the opt-in
+    /// full_readback=true dump, whose truncation note now actually reaches the caller. INTENTIONALLY GLOBAL (PR #127
+    /// review #3): the host ceiling is a transport property, not an in-place-lane one, so this cap applies to EVERY
+    /// AppendFullReadback caller — the in-place verify, forward_record, and the new-file full_readback=true dump all
+    /// hit the same spill bug, and all want the same bound. A caller raises it per-call via max_chars.</summary>
     public const int ReadbackMaxChars = 24_000;
 
     static int Cap(int maxChars) => maxChars > 0 ? maxChars : DefaultMaxChars;

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -54,9 +54,9 @@ public static class WriteTools
             bool in_place = false,
         [Description("Optional, default false. Confirms the one-time in-place trade-off for target (see in_place) — needed only on the FIRST in-place edit of a given plugin, never again for it. Waives the consent to touch your original ONLY; it NEVER skips the record verify.")]
             bool acknowledge = false,
-        [Description("When true, the response ALSO returns the ENTIRE edited record read back from the written patch file on disk (every field, deep — not just the edited leaf). The pre-enable verification: confirm the write landed exactly and nothing else in the record was disturbed, WITHOUT enabling the patch in MO2. (The patch wins nothing until enabled + sorted in MO2 — this read-back is the written file's content, not load-order truth.)")]
+        [Description("When true, the read-back is the FULL deep field-by-field dump of the touched record (every field, not just the edited leaf) — confirm the write landed and nothing else was disturbed, WITHOUT enabling the patch in MO2. For an IN-PLACE edit the touched-record verify ALWAYS runs and is shown COMPACTLY by default (re-read-clean + what landed, every record); true expands it to the deep dump. (The read-back is the written file's content, NOT load-order truth — the patch/edit wins nothing until enabled + sorted in MO2.)")]
             bool full_readback = false,
-        [Description("Optional. Max characters for the whole response; past it the full read-back section is cut with an explicit notice (never silent). 0 = the server default (~80k). Only matters with full_readback=true.")]
+        [Description("Optional. Max characters for the whole response; past it the read-back is cut with an explicit notice (never silent). 0 = a safe default kept under the host's per-response token limit; raise it to widen a full_readback=true dump.")]
             int max_chars = 0) => Guard.Tool("housecarl_set_field", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
@@ -64,7 +64,7 @@ public static class WriteTools
         {
             Formid = formid, FieldPath = field_path, Verb = verb, Value = value, Key = key, Values = values,
         };
-        return Render(svc.ApplyEdits(new[] { op }, patch_name, into, full_readback, target, in_place, acknowledge), max_chars);
+        return Render(svc.ApplyEdits(new[] { op }, patch_name, into, full_readback, target, in_place, acknowledge), max_chars, full_readback);
     });
 
     [McpServerTool(Name = "housecarl_bulk_apply", Title = "Apply many edits in one patch"),
@@ -99,15 +99,15 @@ public static class WriteTools
             bool in_place = false,
         [Description("Optional, default false. Confirms the one-time in-place trade-off for target (see in_place) — needed only on the FIRST in-place edit of a given plugin, never again for it. Waives the consent to touch your original ONLY; it NEVER skips the record verify.")]
             bool acknowledge = false,
-        [Description("When true, the response ALSO returns the ENTIRE record(s) this call touched, read back from the written patch file on disk (every field, deep — not just the edited leaves). The pre-enable verification: confirm composed structures (conditions, container entries) landed exactly and nothing else in each record was disturbed, WITHOUT enabling the patch in MO2. (The patch wins nothing until enabled + sorted in MO2 — this read-back is the written file's content, not load-order truth.)")]
+        [Description("When true, the read-back is the FULL deep field-by-field dump of every record this call touched (not just the edited leaves) — confirm composed structures (conditions, container entries) landed and nothing else was disturbed, WITHOUT enabling the patch in MO2. For an IN-PLACE edit the touched-record verify ALWAYS runs and is shown COMPACTLY by default (per record: re-read-clean + what landed, covering ALL of them); true expands it to the deep dump. (The read-back is the written file's content, NOT load-order truth — the patch/edit wins nothing until enabled + sorted in MO2.)")]
             bool full_readback = false,
-        [Description("Optional. Max characters for the whole response; past it the full read-back section is cut with an explicit notice (never silent). 0 = the server default (~80k). Only matters with full_readback=true.")]
+        [Description("Optional. Max characters for the whole response; past it the read-back is cut with an explicit notice (never silent). 0 = a safe default kept under the host's per-response token limit; raise it to widen a full_readback=true dump.")]
             int max_chars = 0) => Guard.Tool("housecarl_bulk_apply", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         if (operations is null || operations.Length == 0)
             return "error: operations is empty. Pass one or more {formid, field_path, verb, ...} edits.";
-        return Render(svc.ApplyEdits(operations, patch_name, into, full_readback, target, in_place, acknowledge), max_chars);
+        return Render(svc.ApplyEdits(operations, patch_name, into, full_readback, target, in_place, acknowledge), max_chars, full_readback);
     });
 
     [McpServerTool(Name = "housecarl_remove_record", Title = "Remove a whole record from a patch (or a plugin in place)"),
@@ -193,13 +193,13 @@ public static class WriteTools
             bool in_place = false,
         [Description("Optional, default false. Confirms the one-time in-place trade-off for target (see in_place) — needed only on the FIRST in-place write to a given plugin (edit OR create), never again for it. Waives the consent to touch your original ONLY; it NEVER skips the record verify.")]
             bool acknowledge = false,
-        [Description("When true, the response ALSO returns the ENTIRE created record read back from the written patch file on disk (every field, deep — not just the fields you set). The pre-enable verification, WITHOUT enabling the patch in MO2. (The patch wins nothing until enabled + sorted in MO2 — this read-back is the written file's content, not load-order truth.)")]
+        [Description("When true, the read-back is the FULL deep field-by-field dump of the created record (every field, not just the fields you set). For an IN-PLACE create the touched-record verify ALWAYS runs and is shown COMPACTLY by default (re-read-clean + field count per record); true expands it to the deep dump. (The read-back is the written file's content, NOT load-order truth — the patch/edit wins nothing until enabled + sorted in MO2.)")]
             bool full_readback = false,
-        [Description("Optional. Max characters for the whole response; past it the full read-back section is cut with an explicit notice (never silent). 0 = the server default (~80k). Only matters with full_readback=true.")]
+        [Description("Optional. Max characters for the whole response; past it the read-back is cut with an explicit notice (never silent). 0 = a safe default kept under the host's per-response token limit; raise it to widen a full_readback=true dump.")]
             int max_chars = 0) => Guard.Tool("housecarl_create_record", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-        return RenderCreate(svc.CreateRecords(record_type, editorid, operations ?? Array.Empty<BulkOp>(), patch_name, into, full_readback, parent, collection, grid, target, in_place, acknowledge), max_chars);
+        return RenderCreate(svc.CreateRecords(record_type, editorid, operations ?? Array.Empty<BulkOp>(), patch_name, into, full_readback, parent, collection, grid, target, in_place, acknowledge), max_chars, full_readback);
     });
 
     [McpServerTool(Name = "housecarl_bulk_create", Title = "Create many records (incl. a nested one-shot) in one patch"),
@@ -240,15 +240,15 @@ public static class WriteTools
             bool in_place = false,
         [Description("Optional, default false. Confirms the one-time in-place trade-off for target (see in_place) — needed only on the FIRST in-place write to a given plugin (edit OR create), never again for it. Waives the consent to touch your original ONLY; it NEVER skips the record verify.")]
             bool acknowledge = false,
-        [Description("When true, the response ALSO returns each created record IN FULL, read back from the written patch file on disk (every field, deep). The pre-enable verification, WITHOUT enabling the patch in MO2 (the written file's content, not load-order truth).")]
+        [Description("When true, the read-back is the FULL deep field-by-field dump of each created record. For an IN-PLACE create the touched-record verify ALWAYS runs and is shown COMPACTLY by default (re-read-clean + field count per record); true expands it to the deep dump. (The read-back is the written file's content, NOT load-order truth — the patch/edit wins nothing until enabled + sorted in MO2.)")]
             bool full_readback = false,
-        [Description("Optional. Max characters for the whole response; past it the full read-back section is cut with an explicit notice (never silent). 0 = the server default (~80k). Only matters with full_readback=true.")]
+        [Description("Optional. Max characters for the whole response; past it the read-back is cut with an explicit notice (never silent). 0 = a safe default kept under the host's per-response token limit; raise it to widen a full_readback=true dump.")]
             int max_chars = 0) => Guard.Tool("housecarl_bulk_create", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         if (records is null || records.Length == 0)
             return "error: records is empty. Pass one or more {record_type, editorid, operations?, parent?, collection?} specs.";
-        return RenderCreate(svc.CreateRecordsBatch(records, patch_name, into, full_readback, target, in_place, acknowledge), max_chars);
+        return RenderCreate(svc.CreateRecordsBatch(records, patch_name, into, full_readback, target, in_place, acknowledge), max_chars, full_readback);
     });
 
     [McpServerTool(Name = "housecarl_forward_record", Title = "Forward a plugin's version of a record as an override"),
@@ -281,7 +281,7 @@ public static class WriteTools
             string? into = null,
         [Description("When true, the response ALSO returns each forwarded record IN FULL, read back from the written patch file on disk (every field, deep). The pre-enable verification: confirm the copied version is exactly the source's, WITHOUT enabling the patch in MO2 (the written file's content, not load-order truth).")]
             bool full_readback = false,
-        [Description("Optional. Max characters for the whole response; past it the full read-back section is cut with an explicit notice (never silent). 0 = the server default (~80k). Only matters with full_readback=true.")]
+        [Description("Optional. Max characters for the whole response; past it the read-back is cut with an explicit notice (never silent). 0 = a safe default kept under the host's per-response token limit; raise it to widen a full_readback=true dump.")]
             int max_chars = 0) => Guard.Tool("housecarl_forward_record", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
@@ -365,7 +365,7 @@ public static class WriteTools
 
     /// <summary>Compact, parseable confirmation (rulebook: short mutation confirmation + the IDs needed for follow-up).
     /// On refusal, the full reason (every malformed/rejected op) so the caller can fix and retry.</summary>
-    static string Render(WritePatchBuilder.PatchOutcome o, int maxChars = 0)
+    internal static string Render(WritePatchBuilder.PatchOutcome o, int maxChars = 0, bool fullDump = false)   // internal: the compact-readback guard renders one outcome three ways
     {
         if (o.NeedsAcknowledge) return o.Error!;            // the first-touch in-place CONSENT prompt — a required confirmation, NOT an error (Q3)
         if (!o.Success) return "error: " + o.Error;
@@ -397,7 +397,15 @@ public static class WriteTools
         if (o.Ops.Any(op => string.Equals(op.RecordType, VoiceCheck.InfoCatalogName, StringComparison.Ordinal)))
             sb.Append("note: this edit touched a dialogue line (INFO). Voice (.fuz) and result-script coverage are checked on CREATE, not on edits — ")
               .Append("run housecarl_validate_dialogue on the topic (or its owning quest) to audit voice + result-script coverage and the topic graph over the edited line and every other line in the topic.\n");
-        if (o.ReadBack is { } rb) AppendFullReadback(sb, rb, maxChars);
+        // The touched-record verify (forced ON for in-place — the model-C floor substitute — and opt-in for the new-file
+        // lane) renders COMPACT by default and the full field-by-field dump only on full_readback=true (HCBR-2026-06-28-01):
+        // the deep dump of N records with large list fields blew past the host token cap and spilled to a file, reading as
+        // "only some ops applied". The verify itself is unchanged — this is its OUTPUT, not its detection.
+        if (o.ReadBack is { } rb)
+        {
+            if (fullDump) AppendFullReadback(sb, rb, maxChars);
+            else AppendCompactReadback(sb, o.Ops, rb, maxChars);
+        }
         if (o.Note is { } note) sb.Append("note: ").Append(note).Append('\n');
         sb.Append(o.InPlace
             ? $"to make more in-place edits to this plugin, pass target=\"{file}\" in_place=true (no further confirmation needed for it)."
@@ -405,13 +413,15 @@ public static class WriteTools
         return sb.ToString();
     }
 
-    /// <summary>The opt-in full read-back section (HCBR-2026-06-11-02 wave (b)): each touched/created record IN FULL,
+    /// <summary>The full_readback=true read-back section (HCBR-2026-06-11-02 wave (b)): each touched/created record IN FULL,
     /// re-read from the written file on disk. Labeled as exactly that — the written file's content, NOT load-order
     /// truth (the patch wins nothing until enabled in MO2) — so the caller can't mistake it for a winner read.
-    /// Char-budget-bounded with an explicit notice (Q3), same convention as the read tools.</summary>
+    /// Char-budget-bounded with an explicit notice (Q3), same convention as the read tools — now at the LOWER
+    /// <see cref="Wire.ReadbackMaxChars"/> default so the cut-off output stays under the host token ceiling and the
+    /// truncation note actually reaches the caller (HCBR-2026-06-28-01).</summary>
     static void AppendFullReadback(StringBuilder sb, IReadOnlyList<WritePatchBuilder.FullReadback> rb, int maxChars)
     {
-        int cap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        int cap = maxChars > 0 ? maxChars : Wire.ReadbackMaxChars;
         sb.Append("full read-back — the ENTIRE record(s) as written, re-read from the patch file on disk ")
           .Append("(the written file's content, NOT load-order truth; the patch wins nothing until enabled + sorted in MO2):\n");
         for (int i = 0; i < rb.Count; i++)
@@ -438,6 +448,41 @@ public static class WriteTools
                 }
                 sb.Append("    ").Append(f.Path).Append(" = ").Append(f.HasValue ? f.Token : f.Note).Append('\n');
             }
+        }
+    }
+
+    /// <summary>The DEFAULT (full_readback=false) render of the touched-record verify (HCBR-2026-06-28-01). The forced
+    /// in-place re-read still RAN — corruption DETECTION is unchanged; this only reports it COMPACTLY so it can't overflow
+    /// the host token cap the way the deep dump did (which spilled to a file and read as "only some ops applied"). One line
+    /// per record: a re-read-CLEAN marker + field count, OR the NAMED re-read failure (Q3); then the "what landed" identity
+    /// (the new scalar value, or the touched list element + new count) for each op that touched that record. Covers ALL N
+    /// records — bounded by the same char cap with an explicit truncation note, never the silent spill the forced deep dump
+    /// produced. The full field-by-field dump is one full_readback=true away.</summary>
+    static void AppendCompactReadback(StringBuilder sb, IReadOnlyList<WritePatchBuilder.OpResult> ops,
+        IReadOnlyList<WritePatchBuilder.FullReadback> rb, int maxChars)
+    {
+        int cap = maxChars > 0 ? maxChars : Wire.ReadbackMaxChars;
+        sb.Append("verified — every edited record re-read off the written file (compact; pass full_readback=true for the ")
+          .Append("full field-by-field dump):\n");
+        for (int i = 0; i < rb.Count; i++)
+        {
+            if (sb.Length >= cap)
+            {
+                sb.Append("  ... [truncated: ").Append(i).Append(" of ").Append(rb.Count)
+                  .Append(" record(s) shown at max_chars=").Append(cap).Append("; raise max_chars]\n");
+                return;
+            }
+            var r = rb[i];
+            // A re-read that failed is a real inconsistency — surface it LOUD and NAMED (the whole reason the in-place
+            // verify is forced on), never folded into the clean count.
+            if (r.Error is not null) { sb.Append("  ✗ ").Append(r.Target).Append(" — ").Append(r.Error).Append('\n'); continue; }
+            var rec = r.Record!;
+            sb.Append("  ✓ ").Append(rec.Type).Append(' ').Append(rec.FormKey)
+              .Append(" — re-read clean (").Append(rec.Fields.Count).Append(" field(s))");
+            var landed = ops.Where(op => op.Target == r.Target && op.Landed is not null)
+                            .Select(op => $"{op.Label}: {op.Landed}").ToList();
+            if (landed.Count > 0) sb.Append("; ").Append(string.Join("; ", landed));
+            sb.Append('\n');
         }
     }
 
@@ -653,7 +698,7 @@ public static class WriteTools
     /// <summary>Confirmation for housecarl_create_record: the new record's ALLOCATED FormID + editorid + type (the FormID
     /// is the key output — the caller references the new record by it), the patch path + its (derived) masters, and the
     /// fields applied. On refusal, the named reason (Q3) so the caller can fix and retry.</summary>
-    static string RenderCreate(WritePatchBuilder.CreateOutcome o, int maxChars = 0)
+    static string RenderCreate(WritePatchBuilder.CreateOutcome o, int maxChars = 0, bool fullDump = false)
     {
         if (o.NeedsAcknowledge) return o.Error!;            // the first-touch in-place CONSENT prompt — a required confirmation, NOT an error (Q3)
         if (!o.Success) return "error: " + o.Error;
@@ -689,7 +734,14 @@ public static class WriteTools
         AppendVoiceReport(sb, o.Voice, maxChars);
         AppendScriptBindingReport(sb, o.ScriptBinding, maxChars);
         AppendCellShellReport(sb, o.CellShell);
-        if (o.ReadBack is { } rb) AppendFullReadback(sb, rb, maxChars);
+        // Same compact-by-default verify as the edit lane (HCBR-2026-06-28-01): the forced create-in-place re-read still
+        // runs; full_readback=true gives the deep dump, the default reports it compactly (per created record: re-read clean
+        // + field count, or a named failure). The created records' set fields are already listed above.
+        if (o.ReadBack is { } rb)
+        {
+            if (fullDump) AppendFullReadback(sb, rb, maxChars);
+            else AppendCompactReadback(sb, Array.Empty<WritePatchBuilder.OpResult>(), rb, maxChars);
+        }
         if (o.Note is { } note) sb.Append("note: ").Append(note).Append('\n');
         sb.Append("the new FormID above is how you reference this record (SkyPatcher/SPID, or a follow-up edit). ");
         sb.Append(o.InPlace


### PR DESCRIPTION
## What

A multi-op **in-place** edit force-ran the touched-record verify as a deep, depth-16, whole-record dump. For records already holding large list fields (e.g. 6 dialogue INFOs with ~30 conditions each), the combined dump exceeded the host token cap — and at the 80k default even the *gracefully truncated* string was over the host limit, so the host bounced the whole result to a file. It read as "only 2 of 6 ops applied" even though all 6 writes were correct — a silent, Q3-breaking verification gap. (Reported in HCBR-2026-06-28-01.)

## The mechanism (not what the report assumed)

`full_readback=false` does **not** gate the in-place verify — it's forced ON by design (the model-C substitute for the dropped whole-plugin floor; `acknowledge` waives consent but never the verify). So the lever wasn't the flag; it was that the forced verify was deep **and** over-capped.

## The fix

Keep the verify (corruption **detection** unchanged — the deep re-read still runs, failures still named per Q3) but change its **output**:

- **default (`full_readback=false`)** → compact: one `re-read clean (N fields)` line per record (or a named failure), plus the "what landed" identity per op (new scalar value, or touched list element + new count). Covers **all N** records, never overflows.
- **`full_readback=true`** → still the deep field-by-field dump, now bounded at the lower `Wire.ReadbackMaxChars` (24k) so the cut-off output stays under the host limit and its truncation note actually reaches the caller.

Applies to both in-place edit (`set_field`/`bulk_apply`) and in-place create (`create_record`/`bulk_create`). Tool param descriptions updated to match.

## Before → after

- **Before:** ~80k chars for 6 records → spilled to a file → "only 2 of 6 verified."
- **After:** **~1,950 chars** for 6 records, all 6 on their own line, each naming what landed.

## Tests

- New `compact-readback-guard` (15 arms): one real in-place edit over 6 records rendered three ways (compact / full+low-cap / full+default cap) + ground-truth re-open.
- **RED-verified**: forced the old always-deep-dump behavior → the 4 compact arms fail; restored → green.
- `ci-all` **67/67**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)