### PR TITLE
SkyPatcher Wave 2: complete filter surface, op closures, conflict detector, reader tools (35 -> 37)

### DIFF
--- a/.claude/skills/skypatcher-authoring/SKILL.md
+++ b/.claude/skills/skypatcher-authoring/SKILL.md
@@ -71,6 +71,19 @@ Read grammar-core once plus the one record file you need — don't bulk-load eve
    plugin-gated), and — if relevant — the conflict-ordering note (same-field edits resolve by
    filename order `0`→`z`; different-field edits don't conflict).
 
+6. **Verify through the reader** — this is what makes the skill-authored write path safe.
+   After placing the INI (and enabling its mod in MO2 if it's new):
+   - `housecarl_skypatcher_read` on a record the patch targets: the computed post-state must show
+     your ops APPLIED with the intended before → after values. A typo'd filter or operation
+     classifies **Unknown with a loud warning** here — the same line SkyPatcher itself would skip
+     *silently* in game — and a subtly-valid-but-wrong op shows up as the wrong field changing.
+   - `housecarl_skypatcher_layer` for the file-level checks: your INI listed as APPLIED (not
+     BSA-only, not filename-gated off, not shadowed by a same-path file from another mod), in the
+     apply-order position you expect, and no new same-field set conflict against another INI.
+   A patch that passes both is verified against the actual grammar and the actual load order —
+   no game launch needed. (Resolving a reported conflict is the same loop: author the
+   later-sorted INI that pins the intended value, then re-run the reader to confirm it wins.)
+
 ## Bundled-or-warn — never invent SkyPatcher grammar
 
 The reference covers the 27 documented record types. If a filter, operation, or record type isn't
@@ -78,7 +91,9 @@ in it, **say so — don't fabricate a plausible token.** A wrong filter/operatio
 error: SkyPatcher silently skips lines it can't parse, and a mistyped or unresolvable FormID is
 skipped too — so the user gets a patch that quietly does nothing, with no log line pointing at the
 cause. A clear "that's not in the SkyPatcher reference" beats a confident wrong line that wastes a
-debugging session.
+debugging session. The `housecarl_skypatcher_read` verify step (workflow step 6) is the safety net
+for this failure class — an unrecognized key surfaces there as a loud unknown-key warning instead
+of a silent in-game no-op — but it is a net, not a license to guess.
 
 Specifically: **Object Modification (OMOD)** patching is enabled in SkyPatcher but has no
 documentation and no verified grammar (`references/records/object-modification.md`). Surface the
@@ -111,3 +126,5 @@ gap and the leads recorded there; do not guess OMOD syntax.
 - **Conflict model.** SkyPatcher's low-conflict property is real but not magic: same-field set
   operations still resolve by filename order; only add/remove operations truly accumulate. Mention
   this when a user layers multiple patches on one record (`grammar-core.md` §2).
+  `housecarl_skypatcher_layer` reports these same-field set collisions across the whole load
+  order (winner named); `housecarl_skypatcher_read` shows the resolved end state for one record.

--- a/src/housecarl-core/SkyPatcherConflicts.cs
+++ b/src/housecarl-core/SkyPatcherConflicts.cs
@@ -53,8 +53,8 @@ public static class SkyPatcherConflicts
         if (folder.Catalog is null) return conflicts;
         var maps = fieldMap.ForSubfolder(folder.Subfolder);
 
-        // ---- collect every SET-class event in apply order ----
-        var events = new List<(string file, int line, string op, string value, string field, IReadOnlyList<string> targets, bool conditional)>();
+        // ---- collect every SET-class event in apply order (seq = the apply-order index) ----
+        var events = new List<(int seq, string file, int line, string op, string value, string field, IReadOnlyList<string> targets, bool conditional)>();
         foreach (var ol in SkyPatcherDiscovery.OrderedLines(folder))
         {
             if (ol.Parsed.Kind != SkyPatcherLineKind.Patch) continue;
@@ -79,31 +79,39 @@ public static class SkyPatcherConflicts
                 if (cls.Operation!.Tractability == SkyPatcherTractability.Hard) continue;
                 var field = SetFieldOf(maps, seg.Key);
                 if (field is null) continue;   // accumulating / unmapped — not a last-write-wins collision
-                events.Add((ol.File, ol.LineNumber, seg.Key, (seg.RawValue ?? "").Trim(), field, targets, conditional));
+                events.Add((events.Count, ol.File, ol.LineNumber, seg.Key, (seg.RawValue ?? "").Trim(), field, targets, conditional));
             }
         }
 
-        // ---- group by field, then by target token (broad joins every token it can collide with) ----
+        // ---- group by field, then by target token in ONE forward pass (review fold: the per-token
+        //      re-scan was O(tokens × events) — quadratic exactly when most lines target distinct
+        //      records, the common shape). Broad events keep their own group (the broad-vs-broad
+        //      view) AND append to every explicit token's group (broad collides with everything).
         foreach (var fieldGroup in events.GroupBy(e => e.field, StringComparer.Ordinal))
         {
-            var all = fieldGroup.ToList();
-            var tokens = all.SelectMany(e => e.targets).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
-            foreach (var token in tokens)
-            {
-                // Every event that can write this target: an exact token match, or a broad line.
-                var hits = all.Where(e => e.targets.Contains(Broad)
-                        || (token != Broad && e.targets.Contains(token, StringComparer.OrdinalIgnoreCase)))
-                    .ToList();
-                if (token == Broad)
-                    hits = all.Where(e => e.targets.Contains(Broad)).ToList();   // the broad-vs-broad view; broad-vs-explicit reports under the explicit token
-                if (hits.Select(e => e.file).Distinct(StringComparer.OrdinalIgnoreCase).Count() < 2) continue;
-                if (hits.Select(e => e.value).Distinct(StringComparer.OrdinalIgnoreCase).Count() < 2) continue;
-                conflicts.Add(new SkyPatcherConflict(folder.Subfolder, fieldGroup.Key,
-                    token == Broad ? $"(all {folder.Subfolder} records)" : token,
-                    hits.Select(e => new SkyPatcherConflictEntry(e.file, e.line, e.op, e.value, e.conditional)).ToList()));
-            }
+            var byToken = new Dictionary<string, List<(int seq, string file, int line, string op, string value, bool conditional)>>(StringComparer.OrdinalIgnoreCase);
+            var broad = new List<(int seq, string file, int line, string op, string value, bool conditional)>();
+            foreach (var e in fieldGroup)
+                foreach (var token in e.targets)
+                    if (token == Broad) broad.Add((e.seq, e.file, e.line, e.op, e.value, e.conditional));
+                    else (byToken.TryGetValue(token, out var l) ? l : byToken[token] = new()).Add((e.seq, e.file, e.line, e.op, e.value, e.conditional));
+
+            foreach (var (token, own) in byToken.OrderBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase))
+                // Explicit-target group + every broad write of the same field, merged back into apply order.
+                Emit(conflicts, folder.Subfolder, fieldGroup.Key, token, own.Concat(broad).OrderBy(h => h.seq).ToList());
+            Emit(conflicts, folder.Subfolder, fieldGroup.Key, Broad, broad);
         }
         return conflicts;
+    }
+
+    static void Emit(List<SkyPatcherConflict> conflicts, string subfolder, string field, string token,
+        IReadOnlyList<(int seq, string file, int line, string op, string value, bool conditional)> hits)
+    {
+        if (hits.Select(e => e.file).Distinct(StringComparer.OrdinalIgnoreCase).Count() < 2) return;
+        if (hits.Select(e => e.value).Distinct(StringComparer.OrdinalIgnoreCase).Count() < 2) return;
+        conflicts.Add(new SkyPatcherConflict(subfolder, field,
+            token == Broad ? $"(all {subfolder} records)" : token,
+            hits.Select(e => new SkyPatcherConflictEntry(e.file, e.line, e.op, e.value, e.conditional)).ToList()));
     }
 
     /// <summary>The line's target tokens from its PRIMARY filter (normalized FormKey / case-folded
@@ -127,26 +135,47 @@ public static class SkyPatcherConflicts
         return tokens.Count > 0 ? (tokens, conditional) : (new[] { Broad }, conditional);
     }
 
-    /// <summary>The field signature a SET-class op writes (null = not a last-write-wins set: an
-    /// accumulating / collection / stateful / unmapped op). FlagBool includes the flag (two different
-    /// booleans of one flags leaf don't collide); vector/colour components include the component.</summary>
+    /// <summary>The last-write-wins SET-class semantics — a later write of the same field/target
+    /// REPLACES an earlier one, the collision class this detector reports.</summary>
+    internal static readonly IReadOnlySet<SkyPatcherOpSemantic> SetClassSemantics = new HashSet<SkyPatcherOpSemantic>
+    {
+        SkyPatcherOpSemantic.Set, SkyPatcherOpSemantic.SetFromOwnField, SkyPatcherOpSemantic.ModelPath,
+        SkyPatcherOpSemantic.VecComponent, SkyPatcherOpSemantic.ColorChannel, SkyPatcherOpSemantic.FlagBool,
+        SkyPatcherOpSemantic.DictSet, SkyPatcherOpSemantic.TeachSpell, SkyPatcherOpSemantic.TeachSkill,
+    };
+
+    /// <summary>The accumulating / stateful / collection semantics — order matters but nothing is
+    /// silently dropped, so they are NOT conflicts (grammar §2). Together with
+    /// <see cref="SetClassSemantics"/> this must cover EVERY <see cref="SkyPatcherOpSemantic"/> member —
+    /// the conflicts guard pins that partition, so a future semantic can't silently default to
+    /// "accumulating" and make the detector under-report (review finding).</summary>
+    internal static readonly IReadOnlySet<SkyPatcherOpSemantic> AccumulatingSemantics = new HashSet<SkyPatcherOpSemantic>
+    {
+        SkyPatcherOpSemantic.Mult, SkyPatcherOpSemantic.AddNumeric, SkyPatcherOpSemantic.FlagsSet,
+        SkyPatcherOpSemantic.FlagsRemove, SkyPatcherOpSemantic.AddForm, SkyPatcherOpSemantic.RemoveForm,
+        SkyPatcherOpSemantic.ReplaceForm, SkyPatcherOpSemantic.ClearList, SkyPatcherOpSemantic.AddEntry,
+        SkyPatcherOpSemantic.AddEntryOnce, SkyPatcherOpSemantic.RemoveEntry, SkyPatcherOpSemantic.RemoveEntryByCount,
+        SkyPatcherOpSemantic.ReplaceEntry, SkyPatcherOpSemantic.MultCount, SkyPatcherOpSemantic.RemoveByKeyword,
+        SkyPatcherOpSemantic.DictMult, SkyPatcherOpSemantic.BipedSlotsSet, SkyPatcherOpSemantic.BipedSlotsRemove,
+        SkyPatcherOpSemantic.SetEntryCount,
+    };
+
+    /// <summary>The field signature a SET-class op writes (null = accumulating / unmapped — not a
+    /// last-write-wins collision). FlagBool includes the flag (two different booleans of one flags
+    /// leaf don't collide); vector/colour components include the component; dict sets the key.</summary>
     static string? SetFieldOf(IReadOnlyList<RecordMap> maps, string opName)
     {
         foreach (var m in maps)
         {
             var op = m.Ops.GetValueOrDefault(opName);
             if (op is null || op.IsUnmapped) continue;
+            if (!SetClassSemantics.Contains(op.Semantic)) return null;
             return op.Semantic switch
             {
-                SkyPatcherOpSemantic.Set => op.Path,
-                SkyPatcherOpSemantic.SetFromOwnField => op.Path,
-                SkyPatcherOpSemantic.ModelPath => op.Path,
-                SkyPatcherOpSemantic.VecComponent => $"{op.Path}[{op.Component}]",
-                SkyPatcherOpSemantic.ColorChannel => $"{op.Path}[{op.Component}]",
+                SkyPatcherOpSemantic.VecComponent or SkyPatcherOpSemantic.ColorChannel => $"{op.Path}[{op.Component}]",
                 SkyPatcherOpSemantic.FlagBool => $"{op.Path}({op.Flag})",
                 SkyPatcherOpSemantic.DictSet => $"{op.Path}[{op.Key}]",
-                SkyPatcherOpSemantic.TeachSpell or SkyPatcherOpSemantic.TeachSkill => op.Path,
-                _ => null,
+                _ => op.Path,
             };
         }
         return null;

--- a/src/housecarl-core/SkyPatcherConflicts.cs
+++ b/src/housecarl-core/SkyPatcherConflicts.cs
@@ -1,0 +1,154 @@
+namespace HousecarlCore;
+
+/// <summary>
+/// The SkyPatcher INI-vs-INI CONFLICT detector (Wave 2 of the distributor subsystem; plan
+/// dev/plans/SKYPATCHER_DISTRIBUTOR_TOOL_PLAN_2026-07-08.md §3.2.4): group SET-class operations by
+/// (target record, target field) across one type folder's ordered, game-visible line union and flag
+/// the places two files write the SAME field of the SAME target with DIFFERENT values — the
+/// later-sorted file wins (grammar §2 "Conflict resolution"), which is exactly the collision class a
+/// modder can't see without reading every INI.
+///
+/// <para><b>Report-only (locked v1 call, plan §8).</b> The detector names the collision, the entries
+/// in apply order, and the winner; WHICH value should win is the judgment half that stays with the
+/// agent — a tool that auto-decides merges would be a silent-wrong-answer machine (Q3).</para>
+///
+/// <para><b>What counts as a conflict.</b> Only SET-class semantics (a literal last-write-wins field
+/// write: set / self-copy / vector-component / colour-channel / model path / flagBool / dict-set /
+/// Teaches). Add/remove/mult/collection ops ACCUMULATE by design (grammar §2) and are not conflicts;
+/// HARD ops have no static value to compare. Targets: the line's PRIMARY filter tokens (FormID
+/// normalized through the one <see cref="SkyPatcherOverlay.TryFormKey"/> recognizer; EditorIDs
+/// case-folded), or BROAD ("every record of the type") when the line has no bare primary filter —
+/// broad overlaps everything. A line whose applicability ALSO hangs on other filters (keywords,
+/// restrictTo…, gates) is flagged <see cref="SkyPatcherConflictEntry.Conditional"/>: whether the
+/// collision is real then depends on those filters, and the report says so rather than guessing
+/// either way.</para>
+/// </summary>
+public static class SkyPatcherConflicts
+{
+    /// <summary>One same-field, same-target collision: every SET in apply order (the LAST one wins).</summary>
+    public sealed record SkyPatcherConflict(
+        string Subfolder,
+        string Field,
+        string Target,
+        IReadOnlyList<SkyPatcherConflictEntry> Entries)
+    {
+        /// <summary>The write the DLL leaves in place — the last entry in apply order.</summary>
+        public SkyPatcherConflictEntry Winner => Entries[^1];
+        /// <summary>True when ANY entry's applicability also hangs on non-primary filters.</summary>
+        public bool Conditional => Entries.Any(e => e.Conditional);
+    }
+
+    /// <summary>One conflicting write. <see cref="Conditional"/> = the line carries filters beyond the
+    /// primary, so whether it actually applies to the target depends on them.</summary>
+    public sealed record SkyPatcherConflictEntry(string File, int Line, string Op, string Value, bool Conditional);
+
+    /// <summary>All records of the type — the target token a primary-filter-less line writes.</summary>
+    const string Broad = "*";
+
+    /// <summary>Detect the same-field set collisions in one folder's ordered, game-visible union.</summary>
+    public static IReadOnlyList<SkyPatcherConflict> Detect(
+        SkyPatcherDiscovery.FolderScan folder, SkyPatcherCatalog catalog, SkyPatcherFieldMap fieldMap)
+    {
+        var conflicts = new List<SkyPatcherConflict>();
+        if (folder.Catalog is null) return conflicts;
+        var maps = fieldMap.ForSubfolder(folder.Subfolder);
+
+        // ---- collect every SET-class event in apply order ----
+        var events = new List<(string file, int line, string op, string value, string field, IReadOnlyList<string> targets, bool conditional)>();
+        foreach (var ol in SkyPatcherDiscovery.OrderedLines(folder))
+        {
+            if (ol.Parsed.Kind != SkyPatcherLineKind.Patch) continue;
+            var filters = new List<(SkyPatcherSegment seg, SkyPatcherKeyClass cls)>();
+            var ops = new List<(SkyPatcherSegment seg, SkyPatcherKeyClass cls)>();
+            bool unknown = false;
+            foreach (var seg in ol.Parsed.Segments)
+            {
+                var cls = catalog.Classify(folder.Catalog, seg.Key);
+                switch (cls.Role)
+                {
+                    case SkyPatcherKeyRole.Filter: filters.Add((seg, cls)); break;
+                    case SkyPatcherKeyRole.Operation: ops.Add((seg, cls)); break;
+                    default: unknown = true; break;
+                }
+            }
+            if (unknown || ops.Count == 0) continue;   // an unresolvable line can't be honestly grouped (the overlay warns on it)
+
+            var (targets, conditional) = TargetsOf(filters);
+            foreach (var (seg, cls) in ops)
+            {
+                if (cls.Operation!.Tractability == SkyPatcherTractability.Hard) continue;
+                var field = SetFieldOf(maps, seg.Key);
+                if (field is null) continue;   // accumulating / unmapped — not a last-write-wins collision
+                events.Add((ol.File, ol.LineNumber, seg.Key, (seg.RawValue ?? "").Trim(), field, targets, conditional));
+            }
+        }
+
+        // ---- group by field, then by target token (broad joins every token it can collide with) ----
+        foreach (var fieldGroup in events.GroupBy(e => e.field, StringComparer.Ordinal))
+        {
+            var all = fieldGroup.ToList();
+            var tokens = all.SelectMany(e => e.targets).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+            foreach (var token in tokens)
+            {
+                // Every event that can write this target: an exact token match, or a broad line.
+                var hits = all.Where(e => e.targets.Contains(Broad)
+                        || (token != Broad && e.targets.Contains(token, StringComparer.OrdinalIgnoreCase)))
+                    .ToList();
+                if (token == Broad)
+                    hits = all.Where(e => e.targets.Contains(Broad)).ToList();   // the broad-vs-broad view; broad-vs-explicit reports under the explicit token
+                if (hits.Select(e => e.file).Distinct(StringComparer.OrdinalIgnoreCase).Count() < 2) continue;
+                if (hits.Select(e => e.value).Distinct(StringComparer.OrdinalIgnoreCase).Count() < 2) continue;
+                conflicts.Add(new SkyPatcherConflict(folder.Subfolder, fieldGroup.Key,
+                    token == Broad ? $"(all {folder.Subfolder} records)" : token,
+                    hits.Select(e => new SkyPatcherConflictEntry(e.file, e.line, e.op, e.value, e.conditional)).ToList()));
+            }
+        }
+        return conflicts;
+    }
+
+    /// <summary>The line's target tokens from its PRIMARY filter (normalized FormKey / case-folded
+    /// EditorID), or BROAD when no bare primary names records. Conditional = any other filter present
+    /// (whether the line hits the target then depends on record state the detector doesn't evaluate).</summary>
+    static (IReadOnlyList<string> targets, bool conditional) TargetsOf(
+        IReadOnlyList<(SkyPatcherSegment seg, SkyPatcherKeyClass cls)> filters)
+    {
+        var tokens = new List<string>();
+        bool conditional = false;
+        foreach (var (seg, cls) in filters)
+        {
+            if (cls.Filter!.Kind == SkyPatcherFilterKind.Primary && (cls.Connective ?? "") == "")
+                foreach (var v in seg.Values)
+                    tokens.Add(v.Address is { IsFormId: true } a && SkyPatcherOverlay.TryFormKey(a, out var fk)
+                        ? fk.ToString()
+                        : v.Raw.ToLowerInvariant());
+            else
+                conditional = true;   // Excluded-primary, crosscutting, restrictTo, gates — narrows applicability
+        }
+        return tokens.Count > 0 ? (tokens, conditional) : (new[] { Broad }, conditional);
+    }
+
+    /// <summary>The field signature a SET-class op writes (null = not a last-write-wins set: an
+    /// accumulating / collection / stateful / unmapped op). FlagBool includes the flag (two different
+    /// booleans of one flags leaf don't collide); vector/colour components include the component.</summary>
+    static string? SetFieldOf(IReadOnlyList<RecordMap> maps, string opName)
+    {
+        foreach (var m in maps)
+        {
+            var op = m.Ops.GetValueOrDefault(opName);
+            if (op is null || op.IsUnmapped) continue;
+            return op.Semantic switch
+            {
+                SkyPatcherOpSemantic.Set => op.Path,
+                SkyPatcherOpSemantic.SetFromOwnField => op.Path,
+                SkyPatcherOpSemantic.ModelPath => op.Path,
+                SkyPatcherOpSemantic.VecComponent => $"{op.Path}[{op.Component}]",
+                SkyPatcherOpSemantic.ColorChannel => $"{op.Path}[{op.Component}]",
+                SkyPatcherOpSemantic.FlagBool => $"{op.Path}({op.Flag})",
+                SkyPatcherOpSemantic.DictSet => $"{op.Path}[{op.Key}]",
+                SkyPatcherOpSemantic.TeachSpell or SkyPatcherOpSemantic.TeachSkill => op.Path,
+                _ => null,
+            };
+        }
+        return null;
+    }
+}

--- a/src/housecarl-core/SkyPatcherFieldMap.cs
+++ b/src/housecarl-core/SkyPatcherFieldMap.cs
@@ -90,8 +90,88 @@ public sealed class SkyPatcherFieldMap
             throw new InvalidOperationException($"SkyPatcher field map [{subfolder}]: 'ops' is missing or not an object.");
         foreach (var p in opsEl.EnumerateObject())
             ops[p.Name] = ParseOp(subfolder, p.Name, p.Value);
-        return new RecordMap(subfolder, recordType, ops);
+
+        // Wave 2: the per-record FILTER evaluation specs (base filter name → how the overlay evaluates
+        // it against the record). Same wrong-kind-throws-loud contract as 'ops'.
+        var filters = new Dictionary<string, FilterSpec>(StringComparer.Ordinal);
+        if (el.TryGetProperty("filters", out var fEl))
+        {
+            if (fEl.ValueKind != JsonValueKind.Object)
+                throw new InvalidOperationException($"SkyPatcher field map [{subfolder}]: 'filters' is present but not an object.");
+            foreach (var p in fEl.EnumerateObject())
+                filters[p.Name] = ParseFilter(subfolder, p.Name, p.Value);
+        }
+        return new RecordMap(subfolder, recordType, ops, filters);
     }
+
+    static FilterSpec ParseFilter(string subfolder, string name, JsonElement el)
+    {
+        if (el.ValueKind != JsonValueKind.Object)
+            throw new InvalidOperationException($"SkyPatcher field map [{subfolder}.filters.{name}]: entry is not an object.");
+
+        var unmapped = OptStr(el, "unmapped");
+        if (unmapped is not null)
+            return FilterSpec.MakeUnmapped(unmapped);
+
+        var eval = ParseFilterEval(Str(el, "eval"), $"{subfolder}.filters.{name}");
+
+        // 'path' (one) or 'paths' (several — a filter that matches ANY of a few leaves, e.g. a race's
+        // male+female voice). Exactly one of the two must be present.
+        string[] paths;
+        if (el.TryGetProperty("paths", out var ps))
+        {
+            if (ps.ValueKind != JsonValueKind.Array)
+                throw new InvalidOperationException($"SkyPatcher field map [{subfolder}.filters.{name}]: 'paths' is not an array.");
+            paths = ps.EnumerateArray().Select(p => p.GetString()
+                ?? throw new InvalidOperationException($"SkyPatcher field map [{subfolder}.filters.{name}]: 'paths' entry is not a string.")).ToArray();
+            if (el.TryGetProperty("path", out _))
+                throw new InvalidOperationException($"SkyPatcher field map [{subfolder}.filters.{name}]: has BOTH 'path' and 'paths'.");
+        }
+        else if (el.TryGetProperty("path", out _)) paths = new[] { Str(el, "path") };
+        else if (eval == SkyPatcherFilterEval.DonorKeywords) paths = Array.Empty<string>();   // reads the donor's keyword list, no own path
+        else throw new InvalidOperationException($"SkyPatcher field map [{subfolder}.filters.{name}]: needs 'path' or 'paths'.");
+
+        Dictionary<string, string>? valueMap = null;
+        if (el.TryGetProperty("valueMap", out var vm))
+        {
+            if (vm.ValueKind != JsonValueKind.Object)
+                throw new InvalidOperationException($"SkyPatcher field map [{subfolder}.filters.{name}]: 'valueMap' is not an object.");
+            valueMap = new(StringComparer.OrdinalIgnoreCase);
+            foreach (var p in vm.EnumerateObject())
+                valueMap[p.Name] = p.Value.GetString()
+                    ?? throw new InvalidOperationException($"SkyPatcher field map [{subfolder}.filters.{name}]: valueMap '{p.Name}' is not a string.");
+        }
+
+        return new FilterSpec(
+            eval, paths,
+            KeyPath: OptStr(el, "keyPath"),
+            FormType: OptStr(el, "formType"),
+            Flag: OptStr(el, "flag"),
+            Invert: el.TryGetProperty("invert", out var inv) && inv.ValueKind == JsonValueKind.True,
+            LinkPath: OptStr(el, "linkPath"),
+            EidSubstring: el.TryGetProperty("eidSubstring", out var es) && es.ValueKind == JsonValueKind.True,
+            ValueMap: valueMap,
+            Note: OptStr(el, "note"),
+            Unmapped: null);
+    }
+
+    static SkyPatcherFilterEval ParseFilterEval(string s, string ctx) => s switch
+    {
+        "formEquals" => SkyPatcherFilterEval.FormEquals,
+        "formInList" => SkyPatcherFilterEval.FormInList,
+        "enumEquals" => SkyPatcherFilterEval.EnumEquals,
+        "flagBool" => SkyPatcherFilterEval.FlagBool,
+        "flagAnyOf" => SkyPatcherFilterEval.FlagAnyOf,
+        "gender" => SkyPatcherFilterEval.Gender,
+        "pcLevelMult" => SkyPatcherFilterEval.PcLevelMult,
+        "substringLeaf" => SkyPatcherFilterEval.SubstringLeaf,
+        "donorSubstring" => SkyPatcherFilterEval.DonorSubstring,
+        "donorKeywords" => SkyPatcherFilterEval.DonorKeywords,
+        "numericLess" => SkyPatcherFilterEval.NumericLess,
+        "bipedSlots" => SkyPatcherFilterEval.BipedSlots,
+        "linkedOriginPlugin" => SkyPatcherFilterEval.LinkedOriginPlugin,
+        _ => throw new InvalidOperationException($"SkyPatcher field map [{ctx}]: unknown filter eval '{s}'."),
+    };
 
     static OpMap ParseOp(string subfolder, string opName, JsonElement el)
     {
@@ -228,8 +308,76 @@ public enum SkyPatcherOpSemantic
     RemoveByKeyword,
 }
 
