### PR TITLE
feat(read): housecarl_skse_inventory — SKSE-plugin-layer visibility (tiers A+C)

### DIFF
--- a/src/housecarl-core/SksePluginReader.cs
+++ b/src/housecarl-core/SksePluginReader.cs
@@ -69,11 +69,13 @@ public static class SksePluginReader
     }
 
     /// <summary>One DLL's static SKSE identity. <see cref="Version"/> is non-null only for <see cref="SksePluginKind.Modern"/>.
-    /// <see cref="Note"/> carries the Q3 reason for any non-Modern kind (why the metadata isn't readable).</summary>
+    /// <see cref="Is64Bit"/> is <c>null</c> when the COFF machine field was never read (a non-PE / unopenable file whose
+    /// bitness is genuinely UNKNOWN — it is NEVER presented as 32-bit on a guess). <see cref="Note"/> carries the Q3 reason
+    /// for any non-Modern kind (why the metadata isn't readable).</summary>
     public sealed record SksePluginInfo(
         string FileName,
         SksePluginKind Kind,
-        bool Is64Bit,
+        bool? Is64Bit,
         SkseVersionInfo? Version,
         string? Note);
 
@@ -88,11 +90,17 @@ public static class SksePluginReader
         {
             using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
             using var pe = new PEReader(fs);
-            if (pe.PEHeaders.PEHeader is null)
-                return new SksePluginInfo(file, SksePluginKind.Unreadable, false, null, "no PE optional header");
-
+            // The COFF machine field is available as soon as the PE opened — read the real bitness even when the optional
+            // header is missing, so an Unreadable-with-no-optional-header still reports a TRUE x64/x86 rather than a
+            // fabricated one. Only the catch paths below (which never got this far) leave bitness null = UNKNOWN.
             bool is64 = pe.PEHeaders.CoffHeader.Machine == Machine.Amd64;
+            if (pe.PEHeaders.PEHeader is null)
+                return new SksePluginInfo(file, SksePluginKind.Unreadable, is64, null, "no PE optional header");
+
             var exports = ReadExportRvas(pe);
+            if (exports is null)   // export directory present but CORRUPT — a parse failure, NOT "no exports" (Q3: don't misclassify a corrupt DLL as a bundled dependency)
+                return new SksePluginInfo(file, SksePluginKind.Unreadable, is64, null, "corrupt PE export directory — could not enumerate exports");
+
             bool hasVersion = exports.TryGetValue("SKSEPlugin_Version", out int versionRva) && versionRva != 0;
             bool hasQuery = exports.ContainsKey("SKSEPlugin_Query");
             bool hasLoad = exports.ContainsKey("SKSEPlugin_Load") || exports.ContainsKey("SKSEPlugin_Preload");
@@ -105,20 +113,25 @@ public static class SksePluginReader
                 return new SksePluginInfo(file, SksePluginKind.LegacyQuery, is64, null,
                     "legacy SE/VR plugin: exports SKSEPlugin_Query (metadata is filled at runtime), so name/version are not statically readable");
 
-            // Modern: slice the version blob out of its section and decode. GetSectionData maps the RVA to the
-            // containing section for us; the struct is 0x350 bytes, we read what's available and decode defensively.
+            // Modern: slice the version blob out of its section and decode. A real SKSEPluginVersionData is a FULL
+            // 0x350-byte struct whose dataVersion (0x000) is kVersion (>= 1); a version export whose RVA maps to no
+            // section, a forwarder, or a corrupt EAT yields a short or all-zero blob — degrade honestly rather than
+            // present a phantom "" v0.0.0 plugin (Q3).
             var block = pe.GetSectionData(versionRva);
             byte[] blob = block.GetReader().ReadBytes(Math.Min(0x350, block.Length));
+            if (blob.Length < 0x350 || BitConverter.ToUInt32(blob, 0) == 0)
+                return new SksePluginInfo(file, SksePluginKind.Unreadable, is64, null,
+                    "exports SKSEPlugin_Version but its RVA does not resolve to a readable version blob (a forwarded or corrupt export)");
             var ver = DecodeVersionBlob(blob);
             return new SksePluginInfo(file, SksePluginKind.Modern, is64, ver, null);
         }
         catch (BadImageFormatException ex)
         {
-            return new SksePluginInfo(file, SksePluginKind.Unreadable, false, null, $"not a valid PE image: {ex.Message}");
+            return new SksePluginInfo(file, SksePluginKind.Unreadable, null, null, $"not a valid PE image: {ex.Message}");
         }
         catch (Exception ex)
         {
-            return new SksePluginInfo(file, SksePluginKind.Unreadable, false, null, $"could not read: {ex.GetType().Name}: {ex.Message}");
+            return new SksePluginInfo(file, SksePluginKind.Unreadable, null, null, $"could not read: {ex.GetType().Name}: {ex.Message}");
         }
     }
 
@@ -200,13 +213,14 @@ public static class SksePluginReader
 
     /// <summary>Walk the PE export directory and return name → export RVA (data exports point AT the data). Minimal by
     /// design: the SKSE loader itself resolves symbols by exact unmangled name string, so a name lookup is all we need.
-    /// Returns an empty map for a DLL with no export table. Never throws — a malformed table yields the names it could
-    /// read.</summary>
-    static Dictionary<string, int> ReadExportRvas(PEReader pe)
+    /// Returns an EMPTY map for a DLL with genuinely no export table (→ classify NotSkse), but <c>null</c> when the directory
+    /// is present yet CORRUPT (a parse failure — the caller classifies Unreadable, never silently as a bundled dependency,
+    /// Q3). Never throws.</summary>
+    static Dictionary<string, int>? ReadExportRvas(PEReader pe)
     {
         var byName = new Dictionary<string, int>(StringComparer.Ordinal);
         var dir = pe.PEHeaders.PEHeader!.ExportTableDirectory;
-        if (dir.Size == 0 || dir.RelativeVirtualAddress == 0) return byName;
+        if (dir.Size == 0 || dir.RelativeVirtualAddress == 0) return byName;   // no export table → empty (genuinely no exports)
         try
         {
             var ed = pe.GetSectionData(dir.RelativeVirtualAddress).GetReader();
@@ -221,6 +235,12 @@ public static class SksePluginReader
             int eatRva = ed.ReadInt32();     // AddressOfFunctions
             int nameRva = ed.ReadInt32();    // AddressOfNames
             int ordRva = ed.ReadInt32();     // AddressOfNameOrdinals
+
+            // Bound the counts against corruption BEFORE allocating/looping: a real DLL exports at most a few thousand
+            // symbols, so a bogus count means a corrupt directory. Trusting it would OOM `new int[numFuncs]` or spin the
+            // loops — refuse it as a parse failure (null → Unreadable), never trust a corruption-controlled length.
+            const uint MaxExports = 65536;
+            if (numFuncs > MaxExports || numNames > MaxExports) return null;
 
             var eat = pe.GetSectionData(eatRva).GetReader();
             var funcRvas = new int[numFuncs];
@@ -239,7 +259,7 @@ public static class SksePluginReader
                 byName[sb.ToString()] = ord < funcRvas.Length ? funcRvas[ord] : 0;
             }
         }
-        catch { /* malformed export table → return what we have; classification degrades to NotSkse, never a throw (Q3) */ }
+        catch { return null; /* corrupt directory (bad RVA / truncated table / unterminated string) → parse-failure signal, NOT a silent empty map that would misclassify as NotSkse (Q3) */ }
         return byName;
     }
 }

