### PR TITLE
feat(skypatcher): the ITM triple — dead writes, cross-INI duplicates, no-op writes

### DIFF
--- a/.claude/skills/skypatcher-authoring/SKILL.md
+++ b/.claude/skills/skypatcher-authoring/SKILL.md
@@ -79,7 +79,9 @@ Read grammar-core once plus the one record file you need — don't bulk-load eve
      *silently* in game — and a subtly-valid-but-wrong op shows up as the wrong field changing.
    - `housecarl_skypatcher_layer` for the file-level checks: your INI listed as APPLIED (not
      BSA-only, not filename-gated off, not shadowed by a same-path file from another mod), in the
-     apply-order position you expect, and no new same-field set conflict against another INI.
+     apply-order position you expect, no new same-field set conflict against another INI, and no
+     intra-file dead line (ITM) — your own file setting the same field of the same target twice
+     is an authoring slip; only the last write applies.
    A patch that passes both is verified against the actual grammar and the actual load order —
    no game launch needed. (Resolving a reported conflict is the same loop: author the
    later-sorted INI that pins the intended value, then re-run the reader to confirm it wins.)

--- a/.claude/skills/skypatcher-authoring/SKILL.md
+++ b/.claude/skills/skypatcher-authoring/SKILL.md
@@ -79,11 +79,14 @@ Read grammar-core once plus the one record file you need — don't bulk-load eve
      *silently* in game — and a subtly-valid-but-wrong op shows up as the wrong field changing.
    - `housecarl_skypatcher_layer` for the file-level checks: your INI listed as APPLIED (not
      BSA-only, not filename-gated off, not shadowed by a same-path file from another mod), in the
-     apply-order position you expect, no new same-field set conflict against another INI, and no
-     intra-file dead write (ITM) — a later line of your own file unconditionally overwriting
-     every target of an earlier set is an authoring slip; only the last write applies. (The
-     report lists only writes that are FULLY dead — partial or conditional-only overwrites are
-     not flagged, because the earlier write may still fire.)
+     apply-order position you expect, no new same-field set conflict against another INI, and
+     none of the three ITM classes pointing at your file: an intra-file dead write (a later line
+     of your own file unconditionally overwrites every target of an earlier set — only the last
+     write applies), a cross-INI duplicate (your line sets the same field/target to the same
+     value another INI already sets), or a no-op write (the replay shows your SET writes the
+     value the record already has). All three are authoring slips to fix at the source. (Dead
+     writes list only FULLY dead ones — partial or conditional-only overwrites are not flagged,
+     because the earlier write may still fire.)
    A patch that passes both is verified against the actual grammar and the actual load order —
    no game launch needed. (Resolving a reported conflict is the same loop: author the
    later-sorted INI that pins the intended value, then re-run the reader to confirm it wins.)

--- a/.claude/skills/skypatcher-authoring/SKILL.md
+++ b/.claude/skills/skypatcher-authoring/SKILL.md
@@ -80,8 +80,10 @@ Read grammar-core once plus the one record file you need — don't bulk-load eve
    - `housecarl_skypatcher_layer` for the file-level checks: your INI listed as APPLIED (not
      BSA-only, not filename-gated off, not shadowed by a same-path file from another mod), in the
      apply-order position you expect, no new same-field set conflict against another INI, and no
-     intra-file dead line (ITM) — your own file setting the same field of the same target twice
-     is an authoring slip; only the last write applies.
+     intra-file dead write (ITM) — a later line of your own file unconditionally overwriting
+     every target of an earlier set is an authoring slip; only the last write applies. (The
+     report lists only writes that are FULLY dead — partial or conditional-only overwrites are
+     not flagged, because the earlier write may still fire.)
    A patch that passes both is verified against the actual grammar and the actual load order —
    no game launch needed. (Resolving a reported conflict is the same loop: author the
    later-sorted INI that pins the intended value, then re-run the reader to confirm it wins.)

--- a/src/housecarl-core/SkyPatcherConflicts.cs
+++ b/src/housecarl-core/SkyPatcherConflicts.cs
@@ -36,6 +36,12 @@ namespace HousecarlCore;
 /// reported; a conditional EARLIER write killed unconditionally is dead either way — applied or not,
 /// the later write decides the field). These are a separate report class, not conflicts — no
 /// cross-mod judgment call, just same-author redundancy.</para>
+///
+/// <para><b>Cross-INI duplicate writes (the second ITM class).</b> Two files SET the same field of
+/// the same target to the SAME value — the value-identical complement of a conflict (which requires
+/// differing values). Nothing is wrong in game, but one copy is redundant: keep either (the LAST
+/// would win if they ever diverge). A value-MIXED group stays a conflict only — the duplicate pair
+/// inside it is visible in the conflict's own entry list, not double-reported.</para>
 /// </summary>
 public static class SkyPatcherConflicts
 {
@@ -73,10 +79,23 @@ public static class SkyPatcherConflicts
     public sealed record SkyPatcherItmEntry(
         int Line, string Op, string Value, string Targets, bool Conditional, IReadOnlyList<int> KillerLines);
 
-    /// <summary>Both report classes from the one detection pass.</summary>
+    /// <summary>One cross-INI duplicate: ≥2 files write the same field/target with ONE distinct value
+    /// (case-insensitive). Same entry shape as a conflict — the classes differ only by the value gate.</summary>
+    public sealed record SkyPatcherDuplicate(
+        string Subfolder,
+        string Field,
+        string Target,
+        IReadOnlyList<SkyPatcherConflictEntry> Entries)
+    {
+        /// <summary>True when ANY entry's applicability also hangs on non-primary filters.</summary>
+        public bool Conditional => Entries.Any(e => e.Conditional);
+    }
+
+    /// <summary>All report classes from the one detection pass.</summary>
     public sealed record Report(
         IReadOnlyList<SkyPatcherConflict> Conflicts,
-        IReadOnlyList<SkyPatcherItm> Itms);
+        IReadOnlyList<SkyPatcherItm> Itms,
+        IReadOnlyList<SkyPatcherDuplicate> Duplicates);
 
     /// <summary>All records of the type — the target token a primary-filter-less line writes.</summary>
     const string Broad = "*";
@@ -88,7 +107,8 @@ public static class SkyPatcherConflicts
     {
         var conflicts = new List<SkyPatcherConflict>();
         var itms = new List<SkyPatcherItm>();
-        if (folder.Catalog is null) return new Report(conflicts, itms);
+        var duplicates = new List<SkyPatcherDuplicate>();
+        if (folder.Catalog is null) return new Report(conflicts, itms, duplicates);
         var maps = fieldMap.ForSubfolder(folder.Subfolder);
 
         // ---- collect every SET-class event in apply order (seq = the apply-order index) ----
@@ -136,8 +156,8 @@ public static class SkyPatcherConflicts
 
             foreach (var (token, own) in byToken.OrderBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase))
                 // Explicit-target group + every broad write of the same field, merged back into apply order.
-                Emit(conflicts, folder.Subfolder, fieldGroup.Key, token, own.Concat(broad).OrderBy(h => h.seq).ToList());
-            Emit(conflicts, folder.Subfolder, fieldGroup.Key, Broad, broad);
+                Emit(conflicts, duplicates, folder.Subfolder, fieldGroup.Key, token, own.Concat(broad).OrderBy(h => h.seq).ToList());
+            Emit(conflicts, duplicates, folder.Subfolder, fieldGroup.Key, Broad, broad);
         }
 
         // ---- intra-file dead writes (ITM-class): a later line of the SAME file unconditionally
@@ -190,17 +210,21 @@ public static class SkyPatcherConflicts
                 itms.Add(new SkyPatcherItm(folder.Subfolder, fileFieldGroup.Key.field, fileFieldGroup.Key.file, dead));
             }
         }
-        return new Report(conflicts, itms);
+        return new Report(conflicts, itms, duplicates);
     }
 
-    static void Emit(List<SkyPatcherConflict> conflicts, string subfolder, string field, string token,
+    static void Emit(List<SkyPatcherConflict> conflicts, List<SkyPatcherDuplicate> duplicates,
+        string subfolder, string field, string token,
         IReadOnlyList<(int seq, string file, int line, string op, string value, bool conditional)> hits)
     {
         if (hits.Select(e => e.file).Distinct(StringComparer.OrdinalIgnoreCase).Count() < 2) return;
-        if (hits.Select(e => e.value).Distinct(StringComparer.OrdinalIgnoreCase).Count() < 2) return;
-        conflicts.Add(new SkyPatcherConflict(subfolder, field,
-            token == Broad ? $"(all {subfolder} records)" : token,
-            hits.Select(e => new SkyPatcherConflictEntry(e.file, e.line, e.op, e.value, e.conditional)).ToList()));
+        var target = token == Broad ? $"(all {subfolder} records)" : token;
+        var entries = hits.Select(e => new SkyPatcherConflictEntry(e.file, e.line, e.op, e.value, e.conditional)).ToList();
+        // One distinct value across ≥2 files = the cross-INI DUPLICATE class (ITM); ≥2 = a conflict.
+        if (hits.Select(e => e.value).Distinct(StringComparer.OrdinalIgnoreCase).Count() < 2)
+            duplicates.Add(new SkyPatcherDuplicate(subfolder, field, target, entries));
+        else
+            conflicts.Add(new SkyPatcherConflict(subfolder, field, target, entries));
     }
 
     /// <summary>The line's target tokens from its PRIMARY filter (normalized FormKey / case-folded
@@ -225,8 +249,9 @@ public static class SkyPatcherConflicts
     }
 
     /// <summary>The last-write-wins SET-class semantics — a later write of the same field/target
