### PR TITLE
feat(nif_inspect): NIF layer Wave 1 — housecarl_nif_inspect (tool #34)

### DIFF
--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -47,6 +47,11 @@ GPL-3.0-only   (copyleft — the same license as houseCARL; see the LICENSE file
   GameFinder.StoreHandlers.Steam   4.4.0    github.com/erri120/GameFinder
   GameFinder.StoreHandlers.Xbox    4.4.0    github.com/erri120/GameFinder
   GameFinder.Wine                  4.4.0    github.com/erri120/GameFinder
+  NiflySharp                       1.0.0    github.com/ousnius/NiflySharp
+
+  NiflySharp (NuGet package "Nifly", by ousnius / the nifly project) is the
+  asset-internal mesh reader the NIF layer is built on — pure C#, source-generated
+  from nifxml. It is GPL-3.0-only, the same license as houseCARL.
 
   These components are distributed under the GPL-3.0-only terms reproduced in the
   LICENSE file. One copy of the GPLv3 text covers all of them.

--- a/plugin/THIRD-PARTY-NOTICES.txt
+++ b/plugin/THIRD-PARTY-NOTICES.txt
@@ -47,6 +47,11 @@ GPL-3.0-only   (copyleft — the same license as houseCARL; see the LICENSE file
   GameFinder.StoreHandlers.Steam   4.4.0    github.com/erri120/GameFinder
   GameFinder.StoreHandlers.Xbox    4.4.0    github.com/erri120/GameFinder
   GameFinder.Wine                  4.4.0    github.com/erri120/GameFinder
+  NiflySharp                       1.0.0    github.com/ousnius/NiflySharp
+
+  NiflySharp (NuGet package "Nifly", by ousnius / the nifly project) is the
+  asset-internal mesh reader the NIF layer is built on — pure C#, source-generated
+  from nifxml. It is GPL-3.0-only, the same license as houseCARL.
 
   These components are distributed under the GPL-3.0-only terms reproduced in the
   LICENSE file. One copy of the GPLv3 text covers all of them.

--- a/src/housecarl-core/NifService.cs
+++ b/src/housecarl-core/NifService.cs
@@ -28,6 +28,34 @@ public static class NifService
     const uint SkyrimSeUserVersion = 12;
     const uint SkyrimSeStreamVersion = 100;
 
+    // NiAVObject flag DEFAULTS per concrete type, SSE-effective — transcribed BY CONSTRUCTION from nif.xml's
+    // NiAVObject.Flags <default onlyT=...> table (the SAME nif.xml NiflySharp is generated from): the SSE-specific value
+    // where one exists, else the unversioned value; FO3/FO4-only variants excluded. nif.xml does NOT name the individual
+    // bits (Flags is a plain uint there, and community docs note most are unused), so houseCARL decodes flags by
+    // DEVIATION from these authoritative defaults rather than inventing bit-names — and always states the one bit nif.xml
+    // DOES document: 0x80000 ("Skyrim lacks it sometimes; FO4 lacks it always"), the head-vs-hair-class signal.
+    static readonly IReadOnlyDictionary<string, uint> AvFlagsSseDefaults = new Dictionary<string, uint>(StringComparer.Ordinal)
+    {
+        ["NiNode"] = 0xE, ["NiLight"] = 0xE, ["BSMultiBoundNode"] = 0xE,
+        ["BSTriShape"] = 0x8000E, ["BSSubIndexTriShape"] = 0xE, ["BSMeshLODTriShape"] = 0x100E,
+        ["BSFadeNode"] = 0x8000E, ["NiParticleSystem"] = 0x8000E, ["BSMasterParticleSystem"] = 0x8000E,
+        ["BSStripParticleSystem"] = 0x8000E, ["NiTriShape"] = 0x8000E, ["NiTriStrips"] = 0x8000E,
+        ["BSSegmentedTriShape"] = 0xE, ["BSLeafAnimNode"] = 0x808000E, ["BSTreeNode"] = 0x8080E,
+        ["BSDebrisNode"] = 0x8000F, ["BSBlastNode"] = 0x8000F, ["BSDamageStage"] = 0x8000F,
+        ["BSOrderedNode"] = 0x8200E, ["BSLODTriShape"] = 0x800000E,
+    };
+
+    /// <summary>The SSE-effective NiAVObject flag default for a block, resolved UP the type's inheritance chain (a
+    /// BSDynamicTriShape has no own default → its parent BSTriShape's applies, matching nif.xml's onlyT semantics), or
+    /// (null, null) if no ancestor up to <see cref="object"/> has a documented default. Only consulted for SE meshes —
+    /// the table is SSE values, so a non-SE mesh gets no (misleading) default comparison.</summary>
+    static (uint? Value, string? FromType) ResolveAvDefault(Type? t)
+    {
+        for (var cur = t; cur is not null && cur != typeof(object); cur = cur.BaseType)
+            if (AvFlagsSseDefaults.TryGetValue(cur.Name, out var v)) return (v, cur.Name);
+        return (null, null);
+    }
+
     /// <summary>Inspect a mesh from its raw bytes. Returns the model on success, or a named error (Q3) — a parse the
     /// library rejects, an empty buffer, or a structure read that failed after a clean load. Never throws for an
     /// expected bad-file condition; never returns a partial model.</summary>
@@ -106,23 +134,24 @@ public static class NifService
         var unknownDistinct = unknownTypes.Distinct(StringComparer.Ordinal).OrderBy(t => t, StringComparer.Ordinal).ToList();
 
         var shapes = new List<NifShape>();
-        foreach (var shape in nif.GetShapes()) shapes.Add(BuildShape(nif, shape));
+        foreach (var shape in nif.GetShapes()) shapes.Add(BuildShape(nif, shape, isSe));
 
         return new NifInspect(
             version.VersionString ?? "", user, stream, isSe,
             blockCount, blockTypes,
             nif.HasUnknownBlocks, unknownDistinct,
-            shapes, BuildNodeTree(nif), ReadHeaderStrings(header));
+            shapes, BuildNodeTree(nif, isSe), ReadHeaderStrings(header));
     }
 
     /// <summary>One shape's N2-whitelist values. Every ref is read DIRECTLY off the shape (the SE-safe path); the
     /// partition list is present only for a BSDismember skin instance, alpha only when the shape carries an alpha
     /// property, and a texture slot only when its path is non-empty.</summary>
-    static NifShape BuildShape(NifFile nif, INiShape shape)
+    static NifShape BuildShape(NifFile nif, INiShape shape, bool isSe)
     {
         string name = shape.Name?.String ?? "";
         uint flags = 0; float scale = 1f;
         if (shape is NiAVObject av) { flags = av.Flags_ui; scale = av.Scale; }
+        var (defVal, defType) = isSe ? ResolveAvDefault(shape.GetType()) : (null, null);
 
         var partitions = new List<NifPartition>();
         if (shape.SkinInstanceRef is not null && nif.GetBlock(shape.SkinInstanceRef) is BSDismemberSkinInstance dis)
@@ -147,13 +176,13 @@ public static class NifService
             }
 
         var bones = nif.GetShapeBoneNames(shape) ?? new List<string>();
-        return new NifShape(name, flags, scale, partitions, alpha, textures, bones);
+        return new NifShape(name, flags, scale, shape.GetType().Name, defVal, defType, partitions, alpha, textures, bones);
     }
 
     /// <summary>Pre-order the NiNode hierarchy from the root(s), depth-annotated, each node with its NiAVObject flags.
     /// Only NiNode children are walked (shapes are covered by <see cref="NifInspect.Shapes"/>). A reference-identity
     /// visited set guards against a malformed file's cycle so the walk always terminates.</summary>
