### PR TITLE
feat(nif_set): NIF layer Wave 2 — housecarl_nif_set (tool #35)

### DIFF
--- a/src/housecarl-core/NifService.cs
+++ b/src/housecarl-core/NifService.cs
@@ -217,6 +217,413 @@ public static class NifService
         }
         return strings;
     }
+
+    // ======================================================================
+    //  NIF layer Wave 2 — whitelist WRITES (housecarl_nif_set). Pure bytes-in / verified-bytes-out.
+    // ======================================================================
+
+    /// <summary>Apply the N2-whitelist write op(s) to a mesh's raw bytes and hand back the VERIFIED edited bytes, or a
+    /// named refusal (Q3) — the format-level core behind <c>housecarl_nif_set</c>. Like <see cref="Inspect"/> it knows
+    /// nothing of MO2/VFS; the service layer resolves the winning bytes, calls this, and writes the result.
+    ///
+    /// Refuses (nothing written) when: the mesh won't parse; it is NOT a Skyrim SE stream (a normalized cross-game write
+    /// is untested territory — spike §7); a target shape/node/property named by an op isn't found or is ambiguous; an op
+    /// can't apply (e.g. set_partition on a shape with no dismember skin). Unknown blocks are WARN-and-proceed — they are
+    /// preserved byte-for-byte by construction and the census gate proves it (PRFAQ N6; Wave-2 posture).
+    ///
+    /// Every successful write passes TWO offset-immune gates before its bytes are returned (spike §4, empirically refined
+    /// 2026-07-08 from a position-diff to a block-content diff so a length-changing rename can't false-abort):
+    ///   1. BLOCK-CONTENT DIFF — normalize the unedited mesh and the edited mesh through nifly's canonical writer, slice
+    ///      BOTH by their own block-size tables, and compare block CONTENT by index. Only the block(s)/header the op
+    ///      claims to touch may differ; any other change (a stray block, geometry, the footer) → abort. Content-diff is
+    ///      immune to the file-offset shift a grown/shrunk string table causes, which a raw byte-position diff is not.
+    ///   2. SEMANTIC READ-BACK — reload the written bytes, re-inspect, and assert each op's target now reads as requested
+    ///      (catches a silent no-op write), the block census + unknown-block count are unchanged, the SE stream is intact,
+    ///      and the file reloads clean.
+    /// A gate failure returns the refusal with nothing written — the writer never hands back an unverified mesh.</summary>
+    public static NifSetOutcome Set(byte[] bytes, IReadOnlyList<NifSetOp> ops)
+    {
+        if (bytes is null || bytes.Length == 0)
+            return NifSetOutcome.Fail("the mesh is empty (0 bytes) — nothing to edit.");
+        if (ops is null || ops.Count == 0)
+            return NifSetOutcome.Fail("no write op was given.");
+
+        // ---- parse (same fail-loud posture as Inspect) ----
+        var nif = new NifFile();
+        try
+        {
+            using var ms = new MemoryStream(bytes, writable: false);
+            if (nif.Load(ms) != 0)
+                return NifSetOutcome.Fail("NiflySharp could not parse this mesh — it may be truncated, not a NIF, or a format the library rejects. Nothing was written.");
+        }
+        catch (Exception ex) { return NifSetOutcome.Fail(DescribeLoadException(ex)); }
+
+        NifInspect pre;
+        try { pre = Build(nif); }
+        catch (Exception ex) { return NifSetOutcome.Fail($"the mesh parsed but reading its structure failed — {ex.GetType().Name}: {ex.Message}. Nothing was written."); }
+
+        // ---- SE-stream gate: nif_set refuses a non-SE mesh by name (plan §2 version guard; spike §7) ----
+        if (!pre.IsSkyrimSE)
+            return NifSetOutcome.Fail(
+                $"this is NOT a Skyrim SE mesh (user {pre.UserVersion} / stream {pre.StreamVersion}; SE is user 12 / stream 100). " +
+                "nif_set only writes SE-stream meshes — a normalized cross-game (LE / FO4 / Starfield) write is untested and refused. Nothing was written.");
+
+        // ---- apply each op; record the exact block(s)/header each is allowed to touch ----
+        var applied = new List<NifOpResult>(ops.Count);
+        var expectedBlocks = new HashSet<int>();
+        bool expectHeader = false;
+        foreach (var op in ops)
+        {
+            var r = ApplyOp(nif, op);
+            if (r.Error is not null) return NifSetOutcome.Fail(r.Error);   // target-not-found / ambiguous / not-applicable → nothing written
+            applied.Add(new NifOpResult(op.Kind.ToString(), r.Target!, r.Before!, r.After!));
+            if (r.TouchedBlock is { } b) expectedBlocks.Add(b);
+            if (r.TouchedHeader) expectHeader = true;
+        }
+
+        // ---- save the edited mesh to memory ----
+        byte[] edited;
+        try
+        {
+            using var outMs = new MemoryStream();
+            if (nif.Save(outMs) != 0) return NifSetOutcome.Fail("NiflySharp failed to save the edited mesh. Nothing was written.");
+            edited = outMs.ToArray();
+        }
+        catch (Exception ex) { return NifSetOutcome.Fail($"saving the edited mesh threw — {ex.GetType().Name}: {ex.Message}. Nothing was written."); }
+
+        // ---- GATE 1: block-content diff (offset-immune) ----
+        var g1 = VerifyBlockContent(bytes, edited, expectedBlocks, expectHeader);
+        if (g1 is not null) return NifSetOutcome.Fail(g1);
+
+        // ---- GATE 2: semantic read-back ----
+        var g2 = VerifyReadBack(edited, pre, ops, out var warnings);
+        if (g2 is not null) return NifSetOutcome.Fail(g2);
+
+        var report = new NifSetReport(applied,
+            expectedBlocks.OrderBy(i => i).ToList(), expectHeader,
+            edited.Length - bytes.Length, warnings);
+        return new NifSetOutcome(edited, report, null);
+    }
+
+    /// <summary>Apply one op to <paramref name="nif"/>, returning the target's before/after value, the single block index
+    /// it is allowed to change (or header for a rename), or a NAMED error (Q3) that aborts the whole call. The write APIs
+    /// follow the empirically-confirmed NiflySharp rules: bitfield sub-values (alpha flags) are structs (read-modify-write
+    /// then re-assign); a block is resolved and mutated via its OWNING ref, never a freshly-built one (which does not
+    /// persist on save).</summary>
+    static (string? Error, string? Target, string? Before, string? After, int? TouchedBlock, bool TouchedHeader) ApplyOp(NifFile nif, NifSetOp op)
+    {
+        switch (op.Kind)
+        {
+            case NifSetOpKind.RenameShape:
+            {
+                if (string.IsNullOrEmpty(op.NewName)) return ("rename_shape needs a new_name.", null, null, null, null, false);
+                var (shape, err) = ResolveShape(nif, op.Target);
+                if (err is not null) return (err, null, null, null, null, false);
+                var av = (NiflySharp.Blocks.NiAVObject)shape!;
+                string before = av.Name?.String ?? "";
+                av.Name = new NiStringRef(op.NewName);
+                return (null, op.Target, before, op.NewName, null, true);   // a Name lives ONLY in the header string table
+            }
+            case NifSetOpKind.RenameNode:
+            {
+                if (string.IsNullOrEmpty(op.NewName)) return ("rename_node needs a new_name.", null, null, null, null, false);
+                var (node, err) = ResolveNode(nif, op.Target);
+                if (err is not null) return (err, null, null, null, null, false);
+                string before = node!.Name?.String ?? "";
+                node.Name = new NiStringRef(op.NewName);
+                return (null, op.Target, before, op.NewName, null, true);
+            }
+            case NifSetOpKind.SetFlags:
+            {
+                if (op.Flags is not { } flags) return ("set_flags needs a flags value.", null, null, null, null, false);
+                var (av, err) = ResolveAvObject(nif, op.Target);
+                if (err is not null) return (err, null, null, null, null, false);
+                string before = $"0x{av!.Flags_ui:X}";
+                av.Flags_ui = flags;
+                return (null, op.Target, before, $"0x{flags:X}", BlockIndexOf(nif, av), false);
+            }
+            case NifSetOpKind.SetScale:
+            {
+                if (op.Scale is not { } scale) return ("set_scale needs a scale value.", null, null, null, null, false);
+                var (av, err) = ResolveAvObject(nif, op.Target);
+                if (err is not null) return (err, null, null, null, null, false);
+                string before = av!.Scale.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                av.Scale = scale;
+                return (null, op.Target, before, scale.ToString(System.Globalization.CultureInfo.InvariantCulture), BlockIndexOf(nif, av), false);
+            }
+            case NifSetOpKind.SetAlpha:
+            {
+                if (op.AlphaFlags is null && op.AlphaThreshold is null) return ("set_alpha needs an alpha_flags word and/or an alpha_threshold.", null, null, null, null, false);
+                var (shape, err) = ResolveShape(nif, op.Target);
+                if (err is not null) return (err, null, null, null, null, false);
+                if (!shape!.HasAlphaProperty || nif.GetBlock<NiAlphaProperty>(shape.AlphaPropertyRef) is not { } ap)
+                    return ($"shape '{op.Target}' has no alpha property to set. Nothing was written.", null, null, null, null, false);
+                string before = $"0x{ap.Flags.Value:X4}/thr{ap.Threshold}";
+                if (op.AlphaFlags is { } fw) { var fl = ap.Flags; fl.Value = fw; ap.Flags = fl; }   // AlphaFlags is a STRUCT — reassign
+                if (op.AlphaThreshold is { } th) ap.Threshold = th;
+                return (null, op.Target, before, $"0x{ap.Flags.Value:X4}/thr{ap.Threshold}", BlockIndexOf(nif, ap), false);
+            }
+            case NifSetOpKind.SetPartition:
+            {
+                if (op.BodyPartId is not { } bp) return ("set_partition needs a body_part_id.", null, null, null, null, false);
+                var (shape, err) = ResolveShape(nif, op.Target);
+                if (err is not null) return (err, null, null, null, null, false);
+                if (shape!.SkinInstanceRef is null || nif.GetBlock(shape.SkinInstanceRef) is not BSDismemberSkinInstance dis)
+                    return ($"shape '{op.Target}' has no BSDismember skin instance — no partitions to set. Nothing was written.", null, null, null, null, false);
+                var list = dis.Partitions;
+                if (list is null || list.Count == 0) return ($"shape '{op.Target}' has an empty partition list. Nothing was written.", null, null, null, null, false);
+                int idx;
+                if (op.PartitionIndex is { } pi) { if (pi < 0 || pi >= list.Count) return ($"partition_index {pi} out of range (shape '{op.Target}' has {list.Count} partition(s)). Nothing was written.", null, null, null, null, false); idx = pi; }
+                else if (list.Count == 1) idx = 0;
+                else return ($"shape '{op.Target}' has {list.Count} partitions — pass partition_index to say which. Nothing was written.", null, null, null, null, false);
+                string before = $"[{idx}]={(int)list[idx].BodyPart}";
+                var p = list[idx]; p.BodyPart = (NiflySharp.Enums.BSDismemberBodyPartType)bp; list[idx] = p; dis.Partitions = list;   // list of STRUCT — reassign
+                return (null, op.Target, before, $"[{idx}]={bp}", BlockIndexOf(nif, dis), false);
+            }
+            case NifSetOpKind.SetPath:
+            {
+                if (op.TextureSlot is not { } slot) return ("set_path needs a texture_slot.", null, null, null, null, false);
+                if (op.Path is null) return ("set_path needs a path.", null, null, null, null, false);
+                var (shape, err) = ResolveShape(nif, op.Target);
+                if (err is not null) return (err, null, null, null, null, false);
+                var shader = nif.GetShader(shape!);
+                if (shader?.TextureSetRef is null || nif.GetBlock(shader.TextureSetRef) is not BSShaderTextureSet ts)
+                    return ($"shape '{op.Target}' has no shader texture set — no path to swap. Nothing was written.", null, null, null, null, false);
+                if (slot < 0 || slot >= ts.Textures.Count)
+                    return ($"texture_slot {slot} out of range (shape '{op.Target}' has {ts.Textures.Count} slot(s)). Nothing was written.", null, null, null, null, false);
+                var tex = ts.Textures[slot] ?? new NiflySharp.NiString4();
+                string before = tex.Content ?? "";
+                tex.Content = op.Path; ts.Textures[slot] = tex;
+                return (null, op.Target, $"tex[{slot}]={before}", $"tex[{slot}]={op.Path}", BlockIndexOf(nif, ts), false);
+            }
+            default:
+                return ($"unsupported op '{op.Kind}'.", null, null, null, null, false);
+        }
+    }
+
+    // ---- target resolution (Q3: not-found and ambiguous are NAMED refusals, never a silent first-match write) ----
+
+    static (INiShape? Shape, string? Error) ResolveShape(NifFile nif, string name)
+    {
+        var matches = nif.GetShapes().Where(s => (s.Name?.String ?? "") == name).ToList();
+        if (matches.Count == 0) return (null, $"no shape named '{name}' in this mesh. Shapes: {ShapeNames(nif)}. Nothing was written.");
+        if (matches.Count > 1) return (null, $"more than one shape is named '{name}' — ambiguous, refusing rather than guess which. Nothing was written.");
+        return (matches[0], null);
+    }
+
+    static (NiNode? Node, string? Error) ResolveNode(NifFile nif, string name)
+    {
+        var matches = nif.Blocks.OfType<NiNode>().Where(n => (n.Name?.String ?? "") == name).ToList();
+        if (matches.Count == 0) return (null, $"no node named '{name}' in this mesh. Nothing was written.");
+        if (matches.Count > 1) return (null, $"more than one node is named '{name}' — ambiguous, refusing rather than guess which. Nothing was written.");
+        return (matches[0], null);
+    }
+
+    /// <summary>Resolve a named NiAVObject (a shape OR a node — set_flags/set_scale apply to either). Ambiguity across the
+    /// whole AV-object population is a named refusal.</summary>
+    static (NiflySharp.Blocks.NiAVObject? Av, string? Error) ResolveAvObject(NifFile nif, string name)
+    {
+        var matches = nif.Blocks.OfType<NiflySharp.Blocks.NiAVObject>().Where(a => (a.Name?.String ?? "") == name).ToList();
+        if (matches.Count == 0) return (null, $"no shape or node named '{name}' in this mesh. Nothing was written.");
+        if (matches.Count > 1) return (null, $"more than one shape/node is named '{name}' — ambiguous, refusing rather than guess which. Nothing was written.");
+        return (matches[0], null);
+    }
+
+    static string ShapeNames(NifFile nif) => string.Join(", ", nif.GetShapes().Select(s => "'" + (s.Name?.String ?? "") + "'"));
+
+    /// <summary>The block id of a block within the file (parallel to Header.GetBlockSize/TypeName), by reference identity —
+    /// the index the block-content diff will compare. -1 (never expected) if the block isn't in the list.</summary>
+    static int BlockIndexOf(NifFile nif, object block)
+    {
+        var blocks = nif.Blocks;
+        for (int i = 0; i < blocks.Count; i++) if (ReferenceEquals(blocks[i], block)) return i;
+        return -1;
+    }
+
+    /// <summary>GATE 1 — block-content diff. Normalize the ORIGINAL bytes (reload+save) and compare, block-content by
+    /// index, against the edited output (both sliced by their OWN block-size tables so a grown/shrunk header string table
+    /// can't misalign the comparison). Returns null when only the expected block(s)/header changed; else a NAMED refusal.
+    /// If the block layout can't be recovered on either side, it REFUSES (can't verify ⇒ won't write — never a silent
+    /// pass). Internal so the guard can RED-prove it catches a collateral (non-expected-block) change directly.</summary>
+    internal static string? VerifyBlockContent(byte[] original, byte[] edited, HashSet<int> expectedBlocks, bool expectHeader)
+    {
+        byte[] normBaseline;
+        try
+        {
+            var b = new NifFile();
+            using var ms = new MemoryStream(original, writable: false);
+            if (b.Load(ms) != 0) return "verification could not re-parse the original mesh to normalize it — refusing to write.";
+            using var outMs = new MemoryStream();
+            if (b.Save(outMs) != 0) return "verification could not normalize the original mesh — refusing to write.";
+            normBaseline = outMs.ToArray();
+        }
+        catch (Exception ex) { return $"verification threw while normalizing the original mesh ({ex.GetType().Name}) — refusing to write."; }
+
+        var a = SliceBlocks(normBaseline);
+        var c = SliceBlocks(edited);
+        if (a is null || c is null) return "verification could not recover the block layout to compare — refusing to write (nothing changed on disk).";
+        if (a.Value.blocks.Length != c.Value.blocks.Length)
+            return $"the edit changed the block COUNT ({a.Value.blocks.Length} → {c.Value.blocks.Length}) — a structural change no whitelist op should make. Refusing, nothing written.";
+
+        var changed = new List<int>();
+        for (int i = 0; i < c.Value.blocks.Length; i++)
+            if (!a.Value.blocks[i].AsSpan().SequenceEqual(c.Value.blocks[i])) changed.Add(i);
+
+        var unexpected = changed.Where(i => !expectedBlocks.Contains(i)).ToList();
+        if (unexpected.Count > 0)
+            return $"the edit changed block(s) [{string.Join(", ", unexpected.Select(i => i + " " + c.Value.types[i]))}] it should not have touched (expected only [{string.Join(", ", expectedBlocks.OrderBy(x => x))}]). Refusing, nothing written.";
+
+        // A header change is legitimate in exactly two cases: a rename (edits the authored string table — the op declares
+        // it via expectHeader), OR a touched block changed SIZE (the header's derived block-SIZE table records each
+        // block's byte length, so growing/shrinking an expected block mechanically updates it — e.g. a longer texture
+        // path). Any OTHER header change is real collateral → refuse. (Found on real facegen data 2026-07-08: the
+        // synthetic same-length ops never resize a block, so only a corpus set_path surfaced the block-size-table path.)
+        bool expectedBlockResized = expectedBlocks.Any(i => i >= 0 && i < a.Value.blocks.Length && a.Value.blocks[i].Length != c.Value.blocks[i].Length);
+        if (c.Value.header.AsSpan().SequenceEqual(a.Value.header) == false && !expectHeader && !expectedBlockResized)
+            return "the edit changed the header (its string table or a non-touched block's size entry), which no in-place same-size op should. Refusing, nothing written.";
+        if (c.Value.footer.AsSpan().SequenceEqual(a.Value.footer) == false)
+            return "the edit changed the file footer (root references) — a structural change no whitelist op should make. Refusing, nothing written.";
+        return null;
+    }
+
+    /// <summary>Slice a normalized NIF buffer into (header bytes, per-block content bytes, footer bytes) using its OWN
+    /// block-size table + a footer-length recovery (numRoots consistency check — the spike's difftrace layout recovery).
+    /// null if the layout can't be recovered (the caller refuses).</summary>
+    static (byte[] header, byte[][] blocks, string[] types, byte[] footer)? SliceBlocks(byte[] buf)
+    {
+        NifFile nif;
+        try
+        {
+            nif = new NifFile();
+            using var ms = new MemoryStream(buf, writable: false);
+            if (nif.Load(ms) != 0) return null;
+        }
+        catch { return null; }
+
+        int bc = nif.Header.BlockCount;
+        long sum = 0; var sizes = new int[bc]; var types = new string[bc];
+        for (int i = 0; i < bc; i++) { sizes[i] = nif.Header.GetBlockSize(i); types[i] = nif.Header.GetBlockTypeNameById(i) ?? "?"; sum += sizes[i]; }
+
+        long headerEnd = -1; long footerLen = 0;
+        for (int nRoots = 0; nRoots <= 64; nRoots++)
+        {
+            long fl = 4 + 4L * nRoots; long cand = buf.LongLength - fl - sum;
+            if (cand <= 0) break;
+            if (cand + sum + 4 <= buf.LongLength && BitConverter.ToUInt32(buf, (int)(cand + sum)) == nRoots) { headerEnd = cand; footerLen = fl; break; }
+        }
+        if (headerEnd < 0) return null;
+
+        var header = new byte[headerEnd];
+        Array.Copy(buf, 0, header, 0, headerEnd);
+        var blocks = new byte[bc][];
+        long pos = headerEnd;
+        for (int i = 0; i < bc; i++)
+        {
+            if (pos + sizes[i] > buf.LongLength) return null;
+            blocks[i] = new byte[sizes[i]];
+            Array.Copy(buf, pos, blocks[i], 0, sizes[i]);
+            pos += sizes[i];
+        }
+        var footer = new byte[footerLen];
+        if (footerLen > 0 && pos + footerLen <= buf.LongLength) Array.Copy(buf, pos, footer, 0, footerLen);
+        return (header, blocks, types, footer);
+    }
+
+    /// <summary>GATE 2 — semantic read-back. Reload the WRITTEN bytes, re-inspect, and assert: the file reloads clean and
+    /// is still an SE stream; the block census + unknown-block count match the pre-edit inspect (no structural drift); and
+    /// each op's target now reads as REQUESTED (a value that didn't take — a silent no-op — aborts here). Returns null on
+    /// success; else a NAMED refusal. Also emits any WARN-and-proceed notes (unknown blocks preserved). Internal so the
+    /// guard can RED-prove it catches a no-op write directly.</summary>
+    internal static string? VerifyReadBack(byte[] edited, NifInspect pre, IReadOnlyList<NifSetOp> ops, out IReadOnlyList<string> warnings)
+    {
+        warnings = Array.Empty<string>();
+        var re = new NifFile();
+        try
+        {
+            using var ms = new MemoryStream(edited, writable: false);
+            if (re.Load(ms) != 0) return "the written mesh failed to reload for verification — refusing (nothing changed on disk).";
+        }
+        catch (Exception ex) { return $"the written mesh threw on reload for verification ({ex.GetType().Name}) — refusing (nothing changed on disk)."; }
+
+        NifInspect post;
+        try { post = Build(re); }
+        catch (Exception ex) { return $"the written mesh re-inspect failed ({ex.GetType().Name}) — refusing (nothing changed on disk)."; }
+
+        if (!post.IsSkyrimSE) return "the written mesh is no longer an SE stream — refusing (nothing changed on disk).";
+        if (!CensusEqual(pre.BlockTypes, post.BlockTypes))
+            return "the written mesh's block census changed vs the original — a structural drift no whitelist op should cause. Refusing (nothing changed on disk).";
+        if (pre.UnknownBlockTypes.Count != post.UnknownBlockTypes.Count)
+            return "the written mesh's unknown-block count changed vs the original — refusing (nothing changed on disk).";
+
+        foreach (var op in ops)
+        {
+            var (ok, actual) = ReadBackMatches(re, op);
+            if (!ok)
+                return $"read-back shows the {op.Kind} on '{op.Target}' did NOT take effect (now reads {actual}) — refusing (nothing changed on disk).";
+        }
+
+        if (post.HasUnknownBlocks)
+            warnings = new[] { $"this mesh carries {post.UnknownBlockTypes.Count} unknown block type(s) ({string.Join(", ", post.UnknownBlockTypes)}) — preserved byte-for-byte (the census gate confirmed it); the edit did not touch them." };
+        return null;
+    }
+
+    static bool CensusEqual(IReadOnlyList<NifBlockTypeCount> a, IReadOnlyList<NifBlockTypeCount> b)
+    {
+        if (a.Count != b.Count) return false;
+        for (int i = 0; i < a.Count; i++) if (a[i].Type != b[i].Type || a[i].Count != b[i].Count) return false;
+        return true;
+    }
+
+    /// <summary>Re-resolve an op's target in the RELOADED mesh and confirm the written value equals what was requested
+    /// (renames resolve by the NEW name). Returns (matched, actual-as-read) — a false catches a write that silently did
+    /// not persist.</summary>
+    static (bool ok, string actual) ReadBackMatches(NifFile nif, NifSetOp op)
+    {
+        switch (op.Kind)
+        {
+            case NifSetOpKind.RenameShape:
+                return (nif.GetShapes().Any(s => (s.Name?.String ?? "") == op.NewName), $"shape names {ShapeNames(nif)}");
+            case NifSetOpKind.RenameNode:
+                return (nif.Blocks.OfType<NiNode>().Any(n => (n.Name?.String ?? "") == op.NewName), "(node name)");
+            case NifSetOpKind.SetFlags:
+            {
+                var av = nif.Blocks.OfType<NiflySharp.Blocks.NiAVObject>().FirstOrDefault(a => (a.Name?.String ?? "") == op.Target);
+                return (av is not null && op.Flags is { } f && av.Flags_ui == f, av is null ? "(target gone)" : $"0x{av.Flags_ui:X}");
+            }
+            case NifSetOpKind.SetScale:
+            {
+                var av = nif.Blocks.OfType<NiflySharp.Blocks.NiAVObject>().FirstOrDefault(a => (a.Name?.String ?? "") == op.Target);
+                return (av is not null && op.Scale is { } sc && Math.Abs(av.Scale - sc) < 1e-6f, av is null ? "(target gone)" : av.Scale.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            }
+            case NifSetOpKind.SetAlpha:
+            {
+                var s = nif.GetShapes().FirstOrDefault(x => (x.Name?.String ?? "") == op.Target);
+                var ap = s is not null && s.HasAlphaProperty ? nif.GetBlock<NiAlphaProperty>(s.AlphaPropertyRef) : null;
+                if (ap is null) return (false, "(no alpha)");
+                bool okF = op.AlphaFlags is not { } fw || ap.Flags.Value == fw;
+                bool okT = op.AlphaThreshold is not { } th || ap.Threshold == th;
+                return (okF && okT, $"0x{ap.Flags.Value:X4}/thr{ap.Threshold}");
+            }
+            case NifSetOpKind.SetPartition:
+            {
+                var s = nif.GetShapes().FirstOrDefault(x => (x.Name?.String ?? "") == op.Target);
+                var dis = s?.SkinInstanceRef is not null ? nif.GetBlock(s.SkinInstanceRef) as BSDismemberSkinInstance : null;
+                if (dis?.Partitions is null || dis.Partitions.Count == 0) return (false, "(no partitions)");
+                int idx = op.PartitionIndex ?? 0;
+                if (idx < 0 || idx >= dis.Partitions.Count) return (false, "(index gone)");
+                return (op.BodyPartId is { } bp && (int)dis.Partitions[idx].BodyPart == bp, $"[{idx}]={(int)dis.Partitions[idx].BodyPart}");
+            }
+            case NifSetOpKind.SetPath:
+            {
+                var s = nif.GetShapes().FirstOrDefault(x => (x.Name?.String ?? "") == op.Target);
+                var shader = s is not null ? nif.GetShader(s) : null;
+                var ts = shader?.TextureSetRef is not null ? nif.GetBlock(shader.TextureSetRef) as BSShaderTextureSet : null;
+                if (ts is null || op.TextureSlot is not { } slot || slot < 0 || slot >= ts.Textures.Count) return (false, "(no texset/slot)");
+                return ((ts.Textures[slot]?.Content ?? "") == op.Path, $"tex[{slot}]={ts.Textures[slot]?.Content}");
+            }
+            default: return (false, "(unknown op)");
+        }
+    }
 }
 
 // ======================================================================
