### PR TITLE
fix(write): single-gender ArmorAddon create just works + named-refusal safety net for wrapped null-arms

### DIFF
--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1472,10 +1472,9 @@ public static class WriteEngine
         // like Level, or need a hand-curated required-arm list (cornerstone §3) — so there is still no by-construction
         // required/optional signal to gate on. The serialize boundary is the honest place to fail it (Q3). WritePatchStaged
         // already discards its temp on any throw, so nothing is on disk; re-stamp ONLY a null-arm NRE — whether BARE (the
-        // synchronous case, e.g. Condition.Data) OR wrapped in the parallel writer's nested AggregateException
-        // (HCBR-2026-07-04: a single-gender GenderedItem formlink half, ArmorAddon SkinTexture) — as a NAMED refusal via
-        // RootNullArm; other serialize errors keep their own type/message. The existing WritePatchBuilder serialize
-        // catches render it loud + all-or-nothing.
+        // synchronous case, e.g. Condition.Data) OR wrapped in the parallel writer's nested AggregateException (a null
+        // required sub-field can take either serialize path) — as a NAMED refusal via RootNullArm; other serialize errors
+        // keep their own type/message. The existing WritePatchBuilder serialize catches render it loud + all-or-nothing.
         string staged;
         try { staged = WritePatchStaged(patchMod, ordered, baseline, outputPath); }
         catch (Exception ex) when (RootNullArm(ex) is { } nre) { throw new NullArmSerializeException(nre); }
@@ -1493,19 +1492,21 @@ public static class WriteEngine
             : $"{ex.GetType().Name}: {ex.Message}";
 
     /// <summary>Unwrap a serialize-boundary throw to the root <see cref="NullReferenceException"/> that signals a
