### PR TITLE
fix(write): QuestAlias FNAM + VTCK CK-parity fill — HCBR-2026-07-10

### DIFF
--- a/src/housecarl-core/DialogueCkParity.cs
+++ b/src/housecarl-core/DialogueCkParity.cs
@@ -1,3 +1,4 @@
+using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Skyrim;
 
 namespace HousecarlCore;
@@ -39,6 +40,8 @@ namespace HousecarlCore;
 //                                                    on vanilla Custom topics — NON-NULLABLE float, see below)
 //    • QUST (Quest)          NextAliasID (ANAM)    → next-alias-ID counter: max(existing alias ID)+1, else 0
 //    • QUST QuestObjective   Flags      (FNAM)     → 0 (no flags), materialised per objective
+//    • QUST QuestAlias       Flags      (FNAM)     → 0 (no flags), materialised per alias
+//    • QUST QuestAlias       VoiceTypes (VTCK)     → null-link (0x00000000), materialised per alias
 //
 //  ONE S2 FIELD IS NOT NULLABLE — DIAL Priority is a plain float that defaults to 0, so "the author left it unset"
 //  can't be read off is-null the way every other field here is. The create path detects it from the AUTHOR'S OP LIST
@@ -299,8 +302,9 @@ public static class DialogueCkParity
             + "Priority at all — an explicit value, including 0, always wins. CK-parity seed.");
     }
 
-    /// <summary>QUST (Quest) CK-parity defaults — the NextAliasID (ANAM) counter and each objective's Flags (FNAM),
-    /// both nullable and omitted by Mutagen when unset; a CK-authored Quest carries both. NON-OVERRIDE throughout.
+    /// <summary>QUST (Quest) CK-parity defaults — the NextAliasID (ANAM) counter, each objective's Flags (FNAM), and
+    /// each alias's Flags (FNAM) + VoiceTypes (VTCK), all nullable and omitted by Mutagen when unset; a CK-authored
+    /// Quest carries every one. NON-OVERRIDE throughout.
     ///
     /// NextAliasID (ANAM): the next alias ID the CK would hand out. For a FRESHLY-created quest (no deletion history)
     /// that is max(existing alias ID)+1, or 0 for an alias-less quest (160 vanilla alias-less quests read 0). NOTE the
@@ -311,7 +315,20 @@ public static class DialogueCkParity
     ///
     /// QuestObjective.Flags (FNAM): materialise 0 (no flags) on each objective the author left null — the value every
     /// vanilla objective carries. The sole flag (OrWithPrevious) stays an explicit authoring choice a 0-fill does NOT
-    /// set (like Goodbye on the INFO Flags struct). Returns every fill applied (ANAM + one per materialised objective).</summary>
+    /// set (like Goodbye on the INFO Flags struct).
+    ///
+    /// QuestAlias.Flags (FNAM) + VoiceTypes (VTCK): the CK writes both on a REFERENCE alias, even zero/null
+    /// (HCBR-2026-07-10 — a byte-audit vs a CK-authored sibling whose every alias carries FNAM + VTCK; the reported
+    /// shape is a reference alias, block ALST/ALID/FNAM/ALFR/VTCK/ALED). Mutagen omits each when unset, so a composed
+    /// QuestAlias that sets neither writes ALST/ALID/ALFR/ALED (FNAM + VTCK absent) instead. Materialise Flags→0 (no
+    /// flags — named alias flags like Optional/Essential stay an explicit authoring choice a 0-fill does NOT set) on
+    /// EVERY alias (FNAM is carried by both reference and location aliases), and VoiceTypes→the null link (0x00000000,
+    /// a present-but-empty VTCK) only on a REFERENCE alias (voice types are an actor/reference concept — a Location
+    /// alias resolves to a place, not an actor; scoping VTCK to reference aliases covers the report without over-adding
+    /// a subrecord CK may omit on location aliases, which would also make MissingQuestDefaults false-warn on real
+    /// CK-authored location aliases). Same #131 asymmetry as the objective FNAM right above; S2 (byte-parity — no
+    /// confirmed crash: the report did NOT launch-test the omitted shape, so this closes the CK divergence, not a
+    /// proven CTD). Returns every fill applied (ANAM + one per materialised objective + up to two per materialised alias).</summary>
     public static IReadOnlyList<CkParityFill> ApplyQuestDefaults(IQuest quest)
     {
         var fills = new List<CkParityFill>();
@@ -343,13 +360,51 @@ public static class DialogueCkParity
             idx++;
         }
 