--- a/src/housecarl-core/SksePluginReader.cs
+++ b/src/housecarl-core/SksePluginReader.cs
@@ -1,0 +1,245 @@
+using System.Reflection.PortableExecutable;
+using System.Text;
+
+namespace HousecarlCore;
+
+/// <summary>
+/// Tier A+C of the SKSE-plugin-layer visibility gap (bug report 2026-06-08_gap_skse-plugin-layer-visibility):
+/// reads what an SKSE plugin DLL DECLARES about itself, STATICALLY — no loading, no execution, no runtime state.
+/// The whole capability's hard ceiling is tier E (DLL *behavior*), which stays UNREACHABLE by design; this reader
+/// stops at the declared manifest, exactly the trustworthy line.
+///
+/// The mechanism, confirmed empirically against the live load order (297 real DLLs) and anchored to the two
+/// CommonLib lineages' identical <c>SKSE::PluginVersionData</c> layout (alandtse/CommonLibVR@ng and
+/// powerof3/CommonLibSSE@dev):
+///
+///   • The AE-era SKSE loader reads an exported DATA BLOB named <c>SKSEPlugin_Version</c> without executing the
+///     DLL (plugin-skeleton.md §1), so its bytes are a static manifest: plugin name, author, version, the
+///     version-independence flags (Address Library / signature-scanning / struct-compat), the compatible-runtime
+///     list, and the XSE version floor. That is the whole of tier C, and it is what a modern plugin exports.
+///   • The older SE/VR loader instead CALLS an exported FUNCTION <c>SKSEPlugin_Query</c> that fills its info at
+///     runtime — so a query-ONLY (no <c>SKSEPlugin_Version</c>) plugin's metadata is NOT statically readable. We
+///     classify it <see cref="SksePluginKind.LegacyQuery"/> and say so (Q3: an honest "can't read this
+///     statically", never an invented name).
+///   • A DLL in SKSE\Plugins with NONE of the SKSE exports is a bundled dependency, not a plugin
+///     (<see cref="SksePluginKind.NotSkse"/>) — e.g. CrashLogger's msdia140.dll.
+///
+/// The struct layout is load-bearing and was VALIDATED byte-for-byte (SPID → "Spell Perk Item Distributor" /
+/// "powerofthree", flags 0x5 = AddressLibrary|UpdatedStructs; OAR → AddressLibrary|NoStructs, compat 1.6.1170) —
+/// the one non-obvious detail is <c>supportEmail[252]</c> (NOT 256), which puts <c>versionIndependenceEx</c> at
+/// 0x304, not 0x308. See <see cref="DecodeVersionBlob"/> for the offset map. This reader NEVER guesses a layout:
+/// the offsets come from the pinned headers, and the skse-reader-guard probe pins the decode against them.
+/// </summary>
+public static class SksePluginReader
+{
+    /// <summary>How a DLL under SKSE\Plugins relates to the SKSE plugin ABI. Drives what metadata (if any) is readable.</summary>
+    public enum SksePluginKind
+    {
+        /// <summary>Exports the <c>SKSEPlugin_Version</c> data blob → full tier-C metadata is statically readable.</summary>
+        Modern,
+        /// <summary>Exports <c>SKSEPlugin_Query</c>/<c>SKSEPlugin_Load</c> but NO version blob — an SE/VR-era plugin whose
+        /// metadata is filled at runtime, so it is not statically readable (Q3 honest degrade).</summary>
+        LegacyQuery,
+        /// <summary>No SKSE export at all — a bundled dependency DLL, not a plugin.</summary>
+        NotSkse,
+        /// <summary>Not a readable PE image (corrupt / not actually a DLL). Surfaced, never silently skipped.</summary>
+        Unreadable,
+    }
+
+    /// <summary>The statically-declared manifest of a MODERN plugin (the <c>SKSEPlugin_Version</c> blob), decoded.
+    /// <see cref="CompatibleVersions"/> is the loader's hard runtime list and is meaningful ONLY when
+    /// <see cref="VersionIndependent"/> is false — a version-independent plugin's loader ignores it (some builds pad it
+    /// with 1.0.0 noise), so the renderer suppresses it there.</summary>
+    public sealed record SkseVersionInfo(
+        string Name,
+        string Author,
+        string SupportEmail,
+        string PluginVersion,
+        bool UsesAddressLibrary,
+        bool UsesSignatureScanning,
+        bool UsesUpdatedStructs,
+        bool DeclaresNoStructs,
+        IReadOnlyList<string> CompatibleVersions,
+        string? MinimumXseVersion)
+    {
+        /// <summary>True if the plugin declared ANY version-independence path (Address Library or signature scanning),
+        /// so the loader does NOT pin it to <see cref="CompatibleVersions"/>. False ⇒ version-LOCKED: it loads only on
+        /// the exact runtimes it lists — the compat-risk signal tier C exists to surface.</summary>
+        public bool VersionIndependent => UsesAddressLibrary || UsesSignatureScanning;
+    }
+
+    /// <summary>One DLL's static SKSE identity. <see cref="Version"/> is non-null only for <see cref="SksePluginKind.Modern"/>.
+    /// <see cref="Note"/> carries the Q3 reason for any non-Modern kind (why the metadata isn't readable).</summary>
+    public sealed record SksePluginInfo(
+        string FileName,
+        SksePluginKind Kind,
+        bool Is64Bit,
+        SkseVersionInfo? Version,
+        string? Note);
+
+    /// <summary>Read one DLL's static SKSE manifest off disk. Never throws for a bad/odd file — an unreadable image is
+    /// reported as <see cref="SksePluginKind.Unreadable"/> with the reason (Q3). Reads the file with a plain read-share
+    /// stream (no handle held at rest — the file is closed before return), consistent with houseCARL's "MO2/xEdit can
+    /// move plugins freely" invariant.</summary>
+    public static SksePluginInfo Read(string filePath)
+    {
+        string file = Path.GetFileName(filePath);
+        try
+        {
+            using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            using var pe = new PEReader(fs);
+            if (pe.PEHeaders.PEHeader is null)
+                return new SksePluginInfo(file, SksePluginKind.Unreadable, false, null, "no PE optional header");
+
+            bool is64 = pe.PEHeaders.CoffHeader.Machine == Machine.Amd64;
+            var exports = ReadExportRvas(pe);
+            bool hasVersion = exports.TryGetValue("SKSEPlugin_Version", out int versionRva) && versionRva != 0;
+            bool hasQuery = exports.ContainsKey("SKSEPlugin_Query");
+            bool hasLoad = exports.ContainsKey("SKSEPlugin_Load") || exports.ContainsKey("SKSEPlugin_Preload");
+
+            if (!hasVersion && !hasQuery && !hasLoad)
+                return new SksePluginInfo(file, SksePluginKind.NotSkse, is64, null,
+                    "no SKSE export (SKSEPlugin_Version/Query/Load) — a bundled dependency DLL, not a plugin");
+
+            if (!hasVersion)
+                return new SksePluginInfo(file, SksePluginKind.LegacyQuery, is64, null,
+                    "legacy SE/VR plugin: exports SKSEPlugin_Query (metadata is filled at runtime), so name/version are not statically readable");
+
+            // Modern: slice the version blob out of its section and decode. GetSectionData maps the RVA to the
+            // containing section for us; the struct is 0x350 bytes, we read what's available and decode defensively.
+            var block = pe.GetSectionData(versionRva);
+            byte[] blob = block.GetReader().ReadBytes(Math.Min(0x350, block.Length));
+            var ver = DecodeVersionBlob(blob);
+            return new SksePluginInfo(file, SksePluginKind.Modern, is64, ver, null);
+        }
+        catch (BadImageFormatException ex)
+        {
+            return new SksePluginInfo(file, SksePluginKind.Unreadable, false, null, $"not a valid PE image: {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            return new SksePluginInfo(file, SksePluginKind.Unreadable, false, null, $"could not read: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>Decode the raw <c>SKSEPlugin_Version</c> blob bytes into the manifest. PURE + bounds-checked so the CI
+    /// probe can pin the exact offset map WITHOUT a real PE. The layout (identical in alandtse/CommonLibVR@ng and
+    /// powerof3/CommonLibSSE@dev, ABI-fixed by the SKSE loader):
+    /// <code>
+    /// 0x000 uint32  dataVersion
+    /// 0x004 uint32  pluginVersion          (REL::Version.pack: maj&lt;&lt;24 | min&lt;&lt;16 | patch&lt;&lt;4 | build)
+    /// 0x008 char    pluginName[256]
+    /// 0x108 char    author[256]
+    /// 0x208 char    supportEmail[252]      &lt;-- 252, NOT 256 (the one non-obvious offset)
+    /// 0x304 uint32  versionIndependenceEx  (bit0 = NoStructUse)
+    /// 0x308 uint32  versionIndependence    (bit0 = AddressLibraryPostAE, bit1 = Signatures, bit2 = StructsPost629)
+    /// 0x30C uint32  compatibleVersions[16] (zero-terminated list of REL::Version.pack values)
+    /// 0x34C uint32  xseMinimum
+    /// </code></summary>
+    public static SkseVersionInfo DecodeVersionBlob(ReadOnlySpan<byte> b)
+    {
+        uint pluginVersion = U32(b, 0x004);
+        string name = AsciiZ(b, 0x008, 256);
+        string author = AsciiZ(b, 0x108, 256);
+        string email = AsciiZ(b, 0x208, 252);
+        uint viEx = U32(b, 0x304);
+        uint vi = U32(b, 0x308);
+        var compat = new List<string>();
+        for (int i = 0; i < 16; i++)
+        {
+            uint packed = U32(b, 0x30C + i * 4);
+            if (packed == 0) break;                     // zero-terminated list
+            compat.Add(UnpackVersion(packed));
+        }
+        uint xseMin = U32(b, 0x34C);
+
+        return new SkseVersionInfo(
+            Name: name,
+            Author: author,
+            SupportEmail: email,
+            PluginVersion: UnpackVersion(pluginVersion),
+            UsesAddressLibrary: (vi & 0x1) != 0,        // kVersionIndependent_AddressLibraryPostAE
+            UsesSignatureScanning: (vi & 0x2) != 0,     // kVersionIndependent_Signatures
+            UsesUpdatedStructs: (vi & 0x4) != 0,        // kVersionIndependent_StructsPost629
+            DeclaresNoStructs: (viEx & 0x1) != 0,       // kVersionIndependentEx_NoStructUse
+            CompatibleVersions: compat,
+            MinimumXseVersion: xseMin == 0 ? null : UnpackVersion(xseMin));
+    }
+
+    /// <summary>Unpack a <c>REL::Version</c> uint32 to "maj.min.patch[.build]" — the exact CommonLib packing
+    /// (maj 8b &lt;&lt; 24 | min 8b &lt;&lt; 16 | patch 12b &lt;&lt; 4 | build 4b). Trailing .build is shown only when non-zero
+    /// (most plugins declare only maj[.min.patch]).</summary>
+    public static string UnpackVersion(uint v)
+    {
+        int major = (int)((v >> 24) & 0xFF);
+        int minor = (int)((v >> 16) & 0xFF);
+        int patch = (int)((v >> 4) & 0xFFF);
+        int build = (int)(v & 0xF);
+        return build != 0 ? $"{major}.{minor}.{patch}.{build}" : $"{major}.{minor}.{patch}";
+    }
+
+    static uint U32(ReadOnlySpan<byte> b, int off) =>
+        off + 4 <= b.Length ? BitConverter.ToUInt32(b.Slice(off, 4)) : 0u;
+
+    /// <summary>Read an ASCII, null-terminated field of at most <paramref name="max"/> bytes at <paramref name="off"/>.
+    /// Trailing non-printables are trimmed defensively (a garbage blob never yields control chars in the render).</summary>
+    static string AsciiZ(ReadOnlySpan<byte> buf, int off, int max)
+    {
+        if (off >= buf.Length) return "";
+        int limit = Math.Min(off + max, buf.Length);
+        int end = off;
+        while (end < limit && buf[end] != 0) end++;
+        var sb = new StringBuilder(end - off);
+        for (int i = off; i < end; i++)
+        {
+            byte c = buf[i];
+            sb.Append(c is >= 0x20 and < 0x7F ? (char)c : ' ');   // printable ASCII only; others → space (Q3: no control chars leak into output)
+        }
+        return sb.ToString().Trim();
+    }
+
+    /// <summary>Walk the PE export directory and return name → export RVA (data exports point AT the data). Minimal by
+    /// design: the SKSE loader itself resolves symbols by exact unmangled name string, so a name lookup is all we need.
+    /// Returns an empty map for a DLL with no export table. Never throws — a malformed table yields the names it could
+    /// read.</summary>
+    static Dictionary<string, int> ReadExportRvas(PEReader pe)
+    {
+        var byName = new Dictionary<string, int>(StringComparer.Ordinal);
+        var dir = pe.PEHeaders.PEHeader!.ExportTableDirectory;
+        if (dir.Size == 0 || dir.RelativeVirtualAddress == 0) return byName;
+        try
+        {
+            var ed = pe.GetSectionData(dir.RelativeVirtualAddress).GetReader();
+            ed.Offset = 0;
+            ed.ReadUInt32();                 // Characteristics
+            ed.ReadUInt32();                 // TimeDateStamp
+            ed.ReadUInt16(); ed.ReadUInt16();// Major/Minor version
+            ed.ReadUInt32();                 // Name RVA
+            ed.ReadUInt32();                 // OrdinalBase
+            uint numFuncs = ed.ReadUInt32(); // AddressOfFunctions count
+            uint numNames = ed.ReadUInt32(); // AddressOfNames count
+            int eatRva = ed.ReadInt32();     // AddressOfFunctions
+            int nameRva = ed.ReadInt32();    // AddressOfNames
+            int ordRva = ed.ReadInt32();     // AddressOfNameOrdinals
+
+            var eat = pe.GetSectionData(eatRva).GetReader();
+            var funcRvas = new int[numFuncs];
+            for (int i = 0; i < numFuncs; i++) funcRvas[i] = eat.ReadInt32();
+
+            var nameTab = pe.GetSectionData(nameRva).GetReader();
+            var ordTab = pe.GetSectionData(ordRva).GetReader();
+            for (int i = 0; i < numNames; i++)
+            {
+                int strRva = nameTab.ReadInt32();
+                var sr = pe.GetSectionData(strRva).GetReader();
+                var sb = new StringBuilder(32);
+                byte c;
+                while ((c = sr.ReadByte()) != 0) sb.Append((char)c);
+                ushort ord = ordTab.ReadUInt16();
+                byName[sb.ToString()] = ord < funcRvas.Length ? funcRvas[ord] : 0;
+            }
+        }
+        catch { /* malformed export table → return what we have; classification degrades to NotSkse, never a throw (Q3) */ }
+        return byName;
+    }
+}

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -92,6 +92,10 @@ public static class CiAll
         ("overwrite-resolve-guard", OverwriteResolveProbe.RunGuard),
         ("asset-resolver-guard", AssetResolverProbe.RunGuard),
         ("asset-status-guard", AssetStatusProbe.RunGuard),
+        // SKSE-plugin-layer visibility (gap 2026-06-08, tier C): pins the SKSEPlugin_Version decode contract (the
+        // reverse-engineered offset map — supportEmail is 252, not 256 — + the flag/version/compat interpretation) and
+        // the honest-degrade paths (real-PE Read → NotSkse; non-PE / missing → Unreadable, never a throw).
+        ("skse-reader-guard", SkseReaderProbe.RunGuard),
         ("mo2instance-probe", Mo2InstanceProbe.RunProbe),
         ("atomic-commit-guard", AtomicCommitProbe.RunGuard),
         ("place-asset-guard", PlaceAssetProbe.RunGuard),

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -226,6 +226,10 @@ if (args.Length > 0 && args[0] == "remap-wave1-real") return RemapWave1Probe.Run
 // round-trip on disk), and whether IMajorRecordGetterEnumerable is the by-construction recurse discriminator.
 if (args.Length > 0 && args[0] == "remap-wave2-nested-mech") return RemapWave2NestedMechProbe.RunMechanism(args[1..]);
 
+// SKSE-plugin-layer visibility (gap 2026-06-08) MANUAL real-data harness: run housecarl_skse_inventory against a live
+// MO2 instance and print the render + timing (the CI skse-reader-guard pins the decode; this proves the full inventory).
+if (args.Length > 0 && args[0] == "skse-inventory-real") return SkseInventoryProbe.RunReal(args[1..]);
+
 var outputDir = Path.GetFullPath(args.Length > 0 ? args[0] : "generated");
 // The slim reference tree ships INSIDE the skill (tracked); corpus.json + summary stay in generated/.
 // Default assumes the generator is run from the repo root (as `dotnet run --project src/housecarl-generator`).

--- a/src/housecarl-generator/SkseInventoryProbe.cs
+++ b/src/housecarl-generator/SkseInventoryProbe.cs
@@ -1,0 +1,38 @@
+using System.Diagnostics;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// MANUAL real-data harness for housecarl_skse_inventory (SKSE-plugin-layer visibility, gap 2026-06-08). Runs the REAL
+/// service + renderer against a live MO2 instance and prints exactly what the tool would return, plus a timing line —
+/// the empirical re-check Aaron drives (the CI skse-reader-guard pins the DECODE; this proves the whole inventory over
+/// real DLLs). NOT in ci-all (needs a real instance + game install). Read-only; touches nothing but a temp user.json.
+/// Usage: dotnet run --project src/housecarl-generator -- skse-inventory-real --mo2 "&lt;MO2 instance&gt;" [--filter &lt;substr&gt;]
+/// </summary>
+internal static class SkseInventoryProbe
+{
+    public static int RunReal(string[] args)
+    {
+        string? mo2 = ArgVal(args, "--mo2");
+        string? filter = ArgVal(args, "--filter");
+        if (mo2 is null) { Console.WriteLine("skse-inventory-real needs --mo2 <MO2 instance folder>"); return 2; }
+
+        var store = new UserConfigStore(Path.Combine(Path.GetTempPath(), "hc-skse-real-" + Guid.NewGuid().ToString("N") + ".json"));
+        using var svc = LoadOrderService.WithInstance(mo2, 0, store);
+        var sw = Stopwatch.StartNew();
+        var data = svc.SkseInventory();
+        sw.Stop();
+
+        Console.WriteLine(SkseInventoryWire.Render(data, filter, 80_000));
+        Console.WriteLine($"\n[timing] SkseInventory over {data.Dlls.Count} DLLs + {data.Configs.Count} configs in {sw.ElapsedMilliseconds} ms");
+        return 0;
+    }
+
+    static string? ArgVal(string[] a, string key)
+    {
+        int i = Array.IndexOf(a, key);
+        return i >= 0 && i + 1 < a.Length ? a[i + 1] : null;
+    }
+}

--- a/src/housecarl-generator/SkseReaderProbe.cs
+++ b/src/housecarl-generator/SkseReaderProbe.cs
@@ -1,0 +1,147 @@
+using System.Text;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SKSE-plugin reader guard (gap 2026-06-08 — SKSE-plugin-layer visibility, tier C). Pins the two things
+/// <see cref="SksePluginReader"/> got RIGHT only by reverse-engineering + empirical validation against the live load
+/// order, so a later "cleanup" can't silently rot them:
+///
+///   • The <c>SKSEPlugin_Version</c> blob OFFSET MAP — most importantly that <c>supportEmail</c> is 252 bytes (NOT
+///     256), which puts <c>versionIndependenceEx</c> at 0x304 and <c>versionIndependence</c> at 0x308. Arms A/F fail
+///     the instant someone "fixes" email to 256 (both flag fields shift and the wrong bytes are read).
+///   • The flag decode (Address Library / signature-scanning / updated-structs / no-structs), the version-locked vs
+///     version-independent classification, the zero-terminated compatibleVersions list, and the REL::Version packing.
+///   • The Read() path on a REAL PE image (the runner's own managed assembly) classifies as NotSkse WITHOUT throwing,
+///     and a non-PE / missing file degrades to Unreadable (Q3 — never a throw that aborts an inventory).
+///
+/// The whole-inventory PE-walk over real DLLs is validated empirically against the actual load order (297 DLLs at
+/// authoring time); this guard is the CI-runnable regression net for the decode contract + the honest-degrade paths.
+/// Self-contained: synthetic blobs in memory + one temp junk file; no MO2 instance, no game data, no corpus.
+/// </summary>
+internal static class SkseReaderProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" skse-reader guard — SKSEPlugin_Version decode + honest-degrade (tier C)");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        // ---- A: Address Library plugin (the OAR shape) — pins name/author/email at 0x008/0x108/0x208, the flags at
+        //         0x304 (NoStructs) + 0x308 (AddressLibrary), compat, and the 3.0.0 version. ----
+        Console.WriteLine("--- A: Address Library plugin (name/author/email + AddrLib+NoStructs + compat + version) ---");
+        var a = SksePluginReader.DecodeVersionBlob(MakeBlob(
+            pluginVersion: Pack(3, 0, 0, 0), name: "Test Plugin", author: "Tester", email: "t@example.com",
+            viEx: 0x1 /*NoStructs*/, vi: 0x1 /*AddressLibrary*/, compat: new[] { Pack(1, 6, 1170, 0) }, xseMin: 0));
+        Check(a.Name == "Test Plugin", $"Name == 'Test Plugin' (got '{a.Name}')");
+        Check(a.Author == "Tester", $"Author == 'Tester' (got '{a.Author}')");
+        Check(a.SupportEmail == "t@example.com", $"SupportEmail decoded (got '{a.SupportEmail}')");
+        Check(a.PluginVersion == "3.0.0", $"PluginVersion == '3.0.0' (got '{a.PluginVersion}')");
+        Check(a.UsesAddressLibrary, "UsesAddressLibrary true (vi bit0 @ 0x308)");
+        Check(a.DeclaresNoStructs, "DeclaresNoStructs true (viEx bit0 @ 0x304 — proves email is 252, not 256)");
+        Check(a.VersionIndependent, "VersionIndependent true (Address Library ⇒ not runtime-locked)");
+        Check(a.CompatibleVersions.Count == 1 && a.CompatibleVersions[0] == "1.6.1170", "CompatibleVersions == [1.6.1170]");
+        Check(a.MinimumXseVersion is null, "MinimumXseVersion null when xseMinimum == 0");
+
+        // ---- B: version-LOCKED plugin (the fiss shape) — no independence flag ⇒ loads ONLY on its listed runtime. ----
+        Console.WriteLine("\n--- B: version-LOCKED plugin (no independence flag → hard runtime list) ---");
+        var b = SksePluginReader.DecodeVersionBlob(MakeBlob(
+            pluginVersion: Pack(0, 0, 8, 13), name: "Locked", author: "", email: "",
+            viEx: 0, vi: 0, compat: new[] { Pack(1, 6, 640, 0) }, xseMin: 0));
+        Check(!b.VersionIndependent, "VersionIndependent false (no AddrLib / no SigScan)");
+        Check(!b.UsesAddressLibrary && !b.UsesSignatureScanning, "no independence flags set");
+        Check(b.CompatibleVersions.Count == 1 && b.CompatibleVersions[0] == "1.6.640", "CompatibleVersions == [1.6.640] (the hard target)");
+        Check(b.PluginVersion == "0.0.8.13", $"PluginVersion keeps a non-zero build (got '{b.PluginVersion}')");
+
+        // ---- C: signature-scanning + updated-structs + an XSE floor. ----
+        Console.WriteLine("\n--- C: signature-scanning + updated-structs + XSE minimum ---");
+        var c = SksePluginReader.DecodeVersionBlob(MakeBlob(
+            pluginVersion: Pack(1, 2, 3, 0), name: "Sig", author: "", email: "",
+            viEx: 0, vi: 0x2 | 0x4 /*Signatures | StructsPost629*/, compat: Array.Empty<uint>(), xseMin: Pack(2, 2, 3, 0)));
+        Check(c.UsesSignatureScanning, "UsesSignatureScanning true (vi bit1)");
+        Check(c.UsesUpdatedStructs, "UsesUpdatedStructs true (vi bit2)");
+        Check(!c.UsesAddressLibrary, "UsesAddressLibrary false");
+        Check(c.VersionIndependent, "VersionIndependent true (signature scanning also frees it from the runtime list)");
+        Check(c.MinimumXseVersion == "2.2.3", $"MinimumXseVersion == '2.2.3' (got '{c.MinimumXseVersion ?? "null"}')");
+
+        // ---- D: compatibleVersions is ZERO-TERMINATED — a value after a 0 is ignored (loader semantics). ----
+        Console.WriteLine("\n--- D: compatibleVersions zero-termination ---");
+        var d = SksePluginReader.DecodeVersionBlob(MakeBlob(
+            pluginVersion: 0, name: "Z", author: "", email: "",
+            viEx: 0, vi: 0, compat: new[] { Pack(1, 5, 97, 0), Pack(1, 6, 640, 0), 0u, Pack(9, 9, 9, 0) }, xseMin: 0));
+        Check(d.CompatibleVersions.Count == 2, $"stops at the zero terminator — 2 entries, not 4 (got {d.CompatibleVersions.Count})");
+        Check(d.CompatibleVersions.SequenceEqual(new[] { "1.5.97", "1.6.640" }), "the two pre-terminator versions decode");
+
+        // ---- E: REL::Version packing is exact (maj<<24 | min<<16 | patch<<4 | build). ----
+        Console.WriteLine("\n--- E: REL::Version unpack ---");
+        Check(SksePluginReader.UnpackVersion(0x07000000) == "7.0.0", "0x07000000 → 7.0.0 (SPID major-only)");
+        Check(SksePluginReader.UnpackVersion(0x01064920) == "1.6.1170", "0x01064920 → 1.6.1170 (RUNTIME_SSE_LATEST)");
+        Check(SksePluginReader.UnpackVersion(0x0000008D) == "0.0.8.13", "0x0000008D → 0.0.8.13 (build nibble preserved)");
+
+        // ---- F: the 252-byte offset regression, isolated — swap the two flag fields and prove each is read at its own
+        //         offset. If email were 256, both would shift and BOTH sub-checks would flip. ----
+        Console.WriteLine("\n--- F: supportEmail-is-252 offset regression (viEx@0x304 vs vi@0x308 are distinct) ---");
+        var f1 = SksePluginReader.DecodeVersionBlob(MakeBlob(0, "F1", "", "", viEx: 0x1, vi: 0x0, compat: Array.Empty<uint>(), xseMin: 0));
+        Check(f1.DeclaresNoStructs && !f1.UsesAddressLibrary, "viEx=1,vi=0 → NoStructs only (0x304 is viEx)");
+        var f2 = SksePluginReader.DecodeVersionBlob(MakeBlob(0, "F2", "", "", viEx: 0x0, vi: 0x1, compat: Array.Empty<uint>(), xseMin: 0));
+        Check(!f2.DeclaresNoStructs && f2.UsesAddressLibrary, "viEx=0,vi=1 → AddressLibrary only (0x308 is vi)");
+
+        // ---- G: Read() on a REAL PE (the runner's own managed assembly) — classifies without throwing. ----
+        Console.WriteLine("\n--- G: Read() on a real PE image (managed assembly → NotSkse, no throw) ---");
+        string ownPath = typeof(SksePluginReader).Assembly.Location;
+        var g = SksePluginReader.Read(ownPath);
+        Check(g.Kind == SksePluginReader.SksePluginKind.NotSkse,
+              $"a managed assembly with no SKSE export classifies NotSkse (got {g.Kind})");
+        Check(g.Note is { Length: > 0 }, "NotSkse carries a Q3 note explaining why");
+        Check(g.Version is null, "no version manifest for a non-plugin DLL");
+
+        // ---- H: honest degrade — a non-PE file and a missing path both yield Unreadable, never a throw. ----
+        Console.WriteLine("\n--- H: honest-degrade (non-PE + missing path → Unreadable, no throw) ---");
+        var junk = Path.Combine(Path.GetTempPath(), "hc-skse-junk-" + Guid.NewGuid().ToString("N") + ".dll");
+        try
+        {
+            File.WriteAllBytes(junk, Encoding.ASCII.GetBytes("this is not a PE file at all, just some bytes"));
+            var h1 = SksePluginReader.Read(junk);
+            Check(h1.Kind == SksePluginReader.SksePluginKind.Unreadable, $"non-PE bytes → Unreadable (got {h1.Kind})");
+            var h2 = SksePluginReader.Read(Path.Combine(Path.GetTempPath(), "hc-skse-does-not-exist-" + Guid.NewGuid().ToString("N") + ".dll"));
+            Check(h2.Kind == SksePluginReader.SksePluginKind.Unreadable, $"missing file → Unreadable, no throw (got {h2.Kind})");
+        }
+        finally { try { File.Delete(junk); } catch { /* temp scratch */ } }
+
+        Console.WriteLine();
+        Console.WriteLine(fail == 0 ? "================ ALL PASS ================" : $"================ {fail} CHECK(S) FAILED ================");
+        return fail == 0 ? 0 : 1;
+    }
+
+    /// <summary>Lay out a synthetic <c>SKSEPlugin_Version</c> blob at the CONFIRMED offsets — the reference layout the
+    /// reader must agree with. (This is the "correct answer key"; the reader is what's under test.)</summary>
+    static byte[] MakeBlob(uint pluginVersion, string name, string author, string email, uint viEx, uint vi, uint[] compat, uint xseMin)
+    {
+        var b = new byte[0x350];
+        BitConverter.GetBytes(1u).CopyTo(b, 0x000);              // dataVersion = kVersion
+        BitConverter.GetBytes(pluginVersion).CopyTo(b, 0x004);
+        WriteAscii(b, 0x008, name, 256);
+        WriteAscii(b, 0x108, author, 256);
+        WriteAscii(b, 0x208, email, 252);                        // 252 — the load-bearing size
+        BitConverter.GetBytes(viEx).CopyTo(b, 0x304);
+        BitConverter.GetBytes(vi).CopyTo(b, 0x308);
+        for (int i = 0; i < compat.Length && i < 16; i++) BitConverter.GetBytes(compat[i]).CopyTo(b, 0x30C + i * 4);
+        BitConverter.GetBytes(xseMin).CopyTo(b, 0x34C);
+        return b;
+    }
+
+    static void WriteAscii(byte[] b, int off, string s, int max)
+    {
+        var bytes = Encoding.ASCII.GetBytes(s);
+        Array.Copy(bytes, 0, b, off, Math.Min(bytes.Length, max - 1));   // leave the null terminator (rest is already zero)
+    }
+
+    /// <summary>Mirror of REL::Version::pack (maj 8b &lt;&lt; 24 | min 8b &lt;&lt; 16 | patch 12b &lt;&lt; 4 | build 4b) — for building
+    /// the answer-key blobs. The reader's UnpackVersion is the inverse under test.</summary>
+    static uint Pack(int maj, int min, int patch, int build) =>
+        (uint)(((maj & 0xFF) << 24) | ((min & 0xFF) << 16) | ((patch & 0xFFF) << 4) | (build & 0xF));
+}