-    /// composed-null-arm failure — or null when the failure is NOT purely a null-arm one. The SYNCHRONOUS case is a
-    /// bare NRE (a Condition missing its Data arm). But Mutagen's binary writer runs record writes through a PARALLEL
-    /// path, so a null required sub-field can also surface WRAPPED: HCBR-2026-07-04 captured a DOUBLY-nested
-    /// <see cref="AggregateException"/> whose leaf was a Mutagen <c>SubrecordException</c> wrapping the NRE — for an
-    /// ArmorAddon whose <c>SkinTexture</c> (a GenderedItem of a FormLink) had only its Female half set, leaving the
-    /// Male half a null formlink the writer dereferenced. A bare-NRE catch misses that, so the opaque AggregateException
-    /// rendered raw instead of as the loud NAMED refusal the codebase already built. This flattens the aggregate nesting
-    /// (<see cref="AggregateException.Flatten"/>) and, for each leaf, walks its <see cref="Exception.InnerException"/>
-    /// chain to the ROOT cause — re-stamping ONLY when EVERY leaf's root is a <see cref="NullReferenceException"/> (the
-    /// whole failure IS the null-arm case), returning the first such NRE as the preserved inner. Any leaf whose root is
-    /// NOT an NRE returns null, so that genuine other error keeps its own type + message (Q3 — never mask an unrelated
-    /// throw behind the null-arm refusal). A non-NRE-rooted throw returns null and propagates unchanged.</summary>
-    static NullReferenceException? RootNullArm(Exception ex)
+    /// composed-null-arm failure — or null when the failure is NOT purely a null-arm one. A null required modeled
+    /// sub-field (canonically a COMPOSED record missing a required polymorphic arm — a Condition without its Data arm)
+    /// is dereferenced by Mutagen's writer as a bare NRE. But that writer runs record writes through a PARALLEL path,
+    /// so the SAME NRE can surface WRAPPED — one or more nested <see cref="AggregateException"/>s around a Mutagen
+    /// <c>SubrecordException</c> (HCBR-2026-07-04 captured a doubly-nested one). A bare-<see cref="NullReferenceException"/>
+    /// catch misses the wrapped shape and lets the opaque AggregateException render raw instead of as the loud NAMED
+    /// refusal — so, regardless of which serialize path a record takes, this normalizes both. It flattens the aggregate
+    /// nesting (<see cref="AggregateException.Flatten"/>) and, for each leaf, walks its
+    /// <see cref="Exception.InnerException"/> chain to the ROOT cause — re-stamping ONLY when EVERY leaf's root is a
+    /// <see cref="NullReferenceException"/> (the whole failure IS the null-arm case), returning the first such NRE as the
+    /// preserved inner. Any leaf whose root is NOT an NRE returns null, so that genuine other error keeps its own type +
+    /// message (Q3 — never mask an unrelated throw). (The discovery case — a single-gender GenderedItem formlink half —
+    /// is now prevented at the root by <see cref="EmptyFormLinkOf"/>, so this stays as the general safety net for the
+    /// composition null-arm that can still occur.) Unit-covered by nullarm-guard R1–R5.</summary>
+    internal static NullReferenceException? RootNullArm(Exception ex)
     {
         static NullReferenceException? Root(Exception e)
         {
@@ -1600,8 +1601,8 @@ public static class WriteEngine
         var ordered = ownMasters as ISkyrimModGetter[] ?? ownMasters.ToArray();
         // Same composed-null-arm serialize guard as WritePatch (an in-place edit can compose a record too): a required
         // sub-field left null surfaces as a bare NRE at the writer deref, OR — from the parallel writer — as an
-        // AggregateException-wrapped one (a single-gender GenderedItem formlink half); RootNullArm unwraps both and
-        // re-stamps ONLY that as a NAMED refusal; the staged temp is already discarded on any throw (nothing on disk), original byte-intact.
+        // AggregateException-wrapped one; RootNullArm unwraps both and re-stamps ONLY that as a NAMED refusal; the staged
+        // temp is already discarded on any throw (nothing on disk), original byte-intact.
         string staged;
         try { staged = WriteInPlaceStaged(targetMod, ordered, outputPath); }
         catch (Exception ex) when (RootNullArm(ex) is { } nre) { throw new NullArmSerializeException(nre); }
@@ -1846,9 +1847,12 @@ public static class WriteEngine
     /// set of record types, which the cornerstone forbids):
     /// <list type="bullet">
     /// <item><c>GenderedItem&lt;T&gt;</c> — a male/female pair whose BOTH halves are mutable (corpus: Male/Female
-    /// writable). Materialize with <c>default(T)</c> parts — 0 for a value T, null for a ref T — and let navigation
-    /// populate them; a null ref half is then materialized on demand if navigated into, matching an absent half
-    /// EXACTLY. Byte-proven by write-proof Phase 4.</item>
+    /// writable). Materialize each part per its kind: a FORMLINK half as a NON-NULL empty link
+    /// (<see cref="EmptyFormLinkOf"/> — a null formlink half is dereferenced by the writer, HCBR-2026-07-04); a
+    /// MODEL / ref half as <c>null</c> (the writer tolerates it and it materializes on demand if navigated into); a
+    /// value half as <c>default</c> (0). An un-set half then matches what the binary READER produces for an absent
+    /// half, so a single-gender item (e.g. a skin ArmorAddon's <c>SkinTexture</c>) serializes to a valid record.
+    /// Byte-proven by write-proof Phase 4 + nullarm-guard B3.</item>
     /// <item><c>Array2d&lt;T&gt;</c> — a terrain grid (on Cell/Landscape: VertexHeightMap/VertexNormals/VertexColors,
     /// CellMaxHeightData). Its cells are reached through a 2D indexer (<c>grid[x,y]</c>), NOT named members, so they sit
     /// BELOW the reflectable-member granularity houseCARL's surface is built from: an indexer-shaped Mutagen-modeling
@@ -1861,17 +1865,30 @@ public static class WriteEngine
         var defName = (concrete.IsGenericType ? concrete.GetGenericTypeDefinition() : concrete).Name;
         if (defName.StartsWith("GenderedItem", StringComparison.Ordinal))
         {
-            // GenderedItem<T>(T male, T female) — default(T) per part: 0 for a value T, null for a ref T (a null ref
-            // half is then materialized on demand if navigated into, matching an absent half exactly).
+            // GenderedItem<T>(T male, T female): pick the smallest positional ctor, then build each part per its kind (below).
             var ctor = concrete.GetConstructors().Where(c => c.GetParameters().Length > 0)
                 .OrderBy(c => c.GetParameters().Length).First();
-            var args = ctor.GetParameters().Select(p => DefaultOf(p.ParameterType)).ToArray();
+            // A FORMLINK half must be a NON-NULL empty link, not null: Mutagen's writer dereferences a null formlink
+            // half (HCBR-2026-07-04, ArmorAddon.SkinTexture), while an empty link serializes to an absent/00000000 slot
+            // — exactly what the binary READER produces for an un-set gender half, so a single-gender skin AA authored
+            // fresh now WRITES instead of throwing. A Model / ref half stays null (the writer tolerates it, and it
+            // materializes on demand if navigated into — WorldModel); a value half stays default(0).
+            var args = ctor.GetParameters().Select(p => EmptyFormLinkOf(p.ParameterType) ?? DefaultOf(p.ParameterType)).ToArray();
             return ctor.Invoke(args);
         }
         throw new CompositionRequiredException(t.Name, t);   // Array2d<T> (indexer-shaped Mutagen residual, named like PEX) + any unknown composition — named, loud (Q3)
     }
 
     static object? DefaultOf(Type t) => t.IsValueType ? System.Activator.CreateInstance(t) : null;
+
+    /// <summary>If <paramref name="t"/> is a FormLink-family type (nullable or not, mutable/getter interface or the
+    /// concrete struct), return a NON-NULL EMPTY link — a Null-FormKey instance of the matching concrete struct; else
+    /// null. Recognised by generic definition via <see cref="TryFormLink"/> (a null-synonym value), the same
+    /// by-construction predicate the engine already uses to coerce a formlink value — never a per-record-type
+    /// hand-list. Used to materialize a GenderedItem's formlink half (HCBR-2026-07-04): an un-set half must be an
+    /// empty link the writer serializes as an absent/00000000 slot, NOT a null the parallel writer dereferences into
+    /// an AggregateException-wrapped NRE.</summary>
+    static object? EmptyFormLinkOf(Type t) => TryFormLink("0", t, out var link) ? link : null;
 
     /// <summary>Map a (possibly getter/interface) type to the concrete settable class the engine can instantiate: a
     /// generic interface <c>IFoo&lt;T&gt;</c> → concrete <c>Foo&lt;T&gt;</c> (GenderedItem/Array2d live in
@@ -3170,9 +3187,9 @@ public sealed class CompositionRequiredException : InvalidOperationException
 /// <summary>A serialize-boundary <see cref="NullReferenceException"/> re-stamped as a loud, NAMED refusal
 /// (HCBR-2026-06-15-01 PR-C, PART B). Mutagen's binary writer throws a bare NRE — no field name — when it dereferences
 /// a record's REQUIRED modeled sub-field that was left null; the dominant cause is a COMPOSED record missing a required
-/// polymorphic sub-arm (a Condition without its Data arm, an element missing a required part), or a GenderedItem with a
-/// single FormLink gender half (ArmorAddon SkinTexture — the null half the parallel writer wraps in an AggregateException,
-/// HCBR-2026-07-04). The corpus now carries
+/// polymorphic sub-arm (a Condition without its Data arm, an element missing a required part) — and, per HCBR-2026-07-04,
+/// the null may surface bare OR wrapped in the parallel writer's AggregateException (see <see cref="WriteEngine.RootNullArm"/>).
+/// The corpus now carries
 /// faithful polymorphic nullability (S4 Track D), but that flag is NOT a "required arm at serialize" signal —
 /// NpcConfiguration.Level reads <c>Nullable=false</c> yet serializes fine when null, while Condition.Data (also
 /// <c>Nullable=false</c>) throws — so a pre-flight gate on the flag would over-reject or need a hand-curated list
@@ -3183,13 +3200,11 @@ public sealed class NullArmSerializeException : InvalidOperationException
 {
     public NullArmSerializeException(Exception inner)
         : base("a required modeled sub-field was null when Mutagen serialized the patch (a NullReferenceException in the " +
-               "writer). Two known causes: (1) a COMPOSED record that left a required polymorphic sub-field unset — e.g. a " +
-               "Condition composed without its Data arm, or a leveled-list / effect element missing a required part — fix by " +
-               "composing that sub-field too (select the arm via compose); (2) a GenderedItem whose element is a FormLink " +
-               "(e.g. an ArmorAddon's SkinTexture) with only ONE gender half set, leaving the other half a null formlink the " +
-               "writer dereferences — fix by setting the other gender half too, or clearing it with '0' / 'Null' for a " +
-               "genuinely single-gender item. Nothing was written — the staged file was discarded and the target is " +
-               "untouched. If neither applies, this is an engine/Mutagen inconsistency — surface it, don't work around it.", inner)
+               "writer). The cause is a COMPOSED record that left a required polymorphic sub-field unset — e.g. a Condition " +
+               "composed without its Data arm, or a leveled-list / effect element missing a required part. Compose that " +
+               "sub-field too (select the arm via compose). Nothing was written — the staged file was discarded and the " +
+               "target is untouched. If no composition was involved, this is an engine/Mutagen inconsistency — surface it, " +
+               "don't work around it.", inner)
     {
     }
 }

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1471,12 +1471,14 @@ public static class WriteEngine
         // fine when null (nullarm-guard B2). A pre-flight gate on the flag would over-reject a legitimately-absent field
         // like Level, or need a hand-curated required-arm list (cornerstone §3) — so there is still no by-construction
         // required/optional signal to gate on. The serialize boundary is the honest place to fail it (Q3). WritePatchStaged
