### PR TITLE
fix(write): created-record self-reference + compose-struct @refs + into= edits resolve the extended patch (HCBR-2026-07-10-01)

### DIFF
--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -345,6 +345,13 @@ public sealed class CorpusRulebook
                 return $"Same-call reference '{req.Value}' for '{leaf.Name}' is only valid as a Set value on a singular " +
                        $"FormLink field or an Add value on a FormLink list (the verb was '{req.Verb}', '{leaf.Name}' " +
                        $"is a {leaf.Cardinality}).";
+            // A stray compose spec riding alongside an admitted '@' value would skip validation (this gate RETURNS
+            // before the compose branches) yet be WALKED by apply's substitution recursion — a bad token inside it
+            // would then fail under the "internal: pre-flight should have caught it" wrapper, blaming the engine for
+            // input the gate never saw (PR #166 review finding 1). Refuse it loud instead.
+            if (req.Struct is not null)
+                return $"Same-call reference '{req.Value}' for '{leaf.Name}' takes no compose spec — the '@editorid' " +
+                       "value IS the whole FormLink target; remove struct=.";
             return siblingEditorIds.Contains(sibEdid) ? null
                 : $"Same-call reference '{req.Value}' for '{leaf.Name}': no record with editorid '{sibEdid}' is created " +
                   "EARLIER in this call (a record may also reference ITSELF by its own editorid) — declare it before " +
@@ -365,6 +372,10 @@ public sealed class CorpusRulebook
             if (!(req.Verb == "ReplaceAll" && leaf.Cardinality == "list" && leaf.FormLinkTarget is not null))
                 return $"a '@editorid' same-call reference for '{leaf.Name}' is only supported as an Add value or a " +
                        $"ReplaceAll value on a FormLink list (the verb was '{req.Verb}', '{leaf.Name}' is a {leaf.Cardinality}).";
