### PR TITLE
fix(write-lanes): in-place / forward flow defects — HCBR-2026-07-08-01 F1–F4

### DIFF
--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -636,7 +636,7 @@ public static class WriteEngine
     /// without needing a patch mod in hand.</summary>
     public static bool RecordNeedsSourceCache(IMajorRecordGetter source)
     {
-        foreach (var (_, _, getterIface) in EnumerateFlatGroups(typeof(SkyrimMod)))
+        foreach (var (_, getterIface) in FlatGroupTypes)
             if (getterIface.IsInstanceOfType(source)) return false;
         return true;
     }
@@ -650,10 +650,19 @@ public static class WriteEngine
     /// correctly. Same <see cref="EnumerateFlatGroups"/> enumeration as every other flat-vs-nested decision (no drift).</summary>
     public static Type RemovalTypeFor(IMajorRecordGetter record)
     {
-        foreach (var (_, tMajor, getterIface) in EnumerateFlatGroups(typeof(SkyrimMod)))
+        foreach (var (tMajor, getterIface) in FlatGroupTypes)
             if (getterIface.IsInstanceOfType(record)) return tMajor;
         return record.GetType();
     }
+
+    /// <summary>The flat groups' (T, getter-interface) pairs for <see cref="SkyrimMod"/>, MEMOIZED (the
+    /// <see cref="_abstractGroups"/> precedent): pure reflection metadata, constant for the process lifetime —
+    /// <see cref="RemovalTypeFor"/> runs per record when the remove lanes index a whole plugin (PR #163 review #2),
+    /// so the per-call property walk was an avoidable O(records × properties). Derived from the SAME
+    /// <see cref="EnumerateFlatGroups"/> enumeration (no drift).</summary>
+    static IReadOnlyList<(Type tMajor, Type getterIface)> FlatGroupTypes => _flatGroupTypes.Value;
+    static readonly Lazy<IReadOnlyList<(Type tMajor, Type getterIface)>> _flatGroupTypes =
+        new(() => EnumerateFlatGroups(typeof(SkyrimMod)).Select(g => (g.tMajor, g.getterIface)).ToList());
 
     /// <summary>
     /// Generic <c>GetOrAddAsOverride</c>. Flat-group records (the common case) resolve by matching the

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -641,6 +641,20 @@ public static class WriteEngine
         return true;
     }
 
+    /// <summary>The Type to hand Mutagen's typed <c>Remove(FormKey, Type, throwIfUnknown)</c> for
+    /// <paramref name="record"/>: the record's FLAT GROUP's <c>T</c> when one matches, else the runtime type (nested-group
+    /// records — the shape the remove-record-probe proved reaches Cell/Placed*/INFO/Navmesh/Landscape). The flat-group
+    /// answer matters for the abstract-base groups (Global, GameSetting): HCBR-2026-07-08-01 F3 proved that passing a
+    /// concrete SUBCLASS of the group's T (a <c>GlobalShort</c> under <c>SkyrimGroup&lt;Global&gt;</c>) makes Mutagen's
+    /// remove routing silently NO-OP — <c>throwIfUnknown:true</c> notwithstanding — while the group's own T removes
+    /// correctly. Same <see cref="EnumerateFlatGroups"/> enumeration as every other flat-vs-nested decision (no drift).</summary>
+    public static Type RemovalTypeFor(IMajorRecordGetter record)
+    {
+        foreach (var (_, tMajor, getterIface) in EnumerateFlatGroups(typeof(SkyrimMod)))
+            if (getterIface.IsInstanceOfType(record)) return tMajor;
+        return record.GetType();
+    }
+
     /// <summary>
     /// Generic <c>GetOrAddAsOverride</c>. Flat-group records (the common case) resolve by matching the
     /// <c>SkyrimGroup&lt;T&gt;</c> whose <c>T</c> carries the record's getter interface, then invoking the

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -525,6 +525,11 @@ public static class WritePatchBuilder
             { return PatchOutcome.Fail($"cannot open '{fileName}' to edit in place ({WriteEngine.Describe(ex)}) — a plugin Mutagen can't parse is refused, not re-emitted minus what it couldn't read (Q3). The file is UNTOUCHED."); }
         if (!string.Equals(targetMod.ModKey.FileName.String, fileName, StringComparison.OrdinalIgnoreCase))
             return PatchOutcome.Fail($"in-place ModKey '{targetMod.ModKey.FileName}' must match the target filename '{fileName}'.");
+        // The author's DECLARED masters, captured before any mutation — the re-opened header is diffed against this
+        // to surface a master GROW as an explicit re-sort note (PR #163 review #1: a grown master is itself a
+        // re-sort trigger — the plugin is invalid until it loads AFTER its new master — independent of winners).
+        var mastersBefore = targetMod.ModHeader.MasterReferences
+            .Select(m => m.Master.FileName.String).ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         // --- Phase 3: apply each verb to the TARGET's OWN record. GenericGetOrAddAsOverride on the target's own body
         //     (already present in targetMod) returns THAT record (get-semantics) — the verb edits the file's own body,
@@ -605,7 +610,21 @@ public static class WritePatchBuilder
             { return PatchOutcome.Fail($"'{fileName}' was edited in place but could not be re-opened to verify: {ex.Message}"); }
         finally { (back as IDisposable)?.Dispose(); }
 
-        return new PatchOutcome(true, null, targetPath, false, masters, ops, bytes) { ReadBack = readBack, InPlace = true };
+        return new PatchOutcome(true, null, targetPath, false, masters, ops, bytes)
+            { ReadBack = readBack, InPlace = true, Note = MasterGrowNote(fileName, mastersBefore, masters) };
+    }
+
+    /// <summary>The explicit re-sort note when an in-place write GREW the target's master header (PR #163 review #1):
+    /// Skyrim loads a plugin only AFTER its masters, so a newly added master — e.g. an edit's FormLink into an
+    /// active-but-undeclared plugin (F2), or a forwarded body's references (F4) — leaves the file invalid until the
+    /// order is re-sorted, independent of any conflict-winner change. Null when nothing was added (the common case,
+    /// and any prune: a shrink never breaks load eligibility).</summary>
+    static string? MasterGrowNote(string fileName, HashSet<string> mastersBefore, IReadOnlyList<string> mastersAfter)
+    {
+        var grown = mastersAfter.Where(m => !mastersBefore.Contains(m)).ToList();
+        if (grown.Count == 0) return null;
+        return $"{string.Join(", ", grown)} {(grown.Count == 1 ? "was" : "were")} added as a master of '{fileName}' — " +
+               "a plugin loads only if its masters load BEFORE it, so re-sort your load order (LOOT / MO2) before playing.";
     }
 
     /// <summary>Resolve the target's OWN declared masters to on-disk overlays in declared order — the load order
@@ -1003,6 +1022,10 @@ public static class WritePatchBuilder
             { return ForwardOutcome.Fail($"cannot open '{fileName}' to forward into in place ({WriteEngine.Describe(ex)}) — a plugin Mutagen can't parse is refused, not re-emitted minus what it couldn't read (Q3). The file is UNTOUCHED."); }
         if (!string.Equals(targetMod.ModKey.FileName.String, fileName, StringComparison.OrdinalIgnoreCase))
             return ForwardOutcome.Fail($"in-place ModKey '{targetMod.ModKey.FileName}' must match the target filename '{fileName}'.");
+        // Declared masters before any mutation — diffed against the re-opened header for the master-grow re-sort
+        // note (PR #163 review #1; see MasterGrowNote).
+        var mastersBefore = targetMod.ModHeader.MasterReferences
+            .Select(m => m.Master.FileName.String).ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         // --- Phase 3: replace-or-copy each source body into the TARGET (the F1 semantic — a carried FormKey is
         //     REPLACED, verified dropped before the copy; nothing is serialized until Phase 4, so any refusal here
@@ -1071,7 +1094,8 @@ public static class WritePatchBuilder
             { return ForwardOutcome.Fail($"'{fileName}' was rewritten but could not be re-opened to verify: {ex.Message}"); }
         finally { (back as IDisposable)?.Dispose(); }
 
-        return new ForwardOutcome(true, null, targetPath, false, forwarded, masters, bytes) { ReadBack = readBack, InPlace = true };
+        return new ForwardOutcome(true, null, targetPath, false, forwarded, masters, bytes)
+            { ReadBack = readBack, InPlace = true, Note = MasterGrowNote(fileName, mastersBefore, masters) };
     }
 
     /// <summary>One record to FORWARD: take plugin <see cref="FromPlugin"/>'s version of <see cref="Target"/> and carry
@@ -1301,7 +1325,7 @@ public static class WritePatchBuilder
                         return ForwardOutcome.Fail(
                             $"cannot replace {spec.Target}: the patch already carries this record and its existing " +
                             "override could not be dropped before the copy (the engine no-op'd without throwing) — " +
-                            "surfaced, not a silent skip (Q3); NO patch written.");
+                            "surfaced, not a silent skip (Q3); nothing was serialized (the extended patch's on-disk file is untouched).");
                     replaced = true;
                 }
                 ILinkCache? cache = WriteEngine.RecordNeedsSourceCache(body) ? session.LinkCacheFor(spec.FromPlugin) : null;

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Cache;
+using Mutagen.Bethesda.Plugins.Exceptions;
 using Mutagen.Bethesda.Plugins.Records;
 using Mutagen.Bethesda.Skyrim;
 
@@ -567,19 +568,24 @@ public static class WritePatchBuilder
         // --- Phase 4: re-serialize the WHOLE target back over itself (model C — the probe's incantation via WriteInPlace,
         //     NOT WritePatch). Release the target overlay first (the winner-IS-the-target common case made common — the
         //     two-part self-lock guard, here on a FOREIGN target: ReleaseOverlay disposes every session overlay on the
-        //     target, flat via GetRecord and nested via LinkCacheFor, before the File.Replace). Resolve the target's own
-        //     declared masters to overlays for a faithful re-emit; dispose them after the write. ---
+        //     target, flat via GetRecord and nested via LinkCacheFor, before the File.Replace). The resolution context is
+        //     the WHOLE known-master set (AllMastersExcept — the same context the in-place CREATE lane serializes
+        //     against), NOT just the target's declared masters: an edit that composes a FormLink to an ACTIVE plugin the
+        //     target didn't yet master must GROW the header (Mutagen lean-derives it from the records' actual links —
+        //     exactly how forward_record grows masters), instead of failing MissingModException against a context that
+        //     artificially excluded the referenced plugin (HCBR-2026-07-08-01 F2). A link to a plugin genuinely NOT
+        //     active still fails loud below (Q3), now meaning what it says. ---
         session.ReleaseOverlay(fileName);
-        var masterOverlays = new List<IDisposable>();
-        try
+        try { WriteEngine.WriteInPlace(targetMod, session.AllMastersExcept(fileName), targetPath); }
+        catch (MissingModException ex)
         {
-            ISkyrimModGetter[] ownMasters = ResolveOwnMasters(view, targetMod, masterOverlays, out var missing);
-            if (missing is not null) return PatchOutcome.Fail(missing);
-            try { WriteEngine.WriteInPlace(targetMod, ownMasters, targetPath); }
-            catch (Exception ex)
-                { return PatchOutcome.Fail($"writing '{fileName}' in place failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}"); }
+            return PatchOutcome.Fail(
+                $"writing '{fileName}' in place failed: the edited records reference a plugin that is NOT active in " +
+                $"the load order ({ex.Message}) — a reference into an inactive plugin can't resolve in game. " +
+                "Enable that plugin in MO2 (or reference an active one) and retry. The existing file is untouched.");
         }
-        finally { foreach (var d in masterOverlays) { try { d.Dispose(); } catch { /* best-effort; never mask the write result */ } } }
+        catch (Exception ex)
+            { return PatchOutcome.Fail($"writing '{fileName}' in place failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}"); }
 
         // --- Phase 5: re-open the now-edited file and report its master header — and the touched-record verify (default
         //     ON for in-place): each edited record read back IN FULL off the on-disk bytes (the model-C substitute for
@@ -668,10 +674,11 @@ public static class WritePatchBuilder
 
         // Present-check: index what the patch ACTUALLY carries (one enumeration — walks flat + nested), so a target the
         // patch doesn't define is refused loud rather than silently no-op'd by Remove. Captures type+editorid for the
-        // report AND the runtime type, which routes the typed Remove straight to the record's group below.
+        // report AND the removal-routing type: the record's FLAT GROUP's T, not the concrete runtime type — a subclass
+        // of an abstract group's T (GlobalShort) makes Mutagen's Remove silently no-op (HCBR-2026-07-08-01 F3).
         var carried = new Dictionary<FormKey, (string type, string? edid, Type runtime)>();
         foreach (var r in patchMod.EnumerateMajorRecords())
