### PR TITLE
fix(check_errors): exempt engine-implicit PlayerRef/Player from the dangling sweep

### DIFF
--- a/src/housecarl-core/DialogueValidate.cs
+++ b/src/housecarl-core/DialogueValidate.cs
@@ -525,24 +525,9 @@ public static class DialogueValidate
         foreach (var resp in info.Responses) Scan(resp.Text?.String, $"response {++rnum} text");
     }
 
-    /// <summary>Engine-implicit forms — the sub-0x800 hardcoded references the engine defines but that are NOT normal
-    /// records in the base master's data, so the load-order index can't resolve them (a false "not in the active load
-    /// order"). A dialogue condition legitimately Runs On / points at these: PlayerRef (the player's placed reference,
-    /// for HasSpell / actor-value player-state gates) and the Player base NPC_ (a GetIsID Player form param). The
-    /// condition lints (1 + 3) treat them as valid targets so a standard player-state gate validates clean (Junti
-    /// 2026-07-03: xEdit resolves 000014 as PlayerRef; the gates are proven working in game). Scoped to the two the
-    /// report proves — a PRECISE set, NOT the whole reserved range, so a genuinely-typo'd sub-0x800 FormID still WARNs.
-    /// Skyrim.esm is the SSE base master (houseCARL is SSE-only). Extend if more engine-implicit forms surface.</summary>
-    static readonly ModKey SkyrimBaseMaster = new("Skyrim", ModType.Master);
-    static readonly HashSet<FormKey> EngineImplicitForms = new()
-    {
-        new FormKey(SkyrimBaseMaster, 0x14),   // PlayerRef — the player's placed reference (a Run On Reference target)
-        new FormKey(SkyrimBaseMaster, 0x07),   // Player    — the player base NPC_ (a GetIsID / form-param target)
-    };
-
-    /// <summary>True when <paramref name="fk"/> is one of the <see cref="EngineImplicitForms"/> — a hardcoded engine
-    /// reference the index can't resolve, so the condition lints must not mistake it for a dangling reference.</summary>
-    static bool IsEngineImplicit(FormKey fk) => EngineImplicitForms.Contains(fk);
+    // Engine-implicit forms (PlayerRef 000014, Player 000007) — the sub-0x800 hardcoded references the index can't
+    // resolve — are exempted from condition lints 1 + 3 so a standard player-state gate validates clean. The precise
+    // set + rationale live in the ONE shared home (EngineImplicit), also used by the check_errors integrity sweep.
 
     /// <summary>Static condition-lint suite (item 4) over one INFO's <c>Conditions</c> (CTDA rows) — the
     /// data-layer-decidable subset the §4 design decision (A-iii) authorises. Every lint here is a TRUE-positive
@@ -595,7 +580,7 @@ public static class DialogueValidate
                 if (data.Reference.IsNull)
                     issues.Add(new(DialogueIssueSeverity.Warning,
                         $"INFO {info.FormKey} condition #{n} ({fn}) is set to Run On a specific reference, but no reference is set — it evaluates against nothing, so the gate never behaves as intended."));
-                else if (!inOrder(refKey) && !IsEngineImplicit(refKey))
+                else if (!inOrder(refKey) && !EngineImplicit.IsImplicit(refKey))
                     issues.Add(new(DialogueIssueSeverity.Warning,
                         $"INFO {info.FormKey} condition #{n} ({fn}) Run On reference {refKey} is not in the active load order — the gate evaluates against nothing."));
             }
@@ -632,7 +617,7 @@ public static class DialogueValidate
                 FormKey? paramFk =
                     v is IFormLinkGetter fl && !fl.IsNull ? fl.FormKey
                     : floiIsForm && WriteEngine.IsFormLinkOrIndex(p.PropertyType) ? WriteEngine.ReadFloiFormKey(v) : null;
-                if (paramFk is { } pk && !inOrder(pk) && !IsEngineImplicit(pk))
+                if (paramFk is { } pk && !inOrder(pk) && !EngineImplicit.IsImplicit(pk))
                     issues.Add(new(DialogueIssueSeverity.Warning,
                         $"INFO {info.FormKey} condition #{n} ({fn}) references {pk}, which is not in the active load order — a deleted/disabled form or a wrong FormID, so the condition can't evaluate as intended."));
             }

