### PR TITLE
fix(write): SetAtIndex composes modeled list elements — HCBR-2026-07-10

### DIFF
--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -589,15 +589,25 @@ public sealed class CorpusRulebook
             // earlier PR-review note guarded against). StructElementLegality resolves a polymorphic-base element's arm
             // (Package.Data -> an APackageData arm) + validates contents recursively. (A composable dict SET is gated at
             // the dict-Set block above — same StructElementLegality.)
-            if (req.Verb == "Add")
+            // Add (append a new element) and SetAtIndex (overwrite the element at an index) both build the element FROM
+            // PARTS against the element type, validated by the SAME StructElementLegality (poly-base arm resolution +
+            // recursive contents; a null spec → "supply a compose spec, not a plain value"). SetAtIndex's index PRESENCE
+            // (VerbLegality) and SHAPE (step-4-key block above) are already gated by the time control reaches here, and
+            // the in-RANGE bound is apply's (no live list at the gate) — so the only thing left for a SetAtIndex compose
+            // is the spec, identical to Add. This closes HCBR-2026-07-10: an in-place condition-row REPLACEMENT no longer
+            // needs Remove+Add (which moved the row to the list END — harmless for an AND row, but breaking an OR-group).
+            // The composable fence (IsComposableElement = Struct/Arm ONLY) keeps this off owned-record elements, which
+            // step-4-rec above already redirects to the record axis.
+            if (req.Verb is "Add" or "SetAtIndex")
                 return StructElementLegality(leaf, req.Struct, siblingEditorIds);
-            // ReplaceAll/SetAtIndex/Merge of modeled elements are all deferred (only Add/Set composes). Merge is dict-only
-            // and was previously OMITTED here, so a Package.Data Merge fell through to ACCEPT then threw 'No coercion
-            // rule' at apply (matrix-critic finding) — folding it in closes that. Verb named in the message so it reads
-            // accurately for each.
-            if (req.Verb is "ReplaceAll" or "SetAtIndex" or "Merge")
-                return $"'{leaf.Name}' holds modeled elements ({leaf.ElementTypeRef}); only Add (build-from-parts) " +
-                       $"composes them — {req.Verb} of modeled elements is a later surface.";
+            // ReplaceAll/Merge of modeled elements stay deferred: ReplaceAll would need a LIST of compose specs and Merge
+            // a dict of them (req.Values / req.Entries are plain-string shapes), distinct input surfaces not opened here.
+            // Merge is dict-only and was previously OMITTED, so a Package.Data Merge fell through to ACCEPT then threw
+            // 'No coercion rule' at apply (matrix-critic finding) — folding it in closes that. Verb named in the message.
+            if (req.Verb is "ReplaceAll" or "Merge")
+                return $"'{leaf.Name}' holds modeled elements ({leaf.ElementTypeRef}); compose them one at a time " +
+                       $"(Add to append, SetAtIndex to overwrite an index; Set for a dict key) — {req.Verb} of modeled " +
+                       $"elements is a later surface.";
         }
         // (step 4-rmv) Remove-BY-VALUE on a NON-PLAIN-VALUE element — a list Remove with NO key is by-value
         // (ApplyListVerb -> Coerce(req.Value!, elem)); an element that is neither coercible (step-4b) nor formlink

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -486,8 +486,9 @@ public sealed class CorpusRulebook
         // but for the absent-value case: the step-4a formlink check below uses `is { } ev`, which SKIPS a null slot.
         // Gate it here for EVERY coercible element (formlink + non-formlink), by construction. NO req.Struct guard, by
         // design (PR #77 review finding 1): a coercible element is NEVER built from a StructSpec, so a struct supplied