@@ -284,3 +691,49 @@ public sealed record NifTexture(int Slot, string Path);
 /// nif.xml-documented SSE flag default for that type (via <see cref="FlagsDefaultType"/>) — null when none is documented
 /// / the mesh isn't SE. The renderer decodes <see cref="Flags"/> by deviation from the default, like it does for shapes.</summary>
 public sealed record NifNode(int Depth, string Name, uint Flags, string BlockType, uint? FlagsDefault, string? FlagsDefaultType);
+
+// ======================================================================
+//  NIF-layer WRITE model — the N2 whitelist op(s) and the verified outcome (Wave 2).
+// ======================================================================
+
+/// <summary>The six N2-whitelist write op kinds. Renames edit the header string table; the others edit one block.</summary>
+public enum NifSetOpKind { RenameShape, RenameNode, SetFlags, SetScale, SetPartition, SetAlpha, SetPath }
+
+/// <summary>One write op. <see cref="Target"/> is the shape/node name it addresses (the CURRENT name, for a rename).
+/// The value fields are read per <see cref="Kind"/> and are otherwise null: <see cref="NewName"/> (rename), <see
+/// cref="Flags"/> (set_flags), <see cref="Scale"/> (set_scale), <see cref="BodyPartId"/> + optional
+/// <see cref="PartitionIndex"/> (set_partition), <see cref="AlphaFlags"/> and/or <see cref="AlphaThreshold"/>
+/// (set_alpha), <see cref="TextureSlot"/> + <see cref="Path"/> (set_path — a BSShaderTextureSet slot).</summary>
+public sealed record NifSetOp(
+    NifSetOpKind Kind,
+    string Target,
+    string? NewName = null,
+    uint? Flags = null,
+    float? Scale = null,
+    int? BodyPartId = null,
+    int? PartitionIndex = null,
+    ushort? AlphaFlags = null,
+    byte? AlphaThreshold = null,
+    int? TextureSlot = null,
+    string? Path = null);
+
+/// <summary>The outcome of <see cref="NifService.Set"/>: exactly one of <see cref="WrittenBytes"/>+<see cref="Report"/>
+/// (success — the VERIFIED edited mesh bytes for the service layer to place) or <see cref="Error"/> (a named refusal,
+/// with nothing written — Q3). Never both, never neither.</summary>
+public sealed record NifSetOutcome(byte[]? WrittenBytes, NifSetReport? Report, string? Error)
+{
+    public static NifSetOutcome Fail(string error) => new(null, null, error);
+}
+
+/// <summary>What a successful <see cref="NifService.Set"/> did: the per-op before→after accounting, the block id(s) the
+/// verification confirmed were the only ones changed (+ whether the header string table changed — a rename), the size
+/// delta, and any WARN-and-proceed notes (e.g. preserved unknown blocks).</summary>
+public sealed record NifSetReport(
+    IReadOnlyList<NifOpResult> Ops,
+    IReadOnlyList<int> ChangedBlocks,
+    bool HeaderChanged,
+    long SizeDelta,
+    IReadOnlyList<string> Warnings);
+
+/// <summary>One applied op's audit line: the op kind, the target it addressed, and the before/after value as read.</summary>
+public sealed record NifOpResult(string Op, string Target, string Before, string After);

