### PR TITLE
release: 1.7.1 — where=-note fix + read-surface & write-lane fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ models — by construction, not a hand-maintained subset.
 
 ### Download — recommended (modders)
 
-1. Download **`houseCARL-1.7.0.zip`** from the [latest release](https://github.com/Avick3110/houseCARL/releases).
+1. Download **`houseCARL-1.7.1.zip`** from the [latest release](https://github.com/Avick3110/houseCARL/releases).
 2. Unzip it and run **`houseCARL-Setup.exe`**.
 3. Pick your host — **`[1] Claude Code`**, **`[2] Codex`**, or **`[3] Both`**. The installer wires
    everything up:
@@ -121,7 +121,7 @@ cd houseCARL
 
 The script regenerates the reflection rulebook, publishes the server framework-dependent (trimming **off**
 — houseCARL is reflection-driven, so trimming would strip types and silently lose coverage), bundles the
-skills, builds the setup utility, and packs `release/houseCARL-1.7.0.zip`. Install the output with
+skills, builds the setup utility, and packs `release/houseCARL-1.7.1.zip`. Install the output with
 `houseCARL-Setup.exe`, `claude --plugin-dir ./dist/housecarl`, or the bundled local-marketplace
 descriptor — see the script header for details.
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "housecarl",
   "displayName": "houseCARL",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Comprehensive data-layer access to your Skyrim SE load order — read any record, author patches into a new plugin, look mods up on Nexus, and look up record schemas, Papyrus signatures, performance reviews, and distributor grammars — in plain English.",
   "author": { "name": "Avick3110" },
   "homepage": "https://github.com/Avick3110/houseCARL",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to houseCARL are documented here. Versioning is [semantic](h
 the `version` in `.claude-plugin/plugin.json` is bumped on each release, so installed users update only
 when it changes.
 
+## 1.7.1 — 2026-07-13
+
+A maintenance release: sharper, louder tool feedback and a write-lane fix. No new tools (still 37) or
+skills (still 12).
+
+**Query & read surface**
+
+- **A `where=` filter that finds nothing now tells you *why*.** When a field-value predicate read no value
+  on every scanned record, the note used to guess "likely a mistyped path" for *every* cause — so a perfectly
+  valid field that simply happens to be unset everywhere read as "this field is unreadable." It now classifies
+  the actual cause — a wrong/mistyped field, a container/list path, a read fault, or a valid-but-unset field —
+  and names the matching next move (for example, that a dialogue topic's player-facing text lives on the DIAL
+  `Name`, not the INFO `Prompt`).
+- **Unknown tool parameters are now rejected instead of ignored.** A misspelled or unsupported parameter name
+  fails loud, rather than being silently dropped and looking like it had no effect.
+- **Clearer container/list rendering and biped-slot decode in reads**, and the `depth=` hint now appears only
+  on the tools that actually support it.
+
+**Write lane**
+
+- **`housecarl_set_field` `SetAtIndex` composes modeled list elements correctly** — setting an element of a
+  modeled list (rather than a plain scalar) no longer mis-applies.
+
 ## 1.7.0 — 2026-07-11
 
 houseCARL learns to **see through more of the runtime layer than the record alone**: merge plugins together,


### PR DESCRIPTION
**PATCH release** for the post-1.7.0 `HCBR-2026-07-12` batch — 7 commits since `v1.7.0`, all fixes/refinements to existing tools. **No new tools (still 37) or skills (still 12).**

### Why now
The 2026-07-12 gap report (`where= cannot read INFO Prompt`) was **already fixed in source** by PR #173 — but the running server is a pre-#173 build, so users (and the reporter) still hit the old note. This cut ships that fix (and the rest of the batch) to the live server.

### Scope (since `v1.7.0`)
- **`where=` no-value note now names the real cause** — valid-but-unset vs mistyped path vs container vs read-fault (was a blanket "likely a mistyped path"). Resolves the INFO-`Prompt` gap: a real field that's simply unset everywhere no longer reads as "unreadable". (`b42d6d1`, `adee592`)
- **Unknown tool parameters are rejected**, not silently ignored. (`2c6c857`)
- **Clearer container/list rendering + biped-slot decode** in reads; `depth=` nudge gated to tools that declare it. (`5692a0b`, `a6d5aaa`)
- **`SetAtIndex` composes modeled list elements** correctly. (`66b4028`, `3fb962b`, HCBR-2026-07-10)

### Changes in this PR
- `plugin/.claude-plugin/plugin.json` — `1.7.0` → `1.7.1` (single source of truth)
- `plugin/CHANGELOG.md` — 1.7.1 entry
- `README.md` — two `houseCARL-1.7.x.zip` strings

### Gates (local, from the worktree)
- **Build GREEN** — corpus 133 types / 1170 total, no anomalies, leak-check clean; packed **334 entries**, skills **12**.
- **K1 GREEN** — `claude plugin validate ./dist/housecarl --strict` → passed.
- Provisional zip SHA256 `610d94914982cfe0de5c516ab55d014bb3284e144ef0e69ac825062326308066`, 17,522,389 B (canonical zip rebuilds from merged `main` at cut).

### Remaining (Aaron's lane — outward-facing acts)
1. Review + merge this PR (rebase-merge; main is PR-protected).
2. Rebuild the canonical zip from merged `main` → `release/houseCARL-1.7.1.zip`; record SHA256 + entry count.
3. GitHub Release: tag `v1.7.1` on the release commit, upload the zip, mark **Latest**.
4. Nexus (mod 181738): bump version, upload MAIN file, paste the changelog.
5. Point the running MCP server at the fresh build so the live behavior matches `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)