-    /// REPLACES an earlier one, the collision class this detector reports.</summary>
-    internal static readonly IReadOnlySet<SkyPatcherOpSemantic> SetClassSemantics = new HashSet<SkyPatcherOpSemantic>
+    /// REPLACES an earlier one, the collision class this detector reports. Public: the layer no-op
+    /// (true-ITM) scan uses the same partition to flag only literal same-value SETs.</summary>
+    public static readonly IReadOnlySet<SkyPatcherOpSemantic> SetClassSemantics = new HashSet<SkyPatcherOpSemantic>
     {
         SkyPatcherOpSemantic.Set, SkyPatcherOpSemantic.SetFromOwnField, SkyPatcherOpSemantic.ModelPath,
         SkyPatcherOpSemantic.VecComponent, SkyPatcherOpSemantic.ColorChannel, SkyPatcherOpSemantic.FlagBool,

--- a/src/housecarl-core/SkyPatcherConflicts.cs
+++ b/src/housecarl-core/SkyPatcherConflicts.cs
@@ -22,6 +22,16 @@ namespace HousecarlCore;
 /// restrictTo…, gates) is flagged <see cref="SkyPatcherConflictEntry.Conditional"/>: whether the
 /// collision is real then depends on those filters, and the report says so rather than guessing
 /// either way.</para>
+///
+/// <para><b>Intra-file dead lines (ITM-class; Aaron-widened from the PR #168 review's open call).</b>
+/// The same pass also reports the SINGLE-file cousin: an earlier SET of the same field/target that a
+/// LATER line in the same file overwrites. The earlier write is dead weight REGARDLESS of value —
+/// same-value twice is the purest form (a line that changes nothing), xEdit's ITM smell at the INI
+/// layer — so unlike cross-file conflicts there is no different-values gate. Coverage is asymmetric:
+/// an explicit-target write is killed by a later same-file explicit-same-target OR broad write; a
+/// BROAD write is killed only by a later same-file broad (a following explicit line leaves it live
+/// for every other record). These are a separate report class, not conflicts — no cross-mod judgment
+/// call, just same-author redundancy.</para>
 /// </summary>
 public static class SkyPatcherConflicts
 {
@@ -42,15 +52,46 @@ public static class SkyPatcherConflicts
     /// primary, so whether it actually applies to the target depends on them.</summary>
     public sealed record SkyPatcherConflictEntry(string File, int Line, string Op, string Value, bool Conditional);
 
+    /// <summary>One file's ITM-class finding: this file's SETs of one field/target in line order, at
+    /// least one of them <see cref="SkyPatcherItmEntry.Dead"/> (overwritten by a later line of the SAME
+    /// file). The last entry is the write the file actually leaves in place.</summary>
+    public sealed record SkyPatcherItm(
+        string Subfolder,
+        string Field,
+        string Target,
+        string File,
+        IReadOnlyList<SkyPatcherItmEntry> Entries)
+    {
+        /// <summary>The write this file leaves in place — the last entry in line order.</summary>
+        public SkyPatcherItmEntry Live => Entries[^1];
+        /// <summary>True when ANY entry's applicability also hangs on non-primary filters — whether
+        /// the overwrite is real then depends on them (a conditional later line may not fire; a
+        /// conditional dead line may never have applied).</summary>
+        public bool Conditional => Entries.Any(e => e.Conditional);
+    }
+
+    /// <summary>One write inside a <see cref="SkyPatcherItm"/>. <see cref="Dead"/> = a later line of
+    /// the same file overwrites this write for the finding's target (a NOT-dead, non-last entry is a
+    /// broad write inside an explicit-target finding — overwritten for THIS target but still live for
+    /// every other record, so not removable).</summary>
+    public sealed record SkyPatcherItmEntry(int Line, string Op, string Value, bool Conditional, bool Dead);
+
+    /// <summary>Both report classes from the one detection pass.</summary>
+    public sealed record Report(
+        IReadOnlyList<SkyPatcherConflict> Conflicts,
+        IReadOnlyList<SkyPatcherItm> Itms);
+
     /// <summary>All records of the type — the target token a primary-filter-less line writes.</summary>
     const string Broad = "*";
 
-    /// <summary>Detect the same-field set collisions in one folder's ordered, game-visible union.</summary>
-    public static IReadOnlyList<SkyPatcherConflict> Detect(
+    /// <summary>Detect the same-field set collisions (INI-vs-INI) and the intra-file dead lines
+    /// (ITM-class) in one folder's ordered, game-visible union.</summary>
+    public static Report Detect(
         SkyPatcherDiscovery.FolderScan folder, SkyPatcherCatalog catalog, SkyPatcherFieldMap fieldMap)
     {
         var conflicts = new List<SkyPatcherConflict>();
-        if (folder.Catalog is null) return conflicts;
+        var itms = new List<SkyPatcherItm>();
+        if (folder.Catalog is null) return new Report(conflicts, itms);
         var maps = fieldMap.ForSubfolder(folder.Subfolder);
 
         // ---- collect every SET-class event in apply order (seq = the apply-order index) ----
@@ -101,7 +142,34 @@ public static class SkyPatcherConflicts
                 Emit(conflicts, folder.Subfolder, fieldGroup.Key, token, own.Concat(broad).OrderBy(h => h.seq).ToList());
             Emit(conflicts, folder.Subfolder, fieldGroup.Key, Broad, broad);
         }
-        return conflicts;
+
+        // ---- intra-file dead lines (ITM-class): one file, one field, one target, written twice.
+        //      A file's lines are contiguous in apply order (files apply whole, in filename sort), so
+        //      same-file overwrites need only that file's own events, walked in line order. ----
+        foreach (var fileFieldGroup in events.GroupBy(e => (e.file, e.field)))
+        {
+            var evs = fileFieldGroup.OrderBy(e => e.seq).ToList();
+            if (evs.Count < 2) continue;
+            foreach (var token in evs.SelectMany(e => e.targets).Distinct(StringComparer.OrdinalIgnoreCase)
+                                     .OrderBy(t => t, StringComparer.OrdinalIgnoreCase))
+            {
+                // The file's writes that hit this token: explicit matches, plus broad writes when the
+                // token is explicit (broad covers everything; nothing but broad covers broad).
+                var covering = evs.Where(e => e.targets.Contains(token, StringComparer.OrdinalIgnoreCase)
+                                              || (token != Broad && e.targets.Contains(Broad))).ToList();
+                if (covering.Count < 2) continue;
+                var entries = covering.Select((e, i) => new SkyPatcherItmEntry(
+                    e.line, e.op, e.value, e.conditional,
+                    // Dead = a later covering line exists AND this write has no life beyond the token:
+                    // a broad write inside an explicit-token finding stays live for other records.
+                    Dead: i < covering.Count - 1 && (token == Broad || !e.targets.Contains(Broad)))).ToList();
+                if (!entries.Any(en => en.Dead)) continue;   // e.g. broad-then-explicit: nothing removable
+                itms.Add(new SkyPatcherItm(folder.Subfolder, fileFieldGroup.Key.field,
+                    token == Broad ? $"(all {folder.Subfolder} records)" : token,
+                    fileFieldGroup.Key.file, entries));
+            }
+        }
+        return new Report(conflicts, itms);
     }
 
     static void Emit(List<SkyPatcherConflict> conflicts, string subfolder, string field, string token,

--- a/src/housecarl-core/SkyPatcherConflicts.cs
+++ b/src/housecarl-core/SkyPatcherConflicts.cs
@@ -1,3 +1,5 @@
+using Mutagen.Bethesda.Plugins;
+
 namespace HousecarlCore;
 
 /// <summary>
@@ -227,6 +229,51 @@ public static class SkyPatcherConflicts
             conflicts.Add(new SkyPatcherConflict(subfolder, field, target, entries));
     }
 
+    /// <summary>The one bare-primary test — a filter segment that NAMES records outright (primary
+    /// kind, no Excluded/other connective). Shared by the conflict/ITM grouping and the layer no-op
+    /// scan's target collection so the two can't silently diverge (review finding).</summary>
+    public static bool IsBarePrimary(SkyPatcherKeyClass cls)
+        => cls.Role == SkyPatcherKeyRole.Filter
+           && cls.Filter!.Kind == SkyPatcherFilterKind.Primary && (cls.Connective ?? "") == "";
+
+    /// <summary>Collect one patch line's explicit PRIMARY targets for the no-op (true-ITM) scan:
+    /// FormID values → <paramref name="forms"/>, non-FormID values → raw EditorID strings (the caller
+    /// resolves them against its folder's record types). A line with operations but NO bare primary
+    /// is counted into <paramref name="broadLines"/> — it writes type-wide and the scan's note says
+    /// it is only evaluated against the explicitly-targeted records.</summary>
+    public static void CollectExplicitPrimaryTargets(
+        SkyPatcherLine parsed, SkyPatcherCatalog catalog, SkyPatcherRecordCatalog recordCatalog,
+        ISet<FormKey> forms, ISet<string> editorIds, ref int broadLines)
+    {
+        if (parsed.Kind != SkyPatcherLineKind.Patch) return;
+        bool hasOp = false, hasExplicit = false;
+        foreach (var seg in parsed.Segments)
+        {
+            var cls = catalog.Classify(recordCatalog, seg.Key);
+            if (cls.Role == SkyPatcherKeyRole.Operation) hasOp = true;
+            else if (IsBarePrimary(cls))
+                foreach (var v in seg.Values)
+                {
+                    hasExplicit = true;
+                    if (v.Address is { IsFormId: true } a && SkyPatcherOverlay.TryFormKey(a, out var fk)) forms.Add(fk);
+                    else editorIds.Add(v.Raw);
+                }
+        }
+        if (hasOp && !hasExplicit) broadLines++;
+    }
+
+    /// <summary>The no-op (true-ITM) candidate test the layer scan applies to a replay's applied ops:
+    /// a SET-class op whose before == after leaf token (the overlay's documented no-op contract),
+    /// excluding deliberate 'none' leave-unchanged values. Accumulating before==after cases (e.g.
+    /// re-adding a present keyword) are NOT this class — they stay skypatcher_read's lane.</summary>
+    public static bool IsNoOpWrite(SkyPatcherOverlay.SkyPatcherAppliedOp a, RecordMap? map)
+    {
+        if (a.Before is null || a.Before != a.After) return false;
+        if (a.RawValue.Trim().Equals("none", StringComparison.OrdinalIgnoreCase)) return false;
+        var op = map?.Ops.GetValueOrDefault(a.Op);
+        return op is not null && !op.IsUnmapped && SetClassSemantics.Contains(op.Semantic);
+    }
+
     /// <summary>The line's target tokens from its PRIMARY filter (normalized FormKey / case-folded
     /// EditorID), or BROAD when no bare primary names records. Conditional = any other filter present
     /// (whether the line hits the target then depends on record state the detector doesn't evaluate).</summary>
@@ -237,7 +284,7 @@ public static class SkyPatcherConflicts
         bool conditional = false;
         foreach (var (seg, cls) in filters)
         {
-            if (cls.Filter!.Kind == SkyPatcherFilterKind.Primary && (cls.Connective ?? "") == "")
+            if (IsBarePrimary(cls))
                 foreach (var v in seg.Values)
                     tokens.Add(v.Address is { IsFormId: true } a && SkyPatcherOverlay.TryFormKey(a, out var fk)
                         ? fk.ToString()

--- a/src/housecarl-core/SkyPatcherConflicts.cs
+++ b/src/housecarl-core/SkyPatcherConflicts.cs
@@ -23,15 +23,19 @@ namespace HousecarlCore;
 /// collision is real then depends on those filters, and the report says so rather than guessing
 /// either way.</para>
 ///
-/// <para><b>Intra-file dead lines (ITM-class; Aaron-widened from the PR #168 review's open call).</b>
-/// The same pass also reports the SINGLE-file cousin: an earlier SET of the same field/target that a
-/// LATER line in the same file overwrites. The earlier write is dead weight REGARDLESS of value —
-/// same-value twice is the purest form (a line that changes nothing), xEdit's ITM smell at the INI
-/// layer — so unlike cross-file conflicts there is no different-values gate. Coverage is asymmetric:
-/// an explicit-target write is killed by a later same-file explicit-same-target OR broad write; a
-/// BROAD write is killed only by a later same-file broad (a following explicit line leaves it live
-/// for every other record). These are a separate report class, not conflicts — no cross-mod judgment
-/// call, just same-author redundancy.</para>
+/// <para><b>Intra-file dead writes (ITM-class; Aaron-widened from the PR #168 review's open call).</b>
+/// The same pass also reports the SINGLE-file cousin: an earlier SET whose EVERY target a later line
+/// of the same file unconditionally re-covers. The dead write is dead weight REGARDLESS of value —
+/// same-value twice is the purest form (a write that changes nothing), xEdit's ITM smell at the INI
+/// layer — so unlike cross-file conflicts there is no different-values gate. The kill rule is strict
+/// so a DEAD verdict is never hedged (this review-fold shape replaced a looser per-token rule that
+/// could call a still-live line removable): ALL of the write's targets must be re-covered — a
+/// multi-target line partially overwritten stays live for the rest, and a BROAD write is covered
+/// only by a later broad (a following explicit line leaves it live for every other record) — and
+/// only UNCONDITIONAL later writes kill (a conditional overwriter may not fire, so its victim is not
+/// reported; a conditional EARLIER write killed unconditionally is dead either way — applied or not,
+/// the later write decides the field). These are a separate report class, not conflicts — no
+/// cross-mod judgment call, just same-author redundancy.</para>
 /// </summary>
 public static class SkyPatcherConflicts
 {
@@ -52,29 +56,22 @@ public static class SkyPatcherConflicts
     /// primary, so whether it actually applies to the target depends on them.</summary>
     public sealed record SkyPatcherConflictEntry(string File, int Line, string Op, string Value, bool Conditional);
 
-    /// <summary>One file's ITM-class finding: this file's SETs of one field/target in line order, at
-    /// least one of them <see cref="SkyPatcherItmEntry.Dead"/> (overwritten by a later line of the SAME
-    /// file). The last entry is the write the file actually leaves in place.</summary>
+    /// <summary>One file's ITM-class finding for one field: the DEAD writes only (every entry is
+    /// removable — a write only lands here when ALL its targets are unconditionally re-covered by
+    /// later lines of the same file), in line order. Entry count IS the physical dead-write count.</summary>
     public sealed record SkyPatcherItm(
         string Subfolder,
         string Field,
-        string Target,
         string File,
-        IReadOnlyList<SkyPatcherItmEntry> Entries)
-    {
-        /// <summary>The write this file leaves in place — the last entry in line order.</summary>
-        public SkyPatcherItmEntry Live => Entries[^1];
-        /// <summary>True when ANY entry's applicability also hangs on non-primary filters — whether
-        /// the overwrite is real then depends on them (a conditional later line may not fire; a
-        /// conditional dead line may never have applied).</summary>
-        public bool Conditional => Entries.Any(e => e.Conditional);
-    }
+        IReadOnlyList<SkyPatcherItmEntry> Entries);
 
-    /// <summary>One write inside a <see cref="SkyPatcherItm"/>. <see cref="Dead"/> = a later line of
-    /// the same file overwrites this write for the finding's target (a NOT-dead, non-last entry is a
-    /// broad write inside an explicit-target finding — overwritten for THIS target but still live for
-    /// every other record, so not removable).</summary>
-    public sealed record SkyPatcherItmEntry(int Line, string Op, string Value, bool Conditional, bool Dead);
+    /// <summary>One dead write inside a <see cref="SkyPatcherItm"/>: its line, op, value, the target
+    /// token(s) it wrote, and the same-file line(s) whose later unconditional writes re-cover every
+    /// target (the nearest coverer per target). <see cref="Conditional"/> = the dead line itself
+    /// carries non-primary filters — informational only; the write is dead either way, because the
+    /// overwrite is unconditional.</summary>
+    public sealed record SkyPatcherItmEntry(
+        int Line, string Op, string Value, string Targets, bool Conditional, IReadOnlyList<int> KillerLines);
 
     /// <summary>Both report classes from the one detection pass.</summary>
     public sealed record Report(
@@ -143,30 +140,54 @@ public static class SkyPatcherConflicts
             Emit(conflicts, folder.Subfolder, fieldGroup.Key, Broad, broad);
         }
 
-        // ---- intra-file dead lines (ITM-class): one file, one field, one target, written twice.
-        //      A file's lines are contiguous in apply order (files apply whole, in filename sort), so
-        //      same-file overwrites need only that file's own events, walked in line order. ----
+        // ---- intra-file dead writes (ITM-class): a later line of the SAME file unconditionally
+        //      re-covers EVERY target of an earlier write. A file's lines are contiguous in apply
+        //      order (files apply whole, in filename sort), so same-file coverage needs only that
+        //      file's own events — walked BACKWARD with a running token → nearest-unconditional-
+        //      coverer map: O(events × targets-per-event), not the per-token re-scan the conflict
+        //      pass's review fold removed. Only unconditional writes enter the map (a conditional
+        //      overwriter may not fire, so it kills nothing); broad coverage is tracked separately
+        //      (broad covers every explicit token; nothing but broad covers broad). ----
         foreach (var fileFieldGroup in events.GroupBy(e => (e.file, e.field)))
         {
-            var evs = fileFieldGroup.OrderBy(e => e.seq).ToList();
+            var evs = fileFieldGroup.ToList();   // already in seq (= line) order by construction
             if (evs.Count < 2) continue;
-            foreach (var token in evs.SelectMany(e => e.targets).Distinct(StringComparer.OrdinalIgnoreCase)
-                                     .OrderBy(t => t, StringComparer.OrdinalIgnoreCase))
+            var nearestCoverer = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            int broadCovererLine = -1;
+            var dead = new List<SkyPatcherItmEntry>();
+            for (int i = evs.Count - 1; i >= 0; i--)
             {
-                // The file's writes that hit this token: explicit matches, plus broad writes when the
-                // token is explicit (broad covers everything; nothing but broad covers broad).
-                var covering = evs.Where(e => e.targets.Contains(token, StringComparer.OrdinalIgnoreCase)
-                                              || (token != Broad && e.targets.Contains(Broad))).ToList();
-                if (covering.Count < 2) continue;
-                var entries = covering.Select((e, i) => new SkyPatcherItmEntry(
-                    e.line, e.op, e.value, e.conditional,
-                    // Dead = a later covering line exists AND this write has no life beyond the token:
-                    // a broad write inside an explicit-token finding stays live for other records.
-                    Dead: i < covering.Count - 1 && (token == Broad || !e.targets.Contains(Broad)))).ToList();
-                if (!entries.Any(en => en.Dead)) continue;   // e.g. broad-then-explicit: nothing removable
-                itms.Add(new SkyPatcherItm(folder.Subfolder, fileFieldGroup.Key.field,
-                    token == Broad ? $"(all {folder.Subfolder} records)" : token,
-                    fileFieldGroup.Key.file, entries));
+                var e = evs[i];
+                var killers = new List<int>();
+                bool allCovered = true;
+                foreach (var t in e.targets)
+                {
+                    // The nearest later unconditional line covering t: its own-token coverer or the
+                    // nearest broad, whichever sits closer (both are later than e by construction).
+                    int k = t == Broad ? broadCovererLine
+                        : nearestCoverer.TryGetValue(t, out var own)
+                            ? (broadCovererLine < 0 ? own : Math.Min(own, broadCovererLine))
+                            : broadCovererLine;
+                    if (k < 0) { allCovered = false; break; }
+                    if (!killers.Contains(k)) killers.Add(k);
+                }
+                if (allCovered)
+                {
+                    killers.Sort();
+                    dead.Add(new SkyPatcherItmEntry(e.line, e.op, e.value,
+                        e.targets is [Broad] ? $"(all {folder.Subfolder} records)" : string.Join(", ", e.targets),
+                        e.conditional, killers));
+                }
+                if (!e.conditional)   // walking backward, this event is now the nearest coverer for its tokens
+                {
+                    if (e.targets.Contains(Broad)) broadCovererLine = e.line;
+                    else foreach (var t in e.targets) nearestCoverer[t] = e.line;
+                }
+            }
+            if (dead.Count > 0)
+            {
+                dead.Reverse();   // back to line order
+                itms.Add(new SkyPatcherItm(folder.Subfolder, fileFieldGroup.Key.field, fileFieldGroup.Key.file, dead));
             }
         }
         return new Report(conflicts, itms);

--- a/src/housecarl-core/SkyPatcherOverlay.cs
+++ b/src/housecarl-core/SkyPatcherOverlay.cs
@@ -800,7 +800,7 @@ public static class SkyPatcherOverlay
     /// Review finding #4: the bare 24-bit mask made every full ESL FormID silently match nothing.
     /// Residual EMPIRICAL item: a bare 6-hex ESL spelling like <c>800123</c> is inherently ambiguous
     /// (documented in the plan's Wave-1 list) — the 24-bit mask applies to it.</summary>
-    internal static bool TryFormKey(FormAddress a, out FormKey fk)
+    public static bool TryFormKey(FormAddress a, out FormKey fk)
     {
         fk = default;
         if (a.Plugin is null || a.FormId is null) return false;

--- a/src/housecarl-generator/SkyPatcherConflictsProbe.cs
+++ b/src/housecarl-generator/SkyPatcherConflictsProbe.cs
@@ -11,6 +11,12 @@ namespace HousecarlGenerator;
 //  file in apply order); accumulating ops are NOT; same-value sets are
 //  NOT; a not-applied file's lines do NOT participate; a broad line
 //  collides with an explicit target; extra filters flag CONDITIONAL.
+//
+//  Also the intra-file dead-line (ITM-class) half: one file writing the
+//  same field/target twice IS an ITM (same value included — deadness
+//  doesn't depend on value); explicit-then-broad kills the explicit;
+//  broad-then-explicit kills NOTHING (broad stays live elsewhere);
+//  accumulating / gated / cross-file writes never ITM.
 // ======================================================================
 public static class SkyPatcherConflictsProbe
 {
@@ -49,7 +55,8 @@ public static class SkyPatcherConflictsProbe
             Ini("y.ini", $"filterByWeapons={target}:reach=2.5"),                   // explicit vs z's BROAD reach
         });
 
-        var conflicts = SkyPatcherConflicts.Detect(folder, catalog, fieldMap);
+        var report = SkyPatcherConflicts.Detect(folder, catalog, fieldMap);
+        var conflicts = report.Conflicts;
         string Dump() => string.Join(" ; ", conflicts.Select(c => $"{c.Field}@{c.Target}:{string.Join("|", c.Entries.Select(e => $"{e.File}={e.Value}"))}"));
 
         var dmg = conflicts.FirstOrDefault(c => c.Field == "BasicStats.Damage");
@@ -72,6 +79,55 @@ public static class SkyPatcherConflictsProbe
             && speed.Entries.Any(e => e.Conditional) && speed.Entries.Any(e => !e.Conditional), Dump());
         failures += Check("different-target sets do NOT collide (no conflict lists 99)",
             conflicts.All(c => c.Entries.All(e => e.Value != "99")), Dump());
+
+        // ---- the intra-file dead-line (ITM-class) half ----
+        failures += Check("cross-file-only writes are NOT ITMs (the conflict fixture yields zero)",
+            report.Itms.Count == 0, string.Join(" ; ", report.Itms.Select(m => $"{m.Field}@{m.Target}:{m.File}")));
+
+        var itmFolder = new SkyPatcherDiscovery.FolderScan("weapon", weapCat, PatchingEnabled: true, Files: new[]
+        {
+            Ini("g.ini",
+                "attackDamage=1",                                                   // BROAD, overwritten by...
+                "attackDamage=2"),                                                  // ...this later BROAD — the earlier is dead
+            Ini("gated2.ini",
+                $"filterByWeapons={target}:weight=1",
+                $"filterByWeapons={target}:weight=2") with { NotApplied = "filename-gated off" },
+            Ini("i.ini",
+                $"filterByWeapons={target}:attackDamage=40",                        // dead — even though...
+                $"filterByWeapons={target}:attackDamage=40",                        // ...the value is IDENTICAL (the purest ITM)
+                $"filterByWeapons={target}:weight=5",                               // dead — a later BROAD covers it
+                "weight=9",
+                "reach=1.0",                                                        // BROAD then explicit: broad stays live elsewhere — NOT an ITM
+                $"filterByWeapons={target}:reach=2.0",
+                $"filterByWeapons={target}:filterByKeywords=Some.esp|200:speed=3",  // dead + CONDITIONAL (extra filter)
+                $"filterByWeapons={target}:speed=7",
+                $"filterByWeapons={target}:keywordsToAdd=Some.esp|100",             // accumulating twice — never an ITM
+                $"filterByWeapons={target}:keywordsToAdd=Some.esp|101"),
+        });
+        var itmReport = SkyPatcherConflicts.Detect(itmFolder, catalog, fieldMap);
+        var itms = itmReport.Itms;
+        string DumpItms() => string.Join(" ; ", itms.Select(m => $"{Path.GetFileName(m.File)}:{m.Field}@{m.Target}:{string.Join("|", m.Entries.Select(e => $"{e.Line}={e.Value}{(e.Dead ? "†" : "")}"))}"));
+
+        var dmgItm = itms.FirstOrDefault(m => m.Field == "BasicStats.Damage" && m.File.Contains("i.ini"));
+        failures += Check("same field/target written twice in ONE file IS an ITM — same value included",
+            dmgItm is not null && dmgItm.Entries.Count == 2 && dmgItm.Entries[0].Dead && !dmgItm.Entries[1].Dead
+            && dmgItm.Live.Value == "40", DumpItms());
+        var wItm = itms.FirstOrDefault(m => m.Field == "BasicStats.Weight");
+        failures += Check("explicit-target write killed by a later same-file BROAD write is dead",
+            wItm is not null && wItm.File.Contains("i.ini") && wItm.Entries.Count == 2
+            && wItm.Entries[0].Dead && wItm.Live.Value == "9", DumpItms());
+        failures += Check("BROAD-then-explicit kills nothing (broad stays live for other records) — no reach ITM",
+            itms.All(m => m.Field != "Data.Reach"), DumpItms());
+        var sItm = itms.FirstOrDefault(m => m.Field == "Data.Speed");
+        failures += Check("a dead line carrying EXTRA filters is flagged CONDITIONAL",
+            sItm is not null && sItm.Conditional && sItm.Entries[0].Dead && sItm.Entries[0].Conditional, DumpItms());
+        failures += Check("accumulating op (keywordsToAdd) twice is NOT an ITM",
+            itms.All(m => m.Field != "Keywords"), DumpItms());
+        var bItm = itms.FirstOrDefault(m => m.File.Contains("g.ini"));
+        failures += Check("BROAD-vs-BROAD in one file IS an ITM (earlier broad dead)",
+            bItm is not null && bItm.Field == "BasicStats.Damage" && bItm.Entries[0].Dead && bItm.Live.Value == "2", DumpItms());
+        failures += Check("a not-applied (gated) file's duplicates do NOT ITM",
+            itms.All(m => !m.File.Contains("gated2")), DumpItms());
 
         // ---- the set/accumulate PARTITION is exhaustive: a new SkyPatcherOpSemantic member cannot
         //      silently default to "accumulating" and make the detector under-report (review fold). ----

--- a/src/housecarl-generator/SkyPatcherConflictsProbe.cs
+++ b/src/housecarl-generator/SkyPatcherConflictsProbe.cs
@@ -154,6 +154,40 @@ public static class SkyPatcherConflictsProbe
         failures += Check("a conditional EARLIER write killed unconditionally IS dead (flagged informational)",
             crItm is not null && crItm.Entries is [{ Line: 3, Conditional: true, KillerLines: [4] }], DumpItms());
 
+        // ---- the no-op (true-ITM) scan's two extracted rules (PR #169 review: the layer scan's
+        //      machinery had zero probe coverage; these pin the shareable halves — the full replay
+        //      wiring is validated live, 23 real no-ops on the ARR 2.0 order). ----
+        var noOpTargets = new HashSet<Mutagen.Bethesda.Plugins.FormKey>();
+        var noOpEids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        int broad = 0;
+        void Collect(string line) => SkyPatcherConflicts.CollectExplicitPrimaryTargets(
+            SkyPatcherParse.ParseLine(line), catalog, weapCat, noOpTargets, noOpEids, ref broad);
+        Collect($"filterByWeapons={target}:attackDamage=40");                       // FormID target
+        Collect("filterByWeapons=IronSword1H,SteelSword1H:attackDamage=40");        // two EditorID targets
+        Collect("attackDamage=60");                                                 // BROAD — counted, no target
+        Collect($"filterByWeaponsExcluded={target}:reach=2");                       // Excluded primary — NOT a bare-primary target (broad line)
+        Collect($"filterByWeapons={target}");                                       // no ops — not a broad WRITE either
+        failures += Check("target collection: FormID → FormKey, EditorIDs → raw strings, broad ops counted, Excluded-primary and op-less lines excluded",
+            noOpTargets.Count == 1 && noOpEids.SetEquals(new[] { "IronSword1H", "SteelSword1H" }) && broad == 2,
+            $"forms={noOpTargets.Count} eids=[{string.Join(",", noOpEids)}] broad={broad}");
+
+        var weapMap = fieldMap.ForSubfolder("weapon")[0];
+        SkyPatcherOverlay.SkyPatcherAppliedOp Ap(string op, string raw, string? before, string? after) =>
+            new("x.ini", 1, op, raw, "p", before, after, null);
+        failures += Check("no-op test: a SET-class op with before == after IS a no-op write",
+            SkyPatcherConflicts.IsNoOpWrite(Ap("attackDamage", "40", "40", "40"), weapMap));
+        failures += Check("no-op test: before != after is NOT",
+            !SkyPatcherConflicts.IsNoOpWrite(Ap("attackDamage", "60", "40", "60"), weapMap));
+        failures += Check("no-op test: a deliberate 'none' leave-unchanged is NOT flagged",
+            !SkyPatcherConflicts.IsNoOpWrite(Ap("setProtected", "none", "true", "true"), fieldMap.ForSubfolder("npc")[0]));
+        failures += Check("no-op test: an ACCUMULATING op with equal tokens is NOT this class (skypatcher_read's lane)",
+            !SkyPatcherConflicts.IsNoOpWrite(Ap("keywordsToAdd", "Some.esp|100", "2 entr(ies)", "2 entr(ies)"), weapMap));
+        failures += Check("no-op test: an unknown/unmapped op or a null map is NOT flagged",
+            !SkyPatcherConflicts.IsNoOpWrite(Ap("nonsenseOp", "1", "1", "1"), weapMap)
+            && !SkyPatcherConflicts.IsNoOpWrite(Ap("attackDamage", "40", "40", "40"), null));
+        failures += Check("no-op test: a null before (no static read) is NOT flagged",
+            !SkyPatcherConflicts.IsNoOpWrite(Ap("attackDamage", "40", null, null), weapMap));
+
         // ---- the set/accumulate PARTITION is exhaustive: a new SkyPatcherOpSemantic member cannot
         //      silently default to "accumulating" and make the detector under-report (review fold). ----
         var unclassified = Enum.GetValues<SkyPatcherOpSemantic>()

--- a/src/housecarl-generator/SkyPatcherConflictsProbe.cs
+++ b/src/housecarl-generator/SkyPatcherConflictsProbe.cs
@@ -74,6 +74,14 @@ public static class SkyPatcherConflictsProbe
             conflicts.All(c => c.Field != "Keywords"), Dump());
         failures += Check("same-value sets are NOT a conflict (weight 5 vs 5)",
             conflicts.All(c => c.Field != "BasicStats.Weight"), Dump());
+        var dup = report.Duplicates.FirstOrDefault(x => x.Field == "BasicStats.Weight");
+        failures += Check("same-value sets across files ARE a cross-INI DUPLICATE (weight 5 vs 5, a.ini + m.ini)",
+            dup is not null && dup.Entries.Count == 2
+            && dup.Entries.Select(e => Path.GetFileName(e.File)).SequenceEqual(new[] { "a.ini", "m.ini" }),
+            string.Join(" ; ", report.Duplicates.Select(x => $"{x.Field}@{x.Target}")));
+        failures += Check("a value-MIXED group stays a conflict only, never double-reported as a duplicate",
+            report.Duplicates.All(x => x.Field != "BasicStats.Damage" && x.Field != "Data.Reach" && x.Field != "Data.Speed"),
+            string.Join(" ; ", report.Duplicates.Select(x => $"{x.Field}@{x.Target}")));
         var reach = conflicts.FirstOrDefault(c => c.Field == "Data.Reach");
         failures += Check("a BROAD set collides with an explicit-target set (reach 1.5 vs 2.5)",
             reach is not null && reach.Entries.Count == 2 && reach.Winner.Value == "2.5", Dump());

--- a/src/housecarl-generator/SkyPatcherConflictsProbe.cs
+++ b/src/housecarl-generator/SkyPatcherConflictsProbe.cs
@@ -12,11 +12,15 @@ namespace HousecarlGenerator;
 //  NOT; a not-applied file's lines do NOT participate; a broad line
 //  collides with an explicit target; extra filters flag CONDITIONAL.
 //
-//  Also the intra-file dead-line (ITM-class) half: one file writing the
-//  same field/target twice IS an ITM (same value included — deadness
-//  doesn't depend on value); explicit-then-broad kills the explicit;
-//  broad-then-explicit kills NOTHING (broad stays live elsewhere);
-//  accumulating / gated / cross-file writes never ITM.
+//  Also the intra-file dead-write (ITM-class) half: a write is dead ONLY
+//  when a later line of the same file unconditionally re-covers EVERY
+//  target (same value included — deadness doesn't depend on value).
+//  RED-proofs the two review-confirmed kill-rule bugs: a multi-target
+//  line partially overwritten is NOT dead (it still carries the other
+//  target's write), and a CONDITIONAL overwriter kills nothing (it may
+//  not fire) — while a conditional EARLIER write killed unconditionally
+//  IS dead. Explicit-then-broad kills; broad-then-explicit kills
+//  nothing; accumulating / gated / cross-file writes never ITM.
 // ======================================================================
 public static class SkyPatcherConflictsProbe
 {
@@ -80,9 +84,9 @@ public static class SkyPatcherConflictsProbe
         failures += Check("different-target sets do NOT collide (no conflict lists 99)",
             conflicts.All(c => c.Entries.All(e => e.Value != "99")), Dump());
 
-        // ---- the intra-file dead-line (ITM-class) half ----
+        // ---- the intra-file dead-write (ITM-class) half ----
         failures += Check("cross-file-only writes are NOT ITMs (the conflict fixture yields zero)",
-            report.Itms.Count == 0, string.Join(" ; ", report.Itms.Select(m => $"{m.Field}@{m.Target}:{m.File}")));
+            report.Itms.Count == 0, string.Join(" ; ", report.Itms.Select(m => $"{m.Field}:{m.File}")));
 
         var itmFolder = new SkyPatcherDiscovery.FolderScan("weapon", weapCat, PatchingEnabled: true, Files: new[]
         {
@@ -97,37 +101,50 @@ public static class SkyPatcherConflictsProbe
                 $"filterByWeapons={target}:attackDamage=40",                        // ...the value is IDENTICAL (the purest ITM)
                 $"filterByWeapons={target}:weight=5",                               // dead — a later BROAD covers it
                 "weight=9",
-                "reach=1.0",                                                        // BROAD then explicit: broad stays live elsewhere — NOT an ITM
+                "reach=1.0",                                                        // BROAD then explicit: broad stays live elsewhere — NOT dead
                 $"filterByWeapons={target}:reach=2.0",
-                $"filterByWeapons={target}:filterByKeywords=Some.esp|200:speed=3",  // dead + CONDITIONAL (extra filter)
-                $"filterByWeapons={target}:speed=7",
                 $"filterByWeapons={target}:keywordsToAdd=Some.esp|100",             // accumulating twice — never an ITM
                 $"filterByWeapons={target}:keywordsToAdd=Some.esp|101"),
+            Ini("multi.ini",
+                $"filterByWeapons={target},{other}:attackDamage=40",                // NOT dead — the later line covers only ONE of its targets
+                $"filterByWeapons={target}:attackDamage=60",
+                $"filterByWeapons={target},{other}:weight=1",                       // dead ONCE — the broad re-covers BOTH targets
+                "weight=2"),
+            Ini("cond.ini",
+                $"filterByWeapons={target}:speed=7",                                // NOT dead — the overwriter is CONDITIONAL (may not fire)
+                $"filterByWeapons={target}:filterByKeywords=Some.esp|200:speed=9",
+                $"filterByWeapons={target}:filterByKeywords=Some.esp|200:reach=1.0",// dead — conditional itself, but killed UNCONDITIONALLY
+                $"filterByWeapons={target}:reach=2.0"),
         });
-        var itmReport = SkyPatcherConflicts.Detect(itmFolder, catalog, fieldMap);
-        var itms = itmReport.Itms;
-        string DumpItms() => string.Join(" ; ", itms.Select(m => $"{Path.GetFileName(m.File)}:{m.Field}@{m.Target}:{string.Join("|", m.Entries.Select(e => $"{e.Line}={e.Value}{(e.Dead ? "†" : "")}"))}"));
+        var itms = SkyPatcherConflicts.Detect(itmFolder, catalog, fieldMap).Itms;
+        string DumpItms() => string.Join(" ; ", itms.Select(m => $"{Path.GetFileName(m.File)}:{m.Field}:{string.Join("|", m.Entries.Select(e => $":{e.Line}={e.Value}→kill:{string.Join("+", e.KillerLines)}"))}"));
 
         var dmgItm = itms.FirstOrDefault(m => m.Field == "BasicStats.Damage" && m.File.Contains("i.ini"));
-        failures += Check("same field/target written twice in ONE file IS an ITM — same value included",
-            dmgItm is not null && dmgItm.Entries.Count == 2 && dmgItm.Entries[0].Dead && !dmgItm.Entries[1].Dead
-            && dmgItm.Live.Value == "40", DumpItms());
-        var wItm = itms.FirstOrDefault(m => m.Field == "BasicStats.Weight");
+        failures += Check("same field/target written twice in ONE file IS a dead write — same value included, killer named",
+            dmgItm is not null && dmgItm.Entries is [{ Line: 1, Value: "40", KillerLines: [2] }], DumpItms());
+        var wItm = itms.FirstOrDefault(m => m.Field == "BasicStats.Weight" && m.File.Contains("i.ini"));
         failures += Check("explicit-target write killed by a later same-file BROAD write is dead",
-            wItm is not null && wItm.File.Contains("i.ini") && wItm.Entries.Count == 2
-            && wItm.Entries[0].Dead && wItm.Live.Value == "9", DumpItms());
-        failures += Check("BROAD-then-explicit kills nothing (broad stays live for other records) — no reach ITM",
-            itms.All(m => m.Field != "Data.Reach"), DumpItms());
-        var sItm = itms.FirstOrDefault(m => m.Field == "Data.Speed");
-        failures += Check("a dead line carrying EXTRA filters is flagged CONDITIONAL",
-            sItm is not null && sItm.Conditional && sItm.Entries[0].Dead && sItm.Entries[0].Conditional, DumpItms());
+            wItm is not null && wItm.Entries is [{ Line: 3, KillerLines: [4] }], DumpItms());
+        failures += Check("BROAD-then-explicit kills nothing (broad stays live for other records) — no i.ini reach ITM",
+            itms.All(m => m.Field != "Data.Reach" || !m.File.Contains("i.ini")), DumpItms());
         failures += Check("accumulating op (keywordsToAdd) twice is NOT an ITM",
             itms.All(m => m.Field != "Keywords"), DumpItms());
         var bItm = itms.FirstOrDefault(m => m.File.Contains("g.ini"));
