### PR TITLE
read-surface discoverability + biped-slot decode (HCBR-2026-07-12)

### DIFF
--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -51,7 +51,9 @@ public sealed class FieldPredicateSet
 
     readonly IReadOnlyList<Predicate> _predicates;
     readonly long[] _valueRead;   // per-predicate: candidates whose path read SOME value
-    readonly long[] _noValue;     // per-predicate: candidates whose path read NO value (absent / no-such-field / container / fault)
+    readonly long[] _noValue;     // per-predicate: candidates whose path read NO value (any reason below)
+    readonly long[] _noField;     // per-predicate SUBSET of _noValue: the path is not a field on the record (mistyped / wrong for this type)
+    readonly long[] _container;   // per-predicate SUBSET of _noValue: the path resolves to a container/list, not a scalar leaf
     long _scanned;
     string? _fatal;
 
@@ -60,6 +62,8 @@ public sealed class FieldPredicateSet
         _predicates = predicates;
         _valueRead = new long[predicates.Count];
         _noValue = new long[predicates.Count];
+        _noField = new long[predicates.Count];
+        _container = new long[predicates.Count];
     }
 
     /// <summary>Set once when a numeric operator meets a non-numeric field value on the first value-bearing
@@ -176,7 +180,19 @@ public sealed class FieldPredicateSet
         {
             var p = _predicates[k];
             var leaf = ReadEngine.ReadLeaf(body, p.PathSegments);   // internal, same assembly — the by-construction read walk
-            if (!leaf.HasValue) { _noValue[k]++; all = false; continue; }
+            if (!leaf.HasValue)
+            {
+                // Classify WHY there was no value, so the Q3 accounting can distinguish a MISTYPED path (no such
+                // field anywhere) from a VALID-but-unset field (the path reads fine; there simply are no values in
+                // this scope) — the two look identical in a bare "0 matches", and conflating them sent a reporter
+                // hunting a non-bug (HCBR-2026-07-12: 'Prompt' is a real INFO field, just unset on all 531 scanned).
+                // Reason vocabulary is ReadLeaf's own notes: "(no field …" = mistyped/wrong-type; a leading '[' =
+                // a container/list summary; anything else (absent / null link / unresolved string / fault) = unset.
+                var note = leaf.Note ?? "";
+                if (note.StartsWith("(no field", StringComparison.Ordinal)) _noField[k]++;
+                else if (note.Length > 0 && note[0] == '[') _container[k]++;
+                _noValue[k]++; all = false; continue;
+            }
             _valueRead[k]++;
             var (satisfied, err) = Compare(p, leaf);
             if (err is not null) { _fatal ??= err; return false; }
@@ -307,10 +323,28 @@ public sealed class FieldPredicateSet
         {
             var path = _predicates[k].PathDisplay;
             if (_valueRead[k] == 0)
-                (notes ??= new()).Add(
-                    $"predicate field '{path}' yielded no readable value on any of {_scanned:N0} scanned record(s) — likely a mistyped path, " +
-                    $"or a container/list path (use a scalar leaf like 'Archetype.ActorValue', or references= for list→FormID membership). " +
-                    $"0 matches on that basis is NOT a confirmed 'nothing matches'.");
+            {
+                // No candidate read a value — but the CAUSE decides whether this is a wrong path or a correct path
+                // over a value-less scope, and those need opposite next moves (fix the path vs. widen the scope). All
+                // four keep the loud marker "yielded no readable value on any" (distinct from the SOFT "had no readable
+                // value on" for a >half-but-not-all miss), then diverge on the actionable reason.
+                const string loud = "yielded no readable value on any of";
+                string reason;
+                if (_noField[k] == _scanned)
+                    reason = $"predicate field '{path}' {loud} {_scanned:N0} scanned record(s) — it is NOT A FIELD on these records " +
+                             $"(a mistyped path, or a field that doesn't exist on this record type); check the field name against the record's schema.";
+                else if (_container[k] == _scanned)
+                    reason = $"predicate field '{path}' {loud} {_scanned:N0} scanned record(s) — it resolves to a container/list here, not a scalar " +
+                             $"leaf; filter on a scalar sub-path (e.g. '{path}[0]' or a nested field), or use references= for list→FormID membership.";
+                else if (_noField[k] == 0 && _container[k] == 0)
+                    reason = $"predicate field '{path}' {loud} {_scanned:N0} scanned record(s) — but the field IS VALID; it is simply UNSET " +
+                             $"(absent/null) on every one, so the path reads fine and there are just no values in this scope. Widen the scope, or " +
+                             $"the value you want may live on a different field (e.g. a dialogue topic's player text is on DIAL 'Name', not INFO 'Prompt').";
+                else
+                    reason = $"predicate field '{path}' {loud} {_scanned:N0} scanned record(s) — a mix of no-such-field ({_noField[k]:N0}), " +
+                             $"container/list ({_container[k]:N0}), and unset; check it's a scalar leaf that exists on these records.";
+                (notes ??= new()).Add(reason + " 0 matches on that basis is NOT a confirmed 'nothing matches'.");
+            }
             else if (_noValue[k] * 2 > _scanned)
                 (notes ??= new()).Add(
                     $"note: '{path}' had no readable value on {_noValue[k]:N0} of {_scanned:N0} scanned record(s) " +

--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -54,6 +54,7 @@ public sealed class FieldPredicateSet
     readonly long[] _noValue;     // per-predicate: candidates whose path read NO value (any reason below)
     readonly long[] _noField;     // per-predicate SUBSET of _noValue: the path is not a field on the record (mistyped / wrong for this type)
     readonly long[] _container;   // per-predicate SUBSET of _noValue: the path resolves to a container/list, not a scalar leaf
+    readonly long[] _unreadable;  // per-predicate SUBSET of _noValue: the path READ FAULTED (Mutagen-unparseable content) — a fault, NOT an unset value
     long _scanned;
     string? _fatal;
 
@@ -64,6 +65,7 @@ public sealed class FieldPredicateSet
         _noValue = new long[predicates.Count];
         _noField = new long[predicates.Count];
         _container = new long[predicates.Count];
+        _unreadable = new long[predicates.Count];
     }
 
     /// <summary>Set once when a numeric operator meets a non-numeric field value on the first value-bearing
@@ -187,9 +189,12 @@ public sealed class FieldPredicateSet
                 // this scope) — the two look identical in a bare "0 matches", and conflating them sent a reporter
                 // hunting a non-bug (HCBR-2026-07-12: 'Prompt' is a real INFO field, just unset on all 531 scanned).
                 // Reason vocabulary is ReadLeaf's own notes: "(no field …" = mistyped/wrong-type; a leading '[' =
-                // a container/list summary; anything else (absent / null link / unresolved string / fault) = unset.
+                // a container/list summary; "(unreadable …" = a Mutagen-parse FAULT (must NOT read as "unset" — that
+                // would confidently assert a valid empty field where the truth is a read fault, Q3); anything else
+                // (absent / null link / unresolved string) = a genuinely-unset valid field.
                 var note = leaf.Note ?? "";
                 if (note.StartsWith("(no field", StringComparison.Ordinal)) _noField[k]++;
+                else if (note.StartsWith("(unreadable", StringComparison.Ordinal)) _unreadable[k]++;
                 else if (note.Length > 0 && note[0] == '[') _container[k]++;
                 _noValue[k]++; all = false; continue;
             }
@@ -329,6 +334,7 @@ public sealed class FieldPredicateSet
                 // four keep the loud marker "yielded no readable value on any" (distinct from the SOFT "had no readable
                 // value on" for a >half-but-not-all miss), then diverge on the actionable reason.
                 const string loud = "yielded no readable value on any of";
+                long unset = _noValue[k] - _noField[k] - _container[k] - _unreadable[k];   // the residue: genuinely-unset valid fields
                 string reason;
                 if (_noField[k] == _scanned)
                     reason = $"predicate field '{path}' {loud} {_scanned:N0} scanned record(s) — it is NOT A FIELD on these records " +
@@ -336,13 +342,18 @@ public sealed class FieldPredicateSet
                 else if (_container[k] == _scanned)
                     reason = $"predicate field '{path}' {loud} {_scanned:N0} scanned record(s) — it resolves to a container/list here, not a scalar " +
                              $"leaf; filter on a scalar sub-path (e.g. '{path}[0]' or a nested field), or use references= for list→FormID membership.";
-                else if (_noField[k] == 0 && _container[k] == 0)
+                else if (_unreadable[k] == _scanned)
+                    reason = $"predicate field '{path}' could not be READ on any of {_scanned:N0} scanned record(s) — a read FAULT (Mutagen could not " +
+                             $"parse the field's content), NOT an unset value. This is a coverage/parse limit on this field, not a filter miss; the " +
+                             $"filter can't judge these records.";
+                else if (_noField[k] == 0 && _container[k] == 0 && _unreadable[k] == 0)
                     reason = $"predicate field '{path}' {loud} {_scanned:N0} scanned record(s) — but the field IS VALID; it is simply UNSET " +
                              $"(absent/null) on every one, so the path reads fine and there are just no values in this scope. Widen the scope, or " +
                              $"the value you want may live on a different field (e.g. a dialogue topic's player text is on DIAL 'Name', not INFO 'Prompt').";
                 else
                     reason = $"predicate field '{path}' {loud} {_scanned:N0} scanned record(s) — a mix of no-such-field ({_noField[k]:N0}), " +
-                             $"container/list ({_container[k]:N0}), and unset; check it's a scalar leaf that exists on these records.";
+                             $"container/list ({_container[k]:N0}), read-fault ({_unreadable[k]:N0}), and unset ({unset:N0}); check it's a scalar " +
+                             $"leaf that exists on these records.";
                 (notes ??= new()).Add(reason + " 0 matches on that basis is NOT a confirmed 'nothing matches'.");
             }
             else if (_noValue[k] * 2 > _scanned)

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -10,8 +10,15 @@ namespace HousecarlCore;
 /// <summary>One field read off a record: a round-trippable <see cref="Token"/> when <see cref="HasValue"/> is
 /// true, else a <see cref="Note"/> explaining why there is no value (absent optional, no such field, a non-leaf
 /// container, or an isolated read fault). The public, structured form of the internal <c>LeafRead</c> — what the
