### PR TITLE
fix(dialogue): S3 validator lints + in-place SEQ auto-flag

### DIFF
--- a/.claude/skills/dialogue-authoring/SKILL.md
+++ b/.claude/skills/dialogue-authoring/SKILL.md
@@ -31,7 +31,9 @@ tools.
 **What houseCARL CANNOT do — say it, never paper over it:**
 - **Evaluate `Conditions` (CTDA).** Conditions decide *when* a line fires. houseCARL **can** statically catch a
   meaningful subset of **malformed** conditions — `housecarl_validate_dialogue` flags a dangling form reference,
-  a dead quest-alias index, an unset Run On reference, and a `GetIsID` pointed at a placed instance — and it can
+  a dead quest-alias index, an unset Run On reference, and a `GetIsID` pointed at a placed instance (it recognizes
+  the engine-implicit `PlayerRef` `000014`/`Player` `000007` forms, so a standard player-state gate — `HasSpell` or
+  an actor-value check Run On `PlayerRef` — validates clean, not false-flagged as missing) — and it can
   read a condition back and **decode** it (the function, its parameters, its Run On scope —
   [`references/condition-functions.md`](references/condition-functions.md)) so you can check it by eye. What it
   **cannot** do is **evaluate** whether a *well-formed* condition passes — only the running game can. So a
@@ -177,11 +179,15 @@ this skill's job.
 
 6. **SEQ, if the quest starts at game start.** Set the quest's Start-Game-Enabled flag, then run
    `housecarl_write_seq` against the plugin. Without it the quest — and all its dialogue — silently never
-   starts. (A plugin with no such quests needs no `.seq`; the tool reports that.)
+   starts. (A plugin with no such quests needs no `.seq`; the tool reports that.) If a later **in-place** edit
+   or removal prunes a master, the on-disk FormIDs shift and the existing `.seq` goes stale — houseCARL flags
+   this in the write's read-back note so you re-run `housecarl_write_seq` (it flags, never silently rewrites).
 
 7. **Validate, then verify.** Run `housecarl_validate_dialogue` on the topic (a DIAL FormID) or the whole
    quest (a QUST FormID). It checks what it can — quest/branch wiring, `LinkTo` and PNAM resolve, voice
-   present, scripts bound — and **prints a standing-limits footer for what it cannot** (the CTDA conditions,
+   present, scripts bound, and every `<Global=X>` text-replacement tag backed by a global in the quest's
+   `TextDisplayGlobals` (an unbacked tag renders as `[...]` in game — a silent failure it now warns on) — and
+   **prints a standing-limits footer for what it cannot** (the CTDA conditions,
    lip-sync, and the dropped-line caveat). Treat the footer as real: a clean pass is not "this will play."
    Read the new records back (`full_readback` on the create call) before telling the user to enable + sort
    the patch in MO2.

--- a/src/housecarl-core/DialogueValidate.cs
+++ b/src/housecarl-core/DialogueValidate.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Text.RegularExpressions;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Records;
 using Mutagen.Bethesda.Skyrim;
@@ -311,10 +312,22 @@ public static class DialogueValidate
         // false "dead alias" against a quest we couldn't read). Non-alias condition lints don't need this and run
         // regardless.
         HashSet<uint>? ownerAliasIds = null;
+        // The EditorIDs of the globals in the owning quest's TextDisplayGlobals list — the set a `<Global=X>` dialogue-text
+        // tag must name to render in game (item: the <Global=X>/TextDisplayGlobals lint). NULL when the owning quest is
+        // unresolvable (unset or not in the order): then we SKIP the tag lint rather than guess (Q3 — never a false
+        // "not in TextDisplayGlobals" against a quest we couldn't read), exactly as the alias-index lints skip.
+        HashSet<string>? ownerTextGlobals = null;
         string ownerQuestLabel = "the owning quest";
         if (questFk is { } ownerFk && resolve(ownerFk) is IQuestGetter ownerQuest)
         {
             ownerAliasIds = ownerQuest.Aliases.Select(a => a.ID).ToHashSet();
+            // Resolve each TextDisplayGlobals FormLink to its GLOB and collect the EditorID (case-insensitive — the engine's
+            // tag match is). A null/unresolvable entry contributes no name (it can't cover a tag anyway); globals resolve
+            // reliably, so this doesn't spuriously mark a real one absent.
+            ownerTextGlobals = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var g in ownerQuest.TextDisplayGlobals)
+                if (!g.FormKey.IsNull && resolve(g.FormKey) is IGlobalGetter glob && glob.EditorID is { Length: > 0 } gid)
+                    ownerTextGlobals.Add(gid);
             ownerQuestLabel = $"the owning quest {ownerQuest.EditorID ?? ownerFk.ToString()}";
         }
 
@@ -337,6 +350,13 @@ public static class DialogueValidate
             int rnum = 0;
             foreach (var resp in info.Responses)
                 CheckEncoding(resp.Text?.String, $"INFO {info.FormKey} response {++rnum} text", issues);
