### PR TITLE
feat(copy_npc_appearance): file lane auto-widens to the donor's defining plugin

### DIFF
--- a/src/housecarl-core/NpcAppearanceAssets.cs
+++ b/src/housecarl-core/NpcAppearanceAssets.cs
@@ -187,7 +187,7 @@ public static class NpcAppearanceAssets
     /// resolved winner could not be read (review finding: discarding it reported an in-use file as "found neither
     /// in the active VFS nor the donor's folder" — factually false, Q3).</summary>
     static (byte[]? Bytes, string? From, string? SkipNote, bool Missing, string? ReadError) ResolveForCarry(
-        string relPath, AssetResolver.AssetView view, DonorDisk? donor, string? donorModFolderName, bool alwaysCarry)
+        string relPath, AssetResolver.AssetView view, IReadOnlyList<DonorDisk> donors, IReadOnlyList<string> donorModFolderNames, bool alwaysCarry)
     {
         string? readError = null;
         var res = view.ResolveForPlacement(relPath);
@@ -197,9 +197,9 @@ public static class NpcAppearanceAssets
             if (!alwaysCarry)
             {
                 bool donorProvides =
-                    (donorModFolderName is not null && string.Equals(winner.ProviderName, donorModFolderName, StringComparison.OrdinalIgnoreCase))
-                    || (donor is not null && winner.Kind == AssetKind.Bsa && winner.ArchivePath is not null
-                        && string.Equals(Path.GetDirectoryName(winner.ArchivePath), donor.Folder, StringComparison.OrdinalIgnoreCase));
+                    donorModFolderNames.Any(n => string.Equals(winner.ProviderName, n, StringComparison.OrdinalIgnoreCase))
+                    || (winner.Kind == AssetKind.Bsa && winner.ArchivePath is not null
+                        && donors.Any(d => string.Equals(Path.GetDirectoryName(winner.ArchivePath), d.Folder, StringComparison.OrdinalIgnoreCase)));
                 if (!donorProvides)
                     return (null, null, $"'{relPath}' — still provided by '{winner.ProviderName}' after the donor is removed; not carried.", false, null);
             }
@@ -209,7 +209,7 @@ public static class NpcAppearanceAssets
             // the winner could not be read — fall through to the donor-disk lane, keeping the named cause
         }
 