-        // already discards its temp on any throw, so nothing is on disk; re-stamp ONLY the opaque NRE as a NAMED refusal
-        // (other serialize errors keep their own type/message). The existing WritePatchBuilder serialize catches render it
-        // loud + all-or-nothing.
+        // already discards its temp on any throw, so nothing is on disk; re-stamp ONLY a null-arm NRE — whether BARE (the
+        // synchronous case, e.g. Condition.Data) OR wrapped in the parallel writer's nested AggregateException
+        // (HCBR-2026-07-04: a single-gender GenderedItem formlink half, ArmorAddon SkinTexture) — as a NAMED refusal via
+        // RootNullArm; other serialize errors keep their own type/message. The existing WritePatchBuilder serialize
+        // catches render it loud + all-or-nothing.
         string staged;
         try { staged = WritePatchStaged(patchMod, ordered, baseline, outputPath); }
-        catch (NullReferenceException ex) { throw new NullArmSerializeException(ex); }
+        catch (Exception ex) when (RootNullArm(ex) is { } nre) { throw new NullArmSerializeException(nre); }
         CommitStagedPatch(staged, outputPath);
     }
 
@@ -1489,6 +1491,41 @@ public static class WriteEngine
         => ex.InnerException is { } inner
             ? $"{ex.GetType().Name}: {ex.Message} [inner: {inner.GetType().Name}: {inner.Message}]"
             : $"{ex.GetType().Name}: {ex.Message}";
+
+    /// <summary>Unwrap a serialize-boundary throw to the root <see cref="NullReferenceException"/> that signals a
+    /// composed-null-arm failure — or null when the failure is NOT purely a null-arm one. The SYNCHRONOUS case is a
+    /// bare NRE (a Condition missing its Data arm). But Mutagen's binary writer runs record writes through a PARALLEL
+    /// path, so a null required sub-field can also surface WRAPPED: HCBR-2026-07-04 captured a DOUBLY-nested
+    /// <see cref="AggregateException"/> whose leaf was a Mutagen <c>SubrecordException</c> wrapping the NRE — for an
+    /// ArmorAddon whose <c>SkinTexture</c> (a GenderedItem of a FormLink) had only its Female half set, leaving the
+    /// Male half a null formlink the writer dereferenced. A bare-NRE catch misses that, so the opaque AggregateException
+    /// rendered raw instead of as the loud NAMED refusal the codebase already built. This flattens the aggregate nesting
+    /// (<see cref="AggregateException.Flatten"/>) and, for each leaf, walks its <see cref="Exception.InnerException"/>
+    /// chain to the ROOT cause — re-stamping ONLY when EVERY leaf's root is a <see cref="NullReferenceException"/> (the
+    /// whole failure IS the null-arm case), returning the first such NRE as the preserved inner. Any leaf whose root is
+    /// NOT an NRE returns null, so that genuine other error keeps its own type + message (Q3 — never mask an unrelated
+    /// throw behind the null-arm refusal). A non-NRE-rooted throw returns null and propagates unchanged.</summary>
+    static NullReferenceException? RootNullArm(Exception ex)
+    {
+        static NullReferenceException? Root(Exception e)
+        {
+            while (e.InnerException is { } inner) e = inner;   // Mutagen wraps the writer NRE in a SubrecordException (parallel path)
+            return e as NullReferenceException;
+        }
+        if (ex is AggregateException agg)
+        {
+            var leaves = agg.Flatten().InnerExceptions;
+            if (leaves.Count == 0) return null;
+            NullReferenceException? first = null;
+            foreach (var leaf in leaves)
+            {
+                if (Root(leaf) is not { } nre) return null;   // a non-NRE-rooted leaf → not purely a null-arm failure
+                first ??= nre;
+            }
+            return first;
+        }
+        return Root(ex);
+    }
 
     /// <summary>Stage 1 of the atomic write: serialize the patch into a temp SUBDIRECTORY beside the target —
     /// same filename (Mutagen's writer ties filename to ModKey), same parent directory (guarantees same NTFS
@@ -1562,11 +1599,12 @@ public static class WriteEngine
         Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
         var ordered = ownMasters as ISkyrimModGetter[] ?? ownMasters.ToArray();
         // Same composed-null-arm serialize guard as WritePatch (an in-place edit can compose a record too): a required
-        // polymorphic sub-field left null surfaces as a bare NRE at the writer deref — re-stamp ONLY that as a NAMED
-        // refusal; the staged temp is already discarded on any throw (nothing on disk), original byte-intact.
+        // sub-field left null surfaces as a bare NRE at the writer deref, OR — from the parallel writer — as an
+        // AggregateException-wrapped one (a single-gender GenderedItem formlink half); RootNullArm unwraps both and
+        // re-stamps ONLY that as a NAMED refusal; the staged temp is already discarded on any throw (nothing on disk), original byte-intact.
         string staged;
         try { staged = WriteInPlaceStaged(targetMod, ordered, outputPath); }
-        catch (NullReferenceException ex) { throw new NullArmSerializeException(ex); }
+        catch (Exception ex) when (RootNullArm(ex) is { } nre) { throw new NullArmSerializeException(nre); }
         CommitStagedPatch(staged, outputPath);
     }
 
@@ -3132,7 +3170,9 @@ public sealed class CompositionRequiredException : InvalidOperationException
 /// <summary>A serialize-boundary <see cref="NullReferenceException"/> re-stamped as a loud, NAMED refusal
 /// (HCBR-2026-06-15-01 PR-C, PART B). Mutagen's binary writer throws a bare NRE — no field name — when it dereferences
 /// a record's REQUIRED modeled sub-field that was left null; the dominant cause is a COMPOSED record missing a required
-/// polymorphic sub-arm (a Condition without its Data arm, an element missing a required part). The corpus now carries
+/// polymorphic sub-arm (a Condition without its Data arm, an element missing a required part), or a GenderedItem with a
+/// single FormLink gender half (ArmorAddon SkinTexture — the null half the parallel writer wraps in an AggregateException,
+/// HCBR-2026-07-04). The corpus now carries
 /// faithful polymorphic nullability (S4 Track D), but that flag is NOT a "required arm at serialize" signal —
 /// NpcConfiguration.Level reads <c>Nullable=false</c> yet serializes fine when null, while Condition.Data (also
 /// <c>Nullable=false</c>) throws — so a pre-flight gate on the flag would over-reject or need a hand-curated list
@@ -3143,11 +3183,13 @@ public sealed class NullArmSerializeException : InvalidOperationException
 {
     public NullArmSerializeException(Exception inner)
         : base("a required modeled sub-field was null when Mutagen serialized the patch (a NullReferenceException in the " +
-               "writer). The most common cause is a COMPOSED record that left a required polymorphic sub-field unset — " +
-               "e.g. a Condition composed without its Data arm, or a leveled-list / effect element missing a required " +
-               "part. Compose that sub-field too (select the arm via compose). Nothing was written — the staged file was " +
-               "discarded and the target is untouched. If no composition was involved, this is an engine/Mutagen " +
-               "inconsistency — surface it, don't work around it.", inner)
+               "writer). Two known causes: (1) a COMPOSED record that left a required polymorphic sub-field unset — e.g. a " +
+               "Condition composed without its Data arm, or a leveled-list / effect element missing a required part — fix by " +
+               "composing that sub-field too (select the arm via compose); (2) a GenderedItem whose element is a FormLink " +
+               "(e.g. an ArmorAddon's SkinTexture) with only ONE gender half set, leaving the other half a null formlink the " +
+               "writer dereferences — fix by setting the other gender half too, or clearing it with '0' / 'Null' for a " +
+               "genuinely single-gender item. Nothing was written — the staged file was discarded and the target is " +
+               "untouched. If neither applies, this is an engine/Mutagen inconsistency — surface it, don't work around it.", inner)
     {
     }
 }