-        // with a null value is itself malformed — SetAtIndex ignores req.Struct entirely (ApplyListVerb is
-        // unconditionally Coerce(req.Value!)), and an Add's BuildStruct on a coercible element throws too; firing on a
+        // with a null value is itself malformed — SetAtIndex now mirrors Add (ApplyListVerb builds from a non-null
+        // req.Struct, else coerces req.Value), and BuildStruct on a coercible element throws for BOTH verbs, so a struct
+        // here can never rescue a null value; firing on a
         // null value REGARDLESS of req.Struct closes both, and "requires an element value" is the right guidance either
         // way (this also matches the singular Set mirror, which carries no struct guard). Verb-scoped to the verbs that
         // consume the singular req.Value — ReplaceAll (req.Values) / Merge (req.Entries) carry their elements elsewhere

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -2123,7 +2123,15 @@ public static class WriteEngine
                 int count = CollectionCount(list);
                 if (idx < 0 || idx >= count)
                     throw new ExpectedApplyRejectionException(IndexRangeMessage(prop.Name, idx, count, append: true));
-                Indexer(lt).GetSetMethod()!.Invoke(list, new[] { (object)idx, Coerce(req.Value!, elem) });
+                // Build the replacement the SAME way Add does — a composable (struct/arm) element FROM PARTS
+                // (req.Struct → BuildStruct), a coercible element by coercing req.Value — then OVERWRITE in place,
+                // preserving the element's list position. Closes HCBR-2026-07-10: replacing one condition row no longer
+                // needs Remove+Add, which moved the row to the list END (harmless for an AND row, but breaking an
+                // OR-group). The gate (CorpusRulebook's composable block) admits a SetAtIndex compose ONLY for a
+                // Struct/Arm element, through the SAME StructElementLegality Add passes, so req.Struct is pre-validated
+                // here; a coercible element still coerces req.Value exactly as before (req.Struct null → the Coerce arm).
+                Indexer(lt).GetSetMethod()!.Invoke(list,
+                    new[] { (object)idx, req.Struct is not null ? BuildStruct(req.Struct) : Coerce(req.Value!, elem) });
                 break;
             }
             case "Remove":

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -245,14 +245,17 @@ namespace HousecarlGenerator;
 /// inputs (target/location/bool/int/float/objectlist/topic). Before Gap 3 the gate refused a dict Add carrying a compose
 /// ('dict-element composition is a later surface') and ApplyDictVerb ignored req.Struct — a correct-but-incomplete case-(c)
 /// deferral, NOT an accept-then-throw. Gap 3 BUILDS it by construction, mirroring the LIST compose path: ApplyDictVerb
-/// Add/Set now BuildStruct(req.Struct) for a composable element, and the gate ACCEPTS the spec via the SAME
+/// Add/Set/SetAtIndex now BuildStruct(req.Struct) for a composable element, and the gate ACCEPTS the spec via the SAME
 /// StructElementLegality the list Add uses (poly-base arm resolution + recursive contents — no per-type wiring). Add stays
-/// throw-on-duplicate (Aaron 2026-06-18); overwrite is Set-with-compose. G6/G7 keep record-element verbs +
-/// ReplaceAll/SetAtIndex/Merge deferred, so only Add/Set compose:
+/// throw-on-duplicate (Aaron 2026-06-18); overwrite is Set-with-compose (dict) or SetAtIndex-with-compose (list, GAP4
+/// below). G6/G7 keep record-element verbs deferred; only ReplaceAll/Merge of modeled elements now stay a later surface:
 ///   GAP3-OK-DICTADD-COMPOSE  — a Package.Data Add carrying a PackageDataBool compose is ACCEPTED (RED before: 'later surface').
 ///   GAP3-OK-DICTSET-COMPOSE  — a Package.Data Set carrying a compose is ACCEPTED (the overwrite path; RED before: 'requires a value').
 ///   GAP3-REJ-BADARM          — a compose type that is not an APackageData arm refuses, naming the legal arms (RED before: 'later surface').
 ///   GAP3-OK-LIST-UNCHANGED   — an ARM-element LIST compose (Faction.Conditions) still composes (the dict-Add change didn't disturb the list path).