-        failures += Check("BROAD-vs-BROAD in one file IS an ITM (earlier broad dead)",
-            bItm is not null && bItm.Field == "BasicStats.Damage" && bItm.Entries[0].Dead && bItm.Live.Value == "2", DumpItms());
+        failures += Check("BROAD-vs-BROAD in one file IS a dead write (earlier broad dead)",
+            bItm is not null && bItm.Field == "BasicStats.Damage" && bItm.Entries is [{ Line: 1, KillerLines: [2] }], DumpItms());
         failures += Check("a not-applied (gated) file's duplicates do NOT ITM",
             itms.All(m => !m.File.Contains("gated2")), DumpItms());
+        // The two review-confirmed kill-rule bugs stay RED-proofed:
+        failures += Check("a MULTI-TARGET write partially overwritten is NOT dead (still live for the other target)",
+            itms.All(m => m.Field != "BasicStats.Damage" || !m.File.Contains("multi.ini")), DumpItms());
+        var mwItm = itms.FirstOrDefault(m => m.Field == "BasicStats.Weight" && m.File.Contains("multi.ini"));
+        failures += Check("a MULTI-TARGET write fully re-covered is dead — reported ONCE (per write, not per token)",
+            mwItm is not null && mwItm.Entries is [{ Line: 3, KillerLines: [4] }], DumpItms());
+        failures += Check("a CONDITIONAL overwriter kills nothing (it may not fire) — no cond.ini speed ITM",
+            itms.All(m => m.Field != "Data.Speed"), DumpItms());
+        var crItm = itms.FirstOrDefault(m => m.Field == "Data.Reach" && m.File.Contains("cond.ini"));
+        failures += Check("a conditional EARLIER write killed unconditionally IS dead (flagged informational)",
+            crItm is not null && crItm.Entries is [{ Line: 3, Conditional: true, KillerLines: [4] }], DumpItms());
 
         // ---- the set/accumulate PARTITION is exhaustive: a new SkyPatcherOpSemantic member cannot
         //      silently default to "accumulating" and make the detector under-report (review fold). ----

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -490,29 +490,14 @@ public sealed class LoadOrderService : IDisposable
             foreach (var folder in scan.Folders)
             {
                 if (folder.Catalog is null || !folder.PatchingEnabled) continue;
-                var folderTypes = fieldMap.ForSubfolder(folder.Subfolder).Select(m => m.RecordType).ToList();
+                var eids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 foreach (var ol in SkyPatcherDiscovery.OrderedLines(folder))
+                    SkyPatcherConflicts.CollectExplicitPrimaryTargets(ol.Parsed, catalog, folder.Catalog, targets, eids, ref broadLines);
+                var folderTypes = fieldMap.ForSubfolder(folder.Subfolder).Select(m => m.RecordType).ToList();
+                foreach (var eid in eids)
                 {
-                    if (ol.Parsed.Kind != SkyPatcherLineKind.Patch) continue;
-                    bool hasOp = false, hasExplicit = false;
-                    foreach (var seg in ol.Parsed.Segments)
-                    {
-                        var cls = catalog.Classify(folder.Catalog, seg.Key);
-                        if (cls.Role == SkyPatcherKeyRole.Operation) hasOp = true;
-                        else if (cls.Role == SkyPatcherKeyRole.Filter
-                                 && cls.Filter!.Kind == SkyPatcherFilterKind.Primary && (cls.Connective ?? "") == "")
-                            foreach (var v in seg.Values)
-                            {
-                                hasExplicit = true;
-                                if (v.Address is { IsFormId: true } a && SkyPatcherOverlay.TryFormKey(a, out var tfk)) targets.Add(tfk);
-                                else
-                                {
-                                    var rfk = folderTypes.Select(t => formResolver.ResolveEditorId(v.Raw, t)).FirstOrDefault(x => x is not null);
-                                    if (rfk is not null) targets.Add(rfk.Value); else unresolvedTargets++;
-                                }
-                            }
-                    }
-                    if (hasOp && !hasExplicit) broadLines++;
+                    var rfk = folderTypes.Select(t => formResolver.ResolveEditorId(eid, t)).FirstOrDefault(x => x is not null);
+                    if (rfk is not null) targets.Add(rfk.Value); else unresolvedTargets++;
                 }
             }
             foreach (var fk in targets)
