### PR TITLE
fix(validate_dialogue): close the INFO CK-parity blind spot + consolidate 3 shared-fact drifts

### DIFF
--- a/src/housecarl-core/AssetRenameService.cs
+++ b/src/housecarl-core/AssetRenameService.cs
@@ -201,7 +201,7 @@ public static class AssetRenameService
             if (!m.Success) continue;                                      // not an INFO-keyed voice file — nothing to remap
             uint full;
             try { full = Convert.ToUInt32(m.Groups[1].Value, 16); } catch { continue; }
-            uint oldLocal = full & 0xFFFFFFu;                              // mask the index byte, exactly like VoicePath emits "00"+6hex
+            uint oldLocal = full & FormIdRange.ObjectIdMask;              // mask the index byte, exactly like VoicePath emits "00"+6hex
             if (!idMap.TryGetValue(oldLocal, out var newLocal)) continue;  // id not renumbered → filename unchanged → no carry
 
             var newId = "00" + newLocal.ToString("X6");

--- a/src/housecarl-core/DialogueCkParity.cs
+++ b/src/housecarl-core/DialogueCkParity.cs
@@ -60,6 +60,14 @@ namespace HousecarlCore;
 /// (Q3). A record that already carried the field produces NO fill (non-override).</summary>
 public readonly record struct CkParityFill(string Label, string Reason);
 
+/// <summary>One CK-parity subrecord a record is MISSING — the read-only counterpart of a <see cref="CkParityFill"/>.
+/// <see cref="Subrecord"/> names the omitted field ("CNAM (FavorLevel)"); <see cref="Detail"/> is why it matters +
+/// the fix. The on-demand dialogue validator surfaces each as a Warning (a CK-editor-crash shape the game itself
+/// tolerates — the same severity class as the BNAM-absent lint). Produced by the SAME null probe the fill path
+/// uses, so a create that FILLS the field and a validate that FLAGS its absence can never disagree (the shared-source
+/// discipline DialogueSubtype set for the SNAM marker, generalised to the rest of the family).</summary>
+public readonly record struct CkParityGap(string Subrecord, string Detail);
+
 /// <summary>The authority for the CK-parity default-populate fields of the DIAL/INFO/DLVW family — the nullable
 /// subrecords the Creation Kit always writes but Mutagen omits when unset. The create path calls the per-type
 /// <c>Apply…Defaults</c> method after the author's edits, fills only the fields left null (NEVER overriding an
@@ -85,8 +93,10 @@ public static class DialogueCkParity
         var fills = new List<CkParityFill>(2);
 
         // FavorLevel (CNAM): nullable enum (FavorLevel?); None is the CK default (Talos' Tease / SexLab Solutions
