### PR TITLE
feat(merge_plugins): A4 merge orchestration - housecarl_merge_plugins (tool #33)

### DIFF
--- a/src/housecarl-core/AssetRenameService.cs
+++ b/src/housecarl-core/AssetRenameService.cs
@@ -152,47 +152,56 @@ public static class AssetRenameService
     /// <summary>Carry the VOICE files (.fuz/.lip/…) of every RENUMBERED dialogue line (INFO) in <paramref name="pPrimePath"/>
     /// from their OLD-FormID name to their NEW-FormID name, writing the new copies under <paramref name="outDir"/> (the P′
     /// mod-folder root, as <see cref="CarryFaceGen"/>). DISCOVERS by SCANNING the plugin's voice prefix rather than re-deriving
-    /// the dialogue graph (see the file header): every file under <c>Sound\Voice\&lt;basename&gt;\</c> whose embedded local
-    /// FormID is a renumbered key in <paramref name="map"/> gets its id segment rewritten to the new id. On a compact the
-    /// plugin keeps its basename, so the folder + voice-type + quest/topic + response-number segments are unchanged — ONLY the
-    /// id moves. Rides the same two-phase <see cref="CarryItems"/> as facegen (same in-place aliasing guard). Best-effort +
-    /// reported (Q3): records are already written, so this never throws and never fails the compact.</summary>
+    /// the dialogue graph (see the file header): every file under <c>Sound\Voice\&lt;source&gt;\</c> whose embedded local
+    /// FormID is a renumbered key in <paramref name="map"/> gets its id segment rewritten to the new id. TWO LANES: on a
+    /// COMPACT the plugin keeps its basename (<paramref name="sourcePlugin"/> omitted), so the folder + voice-type +
+    /// quest/topic + response-number segments are unchanged — ONLY the id moves; on a MERGE the output plugin has a NEW
+    /// name, so the caller passes each DONOR's filename as <paramref name="sourcePlugin"/> (one call per donor) and the
+    /// <c>Sound\Voice\&lt;donor&gt;</c> folder segment is rewritten to the output's name ALONGSIDE the id — the engine
+    /// looks voice up under the DEFINING plugin's folder, which the merge changed for every donor line. Rides the same
+    /// two-phase <see cref="CarryItems"/> as facegen (same in-place aliasing guard). Best-effort + reported (Q3): records
+    /// are already written, so this never throws and never fails the compact/merge.</summary>
     public static VoiceCarryOutcome CarryVoice(
-        string pPrimePath, IReadOnlyDictionary<FormKey, FormKey> map, AssetResolver.AssetView assets, string outDir)
+        string pPrimePath, IReadOnlyDictionary<FormKey, FormKey> map, AssetResolver.AssetView assets, string outDir,
+        string? sourcePlugin = null)
     {
-        var basename = Path.GetFileName(pPrimePath);                        // P′ keeps the source basename → the voice folder name (with ext)
+        var targetBasename = Path.GetFileName(pPrimePath);                  // the OUTPUT plugin's filename → the NEW voice folder name
+        var sourceBasename = sourcePlugin ?? targetBasename;                // compact: same name; merge: the donor's filename (OLD folder)
 
-        // local-id → new-local-id for THIS plugin's renumbered records — the only ones whose voice lives under
-        // Sound\Voice\<basename>\ (an override kept at a master key has its voice under the MASTER's folder, untouched).
+        // local-id → new-local-id for the SOURCE plugin's renumbered records — the only ones whose voice lives under
+        // Sound\Voice\<source>\ (an override kept at a master key has its voice under the MASTER's folder, untouched).
         var idMap = new Dictionary<uint, uint>();
         foreach (var kv in map)
-            if (string.Equals(kv.Key.ModKey.FileName.ToString(), basename, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(kv.Key.ModKey.FileName.ToString(), sourceBasename, StringComparison.OrdinalIgnoreCase))
                 idMap[kv.Key.ID] = kv.Value.ID;
         if (idMap.Count == 0) return VoiceCarryOutcome.None(assets.ReadIncomplete);
 
-        // The new INFO FormKeys need a ModKey for the distinct-line accounting; basename came from a real plugin path, so
-        // this is valid (a malformed name is surfaced rather than silently producing a zero pass — Q3).
+        // The new INFO FormKeys need a ModKey for the distinct-line accounting; the target basename came from a real
+        // plugin path, so this is valid (a malformed name is surfaced rather than silently producing a zero pass — Q3).
         ModKey modKey;
-        try { modKey = ModKey.FromFileName(basename); }
+        try { modKey = ModKey.FromFileName(targetBasename); }
         catch (Exception ex)
         {
             return new VoiceCarryOutcome(0, 0, 0,
-                new[] { $"'{basename}' is not a valid plugin filename for voice carry ({ex.Message}) — verify voiced lines in-game." },
+                new[] { $"'{targetBasename}' is not a valid plugin filename for voice carry ({ex.Message}) — verify voiced lines in-game." },
                 assets.ReadIncomplete);
         }
 
+        var srcPrefix = $@"Sound\Voice\{sourceBasename}";
+        var tgtPrefix = $@"Sound\Voice\{targetBasename}";
         IReadOnlyCollection<string> files;
-        try { files = assets.EnumerateUnder($@"Sound\Voice\{basename}"); }
+        try { files = assets.EnumerateUnder(srcPrefix); }
         catch (Exception ex)
         {
             return new VoiceCarryOutcome(0, 0, 0,
-                new[] { $@"could not scan 'Sound\Voice\{basename}' for voice files ({ex.Message}) — verify voiced lines in-game." },
+                new[] { $"could not scan '{srcPrefix}' for voice files ({ex.Message}) — verify voiced lines in-game." },
                 assets.ReadIncomplete);
         }
         if (files.Count == 0) return VoiceCarryOutcome.None(assets.ReadIncomplete);
 
-        // Build the carry list: each voice file whose embedded id was renumbered → its new-id name (ONLY the id segment
-        // changes — see the header). A file with no '_<8hex>_<num>.<ext>' tail, or whose id wasn't renumbered, is left alone.
+        // Build the carry list: each voice file whose embedded id was renumbered → its new-id name (compact: ONLY the id
+        // segment changes; merge: the plugin folder segment swaps with it — see the header). A file with no
+        // '_<8hex>_<num>.<ext>' tail, or whose id wasn't renumbered, is left alone.
         var items = new List<CarryItem>();
         foreach (var oldRel in files)
         {
@@ -206,8 +215,9 @@ public static class AssetRenameService
 
             var newId = "00" + newLocal.ToString("X6");
             var newFname = fname.Substring(0, m.Groups[1].Index) + newId + fname.Substring(m.Groups[1].Index + m.Groups[1].Length);
-            var dir = Path.GetDirectoryName(oldRel) ?? "";                 // same voice-type folder — only the filename's id moves
-            var newRel = dir.Length == 0 ? newFname : Path.Combine(dir, newFname);
+            var dir = Path.GetDirectoryName(oldRel) ?? "";                 // same voice-type folder; the PLUGIN segment swaps on a merge
+            var newDir = dir.Length >= srcPrefix.Length ? tgtPrefix + dir.Substring(srcPrefix.Length) : dir;
+            var newRel = newDir.Length == 0 ? newFname : Path.Combine(newDir, newFname);
             items.Add(new CarryItem(oldRel, newRel, new FormKey(modKey, newLocal), $"{oldLocal:X6}→{newLocal:X6} {fname}"));
         }
 

--- a/src/housecarl-core/RemapEngine.cs
+++ b/src/housecarl-core/RemapEngine.cs
@@ -377,17 +377,21 @@ public static class RemapEngine
     /// <summary>Renumber ONE record: <c>Duplicate(newKey)</c> it under its new-or-same FormKey (Mutagen's deep-copy under
     /// a new identity — its nested children come along at their OLD keys), then recursively renumber those descendants in
     /// place. Counted once per record (itself, before its descendants) into <paramref name="stats"/>. Mechanism pinned by
-    /// remap-wave2-nested-mech.</summary>
-    static IMajorRecord RenumberOne(IMajorRecordGetter rec, IReadOnlyDictionary<FormKey, FormKey> dict, RenumberStats stats)
+    /// remap-wave2-nested-mech. <paramref name="reg"/> (merge only, null for compact) registers every placed record —
+    /// itself AND each descendant — under its NEW key, so the multi-donor walk can detect cross-donor collisions and
+    /// graft a losing donor's un-relisted children into the winner's copy (<see cref="MergeModsInto"/>).</summary>
+    static IMajorRecord RenumberOne(IMajorRecordGetter rec, IReadOnlyDictionary<FormKey, FormKey> dict, RenumberStats stats,
+        MergePlacement? reg = null)
     {
         bool isRenumber = dict.TryGetValue(rec.FormKey, out var newKey);
         if (!isRenumber) newKey = rec.FormKey;                                            // unmapped (an override) — copy at its own key
         var dup = rec.Duplicate(newKey);
         stats.Copied++;
         if (isRenumber) stats.Renumbered++;
+        reg?.Register(newKey, dup);
         // Only records that actually CONTAIN nested records pay the property-walk cost (Any() short-circuits flat records).
         if (dup is IMajorRecordGetterEnumerable e && e.EnumerateMajorRecords().Any())
-            RenumberDescendants(dup, dict, stats);
+            RenumberDescendants(dup, dict, stats, reg);
         return dup;
     }
 
@@ -405,7 +409,8 @@ public static class RemapEngine
     /// <see cref="IList"/> (<c>ExtendedList&lt;T&gt;</c> does), so the <c>val is IList</c> gate reaches them. If Mutagen
     /// ever broke either, the affected records would be SKIPPED (left at old keys) rather than fail loud — which is why the
     /// guard pins every nesting shape on disk.</para></summary>
-    static void RenumberDescendants(object container, IReadOnlyDictionary<FormKey, FormKey> dict, RenumberStats stats)
+    static void RenumberDescendants(object container, IReadOnlyDictionary<FormKey, FormKey> dict, RenumberStats stats,
+        MergePlacement? reg = null)
     {
         foreach (var prop in container.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
         {
@@ -419,17 +424,17 @@ public static class RemapEngine
                 for (int i = 0; i < list.Count; i++)
                 {
                     var el = list[i];
-                    if (el is IMajorRecordGetter childRec) list[i] = RenumberOne(childRec, dict, stats);
-                    else if (el is IMajorRecordGetterEnumerable) RenumberDescendants(el, dict, stats);
+                    if (el is IMajorRecordGetter childRec) list[i] = RenumberOne(childRec, dict, stats, reg);
+                    else if (el is IMajorRecordGetterEnumerable) RenumberDescendants(el, dict, stats, reg);
                 }
             }
             else if (val is IMajorRecordGetter singleRec)
             {
-                if (prop.CanWrite) prop.SetValue(container, RenumberOne(singleRec, dict, stats));
+                if (prop.CanWrite) prop.SetValue(container, RenumberOne(singleRec, dict, stats, reg));
             }
             else if (val is IMajorRecordGetterEnumerable nestedContainer)
             {
-                RenumberDescendants(nestedContainer, dict, stats);
+                RenumberDescendants(nestedContainer, dict, stats, reg);
             }
         }
     }
@@ -448,6 +453,342 @@ public static class RemapEngine
         var sub = block.SubBlocks.FirstOrDefault(s => s.BlockNumber == subN);
         if (sub is null) { sub = new CellSubBlock { BlockNumber = subN, GroupType = GroupTypeEnum.InteriorCellSubBlock }; block.SubBlocks.Add(sub); }
         sub.Cells.Add(cell);
+    }
+
+    // ======================================================================
+    //  3a-MERGE. MULTI-DONOR RENUMBER — build the merged mod M (plan A4)
+    //  Merge = a RECORDS operation (the 2026-06-27 scope correction): combine the
+    //  donor plugins into ONE new plugin, keep the mods installed. Every donor
+    //  ORIGINATING record necessarily changes identity (its ModKey becomes M's,
+    //  even when the object ID is kept), so the remap dict covers ALL of them —
+    //  collision-only applies to the OBJECT ID (zMerge's default: the first donor
+    //  in load order keeps its IDs; later donors renumber only IDs already taken).
+    //  Cross-donor conflicts on the SAME FormKey resolve to the LOAD-ORDER WINNER
+    //  (the locked resolution) and are REPORTED, never silent; the winner's copy
+    //  places first (donors walk in REVERSE load order) and a losing donor's
+    //  un-relisted nested children (the patch-of-a-donor DIAL/INFO + cell shapes)
+    //  are GRAFTED into the winner's already-placed container — the xEdit cell/
+    //  topic merge semantic, without which merging a mod with its patch silently
+    //  drops the base mod's lines and placed refs (Q3).
+    // ======================================================================
+
+    /// <summary>Per-donor merge-remap accounting: how many originating object IDs the donor KEPT (same 6-hex id under
+    /// the merged ModKey) vs had to be RENUMBERED (the id was already claimed by an earlier-in-load-order donor, or sat
+    /// below the write floor).</summary>
+    public sealed record MergeDonorRemap(string Donor, int Kept, int Renumbered);
+
+    /// <summary>A planned multi-donor remap: the UNION old→new FormKey dict over every donor's originating records
+    /// (keys are donor-qualified FormKeys, so donors can never collide in the dict itself), per-donor kept/renumbered
+    /// accounting, or a loud Q3 refusal (window overflow) with no map.</summary>
+    public sealed record MergeRemapPlan(
+        IReadOnlyDictionary<FormKey, FormKey> Dict, IReadOnlyList<MergeDonorRemap> Donors, string? Error)
+    {
+        public bool Success => Error is null;
+        public static MergeRemapPlan Fail(string error) =>
+            new(new Dictionary<FormKey, FormKey>(), Array.Empty<MergeDonorRemap>(), error);
+    }
+
+    /// <summary>
+    /// Build the merge remap: every donor originating FormKey → a FormKey under <paramref name="targetModKey"/>,
+    /// KEEPING the object ID wherever it is in-window and unclaimed (donors claim in LOAD ORDER, so the first donor
+    /// holding an id keeps it — zMerge's default) and allocating the next free id only for COLLISIONS (an id an
+    /// earlier donor claimed) and for ids below <paramref name="floor"/> (the write floor rejects them). REFUSES
+    /// LOUD (Q3) when the combined donors overflow the window — named, never a truncation.
+    /// </summary>
+    public static MergeRemapPlan BuildMergeRemap(
+        IReadOnlyList<(string Donor, IReadOnlyList<FormKey> Keys)> donorsByLoadOrder,
+        ModKey targetModKey, uint floor, uint ceiling)
+    {
+        if (ceiling < floor) return MergeRemapPlan.Fail($"invalid remap window: ceiling 0x{ceiling:X} < floor 0x{floor:X}.");
+
+        // Pass 1 — claim every keepable id, donors in load order (first claim wins); collect the rest as collisions.
+        var claimed = new HashSet<uint>();
+        var keep = new List<FormKey>();
+        var collide = new List<FormKey>();
+        var seen = new HashSet<FormKey>();                                 // defensive intra-donor de-dupe (BuildSequentialRemap parity)
+        foreach (var (_, keys) in donorsByLoadOrder)
+            foreach (var k in keys)
+            {
+                if (!seen.Add(k)) continue;
+                if (k.ID >= floor && k.ID <= ceiling && claimed.Add(k.ID)) keep.Add(k);
+                else collide.Add(k);
+            }
+
+        long capacity = (long)ceiling - floor + 1;
+        if (seen.Count > capacity)
+            return MergeRemapPlan.Fail(
+                $"cannot merge {seen.Count} originating records into the window 0x{floor:X}–0x{ceiling:X} ({capacity} IDs): " +
+                "the combined donors overflow it. Named, not truncated (Q3).");
+
+        // Pass 2 — kept ids carry over under the merged ModKey; each collision takes the next free id.
+        var dict = new Dictionary<FormKey, FormKey>(seen.Count);
+        foreach (var k in keep) dict[k] = new FormKey(targetModKey, k.ID);
+        uint next = floor;
+        foreach (var k in collide)
+        {
+            while (next <= ceiling && claimed.Contains(next)) next++;
+            if (next > ceiling)
+                return MergeRemapPlan.Fail(
+                    $"cannot merge: the free-id scan ran past the window ceiling 0x{ceiling:X} while renumbering collisions " +
+                    "(the combined donors overflow the window). Named, not truncated (Q3).");
+            dict[k] = new FormKey(targetModKey, next);
+            claimed.Add(next);
+        }
+
+        var perDonor = donorsByLoadOrder
+            .Select(d => new MergeDonorRemap(d.Donor,
+                d.Keys.Count(k => dict.TryGetValue(k, out var nk) && nk.ID == k.ID),
+                d.Keys.Count(k => dict.TryGetValue(k, out var nk) && nk.ID != k.ID)))
+            .ToList();
+        return new MergeRemapPlan(dict, perDonor, null);
+    }
+
+    /// <summary>One cross-donor conflict the merge resolved: the same record (by pre-merge FormKey) carried by two
+    /// donors — the LOAD-ORDER WINNER's version is in the merged plugin, the loser's body is not (its un-relisted
+    /// nested children, if any, were grafted). Reported per losing donor (three donors on one record → two entries).</summary>
+    public sealed record MergeConflict(FormKey Key, string RecordType, string WinnerDonor, string LoserDonor);
+
+    /// <summary>The result of the multi-donor renumber: record accounting + every cross-donor conflict resolved
+    /// (load-order winner), or a loud Q3 refusal with NOTHING half-built that the caller would ship.</summary>
+    public sealed record MergeResult(
+        bool Success, string? Error, int RecordsCopied, int RecordsRenumbered, IReadOnlyList<MergeConflict> Conflicts)
+    {
+        public static MergeResult Fail(string error) => new(false, error, 0, 0, Array.Empty<MergeConflict>());
+    }
+
+    /// <summary>Merge-walk placement registry: every record placed in M so far, keyed by its NEW (post-remap) FormKey,
+    /// with the donor that placed it — the collision detector and graft target for later (earlier-in-load-order) donors.</summary>
+    sealed class MergePlacement
+    {
+        public readonly Dictionary<FormKey, IMajorRecord> Objects = new();
+        public readonly Dictionary<FormKey, string> PlacedBy = new();
+        public string CurrentDonor = "";
+        public void Register(FormKey key, IMajorRecord obj) { Objects[key] = obj; PlacedBy[key] = CurrentDonor; }
+    }
+
+    /// <summary>
+    /// Copy EVERY record of every donor into the (fresh) mod <paramref name="target"/> under its remapped FormKey from
+    /// <paramref name="dict"/>, resolving cross-donor conflicts on the same FormKey to the LOAD-ORDER WINNER. Donors
+    /// walk in REVERSE load order so each record's WINNING version places first (via the same structural walk compact
+    /// uses — <see cref="RenumberOne"/> and the interior-cell block tree); an earlier donor's copy of an already-placed
+    /// record is a reported <see cref="MergeConflict"/>, and its NESTED CHILDREN missing from the winner's copy (a base
+    /// mod's INFOs a patch's DIAL override doesn't re-list; its placed refs under an overridden cell) are GRAFTED into
+    /// the winner's placed container. Then <c>RemapLinks(dict)</c> over the whole target. All-or-nothing (Q3): any
+    /// engine fault abandons the merge with nothing shippable.
+    /// </summary>
+    public static MergeResult MergeModsInto(
+        SkyrimMod target,
+        IReadOnlyList<(string Name, ISkyrimModGetter Mod)> donorsByLoadOrder,
+        IReadOnlyDictionary<FormKey, FormKey> dict)
+    {
+        var stats = new RenumberStats();
+        var reg = new MergePlacement();
+        var conflicts = new List<MergeConflict>();
+        try
+        {
+            foreach (var (name, src) in donorsByLoadOrder.Reverse())      // winner-first: the LAST donor in load order places first
+            {
+                reg.CurrentDonor = name;
+
+                // 1. FLAT top-level groups (each record carries its nested children through RenumberOne's walk).
+                foreach (var (prop, _, _) in WriteEngine.EnumerateFlatGroups(typeof(SkyrimMod)))
+                {
+                    var srcProp = src.GetType().GetProperty(prop.Name);
+                    if (srcProp?.GetValue(src) is not IEnumerable srcGroup) continue;
+                    foreach (var item in srcGroup)
+                    {
+                        if (item is not IMajorRecordGetter rec) continue;
+                        var nk = dict.TryGetValue(rec.FormKey, out var mapped) ? mapped : rec.FormKey;
+                        if (reg.Objects.TryGetValue(nk, out var existing))
+                        {
+                            conflicts.Add(new MergeConflict(rec.FormKey, RecordNaming.StripOverlay(rec.GetType().Name), reg.PlacedBy[nk], name));
+                            GraftMissingDescendants(rec, existing, dict, stats, reg, conflicts);
+                        }
+                        else
+                        {
+                            var dup = RenumberOne(rec, dict, stats, reg);
+                            if (!TryAddToFlatGroup(target, dup))
+                                return MergeResult.Fail(
+                                    $"{RecordNaming.StripOverlay(rec.GetType().Name)} {rec.FormKey} (donor '{name}') is a flat top-level record but no " +
+                                    "matching group was found on the target mod to place its merged copy (engine inconsistency, Q3) — the merge is abandoned with nothing shippable.");
+                        }
+                    }
+                }
+
+                // 2. INTERIOR cells (the mod-level block tree) — placed cell-by-cell, so a losing donor's cell that the
+                //    winner doesn't carry still merges, and a conflicted cell grafts its missing placed refs.
+                if (src.Cells is { } cellsGroup)
+                    foreach (var block in cellsGroup.Records)
+                        foreach (var sub in block.SubBlocks)
+                            foreach (var cell in sub.Cells)
+                            {
+                                var nk = dict.TryGetValue(cell.FormKey, out var mapped) ? mapped : cell.FormKey;
+                                if (reg.Objects.TryGetValue(nk, out var existing))
+                                {
+                                    conflicts.Add(new MergeConflict(cell.FormKey, "Cell", reg.PlacedBy[nk], name));
+                                    GraftMissingDescendants(cell, existing, dict, stats, reg, conflicts);
+                                }
+                                else
+                                {
+                                    var renCell = (Cell)RenumberOne(cell, dict, stats, reg);
+                                    FileInteriorCellByNewId(target, renCell);
+                                }
+                            }
+            }
+
+            // 3. Repoint every internal reference among the merged records (flat AND nested links) to the new keys —
+            //    including every cross-donor reference (a donor-B link into donor-A resolves because A's originating
+            //    keys are all in the dict). Inside the try: a RemapLinks throw is the same structured Q3 refusal.
+            target.RemapLinks(dict);
+        }
+        catch (Exception ex)
+        {
+            return MergeResult.Fail(
+                $"the multi-donor renumber failed ({WriteEngine.Describe(ex)}) — abandoned with nothing shippable (Q3).");
+        }
+
+        return new MergeResult(true, null, stats.Copied, stats.Renumbered, conflicts);
+    }
+
+    /// <summary>Graft a LOSING donor record's nested children into the WINNER's already-placed copy: walk the loser's
+    /// getter with the same discriminators as <see cref="RenumberDescendants"/> (records; the FormKey-less worldspace
+    /// block structs, paired by block NUMBER); a child whose remapped key is already placed recurses (its own children
+    /// may still be missing), an unplaced child is renumbered and APPENDED to the winner's same-named list — the xEdit
+    /// cell/topic merge semantic. A structural mismatch (no same-named settable list on the winner) THROWS — caught by
+    /// <see cref="MergeModsInto"/> into the loud all-or-nothing refusal (Q3), never a silent child drop.</summary>
+    static void GraftMissingDescendants(IMajorRecordGetter loser, IMajorRecord winner,
+        IReadOnlyDictionary<FormKey, FormKey> dict, RenumberStats stats, MergePlacement reg, List<MergeConflict> conflicts)
+    {
+        foreach (var prop in loser.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (prop.GetIndexParameters().Length != 0 || prop.GetGetMethod() is null) continue;
+            object? val;
+            try { val = prop.GetValue(loser); } catch { continue; }
+            if (val is null || val is string || val is byte[]) continue;
+
+            if (val is IMajorRecordGetter singleRec)
+            {
+                GraftSingleton(singleRec, winner, prop.Name, dict, stats, reg, conflicts);
+            }
+            else if (val is IEnumerable seq)
+            {
+                foreach (var el in seq)
+                {
+                    if (el is IMajorRecordGetter childRec)
+                        GraftListChild(childRec, winner, prop.Name, dict, stats, reg, conflicts);
+                    else if (el is IMajorRecordGetterEnumerable blockStruct)
+                        GraftBlock(blockStruct, winner, prop.Name, dict, stats, reg, conflicts);
+                    else break;                                            // a non-record element type — not a record list; skip the property
+                }
+            }
+        }
+    }
+
+    /// <summary>Graft one list-borne child: already placed → report the cross-donor conflict + recurse (grandchildren
+    /// may be missing); unplaced → renumber it and APPEND to the winner container's same-named record list.</summary>
+    static void GraftListChild(IMajorRecordGetter child, IMajorRecord winner, string propName,
+        IReadOnlyDictionary<FormKey, FormKey> dict, RenumberStats stats, MergePlacement reg, List<MergeConflict> conflicts)
+    {
+        var nk = dict.TryGetValue(child.FormKey, out var mapped) ? mapped : child.FormKey;
+        if (reg.Objects.TryGetValue(nk, out var placed))
+        {
+            conflicts.Add(new MergeConflict(child.FormKey, RecordNaming.StripOverlay(child.GetType().Name), reg.PlacedBy[nk], reg.CurrentDonor));
+            GraftMissingDescendants(child, placed, dict, stats, reg, conflicts);
+            return;
+        }
+        if (winner.GetType().GetProperty(propName)?.GetValue(winner) is not IList winnerList)
+            throw new InvalidOperationException(
+                $"cannot graft {RecordNaming.StripOverlay(child.GetType().Name)} {child.FormKey}: the winning donor's " +
+                $"{RecordNaming.StripOverlay(winner.GetType().Name)} {winner.FormKey} has no settable record list '{propName}' to receive it (Q3).");
+        winnerList.Add(RenumberOne(child, dict, stats, reg));
+    }
+
+    /// <summary>Graft one singleton-property child (e.g. a cell's Landscape): already placed → recurse; the winner's
+    /// slot empty → renumber + set; the winner's slot held by a DIFFERENT record → the winner's structure stands and
+    /// the loser's child is REPORTED as a resolved conflict (never silently dropped — Q3).</summary>
+    static void GraftSingleton(IMajorRecordGetter child, IMajorRecord winner, string propName,
+        IReadOnlyDictionary<FormKey, FormKey> dict, RenumberStats stats, MergePlacement reg, List<MergeConflict> conflicts)
+    {
+        var nk = dict.TryGetValue(child.FormKey, out var mapped) ? mapped : child.FormKey;
+        if (reg.Objects.TryGetValue(nk, out var placed))
+        {
+            conflicts.Add(new MergeConflict(child.FormKey, RecordNaming.StripOverlay(child.GetType().Name), reg.PlacedBy[nk], reg.CurrentDonor));
+            GraftMissingDescendants(child, placed, dict, stats, reg, conflicts);
+            return;
+        }
+        var prop = winner.GetType().GetProperty(propName);
+        if (prop is null || !prop.CanWrite)
+            throw new InvalidOperationException(
+                $"cannot graft {RecordNaming.StripOverlay(child.GetType().Name)} {child.FormKey}: the winning donor's " +
+                $"{RecordNaming.StripOverlay(winner.GetType().Name)} {winner.FormKey} has no settable '{propName}' slot to receive it (Q3).");
+        if (prop.GetValue(winner) is IMajorRecord occupant)
+        {
+            // The winner already carries its OWN (different) record in this slot — the winner's structure wins wholesale;
+            // the loser's child is a resolved conflict, reported by the occupant's donor.
+            conflicts.Add(new MergeConflict(child.FormKey, RecordNaming.StripOverlay(child.GetType().Name),
+                reg.PlacedBy.TryGetValue(occupant.FormKey, out var by) ? by : reg.CurrentDonor, reg.CurrentDonor));
+            return;
+        }
+        prop.SetValue(winner, RenumberOne(child, dict, stats, reg));
+    }
+
+    /// <summary>Graft through a FormKey-less worldspace block struct: pair the loser's block with the winner's by block
+    /// NUMBER (X/Y for exterior grids), creating the winner-side block when missing, then graft each leaf cell. The
+    /// worldspace family is the only record-nested block tree (interior cells' mod-level tree is walked cell-by-cell in
+    /// <see cref="MergeModsInto"/>); an unrecognized block shape THROWS — the loud Q3 refusal, never a silent drop.</summary>
+    static void GraftBlock(IMajorRecordGetterEnumerable loserBlock, IMajorRecord winner, string propName,
+        IReadOnlyDictionary<FormKey, FormKey> dict, RenumberStats stats, MergePlacement reg, List<MergeConflict> conflicts)
+    {
+        if (winner.GetType().GetProperty(propName)?.GetValue(winner) is not IList winnerBlocks)
+            throw new InvalidOperationException(
+                $"cannot graft a nested block of '{propName}': the winning donor's {RecordNaming.StripOverlay(winner.GetType().Name)} " +
+                $"{winner.FormKey} has no settable block list '{propName}' to pair against (Q3).");
+
+        switch (loserBlock)
+        {
+            case IWorldspaceBlockGetter wb:
+            {
+                var mBlock = winnerBlocks.Cast<object>().OfType<WorldspaceBlock>()
+                    .FirstOrDefault(b => b.BlockNumberX == wb.BlockNumberX && b.BlockNumberY == wb.BlockNumberY);
+                if (mBlock is null)
+                {
+                    mBlock = new WorldspaceBlock { BlockNumberX = wb.BlockNumberX, BlockNumberY = wb.BlockNumberY, GroupType = wb.GroupType };
+                    winnerBlocks.Add(mBlock);
+                }
+                foreach (var subG in wb.Items) GraftSubBlock(subG, mBlock, dict, stats, reg, conflicts);
+                break;
+            }
+            default:
+                throw new InvalidOperationException(
+                    $"cannot graft: unrecognized nested block shape '{loserBlock.GetType().Name}' under '{propName}' — " +
+                    "refusing rather than silently dropping its records (Q3).");
+        }
+    }
+
+    /// <summary>Pair one worldspace SUB-block by number (creating it winner-side when missing) and graft its cells.</summary>
+    static void GraftSubBlock(IWorldspaceSubBlockGetter loserSub, WorldspaceBlock winnerBlock,
+        IReadOnlyDictionary<FormKey, FormKey> dict, RenumberStats stats, MergePlacement reg, List<MergeConflict> conflicts)
+    {
+        var mSub = winnerBlock.Items
+            .FirstOrDefault(s => s.BlockNumberX == loserSub.BlockNumberX && s.BlockNumberY == loserSub.BlockNumberY);
+        if (mSub is null)
+        {
+            mSub = new WorldspaceSubBlock { BlockNumberX = loserSub.BlockNumberX, BlockNumberY = loserSub.BlockNumberY, GroupType = loserSub.GroupType };
+            winnerBlock.Items.Add(mSub);
+        }
+        foreach (var cell in loserSub.Items)
+        {
+            var nk = dict.TryGetValue(cell.FormKey, out var mapped) ? mapped : cell.FormKey;
+            if (reg.Objects.TryGetValue(nk, out var placed))
+            {
+                conflicts.Add(new MergeConflict(cell.FormKey, "Cell", reg.PlacedBy[nk], reg.CurrentDonor));
+                GraftMissingDescendants(cell, placed, dict, stats, reg, conflicts);
+            }
+            else
+            {
+                mSub.Items.Add((Cell)RenumberOne(cell, dict, stats, reg));
+            }
+        }
     }
 
     // ======================================================================

--- a/src/housecarl-core/RemapEngine.cs
+++ b/src/housecarl-core/RemapEngine.cs
@@ -424,13 +424,37 @@ public static class RemapEngine
                 for (int i = 0; i < list.Count; i++)
                 {
                     var el = list[i];
-                    if (el is IMajorRecordGetter childRec) list[i] = RenumberOne(childRec, dict, stats, reg);
+                    if (el is IMajorRecordGetter childRec)
+                    {
+                        // Merge only (reg != null): a child whose mapped key is ALREADY placed in M — the same record
+                        // carried by two donors under DIFFERENT parents (a moved reference: donor B's cell holds an
+                        // override of donor A's placed ref) — must NOT be duplicated again at the same FormKey. The
+                        // already-placed copy is the load-order winner (winner-first walk); this stale deep-copied
+                        // child is REMOVED from its parent and the conflict is REPORTED (Q3, never a silent second
+                        // record under one FormID — the engine/xEdit-invalid shape the review's C-1 finding named).
+                        var nk = dict.TryGetValue(childRec.FormKey, out var mapped) ? mapped : childRec.FormKey;
+                        if (reg is not null && reg.IsPlaced(childRec, nk, out var placedChild))
+                        {
+                            GraftMissingDescendants(childRec, placedChild, dict, stats, reg);
+                            list.RemoveAt(i); i--;
+                            continue;
+                        }
+                        list[i] = RenumberOne(childRec, dict, stats, reg);
+                    }
                     else if (el is IMajorRecordGetterEnumerable) RenumberDescendants(el, dict, stats, reg);
                 }
             }
             else if (val is IMajorRecordGetter singleRec)
             {
-                if (prop.CanWrite) prop.SetValue(container, RenumberOne(singleRec, dict, stats, reg));
+                if (!prop.CanWrite) continue;
+                var nk = dict.TryGetValue(singleRec.FormKey, out var mapped) ? mapped : singleRec.FormKey;
+                if (reg is not null && reg.IsPlaced(singleRec, nk, out var placedSingle))
+                {
+                    GraftMissingDescendants(singleRec, placedSingle, dict, stats, reg);
+                    prop.SetValue(container, null);                        // the winner's copy lives under ITS parent
+                    continue;
+                }
+                prop.SetValue(container, RenumberOne(singleRec, dict, stats, reg));
             }
             else if (val is IMajorRecordGetterEnumerable nestedContainer)
             {
@@ -501,18 +525,25 @@ public static class RemapEngine
     {
         if (ceiling < floor) return MergeRemapPlan.Fail($"invalid remap window: ceiling 0x{ceiling:X} < floor 0x{floor:X}.");
 
-        // Pass 1 — claim every keepable id, donors in load order (first claim wins); collect the rest as collisions.
+        // Pass 1 — keepable ids write straight into the dict, donors in load order (first claim wins); the rest queue
+        // as collisions. Per-donor kept/renumbered tallies here (renumbered = the donor's total − kept).
         var claimed = new HashSet<uint>();
-        var keep = new List<FormKey>();
         var collide = new List<FormKey>();
         var seen = new HashSet<FormKey>();                                 // defensive intra-donor de-dupe (BuildSequentialRemap parity)
-        foreach (var (_, keys) in donorsByLoadOrder)
+        var dict = new Dictionary<FormKey, FormKey>();
+        var perDonor = new List<MergeDonorRemap>(donorsByLoadOrder.Count);
+        foreach (var (donor, keys) in donorsByLoadOrder)
+        {
+            int kept = 0, total = 0;
             foreach (var k in keys)
             {
                 if (!seen.Add(k)) continue;
-                if (k.ID >= floor && k.ID <= ceiling && claimed.Add(k.ID)) keep.Add(k);
+                total++;
+                if (k.ID >= floor && k.ID <= ceiling && claimed.Add(k.ID)) { dict[k] = new FormKey(targetModKey, k.ID); kept++; }
                 else collide.Add(k);
             }
+            perDonor.Add(new MergeDonorRemap(donor, kept, total - kept));
+        }
 
         long capacity = (long)ceiling - floor + 1;
         if (seen.Count > capacity)
@@ -520,9 +551,8 @@ public static class RemapEngine
                 $"cannot merge {seen.Count} originating records into the window 0x{floor:X}–0x{ceiling:X} ({capacity} IDs): " +
                 "the combined donors overflow it. Named, not truncated (Q3).");
 
-        // Pass 2 — kept ids carry over under the merged ModKey; each collision takes the next free id.
-        var dict = new Dictionary<FormKey, FormKey>(seen.Count);
-        foreach (var k in keep) dict[k] = new FormKey(targetModKey, k.ID);
+        // Pass 2 — each collision takes the next free id. The capacity precheck guarantees one exists for every
+        // collision, so the in-loop ceiling guard is a defensive invariant check, not a reachable refusal.
         uint next = floor;
         foreach (var k in collide)
         {
@@ -530,16 +560,10 @@ public static class RemapEngine
             if (next > ceiling)
                 return MergeRemapPlan.Fail(
                     $"cannot merge: the free-id scan ran past the window ceiling 0x{ceiling:X} while renumbering collisions " +
-                    "(the combined donors overflow the window). Named, not truncated (Q3).");
+                    "(engine invariant violated — the capacity precheck should have refused first). Named, not truncated (Q3).");
             dict[k] = new FormKey(targetModKey, next);
             claimed.Add(next);
         }