-            carried[r.FormKey] = (RecordNaming.StripOverlay(r.GetType().Name), r.EditorID, r.GetType());
+            carried[r.FormKey] = (RecordNaming.StripOverlay(r.GetType().Name), r.EditorID, WriteEngine.RemovalTypeFor(r));
 
         var problems = new List<string>();
         var toRemove = new List<RemovedRecord>(targets.Count);
@@ -711,6 +718,8 @@ public static class WritePatchBuilder
                 $"present-check passed but Remove threw — a real engine inconsistency, surfaced not swallowed (Q3): "
                 + $"{ex.GetType().Name}: {ex.Message}");
         }
+        if (RemoveSurvivors(patchMod, toRemove) is { } survived)
+            return RemovalOutcome.Fail(survived + $" '{fileName}' is UNTOUCHED.");
 
         // Serialize ONCE with the full known-master set; Mutagen keeps the header lean (only-referenced), so a master
         // orphaned by the removal drops here automatically. A referenced master genuinely absent still fails loud (Q3).
@@ -738,6 +747,23 @@ public static class WritePatchBuilder
         finally { (back as IDisposable)?.Dispose(); }
 
         return new RemovalOutcome(true, null, outPath, toRemove, masters, remaining, bytes);
+    }
+
+    /// <summary>IN-MEMORY absence verify run BEFORE any serialize, shared by both remove lanes: Mutagen's typed
+    /// <c>Remove</c> can no-op WITHOUT throwing (<c>throwIfUnknown:true</c> notwithstanding — HCBR-2026-07-08-01 F3
+    /// proved it for a concrete subclass of an abstract group's T), so trusting the void return and serializing anyway
+    /// rewrites the whole file to no effect and only the post-write verify catches it. Checking the mutable mod first
+    /// keeps a future no-op loud with the file UNTOUCHED (Q3). Null ⇒ all targets gone; else the refusal text (the
+    /// caller appends its lane's file-untouched suffix).</summary>
+    static string? RemoveSurvivors(SkyrimMod mod, IReadOnlyList<RemovedRecord> toRemove)
+    {
+        var mustBeGone = toRemove.Select(rr => rr.Target).ToHashSet();
+        var survivors = new List<FormKey>();
+        foreach (var r in mod.EnumerateMajorRecords())
+            if (mustBeGone.Contains(r.FormKey)) survivors.Add(r.FormKey);
+        if (survivors.Count == 0) return null;
+        return $"Remove did not drop {survivors.Count} record(s) ({string.Join(", ", survivors)}) — the engine " +
+               "no-op'd without throwing; a real inconsistency surfaced BEFORE any rewrite, not swallowed (Q3).";
     }
 
     /// <summary>
@@ -798,11 +824,13 @@ public static class WritePatchBuilder
             return RemovalOutcome.Fail($"in-place ModKey '{targetMod.ModKey.FileName}' must match the target filename '{fileName}'.");
 
         // --- Phase 3: present-check against what the TARGET carries (RemoveRecords' contract, unchanged). One enumeration
-        //     (flat + nested) captures type+editorid for the report AND the runtime type that routes the typed Remove. A
-        //     key the file doesn't define/override is REFUSED loud — in-place removes only what the file OWNS. ---
+        //     (flat + nested) captures type+editorid for the report AND the removal-routing type — the record's FLAT
+        //     GROUP's T, not the concrete runtime type: a subclass of an abstract group's T (GlobalShort) makes Mutagen's
+        //     Remove silently no-op (HCBR-2026-07-08-01 F3). A key the file doesn't define/override is REFUSED loud —
+        //     in-place removes only what the file OWNS. ---
         var carried = new Dictionary<FormKey, (string type, string? edid, Type runtime)>();
         foreach (var r in targetMod.EnumerateMajorRecords())
-            carried[r.FormKey] = (RecordNaming.StripOverlay(r.GetType().Name), r.EditorID, r.GetType());
+            carried[r.FormKey] = (RecordNaming.StripOverlay(r.GetType().Name), r.EditorID, WriteEngine.RemovalTypeFor(r));
 
         var problems = new List<string>();
         var toRemove = new List<RemovedRecord>(targets.Count);
@@ -839,6 +867,8 @@ public static class WritePatchBuilder
                 $"present-check passed but Remove threw — a real engine inconsistency, surfaced not swallowed (Q3): "
                 + $"{ex.GetType().Name}: {ex.Message}");
         }
+        if (RemoveSurvivors(targetMod, toRemove) is { } survived)
+            return RemovalOutcome.Fail(survived + $" Your original '{fileName}' is UNTOUCHED.");
 
         // --- Phase 5: re-serialize the WHOLE target back over itself (model C — WriteInPlace, NOT WritePatch). Release
         //     the target overlay first (the self-lock guard on a FOREIGN target: ReleaseOverlay disposes every session
@@ -886,6 +916,164 @@ public static class WritePatchBuilder
         return new RemovalOutcome(true, null, targetPath, toRemove, masters, remaining, bytes) { InPlace = true };
     }
 
+    /// <summary>Phase-1 source resolution SHARED by <see cref="ForwardRecords"/> and <see cref="ForwardRecordsInPlace"/>:
+    /// resolve each spec's body from its NAMED plugin (NOT the load-order winner) off ONE captured view, collecting ALL
+    /// problems (Q3 — refuse the whole call if any; <paramref name="refusal"/> non-null ⇒ the caller fails with it).
+    /// <paramref name="selfIsTarget"/> only shapes the self-forward message (output patch vs in-place target).</summary>
+    static List<(ForwardSpec spec, IMajorRecordGetter body, string priorWinner, bool wasWinner)> ResolveForwardSources(
+        LoadOrderResolver.OverlaySession session, LoadOrderResolver.IndexView view,
+        IReadOnlyList<ForwardSpec> specs, string fileName, bool selfIsTarget, out string? refusal)
+    {
+        var resolved = new List<(ForwardSpec spec, IMajorRecordGetter body, string priorWinner, bool wasWinner)>(specs.Count);
+        var problems = new List<string>();
+        var seen = new HashSet<FormKey>();
+        foreach (var s in specs)
+        {
+            if (!seen.Add(s.Target))
+            { problems.Add($"{s.Target}: forwarded more than once in this call — name each target once (one source per record)."); continue; }
+            if (string.Equals(s.FromPlugin, fileName, StringComparison.OrdinalIgnoreCase))
+            {
+                problems.Add(selfIsTarget
+                    ? $"{s.Target}: from_plugin '{s.FromPlugin}' is the in-place target itself — forwarding a plugin's own version into itself is a no-op; name the OTHER plugin whose version you want carried in."
+                    : $"{s.Target}: from_plugin '{s.FromPlugin}' is the output patch itself — forwarding a patch's own version into itself is a no-op; name the EARLIER plugin whose version you want to re-assert.");
+                continue;
+            }
+            if (!view.ContainsPlugin(s.FromPlugin))
+            { problems.Add($"{s.Target}: source plugin '{s.FromPlugin}' is not in the load order — name an active plugin that defines or overrides this record."); continue; }
+            if (view.ExcludedPlugins.TryGetValue(s.FromPlugin, out var why))
+            { problems.Add($"{s.Target}: source plugin '{s.FromPlugin}' was excluded from this session ({why}) — its records aren't resolvable."); continue; }
+            var body = view.GetRecord(session, s.FromPlugin, s.Target);
+            if (body is null)
+            { problems.Add($"{s.Target}: source plugin '{s.FromPlugin}' is in the load order but does NOT define or override this record (it doesn't touch it) — there is no version of it there to forward."); continue; }
+            var w = view.ResolveWinner(s.Target);
+            resolved.Add((s, body, w?.WinnerPlugin ?? "(none)",
+                w is { } wi && string.Equals(wi.WinnerPlugin, s.FromPlugin, StringComparison.OrdinalIgnoreCase)));
+        }
+        refusal = problems.Count > 0
+            ? $"refused — {problems.Count} of {specs.Count} forward(s) rejected; NOTHING written:\n  - " + string.Join("\n  - ", problems)
+            : null;
+        return resolved;
+    }
+
+    /// <summary>
+    /// Forward records INTO an EXISTING plugin the user owns, IN PLACE — the forward lane's sibling of
+    /// <see cref="ApplyInPlace"/> (HCBR-2026-07-08-01 F4: <c>into=</c> is reserved for houseCARL-owned patches, so a
+    /// non-houseCARL original gets forwards through THIS explicit, consent-gated lane instead). Semantics:
+    /// <list type="bullet">
+    /// <item>SOURCE: each body resolves from its NAMED plugin exactly as <see cref="ForwardRecords"/> Phase 1 (the
+    /// shared <see cref="ResolveForwardSources"/>).</item>
+    /// <item>COLLISION = REPLACE: a FormKey the target already carries has its existing record dropped
+    /// (<see cref="WriteEngine.RemovalTypeFor"/> + the no-op verify) before the copy — the same xEdit
+    /// copy-as-override-into overwrite the default lane's extend now performs (F1), flagged per record.</item>
+    /// <item>SERIALIZE: model C via <see cref="WriteEngine.WriteInPlace"/> against the WHOLE known-master set (the
+    /// in-place create/edit lanes' context) — the header grows from the copied bodies' actual links (F2's mechanic),
+    /// the author's counter survives, no baseline force-include. Atomic swap; any failure leaves the original intact.</item>
+    /// </list>
+    /// CONSENT + the persistent acknowledge handshake are enforced by the SERVICE before this is reached. The full
+    /// read-back (default ON, like every in-place lane) verifies each forwarded record landed on the re-opened file.
+    /// </summary>
+    public static ForwardOutcome ForwardRecordsInPlace(
+        LoadOrderResolver resolver, IReadOnlyList<ForwardSpec> specs, string targetPath, string targetName,
+        bool fullReadback = true)
+    {
+        if (specs.Count == 0) return ForwardOutcome.Fail("no records to forward supplied.");
+
+        // Per-call overlay session (Option B), same as ApplyInPlace — no handle held at rest.
+        using var session = resolver.OpenSession();
+        var fileName = Path.GetFileName(targetPath);
+
+        // --- Phase 1: target guards (the ApplyInPlace posture — never re-serialize a plugin Mutagen can't fully
+        //     parse) + source resolution off ONE captured view. ---
+        var view = resolver.Capture();
+        if (!view.ContainsPlugin(targetName))
+            return ForwardOutcome.Fail($"in-place target '{targetName}' is not an active plugin in the load order.");
+        if (view.ExcludedPlugins.TryGetValue(targetName, out var excluded))
+            return ForwardOutcome.Fail(
+                $"cannot forward into '{targetName}' in place: it was EXCLUDED from this session ({excluded}) — houseCARL won't " +
+                "re-serialize a plugin it can't fully parse (that would risk dropping the record it couldn't read, Q3). The file is UNTOUCHED.");
+        var resolved = ResolveForwardSources(session, view, specs, targetName, selfIsTarget: true, out var refusal);
+        if (refusal is not null) return ForwardOutcome.Fail(refusal);
+
+        // --- Phase 2: open the TARGET mutably (EAGER, the single plugin only — never the order). ---
+        if (!File.Exists(targetPath))
+            return ForwardOutcome.Fail($"in-place target '{fileName}' not found on disk at {targetPath} — the file is untouched.");
+        SkyrimMod targetMod;
+        try { targetMod = SkyrimMod.CreateFromBinary(targetPath, SkyrimRelease.SkyrimSE); }
+        catch (Exception ex)
+            { return ForwardOutcome.Fail($"cannot open '{fileName}' to forward into in place ({WriteEngine.Describe(ex)}) — a plugin Mutagen can't parse is refused, not re-emitted minus what it couldn't read (Q3). The file is UNTOUCHED."); }
+        if (!string.Equals(targetMod.ModKey.FileName.String, fileName, StringComparison.OrdinalIgnoreCase))
+            return ForwardOutcome.Fail($"in-place ModKey '{targetMod.ModKey.FileName}' must match the target filename '{fileName}'.");
+
+        // --- Phase 3: replace-or-copy each source body into the TARGET (the F1 semantic — a carried FormKey is
+        //     REPLACED, verified dropped before the copy; nothing is serialized until Phase 4, so any refusal here
+        //     leaves the on-disk file untouched). ---
+        var alreadyCarried = new Dictionary<FormKey, IMajorRecord>();
+        foreach (var r in targetMod.EnumerateMajorRecords())
+            alreadyCarried[r.FormKey] = r;
+
+        var forwarded = new List<ForwardedRecord>(resolved.Count);
+        foreach (var (spec, body, priorWinner, wasWinner) in resolved)
+        {
+            try
+            {
+                bool replaced = false;
+                if (alreadyCarried.TryGetValue(spec.Target, out var existing))
+                {
+                    ((IMajorRecordEnumerable)targetMod).Remove(spec.Target, WriteEngine.RemovalTypeFor(existing), throwIfUnknown: true);
+                    if (targetMod.EnumerateMajorRecords().Any(x => x.FormKey == spec.Target))
+                        return ForwardOutcome.Fail(
+                            $"cannot replace {spec.Target}: '{fileName}' already carries this record and its existing " +
+                            "version could not be dropped before the copy (the engine no-op'd without throwing) — " +
+                            "surfaced, not a silent skip (Q3); your original is UNTOUCHED.");
+                    replaced = true;
+                }
+                ILinkCache? cache = WriteEngine.RecordNeedsSourceCache(body) ? session.LinkCacheFor(spec.FromPlugin) : null;
+                WriteEngine.GenericGetOrAddAsOverride(targetMod, body, cache);
+                forwarded.Add(new ForwardedRecord(
+                    spec.Target, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID, spec.FromPlugin, priorWinner, wasWinner,
+                    ReplacedExisting: replaced));
+            }
+            catch (Exception ex)
+            {
+                return ForwardOutcome.Fail(
+                    $"engine error forwarding {spec.Target} from '{spec.FromPlugin}': the source resolved but the " +
+                    $"override-copy threw — a real inconsistency, surfaced not swallowed (Q3): {ex.GetType().Name}: {ex.Message}. Your original is UNTOUCHED.");
+            }
+        }
+
+        // --- Phase 4: model-C re-serialize over the original (WriteInPlace, whole known-master set — the copied
+        //     bodies' links grow the header; the self-lock ReleaseOverlay first; atomic swap). ---
+        session.ReleaseOverlay(fileName);
+        try { WriteEngine.WriteInPlace(targetMod, session.AllMastersExcept(fileName), targetPath); }
+        catch (MissingModException ex)
+        {
+            return ForwardOutcome.Fail(
+                $"writing '{fileName}' in place failed: the forwarded records reference a plugin that is NOT active in " +
+                $"the load order ({ex.Message}) — a reference into an inactive plugin can't resolve in game. " +
+                "Enable that plugin in MO2 and retry. The existing file is untouched.");
+        }
+        catch (Exception ex)
+            { return ForwardOutcome.Fail($"writing '{fileName}' in place failed (serialize or commit; the existing file is untouched): {WriteEngine.Describe(ex)}"); }
+
+        // --- Phase 5: re-open + report masters/bytes + the touched-record verify (default ON for in-place). ---
+        IReadOnlyList<string> masters = Array.Empty<string>();
+        IReadOnlyList<FullReadback>? readBack = null;
+        long bytes = 0;
+        ISkyrimModGetter? back = null;
+        try
+        {
+            back = SkyrimMod.CreateFromBinaryOverlay(targetPath, SkyrimRelease.SkyrimSE);
+            masters = back.ModHeader.MasterReferences.Select(m => m.Master.FileName.ToString()).ToList();
+            bytes = new FileInfo(targetPath).Length;
+            if (fullReadback) readBack = ReadBackInFull(back, resolved.Select(r => r.spec.Target));
+        }
+        catch (Exception ex)
+            { return ForwardOutcome.Fail($"'{fileName}' was rewritten but could not be re-opened to verify: {ex.Message}"); }
+        finally { (back as IDisposable)?.Dispose(); }
+
+        return new ForwardOutcome(true, null, targetPath, false, forwarded, masters, bytes) { ReadBack = readBack, InPlace = true };
+    }
+
     /// <summary>One record to FORWARD: take plugin <see cref="FromPlugin"/>'s version of <see cref="Target"/> and carry
     /// it INTO the patch as an override (xEdit's "copy as override into"). Unlike <see cref="PatchEdit"/> there is no
     /// path/verb — the WHOLE source record is deep-copied verbatim, so the SOURCE plugin (not the load-order winner)