--- a/src/housecarl-generator/NullArmGuardProbe.cs
+++ b/src/housecarl-generator/NullArmGuardProbe.cs
@@ -29,11 +29,20 @@ namespace HousecarlGenerator;
 /// re-stamps the serialize-boundary NRE as a loud, NAMED <see cref="NullArmSerializeException"/> — all-or-nothing
 /// (the staged temp is already discarded; the target is untouched), preserving the NRE as <c>InnerException</c>. Q3.
 ///
-/// RED→GREEN: Part A checks A1/A2/A3/A5 are RED if <c>MapStruct</c> drops the nested Struct; Part B check B1 is
-/// RED (a bare <see cref="NullReferenceException"/>, not a <see cref="NullArmSerializeException"/>) without the
-/// <c>WritePatch</c> catch. The FALSE-POSITIVE control (B2) and the illegal-nested-arm reject (A4) are GREEN
-/// before AND after — they prove the fix is NARROW (a valid optional-null poly still serializes; an illegal
-/// nested arm still rejects loud).
+/// PART B (extended HCBR-2026-07-04) — the PARALLEL-WRITER wrap. A GenderedItem whose element is a FormLink
+/// (an ArmorAddon's <c>SkinTexture</c>) with only ONE gender half set leaves the OTHER half a null formlink Mutagen's
+/// writer dereferences — but on its PARALLEL path, so the NRE surfaces WRAPPED in nested <see cref="AggregateException"/>s
+/// (the report captured a doubly-nested one), slipping past a bare-NRE catch and rendering as the opaque AggregateException.
+/// THE FIX: <c>WriteEngine.RootNullArm</c> flattens the aggregate and re-stamps ONLY when every leaf is an NRE, so both the
+/// synchronous (B1) and parallel-wrapped (B3) null-arm cases become the same NAMED refusal, while a null MODEL half
+/// (WorldModel — Mutagen tolerates it) and any other serialize error are untouched.
+///
+/// RED→GREEN: Part A checks A1/A2/A3/A5 are RED if <c>MapStruct</c> drops the nested Struct; Part B checks B1 (bare) and
+/// B3 (parallel-wrapped) are RED (a bare <see cref="NullReferenceException"/> / raw <see cref="AggregateException"/>, not a
+/// <see cref="NullArmSerializeException"/>) without the widened catch. The FALSE-POSITIVE controls (B2 optional null poly;
+/// B4 tolerated null MODEL half) and the illegal-nested-arm reject (A4) are GREEN before AND after — they prove the fix is
+/// NARROW (a valid optional-null poly and a legitimately-absent model half still serialize; an illegal nested arm still
+/// rejects loud). B5 confirms the refusal's recommended single-gender escape (clear the other half with '0') actually writes.
 ///
 /// Self-contained: A1/A2/A5/B1/B2 are pure in-memory Mutagen (no plugin file, no Skyrim.esm); A3/A4 use the
 /// GENERATED corpus.json (built into a unique temp dir on a fresh checkout, exactly as poly-field-descend-guard does).
@@ -172,6 +181,55 @@ public static class NullArmGuardProbe
             var n2 = mod.Npcs.AddNew(); n2.Configuration.Level = new NpcLevel { Level = 1 }; // Sound null, Level set
         });
         Check("B2: optional null polymorphic fields (NPC Sound/Level) still serialize fine (no false refusal)", b2ok, b2Detail);
+
+        // ---- B3: a GenderedItem whose element is a FormLink (ArmorAddon SkinTexture) with only ONE gender half set
+        //          leaves the OTHER half a null formlink Mutagen's PARALLEL writer dereferences → an NRE wrapped in
+        //          nested AggregateExceptions (HCBR-2026-07-04 captured a DOUBLY-nested one). Unlike B1's synchronous
+        //          BARE NRE, this slips past a bare-NRE catch — RootNullArm unwraps it so the refusal is NAMED, not the
+        //          opaque AggregateException the report saw. RED before the catch-widening (threw a raw AggregateException). ----
+        var b3Path = OutPath("hc_nullarm_b3");
+        NullArmSerializeException? b3caught = null; Exception? b3wrong = null;
+        try
+        {
+            SerializeTo(b3Path, mod =>
+            {
+                var arma = mod.ArmorAddons.AddNew();
+                WriteEngine.ApplyVerb(arma, new WriteRequest
+                {
+                    RecordType = "ArmorAddon", Path = new[] { "SkinTexture", "Female" }, Verb = "Set", Value = "000801:hc_nullarm_b3.esp",
+                });
+            });
+        }
+        catch (NullArmSerializeException ex) { b3caught = ex; }
+        catch (Exception ex) { b3wrong = ex; }
+        Check("B3: a single-gender GenderedItem formlink half (ArmorAddon SkinTexture, Male null) fails as a NAMED NullArmSerializeException (not a raw AggregateException)",
+            b3caught is not null, b3wrong is null ? "no exception thrown (serialize unexpectedly succeeded)" : $"threw {b3wrong.GetType().Name}: {b3wrong.Message}");
+        Check("B3b: the refusal names the gender-half cause and preserves the NRE as InnerException",
+            b3caught is not null && b3caught.Message.Contains("gender", StringComparison.OrdinalIgnoreCase) && b3caught.InnerException is NullReferenceException,
+            b3caught?.Message);
+        Check("B3c: nothing was written — all-or-nothing, the target is untouched", !File.Exists(b3Path));
+        CleanOut(b3Path);
+
+        // ---- B4: FALSE-POSITIVE control — a single-gender MODEL half (ArmorAddon WorldModel.Female, Male null) STILL
+        //          serializes fine: Mutagen TOLERATES a null model half (writes only the female subrecord), so the
+        //          widened catch must NOT refuse it. Proves RootNullArm fires only on an actual writer NRE, never on a
+        //          legitimately-absent gender half. GREEN before+after (the fix is narrow — a model half is not a formlink half). ----
+        var (b4ok, b4Detail) = TrySerialize("hc_nullarm_b4", mod =>
+        {
+            var arma = mod.ArmorAddons.AddNew();
+            WriteEngine.ApplyVerb(arma, new WriteRequest { RecordType = "ArmorAddon", Path = new[] { "WorldModel", "Female", "File" }, Verb = "Set", Value = "meshes\\test.nif" });
+        });
+        Check("B4: a single-gender MODEL half (ArmorAddon WorldModel, Male null) still serializes fine (no false refusal)", b4ok, b4Detail);
+
+        // ---- B5: the refusal's recommended fix WORKS — SkinTexture.Female set + Male CLEARED ('0', an empty formlink)
+        //          serializes to a valid single-gender skin AA. Confirms the message's guidance produces a real record. ----
+        var (b5ok, b5Detail) = TrySerialize("hc_nullarm_b5", mod =>
+        {
+            var arma = mod.ArmorAddons.AddNew();
+            WriteEngine.ApplyVerb(arma, new WriteRequest { RecordType = "ArmorAddon", Path = new[] { "SkinTexture", "Female" }, Verb = "Set", Value = "000801:hc_nullarm_b5.esp" });
+            WriteEngine.ApplyVerb(arma, new WriteRequest { RecordType = "ArmorAddon", Path = new[] { "SkinTexture", "Male" }, Verb = "Set", Value = "0" });
+        });
+        Check("B5: SkinTexture.Female + Male cleared ('0') serializes fine — the single-gender escape the refusal recommends", b5ok, b5Detail);
 
         Console.WriteLine();
         Console.WriteLine(failures == 0 ? "nullarm-guard: ALL PASS" : $"nullarm-guard: {failures} FAILURE(S)");