--- a/src/housecarl-core/EngineImplicit.cs
+++ b/src/housecarl-core/EngineImplicit.cs
@@ -1,0 +1,36 @@
+using Mutagen.Bethesda.Plugins;
+
+namespace HousecarlCore;
+
+/// <summary>Engine-implicit forms — the hardcoded references the engine defines but that are NOT normal records in the
+/// base master's data, so the load-order index can't resolve them (<see cref="LoadOrderResolver.IndexView.ResolveWinner"/>
+/// returns null even though the form is real). A FormLink legitimately points at these: PlayerRef (the player's placed
+/// reference — the target of HasSpell / actor-value player-state gates and countless script, package, and condition
+/// links) and the Player base NPC_ (a GetIsID Player form param). Any tool that flags "target not in the active load
+/// order" must exempt them or it false-warns on the standard player-state pattern — so the SINGLE source of truth lives
+/// here, shared by BOTH the dialogue condition lints (<see cref="DialogueValidate"/>) and the integrity sweep
+/// (<see cref="ErrorCheck"/>), keeping their exemptions in lockstep.
+///
+/// Evidence: Junti 2026-07-03 — xEdit resolves 000014 as PlayerRef and the gates are proven working in game (the
+/// validate_dialogue manifestation, fixed in PR #139); the identical class then surfaced in check_errors, which
+/// reported 531/531 dangling refs ALL → 000014:Skyrim.esm, overflowing the tool response
+/// (HCBR checkerrors-playerref-dangling-false-positive).
+///
+/// Scoped to the two the reports prove — a PRECISE set, NOT the whole reserved sub-0x800 range, so a genuinely-typo'd
+/// low FormID still surfaces as a real error. Skyrim.esm is the SSE base master (houseCARL is SSE-only). Extend the set
+/// here if more engine-implicit forms surface — one edit updates every tool.</summary>
+internal static class EngineImplicit
+{
+    static readonly ModKey SkyrimBaseMaster = new("Skyrim", ModType.Master);
+
+    /// <summary>The precise engine-implicit reference set (see the type doc). Add a form here — never widen to a range.</summary>
+    static readonly HashSet<FormKey> Forms = new()
+    {
+        new FormKey(SkyrimBaseMaster, 0x14),   // PlayerRef — the player's placed reference (a Run On Reference / FormLink target)
+        new FormKey(SkyrimBaseMaster, 0x07),   // Player    — the player base NPC_ (a GetIsID / form-param target)
+    };
+
+    /// <summary>True when <paramref name="fk"/> is one of the engine-implicit <see cref="Forms"/> — a hardcoded engine
+    /// reference the index can't resolve, so a reference-resolution check must not mistake it for a dangling reference.</summary>
+    internal static bool IsImplicit(FormKey fk) => Forms.Contains(fk);
+}

--- a/src/housecarl-core/ErrorCheck.cs
+++ b/src/housecarl-core/ErrorCheck.cs
@@ -9,7 +9,9 @@ namespace HousecarlCore;
 /// own <see cref="IFormLinkContainerGetter.EnumerateFormLinks"/> — the by-construction link surface, the same one
 /// cross_plugin_query references= rides) and reports three error classes:
 ///   • DANGLING — a non-null FormLink whose target NO plugin in the active order defines (<see cref="LoadOrderResolver.IndexView.ResolveWinner"/>
-///     is null): a broken reference in the resolvable order.
+///     is null): a broken reference in the resolvable order. Engine-implicit forms (PlayerRef 000014, Player 000007 —
+///     hardcoded refs the index can't resolve but that are never actually broken) are exempted via <see cref="EngineImplicit"/>,
+///     so the standard player-state pattern doesn't false-flag (HCBR: 531/531 dangling all → 000014 before this exemption).
 ///   • MISSING MASTER — a plugin DECLARES a master that is not present in the active order
 ///     (<see cref="LoadOrderResolver.IndexView.ContainsPlugin"/> is false): the plugin's dependency is not installed /
 ///     enabled, the most common load-order break (and the root cause behind a cluster of that master's refs dangling).
@@ -109,6 +111,7 @@ public static class ErrorCheck
                             var target = link.FormKey;
                             if (target.IsNull) continue;            // a null FormLink is a legal optional — not an error (see the class-doc boundary)
                             if (view.ResolveWinner(target) is not null) continue;   // resolves → fine