-        if (donor is not null)
+        foreach (var donor in donors)
         {
             var (bytes, from) = donor.Read(relPath);
             if (bytes is not null) return (bytes, from, null, false, null);
@@ -228,7 +228,7 @@ public static class NpcAppearanceAssets
     public static NpcAssetOutcome CarryAll(
         FormKey donorNpc, FormKey newNpc,
         IReadOnlyList<string> harvestedPaths,
-        AssetResolver.AssetView view, DonorDisk? donor, string? donorModFolderName, string outDir)
+        AssetResolver.AssetView view, IReadOnlyList<DonorDisk> donors, IReadOnlyList<string> donorModFolderNames, string outDir)
     {
         var carried = new List<CarriedAsset>();
         var skipped = new List<string>();
@@ -252,7 +252,7 @@ public static class NpcAppearanceAssets
             try
             {
                 var newRel = FaceGenPath.For(newNpc, slot);
-                var (bytes, from, _, isMissing, readErr) = ResolveForCarry(oldRel, view, donor, donorModFolderName, alwaysCarry: true);
+                var (bytes, from, _, isMissing, readErr) = ResolveForCarry(oldRel, view, donors, donorModFolderNames, alwaysCarry: true);
                 if (isMissing || bytes is null)
                 {
                     if (readErr is not null)
@@ -288,7 +288,7 @@ public static class NpcAppearanceAssets
         {
             try
             {
-                var (bytes, from, skipNote, isMissing, readErr) = ResolveForCarry(rel, view, donor, donorModFolderName, alwaysCarry: false);
+                var (bytes, from, skipNote, isMissing, readErr) = ResolveForCarry(rel, view, donors, donorModFolderNames, alwaysCarry: false);
                 if (skipNote is not null) { skipped.Add(skipNote); continue; }
                 if (isMissing)
                 {

--- a/src/housecarl-core/NpcAppearanceCopy.cs
+++ b/src/housecarl-core/NpcAppearanceCopy.cs
@@ -95,13 +95,19 @@ public static class NpcAppearanceCopy
     public sealed record ClosureItem(IMajorRecordGetter Body, string PulledBy);
 
     /// <summary>The appearance-closure walk result: the records to internalize (donor bodies at donor keys, the
-    /// NPC itself NOT included), the links kept as-is (they resolve actively), or a loud refusal.</summary>
+    /// NPC itself NOT included), the links kept as-is (they resolve actively), or a loud refusal.
+    /// <see cref="FetchMiss"/> marks the refusal class where the donor universe could not PRODUCE a needed record —
+    /// the one class the caller's donor-read context (which files were opened, what an auto-widen did) can explain;
+    /// the other refusals (template, race, cap) are about the donor's shape, and decorating them with read context
+    /// would point the user at the wrong fix.</summary>
     public sealed record ClosureResult(
         bool Success, string? Error,
         IReadOnlyList<ClosureItem> ToInternalize,
-        IReadOnlyList<FormKey> KeptLinks)
+        IReadOnlyList<FormKey> KeptLinks,
+        bool FetchMiss = false)
     {
-        public static ClosureResult Fail(string error) => new(false, error, Array.Empty<ClosureItem>(), Array.Empty<FormKey>());
+        public static ClosureResult Fail(string error, bool fetchMiss = false)
+            => new(false, error, Array.Empty<ClosureItem>(), Array.Empty<FormKey>(), fetchMiss);
     }
 
     /// <summary>
@@ -169,10 +175,8 @@ public static class NpcAppearanceCopy
                 return ClosureResult.Fail(
                     $"the donor's appearance references {key} (via {pulledBy}), which must be internalized (it is donor-" +
                     "defined or does not resolve in the active load order) — but the donor universe cannot produce that " +
-                    "record. Remedies, by cause: if you passed source_plugin= for an OVERRIDE PATCH of the donor, the " +
-                    $"record lives in the donor's own plugin — pass source_plugin='{key.ModKey.FileName}' instead (or omit " +
-                    "source_plugin= entirely when that plugin is active); if it lives in a DISABLED master of the donor, " +
-                    "enable that mod (or keep it as a master) and re-run. Nothing was written.");
+                    $"record. It is defined in '{key.ModKey.FileName}': if that mod is DISABLED, enable it (or keep it " +
+                    "installed as a master) and re-run. Nothing was written.", fetchMiss: true);
 
             toInternalize.Add(new ClosureItem(body, pulledBy));
             var label = $"{RecordNaming.StripOverlay(body.GetType().Name)} {key} ({body.EditorID ?? "<no editorid>"})";

--- a/src/housecarl-generator/NpcCopyProbe.cs
+++ b/src/housecarl-generator/NpcCopyProbe.cs
@@ -143,6 +143,7 @@ public static class NpcCopyProbe
             templatedNpc.Template.SetTo(donorNpcFk);                       // appearance lives on the template → refusal
             templatedNpc.Configuration.TemplateFlags |= NpcConfiguration.TemplateFlag.Traits;
             donorMod.Npcs.Add(templatedNpc);
+            donorMod.Npcs.Add(new Npc(new FormKey(donorKey, 0xD0B), SkyrimRelease.SkyrimSE) { EditorID = "VivStale" });   // definer of the stale-widen NPC (its 0xDEE headpart is defined NOWHERE — the point)
             WriteModDirect(mods, "DonorMod", donorMod, keepMod);
 
             // a SECOND donor whose headpart REUSES the EditorID 'VivHairHP' with DIFFERENT content — the KS Hairdos
@@ -175,6 +176,13 @@ public static class NpcCopyProbe
             vivLook.HeadTexture.SetTo(keptTxstFk);
             vivLook.Weight = 77f;                     // differs from Donor.esp's 42 — the override must WIN
             lookMod.Npcs.Add(vivLook);
+            // a second override whose look references a record Donor.esp does NOT define — the stale-defining-plugin
+            // case: the widen SUCCEEDS yet the fetch still misses, and the refusal must SAY the widen already ran.
+            var staleNpcFk = new FormKey(donorKey, 0xD0B);
+            var vivStale = new Npc(staleNpcFk, SkyrimRelease.SkyrimSE) { EditorID = "VivStale" };
+            vivStale.Race.SetTo(raceFk);
+            vivStale.HeadParts.Add(new FormKey(donorKey, 0xDEE));   // Donor.esp defines no 0xDEE
+            lookMod.Npcs.Add(vivStale);
             WriteModDirect(mods, "DonorLookMod", lookMod, keepMod, donorMod);
 
             // an override patch whose DEFINING plugin is nowhere on disk — the widen-failure NOTE lane.
@@ -187,7 +195,35 @@ public static class NpcCopyProbe
             ghostOverride.Race.SetTo(raceFk);
             ghostOverride.HeadParts.Add(new FormKey(ghostKey, 0xF01));                 // needs Ghost.esp — unproducible
             orphanMod.Npcs.Add(ghostOverride);
+            // a TEMPLATED override in the same orphan patch — its refusal is about the donor's SHAPE, not the read,
+            // so the widen-miss note must NOT decorate it.
+            var ghostTplFk = new FormKey(ghostKey, 0xF02);
+            var ghostTpl = new Npc(ghostTplFk, SkyrimRelease.SkyrimSE) { EditorID = "GhostTpl" };
+            ghostTpl.Race.SetTo(raceFk);
+            ghostTpl.Template.SetTo(ghostNpcFk);
+            ghostTpl.Configuration.TemplateFlags |= NpcConfiguration.TemplateFlag.Traits;
+            orphanMod.Npcs.Add(ghostTpl);
             WriteModDirect(mods, "OrphanPatchMod", orphanMod, keepMod, ghostMod);
+
+            // a defining plugin present in TWO disabled folders — the widen's AMBIGUOUS decline lane.
+            var twinKey = new ModKey("Twin", ModType.Plugin);
+            var twinNpcFk = new FormKey(twinKey, 0x800);
+            var twinHpFk = new FormKey(twinKey, 0x801);
+            var twinMod = new SkyrimMod(twinKey, SkyrimRelease.SkyrimSE);
+            twinMod.HeadParts.Add(new HeadPart(twinHpFk, SkyrimRelease.SkyrimSE) { EditorID = "TwinHP" });
+            var twinNpc = new Npc(twinNpcFk, SkyrimRelease.SkyrimSE) { EditorID = "Twin" };
+            twinNpc.Race.SetTo(raceFk);
+            twinNpc.HeadParts.Add(twinHpFk);
+            twinMod.Npcs.Add(twinNpc);
+            WriteModDirect(mods, "TwinModA", twinMod, keepMod);
+            WriteModDirect(mods, "TwinModB", twinMod, keepMod);
+            var twinPatchKey = new ModKey("TwinPatch", ModType.Plugin);
+            var twinPatchMod = new SkyrimMod(twinPatchKey, SkyrimRelease.SkyrimSE);
+            var twinOverride = new Npc(twinNpcFk, SkyrimRelease.SkyrimSE) { EditorID = "Twin" };
+            twinOverride.Race.SetTo(raceFk);
+            twinOverride.HeadParts.Add(twinHpFk);                                      // needs Twin.esp — which is ambiguous
+            twinPatchMod.Npcs.Add(twinOverride);
+            WriteModDirect(mods, "TwinPatchMod", twinPatchMod, keepMod, twinMod);
 
             // donor-only loose assets: the facegen pair (geom embeds a texture path for the scrape), the scraped
             // texture, and the record-referenced hair model.
@@ -206,7 +242,7 @@ public static class NpcCopyProbe
             WriteProfile(prof,
                 loadorder: new[] { vanKey.FileName.String, keepKey.FileName.String, folKey.FileName.String },
                 plugins: new[] { "*" + vanKey.FileName, "*" + keepKey.FileName, "*" + folKey.FileName },
-                modlist: new[] { "+ContestMod", "+FollowerMod", "+KeepMod", "+FakeVanilla", "-DonorMod", "-Donor2Mod", "-DonorLookMod", "-OrphanPatchMod" });
+                modlist: new[] { "+ContestMod", "+FollowerMod", "+KeepMod", "+FakeVanilla", "-DonorMod", "-Donor2Mod", "-DonorLookMod", "-OrphanPatchMod", "-TwinModA", "-TwinModB", "-TwinPatchMod" });
             WriteSkyrimIni(prof);
 
             using var svc = LoadOrderService.WithInstance(inst, 0, new UserConfigStore(Path.Combine(root, "user.json")));
@@ -387,6 +423,15 @@ public static class NpcCopyProbe
                         "widen: the NAMED file's override WINS — its look (Weight 77), not the defining plugin's (42)");
                     Check(npc is not null && npc.HeadParts.Count == 2,
                         "widen: both headparts arrive — the named file's own and the defining plugin's");
+
+                    // the ASSET half must widen too (review finding): the facegen pair + donor-only files live in
+                    // the DEFINING plugin's folder, which the named override patch's folder does not contain.
+                    var outDir = Path.GetDirectoryName(o.OutPath!)!;
+                    Check(o.Assets is { FaceGenMeshCarried: true } &&
+                          File.Exists(Path.Combine(outDir, $@"meshes\actors\character\facegendata\facegeom\MyFollower.esp\00000800.nif")),
+                        "widen assets: the facegen pair is carried from the DEFINING plugin's folder (not the named patch's)");
+                    Check(File.Exists(Path.Combine(outDir, hairRel)),
+                        "widen assets: the record-referenced model carries from the defining plugin's folder");
                 }
             }
 
