### PR TITLE
feat: housecarl_copy_npc_appearance — the composed standalone-NPC-copy verb (chain Stage 3)

### DIFF
--- a/src/housecarl-core/AssetRenameService.cs
+++ b/src/housecarl-core/AssetRenameService.cs
@@ -344,24 +344,7 @@ public static class AssetRenameService
     static readonly System.Text.RegularExpressions.Regex VoiceIdRx =
         new(@"_([0-9A-Fa-f]{8})_\d+\.[A-Za-z0-9]+$", System.Text.RegularExpressions.RegexOptions.Compiled);
 
-    /// <summary>Read the bytes of a resolved WINNING provider — a loose file off disk, or a single BSA entry via native
-    /// Mutagen (zero handle at rest, the AssetResolver.TryReadArchiveEntry cornerstone). Mirrors LoadOrderService.ReadResolvedSource
-    /// but lives in core (the service's home) so the spine has no mcp dependency. A named error (Q3) if the resolved copy
-    /// vanished between resolve and read, or the archive can't be read.</summary>
-    static (byte[]? bytes, string? error) ReadWinner(PlacementSource s)
-    {
-        if (s.Kind == AssetKind.Loose)
-        {
-            var p = s.LooseFilePath!;
-            if (!File.Exists(p)) return (null, $"the resolved loose source '{p}' is no longer on disk");
-            try { return (File.ReadAllBytes(p), null); }
-            catch (Exception ex) { return (null, $"could not read resolved source '{p}': {ex.Message}"); }
-        }
-        try
-        {
-            var b = AssetResolver.TryReadArchiveEntry(s.ArchivePath!, s.EntryPath);
-            return b is null ? (null, $"entry '{s.EntryPath}' not found inside '{Path.GetFileName(s.ArchivePath!)}'") : (b, null);
-        }
-        catch (Exception ex) { return (null, $"could not read archive '{Path.GetFileName(s.ArchivePath!)}': {ex.Message}"); }
-    }
+    /// <summary>Read the bytes of a resolved WINNING provider — delegates to the ONE shared loose-vs-BSA read
+    /// (<see cref="AssetResolver.ReadPlacementSource"/>; review finding — this was copy #2 of three).</summary>
+    static (byte[]? bytes, string? error) ReadWinner(PlacementSource s) => AssetResolver.ReadPlacementSource(s);
 }

--- a/src/housecarl-core/AssetResolver.cs
+++ b/src/housecarl-core/AssetResolver.cs
@@ -252,6 +252,29 @@ public sealed class AssetResolver : IDisposable
         finally { (reader as IDisposable)?.Dispose(); }           // INERT in 0.53.1 — belt-and-braces, see ReadArchiveTable
     }
 
+    /// <summary>Read the bytes of ONE resolved provider — a loose file off disk, or a single BSA entry via
+    /// <see cref="TryReadArchiveEntry"/>. THE shared home for the loose-vs-BSA winner read (review finding: this
+    /// logic had grown three near-verbatim copies — AssetRenameService.ReadWinner and the NPC-copy asset carry now
+    /// both ride this one; LoadOrderService.ReadResolvedSource remains a desc-carrying sibling with probe-pinned
+    /// message strings, folded here on its next deliberate touch). A named error (Q3) when the resolved copy
+    /// vanished between resolve and read, or the archive can't be read.</summary>
+    public static (byte[]? Bytes, string? Error) ReadPlacementSource(PlacementSource s)
+    {
+        if (s.Kind == AssetKind.Loose)
+        {
+            var p = s.LooseFilePath;
+            if (p is null || !File.Exists(p)) return (null, $"the resolved loose source '{p}' is no longer on disk");
+            try { return (File.ReadAllBytes(p), null); }
+            catch (Exception ex) { return (null, $"could not read resolved source '{p}': {ex.Message}"); }
+        }
+        try
+        {
+            var b = s.ArchivePath is null ? null : TryReadArchiveEntry(s.ArchivePath, s.EntryPath);
+            return b is null ? (null, $"entry '{s.EntryPath}' not found inside '{Path.GetFileName(s.ArchivePath ?? "?")}'") : (b, null);
+        }
+        catch (Exception ex) { return (null, $"could not read archive '{Path.GetFileName(s.ArchivePath ?? "?")}': {ex.Message}"); }
+    }
+
     /// <summary>Resolve one Data-relative asset path: where it lives and which copy wins. See <see cref="AssetHit"/>.
     /// Single-shot — this call captures its own build; a caller making MANY reads in one logical operation should
     /// <see cref="Capture"/> once and read off the view so the scan and its failure list share one build.</summary>

--- a/src/housecarl-core/NpcAppearanceAssets.cs
+++ b/src/housecarl-core/NpcAppearanceAssets.cs
@@ -18,21 +18,22 @@ namespace HousecarlCore;
 //       engine resolves the facetint from the FormKey path and IGNORES the path
 //       embedded inside the .nif — so a rename needs NO .nif editing, ever.
 //
-//    2. REFERENCED-ASSET HARVEST — the internalized records' own asset paths (headpart
-//       models, texture-set .dds, morph .tri) via a generic IAssetLinkGetter walk (no
-//       per-type hand list), PLUS a conservative string-scan of the carried facegeom
-//       bytes for the skin/hair textures the geom embeds (NifSkope slots — the engine
-//       DOES use those; with the donor disabled they would silently unresolve). No NIF
-//       parser: paths in a .nif are plain ASCII, and a false-positive costs one skipped
-//       candidate, never a wrong write.
+//    2. REFERENCED-ASSET CARRY — the harvested asset paths (the caller collects them
+//       from the IN-PATCH duplicates pre-serialize via HarvestAssetPaths — a generic
+//       IAssetLinkGetter walk, no per-type hand list), PLUS a conservative string-scan
+//       of the carried facegeom bytes for the skin/hair textures the geom embeds
+//       (NifSkope slots — the engine DOES use those; with the donor disabled they
+//       would silently unresolve). No NIF parser: paths in a .nif are plain ASCII,
+//       and a false-positive costs one skipped candidate, never a wrong write.
 //
 //    3. THE CARRY RULE — a harvested path is carried iff its bytes would VANISH with the
 //       donor: the active VFS winner is the donor's own mod folder / BSA, or the path
 //       resolves nowhere active but exists in the (disabled) donor's folder. A path
 //       another active provider (vanilla BSA, a shared-resource mod) supplies is
-//       SKIPPED + noted — it keeps resolving without the donor. Best-effort + reported
-//       (Q3): the records are already written, so a carry miss is a NAMED warning,
-//       never a silent gap and never a failed copy.
+//       SKIPPED + noted — it keeps resolving without the donor. The facegen pair is
+//       the exception (alwaysCarry): its DESTINATION path is new, so it is a rename
+//       from wherever the winning copy lives. Best-effort + reported (Q3): the records
+//       are already written, so a carry miss is a NAMED warning, never a silent gap.
 // ======================================================================
 
 /// <summary>One carried file: old → new Data-relative path (identical except the facegen pair), bytes, and where
@@ -40,11 +41,14 @@ namespace HousecarlCore;
 public sealed record CarriedAsset(string OldRelPath, string NewRelPath, long Bytes, string From);
 
 /// <summary>The asset-carry half's outcome: what moved, what was deliberately left (another active provider still
-/// supplies it), what was referenced but found nowhere (verify in-game), and named failures. Never throws.</summary>
+/// supplies it), what was referenced but found nowhere (verify in-game), VFS-precedence warnings (a carried file
+/// whose destination path an ACTIVE provider already supplies does not win until sorted above it — the
+/// facegen-diagnostics keystone: file precedence is its own system), and named failures. Never throws.</summary>
 public sealed record NpcAssetOutcome(
     IReadOnlyList<CarriedAsset> Carried,
     IReadOnlyList<string> SkippedStillProvided,
     IReadOnlyList<string> Missing,
+    IReadOnlyList<string> Warnings,
     IReadOnlyList<string> Failures,
     bool FaceGenMeshCarried,
     bool FaceGenTintCarried);
@@ -99,42 +103,52 @@ public static class NpcAppearanceAssets
 
     /// <summary>Conservative texture-path scan of facegeom bytes: every ASCII run that starts 'textures\' (either
     /// slash) and ends '.dds', case-insensitive — the skin/hair texture paths a facegen .nif embeds and the engine
-    /// resolves at render time. No NIF parsing: a path in a .nif is stored as plain text, and this is the same
-    /// byte-scrape the 2026-07-01 build test used. A false positive costs one 'referenced but found nowhere' note.</summary>
+    /// resolves at render time. No NIF parsing: a path in a .nif is stored as plain text (the same byte-scrape the
+    /// 2026-07-01 build test used); a false positive costs one 'referenced but found nowhere' note. Within a
+    /// printable run the match ends at the FIRST '.dds' (review finding: last-match glued two adjacent paths into
+    /// garbage), and the scan resumes right after the matched path so a second 'textures\…' in the same run is
+    /// still found; the resume never skips a byte (review finding: an 'i = end' reset over the for-increment ate
+    /// the first byte of a path that started exactly at a run boundary).</summary>
     public static IReadOnlyList<string> ScrapeNifTexturePaths(byte[] nif)
     {
         var found = new List<string>();
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var lower = new byte[] { (byte)'t', (byte)'e', (byte)'x', (byte)'t', (byte)'u', (byte)'r', (byte)'e', (byte)'s' };
-        for (int i = 0; i + 12 < nif.Length; i++)                        // 12 = 'textures\' + 'a.dds' lower bound
+        var prefix = "textures"u8.ToArray();
+        for (int i = 0; i + prefix.Length + 5 <= nif.Length; i++)         // +5 = '\' + shortest 'a.dds' won't fit past this
         {
             int j = 0;
-            while (j < lower.Length && i + j < nif.Length && (nif[i + j] | 0x20) == lower[j]) j++;
-            if (j != lower.Length) continue;
+            while (j < prefix.Length && (nif[i + j] | 0x20) == prefix[j]) j++;
+            if (j != prefix.Length) continue;
             int k = i + j;
             if (k >= nif.Length || (nif[k] != (byte)'\\' && nif[k] != (byte)'/')) continue;
 
-            // Extend through printable path chars until it stops; accept only if it ends '.dds'.
-            int end = k;
+            // Extend through printable path chars, stopping at the FIRST '.dds' (case-insensitive).
+            int end = k + 1, ddsEnd = -1;
             while (end < nif.Length && end - i < 260)
             {
                 byte b = nif[end];
                 if (b < 0x20 || b > 0x7E) break;
                 end++;
+                if (end - i >= 4
+                    && nif[end - 4] == (byte)'.'
+                    && (nif[end - 3] | 0x20) == (byte)'d'
+                    && (nif[end - 2] | 0x20) == (byte)'d'
+                    && (nif[end - 1] | 0x20) == (byte)'s')
+                { ddsEnd = end; break; }
             }
-            var s = Encoding.ASCII.GetString(nif, i, end - i);
-            var dds = s.LastIndexOf(".dds", StringComparison.OrdinalIgnoreCase);
-            if (dds <= 0) { i = end; continue; }
-            var path = s[..(dds + 4)].Replace('/', '\\');
+            if (ddsEnd < 0) { i = end - 1; continue; }                    // no '.dds' in this run — resume AT the stop byte
+
+            var path = Encoding.ASCII.GetString(nif, i, ddsEnd - i).Replace('/', '\\');
             if (seen.Add(path)) found.Add(path);
-            i = end;
+            i = ddsEnd - 1;                                               // resume right after the match (for-increment lands on the next byte)
         }
         return found;
     }
 
-    /// <summary>Where the (possibly disabled) donor's own files live on disk: the donor plugin's MO2 mod folder plus
-    /// any BSAs sitting at its root — the direct-disk lane for a donor the active VFS cannot see. Null folder = the
-    /// donor was read via a direct path outside ModsDir; only its own directory is scanned.</summary>
+    /// <summary>Where the donor's own files live on disk: the donor plugin's containing folder plus any BSAs at its
+    /// root — the direct-disk lane for a DISABLED donor the active VFS cannot see. The caller only constructs one
+    /// for a donor under an MO2 mod folder (never for the game Data folder — there every vanilla BSA would
+    /// misclassify as "the donor's", review finding).</summary>
     public sealed record DonorDisk(string Folder, IReadOnlyList<string> Bsas)
     {
         public static DonorDisk For(string donorPluginPath)
@@ -166,36 +180,49 @@ public static class NpcAppearanceAssets
         }
     }
 
-    /// <summary>Resolve ONE Data-relative path under the carry rule (file header §3). Returns the bytes + provenance
-    /// when the path must be carried, (null, note) when it is deliberately skipped or missing.</summary>
+    /// <summary>Read the bytes of a resolved provider — loose file or BSA entry. One home for the loose-vs-BSA read
+    /// this file needs twice (facegen + referenced assets); named error on a vanished/unreadable source.</summary>
+    static (byte[]? Bytes, string? Error) ReadSource(PlacementSource s)
+    {
+        if (s.Kind == AssetKind.Loose)
+        {
+            var p = s.LooseFilePath;
+            if (p is null || !File.Exists(p)) return (null, $"the resolved loose source '{p}' is no longer on disk");
+            try { return (File.ReadAllBytes(p), null); }
+            catch (Exception ex) { return (null, $"could not read resolved source '{p}': {ex.Message}"); }
+        }
+        try
+        {
+            var b = s.ArchivePath is null ? null : AssetResolver.TryReadArchiveEntry(s.ArchivePath, s.EntryPath);
+            return b is null ? (null, $"entry '{s.EntryPath}' not found inside '{Path.GetFileName(s.ArchivePath ?? "?")}'") : (b, null);
+        }
+        catch (Exception ex) { return (null, $"could not read archive '{Path.GetFileName(s.ArchivePath ?? "?")}': {ex.Message}"); }
+    }
+
+    /// <summary>Resolve ONE Data-relative path under the carry rule (file header §3). <paramref name="alwaysCarry"/>
+    /// = the facegen-rename case: the destination path is NEW, so the bytes move from wherever the winning copy
+    /// lives (the donor-provides test doesn't apply). Returns the bytes + provenance when the path must be carried,
+    /// (null, note) when deliberately skipped, or a miss.</summary>
     static (byte[]? Bytes, string? From, string? SkipNote, bool Missing) ResolveForCarry(
-        string relPath, AssetResolver.AssetView view, DonorDisk? donor, string? donorModFolderName)
+        string relPath, AssetResolver.AssetView view, DonorDisk? donor, string? donorModFolderName, bool alwaysCarry)
     {
         var res = view.ResolveForPlacement(relPath);
         if (res.Sources.Count > 0)
         {
             var winner = res.Sources[0];
-            bool donorProvides =
-                (donorModFolderName is not null && string.Equals(winner.ProviderName, donorModFolderName, StringComparison.OrdinalIgnoreCase))
-                || (donor is not null && winner.Kind == AssetKind.Bsa && winner.ArchivePath is not null
-                    && string.Equals(Path.GetDirectoryName(winner.ArchivePath), donor.Folder, StringComparison.OrdinalIgnoreCase));
-            if (!donorProvides)
-                return (null, null, $"'{relPath}' — still provided by '{winner.ProviderName}' after the donor is removed; not carried.", false);
-
-            if (winner.Kind == AssetKind.Loose && winner.LooseFilePath is not null && File.Exists(winner.LooseFilePath))
+            if (!alwaysCarry)
             {
-                try { return (File.ReadAllBytes(winner.LooseFilePath), $"'{winner.ProviderName}' (loose)", null, false); }
-                catch { /* fall through to the donor-disk lane */ }
+                bool donorProvides =
+                    (donorModFolderName is not null && string.Equals(winner.ProviderName, donorModFolderName, StringComparison.OrdinalIgnoreCase))
+                    || (donor is not null && winner.Kind == AssetKind.Bsa && winner.ArchivePath is not null
+                        && string.Equals(Path.GetDirectoryName(winner.ArchivePath), donor.Folder, StringComparison.OrdinalIgnoreCase));
+                if (!donorProvides)
+                    return (null, null, $"'{relPath}' — still provided by '{winner.ProviderName}' after the donor is removed; not carried.", false);
             }
-            if (winner.Kind == AssetKind.Bsa && winner.ArchivePath is not null)
-            {
-                try
-                {
-                    var b = AssetResolver.TryReadArchiveEntry(winner.ArchivePath, winner.EntryPath);
-                    if (b is not null) return (b, $"'{Path.GetFileName(winner.ArchivePath)}'", null, false);
-                }
-                catch { /* fall through */ }
-            }
+            var (bytes, _) = ReadSource(winner);
+            if (bytes is not null)
+                return (bytes, winner.Kind == AssetKind.Loose ? $"'{winner.ProviderName}' (loose)" : $"'{Path.GetFileName(winner.ArchivePath!)}'", null, false);
+            // the winner vanished between resolve and read — fall through to the donor-disk lane
         }
 
         if (donor is not null)
@@ -207,53 +234,46 @@ public static class NpcAppearanceAssets
     }
 
     /// <summary>
-    /// The whole asset carry for one copied NPC: rename the facegen pair donor-key → new-key (always carried when
-    /// found — the destination path is NEW, so this is a move, not a keep), scrape the carried geom for its embedded
-    /// textures, harvest the internalized records' asset links, and carry each harvested path under the carry rule.
+    /// The whole asset carry for one copied NPC: rename the facegen pair donor-key → new-key, scrape the carried
+    /// geom for its embedded textures, and carry each harvested path under the carry rule.
+    /// <paramref name="harvestedPaths"/> comes from the caller's pre-serialize harvest of the in-patch duplicates.
     /// Writes go under <paramref name="outDir"/> (the patch mod folder) via staged temp + <see cref="AtomicFile"/>.
-    /// Never throws; every miss/failure is named in the outcome (Q3).
+    /// A carried file whose DESTINATION relpath an active provider already supplies gets a precedence WARNING
+    /// (it does not win until the patch is sorted above that provider). Never throws; every miss/failure named (Q3).
     /// </summary>
     public static NpcAssetOutcome CarryAll(
         FormKey donorNpc, FormKey newNpc,
-        IReadOnlyList<IMajorRecordGetter> internalized,
+        IReadOnlyList<string> harvestedPaths,
         AssetResolver.AssetView view, DonorDisk? donor, string? donorModFolderName, string outDir)
     {
         var carried = new List<CarriedAsset>();
         var skipped = new List<string>();
         var missing = new List<string>();
+        var warnings = new List<string>();
         var failures = new List<string>();
         bool meshCarried = false, tintCarried = false;
         byte[]? geomBytes = null;
 
-        // ---- 1. the facegen pair: donor path → NEW path (a rename — carried from wherever the winning copy lives) ----
+        void WarnIfDestinationContested(string newRel)
+        {
+            var already = view.ResolveForPlacement(newRel);
+            if (already.Sources.Count > 0)
+                warnings.Add($"'{newRel}' is ALREADY provided by '{already.Sources[0].ProviderName}' — the carried copy does " +
+                             "not win until the patch mod is sorted ABOVE that provider in MO2 (file precedence is its own system).");
+        }
+
+        // ---- 1. the facegen pair: donor path → NEW path (a rename — alwaysCarry from the winning copy) ----
         foreach (var (slot, oldRel) in FaceGenPath.Both(donorNpc))
         {
             var newRel = FaceGenPath.For(newNpc, slot);
-            byte[]? bytes = null; string? from = null;
-            var res = view.ResolveForPlacement(oldRel);
-            if (res.Sources.Count > 0)
-            {
-                var w = res.Sources[0];
-                try
-                {
-                    bytes = w.Kind == AssetKind.Loose
-                        ? (w.LooseFilePath is not null && File.Exists(w.LooseFilePath) ? File.ReadAllBytes(w.LooseFilePath) : null)
-                        : (w.ArchivePath is not null ? AssetResolver.TryReadArchiveEntry(w.ArchivePath, w.EntryPath) : null);
-                    from = w.Kind == AssetKind.Loose ? $"'{w.ProviderName}' (loose)" : $"'{Path.GetFileName(w.ArchivePath!)}'";
-                }
-                catch (Exception ex) { failures.Add($"facegen {slot}: could not read the resolved winner — {ex.Message}"); }
-            }
-            if (bytes is null && donor is not null)
-            {
-                var (b, f) = donor.Read(oldRel);
-                bytes = b; from = f;
-            }
-            if (bytes is null)
+            var (bytes, from, _, isMissing) = ResolveForCarry(oldRel, view, donor, donorModFolderName, alwaysCarry: true);
+            if (isMissing || bytes is null)
             {
                 missing.Add($"facegen {slot} '{oldRel}' — found neither in the active VFS nor the donor's folder. " +
                             "Without it the engine regenerates the head at runtime (grey/dark-face risk); verify in-game.");
                 continue;
             }
+            WarnIfDestinationContested(newRel);
             if (WriteCarried(outDir, newRel, bytes, failures))
             {
                 carried.Add(new CarriedAsset(oldRel, newRel, bytes.Length, from ?? "?"));
@@ -262,16 +282,17 @@ public static class NpcAppearanceAssets
             }
         }
 
-        // ---- 2. harvest: record asset links + the geom's embedded textures ----
-        var wanted = new List<string>(HarvestAssetPaths(internalized));
+        // ---- 2. harvest: the caller's record-link harvest + the geom's embedded textures ----
+        var wanted = new List<string>(harvestedPaths);
+        var wantedSet = new HashSet<string>(harvestedPaths, StringComparer.OrdinalIgnoreCase);
         if (geomBytes is not null)
             foreach (var p in ScrapeNifTexturePaths(geomBytes))
-                if (!wanted.Contains(p, StringComparer.OrdinalIgnoreCase)) wanted.Add(p);
+                if (wantedSet.Add(p)) wanted.Add(p);
 
         // ---- 3. carry each harvested path under the rule (same relpath — a keep-resolving move, not a rename) ----
         foreach (var rel in wanted)
         {
-            var (bytes, from, skipNote, isMissing) = ResolveForCarry(rel, view, donor, donorModFolderName);
+            var (bytes, from, skipNote, isMissing) = ResolveForCarry(rel, view, donor, donorModFolderName, alwaysCarry: false);
             if (skipNote is not null) { skipped.Add(skipNote); continue; }
             if (isMissing) { missing.Add($"'{rel}' — referenced by the copied records/geom but found nowhere (active VFS or donor folder); verify in-game."); continue; }
             if (bytes is null) continue;
@@ -279,7 +300,7 @@ public static class NpcAppearanceAssets
                 carried.Add(new CarriedAsset(rel, rel, bytes.Length, from ?? "?"));
         }
 
-        return new NpcAssetOutcome(carried, skipped, missing, failures, meshCarried, tintCarried);
+        return new NpcAssetOutcome(carried, skipped, missing, warnings, failures, meshCarried, tintCarried);
     }
 
     /// <summary>Stage + atomically commit one carried file under <paramref name="outDir"/>. A failure is a named

--- a/src/housecarl-core/NpcAppearanceAssets.cs
+++ b/src/housecarl-core/NpcAppearanceAssets.cs
@@ -1,0 +1,302 @@
+using System.Collections;
+using System.Reflection;
+using System.Text;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Assets;
+using Mutagen.Bethesda.Plugins.Records;
+
+namespace HousecarlCore;
+
+// ======================================================================
+//  NpcAppearanceAssets — the FILE half of the composed standalone-NPC-copy verb
+//  (capability chain Stage 3 §1 items 3–4). Three jobs:
+//
+//    1. FACEGEN RENAME — the donor's baked facegeom .nif + facetint .dds move to the
+//       NEW NPC's FormKey path (FaceGenPath — folder = the defining master, so the
+//       apply lane files under the TARGET's plugin, the clone lane under the patch).
+//       Empirically pinned (the 2026-07-01 build test, NPC2 cross-validated): the
+//       engine resolves the facetint from the FormKey path and IGNORES the path
+//       embedded inside the .nif — so a rename needs NO .nif editing, ever.
+//
+//    2. REFERENCED-ASSET HARVEST — the internalized records' own asset paths (headpart
+//       models, texture-set .dds, morph .tri) via a generic IAssetLinkGetter walk (no
+//       per-type hand list), PLUS a conservative string-scan of the carried facegeom
+//       bytes for the skin/hair textures the geom embeds (NifSkope slots — the engine
+//       DOES use those; with the donor disabled they would silently unresolve). No NIF
+//       parser: paths in a .nif are plain ASCII, and a false-positive costs one skipped
+//       candidate, never a wrong write.
+//
+//    3. THE CARRY RULE — a harvested path is carried iff its bytes would VANISH with the
+//       donor: the active VFS winner is the donor's own mod folder / BSA, or the path
+//       resolves nowhere active but exists in the (disabled) donor's folder. A path
+//       another active provider (vanilla BSA, a shared-resource mod) supplies is
+//       SKIPPED + noted — it keeps resolving without the donor. Best-effort + reported
+//       (Q3): the records are already written, so a carry miss is a NAMED warning,
+//       never a silent gap and never a failed copy.
+// ======================================================================
+
+/// <summary>One carried file: old → new Data-relative path (identical except the facegen pair), bytes, and where
+/// the winning copy came from.</summary>
+public sealed record CarriedAsset(string OldRelPath, string NewRelPath, long Bytes, string From);
+
+/// <summary>The asset-carry half's outcome: what moved, what was deliberately left (another active provider still
+/// supplies it), what was referenced but found nowhere (verify in-game), and named failures. Never throws.</summary>
+public sealed record NpcAssetOutcome(
+    IReadOnlyList<CarriedAsset> Carried,
+    IReadOnlyList<string> SkippedStillProvided,
+    IReadOnlyList<string> Missing,
+    IReadOnlyList<string> Failures,
+    bool FaceGenMeshCarried,
+    bool FaceGenTintCarried);
+
+public static class NpcAppearanceAssets
+{
+    /// <summary>Harvest every asset path the given records list — the generic <see cref="IAssetLinkGetter"/> walk over
+    /// each record's property graph (lists + substructs included), by construction rather than a per-type field list.
+    /// Paths come back Data-relative (Mutagen's DataRelativePath — e.g. a Model.File 'x.nif' → 'meshes\x.nif').</summary>
+    public static IReadOnlyList<string> HarvestAssetPaths(IEnumerable<IMajorRecordGetter> records)
+    {
+        var paths = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var rec in records)
+            HarvestFrom(rec, paths, seen, new HashSet<object>(ReferenceEqualityComparer.Instance), depth: 0);
+        return paths;
+    }
+
+    static void HarvestFrom(object node, List<string> paths, HashSet<string> seen, HashSet<object> visited, int depth)
+    {
+        if (depth > 6 || node is string || !visited.Add(node)) return;
+
+        if (node is IAssetLinkGetter asset)
+        {
+            string? rel = null;
+            try { rel = asset.DataRelativePath.Path; } catch { /* an unset link — nothing to harvest */ }
+            if (!string.IsNullOrWhiteSpace(rel) && seen.Add(rel)) paths.Add(rel);
+            return;
+        }
+
+        if (node is IEnumerable en and not IFormLinkGetter)
+        {
+            foreach (var el in en)
+                if (el is not null) HarvestFrom(el, paths, seen, visited, depth + 1);
+            return;
+        }
+
+        // Only descend Mutagen model types (their namespace), never arbitrary BCL values — keeps the walk cheap + safe.
+        var t = node.GetType();
+        if (t.Namespace is null || !t.Namespace.StartsWith("Mutagen.Bethesda", StringComparison.Ordinal)) return;
+        if (node is IFormLinkGetter) return;                              // a link is an identity, not an asset container
+
+        foreach (var prop in t.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (prop.GetIndexParameters().Length != 0 || prop.GetGetMethod() is null) continue;
+            object? val;
+            try { val = prop.GetValue(node); } catch { continue; }
+            if (val is null) continue;
+            HarvestFrom(val, paths, seen, visited, depth + 1);
+        }
+    }
+
+    /// <summary>Conservative texture-path scan of facegeom bytes: every ASCII run that starts 'textures\' (either
+    /// slash) and ends '.dds', case-insensitive — the skin/hair texture paths a facegen .nif embeds and the engine
+    /// resolves at render time. No NIF parsing: a path in a .nif is stored as plain text, and this is the same
+    /// byte-scrape the 2026-07-01 build test used. A false positive costs one 'referenced but found nowhere' note.</summary>
+    public static IReadOnlyList<string> ScrapeNifTexturePaths(byte[] nif)
+    {
+        var found = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var lower = new byte[] { (byte)'t', (byte)'e', (byte)'x', (byte)'t', (byte)'u', (byte)'r', (byte)'e', (byte)'s' };
+        for (int i = 0; i + 12 < nif.Length; i++)                        // 12 = 'textures\' + 'a.dds' lower bound
+        {
+            int j = 0;
+            while (j < lower.Length && i + j < nif.Length && (nif[i + j] | 0x20) == lower[j]) j++;
+            if (j != lower.Length) continue;
+            int k = i + j;
+            if (k >= nif.Length || (nif[k] != (byte)'\\' && nif[k] != (byte)'/')) continue;
+
+            // Extend through printable path chars until it stops; accept only if it ends '.dds'.
+            int end = k;
+            while (end < nif.Length && end - i < 260)
+            {
+                byte b = nif[end];
+                if (b < 0x20 || b > 0x7E) break;
+                end++;
+            }
+            var s = Encoding.ASCII.GetString(nif, i, end - i);
+            var dds = s.LastIndexOf(".dds", StringComparison.OrdinalIgnoreCase);
+            if (dds <= 0) { i = end; continue; }
+            var path = s[..(dds + 4)].Replace('/', '\\');
+            if (seen.Add(path)) found.Add(path);
+            i = end;
+        }
+        return found;
+    }
+
+    /// <summary>Where the (possibly disabled) donor's own files live on disk: the donor plugin's MO2 mod folder plus
+    /// any BSAs sitting at its root — the direct-disk lane for a donor the active VFS cannot see. Null folder = the
+    /// donor was read via a direct path outside ModsDir; only its own directory is scanned.</summary>
+    public sealed record DonorDisk(string Folder, IReadOnlyList<string> Bsas)
+    {
+        public static DonorDisk For(string donorPluginPath)
+        {
+            var dir = Path.GetDirectoryName(donorPluginPath)!;
+            List<string> bsas;
+            try { bsas = Directory.EnumerateFiles(dir, "*.bsa", SearchOption.TopDirectoryOnly).ToList(); }
+            catch { bsas = new List<string>(); }
+            return new DonorDisk(dir, bsas);
+        }
+
+        /// <summary>Read a Data-relative path from the donor's own disk (loose first, then its root BSAs). Null = absent.</summary>
+        public (byte[]? Bytes, string? From) Read(string relPath)
+        {
+            var loose = Path.Combine(Folder, relPath);
+            if (File.Exists(loose))
+            {
+                try { return (File.ReadAllBytes(loose), $"donor folder (loose)"); }
+                catch { /* fall through to BSAs */ }
+            }
+            foreach (var bsa in Bsas)
+            {
+                byte[]? b;
+                try { b = AssetResolver.TryReadArchiveEntry(bsa, relPath); }
+                catch { continue; }
+                if (b is not null) return (b, $"donor archive '{Path.GetFileName(bsa)}'");
+            }
+            return (null, null);
+        }
+    }
+
+    /// <summary>Resolve ONE Data-relative path under the carry rule (file header §3). Returns the bytes + provenance
+    /// when the path must be carried, (null, note) when it is deliberately skipped or missing.</summary>
+    static (byte[]? Bytes, string? From, string? SkipNote, bool Missing) ResolveForCarry(
+        string relPath, AssetResolver.AssetView view, DonorDisk? donor, string? donorModFolderName)
+    {
+        var res = view.ResolveForPlacement(relPath);
+        if (res.Sources.Count > 0)
+        {
+            var winner = res.Sources[0];
+            bool donorProvides =
+                (donorModFolderName is not null && string.Equals(winner.ProviderName, donorModFolderName, StringComparison.OrdinalIgnoreCase))
+                || (donor is not null && winner.Kind == AssetKind.Bsa && winner.ArchivePath is not null
+                    && string.Equals(Path.GetDirectoryName(winner.ArchivePath), donor.Folder, StringComparison.OrdinalIgnoreCase));
+            if (!donorProvides)
+                return (null, null, $"'{relPath}' — still provided by '{winner.ProviderName}' after the donor is removed; not carried.", false);
+
+            if (winner.Kind == AssetKind.Loose && winner.LooseFilePath is not null && File.Exists(winner.LooseFilePath))
+            {
+                try { return (File.ReadAllBytes(winner.LooseFilePath), $"'{winner.ProviderName}' (loose)", null, false); }
+                catch { /* fall through to the donor-disk lane */ }
+            }
+            if (winner.Kind == AssetKind.Bsa && winner.ArchivePath is not null)
+            {
+                try
+                {
+                    var b = AssetResolver.TryReadArchiveEntry(winner.ArchivePath, winner.EntryPath);
+                    if (b is not null) return (b, $"'{Path.GetFileName(winner.ArchivePath)}'", null, false);
+                }
+                catch { /* fall through */ }
+            }
+        }
+
+        if (donor is not null)
+        {
+            var (bytes, from) = donor.Read(relPath);
+            if (bytes is not null) return (bytes, from, null, false);
+        }
+        return (null, null, null, true);
+    }
+
+    /// <summary>
+    /// The whole asset carry for one copied NPC: rename the facegen pair donor-key → new-key (always carried when
+    /// found — the destination path is NEW, so this is a move, not a keep), scrape the carried geom for its embedded
+    /// textures, harvest the internalized records' asset links, and carry each harvested path under the carry rule.
+    /// Writes go under <paramref name="outDir"/> (the patch mod folder) via staged temp + <see cref="AtomicFile"/>.
+    /// Never throws; every miss/failure is named in the outcome (Q3).
+    /// </summary>
+    public static NpcAssetOutcome CarryAll(
+        FormKey donorNpc, FormKey newNpc,
+        IReadOnlyList<IMajorRecordGetter> internalized,
+        AssetResolver.AssetView view, DonorDisk? donor, string? donorModFolderName, string outDir)
+    {
+        var carried = new List<CarriedAsset>();
+        var skipped = new List<string>();
+        var missing = new List<string>();
+        var failures = new List<string>();
+        bool meshCarried = false, tintCarried = false;
+        byte[]? geomBytes = null;
+
+        // ---- 1. the facegen pair: donor path → NEW path (a rename — carried from wherever the winning copy lives) ----
+        foreach (var (slot, oldRel) in FaceGenPath.Both(donorNpc))
+        {
+            var newRel = FaceGenPath.For(newNpc, slot);
+            byte[]? bytes = null; string? from = null;
+            var res = view.ResolveForPlacement(oldRel);
+            if (res.Sources.Count > 0)
+            {
+                var w = res.Sources[0];
+                try
+                {
+                    bytes = w.Kind == AssetKind.Loose
+                        ? (w.LooseFilePath is not null && File.Exists(w.LooseFilePath) ? File.ReadAllBytes(w.LooseFilePath) : null)
+                        : (w.ArchivePath is not null ? AssetResolver.TryReadArchiveEntry(w.ArchivePath, w.EntryPath) : null);
+                    from = w.Kind == AssetKind.Loose ? $"'{w.ProviderName}' (loose)" : $"'{Path.GetFileName(w.ArchivePath!)}'";
+                }
+                catch (Exception ex) { failures.Add($"facegen {slot}: could not read the resolved winner — {ex.Message}"); }
+            }
+            if (bytes is null && donor is not null)
+            {
+                var (b, f) = donor.Read(oldRel);
+                bytes = b; from = f;
+            }
+            if (bytes is null)
+            {
+                missing.Add($"facegen {slot} '{oldRel}' — found neither in the active VFS nor the donor's folder. " +
+                            "Without it the engine regenerates the head at runtime (grey/dark-face risk); verify in-game.");
+                continue;
+            }
+            if (WriteCarried(outDir, newRel, bytes, failures))
+            {
+                carried.Add(new CarriedAsset(oldRel, newRel, bytes.Length, from ?? "?"));
+                if (slot == FaceGenSlot.Mesh) { meshCarried = true; geomBytes = bytes; }
+                else tintCarried = true;
+            }
+        }
+
+        // ---- 2. harvest: record asset links + the geom's embedded textures ----
+        var wanted = new List<string>(HarvestAssetPaths(internalized));
+        if (geomBytes is not null)
+            foreach (var p in ScrapeNifTexturePaths(geomBytes))
+                if (!wanted.Contains(p, StringComparer.OrdinalIgnoreCase)) wanted.Add(p);
+
+        // ---- 3. carry each harvested path under the rule (same relpath — a keep-resolving move, not a rename) ----
+        foreach (var rel in wanted)
+        {
+            var (bytes, from, skipNote, isMissing) = ResolveForCarry(rel, view, donor, donorModFolderName);
+            if (skipNote is not null) { skipped.Add(skipNote); continue; }
+            if (isMissing) { missing.Add($"'{rel}' — referenced by the copied records/geom but found nowhere (active VFS or donor folder); verify in-game."); continue; }
+            if (bytes is null) continue;
+            if (WriteCarried(outDir, rel, bytes, failures))
+                carried.Add(new CarriedAsset(rel, rel, bytes.Length, from ?? "?"));
+        }
+
+        return new NpcAssetOutcome(carried, skipped, missing, failures, meshCarried, tintCarried);
+    }
+
+    /// <summary>Stage + atomically commit one carried file under <paramref name="outDir"/>. A failure is a named
+    /// entry in <paramref name="failures"/>, never a throw (the records are already written).</summary>
+    static bool WriteCarried(string outDir, string relPath, byte[] bytes, List<string> failures)
+    {
+        try
+        {
+            var final = Path.Combine(outDir, relPath);
+            Directory.CreateDirectory(Path.GetDirectoryName(final)!);
+            AtomicFile.WriteAllBytes(final, bytes);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            failures.Add($"could not write '{relPath}' — {ex.Message}");
+            return false;
+        }
+    }
+}

--- a/src/housecarl-core/NpcAppearanceAssets.cs
+++ b/src/housecarl-core/NpcAppearanceAssets.cs
@@ -180,32 +180,16 @@ public static class NpcAppearanceAssets
         }
     }
 
-    /// <summary>Read the bytes of a resolved provider — loose file or BSA entry. One home for the loose-vs-BSA read
-    /// this file needs twice (facegen + referenced assets); named error on a vanished/unreadable source.</summary>
-    static (byte[]? Bytes, string? Error) ReadSource(PlacementSource s)
-    {
-        if (s.Kind == AssetKind.Loose)
-        {
-            var p = s.LooseFilePath;
-            if (p is null || !File.Exists(p)) return (null, $"the resolved loose source '{p}' is no longer on disk");
-            try { return (File.ReadAllBytes(p), null); }
-            catch (Exception ex) { return (null, $"could not read resolved source '{p}': {ex.Message}"); }
-        }
-        try
-        {
-            var b = s.ArchivePath is null ? null : AssetResolver.TryReadArchiveEntry(s.ArchivePath, s.EntryPath);
-            return b is null ? (null, $"entry '{s.EntryPath}' not found inside '{Path.GetFileName(s.ArchivePath ?? "?")}'") : (b, null);
-        }
-        catch (Exception ex) { return (null, $"could not read archive '{Path.GetFileName(s.ArchivePath ?? "?")}': {ex.Message}"); }
-    }
-
     /// <summary>Resolve ONE Data-relative path under the carry rule (file header §3). <paramref name="alwaysCarry"/>
     /// = the facegen-rename case: the destination path is NEW, so the bytes move from wherever the winning copy
     /// lives (the donor-provides test doesn't apply). Returns the bytes + provenance when the path must be carried,
-    /// (null, note) when deliberately skipped, or a miss.</summary>
-    static (byte[]? Bytes, string? From, string? SkipNote, bool Missing) ResolveForCarry(
+    /// (null, note) when deliberately skipped, or a miss — with <c>ReadError</c> carrying the REAL cause when a
+    /// resolved winner could not be read (review finding: discarding it reported an in-use file as "found neither
+    /// in the active VFS nor the donor's folder" — factually false, Q3).</summary>
+    static (byte[]? Bytes, string? From, string? SkipNote, bool Missing, string? ReadError) ResolveForCarry(
         string relPath, AssetResolver.AssetView view, DonorDisk? donor, string? donorModFolderName, bool alwaysCarry)
     {
+        string? readError = null;
         var res = view.ResolveForPlacement(relPath);
         if (res.Sources.Count > 0)
         {
@@ -217,20 +201,20 @@ public static class NpcAppearanceAssets
                     || (donor is not null && winner.Kind == AssetKind.Bsa && winner.ArchivePath is not null
                         && string.Equals(Path.GetDirectoryName(winner.ArchivePath), donor.Folder, StringComparison.OrdinalIgnoreCase));
                 if (!donorProvides)
-                    return (null, null, $"'{relPath}' — still provided by '{winner.ProviderName}' after the donor is removed; not carried.", false);
+                    return (null, null, $"'{relPath}' — still provided by '{winner.ProviderName}' after the donor is removed; not carried.", false, null);
             }
-            var (bytes, _) = ReadSource(winner);
+            (var bytes, readError) = AssetResolver.ReadPlacementSource(winner);
             if (bytes is not null)
-                return (bytes, winner.Kind == AssetKind.Loose ? $"'{winner.ProviderName}' (loose)" : $"'{Path.GetFileName(winner.ArchivePath!)}'", null, false);
-            // the winner vanished between resolve and read — fall through to the donor-disk lane
+                return (bytes, winner.Kind == AssetKind.Loose ? $"'{winner.ProviderName}' (loose)" : $"'{Path.GetFileName(winner.ArchivePath!)}'", null, false, null);
+            // the winner could not be read — fall through to the donor-disk lane, keeping the named cause
         }
 
         if (donor is not null)
         {
             var (bytes, from) = donor.Read(relPath);
-            if (bytes is not null) return (bytes, from, null, false);
+            if (bytes is not null) return (bytes, from, null, false, null);
         }
-        return (null, null, null, true);
+        return (null, null, null, true, readError);
     }
 
     /// <summary>
@@ -265,21 +249,28 @@ public static class NpcAppearanceAssets
         // ---- 1. the facegen pair: donor path → NEW path (a rename — alwaysCarry from the winning copy) ----
         foreach (var (slot, oldRel) in FaceGenPath.Both(donorNpc))
         {
-            var newRel = FaceGenPath.For(newNpc, slot);
-            var (bytes, from, _, isMissing) = ResolveForCarry(oldRel, view, donor, donorModFolderName, alwaysCarry: true);
-            if (isMissing || bytes is null)
+            try
             {
-                missing.Add($"facegen {slot} '{oldRel}' — found neither in the active VFS nor the donor's folder. " +
-                            "Without it the engine regenerates the head at runtime (grey/dark-face risk); verify in-game.");
-                continue;
+                var newRel = FaceGenPath.For(newNpc, slot);
+                var (bytes, from, _, isMissing, readErr) = ResolveForCarry(oldRel, view, donor, donorModFolderName, alwaysCarry: true);
+                if (isMissing || bytes is null)
+                {
+                    if (readErr is not null)
+                        failures.Add($"facegen {slot} '{oldRel}': the winning copy exists but could not be read — {readErr}. Re-run once the file is free, or carry it with housecarl_place_asset.");
+                    else
+                        missing.Add($"facegen {slot} '{oldRel}' — found neither in the active VFS nor the donor's folder. " +
+                                    "Without it the engine regenerates the head at runtime (grey/dark-face risk); verify in-game.");
+                    continue;
+                }
+                WarnIfDestinationContested(newRel);
+                if (WriteCarried(outDir, newRel, bytes, failures))
+                {
+                    carried.Add(new CarriedAsset(oldRel, newRel, bytes.Length, from ?? "?"));
+                    if (slot == FaceGenSlot.Mesh) { meshCarried = true; geomBytes = bytes; }
+                    else tintCarried = true;
+                }
             }
-            WarnIfDestinationContested(newRel);
-            if (WriteCarried(outDir, newRel, bytes, failures))
-            {
-                carried.Add(new CarriedAsset(oldRel, newRel, bytes.Length, from ?? "?"));
-                if (slot == FaceGenSlot.Mesh) { meshCarried = true; geomBytes = bytes; }
-                else tintCarried = true;
-            }
+            catch (Exception ex) { failures.Add($"facegen {slot} '{oldRel}': {ex.Message}"); }
         }
 
         // ---- 2. harvest: the caller's record-link harvest + the geom's embedded textures ----
@@ -289,15 +280,29 @@ public static class NpcAppearanceAssets
             foreach (var p in ScrapeNifTexturePaths(geomBytes))
                 if (wantedSet.Add(p)) wanted.Add(p);
 
-        // ---- 3. carry each harvested path under the rule (same relpath — a keep-resolving move, not a rename) ----
+        // ---- 3. carry each harvested path under the rule (same relpath — a keep-resolving move, not a rename).
+        //         Per-path fault isolation (review finding): ONE dirty path (a '..' segment surviving in a mod
+        //         author's data, a scrape false-positive) is ONE named failure — never an abort that silently
+        //         drops every path after it while reporting "asset carry skipped". ----
         foreach (var rel in wanted)
         {
-            var (bytes, from, skipNote, isMissing) = ResolveForCarry(rel, view, donor, donorModFolderName, alwaysCarry: false);
-            if (skipNote is not null) { skipped.Add(skipNote); continue; }
-            if (isMissing) { missing.Add($"'{rel}' — referenced by the copied records/geom but found nowhere (active VFS or donor folder); verify in-game."); continue; }
-            if (bytes is null) continue;
-            if (WriteCarried(outDir, rel, bytes, failures))
-                carried.Add(new CarriedAsset(rel, rel, bytes.Length, from ?? "?"));
+            try
+            {
+                var (bytes, from, skipNote, isMissing, readErr) = ResolveForCarry(rel, view, donor, donorModFolderName, alwaysCarry: false);
+                if (skipNote is not null) { skipped.Add(skipNote); continue; }
+                if (isMissing)
+                {
+                    if (readErr is not null)
+                        failures.Add($"'{rel}': the winning copy exists but could not be read — {readErr}.");
+                    else
+                        missing.Add($"'{rel}' — referenced by the copied records/geom but found nowhere (active VFS or donor folder); verify in-game.");
+                    continue;
+                }
+                if (bytes is null) continue;
+                if (WriteCarried(outDir, rel, bytes, failures))
+                    carried.Add(new CarriedAsset(rel, rel, bytes.Length, from ?? "?"));
+            }
+            catch (Exception ex) { failures.Add($"'{rel}': {ex.Message}"); }
         }
 
         return new NpcAssetOutcome(carried, skipped, missing, warnings, failures, meshCarried, tintCarried);

--- a/src/housecarl-core/NpcAppearanceCopy.cs
+++ b/src/housecarl-core/NpcAppearanceCopy.cs
@@ -44,7 +44,15 @@ namespace HousecarlCore;
 /// they were preserved.</summary>
 public sealed record InternalizedRecord(string Type, string EditorId, FormKey OldKey, FormKey NewKey, string PulledBy);
 
-/// <summary>The composed copy's outcome — everything the tool render needs, or a loud refusal with nothing written.</summary>
+/// <summary>The composed copy's outcome — everything the tool render needs, or a loud refusal with nothing written.
+/// <see cref="Warning"/> is a POST-COMMIT caveat: the patch WAS written but a follow-up step (read-back) failed —
+/// never conflated with a refusal (that mislabel would send the user re-running against a live patch).
+/// <see cref="Reused"/> = extend-lane dedupe: donor records a PRIOR run already internalized into this patch
+/// (matched by type + preserved EditorID) are re-linked, not re-copied — a second copy would put two same-named
+/// headparts in one plugin and break the facegeom block-name mapping. <see cref="HarvestedAssetPaths"/> is
+/// collected from the IN-PATCH duplicates BEFORE serialize (overlay-backed donor bodies may be released by then).
+/// <see cref="DonorIsBaseGame"/> = the donor is defined in a base-game/implicit master: nothing is being
+/// "removed", so no records are donor-bound — the copy is an override-style transplant, said plainly.</summary>
 public sealed record NpcCopyOutcome(
     bool Success, string? Error,
     string Mode,                                          // "apply" | "clone"
@@ -52,16 +60,19 @@ public sealed record NpcCopyOutcome(
     FormKey NewNpcKey,                                    // apply: the target's key; clone: the clone's new key
     string? OutPath, bool Extended,
     IReadOnlyList<InternalizedRecord> Internalized,
+    IReadOnlyList<string> Reused,
     int KeptLinkCount,
     IReadOnlyList<string> CopiedFields,                   // apply mode
     IReadOnlyList<NpcAppearanceCopy.StripReport> Stripped, // clone mode
-    IReadOnlyList<string> Masters, bool DonorAmongMasters,
-    NpcAssetOutcome? Assets, long Bytes)
+    IReadOnlyList<string> Masters, bool DonorAmongMasters, bool DonorIsBaseGame,
+    IReadOnlyList<string> HarvestedAssetPaths,
+    NpcAssetOutcome? Assets, long Bytes, string? Warning)
 {
     public static NpcCopyOutcome Fail(string error) => new(
         false, error, "", default, "", false, default, null, false,
-        Array.Empty<InternalizedRecord>(), 0, Array.Empty<string>(),
-        Array.Empty<NpcAppearanceCopy.StripReport>(), Array.Empty<string>(), false, null, 0);
+        Array.Empty<InternalizedRecord>(), Array.Empty<string>(), 0, Array.Empty<string>(),
+        Array.Empty<NpcAppearanceCopy.StripReport>(), Array.Empty<string>(), false, false,
+        Array.Empty<string>(), null, 0, null);
 }
 
 public static class NpcAppearanceCopy
@@ -105,6 +116,17 @@ public static class NpcAppearanceCopy
     public static ClosureResult CollectAppearanceClosure(
         INpcGetter donor, IReadOnlySet<ModKey> donorMods, DonorFetch fetch, ActiveResolve resolvesActively)
     {
+        // A donor that INHERITS its traits from a template (TemplateFlags.Traits) has EMPTY appearance fields on its
+        // own record — the look lives on the template. Copying "nothing" would succeed and, in the apply lane,
+        // actively WIPE the target's face (a Q3 silent wrong answer). Refuse with the real remedy.
+        if (donor.Template is { IsNull: false } tpl
+            && donor.Configuration.TemplateFlags.HasFlag(NpcConfiguration.TemplateFlag.Traits))
+            return ClosureResult.Fail(
+                $"the donor NPC inherits its TRAITS (appearance) from a template ({tpl.FormKey}) — its own record carries " +
+                "no appearance to copy, and copying the empty fields would blank the target's face. Pass the TEMPLATE " +
+                "NPC as the donor instead (resolve the Template chain to the record that actually carries the look). " +
+                "Nothing was written.");
+
         var seeds = new List<(FormKey Key, string Field)>();
         foreach (var hp in donor.HeadParts)
             if (!hp.FormKey.IsNull) seeds.Add((hp.FormKey, "HeadParts"));
@@ -256,10 +278,16 @@ public static class NpcAppearanceCopy
         return new StripResult(true, null, stripped);
     }
 
-    /// <summary>Null a single FormLink property's key if the link type supports it (FormLinkNullable exposes
-    /// SetToNull; a required FormLink does not). Returns false when the link is required.</summary>
+    /// <summary>Null a single FormLink property's key iff the link is genuinely NULLABLE — the record model's
+    /// <c>IFormLinkNullableGetter</c>, not the presence of a SetToNull method: in Mutagen 0.53.1 the REQUIRED
+    /// <c>FormLink&lt;T&gt;</c> ALSO exposes SetToNull (review finding — method-presence made the required-link
+    /// refusal dead code and silently wrote a NULL required field, e.g. a clone with Class=00000000). Returns
+    /// false for a required link, which the caller escalates to the loud refusal.</summary>
     static bool TrySetLinkNull(object link)
     {
+        bool nullable = link.GetType().GetInterfaces().Any(i =>
+            i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IFormLinkNullable<>));
+        if (!nullable) return false;                                      // required by the record model — never nulled
         var m = link.GetType().GetMethod("SetToNull", Type.EmptyTypes);
         if (m is null) return false;
         m.Invoke(link, null);
@@ -301,11 +329,42 @@ public static class NpcAppearanceCopy
                 patchMod = new SkyrimMod(new ModKey(Path.GetFileNameWithoutExtension(outPath), ModType.Plugin), SkyrimRelease.SkyrimSE);
             WriteEngine.EnsureFormIdFloor(patchMod);
 
-            // ---- allocate NEW keys (the patch's own 0x800+ counter) for the closure (+ the clone) ----
-            var toCopy = new List<IMajorRecordGetter>(closure.ToInternalize.Select(i => i.Body));
-            if (clone) toCopy.Add(donorNpc);
-            uint next = patchMod.ModHeader.Stats.NextFormID;
+            // ---- extend-lane DEDUPE (review finding): a PRIOR run may already have internalized this donor's
+            //      records into the patch. Re-copying would put TWO records with the same preserved EditorID in one
+            //      plugin — ambiguous for the engine's facegeom block-name mapping, the exact invariant EditorID
+            //      preservation protects. Match by type + EditorID (both preserved by design) → REUSE the existing
+            //      copy: map the donor key to it and skip the duplicate. Each reuse is reported.
+            var toCopy = new List<IMajorRecordGetter>();
             var dict = new Dictionary<FormKey, FormKey>();
+            var reused = new List<string>();
+            if (extend)
+            {
+                var existing = patchMod.EnumerateMajorRecords()
+                    .Where(r => r.FormKey.ModKey == patchMod.ModKey && !string.IsNullOrEmpty(r.EditorID))
+                    .ToDictionary(r => (RecordNaming.StripOverlay(r.GetType().Name), r.EditorID!), r => r.FormKey,
+                                  EqualityComparer<(string, string)>.Default);
+                foreach (var i in closure.ToInternalize)
+                {
+                    var sig = (RecordNaming.StripOverlay(i.Body.GetType().Name), i.Body.EditorID ?? "");
+                    if (sig.Item2.Length > 0 && existing.TryGetValue(sig, out var prior))
+                    { dict[i.Body.FormKey] = prior; reused.Add($"{sig.Item1} '{sig.Item2}'  {i.Body.FormKey} → {prior} (already in the patch — reused, not re-copied)"); }
+                    else toCopy.Add(i.Body);
+                }
+            }
+            else toCopy.AddRange(closure.ToInternalize.Select(i => i.Body));
+            if (clone)
+            {
+                // a clone re-run into the same patch would mint a SECOND NPC with the same EditorID — refuse with the
+                // real choice instead (the dedupe above deliberately covers only the appearance subtree).
+                if (extend && patchMod.Npcs.Any(n => string.Equals(n.EditorID, newEditorid!.Trim(), StringComparison.OrdinalIgnoreCase)))
+                    return NpcCopyOutcome.Fail(
+                        $"'{patchFileName}' already contains an NPC with EditorID '{newEditorid!.Trim()}' — cloning again " +
+                        "would duplicate it. Pick a different new_editorid, or target the existing NPC via target_formid=.");
+                toCopy.Add(donorNpc);
+            }
+
+            // ---- allocate NEW keys (the patch's own 0x800+ counter) for what actually gets copied ----
+            uint next = patchMod.ModHeader.Stats.NextFormID;
             foreach (var rec in toCopy)
             {
                 if (next > FormIdRange.ObjectIdMax)
@@ -314,9 +373,27 @@ public static class NpcAppearanceCopy
             }
             patchMod.ModHeader.Stats.NextFormID = next;
 
-            // ---- duplicate + remap (EditorIDs preserved by Duplicate — the facegeom block-name identity) ----
-            var ren = RemapEngine.RenumberRecordsInto(patchMod, toCopy, dict);
+            // ---- duplicate + remap in a SCRATCH mod (review finding): RenumberRecordsInto's whole-mod RemapLinks
+            //      honors its fresh-target contract there, so an EXTENDED patch's PRE-EXISTING records are never
+            //      silently repointed (a user record deliberately referencing the active donor stays untouched).
+            //      The scratch shares the patch's ModKey, so the allocated keys are final; the remapped copies are
+            //      then transplanted into the real patch. EditorIDs preserved by Duplicate (block-name identity).
+            var scratch = new SkyrimMod(patchMod.ModKey, SkyrimRelease.SkyrimSE);
+            var ren = RemapEngine.RenumberRecordsInto(scratch, toCopy, dict);
             if (!ren.Success) return NpcCopyOutcome.Fail(ren.Error!);
+            foreach (var rec in scratch.EnumerateMajorRecords())
+                if (!RemapEngine.TryAddToFlatGroup(patchMod, (IMajorRecord)rec))
+                    return NpcCopyOutcome.Fail(
+                        $"{RecordNaming.StripOverlay(rec.GetType().Name)} {rec.FormKey} could not be transplanted into the patch (engine inconsistency, Q3). Nothing usable was written.");
+
+            // ---- the internalized report — built BEFORE serialize (review finding: donor bodies can be backed by a
+            //      session overlay the master set releases at serialize; reading them afterwards is a disposed-mmap read).
+            var internalized = closure.ToInternalize
+                .Where(i => dict.ContainsKey(i.Body.FormKey) && toCopy.Any(t => t.FormKey == i.Body.FormKey))
+                .Select(i => new InternalizedRecord(
+                    RecordNaming.StripOverlay(i.Body.GetType().Name), i.Body.EditorID ?? "<no editorid>",
+                    i.Body.FormKey, dict[i.Body.FormKey], i.PulledBy))
+                .ToList();
 
             FormKey newNpcKey;
             var copiedFields = (IReadOnlyList<string>)Array.Empty<string>();
@@ -357,44 +434,61 @@ public static class NpcAppearanceCopy
 
                 newNpcKey = targetFk;
                 copiedFields = CopyAppearanceFields(donorNpc, targetOverride);
-                patchMod.RemapLinks(dict);   // repoint the just-copied fields at the internalized copies
+                targetOverride.RemapLinks(dict);   // repoint ONLY the override's just-copied fields (never the rest of an extended patch)
 
-                // belt-and-braces (Q3): nothing donor-internal may remain on the override after the remap.
+                // belt-and-braces (Q3): nothing DONOR-INTERNAL may remain on the override after the remap. Scoped to
+                // donor keys only (review finding): a target's PRE-EXISTING dangling link (mod-update dirt whose master
+                // is still declared) is not this operation's defect and must not hard-block a legitimate copy.
                 var leak = ((IFormLinkContainerGetter)targetOverride).EnumerateFormLinks()
-                    .FirstOrDefault(l => !l.FormKey.IsNull && isForeign(l.FormKey));
+                    .FirstOrDefault(l => !l.FormKey.IsNull && donorMods.Contains(l.FormKey.ModKey));
                 if (leak is not null && !leak.FormKey.IsNull)
                     return NpcCopyOutcome.Fail(
-                        $"after the copy the target still references {leak.FormKey}, which is donor-internal or unresolvable — " +
-                        "refusing to write a patch that would master the donor (Q3). This is unexpected; please report it.");
+                        $"after the copy the target still references {leak.FormKey} in the donor's plugin — refusing to " +
+                        "write a patch that would master the donor (Q3). If the target deliberately references the donor " +
+                        "in a non-appearance field (an outfit, a faction), remove that first or clone instead. Nothing was written.");
             }
+
+            // ---- HARVEST asset paths from the IN-PATCH duplicates, pre-serialize (they are plain in-memory records;
+            //      the donor-overlay bodies may be released before the service's asset carry runs — review finding).
+            var newKeys = internalized.Select(i => i.NewKey).ToHashSet();
+            var duplicates = patchMod.EnumerateMajorRecords().Where(r => newKeys.Contains(r.FormKey)).Cast<IMajorRecordGetter>().ToList();
+            var harvested = NpcAppearanceAssets.HarvestAssetPaths(duplicates);
 
             // ---- serialize (multi-master; the caller's mastersFor handles the active-patch self-lock) ----
             try { WriteEngine.WritePatch(patchMod, mastersFor(patchFileName), outPath); }
             catch (Exception ex) { return NpcCopyOutcome.Fail($"serialize failed — {WriteEngine.Describe(ex)}. Nothing usable was written."); }
 
-            var back = SkyrimMod.CreateFromBinaryOverlay(outPath, SkyrimRelease.SkyrimSE);
-            List<string> masters;
-            long bytes;
+            // ---- post-commit read-back — the patch IS on disk from here; a read-back failure is a WARNING on a
+            //      success, never a "nothing was written" (review finding: that mislabel invites a duplicate re-run).
+            var masters = new List<string>();
+            long bytes = 0;
+            bool donorAmongMasters = false;
+            string? warning = null;
             try
             {
-                masters = back.ModHeader.MasterReferences.Select(m => m.Master.FileName.ToString()).ToList();
-                bytes = new FileInfo(outPath).Length;
+                var back = SkyrimMod.CreateFromBinaryOverlay(outPath, SkyrimRelease.SkyrimSE);
+                try
+                {
+                    masters = back.ModHeader.MasterReferences.Select(m => m.Master.FileName.ToString()).ToList();
+                    bytes = new FileInfo(outPath).Length;
+                }
+                finally { (back as IDisposable)?.Dispose(); }
+                donorAmongMasters = masters.Any(m => { try { return donorMods.Contains(ModKey.FromFileName(m)); } catch { return false; } });
             }
-            finally { (back as IDisposable)?.Dispose(); }
-            bool donorAmongMasters = masters.Any(m => { try { return donorMods.Contains(ModKey.FromFileName(m)); } catch { return false; } });
-
-            var internalized = closure.ToInternalize
-                .Select(i => new InternalizedRecord(
-                    RecordNaming.StripOverlay(i.Body.GetType().Name), i.Body.EditorID ?? "<no editorid>",
-                    i.Body.FormKey, dict[i.Body.FormKey], i.PulledBy))
-                .ToList();
+            catch (Exception ex)
+            {
+                warning = $"the patch WAS written, but the post-write read-back failed ({ex.Message}) — the masters list " +
+                          "could not be verified this call. Do NOT re-run blindly (that would mint a duplicate patch); " +
+                          "inspect the plugin with housecarl_read_plugin_file.";
+            }
 
             return new NpcCopyOutcome(
                 true, null, clone ? "clone" : "apply",
                 donorNpc.FormKey, donorReadFrom, donorOutOfLoadOrder,
                 newNpcKey, outPath, extend,
-                internalized, closure.KeptLinks.Count,
-                copiedFields, strippedReports, masters, donorAmongMasters, null, bytes);
+                internalized, reused, closure.KeptLinks.Count,
+                copiedFields, strippedReports, masters, donorAmongMasters, donorMods.Count == 0,
+                harvested, null, bytes, warning);
         }
         catch (Exception ex)
         {
@@ -447,6 +541,18 @@ public static class NpcAppearanceCopy
         {
             target.Race.SetTo(donor.Race.FormKey);
             copied.Add($"Race (target's differed — copied {donor.Race.FormKey}; facegen is race-fitted)");
+        }
+
+        // GENDER (review finding): headparts, tint masks and the baked facegen are all gender-fitted — a female
+        // donor's look on a male-flagged target hands the engine female headparts under a male body/skeleton (the
+        // wrong-head/dark-face class this verb exists to kill). Match the Female flag to the donor, loudly.
+        bool donorFemale = donor.Configuration.Flags.HasFlag(NpcConfiguration.Flag.Female);
+        bool targetFemale = target.Configuration.Flags.HasFlag(NpcConfiguration.Flag.Female);
+        if (donorFemale != targetFemale)
+        {
+            if (donorFemale) target.Configuration.Flags |= NpcConfiguration.Flag.Female;
+            else target.Configuration.Flags &= ~NpcConfiguration.Flag.Female;
+            copied.Add($"Configuration.Flags.Female (target's gender differed — matched to the donor; headparts/facegen are gender-fitted)");
         }
 
         return copied;

--- a/src/housecarl-core/NpcAppearanceCopy.cs
+++ b/src/housecarl-core/NpcAppearanceCopy.cs
@@ -169,8 +169,10 @@ public static class NpcAppearanceCopy
                 return ClosureResult.Fail(
                     $"the donor's appearance references {key} (via {pulledBy}), which must be internalized (it is donor-" +
                     "defined or does not resolve in the active load order) — but the donor universe cannot produce that " +
-                    "record. If it lives in a DISABLED master of the donor, enable that mod (or keep it as a master) and " +
-                    "re-run. Nothing was written.");
+                    "record. Remedies, by cause: if you passed source_plugin= for an OVERRIDE PATCH of the donor, the " +
+                    $"record lives in the donor's own plugin — pass source_plugin='{key.ModKey.FileName}' instead (or omit " +
+                    "source_plugin= entirely when that plugin is active); if it lives in a DISABLED master of the donor, " +
+                    "enable that mod (or keep it as a master) and re-run. Nothing was written.");
 
             toInternalize.Add(new ClosureItem(body, pulledBy));
             var label = $"{RecordNaming.StripOverlay(body.GetType().Name)} {key} ({body.EditorID ?? "<no editorid>"})";
@@ -339,16 +341,54 @@ public static class NpcAppearanceCopy
             var reused = new List<string>();
             if (extend)
             {
-                var existing = patchMod.EnumerateMajorRecords()
-                    .Where(r => r.FormKey.ModKey == patchMod.ModKey && !string.IsNullOrEmpty(r.EditorID))
-                    .ToDictionary(r => (RecordNaming.StripOverlay(r.GetType().Name), r.EditorID!), r => r.FormKey,
-                                  EqualityComparer<(string, string)>.Default);
+                // Group patch-originating records by type + EditorID — OrdinalIgnoreCase (matching the clone
+                // dup-check and the create-path upsert; review finding: an ordinal compare re-copied a case-differing
+                // prior copy, minting the exact duplicate this dedupe prevents) and DUPLICATE-TOLERANT (same-named
+                // records exist in the wild per the nested-create re-run semantics; a raw ToDictionary threw).
+                var groups = new Dictionary<string, List<IMajorRecordGetter>>(StringComparer.OrdinalIgnoreCase);
+                foreach (var r in patchMod.EnumerateMajorRecords())
+                {
+                    if (r.FormKey.ModKey != patchMod.ModKey || string.IsNullOrEmpty(r.EditorID)) continue;
+                    var key = RecordNaming.StripOverlay(r.GetType().Name) + "\0" + r.EditorID;
+                    if (!groups.TryGetValue(key, out var l)) groups[key] = l = new List<IMajorRecordGetter>();
+                    l.Add(r);
+                }
+                // Pass 1 — pair up name matches; the candidate map must be COMPLETE before any content check,
+                // because matched records reference each other (a headpart → its texture set).
+                var matches = new List<(ClosureItem Item, IMajorRecordGetter Existing)>();
+                var candDict = new Dictionary<FormKey, FormKey>();
                 foreach (var i in closure.ToInternalize)
                 {
-                    var sig = (RecordNaming.StripOverlay(i.Body.GetType().Name), i.Body.EditorID ?? "");
-                    if (sig.Item2.Length > 0 && existing.TryGetValue(sig, out var prior))
-                    { dict[i.Body.FormKey] = prior; reused.Add($"{sig.Item1} '{sig.Item2}'  {i.Body.FormKey} → {prior} (already in the patch — reused, not re-copied)"); }
-                    else toCopy.Add(i.Body);
+                    var type = RecordNaming.StripOverlay(i.Body.GetType().Name);
+                    var edid = i.Body.EditorID;
+                    if (string.IsNullOrEmpty(edid) || !groups.TryGetValue(type + "\0" + edid, out var cands))
+                    { toCopy.Add(i.Body); continue; }
+                    if (cands.Count > 1)
+                        return NpcCopyOutcome.Fail(
+                            $"'{patchFileName}' already contains {cands.Count} {type} records with EditorID '{edid}' — matching this " +
+                            "donor's record against them is ambiguous, and re-copying would add a third. Clean the duplicates up (or " +
+                            "copy into a different patch). Nothing was written.");
+                    matches.Add((i, cands[0]));
+                    candDict[i.Body.FormKey] = cands[0].FormKey;
+                }
+                // Pass 2 — CONTENT equality (review finding): a prior copy is reused only when it IS this donor's
+                // record. Same-named but DIFFERENT records are a real load-order fact (KS Hairdos-derived NPCs reuse
+                // headpart EditorIDs across mods) — reusing one would silently wire this NPC to the OTHER donor's
+                // part; re-copying would duplicate the EditorID and break facegeom block-name identity. So: refuse
+                // loud, naming the collision. Equality is judged on a probe duplicate under the existing key with
+                // sibling links mapped to their candidates — i.e. "would copying produce exactly this record?"
+                foreach (var (item, existing) in matches)
+                {
+                    var probe = item.Body.Duplicate(existing.FormKey);
+                    probe.RemapLinks(candDict);
+                    if (!probe.Equals(existing))
+                        return NpcCopyOutcome.Fail(
+                            $"'{patchFileName}' already contains {RecordNaming.StripOverlay(existing.GetType().Name)} '{existing.EditorID}' " +
+                            $"({existing.FormKey}) from a previous copy, and its CONTENT differs from this donor's {item.Body.FormKey} — " +
+                            "reusing it would wire this NPC to the other donor's record; re-copying would duplicate the EditorID and " +
+                            "break the facegeom block-name mapping. Copy into a DIFFERENT patch. Nothing was written.");
+                    dict[item.Body.FormKey] = existing.FormKey;
+                    reused.Add($"{RecordNaming.StripOverlay(existing.GetType().Name)} '{existing.EditorID}'  {item.Body.FormKey} → {existing.FormKey} (already in the patch, content-identical — reused, not re-copied)");
                 }
             }
             else toCopy.AddRange(closure.ToInternalize.Select(i => i.Body));

--- a/src/housecarl-core/NpcAppearanceCopy.cs
+++ b/src/housecarl-core/NpcAppearanceCopy.cs
@@ -1,0 +1,454 @@
+using System.Collections;
+using System.Reflection;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using Noggog;
+
+namespace HousecarlCore;
+
+// ======================================================================
+//  NpcAppearanceCopy — the record half of the composed standalone-NPC-copy verb
+//  (capability chain Stage 3; STANDALONE_NPC_COPY_CAPABILITY_CHAIN_2026-07-02 §1).
+//
+//  THE MECHANISM: Mutagen's public record.Duplicate(newKey) + RemapLinks — the SAME
+//  blessed deep-copy the RemapEngine pins (remap-wave1-mech), NOT a field-by-field
+//  re-authoring. That choice is load-bearing: the 2026-07-01 build test proved two
+//  appearance facts empirically (HDPT.Parts morph-.tri refs are load-bearing for
+//  lip-sync; TextureLighting defaults to 0 = dark skin on fresh creates), and BOTH
+//  traps are structurally impossible under a whole-record copy — Duplicate carries
+//  every field, so there is no field for a future session to forget.
+//
+//  THE INTERNALIZE RULE (what gets deep-copied vs what stays a link):
+//    a linked record is INTERNALIZED (duplicated into the patch under a new key) iff
+//      • its defining plugin IS the donor's plugin (the plugin being standalone-ized
+//        away from — even if currently active), OR
+//      • it does not resolve in the ACTIVE load order (it would be a missing master).
+//    Every other link (vanilla, active shared-resource mods) stays a link — the patch
+//    masters it normally. Headpart EditorIDs are PRESERVED on the copies: the engine
+//    maps facegeom shape names → headparts BY NAME (build-test-pinned), so renaming
+//    them would silently regenerate a vanilla head.
+//
+//  CLONE-MODE STRIP (Q3 — a standalone clone must be donor-free, loudly):
+//    after internalize + remap, any link on the clone still pointing into the donor
+//    (or at an unresolvable key) is NON-appearance (factions, outfits, packages,
+//    VMAD…). Those are STRIPPED — nullable link → null; list entry → removed;
+//    nullable link-bearing substruct → null — and EVERY strip is reported by field
+//    name. A non-strippable (required, non-list) foreign link is a LOUD refusal,
+//    never a silent keep (it would drag the donor back in as a master).
+// ======================================================================
+
+/// <summary>One internalized record for the report: what it is, where it came from, where it landed — EditorID
+/// included because headpart EditorIDs are load-bearing (facegeom block-name identity) and the report should show
+/// they were preserved.</summary>
+public sealed record InternalizedRecord(string Type, string EditorId, FormKey OldKey, FormKey NewKey, string PulledBy);
+
+/// <summary>The composed copy's outcome — everything the tool render needs, or a loud refusal with nothing written.</summary>
+public sealed record NpcCopyOutcome(
+    bool Success, string? Error,
+    string Mode,                                          // "apply" | "clone"
+    FormKey DonorKey, string DonorReadFrom, bool DonorOutOfLoadOrder,
+    FormKey NewNpcKey,                                    // apply: the target's key; clone: the clone's new key
+    string? OutPath, bool Extended,
+    IReadOnlyList<InternalizedRecord> Internalized,
+    int KeptLinkCount,
+    IReadOnlyList<string> CopiedFields,                   // apply mode
+    IReadOnlyList<NpcAppearanceCopy.StripReport> Stripped, // clone mode
+    IReadOnlyList<string> Masters, bool DonorAmongMasters,
+    NpcAssetOutcome? Assets, long Bytes)
+{
+    public static NpcCopyOutcome Fail(string error) => new(
+        false, error, "", default, "", false, default, null, false,
+        Array.Empty<InternalizedRecord>(), 0, Array.Empty<string>(),
+        Array.Empty<NpcAppearanceCopy.StripReport>(), Array.Empty<string>(), false, null, 0);
+}
+
+public static class NpcAppearanceCopy
+{
+    /// <summary>Named cap on the appearance closure walk. A real appearance subtree is small (the build test:
+    /// 8 records); a walk that blows past this is a runaway (a donor-internal custom race pulling skeletons,
+    /// body mods, …) and is REFUSED LOUD with the chain of what pulled what — never silently truncated (Q3).</summary>
+    public const int ClosureCap = 128;
+
+    /// <summary>Fetch a record body from the DONOR's universe by FormKey (the donor file's own version in the
+    /// out-of-load-order lane; the load-order winner in the active lane). Null = the donor universe doesn't have it.</summary>
+    public delegate IMajorRecordGetter? DonorFetch(FormKey fk);
+
+    /// <summary>Does this FormKey resolve in the ACTIVE load order? (If yes and it isn't donor-defined, the
+    /// patch can simply master it — no internalize needed.)</summary>
+    public delegate bool ActiveResolve(FormKey fk);
+
+    /// <summary>One internalized record: the donor-universe body plus why it was pulled in (the parent chain tail,
+    /// for the closure-cap refusal message and the report).</summary>
+    public sealed record ClosureItem(IMajorRecordGetter Body, string PulledBy);
+
+    /// <summary>The appearance-closure walk result: the records to internalize (donor bodies at donor keys, the
+    /// NPC itself NOT included), the links kept as-is (they resolve actively), or a loud refusal.</summary>
+    public sealed record ClosureResult(
+        bool Success, string? Error,
+        IReadOnlyList<ClosureItem> ToInternalize,
+        IReadOnlyList<FormKey> KeptLinks)
+    {
+        public static ClosureResult Fail(string error) => new(false, error, Array.Empty<ClosureItem>(), Array.Empty<FormKey>());
+    }
+
+    /// <summary>
+    /// Walk the donor NPC's APPEARANCE seeds (HeadParts, HairColor, HeadTexture, WornArmor — the four link-bearing
+    /// appearance fields; FaceMorph/FaceParts/TintLayers/TextureLighting are inline values with no links) and collect
+    /// the closure of records that must be internalized under the rule in the file header. Expansion is the generic
+    /// <see cref="IFormLinkContainerGetter.EnumerateFormLinks"/> walk — by construction, no per-type hand list — so a
+    /// headpart's ExtraParts/TextureSet/Color, an armor's Armature, an armature's skin textures all follow the same rule.
+    /// A donor-internal link whose body the donor universe cannot produce is a LOUD refusal (a half-broken donor),
+    /// as is a closure past <see cref="ClosureCap"/> (a runaway — typically a donor-internal custom race).
+    /// </summary>
+    public static ClosureResult CollectAppearanceClosure(
+        INpcGetter donor, IReadOnlySet<ModKey> donorMods, DonorFetch fetch, ActiveResolve resolvesActively)
+    {
+        var seeds = new List<(FormKey Key, string Field)>();
+        foreach (var hp in donor.HeadParts)
+            if (!hp.FormKey.IsNull) seeds.Add((hp.FormKey, "HeadParts"));
+        if (donor.HairColor is { IsNull: false } hc) seeds.Add((hc.FormKey, "HairColor"));
+        if (donor.HeadTexture is { IsNull: false } ht) seeds.Add((ht.FormKey, "HeadTexture"));
+        if (donor.WornArmor is { IsNull: false } wa) seeds.Add((wa.FormKey, "WornArmor"));
+
+        // The RACE is a link-bearing appearance-adjacent field, but a race is NOT an internalizable subtree (it pulls
+        // skeletons/body meshes/other races — the runaway the cap exists for). Donor-internal race → refuse UP FRONT
+        // with the real remedy, not a cap message.
+        if (donor.Race is { IsNull: false } race && (donorMods.Contains(race.FormKey.ModKey) || !resolvesActively(race.FormKey)))
+            return ClosureResult.Fail(
+                $"the donor NPC's Race ({race.FormKey}) is defined in the donor plugin (or does not resolve in the active " +
+                "load order). Standalone-copying a custom RACE is out of this verb's scope — a race pulls skeletons, body " +
+                "meshes and sibling races, not an appearance subtree. Keep the race mod installed+active as a master, or " +
+                "choose a donor on a standard race. Nothing was written.");
+
+        var toInternalize = new List<ClosureItem>();
+        var kept = new List<FormKey>();
+        var seen = new HashSet<FormKey>();
+        var queue = new Queue<(FormKey Key, string PulledBy)>();
+        foreach (var (key, field) in seeds) queue.Enqueue((key, $"Npc.{field}"));
+
+        while (queue.Count > 0)
+        {
+            var (key, pulledBy) = queue.Dequeue();
+            if (key.IsNull || !seen.Add(key)) continue;
+
+            bool internalize = donorMods.Contains(key.ModKey) || !resolvesActively(key);
+            if (!internalize) { kept.Add(key); continue; }
+
+            if (toInternalize.Count >= ClosureCap)
+                return ClosureResult.Fail(
+                    $"the appearance closure exceeded {ClosureCap} records (last pull: {key} via {pulledBy}) — a real " +
+                    "appearance subtree is small (typically well under 30 records), so this is a runaway walk (e.g. a " +
+                    "donor-internal shared-resource web). Refusing rather than silently truncating (Q3). Nothing was written.");
+
+            var body = fetch(key);
+            if (body is null)
+                return ClosureResult.Fail(
+                    $"the donor's appearance references {key} (via {pulledBy}), which must be internalized (it is donor-" +
+                    "defined or does not resolve in the active load order) — but the donor universe cannot produce that " +
+                    "record. If it lives in a DISABLED master of the donor, enable that mod (or keep it as a master) and " +
+                    "re-run. Nothing was written.");
+
+            toInternalize.Add(new ClosureItem(body, pulledBy));
+            var label = $"{RecordNaming.StripOverlay(body.GetType().Name)} {key} ({body.EditorID ?? "<no editorid>"})";
+            if (body is IFormLinkContainerGetter flc)
+                foreach (var link in flc.EnumerateFormLinks())
+                    if (!link.FormKey.IsNull && !seen.Contains(link.FormKey))
+                        queue.Enqueue((link.FormKey, label));
+        }
+
+        return new ClosureResult(true, null, toInternalize, kept);
+    }
+
+    // ======================================================================
+    //  CLONE-MODE STRIP — remove every remaining foreign link, loudly
+    // ======================================================================
+
+    /// <summary>One stripped foreign link: the field it sat on and what was removed (for the Q3 report — every
+    /// strip is named, so "standalone" never silently means "quietly different").</summary>
+    public sealed record StripReport(string Field, string Removed);
+
+    /// <summary>The strip-pass result: what was stripped (each named), or a loud refusal (a REQUIRED foreign link
+    /// this pass cannot remove without inventing data — e.g. a donor-internal Class).</summary>
+    public sealed record StripResult(bool Success, string? Error, IReadOnlyList<StripReport> Stripped)
+    {
+        public static StripResult Fail(string error) => new(false, error, Array.Empty<StripReport>());
+    }
+
+    /// <summary>
+    /// Remove every link on <paramref name="record"/> for which <paramref name="isForeign"/> holds (after the
+    /// appearance remap, those are the donor's NON-appearance references — factions, outfits, packages, VMAD, …).
+    /// Reflection walk over the record's own properties, one strip rule per shape:
+    ///   • nullable FormLink → set null;   • list of FormLinks → remove the foreign entries;
+    ///   • list of link-BEARING elements (Factions' RankPlacement, Items' ContainerEntry, …) → remove the elements
+    ///     carrying a foreign link;   • nullable link-bearing substruct (VMAD, Sound…) → set the property null;
+    ///   • a REQUIRED (non-nullable, non-list) foreign link → LOUD refusal, never a silent keep (Q3 — keeping it
+    ///     would master the donor and the "standalone" claim would be silently false).
+    /// Every strip is reported by field name.
+    /// </summary>
+    public static StripResult StripForeignLinks(IMajorRecord record, Func<FormKey, bool> isForeign)
+    {
+        var stripped = new List<StripReport>();
+        foreach (var prop in record.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (prop.GetIndexParameters().Length != 0 || prop.GetGetMethod() is null) continue;
+            if (prop.Name is "FormKey" or "EditorID") continue;
+            object? val;
+            try { val = prop.GetValue(record); } catch { continue; }
+            if (val is null) continue;
+
+            // 1. A single FormLink property (nullable or required).
+            if (val is IFormLinkGetter singleLink)
+            {
+                if (singleLink.FormKeyNullable is not { } fk || fk.IsNull || !isForeign(fk)) continue;
+                if (TrySetLinkNull(val))
+                    stripped.Add(new StripReport(prop.Name, fk.ToString()));
+                else
+                    return StripResult.Fail(
+                        $"the clone's REQUIRED field '{prop.Name}' points at {fk}, which is donor-internal (or unresolvable) " +
+                        "and cannot be nulled or removed — stripping it would invent data, keeping it would silently master " +
+                        "the donor. Use the apply lane instead: scaffold your own NPC (with your own " +
+                        $"{prop.Name}) and copy the donor's appearance onto it. Nothing was written.");
+                continue;
+            }
+
+            // 2. A list — of FormLinks directly, or of link-bearing elements.
+            if (val is IList list && val is not string)
+            {
+                for (int i = list.Count - 1; i >= 0; i--)
+                {
+                    var el = list[i];
+                    if (el is IFormLinkGetter elLink)
+                    {
+                        if (elLink.FormKeyNullable is { } lk && !lk.IsNull && isForeign(lk))
+                        { list.RemoveAt(i); stripped.Add(new StripReport($"{prop.Name}[{i}]", lk.ToString())); }
+                    }
+                    else if (el is IFormLinkContainerGetter elc)
+                    {
+                        var foreignKeys = elc.EnumerateFormLinks()
+                            .Where(l => !l.FormKey.IsNull && isForeign(l.FormKey))
+                            .Select(l => l.FormKey.ToString()).Distinct().ToList();
+                        if (foreignKeys.Count > 0)
+                        { list.RemoveAt(i); stripped.Add(new StripReport($"{prop.Name}[{i}]", string.Join(", ", foreignKeys))); }
+                    }
+                }
+                continue;
+            }
+
+            // 3. A link-bearing substruct / polymorphic field (VMAD, Sound, …): if ANY of its links is foreign,
+            //    null the whole property (they are optional adornments on an NPC) — or refuse loud if it can't be nulled.
+            if (val is IFormLinkContainerGetter sub)
+            {
+                var foreign = sub.EnumerateFormLinks()
+                    .Where(l => !l.FormKey.IsNull && isForeign(l.FormKey))
+                    .Select(l => l.FormKey.ToString()).Distinct().ToList();
+                if (foreign.Count == 0) continue;
+                if (prop.CanWrite)
+                { prop.SetValue(record, null); stripped.Add(new StripReport(prop.Name, string.Join(", ", foreign))); }
+                else
+                    return StripResult.Fail(
+                        $"the clone's field '{prop.Name}' carries donor-internal (or unresolvable) reference(s) " +
+                        $"({string.Join(", ", foreign)}) and the property cannot be cleared. Use the apply lane " +
+                        "(scaffold your own NPC, copy the appearance onto it). Nothing was written.");
+            }
+        }
+        return new StripResult(true, null, stripped);
+    }
+
+    /// <summary>Null a single FormLink property's key if the link type supports it (FormLinkNullable exposes
+    /// SetToNull; a required FormLink does not). Returns false when the link is required.</summary>
+    static bool TrySetLinkNull(object link)
+    {
+        var m = link.GetType().GetMethod("SetToNull", Type.EmptyTypes);
+        if (m is null) return false;
+        m.Invoke(link, null);
+        return true;
+    }
+
+    // ======================================================================
+    //  BUILD + WRITE — the patch-mod construction half (core, WritePatchBuilder-style:
+    //  the mcp service does lanes/folders/MO2; this does records + serialize)
+    // ======================================================================
+
+    /// <summary>
+    /// Build the copy into a patch mod at <paramref name="outPath"/> and serialize it: allocate new 0x800+ keys,
+    /// Duplicate + RemapLinks the closure (+ the clone), run the mode lane (clone strip / apply field-copy), write
+    /// multi-master, read back the header. <paramref name="mastersFor"/> supplies the known-master set for the
+    /// serialize, keyed by the patch filename (the caller's session releases any overlay on the target first — the
+    /// active-patch self-lock fix). Returns the outcome WITHOUT the asset half (the service appends it — assets need
+    /// the MO2 asset view, which is the service's). Every refusal is loud with nothing usable written (Q3).
+    /// </summary>
+    public static NpcCopyOutcome BuildAndWrite(
+        INpcGetter donorNpc, IReadOnlySet<ModKey> donorMods, ClosureResult closure,
+        bool clone, string? newEditorid, string? newName,
+        FormKey targetFk, INpcGetter? targetActiveBody,
+        ActiveResolve resolvesActively,
+        string outPath, bool extend,
+        Func<string, IReadOnlyList<ISkyrimModGetter>> mastersFor,
+        string donorReadFrom, bool donorOutOfLoadOrder)
+    {
+        var patchFileName = Path.GetFileName(outPath);
+        try
+        {
+            SkyrimMod patchMod;
+            if (extend)
+            {
+                try { patchMod = SkyrimMod.CreateFromBinary(outPath, SkyrimRelease.SkyrimSE); }
+                catch (Exception ex) { return NpcCopyOutcome.Fail($"could not open '{patchFileName}' to extend: {ex.Message}"); }
+            }
+            else
+                patchMod = new SkyrimMod(new ModKey(Path.GetFileNameWithoutExtension(outPath), ModType.Plugin), SkyrimRelease.SkyrimSE);
+            WriteEngine.EnsureFormIdFloor(patchMod);
+
+            // ---- allocate NEW keys (the patch's own 0x800+ counter) for the closure (+ the clone) ----
+            var toCopy = new List<IMajorRecordGetter>(closure.ToInternalize.Select(i => i.Body));
+            if (clone) toCopy.Add(donorNpc);
+            uint next = patchMod.ModHeader.Stats.NextFormID;
+            var dict = new Dictionary<FormKey, FormKey>();
+            foreach (var rec in toCopy)
+            {
+                if (next > FormIdRange.ObjectIdMax)
+                    return NpcCopyOutcome.Fail($"cannot allocate a new FormID: the patch's NextObjectID counter is past 0x{FormIdRange.ObjectIdMax:X}.");
+                dict[rec.FormKey] = new FormKey(patchMod.ModKey, next++);
+            }
+            patchMod.ModHeader.Stats.NextFormID = next;
+
+            // ---- duplicate + remap (EditorIDs preserved by Duplicate — the facegeom block-name identity) ----
+            var ren = RemapEngine.RenumberRecordsInto(patchMod, toCopy, dict);
+            if (!ren.Success) return NpcCopyOutcome.Fail(ren.Error!);
+
+            FormKey newNpcKey;
+            var copiedFields = (IReadOnlyList<string>)Array.Empty<string>();
+            var strippedReports = (IReadOnlyList<StripReport>)Array.Empty<StripReport>();
+            Func<FormKey, bool> isForeign = fk2 =>
+                donorMods.Contains(fk2.ModKey) || (fk2.ModKey != patchMod.ModKey && !resolvesActively(fk2));
+
+            if (clone)
+            {
+                newNpcKey = dict[donorNpc.FormKey];
+                var cloneNpc = patchMod.Npcs.FirstOrDefault(n => n.FormKey == newNpcKey)
+                    ?? throw new InvalidOperationException("the clone vanished from the patch after renumber (engine inconsistency, Q3).");
+                cloneNpc.EditorID = newEditorid!.Trim();
+                if (!string.IsNullOrWhiteSpace(newName)) cloneNpc.Name = newName.Trim();
+
+                // strip every remaining donor-internal / unresolvable link — each named, or a loud refusal.
+                var strip = StripForeignLinks(cloneNpc, isForeign);
+                if (!strip.Success) return NpcCopyOutcome.Fail(strip.Error!);
+                strippedReports = strip.Stripped;
+            }
+            else
+            {
+                // apply lane: the target NPC — an active winner the service fetched, or (not-yet-enabled patch) the
+                // extend target's own record.
+                Npc targetOverride;
+                if (targetFk.ModKey == patchMod.ModKey)
+                {
+                    targetOverride = patchMod.Npcs.FirstOrDefault(n => n.FormKey == targetFk)
+                        ?? throw new InvalidOperationException(
+                            $"{targetFk} names this patch, but '{patchFileName}' defines no such NPC. Create the NPC first (housecarl_create_record) or pass an active NPC's formid.");
+                }
+                else if (targetActiveBody is not null)
+                {
+                    targetOverride = (Npc)WriteEngine.GenericGetOrAddAsOverride(patchMod, targetActiveBody);
+                }
+                else
+                    return NpcCopyOutcome.Fail("apply lane reached the build without a target body (engine inconsistency, Q3).");
+
+                newNpcKey = targetFk;
+                copiedFields = CopyAppearanceFields(donorNpc, targetOverride);
+                patchMod.RemapLinks(dict);   // repoint the just-copied fields at the internalized copies
+
+                // belt-and-braces (Q3): nothing donor-internal may remain on the override after the remap.
+                var leak = ((IFormLinkContainerGetter)targetOverride).EnumerateFormLinks()
+                    .FirstOrDefault(l => !l.FormKey.IsNull && isForeign(l.FormKey));
+                if (leak is not null && !leak.FormKey.IsNull)
+                    return NpcCopyOutcome.Fail(
+                        $"after the copy the target still references {leak.FormKey}, which is donor-internal or unresolvable — " +
+                        "refusing to write a patch that would master the donor (Q3). This is unexpected; please report it.");
+            }
+
+            // ---- serialize (multi-master; the caller's mastersFor handles the active-patch self-lock) ----
+            try { WriteEngine.WritePatch(patchMod, mastersFor(patchFileName), outPath); }
+            catch (Exception ex) { return NpcCopyOutcome.Fail($"serialize failed — {WriteEngine.Describe(ex)}. Nothing usable was written."); }
+
+            var back = SkyrimMod.CreateFromBinaryOverlay(outPath, SkyrimRelease.SkyrimSE);
+            List<string> masters;
+            long bytes;
+            try
+            {
+                masters = back.ModHeader.MasterReferences.Select(m => m.Master.FileName.ToString()).ToList();
+                bytes = new FileInfo(outPath).Length;
+            }
+            finally { (back as IDisposable)?.Dispose(); }
+            bool donorAmongMasters = masters.Any(m => { try { return donorMods.Contains(ModKey.FromFileName(m)); } catch { return false; } });
+
+            var internalized = closure.ToInternalize
+                .Select(i => new InternalizedRecord(
+                    RecordNaming.StripOverlay(i.Body.GetType().Name), i.Body.EditorID ?? "<no editorid>",
+                    i.Body.FormKey, dict[i.Body.FormKey], i.PulledBy))
+                .ToList();
+
+            return new NpcCopyOutcome(
+                true, null, clone ? "clone" : "apply",
+                donorNpc.FormKey, donorReadFrom, donorOutOfLoadOrder,
+                newNpcKey, outPath, extend,
+                internalized, closure.KeptLinks.Count,
+                copiedFields, strippedReports, masters, donorAmongMasters, null, bytes);
+        }
+        catch (Exception ex)
+        {
+            return NpcCopyOutcome.Fail($"copy failed — {WriteEngine.Describe(ex)}. Nothing usable was written.");
+        }
+    }
+
+    // ======================================================================
+    //  APPLY-MODE FIELD COPY — donor appearance onto an EXISTING target NPC
+    // ======================================================================
+
+    /// <summary>
+    /// Copy the donor's appearance FIELDS onto <paramref name="target"/> (an override the caller already placed in
+    /// the patch). Whole-field copies via Mutagen DeepCopy/SetTo — the same no-field-left-behind property the clone
+    /// lane gets from Duplicate: TintLayers, TextureLighting (the dark-skin default trap), FaceMorph/FaceParts,
+    /// Weight/Height all carry the donor's exact values. Links are copied at their DONOR keys; the caller's
+    /// RemapLinks pass repoints the internalized ones. Returns the copied-field names for the report — including a
+    /// prominent Race note when the donor's race differs (facegen is race-fitted; not copying it would neck-seam).
+    /// </summary>
+    public static IReadOnlyList<string> CopyAppearanceFields(INpcGetter donor, Npc target)
+    {
+        var copied = new List<string>();
+
+        target.HeadParts.SetTo(donor.HeadParts.Select(l => new FormLink<IHeadPartGetter>(l.FormKey)));
+        copied.Add($"HeadParts ({donor.HeadParts.Count})");
+
+        target.HairColor.SetTo(donor.HairColor?.FormKeyNullable);
+        copied.Add("HairColor");
+        target.HeadTexture.SetTo(donor.HeadTexture?.FormKeyNullable);
+        copied.Add("HeadTexture");
+        target.WornArmor.SetTo(donor.WornArmor?.FormKeyNullable);
+        copied.Add("WornArmor");
+
+        target.FaceMorph = donor.FaceMorph?.DeepCopy();
+        copied.Add("FaceMorph");
+        target.FaceParts = donor.FaceParts?.DeepCopy();
+        copied.Add("FaceParts");
+
+        target.TintLayers.SetTo(donor.TintLayers.Select(t => t.DeepCopy()));
+        copied.Add($"TintLayers ({donor.TintLayers.Count})");
+
+        target.TextureLighting = donor.TextureLighting;
+        copied.Add("TextureLighting");
+
+        target.Weight = donor.Weight;
+        target.Height = donor.Height;
+        copied.Add("Weight/Height");
+
+        if (target.Race.FormKey != donor.Race.FormKey)
+        {
+            target.Race.SetTo(donor.Race.FormKey);
+            copied.Add($"Race (target's differed — copied {donor.Race.FormKey}; facegen is race-fitted)");
+        }
+
+        return copied;
+    }
+}

--- a/src/housecarl-core/RemapEngine.cs
+++ b/src/housecarl-core/RemapEngine.cs
@@ -274,7 +274,7 @@ public static class RemapEngine
     /// surface derives from (no drift). An abstract group (e.g. <c>SkyrimGroup&lt;Global&gt;</c>) matches its concrete arm
     /// (<c>GlobalFloat</c>) because <c>tMajor.IsInstanceOfType(dup)</c> holds and <c>Add(Global)</c> accepts the subtype.
     /// Returns false when no flat group fits (a nested-only record) — the caller fails loud.</summary>
-    static bool TryAddToFlatGroup(SkyrimMod target, IMajorRecord dup)
+    internal static bool TryAddToFlatGroup(SkyrimMod target, IMajorRecord dup)
     {
         foreach (var (prop, tMajor, _) in WriteEngine.EnumerateFlatGroups(target.GetType()))
         {

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -148,6 +148,11 @@ public static class CiAll
         // read, the OUT-OF-LOAD-ORDER stamp, the missing-master advisory, and the Q3 refusals (missing/ambiguous
         // filename, bad/absent FormID, formid+type together). Opens its OWN overlay — never touches the resolver index.
         ("read-plugin-file-guard", ReadPluginFileProbe.RunGuard),
+        // STANDALONE-COPY CHAIN Stage 3 — housecarl_copy_npc_appearance: the composed verb. Duplicate+RemapLinks the
+        // donor's appearance closure under new keys (HDPT EditorIDs preserved — facegeom block-name identity; HDPT.Parts
+        // — the lip-sync layer — carried by the whole-record copy), facegen pair renamed to the new FormKey path, donor-
+        // only assets carried (record harvest + geom byte-scrape), clone-mode strips NAMED, donor NEVER a master.
+        ("copy-npc-appearance-guard", NpcCopyProbe.RunGuard),
     };
 
     /// <summary>Dispatch a single CI guard by name through the registry — the ONE place a CI probe is listed, so

--- a/src/housecarl-generator/NpcCopyProbe.cs
+++ b/src/housecarl-generator/NpcCopyProbe.cs
@@ -1,0 +1,293 @@
+using System.Linq;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// STANDALONE-NPC-COPY guard (housecarl_copy_npc_appearance — capability chain Stage 3). Drives the REAL
+/// <see cref="LoadOrderService.CopyNpcAppearance"/> over a synthetic MO2 instance with a DISABLED donor (the realistic
+/// case the chain exists for), pinning the empirical MUSTs the 2026-07-01 build test paid for:
+///   APPLY      — donor appearance onto an existing active NPC: the closure internalizes the donor's HDPT/TXST/CLFM
+///                under NEW keys with EditorIDs PRESERVED (facegeom block-name identity), HDPT.Parts (.tri morph refs —
+///                the lip-sync layer) arrive on the copy, ExtraParts/TextureSet links are REMAPPED to the copies, a link
+///                into an ACTIVE master is KEPT (not internalized), TintLayers/TextureLighting carry the donor's exact
+///                values (the dark-skin default trap), and the DONOR IS NOT A MASTER of the patch (the standalone claim).
+///   ASSETS     — the facegen pair is RENAMED to the TARGET's FormKey path (folder = the target's defining plugin), the
+///                geom's embedded texture (byte-scraped) and the record-referenced model are carried from the disabled
+///                donor's folder, and an unresolvable referenced path is a NAMED miss, never silent (Q3).
+///   CLONE      — a full standalone clone: new EditorID/Name, appearance remapped, and the donor-internal NON-appearance
+///                links (a faction membership, a default outfit) STRIPPED with each strip NAMED in the outcome.
+///   REFUSALS   — both/neither target modes; a donor formid the active order can't see (the message routes to
+///                source_plugin=); a non-NPC donor; a donor-internal custom RACE (out of scope, named).
+/// Run: dotnet run --project src/housecarl-generator -- copy-npc-appearance-guard
+/// </summary>
+public static class NpcCopyProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  STANDALONE-NPC-COPY guard (housecarl_copy_npc_appearance)  ################");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        var root = Path.Combine(Path.GetTempPath(), "hc-npc-copy-guard-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            // ================= shared fixture: active master + active follower scaffold + DISABLED donor =================
+            var inst = Path.Combine(root, "inst");
+            var (mods, prof) = MakeInstance(inst);
+
+            var keepKey = new ModKey("HcKeepMe", ModType.Master);
+            var raceFk = new FormKey(keepKey, 0x800);
+            var keptTxstFk = new FormKey(keepKey, 0x801);
+            var keepMod = new SkyrimMod(keepKey, SkyrimRelease.SkyrimSE);
+            keepMod.Races.Add(new Race(raceFk, SkyrimRelease.SkyrimSE) { EditorID = "HcRace" });
+            keepMod.TextureSets.Add(new TextureSet(keptTxstFk, SkyrimRelease.SkyrimSE) { EditorID = "HcKeptTex" });
+            WriteModDirect(mods, "KeepMod", keepMod);
+
+            var folKey = new ModKey("MyFollower", ModType.Plugin);
+            var targetFk = new FormKey(folKey, 0x800);
+            var folMod = new SkyrimMod(folKey, SkyrimRelease.SkyrimSE);
+            var saela = new Npc(targetFk, SkyrimRelease.SkyrimSE) { EditorID = "Saela" };
+            saela.Race.SetTo(raceFk);
+            folMod.Npcs.Add(saela);
+            WriteModDirect(mods, "FollowerMod", folMod, keepMod);
+
+            var donorKey = new ModKey("Donor", ModType.Plugin);
+            var donorNpcFk = new FormKey(donorKey, 0xD62);
+            var texFk = new FormKey(donorKey, 0xD00);
+            var hairFk = new FormKey(donorKey, 0xD01);
+            var hairlineFk = new FormKey(donorKey, 0xD02);
+            var colorFk = new FormKey(donorKey, 0xD03);
+            var factionFk = new FormKey(donorKey, 0xD04);
+            var outfitFk = new FormKey(donorKey, 0xD05);
+            var badRaceFk = new FormKey(donorKey, 0xD06);
+            var badNpcFk = new FormKey(donorKey, 0xD07);
+
+            var donorMod = new SkyrimMod(donorKey, SkyrimRelease.SkyrimSE);
+            donorMod.TextureSets.Add(new TextureSet(texFk, SkyrimRelease.SkyrimSE) { EditorID = "VivTex" });
+            var hairline = new HeadPart(hairlineFk, SkyrimRelease.SkyrimSE) { EditorID = "VivHairlineHP" };
+            hairline.Parts.Add(new Part { PartType = Part.PartTypeEnum.Tri, FileName = @"Actors\Character\Character Assets\FemaleHead.tri" });
+            donorMod.HeadParts.Add(hairline);
+            var hair = new HeadPart(hairFk, SkyrimRelease.SkyrimSE) { EditorID = "VivHairHP" };
+            hair.TextureSet.SetTo(texFk);
+            hair.ExtraParts.Add(hairlineFk);
+            hair.Parts.Add(new Part { PartType = Part.PartTypeEnum.Tri, FileName = @"Actors\Character\Character Assets\FemaleHead.tri" });
+            hair.Parts.Add(new Part { PartType = Part.PartTypeEnum.RaceMorph, FileName = @"Actors\Character\Character Assets\FemaleHeadRaces.tri" });
+            hair.Model = new Model { File = @"actors\character\viv\hair.nif" };
+            donorMod.HeadParts.Add(hair);
+            donorMod.Colors.Add(new ColorRecord(colorFk, SkyrimRelease.SkyrimSE) { EditorID = "VivColor" });
+            donorMod.Factions.Add(new Faction(factionFk, SkyrimRelease.SkyrimSE) { EditorID = "VivFaction" });
+            donorMod.Outfits.Add(new Outfit(outfitFk, SkyrimRelease.SkyrimSE) { EditorID = "VivOutfit" });
+            donorMod.Races.Add(new Race(badRaceFk, SkyrimRelease.SkyrimSE) { EditorID = "VivRace" });
+
+            var viv = new Npc(donorNpcFk, SkyrimRelease.SkyrimSE) { EditorID = "Viv", Name = "Vivace" };
+            viv.Race.SetTo(raceFk);
+            viv.HeadParts.Add(hairFk);
+            viv.HairColor.SetTo(colorFk);
+            viv.HeadTexture.SetTo(keptTxstFk);                             // kept link — resolves via the ACTIVE master
+            viv.TextureLighting = System.Drawing.Color.FromArgb(255, 246, 237, 235);
+            viv.TintLayers.Add(new TintLayer { Index = 3, InterpolationValue = 1.0f, Color = System.Drawing.Color.FromArgb(255, 90, 60, 50) });
+            viv.TintLayers.Add(new TintLayer { Index = 7, InterpolationValue = 0.5f });
+            viv.Weight = 42f;
+            viv.Factions.Add(new RankPlacement { Faction = factionFk.ToLink<IFactionGetter>(), Rank = 0 });   // clone-strip candidate
+            viv.DefaultOutfit.SetTo(outfitFk);                                                                 // clone-strip candidate
+            donorMod.Npcs.Add(viv);
+
+            var badNpc = new Npc(badNpcFk, SkyrimRelease.SkyrimSE) { EditorID = "VivBadRace" };
+            badNpc.Race.SetTo(badRaceFk);                                  // donor-internal custom race → the named refusal
+            donorMod.Npcs.Add(badNpc);
+            WriteModDirect(mods, "DonorMod", donorMod, keepMod);
+
+            // donor-only loose assets: the facegen pair (geom embeds a texture path for the scrape), the scraped
+            // texture, and the record-referenced hair model.
+            var donorDir = Path.Combine(mods, "DonorMod");
+            var geomRel = $@"meshes\actors\character\facegendata\facegeom\Donor.esp\00000D62.nif";
+            var tintRel = $@"textures\actors\character\facegendata\facetint\Donor.esp\00000D62.dds";
+            var skinRel = $@"textures\actors\viv\skin.dds";
+            var hairRel = $@"meshes\actors\character\viv\hair.nif";
+            var geomBytes = new byte[] { 1, 2, 3, 0 }
+                .Concat(System.Text.Encoding.ASCII.GetBytes(skinRel)).Concat(new byte[] { 0, 9, 8 }).ToArray();
+            WriteFixture(donorDir, geomRel, geomBytes);
+            WriteFixture(donorDir, tintRel, new byte[] { 0xDD, 0x51 });
+            WriteFixture(donorDir, skinRel, new byte[] { 0x51, 0x4B });
+            WriteFixture(donorDir, hairRel, new byte[] { 0x4E, 0x1F });
+
+            WriteProfile(prof,
+                loadorder: new[] { keepKey.FileName.String, folKey.FileName.String },
+                plugins: new[] { "*" + keepKey.FileName, "*" + folKey.FileName },
+                modlist: new[] { "+FollowerMod", "+KeepMod", "-DonorMod" });
+            WriteSkyrimIni(prof);
+
+            using var svc = LoadOrderService.WithInstance(inst, 0, new UserConfigStore(Path.Combine(root, "user.json")));
+            svc.Stats();
+
+            // ================= 1. APPLY — disabled donor's appearance onto the active follower =================
+            {
+                var o = svc.CopyNpcAppearance(donorNpcFk.ToString(), "Donor.esp", null,
+                                              targetFk.ToString(), null, null, "SaelaFace", null);
+                Check(o.Success, $"apply: succeeds ({o.Error})");
+                Check(o.Success && o.Mode == "apply" && o.DonorOutOfLoadOrder, "apply: mode=apply, donor stamped OUT-OF-LOAD-ORDER");
+                Check(o.Success && o.Internalized.Count == 4, $"apply: internalizes exactly the donor subtree — 2 HDPT + TXST + CLFM (got {o.Internalized.Count})");
+                Check(o.Success && o.Internalized.All(r => r.NewKey.ModKey.FileName.String == "SaelaFace.esp"), "apply: every copy lands under the patch's own new FormIDs");
+                Check(o.Success && !o.DonorAmongMasters && !o.Masters.Contains("Donor.esp", StringComparer.OrdinalIgnoreCase),
+                    "apply: THE STANDALONE CLAIM — the donor is NOT among the patch masters");
+                Check(o.Success && o.Masters.Contains("HcKeepMe.esm", StringComparer.OrdinalIgnoreCase),
+                    "apply: the kept active-master link IS mastered (HcKeepMe.esm)");
+
+                if (o.Success)
+                {
+                    using var pd = OpenDisposable(o.OutPath!, out var patch);
+                    var npc = patch.Npcs.FirstOrDefault(n => n.FormKey == targetFk);
+                    Check(npc is not null, "apply: the patch overrides the target NPC");
+                    if (npc is not null)
+                    {
+                        var patchKey = ModKey.FromFileName("SaelaFace.esp");
+                        Check(npc.HeadParts.Count == 1 && npc.HeadParts[0].FormKey.ModKey == patchKey,
+                            "apply: HeadParts remapped to the internalized copy");
+                        Check(npc.HeadTexture is { IsNull: false } htl && htl.FormKey == keptTxstFk,
+                            "apply: the ACTIVE-master link is KEPT, not internalized");
+                        Check(npc.TintLayers.Count == 2 && npc.TintLayers[0].Index == 3,
+                            "apply: TintLayers carry the donor's layers");
+                        Check(npc.TextureLighting is { } tl && tl.R == 246 && tl.G == 237 && tl.B == 235,
+                            "apply: TextureLighting carries the donor's value (the dark-skin default trap)");
+                        Check(Math.Abs(npc.Weight - 42f) < 0.001, "apply: Weight carries");
+                        Check(npc.HairColor is { IsNull: false } hcl && hcl.FormKey.ModKey == patchKey,
+                            "apply: HairColor remapped to the internalized CLFM");
+
+                        var hairCopy = patch.HeadParts.FirstOrDefault(h => h.EditorID == "VivHairHP");
+                        Check(hairCopy is not null, "apply: HDPT EditorID PRESERVED (facegeom block-name identity)");
+                        if (hairCopy is not null)
+                        {
+                            Check(hairCopy.Parts.Count == 2, "apply: HDPT.Parts (.tri morph refs — the LIP-SYNC layer) arrive on the copy");
+                            Check(hairCopy.ExtraParts.Count == 1 && hairCopy.ExtraParts[0].FormKey.ModKey == patchKey,
+                                "apply: ExtraParts remapped to the copied hairline");
+                            Check(hairCopy.TextureSet is { IsNull: false } ts && ts.FormKey.ModKey == patchKey,
+                                "apply: HDPT.TextureSet remapped to the copied TXST");
+                        }
+                    }
+
+                    var outDir = Path.GetDirectoryName(o.OutPath!)!;
+                    Check(File.Exists(Path.Combine(outDir, $@"meshes\actors\character\facegendata\facegeom\MyFollower.esp\00000800.nif")),
+                        "assets: facegeom RENAMED to the TARGET's FormKey path (folder = the target's defining plugin)");
+                    Check(File.Exists(Path.Combine(outDir, $@"textures\actors\character\facegendata\facetint\MyFollower.esp\00000800.dds")),
+                        "assets: facetint renamed alongside");
+                    Check(File.Exists(Path.Combine(outDir, skinRel)),
+                        "assets: the geom's EMBEDDED texture (byte-scraped) carried from the disabled donor's folder");
+                    Check(File.Exists(Path.Combine(outDir, hairRel)),
+                        "assets: the record-referenced model carried from the disabled donor's folder");
+                    Check(o.Assets is { } aa && aa.Missing.Any(m => m.Contains("FemaleHead.tri", StringComparison.OrdinalIgnoreCase)),
+                        "assets: an unresolvable referenced path is a NAMED miss (Q3), never silent");
+                }
+            }
+
+            // ================= 2. CLONE — a full standalone clone with the strips NAMED =================
+            {
+                var o = svc.CopyNpcAppearance(donorNpcFk.ToString(), "Donor.esp", null,
+                                              null, "VivClone", "Vivi", "VivCloneP", null);
+                Check(o.Success, $"clone: succeeds ({o.Error})");
+                Check(o.Success && !o.DonorAmongMasters, "clone: the donor is NOT among the patch masters");
+                Check(o.Success && o.Stripped.Any(s => s.Field.StartsWith("Factions[", StringComparison.Ordinal)),
+                    "clone: the donor-faction membership is STRIPPED and NAMED");
+                Check(o.Success && o.Stripped.Any(s => s.Field == "DefaultOutfit"),
+                    "clone: the donor DefaultOutfit is STRIPPED and NAMED");
+                if (o.Success)
+                {
+                    using var pd = OpenDisposable(o.OutPath!, out var patch);
+                    var cl = patch.Npcs.FirstOrDefault(n => n.EditorID == "VivClone");
+                    Check(cl is not null && cl.FormKey == o.NewNpcKey, "clone: the new NPC exists under its reported new key");
+                    if (cl is not null)
+                    {
+                        Check(cl.Name?.String == "Vivi", "clone: new Name applied");
+                        Check(cl.HeadParts.Count == 1 && cl.HeadParts[0].FormKey.ModKey == cl.FormKey.ModKey,
+                            "clone: HeadParts remapped to the internalized copies");
+                        Check(cl.Factions.Count == 0 && (cl.DefaultOutfit is null || cl.DefaultOutfit.IsNull),
+                            "clone: the stripped references are really gone from the record");
+                        Check(cl.TextureLighting is { } tl2 && tl2.R == 246, "clone: TextureLighting carried by the whole-record copy");
+                    }
+                    var outDir = Path.GetDirectoryName(o.OutPath!)!;
+                    var newId = "00" + o.NewNpcKey.ID.ToString("X6");
+                    Check(File.Exists(Path.Combine(outDir, $@"meshes\actors\character\facegendata\facegeom\VivCloneP.esp\{newId}.nif")),
+                        "clone: facegeom renamed to the CLONE's FormKey path (folder = the patch)");
+                }
+            }
+
+            // ================= 3. Q3 refusals =================
+            {
+                var both = svc.CopyNpcAppearance(donorNpcFk.ToString(), "Donor.esp", null, targetFk.ToString(), "X", null, null, null);
+                Check(!both.Success && both.Error!.Contains("EXACTLY ONE"), "refusal: both target modes named");
+                var neither = svc.CopyNpcAppearance(donorNpcFk.ToString(), "Donor.esp", null, null, null, null, null, null);
+                Check(!neither.Success && neither.Error!.Contains("EXACTLY ONE"), "refusal: neither target mode named");
+                var inactive = svc.CopyNpcAppearance(donorNpcFk.ToString(), null, null, targetFk.ToString(), null, null, null, null);
+                Check(!inactive.Success && inactive.Error!.Contains("source_plugin"),
+                    "refusal: a donor the active order can't see routes to source_plugin=");
+                var notNpc = svc.CopyNpcAppearance(texFk.ToString(), "Donor.esp", null, targetFk.ToString(), null, null, null, null);
+                Check(!notNpc.Success && notNpc.Error!.Contains("not an NPC"), "refusal: a non-NPC donor is named");
+                var badRace = svc.CopyNpcAppearance(badNpcFk.ToString(), "Donor.esp", null, targetFk.ToString(), null, null, null, null);
+                Check(!badRace.Success && badRace.Error!.Contains("RACE"), "refusal: a donor-internal custom race is out of scope, NAMED");
+                Check(!Directory.Exists(Path.Combine(mods, "houseCARL - houseCARL_NpcCopy")),
+                    "refusal: no orphan patch folder is left behind (hunt F4)");
+            }
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { /* best-effort temp cleanup */ }
+        }
+
+        Console.WriteLine();
+        Console.WriteLine(fail == 0 ? "ALL CHECKS PASSED" : $"{fail} CHECK(S) FAILED");
+        return fail == 0 ? 0 : 1;
+    }
+
+    // ---- synthetic MO2 layout helpers (the SeqRegen / ReadPluginFile probe pattern) ----
+
+    static (string mods, string prof) MakeInstance(string inst)
+    {
+        var mods = Path.Combine(inst, "mods");
+        var data = Path.Combine(inst, "game", "Data");
+        var prof = Path.Combine(inst, "profiles", "Default");
+        foreach (var d in new[] { mods, data, prof }) Directory.CreateDirectory(d);
+        File.WriteAllText(Path.Combine(inst, "ModOrganizer.ini"),
+            "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+            + Path.Combine(inst, "game").Replace(@"\", @"\\") + ")\r\n");
+        return (mods, prof);
+    }
+
+    static void WriteModDirect(string mods, string folder, SkyrimMod m, params ISkyrimModGetter[] masters)
+    {
+        var dir = Path.Combine(mods, folder);
+        Directory.CreateDirectory(dir);
+        m.BeginWrite.ToPath(Path.Combine(dir, m.ModKey.FileName.String)).WithLoadOrder(masters).Write();
+    }
+
+    static void WriteProfile(string prof, string[] loadorder, string[] plugins, string[] modlist)
+    {
+        Directory.CreateDirectory(prof);
+        File.WriteAllText(Path.Combine(prof, "loadorder.txt"), "# header\r\n" + string.Join("\r\n", loadorder) + "\r\n");
+        File.WriteAllText(Path.Combine(prof, "plugins.txt"), string.Join("\r\n", plugins) + "\r\n");
+        File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n" + string.Join("\r\n", modlist) + "\r\n");
+    }
+
+    static void WriteSkyrimIni(string prof) =>
+        File.WriteAllText(Path.Combine(prof, "Skyrim.ini"), "[Archive]\r\nsResourceArchiveList=\r\n");
+
+    static void WriteFixture(string modDir, string relPath, byte[] bytes)
+    {
+        var p = Path.Combine(modDir, relPath);
+        Directory.CreateDirectory(Path.GetDirectoryName(p)!);
+        File.WriteAllBytes(p, bytes);
+    }
+
+    /// <summary>Open a written patch as an overlay, returning the disposable so `using` releases the handle.</summary>
+    static IDisposable OpenDisposable(string path, out ISkyrimModGetter mod)
+    {
+        var ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE);
+        mod = ov;
+        return (IDisposable)ov;
+    }
+}

--- a/src/housecarl-generator/NpcCopyProbe.cs
+++ b/src/housecarl-generator/NpcCopyProbe.cs
@@ -95,6 +95,7 @@ public static class NpcCopyProbe
             donorMod.TextureSets.Add(new TextureSet(texFk, SkyrimRelease.SkyrimSE) { EditorID = "VivTex" });
             var hairline = new HeadPart(hairlineFk, SkyrimRelease.SkyrimSE) { EditorID = "VivHairlineHP" };
             hairline.Parts.Add(new Part { PartType = Part.PartTypeEnum.Tri, FileName = @"Actors\Character\Character Assets\FemaleHead.tri" });
+            hairline.Model = new Model { File = @"..\escape.nif" };       // a dirty '..' path — must become ONE named failure, never abort the carry
             donorMod.HeadParts.Add(hairline);
             var hair = new HeadPart(hairFk, SkyrimRelease.SkyrimSE) { EditorID = "VivHairHP" };
             hair.TextureSet.SetTo(texFk);
@@ -141,6 +142,20 @@ public static class NpcCopyProbe
             donorMod.Npcs.Add(templatedNpc);
             WriteModDirect(mods, "DonorMod", donorMod, keepMod);
 
+            // a SECOND donor whose headpart REUSES the EditorID 'VivHairHP' with DIFFERENT content — the KS Hairdos
+            // EditorID-collision case: extend-reuse must refuse loud, never silently wire this NPC to the other
+            // donor's copy and never mint a duplicate EditorID.
+            var donor2Key = new ModKey("Donor2", ModType.Plugin);
+            var donor2NpcFk = new FormKey(donor2Key, 0xE00);
+            var donor2Mod = new SkyrimMod(donor2Key, SkyrimRelease.SkyrimSE);
+            var hair2 = new HeadPart(new FormKey(donor2Key, 0xE01), SkyrimRelease.SkyrimSE) { EditorID = "VivHairHP" };  // same name, no Parts/TextureSet — different content
+            donor2Mod.HeadParts.Add(hair2);
+            var viv2 = new Npc(donor2NpcFk, SkyrimRelease.SkyrimSE) { EditorID = "Viv2" };
+            viv2.Race.SetTo(raceFk);
+            viv2.HeadParts.Add(hair2.FormKey);
+            donor2Mod.Npcs.Add(viv2);
+            WriteModDirect(mods, "Donor2Mod", donor2Mod, keepMod);
+
             // donor-only loose assets: the facegen pair (geom embeds a texture path for the scrape), the scraped
             // texture, and the record-referenced hair model.
             var donorDir = Path.Combine(mods, "DonorMod");
@@ -158,7 +173,7 @@ public static class NpcCopyProbe
             WriteProfile(prof,
                 loadorder: new[] { vanKey.FileName.String, keepKey.FileName.String, folKey.FileName.String },
                 plugins: new[] { "*" + vanKey.FileName, "*" + keepKey.FileName, "*" + folKey.FileName },
-                modlist: new[] { "+ContestMod", "+FollowerMod", "+KeepMod", "+FakeVanilla", "-DonorMod" });
+                modlist: new[] { "+ContestMod", "+FollowerMod", "+KeepMod", "+FakeVanilla", "-DonorMod", "-Donor2Mod" });
             WriteSkyrimIni(prof);
 
             using var svc = LoadOrderService.WithInstance(inst, 0, new UserConfigStore(Path.Combine(root, "user.json")));
@@ -274,6 +289,37 @@ public static class NpcCopyProbe
                 }
                 Check(o.Success && o.Assets is { } ca && ca.Warnings.Any(w => w.Contains("ALREADY provided")),
                     "re-run: a contested facegen DESTINATION gets a named precedence warning (file precedence is its own system)");
+            }
+
+            // ================= 2b-ii. EDITORID COLLISION — same name, DIFFERENT content → loud refusal =================
+            {
+                var o = svc.CopyNpcAppearance(donor2NpcFk.ToString(), "Donor2.esp", null,
+                                              target2Fk.ToString(), null, null, null, "SaelaFace");
+                Check(!o.Success && o.Error!.Contains("CONTENT differs"),
+                    "collision: a same-EditorID, different-content prior copy REFUSES loud — never silently rewired, never re-copied");
+            }
+
+            // ================= 2b-iii. dirty '..' asset path — ONE named failure, carry not aborted =================
+            {
+                // pinned off arm 1's outcome shape: re-check on a fresh apply into a fresh patch.
+                var o = svc.CopyNpcAppearance(donorNpcFk.ToString(), "Donor.esp", null,
+                                              targetFk.ToString(), null, null, "DirtyPathCheck", null);
+                Check(o.Success && o.Assets is { } da
+                      && da.Failures.Any(f => f.Contains("escape.nif"))
+                      && da.Carried.Any(c => c.NewRelPath.EndsWith("skin.dds", StringComparison.OrdinalIgnoreCase)),
+                    "dirty path: a '..' asset path is ONE named failure and the paths after it still carry");
+            }
+
+            // ================= 2b-iv. unverified read-back render — no categorical standalone claim =================
+            {
+                var fake = new NpcCopyOutcome(true, null, "apply", donorNpcFk, "test", false, targetFk, "X.esp", false,
+                    Array.Empty<InternalizedRecord>(), Array.Empty<string>(), 0, Array.Empty<string>(),
+                    Array.Empty<NpcAppearanceCopy.StripReport>(), Array.Empty<string>(), false, false,
+                    Array.Empty<string>(), null, 0,
+                    "the patch WAS written, but the post-write read-back failed (test) — the masters list could not be verified this call.");
+                var render = NpcCopyTools.Render(fake);
+                Check(render.Contains("NOT VERIFIED") && !render.Contains("standalone: the donor is NOT a master"),
+                    "render: a failed read-back never asserts the standalone claim it could not verify");
             }
 
             // ================= 2c. BASE-GAME donor — never donor-bound (the vanilla-look transplant lane) =================

--- a/src/housecarl-generator/NpcCopyProbe.cs
+++ b/src/housecarl-generator/NpcCopyProbe.cs
@@ -52,11 +52,33 @@ public static class NpcCopyProbe
 
             var folKey = new ModKey("MyFollower", ModType.Plugin);
             var targetFk = new FormKey(folKey, 0x800);
+            var target2Fk = new FormKey(folKey, 0x801);
             var folMod = new SkyrimMod(folKey, SkyrimRelease.SkyrimSE);
             var saela = new Npc(targetFk, SkyrimRelease.SkyrimSE) { EditorID = "Saela" };
             saela.Race.SetTo(raceFk);
             folMod.Npcs.Add(saela);
+            var saela2 = new Npc(target2Fk, SkyrimRelease.SkyrimSE) { EditorID = "Saela2" };
+            saela2.Race.SetTo(raceFk);
+            folMod.Npcs.Add(saela2);
             WriteModDirect(mods, "FollowerMod", folMod, keepMod);
+
+            // a fixture "Skyrim.esm" — the BASE-GAME-donor lane (Implicits BaseMasters match by name); its NPC's
+            // race + headpart live in itself, and none of that may classify as donor-internal.
+            var vanKey = new ModKey("Skyrim", ModType.Master);
+            var vanNpcFk = new FormKey(vanKey, 0x900);
+            var vanMod = new SkyrimMod(vanKey, SkyrimRelease.SkyrimSE);
+            vanMod.Races.Add(new Race(new FormKey(vanKey, 0x901), SkyrimRelease.SkyrimSE) { EditorID = "VanRace" });
+            var vanHp = new HeadPart(new FormKey(vanKey, 0x902), SkyrimRelease.SkyrimSE) { EditorID = "VanHairHP" };
+            vanMod.HeadParts.Add(vanHp);
+            var vanNpc = new Npc(vanNpcFk, SkyrimRelease.SkyrimSE) { EditorID = "VanDonor" };
+            vanNpc.Race.SetTo(new FormKey(vanKey, 0x901));
+            vanNpc.HeadParts.Add(vanHp.FormKey);
+            vanMod.Npcs.Add(vanNpc);
+            WriteModDirect(mods, "FakeVanilla", vanMod);
+
+            // an active mod already providing Saela2's facegen DESTINATION path — the precedence-warning arm.
+            WriteFixture(Path.Combine(mods, "ContestMod"),
+                $@"meshes\actors\character\facegendata\facegeom\MyFollower.esp\00000801.nif", new byte[] { 0xAA });
 
             var donorKey = new ModKey("Donor", ModType.Plugin);
             var donorNpcFk = new FormKey(donorKey, 0xD62);
@@ -86,7 +108,13 @@ public static class NpcCopyProbe
             donorMod.Outfits.Add(new Outfit(outfitFk, SkyrimRelease.SkyrimSE) { EditorID = "VivOutfit" });
             donorMod.Races.Add(new Race(badRaceFk, SkyrimRelease.SkyrimSE) { EditorID = "VivRace" });
 
+            var classFk = new FormKey(donorKey, 0xD08);
+            var classedNpcFk = new FormKey(donorKey, 0xD09);
+            var templatedNpcFk = new FormKey(donorKey, 0xD0A);
+            donorMod.Classes.Add(new Class(classFk, SkyrimRelease.SkyrimSE) { EditorID = "VivClass" });
+
             var viv = new Npc(donorNpcFk, SkyrimRelease.SkyrimSE) { EditorID = "Viv", Name = "Vivace" };
+            viv.Configuration.Flags |= NpcConfiguration.Flag.Female;      // gender-fitted appearance — the match-to-donor arm
             viv.Race.SetTo(raceFk);
             viv.HeadParts.Add(hairFk);
             viv.HairColor.SetTo(colorFk);
@@ -102,6 +130,15 @@ public static class NpcCopyProbe
             var badNpc = new Npc(badNpcFk, SkyrimRelease.SkyrimSE) { EditorID = "VivBadRace" };
             badNpc.Race.SetTo(badRaceFk);                                  // donor-internal custom race → the named refusal
             donorMod.Npcs.Add(badNpc);
+            var classedNpc = new Npc(classedNpcFk, SkyrimRelease.SkyrimSE) { EditorID = "VivClassed" };
+            classedNpc.Race.SetTo(raceFk);
+            classedNpc.Class.SetTo(classFk);                               // donor-internal REQUIRED link → clone must refuse, never null it
+            donorMod.Npcs.Add(classedNpc);
+            var templatedNpc = new Npc(templatedNpcFk, SkyrimRelease.SkyrimSE) { EditorID = "VivTemplated" };
+            templatedNpc.Race.SetTo(raceFk);
+            templatedNpc.Template.SetTo(donorNpcFk);                       // appearance lives on the template → refusal
+            templatedNpc.Configuration.TemplateFlags |= NpcConfiguration.TemplateFlag.Traits;
+            donorMod.Npcs.Add(templatedNpc);
             WriteModDirect(mods, "DonorMod", donorMod, keepMod);
 
             // donor-only loose assets: the facegen pair (geom embeds a texture path for the scrape), the scraped
@@ -119,9 +156,9 @@ public static class NpcCopyProbe
             WriteFixture(donorDir, hairRel, new byte[] { 0x4E, 0x1F });
 
             WriteProfile(prof,
-                loadorder: new[] { keepKey.FileName.String, folKey.FileName.String },
-                plugins: new[] { "*" + keepKey.FileName, "*" + folKey.FileName },
-                modlist: new[] { "+FollowerMod", "+KeepMod", "-DonorMod" });
+                loadorder: new[] { vanKey.FileName.String, keepKey.FileName.String, folKey.FileName.String },
+                plugins: new[] { "*" + vanKey.FileName, "*" + keepKey.FileName, "*" + folKey.FileName },
+                modlist: new[] { "+ContestMod", "+FollowerMod", "+KeepMod", "+FakeVanilla", "-DonorMod" });
             WriteSkyrimIni(prof);
 
             using var svc = LoadOrderService.WithInstance(inst, 0, new UserConfigStore(Path.Combine(root, "user.json")));
@@ -157,6 +194,8 @@ public static class NpcCopyProbe
                         Check(npc.TextureLighting is { } tl && tl.R == 246 && tl.G == 237 && tl.B == 235,
                             "apply: TextureLighting carries the donor's value (the dark-skin default trap)");
                         Check(Math.Abs(npc.Weight - 42f) < 0.001, "apply: Weight carries");
+                        Check(npc.Configuration.Flags.HasFlag(NpcConfiguration.Flag.Female),
+                            "apply: the GENDER flag matches the donor (headparts/facegen are gender-fitted)");
                         Check(npc.HairColor is { IsNull: false } hcl && hcl.FormKey.ModKey == patchKey,
                             "apply: HairColor remapped to the internalized CLFM");
 
@@ -215,6 +254,70 @@ public static class NpcCopyProbe
                     Check(File.Exists(Path.Combine(outDir, $@"meshes\actors\character\facegendata\facegeom\VivCloneP.esp\{newId}.nif")),
                         "clone: facegeom renamed to the CLONE's FormKey path (folder = the patch)");
                 }
+            }
+
+            // ================= 2b. EXTEND RE-RUN — dedupe the already-internalized subtree + precedence warning =================
+            {
+                var o = svc.CopyNpcAppearance(donorNpcFk.ToString(), "Donor.esp", null,
+                                              target2Fk.ToString(), null, null, null, "SaelaFace");
+                Check(o.Success, $"re-run: apply onto a SECOND target into the SAME patch succeeds ({o.Error})");
+                Check(o.Success && o.Reused.Count == 4 && o.Internalized.Count == 0,
+                    $"re-run: the donor subtree is REUSED, not re-copied (reused {o.Reused.Count}, internalized {o.Internalized.Count})");
+                if (o.Success)
+                {
+                    using var pd = OpenDisposable(o.OutPath!, out var patch);
+                    Check(patch.HeadParts.Count(h => h.EditorID == "VivHairHP") == 1,
+                        "re-run: exactly ONE 'VivHairHP' in the patch — no duplicate EditorIDs to break block-name mapping");
+                    var npc2 = patch.Npcs.FirstOrDefault(n => n.FormKey == target2Fk);
+                    Check(npc2 is not null && npc2.HeadParts.Count == 1 && npc2.HeadParts[0].FormKey == patch.HeadParts.First(h => h.EditorID == "VivHairHP").FormKey,
+                        "re-run: the second target is wired to the REUSED copy");
+                }
+                Check(o.Success && o.Assets is { } ca && ca.Warnings.Any(w => w.Contains("ALREADY provided")),
+                    "re-run: a contested facegen DESTINATION gets a named precedence warning (file precedence is its own system)");
+            }
+
+            // ================= 2c. BASE-GAME donor — never donor-bound (the vanilla-look transplant lane) =================
+            {
+                var o = svc.CopyNpcAppearance(vanNpcFk.ToString(), null, null,
+                                              targetFk.ToString(), null, null, "VanFace", null);
+                Check(o.Success, $"base-game donor: succeeds — no nonsense custom-race refusal ({o.Error})");
+                Check(o.Success && o.DonorIsBaseGame && o.Internalized.Count == 0,
+                    "base-game donor: nothing internalized (its records resolve everywhere), said plainly");
+                Check(o.Success && o.Masters.Contains("Skyrim.esm", StringComparer.OrdinalIgnoreCase),
+                    "base-game donor: the links stay links — Skyrim.esm mastered normally");
+            }
+
+            // ================= 2d. clone refusals the fold added =================
+            {
+                var req = svc.CopyNpcAppearance(classedNpcFk.ToString(), "Donor.esp", null,
+                                                null, "VivClassedClone", null, "VivClassedP", null);
+                Check(!req.Success && req.Error!.Contains("REQUIRED") && req.Error!.Contains("apply lane"),
+                    "clone: a donor-internal REQUIRED link (Class) REFUSES loud — never silently nulled");
+                var tpl = svc.CopyNpcAppearance(templatedNpcFk.ToString(), "Donor.esp", null,
+                                                targetFk.ToString(), null, null, null, null);
+                Check(!tpl.Success && tpl.Error!.Contains("template"),
+                    "refusal: a Traits-TEMPLATED donor is named (its own record carries no appearance)");
+                var dup = svc.CopyNpcAppearance(donorNpcFk.ToString(), "Donor.esp", null,
+                                                null, "VivClone", null, null, "VivCloneP");
+                Check(!dup.Success && dup.Error!.Contains("already contains an NPC"),
+                    "clone re-run: minting the same EditorID into the same patch is refused");
+            }
+
+            // ================= 2e. the NIF texture scanner — boundary + multi-match (review findings) =================
+            {
+                static byte[] Ascii(string s) => System.Text.Encoding.ASCII.GetBytes(s);
+                var two = Ascii("junk\0textures\\a\\one.dds\0mid\0textures\\b\\two.dds\0");
+                var got = NpcAppearanceAssets.ScrapeNifTexturePaths(two);
+                Check(got.Count == 2 && got.Contains(@"textures\a\one.dds") && got.Contains(@"textures\b\two.dds"),
+                    $"scanner: two paths in one buffer both found (got {string.Join(" | ", got)})");
+                var glued = Ascii("textures\\a\\one.dds_textures\\b\\two.dds\0");     // one printable run, two paths
+                var got2 = NpcAppearanceAssets.ScrapeNifTexturePaths(glued);
+                Check(got2.Count == 2 && got2[0] == @"textures\a\one.dds" && got2[1] == @"textures\b\two.dds",
+                    "scanner: FIRST-.dds match — adjacent paths in one run never glue into garbage");
+                var longRun = Ascii(new string('x', 300) + "textures\\c\\three.dds\0"); // path right after a capped printable run
+                var got3 = NpcAppearanceAssets.ScrapeNifTexturePaths(longRun);
+                Check(got3.Count == 1 && got3[0] == @"textures\c\three.dds",
+                    "scanner: a path starting at a capped-run boundary is not skipped");
             }
 
             // ================= 3. Q3 refusals =================

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1876,6 +1876,192 @@ public sealed class LoadOrderService : IDisposable
         }
     }
 
+    /// <summary>The composed standalone-NPC-copy verb (housecarl_copy_npc_appearance — capability chain Stage 3).
+    /// Deep-copies a donor NPC's appearance-record subtree into a houseCARL patch under NEW FormKeys (Duplicate +
+    /// RemapLinks — the RemapEngine mechanism, so every field carries by construction: HDPT.Parts morph refs,
+    /// TextureLighting, tints), preserves headpart EditorIDs (facegeom block-name identity), renames the facegen
+    /// pair to the new key's path, and carries the donor-only textures/meshes the records + geom reference.
+    /// TWO TARGET MODES: <paramref name="targetFormid"/> dresses an EXISTING NPC (appearance fields copied onto an
+    /// override); <paramref name="newEditorid"/> mints a full standalone CLONE (donor NPC duplicated; every remaining
+    /// donor-internal non-appearance link stripped + reported by name — Q3, the clone is donor-free LOUDLY).
+    /// The donor may be ACTIVE (read via the load-order winner) or sit in a plugin FILE houseCARL locates across
+    /// enabled/disabled mod folders (<paramref name="sourcePlugin"/> — the read_plugin_file lane, stamped
+    /// out-of-load-order in the outcome). Never touches the donor; output = folder-per-patch or into= extend.</summary>
+    public NpcCopyOutcome CopyNpcAppearance(
+        string sourceFormid, string? sourcePlugin, string? sourceMod,
+        string? targetFormid, string? newEditorid, string? newName,
+        string? patchName, string? into)
+    {
+        // ---- 0. argument shape (Q3 — exactly one target mode) ----
+        FormKey donorFk;
+        try { donorFk = FormKey.Factory((sourceFormid ?? "").Trim()); }
+        catch (Exception ex) { return NpcCopyOutcome.Fail($"bad source formid '{sourceFormid}': {ex.Message}. Expected 'XXXXXX:Plugin.esp', e.g. '000D62:Vivace.esp'."); }
+
+        bool apply = !string.IsNullOrWhiteSpace(targetFormid);
+        bool clone = !string.IsNullOrWhiteSpace(newEditorid);
+        if (apply == clone)
+            return NpcCopyOutcome.Fail(
+                "pass EXACTLY ONE target: target_formid= (copy the donor's appearance onto an EXISTING NPC) or " +
+                "new_editorid= (mint a full standalone CLONE of the donor as a new NPC).");
+        FormKey targetFk = default;
+        if (apply)
+        {
+            try { targetFk = FormKey.Factory(targetFormid!.Trim()); }
+            catch (Exception ex) { return NpcCopyOutcome.Fail($"bad target formid '{targetFormid}': {ex.Message}."); }
+        }
+
+        lock (_writeGate)
+        {
+            var resolver = Resolver;
+            var view = resolver.Capture();
+            if (!Directory.Exists(_modsDir))
+                return NpcCopyOutcome.Fail($"cannot write: ModsDir '{_modsDir}' does not exist. Check HouseCarl:ModsDir.");
+
+            using var session = resolver.OpenSession();
+
+            // ---- 1. read the donor NPC — the ACTIVE lane (load-order winner) or the FILE lane (any plugin on disk,
+            //         disabled included — the read_plugin_file machinery; results stamped out-of-load-order). ----
+            INpcGetter donorNpc;
+            NpcAppearanceCopy.DonorFetch fetch;
+            var donorMods = new HashSet<ModKey> { donorFk.ModKey };
+            string donorReadFrom; bool outOfLoadOrder;
+            ISkyrimModGetter? donorOverlay = null;    // file lane only — disposed in finally
+            string? donorFilePath = null;             // file lane: the located file; active lane: the winner's path (for the donor-disk asset fallback)
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(sourcePlugin))
+                {
+                    string modsDir, dataDir, overwriteDir, profileDir;
+                    lock (_gate) { EnsurePathsDerived(); modsDir = _modsDir; dataDir = _dataDir; overwriteDir = _overwriteDir; profileDir = _profileDir; }
+                    var comp = Mo2LoadOrder.ReadComposition(profileDir);
+                    var sp = sourcePlugin.Trim();
+                    if (LooksLikePath(sp))
+                    {
+                        if (!File.Exists(sp)) return NpcCopyOutcome.Fail($"no file at path '{sp}'.");
+                        donorFilePath = Path.GetFullPath(sp); donorReadFrom = $"direct path '{donorFilePath}'";
+                    }
+                    else if (!string.IsNullOrWhiteSpace(sourceMod))
+                    {
+                        var cand = Path.Combine(modsDir, sourceMod.Trim(), Path.GetFileName(sp));
+                        if (!File.Exists(cand)) return NpcCopyOutcome.Fail($"mod folder '{sourceMod.Trim()}' under ModsDir does not provide '{Path.GetFileName(sp)}'.");
+                        donorFilePath = cand; donorReadFrom = $"file '{sp}' in mod '{sourceMod.Trim()}'";
+                    }
+                    else
+                    {
+                        var hits = Mo2LoadOrder.LocatePlugin(comp, modsDir, dataDir, overwriteDir, sp);
+                        if (hits.Count == 0)
+                            return NpcCopyOutcome.Fail($"'{sp}' is in no mod folder (enabled or disabled), the overwrite folder, or the game Data folder. Check the filename, pass an absolute path, or the exact folder via source_mod=.");
+                        if (hits.Count > 1)
+                            return NpcCopyOutcome.Fail($"'{sp}' exists in {hits.Count} places ({string.Join(" | ", hits.Select(h => h.Where))}) — pass source_mod= to pick one.");
+                        donorFilePath = hits[0].Path; donorReadFrom = $"file '{sp}' ({hits[0].Where}{(hits[0].Enabled ? "" : ", DISABLED")})";
+                    }
+                    outOfLoadOrder = true;
+                    try { donorMods.Add(ModKey.FromFileName(Path.GetFileName(donorFilePath))); } catch { /* a direct path with an odd name — donorFk.ModKey still governs */ }
+
+                    donorOverlay = LoadOrderResolver.OpenOverlay(donorFilePath, string.IsNullOrEmpty(dataDir) ? null : dataDir);
+                    var index = new Dictionary<FormKey, IMajorRecordGetter>();
+                    foreach (var r in donorOverlay.EnumerateMajorRecords()) index[r.FormKey] = r;
+                    if (!index.TryGetValue(donorFk, out var donorBody))
+                        return NpcCopyOutcome.Fail($"file '{Path.GetFileName(donorFilePath)}' does not define or override {donorFk}. This reads the FILE's own records (out of load order); for an active donor omit source_plugin=.");
+                    if (donorBody is not INpcGetter fileNpc)
+                        return NpcCopyOutcome.Fail($"{donorFk} in '{Path.GetFileName(donorFilePath)}' is a {RecordNaming.StripOverlay(donorBody.GetType().Name)}, not an NPC.");
+                    donorNpc = fileNpc;
+                    fetch = fk2 => index.TryGetValue(fk2, out var b) ? b : null;
+                }
+                else
+                {
+                    var winner = view.ResolveWinner(donorFk);
+                    if (winner is null)
+                        return NpcCopyOutcome.Fail(
+                            $"{donorFk} is not present in the active load order. If the donor plugin is DISABLED, pass source_plugin= " +
+                            "(its filename — houseCARL locates it across enabled AND disabled mod folders) to read it out of load order.");
+                    var body = view.GetRecord(session, winner.Value.WinnerPlugin, donorFk);
+                    if (body is null)
+                        return NpcCopyOutcome.Fail($"could not fetch {donorFk} from its winner '{winner.Value.WinnerPlugin}'.");
+                    if (body is not INpcGetter activeNpc)
+                        return NpcCopyOutcome.Fail($"{donorFk} is a {RecordNaming.StripOverlay(body.GetType().Name)}, not an NPC.");
+                    donorNpc = activeNpc;
+                    donorReadFrom = $"active load order (winner: {winner.Value.WinnerPlugin})";
+                    outOfLoadOrder = false;
+                    donorFilePath = view.PluginPath(donorFk.ModKey.FileName.ToString());
+                    fetch = fk2 =>
+                    {
+                        var w2 = view.ResolveWinner(fk2);
+                        return w2 is null ? null : view.GetRecord(session, w2.Value.WinnerPlugin, fk2);
+                    };
+                }
+
+                NpcAppearanceCopy.ActiveResolve active = fk2 => view.ResolveWinner(fk2) is not null;
+
+                // ---- 2. the appearance closure (generic link walk; loud refusals — custom race, runaway, unreadable) ----
+                var closure = NpcAppearanceCopy.CollectAppearanceClosure(donorNpc, donorMods, fetch, active);
+                if (!closure.Success) return NpcCopyOutcome.Fail(closure.Error!);
+
+                // ---- 3. output patch (folder-per-patch or into= extend — the record lane's resolver + ownership gate) ----
+                string outPath; bool extend, created;
+                var defaultStem = clone ? newEditorid!.Trim() : "houseCARL_NpcCopy";
+                try { outPath = ResolveOutputPath(patchName ?? (into is null ? defaultStem : null), into, out extend, out created); }
+                catch (Exception ex) { return NpcCopyOutcome.Fail(ex.Message); }
+                var patchFileName = Path.GetFileName(outPath);
+                var patchModKey = ModKey.FromFileName(patchFileName);
+
+                // ---- 4. apply lane: resolve the ACTIVE target body up front (an in-patch target — its formid names
+                //         the patch itself — is resolved inside the build, off the opened patch mod). ----
+                INpcGetter? targetActiveBody = null;
+                if (apply && targetFk.ModKey != patchModKey)
+                {
+                    if (donorMods.Contains(targetFk.ModKey))
+                        return NpcCopyOutcome.Fail("the target NPC lives in the DONOR's plugin — that cannot be standalone-ized onto itself; pick a target outside the donor (or use new_editorid= to clone).");
+                    var tw = view.ResolveWinner(targetFk);
+                    if (tw is null)
+                        return NpcCopyOutcome.Fail(
+                            $"target {targetFk} is not present in the active load order. The target must be an ACTIVE NPC " +
+                            "(enable its plugin in MO2), or a record in the patch itself (into= that patch and use its formid).");
+                    var tb = view.GetRecord(session, tw.Value.WinnerPlugin, targetFk);
+                    if (tb is not INpcGetter tnpc)
+                        return NpcCopyOutcome.Fail($"target {targetFk} is a {RecordNaming.StripOverlay(tb?.GetType().Name ?? "<unfetchable>")}, not an NPC.");
+                    targetActiveBody = tnpc;
+                }
+
+                // ---- 5. build + serialize (core — Duplicate/RemapLinks, mode lane, multi-master write) ----
+                var outcome = NpcAppearanceCopy.BuildAndWrite(
+                    donorNpc, donorMods, closure,
+                    clone, newEditorid, newName,
+                    targetFk, targetActiveBody,
+                    fk2 => view.ResolveWinner(fk2) is not null,
+                    outPath, extend,
+                    pf => { session.ReleaseOverlay(pf); return session.AllMastersExcept(pf); },   // active-patch self-lock fix
+                    donorReadFrom, outOfLoadOrder);
+                if (!outcome.Success)
+                {
+                    if (created) RemoveFolderCreatedThisCall(outPath);   // hunt F4: a refused copy leaves no orphan
+                    return outcome;
+                }
+
+                // ---- 6. asset carry (facegen rename + donor-only textures/meshes) — best-effort + reported (Q3) ----
+                NpcAssetOutcome assets;
+                try
+                {
+                    AssetResolver assetResolver;
+                    lock (_gate) { assetResolver = Assets; }
+                    var assetView = assetResolver.Capture();
+                    var donorDisk = donorFilePath is not null ? NpcAppearanceAssets.DonorDisk.For(donorFilePath) : null;
+                    var donorFolderName = donorFilePath is not null ? Path.GetFileName(Path.GetDirectoryName(donorFilePath)) : null;
+                    assets = NpcAppearanceAssets.CarryAll(
+                        donorFk, outcome.NewNpcKey, closure.ToInternalize.Select(i => i.Body).ToList(),
+                        assetView, donorDisk, donorFolderName, Path.GetDirectoryName(outPath)!);
+                }
+                catch (Exception ex)
+                {
+                    assets = new NpcAssetOutcome(Array.Empty<CarriedAsset>(), Array.Empty<string>(), Array.Empty<string>(),
+                        new[] { $"asset carry skipped — the asset layer could not be built ({ex.Message}); carry the facegen pair with housecarl_place_asset and verify in-game." }, false, false);
+                }
+                return outcome with { Assets = assets };
+            }
+            finally { (donorOverlay as IDisposable)?.Dispose(); }
+        }
+    }
+
     /// <summary>Create a BRAND-NEW record (housecarl_create_record) — the net-new authoring capability, the sibling of
     /// <see cref="ApplyEdits"/>. Resolves <paramref name="recordType"/> (catalog name or 4-char signature) to ONE concrete
     /// catalog name (unknown/ambiguous → Q3), maps the field <paramref name="operations"/> to core <see cref="WriteRequest"/>s

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1,4 +1,4 @@
-﻿using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Records;
 using Mutagen.Bethesda.Skyrim;
 
@@ -7,40 +7,40 @@ namespace HousecarlMcp;
 /// <summary>
 /// Owns the load-order resolver's lifecycle for the server and is the single place the tools reach the proven
 /// cores (<see cref="LoadOrderResolver"/> + <see cref="ReadEngine"/>; writes join in Beat C). This is the
-/// server-side half of the Â§8.4 cleave: tools call clean methods here; here calls the core's public API.
+/// server-side half of the §8.4 cleave: tools call clean methods here; here calls the core's public API.
 ///
-/// â€¢ LAZY build â€” the ~10s/180MB index build is deferred to first use, so startup + tools/list are instant.
-/// â€¢ FRESH â€” each query runs the cheap mtime stat-sweep (<see cref="LoadOrderResolver.RefreshIfStale"/>);
+/// • LAZY build — the ~10s/180MB index build is deferred to first use, so startup + tools/list are instant.
+/// • FRESH — each query runs the cheap mtime stat-sweep (<see cref="LoadOrderResolver.RefreshIfStale"/>);
 ///   a mid-session plugin edit auto-rebuilds (~11s), no restart needed.
-/// â€¢ THREAD-SAFE â€” the HTTP server is concurrent; build + refresh are serialized on one gate.
+/// • THREAD-SAFE — the HTTP server is concurrent; build + refresh are serialized on one gate.
 ///
-/// ORDER is the TRUE active order (Â§8.5), read statically from the MO2 profile's loadorder.txt + modlist.txt +
-/// plugins.txt via <see cref="Mo2LoadOrder"/> â€” masters first â†’ highest-priority winner last, the ~110 duplicate-name
+/// ORDER is the TRUE active order (§8.5), read statically from the MO2 profile's loadorder.txt + modlist.txt +
+/// plugins.txt via <see cref="Mo2LoadOrder"/> — masters first → highest-priority winner last, the ~110 duplicate-name
 /// plugins resolved by mod priority. No USVFS, no live MO2 state (both failed in the legacy build); the server reads
 /// REAL plugin paths and runs standalone. Freshness is AUTONOMOUS + lazy: the cheap mtime sweep re-reads the profile on
-/// the NEXT tool call whenever the user's MO2 edits changed it â€” no restart, no manual refresh step. See memory
+/// the NEXT tool call whenever the user's MO2 edits changed it — no restart, no manual refresh step. See memory
 /// project_mo2_load_order_resolution.
 /// </summary>
 public sealed class LoadOrderService : IDisposable
 {
-    // INSTANCE mode (the product default): one configured path â€” the MO2 instance folder â€” from which ProfileDir/ModsDir/
+    // INSTANCE mode (the product default): one configured path — the MO2 instance folder — from which ProfileDir/ModsDir/
     // DataDir + the active profile are DERIVED (via Mo2Instance, reading ModOrganizer.ini), and a profile SWITCH is picked
     // up on the next tool call. EXPLICIT mode (dev / non-portable override): the three paths are configured directly and
-    // _instanceDir stays null (no ini watch). UNCONFIGURED: neither was set â€” the server still BOOTS; every tool returns the
+    // _instanceDir stays null (no ini watch). UNCONFIGURED: neither was set — the server still BOOTS; every tool returns the
     // trained prompt (so houseCARL asks the user for the path) until housecarl_set_mo2_instance is called.
     string? _instanceDir;                          // INSTANCE-mode source of truth; null in explicit/unconfigured mode
     string _dataDir;                               // DERIVED (instance mode) or configured (explicit); mutable for a live profile switch
     string _modsDir;
     string _profileDir;
     string _profileName;                           // the active profile (instance mode: from selected_profile)
-    string _overwriteDir = "";                     // MO2's overwrite layer (instance mode: derived; explicit mode: none) â€” hunt F9
-    bool _configured;                              // false â‡’ tools return the trained prompt instead of resolving
+    string _overwriteDir = "";                     // MO2's overwrite layer (instance mode: derived; explicit mode: none) — hunt F9
+    bool _configured;                              // false ⇒ tools return the trained prompt instead of resolving
     readonly UserConfigStore _store;               // the sole owner of houseCARL.user.json (MO2 instance dir + tool paths)
     readonly int _maxPlugins;
     readonly object _gate = new();
-    // Serializes the WHOLE resolveâ†’stageâ†’commit of every .esp write (2026-06-12 hunt F2): the MCP SDK dispatches tool
+    // Serializes the WHOLE resolve→stage→commit of every .esp write (2026-06-12 hunt F2): the MCP SDK dispatches tool
     // calls CONCURRENTLY, and without this two same-name writes could allocate the same folder (UniqueStem TOCTOU) and
-    // cross-commit through the fixed .housecarl-tmp staging path â€” R1's success message shipping R2's bytes. Writes are
+    // cross-commit through the fixed .housecarl-tmp staging path — R1's success message shipping R2's bytes. Writes are
     // seconds-long and rare; serializing them is correct (accuracy over perf). SetInstance takes it too, so an instance
     // switch can never tear a write in flight across instances. Lock order where both are held: _writeGate THEN _gate.
     readonly object _writeGate = new();
@@ -48,16 +48,16 @@ public sealed class LoadOrderService : IDisposable
     CorpusRulebook? _rulebook;
     IReadOnlyList<string> _orderWarnings = Array.Empty<string>();
     // facegen-diagnostics Phase 2: the VFS-aware asset resolver (housecarl_asset_status), built LAZILY and only on an
-    // ASSET query â€” a pure-record session never pays for it â€” and kept fresh the same way _resolver is. Dropped +
+    // ASSET query — a pure-record session never pays for it — and kept fresh the same way _resolver is. Dropped +
     // rebuilt whenever the active profile changes (InvalidateAssetResolver in ReResolve / SetInstance): an enabled-mod
     // toggle changes the loose roots and the active-archive set, not just the plugin order. CHEAP to build (it reads BSA
     // file-TABLES, not the ~10s/180MB record index), so a full rebuild on a profile change is fine. See memory
     // project_facegen_diagnostics_resolver.
     AssetResolver? _assetResolver;
-    IReadOnlyList<string> _assetWarnings = Array.Empty<string>();   // discovery warnings from the asset build (e.g. a Skyrim.ini we couldn't find â†’ base BSAs unscanned)
+    IReadOnlyList<string> _assetWarnings = Array.Empty<string>();   // discovery warnings from the asset build (e.g. a Skyrim.ini we couldn't find → base BSAs unscanned)
     // Freshness baselines are the files' LAST-SEEN MTIMES compared by VALUE (!=), the same model the resolver itself
-    // uses â€” NOT wall-clock stamps compared by ORDER (2026-06-12 hunt F8: `mtime > builtUtc` was blind to an mtime
-    // REGRESSION, so MO2's "Restore Backup" â€” which restores a profile file with an OLDER mtime â€” stayed invisible
+    // uses — NOT wall-clock stamps compared by ORDER (2026-06-12 hunt F8: `mtime > builtUtc` was blind to an mtime
+    // REGRESSION, so MO2's "Restore Backup" — which restores a profile file with an OLDER mtime — stayed invisible
     // for the process lifetime). Each baseline is statted BEFORE the read it baselines (TOCTOU: a write landing
     // during/after the read shows as a changed mtime on the next check, never absorbed).
     DateTime[] _profileMtimes = new DateTime[ProfileFileNames.Length];   // per ProfileFileNames, recorded at each order build
@@ -79,7 +79,7 @@ public sealed class LoadOrderService : IDisposable
     }
 
     /// <summary>INSTANCE mode (product default): derive the load-order roots + active profile from ONE MO2 instance folder
-    /// (lazily, on the first build). A null/blank <paramref name="instanceDir"/> â‡’ UNCONFIGURED (boots; tools prompt for the
+    /// (lazily, on the first build). A null/blank <paramref name="instanceDir"/> ⇒ UNCONFIGURED (boots; tools prompt for the
     /// path). The instance is re-read on a profile switch, so a mid-session switch is followed.</summary>
     public static LoadOrderService WithInstance(string? instanceDir, int maxPlugins, UserConfigStore store)
         => new(string.IsNullOrWhiteSpace(instanceDir) ? null : instanceDir.Trim(),
@@ -91,7 +91,7 @@ public sealed class LoadOrderService : IDisposable
         => new(null, dataDir, modsDir, profileDir, configured: true, maxPlugins, store);
 
     /// <summary>TEST SEAM (the harness' CI regression guards only): wrap a PREBUILT resolver so a guard can drive
-    /// the service-layer query logic (CrossQuery's scan loop) on synthetic plugins â€” no MO2 profile, no user config
+    /// the service-layer query logic (CrossQuery's scan loop) on synthetic plugins — no MO2 profile, no user config
     /// on disk. Explicit-mode freshness checks no-op (no ini, empty profile dir); the caller owns the resolver's
     /// lifetime. Never used by the product.</summary>
     internal static LoadOrderService ForGuard(LoadOrderResolver resolver, UserConfigStore store)
@@ -101,11 +101,11 @@ public sealed class LoadOrderService : IDisposable
         return svc;
     }
 
-    /// <summary>Non-fatal warnings from the last order build (Q3) â€” e.g. a plugin the load order lists that no enabled
+    /// <summary>Non-fatal warnings from the last order build (Q3) — e.g. a plugin the load order lists that no enabled
     /// mod provides (stale profile files). Surfaced, never swallowed. Empty until the resolver first builds.</summary>
     public IReadOnlyList<string> OrderWarnings => _orderWarnings;
 
-    /// <summary>The write pre-flight rulebook (corpus.json), loaded once. CorpusPath is set absolute at startup (Â§8.4),
+    /// <summary>The write pre-flight rulebook (corpus.json), loaded once. CorpusPath is set absolute at startup (§8.4),
     /// so this resolves regardless of the MO2-launched process's CWD.</summary>
     CorpusRulebook Rulebook => _rulebook ??= CorpusRulebook.Load();
 
@@ -117,12 +117,12 @@ public sealed class LoadOrderService : IDisposable
         {
             lock (_gate)
             {
-                if (!_configured) throw NotConfigured();          // fresh install / empty config â†’ every tool prompts for the MO2 path
+                if (!_configured) throw NotConfigured();          // fresh install / empty config → every tool prompts for the MO2 path
                 if (_resolver is null)
                 {
                     EnsurePathsDerived();                         // instance mode: derive ProfileDir/ModsDir/DataDir + active profile from ModOrganizer.ini
-                    // Â§8.5: the TRUE active order, read statically from the MO2 profile (loadorder.txt + modlist.txt +
-                    // plugins.txt) â€” no VFS, no live MO2 state. See HousecarlCore.Mo2LoadOrder + memory
+                    // §8.5: the TRUE active order, read statically from the MO2 profile (loadorder.txt + modlist.txt +
+                    // plugins.txt) — no VFS, no live MO2 state. See HousecarlCore.Mo2LoadOrder + memory
                     // project_mo2_load_order_resolution.
                     var profileMtimes = StatProfileFiles();      // stat BEFORE the read (TOCTOU): a profile write during the build is caught next call, not missed
                     var order = Mo2LoadOrder.Build(_profileDir, _modsDir, _dataDir, _overwriteDir);
@@ -140,15 +140,15 @@ public sealed class LoadOrderService : IDisposable
                 }
                 else if (Monitor.TryEnter(_writeGate))
                 {
-                    // Lazy freshness, run on each tool call once the snapshot exists â€” but DEFERRED while a WRITE is
-                    // in flight (PR #51 review note): a refresh here can rebuild the index â€” transiently mmap-opening
+                    // Lazy freshness, run on each tool call once the snapshot exists — but DEFERRED while a WRITE is
+                    // in flight (PR #51 review note): a refresh here can rebuild the index — transiently mmap-opening
                     // every plugin INCLUDING the file a concurrent write is serializing (the PR #24 "no mapped handle
-                    // on the target survives the serialize" invariant, breached from the read path) â€” and dispose-swap
+                    // on the target survives the serialize" invariant, breached from the read path) — and dispose-swap
                     // the resolver that write captured. TryEnter probes the write gate WITHOUT blocking: it cannot
-                    // deadlock (no blocking _gateâ†’_writeGate wait â€” the established blocking order stays _writeGate
+                    // deadlock (no blocking _gate→_writeGate wait — the established blocking order stays _writeGate
                     // THEN _gate), and Monitor reentrancy keeps the write's OWN entry refresh working (it holds
                     // _writeGate, so its TryEnter succeeds). A skipped refresh serves the last good snapshot and
-                    // re-checks on the next call â€” the freshness contract is per-call lazy, so deferral behind a
+                    // re-checks on the next call — the freshness contract is per-call lazy, so deferral behind a
                     // seconds-long write is honest staleness, never wrongness (freshness-capture-guard arm 5).
                     try
                     {
@@ -164,11 +164,11 @@ public sealed class LoadOrderService : IDisposable
 
     // ---- facegen-diagnostics Phase 2: VFS asset resolution (housecarl_asset_status) ----------------------
 
-    /// <summary>The VFS-aware asset resolver, built on first ASSET query and kept fresh on every subsequent one â€” the
+    /// <summary>The VFS-aware asset resolver, built on first ASSET query and kept fresh on every subsequent one — the
     /// asset twin of <see cref="Resolver"/>. Runs the SAME profile-freshness driver (a switch / toggle / re-sort drops it
-    /// via <see cref="ReResolve"/> â†’ <see cref="InvalidateAssetResolver"/>, so it rebuilds against the new profile), then
+    /// via <see cref="ReResolve"/> → <see cref="InvalidateAssetResolver"/>, so it rebuilds against the new profile), then
     /// its own cheap BSA-byte / warmed-loose-subtree content sweep. Crucially it does NOT force the heavy
-    /// <see cref="Resolver"/> build â€” an asset-only query stays cheap (the freshness driver is null-safe for _resolver).
+    /// <see cref="Resolver"/> build — an asset-only query stays cheap (the freshness driver is null-safe for _resolver).
     /// The getter takes <see cref="_gate"/> (reentrant), so callers need not pre-hold it.</summary>
     AssetResolver Assets
     {
@@ -176,9 +176,9 @@ public sealed class LoadOrderService : IDisposable
         {
             lock (_gate)
             {
-                if (!_configured) throw NotConfigured();           // fresh install â†’ the tool returns the trained prompt instead
+                if (!_configured) throw NotConfigured();           // fresh install → the tool returns the trained prompt instead
                 EnsurePathsDerived();                              // derive the roots on first use (instance mode)
-                // Profile freshness (switch / toggle / re-sort) â€” shared with the record path, deferred behind an in-flight
+                // Profile freshness (switch / toggle / re-sort) — shared with the record path, deferred behind an in-flight
                 // write like the record refresh. ReResolve is null-safe for _resolver, so this FOLLOWS a profile change
                 // WITHOUT building the record index, and drops _assetResolver when the active set changed.
                 if (Monitor.TryEnter(_writeGate))
@@ -201,19 +201,19 @@ public sealed class LoadOrderService : IDisposable
     }
 
     /// <summary>Build the asset resolver from the current roots: discover the active BSAs (co-name + Skyrim.ini base
-    /// archives, VFS-resolved + ranked â€” <see cref="ArchiveDiscovery"/>) and read the enabled-mod priority list, both
+    /// archives, VFS-resolved + ranked — <see cref="ArchiveDiscovery"/>) and read the enabled-mod priority list, both
     /// from the same cheap static profile read the record path uses. The gamePath (for the game-dir Skyrim.ini fallback)
     /// is DataDir's parent (DataDir = gamePath\Data). Caller holds <see cref="_gate"/>.</summary>
     AssetResolver BuildAssetResolverLocked()
     {
-        var comp = Mo2LoadOrder.ReadComposition(_profileDir);                       // EnabledMods (priority) â€” cheap text parse
+        var comp = Mo2LoadOrder.ReadComposition(_profileDir);                       // EnabledMods (priority) — cheap text parse
         var gamePath = _dataDir.Length > 0 ? Path.GetDirectoryName(_dataDir.TrimEnd('\\', '/')) ?? "" : "";
         var discovery = ArchiveDiscovery.Discover(_profileDir, _modsDir, _dataDir, _overwriteDir, gamePath);
         _assetWarnings = discovery.Warnings;
         return AssetResolver.Build(_overwriteDir, _modsDir, _dataDir, comp.EnabledMods, discovery.Archives);
     }
 
-    /// <summary>Drop the asset resolver so the next asset query rebuilds it â€” the active-mod/archive SET changed
+    /// <summary>Drop the asset resolver so the next asset query rebuilds it — the active-mod/archive SET changed
     /// (AssetResolver.RefreshIfStale only catches a BSA's bytes / a warmed subtree, not a membership change). No-op when
     /// none is built (a pure-record session never pays for the asset resolver). Caller holds <see cref="_gate"/>.</summary>
     void InvalidateAssetResolver() { _assetResolver?.Dispose(); _assetResolver = null; }
@@ -233,7 +233,7 @@ public sealed class LoadOrderService : IDisposable
             {
                 var p = (raw ?? "").Trim();
                 try { results.Add(new AssetPathResult(p, view.Resolve(p), null)); }
-                catch (ArgumentException ex) { results.Add(new AssetPathResult(p, null, ex.Message)); }   // bad path â†’ per-path Q3 note
+                catch (ArgumentException ex) { results.Add(new AssetPathResult(p, null, ex.Message)); }   // bad path → per-path Q3 note
             }
             return new AssetStatusData(results, view.BsaFailures, view.ReadIncomplete, _assetWarnings, _profileName);
         }
@@ -243,19 +243,19 @@ public sealed class LoadOrderService : IDisposable
     //      each plugin DLL's STATICALLY declared manifest (tier C). Read-only; reuses the asset VFS + the PE reader. ----
 
     /// <summary>Inventory the SKSE-plugin layer as the ACTIVE load order resolves it (housecarl_skse_inventory): the FULL
-    /// DEPTH of Data\SKSE\Plugins â€” every <c>.dll</c> plugin and every <c>.ini</c>/<c>.toml</c>/<c>.json</c>/<c>.yaml</c>
-    /// config at any depth â€” with the mod that WINS the VFS for each (tier A), and for every plugin DLL the statically-
-    /// declared manifest â€” name/author/version, Address Library vs version-LOCKED, target runtimes, XSE floor â€” via
+    /// DEPTH of Data\SKSE\Plugins — every <c>.dll</c> plugin and every <c>.ini</c>/<c>.toml</c>/<c>.json</c>/<c>.yaml</c>
+    /// config at any depth — with the mod that WINS the VFS for each (tier A), and for every plugin DLL the statically-
+    /// declared manifest — name/author/version, Address Library vs version-LOCKED, target runtimes, XSE floor — via
     /// <see cref="SksePluginReader"/> (tier C). Tier E (DLL behavior) stays out of reach by design. FULL VISIBILITY, by
-    /// construction: every file is accounted for â€” configs carry their derived subfolder <see cref="SkseFileEntry.Group"/>
-    /// (the immediate folder under SKSE\Plugins â€” SkyPatcher / DynamicStringDistributor / OStim / â€¦, WHATEVER the modlist
+    /// construction: every file is accounted for — configs carry their derived subfolder <see cref="SkseFileEntry.Group"/>
+    /// (the immediate folder under SKSE\Plugins — SkyPatcher / DynamicStringDistributor / OStim / …, WHATEVER the modlist
     /// ships, never a hardcoded set) so the renderer can group them compactly, and non-config content (animation data etc.)
     /// is counted in <see cref="SkseInventoryData.OtherFileCount"/>, never silently dropped. DLLs keep their SKSE-loader
     /// truth: a subfolder DLL is SEEN but flagged (SKSE scans Data\SKSE\Plugins*.dll top-level only, so it isn't loaded as a
     /// plugin). ONE asset capture pins the whole scan (list + <see cref="AssetView.ReadIncomplete"/> caveat = one build); the
     /// enumerate + resolve + PE reads run OUTSIDE the gate (the captured view is a handle-free immutable snapshot), so an
     /// inventory never serializes other tool calls behind its file I/O. Distributor INIs (SPID <c>*_DISTR</c>, KID
-    /// <c>*_KID</c>) live in Data\ ROOT, not here, and are owned by their authoring skills â€” out of this scope by design.</summary>
+    /// <c>*_KID</c>) live in Data\ ROOT, not here, and are owned by their authoring skills — out of this scope by design.</summary>
     public SkseInventoryData SkseInventory()
     {
         AssetResolver.AssetView view;
@@ -279,7 +279,7 @@ public sealed class LoadOrderService : IDisposable
             var ext = Path.GetExtension(rel).ToLowerInvariant();
             bool isDll = ext is ".dll";
             bool isConfig = ext is ".ini" or ".toml" or ".json" or ".yaml" or ".yml";
-            if (!isDll && !isConfig) { otherFiles++; continue; }  // content/other (.hkx/.txt/.pdb/â€¦) â€” ACCOUNTED FOR, not listed
+            if (!isDll && !isConfig) { otherFiles++; continue; }  // content/other (.hkx/.txt/.pdb/…) — ACCOUNTED FOR, not listed
 
             string group = SkseGroupOf(rel, pre);                 // "" = top-level; else the immediate subfolder (the derived group key)
             var place = view.ResolveForPlacement(rel);
@@ -296,9 +296,9 @@ public sealed class LoadOrderService : IDisposable
                 if (winner is { Kind: AssetKind.Loose, LooseFilePath: { } path })
                     info = SksePluginReader.Read(path);           // the winning loose copy
                 else if (winner is null) note = "no active mod provides this DLL";
-                else note = "provided ONLY inside a BSA â€” the SKSE loader scans loose Data\\SKSE\\Plugins only, so this DLL will not load";
+                else note = "provided ONLY inside a BSA — the SKSE loader scans loose Data\\SKSE\\Plugins only, so this DLL will not load";
                 if (group.Length > 0 && note is null)
-                    note = $"in subfolder '{group}' â€” NOT on SKSE's loader path (scans SKSE\\Plugins\\*.dll top-level only); a bundled/parent-loaded DLL, not a plugin SKSE loads";
+                    note = $"in subfolder '{group}' — NOT on SKSE's loader path (scans SKSE\\Plugins\\*.dll top-level only); a bundled/parent-loaded DLL, not a plugin SKSE loads";
                 dlls.Add(new SkseFileEntry(rel, Path.GetFileName(rel), group, providers, info, note));
             }
             else
@@ -307,10 +307,10 @@ public sealed class LoadOrderService : IDisposable
         return new SkseInventoryData(dlls, configs, otherFiles, view.BsaFailures, view.ReadIncomplete, warnings, profileName);
     }
 
-    /// <summary>The immediate subfolder under SKSE\Plugins a file sits in ("" = directly at top level) â€” the DERIVED,
+    /// <summary>The immediate subfolder under SKSE\Plugins a file sits in ("" = directly at top level) — the DERIVED,
     /// by-construction grouping key for the SKSE inventory. Whatever a modlist ships becomes a group; there is NO hardcoded
     /// framework list (a hand-maintained list would be a cornerstone violation + a Q3 silent-miscategorize for any framework
-    /// not on it). e.g. <c>SKSE\Plugins\SkyPatcher\Weapons\x.ini</c> â†’ "SkyPatcher"; <c>SKSE\Plugins\EngineFixes.toml</c> â†’ "".</summary>
+    /// not on it). e.g. <c>SKSE\Plugins\SkyPatcher\Weapons\x.ini</c> → "SkyPatcher"; <c>SKSE\Plugins\EngineFixes.toml</c> → "".</summary>
     static string SkseGroupOf(string rel, string pre)
     {
         if (!rel.StartsWith(pre, StringComparison.OrdinalIgnoreCase)) return "";
@@ -322,12 +322,12 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>Place one-or-more assets (FaceGen .nif/.dds, or any Data-relative file) into a NEW houseCARL-owned MO2 mod
     /// folder so the CORRECT copy can win the VFS (housecarl_place_asset = one; housecarl_bulk_place_asset = many). For
-    /// each request: resolve its current providers (auto-resolve a source when none was named â€” sole provider used, &gt;1
+    /// each request: resolve its current providers (auto-resolve a source when none was named — sole provider used, &gt;1
     /// refused as ambiguous, 0 refused with guidance), read the source bytes IN PROCESS (a loose file, or a single entry
     /// out of a BSA via native Mutagen), and write them CRASH-ATOMICALLY (<see cref="AtomicFile.WriteAllBytes"/>) under the
     /// owned folder. Originals untouched (we only ever write a fresh / houseCARL-owned folder). NON-DESTRUCTIVE on failure:
     /// a fresh folder that ended up with NOTHING placed is removed (no orphan); a partial one is kept + named. Q3 honesty:
-    /// "wrote it" â‰  "it wins" â€” the fresh mod must be ENABLED + SORTED above the current winner, which the render reports;
+    /// "wrote it" ≠ "it wins" — the fresh mod must be ENABLED + SORTED above the current winner, which the render reports;
     /// this never claims the fix took effect on write. Serialized on the write gate (one placement batch at a time).</summary>
     public PlaceOutcome PlaceAssets(IReadOnlyList<PlaceRequest> requests, string? patchName, string? into)
     {
@@ -336,7 +336,7 @@ public sealed class LoadOrderService : IDisposable
         lock (_writeGate)                                                 // hunt F2 sibling: one placement batch at a time, resolve->stage->commit
         {
             // PRECONDITION: _writeGate is held for the WHOLE method. ResolvePatchModFolder and the `Assets` getter each
-            // take-and-release _gate, so this method straddles two _gate sections â€” safe ONLY because _writeGate excludes
+            // take-and-release _gate, so this method straddles two _gate sections — safe ONLY because _writeGate excludes
             // every other writer and instance-switch throughout, so no profile refresh can land between them. Do not call
             // PlaceOne/Assets here outside this _writeGate hold.
             RiderFolder rf;
@@ -348,7 +348,7 @@ public sealed class LoadOrderService : IDisposable
             try { lock (_gate) { resolver = Assets; warnings = _assetWarnings; } }
             catch (Exception ex)
             {
-                var residue = RemoveOrNameRiderResidue(rf);              // nothing placed yet â†’ a fresh folder is an orphan
+                var residue = RemoveOrNameRiderResidue(rf);              // nothing placed yet → a fresh folder is an orphan
                 return PlaceOutcome.Fail($"could not resolve the asset layer (the MO2 instance may not be readable): {ex.Message}"
                     + (residue is null ? "" : $" The freshly created mod folder was left at '{residue}'."));
             }
@@ -362,7 +362,7 @@ public sealed class LoadOrderService : IDisposable
                 if (r.Placed) placed++;
             }
 
-            // Nothing placed into a FRESH folder â†’ remove the orphan (the .esp F4 / rider H2 principle). A reused into=
+            // Nothing placed into a FRESH folder → remove the orphan (the .esp F4 / rider H2 principle). A reused into=
             // folder (the user owns it) is never touched. A partial fresh folder is kept and its path surfaced.
             string? leftover = placed == 0 ? RemoveOrNameRiderResidue(rf) : null;
             return new PlaceOutcome(results, placed > 0 ? rf.ModFolder : null, warnings, leftover, null);
@@ -371,7 +371,7 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>Place ONE asset: validate the destination rel-path (reject drive-rooted/'..' through the resolver's own
     /// gate, Q3), get the source bytes (explicit source= or auto-resolve), and write them crash-atomically under
-    /// <paramref name="outDir"/>. Reports the CURRENT VFS winner so the caller knows what to sort the fresh mod above â€”
+    /// <paramref name="outDir"/>. Reports the CURRENT VFS winner so the caller knows what to sort the fresh mod above —
     /// the placed file does NOT win until the mod is enabled + sorted (the fresh folder isn't in the active profile yet).
     /// A per-asset failure is a recoverable named error, never a thrown batch abort.</summary>
     PlaceResult PlaceOne(PlaceRequest req, AssetResolver resolver, string outDir)
@@ -380,7 +380,7 @@ public sealed class LoadOrderService : IDisposable
         try { rel = AssetResolver.ValidateRelPath(req.AssetPath); }
         catch (ArgumentException ex) { return PlaceResult.Fail(req.AssetPath, ex.Message); }
 
-        var res = resolver.ResolveForPlacement(rel);                     // rel already validated â€” won't throw
+        var res = resolver.ResolveForPlacement(rel);                     // rel already validated — won't throw
         var winner = res.Sources.Count > 0 ? DescribeSource(res.Sources[0]) : null;
 
         // ---- source bytes: explicit source= wins; else auto-resolve the sole provider ----
@@ -402,7 +402,7 @@ public sealed class LoadOrderService : IDisposable
                     winner);
             if (res.Ambiguous)
                 return PlaceResult.Fail(rel,
-                    $"{res.Sources.Count} sources provide '{rel}' â€” ambiguous, so place_asset will not guess which copy is correct (the skill decides). "
+                    $"{res.Sources.Count} sources provide '{rel}' — ambiguous, so place_asset will not guess which copy is correct (the skill decides). "
                     + $"Pass source= one of: {string.Join("; ", res.Sources.Select(SourceHint))}.",
                     winner);
             var (b, desc, err) = ReadResolvedSource(res.Sources[0]);
@@ -419,19 +419,19 @@ public sealed class LoadOrderService : IDisposable
         }
         catch (Exception ex) { return PlaceResult.Fail(rel, $"could not write '{rel}' into the patch folder: {ex.Message}", winner); }
 
-        // ---- integrity (Q3: THIS run wrote it; the on-disk size matches the source bytes â€” no false success) ----
-        // Belt-and-braces truncation / short-write detection â€” NOT a content hash (the bytes are in-memory and the swap is
+        // ---- integrity (Q3: THIS run wrote it; the on-disk size matches the source bytes — no false success) ----
+        // Belt-and-braces truncation / short-write detection — NOT a content hash (the bytes are in-memory and the swap is
         // atomic, so a same-length corruption isn't a reachable failure of this path; a size mismatch would mean the OS
         // wrote fewer bytes than handed). Defensive, not the primary guarantee (that's AtomicFile's crash-atomic swap).
         long size; try { size = new FileInfo(dest).Length; } catch { size = -1; }
         if (size != bytes.Length)
             return PlaceResult.Fail(rel,
-                $"wrote '{rel}' but its on-disk size ({size}) does not match the {bytes.Length} source byte(s) â€” verify before relying on it.", winner);
+                $"wrote '{rel}' but its on-disk size ({size}) does not match the {bytes.Length} source byte(s) — verify before relying on it.", winner);
         return new PlaceResult(rel, true, bytes.Length, sourceDesc, winner, null);
     }
 
     /// <summary>Read an EXPLICIT source= the caller named. Forms: "&lt;archive.bsa&gt;|&lt;entry&gt;" (a specific BSA
-    /// entry, split on the FIRST '|'); a path ending ".bsa" (the entry is the destination rel-path â€” the FaceGen case,
+    /// entry, split on the FIRST '|'); a path ending ".bsa" (the entry is the destination rel-path — the FaceGen case,
     /// where the entry inside the BSA IS the Data-relative path); any other path (a loose file on disk). Returns the bytes
     /// + a human description, or a NAMED error (Q3) for a missing file / missing entry / unreadable archive.</summary>
     static (byte[]? bytes, string? desc, string? error) ReadExplicitSource(string source, string destRel)
@@ -442,10 +442,10 @@ public sealed class LoadOrderService : IDisposable
             return ReadBsaEntry(source[..bar].Trim().Trim('"'), source[(bar + 1)..].Trim().Trim('"'));
         // Strip surrounding quotes BEFORE the .bsa-vs-loose routing decision (NOT inside each branch): a quoted ".bsa"
         // path ends in '"' not ".bsa", so routing on the raw string would read the WHOLE archive as a loose file and
-        // place it as the asset â€” a silent-wrong placement that passes the size check (Q3). The ONE trim point.
+        // place it as the asset — a silent-wrong placement that passes the size check (Q3). The ONE trim point.
         source = source.Trim('"');
         if (source.EndsWith(".bsa", StringComparison.OrdinalIgnoreCase))
-            return ReadBsaEntry(source, destRel);                        // .bsa with no explicit entry â†’ entry := the destination path
+            return ReadBsaEntry(source, destRel);                        // .bsa with no explicit entry → entry := the destination path
         string path;
         try { path = Path.GetFullPath(source); }
         catch (Exception ex) { return (null, null, $"source '{source}' is not a usable path: {ex.Message}"); }
@@ -469,7 +469,7 @@ public sealed class LoadOrderService : IDisposable
         return ReadBsaEntry(s.ArchivePath!, s.EntryPath);
     }
 
-    /// <summary>Read one entry out of a BSA (native Mutagen, no BSArch, zero handles at rest â€” see
+    /// <summary>Read one entry out of a BSA (native Mutagen, no BSArch, zero handles at rest — see
     /// <see cref="AssetResolver.TryReadArchiveEntry"/>). Named errors (Q3) for a missing archive, an entry not inside it,
     /// or an unreadable archive.</summary>
     static (byte[]? bytes, string? desc, string? error) ReadBsaEntry(string archive, string entry)
@@ -505,14 +505,14 @@ public sealed class LoadOrderService : IDisposable
     }
 
     /// <summary>Diagnostic snapshot for housecarl_load_order_status: the CURRENT enabled/disabled composition (read fresh
-    /// from the profile text files â€” cheap, no folder walk, so a just-toggled mod/plugin shows immediately), plus the
+    /// from the profile text files — cheap, no folder walk, so a just-toggled mod/plugin shows immediately), plus the
     /// resolver's resolved-plugin count + Q3 warnings from its last build, plus a staleness flag if the profile files
-    /// changed since that build (Q3 â€” never present a stale picture as current). Forces the lazy resolver build.</summary>
+    /// changed since that build (Q3 — never present a stale picture as current). Forces the lazy resolver build.</summary>
     public LoadOrderStatusData StatusData()
     {
         // The view AND the per-build fields beside it (warnings / staleness / profile dir) are snapshotted under ONE
         // gate hold (2026-06-12 hunt F6): they used to be read outside the gate after Capture() returned, so a
-        // concurrent freshness rebuild landing in that gap could compose one status line from TWO adjacent builds â€”
+        // concurrent freshness rebuild landing in that gap could compose one status line from TWO adjacent builds —
         // the count from one, the warnings beside it from another. The fresh composition stays OUTSIDE the gate by
         // design (it is documented as always-current and is not judged against the resolver's build).
         LoadOrderResolver.IndexView view; IReadOnlyList<string> warnings; bool profileChanged; string profileDir; string profileName; string? instanceDir;
@@ -522,8 +522,8 @@ public sealed class LoadOrderService : IDisposable
             warnings = _orderWarnings;
             profileChanged = ProfileFilesChanged();
             profileDir = _profileDir;
-            profileName = _profileName;                            // captured under the SAME gate (hunt F6) â€” one snapshot, never re-derived at render
-            instanceDir = _instanceDir;                            // the configured MO2 instance folder; null â‡’ explicit-paths / unconfigured mode
+            profileName = _profileName;                            // captured under the SAME gate (hunt F6) — one snapshot, never re-derived at render
+            instanceDir = _instanceDir;                            // the configured MO2 instance folder; null ⇒ explicit-paths / unconfigured mode
         }
         var comp = Mo2LoadOrder.ReadComposition(profileDir);       // FRESH composition (always current)
         return new LoadOrderStatusData(
@@ -531,49 +531,49 @@ public sealed class LoadOrderService : IDisposable
     }
 
     /// <summary>Inspect a NAMED profile's enabled/disabled composition WITHOUT switching to it (9.2: "can't inspect an
-    /// inactive profile") â€” INSTANCE MODE ONLY. The profiles root is the PARENT of the active profile's dir, so MO2's
+    /// inactive profile") — INSTANCE MODE ONLY. The profiles root is the PARENT of the active profile's dir, so MO2's
     /// base_directory redirect is honored by construction (the active ProfileDir already incorporates it) and a stale
-    /// active-profile dir doesn't matter â€” every profile is a sibling folder there. Reads with the cheap text-only
+    /// active-profile dir doesn't matter — every profile is a sibling folder there. Reads with the cheap text-only
     /// <see cref="Mo2LoadOrder.ReadComposition"/>, NOT <see cref="Mo2LoadOrder.Build"/> (Build walks every enabled mod
-    /// folder â€” thousands of dir enumerations) â€” so inspecting an inactive profile never builds the record index and never
+    /// folder — thousands of dir enumerations) — so inspecting an inactive profile never builds the record index and never
     /// changes the active profile. EXPLICIT-paths mode has no profiles root (the dir is configured arbitrarily), so a named
     /// read REFUSES LOUD there rather than enumerate a non-profiles folder. A <paramref name="requested"/> name matching no
-    /// profile is reported with the available names (Q3 â€” never a silently-empty composition); a null/blank name returns
+    /// profile is reported with the available names (Q3 — never a silently-empty composition); a null/blank name returns
     /// just the available list (the discovery affordance on the default status). Case-insensitive name match.</summary>
     public NamedProfileResult NamedProfileComposition(string? requested)
     {
         string? instanceDir; string profilesRoot;
         lock (_gate)
         {
-            if (!_configured) throw NotConfigured();              // fresh install â†’ the tool returns the trained prompt
+            if (!_configured) throw NotConfigured();              // fresh install → the tool returns the trained prompt
             EnsurePathsDerived();                                 // instance mode: derive the ACTIVE ProfileDir (cheap ini read; throws Q3 if the instance is unusable)
             instanceDir = _instanceDir;
             profilesRoot = instanceDir is null ? "" : (Path.GetDirectoryName(_profileDir.TrimEnd('\\', '/')) ?? "");
         }
 
         var name = string.IsNullOrWhiteSpace(requested) ? null : requested.Trim();
-        if (instanceDir is null)                                  // explicit-paths mode â€” no profiles root (refuse loud; the tool renders the named-mode-only message)
+        if (instanceDir is null)                                  // explicit-paths mode — no profiles root (refuse loud; the tool renders the named-mode-only message)
             return new NamedProfileResult(InstanceMode: false, AvailableProfiles: Array.Empty<string>(), RequestedName: name, ResolvedProfileDir: null, Composition: null, Warnings: Array.Empty<string>());
 
-        var available = ListProfiles(profilesRoot);              // directory listing OUTSIDE the gate (like StatusData's ReadComposition) â€” no lock held over I/O
-        if (name is null)                                        // no name â†’ the discovery list only (default-status affordance)
+        var available = ListProfiles(profilesRoot);              // directory listing OUTSIDE the gate (like StatusData's ReadComposition) — no lock held over I/O
+        if (name is null)                                        // no name → the discovery list only (default-status affordance)
             return new NamedProfileResult(true, available, null, null, null, Array.Empty<string>());
 
         var match = available.FirstOrDefault(p => string.Equals(p, name, StringComparison.OrdinalIgnoreCase));
-        if (match is null)                                       // named profile not found â†’ Q3: report it WITH the available names, never an empty composition
+        if (match is null)                                       // named profile not found → Q3: report it WITH the available names, never an empty composition
             return new NamedProfileResult(true, available, name, null, null, Array.Empty<string>());
 
         var dir = Path.Combine(profilesRoot, match);
-        var warnings = new List<string>();                       // surface read notes (e.g. a missing modlist.txt) â€” so a 0-mods inspected profile isn't silently mistaken for empty (Q3)
-        var comp = Mo2LoadOrder.ReadComposition(dir, warnings);  // cheap text parse of THAT profile's loadorder/modlist/plugins â€” no index build, no switch
+        var warnings = new List<string>();                       // surface read notes (e.g. a missing modlist.txt) — so a 0-mods inspected profile isn't silently mistaken for empty (Q3)
+        var comp = Mo2LoadOrder.ReadComposition(dir, warnings);  // cheap text parse of THAT profile's loadorder/modlist/plugins — no index build, no switch
         return new NamedProfileResult(true, available, match, dir, comp, warnings);
     }
 
-    /// <summary>The USABLE profile names under <paramref name="profilesRoot"/> â€” each MO2 profile is one subfolder, and a
+    /// <summary>The USABLE profile names under <paramref name="profilesRoot"/> — each MO2 profile is one subfolder, and a
     /// profile that's been opened at least once has a loadorder.txt (the same validity signal <see cref="Mo2Instance"/> uses
-    /// for the ACTIVE profile). Folders WITHOUT one â€” a never-opened profile, or a stray non-profile dir â€” are skipped, so
+    /// for the ACTIVE profile). Folders WITHOUT one — a never-opened profile, or a stray non-profile dir — are skipped, so
     /// the list never OFFERS (and a name match never LANDS ON) a folder that would read back as an all-zero composition
-    /// (Q3: don't present an uninitialized folder as an empty profile). Sorted case-insensitively. Never throws â€” an
+    /// (Q3: don't present an uninitialized folder as an empty profile). Sorted case-insensitively. Never throws — an
     /// unreadable/absent root yields an empty list, so the caller surfaces "no profiles" honestly rather than failing the
     /// whole status read.</summary>
     static IReadOnlyList<string> ListProfiles(string profilesRoot)
@@ -582,28 +582,28 @@ public sealed class LoadOrderService : IDisposable
         try
         {
             return Directory.EnumerateDirectories(profilesRoot)
-                .Where(d => File.Exists(Path.Combine(d, "loadorder.txt")))   // an opened MO2 profile has loadorder.txt â€” skip stray/never-opened folders (Q3, accuracy over the per-folder stat)
+                .Where(d => File.Exists(Path.Combine(d, "loadorder.txt")))   // an opened MO2 profile has loadorder.txt — skip stray/never-opened folders (Q3, accuracy over the per-folder stat)
                 .Select(d => Path.GetFileName(d.TrimEnd('\\', '/')))
                 .Where(n => !string.IsNullOrEmpty(n))
                 .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
                 .ToList();
         }
-        catch { return Array.Empty<string>(); }                  // root vanished / access denied â€” empty, not a thrown status read
+        catch { return Array.Empty<string>(); }                  // root vanished / access denied — empty, not a thrown status read
     }
 
-    /// <summary>True if any of the three MO2 profile files' mtimes DIFFERS from the last build's baseline â€” the user
+    /// <summary>True if any of the three MO2 profile files' mtimes DIFFERS from the last build's baseline — the user
     /// toggled mods/plugins, re-sorted, or RESTORED A BACKUP since, so the resolver's resolved set is behind the live
     /// profile. Compared by value (!=), like the resolver's own plugin sweep: a restored backup carries an OLDER
     /// mtime, which an is-newer comparison was blind to (hunt F8). Caller holds <see cref="_gate"/>.</summary>
     bool ProfileFilesChanged()
     {
-        if (_profileDir.Length == 0) return false;                 // guard seam / not yet derived â€” nothing to compare against
+        if (_profileDir.Length == 0) return false;                 // guard seam / not yet derived — nothing to compare against
         for (int i = 0; i < ProfileFileNames.Length; i++)
             if (SafeMtime(Path.Combine(_profileDir, ProfileFileNames[i])) != _profileMtimes[i]) return true;
         return false;
     }
 
-    /// <summary>The three profile files' current mtimes, in <see cref="ProfileFileNames"/> order â€” the freshness
+    /// <summary>The three profile files' current mtimes, in <see cref="ProfileFileNames"/> order — the freshness
     /// baseline a build records. Stat BEFORE the read it baselines (TOCTOU). Caller holds <see cref="_gate"/>.</summary>
     DateTime[] StatProfileFiles()
     {
@@ -617,40 +617,40 @@ public sealed class LoadOrderService : IDisposable
         try { return File.GetLastWriteTimeUtc(path); } catch { return DateTime.MinValue; }
     }
 
-    /// <summary>To-do #6 â€” LAZY freshness, run on each tool call once the snapshot exists. Two signals, both cheap-mtime:
-    /// (1) instance mode â€” did the user SWITCH PROFILES (ModOrganizer.ini changed)? then re-derive the roots + re-resolve
+    /// <summary>To-do #6 — LAZY freshness, run on each tool call once the snapshot exists. Two signals, both cheap-mtime:
+    /// (1) instance mode — did the user SWITCH PROFILES (ModOrganizer.ini changed)? then re-derive the roots + re-resolve
     /// against the new profile (<see cref="RederiveIfIniChanged"/>). (2) did the ACTIVE profile's files change (a toggle /
-    /// re-sort)? then CHEAPLY re-resolve, paying the ~12s deep re-index ONLY when the resolved order actually changed â€” so a
+    /// re-sort)? then CHEAPLY re-resolve, paying the ~12s deep re-index ONLY when the resolved order actually changed — so a
     /// no-plugin toggle, or a change that nets back to the same order, costs ~nothing. NEVER fires BETWEEN tool calls (no
     /// watcher / no loop), so an actively-sorting/switching user can't make the server thrash. Caller holds <see cref="_gate"/>;
     /// <see cref="_resolver"/> is non-null.</summary>
     void RefreshOnProfileChange()
     {
         if (RederiveIfIniChanged()) return;                      // instance mode: a profile SWITCH already re-derived + re-resolved
-        if (!ProfileFilesChanged()) return;                      // nothing touched the active profile â†’ nothing to do
+        if (!ProfileFilesChanged()) return;                      // nothing touched the active profile → nothing to do
         ReResolve();
     }
 
     /// <summary>Instance mode only: if ModOrganizer.ini changed since we last read it AND the user switched profiles (or
     /// moved the game path), re-derive ProfileDir/ModsDir/DataDir + the active profile and re-resolve against the new
-    /// profile. This is how a mid-session profile switch is followed â€” lazily, on the NEXT tool call, by the SAME cheap-mtime
+    /// profile. This is how a mid-session profile switch is followed — lazily, on the NEXT tool call, by the SAME cheap-mtime
     /// model as the per-profile-file check. Returns true iff it handled a switch (caller then skips the per-file check).
     /// Tolerates a transient/invalid read (MO2 mid-write): keeps the last good set and retries next call. Caller holds the gate.</summary>
     bool RederiveIfIniChanged()
     {
-        if (_instanceDir is null) return false;                  // explicit/override mode â€” no ini to watch
+        if (_instanceDir is null) return false;                  // explicit/override mode — no ini to watch
         var ini = Mo2Instance.IniPath(_instanceDir);
-        if (!File.Exists(ini)) return false;                     // missing/mid-replace â†’ keep last good, retry next call
+        if (!File.Exists(ini)) return false;                     // missing/mid-replace → keep last good, retry next call
         var iniMtime = SafeMtime(ini);                           // stat BEFORE the read (TOCTOU): an ini write during/after TryResolve is caught next call
-        if (iniMtime == _iniMtime) return false;                 // compared by VALUE â€” a restored-backup ini (OLDER mtime) is a change too (hunt F8)
-        if (!Mo2Instance.TryResolve(_instanceDir, out var p) || p is null) return false;   // mid-write/invalid â†’ keep last good, retry next call
+        if (iniMtime == _iniMtime) return false;                 // compared by VALUE — a restored-backup ini (OLDER mtime) is a change too (hunt F8)
+        if (!Mo2Instance.TryResolve(_instanceDir, out var p) || p is null) return false;   // mid-write/invalid → keep last good, retry next call
         _iniMtime = iniMtime;                                    // advance only on a clean read
         bool switched = !PathEq(p.ProfileDir, _profileDir) || !PathEq(p.ModsDir, _modsDir) || !PathEq(p.DataDir, _dataDir)
                         || !PathEq(p.OverwriteDir, _overwriteDir);
         if (!switched) return false;                             // ini touched but nothing we resolve from changed
         _profileDir = p.ProfileDir; _modsDir = p.ModsDir; _dataDir = p.DataDir; _profileName = p.ProfileName; _overwriteDir = p.OverwriteDir;
-        InvalidateClassParents();                                // the mods tree may have moved â€” drop the cached hierarchy with it
-        ReResolve();                                             // a new profile â‡’ the order differs â‡’ ReResolve deep-re-indexes
+        InvalidateClassParents();                                // the mods tree may have moved — drop the cached hierarchy with it
+        ReResolve();                                             // a new profile ⇒ the order differs ⇒ ReResolve deep-re-indexes
         return true;
     }
 
@@ -666,12 +666,12 @@ public sealed class LoadOrderService : IDisposable
 
         if (paths.Count > 0 && !paths.SequenceEqual(_resolvedPaths, StringComparer.OrdinalIgnoreCase))
         {
-            // The active set/order genuinely changed â†’ re-take the snapshot (the ~12s deep re-index). Build FIRST so the
+            // The active set/order genuinely changed → re-take the snapshot (the ~12s deep re-index). Build FIRST so the
             // old snapshot survives if it throws; only then dispose + swap. Guarded on `_resolver is not null`: an
-            // ASSET-only query (Phase 2) can drive this re-resolve before any record index exists â€” it must NOT pay the
+            // ASSET-only query (Phase 2) can drive this re-resolve before any record index exists — it must NOT pay the
             // heavy build here (the record getter builds fresh against these paths on its own next call). The record
             // path always has a non-null _resolver when it reaches here, so its behaviour is unchanged.
-            InvalidateAssetResolver();   // the active-mod/archive set changed â†’ the asset resolver rebuilds lazily
+            InvalidateAssetResolver();   // the active-mod/archive set changed → the asset resolver rebuilds lazily
             if (_resolver is not null)
             {
                 var rebuilt = LoadOrderResolver.Build(paths);
@@ -684,36 +684,36 @@ public sealed class LoadOrderService : IDisposable
         }
         else if (paths.Count > 0)
         {
-            // The profile was touched but the resolved PLUGIN order is identical (e.g. a no-plugin mod toggled) â€” no deep
+            // The profile was touched but the resolved PLUGIN order is identical (e.g. a no-plugin mod toggled) — no deep
             // re-index. But a plugin-less toggle still changes the loose roots / active-archive set, so the asset resolver
             // is dropped to rebuild; just advance the freshness baseline so the staleness flag clears.
             InvalidateAssetResolver();
             _orderWarnings = order.Warnings;
             _profileMtimes = profileMtimes;
         }
-        // paths.Count == 0 â†’ almost certainly a transient mid-write read; keep the last good snapshot and DON'T advance the
+        // paths.Count == 0 → almost certainly a transient mid-write read; keep the last good snapshot and DON'T advance the
         // baseline, so the next tool call re-checks and self-recovers once MO2 finishes writing.
     }
 
     /// <summary>Instance mode: on the first resolver build, read ModOrganizer.ini and derive ProfileDir/ModsDir/DataDir +
-    /// the active profile â€” throwing a clear Q3 message (naming what's missing) if the configured instance isn't usable.
+    /// the active profile — throwing a clear Q3 message (naming what's missing) if the configured instance isn't usable.
     /// Explicit mode (paths already set) and re-derives (paths already non-empty) are no-ops. Stamps the ini-read baseline
     /// so the profile-switch check has a reference point. Caller holds the gate.</summary>
     void EnsurePathsDerived()
     {
-        if (_instanceDir is null) return;                        // explicit mode â€” roots configured directly
+        if (_instanceDir is null) return;                        // explicit mode — roots configured directly
         if (_profileDir.Length > 0) return;                      // already derived (a prior build / SetInstance); RederiveIfIniChanged owns later updates
         var iniMtime = SafeMtime(Mo2Instance.IniPath(_instanceDir));   // stat BEFORE the read (TOCTOU): an ini write during/after Resolve is caught next call
         var p = Mo2Instance.Resolve(_instanceDir);               // throws (Q3) naming the missing piece if not a usable instance
         _profileDir = p.ProfileDir; _modsDir = p.ModsDir; _dataDir = p.DataDir; _profileName = p.ProfileName; _overwriteDir = p.OverwriteDir;
         _iniMtime = iniMtime;
-        InvalidateClassParents();                                // _modsDir just gained a value â€” a cache built before derivation is baseline-only (hunt F1)
+        InvalidateClassParents();                                // _modsDir just gained a value — a cache built before derivation is baseline-only (hunt F1)
     }
 
     static bool PathEq(string a, string b) =>
         string.Equals(a.TrimEnd('\\', '/'), b.TrimEnd('\\', '/'), StringComparison.OrdinalIgnoreCase);
 
-    /// <summary>Whether houseCARL has an MO2 location to resolve against. False on a fresh install with no config â€” the
+    /// <summary>Whether houseCARL has an MO2 location to resolve against. False on a fresh install with no config — the
     /// server still runs; every tool returns the trained prompt until <see cref="SetInstance"/> is called.</summary>
     public bool IsConfigured { get { lock (_gate) { return _configured; } } }
 
@@ -721,12 +721,12 @@ public sealed class LoadOrderService : IDisposable
     /// name); "" when unconfigured. For the status surface.</summary>
     public string ProfileName { get { lock (_gate) { return _profileName; } } }
 
-    /// <summary>The game install directory the load order points at â€” DataDir's PARENT (DataDir = gamePath\Data), the same
-    /// derivation the asset-discovery path uses â€” or null when it isn't derivable. The compile rider's auto-detect HINT: the
-    /// CK installs its compiler at &lt;gamePath&gt;\Papyrus Compiler\PapyrusCompiler.exe (6.2). NULL-SAFE by contract â€” it is
+    /// <summary>The game install directory the load order points at — DataDir's PARENT (DataDir = gamePath\Data), the same
+    /// derivation the asset-discovery path uses — or null when it isn't derivable. The compile rider's auto-detect HINT: the
+    /// CK installs its compiler at &lt;gamePath&gt;\Papyrus Compiler\PapyrusCompiler.exe (6.2). NULL-SAFE by contract — it is
     /// best-effort plumbing, so a failure here must fall through to the forcing prompt, NEVER throw and abort the compile:
     /// returns null when unconfigured (no _configured guard would otherwise hit EnsurePathsDerived's NotConfigured throw),
-    /// when the instance is unusable (EnsurePathsDerived throws naming the missing piece â€” the rider's own config gate
+    /// when the instance is unusable (EnsurePathsDerived throws naming the missing piece — the rider's own config gate
     /// reports that; here it's just "no hint"), or when DataDir hasn't been derived yet. Takes <see cref="_gate"/> like the
     /// other derived-root reads; works in explicit mode too (DataDir is set directly, EnsurePathsDerived no-ops).</summary>
     public string? GameDirOrNull()
@@ -735,20 +735,20 @@ public sealed class LoadOrderService : IDisposable
         {
             if (!_configured) return null;
             try { EnsurePathsDerived(); }
-            catch { return null; }                                  // unusable instance â†’ no hint (Q3: the rider's config gate names the real problem)
+            catch { return null; }                                  // unusable instance → no hint (Q3: the rider's config gate names the real problem)
             return _dataDir.Length > 0 ? Path.GetDirectoryName(_dataDir.TrimEnd('\\', '/')) : null;
         }
     }
 
-    /// <summary>The game directories to search for the Creation Kit's compiler, in PRIORITY ORDER â€” the compile rider's
+    /// <summary>The game directories to search for the Creation Kit's compiler, in PRIORITY ORDER — the compile rider's
     /// auto-detect hints (6.2). [0] = the load order's OWN game dir (<see cref="GameDirOrNull"/>): correct when MO2 points
     /// straight at a real, CK-equipped install. Then the GameFinder/Mutagen-located real Skyrim SE install(s): in the common
     /// MO2 "Stock Game" setup (Aaron 2026-06-17) the load order points at a COPY that has NEITHER the CK nor the vanilla
-    /// script sources â€” both live in the Steam install â€” so the located install is the one that actually hits. De-duplicated,
+    /// script sources — both live in the Steam install — so the located install is the one that actually hits. De-duplicated,
     /// nulls dropped. BEST-EFFORT + NULL-SAFE end to end: the locator reads the registry/Steam, so a miss or a throw just
     /// yields fewer hints (the forcing prompt then names what was checked), it NEVER aborts the compile.
     /// <para>LOAD-BEARING (do NOT "simplify"): the compile rider derives the vanilla SOURCE folder from the RESOLVED
-    /// COMPILER's own game dir (<see cref="CompileTools.BuildImports"/>), NOT from these hints and NOT from the data dir â€” so
+    /// COMPILER's own game dir (<see cref="CompileTools.BuildImports"/>), NOT from these hints and NOT from the data dir — so
     /// once the compiler resolves to the Steam install, its sibling Data\Source\Scripts is used, never the Stock Game copy's
     /// (which usually has none). Keying sources off the data dir would re-break exactly the Stock-Game case this fixes.</para></summary>
     public IReadOnlyList<string> CompilerGameDirHints()
@@ -757,13 +757,13 @@ public sealed class LoadOrderService : IDisposable
         if (GameDirOrNull() is { } loadOrderGameDir) hints.Add(loadOrderGameDir);
         try
         {
-            // The bundled GameFinder locator (Steam/GOG/Xbox), via Mutagen â€” finds the REAL Skyrim SE install (App 489830),
+            // The bundled GameFinder locator (Steam/GOG/Xbox), via Mutagen — finds the REAL Skyrim SE install (App 489830),
             // where the Creation Kit + sources live, regardless of where MO2's load order points.
             if (new Mutagen.Bethesda.Installs.GameLocator().TryGetGameDirectory(
                     Mutagen.Bethesda.GameRelease.SkyrimSE, out var dir) && !string.IsNullOrWhiteSpace(dir.Path))
                 hints.Add(NormalizeGameDir(dir.Path));
         }
-        catch { /* GameFinder / registry hiccup â†’ just the load-order hint (best-effort; the prompt still names it) */ }
+        catch { /* GameFinder / registry hiccup → just the load-order hint (best-effort; the prompt still names it) */ }
         return hints.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
     }
 
@@ -775,20 +775,20 @@ public sealed class LoadOrderService : IDisposable
         return Path.GetFileName(t).Equals("Data", StringComparison.OrdinalIgnoreCase) ? (Path.GetDirectoryName(t) ?? t) : t;
     }
 
-    /// <summary>Point houseCARL at an MO2 instance folder â€” first-run setup AND switching between instances ("jump around").
-    /// VALIDATES it (<see cref="Mo2Instance.Resolve"/> throws a clear Q3 message if it isn't usable â€” nothing is changed or
+    /// <summary>Point houseCARL at an MO2 instance folder — first-run setup AND switching between instances ("jump around").
+    /// VALIDATES it (<see cref="Mo2Instance.Resolve"/> throws a clear Q3 message if it isn't usable — nothing is changed or
     /// persisted on failure), then re-points the live service (derives the roots + active profile, drops the cached resolver
     /// so the next tool call rebuilds against the new instance) and PERSISTS the choice to the user config file so it
     /// survives a restart. Returns the derived paths + whether the persist succeeded, for the tool's confirmation.</summary>
     public (Mo2InstancePaths paths, bool persisted, string? persistError, string? persistNote) SetInstance(string instanceDir)
     {
-        // The ini baseline is statted BEFORE Resolve reads the instance (hunt F7 â€” this was the one stamp-AFTER-the-read
+        // The ini baseline is statted BEFORE Resolve reads the instance (hunt F7 — this was the one stamp-AFTER-the-read
         // in the file: an MO2 ini write landing between Resolve's read and the stamp was absorbed into the baseline and
         // its profile switch stayed invisible forever). Statting first makes a during/after-read write show as a changed
-        // mtime on the next call â€” the same TOCTOU discipline every other baseline here follows.
+        // mtime on the next call — the same TOCTOU discipline every other baseline here follows.
         var iniMtime = SafeMtime(Mo2Instance.IniPath(instanceDir.Trim()));
-        var paths = Mo2Instance.Resolve(instanceDir);            // throws (Q3) if not a usable MO2 instance â€” the tool renders the reason
-        lock (_writeGate)                                        // hunt F2: an instance switch waits for any in-flight write â€” never tears one across instances
+        var paths = Mo2Instance.Resolve(instanceDir);            // throws (Q3) if not a usable MO2 instance — the tool renders the reason
+        lock (_writeGate)                                        // hunt F2: an instance switch waits for any in-flight write — never tears one across instances
         lock (_gate)
         {
             _instanceDir = paths.InstanceDir;
@@ -799,19 +799,19 @@ public sealed class LoadOrderService : IDisposable
             _resolver?.Dispose(); _resolver = null;              // force a rebuild against the new instance on the next query
             _assetResolver?.Dispose(); _assetResolver = null;    // the asset resolver rebuilds against the new instance too (Phase 2)
             _resolvedPaths = Array.Empty<string>();
-            _profileMtimes = new DateTime[ProfileFileNames.Length];   // unset â€” the next build records fresh baselines against the new profile
+            _profileMtimes = new DateTime[ProfileFileNames.Length];   // unset — the next build records fresh baselines against the new profile
             _orderWarnings = Array.Empty<string>();
-            InvalidateClassParents();                            // every sibling cache drops on a switch â€” the hierarchy too (PR #47 review)
+            InvalidateClassParents();                            // every sibling cache drops on a switch — the hierarchy too (PR #47 review)
         }
         var (persisted, persistError, persistNote) = PersistInstanceDir(paths.InstanceDir);
         return (paths, persisted, persistError, persistNote);
     }
 
     /// <summary>Persist the chosen instance dir through the shared <see cref="UserConfigStore"/> (read-modify-write), so it
-    /// survives a restart AND coexists with any saved tool paths â€” the store never clobbers the other concern's field.
-    /// Best-effort + HONEST (Q3): a write failure (e.g. a read-only data dir) is reported, not swallowed â€” the session
+    /// survives a restart AND coexists with any saved tool paths — the store never clobbers the other concern's field.
+    /// Best-effort + HONEST (Q3): a write failure (e.g. a read-only data dir) is reported, not swallowed — the session
     /// still works, but the user is told the choice won't survive a restart. <c>note</c> carries a corrupt-file recovery
-    /// (hunt F3 â€” the prior file was backed up; other saved settings were lost), rendered even on success.</summary>
+    /// (hunt F3 — the prior file was backed up; other saved settings were lost), rendered even on success.</summary>
     (bool ok, string? error, string? note) PersistInstanceDir(string instanceDir)
         => _store.Update(c => c.Mo2InstanceDir = instanceDir);
 
@@ -819,14 +819,14 @@ public sealed class LoadOrderService : IDisposable
     /// silently pick among several) and call the setup tool. Tools RETURN this (so the client SEES it) via <see cref="ConfigPromptOrNull"/>; the <see cref="Resolver"/>
     /// getter also THROWS it as a backstop. The two must say the same thing, hence one shared string.</summary>
     const string NotConfiguredText =
-        "houseCARL has no Mod Organizer 2 instance configured yet. Ask the user which MO2 instance folder to use â€” the " +
+        "houseCARL has no Mod Organizer 2 instance configured yet. Ask the user which MO2 instance folder to use — the " +
         "folder that contains ModOrganizer.ini (for a Wabbajack / portable list, that's the list's install folder). You " +
         "may help locate it, but do NOT silently pick one when more than one MO2 install exists: list the candidates you " +
         "found and let the user choose. State which folder you're using, then call housecarl_set_mo2_instance with that path.";
 
     /// <summary>Tools call this FIRST: returns the trained prompt (a normal result string the client SEES) when
-    /// unconfigured, else null (proceed). Preferred over letting <see cref="Resolver"/> throw â€” the MCP framework
-    /// genericizes a thrown exception to "An error occurred invoking 'â€¦'", so a THROW never delivers the guidance to the
+    /// unconfigured, else null (proceed). Preferred over letting <see cref="Resolver"/> throw — the MCP framework
+    /// genericizes a thrown exception to "An error occurred invoking '…'", so a THROW never delivers the guidance to the
     /// client, but a returned string does (measured 2026-06-02 during the server-driven proof).</summary>
     public string? ConfigPromptOrNull() { lock (_gate) { return _configured ? null : NotConfiguredText; } }
 
@@ -835,43 +835,43 @@ public sealed class LoadOrderService : IDisposable
     /// <summary>Resolve + read one record (the read_record primitive). Reads the WINNER's body by default, or a
     /// named <paramref name="plugin"/>'s version; with <paramref name="conflictTree"/> also returns the ordered
     /// touching-plugin list. Honest, recoverable errors (Q3): not-in-order, plugin-doesn't-touch, fetch
-    /// inconsistency â€” never a silent empty result.</summary>
+    /// inconsistency — never a silent empty result.</summary>
     public ReadOutcome ResolveRead(FormKey fk, string? plugin, IReadOnlyList<string>? fields, bool conflictTree, int depth = 1)
     {
         var resolver = Resolver;
         return ResolveRead(resolver, resolver.Capture(), fk, plugin, fields, conflictTree, depth);
     }
 
-    /// <summary>Layer B unit C2 â€” the on-demand whole-topic dialogue-graph validator (housecarl_validate_dialogue):
+    /// <summary>Layer B unit C2 — the on-demand whole-topic dialogue-graph validator (housecarl_validate_dialogue):
     /// resolve <paramref name="fk"/> to its load-order winner and, when it is a dialogue topic (DIAL) validate that
-    /// topic's whole graph, or when a quest (QUST) fan out to EVERY topic the quest owns â€” all against the resolved
+    /// topic's whole graph, or when a quest (QUST) fan out to EVERY topic the quest owns — all against the resolved
     /// load-order winners (what the game actually sees). The on-demand counterpart of the per-create voice (unit B)
     /// + result-script (unit C1) teeth, auditing existing INFOs the create-time checks never re-touch. The whole
     /// Skyrim-typed walk (winner resolution, the DIAL/QUST branch, the graph + per-INFO checks) lives in CORE
     /// (<see cref="DialogueValidate"/>), so the service stays Mutagen.Skyrim-free exactly like the voice/script
-    /// enrichers â€” here it just hands core the live record resolver + the VFS asset resolver. NEVER throws over a
+    /// enrichers — here it just hands core the live record resolver + the VFS asset resolver. NEVER throws over a
     /// verify step: a mid-run resolve/asset failure rides <see cref="DialogueValidationReport.CheckError"/>, and a
     /// not-in-order / not-a-DIAL-or-QUST input is a NAMED <see cref="DialogueValidationReport.Error"/> (Q3).</summary>
     public DialogueValidationReport ValidateDialogue(FormKey fk) => DialogueValidate.Run(Resolver, Assets, fk);
 
     /// <summary>The read body, answered entirely off ONE captured view (HCBR-2026-06-11-02): excluded-check, winner,
-    /// and touching-plugin list all describe the SAME build â€” a freshness rebuild landing mid-read can no longer make
+    /// and touching-plugin list all describe the SAME build — a freshness rebuild landing mid-read can no longer make
     /// a record's reported winner disagree with its own TOUCHING LIST. (The body fetch reads the file on disk through
     /// the session; a mid-read file edit surfaces as the existing named fetch-inconsistency error, never torn values.
     /// Known residue, review #1: the conflict-tree DIFF the render layer adds is a separate <see cref="ResolveTree"/>
     /// call with its own capture, so one rendered response can still pair this read's build with an adjacent build's
-    /// diff â€” same low-severity class, named for the next wave rather than threaded through the render API here.)</summary>
+    /// diff — same low-severity class, named for the next wave rather than threaded through the render API here.)</summary>
     ReadOutcome ResolveRead(LoadOrderResolver resolver, LoadOrderResolver.IndexView view,
                             FormKey fk, string? plugin, IReadOnlyList<string>? fields, bool conflictTree, int depth)
     {
-        // An explicitly-requested plugin that was EXCLUDED this session (unparseable/unopenable) â†’ say so (Q3),
+        // An explicitly-requested plugin that was EXCLUDED this session (unparseable/unopenable) → say so (Q3),
         // rather than fall through to a misleading "does not define this record".
         if (plugin is not null && view.ExcludedPlugins.TryGetValue(plugin, out var pWhy))
             return ReadOutcome.Fail(fk, $"Plugin '{plugin}' was excluded from this session: {pWhy}");
 
         // An explicitly-requested plugin that is NOT IN THE ORDER AT ALL is its own failure mode (HCBR-2026-06-11-02
         // wave (a)): GetRecord returns null for it, and falling through would render the FALSE "does not define this
-        // record" â€” which reads as "my write was lost" and invites re-issuing the ops (duplicate list Adds into the
+        // record" — which reads as "my write was lost" and invites re-issuing the ops (duplicate list Adds into the
         // patch). Name the true condition + the working verify paths instead. Aaron-decided Option A: houseCARL does
         // NOT read disabled plugins off disk (non-winner content masquerading as load-order truth is the Q3 hazard).
         if (plugin is not null && !view.ContainsPlugin(plugin))
@@ -882,12 +882,12 @@ public sealed class LoadOrderService : IDisposable
                 "plugins off disk. If this is a freshly written houseCARL patch, it isn't enabled yet: enable + sort it in " +
                 "MO2, then re-read. To verify a write BEFORE enabling, use the write call's own read-back " +
                 "(full_readback=true returns the whole written record). If a prior write into this patch reported success, " +
-                "the edits DID land â€” do not re-issue them (re-running list Adds would duplicate entries).");
+                "the edits DID land — do not re-issue them (re-running list Adds would duplicate entries).");
 
         var winner = view.ResolveWinner(fk);
         if (winner is null)
         {
-            // If the record's defining plugin was excluded, that's WHY it's missing â€” name it (Q3), not a bare "not present".
+            // If the record's defining plugin was excluded, that's WHY it's missing — name it (Q3), not a bare "not present".
             var defining = fk.ModKey.FileName.ToString();
             if (view.ExcludedPlugins.TryGetValue(defining, out var dWhy))
                 return ReadOutcome.Fail(fk, $"FormID {fk} is not resolvable: its plugin '{defining}' was excluded from this session: {dWhy}");
@@ -899,7 +899,7 @@ public sealed class LoadOrderService : IDisposable
         var rec = view.GetRecord(session, source, fk);                    // excluded-check pinned to the SAME view the winner came from (hunt F5 discipline)
         if (rec is null)
             return ReadOutcome.Fail(fk, plugin is null
-                ? $"Winner '{winner.Value.WinnerPlugin}' did not yield {fk} on fetch â€” a load-order inconsistency."
+                ? $"Winner '{winner.Value.WinnerPlugin}' did not yield {fk} on fetch — a load-order inconsistency."
                 : $"Plugin '{plugin}' does not define {fk} (it does not touch this record). The winner is '{winner.Value.WinnerPlugin}'.");
 
         var record = ReadEngine.ReadFields(rec, fields, depth);           // materialise while the session (overlay) is open
@@ -908,13 +908,13 @@ public sealed class LoadOrderService : IDisposable
     }
 
     /// <summary>How deep the conflict diff reads each touching body. The diff must compare CONTENT, not the
-    /// depth-1 count summaries that masked equal-count list deltas (HCBR-2026-06-09-01) â€” deep enough to reach
+    /// depth-1 count summaries that masked equal-count list deltas (HCBR-2026-06-09-01) — deep enough to reach
     /// every modeled scalar leaf (the walk is bounded by the modeled-corpus boundary + ReadEngine's expansion
     /// cap, whose truncation sentinel FieldsDiff surfaces as Complete=false).</summary>
     internal const int ConflictDiffDepth = 16;
 
-    /// <summary>The winner's full conflict tree, MATERIALISED â€” every touching plugin's name + its fields read off its
-    /// own body, in priority order (winner last) â€” for the field-level diff view, read DEEP (<see cref="ConflictDiffDepth"/>)
+    /// <summary>The winner's full conflict tree, MATERIALISED — every touching plugin's name + its fields read off its
+    /// own body, in priority order (winner last) — for the field-level diff view, read DEEP (<see cref="ConflictDiffDepth"/>)
     /// so the diff compares list/substruct CONTENT, not depth-1 count summaries (HCBR-2026-06-09-01). Opens a per-call
     /// session, fetches each touching body, reads its <paramref name="fields"/> into a plain DTO, then DISPOSES the
     /// session (Option B): the render layer never touches a live overlay or holds a handle. null if the FormKey isn't
@@ -931,7 +931,7 @@ public sealed class LoadOrderService : IDisposable
         return new ConflictTreeView(nodes);
     }
 
-    /// <summary>A header-only summary for one record (winner + type + editorid, no field dump) â€” the compact
+    /// <summary>A header-only summary for one record (winner + type + editorid, no field dump) — the compact
     /// one-line-per-match view cross_plugin_query uses by default. One winner-body fetch; holds nothing.</summary>
     public RecordSummary ResolveSummary(FormKey fk)
     {
@@ -956,7 +956,7 @@ public sealed class LoadOrderService : IDisposable
     public IReadOnlyList<ReadOutcome> ResolveBatch(IReadOnlyList<string> formids, IReadOnlyList<string>? fields, bool conflictTree, int depth = 1)
     {
         var resolver = Resolver;                // build/refresh ONCE for the batch
-        var view = resolver.Capture();          // ONE build for every item â€” the whole batch is one logical operation (HCBR-2026-06-11-02)
+        var view = resolver.Capture();          // ONE build for every item — the whole batch is one logical operation (HCBR-2026-06-11-02)
         var outcomes = new List<ReadOutcome>(formids.Count);
         foreach (var raw in formids)
         {
@@ -989,9 +989,9 @@ public sealed class LoadOrderService : IDisposable
         if (!hasType && !conflictsOnly && !hasPlugins && !bodyFilter)
             return CrossQueryOutcome.Fail("cross_plugin_query needs at least one of: type=, conflicts_only=true, editorid_contains=, references=, where=, or plugins=.");
         if (bodyFilter && !hasType && !hasPlugins)
-            return CrossQueryOutcome.Fail("editorid_contains/references/where is a body scan and must be combined with type= or plugins= to bound it (conflicts_only= alone is not enough â€” an unbounded body scan over the whole order is refused). A global reverse-reference index is a future capability.");
+            return CrossQueryOutcome.Fail("editorid_contains/references/where is a body scan and must be combined with type= or plugins= to bound it (conflicts_only= alone is not enough — an unbounded body scan over the whole order is refused). A global reverse-reference index is a future capability.");
 
-        // where= â†’ the field-value predicate set. Parsed up front so a malformed predicate refuses the call BEFORE
+        // where= → the field-value predicate set. Parsed up front so a malformed predicate refuses the call BEFORE
         // any scan (Q3). The predicate reuses the read engine's path-walk, so its reach == the read surface's reach.
         FieldPredicateSet? predicate = null;
         if (hasWhere)
@@ -1006,22 +1006,22 @@ public sealed class LoadOrderService : IDisposable
         catch (ArgumentException ex) { return CrossQueryOutcome.Fail(ex.Message); }   // unknown type
 
         var keys = new List<FormKey>();
-        var sources = new List<string?>();                                    // parallel to keys: the plugin whose body matched (null â‡’ winner), so the render displays the SAME body it filtered
+        var sources = new List<string?>();                                    // parallel to keys: the plugin whose body matched (null ⇒ winner), so the render displays the SAME body it filtered
         List<RecordSummary>? prefilled = (hasType || hasPlugins) ? new() : null;   // parallel to keys; null = renderer fills lazily
         int total = 0;
-        int unscannable = 0;                                                  // records whose body tests THREW (Mutagen-unparseable content) â€” excluded + accounted, never silent (Q3)
+        int unscannable = 0;                                                  // records whose body tests THREW (Mutagen-unparseable content) — excluded + accounted, never silent (Q3)
         var unscannableSamples = new List<string>();
 
         if (hasType || hasPlugins)                                            // a body-bearing scope: stream + filter in hand
         {
             // RecordsIn / WinnerRecordsOfType are LAZY iterators: ScopeIndices (a plugin not in the order) and
-            // EnumerateMajorRecords(throwIfUnknown) throw on ENUMERATION, not on creation â€” so the try must wrap the
+            // EnumerateMajorRecords(throwIfUnknown) throw on ENUMERATION, not on creation — so the try must wrap the
             // foreach, not just the assignment, or the clean Q3 message escapes as a generic framework error.
             var seen = new HashSet<FormKey>();
             try
             {
                 // Carry the SOURCE plugin per record so the render shows the body the scan filtered (not the winner):
-                // plugins= â†’ the scoped plugin's filename; type= â†’ null (â‡’ the winner, the WinnerRecordsOfType body).
+                // plugins= → the scoped plugin's filename; type= → null (⇒ the winner, the WinnerRecordsOfType body).
                 IEnumerable<(FormKey fk, int depth, IMajorRecordGetter body, string? source)> stream =
                     hasPlugins ? view.RecordsIn(plugins!, types).Select(x => (fk: x.fk, depth: x.depth, body: x.body, source: (string?)x.source))  // the scoped plugin's own body
                                : view.WinnerRecordsOfType(types!).Select(x => (fk: x.fk, depth: x.depth, body: x.body, source: (string?)null));    // the load-order winner's body
@@ -1030,9 +1030,9 @@ public sealed class LoadOrderService : IDisposable
                     if (conflictsOnly && depth <= 1) continue;
                     // PER-RECORD FAULT ISOLATION (HCBR-2026-06-09-03): the body tests lazily parse subrecord
                     // content (references= walks Effects etc. via Mutagen's EnumerateFormLinks), so ONE record
-                    // Mutagen can't parse used to abort the WHOLE call as an opaque transport error â€” the
+                    // Mutagen can't parse used to abort the WHOLE call as an opaque transport error — the
                     // scan-level twin of the PKCU index-build fix. Such a record is excluded and ACCOUNTED in
-                    // the response (never a silent skip, never a guessed match â€” Q3).
+                    // the response (never a silent skip, never a guessed match — Q3).
                     try
                     {
                         if (!string.IsNullOrEmpty(editoridContains)
@@ -1041,21 +1041,21 @@ public sealed class LoadOrderService : IDisposable
                         if (references is { } target
                             && !(body is IFormLinkContainerGetter flc && flc.EnumerateFormLinks().Any(l => l.FormKey == target)))
                             continue;
-                        if (predicate is not null && !predicate.Matches(body))    // value filter â€” same in-hand body, no extra fetch
+                        if (predicate is not null && !predicate.Matches(body))    // value filter — same in-hand body, no extra fetch
                         {
-                            if (predicate.FatalError is not null) break;          // numeric op vs non-numeric field â€” abort + surface (Q3)
+                            if (predicate.FatalError is not null) break;          // numeric op vs non-numeric field — abort + surface (Q3)
                             continue;
                         }
                         // De-dup (a FK can recur across scoped plugins). This runs AFTER the filters, so under
                         // plugins=[A,B] the source recorded for a shared FK is the FIRST scoped plugin (in plugins=
-                        // array order) whose body PASSED the filters â€” deterministic, and it's the body we'll display.
+                        // array order) whose body PASSED the filters — deterministic, and it's the body we'll display.
                         if (!seen.Add(fk)) continue;
                         total++;
-                        if (keys.Count < limit)                                   // in-hand body â†’ fill the summary for free
+                        if (keys.Count < limit)                                   // in-hand body → fill the summary for free
                         {
                             keys.Add(fk);
-                            sources.Add(source);                                  // the body we filtered IS the body we'll display (null â‡’ winner)
-                            // winner= off the SAME view the scan runs on â€” a rebuild landing mid-scan can no longer
+                            sources.Add(source);                                  // the body we filtered IS the body we'll display (null ⇒ winner)
+                            // winner= off the SAME view the scan runs on — a rebuild landing mid-scan can no longer
                             // make a row's winner reflect a newer build than the depth beside it (HCBR-2026-06-11-02).
                             prefilled!.Add(new RecordSummary(fk, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID,
                                                              view.ResolveWinner(fk)?.WinnerPlugin ?? "?", depth, null));
@@ -1065,29 +1065,29 @@ public sealed class LoadOrderService : IDisposable
                     {
                         unscannable++;
                         if (unscannableSamples.Count < 3)
-                            unscannableSamples.Add($"{fk}{(source is null ? "" : $" in {source}")} â€” {ex.GetType().Name}: {ex.Message}");
+                            unscannableSamples.Add($"{fk}{(source is null ? "" : $" in {source}")} — {ex.GetType().Name}: {ex.Message}");
                     }
                 }
             }
             catch (ArgumentException ex) { return CrossQueryOutcome.Fail(ex.Message); } // plugin not in order / unknown type
-            // Anything else escaping the stream itself still gets a NAMED failure â€” the MCP layer's generic
-            // "An error occurred invoking â€¦" must never be the terminal diagnostic for a data failure (Q3).
+            // Anything else escaping the stream itself still gets a NAMED failure — the MCP layer's generic
+            // "An error occurred invoking …" must never be the terminal diagnostic for a data failure (Q3).
             catch (Exception ex) { return CrossQueryOutcome.Fail($"scan aborted: {ex.GetType().Name}: {ex.Message}"); }
-            if (predicate?.FatalError is not null) return CrossQueryOutcome.Fail(predicate.FatalError); // typed predicate error â€” fail fast, named (Q3)
+            if (predicate?.FatalError is not null) return CrossQueryOutcome.Fail(predicate.FatalError); // typed predicate error — fail fast, named (Q3)
         }
-        else                                                                  // conflicts_only alone â€” index keys only; NO body fetch
+        else                                                                  // conflicts_only alone — index keys only; NO body fetch
         {
             // Summaries here would each need a winner-body fetch; leaving them to the renderer (which stops at
             // max_chars) means a big limit with a small max_chars doesn't fetch bodies it will never show.
             foreach (var fk in view.ConflictKeys())
             {
                 total++;
-                if (keys.Count < limit) { keys.Add(fk); sources.Add(null); }   // no scoped plugin â†’ display the winner
+                if (keys.Count < limit) { keys.Add(fk); sources.Add(null); }   // no scoped plugin → display the winner
             }
         }
         // Unscannable accounting (Q3): name the count, the first few offenders with Mutagen's reason, and what
-        // a caller can still do â€” these records are invisible to the body filters, not "0 matches" silence.
-        // "instance(s) â€¦ where they threw" because under plugins= a FormKey is tested once per scoped plugin:
+        // a caller can still do — these records are invisible to the body filters, not "0 matches" silence.
+        // "instance(s) … where they threw" because under plugins= a FormKey is tested once per scoped plugin:
         // a copy that throws is skipped while another plugin's copy of the same FK can still match (PR #27 review).
         string? scanNote = unscannable == 0 ? null
             : $"note: {unscannable} record instance(s) could not be scanned (Mutagen could not parse their content) and were skipped where they threw: "
@@ -1097,12 +1097,12 @@ public sealed class LoadOrderService : IDisposable
         return new CrossQueryOutcome(keys, prefilled, total, total > keys.Count, null, predicate?.AccountingNote(), sources, scanNote);
     }
 
-    // ---- effect-chain resolver (housecarl_effect_chain â€” gap 2026-06-08) --------------------------------
+    // ---- effect-chain resolver (housecarl_effect_chain — gap 2026-06-08) --------------------------------
 
     /// <summary>Resolve which SPEL/ENCH/ALCH/SCRL/INGR apply a MagicEffect, each with the magnitude/area/duration from
     /// the MATCHING effect entry (housecarl_effect_chain). Thin wiring over the core: resolve the optional type-narrow
-    /// (each must be one of the five effect-bearing records â€” a non-member is refused loud, never a silent empty scan),
-    /// then drive <see cref="EffectChain.Resolve"/> (Q3 typed-match gate â†’ winner-body scan). All the logic + the Q3
+    /// (each must be one of the five effect-bearing records — a non-member is refused loud, never a silent empty scan),
+    /// then drive <see cref="EffectChain.Resolve"/> (Q3 typed-match gate → winner-body scan). All the logic + the Q3
     /// teeth live in core so the self-contained guard drives this same path on synthetic plugins.</summary>
     public EffectChainResult ResolveEffectChain(FormKey mgef, IReadOnlyList<string>? typesNarrow, int limit)
     {
@@ -1113,13 +1113,13 @@ public sealed class LoadOrderService : IDisposable
             foreach (var ts in typesNarrow)
             {
                 IReadOnlyList<Type> resolved;
-                try { resolved = ResolveTypeFilter(ts.Trim()); }              // unknown type â†’ named Q3 error (same as cross_plugin_query)
+                try { resolved = ResolveTypeFilter(ts.Trim()); }              // unknown type → named Q3 error (same as cross_plugin_query)
                 catch (ArgumentException ex) { return EffectChainResult.Fail(ex.Message); }
                 foreach (var t in resolved)
                 {
                     if (!EffectChain.CarrierTypes.Contains(t))
                         return EffectChainResult.Fail(
-                            $"type '{ts}' is not effect-bearing â€” effect_chain scans only Spell/ObjectEffect/Ingestible/Scroll/Ingredient " +
+                            $"type '{ts}' is not effect-bearing — effect_chain scans only Spell/ObjectEffect/Ingestible/Scroll/Ingredient " +
                             "(SPEL/ENCH/ALCH/SCRL/INGR), the records that carry an Effects list. Drop it or pass one of those.");
                     if (!picked.Contains(t)) picked.Add(t);
                 }
@@ -1131,9 +1131,9 @@ public sealed class LoadOrderService : IDisposable
         return EffectChain.Resolve(Resolver, mgef, scope, limit);
     }
 
-    // ---- integrity sweep (housecarl_check_errors â€” audit A1) --------------------------------------------
+    // ---- integrity sweep (housecarl_check_errors — audit A1) --------------------------------------------
 
-    /// <summary>Sweep the active order (or the given <paramref name="plugins"/> scope) for record integrity errors â€”
+    /// <summary>Sweep the active order (or the given <paramref name="plugins"/> scope) for record integrity errors —
     /// dangling FormLinks, missing masters, and parse failures (housecarl_check_errors). Thin wiring over the
     /// core <see cref="ErrorCheck.Run"/>, which holds all the scan logic + Q3 teeth so the self-contained guard drives
     /// this same path over synthetic plugins. Read-only; composes existing primitives, no new dependency.</summary>
@@ -1143,7 +1143,7 @@ public sealed class LoadOrderService : IDisposable
     // ---- script-property sweep (housecarl_validate_scripts) --------------------------------------------
 
     /// <summary>Sweep the active order (or the given <paramref name="plugins"/> scope) for VMAD script properties that
-    /// are declared in the attached script's .pex (or an ancestor it extends) but left UNBOUND on the record â€” a silent
+    /// are declared in the attached script's .pex (or an ancestor it extends) but left UNBOUND on the record — a silent
     /// <c>None</c> (housecarl_validate_scripts). Thin wiring over the core <see cref="ScriptPropertyCheck.Run"/>, which
     /// holds all the cross-check logic + Q3 teeth so the self-contained guard drives this same path over synthetic
     /// records + a planted .pex. Passes the live <see cref="Assets"/> resolver (the same one the dialogue validator and
@@ -1151,30 +1151,30 @@ public sealed class LoadOrderService : IDisposable
     public ScriptCheckResult ValidateScripts(IReadOnlyList<string>? plugins, int limit)
         => ScriptPropertyCheck.Run(Resolver, Assets, plugins, limit);
 
-    // ---- writes (Â§8.4 Beat C: housecarl_set_field / housecarl_bulk_apply) -------------------------------
+    // ---- writes (§8.4 Beat C: housecarl_set_field / housecarl_bulk_apply) -------------------------------
 
     /// <summary>Apply one-or-more edits as a single patch (housecarl_set_field = one op; housecarl_bulk_apply = many).
     /// Parses each op's FormID + field path + (optional) composition spec to the core's <see cref="WritePatchBuilder.PatchEdit"/>,
-    /// resolves the output path as a NEW MO2 mod folder under ModsDir (folder-per-patch â€” see <see cref="ResolveOutputPath"/>),
-    /// then drives the proven public cleave <see cref="WritePatchBuilder.Apply"/> (resolve winner â†’ derive type â†’ pre-flight
-    /// ALL â†’ override â†’ ApplyVerb â†’ multi-master serialize). ALL-OR-NOTHING (Q3): a single malformed op or pre-flight reject
+    /// resolves the output path as a NEW MO2 mod folder under ModsDir (folder-per-patch — see <see cref="ResolveOutputPath"/>),
+    /// then drives the proven public cleave <see cref="WritePatchBuilder.Apply"/> (resolve winner → derive type → pre-flight
+    /// ALL → override → ApplyVerb → multi-master serialize). ALL-OR-NOTHING (Q3): a single malformed op or pre-flight reject
     /// refuses the whole call with no file written. Writes go to a NEW patch by default; <paramref name="into"/> EXTENDS an
     /// existing houseCARL-owned patch (the multi-session accumulation lever). Returns null-Error outcome on success.
     /// <paramref name="fullReadback"/> additionally reads every touched record back IN FULL off the written file
-    /// (the pre-enable verify loop â€” wishlist #3 re-scoped / HCBR-2026-06-11-02 wave (b)).</summary>
+    /// (the pre-enable verify loop — wishlist #3 re-scoped / HCBR-2026-06-11-02 wave (b)).</summary>
     public WritePatchBuilder.PatchOutcome ApplyEdits(IReadOnlyList<BulkOp> ops, string? patchName, string? into,
         bool fullReadback = false, string? target = null, bool inPlace = false, bool acknowledge = false)
     {
         if (ops.Count == 0)
             return WritePatchBuilder.PatchOutcome.Fail("no operations supplied.");
 
-        // In-place is the explicit, named-file opt-in (the SECOND write lane â€” edit an existing plugin, incl. one
+        // In-place is the explicit, named-file opt-in (the SECOND write lane — edit an existing plugin, incl. one
         // houseCARL didn't author, instead of writing a new patch). Validate the contract up front (Q3): it REQUIRES a
-        // target=, and it is mutually exclusive with into= (which EXTENDS a houseCARL patch â€” a different lane). target=
-        // without in_place is a no-op the caller likely didn't mean â€” name it rather than silently ignore it.
+        // target=, and it is mutually exclusive with into= (which EXTENDS a houseCARL patch — a different lane). target=
+        // without in_place is a no-op the caller likely didn't mean — name it rather than silently ignore it.
         if (inPlace && string.IsNullOrWhiteSpace(target))
             return WritePatchBuilder.PatchOutcome.Fail(
-                "in_place=true requires target=<plugin filename> â€” name the existing plugin to edit in place. (Omit in_place to write a new patch instead â€” the default, originals untouched.)");
+                "in_place=true requires target=<plugin filename> — name the existing plugin to edit in place. (Omit in_place to write a new patch instead — the default, originals untouched.)");
         if (inPlace && !string.IsNullOrWhiteSpace(into))
             return WritePatchBuilder.PatchOutcome.Fail(
                 "in_place=true and into= are mutually exclusive: into= EXTENDS a houseCARL patch, while in_place edits an existing plugin in place. Use one lane or the other.");
@@ -1183,7 +1183,7 @@ public sealed class LoadOrderService : IDisposable
                 "target= is only meaningful with in_place=true (it names the plugin to edit in place). For the default patch lane omit target=; use into= to extend an existing houseCARL patch.");
 
         // Map every op to a core PatchEdit, collecting ALL parse problems first (all-or-nothing, like the cleave).
-        // Pure parsing â€” runs outside the write gate so a malformed call never queues behind a real write.
+        // Pure parsing — runs outside the write gate so a malformed call never queues behind a real write.
         var edits = new List<WritePatchBuilder.PatchEdit>(ops.Count);
         var problems = new List<string>();
         for (int i = 0; i < ops.Count; i++)
@@ -1193,9 +1193,9 @@ public sealed class LoadOrderService : IDisposable
         }
         if (problems.Count > 0)
             return WritePatchBuilder.PatchOutcome.Fail(
-                $"refused â€” {problems.Count} of {ops.Count} operation(s) malformed; NO patch written:\n  - " + string.Join("\n  - ", problems));
+                $"refused — {problems.Count} of {ops.Count} operation(s) malformed; NO patch written:\n  - " + string.Join("\n  - ", problems));
 
-        lock (_writeGate)                                                 // hunt F2: one write at a time, resolveâ†’commit
+        lock (_writeGate)                                                 // hunt F2: one write at a time, resolve→commit
         {
             var resolver = Resolver;                                      // builds/refreshes the index
             var rulebook = Rulebook;
@@ -1213,29 +1213,29 @@ public sealed class LoadOrderService : IDisposable
         }
     }
 
-    /// <summary>The in-place branch of <see cref="ApplyEdits"/> (in-place write lane, Wave 1) â€” runs under _writeGate.
+    /// <summary>The in-place branch of <see cref="ApplyEdits"/> (in-place write lane, Wave 1) — runs under _writeGate.
     /// (1) resolves <paramref name="target"/> to its REAL on-disk path via the load order (NOT the houseCARL-owned
-    /// folder model â€” the foreign-plugin resolver, the sibling of <see cref="ResolveOwnedPatchFolder"/> with the
+    /// folder model — the foreign-plugin resolver, the sibling of <see cref="ResolveOwnedPatchFolder"/> with the
     /// ownership gate DROPPED); (2) enforces the server-side, PERSISTENT first-touch CONSENT handshake (keyed off the
     /// resolved path, stored in <see cref="UserConfigStore"/>); (3) checks the writable parent; (4) drives
     /// <see cref="WritePatchBuilder.ApplyInPlace"/> with the touched-record verify forced ON; (5) on success stamps the
-    /// distinct <c>editedInPlace=</c> marker (NEVER <c>generated=true</c> â€” the user mod must keep failing
+    /// distinct <c>editedInPlace=</c> marker (NEVER <c>generated=true</c> — the user mod must keep failing
     /// <see cref="IsHouseCarlOwned"/> so a later into= can't blind-overwrite it). <paramref name="acknowledge"/> waives
-    /// the CONSENT axis ONLY â€” the verify is a corruption-axis fact no acknowledgement overrides.</summary>
+    /// the CONSENT axis ONLY — the verify is a corruption-axis fact no acknowledgement overrides.</summary>
     WritePatchBuilder.PatchOutcome ApplyEditsInPlace(
         LoadOrderResolver resolver, CorpusRulebook rulebook, IReadOnlyList<WritePatchBuilder.PatchEdit> edits,
         string target, bool acknowledge)
     {
-        // (1) Resolve target -> real on-disk path via the load order (by plugin FILENAME â€” unique in an order). Refuse
+        // (1) Resolve target -> real on-disk path via the load order (by plugin FILENAME — unique in an order). Refuse
         //     loud if it isn't a real active plugin (closes the coincidental-folder collision the into= lane can hit).
         var view = resolver.Capture();
         var targetPath = ResolveActivePluginPath(view, Path.GetFileName(target.Trim()), out var targetName);
         if (targetPath is null)
             return WritePatchBuilder.PatchOutcome.Fail(
-                $"in-place target '{target}' is not an active plugin in the load order â€” name a plugin enabled in MO2, by its " +
+                $"in-place target '{target}' is not an active plugin in the load order — name a plugin enabled in MO2, by its " +
                 "plugin filename (e.g. 'CoolWeapons.esp'). in-place edits the file the game actually loads. Nothing was written.");
 
-        // (2) CONSENT axis â€” the persistent, server-enforced first-touch handshake, keyed off the resolved path. NOT a
+        // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path. NOT a
         //     sticky mode: each in-place write still names its own target=, so this only stops re-explaining the
         //     trade-off; it never makes an ambiguous request route to in-place.
         bool already = _store.IsInPlaceAcknowledged(targetPath);
@@ -1245,21 +1245,21 @@ public sealed class LoadOrderService : IDisposable
         if (!already && acknowledge)
         {
             var (ok, err) = _store.RecordInPlaceAcknowledged(targetPath);
-            if (!ok) ackNote = $"the in-place acknowledgement could not be saved ({err}) â€” the edit proceeded, but a future session will re-prompt for this plugin.";
+            if (!ok) ackNote = $"the in-place acknowledgement could not be saved ({err}) — the edit proceeded, but a future session will re-prompt for this plugin.";
         }
 
-        // (3) Writable, same-volume parent pre-flight â€” refuse rather than degrade (the swap stages a sibling temp in
+        // (3) Writable, same-volume parent pre-flight — refuse rather than degrade (the swap stages a sibling temp in
         //     this dir; AtomicFile.Commit already refuses cross-volume loud, this catches a read-only/locked parent up
         //     front with a clear message before any work).
         if (InPlaceParentUnwritable(targetPath, out var why))
             return WritePatchBuilder.PatchOutcome.Fail(why);
 
-        // (4) The write â€” touched-record verify forced ON (the model-C substitute for the dropped whole-plugin floor).
+        // (4) The write — touched-record verify forced ON (the model-C substitute for the dropped whole-plugin floor).
         var outcome = WritePatchBuilder.ApplyInPlace(resolver, rulebook, edits, targetPath, targetName, fullReadback: true);
 
         // (5) On success, stamp the distinct audit marker + auto-flag a now-stale .seq (both best-effort; neither miss
         //     fails the done edit, Q3-noted). SEQ flag (Track C): an in-place edit can prune a master and shift the own
-        //     records' on-disk FormIDs, staling the plugin's .seq â€” surfaced as a note, never auto-regen'd (Aaron 2026-07-04).
+        //     records' on-disk FormIDs, staling the plugin's .seq — surfaced as a note, never auto-regen'd (Aaron 2026-07-04).
         if (outcome.Success)
         {
             var markerNote = MergeEditedInPlaceMarker(Path.GetDirectoryName(targetPath));
@@ -1269,16 +1269,16 @@ public sealed class LoadOrderService : IDisposable
         }
         else if (ackNote is not null)
         {
-            // The acknowledgement was recorded but the write then failed â€” keep the (now-honest) note alongside the error.
+            // The acknowledgement was recorded but the write then failed — keep the (now-honest) note alongside the error.
             return outcome with { Note = ackNote };
         }
         return outcome;
     }
 
-    /// <summary>Resolve an ACTIVE plugin's on-disk path by filename (in-place write lane) â€” exact match first, then a
-    /// lenient retry appending each plugin extension if the caller dropped it (e.g. 'CoolWeapons' â†’ 'CoolWeapons.esp').
-    /// <paramref name="resolvedName"/> echoes the canonical filename that matched. Null â‡’ no such active plugin (the
-    /// caller refuses loud). The path is the load order's WINNING path for that filename â€” the file the game loads.</summary>
+    /// <summary>Resolve an ACTIVE plugin's on-disk path by filename (in-place write lane) — exact match first, then a
+    /// lenient retry appending each plugin extension if the caller dropped it (e.g. 'CoolWeapons' → 'CoolWeapons.esp').
+    /// <paramref name="resolvedName"/> echoes the canonical filename that matched. Null ⇒ no such active plugin (the
+    /// caller refuses loud). The path is the load order's WINNING path for that filename — the file the game loads.</summary>
     static string? ResolveActivePluginPath(LoadOrderResolver.IndexView view, string raw, out string resolvedName)
     {
         resolvedName = raw;
@@ -1299,17 +1299,17 @@ public sealed class LoadOrderService : IDisposable
     /// xEdit/CK do on save with the touched records VERIFIED and Mutagen trusted for the rest, and the default new-patch
     /// lane stays recommended. Waives the CONSENT axis only (re-call with acknowledge=true).</summary>
     static string InPlaceHandshakeText(string pluginName, string path) =>
-        $"in-place edit of '{pluginName}' â€” first-time confirmation (shown once for this plugin):\n" +
-        $"  â€¢ This writes to your ORIGINAL file ({path}). It will NO LONGER be untouched, and houseCARL keeps NO backup or undo â€” keep your own.\n" +
-        "  â€¢ houseCARL re-lays-out the WHOLE plugin the way xEdit/CK do on save (every record re-serialized), VERIFIES the records you edit, and trusts Mutagen for the rest.\n" +
-        "  â€¢ It still refuses if the file can't be parsed, or carries engine-reserved (sub-0x800) records.\n" +
-        "  â€¢ The default lane (a NEW patch, originals untouched) stays the recommended way â€” this is the explicit opt-in.\n" +
+        $"in-place edit of '{pluginName}' — first-time confirmation (shown once for this plugin):\n" +
+        $"  • This writes to your ORIGINAL file ({path}). It will NO LONGER be untouched, and houseCARL keeps NO backup or undo — keep your own.\n" +
+        "  • houseCARL re-lays-out the WHOLE plugin the way xEdit/CK do on save (every record re-serialized), VERIFIES the records you edit, and trusts Mutagen for the rest.\n" +
+        "  • It still refuses if the file can't be parsed, or carries engine-reserved (sub-0x800) records.\n" +
+        "  • The default lane (a NEW patch, originals untouched) stays the recommended way — this is the explicit opt-in.\n" +
         "Re-call the SAME edit with acknowledge=true to proceed.";
 
-    /// <summary>Writable-parent pre-flight for the in-place swap (Â§6 layer 3): the staged temp is a sibling of the
+    /// <summary>Writable-parent pre-flight for the in-place swap (§6 layer 3): the staged temp is a sibling of the
     /// target, so prove the parent is writable NOW, loud, rather than degrade to a non-atomic write later. True (with a
-    /// named <paramref name="why"/>) â‡’ refuse. Probes by writing + deleting an empty sibling temp. This checks the PARENT
-    /// is writable â€” NOT that the target file isn't EXTERNALLY locked (MO2/xEdit mid-operation); that case isn't
+    /// named <paramref name="why"/>) ⇒ refuse. Probes by writing + deleting an empty sibling temp. This checks the PARENT
+    /// is writable — NOT that the target file isn't EXTERNALLY locked (MO2/xEdit mid-operation); that case isn't
     /// pre-empted here but surfaces LOUD at the <c>File.Replace</c> swap with the original byte-intact (the correct Q3
     /// outcome, not a corruption path), so it needs no separate pre-flight.</summary>
     static bool InPlaceParentUnwritable(string targetPath, out string why)
@@ -1318,7 +1318,7 @@ public sealed class LoadOrderService : IDisposable
         var dir = Path.GetDirectoryName(targetPath);
         if (string.IsNullOrEmpty(dir) || !Directory.Exists(dir))
         {
-            why = $"in-place refused: the target's parent folder '{dir}' does not exist â€” nothing written.";
+            why = $"in-place refused: the target's parent folder '{dir}' does not exist — nothing written.";
             return true;
         }
         try
@@ -1330,16 +1330,16 @@ public sealed class LoadOrderService : IDisposable
         }
         catch (Exception ex)
         {
-            why = $"in-place refused: the target's folder '{dir}' is not writable ({ex.GetType().Name}: {ex.Message}) â€” houseCARL " +
+            why = $"in-place refused: the target's folder '{dir}' is not writable ({ex.GetType().Name}: {ex.Message}) — houseCARL " +
                   "won't degrade to a non-atomic write. Make the mod folder writable (or move the plugin somewhere writable) and retry. Nothing written.";
             return true;
         }
     }
 
     /// <summary>Stamp the distinct <c>[houseCARL] editedInPlace=&lt;ISO&gt;</c> audit line into the target mod's
-    /// <c>meta.ini</c> (the MO2-undeployed mod-root file) â€” a breadcrumb that houseCARL touched this user mod, WITHOUT
+    /// <c>meta.ini</c> (the MO2-undeployed mod-root file) — a breadcrumb that houseCARL touched this user mod, WITHOUT
     /// ever writing <c>generated=true</c> (so <see cref="IsHouseCarlOwned"/> still reads FALSE and a later into= can't
-    /// blind-overwrite it â€” the safety property). PRESERVES every existing line (merges into / creates the
+    /// blind-overwrite it — the safety property). PRESERVES every existing line (merges into / creates the
     /// <c>[houseCARL]</c> section), and only for an MO2 mod folder under ModsDir (never pollutes the game Data dir for a
     /// loose plugin). Best-effort: returns a Q3 note on failure (the edit already succeeded), null on success or N/A.</summary>
     string? MergeEditedInPlaceMarker(string? modFolder)
@@ -1364,7 +1364,7 @@ public sealed class LoadOrderService : IDisposable
                 for (int i = sec + 1; i < lines.Count; i++)
                 {
                     var t = lines[i].Trim();
-                    if (t.StartsWith('[') && t.EndsWith(']')) break;                          // next section â€” stop
+                    if (t.StartsWith('[') && t.EndsWith(']')) break;                          // next section — stop
                     if (t.Replace(" ", "").StartsWith("editedInPlace=", StringComparison.OrdinalIgnoreCase)) { edited = i; break; }
                 }
                 if (edited >= 0) lines[edited] = stamp; else lines.Insert(sec + 1, stamp);    // update-or-insert within the section
@@ -1374,11 +1374,11 @@ public sealed class LoadOrderService : IDisposable
         }
         catch (Exception ex)
         {
-            return $"the editedInPlace audit marker could not be written to the target's meta.ini ({ex.GetType().Name}) â€” the edit itself succeeded.";
+            return $"the editedInPlace audit marker could not be written to the target's meta.ini ({ex.GetType().Name}) — the edit itself succeeded.";
         }
     }
 
-    /// <summary>True iff <paramref name="folder"/> is ModsDir itself or a folder directly/indirectly under it â€” the gate
+    /// <summary>True iff <paramref name="folder"/> is ModsDir itself or a folder directly/indirectly under it — the gate
     /// that keeps the editedInPlace marker out of the game Data dir for a loose (non-MO2-managed) in-place target.</summary>
     bool IsUnderModsDir(string folder)
     {
@@ -1402,16 +1402,16 @@ public sealed class LoadOrderService : IDisposable
         return present.Length == 0 ? null : string.Join(" ", present);
     }
 
-    /// <summary>The in-place SEQ auto-flag (Track C / Heisen Â§3 gap-4, Aaron 2026-07-04: FLAG, never auto-regen). After an
+    /// <summary>The in-place SEQ auto-flag (Track C / Heisen §3 gap-4, Aaron 2026-07-04: FLAG, never auto-regen). After an
     /// in-place write that re-serialized <paramref name="targetPath"/>, a master-prune may have shifted every own record's
-    /// on-disk FormID and staled the plugin's <c>.seq</c> â€” its Start-Game-Enabled quests would then silently never start
+    /// on-disk FormID and staled the plugin's <c>.seq</c> — its Start-Game-Enabled quests would then silently never start
     /// on a fresh save. Resolve the plugin's <c>.seq</c> through the SAME captured VFS view the compact SEQ gate uses
-    /// (loose roots + active BSAs â€” not a bare folder check, which would miss a <c>write_seq</c>-filed or BSA-packed .seq),
+    /// (loose roots + active BSAs — not a bare folder check, which would miss a <c>write_seq</c>-filed or BSA-packed .seq),
     /// and if a LOOSE <c>.seq</c> exists but no longer lists one or more SGE quests at their CURRENT on-disk FormIDs,
     /// return a WARNING naming them + the fix (<c>housecarl_write_seq</c>). Null when there's nothing to flag (no .seq, a
-    /// BSA-only .seq whose bytes we can't check here, or every SGE quest still covered â€” an ordinary in-place edit that
+    /// BSA-only .seq whose bytes we can't check here, or every SGE quest still covered — an ordinary in-place edit that
     /// changed no masters leaves the FormIDs put, so a previously-valid .seq stays covered and this stays quiet). BEST-
-    /// EFFORT (Q3): any failure yields a soft advisory, never a throw â€” the write already succeeded, and a freshness check
+    /// EFFORT (Q3): any failure yields a soft advisory, never a throw — the write already succeeded, and a freshness check
     /// that couldn't run must not fail the done edit, but it says so rather than going silent.</summary>
     string? SeqStaleInPlaceNote(string targetPath, string targetName)
     {
@@ -1422,9 +1422,9 @@ public sealed class LoadOrderService : IDisposable
             var av = assetResolver.Capture();
             var seqRel = $@"SEQ\{Path.GetFileNameWithoutExtension(targetPath)}.seq";
             var seqSource = av.ResolveForPlacement(seqRel).Sources.FirstOrDefault();
-            if (seqSource?.LooseFilePath is not { } seqPath) return null;      // no .seq, or a BSA-only one (bytes uncheckable here) â†’ nothing to flag
+            if (seqSource?.LooseFilePath is not { } seqPath) return null;      // no .seq, or a BSA-only one (bytes uncheckable here) → nothing to flag
             var uncovered = SeqFile.UncoveredSgeQuests(targetPath, File.ReadAllBytes(seqPath));
-            if (uncovered.Count == 0) return null;                            // the .seq still lists every SGE quest â†’ not staled
+            if (uncovered.Count == 0) return null;                            // the .seq still lists every SGE quest → not staled
             var names = string.Join(", ", uncovered.Select(q => q.EditorId ?? q.FormKey.ToString()));
             bool one = uncovered.Count == 1;
             return $"the .seq for '{targetName}' no longer lists {(one ? "its start-game-enabled quest" : $"{uncovered.Count} of its start-game-enabled quests")} "
@@ -1433,33 +1433,33 @@ public sealed class LoadOrderService : IDisposable
         }
         catch (Exception ex)
         {
-            return $"could not check whether '{targetName}'s .seq is still current after this edit ({ex.GetType().Name}) â€” "
+            return $"could not check whether '{targetName}'s .seq is still current after this edit ({ex.GetType().Name}) — "
                  + "if it has start-game-enabled quests, run housecarl_validate_dialogue on the quest to confirm the .seq still lists them.";
         }
     }
 
-    /// <summary>Remove WHOLE records a houseCARL patch carries (housecarl_remove_record) â€” literal drop-from-plugin, the
+    /// <summary>Remove WHOLE records a houseCARL patch carries (housecarl_remove_record) — literal drop-from-plugin, the
     /// companion to <see cref="ApplyEdits"/>. In the DEFAULT lane <paramref name="patch"/> is REQUIRED and names an existing
-    /// houseCARL-owned patch (resolved + ownership-gated via the same <c>into=</c> path as an extend â€” refuses a folder
+    /// houseCARL-owned patch (resolved + ownership-gated via the same <c>into=</c> path as an extend — refuses a folder
     /// houseCARL didn't create, Q3); removal only makes sense against a patch that already carries the record. In the
     /// IN-PLACE lane (Wave 2: <paramref name="target"/> + <paramref name="inPlace"/>) it drops the record from an EXISTING
-    /// plugin in place (incl. one houseCARL didn't author) instead â€” see <see cref="RemoveRecordsInPlace"/>. Parses every
+    /// plugin in place (incl. one houseCARL didn't author) instead — see <see cref="RemoveRecordsInPlace"/>. Parses every
     /// formid (all-or-nothing on a malformed one), then drives <see cref="WritePatchBuilder.RemoveRecords"/> (present-check
-    /// â†’ mod.Remove â†’ re-serialize, with clean-masters riding along). The default lane never touches originals (only the
+    /// → mod.Remove → re-serialize, with clean-masters riding along). The default lane never touches originals (only the
     /// patch folder is written).</summary>
     public WritePatchBuilder.RemovalOutcome RemoveRecords(IReadOnlyList<string> formids, string? patch,
         string? target = null, bool inPlace = false, bool acknowledge = false)
     {
         if (formids is null || formids.Count == 0)
-            return WritePatchBuilder.RemovalOutcome.Fail("no formids supplied â€” pass the FormID(s) of the record(s) to remove.");
+            return WritePatchBuilder.RemovalOutcome.Fail("no formids supplied — pass the FormID(s) of the record(s) to remove.");
 
-        // In-place is the explicit, named-file opt-in (the SECOND remove lane â€” drop a record from an EXISTING plugin, incl.
+        // In-place is the explicit, named-file opt-in (the SECOND remove lane — drop a record from an EXISTING plugin, incl.
         // one houseCARL didn't author, instead of from a houseCARL patch). Validate the contract up front (Q3): it REQUIRES
         // a target=, and it is mutually exclusive with patch= (the houseCARL-owned lane). target= without in_place is a
-        // no-op the caller likely didn't mean â€” name it rather than silently ignore it. (Mirrors ApplyEdits' contract.)
+        // no-op the caller likely didn't mean — name it rather than silently ignore it. (Mirrors ApplyEdits' contract.)
         if (inPlace && string.IsNullOrWhiteSpace(target))
             return WritePatchBuilder.RemovalOutcome.Fail(
-                "in_place=true requires target=<plugin filename> â€” name the existing plugin to remove the record from in place. (Omit in_place to drop the record from a houseCARL patch instead â€” the default.)");
+                "in_place=true requires target=<plugin filename> — name the existing plugin to remove the record from in place. (Omit in_place to drop the record from a houseCARL patch instead — the default.)");
         if (inPlace && !string.IsNullOrWhiteSpace(patch))
             return WritePatchBuilder.RemovalOutcome.Fail(
                 "in_place=true and patch= are mutually exclusive: patch= drops a record from a houseCARL patch, while in_place removes it from an existing plugin in place. Use one lane or the other.");
@@ -1468,9 +1468,9 @@ public sealed class LoadOrderService : IDisposable
                 "target= is only meaningful with in_place=true (it names the plugin to remove from in place). For the default lane omit target=; use patch= to name the houseCARL patch.");
         if (!inPlace && string.IsNullOrWhiteSpace(patch))
             return WritePatchBuilder.RemovalOutcome.Fail(
-                "patch is required â€” name the houseCARL patch to remove the record from (removal only targets a patch that already carries it). To remove from an existing plugin IN PLACE instead, pass target=<plugin filename> + in_place=true.");
+                "patch is required — name the houseCARL patch to remove the record from (removal only targets a patch that already carries it). To remove from an existing plugin IN PLACE instead, pass target=<plugin filename> + in_place=true.");
 
-        // Parse every formid first, collecting ALL problems (all-or-nothing, like the edit path). Pure â€” outside the gate.
+        // Parse every formid first, collecting ALL problems (all-or-nothing, like the edit path). Pure — outside the gate.
         var keys = new List<FormKey>(formids.Count);
         var problems = new List<string>();
         for (int i = 0; i < formids.Count; i++)
@@ -1482,16 +1482,16 @@ public sealed class LoadOrderService : IDisposable
         }
         if (problems.Count > 0)
             return WritePatchBuilder.RemovalOutcome.Fail(
-                $"refused â€” {problems.Count} of {formids.Count} formid(s) malformed; NOTHING removed:\n  - " + string.Join("\n  - ", problems));
+                $"refused — {problems.Count} of {formids.Count} formid(s) malformed; NOTHING removed:\n  - " + string.Join("\n  - ", problems));
 
-        lock (_writeGate)                                                 // hunt F2: removal re-serializes the patch â€” same gate
+        lock (_writeGate)                                                 // hunt F2: removal re-serializes the patch — same gate
         {
             var resolver = Resolver;                                      // builds/refreshes the index (Overlays for the re-serialize)
 
             if (inPlace)
                 return RemoveRecordsInPlace(resolver, keys, target!.Trim(), acknowledge);
 
-            // Resolve + ownership-gate the patch path via the into= (extend) path â€” must exist + carry the houseCARL marker.
+            // Resolve + ownership-gate the patch path via the into= (extend) path — must exist + carry the houseCARL marker.
             string outPath;
             try { outPath = ResolveOutputPath(patchName: null, into: patch, out _, out _); }
             catch (Exception ex) { return WritePatchBuilder.RemovalOutcome.Fail(ex.Message); }
@@ -1500,16 +1500,16 @@ public sealed class LoadOrderService : IDisposable
         }
     }
 
-    /// <summary>The in-place branch of <see cref="RemoveRecords"/> (in-place write lane, Wave 2) â€” runs under _writeGate.
+    /// <summary>The in-place branch of <see cref="RemoveRecords"/> (in-place write lane, Wave 2) — runs under _writeGate.
     /// The remove counterpart of <see cref="ApplyEditsInPlace"/>, and it REUSES every Wave-1 in-place seam: the same
     /// foreign-target resolver (<see cref="ResolveActivePluginPath"/>), the same PERSISTENT first-touch CONSENT handshake
-    /// (keyed off the resolved path in <see cref="UserConfigStore"/>, SHARED with the edit + create lanes â€” acknowledging a
+    /// (keyed off the resolved path in <see cref="UserConfigStore"/>, SHARED with the edit + create lanes — acknowledging a
     /// plugin once covers all three), the same writable-parent pre-flight, and the same distinct <c>editedInPlace=</c>
-    /// marker (NEVER <c>generated=true</c> â€” the user mod keeps failing <see cref="IsHouseCarlOwned"/> so a later into=
+    /// marker (NEVER <c>generated=true</c> — the user mod keeps failing <see cref="IsHouseCarlOwned"/> so a later into=
     /// can't blind-overwrite it). It drives <see cref="WritePatchBuilder.RemoveRecordsInPlace"/> (drop the record from the
-    /// target's OWN file, with the absence verify forced ON). <paramref name="acknowledge"/> waives the CONSENT axis ONLY â€”
+    /// target's OWN file, with the absence verify forced ON). <paramref name="acknowledge"/> waives the CONSENT axis ONLY —
     /// the verify is a corruption-axis fact no acknowledgement overrides. (No CorpusRulebook: a removal pre-flights nothing
-    /// â€” the present-check that the target carries the record is the whole gate.)</summary>
+    /// — the present-check that the target carries the record is the whole gate.)</summary>
     WritePatchBuilder.RemovalOutcome RemoveRecordsInPlace(
         LoadOrderResolver resolver, IReadOnlyList<FormKey> keys, string target, bool acknowledge)
     {
@@ -1519,12 +1519,12 @@ public sealed class LoadOrderService : IDisposable
         var targetPath = ResolveActivePluginPath(view, Path.GetFileName(target.Trim()), out var targetName);
         if (targetPath is null)
             return WritePatchBuilder.RemovalOutcome.Fail(
-                $"in-place target '{target}' is not an active plugin in the load order â€” name a plugin enabled in MO2, by its " +
+                $"in-place target '{target}' is not an active plugin in the load order — name a plugin enabled in MO2, by its " +
                 "plugin filename (e.g. 'CoolWeapons.esp'). in-place removes from the file the game actually loads. Nothing was written.");
 
-        // (2) CONSENT axis â€” the persistent, server-enforced first-touch handshake, keyed off the resolved path (shared
+        // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path (shared
         //     with the edit + create lanes: acknowledging a plugin once covers editing, creating into, AND removing from
-        //     it in place â€” it's the same "touch your original" trade-off).
+        //     it in place — it's the same "touch your original" trade-off).
         bool already = _store.IsInPlaceAcknowledged(targetPath);
         if (!already && !acknowledge)
             return WritePatchBuilder.RemovalOutcome.NeedsAck(InPlaceHandshakeText(targetName, targetPath));
@@ -1532,19 +1532,19 @@ public sealed class LoadOrderService : IDisposable
         if (!already && acknowledge)
         {
             var (ok, err) = _store.RecordInPlaceAcknowledged(targetPath);
-            if (!ok) ackNote = $"the in-place acknowledgement could not be saved ({err}) â€” the removal proceeded, but a future session will re-prompt for this plugin.";
+            if (!ok) ackNote = $"the in-place acknowledgement could not be saved ({err}) — the removal proceeded, but a future session will re-prompt for this plugin.";
         }
 
-        // (3) Writable, same-volume parent pre-flight â€” refuse rather than degrade (the swap stages a sibling temp here).
+        // (3) Writable, same-volume parent pre-flight — refuse rather than degrade (the swap stages a sibling temp here).
         if (InPlaceParentUnwritable(targetPath, out var why))
             return WritePatchBuilder.RemovalOutcome.Fail(why);
 
-        // (4) The write â€” absence verify forced ON (the model-C substitute for the dropped whole-plugin floor).
+        // (4) The write — absence verify forced ON (the model-C substitute for the dropped whole-plugin floor).
         var outcome = WritePatchBuilder.RemoveRecordsInPlace(resolver, keys, targetPath, targetName);
 
         // (5) On success, stamp the distinct audit marker + auto-flag a now-stale .seq (both best-effort; neither miss
         //     fails the done removal, Q3-noted). SEQ flag (Track C): a removal can drop the last reference to a master
-        //     (a prune) and shift on-disk FormIDs, staling the plugin's .seq â€” surfaced, never auto-regenerated.
+        //     (a prune) and shift on-disk FormIDs, staling the plugin's .seq — surfaced, never auto-regenerated.
         if (outcome.Success)
         {
             var markerNote = MergeEditedInPlaceMarker(Path.GetDirectoryName(targetPath));
@@ -1554,28 +1554,28 @@ public sealed class LoadOrderService : IDisposable
         }
         else if (ackNote is not null)
         {
-            // The acknowledgement was recorded but the write then failed â€” keep the (now-honest) note alongside the error.
+            // The acknowledgement was recorded but the write then failed — keep the (now-honest) note alongside the error.
             return outcome with { Note = ackNote };
         }
         return outcome;
     }
 
     /// <summary>Forward a NAMED plugin's version of one-or-more records into a patch as an override (housecarl_forward_record)
-    /// â€” xEdit's "copy as override into", the inverse of <see cref="ApplyEdits"/>'s winner-override. Parses every formid
+    /// — xEdit's "copy as override into", the inverse of <see cref="ApplyEdits"/>'s winner-override. Parses every formid
     /// (all-or-nothing on a malformed one), resolves the folder-per-patch output (fresh, or <paramref name="into"/> an
     /// existing houseCARL-owned patch), then drives <see cref="WritePatchBuilder.ForwardRecords"/> (resolve each source
-    /// body from <paramref name="fromPlugin"/> â†’ deep-copy as override â†’ multi-master serialize). The whole source record
-    /// is copied verbatim, so the SOURCE plugin (not the load-order winner) decides the content â€” and forwarding the
+    /// body from <paramref name="fromPlugin"/> → deep-copy as override → multi-master serialize). The whole source record
+    /// is copied verbatim, so the SOURCE plugin (not the load-order winner) decides the content — and forwarding the
     /// ORIGIN master reverts a record to vanilla. Originals are never touched (only the patch folder is written).</summary>
     public WritePatchBuilder.ForwardOutcome ForwardRecords(IReadOnlyList<string> formids, string fromPlugin, string? patchName, string? into, bool fullReadback = false)
     {
         if (string.IsNullOrWhiteSpace(fromPlugin))
             return WritePatchBuilder.ForwardOutcome.Fail(
-                "from_plugin is required â€” name the plugin whose version of the record(s) to forward (the earlier override, or a master to revert to vanilla).");
+                "from_plugin is required — name the plugin whose version of the record(s) to forward (the earlier override, or a master to revert to vanilla).");
         if (formids is null || formids.Count == 0)
-            return WritePatchBuilder.ForwardOutcome.Fail("no formids supplied â€” pass the FormID(s) to forward from the source plugin.");
+            return WritePatchBuilder.ForwardOutcome.Fail("no formids supplied — pass the FormID(s) to forward from the source plugin.");
 
-        // Parse every formid first, collecting ALL problems (all-or-nothing, like the edit/remove paths). Pure â€” outside the gate.
+        // Parse every formid first, collecting ALL problems (all-or-nothing, like the edit/remove paths). Pure — outside the gate.
         var fp = fromPlugin.Trim();
         var specs = new List<WritePatchBuilder.ForwardSpec>(formids.Count);
         var problems = new List<string>();
@@ -1588,9 +1588,9 @@ public sealed class LoadOrderService : IDisposable
         }
         if (problems.Count > 0)
             return WritePatchBuilder.ForwardOutcome.Fail(
-                $"refused â€” {problems.Count} of {formids.Count} formid(s) malformed; NOTHING forwarded:\n  - " + string.Join("\n  - ", problems));
+                $"refused — {problems.Count} of {formids.Count} formid(s) malformed; NOTHING forwarded:\n  - " + string.Join("\n  - ", problems));
 
-        lock (_writeGate)                                                 // hunt F2: one write at a time, resolveâ†’commit
+        lock (_writeGate)                                                 // hunt F2: one write at a time, resolve→commit
         {
             var resolver = Resolver;                                      // builds/refreshes the index (Overlays for the source fetch + serialize)
 
@@ -1604,11 +1604,11 @@ public sealed class LoadOrderService : IDisposable
         }
     }
 
-    /// <summary>Create an EMPTY, HEADER-ONLY plugin (housecarl_create_plugin) â€” a valid TES4 header with ZERO records,
+    /// <summary>Create an EMPTY, HEADER-ONLY plugin (housecarl_create_plugin) — a valid TES4 header with ZERO records,
     /// no masters, optionally ESL-flagged, named EXACTLY <paramref name="pluginName"/>. The clean primitive for "I need
-    /// plugin <c>Foo.esp</c> to exist" (a basename-bound SKSE config trigger, a placeholder ESL, a dummy master) â€” it
+    /// plugin <c>Foo.esp</c> to exist" (a basename-bound SKSE config trigger, a placeholder ESL, a dummy master) — it
     /// authors no record, so it adds no conflict footprint (HCBR-2026-06-19-02). UNLIKE the patch-write paths, the name
-    /// is used VERBATIM â€” never auto-suffixed â€” because a trigger plugin's whole job is that its basename matches the
+    /// is used VERBATIM — never auto-suffixed — because a trigger plugin's whole job is that its basename matches the
     /// config bound to it; so a name collision REFUSES loud (Q3) rather than rename or overwrite: (a) a plugin of that
     /// basename already active in the order (creating another would shadow it), or (b) a houseCARL mod folder of that
     /// name already on disk. The core <see cref="WritePatchBuilder.CreatePlugin"/> builds + serializes + re-reads to
@@ -1617,14 +1617,14 @@ public sealed class LoadOrderService : IDisposable
     {
         if (string.IsNullOrWhiteSpace(pluginName))
             return WritePatchBuilder.CreatePluginOutcome.Fail(
-                "plugin_name is required â€” a header-only plugin has no record to derive a name from, so name it explicitly (e.g. 'Authoria - CraftingCategories').");
+                "plugin_name is required — a header-only plugin has no record to derive a name from, so name it explicitly (e.g. 'Authoria - CraftingCategories').");
 
         var stem = PatchStem(pluginName);
         if (string.IsNullOrWhiteSpace(stem))
             return WritePatchBuilder.CreatePluginOutcome.Fail(
-                $"plugin_name '{pluginName}' has no usable name once path parts and the plugin extension are stripped â€” give a plain name like 'MyTrigger'.");
+                $"plugin_name '{pluginName}' has no usable name once path parts and the plugin extension are stripped — give a plain name like 'MyTrigger'.");
 
-        lock (_writeGate)                                                 // hunt F2: one write at a time, resolveâ†’commit
+        lock (_writeGate)                                                 // hunt F2: one write at a time, resolve→commit
         {
             // Touch Resolver FIRST: in instance mode _modsDir is derived LAZILY (EnsurePathsDerived runs inside the
             // Resolver getter), so a cold first-call (create_plugin before any read warmed the index) would otherwise
@@ -1634,18 +1634,18 @@ public sealed class LoadOrderService : IDisposable
             if (!Directory.Exists(_modsDir))
                 return WritePatchBuilder.CreatePluginOutcome.Fail($"cannot write: ModsDir '{_modsDir}' does not exist. Check HouseCarl:ModsDir.");
 
-            // COLLISION (Q3): the basename is load-bearing for a trigger, so NEVER auto-suffix â€” refuse loud instead.
-            // (a) an active plugin already owns this basename â€” a second one would shadow it (MO2 picks one by mod order).
+            // COLLISION (Q3): the basename is load-bearing for a trigger, so NEVER auto-suffix — refuse loud instead.
+            // (a) an active plugin already owns this basename — a second one would shadow it (MO2 picks one by mod order).
             foreach (var ext in PluginExts)                              // .esp / .esm / .esl
                 if (view.ContainsPlugin(stem + ext))
                     return WritePatchBuilder.CreatePluginOutcome.Fail(
-                        $"a plugin named '{stem + ext}' is already active in your load order â€” a header-only trigger needs a UNIQUE basename (a second one would shadow it, MO2 picking the winner by mod order). Choose a different name.");
-            // (b) a houseCARL mod folder of this exact name already exists â€” don't overwrite (could clobber a real patch
+                        $"a plugin named '{stem + ext}' is already active in your load order — a header-only trigger needs a UNIQUE basename (a second one would shadow it, MO2 picking the winner by mod order). Choose a different name.");
+            // (b) a houseCARL mod folder of this exact name already exists — don't overwrite (could clobber a real patch
             //     sharing the name) and don't auto-rename (would break the basename trigger): refuse and point at it.
             var folder = Path.Combine(_modsDir, ModFolderName(stem));
             if (Directory.Exists(folder))
                 return WritePatchBuilder.CreatePluginOutcome.Fail(
-                    $"a houseCARL output folder '{ModFolderName(stem)}' already exists â€” houseCARL won't auto-rename a header-only plugin (its exact basename is what makes the trigger resolve). Remove that folder in MO2, or choose a different name.");
+                    $"a houseCARL output folder '{ModFolderName(stem)}' already exists — houseCARL won't auto-rename a header-only plugin (its exact basename is what makes the trigger resolve). Remove that folder in MO2, or choose a different name.");
 
             Directory.CreateDirectory(folder);
             var plugin = stem + ".esp";
@@ -1658,35 +1658,35 @@ public sealed class LoadOrderService : IDisposable
         }
     }
 
-    /// <summary>COMPACT / ESL-renumber a plugin (housecarl_compact_plugin, A2) â€” the data-layer twin of xEdit's "Compact
-    /// FormIDs for ESL". Renumbers <paramref name="pluginName"/>'s ORIGINATING records (flat AND nested â€” cells, placed
-    /// refs, dialog INFOs) into the light range 0x800â€“0xFFF (the 2048-ID window; <paramref name="esl"/>=false renumbers
+    /// <summary>COMPACT / ESL-renumber a plugin (housecarl_compact_plugin, A2) — the data-layer twin of xEdit's "Compact
+    /// FormIDs for ESL". Renumbers <paramref name="pluginName"/>'s ORIGINATING records (flat AND nested — cells, placed
+    /// refs, dialog INFOs) into the light range 0x800–0xFFF (the 2048-ID window; <paramref name="esl"/>=false renumbers
     /// contiguously without the light flag / ceiling), repoints every internal reference, keeps overrides at their master
-    /// FormIDs, and emits the result. Output model (Aaron 2026-06-26): a NEW plugin Pâ€² keeping the source's EXACT basename
-    /// (so external masters still resolve) in a fresh houseCARL mod folder by default â€” original UNTOUCHED, reviewable in
+    /// FormIDs, and emits the result. Output model (Aaron 2026-06-26): a NEW plugin P′ keeping the source's EXACT basename
+    /// (so external masters still resolve) in a fresh houseCARL mod folder by default — original UNTOUCHED, reviewable in
     /// xEdit before you swap; <paramref name="inPlace"/>=true overwrites the original instead (the xEdit norm; rides the
     /// in-place consent, no backup).
     ///
-    /// <para>The load-bearing safety (Q3, plan Â§2): renumbering breaks any reference from OUTSIDE the plugin (they'd point
+    /// <para>The load-bearing safety (Q3, plan §2): renumbering breaks any reference from OUTSIDE the plugin (they'd point
     /// at FormIDs that no longer exist). The identify-pass finds those external referencers across the whole order. NO
-    /// external referencers â‡’ the clean default path (emit Pâ€², done). External referencers present â‡’ REFUSED LOUD with the
+    /// external referencers ⇒ the clean default path (emit P′, done). External referencers present ⇒ REFUSED LOUD with the
     /// list, UNLESS <paramref name="repointExternals"/>=true, which ALSO rewrites each of them in place to follow the
     /// renumber. Any in-place overwrite (the target in the in-place lane, and/or the external referencers) requires
-    /// <paramref name="acknowledge"/>=true â€” a first call without it returns a CONFIRM prompt listing exactly what will be
+    /// <paramref name="acknowledge"/>=true — a first call without it returns a CONFIRM prompt listing exactly what will be
     /// rewritten (never a silent original-file edit).</para>
     ///
     /// <para>Refuses loud + writes nothing on: the plugin not active / excluded (unparseable) / not on disk; MORE than the
-    /// light window holds (the hard ESL ceiling â€” named, never truncated); a declared master not active; a serialize fault.
+    /// light window holds (the hard ESL ceiling — named, never truncated); a declared master not active; a serialize fault.
     /// Renumber mechanism + nested coverage: <see cref="RemapEngine.RenumberModInto"/> (remap-wave1/2). Serialized on the
-    /// write gate; the identify-pass is one whole-order link walk (~25s at full scale â€” a deliberate, one-shot operation).</para></summary>
+    /// write gate; the identify-pass is one whole-order link walk (~25s at full scale — a deliberate, one-shot operation).</para></summary>
     public WritePatchBuilder.CompactOutcome CompactPlugin(
         string pluginName, bool esl = true, bool inPlace = false, bool repointExternals = false,
         bool acknowledge = false, string? patchName = null)
     {
         if (string.IsNullOrWhiteSpace(pluginName))
-            return WritePatchBuilder.CompactOutcome.Fail("plugin is required â€” name the plugin filename to compact (e.g. 'CoolMod.esp').");
+            return WritePatchBuilder.CompactOutcome.Fail("plugin is required — name the plugin filename to compact (e.g. 'CoolMod.esp').");
 
-        lock (_writeGate)                                                 // one write at a time; the whole resolveâ†’buildâ†’repoint runs under it
+        lock (_writeGate)                                                 // one write at a time; the whole resolve→build→repoint runs under it
         {
             var resolver = Resolver;                                      // builds/refreshes; reentrant with _writeGate
             var view = resolver.Capture();
@@ -1696,14 +1696,14 @@ public sealed class LoadOrderService : IDisposable
             var name = pluginName.Trim();
             if (!view.ContainsPlugin(name))
                 return WritePatchBuilder.CompactOutcome.Fail(
-                    $"'{name}' is not an active plugin in your load order â€” compact targets an active plugin (so its records, and the plugins that reference it, can be read). Pass the exact filename (e.g. 'CoolMod.esp').");
+                    $"'{name}' is not an active plugin in your load order — compact targets an active plugin (so its records, and the plugins that reference it, can be read). Pass the exact filename (e.g. 'CoolMod.esp').");
             if (view.ExcludedPlugins.TryGetValue(name, out var excluded))
                 return WritePatchBuilder.CompactOutcome.Fail(
-                    $"cannot compact '{name}': it was EXCLUDED from this session ({excluded}) â€” houseCARL won't renumber a plugin it can't fully parse. The file is untouched.");
+                    $"cannot compact '{name}': it was EXCLUDED from this session ({excluded}) — houseCARL won't renumber a plugin it can't fully parse. The file is untouched.");
 
             var srcPath = view.PluginPath(name);
             if (srcPath is null || !File.Exists(srcPath))
-                return WritePatchBuilder.CompactOutcome.Fail($"'{name}' not found on disk at {srcPath ?? "<unresolved>"} â€” nothing to compact.");
+                return WritePatchBuilder.CompactOutcome.Fail($"'{name}' not found on disk at {srcPath ?? "<unresolved>"} — nothing to compact.");
 
             ModKey modKey;
             try { modKey = ModKey.FromFileName(name); }
@@ -1714,64 +1714,64 @@ public sealed class LoadOrderService : IDisposable
                 return WritePatchBuilder.CompactOutcome.Fail(keyErr!);
             if (keys.Count == 0)
                 return WritePatchBuilder.CompactOutcome.Fail(
-                    $"'{name}' defines no originating records to renumber (it carries only overrides, or is empty) â€” nothing to compact.");
+                    $"'{name}' defines no originating records to renumber (it carries only overrides, or is empty) — nothing to compact.");
 
             uint floor = RemapEngine.EslFloor;
             uint ceiling = esl ? RemapEngine.EslCeiling : FormIdRange.ObjectIdMax;   // light window, or the full 24-bit object-ID range
             var plan = RemapEngine.BuildSequentialRemap(keys, modKey, floor, ceiling);
             if (!plan.Success) return WritePatchBuilder.CompactOutcome.Fail(plan.Error!);
 
-            // 2. identify-pass â€” which plugins OUTSIDE the target reference a record being renumbered (the break risk).
+            // 2. identify-pass — which plugins OUTSIDE the target reference a record being renumbered (the break risk).
             var targets = plan.Dict.Keys.ToHashSet();
             var transformSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { name };
             var id = RemapEngine.IdentifyExternalReferencers(resolver, targets, transformSet);
 
-            // 3. external-referencer policy (Q3 â€” never silently ship a compaction that dangles an external reference).
+            // 3. external-referencer policy (Q3 — never silently ship a compaction that dangles an external reference).
             if (id.HasExternalReferencers)
             {
-                var refList = $"{string.Join(", ", id.ExternalPlugins.Take(25))}{(id.ExternalPlugins.Count > 25 ? $", â€¦ (+{id.ExternalPlugins.Count - 25} more)" : "")}";
+                var refList = $"{string.Join(", ", id.ExternalPlugins.Take(25))}{(id.ExternalPlugins.Count > 25 ? $", … (+{id.ExternalPlugins.Count - 25} more)" : "")}";
                 if (!repointExternals)
                     return WritePatchBuilder.CompactOutcome.Fail(
-                        $"refused â€” {id.ExternalPlugins.Count} plugin(s) outside '{name}' reference records it is about to renumber; compacting it " +
+                        $"refused — {id.ExternalPlugins.Count} plugin(s) outside '{name}' reference records it is about to renumber; compacting it " +
                         $"WOULD BREAK those references (they would point at FormIDs that no longer exist). Referencers: {refList}. " +
                         "Re-run with repoint_externals=true AND in_place=true (+ acknowledge=true) to ALSO rewrite those plugins in place to follow " +
                         "the renumber, or handle them yourself first. Nothing was written.");
                 // repoint is only COHERENT paired with in_place (PR #122 review #1): in the new-file lane the renumbered
-                // records live ONLY in the not-yet-active Pâ€², so repointing the externals now would leave them dangling
-                // against the still-active original until the MO2 swap â€” and broken if the user rejects Pâ€². Couple them.
+                // records live ONLY in the not-yet-active P′, so repointing the externals now would leave them dangling
+                // against the still-active original until the MO2 swap — and broken if the user rejects P′. Couple them.
                 if (!inPlace)
                     return WritePatchBuilder.CompactOutcome.Fail(
-                        $"refused â€” repoint_externals requires in_place=true. {id.ExternalPlugins.Count} plugin(s) reference records being renumbered " +
-                        $"({refList}); in the new-file lane those records exist ONLY in the not-yet-active Pâ€², so repointing the externals now would leave " +
-                        "them dangling against the still-active original until you complete the MO2 swap (and broken if you reject Pâ€²). Either compact IN " +
-                        "PLACE (in_place=true) so the target and its referrers move together, or handle the externals yourself after enabling Pâ€². Nothing was written.");
+                        $"refused — repoint_externals requires in_place=true. {id.ExternalPlugins.Count} plugin(s) reference records being renumbered " +
+                        $"({refList}); in the new-file lane those records exist ONLY in the not-yet-active P′, so repointing the externals now would leave " +
+                        "them dangling against the still-active original until you complete the MO2 swap (and broken if you reject P′). Either compact IN " +
+                        "PLACE (in_place=true) so the target and its referrers move together, or handle the externals yourself after enabling P′. Nothing was written.");
             }
 
-            // 4. consent gate â€” any in-place overwrite (the target, and/or the external referencers) needs acknowledge=true.
+            // 4. consent gate — any in-place overwrite (the target, and/or the external referencers) needs acknowledge=true.
             bool willOverwriteTarget = inPlace;
             bool willRepoint = id.HasExternalReferencers && repointExternals;
             if ((willOverwriteTarget || willRepoint) && !acknowledge)
             {
                 var c = new System.Text.StringBuilder();
-                c.Append("CONFIRM in-place rewrite (your ORIGINAL file(s) will be rewritten â€” no houseCARL backup or undo; keep your own):\n");
+                c.Append("CONFIRM in-place rewrite (your ORIGINAL file(s) will be rewritten — no houseCARL backup or undo; keep your own):\n");
                 if (willOverwriteTarget) c.Append($"  - '{name}' will be OVERWRITTEN in place with its compacted form.\n");
                 if (willRepoint)
                 {
                     c.Append($"  - {id.ExternalPlugins.Count} external referencer(s) will be REWRITTEN in place to repoint to the new FormIDs:\n");
-                    foreach (var pl in id.ExternalPlugins.Take(25)) c.Append($"      Â· {pl}\n");
-                    if (id.ExternalPlugins.Count > 25) c.Append($"      Â· â€¦ (+{id.ExternalPlugins.Count - 25} more)\n");
+                    foreach (var pl in id.ExternalPlugins.Take(25)) c.Append($"      · {pl}\n");
+                    if (id.ExternalPlugins.Count > 25) c.Append($"      · … (+{id.ExternalPlugins.Count - 25} more)\n");
                 }
                 c.Append("Re-call with acknowledge=true to proceed.");
                 return WritePatchBuilder.CompactOutcome.Confirm(c.ToString());
             }
 
-            // pre-flight the in-place target's parent is writable BEFORE any work â€” the in-place edit lane's layer-3 check,
+            // pre-flight the in-place target's parent is writable BEFORE any work — the in-place edit lane's layer-3 check,
             // a nicer early refusal than failing deep in the atomic swap (PR #122 review #2). Each external referencer gets
             // the same guarantee inside RepointInPlace's own all-or-nothing write.
             if (inPlace && InPlaceParentUnwritable(srcPath, out var unwritable))
                 return WritePatchBuilder.CompactOutcome.Fail(unwritable);
 
-            // 5. output location â€” in-place (overwrite the original) or a NEW file keeping the source's EXACT basename in
+            // 5. output location — in-place (overwrite the original) or a NEW file keeping the source's EXACT basename in
             //    a fresh houseCARL mod folder (so its masters still resolve; the user swaps the folder in MO2 to use it).
             string outPath; bool createdFresh = false; RiderFolder rf = default;
             if (inPlace) outPath = srcPath;
@@ -1780,7 +1780,7 @@ public sealed class LoadOrderService : IDisposable
                 try { rf = ResolvePatchModFolder(patchName, null, Path.GetFileNameWithoutExtension(name) + " compacted"); }
                 catch (InvalidOperationException ex) { return WritePatchBuilder.CompactOutcome.Fail(ex.Message); }
                 createdFresh = rf.CreatedFresh;
-                WriteOwnerMeta(rf.ModFolder, name);                       // Pâ€² keeps the source's exact basename
+                WriteOwnerMeta(rf.ModFolder, name);                       // P′ keeps the source's exact basename
                 outPath = Path.Combine(rf.OutputDir, name);
             }
 
@@ -1801,21 +1801,21 @@ public sealed class LoadOrderService : IDisposable
                     repointed.Add(new WritePatchBuilder.RepointReport(ext, rep.Success, rep.Error));
                 }
 
-            // 7b. carry the FormID-keyed assets a renumber moves â€” FaceGen head mesh/tint (A1) + voice .fuz/.lip (A2). The
+            // 7b. carry the FormID-keyed assets a renumber moves — FaceGen head mesh/tint (A1) + voice .fuz/.lip (A2). The
             //     records renumbered, so the asset FILES the engine looks up BY FormID must follow, or a compacted NPC mod
             //     silently dark-faces and a voiced mod goes mute (the gap this research exposed in the shipped tool). ONE
             //     captured asset view feeds both carries AND the 7c SEQ gate, so all three agree on what's in the VFS. Best-
             //     effort + REPORTED (Q3): the records are already written, so an asset we can't carry is a NAMED warning in the
-            //     outcome, never a failure of the compaction â€” and the asset layer failing to build never fails the compact
-            //     either. outDir = the Pâ€² mod-folder root (the directory holding the plugin) in BOTH lanes (new-file: the
+            //     outcome, never a failure of the compaction — and the asset layer failing to build never fails the compact
+            //     either. outDir = the P′ mod-folder root (the directory holding the plugin) in BOTH lanes (new-file: the
             //     fresh folder; in-place: the target's own folder).
-            //   SEQ-gate (for 7c, refresh-only): "did the source SHIP a .seq?" is a VFS question, not a single-folder one â€” a
+            //   SEQ-gate (for 7c, refresh-only): "did the source SHIP a .seq?" is a VFS question, not a single-folder one — a
             //   prior housecarl_write_seq run files the .seq in its OWN houseCARL_SEQ mod folder, and a packed mod ships it in
             //   a BSA. So resolve SEQ\<basename>.seq through the SAME captured view (mirrors the dialogue validator's CheckSeq),
-            //   never a loose File.Exists on the source folder â€” which would miss both and re-open the silent failure A3 closes.
+            //   never a loose File.Exists on the source folder — which would miss both and re-open the silent failure A3 closes.
             AssetRenameOutcome assetRename;
             VoiceCarryOutcome voiceRename;
-            bool? seqGate = null;                                          // the VFS gate result â€” SET the moment the view resolves, BEFORE the carries
+            bool? seqGate = null;                                          // the VFS gate result — SET the moment the view resolves, BEFORE the carries
             var srcSeqRel = $@"SEQ\{Path.GetFileNameWithoutExtension(srcPath)}.seq";
             try
             {
@@ -1830,20 +1830,20 @@ public sealed class LoadOrderService : IDisposable
             catch (Exception ex)
             {
                 assetRename = new AssetRenameOutcome(0, 0, 0,
-                    new[] { $"facegen carry skipped â€” the asset layer could not be built ({ex.Message}); verify NPC faces in-game." }, false);
+                    new[] { $"facegen carry skipped — the asset layer could not be built ({ex.Message}); verify NPC faces in-game." }, false);
                 voiceRename = new VoiceCarryOutcome(0, 0, 0,
-                    new[] { $"voice carry skipped â€” the asset layer could not be built ({ex.Message}); verify voiced lines in-game." }, false);
+                    new[] { $"voice carry skipped — the asset layer could not be built ({ex.Message}); verify voiced lines in-game." }, false);
             }
-            // The gate is the VFS answer whenever the view resolved â€” even if a LATER carry threw, a carry failure must NOT
-            // downgrade a good gate result (re-review). Only when the view never resolved (seqGate still null â€” the asset layer
+            // The gate is the VFS answer whenever the view resolved — even if a LATER carry threw, a carry failure must NOT
+            // downgrade a good gate result (re-review). Only when the view never resolved (seqGate still null — the asset layer
             // couldn't be built) fall back to the loose-only check (degraded, never worse than the pre-fix behavior).
             bool sourceHadSeq = seqGate ?? File.Exists(Path.Combine(Path.GetDirectoryName(srcPath)!, srcSeqRel));
 
             // 7c. REFRESH the start-game-enabled-quest .seq from the RENUMBERED plugin when the source SHIPPED one (the VFS
             //     gate above). A renumber shifts every SGE quest's master-relative on-disk FormID, so a shipped .seq is now
-            //     STALE â€” its quests would silently never start (the failure SeqFile exists to prevent). REFRESH-ONLY
-            //     (maintainer's call): if the source shipped NO .seq we do NOT invent one (xEdit-compaction parity) â€”
-            //     RegenerateSeq returns a named advisory. The REGEN itself is off Pâ€² (SeqFile.Build â€” the write_seq path) and
+            //     STALE — its quests would silently never start (the failure SeqFile exists to prevent). REFRESH-ONLY
+            //     (maintainer's call): if the source shipped NO .seq we do NOT invent one (xEdit-compaction parity) —
+            //     RegenerateSeq returns a named advisory. The REGEN itself is off P′ (SeqFile.Build — the write_seq path) and
             //     needs no resolver; only the gate consults the view. Best-effort + REPORTED (Q3): RegenerateSeq never throws
             //     and never fails the compact; the outer guard is belt-and-suspenders.
             SeqRegenOutcome seqRegen;
@@ -1851,16 +1851,16 @@ public sealed class LoadOrderService : IDisposable
             catch (Exception ex)
             {
                 seqRegen = new SeqRegenOutcome(0, false, null,
-                    new[] { $"SEQ regenerate skipped ({ex.Message}) â€” if '{name}' has start-game-enabled quests, run housecarl_write_seq on the compacted plugin." });
+                    new[] { $"SEQ regenerate skipped ({ex.Message}) — if '{name}' has start-game-enabled quests, run housecarl_write_seq on the compacted plugin." });
             }
 
             // 8. audit markers (PR #122 review #2): stamp the distinct editedInPlace= breadcrumb into the meta.ini of EVERY
-            //    file rewritten IN PLACE â€” the target (in-place lane) + each successfully repointed external â€” matching the
+            //    file rewritten IN PLACE — the target (in-place lane) + each successfully repointed external — matching the
             //    traceability the in-place EDIT lane gives. The CONSENT model deliberately stays compact's own per-call
             //    confirm (NOT the persistent _store ack the edit lane uses): a compaction can rewrite a broad surface (the
             //    target + N externals), so each one re-confirms with its exact overwrite list rather than letting a stale
             //    field-edit ack silently authorize a full renumber. Markers are best-effort (a miss never fails the done
-            //    write, Q3) â€” any miss is surfaced in Note.
+            //    write, Q3) — any miss is surfaced in Note.
             var markerNotes = new List<string>();
             if (inPlace) { var n = MergeEditedInPlaceMarker(Path.GetDirectoryName(srcPath)); if (n is not null) markerNotes.Add(n); }
             foreach (var r in repointed.Where(r => r.Success))
@@ -1876,23 +1876,23 @@ public sealed class LoadOrderService : IDisposable
         }
     }
 
-    /// <summary>The composed standalone-NPC-copy verb (housecarl_copy_npc_appearance â€” capability chain Stage 3).
+    /// <summary>The composed standalone-NPC-copy verb (housecarl_copy_npc_appearance — capability chain Stage 3).
     /// Deep-copies a donor NPC's appearance-record subtree into a houseCARL patch under NEW FormKeys (Duplicate +
-    /// RemapLinks â€” the RemapEngine mechanism, so every field carries by construction: HDPT.Parts morph refs,
+    /// RemapLinks — the RemapEngine mechanism, so every field carries by construction: HDPT.Parts morph refs,
     /// TextureLighting, tints), preserves headpart EditorIDs (facegeom block-name identity), renames the facegen
     /// pair to the new key's path, and carries the donor-only textures/meshes the records + geom reference.
     /// TWO TARGET MODES: <paramref name="targetFormid"/> dresses an EXISTING NPC (appearance fields copied onto an
     /// override); <paramref name="newEditorid"/> mints a full standalone CLONE (donor NPC duplicated; every remaining
-    /// donor-internal non-appearance link stripped + reported by name â€” Q3, the clone is donor-free LOUDLY).
+    /// donor-internal non-appearance link stripped + reported by name — Q3, the clone is donor-free LOUDLY).
     /// The donor may be ACTIVE (read via the load-order winner) or sit in a plugin FILE houseCARL locates across
-    /// enabled/disabled mod folders (<paramref name="sourcePlugin"/> â€” the read_plugin_file lane, stamped
+    /// enabled/disabled mod folders (<paramref name="sourcePlugin"/> — the read_plugin_file lane, stamped
     /// out-of-load-order in the outcome). Never touches the donor; output = folder-per-patch or into= extend.</summary>
     public NpcCopyOutcome CopyNpcAppearance(
         string sourceFormid, string? sourcePlugin, string? sourceMod,
         string? targetFormid, string? newEditorid, string? newName,
         string? patchName, string? into)
     {
-        // ---- 0. argument shape (Q3 â€” exactly one target mode) ----
+        // ---- 0. argument shape (Q3 — exactly one target mode) ----
         FormKey donorFk;
         try { donorFk = FormKey.Factory((sourceFormid ?? "").Trim()); }
         catch (Exception ex) { return NpcCopyOutcome.Fail($"bad source formid '{sourceFormid}': {ex.Message}. Expected 'XXXXXX:Plugin.esp', e.g. '000D62:Vivace.esp'."); }
@@ -1919,11 +1919,11 @@ public sealed class LoadOrderService : IDisposable
 
             using var session = resolver.OpenSession();
 
-            // ---- 1. read the donor NPC â€” the ACTIVE lane (load-order winner) or the FILE lane (any plugin on disk,
-            //         disabled included â€” the read_plugin_file machinery; results stamped out-of-load-order). ----
+            // ---- 1. read the donor NPC — the ACTIVE lane (load-order winner) or the FILE lane (any plugin on disk,
+            //         disabled included — the read_plugin_file machinery; results stamped out-of-load-order). ----
             INpcGetter donorNpc;
             NpcAppearanceCopy.DonorFetch fetch;
-            // "Donor-bound" ModKeys â€” the plugin(s) being standalone-ized away from. A BASE-GAME/implicit master is
+            // "Donor-bound" ModKeys — the plugin(s) being standalone-ized away from. A BASE-GAME/implicit master is
             // NEVER donor-bound (review finding): copying a vanilla-defined NPC's look must not classify NordRace or
             // vanilla headparts as "donor-internal" (that produced a nonsense custom-race refusal and would wholesale-
             // internalize vanilla records). With an empty set the copy is an override-style transplant, said plainly.
@@ -1931,7 +1931,7 @@ public sealed class LoadOrderService : IDisposable
             var donorMods = new HashSet<ModKey>();
             if (!baseMasters.Contains(donorFk.ModKey)) donorMods.Add(donorFk.ModKey);
             string donorReadFrom; bool outOfLoadOrder;
-            ISkyrimModGetter? donorOverlay = null;    // file lane only â€” disposed in finally
+            ISkyrimModGetter? donorOverlay = null;    // file lane only — disposed in finally
             string? donorFilePath = null;             // file lane: the located file; active lane: the winner's path (for the donor-disk asset fallback)
             string dataDirForAssets;
             try
@@ -1946,7 +1946,7 @@ public sealed class LoadOrderService : IDisposable
                     var loc = LocatePluginFileOnDisk(comp, modsDir, dataDir, overwriteDir, sp, sourceMod);
                     if (loc.Error is not null) return NpcCopyOutcome.Fail(loc.Error);
                     if (loc.Ambiguous is not null)
-                        return NpcCopyOutcome.Fail($"'{sp}' exists in {loc.Ambiguous.Count} places ({string.Join(" | ", loc.Ambiguous.Select(h => h.Where))}) â€” pass source_mod= to pick one.");
+                        return NpcCopyOutcome.Fail($"'{sp}' exists in {loc.Ambiguous.Count} places ({string.Join(" | ", loc.Ambiguous.Select(h => h.Where))}) — pass source_mod= to pick one.");
                     donorFilePath = loc.Path!;
                     donorReadFrom = loc.Where == "direct path"
                         ? $"direct path '{donorFilePath}'"
@@ -1957,15 +1957,15 @@ public sealed class LoadOrderService : IDisposable
                         var fileKey = ModKey.FromFileName(Path.GetFileName(donorFilePath));
                         if (!baseMasters.Contains(fileKey)) donorMods.Add(fileKey);
                     }
-                    catch { /* a direct path with an odd name â€” donorFk.ModKey still governs */ }
+                    catch { /* a direct path with an odd name — donorFk.ModKey still governs */ }
 
                     donorOverlay = LoadOrderResolver.OpenOverlay(donorFilePath, string.IsNullOrEmpty(dataDir) ? null : dataDir);
-                    // Lazy per-type link cache â€” no eager whole-file parse (review finding), and per-resolve fault
+                    // Lazy per-type link cache — no eager whole-file parse (review finding), and per-resolve fault
                     // isolation: one unparseable record elsewhere in the file must not abort the verb (Q3).
                     var donorCache = donorOverlay.ToImmutableLinkCache();
                     IMajorRecordGetter? donorBody;
                     try { donorBody = donorCache.TryResolve(donorFk, out var db) ? db : null; }
-                    catch (Exception ex) { return NpcCopyOutcome.Fail($"'{Path.GetFileName(donorFilePath)}' could not be read around {donorFk} â€” a record Mutagen cannot parse: {ex.Message}"); }
+                    catch (Exception ex) { return NpcCopyOutcome.Fail($"'{Path.GetFileName(donorFilePath)}' could not be read around {donorFk} — a record Mutagen cannot parse: {ex.Message}"); }
                     if (donorBody is null)
                         return NpcCopyOutcome.Fail($"file '{Path.GetFileName(donorFilePath)}' does not define or override {donorFk}. This reads the FILE's own records (out of load order); for an active donor omit source_plugin=.");
                     if (donorBody is not INpcGetter fileNpc)
@@ -1979,7 +1979,7 @@ public sealed class LoadOrderService : IDisposable
                     if (winner is null)
                         return NpcCopyOutcome.Fail(
                             $"{donorFk} is not present in the active load order. If the donor plugin is DISABLED, pass source_plugin= " +
-                            "(its filename â€” houseCARL locates it across enabled AND disabled mod folders) to read it out of load order.");
+                            "(its filename — houseCARL locates it across enabled AND disabled mod folders) to read it out of load order.");
                     var body = view.GetRecord(session, winner.Value.WinnerPlugin, donorFk);
                     if (body is null)
                         return NpcCopyOutcome.Fail($"could not fetch {donorFk} from its winner '{winner.Value.WinnerPlugin}'.");
@@ -1999,11 +1999,11 @@ public sealed class LoadOrderService : IDisposable
 
                 NpcAppearanceCopy.ActiveResolve active = fk2 => view.ResolveWinner(fk2) is not null;
 
-                // ---- 2. the appearance closure (generic link walk; loud refusals â€” custom race, runaway, unreadable) ----
+                // ---- 2. the appearance closure (generic link walk; loud refusals — custom race, runaway, unreadable) ----
                 var closure = NpcAppearanceCopy.CollectAppearanceClosure(donorNpc, donorMods, fetch, active);
                 if (!closure.Success) return NpcCopyOutcome.Fail(closure.Error!);
 
-                // ---- 3. output patch (folder-per-patch or into= extend â€” the record lane's resolver + ownership gate) ----
+                // ---- 3. output patch (folder-per-patch or into= extend — the record lane's resolver + ownership gate) ----
                 string outPath; bool extend, created;
                 var defaultStem = clone ? newEditorid!.Trim() : "houseCARL_NpcCopy";
                 try { outPath = ResolveOutputPath(patchName ?? (into is null ? defaultStem : null), into, out extend, out created); }
@@ -2011,13 +2011,13 @@ public sealed class LoadOrderService : IDisposable
                 var patchFileName = Path.GetFileName(outPath);
                 var patchModKey = ModKey.FromFileName(patchFileName);
 
-                // ---- 4. apply lane: resolve the ACTIVE target body up front (an in-patch target â€” its formid names
-                //         the patch itself â€” is resolved inside the build, off the opened patch mod). ----
+                // ---- 4. apply lane: resolve the ACTIVE target body up front (an in-patch target — its formid names
+                //         the patch itself — is resolved inside the build, off the opened patch mod). ----
                 INpcGetter? targetActiveBody = null;
                 if (apply && targetFk.ModKey != patchModKey)
                 {
                     if (donorMods.Contains(targetFk.ModKey))
-                        return NpcCopyOutcome.Fail("the target NPC lives in the DONOR's plugin â€” that cannot be standalone-ized onto itself; pick a target outside the donor (or use new_editorid= to clone).");
+                        return NpcCopyOutcome.Fail("the target NPC lives in the DONOR's plugin — that cannot be standalone-ized onto itself; pick a target outside the donor (or use new_editorid= to clone).");
                     var tw = view.ResolveWinner(targetFk);
                     if (tw is null)
                         return NpcCopyOutcome.Fail(
@@ -2030,17 +2030,17 @@ public sealed class LoadOrderService : IDisposable
                 }
 
                 // ---- 4b. the donor FILE must not be the output patch (review finding: the donor overlay stays
-                //          memory-mapped through the serialize â€” the exact self-lock class the write path guards).
+                //          memory-mapped through the serialize — the exact self-lock class the write path guards).
                 if (donorFilePath is not null
                     && string.Equals(Path.GetFullPath(donorFilePath), Path.GetFullPath(outPath), StringComparison.OrdinalIgnoreCase))
                 {
                     if (created) RemoveFolderCreatedThisCall(outPath);
                     return NpcCopyOutcome.Fail(
-                        "the donor plugin file IS the output patch â€” reading and rewriting the same file in one call would " +
+                        "the donor plugin file IS the output patch — reading and rewriting the same file in one call would " +
                         "deadlock on its own open handle. Copy into a DIFFERENT patch (omit into=, or name another).");
                 }
 
-                // ---- 5. build + serialize (core â€” Duplicate/RemapLinks, mode lane, multi-master write) ----
+                // ---- 5. build + serialize (core — Duplicate/RemapLinks, mode lane, multi-master write) ----
                 var outcome = NpcAppearanceCopy.BuildAndWrite(
                     donorNpc, donorMods, closure,
                     clone, newEditorid, newName,
@@ -2055,10 +2055,10 @@ public sealed class LoadOrderService : IDisposable
                     return outcome;
                 }
 
-                // ---- 6. asset carry (facegen rename + donor-only textures/meshes) â€” best-effort + reported (Q3).
+                // ---- 6. asset carry (facegen rename + donor-only textures/meshes) — best-effort + reported (Q3).
                 //         Paths were harvested from the IN-PATCH duplicates pre-serialize (never the donor overlay,
                 //         which may be released by now). The donor-disk direct lane only exists for a donor under an
-                //         MO2 mod folder â€” NEVER the game Data folder, where every vanilla BSA would misclassify as
+                //         MO2 mod folder — NEVER the game Data folder, where every vanilla BSA would misclassify as
                 //         "the donor's" (review finding). ----
                 NpcAssetOutcome assets;
                 try
@@ -2078,7 +2078,7 @@ public sealed class LoadOrderService : IDisposable
                 catch (Exception ex)
                 {
                     assets = new NpcAssetOutcome(Array.Empty<CarriedAsset>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(),
-                        new[] { $"asset carry skipped â€” the asset layer could not be built ({ex.Message}); carry the facegen pair with housecarl_place_asset and verify in-game." }, false, false);
+                        new[] { $"asset carry skipped — the asset layer could not be built ({ex.Message}); carry the facegen pair with housecarl_place_asset and verify in-game." }, false, false);
                 }
                 return outcome with { Assets = assets };
             }
@@ -2086,12 +2086,12 @@ public sealed class LoadOrderService : IDisposable
         }
     }
 
-    /// <summary>Create a BRAND-NEW record (housecarl_create_record) â€” the net-new authoring capability, the sibling of
+    /// <summary>Create a BRAND-NEW record (housecarl_create_record) — the net-new authoring capability, the sibling of
     /// <see cref="ApplyEdits"/>. Resolves <paramref name="recordType"/> (catalog name or 4-char signature) to ONE concrete
-    /// catalog name (unknown/ambiguous â†’ Q3), maps the field <paramref name="operations"/> to core <see cref="WriteRequest"/>s
-    /// rooted at that type (a create op takes NO formid â€” it sets fields on the new record), resolves the folder-per-patch
+    /// catalog name (unknown/ambiguous → Q3), maps the field <paramref name="operations"/> to core <see cref="WriteRequest"/>s
+    /// rooted at that type (a create op takes NO formid — it sets fields on the new record), resolves the folder-per-patch
     /// output (fresh, or <paramref name="into"/> an existing houseCARL-owned patch), then drives
-    /// <see cref="WritePatchBuilder.CreateRecords"/> (pre-flight ALL â†’ AddNew/NestedAddNew â†’ ApplyVerb â†’ multi-master serialize).
+    /// <see cref="WritePatchBuilder.CreateRecords"/> (pre-flight ALL → AddNew/NestedAddNew → ApplyVerb → multi-master serialize).
     /// The new record's FormID is auto-allocated (local 0x800+) and reported; originals are never touched. A flat top-level
     /// record needs no <paramref name="parent"/>; a NESTED child (a dialogue line, a placed ref) passes <paramref name="parent"/>
     /// (an existing parent's FormKey, or a record created in a prior into= call) and, when the parent holds more than one
@@ -2105,21 +2105,21 @@ public sealed class LoadOrderService : IDisposable
         var spec = BuildCreateSpec(recordType, editorid, operations, parent, collection, grid, where: null, problems);
         if (spec is null)
             return WritePatchBuilder.CreateOutcome.Fail(
-                $"refused â€” {problems.Count} problem(s) creating the record; NOTHING created:\n  - " + string.Join("\n  - ", problems));
+                $"refused — {problems.Count} problem(s) creating the record; NOTHING created:\n  - " + string.Join("\n  - ", problems));
         return CommitCreate(new[] { spec }, patchName, into, fullReadback, target, inPlace, acknowledge);
     }
 
-    /// <summary>Create MANY new records in ONE patch (housecarl_bulk_create) â€” the batch sibling of
+    /// <summary>Create MANY new records in ONE patch (housecarl_bulk_create) — the batch sibling of
     /// <see cref="CreateRecords"/>, and the one-shot lever for a nested unit (a dialogue topic + its lines, a cell + its
     /// placed refs) where a child's <c>parent</c> names a same-call sibling by editorid. Each spec is mapped exactly as
-    /// the single create (type resolution + field-op mapping + parent/collection); ALL-OR-NOTHING (Q3) â€” any malformed
+    /// the single create (type resolution + field-op mapping + parent/collection); ALL-OR-NOTHING (Q3) — any malformed
     /// spec refuses the whole call (with per-record reasons) and the core <see cref="WritePatchBuilder.CreateRecords"/>
     /// likewise refuses the whole batch on any creatability/parent problem. One serialize for the lot.</summary>
     public WritePatchBuilder.CreateOutcome CreateRecordsBatch(IReadOnlyList<CreateOp> records, string? patchName, string? into, bool fullReadback = false,
         string? target = null, bool inPlace = false, bool acknowledge = false)
     {
         if (records is null || records.Count == 0)
-            return WritePatchBuilder.CreateOutcome.Fail("no records to create supplied â€” pass one or more {record_type, editorid, operations?, parent?, collection?} specs.");
+            return WritePatchBuilder.CreateOutcome.Fail("no records to create supplied — pass one or more {record_type, editorid, operations?, parent?, collection?} specs.");
 
         var problems = new List<string>();
         var specs = new List<WritePatchBuilder.CreateSpec>(records.Count);
@@ -2131,15 +2131,15 @@ public sealed class LoadOrderService : IDisposable
         }
         if (problems.Count > 0)
             return WritePatchBuilder.CreateOutcome.Fail(
-                $"refused â€” {problems.Count} problem(s) across {records.Count} record(s); NOTHING created:\n  - " + string.Join("\n  - ", problems));
+                $"refused — {problems.Count} problem(s) across {records.Count} record(s); NOTHING created:\n  - " + string.Join("\n  - ", problems));
         return CommitCreate(specs, patchName, into, fullReadback, target, inPlace, acknowledge);
     }
 
     /// <summary>Build ONE core <see cref="WritePatchBuilder.CreateSpec"/> from wire parts (shared by the single create and
     /// the batch): resolve <paramref name="recordType"/> (catalog name or 4-char signature) to ONE concrete catalog name
-    /// (unknown/ambiguous â†’ a problem), require an editorid, map each field <paramref name="operations"/> op to a core
+    /// (unknown/ambiguous → a problem), require an editorid, map each field <paramref name="operations"/> op to a core
     /// <see cref="WriteRequest"/> rooted at that type, and carry <paramref name="parent"/>/<paramref name="collection"/>
-    /// through (a nested child) â€” null â‡’ a flat top-level record. Every problem (with the optional <paramref name="where"/>
+    /// through (a nested child) — null ⇒ a flat top-level record. Every problem (with the optional <paramref name="where"/>
     /// label) is APPENDED to <paramref name="problems"/>; returns null iff this record contributed any (all-or-nothing).</summary>
     WritePatchBuilder.CreateSpec? BuildCreateSpec(string? recordType, string? editorid, IReadOnlyList<BulkOp> operations,
         string? parent, string? collection, string? grid, string? where, List<string> problems)
@@ -2156,15 +2156,15 @@ public sealed class LoadOrderService : IDisposable
             {
                 var types = ResolveTypeFilter(recordType.Trim());
                 if (types.Count != 1)
-                    problems.Add($"{prefix}record_type '{recordType}' is ambiguous ({types.Count} matches) â€” use a specific catalog name (e.g. one of: {string.Join(", ", types.Select(t => RecordNaming.StripGetterInterface(t.Name)))}).");
+                    problems.Add($"{prefix}record_type '{recordType}' is ambiguous ({types.Count} matches) — use a specific catalog name (e.g. one of: {string.Join(", ", types.Select(t => RecordNaming.StripGetterInterface(t.Name)))}).");
                 else catalogName = RecordNaming.StripGetterInterface(types[0].Name);
             }
             catch (ArgumentException ex) { problems.Add($"{prefix}{ex.Message}"); }
         }
         if (string.IsNullOrWhiteSpace(editorid))
-            problems.Add($"{prefix}editorid is required â€” the EditorID the new record is referenced by (e.g. in SkyPatcher/SPID).");
+            problems.Add($"{prefix}editorid is required — the EditorID the new record is referenced by (e.g. in SkyPatcher/SPID).");
 
-        // Map each field op â†’ a core WriteRequest rooted at the create type (only once the type resolved; collect ALL malformed ops).
+        // Map each field op → a core WriteRequest rooted at the create type (only once the type resolved; collect ALL malformed ops).
         var edits = new List<WriteRequest>(operations.Count);
         if (catalogName is not null)
             for (int i = 0; i < operations.Count; i++)
@@ -2189,14 +2189,14 @@ public sealed class LoadOrderService : IDisposable
     WritePatchBuilder.CreateOutcome CommitCreate(IReadOnlyList<WritePatchBuilder.CreateSpec> specs, string? patchName, string? into, bool fullReadback,
         string? target = null, bool inPlace = false, bool acknowledge = false)
     {
-        // In-place is the explicit, named-file opt-in (the SECOND write lane â€” create into an existing plugin, incl. one
+        // In-place is the explicit, named-file opt-in (the SECOND write lane — create into an existing plugin, incl. one
         // houseCARL didn't author, instead of writing a new patch). Validate the contract up front (Q3): it REQUIRES a
-        // target=, is mutually exclusive with into= (which EXTENDS a houseCARL patch â€” a different lane), and target=
-        // without in_place is a no-op the caller likely didn't mean â€” name it rather than silently ignore it. (Mirrors
+        // target=, is mutually exclusive with into= (which EXTENDS a houseCARL patch — a different lane), and target=
+        // without in_place is a no-op the caller likely didn't mean — name it rather than silently ignore it. (Mirrors
         // ApplyEdits' in-place contract exactly.)
         if (inPlace && string.IsNullOrWhiteSpace(target))
             return WritePatchBuilder.CreateOutcome.Fail(
-                "in_place=true requires target=<plugin filename> â€” name the existing plugin to create into in place. (Omit in_place to write a new patch instead â€” the default, originals untouched.)");
+                "in_place=true requires target=<plugin filename> — name the existing plugin to create into in place. (Omit in_place to write a new patch instead — the default, originals untouched.)");
         if (inPlace && !string.IsNullOrWhiteSpace(into))
             return WritePatchBuilder.CreateOutcome.Fail(
                 "in_place=true and into= are mutually exclusive: into= EXTENDS a houseCARL patch, while in_place creates into an existing plugin in place. Use one lane or the other.");
@@ -2204,7 +2204,7 @@ public sealed class LoadOrderService : IDisposable
             return WritePatchBuilder.CreateOutcome.Fail(
                 "target= is only meaningful with in_place=true (it names the plugin to create into in place). For the default patch lane omit target=; use into= to extend an existing houseCARL patch.");
 
-        lock (_writeGate)                                                 // hunt F2: one write at a time, resolveâ†’commit
+        lock (_writeGate)                                                 // hunt F2: one write at a time, resolve→commit
         {
             var resolver = Resolver;
             var rulebook = Rulebook;
@@ -2218,26 +2218,26 @@ public sealed class LoadOrderService : IDisposable
 
             var outcome = WritePatchBuilder.CreateRecords(resolver, rulebook, specs, outPath, extend, fullReadback);
             if (!outcome.Success && created) RemoveFolderCreatedThisCall(outPath);   // hunt F4: a refused create leaves no orphan
-            // Layer B dialogue teeth + the coordinate-keyed cell teeth â€” all post-write verify steps (the proven
+            // Layer B dialogue teeth + the coordinate-keyed cell teeth — all post-write verify steps (the proven
             // CreateRecords path stays untouched): unit B voice (.fuz/.lip) coverage, unit C the result-script binding,
-            // then the Â§4-(b) structural-shell report. Each is a no-op unless the call created the relevant record kind
+            // then the §4-(b) structural-shell report. Each is a no-op unless the call created the relevant record kind
             // (a dialogue line / a cell); none can fail the create (the write already succeeded).
             return outcome.Success ? EnrichWithCellShell(EnrichWithScriptCheck(EnrichWithVoiceCheck(outcome, resolver))) : outcome;
         }
     }
 
-    /// <summary>The in-place branch of <see cref="CommitCreate"/> (in-place write lane, Wave 1b) â€” the create-side
+    /// <summary>The in-place branch of <see cref="CommitCreate"/> (in-place write lane, Wave 1b) — the create-side
     /// companion of <see cref="ApplyEditsInPlace"/>, and it REUSES every Wave-1 in-place seam: the same foreign-target
     /// resolver (<see cref="ResolveActivePluginPath"/>), the same PERSISTENT first-touch CONSENT handshake (keyed off the
     /// resolved path in <see cref="UserConfigStore"/>), the same writable-parent pre-flight, and the same distinct
-    /// <c>editedInPlace=</c> marker (NEVER <c>generated=true</c> â€” the user mod keeps failing
+    /// <c>editedInPlace=</c> marker (NEVER <c>generated=true</c> — the user mod keeps failing
     /// <see cref="IsHouseCarlOwned"/> so a later into= can't blind-overwrite it). THREE divergences from
     /// <see cref="ApplyEditsInPlace"/>: (1) it drives <see cref="WritePatchBuilder.CreateRecordsInPlace"/>
     /// (allocate-into-target, not edit-own-record); (2) it returns a <see cref="WritePatchBuilder.CreateOutcome"/>; and
-    /// (3) because in-place create has FULL parity â€” it can author dialogue lines / cells under any parent, unlike
-    /// <c>set_field</c> â€” it runs the SAME post-write voice/result-script/cell-shell coverage teeth the patch-lane create
+    /// (3) because in-place create has FULL parity — it can author dialogue lines / cells under any parent, unlike
+    /// <c>set_field</c> — it runs the SAME post-write voice/result-script/cell-shell coverage teeth the patch-lane create
     /// runs (<see cref="ApplyEditsInPlace"/> is marker-only). The created-record verify is forced ON (the model-C
-    /// substitute for the dropped whole-plugin floor). <paramref name="acknowledge"/> waives the CONSENT axis ONLY â€” the
+    /// substitute for the dropped whole-plugin floor). <paramref name="acknowledge"/> waives the CONSENT axis ONLY — the
     /// verify is a corruption-axis fact no acknowledgement overrides. Runs under <c>_writeGate</c> (the caller holds it).</summary>
     WritePatchBuilder.CreateOutcome CommitCreateInPlace(
         LoadOrderResolver resolver, CorpusRulebook rulebook, IReadOnlyList<WritePatchBuilder.CreateSpec> specs,
@@ -2249,11 +2249,11 @@ public sealed class LoadOrderService : IDisposable
         var targetPath = ResolveActivePluginPath(view, Path.GetFileName(target.Trim()), out var targetName);
         if (targetPath is null)
             return WritePatchBuilder.CreateOutcome.Fail(
-                $"in-place target '{target}' is not an active plugin in the load order â€” name a plugin enabled in MO2, by its " +
+                $"in-place target '{target}' is not an active plugin in the load order — name a plugin enabled in MO2, by its " +
                 "plugin filename (e.g. 'CoolWeapons.esp'). in-place creates into the file the game actually loads. Nothing was written.");
 
-        // (2) CONSENT axis â€” the persistent, server-enforced first-touch handshake, keyed off the resolved path (shared with
-        //     the edit lane: acknowledging a plugin once covers BOTH editing and creating into it in place â€” it's the same
+        // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path (shared with
+        //     the edit lane: acknowledging a plugin once covers BOTH editing and creating into it in place — it's the same
         //     "touch your original" trade-off).
         bool already = _store.IsInPlaceAcknowledged(targetPath);
         if (!already && !acknowledge)
@@ -2262,17 +2262,17 @@ public sealed class LoadOrderService : IDisposable
         if (!already && acknowledge)
         {
             var (ok, err) = _store.RecordInPlaceAcknowledged(targetPath);
-            if (!ok) ackNote = $"the in-place acknowledgement could not be saved ({err}) â€” the create proceeded, but a future session will re-prompt for this plugin.";
+            if (!ok) ackNote = $"the in-place acknowledgement could not be saved ({err}) — the create proceeded, but a future session will re-prompt for this plugin.";
         }
 
-        // (3) Writable, same-volume parent pre-flight â€” refuse rather than degrade (the swap stages a sibling temp here).
+        // (3) Writable, same-volume parent pre-flight — refuse rather than degrade (the swap stages a sibling temp here).
         if (InPlaceParentUnwritable(targetPath, out var why))
             return WritePatchBuilder.CreateOutcome.Fail(why);
 
-        // (4) The write â€” created-record verify forced ON (the model-C substitute for the dropped whole-plugin floor).
+        // (4) The write — created-record verify forced ON (the model-C substitute for the dropped whole-plugin floor).
         var outcome = WritePatchBuilder.CreateRecordsInPlace(resolver, rulebook, specs, targetPath, targetName, fullReadback: true);
 
-        // (5) On success: run the SAME post-write teeth the patch lane runs (the service owns the live AssetResolver) â€”
+        // (5) On success: run the SAME post-write teeth the patch lane runs (the service owns the live AssetResolver) —
         //     in-place create can now author dialogue lines / cells under any parent, so voice (.fuz) + result-script +
         //     cell-shell coverage must be checked here too (each a no-op unless that record kind was created; none can
         //     fail the write, which already succeeded). Then stamp the distinct audit marker (best-effort; a marker miss
@@ -2285,15 +2285,15 @@ public sealed class LoadOrderService : IDisposable
             return note is not null ? enriched with { Note = note } : enriched;
         }
         if (ackNote is not null)
-            // The acknowledgement was recorded but the write then failed â€” keep the (now-honest) note alongside the error.
+            // The acknowledgement was recorded but the write then failed — keep the (now-honest) note alongside the error.
             return outcome with { Note = ackNote };
         return outcome;
     }
 
-    /// <summary>Layer B unit B â€” the on-disk voice (.fuz/.lip) presence check, run as a POST-WRITE step on a SUCCESSFUL
+    /// <summary>Layer B unit B — the on-disk voice (.fuz/.lip) presence check, run as a POST-WRITE step on a SUCCESSFUL
     /// create (the service owns the live <see cref="Assets"/> resolver; the proven core create path stays asset-free and
-    /// untouched). Only fires when the call created â‰¥1 dialogue line (INFO): <see cref="VoiceCheck.Run"/> re-opens the
-    /// written patch read-only, computes each created voiced line's expected path, and checks the VFS â€” the report rides
+    /// untouched). Only fires when the call created ≥1 dialogue line (INFO): <see cref="VoiceCheck.Run"/> re-opens the
+    /// written patch read-only, computes each created voiced line's expected path, and checks the VFS — the report rides
     /// back on <see cref="WritePatchBuilder.CreateOutcome.Voice"/>. NEVER fails the create (the write already succeeded);
     /// a check failure is surfaced on the report's CheckError (Q3), and even a thrown Assets-build is caught here so a
     /// dialogue create never regresses to an error outcome over a verify step. Caller holds <see cref="_writeGate"/>; the
@@ -2311,14 +2311,14 @@ public sealed class LoadOrderService : IDisposable
         return report.IsEmpty ? outcome : outcome with { Voice = report };
     }
 
-    /// <summary>Layer B unit C â€” the per-create RESULT-SCRIPT binding check, run as a POST-WRITE step on a SUCCESSFUL
+    /// <summary>Layer B unit C — the per-create RESULT-SCRIPT binding check, run as a POST-WRITE step on a SUCCESSFUL
     /// create (the service owns the live <see cref="Assets"/> resolver; the proven core create path stays asset-free and
-    /// untouched), exactly like <see cref="EnrichWithVoiceCheck"/>. Only fires when the call created â‰¥1 dialogue line
+    /// untouched), exactly like <see cref="EnrichWithVoiceCheck"/>. Only fires when the call created ≥1 dialogue line
     /// (INFO): <see cref="DialogueScriptCheck.Run"/> re-opens the written patch read-only, validates each created INFO's
-    /// VMAD result-script binding and checks its compiled `.pex` on disk â€” the report rides back on
+    /// VMAD result-script binding and checks its compiled `.pex` on disk — the report rides back on
     /// <see cref="WritePatchBuilder.CreateOutcome.ScriptBinding"/>. NEVER fails the create (the write already succeeded);
     /// a check failure is surfaced on the report's CheckError (Q3), and even a thrown Assets-build is caught here. Needs
-    /// no LoadOrderResolver â€” the binding lives wholly on the INFO + the on-disk `.pex` (no graph resolution).</summary>
+    /// no LoadOrderResolver — the binding lives wholly on the INFO + the on-disk `.pex` (no graph resolution).</summary>
     WritePatchBuilder.CreateOutcome EnrichWithScriptCheck(WritePatchBuilder.CreateOutcome outcome)
     {
         bool anyInfo = false;
@@ -2332,13 +2332,13 @@ public sealed class LoadOrderService : IDisposable
         return report.IsEmpty ? outcome : outcome with { ScriptBinding = report };
     }
 
-    /// <summary>The coordinate-keyed Â§4-(b) teeth â€” the structural-SHELL report, a POST-WRITE step on a SUCCESSFUL
-    /// create exactly like <see cref="EnrichWithVoiceCheck"/>. Only fires when the call created â‰¥1 Cell:
+    /// <summary>The coordinate-keyed §4-(b) teeth — the structural-SHELL report, a POST-WRITE step on a SUCCESSFUL
+    /// create exactly like <see cref="EnrichWithVoiceCheck"/>. Only fires when the call created ≥1 Cell:
     /// <see cref="CellShellCheck.Run"/> re-opens the written patch read-only, reads each created cell's interior/exterior
-    /// kind, and lists the world content houseCARL does NOT author (lighting / terrain / water / navmesh â€” Aaron
-    /// 2026-06-20: no CK work) â€” the report rides back on <see cref="WritePatchBuilder.CreateOutcome.CellShell"/>. NEVER
+    /// kind, and lists the world content houseCARL does NOT author (lighting / terrain / water / navmesh — Aaron
+    /// 2026-06-20: no CK work) — the report rides back on <see cref="WritePatchBuilder.CreateOutcome.CellShell"/>. NEVER
     /// fails the create (the cell IS written; this only says what the author must still provide); a check failure is
-    /// surfaced on the report's CheckError (Q3). Needs no resolver/assets â€” the kind comes off the written cell's flag.</summary>
+    /// surfaced on the report's CheckError (Q3). Needs no resolver/assets — the kind comes off the written cell's flag.</summary>
     WritePatchBuilder.CreateOutcome EnrichWithCellShell(WritePatchBuilder.CreateOutcome outcome)
     {
         bool anyCell = false;
@@ -2353,7 +2353,7 @@ public sealed class LoadOrderService : IDisposable
     }
 
     /// <summary>Map a wire field-op to a core <see cref="WriteRequest"/> for CREATE: RecordType is the create type (not
-    /// derived), and a create op carries NO formid (it sets a field on the new record, whose id is auto-allocated) â€” a
+    /// derived), and a create op carries NO formid (it sets a field on the new record, whose id is auto-allocated) — a
     /// stray formid is refused loud (Q3) rather than silently ignored. Builds the composition <see cref="StructSpec"/> the
     /// same way <see cref="MapEdit"/> does (so a created Spell's Effects / LeveledItem's Entries compose identically).</summary>
     WriteRequest? MapCreateEdit(BulkOp op, int index, string recordType, out string? error)
@@ -2385,7 +2385,7 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>Map a wire op to a core <see cref="WritePatchBuilder.PatchEdit"/>: parse the FormID, split the dotted
     /// field path, and (if present) build the composition <see cref="StructSpec"/>. RecordType is NOT taken from the wire
-    /// â€” the cleave derives it from the resolved winner. Returns null + a named error (Q3) on any malformed input.</summary>
+    /// — the cleave derives it from the resolved winner. Returns null + a named error (Q3) on any malformed input.</summary>
     WritePatchBuilder.PatchEdit? MapEdit(BulkOp op, int index, out string? error)
     {
         error = null;
@@ -2412,16 +2412,16 @@ public sealed class LoadOrderService : IDisposable
         };
     }
 
-    /// <summary>Build a core composition <see cref="StructSpec"/> from the wire shape â€” flat <c>fields</c> (coercible
+    /// <summary>Build a core composition <see cref="StructSpec"/> from the wire shape — flat <c>fields</c> (coercible
     /// sub-fields), positional <c>ctor_args</c>, and nested <c>sets</c> (each a path+verb+value applied to the built
     /// struct, e.g. a leveled-list entry's Data.Level / Data.Reference). The nested sets' RecordType carries the struct
     /// type (the validator roots them at the struct schema, so it's a label). A nested set may itself carry a
-    /// <c>compose</c> (HCBR-2026-06-15-01 PR-C) â€” a recursive <see cref="StructSpec"/> selecting a polymorphic
-    /// sub-ARM (e.g. <c>sets:[{path:'Data', compose:{type:'GetActorValueConditionData', â€¦}}]</c>) â€” mapped here into
+    /// <c>compose</c> (HCBR-2026-06-15-01 PR-C) — a recursive <see cref="StructSpec"/> selecting a polymorphic
+    /// sub-ARM (e.g. <c>sets:[{path:'Data', compose:{type:'GetActorValueConditionData', …}}]</c>) — mapped here into
     /// the nested <see cref="WriteRequest.Struct"/> the core already applies + validates end-to-end (BuildStruct
     /// recurses on a Set/Add carrying a Struct; the rulebook's ArmLegality validates compose.type against the leaf's
     /// legal arms). Without this propagation a nested set could only set a coercible scalar, never a sub-arm. Q3 on a
-    /// malformed spec. <c>internal static</c> is the harness seam (the PR-C guard drives the wireâ†’core mapping directly,
+    /// malformed spec. <c>internal static</c> is the harness seam (the PR-C guard drives the wire→core mapping directly,
     /// like the other engine helpers; it touches no instance state).</summary>
     internal static StructSpec? MapStruct(StructInput s, string where, out string? error)
     {
@@ -2455,17 +2455,17 @@ public sealed class LoadOrderService : IDisposable
         => dotted.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
     /// <summary>Resolve a patch's output path under the FOLDER-PER-PATCH model (Aaron-locked 2026-06-02): each patch is
-    /// its OWN MO2 mod folder â€” <c>&lt;ModsDir&gt;\houseCARL - &lt;name&gt;\&lt;name&gt;.esp</c> â€” so every houseCARL
+    /// its OWN MO2 mod folder — <c>&lt;ModsDir&gt;\houseCARL - &lt;name&gt;\&lt;name&gt;.esp</c> — so every houseCARL
     /// plugin is a first-class mod the user enables / orders / removes independently. A NEW patch always creates a fresh,
-    /// marker-stamped folder (name auto-suffixed _001â€¦ so a prior reviewed patch is never clobbered);
+    /// marker-stamped folder (name auto-suffixed _001… so a prior reviewed patch is never clobbered);
     /// <paramref name="into"/> EXTENDS an existing houseCARL-owned patch (replace / modify its own plugins).
-    /// ORIGINALS UNTOUCHED is structural (CLAUDE.md Â§1): houseCARL only ever writes a folder that is brand-NEW or carries
-    /// its own <c>meta.ini</c> marker â€” it REFUSES (Q3) to write a folder it didn't create (a user mod), even on a name
+    /// ORIGINALS UNTOUCHED is structural (CLAUDE.md §1): houseCARL only ever writes a folder that is brand-NEW or carries
+    /// its own <c>meta.ini</c> marker — it REFUSES (Q3) to write a folder it didn't create (a user mod), even on a name
     /// collision. The caller name is reduced to a bare stem (no directory parts) so it can never escape ModsDir.
     /// Runs under <see cref="_gate"/> like its sibling <see cref="ResolvePatchModFolder"/> (hunt F2): the UniqueStem
     /// check-then-create is only race-free when every folder allocation is serialized on the one gate.
     /// <paramref name="createdFolder"/> reports whether THIS call created the fresh folder, so a refused write can
-    /// remove it again (hunt F4 â€” "NO patch written" must not leave an orphan folder accreting _001/_002 on retry).</summary>
+    /// remove it again (hunt F4 — "NO patch written" must not leave an orphan folder accreting _001/_002 on retry).</summary>
     string ResolveOutputPath(string? patchName, string? into, out bool extend, out bool createdFolder)
     {
         lock (_gate)
@@ -2478,10 +2478,10 @@ public sealed class LoadOrderService : IDisposable
             {
                 extend = true;
                 // The .esp write lane shares the 4-step EXTEND resolver with the rider/asset lane (HCBR-2026-06-23) so
-                // "extend my renamed patch" behaves IDENTICALLY across records, scripts, BSAs, and assets. needEsp:true â€”
+                // "extend my renamed patch" behaves IDENTICALLY across records, scripts, BSAs, and assets. needEsp:true —
                 // the canonical fast path only short-circuits a folder that actually holds <stem>.esp; we then pick the .esp
-                // to extend inside the resolved folder: the <stem>.esp it holds, or â€” via the by-folder catch-all, where the
-                // folder & plugin names differ â€” the folder's single plugin (Q3-refuse if it holds none or several).
+                // to extend inside the resolved folder: the <stem>.esp it holds, or — via the by-folder catch-all, where the
+                // folder & plugin names differ — the folder's single plugin (Q3-refuse if it holds none or several).
                 var folder = ResolveOwnedPatchFolder(into, needEsp: true);
                 var direct = Path.Combine(folder, PatchStem(into) + ".esp");
                 if (File.Exists(direct)) return direct;
@@ -2505,7 +2505,7 @@ public sealed class LoadOrderService : IDisposable
     /// <summary>Hunt F4: a write that was REFUSED after <see cref="ResolveOutputPath"/> created a fresh folder removes
     /// that folder again, so "NO patch written" is true of the disk too (no orphan accreting _001/_002 on retry).
     /// DELETION-SAFE by content check, not trust: only a folder holding NOTHING beyond our own meta.ini (and an empty
-    /// <c>.housecarl-tmp</c> staging leftover) is removed â€” anything else present means the folder gained real content
+    /// <c>.housecarl-tmp</c> staging leftover) is removed — anything else present means the folder gained real content
     /// and stays. Best-effort: a cleanup failure never masks the write's own (already-reported) outcome.</summary>
     static void RemoveFolderCreatedThisCall(string outPath)
     {
@@ -2519,7 +2519,7 @@ public sealed class LoadOrderService : IDisposable
                 if (File.Exists(entry) && name.Equals("meta.ini", StringComparison.OrdinalIgnoreCase)) continue;
                 if (Directory.Exists(entry) && name.Equals(".housecarl-tmp", StringComparison.OrdinalIgnoreCase)
                     && !Directory.EnumerateFileSystemEntries(entry).Any()) continue;
-                return;                                       // real content appeared â€” leave the folder alone
+                return;                                       // real content appeared — leave the folder alone
             }
             Directory.Delete(folder, recursive: true);
         }
@@ -2533,7 +2533,7 @@ public sealed class LoadOrderService : IDisposable
     public readonly record struct RiderFolder(string OutputDir, string ModFolder, bool CreatedFresh);
 
     /// <summary>Resolve a houseCARL-owned MOD FOLDER under ModsDir for a NON-.esp output (compiled scripts, a packed .bsa,
-    /// extracted loose files) â€” the folder-per-patch model generalised beyond the .esp write path. A fresh marker-stamped
+    /// extracted loose files) — the folder-per-patch model generalised beyond the .esp write path. A fresh marker-stamped
     /// folder (<paramref name="defaultStem"/> names it when patchName is blank; auto-suffixed so a prior one is never
     /// clobbered) or <paramref name="into"/> an existing houseCARL-owned one. ORIGINALS UNTOUCHED (Q3): refuses a folder
     /// houseCARL didn't create. Derives ModsDir CHEAPLY (reads ModOrganizer.ini; NO ~10s index build). Throws the trained
@@ -2553,10 +2553,10 @@ public sealed class LoadOrderService : IDisposable
                 // The SAME shared 4-step EXTEND resolver as the .esp write path (HCBR-2026-06-23): a renamed houseCARL patch
                 // folder is found by the .esp it holds OR by its new name, so compile / decompile / bsa_repack / place_asset
                 // into= behaves exactly like record into= (before this, a renamed folder fell to a misleading "folder not
-                // found"). needEsp:false â€” a rider targets the FOLDER itself (it writes scripts / a .bsa / loose files into
+                // found"). needEsp:false — a rider targets the FOLDER itself (it writes scripts / a .bsa / loose files into
                 // it, not an .esp), so it does NOT require a <stem>.esp to be present.
                 var folder = ResolveOwnedPatchFolder(into, needEsp: false);
-                return new RiderFolder(folder, folder, CreatedFresh: false);   // reused â€” the user owns it; cleanup leaves it
+                return new RiderFolder(folder, folder, CreatedFresh: false);   // reused — the user owns it; cleanup leaves it
             }
 
             var newStem = UniqueStem(PatchStem(string.IsNullOrWhiteSpace(patchName) ? defaultStem : patchName!));
@@ -2567,7 +2567,7 @@ public sealed class LoadOrderService : IDisposable
         }
     }
 
-    /// <summary>The <c>Scripts\</c> output folder for a COMPILED .pex (the compile rider) â€” a houseCARL mod folder via
+    /// <summary>The <c>Scripts\</c> output folder for a COMPILED .pex (the compile rider) — a houseCARL mod folder via
     /// <see cref="ResolvePatchModFolder"/> plus its <c>Scripts\</c> subfolder, where MO2 deploys compiled Papyrus into the
     /// game's Data\Scripts. Carries the mod-folder root + fresh flag through for residue cleanup.</summary>
     public RiderFolder ResolveCompiledScriptFolder(string? patchName, string? into)
@@ -2580,12 +2580,12 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>output_dir= escape hatch (6.3): the user names WHERE the compiled .pex lands, instead of houseCARL cutting a
     /// fresh folder-per-patch mod folder. DECIDED contract (Aaron 2026-06-16): output_dir is a mod-folder ROOT and houseCARL
-    /// appends Scripts\ â€” matching <see cref="ResolveCompiledScriptFolder"/> + MO2's deploy model so the .pex actually loads â€”
+    /// appends Scripts\ — matching <see cref="ResolveCompiledScriptFolder"/> + MO2's deploy model so the .pex actually loads —
     /// with a DOUBLE-SCRIPTS guard (don't append a second Scripts\ if it's already there). Does NOT call
-    /// <see cref="ResolvePatchModFolder"/> (no houseCARL mod folder is cut under ModsDir), and the folder is USER-OWNED â€” the
+    /// <see cref="ResolvePatchModFolder"/> (no houseCARL mod folder is cut under ModsDir), and the folder is USER-OWNED — the
     /// returned <see cref="RiderFolder"/> carries CreatedFresh=false, so <see cref="RemoveOrNameRiderResidue"/> never deletes
     /// it on a failed compile (it early-returns on !CreatedFresh). <paramref name="deployWarning"/> is a Q3 note (non-null)
-    /// when the final Scripts\ path is under neither the MO2 mods tree nor the game's Data â€” the .pex compiles but the game
+    /// when the final Scripts\ path is under neither the MO2 mods tree nor the game's Data — the .pex compiles but the game
     /// won't auto-load it from there, so a clean "done" is never reported for a .pex that won't deploy. Refuses loud (Q3) on
     /// an unusable output_dir (a malformed path, or a path that names an existing FILE).</summary>
     public RiderFolder ResolveExplicitScriptFolder(string outputDir, out string? deployWarning)
@@ -2598,18 +2598,18 @@ public sealed class LoadOrderService : IDisposable
             try { root = Path.GetFullPath((outputDir ?? "").Trim().Trim('"')); }
             catch (Exception ex) { throw new InvalidOperationException($"output_dir '{outputDir}' is not a usable path ({ex.Message})."); }
             if (File.Exists(root))
-                throw new InvalidOperationException($"output_dir '{root}' is a file, not a folder. Give a mod-folder root â€” houseCARL appends Scripts\\.");
+                throw new InvalidOperationException($"output_dir '{root}' is a file, not a folder. Give a mod-folder root — houseCARL appends Scripts\\.");
 
             var (scriptsDir, appended, warn) = ScriptOutputContract(root, _modsDir, _dataDir);
-            // Friendly Q3 message if the folder can't be created â€” e.g. <output_dir>\Scripts already exists AS A FILE, or
-            // the path is read-only â€” instead of letting the IO/access exception reach Guard.Tool's generic "internal
+            // Friendly Q3 message if the folder can't be created — e.g. <output_dir>\Scripts already exists AS A FILE, or
+            // the path is read-only — instead of letting the IO/access exception reach Guard.Tool's generic "internal
             // failure" (which would wrongly read as a houseCARL bug, not bad input). The File.Exists(root) guard above
             // already catches the common "output_dir itself is a file" shape; this rounds out the rest.
             try { Directory.CreateDirectory(scriptsDir); }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             { throw new InvalidOperationException($"output_dir: couldn't create the output folder '{scriptsDir}' ({ex.Message}). Check the path and that it's writable."); }
             deployWarning = warn;
-            // ModFolder = the mod-folder root (inert here â€” cleanup is bypassed by CreatedFresh=false â€” but kept honest):
+            // ModFolder = the mod-folder root (inert here — cleanup is bypassed by CreatedFresh=false — but kept honest):
             // when the user pointed AT a Scripts\ dir, the root is its parent; otherwise the path they gave IS the root.
             var modRoot = appended ? root : (Path.GetDirectoryName(scriptsDir.TrimEnd('\\', '/')) ?? scriptsDir);
             return new RiderFolder(scriptsDir, modRoot, CreatedFresh: false);   // user-owned: residue cleanup never touches it
@@ -2618,10 +2618,10 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>PURE (no filesystem access) resolution of the output_dir= contract, so the riskiest 6.3 change is provable in
     /// CI without an MO2 instance. Appends Scripts\ to a mod-folder root, with the DOUBLE-SCRIPTS GUARD (a root already ending
-    /// in a Scripts segment â€” any case, trailing separator tolerated â€” is taken as-is, never doubled). <paramref name="outputDir"/>
+    /// in a Scripts segment — any case, trailing separator tolerated — is taken as-is, never doubled). <paramref name="outputDir"/>
     /// is expected absolute (the caller GetFullPaths it). Returns the final Scripts dir, whether Scripts\ was appended, and a
     /// Q3 deployWarning when the result is under neither <paramref name="modsDir"/> (a mod's Scripts\ is VFS-deployed) nor
-    /// <paramref name="dataDir"/> (a direct game install) â€” the one "this won't load" case the contract can't fix by
+    /// <paramref name="dataDir"/> (a direct game install) — the one "this won't load" case the contract can't fix by
     /// construction, so it's surfaced rather than reported as a clean success.</summary>
     internal static (string scriptsDir, bool appendedScripts, string? deployWarning) ScriptOutputContract(
         string outputDir, string modsDir, string dataDir)
@@ -2632,20 +2632,20 @@ public sealed class LoadOrderService : IDisposable
         // Deployable = the .pex will ACTUALLY auto-load. MO2 overlays a mod folder's CONTENTS onto the game Data root, so a
         // deployable mod Scripts\ is EXACTLY <mods>\<modFolder>\Scripts (mod folder a direct child of mods; Scripts directly
         // under it). A bare <mods>\Scripts (no mod folder) and a nested <mods>\X\Sub\Scripts (lands at Data\Sub\Scripts, not
-        // Data\Scripts) do NOT load â€” so they correctly WARN (review nit: "under mods" alone was too loose). A direct game
+        // Data\Scripts) do NOT load — so they correctly WARN (review nit: "under mods" alone was too loose). A direct game
         // install loads exactly <data>\Scripts.
         bool deployable = IsModScriptsFolder(scriptsDir, modsDir) || IsDataScriptsFolder(scriptsDir, dataDir);
         string? warn = deployable ? null :
             $"note: '{scriptsDir}' isn't a folder MO2 (or the game) auto-loads scripts from, so the compiled .pex won't " +
-            "deploy on its own â€” it compiled fine, but you must place it where the game loads scripts yourself: a mod's " +
+            "deploy on its own — it compiled fine, but you must place it where the game loads scripts yourself: a mod's " +
             "own Scripts\\ folder (<mods>\\<YourMod>\\Scripts) or the game's <Data>\\Scripts.";
         return (scriptsDir, !alreadyScripts, warn);
     }
 
-    /// <summary>A Scripts\ folder MO2 actually deploys: <c>&lt;modsDir&gt;\&lt;modFolder&gt;\Scripts</c> exactly â€” the mod
+    /// <summary>A Scripts\ folder MO2 actually deploys: <c>&lt;modsDir&gt;\&lt;modFolder&gt;\Scripts</c> exactly — the mod
     /// folder a DIRECT child of the mods root, Scripts directly under it (MO2 maps a mod folder's contents onto the Data
     /// root, so <c>&lt;mods&gt;\Scripts</c> has no mod and <c>&lt;mods&gt;\X\Sub\Scripts</c> lands at Data\Sub\Scripts). Empty
-    /// mods root (unconfigured) â†’ false. Case-insensitive, normalized.</summary>
+    /// mods root (unconfigured) → false. Case-insensitive, normalized.</summary>
     static bool IsModScriptsFolder(string scriptsDir, string modsDir)
     {
         if (string.IsNullOrEmpty(modsDir)) return false;
@@ -2653,7 +2653,7 @@ public sealed class LoadOrderService : IDisposable
         return modFolder is not null && PathEquals(Path.GetDirectoryName(modFolder), modsDir);
     }
 
-    /// <summary>A direct game install loads exactly <c>&lt;dataDir&gt;\Scripts</c> (not Data\Sub\Scripts). Empty data dir â†’
+    /// <summary>A direct game install loads exactly <c>&lt;dataDir&gt;\Scripts</c> (not Data\Sub\Scripts). Empty data dir →
     /// false. Case-insensitive, normalized.</summary>
     static bool IsDataScriptsFolder(string scriptsDir, string dataDir)
     {
@@ -2662,15 +2662,15 @@ public sealed class LoadOrderService : IDisposable
     }
 
     /// <summary>Case-insensitive equality of two paths after full-path normalization + trailing-separator trim (no
-    /// filesystem access). A null left side (no parent â€” e.g. a drive root) is never equal.</summary>
+    /// filesystem access). A null left side (no parent — e.g. a drive root) is never equal.</summary>
     static bool PathEquals(string? a, string b)
     {
         if (a is null) return false;
         return Path.GetFullPath(a).TrimEnd('\\', '/').Equals(Path.GetFullPath(b).TrimEnd('\\', '/'), StringComparison.OrdinalIgnoreCase);
     }
 
-    /// <summary>The <c>Source\Scripts\</c> output folder for a DECOMPILED .psc (the decompile rider) â€” the SE-canonical
-    /// source layout, and the same default patch stem as the compile rider so decompile â†’ edit â†’ compile naturally
+    /// <summary>The <c>Source\Scripts\</c> output folder for a DECOMPILED .psc (the decompile rider) — the SE-canonical
+    /// source layout, and the same default patch stem as the compile rider so decompile → edit → compile naturally
     /// accumulates in one houseCARL patch folder via <c>into=</c>. Carries the root + fresh flag through for cleanup.</summary>
     public RiderFolder ResolveDecompiledSourceFolder(string? patchName, string? into)
     {
@@ -2681,24 +2681,24 @@ public sealed class LoadOrderService : IDisposable
     }
 
     /// <summary>Hunt H2 (Aaron 2026-06-13): a NON-.esp rider (compile / decompile / repack) that FAILED after creating a
-    /// fresh houseCARL mod folder cleans up after itself â€” the .esp F4 "a refusal leaves no orphan folder" principle,
+    /// fresh houseCARL mod folder cleans up after itself — the .esp F4 "a refusal leaves no orphan folder" principle,
     /// generalised to the riders. If the fresh folder is GENUINELY EMPTY (holds NOTHING but our own meta.ini marker
     /// anywhere in its tree) it is DELETED, so "no output written" is true of the disk; if real output DID land (a
-    /// partial .bsa, some written .psc/.pex), the folder STAYS and its path is RETURNED so the rider can NAME it â€”
+    /// partial .bsa, some written .psc/.pex), the folder STAYS and its path is RETURNED so the rider can NAME it —
     /// houseCARL never deletes content it didn't recognise as its own marker. A REUSED into= folder
     /// (<see cref="RiderFolder.CreatedFresh"/> = false) is never touched: the user owns it. Returns the leftover path to
     /// name, or null (deleted, or nothing to do). Best-effort: a cleanup hiccup never masks the rider's own outcome.</summary>
     internal string? RemoveOrNameRiderResidue(RiderFolder folder)
     {
-        if (!folder.CreatedFresh) return null;             // into= reuse â€” the user owns it, never deleted or named
+        if (!folder.CreatedFresh) return null;             // into= reuse — the user owns it, never deleted or named
         var root = folder.ModFolder;
         try
         {
             if (!Directory.Exists(root)) return null;
             bool onlyMarker = Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories)
                 .All(f => Path.GetFileName(f).Equals("meta.ini", StringComparison.OrdinalIgnoreCase));
-            if (onlyMarker) { Directory.Delete(root, recursive: true); return null; }   // genuinely empty â†’ gone, nothing to name
-            return root;                                   // real output landed â†’ keep it, hand back the path to NAME
+            if (onlyMarker) { Directory.Delete(root, recursive: true); return null; }   // genuinely empty → gone, nothing to name
+            return root;                                   // real output landed → keep it, hand back the path to NAME
         }
         catch (IOException) { return Directory.Exists(root) ? root : null; }
         catch (UnauthorizedAccessException) { return Directory.Exists(root) ? root : null; }
@@ -2706,7 +2706,7 @@ public sealed class LoadOrderService : IDisposable
 
     // ---- Layer B unit D: write the start-game-enabled-quest .seq file (housecarl_write_seq) ----
 
-    /// <summary>The <c>SEQ\</c> output folder for a generated <c>.seq</c> (the SEQ rider) â€” a houseCARL mod folder via
+    /// <summary>The <c>SEQ\</c> output folder for a generated <c>.seq</c> (the SEQ rider) — a houseCARL mod folder via
     /// <see cref="ResolvePatchModFolder"/> plus its <c>SEQ\</c> subfolder, where MO2 deploys it into the game's
     /// <c>Data\SEQ</c>. Sibling of <see cref="ResolveCompiledScriptFolder"/>; carries the mod-folder root + fresh flag
     /// through for residue cleanup.</summary>
@@ -2719,10 +2719,10 @@ public sealed class LoadOrderService : IDisposable
     }
 
     /// <summary>If <paramref name="pluginPath"/> lives in a houseCARL-owned mod folder DIRECTLY under ModsDir, return that
-    /// folder's patch STEM, so the <c>.seq</c> defaults into the SAME folder as the <c>.esp</c> â€” one mod to enable, and
+    /// folder's patch STEM, so the <c>.seq</c> defaults into the SAME folder as the <c>.esp</c> — one mod to enable, and
     /// no second fresh folder the user might forget to enable (a real Q3 footgun: a .seq in an un-enabled folder leaves the
     /// quest silently dead). Only when the folder is the canonical <c>houseCARL - &lt;stem&gt;</c> for THIS plugin (so a
-    /// later <c>into=&lt;stem&gt;</c> resolves to exactly this folder); otherwise null â†’ the caller cuts a fresh folder.</summary>
+    /// later <c>into=&lt;stem&gt;</c> resolves to exactly this folder); otherwise null → the caller cuts a fresh folder.</summary>
     string? OwnedPluginFolderStem(string pluginPath)
     {
         var dir = Path.GetDirectoryName(pluginPath);
@@ -2734,11 +2734,11 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>Write a plugin's start-game-enabled-quest <c>.seq</c> (housecarl_write_seq). Opens <paramref name="plugin"/>
     /// (a path to an .esp/.esm/.esl), collects every Start-Game-Enabled quest it defines, and writes
-    /// <c>&lt;ModFolder&gt;\SEQ\&lt;plugin&gt;.seq</c> â€” the file the engine reads to actually START those quests (the flag
+    /// <c>&lt;ModFolder&gt;\SEQ\&lt;plugin&gt;.seq</c> — the file the engine reads to actually START those quests (the flag
     /// alone does nothing; the same gated, crash-atomic, non-destructive folder-per-patch model as the compile/asset
     /// riders). Output folder DEFAULTS to the plugin's OWN houseCARL folder when it lives in one (so the .seq deploys with
     /// the .esp); else a fresh folder, or <paramref name="into"/>/<paramref name="patchName"/> when given. A plugin with NO
-    /// SGE quests writes NOTHING and cuts no folder (a .seq is only needed for SGE quests â€” Q3, not a silent empty file).
+    /// SGE quests writes NOTHING and cuts no folder (a .seq is only needed for SGE quests — Q3, not a silent empty file).
     /// Serialized on the write gate (one write at a time), like its sibling writers.</summary>
     public SeqOutcome WriteSeq(string plugin, string? patchName, string? into)
     {
@@ -2751,18 +2751,18 @@ public sealed class LoadOrderService : IDisposable
         if (!PluginExts.Contains(Path.GetExtension(pluginPath), StringComparer.OrdinalIgnoreCase))
             return SeqOutcome.Fail($"'{Path.GetFileName(pluginPath)}' is not a plugin (.esp/.esm/.esl).");
 
-        lock (_writeGate)                                                // one write at a time (hunt F2 sibling): build â†’ resolve â†’ commit
+        lock (_writeGate)                                                // one write at a time (hunt F2 sibling): build → resolve → commit
         {
             if (ConfigPromptOrNull() is { } cfgPrompt) return SeqOutcome.Fail(cfgPrompt);   // need ModsDir for the output folder
-            lock (_gate) EnsurePathsDerived();                          // derive ModsDir for the owned-folder check (lock order: _writeGate â†’ _gate)
+            lock (_gate) EnsurePathsDerived();                          // derive ModsDir for the owned-folder check (lock order: _writeGate → _gate)
 
-            // Build the .seq from the plugin (read-only overlay, disposed inside â€” zero handles at rest).
+            // Build the .seq from the plugin (read-only overlay, disposed inside — zero handles at rest).
             SeqFile.SeqBuild built;
             try { built = SeqFile.Build(pluginPath); }
             catch (Exception ex)
             { return SeqOutcome.Fail($"could not read '{Path.GetFileName(pluginPath)}' as a plugin: {ex.Message}"); }
 
-            // No SGE quests â†’ no .seq needed; write nothing, cut no folder (Q3: a clean, explicit "nothing to do").
+            // No SGE quests → no .seq needed; write nothing, cut no folder (Q3: a clean, explicit "nothing to do").
             if (built.Quests.Count == 0)
                 return new SeqOutcome(true, null, null, null, built.Quests, built.PluginFileName, false);
 
@@ -2773,21 +2773,21 @@ public sealed class LoadOrderService : IDisposable
             try { rf = ResolveSeqFolder(patchName, autoInto ?? into); }
             catch (InvalidOperationException ex) { return SeqOutcome.Fail(ex.Message); }
 
-            // Crash-atomic write of <plugin>.seq under SEQ\ (originals untouched â€” a houseCARL-owned folder only).
+            // Crash-atomic write of <plugin>.seq under SEQ\ (originals untouched — a houseCARL-owned folder only).
             var seqName = Path.GetFileNameWithoutExtension(pluginPath) + ".seq";
             var dest = Path.Combine(rf.OutputDir, seqName);
             try { AtomicFile.WriteAllBytes(dest, built.Bytes); }
             catch (Exception ex)
             {
-                var residue = RemoveOrNameRiderResidue(rf);             // nothing landed â†’ a fresh folder is an orphan
+                var residue = RemoveOrNameRiderResidue(rf);             // nothing landed → a fresh folder is an orphan
                 return SeqOutcome.Fail($"could not write '{seqName}': {ex.Message}"
                     + (residue is null ? "" : $" The freshly created folder was left at '{residue}'."));
             }
 
-            // Integrity (Q3: THIS run wrote it; on-disk size matches the bytes we built â€” no false success).
+            // Integrity (Q3: THIS run wrote it; on-disk size matches the bytes we built — no false success).
             long size; try { size = new FileInfo(dest).Length; } catch { size = -1; }
             if (size != built.Bytes.Length)
-                return SeqOutcome.Fail($"wrote '{seqName}' but its on-disk size ({size}) does not match the {built.Bytes.Length} expected byte(s) â€” verify before relying on it.");
+                return SeqOutcome.Fail($"wrote '{seqName}' but its on-disk size ({size}) does not match the {built.Bytes.Length} expected byte(s) — verify before relying on it.");
 
             return new SeqOutcome(true, null, dest, rf.ModFolder, built.Quests, built.PluginFileName, autoInto is not null);
         }
@@ -2800,18 +2800,18 @@ public sealed class LoadOrderService : IDisposable
     readonly object _classParentsLock = new();
 
     /// <summary>Drop the cached hierarchy whenever <see cref="_modsDir"/> can have changed (instance switch /
-    /// profile re-derive) â€” a stale tree's edges could suppress a cast the NEW order's hierarchy doesn't
-    /// justify (a recompile-fail, not silent wrong semantics â€” but stale is stale). Rebuilds lazily.</summary>
+    /// profile re-derive) — a stale tree's edges could suppress a cast the NEW order's hierarchy doesn't
+    /// justify (a recompile-fail, not silent wrong semantics — but stale is stale). Rebuilds lazily.</summary>
     void InvalidateClassParents() { lock (_classParentsLock) { _classParents = null; _classParentsNote = null; } }
 
-    /// <summary>The decompiler's childâ†’parent class map: committed vanilla baseline (beside the exe) + loose .psc
-    /// headers across the MO2 mods tree (mods that ship sources â€” SKSE, PO3, â€¦). Built on FIRST decompile call,
+    /// <summary>The decompiler's child→parent class map: committed vanilla baseline (beside the exe) + loose .psc
+    /// headers across the MO2 mods tree (mods that ship sources — SKSE, PO3, …). Built on FIRST decompile call,
     /// cached for process lifetime (a SOFT input by construction: missing pieces = explicit casts in the output,
-    /// never wrong code â€” the note names any degraded mode, Q3). The input pex's own folder is topped up per call
-    /// by the tool, not here (it varies per input). Paths derive FIRST (under the gate â€” the established
-    /// gateâ†’parents lock order): in instance mode ModsDir is lazy, and a decompile-first session used to build
+    /// never wrong code — the note names any degraded mode, Q3). The input pex's own folder is topped up per call
+    /// by the tool, not here (it varies per input). Paths derive FIRST (under the gate — the established
+    /// gate→parents lock order): in instance mode ModsDir is lazy, and a decompile-first session used to build
     /// and cache the baseline-only map for process lifetime with the mods-tree harvest silently skipped
-    /// (2026-06-12 adversarial hunt F1, proven â€” the third _modsDir-mutation site missed by the PR #47 fix).</summary>
+    /// (2026-06-12 adversarial hunt F1, proven — the third _modsDir-mutation site missed by the PR #47 fix).</summary>
     public (Dictionary<string, string> Edges, string? Note) ClassParentsForDecompile()
     {
         lock (_gate)
@@ -2830,7 +2830,7 @@ public sealed class LoadOrderService : IDisposable
                     if (!string.IsNullOrEmpty(_modsDir) && Directory.Exists(_modsDir))
                         HousecarlCore.PapyrusClassParents.AddFromPscHeaders(edges, new[] { _modsDir });
                 }
-                catch { /* fewer edges, never fatal â€” the baseline still applies */ }
+                catch { /* fewer edges, never fatal — the baseline still applies */ }
                 _classParents = edges;
                 _classParentsNote = note;
             }
@@ -2842,14 +2842,14 @@ public sealed class LoadOrderService : IDisposable
     /// pane and is the human-visible ownership signal (the meta.ini marker is the structural one).</summary>
     static string ModFolderName(string stem) => "houseCARL - " + stem;
 
-    /// <summary>Plugin extensions stripped from a caller-supplied patch name (case-insensitive). NOT every dot â€” see
+    /// <summary>Plugin extensions stripped from a caller-supplied patch name (case-insensitive). NOT every dot — see
     /// <see cref="PatchStem"/>. Aliases the one shared home (<see cref="HousecarlCore.PluginFile.Extensions"/>) so this
     /// and the load-order reader / name-suggester copies can't diverge.</summary>
     static readonly string[] PluginExts = PluginFile.Extensions;
 
-    /// <summary>Reduce a caller name to a safe bare STEM â€” no directory parts (so "../x" / "C:\y" can't escape ModsDir),
+    /// <summary>Reduce a caller name to a safe bare STEM — no directory parts (so "../x" / "C:\y" can't escape ModsDir),
     /// stripping ONLY a trailing plugin extension (.esp/.esm/.esl), not every dot. A dotted patch name like
-    /// "My.Cool.Patch" must survive intact: Path.GetFileNameWithoutExtension would clip it to "My.Cool" â€” and then an
+    /// "My.Cool.Patch" must survive intact: Path.GetFileNameWithoutExtension would clip it to "My.Cool" — and then an
     /// into="My.Cool.Patch" extend would look for the wrong folder, a silent name divergence. The plugin is always
     /// <c>&lt;stem&gt;.esp</c>; the mod folder is <c>houseCARL - &lt;stem&gt;</c>.</summary>
     static string PatchStem(string raw)
@@ -2860,7 +2860,7 @@ public sealed class LoadOrderService : IDisposable
         return string.IsNullOrEmpty(name) ? "houseCARL_Patch" : name;
     }
 
-    /// <summary>The given stem if its mod folder is free, else the first free "<c>&lt;stem&gt;_NNN</c>" â€” never clobbers
+    /// <summary>The given stem if its mod folder is free, else the first free "<c>&lt;stem&gt;_NNN</c>" — never clobbers
     /// an existing folder (houseCARL's own OR a user's; into= is the way to grow an existing houseCARL patch).</summary>
     string UniqueStem(string stem)
     {
@@ -2870,17 +2870,17 @@ public sealed class LoadOrderService : IDisposable
             var cand = $"{stem}_{i:D3}";
             if (!Directory.Exists(Path.Combine(_modsDir, ModFolderName(cand)))) return cand;
         }
-        throw new InvalidOperationException($"too many patches named '{stem}' under ModsDir â€” clean some out.");
+        throw new InvalidOperationException($"too many patches named '{stem}' under ModsDir — clean some out.");
     }
 
     /// <summary>The 4-step <c>into=</c> EXTEND resolver, SHARED by the .esp write path (<see cref="ResolveOutputPath"/>)
     /// and the rider/asset path (<see cref="ResolvePatchModFolder"/>) so "extend my renamed patch" behaves IDENTICALLY
-    /// across records, scripts, BSAs, and assets (HCBR-2026-06-23 â€” the record lane was fixed first; this closes the
+    /// across records, scripts, BSAs, and assets (HCBR-2026-06-23 — the record lane was fixed first; this closes the
     /// sibling). Resolves <paramref name="into"/> to the houseCARL-OWNED mod FOLDER it names: (1) the canonical
-    /// "houseCARL - &lt;stem&gt;" fast path; (2) by the &lt;stem&gt;.esp it HOLDS (the folder was renamed â€” the .esp basename
+    /// "houseCARL - &lt;stem&gt;" fast path; (2) by the &lt;stem&gt;.esp it HOLDS (the folder was renamed — the .esp basename
     /// is fixed by SPID/CSF/masters); (3) by the folder's OWN name (the catch-all; folder &amp; plugin names need not match);
     /// (4) loud Q3 refusals naming every place searched, a FOREIGN (un-owned) collision distinguished from a genuine miss.
-    /// Ownership-gated at every step â€” a plugin houseCARL didn't make stays refused (no foreign-plugin door; that's the
+    /// Ownership-gated at every step — a plugin houseCARL didn't make stays refused (no foreign-plugin door; that's the
     /// separate in-place lane). <paramref name="needEsp"/> tightens the canonical fast path for the RECORD lane (the folder
     /// must actually hold &lt;stem&gt;.esp to short-circuit, else fall through); the rider lane targets the folder itself, so
     /// it short-circuits on folder-exists+owned. Caller holds <see cref="_gate"/>.</summary>
@@ -2889,29 +2889,29 @@ public sealed class LoadOrderService : IDisposable
         var stem = PatchStem(into);                             // strips a trailing .esp/.esm/.esl; no directory parts (can't escape ModsDir)
         var espName = stem + ".esp";
 
-        // (1) CANONICAL fast path â€” "houseCARL - <stem>" still owns the patch (common case; no scan). The record lane also
+        // (1) CANONICAL fast path — "houseCARL - <stem>" still owns the patch (common case; no scan). The record lane also
         //     requires it to HOLD <stem>.esp (needEsp); the rider lane only needs the owned folder.
         var canonical = Path.Combine(_modsDir, ModFolderName(stem));
         if (Directory.Exists(canonical) && IsHouseCarlOwned(canonical) && (!needEsp || File.Exists(Path.Combine(canonical, espName))))
             return canonical;
 
-        // (2) by PLUGIN name â€” the owned folder HOLDING <stem>.esp, whatever it's now called (the renamed-folder case).
+        // (2) by PLUGIN name — the owned folder HOLDING <stem>.esp, whatever it's now called (the renamed-folder case).
         var byEsp = OwnedFoldersHolding(espName)
             .Select(p => Path.GetDirectoryName(p)!).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
         if (byEsp.Count == 1) return byEsp[0];
         if (byEsp.Count > 1)
             throw new InvalidOperationException(
-                $"cannot extend: {byEsp.Count} houseCARL folders carry '{espName}' â€” ambiguous, refusing to guess. " +
+                $"cannot extend: {byEsp.Count} houseCARL folders carry '{espName}' — ambiguous, refusing to guess. " +
                 "Pass the CONTAINING mod-folder name as into= to pick one (folder & plugin names need not match): " +
                 string.Join("  |  ", byEsp.Select(d => $"into=\"{Path.GetFileName(d)}\"")) + ".");
 
-        // (3) FOLDER catch-all â€” into= NAMES the mod folder itself (the same-named-plugin disambiguator, and the way to
+        // (3) FOLDER catch-all — into= NAMES the mod folder itself (the same-named-plugin disambiguator, and the way to
         //     point at a renamed folder by its new name).
         var named = ResolveOwnedFolderByName(into);
         if (named is not null) return named;
 
-        // (4) Nothing matched. Distinguish a FOREIGN (un-owned) name collision â€” refused for the same reason as ever
-        //     (originals untouched, Q3) â€” from a genuine miss, NAMING every place searched (the report asked the refusal
+        // (4) Nothing matched. Distinguish a FOREIGN (un-owned) name collision — refused for the same reason as ever
+        //     (originals untouched, Q3) — from a genuine miss, NAMING every place searched (the report asked the refusal
         //     to reveal all the required pieces at once, not one half per failed call).
         var bareName = Path.GetFileName(into.Trim());
         foreach (var cand in new[] { ModFolderName(stem), bareName })
@@ -2919,7 +2919,7 @@ public sealed class LoadOrderService : IDisposable
             var candPath = string.IsNullOrEmpty(cand) ? null : Path.Combine(_modsDir, cand);
             if (candPath is not null && Directory.Exists(candPath) && !IsHouseCarlOwned(candPath))
                 throw new InvalidOperationException(
-                    $"cannot extend: mod folder '{cand}' exists but was NOT created by houseCARL (no marker) â€” " +
+                    $"cannot extend: mod folder '{cand}' exists but was NOT created by houseCARL (no marker) — " +
                     "refusing to write into a folder houseCARL doesn't own (originals untouched, Q3). Use a different patch name.");
         }
         throw new InvalidOperationException(
@@ -2930,7 +2930,7 @@ public sealed class LoadOrderService : IDisposable
     }
 
     /// <summary>houseCARL-OWNED mod folders under ModsDir holding a plugin file named <paramref name="espFileName"/> at
-    /// their root â€” the decoupled resolver behind <c>into=</c>. The .esp basename is FIXED (SPID <c>_DISTR</c>, the CSF
+    /// their root — the decoupled resolver behind <c>into=</c>. The .esp basename is FIXED (SPID <c>_DISTR</c>, the CSF
     /// JSON, and masters all bind the patch by its filename), while the MO2 mod-FOLDER name is the user's to rename for
     /// organization; so an extend finds the patch by the plugin it holds, not by the folder's current name. Ownership-gated
     /// (the marker) so a user mod that merely shares the basename is NEVER returned (originals untouched, Q3). Full .esp paths.</summary>
@@ -2946,9 +2946,9 @@ public sealed class LoadOrderService : IDisposable
     }
 
     /// <summary>A houseCARL-OWNED mod folder named exactly <paramref name="rawName"/> or "<c>houseCARL - &lt;rawName&gt;</c>"
-    /// â€” the FOLDER catch-all behind <c>into=</c>: the user NAMES the containing mod folder when the plugin basename is
+    /// — the FOLDER catch-all behind <c>into=</c>: the user NAMES the containing mod folder when the plugin basename is
     /// ambiguous (or to point at a renamed folder by its new name), and the folder name need NOT match the .esp inside.
-    /// Bare name only (no directory parts â€” can't escape ModsDir). Null when no such folder is houseCARL-owned.</summary>
+    /// Bare name only (no directory parts — can't escape ModsDir). Null when no such folder is houseCARL-owned.</summary>
     string? ResolveOwnedFolderByName(string rawName)
     {
         var bare = Path.GetFileName(rawName.Trim());
@@ -2963,7 +2963,7 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>The single top-level plugin (.esp/.esm/.esl) in a houseCARL folder, so <c>into=</c> a folder NAME can edit
     /// "the plugin in this folder" without re-stating its basename. Null + a named <paramref name="reason"/> when the folder
-    /// holds none or more than one (Q3 â€” never guess which of several to extend).</summary>
+    /// holds none or more than one (Q3 — never guess which of several to extend).</summary>
     static string? SoleEspInFolder(string folder, out string reason)
     {
         var plugins = Directory.EnumerateFiles(folder)
@@ -2972,12 +2972,12 @@ public sealed class LoadOrderService : IDisposable
         if (plugins.Count == 1) { reason = ""; return plugins[0]; }
         reason = plugins.Count == 0
             ? "holds no plugin (.esp/.esm/.esl) to extend"
-            : $"holds {plugins.Count} plugins ({string.Join(", ", plugins.Select(Path.GetFileName))}) â€” name the one to extend by passing its filename as into=";
+            : $"holds {plugins.Count} plugins ({string.Join(", ", plugins.Select(Path.GetFileName))}) — name the one to extend by passing its filename as into=";
         return null;
     }
 
     /// <summary>A mod folder is houseCARL-owned iff its <c>meta.ini</c> carries the <c>[houseCARL] generated=true</c>
-    /// marker. The marker lives in meta.ini â€” the one mod-root file MO2 does NOT deploy into the game Data folder â€” so it
+    /// marker. The marker lives in meta.ini — the one mod-root file MO2 does NOT deploy into the game Data folder — so it
     /// never pollutes Data. FAIL-SAFE (Q3): a missing / stripped marker reads as NOT owned, so houseCARL refuses to
     /// modify the folder rather than risk touching a user mod.</summary>
     static bool IsHouseCarlOwned(string folder)
@@ -3021,16 +3021,16 @@ public sealed class LoadOrderService : IDisposable
 
     // ---- housecarl_read_plugin_file : a RAW, out-of-load-order read of ONE plugin FILE (active or not) ----
 
-    /// <summary>Read ONE plugin file directly off disk â€” INCLUDING a plugin DISABLED in MO2 â€” returning THAT FILE's
+    /// <summary>Read ONE plugin file directly off disk — INCLUDING a plugin DISABLED in MO2 — returning THAT FILE's
     /// own version of a record (<paramref name="formid"/>), the records of a type it defines (<paramref name="type"/>),
     /// or a record-type summary (neither). The standalone-copy chain's Stage-1 enabler: it reaches a donor you're
     /// REMOVING from the active order, which the resolver (active profile only) cannot see.
     ///
     /// <para>STRUCTURAL PURITY (why a separate method, not a flag on <see cref="ResolveRead"/>): it opens its OWN
-    /// overlay via <see cref="LoadOrderResolver.OpenOverlay"/>, materialises, and DISPOSES it â€” it never consults the
+    /// overlay via <see cref="LoadOrderResolver.OpenOverlay"/>, materialises, and DISPOSES it — it never consults the
     /// resolver index and never reports a winner/conflict, so a raw-file read cannot masquerade as load-order truth
     /// (the renderer stamps every result OUT-OF-LOAD-ORDER) and no handle is held at rest (the donor is never locked).
-    /// It emits FormLink fields as FormKey tokens exactly like <see cref="ResolveRead"/> â€” it does NOT follow links, so
+    /// It emits FormLink fields as FormKey tokens exactly like <see cref="ResolveRead"/> — it does NOT follow links, so
     /// it needs no master files present; declared masters that are not installed are reported as an advisory (Q3).</para>
     ///
     /// <para>Read-only. Q3: a missing/ambiguous filename, a bad or absent FormID, or a record Mutagen cannot parse is
@@ -3039,7 +3039,7 @@ public sealed class LoadOrderService : IDisposable
                                             IReadOnlyList<string>? fields, int depth, string? editoridContains, int limit)
     {
         if (string.IsNullOrWhiteSpace(plugin))
-            return PluginFileOutcome.Fail(plugin ?? "", "plugin is required â€” a plugin filename (e.g. 'Vivace.esp') or an absolute path to a .esp/.esm/.esl.");
+            return PluginFileOutcome.Fail(plugin ?? "", "plugin is required — a plugin filename (e.g. 'Vivace.esp') or an absolute path to a .esp/.esm/.esl.");
         plugin = plugin.Trim();
 
         bool hasFormid = !string.IsNullOrWhiteSpace(formid);
@@ -3059,31 +3059,31 @@ public sealed class LoadOrderService : IDisposable
         try { lock (_gate) { EnsurePathsDerived(); modsDir = _modsDir; dataDir = _dataDir; overwriteDir = _overwriteDir; profileDir = _profileDir; } }
         catch (Exception ex) { return PluginFileOutcome.Fail(plugin, ex.Message); }
 
-        var comp = Mo2LoadOrder.ReadComposition(profileDir);           // cheap text parse (enabled + disabled folders) â€” reused for locate + master advisory
+        var comp = Mo2LoadOrder.ReadComposition(profileDir);           // cheap text parse (enabled + disabled folders) — reused for locate + master advisory
 
-        // Locate the file â€” the shared on-disk plugin-locate contract (also the copy-npc-appearance donor lane;
+        // Locate the file — the shared on-disk plugin-locate contract (also the copy-npc-appearance donor lane;
         // one home so the two tools can never find different files for the same filename).
         var loc = LocatePluginFileOnDisk(comp, modsDir, dataDir, overwriteDir, plugin, mod);
         if (loc.Error is not null) return PluginFileOutcome.Fail(plugin, loc.Error);
         if (loc.Ambiguous is not null) return PluginFileOutcome.AmbiguousHits(plugin, loc.Ambiguous);
         string path = loc.Path!, where = loc.Where; bool enabled = loc.Enabled;
 
-        // Open OUR OWN overlay (OpenOverlay wires localized-string resolution), read, then DISPOSE â€” zero handles at rest.
+        // Open OUR OWN overlay (OpenOverlay wires localized-string resolution), read, then DISPOSE — zero handles at rest.
         ISkyrimModGetter ov;
         try { ov = LoadOrderResolver.OpenOverlay(path, string.IsNullOrEmpty(dataDir) ? null : dataDir); }
         catch (Exception ex) { return PluginFileOutcome.Fail(plugin, $"could not open '{path}' as a Skyrim plugin: {ex.Message}"); }
         try
         {
             var masters = ov.ModHeader.MasterReferences.Select(m => m.Master.FileName.ToString()).ToList();
-            // Classify each declared master by whether it will actually LOAD (Q3 â€” the "won't load without them" warning
+            // Classify each declared master by whether it will actually LOAD (Q3 — the "won't load without them" warning
             // must fire exactly when it applies). Two distinct shortfalls, because their remedies differ:
-            //   â€¢ missing  â€” installed NOWHERE in the install (install it).
-            //   â€¢ inactive â€” installed but NOT in the active order: it lives only in a DISABLED mod, or is unchecked
+            //   • missing  — installed NOWHERE in the install (install it).
+            //   • inactive — installed but NOT in the active order: it lives only in a DISABLED mod, or is unchecked
             //                (enable it). A disabled mod is not active, so counting its file as "satisfied" would be the
             //                precise false-negative this split exists to prevent (PR #148 review): it suppresses the
             //                "won't load" warning exactly when it applies.
-            // "Active" is read from the PROFILE (plugins.txt actives + the force-loaded implicit masters) â€” the same
-            // active-order notion housecarl_check_errors uses â€” NOT mere on-disk presence, so the two tools agree.
+            // "Active" is read from the PROFILE (plugins.txt actives + the force-loaded implicit masters) — the same
+            // active-order notion housecarl_check_errors uses — NOT mere on-disk presence, so the two tools agree.
             var missing = new List<string>();
             var inactive = new List<string>();
             foreach (var m in masters)
@@ -3103,9 +3103,9 @@ public sealed class LoadOrderService : IDisposable
             {
                 IMajorRecordGetter? rec;
                 try { rec = ov.EnumerateMajorRecords().FirstOrDefault(r => r.FormKey == fk); }
-                catch (Exception ex) { return baseOut with { Mode = "error", Error = $"'{Path.GetFileName(path)}' could not be fully read â€” a record Mutagen cannot parse before reaching {fk}: {ex.Message}" }; }
+                catch (Exception ex) { return baseOut with { Mode = "error", Error = $"'{Path.GetFileName(path)}' could not be fully read — a record Mutagen cannot parse before reaching {fk}: {ex.Message}" }; }
                 if (rec is null)
-                    return baseOut with { Mode = "error", Error = $"file '{Path.GetFileName(path)}' does not define or override {fk}. This reads the FILE's OWN records only â€” it does not resolve across masters or report a load-order winner; use housecarl_read_record for the winner." };
+                    return baseOut with { Mode = "error", Error = $"file '{Path.GetFileName(path)}' does not define or override {fk}. This reads the FILE's OWN records only — it does not resolve across masters or report a load-order winner; use housecarl_read_record for the winner." };
                 return baseOut with { Mode = "read", Record = ReadEngine.ReadFields(rec, fields, depth <= 0 ? 1 : depth) };
             }
 
@@ -3128,11 +3128,11 @@ public sealed class LoadOrderService : IDisposable
                         else capped = true;
                     }
                 }
-                catch (Exception ex) { return baseOut with { Mode = "error", Error = $"'{Path.GetFileName(path)}' could not be fully enumerated â€” a record Mutagen cannot parse: {ex.Message}" }; }
+                catch (Exception ex) { return baseOut with { Mode = "error", Error = $"'{Path.GetFileName(path)}' could not be fully enumerated — a record Mutagen cannot parse: {ex.Message}" }; }
                 return baseOut with { Mode = "enumerate", Rows = rows, RowTotal = total, Capped = capped };
             }
 
-            // neither â†’ a record-type summary of what the file defines/overrides (donor discovery).
+            // neither → a record-type summary of what the file defines/overrides (donor discovery).
             var counts = new Dictionary<string, int>(StringComparer.Ordinal);
             int recTotal = 0;
             try
@@ -3144,7 +3144,7 @@ public sealed class LoadOrderService : IDisposable
                     counts[tn] = counts.TryGetValue(tn, out var c) ? c + 1 : 1;
                 }
             }
-            catch (Exception ex) { return baseOut with { Mode = "error", Error = $"'{Path.GetFileName(path)}' could not be fully enumerated â€” a record Mutagen cannot parse: {ex.Message}" }; }
+            catch (Exception ex) { return baseOut with { Mode = "error", Error = $"'{Path.GetFileName(path)}' could not be fully enumerated — a record Mutagen cannot parse: {ex.Message}" }; }
             var typeCounts = counts.OrderByDescending(kv => kv.Value).ThenBy(kv => kv.Key, StringComparer.Ordinal)
                                    .Select(kv => new PluginTypeCount(kv.Key, kv.Value)).ToList();
             return baseOut with { Mode = "summary", TypeCounts = typeCounts, RecordTotal = recTotal };
@@ -3158,10 +3158,10 @@ public sealed class LoadOrderService : IDisposable
         string? Path, string Where, bool Enabled, IReadOnlyList<PluginFileHit>? Ambiguous, string? Error);
 
     /// <summary>THE on-disk plugin-locate contract, shared by read_plugin_file and the copy-npc-appearance donor
-    /// lane (review finding: a second inline copy had already diverged â€” the mod= lane forgot the enabled flag). A
+    /// lane (review finding: a second inline copy had already diverged — the mod= lane forgot the enabled flag). A
     /// direct PATH (rooted / has a separator) is used verbatim ("inspect ANY plugin file"); otherwise the argument
     /// is a FILENAME found across the whole install (enabled + disabled mod folders, overwrite, Data), with
-    /// <paramref name="mod"/> narrowing a name several folders provide. Ambiguity comes back structured â€” each
+    /// <paramref name="mod"/> narrowing a name several folders provide. Ambiguity comes back structured — each
     /// caller renders its own remedy.</summary>
     internal static PluginLocateResult LocatePluginFileOnDisk(
         Mo2Composition comp, string modsDir, string dataDir, string overwriteDir, string plugin, string? mod)
@@ -3186,23 +3186,23 @@ public sealed class LoadOrderService : IDisposable
         return new(hits[0].Path, hits[0].Where, hits[0].Enabled, null, null);
     }
 
-    /// <summary>Does the user's `plugin` argument denote a PATH (use verbatim â€” the "inspect any file" case) rather
+    /// <summary>Does the user's `plugin` argument denote a PATH (use verbatim — the "inspect any file" case) rather
     /// than a bare filename (locate in the MO2 folders)? True if rooted or carrying a directory separator: 'C:\..\X.esp'
     /// or 'mods\M\X.esp' is a path; a bare 'X.esp' is a filename.</summary>
     static bool LooksLikePath(string s) => Path.IsPathRooted(s) || s.Contains('\\') || s.Contains('/');
 
-    // ---- corpus-backed type resolution (signature "WEAP" / catalog name "Weapon" â†’ getter Type(s)) -------
+    // ---- corpus-backed type resolution (signature "WEAP" / catalog name "Weapon" → getter Type(s)) -------
 
     Dictionary<string, List<Type>>? _typeLookup;
     Dictionary<string, List<Type>> TypeLookup => _typeLookup ??= BuildTypeLookup();
 
-    /// <summary>Build the type-string â†’ getter-Type(s) map from the corpus (the authoritative type catalog).
+    /// <summary>Build the type-string → getter-Type(s) map from the corpus (the authoritative type catalog).
     /// Keyed by BOTH catalog name and 4-char signature; the 2 many-to-one signatures (GMST/GLOB) accumulate
     /// their variants so a signature query unions them. The 2 abstract-group BASE names (Global / GameSetting,
-    /// kind="polymorphic-base") map to their concrete arms' getter Types BY CONSTRUCTION â€” the same arm union the
-    /// GMST/GLOB signature already yields â€” so a query by the base name unions them too and the ambiguity branch at
+    /// kind="polymorphic-base") map to their concrete arms' getter Types BY CONSTRUCTION — the same arm union the
+    /// GMST/GLOB signature already yields — so a query by the base name unions them too and the ambiguity branch at
     /// ResolveTypeFilter's callers names the variants. A corpus AQ name that won't load is skipped here and surfaces
-    /// as "unknown type" at query time â€” never a silent wrong type.</summary>
+    /// as "unknown type" at query time — never a silent wrong type.</summary>
     static Dictionary<string, List<Type>> BuildTypeLookup()
     {
         var lookup = new Dictionary<string, List<Type>>(StringComparer.OrdinalIgnoreCase);
@@ -3221,8 +3221,8 @@ public sealed class LoadOrderService : IDisposable
             Add(ts.Name, t);
             Add(ts.Signature, t);
         }
-        // Abstract-group base names (Global / GameSetting) â†’ their concrete arms' getter Types. The arms are listed
-        // on the polymorphic-base's own corpus entry, so the union is derived, not hand-wired (cornerstone Â§3): a query
+        // Abstract-group base names (Global / GameSetting) → their concrete arms' getter Types. The arms are listed
+        // on the polymorphic-base's own corpus entry, so the union is derived, not hand-wired (cornerstone §3): a query
         // type='Global' resolves to the same set GLOB does, and the existing many-match guidance names the variants.
         foreach (var ts in corpus.Types.Values)
         {
@@ -3235,7 +3235,7 @@ public sealed class LoadOrderService : IDisposable
         return lookup;
     }
 
-    /// <summary>A user type string â†’ its getter Type(s). Throws (Q3) naming the bad input and what's expected.</summary>
+    /// <summary>A user type string → its getter Type(s). Throws (Q3) naming the bad input and what's expected.</summary>
     IReadOnlyList<Type> ResolveTypeFilter(string type)
     {
         if (TypeLookup.TryGetValue(type.Trim(), out var types)) return types;
@@ -3249,7 +3249,7 @@ public sealed class LoadOrderService : IDisposable
     }
 }
 
-/// <summary>The outcome of a read_record resolve+read. <see cref="Error"/> non-null â‡’ the read failed (with a
+/// <summary>The outcome of a read_record resolve+read. <see cref="Error"/> non-null ⇒ the read failed (with a
 /// recoverable, named reason); otherwise <see cref="Record"/> carries the fields read off <see cref="SourcePlugin"/>.</summary>
 public sealed record ReadOutcome(
     FormKey FormKey,
@@ -3263,13 +3263,13 @@ public sealed record ReadOutcome(
     public static ReadOutcome Fail(FormKey fk, string error) => new(fk, null, null, null, 0, null, error);
 }
 
-/// <summary>The outcome of a cross_plugin_query. <see cref="Error"/> non-null â‡’ the query was rejected (with a
-/// recoverable, named reason â€” bad filter combo / unknown type / plugin not in order). Otherwise <see cref="Keys"/>
+/// <summary>The outcome of a cross_plugin_query. <see cref="Error"/> non-null ⇒ the query was rejected (with a
+/// recoverable, named reason — bad filter combo / unknown type / plugin not in order). Otherwise <see cref="Keys"/>
 /// are the matched FormKeys (at most `limit`); <see cref="Prefilled"/> (parallel to Keys) carries the in-hand
 /// summaries for the type/plugins paths, or is null for the conflicts_only-alone path (the renderer fills those
 /// lazily, bounded by max_chars). <see cref="Sources"/> (parallel to Keys) is the plugin whose body produced each
-/// match â€” the scoped plugin under plugins=, or null under type=/conflicts_only (â‡’ the renderer displays the
-/// winner) â€” so the detail render shows the SAME body the scan filtered and display never contradicts filter.
+/// match — the scoped plugin under plugins=, or null under type=/conflicts_only (⇒ the renderer displays the
+/// winner) — so the detail render shows the SAME body the scan filtered and display never contradicts filter.
 /// <see cref="Total"/> is the true match count; <see cref="Capped"/> is true when Total exceeded what was returned.</summary>
 public sealed record CrossQueryOutcome(
     IReadOnlyList<FormKey> Keys, IReadOnlyList<RecordSummary>? Prefilled, int Total, bool Capped, string? Error,
@@ -3278,20 +3278,20 @@ public sealed record CrossQueryOutcome(
     public static CrossQueryOutcome Fail(string error) => new(Array.Empty<FormKey>(), null, 0, false, error);
 }
 
-/// <summary>A compact, header-only record summary (no field dump) â€” the per-match line cross_plugin_query emits
-/// by default. <see cref="Error"/> non-null â‡’ the winner couldn't be summarised (named, recoverable â€” Q3).</summary>
+/// <summary>A compact, header-only record summary (no field dump) — the per-match line cross_plugin_query emits
+/// by default. <see cref="Error"/> non-null ⇒ the winner couldn't be summarised (named, recoverable — Q3).</summary>
 public sealed record RecordSummary(FormKey FormKey, string Type, string? EditorId, string Winner, int OverrideDepth, string? Error);
 
 /// <summary>One enumerate/read row from a raw plugin-file read: a record the file DEFINES or OVERRIDES, as its
-/// FormKey + type + EditorID. NOT a load-order winner â€” the FILE's own record.</summary>
+/// FormKey + type + EditorID. NOT a load-order winner — the FILE's own record.</summary>
 public sealed record PluginRecordRow(string FormKey, string Type, string? EditorId);
 
 /// <summary>One summary row: a record type the file touches and how many records of it the file defines/overrides.</summary>
 public sealed record PluginTypeCount(string Type, int Count);
 
-/// <summary>The outcome of a housecarl_read_plugin_file call â€” a RAW, OUT-OF-LOAD-ORDER read of ONE plugin file
-/// (active or not), never resolved against the load order. <see cref="Error"/> non-null â‡’ the call failed with a
-/// named, recoverable reason (<see cref="Mode"/> "error"). <see cref="Mode"/> "ambiguous" â‡’ the filename matched
+/// <summary>The outcome of a housecarl_read_plugin_file call — a RAW, OUT-OF-LOAD-ORDER read of ONE plugin file
+/// (active or not), never resolved against the load order. <see cref="Error"/> non-null ⇒ the call failed with a
+/// named, recoverable reason (<see cref="Mode"/> "error"). <see cref="Mode"/> "ambiguous" ⇒ the filename matched
 /// several folders (<see cref="Ambiguous"/> lists them) and the caller must disambiguate. Otherwise <see cref="Mode"/>
 /// is "read" (<see cref="Record"/>), "enumerate" (<see cref="Rows"/> + <see cref="RowTotal"/>/<see cref="Capped"/>),
 /// or "summary" (<see cref="TypeCounts"/> + <see cref="RecordTotal"/>). <see cref="FilePath"/>/<see cref="Where"/>/
@@ -3321,9 +3321,9 @@ public sealed record PluginFileOutcome
         new() { Requested = requested, Mode = "ambiguous", Ambiguous = hits };
 }
 
-/// <summary>The MATERIALISED conflict tree the render layer consumes â€” each touching plugin's name + the fields read
+/// <summary>The MATERIALISED conflict tree the render layer consumes — each touching plugin's name + the fields read
 /// off its own body, in priority order (winner last). Built by <see cref="LoadOrderService.ResolveTree"/> with the
-/// per-call session already disposed, so it carries NO live overlay (Option B â€” the renderer never holds a handle).</summary>
+/// per-call session already disposed, so it carries NO live overlay (Option B — the renderer never holds a handle).</summary>
 public sealed record ConflictTreeView(IReadOnlyList<ConflictNodeView> Nodes)
 {
     public ConflictNodeView Winner => Nodes[^1];
@@ -3334,9 +3334,9 @@ public sealed record ConflictNodeView(string Plugin, RecordFields Record);
 
 /// <summary>The data behind housecarl_load_order_status. <see cref="Composition"/> is the fresh enabled/disabled picture;
 /// <see cref="ResolvedPluginCount"/> + <see cref="Warnings"/> are the resolver's actual last-build state;
-/// <see cref="ProfileChanged"/> is true only when a refresh was attempted but is still pending (e.g. MO2 was mid-write) â€”
-/// houseCARL re-reads automatically on the next tool call; no restart. <see cref="ExcludedPlugins"/> (name â†’ reason) are
-/// plugins dropped from the index this build (unopenable, or carrying a record Mutagen can't parse) â€” surfaced so the
+/// <see cref="ProfileChanged"/> is true only when a refresh was attempted but is still pending (e.g. MO2 was mid-write) —
+/// houseCARL re-reads automatically on the next tool call; no restart. <see cref="ExcludedPlugins"/> (name → reason) are
+/// plugins dropped from the index this build (unopenable, or carrying a record Mutagen can't parse) — surfaced so the
 /// user can fix/remove them (Q3).</summary>
 public sealed record LoadOrderStatusData(
     Mo2Composition Composition,
@@ -3345,18 +3345,18 @@ public sealed record LoadOrderStatusData(
     int MaxPlugins,
     bool ProfileChanged,
     string ProfileDir,
-    string ProfileName,         // the ACTIVE profile (instance mode: MO2's selected_profile; explicit: the dir name) â€” captured under the gate, not re-derived at render
-    string? InstanceDir,        // the resolved MO2 instance folder houseCARL is pointed at; null â‡’ explicit-paths / unconfigured mode
+    string ProfileName,         // the ACTIVE profile (instance mode: MO2's selected_profile; explicit: the dir name) — captured under the gate, not re-derived at render
+    string? InstanceDir,        // the resolved MO2 instance folder houseCARL is pointed at; null ⇒ explicit-paths / unconfigured mode
     IReadOnlyDictionary<string, string> ExcludedPlugins);
 
-/// <summary>The result of <see cref="LoadOrderService.NamedProfileComposition"/> â€” the profiles affordance behind
+/// <summary>The result of <see cref="LoadOrderService.NamedProfileComposition"/> — the profiles affordance behind
 /// housecarl_load_order_status' profile= param. <see cref="InstanceMode"/> is false in explicit-paths mode (no profiles
-/// root â€” a named read refuses loud). <see cref="AvailableProfiles"/> lists the profile folders (instance mode; empty in
+/// root — a named read refuses loud). <see cref="AvailableProfiles"/> lists the profile folders (instance mode; empty in
 /// explicit mode), used both for the default-status discovery line and to name the options when a requested profile isn't
 /// found. <see cref="RequestedName"/> echoes the trimmed name asked for (null if none). <see cref="Composition"/> +
 /// <see cref="ResolvedProfileDir"/> are set ONLY when a requested profile was found and read; a non-null RequestedName with
-/// a null Composition is the "not found" case (Q3 â€” AvailableProfiles names the real options, never a silent empty).
-/// <see cref="Warnings"/> carries any Q3 notes from reading the inspected profile (e.g. a missing modlist.txt â€” so a
+/// a null Composition is the "not found" case (Q3 — AvailableProfiles names the real options, never a silent empty).
+/// <see cref="Warnings"/> carries any Q3 notes from reading the inspected profile (e.g. a missing modlist.txt — so a
 /// 0-enabled-mods render is never mistaken for a genuinely-empty profile); empty unless a profile was found and read.</summary>
 public sealed record NamedProfileResult(
     bool InstanceMode,
@@ -3368,13 +3368,13 @@ public sealed record NamedProfileResult(
 
 /// <summary>One queried asset path's resolution behind housecarl_asset_status: the resolver's <see cref="AssetHit"/>
 /// (which sources have it + which wins + an ambiguity flag), or an <see cref="Error"/> when the path was rejected (a
-/// drive-rooted or '..'-escaping path â€” per-path Q3, never fails the batch). <see cref="Hit"/> is null iff
+/// drive-rooted or '..'-escaping path — per-path Q3, never fails the batch). <see cref="Hit"/> is null iff
 /// <see cref="Error"/> is set.</summary>
 public sealed record AssetPathResult(string RelPath, AssetHit? Hit, string? Error);
 
 /// <summary>The data behind housecarl_asset_status: one <see cref="AssetPathResult"/> per queried path, plus the
-/// build-level Q3 caveats â€” <see cref="BsaFailures"/> (archives that couldn't be read) and <see cref="ReadIncomplete"/>
-/// (an Exists=false answer may be wrong because a BSA failed to read) â€” and <see cref="Warnings"/> from archive
+/// build-level Q3 caveats — <see cref="BsaFailures"/> (archives that couldn't be read) and <see cref="ReadIncomplete"/>
+/// (an Exists=false answer may be wrong because a BSA failed to read) — and <see cref="Warnings"/> from archive
 /// discovery (e.g. a Skyrim.ini that couldn't be found, so base-game BSAs weren't scanned). <see cref="ProfileName"/>
 /// names the active profile the answer describes.</summary>
 public sealed record AssetStatusData(
@@ -3389,9 +3389,9 @@ public sealed record AssetStatusData(
 public sealed record SkseProvider(string Name, string Kind);
 
 /// <summary>One file found under Data\SKSE\Plugins in the active load order (housecarl_skse_inventory). <see cref="Group"/> is the
-/// immediate subfolder it sits in ("" = top level) â€” the derived render-grouping key. <see cref="Providers"/> is the FULL conflict
-/// chain â€” every mod that ships this exact file, WINNER FIRST then the losers in precedence order (the same winnerâ†’loser
-/// transparency the asset tools give), each tagged loose/BSA; empty â‡’ nothing active provides it. <see cref="Plugin"/> is the tier-C
+/// immediate subfolder it sits in ("" = top level) — the derived render-grouping key. <see cref="Providers"/> is the FULL conflict
+/// chain — every mod that ships this exact file, WINNER FIRST then the losers in precedence order (the same winner→loser
+/// transparency the asset tools give), each tagged loose/BSA; empty ⇒ nothing active provides it. <see cref="Plugin"/> is the tier-C
 /// static manifest, set ONLY for a <c>.dll</c> whose winning copy is loose (null for configs and for a BSA-only/unresolved DLL);
 /// <see cref="Note"/> carries the Q3 reason when a DLL has no readable manifest / isn't loader-scoped.</summary>
 public sealed record SkseFileEntry(
@@ -3408,11 +3408,11 @@ public sealed record SkseFileEntry(
     public string? WinningProvider => Winner?.Name;
     /// <summary>The winner's kind ("loose" | "BSA"), or "none" when unprovided.</summary>
     public string ProviderKind => Winner?.Kind ?? "none";
-    /// <summary>How many mods ship this exact file â€” &gt; 1 is contention worth surfacing.</summary>
+    /// <summary>How many mods ship this exact file — &gt; 1 is contention worth surfacing.</summary>
     public int ProviderCount => Providers.Count;
 }
 
-/// <summary>The data behind housecarl_skse_inventory: the SKSE-plugin layer of the active load order â€” <see cref="Dlls"/> (each a
+/// <summary>The data behind housecarl_skse_inventory: the SKSE-plugin layer of the active load order — <see cref="Dlls"/> (each a
 /// plugin DLL with its winning provider + static tier-C manifest) and <see cref="Configs"/> (their .ini/.toml/.json/.yaml with the
 /// winning provider), plus <see cref="OtherFileCount"/> (uncategorized files like .pdb/.txt, counted not listed). The build-level Q3
 /// caveats <see cref="BsaFailures"/> / <see cref="ReadIncomplete"/> and discovery <see cref="Warnings"/> ride along; <see cref="ProfileName"/>
@@ -3428,12 +3428,12 @@ public sealed record SkseInventoryData(
 
 /// <summary>One asset to PLACE (housecarl_place_asset / bulk). <see cref="AssetPath"/> is the resolved Data-relative
 /// DESTINATION (the tool computes it from a FormID+slot for FaceGen, or takes a raw path). <see cref="Source"/> is the
-/// correct copy to place â€” a loose file path, "&lt;archive.bsa&gt;|&lt;entry&gt;", or a ".bsa" path (entry := AssetPath);
-/// null/blank â‡’ auto-resolve (use the sole VFS provider; &gt;1 ambiguous and 0 absent are per-asset refusals, Q3).</summary>
+/// correct copy to place — a loose file path, "&lt;archive.bsa&gt;|&lt;entry&gt;", or a ".bsa" path (entry := AssetPath);
+/// null/blank ⇒ auto-resolve (use the sole VFS provider; &gt;1 ambiguous and 0 absent are per-asset refusals, Q3).</summary>
 public sealed record PlaceRequest(string AssetPath, string? Source);
 
-/// <summary>One placed asset's outcome. <see cref="Placed"/> false â‡’ <see cref="Error"/> names why (recoverable, per-asset
-/// Q3). <see cref="CurrentWinner"/> is the source that currently wins the VFS for this path (the sort target â€” the placed
+/// <summary>One placed asset's outcome. <see cref="Placed"/> false ⇒ <see cref="Error"/> names why (recoverable, per-asset
+/// Q3). <see cref="CurrentWinner"/> is the source that currently wins the VFS for this path (the sort target — the placed
 /// copy does NOT win until the fresh mod is enabled + sorted above it), or null if nothing provided it before.</summary>
 public sealed record PlaceResult(string AssetPath, bool Placed, long Bytes, string? SourceDesc, string? CurrentWinner, string? Error)
 {
@@ -3441,7 +3441,7 @@ public sealed record PlaceResult(string AssetPath, bool Placed, long Bytes, stri
         => new(assetPath, false, 0, null, currentWinner, error);
 }
 
-/// <summary>The outcome of place_asset / bulk_place_asset. <see cref="Error"/> non-null â‡’ the whole call was rejected
+/// <summary>The outcome of place_asset / bulk_place_asset. <see cref="Error"/> non-null ⇒ the whole call was rejected
 /// before any placement (unconfigured, an into= folder houseCARL doesn't own, the asset layer wouldn't build). Else
 /// <see cref="Results"/> is per-asset; <see cref="ModFolder"/> is the houseCARL mod the placed files landed in (null when
 /// none placed); <see cref="Warnings"/> carries the asset-discovery caveats (Q3); <see cref="LeftoverFolder"/> names a
@@ -3453,9 +3453,9 @@ public sealed record PlaceOutcome(
         => new(Array.Empty<PlaceResult>(), null, Array.Empty<string>(), null, error);
 }
 
-/// <summary>The outcome of housecarl_write_seq. <see cref="Error"/> non-null â‡’ the call was rejected (no plugin, unreadable
+/// <summary>The outcome of housecarl_write_seq. <see cref="Error"/> non-null ⇒ the call was rejected (no plugin, unreadable
 /// plugin, an into= folder houseCARL doesn't own, a failed write). On success: <see cref="Quests"/> is every SGE quest
-/// covered (EMPTY â‡’ the plugin had none, so <see cref="SeqPath"/> is null and nothing was written â€” a clean no-op, not a
+/// covered (EMPTY ⇒ the plugin had none, so <see cref="SeqPath"/> is null and nothing was written — a clean no-op, not a
 /// failure); <see cref="SeqPath"/> is the written <c>.seq</c> and <see cref="ModFolder"/> the houseCARL mod it landed in;
 /// <see cref="WroteIntoPluginFolder"/> is true when it defaulted into the plugin's OWN folder (so one mod enables both).
 /// A write-failure residue path (a fresh folder kept because the write half-landed) is folded into <see cref="Error"/>.</summary>

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1,4 +1,4 @@
-using Mutagen.Bethesda.Plugins;
+﻿using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Records;
 using Mutagen.Bethesda.Skyrim;
 
@@ -7,40 +7,40 @@ namespace HousecarlMcp;
 /// <summary>
 /// Owns the load-order resolver's lifecycle for the server and is the single place the tools reach the proven
 /// cores (<see cref="LoadOrderResolver"/> + <see cref="ReadEngine"/>; writes join in Beat C). This is the
-/// server-side half of the §8.4 cleave: tools call clean methods here; here calls the core's public API.
+/// server-side half of the Â§8.4 cleave: tools call clean methods here; here calls the core's public API.
 ///
-/// • LAZY build — the ~10s/180MB index build is deferred to first use, so startup + tools/list are instant.
-/// • FRESH — each query runs the cheap mtime stat-sweep (<see cref="LoadOrderResolver.RefreshIfStale"/>);
+/// â€¢ LAZY build â€” the ~10s/180MB index build is deferred to first use, so startup + tools/list are instant.
+/// â€¢ FRESH â€” each query runs the cheap mtime stat-sweep (<see cref="LoadOrderResolver.RefreshIfStale"/>);
 ///   a mid-session plugin edit auto-rebuilds (~11s), no restart needed.
-/// • THREAD-SAFE — the HTTP server is concurrent; build + refresh are serialized on one gate.
+/// â€¢ THREAD-SAFE â€” the HTTP server is concurrent; build + refresh are serialized on one gate.
 ///
-/// ORDER is the TRUE active order (§8.5), read statically from the MO2 profile's loadorder.txt + modlist.txt +
-/// plugins.txt via <see cref="Mo2LoadOrder"/> — masters first → highest-priority winner last, the ~110 duplicate-name
+/// ORDER is the TRUE active order (Â§8.5), read statically from the MO2 profile's loadorder.txt + modlist.txt +
+/// plugins.txt via <see cref="Mo2LoadOrder"/> â€” masters first â†’ highest-priority winner last, the ~110 duplicate-name
 /// plugins resolved by mod priority. No USVFS, no live MO2 state (both failed in the legacy build); the server reads
 /// REAL plugin paths and runs standalone. Freshness is AUTONOMOUS + lazy: the cheap mtime sweep re-reads the profile on
-/// the NEXT tool call whenever the user's MO2 edits changed it — no restart, no manual refresh step. See memory
+/// the NEXT tool call whenever the user's MO2 edits changed it â€” no restart, no manual refresh step. See memory
 /// project_mo2_load_order_resolution.
 /// </summary>
 public sealed class LoadOrderService : IDisposable
 {
-    // INSTANCE mode (the product default): one configured path — the MO2 instance folder — from which ProfileDir/ModsDir/
+    // INSTANCE mode (the product default): one configured path â€” the MO2 instance folder â€” from which ProfileDir/ModsDir/
     // DataDir + the active profile are DERIVED (via Mo2Instance, reading ModOrganizer.ini), and a profile SWITCH is picked
     // up on the next tool call. EXPLICIT mode (dev / non-portable override): the three paths are configured directly and
-    // _instanceDir stays null (no ini watch). UNCONFIGURED: neither was set — the server still BOOTS; every tool returns the
+    // _instanceDir stays null (no ini watch). UNCONFIGURED: neither was set â€” the server still BOOTS; every tool returns the
     // trained prompt (so houseCARL asks the user for the path) until housecarl_set_mo2_instance is called.
     string? _instanceDir;                          // INSTANCE-mode source of truth; null in explicit/unconfigured mode
     string _dataDir;                               // DERIVED (instance mode) or configured (explicit); mutable for a live profile switch
     string _modsDir;
     string _profileDir;
     string _profileName;                           // the active profile (instance mode: from selected_profile)
-    string _overwriteDir = "";                     // MO2's overwrite layer (instance mode: derived; explicit mode: none) — hunt F9
-    bool _configured;                              // false ⇒ tools return the trained prompt instead of resolving
+    string _overwriteDir = "";                     // MO2's overwrite layer (instance mode: derived; explicit mode: none) â€” hunt F9
+    bool _configured;                              // false â‡’ tools return the trained prompt instead of resolving
     readonly UserConfigStore _store;               // the sole owner of houseCARL.user.json (MO2 instance dir + tool paths)
     readonly int _maxPlugins;
     readonly object _gate = new();
-    // Serializes the WHOLE resolve→stage→commit of every .esp write (2026-06-12 hunt F2): the MCP SDK dispatches tool
+    // Serializes the WHOLE resolveâ†’stageâ†’commit of every .esp write (2026-06-12 hunt F2): the MCP SDK dispatches tool
     // calls CONCURRENTLY, and without this two same-name writes could allocate the same folder (UniqueStem TOCTOU) and
-    // cross-commit through the fixed .housecarl-tmp staging path — R1's success message shipping R2's bytes. Writes are
+    // cross-commit through the fixed .housecarl-tmp staging path â€” R1's success message shipping R2's bytes. Writes are
     // seconds-long and rare; serializing them is correct (accuracy over perf). SetInstance takes it too, so an instance
     // switch can never tear a write in flight across instances. Lock order where both are held: _writeGate THEN _gate.
     readonly object _writeGate = new();
@@ -48,16 +48,16 @@ public sealed class LoadOrderService : IDisposable
     CorpusRulebook? _rulebook;
     IReadOnlyList<string> _orderWarnings = Array.Empty<string>();
     // facegen-diagnostics Phase 2: the VFS-aware asset resolver (housecarl_asset_status), built LAZILY and only on an
-    // ASSET query — a pure-record session never pays for it — and kept fresh the same way _resolver is. Dropped +
+    // ASSET query â€” a pure-record session never pays for it â€” and kept fresh the same way _resolver is. Dropped +
     // rebuilt whenever the active profile changes (InvalidateAssetResolver in ReResolve / SetInstance): an enabled-mod
     // toggle changes the loose roots and the active-archive set, not just the plugin order. CHEAP to build (it reads BSA
     // file-TABLES, not the ~10s/180MB record index), so a full rebuild on a profile change is fine. See memory
     // project_facegen_diagnostics_resolver.
     AssetResolver? _assetResolver;
-    IReadOnlyList<string> _assetWarnings = Array.Empty<string>();   // discovery warnings from the asset build (e.g. a Skyrim.ini we couldn't find → base BSAs unscanned)
+    IReadOnlyList<string> _assetWarnings = Array.Empty<string>();   // discovery warnings from the asset build (e.g. a Skyrim.ini we couldn't find â†’ base BSAs unscanned)
     // Freshness baselines are the files' LAST-SEEN MTIMES compared by VALUE (!=), the same model the resolver itself
-    // uses — NOT wall-clock stamps compared by ORDER (2026-06-12 hunt F8: `mtime > builtUtc` was blind to an mtime
-    // REGRESSION, so MO2's "Restore Backup" — which restores a profile file with an OLDER mtime — stayed invisible
+    // uses â€” NOT wall-clock stamps compared by ORDER (2026-06-12 hunt F8: `mtime > builtUtc` was blind to an mtime
+    // REGRESSION, so MO2's "Restore Backup" â€” which restores a profile file with an OLDER mtime â€” stayed invisible
     // for the process lifetime). Each baseline is statted BEFORE the read it baselines (TOCTOU: a write landing
     // during/after the read shows as a changed mtime on the next check, never absorbed).
     DateTime[] _profileMtimes = new DateTime[ProfileFileNames.Length];   // per ProfileFileNames, recorded at each order build
@@ -79,7 +79,7 @@ public sealed class LoadOrderService : IDisposable
     }
 
     /// <summary>INSTANCE mode (product default): derive the load-order roots + active profile from ONE MO2 instance folder
-    /// (lazily, on the first build). A null/blank <paramref name="instanceDir"/> ⇒ UNCONFIGURED (boots; tools prompt for the
+    /// (lazily, on the first build). A null/blank <paramref name="instanceDir"/> â‡’ UNCONFIGURED (boots; tools prompt for the
     /// path). The instance is re-read on a profile switch, so a mid-session switch is followed.</summary>
     public static LoadOrderService WithInstance(string? instanceDir, int maxPlugins, UserConfigStore store)
         => new(string.IsNullOrWhiteSpace(instanceDir) ? null : instanceDir.Trim(),
@@ -91,7 +91,7 @@ public sealed class LoadOrderService : IDisposable
         => new(null, dataDir, modsDir, profileDir, configured: true, maxPlugins, store);
 
     /// <summary>TEST SEAM (the harness' CI regression guards only): wrap a PREBUILT resolver so a guard can drive
-    /// the service-layer query logic (CrossQuery's scan loop) on synthetic plugins — no MO2 profile, no user config
+    /// the service-layer query logic (CrossQuery's scan loop) on synthetic plugins â€” no MO2 profile, no user config
     /// on disk. Explicit-mode freshness checks no-op (no ini, empty profile dir); the caller owns the resolver's
     /// lifetime. Never used by the product.</summary>
     internal static LoadOrderService ForGuard(LoadOrderResolver resolver, UserConfigStore store)
@@ -101,11 +101,11 @@ public sealed class LoadOrderService : IDisposable
         return svc;
     }
 
-    /// <summary>Non-fatal warnings from the last order build (Q3) — e.g. a plugin the load order lists that no enabled
+    /// <summary>Non-fatal warnings from the last order build (Q3) â€” e.g. a plugin the load order lists that no enabled
     /// mod provides (stale profile files). Surfaced, never swallowed. Empty until the resolver first builds.</summary>
     public IReadOnlyList<string> OrderWarnings => _orderWarnings;
 
-    /// <summary>The write pre-flight rulebook (corpus.json), loaded once. CorpusPath is set absolute at startup (§8.4),
+    /// <summary>The write pre-flight rulebook (corpus.json), loaded once. CorpusPath is set absolute at startup (Â§8.4),
     /// so this resolves regardless of the MO2-launched process's CWD.</summary>
     CorpusRulebook Rulebook => _rulebook ??= CorpusRulebook.Load();
 
@@ -117,12 +117,12 @@ public sealed class LoadOrderService : IDisposable
         {
             lock (_gate)
             {
-                if (!_configured) throw NotConfigured();          // fresh install / empty config → every tool prompts for the MO2 path
+                if (!_configured) throw NotConfigured();          // fresh install / empty config â†’ every tool prompts for the MO2 path
                 if (_resolver is null)
                 {
                     EnsurePathsDerived();                         // instance mode: derive ProfileDir/ModsDir/DataDir + active profile from ModOrganizer.ini
-                    // §8.5: the TRUE active order, read statically from the MO2 profile (loadorder.txt + modlist.txt +
-                    // plugins.txt) — no VFS, no live MO2 state. See HousecarlCore.Mo2LoadOrder + memory
+                    // Â§8.5: the TRUE active order, read statically from the MO2 profile (loadorder.txt + modlist.txt +
+                    // plugins.txt) â€” no VFS, no live MO2 state. See HousecarlCore.Mo2LoadOrder + memory
                     // project_mo2_load_order_resolution.
                     var profileMtimes = StatProfileFiles();      // stat BEFORE the read (TOCTOU): a profile write during the build is caught next call, not missed
                     var order = Mo2LoadOrder.Build(_profileDir, _modsDir, _dataDir, _overwriteDir);
@@ -140,15 +140,15 @@ public sealed class LoadOrderService : IDisposable
                 }
                 else if (Monitor.TryEnter(_writeGate))
                 {
-                    // Lazy freshness, run on each tool call once the snapshot exists — but DEFERRED while a WRITE is
-                    // in flight (PR #51 review note): a refresh here can rebuild the index — transiently mmap-opening
+                    // Lazy freshness, run on each tool call once the snapshot exists â€” but DEFERRED while a WRITE is
+                    // in flight (PR #51 review note): a refresh here can rebuild the index â€” transiently mmap-opening
                     // every plugin INCLUDING the file a concurrent write is serializing (the PR #24 "no mapped handle
-                    // on the target survives the serialize" invariant, breached from the read path) — and dispose-swap
+                    // on the target survives the serialize" invariant, breached from the read path) â€” and dispose-swap
                     // the resolver that write captured. TryEnter probes the write gate WITHOUT blocking: it cannot
-                    // deadlock (no blocking _gate→_writeGate wait — the established blocking order stays _writeGate
+                    // deadlock (no blocking _gateâ†’_writeGate wait â€” the established blocking order stays _writeGate
                     // THEN _gate), and Monitor reentrancy keeps the write's OWN entry refresh working (it holds
                     // _writeGate, so its TryEnter succeeds). A skipped refresh serves the last good snapshot and
-                    // re-checks on the next call — the freshness contract is per-call lazy, so deferral behind a
+                    // re-checks on the next call â€” the freshness contract is per-call lazy, so deferral behind a
                     // seconds-long write is honest staleness, never wrongness (freshness-capture-guard arm 5).
                     try
                     {
@@ -164,11 +164,11 @@ public sealed class LoadOrderService : IDisposable
 
     // ---- facegen-diagnostics Phase 2: VFS asset resolution (housecarl_asset_status) ----------------------
 
-    /// <summary>The VFS-aware asset resolver, built on first ASSET query and kept fresh on every subsequent one — the
+    /// <summary>The VFS-aware asset resolver, built on first ASSET query and kept fresh on every subsequent one â€” the
     /// asset twin of <see cref="Resolver"/>. Runs the SAME profile-freshness driver (a switch / toggle / re-sort drops it
-    /// via <see cref="ReResolve"/> → <see cref="InvalidateAssetResolver"/>, so it rebuilds against the new profile), then
+    /// via <see cref="ReResolve"/> â†’ <see cref="InvalidateAssetResolver"/>, so it rebuilds against the new profile), then
     /// its own cheap BSA-byte / warmed-loose-subtree content sweep. Crucially it does NOT force the heavy
-    /// <see cref="Resolver"/> build — an asset-only query stays cheap (the freshness driver is null-safe for _resolver).
+    /// <see cref="Resolver"/> build â€” an asset-only query stays cheap (the freshness driver is null-safe for _resolver).
     /// The getter takes <see cref="_gate"/> (reentrant), so callers need not pre-hold it.</summary>
     AssetResolver Assets
     {
@@ -176,9 +176,9 @@ public sealed class LoadOrderService : IDisposable
         {
             lock (_gate)
             {
-                if (!_configured) throw NotConfigured();           // fresh install → the tool returns the trained prompt instead
+                if (!_configured) throw NotConfigured();           // fresh install â†’ the tool returns the trained prompt instead
                 EnsurePathsDerived();                              // derive the roots on first use (instance mode)
-                // Profile freshness (switch / toggle / re-sort) — shared with the record path, deferred behind an in-flight
+                // Profile freshness (switch / toggle / re-sort) â€” shared with the record path, deferred behind an in-flight
                 // write like the record refresh. ReResolve is null-safe for _resolver, so this FOLLOWS a profile change
                 // WITHOUT building the record index, and drops _assetResolver when the active set changed.
                 if (Monitor.TryEnter(_writeGate))
@@ -201,19 +201,19 @@ public sealed class LoadOrderService : IDisposable
     }
 
     /// <summary>Build the asset resolver from the current roots: discover the active BSAs (co-name + Skyrim.ini base
-    /// archives, VFS-resolved + ranked — <see cref="ArchiveDiscovery"/>) and read the enabled-mod priority list, both
+    /// archives, VFS-resolved + ranked â€” <see cref="ArchiveDiscovery"/>) and read the enabled-mod priority list, both
     /// from the same cheap static profile read the record path uses. The gamePath (for the game-dir Skyrim.ini fallback)
     /// is DataDir's parent (DataDir = gamePath\Data). Caller holds <see cref="_gate"/>.</summary>
     AssetResolver BuildAssetResolverLocked()
     {
-        var comp = Mo2LoadOrder.ReadComposition(_profileDir);                       // EnabledMods (priority) — cheap text parse
+        var comp = Mo2LoadOrder.ReadComposition(_profileDir);                       // EnabledMods (priority) â€” cheap text parse
         var gamePath = _dataDir.Length > 0 ? Path.GetDirectoryName(_dataDir.TrimEnd('\\', '/')) ?? "" : "";
         var discovery = ArchiveDiscovery.Discover(_profileDir, _modsDir, _dataDir, _overwriteDir, gamePath);
         _assetWarnings = discovery.Warnings;
         return AssetResolver.Build(_overwriteDir, _modsDir, _dataDir, comp.EnabledMods, discovery.Archives);
     }
 
-    /// <summary>Drop the asset resolver so the next asset query rebuilds it — the active-mod/archive SET changed
+    /// <summary>Drop the asset resolver so the next asset query rebuilds it â€” the active-mod/archive SET changed
     /// (AssetResolver.RefreshIfStale only catches a BSA's bytes / a warmed subtree, not a membership change). No-op when
     /// none is built (a pure-record session never pays for the asset resolver). Caller holds <see cref="_gate"/>.</summary>
     void InvalidateAssetResolver() { _assetResolver?.Dispose(); _assetResolver = null; }
@@ -233,7 +233,7 @@ public sealed class LoadOrderService : IDisposable
             {
                 var p = (raw ?? "").Trim();
                 try { results.Add(new AssetPathResult(p, view.Resolve(p), null)); }
-                catch (ArgumentException ex) { results.Add(new AssetPathResult(p, null, ex.Message)); }   // bad path → per-path Q3 note
+                catch (ArgumentException ex) { results.Add(new AssetPathResult(p, null, ex.Message)); }   // bad path â†’ per-path Q3 note
             }
             return new AssetStatusData(results, view.BsaFailures, view.ReadIncomplete, _assetWarnings, _profileName);
         }
@@ -243,19 +243,19 @@ public sealed class LoadOrderService : IDisposable
     //      each plugin DLL's STATICALLY declared manifest (tier C). Read-only; reuses the asset VFS + the PE reader. ----
 
     /// <summary>Inventory the SKSE-plugin layer as the ACTIVE load order resolves it (housecarl_skse_inventory): the FULL
-    /// DEPTH of Data\SKSE\Plugins — every <c>.dll</c> plugin and every <c>.ini</c>/<c>.toml</c>/<c>.json</c>/<c>.yaml</c>
-    /// config at any depth — with the mod that WINS the VFS for each (tier A), and for every plugin DLL the statically-
-    /// declared manifest — name/author/version, Address Library vs version-LOCKED, target runtimes, XSE floor — via
+    /// DEPTH of Data\SKSE\Plugins â€” every <c>.dll</c> plugin and every <c>.ini</c>/<c>.toml</c>/<c>.json</c>/<c>.yaml</c>
+    /// config at any depth â€” with the mod that WINS the VFS for each (tier A), and for every plugin DLL the statically-
+    /// declared manifest â€” name/author/version, Address Library vs version-LOCKED, target runtimes, XSE floor â€” via
     /// <see cref="SksePluginReader"/> (tier C). Tier E (DLL behavior) stays out of reach by design. FULL VISIBILITY, by
-    /// construction: every file is accounted for — configs carry their derived subfolder <see cref="SkseFileEntry.Group"/>
-    /// (the immediate folder under SKSE\Plugins — SkyPatcher / DynamicStringDistributor / OStim / …, WHATEVER the modlist
+    /// construction: every file is accounted for â€” configs carry their derived subfolder <see cref="SkseFileEntry.Group"/>
+    /// (the immediate folder under SKSE\Plugins â€” SkyPatcher / DynamicStringDistributor / OStim / â€¦, WHATEVER the modlist
     /// ships, never a hardcoded set) so the renderer can group them compactly, and non-config content (animation data etc.)
     /// is counted in <see cref="SkseInventoryData.OtherFileCount"/>, never silently dropped. DLLs keep their SKSE-loader
     /// truth: a subfolder DLL is SEEN but flagged (SKSE scans Data\SKSE\Plugins*.dll top-level only, so it isn't loaded as a
     /// plugin). ONE asset capture pins the whole scan (list + <see cref="AssetView.ReadIncomplete"/> caveat = one build); the
     /// enumerate + resolve + PE reads run OUTSIDE the gate (the captured view is a handle-free immutable snapshot), so an
     /// inventory never serializes other tool calls behind its file I/O. Distributor INIs (SPID <c>*_DISTR</c>, KID
-    /// <c>*_KID</c>) live in Data\ ROOT, not here, and are owned by their authoring skills — out of this scope by design.</summary>
+    /// <c>*_KID</c>) live in Data\ ROOT, not here, and are owned by their authoring skills â€” out of this scope by design.</summary>
     public SkseInventoryData SkseInventory()
     {
         AssetResolver.AssetView view;
@@ -279,7 +279,7 @@ public sealed class LoadOrderService : IDisposable
             var ext = Path.GetExtension(rel).ToLowerInvariant();
             bool isDll = ext is ".dll";
             bool isConfig = ext is ".ini" or ".toml" or ".json" or ".yaml" or ".yml";
-            if (!isDll && !isConfig) { otherFiles++; continue; }  // content/other (.hkx/.txt/.pdb/…) — ACCOUNTED FOR, not listed
+            if (!isDll && !isConfig) { otherFiles++; continue; }  // content/other (.hkx/.txt/.pdb/â€¦) â€” ACCOUNTED FOR, not listed
 
             string group = SkseGroupOf(rel, pre);                 // "" = top-level; else the immediate subfolder (the derived group key)
             var place = view.ResolveForPlacement(rel);
@@ -296,9 +296,9 @@ public sealed class LoadOrderService : IDisposable
                 if (winner is { Kind: AssetKind.Loose, LooseFilePath: { } path })
                     info = SksePluginReader.Read(path);           // the winning loose copy
                 else if (winner is null) note = "no active mod provides this DLL";
-                else note = "provided ONLY inside a BSA — the SKSE loader scans loose Data\\SKSE\\Plugins only, so this DLL will not load";
+                else note = "provided ONLY inside a BSA â€” the SKSE loader scans loose Data\\SKSE\\Plugins only, so this DLL will not load";
                 if (group.Length > 0 && note is null)
-                    note = $"in subfolder '{group}' — NOT on SKSE's loader path (scans SKSE\\Plugins\\*.dll top-level only); a bundled/parent-loaded DLL, not a plugin SKSE loads";
+                    note = $"in subfolder '{group}' â€” NOT on SKSE's loader path (scans SKSE\\Plugins\\*.dll top-level only); a bundled/parent-loaded DLL, not a plugin SKSE loads";
                 dlls.Add(new SkseFileEntry(rel, Path.GetFileName(rel), group, providers, info, note));
             }
             else
@@ -307,10 +307,10 @@ public sealed class LoadOrderService : IDisposable
         return new SkseInventoryData(dlls, configs, otherFiles, view.BsaFailures, view.ReadIncomplete, warnings, profileName);
     }
 
-    /// <summary>The immediate subfolder under SKSE\Plugins a file sits in ("" = directly at top level) — the DERIVED,
+    /// <summary>The immediate subfolder under SKSE\Plugins a file sits in ("" = directly at top level) â€” the DERIVED,
     /// by-construction grouping key for the SKSE inventory. Whatever a modlist ships becomes a group; there is NO hardcoded
     /// framework list (a hand-maintained list would be a cornerstone violation + a Q3 silent-miscategorize for any framework
-    /// not on it). e.g. <c>SKSE\Plugins\SkyPatcher\Weapons\x.ini</c> → "SkyPatcher"; <c>SKSE\Plugins\EngineFixes.toml</c> → "".</summary>
+    /// not on it). e.g. <c>SKSE\Plugins\SkyPatcher\Weapons\x.ini</c> â†’ "SkyPatcher"; <c>SKSE\Plugins\EngineFixes.toml</c> â†’ "".</summary>
     static string SkseGroupOf(string rel, string pre)
     {
         if (!rel.StartsWith(pre, StringComparison.OrdinalIgnoreCase)) return "";
@@ -322,12 +322,12 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>Place one-or-more assets (FaceGen .nif/.dds, or any Data-relative file) into a NEW houseCARL-owned MO2 mod
     /// folder so the CORRECT copy can win the VFS (housecarl_place_asset = one; housecarl_bulk_place_asset = many). For
-    /// each request: resolve its current providers (auto-resolve a source when none was named — sole provider used, &gt;1
+    /// each request: resolve its current providers (auto-resolve a source when none was named â€” sole provider used, &gt;1
     /// refused as ambiguous, 0 refused with guidance), read the source bytes IN PROCESS (a loose file, or a single entry
     /// out of a BSA via native Mutagen), and write them CRASH-ATOMICALLY (<see cref="AtomicFile.WriteAllBytes"/>) under the
     /// owned folder. Originals untouched (we only ever write a fresh / houseCARL-owned folder). NON-DESTRUCTIVE on failure:
     /// a fresh folder that ended up with NOTHING placed is removed (no orphan); a partial one is kept + named. Q3 honesty:
-    /// "wrote it" ≠ "it wins" — the fresh mod must be ENABLED + SORTED above the current winner, which the render reports;
+    /// "wrote it" â‰  "it wins" â€” the fresh mod must be ENABLED + SORTED above the current winner, which the render reports;
     /// this never claims the fix took effect on write. Serialized on the write gate (one placement batch at a time).</summary>
     public PlaceOutcome PlaceAssets(IReadOnlyList<PlaceRequest> requests, string? patchName, string? into)
     {
@@ -336,7 +336,7 @@ public sealed class LoadOrderService : IDisposable
         lock (_writeGate)                                                 // hunt F2 sibling: one placement batch at a time, resolve->stage->commit
         {
             // PRECONDITION: _writeGate is held for the WHOLE method. ResolvePatchModFolder and the `Assets` getter each
-            // take-and-release _gate, so this method straddles two _gate sections — safe ONLY because _writeGate excludes
+            // take-and-release _gate, so this method straddles two _gate sections â€” safe ONLY because _writeGate excludes
             // every other writer and instance-switch throughout, so no profile refresh can land between them. Do not call
             // PlaceOne/Assets here outside this _writeGate hold.
             RiderFolder rf;
@@ -348,7 +348,7 @@ public sealed class LoadOrderService : IDisposable
             try { lock (_gate) { resolver = Assets; warnings = _assetWarnings; } }
             catch (Exception ex)
             {
-                var residue = RemoveOrNameRiderResidue(rf);              // nothing placed yet → a fresh folder is an orphan
+                var residue = RemoveOrNameRiderResidue(rf);              // nothing placed yet â†’ a fresh folder is an orphan
                 return PlaceOutcome.Fail($"could not resolve the asset layer (the MO2 instance may not be readable): {ex.Message}"
                     + (residue is null ? "" : $" The freshly created mod folder was left at '{residue}'."));
             }
@@ -362,7 +362,7 @@ public sealed class LoadOrderService : IDisposable
                 if (r.Placed) placed++;
             }
 
-            // Nothing placed into a FRESH folder → remove the orphan (the .esp F4 / rider H2 principle). A reused into=
+            // Nothing placed into a FRESH folder â†’ remove the orphan (the .esp F4 / rider H2 principle). A reused into=
             // folder (the user owns it) is never touched. A partial fresh folder is kept and its path surfaced.
             string? leftover = placed == 0 ? RemoveOrNameRiderResidue(rf) : null;
             return new PlaceOutcome(results, placed > 0 ? rf.ModFolder : null, warnings, leftover, null);
@@ -371,7 +371,7 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>Place ONE asset: validate the destination rel-path (reject drive-rooted/'..' through the resolver's own
     /// gate, Q3), get the source bytes (explicit source= or auto-resolve), and write them crash-atomically under
-    /// <paramref name="outDir"/>. Reports the CURRENT VFS winner so the caller knows what to sort the fresh mod above —
+    /// <paramref name="outDir"/>. Reports the CURRENT VFS winner so the caller knows what to sort the fresh mod above â€”
     /// the placed file does NOT win until the mod is enabled + sorted (the fresh folder isn't in the active profile yet).
     /// A per-asset failure is a recoverable named error, never a thrown batch abort.</summary>
     PlaceResult PlaceOne(PlaceRequest req, AssetResolver resolver, string outDir)
@@ -380,7 +380,7 @@ public sealed class LoadOrderService : IDisposable
         try { rel = AssetResolver.ValidateRelPath(req.AssetPath); }
         catch (ArgumentException ex) { return PlaceResult.Fail(req.AssetPath, ex.Message); }
 
-        var res = resolver.ResolveForPlacement(rel);                     // rel already validated — won't throw
+        var res = resolver.ResolveForPlacement(rel);                     // rel already validated â€” won't throw
         var winner = res.Sources.Count > 0 ? DescribeSource(res.Sources[0]) : null;
 
         // ---- source bytes: explicit source= wins; else auto-resolve the sole provider ----
@@ -402,7 +402,7 @@ public sealed class LoadOrderService : IDisposable
                     winner);
             if (res.Ambiguous)
                 return PlaceResult.Fail(rel,
-                    $"{res.Sources.Count} sources provide '{rel}' — ambiguous, so place_asset will not guess which copy is correct (the skill decides). "
+                    $"{res.Sources.Count} sources provide '{rel}' â€” ambiguous, so place_asset will not guess which copy is correct (the skill decides). "
                     + $"Pass source= one of: {string.Join("; ", res.Sources.Select(SourceHint))}.",
                     winner);
             var (b, desc, err) = ReadResolvedSource(res.Sources[0]);
@@ -419,19 +419,19 @@ public sealed class LoadOrderService : IDisposable
         }
         catch (Exception ex) { return PlaceResult.Fail(rel, $"could not write '{rel}' into the patch folder: {ex.Message}", winner); }
 
-        // ---- integrity (Q3: THIS run wrote it; the on-disk size matches the source bytes — no false success) ----
-        // Belt-and-braces truncation / short-write detection — NOT a content hash (the bytes are in-memory and the swap is
+        // ---- integrity (Q3: THIS run wrote it; the on-disk size matches the source bytes â€” no false success) ----
+        // Belt-and-braces truncation / short-write detection â€” NOT a content hash (the bytes are in-memory and the swap is
         // atomic, so a same-length corruption isn't a reachable failure of this path; a size mismatch would mean the OS
         // wrote fewer bytes than handed). Defensive, not the primary guarantee (that's AtomicFile's crash-atomic swap).
         long size; try { size = new FileInfo(dest).Length; } catch { size = -1; }
         if (size != bytes.Length)
             return PlaceResult.Fail(rel,
-                $"wrote '{rel}' but its on-disk size ({size}) does not match the {bytes.Length} source byte(s) — verify before relying on it.", winner);
+                $"wrote '{rel}' but its on-disk size ({size}) does not match the {bytes.Length} source byte(s) â€” verify before relying on it.", winner);
         return new PlaceResult(rel, true, bytes.Length, sourceDesc, winner, null);
     }
 
     /// <summary>Read an EXPLICIT source= the caller named. Forms: "&lt;archive.bsa&gt;|&lt;entry&gt;" (a specific BSA
-    /// entry, split on the FIRST '|'); a path ending ".bsa" (the entry is the destination rel-path — the FaceGen case,
+    /// entry, split on the FIRST '|'); a path ending ".bsa" (the entry is the destination rel-path â€” the FaceGen case,
     /// where the entry inside the BSA IS the Data-relative path); any other path (a loose file on disk). Returns the bytes
     /// + a human description, or a NAMED error (Q3) for a missing file / missing entry / unreadable archive.</summary>
     static (byte[]? bytes, string? desc, string? error) ReadExplicitSource(string source, string destRel)
@@ -442,10 +442,10 @@ public sealed class LoadOrderService : IDisposable
             return ReadBsaEntry(source[..bar].Trim().Trim('"'), source[(bar + 1)..].Trim().Trim('"'));
         // Strip surrounding quotes BEFORE the .bsa-vs-loose routing decision (NOT inside each branch): a quoted ".bsa"
         // path ends in '"' not ".bsa", so routing on the raw string would read the WHOLE archive as a loose file and
-        // place it as the asset — a silent-wrong placement that passes the size check (Q3). The ONE trim point.
+        // place it as the asset â€” a silent-wrong placement that passes the size check (Q3). The ONE trim point.
         source = source.Trim('"');
         if (source.EndsWith(".bsa", StringComparison.OrdinalIgnoreCase))
-            return ReadBsaEntry(source, destRel);                        // .bsa with no explicit entry → entry := the destination path
+            return ReadBsaEntry(source, destRel);                        // .bsa with no explicit entry â†’ entry := the destination path
         string path;
         try { path = Path.GetFullPath(source); }
         catch (Exception ex) { return (null, null, $"source '{source}' is not a usable path: {ex.Message}"); }
@@ -469,7 +469,7 @@ public sealed class LoadOrderService : IDisposable
         return ReadBsaEntry(s.ArchivePath!, s.EntryPath);
     }
 
-    /// <summary>Read one entry out of a BSA (native Mutagen, no BSArch, zero handles at rest — see
+    /// <summary>Read one entry out of a BSA (native Mutagen, no BSArch, zero handles at rest â€” see
     /// <see cref="AssetResolver.TryReadArchiveEntry"/>). Named errors (Q3) for a missing archive, an entry not inside it,
     /// or an unreadable archive.</summary>
     static (byte[]? bytes, string? desc, string? error) ReadBsaEntry(string archive, string entry)
@@ -505,14 +505,14 @@ public sealed class LoadOrderService : IDisposable
     }
 
     /// <summary>Diagnostic snapshot for housecarl_load_order_status: the CURRENT enabled/disabled composition (read fresh
-    /// from the profile text files — cheap, no folder walk, so a just-toggled mod/plugin shows immediately), plus the
+    /// from the profile text files â€” cheap, no folder walk, so a just-toggled mod/plugin shows immediately), plus the
     /// resolver's resolved-plugin count + Q3 warnings from its last build, plus a staleness flag if the profile files
-    /// changed since that build (Q3 — never present a stale picture as current). Forces the lazy resolver build.</summary>
+    /// changed since that build (Q3 â€” never present a stale picture as current). Forces the lazy resolver build.</summary>
     public LoadOrderStatusData StatusData()
     {
         // The view AND the per-build fields beside it (warnings / staleness / profile dir) are snapshotted under ONE
         // gate hold (2026-06-12 hunt F6): they used to be read outside the gate after Capture() returned, so a
-        // concurrent freshness rebuild landing in that gap could compose one status line from TWO adjacent builds —
+        // concurrent freshness rebuild landing in that gap could compose one status line from TWO adjacent builds â€”
         // the count from one, the warnings beside it from another. The fresh composition stays OUTSIDE the gate by
         // design (it is documented as always-current and is not judged against the resolver's build).
         LoadOrderResolver.IndexView view; IReadOnlyList<string> warnings; bool profileChanged; string profileDir; string profileName; string? instanceDir;
@@ -522,8 +522,8 @@ public sealed class LoadOrderService : IDisposable
             warnings = _orderWarnings;
             profileChanged = ProfileFilesChanged();
             profileDir = _profileDir;
-            profileName = _profileName;                            // captured under the SAME gate (hunt F6) — one snapshot, never re-derived at render
-            instanceDir = _instanceDir;                            // the configured MO2 instance folder; null ⇒ explicit-paths / unconfigured mode
+            profileName = _profileName;                            // captured under the SAME gate (hunt F6) â€” one snapshot, never re-derived at render
+            instanceDir = _instanceDir;                            // the configured MO2 instance folder; null â‡’ explicit-paths / unconfigured mode
         }
         var comp = Mo2LoadOrder.ReadComposition(profileDir);       // FRESH composition (always current)
         return new LoadOrderStatusData(
@@ -531,49 +531,49 @@ public sealed class LoadOrderService : IDisposable
     }
 
     /// <summary>Inspect a NAMED profile's enabled/disabled composition WITHOUT switching to it (9.2: "can't inspect an
-    /// inactive profile") — INSTANCE MODE ONLY. The profiles root is the PARENT of the active profile's dir, so MO2's
+    /// inactive profile") â€” INSTANCE MODE ONLY. The profiles root is the PARENT of the active profile's dir, so MO2's
     /// base_directory redirect is honored by construction (the active ProfileDir already incorporates it) and a stale
-    /// active-profile dir doesn't matter — every profile is a sibling folder there. Reads with the cheap text-only
+    /// active-profile dir doesn't matter â€” every profile is a sibling folder there. Reads with the cheap text-only
     /// <see cref="Mo2LoadOrder.ReadComposition"/>, NOT <see cref="Mo2LoadOrder.Build"/> (Build walks every enabled mod
-    /// folder — thousands of dir enumerations) — so inspecting an inactive profile never builds the record index and never
+    /// folder â€” thousands of dir enumerations) â€” so inspecting an inactive profile never builds the record index and never
     /// changes the active profile. EXPLICIT-paths mode has no profiles root (the dir is configured arbitrarily), so a named
     /// read REFUSES LOUD there rather than enumerate a non-profiles folder. A <paramref name="requested"/> name matching no
-    /// profile is reported with the available names (Q3 — never a silently-empty composition); a null/blank name returns
+    /// profile is reported with the available names (Q3 â€” never a silently-empty composition); a null/blank name returns
     /// just the available list (the discovery affordance on the default status). Case-insensitive name match.</summary>
     public NamedProfileResult NamedProfileComposition(string? requested)
     {
         string? instanceDir; string profilesRoot;
         lock (_gate)
         {
-            if (!_configured) throw NotConfigured();              // fresh install → the tool returns the trained prompt
+            if (!_configured) throw NotConfigured();              // fresh install â†’ the tool returns the trained prompt
             EnsurePathsDerived();                                 // instance mode: derive the ACTIVE ProfileDir (cheap ini read; throws Q3 if the instance is unusable)
             instanceDir = _instanceDir;
             profilesRoot = instanceDir is null ? "" : (Path.GetDirectoryName(_profileDir.TrimEnd('\\', '/')) ?? "");
         }
 
         var name = string.IsNullOrWhiteSpace(requested) ? null : requested.Trim();
-        if (instanceDir is null)                                  // explicit-paths mode — no profiles root (refuse loud; the tool renders the named-mode-only message)
+        if (instanceDir is null)                                  // explicit-paths mode â€” no profiles root (refuse loud; the tool renders the named-mode-only message)
             return new NamedProfileResult(InstanceMode: false, AvailableProfiles: Array.Empty<string>(), RequestedName: name, ResolvedProfileDir: null, Composition: null, Warnings: Array.Empty<string>());
 
-        var available = ListProfiles(profilesRoot);              // directory listing OUTSIDE the gate (like StatusData's ReadComposition) — no lock held over I/O
-        if (name is null)                                        // no name → the discovery list only (default-status affordance)
+        var available = ListProfiles(profilesRoot);              // directory listing OUTSIDE the gate (like StatusData's ReadComposition) â€” no lock held over I/O
+        if (name is null)                                        // no name â†’ the discovery list only (default-status affordance)
             return new NamedProfileResult(true, available, null, null, null, Array.Empty<string>());
 
         var match = available.FirstOrDefault(p => string.Equals(p, name, StringComparison.OrdinalIgnoreCase));
-        if (match is null)                                       // named profile not found → Q3: report it WITH the available names, never an empty composition
+        if (match is null)                                       // named profile not found â†’ Q3: report it WITH the available names, never an empty composition
             return new NamedProfileResult(true, available, name, null, null, Array.Empty<string>());
 
         var dir = Path.Combine(profilesRoot, match);
-        var warnings = new List<string>();                       // surface read notes (e.g. a missing modlist.txt) — so a 0-mods inspected profile isn't silently mistaken for empty (Q3)
-        var comp = Mo2LoadOrder.ReadComposition(dir, warnings);  // cheap text parse of THAT profile's loadorder/modlist/plugins — no index build, no switch
+        var warnings = new List<string>();                       // surface read notes (e.g. a missing modlist.txt) â€” so a 0-mods inspected profile isn't silently mistaken for empty (Q3)
+        var comp = Mo2LoadOrder.ReadComposition(dir, warnings);  // cheap text parse of THAT profile's loadorder/modlist/plugins â€” no index build, no switch
         return new NamedProfileResult(true, available, match, dir, comp, warnings);
     }
 
-    /// <summary>The USABLE profile names under <paramref name="profilesRoot"/> — each MO2 profile is one subfolder, and a
+    /// <summary>The USABLE profile names under <paramref name="profilesRoot"/> â€” each MO2 profile is one subfolder, and a
     /// profile that's been opened at least once has a loadorder.txt (the same validity signal <see cref="Mo2Instance"/> uses
-    /// for the ACTIVE profile). Folders WITHOUT one — a never-opened profile, or a stray non-profile dir — are skipped, so
+    /// for the ACTIVE profile). Folders WITHOUT one â€” a never-opened profile, or a stray non-profile dir â€” are skipped, so
     /// the list never OFFERS (and a name match never LANDS ON) a folder that would read back as an all-zero composition
-    /// (Q3: don't present an uninitialized folder as an empty profile). Sorted case-insensitively. Never throws — an
+    /// (Q3: don't present an uninitialized folder as an empty profile). Sorted case-insensitively. Never throws â€” an
     /// unreadable/absent root yields an empty list, so the caller surfaces "no profiles" honestly rather than failing the
     /// whole status read.</summary>
     static IReadOnlyList<string> ListProfiles(string profilesRoot)
@@ -582,28 +582,28 @@ public sealed class LoadOrderService : IDisposable
         try
         {
             return Directory.EnumerateDirectories(profilesRoot)
-                .Where(d => File.Exists(Path.Combine(d, "loadorder.txt")))   // an opened MO2 profile has loadorder.txt — skip stray/never-opened folders (Q3, accuracy over the per-folder stat)
+                .Where(d => File.Exists(Path.Combine(d, "loadorder.txt")))   // an opened MO2 profile has loadorder.txt â€” skip stray/never-opened folders (Q3, accuracy over the per-folder stat)
                 .Select(d => Path.GetFileName(d.TrimEnd('\\', '/')))
                 .Where(n => !string.IsNullOrEmpty(n))
                 .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
                 .ToList();
         }
-        catch { return Array.Empty<string>(); }                  // root vanished / access denied — empty, not a thrown status read
+        catch { return Array.Empty<string>(); }                  // root vanished / access denied â€” empty, not a thrown status read
     }
 
-    /// <summary>True if any of the three MO2 profile files' mtimes DIFFERS from the last build's baseline — the user
+    /// <summary>True if any of the three MO2 profile files' mtimes DIFFERS from the last build's baseline â€” the user
     /// toggled mods/plugins, re-sorted, or RESTORED A BACKUP since, so the resolver's resolved set is behind the live
     /// profile. Compared by value (!=), like the resolver's own plugin sweep: a restored backup carries an OLDER
     /// mtime, which an is-newer comparison was blind to (hunt F8). Caller holds <see cref="_gate"/>.</summary>
     bool ProfileFilesChanged()
     {
-        if (_profileDir.Length == 0) return false;                 // guard seam / not yet derived — nothing to compare against
+        if (_profileDir.Length == 0) return false;                 // guard seam / not yet derived â€” nothing to compare against
         for (int i = 0; i < ProfileFileNames.Length; i++)
             if (SafeMtime(Path.Combine(_profileDir, ProfileFileNames[i])) != _profileMtimes[i]) return true;
         return false;
     }
 
-    /// <summary>The three profile files' current mtimes, in <see cref="ProfileFileNames"/> order — the freshness
+    /// <summary>The three profile files' current mtimes, in <see cref="ProfileFileNames"/> order â€” the freshness
     /// baseline a build records. Stat BEFORE the read it baselines (TOCTOU). Caller holds <see cref="_gate"/>.</summary>
     DateTime[] StatProfileFiles()
     {
@@ -617,40 +617,40 @@ public sealed class LoadOrderService : IDisposable
         try { return File.GetLastWriteTimeUtc(path); } catch { return DateTime.MinValue; }
     }
 
-    /// <summary>To-do #6 — LAZY freshness, run on each tool call once the snapshot exists. Two signals, both cheap-mtime:
-    /// (1) instance mode — did the user SWITCH PROFILES (ModOrganizer.ini changed)? then re-derive the roots + re-resolve
+    /// <summary>To-do #6 â€” LAZY freshness, run on each tool call once the snapshot exists. Two signals, both cheap-mtime:
+    /// (1) instance mode â€” did the user SWITCH PROFILES (ModOrganizer.ini changed)? then re-derive the roots + re-resolve
     /// against the new profile (<see cref="RederiveIfIniChanged"/>). (2) did the ACTIVE profile's files change (a toggle /
-    /// re-sort)? then CHEAPLY re-resolve, paying the ~12s deep re-index ONLY when the resolved order actually changed — so a
+    /// re-sort)? then CHEAPLY re-resolve, paying the ~12s deep re-index ONLY when the resolved order actually changed â€” so a
     /// no-plugin toggle, or a change that nets back to the same order, costs ~nothing. NEVER fires BETWEEN tool calls (no
     /// watcher / no loop), so an actively-sorting/switching user can't make the server thrash. Caller holds <see cref="_gate"/>;
     /// <see cref="_resolver"/> is non-null.</summary>
     void RefreshOnProfileChange()
     {
         if (RederiveIfIniChanged()) return;                      // instance mode: a profile SWITCH already re-derived + re-resolved
-        if (!ProfileFilesChanged()) return;                      // nothing touched the active profile → nothing to do
+        if (!ProfileFilesChanged()) return;                      // nothing touched the active profile â†’ nothing to do
         ReResolve();
     }
 
     /// <summary>Instance mode only: if ModOrganizer.ini changed since we last read it AND the user switched profiles (or
     /// moved the game path), re-derive ProfileDir/ModsDir/DataDir + the active profile and re-resolve against the new
-    /// profile. This is how a mid-session profile switch is followed — lazily, on the NEXT tool call, by the SAME cheap-mtime
+    /// profile. This is how a mid-session profile switch is followed â€” lazily, on the NEXT tool call, by the SAME cheap-mtime
     /// model as the per-profile-file check. Returns true iff it handled a switch (caller then skips the per-file check).
     /// Tolerates a transient/invalid read (MO2 mid-write): keeps the last good set and retries next call. Caller holds the gate.</summary>
     bool RederiveIfIniChanged()
     {
-        if (_instanceDir is null) return false;                  // explicit/override mode — no ini to watch
+        if (_instanceDir is null) return false;                  // explicit/override mode â€” no ini to watch
         var ini = Mo2Instance.IniPath(_instanceDir);
-        if (!File.Exists(ini)) return false;                     // missing/mid-replace → keep last good, retry next call
+        if (!File.Exists(ini)) return false;                     // missing/mid-replace â†’ keep last good, retry next call
         var iniMtime = SafeMtime(ini);                           // stat BEFORE the read (TOCTOU): an ini write during/after TryResolve is caught next call
-        if (iniMtime == _iniMtime) return false;                 // compared by VALUE — a restored-backup ini (OLDER mtime) is a change too (hunt F8)
-        if (!Mo2Instance.TryResolve(_instanceDir, out var p) || p is null) return false;   // mid-write/invalid → keep last good, retry next call
+        if (iniMtime == _iniMtime) return false;                 // compared by VALUE â€” a restored-backup ini (OLDER mtime) is a change too (hunt F8)
+        if (!Mo2Instance.TryResolve(_instanceDir, out var p) || p is null) return false;   // mid-write/invalid â†’ keep last good, retry next call
         _iniMtime = iniMtime;                                    // advance only on a clean read
         bool switched = !PathEq(p.ProfileDir, _profileDir) || !PathEq(p.ModsDir, _modsDir) || !PathEq(p.DataDir, _dataDir)
                         || !PathEq(p.OverwriteDir, _overwriteDir);
         if (!switched) return false;                             // ini touched but nothing we resolve from changed
         _profileDir = p.ProfileDir; _modsDir = p.ModsDir; _dataDir = p.DataDir; _profileName = p.ProfileName; _overwriteDir = p.OverwriteDir;
-        InvalidateClassParents();                                // the mods tree may have moved — drop the cached hierarchy with it
-        ReResolve();                                             // a new profile ⇒ the order differs ⇒ ReResolve deep-re-indexes
+        InvalidateClassParents();                                // the mods tree may have moved â€” drop the cached hierarchy with it
+        ReResolve();                                             // a new profile â‡’ the order differs â‡’ ReResolve deep-re-indexes
         return true;
     }
 
@@ -666,12 +666,12 @@ public sealed class LoadOrderService : IDisposable
 
         if (paths.Count > 0 && !paths.SequenceEqual(_resolvedPaths, StringComparer.OrdinalIgnoreCase))
         {
-            // The active set/order genuinely changed → re-take the snapshot (the ~12s deep re-index). Build FIRST so the
+            // The active set/order genuinely changed â†’ re-take the snapshot (the ~12s deep re-index). Build FIRST so the
             // old snapshot survives if it throws; only then dispose + swap. Guarded on `_resolver is not null`: an
-            // ASSET-only query (Phase 2) can drive this re-resolve before any record index exists — it must NOT pay the
+            // ASSET-only query (Phase 2) can drive this re-resolve before any record index exists â€” it must NOT pay the
             // heavy build here (the record getter builds fresh against these paths on its own next call). The record
             // path always has a non-null _resolver when it reaches here, so its behaviour is unchanged.
-            InvalidateAssetResolver();   // the active-mod/archive set changed → the asset resolver rebuilds lazily
+            InvalidateAssetResolver();   // the active-mod/archive set changed â†’ the asset resolver rebuilds lazily
             if (_resolver is not null)
             {
                 var rebuilt = LoadOrderResolver.Build(paths);
@@ -684,36 +684,36 @@ public sealed class LoadOrderService : IDisposable
         }
         else if (paths.Count > 0)
         {
-            // The profile was touched but the resolved PLUGIN order is identical (e.g. a no-plugin mod toggled) — no deep
+            // The profile was touched but the resolved PLUGIN order is identical (e.g. a no-plugin mod toggled) â€” no deep
             // re-index. But a plugin-less toggle still changes the loose roots / active-archive set, so the asset resolver
             // is dropped to rebuild; just advance the freshness baseline so the staleness flag clears.
             InvalidateAssetResolver();
             _orderWarnings = order.Warnings;
             _profileMtimes = profileMtimes;
         }
-        // paths.Count == 0 → almost certainly a transient mid-write read; keep the last good snapshot and DON'T advance the
+        // paths.Count == 0 â†’ almost certainly a transient mid-write read; keep the last good snapshot and DON'T advance the
         // baseline, so the next tool call re-checks and self-recovers once MO2 finishes writing.
     }
 
     /// <summary>Instance mode: on the first resolver build, read ModOrganizer.ini and derive ProfileDir/ModsDir/DataDir +
-    /// the active profile — throwing a clear Q3 message (naming what's missing) if the configured instance isn't usable.
+    /// the active profile â€” throwing a clear Q3 message (naming what's missing) if the configured instance isn't usable.
     /// Explicit mode (paths already set) and re-derives (paths already non-empty) are no-ops. Stamps the ini-read baseline
     /// so the profile-switch check has a reference point. Caller holds the gate.</summary>
     void EnsurePathsDerived()
     {
-        if (_instanceDir is null) return;                        // explicit mode — roots configured directly
+        if (_instanceDir is null) return;                        // explicit mode â€” roots configured directly
         if (_profileDir.Length > 0) return;                      // already derived (a prior build / SetInstance); RederiveIfIniChanged owns later updates
         var iniMtime = SafeMtime(Mo2Instance.IniPath(_instanceDir));   // stat BEFORE the read (TOCTOU): an ini write during/after Resolve is caught next call
         var p = Mo2Instance.Resolve(_instanceDir);               // throws (Q3) naming the missing piece if not a usable instance
         _profileDir = p.ProfileDir; _modsDir = p.ModsDir; _dataDir = p.DataDir; _profileName = p.ProfileName; _overwriteDir = p.OverwriteDir;
         _iniMtime = iniMtime;
-        InvalidateClassParents();                                // _modsDir just gained a value — a cache built before derivation is baseline-only (hunt F1)
+        InvalidateClassParents();                                // _modsDir just gained a value â€” a cache built before derivation is baseline-only (hunt F1)
     }
 
     static bool PathEq(string a, string b) =>
         string.Equals(a.TrimEnd('\\', '/'), b.TrimEnd('\\', '/'), StringComparison.OrdinalIgnoreCase);
 
-    /// <summary>Whether houseCARL has an MO2 location to resolve against. False on a fresh install with no config — the
+    /// <summary>Whether houseCARL has an MO2 location to resolve against. False on a fresh install with no config â€” the
     /// server still runs; every tool returns the trained prompt until <see cref="SetInstance"/> is called.</summary>
     public bool IsConfigured { get { lock (_gate) { return _configured; } } }
 
@@ -721,12 +721,12 @@ public sealed class LoadOrderService : IDisposable
     /// name); "" when unconfigured. For the status surface.</summary>
     public string ProfileName { get { lock (_gate) { return _profileName; } } }
 
-    /// <summary>The game install directory the load order points at — DataDir's PARENT (DataDir = gamePath\Data), the same
-    /// derivation the asset-discovery path uses — or null when it isn't derivable. The compile rider's auto-detect HINT: the
-    /// CK installs its compiler at &lt;gamePath&gt;\Papyrus Compiler\PapyrusCompiler.exe (6.2). NULL-SAFE by contract — it is
+    /// <summary>The game install directory the load order points at â€” DataDir's PARENT (DataDir = gamePath\Data), the same
+    /// derivation the asset-discovery path uses â€” or null when it isn't derivable. The compile rider's auto-detect HINT: the
+    /// CK installs its compiler at &lt;gamePath&gt;\Papyrus Compiler\PapyrusCompiler.exe (6.2). NULL-SAFE by contract â€” it is
     /// best-effort plumbing, so a failure here must fall through to the forcing prompt, NEVER throw and abort the compile:
     /// returns null when unconfigured (no _configured guard would otherwise hit EnsurePathsDerived's NotConfigured throw),
-    /// when the instance is unusable (EnsurePathsDerived throws naming the missing piece — the rider's own config gate
+    /// when the instance is unusable (EnsurePathsDerived throws naming the missing piece â€” the rider's own config gate
     /// reports that; here it's just "no hint"), or when DataDir hasn't been derived yet. Takes <see cref="_gate"/> like the
     /// other derived-root reads; works in explicit mode too (DataDir is set directly, EnsurePathsDerived no-ops).</summary>
     public string? GameDirOrNull()
@@ -735,20 +735,20 @@ public sealed class LoadOrderService : IDisposable
         {
             if (!_configured) return null;
             try { EnsurePathsDerived(); }
-            catch { return null; }                                  // unusable instance → no hint (Q3: the rider's config gate names the real problem)
+            catch { return null; }                                  // unusable instance â†’ no hint (Q3: the rider's config gate names the real problem)
             return _dataDir.Length > 0 ? Path.GetDirectoryName(_dataDir.TrimEnd('\\', '/')) : null;
         }
     }
 
-    /// <summary>The game directories to search for the Creation Kit's compiler, in PRIORITY ORDER — the compile rider's
+    /// <summary>The game directories to search for the Creation Kit's compiler, in PRIORITY ORDER â€” the compile rider's
     /// auto-detect hints (6.2). [0] = the load order's OWN game dir (<see cref="GameDirOrNull"/>): correct when MO2 points
     /// straight at a real, CK-equipped install. Then the GameFinder/Mutagen-located real Skyrim SE install(s): in the common
     /// MO2 "Stock Game" setup (Aaron 2026-06-17) the load order points at a COPY that has NEITHER the CK nor the vanilla
-    /// script sources — both live in the Steam install — so the located install is the one that actually hits. De-duplicated,
+    /// script sources â€” both live in the Steam install â€” so the located install is the one that actually hits. De-duplicated,
     /// nulls dropped. BEST-EFFORT + NULL-SAFE end to end: the locator reads the registry/Steam, so a miss or a throw just
     /// yields fewer hints (the forcing prompt then names what was checked), it NEVER aborts the compile.
     /// <para>LOAD-BEARING (do NOT "simplify"): the compile rider derives the vanilla SOURCE folder from the RESOLVED
-    /// COMPILER's own game dir (<see cref="CompileTools.BuildImports"/>), NOT from these hints and NOT from the data dir — so
+    /// COMPILER's own game dir (<see cref="CompileTools.BuildImports"/>), NOT from these hints and NOT from the data dir â€” so
     /// once the compiler resolves to the Steam install, its sibling Data\Source\Scripts is used, never the Stock Game copy's
     /// (which usually has none). Keying sources off the data dir would re-break exactly the Stock-Game case this fixes.</para></summary>
     public IReadOnlyList<string> CompilerGameDirHints()
@@ -757,13 +757,13 @@ public sealed class LoadOrderService : IDisposable
         if (GameDirOrNull() is { } loadOrderGameDir) hints.Add(loadOrderGameDir);
         try
         {
-            // The bundled GameFinder locator (Steam/GOG/Xbox), via Mutagen — finds the REAL Skyrim SE install (App 489830),
+            // The bundled GameFinder locator (Steam/GOG/Xbox), via Mutagen â€” finds the REAL Skyrim SE install (App 489830),
             // where the Creation Kit + sources live, regardless of where MO2's load order points.
             if (new Mutagen.Bethesda.Installs.GameLocator().TryGetGameDirectory(
                     Mutagen.Bethesda.GameRelease.SkyrimSE, out var dir) && !string.IsNullOrWhiteSpace(dir.Path))
                 hints.Add(NormalizeGameDir(dir.Path));
         }
-        catch { /* GameFinder / registry hiccup → just the load-order hint (best-effort; the prompt still names it) */ }
+        catch { /* GameFinder / registry hiccup â†’ just the load-order hint (best-effort; the prompt still names it) */ }
         return hints.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
     }
 
@@ -775,20 +775,20 @@ public sealed class LoadOrderService : IDisposable
         return Path.GetFileName(t).Equals("Data", StringComparison.OrdinalIgnoreCase) ? (Path.GetDirectoryName(t) ?? t) : t;
     }
 
-    /// <summary>Point houseCARL at an MO2 instance folder — first-run setup AND switching between instances ("jump around").
-    /// VALIDATES it (<see cref="Mo2Instance.Resolve"/> throws a clear Q3 message if it isn't usable — nothing is changed or
+    /// <summary>Point houseCARL at an MO2 instance folder â€” first-run setup AND switching between instances ("jump around").
+    /// VALIDATES it (<see cref="Mo2Instance.Resolve"/> throws a clear Q3 message if it isn't usable â€” nothing is changed or
     /// persisted on failure), then re-points the live service (derives the roots + active profile, drops the cached resolver
     /// so the next tool call rebuilds against the new instance) and PERSISTS the choice to the user config file so it
     /// survives a restart. Returns the derived paths + whether the persist succeeded, for the tool's confirmation.</summary>
     public (Mo2InstancePaths paths, bool persisted, string? persistError, string? persistNote) SetInstance(string instanceDir)
     {
-        // The ini baseline is statted BEFORE Resolve reads the instance (hunt F7 — this was the one stamp-AFTER-the-read
+        // The ini baseline is statted BEFORE Resolve reads the instance (hunt F7 â€” this was the one stamp-AFTER-the-read
         // in the file: an MO2 ini write landing between Resolve's read and the stamp was absorbed into the baseline and
         // its profile switch stayed invisible forever). Statting first makes a during/after-read write show as a changed
-        // mtime on the next call — the same TOCTOU discipline every other baseline here follows.
+        // mtime on the next call â€” the same TOCTOU discipline every other baseline here follows.
         var iniMtime = SafeMtime(Mo2Instance.IniPath(instanceDir.Trim()));
-        var paths = Mo2Instance.Resolve(instanceDir);            // throws (Q3) if not a usable MO2 instance — the tool renders the reason
-        lock (_writeGate)                                        // hunt F2: an instance switch waits for any in-flight write — never tears one across instances
+        var paths = Mo2Instance.Resolve(instanceDir);            // throws (Q3) if not a usable MO2 instance â€” the tool renders the reason
+        lock (_writeGate)                                        // hunt F2: an instance switch waits for any in-flight write â€” never tears one across instances
         lock (_gate)
         {
             _instanceDir = paths.InstanceDir;
@@ -799,19 +799,19 @@ public sealed class LoadOrderService : IDisposable
             _resolver?.Dispose(); _resolver = null;              // force a rebuild against the new instance on the next query
             _assetResolver?.Dispose(); _assetResolver = null;    // the asset resolver rebuilds against the new instance too (Phase 2)
             _resolvedPaths = Array.Empty<string>();
-            _profileMtimes = new DateTime[ProfileFileNames.Length];   // unset — the next build records fresh baselines against the new profile
+            _profileMtimes = new DateTime[ProfileFileNames.Length];   // unset â€” the next build records fresh baselines against the new profile
             _orderWarnings = Array.Empty<string>();
-            InvalidateClassParents();                            // every sibling cache drops on a switch — the hierarchy too (PR #47 review)
+            InvalidateClassParents();                            // every sibling cache drops on a switch â€” the hierarchy too (PR #47 review)
         }
         var (persisted, persistError, persistNote) = PersistInstanceDir(paths.InstanceDir);
         return (paths, persisted, persistError, persistNote);
     }
 
     /// <summary>Persist the chosen instance dir through the shared <see cref="UserConfigStore"/> (read-modify-write), so it
-    /// survives a restart AND coexists with any saved tool paths — the store never clobbers the other concern's field.
-    /// Best-effort + HONEST (Q3): a write failure (e.g. a read-only data dir) is reported, not swallowed — the session
+    /// survives a restart AND coexists with any saved tool paths â€” the store never clobbers the other concern's field.
+    /// Best-effort + HONEST (Q3): a write failure (e.g. a read-only data dir) is reported, not swallowed â€” the session
     /// still works, but the user is told the choice won't survive a restart. <c>note</c> carries a corrupt-file recovery
-    /// (hunt F3 — the prior file was backed up; other saved settings were lost), rendered even on success.</summary>
+    /// (hunt F3 â€” the prior file was backed up; other saved settings were lost), rendered even on success.</summary>
     (bool ok, string? error, string? note) PersistInstanceDir(string instanceDir)
         => _store.Update(c => c.Mo2InstanceDir = instanceDir);
 
@@ -819,14 +819,14 @@ public sealed class LoadOrderService : IDisposable
     /// silently pick among several) and call the setup tool. Tools RETURN this (so the client SEES it) via <see cref="ConfigPromptOrNull"/>; the <see cref="Resolver"/>
     /// getter also THROWS it as a backstop. The two must say the same thing, hence one shared string.</summary>
     const string NotConfiguredText =
-        "houseCARL has no Mod Organizer 2 instance configured yet. Ask the user which MO2 instance folder to use — the " +
+        "houseCARL has no Mod Organizer 2 instance configured yet. Ask the user which MO2 instance folder to use â€” the " +
         "folder that contains ModOrganizer.ini (for a Wabbajack / portable list, that's the list's install folder). You " +
         "may help locate it, but do NOT silently pick one when more than one MO2 install exists: list the candidates you " +
         "found and let the user choose. State which folder you're using, then call housecarl_set_mo2_instance with that path.";
 
     /// <summary>Tools call this FIRST: returns the trained prompt (a normal result string the client SEES) when
-    /// unconfigured, else null (proceed). Preferred over letting <see cref="Resolver"/> throw — the MCP framework
-    /// genericizes a thrown exception to "An error occurred invoking '…'", so a THROW never delivers the guidance to the
+    /// unconfigured, else null (proceed). Preferred over letting <see cref="Resolver"/> throw â€” the MCP framework
+    /// genericizes a thrown exception to "An error occurred invoking 'â€¦'", so a THROW never delivers the guidance to the
     /// client, but a returned string does (measured 2026-06-02 during the server-driven proof).</summary>
     public string? ConfigPromptOrNull() { lock (_gate) { return _configured ? null : NotConfiguredText; } }
 
@@ -835,43 +835,43 @@ public sealed class LoadOrderService : IDisposable
     /// <summary>Resolve + read one record (the read_record primitive). Reads the WINNER's body by default, or a
     /// named <paramref name="plugin"/>'s version; with <paramref name="conflictTree"/> also returns the ordered
     /// touching-plugin list. Honest, recoverable errors (Q3): not-in-order, plugin-doesn't-touch, fetch
-    /// inconsistency — never a silent empty result.</summary>
+    /// inconsistency â€” never a silent empty result.</summary>
     public ReadOutcome ResolveRead(FormKey fk, string? plugin, IReadOnlyList<string>? fields, bool conflictTree, int depth = 1)
     {
         var resolver = Resolver;
         return ResolveRead(resolver, resolver.Capture(), fk, plugin, fields, conflictTree, depth);
     }
 
-    /// <summary>Layer B unit C2 — the on-demand whole-topic dialogue-graph validator (housecarl_validate_dialogue):
+    /// <summary>Layer B unit C2 â€” the on-demand whole-topic dialogue-graph validator (housecarl_validate_dialogue):
     /// resolve <paramref name="fk"/> to its load-order winner and, when it is a dialogue topic (DIAL) validate that
-    /// topic's whole graph, or when a quest (QUST) fan out to EVERY topic the quest owns — all against the resolved
+    /// topic's whole graph, or when a quest (QUST) fan out to EVERY topic the quest owns â€” all against the resolved
     /// load-order winners (what the game actually sees). The on-demand counterpart of the per-create voice (unit B)
     /// + result-script (unit C1) teeth, auditing existing INFOs the create-time checks never re-touch. The whole
     /// Skyrim-typed walk (winner resolution, the DIAL/QUST branch, the graph + per-INFO checks) lives in CORE
     /// (<see cref="DialogueValidate"/>), so the service stays Mutagen.Skyrim-free exactly like the voice/script
-    /// enrichers — here it just hands core the live record resolver + the VFS asset resolver. NEVER throws over a
+    /// enrichers â€” here it just hands core the live record resolver + the VFS asset resolver. NEVER throws over a
     /// verify step: a mid-run resolve/asset failure rides <see cref="DialogueValidationReport.CheckError"/>, and a
     /// not-in-order / not-a-DIAL-or-QUST input is a NAMED <see cref="DialogueValidationReport.Error"/> (Q3).</summary>
     public DialogueValidationReport ValidateDialogue(FormKey fk) => DialogueValidate.Run(Resolver, Assets, fk);
 
     /// <summary>The read body, answered entirely off ONE captured view (HCBR-2026-06-11-02): excluded-check, winner,
-    /// and touching-plugin list all describe the SAME build — a freshness rebuild landing mid-read can no longer make
+    /// and touching-plugin list all describe the SAME build â€” a freshness rebuild landing mid-read can no longer make
     /// a record's reported winner disagree with its own TOUCHING LIST. (The body fetch reads the file on disk through
     /// the session; a mid-read file edit surfaces as the existing named fetch-inconsistency error, never torn values.
     /// Known residue, review #1: the conflict-tree DIFF the render layer adds is a separate <see cref="ResolveTree"/>
     /// call with its own capture, so one rendered response can still pair this read's build with an adjacent build's
-    /// diff — same low-severity class, named for the next wave rather than threaded through the render API here.)</summary>
+    /// diff â€” same low-severity class, named for the next wave rather than threaded through the render API here.)</summary>
     ReadOutcome ResolveRead(LoadOrderResolver resolver, LoadOrderResolver.IndexView view,
                             FormKey fk, string? plugin, IReadOnlyList<string>? fields, bool conflictTree, int depth)
     {
-        // An explicitly-requested plugin that was EXCLUDED this session (unparseable/unopenable) → say so (Q3),
+        // An explicitly-requested plugin that was EXCLUDED this session (unparseable/unopenable) â†’ say so (Q3),
         // rather than fall through to a misleading "does not define this record".
         if (plugin is not null && view.ExcludedPlugins.TryGetValue(plugin, out var pWhy))
             return ReadOutcome.Fail(fk, $"Plugin '{plugin}' was excluded from this session: {pWhy}");
 
         // An explicitly-requested plugin that is NOT IN THE ORDER AT ALL is its own failure mode (HCBR-2026-06-11-02
         // wave (a)): GetRecord returns null for it, and falling through would render the FALSE "does not define this
-        // record" — which reads as "my write was lost" and invites re-issuing the ops (duplicate list Adds into the
+        // record" â€” which reads as "my write was lost" and invites re-issuing the ops (duplicate list Adds into the
         // patch). Name the true condition + the working verify paths instead. Aaron-decided Option A: houseCARL does
         // NOT read disabled plugins off disk (non-winner content masquerading as load-order truth is the Q3 hazard).
         if (plugin is not null && !view.ContainsPlugin(plugin))
@@ -882,12 +882,12 @@ public sealed class LoadOrderService : IDisposable
                 "plugins off disk. If this is a freshly written houseCARL patch, it isn't enabled yet: enable + sort it in " +
                 "MO2, then re-read. To verify a write BEFORE enabling, use the write call's own read-back " +
                 "(full_readback=true returns the whole written record). If a prior write into this patch reported success, " +
-                "the edits DID land — do not re-issue them (re-running list Adds would duplicate entries).");
+                "the edits DID land â€” do not re-issue them (re-running list Adds would duplicate entries).");
 
         var winner = view.ResolveWinner(fk);
         if (winner is null)
         {
-            // If the record's defining plugin was excluded, that's WHY it's missing — name it (Q3), not a bare "not present".
+            // If the record's defining plugin was excluded, that's WHY it's missing â€” name it (Q3), not a bare "not present".
             var defining = fk.ModKey.FileName.ToString();
             if (view.ExcludedPlugins.TryGetValue(defining, out var dWhy))
                 return ReadOutcome.Fail(fk, $"FormID {fk} is not resolvable: its plugin '{defining}' was excluded from this session: {dWhy}");
@@ -899,7 +899,7 @@ public sealed class LoadOrderService : IDisposable
         var rec = view.GetRecord(session, source, fk);                    // excluded-check pinned to the SAME view the winner came from (hunt F5 discipline)
         if (rec is null)
             return ReadOutcome.Fail(fk, plugin is null
-                ? $"Winner '{winner.Value.WinnerPlugin}' did not yield {fk} on fetch — a load-order inconsistency."
+                ? $"Winner '{winner.Value.WinnerPlugin}' did not yield {fk} on fetch â€” a load-order inconsistency."
                 : $"Plugin '{plugin}' does not define {fk} (it does not touch this record). The winner is '{winner.Value.WinnerPlugin}'.");
 
         var record = ReadEngine.ReadFields(rec, fields, depth);           // materialise while the session (overlay) is open
@@ -908,13 +908,13 @@ public sealed class LoadOrderService : IDisposable
     }
 
     /// <summary>How deep the conflict diff reads each touching body. The diff must compare CONTENT, not the
-    /// depth-1 count summaries that masked equal-count list deltas (HCBR-2026-06-09-01) — deep enough to reach
+    /// depth-1 count summaries that masked equal-count list deltas (HCBR-2026-06-09-01) â€” deep enough to reach
     /// every modeled scalar leaf (the walk is bounded by the modeled-corpus boundary + ReadEngine's expansion
     /// cap, whose truncation sentinel FieldsDiff surfaces as Complete=false).</summary>
     internal const int ConflictDiffDepth = 16;
 
-    /// <summary>The winner's full conflict tree, MATERIALISED — every touching plugin's name + its fields read off its
-    /// own body, in priority order (winner last) — for the field-level diff view, read DEEP (<see cref="ConflictDiffDepth"/>)
+    /// <summary>The winner's full conflict tree, MATERIALISED â€” every touching plugin's name + its fields read off its
+    /// own body, in priority order (winner last) â€” for the field-level diff view, read DEEP (<see cref="ConflictDiffDepth"/>)
     /// so the diff compares list/substruct CONTENT, not depth-1 count summaries (HCBR-2026-06-09-01). Opens a per-call
     /// session, fetches each touching body, reads its <paramref name="fields"/> into a plain DTO, then DISPOSES the
     /// session (Option B): the render layer never touches a live overlay or holds a handle. null if the FormKey isn't
@@ -931,7 +931,7 @@ public sealed class LoadOrderService : IDisposable
         return new ConflictTreeView(nodes);
     }
 
-    /// <summary>A header-only summary for one record (winner + type + editorid, no field dump) — the compact
+    /// <summary>A header-only summary for one record (winner + type + editorid, no field dump) â€” the compact
     /// one-line-per-match view cross_plugin_query uses by default. One winner-body fetch; holds nothing.</summary>
     public RecordSummary ResolveSummary(FormKey fk)
     {
@@ -956,7 +956,7 @@ public sealed class LoadOrderService : IDisposable
     public IReadOnlyList<ReadOutcome> ResolveBatch(IReadOnlyList<string> formids, IReadOnlyList<string>? fields, bool conflictTree, int depth = 1)
     {
         var resolver = Resolver;                // build/refresh ONCE for the batch
-        var view = resolver.Capture();          // ONE build for every item — the whole batch is one logical operation (HCBR-2026-06-11-02)
+        var view = resolver.Capture();          // ONE build for every item â€” the whole batch is one logical operation (HCBR-2026-06-11-02)
         var outcomes = new List<ReadOutcome>(formids.Count);
         foreach (var raw in formids)
         {
@@ -989,9 +989,9 @@ public sealed class LoadOrderService : IDisposable
         if (!hasType && !conflictsOnly && !hasPlugins && !bodyFilter)
             return CrossQueryOutcome.Fail("cross_plugin_query needs at least one of: type=, conflicts_only=true, editorid_contains=, references=, where=, or plugins=.");
         if (bodyFilter && !hasType && !hasPlugins)
-            return CrossQueryOutcome.Fail("editorid_contains/references/where is a body scan and must be combined with type= or plugins= to bound it (conflicts_only= alone is not enough — an unbounded body scan over the whole order is refused). A global reverse-reference index is a future capability.");
+            return CrossQueryOutcome.Fail("editorid_contains/references/where is a body scan and must be combined with type= or plugins= to bound it (conflicts_only= alone is not enough â€” an unbounded body scan over the whole order is refused). A global reverse-reference index is a future capability.");
 
-        // where= → the field-value predicate set. Parsed up front so a malformed predicate refuses the call BEFORE
+        // where= â†’ the field-value predicate set. Parsed up front so a malformed predicate refuses the call BEFORE
         // any scan (Q3). The predicate reuses the read engine's path-walk, so its reach == the read surface's reach.
         FieldPredicateSet? predicate = null;
         if (hasWhere)
@@ -1006,22 +1006,22 @@ public sealed class LoadOrderService : IDisposable
         catch (ArgumentException ex) { return CrossQueryOutcome.Fail(ex.Message); }   // unknown type
 
         var keys = new List<FormKey>();
-        var sources = new List<string?>();                                    // parallel to keys: the plugin whose body matched (null ⇒ winner), so the render displays the SAME body it filtered
+        var sources = new List<string?>();                                    // parallel to keys: the plugin whose body matched (null â‡’ winner), so the render displays the SAME body it filtered
         List<RecordSummary>? prefilled = (hasType || hasPlugins) ? new() : null;   // parallel to keys; null = renderer fills lazily
         int total = 0;
-        int unscannable = 0;                                                  // records whose body tests THREW (Mutagen-unparseable content) — excluded + accounted, never silent (Q3)
+        int unscannable = 0;                                                  // records whose body tests THREW (Mutagen-unparseable content) â€” excluded + accounted, never silent (Q3)
         var unscannableSamples = new List<string>();
 
         if (hasType || hasPlugins)                                            // a body-bearing scope: stream + filter in hand
         {
             // RecordsIn / WinnerRecordsOfType are LAZY iterators: ScopeIndices (a plugin not in the order) and
-            // EnumerateMajorRecords(throwIfUnknown) throw on ENUMERATION, not on creation — so the try must wrap the
+            // EnumerateMajorRecords(throwIfUnknown) throw on ENUMERATION, not on creation â€” so the try must wrap the
             // foreach, not just the assignment, or the clean Q3 message escapes as a generic framework error.
             var seen = new HashSet<FormKey>();
             try
             {
                 // Carry the SOURCE plugin per record so the render shows the body the scan filtered (not the winner):
-                // plugins= → the scoped plugin's filename; type= → null (⇒ the winner, the WinnerRecordsOfType body).
+                // plugins= â†’ the scoped plugin's filename; type= â†’ null (â‡’ the winner, the WinnerRecordsOfType body).
                 IEnumerable<(FormKey fk, int depth, IMajorRecordGetter body, string? source)> stream =
                     hasPlugins ? view.RecordsIn(plugins!, types).Select(x => (fk: x.fk, depth: x.depth, body: x.body, source: (string?)x.source))  // the scoped plugin's own body
                                : view.WinnerRecordsOfType(types!).Select(x => (fk: x.fk, depth: x.depth, body: x.body, source: (string?)null));    // the load-order winner's body
@@ -1030,9 +1030,9 @@ public sealed class LoadOrderService : IDisposable
                     if (conflictsOnly && depth <= 1) continue;
                     // PER-RECORD FAULT ISOLATION (HCBR-2026-06-09-03): the body tests lazily parse subrecord
                     // content (references= walks Effects etc. via Mutagen's EnumerateFormLinks), so ONE record
-                    // Mutagen can't parse used to abort the WHOLE call as an opaque transport error — the
+                    // Mutagen can't parse used to abort the WHOLE call as an opaque transport error â€” the
                     // scan-level twin of the PKCU index-build fix. Such a record is excluded and ACCOUNTED in
-                    // the response (never a silent skip, never a guessed match — Q3).
+                    // the response (never a silent skip, never a guessed match â€” Q3).
                     try
                     {
                         if (!string.IsNullOrEmpty(editoridContains)
@@ -1041,21 +1041,21 @@ public sealed class LoadOrderService : IDisposable
                         if (references is { } target
                             && !(body is IFormLinkContainerGetter flc && flc.EnumerateFormLinks().Any(l => l.FormKey == target)))
                             continue;
-                        if (predicate is not null && !predicate.Matches(body))    // value filter — same in-hand body, no extra fetch
+                        if (predicate is not null && !predicate.Matches(body))    // value filter â€” same in-hand body, no extra fetch
                         {
-                            if (predicate.FatalError is not null) break;          // numeric op vs non-numeric field — abort + surface (Q3)
+                            if (predicate.FatalError is not null) break;          // numeric op vs non-numeric field â€” abort + surface (Q3)
                             continue;
                         }
                         // De-dup (a FK can recur across scoped plugins). This runs AFTER the filters, so under
                         // plugins=[A,B] the source recorded for a shared FK is the FIRST scoped plugin (in plugins=
-                        // array order) whose body PASSED the filters — deterministic, and it's the body we'll display.
+                        // array order) whose body PASSED the filters â€” deterministic, and it's the body we'll display.
                         if (!seen.Add(fk)) continue;
                         total++;
-                        if (keys.Count < limit)                                   // in-hand body → fill the summary for free
+                        if (keys.Count < limit)                                   // in-hand body â†’ fill the summary for free
                         {
                             keys.Add(fk);
-                            sources.Add(source);                                  // the body we filtered IS the body we'll display (null ⇒ winner)
-                            // winner= off the SAME view the scan runs on — a rebuild landing mid-scan can no longer
+                            sources.Add(source);                                  // the body we filtered IS the body we'll display (null â‡’ winner)
+                            // winner= off the SAME view the scan runs on â€” a rebuild landing mid-scan can no longer
                             // make a row's winner reflect a newer build than the depth beside it (HCBR-2026-06-11-02).
                             prefilled!.Add(new RecordSummary(fk, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID,
                                                              view.ResolveWinner(fk)?.WinnerPlugin ?? "?", depth, null));
@@ -1065,29 +1065,29 @@ public sealed class LoadOrderService : IDisposable
                     {
                         unscannable++;
                         if (unscannableSamples.Count < 3)
-                            unscannableSamples.Add($"{fk}{(source is null ? "" : $" in {source}")} — {ex.GetType().Name}: {ex.Message}");
+                            unscannableSamples.Add($"{fk}{(source is null ? "" : $" in {source}")} â€” {ex.GetType().Name}: {ex.Message}");
                     }
                 }
             }
             catch (ArgumentException ex) { return CrossQueryOutcome.Fail(ex.Message); } // plugin not in order / unknown type
-            // Anything else escaping the stream itself still gets a NAMED failure — the MCP layer's generic
-            // "An error occurred invoking …" must never be the terminal diagnostic for a data failure (Q3).
+            // Anything else escaping the stream itself still gets a NAMED failure â€” the MCP layer's generic
+            // "An error occurred invoking â€¦" must never be the terminal diagnostic for a data failure (Q3).
             catch (Exception ex) { return CrossQueryOutcome.Fail($"scan aborted: {ex.GetType().Name}: {ex.Message}"); }
-            if (predicate?.FatalError is not null) return CrossQueryOutcome.Fail(predicate.FatalError); // typed predicate error — fail fast, named (Q3)
+            if (predicate?.FatalError is not null) return CrossQueryOutcome.Fail(predicate.FatalError); // typed predicate error â€” fail fast, named (Q3)
         }
-        else                                                                  // conflicts_only alone — index keys only; NO body fetch
+        else                                                                  // conflicts_only alone â€” index keys only; NO body fetch
         {
             // Summaries here would each need a winner-body fetch; leaving them to the renderer (which stops at
             // max_chars) means a big limit with a small max_chars doesn't fetch bodies it will never show.
             foreach (var fk in view.ConflictKeys())
             {
                 total++;
-                if (keys.Count < limit) { keys.Add(fk); sources.Add(null); }   // no scoped plugin → display the winner
+                if (keys.Count < limit) { keys.Add(fk); sources.Add(null); }   // no scoped plugin â†’ display the winner
             }
         }
         // Unscannable accounting (Q3): name the count, the first few offenders with Mutagen's reason, and what
-        // a caller can still do — these records are invisible to the body filters, not "0 matches" silence.
-        // "instance(s) … where they threw" because under plugins= a FormKey is tested once per scoped plugin:
+        // a caller can still do â€” these records are invisible to the body filters, not "0 matches" silence.
+        // "instance(s) â€¦ where they threw" because under plugins= a FormKey is tested once per scoped plugin:
         // a copy that throws is skipped while another plugin's copy of the same FK can still match (PR #27 review).
         string? scanNote = unscannable == 0 ? null
             : $"note: {unscannable} record instance(s) could not be scanned (Mutagen could not parse their content) and were skipped where they threw: "
@@ -1097,12 +1097,12 @@ public sealed class LoadOrderService : IDisposable
         return new CrossQueryOutcome(keys, prefilled, total, total > keys.Count, null, predicate?.AccountingNote(), sources, scanNote);
     }
 
-    // ---- effect-chain resolver (housecarl_effect_chain — gap 2026-06-08) --------------------------------
+    // ---- effect-chain resolver (housecarl_effect_chain â€” gap 2026-06-08) --------------------------------
 
     /// <summary>Resolve which SPEL/ENCH/ALCH/SCRL/INGR apply a MagicEffect, each with the magnitude/area/duration from
     /// the MATCHING effect entry (housecarl_effect_chain). Thin wiring over the core: resolve the optional type-narrow
-    /// (each must be one of the five effect-bearing records — a non-member is refused loud, never a silent empty scan),
-    /// then drive <see cref="EffectChain.Resolve"/> (Q3 typed-match gate → winner-body scan). All the logic + the Q3
+    /// (each must be one of the five effect-bearing records â€” a non-member is refused loud, never a silent empty scan),
+    /// then drive <see cref="EffectChain.Resolve"/> (Q3 typed-match gate â†’ winner-body scan). All the logic + the Q3
     /// teeth live in core so the self-contained guard drives this same path on synthetic plugins.</summary>
     public EffectChainResult ResolveEffectChain(FormKey mgef, IReadOnlyList<string>? typesNarrow, int limit)
     {
@@ -1113,13 +1113,13 @@ public sealed class LoadOrderService : IDisposable
             foreach (var ts in typesNarrow)
             {
                 IReadOnlyList<Type> resolved;
-                try { resolved = ResolveTypeFilter(ts.Trim()); }              // unknown type → named Q3 error (same as cross_plugin_query)
+                try { resolved = ResolveTypeFilter(ts.Trim()); }              // unknown type â†’ named Q3 error (same as cross_plugin_query)
                 catch (ArgumentException ex) { return EffectChainResult.Fail(ex.Message); }
                 foreach (var t in resolved)
                 {
                     if (!EffectChain.CarrierTypes.Contains(t))
                         return EffectChainResult.Fail(
-                            $"type '{ts}' is not effect-bearing — effect_chain scans only Spell/ObjectEffect/Ingestible/Scroll/Ingredient " +
+                            $"type '{ts}' is not effect-bearing â€” effect_chain scans only Spell/ObjectEffect/Ingestible/Scroll/Ingredient " +
                             "(SPEL/ENCH/ALCH/SCRL/INGR), the records that carry an Effects list. Drop it or pass one of those.");
                     if (!picked.Contains(t)) picked.Add(t);
                 }
@@ -1131,9 +1131,9 @@ public sealed class LoadOrderService : IDisposable
         return EffectChain.Resolve(Resolver, mgef, scope, limit);
     }
 
-    // ---- integrity sweep (housecarl_check_errors — audit A1) --------------------------------------------
+    // ---- integrity sweep (housecarl_check_errors â€” audit A1) --------------------------------------------
 
-    /// <summary>Sweep the active order (or the given <paramref name="plugins"/> scope) for record integrity errors —
+    /// <summary>Sweep the active order (or the given <paramref name="plugins"/> scope) for record integrity errors â€”
     /// dangling FormLinks, missing masters, and parse failures (housecarl_check_errors). Thin wiring over the
     /// core <see cref="ErrorCheck.Run"/>, which holds all the scan logic + Q3 teeth so the self-contained guard drives
     /// this same path over synthetic plugins. Read-only; composes existing primitives, no new dependency.</summary>
@@ -1143,7 +1143,7 @@ public sealed class LoadOrderService : IDisposable
     // ---- script-property sweep (housecarl_validate_scripts) --------------------------------------------
 
     /// <summary>Sweep the active order (or the given <paramref name="plugins"/> scope) for VMAD script properties that
-    /// are declared in the attached script's .pex (or an ancestor it extends) but left UNBOUND on the record — a silent
+    /// are declared in the attached script's .pex (or an ancestor it extends) but left UNBOUND on the record â€” a silent
     /// <c>None</c> (housecarl_validate_scripts). Thin wiring over the core <see cref="ScriptPropertyCheck.Run"/>, which
     /// holds all the cross-check logic + Q3 teeth so the self-contained guard drives this same path over synthetic
     /// records + a planted .pex. Passes the live <see cref="Assets"/> resolver (the same one the dialogue validator and
@@ -1151,30 +1151,30 @@ public sealed class LoadOrderService : IDisposable
     public ScriptCheckResult ValidateScripts(IReadOnlyList<string>? plugins, int limit)
         => ScriptPropertyCheck.Run(Resolver, Assets, plugins, limit);
 
-    // ---- writes (§8.4 Beat C: housecarl_set_field / housecarl_bulk_apply) -------------------------------
+    // ---- writes (Â§8.4 Beat C: housecarl_set_field / housecarl_bulk_apply) -------------------------------
 
     /// <summary>Apply one-or-more edits as a single patch (housecarl_set_field = one op; housecarl_bulk_apply = many).
     /// Parses each op's FormID + field path + (optional) composition spec to the core's <see cref="WritePatchBuilder.PatchEdit"/>,
-    /// resolves the output path as a NEW MO2 mod folder under ModsDir (folder-per-patch — see <see cref="ResolveOutputPath"/>),
-    /// then drives the proven public cleave <see cref="WritePatchBuilder.Apply"/> (resolve winner → derive type → pre-flight
-    /// ALL → override → ApplyVerb → multi-master serialize). ALL-OR-NOTHING (Q3): a single malformed op or pre-flight reject
+    /// resolves the output path as a NEW MO2 mod folder under ModsDir (folder-per-patch â€” see <see cref="ResolveOutputPath"/>),
+    /// then drives the proven public cleave <see cref="WritePatchBuilder.Apply"/> (resolve winner â†’ derive type â†’ pre-flight
+    /// ALL â†’ override â†’ ApplyVerb â†’ multi-master serialize). ALL-OR-NOTHING (Q3): a single malformed op or pre-flight reject
     /// refuses the whole call with no file written. Writes go to a NEW patch by default; <paramref name="into"/> EXTENDS an
     /// existing houseCARL-owned patch (the multi-session accumulation lever). Returns null-Error outcome on success.
     /// <paramref name="fullReadback"/> additionally reads every touched record back IN FULL off the written file
-    /// (the pre-enable verify loop — wishlist #3 re-scoped / HCBR-2026-06-11-02 wave (b)).</summary>
+    /// (the pre-enable verify loop â€” wishlist #3 re-scoped / HCBR-2026-06-11-02 wave (b)).</summary>
     public WritePatchBuilder.PatchOutcome ApplyEdits(IReadOnlyList<BulkOp> ops, string? patchName, string? into,
         bool fullReadback = false, string? target = null, bool inPlace = false, bool acknowledge = false)
     {
         if (ops.Count == 0)
             return WritePatchBuilder.PatchOutcome.Fail("no operations supplied.");
 
-        // In-place is the explicit, named-file opt-in (the SECOND write lane — edit an existing plugin, incl. one
+        // In-place is the explicit, named-file opt-in (the SECOND write lane â€” edit an existing plugin, incl. one
         // houseCARL didn't author, instead of writing a new patch). Validate the contract up front (Q3): it REQUIRES a
-        // target=, and it is mutually exclusive with into= (which EXTENDS a houseCARL patch — a different lane). target=
-        // without in_place is a no-op the caller likely didn't mean — name it rather than silently ignore it.
+        // target=, and it is mutually exclusive with into= (which EXTENDS a houseCARL patch â€” a different lane). target=
+        // without in_place is a no-op the caller likely didn't mean â€” name it rather than silently ignore it.
         if (inPlace && string.IsNullOrWhiteSpace(target))
             return WritePatchBuilder.PatchOutcome.Fail(
-                "in_place=true requires target=<plugin filename> — name the existing plugin to edit in place. (Omit in_place to write a new patch instead — the default, originals untouched.)");
+                "in_place=true requires target=<plugin filename> â€” name the existing plugin to edit in place. (Omit in_place to write a new patch instead â€” the default, originals untouched.)");
         if (inPlace && !string.IsNullOrWhiteSpace(into))
             return WritePatchBuilder.PatchOutcome.Fail(
                 "in_place=true and into= are mutually exclusive: into= EXTENDS a houseCARL patch, while in_place edits an existing plugin in place. Use one lane or the other.");
@@ -1183,7 +1183,7 @@ public sealed class LoadOrderService : IDisposable
                 "target= is only meaningful with in_place=true (it names the plugin to edit in place). For the default patch lane omit target=; use into= to extend an existing houseCARL patch.");
 
         // Map every op to a core PatchEdit, collecting ALL parse problems first (all-or-nothing, like the cleave).
-        // Pure parsing — runs outside the write gate so a malformed call never queues behind a real write.
+        // Pure parsing â€” runs outside the write gate so a malformed call never queues behind a real write.
         var edits = new List<WritePatchBuilder.PatchEdit>(ops.Count);
         var problems = new List<string>();
         for (int i = 0; i < ops.Count; i++)
@@ -1193,9 +1193,9 @@ public sealed class LoadOrderService : IDisposable
         }
         if (problems.Count > 0)
             return WritePatchBuilder.PatchOutcome.Fail(
-                $"refused — {problems.Count} of {ops.Count} operation(s) malformed; NO patch written:\n  - " + string.Join("\n  - ", problems));
+                $"refused â€” {problems.Count} of {ops.Count} operation(s) malformed; NO patch written:\n  - " + string.Join("\n  - ", problems));
 
-        lock (_writeGate)                                                 // hunt F2: one write at a time, resolve→commit
+        lock (_writeGate)                                                 // hunt F2: one write at a time, resolveâ†’commit
         {
             var resolver = Resolver;                                      // builds/refreshes the index
             var rulebook = Rulebook;
@@ -1213,29 +1213,29 @@ public sealed class LoadOrderService : IDisposable
         }
     }
 
-    /// <summary>The in-place branch of <see cref="ApplyEdits"/> (in-place write lane, Wave 1) — runs under _writeGate.
+    /// <summary>The in-place branch of <see cref="ApplyEdits"/> (in-place write lane, Wave 1) â€” runs under _writeGate.
     /// (1) resolves <paramref name="target"/> to its REAL on-disk path via the load order (NOT the houseCARL-owned
-    /// folder model — the foreign-plugin resolver, the sibling of <see cref="ResolveOwnedPatchFolder"/> with the
+    /// folder model â€” the foreign-plugin resolver, the sibling of <see cref="ResolveOwnedPatchFolder"/> with the
     /// ownership gate DROPPED); (2) enforces the server-side, PERSISTENT first-touch CONSENT handshake (keyed off the
     /// resolved path, stored in <see cref="UserConfigStore"/>); (3) checks the writable parent; (4) drives
     /// <see cref="WritePatchBuilder.ApplyInPlace"/> with the touched-record verify forced ON; (5) on success stamps the
-    /// distinct <c>editedInPlace=</c> marker (NEVER <c>generated=true</c> — the user mod must keep failing
+    /// distinct <c>editedInPlace=</c> marker (NEVER <c>generated=true</c> â€” the user mod must keep failing
     /// <see cref="IsHouseCarlOwned"/> so a later into= can't blind-overwrite it). <paramref name="acknowledge"/> waives
-    /// the CONSENT axis ONLY — the verify is a corruption-axis fact no acknowledgement overrides.</summary>
+    /// the CONSENT axis ONLY â€” the verify is a corruption-axis fact no acknowledgement overrides.</summary>
     WritePatchBuilder.PatchOutcome ApplyEditsInPlace(
         LoadOrderResolver resolver, CorpusRulebook rulebook, IReadOnlyList<WritePatchBuilder.PatchEdit> edits,
         string target, bool acknowledge)
     {
-        // (1) Resolve target -> real on-disk path via the load order (by plugin FILENAME — unique in an order). Refuse
+        // (1) Resolve target -> real on-disk path via the load order (by plugin FILENAME â€” unique in an order). Refuse
         //     loud if it isn't a real active plugin (closes the coincidental-folder collision the into= lane can hit).
         var view = resolver.Capture();
         var targetPath = ResolveActivePluginPath(view, Path.GetFileName(target.Trim()), out var targetName);
         if (targetPath is null)
             return WritePatchBuilder.PatchOutcome.Fail(
-                $"in-place target '{target}' is not an active plugin in the load order — name a plugin enabled in MO2, by its " +
+                $"in-place target '{target}' is not an active plugin in the load order â€” name a plugin enabled in MO2, by its " +
                 "plugin filename (e.g. 'CoolWeapons.esp'). in-place edits the file the game actually loads. Nothing was written.");
 
-        // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path. NOT a
+        // (2) CONSENT axis â€” the persistent, server-enforced first-touch handshake, keyed off the resolved path. NOT a
         //     sticky mode: each in-place write still names its own target=, so this only stops re-explaining the
         //     trade-off; it never makes an ambiguous request route to in-place.
         bool already = _store.IsInPlaceAcknowledged(targetPath);
@@ -1245,21 +1245,21 @@ public sealed class LoadOrderService : IDisposable
         if (!already && acknowledge)
         {
             var (ok, err) = _store.RecordInPlaceAcknowledged(targetPath);
-            if (!ok) ackNote = $"the in-place acknowledgement could not be saved ({err}) — the edit proceeded, but a future session will re-prompt for this plugin.";
+            if (!ok) ackNote = $"the in-place acknowledgement could not be saved ({err}) â€” the edit proceeded, but a future session will re-prompt for this plugin.";
         }
 
-        // (3) Writable, same-volume parent pre-flight — refuse rather than degrade (the swap stages a sibling temp in
+        // (3) Writable, same-volume parent pre-flight â€” refuse rather than degrade (the swap stages a sibling temp in
         //     this dir; AtomicFile.Commit already refuses cross-volume loud, this catches a read-only/locked parent up
         //     front with a clear message before any work).
         if (InPlaceParentUnwritable(targetPath, out var why))
             return WritePatchBuilder.PatchOutcome.Fail(why);
 
-        // (4) The write — touched-record verify forced ON (the model-C substitute for the dropped whole-plugin floor).
+        // (4) The write â€” touched-record verify forced ON (the model-C substitute for the dropped whole-plugin floor).
         var outcome = WritePatchBuilder.ApplyInPlace(resolver, rulebook, edits, targetPath, targetName, fullReadback: true);
 
         // (5) On success, stamp the distinct audit marker + auto-flag a now-stale .seq (both best-effort; neither miss
         //     fails the done edit, Q3-noted). SEQ flag (Track C): an in-place edit can prune a master and shift the own
-        //     records' on-disk FormIDs, staling the plugin's .seq — surfaced as a note, never auto-regen'd (Aaron 2026-07-04).
+        //     records' on-disk FormIDs, staling the plugin's .seq â€” surfaced as a note, never auto-regen'd (Aaron 2026-07-04).
         if (outcome.Success)
         {
             var markerNote = MergeEditedInPlaceMarker(Path.GetDirectoryName(targetPath));
@@ -1269,16 +1269,16 @@ public sealed class LoadOrderService : IDisposable
         }
         else if (ackNote is not null)
         {
-            // The acknowledgement was recorded but the write then failed — keep the (now-honest) note alongside the error.
+            // The acknowledgement was recorded but the write then failed â€” keep the (now-honest) note alongside the error.
             return outcome with { Note = ackNote };
         }
         return outcome;
     }
 
-    /// <summary>Resolve an ACTIVE plugin's on-disk path by filename (in-place write lane) — exact match first, then a
-    /// lenient retry appending each plugin extension if the caller dropped it (e.g. 'CoolWeapons' → 'CoolWeapons.esp').
-    /// <paramref name="resolvedName"/> echoes the canonical filename that matched. Null ⇒ no such active plugin (the
-    /// caller refuses loud). The path is the load order's WINNING path for that filename — the file the game loads.</summary>
+    /// <summary>Resolve an ACTIVE plugin's on-disk path by filename (in-place write lane) â€” exact match first, then a
+    /// lenient retry appending each plugin extension if the caller dropped it (e.g. 'CoolWeapons' â†’ 'CoolWeapons.esp').
+    /// <paramref name="resolvedName"/> echoes the canonical filename that matched. Null â‡’ no such active plugin (the
+    /// caller refuses loud). The path is the load order's WINNING path for that filename â€” the file the game loads.</summary>
     static string? ResolveActivePluginPath(LoadOrderResolver.IndexView view, string raw, out string resolvedName)
     {
         resolvedName = raw;
@@ -1299,17 +1299,17 @@ public sealed class LoadOrderService : IDisposable
     /// xEdit/CK do on save with the touched records VERIFIED and Mutagen trusted for the rest, and the default new-patch
     /// lane stays recommended. Waives the CONSENT axis only (re-call with acknowledge=true).</summary>
     static string InPlaceHandshakeText(string pluginName, string path) =>
-        $"in-place edit of '{pluginName}' — first-time confirmation (shown once for this plugin):\n" +
-        $"  • This writes to your ORIGINAL file ({path}). It will NO LONGER be untouched, and houseCARL keeps NO backup or undo — keep your own.\n" +
-        "  • houseCARL re-lays-out the WHOLE plugin the way xEdit/CK do on save (every record re-serialized), VERIFIES the records you edit, and trusts Mutagen for the rest.\n" +
-        "  • It still refuses if the file can't be parsed, or carries engine-reserved (sub-0x800) records.\n" +
-        "  • The default lane (a NEW patch, originals untouched) stays the recommended way — this is the explicit opt-in.\n" +
+        $"in-place edit of '{pluginName}' â€” first-time confirmation (shown once for this plugin):\n" +
+        $"  â€¢ This writes to your ORIGINAL file ({path}). It will NO LONGER be untouched, and houseCARL keeps NO backup or undo â€” keep your own.\n" +
+        "  â€¢ houseCARL re-lays-out the WHOLE plugin the way xEdit/CK do on save (every record re-serialized), VERIFIES the records you edit, and trusts Mutagen for the rest.\n" +
+        "  â€¢ It still refuses if the file can't be parsed, or carries engine-reserved (sub-0x800) records.\n" +
+        "  â€¢ The default lane (a NEW patch, originals untouched) stays the recommended way â€” this is the explicit opt-in.\n" +
         "Re-call the SAME edit with acknowledge=true to proceed.";
 
-    /// <summary>Writable-parent pre-flight for the in-place swap (§6 layer 3): the staged temp is a sibling of the
+    /// <summary>Writable-parent pre-flight for the in-place swap (Â§6 layer 3): the staged temp is a sibling of the
     /// target, so prove the parent is writable NOW, loud, rather than degrade to a non-atomic write later. True (with a
-    /// named <paramref name="why"/>) ⇒ refuse. Probes by writing + deleting an empty sibling temp. This checks the PARENT
-    /// is writable — NOT that the target file isn't EXTERNALLY locked (MO2/xEdit mid-operation); that case isn't
+    /// named <paramref name="why"/>) â‡’ refuse. Probes by writing + deleting an empty sibling temp. This checks the PARENT
+    /// is writable â€” NOT that the target file isn't EXTERNALLY locked (MO2/xEdit mid-operation); that case isn't
     /// pre-empted here but surfaces LOUD at the <c>File.Replace</c> swap with the original byte-intact (the correct Q3
     /// outcome, not a corruption path), so it needs no separate pre-flight.</summary>
     static bool InPlaceParentUnwritable(string targetPath, out string why)
@@ -1318,7 +1318,7 @@ public sealed class LoadOrderService : IDisposable
         var dir = Path.GetDirectoryName(targetPath);
         if (string.IsNullOrEmpty(dir) || !Directory.Exists(dir))
         {
-            why = $"in-place refused: the target's parent folder '{dir}' does not exist — nothing written.";
+            why = $"in-place refused: the target's parent folder '{dir}' does not exist â€” nothing written.";
             return true;
         }
         try
@@ -1330,16 +1330,16 @@ public sealed class LoadOrderService : IDisposable
         }
         catch (Exception ex)
         {
-            why = $"in-place refused: the target's folder '{dir}' is not writable ({ex.GetType().Name}: {ex.Message}) — houseCARL " +
+            why = $"in-place refused: the target's folder '{dir}' is not writable ({ex.GetType().Name}: {ex.Message}) â€” houseCARL " +
                   "won't degrade to a non-atomic write. Make the mod folder writable (or move the plugin somewhere writable) and retry. Nothing written.";
             return true;
         }
     }
 
     /// <summary>Stamp the distinct <c>[houseCARL] editedInPlace=&lt;ISO&gt;</c> audit line into the target mod's
-    /// <c>meta.ini</c> (the MO2-undeployed mod-root file) — a breadcrumb that houseCARL touched this user mod, WITHOUT
+    /// <c>meta.ini</c> (the MO2-undeployed mod-root file) â€” a breadcrumb that houseCARL touched this user mod, WITHOUT
     /// ever writing <c>generated=true</c> (so <see cref="IsHouseCarlOwned"/> still reads FALSE and a later into= can't
-    /// blind-overwrite it — the safety property). PRESERVES every existing line (merges into / creates the
+    /// blind-overwrite it â€” the safety property). PRESERVES every existing line (merges into / creates the
     /// <c>[houseCARL]</c> section), and only for an MO2 mod folder under ModsDir (never pollutes the game Data dir for a
     /// loose plugin). Best-effort: returns a Q3 note on failure (the edit already succeeded), null on success or N/A.</summary>
     string? MergeEditedInPlaceMarker(string? modFolder)
@@ -1364,7 +1364,7 @@ public sealed class LoadOrderService : IDisposable
                 for (int i = sec + 1; i < lines.Count; i++)
                 {
                     var t = lines[i].Trim();
-                    if (t.StartsWith('[') && t.EndsWith(']')) break;                          // next section — stop
+                    if (t.StartsWith('[') && t.EndsWith(']')) break;                          // next section â€” stop
                     if (t.Replace(" ", "").StartsWith("editedInPlace=", StringComparison.OrdinalIgnoreCase)) { edited = i; break; }
                 }
                 if (edited >= 0) lines[edited] = stamp; else lines.Insert(sec + 1, stamp);    // update-or-insert within the section
@@ -1374,11 +1374,11 @@ public sealed class LoadOrderService : IDisposable
         }
         catch (Exception ex)
         {
-            return $"the editedInPlace audit marker could not be written to the target's meta.ini ({ex.GetType().Name}) — the edit itself succeeded.";
+            return $"the editedInPlace audit marker could not be written to the target's meta.ini ({ex.GetType().Name}) â€” the edit itself succeeded.";
         }
     }
 
-    /// <summary>True iff <paramref name="folder"/> is ModsDir itself or a folder directly/indirectly under it — the gate
+    /// <summary>True iff <paramref name="folder"/> is ModsDir itself or a folder directly/indirectly under it â€” the gate
     /// that keeps the editedInPlace marker out of the game Data dir for a loose (non-MO2-managed) in-place target.</summary>
     bool IsUnderModsDir(string folder)
     {
@@ -1402,16 +1402,16 @@ public sealed class LoadOrderService : IDisposable
         return present.Length == 0 ? null : string.Join(" ", present);
     }
 
-    /// <summary>The in-place SEQ auto-flag (Track C / Heisen §3 gap-4, Aaron 2026-07-04: FLAG, never auto-regen). After an
+    /// <summary>The in-place SEQ auto-flag (Track C / Heisen Â§3 gap-4, Aaron 2026-07-04: FLAG, never auto-regen). After an
     /// in-place write that re-serialized <paramref name="targetPath"/>, a master-prune may have shifted every own record's
-    /// on-disk FormID and staled the plugin's <c>.seq</c> — its Start-Game-Enabled quests would then silently never start
+    /// on-disk FormID and staled the plugin's <c>.seq</c> â€” its Start-Game-Enabled quests would then silently never start
     /// on a fresh save. Resolve the plugin's <c>.seq</c> through the SAME captured VFS view the compact SEQ gate uses
-    /// (loose roots + active BSAs — not a bare folder check, which would miss a <c>write_seq</c>-filed or BSA-packed .seq),
+    /// (loose roots + active BSAs â€” not a bare folder check, which would miss a <c>write_seq</c>-filed or BSA-packed .seq),
     /// and if a LOOSE <c>.seq</c> exists but no longer lists one or more SGE quests at their CURRENT on-disk FormIDs,
     /// return a WARNING naming them + the fix (<c>housecarl_write_seq</c>). Null when there's nothing to flag (no .seq, a
-    /// BSA-only .seq whose bytes we can't check here, or every SGE quest still covered — an ordinary in-place edit that
+    /// BSA-only .seq whose bytes we can't check here, or every SGE quest still covered â€” an ordinary in-place edit that
     /// changed no masters leaves the FormIDs put, so a previously-valid .seq stays covered and this stays quiet). BEST-
-    /// EFFORT (Q3): any failure yields a soft advisory, never a throw — the write already succeeded, and a freshness check
+    /// EFFORT (Q3): any failure yields a soft advisory, never a throw â€” the write already succeeded, and a freshness check
     /// that couldn't run must not fail the done edit, but it says so rather than going silent.</summary>
     string? SeqStaleInPlaceNote(string targetPath, string targetName)
     {
@@ -1422,9 +1422,9 @@ public sealed class LoadOrderService : IDisposable
             var av = assetResolver.Capture();
             var seqRel = $@"SEQ\{Path.GetFileNameWithoutExtension(targetPath)}.seq";
             var seqSource = av.ResolveForPlacement(seqRel).Sources.FirstOrDefault();
-            if (seqSource?.LooseFilePath is not { } seqPath) return null;      // no .seq, or a BSA-only one (bytes uncheckable here) → nothing to flag
+            if (seqSource?.LooseFilePath is not { } seqPath) return null;      // no .seq, or a BSA-only one (bytes uncheckable here) â†’ nothing to flag
             var uncovered = SeqFile.UncoveredSgeQuests(targetPath, File.ReadAllBytes(seqPath));
-            if (uncovered.Count == 0) return null;                            // the .seq still lists every SGE quest → not staled
+            if (uncovered.Count == 0) return null;                            // the .seq still lists every SGE quest â†’ not staled
             var names = string.Join(", ", uncovered.Select(q => q.EditorId ?? q.FormKey.ToString()));
             bool one = uncovered.Count == 1;
             return $"the .seq for '{targetName}' no longer lists {(one ? "its start-game-enabled quest" : $"{uncovered.Count} of its start-game-enabled quests")} "
@@ -1433,33 +1433,33 @@ public sealed class LoadOrderService : IDisposable
         }
         catch (Exception ex)
         {
-            return $"could not check whether '{targetName}'s .seq is still current after this edit ({ex.GetType().Name}) — "
+            return $"could not check whether '{targetName}'s .seq is still current after this edit ({ex.GetType().Name}) â€” "
                  + "if it has start-game-enabled quests, run housecarl_validate_dialogue on the quest to confirm the .seq still lists them.";
         }
     }
 
-    /// <summary>Remove WHOLE records a houseCARL patch carries (housecarl_remove_record) — literal drop-from-plugin, the
+    /// <summary>Remove WHOLE records a houseCARL patch carries (housecarl_remove_record) â€” literal drop-from-plugin, the
     /// companion to <see cref="ApplyEdits"/>. In the DEFAULT lane <paramref name="patch"/> is REQUIRED and names an existing
-    /// houseCARL-owned patch (resolved + ownership-gated via the same <c>into=</c> path as an extend — refuses a folder
+    /// houseCARL-owned patch (resolved + ownership-gated via the same <c>into=</c> path as an extend â€” refuses a folder
     /// houseCARL didn't create, Q3); removal only makes sense against a patch that already carries the record. In the
     /// IN-PLACE lane (Wave 2: <paramref name="target"/> + <paramref name="inPlace"/>) it drops the record from an EXISTING
-    /// plugin in place (incl. one houseCARL didn't author) instead — see <see cref="RemoveRecordsInPlace"/>. Parses every
+    /// plugin in place (incl. one houseCARL didn't author) instead â€” see <see cref="RemoveRecordsInPlace"/>. Parses every
     /// formid (all-or-nothing on a malformed one), then drives <see cref="WritePatchBuilder.RemoveRecords"/> (present-check
-    /// → mod.Remove → re-serialize, with clean-masters riding along). The default lane never touches originals (only the
+    /// â†’ mod.Remove â†’ re-serialize, with clean-masters riding along). The default lane never touches originals (only the
     /// patch folder is written).</summary>
     public WritePatchBuilder.RemovalOutcome RemoveRecords(IReadOnlyList<string> formids, string? patch,
         string? target = null, bool inPlace = false, bool acknowledge = false)
     {
         if (formids is null || formids.Count == 0)
-            return WritePatchBuilder.RemovalOutcome.Fail("no formids supplied — pass the FormID(s) of the record(s) to remove.");
+            return WritePatchBuilder.RemovalOutcome.Fail("no formids supplied â€” pass the FormID(s) of the record(s) to remove.");
 
-        // In-place is the explicit, named-file opt-in (the SECOND remove lane — drop a record from an EXISTING plugin, incl.
+        // In-place is the explicit, named-file opt-in (the SECOND remove lane â€” drop a record from an EXISTING plugin, incl.
         // one houseCARL didn't author, instead of from a houseCARL patch). Validate the contract up front (Q3): it REQUIRES
         // a target=, and it is mutually exclusive with patch= (the houseCARL-owned lane). target= without in_place is a
-        // no-op the caller likely didn't mean — name it rather than silently ignore it. (Mirrors ApplyEdits' contract.)
+        // no-op the caller likely didn't mean â€” name it rather than silently ignore it. (Mirrors ApplyEdits' contract.)
         if (inPlace && string.IsNullOrWhiteSpace(target))
             return WritePatchBuilder.RemovalOutcome.Fail(
-                "in_place=true requires target=<plugin filename> — name the existing plugin to remove the record from in place. (Omit in_place to drop the record from a houseCARL patch instead — the default.)");
+                "in_place=true requires target=<plugin filename> â€” name the existing plugin to remove the record from in place. (Omit in_place to drop the record from a houseCARL patch instead â€” the default.)");
         if (inPlace && !string.IsNullOrWhiteSpace(patch))
             return WritePatchBuilder.RemovalOutcome.Fail(
                 "in_place=true and patch= are mutually exclusive: patch= drops a record from a houseCARL patch, while in_place removes it from an existing plugin in place. Use one lane or the other.");
@@ -1468,9 +1468,9 @@ public sealed class LoadOrderService : IDisposable
                 "target= is only meaningful with in_place=true (it names the plugin to remove from in place). For the default lane omit target=; use patch= to name the houseCARL patch.");
         if (!inPlace && string.IsNullOrWhiteSpace(patch))
             return WritePatchBuilder.RemovalOutcome.Fail(
-                "patch is required — name the houseCARL patch to remove the record from (removal only targets a patch that already carries it). To remove from an existing plugin IN PLACE instead, pass target=<plugin filename> + in_place=true.");
+                "patch is required â€” name the houseCARL patch to remove the record from (removal only targets a patch that already carries it). To remove from an existing plugin IN PLACE instead, pass target=<plugin filename> + in_place=true.");
 
-        // Parse every formid first, collecting ALL problems (all-or-nothing, like the edit path). Pure — outside the gate.
+        // Parse every formid first, collecting ALL problems (all-or-nothing, like the edit path). Pure â€” outside the gate.
         var keys = new List<FormKey>(formids.Count);
         var problems = new List<string>();
         for (int i = 0; i < formids.Count; i++)
@@ -1482,16 +1482,16 @@ public sealed class LoadOrderService : IDisposable
         }
         if (problems.Count > 0)
             return WritePatchBuilder.RemovalOutcome.Fail(
-                $"refused — {problems.Count} of {formids.Count} formid(s) malformed; NOTHING removed:\n  - " + string.Join("\n  - ", problems));
+                $"refused â€” {problems.Count} of {formids.Count} formid(s) malformed; NOTHING removed:\n  - " + string.Join("\n  - ", problems));
 
-        lock (_writeGate)                                                 // hunt F2: removal re-serializes the patch — same gate
+        lock (_writeGate)                                                 // hunt F2: removal re-serializes the patch â€” same gate
         {
             var resolver = Resolver;                                      // builds/refreshes the index (Overlays for the re-serialize)
 
             if (inPlace)
                 return RemoveRecordsInPlace(resolver, keys, target!.Trim(), acknowledge);
 
-            // Resolve + ownership-gate the patch path via the into= (extend) path — must exist + carry the houseCARL marker.
+            // Resolve + ownership-gate the patch path via the into= (extend) path â€” must exist + carry the houseCARL marker.
             string outPath;
             try { outPath = ResolveOutputPath(patchName: null, into: patch, out _, out _); }
             catch (Exception ex) { return WritePatchBuilder.RemovalOutcome.Fail(ex.Message); }
@@ -1500,16 +1500,16 @@ public sealed class LoadOrderService : IDisposable
         }
     }
 
-    /// <summary>The in-place branch of <see cref="RemoveRecords"/> (in-place write lane, Wave 2) — runs under _writeGate.
+    /// <summary>The in-place branch of <see cref="RemoveRecords"/> (in-place write lane, Wave 2) â€” runs under _writeGate.
     /// The remove counterpart of <see cref="ApplyEditsInPlace"/>, and it REUSES every Wave-1 in-place seam: the same
     /// foreign-target resolver (<see cref="ResolveActivePluginPath"/>), the same PERSISTENT first-touch CONSENT handshake
-    /// (keyed off the resolved path in <see cref="UserConfigStore"/>, SHARED with the edit + create lanes — acknowledging a
+    /// (keyed off the resolved path in <see cref="UserConfigStore"/>, SHARED with the edit + create lanes â€” acknowledging a
     /// plugin once covers all three), the same writable-parent pre-flight, and the same distinct <c>editedInPlace=</c>
-    /// marker (NEVER <c>generated=true</c> — the user mod keeps failing <see cref="IsHouseCarlOwned"/> so a later into=
+    /// marker (NEVER <c>generated=true</c> â€” the user mod keeps failing <see cref="IsHouseCarlOwned"/> so a later into=
     /// can't blind-overwrite it). It drives <see cref="WritePatchBuilder.RemoveRecordsInPlace"/> (drop the record from the
-    /// target's OWN file, with the absence verify forced ON). <paramref name="acknowledge"/> waives the CONSENT axis ONLY —
+    /// target's OWN file, with the absence verify forced ON). <paramref name="acknowledge"/> waives the CONSENT axis ONLY â€”
     /// the verify is a corruption-axis fact no acknowledgement overrides. (No CorpusRulebook: a removal pre-flights nothing
-    /// — the present-check that the target carries the record is the whole gate.)</summary>
+    /// â€” the present-check that the target carries the record is the whole gate.)</summary>
     WritePatchBuilder.RemovalOutcome RemoveRecordsInPlace(
         LoadOrderResolver resolver, IReadOnlyList<FormKey> keys, string target, bool acknowledge)
     {
@@ -1519,12 +1519,12 @@ public sealed class LoadOrderService : IDisposable
         var targetPath = ResolveActivePluginPath(view, Path.GetFileName(target.Trim()), out var targetName);
         if (targetPath is null)
             return WritePatchBuilder.RemovalOutcome.Fail(
-                $"in-place target '{target}' is not an active plugin in the load order — name a plugin enabled in MO2, by its " +
+                $"in-place target '{target}' is not an active plugin in the load order â€” name a plugin enabled in MO2, by its " +
                 "plugin filename (e.g. 'CoolWeapons.esp'). in-place removes from the file the game actually loads. Nothing was written.");
 
-        // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path (shared
+        // (2) CONSENT axis â€” the persistent, server-enforced first-touch handshake, keyed off the resolved path (shared
         //     with the edit + create lanes: acknowledging a plugin once covers editing, creating into, AND removing from
-        //     it in place — it's the same "touch your original" trade-off).
+        //     it in place â€” it's the same "touch your original" trade-off).
         bool already = _store.IsInPlaceAcknowledged(targetPath);
         if (!already && !acknowledge)
             return WritePatchBuilder.RemovalOutcome.NeedsAck(InPlaceHandshakeText(targetName, targetPath));
@@ -1532,19 +1532,19 @@ public sealed class LoadOrderService : IDisposable
         if (!already && acknowledge)
         {
             var (ok, err) = _store.RecordInPlaceAcknowledged(targetPath);
-            if (!ok) ackNote = $"the in-place acknowledgement could not be saved ({err}) — the removal proceeded, but a future session will re-prompt for this plugin.";
+            if (!ok) ackNote = $"the in-place acknowledgement could not be saved ({err}) â€” the removal proceeded, but a future session will re-prompt for this plugin.";
         }
 
-        // (3) Writable, same-volume parent pre-flight — refuse rather than degrade (the swap stages a sibling temp here).
+        // (3) Writable, same-volume parent pre-flight â€” refuse rather than degrade (the swap stages a sibling temp here).
         if (InPlaceParentUnwritable(targetPath, out var why))
             return WritePatchBuilder.RemovalOutcome.Fail(why);
 
-        // (4) The write — absence verify forced ON (the model-C substitute for the dropped whole-plugin floor).
+        // (4) The write â€” absence verify forced ON (the model-C substitute for the dropped whole-plugin floor).
         var outcome = WritePatchBuilder.RemoveRecordsInPlace(resolver, keys, targetPath, targetName);
 
         // (5) On success, stamp the distinct audit marker + auto-flag a now-stale .seq (both best-effort; neither miss
         //     fails the done removal, Q3-noted). SEQ flag (Track C): a removal can drop the last reference to a master
-        //     (a prune) and shift on-disk FormIDs, staling the plugin's .seq — surfaced, never auto-regenerated.
+        //     (a prune) and shift on-disk FormIDs, staling the plugin's .seq â€” surfaced, never auto-regenerated.
         if (outcome.Success)
         {
             var markerNote = MergeEditedInPlaceMarker(Path.GetDirectoryName(targetPath));
@@ -1554,28 +1554,28 @@ public sealed class LoadOrderService : IDisposable
         }
         else if (ackNote is not null)
         {
-            // The acknowledgement was recorded but the write then failed — keep the (now-honest) note alongside the error.
+            // The acknowledgement was recorded but the write then failed â€” keep the (now-honest) note alongside the error.
             return outcome with { Note = ackNote };
         }
         return outcome;
     }
 
     /// <summary>Forward a NAMED plugin's version of one-or-more records into a patch as an override (housecarl_forward_record)
-    /// — xEdit's "copy as override into", the inverse of <see cref="ApplyEdits"/>'s winner-override. Parses every formid
+    /// â€” xEdit's "copy as override into", the inverse of <see cref="ApplyEdits"/>'s winner-override. Parses every formid
     /// (all-or-nothing on a malformed one), resolves the folder-per-patch output (fresh, or <paramref name="into"/> an
     /// existing houseCARL-owned patch), then drives <see cref="WritePatchBuilder.ForwardRecords"/> (resolve each source
-    /// body from <paramref name="fromPlugin"/> → deep-copy as override → multi-master serialize). The whole source record
-    /// is copied verbatim, so the SOURCE plugin (not the load-order winner) decides the content — and forwarding the
+    /// body from <paramref name="fromPlugin"/> â†’ deep-copy as override â†’ multi-master serialize). The whole source record
+    /// is copied verbatim, so the SOURCE plugin (not the load-order winner) decides the content â€” and forwarding the
     /// ORIGIN master reverts a record to vanilla. Originals are never touched (only the patch folder is written).</summary>
     public WritePatchBuilder.ForwardOutcome ForwardRecords(IReadOnlyList<string> formids, string fromPlugin, string? patchName, string? into, bool fullReadback = false)
     {
         if (string.IsNullOrWhiteSpace(fromPlugin))
             return WritePatchBuilder.ForwardOutcome.Fail(
-                "from_plugin is required — name the plugin whose version of the record(s) to forward (the earlier override, or a master to revert to vanilla).");
+                "from_plugin is required â€” name the plugin whose version of the record(s) to forward (the earlier override, or a master to revert to vanilla).");
         if (formids is null || formids.Count == 0)
-            return WritePatchBuilder.ForwardOutcome.Fail("no formids supplied — pass the FormID(s) to forward from the source plugin.");
+            return WritePatchBuilder.ForwardOutcome.Fail("no formids supplied â€” pass the FormID(s) to forward from the source plugin.");
 
-        // Parse every formid first, collecting ALL problems (all-or-nothing, like the edit/remove paths). Pure — outside the gate.
+        // Parse every formid first, collecting ALL problems (all-or-nothing, like the edit/remove paths). Pure â€” outside the gate.
         var fp = fromPlugin.Trim();
         var specs = new List<WritePatchBuilder.ForwardSpec>(formids.Count);
         var problems = new List<string>();
@@ -1588,9 +1588,9 @@ public sealed class LoadOrderService : IDisposable
         }
         if (problems.Count > 0)
             return WritePatchBuilder.ForwardOutcome.Fail(
-                $"refused — {problems.Count} of {formids.Count} formid(s) malformed; NOTHING forwarded:\n  - " + string.Join("\n  - ", problems));
+                $"refused â€” {problems.Count} of {formids.Count} formid(s) malformed; NOTHING forwarded:\n  - " + string.Join("\n  - ", problems));
 
-        lock (_writeGate)                                                 // hunt F2: one write at a time, resolve→commit
+        lock (_writeGate)                                                 // hunt F2: one write at a time, resolveâ†’commit
         {
             var resolver = Resolver;                                      // builds/refreshes the index (Overlays for the source fetch + serialize)
 
@@ -1604,11 +1604,11 @@ public sealed class LoadOrderService : IDisposable
         }
     }
 
-    /// <summary>Create an EMPTY, HEADER-ONLY plugin (housecarl_create_plugin) — a valid TES4 header with ZERO records,
+    /// <summary>Create an EMPTY, HEADER-ONLY plugin (housecarl_create_plugin) â€” a valid TES4 header with ZERO records,
     /// no masters, optionally ESL-flagged, named EXACTLY <paramref name="pluginName"/>. The clean primitive for "I need
-    /// plugin <c>Foo.esp</c> to exist" (a basename-bound SKSE config trigger, a placeholder ESL, a dummy master) — it
+    /// plugin <c>Foo.esp</c> to exist" (a basename-bound SKSE config trigger, a placeholder ESL, a dummy master) â€” it
     /// authors no record, so it adds no conflict footprint (HCBR-2026-06-19-02). UNLIKE the patch-write paths, the name
-    /// is used VERBATIM — never auto-suffixed — because a trigger plugin's whole job is that its basename matches the
+    /// is used VERBATIM â€” never auto-suffixed â€” because a trigger plugin's whole job is that its basename matches the
     /// config bound to it; so a name collision REFUSES loud (Q3) rather than rename or overwrite: (a) a plugin of that
     /// basename already active in the order (creating another would shadow it), or (b) a houseCARL mod folder of that
     /// name already on disk. The core <see cref="WritePatchBuilder.CreatePlugin"/> builds + serializes + re-reads to
@@ -1617,14 +1617,14 @@ public sealed class LoadOrderService : IDisposable
     {
         if (string.IsNullOrWhiteSpace(pluginName))
             return WritePatchBuilder.CreatePluginOutcome.Fail(
-                "plugin_name is required — a header-only plugin has no record to derive a name from, so name it explicitly (e.g. 'Authoria - CraftingCategories').");
+                "plugin_name is required â€” a header-only plugin has no record to derive a name from, so name it explicitly (e.g. 'Authoria - CraftingCategories').");
 
         var stem = PatchStem(pluginName);
         if (string.IsNullOrWhiteSpace(stem))
             return WritePatchBuilder.CreatePluginOutcome.Fail(
-                $"plugin_name '{pluginName}' has no usable name once path parts and the plugin extension are stripped — give a plain name like 'MyTrigger'.");
+                $"plugin_name '{pluginName}' has no usable name once path parts and the plugin extension are stripped â€” give a plain name like 'MyTrigger'.");
 
-        lock (_writeGate)                                                 // hunt F2: one write at a time, resolve→commit
+        lock (_writeGate)                                                 // hunt F2: one write at a time, resolveâ†’commit
         {
             // Touch Resolver FIRST: in instance mode _modsDir is derived LAZILY (EnsurePathsDerived runs inside the
             // Resolver getter), so a cold first-call (create_plugin before any read warmed the index) would otherwise
@@ -1634,18 +1634,18 @@ public sealed class LoadOrderService : IDisposable
             if (!Directory.Exists(_modsDir))
                 return WritePatchBuilder.CreatePluginOutcome.Fail($"cannot write: ModsDir '{_modsDir}' does not exist. Check HouseCarl:ModsDir.");
 
-            // COLLISION (Q3): the basename is load-bearing for a trigger, so NEVER auto-suffix — refuse loud instead.
-            // (a) an active plugin already owns this basename — a second one would shadow it (MO2 picks one by mod order).
+            // COLLISION (Q3): the basename is load-bearing for a trigger, so NEVER auto-suffix â€” refuse loud instead.
+            // (a) an active plugin already owns this basename â€” a second one would shadow it (MO2 picks one by mod order).
             foreach (var ext in PluginExts)                              // .esp / .esm / .esl
                 if (view.ContainsPlugin(stem + ext))
                     return WritePatchBuilder.CreatePluginOutcome.Fail(
-                        $"a plugin named '{stem + ext}' is already active in your load order — a header-only trigger needs a UNIQUE basename (a second one would shadow it, MO2 picking the winner by mod order). Choose a different name.");
-            // (b) a houseCARL mod folder of this exact name already exists — don't overwrite (could clobber a real patch
+                        $"a plugin named '{stem + ext}' is already active in your load order â€” a header-only trigger needs a UNIQUE basename (a second one would shadow it, MO2 picking the winner by mod order). Choose a different name.");
+            // (b) a houseCARL mod folder of this exact name already exists â€” don't overwrite (could clobber a real patch
             //     sharing the name) and don't auto-rename (would break the basename trigger): refuse and point at it.
             var folder = Path.Combine(_modsDir, ModFolderName(stem));
             if (Directory.Exists(folder))
                 return WritePatchBuilder.CreatePluginOutcome.Fail(
-                    $"a houseCARL output folder '{ModFolderName(stem)}' already exists — houseCARL won't auto-rename a header-only plugin (its exact basename is what makes the trigger resolve). Remove that folder in MO2, or choose a different name.");
+                    $"a houseCARL output folder '{ModFolderName(stem)}' already exists â€” houseCARL won't auto-rename a header-only plugin (its exact basename is what makes the trigger resolve). Remove that folder in MO2, or choose a different name.");
 
             Directory.CreateDirectory(folder);
             var plugin = stem + ".esp";
@@ -1658,35 +1658,35 @@ public sealed class LoadOrderService : IDisposable
         }
     }
 
-    /// <summary>COMPACT / ESL-renumber a plugin (housecarl_compact_plugin, A2) — the data-layer twin of xEdit's "Compact
-    /// FormIDs for ESL". Renumbers <paramref name="pluginName"/>'s ORIGINATING records (flat AND nested — cells, placed
-    /// refs, dialog INFOs) into the light range 0x800–0xFFF (the 2048-ID window; <paramref name="esl"/>=false renumbers
+    /// <summary>COMPACT / ESL-renumber a plugin (housecarl_compact_plugin, A2) â€” the data-layer twin of xEdit's "Compact
+    /// FormIDs for ESL". Renumbers <paramref name="pluginName"/>'s ORIGINATING records (flat AND nested â€” cells, placed
+    /// refs, dialog INFOs) into the light range 0x800â€“0xFFF (the 2048-ID window; <paramref name="esl"/>=false renumbers
     /// contiguously without the light flag / ceiling), repoints every internal reference, keeps overrides at their master
-    /// FormIDs, and emits the result. Output model (Aaron 2026-06-26): a NEW plugin P′ keeping the source's EXACT basename
-    /// (so external masters still resolve) in a fresh houseCARL mod folder by default — original UNTOUCHED, reviewable in
+    /// FormIDs, and emits the result. Output model (Aaron 2026-06-26): a NEW plugin Pâ€² keeping the source's EXACT basename
+    /// (so external masters still resolve) in a fresh houseCARL mod folder by default â€” original UNTOUCHED, reviewable in
     /// xEdit before you swap; <paramref name="inPlace"/>=true overwrites the original instead (the xEdit norm; rides the
     /// in-place consent, no backup).
     ///
-    /// <para>The load-bearing safety (Q3, plan §2): renumbering breaks any reference from OUTSIDE the plugin (they'd point
+    /// <para>The load-bearing safety (Q3, plan Â§2): renumbering breaks any reference from OUTSIDE the plugin (they'd point
     /// at FormIDs that no longer exist). The identify-pass finds those external referencers across the whole order. NO
-    /// external referencers ⇒ the clean default path (emit P′, done). External referencers present ⇒ REFUSED LOUD with the
+    /// external referencers â‡’ the clean default path (emit Pâ€², done). External referencers present â‡’ REFUSED LOUD with the
     /// list, UNLESS <paramref name="repointExternals"/>=true, which ALSO rewrites each of them in place to follow the
     /// renumber. Any in-place overwrite (the target in the in-place lane, and/or the external referencers) requires
-    /// <paramref name="acknowledge"/>=true — a first call without it returns a CONFIRM prompt listing exactly what will be
+    /// <paramref name="acknowledge"/>=true â€” a first call without it returns a CONFIRM prompt listing exactly what will be
     /// rewritten (never a silent original-file edit).</para>
     ///
     /// <para>Refuses loud + writes nothing on: the plugin not active / excluded (unparseable) / not on disk; MORE than the
-    /// light window holds (the hard ESL ceiling — named, never truncated); a declared master not active; a serialize fault.
+    /// light window holds (the hard ESL ceiling â€” named, never truncated); a declared master not active; a serialize fault.
     /// Renumber mechanism + nested coverage: <see cref="RemapEngine.RenumberModInto"/> (remap-wave1/2). Serialized on the
-    /// write gate; the identify-pass is one whole-order link walk (~25s at full scale — a deliberate, one-shot operation).</para></summary>
+    /// write gate; the identify-pass is one whole-order link walk (~25s at full scale â€” a deliberate, one-shot operation).</para></summary>
     public WritePatchBuilder.CompactOutcome CompactPlugin(
         string pluginName, bool esl = true, bool inPlace = false, bool repointExternals = false,
         bool acknowledge = false, string? patchName = null)
     {
         if (string.IsNullOrWhiteSpace(pluginName))
-            return WritePatchBuilder.CompactOutcome.Fail("plugin is required — name the plugin filename to compact (e.g. 'CoolMod.esp').");
+            return WritePatchBuilder.CompactOutcome.Fail("plugin is required â€” name the plugin filename to compact (e.g. 'CoolMod.esp').");
 
-        lock (_writeGate)                                                 // one write at a time; the whole resolve→build→repoint runs under it
+        lock (_writeGate)                                                 // one write at a time; the whole resolveâ†’buildâ†’repoint runs under it
         {
             var resolver = Resolver;                                      // builds/refreshes; reentrant with _writeGate
             var view = resolver.Capture();
@@ -1696,14 +1696,14 @@ public sealed class LoadOrderService : IDisposable
             var name = pluginName.Trim();
             if (!view.ContainsPlugin(name))
                 return WritePatchBuilder.CompactOutcome.Fail(
-                    $"'{name}' is not an active plugin in your load order — compact targets an active plugin (so its records, and the plugins that reference it, can be read). Pass the exact filename (e.g. 'CoolMod.esp').");
+                    $"'{name}' is not an active plugin in your load order â€” compact targets an active plugin (so its records, and the plugins that reference it, can be read). Pass the exact filename (e.g. 'CoolMod.esp').");
             if (view.ExcludedPlugins.TryGetValue(name, out var excluded))
                 return WritePatchBuilder.CompactOutcome.Fail(
-                    $"cannot compact '{name}': it was EXCLUDED from this session ({excluded}) — houseCARL won't renumber a plugin it can't fully parse. The file is untouched.");
+                    $"cannot compact '{name}': it was EXCLUDED from this session ({excluded}) â€” houseCARL won't renumber a plugin it can't fully parse. The file is untouched.");
 
             var srcPath = view.PluginPath(name);
             if (srcPath is null || !File.Exists(srcPath))
-                return WritePatchBuilder.CompactOutcome.Fail($"'{name}' not found on disk at {srcPath ?? "<unresolved>"} — nothing to compact.");
+                return WritePatchBuilder.CompactOutcome.Fail($"'{name}' not found on disk at {srcPath ?? "<unresolved>"} â€” nothing to compact.");
 
             ModKey modKey;
             try { modKey = ModKey.FromFileName(name); }
@@ -1714,64 +1714,64 @@ public sealed class LoadOrderService : IDisposable
                 return WritePatchBuilder.CompactOutcome.Fail(keyErr!);
             if (keys.Count == 0)
                 return WritePatchBuilder.CompactOutcome.Fail(
-                    $"'{name}' defines no originating records to renumber (it carries only overrides, or is empty) — nothing to compact.");
+                    $"'{name}' defines no originating records to renumber (it carries only overrides, or is empty) â€” nothing to compact.");
 
             uint floor = RemapEngine.EslFloor;
             uint ceiling = esl ? RemapEngine.EslCeiling : FormIdRange.ObjectIdMax;   // light window, or the full 24-bit object-ID range
             var plan = RemapEngine.BuildSequentialRemap(keys, modKey, floor, ceiling);
             if (!plan.Success) return WritePatchBuilder.CompactOutcome.Fail(plan.Error!);
 
-            // 2. identify-pass — which plugins OUTSIDE the target reference a record being renumbered (the break risk).
+            // 2. identify-pass â€” which plugins OUTSIDE the target reference a record being renumbered (the break risk).
             var targets = plan.Dict.Keys.ToHashSet();
             var transformSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { name };
             var id = RemapEngine.IdentifyExternalReferencers(resolver, targets, transformSet);
 
-            // 3. external-referencer policy (Q3 — never silently ship a compaction that dangles an external reference).
+            // 3. external-referencer policy (Q3 â€” never silently ship a compaction that dangles an external reference).
             if (id.HasExternalReferencers)
             {
-                var refList = $"{string.Join(", ", id.ExternalPlugins.Take(25))}{(id.ExternalPlugins.Count > 25 ? $", … (+{id.ExternalPlugins.Count - 25} more)" : "")}";
+                var refList = $"{string.Join(", ", id.ExternalPlugins.Take(25))}{(id.ExternalPlugins.Count > 25 ? $", â€¦ (+{id.ExternalPlugins.Count - 25} more)" : "")}";
                 if (!repointExternals)
                     return WritePatchBuilder.CompactOutcome.Fail(
-                        $"refused — {id.ExternalPlugins.Count} plugin(s) outside '{name}' reference records it is about to renumber; compacting it " +
+                        $"refused â€” {id.ExternalPlugins.Count} plugin(s) outside '{name}' reference records it is about to renumber; compacting it " +
                         $"WOULD BREAK those references (they would point at FormIDs that no longer exist). Referencers: {refList}. " +
                         "Re-run with repoint_externals=true AND in_place=true (+ acknowledge=true) to ALSO rewrite those plugins in place to follow " +
                         "the renumber, or handle them yourself first. Nothing was written.");
                 // repoint is only COHERENT paired with in_place (PR #122 review #1): in the new-file lane the renumbered
-                // records live ONLY in the not-yet-active P′, so repointing the externals now would leave them dangling
-                // against the still-active original until the MO2 swap — and broken if the user rejects P′. Couple them.
+                // records live ONLY in the not-yet-active Pâ€², so repointing the externals now would leave them dangling
+                // against the still-active original until the MO2 swap â€” and broken if the user rejects Pâ€². Couple them.
                 if (!inPlace)
                     return WritePatchBuilder.CompactOutcome.Fail(
-                        $"refused — repoint_externals requires in_place=true. {id.ExternalPlugins.Count} plugin(s) reference records being renumbered " +
-                        $"({refList}); in the new-file lane those records exist ONLY in the not-yet-active P′, so repointing the externals now would leave " +
-                        "them dangling against the still-active original until you complete the MO2 swap (and broken if you reject P′). Either compact IN " +
-                        "PLACE (in_place=true) so the target and its referrers move together, or handle the externals yourself after enabling P′. Nothing was written.");
+                        $"refused â€” repoint_externals requires in_place=true. {id.ExternalPlugins.Count} plugin(s) reference records being renumbered " +
+                        $"({refList}); in the new-file lane those records exist ONLY in the not-yet-active Pâ€², so repointing the externals now would leave " +
+                        "them dangling against the still-active original until you complete the MO2 swap (and broken if you reject Pâ€²). Either compact IN " +
+                        "PLACE (in_place=true) so the target and its referrers move together, or handle the externals yourself after enabling Pâ€². Nothing was written.");
             }
 
-            // 4. consent gate — any in-place overwrite (the target, and/or the external referencers) needs acknowledge=true.
+            // 4. consent gate â€” any in-place overwrite (the target, and/or the external referencers) needs acknowledge=true.
             bool willOverwriteTarget = inPlace;
             bool willRepoint = id.HasExternalReferencers && repointExternals;
             if ((willOverwriteTarget || willRepoint) && !acknowledge)
             {
                 var c = new System.Text.StringBuilder();
-                c.Append("CONFIRM in-place rewrite (your ORIGINAL file(s) will be rewritten — no houseCARL backup or undo; keep your own):\n");
+                c.Append("CONFIRM in-place rewrite (your ORIGINAL file(s) will be rewritten â€” no houseCARL backup or undo; keep your own):\n");
                 if (willOverwriteTarget) c.Append($"  - '{name}' will be OVERWRITTEN in place with its compacted form.\n");
                 if (willRepoint)
                 {
                     c.Append($"  - {id.ExternalPlugins.Count} external referencer(s) will be REWRITTEN in place to repoint to the new FormIDs:\n");
-                    foreach (var pl in id.ExternalPlugins.Take(25)) c.Append($"      · {pl}\n");
-                    if (id.ExternalPlugins.Count > 25) c.Append($"      · … (+{id.ExternalPlugins.Count - 25} more)\n");
+                    foreach (var pl in id.ExternalPlugins.Take(25)) c.Append($"      Â· {pl}\n");
+                    if (id.ExternalPlugins.Count > 25) c.Append($"      Â· â€¦ (+{id.ExternalPlugins.Count - 25} more)\n");
                 }
                 c.Append("Re-call with acknowledge=true to proceed.");
                 return WritePatchBuilder.CompactOutcome.Confirm(c.ToString());
             }
 
-            // pre-flight the in-place target's parent is writable BEFORE any work — the in-place edit lane's layer-3 check,
+            // pre-flight the in-place target's parent is writable BEFORE any work â€” the in-place edit lane's layer-3 check,
             // a nicer early refusal than failing deep in the atomic swap (PR #122 review #2). Each external referencer gets
             // the same guarantee inside RepointInPlace's own all-or-nothing write.
             if (inPlace && InPlaceParentUnwritable(srcPath, out var unwritable))
                 return WritePatchBuilder.CompactOutcome.Fail(unwritable);
 
-            // 5. output location — in-place (overwrite the original) or a NEW file keeping the source's EXACT basename in
+            // 5. output location â€” in-place (overwrite the original) or a NEW file keeping the source's EXACT basename in
             //    a fresh houseCARL mod folder (so its masters still resolve; the user swaps the folder in MO2 to use it).
             string outPath; bool createdFresh = false; RiderFolder rf = default;
             if (inPlace) outPath = srcPath;
@@ -1780,7 +1780,7 @@ public sealed class LoadOrderService : IDisposable
                 try { rf = ResolvePatchModFolder(patchName, null, Path.GetFileNameWithoutExtension(name) + " compacted"); }
                 catch (InvalidOperationException ex) { return WritePatchBuilder.CompactOutcome.Fail(ex.Message); }
                 createdFresh = rf.CreatedFresh;
-                WriteOwnerMeta(rf.ModFolder, name);                       // P′ keeps the source's exact basename
+                WriteOwnerMeta(rf.ModFolder, name);                       // Pâ€² keeps the source's exact basename
                 outPath = Path.Combine(rf.OutputDir, name);
             }
 
@@ -1801,21 +1801,21 @@ public sealed class LoadOrderService : IDisposable
                     repointed.Add(new WritePatchBuilder.RepointReport(ext, rep.Success, rep.Error));
                 }
 
-            // 7b. carry the FormID-keyed assets a renumber moves — FaceGen head mesh/tint (A1) + voice .fuz/.lip (A2). The
+            // 7b. carry the FormID-keyed assets a renumber moves â€” FaceGen head mesh/tint (A1) + voice .fuz/.lip (A2). The
             //     records renumbered, so the asset FILES the engine looks up BY FormID must follow, or a compacted NPC mod
             //     silently dark-faces and a voiced mod goes mute (the gap this research exposed in the shipped tool). ONE
             //     captured asset view feeds both carries AND the 7c SEQ gate, so all three agree on what's in the VFS. Best-
             //     effort + REPORTED (Q3): the records are already written, so an asset we can't carry is a NAMED warning in the
-            //     outcome, never a failure of the compaction — and the asset layer failing to build never fails the compact
-            //     either. outDir = the P′ mod-folder root (the directory holding the plugin) in BOTH lanes (new-file: the
+            //     outcome, never a failure of the compaction â€” and the asset layer failing to build never fails the compact
+            //     either. outDir = the Pâ€² mod-folder root (the directory holding the plugin) in BOTH lanes (new-file: the
             //     fresh folder; in-place: the target's own folder).
-            //   SEQ-gate (for 7c, refresh-only): "did the source SHIP a .seq?" is a VFS question, not a single-folder one — a
+            //   SEQ-gate (for 7c, refresh-only): "did the source SHIP a .seq?" is a VFS question, not a single-folder one â€” a
             //   prior housecarl_write_seq run files the .seq in its OWN houseCARL_SEQ mod folder, and a packed mod ships it in
             //   a BSA. So resolve SEQ\<basename>.seq through the SAME captured view (mirrors the dialogue validator's CheckSeq),
-            //   never a loose File.Exists on the source folder — which would miss both and re-open the silent failure A3 closes.
+            //   never a loose File.Exists on the source folder â€” which would miss both and re-open the silent failure A3 closes.
             AssetRenameOutcome assetRename;
             VoiceCarryOutcome voiceRename;
-            bool? seqGate = null;                                          // the VFS gate result — SET the moment the view resolves, BEFORE the carries
+            bool? seqGate = null;                                          // the VFS gate result â€” SET the moment the view resolves, BEFORE the carries
             var srcSeqRel = $@"SEQ\{Path.GetFileNameWithoutExtension(srcPath)}.seq";
             try
             {
@@ -1830,20 +1830,20 @@ public sealed class LoadOrderService : IDisposable
             catch (Exception ex)
             {
                 assetRename = new AssetRenameOutcome(0, 0, 0,
-                    new[] { $"facegen carry skipped — the asset layer could not be built ({ex.Message}); verify NPC faces in-game." }, false);
+                    new[] { $"facegen carry skipped â€” the asset layer could not be built ({ex.Message}); verify NPC faces in-game." }, false);
                 voiceRename = new VoiceCarryOutcome(0, 0, 0,
-                    new[] { $"voice carry skipped — the asset layer could not be built ({ex.Message}); verify voiced lines in-game." }, false);
+                    new[] { $"voice carry skipped â€” the asset layer could not be built ({ex.Message}); verify voiced lines in-game." }, false);
             }
-            // The gate is the VFS answer whenever the view resolved — even if a LATER carry threw, a carry failure must NOT
-            // downgrade a good gate result (re-review). Only when the view never resolved (seqGate still null — the asset layer
+            // The gate is the VFS answer whenever the view resolved â€” even if a LATER carry threw, a carry failure must NOT
+            // downgrade a good gate result (re-review). Only when the view never resolved (seqGate still null â€” the asset layer
             // couldn't be built) fall back to the loose-only check (degraded, never worse than the pre-fix behavior).
             bool sourceHadSeq = seqGate ?? File.Exists(Path.Combine(Path.GetDirectoryName(srcPath)!, srcSeqRel));
 
             // 7c. REFRESH the start-game-enabled-quest .seq from the RENUMBERED plugin when the source SHIPPED one (the VFS
             //     gate above). A renumber shifts every SGE quest's master-relative on-disk FormID, so a shipped .seq is now
-            //     STALE — its quests would silently never start (the failure SeqFile exists to prevent). REFRESH-ONLY
-            //     (maintainer's call): if the source shipped NO .seq we do NOT invent one (xEdit-compaction parity) —
-            //     RegenerateSeq returns a named advisory. The REGEN itself is off P′ (SeqFile.Build — the write_seq path) and
+            //     STALE â€” its quests would silently never start (the failure SeqFile exists to prevent). REFRESH-ONLY
+            //     (maintainer's call): if the source shipped NO .seq we do NOT invent one (xEdit-compaction parity) â€”
+            //     RegenerateSeq returns a named advisory. The REGEN itself is off Pâ€² (SeqFile.Build â€” the write_seq path) and
             //     needs no resolver; only the gate consults the view. Best-effort + REPORTED (Q3): RegenerateSeq never throws
             //     and never fails the compact; the outer guard is belt-and-suspenders.
             SeqRegenOutcome seqRegen;
@@ -1851,16 +1851,16 @@ public sealed class LoadOrderService : IDisposable
             catch (Exception ex)
             {
                 seqRegen = new SeqRegenOutcome(0, false, null,
-                    new[] { $"SEQ regenerate skipped ({ex.Message}) — if '{name}' has start-game-enabled quests, run housecarl_write_seq on the compacted plugin." });
+                    new[] { $"SEQ regenerate skipped ({ex.Message}) â€” if '{name}' has start-game-enabled quests, run housecarl_write_seq on the compacted plugin." });
             }
 
             // 8. audit markers (PR #122 review #2): stamp the distinct editedInPlace= breadcrumb into the meta.ini of EVERY
-            //    file rewritten IN PLACE — the target (in-place lane) + each successfully repointed external — matching the
+            //    file rewritten IN PLACE â€” the target (in-place lane) + each successfully repointed external â€” matching the
             //    traceability the in-place EDIT lane gives. The CONSENT model deliberately stays compact's own per-call
             //    confirm (NOT the persistent _store ack the edit lane uses): a compaction can rewrite a broad surface (the
             //    target + N externals), so each one re-confirms with its exact overwrite list rather than letting a stale
             //    field-edit ack silently authorize a full renumber. Markers are best-effort (a miss never fails the done
-            //    write, Q3) — any miss is surfaced in Note.
+            //    write, Q3) â€” any miss is surfaced in Note.
             var markerNotes = new List<string>();
             if (inPlace) { var n = MergeEditedInPlaceMarker(Path.GetDirectoryName(srcPath)); if (n is not null) markerNotes.Add(n); }
             foreach (var r in repointed.Where(r => r.Success))
@@ -1876,23 +1876,23 @@ public sealed class LoadOrderService : IDisposable
         }
     }
 
-    /// <summary>The composed standalone-NPC-copy verb (housecarl_copy_npc_appearance — capability chain Stage 3).
+    /// <summary>The composed standalone-NPC-copy verb (housecarl_copy_npc_appearance â€” capability chain Stage 3).
     /// Deep-copies a donor NPC's appearance-record subtree into a houseCARL patch under NEW FormKeys (Duplicate +
-    /// RemapLinks — the RemapEngine mechanism, so every field carries by construction: HDPT.Parts morph refs,
+    /// RemapLinks â€” the RemapEngine mechanism, so every field carries by construction: HDPT.Parts morph refs,
     /// TextureLighting, tints), preserves headpart EditorIDs (facegeom block-name identity), renames the facegen
     /// pair to the new key's path, and carries the donor-only textures/meshes the records + geom reference.
     /// TWO TARGET MODES: <paramref name="targetFormid"/> dresses an EXISTING NPC (appearance fields copied onto an
     /// override); <paramref name="newEditorid"/> mints a full standalone CLONE (donor NPC duplicated; every remaining
-    /// donor-internal non-appearance link stripped + reported by name — Q3, the clone is donor-free LOUDLY).
+    /// donor-internal non-appearance link stripped + reported by name â€” Q3, the clone is donor-free LOUDLY).
     /// The donor may be ACTIVE (read via the load-order winner) or sit in a plugin FILE houseCARL locates across
-    /// enabled/disabled mod folders (<paramref name="sourcePlugin"/> — the read_plugin_file lane, stamped
+    /// enabled/disabled mod folders (<paramref name="sourcePlugin"/> â€” the read_plugin_file lane, stamped
     /// out-of-load-order in the outcome). Never touches the donor; output = folder-per-patch or into= extend.</summary>
     public NpcCopyOutcome CopyNpcAppearance(
         string sourceFormid, string? sourcePlugin, string? sourceMod,
         string? targetFormid, string? newEditorid, string? newName,
         string? patchName, string? into)
     {
-        // ---- 0. argument shape (Q3 — exactly one target mode) ----
+        // ---- 0. argument shape (Q3 â€” exactly one target mode) ----
         FormKey donorFk;
         try { donorFk = FormKey.Factory((sourceFormid ?? "").Trim()); }
         catch (Exception ex) { return NpcCopyOutcome.Fail($"bad source formid '{sourceFormid}': {ex.Message}. Expected 'XXXXXX:Plugin.esp', e.g. '000D62:Vivace.esp'."); }
@@ -1919,54 +1919,59 @@ public sealed class LoadOrderService : IDisposable
 
             using var session = resolver.OpenSession();
 
-            // ---- 1. read the donor NPC — the ACTIVE lane (load-order winner) or the FILE lane (any plugin on disk,
-            //         disabled included — the read_plugin_file machinery; results stamped out-of-load-order). ----
+            // ---- 1. read the donor NPC â€” the ACTIVE lane (load-order winner) or the FILE lane (any plugin on disk,
+            //         disabled included â€” the read_plugin_file machinery; results stamped out-of-load-order). ----
             INpcGetter donorNpc;
             NpcAppearanceCopy.DonorFetch fetch;
-            var donorMods = new HashSet<ModKey> { donorFk.ModKey };
+            // "Donor-bound" ModKeys â€” the plugin(s) being standalone-ized away from. A BASE-GAME/implicit master is
+            // NEVER donor-bound (review finding): copying a vanilla-defined NPC's look must not classify NordRace or
+            // vanilla headparts as "donor-internal" (that produced a nonsense custom-race refusal and would wholesale-
+            // internalize vanilla records). With an empty set the copy is an override-style transplant, said plainly.
+            var baseMasters = Mutagen.Bethesda.Plugins.Implicits.Get(Mutagen.Bethesda.GameRelease.SkyrimSE).BaseMasters;
+            var donorMods = new HashSet<ModKey>();
+            if (!baseMasters.Contains(donorFk.ModKey)) donorMods.Add(donorFk.ModKey);
             string donorReadFrom; bool outOfLoadOrder;
-            ISkyrimModGetter? donorOverlay = null;    // file lane only — disposed in finally
+            ISkyrimModGetter? donorOverlay = null;    // file lane only â€” disposed in finally
             string? donorFilePath = null;             // file lane: the located file; active lane: the winner's path (for the donor-disk asset fallback)
+            string dataDirForAssets;
             try
             {
                 if (!string.IsNullOrWhiteSpace(sourcePlugin))
                 {
                     string modsDir, dataDir, overwriteDir, profileDir;
                     lock (_gate) { EnsurePathsDerived(); modsDir = _modsDir; dataDir = _dataDir; overwriteDir = _overwriteDir; profileDir = _profileDir; }
+                    dataDirForAssets = dataDir;
                     var comp = Mo2LoadOrder.ReadComposition(profileDir);
                     var sp = sourcePlugin.Trim();
-                    if (LooksLikePath(sp))
-                    {
-                        if (!File.Exists(sp)) return NpcCopyOutcome.Fail($"no file at path '{sp}'.");
-                        donorFilePath = Path.GetFullPath(sp); donorReadFrom = $"direct path '{donorFilePath}'";
-                    }
-                    else if (!string.IsNullOrWhiteSpace(sourceMod))
-                    {
-                        var cand = Path.Combine(modsDir, sourceMod.Trim(), Path.GetFileName(sp));
-                        if (!File.Exists(cand)) return NpcCopyOutcome.Fail($"mod folder '{sourceMod.Trim()}' under ModsDir does not provide '{Path.GetFileName(sp)}'.");
-                        donorFilePath = cand; donorReadFrom = $"file '{sp}' in mod '{sourceMod.Trim()}'";
-                    }
-                    else
-                    {
-                        var hits = Mo2LoadOrder.LocatePlugin(comp, modsDir, dataDir, overwriteDir, sp);
-                        if (hits.Count == 0)
-                            return NpcCopyOutcome.Fail($"'{sp}' is in no mod folder (enabled or disabled), the overwrite folder, or the game Data folder. Check the filename, pass an absolute path, or the exact folder via source_mod=.");
-                        if (hits.Count > 1)
-                            return NpcCopyOutcome.Fail($"'{sp}' exists in {hits.Count} places ({string.Join(" | ", hits.Select(h => h.Where))}) — pass source_mod= to pick one.");
-                        donorFilePath = hits[0].Path; donorReadFrom = $"file '{sp}' ({hits[0].Where}{(hits[0].Enabled ? "" : ", DISABLED")})";
-                    }
+                    var loc = LocatePluginFileOnDisk(comp, modsDir, dataDir, overwriteDir, sp, sourceMod);
+                    if (loc.Error is not null) return NpcCopyOutcome.Fail(loc.Error);
+                    if (loc.Ambiguous is not null)
+                        return NpcCopyOutcome.Fail($"'{sp}' exists in {loc.Ambiguous.Count} places ({string.Join(" | ", loc.Ambiguous.Select(h => h.Where))}) â€” pass source_mod= to pick one.");
+                    donorFilePath = loc.Path!;
+                    donorReadFrom = loc.Where == "direct path"
+                        ? $"direct path '{donorFilePath}'"
+                        : $"file '{sp}' ({loc.Where}{(loc.Enabled ? "" : ", DISABLED")})";
                     outOfLoadOrder = true;
-                    try { donorMods.Add(ModKey.FromFileName(Path.GetFileName(donorFilePath))); } catch { /* a direct path with an odd name — donorFk.ModKey still governs */ }
+                    try
+                    {
+                        var fileKey = ModKey.FromFileName(Path.GetFileName(donorFilePath));
+                        if (!baseMasters.Contains(fileKey)) donorMods.Add(fileKey);
+                    }
+                    catch { /* a direct path with an odd name â€” donorFk.ModKey still governs */ }
 
                     donorOverlay = LoadOrderResolver.OpenOverlay(donorFilePath, string.IsNullOrEmpty(dataDir) ? null : dataDir);
-                    var index = new Dictionary<FormKey, IMajorRecordGetter>();
-                    foreach (var r in donorOverlay.EnumerateMajorRecords()) index[r.FormKey] = r;
-                    if (!index.TryGetValue(donorFk, out var donorBody))
+                    // Lazy per-type link cache â€” no eager whole-file parse (review finding), and per-resolve fault
+                    // isolation: one unparseable record elsewhere in the file must not abort the verb (Q3).
+                    var donorCache = donorOverlay.ToImmutableLinkCache();
+                    IMajorRecordGetter? donorBody;
+                    try { donorBody = donorCache.TryResolve(donorFk, out var db) ? db : null; }
+                    catch (Exception ex) { return NpcCopyOutcome.Fail($"'{Path.GetFileName(donorFilePath)}' could not be read around {donorFk} â€” a record Mutagen cannot parse: {ex.Message}"); }
+                    if (donorBody is null)
                         return NpcCopyOutcome.Fail($"file '{Path.GetFileName(donorFilePath)}' does not define or override {donorFk}. This reads the FILE's own records (out of load order); for an active donor omit source_plugin=.");
                     if (donorBody is not INpcGetter fileNpc)
                         return NpcCopyOutcome.Fail($"{donorFk} in '{Path.GetFileName(donorFilePath)}' is a {RecordNaming.StripOverlay(donorBody.GetType().Name)}, not an NPC.");
                     donorNpc = fileNpc;
-                    fetch = fk2 => index.TryGetValue(fk2, out var b) ? b : null;
+                    fetch = fk2 => { try { return donorCache.TryResolve(fk2, out var b) ? b : null; } catch { return null; } };
                 }
                 else
                 {
@@ -1974,7 +1979,7 @@ public sealed class LoadOrderService : IDisposable
                     if (winner is null)
                         return NpcCopyOutcome.Fail(
                             $"{donorFk} is not present in the active load order. If the donor plugin is DISABLED, pass source_plugin= " +
-                            "(its filename — houseCARL locates it across enabled AND disabled mod folders) to read it out of load order.");
+                            "(its filename â€” houseCARL locates it across enabled AND disabled mod folders) to read it out of load order.");
                     var body = view.GetRecord(session, winner.Value.WinnerPlugin, donorFk);
                     if (body is null)
                         return NpcCopyOutcome.Fail($"could not fetch {donorFk} from its winner '{winner.Value.WinnerPlugin}'.");
@@ -1984,6 +1989,7 @@ public sealed class LoadOrderService : IDisposable
                     donorReadFrom = $"active load order (winner: {winner.Value.WinnerPlugin})";
                     outOfLoadOrder = false;
                     donorFilePath = view.PluginPath(donorFk.ModKey.FileName.ToString());
+                    lock (_gate) { EnsurePathsDerived(); dataDirForAssets = _dataDir; }
                     fetch = fk2 =>
                     {
                         var w2 = view.ResolveWinner(fk2);
@@ -1993,11 +1999,11 @@ public sealed class LoadOrderService : IDisposable
 
                 NpcAppearanceCopy.ActiveResolve active = fk2 => view.ResolveWinner(fk2) is not null;
 
-                // ---- 2. the appearance closure (generic link walk; loud refusals — custom race, runaway, unreadable) ----
+                // ---- 2. the appearance closure (generic link walk; loud refusals â€” custom race, runaway, unreadable) ----
                 var closure = NpcAppearanceCopy.CollectAppearanceClosure(donorNpc, donorMods, fetch, active);
                 if (!closure.Success) return NpcCopyOutcome.Fail(closure.Error!);
 
-                // ---- 3. output patch (folder-per-patch or into= extend — the record lane's resolver + ownership gate) ----
+                // ---- 3. output patch (folder-per-patch or into= extend â€” the record lane's resolver + ownership gate) ----
                 string outPath; bool extend, created;
                 var defaultStem = clone ? newEditorid!.Trim() : "houseCARL_NpcCopy";
                 try { outPath = ResolveOutputPath(patchName ?? (into is null ? defaultStem : null), into, out extend, out created); }
@@ -2005,13 +2011,13 @@ public sealed class LoadOrderService : IDisposable
                 var patchFileName = Path.GetFileName(outPath);
                 var patchModKey = ModKey.FromFileName(patchFileName);
 
-                // ---- 4. apply lane: resolve the ACTIVE target body up front (an in-patch target — its formid names
-                //         the patch itself — is resolved inside the build, off the opened patch mod). ----
+                // ---- 4. apply lane: resolve the ACTIVE target body up front (an in-patch target â€” its formid names
+                //         the patch itself â€” is resolved inside the build, off the opened patch mod). ----
                 INpcGetter? targetActiveBody = null;
                 if (apply && targetFk.ModKey != patchModKey)
                 {
                     if (donorMods.Contains(targetFk.ModKey))
-                        return NpcCopyOutcome.Fail("the target NPC lives in the DONOR's plugin — that cannot be standalone-ized onto itself; pick a target outside the donor (or use new_editorid= to clone).");
+                        return NpcCopyOutcome.Fail("the target NPC lives in the DONOR's plugin â€” that cannot be standalone-ized onto itself; pick a target outside the donor (or use new_editorid= to clone).");
                     var tw = view.ResolveWinner(targetFk);
                     if (tw is null)
                         return NpcCopyOutcome.Fail(
@@ -2023,12 +2029,23 @@ public sealed class LoadOrderService : IDisposable
                     targetActiveBody = tnpc;
                 }
 
-                // ---- 5. build + serialize (core — Duplicate/RemapLinks, mode lane, multi-master write) ----
+                // ---- 4b. the donor FILE must not be the output patch (review finding: the donor overlay stays
+                //          memory-mapped through the serialize â€” the exact self-lock class the write path guards).
+                if (donorFilePath is not null
+                    && string.Equals(Path.GetFullPath(donorFilePath), Path.GetFullPath(outPath), StringComparison.OrdinalIgnoreCase))
+                {
+                    if (created) RemoveFolderCreatedThisCall(outPath);
+                    return NpcCopyOutcome.Fail(
+                        "the donor plugin file IS the output patch â€” reading and rewriting the same file in one call would " +
+                        "deadlock on its own open handle. Copy into a DIFFERENT patch (omit into=, or name another).");
+                }
+
+                // ---- 5. build + serialize (core â€” Duplicate/RemapLinks, mode lane, multi-master write) ----
                 var outcome = NpcAppearanceCopy.BuildAndWrite(
                     donorNpc, donorMods, closure,
                     clone, newEditorid, newName,
                     targetFk, targetActiveBody,
-                    fk2 => view.ResolveWinner(fk2) is not null,
+                    active,
                     outPath, extend,
                     pf => { session.ReleaseOverlay(pf); return session.AllMastersExcept(pf); },   // active-patch self-lock fix
                     donorReadFrom, outOfLoadOrder);
@@ -2038,23 +2055,30 @@ public sealed class LoadOrderService : IDisposable
                     return outcome;
                 }
 
-                // ---- 6. asset carry (facegen rename + donor-only textures/meshes) — best-effort + reported (Q3) ----
+                // ---- 6. asset carry (facegen rename + donor-only textures/meshes) â€” best-effort + reported (Q3).
+                //         Paths were harvested from the IN-PATCH duplicates pre-serialize (never the donor overlay,
+                //         which may be released by now). The donor-disk direct lane only exists for a donor under an
+                //         MO2 mod folder â€” NEVER the game Data folder, where every vanilla BSA would misclassify as
+                //         "the donor's" (review finding). ----
                 NpcAssetOutcome assets;
                 try
                 {
                     AssetResolver assetResolver;
                     lock (_gate) { assetResolver = Assets; }
                     var assetView = assetResolver.Capture();
-                    var donorDisk = donorFilePath is not null ? NpcAppearanceAssets.DonorDisk.For(donorFilePath) : null;
-                    var donorFolderName = donorFilePath is not null ? Path.GetFileName(Path.GetDirectoryName(donorFilePath)) : null;
+                    var donorDir = donorFilePath is not null ? Path.GetDirectoryName(donorFilePath) : null;
+                    bool donorInData = donorDir is not null && !string.IsNullOrEmpty(dataDirForAssets)
+                        && string.Equals(Path.GetFullPath(donorDir), Path.GetFullPath(dataDirForAssets), StringComparison.OrdinalIgnoreCase);
+                    var donorDisk = donorFilePath is not null && !donorInData ? NpcAppearanceAssets.DonorDisk.For(donorFilePath) : null;
+                    var donorFolderName = donorDisk is not null ? Path.GetFileName(donorDisk.Folder) : null;
                     assets = NpcAppearanceAssets.CarryAll(
-                        donorFk, outcome.NewNpcKey, closure.ToInternalize.Select(i => i.Body).ToList(),
+                        donorFk, outcome.NewNpcKey, outcome.HarvestedAssetPaths,
                         assetView, donorDisk, donorFolderName, Path.GetDirectoryName(outPath)!);
                 }
                 catch (Exception ex)
                 {
-                    assets = new NpcAssetOutcome(Array.Empty<CarriedAsset>(), Array.Empty<string>(), Array.Empty<string>(),
-                        new[] { $"asset carry skipped — the asset layer could not be built ({ex.Message}); carry the facegen pair with housecarl_place_asset and verify in-game." }, false, false);
+                    assets = new NpcAssetOutcome(Array.Empty<CarriedAsset>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(),
+                        new[] { $"asset carry skipped â€” the asset layer could not be built ({ex.Message}); carry the facegen pair with housecarl_place_asset and verify in-game." }, false, false);
                 }
                 return outcome with { Assets = assets };
             }
@@ -2062,12 +2086,12 @@ public sealed class LoadOrderService : IDisposable
         }
     }
 
-    /// <summary>Create a BRAND-NEW record (housecarl_create_record) — the net-new authoring capability, the sibling of
+    /// <summary>Create a BRAND-NEW record (housecarl_create_record) â€” the net-new authoring capability, the sibling of
     /// <see cref="ApplyEdits"/>. Resolves <paramref name="recordType"/> (catalog name or 4-char signature) to ONE concrete
-    /// catalog name (unknown/ambiguous → Q3), maps the field <paramref name="operations"/> to core <see cref="WriteRequest"/>s
-    /// rooted at that type (a create op takes NO formid — it sets fields on the new record), resolves the folder-per-patch
+    /// catalog name (unknown/ambiguous â†’ Q3), maps the field <paramref name="operations"/> to core <see cref="WriteRequest"/>s
+    /// rooted at that type (a create op takes NO formid â€” it sets fields on the new record), resolves the folder-per-patch
     /// output (fresh, or <paramref name="into"/> an existing houseCARL-owned patch), then drives
-    /// <see cref="WritePatchBuilder.CreateRecords"/> (pre-flight ALL → AddNew/NestedAddNew → ApplyVerb → multi-master serialize).
+    /// <see cref="WritePatchBuilder.CreateRecords"/> (pre-flight ALL â†’ AddNew/NestedAddNew â†’ ApplyVerb â†’ multi-master serialize).
     /// The new record's FormID is auto-allocated (local 0x800+) and reported; originals are never touched. A flat top-level
     /// record needs no <paramref name="parent"/>; a NESTED child (a dialogue line, a placed ref) passes <paramref name="parent"/>
     /// (an existing parent's FormKey, or a record created in a prior into= call) and, when the parent holds more than one
@@ -2081,21 +2105,21 @@ public sealed class LoadOrderService : IDisposable
         var spec = BuildCreateSpec(recordType, editorid, operations, parent, collection, grid, where: null, problems);
         if (spec is null)
             return WritePatchBuilder.CreateOutcome.Fail(
-                $"refused — {problems.Count} problem(s) creating the record; NOTHING created:\n  - " + string.Join("\n  - ", problems));
+                $"refused â€” {problems.Count} problem(s) creating the record; NOTHING created:\n  - " + string.Join("\n  - ", problems));
         return CommitCreate(new[] { spec }, patchName, into, fullReadback, target, inPlace, acknowledge);
     }
 
-    /// <summary>Create MANY new records in ONE patch (housecarl_bulk_create) — the batch sibling of
+    /// <summary>Create MANY new records in ONE patch (housecarl_bulk_create) â€” the batch sibling of
     /// <see cref="CreateRecords"/>, and the one-shot lever for a nested unit (a dialogue topic + its lines, a cell + its
     /// placed refs) where a child's <c>parent</c> names a same-call sibling by editorid. Each spec is mapped exactly as
-    /// the single create (type resolution + field-op mapping + parent/collection); ALL-OR-NOTHING (Q3) — any malformed
+    /// the single create (type resolution + field-op mapping + parent/collection); ALL-OR-NOTHING (Q3) â€” any malformed
     /// spec refuses the whole call (with per-record reasons) and the core <see cref="WritePatchBuilder.CreateRecords"/>
     /// likewise refuses the whole batch on any creatability/parent problem. One serialize for the lot.</summary>
     public WritePatchBuilder.CreateOutcome CreateRecordsBatch(IReadOnlyList<CreateOp> records, string? patchName, string? into, bool fullReadback = false,
         string? target = null, bool inPlace = false, bool acknowledge = false)
     {
         if (records is null || records.Count == 0)
-            return WritePatchBuilder.CreateOutcome.Fail("no records to create supplied — pass one or more {record_type, editorid, operations?, parent?, collection?} specs.");
+            return WritePatchBuilder.CreateOutcome.Fail("no records to create supplied â€” pass one or more {record_type, editorid, operations?, parent?, collection?} specs.");
 
         var problems = new List<string>();
         var specs = new List<WritePatchBuilder.CreateSpec>(records.Count);
@@ -2107,15 +2131,15 @@ public sealed class LoadOrderService : IDisposable
         }
         if (problems.Count > 0)
             return WritePatchBuilder.CreateOutcome.Fail(
-                $"refused — {problems.Count} problem(s) across {records.Count} record(s); NOTHING created:\n  - " + string.Join("\n  - ", problems));
+                $"refused â€” {problems.Count} problem(s) across {records.Count} record(s); NOTHING created:\n  - " + string.Join("\n  - ", problems));
         return CommitCreate(specs, patchName, into, fullReadback, target, inPlace, acknowledge);
     }
 
     /// <summary>Build ONE core <see cref="WritePatchBuilder.CreateSpec"/> from wire parts (shared by the single create and
     /// the batch): resolve <paramref name="recordType"/> (catalog name or 4-char signature) to ONE concrete catalog name
-    /// (unknown/ambiguous → a problem), require an editorid, map each field <paramref name="operations"/> op to a core
+    /// (unknown/ambiguous â†’ a problem), require an editorid, map each field <paramref name="operations"/> op to a core
     /// <see cref="WriteRequest"/> rooted at that type, and carry <paramref name="parent"/>/<paramref name="collection"/>
-    /// through (a nested child) — null ⇒ a flat top-level record. Every problem (with the optional <paramref name="where"/>
+    /// through (a nested child) â€” null â‡’ a flat top-level record. Every problem (with the optional <paramref name="where"/>
     /// label) is APPENDED to <paramref name="problems"/>; returns null iff this record contributed any (all-or-nothing).</summary>
     WritePatchBuilder.CreateSpec? BuildCreateSpec(string? recordType, string? editorid, IReadOnlyList<BulkOp> operations,
         string? parent, string? collection, string? grid, string? where, List<string> problems)
@@ -2132,15 +2156,15 @@ public sealed class LoadOrderService : IDisposable
             {
                 var types = ResolveTypeFilter(recordType.Trim());
                 if (types.Count != 1)
-                    problems.Add($"{prefix}record_type '{recordType}' is ambiguous ({types.Count} matches) — use a specific catalog name (e.g. one of: {string.Join(", ", types.Select(t => RecordNaming.StripGetterInterface(t.Name)))}).");
+                    problems.Add($"{prefix}record_type '{recordType}' is ambiguous ({types.Count} matches) â€” use a specific catalog name (e.g. one of: {string.Join(", ", types.Select(t => RecordNaming.StripGetterInterface(t.Name)))}).");
                 else catalogName = RecordNaming.StripGetterInterface(types[0].Name);
             }
             catch (ArgumentException ex) { problems.Add($"{prefix}{ex.Message}"); }
         }
         if (string.IsNullOrWhiteSpace(editorid))
-            problems.Add($"{prefix}editorid is required — the EditorID the new record is referenced by (e.g. in SkyPatcher/SPID).");
+            problems.Add($"{prefix}editorid is required â€” the EditorID the new record is referenced by (e.g. in SkyPatcher/SPID).");
 
-        // Map each field op → a core WriteRequest rooted at the create type (only once the type resolved; collect ALL malformed ops).
+        // Map each field op â†’ a core WriteRequest rooted at the create type (only once the type resolved; collect ALL malformed ops).
         var edits = new List<WriteRequest>(operations.Count);
         if (catalogName is not null)
             for (int i = 0; i < operations.Count; i++)
@@ -2165,14 +2189,14 @@ public sealed class LoadOrderService : IDisposable
     WritePatchBuilder.CreateOutcome CommitCreate(IReadOnlyList<WritePatchBuilder.CreateSpec> specs, string? patchName, string? into, bool fullReadback,
         string? target = null, bool inPlace = false, bool acknowledge = false)
     {
-        // In-place is the explicit, named-file opt-in (the SECOND write lane — create into an existing plugin, incl. one
+        // In-place is the explicit, named-file opt-in (the SECOND write lane â€” create into an existing plugin, incl. one
         // houseCARL didn't author, instead of writing a new patch). Validate the contract up front (Q3): it REQUIRES a
-        // target=, is mutually exclusive with into= (which EXTENDS a houseCARL patch — a different lane), and target=
-        // without in_place is a no-op the caller likely didn't mean — name it rather than silently ignore it. (Mirrors
+        // target=, is mutually exclusive with into= (which EXTENDS a houseCARL patch â€” a different lane), and target=
+        // without in_place is a no-op the caller likely didn't mean â€” name it rather than silently ignore it. (Mirrors
         // ApplyEdits' in-place contract exactly.)
         if (inPlace && string.IsNullOrWhiteSpace(target))
             return WritePatchBuilder.CreateOutcome.Fail(
-                "in_place=true requires target=<plugin filename> — name the existing plugin to create into in place. (Omit in_place to write a new patch instead — the default, originals untouched.)");
+                "in_place=true requires target=<plugin filename> â€” name the existing plugin to create into in place. (Omit in_place to write a new patch instead â€” the default, originals untouched.)");
         if (inPlace && !string.IsNullOrWhiteSpace(into))
             return WritePatchBuilder.CreateOutcome.Fail(
                 "in_place=true and into= are mutually exclusive: into= EXTENDS a houseCARL patch, while in_place creates into an existing plugin in place. Use one lane or the other.");
@@ -2180,7 +2204,7 @@ public sealed class LoadOrderService : IDisposable
             return WritePatchBuilder.CreateOutcome.Fail(
                 "target= is only meaningful with in_place=true (it names the plugin to create into in place). For the default patch lane omit target=; use into= to extend an existing houseCARL patch.");
 
-        lock (_writeGate)                                                 // hunt F2: one write at a time, resolve→commit
+        lock (_writeGate)                                                 // hunt F2: one write at a time, resolveâ†’commit
         {
             var resolver = Resolver;
             var rulebook = Rulebook;
@@ -2194,26 +2218,26 @@ public sealed class LoadOrderService : IDisposable
 
             var outcome = WritePatchBuilder.CreateRecords(resolver, rulebook, specs, outPath, extend, fullReadback);
             if (!outcome.Success && created) RemoveFolderCreatedThisCall(outPath);   // hunt F4: a refused create leaves no orphan
-            // Layer B dialogue teeth + the coordinate-keyed cell teeth — all post-write verify steps (the proven
+            // Layer B dialogue teeth + the coordinate-keyed cell teeth â€” all post-write verify steps (the proven
             // CreateRecords path stays untouched): unit B voice (.fuz/.lip) coverage, unit C the result-script binding,
-            // then the §4-(b) structural-shell report. Each is a no-op unless the call created the relevant record kind
+            // then the Â§4-(b) structural-shell report. Each is a no-op unless the call created the relevant record kind
             // (a dialogue line / a cell); none can fail the create (the write already succeeded).
             return outcome.Success ? EnrichWithCellShell(EnrichWithScriptCheck(EnrichWithVoiceCheck(outcome, resolver))) : outcome;
         }
     }
 
-    /// <summary>The in-place branch of <see cref="CommitCreate"/> (in-place write lane, Wave 1b) — the create-side
+    /// <summary>The in-place branch of <see cref="CommitCreate"/> (in-place write lane, Wave 1b) â€” the create-side
     /// companion of <see cref="ApplyEditsInPlace"/>, and it REUSES every Wave-1 in-place seam: the same foreign-target
     /// resolver (<see cref="ResolveActivePluginPath"/>), the same PERSISTENT first-touch CONSENT handshake (keyed off the
     /// resolved path in <see cref="UserConfigStore"/>), the same writable-parent pre-flight, and the same distinct
-    /// <c>editedInPlace=</c> marker (NEVER <c>generated=true</c> — the user mod keeps failing
+    /// <c>editedInPlace=</c> marker (NEVER <c>generated=true</c> â€” the user mod keeps failing
     /// <see cref="IsHouseCarlOwned"/> so a later into= can't blind-overwrite it). THREE divergences from
     /// <see cref="ApplyEditsInPlace"/>: (1) it drives <see cref="WritePatchBuilder.CreateRecordsInPlace"/>
     /// (allocate-into-target, not edit-own-record); (2) it returns a <see cref="WritePatchBuilder.CreateOutcome"/>; and
-    /// (3) because in-place create has FULL parity — it can author dialogue lines / cells under any parent, unlike
-    /// <c>set_field</c> — it runs the SAME post-write voice/result-script/cell-shell coverage teeth the patch-lane create
+    /// (3) because in-place create has FULL parity â€” it can author dialogue lines / cells under any parent, unlike
+    /// <c>set_field</c> â€” it runs the SAME post-write voice/result-script/cell-shell coverage teeth the patch-lane create
     /// runs (<see cref="ApplyEditsInPlace"/> is marker-only). The created-record verify is forced ON (the model-C
-    /// substitute for the dropped whole-plugin floor). <paramref name="acknowledge"/> waives the CONSENT axis ONLY — the
+    /// substitute for the dropped whole-plugin floor). <paramref name="acknowledge"/> waives the CONSENT axis ONLY â€” the
     /// verify is a corruption-axis fact no acknowledgement overrides. Runs under <c>_writeGate</c> (the caller holds it).</summary>
     WritePatchBuilder.CreateOutcome CommitCreateInPlace(
         LoadOrderResolver resolver, CorpusRulebook rulebook, IReadOnlyList<WritePatchBuilder.CreateSpec> specs,
@@ -2225,11 +2249,11 @@ public sealed class LoadOrderService : IDisposable
         var targetPath = ResolveActivePluginPath(view, Path.GetFileName(target.Trim()), out var targetName);
         if (targetPath is null)
             return WritePatchBuilder.CreateOutcome.Fail(
-                $"in-place target '{target}' is not an active plugin in the load order — name a plugin enabled in MO2, by its " +
+                $"in-place target '{target}' is not an active plugin in the load order â€” name a plugin enabled in MO2, by its " +
                 "plugin filename (e.g. 'CoolWeapons.esp'). in-place creates into the file the game actually loads. Nothing was written.");
 
-        // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path (shared with
-        //     the edit lane: acknowledging a plugin once covers BOTH editing and creating into it in place — it's the same
+        // (2) CONSENT axis â€” the persistent, server-enforced first-touch handshake, keyed off the resolved path (shared with
+        //     the edit lane: acknowledging a plugin once covers BOTH editing and creating into it in place â€” it's the same
         //     "touch your original" trade-off).
         bool already = _store.IsInPlaceAcknowledged(targetPath);
         if (!already && !acknowledge)
@@ -2238,17 +2262,17 @@ public sealed class LoadOrderService : IDisposable
         if (!already && acknowledge)
         {
             var (ok, err) = _store.RecordInPlaceAcknowledged(targetPath);
-            if (!ok) ackNote = $"the in-place acknowledgement could not be saved ({err}) — the create proceeded, but a future session will re-prompt for this plugin.";
+            if (!ok) ackNote = $"the in-place acknowledgement could not be saved ({err}) â€” the create proceeded, but a future session will re-prompt for this plugin.";
         }
 
-        // (3) Writable, same-volume parent pre-flight — refuse rather than degrade (the swap stages a sibling temp here).
+        // (3) Writable, same-volume parent pre-flight â€” refuse rather than degrade (the swap stages a sibling temp here).
         if (InPlaceParentUnwritable(targetPath, out var why))
             return WritePatchBuilder.CreateOutcome.Fail(why);
 
-        // (4) The write — created-record verify forced ON (the model-C substitute for the dropped whole-plugin floor).
+        // (4) The write â€” created-record verify forced ON (the model-C substitute for the dropped whole-plugin floor).
         var outcome = WritePatchBuilder.CreateRecordsInPlace(resolver, rulebook, specs, targetPath, targetName, fullReadback: true);
 
-        // (5) On success: run the SAME post-write teeth the patch lane runs (the service owns the live AssetResolver) —
+        // (5) On success: run the SAME post-write teeth the patch lane runs (the service owns the live AssetResolver) â€”
         //     in-place create can now author dialogue lines / cells under any parent, so voice (.fuz) + result-script +
         //     cell-shell coverage must be checked here too (each a no-op unless that record kind was created; none can
         //     fail the write, which already succeeded). Then stamp the distinct audit marker (best-effort; a marker miss
@@ -2261,15 +2285,15 @@ public sealed class LoadOrderService : IDisposable
             return note is not null ? enriched with { Note = note } : enriched;
         }
         if (ackNote is not null)
-            // The acknowledgement was recorded but the write then failed — keep the (now-honest) note alongside the error.
+            // The acknowledgement was recorded but the write then failed â€” keep the (now-honest) note alongside the error.
             return outcome with { Note = ackNote };
         return outcome;
     }
 
-    /// <summary>Layer B unit B — the on-disk voice (.fuz/.lip) presence check, run as a POST-WRITE step on a SUCCESSFUL
+    /// <summary>Layer B unit B â€” the on-disk voice (.fuz/.lip) presence check, run as a POST-WRITE step on a SUCCESSFUL
     /// create (the service owns the live <see cref="Assets"/> resolver; the proven core create path stays asset-free and
-    /// untouched). Only fires when the call created ≥1 dialogue line (INFO): <see cref="VoiceCheck.Run"/> re-opens the
-    /// written patch read-only, computes each created voiced line's expected path, and checks the VFS — the report rides
+    /// untouched). Only fires when the call created â‰¥1 dialogue line (INFO): <see cref="VoiceCheck.Run"/> re-opens the
+    /// written patch read-only, computes each created voiced line's expected path, and checks the VFS â€” the report rides
     /// back on <see cref="WritePatchBuilder.CreateOutcome.Voice"/>. NEVER fails the create (the write already succeeded);
     /// a check failure is surfaced on the report's CheckError (Q3), and even a thrown Assets-build is caught here so a
     /// dialogue create never regresses to an error outcome over a verify step. Caller holds <see cref="_writeGate"/>; the
@@ -2287,14 +2311,14 @@ public sealed class LoadOrderService : IDisposable
         return report.IsEmpty ? outcome : outcome with { Voice = report };
     }
 
-    /// <summary>Layer B unit C — the per-create RESULT-SCRIPT binding check, run as a POST-WRITE step on a SUCCESSFUL
+    /// <summary>Layer B unit C â€” the per-create RESULT-SCRIPT binding check, run as a POST-WRITE step on a SUCCESSFUL
     /// create (the service owns the live <see cref="Assets"/> resolver; the proven core create path stays asset-free and
-    /// untouched), exactly like <see cref="EnrichWithVoiceCheck"/>. Only fires when the call created ≥1 dialogue line
+    /// untouched), exactly like <see cref="EnrichWithVoiceCheck"/>. Only fires when the call created â‰¥1 dialogue line
     /// (INFO): <see cref="DialogueScriptCheck.Run"/> re-opens the written patch read-only, validates each created INFO's
-    /// VMAD result-script binding and checks its compiled `.pex` on disk — the report rides back on
+    /// VMAD result-script binding and checks its compiled `.pex` on disk â€” the report rides back on
     /// <see cref="WritePatchBuilder.CreateOutcome.ScriptBinding"/>. NEVER fails the create (the write already succeeded);
     /// a check failure is surfaced on the report's CheckError (Q3), and even a thrown Assets-build is caught here. Needs
-    /// no LoadOrderResolver — the binding lives wholly on the INFO + the on-disk `.pex` (no graph resolution).</summary>
+    /// no LoadOrderResolver â€” the binding lives wholly on the INFO + the on-disk `.pex` (no graph resolution).</summary>
     WritePatchBuilder.CreateOutcome EnrichWithScriptCheck(WritePatchBuilder.CreateOutcome outcome)
     {
         bool anyInfo = false;
@@ -2308,13 +2332,13 @@ public sealed class LoadOrderService : IDisposable
         return report.IsEmpty ? outcome : outcome with { ScriptBinding = report };
     }
 
-    /// <summary>The coordinate-keyed §4-(b) teeth — the structural-SHELL report, a POST-WRITE step on a SUCCESSFUL
-    /// create exactly like <see cref="EnrichWithVoiceCheck"/>. Only fires when the call created ≥1 Cell:
+    /// <summary>The coordinate-keyed Â§4-(b) teeth â€” the structural-SHELL report, a POST-WRITE step on a SUCCESSFUL
+    /// create exactly like <see cref="EnrichWithVoiceCheck"/>. Only fires when the call created â‰¥1 Cell:
     /// <see cref="CellShellCheck.Run"/> re-opens the written patch read-only, reads each created cell's interior/exterior
-    /// kind, and lists the world content houseCARL does NOT author (lighting / terrain / water / navmesh — Aaron
-    /// 2026-06-20: no CK work) — the report rides back on <see cref="WritePatchBuilder.CreateOutcome.CellShell"/>. NEVER
+    /// kind, and lists the world content houseCARL does NOT author (lighting / terrain / water / navmesh â€” Aaron
+    /// 2026-06-20: no CK work) â€” the report rides back on <see cref="WritePatchBuilder.CreateOutcome.CellShell"/>. NEVER
     /// fails the create (the cell IS written; this only says what the author must still provide); a check failure is
-    /// surfaced on the report's CheckError (Q3). Needs no resolver/assets — the kind comes off the written cell's flag.</summary>
+    /// surfaced on the report's CheckError (Q3). Needs no resolver/assets â€” the kind comes off the written cell's flag.</summary>
     WritePatchBuilder.CreateOutcome EnrichWithCellShell(WritePatchBuilder.CreateOutcome outcome)
     {
         bool anyCell = false;
@@ -2329,7 +2353,7 @@ public sealed class LoadOrderService : IDisposable
     }
 
     /// <summary>Map a wire field-op to a core <see cref="WriteRequest"/> for CREATE: RecordType is the create type (not
-    /// derived), and a create op carries NO formid (it sets a field on the new record, whose id is auto-allocated) — a
+    /// derived), and a create op carries NO formid (it sets a field on the new record, whose id is auto-allocated) â€” a
     /// stray formid is refused loud (Q3) rather than silently ignored. Builds the composition <see cref="StructSpec"/> the
     /// same way <see cref="MapEdit"/> does (so a created Spell's Effects / LeveledItem's Entries compose identically).</summary>
     WriteRequest? MapCreateEdit(BulkOp op, int index, string recordType, out string? error)
@@ -2361,7 +2385,7 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>Map a wire op to a core <see cref="WritePatchBuilder.PatchEdit"/>: parse the FormID, split the dotted
     /// field path, and (if present) build the composition <see cref="StructSpec"/>. RecordType is NOT taken from the wire
-    /// — the cleave derives it from the resolved winner. Returns null + a named error (Q3) on any malformed input.</summary>
+    /// â€” the cleave derives it from the resolved winner. Returns null + a named error (Q3) on any malformed input.</summary>
     WritePatchBuilder.PatchEdit? MapEdit(BulkOp op, int index, out string? error)
     {
         error = null;
@@ -2388,16 +2412,16 @@ public sealed class LoadOrderService : IDisposable
         };
     }
 
-    /// <summary>Build a core composition <see cref="StructSpec"/> from the wire shape — flat <c>fields</c> (coercible
+    /// <summary>Build a core composition <see cref="StructSpec"/> from the wire shape â€” flat <c>fields</c> (coercible
     /// sub-fields), positional <c>ctor_args</c>, and nested <c>sets</c> (each a path+verb+value applied to the built
     /// struct, e.g. a leveled-list entry's Data.Level / Data.Reference). The nested sets' RecordType carries the struct
     /// type (the validator roots them at the struct schema, so it's a label). A nested set may itself carry a
-    /// <c>compose</c> (HCBR-2026-06-15-01 PR-C) — a recursive <see cref="StructSpec"/> selecting a polymorphic
-    /// sub-ARM (e.g. <c>sets:[{path:'Data', compose:{type:'GetActorValueConditionData', …}}]</c>) — mapped here into
+    /// <c>compose</c> (HCBR-2026-06-15-01 PR-C) â€” a recursive <see cref="StructSpec"/> selecting a polymorphic
+    /// sub-ARM (e.g. <c>sets:[{path:'Data', compose:{type:'GetActorValueConditionData', â€¦}}]</c>) â€” mapped here into
     /// the nested <see cref="WriteRequest.Struct"/> the core already applies + validates end-to-end (BuildStruct
     /// recurses on a Set/Add carrying a Struct; the rulebook's ArmLegality validates compose.type against the leaf's
     /// legal arms). Without this propagation a nested set could only set a coercible scalar, never a sub-arm. Q3 on a
-    /// malformed spec. <c>internal static</c> is the harness seam (the PR-C guard drives the wire→core mapping directly,
+    /// malformed spec. <c>internal static</c> is the harness seam (the PR-C guard drives the wireâ†’core mapping directly,
     /// like the other engine helpers; it touches no instance state).</summary>
     internal static StructSpec? MapStruct(StructInput s, string where, out string? error)
     {
@@ -2431,17 +2455,17 @@ public sealed class LoadOrderService : IDisposable
         => dotted.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
     /// <summary>Resolve a patch's output path under the FOLDER-PER-PATCH model (Aaron-locked 2026-06-02): each patch is
-    /// its OWN MO2 mod folder — <c>&lt;ModsDir&gt;\houseCARL - &lt;name&gt;\&lt;name&gt;.esp</c> — so every houseCARL
+    /// its OWN MO2 mod folder â€” <c>&lt;ModsDir&gt;\houseCARL - &lt;name&gt;\&lt;name&gt;.esp</c> â€” so every houseCARL
     /// plugin is a first-class mod the user enables / orders / removes independently. A NEW patch always creates a fresh,
-    /// marker-stamped folder (name auto-suffixed _001… so a prior reviewed patch is never clobbered);
+    /// marker-stamped folder (name auto-suffixed _001â€¦ so a prior reviewed patch is never clobbered);
     /// <paramref name="into"/> EXTENDS an existing houseCARL-owned patch (replace / modify its own plugins).
-    /// ORIGINALS UNTOUCHED is structural (CLAUDE.md §1): houseCARL only ever writes a folder that is brand-NEW or carries
-    /// its own <c>meta.ini</c> marker — it REFUSES (Q3) to write a folder it didn't create (a user mod), even on a name
+    /// ORIGINALS UNTOUCHED is structural (CLAUDE.md Â§1): houseCARL only ever writes a folder that is brand-NEW or carries
+    /// its own <c>meta.ini</c> marker â€” it REFUSES (Q3) to write a folder it didn't create (a user mod), even on a name
     /// collision. The caller name is reduced to a bare stem (no directory parts) so it can never escape ModsDir.
     /// Runs under <see cref="_gate"/> like its sibling <see cref="ResolvePatchModFolder"/> (hunt F2): the UniqueStem
     /// check-then-create is only race-free when every folder allocation is serialized on the one gate.
     /// <paramref name="createdFolder"/> reports whether THIS call created the fresh folder, so a refused write can
-    /// remove it again (hunt F4 — "NO patch written" must not leave an orphan folder accreting _001/_002 on retry).</summary>
+    /// remove it again (hunt F4 â€” "NO patch written" must not leave an orphan folder accreting _001/_002 on retry).</summary>
     string ResolveOutputPath(string? patchName, string? into, out bool extend, out bool createdFolder)
     {
         lock (_gate)
@@ -2454,10 +2478,10 @@ public sealed class LoadOrderService : IDisposable
             {
                 extend = true;
                 // The .esp write lane shares the 4-step EXTEND resolver with the rider/asset lane (HCBR-2026-06-23) so
-                // "extend my renamed patch" behaves IDENTICALLY across records, scripts, BSAs, and assets. needEsp:true —
+                // "extend my renamed patch" behaves IDENTICALLY across records, scripts, BSAs, and assets. needEsp:true â€”
                 // the canonical fast path only short-circuits a folder that actually holds <stem>.esp; we then pick the .esp
-                // to extend inside the resolved folder: the <stem>.esp it holds, or — via the by-folder catch-all, where the
-                // folder & plugin names differ — the folder's single plugin (Q3-refuse if it holds none or several).
+                // to extend inside the resolved folder: the <stem>.esp it holds, or â€” via the by-folder catch-all, where the
+                // folder & plugin names differ â€” the folder's single plugin (Q3-refuse if it holds none or several).
                 var folder = ResolveOwnedPatchFolder(into, needEsp: true);
                 var direct = Path.Combine(folder, PatchStem(into) + ".esp");
                 if (File.Exists(direct)) return direct;
@@ -2481,7 +2505,7 @@ public sealed class LoadOrderService : IDisposable
     /// <summary>Hunt F4: a write that was REFUSED after <see cref="ResolveOutputPath"/> created a fresh folder removes
     /// that folder again, so "NO patch written" is true of the disk too (no orphan accreting _001/_002 on retry).
     /// DELETION-SAFE by content check, not trust: only a folder holding NOTHING beyond our own meta.ini (and an empty
-    /// <c>.housecarl-tmp</c> staging leftover) is removed — anything else present means the folder gained real content
+    /// <c>.housecarl-tmp</c> staging leftover) is removed â€” anything else present means the folder gained real content
     /// and stays. Best-effort: a cleanup failure never masks the write's own (already-reported) outcome.</summary>
     static void RemoveFolderCreatedThisCall(string outPath)
     {
@@ -2495,7 +2519,7 @@ public sealed class LoadOrderService : IDisposable
                 if (File.Exists(entry) && name.Equals("meta.ini", StringComparison.OrdinalIgnoreCase)) continue;
                 if (Directory.Exists(entry) && name.Equals(".housecarl-tmp", StringComparison.OrdinalIgnoreCase)
                     && !Directory.EnumerateFileSystemEntries(entry).Any()) continue;
-                return;                                       // real content appeared — leave the folder alone
+                return;                                       // real content appeared â€” leave the folder alone
             }
             Directory.Delete(folder, recursive: true);
         }
@@ -2509,7 +2533,7 @@ public sealed class LoadOrderService : IDisposable
     public readonly record struct RiderFolder(string OutputDir, string ModFolder, bool CreatedFresh);
 
     /// <summary>Resolve a houseCARL-owned MOD FOLDER under ModsDir for a NON-.esp output (compiled scripts, a packed .bsa,
-    /// extracted loose files) — the folder-per-patch model generalised beyond the .esp write path. A fresh marker-stamped
+    /// extracted loose files) â€” the folder-per-patch model generalised beyond the .esp write path. A fresh marker-stamped
     /// folder (<paramref name="defaultStem"/> names it when patchName is blank; auto-suffixed so a prior one is never
     /// clobbered) or <paramref name="into"/> an existing houseCARL-owned one. ORIGINALS UNTOUCHED (Q3): refuses a folder
     /// houseCARL didn't create. Derives ModsDir CHEAPLY (reads ModOrganizer.ini; NO ~10s index build). Throws the trained
@@ -2529,10 +2553,10 @@ public sealed class LoadOrderService : IDisposable
                 // The SAME shared 4-step EXTEND resolver as the .esp write path (HCBR-2026-06-23): a renamed houseCARL patch
                 // folder is found by the .esp it holds OR by its new name, so compile / decompile / bsa_repack / place_asset
                 // into= behaves exactly like record into= (before this, a renamed folder fell to a misleading "folder not
-                // found"). needEsp:false — a rider targets the FOLDER itself (it writes scripts / a .bsa / loose files into
+                // found"). needEsp:false â€” a rider targets the FOLDER itself (it writes scripts / a .bsa / loose files into
                 // it, not an .esp), so it does NOT require a <stem>.esp to be present.
                 var folder = ResolveOwnedPatchFolder(into, needEsp: false);
-                return new RiderFolder(folder, folder, CreatedFresh: false);   // reused — the user owns it; cleanup leaves it
+                return new RiderFolder(folder, folder, CreatedFresh: false);   // reused â€” the user owns it; cleanup leaves it
             }
 
             var newStem = UniqueStem(PatchStem(string.IsNullOrWhiteSpace(patchName) ? defaultStem : patchName!));
@@ -2543,7 +2567,7 @@ public sealed class LoadOrderService : IDisposable
         }
     }
 
-    /// <summary>The <c>Scripts\</c> output folder for a COMPILED .pex (the compile rider) — a houseCARL mod folder via
+    /// <summary>The <c>Scripts\</c> output folder for a COMPILED .pex (the compile rider) â€” a houseCARL mod folder via
     /// <see cref="ResolvePatchModFolder"/> plus its <c>Scripts\</c> subfolder, where MO2 deploys compiled Papyrus into the
     /// game's Data\Scripts. Carries the mod-folder root + fresh flag through for residue cleanup.</summary>
     public RiderFolder ResolveCompiledScriptFolder(string? patchName, string? into)
@@ -2556,12 +2580,12 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>output_dir= escape hatch (6.3): the user names WHERE the compiled .pex lands, instead of houseCARL cutting a
     /// fresh folder-per-patch mod folder. DECIDED contract (Aaron 2026-06-16): output_dir is a mod-folder ROOT and houseCARL
-    /// appends Scripts\ — matching <see cref="ResolveCompiledScriptFolder"/> + MO2's deploy model so the .pex actually loads —
+    /// appends Scripts\ â€” matching <see cref="ResolveCompiledScriptFolder"/> + MO2's deploy model so the .pex actually loads â€”
     /// with a DOUBLE-SCRIPTS guard (don't append a second Scripts\ if it's already there). Does NOT call
-    /// <see cref="ResolvePatchModFolder"/> (no houseCARL mod folder is cut under ModsDir), and the folder is USER-OWNED — the
+    /// <see cref="ResolvePatchModFolder"/> (no houseCARL mod folder is cut under ModsDir), and the folder is USER-OWNED â€” the
     /// returned <see cref="RiderFolder"/> carries CreatedFresh=false, so <see cref="RemoveOrNameRiderResidue"/> never deletes
     /// it on a failed compile (it early-returns on !CreatedFresh). <paramref name="deployWarning"/> is a Q3 note (non-null)
-    /// when the final Scripts\ path is under neither the MO2 mods tree nor the game's Data — the .pex compiles but the game
+    /// when the final Scripts\ path is under neither the MO2 mods tree nor the game's Data â€” the .pex compiles but the game
     /// won't auto-load it from there, so a clean "done" is never reported for a .pex that won't deploy. Refuses loud (Q3) on
     /// an unusable output_dir (a malformed path, or a path that names an existing FILE).</summary>
     public RiderFolder ResolveExplicitScriptFolder(string outputDir, out string? deployWarning)
@@ -2574,18 +2598,18 @@ public sealed class LoadOrderService : IDisposable
             try { root = Path.GetFullPath((outputDir ?? "").Trim().Trim('"')); }
             catch (Exception ex) { throw new InvalidOperationException($"output_dir '{outputDir}' is not a usable path ({ex.Message})."); }
             if (File.Exists(root))
-                throw new InvalidOperationException($"output_dir '{root}' is a file, not a folder. Give a mod-folder root — houseCARL appends Scripts\\.");
+                throw new InvalidOperationException($"output_dir '{root}' is a file, not a folder. Give a mod-folder root â€” houseCARL appends Scripts\\.");
 
             var (scriptsDir, appended, warn) = ScriptOutputContract(root, _modsDir, _dataDir);
-            // Friendly Q3 message if the folder can't be created — e.g. <output_dir>\Scripts already exists AS A FILE, or
-            // the path is read-only — instead of letting the IO/access exception reach Guard.Tool's generic "internal
+            // Friendly Q3 message if the folder can't be created â€” e.g. <output_dir>\Scripts already exists AS A FILE, or
+            // the path is read-only â€” instead of letting the IO/access exception reach Guard.Tool's generic "internal
             // failure" (which would wrongly read as a houseCARL bug, not bad input). The File.Exists(root) guard above
             // already catches the common "output_dir itself is a file" shape; this rounds out the rest.
             try { Directory.CreateDirectory(scriptsDir); }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             { throw new InvalidOperationException($"output_dir: couldn't create the output folder '{scriptsDir}' ({ex.Message}). Check the path and that it's writable."); }
             deployWarning = warn;
-            // ModFolder = the mod-folder root (inert here — cleanup is bypassed by CreatedFresh=false — but kept honest):
+            // ModFolder = the mod-folder root (inert here â€” cleanup is bypassed by CreatedFresh=false â€” but kept honest):
             // when the user pointed AT a Scripts\ dir, the root is its parent; otherwise the path they gave IS the root.
             var modRoot = appended ? root : (Path.GetDirectoryName(scriptsDir.TrimEnd('\\', '/')) ?? scriptsDir);
             return new RiderFolder(scriptsDir, modRoot, CreatedFresh: false);   // user-owned: residue cleanup never touches it
@@ -2594,10 +2618,10 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>PURE (no filesystem access) resolution of the output_dir= contract, so the riskiest 6.3 change is provable in
     /// CI without an MO2 instance. Appends Scripts\ to a mod-folder root, with the DOUBLE-SCRIPTS GUARD (a root already ending
-    /// in a Scripts segment — any case, trailing separator tolerated — is taken as-is, never doubled). <paramref name="outputDir"/>
+    /// in a Scripts segment â€” any case, trailing separator tolerated â€” is taken as-is, never doubled). <paramref name="outputDir"/>
     /// is expected absolute (the caller GetFullPaths it). Returns the final Scripts dir, whether Scripts\ was appended, and a
     /// Q3 deployWarning when the result is under neither <paramref name="modsDir"/> (a mod's Scripts\ is VFS-deployed) nor
-    /// <paramref name="dataDir"/> (a direct game install) — the one "this won't load" case the contract can't fix by
+    /// <paramref name="dataDir"/> (a direct game install) â€” the one "this won't load" case the contract can't fix by
     /// construction, so it's surfaced rather than reported as a clean success.</summary>
     internal static (string scriptsDir, bool appendedScripts, string? deployWarning) ScriptOutputContract(
         string outputDir, string modsDir, string dataDir)
@@ -2608,20 +2632,20 @@ public sealed class LoadOrderService : IDisposable
         // Deployable = the .pex will ACTUALLY auto-load. MO2 overlays a mod folder's CONTENTS onto the game Data root, so a
         // deployable mod Scripts\ is EXACTLY <mods>\<modFolder>\Scripts (mod folder a direct child of mods; Scripts directly
         // under it). A bare <mods>\Scripts (no mod folder) and a nested <mods>\X\Sub\Scripts (lands at Data\Sub\Scripts, not
-        // Data\Scripts) do NOT load — so they correctly WARN (review nit: "under mods" alone was too loose). A direct game
+        // Data\Scripts) do NOT load â€” so they correctly WARN (review nit: "under mods" alone was too loose). A direct game
         // install loads exactly <data>\Scripts.
         bool deployable = IsModScriptsFolder(scriptsDir, modsDir) || IsDataScriptsFolder(scriptsDir, dataDir);
         string? warn = deployable ? null :
             $"note: '{scriptsDir}' isn't a folder MO2 (or the game) auto-loads scripts from, so the compiled .pex won't " +
-            "deploy on its own — it compiled fine, but you must place it where the game loads scripts yourself: a mod's " +
+            "deploy on its own â€” it compiled fine, but you must place it where the game loads scripts yourself: a mod's " +
             "own Scripts\\ folder (<mods>\\<YourMod>\\Scripts) or the game's <Data>\\Scripts.";
         return (scriptsDir, !alreadyScripts, warn);
     }
 
-    /// <summary>A Scripts\ folder MO2 actually deploys: <c>&lt;modsDir&gt;\&lt;modFolder&gt;\Scripts</c> exactly — the mod
+    /// <summary>A Scripts\ folder MO2 actually deploys: <c>&lt;modsDir&gt;\&lt;modFolder&gt;\Scripts</c> exactly â€” the mod
     /// folder a DIRECT child of the mods root, Scripts directly under it (MO2 maps a mod folder's contents onto the Data
     /// root, so <c>&lt;mods&gt;\Scripts</c> has no mod and <c>&lt;mods&gt;\X\Sub\Scripts</c> lands at Data\Sub\Scripts). Empty
-    /// mods root (unconfigured) → false. Case-insensitive, normalized.</summary>
+    /// mods root (unconfigured) â†’ false. Case-insensitive, normalized.</summary>
     static bool IsModScriptsFolder(string scriptsDir, string modsDir)
     {
         if (string.IsNullOrEmpty(modsDir)) return false;
@@ -2629,7 +2653,7 @@ public sealed class LoadOrderService : IDisposable
         return modFolder is not null && PathEquals(Path.GetDirectoryName(modFolder), modsDir);
     }
 
-    /// <summary>A direct game install loads exactly <c>&lt;dataDir&gt;\Scripts</c> (not Data\Sub\Scripts). Empty data dir →
+    /// <summary>A direct game install loads exactly <c>&lt;dataDir&gt;\Scripts</c> (not Data\Sub\Scripts). Empty data dir â†’
     /// false. Case-insensitive, normalized.</summary>
     static bool IsDataScriptsFolder(string scriptsDir, string dataDir)
     {
@@ -2638,15 +2662,15 @@ public sealed class LoadOrderService : IDisposable
     }
 
     /// <summary>Case-insensitive equality of two paths after full-path normalization + trailing-separator trim (no
-    /// filesystem access). A null left side (no parent — e.g. a drive root) is never equal.</summary>
+    /// filesystem access). A null left side (no parent â€” e.g. a drive root) is never equal.</summary>
     static bool PathEquals(string? a, string b)
     {
         if (a is null) return false;
         return Path.GetFullPath(a).TrimEnd('\\', '/').Equals(Path.GetFullPath(b).TrimEnd('\\', '/'), StringComparison.OrdinalIgnoreCase);
     }
 
-    /// <summary>The <c>Source\Scripts\</c> output folder for a DECOMPILED .psc (the decompile rider) — the SE-canonical
-    /// source layout, and the same default patch stem as the compile rider so decompile → edit → compile naturally
+    /// <summary>The <c>Source\Scripts\</c> output folder for a DECOMPILED .psc (the decompile rider) â€” the SE-canonical
+    /// source layout, and the same default patch stem as the compile rider so decompile â†’ edit â†’ compile naturally
     /// accumulates in one houseCARL patch folder via <c>into=</c>. Carries the root + fresh flag through for cleanup.</summary>
     public RiderFolder ResolveDecompiledSourceFolder(string? patchName, string? into)
     {
@@ -2657,24 +2681,24 @@ public sealed class LoadOrderService : IDisposable
     }
 
     /// <summary>Hunt H2 (Aaron 2026-06-13): a NON-.esp rider (compile / decompile / repack) that FAILED after creating a
-    /// fresh houseCARL mod folder cleans up after itself — the .esp F4 "a refusal leaves no orphan folder" principle,
+    /// fresh houseCARL mod folder cleans up after itself â€” the .esp F4 "a refusal leaves no orphan folder" principle,
     /// generalised to the riders. If the fresh folder is GENUINELY EMPTY (holds NOTHING but our own meta.ini marker
     /// anywhere in its tree) it is DELETED, so "no output written" is true of the disk; if real output DID land (a
-    /// partial .bsa, some written .psc/.pex), the folder STAYS and its path is RETURNED so the rider can NAME it —
+    /// partial .bsa, some written .psc/.pex), the folder STAYS and its path is RETURNED so the rider can NAME it â€”
     /// houseCARL never deletes content it didn't recognise as its own marker. A REUSED into= folder
     /// (<see cref="RiderFolder.CreatedFresh"/> = false) is never touched: the user owns it. Returns the leftover path to
     /// name, or null (deleted, or nothing to do). Best-effort: a cleanup hiccup never masks the rider's own outcome.</summary>
     internal string? RemoveOrNameRiderResidue(RiderFolder folder)
     {
-        if (!folder.CreatedFresh) return null;             // into= reuse — the user owns it, never deleted or named
+        if (!folder.CreatedFresh) return null;             // into= reuse â€” the user owns it, never deleted or named
         var root = folder.ModFolder;
         try
         {
             if (!Directory.Exists(root)) return null;
             bool onlyMarker = Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories)
                 .All(f => Path.GetFileName(f).Equals("meta.ini", StringComparison.OrdinalIgnoreCase));
-            if (onlyMarker) { Directory.Delete(root, recursive: true); return null; }   // genuinely empty → gone, nothing to name
-            return root;                                   // real output landed → keep it, hand back the path to NAME
+            if (onlyMarker) { Directory.Delete(root, recursive: true); return null; }   // genuinely empty â†’ gone, nothing to name
+            return root;                                   // real output landed â†’ keep it, hand back the path to NAME
         }
         catch (IOException) { return Directory.Exists(root) ? root : null; }
         catch (UnauthorizedAccessException) { return Directory.Exists(root) ? root : null; }
@@ -2682,7 +2706,7 @@ public sealed class LoadOrderService : IDisposable
 
     // ---- Layer B unit D: write the start-game-enabled-quest .seq file (housecarl_write_seq) ----
 
-    /// <summary>The <c>SEQ\</c> output folder for a generated <c>.seq</c> (the SEQ rider) — a houseCARL mod folder via
+    /// <summary>The <c>SEQ\</c> output folder for a generated <c>.seq</c> (the SEQ rider) â€” a houseCARL mod folder via
     /// <see cref="ResolvePatchModFolder"/> plus its <c>SEQ\</c> subfolder, where MO2 deploys it into the game's
     /// <c>Data\SEQ</c>. Sibling of <see cref="ResolveCompiledScriptFolder"/>; carries the mod-folder root + fresh flag
     /// through for residue cleanup.</summary>
@@ -2695,10 +2719,10 @@ public sealed class LoadOrderService : IDisposable
     }
 
     /// <summary>If <paramref name="pluginPath"/> lives in a houseCARL-owned mod folder DIRECTLY under ModsDir, return that
-    /// folder's patch STEM, so the <c>.seq</c> defaults into the SAME folder as the <c>.esp</c> — one mod to enable, and
+    /// folder's patch STEM, so the <c>.seq</c> defaults into the SAME folder as the <c>.esp</c> â€” one mod to enable, and
     /// no second fresh folder the user might forget to enable (a real Q3 footgun: a .seq in an un-enabled folder leaves the
     /// quest silently dead). Only when the folder is the canonical <c>houseCARL - &lt;stem&gt;</c> for THIS plugin (so a
-    /// later <c>into=&lt;stem&gt;</c> resolves to exactly this folder); otherwise null → the caller cuts a fresh folder.</summary>
+    /// later <c>into=&lt;stem&gt;</c> resolves to exactly this folder); otherwise null â†’ the caller cuts a fresh folder.</summary>
     string? OwnedPluginFolderStem(string pluginPath)
     {
         var dir = Path.GetDirectoryName(pluginPath);
@@ -2710,11 +2734,11 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>Write a plugin's start-game-enabled-quest <c>.seq</c> (housecarl_write_seq). Opens <paramref name="plugin"/>
     /// (a path to an .esp/.esm/.esl), collects every Start-Game-Enabled quest it defines, and writes
-    /// <c>&lt;ModFolder&gt;\SEQ\&lt;plugin&gt;.seq</c> — the file the engine reads to actually START those quests (the flag
+    /// <c>&lt;ModFolder&gt;\SEQ\&lt;plugin&gt;.seq</c> â€” the file the engine reads to actually START those quests (the flag
     /// alone does nothing; the same gated, crash-atomic, non-destructive folder-per-patch model as the compile/asset
     /// riders). Output folder DEFAULTS to the plugin's OWN houseCARL folder when it lives in one (so the .seq deploys with
     /// the .esp); else a fresh folder, or <paramref name="into"/>/<paramref name="patchName"/> when given. A plugin with NO
-    /// SGE quests writes NOTHING and cuts no folder (a .seq is only needed for SGE quests — Q3, not a silent empty file).
+    /// SGE quests writes NOTHING and cuts no folder (a .seq is only needed for SGE quests â€” Q3, not a silent empty file).
     /// Serialized on the write gate (one write at a time), like its sibling writers.</summary>
     public SeqOutcome WriteSeq(string plugin, string? patchName, string? into)
     {
@@ -2727,18 +2751,18 @@ public sealed class LoadOrderService : IDisposable
         if (!PluginExts.Contains(Path.GetExtension(pluginPath), StringComparer.OrdinalIgnoreCase))
             return SeqOutcome.Fail($"'{Path.GetFileName(pluginPath)}' is not a plugin (.esp/.esm/.esl).");
 
-        lock (_writeGate)                                                // one write at a time (hunt F2 sibling): build → resolve → commit
+        lock (_writeGate)                                                // one write at a time (hunt F2 sibling): build â†’ resolve â†’ commit
         {
             if (ConfigPromptOrNull() is { } cfgPrompt) return SeqOutcome.Fail(cfgPrompt);   // need ModsDir for the output folder
-            lock (_gate) EnsurePathsDerived();                          // derive ModsDir for the owned-folder check (lock order: _writeGate → _gate)
+            lock (_gate) EnsurePathsDerived();                          // derive ModsDir for the owned-folder check (lock order: _writeGate â†’ _gate)
 
-            // Build the .seq from the plugin (read-only overlay, disposed inside — zero handles at rest).
+            // Build the .seq from the plugin (read-only overlay, disposed inside â€” zero handles at rest).
             SeqFile.SeqBuild built;
             try { built = SeqFile.Build(pluginPath); }
             catch (Exception ex)
             { return SeqOutcome.Fail($"could not read '{Path.GetFileName(pluginPath)}' as a plugin: {ex.Message}"); }
 
-            // No SGE quests → no .seq needed; write nothing, cut no folder (Q3: a clean, explicit "nothing to do").
+            // No SGE quests â†’ no .seq needed; write nothing, cut no folder (Q3: a clean, explicit "nothing to do").
             if (built.Quests.Count == 0)
                 return new SeqOutcome(true, null, null, null, built.Quests, built.PluginFileName, false);
 
@@ -2749,21 +2773,21 @@ public sealed class LoadOrderService : IDisposable
             try { rf = ResolveSeqFolder(patchName, autoInto ?? into); }
             catch (InvalidOperationException ex) { return SeqOutcome.Fail(ex.Message); }
 
-            // Crash-atomic write of <plugin>.seq under SEQ\ (originals untouched — a houseCARL-owned folder only).
+            // Crash-atomic write of <plugin>.seq under SEQ\ (originals untouched â€” a houseCARL-owned folder only).
             var seqName = Path.GetFileNameWithoutExtension(pluginPath) + ".seq";
             var dest = Path.Combine(rf.OutputDir, seqName);
             try { AtomicFile.WriteAllBytes(dest, built.Bytes); }
             catch (Exception ex)
             {
-                var residue = RemoveOrNameRiderResidue(rf);             // nothing landed → a fresh folder is an orphan
+                var residue = RemoveOrNameRiderResidue(rf);             // nothing landed â†’ a fresh folder is an orphan
                 return SeqOutcome.Fail($"could not write '{seqName}': {ex.Message}"
                     + (residue is null ? "" : $" The freshly created folder was left at '{residue}'."));
             }
 
-            // Integrity (Q3: THIS run wrote it; on-disk size matches the bytes we built — no false success).
+            // Integrity (Q3: THIS run wrote it; on-disk size matches the bytes we built â€” no false success).
             long size; try { size = new FileInfo(dest).Length; } catch { size = -1; }
             if (size != built.Bytes.Length)
-                return SeqOutcome.Fail($"wrote '{seqName}' but its on-disk size ({size}) does not match the {built.Bytes.Length} expected byte(s) — verify before relying on it.");
+                return SeqOutcome.Fail($"wrote '{seqName}' but its on-disk size ({size}) does not match the {built.Bytes.Length} expected byte(s) â€” verify before relying on it.");
 
             return new SeqOutcome(true, null, dest, rf.ModFolder, built.Quests, built.PluginFileName, autoInto is not null);
         }
@@ -2776,18 +2800,18 @@ public sealed class LoadOrderService : IDisposable
     readonly object _classParentsLock = new();
 
     /// <summary>Drop the cached hierarchy whenever <see cref="_modsDir"/> can have changed (instance switch /
-    /// profile re-derive) — a stale tree's edges could suppress a cast the NEW order's hierarchy doesn't
-    /// justify (a recompile-fail, not silent wrong semantics — but stale is stale). Rebuilds lazily.</summary>
+    /// profile re-derive) â€” a stale tree's edges could suppress a cast the NEW order's hierarchy doesn't
+    /// justify (a recompile-fail, not silent wrong semantics â€” but stale is stale). Rebuilds lazily.</summary>
     void InvalidateClassParents() { lock (_classParentsLock) { _classParents = null; _classParentsNote = null; } }
 
-    /// <summary>The decompiler's child→parent class map: committed vanilla baseline (beside the exe) + loose .psc
-    /// headers across the MO2 mods tree (mods that ship sources — SKSE, PO3, …). Built on FIRST decompile call,
+    /// <summary>The decompiler's childâ†’parent class map: committed vanilla baseline (beside the exe) + loose .psc
+    /// headers across the MO2 mods tree (mods that ship sources â€” SKSE, PO3, â€¦). Built on FIRST decompile call,
     /// cached for process lifetime (a SOFT input by construction: missing pieces = explicit casts in the output,
-    /// never wrong code — the note names any degraded mode, Q3). The input pex's own folder is topped up per call
-    /// by the tool, not here (it varies per input). Paths derive FIRST (under the gate — the established
-    /// gate→parents lock order): in instance mode ModsDir is lazy, and a decompile-first session used to build
+    /// never wrong code â€” the note names any degraded mode, Q3). The input pex's own folder is topped up per call
+    /// by the tool, not here (it varies per input). Paths derive FIRST (under the gate â€” the established
+    /// gateâ†’parents lock order): in instance mode ModsDir is lazy, and a decompile-first session used to build
     /// and cache the baseline-only map for process lifetime with the mods-tree harvest silently skipped
-    /// (2026-06-12 adversarial hunt F1, proven — the third _modsDir-mutation site missed by the PR #47 fix).</summary>
+    /// (2026-06-12 adversarial hunt F1, proven â€” the third _modsDir-mutation site missed by the PR #47 fix).</summary>
     public (Dictionary<string, string> Edges, string? Note) ClassParentsForDecompile()
     {
         lock (_gate)
@@ -2806,7 +2830,7 @@ public sealed class LoadOrderService : IDisposable
                     if (!string.IsNullOrEmpty(_modsDir) && Directory.Exists(_modsDir))
                         HousecarlCore.PapyrusClassParents.AddFromPscHeaders(edges, new[] { _modsDir });
                 }
-                catch { /* fewer edges, never fatal — the baseline still applies */ }
+                catch { /* fewer edges, never fatal â€” the baseline still applies */ }
                 _classParents = edges;
                 _classParentsNote = note;
             }
@@ -2818,14 +2842,14 @@ public sealed class LoadOrderService : IDisposable
     /// pane and is the human-visible ownership signal (the meta.ini marker is the structural one).</summary>
     static string ModFolderName(string stem) => "houseCARL - " + stem;
 
-    /// <summary>Plugin extensions stripped from a caller-supplied patch name (case-insensitive). NOT every dot — see
+    /// <summary>Plugin extensions stripped from a caller-supplied patch name (case-insensitive). NOT every dot â€” see
     /// <see cref="PatchStem"/>. Aliases the one shared home (<see cref="HousecarlCore.PluginFile.Extensions"/>) so this
     /// and the load-order reader / name-suggester copies can't diverge.</summary>
     static readonly string[] PluginExts = PluginFile.Extensions;
 
-    /// <summary>Reduce a caller name to a safe bare STEM — no directory parts (so "../x" / "C:\y" can't escape ModsDir),
+    /// <summary>Reduce a caller name to a safe bare STEM â€” no directory parts (so "../x" / "C:\y" can't escape ModsDir),
     /// stripping ONLY a trailing plugin extension (.esp/.esm/.esl), not every dot. A dotted patch name like
-    /// "My.Cool.Patch" must survive intact: Path.GetFileNameWithoutExtension would clip it to "My.Cool" — and then an
+    /// "My.Cool.Patch" must survive intact: Path.GetFileNameWithoutExtension would clip it to "My.Cool" â€” and then an
     /// into="My.Cool.Patch" extend would look for the wrong folder, a silent name divergence. The plugin is always
     /// <c>&lt;stem&gt;.esp</c>; the mod folder is <c>houseCARL - &lt;stem&gt;</c>.</summary>
     static string PatchStem(string raw)
@@ -2836,7 +2860,7 @@ public sealed class LoadOrderService : IDisposable
         return string.IsNullOrEmpty(name) ? "houseCARL_Patch" : name;
     }
 
-    /// <summary>The given stem if its mod folder is free, else the first free "<c>&lt;stem&gt;_NNN</c>" — never clobbers
+    /// <summary>The given stem if its mod folder is free, else the first free "<c>&lt;stem&gt;_NNN</c>" â€” never clobbers
     /// an existing folder (houseCARL's own OR a user's; into= is the way to grow an existing houseCARL patch).</summary>
     string UniqueStem(string stem)
     {
@@ -2846,17 +2870,17 @@ public sealed class LoadOrderService : IDisposable
             var cand = $"{stem}_{i:D3}";
             if (!Directory.Exists(Path.Combine(_modsDir, ModFolderName(cand)))) return cand;
         }
-        throw new InvalidOperationException($"too many patches named '{stem}' under ModsDir — clean some out.");
+        throw new InvalidOperationException($"too many patches named '{stem}' under ModsDir â€” clean some out.");
     }
 
     /// <summary>The 4-step <c>into=</c> EXTEND resolver, SHARED by the .esp write path (<see cref="ResolveOutputPath"/>)
     /// and the rider/asset path (<see cref="ResolvePatchModFolder"/>) so "extend my renamed patch" behaves IDENTICALLY
-    /// across records, scripts, BSAs, and assets (HCBR-2026-06-23 — the record lane was fixed first; this closes the
+    /// across records, scripts, BSAs, and assets (HCBR-2026-06-23 â€” the record lane was fixed first; this closes the
     /// sibling). Resolves <paramref name="into"/> to the houseCARL-OWNED mod FOLDER it names: (1) the canonical
-    /// "houseCARL - &lt;stem&gt;" fast path; (2) by the &lt;stem&gt;.esp it HOLDS (the folder was renamed — the .esp basename
+    /// "houseCARL - &lt;stem&gt;" fast path; (2) by the &lt;stem&gt;.esp it HOLDS (the folder was renamed â€” the .esp basename
     /// is fixed by SPID/CSF/masters); (3) by the folder's OWN name (the catch-all; folder &amp; plugin names need not match);
     /// (4) loud Q3 refusals naming every place searched, a FOREIGN (un-owned) collision distinguished from a genuine miss.
-    /// Ownership-gated at every step — a plugin houseCARL didn't make stays refused (no foreign-plugin door; that's the
+    /// Ownership-gated at every step â€” a plugin houseCARL didn't make stays refused (no foreign-plugin door; that's the
     /// separate in-place lane). <paramref name="needEsp"/> tightens the canonical fast path for the RECORD lane (the folder
     /// must actually hold &lt;stem&gt;.esp to short-circuit, else fall through); the rider lane targets the folder itself, so
     /// it short-circuits on folder-exists+owned. Caller holds <see cref="_gate"/>.</summary>
@@ -2865,29 +2889,29 @@ public sealed class LoadOrderService : IDisposable
         var stem = PatchStem(into);                             // strips a trailing .esp/.esm/.esl; no directory parts (can't escape ModsDir)
         var espName = stem + ".esp";
 
-        // (1) CANONICAL fast path — "houseCARL - <stem>" still owns the patch (common case; no scan). The record lane also
+        // (1) CANONICAL fast path â€” "houseCARL - <stem>" still owns the patch (common case; no scan). The record lane also
         //     requires it to HOLD <stem>.esp (needEsp); the rider lane only needs the owned folder.
         var canonical = Path.Combine(_modsDir, ModFolderName(stem));
         if (Directory.Exists(canonical) && IsHouseCarlOwned(canonical) && (!needEsp || File.Exists(Path.Combine(canonical, espName))))
             return canonical;
 
-        // (2) by PLUGIN name — the owned folder HOLDING <stem>.esp, whatever it's now called (the renamed-folder case).
+        // (2) by PLUGIN name â€” the owned folder HOLDING <stem>.esp, whatever it's now called (the renamed-folder case).
         var byEsp = OwnedFoldersHolding(espName)
             .Select(p => Path.GetDirectoryName(p)!).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
         if (byEsp.Count == 1) return byEsp[0];
         if (byEsp.Count > 1)
             throw new InvalidOperationException(
-                $"cannot extend: {byEsp.Count} houseCARL folders carry '{espName}' — ambiguous, refusing to guess. " +
+                $"cannot extend: {byEsp.Count} houseCARL folders carry '{espName}' â€” ambiguous, refusing to guess. " +
                 "Pass the CONTAINING mod-folder name as into= to pick one (folder & plugin names need not match): " +
                 string.Join("  |  ", byEsp.Select(d => $"into=\"{Path.GetFileName(d)}\"")) + ".");
 
-        // (3) FOLDER catch-all — into= NAMES the mod folder itself (the same-named-plugin disambiguator, and the way to
+        // (3) FOLDER catch-all â€” into= NAMES the mod folder itself (the same-named-plugin disambiguator, and the way to
         //     point at a renamed folder by its new name).
         var named = ResolveOwnedFolderByName(into);
         if (named is not null) return named;
 
-        // (4) Nothing matched. Distinguish a FOREIGN (un-owned) name collision — refused for the same reason as ever
-        //     (originals untouched, Q3) — from a genuine miss, NAMING every place searched (the report asked the refusal
+        // (4) Nothing matched. Distinguish a FOREIGN (un-owned) name collision â€” refused for the same reason as ever
+        //     (originals untouched, Q3) â€” from a genuine miss, NAMING every place searched (the report asked the refusal
         //     to reveal all the required pieces at once, not one half per failed call).
         var bareName = Path.GetFileName(into.Trim());
         foreach (var cand in new[] { ModFolderName(stem), bareName })
@@ -2895,7 +2919,7 @@ public sealed class LoadOrderService : IDisposable
             var candPath = string.IsNullOrEmpty(cand) ? null : Path.Combine(_modsDir, cand);
             if (candPath is not null && Directory.Exists(candPath) && !IsHouseCarlOwned(candPath))
                 throw new InvalidOperationException(
-                    $"cannot extend: mod folder '{cand}' exists but was NOT created by houseCARL (no marker) — " +
+                    $"cannot extend: mod folder '{cand}' exists but was NOT created by houseCARL (no marker) â€” " +
                     "refusing to write into a folder houseCARL doesn't own (originals untouched, Q3). Use a different patch name.");
         }
         throw new InvalidOperationException(
@@ -2906,7 +2930,7 @@ public sealed class LoadOrderService : IDisposable
     }
 
     /// <summary>houseCARL-OWNED mod folders under ModsDir holding a plugin file named <paramref name="espFileName"/> at
-    /// their root — the decoupled resolver behind <c>into=</c>. The .esp basename is FIXED (SPID <c>_DISTR</c>, the CSF
+    /// their root â€” the decoupled resolver behind <c>into=</c>. The .esp basename is FIXED (SPID <c>_DISTR</c>, the CSF
     /// JSON, and masters all bind the patch by its filename), while the MO2 mod-FOLDER name is the user's to rename for
     /// organization; so an extend finds the patch by the plugin it holds, not by the folder's current name. Ownership-gated
     /// (the marker) so a user mod that merely shares the basename is NEVER returned (originals untouched, Q3). Full .esp paths.</summary>
@@ -2922,9 +2946,9 @@ public sealed class LoadOrderService : IDisposable
     }
 
     /// <summary>A houseCARL-OWNED mod folder named exactly <paramref name="rawName"/> or "<c>houseCARL - &lt;rawName&gt;</c>"
-    /// — the FOLDER catch-all behind <c>into=</c>: the user NAMES the containing mod folder when the plugin basename is
+    /// â€” the FOLDER catch-all behind <c>into=</c>: the user NAMES the containing mod folder when the plugin basename is
     /// ambiguous (or to point at a renamed folder by its new name), and the folder name need NOT match the .esp inside.
-    /// Bare name only (no directory parts — can't escape ModsDir). Null when no such folder is houseCARL-owned.</summary>
+    /// Bare name only (no directory parts â€” can't escape ModsDir). Null when no such folder is houseCARL-owned.</summary>
     string? ResolveOwnedFolderByName(string rawName)
     {
         var bare = Path.GetFileName(rawName.Trim());
@@ -2939,7 +2963,7 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>The single top-level plugin (.esp/.esm/.esl) in a houseCARL folder, so <c>into=</c> a folder NAME can edit
     /// "the plugin in this folder" without re-stating its basename. Null + a named <paramref name="reason"/> when the folder
-    /// holds none or more than one (Q3 — never guess which of several to extend).</summary>
+    /// holds none or more than one (Q3 â€” never guess which of several to extend).</summary>
     static string? SoleEspInFolder(string folder, out string reason)
     {
         var plugins = Directory.EnumerateFiles(folder)
@@ -2948,12 +2972,12 @@ public sealed class LoadOrderService : IDisposable
         if (plugins.Count == 1) { reason = ""; return plugins[0]; }
         reason = plugins.Count == 0
             ? "holds no plugin (.esp/.esm/.esl) to extend"
-            : $"holds {plugins.Count} plugins ({string.Join(", ", plugins.Select(Path.GetFileName))}) — name the one to extend by passing its filename as into=";
+            : $"holds {plugins.Count} plugins ({string.Join(", ", plugins.Select(Path.GetFileName))}) â€” name the one to extend by passing its filename as into=";
         return null;
     }
 
     /// <summary>A mod folder is houseCARL-owned iff its <c>meta.ini</c> carries the <c>[houseCARL] generated=true</c>
-    /// marker. The marker lives in meta.ini — the one mod-root file MO2 does NOT deploy into the game Data folder — so it
+    /// marker. The marker lives in meta.ini â€” the one mod-root file MO2 does NOT deploy into the game Data folder â€” so it
     /// never pollutes Data. FAIL-SAFE (Q3): a missing / stripped marker reads as NOT owned, so houseCARL refuses to
     /// modify the folder rather than risk touching a user mod.</summary>
     static bool IsHouseCarlOwned(string folder)
@@ -2997,16 +3021,16 @@ public sealed class LoadOrderService : IDisposable
 
     // ---- housecarl_read_plugin_file : a RAW, out-of-load-order read of ONE plugin FILE (active or not) ----
 
-    /// <summary>Read ONE plugin file directly off disk — INCLUDING a plugin DISABLED in MO2 — returning THAT FILE's
+    /// <summary>Read ONE plugin file directly off disk â€” INCLUDING a plugin DISABLED in MO2 â€” returning THAT FILE's
     /// own version of a record (<paramref name="formid"/>), the records of a type it defines (<paramref name="type"/>),
     /// or a record-type summary (neither). The standalone-copy chain's Stage-1 enabler: it reaches a donor you're
     /// REMOVING from the active order, which the resolver (active profile only) cannot see.
     ///
     /// <para>STRUCTURAL PURITY (why a separate method, not a flag on <see cref="ResolveRead"/>): it opens its OWN
-    /// overlay via <see cref="LoadOrderResolver.OpenOverlay"/>, materialises, and DISPOSES it — it never consults the
+    /// overlay via <see cref="LoadOrderResolver.OpenOverlay"/>, materialises, and DISPOSES it â€” it never consults the
     /// resolver index and never reports a winner/conflict, so a raw-file read cannot masquerade as load-order truth
     /// (the renderer stamps every result OUT-OF-LOAD-ORDER) and no handle is held at rest (the donor is never locked).
-    /// It emits FormLink fields as FormKey tokens exactly like <see cref="ResolveRead"/> — it does NOT follow links, so
+    /// It emits FormLink fields as FormKey tokens exactly like <see cref="ResolveRead"/> â€” it does NOT follow links, so
     /// it needs no master files present; declared masters that are not installed are reported as an advisory (Q3).</para>
     ///
     /// <para>Read-only. Q3: a missing/ambiguous filename, a bad or absent FormID, or a record Mutagen cannot parse is
@@ -3015,7 +3039,7 @@ public sealed class LoadOrderService : IDisposable
                                             IReadOnlyList<string>? fields, int depth, string? editoridContains, int limit)
     {
         if (string.IsNullOrWhiteSpace(plugin))
-            return PluginFileOutcome.Fail(plugin ?? "", "plugin is required — a plugin filename (e.g. 'Vivace.esp') or an absolute path to a .esp/.esm/.esl.");
+            return PluginFileOutcome.Fail(plugin ?? "", "plugin is required â€” a plugin filename (e.g. 'Vivace.esp') or an absolute path to a .esp/.esm/.esl.");
         plugin = plugin.Trim();
 
         bool hasFormid = !string.IsNullOrWhiteSpace(formid);
@@ -3035,50 +3059,31 @@ public sealed class LoadOrderService : IDisposable
         try { lock (_gate) { EnsurePathsDerived(); modsDir = _modsDir; dataDir = _dataDir; overwriteDir = _overwriteDir; profileDir = _profileDir; } }
         catch (Exception ex) { return PluginFileOutcome.Fail(plugin, ex.Message); }
 
-        var comp = Mo2LoadOrder.ReadComposition(profileDir);           // cheap text parse (enabled + disabled folders) — reused for locate + master advisory
+        var comp = Mo2LoadOrder.ReadComposition(profileDir);           // cheap text parse (enabled + disabled folders) â€” reused for locate + master advisory
 
-        // Locate the file. A direct PATH (rooted / has a separator) is used verbatim — "inspect ANY plugin file";
-        // otherwise treat `plugin` as a FILENAME and find it across the whole install. mod= narrows a name several
-        // folders provide to one MO2 mod folder.
-        string path, where; bool enabled;
-        if (LooksLikePath(plugin))
-        {
-            if (!File.Exists(plugin)) return PluginFileOutcome.Fail(plugin, $"no file at path '{plugin}'.");
-            path = Path.GetFullPath(plugin); where = "direct path"; enabled = false;
-        }
-        else if (!string.IsNullOrWhiteSpace(mod))
-        {
-            var fn = Path.GetFileName(plugin);
-            var cand = Path.Combine(modsDir, mod.Trim(), fn);
-            if (!File.Exists(cand)) return PluginFileOutcome.Fail(plugin, $"mod folder '{mod.Trim()}' under ModsDir does not provide '{fn}'.");
-            path = cand; where = $"mod '{mod.Trim()}'"; enabled = comp.EnabledMods.Contains(mod.Trim(), StringComparer.OrdinalIgnoreCase);
-        }
-        else
-        {
-            var hits = Mo2LoadOrder.LocatePlugin(comp, modsDir, dataDir, overwriteDir, plugin);
-            if (hits.Count == 0)
-                return PluginFileOutcome.Fail(plugin, $"'{Path.GetFileName(plugin)}' is in no mod folder (enabled or disabled), the overwrite folder, or the game Data folder. Check the filename, pass an absolute path, or (if it's an MO2 mod) the exact folder via mod=.");
-            if (hits.Count > 1)
-                return PluginFileOutcome.AmbiguousHits(plugin, hits);
-            path = hits[0].Path; where = hits[0].Where; enabled = hits[0].Enabled;
-        }
+        // Locate the file â€” the shared on-disk plugin-locate contract (also the copy-npc-appearance donor lane;
+        // one home so the two tools can never find different files for the same filename).
+        var loc = LocatePluginFileOnDisk(comp, modsDir, dataDir, overwriteDir, plugin, mod);
+        if (loc.Error is not null) return PluginFileOutcome.Fail(plugin, loc.Error);
+        if (loc.Ambiguous is not null) return PluginFileOutcome.AmbiguousHits(plugin, loc.Ambiguous);
+        string path = loc.Path!, where = loc.Where; bool enabled = loc.Enabled;
 
-        // Open OUR OWN overlay (OpenOverlay wires localized-string resolution), read, then DISPOSE — zero handles at rest.
+        // Open OUR OWN overlay (OpenOverlay wires localized-string resolution), read, then DISPOSE â€” zero handles at rest.
         ISkyrimModGetter ov;
         try { ov = LoadOrderResolver.OpenOverlay(path, string.IsNullOrEmpty(dataDir) ? null : dataDir); }
         catch (Exception ex) { return PluginFileOutcome.Fail(plugin, $"could not open '{path}' as a Skyrim plugin: {ex.Message}"); }
         try
         {
             var masters = ov.ModHeader.MasterReferences.Select(m => m.Master.FileName.ToString()).ToList();
-            // Classify each declared master by whether it will actually LOAD (Q3 — the "won't load without them" warning
+            // Classify each declared master by whether it will actually LOAD (Q3 â€” the "won't load without them" warning
             // must fire exactly when it applies). Two distinct shortfalls, because their remedies differ:
-            //   • missing  — installed NOWHERE in the install (install it).
-            //   • inactive — installed but NOT in the active order: it lives only in a DISABLED mod, or is unchecked
+            //   â€¢ missing  â€” installed NOWHERE in the install (install it).
+            //   â€¢ inactive â€” installed but NOT in the active order: it lives only in a DISABLED mod, or is unchecked
             //                (enable it). A disabled mod is not active, so counting its file as "satisfied" would be the
             //                precise false-negative this split exists to prevent (PR #148 review): it suppresses the
             //                "won't load" warning exactly when it applies.
-            // "Active" is read from the PROFILE (plugins.txt actives + the force-loaded implicit masters) — the same
-            // active-order notion housecarl_check_errors uses — NOT mere on-disk presence, so the two tools agree.
+            // "Active" is read from the PROFILE (plugins.txt actives + the force-loaded implicit masters) â€” the same
+            // active-order notion housecarl_check_errors uses â€” NOT mere on-disk presence, so the two tools agree.
             var missing = new List<string>();
             var inactive = new List<string>();
             foreach (var m in masters)
@@ -3098,9 +3103,9 @@ public sealed class LoadOrderService : IDisposable
             {
                 IMajorRecordGetter? rec;
                 try { rec = ov.EnumerateMajorRecords().FirstOrDefault(r => r.FormKey == fk); }
-                catch (Exception ex) { return baseOut with { Mode = "error", Error = $"'{Path.GetFileName(path)}' could not be fully read — a record Mutagen cannot parse before reaching {fk}: {ex.Message}" }; }
+                catch (Exception ex) { return baseOut with { Mode = "error", Error = $"'{Path.GetFileName(path)}' could not be fully read â€” a record Mutagen cannot parse before reaching {fk}: {ex.Message}" }; }
                 if (rec is null)
-                    return baseOut with { Mode = "error", Error = $"file '{Path.GetFileName(path)}' does not define or override {fk}. This reads the FILE's OWN records only — it does not resolve across masters or report a load-order winner; use housecarl_read_record for the winner." };
+                    return baseOut with { Mode = "error", Error = $"file '{Path.GetFileName(path)}' does not define or override {fk}. This reads the FILE's OWN records only â€” it does not resolve across masters or report a load-order winner; use housecarl_read_record for the winner." };
                 return baseOut with { Mode = "read", Record = ReadEngine.ReadFields(rec, fields, depth <= 0 ? 1 : depth) };
             }
 
@@ -3123,11 +3128,11 @@ public sealed class LoadOrderService : IDisposable
                         else capped = true;
                     }
                 }
-                catch (Exception ex) { return baseOut with { Mode = "error", Error = $"'{Path.GetFileName(path)}' could not be fully enumerated — a record Mutagen cannot parse: {ex.Message}" }; }
+                catch (Exception ex) { return baseOut with { Mode = "error", Error = $"'{Path.GetFileName(path)}' could not be fully enumerated â€” a record Mutagen cannot parse: {ex.Message}" }; }
                 return baseOut with { Mode = "enumerate", Rows = rows, RowTotal = total, Capped = capped };
             }
 
-            // neither → a record-type summary of what the file defines/overrides (donor discovery).
+            // neither â†’ a record-type summary of what the file defines/overrides (donor discovery).
             var counts = new Dictionary<string, int>(StringComparer.Ordinal);
             int recTotal = 0;
             try
@@ -3139,7 +3144,7 @@ public sealed class LoadOrderService : IDisposable
                     counts[tn] = counts.TryGetValue(tn, out var c) ? c + 1 : 1;
                 }
             }
-            catch (Exception ex) { return baseOut with { Mode = "error", Error = $"'{Path.GetFileName(path)}' could not be fully enumerated — a record Mutagen cannot parse: {ex.Message}" }; }
+            catch (Exception ex) { return baseOut with { Mode = "error", Error = $"'{Path.GetFileName(path)}' could not be fully enumerated â€” a record Mutagen cannot parse: {ex.Message}" }; }
             var typeCounts = counts.OrderByDescending(kv => kv.Value).ThenBy(kv => kv.Key, StringComparer.Ordinal)
                                    .Select(kv => new PluginTypeCount(kv.Key, kv.Value)).ToList();
             return baseOut with { Mode = "summary", TypeCounts = typeCounts, RecordTotal = recTotal };
@@ -3148,23 +3153,56 @@ public sealed class LoadOrderService : IDisposable
         finally { (ov as IDisposable)?.Dispose(); }
     }
 
-    /// <summary>Does the user's `plugin` argument denote a PATH (use verbatim — the "inspect any file" case) rather
+    /// <summary>One located plugin file, or why not. Exactly one of Path / Ambiguous / Error is set.</summary>
+    internal readonly record struct PluginLocateResult(
+        string? Path, string Where, bool Enabled, IReadOnlyList<PluginFileHit>? Ambiguous, string? Error);
+
+    /// <summary>THE on-disk plugin-locate contract, shared by read_plugin_file and the copy-npc-appearance donor
+    /// lane (review finding: a second inline copy had already diverged â€” the mod= lane forgot the enabled flag). A
+    /// direct PATH (rooted / has a separator) is used verbatim ("inspect ANY plugin file"); otherwise the argument
+    /// is a FILENAME found across the whole install (enabled + disabled mod folders, overwrite, Data), with
+    /// <paramref name="mod"/> narrowing a name several folders provide. Ambiguity comes back structured â€” each
+    /// caller renders its own remedy.</summary>
+    internal static PluginLocateResult LocatePluginFileOnDisk(
+        Mo2Composition comp, string modsDir, string dataDir, string overwriteDir, string plugin, string? mod)
+    {
+        if (LooksLikePath(plugin))
+        {
+            if (!File.Exists(plugin)) return new(null, "", false, null, $"no file at path '{plugin}'.");
+            return new(Path.GetFullPath(plugin), "direct path", false, null, null);
+        }
+        if (!string.IsNullOrWhiteSpace(mod))
+        {
+            var fn = Path.GetFileName(plugin);
+            var cand = Path.Combine(modsDir, mod.Trim(), fn);
+            if (!File.Exists(cand)) return new(null, "", false, null, $"mod folder '{mod.Trim()}' under ModsDir does not provide '{fn}'.");
+            return new(cand, $"mod '{mod.Trim()}'", comp.EnabledMods.Contains(mod.Trim(), StringComparer.OrdinalIgnoreCase), null, null);
+        }
+        var hits = Mo2LoadOrder.LocatePlugin(comp, modsDir, dataDir, overwriteDir, plugin);
+        if (hits.Count == 0)
+            return new(null, "", false, null,
+                $"'{Path.GetFileName(plugin)}' is in no mod folder (enabled or disabled), the overwrite folder, or the game Data folder. Check the filename, pass an absolute path, or (if it's an MO2 mod) the exact folder via mod=.");
+        if (hits.Count > 1) return new(null, "", false, hits, null);
+        return new(hits[0].Path, hits[0].Where, hits[0].Enabled, null, null);
+    }
+
+    /// <summary>Does the user's `plugin` argument denote a PATH (use verbatim â€” the "inspect any file" case) rather
     /// than a bare filename (locate in the MO2 folders)? True if rooted or carrying a directory separator: 'C:\..\X.esp'
     /// or 'mods\M\X.esp' is a path; a bare 'X.esp' is a filename.</summary>
     static bool LooksLikePath(string s) => Path.IsPathRooted(s) || s.Contains('\\') || s.Contains('/');
 
-    // ---- corpus-backed type resolution (signature "WEAP" / catalog name "Weapon" → getter Type(s)) -------
+    // ---- corpus-backed type resolution (signature "WEAP" / catalog name "Weapon" â†’ getter Type(s)) -------
 
     Dictionary<string, List<Type>>? _typeLookup;
     Dictionary<string, List<Type>> TypeLookup => _typeLookup ??= BuildTypeLookup();
 
-    /// <summary>Build the type-string → getter-Type(s) map from the corpus (the authoritative type catalog).
+    /// <summary>Build the type-string â†’ getter-Type(s) map from the corpus (the authoritative type catalog).
     /// Keyed by BOTH catalog name and 4-char signature; the 2 many-to-one signatures (GMST/GLOB) accumulate
     /// their variants so a signature query unions them. The 2 abstract-group BASE names (Global / GameSetting,
-    /// kind="polymorphic-base") map to their concrete arms' getter Types BY CONSTRUCTION — the same arm union the
-    /// GMST/GLOB signature already yields — so a query by the base name unions them too and the ambiguity branch at
+    /// kind="polymorphic-base") map to their concrete arms' getter Types BY CONSTRUCTION â€” the same arm union the
+    /// GMST/GLOB signature already yields â€” so a query by the base name unions them too and the ambiguity branch at
     /// ResolveTypeFilter's callers names the variants. A corpus AQ name that won't load is skipped here and surfaces
-    /// as "unknown type" at query time — never a silent wrong type.</summary>
+    /// as "unknown type" at query time â€” never a silent wrong type.</summary>
     static Dictionary<string, List<Type>> BuildTypeLookup()
     {
         var lookup = new Dictionary<string, List<Type>>(StringComparer.OrdinalIgnoreCase);
@@ -3183,8 +3221,8 @@ public sealed class LoadOrderService : IDisposable
             Add(ts.Name, t);
             Add(ts.Signature, t);
         }
-        // Abstract-group base names (Global / GameSetting) → their concrete arms' getter Types. The arms are listed
-        // on the polymorphic-base's own corpus entry, so the union is derived, not hand-wired (cornerstone §3): a query
+        // Abstract-group base names (Global / GameSetting) â†’ their concrete arms' getter Types. The arms are listed
+        // on the polymorphic-base's own corpus entry, so the union is derived, not hand-wired (cornerstone Â§3): a query
         // type='Global' resolves to the same set GLOB does, and the existing many-match guidance names the variants.
         foreach (var ts in corpus.Types.Values)
         {
@@ -3197,7 +3235,7 @@ public sealed class LoadOrderService : IDisposable
         return lookup;
     }
 
-    /// <summary>A user type string → its getter Type(s). Throws (Q3) naming the bad input and what's expected.</summary>
+    /// <summary>A user type string â†’ its getter Type(s). Throws (Q3) naming the bad input and what's expected.</summary>
     IReadOnlyList<Type> ResolveTypeFilter(string type)
     {
         if (TypeLookup.TryGetValue(type.Trim(), out var types)) return types;
@@ -3211,7 +3249,7 @@ public sealed class LoadOrderService : IDisposable
     }
 }
 
-/// <summary>The outcome of a read_record resolve+read. <see cref="Error"/> non-null ⇒ the read failed (with a
+/// <summary>The outcome of a read_record resolve+read. <see cref="Error"/> non-null â‡’ the read failed (with a
 /// recoverable, named reason); otherwise <see cref="Record"/> carries the fields read off <see cref="SourcePlugin"/>.</summary>
 public sealed record ReadOutcome(
     FormKey FormKey,
@@ -3225,13 +3263,13 @@ public sealed record ReadOutcome(
     public static ReadOutcome Fail(FormKey fk, string error) => new(fk, null, null, null, 0, null, error);
 }
 
-/// <summary>The outcome of a cross_plugin_query. <see cref="Error"/> non-null ⇒ the query was rejected (with a
-/// recoverable, named reason — bad filter combo / unknown type / plugin not in order). Otherwise <see cref="Keys"/>
+/// <summary>The outcome of a cross_plugin_query. <see cref="Error"/> non-null â‡’ the query was rejected (with a
+/// recoverable, named reason â€” bad filter combo / unknown type / plugin not in order). Otherwise <see cref="Keys"/>
 /// are the matched FormKeys (at most `limit`); <see cref="Prefilled"/> (parallel to Keys) carries the in-hand
 /// summaries for the type/plugins paths, or is null for the conflicts_only-alone path (the renderer fills those
 /// lazily, bounded by max_chars). <see cref="Sources"/> (parallel to Keys) is the plugin whose body produced each
-/// match — the scoped plugin under plugins=, or null under type=/conflicts_only (⇒ the renderer displays the
-/// winner) — so the detail render shows the SAME body the scan filtered and display never contradicts filter.
+/// match â€” the scoped plugin under plugins=, or null under type=/conflicts_only (â‡’ the renderer displays the
+/// winner) â€” so the detail render shows the SAME body the scan filtered and display never contradicts filter.
 /// <see cref="Total"/> is the true match count; <see cref="Capped"/> is true when Total exceeded what was returned.</summary>
 public sealed record CrossQueryOutcome(
     IReadOnlyList<FormKey> Keys, IReadOnlyList<RecordSummary>? Prefilled, int Total, bool Capped, string? Error,
@@ -3240,20 +3278,20 @@ public sealed record CrossQueryOutcome(
     public static CrossQueryOutcome Fail(string error) => new(Array.Empty<FormKey>(), null, 0, false, error);
 }
 
-/// <summary>A compact, header-only record summary (no field dump) — the per-match line cross_plugin_query emits
-/// by default. <see cref="Error"/> non-null ⇒ the winner couldn't be summarised (named, recoverable — Q3).</summary>
+/// <summary>A compact, header-only record summary (no field dump) â€” the per-match line cross_plugin_query emits
+/// by default. <see cref="Error"/> non-null â‡’ the winner couldn't be summarised (named, recoverable â€” Q3).</summary>
 public sealed record RecordSummary(FormKey FormKey, string Type, string? EditorId, string Winner, int OverrideDepth, string? Error);
 
 /// <summary>One enumerate/read row from a raw plugin-file read: a record the file DEFINES or OVERRIDES, as its
-/// FormKey + type + EditorID. NOT a load-order winner — the FILE's own record.</summary>
+/// FormKey + type + EditorID. NOT a load-order winner â€” the FILE's own record.</summary>
 public sealed record PluginRecordRow(string FormKey, string Type, string? EditorId);
 
 /// <summary>One summary row: a record type the file touches and how many records of it the file defines/overrides.</summary>
 public sealed record PluginTypeCount(string Type, int Count);
 
-/// <summary>The outcome of a housecarl_read_plugin_file call — a RAW, OUT-OF-LOAD-ORDER read of ONE plugin file
-/// (active or not), never resolved against the load order. <see cref="Error"/> non-null ⇒ the call failed with a
-/// named, recoverable reason (<see cref="Mode"/> "error"). <see cref="Mode"/> "ambiguous" ⇒ the filename matched
+/// <summary>The outcome of a housecarl_read_plugin_file call â€” a RAW, OUT-OF-LOAD-ORDER read of ONE plugin file
+/// (active or not), never resolved against the load order. <see cref="Error"/> non-null â‡’ the call failed with a
+/// named, recoverable reason (<see cref="Mode"/> "error"). <see cref="Mode"/> "ambiguous" â‡’ the filename matched
 /// several folders (<see cref="Ambiguous"/> lists them) and the caller must disambiguate. Otherwise <see cref="Mode"/>
 /// is "read" (<see cref="Record"/>), "enumerate" (<see cref="Rows"/> + <see cref="RowTotal"/>/<see cref="Capped"/>),
 /// or "summary" (<see cref="TypeCounts"/> + <see cref="RecordTotal"/>). <see cref="FilePath"/>/<see cref="Where"/>/
@@ -3283,9 +3321,9 @@ public sealed record PluginFileOutcome
         new() { Requested = requested, Mode = "ambiguous", Ambiguous = hits };
 }
 
-/// <summary>The MATERIALISED conflict tree the render layer consumes — each touching plugin's name + the fields read
+/// <summary>The MATERIALISED conflict tree the render layer consumes â€” each touching plugin's name + the fields read
 /// off its own body, in priority order (winner last). Built by <see cref="LoadOrderService.ResolveTree"/> with the
-/// per-call session already disposed, so it carries NO live overlay (Option B — the renderer never holds a handle).</summary>
+/// per-call session already disposed, so it carries NO live overlay (Option B â€” the renderer never holds a handle).</summary>
 public sealed record ConflictTreeView(IReadOnlyList<ConflictNodeView> Nodes)
 {
     public ConflictNodeView Winner => Nodes[^1];
@@ -3296,9 +3334,9 @@ public sealed record ConflictNodeView(string Plugin, RecordFields Record);
 
 /// <summary>The data behind housecarl_load_order_status. <see cref="Composition"/> is the fresh enabled/disabled picture;
 /// <see cref="ResolvedPluginCount"/> + <see cref="Warnings"/> are the resolver's actual last-build state;
-/// <see cref="ProfileChanged"/> is true only when a refresh was attempted but is still pending (e.g. MO2 was mid-write) —
-/// houseCARL re-reads automatically on the next tool call; no restart. <see cref="ExcludedPlugins"/> (name → reason) are
-/// plugins dropped from the index this build (unopenable, or carrying a record Mutagen can't parse) — surfaced so the
+/// <see cref="ProfileChanged"/> is true only when a refresh was attempted but is still pending (e.g. MO2 was mid-write) â€”
+/// houseCARL re-reads automatically on the next tool call; no restart. <see cref="ExcludedPlugins"/> (name â†’ reason) are
+/// plugins dropped from the index this build (unopenable, or carrying a record Mutagen can't parse) â€” surfaced so the
 /// user can fix/remove them (Q3).</summary>
 public sealed record LoadOrderStatusData(
     Mo2Composition Composition,
@@ -3307,18 +3345,18 @@ public sealed record LoadOrderStatusData(
     int MaxPlugins,
     bool ProfileChanged,
     string ProfileDir,
-    string ProfileName,         // the ACTIVE profile (instance mode: MO2's selected_profile; explicit: the dir name) — captured under the gate, not re-derived at render
-    string? InstanceDir,        // the resolved MO2 instance folder houseCARL is pointed at; null ⇒ explicit-paths / unconfigured mode
+    string ProfileName,         // the ACTIVE profile (instance mode: MO2's selected_profile; explicit: the dir name) â€” captured under the gate, not re-derived at render
+    string? InstanceDir,        // the resolved MO2 instance folder houseCARL is pointed at; null â‡’ explicit-paths / unconfigured mode
     IReadOnlyDictionary<string, string> ExcludedPlugins);
 
-/// <summary>The result of <see cref="LoadOrderService.NamedProfileComposition"/> — the profiles affordance behind
+/// <summary>The result of <see cref="LoadOrderService.NamedProfileComposition"/> â€” the profiles affordance behind
 /// housecarl_load_order_status' profile= param. <see cref="InstanceMode"/> is false in explicit-paths mode (no profiles
-/// root — a named read refuses loud). <see cref="AvailableProfiles"/> lists the profile folders (instance mode; empty in
+/// root â€” a named read refuses loud). <see cref="AvailableProfiles"/> lists the profile folders (instance mode; empty in
 /// explicit mode), used both for the default-status discovery line and to name the options when a requested profile isn't
 /// found. <see cref="RequestedName"/> echoes the trimmed name asked for (null if none). <see cref="Composition"/> +
 /// <see cref="ResolvedProfileDir"/> are set ONLY when a requested profile was found and read; a non-null RequestedName with
-/// a null Composition is the "not found" case (Q3 — AvailableProfiles names the real options, never a silent empty).
-/// <see cref="Warnings"/> carries any Q3 notes from reading the inspected profile (e.g. a missing modlist.txt — so a
+/// a null Composition is the "not found" case (Q3 â€” AvailableProfiles names the real options, never a silent empty).
+/// <see cref="Warnings"/> carries any Q3 notes from reading the inspected profile (e.g. a missing modlist.txt â€” so a
 /// 0-enabled-mods render is never mistaken for a genuinely-empty profile); empty unless a profile was found and read.</summary>
 public sealed record NamedProfileResult(
     bool InstanceMode,
@@ -3330,13 +3368,13 @@ public sealed record NamedProfileResult(
 
 /// <summary>One queried asset path's resolution behind housecarl_asset_status: the resolver's <see cref="AssetHit"/>
 /// (which sources have it + which wins + an ambiguity flag), or an <see cref="Error"/> when the path was rejected (a
-/// drive-rooted or '..'-escaping path — per-path Q3, never fails the batch). <see cref="Hit"/> is null iff
+/// drive-rooted or '..'-escaping path â€” per-path Q3, never fails the batch). <see cref="Hit"/> is null iff
 /// <see cref="Error"/> is set.</summary>
 public sealed record AssetPathResult(string RelPath, AssetHit? Hit, string? Error);
 
 /// <summary>The data behind housecarl_asset_status: one <see cref="AssetPathResult"/> per queried path, plus the
-/// build-level Q3 caveats — <see cref="BsaFailures"/> (archives that couldn't be read) and <see cref="ReadIncomplete"/>
-/// (an Exists=false answer may be wrong because a BSA failed to read) — and <see cref="Warnings"/> from archive
+/// build-level Q3 caveats â€” <see cref="BsaFailures"/> (archives that couldn't be read) and <see cref="ReadIncomplete"/>
+/// (an Exists=false answer may be wrong because a BSA failed to read) â€” and <see cref="Warnings"/> from archive
 /// discovery (e.g. a Skyrim.ini that couldn't be found, so base-game BSAs weren't scanned). <see cref="ProfileName"/>
 /// names the active profile the answer describes.</summary>
 public sealed record AssetStatusData(
@@ -3351,9 +3389,9 @@ public sealed record AssetStatusData(
 public sealed record SkseProvider(string Name, string Kind);
 
 /// <summary>One file found under Data\SKSE\Plugins in the active load order (housecarl_skse_inventory). <see cref="Group"/> is the
-/// immediate subfolder it sits in ("" = top level) — the derived render-grouping key. <see cref="Providers"/> is the FULL conflict
-/// chain — every mod that ships this exact file, WINNER FIRST then the losers in precedence order (the same winner→loser
-/// transparency the asset tools give), each tagged loose/BSA; empty ⇒ nothing active provides it. <see cref="Plugin"/> is the tier-C
+/// immediate subfolder it sits in ("" = top level) â€” the derived render-grouping key. <see cref="Providers"/> is the FULL conflict
+/// chain â€” every mod that ships this exact file, WINNER FIRST then the losers in precedence order (the same winnerâ†’loser
+/// transparency the asset tools give), each tagged loose/BSA; empty â‡’ nothing active provides it. <see cref="Plugin"/> is the tier-C
 /// static manifest, set ONLY for a <c>.dll</c> whose winning copy is loose (null for configs and for a BSA-only/unresolved DLL);
 /// <see cref="Note"/> carries the Q3 reason when a DLL has no readable manifest / isn't loader-scoped.</summary>
 public sealed record SkseFileEntry(
@@ -3370,11 +3408,11 @@ public sealed record SkseFileEntry(
     public string? WinningProvider => Winner?.Name;
     /// <summary>The winner's kind ("loose" | "BSA"), or "none" when unprovided.</summary>
     public string ProviderKind => Winner?.Kind ?? "none";
-    /// <summary>How many mods ship this exact file — &gt; 1 is contention worth surfacing.</summary>
+    /// <summary>How many mods ship this exact file â€” &gt; 1 is contention worth surfacing.</summary>
     public int ProviderCount => Providers.Count;
 }
 
-/// <summary>The data behind housecarl_skse_inventory: the SKSE-plugin layer of the active load order — <see cref="Dlls"/> (each a
+/// <summary>The data behind housecarl_skse_inventory: the SKSE-plugin layer of the active load order â€” <see cref="Dlls"/> (each a
 /// plugin DLL with its winning provider + static tier-C manifest) and <see cref="Configs"/> (their .ini/.toml/.json/.yaml with the
 /// winning provider), plus <see cref="OtherFileCount"/> (uncategorized files like .pdb/.txt, counted not listed). The build-level Q3
 /// caveats <see cref="BsaFailures"/> / <see cref="ReadIncomplete"/> and discovery <see cref="Warnings"/> ride along; <see cref="ProfileName"/>
@@ -3390,12 +3428,12 @@ public sealed record SkseInventoryData(
 
 /// <summary>One asset to PLACE (housecarl_place_asset / bulk). <see cref="AssetPath"/> is the resolved Data-relative
 /// DESTINATION (the tool computes it from a FormID+slot for FaceGen, or takes a raw path). <see cref="Source"/> is the
-/// correct copy to place — a loose file path, "&lt;archive.bsa&gt;|&lt;entry&gt;", or a ".bsa" path (entry := AssetPath);
-/// null/blank ⇒ auto-resolve (use the sole VFS provider; &gt;1 ambiguous and 0 absent are per-asset refusals, Q3).</summary>
+/// correct copy to place â€” a loose file path, "&lt;archive.bsa&gt;|&lt;entry&gt;", or a ".bsa" path (entry := AssetPath);
+/// null/blank â‡’ auto-resolve (use the sole VFS provider; &gt;1 ambiguous and 0 absent are per-asset refusals, Q3).</summary>
 public sealed record PlaceRequest(string AssetPath, string? Source);
 
-/// <summary>One placed asset's outcome. <see cref="Placed"/> false ⇒ <see cref="Error"/> names why (recoverable, per-asset
-/// Q3). <see cref="CurrentWinner"/> is the source that currently wins the VFS for this path (the sort target — the placed
+/// <summary>One placed asset's outcome. <see cref="Placed"/> false â‡’ <see cref="Error"/> names why (recoverable, per-asset
+/// Q3). <see cref="CurrentWinner"/> is the source that currently wins the VFS for this path (the sort target â€” the placed
 /// copy does NOT win until the fresh mod is enabled + sorted above it), or null if nothing provided it before.</summary>
 public sealed record PlaceResult(string AssetPath, bool Placed, long Bytes, string? SourceDesc, string? CurrentWinner, string? Error)
 {
@@ -3403,7 +3441,7 @@ public sealed record PlaceResult(string AssetPath, bool Placed, long Bytes, stri
         => new(assetPath, false, 0, null, currentWinner, error);
 }
 
-/// <summary>The outcome of place_asset / bulk_place_asset. <see cref="Error"/> non-null ⇒ the whole call was rejected
+/// <summary>The outcome of place_asset / bulk_place_asset. <see cref="Error"/> non-null â‡’ the whole call was rejected
 /// before any placement (unconfigured, an into= folder houseCARL doesn't own, the asset layer wouldn't build). Else
 /// <see cref="Results"/> is per-asset; <see cref="ModFolder"/> is the houseCARL mod the placed files landed in (null when
 /// none placed); <see cref="Warnings"/> carries the asset-discovery caveats (Q3); <see cref="LeftoverFolder"/> names a
@@ -3415,9 +3453,9 @@ public sealed record PlaceOutcome(
         => new(Array.Empty<PlaceResult>(), null, Array.Empty<string>(), null, error);
 }
 
-/// <summary>The outcome of housecarl_write_seq. <see cref="Error"/> non-null ⇒ the call was rejected (no plugin, unreadable
+/// <summary>The outcome of housecarl_write_seq. <see cref="Error"/> non-null â‡’ the call was rejected (no plugin, unreadable
 /// plugin, an into= folder houseCARL doesn't own, a failed write). On success: <see cref="Quests"/> is every SGE quest
-/// covered (EMPTY ⇒ the plugin had none, so <see cref="SeqPath"/> is null and nothing was written — a clean no-op, not a
+/// covered (EMPTY â‡’ the plugin had none, so <see cref="SeqPath"/> is null and nothing was written â€” a clean no-op, not a
 /// failure); <see cref="SeqPath"/> is the written <c>.seq</c> and <see cref="ModFolder"/> the houseCARL mod it landed in;
 /// <see cref="WroteIntoPluginFolder"/> is true when it defaulted into the plugin's OWN folder (so one mod enables both).
 /// A write-failure residue path (a fresh folder kept because the write half-landed) is folded into <see cref="Error"/>.</summary>

--- a/src/housecarl-mcp/NpcCopyTools.cs
+++ b/src/housecarl-mcp/NpcCopyTools.cs
@@ -1,0 +1,116 @@
+using System.ComponentModel;
+using System.Text;
+using ModelContextProtocol.Server;
+using HousecarlCore;
+
+namespace HousecarlMcp;
+
+/// <summary>
+/// houseCARL standalone-NPC-copy tool — the composed verb the capability chain builds toward (Stage 3): one
+/// reviewable operation that forks a donor NPC's appearance into a houseCARL patch with NO donor master, no CK,
+/// no .nif editing. Mechanism = Duplicate + RemapLinks (whole-record copies), so the two empirically-pinned traps
+/// (HDPT.Parts morph refs → lip-sync; TextureLighting=0 → dark skin) are structurally impossible to reproduce.
+/// The donor may be DISABLED — houseCARL reads its file out of load order (the read_plugin_file lane) and says so.
+/// </summary>
+[McpServerToolType]
+public static class NpcCopyTools
+{
+    [McpServerTool(Name = "housecarl_copy_npc_appearance", Title = "Copy an NPC's appearance as a standalone (no donor master)"),
+     Description(
+         "Copy a donor NPC's whole APPEARANCE — headparts (with their texture sets, extra parts and the morph .tri " +
+         "references that drive lip-sync), face morph/parts, tint layers, texture lighting, hair color, head texture, " +
+         "worn armor link, weight/height — into a houseCARL patch as a TRUE STANDALONE: donor-defined records are " +
+         "deep-copied under NEW FormIDs (headpart EditorIDs preserved — the engine maps baked facegeom shapes to " +
+         "headparts BY NAME), the baked facegen pair (.nif geometry + .dds tint) is renamed to the new FormID's path, " +
+         "and the donor-only textures/meshes the records and geometry reference are carried — so the result works with " +
+         "the donor plugin REMOVED. No donor master, no CK, no .nif editing. TWO MODES (pass exactly one): " +
+         "target_formid= copies the appearance ONTO AN EXISTING NPC (e.g. a follower you scaffolded); new_editorid= " +
+         "mints a FULL CLONE as a new NPC record — any donor-internal NON-appearance links on the clone (factions, " +
+         "outfits, packages, scripts) are STRIPPED and each strip is reported (the clone is donor-free, loudly). The " +
+         "donor may be ACTIVE (source_formid resolves via the load order) or DISABLED — pass source_plugin= (its " +
+         "filename; houseCARL locates it across enabled AND disabled MO2 mod folders, or an absolute path) and the " +
+         "read is stamped OUT-OF-LOAD-ORDER. Writes a NEW plugin (folder-per-patch) or extends an existing houseCARL " +
+         "patch via into=. Originals untouched. Refuses loud on a donor-internal custom RACE (out of scope — keep the " +
+         "race mod as a master), a runaway closure, or anything that would silently master the donor.")]
+    public static string CopyNpcAppearance(
+        LoadOrderService svc,
+        [Description("The donor NPC's FormID 'XXXXXX:Plugin.esp' (e.g. '000D62:Vivace.esp') — the appearance being copied.")]
+            string source_formid,
+        [Description("Optional. Read the donor from this plugin FILE instead of the active load order — the DISABLED-donor lane. A filename ('Vivace.esp'; located across enabled+disabled mod folders, overwrite and Data) or an absolute path. Omit when the donor is active.")]
+            string? source_plugin = null,
+        [Description("Optional (with source_plugin). The exact MO2 mod-folder name to read the plugin from, when the filename exists in several folders.")]
+            string? source_mod = null,
+        [Description("APPLY MODE: the EXISTING NPC to dress in the donor's appearance — 'XXXXXX:Plugin.esp'. An active NPC, or a record in the target patch itself (with into=). Pass this OR new_editorid, not both.")]
+            string? target_formid = null,
+        [Description("CLONE MODE: mint a full standalone clone of the donor as a NEW NPC with this EditorID. Pass this OR target_formid, not both.")]
+            string? new_editorid = null,
+        [Description("Optional (clone mode). The clone's display Name; defaults to the donor's.")]
+            string? new_name = null,
+        [Description("Optional. Base name for the NEW patch plugin + mod folder (default: the new_editorid in clone mode, 'houseCARL_NpcCopy' otherwise); auto-suffixed if taken.")]
+            string? patch_name = null,
+        [Description("Optional. Extend an existing houseCARL patch instead of creating a fresh one — the patch plugin's filename (found even if you renamed its MO2 folder) or the mod-folder name.")]
+            string? into = null) => Guard.Tool("housecarl_copy_npc_appearance", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        return Render(svc.CopyNpcAppearance(source_formid, source_plugin, source_mod,
+                                            target_formid, new_editorid, new_name, patch_name, into));
+    });
+
+    static string Render(NpcCopyOutcome o)
+    {
+        if (!o.Success) return "error: " + o.Error;
+
+        var sb = new StringBuilder();
+        sb.AppendLine(o.Mode == "clone"
+            ? $"CLONED {o.DonorKey} → new NPC {o.NewNpcKey} in {Path.GetFileName(o.OutPath!)}{(o.Extended ? " (extended)" : " (new patch)")}."
+            : $"APPLIED {o.DonorKey}'s appearance onto {o.NewNpcKey} in {Path.GetFileName(o.OutPath!)}{(o.Extended ? " (extended)" : " (new patch)")}.");
+        sb.AppendLine($"donor read from: {o.DonorReadFrom}{(o.DonorOutOfLoadOrder ? "  [OUT-OF-LOAD-ORDER — the game does not load this file; the copy is what makes it live]" : "")}");
+        sb.AppendLine($"plugin: {o.OutPath} ({o.Bytes:N0} bytes)");
+        sb.AppendLine($"masters: {(o.Masters.Count == 0 ? "<none>" : string.Join(", ", o.Masters))}");
+        sb.AppendLine(o.DonorAmongMasters
+            ? "!! the donor IS among the masters — the copy is NOT standalone. This is unexpected; please report it."
+            : "standalone: the donor is NOT a master of the patch.");
+
+        if (o.Internalized.Count > 0)
+        {
+            sb.AppendLine($"\ninternalized {o.Internalized.Count} donor record(s) under new FormIDs (EditorIDs preserved — facegeom block-name identity):");
+            foreach (var r in o.Internalized)
+                sb.AppendLine($"  - {r.Type} '{r.EditorId}'  {r.OldKey} → {r.NewKey}   (via {r.PulledBy})");
+        }
+        if (o.KeptLinkCount > 0)
+            sb.AppendLine($"kept {o.KeptLinkCount} link(s) to records that resolve in your active load order (vanilla / shared resources) — mastered normally.");
+
+        if (o.Mode == "apply" && o.CopiedFields.Count > 0)
+            sb.AppendLine($"\ncopied appearance fields: {string.Join(", ", o.CopiedFields)}");
+
+        if (o.Mode == "clone")
+        {
+            if (o.Stripped.Count > 0)
+            {
+                sb.AppendLine($"\nSTRIPPED {o.Stripped.Count} donor-internal NON-appearance reference(s) from the clone (it must not master the donor):");
+                foreach (var s in o.Stripped) sb.AppendLine($"  - {s.Field}  (was {s.Removed})");
+                sb.AppendLine("  the clone keeps the donor's LOOK but not its donor-defined factions/outfits/packages/scripts — re-author those against your own or vanilla systems as needed.");
+            }
+            else
+                sb.AppendLine("\nno donor-internal non-appearance references needed stripping.");
+        }
+
+        if (o.Assets is { } a)
+        {
+            sb.AppendLine($"\nassets: {a.Carried.Count} file(s) carried" +
+                          $"{(a.FaceGenMeshCarried && a.FaceGenTintCarried ? " (facegen pair renamed to the new FormID path)" : "")}.");
+            foreach (var c in a.Carried)
+                sb.AppendLine(c.OldRelPath.Equals(c.NewRelPath, StringComparison.OrdinalIgnoreCase)
+                    ? $"  - {c.NewRelPath}  ({c.Bytes:N0} B, from {c.From})"
+                    : $"  - {c.OldRelPath} → {c.NewRelPath}  ({c.Bytes:N0} B, from {c.From})");
+            if (!a.FaceGenMeshCarried || !a.FaceGenTintCarried)
+                sb.AppendLine($"  !! facegen {(a.FaceGenMeshCarried ? "TINT" : a.FaceGenTintCarried ? "MESH" : "MESH + TINT")} not carried — see the misses below; without the pair the engine regenerates the head (grey/dark-face risk). Verify in-game.");
+            foreach (var s in a.SkippedStillProvided) sb.AppendLine($"  · skipped: {s}");
+            foreach (var m in a.Missing) sb.AppendLine($"  !! missing: {m}");
+            foreach (var f in a.Failures) sb.AppendLine($"  !! {f}");
+        }
+
+        sb.AppendLine($"\nNEXT: enable the mod folder in MO2 (it holds the plugin AND the carried files) and sort the plugin; then test in-game — face, hair, lip-sync while speaking.");
+        return sb.ToString().TrimEnd();
+    }
+}

--- a/src/housecarl-mcp/NpcCopyTools.cs
+++ b/src/housecarl-mcp/NpcCopyTools.cs
@@ -56,7 +56,7 @@ public static class NpcCopyTools
                                             target_formid, new_editorid, new_name, patch_name, into));
     });
 
-    static string Render(NpcCopyOutcome o)
+    internal static string Render(NpcCopyOutcome o)   // internal: the guard pins the unverified-read-back render (review finding 2)
     {
         if (!o.Success) return "error: " + o.Error;
 
@@ -66,14 +66,25 @@ public static class NpcCopyTools
             : $"APPLIED {o.DonorKey}'s appearance onto {o.NewNpcKey} in {Path.GetFileName(o.OutPath!)}{(o.Extended ? " (extended)" : " (new patch)")}.");
         sb.AppendLine($"donor read from: {o.DonorReadFrom}{(o.DonorOutOfLoadOrder ? "  [OUT-OF-LOAD-ORDER — the game does not load this file; the copy is what makes it live]" : "")}");
         sb.AppendLine($"plugin: {o.OutPath} ({o.Bytes:N0} bytes)");
-        sb.AppendLine($"masters: {(o.Masters.Count == 0 ? "<none>" : string.Join(", ", o.Masters))}");
-        if (o.Warning is not null) sb.AppendLine($"!! {o.Warning}");
-        if (o.DonorIsBaseGame)
-            sb.AppendLine("note: the donor is defined in a base-game master (always loaded) — nothing is being \"removed\", so links to it are kept and mastered normally; this copy is an appearance transplant, not a standalone-ization.");
+        // When the post-write read-back failed, the masters/standalone facts are UNVERIFIED — asserting them from
+        // default-empty values would report a donor-mastered patch as standalone on exactly the path where
+        // verification broke (review finding). Say only what is known.
+        if (o.Warning is not null)
+        {
+            sb.AppendLine("masters: <NOT VERIFIED — read-back failed>");
+            sb.AppendLine($"!! {o.Warning}");
+            sb.AppendLine("standalone: NOT VERIFIED — confirm with housecarl_read_plugin_file that the donor is absent from the masters before relying on this copy.");
+        }
         else
-            sb.AppendLine(o.DonorAmongMasters
-                ? "!! the donor IS among the masters — the copy is NOT standalone. This is unexpected; please report it."
-                : "standalone: the donor is NOT a master of the patch.");
+        {
+            sb.AppendLine($"masters: {(o.Masters.Count == 0 ? "<none>" : string.Join(", ", o.Masters))}");
+            if (o.DonorIsBaseGame)
+                sb.AppendLine("note: the donor is defined in a base-game master (always loaded) — nothing is being \"removed\", so links to it are kept and mastered normally; this copy is an appearance transplant, not a standalone-ization.");
+            else
+                sb.AppendLine(o.DonorAmongMasters
+                    ? "!! the donor IS among the masters — the copy is NOT standalone. This is unexpected; please report it."
+                    : "standalone: the donor is NOT a master of the patch.");
+        }
 
         if (o.Internalized.Count > 0)
         {

--- a/src/housecarl-mcp/NpcCopyTools.cs
+++ b/src/housecarl-mcp/NpcCopyTools.cs
@@ -67,15 +67,24 @@ public static class NpcCopyTools
         sb.AppendLine($"donor read from: {o.DonorReadFrom}{(o.DonorOutOfLoadOrder ? "  [OUT-OF-LOAD-ORDER — the game does not load this file; the copy is what makes it live]" : "")}");
         sb.AppendLine($"plugin: {o.OutPath} ({o.Bytes:N0} bytes)");
         sb.AppendLine($"masters: {(o.Masters.Count == 0 ? "<none>" : string.Join(", ", o.Masters))}");
-        sb.AppendLine(o.DonorAmongMasters
-            ? "!! the donor IS among the masters — the copy is NOT standalone. This is unexpected; please report it."
-            : "standalone: the donor is NOT a master of the patch.");
+        if (o.Warning is not null) sb.AppendLine($"!! {o.Warning}");
+        if (o.DonorIsBaseGame)
+            sb.AppendLine("note: the donor is defined in a base-game master (always loaded) — nothing is being \"removed\", so links to it are kept and mastered normally; this copy is an appearance transplant, not a standalone-ization.");
+        else
+            sb.AppendLine(o.DonorAmongMasters
+                ? "!! the donor IS among the masters — the copy is NOT standalone. This is unexpected; please report it."
+                : "standalone: the donor is NOT a master of the patch.");
 
         if (o.Internalized.Count > 0)
         {
             sb.AppendLine($"\ninternalized {o.Internalized.Count} donor record(s) under new FormIDs (EditorIDs preserved — facegeom block-name identity):");
             foreach (var r in o.Internalized)
                 sb.AppendLine($"  - {r.Type} '{r.EditorId}'  {r.OldKey} → {r.NewKey}   (via {r.PulledBy})");
+        }
+        if (o.Reused.Count > 0)
+        {
+            sb.AppendLine($"reused {o.Reused.Count} record(s) a prior run already internalized into this patch (a second copy would duplicate their EditorIDs):");
+            foreach (var r in o.Reused) sb.AppendLine($"  - {r}");
         }
         if (o.KeptLinkCount > 0)
             sb.AppendLine($"kept {o.KeptLinkCount} link(s) to records that resolve in your active load order (vanilla / shared resources) — mastered normally.");
@@ -106,6 +115,7 @@ public static class NpcCopyTools
             if (!a.FaceGenMeshCarried || !a.FaceGenTintCarried)
                 sb.AppendLine($"  !! facegen {(a.FaceGenMeshCarried ? "TINT" : a.FaceGenTintCarried ? "MESH" : "MESH + TINT")} not carried — see the misses below; without the pair the engine regenerates the head (grey/dark-face risk). Verify in-game.");
             foreach (var s in a.SkippedStillProvided) sb.AppendLine($"  · skipped: {s}");
+            foreach (var w in a.Warnings) sb.AppendLine($"  !! precedence: {w}");
             foreach (var m in a.Missing) sb.AppendLine($"  !! missing: {m}");
             foreach (var f in a.Failures) sb.AppendLine($"  !! {f}");
         }


### PR DESCRIPTION
## What

`housecarl_copy_npc_appearance` (tool 32) — the **capability chain Stage 3 payoff verb**: fork a donor NPC's appearance into a houseCARL patch as a true standalone — no donor master, no CK, no `.nif` editing. One reviewable call replaces the ~dozen hand-orchestrated calls the 2026-07-01 build test (Saela wearing Vivace's face) needed.

## Design (Aaron's picks this session)

- **Composed tool verb** (not a skill-orchestrated recipe) — the two empirically-pinned traps are encoded in code, not discipline.
- **Both target modes**: `target_formid=` dresses an existing NPC; `new_editorid=` mints a full standalone clone.

## Mechanism — why Duplicate, not field-authoring

`Duplicate(newKey)` + `RemapLinks` (the RemapEngine pattern). A whole-record copy carries **every** field by construction, so the build test's two traps are structurally impossible to reproduce:
- `HDPT.Parts` (.tri morph refs) — skipping them froze lips; here they cannot be skipped.
- `TextureLighting` — the =0 fresh-create default made dark skin; here the donor's value carries.

Headpart **EditorIDs are preserved** on the copies — the engine maps baked facegeom shapes to headparts by name.

## Key behaviors

- **Internalize rule**: a linked record is deep-copied iff donor-defined or not actively resolvable; links to active masters stay links. Loud refusals: donor-internal custom RACE, runaway closure (named cap 128), unreadable donor-internal record.
- **Clone strip (Q3)**: remaining donor-internal non-appearance links (factions, outfits, packages, VMAD) are stripped and **each strip is named**; a required foreign link (e.g. a donor-internal Class) refuses loud with the apply-lane remedy.
- **Donor lanes**: active, or a plugin file located across enabled+**disabled** mod folders (the `read_plugin_file` machinery) — stamped OUT-OF-LOAD-ORDER.
- **Assets**: facegen pair renamed to the new FormKey path; referenced assets harvested generically (IAssetLinkGetter walk) + a conservative byte-scrape of the carried geom for embedded textures; carried iff the bytes would vanish with the donor (direct-disk donor-folder lane for disabled donors). Best-effort + reported; misses named.
- **The standalone assertion**: the outcome verifies and reports the donor is NOT among the written patch's masters.

## Proof

- New guard `copy-npc-appearance-guard` — **38 checks** over a synthetic MO2 instance with a DISABLED donor: apply, clone, asset carry (incl. the byte-scrape and the named-miss), and 6 Q3 refusals.
- **RED-proven twice**: strip disabled → 4 arms fail (Mutagen's serialize also refuses the missing master — a second net); apply-lane remap disabled → 6 arms fail (the belt-and-braces foreign-link check fires first).
- **ci-all 75/75** from the worktree root.

## Not in this PR

- README/CHANGELOG counts (release-cut docs sweep, per the 1.6.0 pattern).
- npc-authoring skill integration (the sub-project exercises the verb on its build ladder — rung work, separate lane).
- In-game validation of a real fork — the primitives were Aaron-confirmed in-game 2026-07-01; the composed verb should get a live pass on the next rung session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)