### PR TITLE
feat(read): housecarl_validate_scripts — catch VMAD properties declared in the .pex but left unbound

### DIFF
--- a/src/housecarl-core/ScriptPropertyCheck.cs
+++ b/src/housecarl-core/ScriptPropertyCheck.cs
@@ -1,0 +1,354 @@
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using Mutagen.Bethesda.Pex;
+using Mutagen.Bethesda;
+
+namespace HousecarlCore;
+
+/// <summary>
+/// The SCRIPT-PROPERTY binding sweep (housecarl_validate_scripts): for every record carrying a VMAD it cross-checks
+/// the properties BOUND on the record's script attachment against the properties the attached script's compiled
+/// <c>.pex</c> — and its whole <c>extends</c> chain — actually DECLARES, and reports the ones that are declared but
+/// left UNBOUND (a silent <c>None</c>). This is the failure the bug store names on 2026-07-04: a quest script declared
+/// <c>Spell Property CallVesyraPower Auto</c>, the code guarded on it, the VMAD never bound it → <c>AddSpell(None)</c>
+/// no-op while the trace logged "power granted". Maximally misleading (function runs, effect absent, logs clean), and
+/// the same class as the CK's STMain auto-add bug — every scripted mod hits it eventually.
+///
+/// WHY THIS IS A COMPOSE-PRIMITIVES JOB (no new dependency, the <see cref="ErrorCheck"/> pattern): both halves are
+/// already modeled. The RECORD half is Mutagen's VMAD (<see cref="IHaveVirtualMachineAdapterGetter"/> →
+/// <see cref="IAVirtualMachineAdapterGetter.Scripts"/> → <see cref="IScriptEntryGetter"/> with its bound
+/// <see cref="IScriptPropertyGetter"/> list). The SCRIPT half is Mutagen's <c>.pex</c> model (<see cref="PexObject.Properties"/>,
+/// each an <see cref="PexObjectProperty"/> with its <c>Auto</c> flag + declared type) — the same model
+/// <see cref="PapyrusDecompiler"/> reads. The two are joined through the VFS: <see cref="AssetResolver"/> resolves
+/// <c>Scripts\&lt;class&gt;.pex</c> (loose OR BSA-packed), and each <c>.pex</c> self-declares its parent
+/// (<see cref="PexObject.ParentClassName"/>), so the extends chain walks itself with no external hierarchy map.
+///
+/// WHAT COUNTS AS A FINDING (kept HIGH-SIGNAL so a clean result is trustworthy and the sweep never cries wolf — Q3):
+///   • UNBOUND OBJECT property — an <c>Auto</c> property of a FORM/object type (Spell, Quest, ObjectReference, …)
+///     declared in the chain but absent from the VMAD. Unbound ⇒ <c>None</c> ⇒ the silent-no-op footgun. HIGH.
+///   • UNBOUND SCALAR property with NO initializer — an <c>Auto</c> Int/Float/Bool/String declared without a baked
+///     default and absent from the VMAD ⇒ defaults to 0 / 0.0 / false / "" which may be wrong (a "% chance" meant to
+///     be 50 silently becomes 0). MEDIUM. A scalar that DOES carry an initializer is NOT flagged — it has the author's
+///     intended default, so leaving it unbound is correct, not a bug.
+///   • BOUND-BUT-NULL object property — present in the VMAD as a <see cref="IScriptObjectPropertyGetter"/> whose Object
+///     link is null. The same <c>None</c> at runtime, but MORE often intentional (the slot exists, filled at runtime),
+///     so it is ADVISORY, ranked below the absent findings.
+///
+/// HONEST BOUNDARY (Q3 — the sweep claims exactly this, never more, and every degraded mode is NAMED, never silent):
+///   • It checks <c>Auto</c> properties only — the CK-editable, silently-defaulting kind. Full properties with custom
+///     Get/Set handlers are code-driven and are not flagged.
+///   • "Unbound may be intentional" — an object property is sometimes filled by script at runtime; the finding is a
+///     flag to VERIFY, not a proven defect. Object-type absences are ranked first because they are the silent-None class.
+///   • If a script's OWN <c>.pex</c> is not on disk (uncompiled, or not in the VFS) the attachment is reported
+///     UNVERIFIABLE, never silently passed. If an ANCESTOR <c>.pex</c> is missing the chain is truncated with a named
+///     note — the properties we COULD read are still checked.
+///   • A BSA that failed to read this build is surfaced (<see cref="AssetResolver.AssetView.ReadIncomplete"/>), so a
+///     "not found" that may merely be unscanned is never read as an authoritative absence.
+///
+/// Composes existing primitives only, holds nothing past each record (the <see cref="ErrorCheck"/> Option-B discipline):
+/// the per-plugin record stream (<c>RecordsIn</c>), the VFS resolver (one captured <see cref="AssetResolver.AssetView"/>
+/// so every <c>.pex</c> lookup + the read-incomplete caveat agree on ONE build), and per-record fault isolation.
+/// </summary>
+public static class ScriptPropertyCheck
+{
+    /// <summary>Sweep <paramref name="scope"/> (plugin filenames; null/empty = the whole active order minus excluded
+    /// plugins) over the order <paramref name="resolver"/> holds, resolving each attached script's <c>.pex</c> through
+    /// <paramref name="assets"/>. <paramref name="limit"/> caps the number of property FINDINGS collected across the
+    /// sweep (the true totals are always counted). A bad/excluded scope name fails LOUD (Q3) with no partial result —
+    /// the <see cref="ErrorCheck"/> contract, verbatim.</summary>
+    public static ScriptCheckResult Run(LoadOrderResolver resolver, AssetResolver assets,
+                                        IReadOnlyList<string>? scope, int limit)
+    {
+        var view = resolver.Capture();
+        var av = assets.Capture();          // ONE asset build → every .pex lookup + ReadIncomplete describe the same build
+
+        // --- resolve the plugin set to scan (Q3: a bad or excluded explicit scope name fails loud, never a silent skip). ---
+        List<string> targets;
+        if (scope is { Count: > 0 })
+        {
+            targets = new List<string>(scope.Count);
+            foreach (var name in scope)
+            {
+                if (!view.ContainsPlugin(name))
+                    return ScriptCheckResult.Fail($"plugin not in the load order: {name}");
+                if (view.ExcludedPlugins.TryGetValue(name, out var why))
+                    return ScriptCheckResult.Fail(
+                        $"plugin '{name}' was excluded from this session because it could not be parsed ({why}) — fix or remove it upstream; it cannot be checked.");
+                targets.Add(name);
+            }
+        }
+        else
+        {
+            targets = new List<string>();
+            foreach (var n in resolver.PluginNames)
+                if (!view.ExcludedPlugins.ContainsKey(n)) targets.Add(n);
+        }
+
+        // A per-sweep .pex property-set cache: many records attach the SAME script class (SPID-distributed abilities,
+        // a mod's shared controller), so the chain read is resolved ONCE per class, not once per record.
+        var chainCache = new Dictionary<string, ChainResult>(StringComparer.OrdinalIgnoreCase);
+
+        var reports = new List<RecordScriptFindings>();
+        int recordsWithScripts = 0, totalUnbound = 0, totalNull = 0, totalUnverifiable = 0;
+        int findingBudget = limit;
+        bool capped = false;
+
+        foreach (var plugin in targets)
+        {
+            string? scanError = null;
+            try
+            {
+                foreach (var (fk, _, body, _) in view.RecordsIn(new[] { plugin }, null))
+                {
+                    // PER-RECORD FAULT ISOLATION (the ErrorCheck / cross_plugin_query idiom): a VMAD Mutagen can't parse
+                    // is excluded + accounted per record, never an opaque whole-call abort and never a silent skip (Q3).
+                    try
+                    {
+                        if (body is not IHaveVirtualMachineAdapterGetter have) continue;
+                        if (have.VirtualMachineAdapter is not { } vmad) continue;
+                        if (vmad.Scripts.Count == 0) continue;
+                        recordsWithScripts++;
+
+                        var unbound = new List<UnboundProperty>();
+                        var nulls = new List<NullObjectProperty>();
+                        var unver = new List<ScriptUnverifiable>();
+
+                        foreach (var entry in vmad.Scripts)
+                        {
+                            var scriptClass = entry.Name?.Trim();
+                            if (string.IsNullOrEmpty(scriptClass))
+                            {
+                                unver.Add(new ScriptUnverifiable("(unnamed)",
+                                    "the script attachment carries no class name — can't resolve its .pex to check its properties."));
+                                continue;
+                            }
+
+                            // Bound-but-null object properties: the slot exists in the VMAD, its Object link is null.
+                            foreach (var p in entry.Properties)
+                                if (p is IScriptObjectPropertyGetter op && op.Object.FormKey.IsNull && !string.IsNullOrWhiteSpace(p.Name))
+                                    nulls.Add(new NullObjectProperty(scriptClass, p.Name!.Trim()));
+
+                            var chain = ResolveChain(av, chainCache, scriptClass);
+                            if (chain.OwnLoadError is not null)
+                            {
+                                unver.Add(new ScriptUnverifiable(scriptClass, chain.OwnLoadError));
+                                continue;   // can't read the script's own properties — nothing to compare against
+                            }
+
+                            var boundNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                            foreach (var p in entry.Properties)
+                                if (!string.IsNullOrWhiteSpace(p.Name)) boundNames.Add(p.Name!.Trim());
+
+                            foreach (var d in chain.Declared)
+                            {
+                                if (boundNames.Contains(d.Name)) continue;
+                                // A scalar with a baked initializer has the author's intended default — leaving it
+                                // unbound is correct, so it is NOT a finding (keeps the scalar signal from crying wolf).
+                                if (!d.IsObjectType && d.HasInitializer) continue;
+                                unbound.Add(new UnboundProperty(scriptClass, d.DeclaringScript, d.Name, d.TypeName, d.IsObjectType));
+                            }
+
+                            if (chain.ChainNote is not null)
+                                unver.Add(new ScriptUnverifiable(scriptClass, chain.ChainNote));
+                        }
+
+                        if (unbound.Count == 0 && nulls.Count == 0 && unver.Count == 0) continue;
+
+                        // Apply the shared finding budget (unbound + null are the capped population; unverifiable notes
+                        // are few and always kept). The true totals are counted regardless of the cap.
+                        totalUnbound += unbound.Count;
+                        totalNull += nulls.Count;
+                        totalUnverifiable += unver.Count;
+
+                        var keptUnbound = new List<UnboundProperty>();
+                        var keptNull = new List<NullObjectProperty>();
+                        foreach (var u in unbound) { if (findingBudget > 0) { keptUnbound.Add(u); findingBudget--; } else capped = true; }
+                        foreach (var n in nulls)   { if (findingBudget > 0) { keptNull.Add(n);   findingBudget--; } else capped = true; }
+
+                        reports.Add(new RecordScriptFindings(
+                            fk, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID, plugin,
+                            keptUnbound, keptNull, unver));
+                    }
+                    catch (Exception ex)
+                    {
+                        scanError = (scanError is null ? "" : scanError + "; ")
+                                  + $"a record's script adapter could not be read ({fk} — {ex.GetType().Name}: {ex.Message})";
+                    }
+                }
+            }
+            // The plugin enumeration itself faulting is NAMED per-plugin and the sweep continues — never the MCP
+            // layer's opaque transport error (Q3, the ErrorCheck contract).
+            catch (Exception ex)
+            {
+                reports.Add(RecordScriptFindings.PluginScanError(plugin,
+                    $"record enumeration aborted partway: {ex.GetType().Name}: {ex.Message}"));
+            }
+
+            if (scanError is not null)
+                reports.Add(RecordScriptFindings.PluginScanError(plugin, scanError));
+        }
+
+        return new ScriptCheckResult(reports, targets.Count, recordsWithScripts, totalUnbound, totalNull,
+                                     totalUnverifiable, capped, av.ReadIncomplete, view.ExcludedPlugins, null);
+    }
+
+    // ---- .pex extends-chain resolution ----------------------------------------------------------------
+
+    /// <summary>Every <c>Auto</c> property declared across a script's extends chain (most-derived class first;
+    /// de-duplicated by name so an override does not double-count), any <see cref="ChainNote"/> for an ancestor whose
+    /// <c>.pex</c> could not be read (partial — what we could read is still checked), and <see cref="OwnLoadError"/> set
+    /// when the script's OWN <c>.pex</c> could not be read (→ the attachment is unverifiable, nothing to compare).</summary>
+    sealed record ChainResult(IReadOnlyList<DeclaredProp> Declared, string? ChainNote, string? OwnLoadError);
+
+    /// <summary>One <c>Auto</c> property the chain declares: its <see cref="Name"/>, the <c>.pex</c> <see cref="TypeName"/>,
+    /// the script it is <see cref="DeclaringScript"/>d in (the most-derived class or an ancestor), whether it carries a
+    /// baked <see cref="HasInitializer"/> default, and whether its type is a FORM/object type (<see cref="IsObjectType"/> —
+    /// the silent-None class) versus a scalar.</summary>
+    sealed record DeclaredProp(string Name, string TypeName, string DeclaringScript, bool HasInitializer, bool IsObjectType);
+
+    static ChainResult ResolveChain(AssetResolver.AssetView av, Dictionary<string, ChainResult> cache, string scriptClass)
+    {
+        if (cache.TryGetValue(scriptClass, out var hit)) return hit;
+        var result = BuildChain(av, scriptClass);
+        cache[scriptClass] = result;
+        return result;
+    }
+
+    static ChainResult BuildChain(AssetResolver.AssetView av, string scriptClass)
+    {
+        var byName = new Dictionary<string, DeclaredProp>(StringComparer.OrdinalIgnoreCase);   // first (most-derived) wins
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        string? current = scriptClass;
+        string? chainNote = null;
+
+        for (int hops = 0; current is { Length: > 0 } && hops < 64; hops++)
+        {
+            if (!visited.Add(current)) break;   // cycle guard (a malformed hierarchy) — stop, never spin
+
+            if (!TryLoadPex(av, current, out var pex, out var reason))
+            {
+                if (hops == 0)
+                    return new ChainResult(Array.Empty<DeclaredProp>(), null, reason);   // the script's OWN .pex — unverifiable
+                chainNote = $"the extends chain was truncated at '{current}' ({reason}) — properties it and its ancestors declare were not checked.";
+                break;
+            }
+
+            // A single-script .pex has one object named for the class; take the matching object (else the first).
+            var obj = pex!.Objects.FirstOrDefault(o => string.Equals(o.Name, current, StringComparison.OrdinalIgnoreCase))
+                      ?? pex.Objects.FirstOrDefault();
+            if (obj is null) { chainNote ??= $"'{current}.pex' held no script object — its properties were not checked."; break; }
+
+            foreach (var p in obj.Properties)
+            {
+                if (!p.Flags.HasFlag(PropertyFlags.AutoVar)) continue;   // Auto (editable, silently-defaulting) props only
+                var name = p.Name?.Trim();
+                if (string.IsNullOrEmpty(name) || byName.ContainsKey(name)) continue;
+                var typeName = (p.TypeName ?? "").Trim();
+                var backing = obj.Variables.FirstOrDefault(v =>
+                    string.Equals(v.Name, p.AutoVarName, StringComparison.OrdinalIgnoreCase));
+                bool hasInit = backing is not null && PapyrusDecompiler.InitText(backing.VariableData) is not null;
+                byName[name] = new DeclaredProp(name, typeName, current, hasInit, IsObjectType(typeName));
+            }
+
+            current = string.IsNullOrWhiteSpace(obj.ParentClassName) ? null : obj.ParentClassName.Trim();
+        }
+
+        return new ChainResult(byName.Values.ToList(), chainNote, null);
+    }
+
+    /// <summary>Open <c>Scripts\&lt;class&gt;.pex</c> off the winning VFS source (loose OR BSA-packed). Returns false with
+    /// a NAMED reason (not on disk / Mutagen can't read it) — never a silent absence (Q3). Loose reads from the file
+    /// path; a BSA member is read into memory and opened from a stream (Mutagen 0.53.1 <see cref="PexFile.CreateFromStream"/>).</summary>
+    static bool TryLoadPex(AssetResolver.AssetView av, string scriptClass, out PexFile? pex, out string? reason)
+    {
+        pex = null; reason = null;
+        var rel = $@"Scripts\{scriptClass.Replace(':', '\\')}.pex";   // a namespaced class Ns:Script lives at Scripts\Ns\Script.pex
+        var res = av.ResolveForPlacement(rel);
+        if (res.Sources.Count == 0)
+        {
+            reason = $"'{rel}' is not on disk (the script is not compiled, or not in the load order){(av.ReadIncomplete ? " — and a BSA failed to read this build, so it may merely be unscanned" : "")}.";
+            return false;
+        }
+        var src = res.Sources[0];   // winner first
+        try
+        {
+            if (src.LooseFilePath is not null)
+                pex = PexFile.CreateFromFile(src.LooseFilePath, GameCategory.Skyrim);
+            else if (src.ArchivePath is not null)
+            {
+                var bytes = AssetResolver.TryReadArchiveEntry(src.ArchivePath, src.EntryPath);
+                if (bytes is null) { reason = $"'{rel}' vanished from '{Path.GetFileName(src.ArchivePath)}' between listing and read."; return false; }
+                using var ms = new MemoryStream(bytes);
+                pex = PexFile.CreateFromStream(ms, GameCategory.Skyrim);
+            }
+            else { reason = $"'{rel}' resolved to no readable source."; return false; }
+            return true;
+        }
+        catch (Exception ex)
+        {
+            pex = null;
+            reason = $"Mutagen cannot read '{rel}' ({ex.GetType().Name}: {ex.Message}) — the known unreadable-pex class.";
+            return false;
+        }
+    }
+
+    /// <summary>A property TYPE is a scalar (Int/Float/Bool/String) — leaving it unbound defaults to 0/0.0/false/"".
+    /// Everything else (a form type, or an array) is an OBJECT type: unbound ⇒ <c>None</c>, the silent-no-op footgun.</summary>
+    static bool IsObjectType(string typeName)
+        => !(typeName.Equals("Int", StringComparison.OrdinalIgnoreCase)
+             || typeName.Equals("Float", StringComparison.OrdinalIgnoreCase)
+             || typeName.Equals("Bool", StringComparison.OrdinalIgnoreCase)
+             || typeName.Equals("String", StringComparison.OrdinalIgnoreCase));
+}
+
+/// <summary>One Auto property declared in a record's attached script (or an ancestor) but NOT bound in the record's
+/// VMAD. <paramref name="Script"/> is the attached class; <paramref name="DeclaringScript"/> is where the property is
+/// declared (the class itself or an ancestor it extends). <paramref name="IsObjectType"/> = a form/object type whose
+/// unbound value is <c>None</c> (HIGH risk) vs a scalar (MEDIUM).</summary>
+public sealed record UnboundProperty(string Script, string DeclaringScript, string PropertyName, string PexTypeName, bool IsObjectType);
+
+/// <summary>One object property present in the VMAD but with a NULL Object link — the same <c>None</c> at runtime,
+/// but more often intentional (a slot filled at runtime), so it is advisory.</summary>
+public sealed record NullObjectProperty(string Script, string PropertyName);
+
+/// <summary>A script attachment houseCARL could not fully check, with the NAMED reason (its <c>.pex</c> is not on disk /
+/// unreadable, an ancestor .pex was missing so the chain was truncated, or the attachment had no class name) —
+/// surfaced, never a silent pass (Q3).</summary>
+public sealed record ScriptUnverifiable(string Script, string Reason);
+
+/// <summary>Every script-property finding on one record: its unbound properties (the primary findings), bound-but-null
+/// object properties (advisory), and any unverifiable script attachments — OR, when the plugin's own record enumeration
+/// faulted, a <paramref name="ScanError"/>.</summary>
+public sealed record RecordScriptFindings(
+    FormKey Record, string RecordType, string? EditorId, string Plugin,
+    IReadOnlyList<UnboundProperty> Unbound, IReadOnlyList<NullObjectProperty> NullObjects,
+    IReadOnlyList<ScriptUnverifiable> Unverifiable, string? ScanError = null)
+{
+    public static RecordScriptFindings PluginScanError(string plugin, string error) =>
+        new(FormKey.Null, "", null, plugin,
+            Array.Empty<UnboundProperty>(), Array.Empty<NullObjectProperty>(),
+            Array.Empty<ScriptUnverifiable>(), error);
+}
+
+/// <summary>The result of <see cref="ScriptPropertyCheck.Run"/>: the per-record findings (only records WITH findings;
+/// clean scripted records are counted in <paramref name="RecordsWithScripts"/> but omitted), the sweep totals, whether
+/// the finding list was capped, whether a BSA failed to read this build (so a "not on disk" may be unscanned), the
+/// plugins the index build excluded, and — on a Q3 scope error — a recoverable <see cref="Error"/> with no reports.</summary>
+public sealed record ScriptCheckResult(
+    IReadOnlyList<RecordScriptFindings> Reports,
+    int PluginsScanned,
+    int RecordsWithScripts,
+    int TotalUnbound,
+    int TotalNullObject,
+    int TotalUnverifiable,
+    bool Capped,
+    bool ReadIncomplete,
+    IReadOnlyDictionary<string, string> ExcludedPlugins,
+    string? Error)
+{
+    public bool Success => Error is null;
+    public static ScriptCheckResult Fail(string error) =>
+        new(Array.Empty<RecordScriptFindings>(), 0, 0, 0, 0, 0, false, false,
+            new Dictionary<string, string>(), error);
+}