-
-        var perDonor = donorsByLoadOrder
-            .Select(d => new MergeDonorRemap(d.Donor,
-                d.Keys.Count(k => dict.TryGetValue(k, out var nk) && nk.ID == k.ID),
-                d.Keys.Count(k => dict.TryGetValue(k, out var nk) && nk.ID != k.ID)))
-            .ToList();
         return new MergeRemapPlan(dict, perDonor, null);
     }
 
@@ -557,13 +581,28 @@ public static class RemapEngine
     }
 
     /// <summary>Merge-walk placement registry: every record placed in M so far, keyed by its NEW (post-remap) FormKey,
-    /// with the donor that placed it — the collision detector and graft target for later (earlier-in-load-order) donors.</summary>
+    /// with the donor that placed it — the collision detector and graft target for later (earlier-in-load-order) donors.
+    /// Carries the conflict list too, so EVERY site that resolves a collision (the top-level walk, the graft helpers,
+    /// and the in-flight <see cref="RenumberDescendants"/> drop below) reports through one channel.</summary>
     sealed class MergePlacement
     {
         public readonly Dictionary<FormKey, IMajorRecord> Objects = new();
         public readonly Dictionary<FormKey, string> PlacedBy = new();
+        public readonly List<MergeConflict> Conflicts = new();
         public string CurrentDonor = "";
         public void Register(FormKey key, IMajorRecord obj) { Objects[key] = obj; PlacedBy[key] = CurrentDonor; }
+
+        /// <summary>True when the mapped key is already placed in M — records the cross-donor conflict (winner = the
+        /// donor that placed it; the walk runs winner-first) and hands back the placed object for a graft recurse.</summary>
+        public bool IsPlaced(IMajorRecordGetter rec, FormKey nk, out IMajorRecord placed)
+        {
+            if (Objects.TryGetValue(nk, out placed!))
+            {
+                Conflicts.Add(new MergeConflict(rec.FormKey, RecordNaming.StripOverlay(rec.GetType().Name), PlacedBy[nk], CurrentDonor));
+                return true;
+            }
+            return false;
+        }
     }
 
     /// <summary>