+
+            // <Global=X> text-replacement lint: a `<Global=X>` tag in a Prompt/response renders as `[...]` in game unless
+            // X names a global in the owning quest's TextDisplayGlobals (Heisen §3 non-gap). A silent failure — the record
+            // is byte-valid and the tag just fails to substitute — so it's a WARN. Skipped when the owning quest is
+            // unresolvable (ownerTextGlobals null — never guessed, Q3).
+            if (ownerTextGlobals is not null)
+                CheckGlobalTags(info, ownerTextGlobals, ownerQuestLabel, issues);
 
             // PNAM (PreviousDialog): vanilla leaves it empty and orders intra-topic by Conditions, so ABSENCE is the
             // norm and is NEVER flagged. Only a SET previous-link that doesn't resolve to an INFO is a real defect.
@@ -466,6 +486,64 @@ public static class DialogueValidate
             $"{locus} contains non-ASCII char(s) {desc} — the CK/Papyrus user-facing text surface is Windows-1252/ASCII, so these usually render as in-game mojibake.{sug}"));
     }
 
+    /// <summary>The <c>&lt;Global=X&gt;</c> text-replacement tags in a Prompt/response — the engine substitutes each
+    /// with the named global's value at runtime. Group 1 is the global's EditorID (<c>[^&lt;&gt;]+</c> — everything up
+    /// to the closing bracket, trimmed by the caller). The optional <c>(?:\.\w+)?</c> covers the CK's formatting-subtag
+    /// variants — <c>&lt;Global.Time=X&gt;</c>, <c>&lt;Global.Hour12=X&gt;</c>, <c>&lt;Global.Minutes=X&gt;</c> — where
+    /// the modifier sits BEFORE the <c>=</c> and the EditorID after it (CK wiki: Text Replacement). Those name a global
+    /// that ALSO must be in the quest's TextDisplayGlobals, so the lint must catch a missing one there too — a plain
+    /// <c>&lt;Global=</c> anchor would silently skip them (the exact <c>[...]</c> failure this lint exists to catch).
+    /// Case-insensitive on the tag word.</summary>
+    static readonly Regex GlobalTagRx = new(@"<Global(?:\.\w+)?=([^<>]+)>", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary><c>&lt;Global=X&gt;</c> text-replacement lint: scan this INFO's player-facing strings (menu Prompt +
+    /// each spoken response) for <c>&lt;Global=X&gt;</c> tags and WARN on any X that is NOT the EditorID of a global in
+    /// the owning quest's <see cref="IQuestGetter.TextDisplayGlobals"/> — such a tag renders as <c>[...]</c> in game
+    /// (the global is never substituted; a SILENT failure the record's byte-validity hides — Heisen §3 non-gap). WARN
+    /// and report-only (the validator never rewrites); one WARN per distinct missing name per INFO (a name repeated in
+    /// the line is not nagged twice). The caller invokes this only when the owning quest resolved, so
+    /// <paramref name="ownerTextGlobals"/> is the real set — possibly EMPTY, which correctly means every tag is
+    /// uncovered — never a guess (Q3).</summary>
+    static void CheckGlobalTags(IDialogResponsesGetter info, HashSet<string> ownerTextGlobals, string ownerQuestLabel, List<DialogueIssue> issues)
+    {
+        var flagged = new HashSet<string>(StringComparer.OrdinalIgnoreCase);   // one WARN per distinct missing name per INFO
+        void Scan(string? text, string locus)
+        {
+            if (string.IsNullOrEmpty(text)) return;
+            foreach (Match m in GlobalTagRx.Matches(text))
+            {
+                var name = m.Groups[1].Value.Trim();
+                if (name.Length == 0 || ownerTextGlobals.Contains(name) || !flagged.Add(name)) continue;
+                issues.Add(new(DialogueIssueSeverity.Warning,
+                    $"INFO {info.FormKey} {locus} uses the text-replacement tag {m.Value}, but {name} is not a "
+                    + $"global in {ownerQuestLabel}'s TextDisplayGlobals — in game the tag renders as [...] (the global is "
+                    + $"never substituted). Add {name} to the quest's Text Display Globals."));
+            }
+        }
+        Scan(info.Prompt?.String, "Prompt");
+        int rnum = 0;
+        foreach (var resp in info.Responses) Scan(resp.Text?.String, $"response {++rnum} text");
+    }
+
+    /// <summary>Engine-implicit forms — the sub-0x800 hardcoded references the engine defines but that are NOT normal
+    /// records in the base master's data, so the load-order index can't resolve them (a false "not in the active load
+    /// order"). A dialogue condition legitimately Runs On / points at these: PlayerRef (the player's placed reference,
+    /// for HasSpell / actor-value player-state gates) and the Player base NPC_ (a GetIsID Player form param). The
+    /// condition lints (1 + 3) treat them as valid targets so a standard player-state gate validates clean (Junti
+    /// 2026-07-03: xEdit resolves 000014 as PlayerRef; the gates are proven working in game). Scoped to the two the
+    /// report proves — a PRECISE set, NOT the whole reserved range, so a genuinely-typo'd sub-0x800 FormID still WARNs.
+    /// Skyrim.esm is the SSE base master (houseCARL is SSE-only). Extend if more engine-implicit forms surface.</summary>
+    static readonly ModKey SkyrimBaseMaster = new("Skyrim", ModType.Master);
+    static readonly HashSet<FormKey> EngineImplicitForms = new()
+    {
+        new FormKey(SkyrimBaseMaster, 0x14),   // PlayerRef — the player's placed reference (a Run On Reference target)
+        new FormKey(SkyrimBaseMaster, 0x07),   // Player    — the player base NPC_ (a GetIsID / form-param target)
+    };
+
+    /// <summary>True when <paramref name="fk"/> is one of the <see cref="EngineImplicitForms"/> — a hardcoded engine
+    /// reference the index can't resolve, so the condition lints must not mistake it for a dangling reference.</summary>
+    static bool IsEngineImplicit(FormKey fk) => EngineImplicitForms.Contains(fk);
+
     /// <summary>Static condition-lint suite (item 4) over one INFO's <c>Conditions</c> (CTDA rows) — the
     /// data-layer-decidable subset the §4 design decision (A-iii) authorises. Every lint here is a TRUE-positive
     /// STRUCTURAL defect (a malformed condition), never a behavioural guess: houseCARL still cannot EVALUATE whether
@@ -517,7 +595,7 @@ public static class DialogueValidate
                 if (data.Reference.IsNull)
                     issues.Add(new(DialogueIssueSeverity.Warning,
                         $"INFO {info.FormKey} condition #{n} ({fn}) is set to Run On a specific reference, but no reference is set — it evaluates against nothing, so the gate never behaves as intended."));
-                else if (!inOrder(refKey))
+                else if (!inOrder(refKey) && !IsEngineImplicit(refKey))
                     issues.Add(new(DialogueIssueSeverity.Warning,
                         $"INFO {info.FormKey} condition #{n} ({fn}) Run On reference {refKey} is not in the active load order — the gate evaluates against nothing."));
             }