-/// MCP server's read tools emit.</summary>
-public sealed record FieldValue(string Path, bool HasValue, string? Token, string? Note);
+/// MCP server's read tools emit.
+///
+/// <para><see cref="Display"/> is a DISPLAY-ONLY annotation the render layer appends in parentheses after the
+/// value — NOT part of the round-trip token (the write surface reads <see cref="Token"/>, the round-trip oracle
+/// drives the internal <c>LeafRead</c>, and <c>FieldsDiff</c> compares Token/Note), so it is invisible to write,
+/// read-proof, and diff. Used to decode a value that is correct but opaque — a biped-slot bitmask into its slot
+/// numbers (HCBR-2026-07-12) — without disturbing the token that must round-trip. Null on every leaf that needs
+/// no annotation.</para></summary>
+public sealed record FieldValue(string Path, bool HasValue, string? Token, string? Note, string? Display = null);
 
 /// <summary>A located record read out as structured fields — the public (params)->(result) result the MCP
 /// server's read tools return (the §8.4 read cleave). Identity (<see cref="Type"/> / <see cref="FormKey"/> /
@@ -132,7 +139,7 @@ public static class ReadEngine
         var depth = int.TryParse(f.GetValueOrDefault("depth"), out var dN) && dN > 0 ? dN : 1;
         var rf = ReadFields(target, paths.Count > 0 ? paths : null, depth);
         foreach (var fv in rf.Fields)