--- a/src/housecarl-core/ScriptPropertyCheck.cs
+++ b/src/housecarl-core/ScriptPropertyCheck.cs
@@ -18,7 +18,9 @@ namespace HousecarlCore;
 /// WHY THIS IS A COMPOSE-PRIMITIVES JOB (no new dependency, the <see cref="ErrorCheck"/> pattern): both halves are
 /// already modeled. The RECORD half is Mutagen's VMAD (<see cref="IHaveVirtualMachineAdapterGetter"/> →
 /// <see cref="IAVirtualMachineAdapterGetter.Scripts"/> → <see cref="IScriptEntryGetter"/> with its bound
-/// <see cref="IScriptPropertyGetter"/> list). The SCRIPT half is Mutagen's <c>.pex</c> model (<see cref="PexObject.Properties"/>,
+/// <see cref="IScriptPropertyGetter"/> list) — PLUS a QUEST's alias-attached scripts (<see cref="IQuestAdapterGetter.Aliases"/>),
+/// collected by <see cref="CollectScriptEntries"/> so an alias-bound property isn't silently skipped. The SCRIPT half is
+/// Mutagen's <c>.pex</c> model (<see cref="PexObject.Properties"/>,
 /// each an <see cref="PexObjectProperty"/> with its <c>Auto</c> flag + declared type) — the same model
 /// <see cref="PapyrusDecompiler"/> reads. The two are joined through the VFS: <see cref="AssetResolver"/> resolves
 /// <c>Scripts\&lt;class&gt;.pex</c> (loose OR BSA-packed), and each <c>.pex</c> self-declares its parent