@@ -554,7 +632,7 @@ public static class DialogueValidate
                 FormKey? paramFk =
                     v is IFormLinkGetter fl && !fl.IsNull ? fl.FormKey
                     : floiIsForm && WriteEngine.IsFormLinkOrIndex(p.PropertyType) ? WriteEngine.ReadFloiFormKey(v) : null;
-                if (paramFk is { } pk && !inOrder(pk))
+                if (paramFk is { } pk && !inOrder(pk) && !IsEngineImplicit(pk))
                     issues.Add(new(DialogueIssueSeverity.Warning,
                         $"INFO {info.FormKey} condition #{n} ({fn}) references {pk}, which is not in the active load order — a deleted/disabled form or a wrong FormID, so the condition can't evaluate as intended."));
             }

--- a/src/housecarl-core/SeqFile.cs
+++ b/src/housecarl-core/SeqFile.cs
@@ -99,4 +99,23 @@ public static class SeqFile
             if (BinaryPrimitives.ReadUInt32LittleEndian(seqBytes.Slice(i)) == onDiskFormId) return true;
         return false;
     }
+
+    /// <summary>Post-write staleness check (the in-place SEQ auto-flag): given a freshly-written <paramref name="pluginPath"/>
+    /// and the bytes of an EXISTING <c>.seq</c> resolved for it, return every Start-Game-Enabled quest whose CURRENT on-disk
+    /// FormID is NOT listed in that <c>.seq</c> — the quests the stale <c>.seq</c> would silently fail to start on a fresh
+    /// save. EMPTY ⇒ the <c>.seq</c> is consistent with the plugin (or the plugin has no SGE quests). This is the exact
+    /// condition an in-place master-prune creates: dropping a master shifts every own record's master-index slot, so each
+    /// SGE quest's on-disk FormID moves and the shipped <c>.seq</c> no longer lists it (Heisen §3 gap-4 — Update.esm pruned
+    /// → 0x02000806 became 0x01000806). Reuses <see cref="Build"/> (the same SGE enumeration + on-disk-FormID encoding the
+    /// author-time <c>.seq</c> write uses) and <see cref="SeqContains"/>, so the write-time flag and a <c>write_seq</c>
+    /// regen can never disagree about which quests a <c>.seq</c> must list. Read-only; opens + disposes the overlay
+    /// (Option B). The CALLER decides to warn (auto-flag, Aaron 2026-07-04) — this never mutates the <c>.seq</c>.</summary>
+    public static IReadOnlyList<SeqQuest> UncoveredSgeQuests(string pluginPath, ReadOnlySpan<byte> existingSeqBytes)
+    {
+        var build = Build(pluginPath);                       // SGE quests + their current on-disk FormIDs, off the written plugin
+        var uncovered = new List<SeqQuest>();
+        foreach (var q in build.Quests)
+            if (!SeqContains(existingSeqBytes, q.OnDiskFormId)) uncovered.Add(q);
+        return uncovered;
+    }
 }