+///   GAP4-OK-SETIDX-COMPOSE   — a list SetAtIndex carrying an arm compose is ACCEPTED at the gate (RED before: 'SetAtIndex of modeled elements is a later surface'; HCBR-2026-07-10).
+///   GAP4-REJ-SETIDX-NOSTRUCT — a plain-value SetAtIndex on an arm-element list refuses (needs a compose spec), same as Add — gate==apply.
+///   GAP4-E2E-SETIDX-COMPOSE  — SetAtIndex[0] OVERWRITES an arm element in place (count unchanged, [0]=new, [1]=untouched — the list POSITION the Remove+Add workaround lost).
 ///   GAP3-E2E                 — a composed PackageDataBool(Data=true) round-trips through the real create+apply path onto Package.Data[0] on disk.
 ///   GAP3-E2E-SET             — the Set-OVERWRITE apply branch round-trips: Add Data[0]=false then Set Data[0]=true reads Data==true on disk (the dup escape hatch).
 ///   GAP3-REJ-DUP             — an Add of an already-present key refuses (apply-time) end-to-end, NO file written, naming Set as the overwrite path,
@@ -1020,18 +1023,20 @@ public static class NestedCreateGuardProbe
         }
 
         // ---------- FLELEM-REJ-NULLSETIDX: a compose supplied with NO value on a coercible SetAtIndex still refuses ----------
