### PR TITLE
refactor(skypatcher): Wave-1 review cleanup cluster (deferred out of PR #165)

### DIFF
--- a/src/housecarl-core/EmbeddedJson.cs
+++ b/src/housecarl-core/EmbeddedJson.cs
@@ -1,0 +1,18 @@
+namespace HousecarlCore;
+
+/// <summary>The ONE embedded-JSON resource reader — the SkyPatcher catalog and field map ship as
+/// housecarl-core embedded resources and each hand-rolled an identical loader (deduped, PR #165
+/// review cleanup). Throws loudly on a missing resource: a silently-empty load is exactly the Q3
+/// degrade both call sites' Load() contracts forbid.</summary>
+internal static class EmbeddedJson
+{
+    public static string Read(string fileName, string what)
+    {
+        var asm = typeof(EmbeddedJson).Assembly;
+        var name = asm.GetManifestResourceNames().FirstOrDefault(n => n.EndsWith(fileName, StringComparison.OrdinalIgnoreCase))
+            ?? throw new InvalidOperationException($"{what} resource '{fileName}' is not embedded in housecarl-core.");
+        using var s = asm.GetManifestResourceStream(name)!;
+        using var r = new StreamReader(s);
+        return r.ReadToEnd();
+    }
+}

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -206,6 +206,26 @@ public static class ReadEngine
         catch (Exception ex) { return LeafRead.None($"(unreadable: {ex.Message})"); }
     }
 
+    /// <summary>The FormKeys on a record's <c>Keywords</c> list — the ONE keyword walk (previously
+    /// triplicated across the SkyPatcher overlay, the post-state service resolver, and the show CLI,
+    /// with diverging property resolution and non-formlink handling). Resolves the property the same
+    /// way the engines do (<see cref="WriteEngine.ResolveProperty"/>), so explicit-interface getters
+    /// can't hide it. Null = the type has no keyword list, or an item isn't a formlink (surfaced loud
+    /// by callers, never guessed empty).</summary>
+    public static IReadOnlyList<FormKey>? KeywordKeys(object record)
+    {
+        var p = WriteEngine.ResolveProperty(record.GetType(), "Keywords");
+        if (p is null) return null;
+        if (p.GetValue(record) is not System.Collections.IEnumerable list) return new List<FormKey>();   // absent list reads as empty
+        var keys = new List<FormKey>();
+        foreach (var item in list)
+        {
+            if (item is IFormLinkGetter link) keys.Add(link.FormKey);
+            else return null;
+        }
+        return keys;
+    }
+
     /// <summary>A "no such field" note that, when the owner is a collection, points the caller at bracket
     /// indexing — the common <c>.0</c>-vs-<c>[0]</c> confusion (the read analog of the write pre-flight's
     /// bracket hint in <c>CorpusRulebook</c>). Brackets are how you step into a list/dict element mid-path;

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -210,13 +210,22 @@ public static class ReadEngine
     /// triplicated across the SkyPatcher overlay, the post-state service resolver, and the show CLI,
     /// with diverging property resolution and non-formlink handling). Resolves the property the same
     /// way the engines do (<see cref="WriteEngine.ResolveProperty"/>), so explicit-interface getters
-    /// can't hide it. Null = the type has no keyword list, or an item isn't a formlink (surfaced loud
-    /// by callers, never guessed empty).</summary>
+    /// can't hide it. An ABSENT (null) list honestly reads as EMPTY — a record with no keyword list
+    /// carries no keywords. Null is reserved for "no such property / not a formlink list" (surfaced
+    /// loud by callers, never guessed).</summary>
     public static IReadOnlyList<FormKey>? KeywordKeys(object record)
     {
         var p = WriteEngine.ResolveProperty(record.GetType(), "Keywords");
         if (p is null) return null;
         if (p.GetValue(record) is not System.Collections.IEnumerable list) return new List<FormKey>();   // absent list reads as empty
+        return FormLinkKeys(list);
+    }
+
+    /// <summary>The FormKeys of one formlink-list value — the ONE enumerable→FormKey walk
+    /// (<see cref="KeywordKeys"/> and the SkyPatcher overlay's list ops both ride it, so link-reading
+    /// can't drift between them). Null the moment an element isn't a formlink (loud upstream).</summary>
+    public static List<FormKey>? FormLinkKeys(System.Collections.IEnumerable list)
+    {
         var keys = new List<FormKey>();
         foreach (var item in list)
         {

--- a/src/housecarl-core/SkyPatcherCatalog.cs
+++ b/src/housecarl-core/SkyPatcherCatalog.cs
@@ -100,7 +100,7 @@ public sealed class SkyPatcherCatalog
 
     /// <summary>Load the embedded catalog (memoized). Throws loudly on a missing/malformed resource — a
     /// catalog that silently loaded empty would make every op read as Unknown (a Q3 silent-degrade).</summary>
-    public static SkyPatcherCatalog Load() => _cached ??= LoadFrom(ReadEmbeddedJson());
+    public static SkyPatcherCatalog Load() => _cached ??= LoadFrom(EmbeddedJson.Read("skypatcher-catalog.json", "SkyPatcher catalog"));
 
     /// <summary>Parse a catalog from JSON text (also the guard's entry point for a fixture).</summary>
     public static SkyPatcherCatalog LoadFrom(string json)
@@ -110,16 +110,6 @@ public sealed class SkyPatcherCatalog
         foreach (var el in doc.RootElement.EnumerateArray())
             records.Add(ParseRecord(el));
         return new SkyPatcherCatalog(records);
-    }
-
-    static string ReadEmbeddedJson()
-    {
-        var asm = typeof(SkyPatcherCatalog).Assembly;
-        var name = asm.GetManifestResourceNames().FirstOrDefault(n => n.EndsWith("skypatcher-catalog.json", StringComparison.OrdinalIgnoreCase))
-            ?? throw new InvalidOperationException("SkyPatcher catalog resource 'skypatcher-catalog.json' is not embedded in housecarl-core.");
-        using var s = asm.GetManifestResourceStream(name)!;
-        using var r = new StreamReader(s);
-        return r.ReadToEnd();
     }
 
     static SkyPatcherRecordCatalog ParseRecord(JsonElement el)

--- a/src/housecarl-core/SkyPatcherDiscovery.cs
+++ b/src/housecarl-core/SkyPatcherDiscovery.cs
@@ -174,15 +174,13 @@ public static class SkyPatcherDiscovery
     }
 
     /// <summary>The plugin a filename gates on: 'Skyrim.esm.ini' → "Skyrim.esm"; 'myEdits.ini' → null.
-    /// The gate is the ini-stripped basename ending in a plugin extension (grammar §2).</summary>
+    /// The gate is the ini-stripped basename ending in a plugin extension (grammar §2; the ONE
+    /// extension list — <see cref="PluginFile.Extensions"/>).</summary>
     public static string? GatePluginOf(string relPath)
     {
         var stem = Path.GetFileNameWithoutExtension(relPath);   // strips the '.ini'
         var ext = Path.GetExtension(stem);
-        return ext.Equals(".esp", StringComparison.OrdinalIgnoreCase)
-            || ext.Equals(".esm", StringComparison.OrdinalIgnoreCase)
-            || ext.Equals(".esl", StringComparison.OrdinalIgnoreCase)
-            ? stem : null;
+        return PluginFile.Extensions.Any(e => ext.Equals(e, StringComparison.OrdinalIgnoreCase)) ? stem : null;
     }
 
     /// <summary>The ordered, game-visible line union for one folder — what the overlay replays. Only