--- a/src/housecarl-generator/DialogueValidateGuardProbe.cs
+++ b/src/housecarl-generator/DialogueValidateGuardProbe.cs
@@ -49,6 +49,11 @@ namespace HousecarlGenerator;
 ///   COND-GETISID-PLACED— GetIsID pointed at a PLACED reference WARNs ('placed reference'), NOT the dangling-param lint (item 4).
 ///   TEXT-MOJIBAKE— a line whose player-facing text carries non-ASCII chars (ellipsis/em-dash) WARNs, naming them (item 1).
 ///   TEXT-CLEAN   — pure-ASCII player-facing text is NOT flagged — the lint keys on >0x7F, not "has text" (item 1).
+///   GLOBAL-TAG-OK — a <Global=X> whose X IS in the owning quest's TextDisplayGlobals is NOT flagged (the no-false-positive lock).
+///   GLOBAL-TAG-MISSING— a <Global=X> whose X is NOT in TextDisplayGlobals WARNs (naming it) — the [...]-in-game teeth (Track B).
+///   GLOBAL-TAG-SUBTAG — a CK formatting-subtag form <Global.Time=X> (modifier before the =) with an uncovered global ALSO WARNs (regex covers the pre-= subtag; PR #139 review).
+///   PLAYERREF-WHITELIST— Run On the engine-implicit PlayerRef (000014:Skyrim.esm), absent from the order, is NOT flagged (the sub-0x800 whitelist, Junti false-positive fix).
+///   PLAYERREF-CONTROL— Run On a NON-whitelisted missing reference still WARNs — the whitelist is a precise 2-form set, not the whole reserved range.
 ///   QUEST-FANOUT — validating a QUEST fans out to EXACTLY the topics it owns (2 here), kind="quest".
 ///   REJ-NOTFOUND — a FormID not in the active order is a NAMED error ('not in the active load order').
 ///   REJ-WRONGTYPE— a FormID resolving to neither a DIAL nor a QUST (a Weapon) is a NAMED error ('not a dialogue topic').
@@ -68,6 +73,7 @@ public static class DialogueValidateGuardProbe
         string mPath = Path.Combine(tmpDir, mKey.FileName.String);
         FormKey cleanFk, linkBadFk, pnamBadFk, pnamOkFk, deletedFk, noQuestFk, badBranchFk, voicedFk, scriptedFk, condFk, qFanFk, weapFk, encBadFk, encOkFk;
         FormKey condCleanFk, condRefUnsetFk, condDeadAliasFk, condDeadLocAliasFk, condDeadQAliasFk, condAliasOkFk, condAliasFloiFk, condDanglingFk, condGlobalFk, condGetIsIdOkFk, condGetIsIdFk;
+        FormKey globOkFk, globBadFk, globSubFk, playerRefFk, playerRefCtlFk;
         try
         {
             var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
@@ -290,6 +296,44 @@ public static class DialogueValidateGuardProbe
             var tf1 = m.DialogTopics.AddNew(); tf1.EditorID = "HcDvFan1"; tf1.Quest.SetTo(qFan.FormKey); tf1.Responses.Add(Info("HcDvFan1I"));
             var tf2 = m.DialogTopics.AddNew(); tf2.EditorID = "HcDvFan2"; tf2.Quest.SetTo(qFan.FormKey); tf2.Responses.Add(Info("HcDvFan2I"));
 
+            // GLOBAL-TAG lint (Track B): qMain gains one GLOB in its TextDisplayGlobals. One topic tags <Global=HcDvKnownGlobal>
+            // (COVERED — not flagged), another tags <Global=HcDvUnknownGlobal> (UNCOVERED — WARN; renders as [...] in game).
+            // Both owned by qMain so the lint has a resolvable TextDisplayGlobals set. ASCII text only (no encoding false flag).
+            var knownGlob = new GlobalShort(m.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "HcDvKnownGlobal" };
+            m.Globals.Add(knownGlob);
+            qMain.TextDisplayGlobals.Add(new FormLink<IGlobalGetter>(knownGlob.FormKey));
+
+            var tGlobOk = m.DialogTopics.AddNew(); tGlobOk.EditorID = "HcDvGlobOk"; tGlobOk.Quest.SetTo(qMain.FormKey);
+            { var i = Info("HcDvGlobOkI"); i.Prompt = "It will cost <Global=HcDvKnownGlobal> gold."; tGlobOk.Responses.Add(i); globOkFk = tGlobOk.FormKey; }
+
+            var tGlobBad = m.DialogTopics.AddNew(); tGlobBad.EditorID = "HcDvGlobBad"; tGlobBad.Quest.SetTo(qMain.FormKey);
+            { var i = Info("HcDvGlobBadI"); i.Prompt = "It will cost <Global=HcDvUnknownGlobal> gold."; tGlobBad.Responses.Add(i); globBadFk = tGlobBad.FormKey; }
+
+            // The CK formatting-subtag form <Global.Time=X> (modifier BEFORE the =) naming an uncovered global must ALSO
+            // WARN — those produce the same silent [...] failure, so the plain <Global= anchor would miss them (PR #139 review).
+            var tGlobSub = m.DialogTopics.AddNew(); tGlobSub.EditorID = "HcDvGlobSub"; tGlobSub.Quest.SetTo(qMain.FormKey);
+            { var i = Info("HcDvGlobSubI"); i.Prompt = "Opens in <Global.Time=HcDvUnknownGlobal> hours."; tGlobSub.Responses.Add(i); globSubFk = tGlobSub.FormKey; }
+
+            // PLAYERREF whitelist (Track B — engine-implicit sub-0x800 forms): a condition Run On PlayerRef (000014:Skyrim.esm),
+            // which is NOT in this synthetic order, must NOT warn (the whitelist — the false-positive fix). The CONTROL runs on
+            // a NON-whitelisted missing ref and MUST still warn, proving the whitelist is a precise 2-form set, not blanket.
+            var tPlayerRef = m.DialogTopics.AddNew(); tPlayerRef.EditorID = "HcDvPlayerRef"; tPlayerRef.Quest.SetTo(qMain.FormKey);
+            {
+                var i = Info("HcDvPlayerRefI");
+                var d = new GetActorValueConditionData { ActorValue = ActorValue.Health, RunOnType = Condition.RunOnType.Reference };
+                d.Reference.SetTo(new FormKey(new ModKey("Skyrim", ModType.Master), 0x14));   // PlayerRef 000014:Skyrim.esm (engine-implicit)
+                i.Conditions.Add(new ConditionFloat { CompareOperator = CompareOperator.GreaterThan, ComparisonValue = 0f, Data = d });
+                tPlayerRef.Responses.Add(i); playerRefFk = tPlayerRef.FormKey;
+            }
+            var tPlayerRefCtl = m.DialogTopics.AddNew(); tPlayerRefCtl.EditorID = "HcDvPlayerRefCtl"; tPlayerRefCtl.Quest.SetTo(qMain.FormKey);
+            {
+                var i = Info("HcDvPlayerRefCtlI");
+                var d = new GetActorValueConditionData { ActorValue = ActorValue.Health, RunOnType = Condition.RunOnType.Reference };
+                d.Reference.SetTo(new FormKey(mKey, 0x00BBBB01));   // a synthetic-master ref that is NOT a record → dangling AND not whitelisted
+                i.Conditions.Add(new ConditionFloat { CompareOperator = CompareOperator.GreaterThan, ComparisonValue = 0f, Data = d });
+                tPlayerRefCtl.Responses.Add(i); playerRefCtlFk = tPlayerRefCtl.FormKey;
+            }
+
             // Give every branch-LESS fixture topic the shared well-formed branch — SAME reason as the SNAM loop
             // below: this guard tests the GRAPH/CONDITION/VOICE lints, not the BNAM-absent lint (that's
             // dialogue-ckparity-guard's job), so its Custom topics must be branch-clean or a "no issues" arm would
@@ -500,6 +544,44 @@ public static class DialogueValidateGuardProbe
             all &= Pass("TEXT-CLEAN no false flag", ok, t is null ? "no topic" : Issues(t));
         }
 
