### PR TITLE
Parse MO2 2.5.x ModOrganizer.ini: tolerate spaces around '='

### DIFF
--- a/src/housecarl-core/Mo2Instance.cs
+++ b/src/housecarl-core/Mo2Instance.cs
@@ -164,9 +164,11 @@ public static class Mo2Instance
         foreach (var raw in lines)
         {
             var line = raw.TrimStart();
-            if (line.Length <= key.Length || line[key.Length] != '=') continue;
-            if (line.AsSpan(0, key.Length).Equals(key, StringComparison.OrdinalIgnoreCase))
-                return line[(key.Length + 1)..];
+            int eq = line.IndexOf('=');
+            if (eq < 0) continue;
+            // Tolerate whitespace around '=' — MO2 2.5.x writes "key = value"; older MO2 wrote "key=value".
+            if (line.AsSpan(0, eq).TrimEnd().Equals(key, StringComparison.OrdinalIgnoreCase))
+                return line[(eq + 1)..];
         }
         return null;
     }


### PR DESCRIPTION
Fixes #128.

`FindValue` only matched `key=value` (the `=` immediately after the key). MO2 2.5.x writes `key = value` with spaces around the `=`, so `selected_profile`/`gamePath` were reported missing and `set_mo2_instance` refused to attach.

This finds the first `=` and compares the **trimmed** key, so both `key=value` (older MO2) and `key = value` (MO2 2.5.x) parse. `CleanValue` already trims the returned value, so the leading space after `=` is handled; `@ByteArray(...)` unwrapping is unaffected.

```diff
-            if (line.Length <= key.Length || line[key.Length] != '=') continue;
-            if (line.AsSpan(0, key.Length).Equals(key, StringComparison.OrdinalIgnoreCase))
-                return line[(key.Length + 1)..];
+            int eq = line.IndexOf('=');
+            if (eq < 0) continue;
+            if (line.AsSpan(0, eq).TrimEnd().Equals(key, StringComparison.OrdinalIgnoreCase))
+                return line[(eq + 1)..];
```

**Verification** — against a real MO2 2.5.2 Wabbajack instance (byte-confirmed `selected_profile = @ByteArray(...)` with spaces): before, `ReadSelectedProfile` → `null` and `Validate` failed with "no selected_profile / no gamePath"; after, both resolve the profile name, gamePath, DataDir, and ModsDir correctly. `housecarl-core` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