--- a/src/housecarl-core/SkyPatcherDiscovery.cs
+++ b/src/housecarl-core/SkyPatcherDiscovery.cs
@@ -60,12 +60,40 @@ public static class SkyPatcherDiscovery
         IReadOnlyList<string> Notes,
         bool ReadIncomplete);
 
+    /// <summary>Per-file INI parse cache — the same cheap-mtime freshness discipline the rest of
+    /// houseCARL uses. Keyed on the winning loose file's full path; an entry is fresh while its
+    /// (mtime, length) pair matches, so an edited/replaced INI re-reads on the next scan and an
+    /// untouched layer costs zero re-parses per post-state call. Thread-safe (a post-state call runs
+    /// outside the service gate). Entries for deleted files just stop being hit — bounded by the
+    /// layer's INI count.</summary>
+    public sealed class ParseCache
+    {
+        readonly object _lock = new();
+        readonly Dictionary<string, (DateTime MtimeUtc, long Length, IReadOnlyList<SkyPatcherLine> Lines)> _byPath = new(StringComparer.OrdinalIgnoreCase);
+
+        internal IReadOnlyList<SkyPatcherLine> GetOrParse(string path)
+        {
+            var fi = new FileInfo(path);
+            var mtime = fi.LastWriteTimeUtc;
+            var length = fi.Length;
+            lock (_lock)
+                if (_byPath.TryGetValue(path, out var hit) && hit.MtimeUtc == mtime && hit.Length == length)
+                    return hit.Lines;
+            // (If the file changes between the stamp and the read, the stale content is keyed under the
+            //  OLD stamp and the next call's fresh stamp misses it — self-healing, never wedged.)
+            var lines = SkyPatcherParse.ParseFile(File.ReadAllText(path));
+            lock (_lock) _byPath[path] = (mtime, length, lines);
+            return lines;
+        }
+    }
+
     /// <summary>
     /// Scan the SkyPatcher layer off one pinned asset view. <paramref name="pluginPresent"/> answers
     /// the filename gate (plugin filename incl. extension, case-insensitive). Pure read; the view is
     /// handle-free, so this can run outside the service gate like the SKSE inventory does.
+    /// <paramref name="cache"/> (optional) skips the read+parse for INIs unchanged since the last scan.
     /// </summary>
-    public static LayerScan Scan(AssetResolver.AssetView view, SkyPatcherCatalog catalog, Func<string, bool> pluginPresent)
+    public static LayerScan Scan(AssetResolver.AssetView view, SkyPatcherCatalog catalog, Func<string, bool> pluginPresent, ParseCache? cache = null)
     {
         var notes = new List<string>();
         var byFolder = new Dictionary<string, List<IniFile>>(StringComparer.OrdinalIgnoreCase);
@@ -104,7 +132,12 @@ public static class SkyPatcherDiscovery
                 if (gate is not null && !pluginPresent(gate))
                     notApplied = $"filename-gated on plugin '{gate}', which is not in the active load order";
 
-                try { lines = SkyPatcherParse.ParseFile(File.ReadAllText(winner.LooseFilePath!)); }
+                try
+                {
+                    lines = cache is null
+                        ? SkyPatcherParse.ParseFile(File.ReadAllText(winner.LooseFilePath!))
+                        : cache.GetOrParse(winner.LooseFilePath!);
+                }
                 catch (Exception ex)
                 {
                     notApplied ??= $"winning copy could not be read: {ex.Message}";

--- a/src/housecarl-core/SkyPatcherFieldMap.cs
+++ b/src/housecarl-core/SkyPatcherFieldMap.cs
@@ -69,7 +69,7 @@ public sealed class SkyPatcherFieldMap
 
     /// <summary>Load the embedded field map (memoized). Throws loudly on a missing/malformed resource —
     /// a map that silently loaded empty would flag every op unmapped (a Q3 silent-degrade).</summary>
-    public static SkyPatcherFieldMap Load() => _cached ??= LoadFrom(ReadEmbeddedJson());
+    public static SkyPatcherFieldMap Load() => _cached ??= LoadFrom(EmbeddedJson.Read("skypatcher-fieldmap.json", "SkyPatcher field map"));
 
     /// <summary>Parse a field map from JSON text (also the guard's entry point for a fixture).</summary>
     public static SkyPatcherFieldMap LoadFrom(string json)
@@ -79,16 +79,6 @@ public sealed class SkyPatcherFieldMap
         foreach (var el in doc.RootElement.EnumerateArray())
             records.Add(ParseRecord(el));
         return new SkyPatcherFieldMap(records);
-    }
-
-    static string ReadEmbeddedJson()
-    {
-        var asm = typeof(SkyPatcherFieldMap).Assembly;
-        var name = asm.GetManifestResourceNames().FirstOrDefault(n => n.EndsWith("skypatcher-fieldmap.json", StringComparison.OrdinalIgnoreCase))
-            ?? throw new InvalidOperationException("SkyPatcher field map resource 'skypatcher-fieldmap.json' is not embedded in housecarl-core.");
-        using var s = asm.GetManifestResourceStream(name)!;
-        using var r = new StreamReader(s);
-        return r.ReadToEnd();
     }
 
     static RecordMap ParseRecord(JsonElement el)

--- a/src/housecarl-core/SkyPatcherOverlay.cs
+++ b/src/housecarl-core/SkyPatcherOverlay.cs
@@ -926,12 +926,7 @@ public static class SkyPatcherOverlay
 
     // ---- record-local reads for filters --------------------------------------------------------------
 
-    static IReadOnlyList<FormKey>? RecordKeywords(object record)
-    {
-        var p = record.GetType().GetProperty("Keywords");
-        if (p is null) return null;
-        return FormLinkList(record, new[] { "Keywords" });
-    }
+    static IReadOnlyList<FormKey>? RecordKeywords(object record) => ReadEngine.KeywordKeys(record);
 
     static string? RecordName(object record)
     {

--- a/src/housecarl-core/SkyPatcherOverlay.cs
+++ b/src/housecarl-core/SkyPatcherOverlay.cs
@@ -380,23 +380,20 @@ public static class SkyPatcherOverlay
             }
             case SkyPatcherOpSemantic.VecComponent:
             {
+                // One component of a P3* point. ReadEngine renders a point as its ctor-order components
+                // ("x,y,z") and WriteEngine coerces the same form back, so the edit is a token splice +
+                // an engine Set of the whole value — no hand-rolled struct rebuild to drift.
                 var raw = seg.Values.Count > 0 ? seg.Values[0].Raw : "";
-                var (parent, leaf) = Navigate(record, segs);
-                var vec = leaf.GetValue(parent) ?? throw new InvalidOperationException($"'{map.Path}' is absent");
+                if (!double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out _))
+                { warnings.Add($"{where}: '{seg.Key}={raw}' — not a number; skipped."); return; }
                 var comp = map.Component ?? throw new InvalidOperationException($"'{seg.Key}' mapping has no component");
-                var names = new[] { "X", "Y", "Z" };
-                var before = VecToken(vec);
-                var t = vec.GetType();
-                object boxed = vec;
-                var prop = t.GetProperty(names[comp]) ?? throw new InvalidOperationException($"{t.Name} has no {names[comp]}");
-                var newComp = Convert.ChangeType(double.Parse(raw, CultureInfo.InvariantCulture), prop.PropertyType.IsEnum ? typeof(int) : prop.PropertyType, CultureInfo.InvariantCulture);
-                // P3Int16/P3Float are immutable structs — rebuild via the (x, y, z) ctor with one component swapped.
-                var comps = names.Select(n => t.GetProperty(n)!.GetValue(boxed)!).ToArray();
-                comps[comp] = newComp;
-                var ctor = t.GetConstructors().FirstOrDefault(c => c.GetParameters().Length == 3)
-                    ?? throw new InvalidOperationException($"{t.Name} has no 3-arg constructor");
-                leaf.SetValue(parent, ctor.Invoke(comps));
-                applied.Add(new SkyPatcherAppliedOp(line.File, line.LineNumber, seg.Key, raw, $"{map.Path}.{names[comp]}", before, VecToken(leaf.GetValue(parent)!), null));
+                var before = LeafToken(record, segs);
+                var parts = before?.Split(',');
+                if (parts is null || comp >= parts.Length)
+                { warnings.Add($"{where}: '{seg.Key}' — '{map.Path}' is absent or not a {comp + 1}+-component point ('{before ?? "<unreadable>"}'); skipped."); return; }
+                parts[comp] = raw.Trim();
+                WriteEngine.ApplyVerb(record, new WriteRequest { RecordType = fieldMap.RecordType, Path = segs, Verb = "Set", Value = string.Join(",", parts) });
+                applied.Add(new SkyPatcherAppliedOp(line.File, line.LineNumber, seg.Key, raw, $"{map.Path}.{"XYZ"[comp]}", before, LeafToken(record, segs), null));
                 break;
             }
             case SkyPatcherOpSemantic.ModelPath:
@@ -438,13 +435,21 @@ public static class SkyPatcherOverlay
                     { warnings.Add($"{where}: '{seg.Key}' — flag '{v.Raw}' is not a {leaf.PropertyType.Name} member (no valueMap match either); that flag skipped."); continue; }
                     bits = map.Semantic == SkyPatcherOpSemantic.FlagsSet ? bits | bit : bits & ~bit;
                 }
-                leaf.SetValue(parent, Enum.ToObject(leaf.PropertyType, bits));
+                SetEnumBits(record, fieldMap, segs, bits);
                 applied.Add(new SkyPatcherAppliedOp(line.File, line.LineNumber, seg.Key, seg.RawValue ?? "", map.Path, before, LeafToken(record, segs), null));
                 break;
             }
             case SkyPatcherOpSemantic.FlagBool:
             {
                 var raw = seg.Values.Count > 0 ? seg.Values[0].Raw : "";
+                // 'none' is a LEGAL token on these ops (grammar: setEssential/setProtected/… — "none = leave
+                // unchanged"): a visible no-op, not the "not a boolean" warning it used to draw.
+                if (raw.Equals("none", StringComparison.OrdinalIgnoreCase))
+                {
+                    var cur = LeafToken(record, segs);
+                    applied.Add(new SkyPatcherAppliedOp(line.File, line.LineNumber, seg.Key, raw, map.Path, cur, cur, "none — leave unchanged"));
+                    return;
+                }
                 bool on = raw.Equals("true", StringComparison.OrdinalIgnoreCase) || raw.Equals("yes", StringComparison.OrdinalIgnoreCase) || raw == "1";
                 bool off = raw.Equals("false", StringComparison.OrdinalIgnoreCase) || raw.Equals("no", StringComparison.OrdinalIgnoreCase) || raw == "0";
                 if (!on && !off) { warnings.Add($"{where}: '{seg.Key}={raw}' — not a boolean; skipped."); return; }
@@ -455,7 +460,7 @@ public static class SkyPatcherOverlay
                 var before = LeafToken(record, segs);
                 ulong bits = Convert.ToUInt64(leaf.GetValue(parent) ?? 0UL, CultureInfo.InvariantCulture);
                 bits = on ? bits | bit : bits & ~bit;
-                leaf.SetValue(parent, Enum.ToObject(leaf.PropertyType, bits));
+                SetEnumBits(record, fieldMap, segs, bits);
                 applied.Add(new SkyPatcherAppliedOp(line.File, line.LineNumber, seg.Key, raw, $"{map.Path} ({flagToken})", before, LeafToken(record, segs), map.Note));
                 break;
             }
@@ -494,7 +499,7 @@ public static class SkyPatcherOverlay
                     var a = ResolveFormToken(aTok, map.FormType, resolver);
                     var b = ResolveFormToken(bTok, map.FormType, resolver);
                     if (a is null || b is null) { warnings.Add($"{where}: '{seg.Key}={v.Raw}' — form(s) not resolvable; skipped."); continue; }
-                    int n = ReplaceInFormLinkList(record, segs, a.Value, b.Value);
+                    int n = ReplaceInFormLinkList(record, fieldMap.RecordType, segs, a.Value, b.Value);
                     applied.Add(new SkyPatcherAppliedOp(line.File, line.LineNumber, seg.Key, v.Raw, map.Path, null, null,
                         n > 0 ? $"replaced {n} occurrence(s)" : "form A not present — no change"));
                 }
@@ -508,7 +513,9 @@ public static class SkyPatcherOverlay
                 var (parent, leaf) = Navigate(record, segs);
                 var coll = leaf.GetValue(parent);
                 int had = coll is null ? 0 : CountOf(coll);
-                if (coll is not null) coll.GetType().GetMethod("Clear", Type.EmptyTypes)?.Invoke(coll, null);
+                // Clear = the engine's ReplaceAll with no values (same clear the verb surface exposes).
+                if (coll is not null)
+                    WriteEngine.ApplyVerb(record, new WriteRequest { RecordType = fieldMap.RecordType, Path = segs, Verb = "ReplaceAll" });
                 applied.Add(new SkyPatcherAppliedOp(line.File, line.LineNumber, seg.Key, raw, map.Path, $"{had} entr(ies)", "0 entries", "cleared"));
                 break;
             }
@@ -621,7 +628,7 @@ public static class SkyPatcherOverlay
                     }
                     var k = ResolveFormToken(args[0], map.FormType, resolver);
                     if (k is null) { warnings.Add($"{where}: '{seg.Key}={v.Raw}' — form not resolvable; skipped."); continue; }
-                    int n = RemoveEntriesByKey(record, segs, el, k.Value);
+                    int n = RemoveEntriesByKey(record, fieldMap.RecordType, segs, el, k.Value);
                     applied.Add(new SkyPatcherAppliedOp(line.File, line.LineNumber, seg.Key, v.Raw, map.Path, null, null,
                         n > 0 ? $"removed {n} entr(ies)" : "no matching entry — no change"));
                     break;