-            Console.WriteLine($"  {fv.Path} = {(fv.HasValue ? fv.Token : fv.Note)}");
+            Console.WriteLine($"  {fv.Path} = {(fv.HasValue ? fv.Token : fv.Note)}{(fv.Display is null ? "" : $"   ({fv.Display})")}");
         return 0;
     }
 
@@ -156,7 +163,15 @@ public static class ReadEngine
             {
                 var seg = p.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
                 var r = ReadLeaf(record, seg);
-                fields.Add(new FieldValue(p, r.HasValue, r.HasValue ? r.Token : null, r.HasValue ? null : r.Note));
+                string? note = r.HasValue ? null : r.Note;
+                // An UNEXPANDED container / substruct leaf self-documents the lever that opens it: at the depth-1
+                // default it renders as a count/summary ("[list: 2 item(s)]", "[BodyTemplate]"), and an agent that
+                // doesn't know to raise depth= invents a param and hand-rolls a parser instead of turning the knob
+                // (HCBR-2026-07-12). No-value NOTES are parenthesized ("(absent)", "(null link)"), so the leading-'['
+                // test targets exactly the container/substruct summaries. Depth-1 only (this branch) — the deep read
+                // FieldsDiff runs never sees the hint (it reads at expansion depth, a different summary path).
+                if (note is { Length: > 0 } && note[0] == '[') note += " — pass depth=2 to expand";
+                fields.Add(new FieldValue(p, r.HasValue, r.HasValue ? r.Token : null, note, FlagSlotDisplay(r)));
             }
         }
         else