-    static List<NifNode> BuildNodeTree(NifFile nif)
+    static List<NifNode> BuildNodeTree(NifFile nif, bool isSe)
     {
         var nodes = new List<NifNode>();
         var seen = new HashSet<object>(ReferenceEqualityComparer.Instance);
@@ -162,7 +191,8 @@ public static class NifService
         {
             if (node is null || !seen.Add(node)) return;
             uint flags = node is NiAVObject av ? av.Flags_ui : 0u;
-            nodes.Add(new NifNode(depth, node.Name?.String ?? "", flags));
+            var (defVal, defType) = isSe ? ResolveAvDefault(node.GetType()) : (null, null);
+            nodes.Add(new NifNode(depth, node.Name?.String ?? "", flags, node.GetType().Name, defVal, defType));
             foreach (var cref in node.Children.References)
                 if (nif.GetBlock(cref) is NiNode child) Walk(child, depth + 1);
         }
@@ -218,11 +248,16 @@ public sealed record NifBlockTypeCount(string Type, int Count);
 
 /// <summary>One shape and its N2-whitelist values. <see cref="Partitions"/> is empty unless the shape has a
 /// BSDismember skin instance; <see cref="Alpha"/> is null unless it carries an alpha property; <see cref="Textures"/>
-/// lists only non-empty texture-set slots.</summary>
+/// lists only non-empty texture-set slots. <see cref="FlagsDefault"/> is the nif.xml-documented SSE default for the
+/// block's type (via <see cref="FlagsDefaultType"/>, the ancestor it came from), or null when none is documented / the
+/// mesh isn't SE — the renderer decodes <see cref="Flags"/> by deviation from it (nif.xml doesn't name the bits).</summary>
 public sealed record NifShape(
     string Name,
     uint Flags,
     float Scale,
+    string BlockType,
+    uint? FlagsDefault,
+    string? FlagsDefaultType,
     IReadOnlyList<NifPartition> Partitions,
     NifAlpha? Alpha,
     IReadOnlyList<NifTexture> Textures,
@@ -245,5 +280,7 @@ public sealed record NifAlpha(
 /// <summary>One embedded texture path at its BSShaderTextureSet slot index (0 diffuse, 1 normal, … 6 tint/detail, …).</summary>
 public sealed record NifTexture(int Slot, string Path);
 
-/// <summary>One node in the pre-order NiNode tree: its depth (0 = root), name, and NiAVObject flags.</summary>
-public sealed record NifNode(int Depth, string Name, uint Flags);
+/// <summary>One node in the pre-order NiNode tree: its depth (0 = root), name, NiAVObject flags, block type, and the
+/// nif.xml-documented SSE flag default for that type (via <see cref="FlagsDefaultType"/>) — null when none is documented
+/// / the mesh isn't SE. The renderer decodes <see cref="Flags"/> by deviation from the default, like it does for shapes.</summary>
+public sealed record NifNode(int Depth, string Name, uint Flags, string BlockType, uint? FlagsDefault, string? FlagsDefaultType);

--- a/src/housecarl-core/NifService.cs
+++ b/src/housecarl-core/NifService.cs
@@ -34,7 +34,7 @@ public static class NifService
     // bits (Flags is a plain uint there, and community docs note most are unused), so houseCARL decodes flags by
     // DEVIATION from these authoritative defaults rather than inventing bit-names — and always states the one bit nif.xml
     // DOES document: 0x80000 ("Skyrim lacks it sometimes; FO4 lacks it always"), the head-vs-hair-class signal.
-    static readonly IReadOnlyDictionary<string, uint> AvFlagsSseDefaults = new Dictionary<string, uint>(StringComparer.Ordinal)
+    internal static readonly IReadOnlyDictionary<string, uint> AvFlagsSseDefaults = new Dictionary<string, uint>(StringComparer.Ordinal)
     {
         ["NiNode"] = 0xE, ["NiLight"] = 0xE, ["BSMultiBoundNode"] = 0xE,
         ["BSTriShape"] = 0x8000E, ["BSSubIndexTriShape"] = 0xE, ["BSMeshLODTriShape"] = 0x100E,

--- a/src/housecarl-core/NifService.cs
+++ b/src/housecarl-core/NifService.cs
@@ -1,0 +1,249 @@
+using NiflySharp;
+using NiflySharp.Blocks;
+
+namespace HousecarlCore;
+
+/// <summary>
+/// The NIF-layer format service (Wave 1: read). Turns the RAW BYTES of a Skyrim mesh into the data model behind
+/// <c>housecarl_nif_inspect</c> — the header/version, the block census, the shapes with their N2-whitelist values
+/// (names, NiAVObject flags + scale, BSDismember partitions, alpha property, texture-set paths, bone lists), the node
+/// tree, and the header string table. PURE format logic: bytes in, model out — it knows nothing of MO2, the VFS, or
+/// which mod won (that seam is <see cref="LoadOrderService"/>, which resolves the winning bytes and hands them here),
+/// so it is fully testable off a synthetic in-memory mesh with no live workspace (nif-service-guard).
+///
+/// Reads ride NiflySharp 1.0.0 (NuGet <c>Nifly</c>) — pure C#, source-generated from nifxml, spike-proven over 87,937
+/// workspace nifs (SPIKE_NIF_LAYER_2026-07-08: 99.98% loose / 100.00% vanilla parse, zero unknown blocks in any SE
+/// mesh). Library quirks coded around per the spike: the alpha/shader/skin refs are read DIRECTLY
+/// (<see cref="INiShape.AlphaPropertyRef"/> etc.) — NEVER via <c>NifFile.GetPropertyOfType&lt;T&gt;</c>, which NREs on
+/// SE-style shapes whose legacy <c>Properties</c> list is null.
+///
+/// Fail-loud (Q3, PRFAQ N6): a parse failure is a NAMED, recoverable outcome (<see cref="NifInspectOutcome.Error"/>),
+/// not a throw or a half-model — including NiflySharp's one strict-boolean rejection class, which houseCARL surfaces
+/// with the NifSkope remedy rather than hand-patching around. Unknown blocks are REPORTED (count + their real on-disk
+/// type names) and left intact — the model tells the truth about what it could and could not model.
+/// </summary>
+public static class NifService
+{
+    // Skyrim SE header identity: NIF 20.2.0.7, user version 12, stream version 100 (LE = stream 83, FO4 = 130).
+    const uint SkyrimSeUserVersion = 12;
+    const uint SkyrimSeStreamVersion = 100;
+
+    /// <summary>Inspect a mesh from its raw bytes. Returns the model on success, or a named error (Q3) — a parse the
+    /// library rejects, an empty buffer, or a structure read that failed after a clean load. Never throws for an
+    /// expected bad-file condition; never returns a partial model.</summary>
+    public static NifInspectOutcome Inspect(byte[] bytes)
+    {
+        if (bytes is null || bytes.Length == 0)
+            return new NifInspectOutcome(null, "the mesh is empty (0 bytes) — nothing to inspect.");
+
+        var nif = new NifFile();
+        try
+        {
+            using var ms = new MemoryStream(bytes, writable: false);
+            int rc = nif.Load(ms);
+            if (rc != 0)
+                return new NifInspectOutcome(null,
+                    $"NiflySharp could not parse this mesh (Load returned {rc}) — it may be truncated, not a NIF, or a " +
+                    "format the library rejects. If NifSkope opens it, it is a valid-but-nonstandard file houseCARL will not guess at.");
+        }
+        catch (Exception ex)
+        {
+            return new NifInspectOutcome(null, DescribeLoadException(ex));
+        }
+
+        try
+        {
+            return new NifInspectOutcome(Build(nif), null);
+        }
+        catch (Exception ex)
+        {
+            // The file loaded but reading its structure threw — a real defect surface, not an expected bad file. Fail
+            // loud with the type + message; never hand back a half-built model (Q3).
+            return new NifInspectOutcome(null, $"the mesh parsed but reading its structure failed — {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>Turn a load exception into a named, actionable error. NiflySharp's one strict-boolean rejection class
+    /// (the spike's 13 loud failures — "Byte value for boolean is > 2!", a nonstandard byte some exporters write) is
+    /// called out by name with the NifSkope remedy, so the tool never reads as a silent "absent" and houseCARL never
+    /// hand-patches around the strict read.</summary>
+    static string DescribeLoadException(Exception ex)
+    {
+        var m = ex.Message ?? "";
+        if (m.Contains("boolean", StringComparison.OrdinalIgnoreCase))
+            return "NiflySharp refused this mesh: a boolean field holds a non-0/1 byte, which the library rejects strictly " +
+                   "(some exporters write it). The file is otherwise a valid SE mesh — NifSkope can open it — and houseCARL " +
+                   $"will not hand-patch around the strict read. ({ex.GetType().Name}: {m})";
+        return $"NiflySharp threw while parsing this mesh — {ex.GetType().Name}: {m}";
+    }
+
+    static NifInspect Build(NifFile nif)
+    {
+        var header = nif.Header;
+        var version = header.Version;
+        uint user = version.UserVersion;
+        uint stream = version.StreamVersion;
+        bool isSe = user == SkyrimSeUserVersion && stream == SkyrimSeStreamVersion;
+
+        int blockCount = header.BlockCount;
+        var blocks = nif.Blocks;   // List<INiObject>, indexed by block id (parallel to Header.GetBlockTypeNameById)
+
+        // Block census by ON-DISK type name (what xEdit/NifSkope show) — this also names unknown blocks faithfully,
+        // where GetType().Name would flatten every one of them to "NiUnknown".
+        var typeById = new string[blockCount];
+        for (int i = 0; i < blockCount; i++) typeById[i] = header.GetBlockTypeNameById(i) ?? "?";
+        var blockTypes = typeById
+            .GroupBy(t => t)
+            .Select(g => new NifBlockTypeCount(g.Key, g.Count()))
+            .OrderByDescending(c => c.Count).ThenBy(c => c.Type, StringComparer.Ordinal)
+            .ToList();
+
+        // Unknown blocks reported by their real on-disk type (preserved-but-opaque — PRFAQ N6). GetType() on a
+        // NiUnknown is just "NiUnknown"; the informative name lives in the header's block-type table.
+        var unknownTypes = new List<string>();
+        for (int i = 0; i < blocks.Count && i < blockCount; i++)
+            if (blocks[i] is NiUnknown) unknownTypes.Add(typeById[i]);
+        var unknownDistinct = unknownTypes.Distinct(StringComparer.Ordinal).OrderBy(t => t, StringComparer.Ordinal).ToList();
+
+        var shapes = new List<NifShape>();
+        foreach (var shape in nif.GetShapes()) shapes.Add(BuildShape(nif, shape));
+
+        return new NifInspect(
+            version.VersionString ?? "", user, stream, isSe,
+            blockCount, blockTypes,
+            nif.HasUnknownBlocks, unknownDistinct,
+            shapes, BuildNodeTree(nif), ReadHeaderStrings(header));
+    }
+
+    /// <summary>One shape's N2-whitelist values. Every ref is read DIRECTLY off the shape (the SE-safe path); the
+    /// partition list is present only for a BSDismember skin instance, alpha only when the shape carries an alpha
+    /// property, and a texture slot only when its path is non-empty.</summary>
+    static NifShape BuildShape(NifFile nif, INiShape shape)
+    {
+        string name = shape.Name?.String ?? "";
+        uint flags = 0; float scale = 1f;
+        if (shape is NiAVObject av) { flags = av.Flags_ui; scale = av.Scale; }
+
+        var partitions = new List<NifPartition>();
+        if (shape.SkinInstanceRef is not null && nif.GetBlock(shape.SkinInstanceRef) is BSDismemberSkinInstance dis)
+            foreach (var p in dis.Partitions)
+                partitions.Add(new NifPartition((int)p.BodyPart, p.BodyPart.ToString(), (int)p.PartFlag));
+
+        NifAlpha? alpha = null;
+        if (shape.HasAlphaProperty && nif.GetBlock<NiAlphaProperty>(shape.AlphaPropertyRef) is { } ap)
+        {
+            var f = ap.Flags;
+            alpha = new NifAlpha(f.Value, f.AlphaBlend, f.SourceBlendMode.ToString(), f.DestinationBlendMode.ToString(),
+                                 f.AlphaTest, f.TestFunc.ToString(), ap.Threshold);
+        }
+
+        var textures = new List<NifTexture>();
+        var shader = nif.GetShader(shape);
+        if (shader?.TextureSetRef is not null && nif.GetBlock(shader.TextureSetRef) is BSShaderTextureSet ts)
+            for (int i = 0; i < ts.Textures.Count; i++)
+            {
+                var c = ts.Textures[i]?.Content;
+                if (!string.IsNullOrEmpty(c)) textures.Add(new NifTexture(i, c));
+            }
+
+        var bones = nif.GetShapeBoneNames(shape) ?? new List<string>();
+        return new NifShape(name, flags, scale, partitions, alpha, textures, bones);
+    }
+
+    /// <summary>Pre-order the NiNode hierarchy from the root(s), depth-annotated, each node with its NiAVObject flags.
+    /// Only NiNode children are walked (shapes are covered by <see cref="NifInspect.Shapes"/>). A reference-identity
+    /// visited set guards against a malformed file's cycle so the walk always terminates.</summary>
+    static List<NifNode> BuildNodeTree(NifFile nif)
+    {
+        var nodes = new List<NifNode>();
+        var seen = new HashSet<object>(ReferenceEqualityComparer.Instance);
+
+        void Walk(NiNode node, int depth)
+        {
+            if (node is null || !seen.Add(node)) return;
+            uint flags = node is NiAVObject av ? av.Flags_ui : 0u;
+            nodes.Add(new NifNode(depth, node.Name?.String ?? "", flags));
+            foreach (var cref in node.Children.References)
+                if (nif.GetBlock(cref) is NiNode child) Walk(child, depth + 1);
+        }
+
+        foreach (var root in nif.GetRootNodes()) Walk(root, 0);
+        return nodes;
+    }
+
+    /// <summary>The header string table (shape/node/bone names, material and .tri/BODYTRI/physics-xml paths). The table
+    /// is a flat, contiguous list; <c>GetString(i)</c> returns "" — never null — once past the end, so we read from 0
+    /// until the first empty slot. A legitimately-empty entry ends the read early: an HONEST bound (the high-value
+    /// strings sit contiguous at the front), never a silent wrong answer. Capped so a corrupt count cannot spin.</summary>
+    static List<string> ReadHeaderStrings(NiHeader header)
+    {
+        var strings = new List<string>();
+        const int cap = 8192;
+        for (int i = 0; i < cap; i++)
+        {
+            var s = header.GetString(i);
+            if (string.IsNullOrEmpty(s)) break;
+            strings.Add(s);
+        }
+        return strings;
+    }
+}
+
+// ======================================================================
+//  NIF-layer data model — the format-level result of an inspect (core; the service layer wraps it with VFS info).
+// ======================================================================
+
+/// <summary>The outcome of <see cref="NifService.Inspect"/>: exactly one of <see cref="Inspect"/> (success) or
+/// <see cref="Error"/> (a named, recoverable parse/read failure — Q3). Never both, never neither.</summary>
+public sealed record NifInspectOutcome(NifInspect? Inspect, string? Error);
+
+/// <summary>Everything <see cref="NifService.Inspect"/> can model about a mesh, built in full (a single mesh is
+/// sub-second — the renderer chooses which sections to show). <see cref="IsSkyrimSE"/> is the header identity
+/// (user 12 / stream 100); <see cref="UnknownBlockTypes"/> names any preserved-but-opaque block by its on-disk type.</summary>
+public sealed record NifInspect(
+    string VersionString,
+    uint UserVersion,
+    uint StreamVersion,
+    bool IsSkyrimSE,
+    int BlockCount,
+    IReadOnlyList<NifBlockTypeCount> BlockTypes,
+    bool HasUnknownBlocks,
+    IReadOnlyList<string> UnknownBlockTypes,
+    IReadOnlyList<NifShape> Shapes,
+    IReadOnlyList<NifNode> Nodes,
+    IReadOnlyList<string> HeaderStrings);
+
+/// <summary>One block type and how many of it the mesh has, by the on-disk (xEdit/NifSkope) type name.</summary>
+public sealed record NifBlockTypeCount(string Type, int Count);
+
+/// <summary>One shape and its N2-whitelist values. <see cref="Partitions"/> is empty unless the shape has a
+/// BSDismember skin instance; <see cref="Alpha"/> is null unless it carries an alpha property; <see cref="Textures"/>
+/// lists only non-empty texture-set slots.</summary>
+public sealed record NifShape(
+    string Name,
+    uint Flags,
+    float Scale,
+    IReadOnlyList<NifPartition> Partitions,
+    NifAlpha? Alpha,
+    IReadOnlyList<NifTexture> Textures,
+    IReadOnlyList<string> Bones);
+
+/// <summary>One BSDismember partition: the body-part id, its decoded enum name (e.g. SBP_30_HEAD), and the part flags.</summary>
+public sealed record NifPartition(int BodyPartId, string BodyPartName, int PartFlags);
+
+/// <summary>An NiAlphaProperty decoded: the raw 16-bit flags word plus the semantic pieces (blend on/off + source and
+/// destination blend functions, alpha test on/off + test function, and the 0–255 threshold).</summary>
+public sealed record NifAlpha(
+    ushort Flags,
+    bool Blend,
+    string SourceBlendMode,
+    string DestinationBlendMode,
+    bool Test,
+    string TestFunction,
+    byte Threshold);
+
+/// <summary>One embedded texture path at its BSShaderTextureSet slot index (0 diffuse, 1 normal, … 6 tint/detail, …).</summary>
+public sealed record NifTexture(int Slot, string Path);
+
+/// <summary>One node in the pre-order NiNode tree: its depth (0 = root), name, and NiAVObject flags.</summary>
+public sealed record NifNode(int Depth, string Name, uint Flags);

--- a/src/housecarl-core/housecarl-core.csproj
+++ b/src/housecarl-core/housecarl-core.csproj
@@ -27,6 +27,10 @@
   <ItemGroup>
     <!-- The reflection target the extracted cores bind against. Pinned 0.53.1 (spike-proven), matching both consumers. -->
     <PackageReference Include="Mutagen.Bethesda.Skyrim" Version="0.53.1" />
+    <!-- The NIF layer's asset-internal reader/writer. Pure C#, GPL-3.0 (compatible with our GPL-3.0-only), source-
+         generated from nifxml = coverage by construction. Pinned 1.0.0 (spike-proven over 87,937 workspace nifs —
+         SPIKE_NIF_LAYER_2026-07-08); bump deliberately. Notices: THIRD-PARTY-NOTICES.txt (GPL-3.0 block). -->
+    <PackageReference Include="Nifly" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -100,6 +100,10 @@ public static class CiAll
         ("mo2instance-probe", Mo2InstanceProbe.RunProbe),
         ("atomic-commit-guard", AtomicCommitProbe.RunGuard),
         ("place-asset-guard", PlaceAssetProbe.RunGuard),
+        // NIF layer Wave 1: NifService.Inspect decodes an authored SE mesh's N2-whitelist values (version, census, node
+        // tree, shape flags/scale, dismember partitions, alpha) and refuses a bad file loud. Self-contained (the fixture
+        // is authored in-memory via NiflySharp); the spike §5 facegen smoke arm is existence-gated (SKIPs off-corpus).
+        ("nif-service-guard", NifServiceGuardProbe.RunGuard),
         ("strings-decision-guard", StringsDecisionProbe.RunGuard),
         ("assetlink-write-guard", AssetLinkWriteProbe.RunGuard),
         // The two coercion COMPLETENESS proofs, now CI guards (were manual-only — the coerce-audit blind spot that

--- a/src/housecarl-generator/NifServiceGuardProbe.cs
+++ b/src/housecarl-generator/NifServiceGuardProbe.cs
@@ -82,7 +82,12 @@ internal static class NifServiceGuardProbe
                       $"BSDismember partitions decode to SBP_* names + flags — [{string.Join(", ", shape.Partitions.Select(p => p.BodyPartId + " " + p.BodyPartName + " f" + p.PartFlags))}]");
                 Check(shape.Alpha is { Flags: 0x12ED, Blend: true, Test: true, Threshold: 128 },
                       $"alpha property decodes (0x12ED, blend+test, thr 128) — {(shape.Alpha is null ? "NONE" : $"0x{shape.Alpha.Flags:X4} blend={shape.Alpha.Blend} test={shape.Alpha.Test} thr={shape.Alpha.Threshold}")}");
+                Check(shape.BlockType == "BSTriShape" && shape.FlagsDefault == 0x8000E && shape.FlagsDefaultType == "BSTriShape",
+                      $"shape flag default resolved from nif.xml (BSTriShape → 0x8000E) — {shape.BlockType}/{(shape.FlagsDefault is { } fd ? "0x" + fd.ToString("X") : "none")}");
             }
+            var childA = nif.Nodes.FirstOrDefault(n => n.Name == "GuardChildA");
+            Check(childA is { BlockType: "NiNode", FlagsDefault: 0xE, FlagsDefaultType: "NiNode" },
+                  $"node flag default resolved from nif.xml (NiNode → 0xE) — {(childA is null ? "MISSING" : childA.BlockType + "/" + (childA.FlagsDefault is { } nd ? "0x" + nd.ToString("X") : "none"))}");
         }
 
         // ---- refusal arms (Q3): a bad file is a named error, never a throw or a half-model ----
@@ -127,6 +132,12 @@ internal static class NifServiceGuardProbe
         var unkSec = NifWire.Render(FakeData(FakeInspect(1, 0, false, Array.Empty<string>()), null), summaryOnly, new[] { "bogus" }, 80_000);
         Check(unkSec.Contains("unrecognized section"), "an unrecognized sections= token is surfaced, never silently ignored");
 
+        // flag decode: a shape at 0x400000E vs the BSTriShape default 0x8000E → 0x80000 clear (missing), +0x4000000 extra.
+        var shapesSec = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "shapes" };
+        var decoded = NifWire.Render(FakeData(FakeInspect(1, 0, false, Array.Empty<string>()), null), shapesSec, Array.Empty<string>(), 80_000);
+        Check(decoded.Contains("0x80000 clear") && decoded.Contains("vs BSTriShape default 0x8000E") && decoded.Contains("+0x4000000") && decoded.Contains("-0x80000"),
+              "NiAVObject flags decode by deviation from the nif.xml default + the 0x80000 bit (no invented bit-names)");
+
         // ---- corpus smoke (existence-gated): the spike §5 facegen truths — texture paths + bones on REAL data ----
         Console.WriteLine();
         Console.WriteLine("--- corpus smoke: spike §5 facegen regression truths (existence-gated) ---");
@@ -158,6 +169,12 @@ internal static class NifServiceGuardProbe
                 if (hair is not null) Check(hair.Alpha is { Flags: 0x12ED, Blend: true }, $"LucienHair alpha 0x12ED blend=true — {(hair.Alpha is null ? "NONE" : $"0x{hair.Alpha.Flags:X4} blend={hair.Alpha.Blend}")}");
                 if (hairline is not null) Check(hairline.Alpha is { Flags: 0x12EE, Blend: false, Test: true, Threshold: 180 },
                       $"LucienHairLine alpha 0x12EE blend=false test=true thr180 — {(hairline.Alpha is null ? "NONE" : $"0x{hairline.Alpha.Flags:X4} blend={hairline.Alpha.Blend} test={hairline.Alpha.Test} thr={hairline.Alpha.Threshold}")}");
+                // flag-default inheritance on LIVE data: facegen shapes are BSDynamicTriShape (no own nif.xml default) →
+                // the resolver must walk to the BSTriShape parent's 0x8000E. Proves the inheritance walk on a real mesh.
+                var dyn = fg.Shapes.FirstOrDefault(x => x.BlockType == "BSDynamicTriShape");
+                if (dyn is not null)
+                    Check(dyn.FlagsDefault == 0x8000E && dyn.FlagsDefaultType == "BSTriShape",
+                          $"a real BSDynamicTriShape inherits the BSTriShape flag default 0x8000E — 0x{(dyn.FlagsDefault is { } d ? d.ToString("X") : "none")} from {dyn.FlagsDefaultType ?? "(none)"}");
             }
         }
 
@@ -179,12 +196,12 @@ internal static class NifServiceGuardProbe
             if (i < withPartitions)
                 for (int p = 0; p < partsPerShape; p++)
                     parts.Add(new NifPartition(30 + p, "SBP_" + (30 + p) + "_PART", 257));
-            shapes.Add(new NifShape("Shape" + i, 0x400000E, 1f, parts, null, new List<NifTexture>(), new List<string>()));
+            shapes.Add(new NifShape("Shape" + i, 0x400000E, 1f, "BSTriShape", 0x8000E, "BSTriShape", parts, null, new List<NifTexture>(), new List<string>()));
         }
         return new NifInspect("20.2.0.7", 12, 100, true, totalShapes + 1,
             new List<NifBlockTypeCount> { new("BSTriShape", totalShapes), new("NiNode", 1) },
             hasUnknown, unknownTypes,
-            shapes, new List<NifNode> { new(0, "Root", 0xE) }, new List<string> { "Root", "Shape0" });
+            shapes, new List<NifNode> { new(0, "Root", 0xE, "NiNode", 0xE, "NiNode") }, new List<string> { "Root", "Shape0" });
     }
 
     /// <summary>Wrap an inspect model (or an error) in the service-layer <see cref="NifInspectData"/> with a two-provider