@@ -632,7 +639,7 @@ public static class SkyPatcherOverlay
                     if (k is null || args.Count < 2 || !int.TryParse(args[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var dec))
                     { warnings.Add($"{where}: '{seg.Key}={v.Raw}' — expected form~count; skipped."); continue; }
                     var countPath = el.CountPath ?? throw new InvalidOperationException($"'{seg.Key}' element has no countPath");
-                    int touched = AdjustEntryCounts(record, segs, el, k.Value, countPath, c => c - dec);
+                    int touched = AdjustEntryCounts(record, fieldMap.RecordType, segs, el, k.Value, countPath, c => c - dec);
                     applied.Add(new SkyPatcherAppliedOp(line.File, line.LineNumber, seg.Key, v.Raw, map.Path, null, null,
                         touched > 0 ? $"count reduced by {dec} on {touched} entr(ies) (entries at ≤0 removed)" : "no matching entry — no change"));
                     break;
@@ -670,7 +677,7 @@ public static class SkyPatcherOverlay
                 {
                     var kw = ResolveFormToken(args[0], "Keyword", resolver);
                     if (kw is null) { warnings.Add($"{where}: '{seg.Key}={v.Raw}' — keyword not resolvable; skipped."); continue; }
-                    var (removed, unresolved) = RemoveEntriesByTargetKeyword(record, segs, el, kw.Value, resolver);
+                    var (removed, unresolved) = RemoveEntriesByTargetKeyword(record, fieldMap.RecordType, segs, el, kw.Value, resolver);
                     if (unresolved > 0)
                         warnings.Add($"{where}: '{seg.Key}={v.Raw}' — {unresolved} entr(ies) whose target record could not be resolved were LEFT IN PLACE (never removed on a guess).");
                     applied.Add(new SkyPatcherAppliedOp(line.File, line.LineNumber, seg.Key, v.Raw, map.Path, null, null,
@@ -693,9 +700,10 @@ public static class SkyPatcherOverlay
         return r.HasValue ? r.Token : null;
     }
 
-    /// <summary>Navigate to the leaf's PARENT + PropertyInfo (read-write reflection access for the ops
-    /// the verb engine doesn't cover: flags bit math, vector components, direct list surgery). Rides
-    /// the same ParseSegment/ResolveProperty/StepIntoElement walk as the engines.</summary>
+    /// <summary>Navigate to the leaf's PARENT + PropertyInfo — READ access only (raw enum bits for the
+    /// flag math, live collection handles for entry matching); every MUTATION goes back through
+    /// <see cref="WriteEngine.ApplyVerb"/>. Rides the same ParseSegment/ResolveProperty/StepIntoElement
+    /// walk as the engines.</summary>
     static (object parent, PropertyInfo leaf) Navigate(object record, string[] segs)
     {
         object current = record;
@@ -713,12 +721,11 @@ public static class SkyPatcherOverlay
         return (current, leaf);
     }
 
-    static string VecToken(object vec)
-    {
-        var t = vec.GetType();
-        string P(string n) => Convert.ToString(t.GetProperty(n)?.GetValue(vec), CultureInfo.InvariantCulture) ?? "?";
-        return $"({P("X")}, {P("Y")}, {P("Z")})";
-    }
+    /// <summary>Write a computed flag-bit value back through the verb engine: an enum leaf Set with the
+    /// numeric token (Enum.Parse accepts it) — the ONE mutation path, same coercion as every other Set.</summary>
+    static void SetEnumBits(object record, RecordMap fieldMap, string[] segs, ulong bits)
+        => WriteEngine.ApplyVerb(record, new WriteRequest
+        { RecordType = fieldMap.RecordType, Path = segs, Verb = "Set", Value = bits.ToString(CultureInfo.InvariantCulture) });
 
     /// <summary>Format a computed stateful result for the leaf's actual type: integral leaves round to
     /// nearest (how the DLL lands fractional mults on int fields is a Wave-1 EMPIRICAL item — round is
@@ -757,7 +764,9 @@ public static class SkyPatcherOverlay
         return resolver.ResolveEditorId(token, formType);
     }
 
-    static bool LooksLikeForm(string raw) => raw.Contains('|');
+    /// <summary>A sub-arg that IS the unambiguous <c>Plugin|FormID</c> address form — the ONE recognizer
+    /// (<see cref="SkyPatcherParse.TryParseAddress"/>), not a '|' sniff that also matched form=count packs.</summary>
+    static bool LooksLikeForm(string raw) => SkyPatcherParse.TryParseAddress(raw) is { IsFormId: true };
 
     static string FormHint(SkyPatcherValue v, OpMap map)
         => v.Address is { IsFormId: true }
@@ -809,23 +818,25 @@ public static class SkyPatcherOverlay
         return keys;
     }
 
-    static int ReplaceInFormLinkList(object record, string[] segs, FormKey a, FormKey b)
+    static int ReplaceInFormLinkList(object record, string recordType, string[] segs, FormKey a, FormKey b)
     {
-        var list = ListAt(record, segs);
-        if (list is null) return 0;
+        var keys = FormLinkList(record, segs);
+        if (keys is null) return 0;
         int n = 0;
-        for (int i = 0; i < list.Count; i++)
+        for (int i = 0; i < keys.Count; i++)
         {
-            var item = list[i];
-            if (item?.GetType().GetProperty("FormKey")?.GetValue(item) is FormKey fk && fk == a)
-            {
-                // FormLink<T> is immutable — build a new link of the same concrete type pointing at b.
-                var made = Activator.CreateInstance(item.GetType(), b);
-                list[i] = made; n++;
-            }
+            if (keys[i] != a) continue;
+            // Re-point the element through the engine's SetAtIndex — same formlink coercion as every Set.
+            WriteEngine.ApplyVerb(record, new WriteRequest { RecordType = recordType, Path = segs, Verb = "SetAtIndex", Key = i.ToString(CultureInfo.InvariantCulture), Value = b.ToString() });
+            n++;
         }
         return n;
     }
+
+    /// <summary>Remove one list element by index through the engine (RemoveAt) — the ONE list-surgery path.</summary>
+    static void RemoveListElementAt(object record, string recordType, string[] segs, int index)
+        => WriteEngine.ApplyVerb(record, new WriteRequest
+        { RecordType = recordType, Path = segs, Verb = "Remove", Key = index.ToString(CultureInfo.InvariantCulture) });
 
     static string? EntryKeyToken(object entry, ElementMap el)
         => el.KeyPath is null ? null : LeafToken(entry, SplitPath(el.KeyPath));
@@ -842,12 +853,11 @@ public static class SkyPatcherOverlay
         return hits;
     }
 
-    static int RemoveEntriesByKey(object record, string[] segs, ElementMap el, FormKey key)
+    static int RemoveEntriesByKey(object record, string recordType, string[] segs, ElementMap el, FormKey key)
     {
-        var list = ListAt(record, segs);
-        if (list is null) return 0;
+        if (ListAt(record, segs) is null) return 0;
         var idx = EntryIndicesByKey(record, segs, el, key);
-        for (int i = idx.Count - 1; i >= 0; i--) list.RemoveAt(idx[i]);
+        for (int i = idx.Count - 1; i >= 0; i--) RemoveListElementAt(record, recordType, segs, idx[i]);
         return idx.Count;
     }
 