@@ -291,7 +306,7 @@ public static class ReadEngine
     {
         if (budget < 0) return;
         var leaf = EmitToken(val, declaredType, parent);
-        if (leaf.HasValue) { Emit(sink, ref budget, new FieldValue(path, true, leaf.Token, null)); return; }
+        if (leaf.HasValue) { Emit(sink, ref budget, new FieldValue(path, true, leaf.Token, null, FlagSlotDisplay(leaf))); return; }
         if (val is null) { Emit(sink, ref budget, new FieldValue(path, false, null, leaf.Note)); return; }
         // a link (incl. a null FormKey, or an FLOI) is a note, not an openable container/substruct.
         if (val is IFormLinkGetter || WriteEngine.IsFormLinkOrIndex(Nullable.GetUnderlyingType(declaredType) ?? declaredType))
@@ -637,6 +652,24 @@ public static class ReadEngine
         catch { return false; }
     }
 
+    /// <summary>The DISPLAY-ONLY biped-slot decode for a <c>BodyTemplate.FirstPersonFlags</c> leaf (enum
+    /// <c>BipedObjectFlag</c>): the equipped SLOT NUMBERS ("slots 32, 34, 53") derived from the bit pattern
+    /// (slot = 30 + bit index). Armor/slot analysis wants the slot numbers, but <c>[Flags].ToString()</c> gives
+    /// enum NAMES when every set bit is named ("Body") and falls back to a bare decimal the moment an unnamed
+    /// modder slot is set (e.g. <c>8388980</c> for a slot-53 addon) — neither is the slot list the modder reasons
+    /// in (HCBR-2026-07-12). This annotation rides <see cref="FieldValue.Display"/>, so the round-trip
+    /// <see cref="LeafRead.Token"/> is untouched (write/read-proof/diff never see it). Gated to BipedObjectFlag by
+    /// name — the slot=30+bit mapping is meaningless for any other <c>[Flags]</c> enum. Null for every non-biped
+    /// leaf, an unset mask, or a non-flags value.</summary>
+    internal static string? FlagSlotDisplay(LeafRead leaf)
+    {
+        if (!leaf.HasValue || leaf.Flags is not { } fb || fb.EnumType.Name != "BipedObjectFlag") return null;
+        var slots = new List<int>();
+        for (int i = 0; i < 32; i++) if ((fb.Bits & (1UL << i)) != 0) slots.Add(30 + i);
+        if (slots.Count == 0) return null;
+        return (slots.Count == 1 ? "slot " : "slots ") + string.Join(", ", slots);
+    }
+
     // -- primitive family (mirror TryPrimitive) --------------------------------
     static bool TryEmitPrimitive(object val, out string token)
     {
@@ -833,16 +866,20 @@ public static class ReadEngine
     }
 
     /// <summary>A short, non-round-trippable description of a container leaf (substruct / list / dict /