--- a/src/housecarl-generator/NullArmGuardProbe.cs
+++ b/src/housecarl-generator/NullArmGuardProbe.cs
@@ -29,20 +29,22 @@ namespace HousecarlGenerator;
 /// re-stamps the serialize-boundary NRE as a loud, NAMED <see cref="NullArmSerializeException"/> — all-or-nothing
 /// (the staged temp is already discarded; the target is untouched), preserving the NRE as <c>InnerException</c>. Q3.
 ///
-/// PART B (extended HCBR-2026-07-04) — the PARALLEL-WRITER wrap. A GenderedItem whose element is a FormLink
-/// (an ArmorAddon's <c>SkinTexture</c>) with only ONE gender half set leaves the OTHER half a null formlink Mutagen's
-/// writer dereferences — but on its PARALLEL path, so the NRE surfaces WRAPPED in nested <see cref="AggregateException"/>s
-/// (the report captured a doubly-nested one), slipping past a bare-NRE catch and rendering as the opaque AggregateException.
-/// THE FIX: <c>WriteEngine.RootNullArm</c> flattens the aggregate and re-stamps ONLY when every leaf is an NRE, so both the
-/// synchronous (B1) and parallel-wrapped (B3) null-arm cases become the same NAMED refusal, while a null MODEL half
-/// (WorldModel — Mutagen tolerates it) and any other serialize error are untouched.
+/// PART B (extended HCBR-2026-07-04) — single-gender GenderedItem formlink halves + the parallel-writer wrap. TWO coupled
+/// fixes. (i) THE ROOT FIX: a GenderedItem whose element is a FormLink (an ArmorAddon's <c>SkinTexture</c>) authored with
+/// only ONE gender half set used to leave the OTHER half a NULL formlink Mutagen's writer dereferenced (an NRE, wrapped in
+/// nested <see cref="AggregateException"/>s on the parallel path). <c>WriteEngine.EmptyFormLinkOf</c> now materializes an
+/// un-set formlink half as a NON-NULL empty link (mirroring the binary reader), so a fresh single-gender skin AA WRITES
+/// (B3). (ii) THE SAFETY NET: <c>WriteEngine.RootNullArm</c> flattens an <see cref="AggregateException"/> and walks each
+/// leaf to its root, re-stamping ONLY an all-NRE-rooted failure as the NAMED <see cref="NullArmSerializeException"/> — so a
+/// COMPOSITION null-arm (a Condition without its Data arm, B1) renders NAMED whether it arrives bare or parallel-wrapped,
+/// while a null MODEL half (WorldModel — Mutagen tolerates it, B4) and any other serialize error are untouched.
 ///
-/// RED→GREEN: Part A checks A1/A2/A3/A5 are RED if <c>MapStruct</c> drops the nested Struct; Part B checks B1 (bare) and
-/// B3 (parallel-wrapped) are RED (a bare <see cref="NullReferenceException"/> / raw <see cref="AggregateException"/>, not a
-/// <see cref="NullArmSerializeException"/>) without the widened catch. The FALSE-POSITIVE controls (B2 optional null poly;
-/// B4 tolerated null MODEL half) and the illegal-nested-arm reject (A4) are GREEN before AND after — they prove the fix is
-/// NARROW (a valid optional-null poly and a legitimately-absent model half still serialize; an illegal nested arm still
-/// rejects loud). B5 confirms the refusal's recommended single-gender escape (clear the other half with '0') actually writes.
+/// RED→GREEN: Part A checks A1/A2/A3/A5 are RED if <c>MapStruct</c> drops the nested Struct. Part B: B3 (single-gender skin
+/// AA WRITES) is RED before the materializer fix (threw an AggregateException-wrapped NRE); R1–R5 unit-cover RootNullArm's
+/// unwrap (bare / doubly-nested / wrapper-of-NRE / mixed-non-NRE / non-NRE) deterministically; B1 (composition null-arm ->
+/// NAMED refusal) stays GREEN. The FALSE-POSITIVE controls (B2 optional null poly; B4 tolerated null MODEL half) and the
+/// illegal-nested-arm reject (A4) are GREEN before AND after — proving both fixes are NARROW. B5 (explicit '0'-clear) and
+/// B6 (edit-existing overlay round-trip) confirm the single-gender record is valid and existing records are unaffected.
 ///
 /// Self-contained: A1/A2/A5/B1/B2 are pure in-memory Mutagen (no plugin file, no Skyrim.esm); A3/A4 use the
 /// GENERATED corpus.json (built into a unique temp dir on a fresh checkout, exactly as poly-field-descend-guard does).
@@ -182,33 +184,17 @@ public static class NullArmGuardProbe
         });
         Check("B2: optional null polymorphic fields (NPC Sound/Level) still serialize fine (no false refusal)", b2ok, b2Detail);
 