@@ -861,7 +871,7 @@ public static class SkyPatcherOverlay
         return idx.Count;
     }
 
-    static int AdjustEntryCounts(object record, string[] segs, ElementMap el, FormKey key, string countPath, Func<int, int> f)
+    static int AdjustEntryCounts(object record, string recordType, string[] segs, ElementMap el, FormKey key, string countPath, Func<int, int> f)
     {
         var list = ListAt(record, segs);
         if (list is null) return 0;
@@ -873,7 +883,7 @@ public static class SkyPatcherOverlay
             var tok = LeafToken(entry, cSegs);
             if (tok is null || !int.TryParse(tok, NumberStyles.Integer, CultureInfo.InvariantCulture, out var c)) continue;
             int now = f(c);
-            if (now <= 0) list.RemoveAt(i);
+            if (now <= 0) RemoveListElementAt(record, recordType, segs, i);
             else WriteEngine.ApplyVerb(entry, new WriteRequest { RecordType = el.Type, Path = cSegs, Verb = "Set", Value = now.ToString(CultureInfo.InvariantCulture) });
         }
         return idx.Count;
@@ -898,7 +908,7 @@ public static class SkyPatcherOverlay
         return touched;
     }
 
-    static (int removed, int unresolved) RemoveEntriesByTargetKeyword(object record, string[] segs, ElementMap el, FormKey keyword, IFormResolver resolver)
+    static (int removed, int unresolved) RemoveEntriesByTargetKeyword(object record, string recordType, string[] segs, ElementMap el, FormKey keyword, IFormResolver resolver)
     {
         var list = ListAt(record, segs);
         if (list is null || el.KeyPath is null) return (0, 0);
@@ -909,7 +919,7 @@ public static class SkyPatcherOverlay
             if (tok is null || !FormKey.TryFactory(tok, out var target)) { unresolved++; continue; }
             var kws = resolver.KeywordsOf(target);
             if (kws is null) { unresolved++; continue; }
-            if (kws.Contains(keyword)) { list.RemoveAt(i); removed++; }
+            if (kws.Contains(keyword)) { RemoveListElementAt(record, recordType, segs, i); removed++; }
         }
         return (removed, unresolved);
     }

--- a/src/housecarl-core/SkyPatcherOverlay.cs
+++ b/src/housecarl-core/SkyPatcherOverlay.cs
@@ -241,7 +241,7 @@ public static class SkyPatcherOverlay
             {
                 case "filterByKeywords":
                 {
-                    var mine = RecordKeywords(record);
+                    var mine = ReadEngine.KeywordKeys(record);
                     if (mine is null) return FilterVerdict.Unresolved;   // type has no keyword list we can read
                     var wanted = new List<FormKey>();
                     int unresolved = 0;
@@ -384,14 +384,24 @@ public static class SkyPatcherOverlay
                 // ("x,y,z") and WriteEngine coerces the same form back, so the edit is a token splice +
                 // an engine Set of the whole value — no hand-rolled struct rebuild to drift.
                 var raw = seg.Values.Count > 0 ? seg.Values[0].Raw : "";
-                if (!double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out _))
+                if (!double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var num))
                 { warnings.Add($"{where}: '{seg.Key}={raw}' — not a number; skipped."); return; }
                 var comp = map.Component ?? throw new InvalidOperationException($"'{seg.Key}' mapping has no component");
                 var before = LeafToken(record, segs);
                 var parts = before?.Split(',');
                 if (parts is null || comp >= parts.Length)
                 { warnings.Add($"{where}: '{seg.Key}' — '{map.Path}' is absent or not a {comp + 1}+-component point ('{before ?? "<unreadable>"}'); skipped."); return; }
-                parts[comp] = raw.Trim();
+                // An INTEGRAL component (P3Int16 — ObjectBounds) rounds fractional input away-from-zero
+                // — the same declared assumption FormatNumericFor carries (Wave-1 empirical item); the
+                // engine's per-component Parse would otherwise reject '3.5' where the old rebuild rounded
+                // it (review fold). The component's ctor-parameter type is the recognizer, not a type list.
+                var leafType = Navigate(record, segs).leaf.PropertyType;
+                var ptType = Nullable.GetUnderlyingType(leafType) ?? leafType;
+                var ctorPs = ptType.GetConstructors().FirstOrDefault(c => c.GetParameters().Length == parts.Length)?.GetParameters();
+                bool integral = ctorPs is not null && comp < ctorPs.Length && IsIntegral(ctorPs[comp].ParameterType);
+                parts[comp] = integral
+                    ? Math.Round(num, MidpointRounding.AwayFromZero).ToString(CultureInfo.InvariantCulture)
+                    : raw.Trim();
                 WriteEngine.ApplyVerb(record, new WriteRequest { RecordType = fieldMap.RecordType, Path = segs, Verb = "Set", Value = string.Join(",", parts) });
                 applied.Add(new SkyPatcherAppliedOp(line.File, line.LineNumber, seg.Key, raw, $"{map.Path}.{"XYZ"[comp]}", before, LeafToken(record, segs), null));
                 break;
@@ -733,12 +743,18 @@ public static class SkyPatcherOverlay
     static string FormatNumericFor(object record, string[] segs, double result)
     {
         var (parent, leaf) = Navigate(record, segs);
-        var t = Nullable.GetUnderlyingType(leaf.PropertyType) ?? leaf.PropertyType;
-        bool integral = t == typeof(byte) || t == typeof(sbyte) || t == typeof(short) || t == typeof(ushort)
-                     || t == typeof(int) || t == typeof(uint) || t == typeof(long) || t == typeof(ulong);
-        return integral
+        return IsIntegral(leaf.PropertyType)
             ? Math.Round(result, MidpointRounding.AwayFromZero).ToString(CultureInfo.InvariantCulture)
             : result.ToString("R", CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>An integral numeric leaf/component (nullable unwrapped) — the ONE recognizer behind the
+    /// declared fractional-rounding assumption (FormatNumericFor + the VecComponent splice).</summary>
+    static bool IsIntegral(Type type)
+    {
+        var t = Nullable.GetUnderlyingType(type) ?? type;
+        return t == typeof(byte) || t == typeof(sbyte) || t == typeof(short) || t == typeof(ushort)
+            || t == typeof(int) || t == typeof(uint) || t == typeof(long) || t == typeof(ulong);
     }
 
     static bool TryParseEnumMember(Type enumType, string token, out ulong bits)
@@ -803,19 +819,14 @@ public static class SkyPatcherOverlay
         return leaf.GetValue(parent) as System.Collections.IList;
     }
 
-    /// <summary>A formlink list's FormKeys (null when the path isn't a formlink list / list is absent).</summary>
+    /// <summary>A formlink list's FormKeys (null when the path isn't a formlink list; absent reads as
+    /// empty). The walk itself is the shared <see cref="ReadEngine.FormLinkKeys"/> (review fold — two
+    /// link-reading strategies in one assembly was the drift this cleanup exists to kill).</summary>
     static List<FormKey>? FormLinkList(object record, string[] segs)
     {
         var (parent, leaf) = Navigate(record, segs);
         if (leaf.GetValue(parent) is not System.Collections.IEnumerable list) return new List<FormKey>();   // absent list reads as empty
-        var keys = new List<FormKey>();
-        foreach (var item in list)
-        {
-            var fkProp = item?.GetType().GetProperty("FormKey");
-            if (fkProp?.GetValue(item) is FormKey fk) keys.Add(fk);
-            else return null;
-        }
-        return keys;
+        return ReadEngine.FormLinkKeys(list);
     }
 
     static int ReplaceInFormLinkList(object record, string recordType, string[] segs, FormKey a, FormKey b)
@@ -855,8 +866,7 @@ public static class SkyPatcherOverlay
 
     static int RemoveEntriesByKey(object record, string recordType, string[] segs, ElementMap el, FormKey key)
     {
-        if (ListAt(record, segs) is null) return 0;
-        var idx = EntryIndicesByKey(record, segs, el, key);
+        var idx = EntryIndicesByKey(record, segs, el, key);   // absent/null list yields no indices — no separate guard walk
         for (int i = idx.Count - 1; i >= 0; i--) RemoveListElementAt(record, recordType, segs, idx[i]);
         return idx.Count;
     }
@@ -925,8 +935,6 @@ public static class SkyPatcherOverlay
     }
 
     // ---- record-local reads for filters --------------------------------------------------------------
