### PR TITLE
validate_dialogue: close the CK-parity residual (DLVW/DLBR inputs + quest-level ANAM/FNAM)

### DIFF
--- a/src/housecarl-core/DialogueCkParity.cs
+++ b/src/housecarl-core/DialogueCkParity.cs
@@ -167,7 +167,7 @@ public static class DialogueCkParity
     {
         var fills = new List<CkParityFill>(2);
 
-        if (view.DNAM is null)
+        if (!HasDnam(view))
         {
             view.DNAM = Convert.FromHexString(ViewDnamHex);
             fills.Add(new CkParityFill(
@@ -176,7 +176,7 @@ public static class DialogueCkParity
                 + "BNAM-less topics) crashes the Creation Kit's Dialogue Views editor. CK-parity default-populate."));
         }
 
-        if (view.ENAM is null)
+        if (!HasEnam(view))
         {
             view.ENAM = Convert.FromHexString(ViewEnamHex);
             fills.Add(new CkParityFill(
@@ -186,6 +186,37 @@ public static class DialogueCkParity
         }
 
         return fills;
+    }
+
+    // --- DLVW presence predicates: the single home for "does this DialogView carry the byte subrecord?",
+    //     consulted by BOTH ApplyViewDefaults (fills when absent) and MissingViewDefaults (flags when absent) —
+    //     the same shared-source discipline as the INFO predicates above (Q3, no drift). ---
+    static bool HasDnam(IDialogViewGetter view) => view.DNAM is not null;   // DNAM
+    static bool HasEnam(IDialogViewGetter view) => view.ENAM is not null;   // ENAM
+
+    /// <summary>The CK-parity subrecords a DLVW (DialogView) is MISSING — the read-only counterpart of
+    /// <see cref="ApplyViewDefaults"/>, for the on-demand dialogue validator's DialogView input. Shares the exact
+    /// presence predicates the fill path uses, so fill and check can never disagree. Empty when the view carries
+    /// both byte subrecords (every CK-authored view does). Reads only the getter; NEVER mutates.</summary>
+    public static IReadOnlyList<CkParityGap> MissingViewDefaults(IDialogViewGetter view)
+    {
+        var gaps = new List<CkParityGap>(2);
+
+        if (!HasDnam(view))
+            gaps.Add(new CkParityGap("DNAM",
+                $"every CK-authored DialogView carries the DNAM byte subrecord (0x{ViewDnamHex}); a bare DLVW (with "
+                + "BNAM-less topics) crashes the Creation Kit's Dialogue Views editor (FlowchartX64 null-deref — the "
+                + "game itself tolerates it). houseCARL's create tools auto-fill it — housecarl_set_field DNAM="
+                + ViewDnamHex + " to populate it."));
+
+        if (!HasEnam(view))
+            gaps.Add(new CkParityGap("ENAM",
+                $"every CK-authored DialogView carries the ENAM byte subrecord (0x{ViewEnamHex}), pairing with DNAM "
+                + "for Creation Kit Dialogue Views parity; a bare DLVW crashes the CK's Dialogue Views editor (the "
+                + "game itself tolerates it). houseCARL's create tools auto-fill it — housecarl_set_field ENAM="
+                + ViewEnamHex + " to populate it."));
+
+        return gaps;
     }
 
     // ==================================================================================================
@@ -214,7 +245,7 @@ public static class DialogueCkParity
     {
         var fills = new List<CkParityFill>(1);
 
-        if (branch.Category is null)
+        if (!HasCategory(branch))
         {
             branch.Category = BranchCategoryDefault;
             fills.Add(new CkParityFill(
@@ -227,6 +258,28 @@ public static class DialogueCkParity
         }
 
         return fills;
+    }
+
+    // --- DLBR presence predicate: the single home for "does this DialogBranch carry TNAM?", consulted by BOTH
+    //     ApplyBranchDefaults (fills when absent) and MissingBranchDefaults (flags when absent) — no drift (Q3). ---
+    static bool HasCategory(IDialogBranchGetter branch) => branch.Category is not null;   // TNAM
+
+    /// <summary>The CK-parity subrecord a DLBR (DialogBranch) is MISSING — the read-only counterpart of
+    /// <see cref="ApplyBranchDefaults"/>, for the on-demand dialogue validator's DialogBranch input. Shares the exact
+    /// presence predicate the fill path uses, so fill and check can never disagree. S2 (byte-parity only — no
+    /// confirmed crash): a missing TNAM is a structural mismatch vs a CK-authored branch, not a known failure.
+    /// Empty when the branch carries a Category. Reads only the getter; NEVER mutates.</summary>
+    public static IReadOnlyList<CkParityGap> MissingBranchDefaults(IDialogBranchGetter branch)
+    {
+        var gaps = new List<CkParityGap>(1);
+
+        if (!HasCategory(branch))
+            gaps.Add(new CkParityGap("TNAM (Category)",
+                "every CK-authored DialogBranch carries the TNAM (Category) subrecord (~all vanilla branches carry "
+                + "Player); a branch missing it differs structurally from a CK-authored one (byte-parity only — no "
+                + "confirmed crash). houseCARL's create tools auto-fill it — set Category (e.g. Player) to populate it."));
+
+        return gaps;
     }
 
     /// <summary>DIAL (DialogTopic) Priority (PNAM) CK seed. UNLIKE every other field here, Priority is a NON-NULLABLE
@@ -263,7 +316,7 @@ public static class DialogueCkParity
     {
         var fills = new List<CkParityFill>();
 
-        if (quest.NextAliasID is null)
+        if (!HasNextAliasID(quest))
         {
             bool hasAliases = quest.Aliases.Count > 0;
             uint next = hasAliases ? quest.Aliases.Max(a => a.ID) + 1u : 0u;
@@ -278,7 +331,7 @@ public static class DialogueCkParity
         int idx = 0;
         foreach (var objective in quest.Objectives)
         {
-            if (objective.Flags is null)
+            if (!HasObjectiveFlags(objective))
             {
                 objective.Flags = default(QuestObjective.Flag);   // (QuestObjective.Flag)0 — no flags set
                 fills.Add(new CkParityFill(
@@ -291,5 +344,41 @@ public static class DialogueCkParity
         }
 
         return fills;
+    }
+
+    // --- QUST presence predicates: the single home for "does this Quest carry the CK-parity subrecord?", consulted
+    //     by BOTH ApplyQuestDefaults (fills when absent) and MissingQuestDefaults (flags when absent) — no drift (Q3). ---
+    static bool HasNextAliasID(IQuestGetter quest) => quest.NextAliasID is not null;                 // ANAM
+    static bool HasObjectiveFlags(IQuestObjectiveGetter objective) => objective.Flags is not null;   // FNAM
+
+    /// <summary>The CK-parity subrecords a QUST (Quest) is MISSING — the read-only counterpart of
+    /// <see cref="ApplyQuestDefaults"/>, for the on-demand dialogue validator's QUEST input (checked ONCE per quest,
+    /// never per topic). Shares the exact presence predicates the fill path uses, so fill and check can never
+    /// disagree. S2 (byte-parity only — no confirmed crash). PRESENCE only: the fill's max-alias-id+1 derivation is
+    /// create-lane-correct (an edited quest's ANAM is a CK high-water mark that can legitimately exceed max+1), so
+    /// this checks "is ANAM absent?", never judges its VALUE. Empty when ANAM is present and every objective carries
+    /// FNAM. Reads only the getter; NEVER mutates.</summary>
+    public static IReadOnlyList<CkParityGap> MissingQuestDefaults(IQuestGetter quest)
+    {
+        var gaps = new List<CkParityGap>();
+
+        if (!HasNextAliasID(quest))
+            gaps.Add(new CkParityGap("ANAM (NextAliasID)",
+                "every CK-authored Quest carries the ANAM (next-alias-ID counter) subrecord; a quest missing it "
+                + "differs structurally from a CK-authored one (byte-parity only — no confirmed crash). houseCARL's "
+                + "create tools auto-fill it — set NextAliasID (the next alias ID the CK would hand out) to populate it."));
+
+        int idx = 0;
+        foreach (var objective in quest.Objectives)
+        {
+            if (!HasObjectiveFlags(objective))
+                gaps.Add(new CkParityGap($"Objectives[{idx}] (Index {objective.Index}) FNAM (Flags)",
+                    "every CK-authored quest objective carries the FNAM (flags) subrecord (vanilla objectives carry 0); "
+                    + "an objective missing it differs structurally from a CK-authored one (byte-parity only — no "
+                    + "confirmed crash). houseCARL's create tools auto-fill it — set the objective's Flags to populate it."));
+            idx++;
+        }
+
+        return gaps;
     }
 }

--- a/src/housecarl-core/DialogueValidate.cs
+++ b/src/housecarl-core/DialogueValidate.cs
@@ -39,11 +39,13 @@ namespace HousecarlCore;
 //  WHAT IT DELIBERATELY CANNOT CHECK (grill-rev C2 — the validator is the ONLY non-advisory enforcement, so it
 //  must NAME the gaps, never let "checks passed" read as "this will play"): the CTDA conditions that gate when a
 //  line fires are semantic and only the game evaluates them; lip-sync accuracy + audio content are out of the
-//  data layer. Both are declared as standing limits the render surfaces loudly (Q3). Also NOT checked (the rest of
-//  the CK-parity family DialogueCkParity fills on create): DLVW DNAM/ENAM (a DialogView is not a validator input —
-//  validate takes a DIAL or a QUST); DLBR TNAM and QUST ANAM/objective FNAM (S2 byte-parity, no crash — a future
-//  DLBR/QUST-record pass, not a per-topic lint); and DIAL Priority (PNAM), a non-nullable float with no "unset"
-//  signal to read off the winning record. INFO CNAM/ENAM (the S1 confirmed-CK-crash member) IS checked, above.
+//  data layer. Both are declared as standing limits the render surfaces loudly (Q3). The ONE permanent CK-parity
+//  boundary: DIAL Priority (PNAM) — a non-nullable float with no "unset" signal to read off a finished winning
+//  record (the create path distinguishes author-set-0 from unset via the author's op list, which the validator
+//  does not have), so flagging its absence would false-positive every legitimately-priority-0 topic. The REST of
+//  the CK-parity family IS checked: INFO CNAM/ENAM per live INFO (S1, in ValidateTopic); DLVW DNAM/ENAM and DLBR
+//  TNAM as their OWN input kinds (a DialogView / DialogBranch FormID is a record-level CK-parity check — no
+//  topic graph to walk); QUST ANAM/objective FNAM once per QUEST input (InputIssues, never repeated per topic).
 //
 //  RESOLUTION SCOPE (Aaron 2026-06-19): LOAD-ORDER-AWARE, like every other houseCARL read — it validates what
 //  the active load order resolves (the modlist-author's "does this play in THIS list" view). An isolated
@@ -97,11 +99,15 @@ public sealed record SeqLintFinding(
     bool SeqExists, bool? SeqContainsQuest, bool? SeqNewerThanPlugin, string? Note);
 
 /// <summary>The whole-validation report for one <c>housecarl_validate_dialogue</c> call: the resolved input
-/// (<see cref="Input"/>, <see cref="InputKind"/> = "topic"/"quest"/"error", <see cref="InputEditorId"/>) and the
-/// per-topic validations. A top-level recoverable miss (the FormID isn't in the order, or resolves to neither a
-/// DIAL nor a QUST) is a NAMED <see cref="Error"/>; a mid-run throw is surfaced on <see cref="CheckError"/> — both
-/// honest, never a silent empty pass (Q3). <see cref="ReadIncomplete"/> carries the asset-layer caveat (a BSA that
-/// failed to read, so an "absent" voice/.pex may merely be unscanned).</summary>
+/// (<see cref="Input"/>, <see cref="InputKind"/> = "topic"/"quest"/"view"/"branch"/"error",
+/// <see cref="InputEditorId"/>) and the per-topic validations. A top-level recoverable miss (the FormID isn't in
+/// the order, or resolves to none of the four input types) is a NAMED <see cref="Error"/>; a mid-run throw is
+/// surfaced on <see cref="CheckError"/> — both honest, never a silent empty pass (Q3).
+/// <see cref="ReadIncomplete"/> carries the asset-layer caveat (a BSA that failed to read, so an "absent"
+/// voice/.pex may merely be unscanned). <see cref="InputIssues"/> carries INPUT-LEVEL findings that belong to the
+/// input record itself, not to any one topic: the QUST ANAM/objective-FNAM CK-parity gaps (checked once — a
+/// multi-topic quest is never nagged N times) and the DLVW/DLBR CK-parity gaps (those inputs have no Topics at
+/// all — Topics stays empty and the render says what WAS checked).</summary>
 public sealed record DialogueValidationReport(
     FormKey Input, string InputKind, string? InputEditorId, string? InputWinnerPlugin,
     IReadOnlyList<TopicValidation> Topics)
@@ -109,6 +115,11 @@ public sealed record DialogueValidationReport(
     public string? Error { get; init; }
     public string? CheckError { get; init; }
     public bool ReadIncomplete { get; init; }
+
+    /// <summary>Input-level findings that belong to the INPUT record itself, not any one topic: quest CK-parity gaps
+    /// (ANAM / objective FNAM, checked once per QUEST input) and the DLVW/DLBR CK-parity gaps (the whole finding set
+    /// for those input kinds). Empty for a DIAL input and for a gap-free record.</summary>
+    public IReadOnlyList<DialogueIssue> InputIssues { get; init; } = Array.Empty<DialogueIssue>();
 
     /// <summary>The SEQ staleness/coverage lint (item 7), set only for a Start-Game-Enabled QUEST input; null
     /// otherwise (a non-SGE quest, or a DIAL input — a topic isn't a quest, so a .seq isn't its concern).</summary>
@@ -131,12 +142,14 @@ public static class DialogueValidate
 
     /// <summary>Resolve <paramref name="fk"/> to its load-order winner and validate the dialogue graph: a DIAL →
     /// validate that one topic; a QUST → fan out to EVERY topic the quest owns (a whole-order DIAL winner scan,
-    /// filtered by DialogTopic.Quest, because a topic points UP at its quest — the quest holds no topic list).
-    /// Builds the load-order winner <c>Resolve</c> closure (each INFO's Speaker → NPC → VoiceType, and the topic's
-    /// Quest) + the asset view off the live resolvers, and opens ONE overlay session for the run. NEVER throws: a
-    /// recoverable miss (not in the order, or neither a DIAL nor a QUST) is a NAMED
-    /// <see cref="DialogueValidationReport.Error"/>; a mid-run throw rides
-    /// <see cref="DialogueValidationReport.CheckError"/> (Q3 — surfaced, never a silent empty pass).</summary>
+    /// filtered by DialogTopic.Quest, because a topic points UP at its quest — the quest holds no topic list) plus
+    /// the quest's own CK-parity gaps (ANAM / objective FNAM) as InputIssues; a DLVW or DLBR → a RECORD-LEVEL
+    /// CK-parity check (the DNAM/ENAM and TNAM subrecords DialogueCkParity fills on create — no topic graph to
+    /// walk, so Topics stays empty and the render names the narrower scope). Builds the load-order winner
+    /// <c>Resolve</c> closure (each INFO's Speaker → NPC → VoiceType, and the topic's Quest) + the asset view off
+    /// the live resolvers, and opens ONE overlay session for the run. NEVER throws: a recoverable miss (not in the
+    /// order, or none of the four input types) is a NAMED <see cref="DialogueValidationReport.Error"/>; a mid-run
+    /// throw rides <see cref="DialogueValidationReport.CheckError"/> (Q3 — surfaced, never a silent empty pass).</summary>
     public static DialogueValidationReport Run(LoadOrderResolver resolver, AssetResolver assets, FormKey fk)
     {
         try
@@ -165,7 +178,7 @@ public static class DialogueValidate
             var win = view.ResolveWinner(fk);
             if (win is null)
                 return DialogueValidationReport.ForError(fk,
-                    $"{fk} is not in the active load order — nothing to validate. Pass a dialogue topic (DIAL) FormID to validate one topic, or a quest (QUST) FormID to validate all of a quest's topics.");
+                    $"{fk} is not in the active load order — nothing to validate. Pass a dialogue topic (DIAL) FormID to validate one topic, a quest (QUST) FormID to validate all of a quest's topics, or a dialogue view (DLVW) / branch (DLBR) FormID for a record-level CK-parity check.");
 
             var body = view.GetRecord(session, win.Value.WinnerPlugin, fk);
             if (body is null)
@@ -198,12 +211,47 @@ public static class DialogueValidate
                     var wp = view.ResolveWinner(tfk)?.WinnerPlugin ?? win.Value.WinnerPlugin;
                     topics.Add(ValidateTopic(dt, wp, InOrder, Resolve, av));
                 }
+
+                // Quest-level CK-parity gaps (ANAM / objective FNAM) — checked ONCE on the winning quest record and
+                // surfaced as InputIssues, never per topic (a multi-topic quest would repeat the same quest gap N
+                // times). The absence probes are DialogueCkParity's — the SAME ones ApplyQuestDefaults fills through,
+                // so fill and check can't drift (Q3). S2 byte-parity → Warning. PRESENCE only: the validator never
+                // judges the ANAM VALUE (an edited quest's ANAM is a legitimate CK high-water mark).
+                var questGaps = DialogueCkParity.MissingQuestDefaults(quest)
+                    .Select(g => new DialogueIssue(DialogueIssueSeverity.Warning,
+                        $"Quest {fk} is missing the {g.Subrecord} subrecord — {g.Detail}"))
+                    .ToList();
+
                 return new DialogueValidationReport(fk, "quest", quest.EditorID ?? "", win.Value.WinnerPlugin, topics)
-                    { ReadIncomplete = av.ReadIncomplete, SeqLint = seqLint };
+                    { ReadIncomplete = av.ReadIncomplete, SeqLint = seqLint, InputIssues = questGaps };
+            }
+
+            // DLVW / DLBR inputs: a RECORD-LEVEL CK-parity check — these carry no INFO list, so there is no topic
+            // graph/voice/script surface to walk; the finding set IS the CK-parity gaps (the same subrecords
+            // DialogueCkParity fills on create, via the SAME shared presence predicates — no drift, Q3). Topics
+            // stays empty; the render names the narrower scope so a clean pass never reads as a graph validation.
+            if (body is IDialogViewGetter dlvw)
+            {
+                var gaps = DialogueCkParity.MissingViewDefaults(dlvw)
+                    .Select(g => new DialogueIssue(DialogueIssueSeverity.Warning,
+                        $"DialogView {fk} is missing the {g.Subrecord} subrecord — {g.Detail}"))
+                    .ToList();
+                return new DialogueValidationReport(fk, "view", dlvw.EditorID ?? "", win.Value.WinnerPlugin,
+                    Array.Empty<TopicValidation>()) { InputIssues = gaps };
+            }
+
+            if (body is IDialogBranchGetter dlbr)
+            {
+                var gaps = DialogueCkParity.MissingBranchDefaults(dlbr)
+                    .Select(g => new DialogueIssue(DialogueIssueSeverity.Warning,
+                        $"DialogBranch {fk} is missing the {g.Subrecord} subrecord — {g.Detail}"))
+                    .ToList();
+                return new DialogueValidationReport(fk, "branch", dlbr.EditorID ?? "", win.Value.WinnerPlugin,
+                    Array.Empty<TopicValidation>()) { InputIssues = gaps };
             }
 
             return DialogueValidationReport.ForError(fk,
-                $"{fk} resolves to a {RecordNaming.StripOverlay(body.GetType().Name)} in {win.Value.WinnerPlugin}, not a dialogue topic (DIAL) or quest (QUST). Pass a DIAL FormID to validate one topic, or a QUST FormID to validate every topic a quest owns.");
+                $"{fk} resolves to a {RecordNaming.StripOverlay(body.GetType().Name)} in {win.Value.WinnerPlugin}, not a dialogue topic (DIAL), quest (QUST), dialogue view (DLVW), or dialogue branch (DLBR). Pass a DIAL FormID to validate one topic, a QUST FormID to validate every topic a quest owns, or a DLVW/DLBR FormID for a record-level CK-parity check.");
         }
         catch (Exception ex)
         {
@@ -353,9 +401,9 @@ public static class DialogueValidate
             // The absence probe is DialogueCkParity's — the SAME one the create path FILLS through — so a create that
             // populates the subrecord and this check that flags its absence can never drift (Q3). Real CK/xEdit-authored
             // INFOs always carry both, so this fires only on a bare-authored record; houseCARL's own create tools
-            // auto-fill it. (The rest of the CK-parity family — DLVW DNAM/ENAM, DLBR TNAM, QUST ANAM/objective FNAM,
-            // DIAL PNAM — is NOT checked here: DLVW isn't a validator input, PNAM is a non-nullable float with no
-            // "unset" signal, and the others are S2 byte-parity, not a crash. See the header's CANNOT-CHECK note.)
+            // auto-fill it. (The rest of the CK-parity family lives elsewhere: DLVW DNAM/ENAM and DLBR TNAM are their
+            // own input kinds, QUST ANAM/objective FNAM rides the quest input's InputIssues, and DIAL PNAM is the one
+            // permanent boundary — a non-nullable float with no "unset" signal. See the header's CANNOT-CHECK note.)
             foreach (var gap in DialogueCkParity.MissingInfoDefaults(info))
                 issues.Add(new(DialogueIssueSeverity.Warning,
                     $"INFO {info.FormKey} is missing the {gap.Subrecord} subrecord — {gap.Detail}"));

--- a/src/housecarl-core/DialogueValidate.cs
+++ b/src/housecarl-core/DialogueValidate.cs
@@ -125,8 +125,8 @@ public sealed record DialogueValidationReport(
     /// otherwise (a non-SGE quest, or a DIAL input — a topic isn't a quest, so a .seq isn't its concern).</summary>
     public SeqLintFinding? SeqLint { get; init; }
 
-    /// <summary>The FormID isn't in the active order, or resolves to neither a DIAL nor a QUST — a recoverable,
-    /// named error the tool renders as guidance (Q3), not a thrown failure.</summary>
+    /// <summary>The FormID isn't in the active order, or resolves to none of the four input types (DIAL, QUST,
+    /// DLVW, DLBR) — a recoverable, named error the tool renders as guidance (Q3), not a thrown failure.</summary>
     public static DialogueValidationReport ForError(FormKey fk, string error) =>
         new(fk, "error", null, null, Array.Empty<TopicValidation>()) { Error = error };
 
@@ -139,6 +139,13 @@ public static class DialogueValidate
 {
     /// <summary>The type filter for the quest fan-out scan — every winning DialogTopic (DIAL) in the order.</summary>
     static readonly Type[] DialTypes = { typeof(IDialogTopicGetter) };
+
+    /// <summary>The ONE home for rendering a <see cref="CkParityGap"/> as a validator finding — "{noun} {fk} is
+    /// missing the {Subrecord} subrecord — {Detail}", always a Warning (every member of the family is a CK-editor /
+    /// byte-parity shape the game itself tolerates). All four gap surfaces (per-INFO, quest InputIssues, DLVW,
+    /// DLBR) go through this, so a wording or severity change is one edit, never four drifting copies.</summary>
+    static DialogueIssue GapIssue(string noun, FormKey fk, CkParityGap gap) =>
+        new(DialogueIssueSeverity.Warning, $"{noun} {fk} is missing the {gap.Subrecord} subrecord — {gap.Detail}");
 
     /// <summary>Resolve <paramref name="fk"/> to its load-order winner and validate the dialogue graph: a DIAL →
     /// validate that one topic; a QUST → fan out to EVERY topic the quest owns (a whole-order DIAL winner scan,
@@ -218,9 +225,7 @@ public static class DialogueValidate
                 // so fill and check can't drift (Q3). S2 byte-parity → Warning. PRESENCE only: the validator never
                 // judges the ANAM VALUE (an edited quest's ANAM is a legitimate CK high-water mark).
                 var questGaps = DialogueCkParity.MissingQuestDefaults(quest)
-                    .Select(g => new DialogueIssue(DialogueIssueSeverity.Warning,
-                        $"Quest {fk} is missing the {g.Subrecord} subrecord — {g.Detail}"))
-                    .ToList();
+                    .Select(g => GapIssue("Quest", fk, g)).ToList();
 
                 return new DialogueValidationReport(fk, "quest", quest.EditorID ?? "", win.Value.WinnerPlugin, topics)
                     { ReadIncomplete = av.ReadIncomplete, SeqLint = seqLint, InputIssues = questGaps };
@@ -233,9 +238,7 @@ public static class DialogueValidate
             if (body is IDialogViewGetter dlvw)
             {
                 var gaps = DialogueCkParity.MissingViewDefaults(dlvw)
-                    .Select(g => new DialogueIssue(DialogueIssueSeverity.Warning,
-                        $"DialogView {fk} is missing the {g.Subrecord} subrecord — {g.Detail}"))
-                    .ToList();
+                    .Select(g => GapIssue("DialogView", fk, g)).ToList();
                 return new DialogueValidationReport(fk, "view", dlvw.EditorID ?? "", win.Value.WinnerPlugin,
                     Array.Empty<TopicValidation>()) { InputIssues = gaps };
             }
@@ -243,9 +246,7 @@ public static class DialogueValidate
             if (body is IDialogBranchGetter dlbr)
             {
                 var gaps = DialogueCkParity.MissingBranchDefaults(dlbr)
-                    .Select(g => new DialogueIssue(DialogueIssueSeverity.Warning,
-                        $"DialogBranch {fk} is missing the {g.Subrecord} subrecord — {g.Detail}"))
-                    .ToList();
+                    .Select(g => GapIssue("DialogBranch", fk, g)).ToList();
                 return new DialogueValidationReport(fk, "branch", dlbr.EditorID ?? "", win.Value.WinnerPlugin,
                     Array.Empty<TopicValidation>()) { InputIssues = gaps };
             }
@@ -405,8 +406,7 @@ public static class DialogueValidate
             // own input kinds, QUST ANAM/objective FNAM rides the quest input's InputIssues, and DIAL PNAM is the one
             // permanent boundary — a non-nullable float with no "unset" signal. See the header's CANNOT-CHECK note.)
             foreach (var gap in DialogueCkParity.MissingInfoDefaults(info))
-                issues.Add(new(DialogueIssueSeverity.Warning,
-                    $"INFO {info.FormKey} is missing the {gap.Subrecord} subrecord — {gap.Detail}"));
+                issues.Add(GapIssue("INFO", info.FormKey, gap));
 
             // Fragment-presence tally (item 8): does this line carry a result-script FRAGMENT (a code path that can
             // surface in Papyrus.log)? Via the single fragment-presence home, so this never drifts from the per-INFO

--- a/src/housecarl-generator/DialogueCkParityGuardProbe.cs
+++ b/src/housecarl-generator/DialogueCkParityGuardProbe.cs
@@ -30,6 +30,12 @@ namespace HousecarlGenerator;
 ///   INFO-GAP-PROBE    — the anti-drift tie: MissingInfoDefaults (the validator's check side) and ApplyInfoDefaults
 ///                       (the fill side) read ONE shared presence predicate — a bare INFO reports exactly the CNAM+ENAM
 ///                       gaps, and after the fill reports none (a field in one path but not the other breaks this).
+///   DLVW-GAP-PROBE    — same anti-drift tie for the DLVW: a bare DialogView reports exactly the DNAM+ENAM gaps
+///                       via MissingViewDefaults, none after ApplyViewDefaults (shared presence predicates).
+///   DLBR-GAP-PROBE    — same tie for the DLBR: a bare DialogBranch reports exactly the TNAM gap via
+///                       MissingBranchDefaults, none after ApplyBranchDefaults.
+///   QUST-GAP-PROBE    — same tie for the QUST: a bare quest with one Flags-less objective reports exactly the
+///                       ANAM + FNAM gaps via MissingQuestDefaults, none after ApplyQuestDefaults.
 ///   DLVW-AUTOFILL     — create a bare DialogView → written DNAM=00, ENAM=00000000, both REPORTED.
 ///   DLVW-DNAM-WINS    — an explicit DNAM=FF is NOT overridden to 00 (ENAM still auto-fills).
 ///   BNAM-LINT         — a Custom topic with no Branch → validate_dialogue raises a Warning naming Branch (BNAM); a
@@ -178,6 +184,48 @@ internal static class DialogueCkParityGuardProbe
                 int after = DialogueCkParity.MissingInfoDefaults(info).Count;
                 Check(flaggedBoth && after == 0,
                     $"INFO-GAP-PROBE bare INFO → CNAM+ENAM gaps (before={before.Count}), none after fill (after={after}) — check/fill share one predicate");
+            }
+
+            // ---- DLVW-GAP-PROBE: the same anti-drift tie for the DialogView — MissingViewDefaults (the validator's
+            //      check side) and ApplyViewDefaults (the fill side) read the SAME presence predicates: a bare DLVW
+            //      reports exactly the DNAM+ENAM gaps, none after the fill. Pure logic — no service/disk. ----
+            {
+                var view = new DialogView(FormKey.Factory("000801:HcCkpGapProbe.esm"), SkyrimRelease.SkyrimSE);
+                var before = DialogueCkParity.MissingViewDefaults(view);
+                bool flaggedBoth = before.Count == 2
+                    && before.Any(g => g.Subrecord.Contains("DNAM", StringComparison.OrdinalIgnoreCase))
+                    && before.Any(g => g.Subrecord.Contains("ENAM", StringComparison.OrdinalIgnoreCase));
+                DialogueCkParity.ApplyViewDefaults(view);
+                int after = DialogueCkParity.MissingViewDefaults(view).Count;
+                Check(flaggedBoth && after == 0,
+                    $"DLVW-GAP-PROBE bare DialogView → DNAM+ENAM gaps (before={before.Count}), none after fill (after={after}) — check/fill share one predicate");
+            }
+
+            // ---- DLBR-GAP-PROBE: the same tie for the DialogBranch — a bare DLBR reports exactly the TNAM gap,
+            //      none after ApplyBranchDefaults. ----
+            {
+                var br = new DialogBranch(FormKey.Factory("000802:HcCkpGapProbe.esm"), SkyrimRelease.SkyrimSE);
+                var before = DialogueCkParity.MissingBranchDefaults(br);
+                bool flagged = before.Count == 1 && before[0].Subrecord.Contains("TNAM", StringComparison.OrdinalIgnoreCase);
+                DialogueCkParity.ApplyBranchDefaults(br);
+                int after = DialogueCkParity.MissingBranchDefaults(br).Count;
+                Check(flagged && after == 0,
+                    $"DLBR-GAP-PROBE bare DialogBranch → TNAM gap (before={before.Count}), none after fill (after={after}) — check/fill share one predicate");
+            }
+
+            // ---- QUST-GAP-PROBE: the same tie for the Quest — a bare quest with one Flags-less objective reports
+            //      exactly the ANAM + FNAM gaps, none after ApplyQuestDefaults. ----
+            {
+                var q = new Quest(FormKey.Factory("000803:HcCkpGapProbe.esm"), SkyrimRelease.SkyrimSE);
+                q.Objectives.Add(new QuestObjective { Index = 10 });   // Flags null
+                var before = DialogueCkParity.MissingQuestDefaults(q);
+                bool flaggedBoth = before.Count == 2
+                    && before.Any(g => g.Subrecord.Contains("ANAM", StringComparison.OrdinalIgnoreCase))
+                    && before.Any(g => g.Subrecord.Contains("FNAM", StringComparison.OrdinalIgnoreCase) && g.Subrecord.Contains("Objectives[0]", StringComparison.Ordinal));
+                DialogueCkParity.ApplyQuestDefaults(q);
+                int after = DialogueCkParity.MissingQuestDefaults(q).Count;
+                Check(flaggedBoth && after == 0,
+                    $"QUST-GAP-PROBE bare Quest+objective → ANAM+FNAM gaps (before={before.Count}), none after fill (after={after}) — check/fill share one predicate");
             }
 
             // ---- DLVW-AUTOFILL: create a bare DialogView → written DNAM=00, ENAM=00000000, both reported. ----

--- a/src/housecarl-generator/DialogueValidateGuardProbe.cs
+++ b/src/housecarl-generator/DialogueValidateGuardProbe.cs
@@ -30,6 +30,15 @@ namespace HousecarlGenerator;
 ///   INFO-CKPARITY-GAP— a live INFO missing CNAM (FavorLevel) / ENAM (Flags) WARNs twice, naming each — the CK-editor-crash
 ///                  catch, via the SHARED DialogueCkParity.MissingInfoDefaults probe the create path fills through.
 ///   INFO-CKPARITY-OK — a CK-parity-complete INFO (Info() runs ApplyInfoDefaults) is NOT flagged — the no-false-positive lock.
+///   VIEW-CKPARITY-GAP— a bare DLVW input → kind "view", zero topics, and Warnings naming DNAM + ENAM (the CK Dialogue
+///                  Views crash shape) — end-to-end through the new DialogView input path (shared MissingViewDefaults probe).
+///   VIEW-CKPARITY-OK — a CK-parity-complete DLVW (ApplyViewDefaults-filled) reports NO input issues — no-false-positive lock.
+///   BRANCH-CKPARITY-GAP— a bare DLBR input → kind "branch" and a Warning naming TNAM (S2 byte-parity) — end-to-end
+///                  through the new DialogBranch input path (shared MissingBranchDefaults probe).
+///   BRANCH-CKPARITY-OK— a Category-set DLBR reports NO input issues — no-false-positive lock.
+///   QUST-CKPARITY-GAP— a QUEST input whose quest lacks ANAM and has a Flags-less objective → InputIssues warns BOTH,
+///                  ONCE at quest level (never per topic) — the shared MissingQuestDefaults probe end-to-end.
+///   QUST-CKPARITY-OK — a CK-parity-complete quest (ApplyQuestDefaults-filled) reports NO input issues — no-false-positive lock.
 ///   NO-QUEST     — a topic with DialogTopic.Quest unset warns 'Quest' — the unowned-topic teeth.
 ///   BAD-BRANCH   — DialogTopic.Branch pointing at a non-DLBR is a PROBLEM naming 'Branch'.
 ///   VOICE-WIRED  — a voiced line with no .fuz surfaces as a SILENT VoiceLine IN THE VALIDATOR (reused VoiceCheck).
@@ -77,6 +86,7 @@ public static class DialogueValidateGuardProbe
         FormKey cleanFk, linkBadFk, pnamBadFk, pnamOkFk, deletedFk, noQuestFk, badBranchFk, voicedFk, scriptedFk, condFk, qFanFk, weapFk, encBadFk, encOkFk;
         FormKey condCleanFk, condRefUnsetFk, condDeadAliasFk, condDeadLocAliasFk, condDeadQAliasFk, condAliasOkFk, condAliasFloiFk, condDanglingFk, condGlobalFk, condGetIsIdOkFk, condGetIsIdFk;
         FormKey globOkFk, globBadFk, globSubFk, playerRefFk, playerRefCtlFk, ckGapFk, ckOkFk;
+        FormKey viewGapFk, viewOkFk, brGapFk, brOkFk, qGapFk, qOkFk;
         try
         {
             var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
@@ -361,6 +371,27 @@ public static class DialogueValidateGuardProbe
             tCkOk.Responses.Add(Info("HcDvCkOkI"));
             ckOkFk = tCkOk.FormKey;
 
+            // VIEW-CKPARITY (the new DLVW input kind): a BARE DialogView (DNAM/ENAM both absent — the CK Dialogue
+            // Views crash shape) vs a CK-parity-COMPLETE one (via the same ApplyViewDefaults the create path runs).
+            var vGap = m.DialogViews.AddNew(); vGap.EditorID = "HcDvViewGap"; viewGapFk = vGap.FormKey;
+            var vOk = m.DialogViews.AddNew(); vOk.EditorID = "HcDvViewOk";
+            DialogueCkParity.ApplyViewDefaults(vOk); viewOkFk = vOk.FormKey;
+
+            // BRANCH-CKPARITY (the new DLBR input kind): a BARE DialogBranch (no Category/TNAM) vs one with an
+            // explicit Category. (The shared `branch` fixture above is only ever a Branch TARGET, never an input.)
+            var brGap = m.DialogBranches.AddNew(); brGap.EditorID = "HcDvBrGap"; brGapFk = brGap.FormKey;
+            var brOk = m.DialogBranches.AddNew(); brOk.EditorID = "HcDvBrOk";
+            brOk.Category = DialogBranch.CategoryType.Player; brOkFk = brOk.FormKey;
+
+            // QUST-CKPARITY (quest-level InputIssues): a quest lacking ANAM with one Flags-less objective (both
+            // gaps) vs a CK-parity-complete quest (ApplyQuestDefaults-filled). Neither owns any topics — the arms
+            // prove the gaps ride the INPUT level, independent of the topic fan-out.
+            var qGap = m.Quests.AddNew(); qGap.EditorID = "HcDvQGap";
+            qGap.Objectives.Add(new QuestObjective { Index = 1 }); qGapFk = qGap.FormKey;
+            var qOk = m.Quests.AddNew(); qOk.EditorID = "HcDvQOk";
+            qOk.Objectives.Add(new QuestObjective { Index = 1 });
+            DialogueCkParity.ApplyQuestDefaults(qOk); qOkFk = qOk.FormKey;
+
             // Give every branch-LESS fixture topic the shared well-formed branch — SAME reason as the SNAM loop
             // below: this guard tests the GRAPH/CONDITION/VOICE lints, not the BNAM-absent lint (that's
             // dialogue-ckparity-guard's job), so its Custom topics must be branch-clean or a "no issues" arm would
@@ -443,6 +474,53 @@ public static class DialogueValidateGuardProbe
             bool ok = t is not null && t.InfoCount == 1
                 && !t.Issues.Any(i => i.Message.Contains("CNAM", StringComparison.Ordinal) || i.Message.Contains("ENAM", StringComparison.Ordinal));
             all &= Pass("INFO-CKPARITY-OK not flagged", ok, t is null ? "no topic" : $"infos={t.InfoCount} issues={t.Issues.Count}: {Issues(t)}");
+        }
+
+        // ---------- VIEW-CKPARITY-GAP: a bare DLVW input → kind "view", zero topics, Warnings naming DNAM + ENAM ----------
+        {
+            var r = DialogueValidate.Run(resolver, assets, viewGapFk);
+            bool ok = r.InputKind == "view" && r.Error is null && r.Topics.Count == 0
+                && r.InputIssues.Any(i => i.Severity == DialogueIssueSeverity.Warning && i.Message.Contains("DNAM", StringComparison.Ordinal))
+                && r.InputIssues.Any(i => i.Severity == DialogueIssueSeverity.Warning && i.Message.Contains("ENAM", StringComparison.Ordinal));
+            all &= Pass("VIEW-CKPARITY-GAP warns DNAM+ENAM", ok, $"kind={r.InputKind} issues={InputIssues(r)}");
+        }
+
+        // ---------- VIEW-CKPARITY-OK: a CK-parity-complete DLVW reports NO input issues — the no-false-positive lock ----------
+        {
+            var r = DialogueValidate.Run(resolver, assets, viewOkFk);
+            bool ok = r.InputKind == "view" && r.Error is null && r.InputIssues.Count == 0;
+            all &= Pass("VIEW-CKPARITY-OK not flagged", ok, $"kind={r.InputKind} issues={InputIssues(r)}");
+        }
+
+        // ---------- BRANCH-CKPARITY-GAP: a bare DLBR input → kind "branch", a Warning naming TNAM ----------
+        {
+            var r = DialogueValidate.Run(resolver, assets, brGapFk);
+            bool ok = r.InputKind == "branch" && r.Error is null && r.Topics.Count == 0
+                && r.InputIssues.Any(i => i.Severity == DialogueIssueSeverity.Warning && i.Message.Contains("TNAM", StringComparison.Ordinal));
+            all &= Pass("BRANCH-CKPARITY-GAP warns TNAM", ok, $"kind={r.InputKind} issues={InputIssues(r)}");
+        }
+
+        // ---------- BRANCH-CKPARITY-OK: a Category-set DLBR reports NO input issues — the no-false-positive lock ----------
+        {
+            var r = DialogueValidate.Run(resolver, assets, brOkFk);
+            bool ok = r.InputKind == "branch" && r.Error is null && r.InputIssues.Count == 0;
+            all &= Pass("BRANCH-CKPARITY-OK not flagged", ok, $"kind={r.InputKind} issues={InputIssues(r)}");
+        }
+
+        // ---------- QUST-CKPARITY-GAP: a quest lacking ANAM + a Flags-less objective → InputIssues warns BOTH, once, at quest level ----------
+        {
+            var r = DialogueValidate.Run(resolver, assets, qGapFk);
+            bool ok = r.InputKind == "quest" && r.Error is null
+                && r.InputIssues.Count(i => i.Severity == DialogueIssueSeverity.Warning && i.Message.Contains("ANAM", StringComparison.Ordinal)) == 1
+                && r.InputIssues.Count(i => i.Severity == DialogueIssueSeverity.Warning && i.Message.Contains("FNAM", StringComparison.Ordinal)) == 1;
+            all &= Pass("QUST-CKPARITY-GAP warns ANAM+FNAM", ok, $"kind={r.InputKind} issues={InputIssues(r)}");
+        }
+
+        // ---------- QUST-CKPARITY-OK: a CK-parity-complete quest reports NO input issues — the no-false-positive lock ----------
+        {
+            var r = DialogueValidate.Run(resolver, assets, qOkFk);
+            bool ok = r.InputKind == "quest" && r.Error is null && r.InputIssues.Count == 0;
+            all &= Pass("QUST-CKPARITY-OK not flagged", ok, $"kind={r.InputKind} issues={InputIssues(r)}");
         }
 
         // ---------- NO-QUEST: an unowned topic warns 'Quest' ----------
@@ -651,7 +729,7 @@ public static class DialogueValidateGuardProbe
 
         Console.WriteLine();
         Console.WriteLine(all
-            ? "RESULT: PASS — the dialogue-graph validator holds (no false PNAM-absence flag, LinkTo + dangling-PNAM teeth, deleted-skip, voice/script reuse, encoding lint, condition lints (item 4), <Global=X>/TextDisplayGlobals + PlayerRef-whitelist lints (Track B), fan-out, named rejects)."
+            ? "RESULT: PASS — the dialogue-graph validator holds (no false PNAM-absence flag, LinkTo + dangling-PNAM teeth, deleted-skip, voice/script reuse, encoding lint, condition lints (item 4), <Global=X>/TextDisplayGlobals + PlayerRef-whitelist lints (Track B), INFO/DLVW/DLBR/QUST CK-parity checks, fan-out, named rejects)."
             : "RESULT: FAIL — at least one arm regressed (see above).");
         try { Directory.Delete(tmpDir, recursive: true); } catch { }
         return all ? 0 : 1;
@@ -672,6 +750,8 @@ public static class DialogueValidateGuardProbe
     static TopicValidation? One(DialogueValidationReport r) => r.Topics.Count == 1 ? r.Topics[0] : null;
 
     static string Issues(TopicValidation t) => t.Issues.Count == 0 ? "<none>" : string.Join(" | ", t.Issues.Select(i => $"[{i.Severity}] {i.Message}"));
+
+    static string InputIssues(DialogueValidationReport r) => r.InputIssues.Count == 0 ? "<none>" : string.Join(" | ", r.InputIssues.Select(i => $"[{i.Severity}] {i.Message}"));
 
     static bool Pass(string label, bool ok, string detail)
     {

--- a/src/housecarl-generator/DialogueValidateGuardProbe.cs
+++ b/src/housecarl-generator/DialogueValidateGuardProbe.cs
@@ -68,7 +68,9 @@ namespace HousecarlGenerator;
 ///   PLAYERREF-CONTROL— Run On a NON-whitelisted missing reference still WARNs — the whitelist is a precise 2-form set, not the whole reserved range.
 ///   QUEST-FANOUT — validating a QUEST fans out to EXACTLY the topics it owns (2 here), kind="quest".
 ///   REJ-NOTFOUND — a FormID not in the active order is a NAMED error ('not in the active load order').
-///   REJ-WRONGTYPE— a FormID resolving to neither a DIAL nor a QUST (a Weapon) is a NAMED error ('not a dialogue topic').
+///   REJ-WRONGTYPE— a FormID resolving to none of the four input types (a Weapon) is a NAMED error ('not a dialogue
+///                  topic') that names ALL FOUR accepted kinds (DIAL/QUST/DLVW/DLBR) — pinning the guidance strings
+///                  against the input-kind drift this PR itself demonstrated (REJ-NOTFOUND pins its string too).
 /// </summary>
 public static class DialogueValidateGuardProbe
 {
@@ -716,14 +718,16 @@ public static class DialogueValidateGuardProbe
         {
             var ghost = new FormKey(new ModKey("HcDvGhost", ModType.Plugin), 0x000800);
             var r = DialogueValidate.Run(resolver, assets, ghost);
-            bool ok = r.InputKind == "error" && r.Error is not null && r.Error.Contains("not in the active load order", StringComparison.OrdinalIgnoreCase) && r.Topics.Count == 0;
+            bool ok = r.InputKind == "error" && r.Error is not null && r.Error.Contains("not in the active load order", StringComparison.OrdinalIgnoreCase) && r.Topics.Count == 0
+                && NamesAllInputKinds(r.Error);
             all &= Pass("REJ-NOTFOUND named error", ok, $"kind={r.InputKind} err=[{r.Error}]");
         }
 
         // ---------- REJ-WRONGTYPE: a Weapon FormID is a NAMED 'not a dialogue topic or quest' error ----------
         {
             var r = DialogueValidate.Run(resolver, assets, weapFk);
-            bool ok = r.InputKind == "error" && r.Error is not null && r.Error.Contains("not a dialogue topic", StringComparison.OrdinalIgnoreCase) && r.Topics.Count == 0;
+            bool ok = r.InputKind == "error" && r.Error is not null && r.Error.Contains("not a dialogue topic", StringComparison.OrdinalIgnoreCase) && r.Topics.Count == 0
+                && NamesAllInputKinds(r.Error);
             all &= Pass("REJ-WRONGTYPE named error", ok, $"kind={r.InputKind} err=[{r.Error}]");
         }
 
@@ -749,9 +753,17 @@ public static class DialogueValidateGuardProbe
     /// single-topic arms read its one TopicValidation directly.</summary>
     static TopicValidation? One(DialogueValidationReport r) => r.Topics.Count == 1 ? r.Topics[0] : null;
 
-    static string Issues(TopicValidation t) => t.Issues.Count == 0 ? "<none>" : string.Join(" | ", t.Issues.Select(i => $"[{i.Severity}] {i.Message}"));
+    static string Issues(IReadOnlyList<DialogueIssue> issues) => issues.Count == 0 ? "<none>" : string.Join(" | ", issues.Select(i => $"[{i.Severity}] {i.Message}"));
 
-    static string InputIssues(DialogueValidationReport r) => r.InputIssues.Count == 0 ? "<none>" : string.Join(" | ", r.InputIssues.Select(i => $"[{i.Severity}] {i.Message}"));
+    static string Issues(TopicValidation t) => Issues(t.Issues);
+
+    static string InputIssues(DialogueValidationReport r) => Issues(r.InputIssues);
+
+    /// <summary>Does a reject-guidance string name ALL FOUR accepted input kinds (DIAL, QUST, DLVW, DLBR)? Pins the
+    /// error guidance against input-kind drift — a fifth kind added without updating the reject strings fails here.</summary>
+    static bool NamesAllInputKinds(string error) =>
+        error.Contains("DIAL", StringComparison.Ordinal) && error.Contains("QUST", StringComparison.Ordinal)
+        && error.Contains("DLVW", StringComparison.Ordinal) && error.Contains("DLBR", StringComparison.Ordinal);
 
     static bool Pass(string label, bool ok, string detail)
     {

--- a/src/housecarl-generator/DialogueValidateGuardProbe.cs
+++ b/src/housecarl-generator/DialogueValidateGuardProbe.cs
@@ -1,7 +1,9 @@
+using System.Text.RegularExpressions;
 using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Skyrim;
 using HousecarlCore;
+using HousecarlMcp;
 
 namespace HousecarlGenerator;
 
@@ -39,6 +41,10 @@ namespace HousecarlGenerator;
 ///   QUST-CKPARITY-GAP— a QUEST input whose quest lacks ANAM and has a Flags-less objective → InputIssues warns BOTH,
 ///                  ONCE at quest level (never per topic) — the shared MissingQuestDefaults probe end-to-end.
 ///   QUST-CKPARITY-OK — a CK-parity-complete quest (ApplyQuestDefaults-filled) reports NO input issues — no-false-positive lock.
+///   RENDER-SCOPE-PIN — the hand-written "CK-parity: OK" prose in DialogueWire names EVERY subrecord the check
+///                  actually covers. The checked set is DERIVED from Missing*Defaults on a bare record (never
+///                  hand-listed here), so adding a subrecord to a check fails this arm until the OK line names it
+///                  — the render-level anti-drift tie (PR #155 review finding 5; AssetStatusProbe render-pin pattern).
 ///   NO-QUEST     — a topic with DialogTopic.Quest unset warns 'Quest' — the unowned-topic teeth.
 ///   BAD-BRANCH   — DialogTopic.Branch pointing at a non-DLBR is a PROBLEM naming 'Branch'.
 ///   VOICE-WIRED  — a voiced line with no .fuz surfaces as a SILENT VoiceLine IN THE VALIDATOR (reused VoiceCheck).
@@ -525,6 +531,34 @@ public static class DialogueValidateGuardProbe
             all &= Pass("QUST-CKPARITY-OK not flagged", ok, $"kind={r.InputKind} issues={InputIssues(r)}");
         }
 
+        // ---------- RENDER-SCOPE-PIN: the "CK-parity: OK" prose names EVERY subrecord the check covers ----------
+        // The OK lines in DialogueWire are hand-written scope declarations ("the DNAM and ENAM byte subrecords …
+        // are both present") — a third statement of the checked-subrecord set, outside the fill/check predicate
+        // tie. This arm pins them: the authoritative set is DERIVED here by running Missing*Defaults on a BARE
+        // record and extracting each gap's 4-char signature — never hand-listed — so a subrecord added to a check
+        // fails this arm until the corresponding OK line names it (a clean pass must never under-claim its scope, Q3).
+        {
+            var pinView = GapSigs(DialogueCkParity.MissingViewDefaults(
+                new DialogView(FormKey.Factory("000900:HcDvPin.esm"), SkyrimRelease.SkyrimSE)));
+            var pinBranch = GapSigs(DialogueCkParity.MissingBranchDefaults(
+                new DialogBranch(FormKey.Factory("000901:HcDvPin.esm"), SkyrimRelease.SkyrimSE)));
+            var pinQuest = new Quest(FormKey.Factory("000902:HcDvPin.esm"), SkyrimRelease.SkyrimSE);
+            pinQuest.Objectives.Add(new QuestObjective { Index = 1 });   // one Flags-less objective so FNAM is in the set
+            var pinQ = GapSigs(DialogueCkParity.MissingQuestDefaults(pinQuest));
+
+            string rView = DialogueWire.Render(DialogueValidate.Run(resolver, assets, viewOkFk), 0);
+            string rBr = DialogueWire.Render(DialogueValidate.Run(resolver, assets, brOkFk), 0);
+            string rQ = DialogueWire.Render(DialogueValidate.Run(resolver, assets, qOkFk), 0);
+            bool viewNamed = rView.Contains("CK-parity: OK", StringComparison.Ordinal)
+                && pinView.Length > 0 && pinView.All(s => rView.Contains(s, StringComparison.Ordinal));
+            bool brNamed = rBr.Contains("CK-parity: OK", StringComparison.Ordinal)
+                && pinBranch.Length > 0 && pinBranch.All(s => rBr.Contains(s, StringComparison.Ordinal));
+            bool qNamed = rQ.Contains("quest CK-parity: OK", StringComparison.Ordinal)
+                && pinQ.Length > 0 && pinQ.All(s => rQ.Contains(s, StringComparison.Ordinal));
+            all &= Pass("RENDER-SCOPE-PIN OK lines name checked set", viewNamed && brNamed && qNamed,
+                $"view[{string.Join(",", pinView)}]={viewNamed} branch[{string.Join(",", pinBranch)}]={brNamed} quest[{string.Join(",", pinQ)}]={qNamed}");
+        }
+
         // ---------- NO-QUEST: an unowned topic warns 'Quest' ----------
         {
             var t = One(DialogueValidate.Run(resolver, assets, noQuestFk));
@@ -758,6 +792,12 @@ public static class DialogueValidateGuardProbe
     static string Issues(TopicValidation t) => Issues(t.Issues);
 
     static string InputIssues(DialogueValidationReport r) => Issues(r.InputIssues);
+
+    /// <summary>The 4-char subrecord signatures (DNAM/ENAM/TNAM/ANAM/FNAM/…) a gap list names — the authoritative
+    /// checked-set for the RENDER-SCOPE-PIN arm, derived from Missing*Defaults' own output (by construction,
+    /// never hand-listed in the probe).</summary>
+    static string[] GapSigs(IReadOnlyList<CkParityGap> gaps) =>
+        gaps.SelectMany(g => Regex.Matches(g.Subrecord, @"\b[A-Z]{4}\b").Select(m => m.Value)).Distinct().ToArray();
 
     /// <summary>Does a reject-guidance string name ALL FOUR accepted input kinds (DIAL, QUST, DLVW, DLBR)? Pins the
     /// error guidance against input-kind drift — a fifth kind added without updating the reject strings fails here.</summary>

--- a/src/housecarl-mcp/DialogueTools.cs
+++ b/src/housecarl-mcp/DialogueTools.cs
@@ -18,7 +18,10 @@ public static class DialogueTools
      Description(
          "Validate a dialogue topic's whole graph against the load order — what the game actually sees. Pass a " +
          "dialogue topic (DIAL) FormID to validate that one topic, or a quest (QUST) FormID to validate EVERY topic " +
-         "the quest owns. Checks the things houseCARL CAN verify at the data layer: the topic is wired to a quest, " +
+         "the quest owns (plus the quest's own CK-parity subrecords, checked once). A dialogue view (DLVW) or " +
+         "dialogue branch (DLBR) FormID runs a record-level CK-parity check (the DNAM/ENAM and TNAM subrecords the " +
+         "Creation Kit always writes — a bare DLVW crashes the CK's Dialogue Views editor). " +
+         "Checks the things houseCARL CAN verify at the data layer: the topic is wired to a quest, " +
          "the dialogue branch resolves, the INFO.LinkTo conversation chain (topic -> next topic) has no dangling " +
          "targets, and no previous-link (PNAM) is dangling — an EMPTY PNAM is normal (vanilla selects among a " +
          "topic's lines by their conditions, not a previous-link chain), so absence is never flagged; plus (reusing " +
@@ -34,7 +37,7 @@ public static class DialogueTools
          "housecarl_create_record; to inspect a single record use housecarl_read_record.")]
     public static string ValidateDialogue(
         LoadOrderService svc,
-        [Description("The dialogue topic (DIAL) or quest (QUST) FormID as 'XXXXXX:Plugin.esp' — 6 hex digits, a colon, then the defining master's filename. A DIAL validates one topic; a QUST validates every topic that quest owns.")]
+        [Description("The dialogue topic (DIAL), quest (QUST), dialogue view (DLVW), or dialogue branch (DLBR) FormID as 'XXXXXX:Plugin.esp' — 6 hex digits, a colon, then the defining master's filename. A DIAL validates one topic; a QUST validates every topic that quest owns; a DLVW/DLBR runs a record-level CK-parity check.")]
             string formid,
         [Description("Optional. Max characters before the report is cut with an explicit notice (never silent). 0 = the server default (~80k). Raise for a quest that owns many topics.")]
             int max_chars = 0) => Guard.Tool("housecarl_validate_dialogue", () =>
@@ -65,6 +68,28 @@ static class DialogueWire
         if (r.Error is not null) return "error: " + r.Error;
 
         var sb = new StringBuilder();
+
+        // DLVW/DLBR inputs: a RECORD-LEVEL CK-parity check — no topic graph, so no per-topic blocks and no
+        // topic-shaped standing-limits footer. The scope note names what this did NOT check (Q3 — a clean pass
+        // here must never read as a graph/voice/script validation).
+        if (r.InputKind is "view" or "branch")
+        {
+            string kind = r.InputKind == "view" ? "dialogue view (DLVW)" : "dialogue branch (DLBR)";
+            sb.Append("validate_dialogue: ").Append(kind).Append(' ').Append(Edid(r.InputEditorId))
+              .Append(" (").Append(r.Input).Append(") — winner ").Append(r.InputWinnerPlugin).Append('\n');
+            if (r.InputIssues.Count == 0)
+                sb.Append("  CK-parity: OK — ").Append(r.InputKind == "view"
+                    ? "the DNAM and ENAM byte subrecords the Creation Kit always writes are both present.\n"
+                    : "the TNAM (Category) subrecord the Creation Kit always writes is present.\n");
+            else
+                foreach (var iss in r.InputIssues)
+                    sb.Append("  ").Append(iss.Severity == DialogueIssueSeverity.Problem ? "[X] " : "[!] ")
+                      .Append(iss.Message).Append('\n');
+            sb.Append("scope: this is a record-level CK-parity check only — it does not validate any dialogue graph, "
+                    + "voice, script, or condition surface. Validate the owning topics (DIAL) or quest (QUST) for those.");
+            return sb.ToString();
+        }
+
         if (r.InputKind == "quest")
         {
             sb.Append("validate_dialogue: quest ").Append(Edid(r.InputEditorId)).Append(" (").Append(r.Input).Append(')')
@@ -73,6 +98,16 @@ static class DialogueWire
                 sb.Append("  no dialogue topics in the active load order are owned by this quest — nothing to validate. " +
                           "If you expected some, check those topics set DialogTopic.Quest to this quest and that their plugin is enabled.\n");
             AppendSeq(sb, r.SeqLint);
+
+            // Quest-level CK-parity (ANAM / objective FNAM) — input-level findings, printed ONCE here, never per
+            // topic. An explicit OK line, matching the per-topic "graph: OK" style (a sub-check that ran and passed
+            // is stated, not silent).
+            if (r.InputIssues.Count == 0)
+                sb.Append("  quest CK-parity: OK — the NextAliasID (ANAM) subrecord is present and every objective carries its Flags (FNAM).\n");
+            else
+                foreach (var iss in r.InputIssues)
+                    sb.Append("  ").Append(iss.Severity == DialogueIssueSeverity.Problem ? "[X] " : "[!] ")
+                      .Append(iss.Message).Append('\n');
         }
 
         for (int i = 0; i < r.Topics.Count; i++)

--- a/src/housecarl-mcp/DialogueTools.cs
+++ b/src/housecarl-mcp/DialogueTools.cs
@@ -57,6 +57,22 @@ public static class DialogueTools
 /// mistaken for "this will play"). Budget-bounded like the read tools (explicit cut at max_chars, never silent).</summary>
 static class DialogueWire
 {
+    /// <summary>The ONE home for rendering a finding list — each as "[X]/[!] message" at <paramref name="pad"/>,
+    /// budget-aware: at the cap it appends an EXPLICIT truncation notice and returns false so the caller can stop
+    /// (max_chars' "cut with an explicit notice (never silent)" contract, Q3). Shared by the per-topic graph
+    /// issues and the input-level (quest/DLVW/DLBR) findings, so the severity glyph and the cap discipline can
+    /// never diverge between the two levels of one report.</summary>
+    static bool AppendIssues(StringBuilder sb, IReadOnlyList<DialogueIssue> issues, string pad, int cap)
+    {
+        foreach (var iss in issues)
+        {
+            if (sb.Length >= cap) { sb.Append(pad).Append("... [truncated at max_chars]\n"); return false; }
+            sb.Append(pad).Append(iss.Severity == DialogueIssueSeverity.Problem ? "[X] " : "[!] ")
+              .Append(iss.Message).Append('\n');
+        }
+        return true;
+    }
+
     public static string Render(DialogueValidationReport r, int maxChars)
     {
         int cap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
@@ -82,9 +98,7 @@ static class DialogueWire
                     ? "the DNAM and ENAM byte subrecords the Creation Kit always writes are both present.\n"
                     : "the TNAM (Category) subrecord the Creation Kit always writes is present.\n");
             else
-                foreach (var iss in r.InputIssues)
-                    sb.Append("  ").Append(iss.Severity == DialogueIssueSeverity.Problem ? "[X] " : "[!] ")
-                      .Append(iss.Message).Append('\n');
+                AppendIssues(sb, r.InputIssues, "  ", cap);
             sb.Append("scope: this is a record-level CK-parity check only — it does not validate any dialogue graph, "
                     + "voice, script, or condition surface. Validate the owning topics (DIAL) or quest (QUST) for those.");
             return sb.ToString();
@@ -105,9 +119,7 @@ static class DialogueWire
             if (r.InputIssues.Count == 0)
                 sb.Append("  quest CK-parity: OK — the NextAliasID (ANAM) subrecord is present and every objective carries its Flags (FNAM).\n");
             else
-                foreach (var iss in r.InputIssues)
-                    sb.Append("  ").Append(iss.Severity == DialogueIssueSeverity.Problem ? "[X] " : "[!] ")
-                      .Append(iss.Message).Append('\n');
+                AppendIssues(sb, r.InputIssues, "  ", cap);
         }
 
         for (int i = 0; i < r.Topics.Count; i++)
@@ -167,12 +179,7 @@ static class DialogueWire
         else
         {
             sb.Append(pad).Append("  graph: ").Append(t.Issues.Count).Append(" issue(s):\n");
-            foreach (var iss in t.Issues)
-            {
-                if (sb.Length >= cap) { sb.Append(pad).Append("    ... [truncated at max_chars]\n"); return; }
-                sb.Append(pad).Append("    ").Append(iss.Severity == DialogueIssueSeverity.Problem ? "[X] " : "[!] ")
-                  .Append(iss.Message).Append('\n');
-            }
+            if (!AppendIssues(sb, t.Issues, pad + "    ", cap)) return;
         }
 
         AppendVoice(sb, t, pad, cap);


### PR DESCRIPTION
Implements the follow-up pass planned in `dev/plans/DIALOGUE_CKPARITY_VALIDATE_RESIDUAL_2026-07-06.md` — the CK-parity checks the shared-logic-consolidation PR deliberately deferred. Every remaining member of the family `DialogueCkParity` fills on create is now also **checked** by `housecarl_validate_dialogue`, with the same anti-drift discipline as INFO CNAM/ENAM: one shared presence predicate per field, consumed by both the fill path and the check path.

## What changed

**`DialogueCkParity`** — shared predicates `HasDnam`/`HasEnam` (DLVW), `HasCategory` (DLBR), `HasNextAliasID`/`HasObjectiveFlags` (QUST); the existing `Apply*Defaults` now route through them; new read-only `MissingViewDefaults` / `MissingBranchDefaults` / `MissingQuestDefaults` counterparts.

**`DialogueValidate`** —
- **DLVW and DLBR become input kinds** (`view` / `branch`): a record-level CK-parity check (no topic graph to walk). A bare DLVW is the S1 confirmed CK Dialogue Views editor crash — the highest-value residual item. DLBR rides the same path (the plan's suggested resolution of its per-topic-dedup judgement call).
- **QUEST input** additionally reports ANAM / per-objective FNAM gaps ONCE, via a new report-level `InputIssues` list — never repeated per topic. Presence-only (the validator never judges the ANAM value; an edited quest's ANAM is a legitimate CK high-water mark).
- DIAL Priority (PNAM) stays the documented permanent boundary (non-nullable float, no unset signal on a finished record); the header's CANNOT-CHECK note is synced to the new reality.

**`DialogueWire`** — renders the two new input kinds with an explicit scope note (record-level CK-parity only — not a graph/voice/script validation, Q3) and a quest CK-parity block (explicit OK line or the warnings); tool + param descriptions updated.

**Guards** —
- `dialogue-ckparity-guard`: `DLVW-GAP-PROBE`, `DLBR-GAP-PROBE`, `QUST-GAP-PROBE` — the unit anti-drift ties (bare record reports exactly the gaps, none after the fill).
- `dialogue-validate-guard`: `VIEW/BRANCH/QUST-CKPARITY-GAP` + `-OK` end-to-end arm pairs (gap warned through the validator; a CK-parity-complete record is never flagged).

## Verification

- `dialogue-ckparity-guard`: PASS (all arms incl. 3 new)
- `dialogue-validate-guard`: PASS (all arms incl. 6 new)
- `ci-all`: **74/74 PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)