@@ -583,7 +622,6 @@ public static class RemapEngine
     {
         var stats = new RenumberStats();
         var reg = new MergePlacement();
-        var conflicts = new List<MergeConflict>();
         try
         {
             foreach (var (name, src) in donorsByLoadOrder.Reverse())      // winner-first: the LAST donor in load order places first
@@ -599,10 +637,9 @@ public static class RemapEngine
                     {
                         if (item is not IMajorRecordGetter rec) continue;
                         var nk = dict.TryGetValue(rec.FormKey, out var mapped) ? mapped : rec.FormKey;
-                        if (reg.Objects.TryGetValue(nk, out var existing))
+                        if (reg.IsPlaced(rec, nk, out var existing))
                         {
-                            conflicts.Add(new MergeConflict(rec.FormKey, RecordNaming.StripOverlay(rec.GetType().Name), reg.PlacedBy[nk], name));
-                            GraftMissingDescendants(rec, existing, dict, stats, reg, conflicts);
+                            GraftMissingDescendants(rec, existing, dict, stats, reg);
                         }
                         else
                         {
@@ -623,10 +660,9 @@ public static class RemapEngine
                             foreach (var cell in sub.Cells)
                             {
                                 var nk = dict.TryGetValue(cell.FormKey, out var mapped) ? mapped : cell.FormKey;
-                                if (reg.Objects.TryGetValue(nk, out var existing))
+                                if (reg.IsPlaced(cell, nk, out var existing))
                                 {
-                                    conflicts.Add(new MergeConflict(cell.FormKey, "Cell", reg.PlacedBy[nk], name));
-                                    GraftMissingDescendants(cell, existing, dict, stats, reg, conflicts);
+                                    GraftMissingDescendants(cell, existing, dict, stats, reg);
                                 }
                                 else
                                 {
@@ -647,17 +683,18 @@ public static class RemapEngine
                 $"the multi-donor renumber failed ({WriteEngine.Describe(ex)}) — abandoned with nothing shippable (Q3).");
         }
 
-        return new MergeResult(true, null, stats.Copied, stats.Renumbered, conflicts);
+        return new MergeResult(true, null, stats.Copied, stats.Renumbered, reg.Conflicts);
     }
 
     /// <summary>Graft a LOSING donor record's nested children into the WINNER's already-placed copy: walk the loser's
     /// getter with the same discriminators as <see cref="RenumberDescendants"/> (records; the FormKey-less worldspace
     /// block structs, paired by block NUMBER); a child whose remapped key is already placed recurses (its own children
     /// may still be missing), an unplaced child is renumbered and APPENDED to the winner's same-named list — the xEdit
-    /// cell/topic merge semantic. A structural mismatch (no same-named settable list on the winner) THROWS — caught by
-    /// <see cref="MergeModsInto"/> into the loud all-or-nothing refusal (Q3), never a silent child drop.</summary>
+    /// cell/topic merge semantic (the winner's receiving list is resolved ONCE per property, not per element). A
+    /// structural mismatch (no same-named settable list on the winner) THROWS — caught by <see cref="MergeModsInto"/>
+    /// into the loud all-or-nothing refusal (Q3), never a silent child drop.</summary>
     static void GraftMissingDescendants(IMajorRecordGetter loser, IMajorRecord winner,
-        IReadOnlyDictionary<FormKey, FormKey> dict, RenumberStats stats, MergePlacement reg, List<MergeConflict> conflicts)
+        IReadOnlyDictionary<FormKey, FormKey> dict, RenumberStats stats, MergePlacement reg)
     {
         foreach (var prop in loser.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
         {
@@ -668,52 +705,49 @@ public static class RemapEngine
 
             if (val is IMajorRecordGetter singleRec)
             {
-                GraftSingleton(singleRec, winner, prop.Name, dict, stats, reg, conflicts);
+                GraftSingleton(singleRec, winner, prop.Name, dict, stats, reg);
             }
             else if (val is IEnumerable seq)
             {
+                IList? winnerList = null;                                  // resolved lazily, ONCE per property
+                IList WinnerList(string what) => winnerList ??=
+                    winner.GetType().GetProperty(prop.Name)?.GetValue(winner) as IList
+                    ?? throw new InvalidOperationException(
+                        $"cannot graft {what}: the winning donor's {RecordNaming.StripOverlay(winner.GetType().Name)} " +
+                        $"{winner.FormKey} has no settable record list '{prop.Name}' to receive it (Q3).");
                 foreach (var el in seq)
                 {
                     if (el is IMajorRecordGetter childRec)
-                        GraftListChild(childRec, winner, prop.Name, dict, stats, reg, conflicts);
+                    {
+                        var nk = dict.TryGetValue(childRec.FormKey, out var mapped) ? mapped : childRec.FormKey;
+                        if (reg.IsPlaced(childRec, nk, out var placed))
+                        {
+                            GraftMissingDescendants(childRec, placed, dict, stats, reg);
+                            continue;
+                        }
+                        WinnerList($"{RecordNaming.StripOverlay(childRec.GetType().Name)} {childRec.FormKey}")
+                            .Add(RenumberOne(childRec, dict, stats, reg));
+                    }
                     else if (el is IMajorRecordGetterEnumerable blockStruct)
-                        GraftBlock(blockStruct, winner, prop.Name, dict, stats, reg, conflicts);
+                    {
+                        GraftBlock(blockStruct, WinnerList($"a nested block of '{prop.Name}'"), prop.Name, dict, stats, reg);
+                    }
                     else break;                                            // a non-record element type — not a record list; skip the property
                 }
             }
         }
     }
 
-    /// <summary>Graft one list-borne child: already placed → report the cross-donor conflict + recurse (grandchildren
-    /// may be missing); unplaced → renumber it and APPEND to the winner container's same-named record list.</summary>
-    static void GraftListChild(IMajorRecordGetter child, IMajorRecord winner, string propName,
-        IReadOnlyDictionary<FormKey, FormKey> dict, RenumberStats stats, MergePlacement reg, List<MergeConflict> conflicts)
-    {
-        var nk = dict.TryGetValue(child.FormKey, out var mapped) ? mapped : child.FormKey;
-        if (reg.Objects.TryGetValue(nk, out var placed))
-        {
-            conflicts.Add(new MergeConflict(child.FormKey, RecordNaming.StripOverlay(child.GetType().Name), reg.PlacedBy[nk], reg.CurrentDonor));
-            GraftMissingDescendants(child, placed, dict, stats, reg, conflicts);
-            return;
-        }
-        if (winner.GetType().GetProperty(propName)?.GetValue(winner) is not IList winnerList)
-            throw new InvalidOperationException(
-                $"cannot graft {RecordNaming.StripOverlay(child.GetType().Name)} {child.FormKey}: the winning donor's " +
-                $"{RecordNaming.StripOverlay(winner.GetType().Name)} {winner.FormKey} has no settable record list '{propName}' to receive it (Q3).");
-        winnerList.Add(RenumberOne(child, dict, stats, reg));
-    }
-
     /// <summary>Graft one singleton-property child (e.g. a cell's Landscape): already placed → recurse; the winner's
     /// slot empty → renumber + set; the winner's slot held by a DIFFERENT record → the winner's structure stands and
     /// the loser's child is REPORTED as a resolved conflict (never silently dropped — Q3).</summary>
     static void GraftSingleton(IMajorRecordGetter child, IMajorRecord winner, string propName,
-        IReadOnlyDictionary<FormKey, FormKey> dict, RenumberStats stats, MergePlacement reg, List<MergeConflict> conflicts)
+        IReadOnlyDictionary<FormKey, FormKey> dict, RenumberStats stats, MergePlacement reg)
     {
         var nk = dict.TryGetValue(child.FormKey, out var mapped) ? mapped : child.FormKey;
-        if (reg.Objects.TryGetValue(nk, out var placed))
+        if (reg.IsPlaced(child, nk, out var placed))
         {
-            conflicts.Add(new MergeConflict(child.FormKey, RecordNaming.StripOverlay(child.GetType().Name), reg.PlacedBy[nk], reg.CurrentDonor));
-            GraftMissingDescendants(child, placed, dict, stats, reg, conflicts);
+            GraftMissingDescendants(child, placed, dict, stats, reg);
             return;
         }
         var prop = winner.GetType().GetProperty(propName);
@@ -725,7 +759,7 @@ public static class RemapEngine
         {
             // The winner already carries its OWN (different) record in this slot — the winner's structure wins wholesale;
             // the loser's child is a resolved conflict, reported by the occupant's donor.
-            conflicts.Add(new MergeConflict(child.FormKey, RecordNaming.StripOverlay(child.GetType().Name),
+            reg.Conflicts.Add(new MergeConflict(child.FormKey, RecordNaming.StripOverlay(child.GetType().Name),
                 reg.PlacedBy.TryGetValue(occupant.FormKey, out var by) ? by : reg.CurrentDonor, reg.CurrentDonor));
             return;
         }
@@ -736,14 +770,9 @@ public static class RemapEngine
     /// NUMBER (X/Y for exterior grids), creating the winner-side block when missing, then graft each leaf cell. The
     /// worldspace family is the only record-nested block tree (interior cells' mod-level tree is walked cell-by-cell in
     /// <see cref="MergeModsInto"/>); an unrecognized block shape THROWS — the loud Q3 refusal, never a silent drop.</summary>
-    static void GraftBlock(IMajorRecordGetterEnumerable loserBlock, IMajorRecord winner, string propName,
-        IReadOnlyDictionary<FormKey, FormKey> dict, RenumberStats stats, MergePlacement reg, List<MergeConflict> conflicts)
+    static void GraftBlock(IMajorRecordGetterEnumerable loserBlock, IList winnerBlocks, string propName,
+        IReadOnlyDictionary<FormKey, FormKey> dict, RenumberStats stats, MergePlacement reg)
     {
-        if (winner.GetType().GetProperty(propName)?.GetValue(winner) is not IList winnerBlocks)
-            throw new InvalidOperationException(
-                $"cannot graft a nested block of '{propName}': the winning donor's {RecordNaming.StripOverlay(winner.GetType().Name)} " +
-                $"{winner.FormKey} has no settable block list '{propName}' to pair against (Q3).");
-
         switch (loserBlock)
         {
             case IWorldspaceBlockGetter wb:
@@ -755,7 +784,7 @@ public static class RemapEngine
                     mBlock = new WorldspaceBlock { BlockNumberX = wb.BlockNumberX, BlockNumberY = wb.BlockNumberY, GroupType = wb.GroupType };
                     winnerBlocks.Add(mBlock);
                 }
-                foreach (var subG in wb.Items) GraftSubBlock(subG, mBlock, dict, stats, reg, conflicts);
+                foreach (var subG in wb.Items) GraftSubBlock(subG, mBlock, dict, stats, reg);
                 break;
             }
             default:
@@ -767,7 +796,7 @@ public static class RemapEngine
 
     /// <summary>Pair one worldspace SUB-block by number (creating it winner-side when missing) and graft its cells.</summary>
     static void GraftSubBlock(IWorldspaceSubBlockGetter loserSub, WorldspaceBlock winnerBlock,
-        IReadOnlyDictionary<FormKey, FormKey> dict, RenumberStats stats, MergePlacement reg, List<MergeConflict> conflicts)
+        IReadOnlyDictionary<FormKey, FormKey> dict, RenumberStats stats, MergePlacement reg)
     {
         var mSub = winnerBlock.Items
             .FirstOrDefault(s => s.BlockNumberX == loserSub.BlockNumberX && s.BlockNumberY == loserSub.BlockNumberY);
@@ -779,10 +808,9 @@ public static class RemapEngine
         foreach (var cell in loserSub.Items)
         {
             var nk = dict.TryGetValue(cell.FormKey, out var mapped) ? mapped : cell.FormKey;
-            if (reg.Objects.TryGetValue(nk, out var placed))
+            if (reg.IsPlaced(cell, nk, out var placed))
             {
-                conflicts.Add(new MergeConflict(cell.FormKey, "Cell", reg.PlacedBy[nk], reg.CurrentDonor));
-                GraftMissingDescendants(cell, placed, dict, stats, reg, conflicts);
+                GraftMissingDescendants(cell, placed, dict, stats, reg);
             }
             else
             {

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -1395,10 +1395,11 @@ public static class WritePatchBuilder
                 $"be remapped, and writing it would keep the donor as a master of its own merge. Fix the source (xEdit: check for " +
                 $"deleted/injected records) or drop that donor. Samples: {string.Join("; ", dangling)}. Nothing was written.");
 
-        // 3. NextObjectID above the highest merged id (header metadata for the CK's next new record; write floor minimum).
+        // 3. NextObjectID above the highest merged id (header metadata for the CK's next new record; write floor minimum,
+        //    ceiling-clamped — a donor legitimately holding 0xFFFFFF would otherwise push it past the 24-bit object range).
         uint maxUsed = 0;
         foreach (var nk in dict.Values) if (nk.ID > maxUsed) maxUsed = nk.ID;
-        m.ModHeader.Stats.NextFormID = Math.Max(FormIdRange.EslWindowFloor, maxUsed + 1);
+        m.ModHeader.Stats.NextFormID = Math.Min(FormIdRange.ObjectIdMax, Math.Max(FormIdRange.EslWindowFloor, maxUsed + 1));
 
         // 4. Resolve the computed master set to overlays (absence OR unparseability is a loud refusal — an open throw
         //    escaping here would skip the caller's rider-folder cleanup) + the master-aware serialize.

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -1235,8 +1235,8 @@ public static class WritePatchBuilder
         }
         catch (Exception ex)
         {
-            error = $"cannot parse '{modKey.FileName}' to compact it ({WriteEngine.Describe(ex)}) — houseCARL won't renumber a " +
-                    "plugin it can't fully read (it would risk dropping a record it couldn't parse, Q3).";
+            error = $"cannot parse '{modKey.FileName}' to renumber it ({WriteEngine.Describe(ex)}) — houseCARL won't renumber a " +
+                    "plugin it can't fully read (it would risk dropping a record it couldn't parse, Q3).";   // op-neutral: compact AND merge surface this verbatim
             return false;
         }
         finally { (ov as IDisposable)?.Dispose(); }
@@ -1400,7 +1400,8 @@ public static class WritePatchBuilder
         foreach (var nk in dict.Values) if (nk.ID > maxUsed) maxUsed = nk.ID;
         m.ModHeader.Stats.NextFormID = Math.Max(FormIdRange.EslWindowFloor, maxUsed + 1);
 
-        // 4. Resolve the computed master set to overlays (absence is a loud refusal) + the master-aware serialize.
+        // 4. Resolve the computed master set to overlays (absence OR unparseability is a loud refusal — an open throw
+        //    escaping here would skip the caller's rider-folder cleanup) + the master-aware serialize.
         var masterOverlays = new List<IDisposable>();
         try
         {
@@ -1412,7 +1413,13 @@ public static class WritePatchBuilder
                     return MergeBuildResult.Fail(
                         $"cannot merge: donor master '{mfn}' is not active in the load order, so the references into it can't " +
                         "resolve for the serialize. Enable that master first. Nothing was written.");
-                var mov = SkyrimMod.CreateFromBinaryOverlay(mp, SkyrimRelease.SkyrimSE);
+                ISkyrimModGetter mov;
+                try { mov = SkyrimMod.CreateFromBinaryOverlay(mp, SkyrimRelease.SkyrimSE); }
+                catch (Exception ex)
+                {
+                    return MergeBuildResult.Fail(
+                        $"cannot merge: donor master '{mfn}' could not be opened for the serialize ({WriteEngine.Describe(ex)}). Nothing was written.");
+                }
                 masterOverlays.Add((IDisposable)mov); resolved.Add(mov);
             }
             try { WriteEngine.WriteInPlace(m, resolved, outPath); }
@@ -1424,8 +1431,19 @@ public static class WritePatchBuilder
         }
         finally { foreach (var d in masterOverlays) { try { d.Dispose(); } catch { /* best-effort; never mask the write result */ } } }
 
-        long bytes = 0; try { bytes = new FileInfo(outPath).Length; } catch { }
-        return new MergeBuildResult(true, null, masters, mr.RecordsCopied, mr.RecordsRenumbered, mr.Conflicts, bytes);
+        // 5. Report the masters the written HEADER actually carries (Mutagen lean-derives the list from referenced
+        //    content, so a declared-but-unreferenced donor master vanishes here) — the report must match what xEdit
+        //    shows, not the pre-computed union. Read-back is best-effort: on a re-open fault, fall back to the union.
+        IReadOnlyList<string> writtenMasters = masters;
+        long bytes = 0;
+        try
+        {
+            bytes = new FileInfo(outPath).Length;
+            using var wr = SkyrimMod.CreateFromBinaryOverlay(outPath, SkyrimRelease.SkyrimSE);
+            writtenMasters = wr.ModHeader.MasterReferences.Select(x => x.Master.FileName.String).ToList();
+        }
+        catch { /* best-effort read-back; the union is a correct superset */ }
+        return new MergeBuildResult(true, null, writtenMasters, mr.RecordsCopied, mr.RecordsRenumbered, mr.Conflicts, bytes);
     }
 
     /// <summary>

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -975,6 +975,30 @@ public static class WritePatchBuilder
                 Array.Empty<string>(), Array.Empty<RepointReport>(), 0, 0, Array.Empty<string>());
     }
 
+    /// <summary>The merge tool's outcome (A4): the merged plugin's identity + per-donor remap accounting + every
+    /// cross-donor conflict (load-order winner, reported never silent) + the identify-pass WARN surfaces (external
+    /// referencers AND overriders — merge never refuses on them, the donors stay installed and active until the user
+    /// swaps in MO2, so nothing breaks at write time; the report names each with the remedy) + the FormID-keyed asset
+    /// carry accounting (facegen/voice/SEQ — a merge renames the plugin, so EVERY donor NPC's facegen and EVERY voiced
+    /// line moves to the new-name folders, not just the collided ones). Merge has NO in-place lane and overwrites
+    /// nothing, so there is no consent gate.</summary>
+    public sealed record MergeOutcome(
+        bool Success, string? Error, string OutputPath, string OutputName,
+        IReadOnlyList<string> Donors, IReadOnlyList<string> Masters,
+        int RecordsCopied, int RecordsRenumbered,
+        IReadOnlyList<RemapEngine.MergeDonorRemap> DonorRemaps,
+        IReadOnlyList<RemapEngine.MergeConflict> Conflicts,
+        IReadOnlyList<string> ExternalPlugins, IReadOnlyList<string> ExternalOverriders,
+        int PluginsScanned, int UnscannableRecords, IReadOnlyList<string> UnscannableSamples,
+        long Bytes, string? Note = null,
+        AssetRenameOutcome? AssetRename = null, VoiceCarryOutcome? VoiceRename = null, SeqRegenOutcome? SeqRegen = null)
+    {
+        public static MergeOutcome Fail(string error) =>
+            new(false, error, "", "", Array.Empty<string>(), Array.Empty<string>(), 0, 0,
+                Array.Empty<RemapEngine.MergeDonorRemap>(), Array.Empty<RemapEngine.MergeConflict>(),
+                Array.Empty<string>(), Array.Empty<string>(), 0, 0, Array.Empty<string>(), 0);
+    }
+
     /// <summary>
     /// FORWARD a NAMED plugin's version of each record INTO the patch as an override — xEdit's "copy as override into",
     /// the inverse of <see cref="Apply"/>'s winner-override. Where Apply/Create author NEW content, this re-asserts an
@@ -1296,6 +1320,112 @@ public static class WritePatchBuilder
 
         long bytes = 0; try { bytes = new FileInfo(outPath).Length; } catch { }
         return new CompactBuildResult(true, null, declaredMasters, ren.RecordsCopied, ren.RecordsRenumbered, bytes);
+    }
+
+    /// <summary>The result of the core merge build: success + the RESOLVED master set / record accounting / cross-donor
+    /// conflicts / byte size, or a loud Q3 refusal with <c>outPath</c> UNTOUCHED (an unopenable donor, an engine fault,
+    /// a dangling donor reference that would keep a donor as a master, an absent master, a serialize fault).</summary>
+    public sealed record MergeBuildResult(
+        bool Success, string? Error, IReadOnlyList<string> Masters, int RecordsCopied, int RecordsRenumbered,
+        IReadOnlyList<RemapEngine.MergeConflict> Conflicts, long Bytes)
+    {
+        public static MergeBuildResult Fail(string error) =>
+            new(false, error, Array.Empty<string>(), 0, 0, Array.Empty<RemapEngine.MergeConflict>(), 0);
+    }
+
+    /// <summary>
+    /// Build the merged plugin M from the donors (in LOAD ORDER) and write it to <paramref name="outPath"/> (always a
+    /// NEW file — merge has no in-place lane; the donors are never touched). Opens every donor as a lazy overlay,
+    /// renumbers them into one fresh <see cref="SkyrimMod"/> via <see cref="RemapEngine.MergeModsInto"/> (load-order
+    /// winner on cross-donor conflicts, losers' un-relisted children grafted), then enforces the donor-master-survives
+    /// check (Q3, the zMerge "Clean" pattern): any link still pointing INTO a donor after the remap is a DANGLING source
+    /// reference (the donor never defined that FormID, so the dict couldn't map it) — writing it would re-declare the
+    /// donor as a master of its own merge, so the build REFUSES with the offending links NAMED. Masters =
+    /// <paramref name="masters"/> (union of donor declared masters minus the donors, load-order sorted — the
+    /// orchestrator computes it off the captured view), resolved to overlays for the master-aware serialize;
+    /// <see cref="WriteEngine.WriteInPlace"/> then derives the header's master list from actual content against them.
+    /// All-or-nothing (Q3): any refusal or fault leaves <paramref name="outPath"/> untouched.
+    /// </summary>
+    public static MergeBuildResult MergeBuild(
+        IReadOnlyList<(string Name, string Path, ModKey Key)> donorsByLoadOrder, ModKey outKey,
+        IReadOnlyDictionary<FormKey, FormKey> dict, IReadOnlyList<string> masters,
+        Func<string, string?> resolveMasterPath, string outPath)
+    {
+        // 1. Open every donor overlay, build M in memory, dispose the donors before the write (no handle at rest;
+        //    merge never writes over a donor, but the discipline is uniform).
+        var m = new SkyrimMod(outKey, SkyrimRelease.SkyrimSE);
+        RemapEngine.MergeResult mr;
+        var donorSet = new HashSet<ModKey>(donorsByLoadOrder.Select(d => d.Key));
+        var overlays = new List<IDisposable>();
+        try
+        {
+            var mods = new List<(string, ISkyrimModGetter)>(donorsByLoadOrder.Count);
+            foreach (var (name, path, _) in donorsByLoadOrder)
+            {
+                ISkyrimModGetter ov;
+                try { ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE); }
+                catch (Exception ex)
+                {
+                    return MergeBuildResult.Fail($"cannot open donor '{name}' to merge it ({WriteEngine.Describe(ex)}) — nothing written.");
+                }
+                overlays.Add((IDisposable)ov);
+                mods.Add((name, ov));
+            }
+            mr = RemapEngine.MergeModsInto(m, mods, dict);
+        }
+        finally { foreach (var d in overlays) { try { d.Dispose(); } catch { /* best-effort */ } } }
+        if (!mr.Success) return MergeBuildResult.Fail(mr.Error!);
+
+        // 2. Donor-master-survives check (Q3): after RemapLinks, NO link may still point into a donor. One that does is
+        //    a reference to a FormID the donor never DEFINED (a dangling source ref — the dict maps every real donor key),
+        //    and serializing it would re-declare the donor as a master of its own merge. Named, never silent.
+        var dangling = new List<string>();
+        int danglingCount = 0;
+        foreach (var rec in m.EnumerateMajorRecords())
+            foreach (var link in rec.EnumerateFormLinks())
+                if (!link.FormKey.IsNull && donorSet.Contains(link.FormKey.ModKey))
+                {
+                    danglingCount++;
+                    if (dangling.Count < 10) dangling.Add($"{rec.FormKey} → {link.FormKey}");
+                }
+        if (danglingCount > 0)
+            return MergeBuildResult.Fail(
+                $"refused — {danglingCount} reference(s) in the merged content still point INTO a donor after the renumber. " +
+                "Each targets a FormID its donor never DEFINES (a dangling reference already broken in the source), so it cannot " +
+                $"be remapped, and writing it would keep the donor as a master of its own merge. Fix the source (xEdit: check for " +
+                $"deleted/injected records) or drop that donor. Samples: {string.Join("; ", dangling)}. Nothing was written.");
+
+        // 3. NextObjectID above the highest merged id (header metadata for the CK's next new record; write floor minimum).
+        uint maxUsed = 0;
+        foreach (var nk in dict.Values) if (nk.ID > maxUsed) maxUsed = nk.ID;
+        m.ModHeader.Stats.NextFormID = Math.Max(FormIdRange.EslWindowFloor, maxUsed + 1);
+
+        // 4. Resolve the computed master set to overlays (absence is a loud refusal) + the master-aware serialize.
+        var masterOverlays = new List<IDisposable>();
+        try
+        {
+            var resolved = new List<ISkyrimModGetter>(masters.Count);
+            foreach (var mfn in masters)
+            {
+                var mp = resolveMasterPath(mfn);
+                if (mp is null)
+                    return MergeBuildResult.Fail(
+                        $"cannot merge: donor master '{mfn}' is not active in the load order, so the references into it can't " +
+                        "resolve for the serialize. Enable that master first. Nothing was written.");
+                var mov = SkyrimMod.CreateFromBinaryOverlay(mp, SkyrimRelease.SkyrimSE);
+                masterOverlays.Add((IDisposable)mov); resolved.Add(mov);
+            }
+            try { WriteEngine.WriteInPlace(m, resolved, outPath); }
+            catch (Exception ex)
+            {
+                return MergeBuildResult.Fail(
+                    $"writing the merged plugin failed (serialize or commit; nothing partial left): {WriteEngine.Describe(ex)}.");
+            }
+        }
+        finally { foreach (var d in masterOverlays) { try { d.Dispose(); } catch { /* best-effort; never mask the write result */ } } }
+
+        long bytes = 0; try { bytes = new FileInfo(outPath).Length; } catch { }
+        return new MergeBuildResult(true, null, masters, mr.RecordsCopied, mr.RecordsRenumbered, mr.Conflicts, bytes);
     }
 
     /// <summary>

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -137,6 +137,13 @@ public static class CiAll
         // REGENERATES its .seq from the renumbered plugin (a renumber shifts the on-disk FormIDs a stale .seq lists, so its
         // quests would silently never start). NOT a map-rename — rebuilt from P′. New-file + in-place-stale-replace + multi-quest + no-SGE.
         ("seq-regen-guard", SeqRegenProbe.RunGuard),