@@ -398,6 +443,30 @@ public static class NpcCopyProbe
                     "widen-miss: the closure refusal still fires when the defining plugin is nowhere on disk");
                 Check(!o.Success && o.Error!.Contains("Ghost.esp") && o.Error!.Contains("auto-searched"),
                     "widen-miss: the refusal carries the NOTE that auto-widening was attempted and why it could not");
+            }
+
+            // ================= 2c-iv. widen SUCCEEDED yet the record is missing — the refusal says the widen ran =================
+            {
+                var o = svc.CopyNpcAppearance(staleNpcFk.ToString(), "DonorLook.esp", null,
+                                              targetFk.ToString(), null, null, null, null);
+                Check(!o.Success && o.Error!.Contains("cannot produce") && o.Error!.Contains("AUTO-READ"),
+                    "widen-stale: a fetch-miss AFTER a successful widen names the auto-read — never a circular 'pass the plugin' dead end");
+            }
+
+            // ================= 2c-v. a non-fetch refusal is NOT decorated with widen context =================
+            {
+                var o = svc.CopyNpcAppearance(ghostTplFk.ToString(), "OrphanPatch.esp", null,
+                                              targetFk.ToString(), null, null, null, null);
+                Check(!o.Success && o.Error!.Contains("template") && !o.Error!.Contains("auto-searched"),
+                    "widen-scope: a TEMPLATE refusal (donor shape, not the read) carries NO widen note — no red herring");
+            }
+
+            // ================= 2c-vi. AMBIGUOUS defining plugin — declined loudly, named in the refusal =================
+            {
+                var o = svc.CopyNpcAppearance(twinNpcFk.ToString(), "TwinPatch.esp", null,
+                                              targetFk.ToString(), null, null, null, null);
+                Check(!o.Success && o.Error!.Contains("exists in 2 places") && o.Error!.Contains("not auto-read"),
+                    "widen-ambiguous: a defining plugin in two folders declines the widen and the refusal SAYS so");
             }
 
             // ================= 2d. clone refusals the fold added =================

--- a/src/housecarl-generator/NpcCopyProbe.cs
+++ b/src/housecarl-generator/NpcCopyProbe.cs
@@ -22,6 +22,9 @@ namespace HousecarlGenerator;
 ///                donor's folder, and an unresolvable referenced path is a NAMED miss, never silent (Q3).
 ///   CLONE      — a full standalone clone: new EditorID/Name, appearance remapped, and the donor-internal NON-appearance
 ///                links (a faction membership, a default outfit) STRIPPED with each strip NAMED in the outcome.
+///   AUTO-WIDEN — source_plugin= naming an OVERRIDE PATCH of the donor pulls the DEFINING plugin in behind it
+///                (the override wins, records internalize from both, the render says so); a defining plugin
+///                nowhere on disk becomes a NOTE on the closure refusal, never a silent degrade.
 ///   REFUSALS   — both/neither target modes; a donor formid the active order can't see (the message routes to
 ///                source_plugin=); a non-NPC donor; a donor-internal custom RACE (out of scope, named).
 /// Run: dotnet run --project src/housecarl-generator -- copy-npc-appearance-guard
@@ -156,6 +159,36 @@ public static class NpcCopyProbe
             donor2Mod.Npcs.Add(viv2);
             WriteModDirect(mods, "Donor2Mod", donor2Mod, keepMod);
 