@@ -524,16 +509,20 @@ public sealed class LoadOrderService : IDisposable
                     if (fo.Result is not { } res) continue;
                     var map = fieldMap.For(fo.Subfolder, r.TypeName!);
                     foreach (var a in res.Applied)
-                    {
-                        if (a.Before is null || a.Before != a.After) continue;
-                        if (a.RawValue.Trim().Equals("none", StringComparison.OrdinalIgnoreCase)) continue;   // deliberate leave-unchanged
-                        var op = map?.Ops.GetValueOrDefault(a.Op);
-                        if (op is null || op.IsUnmapped || !SkyPatcherConflicts.SetClassSemantics.Contains(op.Semantic)) continue;
-                        noOps.Add(new SkyPatcherNoOpWrite(fo.Subfolder, fk.ToString(), r.EditorId,
-                            a.FieldPath, a.File, a.LineNumber, a.Op, a.RawValue, a.Before));
-                    }
+                        if (SkyPatcherConflicts.IsNoOpWrite(a, map))
+                            noOps.Add(new SkyPatcherNoOpWrite(fo.Subfolder, fk.ToString(), r.EditorId,
+                                a.FieldPath, a.File, a.LineNumber, a.Op, a.RawValue, a.Before!));
                 }
             }
+            // Stable output — targets is a hash set, so without this the findings' order varies run
+            // to run, and the re-run-to-confirm workflow needs diffable output (review finding).
+            noOps.Sort((x, y) =>
+            {
+                int c = string.Compare(x.File, y.File, StringComparison.OrdinalIgnoreCase);
+                if (c != 0) return c;
+                c = x.Line.CompareTo(y.Line);
+                return c != 0 ? c : string.Compare(x.FormKey, y.FormKey, StringComparison.OrdinalIgnoreCase);
+            });
             if (broadLines > 0) noOpNotes.Add($"no-op scan: {broadLines} broad (type-wide) line(s) were evaluated only against the explicitly-targeted records, not every record of their type.");
             if (unresolvedTargets > 0) noOpNotes.Add($"no-op scan: {unresolvedTargets} explicit target(s) did not resolve (the overlay's per-record warnings name them via housecarl_skypatcher_read).");
             if (failedReplays > 0) noOpNotes.Add($"no-op scan: {failedReplays} targeted record(s) could not be replayed (not in the order / unpatchable type / copy failure).");

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -439,9 +439,14 @@ public sealed class LoadOrderService : IDisposable
         var fieldMap = SkyPatcherFieldMap.Load();
         var scan = SkyPatcherDiscovery.Scan(assets, catalog, view.ContainsPlugin, _skyPatcherParseCache);
         var conflicts = new List<SkyPatcherConflicts.SkyPatcherConflict>();