+        // QuestAlias FNAM (Flags) + VTCK (VoiceTypes): the CK writes both on a reference alias (HCBR-2026-07-10).
+        // Materialise each the author left null — Flags→0 on EVERY alias (both alias types carry FNAM); VoiceTypes→the
+        // null link only on a REFERENCE alias (VTCK is an actor/reference concept — a Location alias resolves to a
+        // place, and CK may omit VTCK there; scoping avoids over-adding + a MissingQuestDefaults false-warn on real
+        // CK-authored location aliases). Non-override throughout.
+        int aidx = 0;
+        foreach (var alias in quest.Aliases)
+        {
+            if (!HasAliasFlags(alias))
+            {
+                alias.Flags = default(QuestAlias.Flag);           // (QuestAlias.Flag)0 — no flags set
+                fills.Add(new CkParityFill(
+                    $"Aliases[{aidx}] (ID {alias.ID}) Flags (FNAM subrecord) auto-set to 0 (no flags)",
+                    "0 — every CK-authored quest alias carries the FNAM (flags) subrecord, value 0 when no alias flags "
+                    + "are set. This materialises the subrecord only; alias flags (Optional, Essential, …) stay an "
+                    + "explicit authoring choice. CK-parity default-populate."));
+            }
+            if (IsReferenceAlias(alias) && !HasAliasVoiceTypes(alias))
+            {
+                alias.VoiceTypes.SetTo(FormKey.Null);             // present-but-null VTCK (0x00000000), the CK's empty voice-type link
+                fills.Add(new CkParityFill(
+                    $"Aliases[{aidx}] (ID {alias.ID}) VoiceTypes (VTCK subrecord) auto-set to the null link (0x00000000)",
+                    "null link — every CK-authored quest REFERENCE alias carries the VTCK (voice-types) subrecord; an "
+                    + "alias with no voice type carries it as a null link (0x00000000), not omitted. This materialises "
+                    + "the empty subrecord only; a real voice-type list stays an explicit authoring choice. CK-parity "
+                    + "default-populate."));
+            }
+            aidx++;
+        }
+
         return fills;
     }
 
     // --- QUST presence predicates: the single home for "does this Quest carry the CK-parity subrecord?", consulted
-    //     by BOTH ApplyQuestDefaults (fills when absent) and MissingQuestDefaults (flags when absent) — no drift (Q3). ---
+    //     by BOTH ApplyQuestDefaults (fills when absent) and MissingQuestDefaults (flags when absent) — no drift (Q3).
+    //     The alias VTCK probe reads FormKeyNullable (not the rendered value): an ABSENT VTCK and a present null-link
+    //     both render "(null link)" (ReadEngine.NullLinkNote — a null FormKey), so only FormKeyNullable distinguishes
+    //     "author set no voice types" (null → fill) from "author set the null link / a real list" (non-null → keep). ---
     static bool HasNextAliasID(IQuestGetter quest) => quest.NextAliasID is not null;                 // ANAM
     static bool HasObjectiveFlags(IQuestObjectiveGetter objective) => objective.Flags is not null;   // FNAM
+    static bool HasAliasFlags(IQuestAliasGetter alias) => alias.Flags is not null;                    // FNAM (alias)
+    static bool HasAliasVoiceTypes(IQuestAliasGetter alias) => alias.VoiceTypes.FormKeyNullable is not null;  // VTCK
+    // VTCK is scoped to reference aliases: a Location alias resolves to a place, not an actor, so voice types don't
+    // apply and CK may omit VTCK there — the same gate guards both the fill and the gap so they can't drift.
+    static bool IsReferenceAlias(IQuestAliasGetter alias) => alias.Type == QuestAlias.TypeEnum.Reference;
 
     /// <summary>The CK-parity subrecords a QUST (Quest) is MISSING — the read-only counterpart of
     /// <see cref="ApplyQuestDefaults"/>, for the on-demand dialogue validator's QUEST input (checked ONCE per quest,
@@ -357,7 +412,7 @@ public static class DialogueCkParity
     /// disagree. S2 (byte-parity only — no confirmed crash). PRESENCE only: the fill's max-alias-id+1 derivation is
     /// create-lane-correct (an edited quest's ANAM is a CK high-water mark that can legitimately exceed max+1), so
     /// this checks "is ANAM absent?", never judges its VALUE. Empty when ANAM is present and every objective carries