--- a/src/housecarl-core/NifService.cs
+++ b/src/housecarl-core/NifService.cs
@@ -319,6 +319,11 @@ public static class NifService
                 if (string.IsNullOrEmpty(op.NewName)) return ("rename_shape needs a new_name.", null, null, null, null, false);
                 var (shape, err) = ResolveShape(nif, op.Target);
                 if (err is not null) return (err, null, null, null, null, false);
+                // Refuse renaming ONTO an existing shape name — it manufactures the ambiguity the resolver refuses, and it
+                // would defeat the read-back check (which confirms a rename by the NEW name existing): if nifly ever
+                // dropped the rename while another shape already bore that name, gate 2 would false-pass.
+                if (nif.GetShapes().Any(s => !ReferenceEquals(s, shape) && (s.Name?.String ?? "") == op.NewName))
+                    return ($"a shape is already named '{op.NewName}' — renaming onto it would create an ambiguous duplicate. Refusing, nothing written.", null, null, null, null, false);
                 var av = (NiflySharp.Blocks.NiAVObject)shape!;
                 string before = av.Name?.String ?? "";
                 av.Name = new NiStringRef(op.NewName);
@@ -329,6 +334,8 @@ public static class NifService
                 if (string.IsNullOrEmpty(op.NewName)) return ("rename_node needs a new_name.", null, null, null, null, false);
                 var (node, err) = ResolveNode(nif, op.Target);
                 if (err is not null) return (err, null, null, null, null, false);
+                if (nif.Blocks.OfType<NiNode>().Any(n => !ReferenceEquals(n, node) && (n.Name?.String ?? "") == op.NewName))
+                    return ($"a node is already named '{op.NewName}' — renaming onto it would create an ambiguous duplicate. Refusing, nothing written.", null, null, null, null, false);
                 string before = node!.Name?.String ?? "";
                 node.Name = new NiStringRef(op.NewName);
                 return (null, op.Target, before, op.NewName, null, true);
@@ -504,12 +511,26 @@ public static class NifService
         long sum = 0; var sizes = new int[bc]; var types = new string[bc];
         for (int i = 0; i < bc; i++) { sizes[i] = nif.Header.GetBlockSize(i); types[i] = nif.Header.GetBlockTypeNameById(i) ?? "?"; sum += sizes[i]; }
 
+        // Recover the header/footer boundary. The footer is [Num Roots : uint][Roots : uint * numRoots]. We scan numRoots
+        // upward and accept the FIRST candidate whose footer both (a) leads with a Num-Roots field equal to the candidate
+        // AND (b) has every root ref a valid block index. Start at 1 — a NIF always has ≥1 root — so the degenerate
+        // numRoots=0 case can't false-match on a mesh whose sole root is block 0 (its trailing root ref reads as 0, which
+        // would spuriously satisfy a numRoots=0 candidate and shift every block window +4). The root-ref validity check
+        // makes a spurious earlier match astronomically unlikely; the true footer always validates.
         long headerEnd = -1; long footerLen = 0;
-        for (int nRoots = 0; nRoots <= 64; nRoots++)
+        for (int nRoots = 1; nRoots <= 64; nRoots++)
         {
             long fl = 4 + 4L * nRoots; long cand = buf.LongLength - fl - sum;
             if (cand <= 0) break;
-            if (cand + sum + 4 <= buf.LongLength && BitConverter.ToUInt32(buf, (int)(cand + sum)) == nRoots) { headerEnd = cand; footerLen = fl; break; }
+            if (cand + sum + fl > buf.LongLength) continue;
+            if (BitConverter.ToUInt32(buf, (int)(cand + sum)) != (uint)nRoots) continue;
+            bool refsValid = true;
+            for (int r = 0; r < nRoots; r++)
+            {
+                uint rootRef = BitConverter.ToUInt32(buf, (int)(cand + sum + 4 + 4L * r));
+                if (rootRef >= (uint)bc) { refsValid = false; break; }   // a root ref must index a real block
+            }
+            if (refsValid) { headerEnd = cand; footerLen = fl; break; }
         }
         if (headerEnd < 0) return null;
 

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -104,6 +104,10 @@ public static class CiAll
         // tree, shape flags/scale, dismember partitions, alpha) and refuses a bad file loud. Self-contained (the fixture
         // is authored in-memory via NiflySharp); the spike §5 facegen smoke arm is existence-gated (SKIPs off-corpus).
         ("nif-service-guard", NifServiceGuardProbe.RunGuard),
+        // NIF Wave 2 — housecarl_nif_set: each whitelist write op applies + verifies (two offset-immune gates), the gates
+        // RED-prove they catch a collateral/no-op write, and every can't-do is a named refusal. Self-contained; the
+        // set_path success arm is corpus-gated (nifly's read-only TextureSetRef blocks synthesizing a texture set).
+        ("nif-set-guard", NifSetGuardProbe.RunGuard),
         ("strings-decision-guard", StringsDecisionProbe.RunGuard),
         ("assetlink-write-guard", AssetLinkWriteProbe.RunGuard),
         // The two coercion COMPLETENESS proofs, now CI guards (were manual-only — the coerce-audit blind spot that