+        // COMPACT/MERGE Wave A4 — the merge tool (housecarl_merge_plugins) end-to-end over a synthetic MO2 instance:
+        // multi-donor collision-only renumber (first donor keeps ids), cross-donor LOAD-ORDER-WINNER conflicts each
+        // reported, the un-relisted-child GRAFT (a patch's DIAL override + the base mod's second INFO — the arm that
+        // fails if merging a mod with its patch drops the base mod's lines), warn-not-refuse externals (referencer +
+        // overrider named, in the outcome AND the rendered output), facegen/voice carried to the MERGED plugin-name
+        // folders + .seq regen, donors byte-untouched, and the four loud refusals.
+        ("merge-service-guard", MergeServiceGuardProbe.RunGuard),
         // COMPACT in-place verify read-back (HCBR-2026-06-28-01) — a multi-op in-place edit's forced touched-record verify
         // renders COMPACT by default (one re-read-clean line per record, all N, names what landed) instead of a deep
         // whole-record dump that overflowed the host token cap and spilled to a file (reading as "only some ops applied").

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -142,7 +142,7 @@ public static class CiAll
         // reported, the un-relisted-child GRAFT (a patch's DIAL override + the base mod's second INFO — the arm that
         // fails if merging a mod with its patch drops the base mod's lines), warn-not-refuse externals (referencer +
         // overrider named, in the outcome AND the rendered output), facegen/voice carried to the MERGED plugin-name
-        // folders + .seq regen, donors byte-untouched, and the four loud refusals.
+        // folders + .seq regen, donors byte-untouched, and the five loud refusals.
         ("merge-service-guard", MergeServiceGuardProbe.RunGuard),
         // COMPACT in-place verify read-back (HCBR-2026-06-28-01) — a multi-op in-place edit's forced touched-record verify
         // renders COMPACT by default (one re-read-clean line per record, all N, names what landed) instead of a deep

--- a/src/housecarl-generator/MergeServiceGuardProbe.cs
+++ b/src/housecarl-generator/MergeServiceGuardProbe.cs
@@ -241,6 +241,12 @@ public static class MergeServiceGuardProbe
                 var rendered = WriteTools.RenderMerge(o);
                 Check(rendered.Contains("WARNING") && rendered.Contains("HcMgDep.esp") && rendered.Contains("HcMgOvr.esp"),
                     "WARN both warnings reach the rendered user output");
+                // The swap instruction must stay PLUGIN-level (PR #158 independent review #1): "disable the donor MODS"
+                // (compact's instruction) would yank the donors' path-referenced assets out of the VFS — the merged
+                // records still load meshes/textures/scripts from the donor folders.
+                Check(rendered.Contains("deactivate the donor PLUGINS") && rendered.Contains("KEEP the donor mod folders enabled")
+                      && !rendered.Contains("DISABLE the donor mods"),
+                    "SWAP instruction is plugin-level (donor mod folders stay enabled)");
                 // ASSETS: facegen pair + voice under the MERGED plugin-name folders; .seq regenerated (A shipped one).
                 var outDir = Path.GetDirectoryName(o.OutputPath)!;
                 var newFace = FaceGenPath.Both(new FormKey(mergedKey, 0xA20)).ToList();