+        // ---------- GLOBAL-TAG-OK (Track B): a <Global=X> covered by the quest's TextDisplayGlobals is NOT flagged ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, globOkFk));
+            bool ok = t is not null && !t.Issues.Any(i => i.Message.Contains("TextDisplayGlobals", StringComparison.Ordinal));
+            all &= Pass("GLOBAL-TAG-OK not flagged", ok, t is null ? "no topic" : $"issues={t.Issues.Count}: {Issues(t)}");
+        }
+
+        // ---------- GLOBAL-TAG-MISSING (Track B): a <Global=X> NOT in TextDisplayGlobals WARNs, naming X ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, globBadFk));
+            bool ok = t is not null && t.Issues.Any(i => i.Severity == DialogueIssueSeverity.Warning
+                && i.Message.Contains("TextDisplayGlobals", StringComparison.Ordinal) && i.Message.Contains("HcDvUnknownGlobal", StringComparison.Ordinal));
+            all &= Pass("GLOBAL-TAG-MISSING warns", ok, t is null ? "no topic" : Issues(t));
+        }
+
+        // ---------- GLOBAL-TAG-SUBTAG (Track B): a <Global.Time=X> subtag form (modifier before =) with an uncovered global WARNs ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, globSubFk));
+            bool ok = t is not null && t.Issues.Any(i => i.Severity == DialogueIssueSeverity.Warning
+                && i.Message.Contains("TextDisplayGlobals", StringComparison.Ordinal) && i.Message.Contains("HcDvUnknownGlobal", StringComparison.Ordinal));
+            all &= Pass("GLOBAL-TAG-SUBTAG warns", ok, t is null ? "no topic" : Issues(t));
+        }
+
+        // ---------- PLAYERREF-WHITELIST (Track B): Run On engine-implicit PlayerRef (000014:Skyrim.esm) is NOT flagged ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, playerRefFk));
+            bool ok = t is not null && t.Issues.Count == 0;
+            all &= Pass("PLAYERREF-WHITELIST not flagged", ok, t is null ? "no topic" : $"issues={t.Issues.Count}: {Issues(t)}");
+        }
+
+        // ---------- PLAYERREF-CONTROL (Track B): Run On a non-whitelisted missing ref still WARNs (precise, not blanket) ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, playerRefCtlFk));
+            bool ok = t is not null && t.Issues.Any(i => i.Severity == DialogueIssueSeverity.Warning
+                && i.Message.Contains("Run On reference", StringComparison.Ordinal) && i.Message.Contains("not in the active load order", StringComparison.Ordinal));
+            all &= Pass("PLAYERREF-CONTROL warns missing", ok, t is null ? "no topic" : Issues(t));
+        }
+
         // ---------- QUEST-FANOUT: validating a quest fans out to EXACTLY its 2 topics ----------
         {
             var r = DialogueValidate.Run(resolver, assets, qFanFk);
@@ -524,7 +606,7 @@ public static class DialogueValidateGuardProbe
 
         Console.WriteLine();
         Console.WriteLine(all
-            ? "RESULT: PASS — the dialogue-graph validator holds (no false PNAM-absence flag, LinkTo + dangling-PNAM teeth, deleted-skip, voice/script reuse, encoding lint, condition lints (item 4), fan-out, named rejects)."
+            ? "RESULT: PASS — the dialogue-graph validator holds (no false PNAM-absence flag, LinkTo + dangling-PNAM teeth, deleted-skip, voice/script reuse, encoding lint, condition lints (item 4), <Global=X>/TextDisplayGlobals + PlayerRef-whitelist lints (Track B), fan-out, named rejects)."
             : "RESULT: FAIL — at least one arm regressed (see above).");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return all ? 0 : 1;

--- a/src/housecarl-generator/SeqStalenessProbe.cs
+++ b/src/housecarl-generator/SeqStalenessProbe.cs
@@ -20,6 +20,11 @@ namespace HousecarlGenerator;
 ///   SEQ-CLEAN-NO-FLAG — a NON-SGE quest yields NO lint (SeqLint null) — fires ONLY for SGE quests, never nags.
 ///   SEQ-OVERRIDE-AMBIGUOUS — an override that ADDS SGE the master lacks → winner != defining, so the render softens
 ///                    to a [?] ambiguity instead of a false "dormant" against the defining master (Q3, review fold).
+/// Plus the Track C in-place SEQ auto-flag DETECTOR (SeqFile.UncoveredSgeQuests — the post-write staleness check the
+/// in-place edit/remove lanes surface as a note, Aaron 2026-07-04):
+///   SEQ-INPLACE-UNCOVERED — an SGE quest absent from the .seq is returned, a covered one is not, a non-SGE is ignored.
+///   SEQ-INPLACE-FRESH     — a .seq listing every SGE quest at its CURRENT on-disk FormID → none uncovered (masters-unchanged edit stays quiet).
+///   SEQ-INPLACE-ALL-STALE — a .seq matching no current FormID (the master-prune shift) → every SGE quest uncovered.
 ///
 /// Run: dotnet run --project src/housecarl-generator -- seq-staleness-guard
 /// </summary>
@@ -113,12 +118,28 @@ public static class SeqStalenessProbe
             Check(ovr is { QuestIsSge: true, SeqExists: false }
                   && !string.Equals(ovr.WinnerPlugin, ovr.DefiningPlugin, StringComparison.OrdinalIgnoreCase),
                 $"SEQ-OVERRIDE-AMBIGUOUS override adds SGE → winner!=defining (render softens to [?], not a false dormant against the master) — {Show(ovr)}");
+
+            // ---- Track C: the in-place SEQ auto-flag DETECTOR (SeqFile.UncoveredSgeQuests). Reuses the OK master (qOk +
+            // qNotListed are SGE; qPlain is RunOnce) and its .seq (lists qOk only). The detector reuses the SAME on-disk
+            // FormID encoding as the author-time .seq write, so the write-time flag and a write_seq regen can't disagree.
+            var okBytes = File.ReadAllBytes(okSeq);
+            var uncovered = SeqFile.UncoveredSgeQuests(okPath, okBytes);
+            Check(uncovered.Count == 1 && uncovered[0].FormKey == qNotListedFk,
+                $"SEQ-INPLACE-UNCOVERED an SGE quest absent from the .seq is returned (qNotListed), a covered one (qOk) is not, non-SGE ignored — count={uncovered.Count}");
+
+            var fullBytes = SeqFile.Serialize(new[] { SeqFile.OnDiskFormIdFromPlugin(okPath, qOkFk), SeqFile.OnDiskFormIdFromPlugin(okPath, qNotListedFk) });
+            Check(SeqFile.UncoveredSgeQuests(okPath, fullBytes).Count == 0,
+                "SEQ-INPLACE-FRESH a .seq listing every SGE quest at its current on-disk FormID → none uncovered (a masters-unchanged edit stays quiet)");
+
+            var staleBytes = SeqFile.Serialize(new[] { 0xDEADBEEFu });   // a .seq matching no current FormID — the master-prune shift
+            Check(SeqFile.UncoveredSgeQuests(okPath, staleBytes).Count == 2,
+                "SEQ-INPLACE-ALL-STALE a .seq matching no current FormID → both SGE quests uncovered (the flag the in-place lanes raise)");
         }
         catch (Exception ex) { Console.WriteLine("  FAIL  guard threw: " + ex); fail++; }
         finally { try { Directory.Delete(root, recursive: true); } catch { /* best-effort temp cleanup */ } }
 
         Console.WriteLine();
