### PR TITLE
feat(write): substruct compose-Set — fill a whole modeled-struct field in one op (chain Stage 2b)

### DIFF
--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -414,6 +414,15 @@ public sealed class CorpusRulebook
         }
         if (req.Verb is "Set" && leaf.Cardinality == "polymorphic")
             return ArmLegality(leaf, req.Struct);
+        // A whole modeled-STRUCT substruct leaf (FaceParts, ObjectBounds, FaceMorph, a concrete script-property arm, …) is
+        // Set by composing its value FROM PARTS — the leaf twin of the dict-element (above) and polymorphic-arm (just above)
+        // compose paths, validated by the SAME StructSpecContents. Apply already builds it (ApplyScalarVerb req.Struct ->
+        // BuildStruct), so this LIFTS the documented safe over-reject (write-preflight audit §3(b)) so a one-shot subtree
+        // author can fill an absent struct in ONE op. SchemaClassifier scopes it so a coercible substruct (TranslatedString)
+        // keeps its plain-value Set below, and a composition-residual (GenderedItem — diverted to [0]/[1] upstream — /
+        // Array2d — no paramless ctor) stays out (gate==apply, no accept-then-throw). Chain Stage 2b.
+        if (req.Verb is "Set" && SchemaClassifier.IsComposableSubstructLeaf(leaf, _corpus))
+            return StructLeafLegality(leaf, req.Struct);
         if (req.Verb is "Set")
         {
             if (req.Value is null) return $"Set on '{leaf.Name}' requires a value.";
@@ -643,6 +652,27 @@ public sealed class CorpusRulebook
             return $"Element spec type '{spec.Type}' does not match '{leaf.Name}' element type '{er}'.{legal}";
         }
         return StructSpecContents(spec, specSchema);
+    }
+
+    /// <summary>Validate a whole-struct compose Set on a SUBSTRUCT leaf — the leaf twin of <see cref="StructElementLegality"/>,
+    /// keyed on the leaf's own <see cref="FieldSchema.TypeRef"/>. The spec must be present and its type must match the leaf's
+    /// struct type; its contents then validate against that type's schema via the shared <see cref="StructSpecContents"/>
+    /// (flat Fields + nested Sets + ctor-args) — the SAME recognizer the struct-element Add and polymorphic-arm Set use, so
+    /// the three composition entry points can't disagree. A substruct leaf's TypeRef is always a CONCRETE struct/arm (a
+    /// polymorphic FIELD is cardinality "polymorphic", handled above), so a straight name-match is correct — no poly-base
+    /// arm resolution. Reached only for a <see cref="SchemaClassifier.IsComposableSubstructLeaf"/> leaf (TypeRef non-null,
+    /// corpus-present, apply-instantiable) — the null-spec branch replaces the misleading scalar "requires a value".</summary>
+    string? StructLeafLegality(FieldSchema leaf, StructSpec? spec)
+    {
+        var tr = leaf.TypeRef!;               // non-null by IsComposableSubstructLeaf
+        var schema = Type(tr);
+        if (schema is null) return $"Struct type '{tr}' for '{leaf.Name}' absent from corpus.";
+        if (spec is null)
+            return $"'{leaf.Name}' is a {tr} struct — set it by composing from parts (a compose spec, e.g. " +
+                   $"{{\"type\":\"{tr}\", \"fields\":{{…}}}}), or navigate into it and Set a sub-field; a plain value can't express a struct.";
+        if (spec.Type != tr)
+            return $"Compose type '{spec.Type}' does not match '{leaf.Name}' struct type '{tr}'.";
+        return StructSpecContents(spec, schema);
     }
 
     /// <summary>Validate a build-from-parts spec's CONTENTS against its declared struct type: flat <see cref="StructSpec.Fields"/>

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -425,7 +425,14 @@ public sealed class CorpusRulebook
             return StructLeafLegality(leaf, req.Struct);
         if (req.Verb is "Set")
         {
-            if (req.Value is null) return $"Set on '{leaf.Name}' requires a value.";
+            // A compose spec reaching HERE means the leaf isn't a compose target (not a composable substruct/dict/poly —
+            // those branch above): a coercible substruct (a TranslatedString — set as one value, not built from parts), a
+            // formlink, or a plain scalar. Name the plain-value path instead of the misleading "requires a value" (which
+            // reads as "value= is absent"). compose is for a build-from-parts struct/dict/polymorphic field only.
+            if (req.Value is null)
+                return req.Struct is not null
+                    ? $"'{leaf.Name}' is set from a plain value (value=…), not a compose spec."
+                    : $"Set on '{leaf.Name}' requires a value.";
             // formlink / substruct-whole: the engine must be able to coerce the leaf's whole type. A normal formlink
             // coerces; a condition FormLinkOrIndex is handled by the parent-aware SetFloi branch (wave 4) — validate
             // its target-value SHAPE here; a non-string substruct still rejects honestly (so pre-flight never

--- a/src/housecarl-core/SchemaClassifier.cs
+++ b/src/housecarl-core/SchemaClassifier.cs
@@ -108,4 +108,22 @@ public static class SchemaClassifier
     /// AssetLink-path elements (set as one value). Defined via <see cref="ClassifyElement"/> so it cannot drift from it.</summary>
     public static bool IsStructElement(FieldSchema f, Corpus corpus) =>
         ClassifyElement(f, corpus) == ElementKind.Struct;
+
+    /// <summary>True iff a scalar SUBSTRUCT leaf can be Set by composing its whole value FROM PARTS (a StructSpec) — the
+    /// LEAF twin of <see cref="IsStructElement"/>, keyed on the leaf's own <see cref="FieldSchema.TypeRef"/> instead of an
+    /// element ref. Requires ALL of: a substruct leaf; whose modeled type is a build-from-parts struct OR concrete arm
+    /// (corpus Kind); that is NOT coercible-from-a-value (<see cref="CoercibleLeaf"/> — a TranslatedString substruct keeps
+    /// its plain-value Set, never re-routed to compose-only); and that <see cref="WriteEngine.IsPlainComposableStruct"/>
+    /// can instantiate — which EXCLUDES the composition-residuals <c>GenderedItem&lt;T&gt;</c>/<c>Array2d&lt;T&gt;</c> (no
+    /// parameterless ctor; BuildStruct would throw). The last two guards keep the accept in lock-step with what
+    /// <c>ApplyScalarVerb</c> req.Struct → <c>BuildStruct</c> can actually build (gate==apply). Gendered leaves never reach
+    /// the compose gate — <c>CorpusRulebook</c> diverts them to their [0]/[1] halves upstream. Corpus-derived, no per-type
+    /// wiring (cornerstone): the set of composable substructs IS the set of modeled build-from-parts struct/arm types.</summary>
+    public static bool IsComposableSubstructLeaf(FieldSchema f, Corpus corpus)
+    {
+        if (f.Cardinality != "substruct" || f.TypeRef is not { } tr) return false;
+        if (corpus.Types.GetValueOrDefault(tr)?.Kind is not ("struct" or "arm")) return false;
+        if (CoercibleLeaf(f)) return false;                       // coercible substruct → keeps its plain-value Set
+        return WriteEngine.IsPlainComposableStruct(tr);           // excludes GenderedItem/Array2d (no paramless ctor)
+    }
 }

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1797,6 +1797,23 @@ public static class WriteEngine
             $"Unknown struct type '{name}' — no concrete class in Mutagen.Bethesda.Skyrim nor any Mutagen assembly. " +
             "If Mutagen models it under another name, surface that; never guess.");
 