@@ -899,9 +1087,13 @@ public static class WritePatchBuilder
     /// <summary>One record forwarded by <see cref="ForwardRecords"/> — its FormKey + type + editorid, the source plugin
     /// whose version was copied, and the load-order winner it will out-rank once the patch is enabled (so the caller
     /// sees what the forward CHANGES). <see cref="WasAlreadyWinner"/>=true ⇒ the forwarded version WAS already the
-    /// winner, so this override is a redundant no-op copy — surfaced, never silent (Q3).</summary>
+    /// winner, so this override is a redundant no-op copy — surfaced, never silent (Q3).
+    /// <see cref="ReplacedExisting"/>=true ⇒ the patch ALREADY carried this FormKey and its existing record was
+    /// REPLACED by the source's body (the xEdit copy-as-override-into semantic; HCBR-2026-07-08-01 F1 — the old
+    /// GetOrAdd path kept the existing record and skipped the copy while still reporting "forwarded").</summary>
     public sealed record ForwardedRecord(
-        FormKey Target, string RecordType, string? EditorId, string FromPlugin, string PriorWinner, bool WasAlreadyWinner);
+        FormKey Target, string RecordType, string? EditorId, string FromPlugin, string PriorWinner, bool WasAlreadyWinner,
+        bool ReplacedExisting = false);
 
     /// <summary>The outcome of a <see cref="ForwardRecords"/> call. <see cref="Error"/> non-null ⇒ the whole call was
     /// refused (no file written) with a named, recoverable reason (Q3 — a source plugin not in the order / excluded /
@@ -915,8 +1107,27 @@ public static class WritePatchBuilder
     {
         public IReadOnlyList<FullReadback>? ReadBack { get; init; }
 
+        /// <summary>True ⇒ the forwards were written INTO the target's own file (<see cref="ForwardRecordsInPlace"/> —
+        /// the in-place write lane), not a houseCARL patch folder. Mirrors <see cref="PatchOutcome"/>.</summary>
+        public bool InPlace { get; init; }
+
+        /// <summary>True ⇒ NOT a write and NOT an error: the server-enforced first-touch in-place CONSENT handshake.
+        /// <see cref="Error"/> carries the prompt verbatim (re-call with acknowledge=true). Rendered as a confirmation
+        /// prompt, never "error:" (Q3). Nothing was written. Mirrors <see cref="PatchOutcome.NeedsAcknowledge"/>.</summary>
+        public bool NeedsAcknowledge { get; init; }
+
+        /// <summary>An optional Q3 honesty note appended to a SUCCESSFUL outcome — a side effect that didn't land cleanly
+        /// even though the write did. Null when there's nothing to add. Mirrors <see cref="PatchOutcome.Note"/>.</summary>
+        public string? Note { get; init; }
+
         public static ForwardOutcome Fail(string error) =>
             new(false, error, "", false, Array.Empty<ForwardedRecord>(), Array.Empty<string>(), 0);
+
+        /// <summary>The first-touch in-place consent handshake: no write, no error — a required confirmation carrying the
+        /// trade-off <paramref name="prompt"/> (the caller re-calls with acknowledge=true). Mirrors
+        /// <see cref="PatchOutcome.NeedsAck"/>.</summary>
+        public static ForwardOutcome NeedsAck(string prompt) =>
+            new(false, prompt, "", false, Array.Empty<ForwardedRecord>(), Array.Empty<string>(), 0) { NeedsAcknowledge = true };
     }
 
     /// <summary>The outcome of a <see cref="CreatePlugin"/> call. <see cref="Error"/> non-null ⇒ the call was refused
@@ -1042,30 +1253,8 @@ public static class WritePatchBuilder
         //     case ever bites, the clean fix is a single-pass batch fetch keyed by from_plugin (group specs by source,
         //     enumerate the overlay once collecting all wanted FormKeys) — deferred until measured. ---
         var view = resolver.Capture();
-        var resolved = new List<(ForwardSpec spec, IMajorRecordGetter body, string priorWinner, bool wasWinner)>(specs.Count);
-        var problems = new List<string>();
-        var seen = new HashSet<FormKey>();
-        foreach (var s in specs)
-        {
-            if (!seen.Add(s.Target))
-            { problems.Add($"{s.Target}: forwarded more than once in this call — name each target once (one source per record)."); continue; }
-            if (string.Equals(s.FromPlugin, fileName, StringComparison.OrdinalIgnoreCase))
-            { problems.Add($"{s.Target}: from_plugin '{s.FromPlugin}' is the output patch itself — forwarding a patch's own version into itself is a no-op; name the EARLIER plugin whose version you want to re-assert."); continue; }
-            if (!view.ContainsPlugin(s.FromPlugin))
-            { problems.Add($"{s.Target}: source plugin '{s.FromPlugin}' is not in the load order — name an active plugin that defines or overrides this record."); continue; }
-            if (view.ExcludedPlugins.TryGetValue(s.FromPlugin, out var why))
-            { problems.Add($"{s.Target}: source plugin '{s.FromPlugin}' was excluded from this session ({why}) — its records aren't resolvable."); continue; }
-            var body = view.GetRecord(session, s.FromPlugin, s.Target);
-            if (body is null)
-            { problems.Add($"{s.Target}: source plugin '{s.FromPlugin}' is in the load order but does NOT define or override this record (it doesn't touch it) — there is no version of it there to forward."); continue; }
-            var w = view.ResolveWinner(s.Target);
-            resolved.Add((s, body, w?.WinnerPlugin ?? "(none)",
-                w is { } wi && string.Equals(wi.WinnerPlugin, s.FromPlugin, StringComparison.OrdinalIgnoreCase)));
-        }
-        if (problems.Count > 0)
-            return ForwardOutcome.Fail(
-                $"refused — {problems.Count} of {specs.Count} forward(s) rejected; NO patch written:\n  - "
-                + string.Join("\n  - ", problems));
+        var resolved = ResolveForwardSources(session, view, specs, fileName, selfIsTarget: false, out var refusal);
+        if (refusal is not null) return ForwardOutcome.Fail(refusal);
 
         // --- Phase 2: open (extend) or create the patch mod (identical to Apply Phase 2). ---
         SkyrimMod patchMod;
@@ -1085,17 +1274,41 @@ public static class WritePatchBuilder
 
         // --- Phase 3: deep-copy each source body INTO the patch as an override. NO ApplyVerb — the copy IS the forward
         //     (GenericGetOrAddAsOverride duplicates the source's whole content; a nested record gets the source overlay's