--- a/src/housecarl-generator/NifServiceGuardProbe.cs
+++ b/src/housecarl-generator/NifServiceGuardProbe.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using HousecarlCore;
+using HousecarlMcp;
 using NiflySharp;
 using NiflySharp.Blocks;
 
@@ -92,6 +93,40 @@ internal static class NifServiceGuardProbe
         var garbage = NifService.Inspect(Encoding.ASCII.GetBytes("this is plainly not a NIF file, just ASCII text padding padding padding."));
         Check(garbage.Inspect is null && garbage.Error is not null, $"non-NIF garbage → named error, not a throw — {garbage.Error ?? "(none!)"}");
 
+        // ---- render layer (NifWire.Render via synthetic NifInspectData — the AssetStatusProbe G-layer pattern) ----
+        Console.WriteLine();
+        Console.WriteLine("--- render: alarms-first, error/provider chain, filtered omitted-count, unknown-empty edge ---");
+        var summaryOnly = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        var ok = NifWire.Render(FakeData(FakeInspect(3, 1, false, Array.Empty<string>()), null), summaryOnly, Array.Empty<string>(), 80_000);
+        Check(ok.Contains("read from: ModA") && ok.Contains("20.2.0.7") && ok.Contains("[Skyrim SE]") && ok.Contains("Shape0"),
+              "success render carries winner + version + SE flag + shape names");
+
+        var abs = NifWire.Render(FakeData(null, "ABSENT — no active mod or BSA provides this mesh path.",
+                                          bsaFailures: new[] { "Bad.bsa (loaded by P.esp): truncated" }), summaryOnly, Array.Empty<string>(), 80_000);
+        Check(abs.Contains("could NOT be read")
+              && abs.IndexOf("could NOT be read", StringComparison.Ordinal) < abs.IndexOf("ABSENT", StringComparison.Ordinal),
+              "the read-failure alarm renders BEFORE the ABSENT error (a Q3 alarm can't be buried)");
+        Check(abs.Contains("ModA (loose) > Base.bsa (BSA)"), "the error path still shows the winner→loser provider chain");
+
+        var amb = NifWire.Render(FakeData(FakeInspect(1, 0, false, Array.Empty<string>()), null, ambiguous: true), summaryOnly, Array.Empty<string>(), 80_000);
+        Check(amb.Contains("more than one source"), "ambiguity is surfaced as a note");
+
+        // finding #2: a cut INSIDE a filtered section counts the filtered remainder (≤2 of 4 shapes), never the total.
+        // 4 shapes, 2 with (30) partitions each; a small cap cuts after the first partition line → "1 more omitted",
+        // never "3"/"4 more omitted" (the pre-fix total-based count).
+        var wantParts = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "partitions" };
+        var cut = NifWire.Render(FakeData(FakeInspect(4, 2, false, Array.Empty<string>(), partsPerShape: 30), null), wantParts, Array.Empty<string>(), 400);
+        Check(cut.Contains("more omitted") && !cut.Contains("3 more omitted") && !cut.Contains("4 more omitted"),
+              $"a filtered-section cut counts the FILTERED remainder, not the total shape count — {(cut.Contains("more omitted") ? "cut fired, remainder bounded" : "NO CUT (retune)")}");
+
+        // finding #3: HasUnknownBlocks true but no named types → 'present', never a bare '0 type(s) —'.
+        var ue = NifWire.Render(FakeData(FakeInspect(1, 0, true, Array.Empty<string>()), null), summaryOnly, Array.Empty<string>(), 80_000);
+        Check(ue.Contains("unknown blocks: present") && !ue.Contains("0 type(s)"), "HasUnknownBlocks with no named types renders 'present', not '0 type(s)'");
+
+        var unkSec = NifWire.Render(FakeData(FakeInspect(1, 0, false, Array.Empty<string>()), null), summaryOnly, new[] { "bogus" }, 80_000);
+        Check(unkSec.Contains("unrecognized section"), "an unrecognized sections= token is surfaced, never silently ignored");
+
         // ---- corpus smoke (existence-gated): the spike §5 facegen truths — texture paths + bones on REAL data ----
         Console.WriteLine();
         Console.WriteLine("--- corpus smoke: spike §5 facegen regression truths (existence-gated) ---");