+    /// <summary>True iff <see cref="BuildStruct"/> can instantiate this catalog TYPE from a PARAMETERLESS compose (no
+    /// ctor_args, no composition): the name resolves via <see cref="ResolveStructType"/> to a concrete Mutagen type with
+    /// a public parameterless ctor. The gate-side twin of what <see cref="Instantiate"/> does with no ctor_args — it
+    /// EXCLUDES the composition-residuals <c>GenderedItem&lt;T&gt;</c> / <c>Array2d&lt;T&gt;</c> (no parameterless ctor,
+    /// so Instantiate routes to <see cref="InstantiateComposition"/>, which builds only gendered halves and throws for the
+    /// rest) and any name ResolveStructType can't resolve. Used by the substruct-leaf compose gate so it accepts EXACTLY
+    /// what apply can build (gate==apply, by construction; no per-type list). A ctor-arg-only type is (correctly) excluded:
+    /// a substruct leaf whose whole value needs positional ctor args is not a plain compose target.</summary>
+    internal static bool IsPlainComposableStruct(string? typeName)
+    {
+        if (typeName is null) return false;
+        Type t;
+        try { t = ResolveStructType(typeName); }
+        catch { return false; }
+        return t.GetConstructor(Type.EmptyTypes) is not null;
+    }
+
     /// <summary>Instantiate a concrete type for build-from-parts. Order: explicit positional ctor args (discriminator
     /// arm like <c>MagicEffectArchetype(TypeEnum)</c>, or composition parts) → parameterless ctor (the common case) →
     /// composition build (no parameterless ctor + no explicit args).</summary>

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -337,6 +337,8 @@ namespace HousecarlGenerator;
 ///   SUBSTRUCT-SET-ARRAY2D-REJECTED  — an Array2d composition-residual is NOT opened (no accept-then-throw; the paramless-ctor exclusion).
 ///   SUBSTRUCT-SET-COMPOSE-E2E       — a composed NpcFaceParts(Nose=32) round-trips through the real create+apply path onto NPC_.FaceParts on disk.
 ///   SUBSTRUCT-SET-DOTTED-VIVIFY     — the report's ideal (b): Set FaceParts.Nose on an ABSENT struct auto-vivifies it then sets the sub-field, E2E.
+///   SUBSTRUCT-SET-ARM-COMPOSE-E2E   — the ARM-typed case round-trips build+assign+SERIALIZE: a composed SceneScriptFragments lands on Scene.VMAD.ScriptFragments on disk (PR #147 review finding 2).
+///   SUBSTRUCT-SET-COERCIBLE-COMPOSE-MSG — a compose on a COERCIBLE substruct (ButtonLabel) names the plain-value path, not the misleading 'requires a value' (PR #147 review finding 3).
 /// </summary>
 public static class NestedCreateGuardProbe
 {
@@ -2338,11 +2340,45 @@ public static class NestedCreateGuardProbe
             Console.WriteLine($"   SUBSTRUCT-SET-DOTTED-VIVIFY        : {(substructDottedVivifyOk ? "PASS — Set FaceParts.Nose on an ABSENT struct auto-vivifies it then sets the sub-field (report ideal b, guaranteed)" : $"FAIL — success={o.Success} present={present} err=[{o.Error}]")}");
         }
 
