### PR TITLE
feat(bsa): extract-failure message names why BSArch wrote nothing

### DIFF
--- a/src/housecarl-mcp/BsaTools.cs
+++ b/src/housecarl-mcp/BsaTools.cs
@@ -97,8 +97,17 @@ public static class BsaTools
         var r = HousecarlCore.BsaArchive.Unpack(bsarch!, archive, target);
         if (!r.Ran) return "error: " + r.RunError;
         if (!r.Success)
+            // BSArch RAN (we returned above on !Ran) but wrote nothing. Two real causes, named so the failure is
+            // self-explanatory (Q3): (1) BSArch's unpacker is stricter than the game engine, so an archive written by
+            // a non-standard tool can list + load in-game yet unpack to nothing — re-pack it with BSArch or the CK's
+            // Archive.exe/CAO to get a conformant archive; (2) the dest already holds byte-identical files with
+            // restored timestamps, which reads as "nothing new". The raw output below distinguishes them.
             return $"extract FAILED: '{Path.GetFileName(archive)}' produced no new or changed files in '{target}' this run." +
                    (managed ? $" The freshly created mod folder (with only houseCARL's meta.ini marker) was left at '{target}' — delete it or retry into it." : "") +
+                   "\nBSArch ran but extracted nothing. Most likely the archive is non-standard: BSArch's unpacker is " +
+                   "stricter than the game, so an archive written by a custom tool can list and load in-game yet fail to " +
+                   "unpack — re-pack it with BSArch or the CK's Archive.exe. (If the dest already holds identical files, " +
+                   "that also reads as 'nothing new'.)" +
                    "\nRaw BSArch output:\n" + r.Raw;
 
         var sb = new StringBuilder();


### PR DESCRIPTION
Close-out of the `bsa-extract-noop-valid-bsa` gap report (HCBR-2026-07-06) — **not a houseCARL bug; a known BSArch boundary.** Report archived.

## Investigation
- The report's premise ("houseCARL already parses BSAs for `bsa_list`, just add a write path") is **false** — `BsaArchive` shells to BSArch for *everything*, including `list`. houseCARL has **no native BSA parser**.
- The apostrophe-in-path theory was **refuted empirically**: a known-good BSA copied to an apostrophe archive-name + apostrophe dest unpacks fine through BSArch's exact invocation (and installed mods like `Slordar's` / `Senua's` ship apostrophe-path BSAs that work in-game).
- BSArch's `-list` worked on the original archive, so the differentiator was **the archive itself**: the report's custom python v105 writer produced a structure BSArch's `-list` + the game tolerate but BSArch's *unpacker* (stricter than the game) rejects. It wrote nothing and houseCARL reported that honestly — Q3 working as designed.

A native extractor (to consume archives BSArch dislikes) is a real but narrow-value new capability — deferred as its own project, not a bug fix.

## This change
The extract-FAILED message now names the two real causes so the failure is self-explanatory next time:
1. a non-standard archive BSArch won't unpack → re-pack with BSArch / the CK's Archive.exe
2. the dest already holds byte-identical files (reads as "nothing new")

The raw BSArch output below the message distinguishes them. Message-only; no probe asserts the text; the MCP project builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)