-        Console.WriteLine(fail == 0 ? "ALL SEQ-STALENESS GUARD ARMS PASSED" : $"SEQ-STALENESS GUARD: {fail} ARM(S) FAILED");
+        Console.WriteLine(fail == 0 ? "ALL SEQ-STALENESS GUARD ARMS PASSED (incl. Track C in-place auto-flag detector)" : $"SEQ-STALENESS GUARD: {fail} ARM(S) FAILED");
         return fail == 0 ? 0 : 1;
     }
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1166,11 +1166,14 @@ public sealed class LoadOrderService : IDisposable
         // (4) The write — touched-record verify forced ON (the model-C substitute for the dropped whole-plugin floor).
         var outcome = WritePatchBuilder.ApplyInPlace(resolver, rulebook, edits, targetPath, targetName, fullReadback: true);
 
-        // (5) On success, stamp the distinct audit marker (best-effort; a marker miss never fails the done edit, Q3-noted).
+        // (5) On success, stamp the distinct audit marker + auto-flag a now-stale .seq (both best-effort; neither miss
+        //     fails the done edit, Q3-noted). SEQ flag (Track C): an in-place edit can prune a master and shift the own
+        //     records' on-disk FormIDs, staling the plugin's .seq — surfaced as a note, never auto-regen'd (Aaron 2026-07-04).
         if (outcome.Success)
         {
             var markerNote = MergeEditedInPlaceMarker(Path.GetDirectoryName(targetPath));
-            var note = JoinNotes(ackNote, markerNote);
+            var seqNote = SeqStaleInPlaceNote(targetPath, targetName);
+            var note = JoinNotes(ackNote, markerNote, seqNote);
             if (note is not null) return outcome with { Note = note };
         }
         else if (ackNote is not null)