--- a/src/housecarl-generator/NifSetGuardProbe.cs
+++ b/src/housecarl-generator/NifSetGuardProbe.cs
@@ -1,0 +1,304 @@
+using System.Text;
+using HousecarlCore;
+using NiflySharp;
+using NiflySharp.Blocks;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// NifSet guard (NIF layer Wave 2). Proves <see cref="NifService.Set"/> — the byte-level mesh writer behind
+/// housecarl_nif_set — applies each N2-whitelist op correctly, VERIFIES it with the two offset-immune gates, and
+/// REFUSES loud on anything it can't safely do. Self-contained: every fixture is AUTHORED at probe time via NiflySharp
+/// itself (the spike CreateAndSave_SE recipe), so no third-party mesh ships in-repo.
+///
+/// Write arms (each op applied end-to-end through Set(), then re-inspected — a silent no-op is caught by read-back):
+///   • set_flags / set_scale — the value changes and every OTHER whitelist value is preserved.
+///   • set_alpha — flags word + threshold change together, preserved elsewhere.
+///   • set_partition — a BSDismember body-part id changes on the named shape.
+///   • rename_shape (same length AND longer) — the header-string edit lands and the length-changing case does NOT
+///     false-abort (the empirical reason gate 1 is a block-CONTENT diff, not a byte-position diff — 2026-07-08).
+///   • rename_node — a node's header-string name changes.
+///
+/// Verification RED arms (prove the gates CATCH a bad write, not merely pass through — called directly):
+///   • gate 1 (block-content) — an edit that also changed a NON-expected block is REFUSED; the same edit with that
+///     block in the expected set passes. (Proves the collateral-change abort is real.)
+///   • gate 2 (semantic read-back) — an op whose value did NOT take (a no-op) is REFUSED; the real edit passes.
+///
+/// Refusal arms (Q3 — a can't-do is a named refusal, nothing written):
+///   • non-SE stream, target-not-found, ambiguous target, op-not-applicable (set_partition/set_alpha/set_path on a
+///     shape lacking that property), out-of-range index/slot, empty ops/bytes.
+///
+/// Corpus smoke (existence-gated): set_path's success path on a REAL facegen mesh (slot 6 facetint swap) — the one op
+/// whose synthetic fixture nifly's read-only TextureSetRef blocks authoring of; SKIPs cleanly without the corpus.
+///
+/// Run: dotnet run --project src/housecarl-generator nif-set-guard ["&lt;a-facegen.nif&gt;"]
+/// </summary>
+internal static class NifSetGuardProbe
+{
+    const string DefaultSmoke = @"E:\Skyrim Modding\ARR 2.0\mods\A makeover for Lucien\meshes\actors\character\FaceGenData\FaceGeom\lucien.esp\00005900.nif";
+
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" nif-set guard — whitelist writes + verification (housecarl_nif_set)");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        var seBytes = BuildSyntheticSe();
+
+        // ---- write arms: each op end-to-end through Set(), then re-inspected ----
+        Console.WriteLine("--- writes: each N2 op applies, verifies, and preserves everything else ---");
+
+        // set_flags: shape flags change; scale / alpha / partitions untouched.
+        {
+            var o = NifService.Set(seBytes, new[] { new NifSetOp(NifSetOpKind.SetFlags, "GuardShape", Flags: 0x800000E) });
+            Check(o.Error is null && o.WrittenBytes is not null, $"set_flags succeeds — {o.Error ?? "ok"}");
+            var s = ShapeOf(o.WrittenBytes, "GuardShape");
+            Check(s is { Flags: 0x800000E }, $"set_flags read-back is 0x800000E — 0x{s?.Flags:X}");
+            Check(s is { Scale: 1.25f } && s.Alpha is { Flags: 0x12ED } && s.Partitions.Count == 2,
+                  "set_flags preserved scale / alpha / partitions");
+            Check(o.Report is { Ops.Count: 1 } && o.Report.HeaderChanged == false && o.Report.ChangedBlocks.Count == 1,
+                  $"set_flags report: 1 op, header unchanged, 1 block — {(o.Report is null ? "no report" : $"hdr={o.Report.HeaderChanged} blocks={o.Report.ChangedBlocks.Count}")}");
+        }
+
+        // set_scale
+        {
+            var o = NifService.Set(seBytes, new[] { new NifSetOp(NifSetOpKind.SetScale, "GuardShape", Scale: 2.5f) });
+            var s = ShapeOf(o.WrittenBytes, "GuardShape");
+            Check(o.Error is null && s is not null && Math.Abs(s.Scale - 2.5f) < 1e-6f, $"set_scale read-back is 2.5 — {s?.Scale.ToString() ?? o.Error}");
+            Check(s is { Flags: 0x400000E }, "set_scale preserved flags");
+        }
+
+        // set_alpha: flags word + threshold together
+        {
+            var o = NifService.Set(seBytes, new[] { new NifSetOp(NifSetOpKind.SetAlpha, "GuardShape", AlphaFlags: 0x00ED, AlphaThreshold: 200) });
+            var s = ShapeOf(o.WrittenBytes, "GuardShape");
+            Check(o.Error is null && s?.Alpha is { Flags: 0x00ED, Threshold: 200 },
+                  $"set_alpha read-back 0x00ED/thr200 — {(s?.Alpha is null ? o.Error : $"0x{s.Alpha.Flags:X4}/thr{s.Alpha.Threshold}")}");
+            Check(s is { Flags: 0x400000E, Scale: 1.25f }, "set_alpha preserved flags / scale");
+        }
+
+        // set_partition: body-part id 30 -> 32 on partition 0
+        {
+            var o = NifService.Set(seBytes, new[] { new NifSetOp(NifSetOpKind.SetPartition, "GuardShape", BodyPartId: 32, PartitionIndex: 0) });
+            var s = ShapeOf(o.WrittenBytes, "GuardShape");
+            Check(o.Error is null && s is not null && s.Partitions.Count == 2 && s.Partitions[0].BodyPartId == 32 && s.Partitions[1].BodyPartId == 31,
+                  $"set_partition read-back [0]=32,[1]=31 — {(s is null ? o.Error : string.Join(",", s.Partitions.Select(p => p.BodyPartId)))}");
+        }
+
+        // rename_shape SAME length + LONGER (the length-changing case must NOT false-abort — the whole reason for the
+        // block-content-diff refinement). Both preserve every other value.
+        {
+            var o1 = NifService.Set(seBytes, new[] { new NifSetOp(NifSetOpKind.RenameShape, "GuardShape", NewName: "GuardShapX") });
+            Check(o1.Error is null && ShapeOf(o1.WrittenBytes, "GuardShapX") is not null, $"rename_shape (same length) — {o1.Error ?? "ok"}");
+            Check(o1.Report is { HeaderChanged: true, ChangedBlocks.Count: 0 }, "rename touches the header string table, ZERO blocks");
+
+            var o2 = NifService.Set(seBytes, new[] { new NifSetOp(NifSetOpKind.RenameShape, "GuardShape", NewName: "GuardShapeRenamedMuchLonger") });
+            var s = ShapeOf(o2.WrittenBytes, "GuardShapeRenamedMuchLonger");
+            Check(o2.Error is null && s is not null, $"rename_shape (LONGER) does not false-abort — {o2.Error ?? "ok"}");
+            Check(s is { Flags: 0x400000E, Scale: 1.25f } && s.Alpha is { Flags: 0x12ED } && s.Partitions.Count == 2,
+                  "a length-changing rename preserved flags / scale / alpha / partitions");
+        }
+
+        // rename_node
+        {
+            var o = NifService.Set(seBytes, new[] { new NifSetOp(NifSetOpKind.RenameNode, "GuardChildA", NewName: "RenamedChildA") });
+            var back = NifService.Inspect(o.WrittenBytes ?? Array.Empty<byte>()).Inspect;
+            Check(o.Error is null && back is not null && back.Nodes.Any(n => n.Name == "RenamedChildA") && back.Nodes.All(n => n.Name != "GuardChildA"),
+                  $"rename_node GuardChildA -> RenamedChildA — {o.Error ?? "ok"}");
+        }
+
+        // multi-op in one call
+        {
+            var o = NifService.Set(seBytes, new[]
+            {
+                new NifSetOp(NifSetOpKind.SetFlags, "GuardShape", Flags: 0x800000E),
+                new NifSetOp(NifSetOpKind.SetScale, "GuardShape", Scale: 3f),
+            });
+            var s = ShapeOf(o.WrittenBytes, "GuardShape");
+            Check(o.Error is null && s is { Flags: 0x800000E } && Math.Abs(s!.Scale - 3f) < 1e-6f,
+                  $"two ops in one call both land — {(s is null ? o.Error : $"0x{s.Flags:X}/{s.Scale}")}");
+        }
+
+        // ---- verification RED arms: the gates CATCH a bad write (called directly) ----
+        Console.WriteLine();
+        Console.WriteLine("--- verification: the two gates refuse a bad write, not merely pass ---");
+
+        // gate 1 (block-content): an edit that also changed a NON-expected block is refused.
+        {
+            var (edited2, shapeIdx, childIdx) = TwoBlockEdit(seBytes);
+            var refuse = NifService.VerifyBlockContent(seBytes, edited2, new HashSet<int> { shapeIdx }, expectHeader: false);
+            Check(refuse is not null && refuse.Contains("should not have touched"),
+                  $"gate 1 REFUSES a collateral (non-expected-block) change — {refuse ?? "(passed — BUG)"}");
+            var pass = NifService.VerifyBlockContent(seBytes, edited2, new HashSet<int> { shapeIdx, childIdx }, expectHeader: false);
+            Check(pass is null, $"gate 1 PASSES when both changed blocks are expected — {pass ?? "ok"}");
+        }
+
+        // gate 2 (semantic read-back): an op whose value did NOT take (a no-op) is refused.
+        {
+            var pre = NifService.Inspect(seBytes).Inspect!;
+            // 'edited' == the original bytes (nothing applied), but we claim to have set flags to a NEW value.
+            var noOp = NifService.VerifyReadBack(seBytes, pre, new[] { new NifSetOp(NifSetOpKind.SetFlags, "GuardShape", Flags: 0xABCDE) }, out _);
+            Check(noOp is not null && noOp.Contains("did NOT take effect"),
+                  $"gate 2 REFUSES a no-op write (read-back != requested) — {noOp ?? "(passed — BUG)"}");
+            // and passes when the value really is present (flags already 0x400000E in the original)
+            var real = NifService.VerifyReadBack(seBytes, pre, new[] { new NifSetOp(NifSetOpKind.SetFlags, "GuardShape", Flags: 0x400000E) }, out _);
+            Check(real is null, $"gate 2 PASSES when read-back matches the request — {real ?? "ok"}");
+        }
+
+        // ---- refusal arms (Q3) ----
+        Console.WriteLine();
+        Console.WriteLine("--- refusals: a can't-do is named, nothing written ---");
+
+        Check(NifService.Set(Array.Empty<byte>(), new[] { new NifSetOp(NifSetOpKind.SetFlags, "X", Flags: 1) }).Error is { } e0 && e0.Contains("empty"),
+              "empty bytes → named refusal");
+        Check(NifService.Set(seBytes, Array.Empty<NifSetOp>()).Error is not null, "no ops → named refusal");
+        Check(NifService.Set(seBytes, new[] { new NifSetOp(NifSetOpKind.SetFlags, "NoSuchShape", Flags: 1) }).Error is { } e1 && e1.Contains("no shape or node named"),
+              "target not found → named refusal");
+        Check(NifService.Set(seBytes, new[] { new NifSetOp(NifSetOpKind.SetPartition, "BareShape", BodyPartId: 32) }).Error is { } e2 && e2.Contains("no BSDismember"),
+              "set_partition on a shape with no skin → named refusal");
+        Check(NifService.Set(seBytes, new[] { new NifSetOp(NifSetOpKind.SetAlpha, "BareShape", AlphaThreshold: 10) }).Error is { } e3 && e3.Contains("no alpha property"),
+              "set_alpha on a shape with no alpha → named refusal");
+        Check(NifService.Set(seBytes, new[] { new NifSetOp(NifSetOpKind.SetPath, "BareShape", TextureSlot: 0, Path: "x.dds") }).Error is { } e4 && e4.Contains("no shader texture set"),
+              "set_path on a shape with no texture set → named refusal");
+        Check(NifService.Set(seBytes, new[] { new NifSetOp(NifSetOpKind.SetPartition, "GuardShape", BodyPartId: 32, PartitionIndex: 9) }).Error is { } e5 && e5.Contains("out of range"),
+              "partition_index out of range → named refusal");
+        Check(NifService.Set(seBytes, new[] { new NifSetOp(NifSetOpKind.RenameShape, "GuardShape") }).Error is { } e6 && e6.Contains("new_name"),
+              "rename with no new_name → named refusal");
+
+        // ambiguous target — a mesh with two shapes both named 'Dup'
+        {
+            var dup = BuildDupNameSe();
+            Check(NifService.Set(dup, new[] { new NifSetOp(NifSetOpKind.SetFlags, "Dup", Flags: 1) }).Error is { } ed && ed.Contains("ambiguous"),
+                  "ambiguous shape name → named refusal (never a silent first-match write)");
+        }
+
+        // non-SE stream refusal
+        {
+            var le = TryBuildNonSe();
+            if (le is null) Console.WriteLine("  SKIP  could not author a non-SE fixture on this NiflySharp build (SE gate still covered by the IsSkyrimSE read path).");
+            else Check(NifService.Set(le, new[] { new NifSetOp(NifSetOpKind.SetFlags, "GuardShape", Flags: 1) }).Error is { } el && el.Contains("NOT a Skyrim SE"),
+                       "non-SE stream → named refusal (no cross-game write)");
+        }
+
+        // ---- corpus smoke (existence-gated): set_path success on a REAL facegen mesh ----
+        Console.WriteLine();
+        Console.WriteLine("--- corpus smoke: set_path on a real facegen texture set (existence-gated) ---");
+        var smoke = args.Length > 0 ? args[0] : (Environment.GetEnvironmentVariable("HOUSECARL_NIF_SMOKE") ?? DefaultSmoke);
+        if (!File.Exists(smoke))
+            Console.WriteLine($"  SKIP  no facegen mesh at '{smoke}' (pass one as arg 1 or set HOUSECARL_NIF_SMOKE). set_path shares the in-block machinery the CI arms above prove.");
+        else
+        {
+            var fgBytes = File.ReadAllBytes(smoke);
+            var fg = NifService.Inspect(fgBytes).Inspect;
+            var head = fg?.Shapes.FirstOrDefault(x => x.Textures.Any(t => t.Slot == 6));
+            if (head is null) Console.WriteLine("  SKIP  the smoke mesh has no slot-6 texture to swap.");
+            else
+            {
+                const string newPath = @"textures\actors\character\facegendata\facetint\HOUSECARL_TEST\swapped.dds";
+                var o = NifService.Set(fgBytes, new[] { new NifSetOp(NifSetOpKind.SetPath, head.Name, TextureSlot: 6, Path: newPath) });
+                Check(o.Error is null && o.WrittenBytes is not null, $"set_path on a real facegen slot 6 succeeds — {o.Error ?? "ok"}");
+                var back = ShapeOf(o.WrittenBytes, head.Name);
+                Check(back is not null && back.Textures.Any(t => t.Slot == 6 && t.Path == newPath),
+                      $"set_path read-back shows the new slot-6 path — {back?.Textures.FirstOrDefault(t => t.Slot == 6)?.Path ?? "(gone)"}");
+                Check(back is not null && back.Flags == head.Flags && back.Partitions.Count == head.Partitions.Count,
+                      "set_path on real data preserved the shape's flags / partitions");
+            }
+        }
+
+        Console.WriteLine();
+        Console.WriteLine(fail == 0 ? "================ ALL PASS ================" : $"================ {fail} CHECK(S) FAILED ================");
+        return fail == 0 ? 0 : 1;
+    }
+
+    static NifShape? ShapeOf(byte[]? bytes, string name)
+        => bytes is null ? null : NifService.Inspect(bytes).Inspect?.Shapes.FirstOrDefault(s => s.Name == name);
+
+    /// <summary>Author a synthetic SE mesh: root → GuardChildA node; a full GuardShape (flags/scale/alpha/2 partitions);
+    /// and a BareShape carrying nothing (for the not-applicable refusal arms). The spike CreateAndSave_SE recipe.</summary>
+    static byte[] BuildSyntheticSe()
+    {
+        var ver = new NiVersion { FileVersion = NiVersion.ToFile("20.2.0.7"), UserVersion = 12, StreamVersion = 100 };
+        var f = new NifFile();
+        f.Create(ver, withRootNode: true);
+        var root = f.GetRootNodes().First();
+        root.Name = new NiStringRef("GuardRoot"); root.Flags_ui = 0xE;
+
+        var childA = new NiNode { Name = new NiStringRef("GuardChildA"), Flags_ui = 0x40000E };
+        root.Children.AddBlockRef(f.AddBlock(childA));
+
+        var shape = new BSTriShape { Name = new NiStringRef("GuardShape"), Flags_ui = 0x400000E, Scale = 1.25f };
+        root.Children.AddBlockRef(f.AddBlock(shape));
+        var alpha = new NiAlphaProperty { Threshold = 128 }; alpha.Flags.Value = 0x12ED;
+        shape.AlphaPropertyRef = new NiBlockRef<NiAlphaProperty>(f.AddBlock(alpha));
+        var skin = new BSDismemberSkinInstance
+        {
+            Partitions = new List<NiflySharp.Structs.BodyPartList>
+            {
+                new() { BodyPart = (NiflySharp.Enums.BSDismemberBodyPartType)30, PartFlag = (NiflySharp.Enums.BSPartFlag)257 },
+                new() { BodyPart = (NiflySharp.Enums.BSDismemberBodyPartType)31, PartFlag = (NiflySharp.Enums.BSPartFlag)257 },
+            },
+        };
+        skin.NumPartitions = (uint)skin.Partitions.Count;
+        shape.SkinInstanceRef = new NiBlockRef<NiflySharp.NiObject>(f.AddBlock(skin));
+
+        var bare = new BSTriShape { Name = new NiStringRef("BareShape"), Flags_ui = 0x400000E, Scale = 1f };
+        root.Children.AddBlockRef(f.AddBlock(bare));
+
+        using var ms = new MemoryStream();
+        if (f.Save(ms) != 0) throw new InvalidOperationException("nif-set-guard: authoring the synthetic SE mesh failed to save");
+        return ms.ToArray();
+    }
+
+    /// <summary>A synthetic SE mesh with TWO shapes both named 'Dup' — for the ambiguous-target refusal arm.</summary>
+    static byte[] BuildDupNameSe()
+    {
+        var ver = new NiVersion { FileVersion = NiVersion.ToFile("20.2.0.7"), UserVersion = 12, StreamVersion = 100 };
+        var f = new NifFile();
+        f.Create(ver, withRootNode: true);
+        var root = f.GetRootNodes().First(); root.Name = new NiStringRef("Root"); root.Flags_ui = 0xE;
+        root.Children.AddBlockRef(f.AddBlock(new BSTriShape { Name = new NiStringRef("Dup"), Flags_ui = 0x400000E, Scale = 1f }));
+        root.Children.AddBlockRef(f.AddBlock(new BSTriShape { Name = new NiStringRef("Dup"), Flags_ui = 0x400000E, Scale = 1f }));
+        using var ms = new MemoryStream();
+        if (f.Save(ms) != 0) throw new InvalidOperationException("nif-set-guard: authoring the dup-name mesh failed");
+        return ms.ToArray();
+    }
+
+    /// <summary>Try to author a NON-SE-stream fixture. Returns null if this NiflySharp build won't produce one that
+    /// re-parses as non-SE (the arm SKIPs rather than fail — the SE gate is still exercised by the read path).</summary>
+    static byte[]? TryBuildNonSe()
+    {
+        try
+        {
+            var ver = new NiVersion { FileVersion = NiVersion.ToFile("20.2.0.7"), UserVersion = 12, StreamVersion = 83 };
+            var f = new NifFile();
+            f.Create(ver, withRootNode: true);
+            var root = f.GetRootNodes().First(); root.Name = new NiStringRef("GuardShape"); root.Flags_ui = 0xE;
+            using var ms = new MemoryStream();
+            if (f.Save(ms) != 0) return null;
+            var bytes = ms.ToArray();
+            var chk = NifService.Inspect(bytes).Inspect;
+            return chk is { IsSkyrimSE: false } ? bytes : null;   // only usable if it truly reads back as non-SE
+        }
+        catch { return null; }
+    }
+
+    /// <summary>Author the synthetic mesh, load it, and change TWO blocks (the GuardShape's flags AND GuardChildA's
+    /// flags), returning the edited bytes plus both block ids — the input the gate-1 RED arm feeds VerifyBlockContent.</summary>
+    static (byte[] edited, int shapeIdx, int childIdx) TwoBlockEdit(byte[] seBytes)
+    {
+        var nif = new NifFile();
+        using (var ms = new MemoryStream(seBytes)) nif.Load(ms);
+        var shape = nif.GetShapes().First(s => s.Name?.String == "GuardShape");
+        var child = nif.Blocks.OfType<NiNode>().First(n => n.Name?.String == "GuardChildA");
+        ((NiAVObject)shape).Flags_ui = 0x800000E;
+        child.Flags_ui = 0x123456;
+        nif.GetBlockIndex(shape, out int shapeIdx);
+        nif.GetBlockIndex(child, out int childIdx);
+        using var outMs = new MemoryStream();
+        nif.Save(outMs);
+        return (outMs.ToArray(), shapeIdx, childIdx);
+    }
+}