-        //     link cache on demand, the SAME session.LinkCacheFor path Apply uses + guards). A throw here is a real
-        //     engine inconsistency — fail the WHOLE call (no partial patch), surfaced not swallowed (Q3). ---
+        //     link cache on demand, the SAME session.LinkCacheFor path Apply uses + guards). A FormKey the patch ALREADY
+        //     carries (an extend) is REPLACED — its existing record dropped first, then the source body copied — the
+        //     xEdit copy-as-override-into semantic (HCBR-2026-07-08-01 F1: GetOrAdd's get-semantics on a collision kept
+        //     the existing record and SKIPPED the copy while still reporting "forwarded" — a silent wrong result; the
+        //     drop also lets the serialize grow the master list from the NEW body, which the skip path never did).
+        //     A throw here is a real engine inconsistency — fail the WHOLE call (no partial patch; nothing has been
+        //     serialized, the on-disk file is untouched), surfaced not swallowed (Q3). ---
+        var alreadyCarried = new Dictionary<FormKey, IMajorRecord>();
+        if (extend)
+            foreach (var r in patchMod.EnumerateMajorRecords())
+                alreadyCarried[r.FormKey] = r;
+
         var forwarded = new List<ForwardedRecord>(resolved.Count);
         foreach (var (spec, body, priorWinner, wasWinner) in resolved)
         {
             try
             {
+                bool replaced = false;
+                if (alreadyCarried.TryGetValue(spec.Target, out var existing))
+                {
+                    ((IMajorRecordEnumerable)patchMod).Remove(spec.Target, WriteEngine.RemovalTypeFor(existing), throwIfUnknown: true);
+                    // The typed Remove can no-op WITHOUT throwing (F3's sibling defect) — verify the slot is genuinely
+                    // empty before the copy, else GetOrAdd would silently return the old record again (Q3).
+                    if (patchMod.EnumerateMajorRecords().Any(x => x.FormKey == spec.Target))
+                        return ForwardOutcome.Fail(
+                            $"cannot replace {spec.Target}: the patch already carries this record and its existing " +
+                            "override could not be dropped before the copy (the engine no-op'd without throwing) — " +
+                            "surfaced, not a silent skip (Q3); NO patch written.");
+                    replaced = true;
+                }
                 ILinkCache? cache = WriteEngine.RecordNeedsSourceCache(body) ? session.LinkCacheFor(spec.FromPlugin) : null;
                 WriteEngine.GenericGetOrAddAsOverride(patchMod, body, cache);
                 forwarded.Add(new ForwardedRecord(
-                    spec.Target, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID, spec.FromPlugin, priorWinner, wasWinner));
+                    spec.Target, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID, spec.FromPlugin, priorWinner, wasWinner,
+                    ReplacedExisting: replaced));
             }
             catch (Exception ex)
             {

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -50,6 +50,7 @@ public static class CiAll
         ("source-display-guard", SourceDisplayProbe.RunGuard),
         ("writelock-guard", WriteLockProbe.RunGuard),
         ("inplace-guard", InPlaceProbe.RunGuard),
+        ("subclass-remove-guard", SubclassRemoveGuardProbe.RunGuard),
         ("perk-refs-guard", PerkRefsProbe.RunGuard),
         ("conflict-diff-guard", ConflictDiffProbe.RunGuard),
         ("formid-floor-guard", FormIdFloorProbe.RunGuard),

--- a/src/housecarl-generator/ForwardFromPluginProbe.cs
+++ b/src/housecarl-generator/ForwardFromPluginProbe.cs
@@ -4,6 +4,7 @@ using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Records;
 using Mutagen.Bethesda.Skyrim;
 using HousecarlCore;
+using HousecarlMcp;
 
 namespace HousecarlGenerator;
 
@@ -39,11 +40,18 @@ namespace HousecarlGenerator;
 ///   ALREADY-WINNER    — forward ModB's X (already winning): succeeds, Dmg 30, flagged WasAlreadyWinner (redundant — surfaced, not silent Q3).
 ///   MULTI             — forward [X,Y] from ModA in ONE call: both land (20, 200).
 ///   EXTEND            — forward X (fresh) then Y into the SAME patch (into=): both present (20, 200).
+///   REPLACE           — forward X again from ModB into the same patch: the existing override is REPLACED (30, not 20),
+///                       flagged ReplacedExisting, and the header grows from the NEW body (+ModB via its keyword) —
+///                       HCBR-2026-07-08-01 F1 (the pre-fix GetOrAdd kept the old body, skipped the copy AND the
+///                       master grow, and still reported "forwarded").
 ///   ORIGINALS         — the 4 source plugins are SHA-identical across the whole run (only the patch is ever written).
 ///   REJ-NOTINORDER    — a source plugin not in the order refuses loud ('not in the load order'), NO file.
 ///   REJ-DOESNTDEFINE  — forwarding X from Other (which defines only W) refuses loud ('does NOT define'), NO file.
 ///   REJ-INTOSELF      — from_plugin == the output patch itself refuses loud ('output patch itself'), NO file.
 ///   REJ-DUP           — the SAME target twice in one call refuses loud ('more than once'), NO file.
+///   INPLACE-* (HCBR-2026-07-08-01 F4) — the forward lane's in-place route, on COPIES of the sources: consent
+///                       RED→GREEN into a plugin's own file (NEW), replace-on-collision + master grow (REPLACE),
+///                       the up-front contract (CONTRACT), and the opt-in defaults (OPTIN).
 ///
 /// COVERAGE NOTE (Q3 — surface the gap, don't imply completeness): four of GetRecord's five null/refusal shapes are
 /// armed above (not-in-order, doesn't-define, the-patch-itself, dup). The FIFTH — a source plugin EXCLUDED from the
@@ -117,7 +125,11 @@ public static class ForwardFromPluginProbe
             a.BeginWrite.ToPath(aPath).WithLoadOrder(new ISkyrimModGetter[] { m }).Write();
 
             var b = new SkyrimMod(new ModKey("HcFwdModB", ModType.Plugin), SkyrimRelease.SkyrimSE);
-            ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(b, x)).BasicStats!.Damage = 30;
+            var bx = (IWeapon)WriteEngine.GenericGetOrAddAsOverride(b, x); bx.BasicStats!.Damage = 30;
+            // ModB's X carries a keyword DEFINED IN ModB — so forwarding ModB's X must pull ModB into the patch's
+            // master header (the REPLACE arm's master-grow discriminator; HCBR-2026-07-08-01 F1's skipped-grow half).
+            var bkw = b.Keywords.AddNew(); bkw.EditorID = "HcFwdModBKw";
+            (bx.Keywords ??= new()).Add(bkw.FormKey.ToLink<IKeywordGetter>());
             ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(b, y)).BasicStats!.Damage = 300;
             ((IPlacedObject)WriteEngine.GenericGetOrAddAsOverride(b, placed, mCache)).Scale = 3.0f;
             b.BeginWrite.ToPath(bPath).WithLoadOrder(new ISkyrimModGetter[] { m }).Write();
@@ -228,6 +240,28 @@ public static class ForwardFromPluginProbe
                 firstOk && secondOk && dx == 20 && dy == 200, $"first={firstOk} second={secondOk} dx={dx} dy={dy}");
         }
 
+        // ---- REPLACE (HCBR-2026-07-08-01 F1): forward X from ModA fresh, then X AGAIN from ModB into the same patch.
+        //      The pre-fix GetOrAdd get-semantics kept ModA's body (Dmg 20) and skipped the copy while still reporting
+        //      "forwarded 1 record" — a silent wrong result. The contract now: the existing override is REPLACED by
+        //      ModB's body (Dmg 30), flagged ReplacedExisting, AND the master header grows from the NEW body (ModB's X
+        //      carries a ModB-defined keyword, so ModB must appear — the skipped-master-grow half of the report). ----
+        {
+            string pPath = Path.Combine(tmpDir, "HcFwdReplace.esp");
+            bool firstOk; WritePatchBuilder.ForwardOutcome o2;
+            using (var r = LoadOrderResolver.Build(orderPaths))
+                firstOk = WritePatchBuilder.ForwardRecords(r,
+                    new[] { new WritePatchBuilder.ForwardSpec { Target = xFk, FromPlugin = ModAName } }, pPath, extend: false).Success;
+            using (var r = LoadOrderResolver.Build(orderPaths))
+                o2 = WritePatchBuilder.ForwardRecords(r,
+                    new[] { new WritePatchBuilder.ForwardSpec { Target = xFk, FromPlugin = ModBName } }, pPath, extend: true);
+            var dmg = firstOk && o2.Success ? ReadWeaponDamage(pPath, xFk) : null;
+            bool flagged = o2.Success && o2.Forwarded.Count == 1 && o2.Forwarded[0].ReplacedExisting;
+            bool masterGrown = o2.Success && o2.Masters.Any(mn => mn.Equals(ModBName, StringComparison.OrdinalIgnoreCase));
+            Check("REPLACE: re-forwarding a FormKey the patch already carries replaces the body (X=30, not 20), flags it, grows masters (+ModB)",
+                firstOk && o2.Success && dmg == 30 && flagged && masterGrown,
+                $"first={firstOk} second={o2.Success} dmg={dmg} (want 30) flagged={flagged} masterGrown={masterGrown} masters=[{(o2.Success ? string.Join(",", o2.Masters) : "")}] err=[{Trim(o2.Error)}]");
+        }
+
         // ---- Q3 rejects (whole call refused, NO file written, named reason). ----
         void RejectArm(string label, string stem, WritePatchBuilder.ForwardSpec[] specs, Func<string, bool> msgOk)
         {
@@ -264,6 +298,79 @@ public static class ForwardFromPluginProbe
         bool untouched = shaBefore.All(kv => string.Equals(kv.Value, ShaOf(kv.Key), StringComparison.Ordinal));
         Check("ORIGINALS: the 4 source plugins are byte-identical after the run (only the patch is written)", untouched,
             untouched ? null : "a source plugin's bytes changed — forwarding must never write a source");
+
+        // ==== IN-PLACE lane (HCBR-2026-07-08-01 F4) — forwards INTO an existing plugin's OWN file, consent-gated.
+        //      Runs on COPIES of the sources (this lane rewrites its target BY DESIGN; the ORIGINALS arm above stays
+        //      the default-lane invariant). Drives the REAL service branch (contract + handshake + core). ====
+
+        // ---- INPLACE-NEW: forward ModA's X into Other (which doesn't carry X): consent RED first (file untouched),
+        //      GREEN with acknowledge=true — X=20 lands as Other's override, the origin master joins Other's header. ----
+        {
+            var dir = Path.Combine(tmpDir, "inplace-new"); Directory.CreateDirectory(dir);
+            var oCopy = Path.Combine(dir, OtherName); File.Copy(oPath, oCopy);
+            var before = File.ReadAllBytes(oCopy);
+            bool red, redUntouched; WritePatchBuilder.ForwardOutcome green;
+            using (var r = LoadOrderResolver.Build(new[] { mPath, aPath, bPath, oCopy }))
+            {
+                var svc = LoadOrderService.ForGuard(r, new UserConfigStore(Path.Combine(dir, "user.json")));
+                var first = svc.ForwardRecords(new[] { $"{xFk.ID:X6}:{MasterName}" }, ModAName, null, null,
+                    fullReadback: false, target: OtherName, inPlace: true, acknowledge: false);
+                red = first.NeedsAcknowledge && !first.Success;
+                redUntouched = File.ReadAllBytes(oCopy).AsSpan().SequenceEqual(before);
+                green = svc.ForwardRecords(new[] { $"{xFk.ID:X6}:{MasterName}" }, ModAName, null, null,
+                    fullReadback: false, target: OtherName, inPlace: true, acknowledge: true);
+            }
+            var dmg = ReadWeaponDamage(oCopy, xFk);
+            bool masterGrown = green.Success && green.Masters.Any(mn => mn.Equals(MasterName, StringComparison.OrdinalIgnoreCase));
+            bool pass = red && redUntouched && green.Success && green.InPlace && dmg == 20 && masterGrown
+                     && green.Forwarded.Count == 1 && !green.Forwarded[0].ReplacedExisting;
+            Check("INPLACE-NEW: consent RED (untouched) → GREEN; ModA's X lands in Other's own file (20) + origin master joins its header",
+                pass, $"red={red} redUntouched={redUntouched} green={green.Success} inPlace={green.InPlace} dmg={dmg} (want 20) masterGrown={masterGrown} err=[{Trim(green.Error)}]");
+        }
+
+        // ---- INPLACE-REPLACE: forward ModB's X into ModA (which CARRIES its own X=20 override) — the existing record
+        //      is REPLACED (30), flagged, and ModB joins ModA's masters (the ModB-defined keyword on ModB's X). ----
+        {
+            var dir = Path.Combine(tmpDir, "inplace-replace"); Directory.CreateDirectory(dir);
+            var aCopy = Path.Combine(dir, ModAName); File.Copy(aPath, aCopy);
+            WritePatchBuilder.ForwardOutcome o;
+            using (var r = LoadOrderResolver.Build(new[] { mPath, aCopy, bPath, oPath }))
+            {
+                var svc = LoadOrderService.ForGuard(r, new UserConfigStore(Path.Combine(dir, "user.json")));
+                o = svc.ForwardRecords(new[] { $"{xFk.ID:X6}:{MasterName}" }, ModBName, null, null,
+                    fullReadback: false, target: ModAName, inPlace: true, acknowledge: true);
+            }
+            var dmg = ReadWeaponDamage(aCopy, xFk);
+            bool flagged = o.Success && o.Forwarded.Count == 1 && o.Forwarded[0].ReplacedExisting;
+            bool masterGrown = o.Success && o.Masters.Any(mn => mn.Equals(ModBName, StringComparison.OrdinalIgnoreCase));
+            bool pass = o.Success && o.InPlace && dmg == 30 && flagged && masterGrown;
+            Check("INPLACE-REPLACE: a FormKey the target carries is replaced in its own file (X=30, not 20), flagged, masters grow (+ModB)",
+                pass, $"success={o.Success} inPlace={o.InPlace} dmg={dmg} (want 30) flagged={flagged} masterGrown={masterGrown} masters=[{(o.Success ? string.Join(",", o.Masters) : "")}] err=[{Trim(o.Error)}]");
+        }
+
+        // ---- INPLACE-CONTRACT: the same up-front contract the sibling write tools enforce (Q3, named misuses). ----
+        {
+            using var r = LoadOrderResolver.Build(orderPaths);
+            var svc = LoadOrderService.ForGuard(r, new UserConfigStore(Path.Combine(tmpDir, "contract.user.json")));
+            string fmtX = $"{xFk.ID:X6}:{MasterName}";
+            var noTarget = svc.ForwardRecords(new[] { fmtX }, ModAName, null, null, false, target: null, inPlace: true, acknowledge: true);
+            var withInto = svc.ForwardRecords(new[] { fmtX }, ModAName, null, "somepatch", false, target: OtherName, inPlace: true, acknowledge: true);
+            var targetNoFlag = svc.ForwardRecords(new[] { fmtX }, ModAName, null, null, false, target: OtherName, inPlace: false);
+            bool pass = !noTarget.Success && (noTarget.Error?.Contains("requires target=") ?? false)
+                     && !withInto.Success && (withInto.Error?.Contains("mutually exclusive") ?? false)
+                     && !targetNoFlag.Success && (targetNoFlag.Error?.Contains("only meaningful with in_place") ?? false);
+            Check("INPLACE-CONTRACT: in_place⇔target, ⊥ into= (named refusals)", pass,
+                $"noTarget={Trim(noTarget.Error)} | into={Trim(withInto.Error)} | noFlag={Trim(targetNoFlag.Error)}");
+        }
+
+        // ---- INPLACE-OPTIN: the tool params default OFF by construction (assert the schema, not by omission). ----
+        {
+            var fr = typeof(WriteTools).GetMethod(nameof(WriteTools.ForwardRecord))!;
+            bool pass = fr.GetParameters().First(p => p.Name == "in_place").DefaultValue is false
+                     && fr.GetParameters().First(p => p.Name == "target").DefaultValue is null
+                     && fr.GetParameters().First(p => p.Name == "acknowledge").DefaultValue is false;
+            Check("INPLACE-OPTIN: forward_record's in_place/target/acknowledge default OFF", pass, null);
+        }
 
         Console.WriteLine();
         Console.WriteLine(failures == 0 ? "forward-from-plugin-guard: ALL PASS" : $"forward-from-plugin-guard: {failures} FAILURE(S)");

--- a/src/housecarl-generator/ForwardFromPluginProbe.cs
+++ b/src/housecarl-generator/ForwardFromPluginProbe.cs
@@ -322,10 +322,12 @@ public static class ForwardFromPluginProbe
             }
             var dmg = ReadWeaponDamage(oCopy, xFk);
             bool masterGrown = green.Success && green.Masters.Any(mn => mn.Equals(MasterName, StringComparison.OrdinalIgnoreCase));