@@ -132,6 +167,34 @@ internal static class NifServiceGuardProbe
     }
 
     static bool CensusHas(NifInspect nif, string type, int count) => nif.BlockTypes.Any(t => t.Type == type && t.Count == count);
+
+    /// <summary>A synthetic inspect model for the render-layer arms (no file needed): <paramref name="totalShapes"/>
+    /// shapes, the first <paramref name="withPartitions"/> of them carrying <paramref name="partsPerShape"/> partitions.</summary>
+    static NifInspect FakeInspect(int totalShapes, int withPartitions, bool hasUnknown, IReadOnlyList<string> unknownTypes, int partsPerShape = 2)
+    {
+        var shapes = new List<NifShape>();
+        for (int i = 0; i < totalShapes; i++)
+        {
+            var parts = new List<NifPartition>();
+            if (i < withPartitions)
+                for (int p = 0; p < partsPerShape; p++)
+                    parts.Add(new NifPartition(30 + p, "SBP_" + (30 + p) + "_PART", 257));
+            shapes.Add(new NifShape("Shape" + i, 0x400000E, 1f, parts, null, new List<NifTexture>(), new List<string>()));
+        }
+        return new NifInspect("20.2.0.7", 12, 100, true, totalShapes + 1,
+            new List<NifBlockTypeCount> { new("BSTriShape", totalShapes), new("NiNode", 1) },
+            hasUnknown, unknownTypes,
+            shapes, new List<NifNode> { new(0, "Root", 0xE) }, new List<string> { "Root", "Shape0" });
+    }
+
+    /// <summary>Wrap an inspect model (or an error) in the service-layer <see cref="NifInspectData"/> with a two-provider
+    /// winner→loser chain — the input to <see cref="NifWire.Render"/>.</summary>
+    static NifInspectData FakeData(NifInspect? inspect, string? error, bool ambiguous = false, IReadOnlyList<string>? bsaFailures = null)
+    {
+        var provs = new List<NifProvider> { new("ModA", "loose"), new("Base.bsa", "BSA") };
+        return new NifInspectData("meshes\\test.nif", inspect is null ? null : provs[0], provs, ambiguous,
+            bsaFailures ?? Array.Empty<string>(), false, Array.Empty<string>(), "Default", inspect, error);
+    }
 
     /// <summary>Author a minimal but genuine Skyrim SE mesh in-memory (the spike's CreateAndSave_SE recipe): an SE
     /// header, a 3-level NiNode tree with names + flags, and one BSTriShape carrying a name/flags/scale, two BSDismember

--- a/src/housecarl-generator/NifServiceGuardProbe.cs
+++ b/src/housecarl-generator/NifServiceGuardProbe.cs
@@ -90,6 +90,15 @@ internal static class NifServiceGuardProbe
                   $"node flag default resolved from nif.xml (NiNode → 0xE) — {(childA is null ? "MISSING" : childA.BlockType + "/" + (childA.FlagsDefault is { } nd ? "0x" + nd.ToString("X") : "none"))}");
         }
 
+        // ---- transcription lock: pin distinctive nif.xml SSE flag-defaults so a future edit can't quietly corrupt one ----
+        // (the table is a hand-transcription from nif.xml; the resolver arms above only exercise BSTriShape/NiNode, so
+        // the other entries ride on this direct check — review hardening note.)
+        var defs = NifService.AvFlagsSseDefaults;
+        Check(defs["BSTriShape"] == 0x8000E && defs["NiNode"] == 0xE && defs["BSLeafAnimNode"] == 0x808000E
+              && defs["BSMeshLODTriShape"] == 0x100E && defs["BSOrderedNode"] == 0x8200E && defs["BSLODTriShape"] == 0x800000E
+              && defs["BSTreeNode"] == 0x8080E && defs["BSBlastNode"] == 0x8000F && defs["BSMultiBoundNode"] == 0xE,
+              "nif.xml SSE flag-default transcription intact (distinctive entries pinned against drift)");
+
         // ---- refusal arms (Q3): a bad file is a named error, never a throw or a half-model ----
         Console.WriteLine();
         Console.WriteLine("--- refusal: a bad file is surfaced, never a silent/partial answer ---");