@@ -32,8 +34,8 @@ namespace HousecarlCore;
 ///     be 50 silently becomes 0). MEDIUM. A scalar that DOES carry an initializer is NOT flagged — it has the author's
 ///     intended default, so leaving it unbound is correct, not a bug.
 ///   • BOUND-BUT-NULL object property — present in the VMAD as a <see cref="IScriptObjectPropertyGetter"/> whose Object
-///     link is null. The same <c>None</c> at runtime, but MORE often intentional (the slot exists, filled at runtime),
-///     so it is ADVISORY, ranked below the absent findings.
+///     link is null AND which is not bound to a quest alias instead (Alias &lt; 0). The same <c>None</c> at runtime, but
+///     MORE often intentional (the slot exists, filled at runtime), so it is ADVISORY, ranked below the absent findings.
 ///
 /// HONEST BOUNDARY (Q3 — the sweep claims exactly this, never more, and every degraded mode is NAMED, never silent):
 ///   • It checks <c>Auto</c> properties only — the CK-editable, silently-defaulting kind. Full properties with custom
@@ -107,14 +109,15 @@ public static class ScriptPropertyCheck
                     {
                         if (body is not IHaveVirtualMachineAdapterGetter have) continue;
                         if (have.VirtualMachineAdapter is not { } vmad) continue;
-                        if (vmad.Scripts.Count == 0) continue;
+                        var scriptEntries = CollectScriptEntries(vmad);
+                        if (scriptEntries.Count == 0) continue;
                         recordsWithScripts++;
 
                         var unbound = new List<UnboundProperty>();
                         var nulls = new List<NullObjectProperty>();
                         var unver = new List<ScriptUnverifiable>();
 
-                        foreach (var entry in vmad.Scripts)
+                        foreach (var entry in scriptEntries)
                         {
                             var scriptClass = entry.Name?.Trim();
                             if (string.IsNullOrEmpty(scriptClass))
@@ -124,9 +127,12 @@ public static class ScriptPropertyCheck
                                 continue;
                             }
 
-                            // Bound-but-null object properties: the slot exists in the VMAD, its Object link is null.
+                            // Bound-but-null object properties: the slot exists in the VMAD, its Object link is null AND
+                            // it is NOT bound to a quest alias instead (Alias >= 0). A ScriptObjectProperty binds EITHER an
+                            // Object FormLink OR a quest Alias index (Alias -1 = unset) — an alias-bound property has a null
+                            // Object by design, so flagging it as bound-but-null is a false positive (PR #145 review finding 2).
                             foreach (var p in entry.Properties)
-                                if (p is IScriptObjectPropertyGetter op && op.Object.FormKey.IsNull && !string.IsNullOrWhiteSpace(p.Name))
+                                if (p is IScriptObjectPropertyGetter op && op.Object.FormKey.IsNull && op.Alias < 0 && !string.IsNullOrWhiteSpace(p.Name))
                                     nulls.Add(new NullObjectProperty(scriptClass, p.Name!.Trim()));
 
                             var chain = ResolveChain(av, chainCache, scriptClass);
@@ -191,6 +197,22 @@ public static class ScriptPropertyCheck
 
         return new ScriptCheckResult(reports, targets.Count, recordsWithScripts, totalUnbound, totalNull,
                                      totalUnverifiable, capped, av.ReadIncomplete, view.ExcludedPlugins, null);
+    }
+
+    /// <summary>Every script attachment on the record: the adapter's own <see cref="IAVirtualMachineAdapterGetter.Scripts"/>
+    /// PLUS, for a QUEST, each alias's scripts (<see cref="IQuestAdapterGetter.Aliases"/> →
+    /// <see cref="IQuestFragmentAliasGetter.Scripts"/>). A quest binds scripts to its reference aliases in a SEPARATE
+    /// collection from its own — a property declared on an alias script (the CK's alias-fragment path) would otherwise be
+    /// swept over entirely, a false "clean" on the tool's headline quest use case (PR #145 review finding 1). Each entry
+    /// is the same <see cref="IScriptEntryGetter"/> the per-attachment cross-check handles, so alias scripts flow through
+    /// the identical property comparison.</summary>
+    static List<IScriptEntryGetter> CollectScriptEntries(IAVirtualMachineAdapterGetter vmad)
+    {
+        var entries = new List<IScriptEntryGetter>(vmad.Scripts);
+        if (vmad is IQuestAdapterGetter qa)
+            foreach (var alias in qa.Aliases)
+                entries.AddRange(alias.Scripts);
+        return entries;
     }
 
     // ---- .pex extends-chain resolution ----------------------------------------------------------------

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -46,6 +46,7 @@ public static class CiAll
         ("value-predicate-guard", ValuePredicateProbe.RunGuard),
         ("effect-chain-guard", EffectChainProbe.RunGuard),
         ("check-errors-guard", CheckErrorsProbe.RunGuard),