+        var itms = new List<SkyPatcherConflicts.SkyPatcherItm>();
         foreach (var folder in scan.Folders)
-            conflicts.AddRange(SkyPatcherConflicts.Detect(folder, catalog, fieldMap));
-        return new SkyPatcherLayerData(scan, conflicts, scan.ReadIncomplete || assets.ReadIncomplete, assetWarnings, profileName);
+        {
+            var report = SkyPatcherConflicts.Detect(folder, catalog, fieldMap);
+            conflicts.AddRange(report.Conflicts);
+            itms.AddRange(report.Itms);
+        }
+        return new SkyPatcherLayerData(scan, conflicts, itms, scan.ReadIncomplete || assets.ReadIncomplete, assetWarnings, profileName);
     }
 
     /// <summary>The live-load-order lookups the overlay needs (<see cref="SkyPatcherOverlay.IFormResolver"/>),
@@ -4166,10 +4171,12 @@ public sealed record SkseInventoryData(
     string ProfileName);
 
 /// <summary>The data behind the whole-layer SkyPatcher scan (Wave 2): the ordered discovery scan, the
-/// per-folder INI-vs-INI set collisions, and the build-level Q3 caveats.</summary>
+/// per-folder INI-vs-INI set collisions, the intra-file dead lines (ITM-class), and the build-level
+/// Q3 caveats.</summary>
 public sealed record SkyPatcherLayerData(
     HousecarlCore.SkyPatcherDiscovery.LayerScan Scan,
     IReadOnlyList<HousecarlCore.SkyPatcherConflicts.SkyPatcherConflict> Conflicts,
+    IReadOnlyList<HousecarlCore.SkyPatcherConflicts.SkyPatcherItm> Itms,
     bool ReadIncomplete,
     IReadOnlyList<string> AssetWarnings,
     string ProfileName);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -353,30 +353,49 @@ public sealed class LoadOrderService : IDisposable
             profileName = _profileName;
         }
 