--- a/src/housecarl-generator/NifSetGuardProbe.cs
+++ b/src/housecarl-generator/NifSetGuardProbe.cs
@@ -183,6 +183,66 @@ internal static class NifSetGuardProbe
                        "non-SE stream → named refusal (no cross-game write)");
         }
 
+        // ---- service lanes end-to-end (REAL LoadOrderService over a synthetic MO2 instance — PlaceAssetProbe pattern) ----
+        Console.WriteLine();
+        Console.WriteLine("--- service: new-folder + in-place lanes + persistent consent (real LoadOrderService) ---");
+        const string MeshRel = @"meshes\actors\character\facegendata\facegeom\Test.esp\00000001.nif";
+        var svcRoot = Path.Combine(Path.GetTempPath(), "hc-nif-set-guard-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(svcRoot);
+        try
+        {
+            // DEFAULT (new-folder) lane: the edited mesh lands in a fresh houseCARL folder; original untouched; winner reported.
+            {
+                var inst = Path.Combine(svcRoot, "new");
+                var (mods, _, prof) = MakeInstance(inst);
+                var mod = Path.Combine(mods, "FaceMod"); Directory.CreateDirectory(mod);
+                WriteLoose(mod, MeshRel, seBytes);
+                File.WriteAllText(Path.Combine(mod, "Dummy.esp"), "x");
+                WriteProfile(prof, new[] { "Dummy.esp" }, new[] { "*Dummy.esp" }, new[] { "+FaceMod" });
+                WriteSkyrimIni(prof);
+                using var svc = HousecarlMcp.LoadOrderService.WithInstance(inst, 0, new UserConfigStore(Path.Combine(svcRoot, "u-new.json")));
+
+                var res = svc.NifSet(MeshRel, new[] { new NifSetOp(NifSetOpKind.SetFlags, "GuardShape", Flags: 0x800000E) }, null, "FaceFix", null, inPlace: false, acknowledge: false);
+                Check(res.Error is null && res.OutputModFolder is not null, $"new-folder lane writes a verified mesh into a fresh houseCARL folder — {res.Error ?? "ok"}");
+                var placed = res.OutputModFolder is null ? null : Path.Combine(res.OutputModFolder, MeshRel);
+                Check(placed is not null && File.Exists(placed), "the edited mesh lands at the SAME rel path in the new folder");
+                Check(ShapeOf(placed is null ? null : File.ReadAllBytes(placed), "GuardShape") is { Flags: 0x800000E }, "the placed mesh reads the new flags");
+                Check(File.ReadAllBytes(Path.Combine(mod, MeshRel)).SequenceEqual(seBytes), "the ORIGINAL loose mesh is untouched (non-destructive default)");
+                Check(res.CurrentWinner is { } w && w.Contains("FaceMod"), $"reports the current winner to sort above — {res.CurrentWinner}");
+            }
+
+            // IN-PLACE lane: first call prompts for consent (nothing written); ack writes in place; a later edit needs no re-ack.
+            {
+                var inst = Path.Combine(svcRoot, "ip");
+                var (mods, _, prof) = MakeInstance(inst);
+                var mod = Path.Combine(mods, "FaceMod"); Directory.CreateDirectory(mod);
+                WriteLoose(mod, MeshRel, seBytes);
+                File.WriteAllText(Path.Combine(mod, "Dummy.esp"), "x");
+                WriteProfile(prof, new[] { "Dummy.esp" }, new[] { "*Dummy.esp" }, new[] { "+FaceMod" });
+                WriteSkyrimIni(prof);
+                var loosePath = Path.Combine(mod, MeshRel);
+                using var svc = HousecarlMcp.LoadOrderService.WithInstance(inst, 0, new UserConfigStore(Path.Combine(svcRoot, "u-ip.json")));
+
+                var r1 = svc.NifSet(MeshRel, new[] { new NifSetOp(NifSetOpKind.SetFlags, "GuardShape", Flags: 0x800000E) }, null, null, null, inPlace: true, acknowledge: false);
+                Check(r1.NeedsAcknowledge && r1.Report is null, $"in-place FIRST call without acknowledge → consent prompt, nothing written — {(r1.NeedsAcknowledge ? "prompt" : "NO PROMPT")}");
+                Check(File.ReadAllBytes(loosePath).SequenceEqual(seBytes), "the loose file is untouched by the un-acknowledged in-place call");
+
+                var r2 = svc.NifSet(MeshRel, new[] { new NifSetOp(NifSetOpKind.SetFlags, "GuardShape", Flags: 0x800000E) }, null, null, null, inPlace: true, acknowledge: true);
+                Check(r2.Error is null && r2.InPlace && r2.InPlacePath == loosePath, $"in-place WITH acknowledge overwrites the loose file where it sits — {r2.Error ?? "ok"}");
+                Check(ShapeOf(File.ReadAllBytes(loosePath), "GuardShape") is { Flags: 0x800000E }, "the in-place file now reads the new flags");
+
+                var r3 = svc.NifSet(MeshRel, new[] { new NifSetOp(NifSetOpKind.SetScale, "GuardShape", Scale: 2f) }, null, null, null, inPlace: true, acknowledge: false);
+                Check(r3.Error is null && !r3.NeedsAcknowledge && r3.InPlace, $"a LATER in-place edit of the same file needs NO re-acknowledge (consent persisted) — {(r3.NeedsAcknowledge ? "RE-PROMPTED" : "ok")}");
+
+                // mutual exclusion + absent path refusals through the service
+                Check(svc.NifSet(MeshRel, new[] { new NifSetOp(NifSetOpKind.SetScale, "GuardShape", Scale: 1f) }, null, null, "SomeFolder", inPlace: true, acknowledge: false).Error is { } em && em.Contains("mutually exclusive"),
+                      "in_place + into= → named refusal (mutually exclusive)");
+                Check(svc.NifSet(@"meshes\nope\absent.nif", new[] { new NifSetOp(NifSetOpKind.SetScale, "GuardShape", Scale: 1f) }, null, null, null, false, false).Error is { } ea && ea.Contains("ABSENT"),
+                      "an absent mesh path → ABSENT refusal");
+            }
+        }
+        finally { try { Directory.Delete(svcRoot, recursive: true); } catch { /* temp scratch */ } }
+
         // ---- corpus smoke (existence-gated): set_path success on a REAL facegen mesh ----
         Console.WriteLine();
         Console.WriteLine("--- corpus smoke: set_path on a real facegen texture set (existence-gated) ---");
@@ -300,5 +360,40 @@ internal static class NifSetGuardProbe
         using var outMs = new MemoryStream();
         nif.Save(outMs);
         return (outMs.ToArray(), shapeIdx, childIdx);
+    }
+
+    // ---- synthetic MO2 layout helpers (the PlaceAssetProbe / AssetStatusProbe pattern) ----
+
+    static (string mods, string data, string prof) MakeInstance(string inst)
+    {
+        var mods = Path.Combine(inst, "mods");
+        var data = Path.Combine(inst, "game", "Data");
+        var prof = Path.Combine(inst, "profiles", "Default");
+        foreach (var d in new[] { mods, data, prof }) Directory.CreateDirectory(d);
+        File.WriteAllText(Path.Combine(inst, "ModOrganizer.ini"),
+            "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+            + Path.Combine(inst, "game").Replace(@"\", @"\\") + ")\r\n");
+        return (mods, data, prof);
+    }
+
+    static void WriteProfile(string profDir, string[] loadorder, string[] plugins, string[] modlist)
+    {
+        Directory.CreateDirectory(profDir);
+        File.WriteAllText(Path.Combine(profDir, "loadorder.txt"), "# header\r\n" + string.Join("\r\n", loadorder) + "\r\n");
+        File.WriteAllText(Path.Combine(profDir, "plugins.txt"), string.Join("\r\n", plugins) + "\r\n");
+        File.WriteAllText(Path.Combine(profDir, "modlist.txt"), "# header\r\n" + string.Join("\r\n", modlist) + "\r\n");
+    }
+
+    static void WriteSkyrimIni(string profDir)
+    {
+        Directory.CreateDirectory(profDir);
+        File.WriteAllText(Path.Combine(profDir, "Skyrim.ini"), "[Archive]\r\nsResourceArchiveList=\r\n");
+    }
+
+    static void WriteLoose(string baseDir, string rel, byte[] bytes)
+    {
+        var p = Path.Combine(baseDir, rel);
+        Directory.CreateDirectory(Path.GetDirectoryName(p)!);
+        File.WriteAllBytes(p, bytes);
     }
 }

--- a/src/housecarl-generator/NifSetGuardProbe.cs
+++ b/src/housecarl-generator/NifSetGuardProbe.cs
@@ -167,6 +167,8 @@ internal static class NifSetGuardProbe
               "partition_index out of range → named refusal");
         Check(NifService.Set(seBytes, new[] { new NifSetOp(NifSetOpKind.RenameShape, "GuardShape") }).Error is { } e6 && e6.Contains("new_name"),
               "rename with no new_name → named refusal");
+        Check(NifService.Set(seBytes, new[] { new NifSetOp(NifSetOpKind.RenameShape, "GuardShape", NewName: "BareShape") }).Error is { } e7 && e7.Contains("already named"),
+              "rename ONTO an existing shape name → named refusal (no manufactured duplicate; keeps gate-2 read-back sound)");
 
         // ambiguous target — a mesh with two shapes both named 'Dup'
         {
@@ -265,6 +267,18 @@ internal static class NifSetGuardProbe
                       $"set_path read-back shows the new slot-6 path — {back?.Textures.FirstOrDefault(t => t.Slot == 6)?.Path ?? "(gone)"}");
                 Check(back is not null && back.Flags == head.Flags && back.Partitions.Count == head.Partitions.Count,
                       "set_path on real data preserved the shape's flags / partitions");
+
+                // rename on REAL data — the flagship facegen case, and the op most exposed to nifly's string-table
+                // rebuild (a rebuilt table that reindexed shared strings would change OTHER blocks' name refs → gate-1
+                // would refuse). This arm proves a real-mesh rename does NOT false-refuse — and (with a length change)
+                // exercises the F1 block-slicing recovery on a real footer, where a +4 misalign would surface.
+                var reName = head.Name + "_HC_RENAMED_LONGER";
+                var ro = NifService.Set(fgBytes, new[] { new NifSetOp(NifSetOpKind.RenameShape, head.Name, NewName: reName) });
+                Check(ro.Error is null && ro.WrittenBytes is not null, $"rename_shape on a real facegen mesh does NOT false-refuse — {ro.Error ?? "ok"}");
+                var rb = ShapeOf(ro.WrittenBytes, reName);
+                Check(rb is not null && rb.Flags == head.Flags && rb.Partitions.Count == head.Partitions.Count,
+                      $"the real-mesh rename landed + preserved flags/partitions — {(rb is null ? "shape GONE" : "ok")}");
+                Check(ro.Report is { HeaderChanged: true }, "the real-mesh rename touched the header string table (as expected)");
             }
         }
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -386,6 +386,125 @@ public sealed class LoadOrderService : IDisposable
     /// ternary) so a future AssetKind arm renders its real name, never a silent mislabel.</summary>
     static string KindLabel(AssetKind k) => k switch { AssetKind.Bsa => "BSA", AssetKind.Loose => "loose", var other => other.ToString() };
 