-
-    static IReadOnlyList<FormKey>? RecordKeywords(object record) => ReadEngine.KeywordKeys(record);
 
     static string? RecordName(object record)
     {

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -434,19 +434,15 @@ public static class WriteEngine
         foreach (var p in paths)
             Console.WriteLine($"  {p} = {ReadLeafDisplay(target, p.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries), null)}");
 
-        var kwProp = ResolveProperty(target.GetType(), "Keywords");
-        if (kwProp?.GetValue(target) is System.Collections.IEnumerable kws)
+        if (ReadEngine.KeywordKeys(target) is { } kwKeys)   // the ONE keyword walk (shared)
         {
             var map = new Dictionary<FormKey, string?>();
             foreach (var k in sourceMod.Keywords) map[k.FormKey] = k.EditorID;
             Console.WriteLine("  Keywords:");
-            int i = 0;
-            foreach (var e in kws)
+            for (int i = 0; i < kwKeys.Count; i++)
             {
-                var fk = (e as IFormLinkGetter)?.FormKey;
-                var edid = fk is { } v && map.TryGetValue(v, out var n) ? (n ?? "(no edid)") : "(other master / unresolved)";
-                Console.WriteLine($"    [{i}] {fk}  {edid}");
-                i++;
+                var edid = map.TryGetValue(kwKeys[i], out var n) ? (n ?? "(no edid)") : "(other master / unresolved)";
+                Console.WriteLine($"    [{i}] {kwKeys[i]}  {edid}");
             }
         }
         return 0;

--- a/src/housecarl-generator/SkyPatcherHarness.cs
+++ b/src/housecarl-generator/SkyPatcherHarness.cs
@@ -32,6 +32,25 @@ public static class SkyPatcherHarness
         try { fk = FormKey.Factory(formid.Trim()); }
         catch (Exception ex) { Console.Error.WriteLine($"error: bad FormID '{formid}': {ex.Message}"); return 1; }
 
+        // corpus.json is GENERATED, not tracked — run from outside the repo root the default relative
+        // CorpusPath resolves to nothing and the service's rulebook/type-catalog loads crash unnamed.
+        // Bootstrap the FloiFieldsProbe way: generate into a unique temp dir, cleaned on exit.
+        string? tmp = null;
+        if (!File.Exists(CorpusRulebook.CorpusPath))
+        {
+            tmp = Path.Combine(Path.GetTempPath(), "hc-sp-harness-corpus-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tmp);
+            Console.WriteLine($"corpus.json absent — generating into {tmp} (running outside the repo root)…");
+            var gen = CorpusGenerator.GenerateAll(Path.Combine(tmp, "generated"), Path.Combine(tmp, "refs"));
+            if (gen != 0) { Console.Error.WriteLine("error: corpus generation failed"); return gen; }
+            CorpusRulebook.CorpusPath = Path.Combine(tmp, "generated", "corpus.json");
+        }
+        try { return Run(fk, instance); }
+        finally { if (tmp is not null) { try { Directory.Delete(tmp, recursive: true); } catch { /* best-effort */ } } }
+    }
+
+    static int Run(FormKey fk, string instance)
+    {
         // A throwaway user-config store (the harness never writes tool paths); the service reads the
         // instance exactly as the product does.
         var store = new UserConfigStore(Path.Combine(Path.GetTempPath(), $"hc-sp-harness-{Guid.NewGuid():N}.json"));

--- a/src/housecarl-generator/SkyPatcherOverlayProbe.cs
+++ b/src/housecarl-generator/SkyPatcherOverlayProbe.cs
@@ -180,6 +180,7 @@ public static class SkyPatcherOverlayProbe
 
         failures += NpcEntryOpsArm(catalog, fieldMap, mod);
         failures += LeveledListScopeArm(catalog, fieldMap, mod);
+        failures += FormListArm(catalog, fieldMap, mod);
 
         return Done(failures);
     }
@@ -202,11 +203,14 @@ public static class SkyPatcherOverlayProbe
         var itemC = new FormKey(new ModKey("HcItm", ModType.Plugin), 0x902);
         var facA = new FormKey(new ModKey("HcFac", ModType.Plugin), 0xA01);
 
+        var itemD = new FormKey(new ModKey("HcItm", ModType.Plugin), 0x903);
+
         var npc = mod.Npcs.AddNew();
         npc.EditorID = "HcTestNpc";
         npc.Items = new()
         {
             new ContainerEntry { Item = new ContainerItem { Item = itemA.ToLink<IItemGetter>(), Count = 2 } },
+            new ContainerEntry { Item = new ContainerItem { Item = itemD.ToLink<IItemGetter>(), Count = 1 } },
         };
 
         var me = $"HcSpOv.esp|{npc.FormKey.ID:X}";
@@ -223,6 +227,9 @@ public static class SkyPatcherOverlayProbe
             L("z.ini", 2, $"filterByNpcs={me}:objectsToReplace=HcItm.esp|900~HcItm.esp|902"),    // retarget A → C
             L("z.ini", 3, $"filterByNpcs={me}:objectsToRemove=HcItm.esp|902~5"),                 // QUALIFIED remove ⇒ loud skip
             L("z.ini", 4, $"filterByNpcs={me}:setEssential=true"),                               // flagBool
+            L("z.ini", 5, $"filterByNpcs={me}:removeInventoryObjectsByCount=HcItm.esp|903~2"),   // count 1−2 ≤ 0 ⇒ ENTRY REMOVED (engine RemoveAt path)
+            L("z.ini", 6, $"filterByNpcs={me}:setFlags=unique"),                                 // flagsSet (multi-token bit math → engine Set)
+            L("z.ini", 7, $"filterByNpcs={me}:setProtected=none"),                               // legal 'none' ⇒ VISIBLE leave-unchanged no-op
         };
         var r = SkyPatcherOverlay.Apply(npc, npc.FormKey, npc.EditorID, catalog, npcCat, npcMap, lines, resolver);
 