-    /// FNAM. Reads only the getter; NEVER mutates.</summary>
+    /// FNAM and every alias carries FNAM + VTCK. Reads only the getter; NEVER mutates.</summary>
     public static IReadOnlyList<CkParityGap> MissingQuestDefaults(IQuestGetter quest)
     {
         var gaps = new List<CkParityGap>();
@@ -377,6 +432,23 @@ public static class DialogueCkParity
                     + "an objective missing it differs structurally from a CK-authored one (byte-parity only — no "
                     + "confirmed crash). houseCARL's create tools auto-fill it — set the objective's Flags to populate it."));
             idx++;
+        }
+
+        int aidx = 0;
+        foreach (var alias in quest.Aliases)
+        {
+            if (!HasAliasFlags(alias))
+                gaps.Add(new CkParityGap($"Aliases[{aidx}] (ID {alias.ID}) FNAM (Flags)",
+                    "every CK-authored quest alias carries the FNAM (flags) subrecord (value 0 when no alias flags are "
+                    + "set); an alias missing it differs structurally from a CK-authored one (byte-parity only — no "
+                    + "confirmed crash). houseCARL's create tools auto-fill it — set the alias's Flags to populate it."));
+            if (IsReferenceAlias(alias) && !HasAliasVoiceTypes(alias))
+                gaps.Add(new CkParityGap($"Aliases[{aidx}] (ID {alias.ID}) VTCK (VoiceTypes)",
+                    "every CK-authored quest REFERENCE alias carries the VTCK (voice-types) subrecord (a null link, "
+                    + "0x00000000, when no voice type is set); a reference alias missing it differs structurally from a "
+                    + "CK-authored one (byte-parity only — no confirmed crash). houseCARL's create tools auto-fill it — "
+                    + "set the alias's VoiceTypes to populate it."));
+            aidx++;
         }
 
         return gaps;

--- a/src/housecarl-generator/DialogueCkParityGuardProbe.cs
+++ b/src/housecarl-generator/DialogueCkParityGuardProbe.cs
@@ -34,8 +34,9 @@ namespace HousecarlGenerator;
 ///                       via MissingViewDefaults, none after ApplyViewDefaults (shared presence predicates).
 ///   DLBR-GAP-PROBE    — same tie for the DLBR: a bare DialogBranch reports exactly the TNAM gap via
 ///                       MissingBranchDefaults, none after ApplyBranchDefaults.
-///   QUST-GAP-PROBE    — same tie for the QUST: a bare quest with one Flags-less objective reports exactly the
-///                       ANAM + FNAM gaps via MissingQuestDefaults, none after ApplyQuestDefaults.
+///   QUST-GAP-PROBE    — same tie for the QUST: a bare quest with one Flags-less objective AND one bare alias reports
+///                       exactly the ANAM + objective-FNAM + alias-FNAM + alias-VTCK gaps via MissingQuestDefaults,
+///                       none after ApplyQuestDefaults.
 ///   DLVW-AUTOFILL     — create a bare DialogView → written DNAM=00, ENAM=00000000, both REPORTED.
 ///   DLVW-DNAM-WINS    — an explicit DNAM=FF is NOT overridden to 00 (ENAM still auto-fills).
 ///   BNAM-LINT         — a Custom topic with no Branch → validate_dialogue raises a Warning naming Branch (BNAM); a
@@ -50,6 +51,12 @@ namespace HousecarlGenerator;
 ///   QUST-ANAM-WINS     — (direct) an explicit NextAliasID=9 is NOT overridden by the derive.
 ///   QUST-FNAM-AUTOFILL — (direct) an objective with no Flags → Flags materialised to 0, REPORTED; an explicit
 ///                       objective Flags=OrWithPrevious is NOT reset.