-            bool pass = red && redUntouched && green.Success && green.InPlace && dmg == 20 && masterGrown
+            // PR #163 review #1: the grown master must be surfaced as an explicit re-sort note, not left to "if a winner changed".
+            bool noted = green.Note is not null && green.Note.Contains("added as a master", StringComparison.OrdinalIgnoreCase);
+            bool pass = red && redUntouched && green.Success && green.InPlace && dmg == 20 && masterGrown && noted
                      && green.Forwarded.Count == 1 && !green.Forwarded[0].ReplacedExisting;
-            Check("INPLACE-NEW: consent RED (untouched) → GREEN; ModA's X lands in Other's own file (20) + origin master joins its header",
-                pass, $"red={red} redUntouched={redUntouched} green={green.Success} inPlace={green.InPlace} dmg={dmg} (want 20) masterGrown={masterGrown} err=[{Trim(green.Error)}]");
+            Check("INPLACE-NEW: consent RED (untouched) → GREEN; ModA's X lands in Other's own file (20) + origin master joins its header + re-sort note",
+                pass, $"red={red} redUntouched={redUntouched} green={green.Success} inPlace={green.InPlace} dmg={dmg} (want 20) masterGrown={masterGrown} resortNoted={noted} err=[{Trim(green.Error)}]");
         }
 
         // ---- INPLACE-REPLACE: forward ModB's X into ModA (which CARRIES its own X=20 override) — the existing record
@@ -343,9 +345,10 @@ public static class ForwardFromPluginProbe
             var dmg = ReadWeaponDamage(aCopy, xFk);
             bool flagged = o.Success && o.Forwarded.Count == 1 && o.Forwarded[0].ReplacedExisting;
             bool masterGrown = o.Success && o.Masters.Any(mn => mn.Equals(ModBName, StringComparison.OrdinalIgnoreCase));
-            bool pass = o.Success && o.InPlace && dmg == 30 && flagged && masterGrown;
-            Check("INPLACE-REPLACE: a FormKey the target carries is replaced in its own file (X=30, not 20), flagged, masters grow (+ModB)",
-                pass, $"success={o.Success} inPlace={o.InPlace} dmg={dmg} (want 30) flagged={flagged} masterGrown={masterGrown} masters=[{(o.Success ? string.Join(",", o.Masters) : "")}] err=[{Trim(o.Error)}]");
+            bool noted = o.Note is not null && o.Note.Contains("added as a master", StringComparison.OrdinalIgnoreCase);
+            bool pass = o.Success && o.InPlace && dmg == 30 && flagged && masterGrown && noted;
+            Check("INPLACE-REPLACE: a FormKey the target carries is replaced in its own file (X=30, not 20), flagged, masters grow (+ModB) + re-sort note",
+                pass, $"success={o.Success} inPlace={o.InPlace} dmg={dmg} (want 30) flagged={flagged} masterGrown={masterGrown} resortNoted={noted} masters=[{(o.Success ? string.Join(",", o.Masters) : "")}] err=[{Trim(o.Error)}]");
         }
 
         // ---- INPLACE-CONTRACT: the same up-front contract the sibling write tools enforce (Q3, named misuses). ----

--- a/src/housecarl-generator/InPlaceProbe.cs
+++ b/src/housecarl-generator/InPlaceProbe.cs
@@ -607,9 +607,11 @@ public static class InPlaceProbe
             bool noBaseline = !masters.Any(m => m.Equals("Skyrim.esm", StringComparison.OrdinalIgnoreCase) || m.Equals("Update.esm", StringComparison.OrdinalIgnoreCase));
             bool kept = masters.Any(m => m.Equals(MasterName, StringComparison.OrdinalIgnoreCase));
             bool landed = ReadWeaponHasKeyword(userY, wfk, hkwFk);
-            bool pass = o.Success && o.InPlace && landed && grown && kept && noBaseline;
-            results.Add(("Y edit-lane master GROW (link to an active undeclared plugin lands + grows the header)", pass,
-                $"success={o.Success} keywordLanded={landed} masterGrown={grown} originalMasterKept={kept} noBaseline={noBaseline} masters=[{string.Join(",", masters)}]  [{o.Error ?? "ok"}]"));
+            // PR #163 review #1: a grown master is itself a re-sort trigger — the outcome must SAY so, explicitly.
+            bool noted = o.Note is not null && o.Note.Contains("added as a master", StringComparison.OrdinalIgnoreCase);
+            bool pass = o.Success && o.InPlace && landed && grown && kept && noBaseline && noted;
+            results.Add(("Y edit-lane master GROW (link to an active undeclared plugin lands + grows the header + re-sort note)", pass,
+                $"success={o.Success} keywordLanded={landed} masterGrown={grown} originalMasterKept={kept} noBaseline={noBaseline} resortNoted={noted} masters=[{string.Join(",", masters)}]  [{o.Error ?? "ok"}]"));
         }
 
         // ===== Z — MASTERS (edit) STILL LOUD: a link to a plugin NOT in the load order refuses, file untouched =====

--- a/src/housecarl-generator/InPlaceProbe.cs
+++ b/src/housecarl-generator/InPlaceProbe.cs
@@ -45,7 +45,9 @@ namespace HousecarlGenerator;
 /// Arms A–I cover the EDIT lane; J–Q cover the CREATE lane (J create+counter, O cross-master, M nested-under-a-foreign-parent,
 /// P same-call nested unit, Q exterior-cell-under-a-foreign-worldspace, K handshake, L contract, N opt-in) and arm I also
 /// proves the create lane shares the marker + handshake; R–X cover the REMOVE lane (R override-remove+prune, S refuse-if-
-/// not-carried, T surgical-remove+keep-master, U contract, V resolver, W handshake+cross-lane-share, X opt-in).
+/// not-carried, T surgical-remove+keep-master, U contract, V resolver, W handshake+cross-lane-share, X opt-in);
+/// Y–Z cover the edit lane's MASTER-GROW fix (HCBR-2026-07-08-01 F2: Y — a FormLink to an active-but-undeclared plugin
+/// lands and grows the header; Z — a link to a plugin NOT in the load order still refuses loud, file untouched).
 /// Run: dotnet run --project src/housecarl-generator inplace-guard
 ///
 /// The NESTED lock arm (the LinkCacheFor-on-a-foreign-target path) needs a real nested record + master, so it lives in
@@ -81,6 +83,7 @@ public static class InPlaceProbe
 
         var masterKey = new ModKey("HcInPlaceMaster", ModType.Master);
         FormKey wfk, w2fk, tfk, wsfk;
+        FormKey hkwFk = default;   // a keyword DEFINED in the High plugin (assigned in the High fixture below; arm Y)
         {
             var m = new SkyrimMod(masterKey, SkyrimRelease.SkyrimSE);
             var w = m.Weapons.AddNew(); w.EditorID = "HcIP_Weap"; w.BasicStats = new WeaponBasicStats { Damage = 10 }; w.Name = "MasterSword";
@@ -101,6 +104,10 @@ public static class InPlaceProbe
             var h = new SkyrimMod(new ModKey("HcInPlaceHigh", ModType.Plugin), SkyrimRelease.SkyrimSE);
             var hw = h.Weapons.GetOrAddAsOverride(mOv.Weapons.First(x => x.FormKey == wfk));
             hw.BasicStats!.Damage = 99; hw.Name = "HighSword";
+            // A keyword DEFINED IN High (not an override): the new-master edit arm (Y) links the USER's weapon to it,
+            // which must GROW the user's master header (HCBR-2026-07-08-01 F2) — High is active but not yet a master.
+            var hkw = h.Keywords.AddNew(); hkw.EditorID = "HcIP_HighKw";
+            hkwFk = hkw.FormKey;
             h.BeginWrite.ToPath(highPath).WithLoadOrder(new ISkyrimModGetter[] { mOv }).Write();
         }
         Console.WriteLine($"-- setup: master {MasterName} (weapon {wfk}), user override (dmg 20, 'UserSword', counter 0x123), higher override (dmg 99, 'HighSword') --");
@@ -583,6 +590,45 @@ public static class InPlaceProbe
             results.Add(("X opt-in by construction (remove_record defaults OFF)", pass, $"remove_record={DefOff(rr)}"));
         }
 
+        // ===== Y — MASTERS (edit) GROW: an edit linking to an ACTIVE plugin the target didn't master LANDS + grows =====
+        // HCBR-2026-07-08-01 F2: the edit lane serialized against the target's own declared masters, so composing a
+        // FormLink to an active-but-undeclared plugin threw MissingModException (refused loud, but the edit was
+        // legitimate). Now it serializes against the whole known-master set (the in-place CREATE lane's context): the
+        // user's weapon gains High's own keyword → the edit lands AND HcInPlaceHigh.esp joins the user's master header.
+        // RED on the pre-fix code (MissingModException); the arm-C no-baseline assert still holds separately.
+        {
+            var userY = FreshUser(tmpDir, "Y", userPristine);
+            using var r = LoadOrderResolver.Build(new[] { masterPath, userY, highPath });
+            var o = WritePatchBuilder.ApplyInPlace(r, rulebook,
+                new[] { new WritePatchBuilder.PatchEdit { Target = wfk, Path = new[] { "Keywords" }, Verb = "Add", Value = $"{hkwFk.ID:X6}:{HighName}" } },
+                userY, UserName);
+            var masters = ReadMasters(userY);
+            bool grown = masters.Any(m => m.Equals(HighName, StringComparison.OrdinalIgnoreCase));
+            bool noBaseline = !masters.Any(m => m.Equals("Skyrim.esm", StringComparison.OrdinalIgnoreCase) || m.Equals("Update.esm", StringComparison.OrdinalIgnoreCase));
+            bool kept = masters.Any(m => m.Equals(MasterName, StringComparison.OrdinalIgnoreCase));
+            bool landed = ReadWeaponHasKeyword(userY, wfk, hkwFk);
+            bool pass = o.Success && o.InPlace && landed && grown && kept && noBaseline;
+            results.Add(("Y edit-lane master GROW (link to an active undeclared plugin lands + grows the header)", pass,
+                $"success={o.Success} keywordLanded={landed} masterGrown={grown} originalMasterKept={kept} noBaseline={noBaseline} masters=[{string.Join(",", masters)}]  [{o.Error ?? "ok"}]"));
+        }
+
+        // ===== Z — MASTERS (edit) STILL LOUD: a link to a plugin NOT in the load order refuses, file untouched =====
+        // The F2 fix must not soften Q3: with the whole-order context, a MissingModException now genuinely means "not
+        // active" — assert the refusal names it and the original is byte-untouched.
+        {
+            var userZ = FreshUser(tmpDir, "Z", userPristine);
+            var before = File.ReadAllBytes(userZ);
+            using var r = LoadOrderResolver.Build(new[] { masterPath, userZ, highPath });
+            var o = WritePatchBuilder.ApplyInPlace(r, rulebook,
+                new[] { new WritePatchBuilder.PatchEdit { Target = wfk, Path = new[] { "Keywords" }, Verb = "Add", Value = "000ABC:NotInOrder.esp" } },
+                userZ, UserName);
+            bool untouched = File.ReadAllBytes(userZ).AsSpan().SequenceEqual(before);
+            bool named = !o.Success && (o.Error?.Contains("NOT active", StringComparison.OrdinalIgnoreCase) ?? false);
+            bool pass = named && untouched;
+            results.Add(("Z edit-lane link to a NON-load-order plugin still refuses loud, file untouched", pass,
+                $"refused={!o.Success} named={named} untouched={untouched}  [{Trim(o.Error)}]"));
+        }
+
         Console.WriteLine("── ARMS ──");
         bool all = true;
         foreach (var (name, pass, detail) in results)