-    /// arm) for the read display. Its sub-leaves are the round-trippable surface. A dict renders
-    /// "N pair(s)" (vs a list's "N item(s)") — display-informative, and the in-band marker FieldsDiff
-    /// uses to keep numeric-keyed dicts out of positional-list comparison (PR #28 review).</summary>
+    /// arm) for the read display. Its sub-leaves are the round-trippable surface. A collection renders as a
+    /// clean <c>[list: N item(s)]</c> / <c>[dict: N pair(s)]</c> — the Mutagen overlay class name
+    /// (<c>BinaryOverlayListByStartIndex`1</c>) is container plumbing, NOT the element type, so it is pure noise
+    /// to the reader and is dropped (HCBR-2026-07-12). The <c>item(s)</c>/<c>pair(s)</c> marker is LOAD-BEARING —
+    /// <c>FieldsDiff</c> splits numeric-keyed dicts (Package.Data) out of positional-list comparison on the
+    /// exact <c>" pair(s)]"</c> substring (PR #28 review) — so it is kept verbatim. A substruct keeps its
+    /// <c>[TypeName]</c> (e.g. <c>[BodyTemplate]</c>): there the type name IS informative.</summary>
     static string SummariseContainer(object val, bool isDict = false)
     {
         if (val is System.Collections.IEnumerable en and not string)
         {
             int n = 0;
             foreach (var _ in en) n++;
-            return $"[{RecordNaming.StripGetterInterface(val.GetType().Name)}: {n} {(isDict ? "pair(s)" : "item(s)")}]";
+            return $"[{(isDict ? "dict" : "list")}: {n} {(isDict ? "pair(s)" : "item(s)")}]";
         }
         return $"[{RecordNaming.StripGetterInterface(val.GetType().Name)}]";
     }

--- a/src/housecarl-generator/BindingShimProbe.cs
+++ b/src/housecarl-generator/BindingShimProbe.cs
@@ -158,6 +158,26 @@ public static class BindingShimProbe
                 !h.text.Contains(GenericError) && !h.text.Contains("internal houseCARL failure")
                 && h.text.Contains("required parameter") && h.text.Contains("formids"),
                 h.Describe());
+
+            // -- I: an UNKNOWN parameter (HCBR-2026-07-12). expand=/path=/field= were the audit agent's
+            //    inventions; the SDK binder SILENTLY IGNORES an undeclared argument, so the call ran with the
+            //    intent dropped and no correction reached the agent — which then concluded the capability was
+            //    missing and hand-rolled a parser. Must be a NAMED refusal that names the offender AND lists the
+            //    supported params (pointing at the real knob, depth=), never a silent run (no ConfigPrompt = the
+            //    body never executed) and never the generic error. Required check passes first (formid present).
+            var iRes = Call(stdin, stdout, 10, "housecarl_read_record",
+                """{"formid":"0F1AC1:Skyrim.esm","expand":true}""");
+            failures += Check("I unknown: an undeclared parameter is refused by NAME, listing supported params",
+                !iRes.text.Contains(GenericError) && !iRes.text.Contains(ConfigPrompt)
+                && iRes.text.Contains("unknown parameter") && iRes.text.Contains("expand") && iRes.text.Contains("depth"),
+                iRes.Describe());
+
+            // -- I2: control — the SAME call WITHOUT the stray param binds and reaches the body (proves the
+            //    unknown-param check never rejects a well-formed call; it reaches the config prompt here).
+            var i2 = Call(stdin, stdout, 11, "housecarl_read_record",
+                """{"formid":"0F1AC1:Skyrim.esm"}""");
+            failures += Check("I2 control: the same call without the stray param binds and runs the tool body",
+                !i2.text.Contains(GenericError) && i2.text.Contains(ConfigPrompt), i2.Describe());
         }
         catch (Exception ex)
         {

--- a/src/housecarl-generator/ValuePredicateProbe.cs
+++ b/src/housecarl-generator/ValuePredicateProbe.cs
@@ -255,6 +255,18 @@ public static class ValuePredicateProbe
             Console.WriteLine($"     note: {Trunc(note)}");
         }
 