+///   QUST-ALIAS-AUTOFILL— a quest with a bare alias → the alias FNAM (Flags=0) + VTCK (VoiceTypes=null link) are
+///                       materialised, REPORTED, and — the empirical crux — BOTH survive a disk round-trip (a
+///                       present-but-null VTCK is serialised, not skipped). The HCBR-2026-07-10 fix.
+///   QUST-ALIAS-WINS    — (direct) an alias with explicit Flags + explicit VoiceTypes is NOT overridden (no fill).
+///   QUST-ALIAS-LOCATION— (direct) a Location-type alias gets FNAM (Flags=0) but NOT VTCK (VTCK is scoped to reference
+///                       aliases); MissingQuestDefaults raises no VTCK gap for it (no false-warn on CK location aliases).
 /// </summary>
 internal static class DialogueCkParityGuardProbe
 {
@@ -213,19 +220,23 @@ internal static class DialogueCkParityGuardProbe
                     $"DLBR-GAP-PROBE bare DialogBranch → TNAM gap (before={before.Count}), none after fill (after={after}) — check/fill share one predicate");
             }
 
-            // ---- QUST-GAP-PROBE: the same tie for the Quest — a bare quest with one Flags-less objective reports
-            //      exactly the ANAM + FNAM gaps, none after ApplyQuestDefaults. ----
+            // ---- QUST-GAP-PROBE: the same tie for the Quest — a bare quest with one Flags-less objective AND one bare
+            //      alias reports exactly the ANAM + objective-FNAM + alias-FNAM + alias-VTCK gaps, none after
+            //      ApplyQuestDefaults. ----
             {
                 var q = new Quest(FormKey.Factory("000803:HcCkpGapProbe.esm"), SkyrimRelease.SkyrimSE);
                 q.Objectives.Add(new QuestObjective { Index = 10 });   // Flags null
+                q.Aliases.Add(new QuestAlias { ID = 0 });              // Flags + VoiceTypes both null
                 var before = DialogueCkParity.MissingQuestDefaults(q);
-                bool flaggedBoth = before.Count == 2
+                bool flaggedAll = before.Count == 4
                     && before.Any(g => g.Subrecord.Contains("ANAM", StringComparison.OrdinalIgnoreCase))
-                    && before.Any(g => g.Subrecord.Contains("FNAM", StringComparison.OrdinalIgnoreCase) && g.Subrecord.Contains("Objectives[0]", StringComparison.Ordinal));
+                    && before.Any(g => g.Subrecord.Contains("FNAM", StringComparison.OrdinalIgnoreCase) && g.Subrecord.Contains("Objectives[0]", StringComparison.Ordinal))
+                    && before.Any(g => g.Subrecord.Contains("FNAM", StringComparison.OrdinalIgnoreCase) && g.Subrecord.Contains("Aliases[0]", StringComparison.Ordinal))
+                    && before.Any(g => g.Subrecord.Contains("VTCK", StringComparison.OrdinalIgnoreCase) && g.Subrecord.Contains("Aliases[0]", StringComparison.Ordinal));
                 DialogueCkParity.ApplyQuestDefaults(q);
                 int after = DialogueCkParity.MissingQuestDefaults(q).Count;
-                Check(flaggedBoth && after == 0,
-                    $"QUST-GAP-PROBE bare Quest+objective → ANAM+FNAM gaps (before={before.Count}), none after fill (after={after}) — check/fill share one predicate");
+                Check(flaggedAll && after == 0,
+                    $"QUST-GAP-PROBE bare Quest+objective+alias → ANAM+objFNAM+aliasFNAM+aliasVTCK gaps (before={before.Count}), none after fill (after={after}) — check/fill share one predicate");
             }
 
             // ---- DLVW-AUTOFILL: create a bare DialogView → written DNAM=00, ENAM=00000000, both reported. ----
@@ -358,6 +369,79 @@ internal static class DialogueCkParityGuardProbe
                 bool fnamReported = ofills.Count(f => f.Label.Contains("Flags (FNAM", StringComparison.OrdinalIgnoreCase)) == 1;
                 Check(obj0Filled && obj1Kept && fnamReported,
                     $"QUST-FNAM-AUTOFILL null objective Flags→0 (reported), explicit OrWithPrevious kept — obj0={qObj.Objectives[0].Flags} obj1={qObj.Objectives[1].Flags} reportedOnce={fnamReported}");