@@ -756,6 +802,18 @@ public static class InPlaceProbe
         ISkyrimModGetter? ov = null;
         try { ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE); return ov.Weapons.FirstOrDefault(x => x.FormKey == fk)?.Name?.String ?? "(none)"; }
         catch { return "(read failed)"; }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    static bool ReadWeaponHasKeyword(string path, FormKey wfk, FormKey kwFk)
+    {
+        ISkyrimModGetter? ov = null;
+        try
+        {
+            ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE);
+            return ov.Weapons.FirstOrDefault(x => x.FormKey == wfk)?.Keywords?.Any(k => k.FormKey == kwFk) ?? false;
+        }
+        catch { return false; }
         finally { (ov as IDisposable)?.Dispose(); }
     }
 

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -139,6 +139,10 @@ if (args.Length > 0 && args[0] == "remove-create-probe") return RemoveCreateProb
 // Capability arc scout #2 (remove-record): whole-record removal via mod.Remove(FormKey) — flat + nested + not-found semantics.
 if (args.Length > 0 && args[0] == "remove-record-probe") return RemoveRecordProbe.RunProbe(args[1..]);
 
+// HCBR-2026-07-08-01 F3: subclass-typed Remove (GlobalShort/GameSetting*) silently no-ops — flat-group-T routing +
+// pre-serialize absence verify, RED-proven for both remove lanes.
+if (args.Length > 0 && args[0] == "subclass-remove-guard") return SubclassRemoveGuardProbe.RunGuard(args[1..]);
+
 // Capability arc remove-record proof: drive WritePatchBuilder.RemoveRecords (the core housecarl_remove_record calls) vs a real, large load order.
 if (args.Length > 0 && args[0] == "remove-proof") return RemoveProof.RunRemoveProof(args[1..]);
 

--- a/src/housecarl-generator/SubclassRemoveGuardProbe.cs
+++ b/src/housecarl-generator/SubclassRemoveGuardProbe.cs
@@ -1,0 +1,204 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SELF-CONTAINED CI REGRESSION GUARD for HCBR-2026-07-08-01 F3: removing a record whose concrete class is a
+/// SUBCLASS of its flat group's T (a <c>GlobalShort</c> under <c>SkyrimGroup&lt;Global&gt;</c>, a
+/// <c>GameSettingString</c> under <c>SkyrimGroup&lt;GameSetting&gt;</c>) silently no-op'd: Mutagen's typed
+/// <c>Remove(FormKey, Type, throwIfUnknown:true)</c> does NOT throw for such a type — it just removes nothing —
+/// so the remove lanes rewrote the whole file to no effect and only the post-write verify caught it ("record
+/// still present"). Diagnosis (2026-07-09, this probe's original diag arms) separated the hypotheses:
+///
+///   H-TYPE   (CONFIRMED) — Remove with typeof(GlobalShort) leaves the record in memory; typeof(Global) and
+///                          typeof(IGlobal) remove it. throwIfUnknown:true throws for NEITHER.
+///   H-RETAIN (REFUTED)   — the report's "fails when the origin master must be retained" theory: a Weapon
+///                          override removed while its origin master stays referenced works fine (arm C).
+///
+/// The fix, RED-proven here (every arm fails on the pre-fix code):
+///   1. <see cref="WriteEngine.RemovalTypeFor"/> — both remove lanes route the typed Remove via the record's
+///      FLAT GROUP's T (GlobalShort → Global), not the concrete runtime type; nested records keep the runtime
+///      type (the remove-record-probe's proven shape).
+///   2. <c>RemoveSurvivors</c> — both lanes verify IN MEMORY that every target is gone BEFORE serializing, so
+///      any future engine no-op fails loud with the file UNTOUCHED instead of after a pointless rewrite.
+///
+/// Arms:
+///   A  in-place: GlobalShort override removed while its origin master stays referenced (the report's EXACT
+///      failing shape — GLOB anchor out, banter master retained by the alias).
+///   B  in-place: GlobalShort override as the file's only record (master pruned) — proves A isn't retention-dependent.
+///   C  in-place: Weapon override removed, origin master retained — the H-RETAIN control (passed even pre-fix).
+///   D  default patch lane: GlobalShort removed from a houseCARL patch — the same routing bug lived there too.
+///   E  in-place: GameSettingString — the OTHER abstract flat group, by construction not a Global special-case.
+///   F  primitive documentation: Remove(typeof(GlobalShort)) still no-ops in Mutagen (if an upgrade fixes it,
+///      this arm flags so the routing indirection can be re-evaluated) AND typeof(Global) removes.
+///
+/// Run: dotnet run --project src/housecarl-generator subclass-remove-guard
+/// </summary>
+public static class SubclassRemoveGuardProbe
+{
+    const string MasterName = "HcSubRmMaster.esm";
+    const string UserName = "HcSubRmUser.esp";
+
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  REGRESSION GUARD — subclass-typed remove (HCBR-2026-07-08-01 F3)  ################");
+        Console.WriteLine();
+
+        var tmpDir = Path.Combine(Path.GetTempPath(), "hc-subclass-remove-guard");
+        if (Directory.Exists(tmpDir)) Directory.Delete(tmpDir, recursive: true);
+        Directory.CreateDirectory(tmpDir);
+
+        // ---- Setup: master with a GlobalShort + a GameSettingString + two weapons; a FULL user override plugin
+        //      (G + GMST + W1 + W2) and a G-ONLY user plugin. ----
+        string masterPath = Path.Combine(tmpDir, MasterName);
+        string fullPristine = Path.Combine(tmpDir, "pristine-full", UserName);
+        string gOnlyPristine = Path.Combine(tmpDir, "pristine-gonly", UserName);
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPristine)!);
+        Directory.CreateDirectory(Path.GetDirectoryName(gOnlyPristine)!);
+
+        var masterKey = new ModKey("HcSubRmMaster", ModType.Master);
+        FormKey gfk, gmstFk, w1fk, w2fk;
+        {
+            var m = new SkyrimMod(masterKey, SkyrimRelease.SkyrimSE);
+            var g = new GlobalShort(m.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "HcSR_Glob", Data = 0 };
+            m.Globals.Add(g);
+            var gmst = new GameSettingString(m.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "sHcSR_Gmst", Data = "base" };
+            m.GameSettings.Add(gmst);
+            var w1 = m.Weapons.AddNew(); w1.EditorID = "HcSR_Weap1"; w1.BasicStats = new WeaponBasicStats { Damage = 10 };
+            var w2 = m.Weapons.AddNew(); w2.EditorID = "HcSR_Weap2"; w2.BasicStats = new WeaponBasicStats { Damage = 5 };
+            gfk = g.FormKey; gmstFk = gmst.FormKey; w1fk = w1.FormKey; w2fk = w2.FormKey;
+            m.BeginWrite.ToPath(masterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+        }
+        using (var mOv = SkyrimMod.CreateFromBinaryOverlay(masterPath, SkyrimRelease.SkyrimSE))
+        {
+            var full = new SkyrimMod(new ModKey("HcSubRmUser", ModType.Plugin), SkyrimRelease.SkyrimSE);
+            ((GlobalShort)full.Globals.GetOrAddAsOverride(mOv.Globals.First(x => x.FormKey == gfk))).Data = 1;
+            ((GameSettingString)full.GameSettings.GetOrAddAsOverride(mOv.GameSettings.First(x => x.FormKey == gmstFk))).Data = "over";
+            full.Weapons.GetOrAddAsOverride(mOv.Weapons.First(x => x.FormKey == w1fk)).BasicStats!.Damage = 20;
+            full.Weapons.GetOrAddAsOverride(mOv.Weapons.First(x => x.FormKey == w2fk)).BasicStats!.Damage = 25;
+            full.BeginWrite.ToPath(fullPristine).WithLoadOrder(new ISkyrimModGetter[] { mOv }).Write();
+
+            var gOnly = new SkyrimMod(new ModKey("HcSubRmUser", ModType.Plugin), SkyrimRelease.SkyrimSE);
+            ((GlobalShort)gOnly.Globals.GetOrAddAsOverride(mOv.Globals.First(x => x.FormKey == gfk))).Data = 1;
+            gOnly.BeginWrite.ToPath(gOnlyPristine).WithLoadOrder(new ISkyrimModGetter[] { mOv }).Write();
+        }
+        Console.WriteLine($"-- setup: master (GLOB {gfk}, GMST {gmstFk}, weapons); full user (G+GMST+W1+W2), G-only user --");
+        Console.WriteLine();
+
+        var results = new List<(string name, bool pass, string detail)>();
+
+        // ===== A — in-place: GlobalShort override out, origin master RETAINED (the report's exact shape) =====
+        {
+            var path = Fresh(tmpDir, "A", fullPristine);
+            using var r = LoadOrderResolver.Build(new[] { masterPath, path });
+            var o = WritePatchBuilder.RemoveRecordsInPlace(r, new[] { gfk }, path, UserName);
+            bool gone = !RecordPresent(path, gfk);
+            bool masterKept = ReadMasters(path).Any(m => m.Equals(MasterName, StringComparison.OrdinalIgnoreCase));
+            bool weaponKept = RecordPresent(path, w1fk);
+            bool pass = o.Success && gone && masterKept && weaponKept;
+            results.Add(("A in-place GlobalShort remove, origin master retained", pass,
+                $"success={o.Success} gone={gone} masterKept={masterKept} weaponKept={weaponKept}  [{o.Error ?? "ok"}]"));
+        }
+
+        // ===== B — in-place: GlobalShort override is the ONLY record (master pruned) =====
+        {
+            var path = Fresh(tmpDir, "B", gOnlyPristine);
+            using var r = LoadOrderResolver.Build(new[] { masterPath, path });
+            var o = WritePatchBuilder.RemoveRecordsInPlace(r, new[] { gfk }, path, UserName);
+            bool gone = !RecordPresent(path, gfk);
+            bool pruned = !ReadMasters(path).Any(m => m.Equals(MasterName, StringComparison.OrdinalIgnoreCase));
+            bool pass = o.Success && gone && pruned && o.RemainingRecords == 0;
+            results.Add(("B in-place GlobalShort remove, master pruned (inert shell)", pass,
+                $"success={o.Success} gone={gone} pruned={pruned} remaining={o.RemainingRecords}(want 0)  [{o.Error ?? "ok"}]"));
+        }
+
+        // ===== C — in-place: WEAPON override out, origin master retained (H-RETAIN control) =====
+        {
+            var path = Fresh(tmpDir, "C", fullPristine);
+            using var r = LoadOrderResolver.Build(new[] { masterPath, path });
+            var o = WritePatchBuilder.RemoveRecordsInPlace(r, new[] { w2fk }, path, UserName);
+            bool gone = !RecordPresent(path, w2fk);
+            bool masterKept = ReadMasters(path).Any(m => m.Equals(MasterName, StringComparison.OrdinalIgnoreCase));
+            bool pass = o.Success && gone && masterKept;
+            results.Add(("C in-place Weapon remove, origin master retained (retention control)", pass,
+                $"success={o.Success} gone={gone} masterKept={masterKept}  [{o.Error ?? "ok"}]"));
+        }
+
+        // ===== D — DEFAULT patch lane: GlobalShort removed from a patch (same routing, other lane) =====
+        {
+            var path = Fresh(tmpDir, "D", fullPristine);
+            using var r = LoadOrderResolver.Build(new[] { masterPath, path });
+            var o = WritePatchBuilder.RemoveRecords(r, new[] { gfk }, path);
+            bool gone = !RecordPresent(path, gfk);
+            bool pass = o.Success && gone;
+            results.Add(("D default-lane GlobalShort remove from a patch", pass,
+                $"success={o.Success} gone={gone}  [{o.Error ?? "ok"}]"));
+        }
+
+        // ===== E — in-place: GameSettingString (the OTHER abstract flat group, by construction) =====
+        {
+            var path = Fresh(tmpDir, "E", fullPristine);
+            using var r = LoadOrderResolver.Build(new[] { masterPath, path });
+            var o = WritePatchBuilder.RemoveRecordsInPlace(r, new[] { gmstFk }, path, UserName);
+            bool gone = !RecordPresent(path, gmstFk);
+            bool pass = o.Success && gone;
+            results.Add(("E in-place GameSettingString remove (second abstract family)", pass,
+                $"success={o.Success} gone={gone}  [{o.Error ?? "ok"}]"));
+        }
+
+        // ===== F — the Mutagen PRIMITIVE, documented: subclass type still no-ops; the group's T removes =====
+        {
+            var path = Fresh(tmpDir, "F", fullPristine);
+            var mod = SkyrimMod.CreateFromBinary(path, SkyrimRelease.SkyrimSE);
+            bool subclassThrew = false;
+            try { ((IMajorRecordEnumerable)mod).Remove(gfk, typeof(GlobalShort), throwIfUnknown: true); }
+            catch { subclassThrew = true; }
+            bool subclassNoOp = !subclassThrew && mod.EnumerateMajorRecords().Any(x => x.FormKey == gfk);
+            ((IMajorRecordEnumerable)mod).Remove(gfk, typeof(Global), throwIfUnknown: true);
+            bool groupTypeRemoved = !mod.EnumerateMajorRecords().Any(x => x.FormKey == gfk);
+            bool routedType = WriteEngine.RemovalTypeFor(mod.EnumerateMajorRecords().First(x => x.FormKey == w1fk)) == typeof(Weapon)
+                           && groupTypeRemoved;
+            bool pass = subclassNoOp && groupTypeRemoved && routedType;
+            results.Add(("F primitive: typeof(GlobalShort) no-ops (silently), typeof(Global) removes, RemovalTypeFor routes", pass,
+                $"subclassNoOp={subclassNoOp}(threw={subclassThrew}) groupTypeRemoved={groupTypeRemoved} routedType={routedType}" +
+                (subclassNoOp ? "" : "  << Mutagen's routing CHANGED — re-evaluate RemovalTypeFor")));
+        }
+
+        Console.WriteLine();
+        int failed = 0;
+        Console.WriteLine("================  RESULTS  ================");
+        foreach (var (name, pass, detail) in results)
+        {
+            if (!pass) failed++;
+            Console.WriteLine($"  {(pass ? "PASS" : "FAIL")}  {name}\n        {detail}");
+        }
+        Console.WriteLine();
+        Console.WriteLine(failed == 0 ? "ALL GREEN." : $"{failed} arm(s) FAILED.");
+        return failed == 0 ? 0 : 1;
+    }
+
+    static string Fresh(string tmpDir, string tag, string pristine)
+    {
+        var dir = Path.Combine(tmpDir, tag);
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, UserName);
+        File.Copy(pristine, path, overwrite: true);
+        return path;
+    }
+
+    static bool RecordPresent(string path, FormKey fk)
+    {
+        using var ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE);
+        return ov.EnumerateMajorRecords().Any(x => x.FormKey == fk);
+    }
+
+    static List<string> ReadMasters(string path)
+    {
+        using var ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE);
+        return ov.ModHeader.MasterReferences.Select(m => m.Master.FileName.ToString()).ToList();
+    }
+}

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1473,7 +1473,8 @@ public sealed class LoadOrderService : IDisposable
         {
             var markerNote = MergeEditedInPlaceMarker(Path.GetDirectoryName(targetPath));
             var seqNote = SeqStaleInPlaceNote(targetPath, targetName);
-            var note = JoinNotes(ackNote, markerNote, seqNote);
+            // outcome.Note first — the core's master-grow re-sort note (PR #163 review #1) must survive the merge.
+            var note = JoinNotes(outcome.Note, ackNote, markerNote, seqNote);
             if (note is not null) return outcome with { Note = note };
         }
         else if (ackNote is not null)