+        // 9b. A whole-LIST path (a POPULATED Keywords list) lands in the same container branch — exercising the
+        //     [list: N item(s)] rendering directly, not just the substruct summary above (review item 3).
+        {
+            var kwArmo = mod.Armors.AddNew();
+            kwArmo.Keywords = new() { new FormLink<IKeywordGetter>(projX) };   // a present, non-empty list → container summary, never "unset"
+            var (matched, set) = RunWithSet(new[] { "Keywords = 0FFFFF:hcvalguard.esp" }, new List<IMajorRecordGetter> { kwArmo });
+            var note = set.AccountingNote();
+            Check("list path: 0 matches", matched.Count == 0);
+            Check("list path: surfaced (note mentions container/list)",
+                  note is not null && note.Contains("container/list", StringComparison.Ordinal));
+        }
+
         // 10. NUMERIC operator on a NON-numeric field → fast typed FatalError (not a whole-scan silent skip).
         {
             var (matched, set) = RunWithSet(new[] { "MagicSkill > 5" }, mgefBodies);

--- a/src/housecarl-generator/ValuePredicateProbe.cs
+++ b/src/housecarl-generator/ValuePredicateProbe.cs
@@ -228,13 +228,31 @@ public static class ValuePredicateProbe
             Console.WriteLine($"     note: {Trunc(note)}");
         }
 
-        // 9. LIST path (Keywords) reads as a container → no value → surfaced, never silently matched.
+        // 8b. VALID field, UNSET on ALL scanned → still LOUD, but DISTINGUISHED from a mistyped path: the note says
+        //     the field is valid/unset and does NOT call it "mistyped" (HCBR-2026-07-12 — 'Prompt' is a real INFO
+        //     field, just unset on every one of the 531 scanned; the old "likely a mistyped path" note sent the
+        //     reporter hunting a non-bug). 'Name' (FULL) is a real MagicEffect field left unset by MakeMgef.
         {
-            var (matched, set) = RunWithSet(new[] { "Keywords = 0ABCDE:hcvalguard.esp" }, mgefBodies);
+            var (matched, set) = RunWithSet(new[] { "Name = Whatever" }, mgefBodies);
             var note = set.AccountingNote();
-            Check("list path: 0 matches", matched.Count == 0);
-            Check("list path: surfaced (note mentions list/container)",
+            Check("valid-but-unset: 0 matches", matched.Count == 0);
+            Check("valid-but-unset: LOUD note (not silent zero)",
+                  note is not null && note.Contains("no readable value", StringComparison.Ordinal));
+            Check("valid-but-unset: says VALID/unset, NOT 'mistyped'",
+                  note is not null && note.Contains("VALID", StringComparison.Ordinal) && !note.Contains("mistyped", StringComparison.Ordinal));
+            Console.WriteLine($"     note: {Trunc(note)}");
+        }
+
+        // 9. CONTAINER path (a non-scalar leaf — here the Archetype substruct, populated on every MGEF fixture)
+        //    reads as a container summary → no scalar value → surfaced with the container-specific guidance, never
+        //    silently matched. (A whole-LIST path lands in the same branch by the same '['-summary signal.)
+        {
+            var (matched, set) = RunWithSet(new[] { "Archetype = whatever" }, mgefBodies);
+            var note = set.AccountingNote();
+            Check("container path: 0 matches", matched.Count == 0);
+            Check("container path: surfaced (note mentions container/list)",
                   note is not null && note.Contains("container/list", StringComparison.Ordinal));
+            Console.WriteLine($"     note: {Trunc(note)}");
         }
 
         // 10. NUMERIC operator on a NON-numeric field → fast typed FatalError (not a whole-scan silent skip).

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -568,7 +568,9 @@ static class Wire
                 break;
             }
             var f = r.Fields[i];
-            sb.Append("  ").Append(f.Path).Append(" = ").Append(f.HasValue ? f.Token : f.Note).Append('\n');
+            sb.Append("  ").Append(f.Path).Append(" = ").Append(f.HasValue ? f.Token : f.Note);
+            if (f.Display is not null) sb.Append("   (").Append(f.Display).Append(')');   // display-only annotation (e.g. decoded biped slots) — never the round-trip token
+            sb.Append('\n');
         }
     }
 
@@ -712,7 +714,9 @@ static class Wire
                     break;
                 }
                 var f = r.Fields[i];