+        var fieldMap = SkyPatcherFieldMap.Load();
+        var catalog = SkyPatcherCatalog.Load();
+        using var session = resolver.OpenSession();
+        var scan = SkyPatcherDiscovery.Scan(assets, catalog, view.ContainsPlugin, _skyPatcherParseCache);
+        var scratch = new SkyrimMod(SkyPatcherScratchKey, SkyrimRelease.SkyrimSE);
+        var formResolver = new SkyPatcherServiceResolver(this, view, session);
+
+        var r = ReplaySkyPatcher(view, session, scan, catalog, fieldMap, scratch, formResolver, fk, linesCache: null);
+        if (r.Error is not null) return SkyPatcherPostStateData.Fail(fk, r.Error);
+        return new SkyPatcherPostStateData(null, fk, r.EditorId, r.TypeName, r.WinnerPlugin,
+            r.Folders, scan.Notes, scan.ReadIncomplete || assets.ReadIncomplete, assetWarnings, profileName);
+    }
+
+    /// <summary>The per-record SkyPatcher replay core, shared by the post-state read and the layer
+    /// no-op (true-ITM) scan: resolve the winner, materialize a mutable scratch copy, apply every
+    /// type folder's ordered lines in field-map order. Error = the named reason the record can't be
+    /// replayed (Q3 — the caller decides whether that's a Fail or a skip-with-count).</summary>
+    (string? TypeName, string? WinnerPlugin, string? EditorId, List<SkyPatcherFolderOutcome> Folders, string? Error)
+        ReplaySkyPatcher(
+            LoadOrderResolver.IndexView view, LoadOrderResolver.OverlaySession session,
+            SkyPatcherDiscovery.LayerScan scan, SkyPatcherCatalog catalog, SkyPatcherFieldMap fieldMap,
+            SkyrimMod scratch, SkyPatcherOverlay.IFormResolver formResolver, FormKey fk,
+            Dictionary<string, IReadOnlyList<SkyPatcherOverlay.OrderedLine>>? linesCache)
+    {
+        var none = new List<SkyPatcherFolderOutcome>();
         var winner = view.ResolveWinner(fk);
         if (winner is null)
-            return SkyPatcherPostStateData.Fail(fk, $"FormID {fk} is not present in the load order ({view.PluginCount} plugins).");
+            return (null, null, null, none, $"FormID {fk} is not present in the load order ({view.PluginCount} plugins).");
 
-        using var session = resolver.OpenSession();
         var body = view.GetRecord(session, winner.Value.WinnerPlugin, fk);
         if (body is null)
-            return SkyPatcherPostStateData.Fail(fk, $"Winner '{winner.Value.WinnerPlugin}' did not yield {fk} on fetch — a load-order inconsistency.");
+            return (null, winner.Value.WinnerPlugin, null, none, $"Winner '{winner.Value.WinnerPlugin}' did not yield {fk} on fetch — a load-order inconsistency.");
 
         var typeName = ReadEngine.ReadFields(body, new[] { "EditorID" }).Type;   // the same type naming every read tool reports
-        var fieldMap = SkyPatcherFieldMap.Load();
         var maps = fieldMap.ForRecordType(typeName);
         if (maps.Count == 0)
-            return SkyPatcherPostStateData.Fail(fk,
+            return (typeName, winner.Value.WinnerPlugin, body.EditorID, none,
                 $"Record type '{typeName}' is not a SkyPatcher-patchable type (or has no field map) — the SkyPatcher layer cannot touch {fk}.");
-
-        var catalog = SkyPatcherCatalog.Load();
-        var scan = SkyPatcherDiscovery.Scan(assets, catalog, view.ContainsPlugin, _skyPatcherParseCache);
 
         // The running copy: the winner overridden into an in-memory scratch mod (never written to disk).
         // Nested-group types (CELL / REFR / INFO…) need the source link cache to rebuild their parent
         // chain — the same RecordNeedsSourceCache + LinkCacheFor idiom every write path uses (PR #165
         // review finding #1: without it, 2 of the 27 covered types threw unhandled instead of failing named).
-        var scratch = new SkyrimMod(SkyPatcherScratchKey, SkyrimRelease.SkyrimSE);
         IMajorRecord copy;
         try
         {
@@ -386,11 +405,10 @@ public sealed class LoadOrderService : IDisposable
         }
         catch (Exception ex)
         {
-            return SkyPatcherPostStateData.Fail(fk,
+            return (typeName, winner.Value.WinnerPlugin, body.EditorID, none,
                 $"Could not materialize a mutable copy of {fk} ({typeName}) for the replay — {ex.GetType().Name}: {ex.Message}");
         }
 
-        var formResolver = new SkyPatcherServiceResolver(this, view, session);
         var folders = new List<SkyPatcherFolderOutcome>();
         foreach (var m in maps)
         {
@@ -400,7 +418,10 @@ public sealed class LoadOrderService : IDisposable
                 folders.Add(new SkyPatcherFolderOutcome(m.Subfolder, 0, 0, null, true));
                 continue;
             }
-            var lines = SkyPatcherDiscovery.OrderedLines(folder);
+            IReadOnlyList<SkyPatcherOverlay.OrderedLine> lines;
+            if (linesCache is null) lines = SkyPatcherDiscovery.OrderedLines(folder);
+            else if (!linesCache.TryGetValue(folder.Subfolder, out lines!))
+                linesCache[folder.Subfolder] = lines = SkyPatcherDiscovery.OrderedLines(folder);
             var result = SkyPatcherOverlay.Apply(copy, fk, body.EditorID, catalog, folder.Catalog, m, lines, formResolver);
             // A toggled-off folder contributes NOTHING — reporting its files as "applied" would assert
             // as live the INIs the DLL skips wholesale (review finding #7). Enabled rides along so the
@@ -410,17 +431,18 @@ public sealed class LoadOrderService : IDisposable
                 folder.PatchingEnabled));
         }
 
-        return new SkyPatcherPostStateData(null, fk, body.EditorID, typeName, winner.Value.WinnerPlugin,
-            folders, scan.Notes, scan.ReadIncomplete || assets.ReadIncomplete, assetWarnings, profileName);
+        return (typeName, winner.Value.WinnerPlugin, body.EditorID, folders, null);
     }
 
     /// <summary>
     /// Scan the WHOLE SkyPatcher layer (housecarl_skypatcher_layer): every loose INI as the DLL reads
     /// it (ordered union, VFS same-path collisions surfaced, gates + toggles evaluated) plus the
-    /// INI-vs-INI same-field SET collisions per type folder (<see cref="SkyPatcherConflicts"/>,
-    /// report-only). ONE record capture answers the filename gates + ONE asset capture pins the scan
-    /// (the SkseInventory discipline); the enumerate + parse + detect run OUTSIDE the gate on the
-    /// handle-free captured view. A layer with no INIs is a NAMED outcome, never an empty guess (Q3).
+    /// INI-vs-INI same-field SET collisions and the three ITM classes — intra-file dead writes +
+    /// cross-INI duplicates (<see cref="SkyPatcherConflicts"/>) and the no-op writes (the per-record
+    /// replay below), all report-only. ONE record capture answers the filename gates + ONE asset
+    /// capture pins the scan (the SkseInventory discipline); the enumerate + parse + detect run
+    /// OUTSIDE the gate on the handle-free captured view. A layer with no INIs is a NAMED outcome,
+    /// never an empty guess (Q3).
     /// </summary>
     public SkyPatcherLayerData SkyPatcherLayer()
     {
@@ -440,13 +462,85 @@ public sealed class LoadOrderService : IDisposable
         var scan = SkyPatcherDiscovery.Scan(assets, catalog, view.ContainsPlugin, _skyPatcherParseCache);
         var conflicts = new List<SkyPatcherConflicts.SkyPatcherConflict>();
         var itms = new List<SkyPatcherConflicts.SkyPatcherItm>();
+        var duplicates = new List<SkyPatcherConflicts.SkyPatcherDuplicate>();
         foreach (var folder in scan.Folders)
         {
             var report = SkyPatcherConflicts.Detect(folder, catalog, fieldMap);
             conflicts.AddRange(report.Conflicts);
             itms.AddRange(report.Itms);
+            duplicates.AddRange(report.Duplicates);
         }
-        return new SkyPatcherLayerData(scan, conflicts, itms, scan.ReadIncomplete || assets.ReadIncomplete, assetWarnings, profileName);
+
+        // ---- the TRUE-ITM (no-op write) scan: replay every explicitly-targeted record through the
+        //      same per-record core the post-state read uses, and flag SET-class ops whose before ==
+        //      after — the line writes the value the record already has at that point in the replay
+        //      (which handles chains: a set that restores an earlier INI's change is NOT a no-op).
+        //      Broad (type-wide) lines are evaluated only against the explicitly-targeted records —
+        //      replaying every record of a type is not attempted; the note says so (Q3). Deliberate
+        //      leave-unchanged values ('none') are the author's explicit choice, not flagged. ----
+        var noOps = new List<SkyPatcherNoOpWrite>();
+        var noOpNotes = new List<string>();
+        {
+            using var session = Resolver.OpenSession();
+            var formResolver = new SkyPatcherServiceResolver(this, view, session);
+            var scratch = new SkyrimMod(SkyPatcherScratchKey, SkyrimRelease.SkyrimSE);
+            var linesCache = new Dictionary<string, IReadOnlyList<SkyPatcherOverlay.OrderedLine>>(StringComparer.OrdinalIgnoreCase);
+            var targets = new HashSet<FormKey>();
+            int broadLines = 0, unresolvedTargets = 0, failedReplays = 0;
+            foreach (var folder in scan.Folders)
+            {
+                if (folder.Catalog is null || !folder.PatchingEnabled) continue;
+                var folderTypes = fieldMap.ForSubfolder(folder.Subfolder).Select(m => m.RecordType).ToList();
+                foreach (var ol in SkyPatcherDiscovery.OrderedLines(folder))
+                {
+                    if (ol.Parsed.Kind != SkyPatcherLineKind.Patch) continue;
+                    bool hasOp = false, hasExplicit = false;
+                    foreach (var seg in ol.Parsed.Segments)
+                    {
+                        var cls = catalog.Classify(folder.Catalog, seg.Key);
+                        if (cls.Role == SkyPatcherKeyRole.Operation) hasOp = true;
+                        else if (cls.Role == SkyPatcherKeyRole.Filter
+                                 && cls.Filter!.Kind == SkyPatcherFilterKind.Primary && (cls.Connective ?? "") == "")
+                            foreach (var v in seg.Values)
+                            {
+                                hasExplicit = true;
+                                if (v.Address is { IsFormId: true } a && SkyPatcherOverlay.TryFormKey(a, out var tfk)) targets.Add(tfk);
+                                else
+                                {
+                                    var rfk = folderTypes.Select(t => formResolver.ResolveEditorId(v.Raw, t)).FirstOrDefault(x => x is not null);
+                                    if (rfk is not null) targets.Add(rfk.Value); else unresolvedTargets++;
+                                }
+                            }
+                    }
+                    if (hasOp && !hasExplicit) broadLines++;
+                }
+            }
+            foreach (var fk in targets)
+            {
+                var r = ReplaySkyPatcher(view, session, scan, catalog, fieldMap, scratch, formResolver, fk, linesCache);
+                if (r.Error is not null) { failedReplays++; continue; }
+                foreach (var fo in r.Folders)
+                {
+                    if (fo.Result is not { } res) continue;
+                    var map = fieldMap.For(fo.Subfolder, r.TypeName!);
+                    foreach (var a in res.Applied)
+                    {
+                        if (a.Before is null || a.Before != a.After) continue;
+                        if (a.RawValue.Trim().Equals("none", StringComparison.OrdinalIgnoreCase)) continue;   // deliberate leave-unchanged
+                        var op = map?.Ops.GetValueOrDefault(a.Op);
+                        if (op is null || op.IsUnmapped || !SkyPatcherConflicts.SetClassSemantics.Contains(op.Semantic)) continue;
+                        noOps.Add(new SkyPatcherNoOpWrite(fo.Subfolder, fk.ToString(), r.EditorId,
+                            a.FieldPath, a.File, a.LineNumber, a.Op, a.RawValue, a.Before));
+                    }
+                }
+            }
+            if (broadLines > 0) noOpNotes.Add($"no-op scan: {broadLines} broad (type-wide) line(s) were evaluated only against the explicitly-targeted records, not every record of their type.");
+            if (unresolvedTargets > 0) noOpNotes.Add($"no-op scan: {unresolvedTargets} explicit target(s) did not resolve (the overlay's per-record warnings name them via housecarl_skypatcher_read).");
+            if (failedReplays > 0) noOpNotes.Add($"no-op scan: {failedReplays} targeted record(s) could not be replayed (not in the order / unpatchable type / copy failure).");
+        }
+
+        return new SkyPatcherLayerData(scan, conflicts, itms, duplicates, noOps, noOpNotes,
+            scan.ReadIncomplete || assets.ReadIncomplete, assetWarnings, profileName);
     }
 
     /// <summary>The live-load-order lookups the overlay needs (<see cref="SkyPatcherOverlay.IFormResolver"/>),