+        ("script-property-check-guard", ScriptPropertyCheckProbe.RunGuard),
         ("source-display-guard", SourceDisplayProbe.RunGuard),
         ("writelock-guard", WriteLockProbe.RunGuard),
         ("inplace-guard", InPlaceProbe.RunGuard),

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -35,6 +35,10 @@ if (args.Length > 0 && args[0] == "pkcu-scale-proof") return PkcuProbe.RunScaleP
 // read's freshness refresh defers while a write is in flight (never rebuilds under a serialize).
 if (args.Length > 0 && args[0] == "freshness-capture-guard") return FreshnessCaptureProbe.RunGuard(args[1..]);
 
+// Script-property binding sweep (housecarl_validate_scripts): a VMAD property declared in the attached script's .pex
+// (or an ancestor it extends) but left unbound is a silent None — the reported quest-script AddSpell(None) footgun.
+if (args.Length > 0 && args[0] == "script-property-check-guard") return ScriptPropertyCheckProbe.RunGuard(args[1..]);
+
 // Decompiler baseline hierarchy: emit vanilla-class-parents.json from the CK vanilla sources' own
 // ScriptName-extends headers (committed asset — vanilla sources don't exist on CI; regenerate on game updates).
 if (args.Length > 0 && args[0] == "class-parents") return ClassParentsEmitter.Run(args[1..]);