+        // ---------- SUBSTRUCT-SET-ARM-COMPOSE-E2E: the ARM-typed substruct case round-trips build+assign+SERIALIZE to disk ----------
+        // SUBSTRUCT-SET-ARM-COMPOSE-OK proves only the GATE accepts an arm-typed substruct leaf; this proves apply BUILDS,
+        // ASSIGNS, and SERIALIZES one. Set Scene.VirtualMachineAdapter.ScriptFragments (SceneAdapter is vivified mid-path,
+        // then the arm-typed SceneScriptFragments leaf composed) with the fields it needs to serialize, then re-read the
+        // Scene off disk and confirm its VMAD carries the fragments. Closes PR #147 review finding 2 (arm E2E gap).
+        bool substructArmE2eOk = false;
+        {
+            string pPath = Path.Combine(tmpDir, "HcNcSubArm.esp");
+            var specs = new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "Scene", EditorId = "HcNcSubArmScene",
+                    Edits = new[] { new WriteRequest { RecordType = "Scene", Path = new[] { "VirtualMachineAdapter", "ScriptFragments" }, Verb = "Set",
+                        Struct = new StructSpec { Type = "SceneScriptFragments", Fields = new Dictionary<string, string> { ["FileName"] = "HcScene", ["ExtraBindDataVersion"] = "2" } } } } },
+            };
+            using var r = LoadOrderResolver.Build(new[] { mPath });
+            var o = WritePatchBuilder.CreateRecords(r, rulebook, specs, pPath, extend: false);
+            bool present = o.Success && o.Created.Count > 0 && SceneVmadFragmentsPresent(pPath, o.Created[0].FormKey);
+            substructArmE2eOk = o.Success && present;
+            Console.WriteLine($"   SUBSTRUCT-SET-ARM-COMPOSE-E2E      : {(substructArmE2eOk ? "PASS — a composed SceneScriptFragments (arm) round-trips through create+apply onto Scene.VMAD.ScriptFragments on disk" : $"FAIL — success={o.Success} present={present} err=[{o.Error}]")}");
+        }
+
+        // ---------- SUBSTRUCT-SET-COERCIBLE-COMPOSE-MSG: a compose on a COERCIBLE substruct names the plain-value path ----------
+        // Review finding 3: passing a compose on a coercible substruct (TranslatedString) is a (safe) over-reject — but the
+        // message must name the plain-value path, NOT the misleading "requires a value" (which reads as "value= is absent").
+        bool substructCoercibleMsgOk;
+        {
+            var req = new WriteRequest { RecordType = "APerkEffect", Path = new[] { "ButtonLabel" }, Verb = "Set",
+                Struct = new StructSpec { Type = "TranslatedString" } };
+            var reject = rulebook.Validate(req);
+            substructCoercibleMsgOk = reject is not null && reject.Contains("plain value", StringComparison.OrdinalIgnoreCase)
+                && !reject.Contains("requires a value", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   SUBSTRUCT-SET-COERCIBLE-COMPOSE-MSG: {(substructCoercibleMsgOk ? "PASS — a compose on a coercible substruct (ButtonLabel) names the plain-value path, NOT the misleading 'requires a value'" : $"FAIL — reject=[{reject}]")}");
+        }
+
         Console.WriteLine();
         bool pass = fixturesOk && oneshotOk && multiOk && intoTopicOk && intoCellOk
                     && substructComposeOk && substructArmComposeOk && substructBadTypeOk && substructBadFieldOk
                     && substructNoSpecOk && substructCoercibleOk && substructArray2dRejOk && substructComposeE2eOk
-                    && substructDottedVivifyOk
+                    && substructDottedVivifyOk && substructArmE2eOk && substructCoercibleMsgOk
                     && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendOk
                     && sibrefOk && sibRefListAddOk && sibRefListReplaceOk && sibRejFwdOk && sibRejFwdListOk
                     && sibRejNonflOk && sibRejListSetOk && sibRejDictOk && sibRejApplyOk
@@ -2409,6 +2445,23 @@ public static class NestedCreateGuardProbe
             return n?.FaceParts?.Nose;
         }
         catch { return null; }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    /// <summary>Re-open the written patch and confirm a Scene's VMAD carries a composed SceneScriptFragments — the arm-typed
+    /// substruct compose-Set round-trip: SceneAdapter (Scene.VirtualMachineAdapter) is vivified mid-path, then its arm-typed
+    /// ScriptFragments leaf built FROM PARTS via BuildStruct and serialized. False when the Scene, its VMAD, or the fragments
+    /// is absent (so the E2E fails honestly rather than defaulting to a match).</summary>
+    static bool SceneVmadFragmentsPresent(string patchPath, FormKey sceneFk)
+    {
+        ISkyrimModGetter? ov = null;
+        try
+        {
+            ov = SkyrimMod.CreateFromBinaryOverlay(patchPath, SkyrimRelease.SkyrimSE);
+            var s = ov.Scenes.FirstOrDefault(x => x.FormKey == sceneFk);
+            return s?.VirtualMachineAdapter?.ScriptFragments is not null;
+        }
+        catch { return false; }
         finally { (ov as IDisposable)?.Dispose(); }
     }
 

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -323,6 +323,20 @@ namespace HousecarlGenerator;
 ///                       the speaker chain resolves through patchByKey (same-call records), not the load order.
 ///   VOICE-CHECKERROR  — the check run against a CORRUPT patch path surfaces on VoiceReport.CheckError and does NOT
 ///                       throw / does NOT lose the created records — the Q3 "never demote a successful create" safety net.