+            // an OVERRIDE PATCH of Viv (disabled) — the AUTO-WIDEN lane: naming this file as source_plugin= must
+            // pull Donor.esp (the defining plugin) in behind it, with the patch's override WINNING (its look is the
+            // one being asked for) and records internalized from BOTH plugins.
+            var lookKey = new ModKey("DonorLook", ModType.Plugin);
+            var lookMod = new SkyrimMod(lookKey, SkyrimRelease.SkyrimSE);
+            var lookBrow = new HeadPart(new FormKey(lookKey, 0x800), SkyrimRelease.SkyrimSE) { EditorID = "LookBrowHP" };
+            lookMod.HeadParts.Add(lookBrow);
+            var vivLook = new Npc(donorNpcFk, SkyrimRelease.SkyrimSE) { EditorID = "Viv", Name = "Vivace" };
+            vivLook.Configuration.Flags |= NpcConfiguration.Flag.Female;
+            vivLook.Race.SetTo(raceFk);
+            vivLook.HeadParts.Add(hairFk);            // defined in Donor.esp — reachable ONLY via the widen
+            vivLook.HeadParts.Add(lookBrow.FormKey);  // defined in the named file itself
+            vivLook.HairColor.SetTo(colorFk);         // Donor.esp-internal — widen again
+            vivLook.HeadTexture.SetTo(keptTxstFk);
+            vivLook.Weight = 77f;                     // differs from Donor.esp's 42 — the override must WIN
+            lookMod.Npcs.Add(vivLook);
+            WriteModDirect(mods, "DonorLookMod", lookMod, keepMod, donorMod);
+
+            // an override patch whose DEFINING plugin is nowhere on disk — the widen-failure NOTE lane.
+            var ghostKey = new ModKey("Ghost", ModType.Plugin);
+            var ghostNpcFk = new FormKey(ghostKey, 0xF00);
+            var ghostMod = new SkyrimMod(ghostKey, SkyrimRelease.SkyrimSE);            // master-mapped, NEVER written
+            var orphanKey = new ModKey("OrphanPatch", ModType.Plugin);
+            var orphanMod = new SkyrimMod(orphanKey, SkyrimRelease.SkyrimSE);
+            var ghostOverride = new Npc(ghostNpcFk, SkyrimRelease.SkyrimSE) { EditorID = "Ghost" };
+            ghostOverride.Race.SetTo(raceFk);
+            ghostOverride.HeadParts.Add(new FormKey(ghostKey, 0xF01));                 // needs Ghost.esp — unproducible
+            orphanMod.Npcs.Add(ghostOverride);
+            WriteModDirect(mods, "OrphanPatchMod", orphanMod, keepMod, ghostMod);
+
             // donor-only loose assets: the facegen pair (geom embeds a texture path for the scrape), the scraped
             // texture, and the record-referenced hair model.
             var donorDir = Path.Combine(mods, "DonorMod");
@@ -173,7 +206,7 @@ public static class NpcCopyProbe
             WriteProfile(prof,
                 loadorder: new[] { vanKey.FileName.String, keepKey.FileName.String, folKey.FileName.String },
                 plugins: new[] { "*" + vanKey.FileName, "*" + keepKey.FileName, "*" + folKey.FileName },
-                modlist: new[] { "+ContestMod", "+FollowerMod", "+KeepMod", "+FakeVanilla", "-DonorMod", "-Donor2Mod" });
+                modlist: new[] { "+ContestMod", "+FollowerMod", "+KeepMod", "+FakeVanilla", "-DonorMod", "-Donor2Mod", "-DonorLookMod", "-OrphanPatchMod" });
             WriteSkyrimIni(prof);
 
             using var svc = LoadOrderService.WithInstance(inst, 0, new UserConfigStore(Path.Combine(root, "user.json")));
@@ -331,6 +364,40 @@ public static class NpcCopyProbe
                     "base-game donor: nothing internalized (its records resolve everywhere), said plainly");
                 Check(o.Success && o.Masters.Contains("Skyrim.esm", StringComparer.OrdinalIgnoreCase),
                     "base-game donor: the links stay links — Skyrim.esm mastered normally");
+            }
+
+            // ================= 2c-ii. AUTO-WIDEN — source_plugin= names an OVERRIDE PATCH of the donor =================
+            {
+                var o = svc.CopyNpcAppearance(donorNpcFk.ToString(), "DonorLook.esp", null,
+                                              targetFk.ToString(), null, null, "WidenFace", null);
+                Check(o.Success, $"widen: an override-patch source_plugin succeeds via the defining plugin ({o.Error})");
+                Check(o.Success && o.DonorReadFrom.Contains("AUTO-WIDENED") && o.DonorReadFrom.Contains("Donor.esp"),
+                    "widen: the render SAYS the read was widened and NAMES the defining plugin (nothing silent)");
+                Check(o.Success && o.Internalized.Any(r => r.OldKey.ModKey == donorKey)
+                                && o.Internalized.Any(r => r.OldKey.ModKey == lookKey),
+                    "widen: records internalized from BOTH the named file and the defining plugin");
+                Check(o.Success && !o.Masters.Contains("Donor.esp", StringComparer.OrdinalIgnoreCase)
+                                && !o.Masters.Contains("DonorLook.esp", StringComparer.OrdinalIgnoreCase),
+                    "widen: NEITHER plugin is a master — the standalone claim holds across the widened pair");
+                if (o.Success)
+                {
+                    using var pd = OpenDisposable(o.OutPath!, out var patch);
+                    var npc = patch.Npcs.FirstOrDefault(n => n.FormKey == targetFk);
+                    Check(npc is not null && Math.Abs(npc.Weight - 77f) < 0.001,
+                        "widen: the NAMED file's override WINS — its look (Weight 77), not the defining plugin's (42)");
+                    Check(npc is not null && npc.HeadParts.Count == 2,
+                        "widen: both headparts arrive — the named file's own and the defining plugin's");
+                }
+            }
+
+            // ================= 2c-iii. widen NOT possible — the failure is a NOTE on the closure refusal =================
+            {
+                var o = svc.CopyNpcAppearance(ghostNpcFk.ToString(), "OrphanPatch.esp", null,
+                                              targetFk.ToString(), null, null, null, null);
+                Check(!o.Success && o.Error!.Contains("cannot produce"),
+                    "widen-miss: the closure refusal still fires when the defining plugin is nowhere on disk");
+                Check(!o.Success && o.Error!.Contains("Ghost.esp") && o.Error!.Contains("auto-searched"),
+                    "widen-miss: the refusal carries the NOTE that auto-widening was attempted and why it could not");
             }
 
             // ================= 2d. clone refusals the fold added =================

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1999,7 +1999,7 @@ public sealed class LoadOrderService : IDisposable
                         if (wloc.Error is not null)
                             widenNote = WidenMiss($"was auto-searched for but not found: {wloc.Error}");
                         else if (wloc.Ambiguous is not null)