+                            if (EngineImplicit.IsImplicit(target)) continue;        // engine-implicit (PlayerRef 000014 / Player 000007): the index can't resolve these hardcoded forms, but they are real, never dangling — same precise exemption the dialogue lints use (HCBR: was 531/531 false dangling → 000014)
                             totalDangling++;
                             if (danglingBudget > 0)
                             {

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -37,6 +37,15 @@ namespace HousecarlGenerator;
 ///   SCOPE           — scope=[HcCeBad.esp] reports only Bad (1 plugin scanned), Clean absent.
 ///   SCOPE-Q3        — scope=[a name not in the order] fails LOUD ("not in the load order"), no reports (never a silent skip).
 ///   CAP             — limit=1 over Bad's 2 dangling refs returns 1 but reports the TRUE total (2) and Capped.
+///   PLAYERREF-WHITELIST — engine-implicit refs (000014 PlayerRef, 000007 Player, in Skyrim.esm) are NOT flagged dangling
+///                     (HCBR checkerrors-playerref-dangling-false-positive: check_errors was reporting 531/531 false → 000014).
+///   PLAYERREF-CONTROL   — a DIFFERENT sub-0x800 form (000015:Skyrim.esm) IS still flagged and the plugin totals 1 dangling:
+///                     the exemption is a PRECISE 2-form set, not the whole reserved range, so a real typo'd low FormID surfaces.
+///
+/// PLAYERREF FIXTURE (its own order, engine-implicit whitelist): a stub Skyrim.esm base master, on disk but NOT loaded
+///   (the absent-master shape again, so every ref into it fails ResolveWinner), and HcCePlayer.esp mastering [Skyrim] with
+///   three NPCs whose Race points at 000014 (PlayerRef, whitelisted), 000007 (Player, whitelisted), and 000015 (a
+///   non-whitelisted sub-0x800 control). Built as [HcCePlayer] alone — Skyrim.esm is the missing master.
 ///
 /// COVERAGE NOTE (Q3 — name what this guard LEANS ON rather than re-proves): PARSE failures are not synthesized here.
 ///   Whole-plugin exclusion rides on the index build's ExcludedPlugins machinery (exercised across the suite), and the
@@ -70,7 +79,12 @@ public static class CheckErrorsProbe
         string ghostPath  = Path.Combine(tmpDir, "HcCeGhost.esm");
         string cleanPath  = Path.Combine(tmpDir, "HcCeClean.esp");
         string badPath    = Path.Combine(tmpDir, "HcCeBad.esp");
+        string skyrimPath = Path.Combine(tmpDir, "Skyrim.esm");     // stub base master for the PlayerRef arm — on disk, NOT loaded
+        string playerPath = Path.Combine(tmpDir, "HcCePlayer.esp");
         var deadFk = FormKey.Factory("0F0F0F:HcCeMaster.esm");   // an object id HcCeMaster.esm does NOT define (master present, target absent)
+        var playerRefFk  = FormKey.Factory("000014:Skyrim.esm");  // PlayerRef — engine-implicit, whitelisted (must NOT dangle)
+        var playerBaseFk = FormKey.Factory("000007:Skyrim.esm");  // Player base NPC_ — engine-implicit, whitelisted (must NOT dangle)
+        var sub800Fk     = FormKey.Factory("000015:Skyrim.esm");  // a DIFFERENT sub-0x800 form — NOT whitelisted (MUST dangle: proves precision)
         FormKey masterRaceFk, ghostRaceFk;
         try
         {
@@ -93,6 +107,20 @@ public static class CheckErrorsProbe
             var bGhost = bad.Npcs.AddNew(); bGhost.EditorID = "HcCeBadGhostNpc"; bGhost.Race.SetTo(ghostRaceFk);
             var bDead  = bad.Npcs.AddNew(); bDead.EditorID  = "HcCeBadDeadNpc";  bDead.Race.SetTo(deadFk);
             bad.BeginWrite.ToPath(badPath).WithLoadOrder(new ISkyrimModGetter[] { master, ghost }).Write();
+
+            // PlayerRef whitelist fixture (HCBR checkerrors-playerref-dangling-false-positive). A stub Skyrim.esm base
+            // master, written but NOT loaded into the order below — so every ref into it fails ResolveWinner, the same
+            // absent-master shape as Ghost. HcCePlayer masters [Skyrim] and points three NPC Race links at the two
+            // whitelisted engine-implicit forms (0x14, 0x07) and one non-whitelisted control (0x15). Only 0x15 must dangle.
+            var skyrim = new SkyrimMod(new ModKey("Skyrim", ModType.Master), SkyrimRelease.SkyrimSE);
+            skyrim.Races.AddNew();   // one throwaway record so the stub is a valid, non-empty master
+            skyrim.BeginWrite.ToPath(skyrimPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+            var player = new SkyrimMod(new ModKey("HcCePlayer", ModType.Plugin), SkyrimRelease.SkyrimSE);
+            var pRef  = player.Npcs.AddNew(); pRef.EditorID  = "HcCePlayerRefNpc";  pRef.Race.SetTo(playerRefFk);   // 0x14 — whitelisted
+            var pBase = player.Npcs.AddNew(); pBase.EditorID = "HcCePlayerBaseNpc"; pBase.Race.SetTo(playerBaseFk);  // 0x07 — whitelisted
+            var pDead = player.Npcs.AddNew(); pDead.EditorID = "HcCePlayerDeadNpc"; pDead.Race.SetTo(sub800Fk);      // 0x15 — must dangle
+            player.BeginWrite.ToPath(playerPath).WithLoadOrder(new ISkyrimModGetter[] { skyrim }).Write();
         }
         catch (Exception ex)
         {
@@ -162,6 +190,22 @@ public static class CheckErrorsProbe
             capped.TotalDangling == 2 && capped.Capped
             && capped.Reports.Count == 1 && capped.Reports[0].Dangling.Count == 1,
             $"total={capped.TotalDangling} capped={capped.Capped} collected={(capped.Reports.Count > 0 ? capped.Reports[0].Dangling.Count : -1)}");
+
+        // ---- PLAYERREF: engine-implicit whitelist (its own order; Skyrim.esm on disk but NOT loaded). ----
+        using var rp = LoadOrderResolver.Build(new[] { playerPath });
+        var pl = ErrorCheck.Run(rp, null, 1000);
+        if (!pl.Success) { Console.Error.WriteLine($"error: PlayerRef sweep failed: {pl.Error}"); return 1; }
+        var player2 = pl.Reports.FirstOrDefault(p => p.Plugin == "HcCePlayer.esp");
+
+        Check("PLAYERREF-WHITELIST: engine-implicit refs (000014 PlayerRef, 000007 Player) are NOT flagged dangling",
+            player2 is not null
+            && !player2.Dangling.Any(d => d.Target == playerRefFk)
+            && !player2.Dangling.Any(d => d.Target == playerBaseFk),
+            player2 is null ? "<no report>" : string.Join(",", player2.Dangling.Select(d => d.Target.ToString())));
+
+        Check("PLAYERREF-CONTROL: a non-whitelisted sub-0x800 form (000015) IS still flagged; the plugin totals 1 dangling (exemption is precise, not the whole range)",
+            player2 is not null && player2.Dangling.Any(d => d.Target == sub800Fk) && pl.TotalDangling == 1,
+            player2 is null ? "<no report>" : $"total={pl.TotalDangling} targets=[{string.Join(",", player2.Dangling.Select(d => d.Target.ToString()))}]");
 
         Console.WriteLine();
         Console.WriteLine(failures == 0 ? "check-errors-guard: ALL PASS" : $"check-errors-guard: {failures} FAILURE(S)");


### PR DESCRIPTION
## The bug
`check_errors` on the core ESP reported **531/531 dangling refs, ALL → `000014:Skyrim.esm` (PlayerRef)** — noisy enough to overflow the tool response (HCBR `checkerrors-playerref-dangling-false-positive`, seen 2026-07-04 and again 2026-07-06).

PlayerRef (`000014`) and the Player base NPC_ (`000007`) are engine-implicit hardcoded forms the load-order index can't resolve, but they are never actually broken. This is the **identical false-positive class** that PR #139 (`7ead7bf`) already whitelisted for `validate_dialogue` — that fix simply never extended to `check_errors`. xEdit resolves `000014` as `PlayerRef [PLYR:00000014]`; the affected gates are proven working in game.

## The fix
- **One shared source of truth.** Extract the precise 2-form engine-implicit whitelist out of `DialogueValidate` into a new `EngineImplicit` class in `housecarl-core`, now used by **both** the dialogue condition lints and the integrity sweep. Extend once, both benefit — no more drift between the two.
- `ErrorCheck.Run` skips engine-implicit targets before counting a ref dangling.
- Kept **precise** (`000014` + `000007` in Skyrim.esm), *not* the whole reserved sub-0x800 range — a genuinely typo'd low FormID still surfaces as a real error (proven by the CONTROL arm).

## Verification
- `ci-all` **74/74 green** (rebased onto current `main`, integrated with the two `fix(write)` commits).
- `check-errors-guard` **+2 arms** on a fresh Skyrim-mastered fixture:
  - `PLAYERREF-WHITELIST` — `000014` + `000007` are NOT flagged dangling.
  - `PLAYERREF-CONTROL` — a sibling `000015` **is** still flagged and the plugin totals 1 dangling (exemption is precise, not a range).
- The extraction is proven safe because `dialogue-validate-guard`'s own PlayerRef arms — now routing through `EngineImplicit` — stayed green.

## Not proven here (empirical-first)
The real confirmation is re-running `check_errors` on the core ESP: it should drop that class from 531 to 0. The report shows all 531 were `000014`, so this should zero it out; any other engine form that surfaces is a one-line add to the shared set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)