--- a/src/housecarl-generator/ScriptPropertyCheckProbe.cs
+++ b/src/housecarl-generator/ScriptPropertyCheckProbe.cs
@@ -1,0 +1,276 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using Mutagen.Bethesda.Pex;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SELF-CONTAINED CI REGRESSION GUARD for the SCRIPT-PROPERTY binding sweep (housecarl_validate_scripts). Drives the
+/// REAL product path (<see cref="ScriptPropertyCheck.Run"/> — what the tool calls through the thin service wrapper)
+/// against a SYNTHESIZED plugin + PLANTED .pex fixtures in TEMP — NO Skyrim.esm, so it runs in CI.
+///
+/// THE GAP (reproduced by construction — bug store 2026-07-04): a record's attached script DECLARES a property the
+/// record's VMAD never BINDS, so at runtime it is None and the code that uses it no-ops while the log looks clean. No
+/// existing tool cross-checked the VMAD's bound properties against the .pex's declared ones.
+///
+/// FIXTURE — two planted .pex (a child + the base it extends) and ONE plugin of weapons, each a scenario:
+///   • Scripts\HcSpBase.pex   — declares one Auto property: InheritedThing (ObjectReference).
+///   • Scripts\HcSpChild.pex  — extends HcSpBase; declares MySpell (Spell), MyBoundSpell (Spell), MyChance (Int, no
+///                              init), MyDefaulted (Int = 5, baked init), MyNullSpell (Spell).
+///   • wFootgun — VMAD binds HcSpChild with ONLY { MyBoundSpell→set, MyNullSpell→null }. The reported failure:
+///                MySpell + MyChance + InheritedThing declared-but-unbound; MyDefaulted suppressed (has a default);
+///                MyBoundSpell clean; MyNullSpell bound-but-null.
+///   • wClean   — VMAD binds HcSpChild with ALL six properties, every object one non-null. The no-false-positive
+///                control: a fully-bound record must produce ZERO findings.
+///   • wNoPex   — VMAD binds HcSpNoPex, whose .pex is NOT planted → UNVERIFIABLE, never passed clean (Q3).
+///   • wNoVmad  — a script-free weapon → NOT counted, NEVER nagged.
+///
+/// Arms (ALL required — a GREEN must mean "the contract holds"):
+///   PEX-ROUNDTRIP   — the planted HcSpChild.pex reads back with MySpell as an Auto property (the fixture is valid).
+///   FOOTGUN-OBJECT  — wFootgun's unbound set contains MySpell, typed as an OBJECT (the silent-None class, the report).
+///   CHAIN-WALK      — wFootgun's unbound set contains InheritedThing, declared in the ANCESTOR HcSpBase.
+///   SCALAR-UNINIT   — wFootgun's unbound set contains MyChance (Int, no baked default), typed as a SCALAR.
+///   SCALAR-SUPPRESS — wFootgun's unbound set does NOT contain MyDefaulted (a baked default ⇒ not a silent-wrong).
+///   BOUND-CLEAN     — wFootgun's unbound set does NOT contain MyBoundSpell (it is bound + set).
+///   NULL-ADVISORY   — wFootgun's bound-but-null set contains MyNullSpell (the same None, advisory).
+///   CLEAN-CONTROL   — wClean produces NO report (fully bound ⇒ zero findings: the no-false-positive teeth).
+///   NO-VMAD-IGNORE  — wNoVmad produces NO report and is not counted among records-with-scripts.
+///   UNVERIFIABLE    — wNoPex names HcSpNoPex unverifiable ("not on disk"), never a silent clean (Q3).
+///   RECORDS-COUNT   — exactly 3 records carry scripts (footgun, clean, noPex — noVmad excluded).
+///   SCOPE-Q3        — scope=[a name not in the order] fails LOUD ("not in the load order"), no reports.
+///
+/// Run: dotnet run --project src/housecarl-generator -- script-property-check-guard
+/// </summary>
+public static class ScriptPropertyCheckProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("script-property-check-guard — VMAD script-property binding sweep (housecarl_validate_scripts)");
+        Console.WriteLine();
+        var tmpDir = Path.Combine(Path.GetTempPath(), "hc-script-prop-guard-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tmpDir);
+        try { return RunChecks(tmpDir); }
+        finally { try { Directory.Delete(tmpDir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    static int RunChecks(string tmpDir)
+    {
+        int failures = 0;
+        void Check(string label, bool ok, string? detail = null)
+        {
+            Console.WriteLine($"  {(ok ? "PASS" : "FAIL")}  {label}{(ok || detail is null ? "" : $"\n        -> {detail}")}");
+            if (!ok) failures++;
+        }
+
+        // ---- 1) plant the two .pex fixtures under <tmpDir>\Scripts (the loose "Data" root). ----
+        var scriptsDir = Path.Combine(tmpDir, "Scripts");
+        Directory.CreateDirectory(scriptsDir);
+        try
+        {
+            WritePex(Path.Combine(scriptsDir, "HcSpBase.pex"), "HcSpBase", parent: null,
+                AutoObj("InheritedThing", "ObjectReference"));
+
+            WritePex(Path.Combine(scriptsDir, "HcSpChild.pex"), "HcSpChild", parent: "HcSpBase",
+                AutoObj("MySpell", "Spell"),
+                AutoObj("MyBoundSpell", "Spell"),
+                AutoScalar("MyChance", "Int", initInt: null),
+                AutoScalar("MyDefaulted", "Int", initInt: 5),   // a baked default ⇒ NOT flagged when unbound
+                AutoObj("MyNullSpell", "Spell"));
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"error: could not write .pex fixtures: {ex.GetType().Name}: {(ex.InnerException ?? ex).Message}");
+            return 1;
+        }
+
+        // PEX-ROUNDTRIP — the fixture is a valid .pex whose Auto property table survives the write.
+        try
+        {
+            var back = PexFile.CreateFromFile(Path.Combine(scriptsDir, "HcSpChild.pex"), GameCategory.Skyrim);
+            var o = back.Objects.FirstOrDefault();
+            var mySpell = o?.Properties.FirstOrDefault(p => string.Equals(p.Name, "MySpell", StringComparison.OrdinalIgnoreCase));
+            Check("PEX-ROUNDTRIP: planted HcSpChild.pex reads back with MySpell as an Auto property + parent HcSpBase",
+                mySpell is not null && mySpell.Flags.HasFlag(PropertyFlags.AutoVar)
+                && string.Equals(o!.ParentClassName, "HcSpBase", StringComparison.OrdinalIgnoreCase),
+                $"prop={(mySpell is null ? "<missing>" : $"{mySpell.Name}/Auto={mySpell.Flags.HasFlag(PropertyFlags.AutoVar)}")} parent={o?.ParentClassName}");
+        }
+        catch (Exception ex) { Check("PEX-ROUNDTRIP", false, $"{ex.GetType().Name}: {ex.Message}"); }
+
+        // ---- 2) synthesize the plugin of scripted weapons. ----
+        string pluginPath = Path.Combine(tmpDir, "HcSp.esp");
+        var mKey = new ModKey("HcSp", ModType.Plugin);
+        FormKey footgunFk, cleanFk, noPexFk, noVmadFk;
+        try
+        {
+            var mod = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
+            var self = new FormKey(mKey, 0x000801);   // a non-null in-plugin FormKey for "bound" object props (target need not exist — only IsNull is read)
+
+            // wFootgun — the reported failure shape.
+            var wFootgun = mod.Weapons.AddNew(); wFootgun.EditorID = "HcSpFootgun";
+            wFootgun.VirtualMachineAdapter = Vmad("HcSpChild",
+                ObjProp("MyBoundSpell", self), ObjProp("MyNullSpell", FormKey.Null));
+            footgunFk = wFootgun.FormKey;
+
+            // wClean — fully bound: the no-false-positive control.
+            var wClean = mod.Weapons.AddNew(); wClean.EditorID = "HcSpClean";
+            wClean.VirtualMachineAdapter = Vmad("HcSpChild",
+                ObjProp("MySpell", self), ObjProp("MyBoundSpell", self), ObjProp("MyNullSpell", self),
+                ObjProp("InheritedThing", self), IntProp("MyChance", 3), IntProp("MyDefaulted", 5));
+            cleanFk = wClean.FormKey;
+
+            // wNoPex — a script with no compiled .pex on disk.
+            var wNoPex = mod.Weapons.AddNew(); wNoPex.EditorID = "HcSpNoPex";
+            wNoPex.VirtualMachineAdapter = Vmad("HcSpNoPex");
+            noPexFk = wNoPex.FormKey;
+
+            // wNoVmad — a script-free weapon.
+            var wNoVmad = mod.Weapons.AddNew(); wNoVmad.EditorID = "HcSpNoVmad";
+            noVmadFk = wNoVmad.FormKey;
+
+            mod.BeginWrite.ToPath(pluginPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"error: could not synthesize the plugin: {ex.GetType().Name}: {(ex.InnerException ?? ex).Message}");
+            return 1;
+        }
+
+        // ---- 3) run the REAL product path over the synthesized order + planted VFS. ----
+        using var resolver = LoadOrderResolver.Build(new[] { pluginPath });
+        using var assets = AssetResolver.Build("", "", tmpDir, Array.Empty<string>(), Array.Empty<ActiveArchive>());
+
+        var res = ScriptPropertyCheck.Run(resolver, assets, null, 1000);
+        if (!res.Success) { Console.Error.WriteLine($"error: sweep failed: {res.Error}"); return 1; }
+
+        RecordScriptFindings? Rec(FormKey fk) => res.Reports.FirstOrDefault(r => r.Record == fk);
+        var foot = Rec(footgunFk);
+        bool FootUnbound(string name) => foot is not null && foot.Unbound.Any(u => u.PropertyName == name);
+
+        Check("FOOTGUN-OBJECT: wFootgun's unbound set contains MySpell, typed OBJECT (the reported silent-None)",
+            foot is not null && foot.Unbound.Any(u => u.PropertyName == "MySpell" && u.IsObjectType),
+            foot is null ? "<no report>" : string.Join(",", foot.Unbound.Select(u => $"{u.PropertyName}/{(u.IsObjectType ? "obj" : "scalar")}")));
+
+        Check("CHAIN-WALK: wFootgun's unbound set contains InheritedThing, declared in the ANCESTOR HcSpBase",
+            foot is not null && foot.Unbound.Any(u => u.PropertyName == "InheritedThing"
+                && string.Equals(u.DeclaringScript, "HcSpBase", StringComparison.OrdinalIgnoreCase)),
+            foot is null ? "<no report>" : string.Join(",", foot.Unbound.Select(u => $"{u.PropertyName}@{u.DeclaringScript}")));
+
+        Check("SCALAR-UNINIT: wFootgun's unbound set contains MyChance (Int, no default), typed SCALAR",
+            foot is not null && foot.Unbound.Any(u => u.PropertyName == "MyChance" && !u.IsObjectType),
+            foot is null ? "<no report>" : string.Join(",", foot.Unbound.Select(u => u.PropertyName)));
+
+        Check("SCALAR-SUPPRESS: wFootgun's unbound set does NOT contain MyDefaulted (a baked default ⇒ not a finding)",
+            foot is not null && !FootUnbound("MyDefaulted"),
+            foot is null ? "<no report>" : string.Join(",", foot.Unbound.Select(u => u.PropertyName)));
+
+        Check("BOUND-CLEAN: wFootgun's unbound set does NOT contain MyBoundSpell (it is bound + set)",
+            foot is not null && !FootUnbound("MyBoundSpell"),
+            foot is null ? "<no report>" : string.Join(",", foot.Unbound.Select(u => u.PropertyName)));
+
+        Check("NULL-ADVISORY: wFootgun's bound-but-null set contains MyNullSpell",
+            foot is not null && foot.NullObjects.Any(n => n.PropertyName == "MyNullSpell"),
+            foot is null ? "<no report>" : string.Join(",", foot.NullObjects.Select(n => n.PropertyName)));
+
+        Check("CLEAN-CONTROL: wClean (fully bound) produces NO report (the no-false-positive teeth)",
+            Rec(cleanFk) is null,
+            Rec(cleanFk) is null ? "" : $"unexpected report: {string.Join(",", Rec(cleanFk)!.Unbound.Select(u => u.PropertyName))} null=[{string.Join(",", Rec(cleanFk)!.NullObjects.Select(n => n.PropertyName))}]");
+
+        Check("NO-VMAD-IGNORE: wNoVmad produces NO report (a script-free record is never nagged)",
+            Rec(noVmadFk) is null);
+
+        var noPex = Rec(noPexFk);
+        Check("UNVERIFIABLE: wNoPex names HcSpNoPex unverifiable ('not on disk'), never a silent clean (Q3)",
+            noPex is not null && noPex.Unverifiable.Any(u =>
+                string.Equals(u.Script, "HcSpNoPex", StringComparison.OrdinalIgnoreCase)
+                && u.Reason.Contains("not on disk", StringComparison.OrdinalIgnoreCase)),
+            noPex is null ? "<no report>" : string.Join(" | ", noPex.Unverifiable.Select(u => $"{u.Script}: {u.Reason}")));
+
+        Check("RECORDS-COUNT: exactly 3 records carry scripts (footgun, clean, noPex — noVmad excluded)",
+            res.RecordsWithScripts == 3, $"records-with-scripts={res.RecordsWithScripts}");
+
+        var q3 = ScriptPropertyCheck.Run(resolver, assets, new[] { "HcSpNotReal.esp" }, 1000);
+        Check("SCOPE-Q3: an unknown scope name fails LOUD ('not in the load order'), no reports",
+            !q3.Success && q3.Reports.Count == 0 && q3.Error is not null
+            && q3.Error.Contains("not in the load order", StringComparison.Ordinal),
+            $"success={q3.Success} reports={q3.Reports.Count} err=[{q3.Error}]");
+
+        Console.WriteLine();
+        Console.WriteLine(failures == 0 ? "script-property-check-guard: ALL PASS" : $"script-property-check-guard: {failures} FAILURE(S)");
+        return failures == 0 ? 0 : 1;
+    }
+
+    // ---- fixture builders --------------------------------------------------------------------------
+
+    /// <summary>A VMAD binding ONE script <paramref name="scriptClass"/> with the given bound properties.</summary>
+    static VirtualMachineAdapter Vmad(string scriptClass, params ScriptProperty[] props)
+    {
+        var entry = new ScriptEntry { Name = scriptClass };
+        foreach (var p in props) entry.Properties.Add(p);
+        var vmad = new VirtualMachineAdapter();
+        vmad.Scripts.Add(entry);
+        return vmad;
+    }
+
+    static ScriptObjectProperty ObjProp(string name, FormKey obj)
+    {
+        var p = new ScriptObjectProperty { Name = name, Alias = -1 };
+        if (!obj.IsNull) p.Object.SetTo(obj);
+        return p;
+    }
+
+    static ScriptIntProperty IntProp(string name, int data) => new() { Name = name, Data = data };
+
+    /// <summary>One Auto property to plant in a .pex: the property record + its backing variable (every auto property
+    /// has one, <c>::Name_var</c> — an object/scalar with no initializer carries Null data, an initialized scalar
+    /// carries the baked literal). Modeled on a real Skyrim .pex: an Auto property is Flags = Read|Write|AutoVar with
+    /// NO handler functions (the backing var IS the handler), a non-null DocString, and the autovar name set.</summary>
+    sealed record Decl(PexObjectProperty Prop, PexObjectVariable Backing);
+
+    static Decl Auto(string name, string typeName, int? initInt)
+    {
+        var prop = new PexObjectProperty
+        {
+            Name = name,
+            TypeName = typeName,
+            DocString = "",
+            Flags = PropertyFlags.Read | PropertyFlags.Write | PropertyFlags.AutoVar,
+            AutoVarName = $"::{name}_var",
+        };
+        var data = initInt is int v
+            ? new PexObjectVariableData { VariableType = VariableType.Integer, IntValue = v }
+            : new PexObjectVariableData { VariableType = VariableType.Null };
+        var backing = new PexObjectVariable { Name = $"::{name}_var", TypeName = typeName, VariableData = data };
+        return new Decl(prop, backing);
+    }
+
+    /// <summary>An Auto object/form property (no baked default — a FormID can't be a literal).</summary>
+    static Decl AutoObj(string name, string typeName) => Auto(name, typeName, null);
+
+    /// <summary>An Auto scalar property, optionally with a baked initializer on its backing variable.</summary>
+    static Decl AutoScalar(string name, string typeName, int? initInt) => Auto(name, typeName, initInt);
+
+    /// <summary>Write a single-object .pex with the given Auto properties + backing variables to <paramref name="path"/>
+    /// via Mutagen's native Pex writer. The object carries a non-null DocString, an empty auto-state, and the empty
+    /// '' state — the minimal byte-valid shell a real Skyrim .pex has (verified round-trippable, see --diag).</summary>
+    static void WritePex(string path, string name, string? parent, params Decl[] decls)
+    {
+        var obj = new PexObject { Name = name, ParentClassName = parent ?? "", DocString = "", AutoStateName = "" };
+        obj.States.Add(new PexObjectState { Name = "" });
+        foreach (var d in decls) { obj.Properties.Add(d.Prop); obj.Variables.Add(d.Backing); }
+
+        var pex = new PexFile(GameCategory.Skyrim)
+        {
+            MajorVersion = 3,
+            MinorVersion = 2,
+            GameId = 1,
+            CompilationTime = default,
+            SourceFileName = name + ".psc",
+            Username = "hc",
+            MachineName = "ci",
+        };
+        pex.Objects.Add(obj);
+        pex.WritePexFile(path, GameCategory.Skyrim);   // Mutagen 0.53.1 PexMixIn.WritePexFile(outputPath, gameCategory)
+    }
+}

--- a/src/housecarl-generator/ScriptPropertyCheckProbe.cs
+++ b/src/housecarl-generator/ScriptPropertyCheckProbe.cs
@@ -18,28 +18,32 @@ namespace HousecarlGenerator;
 /// FIXTURE — two planted .pex (a child + the base it extends) and ONE plugin of weapons, each a scenario:
 ///   • Scripts\HcSpBase.pex   — declares one Auto property: InheritedThing (ObjectReference).
 ///   • Scripts\HcSpChild.pex  — extends HcSpBase; declares MySpell (Spell), MyBoundSpell (Spell), MyChance (Int, no
-///                              init), MyDefaulted (Int = 5, baked init), MyNullSpell (Spell).
-///   • wFootgun — VMAD binds HcSpChild with ONLY { MyBoundSpell→set, MyNullSpell→null }. The reported failure:
-///                MySpell + MyChance + InheritedThing declared-but-unbound; MyDefaulted suppressed (has a default);
-///                MyBoundSpell clean; MyNullSpell bound-but-null.
-///   • wClean   — VMAD binds HcSpChild with ALL six properties, every object one non-null. The no-false-positive
-///                control: a fully-bound record must produce ZERO findings.
+///                              init), MyDefaulted (Int = 5, baked init), MyAliasBound (Spell), MyNullSpell (Spell).
+///   • wFootgun — VMAD binds HcSpChild with { MyBoundSpell→set, MyNullSpell→null, MyAliasBound→Alias 2 }. The reported
+///                failure: MySpell + MyChance + InheritedThing declared-but-unbound; MyDefaulted suppressed (has a
+///                default); MyBoundSpell clean; MyNullSpell bound-but-null; MyAliasBound bound-via-alias (neither).
+///   • wClean   — VMAD binds HcSpChild with ALL properties, every object one non-null. The no-false-positive control:
+///                a fully-bound record must produce ZERO findings.
 ///   • wNoPex   — VMAD binds HcSpNoPex, whose .pex is NOT planted → UNVERIFIABLE, never passed clean (Q3).
 ///   • wNoVmad  — a script-free weapon → NOT counted, NEVER nagged.
+///   • aliasQuest — a QUST whose script is attached to a QuestAdapter ALIAS (not the quest's own Scripts), binding
+///                nothing → its declared MySpell is unbound. Proves alias scripts are swept (finding 1).
 ///
 /// Arms (ALL required — a GREEN must mean "the contract holds"):
-///   PEX-ROUNDTRIP   — the planted HcSpChild.pex reads back with MySpell as an Auto property (the fixture is valid).
-///   FOOTGUN-OBJECT  — wFootgun's unbound set contains MySpell, typed as an OBJECT (the silent-None class, the report).
-///   CHAIN-WALK      — wFootgun's unbound set contains InheritedThing, declared in the ANCESTOR HcSpBase.
-///   SCALAR-UNINIT   — wFootgun's unbound set contains MyChance (Int, no baked default), typed as a SCALAR.
-///   SCALAR-SUPPRESS — wFootgun's unbound set does NOT contain MyDefaulted (a baked default ⇒ not a silent-wrong).
-///   BOUND-CLEAN     — wFootgun's unbound set does NOT contain MyBoundSpell (it is bound + set).
-///   NULL-ADVISORY   — wFootgun's bound-but-null set contains MyNullSpell (the same None, advisory).
-///   CLEAN-CONTROL   — wClean produces NO report (fully bound ⇒ zero findings: the no-false-positive teeth).
-///   NO-VMAD-IGNORE  — wNoVmad produces NO report and is not counted among records-with-scripts.
-///   UNVERIFIABLE    — wNoPex names HcSpNoPex unverifiable ("not on disk"), never a silent clean (Q3).
-///   RECORDS-COUNT   — exactly 3 records carry scripts (footgun, clean, noPex — noVmad excluded).
-///   SCOPE-Q3        — scope=[a name not in the order] fails LOUD ("not in the load order"), no reports.
+///   PEX-ROUNDTRIP        — the planted HcSpChild.pex reads back with MySpell as an Auto property (the fixture is valid).
+///   FOOTGUN-OBJECT       — wFootgun's unbound set contains MySpell, typed OBJECT (the silent-None class, the report).
+///   CHAIN-WALK           — wFootgun's unbound set contains InheritedThing, declared in the ANCESTOR HcSpBase.
+///   SCALAR-UNINIT        — wFootgun's unbound set contains MyChance (Int, no baked default), typed SCALAR.
+///   SCALAR-SUPPRESS      — wFootgun's unbound set does NOT contain MyDefaulted (a baked default ⇒ not a silent-wrong).
+///   BOUND-CLEAN          — wFootgun's unbound set does NOT contain MyBoundSpell (it is bound + set).
+///   NULL-ADVISORY        — wFootgun's bound-but-null set contains MyNullSpell (the same None, advisory).
+///   ALIAS-BOUND-NOT-NULL — MyAliasBound (Object null, Alias>=0) is NEITHER unbound NOR bound-but-null (finding 2).
+///   ALIAS-SCRIPT-SWEPT   — aliasQuest's alias-attached script is checked; its unbound set contains MySpell (finding 1).
+///   CLEAN-CONTROL        — wClean produces NO report (fully bound ⇒ zero findings: the no-false-positive teeth).
+///   NO-VMAD-IGNORE       — wNoVmad produces NO report and is not counted among records-with-scripts.
+///   UNVERIFIABLE         — wNoPex names HcSpNoPex unverifiable ("not on disk"), never a silent clean (Q3).
+///   RECORDS-COUNT        — exactly 4 records carry scripts (footgun, clean, noPex, aliasQuest — noVmad excluded).
+///   SCOPE-Q3             — scope=[a name not in the order] fails LOUD ("not in the load order"), no reports.
 ///
 /// Run: dotnet run --project src/housecarl-generator -- script-property-check-guard
 /// </summary>
@@ -77,6 +81,7 @@ public static class ScriptPropertyCheckProbe
                 AutoObj("MyBoundSpell", "Spell"),
                 AutoScalar("MyChance", "Int", initInt: null),
                 AutoScalar("MyDefaulted", "Int", initInt: 5),   // a baked default ⇒ NOT flagged when unbound
+                AutoObj("MyAliasBound", "Spell"),               // bound via a quest Alias (Object null but Alias>=0) — NOT a null finding
                 AutoObj("MyNullSpell", "Spell"));
         }
         catch (Exception ex)