--- a/src/housecarl-generator/SkseReaderProbe.cs
+++ b/src/housecarl-generator/SkseReaderProbe.cs
@@ -98,17 +98,21 @@ internal static class SkseReaderProbe
               $"a managed assembly with no SKSE export classifies NotSkse (got {g.Kind})");
         Check(g.Note is { Length: > 0 }, "NotSkse carries a Q3 note explaining why");
         Check(g.Version is null, "no version manifest for a non-plugin DLL");
+        Check(g.Is64Bit is not null, "a readable PE reports a DETERMINED bitness (not null)");
 
-        // ---- H: honest degrade — a non-PE file and a missing path both yield Unreadable, never a throw. ----
-        Console.WriteLine("\n--- H: honest-degrade (non-PE + missing path → Unreadable, no throw) ---");
+        // ---- H: honest degrade — a non-PE file and a missing path both yield Unreadable, never a throw, and their
+        //         bitness is UNKNOWN (null), never a fabricated 32-bit claim (finding #1: Unreadable had Is64Bit=false). ----
+        Console.WriteLine("\n--- H: honest-degrade (non-PE + missing path → Unreadable, no throw, bitness unknown) ---");
         var junk = Path.Combine(Path.GetTempPath(), "hc-skse-junk-" + Guid.NewGuid().ToString("N") + ".dll");
         try
         {
             File.WriteAllBytes(junk, Encoding.ASCII.GetBytes("this is not a PE file at all, just some bytes"));
             var h1 = SksePluginReader.Read(junk);
             Check(h1.Kind == SksePluginReader.SksePluginKind.Unreadable, $"non-PE bytes → Unreadable (got {h1.Kind})");
+            Check(h1.Is64Bit is null, "non-PE → bitness UNKNOWN (null), NOT a false 32-bit claim (finding #1)");
             var h2 = SksePluginReader.Read(Path.Combine(Path.GetTempPath(), "hc-skse-does-not-exist-" + Guid.NewGuid().ToString("N") + ".dll"));
             Check(h2.Kind == SksePluginReader.SksePluginKind.Unreadable, $"missing file → Unreadable, no throw (got {h2.Kind})");
+            Check(h2.Is64Bit is null, "missing file → bitness UNKNOWN (null)");
         }
         finally { try { File.Delete(junk); } catch { /* temp scratch */ } }
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -284,8 +284,8 @@ public sealed class LoadOrderService : IDisposable
             var place = view.ResolveForPlacement(rel);
             // The FULL conflict chain, winner-first (asset-tool parity): keep every provider + its loose/BSA kind, not just a count.
             var providers = place.Sources