+            // The values-branch twin of the stray-compose guard above (PR #166 review finding 1).
+            if (req.Struct is not null)
+                return $"a '@editorid' same-call reference for '{leaf.Name}' takes no compose spec — the '@editorid' " +
+                       "entries ARE the FormLink elements; remove struct=.";
             foreach (var v in vals)
             {
                 if (WriteEngine.IsSameCallSiblingRef(v, out var vEd))

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -92,9 +92,11 @@ public sealed class CorpusRulebook
 
     /// <summary>Pre-flight (P-VALIDATE order). Returns null if the write is legal, else a fail-loud message.
     /// <paramref name="siblingEditorIds"/> (non-null only on the CREATE-batch path) is the set of editorids created
-    /// EARLIER in the same call: a FormLink value of the form <c>@editorid</c> in that set is accepted as a forward-ref
-    /// the create path resolves post-allocation (HCBR Layer B unit A). Null (the override/set_field path) ⇒ an
-    /// <c>@editorid</c> value is rejected loud — it has no meaning when there are no same-call siblings.</summary>
+    /// EARLIER in the same call PLUS the record being created itself (self-reference — HCBR-2026-07-10-01: a quest's
+    /// VMAD fragment points at its own quest): a FormLink value of the form <c>@editorid</c> in that set is accepted
+    /// as a forward-ref the create path resolves post-allocation (HCBR Layer B unit A). The set threads into composed
+    /// StructSpec Fields/Sets too. Null (the override/set_field path) ⇒ an <c>@editorid</c> value is rejected loud —
+    /// it has no meaning when there are no same-call creations.</summary>
     public string? Validate(WriteRequest req, IReadOnlyCollection<string>? siblingEditorIds = null)
     {
         // (1) resolve the record, then validate rooted at it. ValidateFromType is shared with StructSpec validation
@@ -313,8 +315,9 @@ public sealed class CorpusRulebook
     string? ValueLegality(FieldSchema leaf, WriteRequest req, IReadOnlyCollection<string>? siblingEditorIds = null)
     {
         // Same-call sibling reference ("@editorid", create-context forward-ref — HCBR Layer B unit A). Gate it BEFORE
-        // any verb/cardinality dispatch: it names a record created EARLIER in this same create call, substituted with
-        // that record's real FormKey AFTER allocation (WritePatchBuilder.CreateRecords), and ONLY in create context
+        // any verb/cardinality dispatch: it names a record created EARLIER in this same create call — or the record
+        // being created ITSELF (self-reference, HCBR-2026-07-10-01) — substituted with the real FormKey AFTER
+        // allocation (WritePatchBuilder.CreateRecords), and ONLY in create context
         // (siblingEditorIds non-null) — the Apply/set_field path has no siblings, so an @editorid there rejects loud
         // (never an accept-then-substitute-nothing, Q3). Legal placements, all resolved with identical timing:
         //   • a SINGULAR value — Set on a singular FormLink leaf, OR Add on a FormLink LIST leaf (S4 Track D: LinkTo
@@ -325,8 +328,10 @@ public sealed class CorpusRulebook
         if (WriteEngine.IsSameCallSiblingRef(req.Value, out var sibEdid))
         {
             if (siblingEditorIds is null)
-                return $"'{req.Value}' for '{leaf.Name}': a '@editorid' same-call reference is only valid when creating " +
-                       "records in ONE call (housecarl_bulk_create) — it has no meaning when editing an existing record.";
+                return $"'{req.Value}' for '{leaf.Name}': a '@editorid' reference names a record being created in the " +
+                       "SAME housecarl_create_record / housecarl_bulk_create call — when editing an existing record " +
+                       "there are no same-call creations to point at. Use the target's FormID (a record already " +
+                       "written into a houseCARL patch is addressable by FormID with into= that patch).";
             // The singular value must land on a FormLink TARGET — a singular formlink leaf or a formlink-element list.
             var onFormLink = leaf.Cardinality == "formlink"
                           || (leaf.Cardinality == "list" && leaf.FormLinkTarget is not null);
@@ -342,7 +347,8 @@ public sealed class CorpusRulebook
                        $"is a {leaf.Cardinality}).";
             return siblingEditorIds.Contains(sibEdid) ? null
                 : $"Same-call reference '{req.Value}' for '{leaf.Name}': no record with editorid '{sibEdid}' is created " +
-                  "EARLIER in this call — declare it before the record that references it (in spec order).";
+                  "EARLIER in this call (a record may also reference ITSELF by its own editorid) — declare it before " +
+                  "the record that references it (in spec order).";
         }
         // A sibling token inside req.Values — legal ONLY as a ReplaceAll on a FormLink LIST (S4 Track D); each entry is
         // substituted with its sibling's allocated FormKey (WritePatchBuilder.CreateRecords). Validate the WHOLE list
@@ -352,8 +358,10 @@ public sealed class CorpusRulebook
         if (req.Values is { } vals && vals.Any(v => WriteEngine.IsSameCallSiblingRef(v, out _)))
         {
             if (siblingEditorIds is null)
-                return $"a '@editorid' same-call reference for '{leaf.Name}' is only valid when creating records in ONE " +
-                       "call (housecarl_bulk_create) — it has no meaning when editing an existing record.";
+                return $"a '@editorid' reference for '{leaf.Name}' names a record being created in the SAME " +
+                       "housecarl_create_record / housecarl_bulk_create call — when editing an existing record there " +
+                       "are no same-call creations to point at. Use the target's FormID (a record already written " +
+                       "into a houseCARL patch is addressable by FormID with into= that patch).";
             if (!(req.Verb == "ReplaceAll" && leaf.Cardinality == "list" && leaf.FormLinkTarget is not null))
                 return $"a '@editorid' same-call reference for '{leaf.Name}' is only supported as an Add value or a " +
                        $"ReplaceAll value on a FormLink list (the verb was '{req.Verb}', '{leaf.Name}' is a {leaf.Cardinality}).";
@@ -363,7 +371,8 @@ public sealed class CorpusRulebook
                 {
                     if (!siblingEditorIds.Contains(vEd))
                         return $"Same-call reference '@{vEd}' for '{leaf.Name}': no record with editorid '{vEd}' is " +
-                               "created EARLIER in this call — declare it before the record that references it (in spec order).";
+                               "created EARLIER in this call (a record may also reference ITSELF by its own editorid) — " +
+                               "declare it before the record that references it (in spec order).";
                 }
                 else if (!WriteEngine.IsValidFormLinkValue(v)) return FormLinkElementReject(v, leaf);
             }
@@ -408,12 +417,12 @@ public sealed class CorpusRulebook
             // element (Gap 3, dict-element composition): validate the spec against the element type via the SAME
             // StructElementLegality the Add path uses (poly-base arm resolution + recursive contents) — gate and apply
             // share one recognizer, no drift. A coercible-VALUE dict (Class.SkillWeights, Race.Regen, …) Set coerces.
-            if (IsComposableElement(leaf)) return StructElementLegality(leaf, req.Struct);
+            if (IsComposableElement(leaf)) return StructElementLegality(leaf, req.Struct, siblingEditorIds);
             if (req.Value is null) return $"Set on dict '{leaf.Name}' requires a value.";
             return CheckValue(leaf.ElementType, req.Value, $"dict value for '{leaf.Name}'", leaf.ElementTypeAssemblyQualified);
         }
         if (req.Verb is "Set" && leaf.Cardinality == "polymorphic")
-            return ArmLegality(leaf, req.Struct);
+            return ArmLegality(leaf, req.Struct, siblingEditorIds);
         // A whole modeled-STRUCT substruct leaf (FaceParts, ObjectBounds, FaceMorph, a concrete script-property arm, …) is
         // Set by composing its value FROM PARTS — the leaf twin of the dict-element (above) and polymorphic-arm (just above)
         // compose paths, validated by the SAME StructSpecContents. Apply already builds it (ApplyScalarVerb req.Struct ->
@@ -422,7 +431,7 @@ public sealed class CorpusRulebook
         // keeps its plain-value Set below, and a composition-residual (GenderedItem — diverted to [0]/[1] upstream — /
         // Array2d — no paramless ctor) stays out (gate==apply, no accept-then-throw). Chain Stage 2b.
         if (req.Verb is "Set" && SchemaClassifier.IsComposableSubstructLeaf(leaf, _corpus))
-            return StructLeafLegality(leaf, req.Struct);
+            return StructLeafLegality(leaf, req.Struct, siblingEditorIds);
         if (req.Verb is "Set")
         {
             // A compose spec reaching HERE means the leaf isn't a compose target (not a composable substruct/dict/poly —
@@ -570,7 +579,7 @@ public sealed class CorpusRulebook
             // (Package.Data -> an APackageData arm) + validates contents recursively. (A composable dict SET is gated at
             // the dict-Set block above — same StructElementLegality.)
             if (req.Verb == "Add")
-                return StructElementLegality(leaf, req.Struct);
+                return StructElementLegality(leaf, req.Struct, siblingEditorIds);
             // ReplaceAll/SetAtIndex/Merge of modeled elements are all deferred (only Add/Set composes). Merge is dict-only
             // and was previously OMITTED here, so a Package.Data Merge fell through to ACCEPT then threw 'No coercion
             // rule' at apply (matrix-critic finding) — folding it in closes that. Verb named in the message so it reads
@@ -620,7 +629,7 @@ public sealed class CorpusRulebook
     /// concrete arm like <c>ScriptObjectProperty</c>) — and its contents must validate against the SPEC's own
     /// schema (the arm's fields, not the base's), recursively via the shared validator. Generic over every
     /// polymorphic-base element family — no per-type wiring (cornerstone).</summary>
-    string? StructElementLegality(FieldSchema leaf, StructSpec? spec)
+    string? StructElementLegality(FieldSchema leaf, StructSpec? spec, IReadOnlyCollection<string>? siblingEditorIds = null)
     {
         if (spec is null)
             return $"'{leaf.Name}' takes a build-from-parts element (a modeled {leaf.ElementTypeRef}); supply a compose spec, not a plain value.";
@@ -658,7 +667,7 @@ public sealed class CorpusRulebook
                 ? $" Legal element types: {string.Join(", ", legalArms)}." : "";
             return $"Element spec type '{spec.Type}' does not match '{leaf.Name}' element type '{er}'.{legal}";
         }
-        return StructSpecContents(spec, specSchema);
+        return StructSpecContents(spec, specSchema, siblingEditorIds);
     }
 
     /// <summary>Validate a whole-struct compose Set on a SUBSTRUCT leaf — the leaf twin of <see cref="StructElementLegality"/>,
@@ -669,7 +678,7 @@ public sealed class CorpusRulebook
     /// polymorphic FIELD is cardinality "polymorphic", handled above), so a straight name-match is correct — no poly-base
     /// arm resolution. Reached only for a <see cref="SchemaClassifier.IsComposableSubstructLeaf"/> leaf (TypeRef non-null,
     /// corpus-present, apply-instantiable) — the null-spec branch replaces the misleading scalar "requires a value".</summary>
-    string? StructLeafLegality(FieldSchema leaf, StructSpec? spec)
+    string? StructLeafLegality(FieldSchema leaf, StructSpec? spec, IReadOnlyCollection<string>? siblingEditorIds = null)
     {
         var tr = leaf.TypeRef!;               // non-null by IsComposableSubstructLeaf
         var schema = Type(tr);
@@ -679,14 +688,14 @@ public sealed class CorpusRulebook
                    $"{{\"type\":\"{tr}\", \"fields\":{{…}}}}), or navigate into it and Set a sub-field; a plain value can't express a struct.";
         if (spec.Type != tr)
             return $"Compose type '{spec.Type}' does not match '{leaf.Name}' struct type '{tr}'.";
-        return StructSpecContents(spec, schema);
+        return StructSpecContents(spec, schema, siblingEditorIds);
     }
 
     /// <summary>Validate a build-from-parts spec's CONTENTS against its declared struct type: flat <see cref="StructSpec.Fields"/>
     /// must exist + coerce; nested <see cref="StructSpec.Sets"/> validate by the identical path/leaf rules (recursively,
     /// through <see cref="ValidateFromType"/>). Shared by the polymorphic-arm Set and the struct-element Add so the two
     /// composition entry points can never disagree.</summary>
-    string? StructSpecContents(StructSpec spec, TypeSchema structSchema)
+    string? StructSpecContents(StructSpec spec, TypeSchema structSchema, IReadOnlyCollection<string>? siblingEditorIds = null)
     {
         // (G4) positional ctor_args value-SHAPE + ARITY — the one compose part the gate never checked. A malformed arg
         // or a wrong arity passed pre-flight then threw at apply (Instantiate: Coerce(arg, paramType) / "no constructor
@@ -700,13 +709,35 @@ public sealed class CorpusRulebook
         {
             var af = structSchema.Fields.FirstOrDefault(x => x.Name == f.Key);
             if (af is null) return FieldNotFound(structSchema, f.Key);
+            // A '@editorid' same-call reference in a compose FIELD (HCBR-2026-07-10-01: the VMAD alias-fragment
+            // Property.Object=@<the quest itself> shape) — legal on a singular FORMLINK field in CREATE context only,
+            // mirroring the top-level singular-value gate exactly (formlink-only + declared-earlier-or-self); the
+            // create path substitutes it with the allocated FormKey (WritePatchBuilder.ResolveSiblingRefs). Gated
+            // BEFORE CheckValue, which would otherwise reject the '@' token as a malformed FormLink.
+            if (WriteEngine.IsSameCallSiblingRef(f.Value, out var fEd))
+            {
+                if (siblingEditorIds is null)
+                    return $"a '@editorid' reference for '{f.Key}' on '{spec.Type}' names a record being created in the " +
+                           "SAME housecarl_create_record / housecarl_bulk_create call — when editing an existing record " +
+                           "there are no same-call creations to point at. Use the target's FormID.";
+                if (af.Cardinality != "formlink")
+                    return $"Same-call reference '{f.Value}' for '{f.Key}' on '{spec.Type}' is only valid on a FormLink " +
+                           $"field, but '{f.Key}' is a {af.Cardinality}.";
+                if (!siblingEditorIds.Contains(fEd))
+                    return $"Same-call reference '{f.Value}' for '{f.Key}' on '{spec.Type}': no record with editorid " +
+                           $"'{fEd}' is created EARLIER in this call (a record may also reference ITSELF by its own " +
+                           "editorid) — declare it before the record that references it (in spec order).";
+                continue;
+            }
             if (CheckValue(af.Type, f.Value, $"'{f.Key}' on '{spec.Type}'",
                     af.MutableTypeAssemblyQualified ?? af.GetterTypeAssemblyQualified) is { } e) return e;
         }
         foreach (var s in spec.Sets ?? new())
-            // siblingEditorIds: null — a same-call @editorid forward-ref inside a COMPOSED struct (e.g. a VMAD
-            // property) is out of unit-A scope; it rejects loud here rather than being silently accepted (Q3).
-            if (ValidateFromType(structSchema, s, siblingEditorIds: null) is { } e) return e;
+            // siblingEditorIds threads through — a same-call @editorid ref inside a COMPOSED struct's nested Sets
+            // (e.g. a VMAD quest-fragment's Property.Object=@<own quest>, HCBR-2026-07-10-01) validates by the SAME
+            // gates as a top-level value (formlink-only + declared-earlier-or-self), recursively; on the edit path
+            // (null) it still rejects loud rather than being silently accepted (Q3).
+            if (ValidateFromType(structSchema, s, siblingEditorIds) is { } e) return e;
         return null;
     }
 
@@ -734,7 +765,7 @@ public sealed class CorpusRulebook
 
     /// <summary>Validate a polymorphic Set: the arm must be a legal arm of the field, and its contents (flat fields +
     /// nested sets) must validate against the arm type — the same composition-contents check a struct-element Add uses.</summary>
-    string? ArmLegality(FieldSchema leaf, StructSpec? arm)
+    string? ArmLegality(FieldSchema leaf, StructSpec? arm, IReadOnlyCollection<string>? siblingEditorIds = null)
     {
         if (arm is null) return $"Set on polymorphic field '{leaf.Name}' requires an arm (which arm + its data).";
         // (G8) The standalone-poly-FIELD twin of the StructElementLegality base-reject. A CONCRETE poly-base (e.g.
@@ -752,7 +783,7 @@ public sealed class CorpusRulebook
             return $"Illegal arm '{arm.Type}' for '{leaf.Name}'. Legal arms: {string.Join(", ", legal)}.";
         var armSchema = Type(arm.Type);
         if (armSchema is null) return $"Arm '{arm.Type}' absent from corpus.";
-        return StructSpecContents(arm, armSchema);
+        return StructSpecContents(arm, armSchema, siblingEditorIds);
     }
 
     /// <summary>Resolve a dict leaf's KEY clr type from its own dictionary AQ — the SAME type the apply path keys on

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -313,6 +313,12 @@ public static class WritePatchBuilder
         var view = resolver.Capture();
         var resolved = new List<(PatchEdit edit, IMajorRecordGetter? body, string? winnerPlugin, IMajorRecord? patchLocal, WriteRequest req, string label)>(edits.Count);
         var problems = new List<string>();
+        // Records the extended patch DEFINES (FormKey in the patch's own master space — created by a prior into=
+        // call), built lazily ONCE on the first load-order miss (PR #166 review finding 3: not a per-miss deep walk).
+        // Deliberately NOT every record the patch contains: an override the patch merely CARRIES resolves via the
+        // load order like any other record, so a target whose defining plugin is disabled stays a loud refusal —
+        // never a silent edit of the patch's possibly-stale override copy (PR #166 review finding 2).
+        Dictionary<FormKey, IMajorRecord>? patchDefined = null;
         foreach (var e in edits)
         {
             IMajorRecordGetter? body = null; string? winnerPlugin = null; IMajorRecord? patchLocal = null;
@@ -323,15 +329,27 @@ public static class WritePatchBuilder
                 if (body is null) { problems.Add($"{e.Target}: winner '{w.Value.WinnerPlugin}' did not yield it on fetch (a load-order inconsistency)."); continue; }
                 winnerPlugin = w.Value.WinnerPlugin;
             }
-            else if (extend && patchMod.EnumerateMajorRecords().FirstOrDefault(r => r.FormKey == e.Target) is { } own)
-            {
-                patchLocal = own;
-            }
             else
             {
-                problems.Add($"{e.Target}: not present in the load order ({view.PluginCount} plugins)"
-                    + (extend ? $" or in '{fileName}' (the patch being extended)." : "."));
-                continue;
+                if (extend)
+                {
+                    if (patchDefined is null)
+                    {
+                        patchDefined = new Dictionary<FormKey, IMajorRecord>();
+                        foreach (var r in patchMod.EnumerateMajorRecords())
+                            if (r.FormKey.ModKey == patchMod.ModKey) patchDefined.TryAdd(r.FormKey, r);
+                    }
+                    if (patchDefined.TryGetValue(e.Target, out var own)) patchLocal = own;
+                }
+                if (patchLocal is null)
+                {
+                    problems.Add($"{e.Target}: not present in the load order ({view.PluginCount} plugins)"
+                        + (extend
+                            ? $", and not a record '{fileName}' (the patch being extended) itself defines — a record " +
+                              "the patch merely OVERRIDES resolves via the load order, so its defining plugin must be enabled."
+                            : "."));
+                    continue;
+                }
             }
 
             var recType = RecordNaming.StripOverlay((patchLocal ?? (object)body!).GetType().Name);

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -278,39 +278,10 @@ public static class WritePatchBuilder
         // cache, the known-master set) is opened THROUGH it and disposed when the method returns — no handle held at rest.
         using var session = resolver.OpenSession();
 
-        // --- Phase 1: resolve winner + derive RecordType + pre-flight EVERY edit. Collect ALL problems (so the caller
-        //     sees every fix at once), then refuse the whole call if any (Q3 — never a silently-partial patch).
-        //     ONE captured view answers EVERY edit (2026-06-12 hunt F5): the per-edit single-shot resolves each took
-        //     a fresh capture, so a freshness rebuild landing mid-loop (a concurrent read's refresh) could resolve
-        //     two edits of ONE call against two different builds' winners — a silently MIXED patch
-        //     (freshness-capture-guard arm 4, RED pre-fix: 2 of 12 hammered multi-op writes mixed). The write is one
-        //     logical operation; it reads one build — the same HCBR-2026-06-11-02 discipline the read service follows. ---
-        var view = resolver.Capture();
-        var resolved = new List<(PatchEdit edit, IMajorRecordGetter body, string winnerPlugin, WriteRequest req, string label)>(edits.Count);
-        var problems = new List<string>();
-        foreach (var e in edits)
-        {
-            var w = view.ResolveWinner(e.Target);
-            if (w is null) { problems.Add($"{e.Target}: not present in the load order ({view.PluginCount} plugins)."); continue; }
-            var body = view.GetRecord(session, w.Value.WinnerPlugin, e.Target);
-            if (body is null) { problems.Add($"{e.Target}: winner '{w.Value.WinnerPlugin}' did not yield it on fetch (a load-order inconsistency)."); continue; }
-
-            var recType = RecordNaming.StripOverlay(body.GetType().Name);
-            var req = new WriteRequest
-            {
-                RecordType = recType, Path = e.Path, Verb = e.Verb,
-                Key = e.Key, Value = e.Value, Values = e.Values, Entries = e.Entries, Struct = e.Struct,
-            };
-            var label = Label(req);
-            if (rulebook.Validate(req) is { } reject) { problems.Add($"{recType} {e.Target} [{label}]: {reject}"); continue; }
-            resolved.Add((e, body, w.Value.WinnerPlugin, req, label));
-        }
-        if (problems.Count > 0)
-            return PatchOutcome.Fail(
-                $"refused — {problems.Count} of {edits.Count} edit(s) rejected by resolve/pre-flight; NO patch written:\n  - "
-                + string.Join("\n  - ", problems));
-
-        // --- Phase 2: open (extend) or create the patch mod. The serializer ties the output filename to the ModKey. ---
+        // --- Phase 0: open (extend) or create the patch mod BEFORE resolving targets (HCBR-2026-07-10-01 F3, the
+        //     edit-lane twin of CreateRecords' Phase 0): an extend edit may target a record the PATCH ITSELF defines
+        //     (created by a prior into= call, not yet enabled in MO2), so the opened patch must be consultable by the
+        //     resolve loop. The serializer ties the output filename to the ModKey. ---
         var fileName = Path.GetFileName(outPath);
         SkyrimMod patchMod;
         if (extend)
@@ -327,17 +298,75 @@ public static class WritePatchBuilder
         if (!string.Equals(patchMod.ModKey.FileName.String, fileName, StringComparison.OrdinalIgnoreCase))
             return PatchOutcome.Fail($"patch ModKey '{patchMod.ModKey.FileName}' must match output filename '{fileName}'.");
 
+        // --- Phase 1: resolve winner + derive RecordType + pre-flight EVERY edit. Collect ALL problems (so the caller
+        //     sees every fix at once), then refuse the whole call if any (Q3 — never a silently-partial patch).
+        //     ONE captured view answers EVERY edit (2026-06-12 hunt F5): the per-edit single-shot resolves each took
+        //     a fresh capture, so a freshness rebuild landing mid-loop (a concurrent read's refresh) could resolve
+        //     two edits of ONE call against two different builds' winners — a silently MIXED patch
+        //     (freshness-capture-guard arm 4, RED pre-fix: 2 of 12 hammered multi-op writes mixed). The write is one
+        //     logical operation; it reads one build — the same HCBR-2026-06-11-02 discipline the read service follows.
+        //     A target absent from the load order that the EXTENDED patch itself defines (a record a prior into= call
+        //     created, patch not yet enabled in MO2 — HCBR-2026-07-10-01 F3) resolves to the patch's OWN settable copy
+        //     (patchLocal; Phase 3 edits it directly, no override) — this consults ONLY the named output artifact of
+        //     the current authoring session, never an arbitrary un-enabled plugin, so the Q3 winner-confusion hazard
+        //     the declined read-un-enabled-plugins feature guards against doesn't arise. ---
+        var view = resolver.Capture();
+        var resolved = new List<(PatchEdit edit, IMajorRecordGetter? body, string? winnerPlugin, IMajorRecord? patchLocal, WriteRequest req, string label)>(edits.Count);
+        var problems = new List<string>();
+        foreach (var e in edits)
+        {
+            IMajorRecordGetter? body = null; string? winnerPlugin = null; IMajorRecord? patchLocal = null;
+            var w = view.ResolveWinner(e.Target);
+            if (w is not null)
+            {
+                body = view.GetRecord(session, w.Value.WinnerPlugin, e.Target);
+                if (body is null) { problems.Add($"{e.Target}: winner '{w.Value.WinnerPlugin}' did not yield it on fetch (a load-order inconsistency)."); continue; }
+                winnerPlugin = w.Value.WinnerPlugin;
+            }
+            else if (extend && patchMod.EnumerateMajorRecords().FirstOrDefault(r => r.FormKey == e.Target) is { } own)
+            {
+                patchLocal = own;
+            }
+            else
+            {
+                problems.Add($"{e.Target}: not present in the load order ({view.PluginCount} plugins)"
+                    + (extend ? $" or in '{fileName}' (the patch being extended)." : "."));
+                continue;
+            }
+
+            var recType = RecordNaming.StripOverlay((patchLocal ?? (object)body!).GetType().Name);
+            var req = new WriteRequest
+            {
+                RecordType = recType, Path = e.Path, Verb = e.Verb,
+                Key = e.Key, Value = e.Value, Values = e.Values, Entries = e.Entries, Struct = e.Struct,
+            };
+            var label = Label(req);
+            if (rulebook.Validate(req) is { } reject) { problems.Add($"{recType} {e.Target} [{label}]: {reject}"); continue; }
+            resolved.Add((e, body, winnerPlugin, patchLocal, req, label));
+        }
+        if (problems.Count > 0)
+            return PatchOutcome.Fail(
+                $"refused — {problems.Count} of {edits.Count} edit(s) rejected by resolve/pre-flight; NO patch written:\n  - "
+                + string.Join("\n  - ", problems));
+
         // --- Phase 3: override each winner into the ONE patch mod, then apply. A flat record needs no link cache; a
         //     NESTED record (Cell/Placed*/INFO/Navmesh/Landscape) gets the winner overlay's cache built on demand
         //     (costly → only here, never for the flat common case, never held). A throw here AFTER pre-flight passed is
         //     a real engine inconsistency — fail the WHOLE call (no partial patch), surfaced not swallowed (Q3). ---
         var ops = new List<OpResult>(resolved.Count);
-        foreach (var (e, body, winnerPlugin, req, label) in resolved)
+        foreach (var (e, body, winnerPlugin, patchLocal, req, label) in resolved)
         {
             try
             {
-                ILinkCache? cache = WriteEngine.RecordNeedsSourceCache(body) ? session.LinkCacheFor(winnerPlugin) : null;
-                var ov = WriteEngine.GenericGetOrAddAsOverride(patchMod, body, cache);
+                // A patch-local target (defined only in the extended patch — HCBR-2026-07-10-01 F3) is already a
+                // settable record IN patchMod: edit it directly, no override and no source link cache needed.
+                IMajorRecord ov;
+                if (patchLocal is not null) ov = patchLocal;
+                else
+                {
+                    ILinkCache? cache = WriteEngine.RecordNeedsSourceCache(body!) ? session.LinkCacheFor(winnerPlugin!) : null;
+                    ov = WriteEngine.GenericGetOrAddAsOverride(patchMod, body!, cache);
+                }
                 WriteEngine.ApplyVerb(ov, req);
                 var (after, landed) = DescribeApplied(ov, req);
                 ops.Add(new OpResult(e.Target, req.RecordType, label, true, null, after, landed));
@@ -1768,9 +1797,12 @@ public static class WritePatchBuilder
         var problems = new List<string>();
         var seenEdid = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var declaredEdidType = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);   // editorid -> RecordType (same-call sibling parents)
-        // editorids declared in EARLIER specs (NOT the current one) — the legal targets of a "@editorid" same-call
-        // field forward-ref (HCBR Layer B unit A). Grown at the END of each spec's iteration, so during spec i's edit
-        // validation it holds {0..i-1}: a self-ref (@its-own-editorid) and a forward-ref (a later sibling) both reject.
+        // editorids declared in EARLIER specs PLUS the current one — the legal targets of a "@editorid" same-call
+        // field ref (HCBR Layer B unit A). Grown as each spec DECLARES its editorid (before its edits validate), so
+        // during spec i's edit validation it holds {0..i}: an earlier sibling AND the record itself (self-reference —
+        // HCBR-2026-07-10-01: a quest's VMAD fragment points at its own quest; apply registers the record in
+        // createdByEditorId before applying its edits, so the substitution timing already holds). A forward-ref to a
+        // LATER sibling still rejects loud.
         var priorEditorIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var parentPlans = new List<(IMajorRecordGetter? body, string? winnerPlugin, string? sibling, IMajorRecord? patchParent)?>(specs.Count);
         var cellKinds = new CellCreate[specs.Count];   // coordinate-keyed §4-(b) routing per spec (None / Exterior / Interior)
@@ -1781,6 +1813,7 @@ public static class WritePatchBuilder
             if (string.IsNullOrWhiteSpace(s.EditorId)) { problems.Add($"{s.RecordType}: an editorid is required to create a record (it's how the record is referenced)."); continue; }
             if (!seenEdid.Add(s.EditorId)) { problems.Add($"editorid '{s.EditorId}' is used by more than one record in this call — each created record needs a distinct editorid."); continue; }
             declaredEdidType[s.EditorId] = s.RecordType;
+            priorEditorIds.Add(s.EditorId);   // declared ⇒ referenceable by its own edits (self) and by LATER specs
 
             if (s.ParentRef is null)
             {
@@ -1860,10 +1893,9 @@ public static class WritePatchBuilder
 
             foreach (var req in s.Edits)
                 // siblingEditorIds = priorEditorIds: a "@editorid" FormLink value is accepted iff that editorid was
-                // created in an EARLIER spec of THIS call (resolved to its real FormKey in Phase 3); else rejected loud.
+                // declared in an EARLIER spec of THIS call OR is the record itself (resolved to its real FormKey in
+                // Phase 3); else rejected loud.
                 if (rulebook.Validate(req, priorEditorIds) is { } reject) problems.Add($"{s.RecordType} '{s.EditorId}' [{Label(req)}]: {reject}");
-
-            priorEditorIds.Add(s.EditorId);   // now available as a same-call sibling target for LATER specs (not its own)
         }
         if (problems.Count > 0)
             return CreateOutcome.Fail(
@@ -1951,42 +1983,18 @@ public static class WritePatchBuilder
             var ops = new List<OpResult>(s.Edits.Count);
             foreach (var rawReq in s.Edits)
             {
-                // Resolve a same-call sibling reference (@editorid) in a FormLink value to the sibling's now-allocated
-                // FormKey (HCBR Layer B unit A — the INFO PNAM chain + Topic back-link in one bulk_create). Pre-flight
-                // (Phase 1) already guaranteed any surviving @-token is on a FormLink leaf AND names a record created
-                // EARLIER in this call — so it is already in createdByEditorId; a miss here is a real engine
-                // inconsistency, surfaced not swallowed (Q3). The substituted value is a normal intra-patch FormKey
-                // that ApplyVerb coerces exactly as a literal FormID would (no apply-path change). Two slots carry a
-                // sibling ref (both gated to FormLink targets in pre-flight): the SINGULAR req.Value (a Set on a link,
-                // or — S4 Track D — an Add to a link list), and req.Values (S4 Track D: a ReplaceAll on a link list,
-                // where siblings may mix with literal FormIDs).
-                var req = rawReq;
-                if (WriteEngine.IsSameCallSiblingRef(rawReq.Value, out var sibEdid))
-                {
-                    if (!createdByEditorId.TryGetValue(sibEdid, out var sibRec))
-                        return CreateOutcome.Fail(
-                            $"internal: same-call reference '@{sibEdid}' on new {s.RecordType} '{s.EditorId}' resolved to no " +
-                            "record created in this call — pre-flight should have caught it; surfaced, not swallowed (Q3).");
-                    req = CopyWithValue(rawReq, sibRec.FormKey.ToString());
-                }
-                else if (rawReq.Values is { } rawVals && Array.Exists(rawVals, v => WriteEngine.IsSameCallSiblingRef(v, out _)))
-                {
-                    // ReplaceAll on a FormLink list — resolve each @-entry to its allocated FormKey; literals pass through.
-                    var resolved = new string[rawVals.Length];
-                    for (int vi = 0; vi < rawVals.Length; vi++)
-                    {
-                        if (WriteEngine.IsSameCallSiblingRef(rawVals[vi], out var vEd))
-                        {
-                            if (!createdByEditorId.TryGetValue(vEd, out var vRec))
-                                return CreateOutcome.Fail(
-                                    $"internal: same-call reference '@{vEd}' in a list value on new {s.RecordType} '{s.EditorId}' " +
-                                    "resolved to no record created in this call — pre-flight should have caught it; surfaced, not swallowed (Q3).");
-                            resolved[vi] = vRec.FormKey.ToString();
-                        }
-                        else resolved[vi] = rawVals[vi];
-                    }
-                    req = CopyWithValues(rawReq, resolved);
-                }
+                // Resolve every same-call reference (@editorid) to its now-allocated FormKey (HCBR Layer B unit A —
+                // the INFO PNAM chain + Topic back-link in one bulk_create; HCBR-2026-07-10-01 — self-reference +
+                // compose-struct refs, e.g. a quest's VMAD fragment pointing at its own quest). Pre-flight (Phase 1)
+                // already guaranteed any surviving @-token is on a FormLink target AND names a record declared no
+                // later than this spec — the current record was registered in createdByEditorId just above, so SELF
+                // resolves too; a miss here is a real engine inconsistency, surfaced not swallowed (Q3). The
+                // substituted value is a normal intra-patch FormKey that ApplyVerb coerces exactly as a literal
+                // FormID would (no apply-path change). Slots that carry a ref: the SINGULAR req.Value, req.Values
+                // (ReplaceAll on a link list), and — recursively — a compose Struct's formlink Fields values and
+                // nested Sets (ResolveSiblingRefs walks all of them).
+                var (req, refErr) = ResolveSiblingRefs(rawReq, createdByEditorId, $"new {s.RecordType} '{s.EditorId}'");
+                if (refErr is not null) return CreateOutcome.Fail(refErr);
                 try { WriteEngine.ApplyVerb(rec, req); ops.Add(new OpResult(rec.FormKey, s.RecordType, Label(req), true, null, TryReadAfter(rec, req))); }
                 catch (ExpectedApplyRejectionException ex)
                 {
@@ -2169,23 +2177,85 @@ public static class WritePatchBuilder
     static string Label(WriteRequest r) =>
         $"{r.Verb} {string.Join('.', r.Path)}{(r.Key is not null ? "[" + r.Key + "]" : "")}{(r.Value is not null ? " = " + r.Value : "")}";
 
-    /// <summary>Clone a <see cref="WriteRequest"/> changing ONLY its <see cref="WriteRequest.Value"/> — it's an
-    /// init-only class (no <c>with</c>). Used to substitute a resolved same-call sibling FormKey for the
-    /// <c>@editorid</c> token before apply (HCBR Layer B unit A); every other field is carried verbatim.</summary>
-    static WriteRequest CopyWithValue(WriteRequest r, string value) => new()
+    /// <summary>Resolve every same-call <c>@editorid</c> reference in a request to the referenced record's allocated
+    /// FormKey — the singular <see cref="WriteRequest.Value"/>, each <see cref="WriteRequest.Values"/> entry, and
+    /// (HCBR-2026-07-10-01) a compose <see cref="WriteRequest.Struct"/>'s formlink Fields values + nested Sets,
+    /// recursively. WriteRequest/StructSpec are init-only, so substitution clones; the ORIGINAL instance is returned
+    /// untouched when nothing needed resolving (the common no-token path allocates nothing). A token naming a record
+    /// not in <paramref name="created"/> is a real engine inconsistency (pre-flight gates the declared-earlier-or-self
+    /// rule) — returned as <c>error</c>, surfaced not swallowed (Q3).</summary>
+    static (WriteRequest req, string? error) ResolveSiblingRefs(
+        WriteRequest r, IReadOnlyDictionary<string, IMajorRecord> created, string onWhat)
     {
-        RecordType = r.RecordType, Path = r.Path, Verb = r.Verb, Key = r.Key,
-        Value = value, Values = r.Values, Entries = r.Entries, Struct = r.Struct,
-    };
+        string? err = null;
+        string? One(string? v)
+        {
+            if (err is not null || !WriteEngine.IsSameCallSiblingRef(v, out var ed)) return v;
+            if (created.TryGetValue(ed, out var rec)) return rec.FormKey.ToString();
+            err = $"internal: same-call reference '@{ed}' on {onWhat} resolved to no record created in this call — " +
+                  "pre-flight should have caught it; surfaced, not swallowed (Q3).";
+            return v;
+        }
+        var value = One(r.Value);
+        var values = r.Values;
+        if (values is not null && Array.Exists(values, v => WriteEngine.IsSameCallSiblingRef(v, out _)))
+            values = Array.ConvertAll(values, v => One(v)!);
+        var strct = r.Struct;
+        if (strct is not null)
+        {
+            var (rs, sErr) = ResolveStructSiblingRefs(strct, created, onWhat);
+            err ??= sErr;
+            strct = rs;
+        }
+        if (err is not null) return (r, err);
+        if (ReferenceEquals(value, r.Value) && ReferenceEquals(values, r.Values) && ReferenceEquals(strct, r.Struct))
+            return (r, null);
+        return (new WriteRequest
+        {
+            RecordType = r.RecordType, Path = r.Path, Verb = r.Verb, Key = r.Key,
+            Value = value, Values = values, Entries = r.Entries, Struct = strct,
+        }, null);
+    }
 
-    /// <summary>The <see cref="WriteRequest.Values"/> twin of <see cref="CopyWithValue"/> — clone changing ONLY the
-    /// list contents. Used to substitute resolved same-call sibling FormKeys for <c>@editorid</c> tokens inside a
-    /// FormLink-list ReplaceAll before apply (S4 Track D); every other field is carried verbatim.</summary>
-    static WriteRequest CopyWithValues(WriteRequest r, string[] values) => new()
+    /// <summary>The <see cref="StructSpec"/> half of <see cref="ResolveSiblingRefs"/>: substitute <c>@editorid</c>
+    /// tokens in the spec's flat Fields values and recurse through its nested Sets (a struct element whose own field
+    /// is a struct element resolves for free). Same clone-only-on-change + fail-loud-on-miss contract.</summary>
+    static (StructSpec spec, string? error) ResolveStructSiblingRefs(
+        StructSpec sp, IReadOnlyDictionary<string, IMajorRecord> created, string onWhat)
     {
-        RecordType = r.RecordType, Path = r.Path, Verb = r.Verb, Key = r.Key,
-        Value = r.Value, Values = values, Entries = r.Entries, Struct = r.Struct,
-    };
+        var fields = sp.Fields;
+        if (fields is not null && fields.Values.Any(v => WriteEngine.IsSameCallSiblingRef(v, out _)))
+        {
+            var nf = new Dictionary<string, string>(fields.Count);
+            foreach (var kv in fields)
+            {
+                if (WriteEngine.IsSameCallSiblingRef(kv.Value, out var ed))
+                {
+                    if (!created.TryGetValue(ed, out var rec))
+                        return (sp, $"internal: same-call reference '@{ed}' on {onWhat} resolved to no record created " +
+                                    "in this call — pre-flight should have caught it; surfaced, not swallowed (Q3).");
+                    nf[kv.Key] = rec.FormKey.ToString();
+                }
+                else nf[kv.Key] = kv.Value;
+            }
+            fields = nf;
+        }
+        var sets = sp.Sets;
+        if (sets is not null)
+        {
+            List<WriteRequest>? ns = null;
+            for (int i = 0; i < sets.Count; i++)
+            {
+                var (rr, e) = ResolveSiblingRefs(sets[i], created, onWhat);
+                if (e is not null) return (sp, e);
+                if (ns is null && !ReferenceEquals(rr, sets[i])) ns = new List<WriteRequest>(sets);
+                if (ns is not null) ns[i] = rr;
+            }
+            if (ns is not null) sets = ns;
+        }
+        if (ReferenceEquals(fields, sp.Fields) && ReferenceEquals(sets, sp.Sets)) return (sp, null);
+        return (new StructSpec { Type = sp.Type, Fields = fields, CtorArgs = sp.CtorArgs, Sets = sets }, null);
+    }
 
     /// <summary>Best-effort read-back of the edited leaf off the override (so the caller sees the value landed without a
     /// follow-up read). Reads the leaf PATH (not the keyed element — that's xEdit's job); null on any difficulty — never

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -53,7 +53,24 @@ namespace HousecarlGenerator;
 ///   REJ-SIBDICT        — an @ref inside a dict Merge's Entries values refuses loud ('not inside a dict value' — no
 ///                        formlink-valued dict is modeled, so the dict half stays dormant-by-construction).
 ///   REJ-SIBAPPLY       — an @ref validated with a NULL sibling set (the Apply/set_field context) refuses at the rulebook —
-///                        create-only scoping, so @editorid never becomes an accept-then-substitute-nothing hole (Q3).
+///                        create-only scoping, so @editorid never becomes an accept-then-substitute-nothing hole (Q3);
+///                        the message carries the honest edit-context copy (HCBR-2026-07-10-01 F2), never "use bulk_create".
+///
+/// HCBR-2026-07-10-01 — self-reference + compose-struct @refs + extend-edit resolution (the created-record
+/// self-reference gap: a quest's VMAD alias fragment must point Property.Object at ITS OWN quest — every MCM /
+/// player-alias-script mod — and a fresh patch must be extendable by field edits without an MO2 enable round-trip):
+///   SIBREF-SELF          — a record's own field @refs ITSELF (declared-before-own-edits + apply's register-then-apply
+///                          timing). RED pre-fix: 'created EARLIER in this call'.
+///   SIBREF-STRUCT        — the report's exact shape: @self inside a COMPOSED QuestFragmentAlias' nested Sets
+///                          (Property.Object=@own-quest). RED pre-fix twice: compose Sets validated with a NULL sibling
+///                          set AND apply never substituted @tokens inside req.Struct.
+///   SIBREF-STRUCT-FIELDS — the flat-Fields sugar twin: Object='@self' in a compose FIELD value substitutes too.
+///   REJ-SIBSTRUCT-FWD    — a compose-Sets @ref to a LATER sibling still refuses (declared-earlier holds in composes).
+///   REJ-SIBSTRUCT-NONFL  — a compose-Sets @ref on a NON-formlink field still refuses (substitution stays formlink-scoped).
+///   EXTEND-EDIT          — WritePatchBuilder.Apply(extend:true) resolves a target the PATCH ITSELF defines (created by a
+///                          prior call, not in the load order) to a patch-local direct edit, mixed with a load-order
+///                          target in one call; a truly-absent target refuses naming BOTH places searched. RED pre-fix:
+///                          'not present in the load order (N plugins)'.
 ///
 /// GENERAL FormLink-ELEMENT collection value-shape — the BROADER pre-existing gap the sibling-ref collection gate named: ANY
 /// malformed FormLink ELEMENT (not just an @editorid sibling token) in a collection value was accepted at pre-flight
@@ -702,8 +719,154 @@ public static class NestedCreateGuardProbe
         {
             var req = new WriteRequest { RecordType = "DialogResponses", Path = new[] { "PreviousDialog" }, Verb = "Set", Value = "@AnySibling" };
             var reject = rulebook.Validate(req);   // null sibling set == the override/set_field context
-            sibRejApplyOk = reject is not null && reject.Contains("only valid when creating records in ONE call", StringComparison.OrdinalIgnoreCase);
-            Console.WriteLine($"   REJ-SIBAPPLY @ref on set_field path  : {(sibRejApplyOk ? "PASS — rejected at the gate (no same-call siblings when editing an existing record)" : $"FAIL — reject=[{reject}]")}");
+            // HCBR-2026-07-10-01 F2: the edit-context message must state the create-call meaning + the FormID route,
+            // and must NOT read as "use bulk_create" (the old copy fired identically FROM bulk_create's compose path).
+            sibRejApplyOk = reject is not null
+                && reject.Contains("no same-call creations to point at", StringComparison.OrdinalIgnoreCase)
+                && reject.Contains("FormID", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   REJ-SIBAPPLY @ref on set_field path  : {(sibRejApplyOk ? "PASS — rejected at the gate with the edit-context copy (no same-call creations; use the FormID)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- SIBREF-SELF (HCBR-2026-07-10-01): a record's own field @refs ITSELF ----------
+        // A line whose PreviousDialog points at the line itself — the minimal top-level self-reference. Pre-flight
+        // admits @self (the editorid is declared BEFORE its own edits validate) and apply substitutes the record's
+        // just-allocated FormKey (createdByEditorId registers the record before its edits apply). RED pre-fix:
+        // "no record with editorid ... created EARLIER in this call".
+        bool sibRefSelfOk = false;
+        {
+            string pPath = Path.Combine(tmpDir, "HcNcSelf.esp");
+            var specs = new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogTopic", EditorId = "HcNcSelfTopic", Edits = Array.Empty<WriteRequest>() },
+                new WritePatchBuilder.CreateSpec { RecordType = "DialogResponses", EditorId = "HcNcSelfL1", ParentRef = "HcNcSelfTopic",
+                    Edits = new[] { new WriteRequest { RecordType = "DialogResponses", Path = new[] { "PreviousDialog" }, Verb = "Set", Value = "@HcNcSelfL1" } } },
+            };
+            using var r = LoadOrderResolver.Build(new[] { mPath });
+            var o = WritePatchBuilder.CreateRecords(r, rulebook, specs, pPath, extend: false);
+            FormKey l1Fk = o.Success && o.Created.Count > 1 ? o.Created[1].FormKey : default;
+            var prev = o.Success ? InfoPreviousDialog(pPath, l1Fk) : null;
+            sibRefSelfOk = o.Success && o.Created.Count == 2 && l1Fk != default && prev == l1Fk;
+            Console.WriteLine($"   SIBREF-SELF @own-editorid            : {(sibRefSelfOk ? "PASS — a record's field @refs ITSELF, resolved to its own allocated FormKey" : $"FAIL — success={o.Success} prev=[{prev}] l1=[{l1Fk}] err=[{o.Error}]")}");
+        }
+
+        // ---------- SIBREF-STRUCT (HCBR-2026-07-10-01, the report's exact shape): @self inside a COMPOSED struct's Sets ----------
+        // A quest's VMAD alias fragment must carry Property.Object = THE QUEST'S OWN FormID (the shape of every MCM
+        // quest and player-alias-script mod). One create: Quest + VirtualMachineAdapter.Aliases Add QuestFragmentAlias
+        // whose nested Sets point Property.Object at @the-quest-itself. RED pre-fix twice over: the compose path
+        // validated Sets with a NULL sibling set (refusing with the misleading "only valid ... (housecarl_bulk_create)"
+        // message FROM bulk_create itself), and apply never substituted @tokens inside req.Struct.
+        bool sibRefStructOk = false;
+        {
+            string pPath = Path.Combine(tmpDir, "HcNcVmadSelf.esp");
+            var specs = new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "Quest", EditorId = "HcNcVmadQuest",
+                    Edits = new[] { new WriteRequest { RecordType = "Quest", Path = new[] { "VirtualMachineAdapter", "Aliases" }, Verb = "Add",
+                        Struct = new StructSpec { Type = "QuestFragmentAlias", Sets = new List<WriteRequest>
+                        {
+                            new() { RecordType = "QuestFragmentAlias", Path = new[] { "Property", "Object" }, Verb = "Set", Value = "@HcNcVmadQuest" },
+                            new() { RecordType = "QuestFragmentAlias", Path = new[] { "Property", "Alias" }, Verb = "Set", Value = "0" },
+                        } } } } },
+            };
+            using var r = LoadOrderResolver.Build(new[] { mPath });
+            var o = WritePatchBuilder.CreateRecords(r, rulebook, specs, pPath, extend: false);
+            FormKey qFk = o.Success ? o.Created[0].FormKey : default;
+            var obj = o.Success ? QuestAliasPropertyObject(pPath, qFk) : null;
+            sibRefStructOk = o.Success && o.Created.Count == 1 && qFk != default && obj == qFk;
+            Console.WriteLine($"   SIBREF-STRUCT @self in composed Sets : {(sibRefStructOk ? "PASS — VMAD alias fragment Property.Object resolved to the quest's OWN FormKey (the MCM/player-alias shape)" : $"FAIL — success={o.Success} obj=[{obj}] quest=[{qFk}] err=[{o.Error}]")}");
+        }
+
+        // ---------- SIBREF-STRUCT-FIELDS: the flat-Fields twin — @self in a compose FIELD value ----------
+        // The same fragment with Property composed as a whole-struct Set whose flat FIELDS carry Object='@self' —
+        // proves the Fields sugar admits + substitutes formlink @tokens too (both compose shapes, one behavior).
+        bool sibRefStructFieldsOk = false;
+        {
+            string pPath = Path.Combine(tmpDir, "HcNcVmadSelfF.esp");
+            var specs = new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "Quest", EditorId = "HcNcVmadQuestF",
+                    Edits = new[] { new WriteRequest { RecordType = "Quest", Path = new[] { "VirtualMachineAdapter", "Aliases" }, Verb = "Add",
+                        Struct = new StructSpec { Type = "QuestFragmentAlias", Sets = new List<WriteRequest>
+                        {
+                            new() { RecordType = "QuestFragmentAlias", Path = new[] { "Property" }, Verb = "Set",
+                                Struct = new StructSpec { Type = "ScriptObjectProperty",
+                                    Fields = new Dictionary<string, string> { ["Object"] = "@HcNcVmadQuestF", ["Alias"] = "0" } } },
+                        } } } } },
+            };
+            using var r = LoadOrderResolver.Build(new[] { mPath });
+            var o = WritePatchBuilder.CreateRecords(r, rulebook, specs, pPath, extend: false);
+            FormKey qFk = o.Success ? o.Created[0].FormKey : default;
+            var obj = o.Success ? QuestAliasPropertyObject(pPath, qFk) : null;
+            sibRefStructFieldsOk = o.Success && o.Created.Count == 1 && qFk != default && obj == qFk;
+            Console.WriteLine($"   SIBREF-STRUCT-FIELDS @self in Fields : {(sibRefStructFieldsOk ? "PASS — a compose FIELD value @self resolved to the quest's OWN FormKey (the Fields-sugar twin)" : $"FAIL — success={o.Success} obj=[{obj}] quest=[{qFk}] err=[{o.Error}]")}");
+        }
+
+        // ---------- REJ-SIBSTRUCT-FWD: @ref to a LATER sibling inside composed Sets refuses (declared-earlier holds in composes) ----------
+        bool sibRejStructFwdOk = RejectArm("REJ-SIBSTRUCT-FWD @later in compose", tmpDir, "SibStructFwd", mPath, rulebook,
+            new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "Quest", EditorId = "HcNcSfwQuest",
+                    Edits = new[] { new WriteRequest { RecordType = "Quest", Path = new[] { "VirtualMachineAdapter", "Aliases" }, Verb = "Add",
+                        Struct = new StructSpec { Type = "QuestFragmentAlias", Sets = new List<WriteRequest>
+                        { new() { RecordType = "QuestFragmentAlias", Path = new[] { "Property", "Object" }, Verb = "Set", Value = "@HcNcSfwLater" } } } } } },
+                new WritePatchBuilder.CreateSpec { RecordType = "Keyword", EditorId = "HcNcSfwLater", Edits = Array.Empty<WriteRequest>() },
+            },
+            msg => msg.Contains("EARLIER in this call", StringComparison.OrdinalIgnoreCase));
+
+        // ---------- REJ-SIBSTRUCT-NONFL: @ref on a NON-formlink field inside composed Sets refuses (scoped to formlinks) ----------
+        bool sibRejStructNonflOk = RejectArm("REJ-SIBSTRUCT-NONFL non-formlink   ", tmpDir, "SibStructNonFl", mPath, rulebook,
+            new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "Quest", EditorId = "HcNcSnfQuest",
+                    Edits = new[] { new WriteRequest { RecordType = "Quest", Path = new[] { "VirtualMachineAdapter", "Aliases" }, Verb = "Add",
+                        Struct = new StructSpec { Type = "QuestFragmentAlias", Sets = new List<WriteRequest>
+                        { new() { RecordType = "QuestFragmentAlias", Path = new[] { "Property", "Name" }, Verb = "Set", Value = "@HcNcSnfQuest" } } } } } },
+            },
+            msg => msg.Contains("only valid on a FormLink field", StringComparison.OrdinalIgnoreCase));
+
+        // ---------- EXTEND-EDIT (HCBR-2026-07-10-01 F3): an extend edit targets a record ONLY the patch defines ----------
+        // The report's blocked two-step: create into a patch (not enabled in MO2 — not in the resolver's order), then
+        // Apply extend on the same patch targeting the created record. RED pre-fix: "not present in the load order".
+        // Now the extended patch's own records resolve to a patch-local direct edit; a MIXED call (one load-order
+        // target + one patch-local target) lands both; a genuinely-absent target still refuses loud, naming BOTH
+        // places searched (the load order AND the patch being extended).
+        bool extendEditOk = false;
+        {
+            string pPath = Path.Combine(tmpDir, "HcNcExtEdit.esp");
+            using var r = LoadOrderResolver.Build(new[] { mPath });
+            var co = WritePatchBuilder.CreateRecords(r, rulebook, new[]
+            {
+                new WritePatchBuilder.CreateSpec { RecordType = "MiscItem", EditorId = "HcNcExtMisc", Edits = Array.Empty<WriteRequest>() },
+            }, pPath, extend: false);
+            FormKey miscFk = co.Success ? co.Created[0].FormKey : default;
+            var eo = co.Success
+                ? WritePatchBuilder.Apply(r, rulebook, new[]
+                  {
+                      new WritePatchBuilder.PatchEdit { Target = miscFk, Path = new[] { "Value" }, Verb = "Set", Value = "123" },
+                      new WritePatchBuilder.PatchEdit { Target = masterTopicFk, Path = new[] { "Priority" }, Verb = "Set", Value = "50" },
+                  }, pPath, extend: true)
+                : null;
+            var missFk = new FormKey(new ModKey("HcNcExtEdit", ModType.Plugin), 0xEEE);
+            var miss = WritePatchBuilder.Apply(r, rulebook, new[]
+                { new WritePatchBuilder.PatchEdit { Target = missFk, Path = new[] { "Value" }, Verb = "Set", Value = "1" } }, pPath, extend: true);
+            uint? val = null; float? prio = null;
+            if (eo is { Success: true })
+            {
+                ISkyrimModGetter? ov = null;
+                try
+                {
+                    ov = SkyrimMod.CreateFromBinaryOverlay(pPath, SkyrimRelease.SkyrimSE);
+                    val = ov.MiscItems.FirstOrDefault(x => x.FormKey == miscFk)?.Value;
+                    prio = ov.DialogTopics.FirstOrDefault(x => x.FormKey == masterTopicFk)?.Priority;
+                }
+                catch { }
+                finally { (ov as IDisposable)?.Dispose(); }
+            }
+            bool missNamed = !miss.Success && miss.Error is not null
+                && miss.Error.Contains("load order", StringComparison.OrdinalIgnoreCase)
+                && miss.Error.Contains("the patch being extended", StringComparison.OrdinalIgnoreCase);
+            extendEditOk = co.Success && eo is { Success: true } && val == 123 && prio == 50 && missNamed;
+            Console.WriteLine($"   EXTEND-EDIT patch-defined target     : {(extendEditOk ? "PASS — an extend edit resolves the patch's OWN record (mixed with a load-order target); a truly-absent target refuses naming BOTH" : $"FAIL — create={co.Success} edit={eo?.Success} val=[{val}] prio=[{prio}] missNamed={missNamed} createErr=[{co.Error}] editErr=[{eo?.Error}] missErr=[{miss.Error}]")}");
         }
 
         // ====== GENERAL FormLink-ELEMENT collection value-shape (the broader gap the sibling-ref collection gate named) ======
@@ -2382,6 +2545,8 @@ public static class NestedCreateGuardProbe
                     && rejNoParentOk && rejBadParentOk && rejAmbigOk && rejFwdSibOk && extendOk
                     && sibrefOk && sibRefListAddOk && sibRefListReplaceOk && sibRejFwdOk && sibRejFwdListOk
                     && sibRejNonflOk && sibRejListSetOk && sibRejDictOk && sibRejApplyOk
+                    && sibRefSelfOk && sibRefStructOk && sibRefStructFieldsOk && sibRejStructFwdOk && sibRejStructNonflOk
+                    && extendEditOk
                     && flElemRejGateOk && flElemRejAddOk && flElemNullClearOk && flElemOkE2eOk && flElemRejE2eOk
                     && flElemRejNullAddOk && flElemRejNullAddPlainOk && flElemRejNullSetIdxOk && flElemRejNullAddE2eOk
                     && keyIdxRejDictAddOk && keyIdxRejDictRemoveOk && keyIdxRejSetIdxOk && keyIdxOkListRemoveOk && keyIdxRejSetIdxE2eOk
@@ -2561,6 +2726,21 @@ public static class NestedCreateGuardProbe
                 foreach (var info in t.Responses)
                     if (info.FormKey == infoFk) return select(info);
             return null;
+        }
+        catch { return null; }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    /// <summary>Re-open the written patch and read a created Quest's FIRST VMAD alias fragment's Property.Object
+    /// FormKey (the SIBREF-STRUCT self-reference arms, HCBR-2026-07-10-01). Null if the quest / fragment isn't found.</summary>
+    static FormKey? QuestAliasPropertyObject(string patchPath, FormKey questFk)
+    {
+        ISkyrimModGetter? ov = null;
+        try
+        {
+            ov = SkyrimMod.CreateFromBinaryOverlay(patchPath, SkyrimRelease.SkyrimSE);
+            var q = ov.Quests.FirstOrDefault(x => x.FormKey == questFk);
+            return q?.VirtualMachineAdapter?.Aliases.FirstOrDefault()?.Property?.Object.FormKey;
         }
         catch { return null; }
         finally { (ov as IDisposable)?.Dispose(); }

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -67,10 +67,14 @@ namespace HousecarlGenerator;
 ///   SIBREF-STRUCT-FIELDS — the flat-Fields sugar twin: Object='@self' in a compose FIELD value substitutes too.
 ///   REJ-SIBSTRUCT-FWD    — a compose-Sets @ref to a LATER sibling still refuses (declared-earlier holds in composes).
 ///   REJ-SIBSTRUCT-NONFL  — a compose-Sets @ref on a NON-formlink field still refuses (substitution stays formlink-scoped).
+///   REJ-SIBSTRAYSTRUCT   — a struct= riding alongside an admitted '@' value refuses at the gate (PR #166 review
+///                          finding 1: apply's substitution recursion must never walk an unvalidated stray compose).
 ///   EXTEND-EDIT          — WritePatchBuilder.Apply(extend:true) resolves a target the PATCH ITSELF defines (created by a
 ///                          prior call, not in the load order) to a patch-local direct edit, mixed with a load-order
-///                          target in one call; a truly-absent target refuses naming BOTH places searched. RED pre-fix:
-///                          'not present in the load order (N plugins)'.
+///                          target in one call; a truly-absent target refuses naming BOTH places searched (RED pre-fix:
+///                          'not present in the load order (N plugins)'); an override the patch merely CARRIES, of a
+///                          record whose defining plugin is disabled, still refuses loud (PR #166 review finding 2 —
+///                          patch-local resolution is scoped to records the patch DEFINES, never its override copies).
 ///
 /// GENERAL FormLink-ELEMENT collection value-shape — the BROADER pre-existing gap the sibling-ref collection gate named: ANY
 /// malformed FormLink ELEMENT (not just an @editorid sibling token) in a collection value was accepted at pre-flight
@@ -824,12 +828,27 @@ public static class NestedCreateGuardProbe
             },
             msg => msg.Contains("only valid on a FormLink field", StringComparison.OrdinalIgnoreCase));
 
+        // ---------- REJ-SIBSTRAYSTRUCT (PR #166 review finding 1): a stray compose spec alongside an admitted @value refuses ----------
+        // The sibling gate returns before the compose branches, so a struct= riding on the same op was never validated —
+        // yet apply's substitution recursion WALKS it, and a bad token inside it would fail under the misleading
+        // "internal: pre-flight should have caught it" wrapper. The gate now refuses the stray compose loud.
+        bool sibRejStrayStructOk;
+        {
+            var req = new WriteRequest { RecordType = "DialogResponses", Path = new[] { "Topic" }, Verb = "Set", Value = "@HcNcStrayTopic",
+                Struct = new StructSpec { Type = "QuestFragmentAlias", Fields = new Dictionary<string, string> { ["Version"] = "@Typo" } } };
+            var reject = rulebook.Validate(req, new[] { "HcNcStrayTopic" });
+            sibRejStrayStructOk = reject is not null && reject.Contains("remove struct=", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   REJ-SIBSTRAYSTRUCT stray compose     : {(sibRejStrayStructOk ? "PASS — a struct= alongside an admitted '@' value refuses at the gate (never the 'internal' wrapper at apply)" : $"FAIL — reject=[{reject}]")}");
+        }
+
         // ---------- EXTEND-EDIT (HCBR-2026-07-10-01 F3): an extend edit targets a record ONLY the patch defines ----------
         // The report's blocked two-step: create into a patch (not enabled in MO2 — not in the resolver's order), then
         // Apply extend on the same patch targeting the created record. RED pre-fix: "not present in the load order".
         // Now the extended patch's own records resolve to a patch-local direct edit; a MIXED call (one load-order
         // target + one patch-local target) lands both; a genuinely-absent target still refuses loud, naming BOTH
-        // places searched (the load order AND the patch being extended).
+        // places searched (the load order AND the patch being extended). PLUS the PR #166 review finding 2 leg: an
+        // override the patch merely CARRIES (of a record whose defining plugin is now disabled) does NOT resolve —
+        // the loud refusal is kept, never a silent edit of the patch's stale override copy.
         bool extendEditOk = false;
         {
             string pPath = Path.Combine(tmpDir, "HcNcExtEdit.esp");
@@ -865,8 +884,34 @@ public static class NestedCreateGuardProbe
             bool missNamed = !miss.Success && miss.Error is not null
                 && miss.Error.Contains("load order", StringComparison.OrdinalIgnoreCase)
                 && miss.Error.Contains("the patch being extended", StringComparison.OrdinalIgnoreCase);
-            extendEditOk = co.Success && eo is { Success: true } && val == 123 && prio == 50 && missNamed;
-            Console.WriteLine($"   EXTEND-EDIT patch-defined target     : {(extendEditOk ? "PASS — an extend edit resolves the patch's OWN record (mixed with a load-order target); a truly-absent target refuses naming BOTH" : $"FAIL — create={co.Success} edit={eo?.Success} val=[{val}] prio=[{prio}] missNamed={missNamed} createErr=[{co.Error}] editErr=[{eo?.Error}] missErr=[{miss.Error}]")}");
+
+            // Review finding 2 leg: a second master m2 contributes a record; the patch carries an OVERRIDE of it
+            // (extend with m2 active), then m2 is "disabled" (a resolver without it) — targeting the m2 record must
+            // REFUSE (the patch contains it, but does not DEFINE it), naming the overrides-resolve-via-load-order rule.
+            bool staleOverrideRefused = false;
+            if (co.Success && eo is { Success: true })
+            {
+                var m2Key = new ModKey("HcNcExtM2", ModType.Master);
+                string m2Path = Path.Combine(tmpDir, m2Key.FileName);
+                var m2 = new SkyrimMod(m2Key, SkyrimRelease.SkyrimSE);
+                var m2Misc = m2.MiscItems.AddNew(); m2Misc.EditorID = "HcNcExtM2Misc"; m2Misc.Value = 7;
+                m2.BeginWrite.ToPath(m2Path).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+                using var rBoth = LoadOrderResolver.Build(new[] { mPath, m2Path });
+                var carry = WritePatchBuilder.Apply(rBoth, rulebook, new[]
+                    { new WritePatchBuilder.PatchEdit { Target = m2Misc.FormKey, Path = new[] { "Value" }, Verb = "Set", Value = "9" } }, pPath, extend: true);
+                var stale = carry.Success
+                    ? WritePatchBuilder.Apply(r, rulebook, new[]   // r = m2 NOT in the order ("disabled")
+                        { new WritePatchBuilder.PatchEdit { Target = m2Misc.FormKey, Path = new[] { "Value" }, Verb = "Set", Value = "1" } }, pPath, extend: true)
+                    : null;
+                staleOverrideRefused = carry.Success && stale is { Success: false }
+                    && stale.Error is not null && stale.Error.Contains("OVERRIDES", StringComparison.Ordinal);
+                if (!staleOverrideRefused)
+                    Console.WriteLine($"          stale-override leg detail: carry={carry.Success} stale={stale?.Success} carryErr=[{carry.Error}] staleErr=[{stale?.Error}]");
+            }
+
+            extendEditOk = co.Success && eo is { Success: true } && val == 123 && prio == 50 && missNamed && staleOverrideRefused;
+            Console.WriteLine($"   EXTEND-EDIT patch-defined target     : {(extendEditOk ? "PASS — an extend edit resolves the patch's OWN record (mixed with a load-order target); a truly-absent target refuses naming BOTH; a carried override of a disabled plugin's record still refuses loud" : $"FAIL — create={co.Success} edit={eo?.Success} val=[{val}] prio=[{prio}] missNamed={missNamed} staleOverrideRefused={staleOverrideRefused} createErr=[{co.Error}] editErr=[{eo?.Error}] missErr=[{miss.Error}]")}");
         }
 
         // ====== GENERAL FormLink-ELEMENT collection value-shape (the broader gap the sibling-ref collection gate named) ======
@@ -2546,7 +2591,7 @@ public static class NestedCreateGuardProbe
                     && sibrefOk && sibRefListAddOk && sibRefListReplaceOk && sibRejFwdOk && sibRejFwdListOk
                     && sibRejNonflOk && sibRejListSetOk && sibRejDictOk && sibRejApplyOk
                     && sibRefSelfOk && sibRefStructOk && sibRefStructFieldsOk && sibRejStructFwdOk && sibRejStructNonflOk
-                    && extendEditOk
+                    && sibRejStrayStructOk && extendEditOk
                     && flElemRejGateOk && flElemRejAddOk && flElemNullClearOk && flElemOkE2eOk && flElemRejE2eOk
                     && flElemRejNullAddOk && flElemRejNullAddPlainOk && flElemRejNullSetIdxOk && flElemRejNullAddE2eOk
                     && keyIdxRejDictAddOk && keyIdxRejDictRemoveOk && keyIdxRejSetIdxOk && keyIdxOkListRemoveOk && keyIdxRejSetIdxE2eOk

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -214,8 +214,10 @@ public static class WriteTools
          "field VALUE can ALSO reference a same-call sibling, written '@editorid' — so a dialogue line's order-chain and its " +
          "topic back-link are authored in the SAME call: e.g. on a line, operations:[{field_path:'Topic', value:'@MyTopic'}, " +
          "{field_path:'PreviousDialog', value:'@MyTopic_L1'}] points it at the same-call topic and the prior line. Each '@editorid' " +
-         "must name a record declared EARLIER in this array; it resolves to that record's auto-allocated FormID. (Only on FormLink " +
-         "fields, only in this batch tool — a single create_record has no siblings.) collection= " +
+         "must name a record declared EARLIER in this array OR the record being created ITSELF (self-reference — e.g. a quest's " +
+         "VMAD alias fragment whose Property.Object is the quest: value:'@MyQuest' on MyQuest's own operation; works in single " +
+         "create_record too); it resolves to that record's auto-allocated FormID. (Only on FormLink fields — including formlink " +
+         "fields/sets inside a compose spec.) collection= " +
          "names which child-list when the parent holds more than one that fits (e.g. a cell's 'Persistent'). Each new FormID is " +
          "auto-allocated (the patch's own 0x800+ range) and returned. ALL-OR-NOTHING (Q3): if ANY spec is malformed or fails " +
          "pre-flight (unknown/ambiguous type, missing editorid, illegal field op, a nested child with no resolvable parent, an " +


### PR DESCRIPTION
Fixes **HCBR-2026-07-10-01** (bug-report store) — *created records can't reference themselves, and a fresh patch can't be extended by field edits*. Found while authoring a SunHelm quick-drink hotkey mod: a quest's VMAD alias fragment must carry `Property.Object` = **the quest's own FormID** (the shape of every MCM quest and player-alias-script mod), and no supported path existed.

## What was broken (the report's three interlocking problems)

1. **`@editorid` couldn't self-reference** — pre-flight only admitted editorids declared in *earlier* specs, so a single-record create had nothing to point at. Worse, the report's actual placement is inside a **composed struct's** nested Sets, where the compose path validated with a **null sibling set** (deliberately out of unit-A scope) and apply never substituted `@` tokens inside `req.Struct` at all.
2. **The refusal message was wrong** — the null-siblings copy said *"only valid when creating records in ONE call (housecarl_bulk_create)"*, and fired verbatim **from bulk_create's own compose path**, sending the caller to the tool they were already using.
3. **The two-step fallback was blocked** — `bulk_apply into=` resolved targets against the active load order only, so a record defined solely in the (not-yet-enabled) patch being extended refused with *"not present in the load order"*.

## The fix

- **F1 — self-reference**: a spec's editorid registers as a legal `@` target *before* its own edits validate. The apply side already registered the record in `createdByEditorId` before applying its edits, so the substitution timing already held — only the gate blocked it.
- **F1b — compose-struct refs**: `siblingEditorIds` threads through the whole compose-validation chain (`StructElementLegality` / `StructLeafLegality` / `ArmLegality` → `StructSpecContents`: formlink-gated `Fields` values + nested `Sets`, recursively), and apply-side substitution now recurses into `req.Struct` (`ResolveSiblingRefs` + `ResolveStructSiblingRefs` replace the flat `CopyWithValue`/`CopyWithValues` pair). On the **edit** path the set stays null and `@` still rejects loud (Q3) — with an honest message (F2).
- **F2 — message**: the edit-context refusal now states what `@editorid` means (a same-call creation) and the FormID route, never "use bulk_create".
- **F3 — `into=` edits resolve the extended patch**: `Apply` opens the patch **before** target resolution (the edit-lane twin of `CreateRecords`' Phase 0); on a load-order miss under `extend`, the patch's own record resolves to a **patch-local direct edit** (no override, no source cache). Scope note: this consults only the *named output artifact of the current authoring session* — it is **not** the declined "read un-enabled plugins" feature; the Q3 winner-confusion hazard doesn't arise (per the report's own scoping in "Suggested fixes" #3). The refusal for a truly-absent target now names **both** places searched.
- Report fix #4 (document the deterministic `0x800` allocation) is moot: with F1+F3 the fragile literal-FormID workaround is no longer needed.

## Proof

- **nested-create-guard**, 6 new arms + 1 re-pinned, **all RED-proven** (core fixes stashed → every new arm fails with exactly the report's failure modes → fixes restored → all pass):
  - `SIBREF-SELF` — a record's field `@`refs itself (top-level).
  - `SIBREF-STRUCT` — **the report's exact shape**: Quest + `VirtualMachineAdapter.Aliases` Add `QuestFragmentAlias` with nested Sets `Property.Object=@own-quest`; read back off disk = the quest's own FormKey.
  - `SIBREF-STRUCT-FIELDS` — the flat-Fields sugar twin (`Object:'@self'` in a compose field).
  - `REJ-SIBSTRUCT-FWD` / `REJ-SIBSTRUCT-NONFL` — declared-earlier and formlink-only gates hold inside composes.
  - `EXTEND-EDIT` — create into a patch not in the load order, then `Apply(extend)` targeting that record: lands, mixed with a load-order target in the same call; a truly-absent target refuses naming both.
  - `REJ-SIBAPPLY` — re-pinned to the new edit-context copy.
- **ci-all 81/81 local** (worktree root).

## Not addressed (known later surfaces, noted in the report as related friction)

- `SetAtIndex` of modeled VMAD elements (Add-only composes today) — existing named refusal, demand signal noted.
- `Properties[i].Data` conflicting-arm pre-flight (read-the-element-first) — same class as the CTDA-param compose workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
