### PR TITLE
release: 1.5.0 cut - roll changelog + bump plugin version

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "housecarl",
   "displayName": "houseCARL",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Comprehensive data-layer access to your Skyrim SE load order — read any record, author patches into a new plugin, look mods up on Nexus, and look up record schemas, Papyrus signatures, performance reviews, and distributor grammars — in plain English.",
   "author": { "name": "Avick3110" },
   "homepage": "https://github.com/Avick3110/houseCARL",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -4,9 +4,12 @@ All notable changes to houseCARL are documented here. Versioning is [semantic](h
 the `version` in `.claude-plugin/plugin.json` is bumped on each release, so installed users update only
 when it changes.
 
-## Unreleased
+## 1.5.0 — 2026-07-02
 
-_Accumulating toward the next release — not yet shipped._
+houseCARL gains **plugin surgery**: ESL-compact a plugin with its FormID-keyed assets (facegen, voice, SEQ)
+carried along automatically, and sweep the whole load order for record errors. **Two new tools (→ 28).**
+Plus a crash fix for newly-authored dialogue topics, a compact in-place verify read-back, and a batch of
+silent-failure and ergonomics fixes.
 
 **Two new tools (→ 28) — plugin surgery arrives**
 


### PR DESCRIPTION
## What

The 1.5.0 cut commit: rolls `## Unreleased` to `## 1.5.0 — 2026-07-02` with a release intro paragraph (1.4.0-style), and bumps `.claude-plugin/plugin.json` to `1.5.0`.

## Built + validated from this branch

- `scripts/build-plugin.ps1` → `release/houseCARL-1.5.0.zip` (16.05 MB, 322 entries, 11 skills, leak-check clean)
- `claude plugin validate ./dist/housecarl --strict` → PASSED

## Gate before merge

Per `dev/plans/RELEASE_1.5.0_PACK.md` §3, Aaron live-tests the repackaged zip first (compact_plugin end-to-end with facegen/voice/SEQ, check_errors sweep, DIAL SNAM, ergonomics pass). Merge on his go; tag `v1.5.0` on the merged commit. If the ship day slips, amend the date in the heading before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