-                sb.Append("  ").Append(f.Path).Append(" = ").Append(f.HasValue ? f.Token : f.Note).Append('\n');
+                sb.Append("  ").Append(f.Path).Append(" = ").Append(f.HasValue ? f.Token : f.Note);
+                if (f.Display is not null) sb.Append("   (").Append(f.Display).Append(')');   // display-only annotation (e.g. decoded biped slots) — never the round-trip token
+                sb.Append('\n');
             }
         }
         else if (o.Mode == "enumerate")

--- a/src/housecarl-mcp/ToolCallShim.cs
+++ b/src/housecarl-mcp/ToolCallShim.cs
@@ -208,11 +208,15 @@ internal static class ToolCallShim
 
         var supported = props.EnumerateObject().Select(prop => prop.Name).ToList();
         string plural = unknown.Count == 1 ? "" : "s";
+        // Only nudge toward depth= on a tool that actually HAS it (the read tools) — a depth-less tool would
+        // point at a knob that doesn't exist. The supported list is printed either way, so the nudge is a bonus.
+        string knobHint = supported.Contains("depth")
+            ? " (a wrong/guessed parameter often means the real knob is one of the above, e.g. depth= to expand a list/substruct)"
+            : "";
         return NamedError(
             $"error: {p.Name}: unknown parameter{plural}: {string.Join(", ", unknown)}. This tool accepts only: " +
             $"{string.Join(", ", supported)}. An unrecognized argument is IGNORED (it does not change behavior), so " +
-            $"the call would otherwise run with that intent silently dropped — fix the name (a wrong/guessed parameter " +
-            $"often means the real knob is one of the above, e.g. depth= to expand a list/substruct) and retry.");
+            $"the call would otherwise run with that intent silently dropped — fix the name{knobHint} and retry.");
     }
 
     static CallToolResult NamedError(string text) => new()

--- a/src/housecarl-mcp/ToolCallShim.cs
+++ b/src/housecarl-mcp/ToolCallShim.cs
@@ -49,6 +49,7 @@ internal static class ToolCallShim
                 var schema = tool.ProtocolTool.InputSchema;
                 CoerceObviousShapes(p, schema);
                 if (MissingRequired(p, schema) is { } refusal) return refusal;
+                if (UnknownParameters(p, schema) is { } unknownRefusal) return unknownRefusal;
             }
             return await next(request, cancellationToken);
         }
@@ -175,6 +176,43 @@ internal static class ToolCallShim
         return NamedError(
             $"error: {p.Name}: required parameter{plural} missing: {string.Join(", ", missing)}. Supplied: " +
             $"{(p.Arguments is { Count: > 0 } a ? string.Join(", ", a.Keys) : "(none)")}. Add the missing argument{plural} and retry.");