-/// <summary>One record type's op → field mappings, keyed by the exact catalog op name.</summary>
-public sealed record RecordMap(string Subfolder, string RecordType, IReadOnlyDictionary<string, OpMap> Ops);
+/// <summary>One record type's op → field mappings (keyed by the exact catalog op name) and filter →
+/// evaluation specs (keyed by the exact catalog BASE filter name; connectives are the overlay's job).
+/// A filter absent from <see cref="Filters"/> is either evaluated built-in by the overlay (the
+/// name-keyed families that need no per-record path — primary, keywords, editorid/name contains,
+/// hasPlugins, modNames, the skip/override tokens, alternate textures, attached mgefs) or is a
+/// COVERAGE GAP the filtermap guard fails on — never a silent skip.</summary>
+public sealed record RecordMap(string Subfolder, string RecordType, IReadOnlyDictionary<string, OpMap> Ops,
+    IReadOnlyDictionary<string, FilterSpec> Filters);
+
+/// <summary>How the overlay evaluates a per-record mapped filter against the running copy.</summary>
+public enum SkyPatcherFilterEval
+{
+    /// <summary>A single formlink leaf equals ANY listed form. (A single-valued field can't AND a
+    /// multi-value list — any-of is the only satisfiable reading; declared assumption, noted loud.)</summary>
+    FormEquals,
+    /// <summary>A formlink list (or struct list via <see cref="FilterSpec.KeyPath"/>) contains the listed
+    /// forms — bare = ALL present, Or = any, Excluded = none (the keyword-filter connective semantics).</summary>
+    FormInList,
+    /// <summary>An enum leaf equals ANY listed token (valueMap first, then ignore-case member match).</summary>
+    EnumEquals,
+    /// <summary>ONE fixed flag (<see cref="FilterSpec.Flag"/>) tested against a true/false value;
+    /// <see cref="FilterSpec.Invert"/> flips the sense (restrictToBolts=true ⇒ NonBolt NOT set).</summary>
+    FlagBool,
+    /// <summary>Listed flag tokens tested against a [Flags] enum leaf — bare = all set, Or = any,
+    /// Excluded = none.</summary>
+    FlagAnyOf,
+    /// <summary>NPC gender: token 'female' ⇒ the Female configuration flag set, 'male' ⇒ clear.</summary>
+    Gender,
+    /// <summary>NPC filterByPCLevelMult: whether the polymorphic Configuration.Level is the
+    /// PcLevelMult arm (true) or a static NpcLevel (false).</summary>
+    PcLevelMult,
+    /// <summary>A string leaf contains the listed substring(s) — the Contains-family connectives.</summary>
+    SubstringLeaf,
+    /// <summary>Follow <see cref="FilterSpec.LinkPath"/> to a donor record's winner and substring-match
+    /// a leaf THERE (an NPC's skeleton path lives on its race).</summary>
+    DonorSubstring,
+    /// <summary>Follow <see cref="FilterSpec.LinkPath"/> to a donor record's winner and match the
+    /// keyword list THERE (a recipe's filterByKeywords matches the CREATED OBJECT's keywords).</summary>
+    DonorKeywords,
+    /// <summary>A numeric leaf is strictly less than the listed number (filterByWeightLessThan).</summary>
+    NumericLess,
+    /// <summary>Biped-slot INDICES (0–31; slot number − 30) tested as bits of a BipedObjectFlag leaf.</summary>
+    BipedSlots,
+    /// <summary>The ORIGIN plugin (FormKey master) of the record a formlink leaf points at, tested
+    /// against the listed plugin names (skipRecordByLightingTemplateFromMod — skip semantics ride
+    /// <see cref="FilterSpec.Invert"/>). DECLARED ASSUMPTION: "comes from mod X" = the linked form's
+    /// defining master, not the plugin that last overrode the link.</summary>
+    LinkedOriginPlugin,
+}
+
+/// <summary>One filter's evaluation spec. <see cref="Unmapped"/> non-null ⇒ the filter is EXPLICITLY
+/// not statically evaluable, with the reason the overlay surfaces loud (line skips filter-unresolved).</summary>
+public sealed record FilterSpec(
+    SkyPatcherFilterEval Eval,
+    IReadOnlyList<string> Paths,
+    string? KeyPath,
+    string? FormType,
+    string? Flag,
+    bool Invert,
+    string? LinkPath,
+    bool EidSubstring,
+    IReadOnlyDictionary<string, string>? ValueMap,
+    string? Note,
+    string? Unmapped)
+{
+    internal static FilterSpec MakeUnmapped(string reason)
+        => new(SkyPatcherFilterEval.FormEquals, Array.Empty<string>(), null, null, null, false, null, false, null, null, reason);
+    /// <summary>True when this filter is explicitly declared un-evaluable (loud in the overlay).</summary>
+    public bool IsUnmapped => Unmapped is not null;
+}
 
 /// <summary>One operation's mapping. <see cref="Unmapped"/> non-null ⇒ the op is EXPLICITLY not
 /// modelable, with the reason the overlay surfaces loud (all other members are then unset).</summary>

--- a/src/housecarl-core/SkyPatcherFieldMap.cs
+++ b/src/housecarl-core/SkyPatcherFieldMap.cs
@@ -225,6 +225,7 @@ public sealed class SkyPatcherFieldMap
             EqPacked: el.TryGetProperty("pack", out var pk) && pk.ValueKind == JsonValueKind.String && pk.GetString() == "eq",
             ValueMap: valueMap,
             Element: element,
+            Key: OptStr(el, "key"),
             Note: OptStr(el, "note"),
             Unmapped: null);
     }
@@ -259,6 +260,14 @@ public sealed class SkyPatcherFieldMap
         "replaceEntry" => SkyPatcherOpSemantic.ReplaceEntry,
         "multCount" => SkyPatcherOpSemantic.MultCount,
         "removeByKeyword" => SkyPatcherOpSemantic.RemoveByKeyword,
+        "dictSet" => SkyPatcherOpSemantic.DictSet,
+        "dictMult" => SkyPatcherOpSemantic.DictMult,
+        "colorChannel" => SkyPatcherOpSemantic.ColorChannel,
+        "bipedSlotsSet" => SkyPatcherOpSemantic.BipedSlotsSet,
+        "bipedSlotsRemove" => SkyPatcherOpSemantic.BipedSlotsRemove,
+        "teachSpell" => SkyPatcherOpSemantic.TeachSpell,
+        "teachSkill" => SkyPatcherOpSemantic.TeachSkill,
+        "setEntryCount" => SkyPatcherOpSemantic.SetEntryCount,
         _ => throw new InvalidOperationException($"SkyPatcher field map [{ctx}]: unknown semantic '{s}'."),
     };
 }
@@ -306,6 +315,24 @@ public enum SkyPatcherOpSemantic
     MultCount,
     /// <summary>Remove entries whose TARGET record carries a keyword (removeInventoryObjectsByKeywords…) — needs the resolver.</summary>
     RemoveByKeyword,
+    /// <summary>Set one entry of a numeric-valued dict (<see cref="OpMap.Key"/> — race startingHealth on
+    /// Race.Starting[Health]); rides the engine's dict Set.</summary>
+    DictSet,
+    /// <summary>Multiply one entry of a numeric-valued dict (stateful — order-dependent).</summary>
+    DictMult,
+    /// <summary>Set ONE channel (<see cref="OpMap.Component"/>: 0=R 1=G 2=B) of a whole-value Color leaf —
+    /// the token splice the P3 vector components use, alpha preserved.</summary>
+    ColorChannel,
+    /// <summary>OR biped-slot INDEX bits (0–31; slot number − 30) into a BipedObjectFlag leaf.</summary>
+    BipedSlotsSet,
+    /// <summary>Clear biped-slot INDEX bits from a BipedObjectFlag leaf.</summary>
+    BipedSlotsRemove,
+    /// <summary>Set Book.Teaches to the BookSpell arm holding the given spell (compose-Set through the engine).</summary>
+    TeachSpell,
+    /// <summary>Set Book.Teaches to the BookSkill arm holding the given skill (compose-Set through the engine).</summary>
+    TeachSkill,
+    /// <summary>Set matching entries' count to N (changeCobjsCount form~count; 'null' as the form = ALL entries).</summary>
+    SetEntryCount,
 }
 
 /// <summary>One record type's op → field mappings (keyed by the exact catalog op name) and filter →
@@ -391,11 +418,12 @@ public sealed record OpMap(
     bool EqPacked,
     IReadOnlyDictionary<string, string>? ValueMap,
     ElementMap? Element,
+    string? Key,
     string? Note,
     string? Unmapped)
 {
     internal static OpMap MakeUnmapped(string reason)
-        => new(SkyPatcherOpSemantic.Set, "", null, null, null, null, false, null, null, null, reason);
+        => new(SkyPatcherOpSemantic.Set, "", null, null, null, null, false, null, null, null, null, reason);
     /// <summary>True when this op is explicitly declared un-modelable (loud in the overlay).</summary>
     public bool IsUnmapped => Unmapped is not null;
 }

--- a/src/housecarl-core/SkyPatcherOverlay.cs
+++ b/src/housecarl-core/SkyPatcherOverlay.cs
@@ -747,7 +747,7 @@ public static class SkyPatcherOverlay
     /// Review finding #4: the bare 24-bit mask made every full ESL FormID silently match nothing.
     /// Residual EMPIRICAL item: a bare 6-hex ESL spelling like <c>800123</c> is inherently ambiguous
     /// (documented in the plan's Wave-1 list) — the 24-bit mask applies to it.</summary>
-    static bool TryFormKey(FormAddress a, out FormKey fk)
+    internal static bool TryFormKey(FormAddress a, out FormKey fk)
     {
         fk = default;
         if (a.Plugin is null || a.FormId is null) return false;

--- a/src/housecarl-core/SkyPatcherOverlay.cs
+++ b/src/housecarl-core/SkyPatcherOverlay.cs
@@ -21,12 +21,18 @@ namespace HousecarlCore;
 /// static resolution (runtime math / non-deterministic / copy-from-form) — never a silently-wrong
 /// value. Unknown keys, unmapped ops, unevaluable filters, and value failures are all NAMED warnings.</para>
 ///
-/// <para><b>Filter tier (Wave 1).</b> Evaluated here: the primary filter (FormID/EditorID membership,
-/// + Excluded), <c>filterByKeywords</c>(/Or/Excluded) against the RUNNING copy's keyword list,
-/// <c>filterByEditorIdContains</c>/<c>filterByNameContains</c> families, <c>hasPlugins</c>(/Or), and
-/// the explicit <c>noFilter…</c> tokens. Every other filter family (restrictTo…, override-aware,
-/// record-specific) is NOT yet evaluated: a line carrying one is SKIPPED LOUD as filter-unresolved
-/// (never guessed either way). Wave 2 completes the filter surface.</para>
+/// <para><b>Filter tier (Wave 2 — the COMPLETE surface).</b> Two lanes: (1) BUILT-IN families that
+/// need no per-record path — the primary filter, <c>noFilter…</c>, <c>hasPlugins</c>, keyword /
+/// EditorID-contains / name-contains, <c>filterByModNames</c> (the record's DEFINING master — a
+/// declared assumption, empirical-gate item), the override-aware skip tokens
+/// (<c>modNamesLastOverriddenExcluded</c> = the record's WINNING override plugin;
+/// <c>skipRecordByModNameContains</c>), attached-mgef, and alternate-texture matching; (2) MAP-DRIVEN
+/// per-record filters from the field map's <c>filters</c> specs (<see cref="FilterSpec"/> — form
+/// equality/membership, enum/flag tests, substrings, biped slots, donor reads). A filter that is
+/// neither built-in nor mapped, or that is explicitly unmapped-with-reason (e.g. NPC
+/// <c>restrictToSkill</c> — autocalc NPCs have no static skill value), keeps the Wave-1 behavior:
+/// the line SKIPS LOUD as filter-unresolved, never guessed either way. Per grammar §4 the PLAYER
+/// matches only a lone bare primary filter that names it — every other line excludes the player.</para>
 ///
 /// <para>Navigation and mutation ride the PROVEN engines — <see cref="WriteEngine.ApplyVerb"/> for
 /// sets/adds/removes (same coercion, same materialization) and <see cref="ReadEngine.ReadLeaf"/> for
@@ -52,6 +58,15 @@ public static class SkyPatcherOverlay
 
         /// <summary>Whether a plugin (filename incl. extension) is in the active load order (hasPlugins).</summary>
         bool PluginPresent(string pluginName);
+
+        /// <summary>The plugin (filename incl. extension) whose override of a record WINS the load
+        /// order — the "last override" the override-aware filters yield to. Null = record not present
+        /// (surfaced loud, filter unresolved).</summary>
+        string? WinnerPluginOf(FormKey record);
+
+        /// <summary>The EditorID of a record's load-order winner (filterByArmorAddons' documented
+        /// EditorID-substring match). Null = unresolvable.</summary>
+        string? EditorIdOf(FormKey record);
     }
 
     /// <summary>One parsed line in its apply-order context: which file (Data-relative), which physical
@@ -134,12 +149,12 @@ public static class SkyPatcherOverlay
             if (ops.Count == 0) continue;   // a line with no operation does nothing (grammar §3)
 
             // ---- evaluate the filters against THIS record (Wave-1 tier; unsupported ⇒ loud skip). ----
-            var verdict = EvaluateFilters(mutableRecord, fk, editorId, recordCatalog, fieldMap?.RecordType, filters, resolver, warnings, dedupe);
+            var verdict = EvaluateFilters(mutableRecord, fk, editorId, recordCatalog, fieldMap, filters, resolver, warnings, dedupe);
             if (verdict == FilterVerdict.Unresolved)
             {
                 unresolvedSkips++;
                 var names = string.Join(", ", filters.Select(f => f.seg.Key));
-                warnings.Add($"{where}: line skipped — carries filter(s) this reader does not evaluate yet ({names}); whether it applies to {Ident(fk, editorId)} is UNRESOLVED (Wave-2 filter surface).");
+                warnings.Add($"{where}: line skipped — carries filter(s) with no static evaluation ({names}); whether it applies to {Ident(fk, editorId)} is UNRESOLVED (see the per-filter warning for why).");
                 continue;
             }
             if (verdict == FilterVerdict.NoMatch) continue;
@@ -193,11 +208,36 @@ public static class SkyPatcherOverlay
 
     enum FilterVerdict { Match, NoMatch, Unresolved }
 
+    /// <summary>The player actor — per grammar §4 ALWAYS excluded from filtered and unfiltered lines
+    /// alike; only <c>filterByNpcs=Skyrim.esm|7</c> ALONE patches it.</summary>
+    static readonly FormKey PlayerFormKey = new(new ModKey("Skyrim", ModType.Master), 0x7);
+
+    /// <summary>The filter base names the overlay evaluates WITHOUT a field-map spec (no per-record
+    /// path needed). Shared with the filtermap coverage guard so "built-in" can't silently drift.</summary>
+    public static readonly IReadOnlySet<string> BuiltInFilterBases = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "filterByKeywords", "restrictToKeywords", "filterByEditorIdContains", "filterByNameContains",
+        "filterByModNames", "skipRecordByModNameContains", "modNamesLastOverridden",
+        "filterByMgefs", "filterByAlternateTextures",
+    };
+
     static FilterVerdict EvaluateFilters(object record, FormKey fk, string? editorId,
-        SkyPatcherRecordCatalog recordCatalog, string? mutagenRecordType,
+        SkyPatcherRecordCatalog recordCatalog, RecordMap? fieldMap,
         IReadOnlyList<(SkyPatcherSegment seg, SkyPatcherKeyClass cls)> filters, IFormResolver resolver,
         List<string> warnings, HashSet<string> dedupe)
     {
+        var mutagenRecordType = fieldMap?.RecordType;
+
+        // The player rule (grammar §4): the player is excluded from EVERY line — filtered, restricted,
+        // or unfiltered — except a lone bare primary filter that names it. Strict reading of the
+        // documented "use filterByNpcs=Skyrim.esm|7 ALONE"; declared assumption for the empirical gate.
+        if (fk == PlayerFormKey)
+            return filters.Count == 1
+                && filters[0].cls.Filter!.Kind == SkyPatcherFilterKind.Primary
+                && (filters[0].cls.Connective ?? "") == ""
+                && filters[0].seg.Values.Any(v => MatchesIdentity(v, fk, editorId))
+                ? FilterVerdict.Match : FilterVerdict.NoMatch;
+
         // No filter set → every record of the type is patched (grammar §5).
         if (filters.Count == 0) return FilterVerdict.Match;
 
@@ -206,7 +246,6 @@ public static class SkyPatcherOverlay
         {
             var f = cls.Filter!;
             var conn = cls.Connective ?? "";
-            bool primary = f.Kind == SkyPatcherFilterKind.Primary;
 
             if (f.Kind == SkyPatcherFilterKind.NoFilter)
             {
@@ -229,7 +268,7 @@ public static class SkyPatcherOverlay
                 any = true; continue;
             }
 
-            if (primary)
+            if (f.Kind == SkyPatcherFilterKind.Primary)
             {
                 bool inSet = seg.Values.Any(v => MatchesIdentity(v, fk, editorId));
                 bool ok = conn is "Excluded" or "Exclude" ? !inSet : inSet;
@@ -237,58 +276,450 @@ public static class SkyPatcherOverlay
                 any = true; continue;
             }
 
-            switch (cls.BaseKey)
-            {
-                case "filterByKeywords":
-                {
-                    var mine = ReadEngine.KeywordKeys(record);
-                    if (mine is null) return FilterVerdict.Unresolved;   // type has no keyword list we can read
-                    var wanted = new List<FormKey>();
-                    int unresolved = 0;
-                    foreach (var v in seg.Values)
-                    {
-                        var k = ResolveFormValue(v, "Keyword", resolver);
-                        if (k is null)
-                        {
-                            // A keyword that resolves to NOTHING in the active order can never be attached
-                            // to any record — that's a fact about the order, not a guess: it evaluates as
-                            // not-attached, surfaced ONCE per token (Wave-1 crux finding: real INIs list
-                            // keywords from frameworks the modlist doesn't run, e.g. SLA_KillerHeels).
-                            unresolved++;
-                            if (dedupe.Add($"kw:{v.Raw}"))
-                                warnings.Add($"keyword '{v.Raw}' (in a {cls.BaseKey}{conn}) resolves to nothing in the active order — treated as attached to no record.");
-                        }
-                        else wanted.Add(k.Value);
-                    }
-                    bool ok = conn switch
-                    {
-                        "Or" => wanted.Any(mine.Contains),
-                        "Excluded" or "Exclude" => !wanted.Any(mine.Contains),
-                        // bare = AND: EVERY listed keyword must be attached — an in-order-nonexistent one can't be.
-                        _ => unresolved == 0 && wanted.All(mine.Contains),
-                    };
-                    if (!ok) return FilterVerdict.NoMatch;
-                    any = true; continue;
-                }
-                case "filterByEditorIdContains":
-                {
-                    var eid = editorId ?? "";
-                    bool ok = ContainsVerdict(seg, conn, eid);
-                    if (!ok) return FilterVerdict.NoMatch;
-                    any = true; continue;
-                }
-                case "filterByNameContains":
-                {
-                    var name = RecordName(record) ?? "";
-                    bool ok = ContainsVerdict(seg, conn, name);
-                    if (!ok) return FilterVerdict.NoMatch;
-                    any = true; continue;
-                }
-                default:
-                    return FilterVerdict.Unresolved;   // a filter family Wave 1 does not evaluate — loud skip upstream
-            }
+            var verdict = EvaluateOneFilter(record, fk, editorId, cls, seg, conn, fieldMap, resolver, warnings, dedupe);
+            if (verdict != FilterVerdict.Match) return verdict;
+            any = true;
         }
         return any ? FilterVerdict.Match : FilterVerdict.NoMatch;
+    }
+
+    /// <summary>One non-primary, non-gate filter segment against this record: the built-in families
+    /// first (keyed by base name), then the field map's per-record <see cref="FilterSpec"/>. A map
+    /// entry for a built-in name OVERRIDES the built-in (a recipe's filterByKeywords matches the
+    /// CREATED object's keywords, not its own). Anything else is Unresolved — loud skip upstream.</summary>
+    static FilterVerdict EvaluateOneFilter(object record, FormKey fk, string? editorId,
+        SkyPatcherKeyClass cls, SkyPatcherSegment seg, string conn, RecordMap? fieldMap,
+        IFormResolver resolver, List<string> warnings, HashSet<string> dedupe)
+    {
+        var spec = fieldMap?.Filters.GetValueOrDefault(cls.BaseKey);
+        if (spec is { IsUnmapped: true })
+        {
+            if (dedupe.Add($"fu:{cls.BaseKey}"))
+                warnings.Add($"filter '{cls.BaseKey}' has no static evaluation — {spec.Unmapped}");
+            return FilterVerdict.Unresolved;
+        }
+        if (spec is not null)
+            return EvaluateSpec(record, cls, seg, conn, spec, fieldMap!, resolver, warnings, dedupe);
+
+        switch (cls.BaseKey)
+        {
+            case "filterByKeywords":
+            case "restrictToKeywords":   // post-match narrowing; for ONE record that's the same verdict
+                return KeywordVerdict(ReadEngine.KeywordKeys(record), seg, cls.BaseKey, conn, resolver, warnings, dedupe);
+
+            case "filterByEditorIdContains":
+                return ContainsVerdict(seg, conn, editorId ?? "") ? FilterVerdict.Match : FilterVerdict.NoMatch;
+
+            case "filterByNameContains":
+                return ContainsVerdict(seg, conn, RecordName(record) ?? "") ? FilterVerdict.Match : FilterVerdict.NoMatch;
+
+            case "filterByModNames":
+            {
+                // "Records that come from the named plugin(s)" — the record's DEFINING master
+                // (FormKey.ModKey). DECLARED ASSUMPTION (empirical-gate item): the DLL could
+                // conceivably mean any override provider; the defining master is the reading every
+                // community usage implies (filterByModNames=SomeMod.esp = "that mod's records").
+                var origin = fk.ModKey.FileName.String;
+                bool inSet = seg.Values.Any(v => v.Raw.Equals(origin, StringComparison.OrdinalIgnoreCase));
+                bool ok = conn is "Excluded" or "Exclude" ? !inSet : inSet;
+                return ok ? FilterVerdict.Match : FilterVerdict.NoMatch;
+            }
+            case "skipRecordByModNameContains":
+            {
+                // Skip when the record's source mod name CONTAINS a listed substring (cell.md) —
+                // an inverted filter: match ⇒ the line does NOT apply.
+                var origin = fk.ModKey.FileName.String;
+                bool hit = seg.Values.Any(v => origin.Contains(v.Raw, StringComparison.OrdinalIgnoreCase));
+                return hit ? FilterVerdict.NoMatch : FilterVerdict.Match;
+            }
+            case "modNamesLastOverridden":
+            {
+                // "Skip records whose LAST OVERRIDE is from a named mod" (magic-effect.md) — the
+                // load-order WINNER's plugin, i.e. the record view's conflict winner. Documented only
+                // in the Excluded spelling; any other connective is unresolved, never guessed.
+                if (conn is not ("Excluded" or "Exclude")) return FilterVerdict.Unresolved;
+                var winner = resolver.WinnerPluginOf(fk);
+                if (winner is null)
+                {
+                    if (dedupe.Add($"ov:{fk}"))
+                        warnings.Add($"modNamesLastOverridden{conn}: could not resolve the winning override plugin of {fk} — whether the line yields is UNRESOLVED.");
+                    return FilterVerdict.Unresolved;
+                }
+                bool hit = seg.Values.Any(v => v.Raw.Equals(winner, StringComparison.OrdinalIgnoreCase));
+                return hit ? FilterVerdict.NoMatch : FilterVerdict.Match;
+            }
+            case "filterByMgefs":
+            {
+                // Crosscutting attached-effect match (spell/scroll/ench/ingestible/ingredient): the
+                // Effects array's BaseEffect links. (On the magicEffect folder filterByMgefs is the
+                // PRIMARY filter and never reaches here.)
+                var mine = EntryKeys(record, new[] { "Effects" }, "BaseEffect");
+                return FormSetVerdict(mine, seg, cls.BaseKey, conn, "MagicEffect", resolver, warnings, dedupe);
+            }
+            case "filterByAlternateTextures":
+            {
+                // Items carrying a given texture set: the model's alternate-texture entries' NewTexture.
+                var mine = EntryKeys(record, new[] { "Model", "AlternateTextures" }, "NewTexture");
+                return FormSetVerdict(mine, seg, cls.BaseKey, conn, "TextureSet", resolver, warnings, dedupe);
+            }
+            default:
+                return FilterVerdict.Unresolved;   // neither built-in nor mapped — loud skip upstream
+        }
+    }
+
+    // ---- the map-driven evaluations -----------------------------------------------------------------
+
+    static FilterVerdict EvaluateSpec(object record, SkyPatcherKeyClass cls, SkyPatcherSegment seg,
+        string conn, FilterSpec spec, RecordMap fieldMap, IFormResolver resolver,
+        List<string> warnings, HashSet<string> dedupe)
+    {
+        bool excluded = conn is "Excluded" or "Exclude";
+        switch (spec.Eval)
+        {
+            case SkyPatcherFilterEval.FormEquals:
+            {
+                // Single-valued form field vs a value list: any-of (an AND over one slot is
+                // unsatisfiable for >1 distinct values — see the enum's declared assumption).
+                var current = spec.Paths.Select(p => TryLeafToken(record, p)).Where(t => t is not null).ToList();
+                bool matched = false;
+                foreach (var v in seg.Values)
+                {
+                    var k = ResolveFormValue(v, spec.FormType, resolver);
+                    if (k is null) { WarnUnresolvableForm(v, cls.BaseKey, conn, spec, warnings, dedupe); continue; }
+                    if (current.Any(t => string.Equals(t, k.Value.ToString(), StringComparison.OrdinalIgnoreCase))) { matched = true; break; }
+                }
+                return (excluded ? !matched : matched) ? FilterVerdict.Match : FilterVerdict.NoMatch;
+            }
+            case SkyPatcherFilterEval.FormInList:
+            {
+                var segs = SplitPath(spec.Paths[0]);
+                var mine = spec.KeyPath is null ? TryFormLinkKeys(record, segs) : EntryKeys(record, segs, spec.KeyPath);
+                if (spec.EidSubstring)
+                    return EidAwareListVerdict(mine, seg, cls.BaseKey, conn, spec, resolver, warnings, dedupe);
+                return FormSetVerdict(mine, seg, cls.BaseKey, conn, spec.FormType, resolver, warnings, dedupe);
+            }
+            case SkyPatcherFilterEval.EnumEquals:
+            {
+                var current = spec.Paths.Select(p => TryLeafToken(record, p)).FirstOrDefault(t => t is not null);
+                bool matched = current is not null && seg.Values.Any(v =>
+                {
+                    var member = spec.ValueMap?.GetValueOrDefault(v.Raw) ?? v.Raw;
+                    return string.Equals(current, member, StringComparison.OrdinalIgnoreCase);
+                });
+                return (excluded ? !matched : matched) ? FilterVerdict.Match : FilterVerdict.NoMatch;
+            }
+            case SkyPatcherFilterEval.FlagBool:
+            {
+                var raw = seg.Values.Count > 0 ? seg.Values[0].Raw : "";
+                bool? want = ParseBoolToken(raw);
+                if (want is null)
+                {
+                    if (dedupe.Add($"fb:{cls.BaseKey}:{raw}"))
+                        warnings.Add($"filter '{cls.BaseKey}={raw}' — not a boolean; whether the line applies is UNRESOLVED.");
+                    return FilterVerdict.Unresolved;
+                }
+                ulong bits = FlagBitsAt(record, spec.Paths[0]);
+                if (!TryFlagBit(record, spec.Paths[0], spec.Flag!, out var bit)) return FilterVerdict.Unresolved;
+                bool set = (bits & bit) != 0;
+                if (spec.Invert) set = !set;
+                return set == want.Value ? FilterVerdict.Match : FilterVerdict.NoMatch;
+            }
+            case SkyPatcherFilterEval.FlagAnyOf:
+            {
+                ulong bits = FlagBitsAt(record, spec.Paths[0]);
+                var hits = new List<bool>();
+                foreach (var v in seg.Values)
+                {
+                    var member = spec.ValueMap?.GetValueOrDefault(v.Raw) ?? v.Raw;
+                    if (!TryFlagBit(record, spec.Paths[0], member, out var bit))
+                    {
+                        if (dedupe.Add($"fa:{cls.BaseKey}:{v.Raw}"))
+                            warnings.Add($"filter '{cls.BaseKey}' — flag '{v.Raw}' is not a member of the {spec.Paths[0]} enum (no valueMap match either); whether the line applies is UNRESOLVED.");
+                        return FilterVerdict.Unresolved;
+                    }
+                    hits.Add((bits & bit) != 0);
+                }
+                bool ok = conn switch
+                {
+                    "Or" => hits.Any(h => h),
+                    "Excluded" or "Exclude" => !hits.Any(h => h),
+                    _ => hits.All(h => h),
+                };
+                return ok ? FilterVerdict.Match : FilterVerdict.NoMatch;
+            }
+            case SkyPatcherFilterEval.Gender:
+            {
+                var raw = seg.Values.Count > 0 ? seg.Values[0].Raw : "";
+                bool female;
+                if (raw.Equals("female", StringComparison.OrdinalIgnoreCase)) female = true;
+                else if (raw.Equals("male", StringComparison.OrdinalIgnoreCase)) female = false;
+                else
+                {
+                    if (dedupe.Add($"g:{raw}"))
+                        warnings.Add($"filter '{cls.BaseKey}={raw}' — expected male|female; whether the line applies is UNRESOLVED.");
+                    return FilterVerdict.Unresolved;
+                }
+                ulong bits = FlagBitsAt(record, spec.Paths[0]);
+                if (!TryFlagBit(record, spec.Paths[0], "Female", out var bit)) return FilterVerdict.Unresolved;
+                return ((bits & bit) != 0) == female ? FilterVerdict.Match : FilterVerdict.NoMatch;
+            }
+            case SkyPatcherFilterEval.PcLevelMult:
+            {
+                var raw = seg.Values.Count > 0 ? seg.Values[0].Raw : "";
+                bool? want = ParseBoolToken(raw);
+                if (want is null) return FilterVerdict.Unresolved;
+                var (parent, leaf) = Navigate(record, SplitPath(spec.Paths[0]));
+                bool isMult = leaf.GetValue(parent)?.GetType().Name.Equals("PcLevelMult", StringComparison.Ordinal) == true;
+                return isMult == want.Value ? FilterVerdict.Match : FilterVerdict.NoMatch;
+            }
+            case SkyPatcherFilterEval.SubstringLeaf:
+            {
+                var hay = spec.Paths.Select(p => TryLeafToken(record, p)).FirstOrDefault(t => t is not null) ?? "";
+                return ContainsVerdict(seg, conn, hay) ? FilterVerdict.Match : FilterVerdict.NoMatch;
+            }
+            case SkyPatcherFilterEval.DonorSubstring:
+            {
+                var donor = LinkedFormKey(record, spec.LinkPath!);
+                if (donor is null) return FilterVerdict.NoMatch;   // no link ⇒ nothing to match
+                var hay = resolver.ReadWinnerLeaf(donor.Value, spec.Paths[0]);
+                if (hay is null)
+                {
+                    if (dedupe.Add($"ds:{cls.BaseKey}:{donor}"))
+                        warnings.Add($"filter '{cls.BaseKey}' — could not read '{spec.Paths[0]}' off {donor}'s winner; whether the line applies is UNRESOLVED.");
+                    return FilterVerdict.Unresolved;
+                }
+                return ContainsVerdict(seg, conn, hay) ? FilterVerdict.Match : FilterVerdict.NoMatch;
+            }
+            case SkyPatcherFilterEval.DonorKeywords:
+            {
+                var donor = LinkedFormKey(record, spec.LinkPath!);
+                if (donor is null) return FilterVerdict.NoMatch;
+                var mine = resolver.KeywordsOf(donor.Value);
+                if (mine is null)
+                {
+                    if (dedupe.Add($"dk:{cls.BaseKey}:{donor}"))
+                        warnings.Add($"filter '{cls.BaseKey}' — could not read the keywords of {donor}'s winner; whether the line applies is UNRESOLVED.");
+                    return FilterVerdict.Unresolved;
+                }
+                return KeywordVerdict(mine, seg, cls.BaseKey, conn, resolver, warnings, dedupe);
+            }
+            case SkyPatcherFilterEval.NumericLess:
+            {
+                var tok = TryLeafToken(record, spec.Paths[0]);
+                if (tok is null || !double.TryParse(tok, NumberStyles.Float, CultureInfo.InvariantCulture, out var current))
+                    return FilterVerdict.NoMatch;   // absent/non-numeric leaf can't be "less than N"
+                var raw = seg.Values.Count > 0 ? seg.Values[0].Raw : "";
+                if (!double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var n))
+                {
+                    if (dedupe.Add($"nl:{cls.BaseKey}:{raw}"))
+                        warnings.Add($"filter '{cls.BaseKey}={raw}' — not a number; whether the line applies is UNRESOLVED.");
+                    return FilterVerdict.Unresolved;
+                }
+                return current < n ? FilterVerdict.Match : FilterVerdict.NoMatch;
+            }
+            case SkyPatcherFilterEval.BipedSlots:
+            {
+                ulong bits = FlagBitsAt(record, spec.Paths[0]);
+                var hits = new List<bool>();
+                foreach (var v in seg.Values)
+                {
+                    if (!int.TryParse(v.Raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var idx) || idx is < 0 or > 31)
+                    {
+                        if (dedupe.Add($"bs:{cls.BaseKey}:{v.Raw}"))
+                            warnings.Add($"filter '{cls.BaseKey}' — '{v.Raw}' is not a biped slot INDEX (0–31; slot number − 30); whether the line applies is UNRESOLVED.");
+                        return FilterVerdict.Unresolved;
+                    }
+                    hits.Add((bits & (1UL << idx)) != 0);
+                }
+                bool ok = conn switch
+                {
+                    "Or" => hits.Any(h => h),
+                    "Excluded" or "Exclude" => !hits.Any(h => h),
+                    _ => hits.All(h => h),
+                };
+                return ok ? FilterVerdict.Match : FilterVerdict.NoMatch;
+            }
+            case SkyPatcherFilterEval.LinkedOriginPlugin:
+            {
+                var linked = LinkedFormKey(record, spec.Paths[0]);
+                if (linked is null) return spec.Invert ? FilterVerdict.Match : FilterVerdict.NoMatch;   // no link ⇒ nothing to yield to
+                var linkedOrigin = linked.Value.ModKey.FileName.String;
+                bool hit = seg.Values.Any(v => v.Raw.Equals(linkedOrigin, StringComparison.OrdinalIgnoreCase));
+                if (spec.Invert) return hit ? FilterVerdict.NoMatch : FilterVerdict.Match;   // skip semantics
+                return hit ? FilterVerdict.Match : FilterVerdict.NoMatch;
+            }
+            default:
+                return FilterVerdict.Unresolved;
+        }
+    }
+
+    // ---- filter helpers ------------------------------------------------------------------------------
+
+    /// <summary>The keyword-family verdict (bare = ALL attached, Or = any, Excluded = none) over a
+    /// resolved keyword set. Null set ⇒ the type has no keyword list we can read (unresolved).</summary>
+    static FilterVerdict KeywordVerdict(IReadOnlyList<FormKey>? mine, SkyPatcherSegment seg,
+        string baseKey, string conn, IFormResolver resolver, List<string> warnings, HashSet<string> dedupe)
+    {
+        if (mine is null) return FilterVerdict.Unresolved;
+        var wanted = new List<FormKey>();
+        int unresolved = 0;
+        foreach (var v in seg.Values)
+        {
+            var k = ResolveFormValue(v, "Keyword", resolver);
+            if (k is null)
+            {
+                // A keyword that resolves to NOTHING in the active order can never be attached
+                // to any record — that's a fact about the order, not a guess: it evaluates as
+                // not-attached, surfaced ONCE per token (Wave-1 crux finding: real INIs list
+                // keywords from frameworks the modlist doesn't run, e.g. SLA_KillerHeels).
+                unresolved++;
+                if (dedupe.Add($"kw:{v.Raw}"))
+                    warnings.Add($"keyword '{v.Raw}' (in a {baseKey}{conn}) resolves to nothing in the active order — treated as attached to no record.");
+            }
+            else wanted.Add(k.Value);
+        }
+        bool ok = conn switch
+        {
+            "Or" => wanted.Any(mine.Contains),
+            "Excluded" or "Exclude" => !wanted.Any(mine.Contains),
+            // bare = AND: EVERY listed keyword must be attached — an in-order-nonexistent one can't be.
+            _ => unresolved == 0 && wanted.All(mine.Contains),
+        };
+        return ok ? FilterVerdict.Match : FilterVerdict.NoMatch;
+    }
+
+    /// <summary>List-membership verdict for a set of the record's own attached forms (mgefs, alternate
+    /// textures, factions, recipe ingredients…): bare = ALL listed present, Or = any, Excluded = none.
+    /// An unresolvable listed form is attached to nothing (the keyword-family treatment).</summary>
+    static FilterVerdict FormSetVerdict(IReadOnlyList<FormKey> mine, SkyPatcherSegment seg,
+        string baseKey, string conn, string? formType, IFormResolver resolver,
+        List<string> warnings, HashSet<string> dedupe)
+    {
+        var wanted = new List<FormKey>();
+        int unresolved = 0;
+        foreach (var v in seg.Values)
+        {
+            var k = ResolveFormValue(v, formType, resolver);
+            if (k is null)
+            {
+                unresolved++;
+                if (dedupe.Add($"fs:{baseKey}:{v.Raw}"))
+                    warnings.Add($"form '{v.Raw}' (in a {baseKey}{conn}) resolves to nothing in the active order — treated as attached to no record.");
+            }
+            else wanted.Add(k.Value);
+        }
+        bool ok = conn switch
+        {
+            "Or" => wanted.Any(mine.Contains),
+            "Excluded" or "Exclude" => !wanted.Any(mine.Contains),
+            _ => unresolved == 0 && wanted.All(mine.Contains),
+        };
+        return ok ? FilterVerdict.Match : FilterVerdict.NoMatch;
+    }
+
+    /// <summary>filterByArmorAddons' documented "EditorID substring ok": a listed value that resolves
+    /// to a form matches by key; one that doesn't is a SUBSTRING against each attached form's winner
+    /// EditorID (resolver lookup).</summary>
+    static FilterVerdict EidAwareListVerdict(IReadOnlyList<FormKey> mine, SkyPatcherSegment seg,
+        string baseKey, string conn, FilterSpec spec, IFormResolver resolver,
+        List<string> warnings, HashSet<string> dedupe)
+    {
+        var eids = new Lazy<List<string>>(() => mine
+            .Select(k => resolver.EditorIdOf(k) ?? "")
+            .Where(e => e.Length > 0).ToList());
+        var hits = new List<bool>();
+        foreach (var v in seg.Values)
+        {
+            var k = ResolveFormValue(v, spec.FormType, resolver);
+            hits.Add(k is not null
+                ? mine.Contains(k.Value)
+                : eids.Value.Any(e => e.Contains(v.Raw, StringComparison.OrdinalIgnoreCase)));
+        }
+        bool ok = conn switch
+        {
+            "Or" => hits.Any(h => h),
+            "Excluded" or "Exclude" => !hits.Any(h => h),
+            _ => hits.All(h => h),
+        };
+        return ok ? FilterVerdict.Match : FilterVerdict.NoMatch;
+    }
+
+    /// <summary>A leaf token that treats ANY navigation/absence failure as null — filters read
+    /// optional structure (an absent Model, a null BodyTemplate) as "not there", never a throw.</summary>
+    static string? TryLeafToken(object record, string path)
+    {
+        try { return LeafToken(record, SplitPath(path)); }
+        catch { return null; }
+    }
+
+    /// <summary>The FormKeys of a struct list's key sub-field (Effects→BaseEffect, Factions→Faction…).
+    /// Absent list reads as empty.</summary>
+    static IReadOnlyList<FormKey> EntryKeys(object record, string[] segs, string keyPath)
+    {
+        var keys = new List<FormKey>();
+        System.Collections.IList? list;
+        try { list = ListAt(record, segs); }
+        catch { return keys; }
+        if (list is null) return keys;
+        var kSegs = SplitPath(keyPath);
+        foreach (var entry in list)
+        {
+            if (entry is null) continue;
+            string? tok;
+            try { tok = LeafToken(entry, kSegs); }
+            catch { continue; }
+            if (tok is not null && FormKey.TryFactory(tok, out var k)) keys.Add(k);
+        }
+        return keys;
+    }
+
+    /// <summary>A plain formlink list's keys with absence-as-empty and failure-as-empty (filter read).</summary>
+    static IReadOnlyList<FormKey> TryFormLinkKeys(object record, string[] segs)
+    {
+        try { return FormLinkList(record, segs) ?? new List<FormKey>(); }
+        catch { return new List<FormKey>(); }
+    }
+
+    /// <summary>The FormKey a formlink leaf points at (null = absent/unset/unnavigable).</summary>
+    static FormKey? LinkedFormKey(object record, string path)
+    {
+        var tok = TryLeafToken(record, path);
+        return tok is not null && FormKey.TryFactory(tok, out var k) ? k : null;
+    }
+
+    /// <summary>Raw flag bits of an enum leaf; absent structure reads as 0 (no flags set).</summary>
+    static ulong FlagBitsAt(object record, string path)
+    {
+        try
+        {
+            var (parent, leaf) = Navigate(record, SplitPath(path));
+            return Convert.ToUInt64(leaf.GetValue(parent) ?? 0UL, CultureInfo.InvariantCulture);
+        }
+        catch { return 0; }
+    }
+
+    /// <summary>Resolve a flag member NAME to its bit on the enum leaf at <paramref name="path"/>.</summary>
+    static bool TryFlagBit(object record, string path, string member, out ulong bit)
+    {
+        bit = 0;
+        try
+        {
+            var (parent, leaf) = Navigate(record, SplitPath(path));
+            return TryParseEnumMember(leaf.PropertyType, member, out bit);
+        }
+        catch { return false; }
+    }
+
+    static bool? ParseBoolToken(string raw)
+        => raw.Equals("true", StringComparison.OrdinalIgnoreCase) || raw.Equals("yes", StringComparison.OrdinalIgnoreCase) || raw == "1" ? true
+         : raw.Equals("false", StringComparison.OrdinalIgnoreCase) || raw.Equals("no", StringComparison.OrdinalIgnoreCase) || raw == "0" ? false
+         : null;
+
+    static void WarnUnresolvableForm(SkyPatcherValue v, string baseKey, string conn, FilterSpec spec,
+        List<string> warnings, HashSet<string> dedupe)
+    {
+        if (dedupe.Add($"fe:{baseKey}:{v.Raw}"))
+            warnings.Add($"form '{v.Raw}' (in a {baseKey}{conn}) resolves to nothing in the active order{(spec.FormType is null ? "" : $" among {spec.FormType} winners")} — treated as matching no record.");
     }
 
     static bool ContainsVerdict(SkyPatcherSegment seg, string conn, string haystack)