-        // ---- B3: a GenderedItem whose element is a FormLink (ArmorAddon SkinTexture) with only ONE gender half set
-        //          leaves the OTHER half a null formlink Mutagen's PARALLEL writer dereferences → an NRE wrapped in
-        //          nested AggregateExceptions (HCBR-2026-07-04 captured a DOUBLY-nested one). Unlike B1's synchronous
-        //          BARE NRE, this slips past a bare-NRE catch — RootNullArm unwraps it so the refusal is NAMED, not the
-        //          opaque AggregateException the report saw. RED before the catch-widening (threw a raw AggregateException). ----
-        var b3Path = OutPath("hc_nullarm_b3");
-        NullArmSerializeException? b3caught = null; Exception? b3wrong = null;
-        try
+        // ---- B3: a single-gender GenderedItem whose element is a FormLink (ArmorAddon SkinTexture, Female set /
+        //          Male un-set) now WRITES a valid record — the materializer fills the un-set formlink half with a
+        //          NON-NULL empty link (EmptyFormLinkOf), mirroring Mutagen's binary reader, so the writer no longer
+        //          dereferences a null half. RED before the materializer fix (threw an AggregateException-wrapped NRE).
+        //          This is the "fresh single-gender create just works" fix (HCBR-2026-07-04). ----
+        var (b3ok, b3Detail) = TrySerialize("hc_nullarm_b3", mod =>
         {
-            SerializeTo(b3Path, mod =>
-            {
-                var arma = mod.ArmorAddons.AddNew();
-                WriteEngine.ApplyVerb(arma, new WriteRequest
-                {
-                    RecordType = "ArmorAddon", Path = new[] { "SkinTexture", "Female" }, Verb = "Set", Value = "000801:hc_nullarm_b3.esp",
-                });
-            });
-        }
-        catch (NullArmSerializeException ex) { b3caught = ex; }
-        catch (Exception ex) { b3wrong = ex; }
-        Check("B3: a single-gender GenderedItem formlink half (ArmorAddon SkinTexture, Male null) fails as a NAMED NullArmSerializeException (not a raw AggregateException)",
-            b3caught is not null, b3wrong is null ? "no exception thrown (serialize unexpectedly succeeded)" : $"threw {b3wrong.GetType().Name}: {b3wrong.Message}");
-        Check("B3b: the refusal names the gender-half cause and preserves the NRE as InnerException",
-            b3caught is not null && b3caught.Message.Contains("gender", StringComparison.OrdinalIgnoreCase) && b3caught.InnerException is NullReferenceException,
-            b3caught?.Message);
-        Check("B3c: nothing was written — all-or-nothing, the target is untouched", !File.Exists(b3Path));
-        CleanOut(b3Path);
+            var arma = mod.ArmorAddons.AddNew();
+            WriteEngine.ApplyVerb(arma, new WriteRequest { RecordType = "ArmorAddon", Path = new[] { "SkinTexture", "Female" }, Verb = "Set", Value = "000801:hc_nullarm_b3.esp" });
+        });
+        Check("B3: a single-gender skin AA (SkinTexture.Female only, Male un-set) now WRITES — fresh single-gender create just works", b3ok, b3Detail);
 
         // ---- B4: FALSE-POSITIVE control — a single-gender MODEL half (ArmorAddon WorldModel.Female, Male null) STILL
         //          serializes fine: Mutagen TOLERATES a null model half (writes only the female subrecord), so the
@@ -221,15 +207,16 @@ public static class NullArmGuardProbe
         });
         Check("B4: a single-gender MODEL half (ArmorAddon WorldModel, Male null) still serializes fine (no false refusal)", b4ok, b4Detail);
 
-        // ---- B5: the refusal's recommended fix WORKS — SkinTexture.Female set + Male CLEARED ('0', an empty formlink)
-        //          serializes to a valid single-gender skin AA. Confirms the message's guidance produces a real record. ----
+        // ---- B5: EXPLICITLY clearing the other half ('0') also writes — belt-and-suspenders with B3's auto-empty
+        //          materialization: whether the un-set half is auto-filled (B3) or the author clears it by hand, a
+        //          single-gender skin AA serializes to a valid record. ----
         var (b5ok, b5Detail) = TrySerialize("hc_nullarm_b5", mod =>
         {
             var arma = mod.ArmorAddons.AddNew();
             WriteEngine.ApplyVerb(arma, new WriteRequest { RecordType = "ArmorAddon", Path = new[] { "SkinTexture", "Female" }, Verb = "Set", Value = "000801:hc_nullarm_b5.esp" });
             WriteEngine.ApplyVerb(arma, new WriteRequest { RecordType = "ArmorAddon", Path = new[] { "SkinTexture", "Male" }, Verb = "Set", Value = "0" });
         });
-        Check("B5: SkinTexture.Female + Male cleared ('0') serializes fine — the single-gender escape the refusal recommends", b5ok, b5Detail);
+        Check("B5: SkinTexture.Female + Male explicitly cleared ('0') also serializes fine (belt-and-suspenders with B3's auto-empty half)", b5ok, b5Detail);
 
         // ---- B6: the EDIT-EXISTING path is SAFE — only fresh CREATE bites. Author a single-gender skin AA on disk
         //          (Female texture set, Male cleared), re-open it as a BinaryOverlay, deep-copy it into a fresh patch
@@ -259,6 +246,23 @@ public static class NullArmGuardProbe
         catch (Exception ex) { b6Detail = $"{ex.GetType().Name}: {ex.Message}"; }
         finally { CleanOut(b6src); }
         Check("B6: an on-disk single-gender skin AA round-trips (overlay -> deep-copy -> serialize) without a null-arm refusal — edit-existing is safe, only CREATE bites", b6ok, b6Detail);
+
+        // ---- R1–R5: RootNullArm unwrap logic — DETERMINISTIC unit coverage of the SAFETY NET (independent of Mutagen's
+        //          parallel scheduling; the materializer fix means B3 no longer exercises the wrapped path). RootNullArm
+        //          re-stamps a serialize throw as the NAMED null-arm refusal IFF its ROOT cause is a NullReferenceException
+        //          — through the parallel writer's AggregateException + SubrecordException wrapping (HCBR-2026-07-04) — and
+        //          returns null (leaving the throw untouched) otherwise, so a genuine other error is never masked (Q3). ----
+        var nre = new NullReferenceException("x");
+        Check("R1: a BARE NRE unwraps to itself",
+            ReferenceEquals(WriteEngine.RootNullArm(nre), nre));
+        Check("R2: a doubly-nested AggregateException(NRE leaf) flattens + unwraps to the NRE",
+            ReferenceEquals(WriteEngine.RootNullArm(new AggregateException(new AggregateException(nre))), nre));
+        Check("R3: the report's shape — AggregateException(AggregateException(wrapper(NRE))) — walks the inner chain to the NRE",
+            ReferenceEquals(WriteEngine.RootNullArm(new AggregateException(new AggregateException(new InvalidOperationException("subrecord-style wrapper", nre)))), nre));
+        Check("R4: an aggregate with a NON-NRE-rooted leaf returns null (the genuine error keeps its own type/message — not masked)",
+            WriteEngine.RootNullArm(new AggregateException(nre, new InvalidOperationException("a real, different serialize error"))) is null);
+        Check("R5: a non-NRE-rooted throw returns null (propagates unchanged)",
+            WriteEngine.RootNullArm(new InvalidOperationException("not a null-arm")) is null);
 
         Console.WriteLine();
         Console.WriteLine(failures == 0 ? "nullarm-guard: ALL PASS" : $"nullarm-guard: {failures} FAILURE(S)");

--- a/src/housecarl-generator/NullArmGuardProbe.cs
+++ b/src/housecarl-generator/NullArmGuardProbe.cs
@@ -40,11 +40,13 @@ namespace HousecarlGenerator;
 /// while a null MODEL half (WorldModel — Mutagen tolerates it, B4) and any other serialize error are untouched.
 ///
 /// RED→GREEN: Part A checks A1/A2/A3/A5 are RED if <c>MapStruct</c> drops the nested Struct. Part B: B3 (single-gender skin