@@ -4171,15 +4265,25 @@ public sealed record SkseInventoryData(
     string ProfileName);
 
 /// <summary>The data behind the whole-layer SkyPatcher scan (Wave 2): the ordered discovery scan, the
-/// per-folder INI-vs-INI set collisions, the intra-file dead lines (ITM-class), and the build-level
-/// Q3 caveats.</summary>
+/// per-folder INI-vs-INI set collisions, the three ITM classes (intra-file dead writes, cross-INI
+/// duplicates, no-op writes), and the build-level Q3 caveats.</summary>
 public sealed record SkyPatcherLayerData(
     HousecarlCore.SkyPatcherDiscovery.LayerScan Scan,
     IReadOnlyList<HousecarlCore.SkyPatcherConflicts.SkyPatcherConflict> Conflicts,
     IReadOnlyList<HousecarlCore.SkyPatcherConflicts.SkyPatcherItm> Itms,
+    IReadOnlyList<HousecarlCore.SkyPatcherConflicts.SkyPatcherDuplicate> Duplicates,
+    IReadOnlyList<SkyPatcherNoOpWrite> NoOps,
+    IReadOnlyList<string> NoOpNotes,
     bool ReadIncomplete,
     IReadOnlyList<string> AssetWarnings,
     string ProfileName);
+
+/// <summary>One no-op write (the third ITM class — true ITM): a SET-class op that applied to the
+/// record in the full replay but wrote the value the record already had at that point.
+/// <see cref="Already"/> is that value (the overlay's before == after leaf token).</summary>
+public sealed record SkyPatcherNoOpWrite(
+    string Subfolder, string FormKey, string? EditorId, string FieldPath,
+    string File, int Line, string Op, string Value, string Already);
 
 /// <summary>The data behind the SkyPatcher post-state read (Wave 1): the record's identity + winner, one
 /// <see cref="SkyPatcherFolderOutcome"/> per type folder that can patch it (RACE gets two — race/ + raceHook/),

--- a/src/housecarl-mcp/SkyPatcherTools.cs
+++ b/src/housecarl-mcp/SkyPatcherTools.cs
@@ -27,10 +27,12 @@ public static class SkyPatcherTools
          "that wins the VFS for each file, same-path collisions (the loser's content is never read — flagged), " +
          "Plugin.esp.ini filename gates evaluated against the load order, and SkyPatcher.ini per-type toggles. Then " +
          "reports the INI-vs-INI CONFLICTS: two files setting the SAME field of the SAME record to different values " +
-         "(the later-sorted file wins; add/remove ops accumulate and are not conflicts), plus the intra-file DEAD " +
-         "WRITES (ITM-class): a later line of the SAME file unconditionally re-covers every target of an earlier " +
-         "set — dead regardless of value (a partial or conditional-only overwrite is NOT flagged; the write may " +
-         "still fire). Entries whose applicability " +
+         "(the later-sorted file wins; add/remove ops accumulate and are not conflicts), plus the three ITM " +
+         "classes: intra-file DEAD WRITES (a later line of the SAME file unconditionally re-covers every target " +
+         "of an earlier set — dead regardless of value; partial or conditional-only overwrites are NOT flagged), " +
+         "cross-INI DUPLICATES (two files set the same field/target to the SAME value — one copy is redundant), " +
+         "and NO-OP WRITES (true ITM — the replay shows the SET writes the value the record already has). " +
+         "Entries whose applicability " +
          "also hangs on other filters are flagged conditional rather than guessed. Pass filter= a type folder, mod, " +
          "or filename substring to expand matching files to their patch lines. For ONE record's computed " +
          "post-SkyPatcher state use housecarl_skypatcher_read. Read-only.")]
@@ -96,8 +98,10 @@ static class SkyPatcherWire
           .Append(applied).Append(" applied), ").Append(lines).Append(" patch line(s)");
         if (appliedLines != lines) sb.Append(" (").Append(appliedLines).Append(" in applied files)");   // files vs lines units — don't let a gated file's lines read as live
         int deadWrites = d.Itms.Sum(m => m.Entries.Count);   // entries ARE the dead writes — exact units
-        sb.Append(", ").Append(d.Conflicts.Count).Append(" set-conflict(s), ")
-          .Append(deadWrites).Append(" intra-file dead write(s) (ITM)\n");
+        sb.Append(", ").Append(d.Conflicts.Count).Append(" set-conflict(s); ITM: ")
+          .Append(deadWrites).Append(" intra-file dead write(s), ")
+          .Append(d.Duplicates.Count).Append(" cross-INI duplicate(s), ")
+          .Append(d.NoOps.Count).Append(" no-op write(s)\n");
         if (folders.Count == 0)
             sb.Append("\nno SkyPatcher INIs in the active order (no Data\\SKSE\\Plugins\\SkyPatcher content, or SkyPatcher itself is not installed).\n");
 
@@ -180,6 +184,50 @@ static class SkyPatcherWire
                 shownItms++;
             }
             sb.Append("  (report-only: in YOUR ini a dead write is an authoring slip to fix at the source; in a downloaded mod's it is usually harmless — the last write is what applies. A write partially overwritten, or overwritten only by a conditional line, is NOT listed — it may still fire.)\n");
+        }
+
+        if (d.Duplicates.Count > 0)
+        {
+            sb.Append("\ncross-INI duplicate writes (").Append(d.Duplicates.Count)
+              .Append(") — ITM-class: two or more files set the same field of the same target to the SAME value; one copy is redundant (keep either — the LAST would win if they ever diverge):\n");
+            int shownDups = 0;
+            foreach (var c in d.Duplicates)
+            {
+                if (sb.Length >= cap) { sb.Append("  ... [showing ").Append(shownDups).Append(" of ").Append(d.Duplicates.Count).Append("; raise max_chars]\n"); break; }
+                sb.Append("  - [").Append(c.Subfolder).Append("] ").Append(c.Field).Append(" @ ").Append(c.Target).Append(":\n");
+                foreach (var e in c.Entries)
+                {
+                    if (sb.Length >= cap) { sb.Append("      ... [entries cut at max_chars]\n"); break; }
+                    sb.Append("      ").Append(Path.GetFileName(e.File)).Append(':').Append(e.Line)
+                      .Append("  ").Append(e.Op).Append('=').Append(e.Value)
+                      .Append(e.Conditional ? "   [conditional — the line carries further filters]" : "")
+                      .Append('\n');
+                }
+                shownDups++;
+            }
+        }
+
+        if (d.NoOps.Count > 0)
+        {
+            sb.Append("\nno-op writes (").Append(d.NoOps.Count)
+              .Append(") — true ITM: the SET writes the value the record already has at that point in the replay, so the op changes nothing:\n");
+            int shownNoOps = 0;
+            foreach (var n in d.NoOps)
+            {
+                if (sb.Length >= cap) { sb.Append("  ... [showing ").Append(shownNoOps).Append(" of ").Append(d.NoOps.Count).Append("; raise max_chars]\n"); break; }
+                sb.Append("  - [").Append(n.Subfolder).Append("] ").Append(Path.GetFileName(n.File)).Append(':').Append(n.Line)
+                  .Append("  ").Append(n.Op).Append('=').Append(n.Value)
+                  .Append(" @ ").Append(n.FormKey).Append(n.EditorId is null ? "" : $" ({n.EditorId})")
+                  .Append(" — ").Append(n.FieldPath).Append(" is already ").Append(n.Already)
+                  .Append('\n');
+                shownNoOps++;
+            }
+            sb.Append("  (report-only, and relative to THIS load order: the same line matters in an order where the record's winner differs — unlike dead writes and duplicates, a no-op is not an authoring slip in the INI itself unless you author for this order.)\n");
+        }
+        foreach (var note in d.NoOpNotes)
+        {
+            if (sb.Length >= cap) break;
+            sb.Append("[!] ").Append(note).Append('\n');
         }
 
         foreach (var note in d.Scan.Notes)

--- a/src/housecarl-mcp/SkyPatcherTools.cs
+++ b/src/housecarl-mcp/SkyPatcherTools.cs
@@ -28,8 +28,9 @@ public static class SkyPatcherTools
          "Plugin.esp.ini filename gates evaluated against the load order, and SkyPatcher.ini per-type toggles. Then " +
          "reports the INI-vs-INI CONFLICTS: two files setting the SAME field of the SAME record to different values " +
          "(the later-sorted file wins; add/remove ops accumulate and are not conflicts), plus the intra-file DEAD " +
-         "LINES (ITM-class): one file setting the same field of the same target twice — the earlier write is dead " +
-         "regardless of value. Entries whose applicability " +
+         "WRITES (ITM-class): a later line of the SAME file unconditionally re-covers every target of an earlier " +
+         "set — dead regardless of value (a partial or conditional-only overwrite is NOT flagged; the write may " +
+         "still fire). Entries whose applicability " +
          "also hangs on other filters are flagged conditional rather than guessed. Pass filter= a type folder, mod, " +
          "or filename substring to expand matching files to their patch lines. For ONE record's computed " +
          "post-SkyPatcher state use housecarl_skypatcher_read. Read-only.")]
@@ -94,8 +95,9 @@ static class SkyPatcherWire
           .Append(folders.Count).Append(" type folder(s), ").Append(files).Append(" INI(s) (")
           .Append(applied).Append(" applied), ").Append(lines).Append(" patch line(s)");
         if (appliedLines != lines) sb.Append(" (").Append(appliedLines).Append(" in applied files)");   // files vs lines units — don't let a gated file's lines read as live
+        int deadWrites = d.Itms.Sum(m => m.Entries.Count);   // entries ARE the dead writes — exact units
         sb.Append(", ").Append(d.Conflicts.Count).Append(" set-conflict(s), ")
-          .Append(d.Itms.Count).Append(" intra-file dead line(s) (ITM)\n");
+          .Append(deadWrites).Append(" intra-file dead write(s) (ITM)\n");
         if (folders.Count == 0)
             sb.Append("\nno SkyPatcher INIs in the active order (no Data\\SKSE\\Plugins\\SkyPatcher content, or SkyPatcher itself is not installed).\n");
 
@@ -143,6 +145,7 @@ static class SkyPatcherWire
                 sb.Append("  - [").Append(c.Subfolder).Append("] ").Append(c.Field).Append(" @ ").Append(c.Target).Append(":\n");
                 for (int i = 0; i < c.Entries.Count; i++)
                 {
+                    if (sb.Length >= cap) { sb.Append("      ... [entries cut at max_chars]\n"); break; }
                     var e = c.Entries[i];
                     sb.Append("      ").Append(Path.GetFileName(e.File)).Append(':').Append(e.Line)
                       .Append("  ").Append(e.Op).Append('=').Append(e.Value)
@@ -155,29 +158,28 @@ static class SkyPatcherWire
             sb.Append("  (report-only: which value SHOULD win is a merge decision — resolve by authoring a later-sorted INI via the skypatcher-authoring skill, then re-run this tool to confirm.)\n");
         }
 