@@ -1758,7 +1759,8 @@ public sealed class LoadOrderService : IDisposable
         {
             var markerNote = MergeEditedInPlaceMarker(Path.GetDirectoryName(targetPath));
             var seqNote = SeqStaleInPlaceNote(targetPath, targetName);
-            var note = JoinNotes(ackNote, markerNote, seqNote);
+            // outcome.Note first — the core's master-grow re-sort note (PR #163 review #1) must survive the merge.
+            var note = JoinNotes(outcome.Note, ackNote, markerNote, seqNote);
             if (note is not null) return outcome with { Note = note };
         }
         else if (ackNote is not null)
@@ -1879,7 +1881,8 @@ public sealed class LoadOrderService : IDisposable
         {
             var markerNote = MergeEditedInPlaceMarker(Path.GetDirectoryName(targetPath));
             var seqNote = SeqStaleInPlaceNote(targetPath, targetName);
-            var note = JoinNotes(ackNote, markerNote, seqNote);
+            // outcome.Note first — the core's master-grow re-sort note (PR #163 review #1) must survive the merge.
+            var note = JoinNotes(outcome.Note, ackNote, markerNote, seqNote);
             if (note is not null) return outcome with { Note = note };
         }
         else if (ackNote is not null)

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1775,14 +1775,31 @@ public sealed class LoadOrderService : IDisposable
     /// existing houseCARL-owned patch), then drives <see cref="WritePatchBuilder.ForwardRecords"/> (resolve each source
     /// body from <paramref name="fromPlugin"/> → deep-copy as override → multi-master serialize). The whole source record
     /// is copied verbatim, so the SOURCE plugin (not the load-order winner) decides the content — and forwarding the
-    /// ORIGIN master reverts a record to vanilla. Originals are never touched (only the patch folder is written).</summary>
-    public WritePatchBuilder.ForwardOutcome ForwardRecords(IReadOnlyList<string> formids, string fromPlugin, string? patchName, string? into, bool fullReadback = false)
+    /// ORIGIN master reverts a record to vanilla. Originals are never touched in the default lane (only the patch folder
+    /// is written); <paramref name="target"/>+<paramref name="inPlace"/> is the explicit opt-in third route (in-place
+    /// write lane; HCBR-2026-07-08-01 F4) — forward INTO an existing plugin's own file, consent-gated like the sibling
+    /// write tools — see <see cref="ForwardRecordsInPlace"/>.</summary>
+    public WritePatchBuilder.ForwardOutcome ForwardRecords(IReadOnlyList<string> formids, string fromPlugin, string? patchName, string? into,
+        bool fullReadback = false, string? target = null, bool inPlace = false, bool acknowledge = false)
     {
         if (string.IsNullOrWhiteSpace(fromPlugin))
             return WritePatchBuilder.ForwardOutcome.Fail(
                 "from_plugin is required — name the plugin whose version of the record(s) to forward (the earlier override, or a master to revert to vanilla).");
         if (formids is null || formids.Count == 0)
             return WritePatchBuilder.ForwardOutcome.Fail("no formids supplied — pass the FormID(s) to forward from the source plugin.");
+
+        // In-place is the explicit, named-file opt-in (the same contract as the sibling write tools — Q3, name each
+        // misuse rather than silently ignore a parameter): in_place REQUIRES target=, is mutually exclusive with into=
+        // (the houseCARL-patch lane), and target= without in_place is a no-op the caller likely didn't mean.
+        if (inPlace && string.IsNullOrWhiteSpace(target))
+            return WritePatchBuilder.ForwardOutcome.Fail(
+                "in_place=true requires target=<plugin filename> — name the existing plugin to forward into in place. (Omit in_place to write a new patch instead — the default, originals untouched.)");
+        if (inPlace && !string.IsNullOrWhiteSpace(into))
+            return WritePatchBuilder.ForwardOutcome.Fail(
+                "in_place=true and into= are mutually exclusive: into= EXTENDS a houseCARL patch, while in_place forwards into an existing plugin in place. Use one lane or the other.");
+        if (!inPlace && !string.IsNullOrWhiteSpace(target))
+            return WritePatchBuilder.ForwardOutcome.Fail(
+                "target= is only meaningful with in_place=true (it names the plugin to forward into in place). For the default patch lane omit target=; use into= to extend an existing houseCARL patch.");
 
         // Parse every formid first, collecting ALL problems (all-or-nothing, like the edit/remove paths). Pure — outside the gate.
         var fp = fromPlugin.Trim();
@@ -1803,6 +1820,9 @@ public sealed class LoadOrderService : IDisposable
         {
             var resolver = Resolver;                                      // builds/refreshes the index (Overlays for the source fetch + serialize)
 
+            if (inPlace)
+                return ForwardRecordsInPlace(resolver, specs, target!.Trim(), acknowledge);
+
             string outPath; bool extend, created;
             try { outPath = ResolveOutputPath(patchName, into, out extend, out created); }
             catch (Exception ex) { return WritePatchBuilder.ForwardOutcome.Fail(ex.Message); }
@@ -1811,6 +1831,63 @@ public sealed class LoadOrderService : IDisposable
             if (!outcome.Success && created) RemoveFolderCreatedThisCall(outPath);   // hunt F4: a refused forward leaves no orphan
             return outcome;
         }
+    }
+
+    /// <summary>The in-place branch of <see cref="ForwardRecords"/> (in-place write lane; HCBR-2026-07-08-01 F4) — runs
+    /// under _writeGate. REUSES every in-place seam the edit/create/remove lanes proved: the same foreign-target resolver
+    /// (<see cref="ResolveActivePluginPath"/>), the same PERSISTENT first-touch CONSENT handshake (keyed off the resolved
+    /// path, SHARED across all in-place lanes — acknowledging a plugin once covers edit, create, remove AND forward), the
+    /// same writable-parent pre-flight, and the same distinct <c>editedInPlace=</c> marker (NEVER <c>generated=true</c> —
+    /// the user mod keeps failing <see cref="IsHouseCarlOwned"/> so a later into= can't blind-overwrite it). Drives
+    /// <see cref="WritePatchBuilder.ForwardRecordsInPlace"/> (replace-or-copy into the target's OWN file, touched-record
+    /// verify forced ON). <paramref name="acknowledge"/> waives the CONSENT axis ONLY — the verify is a corruption-axis
+    /// fact no acknowledgement overrides.</summary>
+    WritePatchBuilder.ForwardOutcome ForwardRecordsInPlace(
+        LoadOrderResolver resolver, IReadOnlyList<WritePatchBuilder.ForwardSpec> specs, string target, bool acknowledge)
+    {
+        // (1) Resolve target -> real on-disk path via the load order (by plugin FILENAME). Refuse loud if it isn't a
+        //     real active plugin. Same resolver as the edit + create + remove lanes.
+        var view = resolver.Capture();
+        var targetPath = ResolveActivePluginPath(view, Path.GetFileName(target.Trim()), out var targetName);
+        if (targetPath is null)
+            return WritePatchBuilder.ForwardOutcome.Fail(
+                $"in-place target '{target}' is not an active plugin in the load order — name a plugin enabled in MO2, by its " +
+                "plugin filename (e.g. 'CoolWeapons.esp'). in-place forwards into the file the game actually loads. Nothing was written.");
+
+        // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path (shared
+        //     with the edit/create/remove lanes: it's the same "touch your original" trade-off).
+        bool already = _store.IsInPlaceAcknowledged(targetPath);
+        if (!already && !acknowledge)
+            return WritePatchBuilder.ForwardOutcome.NeedsAck(InPlaceHandshakeText(targetName, targetPath));
+        string? ackNote = null;
+        if (!already && acknowledge)
+        {
+            var (ok, err) = _store.RecordInPlaceAcknowledged(targetPath);
+            if (!ok) ackNote = $"the in-place acknowledgement could not be saved ({err}) — the forward proceeded, but a future session will re-prompt for this plugin.";
+        }
+
+        // (3) Writable, same-volume parent pre-flight — refuse rather than degrade.
+        if (InPlaceParentUnwritable(targetPath, out var why))
+            return WritePatchBuilder.ForwardOutcome.Fail(why);
+
+        // (4) The write — touched-record verify forced ON (the model-C substitute for the dropped whole-plugin floor).
+        var outcome = WritePatchBuilder.ForwardRecordsInPlace(resolver, specs, targetPath, targetName, fullReadback: true);
+
+        // (5) On success, stamp the distinct audit marker + auto-flag a now-stale .seq (both best-effort; neither miss
+        //     fails the done forward, Q3-noted).
+        if (outcome.Success)
+        {
+            var markerNote = MergeEditedInPlaceMarker(Path.GetDirectoryName(targetPath));
+            var seqNote = SeqStaleInPlaceNote(targetPath, targetName);
+            var note = JoinNotes(ackNote, markerNote, seqNote);
+            if (note is not null) return outcome with { Note = note };
+        }
+        else if (ackNote is not null)
+        {
+            // The acknowledgement was recorded but the write then failed — keep the (now-honest) note alongside the error.
+            return outcome with { Note = ackNote };
+        }
+        return outcome;
     }
 
     /// <summary>Create an EMPTY, HEADER-ONLY plugin (housecarl_create_plugin) — a valid TES4 header with ZERO records,

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -267,7 +267,11 @@ public static class WriteTools
          "whole call is refused with a named reason and NOTHING is written if from_plugin isn't in the load order, was " +
          "excluded (unparseable), is the output patch itself, names a target twice, or simply doesn't DEFINE/override a given " +
          "record (nothing there to forward). By default writes a fresh patch named patch_name; into= EXTENDS an existing " +