-/// AA WRITES) is RED before the materializer fix (threw an AggregateException-wrapped NRE); R1–R5 unit-cover RootNullArm's
-/// unwrap (bare / doubly-nested / wrapper-of-NRE / mixed-non-NRE / non-NRE) deterministically; B1 (composition null-arm ->
-/// NAMED refusal) stays GREEN. The FALSE-POSITIVE controls (B2 optional null poly; B4 tolerated null MODEL half) and the
-/// illegal-nested-arm reject (A4) are GREEN before AND after — proving both fixes are NARROW. B5 (explicit '0'-clear) and
-/// B6 (edit-existing overlay round-trip) confirm the single-gender record is valid and existing records are unaffected.
+/// AA WRITES) is RED before the materializer fix (threw an AggregateException-wrapped NRE); B7 feeds the REAL Mutagen
+/// parallel-wrapped null-arm through the actual serialize catch (a forced null half) and confirms it re-stamps NAMED, not
+/// raw; R1–R5 unit-cover RootNullArm's unwrap (bare / doubly-nested / wrapper-of-NRE / mixed-non-NRE / non-NRE)
+/// deterministically; B1 (composition null-arm -> NAMED refusal) stays GREEN. The FALSE-POSITIVE controls (B2 optional null
+/// poly; B4 tolerated null MODEL half) and the illegal-nested-arm reject (A4) are GREEN before AND after — proving both
+/// fixes are NARROW. B5 (explicit '0'-clear) and B6 (edit-existing overlay round-trip) confirm the single-gender record is
+/// valid and existing records are unaffected.
 ///
 /// Self-contained: A1/A2/A5/B1/B2 are pure in-memory Mutagen (no plugin file, no Skyrim.esm); A3/A4 use the
 /// GENERATED corpus.json (built into a unique temp dir on a fresh checkout, exactly as poly-field-descend-guard does).
@@ -226,6 +228,7 @@ public static class NullArmGuardProbe
         //          GREEN before+after — the refusal is CREATE-only; existing mods' single-gender skin AAs (TSOSRefined
         //          NPC torsos, NPC hand-skins, …) forward/edit/compact fine. Confirmed live on 0UlfricNakedSkinTorso. ----
         string b6src = OutPath("hc_nullarm_b6src");
+        string? b6out = null;   // declared out of the try so the finally cleans it on the FAILURE path too (WritePatch stages its GUID dir before it can throw)
         bool b6ok = false; string? b6Detail = null;
         try
         {
@@ -236,28 +239,54 @@ public static class NullArmGuardProbe
                 WriteEngine.ApplyVerb(arma, new WriteRequest { RecordType = "ArmorAddon", Path = new[] { "SkinTexture", "Male" }, Verb = "Set", Value = "0" });
             });
             using var overlay = SkyrimMod.CreateFromBinaryOverlay(b6src, SkyrimRelease.SkyrimSE);
-            var b6out = OutPath("hc_nullarm_b6out");
+            b6out = OutPath("hc_nullarm_b6out");
             var patch = new SkyrimMod(new ModKey(Path.GetFileNameWithoutExtension(b6out), ModType.Plugin), SkyrimRelease.SkyrimSE);
             patch.ArmorAddons.Add(overlay.ArmorAddons.First().DeepCopy());   // the forward/edit deep-copy of an overlay getter
             WriteEngine.WritePatch(patch, new ISkyrimModGetter[] { overlay }, b6out);
             b6ok = File.Exists(b6out);
-            CleanOut(b6out);
         }
         catch (Exception ex) { b6Detail = $"{ex.GetType().Name}: {ex.Message}"; }
-        finally { CleanOut(b6src); }
+        finally { CleanOut(b6src); if (b6out is not null) CleanOut(b6out); }
         Check("B6: an on-disk single-gender skin AA round-trips (overlay -> deep-copy -> serialize) without a null-arm refusal — edit-existing is safe, only CREATE bites", b6ok, b6Detail);
 
-        // ---- R1–R5: RootNullArm unwrap logic — DETERMINISTIC unit coverage of the SAFETY NET (independent of Mutagen's
-        //          parallel scheduling; the materializer fix means B3 no longer exercises the wrapped path). RootNullArm
-        //          re-stamps a serialize throw as the NAMED null-arm refusal IFF its ROOT cause is a NullReferenceException
-        //          — through the parallel writer's AggregateException + SubrecordException wrapping (HCBR-2026-07-04) — and
-        //          returns null (leaving the throw untouched) otherwise, so a genuine other error is never masked (Q3). ----
+        // ---- B7: FAITHFUL real-Mutagen coverage of the wrapped-path safety net. R1–R5 cover RootNullArm's unwrap
+        //          LOGIC against synthetic shapes; this proves the actual serialize CATCH handles the REAL exception
+        //          Mutagen's parallel writer throws. The materializer now fills an un-set formlink half (so B3 writes),
+        //          so the only way to reach a NULL half is to force it: null SkinTexture.Male AFTER materialization,
+        //          then serialize. The genuine AggregateException(SubrecordException(NRE)) must be re-stamped as the
+        //          NAMED NullArmSerializeException, not rendered raw. (Defensive: this state no longer arises via any
+        //          normal op — it documents that IF it ever did, the safety net still fails loud + named.) ----
+        var b7Path = OutPath("hc_nullarm_b7");
+        NullArmSerializeException? b7caught = null; Exception? b7wrong = null;
+        try
+        {
+            SerializeTo(b7Path, mod =>
+            {
+                var arma = mod.ArmorAddons.AddNew();
+                WriteEngine.ApplyVerb(arma, new WriteRequest { RecordType = "ArmorAddon", Path = new[] { "SkinTexture", "Female" }, Verb = "Set", Value = "000801:hc_nullarm_b7.esp" });
+                arma.SkinTexture!.GetType().GetProperty("Male")!.SetValue(arma.SkinTexture, null);   // force the pre-fix null formlink half
+            });
+        }
+        catch (NullArmSerializeException ex) { b7caught = ex; }
+        catch (Exception ex) { b7wrong = ex; }
+        Check("B7: the REAL parallel-wrapped null-arm (a forced null gendered formlink half) is re-stamped as the NAMED NullArmSerializeException, not rendered raw",
+            b7caught is not null, b7wrong is null ? "no exception thrown (serialize unexpectedly succeeded)" : $"threw {b7wrong.GetType().Name}: {b7wrong.Message}");
+        Check("B7b: nothing was written — all-or-nothing", !File.Exists(b7Path));
+        CleanOut(b7Path);
+
+        // ---- R1–R5: RootNullArm unwrap LOGIC — DETERMINISTIC unit coverage against SYNTHETIC exception shapes. The
+        //          real-Mutagen wrapped path is covered end-to-end by B7 above; these pin the branch logic cheaply and
+        //          without depending on Mutagen's parallel scheduling. R2 matches the report's captured message shape
+        //          (nested AggregateExceptions around the NRE); R3's inner wrapper is a structural STAND-IN for Mutagen's
+        //          SubrecordException — the inner-walk is wrapper-type-agnostic, so any wrapper-of-NRE exercises it (the
+        //          REAL SubrecordException is what B7 feeds through). RootNullArm re-stamps IFF the ROOT cause is an NRE,
+        //          else returns null so a genuine other error is never masked (Q3). ----
         var nre = new NullReferenceException("x");
         Check("R1: a BARE NRE unwraps to itself",
             ReferenceEquals(WriteEngine.RootNullArm(nre), nre));
         Check("R2: a doubly-nested AggregateException(NRE leaf) flattens + unwraps to the NRE",
             ReferenceEquals(WriteEngine.RootNullArm(new AggregateException(new AggregateException(nre))), nre));