--- a/src/housecarl-generator/NifServiceGuardProbe.cs
+++ b/src/housecarl-generator/NifServiceGuardProbe.cs
@@ -1,0 +1,176 @@
+using System.Text;
+using HousecarlCore;
+using NiflySharp;
+using NiflySharp.Blocks;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// NifService guard (NIF layer Wave 1). Proves <see cref="NifService.Inspect"/> — the byte-level mesh reader behind
+/// housecarl_nif_inspect — decodes every N2-whitelist value correctly and fails LOUD on a bad file.
+///
+/// Self-contained arms (always run — a synthetic SE mesh AUTHORED at probe time via NiflySharp itself, so NO
+/// third-party mesh ships in-repo; the spike's CreateAndSave_SE recipe, SPIKE_NIF_LAYER_2026-07-08 §7):
+///   • parse — the authored mesh loads clean (no error, no unknown blocks).
+///   • header — version 20.2.0.7, user 12 / stream 100, recognized as a Skyrim SE stream.
+///   • census — the on-disk block type histogram matches what was authored (3 NiNode, 1 BSTriShape, 1 dismember, 1 alpha).
+///   • node tree — pre-order depth + names + NiAVObject flags (root → child A → child B, depths 0/1/2).
+///   • strings — the header string table carries the authored node/shape names.
+///   • shape — name, NiAVObject flags (0x400000E), and scale (1.25) read exactly.
+///   • partitions — BSDismember body parts decode to their SBP_* enum names with the right part flags (30 HEAD, 31 HAIR).
+///   • alpha — the alpha property decodes: raw flags 0x12ED, blend + test on, threshold 128.
+///   • refusal — empty bytes and non-NIF garbage each return a NAMED error (Q3), never a throw or a half-model.
+///
+/// Corpus smoke (existence-gated — a REAL facegen mesh, the spike §5 regression truths for the values the synthetic
+/// fixture can't wire: texture-set paths + bone lists). Runs only when the file is present (arg 1, or env
+/// HOUSECARL_NIF_SMOKE, or the workspace default); SKIPs cleanly otherwise, so CI stays green without the corpus.
+///
+/// Run: dotnet run --project src/housecarl-generator nif-service-guard ["&lt;a-facegen.nif&gt;"]
+/// </summary>
+internal static class NifServiceGuardProbe
+{
+    // The spike §5 ground-truth mesh ('A makeover for Lucien'). Overridable by arg/env so nothing machine-specific is baked in.
+    const string DefaultSmoke = @"E:\Skyrim Modding\ARR 2.0\mods\A makeover for Lucien\meshes\actors\character\FaceGenData\FaceGeom\lucien.esp\00005900.nif";
+
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" nif-service guard — mesh value decode (housecarl_nif_inspect)");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        // ---- self-contained: author a synthetic SE mesh in-memory, inspect it, assert every value ----
+        Console.WriteLine("--- synthetic SE mesh (authored at probe time — no third-party mesh in repo) ---");
+        var bytes = BuildSyntheticSe();
+        var outcome = NifService.Inspect(bytes);
+        Check(outcome.Error is null && outcome.Inspect is not null, $"the authored mesh parses clean — {outcome.Error ?? "ok"}");
+
+        if (outcome.Inspect is { } nif)
+        {
+            Check(nif.IsSkyrimSE && nif.UserVersion == 12 && nif.StreamVersion == 100,
+                  $"header identity: SE stream, user 12 / stream 100 — got user {nif.UserVersion} / stream {nif.StreamVersion}, SE={nif.IsSkyrimSE}");
+            Check(nif.VersionString.Contains("20.2.0.7"), $"version string is 20.2.0.7 — '{nif.VersionString}'");
+            Check(!nif.HasUnknownBlocks && nif.UnknownBlockTypes.Count == 0, "no unknown blocks in an authored SE mesh");
+            Check(nif.BlockCount == 6, $"block count 6 — {nif.BlockCount}");
+            Check(CensusHas(nif, "NiNode", 3) && CensusHas(nif, "BSTriShape", 1)
+                  && CensusHas(nif, "BSDismemberSkinInstance", 1) && CensusHas(nif, "NiAlphaProperty", 1),
+                  $"block census matches what was authored — {string.Join(", ", nif.BlockTypes.Select(t => t.Type + " x" + t.Count))}");
+
+            // node tree — pre-order depth + names + flags
+            Check(nif.Nodes.Count == 3
+                  && nif.Nodes[0] is { Name: "GuardRoot", Depth: 0 }
+                  && nif.Nodes.Any(n => n is { Name: "GuardChildA", Depth: 1 })
+                  && nif.Nodes.Any(n => n is { Name: "GuardChildB", Depth: 2 }),
+                  $"node tree walks root→A→B at depths 0/1/2 — [{string.Join(", ", nif.Nodes.Select(n => n.Name + "@" + n.Depth))}]");
+            Check(nif.Nodes.First(n => n.Name == "GuardChildA").Flags == 0x40000E, "a node's NiAVObject flags read exactly (0x40000E)");
+            Check(nif.HeaderStrings.Contains("GuardRoot") && nif.HeaderStrings.Contains("GuardShape"),
+                  $"the header string table carries the authored names — [{string.Join(", ", nif.HeaderStrings)}]");
+
+            // shape — name / flags / scale / partitions / alpha
+            var shape = nif.Shapes.FirstOrDefault(s => s.Name == "GuardShape");
+            Check(shape is not null, $"the authored shape is found — {(shape is null ? "MISSING" : "'GuardShape'")}");
+            if (shape is not null)
+            {
+                Check(shape.Flags == 0x400000E, $"shape NiAVObject flags 0x400000E — 0x{shape.Flags:X}");
+                Check(Math.Abs(shape.Scale - 1.25f) < 1e-6f, $"shape scale 1.25 — {shape.Scale}");
+                Check(shape.Partitions.Count == 2
+                      && shape.Partitions[0] is { BodyPartId: 30, BodyPartName: "SBP_30_HEAD", PartFlags: 257 }
+                      && shape.Partitions[1] is { BodyPartId: 31, BodyPartName: "SBP_31_HAIR", PartFlags: 257 },
+                      $"BSDismember partitions decode to SBP_* names + flags — [{string.Join(", ", shape.Partitions.Select(p => p.BodyPartId + " " + p.BodyPartName + " f" + p.PartFlags))}]");
+                Check(shape.Alpha is { Flags: 0x12ED, Blend: true, Test: true, Threshold: 128 },
+                      $"alpha property decodes (0x12ED, blend+test, thr 128) — {(shape.Alpha is null ? "NONE" : $"0x{shape.Alpha.Flags:X4} blend={shape.Alpha.Blend} test={shape.Alpha.Test} thr={shape.Alpha.Threshold}")}");
+            }
+        }
+
+        // ---- refusal arms (Q3): a bad file is a named error, never a throw or a half-model ----
+        Console.WriteLine();
+        Console.WriteLine("--- refusal: a bad file is surfaced, never a silent/partial answer ---");
+        var empty = NifService.Inspect(Array.Empty<byte>());
+        Check(empty.Inspect is null && empty.Error is not null, $"empty bytes → named error — {empty.Error ?? "(none!)"}");
+        var garbage = NifService.Inspect(Encoding.ASCII.GetBytes("this is plainly not a NIF file, just ASCII text padding padding padding."));
+        Check(garbage.Inspect is null && garbage.Error is not null, $"non-NIF garbage → named error, not a throw — {garbage.Error ?? "(none!)"}");
+
+        // ---- corpus smoke (existence-gated): the spike §5 facegen truths — texture paths + bones on REAL data ----
+        Console.WriteLine();
+        Console.WriteLine("--- corpus smoke: spike §5 facegen regression truths (existence-gated) ---");
+        var smoke = args.Length > 0 ? args[0] : (Environment.GetEnvironmentVariable("HOUSECARL_NIF_SMOKE") ?? DefaultSmoke);
+        if (!File.Exists(smoke))
+        {
+            Console.WriteLine($"  SKIP  no facegen mesh at '{smoke}' (pass one as arg 1 or set HOUSECARL_NIF_SMOKE). The synthetic arms above are self-contained.");
+        }
+        else
+        {
+            var s = NifService.Inspect(File.ReadAllBytes(smoke));
+            Check(s.Error is null && s.Inspect is not null, $"the facegen mesh parses clean — {s.Error ?? "ok"}");
+            if (s.Inspect is { } fg)
+            {
+                Check(fg.IsSkyrimSE && !fg.HasUnknownBlocks, "facegen is an SE mesh with zero unknown blocks");
+                var head = fg.Shapes.FirstOrDefault(x => x.Name == "LucienHead");
+                var hair = fg.Shapes.FirstOrDefault(x => x.Name == "LucienHair");
+                var hairline = fg.Shapes.FirstOrDefault(x => x.Name == "LucienHairLine");
+                Check(head is not null && hair is not null && hairline is not null,
+                      $"the §5 shapes are present — {string.Join(", ", fg.Shapes.Select(x => x.Name))}");
+                if (head is not null)
+                {
+                    Check(head.Flags == 0x400000E, $"LucienHead flags 0x400000E — 0x{head.Flags:X}");
+                    Check(head.Partitions.Any(p => p is { BodyPartId: 30, BodyPartName: "SBP_30_HEAD" }), "LucienHead has the HEAD partition (30)");
+                    Check(head.Textures.Any(t => t.Slot == 6 && t.Path.Contains(@"facetint\lucien.esp\00005900.dds", StringComparison.OrdinalIgnoreCase)),
+                          "LucienHead texture slot 6 is the facetint path (the RaceMenu tint case)");
+                    Check(head.Bones.Contains("NPC Head [Head]") && head.Bones.Contains("NPC Spine2 [Spn2]"), "LucienHead bone list reads (NPC Head / NPC Spine2)");
+                }
+                if (hair is not null) Check(hair.Alpha is { Flags: 0x12ED, Blend: true }, $"LucienHair alpha 0x12ED blend=true — {(hair.Alpha is null ? "NONE" : $"0x{hair.Alpha.Flags:X4} blend={hair.Alpha.Blend}")}");
+                if (hairline is not null) Check(hairline.Alpha is { Flags: 0x12EE, Blend: false, Test: true, Threshold: 180 },
+                      $"LucienHairLine alpha 0x12EE blend=false test=true thr180 — {(hairline.Alpha is null ? "NONE" : $"0x{hairline.Alpha.Flags:X4} blend={hairline.Alpha.Blend} test={hairline.Alpha.Test} thr={hairline.Alpha.Threshold}")}");
+            }
+        }
+
+        Console.WriteLine();
+        Console.WriteLine(fail == 0 ? "================ ALL PASS ================" : $"================ {fail} CHECK(S) FAILED ================");
+        return fail == 0 ? 0 : 1;
+    }
+
+    static bool CensusHas(NifInspect nif, string type, int count) => nif.BlockTypes.Any(t => t.Type == type && t.Count == count);
+
+    /// <summary>Author a minimal but genuine Skyrim SE mesh in-memory (the spike's CreateAndSave_SE recipe): an SE
+    /// header, a 3-level NiNode tree with names + flags, and one BSTriShape carrying a name/flags/scale, two BSDismember
+    /// partitions, and an alpha property. Every block is REFERENCED (parented / ref'd) so NiflySharp's save-time
+    /// unreferenced-block prune keeps them. Returns the saved bytes — the exact input shape housecarl_nif_inspect reads.</summary>
+    static byte[] BuildSyntheticSe()
+    {
+        var ver = new NiVersion { FileVersion = NiVersion.ToFile("20.2.0.7"), UserVersion = 12, StreamVersion = 100 };
+        var f = new NifFile();
+        f.Create(ver, withRootNode: true);
+        var root = f.GetRootNodes().First();
+        root.Name = new NiStringRef("GuardRoot");
+        root.Flags_ui = 0xE;
+
+        var childA = new NiNode { Name = new NiStringRef("GuardChildA"), Flags_ui = 0x40000E };
+        root.Children.AddBlockRef(f.AddBlock(childA));
+        var childB = new NiNode { Name = new NiStringRef("GuardChildB"), Flags_ui = 0x408000E };
+        childA.Children.AddBlockRef(f.AddBlock(childB));
+
+        var shape = new BSTriShape { Name = new NiStringRef("GuardShape"), Flags_ui = 0x400000E, Scale = 1.25f };
+        root.Children.AddBlockRef(f.AddBlock(shape));
+
+        var alpha = new NiAlphaProperty { Threshold = 128 };
+        alpha.Flags.Value = 0x12ED;
+        shape.AlphaPropertyRef = new NiBlockRef<NiAlphaProperty>(f.AddBlock(alpha));
+
+        var skin = new BSDismemberSkinInstance
+        {
+            Partitions = new List<NiflySharp.Structs.BodyPartList>
+            {
+                new() { BodyPart = (NiflySharp.Enums.BSDismemberBodyPartType)30, PartFlag = (NiflySharp.Enums.BSPartFlag)257 },
+                new() { BodyPart = (NiflySharp.Enums.BSDismemberBodyPartType)31, PartFlag = (NiflySharp.Enums.BSPartFlag)257 },
+            },
+        };
+        skin.NumPartitions = (uint)skin.Partitions.Count;
+        shape.SkinInstanceRef = new NiBlockRef<NiObject>(f.AddBlock(skin));
+
+        using var ms = new MemoryStream();
+        if (f.Save(ms) != 0) throw new InvalidOperationException("nif-service-guard: authoring the synthetic SE mesh failed to save");
+        return ms.ToArray();
+    }
+}

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -318,6 +318,74 @@ public sealed class LoadOrderService : IDisposable
         return slash < 0 ? "" : rel.Substring(pre.Length, slash - pre.Length);
     }
 
