### PR TITLE
release: houseCARL 1.7.0 (staleness pass + version bump + changelog)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ models — by construction, not a hand-maintained subset.
   directly inside an existing plugin (including one it didn't author) instead of writing a separate patch.
   Opt-in, gated by a one-time per-plugin consent prompt, and it keeps **no backup** — so the default
   new-patch lane above stays the default.
+- **Compact and merge plugins** — ESL-compact a plugin into the light-master FormID window, carrying its
+  FormID-keyed assets (facegen, voice) along so a compacted mod's faces don't go dark; or merge several
+  plugins into one, renumbering only on collision and dropping now-unused masters — with the donor mods
+  swapped out at the MO2 layer, originals intact.
+- **Copy an NPC's appearance into a standalone** — lift a face (head parts, tints, the FaceGen mesh and
+  textures) from a donor NPC into a fresh record that carries no dependency on the donor's plugin — the
+  build behind a portable follower or a face transplanted between mods.
 - **Trace a magic effect** — resolve a MagicEffect to every spell, enchantment, potion, scroll, and
   ingredient that carries it, with each one's magnitude, in a single call.
 - **VFS asset layer** — read which copy of any Data-relative file (mesh, texture, script, sound,
@@ -39,9 +46,17 @@ models — by construction, not a hand-maintained subset.
   and place a file as a winning override into a new MO2 mod folder; loose-vs-BSA aware, with FaceGen as the
   headline use case. "Wrote it" is reported honestly as not yet "it wins" — you still enable and sort the
   new mod in MO2.
+- **Read and write a mesh's internals** — open the winning copy of a `.nif` and read the values baked
+  inside it — shape names, embedded skin / FaceTint texture paths, flags, alpha, partitions — and write a
+  whitelisted value back (fix a wrong texture path, rename a shape), verified against a two-gate read-back.
+  The mesh half of the dark-face fix, beside the record half.
 - **See the SKSE-plugin layer** — inventory the DLLs and their config files under `Data\SKSE\Plugins`, each
   resolved to the mod that wins it (with the full conflict chain), and read each winning DLL's declared version
   metadata — name, author, target runtime, Address-Library flag — statically, without loading it.
+- **See through the SkyPatcher layer** — inventory every SkyPatcher INI in your load order at once (apply
+  order, VFS shadows, INI-vs-INI conflicts, and dead / duplicate / no-op writes), or read one record's
+  *true* state after the whole SkyPatcher layer has replayed over it — so a runtime INI edit is as visible
+  as a plugin override. Report-only.
 - **Drive the external toolchain** — compile Papyrus scripts through the Creation Kit's compiler, and
   list / extract / repack BSA archives via BSArch; each tool's path is auto-detected or set once.
 - **Decompile compiled scripts** — reconstruct reviewable `.psc` source from any `.pex` (Mutagen-native,
@@ -76,7 +91,7 @@ models — by construction, not a hand-maintained subset.
 
 ### Download — recommended (modders)
 
-1. Download **`houseCARL-1.6.0.zip`** from the [latest release](https://github.com/Avick3110/houseCARL/releases).
+1. Download **`houseCARL-1.7.0.zip`** from the [latest release](https://github.com/Avick3110/houseCARL/releases).
 2. Unzip it and run **`houseCARL-Setup.exe`**.
 3. Pick your host — **`[1] Claude Code`**, **`[2] Codex`**, or **`[3] Both`**. The installer wires
    everything up:
@@ -106,7 +121,7 @@ cd houseCARL
 
 The script regenerates the reflection rulebook, publishes the server framework-dependent (trimming **off**
 — houseCARL is reflection-driven, so trimming would strip types and silently lose coverage), bundles the
-skills, builds the setup utility, and packs `release/houseCARL-1.6.0.zip`. Install the output with
+skills, builds the setup utility, and packs `release/houseCARL-1.7.0.zip`. Install the output with
 `houseCARL-Setup.exe`, `claude --plugin-dir ./dist/housecarl`, or the bundled local-marketplace
 descriptor — see the script header for details.
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "housecarl",
   "displayName": "houseCARL",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Comprehensive data-layer access to your Skyrim SE load order — read any record, author patches into a new plugin, look mods up on Nexus, and look up record schemas, Papyrus signatures, performance reviews, and distributor grammars — in plain English.",
   "author": { "name": "Avick3110" },
   "homepage": "https://github.com/Avick3110/houseCARL",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -4,6 +4,58 @@ All notable changes to houseCARL are documented here. Versioning is [semantic](h
 the `version` in `.claude-plugin/plugin.json` is bumped on each release, so installed users update only
 when it changes.
 
+## 1.7.0 — 2026-07-11
+
+houseCARL learns to **see through more of the runtime layer than the record alone**: merge plugins together,
+read and write the data baked inside a mesh (`.nif`), and read the entire SkyPatcher layer end to end — what
+it does, where it conflicts, and what a record truly looks like after it replays. **Six new tools (→ 37)**;
+the skill set is unchanged at 12. Plus a dialogue CK-parity push and a batch of write-lane fixes.
+
+**Six new tools (→ 37)**
+
+- **`housecarl_merge_plugins` — merge several plugins into one new plugin.** A RECORDS-level merge with a
+  winner-first graft walk: it renumbers FormIDs **only on collision**, drops masters the merged set no longer
+  needs, and swaps the donor mods out at the **MO2 layer** (their folders stay on disk, just disabled) — your
+  originals are never rewritten. References it can't fold are reported, never silently dropped.
+- **`housecarl_copy_npc_appearance` — copy an NPC's appearance into a standalone.** The composed payoff of the
+  standalone-NPC-copy chain: lift a donor NPC's whole appearance — head parts, tints, and the FaceGen mesh and
+  textures — into a fresh record that carries **no dependency on the donor's plugin**, auto-widening the file
+  lane to the donor's defining plugin. The build behind a portable follower or a face moved between mods, in
+  one call instead of a dozen papercut edits.
+- **`housecarl_nif_inspect` — read the data values inside a Skyrim mesh (`.nif`).** Open the winning copy of a
+  mesh and read what's baked inside it: shape names, the embedded skin / FaceTint texture paths, shader flags,
+  alpha, and partitions. houseCARL's first look *inside* a NIF, and the diagnostic half of the dark-face bug —
+  is the face mesh pointing at the wrong texture, or is a shape misnamed?
+- **`housecarl_nif_set` — write a whitelisted value back into a mesh (`.nif`).** The write companion to
+  `nif_inspect`: rewrite a wrong embedded texture path or rename a shape, gated to a whitelist of safe fields
+  and verified two ways — an offset-immune block-content diff **plus** a semantic read-back — so a mesh is
+  never quietly corrupted. The repair half of the dark-face fix, without leaving houseCARL for NifSkope.
+- **`housecarl_skypatcher_layer` — inventory the entire SkyPatcher layer at once.** Every SkyPatcher INI across
+  your load order resolved into one picture: apply-order union, VFS shadows, filename gates, and INI-vs-INI
+  conflicts — plus the full **ITM triple** (intra-file dead writes, cross-INI duplicates, and true no-op writes
+  that change nothing). Report-only: it tells you what the layer does, it never touches it.
+- **`housecarl_skypatcher_read` — a record's true state after SkyPatcher.** Replays the whole SkyPatcher layer
+  over a single record, in order, and reports what it actually looks like at runtime — the complete filter
+  surface, stateful op-by-op, with tiered honesty on the operations it can't fully model. A runtime INI edit
+  made as visible as a plugin override.
+
+**Dialogue & authoring (CK parity)**
+
+- **Authored dialogue now matches the Creation Kit down to the byte on quest aliases.** Beyond the
+  INFO / DLVW / DLBR / QUST / DIAL fields 1.6.0 closed, a newly-authored quest alias now gets the flags (FNAM)
+  and voice types (VTCK) the CK fills in — so a hand-built quest's aliases don't read as subtly wrong.
+- **`housecarl_validate_dialogue` closes the matching residual.** It validates the DLVW / DLBR inputs and the
+  quest ANAM / FNAM the CK-parity pass fills, and flags a live INFO that's missing its prompt / response text
+  (CNAM / ENAM).
+- **The SkyPatcher authoring reference is extended to the full Wave 0–2 grammar** and the 27-record-type
+  operation→field map that underpins the two new SkyPatcher tools.
+
+**Fixes**
+
+- **Edit tools resolve the extended patch.** An `@editorid` self-reference, and an edit whose `into=` targets a
+  patch you haven't enabled yet, now resolve correctly against the patch being extended.
+- **In-place and forward-record flows hardened** against a batch of edge-case defects surfaced in live testing.
+
 ## 1.6.0 — 2026-07-06
 
 houseCARL learns to **see the parts of your workspace it was blind to**: read a plugin that isn't in your

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -26,6 +26,13 @@ It can:
   existing plugin (including one houseCARL didn't author) instead of writing a separate patch. Opt-in, gated
   by a one-time per-plugin consent prompt, and it keeps **no backup**; the default new-patch lane stays the
   default.
+- **Compact and merge plugins** — ESL-compact a plugin into the light-master FormID window, carrying its
+  FormID-keyed assets (facegen, voice) along so a compacted mod's faces don't go dark; or merge several
+  plugins into one (collision-only renumber, unused masters dropped), with the donor mods swapped out at the
+  MO2 layer and originals intact.
+- **Copy an NPC's appearance into a standalone** — lift a face (head parts, tints, the FaceGen mesh and
+  textures) from a donor NPC into a fresh record with no dependency on the donor's plugin — the build behind
+  a portable follower or a face moved between mods.
 - **Trace a magic effect** — resolve a MagicEffect to every spell, enchantment, potion, scroll, and
   ingredient that carries it, with each one's magnitude, in a single call.
 - **VFS asset layer** — read which copy of any Data-relative file (mesh, texture, script, sound,
@@ -33,9 +40,17 @@ It can:
   and place a file as a winning override into a new MO2 mod folder; loose-vs-BSA aware, with FaceGen as the
   headline use case. "Wrote it" is reported honestly as not yet "it wins" — you still enable and sort the
   new mod in MO2.
+- **Read and write a mesh's internals** — open the winning copy of a `.nif` and read the values baked inside
+  it (shape names, embedded skin / FaceTint texture paths, flags, alpha, partitions), and write a whitelisted
+  value back — fix a wrong texture path, rename a shape — verified against a two-gate read-back. The mesh half
+  of the dark-face fix, beside the record half.
 - **See the SKSE-plugin layer** — inventory the DLLs and their configs under `Data\SKSE\Plugins`, each
   resolved to the mod that wins it (with the conflict chain), and read each winning DLL's version metadata
   (name, author, target runtime, Address-Library flag) statically, without loading it.
+- **See through the SkyPatcher layer** — inventory every SkyPatcher INI in your load order at once (apply
+  order, VFS shadows, INI-vs-INI conflicts, and dead / duplicate / no-op writes), or read one record's *true*
+  state after the whole SkyPatcher layer has replayed over it — a runtime INI edit made as visible as a plugin
+  override. Report-only.
 - **Drive the external toolchain** — compile Papyrus scripts through the Creation Kit's compiler, and
   list / extract / repack BSA archives via BSArch; each tool's path is auto-detected or set once.
 - **Decompile compiled scripts** — reconstruct reviewable `.psc` source from any `.pex` (Mutagen-native,


### PR DESCRIPTION
## houseCARL 1.7.0 — release prep

Release-prep bundle for **1.7.0** (staleness pass + version bump + changelog). No code changes — docs and the version manifest only.

### What's in this PR
- **`release: houseCARL 1.7.0`** — bump `plugin/.claude-plugin/plugin.json` 1.6.0 → 1.7.0 (single source of truth; the build stamps it into the server exe, `START-HERE.txt`, and the zip name) + the 1.7.0 `plugin/CHANGELOG.md` prose entry.
- **`docs: 1.7.0 staleness pass`** — reconcile both READMEs (root + `plugin/`) with the 1.7.0 tool surface: tight capability bullets for the six new tools, and the two `houseCARL-1.6.0.zip` → `1.7.0` version strings.

### Verified scope (from source, not the handoff)
- **Tools 31 → 37.** Confirmed by diffing exact tool-name sets between the 1.6.0 commit `89acca3` and `main`.
- **Six new tools since 1.6.0:** `merge_plugins`, `copy_npc_appearance`, `nif_inspect`, `nif_set`, `skypatcher_layer`, `skypatcher_read`.
- **Handoff correction:** the 1.7.0 handoff listed `compact_plugin` as new — it actually shipped **in** 1.6.0. The genuinely-new sixth tool is `copy_npc_appearance`. Count (31→37) and version (1.7.0) unchanged; changelog is written against the corrected list.
- **Skills unchanged at 12.** CLAUDE.md §7 and standards/ carry no stale counts.

### Gate
- `scripts/build-plugin.ps1` — green, `release/houseCARL-1.7.0.zip` packed.
- `claude plugin validate ./dist/housecarl --strict` — GREEN (K1).

### Not in this PR (Aaron's manual lane, at merge)
- The GitHub Release (tag `v1.7.0`, upload zip, mark Latest) and the Nexus upload (mod 181738). Nexus changelog BBCode draft is at `dev/plans/nexus-description-1.7.0.bbcode.txt`.
- Open decisions to confirm at the cut: empirical-gate waiver (early-tester posture) for `nif_set`/`merge_plugins`/SkyPatcher reader; `prismaui` skill adoption (would bump 12→13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