-        Check("R3: the report's shape — AggregateException(AggregateException(wrapper(NRE))) — walks the inner chain to the NRE",
+        Check("R3: a wrapper-of-NRE leaf (SubrecordException-style stand-in) — the inner chain is walked to the NRE",
             ReferenceEquals(WriteEngine.RootNullArm(new AggregateException(new AggregateException(new InvalidOperationException("subrecord-style wrapper", nre)))), nre));
         Check("R4: an aggregate with a NON-NRE-rooted leaf returns null (the genuine error keeps its own type/message — not masked)",
             WriteEngine.RootNullArm(new AggregateException(nre, new InvalidOperationException("a real, different serialize error"))) is null);

--- a/src/housecarl-generator/NullArmGuardProbe.cs
+++ b/src/housecarl-generator/NullArmGuardProbe.cs
@@ -231,6 +231,35 @@ public static class NullArmGuardProbe
         });
         Check("B5: SkinTexture.Female + Male cleared ('0') serializes fine — the single-gender escape the refusal recommends", b5ok, b5Detail);
 
+        // ---- B6: the EDIT-EXISTING path is SAFE — only fresh CREATE bites. Author a single-gender skin AA on disk
+        //          (Female texture set, Male cleared), re-open it as a BinaryOverlay, deep-copy it into a fresh patch
+        //          (exactly what forward_record / any in-place edit does), and serialize. Mutagen's binary READER fills
+        //          the absent gender half with a NON-NULL empty FormLinkNullable (NOT the null interface the create
+        //          materializer leaves), so the read->copy->serialize round-trip does NOT hit the null-arm refusal.
+        //          GREEN before+after — the refusal is CREATE-only; existing mods' single-gender skin AAs (TSOSRefined
+        //          NPC torsos, NPC hand-skins, …) forward/edit/compact fine. Confirmed live on 0UlfricNakedSkinTorso. ----
+        string b6src = OutPath("hc_nullarm_b6src");
+        bool b6ok = false; string? b6Detail = null;
+        try
+        {
+            SerializeTo(b6src, mod =>
+            {
+                var arma = mod.ArmorAddons.AddNew();
+                WriteEngine.ApplyVerb(arma, new WriteRequest { RecordType = "ArmorAddon", Path = new[] { "SkinTexture", "Female" }, Verb = "Set", Value = "000801:hc_nullarm_b6src.esp" });
+                WriteEngine.ApplyVerb(arma, new WriteRequest { RecordType = "ArmorAddon", Path = new[] { "SkinTexture", "Male" }, Verb = "Set", Value = "0" });
+            });
+            using var overlay = SkyrimMod.CreateFromBinaryOverlay(b6src, SkyrimRelease.SkyrimSE);
+            var b6out = OutPath("hc_nullarm_b6out");
+            var patch = new SkyrimMod(new ModKey(Path.GetFileNameWithoutExtension(b6out), ModType.Plugin), SkyrimRelease.SkyrimSE);
+            patch.ArmorAddons.Add(overlay.ArmorAddons.First().DeepCopy());   // the forward/edit deep-copy of an overlay getter
+            WriteEngine.WritePatch(patch, new ISkyrimModGetter[] { overlay }, b6out);
+            b6ok = File.Exists(b6out);
+            CleanOut(b6out);
+        }
+        catch (Exception ex) { b6Detail = $"{ex.GetType().Name}: {ex.Message}"; }
+        finally { CleanOut(b6src); }
+        Check("B6: an on-disk single-gender skin AA round-trips (overlay -> deep-copy -> serialize) without a null-arm refusal — edit-existing is safe, only CREATE bites", b6ok, b6Detail);
+
         Console.WriteLine();
         Console.WriteLine(failures == 0 ? "nullarm-guard: ALL PASS" : $"nullarm-guard: {failures} FAILURE(S)");
         return failures == 0 ? 0 : 1;


### PR DESCRIPTION
## What
Fixes the `create_record ArmorAddon` null-ref crash when a single-gender skin AA is authored — only one gender half of a formlink `GenderedItem` (e.g. `SkinTexture.Female`) is set. **The fix makes a single-gender skin AA WRITE a valid record** (not refuse), matching how existing records already round-trip and how `WorldModel`'s single-gender model half already works.

## Root cause (empirically corrected)
The report attributed it to an untouched `WorldModel.Male`. Reproduction showed that's **not** the trigger — a null *model* half serializes fine (Mutagen skips it). The real culprit is **`SkinTexture`**, a `GenderedItem` of a *nullable formlink*: the create-time materializer built `GenderedItem<T>(default(T), default(T))`, and for a formlink element `T` (an interface) `default(T)` is null — which Mutagen's writer dereferences. That write runs on Mutagen's **parallel** path, so the NRE surfaces wrapped in nested `AggregateException`s around a `SubrecordException`. Mutagen's binary *reader* instead fills an absent half with a non-null empty `FormLinkNullable`, which is why read records serialize fine.

## Fix — two coupled changes
1. **Root fix — `EmptyFormLinkOf` (make it just work):** the materializer now fills an un-set formlink half with a non-null empty link (via the existing `TryFormLink` recogniser, by construction — no per-type list), mirroring the reader. A `Model`/ref half stays null (writer tolerates it); a value half stays `default(0)`. So **authoring a fresh single-gender skin AA writes cleanly** — no refusal, no escape. Proven by `nullarm-guard` **B3**.
2. **Safety net — `RootNullArm` (defensive):** the two serialize-boundary catches unwrap the parallel writer's `AggregateException` nesting to the root NRE, so a genuine **composition** null-arm (a Condition without its `Data` arm) still renders as the NAMED refusal whether bare or wrapped — never opaque. Re-stamps *only* when every leaf roots to an NRE (a mixed/other error keeps its own type — R4). `internal` + unit-covered R1–R5; **B7** feeds the real Mutagen wrapped exception through the actual catch.

## Coverage
`nullarm-guard`: **B3** (single-gender create WRITES), **B4** (WorldModel single-gender still writes — narrow), **B5** (explicit `'0'`-clear), **B6** (edit-existing overlay round-trip is safe), **B7** (real wrapped null-arm → NAMED, not raw), **R1–R5** (RootNullArm unwrap logic), **B1** unchanged (composition null-arm → NAMED). `ci-all 70/70`.

## Field check (real load order)
The refuse-vs-write question only ever affected fresh authoring: **editing/forwarding/compacting existing single-gender skin AAs was already safe** (proven live on `0UlfricNakedSkinTorso` + guard B6). Single-gender skin AAs are common in the order (TSOSRefined per-NPC torsos, NPC hand-skins, …); none of those edit paths were at risk.

## Not yet in-game-validated
Lands in source; the installed plugin picks it up on next repackage. Real test then: author a single-gender skin AA and confirm it writes + loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)