+    // ---- NIF layer Wave 2: whitelist WRITES into a mesh (housecarl_nif_set) ----
+
+    /// <summary>Apply the N2-whitelist write op(s) to a mesh (housecarl_nif_set): resolve the Data-relative
+    /// <paramref name="relPath"/> to the WINNING copy (or <paramref name="mod"/>'s copy), read its bytes IN PROCESS, hand
+    /// them to <see cref="NifService.Set"/> (which applies + VERIFIES with the two offset-immune gates, or refuses loud —
+    /// nothing is written to disk unless it verified), then place the verified bytes. Two lanes, mirroring the record
+    /// write lanes:
+    ///   • DEFAULT (non-destructive): write into a NEW houseCARL-owned MO2 mod folder (same relative path) that the modder
+    ///     enables + sorts ABOVE the current winner so the edited copy WINS the VFS — originals untouched. A BSA-packed
+    ///     source naturally becomes a loose winning override this way.
+    ///   • IN-PLACE (opt-in, <paramref name="inPlace"/>): OVERWRITE the winning LOOSE file where it sits, riding the SAME
+    ///     persistent first-touch consent handshake as the record in-place lane (keyed on the resolved file path,
+    ///     <see cref="UserConfigStore"/>) — no backup. A BSA-only winner can't be edited in place (there is no loose file);
+    ///     that refuses with the default-lane guidance.
+    /// Serialized on the write gate. Q3 honesty: for the default lane "wrote it" ≠ "it wins" — the render says to enable +
+    /// sort the fresh mod; this never claims the fix took effect on write.</summary>
+    public NifSetResult NifSet(string relPath, IReadOnlyList<NifSetOp> ops, string? mod, string? patchName, string? into, bool inPlace, bool acknowledge)
+    {
+        var rel = (relPath ?? "").Trim();
+        if (rel.Length == 0) return NifSetResult.Fail("no mesh path given. Pass a Data-relative path, e.g. 'meshes\\armor\\iron\\cuirass_1.nif'.");
+        if (ops is null || ops.Count == 0) return NifSetResult.Fail("no write op given — pass at least one op (e.g. set_flags, rename_shape).");
+        if (inPlace && !string.IsNullOrWhiteSpace(into))
+            return NifSetResult.Fail("in_place and into are mutually exclusive — in_place overwrites the winning file where it sits; into= names a NEW houseCARL folder.");
+
+        lock (_writeGate)
+        {
+            AssetResolver.AssetView view; IReadOnlyList<string> warnings; string profileName;
+            try { lock (_gate) { view = Assets.Capture(); warnings = _assetWarnings; profileName = _profileName; } }
+            catch (Exception ex) { return NifSetResult.Fail($"could not resolve the asset layer (the MO2 instance may not be readable): {ex.Message}"); }
+
+            PlacementResolution place;
+            try { place = view.ResolveForPlacement(rel); }
+            catch (ArgumentException ex) { return NifSetResult.Fail($"invalid path — {ex.Message}"); }
+
+            var providers = place.Sources.Select(s => new NifProvider(s.ProviderName, KindLabel(s.Kind))).ToList();
+            if (place.Sources.Count == 0)
+                return NifSetResult.Fail($"ABSENT — no active mod or BSA provides '{rel}', so there is no copy to edit.", providers, profileName);
+
+            // pick the copy to read/edit: the VFS winner, or a specific provider when mod= names one.
+            PlacementSource chosen;
+            if (!string.IsNullOrWhiteSpace(mod))
+            {
+                var pick = place.Sources.FirstOrDefault(s => s.ProviderName.Equals(mod!.Trim(), StringComparison.OrdinalIgnoreCase));
+                if (pick is null)
+                    return NifSetResult.Fail($"mod '{mod!.Trim()}' does not provide this path. Providers (winner first): {string.Join(", ", providers.Select(p => p.Name + " (" + p.Kind + ")"))}.", providers, profileName);
+                chosen = pick;
+            }
+            else chosen = place.Sources[0];
+
+            var (bytes, readErr) = AssetResolver.ReadPlacementSource(chosen);
+            if (bytes is null) return NifSetResult.Fail(readErr ?? "could not read the resolved mesh bytes.", providers, profileName);
+
+            // ---- apply + verify (pure; NOTHING is written unless this returns verified bytes) ----
+            var outcome = NifService.Set(bytes, ops);
+            if (outcome.Error is not null) return NifSetResult.Fail(outcome.Error, providers, profileName);
+            var editedBytes = outcome.WrittenBytes!;
+            var report = outcome.Report!;
+            var chosenProv = new NifProvider(chosen.ProviderName, KindLabel(chosen.Kind));
+
+            // ---- IN-PLACE lane ----
+            if (inPlace)
+            {
+                if (chosen.Kind != AssetKind.Loose || string.IsNullOrEmpty(chosen.LooseFilePath))
+                    return NifSetResult.Fail(
+                        $"in-place needs a LOOSE copy to overwrite, but '{rel}' resolves to {chosen.ProviderName} ({KindLabel(chosen.Kind)}). " +
+                        "Drop in_place to write a loose winning override into a new houseCARL folder instead (the default lane).", providers, profileName);
+                var targetPath = chosen.LooseFilePath!;
+                var meshName = Path.GetFileName(targetPath);
+
+                bool already = _store.IsInPlaceAcknowledged(targetPath);
+                if (!already && !acknowledge)
+                    return NifSetResult.NeedsAck(InPlaceHandshakeText(meshName, targetPath), chosenProv, providers, profileName);
+                string? ackNote = null;
+                if (!already && acknowledge)
+                {
+                    var (ok, err) = _store.RecordInPlaceAcknowledged(targetPath);
+                    if (!ok) ackNote = $"the in-place acknowledgement could not be saved ({err}) — the edit proceeded, but a future session will re-prompt for this file.";
+                }
+
+                if (InPlaceParentUnwritable(targetPath, out var why)) return NifSetResult.Fail(why, providers, profileName);
+                try { AtomicFile.WriteAllBytes(targetPath, editedBytes); }
+                catch (Exception ex) { return NifSetResult.Fail($"could not overwrite '{targetPath}' in place: {ex.Message}. Nothing was written.", providers, profileName); }
+                long sz; try { sz = new FileInfo(targetPath).Length; } catch { sz = -1; }
+                if (sz != editedBytes.Length)
+                    return NifSetResult.Fail($"wrote '{meshName}' but its on-disk size ({sz}) does not match the {editedBytes.Length} verified byte(s) — verify before relying on it.", providers, profileName);
+
+                return NifSetResult.OkInPlace(rel, chosenProv, providers, place.Ambiguous, report, targetPath,
+                    Combine(report.Warnings, ackNote), profileName);
+            }
+
+            // ---- DEFAULT (new-folder) lane ----
+            RiderFolder rf;
+            try { rf = ResolvePatchModFolder(patchName, into, "houseCARL_NifEdit"); }
+            catch (InvalidOperationException ex) { return NifSetResult.Fail(ex.Message, providers, profileName); }
+
+            var dest = Path.Combine(rf.OutputDir, rel);
+            try { Directory.CreateDirectory(Path.GetDirectoryName(dest)!); AtomicFile.WriteAllBytes(dest, editedBytes); }
+            catch (Exception ex)
+            {
+                var residue = RemoveOrNameRiderResidue(rf);
+                return NifSetResult.Fail($"could not write '{rel}' into the patch folder: {ex.Message}"
+                    + (residue is null ? "" : $" The freshly created mod folder was left at '{residue}'."), providers, profileName);
+            }
+            long size; try { size = new FileInfo(dest).Length; } catch { size = -1; }
+            if (size != editedBytes.Length)
+            {
+                RemoveOrNameRiderResidue(rf);
+                return NifSetResult.Fail($"wrote '{rel}' but its on-disk size ({size}) does not match the {editedBytes.Length} verified byte(s) — verify before relying on it.", providers, profileName);
+            }
+
+            string? winner = providers.Count > 0 ? $"{providers[0].Name} ({providers[0].Kind})" : null;
+            return NifSetResult.OkNewFolder(rel, chosenProv, providers, place.Ambiguous, report, rf.ModFolder, winner, warnings, profileName);
+        }
+    }
+
+    /// <summary>Concatenate a warnings list with an optional extra note (in-place ack save failure), dropping nulls.</summary>
+    static IReadOnlyList<string> Combine(IReadOnlyList<string> warnings, string? extra)
+        => extra is null ? warnings : warnings.Append(extra).ToList();
+
     // ---- facegen-diagnostics Phase 3: place an asset so the correct copy WINS the VFS (housecarl_place_asset) ----
 
     /// <summary>Place one-or-more assets (FaceGen .nif/.dds, or any Data-relative file) into a NEW houseCARL-owned MO2 mod
@@ -3766,6 +3885,43 @@ public sealed record NifInspectData(
 {
     public static NifInspectData Fail(string relPath, string error)
         => new(relPath, null, Array.Empty<NifProvider>(), false, Array.Empty<string>(), false, Array.Empty<string>(), "", null, error);
+}
+
+/// <summary>The data behind housecarl_nif_set: the VFS resolution joined to the verified write outcome. Exactly one of
+/// {<see cref="Report"/> (a verified write happened)}, {<see cref="Error"/> (a named refusal — NOTHING written, Q3)},
+/// and {<see cref="NeedsAcknowledge"/> (the in-place first-touch consent prompt — a required confirmation, not an
+/// error)} describes the result. <see cref="OutputModFolder"/> is set on the default-lane success (enable + sort it above
+/// <see cref="CurrentWinner"/>); <see cref="InPlacePath"/> is set on the in-place success (the file overwritten in
+/// place).</summary>
+public sealed record NifSetResult(
+    string RelPath,
+    NifProvider? Edited,
+    IReadOnlyList<NifProvider> Providers,
+    bool Ambiguous,
+    HousecarlCore.NifSetReport? Report,
+    string? Error,
+    bool NeedsAcknowledge,
+    string? AckPrompt,
+    bool InPlace,
+    string? OutputModFolder,
+    string? InPlacePath,
+    string? CurrentWinner,
+    IReadOnlyList<string> Warnings,
+    string ProfileName)
+{
+    public static NifSetResult Fail(string error, IReadOnlyList<NifProvider>? providers = null, string profileName = "")
+        => new("", null, providers ?? Array.Empty<NifProvider>(), false, null, error, false, null, false, null, null, null, Array.Empty<string>(), profileName);
+
+    public static NifSetResult NeedsAck(string prompt, NifProvider edited, IReadOnlyList<NifProvider> providers, string profileName)
+        => new("", edited, providers, false, null, null, true, prompt, true, null, null, null, Array.Empty<string>(), profileName);
+
+    public static NifSetResult OkNewFolder(string rel, NifProvider edited, IReadOnlyList<NifProvider> providers, bool ambiguous,
+        HousecarlCore.NifSetReport report, string modFolder, string? winner, IReadOnlyList<string> warnings, string profileName)
+        => new(rel, edited, providers, ambiguous, report, null, false, null, false, modFolder, null, winner, warnings, profileName);
+
+    public static NifSetResult OkInPlace(string rel, NifProvider edited, IReadOnlyList<NifProvider> providers, bool ambiguous,
+        HousecarlCore.NifSetReport report, string inPlacePath, IReadOnlyList<string> warnings, string profileName)
+        => new(rel, edited, providers, ambiguous, report, null, false, null, true, null, inPlacePath, null, warnings, profileName);
 }
 
 /// <summary>One asset to PLACE (housecarl_place_asset / bulk). <see cref="AssetPath"/> is the resolved Data-relative

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -444,6 +444,8 @@ public sealed class LoadOrderService : IDisposable
             var editedBytes = outcome.WrittenBytes!;
             var report = outcome.Report!;
             var chosenProv = new NifProvider(chosen.ProviderName, KindLabel(chosen.Kind));
+            // Did we edit the VFS WINNER, or a copy a mod=-named loser shadows? Drives the honest "is it live" wording.
+            bool editedIsWinner = place.Sources.Count > 0 && ReferenceEquals(chosen, place.Sources[0]);
 
             // ---- IN-PLACE lane ----
             if (inPlace)
@@ -457,7 +459,7 @@ public sealed class LoadOrderService : IDisposable
 
                 bool already = _store.IsInPlaceAcknowledged(targetPath);
                 if (!already && !acknowledge)
-                    return NifSetResult.NeedsAck(InPlaceHandshakeText(meshName, targetPath), chosenProv, providers, profileName);
+                    return NifSetResult.NeedsAck(NifInPlaceHandshakeText(meshName, targetPath), chosenProv, providers, profileName);
                 string? ackNote = null;
                 if (!already && acknowledge)
                 {
@@ -472,8 +474,8 @@ public sealed class LoadOrderService : IDisposable
                 if (sz != editedBytes.Length)
                     return NifSetResult.Fail($"wrote '{meshName}' but its on-disk size ({sz}) does not match the {editedBytes.Length} verified byte(s) — verify before relying on it.", providers, profileName);
 
-                return NifSetResult.OkInPlace(rel, chosenProv, providers, place.Ambiguous, report, targetPath,
-                    Combine(report.Warnings, ackNote), profileName);
+                return NifSetResult.OkInPlace(rel, chosenProv, providers, place.Ambiguous, editedIsWinner, report, targetPath,
+                    MergeWarnings(report.Warnings, warnings, ackNote), profileName);
             }
 
             // ---- DEFAULT (new-folder) lane ----
@@ -497,13 +499,33 @@ public sealed class LoadOrderService : IDisposable
             }
 
             string? winner = providers.Count > 0 ? $"{providers[0].Name} ({providers[0].Kind})" : null;