+    // ---- NIF layer Wave 1: read the data values inside a mesh (housecarl_nif_inspect) ----
+
+    /// <summary>Inspect the data values inside a Skyrim mesh (housecarl_nif_inspect): resolve the Data-relative
+    /// <paramref name="relPath"/> through the MO2 VFS to the WINNING copy (or a specific loser when <paramref name="mod"/>
+    /// is named), read that copy's bytes IN PROCESS (a loose file, or a single entry out of a BSA via native Mutagen — no
+    /// disk extraction), and hand them to <see cref="NifService.Inspect"/> for the header / block census / shapes /
+    /// partitions / alpha / textures / node tree / string table. Read-only. The asset-tool parity is carried through:
+    /// the full winner→loser provider chain (each tagged loose/BSA), the ambiguity flag, and the build-level Q3 caveats
+    /// (<see cref="AssetView.BsaFailures"/> / ReadIncomplete) ride along, so an ABSENT answer is never over-trusted. ONE
+    /// asset capture pins the whole call; the resolve + byte read + NIF parse run OUTSIDE <see cref="_gate"/> on the
+    /// handle-free captured view, so an inspect never serializes other tool calls behind its file I/O. A parse failure is
+    /// a NAMED outcome (<see cref="NifInspectData.Error"/>), never a throw or a half-model (Q3).</summary>
+    public NifInspectData NifInspect(string relPath, string? mod)
+    {
+        var rel = (relPath ?? "").Trim();
+        if (rel.Length == 0)
+            return NifInspectData.Fail("", "no mesh path given. Pass a Data-relative path, e.g. 'meshes\\actors\\character\\facegendata\\facegeom\\Skyrim.esm\\00000007.nif'.");
+
+        AssetResolver.AssetView view;
+        IReadOnlyList<string> warnings;
+        string profileName;
+        lock (_gate)
+        {
+            view = Assets.Capture();                              // build/refresh the asset resolver under the gate, ONCE
+            warnings = _assetWarnings;
+            profileName = _profileName;
+        }
+
+        // OUTSIDE the gate: the captured view is pinned + handle-free, so resolving + reading + parsing here can't race a
+        // concurrent refresh into wrongness and doesn't block other tools behind our file reads.
+        PlacementResolution place;
+        try { place = view.ResolveForPlacement(rel); }
+        catch (ArgumentException ex) { return NifInspectData.Fail(rel, $"invalid path — {ex.Message}"); }
+
+        var providers = place.Sources.Select(s => new NifProvider(s.ProviderName, KindLabel(s.Kind))).ToList();
+        bool readIncomplete = place.ReadIncomplete || view.ReadIncomplete;
+
+        if (place.Sources.Count == 0)
+            return new NifInspectData(rel, null, providers, place.Ambiguous, view.BsaFailures, readIncomplete, warnings, profileName, null,
+                "ABSENT — no active mod or BSA provides this mesh path" +
+                (readIncomplete ? " (and an archive failed to read this build, so this may be incomplete — see the read-failure note)." : "."));
+
+        // Pick the copy to read: the VFS winner by default, or a specific provider when mod= names one.
+        PlacementSource chosen;
+        if (!string.IsNullOrWhiteSpace(mod))
+        {
+            var pick = place.Sources.FirstOrDefault(s => s.ProviderName.Equals(mod!.Trim(), StringComparison.OrdinalIgnoreCase));
+            if (pick is null)
+                return new NifInspectData(rel, null, providers, place.Ambiguous, view.BsaFailures, readIncomplete, warnings, profileName, null,
+                    $"mod '{mod!.Trim()}' does not provide this path. Providers (winner first): {string.Join(", ", providers.Select(p => p.Name + " (" + p.Kind + ")"))}.");
+            chosen = pick;
+        }
+        else chosen = place.Sources[0];
+
+        var (bytes, readErr) = AssetResolver.ReadPlacementSource(chosen);
+        if (bytes is null)
+            return new NifInspectData(rel, new NifProvider(chosen.ProviderName, KindLabel(chosen.Kind)), providers, place.Ambiguous,
+                view.BsaFailures, readIncomplete, warnings, profileName, null, readErr ?? "could not read the resolved mesh bytes.");
+
+        var outcome = NifService.Inspect(bytes);
+        return new NifInspectData(rel, new NifProvider(chosen.ProviderName, KindLabel(chosen.Kind)), providers, place.Ambiguous,
+            view.BsaFailures, readIncomplete, warnings, profileName, outcome.Inspect, outcome.Error);
+    }
+
+    /// <summary>Render an <see cref="AssetKind"/> as the tool-facing label ("loose" / "BSA"). An explicit switch (not a
+    /// ternary) so a future AssetKind arm renders its real name, never a silent mislabel.</summary>
+    static string KindLabel(AssetKind k) => k switch { AssetKind.Bsa => "BSA", AssetKind.Loose => "loose", var other => other.ToString() };
+
     // ---- facegen-diagnostics Phase 3: place an asset so the correct copy WINS the VFS (housecarl_place_asset) ----
 
     /// <summary>Place one-or-more assets (FaceGen .nif/.dds, or any Data-relative file) into a NEW houseCARL-owned MO2 mod
@@ -3672,6 +3740,33 @@ public sealed record SkseInventoryData(
     bool ReadIncomplete,
     IReadOnlyList<string> Warnings,
     string ProfileName);
+
+/// <summary>One provider of a mesh path: the mod / "overwrite" / "Data" / BSA-filename, and whether it's a "loose" file
+/// or a "BSA" entry. Winner-first ordering lives in <see cref="NifInspectData.Providers"/>.</summary>
+public sealed record NifProvider(string Name, string Kind);
+
+/// <summary>The data behind housecarl_nif_inspect: the VFS resolution of a mesh path joined to the format-level
+/// <see cref="HousecarlCore.NifInspect"/> of the copy that was read. <see cref="Inspected"/> is the provider whose bytes
+/// were parsed (the winner, or the <c>mod=</c>-named copy); <see cref="Providers"/> is the FULL winner→loser chain
+/// (asset-tool parity), <see cref="Ambiguous"/> flags file-layer contention. The build-level Q3 caveats
+/// <see cref="BsaFailures"/> / <see cref="ReadIncomplete"/> and discovery <see cref="Warnings"/> ride along;
+/// <see cref="ProfileName"/> names the active profile. Exactly one of <see cref="Inspect"/> (the mesh model) and
+/// <see cref="Error"/> (ABSENT / bad path / unreadable / parse-refused — all named, Q3) is set on any given result.</summary>
+public sealed record NifInspectData(
+    string RelPath,
+    NifProvider? Inspected,
+    IReadOnlyList<NifProvider> Providers,
+    bool Ambiguous,
+    IReadOnlyList<string> BsaFailures,
+    bool ReadIncomplete,
+    IReadOnlyList<string> Warnings,
+    string ProfileName,
+    HousecarlCore.NifInspect? Inspect,
+    string? Error)
+{
+    public static NifInspectData Fail(string relPath, string error)
+        => new(relPath, null, Array.Empty<NifProvider>(), false, Array.Empty<string>(), false, Array.Empty<string>(), "", null, error);
+}
 
 /// <summary>One asset to PLACE (housecarl_place_asset / bulk). <see cref="AssetPath"/> is the resolved Data-relative
 /// DESTINATION (the tool computes it from a FormID+slot for FaceGen, or takes a raw path). <see cref="Source"/> is the

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -285,8 +285,8 @@ public sealed class LoadOrderService : IDisposable
             var place = view.ResolveForPlacement(rel);
             // The FULL conflict chain, winner-first (asset-tool parity): keep every provider + its loose/BSA kind, not just a count.
             var providers = place.Sources
-                .Select(s => new SkseProvider(s.ProviderName, s.Kind switch { AssetKind.Bsa => "BSA", AssetKind.Loose => "loose", var k => k.ToString() }))
-                .ToList();   // explicit switch (not a ternary): a future AssetKind arm renders its real name, never a silent "loose"
+                .Select(s => new SkseProvider(s.ProviderName, KindLabel(s.Kind)))   // shared kind→label helper (explicit switch, never a silent "loose")
+                .ToList();
             var winner = place.Sources.Count > 0 ? place.Sources[0] : null;
 
             if (isDll)

--- a/src/housecarl-mcp/NifTools.cs
+++ b/src/housecarl-mcp/NifTools.cs
@@ -26,7 +26,8 @@ public static class NifTools
          "mesh_path through Mod Organizer 2's virtual file system to the copy the game actually uses (loose beats BSA; among " +
          "BSAs the later-loaded plugin wins) and report, from that mesh: its header version + whether it is a Skyrim SE " +
          "stream; the block census (every block type and count); any UNKNOWN blocks (named + preserved, never silently " +
-         "dropped); and per shape — the shape name, the NiAVObject flags (hex) and scale, the BSDismember body-part " +
+         "dropped); and per shape — the shape name, the NiAVObject flags (hex, decoded by deviation from the type's " +
+         "documented default plus the 0x80000 bit) and scale, the BSDismember body-part " +
          "partitions (decoded to their SBP_* names), the alpha property (decoded blend / test / threshold), the embedded " +
          "texture-set paths, and the bone list; plus the node tree and the header string table. Use it to answer 'what " +
          "shapes / bones / textures / partitions / alpha does this mesh have', to read a facegen mesh's baked shape names " +
@@ -165,7 +166,8 @@ static class NifWire
         foreach (var s in nif.Shapes)
         {
             if (Cut(sb, cap, nif.Shapes.Count)) return;
-            sb.Append("  '").Append(s.Name).Append("'  flags 0x").Append(s.Flags.ToString("X")).Append("  scale ").Append(Fmt(s.Scale)).Append('\n');
+            sb.Append("  '").Append(s.Name).Append("'  flags ").Append(DescribeFlags(s.Flags, s.FlagsDefault, s.FlagsDefaultType, s.BlockType))
+              .Append("  scale ").Append(Fmt(s.Scale)).Append('\n');
             if (s.Partitions.Count > 0)
                 sb.Append("    partitions: ").Append(string.Join(", ", s.Partitions.Select(p => $"{p.BodyPartId} ({p.BodyPartName}, flags {p.PartFlags})"))).Append('\n');
             if (s.Alpha is not null)
@@ -214,7 +216,7 @@ static class NifWire
         {
             if (Cut(sb, cap, nif.Nodes.Count - shown)) return;
             sb.Append("  ").Append(new string(' ', n.Depth * 2)).Append(n.Name.Length > 0 ? n.Name : "(unnamed)")
-              .Append("  0x").Append(n.Flags.ToString("X")).Append('\n');
+              .Append("  ").Append(DescribeFlags(n.Flags, n.FlagsDefault, n.FlagsDefaultType, n.BlockType)).Append('\n');
             shown++;
         }
     }
@@ -234,6 +236,39 @@ static class NifWire
 
     static string AlphaLine(NifAlpha a)
         => $"flags 0x{a.Flags:X4}  blend={a.Blend} ({a.SourceBlendMode} -> {a.DestinationBlendMode})  test={a.Test} ({a.TestFunction})  threshold {a.Threshold}";
+
+    /// <summary>Render NiAVObject flags: raw hex + a by-construction decode. nif.xml does not name these bits, so we
+    /// decode by DEVIATION from the type's nif.xml-documented SSE default (<paramref name="def"/> from
+    /// <paramref name="defType"/>) — "= default", or the extra/missing bits vs it — and always state the one bit nif.xml
+    /// DOES document, 0x80000 (Skyrim sets it on some AV objects, FO4 never; the head-vs-hair signal). When no default is
+    /// documented for the type, the set-bit positions are listed instead (still exact, still no invented names).</summary>
+    static string DescribeFlags(uint flags, uint? def, string? defType, string blockType)
+    {
+        var sb = new StringBuilder("0x").Append(flags.ToString("X"));
+        sb.Append("  [0x80000 ").Append((flags & 0x80000) != 0 ? "set" : "clear");
+        if (def is { } d)
+        {
+            if (flags == d) sb.Append("; = ").Append(defType).Append(" default");
+            else
+            {
+                uint extra = flags & ~d, missing = d & ~flags;
+                sb.Append("; vs ").Append(defType).Append(" default 0x").Append(d.ToString("X")).Append(':');
+                if (extra != 0) sb.Append(" +0x").Append(extra.ToString("X"));
+                if (missing != 0) sb.Append(" -0x").Append(missing.ToString("X"));
+            }
+        }
+        else
+            sb.Append("; no documented default for ").Append(blockType).Append("; bits ").Append(BitList(flags));
+        return sb.Append(']').ToString();
+    }
+
+    /// <summary>The set bit positions of a 32-bit flags word, comma-joined (e.g. "1,2,3,26"), or "none".</summary>
+    static string BitList(uint f)
+    {
+        var bits = new List<int>();
+        for (int i = 0; i < 32; i++) if ((f & (1u << i)) != 0) bits.Add(i);
+        return bits.Count == 0 ? "none" : string.Join(",", bits);
+    }
 
     /// <summary>Append "<label><a, b, c>" as one line, cut with an explicit notice if it would blow the cap (Q3).</summary>
     static void AppendClampedList(StringBuilder sb, string label, IEnumerable<string> items, int cap)

--- a/src/housecarl-mcp/NifTools.cs
+++ b/src/housecarl-mcp/NifTools.cs
@@ -121,6 +121,10 @@ static class NifWire
 
         if (!nif.HasUnknownBlocks)
             sb.Append("  unknown blocks: none\n");