@@ -101,23 +106,24 @@ public static class ScriptPropertyCheckProbe
         // ---- 2) synthesize the plugin of scripted weapons. ----
         string pluginPath = Path.Combine(tmpDir, "HcSp.esp");
         var mKey = new ModKey("HcSp", ModType.Plugin);
-        FormKey footgunFk, cleanFk, noPexFk, noVmadFk;
+        FormKey footgunFk, cleanFk, noPexFk, noVmadFk, aliasQuestFk;
         try
         {
             var mod = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
             var self = new FormKey(mKey, 0x000801);   // a non-null in-plugin FormKey for "bound" object props (target need not exist — only IsNull is read)
 
-            // wFootgun — the reported failure shape.
+            // wFootgun — the reported failure shape. MyAliasBound is bound via a quest alias (Object null, Alias>=0):
+            // it must count as BOUND (not unbound) and must NOT be flagged bound-but-null (finding 2).
             var wFootgun = mod.Weapons.AddNew(); wFootgun.EditorID = "HcSpFootgun";
             wFootgun.VirtualMachineAdapter = Vmad("HcSpChild",
-                ObjProp("MyBoundSpell", self), ObjProp("MyNullSpell", FormKey.Null));
+                ObjProp("MyBoundSpell", self), ObjProp("MyNullSpell", FormKey.Null), AliasProp("MyAliasBound", 2));
             footgunFk = wFootgun.FormKey;
 
             // wClean — fully bound: the no-false-positive control.
             var wClean = mod.Weapons.AddNew(); wClean.EditorID = "HcSpClean";
             wClean.VirtualMachineAdapter = Vmad("HcSpChild",
                 ObjProp("MySpell", self), ObjProp("MyBoundSpell", self), ObjProp("MyNullSpell", self),
-                ObjProp("InheritedThing", self), IntProp("MyChance", 3), IntProp("MyDefaulted", 5));
+                ObjProp("MyAliasBound", self), ObjProp("InheritedThing", self), IntProp("MyChance", 3), IntProp("MyDefaulted", 5));
             cleanFk = wClean.FormKey;
 
             // wNoPex — a script with no compiled .pex on disk.