-        // reference INFOs all carry FavorLevel = None). Only fill when the author set no favor level.
-        if (info.FavorLevel is null)
+        // reference INFOs all carry FavorLevel = None). Only fill when the author set no favor level. The absence
+        // probe is the shared HasFavorLevel (see below) — the SAME one MissingInfoDefaults flags on, so fill + check
+        // can't drift.
+        if (!HasFavorLevel(info))
         {
             info.FavorLevel = FavorLevel.None;
             fills.Add(new CkParityFill(
@@ -101,7 +111,8 @@ public static class DialogueCkParity
         // null when unset — confirmed empirically: setting a sub-field "materialises" it). A fresh struct is Flags=0,
         // ResetHours=0 — exactly the CK's empty ENAM. Only fill when the author materialised no Flags. NOTE: the
         // Goodbye conversation-ender lives in Flags.Flags; an all-zero fill does NOT set it — that stays explicit.
-        if (info.Flags is null)
+        // Absence probe is the shared HasResponseFlags — the SAME one MissingInfoDefaults flags on (no drift).
+        if (!HasResponseFlags(info))
         {
             info.Flags = new DialogResponseFlags();
             fills.Add(new CkParityFill(
@@ -113,6 +124,38 @@ public static class DialogueCkParity
         }
 
         return fills;
+    }
+
+    // --- Presence predicates: the SINGLE home for "does this INFO carry the CK-parity subrecord?", consulted by
+    //     BOTH the fill path (ApplyInfoDefaults — fills when absent) and the check path (MissingInfoDefaults — flags
+    //     when absent) so the two can never drift (Q3). The null read is reliable on the binary overlay the validator
+    //     uses: an absent optional subrecord reads null, a materialised one reads non-null (see the field notes on
+    //     ApplyInfoDefaults). The getter interface is enough — the fill path passes its mutable record, which is one. ---
+    static bool HasFavorLevel(IDialogResponsesGetter info) => info.FavorLevel is not null;   // CNAM
+    static bool HasResponseFlags(IDialogResponsesGetter info) => info.Flags is not null;      // ENAM
+
+    /// <summary>The CK-parity subrecords an INFO (DialogResponses) is MISSING — the read-only counterpart of
+    /// <see cref="ApplyInfoDefaults"/>, for the on-demand dialogue validator. Shares the exact presence predicates the
+    /// fill path uses, so "the create tool populates it" and "the validator flags its absence" can never disagree.
+    /// Empty when the INFO already carries both subrecords (the well-formed case, which every CK-/xEdit-authored INFO
+    /// is — this only ever fires on a bare-authored record). Reads only the getter; NEVER mutates.</summary>
+    public static IReadOnlyList<CkParityGap> MissingInfoDefaults(IDialogResponsesGetter info)
+    {
+        var gaps = new List<CkParityGap>(2);
+
+        if (!HasFavorLevel(info))
+            gaps.Add(new CkParityGap("CNAM (FavorLevel)",
+                "every CK-authored INFO carries the CNAM (FavorLevel) subrecord; an INFO missing it crashes the "
+                + "Creation Kit the moment its owning topic is opened in the dialogue editor (the game itself tolerates "
+                + "it). houseCARL's create tools auto-fill it — set FavorLevel (e.g. None) to populate it."));
+
+        if (!HasResponseFlags(info))
+            gaps.Add(new CkParityGap("ENAM (response Flags)",
+                "every CK-authored INFO carries the ENAM (response flags + reset-hours) subrecord; an INFO missing it "
+                + "crashes the Creation Kit when its owning topic is opened. houseCARL's create tools auto-fill it — "
+                + "set the response Flags to populate it."));
+
+        return gaps;
     }
 
     /// <summary>DLVW (DialogView) CK-parity defaults — the DNAM and ENAM byte subrecords. Both are nullable

--- a/src/housecarl-core/DialogueValidate.cs
+++ b/src/housecarl-core/DialogueValidate.cs
@@ -25,6 +25,9 @@ namespace HousecarlCore;
 //      and selects intra-topic by Conditions, not by a previous-link chain (empirically confirmed; the §3.6 "PNAM chain
 //      in response order" model was wrong for the existing corpus, so that check was dropped — review fold 2026-06-19).
 //    • Category / Subtype — surfaced as facts (what the game will use), not judged.
+//    • INFO CK-parity — a live INFO missing the FavorLevel (CNAM) or response-Flags (ENAM) subrecord the CK writes
+//      unconditionally (the CK-editor-crash shape DialogueCkParity fills on create). WARN, via the SHARED presence
+//      probe the create path fills through — so the fill side and this check side can't drift.
 //    • Voice + result-script — the existing per-INFO VoiceCheck.CheckInfo + DialogueScriptCheck.CheckInfo run over every
 //      LIVE INFO (reused verbatim, so the create-path and the validator can never drift). DELETED INFOs (a removed line)
 //      are skipped, not validated.
@@ -36,7 +39,11 @@ namespace HousecarlCore;
 //  WHAT IT DELIBERATELY CANNOT CHECK (grill-rev C2 — the validator is the ONLY non-advisory enforcement, so it
 //  must NAME the gaps, never let "checks passed" read as "this will play"): the CTDA conditions that gate when a
 //  line fires are semantic and only the game evaluates them; lip-sync accuracy + audio content are out of the
-//  data layer. Both are declared as standing limits the render surfaces loudly (Q3).
+//  data layer. Both are declared as standing limits the render surfaces loudly (Q3). Also NOT checked (the rest of
+//  the CK-parity family DialogueCkParity fills on create): DLVW DNAM/ENAM (a DialogView is not a validator input —
+//  validate takes a DIAL or a QUST); DLBR TNAM and QUST ANAM/objective FNAM (S2 byte-parity, no crash — a future
+//  DLBR/QUST-record pass, not a per-topic lint); and DIAL Priority (PNAM), a non-nullable float with no "unset"
+//  signal to read off the winning record. INFO CNAM/ENAM (the S1 confirmed-CK-crash member) IS checked, above.
 //
 //  RESOLUTION SCOPE (Aaron 2026-06-19): LOAD-ORDER-AWARE, like every other houseCARL read — it validates what
 //  the active load order resolves (the modlist-author's "does this play in THIS list" view). An isolated
@@ -339,6 +346,19 @@ public static class DialogueValidate
         {
             if (info.IsDeleted) { deleted++; continue; }
             infoCount++;
+
+            // CK-parity subrecords (INFO CNAM/ENAM): a winning INFO missing the FavorLevel (CNAM) or response-Flags
+            // (ENAM) subrecord that Mutagen omits when unset is the shape that crashes the Creation Kit when this
+            // topic is opened in the dialogue editor (the game itself tolerates it → WARN, matching the BNAM lint).
+            // The absence probe is DialogueCkParity's — the SAME one the create path FILLS through — so a create that
+            // populates the subrecord and this check that flags its absence can never drift (Q3). Real CK/xEdit-authored
+            // INFOs always carry both, so this fires only on a bare-authored record; houseCARL's own create tools
+            // auto-fill it. (The rest of the CK-parity family — DLVW DNAM/ENAM, DLBR TNAM, QUST ANAM/objective FNAM,
+            // DIAL PNAM — is NOT checked here: DLVW isn't a validator input, PNAM is a non-nullable float with no
+            // "unset" signal, and the others are S2 byte-parity, not a crash. See the header's CANNOT-CHECK note.)
+            foreach (var gap in DialogueCkParity.MissingInfoDefaults(info))
+                issues.Add(new(DialogueIssueSeverity.Warning,
+                    $"INFO {info.FormKey} is missing the {gap.Subrecord} subrecord — {gap.Detail}"));
 
             // Fragment-presence tally (item 8): does this line carry a result-script FRAGMENT (a code path that can
             // surface in Papyrus.log)? Via the single fragment-presence home, so this never drifts from the per-INFO

--- a/src/housecarl-core/FormIdRange.cs
+++ b/src/housecarl-core/FormIdRange.cs
@@ -1,0 +1,42 @@
+namespace HousecarlCore;
+
+/// <summary>
+/// The single home for Skyrim FormID numeric-range facts — the engine-reserved object-ID floor, the ESL/light-master
+/// window, and the 24-bit object-ID ceiling/mask. Every piece of product code that GUARDS or MASKS a FormID's object
+/// ID reads THESE constants rather than restating the hex, so a change lands in one place — the "one shared home"
+/// discipline <see cref="EngineImplicit"/> set for the engine-implicit forms, applied to numeric ranges. Values are
+/// pinned empirically (Mutagen 0.53.1) by the generator probes: <c>FormIdFloorProbe</c> (the 0x800 floor / the
+/// allocate-from-zero bug) and <c>EslFormIdProbe</c> (the 0x800–0xFFF ESL window). These are hard engine facts, not
+/// tuning knobs — the value of consolidation is that the SAME number can't be quietly changed in one guard and left
+/// stale in another (the drift the PlayerRef whitelist hit before it was single-sourced).
+/// </summary>
+public static class FormIdRange
+{
+    /// <summary>First non-engine-reserved object ID (0x800). Object IDs below this (0x000–0x7FF) are engine-reserved: a
+    /// NEW record allocated there is the FormID-allocation-from-zero bug (0x000000 is the null-reference bit pattern),
+    /// and a serialize carrying an ORIGINATING sub-0x800 record throws <c>LowerFormKeyRangeDisallowed</c>. New-record
+    /// allocation is floored to this (<see cref="WriteEngine.EnsureFormIdFloor"/>). It is ALSO the ESL window floor
+    /// (<see cref="EslWindowFloor"/>) — the same 0x800 boundary, seen from the allocation side.</summary>
+    public const uint EngineReservedFloor = 0x800;
+
+    /// <summary>The light-master (ESL) object-ID window FLOOR — the same 0x800 boundary as
+    /// <see cref="EngineReservedFloor"/> (the ESL window runs from the first usable object ID up to
+    /// <see cref="EslWindowCeiling"/>). Named separately so an ESL caller reads "ESL window", not "allocation floor";
+    /// <c>RemapEngine.EslFloor</c> aliases this.</summary>
+    public const uint EslWindowFloor = EngineReservedFloor;
+
+    /// <summary>The light-master (ESL) object-ID window CEILING, INCLUSIVE (0xFFF). With the floor that is a 2048-ID
+    /// window; an object ID &gt; this in a light-flagged master throws <c>FormIDCompactionOutOfBounds</c> (EslFormIdProbe).
+    /// <c>RemapEngine.EslCeiling</c> aliases this.</summary>
+    public const uint EslWindowCeiling = 0xFFF;
+
+    /// <summary>The maximum object ID (0xFFFFFF). An object ID occupies the low 3 bytes of a FormID (the high byte is
+    /// the master-list index), so a valid object ID is 0x000000–0xFFFFFF. A new-record counter past this has overflowed
+    /// the FormID space — no allocation is possible (<see cref="WriteEngine.EnsureAllocatable"/>).</summary>
+    public const uint ObjectIdMax = 0xFFFFFF;
+
+    /// <summary>The 24-bit object-ID mask (== <see cref="ObjectIdMax"/>): <c>formId &amp; ObjectIdMask</c> strips the high
+    /// master-index byte to leave the bare object ID. Same value as the ceiling; named for the masking use so a call
+    /// site reads "mask off the index byte", not "compare against the max".</summary>
+    public const uint ObjectIdMask = ObjectIdMax;
+}

--- a/src/housecarl-core/Mo2LoadOrder.cs
+++ b/src/housecarl-core/Mo2LoadOrder.cs
@@ -70,7 +70,7 @@ public sealed record PluginFileHit(string Path, string Where, bool Enabled);
 
 public static class Mo2LoadOrder
 {
-    static readonly string[] PluginExts = { ".esp", ".esm", ".esl" };
+    static readonly string[] PluginExts = PluginFile.Extensions;   // the one shared home (HousecarlCore.PluginFile) — no divergent copy
 
     /// <summary>Read the active order from <paramref name="profileDir"/>'s loadorder.txt + modlist.txt + plugins.txt,
     /// resolving each active plugin to its WINNING real path: MO2's <paramref name="overwriteDir"/> first (the overwrite

--- a/src/housecarl-core/PluginFile.cs
+++ b/src/housecarl-core/PluginFile.cs
@@ -1,0 +1,15 @@
+namespace HousecarlCore;
+
+/// <summary>
+/// The single home for "which filename extensions are Skyrim plugins" — the {.esp, .esm, .esl} set. Every place that
+/// decides whether a name is a plugin, or strips a plugin extension, reads THIS one array rather than restating the
+/// set, so a fourth extension (or an exclusion) is a one-line change here instead of a fix that silently leaves the
+/// load-order reader, the write-lane patch-name resolver, and the "did you mean?" suggester disagreeing (the
+/// <see cref="EngineImplicit"/> "one shared home" discipline, for plugin extensions). Match case-INSENSITIVELY.
+/// </summary>
+public static class PluginFile
+{
+    /// <summary>The Skyrim plugin filename extensions — lowercase, leading dot. The ONE definition; the per-class
+    /// <c>PluginExts</c> fields alias this so they can't diverge.</summary>
+    public static readonly string[] Extensions = { ".esp", ".esm", ".esl" };
+}

--- a/src/housecarl-core/PluginNameSuggest.cs
+++ b/src/housecarl-core/PluginNameSuggest.cs
@@ -19,7 +19,7 @@ namespace HousecarlCore;
 /// </summary>
 public static class PluginNameSuggest
 {
-    static readonly string[] PluginExts = { ".esp", ".esm", ".esl" };
+    static readonly string[] PluginExts = PluginFile.Extensions;   // the one shared home (HousecarlCore.PluginFile) — no divergent copy
 
     /// <summary>Up to <paramref name="max"/> nearest candidate names for a missed <paramref name="query"/>, best first.
     /// Empty when nothing clears the relevance bar (no spurious suggestion). Case-insensitive throughout.</summary>

--- a/src/housecarl-core/RemapEngine.cs
+++ b/src/housecarl-core/RemapEngine.cs
@@ -45,8 +45,8 @@ public static class RemapEngine
     /// ceiling, only when the mod is flagged light). The usable window is therefore 0x800–0xFFF INCLUSIVE = 2048 IDs —
     /// NOT the 4096 the build plan's draft refuse-threshold assumed; that reconciliation lands when the compact tool
     /// ships (Wave 2). Compact assigns into this window; the capacity check in <see cref="BuildSequentialRemap"/> enforces it.</summary>
-    public const uint EslFloor = 0x800;
-    public const uint EslCeiling = 0xFFF;
+    public const uint EslFloor = FormIdRange.EslWindowFloor;      // 0x800 — the single home is FormIdRange (shared with the write-allocation floor)
+    public const uint EslCeiling = FormIdRange.EslWindowCeiling;  // 0xFFF
 
     // ======================================================================
     //  1. IDENTIFY-PASS  — the per-operation reverse-walk (plan §2 / §3)

--- a/src/housecarl-core/SeqFile.cs
+++ b/src/housecarl-core/SeqFile.cs
@@ -35,7 +35,7 @@ public static class SeqFile
         for (int i = 0; i < masters.Count; i++)
             if (masters[i] == fk.ModKey) { slot = i; break; }
         if (slot < 0) slot = masters.Count;                 // own/new record: its ModKey is the plugin's, never in its masters
-        return ((uint)slot << 24) | (fk.ID & 0x00FFFFFFu);
+        return ((uint)slot << 24) | (fk.ID & FormIdRange.ObjectIdMask);
     }
 
     /// <summary>Serialize SEQ FormIDs to the on-disk byte layout: each as a 4-byte LITTLE-ENDIAN uint, concatenated, with

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -908,13 +908,7 @@ public static class WriteEngine
     {
         if (!CanCreateType(typeName, out var reason)) throw new InvalidOperationException(reason);
         EnsureFormIdFloor(patchMod);   // a counter rehydrated below 0x800 would hand AddNew engine-reserved IDs (HCBR-2026-06-09-04)
-        // Object IDs are 24-bit; a counter past 0xFFFFFF (a tampered header, or a truly full plugin) cannot allocate —
-        // fail loud HERE, at the allocation boundary (Q3), not in EnsureFormIdFloor: a full-but-valid patch must still
-        // SERIALIZE (WritePatch floors the same counter), it just can't grow. (PR #30 review.)
-        if (patchMod.ModHeader.Stats.NextFormID > 0xFFFFFF)
-            throw new InvalidOperationException(
-                $"cannot allocate a new FormID: the patch's NextObjectID counter is 0x{patchMod.ModHeader.Stats.NextFormID:X} — " +
-                "past the 24-bit object-ID ceiling (0xFFFFFF). The plugin is full or its header counter is corrupt.");
+        EnsureAllocatable(patchMod);   // …and a counter past the 24-bit object-ID ceiling can't allocate — fail loud (Q3)
 
         // Abstract-group arm (GlobalFloat / GameSettingFloat / …): construct the concrete arm + Add(T) it (the abstract T
         // can't go through InvokeAddNew). CanCreateType admitted the arm, so resolution here can't fail benignly.
@@ -1094,12 +1088,26 @@ public static class WriteEngine
     /// </summary>
     public static void EnsureFormIdFloor(SkyrimMod patchMod)
     {
-        uint floor = 0x800;
+        uint floor = FormIdRange.EngineReservedFloor;
         foreach (var r in patchMod.EnumerateMajorRecords())
             if (r.FormKey.ModKey == patchMod.ModKey && r.FormKey.ID >= floor)
                 floor = r.FormKey.ID + 1;
         if (patchMod.ModHeader.Stats.NextFormID < floor)
             patchMod.ModHeader.Stats.NextFormID = floor;
+    }
+
+    /// <summary>Guard that the patch can still allocate: its NextObjectID counter must be within the 24-bit object-ID
+    /// space (≤ <see cref="FormIdRange.ObjectIdMax"/>). Past it (a tampered header, or a truly full plugin) no
+    /// allocation is possible — fail LOUD here, at the allocation boundary (Q3), NOT in <see cref="EnsureFormIdFloor"/>:
+    /// a full-but-valid patch must still SERIALIZE (WritePatch floors the same counter), it just can't grow (PR #30
+    /// review). The four create entry points (flat / nested / exterior-cell / interior-cell) share this one guard so
+    /// the ceiling and its message live in ONE place rather than four identical copies.</summary>
+    static void EnsureAllocatable(SkyrimMod patchMod)
+    {
+        if (patchMod.ModHeader.Stats.NextFormID > FormIdRange.ObjectIdMax)
+            throw new InvalidOperationException(
+                $"cannot allocate a new FormID: the patch's NextObjectID counter is 0x{patchMod.ModHeader.Stats.NextFormID:X} — " +
+                $"past the 24-bit object-ID ceiling (0x{FormIdRange.ObjectIdMax:X}). The plugin is full or its header counter is corrupt.");
     }
 
     /// <summary>Invoke Mutagen's <c>AddNew</c> on a flat group instance. <c>AddNew</c> is NOT a plain instance method on
@@ -1267,10 +1275,7 @@ public static class WriteEngine
             throw new InvalidOperationException($"nested create: collection '{prop.Name}' on '{parentInPatch.GetType().Name}' is not an addable list.");
 
         EnsureFormIdFloor(patchMod);   // a rehydrated (into=) counter below 0x800 would hand engine-reserved IDs (HCBR-2026-06-09-04)
-        if (patchMod.ModHeader.Stats.NextFormID > 0xFFFFFF)
-            throw new InvalidOperationException(
-                $"cannot allocate a new FormID: the patch's NextObjectID counter is 0x{patchMod.ModHeader.Stats.NextFormID:X} — " +
-                "past the 24-bit object-ID ceiling (0xFFFFFF). The plugin is full or its header counter is corrupt.");
+        EnsureAllocatable(patchMod);
         var child = ConstructRecord(childType, AllocateNextFormKey(patchMod));
         if (editorId is not null) child.EditorID = editorId;
         list.Add(child);
@@ -1312,10 +1317,7 @@ public static class WriteEngine
         // AddInteriorCell keeps the no-mutation-before-validation property clean — PR #94 review nit).
         EnsureNoDuplicateCellEditorId(patchMod, editorId);   // no silent duplicate on an into= re-run (cells have a stable EditorID)
         EnsureFormIdFloor(patchMod);   // 0x800 floor, exactly like flat/nested create (HCBR-2026-06-09-04)
-        if (patchMod.ModHeader.Stats.NextFormID > 0xFFFFFF)
-            throw new InvalidOperationException(
-                $"cannot allocate a new FormID: the patch's NextObjectID counter is 0x{patchMod.ModHeader.Stats.NextFormID:X} — " +
-                "past the 24-bit object-ID ceiling (0xFFFFFF). The plugin is full or its header counter is corrupt.");
+        EnsureAllocatable(patchMod);
         int bx = FloorDiv(gridX, 32), by = FloorDiv(gridY, 32), sx = FloorDiv(gridX, 8), sy = FloorDiv(gridY, 8);
         var block = worldspaceInPatch.SubCells.FirstOrDefault(b => b.BlockNumberX == bx && b.BlockNumberY == by);
         if (block is null)
@@ -1344,10 +1346,7 @@ public static class WriteEngine
     {
         EnsureNoDuplicateCellEditorId(patchMod, editorId);   // no silent duplicate on an into= re-run (cells have a stable EditorID)
         EnsureFormIdFloor(patchMod);
-        if (patchMod.ModHeader.Stats.NextFormID > 0xFFFFFF)
-            throw new InvalidOperationException(
-                $"cannot allocate a new FormID: the patch's NextObjectID counter is 0x{patchMod.ModHeader.Stats.NextFormID:X} — " +
-                "past the 24-bit object-ID ceiling (0xFFFFFF). The plugin is full or its header counter is corrupt.");
+        EnsureAllocatable(patchMod);
         var fk = AllocateNextFormKey(patchMod);
         uint id = fk.ID;
         int blockN = (int)(id % 10), subN = (int)((id / 10) % 10);

--- a/src/housecarl-generator/DialogueCkParityGuardProbe.cs
+++ b/src/housecarl-generator/DialogueCkParityGuardProbe.cs
@@ -27,6 +27,9 @@ namespace HousecarlGenerator;
 ///                       materialized Flags (ENAM), and BOTH auto-fills are REPORTED as ops (not silent, Q3).
 ///   INFO-FAVOR-WINS   — an explicit FavorLevel=Large is NOT overridden to None (Flags still auto-fills).
 ///   INFO-FLAGS-WINS   — an explicit Flags (ResetHours=3) is NOT reset by the auto-fill (FavorLevel still auto-fills).
+///   INFO-GAP-PROBE    — the anti-drift tie: MissingInfoDefaults (the validator's check side) and ApplyInfoDefaults
+///                       (the fill side) read ONE shared presence predicate — a bare INFO reports exactly the CNAM+ENAM
+///                       gaps, and after the fill reports none (a field in one path but not the other breaks this).
 ///   DLVW-AUTOFILL     — create a bare DialogView → written DNAM=00, ENAM=00000000, both REPORTED.
 ///   DLVW-DNAM-WINS    — an explicit DNAM=FF is NOT overridden to 00 (ENAM still auto-fills).
 ///   BNAM-LINT         — a Custom topic with no Branch → validate_dialogue raises a Warning naming Branch (BNAM); a
@@ -158,6 +161,23 @@ internal static class DialogueCkParityGuardProbe
                 var (favor, hasFlags, reset) = infoRec is not null ? ReadInfo(o.OutputPath, infoRec.FormKey) : (null, false, 0f);
                 Check(o.Success && hasFlags && Math.Abs(reset - 3f) < 0.001f && favor == FavorLevel.None,
                     $"INFO-FLAGS-WINS explicit Flags.ResetHours=3 kept (not reset), FavorLevel still filled — {(o.Success ? $"reset={reset} favor={favor} hasFlags={hasFlags}" : "err=[" + o.Error + "]")}");
+            }
+
+            // ---- INFO-GAP-PROBE: the anti-drift tie. MissingInfoDefaults (the validator's check side, added with the
+            //      validate_dialogue INFO CK-parity lint) and ApplyInfoDefaults (the create-path fill side) read ONE
+            //      shared presence predicate, so they can't drift: a bare INFO reports EXACTLY the CNAM+ENAM gaps, and
+            //      after the fill reports NONE. A field added to the fill path but not the check (or vice-versa) breaks
+            //      this. Pure logic — no service/disk. ----
+            {
+                var info = new DialogResponses(FormKey.Factory("000800:HcCkpGapProbe.esm"), SkyrimRelease.SkyrimSE);
+                var before = DialogueCkParity.MissingInfoDefaults(info);
+                bool flaggedBoth = before.Count == 2
+                    && before.Any(g => g.Subrecord.Contains("CNAM", StringComparison.OrdinalIgnoreCase))
+                    && before.Any(g => g.Subrecord.Contains("ENAM", StringComparison.OrdinalIgnoreCase));
+                DialogueCkParity.ApplyInfoDefaults(info);
+                int after = DialogueCkParity.MissingInfoDefaults(info).Count;
+                Check(flaggedBoth && after == 0,
+                    $"INFO-GAP-PROBE bare INFO → CNAM+ENAM gaps (before={before.Count}), none after fill (after={after}) — check/fill share one predicate");
             }
 
             // ---- DLVW-AUTOFILL: create a bare DialogView → written DNAM=00, ENAM=00000000, both reported. ----

--- a/src/housecarl-generator/DialogueValidateGuardProbe.cs
+++ b/src/housecarl-generator/DialogueValidateGuardProbe.cs
@@ -27,6 +27,9 @@ namespace HousecarlGenerator;
 ///                  resolve-aware, not blanket (guards against an INFO index-scoping regression). PR #90 review finding 4.
 ///   DELETED-SKIP — a deleted INFO (a removed line) is skipped: not counted live (InfoCount excludes it), tallied as
 ///                  deleted, and never voice/script-checked or graph-flagged.
+///   INFO-CKPARITY-GAP— a live INFO missing CNAM (FavorLevel) / ENAM (Flags) WARNs twice, naming each — the CK-editor-crash
+///                  catch, via the SHARED DialogueCkParity.MissingInfoDefaults probe the create path fills through.
+///   INFO-CKPARITY-OK — a CK-parity-complete INFO (Info() runs ApplyInfoDefaults) is NOT flagged — the no-false-positive lock.
 ///   NO-QUEST     — a topic with DialogTopic.Quest unset warns 'Quest' — the unowned-topic teeth.
 ///   BAD-BRANCH   — DialogTopic.Branch pointing at a non-DLBR is a PROBLEM naming 'Branch'.
 ///   VOICE-WIRED  — a voiced line with no .fuz surfaces as a SILENT VoiceLine IN THE VALIDATOR (reused VoiceCheck).
@@ -73,7 +76,7 @@ public static class DialogueValidateGuardProbe
         string mPath = Path.Combine(tmpDir, mKey.FileName.String);
         FormKey cleanFk, linkBadFk, pnamBadFk, pnamOkFk, deletedFk, noQuestFk, badBranchFk, voicedFk, scriptedFk, condFk, qFanFk, weapFk, encBadFk, encOkFk;
         FormKey condCleanFk, condRefUnsetFk, condDeadAliasFk, condDeadLocAliasFk, condDeadQAliasFk, condAliasOkFk, condAliasFloiFk, condDanglingFk, condGlobalFk, condGetIsIdOkFk, condGetIsIdFk;
-        FormKey globOkFk, globBadFk, globSubFk, playerRefFk, playerRefCtlFk;
+        FormKey globOkFk, globBadFk, globSubFk, playerRefFk, playerRefCtlFk, ckGapFk, ckOkFk;
         try
         {
             var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
@@ -88,7 +91,17 @@ public static class DialogueValidateGuardProbe
             var weap = m.Weapons.AddNew(); weap.EditorID = "HcDvWeap"; weap.BasicStats = new WeaponBasicStats { Damage = 10 };
             weapFk = weap.FormKey;
 
-            DialogResponses Info(string edid) => new(m.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = edid };
+            // Info(): a CK-parity-COMPLETE INFO — run through the same ApplyInfoDefaults the create path uses, so it
+            // carries FavorLevel (CNAM) + response Flags (ENAM) like a real CK-/xEdit-authored line. Without this the
+            // new INFO CK-parity lint would (correctly) flag every bare fixture INFO and trip every "no issues" arm; so
+            // this helper ALSO doubles as the no-false-positive lock for that lint (CLEAN et al. stay green only because
+            // these INFOs are complete). The INFO-CKPARITY-GAP fixture below deliberately does NOT use this.
+            DialogResponses Info(string edid)
+            {
+                var info = new DialogResponses(m.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = edid };
+                DialogueCkParity.ApplyInfoDefaults(info);
+                return info;
+            }
 
             // A plain target topic so CLEAN's LinkTo resolves to a real DIAL.
             var tTarget = m.DialogTopics.AddNew(); tTarget.EditorID = "HcDvLinkTarget"; tTarget.Quest.SetTo(qMain.FormKey);
@@ -334,6 +347,20 @@ public static class DialogueValidateGuardProbe
                 tPlayerRefCtl.Responses.Add(i); playerRefCtlFk = tPlayerRefCtl.FormKey;
             }
 
+            // INFO-CKPARITY-GAP (the new INFO CNAM/ENAM lint): a BARE INFO — NOT run through Info()/ApplyInfoDefaults —
+            // so it lacks the FavorLevel (CNAM) + response-Flags (ENAM) subrecords the CK writes unconditionally. Two
+            // Warnings expected, naming each subrecord (the CK-editor-crash catch). Quest set + the loops below give it a
+            // branch + marker, so those are its ONLY issues. Subtype left non-Custom so the BNAM lint stays silent.
+            var tCkGap = m.DialogTopics.AddNew(); tCkGap.EditorID = "HcDvCkGap"; tCkGap.Quest.SetTo(qMain.FormKey);
+            tCkGap.Responses.Add(new DialogResponses(m.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "HcDvCkGapI" });
+            ckGapFk = tCkGap.FormKey;
+
+            // INFO-CKPARITY-OK: a CK-parity-COMPLETE INFO (via Info(), which fills both subrecords) is NOT flagged — the
+            // explicit no-false-positive lock for the new lint (a real authored INFO carries CNAM+ENAM).
+            var tCkOk = m.DialogTopics.AddNew(); tCkOk.EditorID = "HcDvCkOk"; tCkOk.Quest.SetTo(qMain.FormKey);
+            tCkOk.Responses.Add(Info("HcDvCkOkI"));
+            ckOkFk = tCkOk.FormKey;
+
             // Give every branch-LESS fixture topic the shared well-formed branch — SAME reason as the SNAM loop
             // below: this guard tests the GRAPH/CONDITION/VOICE lints, not the BNAM-absent lint (that's
             // dialogue-ckparity-guard's job), so its Custom topics must be branch-clean or a "no issues" arm would
@@ -398,6 +425,24 @@ public static class DialogueValidateGuardProbe
             bool ok = t is not null && t.InfoCount == 1 && t.DeletedInfoCount == 1
                 && t.ScriptFindings.Count == 0 && t.VoiceLines.Count == 0 && t.Issues.Count == 0;
             all &= Pass("DELETED-SKIP not validated", ok, t is null ? "no topic" : $"live={t.InfoCount} deleted={t.DeletedInfoCount} issues={t.Issues.Count} script={t.ScriptFindings.Count}");
+        }
+
+        // ---------- INFO-CKPARITY-GAP: a bare INFO missing CNAM/ENAM WARNs twice, naming each subrecord (CK-editor-crash catch) ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, ckGapFk));
+            bool cnam = t is not null && t.Issues.Any(i => i.Severity == DialogueIssueSeverity.Warning
+                && i.Message.Contains("CNAM", StringComparison.Ordinal) && i.Message.Contains("Creation Kit", StringComparison.Ordinal));
+            bool enam = t is not null && t.Issues.Any(i => i.Severity == DialogueIssueSeverity.Warning
+                && i.Message.Contains("ENAM", StringComparison.Ordinal) && i.Message.Contains("Creation Kit", StringComparison.Ordinal));
+            all &= Pass("INFO-CKPARITY-GAP warns CNAM+ENAM", cnam && enam, t is null ? "no topic" : Issues(t));
+        }
+
+        // ---------- INFO-CKPARITY-OK: a CK-parity-complete INFO is NOT flagged — the no-false-positive lock ----------
+        {
+            var t = One(DialogueValidate.Run(resolver, assets, ckOkFk));
+            bool ok = t is not null && t.InfoCount == 1
+                && !t.Issues.Any(i => i.Message.Contains("CNAM", StringComparison.Ordinal) || i.Message.Contains("ENAM", StringComparison.Ordinal));
+            all &= Pass("INFO-CKPARITY-OK not flagged", ok, t is null ? "no topic" : $"infos={t.InfoCount} issues={t.Issues.Count}: {Issues(t)}");
         }
 
         // ---------- NO-QUEST: an unowned topic warns 'Quest' ----------

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1717,7 +1717,7 @@ public sealed class LoadOrderService : IDisposable
                     $"'{name}' defines no originating records to renumber (it carries only overrides, or is empty) — nothing to compact.");
 
             uint floor = RemapEngine.EslFloor;
-            uint ceiling = esl ? RemapEngine.EslCeiling : 0xFFFFFFu;      // light window, or the full 24-bit object-ID range
+            uint ceiling = esl ? RemapEngine.EslCeiling : FormIdRange.ObjectIdMax;   // light window, or the full 24-bit object-ID range
             var plan = RemapEngine.BuildSequentialRemap(keys, modKey, floor, ceiling);
             if (!plan.Success) return WritePatchBuilder.CompactOutcome.Fail(plan.Error!);
 
@@ -2633,8 +2633,9 @@ public sealed class LoadOrderService : IDisposable
     static string ModFolderName(string stem) => "houseCARL - " + stem;
 
     /// <summary>Plugin extensions stripped from a caller-supplied patch name (case-insensitive). NOT every dot — see
-    /// <see cref="PatchStem"/>.</summary>
-    static readonly string[] PluginExts = { ".esp", ".esm", ".esl" };
+    /// <see cref="PatchStem"/>. Aliases the one shared home (<see cref="HousecarlCore.PluginFile.Extensions"/>) so this
+    /// and the load-order reader / name-suggester copies can't diverge.</summary>
+    static readonly string[] PluginExts = PluginFile.Extensions;
 
     /// <summary>Reduce a caller name to a safe bare STEM — no directory parts (so "../x" / "C:\y" can't escape ModsDir),
     /// stripping ONLY a trailing plugin extension (.esp/.esm/.esl), not every dot. A dotted patch name like


### PR DESCRIPTION
Two separable pieces, from a shared-logic-drift audit of the tool surface. **ci-all 74/74 green.**

## A — `validate_dialogue` blind spot (commit 1, the real fix)

The dialogue write path (`DialogueCkParity`) auto-fills the FavorLevel (CNAM) and response-Flags (ENAM) subrecords the CK writes unconditionally, but the on-demand validator never checked for them — so a winning INFO missing either (the exact shape that crashes the CK dialogue editor; the game itself tolerates it) passed `validate_dialogue` clean. A silent-pass on a confirmed CK-crash shape (Q3).

- `DialogueCkParity.MissingInfoDefaults` is the read-only counterpart of `ApplyInfoDefaults`, and **both read one shared presence predicate** (`HasFavorLevel` / `HasResponseFlags`) — so the fill side and the check side can't drift (the model `DialogueSubtype` set for the SNAM marker, generalised).
- `ValidateTopic` emits a `Warning` per gap (a CK-editor crash the game tolerates → Warning, matching the BNAM lint). Real CK/xEdit INFOs always carry both, so it fires only on a bare-authored record.
- Guards: `INFO-GAP-PROBE` (the check/fill anti-drift tie — a bare INFO reports both gaps, none after the fill) + `dialogue-validate-guard`'s `Info()` now dogfoods `ApplyInfoDefaults` (the no-false-positive lock) plus `INFO-CKPARITY-GAP`/`OK` arms.

**Scope:** INFO CNAM/ENAM only (the S1 confirmed-crash member). The rest of the CK-parity family is documented as not-checked-here (in the `DialogueValidate` header) and captured as a follow-up plan (`dev/plans/DIALOGUE_CKPARITY_VALIDATE_RESIDUAL_2026-07-06.md`, private): DLVW DNAM/ENAM (needs a new validator input type), DLBR TNAM + QUST ANAM/FNAM (S2 byte-parity), DIAL PNAM (structurally uncheckable — a non-nullable float with no "unset" signal).

## B — three latent shared-fact drifts (commit 2, pure refactor)

Each fact lived as multiple hardcoded copies, so a fix to one would silently leave the others stale (the class the PlayerRef whitelist hit before it was single-sourced). Same values, no behaviour change.

| Fact | Was | Now |
|---|---|---|
| Plugin exts `{.esp,.esm,.esl}` | 3 production copies | one `PluginFile.Extensions`; each `PluginExts` aliases it |
| Object-ID ceiling/mask `0xFFFFFF` | 6 sites, incl. 4 identical WriteEngine guards | `FormIdRange.ObjectIdMax/Mask`; the 4 guards collapse into `WriteEngine.EnsureAllocatable` |
| Engine-reserved floor `0x800` | defined twice, unlinked | one `FormIdRange.EngineReservedFloor`; `RemapEngine.EslFloor` aliases it |

The empirical pins (`FormIdFloorProbe` / `EslFormIdProbe`) use raw literals as test inputs and are untouched.

## Verification

`dotnet build` clean (0 new warnings), full `ci-all` **74/74** — re-checks the three dialogue guards (A) and every FormID-floor / ESL-window / compact / asset-rename / SEQ path (B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)