--- a/src/housecarl-generator/MergeServiceGuardProbe.cs
+++ b/src/housecarl-generator/MergeServiceGuardProbe.cs
@@ -1,0 +1,252 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// COMPACT/MERGE Wave A4 — SERVICE guard for housecarl_merge_plugins (LoadOrderService.MergePlugins) over a synthetic
+/// MO2 instance. The fixture is the real merge shape: a base master, donor A (records + a patch surface: DIAL with two
+/// INFOs, an NPC with facegen, an SGE quest with a shipped .seq, a voiced line), donor B — a PATCH of A later in the
+/// load order (overrides A's DIAL re-listing only ONE modified INFO; overrides the base weapon; collides on an object
+/// id; references A cross-donor) — plus an external referencer and an external overrider OUTSIDE the merge set.
+///   MERGE     — one call merges A+B (arg order scrambled — LOAD order must govern): records land under the new ModKey,
+///               A keeps its ids, B's collision renumbers, the cross-donor ref repoints, masters = base only (donors gone).
+///   WINNER    — cross-donor conflicts resolve to the LOAD-ORDER WINNER: B's DIAL body + B's INFO text + B's base-weapon
+///               override are in M; every conflict is REPORTED with winner/loser named.
+///   GRAFT     — A's second INFO (which B's patch DIAL does NOT re-list) is GRAFTED into the winning topic — the arm that
+///               fails if the graft is dropped (a mod merged with its patch would silently lose the base mod's lines).
+///   WARN      — the external referencer AND overrider are named WARNs; the merge SUCCEEDS (the A4 posture — donors stay
+///               active until the MO2 swap, so nothing breaks at write time); RenderMerge carries both to user output.
+///   ASSETS    — facegen + voice land under the MERGED plugin-name folders (the folder segment IS the plugin name — the
+///               carry every merge needs even with zero id collisions); the .seq regenerates (A shipped one).
+///   REFUSE    — one donor / unknown donor / output already active / output == donor, all loud, nothing written.
+///   UNTOUCHED — the donor files are byte-identical after the merge (new-file lane only).
+/// Run: dotnet run --project src/housecarl-generator merge-service-guard
+/// </summary>
+public static class MergeServiceGuardProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  MERGE Wave A4 — service guard (housecarl_merge_plugins)  ################");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        var root = Path.Combine(Path.GetTempPath(), "hc-merge-service-guard-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            string instance = Path.Combine(root, "instance");
+            string profiles = Path.Combine(instance, "profiles", "Default");
+            string mods = Path.Combine(instance, "mods");
+            string data = Path.Combine(root, "game", "Data");
+            Directory.CreateDirectory(profiles); Directory.CreateDirectory(mods); Directory.CreateDirectory(data);
+            File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+                "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+                + Path.Combine(root, "game").Replace(@"\", @"\\") + ")\r\n");
+
+            // ---- fixture mods ----
+            // Base master: one weapon both donors will override.
+            var baseKey = new ModKey("HcMgBase", ModType.Master);
+            var baseWeap = new FormKey(baseKey, 0xA01);
+            var baseDir = Path.Combine(mods, "BaseMod"); Directory.CreateDirectory(baseDir);
+            {
+                var m = new SkyrimMod(baseKey, SkyrimRelease.SkyrimSE);
+                m.Weapons.Add(new Weapon(baseWeap, SkyrimRelease.SkyrimSE) { EditorID = "HcMgBaseWeap", BasicStats = new WeaponBasicStats { Damage = 5 } });
+                m.BeginWrite.ToPath(Path.Combine(baseDir, baseKey.FileName.String)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            }
+
+            // Donor A: weapon + DIAL(2 INFOs) + NPC (facegen on disk) + SGE quest (shipped .seq) + base-weapon override
+            // + a voiced line's .fuz on disk. The "mod" side of the mod+patch merge.
+            var aKey = new ModKey("HcMgA", ModType.Plugin);
+            var aWeap = new FormKey(aKey, 0xA01);            // same OBJECT id as baseWeap — different plugin, no collision
+            var aDial = new FormKey(aKey, 0xA10);
+            var aInfo1 = new FormKey(aKey, 0xA11);
+            var aInfo2 = new FormKey(aKey, 0xA12);
+            var aNpc = new FormKey(aKey, 0xA20);
+            var aQuest = new FormKey(aKey, 0xA30);
+            var aDir = Path.Combine(mods, "AMod"); Directory.CreateDirectory(aDir);
+            {
+                using var baseOv = SkyrimMod.CreateFromBinaryOverlay(Path.Combine(baseDir, baseKey.FileName.String), SkyrimRelease.SkyrimSE);
+                var m = new SkyrimMod(aKey, SkyrimRelease.SkyrimSE);
+                m.Weapons.Add(new Weapon(aWeap, SkyrimRelease.SkyrimSE) { EditorID = "HcMgAWeap", BasicStats = new WeaponBasicStats { Damage = 7 } });
+                var topic = new DialogTopic(aDial, SkyrimRelease.SkyrimSE) { EditorID = "HcMgTopic" };
+                var i1 = new DialogResponses(aInfo1, SkyrimRelease.SkyrimSE);
+                i1.Responses.Add(new DialogResponse { Text = "A11 base" });
+                var i2 = new DialogResponses(aInfo2, SkyrimRelease.SkyrimSE);
+                i2.Responses.Add(new DialogResponse { Text = "A12 base" });
+                topic.Responses.Add(i1); topic.Responses.Add(i2);
+                m.DialogTopics.Add(topic);
+                m.Npcs.Add(new Npc(aNpc, SkyrimRelease.SkyrimSE) { EditorID = "HcMgNpc" });
+                m.Quests.Add(new Quest(aQuest, SkyrimRelease.SkyrimSE) { EditorID = "HcMgQuest", Flags = Quest.Flag.StartGameEnabled });
+                m.Weapons.GetOrAddAsOverride(baseOv.Weapons.First(w => w.FormKey == baseWeap)).BasicStats!.Damage = 10;   // A's override (the LOSER)
+                m.BeginWrite.ToPath(Path.Combine(aDir, aKey.FileName.String)).WithLoadOrder(new ISkyrimModGetter[] { baseOv }).Write();
+            }
+            // A's on-disk FormID-keyed assets: the facegen pair, one voiced .fuz, the shipped .seq.
+            foreach (var (_, rel) in FaceGenPath.Both(aNpc))
+            {
+                var p = Path.Combine(aDir, rel); Directory.CreateDirectory(Path.GetDirectoryName(p)!);
+                File.WriteAllBytes(p, new byte[] { 0xFA, 0xCE });
+            }
+            var aVoiceRel = Path.Combine("Sound", "Voice", aKey.FileName.String, "MaleEvenToned", "HcQ_HcT_00000A11_1.fuz");
+            Directory.CreateDirectory(Path.GetDirectoryName(Path.Combine(aDir, aVoiceRel))!);
+            File.WriteAllBytes(Path.Combine(aDir, aVoiceRel), new byte[] { 0xF0, 0x02 });
+            Directory.CreateDirectory(Path.Combine(aDir, "SEQ"));
+            File.WriteAllBytes(Path.Combine(aDir, "SEQ", "HcMgA.seq"), new byte[] { 0x30, 0x0A, 0x00, 0x00 });
+
+            // Donor B — the PATCH of A, later in the load order (the WINNER): overrides A's DIAL re-listing ONLY its
+            // modified copy of INFO1 (INFO2 deliberately NOT re-listed — the graft target), overrides the base weapon,
+            // collides with A on object id 0xA01, and references A's weapon cross-donor.
+            var bKey = new ModKey("HcMgB", ModType.Plugin);
+            var bColl = new FormKey(bKey, 0xA01);            // COLLIDES with A's kept 0xA01 → must renumber
+            var bWeap = new FormKey(bKey, 0xB01);
+            var bList = new FormKey(bKey, 0xB02);
+            var bDir = Path.Combine(mods, "BMod"); Directory.CreateDirectory(bDir);
+            {
+                using var baseOv = SkyrimMod.CreateFromBinaryOverlay(Path.Combine(baseDir, baseKey.FileName.String), SkyrimRelease.SkyrimSE);
+                using var aOv = SkyrimMod.CreateFromBinaryOverlay(Path.Combine(aDir, aKey.FileName.String), SkyrimRelease.SkyrimSE);
+                var m = new SkyrimMod(bKey, SkyrimRelease.SkyrimSE);
+                m.Weapons.Add(new Weapon(bColl, SkyrimRelease.SkyrimSE) { EditorID = "HcMgBColl", BasicStats = new WeaponBasicStats { Damage = 3 } });
+                m.Weapons.Add(new Weapon(bWeap, SkyrimRelease.SkyrimSE) { EditorID = "HcMgBWeap", BasicStats = new WeaponBasicStats { Damage = 8 } });
+                var fl = new FormList(bList, SkyrimRelease.SkyrimSE) { EditorID = "HcMgBList" };
+                fl.Items.Add(aWeap.ToLink<ISkyrimMajorRecordGetter>());
+                m.FormLists.Add(fl);
+                var patchTopic = new DialogTopic(aDial, SkyrimRelease.SkyrimSE) { EditorID = "HcMgTopicPatched" };   // override of A's DIAL
+                var pi1 = new DialogResponses(aInfo1, SkyrimRelease.SkyrimSE);                                        // override of A's INFO1
+                pi1.Responses.Add(new DialogResponse { Text = "A11 patched" });
+                patchTopic.Responses.Add(pi1);                                                                        // INFO2 NOT re-listed
+                m.DialogTopics.Add(patchTopic);
+                m.Weapons.GetOrAddAsOverride(baseOv.Weapons.First(w => w.FormKey == baseWeap)).BasicStats!.Damage = 20;   // B's override (the WINNER)
+                m.BeginWrite.ToPath(Path.Combine(bDir, bKey.FileName.String)).WithLoadOrder(new ISkyrimModGetter[] { baseOv, aOv }).Write();
+            }
+
+            // OUTSIDE the merge set: a referencer of A (WARN arm) and an overrider of A (WARN arm).
+            var depKey = new ModKey("HcMgDep", ModType.Plugin);
+            var depDir = Path.Combine(mods, "DepMod"); Directory.CreateDirectory(depDir);
+            {
+                using var aOv = SkyrimMod.CreateFromBinaryOverlay(Path.Combine(aDir, aKey.FileName.String), SkyrimRelease.SkyrimSE);
+                var m = new SkyrimMod(depKey, SkyrimRelease.SkyrimSE);
+                var fl = new FormList(new FormKey(depKey, 0xA01), SkyrimRelease.SkyrimSE) { EditorID = "HcMgDepList" };
+                fl.Items.Add(aWeap.ToLink<ISkyrimMajorRecordGetter>());
+                m.FormLists.Add(fl);
+                m.BeginWrite.ToPath(Path.Combine(depDir, depKey.FileName.String)).WithLoadOrder(new ISkyrimModGetter[] { aOv }).Write();
+            }
+            var ovrKey = new ModKey("HcMgOvr", ModType.Plugin);
+            var ovrDir = Path.Combine(mods, "OvrMod"); Directory.CreateDirectory(ovrDir);
+            {
+                using var aOv = SkyrimMod.CreateFromBinaryOverlay(Path.Combine(aDir, aKey.FileName.String), SkyrimRelease.SkyrimSE);
+                var m = new SkyrimMod(ovrKey, SkyrimRelease.SkyrimSE);
+                m.Weapons.GetOrAddAsOverride(aOv.Weapons.First(w => w.FormKey == aWeap)).BasicStats!.Damage = 99;
+                m.BeginWrite.ToPath(Path.Combine(ovrDir, ovrKey.FileName.String)).WithLoadOrder(new ISkyrimModGetter[] { aOv }).Write();
+            }
+
+            // ---- profile files (load order: Base, A, B, Dep, Ovr — B AFTER A: the patch wins) ----
+            File.WriteAllText(Path.Combine(profiles, "loadorder.txt"),
+                "# header\r\n" + string.Join("\r\n", baseKey.FileName, aKey.FileName, bKey.FileName, depKey.FileName, ovrKey.FileName) + "\r\n");
+            File.WriteAllText(Path.Combine(profiles, "plugins.txt"),
+                string.Join("\r\n", "*" + baseKey.FileName, "*" + aKey.FileName, "*" + bKey.FileName, "*" + depKey.FileName, "*" + ovrKey.FileName) + "\r\n");
+            File.WriteAllText(Path.Combine(profiles, "modlist.txt"),
+                "# header\r\n" + string.Join("\r\n", "+OvrMod", "+DepMod", "+BMod", "+AMod", "+BaseMod") + "\r\n");
+
+            var store = new UserConfigStore(Path.Combine(root, "houseCARL.user.json"));
+            using var svc = LoadOrderService.WithInstance(instance, 0, store);
+            svc.Stats();   // warm the lazy index once
+
+            byte[] aBytesBefore = File.ReadAllBytes(Path.Combine(aDir, aKey.FileName.String));
+            byte[] bBytesBefore = File.ReadAllBytes(Path.Combine(bDir, bKey.FileName.String));
+
+            // ---- MERGE + WINNER + GRAFT + WARN + ASSETS: the one full-shape call (donor args deliberately scrambled) ----
+            var o = svc.MergePlugins(new[] { "HcMgB.esp", "HcMgA.esp" }, "HcMgMerged.esp");
+            var mergedKey = new ModKey("HcMgMerged", ModType.Plugin);
+            {
+                Check(o.Success, $"MERGE succeeds ({(o.Success ? o.OutputPath : "ERR " + o.Error)})");
+                bool idsOk = false, refOk = false, winnerOk = false, graftOk = false, mastersOk = false, collOk = false;
+                if (o.Success && File.Exists(o.OutputPath))
+                {
+                    using var mm = SkyrimMod.CreateFromBinaryOverlay(o.OutputPath, SkyrimRelease.SkyrimSE);
+                    // A kept its ids under the merged key; B's collision renumbered to the first free id (0x800).
+                    idsOk = mm.Weapons.Any(w => w.EditorID == "HcMgAWeap" && w.FormKey == new FormKey(mergedKey, 0xA01))
+                         && mm.Weapons.Any(w => w.EditorID == "HcMgBWeap" && w.FormKey == new FormKey(mergedKey, 0xB01));
+                    collOk = mm.Weapons.Any(w => w.EditorID == "HcMgBColl" && w.FormKey == new FormKey(mergedKey, 0x800));
+                    // B's cross-donor reference into A repointed to the merged key.
+                    refOk = mm.FormLists.FirstOrDefault(f => f.EditorID == "HcMgBList")?.Items.FirstOrDefault()?.FormKey
+                            == new FormKey(mergedKey, 0xA01);
+                    // Load-order winner: B's base-weapon override (damage 20) + B's DIAL body + B's INFO1 text.
+                    var baseOverride = mm.Weapons.FirstOrDefault(w => w.FormKey == baseWeap);
+                    var topic = mm.DialogTopics.FirstOrDefault(t => t.FormKey == new FormKey(mergedKey, 0xA10));
+                    var info1 = topic?.Responses.FirstOrDefault(r => r.FormKey == new FormKey(mergedKey, 0xA11));
+                    winnerOk = baseOverride?.BasicStats?.Damage == 20
+                            && topic?.EditorID == "HcMgTopicPatched"
+                            && info1?.Responses.FirstOrDefault()?.Text.String == "A11 patched";
+                    // THE GRAFT: A's INFO2 (not re-listed by the patch) is present under the winning topic.
+                    var info2 = topic?.Responses.FirstOrDefault(r => r.FormKey == new FormKey(mergedKey, 0xA12));
+                    graftOk = info2?.Responses.FirstOrDefault()?.Text.String == "A12 base";
+                    // Masters: the base only — never a donor.
+                    var masters = mm.ModHeader.MasterReferences.Select(x => x.Master.FileName.String).ToList();
+                    mastersOk = masters.Count == 1 && string.Equals(masters[0], baseKey.FileName.String, StringComparison.OrdinalIgnoreCase);
+                }
+                Check(idsOk, "MERGE A + B keep their non-colliding object ids under the merged key");
+                Check(collOk, "MERGE B's colliding id renumbered to the first free id (0x800)");
+                Check(refOk, "MERGE B's cross-donor reference into A repointed to the merged key");
+                Check(winnerOk, "WINNER load-order winner everywhere (B's base-weapon override + DIAL body + INFO1 text)");
+                Check(graftOk, "GRAFT A's un-relisted INFO2 grafted into the winning topic");
+                Check(mastersOk, $"MERGE masters = base only, donors gone ({string.Join(",", o.Masters)})");
+                Check(o.RecordsCopied == 10 && o.RecordsRenumbered == 9,
+                    $"MERGE record accounting (copied {o.RecordsCopied} expected 10, renumbered {o.RecordsRenumbered} expected 9)");
+                // Conflicts: DIAL (B over A), INFO1 (B over A), base-weapon override (B over A) — each named.
+                bool confOk = o.Conflicts.Count == 3
+                    && o.Conflicts.All(c => c.WinnerDonor == "HcMgB.esp" && c.LoserDonor == "HcMgA.esp")
+                    && o.Conflicts.Any(c => c.Key == aDial) && o.Conflicts.Any(c => c.Key == aInfo1) && o.Conflicts.Any(c => c.Key == baseWeap);
+                Check(confOk, $"WINNER all 3 cross-donor conflicts reported with winner/loser named (got {o.Conflicts.Count})");
+                // Per-donor remap accounting: A keeps 6; B keeps 2, renumbers 1.
+                var ra = o.DonorRemaps.FirstOrDefault(d => d.Donor == "HcMgA.esp");
+                var rb = o.DonorRemaps.FirstOrDefault(d => d.Donor == "HcMgB.esp");
+                Check(ra is { Kept: 6, Renumbered: 0 } && rb is { Kept: 2, Renumbered: 1 },
+                    $"MERGE per-donor id accounting (A {ra?.Kept}/{ra?.Renumbered}, B {rb?.Kept}/{rb?.Renumbered})");
+                // WARN posture: external referencer + overrider NAMED, merge still succeeded.
+                Check(o.ExternalPlugins.Contains("HcMgDep.esp") && o.ExternalOverriders.Contains("HcMgOvr.esp"),
+                    $"WARN external referencer + overrider named, merge NOT refused (refs [{string.Join(",", o.ExternalPlugins)}], ovr [{string.Join(",", o.ExternalOverriders)}])");
+                var rendered = WriteTools.RenderMerge(o);
+                Check(rendered.Contains("WARNING") && rendered.Contains("HcMgDep.esp") && rendered.Contains("HcMgOvr.esp"),
+                    "WARN both warnings reach the rendered user output");
+                // ASSETS: facegen pair + voice under the MERGED plugin-name folders; .seq regenerated (A shipped one).
+                var outDir = Path.GetDirectoryName(o.OutputPath)!;
+                var newFace = FaceGenPath.Both(new FormKey(mergedKey, 0xA20)).ToList();
+                bool faceOk = newFace.Count == 2 && newFace.All(x => File.Exists(Path.Combine(outDir, x.Item2)));
+                bool voiceOk = File.Exists(Path.Combine(outDir, "Sound", "Voice", mergedKey.FileName.String, "MaleEvenToned", "HcQ_HcT_00000A11_1.fuz"));
+                bool seqOk = o.SeqRegen is { Written: true } && File.Exists(Path.Combine(outDir, "SEQ", "HcMgMerged.seq"));
+                Check(faceOk && o.AssetRename?.FacegenFilesCarried == 2, $"ASSETS facegen pair carried to the merged-name folder (files {o.AssetRename?.FacegenFilesCarried})");
+                Check(voiceOk && o.VoiceRename?.FilesCarried == 1, $"ASSETS voice carried to the merged-name folder (files {o.VoiceRename?.FilesCarried})");
+                Check(seqOk, $"ASSETS .seq regenerated for the merged plugin (written {o.SeqRegen?.Written})");
+            }
+
+            // ---- UNTOUCHED: the donors are byte-identical (new-file lane only) ----
+            Check(aBytesBefore.SequenceEqual(File.ReadAllBytes(Path.Combine(aDir, aKey.FileName.String)))
+               && bBytesBefore.SequenceEqual(File.ReadAllBytes(Path.Combine(bDir, bKey.FileName.String))),
+                "UNTOUCHED donor files byte-identical after the merge");
+
+            // ---- REFUSE arms (each loud, nothing written) ----
+            {
+                var r = svc.MergePlugins(new[] { "HcMgA.esp" }, "HcMgX.esp");
+                Check(!r.Success && (r.Error?.Contains("at least TWO", StringComparison.OrdinalIgnoreCase) ?? false),
+                    $"REFUSE one donor ({r.Error?.Split('—')[0].Trim()})");
+                r = svc.MergePlugins(new[] { "HcMgA.esp", "HcMgNope.esp" }, "HcMgX.esp");
+                Check(!r.Success && (r.Error?.Contains("not an active plugin", StringComparison.OrdinalIgnoreCase) ?? false),
+                    $"REFUSE unknown donor ({r.Error?.Split('—')[0].Trim()})");
+                r = svc.MergePlugins(new[] { "HcMgA.esp", "HcMgB.esp" }, "HcMgDep.esp");
+                Check(!r.Success && (r.Error?.Contains("already an active plugin", StringComparison.OrdinalIgnoreCase) ?? false),
+                    $"REFUSE output already in the load order ({r.Error?.Split('—')[0].Trim()})");
+                r = svc.MergePlugins(new[] { "HcMgA.esp", "HcMgB.esp" }, "HcMgA.esp");
+                Check(!r.Success && (r.Error?.Contains("cannot also be a donor", StringComparison.OrdinalIgnoreCase) ?? false),
+                    $"REFUSE output == donor ({r.Error?.Split('—')[0].Trim()})");
+            }
+        }
+        finally { try { Directory.Delete(root, true); } catch { } }
+
+        Console.WriteLine();
+        Console.WriteLine($"=== merge-service-guard: {(fail == 0 ? "PASS" : $"FAIL ({fail})")} ===");
+        return fail == 0 ? 0 : 1;
+    }
+}

--- a/src/housecarl-generator/MergeServiceGuardProbe.cs
+++ b/src/housecarl-generator/MergeServiceGuardProbe.cs
@@ -67,6 +67,8 @@ public static class MergeServiceGuardProbe
             var aInfo2 = new FormKey(aKey, 0xA12);
             var aNpc = new FormKey(aKey, 0xA20);
             var aQuest = new FormKey(aKey, 0xA30);
+            var aRef = new FormKey(aKey, 0xA40);             // the MOVED-REF shape: A originates X in A's cell; B's OWN cell overrides X
+            var aCell = new FormKey(aKey, 0xA41);
             var aDir = Path.Combine(mods, "AMod"); Directory.CreateDirectory(aDir);
             {
                 using var baseOv = SkyrimMod.CreateFromBinaryOverlay(Path.Combine(baseDir, baseKey.FileName.String), SkyrimRelease.SkyrimSE);
@@ -81,6 +83,9 @@ public static class MergeServiceGuardProbe
                 m.DialogTopics.Add(topic);
                 m.Npcs.Add(new Npc(aNpc, SkyrimRelease.SkyrimSE) { EditorID = "HcMgNpc" });
                 m.Quests.Add(new Quest(aQuest, SkyrimRelease.SkyrimSE) { EditorID = "HcMgQuest", Flags = Quest.Flag.StartGameEnabled });
+                var c1 = new Cell(aCell, SkyrimRelease.SkyrimSE) { EditorID = "HcMgACell", Flags = Cell.Flag.IsInteriorCell };
+                c1.Temporary.Add(new PlacedObject(aRef, SkyrimRelease.SkyrimSE) { EditorID = "HcMgRefBase" });
+                FileInterior(m, c1);
                 m.Weapons.GetOrAddAsOverride(baseOv.Weapons.First(w => w.FormKey == baseWeap)).BasicStats!.Damage = 10;   // A's override (the LOSER)
                 m.BeginWrite.ToPath(Path.Combine(aDir, aKey.FileName.String)).WithLoadOrder(new ISkyrimModGetter[] { baseOv }).Write();
             }
@@ -103,6 +108,7 @@ public static class MergeServiceGuardProbe
             var bColl = new FormKey(bKey, 0xA01);            // COLLIDES with A's kept 0xA01 → must renumber
             var bWeap = new FormKey(bKey, 0xB01);
             var bList = new FormKey(bKey, 0xB02);
+            var bCell = new FormKey(bKey, 0xB10);            // B's OWN cell carrying the MOVED override of A's placed ref
             var bDir = Path.Combine(mods, "BMod"); Directory.CreateDirectory(bDir);
             {
                 using var baseOv = SkyrimMod.CreateFromBinaryOverlay(Path.Combine(baseDir, baseKey.FileName.String), SkyrimRelease.SkyrimSE);
@@ -118,6 +124,9 @@ public static class MergeServiceGuardProbe
                 pi1.Responses.Add(new DialogResponse { Text = "A11 patched" });
                 patchTopic.Responses.Add(pi1);                                                                        // INFO2 NOT re-listed
                 m.DialogTopics.Add(patchTopic);
+                var c2 = new Cell(bCell, SkyrimRelease.SkyrimSE) { EditorID = "HcMgBCell", Flags = Cell.Flag.IsInteriorCell };
+                c2.Temporary.Add(new PlacedObject(aRef, SkyrimRelease.SkyrimSE) { EditorID = "HcMgRefMoved" });       // the MOVED reference (override under a DIFFERENT parent)
+                FileInterior(m, c2);
                 m.Weapons.GetOrAddAsOverride(baseOv.Weapons.First(w => w.FormKey == baseWeap)).BasicStats!.Damage = 20;   // B's override (the WINNER)
                 m.BeginWrite.ToPath(Path.Combine(bDir, bKey.FileName.String)).WithLoadOrder(new ISkyrimModGetter[] { baseOv, aOv }).Write();
             }
@@ -192,18 +201,39 @@ public static class MergeServiceGuardProbe
                 Check(refOk, "MERGE B's cross-donor reference into A repointed to the merged key");
                 Check(winnerOk, "WINNER load-order winner everywhere (B's base-weapon override + DIAL body + INFO1 text)");
                 Check(graftOk, "GRAFT A's un-relisted INFO2 grafted into the winning topic");