-                .Select(s => new SkseProvider(s.ProviderName, s.Kind == AssetKind.Bsa ? "BSA" : "loose"))
-                .ToList();
+                .Select(s => new SkseProvider(s.ProviderName, s.Kind switch { AssetKind.Bsa => "BSA", AssetKind.Loose => "loose", var k => k.ToString() }))
+                .ToList();   // explicit switch (not a ternary): a future AssetKind arm renders its real name, never a silent "loose"
             var winner = place.Sources.Count > 0 ? place.Sources[0] : null;
 
             if (isDll)

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -238,6 +238,85 @@ public sealed class LoadOrderService : IDisposable
         }
     }
 
+    // ---- SKSE-plugin-layer visibility (gap 2026-06-08): inventory the DLLs + configs + winning provider (tier A) and
+    //      each plugin DLL's STATICALLY declared manifest (tier C). Read-only; reuses the asset VFS + the PE reader. ----
+
+    /// <summary>Inventory the SKSE-plugin layer as the ACTIVE load order resolves it (housecarl_skse_inventory): the FULL
+    /// DEPTH of Data\SKSE\Plugins — every <c>.dll</c> plugin and every <c>.ini</c>/<c>.toml</c>/<c>.json</c>/<c>.yaml</c>
+    /// config at any depth — with the mod that WINS the VFS for each (tier A), and for every plugin DLL the statically-
+    /// declared manifest — name/author/version, Address Library vs version-LOCKED, target runtimes, XSE floor — via
+    /// <see cref="SksePluginReader"/> (tier C). Tier E (DLL behavior) stays out of reach by design. FULL VISIBILITY, by
+    /// construction: every file is accounted for — configs carry their derived subfolder <see cref="SkseFileEntry.Group"/>
+    /// (the immediate folder under SKSE\Plugins — SkyPatcher / DynamicStringDistributor / OStim / …, WHATEVER the modlist
+    /// ships, never a hardcoded set) so the renderer can group them compactly, and non-config content (animation data etc.)
+    /// is counted in <see cref="SkseInventoryData.OtherFileCount"/>, never silently dropped. DLLs keep their SKSE-loader
+    /// truth: a subfolder DLL is SEEN but flagged (SKSE scans Data\SKSE\Plugins*.dll top-level only, so it isn't loaded as a
+    /// plugin). ONE asset capture pins the whole scan (list + <see cref="AssetView.ReadIncomplete"/> caveat = one build); the
+    /// enumerate + resolve + PE reads run OUTSIDE the gate (the captured view is a handle-free immutable snapshot), so an
+    /// inventory never serializes other tool calls behind its file I/O. Distributor INIs (SPID <c>*_DISTR</c>, KID
+    /// <c>*_KID</c>) live in Data\ ROOT, not here, and are owned by their authoring skills — out of this scope by design.</summary>
+    public SkseInventoryData SkseInventory()
+    {
+        AssetResolver.AssetView view;
+        IReadOnlyList<string> warnings;
+        string profileName;
+        lock (_gate)
+        {
+            view = Assets.Capture();                              // build/refresh the asset resolver under the gate, ONCE
+            warnings = _assetWarnings;
+            profileName = _profileName;
+        }
+        // OUTSIDE the gate: the view is pinned + handle-free (AssetResolver.Dispose is a no-op; Resolve reads only the
+        // captured snapshot + readonly roots), so enumerating + resolving + PE-reading here can't race a concurrent
+        // refresh into wrongness and doesn't block other tools behind our file reads.
+        const string pre = "SKSE\\Plugins\\";
+        var dlls = new List<SkseFileEntry>();
+        var configs = new List<SkseFileEntry>();
+        int otherFiles = 0;
+        foreach (var rel in view.EnumerateUnder("SKSE\\Plugins").OrderBy(p => p, StringComparer.OrdinalIgnoreCase))
+        {
+            var ext = Path.GetExtension(rel).ToLowerInvariant();
+            bool isDll = ext is ".dll";
+            bool isConfig = ext is ".ini" or ".toml" or ".json" or ".yaml" or ".yml";
+            if (!isDll && !isConfig) { otherFiles++; continue; }  // content/other (.hkx/.txt/.pdb/…) — ACCOUNTED FOR, not listed
+
+            string group = SkseGroupOf(rel, pre);                 // "" = top-level; else the immediate subfolder (the derived group key)
+            var place = view.ResolveForPlacement(rel);
+            // The FULL conflict chain, winner-first (asset-tool parity): keep every provider + its loose/BSA kind, not just a count.
+            var providers = place.Sources
+                .Select(s => new SkseProvider(s.ProviderName, s.Kind == AssetKind.Bsa ? "BSA" : "loose"))
+                .ToList();
+            var winner = place.Sources.Count > 0 ? place.Sources[0] : null;
+
+            if (isDll)
+            {
+                SksePluginReader.SksePluginInfo? info = null;
+                string? note = null;
+                if (winner is { Kind: AssetKind.Loose, LooseFilePath: { } path })
+                    info = SksePluginReader.Read(path);           // the winning loose copy
+                else if (winner is null) note = "no active mod provides this DLL";
+                else note = "provided ONLY inside a BSA — the SKSE loader scans loose Data\\SKSE\\Plugins only, so this DLL will not load";
+                if (group.Length > 0 && note is null)
+                    note = $"in subfolder '{group}' — NOT on SKSE's loader path (scans SKSE\\Plugins\\*.dll top-level only); a bundled/parent-loaded DLL, not a plugin SKSE loads";
+                dlls.Add(new SkseFileEntry(rel, Path.GetFileName(rel), group, providers, info, note));
+            }
+            else
+                configs.Add(new SkseFileEntry(rel, Path.GetFileName(rel), group, providers, null, null));
+        }
+        return new SkseInventoryData(dlls, configs, otherFiles, view.BsaFailures, view.ReadIncomplete, warnings, profileName);
+    }
+
+    /// <summary>The immediate subfolder under SKSE\Plugins a file sits in ("" = directly at top level) — the DERIVED,
+    /// by-construction grouping key for the SKSE inventory. Whatever a modlist ships becomes a group; there is NO hardcoded
+    /// framework list (a hand-maintained list would be a cornerstone violation + a Q3 silent-miscategorize for any framework
+    /// not on it). e.g. <c>SKSE\Plugins\SkyPatcher\Weapons\x.ini</c> → "SkyPatcher"; <c>SKSE\Plugins\EngineFixes.toml</c> → "".</summary>
+    static string SkseGroupOf(string rel, string pre)
+    {
+        if (!rel.StartsWith(pre, StringComparison.OrdinalIgnoreCase)) return "";
+        int slash = rel.IndexOf('\\', pre.Length);
+        return slash < 0 ? "" : rel.Substring(pre.Length, slash - pre.Length);
+    }
+
     // ---- facegen-diagnostics Phase 3: place an asset so the correct copy WINS the VFS (housecarl_place_asset) ----
 
     /// <summary>Place one-or-more assets (FaceGen .nif/.dds, or any Data-relative file) into a NEW houseCARL-owned MO2 mod