+    }
+
+    /// <summary>Schema-UNDECLARED arguments in the call → a named refusal listing the offenders and the tool's
+    /// supported parameters, or null to proceed. THE root-cause fix for HCBR-2026-07-12: an argument a tool does
+    /// not declare (<c>expand=</c>, <c>path=</c>, <c>field=</c>) is SILENTLY IGNORED by the SDK binder, so the
+    /// call runs with that intent dropped and no correction reaches the caller — the agent, getting a normal
+    /// (un-expanded) result, concluded the capability was missing and hand-rolled a workaround instead of
+    /// discovering the real knob (<c>depth=</c>). A silently-ignored argument is a silent tool-surface failure
+    /// (Q3); naming it — with the supported list — turns the dead end into a self-correction, exactly as
+    /// <see cref="MissingRequired"/> does for the absent-required case. Schema-driven off the tool's own
+    /// InputSchema, so every current and future parameter is covered by construction. Skipped when a tool's schema
+    /// opts into free-form args (<c>additionalProperties</c> not <c>false</c>); none of houseCARL's tools do today,
+    /// but the check does not assume it. Runs AFTER <see cref="CoerceObviousShapes"/> (which only ever rewrites
+    /// DECLARED keys) and <see cref="MissingRequired"/>, so a well-formed call is byte-identical to before.</summary>
+    static CallToolResult? UnknownParameters(CallToolRequestParams p, JsonElement schema)
+    {
+        if (p.Arguments is not { Count: > 0 } args) return null;
+        if (schema.ValueKind != JsonValueKind.Object) return null;
+        // Respect an explicit opt-in to extra properties: only reject when additionalProperties is absent or false.
+        if (schema.TryGetProperty("additionalProperties", out var ap) && ap.ValueKind != JsonValueKind.False) return null;
+        if (!schema.TryGetProperty("properties", out var props) || props.ValueKind != JsonValueKind.Object) return null;
+
+        List<string>? unknown = null;
+        foreach (var kv in args)
+        {
+            if (kv.Key.Length > 0 && kv.Key[0] == '_') continue;   // MCP/JSON-RPC metadata convention — never a real tool param
+            if (!props.TryGetProperty(kv.Key, out _)) (unknown ??= new()).Add(kv.Key);
+        }
+        if (unknown is null) return null;
+
+        var supported = props.EnumerateObject().Select(prop => prop.Name).ToList();
+        string plural = unknown.Count == 1 ? "" : "s";
+        return NamedError(
+            $"error: {p.Name}: unknown parameter{plural}: {string.Join(", ", unknown)}. This tool accepts only: " +
+            $"{string.Join(", ", supported)}. An unrecognized argument is IGNORED (it does not change behavior), so " +
+            $"the call would otherwise run with that intent silently dropped — fix the name (a wrong/guessed parameter " +
+            $"often means the real knob is one of the above, e.g. depth= to expand a list/substruct) and retry.");
     }
 
     static CallToolResult NamedError(string text) => new()


### PR DESCRIPTION
Three read-surface fixes from the two latest self-usage bug reports (HCBR-2026-07-12). The reports' headline complaint — list/substruct fields opaque, had to hand-roll a Python parser — turned out to be a **discoverability failure, not a capability gap**: `depth=2` already surfaces all of it (verified live). The real issues were the silent-swallow that hid the lever, plus one genuine rendering enhancement.

## Commits
1. **`feat(read): reject unknown tool parameters`** — the root cause. An undeclared arg (`expand=`, `path=`, `field=`) was silently ignored by the SDK binder, so the call ran with the intent dropped and no correction reached the agent — which then concluded the capability was missing and hand-rolled a parser. `ToolCallShim` now names the offender and lists the supported params (pointing at `depth=`), schema-driven off each tool's InputSchema. Q3 (a silently ignored arg is a silent tool-surface failure).
2. **`feat(read): clearer container rendering + biped-slot decode`** — clean `[list: N item(s)]`/`[dict: N pair(s)]` labels (drop the leaked `BinaryOverlayListByStartIndex\`1`); every unexpanded container/substruct ends `— pass depth=2 to expand`; and `BodyTemplate.FirstPersonFlags` carries a display-only slot decode (`slots 32, 34, 53`; slot = 30 + bit). None of this touches the round-trip token — the decode rides a new `FieldValue.Display` channel that write, the read-proof oracle, and `FieldsDiff` all ignore.
3. **`feat(query): sharpen the where= no-value accounting note`** — distinguishes *mistyped path* vs *container/list* vs *valid-but-unset*, each with the right next move, instead of the old blanket "likely a mistyped path."

## Note on report #3
Report #3 (`where=` can't read INFO `Prompt`) was **not a correctness bug** — proven: `where Prompt contains e` returns 1,351 real INFO prompts. The scanned plugin's INFOs simply had no `Prompt` set (player text lives on `DIAL`, not `INFO.Prompt`). Fix 3 improves the *note* that misdescribed the cause, not the reader.

## Verification
- **85/85 probes pass** (`ci-all`), including the read-proof round-trip oracle and the conflict-diff dict/list detection.
- Added guards: `binding-shim-guard` I/I2 (reject unknown param end-to-end over stdio + well-formed control); `value-predicate-guard` valid-but-unset + real container cases.
- Live read of the exact report record `011D4A:UBE_AllRace.esp` (00UBE_NakedTorso): `FirstPersonFlags = 8388980   (slots 32, 34, 35, 36, 38, 53)` — exactly report A's ask, raw token preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)