+///
+/// SUBSTRUCT-SET-* (chain Stage 2b) — a whole modeled-STRUCT substruct LEAF Set by composing its value FROM PARTS (the
+/// leaf twin of the GAP3 dict-element / arm compose paths). Apply already built it (ApplyScalarVerb req.Struct ->
+/// BuildStruct); this lifts the documented safe over-reject (write-preflight audit §3(b)) so a one-shot subtree author
+/// fills an absent struct in ONE op. Scoped by SchemaClassifier.IsComposableSubstructLeaf (gate==apply, no per-type list):
+///   SUBSTRUCT-SET-COMPOSE-OK        — Set NPC_.FaceParts from a NpcFaceParts compose is ACCEPTED (RED: 'requires a value').
+///   SUBSTRUCT-SET-ARM-COMPOSE-OK    — an ARM-typed substruct leaf (SceneAdapter.ScriptFragments) composes too (Aaron's fuller scope).
+///   SUBSTRUCT-SET-COMPOSE-BADTYPE   — a compose type ≠ the leaf's struct type refuses, naming it.
+///   SUBSTRUCT-SET-COMPOSE-BADFIELD  — a malformed compose field (Nose='notauint') refuses (StructSpecContents validates contents).
+///   SUBSTRUCT-SET-NOSPEC            — Set with NO compose names the compose path, NOT the misleading 'requires a value' (the report's message fix).
+///   SUBSTRUCT-SET-COERCIBLE-UNCHANGED — a coercible substruct (TranslatedString) keeps its plain-value Set (the !CoercibleLeaf exclusion; over-reject guard).
+///   SUBSTRUCT-SET-ARRAY2D-REJECTED  — an Array2d composition-residual is NOT opened (no accept-then-throw; the paramless-ctor exclusion).
+///   SUBSTRUCT-SET-COMPOSE-E2E       — a composed NpcFaceParts(Nose=32) round-trips through the real create+apply path onto NPC_.FaceParts on disk.
+///   SUBSTRUCT-SET-DOTTED-VIVIFY     — the report's ideal (b): Set FaceParts.Nose on an ABSENT struct auto-vivifies it then sets the sub-field, E2E.
 /// </summary>
 public static class NestedCreateGuardProbe
 {
@@ -2198,8 +2212,137 @@ public static class NestedCreateGuardProbe
             Console.WriteLine($"   SCRIPT-CHECKERROR surfaced not thrown:{(scriptCheckErrorOk ? "PASS — corrupt patch -> CheckError set, no throw, no findings" : $"FAIL — threw={threw} checkError=[{report.CheckError}] findings={report.Findings.Count}")}");
         }
 