-         "houseCARL patch (accumulate across calls/sessions). Returns the patch path, masters, and per-record what was " +
+         "houseCARL patch (accumulate across calls/sessions). If the extended patch ALREADY carries a forwarded FormKey, its " +
+         "existing override is REPLACED by from_plugin's body (xEdit's copy-as-override overwrite — flagged per record in the " +
+         "response). target= + in_place=true is the opt-in THIRD route: forward INTO an existing plugin's OWN file (incl. one " +
+         "houseCARL didn't author) — same replace-on-collision semantics, same one-time acknowledge= consent as the sibling " +
+         "write tools, master header grown from the copied bodies. Returns the patch path, masters, and per-record what was " +
          "copied + the current winner it will out-rank (a forward whose version is ALREADY winning is flagged redundant).")]
     public static string ForwardRecord(
         LoadOrderService svc,
@@ -277,10 +281,16 @@ public static class WriteTools
             string from_plugin,
         [Description("Optional. Base filename for the new patch (default 'houseCARL_Patch'); auto-suffixed if taken so a prior patch is never overwritten. Ignored if into= is given.")]
             string patch_name = "houseCARL_Patch",
-        [Description("Optional. Filename of an existing houseCARL patch to ADD these forwards to instead of writing a fresh one (accumulate across calls — e.g. forward from a different source plugin into the same patch). Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead (folder & plugin names need not match).")]
+        [Description("Optional. Filename of an existing houseCARL patch to ADD these forwards to instead of writing a fresh one (accumulate across calls — e.g. forward from a different source plugin into the same patch). Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead (folder & plugin names need not match). If the patch already carries a forwarded FormKey, its existing override is REPLACED by from_plugin's body.")]
             string? into = null,
         [Description("When true, the response ALSO returns each forwarded record IN FULL, read back from the written patch file on disk (every field, deep). The pre-enable verification: confirm the copied version is exactly the source's, WITHOUT enabling the patch in MO2 (the written file's content, not load-order truth).")]
             bool full_readback = false,
+        [Description("Optional. IN-PLACE LANE (opt-in): the filename of an EXISTING active plugin to forward INTO in place — including one houseCARL didn't author — instead of writing a new patch (e.g. 'MyHandmadePatch.esp'). Requires in_place=true; mutually exclusive with into=. A FormKey the target already carries is REPLACED by from_plugin's body (xEdit's copy-as-override overwrite). OMIT this (the default) to write a NEW patch and leave every original untouched — the recommended lane.")]
+            string? target = null,
+        [Description("Optional, default false. Confirms the IN-PLACE lane together with target= (see target). Your ORIGINAL plugin file is rewritten — no houseCARL backup or undo. Defaults OFF: omitting it always writes a new patch.")]
+            bool in_place = false,
+        [Description("Optional, default false. Confirms the one-time in-place trade-off for target (see in_place) — needed only on the FIRST in-place write to a given plugin (edit, create, remove, OR forward), never again for it. Waives the consent to touch your original ONLY; it NEVER skips the record verify.")]
+            bool acknowledge = false,
         [Description("Optional. Max characters for the whole response; past it the read-back is cut with an explicit notice (never silent). 0 = a safe default kept under the host's per-response token limit; raise it to widen a full_readback=true dump.")]
             int max_chars = 0) => Guard.Tool("housecarl_forward_record", () =>
     {
@@ -289,7 +299,7 @@ public static class WriteTools
             return "error: formids is empty. Pass one or more 'XXXXXX:Plugin.esp' FormIDs to forward from from_plugin.";
         if (string.IsNullOrWhiteSpace(from_plugin))
             return "error: from_plugin is empty. Name the plugin whose version of the record(s) to forward.";
-        return RenderForward(svc.ForwardRecords(formids, from_plugin, patch_name, into, full_readback), max_chars);
+        return RenderForward(svc.ForwardRecords(formids, from_plugin, patch_name, into, full_readback, target, in_place, acknowledge), max_chars);
     });
 
     [McpServerTool(Name = "housecarl_create_plugin", Title = "Create an empty header-only (trigger) plugin"),
@@ -567,20 +577,30 @@ public static class WriteTools
     /// can fix and retry. Optional full read-back rides along (the pre-enable verify that the copy is the source's).</summary>
     static string RenderForward(WritePatchBuilder.ForwardOutcome o, int maxChars = 0)
     {
+        if (o.NeedsAcknowledge) return o.Error!;            // the first-touch in-place CONSENT prompt — a required confirmation, NOT an error (Q3)
         if (!o.Success) return "error: " + o.Error;
         var file = Path.GetFileName(o.OutputPath);
         var modFolder = Path.GetFileName(Path.GetDirectoryName(o.OutputPath) ?? "");
         var sb = new StringBuilder();
-        sb.Append(o.Extended ? "extended " : "wrote ").Append(file)
-          .Append(o.Extended ? " (existing patch grown; " : " (new patch; ").Append(o.Bytes).Append(" bytes)\n");
-        sb.Append("mod folder: ").Append(modFolder)
-          .Append(o.Extended ? "\n" : "  — enable + sort it in MO2 to use the patch\n");
+        if (o.InPlace)
+            sb.Append("forwarded into ").Append(file).Append(" IN PLACE (").Append(o.Bytes)
+              .Append(" bytes — your ORIGINAL file was rewritten; no houseCARL backup or undo)\n")
+              .Append("mod folder: ").Append(modFolder).Append("  — already active in your load order; re-sort only if a winner changed\n");
+        else
+        {
+            sb.Append(o.Extended ? "extended " : "wrote ").Append(file)
+              .Append(o.Extended ? " (existing patch grown; " : " (new patch; ").Append(o.Bytes).Append(" bytes)\n");
+            sb.Append("mod folder: ").Append(modFolder)
+              .Append(o.Extended ? "\n" : "  — enable + sort it in MO2 to use the patch\n");
+        }
         sb.Append("masters: ").Append(o.Masters.Count == 0 ? "(none)" : string.Join(", ", o.Masters)).Append('\n');
         sb.Append("forwarded ").Append(o.Forwarded.Count).Append(o.Forwarded.Count == 1 ? " record:\n" : " records:\n");
         foreach (var f in o.Forwarded)
         {
             sb.Append("  ").Append(f.RecordType).Append(' ').Append(f.Target).Append("  ").Append(f.EditorId ?? "<no editorid>")
               .Append("  — copied from ").Append(f.FromPlugin);
+            if (f.ReplacedExisting)
+                sb.Append("  [REPLACED the patch's own existing override of this record — the old body is gone (xEdit's copy-as-override-into overwrite)]");
             if (f.WasAlreadyWinner)
                 sb.Append("  [NOTE: this source IS already the load-order winner — the override just re-asserts the content that already wins (a no-op in effect)]");
             else
@@ -588,7 +608,10 @@ public static class WriteTools
             sb.Append('\n');
         }
         if (o.ReadBack is { } rb) AppendFullReadback(sb, rb, maxChars);
-        sb.Append("to forward more into THIS patch (incl. from a different source plugin), pass into=\"").Append(file).Append("\".");
+        if (o.Note is { } note) sb.Append("note: ").Append(note).Append('\n');
+        sb.Append(o.InPlace
+            ? $"to forward more into this plugin, pass target=\"{file}\" in_place=true (no further confirmation needed for it)."
+            : $"to forward more into THIS patch (incl. from a different source plugin), pass into=\"{file}\".");
         return sb.ToString();
     }
 


### PR DESCRIPTION
Fixes all four findings of **HCBR-2026-07-08-01** (the in-place / `into=` edit-flow report from the Ashe–Requiem merge session). One root theme: master-list management + remove routing were inconsistent across the write lanes when the target is an existing plugin. ci-all **79/79** (78 existing + 1 new guard).

## F1 — `forward_record into=` silently no-op'd on a FormKey collision (HIGH, Q3)
`ForwardRecords` used `GenericGetOrAddAsOverride`, whose **get**-semantics on a FormKey the patch already carried returned the existing record, skipped the copy *and* the master grow, and still reported "forwarded 1 record". Now the existing override is **replaced** by the source body (xEdit's copy-as-override-into overwrite), verified dropped before the copy, and flagged `[REPLACED …]` per record in the response. Guard: `forward-from-plugin-guard` REPLACE arm (red pre-fix: body stayed, no flag, no master grow).

## F2 — in-place `set_field`/`bulk_apply` couldn't introduce a new master
`ApplyInPlace` serialized against only the target's *declared* masters, so a composed FormLink to an active-but-undeclared plugin threw `MissingModException`. It now serializes against the **whole known-master set** — the exact context the in-place *create* lane already used (InPlaceProbe arm O) — and Mutagen lean-derives the grown header from actual links. A link to a genuinely inactive plugin still refuses loud, and the message now means what it says. Guards: `inplace-guard` arms **Y** (grow) + **Z** (still-loud, file untouched).

## F3 — in-place `remove_record` "still present" — diagnosed, report's hypothesis refuted
Empirical diagnosis (matrix probe, findings preserved in the new guard's doc): Mutagen's typed `Remove(FormKey, Type, throwIfUnknown: true)` **silently no-ops — no throw —** when `Type` is a concrete *subclass* of an abstract flat group's `T` (`GlobalShort` under `SkyrimGroup<Global>`; `GameSetting*` likewise). The report's retained-origin-master hypothesis is **refuted** (a Weapon removes fine with its master kept). Fix:
- `WriteEngine.RemovalTypeFor` — both remove lanes route the typed Remove via the record's **flat group's `T`** (nested records keep the runtime type; same `EnumerateFlatGroups` enumeration as every other flat-vs-nested decision, no hand-list).
- `RemoveSurvivors` — both lanes verify absence **in memory before serializing**, so any future engine no-op fails loud with the file untouched (the old path rewrote the whole file to no effect and only the post-write verify caught it).

Guard: **`subclass-remove-guard`** (new, in ci-all): both lanes × both abstract families × the retention control, plus a primitive-documentation arm that flags if a Mutagen upgrade ever changes the routing.

## F4 — `forward_record` gets the explicit in-place lane
`target=` + `in_place=` + `acknowledge=` exactly like the sibling write tools: same foreign-target resolver, same **shared persistent consent handshake** (one acknowledge per plugin covers edit/create/remove/forward), same `editedInPlace=` marker (never `generated=true`), replace-on-collision per F1, master grow per F2, touched-record verify forced ON. `into=` stays reserved for houseCARL-owned patches. Guards: INPLACE-NEW / INPLACE-REPLACE / INPLACE-CONTRACT / INPLACE-OPTIN arms.

## Notes for review
- The F1 replace semantic (vs refuse-loud) and folding F4 into this PR were Aaron-approved before build.
- `ResolveOwnMasters` is now used only by the remove lane (edit moved to the whole-order context; remove never adds references, so the faithful own-masters re-emit stays).
- Behavior delta worth eyes: an in-place **edit** of a plugin with a *declared-but-inactive, unreferenced* master previously refused ("enable that master first"); it now succeeds and prunes that master (consistent with the lane's existing prune-on-rewrite behavior; a *referenced* inactive master still refuses loud).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