@@ -128,6 +134,17 @@ public static class ScriptPropertyCheckProbe
             // wNoVmad — a script-free weapon.
             var wNoVmad = mod.Weapons.AddNew(); wNoVmad.EditorID = "HcSpNoVmad";
             noVmadFk = wNoVmad.FormKey;
+
+            // aliasQuest — a QUST whose script is attached to an ALIAS (QuestAdapter.Aliases[].Scripts), NOT the quest's
+            // own Scripts. The alias script binds nothing, so its declared MySpell is unbound — a property the sweep must
+            // find. Before the finding-1 fix this record produced NO report (a false clean on the headline quest case).
+            var quest = mod.Quests.AddNew(); quest.EditorID = "HcSpAliasQuest";
+            var qAdapter = new QuestAdapter();
+            var qAlias = new QuestFragmentAlias { Property = new ScriptObjectProperty { Alias = 0 } };
+            qAlias.Scripts.Add(new ScriptEntry { Name = "HcSpChild" });   // bound properties left empty → all declared are unbound
+            qAdapter.Aliases.Add(qAlias);
+            quest.VirtualMachineAdapter = qAdapter;
+            aliasQuestFk = quest.FormKey;
 
             mod.BeginWrite.ToPath(pluginPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
         }
@@ -173,6 +190,16 @@ public static class ScriptPropertyCheckProbe
             foot is not null && foot.NullObjects.Any(n => n.PropertyName == "MyNullSpell"),
             foot is null ? "<no report>" : string.Join(",", foot.NullObjects.Select(n => n.PropertyName)));
 
+        Check("ALIAS-BOUND-NOT-NULL: MyAliasBound (Object null, Alias>=0) is NOT flagged bound-but-null and NOT unbound (finding 2)",
+            foot is not null && !foot.NullObjects.Any(n => n.PropertyName == "MyAliasBound")
+                && !FootUnbound("MyAliasBound"),
+            foot is null ? "<no report>" : $"null=[{string.Join(",", foot.NullObjects.Select(n => n.PropertyName))}] unbound=[{string.Join(",", foot.Unbound.Select(u => u.PropertyName))}]");
+
+        var aq = Rec(aliasQuestFk);
+        Check("ALIAS-SCRIPT-SWEPT: a QUST's alias-attached script is checked — its unbound set contains MySpell (finding 1)",
+            aq is not null && aq.Unbound.Any(u => u.PropertyName == "MySpell"),
+            aq is null ? "<no report — alias scripts silently skipped>" : string.Join(",", aq.Unbound.Select(u => u.PropertyName)));
+
         Check("CLEAN-CONTROL: wClean (fully bound) produces NO report (the no-false-positive teeth)",
             Rec(cleanFk) is null,
             Rec(cleanFk) is null ? "" : $"unexpected report: {string.Join(",", Rec(cleanFk)!.Unbound.Select(u => u.PropertyName))} null=[{string.Join(",", Rec(cleanFk)!.NullObjects.Select(n => n.PropertyName))}]");
@@ -187,8 +214,8 @@ public static class ScriptPropertyCheckProbe
                 && u.Reason.Contains("not on disk", StringComparison.OrdinalIgnoreCase)),
             noPex is null ? "<no report>" : string.Join(" | ", noPex.Unverifiable.Select(u => $"{u.Script}: {u.Reason}")));
 
-        Check("RECORDS-COUNT: exactly 3 records carry scripts (footgun, clean, noPex — noVmad excluded)",
-            res.RecordsWithScripts == 3, $"records-with-scripts={res.RecordsWithScripts}");
+        Check("RECORDS-COUNT: exactly 4 records carry scripts (footgun, clean, noPex, aliasQuest — noVmad excluded)",
+            res.RecordsWithScripts == 4, $"records-with-scripts={res.RecordsWithScripts}");
 
         var q3 = ScriptPropertyCheck.Run(resolver, assets, new[] { "HcSpNotReal.esp" }, 1000);
         Check("SCOPE-Q3: an unknown scope name fails LOUD ('not in the load order'), no reports",
@@ -219,6 +246,10 @@ public static class ScriptPropertyCheckProbe
         if (!obj.IsNull) p.Object.SetTo(obj);
         return p;
     }
+
+    /// <summary>An object property bound to a quest ALIAS (Alias &gt;= 0), Object left null — the healthy shape that must
+    /// NOT read as bound-but-null (PR #145 review finding 2).</summary>
+    static ScriptObjectProperty AliasProp(string name, short alias) => new() { Name = name, Alias = alias };
 
     static ScriptIntProperty IntProp(string name, int data) => new() { Name = name, Data = data };
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1060,6 +1060,17 @@ public sealed class LoadOrderService : IDisposable
     public ErrorCheckResult CheckErrors(IReadOnlyList<string>? plugins, int limit)
         => ErrorCheck.Run(Resolver, plugins, limit);
 
+    // ---- script-property sweep (housecarl_validate_scripts) --------------------------------------------
+
+    /// <summary>Sweep the active order (or the given <paramref name="plugins"/> scope) for VMAD script properties that
+    /// are declared in the attached script's .pex (or an ancestor it extends) but left UNBOUND on the record — a silent
+    /// <c>None</c> (housecarl_validate_scripts). Thin wiring over the core <see cref="ScriptPropertyCheck.Run"/>, which
+    /// holds all the cross-check logic + Q3 teeth so the self-contained guard drives this same path over synthetic
+    /// records + a planted .pex. Passes the live <see cref="Assets"/> resolver (the same one the dialogue validator and
+    /// facegen use) so a script's .pex is found loose OR BSA-packed. Read-only; composes existing primitives.</summary>
+    public ScriptCheckResult ValidateScripts(IReadOnlyList<string>? plugins, int limit)
+        => ScriptPropertyCheck.Run(Resolver, Assets, plugins, limit);
+
     // ---- writes (§8.4 Beat C: housecarl_set_field / housecarl_bulk_apply) -------------------------------
 
     /// <summary>Apply one-or-more edits as a single patch (housecarl_set_field = one op; housecarl_bulk_apply = many).

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -179,6 +179,35 @@ public static class ReadTools
         var result = svc.CheckErrors(plugins, limit <= 0 ? 1000 : limit);
         return Wire.RenderCheckErrors(result, max_chars);
     });
+
+    [McpServerTool(Name = "housecarl_validate_scripts", ReadOnly = true, Title = "Check scripted records for unbound script properties"),
+     Description(
+         "Script-property binding sweep — catches the silent-None footgun a byte-valid plugin hides: a record whose " +
+         "attached Papyrus script DECLARES a property (e.g. 'Spell Property CallVesyraPower Auto') the record's script " +
+         "data (VMAD) never BINDS, so at runtime it is None and the code that uses it no-ops while the log looks clean " +
+         "(the maximally-misleading 'the function ran, the effect is absent' class — the same as the Creation Kit's " +
+         "auto-add-property bug). For each record carrying a script it reads the attached script's compiled .pex — and " +
+         "every script it EXTENDS — from the load order (loose or BSA), and reports: (1) UNBOUND properties declared " +
+         "but not bound (an object/form type ⇒ None ⇒ the silent no-op, ranked first; an uninitialized scalar ⇒ a " +
+         "0/false/\"\" default that may be wrong); (2) BOUND-BUT-NULL object properties (advisory — sometimes filled at " +
+         "runtime). Read-only. BOUNDARY (never a silent claim of more — Q3): it checks Auto (CK-editable) properties " +
+         "only, not code-driven full properties; 'unbound may be intentional' (a runtime-filled link), so a finding is " +
+         "a flag to VERIFY; and if a script's .pex is not on disk (uncompiled / not in the order) the attachment is " +
+         "reported UNVERIFIABLE, never passed clean. Scope to one plugin for a fast focused check, or omit to sweep the " +
+         "whole active order. Results cap at limit= and max_chars (both overruns explicit).")]
+    public static string ValidateScriptsTool(
+        LoadOrderService svc,
+        [Description("Optional. Plugin filenames to check (e.g. 'MyMod.esp'). A name not in the load order is an error. Omit to sweep the WHOLE active order (every scripted record in every non-excluded plugin) — thorough but heavier; scope to one plugin for a fast, focused check.")]
+            string[]? plugins = null,
+        [Description("Optional. Max property findings (unbound + bound-but-null) to list across the whole sweep (default 1000). The TRUE totals are always reported; over the cap it says so. Unverifiable notes are always listed in full (they are few).")]
+            int limit = 1000,
+        [Description("Optional. Max characters before the response stops with an explicit notice. 0 = the server default (~80k).")]
+            int max_chars = 0) => Guard.Tool("housecarl_validate_scripts", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        var result = svc.ValidateScripts(plugins, limit <= 0 ? 1000 : limit);
+        return Wire.RenderScriptCheck(result, max_chars);
+    });
 }
 
 /// <summary>Compact, parseable `key = value` rendering (Q4.8 lever 1) + the winner-relative conflict diff