--- a/src/housecarl-core/SkyPatcherOverlay.cs
+++ b/src/housecarl-core/SkyPatcherOverlay.cs
@@ -360,7 +360,12 @@ public static class SkyPatcherOverlay
                 // "Skip records whose LAST OVERRIDE is from a named mod" (magic-effect.md) — the
                 // load-order WINNER's plugin, i.e. the record view's conflict winner. Documented only
                 // in the Excluded spelling; any other connective is unresolved, never guessed.
-                if (conn is not ("Excluded" or "Exclude")) return FilterVerdict.Unresolved;
+                if (conn is not ("Excluded" or "Exclude"))
+                {
+                    if (dedupe.Add($"ovc:{cls.BaseKey}{conn}"))
+                        warnings.Add($"filter '{cls.BaseKey}{conn}' — only the Excluded spelling is documented; whether this connective yields or selects is UNRESOLVED.");
+                    return FilterVerdict.Unresolved;
+                }
                 var winner = resolver.WinnerPluginOf(fk);
                 if (winner is null)
                 {
@@ -386,7 +391,11 @@ public static class SkyPatcherOverlay
                 return FormSetVerdict(mine, seg, cls.BaseKey, conn, "TextureSet", resolver, warnings, dedupe);
             }
             default:
-                return FilterVerdict.Unresolved;   // neither built-in nor mapped — loud skip upstream
+                // Neither built-in nor mapped — a coverage gap the filtermap guard should have caught;
+                // named here too so a stale plugin build can't skip silently.
+                if (dedupe.Add($"nf:{cls.BaseKey}"))
+                    warnings.Add($"filter '{cls.BaseKey}' has no evaluation (neither built-in nor in the filter map) — whether lines carrying it apply is UNRESOLVED (a coverage gap; report it).");
+                return FilterVerdict.Unresolved;
         }
     }
 
@@ -403,13 +412,15 @@ public static class SkyPatcherOverlay
             {
                 // Single-valued form field vs a value list: any-of (an AND over one slot is
                 // unsatisfiable for >1 distinct values — see the enum's declared assumption).
+                // No early break on a match — every unresolvable token still earns its once-per-token
+                // warning (review polish).
                 var current = spec.Paths.Select(p => TryLeafToken(record, p)).Where(t => t is not null).ToList();
                 bool matched = false;
                 foreach (var v in seg.Values)
                 {
                     var k = ResolveFormValue(v, spec.FormType, resolver);
                     if (k is null) { WarnUnresolvableForm(v, cls.BaseKey, conn, spec, warnings, dedupe); continue; }
-                    if (current.Any(t => string.Equals(t, k.Value.ToString(), StringComparison.OrdinalIgnoreCase))) { matched = true; break; }
+                    matched |= current.Any(t => string.Equals(t, k.Value.ToString(), StringComparison.OrdinalIgnoreCase));
                 }
                 return (excluded ? !matched : matched) ? FilterVerdict.Match : FilterVerdict.NoMatch;
             }
@@ -457,7 +468,8 @@ public static class SkyPatcherOverlay
                     return FilterVerdict.Unresolved;
                 }
                 var (bits, enumType) = FlagLeaf(record, spec.Paths[0]);
-                if (enumType is null || !TryParseEnumMember(enumType, spec.Flag!, out var bit)) return FilterVerdict.Unresolved;
+                if (enumType is null || !TryParseEnumMember(enumType, spec.Flag!, out var bit))
+                    return UnresolvedLeaf(cls.BaseKey, spec.Paths[0], warnings, dedupe);
                 bool set = (bits & bit) != 0;
                 if (spec.Invert) set = !set;
                 return set == want.Value ? FilterVerdict.Match : FilterVerdict.NoMatch;
@@ -465,7 +477,7 @@ public static class SkyPatcherOverlay
             case SkyPatcherFilterEval.FlagAnyOf:
             {
                 var (bits, enumType) = FlagLeaf(record, spec.Paths[0]);
-                if (enumType is null) return FilterVerdict.Unresolved;
+                if (enumType is null) return UnresolvedLeaf(cls.BaseKey, spec.Paths[0], warnings, dedupe);
                 var hits = new List<bool>();
                 foreach (var v in seg.Values)
                 {
@@ -504,14 +516,20 @@ public static class SkyPatcherOverlay
                     return FilterVerdict.Unresolved;
                 }
                 var (bits, enumType) = FlagLeaf(record, spec.Paths[0]);
-                if (enumType is null || !TryParseEnumMember(enumType, "Female", out var bit)) return FilterVerdict.Unresolved;
+                if (enumType is null || !TryParseEnumMember(enumType, "Female", out var bit))
+                    return UnresolvedLeaf(cls.BaseKey, spec.Paths[0], warnings, dedupe);
                 return ((bits & bit) != 0) == female ? FilterVerdict.Match : FilterVerdict.NoMatch;
             }
             case SkyPatcherFilterEval.PcLevelMult:
             {
                 var raw = seg.Values.Count > 0 ? seg.Values[0].Raw : "";
                 bool? want = ParseBoolToken(raw);
-                if (want is null) return FilterVerdict.Unresolved;
+                if (want is null)
+                {
+                    if (dedupe.Add($"pl:{cls.BaseKey}:{raw}"))
+                        warnings.Add($"filter '{cls.BaseKey}={raw}' — not a boolean; whether the line applies is UNRESOLVED.");
+                    return FilterVerdict.Unresolved;
+                }
                 var (parent, leaf) = Navigate(record, SplitPath(spec.Paths[0]));
                 bool isMult = leaf.GetValue(parent)?.GetType().Name.Equals("PcLevelMult", StringComparison.Ordinal) == true;
                 return isMult == want.Value ? FilterVerdict.Match : FilterVerdict.NoMatch;
@@ -589,6 +607,10 @@ public static class SkyPatcherOverlay
                 return hit ? FilterVerdict.Match : FilterVerdict.NoMatch;
             }
             default:
+                // Unreachable while the FilterSpec parser and this switch agree on the eval kinds —
+                // named anyway so a drift can't skip silently (the same contract every arm honors).
+                if (dedupe.Add($"ue:{cls.BaseKey}"))
+                    warnings.Add($"filter '{cls.BaseKey}' — eval kind '{spec.Eval}' has no evaluator; whether the line applies is UNRESOLVED (report it).");
                 return FilterVerdict.Unresolved;
         }
     }
@@ -730,6 +752,15 @@ public static class SkyPatcherOverlay
             return et.IsEnum ? et : null;
         }
         catch { return null; }
+    }
+
+    /// <summary>The named-warning Unresolved for a flag/enum leaf that can't be resolved on this record
+    /// — every Unresolved return owes a per-filter warning (the line-level skip message points at it).</summary>
+    static FilterVerdict UnresolvedLeaf(string baseKey, string path, List<string> warnings, HashSet<string> dedupe)
+    {
+        if (dedupe.Add($"ul:{baseKey}:{path}"))
+            warnings.Add($"filter '{baseKey}' — could not resolve '{path}' (or its member) on this record; whether the line applies is UNRESOLVED.");
+        return FilterVerdict.Unresolved;
     }
 
     static bool? ParseBoolToken(string raw)

--- a/src/housecarl-core/SkyPatcherOverlay.cs
+++ b/src/housecarl-core/SkyPatcherOverlay.cs
@@ -960,6 +960,98 @@ public static class SkyPatcherOverlay
                 applied.Add(new SkyPatcherAppliedOp(line.File, line.LineNumber, seg.Key, raw, map.Path, $"{had} entr(ies)", "0 entries", "cleared"));
                 break;
             }
+            case SkyPatcherOpSemantic.DictSet:
+            case SkyPatcherOpSemantic.DictMult:
+            {
+                var raw = seg.Values.Count > 0 ? seg.Values[0].Raw : "";
+                if (!double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var operand))
+                { warnings.Add($"{where}: '{seg.Key}={raw}' — not a number; skipped."); return; }
+                var key = map.Key ?? throw new InvalidOperationException($"'{seg.Key}' mapping has no dict key");
+                var current = DictNumericValue(record, segs, key);
+                double result;
+                string? note = null;
+                if (map.Semantic == SkyPatcherOpSemantic.DictMult)
+                {
+                    if (current is null)
+                    { warnings.Add($"{where}: '{seg.Key}' — '{map.Path}[{key}]' has no current value to multiply; skipped."); return; }
+                    result = current.Value * operand;
+                    note = $"stateful: {Num(current.Value)} × {raw}";
+                }
+                else result = operand;
+                // The mutation rides the engine's dict Set (Key = the enum entry) — same coercion as the verb surface.
+                WriteEngine.ApplyVerb(record, new WriteRequest
+                { RecordType = fieldMap.RecordType, Path = segs, Verb = "Set", Key = key, Value = result.ToString("R", CultureInfo.InvariantCulture) });
+                applied.Add(new SkyPatcherAppliedOp(line.File, line.LineNumber, seg.Key, raw, $"{map.Path}[{key}]",
+                    current is null ? null : Num(current.Value), Num(DictNumericValue(record, segs, key) ?? result), note));
+                break;
+            }
+            case SkyPatcherOpSemantic.ColorChannel:
+            {
+                // One channel of a whole-value Color: ReadEngine renders "R,G,B,A" and the engine coerces
+                // the same form back — the P3 vector-component token splice, alpha preserved.
+                var raw = seg.Values.Count > 0 ? seg.Values[0].Raw : "";
+                if (!double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var num))
+                { warnings.Add($"{where}: '{seg.Key}={raw}' — not a number; skipped."); return; }
+                var comp = map.Component ?? throw new InvalidOperationException($"'{seg.Key}' mapping has no component");
+                var before = LeafToken(record, segs);
+                var parts = before?.Split(',');
+                if (parts is null || parts.Length < 3 || comp > 2)
+                { warnings.Add($"{where}: '{seg.Key}' — '{map.Path}' is absent or not an R,G,B[,A] colour ('{before ?? "<unreadable>"}'); skipped."); return; }
+                parts[comp] = Math.Round(num, MidpointRounding.AwayFromZero).ToString(CultureInfo.InvariantCulture);
+                WriteEngine.ApplyVerb(record, new WriteRequest { RecordType = fieldMap.RecordType, Path = segs, Verb = "Set", Value = string.Join(",", parts) });
+                applied.Add(new SkyPatcherAppliedOp(line.File, line.LineNumber, seg.Key, raw, $"{map.Path}.{"RGB"[comp]}", before, LeafToken(record, segs), null));
+                break;
+            }
+            case SkyPatcherOpSemantic.BipedSlotsSet:
+            case SkyPatcherOpSemantic.BipedSlotsRemove:
+            {
+                var (parent, leaf) = Navigate(record, segs);
+                if (!leaf.PropertyType.IsEnum && (Nullable.GetUnderlyingType(leaf.PropertyType)?.IsEnum ?? false) == false)
+                    throw new InvalidOperationException($"'{map.Path}' is not a flags enum");
+                var before = LeafToken(record, segs);
+                ulong bits = Convert.ToUInt64(leaf.GetValue(parent) ?? 0UL, CultureInfo.InvariantCulture);
+                foreach (var v in seg.Values)
+                {
+                    if (!int.TryParse(v.Raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var idx) || idx is < 0 or > 31)
+                    { warnings.Add($"{where}: '{seg.Key}' — '{v.Raw}' is not a biped slot INDEX (0–31; slot number − 30); that slot skipped."); continue; }
+                    bits = map.Semantic == SkyPatcherOpSemantic.BipedSlotsSet ? bits | (1UL << idx) : bits & ~(1UL << idx);
+                }
+                SetEnumBits(record, fieldMap, segs, bits);
+                applied.Add(new SkyPatcherAppliedOp(line.File, line.LineNumber, seg.Key, seg.RawValue ?? "", map.Path, before, LeafToken(record, segs), null));
+                break;
+            }
+            case SkyPatcherOpSemantic.TeachSpell:
+            case SkyPatcherOpSemantic.TeachSkill:
+            {
+                var v = seg.Values.Count > 0 ? seg.Values[0] : null;
+                if (v is null) { warnings.Add($"{where}: '{seg.Key}' has no value; skipped."); return; }
+                var before = LeafToken(record, segs);
+                WriteRequest armSet;
+                string armType;
+                if (map.Semantic == SkyPatcherOpSemantic.TeachSpell)
+                {
+                    var spell = ResolveFormValue(v, map.FormType, resolver);
+                    if (spell is null) { warnings.Add($"{where}: '{seg.Key}={v.Raw}' — spell not resolvable; skipped."); return; }
+                    armType = "BookSpell";
+                    armSet = new WriteRequest { RecordType = armType, Path = new[] { "Spell" }, Verb = "Set", Value = spell.Value.ToString() };
+                }
+                else
+                {
+                    armType = "BookSkill";
+                    var token = map.ValueMap?.GetValueOrDefault(v.Raw) ?? v.Raw;
+                    armSet = new WriteRequest { RecordType = armType, Path = new[] { "Skill" }, Verb = "Set", Value = token };
+                }
+                // The polymorphic Teaches swap is the engine's compose-Set: build the concrete arm from
+                // parts and Set the leaf wholesale — the same path the record-authoring surface uses.
+                WriteEngine.ApplyVerb(record, new WriteRequest
+                {
+                    RecordType = fieldMap.RecordType, Path = segs, Verb = "Set",
+                    Struct = new StructSpec { Type = armType, Sets = new List<WriteRequest> { armSet } },
+                });
+                applied.Add(new SkyPatcherAppliedOp(line.File, line.LineNumber, seg.Key, v.Raw, map.Path, before, LeafToken(record, segs),
+                    $"Teaches → {armType}"));
+                break;
+            }
             case SkyPatcherOpSemantic.AddEntry:
             case SkyPatcherOpSemantic.AddEntryOnce:
             case SkyPatcherOpSemantic.RemoveEntry:
@@ -967,6 +1059,7 @@ public static class SkyPatcherOverlay
             case SkyPatcherOpSemantic.ReplaceEntry:
             case SkyPatcherOpSemantic.MultCount:
             case SkyPatcherOpSemantic.RemoveByKeyword:
+            case SkyPatcherOpSemantic.SetEntryCount:
                 ApplyEntryOp(record, fieldMap, seg, map, line, resolver, applied, warnings);
                 break;
 
@@ -974,6 +1067,22 @@ public static class SkyPatcherOverlay
                 warnings.Add($"{where}: op '{seg.Key}' — semantic {map.Semantic} not implemented; named gap.");
                 break;
         }