-                            widenNote = WidenMiss($"exists in {wloc.Ambiguous.Count} places ({string.Join(" | ", wloc.Ambiguous.Select(h => h.Where))}), so it was not auto-read.");
+                            widenNote = WidenMiss($"exists in {wloc.Ambiguous.Count} places ({string.Join(" | ", wloc.Ambiguous.Select(h => h.Where))}), so it was not auto-read — enable the defining mod, or remove/rename the duplicate copy, and re-run.");
                         else
                         {
                             try
@@ -2121,6 +2121,7 @@ public sealed class LoadOrderService : IDisposable
                         if (sidePath is null) continue;
                         var sideDir = Path.GetDirectoryName(sidePath);
                         if (sideDir is not null && !string.IsNullOrEmpty(dataDirForAssets) && PathEquals(sideDir, dataDirForAssets)) continue;
+                        if (sideDir is not null && donorDisks.Any(d => PathEquals(sideDir, d.Folder))) continue;   // named + defining in one folder = one scan
                         var disk = NpcAppearanceAssets.DonorDisk.For(sidePath);
                         donorDisks.Add(disk);
                         donorFolderNames.Add(Path.GetFileName(disk.Folder));

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1932,7 +1932,10 @@ public sealed class LoadOrderService : IDisposable
             if (!baseMasters.Contains(donorFk.ModKey)) donorMods.Add(donorFk.ModKey);
             string donorReadFrom; bool outOfLoadOrder;
             ISkyrimModGetter? donorOverlay = null;    // file lane only — disposed in finally
+            ISkyrimModGetter? widenOverlay = null;    // file lane, auto-widened defining plugin — disposed in finally
             string? donorFilePath = null;             // file lane: the located file; active lane: the winner's path (for the donor-disk asset fallback)
+            string? widenFilePath = null;             // file lane: the auto-widened defining plugin's file (self-lock check)
+            string widenNote = "";                    // file lane: why an auto-widen did NOT happen — appended to a closure refusal, never a failure of its own
             string dataDirForAssets;
             try
             {
@@ -1952,9 +1955,11 @@ public sealed class LoadOrderService : IDisposable
                         ? $"direct path '{donorFilePath}'"
                         : $"file '{sp}' ({loc.Where}{(loc.Enabled ? "" : ", DISABLED")})";
                     outOfLoadOrder = true;
+                    ModKey? namedFileKey = null;
                     try
                     {
                         var fileKey = ModKey.FromFileName(Path.GetFileName(donorFilePath));
+                        namedFileKey = fileKey;
                         if (!baseMasters.Contains(fileKey)) donorMods.Add(fileKey);
                     }
                     catch { /* a direct path with an odd name — donorFk.ModKey still governs */ }
@@ -1971,7 +1976,44 @@ public sealed class LoadOrderService : IDisposable
                     if (donorBody is not INpcGetter fileNpc)
                         return NpcCopyOutcome.Fail($"{donorFk} in '{Path.GetFileName(donorFilePath)}' is a {RecordNaming.StripOverlay(donorBody.GetType().Name)}, not an NPC.");
                     donorNpc = fileNpc;
-                    fetch = fk2 => { try { return donorCache.TryResolve(fk2, out var b) ? b : null; } catch { return null; } };
+                    NpcAppearanceCopy.DonorFetch namedFetch = fk2 => { try { return donorCache.TryResolve(fk2, out var b) ? b : null; } catch { return null; } };
+                    fetch = namedFetch;
+
+                    // AUTO-WIDEN (Aaron 2026-07-07 — PR #156 finding 6): the named file only OVERRIDES the donor;
+                    // the records a standalone copy must internalize live in the DEFINING plugin, which an override
+                    // patch points at but does not contain. Locate that plugin on disk too and let the closure fall
+                    // through to it — the named file stays first (its override IS the look being asked for). Said
+                    // loudly in the render. A failed locate is only a NOTE carried onto a closure refusal, never a
+                    // hard failure of its own: a donor whose closure never needs the defining plugin must keep working.
+                    if (donorMods.Contains(donorFk.ModKey) && namedFileKey != donorFk.ModKey)
+                    {
+                        var defName = donorFk.ModKey.FileName.String;
+                        var wloc = LocatePluginFileOnDisk(comp, modsDir, dataDir, overwriteDir, defName, null);
+                        if (wloc.Error is not null)
+                            widenNote = $" NOTE: '{Path.GetFileName(donorFilePath)}' only OVERRIDES the donor — its defining plugin '{defName}' was auto-searched for but not found: {wloc.Error}";
+                        else if (wloc.Ambiguous is not null)
+                            widenNote = $" NOTE: '{Path.GetFileName(donorFilePath)}' only OVERRIDES the donor — its defining plugin '{defName}' exists in {wloc.Ambiguous.Count} places ({string.Join(" | ", wloc.Ambiguous.Select(h => h.Where))}), so it was not auto-read.";
+                        else if (!string.Equals(Path.GetFullPath(wloc.Path!), Path.GetFullPath(donorFilePath), StringComparison.OrdinalIgnoreCase))
+                        {
+                            try
+                            {
+                                widenOverlay = LoadOrderResolver.OpenOverlay(wloc.Path!, string.IsNullOrEmpty(dataDir) ? null : dataDir);
+                                var widenCache = widenOverlay.ToImmutableLinkCache();
+                                widenFilePath = wloc.Path;
+                                fetch = fk2 =>
+                                {
+                                    var b = namedFetch(fk2);
+                                    if (b is not null) return b;
+                                    try { return widenCache.TryResolve(fk2, out var wb) ? wb : null; } catch { return null; }
+                                };
+                                donorReadFrom += $"; AUTO-WIDENED to the donor's defining plugin '{defName}' ({wloc.Where}{(wloc.Enabled ? "" : ", DISABLED")}) — the named file only overrides the donor, the defining plugin carries the records being standalone-ized";
+                            }
+                            catch (Exception ex)
+                            {
+                                widenNote = $" NOTE: '{Path.GetFileName(donorFilePath)}' only OVERRIDES the donor — its defining plugin '{defName}' was found but could not be opened: {ex.Message}";
+                            }
+                        }
+                    }
                 }
                 else
                 {
@@ -2001,7 +2043,7 @@ public sealed class LoadOrderService : IDisposable
 
                 // ---- 2. the appearance closure (generic link walk; loud refusals — custom race, runaway, unreadable) ----
                 var closure = NpcAppearanceCopy.CollectAppearanceClosure(donorNpc, donorMods, fetch, active);
-                if (!closure.Success) return NpcCopyOutcome.Fail(closure.Error!);
+                if (!closure.Success) return NpcCopyOutcome.Fail(closure.Error! + widenNote);
 
                 // ---- 3. output patch (folder-per-patch or into= extend — the record lane's resolver + ownership gate) ----
                 string outPath; bool extend, created;
@@ -2029,16 +2071,18 @@ public sealed class LoadOrderService : IDisposable
                     targetActiveBody = tnpc;
                 }
 
-                // ---- 4b. the donor FILE must not be the output patch (review finding: the donor overlay stays
+                // ---- 4b. neither donor-side FILE may be the output patch (review finding: the overlays stay
                 //          memory-mapped through the serialize — the exact self-lock class the write path guards).
-                if (donorFilePath is not null
-                    && string.Equals(Path.GetFullPath(donorFilePath), Path.GetFullPath(outPath), StringComparison.OrdinalIgnoreCase))
-                {
-                    if (created) RemoveFolderCreatedThisCall(outPath);
-                    return NpcCopyOutcome.Fail(
-                        "the donor plugin file IS the output patch — reading and rewriting the same file in one call would " +
-                        "deadlock on its own open handle. Copy into a DIFFERENT patch (omit into=, or name another).");
-                }
+                foreach (var (lockPath, what) in new (string?, string)[]
+                         { (donorFilePath, "donor plugin file"), (widenFilePath, "auto-widened defining plugin") })
+                    if (lockPath is not null
+                        && string.Equals(Path.GetFullPath(lockPath), Path.GetFullPath(outPath), StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (created) RemoveFolderCreatedThisCall(outPath);
+                        return NpcCopyOutcome.Fail(
+                            $"the {what} IS the output patch — reading and rewriting the same file in one call would " +
+                            "deadlock on its own open handle. Copy into a DIFFERENT patch (omit into=, or name another).");
+                    }
 
                 // ---- 5. build + serialize (core — Duplicate/RemapLinks, mode lane, multi-master write) ----
                 var outcome = NpcAppearanceCopy.BuildAndWrite(
@@ -2082,7 +2126,7 @@ public sealed class LoadOrderService : IDisposable
                 }
                 return outcome with { Assets = assets };
             }
-            finally { (donorOverlay as IDisposable)?.Dispose(); }
+            finally { (donorOverlay as IDisposable)?.Dispose(); (widenOverlay as IDisposable)?.Dispose(); }
         }
     }
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1935,7 +1935,7 @@ public sealed class LoadOrderService : IDisposable
             ISkyrimModGetter? widenOverlay = null;    // file lane, auto-widened defining plugin — disposed in finally
             string? donorFilePath = null;             // file lane: the located file; active lane: the winner's path (for the donor-disk asset fallback)
             string? widenFilePath = null;             // file lane: the auto-widened defining plugin's file (self-lock check)