@@ -1299,9 +1302,50 @@ public sealed class LoadOrderService : IDisposable
         catch { return false; }
     }
 
-    /// <summary>Join two optional Q3 notes into one (space-separated), or null when both are absent.</summary>
-    static string? JoinNotes(string? a, string? b)
-        => (a, b) switch { (null, null) => null, (null, _) => b, (_, null) => a, _ => a + " " + b };
+    /// <summary>Join any number of optional Q3 notes into one (space-separated), skipping the null/blank ones; null when
+    /// none are present. Variadic so a lane can fold several best-effort side-effect notes (ack + audit marker + the SEQ
+    /// staleness auto-flag) into the single <c>Note</c> the outcome carries.</summary>
+    static string? JoinNotes(params string?[] notes)
+    {
+        var present = notes.Where(n => !string.IsNullOrWhiteSpace(n)).ToArray();
+        return present.Length == 0 ? null : string.Join(" ", present);
+    }
+
+    /// <summary>The in-place SEQ auto-flag (Track C / Heisen §3 gap-4, Aaron 2026-07-04: FLAG, never auto-regen). After an
+    /// in-place write that re-serialized <paramref name="targetPath"/>, a master-prune may have shifted every own record's
+    /// on-disk FormID and staled the plugin's <c>.seq</c> — its Start-Game-Enabled quests would then silently never start
+    /// on a fresh save. Resolve the plugin's <c>.seq</c> through the SAME captured VFS view the compact SEQ gate uses
+    /// (loose roots + active BSAs — not a bare folder check, which would miss a <c>write_seq</c>-filed or BSA-packed .seq),
+    /// and if a LOOSE <c>.seq</c> exists but no longer lists one or more SGE quests at their CURRENT on-disk FormIDs,
+    /// return a WARNING naming them + the fix (<c>housecarl_write_seq</c>). Null when there's nothing to flag (no .seq, a
+    /// BSA-only .seq whose bytes we can't check here, or every SGE quest still covered — an ordinary in-place edit that
+    /// changed no masters leaves the FormIDs put, so a previously-valid .seq stays covered and this stays quiet). BEST-
+    /// EFFORT (Q3): any failure yields a soft advisory, never a throw — the write already succeeded, and a freshness check
+    /// that couldn't run must not fail the done edit, but it says so rather than going silent.</summary>
+    string? SeqStaleInPlaceNote(string targetPath, string targetName)
+    {
+        try
+        {
+            AssetResolver assetResolver;
+            lock (_gate) { assetResolver = Assets; }                          // reentrant under the held _writeGate (the PlaceAssets idiom)
+            var av = assetResolver.Capture();
+            var seqRel = $@"SEQ\{Path.GetFileNameWithoutExtension(targetPath)}.seq";
+            var seqSource = av.ResolveForPlacement(seqRel).Sources.FirstOrDefault();
+            if (seqSource?.LooseFilePath is not { } seqPath) return null;      // no .seq, or a BSA-only one (bytes uncheckable here) → nothing to flag
+            var uncovered = SeqFile.UncoveredSgeQuests(targetPath, File.ReadAllBytes(seqPath));
+            if (uncovered.Count == 0) return null;                            // the .seq still lists every SGE quest → not staled
+            var names = string.Join(", ", uncovered.Select(q => q.EditorId ?? q.FormKey.ToString()));
+            bool one = uncovered.Count == 1;
+            return $"the .seq for '{targetName}' no longer lists {(one ? "its start-game-enabled quest" : $"{uncovered.Count} of its start-game-enabled quests")} "
+                 + $"at {(one ? "its" : "their")} current on-disk FormID(s) ({names}), so {(one ? "it" : "they")} would silently never start on a fresh save "
+                 + "(a master prune in an in-place write shifts these FormIDs; the .seq may also have been stale before this edit). Regenerate it with housecarl_write_seq.";
+        }
+        catch (Exception ex)
+        {
+            return $"could not check whether '{targetName}'s .seq is still current after this edit ({ex.GetType().Name}) — "
+                 + "if it has start-game-enabled quests, run housecarl_validate_dialogue on the quest to confirm the .seq still lists them.";
+        }
+    }
 
     /// <summary>Remove WHOLE records a houseCARL patch carries (housecarl_remove_record) — literal drop-from-plugin, the
     /// companion to <see cref="ApplyEdits"/>. In the DEFAULT lane <paramref name="patch"/> is REQUIRED and names an existing