@@ -394,6 +423,87 @@ static class Wire
 
         sb.Append("\nboundary: checks FormLink resolution, missing masters, and parse failures. Does NOT verify navmesh/terrain ")
           .Append("spatial integrity (CRC/grid), flag required-but-null fields, or list unused-master cleanup; a null FormLink is a legal optional.\n");
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    // ---- housecarl_validate_scripts -----------------------------------------------------------------
+    public static string RenderScriptCheck(ScriptCheckResult r, int maxChars)
+    {
+        if (r.Error is not null) return "error: " + r.Error;
+        int cap = Cap(maxChars);
+        var sb = new StringBuilder();
+
+        sb.Append("validate_scripts — VMAD script-property binding sweep\n");
+        sb.Append("scanned ").Append(r.PluginsScanned).Append(r.PluginsScanned == 1 ? " plugin · " : " plugins · ")
+          .Append(r.RecordsWithScripts).Append(" record(s) with scripts · ")
+          .Append(r.TotalUnbound).Append(" unbound · ")
+          .Append(r.TotalNullObject).Append(" bound-but-null · ")
+          .Append(r.TotalUnverifiable).Append(" unverifiable");
+        if (r.ExcludedPlugins.Count > 0)
+            sb.Append(" · ").Append(r.ExcludedPlugins.Count).Append(" plugin(s) excluded (unparseable)");
+        sb.Append('\n');
+        if (r.ReadIncomplete)
+            sb.Append("note: a BSA failed to read this build — a '.pex not on disk' below may merely be unscanned, not truly absent (Q3).\n");
+
+        if (r.Reports.Count == 0 && r.ExcludedPlugins.Count == 0)
+            sb.Append("\nNo unbound script properties found in the scanned scope.\n");
+
+        bool truncated = false;
+        foreach (var rec in r.Reports)
+        {
+            if (sb.Length >= cap)
+            {
+                sb.Append("\n... [truncated at max_chars=").Append(cap).Append("; scope plugins= or raise max_chars to see the rest]\n");
+                truncated = true;
+                break;
+            }
+            if (rec.ScanError is not null) { sb.Append("\n[SCAN ERROR] ").Append(rec.Plugin).Append(": ").Append(rec.ScanError).Append('\n'); continue; }
+
+            sb.Append('\n').Append(rec.Unbound.Count > 0 ? "[UNBOUND] " : "[CHECK] ")
+              .Append(rec.Record).Append(" (").Append(rec.RecordType);
+            if (!string.IsNullOrEmpty(rec.EditorId)) sb.Append(" '").Append(rec.EditorId).Append('\'');
+            sb.Append(") in ").Append(rec.Plugin).Append('\n');
+
+            // Unbound findings, object/form types (silent None) FIRST, then uninitialized scalars.
+            foreach (var u in rec.Unbound.OrderByDescending(u => u.IsObjectType))
+            {
+                if (sb.Length >= cap) break;
+                sb.Append("  ").Append(u.IsObjectType ? "! " : "· ")
+                  .Append(u.PropertyName).Append(" (").Append(u.PexTypeName).Append(") on script ").Append(u.Script);
+                if (!string.Equals(u.DeclaringScript, u.Script, StringComparison.OrdinalIgnoreCase))
+                    sb.Append(" [declared in ").Append(u.DeclaringScript).Append(']');
+                sb.Append(u.IsObjectType
+                    ? " — declared but NOT bound → None at runtime (HIGH: object/form type — the silent no-op)\n"
+                    : " — declared but NOT bound → defaults to 0/false/\"\" (scalar, no baked default)\n");
+            }
+            if (rec.NullObjects.Count > 0)
+                sb.Append("  bound-but-null object propert").Append(rec.NullObjects.Count == 1 ? "y: " : "ies: ")
+                  .Append(string.Join(", ", rec.NullObjects.Select(n => $"{n.PropertyName} ({n.Script})")))
+                  .Append("   [advisory — a None link; sometimes intentional, filled at runtime]\n");
+            foreach (var uv in rec.Unverifiable)
+            {
+                if (sb.Length >= cap) break;
+                sb.Append("  could not verify script ").Append(uv.Script).Append(": ").Append(uv.Reason).Append('\n');
+            }
+        }
+
+        if (r.Capped)
+            sb.Append("\n[finding list capped at limit; true totals = ").Append(r.TotalUnbound).Append(" unbound + ")
+              .Append(r.TotalNullObject).Append(" bound-but-null — raise limit= to see all]\n");
+
+        if (!truncated && r.ExcludedPlugins.Count > 0)
+        {
+            sb.Append("\nexcluded plugins (could not be parsed — NOT checked):\n");
+            foreach (var kv in r.ExcludedPlugins)
+            {
+                if (sb.Length >= cap) break;
+                sb.Append("  ").Append(kv.Key).Append(": ").Append(kv.Value).Append('\n');
+            }
+        }
+
+        sb.Append("\nboundary: checks Auto (CK-editable) properties across the extends chain — not code-driven full ")
+          .Append("properties. An unbound object property is the silent-None footgun, but CAN be intentional (filled at runtime) — a ")
+          .Append("finding is a flag to VERIFY. A script whose .pex is not on disk is reported unverifiable, never passed clean.\n");
         return sb.ToString().TrimEnd('\n');
     }
 

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -476,7 +476,7 @@ static class Wire
                     ? " — declared but NOT bound → None at runtime (HIGH: object/form type — the silent no-op)\n"
                     : " — declared but NOT bound → defaults to 0/false/\"\" (scalar, no baked default)\n");
             }
-            if (rec.NullObjects.Count > 0)
+            if (rec.NullObjects.Count > 0 && sb.Length < cap)
                 sb.Append("  bound-but-null object propert").Append(rec.NullObjects.Count == 1 ? "y: " : "ies: ")
                   .Append(string.Join(", ", rec.NullObjects.Select(n => $"{n.PropertyName} ({n.Script})")))
                   .Append("   [advisory — a None link; sometimes intentional, filled at runtime]\n");


### PR DESCRIPTION
## The gap (bug store 2026-07-04)

A record's attached Papyrus script DECLARES a property — e.g. `Spell Property CallVesyraPower Auto` — the code guards on it, and the record's script data (VMAD) never BINDS it → a silent `None`, so `AddSpell(None)` no-ops while the trace logs "power granted". Maximally misleading (function runs, effect absent, logs clean), the same class as the CK's STMain auto-add bug. `check_errors` walks FormLinks; `validate_dialogue` checks fragment binding; **nothing cross-checked a record's bound VMAD properties against the script's declared ones.**

## What this adds — `housecarl_validate_scripts` (read-only)

For every record carrying a VMAD it reads the attached script's compiled `.pex` **AND every script it `extends`** (each `.pex` self-declares its parent — no external hierarchy map), then reports:

- **Unbound object property** (Spell, Quest, ObjectReference…) — `None` at runtime, the silent no-op, ranked first (HIGH).
- **Unbound uninitialized scalar** — defaults to `0/false/""`, may be wrong (MEDIUM).
- **Bound-but-null object property** — the same `None`, but more often intentional (runtime-filled), so advisory.

Composed from existing primitives (no new dependency, the `ErrorCheck` pattern): both halves were already modeled — Mutagen's VMAD (`IHaveVirtualMachineAdapterGetter`) and `.pex` (`PexObject.Properties`) — joined through the `AssetResolver` VFS, so a script's `.pex` is found **loose or BSA-packed**.

## Q3 boundaries (never a silent claim of more)

- Checks **Auto** (CK-editable) properties only — full properties with custom Get/Set are code-driven.
- An Auto **scalar with a baked default is NOT flagged** (it has an intended default — no crying wolf).
- "Unbound may be intentional" (a runtime-filled link) — a finding is a flag to VERIFY; object-type absences ranked first.
- A script's `.pex` not on disk → the attachment is **UNVERIFIABLE**, never passed clean. A missing ancestor `.pex` truncates the chain with a named note. A bad scope name fails loud.

## Verification

- `script-property-check-guard` — a 12-arm self-contained CI guard driving the real `ScriptPropertyCheck.Run` over a synthesized plugin + planted `.pex` fixtures (including an `extends` ancestor): footgun-object / chain-walk / scalar-uninit / scalar-suppress / bound-clean / null-advisory / clean-control / no-vmad-ignore / unverifiable / records-count / scope-Q3.
- **ci-all: 71/71 PASS** (Release).

## Files

- `src/housecarl-core/ScriptPropertyCheck.cs` — the core sweep.
- `src/housecarl-mcp/ReadTools.cs` — the `housecarl_validate_scripts` tool + `RenderScriptCheck`.
- `src/housecarl-mcp/LoadOrderService.cs` — thin `ValidateScripts` wiring (passes the live `Assets` resolver).
- `src/housecarl-generator/ScriptPropertyCheckProbe.cs` + `CiAll.cs` + `Program.cs` — the CI guard + registration.

## Deferred (not in this PR)

- CHANGELOG + tool-count bump (28 → 29) at the next release cut, like the skse skill.
- Not yet run in-game against a live load order (no MO2 instance in the build env) — verified at unit/CI level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)