-            return NifSetResult.OkNewFolder(rel, chosenProv, providers, place.Ambiguous, report, rf.ModFolder, winner, warnings, profileName);
+            return NifSetResult.OkNewFolder(rel, chosenProv, providers, place.Ambiguous, report, rf.ModFolder, winner, MergeWarnings(report.Warnings, warnings, null), profileName);
         }
     }
 
-    /// <summary>Concatenate a warnings list with an optional extra note (in-place ack save failure), dropping nulls.</summary>
-    static IReadOnlyList<string> Combine(IReadOnlyList<string> warnings, string? extra)
-        => extra is null ? warnings : warnings.Append(extra).ToList();
+    /// <summary>Merge the write report's notes (e.g. the unknown-block preservation disclosure) with the asset-layer
+    /// discovery warnings and an optional extra note (in-place ack-save failure) — BOTH lanes surface BOTH sets (Q3: a
+    /// preservation disclosure must not vanish because it rode the other lane's list).</summary>
+    static IReadOnlyList<string> MergeWarnings(IReadOnlyList<string> reportWarnings, IReadOnlyList<string> assetWarnings, string? extra)
+    {
+        var list = new List<string>(reportWarnings.Count + assetWarnings.Count + 1);
+        list.AddRange(reportWarnings);
+        list.AddRange(assetWarnings);
+        if (extra is not null) list.Add(extra);
+        return list;
+    }
+
+    /// <summary>The mesh-specific first-touch in-place consent prompt. Distinct from the PLUGIN handshake
+    /// (<see cref="InPlaceHandshakeText"/>) whose "whole plugin re-serialized / engine-reserved sub-0x800 records" wording
+    /// is false for a .nif — a mesh write is a WHOLE-FILE NiflySharp re-serialization (not a byte-surgical patch), then
+    /// verified. The no-backup + opt-in trade-offs carry over.</summary>
+    static string NifInPlaceHandshakeText(string meshName, string path) =>
+        $"in-place edit of '{meshName}' — first-time confirmation (shown once for this mesh):\n" +
+        $"  • This overwrites your ORIGINAL file ({path}). It will NO LONGER be untouched, and houseCARL keeps NO backup or undo — keep your own.\n" +
+        "  • The written mesh is a WHOLE-FILE re-serialization through NiflySharp's canonical writer (the way NifSkope / BodySlide rewrite a mesh on save), NOT a byte-surgical patch — then VERIFIED (only the value you edited changed; it reloads as a valid SE mesh).\n" +
+        "  • It still refuses if the mesh can't be parsed or isn't a Skyrim SE stream.\n" +
+        "  • The default lane (a NEW mod folder, originals untouched) stays the recommended way — this is the explicit opt-in.\n" +
+        "Re-call the SAME edit with acknowledge=true to proceed.";
 
     // ---- facegen-diagnostics Phase 3: place an asset so the correct copy WINS the VFS (housecarl_place_asset) ----
 
@@ -3903,6 +3925,7 @@ public sealed record NifSetResult(
     bool NeedsAcknowledge,
     string? AckPrompt,
     bool InPlace,
+    bool EditedIsWinner,
     string? OutputModFolder,
     string? InPlacePath,
     string? CurrentWinner,
@@ -3910,18 +3933,18 @@ public sealed record NifSetResult(
     string ProfileName)
 {
     public static NifSetResult Fail(string error, IReadOnlyList<NifProvider>? providers = null, string profileName = "")
-        => new("", null, providers ?? Array.Empty<NifProvider>(), false, null, error, false, null, false, null, null, null, Array.Empty<string>(), profileName);
+        => new("", null, providers ?? Array.Empty<NifProvider>(), false, null, error, false, null, false, false, null, null, null, Array.Empty<string>(), profileName);
 
     public static NifSetResult NeedsAck(string prompt, NifProvider edited, IReadOnlyList<NifProvider> providers, string profileName)
-        => new("", edited, providers, false, null, null, true, prompt, true, null, null, null, Array.Empty<string>(), profileName);
+        => new("", edited, providers, false, null, null, true, prompt, true, false, null, null, null, Array.Empty<string>(), profileName);
 
     public static NifSetResult OkNewFolder(string rel, NifProvider edited, IReadOnlyList<NifProvider> providers, bool ambiguous,
         HousecarlCore.NifSetReport report, string modFolder, string? winner, IReadOnlyList<string> warnings, string profileName)
-        => new(rel, edited, providers, ambiguous, report, null, false, null, false, modFolder, null, winner, warnings, profileName);
+        => new(rel, edited, providers, ambiguous, report, null, false, null, false, true, modFolder, null, winner, warnings, profileName);
 
-    public static NifSetResult OkInPlace(string rel, NifProvider edited, IReadOnlyList<NifProvider> providers, bool ambiguous,
+    public static NifSetResult OkInPlace(string rel, NifProvider edited, IReadOnlyList<NifProvider> providers, bool ambiguous, bool editedIsWinner,
         HousecarlCore.NifSetReport report, string inPlacePath, IReadOnlyList<string> warnings, string profileName)
-        => new(rel, edited, providers, ambiguous, report, null, false, null, true, null, inPlacePath, null, warnings, profileName);
+        => new(rel, edited, providers, ambiguous, report, null, false, null, true, editedIsWinner, null, inPlacePath, null, warnings, profileName);
 }
 
 /// <summary>One asset to PLACE (housecarl_place_asset / bulk). <see cref="AssetPath"/> is the resolved Data-relative

--- a/src/housecarl-mcp/NifTools.cs
+++ b/src/housecarl-mcp/NifTools.cs
@@ -77,6 +77,115 @@ public static class NifTools
         }
         return (want, unknown);
     }
+
+    [McpServerTool(Name = "housecarl_nif_set", Title = "Write a whitelisted data value into a Skyrim mesh (.nif)"),
+     Description(
+         "Write ONE whitelisted DATA VALUE into a Skyrim SE mesh (.nif) at the data layer, beneath NifSkope — then VERIFY " +
+         "the edit before anything lands. Resolve the Data-relative mesh_path through Mod Organizer 2's VFS to the winning " +
+         "copy (or mod=), apply the op, and pass it two offset-immune verification gates (only the block/value the op " +
+         "claims to touch changed; a reload re-reads the new value; census + SE-stream intact) — a failure writes NOTHING " +
+         "and says why. The six ops (op=): rename_shape / rename_node (retitle a baked shape/node — the HDPT-EDID facegen " +
+         "case), set_flags (NiAVObject flags on a shape/node — the 0x80000 head/hair-class bit), set_scale, set_partition " +
+         "(a BSDismember body-part id — pass body_part_id [+ partition_index]), set_alpha (alpha_flags word and/or " +
+         "alpha_threshold — the hair 0x12ED / hairline 0x12EE class), set_path (swap a BSShaderTextureSet slot — pass " +
+         "texture_slot + path; e.g. the FaceTint slot 6 or skin slots 0/1). target= is the shape or node NAME the op edits " +
+         "(from housecarl_nif_inspect). By DEFAULT the verified mesh is written into a NEW houseCARL MO2 mod folder at the " +
+         "same path (originals untouched) — enable it and sort it ABOVE the current winner so the edit wins; a BSA-packed " +
+         "source becomes a loose winning override this way. in_place=true instead OVERWRITES the winning LOOSE file where " +
+         "it sits (opt-in; rides the one-time per-file consent handshake, needs acknowledge=true, NO backup). Only edits " +
+         "data VALUES — never geometry / vertices / the .dds pixels. Refuses loud (Q3): a non-SE mesh, a target it can't " +
+         "find or that's ambiguous, an op that doesn't apply, or any verification miss.")]
+    public static string NifSet(
+        LoadOrderService svc,
+        [Description("The Data-relative mesh path to edit, e.g. 'meshes\\actors\\character\\facegendata\\facegeom\\Skyrim.esm\\00000007.nif'.")]
+            string mesh_path,
+        [Description("The write op: 'rename_shape', 'rename_node', 'set_flags', 'set_scale', 'set_partition', 'set_alpha', or 'set_path'.")]
+            string op,
+        [Description("The NAME of the shape or node the op edits (the current name; from housecarl_nif_inspect). For a rename this is the OLD name.")]
+            string target,
+        [Description("rename_shape / rename_node: the new name.")] string new_name = "",
+        [Description("set_flags: the NiAVObject flags value — hex ('0x800000E') or decimal.")] string flags = "",
+        [Description("set_scale: the scale, e.g. '1.0'.")] string scale = "",
+        [Description("set_partition: the BSDismember body-part id, e.g. '32' (SBP_32_BODY).")] string body_part_id = "",
+        [Description("set_partition: which partition to change when a shape has more than one (0-based). Omit if it has exactly one.")] string partition_index = "",
+        [Description("set_alpha: the 16-bit alpha flags word — hex ('0x12ED') or decimal. Optional if only changing the threshold.")] string alpha_flags = "",
+        [Description("set_alpha: the alpha test threshold, 0-255. Optional if only changing the flags word.")] string alpha_threshold = "",
+        [Description("set_path: the BSShaderTextureSet slot index (0 diffuse, 1 normal, 6 tint/skin/detail, ...).")] string texture_slot = "",
+        [Description("set_path: the new texture path (Data-relative, e.g. 'textures\\...\\facetint\\Mod.esp\\00000ABC.dds').")] string path = "",
+        [Description("Optional. Edit a specific provider's copy instead of the VFS winner — the mod folder name, 'overwrite', 'Data', or a BSA filename from the providers chain. Empty = the winner.")]
+            string mod = "",
+        [Description("Optional. Base name for the NEW mod folder the edited mesh is written into (default lane; auto-suffixed if taken). Ignored with in_place=true.")]
+            string patch_name = "",
+        [Description("Optional. Write into an EXISTING houseCARL-owned mod folder instead of a fresh one (default lane). Mutually exclusive with in_place.")]
+            string into = "",
+        [Description("Optional, default false. IN-PLACE LANE (opt-in): OVERWRITE the winning LOOSE file where it sits instead of writing a new folder — NO backup. Requires acknowledge=true (see below). OMIT (the default) to write a new winning override and leave the original untouched.")]
+            bool in_place = false,
+        [Description("Optional, default false. Confirms the one-time in-place trade-off for this file — needed only on the FIRST in-place edit of a given mesh, never again for it. Waives the consent to overwrite your original ONLY; it NEVER skips the mesh verification.")]
+            bool acknowledge = false,
+        [Description("Optional. Max characters before a list is cut with an explicit notice. 0 = the server default (~80k).")]
+            int max_chars = 0) => Guard.Tool("housecarl_nif_set", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        if (string.IsNullOrWhiteSpace(mesh_path)) return "error: mesh_path is empty. Pass a Data-relative mesh path.";
+        if (string.IsNullOrWhiteSpace(op)) return "error: op is empty. Pass one of: rename_shape, rename_node, set_flags, set_scale, set_partition, set_alpha, set_path.";
+        if (string.IsNullOrWhiteSpace(target)) return "error: target is empty. Pass the shape/node NAME the op edits (from housecarl_nif_inspect).";
+
+        var (built, buildErr) = BuildOp(op.Trim(), target.Trim(), new_name, flags, scale, body_part_id, partition_index, alpha_flags, alpha_threshold, texture_slot, path);
+        if (buildErr is not null) return "error: " + buildErr;
+
+        var data = svc.NifSet(mesh_path, new[] { built! },
+            string.IsNullOrWhiteSpace(mod) ? null : mod,
+            string.IsNullOrWhiteSpace(patch_name) ? null : patch_name,
+            string.IsNullOrWhiteSpace(into) ? null : into,
+            in_place, acknowledge);
+        return NifSetWire.Render(data, max_chars > 0 ? max_chars : 80_000);
+    });
+
+    /// <summary>Turn the flat tool params into one <see cref="NifSetOp"/>, or a friendly NAMED error (Q3) for an unknown op
+    /// or an unparseable value — before the value ever reaches the service. Numeric params are strings so an omitted one is
+    /// distinguishable from a real 0 (partition_index 0 is valid).</summary>
+    static (NifSetOp? Op, string? Error) BuildOp(string op, string target,
+        string newName, string flags, string scale, string bodyPartId, string partitionIndex, string alphaFlags, string alphaThreshold, string textureSlot, string path)
+    {
+        switch (op.ToLowerInvariant())
+        {
+            case "rename_shape": return (new NifSetOp(NifSetOpKind.RenameShape, target, NewName: newName), null);
+            case "rename_node": return (new NifSetOp(NifSetOpKind.RenameNode, target, NewName: newName), null);
+            case "set_flags":
+                if (!TryParseUInt(flags, out var fv)) return (null, $"set_flags needs a flags value (hex '0x800000E' or decimal); got '{flags}'.");
+                return (new NifSetOp(NifSetOpKind.SetFlags, target, Flags: fv), null);
+            case "set_scale":
+                if (!float.TryParse(scale, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var sc))
+                    return (null, $"set_scale needs a numeric scale; got '{scale}'.");
+                return (new NifSetOp(NifSetOpKind.SetScale, target, Scale: sc), null);
+            case "set_partition":
+                if (!int.TryParse(bodyPartId, out var bp)) return (null, $"set_partition needs a numeric body_part_id; got '{bodyPartId}'.");
+                int? pidx = null;
+                if (!string.IsNullOrWhiteSpace(partitionIndex)) { if (!int.TryParse(partitionIndex, out var pi)) return (null, $"partition_index must be a number; got '{partitionIndex}'."); pidx = pi; }
+                return (new NifSetOp(NifSetOpKind.SetPartition, target, BodyPartId: bp, PartitionIndex: pidx), null);
+            case "set_alpha":
+                ushort? af = null; byte? at = null;
+                if (!string.IsNullOrWhiteSpace(alphaFlags)) { if (!TryParseUInt(alphaFlags, out var afu) || afu > ushort.MaxValue) return (null, $"alpha_flags must be a 16-bit value (hex '0x12ED' or decimal); got '{alphaFlags}'."); af = (ushort)afu; }
+                if (!string.IsNullOrWhiteSpace(alphaThreshold)) { if (!byte.TryParse(alphaThreshold, out var atb)) return (null, $"alpha_threshold must be 0-255; got '{alphaThreshold}'."); at = atb; }
+                if (af is null && at is null) return (null, "set_alpha needs alpha_flags and/or alpha_threshold.");
+                return (new NifSetOp(NifSetOpKind.SetAlpha, target, AlphaFlags: af, AlphaThreshold: at), null);
+            case "set_path":
+                if (!int.TryParse(textureSlot, out var slot)) return (null, $"set_path needs a numeric texture_slot; got '{textureSlot}'.");
+                if (string.IsNullOrWhiteSpace(path)) return (null, "set_path needs a path.");
+                return (new NifSetOp(NifSetOpKind.SetPath, target, TextureSlot: slot, Path: path), null);
+            default:
+                return (null, $"unknown op '{op}'. Use one of: rename_shape, rename_node, set_flags, set_scale, set_partition, set_alpha, set_path.");
+        }
+    }
+
+    /// <summary>Parse a uint from hex ('0x...') or decimal.</summary>
+    static bool TryParseUInt(string s, out uint value)
+    {
+        s = (s ?? "").Trim();
+        if (s.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+            return uint.TryParse(s.AsSpan(2), System.Globalization.NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture, out value);
+        return uint.TryParse(s, out value);
+    }
 }
 
 /// <summary>Renders <see cref="NifInspectData"/> as compact, scannable text: the build-level Q3 alarms first (archives