-        if (d.Itms.Count > 0)
+        if (deadWrites > 0)
         {
-            sb.Append("\nintra-file dead lines (").Append(d.Itms.Count)
-              .Append(") — ITM-class: ONE file writes the same field of the same target more than once; the earlier write is dead weight regardless of value:\n");
+            sb.Append("\nintra-file dead writes (").Append(deadWrites)
+              .Append(") — ITM-class: later line(s) of the SAME file unconditionally re-cover EVERY target of the write, so it is dead weight regardless of value:\n");
             int shownItms = 0;
             foreach (var m in d.Itms)
             {
-                if (sb.Length >= cap) { sb.Append("  ... [showing ").Append(shownItms).Append(" of ").Append(d.Itms.Count).Append("; raise max_chars]\n"); break; }
+                if (sb.Length >= cap) { sb.Append("  ... [showing ").Append(shownItms).Append(" of ").Append(d.Itms.Count).Append(" finding(s); raise max_chars]\n"); break; }
                 sb.Append("  - [").Append(m.Subfolder).Append("] ").Append(Path.GetFileName(m.File))
-                  .Append(": ").Append(m.Field).Append(" @ ").Append(m.Target).Append(":\n");
-                for (int i = 0; i < m.Entries.Count; i++)
+                  .Append(": ").Append(m.Field).Append(":\n");
+                foreach (var e in m.Entries)
                 {
-                    var e = m.Entries[i];
+                    if (sb.Length >= cap) { sb.Append("      ... [entries cut at max_chars]\n"); break; }
                     sb.Append("      :").Append(e.Line).Append("  ").Append(e.Op).Append('=').Append(e.Value)
-                      .Append(i == m.Entries.Count - 1 ? "   ← the write the file leaves in place"
-                          : e.Dead ? "   ← DEAD (a later line of this file overwrites it)"
-                          : "   [broad — overwritten for this target, still live for other records]")
-                      .Append(e.Conditional ? "   [conditional — the line carries further filters]" : "")
+                      .Append("  @ ").Append(e.Targets)
+                      .Append("   ← DEAD (overwritten by :").Append(string.Join(", :", e.KillerLines)).Append(')')
+                      .Append(e.Conditional ? "   [carries further filters — dead regardless: the overwrite is unconditional]" : "")
                       .Append('\n');
                 }
                 shownItms++;
             }
-            sb.Append("  (report-only: in YOUR ini a dead line is an authoring slip to fix at the source; in a downloaded mod's it is usually harmless — the last write is what applies.)\n");
+            sb.Append("  (report-only: in YOUR ini a dead write is an authoring slip to fix at the source; in a downloaded mod's it is usually harmless — the last write is what applies. A write partially overwritten, or overwritten only by a conditional line, is NOT listed — it may still fire.)\n");
         }
 
         foreach (var note in d.Scan.Notes)

--- a/src/housecarl-mcp/SkyPatcherTools.cs
+++ b/src/housecarl-mcp/SkyPatcherTools.cs
@@ -27,7 +27,9 @@ public static class SkyPatcherTools
          "that wins the VFS for each file, same-path collisions (the loser's content is never read — flagged), " +
          "Plugin.esp.ini filename gates evaluated against the load order, and SkyPatcher.ini per-type toggles. Then " +
          "reports the INI-vs-INI CONFLICTS: two files setting the SAME field of the SAME record to different values " +
-         "(the later-sorted file wins; add/remove ops accumulate and are not conflicts). Entries whose applicability " +
+         "(the later-sorted file wins; add/remove ops accumulate and are not conflicts), plus the intra-file DEAD " +
+         "LINES (ITM-class): one file setting the same field of the same target twice — the earlier write is dead " +
+         "regardless of value. Entries whose applicability " +
          "also hangs on other filters are flagged conditional rather than guessed. Pass filter= a type folder, mod, " +
          "or filename substring to expand matching files to their patch lines. For ONE record's computed " +
          "post-SkyPatcher state use housecarl_skypatcher_read. Read-only.")]
@@ -92,7 +94,8 @@ static class SkyPatcherWire
           .Append(folders.Count).Append(" type folder(s), ").Append(files).Append(" INI(s) (")
           .Append(applied).Append(" applied), ").Append(lines).Append(" patch line(s)");
         if (appliedLines != lines) sb.Append(" (").Append(appliedLines).Append(" in applied files)");   // files vs lines units — don't let a gated file's lines read as live
-        sb.Append(", ").Append(d.Conflicts.Count).Append(" set-conflict(s)\n");
+        sb.Append(", ").Append(d.Conflicts.Count).Append(" set-conflict(s), ")
+          .Append(d.Itms.Count).Append(" intra-file dead line(s) (ITM)\n");
         if (folders.Count == 0)
             sb.Append("\nno SkyPatcher INIs in the active order (no Data\\SKSE\\Plugins\\SkyPatcher content, or SkyPatcher itself is not installed).\n");
 
@@ -150,6 +153,31 @@ static class SkyPatcherWire
                 shown++;
             }
             sb.Append("  (report-only: which value SHOULD win is a merge decision — resolve by authoring a later-sorted INI via the skypatcher-authoring skill, then re-run this tool to confirm.)\n");
+        }
+
+        if (d.Itms.Count > 0)
+        {
+            sb.Append("\nintra-file dead lines (").Append(d.Itms.Count)
+              .Append(") — ITM-class: ONE file writes the same field of the same target more than once; the earlier write is dead weight regardless of value:\n");
+            int shownItms = 0;
+            foreach (var m in d.Itms)
+            {
+                if (sb.Length >= cap) { sb.Append("  ... [showing ").Append(shownItms).Append(" of ").Append(d.Itms.Count).Append("; raise max_chars]\n"); break; }
+                sb.Append("  - [").Append(m.Subfolder).Append("] ").Append(Path.GetFileName(m.File))
+                  .Append(": ").Append(m.Field).Append(" @ ").Append(m.Target).Append(":\n");
+                for (int i = 0; i < m.Entries.Count; i++)
+                {
+                    var e = m.Entries[i];
+                    sb.Append("      :").Append(e.Line).Append("  ").Append(e.Op).Append('=').Append(e.Value)
+                      .Append(i == m.Entries.Count - 1 ? "   ← the write the file leaves in place"
+                          : e.Dead ? "   ← DEAD (a later line of this file overwrites it)"
+                          : "   [broad — overwritten for this target, still live for other records]")
+                      .Append(e.Conditional ? "   [conditional — the line carries further filters]" : "")
+                      .Append('\n');
+                }
+                shownItms++;
+            }
+            sb.Append("  (report-only: in YOUR ini a dead line is an authoring slip to fix at the source; in a downloaded mod's it is usually harmless — the last write is what applies.)\n");
         }
 
         foreach (var note in d.Scan.Notes)

--- a/src/housecarl-mcp/SkyPatcherTools.cs
+++ b/src/housecarl-mcp/SkyPatcherTools.cs
@@ -177,7 +177,9 @@ static class SkyPatcherWire
                     if (sb.Length >= cap) { sb.Append("      ... [entries cut at max_chars]\n"); break; }
                     sb.Append("      :").Append(e.Line).Append("  ").Append(e.Op).Append('=').Append(e.Value)
                       .Append("  @ ").Append(e.Targets)
-                      .Append("   ← DEAD (overwritten by :").Append(string.Join(", :", e.KillerLines)).Append(')')
+                      .Append("   ← DEAD (overwritten by ")
+                      .Append(string.Join(", ", e.KillerLines.Select(k => k == e.Line ? $":{k} (a later op on the same line)" : $":{k}")))
+                      .Append(')')
                       .Append(e.Conditional ? "   [carries further filters — dead regardless: the overwrite is unconditional]" : "")
                       .Append('\n');
                 }
@@ -205,6 +207,7 @@ static class SkyPatcherWire
                 }
                 shownDups++;
             }
+            sb.Append("  (report-only: which copy to drop is a judgment call — a BROAD line also patches every other record of the type, so removing it loses those; prefer dropping the narrower duplicate.)\n");
         }
 
         if (d.NoOps.Count > 0)


### PR DESCRIPTION
Aaron's widen of the open design call from PR #168, in two steps: first the intra-file lane, then ("resolving ITMs means same lines in one ini, same lines but in separate ini, line that is identical to the winning plugin") the full triple. All three classes are **report-only** additions to `housecarl_skypatcher_layer`.

## The three ITM classes

1. **Intra-file dead writes** — a later line of the SAME file unconditionally re-covers **every** target of an earlier SET. Dead regardless of value (same-value twice is the purest ITM). Strict kill rule so a DEAD verdict is never hedged: partial coverage never kills (a multi-target line re-covered for only one target stays live), broad is covered only by broad, and **conditional overwriters kill nothing** (they may not fire) — while a conditional *earlier* write killed unconditionally is dead either way. Computed per write via a backward unconditional-coverage walk (O(events × targets), no per-token re-scan). Findings hold only dead entries, each naming its killer line(s) — the header count is exact physical dead writes.
2. **Cross-INI duplicates** — ≥2 files SET the same field/target with ONE distinct value: the value-identical complement of a conflict. `Emit` splits the two classes on the value gate; a value-mixed group stays a conflict only, never double-reported.
3. **No-op writes (true ITM)** — the layer scan replays every explicitly-targeted record through the same per-record core `housecarl_skypatcher_read` uses (extracted as a shared `ReplaySkyPatcher` — one view/session/scratch + a per-folder lines cache) and flags SET-class ops whose before == after **at that point in the replay**: chains handled (a set restoring an earlier INI's change is not a no-op), conditional filters evaluated for real, deliberate `none` leave-unchanged excluded, accumulating before==after cases left to `skypatcher_read`. Output sorted (file, line, formkey) for diffable re-runs.

## Architecture
- `SkyPatcherConflicts.Detect` returns `Report(Conflicts, Itms, Duplicates)` off the one event pass; the no-op scan lives in `LoadOrderService.SkyPatcherLayer` (it needs the load order).
- `ReplaySkyPatcher` extraction: `SkyPatcherPostState` and the no-op scan now share one per-record replay core — no duplicated winner/copy/apply logic.
- Shared predicates so rules can't diverge: `IsBarePrimary` (conflict grouping + target collection), `IsNoOpWrite` (the no-op candidate test). `TryFormKey` + `SetClassSemantics` went public for the same reason.

## Honesty (Q3)
- Broad (type-wide) lines are no-op-evaluated only against explicitly-targeted records — a named note says so; unresolved targets and failed replays are counted loud.
- The no-op footer names the semantic nuance: a no-op is relative to THIS load order (the same line matters where the winner differs) — unlike the other two classes, not an authoring slip in the INI itself.
- The duplicates footer hedges the broad case: dropping a BROAD duplicate loses every other record it patches.

## Performance (factual, not gating)
`housecarl_skypatcher_layer` now always runs the per-record replay: cost is O(explicit targets × applied lines) plus an overlay session held for the loop. Measured on the live profile (31 INIs / 212 lines, ~130 targets): **12.6s → 19.8s**. The previously-recorded 7698-line profile is unexercised — re-time when active; a skip flag / target cap is the fallback if it hurts (not added now — no demonstrated need).

## Verification
- **Guard 30/30** (`skypatcher-conflicts-guard`): the original conflict cases + RED-proofs for both review-confirmed kill-rule bugs (multi-target partial NOT dead / reported once when fully covered; conditional killer kills nothing; conditional victim of an unconditional kill IS dead), the duplicate-vs-conflict split both directions, and the no-op scan's extracted rules (target collection + `IsNoOpWrite`, 7 cases).
- **ci-all 85/85** local + remote CI green.
- **Live (ARR 2.0):** 23 REAL no-op writes surfaced on the first run — 'Acoustic Space Improvement Fixes' lines whose CELL winners already carry the identical value — with 5 broad / 4 unresolved / 3 failed-replay counted in notes. 0 dead writes / 0 duplicates / 0 conflicts in the current 212-line profile.
- Review history: this session's 8-angle /code-review (3 CONFIRMED correctness findings → the per-write kill-rule redesign) + the independent review (no-op probe gap, determinism, footers — all folded in `4262b2e`).
- Skill rider is body-only — description untouched, no trigger re-eval owed.

## Follow-ups (standing list)
- 1.7.0 cut ships this with the Wave-2 readers.
- Empirical: re-time + first dead-write/duplicate sighting on the 7698-line profile when it's active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)