+                // MOVED-REF: B's OWN cell carries an override of A's placed ref (a moved reference — the same record
+                // under two DIFFERENT parents across donors). Exactly ONE copy may survive, under the WINNER's parent,
+                // and it must be a reported conflict — the review's C-1 duplicate-FormKey hole, pinned here.
+                {
+                    bool movedOk = false;
+                    if (o.Success && File.Exists(o.OutputPath))
+                    {
+                        using var mm2 = SkyrimMod.CreateFromBinaryOverlay(o.OutputPath, SkyrimRelease.SkyrimSE);
+                        var mRefKey = new FormKey(mergedKey, 0xA40);
+                        var copies = mm2.EnumerateMajorRecords().Where(r => r.FormKey == mRefKey).ToList();
+                        var winnerCell = mm2.EnumerateMajorRecords<ICellGetter>().FirstOrDefault(c => c.FormKey == new FormKey(mergedKey, 0xB10));
+                        var loserCell = mm2.EnumerateMajorRecords<ICellGetter>().FirstOrDefault(c => c.FormKey == new FormKey(mergedKey, 0xA41));
+                        movedOk = copies.Count == 1 && copies[0].EditorID == "HcMgRefMoved"
+                               && winnerCell is not null && winnerCell.Temporary.Any(p => p.FormKey == mRefKey)
+                               && loserCell is not null && !loserCell.Temporary.Any(p => p.FormKey == mRefKey)
+                               && o.Conflicts.Any(c => c.Key == aRef);
+                        Check(movedOk, $"MOVED-REF one copy at the merged key, under the WINNER's cell, conflict reported (copies {copies.Count})");
+                    }
+                    else Check(false, "MOVED-REF (merge failed)");
+                }
                 Check(mastersOk, $"MERGE masters = base only, donors gone ({string.Join(",", o.Masters)})");
-                Check(o.RecordsCopied == 10 && o.RecordsRenumbered == 9,
-                    $"MERGE record accounting (copied {o.RecordsCopied} expected 10, renumbered {o.RecordsRenumbered} expected 9)");
-                // Conflicts: DIAL (B over A), INFO1 (B over A), base-weapon override (B over A) — each named.
-                bool confOk = o.Conflicts.Count == 3
+                Check(o.RecordsCopied == 13 && o.RecordsRenumbered == 12,
+                    $"MERGE record accounting (copied {o.RecordsCopied} expected 13, renumbered {o.RecordsRenumbered} expected 12)");
+                // Conflicts: DIAL (B over A), INFO1 (B over A), base-weapon override (B over A), moved ref (B over A) — each named.
+                bool confOk = o.Conflicts.Count == 4
                     && o.Conflicts.All(c => c.WinnerDonor == "HcMgB.esp" && c.LoserDonor == "HcMgA.esp")
-                    && o.Conflicts.Any(c => c.Key == aDial) && o.Conflicts.Any(c => c.Key == aInfo1) && o.Conflicts.Any(c => c.Key == baseWeap);
-                Check(confOk, $"WINNER all 3 cross-donor conflicts reported with winner/loser named (got {o.Conflicts.Count})");
-                // Per-donor remap accounting: A keeps 6; B keeps 2, renumbers 1.
+                    && o.Conflicts.Any(c => c.Key == aDial) && o.Conflicts.Any(c => c.Key == aInfo1)
+                    && o.Conflicts.Any(c => c.Key == baseWeap) && o.Conflicts.Any(c => c.Key == aRef);
+                Check(confOk, $"WINNER all 4 cross-donor conflicts reported with winner/loser named (got {o.Conflicts.Count})");
+                // Per-donor remap accounting: A keeps 8; B keeps 3, renumbers 1.
                 var ra = o.DonorRemaps.FirstOrDefault(d => d.Donor == "HcMgA.esp");
                 var rb = o.DonorRemaps.FirstOrDefault(d => d.Donor == "HcMgB.esp");
-                Check(ra is { Kept: 6, Renumbered: 0 } && rb is { Kept: 2, Renumbered: 1 },
+                Check(ra is { Kept: 8, Renumbered: 0 } && rb is { Kept: 3, Renumbered: 1 },
                     $"MERGE per-donor id accounting (A {ra?.Kept}/{ra?.Renumbered}, B {rb?.Kept}/{rb?.Renumbered})");
                 // WARN posture: external referencer + overrider NAMED, merge still succeeded.
                 Check(o.ExternalPlugins.Contains("HcMgDep.esp") && o.ExternalOverriders.Contains("HcMgOvr.esp"),
@@ -241,6 +271,10 @@ public static class MergeServiceGuardProbe
                 r = svc.MergePlugins(new[] { "HcMgA.esp", "HcMgB.esp" }, "HcMgA.esp");
                 Check(!r.Success && (r.Error?.Contains("cannot also be a donor", StringComparison.OrdinalIgnoreCase) ?? false),
                     $"REFUSE output == donor ({r.Error?.Split('—')[0].Trim()})");
+                r = svc.MergePlugins(new[] { "HcMgA.esp", "HcMgB.esp" }, "HcMgLight.esl");
+                Check(!r.Success && (r.Error?.Contains(".esl", StringComparison.OrdinalIgnoreCase) ?? false)
+                                 && (r.Error?.Contains("compact", StringComparison.OrdinalIgnoreCase) ?? false),
+                    $"REFUSE .esl output with the compact-after remedy ({r.Error?.Split('—')[0].Trim()})");
             }
         }
         finally { try { Directory.Delete(root, true); } catch { } }
@@ -248,5 +282,18 @@ public static class MergeServiceGuardProbe
         Console.WriteLine();
         Console.WriteLine($"=== merge-service-guard: {(fail == 0 ? "PASS" : $"FAIL ({fail})")} ===");
         return fail == 0 ? 0 : 1;
+    }
+
+    /// <summary>File an interior cell into a mod's Cells block tree by its FormID digits (mirrors WriteEngine.AddInteriorCell).</summary>
+    static void FileInterior(SkyrimMod mod, Cell cell)
+    {
+        uint id = cell.FormKey.ID;
+        int blockN = (int)(id % 10), subN = (int)((id / 10) % 10);
+        var records = mod.Cells.Records;
+        var block = records.FirstOrDefault(b => b.BlockNumber == blockN);
+        if (block is null) { block = new CellBlock { BlockNumber = blockN, GroupType = GroupTypeEnum.InteriorCellBlock }; records.Add(block); }
+        var sub = block.SubBlocks.FirstOrDefault(s => s.BlockNumber == subN);
+        if (sub is null) { sub = new CellSubBlock { BlockNumber = subN, GroupType = GroupTypeEnum.InteriorCellSubBlock }; block.SubBlocks.Add(sub); }
+        sub.Cells.Add(cell);
     }
 }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1881,7 +1881,9 @@ public sealed class LoadOrderService : IDisposable
     /// NEW name (collision-only renumber — the first donor in load order keeps its object IDs; cross-donor conflicts
     /// on the same record resolve to the LOAD-ORDER WINNER and are reported; a losing donor's un-relisted nested
     /// children graft into the winner). The donors are NEVER touched — new-file lane only, no consent gate; the user
-    /// reviews M in xEdit, enables its folder, and disables the donor mods in MO2. External referencers AND overriders
+    /// reviews M in xEdit, enables its folder, and deactivates the donor PLUGINS in MO2 (the donor MOD FOLDERS stay
+    /// enabled — the merged records still reference the donors' path-keyed assets, which only those folders serve;
+    /// the carries cover ONLY the FormID-keyed facegen/voice/seq). External referencers AND overriders
     /// of donor records are WARNED loud and named (never a refusal: nothing breaks at write time — the donors stay
     /// active until the user swaps; the remedy is to include the patch in the merge set or repoint it before disabling
     /// the donors). The FormID-keyed assets follow per donor: EVERY donor NPC's facegen and EVERY voiced line move to

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1903,6 +1903,11 @@ public sealed class LoadOrderService : IDisposable
         ModKey outKey;
         try { outKey = ModKey.FromFileName(outName); }
         catch (Exception ex) { return WritePatchBuilder.MergeOutcome.Fail($"'{outName}' is not a valid plugin filename ({ex.Message})."); }
+        if (outKey.Type == ModType.Light)
+            return WritePatchBuilder.MergeOutcome.Fail(
+                $"refused — '{outName}' has the .esl extension, which the game engine force-treats as a LIGHT master regardless " +
+                "of the header flag, but a merge keeps the donors' object ids in the full range (ids above 0xFFF would be misread " +
+                "in game). Merge to a '.esp' instead, then run housecarl_compact_plugin on it to make it light (the tools compose). Nothing was written.");
         if (donorsRaw.Any(d => string.Equals(d, outName, StringComparison.OrdinalIgnoreCase)))
             return WritePatchBuilder.MergeOutcome.Fail($"the output '{outName}' cannot also be a donor — name a NEW plugin file.");
 
@@ -1917,7 +1922,10 @@ public sealed class LoadOrderService : IDisposable
                     $"'{outName}' is already an active plugin in your load order — the merge output must be a NEW plugin name " +
                     "(merging over an existing plugin would shadow it in MO2).");
 
-            // ---- 1. validate + load-order-sort the donors (merge semantics are load-order semantics — Q3: sort, don't trust arg order) ----
+            // ---- 1. validate + load-order-sort the donors (merge semantics are load-order semantics — Q3: sort, don't
+            //      trust arg order). ONE name→position index serves the donor sort here and the master sort in step 4. ----
+            var orderIndex = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            for (int i = 0; i < resolver.PluginNames.Count; i++) orderIndex[resolver.PluginNames[i]] = i;
             var donorInfos = new List<(string Name, string Path, ModKey Key, int Order)>();
             foreach (var d in donorsRaw)
             {
@@ -1935,14 +1943,12 @@ public sealed class LoadOrderService : IDisposable
                 ModKey dk;
                 try { dk = ModKey.FromFileName(d); }
                 catch (Exception ex) { return WritePatchBuilder.MergeOutcome.Fail($"'{d}' is not a valid plugin filename ({ex.Message})."); }
-                int order = -1;
-                for (int i = 0; i < resolver.PluginNames.Count; i++)
-                    if (string.Equals(resolver.PluginNames[i], d, StringComparison.OrdinalIgnoreCase)) { order = i; break; }
+                if (!orderIndex.TryGetValue(d, out var order))            // unreachable after ContainsPlugin (same source table) — refuse loud, never mis-sort
+                    return WritePatchBuilder.MergeOutcome.Fail($"donor '{d}' has no load-order position (index inconsistency, Q3). Nothing was written.");
                 donorInfos.Add((d, p, dk, order));
             }
             donorInfos.Sort((a, b) => a.Order.CompareTo(b.Order));
             var donorNames = donorInfos.Select(d => d.Name).ToList();
-            var donorKeySet = new HashSet<ModKey>(donorInfos.Select(d => d.Key));
 
             // ---- 2. originating keys per donor + the collision-only remap (first donor keeps its ids — zMerge default) ----
             var donorKeys = new List<(string Donor, IReadOnlyList<FormKey> Keys)>();
@@ -1977,8 +1983,6 @@ public sealed class LoadOrderService : IDisposable
                 foreach (var mfn in declared)
                     if (!transformSet.Contains(mfn) && seenMasters.Add(mfn)) masterSet.Add(mfn);
             }
-            var orderIndex = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-            for (int i = 0; i < resolver.PluginNames.Count; i++) orderIndex[resolver.PluginNames[i]] = i;
             masterSet.Sort((a, b) =>
                 (orderIndex.TryGetValue(a, out var ia) ? ia : int.MaxValue).CompareTo(orderIndex.TryGetValue(b, out var ib) ? ib : int.MaxValue));
 
@@ -2004,15 +2008,16 @@ public sealed class LoadOrderService : IDisposable
             //      (Q3): the records are written, so an asset miss is a named warning, never a failure of the merge. ----
             AssetRenameOutcome assetRename;
             VoiceCarryOutcome voiceRename;
-            bool anyDonorSeq = false;
+            bool? seqGate = null;                                          // the VFS gate — SET the moment the view resolves (compact's seqGate discipline)
             try
             {
                 AssetResolver assetResolver;
                 lock (_gate) { assetResolver = Assets; }                  // reentrant under the held _writeGate (the PlaceAssets idiom)
                 var assetView = assetResolver.Capture();
+                seqGate = false;                                          // the view resolved — the answer below is authoritative
                 foreach (var (dName, _, _, _) in donorInfos)              // "did ANY donor ship a .seq?" — VFS-aware, per donor
                     if (assetView.ResolveForPlacement($@"SEQ\{Path.GetFileNameWithoutExtension(dName)}.seq").Sources.Count > 0)
-                        { anyDonorSeq = true; break; }
+                        { seqGate = true; break; }
                 var outDir = Path.GetDirectoryName(outPath)!;
                 assetRename = AssetRenameService.CarryFaceGen(outPath, plan.Dict, assetView, outDir);
                 var voiceParts = donorInfos
@@ -2029,6 +2034,11 @@ public sealed class LoadOrderService : IDisposable
                 voiceRename = new VoiceCarryOutcome(0, 0, 0,
                     new[] { $"voice carry skipped — the asset layer could not be built ({ex.Message}); verify voiced lines in-game." }, false);
             }
+            // Only when the view never resolved (seqGate still null — the asset layer couldn't be built) fall back to a
+            // loose per-donor-folder check, so an asset-layer fault can't silently downgrade a donor-shipped .seq to
+            // "the donors shipped none" and skip the refresh with a factually wrong advisory (compact's ?? discipline).
+            bool anyDonorSeq = seqGate ?? donorInfos.Any(d =>
+                File.Exists(Path.Combine(Path.GetDirectoryName(d.Path)!, "SEQ", Path.GetFileNameWithoutExtension(d.Name) + ".seq")));
 
             // ---- 8. SEQ — refresh-only, off the merged plugin: rebuilt when ANY donor shipped a .seq (all their SGE
             //      quests now live in M, whose .seq must list the NEW on-disk FormIDs); donors with SGE quests but no
@@ -2041,10 +2051,17 @@ public sealed class LoadOrderService : IDisposable
                     new[] { $"SEQ regenerate skipped ({ex.Message}) — if the donors have start-game-enabled quests, run housecarl_write_seq on '{outName}'." });
             }
 
+            // Q3 — surface the one behavior delta the any-donor SEQ gate can introduce: SeqFile.Build lists EVERY SGE
+            // quest in M, so a quest from a donor that shipped NO .seq (and thus wasn't auto-starting) gains an entry.
+            string? note = seqRegen.Written
+                ? "the regenerated .seq lists EVERY start-game-enabled quest in the merge — including any from a donor that " +
+                  "shipped no .seq of its own (such quests were NOT auto-starting before the merge; they will now)."
+                : null;
+
             return new WritePatchBuilder.MergeOutcome(
                 true, null, outPath, outName, donorNames, build.Masters, build.RecordsCopied, build.RecordsRenumbered,
                 plan.Donors, build.Conflicts, id.ExternalPlugins, id.ExternalOverriders,
-                id.PluginsScanned, id.UnscannableRecords, id.UnscannableSamples, build.Bytes, null,
+                id.PluginsScanned, id.UnscannableRecords, id.UnscannableSamples, build.Bytes, note,
                 assetRename, voiceRename, seqRegen);
         }
     }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1876,6 +1876,179 @@ public sealed class LoadOrderService : IDisposable
         }
     }
 