+        // ====== SUBSTRUCT COMPOSE-SET — whole modeled-struct substruct leaf Set FROM PARTS (chain Stage 2b) ======
+        // A scalar SUBSTRUCT leaf (NPC_.FaceParts = NpcFaceParts, an absent 3-field struct; ObjectBounds; FaceMorph;
+        // a concrete script-property arm; …) is now Set by COMPOSING its whole value from parts — the leaf twin of the
+        // dict-element (GAP3) and polymorphic-arm compose paths, validated by the SAME StructSpecContents. Apply already
+        // built it (ApplyScalarVerb req.Struct -> BuildStruct); this LIFTS the documented safe over-reject (write-preflight
+        // audit §3(b), decision #4 "defer unless you want it" — the chain now wants it) so a one-shot subtree author can
+        // fill an absent struct in ONE op instead of a mandatory extra round-trip. Scoped BY CONSTRUCTION via
+        // SchemaClassifier.IsComposableSubstructLeaf: a COERCIBLE substruct (TranslatedString) keeps its plain-value Set,
+        // and a composition-residual (GenderedItem<T> — diverted to [0]/[1] upstream — / Array2d<T> — no paramless ctor,
+        // BuildStruct would throw) can't slip in (would be an accept-then-throw). Bug: bulk-authoring-sibling-list-refs-and-struct-set.
+
+        // ---------- SUBSTRUCT-SET-COMPOSE-OK: Set NPC_.FaceParts from a NpcFaceParts compose is ACCEPTED ----------
+        bool substructComposeOk;
+        {
+            var req = new WriteRequest { RecordType = "Npc", Path = new[] { "FaceParts" }, Verb = "Set",
+                Struct = new StructSpec { Type = "NpcFaceParts", Fields = new Dictionary<string, string> { ["Nose"] = "32", ["Eyes"] = "0", ["Mouth"] = "0" } } };
+            var reject = rulebook.Validate(req);
+            substructComposeOk = reject is null;
+            Console.WriteLine($"   SUBSTRUCT-SET-COMPOSE-OK           : {(substructComposeOk ? "PASS — a whole-struct compose Set on NPC_.FaceParts is ACCEPTED (RED before: 'Set on FaceParts requires a value' — compose ignored on a scalar Set)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- SUBSTRUCT-SET-ARM-COMPOSE-OK: an ARM-typed substruct leaf composes too (Aaron's fuller scope) ----------
+        // SceneAdapter.ScriptFragments is cardinality substruct with a Kind=arm TypeRef (SceneScriptFragments, paramless
+        // ctor). The predicate admits Kind struct OR arm — both are build-from-parts. (QuestFragmentAlias.Property is the twin.)
+        bool substructArmComposeOk;
+        {
+            var req = new WriteRequest { RecordType = "SceneAdapter", Path = new[] { "ScriptFragments" }, Verb = "Set",
+                Struct = new StructSpec { Type = "SceneScriptFragments" } };
+            var reject = rulebook.Validate(req);
+            substructArmComposeOk = reject is null;
+            Console.WriteLine($"   SUBSTRUCT-SET-ARM-COMPOSE-OK       : {(substructArmComposeOk ? "PASS — an arm-typed substruct leaf (SceneAdapter.ScriptFragments) composes too (RED before: rejected)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- SUBSTRUCT-SET-COMPOSE-BADTYPE: a compose type that isn't the leaf's struct type refuses ----------
+        bool substructBadTypeOk;
+        {
+            var req = new WriteRequest { RecordType = "Npc", Path = new[] { "FaceParts" }, Verb = "Set",
+                Struct = new StructSpec { Type = "Weapon" } };
+            var reject = rulebook.Validate(req);
+            substructBadTypeOk = reject is not null && reject.Contains("does not match", StringComparison.OrdinalIgnoreCase)
+                && reject.Contains("NpcFaceParts", StringComparison.Ordinal);
+            Console.WriteLine($"   SUBSTRUCT-SET-COMPOSE-BADTYPE      : {(substructBadTypeOk ? "PASS — a non-NpcFaceParts compose type is refused, naming the leaf's struct type" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- SUBSTRUCT-SET-COMPOSE-BADFIELD: a malformed compose field value refuses (contents validated) ----------
+        bool substructBadFieldOk;
+        {
+            var req = new WriteRequest { RecordType = "Npc", Path = new[] { "FaceParts" }, Verb = "Set",
+                Struct = new StructSpec { Type = "NpcFaceParts", Fields = new Dictionary<string, string> { ["Nose"] = "notauint" } } };
+            var reject = rulebook.Validate(req);
+            substructBadFieldOk = reject is not null && reject.Contains("Nose", StringComparison.Ordinal);
+            Console.WriteLine($"   SUBSTRUCT-SET-COMPOSE-BADFIELD     : {(substructBadFieldOk ? "PASS — a malformed compose field (Nose='notauint') is refused (StructSpecContents validates the contents)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- SUBSTRUCT-SET-NOSPEC: Set on a composable struct substruct with NO compose gives the compose guidance ----------
+        // Not the misleading "requires a value" (the bug report's specific complaint) — the message names the compose path.
+        bool substructNoSpecOk;
+        {
+            var req = new WriteRequest { RecordType = "Npc", Path = new[] { "FaceParts" }, Verb = "Set", Value = "0" };
+            var reject = rulebook.Validate(req);
+            substructNoSpecOk = reject is not null && reject.Contains("compose spec", StringComparison.OrdinalIgnoreCase)
+                && !reject.Contains("requires a value", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   SUBSTRUCT-SET-NOSPEC guidance      : {(substructNoSpecOk ? "PASS — Set FaceParts with no compose names the compose path, NOT the misleading 'requires a value'" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- SUBSTRUCT-SET-COERCIBLE-UNCHANGED: a coercible substruct (TranslatedString) keeps its plain-value Set ----------
+        // The !CoercibleLeaf exclusion: APerkEffect.ButtonLabel is a TranslatedString substruct (Kind struct) but coerces
+        // from a string — it must NOT be re-routed to compose-only. Accepted before AND after (over-reject regression guard).
+        bool substructCoercibleOk;
+        {
+            var req = new WriteRequest { RecordType = "APerkEffect", Path = new[] { "ButtonLabel" }, Verb = "Set", Value = "Activate" };
+            var reject = rulebook.Validate(req);
+            substructCoercibleOk = reject is null;
+            Console.WriteLine($"   SUBSTRUCT-SET-COERCIBLE-UNCHANGED  : {(substructCoercibleOk ? "PASS — a coercible substruct (APerkEffect.ButtonLabel/TranslatedString) still accepts a plain value (not re-routed to compose)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- SUBSTRUCT-SET-ARRAY2D-REJECTED: a composition-residual (Array2d) is NOT opened (no accept-then-throw) ----------
+        // CellMaxHeightData.HeightMap is a writable substruct with Kind=struct TypeRef ReadOnlyArray2d<Byte> — but it has
+        // NO paramless ctor, so BuildStruct would throw CompositionRequiredException at apply. IsPlainComposableStruct
+        // excludes it, so the gate keeps refusing (via the requires-a-value path) rather than accepting then throwing.
+        // RED if the ctor-exclusion is dropped: the type-matching compose would validate + accept, an accept-then-throw.
+        bool substructArray2dRejOk;
+        {
+            var req = new WriteRequest { RecordType = "CellMaxHeightData", Path = new[] { "HeightMap" }, Verb = "Set",
+                Struct = new StructSpec { Type = "ReadOnlyArray2d<Byte>" } };
+            var reject = rulebook.Validate(req);
+            substructArray2dRejOk = reject is not null;
+            Console.WriteLine($"   SUBSTRUCT-SET-ARRAY2D-REJECTED     : {(substructArray2dRejOk ? "PASS — an Array2d composition-residual is NOT opened to compose (no accept-then-throw; ctor-exclusion holds)" : $"FAIL — reject=[{reject}] (Array2d compose was ACCEPTED — would throw at apply)")}");
+        }
+
+        // ---------- SUBSTRUCT-SET-COMPOSE-E2E: a composed NpcFaceParts round-trips through the REAL create+apply path ----------
+        bool substructComposeE2eOk = false;
+        {
+            string pPath = Path.Combine(tmpDir, "HcNcSubComp.esp");
+            var specs = new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "Npc", EditorId = "HcNcSubCompNpc",
+                    Edits = new[] { new WriteRequest { RecordType = "Npc", Path = new[] { "FaceParts" }, Verb = "Set",
+                        Struct = new StructSpec { Type = "NpcFaceParts", Fields = new Dictionary<string, string> { ["Nose"] = "32", ["Eyes"] = "0", ["Mouth"] = "0" } } } } },
+            };
+            using var r = LoadOrderResolver.Build(new[] { mPath });
+            var o = WritePatchBuilder.CreateRecords(r, rulebook, specs, pPath, extend: false);
+            bool present = o.Success && o.Created.Count > 0 && NpcFacePartsNose(pPath, o.Created[0].FormKey) == 32u;
+            substructComposeE2eOk = o.Success && present;
+            Console.WriteLine($"   SUBSTRUCT-SET-COMPOSE-E2E          : {(substructComposeE2eOk ? "PASS — accepted at the gate AND a NpcFaceParts(Nose=32) written to NPC_.FaceParts on disk" : $"FAIL — success={o.Success} present={present} err=[{o.Error}]")}");
+        }
+
+        // ---------- SUBSTRUCT-SET-DOTTED-VIVIFY: the report's ideal (b) — a dotted sub-path auto-vivifies an ABSENT struct ----------
+        // Set FaceParts.Nose="32" on an NPC with NO FaceParts: ApplyVerb materializes the absent NpcFaceParts substruct
+        // (MaterializeSubstruct) mid-path, then sets Nose. Verifies + GUARANTEES the report's alternative one-op-per-field
+        // path (works independently of the compose Set above — the chain's Stage 3 may use either). E2E round-trip to disk.
+        bool substructDottedVivifyOk = false;
+        {
+            string pPath = Path.Combine(tmpDir, "HcNcSubDotted.esp");
+            var specs = new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "Npc", EditorId = "HcNcSubDottedNpc",
+                    Edits = new[] { new WriteRequest { RecordType = "Npc", Path = new[] { "FaceParts", "Nose" }, Verb = "Set", Value = "32" } } },
+            };
+            using var r = LoadOrderResolver.Build(new[] { mPath });
+            var o = WritePatchBuilder.CreateRecords(r, rulebook, specs, pPath, extend: false);
+            bool present = o.Success && o.Created.Count > 0 && NpcFacePartsNose(pPath, o.Created[0].FormKey) == 32u;
+            substructDottedVivifyOk = o.Success && present;
+            Console.WriteLine($"   SUBSTRUCT-SET-DOTTED-VIVIFY        : {(substructDottedVivifyOk ? "PASS — Set FaceParts.Nose on an ABSENT struct auto-vivifies it then sets the sub-field (report ideal b, guaranteed)" : $"FAIL — success={o.Success} present={present} err=[{o.Error}]")}");
+        }
+
         Console.WriteLine();
         bool pass = fixturesOk && oneshotOk && multiOk && intoTopicOk && intoCellOk
+                    && substructComposeOk && substructArmComposeOk && substructBadTypeOk && substructBadFieldOk
+                    && substructNoSpecOk && substructCoercibleOk && substructArray2dRejOk && substructComposeE2eOk
+                    && substructDottedVivifyOk
                     && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendOk
                     && sibrefOk && sibRefListAddOk && sibRefListReplaceOk && sibRejFwdOk && sibRejFwdListOk
                     && sibRejNonflOk && sibRejListSetOk && sibRejDictOk && sibRejApplyOk
@@ -2251,6 +2394,22 @@ public static class NestedCreateGuardProbe
         bool ok = refused && noFile && named;
         Console.WriteLine($"   {banner}: {(ok ? "PASS — refused by name, no file written" : $"FAIL — refused={refused} noFile={noFile} named={named} err=[{error}]")}");
         return ok;
+    }
+
+    /// <summary>Re-open the written patch and read an NPC's FaceParts.Nose — the substruct compose-Set round-trip (the
+    /// whole NpcFaceParts struct was built FROM PARTS via ApplyScalarVerb req.Struct -> BuildStruct and serialized).
+    /// Returns null when the NPC or its FaceParts is absent (so the E2E fails honestly rather than defaulting to a match).</summary>
+    static uint? NpcFacePartsNose(string patchPath, FormKey npcFk)
+    {
+        ISkyrimModGetter? ov = null;
+        try
+        {
+            ov = SkyrimMod.CreateFromBinaryOverlay(patchPath, SkyrimRelease.SkyrimSE);
+            var n = ov.Npcs.FirstOrDefault(x => x.FormKey == npcFk);
+            return n?.FaceParts?.Nose;
+        }
+        catch { return null; }
+        finally { (ov as IDisposable)?.Dispose(); }
     }
 
     /// <summary>Re-open the written patch and confirm a Package's Data dict carries a composed PackageDataBool(Data=true)

--- a/src/housecarl-generator/SubstructNullableClearProbe.cs
+++ b/src/housecarl-generator/SubstructNullableClearProbe.cs
@@ -17,10 +17,11 @@ namespace HousecarlGenerator;
 ///                       not VMAD-special-cased (both are nullable reference substructs Mutagen models with "?").
 ///   CONTROL-OBJBOUNDS — Remove Armor.ObjectBounds (a genuinely NON-nullable substruct) still REFUSES, naming
 ///                       'non-nullable' — proves the gate is nullability-DRIVEN, not "every substruct is now removable".
-///   CONTROL-SET       — a PLAIN-VALUE Set on the VMAD substruct is STILL refused (a substruct can't be coerced from a
-///                       value) — this probe's fix (nullable-clear) touched nullability data, not the Set path. NOTE: a
-///                       COMPOSE Set on a composable substruct IS now accepted (substruct compose-Set, nested-create-guard
-///                       SUBSTRUCT-SET-* arms) — a different path; this control drives Value="0" (no compose), which stays refused.
+///   CONTROL-SET       — a PLAIN-VALUE Set on the VMAD substruct is STILL refused — this probe's fix (nullable-clear via
+///                       Remove) touched nullability data, not the Set path, so a bare Value="0" (no compose) opens nothing.
+///                       (VMAD's type DialogResponsesAdapter is itself composable, so the bare value is rerouted to the
+///                       compose-or-navigate guidance — NOT a coercion failure; the refusal is what this control asserts.
+///                       A COMPOSE Set on a composable substruct IS separately accepted — nested-create-guard SUBSTRUCT-SET-*.)
 ///   E2E-UNFRAGMENT    — an in-memory INFO carrying a VMAD, driven through the REAL WriteEngine.ApplyVerb Remove,
 ///                       comes back with VirtualMachineAdapter == null (was non-null) — the apply half, un-fragmented.
 ///   PREFLIGHT-POLY(2) — Remove a nullable standalone polymorphic field (Book.Teaches; Npc.Sound) PASSES — the same
@@ -64,11 +65,13 @@ public static class SubstructNullableClearProbe
         bool obOk = obReject is not null && obReject.Contains("non-nullable", StringComparison.OrdinalIgnoreCase);
         Console.WriteLine($"   CONTROL-OBJBOUNDS non-nullable still refuses: {(obOk ? "PASS — Remove ObjectBounds refused, names 'non-nullable' (nullability-driven, not blanket)" : $"FAIL — reject=[{obReject}]")}");
 
-        // CONTROL-SET: a PLAIN-VALUE substruct Set (Value="0", no compose) is still refused — a substruct can't be coerced
-        // from a value. (A COMPOSE Set on a composable substruct is now accepted — separate path, nested-create-guard.)
+        // CONTROL-SET: a PLAIN-VALUE substruct Set (Value="0", no compose) is still refused — the nullable-clear (Remove)
+        // fix touched nullability data, not the Set path. VMAD's DialogResponsesAdapter is composable, so the bare value is
+        // rerouted to the compose-or-navigate guidance (a plain value can't express a struct) — the refusal is the point.
+        // (A COMPOSE Set on a composable substruct is separately accepted — nested-create-guard SUBSTRUCT-SET-*.)
         var setReject = rulebook.Validate(new WriteRequest { RecordType = "DialogResponses", Path = new[] { "VirtualMachineAdapter" }, Verb = "Set", Value = "0" });
         bool setOk = setReject is not null;
-        Console.WriteLine($"   CONTROL-SET       Set on substruct unchanged: {(setOk ? "PASS — Set on VirtualMachineAdapter still refused (navigate-in unchanged)" : "FAIL — Set on a substruct was accepted")}");
+        Console.WriteLine($"   CONTROL-SET       plain-value Set refused    : {(setOk ? "PASS — a bare Value=\"0\" Set on VirtualMachineAdapter is still refused (nullable-clear opened Remove, not the Set path)" : "FAIL — a plain-value Set on a substruct was accepted")}");
 
         // E2E-UNFRAGMENT: the apply half — an INFO with a VMAD, Removed through the real engine, comes back null.
         bool e2eOk = false;

--- a/src/housecarl-generator/SubstructNullableClearProbe.cs
+++ b/src/housecarl-generator/SubstructNullableClearProbe.cs
@@ -17,8 +17,10 @@ namespace HousecarlGenerator;
 ///                       not VMAD-special-cased (both are nullable reference substructs Mutagen models with "?").
 ///   CONTROL-OBJBOUNDS — Remove Armor.ObjectBounds (a genuinely NON-nullable substruct) still REFUSES, naming
 ///                       'non-nullable' — proves the gate is nullability-DRIVEN, not "every substruct is now removable".
-///   CONTROL-SET       — Set on the VMAD substruct is STILL refused (a substruct is navigated INTO, not coerced) —
-///                       only Remove opened; the fix touched nullability data, not the Set path.
+///   CONTROL-SET       — a PLAIN-VALUE Set on the VMAD substruct is STILL refused (a substruct can't be coerced from a
+///                       value) — this probe's fix (nullable-clear) touched nullability data, not the Set path. NOTE: a
+///                       COMPOSE Set on a composable substruct IS now accepted (substruct compose-Set, nested-create-guard
+///                       SUBSTRUCT-SET-* arms) — a different path; this control drives Value="0" (no compose), which stays refused.
 ///   E2E-UNFRAGMENT    — an in-memory INFO carrying a VMAD, driven through the REAL WriteEngine.ApplyVerb Remove,
 ///                       comes back with VirtualMachineAdapter == null (was non-null) — the apply half, un-fragmented.
 ///   PREFLIGHT-POLY(2) — Remove a nullable standalone polymorphic field (Book.Teaches; Npc.Sound) PASSES — the same
@@ -62,7 +64,8 @@ public static class SubstructNullableClearProbe
         bool obOk = obReject is not null && obReject.Contains("non-nullable", StringComparison.OrdinalIgnoreCase);
         Console.WriteLine($"   CONTROL-OBJBOUNDS non-nullable still refuses: {(obOk ? "PASS — Remove ObjectBounds refused, names 'non-nullable' (nullability-driven, not blanket)" : $"FAIL — reject=[{obReject}]")}");
 
-        // CONTROL-SET: a substruct Set is still refused (navigate INTO it) — only Remove opened.
+        // CONTROL-SET: a PLAIN-VALUE substruct Set (Value="0", no compose) is still refused — a substruct can't be coerced
+        // from a value. (A COMPOSE Set on a composable substruct is now accepted — separate path, nested-create-guard.)
         var setReject = rulebook.Validate(new WriteRequest { RecordType = "DialogResponses", Path = new[] { "VirtualMachineAdapter" }, Verb = "Set", Value = "0" });
         bool setOk = setReject is not null;
         Console.WriteLine($"   CONTROL-SET       Set on substruct unchanged: {(setOk ? "PASS — Set on VirtualMachineAdapter still refused (navigate-in unchanged)" : "FAIL — Set on a substruct was accepted")}");


### PR DESCRIPTION
## What

Closes **Issue 2** of bug-report `bulk-authoring-sibling-list-refs-and-struct-set` (chain **Stage 2b**). A scalar **substruct leaf** — `NPC_.FaceParts`, `ObjectBounds`, `FaceMorph`, a concrete script-property arm, … — can now be **Set by composing its whole value from parts** (`compose:{type, fields}`), instead of only being reachable one-sub-field-at-a-time. This is what a one-shot subtree author (the standalone-NPC-copy flow, Stage 3) needs to fill an absent struct in a single reviewable op.

## The key finding — this is a GATE-ONLY change

The apply engine **already builds it**: `ApplyScalarVerb` (`WriteEngine.cs`) already does `Set + req.Struct → BuildStruct → assign`, and a substruct leaf reaches that path. This was a **documented safe over-reject** — write-preflight gap audit §3(b), decision #4 ("defer unless you want it"; the chain now wants it). So the fix only teaches the **gate** to accept what apply already does, mirroring the dict-element (GAP3) and polymorphic-arm compose paths exactly (same shared `StructSpecContents`). **No apply change, no generator/corpus/Schema change, no new tool.**

Both of the report's ideals are now guaranteed:
- **(a)** whole-struct compose-Set (new);
- **(b)** dotted sub-path auto-vivify of an absent struct (`FaceParts.Nose` on an absent `FaceParts`) — already worked via `MaterializeSubstruct`, now locked by a guard arm.

The misleading `"Set on 'X' requires a value"` message is fixed (it named `value=`, the one thing that can't express a struct).

## Scoped by construction (cornerstone — no per-type list)

`SchemaClassifier.IsComposableSubstructLeaf` = `substruct` **+** corpus `Kind ∈ {struct, arm}` **+** `!CoercibleLeaf` **+** `WriteEngine.IsPlainComposableStruct`. The last two guards keep the gate in lock-step with what `BuildStruct` can actually build:
- `!CoercibleLeaf` keeps a **coercible** substruct (`TranslatedString`) on its plain-value Set — not re-routed to compose-only.
- `IsPlainComposableStruct` (resolves + public parameterless ctor) excludes the **composition-residuals** `GenderedItem<T>` / `Array2d<T>` — which have no such ctor and would otherwise be an **accept-then-throw** (all 4 `Array2d` substruct leaves are writable, so this is a real hole avoided, not just defense). Gendered leaves are already diverted to `[0]/[1]` upstream.

Per Aaron's scope pick, **arm-typed** substruct leaves (`SceneAdapter.ScriptFragments`, `QuestFragmentAlias.Property`) are included alongside the ~507 struct-typed ones.

## §4 framing

§4-(a): the cornerstone holds. This *adds* a write path that was surfaced-loud-and-deferred, derived by construction; it aligns the gate with apply. Gate-only, fully reversible.

## Verification

- **9 RED-proven arms** extend `nested-create-guard` **in place** (no new CI step): `SUBSTRUCT-SET-COMPOSE-OK`, `-ARM-COMPOSE-OK`, `-COMPOSE-BADTYPE`, `-COMPOSE-BADFIELD`, `-NOSPEC` (message fix), `-COERCIBLE-UNCHANGED` (over-reject guard), `-ARRAY2D-REJECTED` (accept-then-throw guard), `-COMPOSE-E2E` (gate→apply→disk round-trip: `NpcFaceParts(Nose=32)` read back off disk), `-DOTTED-VIVIFY` (ideal b, E2E).
- `SubstructNullableClearProbe` `CONTROL-SET` still holds (a **plain-value** substruct Set stays refused); its comment updated to note compose-Set is now open.
- **ci-all 72/72.**

## Not yet done (owed before merge)
- In-app MCP round-trip confirmation (empirical-first) — the tool surface (`compose` on Set) is unchanged, but Aaron calling it in-app once packaged is the confirmation step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)