@@ -245,6 +252,63 @@ public static class SkyPatcherOverlayProbe
             string.Join(" | ", npc.Factions.Select(f => $"{f.Faction.FormKey}@{f.Rank}")));
         failures += Check("flagBool set (setEssential=true)",
             npc.Configuration.Flags.HasFlag(NpcConfiguration.Flag.Essential));
+        failures += Check("removeByCount to ≤0 REMOVES the entry (engine RemoveAt path)",
+            !entries.Any(e => e.fk == itemD),
+            string.Join(" | ", entries.Select(e => $"{e.fk}×{e.count}")));
+        failures += Check("flagsSet lands via the engine (setFlags=unique; essential kept)",
+            npc.Configuration.Flags.HasFlag(NpcConfiguration.Flag.Unique)
+            && npc.Configuration.Flags.HasFlag(NpcConfiguration.Flag.Essential),
+            npc.Configuration.Flags.ToString());
+        failures += Check("'none' on a flagBool is a VISIBLE leave-unchanged no-op, not a warning",
+            !npc.Configuration.Flags.HasFlag(NpcConfiguration.Flag.Protected)
+            && r.Applied.Any(a => a.Op == "setProtected" && a.Note is { } n && n.Contains("leave unchanged"))
+            && !r.Warnings.Any(w => w.Contains("setProtected")),
+            string.Join(" ; ", r.Warnings));
+        return failures;
+    }
+
+    /// <summary>The plain-formlink-list surgery the NPC arm can't reach: replaceForm re-points elements
+    /// through the engine's SetAtIndex, clearList empties through the engine's ReplaceAll (review fold —
+    /// these paths were re-plumbed onto WriteEngine and previously had no overlay-level pin).</summary>
+    static int FormListArm(SkyPatcherCatalog catalog, SkyPatcherFieldMap fieldMap, SkyrimMod mod)
+    {
+        Console.WriteLine("  --- formList arm (replaceForm → SetAtIndex, clearList → ReplaceAll) ---");
+        int failures = 0;
+        var flCat = catalog.ForSubfolder("formList")!;
+        var flMap = fieldMap.For("formList", "FormList");
+        failures += Check("formList field map present", flMap is not null);
+        if (flMap is null) return failures;
+
+        var x = new FormKey(new ModKey("HcItm", ModType.Plugin), 0xB01);
+        var y = new FormKey(new ModKey("HcItm", ModType.Plugin), 0xB02);
+        var z = new FormKey(new ModKey("HcItm", ModType.Plugin), 0xB03);
+        var resolver = new StubResolver();
+        SkyPatcherOverlay.OrderedLine L(int n, string text) => new("fl.ini", n, SkyPatcherParse.ParseLine(text));
+
+        // replaceForm: X,Y,X → Z,Y,Z ('='-packed pair per the formList docs) — every X re-pointed in place.
+        var fl = mod.FormLists.AddNew();
+        fl.Items.Add(x.ToLink<ISkyrimMajorRecordGetter>());
+        fl.Items.Add(y.ToLink<ISkyrimMajorRecordGetter>());
+        fl.Items.Add(x.ToLink<ISkyrimMajorRecordGetter>());
+        var me1 = $"HcSpOv.esp|{fl.FormKey.ID:X}";
+        var r1 = SkyPatcherOverlay.Apply(fl, fl.FormKey, null, catalog, flCat, flMap, new[]
+        { L(1, $"filterByFormLists={me1}:formsToReplace=HcItm.esp|B01=HcItm.esp|B03") }, resolver);
+        failures += Check("replaceForm re-points BOTH occurrences in place (X,Y,X → Z,Y,Z)",
+            fl.Items.Select(i => i.FormKey).SequenceEqual(new[] { z, y, z })
+            && r1.Applied.Any(a => a.Op == "formsToReplace" && a.Note is { } n && n.Contains("replaced 2")),
+            string.Join(",", fl.Items.Select(i => i.FormKey.ToString())));
+
+        // clearList: a populated list empties; the applied entry carries the honest before-count.
+        var fl2 = mod.FormLists.AddNew();
+        fl2.Items.Add(x.ToLink<ISkyrimMajorRecordGetter>());
+        fl2.Items.Add(y.ToLink<ISkyrimMajorRecordGetter>());
+        var me2 = $"HcSpOv.esp|{fl2.FormKey.ID:X}";
+        var r2 = SkyPatcherOverlay.Apply(fl2, fl2.FormKey, null, catalog, flCat, flMap, new[]
+        { L(1, $"filterByFormLists={me2}:clear=true") }, resolver);
+        failures += Check("clearList empties the list through the engine (2 → 0, honest before-count)",
+            fl2.Items.Count == 0
+            && r2.Applied.Any(a => a.Op == "clear" && a.Before == "2 entr(ies)" && a.Note == "cleared"),
+            $"count={fl2.Items.Count}");
         return failures;
     }
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -325,6 +325,10 @@ public sealed class LoadOrderService : IDisposable
     /// repeat post-state calls over an untouched layer skip every per-file read+parse.</summary>
     readonly SkyPatcherDiscovery.ParseCache _skyPatcherParseCache = new();
 
+    /// <summary>The in-memory scratch mod the replay copy is overridden into — never written to disk.
+    /// Named per the Housecarl* scratch-mod convention (<c>HousecarlWriteProof</c> is the sibling).</summary>
+    static readonly ModKey SkyPatcherScratchKey = new("HousecarlSkyPatcherScratch", ModType.Plugin);
+
     /// <summary>
     /// Compute one record's true post-SkyPatcher state: discover the loose SkyPatcher INI layer
     /// (<see cref="SkyPatcherDiscovery"/>), replay each applicable type folder's ordered line union onto a
@@ -372,7 +376,7 @@ public sealed class LoadOrderService : IDisposable
         // Nested-group types (CELL / REFR / INFO…) need the source link cache to rebuild their parent
         // chain — the same RecordNeedsSourceCache + LinkCacheFor idiom every write path uses (PR #165
         // review finding #1: without it, 2 of the 27 covered types threw unhandled instead of failing named).
-        var scratch = new SkyrimMod(new ModKey("HousecarlSkyPatcherScratch", ModType.Plugin), SkyrimRelease.SkyrimSE);
+        var scratch = new SkyrimMod(SkyPatcherScratchKey, SkyrimRelease.SkyrimSE);
         IMajorRecord copy;
         try
         {

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -448,11 +448,7 @@ public sealed class LoadOrderService : IDisposable
             var w = _view.ResolveWinner(record);
             if (w is null) return null;
             var rec = _view.GetRecord(_session, w.Value.WinnerPlugin, record);
-            if (rec?.GetType().GetProperty("Keywords")?.GetValue(rec) is not System.Collections.IEnumerable list) return null;
-            var keys = new List<FormKey>();
-            foreach (var item in list)
-                if (item?.GetType().GetProperty("FormKey")?.GetValue(item) is FormKey k) keys.Add(k);
-            return keys;
+            return rec is null ? null : ReadEngine.KeywordKeys(rec);   // the ONE keyword walk (shared)
         }
 
         public bool PluginPresent(string pluginName) => _view.ContainsPlugin(pluginName);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -321,6 +321,10 @@ public sealed class LoadOrderService : IDisposable
     // ---- SkyPatcher distributor Wave 1: the per-record TRUE post-SkyPatcher state (plan
     //      dev/plans/SKYPATCHER_DISTRIBUTOR_TOOL_PLAN_2026-07-08.md — reader-only scope, 2026-07-09). ----
 