+    }
+
+    static string Num(double d) => d.ToString("R", CultureInfo.InvariantCulture);
+
+    /// <summary>The numeric value of one dict entry (null = absent key / absent dict / non-numeric),
+    /// read via the non-generic IDictionary view with the key parsed into the dict's enum key type.</summary>
+    static double? DictNumericValue(object record, string[] segs, string key)
+    {
+        var (parent, leaf) = Navigate(record, segs);
+        if (leaf.GetValue(parent) is not System.Collections.IDictionary dict) return null;
+        var kType = (Nullable.GetUnderlyingType(leaf.PropertyType) ?? leaf.PropertyType).GetGenericArguments()[0];
+        object keyObj;
+        try { keyObj = kType.IsEnum ? Enum.Parse(kType, key, ignoreCase: true) : Convert.ChangeType(key, kType, CultureInfo.InvariantCulture); }
+        catch { return null; }
+        var val = dict.Contains(keyObj) ? dict[keyObj] : null;
+        return val is null ? null : Convert.ToDouble(val, CultureInfo.InvariantCulture);
     }
 
     static void ApplySetOne(object record, RecordMap fieldMap, string opKey, OpMap map, string[] segs,
@@ -1112,6 +1221,30 @@ public static class SkyPatcherOverlay
                     int touched = MultiplyEntryCounts(record, segs, el, scope, countPath, mult);
                     applied.Add(new SkyPatcherAppliedOp(line.File, line.LineNumber, seg.Key, v.Raw, map.Path, null, null,
                         $"counts ×{args[^1]} on {touched} entr(ies) (stateful)"));
+                    break;
+                }
+                case SkyPatcherOpSemantic.SetEntryCount:
+                {
+                    // changeCobjsCount=form~count sets a matching entry's count to N; the documented
+                    // 'null' form means EVERY entry (null~0 = all ingredients to 0).
+                    if (args.Count < 2 || !int.TryParse(args[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var setTo))
+                    { warnings.Add($"{where}: '{seg.Key}={v.Raw}' — expected form~count; skipped."); continue; }
+                    var countPath = el.CountPath ?? throw new InvalidOperationException($"'{seg.Key}' element has no countPath");
+                    List<int> idx;
+                    if (args[0].Equals("null", StringComparison.OrdinalIgnoreCase))
+                        idx = Enumerable.Range(0, ListAt(record, segs)?.Count ?? 0).ToList();
+                    else
+                    {
+                        var k = ResolveFormToken(args[0], map.FormType, resolver);
+                        if (k is null) { warnings.Add($"{where}: '{seg.Key}={v.Raw}' — form not resolvable; skipped."); continue; }
+                        idx = EntryIndicesByKey(record, segs, el, k.Value);
+                    }
+                    var list = ListAt(record, segs);
+                    var cSegs = SplitPath(countPath);
+                    foreach (var i in idx)
+                        WriteEngine.ApplyVerb(list![i]!, new WriteRequest { RecordType = el.Type, Path = cSegs, Verb = "Set", Value = setTo.ToString(CultureInfo.InvariantCulture) });
+                    applied.Add(new SkyPatcherAppliedOp(line.File, line.LineNumber, seg.Key, v.Raw, map.Path, null, null,
+                        idx.Count > 0 ? $"count set to {setTo} on {idx.Count} entr(ies)" : "no matching entry — no change"));
                     break;
                 }
                 case SkyPatcherOpSemantic.RemoveByKeyword:

--- a/src/housecarl-core/SkyPatcherOverlay.cs
+++ b/src/housecarl-core/SkyPatcherOverlay.cs
@@ -231,12 +231,26 @@ public static class SkyPatcherOverlay
         // The player rule (grammar §4): the player is excluded from EVERY line — filtered, restricted,
         // or unfiltered — except a lone bare primary filter that names it. Strict reading of the
         // documented "use filterByNpcs=Skyrim.esm|7 ALONE"; declared assumption for the empirical gate.
+        // "Alone" means no other RECORD filter — hasPlugins gates the LINE on the load order, not the
+        // record, so a plugin-gated player line still applies when its gate passes (review finding:
+        // counting the gate silently excluded every conditional player patch).
         if (fk == PlayerFormKey)
-            return filters.Count == 1
-                && filters[0].cls.Filter!.Kind == SkyPatcherFilterKind.Primary
-                && (filters[0].cls.Connective ?? "") == ""
-                && filters[0].seg.Values.Any(v => MatchesIdentity(v, fk, editorId))
-                ? FilterVerdict.Match : FilterVerdict.NoMatch;
+        {
+            var gates = filters.Where(f2 => f2.cls.Filter!.Kind == SkyPatcherFilterKind.HasPlugins).ToList();
+            var recordFilters = filters.Where(f2 => f2.cls.Filter!.Kind != SkyPatcherFilterKind.HasPlugins).ToList();
+            bool lonePrimary = recordFilters.Count == 1
+                && recordFilters[0].cls.Filter!.Kind == SkyPatcherFilterKind.Primary
+                && (recordFilters[0].cls.Connective ?? "") == ""
+                && recordFilters[0].seg.Values.Any(v => MatchesIdentity(v, fk, editorId));
+            if (!lonePrimary) return FilterVerdict.NoMatch;
+            foreach (var (gSeg, gCls) in gates)
+            {
+                var plugins = gSeg.Values.Select(v => v.Raw).ToList();
+                bool okGate = (gCls.Connective ?? "") == "Or" ? plugins.Any(resolver.PluginPresent) : plugins.All(resolver.PluginPresent);
+                if (!okGate) return FilterVerdict.NoMatch;
+            }
+            return FilterVerdict.Match;
+        }
 
         // No filter set → every record of the type is patched (grammar §5).
         if (filters.Count == 0) return FilterVerdict.Match;
@@ -317,10 +331,19 @@ public static class SkyPatcherOverlay
             {
                 // "Records that come from the named plugin(s)" — the record's DEFINING master
                 // (FormKey.ModKey). DECLARED ASSUMPTION (empirical-gate item): the DLL could
-                // conceivably mean any override provider; the defining master is the reading every
-                // community usage implies (filterByModNames=SomeMod.esp = "that mod's records").
+                // conceivably test the WINNING override's provider instead. When the two readings
+                // AGREE for this record (the overwhelmingly common case) the answer is safe under
+                // either; when they DISAGREE the verdict is honestly UNRESOLVED, never a guess
+                // (review finding — a definite verdict here silently picked a side).
                 var origin = fk.ModKey.FileName.String;
                 bool inSet = seg.Values.Any(v => v.Raw.Equals(origin, StringComparison.OrdinalIgnoreCase));
+                if (resolver.WinnerPluginOf(fk) is { } winner
+                    && seg.Values.Any(v => v.Raw.Equals(winner, StringComparison.OrdinalIgnoreCase)) != inSet)
+                {
+                    if (dedupe.Add($"mn:{fk}"))
+                        warnings.Add($"filterByModNames{conn}: the record's defining master ('{origin}') and winning override ('{winner}') disagree on membership — which one the DLL tests is unverified, so whether the line applies is UNRESOLVED.");
+                    return FilterVerdict.Unresolved;
+                }
                 bool ok = conn is "Excluded" or "Exclude" ? !inSet : inSet;
                 return ok ? FilterVerdict.Match : FilterVerdict.NoMatch;
             }
@@ -400,12 +423,27 @@ public static class SkyPatcherOverlay
             }
             case SkyPatcherFilterEval.EnumEquals:
             {
+                // A token that names NO member of the leaf enum (after valueMap) can never match — but
+                // "never matches" is a silently-WRONG verdict under Excluded (it would flip to Match on
+                // the records the author meant to exclude). Unknown token ⇒ warn + Unresolved, the same
+                // treatment every flag evaluator gives an unknown flag (review finding; the fieldmap's
+                // 'scroll'/'darkness'/'nighteye' notes promise exactly this warning).
                 var current = spec.Paths.Select(p => TryLeafToken(record, p)).FirstOrDefault(t => t is not null);
-                bool matched = current is not null && seg.Values.Any(v =>
+                Type? enumType = null;
+                foreach (var p in spec.Paths)
+                    if (TryLeafEnumType(record, p) is { } et) { enumType = et; break; }
+                bool matched = false;
+                foreach (var v in seg.Values)
                 {
                     var member = spec.ValueMap?.GetValueOrDefault(v.Raw) ?? v.Raw;
-                    return string.Equals(current, member, StringComparison.OrdinalIgnoreCase);
-                });
+                    if (enumType is not null && !TryParseEnumMember(enumType, member, out _))
+                    {
+                        if (dedupe.Add($"ee:{cls.BaseKey}:{v.Raw}"))
+                            warnings.Add($"filter '{cls.BaseKey}' — '{v.Raw}' is not a {enumType.Name} member (no valueMap match either); whether the line applies is UNRESOLVED.");
+                        return FilterVerdict.Unresolved;
+                    }
+                    if (current is not null && string.Equals(current, member, StringComparison.OrdinalIgnoreCase)) matched = true;
+                }
                 return (excluded ? !matched : matched) ? FilterVerdict.Match : FilterVerdict.NoMatch;
             }
             case SkyPatcherFilterEval.FlagBool:
@@ -418,20 +456,21 @@ public static class SkyPatcherOverlay
                         warnings.Add($"filter '{cls.BaseKey}={raw}' — not a boolean; whether the line applies is UNRESOLVED.");
                     return FilterVerdict.Unresolved;
                 }
-                ulong bits = FlagBitsAt(record, spec.Paths[0]);
-                if (!TryFlagBit(record, spec.Paths[0], spec.Flag!, out var bit)) return FilterVerdict.Unresolved;
+                var (bits, enumType) = FlagLeaf(record, spec.Paths[0]);
+                if (enumType is null || !TryParseEnumMember(enumType, spec.Flag!, out var bit)) return FilterVerdict.Unresolved;
                 bool set = (bits & bit) != 0;
                 if (spec.Invert) set = !set;
                 return set == want.Value ? FilterVerdict.Match : FilterVerdict.NoMatch;
             }
             case SkyPatcherFilterEval.FlagAnyOf:
             {
-                ulong bits = FlagBitsAt(record, spec.Paths[0]);
+                var (bits, enumType) = FlagLeaf(record, spec.Paths[0]);
+                if (enumType is null) return FilterVerdict.Unresolved;
                 var hits = new List<bool>();
                 foreach (var v in seg.Values)
                 {
                     var member = spec.ValueMap?.GetValueOrDefault(v.Raw) ?? v.Raw;
-                    if (!TryFlagBit(record, spec.Paths[0], member, out var bit))
+                    if (!TryParseEnumMember(enumType, member, out var bit))
                     {
                         if (dedupe.Add($"fa:{cls.BaseKey}:{v.Raw}"))
                             warnings.Add($"filter '{cls.BaseKey}' — flag '{v.Raw}' is not a member of the {spec.Paths[0]} enum (no valueMap match either); whether the line applies is UNRESOLVED.");
@@ -439,13 +478,7 @@ public static class SkyPatcherOverlay
                     }
                     hits.Add((bits & bit) != 0);
                 }
-                bool ok = conn switch
-                {
-                    "Or" => hits.Any(h => h),
-                    "Excluded" or "Exclude" => !hits.Any(h => h),
-                    _ => hits.All(h => h),
-                };
-                return ok ? FilterVerdict.Match : FilterVerdict.NoMatch;
+                return ConnectiveVerdict(conn, hits) ? FilterVerdict.Match : FilterVerdict.NoMatch;
             }
             case SkyPatcherFilterEval.Gender:
             {
@@ -459,8 +492,19 @@ public static class SkyPatcherOverlay
                         warnings.Add($"filter '{cls.BaseKey}={raw}' — expected male|female; whether the line applies is UNRESOLVED.");
                     return FilterVerdict.Unresolved;
                 }
-                ulong bits = FlagBitsAt(record, spec.Paths[0]);
-                if (!TryFlagBit(record, spec.Paths[0], "Female", out var bit)) return FilterVerdict.Unresolved;
+                // A TRAITS-templated NPC takes its gender from the TEMPLATE actor — the own-record
+                // Female bit is not authoritative, so a definite verdict would be silently wrong for
+                // exactly those NPCs (review finding; the same derived-from-template class that keeps
+                // restrictToSkill unmapped). The gendered eval is NPC-only, so the sibling path is fixed.
+                var (tBits, tType) = FlagLeaf(record, "Configuration.TemplateFlags");
+                if (tType is not null && TryParseEnumMember(tType, "Traits", out var traitsBit) && (tBits & traitsBit) != 0)
+                {
+                    if (dedupe.Add($"gt:{cls.BaseKey}"))
+                        warnings.Add($"filter '{cls.BaseKey}' — this NPC templates its TRAITS (gender comes from the template actor, not this record); whether the line applies is UNRESOLVED.");
+                    return FilterVerdict.Unresolved;
+                }
+                var (bits, enumType) = FlagLeaf(record, spec.Paths[0]);
+                if (enumType is null || !TryParseEnumMember(enumType, "Female", out var bit)) return FilterVerdict.Unresolved;
                 return ((bits & bit) != 0) == female ? FilterVerdict.Match : FilterVerdict.NoMatch;
             }
             case SkyPatcherFilterEval.PcLevelMult:
@@ -519,7 +563,9 @@ public static class SkyPatcherOverlay
             }
             case SkyPatcherFilterEval.BipedSlots:
             {
-                ulong bits = FlagBitsAt(record, spec.Paths[0]);
+                // Absent BodyTemplate reads as "occupies no slots" — a fact about the record, not a
+                // failure — so bits ride even when the enum leaf can't be reached.
+                var (bits, _) = FlagLeaf(record, spec.Paths[0]);
                 var hits = new List<bool>();
                 foreach (var v in seg.Values)
                 {
@@ -531,13 +577,7 @@ public static class SkyPatcherOverlay
                     }
                     hits.Add((bits & (1UL << idx)) != 0);
                 }
-                bool ok = conn switch
-                {
-                    "Or" => hits.Any(h => h),
-                    "Excluded" or "Exclude" => !hits.Any(h => h),
-                    _ => hits.All(h => h),
-                };
-                return ok ? FilterVerdict.Match : FilterVerdict.NoMatch;
+                return ConnectiveVerdict(conn, hits) ? FilterVerdict.Match : FilterVerdict.NoMatch;
             }
             case SkyPatcherFilterEval.LinkedOriginPlugin:
             {
@@ -555,45 +595,32 @@ public static class SkyPatcherOverlay
 
     // ---- filter helpers ------------------------------------------------------------------------------
 
-    /// <summary>The keyword-family verdict (bare = ALL attached, Or = any, Excluded = none) over a
-    /// resolved keyword set. Null set ⇒ the type has no keyword list we can read (unresolved).</summary>
+    /// <summary>THE connective fold (grammar §5) — bare = AND (every hit true, gated by
+    /// <paramref name="bareGuard"/>), Or = any, Excluded/Exclude = none. The ONE copy every
+    /// list-membership evaluator rides (review fold — five hand-kept copies of one grammar rule).</summary>
+    static bool ConnectiveVerdict(string conn, IReadOnlyList<bool> hits, bool bareGuard = true) => conn switch
+    {
+        "Or" => hits.Any(h => h),
+        "Excluded" or "Exclude" => !hits.Any(h => h),
+        _ => bareGuard && hits.All(h => h),
+    };
+
+    /// <summary>The keyword-family verdict — <see cref="FormSetVerdict"/> scoped to Keyword. Null set ⇒
+    /// the type has no keyword list we can read (unresolved).</summary>
     static FilterVerdict KeywordVerdict(IReadOnlyList<FormKey>? mine, SkyPatcherSegment seg,
         string baseKey, string conn, IFormResolver resolver, List<string> warnings, HashSet<string> dedupe)
-    {
-        if (mine is null) return FilterVerdict.Unresolved;
-        var wanted = new List<FormKey>();
-        int unresolved = 0;
-        foreach (var v in seg.Values)
-        {
-            var k = ResolveFormValue(v, "Keyword", resolver);
-            if (k is null)
-            {
-                // A keyword that resolves to NOTHING in the active order can never be attached
-                // to any record — that's a fact about the order, not a guess: it evaluates as
-                // not-attached, surfaced ONCE per token (Wave-1 crux finding: real INIs list
-                // keywords from frameworks the modlist doesn't run, e.g. SLA_KillerHeels).
-                unresolved++;
-                if (dedupe.Add($"kw:{v.Raw}"))
-                    warnings.Add($"keyword '{v.Raw}' (in a {baseKey}{conn}) resolves to nothing in the active order — treated as attached to no record.");
-            }
-            else wanted.Add(k.Value);
-        }
-        bool ok = conn switch
-        {
-            "Or" => wanted.Any(mine.Contains),
-            "Excluded" or "Exclude" => !wanted.Any(mine.Contains),
-            // bare = AND: EVERY listed keyword must be attached — an in-order-nonexistent one can't be.
-            _ => unresolved == 0 && wanted.All(mine.Contains),
-        };
-        return ok ? FilterVerdict.Match : FilterVerdict.NoMatch;
-    }
+        => mine is null ? FilterVerdict.Unresolved
+            : FormSetVerdict(mine, seg, baseKey, conn, "Keyword", resolver, warnings, dedupe, noun: "keyword");
 
-    /// <summary>List-membership verdict for a set of the record's own attached forms (mgefs, alternate
-    /// textures, factions, recipe ingredients…): bare = ALL listed present, Or = any, Excluded = none.
-    /// An unresolvable listed form is attached to nothing (the keyword-family treatment).</summary>
+    /// <summary>List-membership verdict for a set of the record's own attached forms (keywords, mgefs,
+    /// alternate textures, factions, recipe ingredients…): bare = ALL listed present, Or = any,
+    /// Excluded = none. A listed form that resolves to NOTHING in the active order can never be attached
+    /// to any record — that's a fact about the order, not a guess: it evaluates as not-attached,
+    /// surfaced ONCE per token (Wave-1 crux finding: real INIs list keywords from frameworks the
+    /// modlist doesn't run, e.g. SLA_KillerHeels) — and makes the bare-AND unsatisfiable.</summary>
     static FilterVerdict FormSetVerdict(IReadOnlyList<FormKey> mine, SkyPatcherSegment seg,
         string baseKey, string conn, string? formType, IFormResolver resolver,
-        List<string> warnings, HashSet<string> dedupe)
+        List<string> warnings, HashSet<string> dedupe, string noun = "form")
     {
         var wanted = new List<FormKey>();
         int unresolved = 0;
@@ -604,17 +631,12 @@ public static class SkyPatcherOverlay
             {
                 unresolved++;
                 if (dedupe.Add($"fs:{baseKey}:{v.Raw}"))
-                    warnings.Add($"form '{v.Raw}' (in a {baseKey}{conn}) resolves to nothing in the active order — treated as attached to no record.");
+                    warnings.Add($"{noun} '{v.Raw}' (in a {baseKey}{conn}) resolves to nothing in the active order — treated as attached to no record.");
             }
             else wanted.Add(k.Value);
         }
-        bool ok = conn switch
-        {
-            "Or" => wanted.Any(mine.Contains),
-            "Excluded" or "Exclude" => !wanted.Any(mine.Contains),
-            _ => unresolved == 0 && wanted.All(mine.Contains),
-        };
-        return ok ? FilterVerdict.Match : FilterVerdict.NoMatch;
+        return ConnectiveVerdict(conn, wanted.Select(mine.Contains).ToList(), bareGuard: unresolved == 0)
+            ? FilterVerdict.Match : FilterVerdict.NoMatch;
     }
 
     /// <summary>filterByArmorAddons' documented "EditorID substring ok": a listed value that resolves
@@ -635,13 +657,7 @@ public static class SkyPatcherOverlay
                 ? mine.Contains(k.Value)
                 : eids.Value.Any(e => e.Contains(v.Raw, StringComparison.OrdinalIgnoreCase)));
         }
-        bool ok = conn switch
-        {
-            "Or" => hits.Any(h => h),
-            "Excluded" or "Exclude" => !hits.Any(h => h),
-            _ => hits.All(h => h),
-        };
-        return ok ? FilterVerdict.Match : FilterVerdict.NoMatch;
+        return ConnectiveVerdict(conn, hits) ? FilterVerdict.Match : FilterVerdict.NoMatch;
     }
 
     /// <summary>A leaf token that treats ANY navigation/absence failure as null — filters read
@@ -687,27 +703,33 @@ public static class SkyPatcherOverlay
         return tok is not null && FormKey.TryFactory(tok, out var k) ? k : null;
     }
 
-    /// <summary>Raw flag bits of an enum leaf; absent structure reads as 0 (no flags set).</summary>
-    static ulong FlagBitsAt(object record, string path)
+    /// <summary>ONE navigation for the flag-family evaluators: the raw bits AND the enum type of the
+    /// leaf at <paramref name="path"/> (review fold — the old bits+member pair walked the same leaf
+    /// twice, or 1+N times for a value list). Absent structure reads as (0, null): bits honestly say
+    /// "no flags set", and the null type tells member-resolving callers to go Unresolved.</summary>
+    static (ulong bits, Type? enumType) FlagLeaf(object record, string path)
     {
         try
         {
             var (parent, leaf) = Navigate(record, SplitPath(path));
-            return Convert.ToUInt64(leaf.GetValue(parent) ?? 0UL, CultureInfo.InvariantCulture);
+            var et = Nullable.GetUnderlyingType(leaf.PropertyType) ?? leaf.PropertyType;
+            if (!et.IsEnum) return (0, null);
+            return (Convert.ToUInt64(leaf.GetValue(parent) ?? 0UL, CultureInfo.InvariantCulture), et);
         }
-        catch { return 0; }
+        catch { return (0, null); }
     }
 
-    /// <summary>Resolve a flag member NAME to its bit on the enum leaf at <paramref name="path"/>.</summary>
-    static bool TryFlagBit(object record, string path, string member, out ulong bit)
+    /// <summary>The enum type of a leaf (null = not navigable / not an enum) — EnumEquals' unknown-token
+    /// recognizer.</summary>
+    static Type? TryLeafEnumType(object record, string path)
     {
-        bit = 0;
         try
         {
             var (parent, leaf) = Navigate(record, SplitPath(path));
-            return TryParseEnumMember(leaf.PropertyType, member, out bit);
+            var et = Nullable.GetUnderlyingType(leaf.PropertyType) ?? leaf.PropertyType;
+            return et.IsEnum ? et : null;
         }
-        catch { return false; }
+        catch { return null; }
     }
 
     static bool? ParseBoolToken(string raw)