+    /// <summary>Merge two or more ACTIVE plugins into ONE new plugin (housecarl_merge_plugins — the A4 orchestration
+    /// over the compact spine). Merge = a RECORDS operation: the donors' records combine into a fresh plugin under a
+    /// NEW name (collision-only renumber — the first donor in load order keeps its object IDs; cross-donor conflicts
+    /// on the same record resolve to the LOAD-ORDER WINNER and are reported; a losing donor's un-relisted nested
+    /// children graft into the winner). The donors are NEVER touched — new-file lane only, no consent gate; the user
+    /// reviews M in xEdit, enables its folder, and disables the donor mods in MO2. External referencers AND overriders
+    /// of donor records are WARNED loud and named (never a refusal: nothing breaks at write time — the donors stay
+    /// active until the user swaps; the remedy is to include the patch in the merge set or repoint it before disabling
+    /// the donors). The FormID-keyed assets follow per donor: EVERY donor NPC's facegen and EVERY voiced line move to
+    /// the new plugin-name folders (the plugin NAME is part of those paths, so this is the full donor set, not just
+    /// collisions), and a <c>.seq</c> is refreshed when any donor shipped one.</summary>
+    public WritePatchBuilder.MergeOutcome MergePlugins(
+        IReadOnlyList<string>? plugins, string? outputName, string? patchName = null)
+    {
+        // ---- 0. argument shape (Q3 — every refusal names the fix) ----
+        var donorsRaw = (plugins ?? Array.Empty<string>()).Select(p => (p ?? "").Trim()).Where(p => p.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        if (donorsRaw.Count < 2)
+            return WritePatchBuilder.MergeOutcome.Fail(
+                "merge needs at least TWO distinct donor plugins — pass plugins=[\"A.esp\", \"B.esp\", …].");
+        var outName = (outputName ?? "").Trim();
+        if (outName.Length == 0)
+            return WritePatchBuilder.MergeOutcome.Fail(
+                "output is required — name the NEW merged plugin file to create (e.g. 'MyMerge.esp'). It must not already exist in your load order.");
+        ModKey outKey;
+        try { outKey = ModKey.FromFileName(outName); }
+        catch (Exception ex) { return WritePatchBuilder.MergeOutcome.Fail($"'{outName}' is not a valid plugin filename ({ex.Message})."); }
+        if (donorsRaw.Any(d => string.Equals(d, outName, StringComparison.OrdinalIgnoreCase)))
+            return WritePatchBuilder.MergeOutcome.Fail($"the output '{outName}' cannot also be a donor — name a NEW plugin file.");
+
+        lock (_writeGate)                                                 // one write at a time (the compact discipline)
+        {
+            var resolver = Resolver;
+            var view = resolver.Capture();
+            if (!Directory.Exists(_modsDir))
+                return WritePatchBuilder.MergeOutcome.Fail($"cannot write: ModsDir '{_modsDir}' does not exist. Check HouseCarl:ModsDir.");
+            if (view.ContainsPlugin(outName))
+                return WritePatchBuilder.MergeOutcome.Fail(
+                    $"'{outName}' is already an active plugin in your load order — the merge output must be a NEW plugin name " +
+                    "(merging over an existing plugin would shadow it in MO2).");
+
+            // ---- 1. validate + load-order-sort the donors (merge semantics are load-order semantics — Q3: sort, don't trust arg order) ----
+            var donorInfos = new List<(string Name, string Path, ModKey Key, int Order)>();
+            foreach (var d in donorsRaw)
+            {
+                if (!view.ContainsPlugin(d))
+                    return WritePatchBuilder.MergeOutcome.Fail(
+                        $"donor '{d}' is not an active plugin in your load order — merge reads each donor's records and conflict " +
+                        "position from the ACTIVE order. Enable it in MO2 first (pass the exact filename, e.g. 'CoolMod.esp').");
+                if (view.ExcludedPlugins.TryGetValue(d, out var excluded))
+                    return WritePatchBuilder.MergeOutcome.Fail(
+                        $"cannot merge '{d}': it was EXCLUDED from this session ({excluded}) — houseCARL won't merge a plugin it " +
+                        "can't fully parse (it would risk dropping records it couldn't read, Q3). Nothing was written.");
+                var p = view.PluginPath(d);
+                if (p is null || !File.Exists(p))
+                    return WritePatchBuilder.MergeOutcome.Fail($"donor '{d}' not found on disk at {p ?? "<unresolved>"} — nothing to merge.");
+                ModKey dk;
+                try { dk = ModKey.FromFileName(d); }
+                catch (Exception ex) { return WritePatchBuilder.MergeOutcome.Fail($"'{d}' is not a valid plugin filename ({ex.Message})."); }
+                int order = -1;
+                for (int i = 0; i < resolver.PluginNames.Count; i++)
+                    if (string.Equals(resolver.PluginNames[i], d, StringComparison.OrdinalIgnoreCase)) { order = i; break; }
+                donorInfos.Add((d, p, dk, order));
+            }
+            donorInfos.Sort((a, b) => a.Order.CompareTo(b.Order));
+            var donorNames = donorInfos.Select(d => d.Name).ToList();
+            var donorKeySet = new HashSet<ModKey>(donorInfos.Select(d => d.Key));
+
+            // ---- 2. originating keys per donor + the collision-only remap (first donor keeps its ids — zMerge default) ----
+            var donorKeys = new List<(string Donor, IReadOnlyList<FormKey> Keys)>();
+            foreach (var (dName, dPath, dKey, _) in donorInfos)
+            {
+                if (!WritePatchBuilder.TryReadOriginatingKeys(dPath, dKey, out var keys, out var keyErr))
+                    return WritePatchBuilder.MergeOutcome.Fail(keyErr!);
+                donorKeys.Add((dName, keys));                             // a pure-override donor (0 originating keys) is a legit patch donor
+            }
+            var plan = RemapEngine.BuildMergeRemap(donorKeys, outKey, RemapEngine.EslFloor, FormIdRange.ObjectIdMax);
+            if (!plan.Success) return WritePatchBuilder.MergeOutcome.Fail(plan.Error!);
+
+            // ---- 3. identify-pass — WARN-and-proceed (the A4 posture; unlike compact this NEVER refuses: the donors stay
+            //      installed and ACTIVE until the user swaps in MO2, so nothing breaks at write time. The report names each
+            //      affected plugin with the remedy — include it in the merge set, or handle it before disabling the donors.) ----
+            var targets = plan.Dict.Keys.ToHashSet();
+            var transformSet = new HashSet<string>(donorNames, StringComparer.OrdinalIgnoreCase);
+            var id = RemapEngine.IdentifyExternalReferencers(resolver, targets, transformSet);
+
+            // ---- 4. masters = union(donor declared masters) − donors, load-order sorted (each donor's own header order
+            //      is already load-order-consistent; the union sorts by the active order so the merged header is too) ----
+            var masterSet = new List<string>();
+            var seenMasters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var (dName, _, _, _) in donorInfos)
+            {
+                IReadOnlyList<string> declared;
+                try { declared = view.DeclaredMasters(dName); }
+                catch (Exception ex)
+                {
+                    return WritePatchBuilder.MergeOutcome.Fail($"cannot read donor '{dName}' masters ({ex.Message}) — nothing written.");
+                }
+                foreach (var mfn in declared)
+                    if (!transformSet.Contains(mfn) && seenMasters.Add(mfn)) masterSet.Add(mfn);
+            }
+            var orderIndex = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            for (int i = 0; i < resolver.PluginNames.Count; i++) orderIndex[resolver.PluginNames[i]] = i;
+            masterSet.Sort((a, b) =>
+                (orderIndex.TryGetValue(a, out var ia) ? ia : int.MaxValue).CompareTo(orderIndex.TryGetValue(b, out var ib) ? ib : int.MaxValue));
+
+            // ---- 5. output folder (fresh houseCARL mod folder; the merge is ALWAYS a new file — no in-place lane) ----
+            RiderFolder rf;
+            try { rf = ResolvePatchModFolder(patchName, null, Path.GetFileNameWithoutExtension(outName) + " merged"); }
+            catch (InvalidOperationException ex) { return WritePatchBuilder.MergeOutcome.Fail(ex.Message); }
+            WriteOwnerMeta(rf.ModFolder, outName);
+            var outPath = Path.Combine(rf.OutputDir, outName);
+
+            // ---- 6. build + write M ----
+            var build = WritePatchBuilder.MergeBuild(
+                donorInfos.Select(d => (d.Name, d.Path, d.Key)).ToList(), outKey, plan.Dict, masterSet, view.PluginPath, outPath);
+            if (!build.Success)
+            {
+                if (rf.CreatedFresh) RemoveOrNameRiderResidue(rf);        // a refused build leaves no orphan folder
+                return WritePatchBuilder.MergeOutcome.Fail(build.Error!);
+            }
+
+            // ---- 7. FormID-keyed assets follow the renumber, PER DONOR (merge renames the plugin, and the plugin NAME
+            //      is a segment of the facegen + voice paths — so the carry covers EVERY donor NPC/voiced line, not just
+            //      the id collisions). ONE captured asset view feeds the carries AND the SEQ gate. Best-effort + REPORTED
+            //      (Q3): the records are written, so an asset miss is a named warning, never a failure of the merge. ----
+            AssetRenameOutcome assetRename;
+            VoiceCarryOutcome voiceRename;
+            bool anyDonorSeq = false;
+            try
+            {
+                AssetResolver assetResolver;
+                lock (_gate) { assetResolver = Assets; }                  // reentrant under the held _writeGate (the PlaceAssets idiom)
+                var assetView = assetResolver.Capture();
+                foreach (var (dName, _, _, _) in donorInfos)              // "did ANY donor ship a .seq?" — VFS-aware, per donor
+                    if (assetView.ResolveForPlacement($@"SEQ\{Path.GetFileNameWithoutExtension(dName)}.seq").Sources.Count > 0)
+                        { anyDonorSeq = true; break; }
+                var outDir = Path.GetDirectoryName(outPath)!;
+                assetRename = AssetRenameService.CarryFaceGen(outPath, plan.Dict, assetView, outDir);
+                var voiceParts = donorInfos
+                    .Select(d => AssetRenameService.CarryVoice(outPath, plan.Dict, assetView, outDir, sourcePlugin: d.Name))
+                    .ToList();
+                voiceRename = new VoiceCarryOutcome(
+                    voiceParts.Sum(v => v.FilesScanned), voiceParts.Sum(v => v.FilesCarried), voiceParts.Sum(v => v.LinesCarried),
+                    voiceParts.SelectMany(v => v.Failures).ToList(), voiceParts.Any(v => v.ReadIncomplete));
+            }
+            catch (Exception ex)
+            {
+                assetRename = new AssetRenameOutcome(0, 0, 0,
+                    new[] { $"facegen carry skipped — the asset layer could not be built ({ex.Message}); verify NPC faces in-game." }, false);
+                voiceRename = new VoiceCarryOutcome(0, 0, 0,
+                    new[] { $"voice carry skipped — the asset layer could not be built ({ex.Message}); verify voiced lines in-game." }, false);
+            }
+
+            // ---- 8. SEQ — refresh-only, off the merged plugin: rebuilt when ANY donor shipped a .seq (all their SGE
+            //      quests now live in M, whose .seq must list the NEW on-disk FormIDs); donors with SGE quests but no
+            //      shipped .seq get the same NAMED write_seq advisory compact gives. ----
+            SeqRegenOutcome seqRegen;
+            try { seqRegen = AssetRenameService.RegenerateSeq(outPath, Path.GetDirectoryName(outPath)!, anyDonorSeq); }
+            catch (Exception ex)
+            {
+                seqRegen = new SeqRegenOutcome(0, false, null,
+                    new[] { $"SEQ regenerate skipped ({ex.Message}) — if the donors have start-game-enabled quests, run housecarl_write_seq on '{outName}'." });
+            }
+
+            return new WritePatchBuilder.MergeOutcome(
+                true, null, outPath, outName, donorNames, build.Masters, build.RecordsCopied, build.RecordsRenumbered,
+                plan.Donors, build.Conflicts, id.ExternalPlugins, id.ExternalOverriders,
+                id.PluginsScanned, id.UnscannableRecords, id.UnscannableSamples, build.Bytes, null,
+                assetRename, voiceRename, seqRegen);
+        }
+    }
+
     /// <summary>The composed standalone-NPC-copy verb (housecarl_copy_npc_appearance — capability chain Stage 3).
     /// Deep-copies a donor NPC's appearance-record subtree into a houseCARL patch under NEW FormKeys (Duplicate +
     /// RemapLinks — the RemapEngine mechanism, so every field carries by construction: HDPT.Parts morph refs,

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -363,6 +363,38 @@ public static class WriteTools
         return RenderCompact(svc.CompactPlugin(plugin, esl, in_place, repoint_externals, acknowledge, patch_name));
     });
 
+    [McpServerTool(Name = "housecarl_merge_plugins", Title = "Merge plugins into one new plugin"),
+     Description(
+         "MERGE two or more ACTIVE plugins into ONE NEW plugin — a RECORDS operation (the zMerge/'Merge Plugins' job): the " +
+         "donors' records combine under a new filename; the donor FILES and their mods are NEVER touched (new-file lane only, " +
+         "no in-place). RENUMBER is collision-only (zMerge's default): the donor EARLIEST in the load order keeps its FormID " +
+         "object ids; later donors renumber only ids already taken (all records necessarily move to the new plugin's identity). " +
+         "Cross-donor conflicts on the SAME record resolve to the LOAD-ORDER WINNER and are each REPORTED; a losing donor's " +
+         "nested children the winner doesn't re-list (a base mod's dialogue lines under a patched topic; placed refs under a " +
+         "patched cell) are GRAFTED into the winner's copy — so merging a mod WITH its patches is the intended use. ASSETS " +
+         "follow the renumber: every donor NPC's facegen and every voiced line are carried into the new plugin-name folders " +
+         "(those paths embed the plugin NAME, so ALL donor facegen/voice moves, not just collisions), and a .seq is refreshed " +
+         "when any donor shipped one. THE SAFETY (Q3): plugins OUTSIDE the merge that reference or override donor records are " +
+         "WARNED and NAMED, never refused — the donors stay active until you swap in MO2, so nothing breaks at write time; the " +
+         "remedy is to include those patches in the merge set or re-point them before disabling the donors. Refuses loud + " +
+         "writes nothing on: a donor not active / unparseable / not on disk; an output name already in the load order; a " +
+         "dangling donor-internal reference (a donor referencing a FormID no donor defines); a declared master not active. " +
+         "AFTER: review the merged plugin in xEdit, enable its mod folder in MO2, then DISABLE the donor mods. Existing SAVES " +
+         "that depend on the donors will NOT survive (new plugin name + renumbered FormIDs) — best for a new game. Want it " +
+         "light/ESL? Run housecarl_compact_plugin on the merged plugin afterward (the tools compose).")]
+    public static string MergePlugins(
+        LoadOrderService svc,
+        [Description("The donor plugin filenames to merge (at least two, e.g. [\"CoolMod.esp\", \"CoolMod Patch.esp\"]) — each must be active in your load order. Argument order does not matter: houseCARL uses LOAD order for id priority and conflict resolution.")]
+            string[] plugins,
+        [Description("The NEW merged plugin's filename to create (e.g. 'MyMerge.esp') — must NOT already exist in the load order. The donors keep their names and files untouched.")]
+            string output,
+        [Description("Optional. Base name for the NEW mod folder (auto-suffixed if taken). Defaults to '<output> merged'.")]
+            string? patch_name = null) => Guard.Tool("housecarl_merge_plugins", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        return RenderMerge(svc.MergePlugins(plugins, output, patch_name));
+    });
+
     /// <summary>Compact, parseable confirmation (rulebook: short mutation confirmation + the IDs needed for follow-up).
     /// On refusal, the full reason (every malformed/rejected op) so the caller can fix and retry.</summary>
     internal static string Render(WritePatchBuilder.PatchOutcome o, int maxChars = 0, bool fullDump = false)   // internal: the compact-readback guard renders one outcome three ways
@@ -640,58 +672,133 @@ public static class WriteTools
         }
         sb.Append("identify-pass scanned ").Append(o.PluginsScanned).Append(" plugin(s) for external references.\n");
 
-        // FormID-keyed assets carried WITH the renumber (compact/merge Wave A1: facegen) — the renumber moved every record
-        // to a new FormID, so the engine looks the head mesh/tint up under the NEW name; carrying them is what stops a
-        // compacted NPC mod silently dark-facing. Reported, not silent (Q3).
-        if (o.AssetRename is { } ar)
-        {
-            if (ar.FacegenFilesCarried > 0)
-                sb.Append("facegen: carried ").Append(ar.FacegenFilesCarried).Append(ar.FacegenFilesCarried == 1 ? " file for " : " files for ")
-                  .Append(ar.FacegenNpcsCarried).Append(ar.FacegenNpcsCarried == 1 ? " NPC to the new FormIDs" : " NPCs to the new FormIDs")
-                  .Append(o.InPlace ? " (old-FormID facegen left as harmless orphans).\n" : " (in the new mod folder — enabling it carries the faces).\n");
-            else if (ar.NpcCount > 0 && ar.Failures.Count == 0)
-                sb.Append("facegen: none found for this plugin's ").Append(ar.NpcCount).Append(ar.NpcCount == 1 ? " NPC — nothing to carry.\n" : " NPCs — nothing to carry.\n");
-            foreach (var f in ar.Failures.Take(25)) sb.Append("  facegen WARN: ").Append(f).Append('\n');
-            if (ar.Failures.Count > 25) sb.Append("  facegen WARN: … (+").Append(ar.Failures.Count - 25).Append(" more)\n");
-            if (ar.ReadIncomplete)
-                sb.Append("  note: a BSA failed to read this scan, so a 'no facegen' result may be incomplete — verify NPC faces in-game.\n");
-        }
-
-        // Voice (.fuz/.lip) carried WITH the renumber (compact/merge Wave A2) — the renumber moved every INFO to a new
-        // FormID, and a voice filename is keyed by the OLD FormID, so carrying it is what stops a compacted voiced mod
-        // going mute. Reported, not silent (Q3) — and the old "voice NOT carried, verify yourself" reminder is now retired.
-        if (o.VoiceRename is { } vr)
-        {
-            if (vr.FilesCarried > 0)
-                sb.Append("voice: carried ").Append(vr.FilesCarried).Append(vr.FilesCarried == 1 ? " file for " : " files for ")
-                  .Append(vr.LinesCarried).Append(vr.LinesCarried == 1 ? " dialogue line to the new FormIDs" : " dialogue lines to the new FormIDs")
-                  .Append(o.InPlace ? " (old-FormID voice left as harmless orphans).\n" : " (in the new mod folder — enabling it carries the voice).\n");
-            else if (vr.FilesScanned > 0 && vr.Failures.Count == 0)
-                sb.Append("voice: ").Append(vr.FilesScanned).Append(vr.FilesScanned == 1 ? " voice file found, none keyed to a renumbered line" : " voice files found, none keyed to a renumbered line")
-                  .Append(" — nothing to carry.\n");
-            foreach (var f in vr.Failures.Take(25)) sb.Append("  voice WARN: ").Append(f).Append('\n');
-            if (vr.Failures.Count > 25) sb.Append("  voice WARN: … (+").Append(vr.Failures.Count - 25).Append(" more)\n");
-            if (vr.ReadIncomplete)
-                sb.Append("  note: a BSA failed to read this scan, so a 'no voice' result may be incomplete — verify voiced lines in-game.\n");
-        }
-
-        // SEQ (.seq) REFRESHED from the renumbered plugin (compact/merge Wave A3) — a renumber shifts every start-game-
-        // enabled quest's on-disk FormID, so a .seq the source SHIPPED goes stale and its quests silently never start; the
-        // regen writes a fresh, correct .seq next to P′ (refresh-only — a source with no .seq gets a named WARN advising
-        // write_seq, never an invented file). A plugin with no SGE quests renders nothing (the common case). The WARN loop
-        // surfaces both a write-failure and the missing-source-.seq advisory. Reported, not silent (Q3).
-        if (o.SeqRegen is { } sr)
-        {
-            if (sr.Written)
-                sb.Append("SEQ: regenerated — ").Append(sr.SgeQuestCount).Append(sr.SgeQuestCount == 1 ? " start-game-enabled quest" : " start-game-enabled quests")
-                  .Append(o.InPlace ? " (.seq rewritten in place).\n" : " (.seq in the new mod folder's SEQ\\ — enabling it starts the quests).\n");
-            foreach (var f in sr.Failures.Take(25)) sb.Append("  SEQ WARN: ").Append(f).Append('\n');
-            if (sr.Failures.Count > 25) sb.Append("  SEQ WARN: … (+").Append(sr.Failures.Count - 25).Append(" more)\n");
-        }
+        AppendFacegenCarry(sb, o.AssetRename, o.InPlace);
+        AppendVoiceCarry(sb, o.VoiceRename, o.InPlace);
+        AppendSeqRegen(sb, o.SeqRegen, o.InPlace);
 
         if (o.Note is { } note) sb.Append("note: ").Append(note).Append('\n');
         sb.Append("reminder: FormIDs compiled into Papyrus (.pex hardcoded / GetFormFromFile) and any Mutagen-delta ")
           .Append("residual are NOT remappable — verify scripted records after compacting.");