+        else if (nif.UnknownBlockTypes.Count == 0)
+            // The library flagged unknown blocks but none resolved to a NiUnknown we could name (theoretical) — say so
+            // honestly rather than render a bare "0 type(s) —".
+            sb.Append("  unknown blocks: present (types not named — preserved intact, reported not modeled)\n");
         else
             sb.Append("  unknown blocks: ").Append(nif.UnknownBlockTypes.Count).Append(" type(s) — ")
               .Append(string.Join(", ", nif.UnknownBlockTypes))
@@ -176,10 +180,11 @@ static class NifWire
     static void RenderPerShape(StringBuilder sb, NifInspect nif, int cap, string title, Func<NifShape, bool> has, Func<NifShape, string> line)
     {
         sb.Append("\n--- ").Append(title).Append(" ---\n");
+        var matched = nif.Shapes.Where(has).ToList();   // count the omitted remainder over the FILTERED subset, not the total shapes
         int shown = 0;
-        foreach (var s in nif.Shapes.Where(has))
+        foreach (var s in matched)
         {
-            if (Cut(sb, cap, nif.Shapes.Count - shown)) return;
+            if (Cut(sb, cap, matched.Count - shown)) return;
             sb.Append("  '").Append(s.Name).Append("': ").Append(line(s)).Append('\n');
             shown++;
         }
@@ -189,10 +194,11 @@ static class NifWire
     static void RenderPaths(StringBuilder sb, NifInspect nif, int cap)
     {
         sb.Append("\n--- paths (embedded texture-set slots; material/.tri/physics-xml refs appear under sections=strings) ---\n");
+        var textured = nif.Shapes.Where(s => s.Textures.Count > 0).ToList();   // omitted remainder counts the FILTERED subset, not total shapes
         int shown = 0;
-        foreach (var s in nif.Shapes.Where(s => s.Textures.Count > 0))
+        foreach (var s in textured)
         {
-            if (Cut(sb, cap, nif.Shapes.Count - shown)) return;
+            if (Cut(sb, cap, textured.Count - shown)) return;
             sb.Append("  '").Append(s.Name).Append("':\n");
             foreach (var t in s.Textures) sb.Append("    tex[").Append(t.Slot).Append("]: ").Append(t.Path).Append('\n');
             shown++;

--- a/src/housecarl-mcp/NifTools.cs
+++ b/src/housecarl-mcp/NifTools.cs
@@ -1,0 +1,284 @@
+using System.ComponentModel;
+using System.Text;
+using HousecarlCore;
+using ModelContextProtocol.Server;
+
+namespace HousecarlMcp;
+
+/// <summary>
+/// houseCARL NIF tool. Read-only. Reads the DATA VALUES inside a Skyrim mesh (.nif) — header/version, the block census,
+/// each shape's name + NiAVObject flags + scale, its BSDismember partitions, its alpha property, its texture-set paths
+/// and bone list, the node tree, and the header string table — resolving the Data-relative path through MO2's VFS to the
+/// WINNING copy first (loose beats BSA), the same file-layer precedence the asset tools use. Rides NiflySharp
+/// (source-generated from nifxml = coverage by construction); reads BSA-packed meshes straight from archive bytes with
+/// no disk extraction, and holds no file handles at rest. This is the asset-INTERNAL counterpart to housecarl_asset_status
+/// (which answers WHICH file wins): once you know the winning mesh, this answers WHAT IS INSIDE it. Data values in; geometry
+/// / visual content stays out of this capability by design (PRFAQ NIF-layer scope).
+/// </summary>
+[McpServerToolType]
+public static class NifTools
+{
+    static readonly string[] KnownSections = { "shapes", "partitions", "alpha", "paths", "strings", "nodes", "bones" };
+
+    [McpServerTool(Name = "housecarl_nif_inspect", ReadOnly = true, Title = "Inspect the data values inside a Skyrim mesh (.nif)"),
+     Description(
+         "Read the DATA VALUES inside a Skyrim mesh (.nif) at the data layer, beneath NifSkope. Resolve the Data-relative " +
+         "mesh_path through Mod Organizer 2's virtual file system to the copy the game actually uses (loose beats BSA; among " +
+         "BSAs the later-loaded plugin wins) and report, from that mesh: its header version + whether it is a Skyrim SE " +
+         "stream; the block census (every block type and count); any UNKNOWN blocks (named + preserved, never silently " +
+         "dropped); and per shape — the shape name, the NiAVObject flags (hex) and scale, the BSDismember body-part " +
+         "partitions (decoded to their SBP_* names), the alpha property (decoded blend / test / threshold), the embedded " +
+         "texture-set paths, and the bone list; plus the node tree and the header string table. Use it to answer 'what " +
+         "shapes / bones / textures / partitions / alpha does this mesh have', to read a facegen mesh's baked shape names " +
+         "and tint path, to check a skeleton's bone names, or to see a dark-face mesh's flags/alpha/partitions — the " +
+         "asset-INTERNAL companion to housecarl_asset_status (which mod wins) once you know the winning file. Output is a " +
+         "SUMMARY by default (header + census + shape names); pass sections to expand ('shapes','partitions','alpha'," +
+         "'paths','strings','nodes','bones', or 'all'). Pass mod= to inspect a specific provider instead of the winner. An " +
+         "unreadable archive, an absent path, or a mesh NiflySharp refuses (e.g. its strict non-0/1 boolean class) is " +
+         "reported LOUD by name — never a silent 'absent' or a half-answer. Read-only: resolves nothing to disk, writes " +
+         "nothing, changes no load order. Scope: data values only; it does not read or edit geometry / visual content.")]
+    public static string NifInspect(
+        LoadOrderService svc,
+        [Description("The Data-relative mesh path to inspect, e.g. " +
+                     "'meshes\\actors\\character\\facegendata\\facegeom\\Skyrim.esm\\00000007.nif' or " +
+                     "'meshes\\armor\\iron\\cuirass_1.nif'. Relative to the game's Data folder (forward or back slashes both fine).")]
+            string mesh_path,
+        [Description("Optional. Which detail sections to show beyond the summary — any of 'shapes', 'partitions', 'alpha', " +
+                     "'paths', 'strings', 'nodes', 'bones', or 'all'. Comma- or space-separated. Empty = summary only " +
+                     "(header + block census + shape names).")]
+            string sections = "",
+        [Description("Optional. Inspect a specific provider's copy of the mesh instead of the VFS winner — the mod folder " +
+                     "name, 'overwrite', 'Data', or a BSA filename as listed in the providers chain. Empty = the winner.")]
+            string mod = "",
+        [Description("Optional. Max characters before a detail list is cut with an explicit notice. 0 = the server default (~80k).")]
+            int max_chars = 0) => Guard.Tool("housecarl_nif_inspect", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        if (string.IsNullOrWhiteSpace(mesh_path))
+            return "error: mesh_path is empty. Pass a Data-relative mesh path (e.g. 'meshes\\armor\\iron\\cuirass_1.nif').";
+
+        var (want, unknownTokens) = ParseSections(sections);
+        var data = svc.NifInspect(mesh_path, string.IsNullOrWhiteSpace(mod) ? null : mod);
+        return NifWire.Render(data, want, unknownTokens, max_chars > 0 ? max_chars : 80_000);
+    });
+
+    /// <summary>Parse the sections argument into the recognized set + a list of any UNRECOGNIZED tokens (surfaced, never
+    /// silently ignored — Q3). 'all' expands to every known section.</summary>
+    static (HashSet<string> Want, IReadOnlyList<string> Unknown) ParseSections(string sections)
+    {
+        var want = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var unknown = new List<string>();
+        foreach (var raw in (sections ?? "").Split(new[] { ',', ' ', ';', '\t' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (raw.Equals("all", StringComparison.OrdinalIgnoreCase)) { foreach (var s in KnownSections) want.Add(s); }
+            else if (Array.Exists(KnownSections, s => s.Equals(raw, StringComparison.OrdinalIgnoreCase))) want.Add(raw.ToLowerInvariant());
+            else unknown.Add(raw);
+        }
+        return (want, unknown);
+    }
+}
+
+/// <summary>Renders <see cref="NifInspectData"/> as compact, scannable text: the build-level Q3 alarms first (archives
+/// that failed to read; discovery warnings), then the resolution (which copy was read + the provider chain), then — on a
+/// clean read — the summary (version, block census, unknown-block report, shape names, node count) and any requested
+/// detail sections. An ABSENT / bad-path / unreadable / parse-refused result is the error line, loud and named. Detail
+/// lists are bounded by max_chars with an explicit cut notice (Q3 — never silent truncation).</summary>
+static class NifWire
+{
+    public static string Render(NifInspectData d, HashSet<string> want, IReadOnlyList<string> unknownSections, int cap)
+    {
+        var sb = new StringBuilder();
+        sb.Append("nif inspect — ").Append(d.RelPath)
+          .Append("  (profile '").Append(d.ProfileName.Length > 0 ? d.ProfileName : "(unconfigured)").Append("')\n");
+
+        // Q3 alarms FIRST, so a long detail dump can't truncate them away.
+        AppendReadFailures(sb, d.BsaFailures, cap);
+        AppendDiscoveryWarnings(sb, d.Warnings, cap);
+        if (unknownSections.Count > 0)
+            sb.Append("\n[!] unrecognized section(s) ignored: ").Append(string.Join(", ", unknownSections))
+              .Append("  (known: ").Append(string.Join(", ", new[] { "shapes", "partitions", "alpha", "paths", "strings", "nodes", "bones", "all" })).Append(")\n");
+
+        // Error path (ABSENT / bad path / unreadable / parse-refused). Still show the provider chain when we have one.
+        if (d.Inspect is null)
+        {
+            sb.Append('\n').Append(d.Error ?? "unknown error").Append('\n');
+            if (d.Providers.Count > 0) AppendProviders(sb, d.Providers);
+            return sb.ToString().TrimEnd('\n');
+        }
+
+        var nif = d.Inspect;
+        sb.Append("\n  read from: ").Append(d.Inspected!.Name).Append(" (").Append(d.Inspected.Kind).Append(")\n");
+        AppendProviders(sb, d.Providers);
+        if (d.Ambiguous)
+            sb.Append("  note: more than one source provides this mesh — the winner above was read (loose beats BSA). " +
+                      "Pass mod= to inspect another provider's copy.\n");
+
+        sb.Append("  version: ").Append(nif.VersionString.Length > 0 ? nif.VersionString : "(unknown)")
+          .Append("  user ").Append(nif.UserVersion).Append(" stream ").Append(nif.StreamVersion)
+          .Append(nif.IsSkyrimSE ? "  [Skyrim SE]" : "  [NOT an SE stream — LE / FO4 / other]").Append('\n');
+
+        AppendClampedList(sb, "  blocks: " + nif.BlockCount + " — ", nif.BlockTypes.Select(t => t.Type + " x" + t.Count), cap);
+
+        if (!nif.HasUnknownBlocks)
+            sb.Append("  unknown blocks: none\n");
+        else
+            sb.Append("  unknown blocks: ").Append(nif.UnknownBlockTypes.Count).Append(" type(s) — ")
+              .Append(string.Join(", ", nif.UnknownBlockTypes))
+              .Append("  (preserved intact, reported not modeled — likely another game's format)\n");
+
+        AppendClampedList(sb, "  shapes (" + nif.Shapes.Count + "): ", nif.Shapes.Select(s => "'" + s.Name + "'"), cap);
+        sb.Append("  nodes: ").Append(nif.Nodes.Count).Append("  (pass sections=nodes for the tree)\n");
+
+        // ---- detail sections on demand ----
+        if (want.Contains("shapes")) RenderShapesDetail(sb, nif, cap);
+        if (want.Contains("partitions")) RenderPerShape(sb, nif, cap, "partitions", s => s.Partitions.Count > 0,
+            s => string.Join(", ", s.Partitions.Select(p => $"{p.BodyPartId} ({p.BodyPartName}, flags {p.PartFlags})")));
+        if (want.Contains("alpha")) RenderPerShape(sb, nif, cap, "alpha", s => s.Alpha is not null,
+            s => AlphaLine(s.Alpha!));
+        if (want.Contains("paths")) RenderPaths(sb, nif, cap);
+        if (want.Contains("bones")) RenderPerShape(sb, nif, cap, "bones", s => s.Bones.Count > 0,
+            s => string.Join(", ", s.Bones));
+        if (want.Contains("nodes")) RenderNodes(sb, nif, cap);
+        if (want.Contains("strings")) RenderStrings(sb, nif, cap);
+
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    static void AppendProviders(StringBuilder sb, IReadOnlyList<NifProvider> providers)
+    {
+        sb.Append("  providers (").Append(providers.Count).Append("): ");
+        for (int i = 0; i < providers.Count; i++)
+        {
+            if (i > 0) sb.Append(" > ");
+            sb.Append(providers[i].Name).Append(" (").Append(providers[i].Kind).Append(')');
+        }
+        sb.Append('\n');
+    }
+
+    static void RenderShapesDetail(StringBuilder sb, NifInspect nif, int cap)
+    {
+        sb.Append("\n--- shapes (").Append(nif.Shapes.Count).Append(") ---\n");
+        foreach (var s in nif.Shapes)
+        {
+            if (Cut(sb, cap, nif.Shapes.Count)) return;
+            sb.Append("  '").Append(s.Name).Append("'  flags 0x").Append(s.Flags.ToString("X")).Append("  scale ").Append(Fmt(s.Scale)).Append('\n');
+            if (s.Partitions.Count > 0)
+                sb.Append("    partitions: ").Append(string.Join(", ", s.Partitions.Select(p => $"{p.BodyPartId} ({p.BodyPartName}, flags {p.PartFlags})"))).Append('\n');
+            if (s.Alpha is not null)
+                sb.Append("    alpha: ").Append(AlphaLine(s.Alpha)).Append('\n');
+            foreach (var t in s.Textures)
+                sb.Append("    tex[").Append(t.Slot).Append("]: ").Append(t.Path).Append('\n');
+            if (s.Bones.Count > 0)
+                sb.Append("    bones: ").Append(string.Join(", ", s.Bones)).Append('\n');
+        }
+    }
+
+    static void RenderPerShape(StringBuilder sb, NifInspect nif, int cap, string title, Func<NifShape, bool> has, Func<NifShape, string> line)
+    {
+        sb.Append("\n--- ").Append(title).Append(" ---\n");
+        int shown = 0;
+        foreach (var s in nif.Shapes.Where(has))
+        {
+            if (Cut(sb, cap, nif.Shapes.Count - shown)) return;
+            sb.Append("  '").Append(s.Name).Append("': ").Append(line(s)).Append('\n');
+            shown++;
+        }
+        if (shown == 0) sb.Append("  (none)\n");
+    }
+
+    static void RenderPaths(StringBuilder sb, NifInspect nif, int cap)
+    {
+        sb.Append("\n--- paths (embedded texture-set slots; material/.tri/physics-xml refs appear under sections=strings) ---\n");
+        int shown = 0;
+        foreach (var s in nif.Shapes.Where(s => s.Textures.Count > 0))
+        {
+            if (Cut(sb, cap, nif.Shapes.Count - shown)) return;
+            sb.Append("  '").Append(s.Name).Append("':\n");
+            foreach (var t in s.Textures) sb.Append("    tex[").Append(t.Slot).Append("]: ").Append(t.Path).Append('\n');
+            shown++;
+        }
+        if (shown == 0) sb.Append("  (no embedded texture paths)\n");
+    }
+
+    static void RenderNodes(StringBuilder sb, NifInspect nif, int cap)
+    {
+        sb.Append("\n--- node tree (").Append(nif.Nodes.Count).Append(") ---\n");
+        int shown = 0;
+        foreach (var n in nif.Nodes)
+        {
+            if (Cut(sb, cap, nif.Nodes.Count - shown)) return;
+            sb.Append("  ").Append(new string(' ', n.Depth * 2)).Append(n.Name.Length > 0 ? n.Name : "(unnamed)")
+              .Append("  0x").Append(n.Flags.ToString("X")).Append('\n');
+            shown++;
+        }
+    }
+
+    static void RenderStrings(StringBuilder sb, NifInspect nif, int cap)
+    {
+        sb.Append("\n--- header string table (").Append(nif.HeaderStrings.Count).Append(") ---\n");
+        int shown = 0;
+        foreach (var s in nif.HeaderStrings)
+        {
+            if (Cut(sb, cap, nif.HeaderStrings.Count - shown)) return;
+            sb.Append("  [").Append(shown).Append("] ").Append(s).Append('\n');
+            shown++;
+        }
+        if (shown == 0) sb.Append("  (none)\n");
+    }
+
+    static string AlphaLine(NifAlpha a)
+        => $"flags 0x{a.Flags:X4}  blend={a.Blend} ({a.SourceBlendMode} -> {a.DestinationBlendMode})  test={a.Test} ({a.TestFunction})  threshold {a.Threshold}";
+
+    /// <summary>Append "<label><a, b, c>" as one line, cut with an explicit notice if it would blow the cap (Q3).</summary>
+    static void AppendClampedList(StringBuilder sb, string label, IEnumerable<string> items, int cap)
+    {
+        sb.Append(label);
+        var list = items.ToList();
+        int shown = 0;
+        for (; shown < list.Count; shown++)
+        {
+            if (sb.Length >= cap) break;
+            if (shown > 0) sb.Append(", ");
+            sb.Append(list[shown]);
+        }
+        if (shown < list.Count)
+            sb.Append(" … [").Append(list.Count - shown).Append(" more omitted at max_chars=").Append(cap).Append("; raise max_chars to see all]");
+        sb.Append('\n');
+    }
+
+    /// <summary>True (and appends the cut notice) when the buffer has hit the cap mid-section — the per-item loop breaks.</summary>
+    static bool Cut(StringBuilder sb, int cap, int remaining)
+    {
+        if (sb.Length < cap) return false;
+        sb.Append("  … [").Append(Math.Max(remaining, 0)).Append(" more omitted at max_chars=").Append(cap).Append("; raise max_chars to see all]\n");
+        return true;
+    }
+
+    static string Fmt(float f) => f.ToString("0.#######", System.Globalization.CultureInfo.InvariantCulture);
+
+    /// <summary>The archive-read-failure alarm (Q3): BSAs that couldn't be read this build. A mesh present ONLY in one of
+    /// these is indistinguishable from a truly absent one, so it is surfaced LOUD before the answer.</summary>
+    static void AppendReadFailures(StringBuilder sb, IReadOnlyList<string> failures, int cap)
+    {
+        if (failures.Count == 0) return;
+        sb.Append("\n[!] ").Append(failures.Count).Append(" archive(s) could NOT be read this build — a mesh present only in these may read as ABSENT:\n");
+        int shown = 0;
+        foreach (var f in failures)
+        {
+            if (sb.Length >= cap) { sb.Append("  ... [").Append(failures.Count - shown).Append(" more omitted]\n"); break; }
+            sb.Append("  - ").Append(f).Append('\n'); shown++;
+        }
+    }
+
+    static void AppendDiscoveryWarnings(StringBuilder sb, IReadOnlyList<string> warnings, int cap)
+    {
+        if (warnings.Count == 0) return;
+        sb.Append("\n[!] discovery (").Append(warnings.Count).Append("):\n");
+        int shown = 0;
+        foreach (var w in warnings)
+        {
+            if (sb.Length >= cap) { sb.Append("  ... [").Append(warnings.Count - shown).Append(" more omitted]\n"); break; }
+            sb.Append("  - ").Append(w).Append('\n'); shown++;
+        }
+    }
+}


### PR DESCRIPTION
## What this is
NIF layer **Wave 1** — `housecarl_nif_inspect` (tool #34): read the data values inside a Skyrim mesh at the data layer, beneath NifSkope. Provenance: `PRFAQ_NIF_LAYER_2026-07-08` (Aaron-locked) → `SPIKE_NIF_LAYER_2026-07-08` (GO) → `NIF_LAYER_BUILD_PLAN_2026-07-08` (Aaron-go). Scope: **data values in; geometry/visual content out** of this capability.

Resolves a Data-relative mesh path through the MO2 VFS to the winning copy (loose beats BSA), reads BSA-packed meshes **straight from archive bytes — no disk extraction, no handles at rest**, and reports: header/version + SE-stream check, block census, unknown blocks (named + preserved), and per shape — name, NiAVObject flags + scale, BSDismember partitions (decoded `SBP_*`), alpha (decoded blend/test/threshold), texture-set paths, bone lists — plus the node tree and header string table. Summary by default; `sections=` expands; `mod=` inspects a specific provider.

## Architecture (mirrors the asset service/tool split)
- **`NifService` (core)** — pure `byte[]` → model format logic on NiflySharp 1.0.0 (pkg `Nifly`, GPL-3.0, source-generated from nifxml). SE-safe direct refs, never `GetPropertyOfType`. Fail-loud: a parse the library refuses (incl. its strict-boolean class) is a **named** outcome with the NifSkope remedy, never a throw or half-model (Q3, PRFAQ N6).
- **`LoadOrderService.NifInspect`** — resolve winner (or `mod=`) → read bytes → `NifService` → carry the winner→loser provider chain + `BsaFailures`/`ReadIncomplete` (Q3). Capture-then-work-outside-gate, mirroring `SkseInventory`.
- **`NifTools` (mcp)** — the tool + `NifWire` renderer (alarms-first, `max_chars` clamp).

## Evidence
- **`nif-service-guard`: ALL PASS** — a synthetic SE mesh **authored in-memory via NiflySharp** (no third-party mesh in repo) proves version/census/node-tree/shape/partitions/alpha decode + loud refusal. **RED-proved.**
- **Corpus smoke ran live** against the real `A makeover for Lucien` facegen — every spike §5 value reproduced exactly (flags `0x400000E`, partition 30, tint path slot 6, bones, alpha `0x12ED`/`0x12EE` thr 180). Existence-gated (SKIPs off-corpus).
- **`ci-all`: 77/77** (nif guard co-hosts at 62/77). Full Release build clean.

## Honest deltas for review
1. **Shape/node `flags` render as hex, not decoded bit-names** — alpha + partitions *are* decoded (the load-bearing dark-face values). NiAVObject bit-naming is a cheap follow-up.
2. **Synthetic CI fixture can't wire textures** (`TextureSetRef` read-only) **or bones** (skin rigging) — those are guarded only by the existence-gated corpus smoke (proven live), not CI-portable arms.
3. **Tool-level end-to-end** (live server → MO2 → render) not exercised — deferred empirical gate (plan §5 #5, same posture as compact/merge).

## Open scope calls (all Wave 2 / follow-up — none blocked Wave 1)
Unknown-blocks write posture · `npc=` record-derived input · NiflySharp upstream bug report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)