@@ -1006,7 +1028,7 @@ public static class SkyPatcherOverlay
             case SkyPatcherOpSemantic.BipedSlotsRemove:
             {
                 var (parent, leaf) = Navigate(record, segs);
-                if (!leaf.PropertyType.IsEnum && (Nullable.GetUnderlyingType(leaf.PropertyType)?.IsEnum ?? false) == false)
+                if (!(Nullable.GetUnderlyingType(leaf.PropertyType) ?? leaf.PropertyType).IsEnum)
                     throw new InvalidOperationException($"'{map.Path}' is not a flags enum");
                 var before = LeafToken(record, segs);
                 ulong bits = Convert.ToUInt64(leaf.GetValue(parent) ?? 0UL, CultureInfo.InvariantCulture);

--- a/src/housecarl-core/skypatcher-fieldmap.json
+++ b/src/housecarl-core/skypatcher-fieldmap.json
@@ -2,6 +2,14 @@
     {
         "subfolder":  "weapon",
         "recordType":  "Weapon",
+        "filters":  {
+                        "filterByFirstPersonModel":  {"eval": "formEquals", "path": "FirstPersonModel", "formType": "Static"},
+                        "filterBySkills":  {"eval": "enumEquals", "path": "Data.Skill", "valueMap": {"marksman": "Archery"}},
+                        "restrictToSkills":  {"eval": "enumEquals", "path": "Data.Skill", "valueMap": {"marksman": "Archery"}},
+                        "filterByAnimationType":  {"eval": "enumEquals", "path": "Data.AnimationType", "valueMap": {"handtohandmelee": "HandToHand"}},
+                        "restrictToFlags":  {"eval": "flagAnyOf", "path": "Data.Flags", "note": "the reference documents only the boundweapon token (WeaponData.Flag.BoundWeapon, ignore-case match)"},
+                        "filterByHasAmmoFromWeaponList":  {"unmapped": "the reference names this filter but documents no semantics - whether a line carrying it applies cannot be evaluated"}
+                    },
         "ops":  {
                     "fullName":  {
                                      "semantic":  "set",
@@ -211,6 +219,25 @@
     {
         "subfolder":  "npc",
         "recordType":  "Npc",
+        "filters":  {
+                        "filterByRaces":  {"eval": "formEquals", "path": "Race", "formType": "Race"},
+                        "restrictToRaces":  {"eval": "formEquals", "path": "Race", "formType": "Race", "note": "post-match narrowing - for a single record the verdict is identical to a filter"},
+                        "filterByDefaultOutfits":  {"eval": "formEquals", "path": "DefaultOutfit", "formType": "Outfit"},
+                        "filterByFactions":  {"eval": "formInList", "path": "Factions", "keyPath": "Faction", "formType": "Faction"},
+                        "filterByClass":  {"eval": "formEquals", "path": "Class", "formType": "Class"},
+                        "filterByGender":  {"eval": "gender", "path": "Configuration.Flags"},
+                        "restrictToGender":  {"eval": "gender", "path": "Configuration.Flags"},
+                        "filterByPCLevelMult":  {"eval": "pcLevelMult", "path": "Configuration.Level"},
+                        "filterByAutoCalc":  {"eval": "flagBool", "path": "Configuration.Flags", "flag": "AutoCalcStats"},
+                        "filterByEssential":  {"eval": "flagBool", "path": "Configuration.Flags", "flag": "Essential"},
+                        "filterByProtected":  {"eval": "flagBool", "path": "Configuration.Flags", "flag": "Protected"},
+                        "restrictToVoiceType":  {"eval": "formEquals", "path": "Voice", "formType": "VoiceType"},
+                        "restrictToFlags":  {"eval": "flagAnyOf", "path": "Configuration.Flags", "valueMap": {"usestemplate": "UseTemplate", "doesntbleed": "DoesNotBleed"}, "note": "same 4 unresolvable tokens as setFlags (pclevelmult/calcforalltemplates/norumors/noactivation have no Mutagen member) - those evaluate UNRESOLVED loud"},
+                        "restrictToTemplateFlags":  {"eval": "flagAnyOf", "path": "Configuration.TemplateFlags", "valueMap": {"spells": "SpellList", "unused": "ModelAnimation", "aidefpacklist": "DefPackList"}, "note": "same token deltas as setTemplateFlags; copiedtemplate has no Mutagen member and evaluates UNRESOLVED loud"},
+                        "restrictToMaleModelContains":  {"eval": "donorSubstring", "linkPath": "Race", "path": "SkeletalModel.Male.File", "note": "an NPC's skeleton path lives on its RACE - read off the race's load-order winner"},
+                        "restrictToSkill":  {"unmapped": "NPC skills have no static value for auto-calc actors (the engine derives them from class+level at load) - a static skill~min~max verdict would be silently wrong for most NPCs"},
+                        "rvsRestrictToTraits":  {"unmapped": "scopes setRandomVisualStyle, a non-deterministic HARD op - the line it rides has no static resolution anyway"}
+                    },
         "ops":  {
                     "fullName":  {
                                      "semantic":  "set",
@@ -583,6 +610,11 @@
     {
         "subfolder":  "race",
         "recordType":  "Race",
+        "filters":  {
+                        "filterByMaleModelContains":  {"eval": "substringLeaf", "path": "SkeletalModel.Male.File"},
+                        "filterByFemaleModelContains":  {"eval": "substringLeaf", "path": "SkeletalModel.Female.File"},
+                        "filterByVoiceType":  {"eval": "formEquals", "paths": ["Voices.Male", "Voices.Female"], "formType": "VoiceType", "note": "documented only as ...Or - a race matches when EITHER gendered voice is listed"}
+                    },
         "ops":  {
                     "heightMale":  {
                                        "semantic":  "set",
@@ -1067,6 +1099,9 @@
     {
         "subfolder":  "outfit",
         "recordType":  "Outfit",
+        "filters":  {
+                        "filterByForms":  {"eval": "formInList", "path": "Items", "note": "matches outfits CONTAINING the listed object(s); items are Armor or LeveledItem, so a bare EditorID resolves unscoped and warns"}
+                    },
         "ops":  {
                     "formsToAdd":  {
                                        "semantic":  "addForm",
@@ -1197,6 +1232,12 @@
     {
         "subfolder":  "constructibleObject",
         "recordType":  "ConstructibleObject",
+        "filters":  {
+                        "filterByIngredients":  {"eval": "formInList", "path": "Items", "keyPath": "Item.Item", "note": "an ingredient present in the recipe's item list; ingredients can be ANY item type, so a bare EditorID resolves unscoped and warns"},
+                        "filterByWorkBenchKeywords":  {"eval": "formEquals", "path": "WorkbenchKeyword", "formType": "Keyword"},
+                        "filterWorkbenchKeywords":  {"eval": "formEquals", "path": "WorkbenchKeyword", "formType": "Keyword", "note": "the Excluded-only spelling (no 'By') - same field"},
+                        "filterByKeywords":  {"eval": "donorKeywords", "linkPath": "CreatedObject", "note": "the documented semantics match the CREATED OBJECT's keywords, not the recipe's (COBJ has no keyword list) - overrides the built-in keyword walk"}
+                    },
         "ops":  {
                     "workbenchKeyword":  {
                                              "semantic":  "set",
@@ -1299,6 +1340,12 @@
     {
         "subfolder":  "armor",
         "recordType":  "Armor",
+        "filters":  {
+                        "filterByArmorTypes":  {"eval": "enumEquals", "path": "BodyTemplate.ArmorType", "valueMap": {"heavy": "HeavyArmor", "light": "LightArmor"}, "note": "filter tokens heavy|light|clothing differ from the armorType OP tokens (lightarmor|heavyarmor|clothing)"},
+                        "filterByBipedSlots":  {"eval": "bipedSlots", "path": "BodyTemplate.FirstPersonFlags"},
+                        "restrictToBipedSlots":  {"eval": "bipedSlots", "path": "BodyTemplate.FirstPersonFlags"},
+                        "filterByArmorAddons":  {"eval": "formInList", "path": "Armature", "formType": "ArmorAddon", "eidSubstring": true, "note": "the reference documents EditorID SUBSTRING matching - a value that resolves to no form substring-matches the attached addons' winner EditorIDs"}
+                    },
         "ops":  {
                     "fullName":  {
                                      "semantic":  "set",
@@ -1449,6 +1496,10 @@
     {
         "subfolder":  "ammo",
         "recordType":  "Ammunition",
+        "filters":  {
+                        "filterByWeightLessThan":  {"eval": "numericLess", "path": "Weight"},
+                        "restrictToBolts":  {"eval": "flagBool", "path": "Flags", "flag": "NonBolt", "invert": true, "note": "true = bolts only (the NonBolt flag NOT set); false = non-bolts (arrows)"}
+                    },
         "ops":  {
                     "fullName":  {
                                      "semantic":  "set",
@@ -1539,6 +1590,10 @@
     {
         "subfolder":  "spell",
         "recordType":  "Spell",
+        "filters":  {
+                        "filterByFlags":  {"eval": "flagAnyOf", "path": "Flags", "valueMap": {"costoverride": "ManualCostCalc", "pcstartspell": "PCStartSpell", "ignoreloscheck": "AreaEffectIgnoresLOS", "ignoreresistance": "IgnoreResistance", "noabsorb": "NoAbsorbOrReflect", "nodualcastmods": "NoDualCastModification"}, "note": "fooditem/extendduration/instantcast have no SpellDataFlag member (see setFlags) - those tokens evaluate UNRESOLVED loud"},
+                        "restrictToCastingType":  {"eval": "enumEquals", "path": "CastType", "note": "documented token 'scroll' has no Mutagen CastType member and can never match - warned loud at eval"}
+                    },
         "ops":  {
                     "fullName":  {
                                      "semantic":  "set",
@@ -1766,6 +1821,17 @@
     {
         "subfolder":  "magicEffect",
         "recordType":  "MagicEffect",
+        "filters":  {
+                        "filterByArchetypes":  {"eval": "enumEquals", "path": "Archetype.Type", "valueMap": {"boundweapon": "Bound"}, "note": "documented tokens darkness/nighteye have no MagicEffectArchetype.TypeEnum member and can never match - warned loud at eval"},
+                        "filterBySounds":  {"eval": "formInList", "path": "Sounds", "keyPath": "Sound", "formType": "SoundDescriptor", "note": "matches the sound in ANY slot (the documented semantics)"},
+                        "effectShaders":  {"eval": "formEquals", "paths": ["HitShader", "EnchantShader"], "formType": "EffectShader", "note": "documented only as effectShadersExcluded; 'carrying a given effect shader' reads BOTH shader slots"},
+                        "restrictToCastingType":  {"eval": "enumEquals", "path": "CastType"},
+                        "restrictToDeliveryType":  {"eval": "enumEquals", "path": "TargetType"},
+                        "restrictToActorValue":  {"eval": "enumEquals", "path": "Archetype.ActorValue"},
+                        "restrictToResistType":  {"eval": "enumEquals", "path": "ResistValue"},
+                        "restrictToDetrimentalEffects":  {"eval": "flagBool", "path": "Flags", "flag": "Detrimental"},
+                        "restrictToAreaEffects":  {"unmapped": "no single static MGEF field answers 'is an area effect' (area lives on each SPEL/ENCH effect entry, not the MGEF; the NoArea flag governs spellmaking only) - which source the DLL tests needs empirical verification"}
+                    },
         "ops":  {
                     "fullName":  {
                                      "semantic":  "set",
@@ -2016,6 +2082,10 @@
     {
         "subfolder":  "book",
         "recordType":  "Book",
+        "filters":  {
+                        "filterByCastingPerk":  {"unmapped": "no static BOOK field carries a casting perk (Mutagen models Teaches and Flags only) - what the DLL reads needs empirical verification"},
+                        "filterByFlags":  {"eval": "flagAnyOf", "path": "Flags", "valueMap": {"canttake": "CantBeTaken"}, "note": "only canttake is a real Book.Flag bit; advancesactorvalue/teachesspell live in the polymorphic Teaches field and hasbeenread is runtime state - those tokens evaluate UNRESOLVED loud"}
+                    },
         "ops":  {
                     "fullName":  {
                                      "semantic":  "set",
@@ -2552,6 +2622,9 @@
     {
         "subfolder":  "cell",
         "recordType":  "Cell",
+        "filters":  {
+                        "skipRecordByLightingTemplateFromMod":  {"eval": "linkedOriginPlugin", "path": "LightingTemplate", "invert": true, "note": "DECLARED ASSUMPTION: 'the cell's lighting template comes from mod X' = the linked LGTM's defining master (the ELFX/Lux yield case); empirical-gate item"}
+                    },
         "ops":  {
                     "fogNear":  {
                                     "semantic":  "set",
@@ -2731,6 +2804,11 @@
     {
         "subfolder":  "location",
         "recordType":  "Location",
+        "filters":  {
+                        "filterByMusicType":  {"eval": "formEquals", "path": "Music", "formType": "MusicType"},
+                        "filterByParentLocation":  {"eval": "formEquals", "path": "ParentLocation", "formType": "Location"},
+                        "filterByUnreportedCrimeFaction":  {"eval": "formEquals", "path": "UnreportedCrimeFaction", "formType": "Faction"}
+                    },
         "ops":  {
                     "fullName":  {
                                      "semantic":  "set",

--- a/src/housecarl-core/skypatcher-fieldmap.json
+++ b/src/housecarl-core/skypatcher-fieldmap.json
@@ -664,42 +664,18 @@
                                                 "semantic":  "mult",
                                                 "path":  "BaseCarryWeight"
                                             },
-                    "startingHealth":  {
-                                           "unmapped":  "Race starting stats live in Race.Starting, a Dictionary\u003cBasicStat,Single\u003e keyed by the BasicStat enum; dict-keyed overlay paths are a named Wave-2 item"
-                                       },
-                    "startingHealthMult":  {
-                                               "unmapped":  "Race starting stats live in Race.Starting, a Dictionary\u003cBasicStat,Single\u003e keyed by the BasicStat enum; dict-keyed overlay paths are a named Wave-2 item"
-                                           },
-                    "startingStamina":  {
-                                            "unmapped":  "Race starting stats live in Race.Starting, a Dictionary\u003cBasicStat,Single\u003e keyed by the BasicStat enum; dict-keyed overlay paths are a named Wave-2 item"
-                                        },
-                    "startingStaminaMult":  {
-                                                "unmapped":  "Race starting stats live in Race.Starting, a Dictionary\u003cBasicStat,Single\u003e keyed by the BasicStat enum; dict-keyed overlay paths are a named Wave-2 item"
-                                            },
-                    "startingMagicka":  {
-                                            "unmapped":  "Race starting stats live in Race.Starting, a Dictionary\u003cBasicStat,Single\u003e keyed by the BasicStat enum; dict-keyed overlay paths are a named Wave-2 item"
-                                        },
-                    "startingMagickaMult":  {
-                                                "unmapped":  "Race starting stats live in Race.Starting, a Dictionary\u003cBasicStat,Single\u003e keyed by the BasicStat enum; dict-keyed overlay paths are a named Wave-2 item"
-                                            },
-                    "regenHealth":  {
-                                        "unmapped":  "Race regen values live in Race.Regen, a Dictionary\u003cBasicStat,Single\u003e keyed by the BasicStat enum; dict-keyed overlay paths are a named Wave-2 item"
-                                    },
-                    "regenHealthMult":  {
-                                            "unmapped":  "Race regen values live in Race.Regen, a Dictionary\u003cBasicStat,Single\u003e keyed by the BasicStat enum; dict-keyed overlay paths are a named Wave-2 item"
-                                        },
-                    "regenStamina":  {
-                                         "unmapped":  "Race regen values live in Race.Regen, a Dictionary\u003cBasicStat,Single\u003e keyed by the BasicStat enum; dict-keyed overlay paths are a named Wave-2 item"
-                                     },
-                    "regenStaminaMult":  {
-                                             "unmapped":  "Race regen values live in Race.Regen, a Dictionary\u003cBasicStat,Single\u003e keyed by the BasicStat enum; dict-keyed overlay paths are a named Wave-2 item"
-                                         },
-                    "regenMagicka":  {
-                                         "unmapped":  "Race regen values live in Race.Regen, a Dictionary\u003cBasicStat,Single\u003e keyed by the BasicStat enum; dict-keyed overlay paths are a named Wave-2 item"
-                                     },
-                    "regenMagickaMult":  {
-                                             "unmapped":  "Race regen values live in Race.Regen, a Dictionary\u003cBasicStat,Single\u003e keyed by the BasicStat enum; dict-keyed overlay paths are a named Wave-2 item"
-                                         },
+                    "startingHealth":  {"semantic": "dictSet", "path": "Starting", "key": "Health"},
+                    "startingHealthMult":  {"semantic": "dictMult", "path": "Starting", "key": "Health"},
+                    "startingStamina":  {"semantic": "dictSet", "path": "Starting", "key": "Stamina"},
+                    "startingStaminaMult":  {"semantic": "dictMult", "path": "Starting", "key": "Stamina"},
+                    "startingMagicka":  {"semantic": "dictSet", "path": "Starting", "key": "Magicka"},
+                    "startingMagickaMult":  {"semantic": "dictMult", "path": "Starting", "key": "Magicka"},
+                    "regenHealth":  {"semantic": "dictSet", "path": "Regen", "key": "Health"},
+                    "regenHealthMult":  {"semantic": "dictMult", "path": "Regen", "key": "Health"},
+                    "regenStamina":  {"semantic": "dictSet", "path": "Regen", "key": "Stamina"},
+                    "regenStaminaMult":  {"semantic": "dictMult", "path": "Regen", "key": "Stamina"},
+                    "regenMagicka":  {"semantic": "dictSet", "path": "Regen", "key": "Magicka"},
+                    "regenMagickaMult":  {"semantic": "dictMult", "path": "Regen", "key": "Magicka"},
                     "damageUnarmed":  {
                                           "semantic":  "set",
                                           "path":  "UnarmedDamage"
@@ -1300,9 +1276,7 @@
                                                                    "countPath":  "Item.Count"
                                                                }
                                                },
-                    "changeCobjsCount":  {
-                                             "unmapped":  "sets a specific ingredient entry\u0027s count to N (form~count; null~0 = all ingredients to 0) — no set-entry-count semantic exists in the Wave-1 overlay (addEntry/removeEntryByCount/multCount all mutate differently); named Wave-2 item"
-                                         },
+                    "changeCobjsCount":  {"semantic": "setEntryCount", "path": "Items", "formType": "Item", "element": {"type": "ContainerEntry", "keyPath": "Item.Item", "countPath": "Item.Count", "fields": [{"path": "Item.Item", "arg": 0}, {"path": "Item.Count", "arg": 1}]}, "note": "form~count sets that ingredient's count; the documented null~N form sets EVERY entry"},
                     "changeCobjsCountByMult":  {
                                                    "semantic":  "multCount",
                                                    "path":  "Items",
@@ -1435,12 +1409,8 @@
                                              "semantic":  "clearList",
                                              "path":  "Armature"
                                          },
-                    "bipedSlotsToAdd":  {
-                                            "unmapped":  "slot-index → FirstPersonFlags bit math; the documented values are numeric slot indices, and BipedObjectFlag members are names (Head, Body, …) that numeric tokens can\u0027t Enum.Parse — numeric-bit flags semantic is a named Wave-2 item"
-                                        },
-                    "bipedSlotsToRemove":  {
-                                               "unmapped":  "slot-index → FirstPersonFlags bit math; the documented values are numeric slot indices, and BipedObjectFlag members are names (Head, Body, …) that numeric tokens can\u0027t Enum.Parse — numeric-bit flags semantic is a named Wave-2 item"
-                                           },
+                    "bipedSlotsToAdd":  {"semantic": "bipedSlotsSet", "path": "BodyTemplate.FirstPersonFlags", "note": "values are biped slot INDICES (0-31; slot number - 30), OR'd in as bits"},
+                    "bipedSlotsToRemove":  {"semantic": "bipedSlotsRemove", "path": "BodyTemplate.FirstPersonFlags", "note": "values are biped slot INDICES (0-31; slot number - 30), cleared as bits"},
                     "keywordsToAdd":  {
                                           "semantic":  "addForm",
                                           "path":  "Keywords",
@@ -2132,12 +2102,8 @@
                                          "path":  "InventoryArt",
                                          "formType":  "Static"
                                      },
-                    "teachSpell":  {
-                                       "unmapped":  "Book.Teaches is polymorphic (skill vs spell arm: BookSkillLearned vs BookSpellLearned) — a plain formlink set can\u0027t address it; polymorphic overlay set is a named Wave-2 item"
-                                   },
-                    "teachSkill":  {
-                                       "unmapped":  "Book.Teaches is polymorphic (skill vs spell arm: BookSkillLearned vs BookSpellLearned) — a plain enum set can\u0027t address it; polymorphic overlay set is a named Wave-2 item"
-                                   },
+                    "teachSpell":  {"semantic": "teachSpell", "path": "Teaches", "formType": "Spell", "note": "compose-Set of the BookSpell arm (polymorphic Teaches swap through the engine)"},
+                    "teachSkill":  {"semantic": "teachSkill", "path": "Teaches", "valueMap": {"marksman": "Archery", "speechcraft": "Speech"}, "note": "compose-Set of the BookSkill arm; skill tokens match Skill members ignore-case (marksman->Archery, speechcraft->Speech)"},
                     "setFlags":  {
                                      "semantic":  "flagsSet",
                                      "path":  "Flags",
@@ -2650,96 +2616,36 @@
                                          "semantic":  "set",
                                          "path":  "Lighting.DirectionalRotationZ"
                                      },
-                    "ambientRed":  {
-                                       "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.AmbientColor)"
-                                   },
-                    "ambientGreen":  {
-                                         "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.AmbientColor)"
-                                     },
-                    "ambientBlue":  {
-                                        "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.AmbientColor)"
-                                    },
-                    "directionalRed":  {
-                                           "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.DirectionalColor)"
-                                       },
-                    "directionalGreen":  {
-                                             "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.DirectionalColor)"
-                                         },
-                    "directionalBlue":  {
-                                            "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.DirectionalColor)"
-                                        },
-                    "fogColorNearRed":  {
-                                            "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.FogNearColor)"
-                                        },
-                    "fogColorNearGreen":  {
-                                              "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.FogNearColor)"
-                                          },
-                    "fogColorNearBlue":  {
-                                             "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.FogNearColor)"
-                                         },
-                    "directionalAmbientXMinRed":  {
-                                                      "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.AmbientColors.DirectionalXMinus)"
-                                                  },
-                    "directionalAmbientXMinGreen":  {
-                                                        "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.AmbientColors.DirectionalXMinus)"
-                                                    },
-                    "directionalAmbientXMinBlue":  {
-                                                       "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.AmbientColors.DirectionalXMinus)"
-                                                   },
-                    "directionalAmbientXMaxRed":  {
-                                                      "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.AmbientColors.DirectionalXPlus)"
-                                                  },
-                    "directionalAmbientXMaxGreen":  {
-                                                        "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.AmbientColors.DirectionalXPlus)"
-                                                    },
-                    "directionalAmbientXMaxBlue":  {
-                                                       "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.AmbientColors.DirectionalXPlus)"
-                                                   },
-                    "directionalAmbientYMinRed":  {
-                                                      "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.AmbientColors.DirectionalYMinus)"
-                                                  },
-                    "directionalAmbientYMinGreen":  {
-                                                        "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.AmbientColors.DirectionalYMinus)"
-                                                    },
-                    "directionalAmbientYMinBlue":  {
-                                                       "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.AmbientColors.DirectionalYMinus)"
-                                                   },
-                    "directionalAmbientYMaxRed":  {
-                                                      "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.AmbientColors.DirectionalYPlus)"
-                                                  },
-                    "directionalAmbientYMaxGreen":  {
-                                                        "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.AmbientColors.DirectionalYPlus)"
-                                                    },
-                    "directionalAmbientYMaxBlue":  {
-                                                       "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.AmbientColors.DirectionalYPlus)"
-                                                   },
-                    "directionalAmbientZMinRed":  {
-                                                      "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.AmbientColors.DirectionalZMinus)"
-                                                  },
-                    "directionalAmbientZMinGreen":  {
-                                                        "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.AmbientColors.DirectionalZMinus)"
-                                                    },
-                    "directionalAmbientZMinBlue":  {
-                                                       "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.AmbientColors.DirectionalZMinus)"
-                                                   },
-                    "directionalAmbientZMaxRed":  {
-                                                      "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.AmbientColors.DirectionalZPlus)"
-                                                  },
-                    "directionalAmbientZMaxGreen":  {
-                                                        "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.AmbientColors.DirectionalZPlus)"
-                                                    },
-                    "directionalAmbientZMaxBlue":  {
-                                                       "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.AmbientColors.DirectionalZPlus)"
-                                                   },
-                    "directionalAmbientSpecularRed":  {
-                                                          "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.AmbientColors.Specular)"
-                                                      },
-                    "directionalAmbientSpecularGreen":  {
-                                                            "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.AmbientColors.Specular)"
-                                                        },
-                    "directionalAmbientSpecularBlue":  {
-                                                           "unmapped":  "targets one channel of a whole-value Color field — per-channel colour overlay is a named Wave-2 item (the field itself is Lighting.AmbientColors.Specular)"
-                                                       },
+                    "ambientRed":  {"semantic": "colorChannel", "path": "Lighting.AmbientColor", "component": 0},
+                    "ambientGreen":  {"semantic": "colorChannel", "path": "Lighting.AmbientColor", "component": 1},
+                    "ambientBlue":  {"semantic": "colorChannel", "path": "Lighting.AmbientColor", "component": 2},
+                    "directionalRed":  {"semantic": "colorChannel", "path": "Lighting.DirectionalColor", "component": 0},
+                    "directionalGreen":  {"semantic": "colorChannel", "path": "Lighting.DirectionalColor", "component": 1},
+                    "directionalBlue":  {"semantic": "colorChannel", "path": "Lighting.DirectionalColor", "component": 2},
+                    "fogColorNearRed":  {"semantic": "colorChannel", "path": "Lighting.FogNearColor", "component": 0},
+                    "fogColorNearGreen":  {"semantic": "colorChannel", "path": "Lighting.FogNearColor", "component": 1},
+                    "fogColorNearBlue":  {"semantic": "colorChannel", "path": "Lighting.FogNearColor", "component": 2},
+                    "directionalAmbientXMinRed":  {"semantic": "colorChannel", "path": "Lighting.AmbientColors.DirectionalXMinus", "component": 0},
+                    "directionalAmbientXMinGreen":  {"semantic": "colorChannel", "path": "Lighting.AmbientColors.DirectionalXMinus", "component": 1},
+                    "directionalAmbientXMinBlue":  {"semantic": "colorChannel", "path": "Lighting.AmbientColors.DirectionalXMinus", "component": 2},
+                    "directionalAmbientXMaxRed":  {"semantic": "colorChannel", "path": "Lighting.AmbientColors.DirectionalXPlus", "component": 0},
+                    "directionalAmbientXMaxGreen":  {"semantic": "colorChannel", "path": "Lighting.AmbientColors.DirectionalXPlus", "component": 1},
+                    "directionalAmbientXMaxBlue":  {"semantic": "colorChannel", "path": "Lighting.AmbientColors.DirectionalXPlus", "component": 2},
+                    "directionalAmbientYMinRed":  {"semantic": "colorChannel", "path": "Lighting.AmbientColors.DirectionalYMinus", "component": 0},
+                    "directionalAmbientYMinGreen":  {"semantic": "colorChannel", "path": "Lighting.AmbientColors.DirectionalYMinus", "component": 1},
+                    "directionalAmbientYMinBlue":  {"semantic": "colorChannel", "path": "Lighting.AmbientColors.DirectionalYMinus", "component": 2},
+                    "directionalAmbientYMaxRed":  {"semantic": "colorChannel", "path": "Lighting.AmbientColors.DirectionalYPlus", "component": 0},
+                    "directionalAmbientYMaxGreen":  {"semantic": "colorChannel", "path": "Lighting.AmbientColors.DirectionalYPlus", "component": 1},
+                    "directionalAmbientYMaxBlue":  {"semantic": "colorChannel", "path": "Lighting.AmbientColors.DirectionalYPlus", "component": 2},
+                    "directionalAmbientZMinRed":  {"semantic": "colorChannel", "path": "Lighting.AmbientColors.DirectionalZMinus", "component": 0},
+                    "directionalAmbientZMinGreen":  {"semantic": "colorChannel", "path": "Lighting.AmbientColors.DirectionalZMinus", "component": 1},
+                    "directionalAmbientZMinBlue":  {"semantic": "colorChannel", "path": "Lighting.AmbientColors.DirectionalZMinus", "component": 2},
+                    "directionalAmbientZMaxRed":  {"semantic": "colorChannel", "path": "Lighting.AmbientColors.DirectionalZPlus", "component": 0},
+                    "directionalAmbientZMaxGreen":  {"semantic": "colorChannel", "path": "Lighting.AmbientColors.DirectionalZPlus", "component": 1},
+                    "directionalAmbientZMaxBlue":  {"semantic": "colorChannel", "path": "Lighting.AmbientColors.DirectionalZPlus", "component": 2},
+                    "directionalAmbientSpecularRed":  {"semantic": "colorChannel", "path": "Lighting.AmbientColors.Specular", "component": 0},
+                    "directionalAmbientSpecularGreen":  {"semantic": "colorChannel", "path": "Lighting.AmbientColors.Specular", "component": 1},
+                    "directionalAmbientSpecularBlue":  {"semantic": "colorChannel", "path": "Lighting.AmbientColors.Specular", "component": 2},
                     "lightingTemplate":  {
                                              "semantic":  "set",
                                              "path":  "LightingTemplate",

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -200,6 +200,12 @@ public static class CiAll
         // own property resolution; every valueMap/flag token parses into the real leaf enum; element types
         // instantiate and their sub-paths walk. Self-test arm RED-proves the checker catches a broken map.
         ("skypatcher-fieldmap-guard", SkyPatcherFieldMapProbe.RunGuard),
+        // SKYPATCHER DISTRIBUTOR Wave 2 — the INI-vs-INI conflict detector (SkyPatcherConflicts): same-field
+        // SET collisions across the ordered game-visible union (winner = the later file), accumulating ops
+        // never conflict, same-value sets don't, not-applied files don't participate, broad-vs-explicit
+        // collides, extra filters flag CONDITIONAL. Report-only by design (plan §8) — merge decisions stay
+        // agent-side.
+        ("skypatcher-conflicts-guard", SkyPatcherConflictsProbe.RunGuard),
     };
 
     /// <summary>Dispatch a single CI guard by name through the registry — the ONE place a CI probe is listed, so

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -25,6 +25,10 @@ if (args.Length > 0 && args[0] == "vocab") return Probe.RunVocab();
 // the artifact the empirical gate verifies against xEdit + in-game (plan §7 Wave 1).
 if (args.Length > 0 && args[0] == "skypatcher-post-state") return SkyPatcherHarness.Run(args[1..]);
 
+// SkyPatcher Wave-2 harness: the whole-layer scan + INI-vs-INI conflict report off a LIVE MO2 instance,
+// rendered exactly as housecarl_skypatcher_layer returns it (the Wave-2 empirical artifact).
+if (args.Length > 0 && args[0] == "skypatcher-layer") return SkyPatcherHarness.RunLayer(args[1..]);
+
 // Index-build resilience (Nexus bug): feasibility probe — is group enumeration resumable past a parse throw?
 if (args.Length > 0 && args[0] == "pkcu-probe") return PkcuProbe.Run(args[1..]);
 

--- a/src/housecarl-generator/SkyPatcherConflictsProbe.cs
+++ b/src/housecarl-generator/SkyPatcherConflictsProbe.cs
@@ -73,6 +73,16 @@ public static class SkyPatcherConflictsProbe
         failures += Check("different-target sets do NOT collide (no conflict lists 99)",
             conflicts.All(c => c.Entries.All(e => e.Value != "99")), Dump());
 
+        // ---- the set/accumulate PARTITION is exhaustive: a new SkyPatcherOpSemantic member cannot
+        //      silently default to "accumulating" and make the detector under-report (review fold). ----
+        var unclassified = Enum.GetValues<SkyPatcherOpSemantic>()
+            .Where(s => !SkyPatcherConflicts.SetClassSemantics.Contains(s) && !SkyPatcherConflicts.AccumulatingSemantics.Contains(s))
+            .ToList();
+        failures += Check("every op semantic is classified set-class OR accumulating (none silently default)",
+            unclassified.Count == 0, string.Join(", ", unclassified));
+        failures += Check("the set/accumulate sets are disjoint",
+            !SkyPatcherConflicts.SetClassSemantics.Intersect(SkyPatcherConflicts.AccumulatingSemantics).Any());
+
         Console.WriteLine(failures == 0
             ? "[skypatcher-conflicts-guard] PASS — set-collision classification holds."
             : $"[skypatcher-conflicts-guard] FAIL — {failures} case(s).");

--- a/src/housecarl-generator/SkyPatcherConflictsProbe.cs
+++ b/src/housecarl-generator/SkyPatcherConflictsProbe.cs
@@ -1,0 +1,87 @@
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+// ======================================================================
+//  SkyPatcherConflictsProbe — CI guard for the Wave-2 INI-vs-INI conflict
+//  detector (SkyPatcherConflicts; plan §3.2.4, report-only per §8).
+//
+//  RED-proofs the classification lines a wrong model silently corrupts:
+//  a SET-vs-SET same-target collision IS a conflict (winner = the later
+//  file in apply order); accumulating ops are NOT; same-value sets are
+//  NOT; a not-applied file's lines do NOT participate; a broad line
+//  collides with an explicit target; extra filters flag CONDITIONAL.
+// ======================================================================
+public static class SkyPatcherConflictsProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("[skypatcher-conflicts-guard] SkyPatcher INI-vs-INI conflict detector (Wave 2)");
+        int failures = 0;
+
+        var catalog = SkyPatcherCatalog.Load();
+        var fieldMap = SkyPatcherFieldMap.Load();
+        var weapCat = catalog.ForSubfolder("weapon")!;
+
+        SkyPatcherDiscovery.IniFile Ini(string name, params string[] lines) => new(
+            RelPath: $"SKSE\\Plugins\\SkyPatcher\\weapon\\{name}", Subfolder: "weapon", SortKey: name,
+            WinningProvider: "TestMod", ShadowedProviders: Array.Empty<string>(), GatePlugin: null,
+            NotApplied: null, Lines: lines.Select(SkyPatcherParse.ParseLine).ToList());
+
+        const string target = "Skyrim.esm|12EB7";          // 012EB7:Skyrim.esm
+        const string other = "Skyrim.esm|13790";
+
+        var folder = new SkyPatcherDiscovery.FolderScan("weapon", weapCat, PatchingEnabled: true, Files: new[]
+        {
+            Ini("a.ini",
+                $"filterByWeapons={target}:attackDamage=40:weight=5",             // damage + weight sets
+                $"filterByWeapons={target}:keywordsToAdd=Some.esp|100"),          // accumulating — never a conflict
+            Ini("m.ini",
+                $"filterByWeapons={other}:attackDamage=99",                        // DIFFERENT target — no collision
+                $"filterByWeapons={target}:weight=5",                              // SAME value — no collision
+                $"filterByWeapons={target}:filterByKeywords=Some.esp|200:speed=2"),// conditional set
+            Ini("z.ini",
+                $"filterByWeapons={target}:attackDamage=60",                       // the damage collision (z wins)
+                "reach=1.5",                                                        // BROAD set
+                $"filterByWeapons={target}:keywordsToAdd=Some.esp|101",
+                $"filterByWeapons={target}:speed=9"),                              // collides with m's conditional set
+            Ini("gated.ini", $"filterByWeapons={target}:attackDamage=1") with { NotApplied = "filename-gated off" },
+            Ini("y.ini", $"filterByWeapons={target}:reach=2.5"),                   // explicit vs z's BROAD reach
+        });
+
+        var conflicts = SkyPatcherConflicts.Detect(folder, catalog, fieldMap);
+        string Dump() => string.Join(" ; ", conflicts.Select(c => $"{c.Field}@{c.Target}:{string.Join("|", c.Entries.Select(e => $"{e.File}={e.Value}"))}"));
+
+        var dmg = conflicts.FirstOrDefault(c => c.Field == "BasicStats.Damage");
+        failures += Check("SET-vs-SET same-target collision detected (attackDamage a vs z)",
+            dmg is not null && dmg.Entries.Count == 2, Dump());
+        failures += Check("winner = the LATER file in apply order (z.ini, 60)",
+            dmg?.Winner.File == "SKSE\\Plugins\\SkyPatcher\\weapon\\z.ini" && dmg?.Winner.Value == "60", Dump());
+        failures += Check("the not-applied (gated) file's set did NOT participate",
+            dmg is not null && dmg.Entries.All(e => !e.File.Contains("gated")), Dump());
+        failures += Check("accumulating op (keywordsToAdd) is NOT a conflict",
+            conflicts.All(c => c.Field != "Keywords"), Dump());
+        failures += Check("same-value sets are NOT a conflict (weight 5 vs 5)",
+            conflicts.All(c => c.Field != "BasicStats.Weight"), Dump());
+        var reach = conflicts.FirstOrDefault(c => c.Field == "Data.Reach");
+        failures += Check("a BROAD set collides with an explicit-target set (reach 1.5 vs 2.5)",
+            reach is not null && reach.Entries.Count == 2 && reach.Winner.Value == "2.5", Dump());
+        var speed = conflicts.FirstOrDefault(c => c.Field == "Data.Speed");
+        failures += Check("an entry whose line carries EXTRA filters is flagged CONDITIONAL",
+            speed is not null && speed.Conditional
+            && speed.Entries.Any(e => e.Conditional) && speed.Entries.Any(e => !e.Conditional), Dump());
+        failures += Check("different-target sets do NOT collide (no conflict lists 99)",
+            conflicts.All(c => c.Entries.All(e => e.Value != "99")), Dump());
+
+        Console.WriteLine(failures == 0
+            ? "[skypatcher-conflicts-guard] PASS — set-collision classification holds."
+            : $"[skypatcher-conflicts-guard] FAIL — {failures} case(s).");
+        return failures == 0 ? 0 : 1;
+    }
+
+    static int Check(string label, bool ok, string? detail = null)
+    {
+        Console.WriteLine($"  {(ok ? "PASS" : "FAIL")}  {label}{(ok || detail is null ? "" : $"  [{detail}]")}");
+        return ok ? 0 : 1;
+    }
+}

--- a/src/housecarl-generator/SkyPatcherFieldMapProbe.cs
+++ b/src/housecarl-generator/SkyPatcherFieldMapProbe.cs
@@ -310,7 +310,31 @@ public static class SkyPatcherFieldMapProbe
                 foreach (var f in rec.Filters)
                 {
                     if (f.Kind is SkyPatcherFilterKind.Primary or SkyPatcherFilterKind.HasPlugins or SkyPatcherFilterKind.NoFilter) continue;
-                    if (SkyPatcherOverlay.BuiltInFilterBases.Contains(f.Name)) continue;
+                    if (SkyPatcherOverlay.BuiltInFilterBases.Contains(f.Name))
+                    {
+                        // The two built-ins that hardcode Mutagen PATHS in the overlay (attached-mgef,
+                        // alternate-texture) are otherwise exempt from the path walk — a Mutagen rename
+                        // would silently turn them into "attached to nothing" (review finding). Walk
+                        // their code-homed paths here for every type that documents the filter.
+                        foreach (var m in maps.Where(m2 => !m2.Filters.ContainsKey(f.Name)))   // a map override (cobj filterByKeywords) validates as a spec instead
+                        {
+                            var rt = asm.GetType("Mutagen.Bethesda.Skyrim." + m.RecordType);
+                            if (rt is null) continue;
+                            if (f.Name == "filterByMgefs" && f.Kind != SkyPatcherFilterKind.Primary)
+                            {
+                                var leaf = WalkPath(rt, "Effects", $"{rec.Subfolder}.builtin.filterByMgefs", problems);
+                                if (leaf is not null && ListElement(StripNullable(leaf.PropertyType)) is { } el)
+                                    WalkPath(el, "BaseEffect", $"{rec.Subfolder}.builtin.filterByMgefs (keyPath)", problems);
+                            }
+                            else if (f.Name == "filterByAlternateTextures")
+                            {
+                                var leaf = WalkPath(rt, "Model.AlternateTextures", $"{rec.Subfolder}.builtin.filterByAlternateTextures", problems);
+                                if (leaf is not null && ListElement(StripNullable(leaf.PropertyType)) is { } el)
+                                    WalkPath(el, "NewTexture", $"{rec.Subfolder}.builtin.filterByAlternateTextures (keyPath)", problems);
+                            }
+                        }
+                        continue;
+                    }
                     if (!maps.Any(m => m.Filters.ContainsKey(f.Name)))
                         problems.Add($"{rec.Subfolder}.{f.Name} ({f.Kind}) is neither a built-in filter family nor in the filter map (map it, or declare it unmapped with a reason).");
                 }

--- a/src/housecarl-generator/SkyPatcherFieldMapProbe.cs
+++ b/src/housecarl-generator/SkyPatcherFieldMapProbe.cs
@@ -158,7 +158,7 @@ public static class SkyPatcherFieldMapProbe
 
                 // shape ⇄ semantic agreement on the stateful ops (both directions).
                 bool shapeStateful = opDef.Shape is SkyPatcherOpShape.Mult or SkyPatcherOpShape.AddNumeric;
-                bool semStateful = m.Semantic is SkyPatcherOpSemantic.Mult or SkyPatcherOpSemantic.AddNumeric;
+                bool semStateful = m.Semantic is SkyPatcherOpSemantic.Mult or SkyPatcherOpSemantic.AddNumeric or SkyPatcherOpSemantic.DictMult;
                 if (shapeStateful != semStateful)
                     problems.Add($"{ctx}: catalog shape '{opDef.Shape}' vs map semantic '{m.Semantic}' disagree on statefulness.");
 
@@ -212,6 +212,48 @@ public static class SkyPatcherFieldMapProbe
                         if (!IsList(leaf.PropertyType))
                             problems.Add($"{ctx}: clearList targets non-list '{m.Path}'.");
                         break;
+                    case SkyPatcherOpSemantic.DictSet:
+                    case SkyPatcherOpSemantic.DictMult:
+                    {
+                        var dt = StripNullable(leaf.PropertyType);
+                        var dictIface = new[] { dt }.Concat(dt.GetInterfaces())
+                            .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>));
+                        if (dictIface is null) { problems.Add($"{ctx}: dict op targets non-dict '{m.Path}' ({dt.Name})."); break; }
+                        var kt = dictIface.GetGenericArguments()[0];
+                        if (m.Key is null) problems.Add($"{ctx}: dict op needs a 'key'.");
+                        else if (kt.IsEnum && !EnumHas(kt, m.Key))
+                            problems.Add($"{ctx}: dict key '{m.Key}' is not a member of {kt.Name}.");
+                        if (!IsNumeric(dictIface.GetGenericArguments()[1]))
+                            problems.Add($"{ctx}: dict op needs a numeric value type, got {dictIface.GetGenericArguments()[1].Name}.");
+                        break;
+                    }
+                    case SkyPatcherOpSemantic.ColorChannel:
+                        if (m.Component is not (>= 0 and <= 2)) problems.Add($"{ctx}: colorChannel needs component 0..2 (R/G/B).");
+                        if (StripNullable(leaf.PropertyType) != typeof(System.Drawing.Color))
+                            problems.Add($"{ctx}: colorChannel targets non-Color '{m.Path}' ({leaf.PropertyType.Name}).");
+                        break;
+                    case SkyPatcherOpSemantic.BipedSlotsSet:
+                    case SkyPatcherOpSemantic.BipedSlotsRemove:
+                        if (!StripNullable(leaf.PropertyType).IsEnum)
+                            problems.Add($"{ctx}: bipedSlots op targets non-enum '{m.Path}'.");
+                        break;
+                    case SkyPatcherOpSemantic.TeachSpell:
+                    case SkyPatcherOpSemantic.TeachSkill:
+                    {
+                        // The leaf is the polymorphic Teaches base; the compose-Set arm + its sub-field
+                        // must exist and the arm must assign to the leaf.
+                        var arm = asm.GetType("Mutagen.Bethesda.Skyrim." + (m.Semantic == SkyPatcherOpSemantic.TeachSpell ? "BookSpell" : "BookSkill"));
+                        if (arm is null) { problems.Add($"{ctx}: the Teaches arm type is missing from Mutagen."); break; }
+                        if (!leaf.PropertyType.IsAssignableFrom(arm))
+                            problems.Add($"{ctx}: {arm.Name} is not assignable to '{m.Path}' ({leaf.PropertyType.Name}).");
+                        WalkPath(arm, m.Semantic == SkyPatcherOpSemantic.TeachSpell ? "Spell" : "Skill", $"{ctx} (arm field)", problems);
+                        if (m.Semantic == SkyPatcherOpSemantic.TeachSkill && m.ValueMap is not null
+                            && asm.GetType("Mutagen.Bethesda.Skyrim.Skill") is { } skillEnum)
+                            foreach (var (tok, member) in m.ValueMap)
+                                if (!EnumHas(skillEnum, member))
+                                    problems.Add($"{ctx}: valueMap '{tok}' → '{member}' is not a member of Skill.");
+                        break;
+                    }
                     case SkyPatcherOpSemantic.AddEntry:
                     case SkyPatcherOpSemantic.AddEntryOnce:
                     case SkyPatcherOpSemantic.RemoveEntry:
@@ -219,6 +261,7 @@ public static class SkyPatcherFieldMapProbe
                     case SkyPatcherOpSemantic.ReplaceEntry:
                     case SkyPatcherOpSemantic.MultCount:
                     case SkyPatcherOpSemantic.RemoveByKeyword:
+                    case SkyPatcherOpSemantic.SetEntryCount:
                     {
                         if (!IsList(leaf.PropertyType)) { problems.Add($"{ctx}: entry op targets non-list '{m.Path}'."); break; }
                         if (m.Element is null) { problems.Add($"{ctx}: entry op needs an element spec."); break; }
@@ -229,7 +272,7 @@ public static class SkyPatcherFieldMapProbe
                         else if (m.Semantic is not SkyPatcherOpSemantic.MultCount)
                             problems.Add($"{ctx}: entry op needs element.keyPath (the form sub-field it matches on).");
                         if (m.Element.CountPath is { } cp) WalkPath(elType, cp, $"{ctx} (countPath)", problems);
-                        else if (m.Semantic is SkyPatcherOpSemantic.RemoveEntryByCount or SkyPatcherOpSemantic.MultCount)
+                        else if (m.Semantic is SkyPatcherOpSemantic.RemoveEntryByCount or SkyPatcherOpSemantic.MultCount or SkyPatcherOpSemantic.SetEntryCount)
                             problems.Add($"{ctx}: {m.Semantic} needs element.countPath.");
                         break;
                     }

--- a/src/housecarl-generator/SkyPatcherFieldMapProbe.cs
+++ b/src/housecarl-generator/SkyPatcherFieldMapProbe.cs
@@ -42,6 +42,18 @@ public static class SkyPatcherFieldMapProbe
             Console.WriteLine($"  PASS  triangle holds — {map.Records.Count} record map(s), " +
                 $"{map.Records.Sum(r => r.Ops.Count)} op entries ({map.Records.Sum(r => r.Ops.Values.Count(o => o.IsUnmapped))} explicitly unmapped)");
 
+        // ---- Wave 2: the FILTER triangle — catalog filters ⇄ filter specs ⇄ the real Mutagen types ----
+        var filterProblems = ValidateFilters(catalog, map);
+        foreach (var p in filterProblems) Console.WriteLine($"  FAIL  {p}");
+        failures += filterProblems.Count;
+        if (filterProblems.Count == 0)
+            Console.WriteLine($"  PASS  filter triangle holds — {map.Records.Sum(r => r.Filters.Count)} filter specs " +
+                $"({map.Records.Sum(r => r.Filters.Values.Count(f => f.IsUnmapped))} explicitly unmapped) + " +
+                $"{SkyPatcherOverlay.BuiltInFilterBases.Count} built-in families");
+        foreach (var r in map.Records)
+            foreach (var (f, spec) in r.Filters.Where(kv => kv.Value.IsUnmapped))
+                Console.WriteLine($"  note  {r.Subfolder}.{f} filter unmapped: {spec.Unmapped}");
+
         // Visibility: the explicitly-unmapped list (each is a reviewed judgment, listed so drift is seen).
         foreach (var r in map.Records)
             foreach (var (op, m) in r.Ops.Where(kv => kv.Value.IsUnmapped))
@@ -64,6 +76,24 @@ public static class SkyPatcherFieldMapProbe
         failures += Check("self-test: bad valueMap target caught", caught.Any(p => p.Contains("NotARealMember")));
         failures += Check("self-test: mapped HARD op caught", caught.Any(p => p.Contains("mirrorWeapon") && p.Contains("HARD")));
         failures += Check("self-test: stateful-shape disagreement caught", caught.Any(p => p.Contains("attackDamageMult") && p.Contains("semantic")));
+
+        // ---- self-test: the FILTER checker must CATCH a broken filter map ----
+        const string brokenFilters = """
+        [
+         { "subfolder": "npc", "recordType": "Npc",
+           "filters": {
+             "filterByRaces":  { "eval": "formEquals", "path": "NoSuchLink", "formType": "Race" },
+             "filterByAutoCalc": { "eval": "flagBool", "path": "Configuration.Flags", "flag": "NotARealFlag" },
+             "notACatalogFilter": { "eval": "gender", "path": "Configuration.Flags" }
+           },
+           "ops": {} }
+        ]
+        """;
+        var badF = SkyPatcherFieldMap.LoadFrom(brokenFilters);
+        var caughtF = ValidateFilters(catalog, badF, completeness: false);
+        failures += Check("filter self-test: bad path caught", caughtF.Any(p => p.Contains("NoSuchLink")));
+        failures += Check("filter self-test: bad flag member caught", caughtF.Any(p => p.Contains("NotARealFlag")));
+        failures += Check("filter self-test: non-catalog filter caught", caughtF.Any(p => p.Contains("notACatalogFilter")));
 
         Console.WriteLine(failures == 0
             ? "[skypatcher-fieldmap-guard] PASS — catalog ⇄ field map ⇄ Mutagen agree."
@@ -215,6 +245,132 @@ public static class SkyPatcherFieldMapProbe
             }
         }
         return problems;
+    }
+
+    /// <summary>The Wave-2 filter triangle: every catalog filter that is not a primary/gate/noFilter
+    /// token is either a BUILT-IN family (<see cref="SkyPatcherOverlay.BuiltInFilterBases"/>) or has a
+    /// per-record <see cref="FilterSpec"/> (mapped, or explicitly unmapped WITH a reason) — and every
+    /// spec's paths/flags/valueMaps walk the real Mutagen types. A filter that is neither would skip
+    /// lines loud at runtime forever without CI ever noticing the coverage gap.</summary>
+    internal static List<string> ValidateFilters(SkyPatcherCatalog catalog, SkyPatcherFieldMap map, bool completeness = true)
+    {
+        var problems = new List<string>();
+        var asm = typeof(SkyrimMod).Assembly;
+
+        if (completeness)
+        {
+            foreach (var rec in catalog.Records)
+            {
+                if (rec.Sig.Equals("OMOD", StringComparison.OrdinalIgnoreCase)) continue;
+                var maps = map.ForSubfolder(rec.Subfolder);
+                if (maps.Count == 0) continue;   // already a Validate() failure
+                foreach (var f in rec.Filters)
+                {
+                    if (f.Kind is SkyPatcherFilterKind.Primary or SkyPatcherFilterKind.HasPlugins or SkyPatcherFilterKind.NoFilter) continue;
+                    if (SkyPatcherOverlay.BuiltInFilterBases.Contains(f.Name)) continue;
+                    if (!maps.Any(m => m.Filters.ContainsKey(f.Name)))
+                        problems.Add($"{rec.Subfolder}.{f.Name} ({f.Kind}) is neither a built-in filter family nor in the filter map (map it, or declare it unmapped with a reason).");
+                }
+            }
+        }
+
+        foreach (var r in map.Records)
+        {
+            var rec = catalog.ForSubfolder(r.Subfolder);
+            var rootType = asm.GetType("Mutagen.Bethesda.Skyrim." + r.RecordType);
+            if (rec is null || rootType is null) continue;   // already Validate() failures
+
+            foreach (var (name, spec) in r.Filters)
+            {
+                var ctx = $"{r.Subfolder}.filters.{name}";
+                if (!rec.Filters.Any(f => f.Name == name))
+                { problems.Add($"{ctx}: not a filter in the catalog for this record type."); continue; }
+                if (spec.IsUnmapped)
+                {
+                    if (string.IsNullOrWhiteSpace(spec.Unmapped)) problems.Add($"{ctx}: unmapped without a reason.");
+                    continue;
+                }
+
+                if (spec.FormType is { } ft
+                    && asm.GetType("Mutagen.Bethesda.Skyrim." + ft) is null
+                    && asm.GetType("Mutagen.Bethesda.Skyrim.I" + ft + "Getter") is null)
+                    problems.Add($"{ctx}: formType '{ft}' is neither a Mutagen.Bethesda.Skyrim record class nor a link interface (I{ft}Getter).");
+
+                // Donor kinds read their path off ANOTHER record: the linkPath walks the record, the
+                // path walks the LINKED type (recovered from the formlink's getter argument).
+                if (spec.Eval is SkyPatcherFilterEval.DonorSubstring or SkyPatcherFilterEval.DonorKeywords)
+                {
+                    if (spec.LinkPath is null) { problems.Add($"{ctx}: donor eval needs linkPath."); continue; }
+                    var link = WalkPath(rootType, spec.LinkPath, $"{ctx} (linkPath)", problems);
+                    if (link is null) continue;
+                    if (spec.Eval == SkyPatcherFilterEval.DonorSubstring)
+                    {
+                        var donorType = FormLinkTargetType(asm, link.PropertyType);
+                        if (donorType is null) { problems.Add($"{ctx}: linkPath '{spec.LinkPath}' is not a formlink (can't resolve the donor type)."); continue; }
+                        WalkPath(donorType, spec.Paths[0], $"{ctx} (donor path)", problems);
+                    }
+                    continue;
+                }
+
+                foreach (var path in spec.Paths)
+                {
+                    var leaf = WalkPath(rootType, path, ctx, problems);
+                    if (leaf is null) continue;
+                    var et = StripNullable(leaf.PropertyType);
+                    switch (spec.Eval)
+                    {
+                        case SkyPatcherFilterEval.EnumEquals:
+                            if (!et.IsEnum) problems.Add($"{ctx}: enumEquals targets non-enum '{path}' ({et.Name}).");
+                            else if (spec.ValueMap is not null)
+                                foreach (var (tok, member) in spec.ValueMap)
+                                    if (!EnumHas(et, member)) problems.Add($"{ctx}: valueMap '{tok}' → '{member}' is not a member of {et.Name}.");
+                            break;
+                        case SkyPatcherFilterEval.FlagBool:
+                        case SkyPatcherFilterEval.FlagAnyOf:
+                        case SkyPatcherFilterEval.BipedSlots:
+                        case SkyPatcherFilterEval.Gender:
+                            if (!et.IsEnum) { problems.Add($"{ctx}: flag eval targets non-enum '{path}' ({et.Name})."); break; }
+                            if (spec.Eval == SkyPatcherFilterEval.FlagBool && (spec.Flag is null || !EnumHas(et, spec.Flag)))
+                                problems.Add($"{ctx}: flagBool flag '{spec.Flag ?? "<null>"}' is not a member of {et.Name}.");
+                            if (spec.Eval == SkyPatcherFilterEval.Gender && !EnumHas(et, "Female"))
+                                problems.Add($"{ctx}: gender eval needs a Female member on {et.Name}.");
+                            if (spec.ValueMap is not null)
+                                foreach (var (tok, member) in spec.ValueMap)
+                                    if (!EnumHas(et, member)) problems.Add($"{ctx}: valueMap '{tok}' → '{member}' is not a member of {et.Name}.");
+                            break;
+                        case SkyPatcherFilterEval.NumericLess:
+                            if (!IsNumeric(et)) problems.Add($"{ctx}: numericLess targets non-numeric '{path}' ({et.Name}).");
+                            break;
+                        case SkyPatcherFilterEval.FormEquals:
+                        case SkyPatcherFilterEval.LinkedOriginPlugin:
+                            if (!et.Name.Contains("FormLink", StringComparison.Ordinal))
+                                problems.Add($"{ctx}: {spec.Eval} targets non-formlink '{path}' ({et.Name}).");
+                            break;
+                        case SkyPatcherFilterEval.FormInList:
+                        {
+                            if (!IsList(et)) { problems.Add($"{ctx}: formInList targets non-list '{path}'."); break; }
+                            var el = ListElement(et)!;
+                            if (spec.KeyPath is { } kp) WalkPath(el, kp, $"{ctx} (keyPath)", problems);
+                            else if (!el.Name.Contains("FormLink", StringComparison.Ordinal))
+                                problems.Add($"{ctx}: formInList without keyPath needs a formlink list, got List<{el.Name}>.");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        return problems;
+    }
+
+    /// <summary>The MUTABLE Mutagen class a FormLink&lt;IXGetter&gt; leaf points at (null when the
+    /// property isn't a formlink or the target class doesn't resolve).</summary>
+    static Type? FormLinkTargetType(Assembly asm, Type linkProp)
+    {
+        var t = StripNullable(linkProp);
+        if (!t.IsGenericType || !t.Name.Contains("FormLink", StringComparison.Ordinal)) return null;
+        var getter = t.GetGenericArguments()[0].Name;                       // "IRaceGetter"
+        if (!getter.StartsWith('I') || !getter.EndsWith("Getter", StringComparison.Ordinal)) return null;
+        return asm.GetType("Mutagen.Bethesda.Skyrim." + getter[1..^"Getter".Length]);
     }
 
     static void CheckValueMap(OpMap m, Type enumType, string ctx, List<string> problems)

--- a/src/housecarl-generator/SkyPatcherHarness.cs
+++ b/src/housecarl-generator/SkyPatcherHarness.cs
@@ -49,6 +49,50 @@ public static class SkyPatcherHarness
         finally { if (tmp is not null) { try { Directory.Delete(tmp, recursive: true); } catch { /* best-effort */ } } }
     }
 
+    /// <summary>
+    /// The Wave-2 layer harness: the whole SkyPatcher layer + conflict report off a live MO2 instance,
+    /// rendered by the SAME Wire the housecarl_skypatcher_layer tool uses (internals-visible) — what the
+    /// tool will return, verifiable before the plugin repackages.
+    /// Run: dotnet run --project src/housecarl-generator skypatcher-layer --instance &lt;MO2 instance dir&gt; [--filter x]
+    /// </summary>
+    public static int RunLayer(string[] args)
+    {
+        string? instance = null, filter = null;
+        for (int i = 0; i < args.Length; i++)
+        {
+            if (args[i] == "--instance" && i + 1 < args.Length) instance = args[++i];
+            else if (args[i] == "--filter" && i + 1 < args.Length) filter = args[++i];
+        }
+        if (instance is null)
+        {
+            Console.Error.WriteLine("usage: skypatcher-layer --instance <MO2 instance dir> [--filter <folder/mod/file>]");
+            return 1;
+        }
+
+        string? tmp = null;
+        if (!File.Exists(CorpusRulebook.CorpusPath))
+        {
+            tmp = Path.Combine(Path.GetTempPath(), "hc-sp-harness-corpus-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tmp);
+            Console.WriteLine($"corpus.json absent — generating into {tmp} (running outside the repo root)…");
+            var gen = CorpusGenerator.GenerateAll(Path.Combine(tmp, "generated"), Path.Combine(tmp, "refs"));
+            if (gen != 0) { Console.Error.WriteLine("error: corpus generation failed"); return gen; }
+            CorpusRulebook.CorpusPath = Path.Combine(tmp, "generated", "corpus.json");
+        }
+        try
+        {
+            var store = new UserConfigStore(Path.Combine(Path.GetTempPath(), $"hc-sp-harness-{Guid.NewGuid():N}.json"));
+            var svc = LoadOrderService.WithInstance(instance, maxPlugins: 0, store);
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            var data = svc.SkyPatcherLayer();
+            sw.Stop();
+            Console.WriteLine(SkyPatcherWire.RenderLayer(data, filter, 200_000));
+            Console.WriteLine($"\n[{sw.Elapsed.TotalSeconds:N1}s]");
+            return 0;
+        }
+        finally { if (tmp is not null) { try { Directory.Delete(tmp, recursive: true); } catch { /* best-effort */ } } }
+    }
+
     static int Run(FormKey fk, string instance)
     {
         // A throwaway user-config store (the harness never writes tool paths); the service reads the

--- a/src/housecarl-generator/SkyPatcherHarness.cs
+++ b/src/housecarl-generator/SkyPatcherHarness.cs
@@ -32,9 +32,15 @@ public static class SkyPatcherHarness
         try { fk = FormKey.Factory(formid.Trim()); }
         catch (Exception ex) { Console.Error.WriteLine($"error: bad FormID '{formid}': {ex.Message}"); return 1; }
 
-        // corpus.json is GENERATED, not tracked — run from outside the repo root the default relative
-        // CorpusPath resolves to nothing and the service's rulebook/type-catalog loads crash unnamed.
-        // Bootstrap the FloiFieldsProbe way: generate into a unique temp dir, cleaned on exit.
+        return WithCorpus(() => Run(fk, instance));
+    }
+
+    /// <summary>corpus.json is GENERATED, not tracked — run from outside the repo root the default
+    /// relative CorpusPath resolves to nothing and the service's rulebook/type-catalog loads crash
+    /// unnamed. Bootstrap the FloiFieldsProbe way (generate into a unique temp dir, cleaned on exit)
+    /// around <paramref name="body"/> — the ONE bootstrap both harness modes ride (review fold).</summary>
+    static int WithCorpus(Func<int> body)
+    {
         string? tmp = null;
         if (!File.Exists(CorpusRulebook.CorpusPath))
         {
@@ -45,7 +51,7 @@ public static class SkyPatcherHarness
             if (gen != 0) { Console.Error.WriteLine("error: corpus generation failed"); return gen; }
             CorpusRulebook.CorpusPath = Path.Combine(tmp, "generated", "corpus.json");
         }
-        try { return Run(fk, instance); }
+        try { return body(); }
         finally { if (tmp is not null) { try { Directory.Delete(tmp, recursive: true); } catch { /* best-effort */ } } }
     }
 
@@ -69,17 +75,7 @@ public static class SkyPatcherHarness
             return 1;
         }
 
-        string? tmp = null;
-        if (!File.Exists(CorpusRulebook.CorpusPath))
-        {
-            tmp = Path.Combine(Path.GetTempPath(), "hc-sp-harness-corpus-" + Guid.NewGuid().ToString("N"));
-            Directory.CreateDirectory(tmp);
-            Console.WriteLine($"corpus.json absent — generating into {tmp} (running outside the repo root)…");
-            var gen = CorpusGenerator.GenerateAll(Path.Combine(tmp, "generated"), Path.Combine(tmp, "refs"));
-            if (gen != 0) { Console.Error.WriteLine("error: corpus generation failed"); return gen; }
-            CorpusRulebook.CorpusPath = Path.Combine(tmp, "generated", "corpus.json");
-        }
-        try
+        return WithCorpus(() =>
         {
             var store = new UserConfigStore(Path.Combine(Path.GetTempPath(), $"hc-sp-harness-{Guid.NewGuid():N}.json"));
             var svc = LoadOrderService.WithInstance(instance, maxPlugins: 0, store);
@@ -89,8 +85,7 @@ public static class SkyPatcherHarness
             Console.WriteLine(SkyPatcherWire.RenderLayer(data, filter, 200_000));
             Console.WriteLine($"\n[{sw.Elapsed.TotalSeconds:N1}s]");
             return 0;
-        }
-        finally { if (tmp is not null) { try { Directory.Delete(tmp, recursive: true); } catch { /* best-effort */ } } }
+        });
     }
 
     static int Run(FormKey fk, string instance)

--- a/src/housecarl-generator/SkyPatcherOverlayProbe.cs
+++ b/src/housecarl-generator/SkyPatcherOverlayProbe.cs
@@ -401,19 +401,66 @@ public static class SkyPatcherOverlayProbe
                 && r.Warnings.Any(w2 => w2.Contains("restrictToSkill") && w2.Contains("no static evaluation")));
         }
 
-        // ---- the player rule: only a LONE bare primary that names the player applies ----
+        // ---- the player rule: only a LONE bare primary that names the player applies — but a
+        //      hasPlugins LINE gate is not a record filter and must not break "alone" (review fix) ----
         {
+            resolver.Plugins.Add("HcGate.esp");
             var player = new Npc(new FormKey(new ModKey("Skyrim", ModType.Master), 0x7), SkyrimRelease.SkyrimSE);
             var r = SkyPatcherOverlay.Apply(player, player.FormKey, "Player", catalog, catalog.ForSubfolder("npc")!,
                 fieldMap.For("npc", "Npc"), new[]
                 {
                     L(1, "weight=9"),                                            // apply-all EXCLUDES the player
                     L(2, "filterByGender=male:weight=3"),                        // filtered lines exclude the player
-                    L(3, "filterByNpcs=Skyrim.esm|7:filterByEssential=false:weight=5"),   // primary + extra ⇒ still excluded
+                    L(3, "filterByNpcs=Skyrim.esm|7:filterByEssential=false:weight=5"),   // primary + extra RECORD filter ⇒ still excluded
                     L(4, "filterByNpcs=Skyrim.esm|7:weight=7"),                  // the ONE documented way in
+                    // NOTE: the player rule deliberately ignores hasPlugins LINE gates when counting
+                    // "alone" (a gate isn't a record filter) — but that path is unreachable through the
+                    // closed catalog today: hasPlugins is documented on weapon/armor/ammo only, so an
+                    // npc line carrying it classifies Unknown and skips loud BEFORE the player rule.
+                    L(5, "hasPlugins=HcGate.esp:filterByNpcs=Skyrim.esm|7:height=2"),
                 }, resolver);
             failures += Check("player rule: only the lone bare primary applied (weight=7, not 9/3/5)",
                 Math.Abs(player.Weight - 7) < 0.001, $"got {player.Weight}");
+            failures += Check("hasPlugins on an npc line is not in the reference — unknown-key LOUD skip, player untouched",
+                Math.Abs(player.Height - 0) < 0.001
+                && r.Warnings.Any(x => x.Contains("hasPlugins") && x.Contains("not in the SkyPatcher reference")),
+                $"height={player.Height}");
+        }
+
+        // ---- review fixes: EnumEquals unknown-token loud, gender templated-NPC honesty,
+        //      filterByModNames defining-vs-winner disagreement ----
+        {
+            var w = mod.Weapons.AddNew();
+            w.EditorID = "HcEnumWarnBow";
+            w.Data = new WeaponData { Skill = Skill.Archery };
+            w.BasicStats = new WeaponBasicStats { Damage = 5 };
+            resolver.Winners[w.FormKey] = "WinOverride.esp";   // ≠ the defining master HcSpOv.esp
+            var r = SkyPatcherOverlay.Apply(w, w.FormKey, w.EditorID, catalog, catalog.ForSubfolder("weapon")!,
+                fieldMap.For("weapon", "Weapon"), new[]
+                {
+                    L(1, "filterBySkills=notaskill:attackDamage=50"),            // no Skill member ⇒ loud UNRESOLVED, never a silent no-match
+                    L(2, "filterByModNames=WinOverride.esp:attackDamage=60"),    // winner says yes, master says no ⇒ DISAGREE ⇒ UNRESOLVED
+                    L(3, "filterByModNames=Unrelated.esp:attackDamage=70"),      // both readings say no ⇒ agree ⇒ NoMatch (silent, honest)
+                }, resolver);
+            failures += Check("EnumEquals: an unknown enum token is a LOUD unresolved skip, never a silent verdict",
+                w.BasicStats!.Damage == 5
+                && r.Warnings.Any(x => x.Contains("notaskill") && x.Contains("UNRESOLVED")),
+                string.Join(" ; ", r.Warnings));
+            failures += Check("filterByModNames: defining-master vs winning-override DISAGREEMENT is unresolved loud; agreement answers",
+                w.BasicStats.Damage == 5
+                && r.Warnings.Any(x => x.Contains("disagree on membership"))
+                && r.LinesSkippedUnresolvedFilter >= 2,
+                string.Join(" ; ", r.Warnings));
+
+            var templated = mod.Npcs.AddNew();
+            templated.EditorID = "HcTemplatedNpc";
+            templated.Configuration.TemplateFlags |= NpcConfiguration.TemplateFlag.Traits;   // gender comes from the template
+            var r2 = SkyPatcherOverlay.Apply(templated, templated.FormKey, templated.EditorID, catalog, catalog.ForSubfolder("npc")!,
+                fieldMap.For("npc", "Npc"), new[] { L(1, "filterByGender=female:weight=44") }, resolver);
+            failures += Check("gender on a TRAITS-templated NPC is unresolved loud (own Female bit not authoritative)",
+                Math.Abs(templated.Weight - 44) > 0.001
+                && r2.Warnings.Any(x => x.Contains("templates its TRAITS")),
+                string.Join(" ; ", r2.Warnings));
         }
 
         // ---- ammo: numericLess + flagBool-invert (restrictToBolts) ----

--- a/src/housecarl-generator/SkyPatcherOverlayProbe.cs
+++ b/src/housecarl-generator/SkyPatcherOverlayProbe.cs
@@ -1,6 +1,7 @@
 using HousecarlCore;
 using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
 using Mutagen.Bethesda.Skyrim;
 
 namespace HousecarlGenerator;
@@ -28,9 +29,15 @@ public static class SkyPatcherOverlayProbe
         public HashSet<string> Plugins = new(StringComparer.OrdinalIgnoreCase);
         public FormKey? ResolveEditorId(string editorId, string? mutagenType)
             => EditorIds.TryGetValue(editorId, out var fk) ? fk : null;
-        public string? ReadWinnerLeaf(FormKey donor, string path) => null;
-        public IReadOnlyList<FormKey>? KeywordsOf(FormKey record) => null;
+        public Dictionary<FormKey, string> WinnerLeafs = new();       // (donor) → the one leaf the test reads
+        public Dictionary<FormKey, IReadOnlyList<FormKey>> Keywords = new();
+        public Dictionary<FormKey, string> Winners = new();
+        public Dictionary<FormKey, string> Eids = new();
+        public string? ReadWinnerLeaf(FormKey donor, string path) => WinnerLeafs.GetValueOrDefault(donor);
+        public IReadOnlyList<FormKey>? KeywordsOf(FormKey record) => Keywords.GetValueOrDefault(record);
         public bool PluginPresent(string pluginName) => Plugins.Contains(pluginName);
+        public string? WinnerPluginOf(FormKey record) => Winners.GetValueOrDefault(record);
+        public string? EditorIdOf(FormKey record) => Eids.GetValueOrDefault(record);
     }
 
     public static int RunGuard(string[] args)
@@ -69,7 +76,7 @@ public static class SkyPatcherOverlayProbe
         var lines = new[]
         {
             // a.ini — earliest in filename sort.
-            L("a.ini", 1, $"filterByWeapons={me}:attackDamage=40:weight=9:keywordsToAdd=HcKw.esp|802"),
+            L("a.ini", 1, $"filterByWeapons={me}:attackDamage=40:weight=9:keywordsToAdd=HcKw.esp|802:skillType=onehanded"),
             // m.ini — a foreign-record line that must NOT apply, then the later weight set.
             L("m.ini", 1, "filterByWeapons=Other.esp|123:attackDamage=1"),
             L("m.ini", 2, $"filterByWeapons={me}:weight=2"),
@@ -78,7 +85,11 @@ public static class SkyPatcherOverlayProbe
             L("z.ini", 2, "filterByWeapons=HcTestSword:attackDamageToAdd=11"),
             L("z.ini", 3, $"filterByWeapons={me}:critDamageSetToBase=true"),
             L("z.ini", 4, $"filterByWeapons={me}:mirrorWeapon=Skyrim.esm|139B9"),
-            L("z.ini", 5, $"filterByWeapons={me}:restrictToSkills=twohanded:speed=9"),
+            L("z.ini", 5, $"filterByWeapons={me}:restrictToSkills=twohanded:speed=9"),   // Wave 2: EVALUATES (no-match on a onehanded sword)
+            L("z.ini", 25, $"filterByWeapons={me}:restrictToSkills=onehanded:speed=6"), // Wave 2: matches
+            L("z.ini", 26, $"filterByWeapons={me}:filterByHasAmmoFromWeaponList=1:stagger=7"),  // explicitly unmapped filter ⇒ loud skip
+            L("z.ini", 27, $"filterByModNames=HcSpOv.esp:rangeMin=11"),                 // origin-plugin match (built-in)
+            L("z.ini", 28, $"filterByModNamesExcluded=HcSpOv.esp:rangeMin=99"),         // excluded ⇒ NOT applied
             L("z.ini", 6, $"filterByWeapons={me}:notAnOp=1"),
             L("z.ini", 7, $"filterByWeapons={me}:fullName=~Reforged Blade~"),
             L("z.ini", 8, $"filterByWeapons={me}:animationType=bow:weaponHitType=no:soundLevel=silent"),
@@ -128,10 +139,16 @@ public static class SkyPatcherOverlayProbe
         failures += Check("HARD op ⇒ a directive, not a value (mirrorWeapon)",
             result.Directives.Any(d => d.Op == "mirrorWeapon" && d.Reason.Contains("copy-from-form")),
             string.Join(" | ", result.Directives.Select(d => $"{d.Op}:{d.Reason}")));
-        failures += Check("unevaluated filter ⇒ line skipped LOUD (restrictToSkills), speed untouched",
+        failures += Check("restrictToSkills EVALUATES (Wave 2): twohanded no-match, onehanded applies (speed=6)",
+            Math.Abs(weap.Data.Speed - 6) < 0.001
+            && !result.Warnings.Any(w => w.Contains("restrictToSkills") && w.Contains("UNRESOLVED")),
+            $"speed={weap.Data.Speed}");
+        failures += Check("explicitly-unmapped filter ⇒ line skipped LOUD (filterByHasAmmoFromWeaponList), stagger untouched",
             result.LinesSkippedUnresolvedFilter >= 1
-            && result.Warnings.Any(w => w.Contains("restrictToSkills") && w.Contains("UNRESOLVED"))
-            && Math.Abs(weap.Data.Speed - 0) < 0.001, $"speed={weap.Data.Speed}");
+            && result.Warnings.Any(w => w.Contains("filterByHasAmmoFromWeaponList") && w.Contains("no static evaluation"))
+            && Math.Abs(weap.Data.Stagger - 1.5) < 0.001, $"stagger={weap.Data.Stagger}");
+        failures += Check("filterByModNames matches the defining master; Excluded skips (rangeMin=11)",
+            Math.Abs(weap.Data.RangeMin - 11) < 0.001, $"rangeMin={weap.Data.RangeMin}");
         failures += Check("an unknown key poisons the WHOLE line, loud (notAnOp)",
             result.Warnings.Any(w => w.Contains("notAnOp") && w.Contains("UNRESOLVED")));
         failures += Check("unknown ONLY-filter line did NOT become apply-all (stagger untouched by z:20)",
@@ -181,8 +198,227 @@ public static class SkyPatcherOverlayProbe
         failures += NpcEntryOpsArm(catalog, fieldMap, mod);
         failures += LeveledListScopeArm(catalog, fieldMap, mod);
         failures += FormListArm(catalog, fieldMap, mod);
+        failures += Wave2FilterArm(catalog, fieldMap, mod);
 
         return Done(failures);
+    }
+
+    /// <summary>The Wave-2 filter surface — one representative per evaluation kind plus the danger
+    /// cases where a wrong model lands elsewhere: the yield/skip filters (match means the line does
+    /// NOT apply — an un-inverted model applies exactly the lines the author asked to suppress), the
+    /// player rule (an apply-all model patches the player the grammar excludes), enum valueMaps
+    /// (marksman→Archery), donor reads, and the explicit unmapped-filter loud skip.</summary>
+    static int Wave2FilterArm(SkyPatcherCatalog catalog, SkyPatcherFieldMap fieldMap, SkyrimMod mod)
+    {
+        Console.WriteLine("  --- Wave-2 filter arm (map-driven + override-aware + player rule) ---");
+        int failures = 0;
+        var resolver = new StubResolver();
+        SkyPatcherOverlay.OrderedLine L(int n, string text) => new("f.ini", n, SkyPatcherParse.ParseLine(text));
+
+        // ---- weapon: enumEquals + valueMap (marksman→Archery), flagAnyOf (boundweapon) ----
+        {
+            var w = mod.Weapons.AddNew();
+            w.EditorID = "HcBow";
+            w.Data = new WeaponData { Skill = Skill.Archery, AnimationType = WeaponAnimationType.Bow, Flags = WeaponData.Flag.BoundWeapon };
+            w.BasicStats = new WeaponBasicStats { Damage = 5, Weight = 1, Value = 1 };
+            var r = SkyPatcherOverlay.Apply(w, w.FormKey, w.EditorID, catalog, catalog.ForSubfolder("weapon")!,
+                fieldMap.For("weapon", "Weapon"), new[]
+                {
+                    L(1, "filterBySkills=marksman:attackDamage=21"),           // valueMap marksman→Archery
+                    L(2, "filterByAnimationTypeOr=crossbow:attackDamage=1"),   // enum no-match
+                    L(3, "restrictToFlags=boundweapon:weight=3"),              // flagAnyOf, ignore-case member
+                }, resolver);
+            failures += Check("enumEquals + valueMap: marksman matched the Archery-skill bow (damage=21)",
+                w.BasicStats!.Damage == 21, $"got {w.BasicStats.Damage}");
+            failures += Check("enum no-match leaves the record alone (crossbow line)", w.BasicStats.Damage != 1);
+            failures += Check("flagAnyOf: boundweapon flag matched (weight=3)",
+                Math.Abs(w.BasicStats.Weight - 3) < 0.001, $"got {w.BasicStats.Weight}");
+        }
+
+        // ---- npc: gender / flagBool / pcLevelMult / formEquals / formInList(keyPath) / class-Exclude /
+        //      donorSubstring / explicit-unmapped restrictToSkill ----
+        {
+            var raceFk = new FormKey(new ModKey("HcRace", ModType.Plugin), 0xC01);
+            var clsFk = new FormKey(new ModKey("HcCls", ModType.Plugin), 0xD01);
+            var facFk = new FormKey(new ModKey("HcFac", ModType.Plugin), 0xA02);
+            var n = mod.Npcs.AddNew();
+            n.EditorID = "HcFilterNpc";
+            n.Configuration.Flags |= NpcConfiguration.Flag.Female | NpcConfiguration.Flag.Essential;
+            n.Configuration.Level = new PcLevelMult { LevelMult = 1.15f };
+            n.Race.SetTo(raceFk);
+            n.Class.SetTo(clsFk);
+            n.Factions.Add(new RankPlacement { Faction = facFk.ToLink<IFactionGetter>(), Rank = 0 });
+            resolver.WinnerLeafs[raceFk] = "Actors\\Character\\Character Assets\\skeleton.nif";
+            var r = SkyPatcherOverlay.Apply(n, n.FormKey, n.EditorID, catalog, catalog.ForSubfolder("npc")!,
+                fieldMap.For("npc", "Npc"), new[]
+                {
+                    L(1, "filterByGender=female:weight=44"),
+                    L(2, "filterByGender=male:weight=1"),
+                    L(3, "filterByEssential=true:height=1.1"),
+                    L(4, "filterByProtected=true:height=9"),
+                    L(5, "filterByPCLevelMult=true:fullName=~Scaled~"),
+                    L(6, "filterByFactionsOr=HcFac.esp|A02,HcFac.esp|FFF:shortName=~Fac~"),
+                    L(7, "filterByRaces=HcRace.esp|C01:weight=55"),
+                    L(8, "filterByClassExclude=HcCls.esp|D01:height=7"),        // its OWN class ⇒ excluded ⇒ no
+                    L(9, "restrictToMaleModelContains=skeleton:deathItem=HcItm.esp|900"),   // donor read off the race
+                    L(10, "restrictToSkill=onehanded~20~60:calcLevelMax=99"),   // explicitly unmapped ⇒ loud skip
+                }, resolver);
+            failures += Check("gender=female matched, male didn't; race formEquals matched last (weight 44→55)",
+                Math.Abs(n.Weight - 55) < 0.001, $"got {n.Weight}");
+            failures += Check("flagBool: essential matched, protected didn't; class-Exclude skipped (height=1.1)",
+                Math.Abs(n.Height - 1.1) < 0.001, $"got {n.Height}");
+            failures += Check("pcLevelMult arm detected (fullName applied)", n.Name?.String == "Scaled", n.Name?.String ?? "<null>");
+            failures += Check("formInList keyPath (factions, Or) matched", n.ShortName?.String == "Fac", n.ShortName?.String ?? "<null>");
+            failures += Check("donorSubstring: NPC skeleton read off its RACE's winner (deathItem set)",
+                n.DeathItem?.FormKey == new FormKey(new ModKey("HcItm", ModType.Plugin), 0x900),
+                n.DeathItem?.FormKey.ToString() ?? "<null>");
+            failures += Check("restrictToSkill is explicitly unmapped ⇒ loud skip, calcLevelMax untouched",
+                n.Configuration.CalcMaxLevel != 99
+                && r.Warnings.Any(w2 => w2.Contains("restrictToSkill") && w2.Contains("no static evaluation")));
+        }
+
+        // ---- the player rule: only a LONE bare primary that names the player applies ----
+        {
+            var player = new Npc(new FormKey(new ModKey("Skyrim", ModType.Master), 0x7), SkyrimRelease.SkyrimSE);
+            var r = SkyPatcherOverlay.Apply(player, player.FormKey, "Player", catalog, catalog.ForSubfolder("npc")!,
+                fieldMap.For("npc", "Npc"), new[]
+                {
+                    L(1, "weight=9"),                                            // apply-all EXCLUDES the player
+                    L(2, "filterByGender=male:weight=3"),                        // filtered lines exclude the player
+                    L(3, "filterByNpcs=Skyrim.esm|7:filterByEssential=false:weight=5"),   // primary + extra ⇒ still excluded
+                    L(4, "filterByNpcs=Skyrim.esm|7:weight=7"),                  // the ONE documented way in
+                }, resolver);
+            failures += Check("player rule: only the lone bare primary applied (weight=7, not 9/3/5)",
+                Math.Abs(player.Weight - 7) < 0.001, $"got {player.Weight}");
+        }
+
+        // ---- ammo: numericLess + flagBool-invert (restrictToBolts) ----
+        {
+            var a = mod.Ammunitions.AddNew();
+            a.EditorID = "HcArrow";
+            a.Weight = 0.1f;
+            a.Flags = Ammunition.Flag.NonBolt;   // an arrow
+            SkyPatcherOverlay.Apply(a, a.FormKey, a.EditorID, catalog, catalog.ForSubfolder("ammo")!,
+                fieldMap.For("ammo", "Ammunition"), new[]
+                {
+                    L(1, "filterByWeightLessThan=0.5:value=20"),   // 0.1 < 0.5 ⇒ applies
+                    L(2, "filterByWeightLessThan=0.05:value=1"),   // no
+                    L(3, "restrictToBolts=true:weight=9"),          // arrow ⇒ no
+                    L(4, "restrictToBolts=false:weight=0.75"),      // non-bolt ⇒ applies
+                }, resolver);
+            failures += Check("numericLess (weightLessThan 0.5 yes, 0.05 no): value=20", a.Value == 20, $"got {a.Value}");
+            failures += Check("restrictToBolts inverts the NonBolt flag (arrow: true no, false yes): weight=0.75",
+                Math.Abs(a.Weight - 0.75) < 0.001, $"got {a.Weight}");
+        }
+
+        // ---- armor: bipedSlots (INDEX = slot−30) + enum valueMap (heavy) + armorAddons EditorID substring ----
+        {
+            var aaFk = new FormKey(new ModKey("HcAA", ModType.Plugin), 0xE01);
+            var ar = mod.Armors.AddNew();
+            ar.EditorID = "HcCuirass";
+            ar.BodyTemplate = new BodyTemplate { ArmorType = ArmorType.HeavyArmor, FirstPersonFlags = BipedObjectFlag.Body };
+            ar.Armature.Add(aaFk.ToLink<IArmorAddonGetter>());
+            resolver.Eids[aaFk] = "HcTestAAHeavyBody";
+            SkyPatcherOverlay.Apply(ar, ar.FormKey, ar.EditorID, catalog, catalog.ForSubfolder("armor")!,
+                fieldMap.For("armor", "Armor"), new[]
+                {
+                    L(1, "filterByBipedSlots=2:weight=4"),          // Body = index 2 (slot 32) ⇒ applies
+                    L(2, "filterByBipedSlotsOr=0,9:weight=9"),      // head/shield ⇒ no
+                    L(3, "filterByArmorTypes=heavy:damageResist=30"),   // valueMap heavy→HeavyArmor
+                    L(4, "filterByArmorAddons=TestAA:weight=6"),    // EditorID SUBSTRING via the resolver
+                }, resolver);
+            failures += Check("bipedSlots: index 2 (Body) matched, 0/9 didn't; addon EID substring matched (weight 4→6)",
+                Math.Abs(ar.Weight - 6) < 0.001, $"got {ar.Weight}");
+            failures += Check("filterByArmorTypes heavy→HeavyArmor (damageResist=30)",
+                Math.Abs(ar.ArmorRating - 30) < 0.001, $"got {ar.ArmorRating}");
+        }
+
+        // ---- magicEffect: modNamesLastOverriddenExcluded yields to the WINNING plugin; effectShaders
+        //      reads both shader slots; detrimental flagBool ----
+        {
+            var shdFk = new FormKey(new ModKey("HcShd", ModType.Plugin), 0xE01);
+            var g = mod.MagicEffects.AddNew();
+            g.EditorID = "HcMgef";
+            g.Flags |= MagicEffect.Flag.Detrimental;
+            g.HitShader.SetTo(shdFk);
+            resolver.Winners[g.FormKey] = "WinPatch.esp";
+            var r = SkyPatcherOverlay.Apply(g, g.FormKey, g.EditorID, catalog, catalog.ForSubfolder("magicEffect")!,
+                fieldMap.For("magicEffect", "MagicEffect"), new[]
+                {
+                    L(1, "modNamesLastOverriddenExcluded=WinPatch.esp:baseCost=9"),    // last override IS listed ⇒ YIELD
+                    L(2, "modNamesLastOverriddenExcluded=Other.esp:baseCost=12"),      // not listed ⇒ applies
+                    L(3, "effectShadersExcluded=HcShd.esp|E01:spellmakingArea=3"),     // shader attached ⇒ excluded ⇒ no
+                    L(4, "effectShadersExcluded=HcShd.esp|E02:spellmakingArea=7"),     // not attached ⇒ applies
+                    L(5, "restrictToDetrimentalEffects=true:spellmakingCastingTime=2"),
+                }, resolver);
+            failures += Check("modNamesLastOverriddenExcluded YIELDS to the winning plugin (baseCost=12, never 9)",
+                Math.Abs(g.BaseCost - 12) < 0.001, $"got {g.BaseCost}");
+            failures += Check("effectShadersExcluded reads the attached shader (area=7, never 3)",
+                g.SpellmakingArea == 7, $"got {g.SpellmakingArea}");
+            failures += Check("restrictToDetrimentalEffects flagBool (castingTime=2)",
+                Math.Abs(g.SpellmakingCastingTime - 2) < 0.001, $"got {g.SpellmakingCastingTime}");
+        }
+
+        // ---- constructibleObject: donorKeywords (the CREATED object's keywords) + workbench formEquals
+        //      + ingredient formInList(keyPath) ----
+        {
+            var createdFk = new FormKey(new ModKey("HcItm", ModType.Plugin), 0x910);
+            var kwFk = new FormKey(new ModKey("HcKw", ModType.Plugin), 0x820);
+            var forgeFk = new FormKey(new ModKey("HcKw", ModType.Plugin), 0xF01);
+            var ingotFk = new FormKey(new ModKey("HcItm", ModType.Plugin), 0x920);
+            var c = mod.ConstructibleObjects.AddNew();
+            c.EditorID = "HcRecipe";
+            c.CreatedObject.SetTo(createdFk);
+            c.WorkbenchKeyword.SetTo(forgeFk);
+            c.Items = new() { new ContainerEntry { Item = new ContainerItem { Item = ingotFk.ToLink<IItemGetter>(), Count = 2 } } };
+            resolver.Keywords[createdFk] = new[] { kwFk };
+            var r = SkyPatcherOverlay.Apply(c, c.FormKey, c.EditorID, catalog, catalog.ForSubfolder("constructibleObject")!,
+                fieldMap.For("constructibleObject", "ConstructibleObject"), new[]
+                {
+                    L(1, "filterByIngredients=HcItm.esp|920:count=7"),
+                    L(2, "filterByWorkBenchKeywords=HcKw.esp|F01:count=5"),
+                    L(3, "filterByKeywords=HcKw.esp|820:count=3"),          // the CREATED object's keywords (map override)
+                    L(4, "filterByKeywordsExcluded=HcKw.esp|820:count=1"),  // excluded on the donor's keywords ⇒ no
+                }, resolver);
+            failures += Check("cobj: ingredient + workbench + donor-keyword filters all matched (3 count sets, final 3)",
+                r.Applied.Count(x => x.Op == "count") == 3 && c.CreatedObjectCount == 3,
+                $"applied={r.Applied.Count(x => x.Op == "count")}, count={c.CreatedObjectCount?.ToString() ?? "<null>"}");
+        }
+
+        // ---- cell: the two skip filters (linked template's origin + record origin substring) ----
+        {
+            var luxLgtm = new FormKey(new ModKey("Lux", ModType.Plugin), 0xC01);
+            var cell = new Cell(new FormKey(new ModKey("HcSpOv", ModType.Plugin), 0xCE1), SkyrimRelease.SkyrimSE);
+            cell.EditorID = "HcCell";
+            cell.LightingTemplate.SetTo(luxLgtm);
+            var r = SkyPatcherOverlay.Apply(cell, cell.FormKey, cell.EditorID, catalog, catalog.ForSubfolder("cell")!,
+                fieldMap.For("cell", "Cell"), new[]
+                {
+                    L(1, "skipRecordByLightingTemplateFromMod=Lux.esp:fogNear=100"),    // template IS from Lux ⇒ SKIP
+                    L(2, "skipRecordByLightingTemplateFromMod=ELFX.esp:fogNear=200"),   // not ⇒ applies
+                    L(3, "skipRecordByModNameContains=HcSp:fogNear=300"),               // origin contains ⇒ SKIP
+                }, resolver);
+            failures += Check("cell skip filters: Lux-template line yielded, ELFX one applied, origin-substring skipped (fogNear=200)",
+                Math.Abs((cell.Lighting?.FogNear ?? 0) - 200) < 0.001, $"got {cell.Lighting?.FogNear}");
+        }
+
+        // ---- race: substringLeaf on the gendered skeleton path ----
+        {
+            var race = mod.Races.AddNew();
+            race.EditorID = "HcRace";
+            race.SkeletalModel = new GenderedItem<SimpleModel?>(
+                new SimpleModel { File = "Actors\\Character\\Character Assets\\skeleton.nif" }, null);
+            SkyPatcherOverlay.Apply(race, race.FormKey, race.EditorID, catalog, catalog.ForSubfolder("race")!,
+                fieldMap.For("race", "Race"), new[]
+                {
+                    L(1, "filterByMaleModelContains=skeleton:baseCarryweight=150"),
+                    L(2, "filterByFemaleModelContains=skeleton:baseCarryweight=9"),   // female model absent ⇒ no
+                }, resolver);
+            failures += Check("race substringLeaf: male skeleton path matched, absent female didn't (carryweight=150)",
+                Math.Abs(race.BaseCarryWeight - 150) < 0.001, $"got {race.BaseCarryWeight}");
+        }
+
+        return failures;
     }
 
     /// <summary>The struct-ENTRY collection semantics (addEntry/'='-pack, addEntryOnce, removeEntry,

--- a/src/housecarl-generator/SkyPatcherOverlayProbe.cs
+++ b/src/housecarl-generator/SkyPatcherOverlayProbe.cs
@@ -199,8 +199,132 @@ public static class SkyPatcherOverlayProbe
         failures += LeveledListScopeArm(catalog, fieldMap, mod);
         failures += FormListArm(catalog, fieldMap, mod);
         failures += Wave2FilterArm(catalog, fieldMap, mod);
+        failures += Wave2OpClosuresArm(catalog, fieldMap, mod);
 
         return Done(failures);
+    }
+
+    /// <summary>The Wave-2 unmapped-op CLOSURES — the five semantics that turn 47 explicitly-unmapped
+    /// entries into resolved post-state: dict-keyed race stats (Set + stateful Mult), Cell per-channel
+    /// colours (token splice, alpha preserved), armor biped-slot INDEX bit math, Book's polymorphic
+    /// Teaches compose-Set, and the COBJ set-entry-count (incl. the null=ALL form).</summary>
+    static int Wave2OpClosuresArm(SkyPatcherCatalog catalog, SkyPatcherFieldMap fieldMap, SkyrimMod mod)
+    {
+        Console.WriteLine("  --- Wave-2 op-closure arm (dict / colour / biped bits / Teaches / entry count) ---");
+        int failures = 0;
+        var resolver = new StubResolver();
+        SkyPatcherOverlay.OrderedLine L(int n, string text) => new("c.ini", n, SkyPatcherParse.ParseLine(text));
+
+        // ---- race: dictSet + dictMult on Starting/Regen (stateful chain: set 100 then ×1.5 = 150) ----
+        {
+            var race = mod.Races.AddNew();
+            race.EditorID = "HcStatRace";
+            race.Starting[BasicStat.Health] = 50;
+            race.Regen[BasicStat.Magicka] = 3;
+            var r = SkyPatcherOverlay.Apply(race, race.FormKey, race.EditorID, catalog, catalog.ForSubfolder("race")!,
+                fieldMap.For("race", "Race"), new[]
+                {
+                    L(1, "startingHealth=100"),
+                    L(2, "startingHealthMult=1.5"),      // runs on the RUNNING 100, not the original 50
+                    L(3, "regenMagickaMult=2"),
+                    L(4, "startingStaminaMult=2"),        // ABSENT key ⇒ loud skip, never invented
+                }, resolver);
+            failures += Check("race dict stats: set 100 then ×1.5 = 150 (ordered, stateful, running-value)",
+                Math.Abs(race.Starting[BasicStat.Health] - 150) < 0.001, $"got {race.Starting[BasicStat.Health]}");
+            failures += Check("race regen dict mult (3 × 2 = 6)",
+                Math.Abs(race.Regen[BasicStat.Magicka] - 6) < 0.001, $"got {race.Regen[BasicStat.Magicka]}");
+            failures += Check("dict mult on an ABSENT key skips LOUD, never invents a base value",
+                !race.Starting.ContainsKey(BasicStat.Stamina)
+                && r.Warnings.Any(w => w.Contains("startingStaminaMult") && w.Contains("no current value")));
+        }
+
+        // ---- cell: per-channel colour splice (alpha + sibling channels preserved) ----
+        {
+            var cell = new Cell(new FormKey(new ModKey("HcSpOv", ModType.Plugin), 0xCE2), SkyrimRelease.SkyrimSE);
+            cell.EditorID = "HcColorCell";
+            cell.Lighting = new CellLighting { AmbientColor = System.Drawing.Color.FromArgb(255, 10, 20, 30) };
+            var me = "HcSpOv.esp|CE2";
+            SkyPatcherOverlay.Apply(cell, cell.FormKey, cell.EditorID, catalog, catalog.ForSubfolder("cell")!,
+                fieldMap.For("cell", "Cell"), new[]
+                {
+                    L(1, $"filterByCells={me}:ambientRed=64"),
+                    L(2, $"filterByCells={me}:ambientBlue=128"),
+                    L(3, $"filterByCells={me}:directionalAmbientXMinGreen=99"),   // nested AmbientColors struct
+                }, resolver);
+            var c = cell.Lighting!.AmbientColor;
+            failures += Check("colour channels spliced independently (R=64, G kept 20, B=128, A kept 255)",
+                c.R == 64 && c.G == 20 && c.B == 128 && c.A == 255, $"got {c.R},{c.G},{c.B},{c.A}");
+            failures += Check("nested directional-ambient channel landed (XMinus.G=99)",
+                cell.Lighting.AmbientColors?.DirectionalXMinus.G == 99,
+                cell.Lighting.AmbientColors?.DirectionalXMinus.ToString() ?? "<null>");
+        }
+
+        // ---- armor: biped-slot INDEX bit math on the ops side (slot 41 = index 11; 42 = 12) ----
+        {
+            var ar = mod.Armors.AddNew();
+            ar.EditorID = "HcSlotArmor";
+            ar.BodyTemplate = new BodyTemplate { FirstPersonFlags = BipedObjectFlag.LongHair };   // index 11 (slot 41)
+            SkyPatcherOverlay.Apply(ar, ar.FormKey, ar.EditorID, catalog, catalog.ForSubfolder("armor")!,
+                fieldMap.For("armor", "Armor"), new[]
+                {
+                    L(1, "bipedSlotsToRemove=11:bipedSlotsToAdd=12"),   // the armor.md example line
+                }, resolver);
+            failures += Check("bipedSlots ops: index 11 cleared, 12 set (the documented example)",
+                !ar.BodyTemplate!.FirstPersonFlags.HasFlag(BipedObjectFlag.LongHair)
+                && ar.BodyTemplate.FirstPersonFlags.HasFlag(BipedObjectFlag.Circlet),
+                ar.BodyTemplate.FirstPersonFlags.ToString());
+        }
+
+        // ---- book: the polymorphic Teaches compose-Set (spell arm, then skill arm overwrites) ----
+        {
+            var spellFk = new FormKey(new ModKey("HcSpl", ModType.Plugin), 0xF10);
+            var book = mod.Books.AddNew();
+            book.EditorID = "HcTome";
+            var r = SkyPatcherOverlay.Apply(book, book.FormKey, book.EditorID, catalog, catalog.ForSubfolder("book")!,
+                fieldMap.For("book", "Book"), new[]
+                {
+                    L(1, "teachSpell=HcSpl.esp|F10"),
+                    L(2, "teachSkill=marksman"),          // valueMap marksman→Archery; later line wins
+                }, resolver);
+            failures += Check("teachSpell composed the BookSpell arm (visible in the applied note)",
+                r.Applied.Any(a => a.Op == "teachSpell" && a.Note == "Teaches → BookSpell"));
+            failures += Check("teachSkill overwrote with the BookSkill arm (marksman→Archery)",
+                book.Teaches is BookSkill bs && bs.Skill == Skill.Archery,
+                book.Teaches?.GetType().Name ?? "<null>");
+        }
+
+        // ---- cobj: set-entry-count (specific form, then null = ALL) ----
+        {
+            var ingotA = new FormKey(new ModKey("HcItm", ModType.Plugin), 0x930);
+            var ingotB = new FormKey(new ModKey("HcItm", ModType.Plugin), 0x931);
+            var c = mod.ConstructibleObjects.AddNew();
+            c.EditorID = "HcCountRecipe";
+            c.Items = new()
+            {
+                new ContainerEntry { Item = new ContainerItem { Item = ingotA.ToLink<IItemGetter>(), Count = 5 } },
+                new ContainerEntry { Item = new ContainerItem { Item = ingotB.ToLink<IItemGetter>(), Count = 5 } },
+            };
+            SkyPatcherOverlay.Apply(c, c.FormKey, c.EditorID, catalog, catalog.ForSubfolder("constructibleObject")!,
+                fieldMap.For("constructibleObject", "ConstructibleObject"), new[]
+                {
+                    L(1, "changeCobjsCount=HcItm.esp|930~2"),   // one ingredient → 2
+                }, resolver);
+            var counts = c.Items!.Select(e => (fk: e.Item.Item.FormKey, n: e.Item.Count)).ToList();
+            failures += Check("setEntryCount: the matching ingredient set to 2, the other untouched",
+                counts.Any(e => e.fk == ingotA && e.n == 2) && counts.Any(e => e.fk == ingotB && e.n == 5),
+                string.Join(" | ", counts.Select(e => $"{e.fk}×{e.n}")));
+
+            SkyPatcherOverlay.Apply(c, c.FormKey, c.EditorID, catalog, catalog.ForSubfolder("constructibleObject")!,
+                fieldMap.For("constructibleObject", "ConstructibleObject"), new[]
+                {
+                    L(1, "changeCobjsCount=null~0"),            // the documented null form: ALL entries
+                }, resolver);
+            failures += Check("setEntryCount null form hits EVERY entry (all counts 0)",
+                c.Items!.All(e => e.Item.Count == 0),
+                string.Join(" | ", c.Items!.Select(e => $"{e.Item.Item.FormKey}×{e.Item.Count}")));
+        }
+
+        return failures;
     }
 
     /// <summary>The Wave-2 filter surface — one representative per evaluation kind plus the danger

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -414,6 +414,36 @@ public sealed class LoadOrderService : IDisposable
             folders, scan.Notes, scan.ReadIncomplete || assets.ReadIncomplete, assetWarnings, profileName);
     }
 
+    /// <summary>
+    /// Scan the WHOLE SkyPatcher layer (housecarl_skypatcher_layer): every loose INI as the DLL reads
+    /// it (ordered union, VFS same-path collisions surfaced, gates + toggles evaluated) plus the
+    /// INI-vs-INI same-field SET collisions per type folder (<see cref="SkyPatcherConflicts"/>,
+    /// report-only). ONE record capture answers the filename gates + ONE asset capture pins the scan
+    /// (the SkseInventory discipline); the enumerate + parse + detect run OUTSIDE the gate on the
+    /// handle-free captured view. A layer with no INIs is a NAMED outcome, never an empty guess (Q3).
+    /// </summary>
+    public SkyPatcherLayerData SkyPatcherLayer()
+    {
+        var view = Resolver.Capture();
+        AssetResolver.AssetView assets;
+        IReadOnlyList<string> assetWarnings;
+        string profileName;
+        lock (_gate)
+        {
+            assets = Assets.Capture();
+            assetWarnings = _assetWarnings;
+            profileName = _profileName;
+        }
+
+        var catalog = SkyPatcherCatalog.Load();
+        var fieldMap = SkyPatcherFieldMap.Load();
+        var scan = SkyPatcherDiscovery.Scan(assets, catalog, view.ContainsPlugin, _skyPatcherParseCache);
+        var conflicts = new List<SkyPatcherConflicts.SkyPatcherConflict>();
+        foreach (var folder in scan.Folders)
+            conflicts.AddRange(SkyPatcherConflicts.Detect(folder, catalog, fieldMap));
+        return new SkyPatcherLayerData(scan, conflicts, scan.ReadIncomplete || assets.ReadIncomplete, assetWarnings, profileName);
+    }
+
     /// <summary>The live-load-order lookups the overlay needs (<see cref="SkyPatcherOverlay.IFormResolver"/>),
     /// answered off the ONE pinned record view + open session the post-state call holds. EditorID resolution
     /// sweeps the requested type's winners ONCE into an eid→FormKey table (an INI layer typically names many
@@ -4133,6 +4163,15 @@ public sealed record SkseInventoryData(
     IReadOnlyList<string> BsaFailures,
     bool ReadIncomplete,
     IReadOnlyList<string> Warnings,
+    string ProfileName);
+
+/// <summary>The data behind the whole-layer SkyPatcher scan (Wave 2): the ordered discovery scan, the
+/// per-folder INI-vs-INI set collisions, and the build-level Q3 caveats.</summary>
+public sealed record SkyPatcherLayerData(
+    HousecarlCore.SkyPatcherDiscovery.LayerScan Scan,
+    IReadOnlyList<HousecarlCore.SkyPatcherConflicts.SkyPatcherConflict> Conflicts,
+    bool ReadIncomplete,
+    IReadOnlyList<string> AssetWarnings,
     string ProfileName);
 
 /// <summary>The data behind the SkyPatcher post-state read (Wave 1): the record's identity + winner, one

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -464,6 +464,15 @@ public sealed class LoadOrderService : IDisposable
         }
 
         public bool PluginPresent(string pluginName) => _view.ContainsPlugin(pluginName);
+
+        public string? WinnerPluginOf(FormKey record) => _view.ResolveWinner(record)?.WinnerPlugin;
+
+        public string? EditorIdOf(FormKey record)
+        {
+            var w = _view.ResolveWinner(record);
+            if (w is null) return null;
+            return _view.GetRecord(_session, w.Value.WinnerPlugin, record)?.EditorID;
+        }
     }
 
     // ---- NIF layer Wave 1: read the data values inside a mesh (housecarl_nif_inspect) ----

--- a/src/housecarl-mcp/SkyPatcherTools.cs
+++ b/src/housecarl-mcp/SkyPatcherTools.cs
@@ -85,11 +85,14 @@ static class SkyPatcherWire
         int files = folders.Sum(f => f.Files.Count);
         int applied = folders.Sum(f => f.PatchingEnabled ? f.Files.Count(x => x.NotApplied is null) : 0);
         int lines = folders.Sum(f => f.Files.Sum(x => x.Lines.Count(l => l.Kind == SkyPatcherLineKind.Patch)));
+        int appliedLines = folders.Sum(f => f.PatchingEnabled
+            ? f.Files.Where(x => x.NotApplied is null).Sum(x => x.Lines.Count(l => l.Kind == SkyPatcherLineKind.Patch)) : 0);
 
         sb.Append("SkyPatcher layer — profile '").Append(d.ProfileName).Append("' — ")
           .Append(folders.Count).Append(" type folder(s), ").Append(files).Append(" INI(s) (")
-          .Append(applied).Append(" applied), ").Append(lines).Append(" patch line(s), ")
-          .Append(d.Conflicts.Count).Append(" set-conflict(s)\n");
+          .Append(applied).Append(" applied), ").Append(lines).Append(" patch line(s)");
+        if (appliedLines != lines) sb.Append(" (").Append(appliedLines).Append(" in applied files)");   // files vs lines units — don't let a gated file's lines read as live
+        sb.Append(", ").Append(d.Conflicts.Count).Append(" set-conflict(s)\n");
         if (folders.Count == 0)
             sb.Append("\nno SkyPatcher INIs in the active order (no Data\\SKSE\\Plugins\\SkyPatcher content, or SkyPatcher itself is not installed).\n");
 
@@ -135,12 +138,15 @@ static class SkyPatcherWire
             {
                 if (sb.Length >= cap) { sb.Append("  ... [showing ").Append(shown).Append(" of ").Append(d.Conflicts.Count).Append("; raise max_chars]\n"); break; }
                 sb.Append("  - [").Append(c.Subfolder).Append("] ").Append(c.Field).Append(" @ ").Append(c.Target).Append(":\n");
-                foreach (var e in c.Entries)
+                for (int i = 0; i < c.Entries.Count; i++)
+                {
+                    var e = c.Entries[i];
                     sb.Append("      ").Append(Path.GetFileName(e.File)).Append(':').Append(e.Line)
                       .Append("  ").Append(e.Op).Append('=').Append(e.Value)
-                      .Append(e == c.Winner ? "   ← WINS (last in apply order)" : "")
+                      .Append(i == c.Entries.Count - 1 ? "   ← WINS (last in apply order)" : "")   // by INDEX — value-equal entries must not both claim the win
                       .Append(e.Conditional ? "   [conditional — the line carries further filters]" : "")
                       .Append('\n');
+                }
                 shown++;
             }
             sb.Append("  (report-only: which value SHOULD win is a merge decision — resolve by authoring a later-sorted INI via the skypatcher-authoring skill, then re-run this tool to confirm.)\n");

--- a/src/housecarl-mcp/SkyPatcherTools.cs
+++ b/src/housecarl-mcp/SkyPatcherTools.cs
@@ -1,0 +1,231 @@
+using System.ComponentModel;
+using System.Text;
+using HousecarlCore;
+using ModelContextProtocol.Server;
+using Mutagen.Bethesda.Plugins;
+
+namespace HousecarlMcp;
+
+/// <summary>
+/// houseCARL's SkyPatcher DISTRIBUTOR-layer readers (Wave 2 of the distributor subsystem; plan
+/// dev/plans/SKYPATCHER_DISTRIBUTOR_TOOL_PLAN_2026-07-08.md — reader-only scope, locked 2026-07-09).
+/// Read-only. The record tools answer what the PLUGINS say; these answer what the SkyPatcher INI layer
+/// DOES to those records at load: <c>housecarl_skypatcher_layer</c> is the whole-layer inventory +
+/// INI-vs-INI conflict report, <c>housecarl_skypatcher_read</c> is one record's TRUE post-SkyPatcher
+/// state (the ordered, stateful replay). Authoring stays with the skypatcher-authoring skill; these
+/// readers are its verifier (a typo'd op classifies Unknown loud; the computed post-state confirms an
+/// authored INI does what was intended).
+/// </summary>
+[McpServerToolType]
+public static class SkyPatcherTools
+{
+    [McpServerTool(Name = "housecarl_skypatcher_layer", ReadOnly = true, Title = "SkyPatcher layer (INIs, apply order, conflicts)"),
+     Description(
+         "Inventory the SkyPatcher distributor layer of the ACTIVE load order — the runtime record edits the record " +
+         "tools are otherwise blind to. Scans Data\\SKSE\\Plugins\\SkyPatcher exactly as the DLL reads it: every " +
+         "LOOSE INI (BSA-packed ones are flagged NOT applied), per type folder in filename apply order, with the mod " +
+         "that wins the VFS for each file, same-path collisions (the loser's content is never read — flagged), " +
+         "Plugin.esp.ini filename gates evaluated against the load order, and SkyPatcher.ini per-type toggles. Then " +
+         "reports the INI-vs-INI CONFLICTS: two files setting the SAME field of the SAME record to different values " +
+         "(the later-sorted file wins; add/remove ops accumulate and are not conflicts). Entries whose applicability " +
+         "also hangs on other filters are flagged conditional rather than guessed. Pass filter= a type folder, mod, " +
+         "or filename substring to expand matching files to their patch lines. For ONE record's computed " +
+         "post-SkyPatcher state use housecarl_skypatcher_read. Read-only.")]
+    public static string SkyPatcherLayer(
+        LoadOrderService svc,
+        [Description("Optional. A type-folder (e.g. 'weapon'), providing-mod, or INI filename substring (case-insensitive). " +
+            "Expands the matching files to their individual patch lines. Omit for the whole-layer overview.")]
+            string? filter = null,
+        [Description("Optional. Max characters before lists are cut with an explicit notice. 0 = the server default (~80k).")]
+            int max_chars = 0) => Guard.Tool("housecarl_skypatcher_layer", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        var data = svc.SkyPatcherLayer();
+        return SkyPatcherWire.RenderLayer(data, filter?.Trim(), max_chars > 0 ? max_chars : 80_000);
+    });
+
+    [McpServerTool(Name = "housecarl_skypatcher_read", ReadOnly = true, Title = "A record's true post-SkyPatcher state"),
+     Description(
+         "Compute one record's TRUE state after the SkyPatcher layer applies — the answer neither the plugins nor " +
+         "xEdit show. Replays every applicable loose INI's lines in the DLL's apply order (filename sort) onto the " +
+         "record's load-order winner: same-field sets overwrite, …Mult/…ToAdd run on the RUNNING value, collection " +
+         "add/remove accumulate, and the full filter surface is evaluated (primary/keyword/enum/flag/slot/override-" +
+         "aware; the player matches only a lone bare primary). Returns each applied op as field: before → after with " +
+         "its file:line provenance. TIERED HONESTY: ops with no static resolution (runtime math, non-deterministic " +
+         "visual styles, copy-from-form) are returned as flagged DIRECTIVES — never a silently-wrong value — and " +
+         "every unknown key, unevaluable filter, or unresolvable form is a named warning. A record type SkyPatcher " +
+         "can't patch, or that no INI touches, is a named outcome. A FormID is 'XXXXXX:Plugin.esp'. For the " +
+         "whole-layer inventory + conflicts use housecarl_skypatcher_layer. Read-only.")]
+    public static string SkyPatcherRead(
+        LoadOrderService svc,
+        [Description("The record's FormID as 'XXXXXX:Plugin.esp' — 6 hex digits, a colon, then the defining master's filename. Example: '012EB7:Skyrim.esm'.")]
+            string formid,
+        [Description("Optional. Max characters before lists are cut with an explicit notice. 0 = the server default (~80k).")]
+            int max_chars = 0) => Guard.Tool("housecarl_skypatcher_read", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        FormKey fk;
+        try { fk = FormKey.Factory(formid.Trim()); }
+        catch (Exception ex) { return $"error: bad FormID '{formid}': {ex.Message}. Expected 'XXXXXX:Plugin.esp', e.g. '012EB7:Skyrim.esm'."; }
+        var data = svc.SkyPatcherPostState(fk);
+        return SkyPatcherWire.RenderPostState(data, max_chars > 0 ? max_chars : 80_000);
+    });
+}
+
+/// <summary>Renders the SkyPatcher reader DTOs as compact, scannable text — bounded by max_chars with
+/// explicit cut notices (Q3 — never silent truncation), caveats always rendered.</summary>
+static class SkyPatcherWire
+{
+    // ---- housecarl_skypatcher_layer ------------------------------------------------------------------
+
+    public static string RenderLayer(SkyPatcherLayerData d, string? filter, int cap)
+    {
+        var sb = new StringBuilder();
+        var folders = d.Scan.Folders;
+        int files = folders.Sum(f => f.Files.Count);
+        int applied = folders.Sum(f => f.PatchingEnabled ? f.Files.Count(x => x.NotApplied is null) : 0);
+        int lines = folders.Sum(f => f.Files.Sum(x => x.Lines.Count(l => l.Kind == SkyPatcherLineKind.Patch)));
+
+        sb.Append("SkyPatcher layer — profile '").Append(d.ProfileName).Append("' — ")
+          .Append(folders.Count).Append(" type folder(s), ").Append(files).Append(" INI(s) (")
+          .Append(applied).Append(" applied), ").Append(lines).Append(" patch line(s), ")
+          .Append(d.Conflicts.Count).Append(" set-conflict(s)\n");
+        if (folders.Count == 0)
+            sb.Append("\nno SkyPatcher INIs in the active order (no Data\\SKSE\\Plugins\\SkyPatcher content, or SkyPatcher itself is not installed).\n");
+
+        bool In(string? s) => filter is null || (s is not null && s.Contains(filter, StringComparison.OrdinalIgnoreCase));
+
+        foreach (var f in folders)
+        {
+            if (sb.Length >= cap) { sb.Append("... [remaining folders omitted at max_chars — raise it or pass filter=]\n"); break; }
+            int fLines = f.Files.Sum(x => x.Lines.Count(l => l.Kind == SkyPatcherLineKind.Patch));
+            sb.Append("\n").Append(f.Subfolder).Append(": ").Append(f.Files.Count).Append(" INI(s), ").Append(fLines).Append(" patch line(s)");
+            if (!f.PatchingEnabled) sb.Append("  [!] toggled OFF in SkyPatcher.ini — the DLL skips this whole folder");
+            if (f.Catalog is null) sb.Append("  [!] not a documented SkyPatcher record type — content listed, not interpreted");
+            sb.Append('\n');
+            foreach (var file in f.Files)
+            {
+                if (sb.Length >= cap) { sb.Append("  ... [cut at max_chars]\n"); break; }
+                int n = file.Lines.Count(l => l.Kind == SkyPatcherLineKind.Patch);
+                sb.Append("  - ").Append(file.SortKey).Append("  (").Append(n).Append(" line(s)) ← ").Append(file.WinningProvider ?? "(no provider)");
+                if (file.GatePlugin is not null && file.NotApplied is null) sb.Append("  [gated on ").Append(file.GatePlugin).Append(": active]");
+                if (file.NotApplied is not null) sb.Append("  [!] NOT applied: ").Append(file.NotApplied);
+                if (file.ShadowedProviders.Count > 0) sb.Append("  [!] shadows same-path copies from ").Append(string.Join(", ", file.ShadowedProviders));
+                sb.Append('\n');
+                // filter= match (folder, provider, or filename) expands the file to its patch lines.
+                bool expand = filter is not null && (In(f.Subfolder) || In(file.WinningProvider) || In(file.RelPath));
+                if (expand)
+                    for (int i = 0; i < file.Lines.Count; i++)
+                    {
+                        if (sb.Length >= cap) { sb.Append("      ... [lines cut at max_chars]\n"); break; }
+                        var l = file.Lines[i];
+                        if (l.Kind != SkyPatcherLineKind.Patch) continue;
+                        sb.Append("      :").Append(i + 1).Append("  ").Append(l.Raw.Trim()).Append('\n');
+                        if (l.Note is not null) sb.Append("          [!] ").Append(l.Note).Append('\n');
+                    }
+            }
+        }
+
+        if (d.Conflicts.Count > 0)
+        {
+            sb.Append("\nINI-vs-INI set conflicts (").Append(d.Conflicts.Count)
+              .Append(") — same field, same target, different values; the LAST write wins:\n");
+            int shown = 0;
+            foreach (var c in d.Conflicts)
+            {
+                if (sb.Length >= cap) { sb.Append("  ... [showing ").Append(shown).Append(" of ").Append(d.Conflicts.Count).Append("; raise max_chars]\n"); break; }
+                sb.Append("  - [").Append(c.Subfolder).Append("] ").Append(c.Field).Append(" @ ").Append(c.Target).Append(":\n");
+                foreach (var e in c.Entries)
+                    sb.Append("      ").Append(Path.GetFileName(e.File)).Append(':').Append(e.Line)
+                      .Append("  ").Append(e.Op).Append('=').Append(e.Value)
+                      .Append(e == c.Winner ? "   ← WINS (last in apply order)" : "")
+                      .Append(e.Conditional ? "   [conditional — the line carries further filters]" : "")
+                      .Append('\n');
+                shown++;
+            }
+            sb.Append("  (report-only: which value SHOULD win is a merge decision — resolve by authoring a later-sorted INI via the skypatcher-authoring skill, then re-run this tool to confirm.)\n");
+        }
+
+        foreach (var note in d.Scan.Notes)
+        {
+            if (sb.Length >= cap) break;
+            sb.Append("[!] ").Append(note).Append('\n');
+        }
+        AppendCaveats(sb, d.ReadIncomplete, d.AssetWarnings);
+        sb.Append("\n→ housecarl_skypatcher_read '<FormID>' for one record's computed post-SkyPatcher state; filter='<folder/mod/file>' to expand files to their lines.");
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    // ---- housecarl_skypatcher_read -------------------------------------------------------------------
+
+    public static string RenderPostState(SkyPatcherPostStateData d, int cap)
+    {
+        if (d.Error is not null) return $"error: {d.Error}";
+
+        var sb = new StringBuilder();
+        sb.Append("post-SkyPatcher state — ").Append(d.RecordTypeName).Append(' ').Append(d.FormKey)
+          .Append(d.EditorId is null ? "" : $" ({d.EditorId})")
+          .Append("  [winner ").Append(d.WinnerPlugin).Append(", profile '").Append(d.ProfileName).Append("']\n");
+
+        int touched = d.Folders.Sum(f => (f.Result?.Applied.Count ?? 0) + (f.Result?.Directives.Count ?? 0));
+        if (touched == 0 && d.Folders.All(f => f.Result is null || f.Result.LinesMatched == 0))
+            sb.Append("\nno SkyPatcher line in the active order touches this record — its plugin-resolved values ARE its in-game values (as far as this layer goes).\n");
+
+        foreach (var f in d.Folders)
+        {
+            if (sb.Length >= cap) { sb.Append("... [cut at max_chars]\n"); break; }
+            sb.Append("\nfolder '").Append(f.Subfolder).Append("': ").Append(f.IniCount).Append(" applied INI(s), ")
+              .Append(f.LineCount).Append(" line(s) replayed");
+            if (!f.Enabled) { sb.Append("  [!] toggled OFF in SkyPatcher.ini — the DLL skips this folder\n"); continue; }
+            if (f.Result is null) { sb.Append("  (no INIs for this folder)\n"); continue; }
+            var r = f.Result;
+            sb.Append(" — ").Append(r.LinesMatched).Append(" matched this record");
+            if (r.LinesSkippedUnresolvedFilter > 0) sb.Append(", ").Append(r.LinesSkippedUnresolvedFilter).Append(" skipped UNRESOLVED");
+            sb.Append('\n');
+
+            if (r.Applied.Count > 0)
+            {
+                sb.Append("  APPLIED (").Append(r.Applied.Count).Append(") — file:line  op=value  →  field: before → after\n");
+                foreach (var a in r.Applied)
+                {
+                    if (sb.Length >= cap) { sb.Append("  ... [cut at max_chars]\n"); break; }
+                    sb.Append("    ").Append(Path.GetFileName(a.File)).Append(':').Append(a.LineNumber)
+                      .Append("  ").Append(a.Op).Append('=').Append(a.RawValue)
+                      .Append("  →  ").Append(a.FieldPath).Append(": ").Append(a.Before ?? "-").Append(" → ").Append(a.After ?? "-");
+                    if (a.Note is not null) sb.Append("   [").Append(a.Note).Append(']');
+                    sb.Append('\n');
+                }
+            }
+            if (r.Directives.Count > 0)
+            {
+                sb.Append("  NOT RESOLVED — directives (").Append(r.Directives.Count).Append("), no static answer exists (tiered honesty):\n");
+                foreach (var dr in r.Directives)
+                {
+                    if (sb.Length >= cap) { sb.Append("  ... [cut at max_chars]\n"); break; }
+                    sb.Append("    ").Append(Path.GetFileName(dr.File)).Append(':').Append(dr.LineNumber)
+                      .Append("  ").Append(dr.Op).Append('=').Append(dr.RawValue).Append("   [").Append(dr.Reason).Append("]\n");
+                }
+            }
+            foreach (var w in r.Warnings)
+            {
+                if (sb.Length >= cap) break;
+                sb.Append("  [!] ").Append(w).Append('\n');
+            }
+        }
+
+        foreach (var note in d.LayerNotes)
+        {
+            if (sb.Length >= cap) break;
+            sb.Append("[!] ").Append(note).Append('\n');
+        }
+        AppendCaveats(sb, d.ReadIncomplete, d.AssetWarnings);
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    static void AppendCaveats(StringBuilder sb, bool readIncomplete, IReadOnlyList<string> assetWarnings)
+    {
+        if (readIncomplete)
+            sb.Append("[!] a BSA failed to read this build, so an INI present only in it may be missing from this scan (Q3).\n");
+        foreach (var w in assetWarnings) sb.Append("[!] ").Append(w).Append('\n');
+    }
+}


### PR DESCRIPTION
## SkyPatcher Wave 2 — the complete reader (plan `dev/plans/SKYPATCHER_DISTRIBUTOR_TOOL_PLAN_2026-07-08.md`, reader-only scope)

Five commits, in build order:

1. **The COMPLETE filter surface** — the Wave-1 overlay evaluated 6 filter families and loud-skipped the rest; now every documented filter evaluates or is explicitly unmapped-with-reason. 13 map-driven eval kinds (54 specs across 12 record types, every path/flag/valueMap machine-verified against the real Mutagen types), the override-aware yield filters (`modNamesLastOverriddenExcluded` = the record's WINNING override plugin; the Cell skip tokens), `filterByModNames` = the defining master (declared assumption, empirical item), and the grammar's player rule (only a lone bare primary names the player).
2. **The 47 Wave-2-cited unmapped ops closed** (69 → 22 unmapped, the residue genuinely unmodelable): race dict stats, the 30 Cell per-channel colours, armor biped-slot bit math, Book's polymorphic Teaches via compose-Set, COBJ `changeCobjsCount`.
3. **The INI-vs-INI conflict detector** (report-only, per the locked plan call): same-field SET collisions across the ordered union, winner = later file, accumulating ops never conflict, conditional lines flagged rather than guessed.
4. **The tool surface** — `housecarl_skypatcher_layer` (whole-layer inventory + conflicts; `filter=` expands files to lines) and `housecarl_skypatcher_read` (one record's true post-SkyPatcher state; HARD ops as flagged directives — the tiered-honesty contract). Dedicated read tool per the documented §6.2 lean. Tool count **35 → 37**. Plus a `skypatcher-layer` harness mode rendering through the same Wire.
5. **The owed skill rider** — skypatcher-authoring's workflow gains step 6, *verify through the reader* (the §2.1 premise that justified cutting the author tool).

### Empirical (live, Authoria order, 3599 plugins)
- Layer scan: 9 folders / 33 INIs / 7698 patch lines in ~12s; surfaced a REAL same-path VFS shadow (`Stewards of Skyrim\kco_stw.esp.ini`, two mods, one silently never read).
- Post-state on `000D77:FalmerSlayer.esp` (FalmerSlayerHeels): 7497 lines replayed, **0 filter-unresolved skips** (Wave 1 would have skipped every record-specific/restrict line), Trails' `filterByNameContainsOr` keyword add + UBE's `armorAddonsToAdd` both applied, absent-framework keywords warned honestly.
- 0 set-conflicts in the live layer (accumulate-heavy INIs — the guard RED-proofs detection).

### Declared assumptions (empirical-gate items, all loud in code/JSON)
- `filterByModNames` / `skipRecordByModNameContains` test the record's DEFINING master, not an override provider.
- `skipRecordByLightingTemplateFromMod` tests the linked LGTM's defining master (the ELFX/Lux yield case).
- Single-valued form/enum filters read a multi-value list as any-of (the AND reading is unsatisfiable; matches the primary filter's precedent).
- The player rule reads "alone" strictly: primary + any other filter still excludes the player.

### CI
ci-all **85/85** local (new probe: `skypatcher-conflicts-guard`; fieldmap guard gains the filter triangle + self-test; overlay guard gains the filter + op-closure arms).

### Owed after merge (not in this PR)
- Release-cut version bump (1.6.0 → 1.7.0, tool-count change) at cut time.
- Plan-doc status update + session handoff (main checkout `dev/`, gitignored).
- The Wave-2 empirical in-game list rides the standing SkyPatcher gate items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)