+        return sb.ToString();
+    }
+
+    // FormID-keyed assets carried WITH the renumber (Waves A1–A3, shared by compact AND merge — one render home, no
+    // drift). The renumber moved records to new FormIDs (a merge additionally to a new plugin NAME), so the engine looks
+    // facegen/voice up under NEW paths and a shipped .seq goes stale; carrying/refreshing them is what stops a renumbered
+    // NPC mod silently dark-facing, a voiced mod going mute, and SGE quests never starting. Reported, not silent (Q3).
+    // inPlace is always false for merge (it has no in-place lane).
+
+    static void AppendFacegenCarry(StringBuilder sb, AssetRenameOutcome? outcome, bool inPlace)
+    {
+        if (outcome is not { } ar) return;
+        if (ar.FacegenFilesCarried > 0)
+            sb.Append("facegen: carried ").Append(ar.FacegenFilesCarried).Append(ar.FacegenFilesCarried == 1 ? " file for " : " files for ")
+              .Append(ar.FacegenNpcsCarried).Append(ar.FacegenNpcsCarried == 1 ? " NPC to the new FormIDs" : " NPCs to the new FormIDs")
+              .Append(inPlace ? " (old-FormID facegen left as harmless orphans).\n" : " (in the new mod folder — enabling it carries the faces).\n");
+        else if (ar.NpcCount > 0 && ar.Failures.Count == 0)
+            sb.Append("facegen: none found for ").Append(ar.NpcCount).Append(ar.NpcCount == 1 ? " NPC — nothing to carry.\n" : " NPCs — nothing to carry.\n");
+        foreach (var f in ar.Failures.Take(25)) sb.Append("  facegen WARN: ").Append(f).Append('\n');
+        if (ar.Failures.Count > 25) sb.Append("  facegen WARN: … (+").Append(ar.Failures.Count - 25).Append(" more)\n");
+        if (ar.ReadIncomplete)
+            sb.Append("  note: a BSA failed to read this scan, so a 'no facegen' result may be incomplete — verify NPC faces in-game.\n");
+    }
+
+    static void AppendVoiceCarry(StringBuilder sb, VoiceCarryOutcome? outcome, bool inPlace)
+    {
+        if (outcome is not { } vr) return;
+        if (vr.FilesCarried > 0)
+            sb.Append("voice: carried ").Append(vr.FilesCarried).Append(vr.FilesCarried == 1 ? " file for " : " files for ")
+              .Append(vr.LinesCarried).Append(vr.LinesCarried == 1 ? " dialogue line to the new FormIDs" : " dialogue lines to the new FormIDs")
+              .Append(inPlace ? " (old-FormID voice left as harmless orphans).\n" : " (in the new mod folder — enabling it carries the voice).\n");
+        else if (vr.FilesScanned > 0 && vr.Failures.Count == 0)
+            sb.Append("voice: ").Append(vr.FilesScanned).Append(vr.FilesScanned == 1 ? " voice file found, none keyed to a renumbered line" : " voice files found, none keyed to a renumbered line")
+              .Append(" — nothing to carry.\n");
+        foreach (var f in vr.Failures.Take(25)) sb.Append("  voice WARN: ").Append(f).Append('\n');
+        if (vr.Failures.Count > 25) sb.Append("  voice WARN: … (+").Append(vr.Failures.Count - 25).Append(" more)\n");
+        if (vr.ReadIncomplete)
+            sb.Append("  note: a BSA failed to read this scan, so a 'no voice' result may be incomplete — verify voiced lines in-game.\n");
+    }
+
+    static void AppendSeqRegen(StringBuilder sb, SeqRegenOutcome? outcome, bool inPlace)
+    {
+        if (outcome is not { } sr) return;
+        if (sr.Written)
+            sb.Append("SEQ: regenerated — ").Append(sr.SgeQuestCount).Append(sr.SgeQuestCount == 1 ? " start-game-enabled quest" : " start-game-enabled quests")
+              .Append(inPlace ? " (.seq rewritten in place).\n" : " (.seq in the new mod folder's SEQ\\ — enabling it starts the quests).\n");
+        foreach (var f in sr.Failures.Take(25)) sb.Append("  SEQ WARN: ").Append(f).Append('\n');
+        if (sr.Failures.Count > 25) sb.Append("  SEQ WARN: … (+").Append(sr.Failures.Count - 25).Append(" more)\n");
+    }
+
+    /// <summary>Merge confirmation (A4): the merged plugin's identity + the MO2 swap instruction, per-donor id
+    /// accounting, cross-donor conflict resolutions (load-order winner — reported, never silent), the WARN surfaces
+    /// (external referencers/overriders with the remedy), the asset-carry accounting, and the saves/ESL pointers.
+    /// On refusal, the named reason (Q3). internal: the merge guard asserts warnings reach user output.</summary>
+    internal static string RenderMerge(WritePatchBuilder.MergeOutcome o)
+    {
+        if (!o.Success) return "error: " + o.Error;
+        var file = Path.GetFileName(o.OutputPath);
+        var modFolder = Path.GetFileName(Path.GetDirectoryName(o.OutputPath) ?? "");
+        var sb = new StringBuilder();
+        sb.Append("wrote merged ").Append(file).Append(" (new plugin; ").Append(o.Bytes).Append(" bytes) from ")
+          .Append(o.Donors.Count).Append(" donors: ").Append(string.Join(", ", o.Donors)).Append('\n');
+        sb.Append("mod folder: ").Append(modFolder)
+          .Append("  — review in xEdit, enable + sort it in MO2, then DISABLE the donor mods (their files are untouched).\n");
+
+        int overrides = o.RecordsCopied - o.RecordsRenumbered;
+        sb.Append(o.RecordsRenumbered).Append(o.RecordsRenumbered == 1 ? " originating record" : " originating records")
+          .Append(" merged under ").Append(o.OutputName);
+        if (overrides > 0) sb.Append("; ").Append(overrides).Append(overrides == 1 ? " override kept at its master FormID" : " overrides kept at their master FormIDs");
+        sb.Append(".\n");
+        foreach (var d in o.DonorRemaps)
+            sb.Append("  ").Append(d.Donor).Append(": ").Append(d.Kept).Append(" object id(s) kept, ")
+              .Append(d.Renumbered).Append(" renumbered (id collisions / below-floor)\n");
+        sb.Append("masters: ").Append(o.Masters.Count == 0 ? "(none)" : string.Join(", ", o.Masters)).Append('\n');
+
+        if (o.Conflicts.Count == 0)
+            sb.Append("cross-donor conflicts: none — no record was carried by more than one donor.\n");
+        else
+        {
+            sb.Append("cross-donor conflicts (").Append(o.Conflicts.Count).Append(") — each resolved to the LOAD-ORDER WINNER (the losing version is NOT in the merge; its un-relisted nested children were grafted):\n");
+            foreach (var c in o.Conflicts.Take(25))
+                sb.Append("  ").Append(c.RecordType).Append(' ').Append(c.Key).Append("  ").Append(c.WinnerDonor).Append(" won over ").Append(c.LoserDonor).Append('\n');
+            if (o.Conflicts.Count > 25) sb.Append("  … (+").Append(o.Conflicts.Count - 25).Append(" more)\n");
+        }
+
+        // The A4 posture: WARN loud + proceed — the donors stay installed and ACTIVE until the user swaps in MO2, so
+        // nothing is broken at write time; the report names every affected plugin and the remedy. (Unlike compact, which
+        // refuses on referencers: a compact's renumber takes effect under the SAME plugin name, a merge's only when the
+        // user disables the donors — the user holds the switch here.)
+        if (o.ExternalPlugins.Count > 0)
+        {
+            sb.Append("WARNING — ").Append(o.ExternalPlugins.Count).Append(" plugin(s) OUTSIDE the merge REFERENCE donor records. Their references break ")
+              .Append("the moment you disable the donors: include them in the merge set (re-run with them added), or re-point them at '")
+              .Append(o.OutputName).Append("' before the swap:\n");
+            foreach (var pl in o.ExternalPlugins.Take(25)) sb.Append("  ! ").Append(pl).Append('\n');
+            if (o.ExternalPlugins.Count > 25) sb.Append("  ! … (+").Append(o.ExternalPlugins.Count - 25).Append(" more)\n");
+        }
+        else sb.Append("external referencers: none — nothing outside the merge points at a donor record.\n");
+        if (o.ExternalOverriders.Count > 0)
+        {
+            sb.Append("WARNING — ").Append(o.ExternalOverriders.Count).Append(" plugin(s) OUTSIDE the merge OVERRIDE a donor record; those overrides ")
+              .Append("orphan once you disable the donors (an override can't be auto-repointed — identity, not a link). Include them in the merge set, or rebuild them against '")
+              .Append(o.OutputName).Append("':\n");
+            foreach (var pl in o.ExternalOverriders.Take(25)) sb.Append("  ! ").Append(pl).Append('\n');
+            if (o.ExternalOverriders.Count > 25) sb.Append("  ! … (+").Append(o.ExternalOverriders.Count - 25).Append(" more)\n");
+        }
+        if (o.UnscannableRecords > 0)
+            sb.Append("note: ").Append(o.UnscannableRecords).Append(" record(s) couldn't be scanned in the external-reference pass, so a ")
+              .Append("'none' above may be incomplete — verify in xEdit. Samples: ").Append(string.Join("; ", o.UnscannableSamples)).Append('\n');
+        sb.Append("identify-pass scanned ").Append(o.PluginsScanned).Append(" plugin(s) for external references.\n");
+
+        AppendFacegenCarry(sb, o.AssetRename, inPlace: false);
+        AppendVoiceCarry(sb, o.VoiceRename, inPlace: false);
+        AppendSeqRegen(sb, o.SeqRegen, inPlace: false);
+
+        if (o.Note is { } note) sb.Append("note: ").Append(note).Append('\n');
+        sb.Append("reminders: existing SAVES that depend on the donors will not survive the swap (records moved to a new ")
+          .Append("plugin name + new FormIDs) — best for a new game. FormIDs compiled into Papyrus (.pex hardcoded / ")
+          .Append("GetFormFromFile) and any Mutagen-delta residual are NOT remappable — verify scripted records. Want it ")
+          .Append("light? Run housecarl_compact_plugin on '").Append(o.OutputName).Append("' (the tools compose).");
         return sb.ToString();
     }
 

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -379,9 +379,14 @@ public static class WriteTools
          "remedy is to include those patches in the merge set or re-point them before disabling the donors. Refuses loud + " +
          "writes nothing on: a donor not active / unparseable / not on disk; an output name already in the load order; a " +
          "dangling donor-internal reference (a donor referencing a FormID no donor defines); a declared master not active. " +
-         "AFTER: review the merged plugin in xEdit, enable its mod folder in MO2, then DISABLE the donor mods. Existing SAVES " +
-         "that depend on the donors will NOT survive (new plugin name + renumbered FormIDs) — best for a new game. Want it " +
-         "light/ESL? Run housecarl_compact_plugin on the merged plugin afterward (the tools compose).")]
+         "AFTER: review the merged plugin in xEdit, enable its mod folder in MO2, then deactivate the donor PLUGINS (right " +
+         "pane) but KEEP the donor MOD FOLDERS enabled (left pane) — merge carries only the FormID-keyed files the rename " +
+         "breaks (facegen/voice/seq); every other donor asset (meshes, textures, scripts, BSA contents) is still referenced " +
+         "BY PATH from the merged records and loads from the donor folders. Caveat: a donor .bsa stops auto-loading once its " +
+         "same-named plugin is inactive — extract it into the mod folder (housecarl_bsa_extract) or load it via a same-named " +
+         "dummy plugin (housecarl_create_plugin). Existing SAVES that depend on the donors will NOT survive (new plugin name " +
+         "+ renumbered FormIDs) — best for a new game. Want it light/ESL? Run housecarl_compact_plugin on the merged plugin " +
+         "afterward (the tools compose).")]
     public static string MergePlugins(
         LoadOrderService svc,
         [Description("The donor plugin filenames to merge (at least two, e.g. [\"CoolMod.esp\", \"CoolMod Patch.esp\"]) — each must be active in your load order. Argument order does not matter: houseCARL uses LOAD order for id priority and conflict resolution.")]
@@ -741,8 +746,16 @@ public static class WriteTools
         var sb = new StringBuilder();
         sb.Append("wrote merged ").Append(file).Append(" (new plugin; ").Append(o.Bytes).Append(" bytes) from ")
           .Append(o.Donors.Count).Append(" donors: ").Append(string.Join(", ", o.Donors)).Append('\n');
-        sb.Append("mod folder: ").Append(modFolder)
-          .Append("  — review in xEdit, enable + sort it in MO2, then DISABLE the donor mods (their files are untouched).\n");
+        sb.Append("mod folder: ").Append(modFolder).Append("  — review in xEdit, then enable + sort it in MO2.\n");
+        // The swap is PLUGIN-level, not mod-level (merge is a RECORDS op): the merged records still reference the donors'
+        // meshes/textures/scripts/BSA contents BY PATH, and those files live in the donor mod folders — only the
+        // FormID-keyed facegen/voice/seq were carried. "Disable the donor mods" (compact's instruction, where the output
+        // shares the source's basename) would yank all of that out of the VFS with every warning light green.
+        sb.Append("the swap: deactivate the donor PLUGINS (right pane) — their files are untouched — but KEEP the donor mod ")
+          .Append("folders enabled (left pane): the merged records still load the donors' meshes/textures/scripts by path; ")
+          .Append("only facegen/voice/seq were carried. If a donor ships a .bsa, it stops auto-loading once its plugin is ")
+          .Append("deactivated — extract it into the mod folder (housecarl_bsa_extract) or load it via a same-named dummy ")
+          .Append("plugin (housecarl_create_plugin).\n");
 
         int overrides = o.RecordsCopied - o.RecordsRenumbered;
         sb.Append(o.RecordsRenumbered).Append(o.RecordsRenumbered == 1 ? " originating record" : " originating records")
@@ -758,7 +771,7 @@ public static class WriteTools
             sb.Append("cross-donor conflicts: none — no record was carried by more than one donor.\n");
         else
         {
-            sb.Append("cross-donor conflicts (").Append(o.Conflicts.Count).Append(") — each resolved to the LOAD-ORDER WINNER (the losing version is NOT in the merge; its un-relisted nested children were grafted):\n");
+            sb.Append("cross-donor conflicts (").Append(o.Conflicts.Count).Append(") — each resolved to the LOAD-ORDER WINNER (the losing version is NOT in the merge; any un-relisted nested children were grafted):\n");
             foreach (var c in o.Conflicts.Take(25))
                 sb.Append("  ").Append(c.RecordType).Append(' ').Append(c.Key).Append("  ").Append(c.WinnerDonor).Append(" won over ").Append(c.LoserDonor).Append('\n');
             if (o.Conflicts.Count > 25) sb.Append("  … (+").Append(o.Conflicts.Count - 25).Append(" more)\n");
@@ -771,7 +784,7 @@ public static class WriteTools
         if (o.ExternalPlugins.Count > 0)
         {
             sb.Append("WARNING — ").Append(o.ExternalPlugins.Count).Append(" plugin(s) OUTSIDE the merge REFERENCE donor records. Their references break ")
-              .Append("the moment you disable the donors: include them in the merge set (re-run with them added), or re-point them at '")
+              .Append("the moment you deactivate the donor plugins: include them in the merge set (re-run with them added), or re-point them at '")
               .Append(o.OutputName).Append("' before the swap:\n");
             foreach (var pl in o.ExternalPlugins.Take(25)) sb.Append("  ! ").Append(pl).Append('\n');
             if (o.ExternalPlugins.Count > 25) sb.Append("  ! … (+").Append(o.ExternalPlugins.Count - 25).Append(" more)\n");
@@ -780,7 +793,7 @@ public static class WriteTools
         if (o.ExternalOverriders.Count > 0)
         {
             sb.Append("WARNING — ").Append(o.ExternalOverriders.Count).Append(" plugin(s) OUTSIDE the merge OVERRIDE a donor record; those overrides ")
-              .Append("orphan once you disable the donors (an override can't be auto-repointed — identity, not a link). Include them in the merge set, or rebuild them against '")
+              .Append("orphan once you deactivate the donor plugins (an override can't be auto-repointed — identity, not a link). Include them in the merge set, or rebuild them against '")
               .Append(o.OutputName).Append("':\n");
             foreach (var pl in o.ExternalOverriders.Take(25)) sb.Append("  ! ").Append(pl).Append('\n');
             if (o.ExternalOverriders.Count > 25) sb.Append("  ! … (+").Append(o.ExternalOverriders.Count - 25).Append(" more)\n");


### PR DESCRIPTION
## A4 — merge orchestration: `housecarl_merge_plugins` (tool #33)

The compact/merge cluster's payoff wave (plan `dev/plans/ASSET_RENAME_LAYER_PLAN_2026-06-27.md` §2-A4). Merges two or more ACTIVE plugins into ONE new plugin — a **RECORDS operation** (the 2026-06-27 scope correction; never NPC2-style asset-mod consolidation). Donors are **never touched** (new-file lane only, no consent gate): review in xEdit, enable the merged folder, disable the donor mods in MO2.

### Aaron's three A4 scope calls (locked at the session checkpoint)
- **External patches of donors → WARN loud + proceed** (never refuse — donors stay active until the MO2 swap, so nothing breaks at write time; the report names each plugin with the include-it-in-the-merge remedy).
- **No ESL packing in v1** — merge outputs a regular `.esp`; run `housecarl_compact_plugin` on it to make it light (the tools compose; `.esl` output names are refused loud with that remedy).
- **Override auto-fix stays out** — external overriders are detect+warn, compact parity.

### What's in it
- **Collision-only renumber** (`RemapEngine.BuildMergeRemap`): the donor earliest in load order keeps its object ids; later donors renumber only collisions and below-floor ids (zMerge's default). Every originating record necessarily moves to the merged ModKey, so the union dict covers all of them.
- **Multi-donor structural renumber** (`RemapEngine.MergeModsInto`): donors walk in REVERSE load order so each record's LOAD-ORDER WINNER places first (the locked conflict resolution; every loser reported, never silent). A losing donor's un-relisted nested children — a base mod's INFOs under a patched DIAL, placed refs under a patched cell, worldspace blocks paired by grid number — are **GRAFTED** into the winner's container: merging a mod WITH its patches is the intended use, and without the graft the base mod's lines silently vanish.
- **Moved-reference dedup**: the same record carried by two donors under DIFFERENT parents places exactly once (under the winner's parent), reported as a conflict — `RenumberDescendants` consults the placement registry per nested child (merge only; compact's path is untouched, `reg = null`).
- **MergeBuild**: donor-master-survives check (a surviving donor link = a dangling source ref → refused loud with samples, the zMerge "Clean" pattern), masters = union(donor declared) − donors (load-order sorted), and the reported master list is read back from the WRITTEN header (what xEdit will show).
- **Asset spine per donor**: a merge renames the plugin, and the plugin NAME is a folder segment of facegen/voice paths — so EVERY donor NPC's facegen and EVERY voiced line carries to the new-name folders, not just the collided ids (**this corrects the plan doc's "carry shrinks to the collisions"**). `CarryVoice` generalized with `sourcePlugin=` (compact lane byte-identical, default). `.seq` regenerates when ANY donor shipped one (VFS-aware gate + compact's loose-file fallback), with a Q3 note that the regenerated `.seq` lists every SGE quest in the merge.
- **Report** (`RenderMerge`): per-donor id accounting, winner/loser conflict lines, WARN blocks with remedies, the MO2 swap instruction, saves warning, compact-for-ESL pointer. The three asset render sections are factored into shared appenders compact and merge both ride.

### Process
Feat → 8-angle /code-review (8 finders, per-candidate verify) → **11 findings folded** (headline: the moved-reference duplicate-FormKey hole — CONFIRMED, fixed, RED-proven, new guard arm), 3 refuted with hard evidence (incl. an exhaustive reflection scan over all 266 Mutagen 0.53.1 record classes for the graft-walk parity candidates), 1 accepted residual (output-name shadowing outside the active order — the fresh auto-suffixed folder prevents any overwrite). Reuse/dedupe findings that touch the shipped compact path (walk unification, asset-block extraction, `ResolveOwnMasters` generalization, render list helper, probe fixture consolidation) are **deferred to the already-queued cleanup PR** rather than folded into the feature.

### Evidence
- `merge-service-guard`: **23 checks** — merge/collision/cross-donor-ref/winner/graft/moved-ref/masters/accounting/warn-in-outcome+render/assets(facegen+voice+seq)/donors-byte-untouched/5 refusals.
- RED-proven three ways: graft off → 2 arms fail; voice folder-swap off → 1 arm fails; moved-ref dedup off → merge collapses.
- **ci-all 76/76** (was 75; +merge-service-guard).

### Still owed (not this PR)
- The empirical in-game/xEdit pass on a real merged plugin (principle #1 — same posture as compact's deferred gate).
- The cleanup PR (queued): the deferred reuse/dedupe findings above + the PR #156 items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