-            string widenNote = "";                    // file lane: why an auto-widen did NOT happen — appended to a closure refusal, never a failure of its own
+            string widenNote = "";                    // file lane: the auto-widen's read context (what was auto-read, or why it couldn't be) — appended to a FETCH-MISS closure refusal only, never a failure of its own
             string dataDirForAssets;
             try
             {
@@ -1950,10 +1950,14 @@ public sealed class LoadOrderService : IDisposable
                     if (loc.Error is not null) return NpcCopyOutcome.Fail(loc.Error);
                     if (loc.Ambiguous is not null)
                         return NpcCopyOutcome.Fail($"'{sp}' exists in {loc.Ambiguous.Count} places ({string.Join(" | ", loc.Ambiguous.Select(h => h.Where))}) — pass source_mod= to pick one.");
+                    static string Located(PluginLocateResult l) => $"{l.Where}{(l.Enabled ? "" : ", DISABLED")}";
+                    static NpcAppearanceCopy.DonorFetch CacheFetch(Mutagen.Bethesda.Plugins.Cache.ILinkCache c) =>
+                        fk2 => { try { return c.TryResolve(fk2, out var b) ? b : null; } catch { return null; } };
+
                     donorFilePath = loc.Path!;
                     donorReadFrom = loc.Where == "direct path"
                         ? $"direct path '{donorFilePath}'"
-                        : $"file '{sp}' ({loc.Where}{(loc.Enabled ? "" : ", DISABLED")})";
+                        : $"file '{sp}' ({Located(loc)})";
                     outOfLoadOrder = true;
                     ModKey? namedFileKey = null;
                     try
@@ -1976,41 +1980,40 @@ public sealed class LoadOrderService : IDisposable
                     if (donorBody is not INpcGetter fileNpc)
                         return NpcCopyOutcome.Fail($"{donorFk} in '{Path.GetFileName(donorFilePath)}' is a {RecordNaming.StripOverlay(donorBody.GetType().Name)}, not an NPC.");
                     donorNpc = fileNpc;
-                    NpcAppearanceCopy.DonorFetch namedFetch = fk2 => { try { return donorCache.TryResolve(fk2, out var b) ? b : null; } catch { return null; } };
+                    var namedFetch = CacheFetch(donorCache);
                     fetch = namedFetch;
 
                     // AUTO-WIDEN (Aaron 2026-07-07 — PR #156 finding 6): the named file only OVERRIDES the donor;
                     // the records a standalone copy must internalize live in the DEFINING plugin, which an override
                     // patch points at but does not contain. Locate that plugin on disk too and let the closure fall
                     // through to it — the named file stays first (its override IS the look being asked for). Said
-                    // loudly in the render. A failed locate is only a NOTE carried onto a closure refusal, never a
-                    // hard failure of its own: a donor whose closure never needs the defining plugin must keep working.
+                    // loudly in the render on success, and carried as a NOTE onto a fetch-miss closure refusal
+                    // either way (what was read, or why the widen could not happen) — never a hard failure of its
+                    // own: a donor whose closure never needs the defining plugin must keep working.
                     if (donorMods.Contains(donorFk.ModKey) && namedFileKey != donorFk.ModKey)
                     {
                         var defName = donorFk.ModKey.FileName.String;
+                        string WidenMiss(string why) =>
+                            $" NOTE: '{Path.GetFileName(donorFilePath)}' only OVERRIDES the donor — its defining plugin '{defName}' {why}";
                         var wloc = LocatePluginFileOnDisk(comp, modsDir, dataDir, overwriteDir, defName, null);
                         if (wloc.Error is not null)
-                            widenNote = $" NOTE: '{Path.GetFileName(donorFilePath)}' only OVERRIDES the donor — its defining plugin '{defName}' was auto-searched for but not found: {wloc.Error}";
+                            widenNote = WidenMiss($"was auto-searched for but not found: {wloc.Error}");
                         else if (wloc.Ambiguous is not null)
-                            widenNote = $" NOTE: '{Path.GetFileName(donorFilePath)}' only OVERRIDES the donor — its defining plugin '{defName}' exists in {wloc.Ambiguous.Count} places ({string.Join(" | ", wloc.Ambiguous.Select(h => h.Where))}), so it was not auto-read.";
-                        else if (!string.Equals(Path.GetFullPath(wloc.Path!), Path.GetFullPath(donorFilePath), StringComparison.OrdinalIgnoreCase))
+                            widenNote = WidenMiss($"exists in {wloc.Ambiguous.Count} places ({string.Join(" | ", wloc.Ambiguous.Select(h => h.Where))}), so it was not auto-read.");
+                        else
                         {
                             try
                             {
                                 widenOverlay = LoadOrderResolver.OpenOverlay(wloc.Path!, string.IsNullOrEmpty(dataDir) ? null : dataDir);
-                                var widenCache = widenOverlay.ToImmutableLinkCache();
                                 widenFilePath = wloc.Path;
-                                fetch = fk2 =>
-                                {
-                                    var b = namedFetch(fk2);
-                                    if (b is not null) return b;
-                                    try { return widenCache.TryResolve(fk2, out var wb) ? wb : null; } catch { return null; }
-                                };
-                                donorReadFrom += $"; AUTO-WIDENED to the donor's defining plugin '{defName}' ({wloc.Where}{(wloc.Enabled ? "" : ", DISABLED")}) — the named file only overrides the donor, the defining plugin carries the records being standalone-ized";
+                                var widenFetch = CacheFetch(widenOverlay.ToImmutableLinkCache());
+                                fetch = fk2 => namedFetch(fk2) ?? widenFetch(fk2);
+                                donorReadFrom += $"; AUTO-WIDENED to the donor's defining plugin '{defName}' ({Located(wloc)}) — the named file only overrides the donor, the defining plugin carries the records being standalone-ized";
+                                widenNote = $" NOTE: the donor's defining plugin '{defName}' was AUTO-READ as well ({Located(wloc)}) — the missing record is in neither the named file nor it.";
                             }
                             catch (Exception ex)
                             {
-                                widenNote = $" NOTE: '{Path.GetFileName(donorFilePath)}' only OVERRIDES the donor — its defining plugin '{defName}' was found but could not be opened: {ex.Message}";
+                                widenNote = WidenMiss($"was found but could not be opened: {ex.Message}");
                             }
                         }
                     }
@@ -2043,7 +2046,7 @@ public sealed class LoadOrderService : IDisposable
 
                 // ---- 2. the appearance closure (generic link walk; loud refusals — custom race, runaway, unreadable) ----
                 var closure = NpcAppearanceCopy.CollectAppearanceClosure(donorNpc, donorMods, fetch, active);
-                if (!closure.Success) return NpcCopyOutcome.Fail(closure.Error! + widenNote);
+                if (!closure.Success) return NpcCopyOutcome.Fail(closure.Error! + (closure.FetchMiss ? widenNote : ""));
 
                 // ---- 3. output patch (folder-per-patch or into= extend — the record lane's resolver + ownership gate) ----
                 string outPath; bool extend, created;
@@ -2075,8 +2078,7 @@ public sealed class LoadOrderService : IDisposable
                 //          memory-mapped through the serialize — the exact self-lock class the write path guards).
                 foreach (var (lockPath, what) in new (string?, string)[]
                          { (donorFilePath, "donor plugin file"), (widenFilePath, "auto-widened defining plugin") })
-                    if (lockPath is not null
-                        && string.Equals(Path.GetFullPath(lockPath), Path.GetFullPath(outPath), StringComparison.OrdinalIgnoreCase))
+                    if (lockPath is not null && PathEquals(lockPath, outPath))
                     {
                         if (created) RemoveFolderCreatedThisCall(outPath);
                         return NpcCopyOutcome.Fail(
@@ -2101,23 +2103,31 @@ public sealed class LoadOrderService : IDisposable
 
                 // ---- 6. asset carry (facegen rename + donor-only textures/meshes) — best-effort + reported (Q3).
                 //         Paths were harvested from the IN-PATCH duplicates pre-serialize (never the donor overlay,
-                //         which may be released by now). The donor-disk direct lane only exists for a donor under an
-                //         MO2 mod folder — NEVER the game Data folder, where every vanilla BSA would misclassify as
-                //         "the donor's" (review finding). ----
+                //         which may be released by now). Donor-disk direct lanes exist for BOTH donor-side files —
+                //         the named file's folder AND the auto-widened defining plugin's (review finding: a widened
+                //         copy's facegen lives in the DEFINING mod's folder, not the override patch's) — but only
+                //         under an MO2 mod folder, NEVER the game Data folder, where every vanilla BSA would
+                //         misclassify as "the donor's" (review finding). ----
                 NpcAssetOutcome assets;
                 try
                 {
                     AssetResolver assetResolver;
                     lock (_gate) { assetResolver = Assets; }
                     var assetView = assetResolver.Capture();
-                    var donorDir = donorFilePath is not null ? Path.GetDirectoryName(donorFilePath) : null;
-                    bool donorInData = donorDir is not null && !string.IsNullOrEmpty(dataDirForAssets)
-                        && string.Equals(Path.GetFullPath(donorDir), Path.GetFullPath(dataDirForAssets), StringComparison.OrdinalIgnoreCase);
-                    var donorDisk = donorFilePath is not null && !donorInData ? NpcAppearanceAssets.DonorDisk.For(donorFilePath) : null;
-                    var donorFolderName = donorDisk is not null ? Path.GetFileName(donorDisk.Folder) : null;
+                    var donorDisks = new List<NpcAppearanceAssets.DonorDisk>();
+                    var donorFolderNames = new List<string>();
+                    foreach (var sidePath in new[] { donorFilePath, widenFilePath })
+                    {
+                        if (sidePath is null) continue;
+                        var sideDir = Path.GetDirectoryName(sidePath);
+                        if (sideDir is not null && !string.IsNullOrEmpty(dataDirForAssets) && PathEquals(sideDir, dataDirForAssets)) continue;
+                        var disk = NpcAppearanceAssets.DonorDisk.For(sidePath);
+                        donorDisks.Add(disk);
+                        donorFolderNames.Add(Path.GetFileName(disk.Folder));
+                    }
                     assets = NpcAppearanceAssets.CarryAll(
                         donorFk, outcome.NewNpcKey, outcome.HarvestedAssetPaths,
-                        assetView, donorDisk, donorFolderName, Path.GetDirectoryName(outPath)!);
+                        assetView, donorDisks, donorFolderNames, Path.GetDirectoryName(outPath)!);
                 }
                 catch (Exception ex)
                 {

--- a/src/housecarl-mcp/NpcCopyTools.cs
+++ b/src/housecarl-mcp/NpcCopyTools.cs
@@ -36,7 +36,7 @@ public static class NpcCopyTools
         LoadOrderService svc,
         [Description("The donor NPC's FormID 'XXXXXX:Plugin.esp' (e.g. '000D62:Vivace.esp') — the appearance being copied.")]
             string source_formid,
-        [Description("Optional. Read the donor from this plugin FILE instead of the active load order — the DISABLED-donor lane. A filename ('Vivace.esp'; located across enabled+disabled mod folders, overwrite and Data) or an absolute path. Omit when the donor is active.")]
+        [Description("Optional. Read the donor from this plugin FILE instead of the active load order — the DISABLED-donor lane. A filename ('Vivace.esp'; located across enabled+disabled mod folders, overwrite and Data) or an absolute path. An OVERRIDE PATCH of the donor works too: the read auto-widens to the donor's defining plugin (located the same way, reported in the result). Omit when the donor is active.")]
             string? source_plugin = null,
         [Description("Optional (with source_plugin). The exact MO2 mod-folder name to read the plugin from, when the filename exists in several folders.")]
             string? source_mod = null,


### PR DESCRIPTION
Closes the open **finding-6 design question** from PR #156 — Aaron's call (2026-07-07): **auto-widen**.

## What
When `source_plugin=` names an **override patch** of the donor NPC (the file's ModKey ≠ the donor FormKey's defining plugin), the read now **locates the defining plugin on disk too** (the same enabled+disabled mod-folder search) and lets the closure fall through to it. The named file stays first — its override IS the look being copied. **The asset half widens with it** (review fold): the facegen pair and donor-only files are carried from BOTH folders, named patch's first.

## Why
Previously this was a dead end: the refusal's remedies could not produce "the override's look, standalone" at all — passing the defining plugin instead loses the override's edits, and enabling it keeps a master (not standalone).

## Q3 loudness
- A successful widen is stamped into the `donor read from:` render line — names the plugin, where it was found, DISABLED state.
- A **fetch-miss** refusal carries the widen context both ways: what was auto-read ("'A' was AUTO-READ as well — the record is in neither file") or why the widen could not happen (not found / ambiguous with the enable-or-dedupe remedy / unopenable). Non-fetch refusals (template/race/cap) are NOT decorated — `ClosureResult.FetchMiss` scopes the note to the one refusal class it can explain.
- A widen failure is never a hard failure of its own — a donor whose closure never needs the defining plugin keeps working.
- The 4b self-lock check covers the widened file; the widen overlay is disposed alongside the donor overlay.

## Known edges (noted, not built — none block)
- **Ambiguous defining plugin** (2+ on-disk copies): the widen declines loudly with the remedy, but there is no widen-side disambiguator — "override's look, standalone" is unreachable in that configuration without deduping the copies. Scope call for Aaron.
- **Third-plugin closure miss** (a disabled resource master like KS Hairdos): the widen reads one plugin deep; the general mechanism would resolve through the named file's full located master list. Loud refusal with the enable/keep-master remedy today. Scope call for Aaron.
- Assets are stranded only in those same declined-widen cases (they follow the record refusal, nothing silent). The widen-file-unopenable note branch is unpinned by the guard (needs a corrupt-plugin fixture).

## Proof
- Guard: **67 checks** (+13 over main): widen apply (override wins — Weight 77 not 42, records internalized from BOTH plugins, standalone claim across the pair, render stamp, **asset carry from the defining plugin's folder**), widen-miss note, stale-definer AUTO-READ note, template-no-note scope pin, ambiguous decline named.
- **RED-proven three ways**: widen condition disabled → 5 arms fail with the old dead-end refusal; widen disk dropped from the asset list → 2 asset arms fail; (feat commit's arms were RED against pre-widen behavior by construction).
- **ci-all 75/75** local; 8-angle /code-review folded in `78768b5` (10 findings, 8 fixed — see PR comment), independent review approve + polish in `75b5b6a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)