+            }
+
+            // ---- QUST-ALIAS-AUTOFILL: a quest with a bare alias (no Flags/VoiceTypes) → the alias FNAM (Flags=0) and
+            //      VTCK (VoiceTypes=null link) are materialised, REPORTED, and — the empirical crux of the HCBR-2026-07-10
+            //      fix — BOTH survive a disk round-trip. VTCK is the risky one: a present-but-null link (FormKey.Null)
+            //      must be SERIALISED, not skipped as "no value". Write it out, re-read off the binary overlay, confirm
+            //      both subrecords are present. ----
+            {
+                var mA = new SkyrimMod(new ModKey("HcCkpAlias", ModType.Master), SkyrimRelease.SkyrimSE);
+                var qA = mA.Quests.AddNew(); qA.EditorID = "HcCkpAliasQ";
+                qA.NextAliasID = 0;                                                 // isolate the alias findings (no ANAM fill)
+                qA.Aliases.Add(new QuestAlias { ID = 0, Name = "PlayerAlias" });    // Flags + VoiceTypes both null
+                var afills = DialogueCkParity.ApplyQuestDefaults(qA);
+                bool flagsFilled = qA.Aliases[0].Flags == default(QuestAlias.Flag);
+                bool voiceFilled = qA.Aliases[0].VoiceTypes.FormKeyNullable is not null;
+                bool fnamReported = afills.Any(f => f.Label.Contains("Aliases[0]", StringComparison.Ordinal) && f.Label.Contains("FNAM", StringComparison.OrdinalIgnoreCase));
+                bool vtckReported = afills.Any(f => f.Label.Contains("Aliases[0]", StringComparison.Ordinal) && f.Label.Contains("VTCK", StringComparison.OrdinalIgnoreCase));
+
+                var aliasPath = Path.Combine(root, "HcCkpAlias.esm");
+                mA.BeginWrite.ToPath(aliasPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+                bool diskFnam = false, diskVtck = false;
+                ISkyrimModGetter? ov = null;
+                try
+                {
+                    ov = SkyrimMod.CreateFromBinaryOverlay(aliasPath, SkyrimRelease.SkyrimSE);
+                    var ar = ov.Quests.FirstOrDefault(x => x.FormKey == qA.FormKey)?.Aliases.FirstOrDefault(x => x.ID == 0);
+                    diskFnam = ar?.Flags is not null;
+                    diskVtck = ar?.VoiceTypes.FormKeyNullable is not null;
+                }
+                catch { }
+                finally { (ov as IDisposable)?.Dispose(); }
+
+                Check(flagsFilled && voiceFilled && fnamReported && vtckReported && diskFnam && diskVtck,
+                    $"QUST-ALIAS-AUTOFILL bare alias → FNAM=0 + VTCK=null-link materialised + reported + survive disk round-trip — "
+                    + $"flags={flagsFilled} voice={voiceFilled} fnamRep={fnamReported} vtckRep={vtckReported} diskFNAM={diskFnam} diskVTCK={diskVtck}");
+            }
+
+            // ---- QUST-ALIAS-WINS: an alias with explicit Flags + explicit VoiceTypes is NOT overridden (no fill). ----
+            {
+                var mW = new SkyrimMod(new ModKey("HcCkpAliasWins", ModType.Master), SkyrimRelease.SkyrimSE);
+                var qW = mW.Quests.AddNew();
+                qW.NextAliasID = 0;                                                 // isolate the alias findings
+                var explicitVoice = FormKey.Factory("02F7C3:Skyrim.esm");           // a real (non-null) voice-type link — value irrelevant, must be kept
+                var al = new QuestAlias { ID = 0, Flags = QuestAlias.Flag.Optional };
+                al.VoiceTypes.SetTo(explicitVoice);
+                qW.Aliases.Add(al);
+                var wfills = DialogueCkParity.ApplyQuestDefaults(qW);
+                bool flagsKept = qW.Aliases[0].Flags == QuestAlias.Flag.Optional;
+                bool voiceKept = qW.Aliases[0].VoiceTypes.FormKeyNullable == explicitVoice;
+                bool noAliasFill = !wfills.Any(f => f.Label.Contains("Aliases[0]", StringComparison.Ordinal));
+                Check(flagsKept && voiceKept && noAliasFill,
+                    $"QUST-ALIAS-WINS explicit alias Flags=Optional + VoiceTypes kept, no fill — flags={qW.Aliases[0].Flags} voiceKept={voiceKept} noFill={noAliasFill}");
+            }
+
+            // ---- QUST-ALIAS-LOCATION: a LOCATION-type alias gets FNAM (Flags=0) but NOT VTCK — VTCK is scoped to
+            //      reference aliases (voice types are an actor concept; a location alias resolves to a place). Both the
+            //      fill and MissingQuestDefaults must honour the scope (no VTCK fill, no VTCK gap) so no false-warn on a
+            //      CK-authored location alias. ----
+            {
+                var mL = new SkyrimMod(new ModKey("HcCkpAliasLoc", ModType.Master), SkyrimRelease.SkyrimSE);
+                var qL = mL.Quests.AddNew();
+                qL.NextAliasID = 0;                                                             // isolate the alias findings
+                qL.Aliases.Add(new QuestAlias { ID = 0, Type = QuestAlias.TypeEnum.Location });  // Flags + VoiceTypes null
+                var beforeL = DialogueCkParity.MissingQuestDefaults(qL);
+                bool locFnamGap = beforeL.Any(g => g.Subrecord.Contains("FNAM", StringComparison.OrdinalIgnoreCase) && g.Subrecord.Contains("Aliases[0]", StringComparison.Ordinal));
+                bool noLocVtckGap = !beforeL.Any(g => g.Subrecord.Contains("VTCK", StringComparison.OrdinalIgnoreCase));
+                var lfills = DialogueCkParity.ApplyQuestDefaults(qL);
+                bool flagsFilled = qL.Aliases[0].Flags == default(QuestAlias.Flag);
+                bool voiceNotFilled = qL.Aliases[0].VoiceTypes.FormKeyNullable is null;
+                bool noVtckFill = !lfills.Any(f => f.Label.Contains("VTCK", StringComparison.OrdinalIgnoreCase));
+                int afterL = DialogueCkParity.MissingQuestDefaults(qL).Count;
+                Check(locFnamGap && noLocVtckGap && flagsFilled && voiceNotFilled && noVtckFill && afterL == 0,
+                    $"QUST-ALIAS-LOCATION location alias → FNAM filled, VTCK NOT (scoped to reference) — fnamGap={locFnamGap} noVtckGap={noLocVtckGap} flags={flagsFilled} voiceUnset={voiceNotFilled} noVtckFill={noVtckFill} after={afterL}");
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
## What & why

A friend's bug report (HCBR-2026-07-10, report #1 of a 3-report batch): a composed `QuestAlias` that sets neither `Flags` nor `VoiceTypes` writes the alias block `ALST/ALID/ALFR/ALED` — Mutagen omits both nullable subrecords — where a CK-authored **reference** alias carries `ALST/ALID/FNAM/ALFR/VTCK/ALED` (byte-audited vs the CK sibling `ST_Tut01`). This is the same `#131`/`DialogueCkParity` asymmetry the rest of the DIAL/INFO/DLVW/QUST family already closes; objective-FNAM sits right beside the new code.

## The change (`DialogueCkParity.cs`)

Extends `ApplyQuestDefaults` / `MissingQuestDefaults`:
- **alias `Flags` (FNAM) → 0** on **every** alias (both alias types carry FNAM),
- **alias `VoiceTypes` (VTCK) → the null link (0x00000000)** on **reference aliases only**.

Non-override + reported-as-op throughout (Q3); the shared-presence-predicate anti-drift tie (fill side ⇄ validator side) is preserved.

### Scoping call: VTCK is reference-only
The report's evidence is all reference aliases, and VTCK (voice types) is an actor concept — a Location alias resolves to a place. Filling VTCK unconditionally would risk over-adding a subrecord CK may omit on location aliases **and** making `validate_dialogue` false-warn on real CK-authored location aliases (a Q3 wrong answer on real content). So VTCK is gated to `Type == Reference`; FNAM stays universal. (Not yet empirically pinned against a live location-alias quest — the safe side of the uncertainty.)

## Verification

- **The crux** — does a present-but-null FormLink (`FormKey.Null`) actually *serialize* VTCK rather than get skipped? — is pinned by a new **disk round-trip** probe arm: write → re-read overlay → `diskFNAM=True diskVTCK=True`.
- `dialogue-ckparity-guard` gains `QUST-ALIAS-AUTOFILL` (round-trip), `QUST-ALIAS-WINS` (non-override), `QUST-ALIAS-LOCATION` (scoping); `QUST-GAP-PROBE` widened to an alias.
- **ci-all 85/85.**

## Severity

S2 byte-parity — **no confirmed CTD** (the report did not launch-test the omitted shape). This closes the CK divergence, not a proven crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)