@@ -321,5 +430,79 @@ static class NifWire
             if (sb.Length >= cap) { sb.Append("  ... [").Append(warnings.Count - shown).Append(" more omitted]\n"); break; }
             sb.Append("  - ").Append(w).Append('\n'); shown++;
         }
+    }
+}
+
+/// <summary>Renders <see cref="NifSetResult"/>: the resolution (which copy was edited + provider chain), then exactly one
+/// of — the in-place CONSENT prompt (verbatim, a required confirmation not an error), a NAMED refusal (nothing written),
+/// or the verified-write success (the op's before→after, what the verification confirmed changed, and the LANE outcome:
+/// a new mod folder to enable+sort, or the file overwritten in place). Q3: a default-lane success says "wrote it, now
+/// enable+sort" — it never claims the edit is winning on disk yet.</summary>
+static class NifSetWire
+{
+    public static string Render(NifSetResult d, int cap)
+    {
+        var sb = new StringBuilder();
+        sb.Append("nif set — ").Append(d.RelPath.Length > 0 ? d.RelPath : "(mesh)")
+          .Append("  (profile '").Append(d.ProfileName.Length > 0 ? d.ProfileName : "(unconfigured)").Append("')\n");
+
+        // in-place first-touch consent — a required confirmation, returned verbatim (NOT an error, Q3).
+        if (d.NeedsAcknowledge)
+        {
+            sb.Append('\n').Append(d.AckPrompt).Append('\n');
+            return sb.ToString().TrimEnd('\n');
+        }
+
+        // refusal — nothing written.
+        if (d.Report is null || d.Error is not null)
+        {
+            sb.Append('\n').Append(d.Error ?? "unknown error").Append('\n');
+            if (d.Providers.Count > 0) AppendProviders(sb, d.Providers);
+            return sb.ToString().TrimEnd('\n');
+        }
+
+        // success.
+        if (d.Edited is not null) sb.Append("  edited copy: ").Append(d.Edited.Name).Append(" (").Append(d.Edited.Kind).Append(")\n");
+        AppendProviders(sb, d.Providers);
+        if (d.Ambiguous)
+            sb.Append("  note: more than one source provides this mesh — the winner above was edited (loose beats BSA). Pass mod= to edit another copy.\n");
+
+        sb.Append("\n  applied + VERIFIED (two gates: only the op's block/header changed; reload re-reads the value; census intact):\n");
+        foreach (var o in d.Report.Ops)
+            sb.Append("    ").Append(o.Op).Append(" on '").Append(o.Target).Append("': ").Append(o.Before).Append("  ->  ").Append(o.After).Append('\n');
+        sb.Append("  verification: ")
+          .Append(d.Report.HeaderChanged ? "header string table" : "no header change")
+          .Append(d.Report.ChangedBlocks.Count > 0 ? $" + block(s) [{string.Join(", ", d.Report.ChangedBlocks)}]" : " + 0 blocks")
+          .Append("; size ").Append(d.Report.SizeDelta >= 0 ? "+" : "").Append(d.Report.SizeDelta).Append(" byte(s)\n");
+
+        // lane outcome
+        if (d.InPlace)
+            sb.Append("\n  IN-PLACE: overwrote ").Append(d.InPlacePath).Append(" (your original — no houseCARL backup). The edit is live where the file already wins.\n");
+        else
+        {
+            sb.Append("\n  wrote the verified mesh into a new mod folder: ").Append(d.OutputModFolder).Append('\n');
+            sb.Append("  TO MAKE IT WIN: enable this folder in MO2 and sort it ABOVE ")
+              .Append(d.CurrentWinner ?? "the current winner")
+              .Append(" (loose beats BSA; among loose, the later mod wins). 'Wrote it' is not 'it wins' until you do.\n");
+        }
+
+        if (d.Warnings.Count > 0)
+        {
+            sb.Append("\n  notes:\n");
+            foreach (var w in d.Warnings) sb.Append("    - ").Append(w).Append('\n');
+        }
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    static void AppendProviders(StringBuilder sb, IReadOnlyList<NifProvider> providers)
+    {
+        if (providers.Count == 0) return;
+        sb.Append("  providers (").Append(providers.Count).Append("): ");
+        for (int i = 0; i < providers.Count; i++)
+        {
+            if (i > 0) sb.Append(" > ");
+            sb.Append(providers[i].Name).Append(" (").Append(providers[i].Kind).Append(')');
+        }
+        sb.Append('\n');
     }
 }

--- a/src/housecarl-mcp/NifTools.cs
+++ b/src/housecarl-mcp/NifTools.cs
@@ -121,9 +121,7 @@ public static class NifTools
         [Description("Optional, default false. IN-PLACE LANE (opt-in): OVERWRITE the winning LOOSE file where it sits instead of writing a new folder — NO backup. Requires acknowledge=true (see below). OMIT (the default) to write a new winning override and leave the original untouched.")]
             bool in_place = false,
         [Description("Optional, default false. Confirms the one-time in-place trade-off for this file — needed only on the FIRST in-place edit of a given mesh, never again for it. Waives the consent to overwrite your original ONLY; it NEVER skips the mesh verification.")]
-            bool acknowledge = false,
-        [Description("Optional. Max characters before a list is cut with an explicit notice. 0 = the server default (~80k).")]
-            int max_chars = 0) => Guard.Tool("housecarl_nif_set", () =>
+            bool acknowledge = false) => Guard.Tool("housecarl_nif_set", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         if (string.IsNullOrWhiteSpace(mesh_path)) return "error: mesh_path is empty. Pass a Data-relative mesh path.";
@@ -138,7 +136,7 @@ public static class NifTools
             string.IsNullOrWhiteSpace(patch_name) ? null : patch_name,
             string.IsNullOrWhiteSpace(into) ? null : into,
             in_place, acknowledge);
-        return NifSetWire.Render(data, max_chars > 0 ? max_chars : 80_000);
+        return NifSetWire.Render(data);
     });
 
     /// <summary>Turn the flat tool params into one <see cref="NifSetOp"/>, or a friendly NAMED error (Q3) for an unknown op
@@ -440,7 +438,7 @@ static class NifWire
 /// enable+sort" — it never claims the edit is winning on disk yet.</summary>
 static class NifSetWire
 {
-    public static string Render(NifSetResult d, int cap)
+    public static string Render(NifSetResult d)
     {
         var sb = new StringBuilder();
         sb.Append("nif set — ").Append(d.RelPath.Length > 0 ? d.RelPath : "(mesh)")
@@ -473,11 +471,17 @@ static class NifSetWire
         sb.Append("  verification: ")
           .Append(d.Report.HeaderChanged ? "header string table" : "no header change")
           .Append(d.Report.ChangedBlocks.Count > 0 ? $" + block(s) [{string.Join(", ", d.Report.ChangedBlocks)}]" : " + 0 blocks")
-          .Append("; size ").Append(d.Report.SizeDelta >= 0 ? "+" : "").Append(d.Report.SizeDelta).Append(" byte(s)\n");
+          .Append("; net size vs source ").Append(d.Report.SizeDelta >= 0 ? "+" : "").Append(d.Report.SizeDelta)
+          .Append(" byte(s) (includes nifly's canonical re-serialization, not just the edit)\n");
 
         // lane outcome
         if (d.InPlace)
-            sb.Append("\n  IN-PLACE: overwrote ").Append(d.InPlacePath).Append(" (your original — no houseCARL backup). The edit is live where the file already wins.\n");
+        {
+            sb.Append("\n  IN-PLACE: overwrote ").Append(d.InPlacePath).Append(" (your original — no houseCARL backup).");
+            sb.Append(d.EditedIsWinner
+                ? " The edit is live where the file already wins the VFS.\n"
+                : " NOTE: you edited a copy that another provider currently SHADOWS (you passed mod=), so this is not the winning copy in game until that changes.\n");
+        }
         else
         {
             sb.Append("\n  wrote the verified mesh into a new mod folder: ").Append(d.OutputModFolder).Append('\n');


### PR DESCRIPTION
NIF layer **Wave 2**: `housecarl_nif_set` — the whitelist mesh writer, the write half of the read/write seam Wave 1 (`nif_inspect`, #34) opened. Data values in and out of a `.nif`; geometry / `.dds` pixels stay out of scope.

## What it does
The six N2 whitelist ops, one per call, applied to the VFS-winning copy (or `mod=`) and **verified before anything lands**:

| op | edits |
|---|---|
| `rename_shape` / `rename_node` | header-string identity (HDPT-EDID facegen case) |
| `set_flags` | NiAVObject flags (the `0x80000` head/hair-class bit — Sanguine dark-face root cause) |
| `set_scale` | NiAVObject scale |
| `set_partition` | a BSDismember body-part id (HEAD/HAIR/BODY) |
| `set_alpha` | alpha flags word and/or threshold (the hair `0x12ED` / hairline `0x12EE` class) |
| `set_path` | a BSShaderTextureSet slot (v1: texture slots — the FaceTint slot-6 / skin slot-0/1 case; material/xml is a named follow-up) |

## Verification — two offset-immune gates, no opt-out
1. **Block-content diff** — normalize the unedited + edited mesh through nifly's writer, slice both by their own block-size tables, compare block *content* by index; only the op-touched block(s)/header may change, else abort with nothing written. This **replaces** the plan's original byte-*position* diff, which an empirical de-risk showed is defeated by offset shift (a length-changing rename shifts every downstream block's file position). A header change is legitimate only for a rename (authored string table) or when a touched block resized (the header's *derived* block-size table — a longer texture path grows the texset block; found on real facegen data).
2. **Semantic read-back** — reload, re-inspect: each op's target reads as requested (catches a silent no-op write), census + unknown-block count unchanged, SE stream intact, reloads clean.

Refuses loud (Q3, nothing written): non-SE stream, target not found / ambiguous, op not applicable, out-of-range index/slot, empty input. Unknown blocks WARN-and-proceed (census gate proves preservation).

## Write lanes
- **Default (non-destructive):** verified mesh → a new houseCARL MO2 mod folder at the same path; enable + sort above the winner. Originals untouched. Reuses the place-asset write machinery.
- **In-place (opt-in):** overwrite the winning *loose* file, riding the existing per-file consent handshake (no new machinery). BSA-only winner → refuses with default-lane guidance.

## Guard + CI
`nif-set-guard` (in `ci-all`, 78/78 green): every op end-to-end + preserves-everything-else; **both gates RED-proven to catch a collateral-block change and a no-op write** (not merely pass); all refusal arms; both write lanes end-to-end over a synthetic MO2 instance (new-folder + the in-place consent prompt → acknowledge → write → no-re-prompt persistence); corpus-gated `set_path` on real facegen slot 6.

## Owed (not blocking this land)
- Release-cut bump: tool count → 35, CHANGELOG / README / Nexus.
- `facegen-diagnostics` Wave-2 skill update (flip the "must instruct the edit" claims) — batched with the owed live skill pass, post-repackage.
- **In-game empirical gate (principle #1, deferred posture):** Aaron exercises a real repair in game — the tool proves the data layer; the play-test proves the engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)