+    /// <summary>Cross-call INI parse cache (mtime+length keyed — see <see cref="SkyPatcherDiscovery.ParseCache"/>):
+    /// repeat post-state calls over an untouched layer skip every per-file read+parse.</summary>
+    readonly SkyPatcherDiscovery.ParseCache _skyPatcherParseCache = new();
+
     /// <summary>
     /// Compute one record's true post-SkyPatcher state: discover the loose SkyPatcher INI layer
     /// (<see cref="SkyPatcherDiscovery"/>), replay each applicable type folder's ordered line union onto a
@@ -362,7 +366,7 @@ public sealed class LoadOrderService : IDisposable
                 $"Record type '{typeName}' is not a SkyPatcher-patchable type (or has no field map) — the SkyPatcher layer cannot touch {fk}.");
 
         var catalog = SkyPatcherCatalog.Load();
-        var scan = SkyPatcherDiscovery.Scan(assets, catalog, view.ContainsPlugin);
+        var scan = SkyPatcherDiscovery.Scan(assets, catalog, view.ContainsPlugin, _skyPatcherParseCache);
 
         // The running copy: the winner overridden into an in-memory scratch mod (never written to disk).
         // Nested-group types (CELL / REFR / INFO…) need the source link cache to rebuild their parent
@@ -408,14 +412,15 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>The live-load-order lookups the overlay needs (<see cref="SkyPatcherOverlay.IFormResolver"/>),
     /// answered off the ONE pinned record view + open session the post-state call holds. EditorID resolution
-    /// scans the requested type's winners once and memoizes per (type, editorid) — a miss is null (loud
-    /// upstream), never a guess.</summary>
+    /// sweeps the requested type's winners ONCE into an eid→FormKey table (an INI layer typically names many
+    /// EditorIDs of the same type — the old per-eid sweep walked the full order N times); a miss is null
+    /// (loud upstream), never a guess.</summary>
     sealed class SkyPatcherServiceResolver : SkyPatcherOverlay.IFormResolver
     {
         readonly LoadOrderService _svc;
         readonly LoadOrderResolver.IndexView _view;
         readonly LoadOrderResolver.OverlaySession _session;
-        readonly Dictionary<(string type, string eid), FormKey?> _eidCache = new();
+        readonly Dictionary<string, Dictionary<string, FormKey>> _eidsByType = new(StringComparer.OrdinalIgnoreCase);
 
         public SkyPatcherServiceResolver(LoadOrderService svc, LoadOrderResolver.IndexView view, LoadOrderResolver.OverlaySession session)
         { _svc = svc; _view = view; _session = session; }
@@ -423,14 +428,17 @@ public sealed class LoadOrderService : IDisposable
         public FormKey? ResolveEditorId(string editorId, string? mutagenType)
         {
             if (mutagenType is null || string.IsNullOrWhiteSpace(editorId)) return null;
-            var key = (mutagenType, editorId);
-            if (_eidCache.TryGetValue(key, out var hit)) return hit;
-            FormKey? found = null;
-            var types = _svc.ResolveFormScope(mutagenType);
-            if (types is not null)
-                foreach (var (candidate, _, cBody) in _view.WinnerRecordsOfType(types))
-                    if (string.Equals(cBody.EditorID, editorId, StringComparison.OrdinalIgnoreCase)) { found = candidate; break; }
-            return _eidCache[key] = found;
+            if (!_eidsByType.TryGetValue(mutagenType, out var eids))
+            {
+                eids = new Dictionary<string, FormKey>(StringComparer.OrdinalIgnoreCase);
+                var types = _svc.ResolveFormScope(mutagenType);
+                if (types is not null)
+                    foreach (var (candidate, _, cBody) in _view.WinnerRecordsOfType(types))
+                        if (cBody.EditorID is { Length: > 0 } eid && !eids.ContainsKey(eid))   // first winner keeps the slot (the old sweep's break-on-first)
+                            eids[eid] = candidate;
+                _eidsByType[mutagenType] = eids;
+            }
+            return eids.TryGetValue(editorId, out var fk) ? fk : null;
         }
 
         public string? ReadWinnerLeaf(FormKey donor, string path)


### PR DESCRIPTION
## What

The review-verified cleanup cluster deferred out of PR #165 by Aaron's call (2026-07-10 handoff, "the cleanup PR comes FIRST"). Four commits, no behavior additions — consolidation, freshness, and consistency:

1. **Overlay mutations all ride `WriteEngine.ApplyVerb`** (`6cd633c`) — the overlay's header promises every mutation rides the proven engines; three op families hand-rolled theirs. Flag bits now Set through the engine (numeric enum token), vector components splice ReadEngine's round-trippable `x,y,z` token and Set the whole point, list clear rides `ReplaceAll`, entry removals ride `Remove`-by-index, the formlink replace rides `SetAtIndex`. `Navigate()` is now read-only access. Also folded here (same switch): `none` on FlagBool ops (`setEssential=none` — grammar: leave unchanged) is a visible no-op instead of a spurious "not a boolean" warning, and `LooksLikeForm` uses the one `TryParseAddress` recognizer instead of a `'|'` sniff.
2. **One shared keyword walk** (`8464f61`) — the Keywords-list walk existed three times (overlay, post-state service resolver, `show` CLI) and disagreed on property resolution and non-formlink handling. Now `ReadEngine.KeywordKeys`, all three callers ride it.
3. **Freshness** (`73f6f4a`) — `SkyPatcherDiscovery.ParseCache`: per-file (mtime, length)-keyed INI parse cache held by the service across calls; an untouched layer costs zero re-parses per post-state call, an edited INI re-reads on its next scan. The resolver's EditorID resolution sweeps winners once per TYPE into an eid→FormKey table instead of a full-order sweep per (type, eid) miss.
4. **Consistency nits** (`4326550`) — `GatePluginOf` checks `PluginFile.Extensions` (the one extension list); `EmbeddedJson.Read` dedupes the two identical embedded-resource loaders; the post-state scratch ModKey is a named static mirroring the `HousecarlWriteProof` sibling; the `skypatcher-post-state` harness bootstraps a temp corpus when `corpus.json` is absent (FloiFieldsProbe pattern) instead of crashing unnamed outside the repo root.

## Scope decision

Shipped as its **own PR** (Aaron-go 2026-07-10, "go, own PR") — the queued #156+#158 merge-lane dedupe cleanup stays separate.

## Verification

- Full local `ci-all` from the worktree root: **84/84 PASS** (including the skypatcher parse/catalog/discovery/overlay/fieldmap guards — the overlay guard's stateful-replay RED-proof exercises the consolidated flag/vector/clear/removal paths)
- No tool-surface change; tool count stays 35. No fieldmap/catalog data change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