@@ -2877,6 +2956,48 @@ public sealed record AssetPathResult(string RelPath, AssetHit? Hit, string? Erro
 /// names the active profile the answer describes.</summary>
 public sealed record AssetStatusData(
     IReadOnlyList<AssetPathResult> Results,
+    IReadOnlyList<string> BsaFailures,
+    bool ReadIncomplete,
+    IReadOnlyList<string> Warnings,
+    string ProfileName);
+
+/// <summary>One provider of an SKSE-layer file: the mod / "overwrite" / "Data" / BSA-filename, and whether it's a "loose" file or
+/// a "BSA" entry. The winner-first-then-losers ordering lives in <see cref="SkseFileEntry.Providers"/>.</summary>
+public sealed record SkseProvider(string Name, string Kind);
+
+/// <summary>One file found under Data\SKSE\Plugins in the active load order (housecarl_skse_inventory). <see cref="Group"/> is the
+/// immediate subfolder it sits in ("" = top level) — the derived render-grouping key. <see cref="Providers"/> is the FULL conflict
+/// chain — every mod that ships this exact file, WINNER FIRST then the losers in precedence order (the same winner→loser
+/// transparency the asset tools give), each tagged loose/BSA; empty ⇒ nothing active provides it. <see cref="Plugin"/> is the tier-C
+/// static manifest, set ONLY for a <c>.dll</c> whose winning copy is loose (null for configs and for a BSA-only/unresolved DLL);
+/// <see cref="Note"/> carries the Q3 reason when a DLL has no readable manifest / isn't loader-scoped.</summary>
+public sealed record SkseFileEntry(
+    string RelPath,
+    string FileName,
+    string Group,
+    IReadOnlyList<SkseProvider> Providers,
+    SksePluginReader.SksePluginInfo? Plugin,
+    string? Note)
+{
+    /// <summary>The VFS winner (first provider), or null if nothing active provides the file.</summary>
+    public SkseProvider? Winner => Providers.Count > 0 ? Providers[0] : null;
+    /// <summary>The winning provider's name (mod / overwrite / Data / BSA), or null.</summary>
+    public string? WinningProvider => Winner?.Name;
+    /// <summary>The winner's kind ("loose" | "BSA"), or "none" when unprovided.</summary>
+    public string ProviderKind => Winner?.Kind ?? "none";
+    /// <summary>How many mods ship this exact file — &gt; 1 is contention worth surfacing.</summary>
+    public int ProviderCount => Providers.Count;
+}
+
+/// <summary>The data behind housecarl_skse_inventory: the SKSE-plugin layer of the active load order — <see cref="Dlls"/> (each a
+/// plugin DLL with its winning provider + static tier-C manifest) and <see cref="Configs"/> (their .ini/.toml/.json/.yaml with the
+/// winning provider), plus <see cref="OtherFileCount"/> (uncategorized files like .pdb/.txt, counted not listed). The build-level Q3
+/// caveats <see cref="BsaFailures"/> / <see cref="ReadIncomplete"/> and discovery <see cref="Warnings"/> ride along; <see cref="ProfileName"/>
+/// names the active profile the answer describes.</summary>
+public sealed record SkseInventoryData(
+    IReadOnlyList<SkseFileEntry> Dlls,
+    IReadOnlyList<SkseFileEntry> Configs,
+    int OtherFileCount,
     IReadOnlyList<string> BsaFailures,
     bool ReadIncomplete,
     IReadOnlyList<string> Warnings,

--- a/src/housecarl-mcp/SkseTools.cs
+++ b/src/housecarl-mcp/SkseTools.cs
@@ -223,9 +223,10 @@ static class SkseInventoryWire
             sb.Append("  [!] contested by ").Append(e.ProviderCount).Append(" mods — full chain (winner first): ").Append(Chain(e)).Append('\n');
 
         var p = e.Plugin;
-        if (p is null) { sb.Append("  ").Append(e.Note ?? "no static metadata").Append('\n'); return; }
-        if (e.Note is { } note && p.Kind == SksePluginReader.SksePluginKind.Modern && e.Group.Length > 0)
-            sb.Append("  [!] ").Append(note).Append('\n');   // a subfolder DLL that still has a manifest — flag it isn't loader-scoped
+        // Service-level note (subfolder-not-loader-scoped / no active provider / BSA-only) — shown for ANY kind, not just
+        // Modern (fix: a bundled-dependency or unreadable DLL in a subfolder also deserves the loader-path flag).
+        if (e.Note is { } enote) sb.Append("  [!] ").Append(enote).Append('\n');
+        if (p is null) { if (e.Note is null) sb.Append("  no static metadata\n"); return; }
 
         switch (p.Kind)
         {
@@ -233,15 +234,15 @@ static class SkseInventoryWire
             case SksePluginReader.SksePluginKind.NotSkse:
             case SksePluginReader.SksePluginKind.Unreadable:
                 sb.Append("  ").Append(p.Note).Append('\n');
-                if (!p.Is64Bit) sb.Append("  [!] NOT an x64 image — a 32-bit DLL cannot load in Skyrim SE/AE.\n");
-                return;
+                if (p.Is64Bit == false) sb.Append("  [!] NOT an x64 image — a 32-bit DLL cannot load in Skyrim SE/AE.\n");
+                return;   // Is64Bit == false is EXPLICITLY-determined non-x64; null (unknown) never triggers the claim (finding #1)
         }
 
         var v = p.Version!;
         sb.Append("  \"").Append(v.Name).Append("\" by ").Append(v.Author.Length > 0 ? v.Author : "(no author)");
         if (v.SupportEmail.Length > 0) sb.Append(" <").Append(v.SupportEmail).Append('>');
         sb.Append("\n  version ").Append(v.PluginVersion).Append('\n');
-        if (!p.Is64Bit) sb.Append("  [!] NOT an x64 image — a 32-bit DLL cannot load in Skyrim SE/AE.\n");
+        if (p.Is64Bit == false) sb.Append("  [!] NOT an x64 image — a 32-bit DLL cannot load in Skyrim SE/AE.\n");
 
         if (v.VersionIndependent)
         {

--- a/src/housecarl-mcp/SkseTools.cs
+++ b/src/housecarl-mcp/SkseTools.cs
@@ -1,0 +1,320 @@
+using System.ComponentModel;
+using System.Text;
+using HousecarlCore;
+using ModelContextProtocol.Server;
+
+namespace HousecarlMcp;
+
+/// <summary>
+/// houseCARL diagnostic tool (SKSE-plugin-layer visibility, gap 2026-06-08). Read-only. Brings the SKSE-plugin layer —
+/// invisible to every record/asset tool before this — into view: the FULL DEPTH of Data\SKSE\Plugins — the <c>.dll</c>
+/// plugins, and every <c>.toml</c>/<c>.ini</c>/<c>.json</c> config beneath it grouped by its real subfolder — WHICH MOD
+/// wins the VFS for each (tier A), and each plugin's STATICALLY declared manifest — name/author/version, Address Library
+/// vs version-LOCKED, target runtimes, XSE floor (tier C). It reads what a DLL DECLARES about itself (the SKSE loader's own
+/// <c>SKSEPlugin_Version</c> data blob), never what it DOES at runtime — tier E (DLL behavior) is the honest ceiling.
+/// Full visibility, compact by default: everything is accounted for (deep configs rolled into their folder-groups, other
+/// content counted); <c>filter=</c> expands any group or plugin. See <see cref="SksePluginReader"/>.
+/// </summary>
+[McpServerToolType]
+public static class SkseTools
+{
+    [McpServerTool(Name = "housecarl_skse_inventory", ReadOnly = true, Title = "SKSE plugin layer (DLLs, configs, provider & static metadata)"),
+     Description(
+         "Inventory the SKSE-plugin layer of the ACTIVE load order — the layer houseCARL's record/asset tools are otherwise " +
+         "blind to. Covers the FULL depth of Data\\SKSE\\Plugins: the .dll plugins and every .ini/.toml/.json/.yaml config " +
+         "beneath, each with the MOD that wins the VFS for it. Configs are grouped by their real subfolder (SkyPatcher, " +
+         "DynamicStringDistributor, OStim, … — derived from the actual tree, never a hardcoded list), so the default stays " +
+         "compact while accounting for everything; non-config content is counted, never dropped. For every modern plugin it " +
+         "also reads the STATIC manifest the SKSE loader itself reads — name, author, version, whether it uses Address Library " +
+         "(version-independent) or is LOCKED to specific game runtimes, and the XSE floor — by parsing the DLL's " +
+         "SKSEPlugin_Version data export WITHOUT loading or running it. Leads with the diagnostics that matter: version-LOCKED " +
+         "plugins (won't load on a mismatched game version), legacy query-only plugins (metadata set at runtime — not statically " +
+         "readable), non-plugin DLLs (bundled dependencies), subfolder DLLs (not on SKSE's loader path), and any DLL contested " +
+         "by more than one mod. Pass filter= a plugin/mod/DLL name, author, or config FOLDER (e.g. 'SkyPatcher', 'EngineFixes', " +
+         "'po3', 'OStim') to expand that group or see a plugin in full (all flags, compatible runtimes, email, providers, " +
+         "configs). It does NOT read DLL behavior (that's the ceiling), and it does NOT cover distributor INIs (SPID *_DISTR, " +
+         "KID *_KID) — those live in Data\\ root and are owned by the spid-authoring / kid-authoring skills. Read-only.")]
+    public static string SkseInventory(
+        LoadOrderService svc,
+        [Description("Optional. A plugin name, author, DLL filename, providing-mod, or config-FOLDER substring (case-insensitive). " +
+            "Expands the matching config folder to its individual files, and shows full per-plugin detail for a matching DLL. " +
+            "Omit for the whole-layer overview.")]
+            string? filter = null,
+        [Description("Optional. Max characters before lists are cut with an explicit notice. 0 = the server default (~80k).")]
+            int max_chars = 0) => Guard.Tool("housecarl_skse_inventory", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        var data = svc.SkseInventory();
+        return SkseInventoryWire.Render(data, filter, max_chars > 0 ? max_chars : 80_000);
+    });
+}
+
+/// <summary>Renders <see cref="SkseInventoryData"/> as compact, scannable text. Default: summary + compat, the diagnostic
+/// subsets FULLY (version-locked / legacy / non-plugin / subfolder / contested), the top-level plugin roster (terse), then
+/// the config folders GROUPED (count + providers) — everything accounted for, bounded by max_chars with an explicit cut
+/// notice (Q3 — never silent truncation). filter= expands a group to its individual configs, or a plugin to full detail.</summary>
+static class SkseInventoryWire
+{
+    public static string Render(SkseInventoryData d, string? filter, int cap)
+    {
+        if (filter is { Length: > 0 }) return RenderFiltered(d, filter.Trim(), cap);
+
+        var sb = new StringBuilder();
+        // DLLs split by SKSE-loader scope: top-level DLLs are what SKSE loads; subfolder DLLs are seen but not loader-scoped.
+        var loaded = d.Dlls.Where(e => e.Group.Length == 0).ToList();
+        var subfolder = d.Dlls.Where(e => e.Group.Length > 0).ToList();
+        var modern = loaded.Where(e => e.Plugin is { Kind: SksePluginReader.SksePluginKind.Modern }).ToList();
+        var legacy = loaded.Where(e => e.Plugin is { Kind: SksePluginReader.SksePluginKind.LegacyQuery }).ToList();
+        var notPlugin = loaded.Where(e => e.Plugin is { Kind: SksePluginReader.SksePluginKind.NotSkse }).ToList();
+        var unreadable = loaded.Where(e => e.Plugin is { Kind: SksePluginReader.SksePluginKind.Unreadable }).ToList();
+        var bsaOnly = loaded.Where(e => e.Plugin is null).ToList();
+
+        int addrLib = modern.Count(e => e.Plugin!.Version!.UsesAddressLibrary);
+        int sig = modern.Count(e => e.Plugin!.Version!.UsesSignatureScanning);
+        var locked = modern.Where(e => !e.Plugin!.Version!.VersionIndependent).ToList();
+        int groupCount = d.Configs.Select(e => e.Group).Distinct(StringComparer.OrdinalIgnoreCase).Count();
+
+        sb.Append("SKSE plugin layer — profile '").Append(d.ProfileName).Append("' — ")
+          .Append(loaded.Count).Append(" DLL(s), ").Append(d.Configs.Count).Append(" config(s) across ")
+          .Append(groupCount).Append(" folder(s)");
+        if (d.OtherFileCount > 0) sb.Append(", ").Append(d.OtherFileCount).Append(" other file(s)");
+        sb.Append(" (full depth of SKSE\\Plugins)\n");
+        sb.Append("plugins: ").Append(modern.Count).Append(" with static metadata");
+        if (legacy.Count > 0) sb.Append(" · ").Append(legacy.Count).Append(" legacy query-only");
+        if (notPlugin.Count > 0) sb.Append(" · ").Append(notPlugin.Count).Append(" non-plugin (bundled deps)");
+        if (bsaOnly.Count > 0) sb.Append(" · ").Append(bsaOnly.Count).Append(" BSA-only/unresolved");
+        if (unreadable.Count > 0) sb.Append(" · ").Append(unreadable.Count).Append(" unreadable");
+        if (subfolder.Count > 0) sb.Append(" · ").Append(subfolder.Count).Append(" in subfolders (not loader-scoped)");
+        sb.Append('\n');
+        sb.Append("compat: ").Append(addrLib).Append(" Address Library · ").Append(sig).Append(" signature-scanning · ")
+          .Append(locked.Count).Append(" version-LOCKED\n");
+
+        // ── Diagnostic subsets, FIRST and in full (the point of the tool). ──
+        if (locked.Count > 0)
+        {
+            var distinctRuntimes = locked.SelectMany(e => e.Plugin!.Version!.CompatibleVersions)
+                .Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+            sb.Append("\n[!] version-LOCKED plugins (").Append(locked.Count)
+              .Append(") — load ONLY on their listed runtime(s); a mismatch with your game version = won't load:\n");
+            AppendCapped(sb, locked, cap, e =>
+            {
+                var v = e.Plugin!.Version!;
+                string rt = v.CompatibleVersions.Count > 0 ? string.Join(", ", v.CompatibleVersions) : "(none listed!)";
+                return $"  - {e.FileName} → {rt}   [\"{v.Name}\"{Provider(e)}]";
+            });
+            if (distinctRuntimes.Count > 1)
+                sb.Append("      ↑ these target DIFFERENT runtimes (").Append(string.Join(", ", distinctRuntimes))
+                  .Append(") — verify each matches your game version.\n");
+        }
+
+        AppendSubset(sb, "legacy query-only (SE/VR-era — metadata set at runtime, not statically readable)", legacy, cap,
+            e => $"  - {e.FileName}{Provider(e)}");
+        AppendSubset(sb, "non-plugin DLLs (no SKSE export — a bundled dependency, not a plugin)", notPlugin, cap,
+            e => $"  - {e.FileName}{Provider(e)}");
+        AppendSubset(sb, "subfolder DLLs (present but NOT on SKSE's loader path — bundled/parent-loaded, not plugins SKSE loads)", subfolder, cap,
+            e => $"  - {e.Group}\\{e.FileName}{Provider(e)}");
+        AppendSubset(sb, "BSA-only / unresolved DLLs (SKSE loads loose DLLs only — these will NOT load)", bsaOnly, cap,
+            e => $"  - {e.FileName}{Provider(e)}  — {e.Note}");
+        AppendSubset(sb, "unreadable DLLs (not a valid PE image)", unreadable, cap,
+            e => $"  - {e.FileName}{Provider(e)}  — {e.Plugin?.Note}");
+
+        var contested = loaded.Where(e => e.ProviderCount > 1).ToList();
+        AppendSubset(sb, "contested DLLs (shipped by >1 mod — winner-first conflict chain; verify the winner is the one you want)", contested, cap,
+            e => $"  - {e.FileName}: {Chain(e)}");
+
+        // ── Plugin roster (the loaded, metadata-bearing plugins) — terse. ──
+        sb.Append("\nplugins with metadata (").Append(modern.Count).Append(") — name · version · compat · winning mod:\n");
+        AppendCapped(sb, modern.OrderBy(e => e.FileName, StringComparer.OrdinalIgnoreCase).ToList(), cap, e =>
+        {
+            var v = e.Plugin!.Version!;
+            return $"  - {e.FileName}  \"{v.Name}\" v{v.PluginVersion}  {CompatTag(v)}{Provider(e)}";
+        });
+
+        // ── Config FOLDERS — grouped by the derived subfolder, sorted by size. Everything accounted for, compactly. ──
+        if (d.Configs.Count > 0)
+        {
+            var groups = d.Configs.GroupBy(e => e.Group, StringComparer.OrdinalIgnoreCase)
+                .Select(g => (Name: g.Key.Length == 0 ? "(top level)" : g.Key, Count: g.Count(),
+                              Providers: g.Select(e => e.WinningProvider).Where(p => p is not null).Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+                              Contested: g.Count(e => e.ProviderCount > 1)))
+                .OrderByDescending(g => g.Count).ThenBy(g => g.Name, StringComparer.OrdinalIgnoreCase).ToList();
+            sb.Append("\nconfig folders (").Append(groups.Count).Append(") — folder: files ← provider(s):\n");
+            int shown = 0;
+            foreach (var g in groups)
+            {
+                if (sb.Length >= cap) { sb.Append("  ... [showing ").Append(shown).Append(" of ").Append(groups.Count).Append(" folders; raise max_chars]\n"); break; }
+                string prov = g.Providers.Count switch
+                {
+                    0 => "(no active provider)",
+                    <= 2 => string.Join(", ", g.Providers),
+                    _ => $"{g.Providers.Count} mods",
+                };
+                sb.Append("  - ").Append(g.Name).Append(": ").Append(g.Count).Append(" ← ").Append(prov);
+                if (g.Contested > 0) sb.Append("  [").Append(g.Contested).Append(" contested]");
+                sb.Append('\n'); shown++;
+            }
+        }
+
+        sb.Append("(scope: full depth of Data\\SKSE\\Plugins. DLLs are top-level = what SKSE loads; configs at any depth are " +
+                  "grouped by folder above. Non-config content (animation/mesh/etc.) is counted in the 'other file(s)' total.)\n");
+        AppendCaveats(sb, d);
+        sb.Append("\n→ filter='<plugin/mod/DLL name>' for a plugin's full detail, or filter='<folder>' (e.g. SkyPatcher, OStim) to list a config group.");
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    /// <summary>filter= : full detail for every matching DLL, then every matching config (by folder, filename, or provider) —
+    /// so a folder name expands its group, a plugin name shows the manifest, a mod name shows everything it provides.</summary>
+    static string RenderFiltered(SkseInventoryData d, string filter, int cap)
+    {
+        bool In(string? s) => s is not null && s.Contains(filter, StringComparison.OrdinalIgnoreCase);
+        bool MatchDll(SkseFileEntry e) => In(e.FileName) || In(e.WinningProvider) || In(e.Group)
+            || (e.Plugin?.Version is { } v && (In(v.Name) || In(v.Author)));
+        bool MatchCfg(SkseFileEntry e) => In(e.FileName) || In(e.WinningProvider) || In(e.Group);
+
+        var dllHits = d.Dlls.Where(MatchDll).OrderBy(e => e.FileName, StringComparer.OrdinalIgnoreCase).ToList();
+        var cfgHits = d.Configs.Where(MatchCfg).ToList();
+
+        var sb = new StringBuilder();
+        sb.Append("SKSE plugin layer — filter '").Append(filter).Append("' — ")
+          .Append(dllHits.Count).Append(" DLL + ").Append(cfgHits.Count).Append(" config match(es) [profile '").Append(d.ProfileName).Append("']\n");
+
+        if (dllHits.Count == 0 && cfgHits.Count == 0)
+        {
+            sb.Append("\nnothing under SKSE\\Plugins matched. ")
+              .Append(HousecarlCore.PluginNameSuggest.DidYouMean(filter,
+                  d.Dlls.Select(e => e.FileName).Concat(d.Configs.Select(e => e.Group).Where(g => g.Length > 0)).Distinct()));
+            return sb.ToString().TrimEnd('\n');
+        }
+
+        var shownCfg = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var e in dllHits)
+        {
+            if (sb.Length >= cap) { sb.Append("\n  ... [remaining DLL matches omitted at max_chars=").Append(cap).Append("]\n"); break; }
+            AppendDetail(sb, e, d, shownCfg);
+        }
+
+        // Remaining matching configs (not already shown as a DLL's paired config), grouped by folder.
+        var rest = cfgHits.Where(e => !shownCfg.Contains(e.RelPath))
+            .OrderBy(e => e.Group, StringComparer.OrdinalIgnoreCase).ThenBy(e => e.FileName, StringComparer.OrdinalIgnoreCase).ToList();
+        if (rest.Count > 0)
+        {
+            sb.Append("\nmatching configs (").Append(rest.Count).Append("):\n");
+            string? curGroup = null;
+            int shown = 0;
+            foreach (var e in rest)
+            {
+                if (sb.Length >= cap) { sb.Append("  ... [showing ").Append(shown).Append(" of ").Append(rest.Count).Append("; raise max_chars]\n"); break; }
+                string g = e.Group.Length == 0 ? "(top level)" : e.Group;
+                if (g != curGroup) { sb.Append("  ").Append(g).Append(":\n"); curGroup = g; }
+                sb.Append("    - ").Append(e.FileName);
+                if (e.ProviderCount > 1) sb.Append(": ").Append(Chain(e));   // contested config → the full winner→loser chain
+                else sb.Append(Provider(e));
+                sb.Append('\n'); shown++;
+            }
+        }
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    static void AppendDetail(StringBuilder sb, SkseFileEntry e, SkseInventoryData d, HashSet<string> shownCfg)
+    {
+        sb.Append('\n').Append(e.Group.Length > 0 ? e.Group + "\\" : "").Append(e.FileName).Append("  ← ")
+          .Append(e.WinningProvider ?? "(no active provider)").Append(" (").Append(e.ProviderKind).Append(")\n");
+        if (e.ProviderCount > 1)
+            sb.Append("  [!] contested by ").Append(e.ProviderCount).Append(" mods — full chain (winner first): ").Append(Chain(e)).Append('\n');
+
+        var p = e.Plugin;
+        if (p is null) { sb.Append("  ").Append(e.Note ?? "no static metadata").Append('\n'); return; }
+        if (e.Note is { } note && p.Kind == SksePluginReader.SksePluginKind.Modern && e.Group.Length > 0)
+            sb.Append("  [!] ").Append(note).Append('\n');   // a subfolder DLL that still has a manifest — flag it isn't loader-scoped
+
+        switch (p.Kind)
+        {
+            case SksePluginReader.SksePluginKind.LegacyQuery:
+            case SksePluginReader.SksePluginKind.NotSkse:
+            case SksePluginReader.SksePluginKind.Unreadable:
+                sb.Append("  ").Append(p.Note).Append('\n');
+                if (!p.Is64Bit) sb.Append("  [!] NOT an x64 image — a 32-bit DLL cannot load in Skyrim SE/AE.\n");
+                return;
+        }
+
+        var v = p.Version!;
+        sb.Append("  \"").Append(v.Name).Append("\" by ").Append(v.Author.Length > 0 ? v.Author : "(no author)");
+        if (v.SupportEmail.Length > 0) sb.Append(" <").Append(v.SupportEmail).Append('>');
+        sb.Append("\n  version ").Append(v.PluginVersion).Append('\n');
+        if (!p.Is64Bit) sb.Append("  [!] NOT an x64 image — a 32-bit DLL cannot load in Skyrim SE/AE.\n");
+
+        if (v.VersionIndependent)
+        {
+            var how = new List<string>();
+            if (v.UsesAddressLibrary) how.Add("Address Library");
+            if (v.UsesSignatureScanning) how.Add("signature scanning");
+            sb.Append("  runtime compat: version-INDEPENDENT via ").Append(string.Join(" + ", how))
+              .Append(" — loads on any supported game runtime");
+            if (v.UsesAddressLibrary) sb.Append(" (needs the Address Library for SKSE Plugins mod installed)");
+            sb.Append('\n');
+        }
+        else
+        {
+            string rt = v.CompatibleVersions.Count > 0 ? string.Join(", ", v.CompatibleVersions) : "(none listed — will refuse every runtime!)";
+            sb.Append("  runtime compat: version-LOCKED → loads ONLY on ").Append(rt)
+              .Append("  [!] a game version outside this list = won't load\n");
+        }
+        var structs = new List<string>();
+        if (v.UsesUpdatedStructs) structs.Add("post-1.6.629 structs");
+        if (v.DeclaresNoStructs) structs.Add("no CommonLib structs");
+        if (structs.Count > 0) sb.Append("  struct compat: ").Append(string.Join(", ", structs)).Append('\n');
+        if (v.MinimumXseVersion is { } xse) sb.Append("  requires SKSE ≥ ").Append(xse).Append('\n');
+
+        // Paired configs: a config anywhere under SKSE\Plugins whose basename stem matches the DLL (best-effort association).
+        string stem = System.IO.Path.GetFileNameWithoutExtension(e.FileName);
+        var cfgs = d.Configs.Where(c => System.IO.Path.GetFileNameWithoutExtension(c.FileName)
+            .StartsWith(stem, StringComparison.OrdinalIgnoreCase)).ToList();
+        if (cfgs.Count > 0)
+        {
+            sb.Append("  configs: ").Append(string.Join(", ", cfgs.Select(c =>
+                (c.Group.Length > 0 ? c.Group + "\\" : "") + c.FileName + Provider(c)))).Append('\n');
+            foreach (var c in cfgs) shownCfg.Add(c.RelPath);
+        }
+    }
+
+    /// <summary>The compat one-word tag for the terse roster: "AddrLib", "SigScan", or "LOCKED→[runtimes]".</summary>
+    static string CompatTag(SksePluginReader.SkseVersionInfo v)
+    {
+        if (v.UsesAddressLibrary) return "AddrLib";
+        if (v.UsesSignatureScanning) return "SigScan";
+        return "LOCKED→" + (v.CompatibleVersions.Count > 0 ? string.Join("/", v.CompatibleVersions) : "?");
+    }
+
+    static string Provider(SkseFileEntry e) =>
+        e.WinningProvider is null ? "  (no active provider)" : $"  ← {e.WinningProvider}";
+
+    /// <summary>The full VFS conflict chain, winner FIRST then losers in precedence order, each tagged loose/BSA — the
+    /// asset-tool conflict transparency (which mod wins this file, and who it overrides). "(no active provider)" when empty.</summary>
+    static string Chain(SkseFileEntry e) =>
+        e.Providers.Count == 0 ? "(no active provider)" : string.Join(" › ", e.Providers.Select(p => $"{p.Name} ({p.Kind})"));
+
+    static void AppendSubset(StringBuilder sb, string label, IReadOnlyList<SkseFileEntry> items, int cap, Func<SkseFileEntry, string> line)
+    {
+        if (items.Count == 0) return;
+        sb.Append('\n').Append(label).Append(" (").Append(items.Count).Append("):\n");
+        AppendCapped(sb, items, cap, line);
+    }
+
+    static void AppendCapped(StringBuilder sb, IReadOnlyList<SkseFileEntry> items, int cap, Func<SkseFileEntry, string> line)
+    {
+        int shown = 0;
+        foreach (var e in items)
+        {
+            if (sb.Length >= cap) { sb.Append("  ... [showing ").Append(shown).Append(" of ").Append(items.Count).Append("; raise max_chars or use filter= to see all]\n"); break; }
+            sb.Append(line(e)).Append('\n'); shown++;
+        }
+    }
+
+    static void AppendCaveats(StringBuilder sb, SkseInventoryData d)
+    {
+        if (d.ReadIncomplete)
+            sb.Append("[!] a BSA failed to read this build, so a file present only in it may be missing from this inventory (Q3).\n");
+        foreach (var w in d.Warnings) sb.Append("[!] ").Append(w).Append('\n');
+        foreach (var f in d.BsaFailures) sb.Append("[!] archive read failure: ").Append(f).Append('\n');
+    }
+}


### PR DESCRIPTION
Closes the **diagnose half** of the SKSE-plugin-layer visibility gap (bug report `2026-06-08_gap_skse-plugin-layer-visibility`, tiers **A + C**). houseCARL's record/asset tools were blind to the DLLs under `Data\SKSE\Plugins`, their configs, which mod wins each, and what each plugin declares about itself.

## What `housecarl_skse_inventory` does

- **Tier A — inventory (full depth).** Every `.dll` plugin and every `.ini`/`.toml`/`.json`/`.yaml` config under `SKSE\Plugins`, each resolved to its winning VFS provider. **Full visibility by construction:** configs carry their *derived* subfolder group (SkyPatcher / DynamicStringDistributor / OStim / … — whatever the modlist ships, never a hardcoded list) so the render groups them compactly; non-config content is counted, never dropped; a subfolder DLL is *seen but flagged* (SKSE scans `SKSE\Plugins\*.dll` top-level only, so it isn't loaded as a plugin).
- **Conflict-aware at asset-tool parity.** Each file carries the full **winner → loser** provider chain (each tagged loose/BSA), so a contested DLL shows which mod's copy wins and what it overrides — e.g. `EldenParry.dll: dTry Plugin Updates - AE › Elden Parry` — not just a count.
- **Tier C — static metadata.** Parses each winning DLL's `SKSEPlugin_Version` data export **without loading or running it**: name, author, version, Address Library vs version-LOCKED, target runtimes, XSE floor. Tier E (DLL behavior) is the honest ceiling; a legacy `SKSEPlugin_Query`-only plugin degrades to "set at runtime, not statically readable" (Q3), and a no-SKSE-export DLL is flagged a bundled dependency.
- **`filter=`** is free-text (name / mod / author / config **folder**) — expands a group to its individual configs (with conflict chains), or a plugin to full detail. Derived groups → generalizes to any modlist.

## The load-bearing detail

The `SKSEPluginVersionData` byte layout was reverse-engineered, anchored to the `alandtse/CommonLibVR@ng` + `powerof3/CommonLibSSE@dev` headers, and **validated byte-for-byte against the live load order (297 real DLLs)**. The non-obvious catch: `supportEmail[252]` (**not** 256), which puts the flag fields at `0x304`/`0x308` — get it wrong and every compat flag reads garbage.

## Validation

- **`skse-reader-guard`** — a new CI probe (30 assertions) pinning the decode contract (offsets, flags, version packing, zero-terminated compat list) + the honest-degrade paths (real-PE `Read` → NotSkse; non-PE / missing → Unreadable, never a throw).
- **`ci-all` 72/72** — the `LoadOrderService` change broke nothing; `AssetResolver` is untouched.
- **`skse-inventory-real`** — a manual real-data harness (matches the codebase's `--*-real` convention). Live order: 261 DLLs, 720 configs across 51 derived folders, ~370-line overview.

## Caveats (Q3)

- **~7–9s cold** on a large list — the full-depth walk + provider resolve. It's a one-time diagnostic (not a per-turn call), and a chunk is the shared asset-resolver build that any asset query pays once per session. Kept full-depth (accuracy over perf) after weighing it against a lazy-resolve mode that would trade away the overview's per-group provider/conflict detail.
- **Not yet exercised through the live MCP stdio round-trip** — validated via the service + render + reader + regression suite, but the tool's attribute wiring is identical to the other 28 tools. In-app confirmation is the remaining empirical step.

## Follow-ups (not in this PR)

- Release cut owes: tool count **28 → 29** + CHANGELOG (+ the pile already on `main`).
- Minor: a PE `VS_VERSIONINFO` fallback for the ~7 legacy query-only DLLs (best-effort, different source).
- **Highest-value next capability:** a distributor-audit tool (tier B for the SkyPatcher/SPID layer) — SkyPatcher-first (safe resolve+diff), SPID/KID as ref-validation not full filter-simulation (fidelity/Q3 risk). Its own build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