@@ -1407,11 +1451,14 @@ public sealed class LoadOrderService : IDisposable
         // (4) The write — absence verify forced ON (the model-C substitute for the dropped whole-plugin floor).
         var outcome = WritePatchBuilder.RemoveRecordsInPlace(resolver, keys, targetPath, targetName);
 
-        // (5) On success, stamp the distinct audit marker (best-effort; a marker miss never fails the done removal, Q3-noted).
+        // (5) On success, stamp the distinct audit marker + auto-flag a now-stale .seq (both best-effort; neither miss
+        //     fails the done removal, Q3-noted). SEQ flag (Track C): a removal can drop the last reference to a master
+        //     (a prune) and shift on-disk FormIDs, staling the plugin's .seq — surfaced, never auto-regenerated.
         if (outcome.Success)
         {
             var markerNote = MergeEditedInPlaceMarker(Path.GetDirectoryName(targetPath));
-            var note = JoinNotes(ackNote, markerNote);
+            var seqNote = SeqStaleInPlaceNote(targetPath, targetName);
+            var note = JoinNotes(ackNote, markerNote, seqNote);
             if (note is not null) return outcome with { Note = note };
         }
         else if (ackNote is not null)


### PR DESCRIPTION
Picks up **S3 (validators + freshness)** of the dialogue CK-parity fix plan (S1 `d8c1fa2`, S2 `b455baf` already on `main`). Read-only validator lints + one non-destructive write-time flag; no create-lane behavior changes.

## Track B — validator lints (`DialogueValidate.cs`)
- **`<Global=X>` / TextDisplayGlobals lint** — warn when an INFO Prompt/response text-replacement tag names a global not in the owning quest's `TextDisplayGlobals` (renders as `[...]` in game — a silent failure the record's byte-validity hides). Skipped when the owning quest is unresolvable (never guessed — Q3).
- **PlayerRef sub-0x800 whitelist** — condition lints 1 & 3 no longer false-warn on the engine-implicit `PlayerRef 000014` / `Player 000007` (Skyrim.esm), so standard player-state gates (`HasSpell`, actor-value on PlayerRef) validate clean (Junti report). Scoped to those **two proven forms**, not the whole reserved range — a genuinely typo'd sub-0x800 FormID still warns.
- **SubtypeName-unset → warning** — found **already satisfied** by #131's blank-marker escalation (Problem for an own topic / Warning for an override). Confirmed and reported, not duplicated.

## Track C — in-place SEQ auto-flag (`SeqFile.cs` + `LoadOrderService.cs`)
Per the maintainer's decision (**flag, never auto-regen**): after an in-place **edit or removal**, the new `SeqFile.UncoveredSgeQuests` detector checks whether a master-prune staled the plugin's `.seq`; if so, the write's read-back `Note` names the affected Start-Game-Enabled quests and says to run `housecarl_write_seq`. Reuses the compact lane's VFS-based `.seq` resolution; best-effort (a check failure yields a soft advisory, never a thrown write); cause-neutral wording (also honest for a newly-flagged-SGE quest).

**Scope boundary (Q3):** the hook covers the in-place **edit + remove** lanes — exactly the "in-place rewrites prune unused masters" case the report names. The **create-in-place** lane can also shift FormIDs (by *adding* a master) and is deliberately out of scope here; the detector is reusable, so extending it is a small follow-up if wanted.

## Tests & docs
- `dialogue-validate-guard` **+4 arms** (GLOBAL-TAG-OK/MISSING, PLAYERREF-WHITELIST/CONTROL).
- `seq-staleness-guard` **+3 arms** (Track C detector: uncovered / fresh / all-stale).
- `dialogue-authoring` SKILL.md notes both lints + the SEQ flag (light touch; the deeper Track E semantics rewrite stays S4).
- **ci-all 69/69**; full solution builds clean.

Honest scope: the lints are byte/structurally verified via the guards; no new in-game run (read-only lints + a non-destructive advisory note). Only **S4** (Track D ergonomics + Track E SKILL.md semantics) then remains on this plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)