-        // (PR #77 review finding 1.) SetAtIndex NEVER consumes req.Struct — ApplyListVerb's SetAtIndex is unconditionally
-        // Coerce(req.Value!, elem) — so a compose+no-value must NOT suppress the presence gate, else Coerce(null) hits the
-        // same serialize NRE the gate exists to kill. The gate therefore has NO req.Struct guard (a coercible element is
-        // never built from a struct, so a struct here is itself malformed). RED before the finding-1 fold: the gate's old
-        // `&& req.Struct is null` clause let a non-null Struct skip the gate → accepted. Race.MovementTypeNames = List<String>.
+        // (PR #77 review finding 1.) On a COERCIBLE-element list, SetAtIndex coerces req.Value and IGNORES req.Struct
+        // (ApplyListVerb's SetAtIndex coerce arm) — so a compose+no-value must NOT suppress the presence gate, else
+        // Coerce(null) hits the same serialize NRE the gate exists to kill. The presence gate (step-4-pre) therefore has
+        // NO req.Struct guard for a coercible element (which is never built from a struct, so a struct here is itself
+        // malformed). RED before the finding-1 fold: the gate's old `&& req.Struct is null` clause let a non-null Struct
+        // skip the gate → accepted. Race.MovementTypeNames = List<String>, a coercible element. (A SetAtIndex compose on
+        // a STRUCT/ARM element is a different, valid path — built FROM PARTS via the composable block; see GAP4 below.)
         bool flElemRejNullSetIdxOk;
         {
             var req = new WriteRequest { RecordType = "Race", Path = new[] { "MovementTypeNames" }, Verb = "SetAtIndex",
                 Key = "0", Value = null, Struct = new StructSpec { Type = "Keyword" } };
             var reject = rulebook.Validate(req);
             flElemRejNullSetIdxOk = reject is not null && reject.Contains("requires an element value", StringComparison.OrdinalIgnoreCase);
-            Console.WriteLine($"   FLELEM-REJ-NULLSETIDX struct+no value: {(flElemRejNullSetIdxOk ? "PASS — a compose can't suppress the gate on SetAtIndex (which ignores req.Struct)" : $"FAIL — reject=[{reject}]")}");
+            Console.WriteLine($"   FLELEM-REJ-NULLSETIDX struct+no value: {(flElemRejNullSetIdxOk ? "PASS — a compose can't suppress the presence gate on a SetAtIndex into a COERCIBLE element (which ignores req.Struct)" : $"FAIL — reject=[{reject}]")}");
         }
 
         // ---------- FLELEM-REJ-NULLADD-E2E: a missing element value refuses end-to-end with NO file written ----------
@@ -1687,6 +1692,56 @@ public static class NestedCreateGuardProbe
             var reject = rulebook.Validate(req);
             gap3OkListUnchangedOk = reject is null;
             Console.WriteLine($"   GAP3-OK-LIST-UNCHANGED arm-list Add: {(gap3OkListUnchangedOk ? "PASS — an arm-element list compose still composes (the dict-Add change didn't disturb the list path)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- GAP4: SetAtIndex COMPOSING a modeled (arm) element — the HCBR-2026-07-10 gap now closed ----------
+        // Replacing one condition row IN PLACE (the report: swap a faction check across 23 dialogue INFOs) needed
+        // Remove+Add, which moved the row to the list END — harmless for an AND row, but silently breaking an OR-group.
+        // SetAtIndex now composes the replacement FROM PARTS (the SAME StructElementLegality gate + BuildStruct apply the
+        // arm-element Add uses), overwriting the element in place. Proven on Faction.Conditions (List<Condition>, an arm
+        // element — the exact shape of a dialogue INFO's Conditions).
+
+        // GAP4-OK-SETIDX-COMPOSE: the gate ACCEPTS a SetAtIndex carrying an arm compose (RED before: 'later surface').
+        bool gap4OkSetIdxComposeOk;
+        {
+            var req = new WriteRequest { RecordType = "Faction", Path = new[] { "Conditions" }, Verb = "SetAtIndex", Key = "0",
+                Struct = new StructSpec { Type = "ConditionFloat" } };
+            var reject = rulebook.Validate(req);
+            gap4OkSetIdxComposeOk = reject is null;
+            Console.WriteLine($"   GAP4-OK-SETIDX-COMPOSE arm compose : {(gap4OkSetIdxComposeOk ? "PASS — a SetAtIndex carrying an arm compose is ACCEPTED at the gate (RED before: 'SetAtIndex of modeled elements is a later surface')" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // GAP4-REJ-SETIDX-NOSTRUCT: a SetAtIndex on a composable element with a PLAIN VALUE (no compose spec) refuses the
+        // SAME way Add does — StructElementLegality(null) names the compose-spec requirement (gate==apply, no accept-then-throw).
+        bool gap4RejSetIdxNoStructOk;
+        {
+            var req = new WriteRequest { RecordType = "Faction", Path = new[] { "Conditions" }, Verb = "SetAtIndex", Key = "0",
+                Value = "1" };
+            var reject = rulebook.Validate(req);
+            gap4RejSetIdxNoStructOk = reject is not null && reject.Contains("compose spec", StringComparison.OrdinalIgnoreCase);
+            Console.WriteLine($"   GAP4-REJ-SETIDX-NOSTRUCT plain value: {(gap4RejSetIdxNoStructOk ? "PASS — a plain-value SetAtIndex on an arm-element list refuses (needs a compose spec), same as Add" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // GAP4-E2E-SETIDX-COMPOSE: the apply mechanism — OVERWRITE IN PLACE, POSITION PRESERVED. Direct engine (a
+        // Condition list carries no master ref to serialize, mirroring EXPECTED-OK-SETIDX-INRANGE): Add ConditionFloat
+        // {ComparisonValue=1} then {=2}, then SetAtIndex[0] {=3}. Assert the count stayed 2 (OVERWRITE, not append),
+        // element[0] is the NEW value (3), and element[1] is UNCHANGED (2) — the position the Remove+Add workaround lost.
+        // RED before: the gate refused the compose ('later surface'), so the overwrite never ran.
+        bool gap4OkSetIdxComposeE2eOk;
+        {
+            var fac = new Faction(new FormKey(mKey, 0x930u), SkyrimRelease.SkyrimSE);
+            void AddCond(string v) => WriteEngine.ApplyVerb(fac, new WriteRequest { RecordType = "Faction",
+                Path = new[] { "Conditions" }, Verb = "Add",
+                Struct = new StructSpec { Type = "ConditionFloat", Fields = new() { ["ComparisonValue"] = v } } });
+            AddCond("1"); AddCond("2");
+            WriteEngine.ApplyVerb(fac, new WriteRequest { RecordType = "Faction", Path = new[] { "Conditions" },
+                Verb = "SetAtIndex", Key = "0",
+                Struct = new StructSpec { Type = "ConditionFloat", Fields = new() { ["ComparisonValue"] = "3" } } });
+            bool overwrote = fac.Conditions is { Count: 2 } c
+                && c[0] is IConditionFloatGetter c0 && c0.ComparisonValue == 3f
+                && c[1] is IConditionFloatGetter c1 && c1.ComparisonValue == 2f;
+            gap4OkSetIdxComposeE2eOk = overwrote;
+            Console.WriteLine($"   GAP4-E2E-SETIDX-COMPOSE overwrite  : {(gap4OkSetIdxComposeE2eOk ? "PASS — SetAtIndex[0] OVERWROTE in place (count 2, [0]=3 the new value, [1]=2 unchanged — position preserved)" : $"FAIL — conditions=[{string.Join(",", (fac.Conditions ?? new()).OfType<IConditionFloatGetter>().Select(x => x.ComparisonValue))}]")}");
         }
 
         // ---------- GAP3-E2E: a composed PackageDataBool round-trips through the REAL create+apply path onto disk ----------
@@ -2606,6 +2661,7 @@ public static class NestedCreateGuardProbe
                     && g4RejCtorArgShapeOk && g4RejCtorArgArityOk && g4OkCtorArgOk && g4OkNoCtorArgsOk && g4RejCtorArgE2eOk
                     && g7RejDictMergeOk && g7RejComposableRemoveOk && g7RejRecordRemoveOk && g7OkComposableRemoveIdxOk && g7OkDictRemoveKeyOk
                     && gap3OkDictAddComposeOk && gap3OkDictSetComposeOk && gap3RejBadArmOk && gap3OkListUnchangedOk
+                    && gap4OkSetIdxComposeOk && gap4RejSetIdxNoStructOk && gap4OkSetIdxComposeE2eOk
                     && gap3OkE2eOk && gap3OkE2eSetOk && gap3RejDupOk
                     && gap3RejBaseArmOk && gap3RejBaseArmListOk && gap3OkBaseNoOverRejectOk && gap3RejBaseArmE2eOk
                     && gap3RejBaseArmFieldOk && gap3OkArmFieldUnchangedOk


### PR DESCRIPTION
## The gap (HCBR-2026-07-10)

Replacing one modeled list element **in place** — e.g. swapping a CTDA condition row on a dialogue INFO — required `Remove`+`Add`, which moves the row to the **end** of the list. Harmless for an AND row; silently breaks an OR-group. `bulk_apply` `SetAtIndex`+`compose` refused with *"SetAtIndex of modeled elements is a later surface."* Filed against 1.6, still live on 1.7.0.

## Fix

- **Gate** (`CorpusRulebook`): `SetAtIndex` now routes through the **same** `StructElementLegality` `Add` already passes (poly-base arm resolution + recursive contents; a null spec → *"supply a compose spec, not a plain value"*). Index presence/shape stay gated upstream; the composable fence (`Struct`/`Arm` only) keeps this **off owned-record elements**, which `step-4-rec` already redirects to `create_record`. `ReplaceAll`/`Merge` stay deferred (they'd need list/dict compose-spec input shapes — distinct surfaces).
- **Apply** (`WriteEngine.ApplyListVerb`): `SetAtIndex` builds the replacement **from parts**, mirroring `Add`'s build-vs-coerce branch, overwriting **in place** (list position preserved). Coercible elements coerce `req.Value` exactly as before.

## Safety

The classifier already partitions element kinds: composition is fenced to `Struct`/`Arm`; owned child records (`ElementKind.Record`) route to the record axis. `SetAtIndex`-compose inherits that fence by construction — it can never reach an identity-bearing child record. A `Condition` is an `Arm`, which `Add`-compose already handled.

## Verification

- New probes in `nested-create-guard`:
  - `GAP4-OK-SETIDX-COMPOSE` — gate accepts an arm compose (RED before: "later surface").
  - `GAP4-REJ-SETIDX-NOSTRUCT` — plain-value `SetAtIndex` on an arm-element list refuses (needs a compose spec), same as `Add` — gate==apply.
  - `GAP4-E2E-SETIDX-COMPOSE` — `SetAtIndex[0]` overwrites in place: count unchanged, `[0]`=new value, `[1]`=untouched (the position the Remove+Add workaround lost).
- Scoped the now-inaccurate "SetAtIndex ignores req.Struct" rationale on `FLELEM-REJ-NULLSETIDX` to **coercible** elements.
- **`ci-all` 85/85 green.**

## Not covered here

Unit probes prove the mechanism on the exact `Conditions` arm-list type; the original 23-INFO condition-swap has not been replayed through the live MCP tool against a real load order (the in-game gate the release cut covers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)