### PR TITLE
feat(nexus): Tier 0 keyless-Nexus capability — files, changelogs, batch update check, MD5 identify, local update cache

### DIFF
--- a/src/housecarl-core/Mo2ModMeta.cs
+++ b/src/housecarl-core/Mo2ModMeta.cs
@@ -1,0 +1,82 @@
+namespace HousecarlCore;
+
+// ======================================================================
+//  Mo2ModMeta — read the Nexus update-cache fields MO2 writes into each
+//  mod's meta.ini (mods\<Folder>\meta.ini). MO2 has ALREADY paid the Nexus
+//  API cost to learn these; houseCARL just reads its cache — no network,
+//  squarely in the MO2-static-read lane (like Mo2Instance / Mo2LoadOrder).
+//
+//  The [General] fields that drive "is there an update":
+//      modid=12604               (the Nexus mod id; 0/absent ⇒ not a Nexus mod)
+//      version=5.2SE             (the INSTALLED version)
+//      newestVersion=6.11        (what MO2 last learned is newest; empty ⇒ never checked)
+//      ignoredVersion=6.10       (a version the user told MO2 to stop nagging about)
+//      lastNexusUpdate=1778020881(unix seconds of MO2's last update check)
+//
+//  MO2's own rule (what its update flag shows): an update is available when
+//  newestVersion is set, non-empty, and != version (and != ignoredVersion).
+//  We report the RAW fields and let the caller apply that rule, so the
+//  reasoning is visible, never a hidden boolean (Q3).
+//
+//  Format is QSettings-ini (same quirks Mo2Instance documents): a value may
+//  be wrapped @ByteArray(...), @Invalid() means unset, backslashes are
+//  doubled, and string values can be surrounded by double quotes. The
+//  [installedFiles] section uses prefixed keys (1\modid=...) so a plain
+//  first-match on "modid" reads the [General] one, which is written first.
+// ======================================================================
+
+/// <summary>The Nexus update-cache fields from one mod's meta.ini. <see cref="ModId"/> is 0 when the mod has no Nexus
+/// id (a hand-installed mod / separator). <see cref="NewestVersion"/> empty ⇒ MO2 never learned a newer version.</summary>
+public sealed record ModMetaIni(
+    int ModId, string? Version, string? NewestVersion, string? IgnoredVersion, string? LastNexusUpdate);
+
+public static class Mo2ModMeta
+{
+    /// <summary>Read one mod's meta.ini update-cache fields, or null if the file can't be read. A missing/blank field
+    /// reads as null (never throws — the caller keeps going over the rest of the mods folder).</summary>
+    public static ModMetaIni? Read(string metaIniPath)
+    {
+        string[] lines;
+        try { lines = File.ReadAllLines(metaIniPath); }
+        catch { return null; }
+
+        var modidRaw = Clean(FindValue(lines, "modid"));
+        int modId = int.TryParse(modidRaw, out var id) && id > 0 ? id : 0;
+        return new ModMetaIni(
+            modId,
+            Clean(FindValue(lines, "version")),
+            Clean(FindValue(lines, "newestVersion")),
+            Clean(FindValue(lines, "ignoredVersion")),
+            Clean(FindValue(lines, "lastNexusUpdate")));
+    }
+
+    /// <summary>First <c>key=</c> line's raw value, key matched case-insensitively and EXACTLY (so "modid" never matches
+    /// the [installedFiles] "1\modid"). Tolerates whitespace around '='. Null if the key isn't present.</summary>
+    static string? FindValue(string[] lines, string key)
+    {
+        foreach (var raw in lines)
+        {
+            var line = raw.TrimStart();
+            int eq = line.IndexOf('=');
+            if (eq < 0) continue;
+            if (line.AsSpan(0, eq).TrimEnd().Equals(key, StringComparison.OrdinalIgnoreCase))
+                return line[(eq + 1)..];
+        }
+        return null;
+    }
+
+    /// <summary>Clean a QSettings value: strip an <c>@ByteArray(...)</c> wrapper, treat <c>@Invalid()</c> as unset,
+    /// unescape doubled backslashes, and strip a surrounding pair of double quotes. Empty ⇒ null.</summary>
+    static string? Clean(string? raw)
+    {
+        if (raw is null) return null;
+        var v = raw.Trim();
+        if (v.Length == 0 || v.Equals("@Invalid()", StringComparison.OrdinalIgnoreCase)) return null;
+        const string wrap = "@ByteArray(";
+        if (v.StartsWith(wrap, StringComparison.Ordinal) && v.EndsWith(")", StringComparison.Ordinal))
+            v = v[wrap.Length..^1];
+        if (v.Length >= 2 && v[0] == '"' && v[^1] == '"') v = v[1..^1];
+        v = v.Replace(@"\\", @"\").Trim();
+        return v.Length == 0 ? null : v;
+    }
+}

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -99,6 +99,9 @@ public static class CiAll
         // the honest-degrade paths (real-PE Read → NotSkse; non-PE / missing → Unreadable, never a throw).
         ("skse-reader-guard", SkseReaderProbe.RunGuard),
         ("mo2instance-probe", Mo2InstanceProbe.RunProbe),
+        // meta.ini Nexus-update-cache parse (Tier 0 PR review fold): the QSettings quirks + exact-key vs [installedFiles]
+        // 1\modid, the fiddliest OFFLINE logic behind housecarl_update_status — locked with synthetic fixtures.
+        ("mo2-modmeta-guard", Mo2ModMetaProbe.RunGuard),
         ("atomic-commit-guard", AtomicCommitProbe.RunGuard),
         ("place-asset-guard", PlaceAssetProbe.RunGuard),
         // NIF layer Wave 1: NifService.Inspect decodes an authored SE mesh's N2-whitelist values (version, census, node

--- a/src/housecarl-generator/Mo2ModMetaProbe.cs
+++ b/src/housecarl-generator/Mo2ModMetaProbe.cs
@@ -1,0 +1,81 @@
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// Mo2ModMeta parser guard (Nexus Tier 0 PR review fold). The meta.ini Nexus-update-cache reader is pure, offline, and
+/// deterministic with the fiddliest logic in the capability PR — the QSettings quirks (@ByteArray/@Invalid/quotes/doubled
+/// backslash) plus the exact-key match that keeps [General]'s modid from being shadowed by [installedFiles]'s 1\modid —
+/// so it earns a cheap CI guard. Writes synthetic meta.ini files to temp and asserts every field + quirk. Self-contained;
+/// no game data, no corpus.
+/// </summary>
+internal static class Mo2ModMetaProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" mo2-modmeta guard — meta.ini Nexus update-cache parse");
+        Console.WriteLine("================================================================");
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        var dir = Path.Combine(Path.GetTempPath(), "hc-modmeta-guard-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            // A — a standard Nexus meta.ini: all fields, whitespace around '=', and an [installedFiles] section AFTER
+            //     [General] whose 1\modid must NOT be read as the mod's modid (exact-key match).
+            var a = Write(dir, "a.ini",
+                "[General]",
+                "gameName=SkyrimSE",
+                "modid=12604",
+                "version = 6.9",
+                "newestVersion=6.11",
+                "ignoredVersion=6.10",
+                "lastNexusUpdate=1778020881",
+                "[installedFiles]",
+                "1\\modid=99999",
+                "1\\fileid=749043");
+            var ma = Mo2ModMeta.Read(a);
+            Check(ma is not null, "A: standard meta.ini reads");
+            Check(ma!.ModId == 12604, "A: modid = 12604 (NOT the [installedFiles] 99999)");
+            Check(ma.Version == "6.9", "A: version tolerates whitespace-around-= → '6.9'");
+            Check(ma.NewestVersion == "6.11", "A: newestVersion = 6.11");
+            Check(ma.IgnoredVersion == "6.10", "A: ignoredVersion = 6.10");
+            Check(ma.LastNexusUpdate == "1778020881", "A: lastNexusUpdate raw unix seconds");
+
+            // B — QSettings quirks: @ByteArray wrap, @Invalid unset, surrounding quotes, doubled backslash.
+            var b = Write(dir, "b.ini",
+                "[General]",
+                "modid=@ByteArray(266)",
+                "version=\"5.2SE\"",
+                "newestVersion=@Invalid()",
+                "ignoredVersion=a\\\\b");          // literal a\\b in the file → a\b after unescape
+            var mb = Mo2ModMeta.Read(b);
+            Check(mb!.ModId == 266, "B: @ByteArray(266) → 266");
+            Check(mb.Version == "5.2SE", "B: surrounding quotes stripped → 5.2SE");
+            Check(mb.NewestVersion is null, "B: @Invalid() → null");
+            Check(mb.IgnoredVersion == "a\\b", "B: doubled backslash unescaped → a\\b");
+
+            // C — no/invalid modid → ModId 0; absent fields → null (still returns a record, never throws).
+            var c = Write(dir, "c.ini", "[General]", "version=1.0", "modid=notanumber");
+            var mc = Mo2ModMeta.Read(c);
+            Check(mc is not null && mc.ModId == 0, "C: non-integer modid → 0");
+            Check(mc!.NewestVersion is null && mc.IgnoredVersion is null && mc.LastNexusUpdate is null, "C: absent fields → null");
+
+            // D — a file that doesn't exist → null, never a throw (the caller keeps walking the mods folder).
+            Check(Mo2ModMeta.Read(Path.Combine(dir, "does-not-exist.ini")) is null, "D: missing file → null, no throw");
+        }
+        finally { try { Directory.Delete(dir, true); } catch { } }
+
+        Console.WriteLine(fail == 0 ? "[mo2-modmeta-guard] PASS — meta.ini parse holds." : $"[mo2-modmeta-guard] FAIL ({fail})");
+        return fail;
+    }
+
+    static string Write(string dir, string name, params string[] lines)
+    {
+        var p = Path.Combine(dir, name);
+        File.WriteAllLines(p, lines);
+        return p;
+    }
+}

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1014,6 +1014,58 @@ public sealed class LoadOrderService : IDisposable
             comp, warnings, view.PluginCount, _maxPlugins, profileChanged, profileDir, profileName, instanceDir, view.ExcludedPlugins);
     }
 
+    /// <summary>Read MO2's OWN local Nexus update cache — the modid / version / newestVersion / ignoredVersion /
+    /// lastNexusUpdate fields in every managed mod's meta.ini — with NO network (MO2 already paid the API cost). The
+    /// cheap local pre-filter for update triage: it names which mods MO2 already learned a newer version for, plus the
+    /// raw fields so the caller can verify online. Enabled/disabled comes from the ACTIVE profile. Config-gated and uses
+    /// the same lazy path derivation as the other reads; a missing mods folder is NAMED, never a silent empty (Q3).
+    /// Only Nexus-linked mods (a real modid) become entries; hand-installed mods / separators are counted, not listed.</summary>
+    public UpdateCacheData UpdateCache()
+    {
+        string modsDir, profileDir; string? instanceDir;
+        lock (_gate)
+        {
+            if (!_configured) throw NotConfigured();               // fresh install → the tool surfaces the trained prompt
+            EnsurePathsDerived();                                  // instance mode: derive _modsDir/_profileDir from the ini (throws Q3 if unusable)
+            modsDir = _modsDir; profileDir = _profileDir; instanceDir = _instanceDir;
+        }
+
+        if (string.IsNullOrEmpty(modsDir) || !Directory.Exists(modsDir))
+            return new UpdateCacheData(modsDir, instanceDir, Array.Empty<ModUpdateEntry>(), new[] { $"the mods folder is missing: '{modsDir}'" }, 0);
+
+        // Enabled/disabled from the active profile (cheap text read, OUTSIDE the gate; explicit-paths mode may have no
+        // profile → every mod's state is 'unknown', which the render states rather than guessing).
+        var enabled = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var disabled = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (!string.IsNullOrEmpty(profileDir) && Directory.Exists(profileDir))
+        {
+            var comp = Mo2LoadOrder.ReadComposition(profileDir);
+            foreach (var e in comp.EnabledMods) enabled.Add(e);
+            foreach (var d in comp.DisabledMods) disabled.Add(d);
+        }
+
+        IEnumerable<string> dirs;
+        try { dirs = Directory.EnumerateDirectories(modsDir); }
+        catch (Exception ex)
+        { return new UpdateCacheData(modsDir, instanceDir, Array.Empty<ModUpdateEntry>(), new[] { $"cannot list the mods folder '{modsDir}': {ex.Message}" }, 0); }
+
+        var entries = new List<ModUpdateEntry>();
+        int untracked = 0;
+        foreach (var dir in dirs)
+        {
+            var folder = Path.GetFileName(dir);
+            var metaPath = Path.Combine(dir, "meta.ini");
+            if (!File.Exists(metaPath)) { untracked++; continue; }     // separators / hand-installed mods carry no meta.ini
+            var meta = Mo2ModMeta.Read(metaPath);
+            if (meta is null || meta.ModId == 0) { untracked++; continue; }   // not a Nexus-linked mod → not update-checkable
+            bool? state = enabled.Contains(folder) ? true : disabled.Contains(folder) ? false : (bool?)null;
+            entries.Add(new ModUpdateEntry(
+                folder, state, meta.ModId, meta.Version, meta.NewestVersion, meta.IgnoredVersion, meta.LastNexusUpdate));
+        }
+        entries.Sort((a, b) => string.Compare(a.Folder, b.Folder, StringComparison.OrdinalIgnoreCase));
+        return new UpdateCacheData(modsDir, instanceDir, entries, Array.Empty<string>(), untracked);
+    }
+
     /// <summary>Inspect a NAMED profile's enabled/disabled composition WITHOUT switching to it (9.2: "can't inspect an
     /// inactive profile") — INSTANCE MODE ONLY. The profiles root is the PARENT of the active profile's dir, so MO2's
     /// base_directory redirect is honored by construction (the active ProfileDir already incorporates it) and a stale
@@ -4175,6 +4227,24 @@ public sealed record LoadOrderStatusData(
     string ProfileName,         // the ACTIVE profile (instance mode: MO2's selected_profile; explicit: the dir name) — captured under the gate, not re-derived at render
     string? InstanceDir,        // the resolved MO2 instance folder houseCARL is pointed at; null ⇒ explicit-paths / unconfigured mode
     IReadOnlyDictionary<string, string> ExcludedPlugins);
+
+/// <summary>The data behind housecarl_update_status: MO2's own local Nexus update cache read from meta.ini, with no
+/// network. <see cref="Entries"/> is one row per Nexus-linked mod (installed vs newest version, modid, enabled state);
+/// <see cref="UntrackedCount"/> is how many mod folders were skipped as not Nexus-linked (no meta.ini or no modid).
+/// <see cref="Problems"/> carries any Q3 read faults (e.g. a missing mods folder), never a silent empty.</summary>
+public sealed record UpdateCacheData(
+    string ModsDir,
+    string? InstanceDir,
+    IReadOnlyList<ModUpdateEntry> Entries,
+    IReadOnlyList<string> Problems,
+    int UntrackedCount);
+
+/// <summary>One Nexus-linked mod's update-cache row. <see cref="Newest"/> empty ⇒ MO2 never learned a newer version.
+/// MO2's own "update available" rule: <see cref="Newest"/> is set, non-empty, != <see cref="Installed"/>, and !=
+/// <see cref="Ignored"/>. <see cref="Enabled"/> is null when the mod isn't in the active profile (state unknown).
+/// <see cref="LastUpdate"/> is unix-seconds of MO2's last Nexus check (staleness signal).</summary>
+public sealed record ModUpdateEntry(
+    string Folder, bool? Enabled, int ModId, string? Installed, string? Newest, string? Ignored, string? LastUpdate);
 
 /// <summary>The result of <see cref="LoadOrderService.NamedProfileComposition"/> — the profiles affordance behind
 /// housecarl_load_order_status' profile= param. <see cref="InstanceMode"/> is false in explicit-paths mode (no profiles

--- a/src/housecarl-mcp/NexusClient.cs
+++ b/src/housecarl-mcp/NexusClient.cs
@@ -113,6 +113,87 @@ public sealed class NexusClient
             Bool(m, "directDownloadEnabled"), reqs, files));
     }
 
+    /// <summary>Batch "is each of these mods behind?" — for a list of (modId, installedVersion) pairs, resolve each mod's
+    /// name + newest MAIN file (the accurate version of record; a mod's version HEADER can lag its newest file) in as few
+    /// requests as possible. One combined query PER CHUNK: an OR-batched <c>mods()</c> for names/headers + one aliased
+    /// <c>modFiles()</c> per mod for the newest MAIN. modIds are integers (the tool parses them), so inlining them in the
+    /// query text is injection-safe — no user STRING is concatenated in, and the installed version is compared LOCALLY,
+    /// never sent to Nexus. A chunk that fails marks only its own mods Verdict=Error (with the reason) instead of sinking
+    /// the whole batch; the call fails loud only if EVERY chunk failed (Q3).</summary>
+    public async Task<(bool ok, string? error, IReadOnlyList<NexusUpdateStatus> results)> CheckUpdatesAsync(
+        IReadOnlyList<(int modId, string? installed)> mods, CancellationToken ct)
+    {
+        // Dedupe by modId (keep the first installed), preserving order — a duplicate alias would collide in the query.
+        var seen = new HashSet<int>();
+        var ordered = new List<(int modId, string? installed)>();
+        foreach (var m in mods) if (m.modId > 0 && seen.Add(m.modId)) ordered.Add(m);
+        if (ordered.Count == 0) return (false, "no valid mod ids to check.", Array.Empty<NexusUpdateStatus>());
+
+        const int ChunkSize = 25;   // OR-branches + modFiles aliases per request; conservative vs an unknown complexity cap
+        var results = new List<NexusUpdateStatus>(ordered.Count);
+        string? firstError = null;
+
+        for (int i = 0; i < ordered.Count; i += ChunkSize)
+        {
+            var chunk = ordered.Skip(i).Take(ChunkSize).ToList();
+            var g = SkyrimSeGameId;
+            var branches = string.Join(",", chunk.Select(c =>
+                $"{{gameId:{{value:\"{g}\",op:EQUALS}},modId:{{value:\"{c.modId}\",op:EQUALS}}}}"));
+            var aliases = string.Join(" ", chunk.Select(c =>
+                $"f{c.modId}:modFiles(modId:\"{c.modId}\",gameId:\"{g}\"){{ version category date }}"));
+            var query = $"query{{ mods(filter:{{op:OR, filter:[{branches}]}}){{ nodes{{ modId name version }} }} {aliases} }}";
+
+            var (ok, error, data) = await PostAsync(query, new { }, ct);
+            if (!ok)
+            {
+                firstError ??= error;
+                foreach (var c in chunk)
+                    results.Add(new NexusUpdateStatus(c.modId, false, null, null, null, 0, c.installed, UpdateVerdict.Error, error));
+                continue;
+            }
+
+            var nodeById = new Dictionary<int, (string? name, string? version)>();
+            if (data.TryGetProperty("mods", out var mm) && mm.ValueKind == JsonValueKind.Object
+                && mm.TryGetProperty("nodes", out var nodes) && nodes.ValueKind == JsonValueKind.Array)
+                foreach (var n in nodes.EnumerateArray())
+                    nodeById[Int(n, "modId")] = (Str(n, "name"), Str(n, "version"));
+
+            foreach (var c in chunk)
+            {
+                bool found = nodeById.TryGetValue(c.modId, out var meta);
+                var (mainVer, mainDate) = NewestMainFromAlias(data, $"f{c.modId}");
+                UpdateVerdict verdict =
+                    !found                                     ? UpdateVerdict.NotFound :
+                    mainVer is null                            ? UpdateVerdict.NoMainFile :
+                    string.IsNullOrWhiteSpace(c.installed)     ? UpdateVerdict.LatestOnly :
+                    string.Equals(c.installed.Trim(), mainVer.Trim(), StringComparison.OrdinalIgnoreCase)
+                                                               ? UpdateVerdict.Current : UpdateVerdict.Differs;
+                results.Add(new NexusUpdateStatus(
+                    c.modId, found, meta.name, meta.version, mainVer, mainDate, c.installed, verdict));
+            }
+        }
+
+        // Partial failures ride as Error rows; only an all-failed batch fails the call loud (Q3 — never a silent empty).
+        if (firstError is not null && results.All(r => r.Verdict == UpdateVerdict.Error))
+            return (false, firstError, Array.Empty<NexusUpdateStatus>());
+        return (true, null, results);
+    }
+
+    /// <summary>Newest MAIN file (version + unix-seconds date) from an aliased <c>f&lt;modId&gt;</c> modFiles array in a
+    /// batch response; (null, 0) when the mod has no MAIN file. The MAIN file is the accurate version of record.</summary>
+    static (string? version, long date) NewestMainFromAlias(JsonElement data, string alias)
+    {
+        if (!data.TryGetProperty(alias, out var arr) || arr.ValueKind != JsonValueKind.Array) return (null, 0);
+        string? bestVer = null; long bestDate = 0;
+        foreach (var f in arr.EnumerateArray())
+        {
+            if (Str(f, "category") != "MAIN") continue;
+            var d = Long(f, "date");
+            if (bestVer is null || d > bestDate) { bestVer = Str(f, "version") ?? "?"; bestDate = d; }
+        }
+        return (bestVer, bestDate);
+    }
+
     // ──────────────────────────────────────────────────────────────────────────────────────────────────────────
     //  Core POST — the ONE place an exception can come from a Nexus call, so the ONE place Q3 turns every failure into
     //  a returned message. Returns the GraphQL `data` element (cloned to outlive the JsonDocument) on success.
@@ -240,3 +321,17 @@ public sealed record NexusModDetail(
     int ModId, string Name, string? Version, string? Summary, string? Description, string? Author, string Category,
     int Endorsements, int Downloads, string? UpdatedAt, string? CreatedAt, bool AdultContent, string Status,
     bool DirectDownloadEnabled, IReadOnlyList<NexusRequirement> NexusRequirements, IReadOnlyList<NexusFile> Files);
+
+/// <summary>The verdict for one mod in a batch update check. <see cref="Differs"/> deliberately does NOT assert a
+/// direction (behind vs ahead) — a freeform version string like '6.9' vs '6.11' isn't safely comparable, so the tool
+/// reports both versions and lets the reader (or the triage skill) judge; asserting "you're behind" could be wrong when
+/// the user is on a hotfix. <see cref="NoMainFile"/> / <see cref="NotFound"/> / <see cref="Error"/> are the Q3 honest
+/// "couldn't decide" states, never silently folded into "current".</summary>
+public enum UpdateVerdict { NotFound, NoMainFile, Current, Differs, LatestOnly, Error }
+
+/// <summary>One mod's batch update-check result. <paramref name="LatestMainVersion"/>/<paramref name="LatestMainDate"/>
+/// are the newest MAIN file (the accurate version of record); <paramref name="HeaderVersion"/> is the mod's version
+/// header (which can lag). <paramref name="Note"/> carries the failure reason when <paramref name="Verdict"/> is Error.</summary>
+public sealed record NexusUpdateStatus(
+    int ModId, bool Found, string? Name, string? HeaderVersion,
+    string? LatestMainVersion, long LatestMainDate, string? Installed, UpdateVerdict Verdict, string? Note = null);

--- a/src/housecarl-mcp/NexusClient.cs
+++ b/src/housecarl-mcp/NexusClient.cs
@@ -141,7 +141,10 @@ public sealed class NexusClient
                 $"{{gameId:{{value:\"{g}\",op:EQUALS}},modId:{{value:\"{c.modId}\",op:EQUALS}}}}"));
             var aliases = string.Join(" ", chunk.Select(c =>
                 $"f{c.modId}:modFiles(modId:\"{c.modId}\",gameId:\"{g}\"){{ version category date }}"));
-            var query = $"query{{ mods(filter:{{op:OR, filter:[{branches}]}}){{ nodes{{ modId name version }} }} {aliases} }}";
+            // count MUST be >= the chunk size: the mods field defaults to a 20-item page, so without it any chunk of 21+
+            // silently drops the overflow from nodes — and the verdict path reads an absent mod as NotFound, a confidently
+            // WRONG answer at the tool's intended scale (live-proven: 21 matches → 20 nodes without count, 21 with).
+            var query = $"query{{ mods(count:{chunk.Count}, filter:{{op:OR, filter:[{branches}]}}){{ nodes{{ modId name version }} }} {aliases} }}";
 
             var (ok, error, data) = await PostAsync(query, new { }, ct);
             if (!ok)

--- a/src/housecarl-mcp/NexusClient.cs
+++ b/src/housecarl-mcp/NexusClient.cs
@@ -104,7 +104,7 @@ public sealed class NexusClient
             foreach (var f in mf.EnumerateArray())
                 files.Add(new NexusFile(
                     Int(f, "fileId"), Str(f, "name") ?? "", Str(f, "version"),
-                    Str(f, "category") ?? "", Long(f, "date"), Str(f, "description")));
+                    Str(f, "category") ?? "", Long(f, "date"), Str(f, "description"), StrList(f, "changelogText")));
 
         return (true, null, new NexusModDetail(
             Int(m, "modId"), Str(m, "name") ?? "", Str(m, "version"), Str(m, "summary"), Str(m, "description"),
@@ -183,6 +183,14 @@ public sealed class NexusClient
         return 0;
     }
     static bool Bool(JsonElement e, string p) => e.TryGetProperty(p, out var v) && v.ValueKind == JsonValueKind.True;
+    static IReadOnlyList<string> StrList(JsonElement e, string p)
+    {
+        if (!e.TryGetProperty(p, out var v) || v.ValueKind != JsonValueKind.Array) return Array.Empty<string>();
+        var list = new List<string>();
+        foreach (var x in v.EnumerateArray())
+            if (x.ValueKind == JsonValueKind.String) { var s = x.GetString(); if (!string.IsNullOrWhiteSpace(s)) list.Add(s!); }
+        return list;
+    }
 
     // ── GraphQL documents (variable-based ⇒ user input is never string-concatenated into the query) ──
     const string SearchQuery =
@@ -201,7 +209,7 @@ public sealed class NexusClient
               modRequirements { nexusRequirements { nodes { modId modName url notes externalRequirement } } }
             }
             modFiles(modId: $modId, gameId: $gameId) {
-              fileId name version category date description
+              fileId name version category date description changelogText
             }
           }";
 }
@@ -221,8 +229,10 @@ public sealed record NexusSearchResult(int TotalCount, IReadOnlyList<NexusSearch
 public sealed record NexusRequirement(string ModId, string ModName, string? Url, string? Notes, bool ExternalRequirement);
 
 /// <summary>One uploaded file of a mod. <paramref name="Category"/> is MAIN / OPTIONAL / OLD_VERSION / ARCHIVED / …;
-/// <paramref name="Date"/> is a unix-seconds timestamp.</summary>
-public sealed record NexusFile(int FileId, string Name, string? Version, string Category, long Date, string? Description);
+/// <paramref name="Date"/> is a unix-seconds timestamp. <paramref name="ChangelogText"/> is that file/version's changelog
+/// lines (empty when the author wrote none — the caller reports "unknown", never "no changes", per Q3).</summary>
+public sealed record NexusFile(
+    int FileId, string Name, string? Version, string Category, long Date, string? Description, IReadOnlyList<string> ChangelogText);
 
 /// <summary>Full detail for one mod plus its files. Note: <paramref name="Version"/> is the mod's version HEADER, which
 /// can lag the newest MAIN file — the accurate "latest version" is the most recent MAIN entry in <paramref name="Files"/>.</summary>

--- a/src/housecarl-mcp/NexusClient.cs
+++ b/src/housecarl-mcp/NexusClient.cs
@@ -194,6 +194,38 @@ public sealed class NexusClient
         return (bestVer, bestDate);
     }
 
+    /// <summary>Identify uploaded files by MD5 hash — bulk (v2 <c>fileHashes(md5s: [String!]!)</c>, keyless). For each
+    /// matched hash, return the mod (id + name), the file (name/version/category/size), and the game id (so a hash that
+    /// belongs to a NON-Skyrim-SE file is flagged, never mis-attributed — Q3). Hashes with no match simply don't appear
+    /// in the response; the tool maps them back to an explicit "no match". md5s go through a query VARIABLE (never
+    /// concatenated into the query text).</summary>
+    public async Task<(bool ok, string? error, IReadOnlyList<NexusFileHash> results)> IdentifyByHashAsync(
+        IReadOnlyList<string> md5s, CancellationToken ct)
+    {
+        var (ok, error, data) = await PostAsync(FileHashQuery, new { md5s }, ct);
+        if (!ok) return (false, error, Array.Empty<NexusFileHash>());
+
+        var list = new List<NexusFileHash>();
+        if (data.TryGetProperty("fileHashes", out var fh) && fh.ValueKind == JsonValueKind.Array)
+            foreach (var h in fh.EnumerateArray())
+            {
+                int modId = 0; string? modName = null, fileVer = null, fileCat = null;
+                if (h.TryGetProperty("modFile", out var mf) && mf.ValueKind == JsonValueKind.Object)
+                {
+                    modId = Int(mf, "modId"); fileVer = Str(mf, "version"); fileCat = Str(mf, "category");
+                    if (mf.TryGetProperty("mod", out var mod) && mod.ValueKind == JsonValueKind.Object)
+                    {
+                        if (modId == 0) modId = Int(mod, "modId");
+                        modName = Str(mod, "name");
+                    }
+                }
+                list.Add(new NexusFileHash(
+                    Str(h, "md5") ?? "", Str(h, "fileName") ?? "", Str(h, "fileType") ?? "",
+                    Long(h, "fileSize"), Int(h, "gameId"), Int(h, "modFileId"), modId, modName, fileVer, fileCat));
+            }
+        return (true, null, list);
+    }
+
     // ──────────────────────────────────────────────────────────────────────────────────────────────────────────
     //  Core POST — the ONE place an exception can come from a Nexus call, so the ONE place Q3 turns every failure into
     //  a returned message. Returns the GraphQL `data` element (cloned to outlive the JsonDocument) on success.
@@ -293,6 +325,14 @@ public sealed class NexusClient
               fileId name version category date description changelogText
             }
           }";
+
+    const string FileHashQuery =
+        @"query FileHashes($md5s: [String!]!) {
+            fileHashes(md5s: $md5s) {
+              md5 fileName fileType fileSize gameId modFileId
+              modFile { modId version category name mod { modId name } }
+            }
+          }";
 }
 
 // ── result shapes (records ⇒ immutable, value-equal; the tools render these to text) ──
@@ -335,3 +375,9 @@ public enum UpdateVerdict { NotFound, NoMainFile, Current, Differs, LatestOnly, 
 public sealed record NexusUpdateStatus(
     int ModId, bool Found, string? Name, string? HeaderVersion,
     string? LatestMainVersion, long LatestMainDate, string? Installed, UpdateVerdict Verdict, string? Note = null);
+
+/// <summary>One MD5-hash match: the Nexus file (name/type/size) and the mod it belongs to (id + name), plus the file's
+/// version + category and the <paramref name="GameId"/> — a match on a non-Skyrim-SE game is flagged, not mis-attributed.</summary>
+public sealed record NexusFileHash(
+    string Md5, string FileName, string FileType, long FileSize, int GameId, int ModFileId,
+    int ModId, string? ModName, string? FileVersion, string? FileCategory);

--- a/src/housecarl-mcp/NexusTools.cs
+++ b/src/housecarl-mcp/NexusTools.cs
@@ -65,6 +65,10 @@ public static class NexusTools
          "several KB. Pass files=true to list EVERY uploaded file (not just the newest MAIN) — each variant's name, " +
          "version, category, and date — the accurate way to pin the version of a specific FOMOD/modular variant (an " +
          "'SE' vs 'AE' main, an optional patch, a texture-size option) rather than the single newest-main summary. " +
+         "Pass changelog=true to read the mod's per-version CHANGELOG (what changed in each release); combine with " +
+         "since='<your installed version>' to show ONLY entries newer than what you have — the 'is this update worth " +
+         "installing' delta. A mod whose author wrote no changelog is reported UNKNOWN, never 'no changes', so a silent " +
+         "gap is never read as 'safe'. " +
          "READ-ONLY and needs an internet connection (local tools unaffected offline). Does NOT download or install — " +
          "use your mod manager's 'Mod Manager Download' for that. To find a mod by name first, use housecarl_nexus_search.")]
     public static Task<string> NexusMod(
@@ -83,6 +87,15 @@ public static class NexusTools
             "specific variant (e.g. which 'main' is the AE build, an optional add-on's version) — the fix for modular/FOMOD " +
             "mods where the single newest-main line isn't enough.")]
             bool files = false,
+        [Description("Optional. When true, include the mod's per-version CHANGELOG — each release's changelog lines, " +
+            "newest first. Default false. Versions whose author wrote no changelog are reported as UNKNOWN (never 'no " +
+            "changes'). Pair with since= to see only what's newer than your installed version.")]
+            bool changelog = false,
+        [Description("Optional. Your currently-installed version (e.g. '5.2SE', '6.9'). When changelog=true, limits the " +
+            "changelog to releases uploaded AFTER the file matching this version — the 'what changed since I installed it' " +
+            "delta. Matching is by upload DATE (robust), so if this exact version string isn't found among the files, the " +
+            "tool says so and shows the full changelog rather than guessing (Q3). Ignored unless changelog=true.")]
+            string? since = null,
         CancellationToken ct = default) => Guard.Tool("housecarl_nexus_mod", async () =>
     {
         var (modId, parseError) = ResolveModId(mod);
@@ -90,7 +103,7 @@ public static class NexusTools
 
         var (ok, error, detail) = await nexus.GetModAsync(modId, ct);
         if (!ok) return "error: " + error;
-        return Render.Mod(detail!, description, files);
+        return Render.Mod(detail!, description, files, changelog, since);
     }, ct);
 
     /// <summary>Map a friendly sort word to a ModsSort field name; null if unrecognised (the tool reports it — Q3).</summary>
@@ -182,7 +195,8 @@ static class Render
         return sb.ToString();
     }
 
-    public static string Mod(NexusModDetail m, bool includeDescription = false, bool includeFiles = false)
+    public static string Mod(NexusModDetail m, bool includeDescription = false, bool includeFiles = false,
+                             bool includeChangelog = false, string? since = null)
     {
         var sb = new StringBuilder();
         sb.Append(m.Name).Append("  [id ").Append(m.ModId).Append(']');
@@ -227,6 +241,11 @@ static class Render
         // version. GetModAsync already fetches the whole list; this just renders it.
         if (includeFiles) AppendFiles(sb, m.Files);
 
+        // Per-version changelog is opt-in. since= limits it to releases newer than the installed version — the update
+        // delta. Files with no changelog lines are reported UNKNOWN, never silently dropped (Q3 — a missing changelog
+        // must never read as "nothing changed / safe to skip").
+        if (includeChangelog) AppendChangelog(sb, m.Files, since);
+
         // Full description is opt-in (it can run several KB of BBCode/HTML). When asked, clean it to plain text; if the
         // page genuinely has none, SAY so rather than silently omitting (Q3 — an empty section reads as a missing one).
         if (includeDescription)
@@ -269,6 +288,62 @@ static class Render
             }
             sb.Append("\n  - ").Append(f.Name).Append("  v").Append(f.Version ?? "?")
               .Append("  (").Append(f.Date > 0 ? Day(f.Date) : "?").Append(')');
+            shown++;
+        }
+    }
+
+    /// <summary>The per-version changelog, newest release first. Each release's changelog can sit on any of its files
+    /// (a MAIN, an OLD_VERSION, an ARCHIVED copy), so fold the lines together per version and order by the newest upload
+    /// date in the group. <paramref name="since"/> deltas to releases AFTER the installed version's upload date — dates
+    /// are monotonic where freeform version strings ('5.2SE', '6.9') are not comparable, so date is the honest key. A
+    /// version with NO changelog lines is reported UNKNOWN, never omitted (Q3 — a missing changelog is not "no change").
+    /// The section is bounded with an explicit cut (Q3).</summary>
+    static void AppendChangelog(StringBuilder sb, IReadOnlyList<NexusFile> files, string? since)
+    {
+        var byVersion = new Dictionary<string, (long date, List<string> lines)>(StringComparer.OrdinalIgnoreCase);
+        var order = new List<string>();     // first-seen versions — a stable base order before the date sort
+        foreach (var f in files)
+        {
+            var v = f.Version?.Trim();
+            if (string.IsNullOrEmpty(v)) continue;   // a file with no version isn't a release
+            if (!byVersion.TryGetValue(v, out var agg)) { agg = (0L, new List<string>()); order.Add(v); }
+            if (f.Date > agg.date) agg.date = f.Date;
+            foreach (var line in f.ChangelogText) if (!agg.lines.Contains(line)) agg.lines.Add(line);
+            byVersion[v] = agg;
+        }
+
+        sb.Append("\n\n── changelog ──");
+        if (byVersion.Count == 0) { sb.Append("\n(this mod has no versioned files to read a changelog from.)"); return; }
+
+        var versions = order.OrderByDescending(v => byVersion[v].date).ToList();
+
+        // since= delta: keep only releases uploaded AFTER the installed version's file. If that version isn't among the
+        // uploads, say so and show the whole changelog — never silently guess a cutoff (Q3).
+        if (!string.IsNullOrWhiteSpace(since))
+        {
+            var key = since.Trim();
+            if (byVersion.TryGetValue(key, out var found))
+            {
+                var newer = versions.Where(v => byVersion[v].date > found.date).ToList();
+                if (newer.Count == 0) { sb.Append("\nyou're on v").Append(key).Append(" — no newer release on Nexus (you're current)."); return; }
+                sb.Append("\n(only releases newer than your v").Append(key).Append(")");
+                versions = newer;
+            }
+            else sb.Append("\nnote: no file at version '").Append(key)
+                    .Append("' among this mod's uploads — showing the full changelog rather than guessing a delta.");
+        }
+
+        const int Cap = 6000;
+        int shown = 0;
+        foreach (var v in versions)
+        {
+            if (sb.Length >= Cap) { sb.Append("\n  ... [").Append(versions.Count - shown).Append(" older release(s) omitted — narrow with since=, or open the page.]"); break; }
+            var (date, lines) = byVersion[v];
+            sb.Append("\n\nv").Append(v);
+            if (date > 0) sb.Append("  (").Append(Day(date)).Append(')');
+            sb.Append(':');
+            if (lines.Count == 0) sb.Append("\n  (no changelog for this version — UNKNOWN, not necessarily unchanged)");
+            else foreach (var line in lines) sb.Append("\n  - ").Append(OneLine(line, 300));
             shown++;
         }
     }

--- a/src/housecarl-mcp/NexusTools.cs
+++ b/src/housecarl-mcp/NexusTools.cs
@@ -371,12 +371,13 @@ static class Render
             "MAIN" => 0, "UPDATE" => 1, "OPTIONAL" => 2, "MISCELLANEOUS" => 3,
             "OLD_VERSION" => 5, "ARCHIVED" => 6, _ => 4,
         };
-        const int Cap = 6000;   // ≈ the description cap; bounds a pathological archived list
+        const int Cap = 6000;   // ≈ the description cap; bounds a pathological archived list. Measured as a per-SECTION
+        int start = sb.Length;  // delta, not total sb.Length — else files=true + changelog=true lets files starve the changelog.
         string? group = null;
         int shown = 0;
         foreach (var f in files.OrderBy(f => Order(f.Category)).ThenByDescending(f => f.Date))
         {
-            if (sb.Length >= Cap) { sb.Append("\n  ... [").Append(files.Count - shown).Append(" more file(s) omitted — raise the ask or open the page.]"); break; }
+            if (sb.Length - start >= Cap) { sb.Append("\n  ... [").Append(files.Count - shown).Append(" more file(s) omitted — raise the ask or open the page.]"); break; }
             if (!string.Equals(f.Category, group, StringComparison.Ordinal))
             {
                 group = f.Category;
@@ -537,10 +538,11 @@ static class Render
         }
 
         const int Cap = 6000;
+        int start = sb.Length;   // per-SECTION delta (see AppendFiles) — so a big file list can't blank the changelog
         int shown = 0;
         foreach (var v in versions)
         {
-            if (sb.Length >= Cap) { sb.Append("\n  ... [").Append(versions.Count - shown).Append(" older release(s) omitted — narrow with since=, or open the page.]"); break; }
+            if (sb.Length - start >= Cap) { sb.Append("\n  ... [").Append(versions.Count - shown).Append(" older release(s) omitted — narrow with since=, or open the page.]"); break; }
             var (date, lines) = byVersion[v];
             sb.Append("\n\nv").Append(v);
             if (date > 0) sb.Append("  (").Append(Day(date)).Append(')');

--- a/src/housecarl-mcp/NexusTools.cs
+++ b/src/housecarl-mcp/NexusTools.cs
@@ -159,6 +159,49 @@ public static class NexusTools
         return (pairs, bad);
     }
 
+    [McpServerTool(Name = "housecarl_nexus_identify", ReadOnly = true, Title = "Identify a file on Nexus by MD5"),
+     Description(
+         "Identify which Nexus mod (and which uploaded file) a file came from, by its MD5 hash — without a browser or an " +
+         "API key. Give one or more 32-char MD5 hashes; houseCARL returns, per hash, the matching mod (name + id) and the " +
+         "file's name/version/category/size — or 'no match' when no Nexus file has that hash (a hand-edited, repacked, or " +
+         "non-Nexus file). Matching is across ALL games, so a hash belonging to a non-Skyrim-SE file is FLAGGED as such " +
+         "rather than mis-attributed to a same-hash SSE mod (Q3). Use it to trace a mystery loose file back to its source " +
+         "mod. READ-ONLY, needs an internet connection. To get a file's MD5 first, hash it locally (e.g. PowerShell " +
+         "Get-FileHash -Algorithm MD5).")]
+    public static Task<string> NexusIdentify(
+        NexusClient nexus,
+        [Description("One or more MD5 hashes (32 hex characters each), separated by commas, spaces, or newlines. " +
+            "Case-insensitive. Non-hash junk is skipped and listed back to you.")]
+            string md5,
+        CancellationToken ct = default) => Guard.Tool("housecarl_nexus_identify", async () =>
+    {
+        var (hashes, bad) = ParseHashes(md5);
+        if (hashes.Count == 0)
+            return "error: no valid MD5 hashes found — each must be 32 hex characters."
+                 + (bad.Count > 0 ? " Unreadable: " + string.Join(", ", bad) : "");
+
+        var (ok, error, results) = await nexus.IdentifyByHashAsync(hashes, ct);
+        if (!ok) return "error: " + error;
+        return Render.Identify(hashes, results, bad);
+    }, ct);
+
+    /// <summary>Parse the identify input into normalized (lowercase) 32-hex MD5 hashes, de-duplicated, plus the tokens
+    /// that weren't valid hashes (surfaced back, never silently dropped — Q3).</summary>
+    static (List<string> hashes, List<string> bad) ParseHashes(string input)
+    {
+        var hashes = new List<string>();
+        var bad = new List<string>();
+        if (string.IsNullOrWhiteSpace(input)) return (hashes, bad);
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var raw in input.Split(new[] { ',', '\n', ';', '\r', ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var h = raw.Trim().ToLowerInvariant();
+            if (Regex.IsMatch(h, "^[0-9a-f]{32}$")) { if (seen.Add(h)) hashes.Add(h); }
+            else bad.Add(raw.Trim());
+        }
+        return (hashes, bad);
+    }
+
     /// <summary>Map a friendly sort word to a ModsSort field name; null if unrecognised (the tool reports it — Q3).</summary>
     static string? MapSort(string s) => s.Trim().ToLowerInvariant() switch
     {
@@ -343,6 +386,49 @@ static class Render
               .Append("  (").Append(f.Date > 0 ? Day(f.Date) : "?").Append(')');
             shown++;
         }
+    }
+
+    /// <summary>Render MD5-identify results: one block per REQUESTED hash (so a no-match is shown explicitly, not just
+    /// absent), each listing the matched mod + file, or a "no Nexus file matches" line. A match on a non-Skyrim-SE game
+    /// is flagged loud (Q3 — never silently attributed to a same-hash SSE mod). Unreadable tokens are listed at the end.</summary>
+    public static string Identify(IReadOnlyList<string> requested, IReadOnlyList<NexusFileHash> matches, IReadOnlyList<string> unreadable)
+    {
+        var byHash = matches.GroupBy(m => m.Md5, StringComparer.OrdinalIgnoreCase)
+                            .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.OrdinalIgnoreCase);
+        var sb = new StringBuilder();
+        sb.Append("identify — ").Append(requested.Count).Append(" hash(es):");
+        foreach (var h in requested)
+        {
+            sb.Append("\n\n").Append(h);
+            if (!byHash.TryGetValue(h, out var ms) || ms.Count == 0)
+            {
+                sb.Append("\n  no Nexus file matches this md5 — a hand-edited/repacked file, or not from Nexus.");
+                continue;
+            }
+            foreach (var m in ms)
+            {
+                if (m.GameId != NexusClient.SkyrimSeGameId)
+                    sb.Append("\n  [!] this hash matches a NON-Skyrim-SE file (Nexus game id ").Append(m.GameId)
+                      .Append(") — not part of your SSE load order:");
+                sb.Append("\n  ").Append(m.ModName ?? "?").Append("  [id ").Append(m.ModId).Append(']');
+                sb.Append("\n    file: ").Append(m.FileName);
+                if (!string.IsNullOrWhiteSpace(m.FileVersion)) sb.Append("  v").Append(m.FileVersion);
+                if (!string.IsNullOrWhiteSpace(m.FileCategory)) sb.Append("  [").Append(m.FileCategory).Append(']');
+                if (m.FileSize > 0) sb.Append("  ").Append(HumanSize(m.FileSize));
+                if (m.ModId > 0 && m.GameId == NexusClient.SkyrimSeGameId)
+                    sb.Append("\n    ").Append(ModUrlBase).Append(m.ModId);
+            }
+        }
+        if (unreadable.Count > 0) sb.Append("\n\nnot valid md5s (skipped): ").Append(string.Join(", ", unreadable));
+        return sb.ToString();
+    }
+
+    /// <summary>Bytes → a compact human size (B / KB / MB), one decimal.</summary>
+    static string HumanSize(long bytes)
+    {
+        if (bytes >= 1L << 20) return (bytes / (double)(1 << 20)).ToString("0.#") + " MB";
+        if (bytes >= 1L << 10) return (bytes / (double)(1 << 10)).ToString("0.#") + " KB";
+        return bytes + " B";
     }
 
     /// <summary>Render a batch update check: a one-line summary (how many differ / current / not-found / …) then the mods

--- a/src/housecarl-mcp/NexusTools.cs
+++ b/src/housecarl-mcp/NexusTools.cs
@@ -62,7 +62,10 @@ public static class NexusTools
          "version — the accurate 'latest version', because a mod's own version header can lag its newest file. " +
          "Pass description=true to ALSO get the mod's full page write-up (what it does, how it works, usage, " +
          "recommended INI settings, compatibility/conflict notes), cleaned of Nexus markup to plain text — off by default because it can run " +
-         "several KB. READ-ONLY and needs an internet connection (local tools unaffected offline). Does NOT download or install — " +
+         "several KB. Pass files=true to list EVERY uploaded file (not just the newest MAIN) — each variant's name, " +
+         "version, category, and date — the accurate way to pin the version of a specific FOMOD/modular variant (an " +
+         "'SE' vs 'AE' main, an optional patch, a texture-size option) rather than the single newest-main summary. " +
+         "READ-ONLY and needs an internet connection (local tools unaffected offline). Does NOT download or install — " +
          "use your mod manager's 'Mod Manager Download' for that. To find a mod by name first, use housecarl_nexus_search.")]
     public static Task<string> NexusMod(
         NexusClient nexus,
@@ -74,6 +77,12 @@ public static class NexusTools
             "requirements, and latest version only, because the full description can run several KB. Set true when you " +
             "need the detail, e.g. comparing two mods or understanding how one works.")]
             bool description = false,
+        [Description("Optional. When true, list ALL of the mod's uploaded files — every MAIN, UPDATE, OPTIONAL, " +
+            "MISCELLANEOUS, and archived/old file — with each one's name, version, category, and upload date, grouped by " +
+            "category. Default false: the lookup shows only the newest MAIN file. Set true to pin the version of a " +
+            "specific variant (e.g. which 'main' is the AE build, an optional add-on's version) — the fix for modular/FOMOD " +
+            "mods where the single newest-main line isn't enough.")]
+            bool files = false,
         CancellationToken ct = default) => Guard.Tool("housecarl_nexus_mod", async () =>
     {
         var (modId, parseError) = ResolveModId(mod);
@@ -81,7 +90,7 @@ public static class NexusTools
 
         var (ok, error, detail) = await nexus.GetModAsync(modId, ct);
         if (!ok) return "error: " + error;
-        return Render.Mod(detail!, description);
+        return Render.Mod(detail!, description, files);
     }, ct);
 
     /// <summary>Map a friendly sort word to a ModsSort field name; null if unrecognised (the tool reports it — Q3).</summary>
@@ -173,7 +182,7 @@ static class Render
         return sb.ToString();
     }
 
-    public static string Mod(NexusModDetail m, bool includeDescription = false)
+    public static string Mod(NexusModDetail m, bool includeDescription = false, bool includeFiles = false)
     {
         var sb = new StringBuilder();
         sb.Append(m.Name).Append("  [id ").Append(m.ModId).Append(']');
@@ -213,6 +222,11 @@ static class Render
         }
         else sb.Append("\n\nno Nexus requirements listed.");
 
+        // Full file list is opt-in (a big mod has dozens of archived files). When asked, list EVERY file grouped by
+        // category — the fix for modular/FOMOD mods where the single newest-MAIN line can't pin a specific variant's
+        // version. GetModAsync already fetches the whole list; this just renders it.
+        if (includeFiles) AppendFiles(sb, m.Files);
+
         // Full description is opt-in (it can run several KB of BBCode/HTML). When asked, clean it to plain text; if the
         // page genuinely has none, SAY so rather than silently omitting (Q3 — an empty section reads as a missing one).
         if (includeDescription)
@@ -224,6 +238,39 @@ static class Render
 
         sb.Append("\n\n").Append(ModUrlBase).Append(m.ModId);
         return sb.ToString();
+    }
+
+    /// <summary>List every uploaded file, grouped by category in a sensible order (MAIN → UPDATE → OPTIONAL →
+    /// MISCELLANEOUS → other → OLD_VERSION → ARCHIVED), newest-first within each group, as "name  vX  (date)". The whole
+    /// section is bounded (Q3 — a mod with hundreds of archived files can't dominate the response; an over-length cut is
+    /// explicit, never silent). This is the per-variant version detail the newest-MAIN summary can't give.</summary>
+    static void AppendFiles(StringBuilder sb, IReadOnlyList<NexusFile> files)
+    {
+        sb.Append("\n\n── files (").Append(files.Count).Append(") ──");
+        if (files.Count == 0) { sb.Append("\n(this mod has no uploaded files listed.)"); return; }
+
+        // Display order for the categories Nexus emits; an unrecognised category sorts between MISCELLANEOUS and
+        // OLD_VERSION (4) rather than being dropped — a new category type is surfaced, never silently hidden (Q3).
+        static int Order(string c) => c switch
+        {
+            "MAIN" => 0, "UPDATE" => 1, "OPTIONAL" => 2, "MISCELLANEOUS" => 3,
+            "OLD_VERSION" => 5, "ARCHIVED" => 6, _ => 4,
+        };
+        const int Cap = 6000;   // ≈ the description cap; bounds a pathological archived list
+        string? group = null;
+        int shown = 0;
+        foreach (var f in files.OrderBy(f => Order(f.Category)).ThenByDescending(f => f.Date))
+        {
+            if (sb.Length >= Cap) { sb.Append("\n  ... [").Append(files.Count - shown).Append(" more file(s) omitted — raise the ask or open the page.]"); break; }
+            if (!string.Equals(f.Category, group, StringComparison.Ordinal))
+            {
+                group = f.Category;
+                sb.Append("\n ").Append(string.IsNullOrWhiteSpace(group) ? "(uncategorised)" : group).Append(':');
+            }
+            sb.Append("\n  - ").Append(f.Name).Append("  v").Append(f.Version ?? "?")
+              .Append("  (").Append(f.Date > 0 ? Day(f.Date) : "?").Append(')');
+            shown++;
+        }
     }
 
     /// <summary>Substring(0, n) that never splits a surrogate pair: an astral char (emoji, CJK extension B+, …) is two

--- a/src/housecarl-mcp/NexusTools.cs
+++ b/src/housecarl-mcp/NexusTools.cs
@@ -106,6 +106,59 @@ public static class NexusTools
         return Render.Mod(detail!, description, files, changelog, since);
     }, ct);
 
+    [McpServerTool(Name = "housecarl_nexus_check_updates", ReadOnly = true, Title = "Batch-check Nexus mods for updates"),
+     Description(
+         "Check MANY Skyrim Special Edition mods for available updates in ONE call — without a browser and without an API " +
+         "key. Give a list of mods (each a numeric Nexus mod id, optionally with your installed version); houseCARL " +
+         "resolves each mod's newest MAIN file — the accurate 'latest version', because a mod's version header can lag its " +
+         "newest file — and reports per mod: CURRENT, DIFFERS (your version ≠ the newest MAIN; both are shown and the " +
+         "direction is NOT asserted, since freeform version strings aren't safely comparable), no-main-file, or not-found " +
+         "(wrong id, or an LE/other-game mod). Batched into few requests (dozens of mods per call). READ-ONLY, needs an " +
+         "internet connection (local tools work offline). Does NOT download or update anything — it is a REPORT. Build the " +
+         "list cheaply with housecarl_update_status (reads MO2's own local update cache, no network), then use " +
+         "housecarl_nexus_mod changelog=true on anything that DIFFERS to see what actually changed.")]
+    public static Task<string> NexusCheckUpdates(
+        NexusClient nexus,
+        [Description("The mods to check — one entry per mod, separated by commas or newlines. Each entry is a numeric " +
+            "Nexus mod id, optionally followed by your installed version after '=' (or a space or ':'): e.g. " +
+            "'12604=6.9, 266=4.3.8a, 3863'. An entry with no version is reported with its latest version only (no " +
+            "current/behind verdict). Non-numeric junk is skipped and listed back to you.")]
+            string mods,
+        CancellationToken ct = default) => Guard.Tool("housecarl_nexus_check_updates", async () =>
+    {
+        var (pairs, bad) = ParseUpdatePairs(mods);
+        if (pairs.Count == 0)
+            return "error: no mod ids found. Pass entries like '12604=6.9, 266=4.3.8a' (id, optional =installed version), "
+                 + "comma/newline separated." + (bad.Count > 0 ? " Unreadable: " + string.Join(", ", bad) : "");
+
+        var (ok, error, results) = await nexus.CheckUpdatesAsync(pairs, ct);
+        if (!ok) return "error: " + error;
+        return Render.Updates(results, bad);
+    }, ct);
+
+    /// <summary>Parse the check-updates input — comma/newline/semicolon-separated entries, each a numeric mod id with an
+    /// OPTIONAL installed version after '=', ':' or whitespace (e.g. '12604=6.9', '266 4.3.8a', '3863'). Returns the
+    /// (modId, installedVersion|null) pairs plus the tokens it couldn't read (surfaced back, never silently dropped — Q3).</summary>
+    static (List<(int modId, string? installed)> pairs, List<string> bad) ParseUpdatePairs(string input)
+    {
+        var pairs = new List<(int, string?)>();
+        var bad = new List<string>();
+        if (string.IsNullOrWhiteSpace(input)) return (pairs, bad);
+        foreach (var raw in input.Split(new[] { ',', '\n', ';', '\r' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var entry = raw.Trim();
+            if (entry.Length == 0) continue;
+            var m = Regex.Match(entry, @"^(\d+)\s*[:=\s]?\s*(.*)$");
+            if (m.Success && int.TryParse(m.Groups[1].Value, out var id) && id > 0)
+            {
+                var ver = m.Groups[2].Value.Trim();
+                pairs.Add((id, ver.Length == 0 ? null : ver));
+            }
+            else bad.Add(entry);
+        }
+        return (pairs, bad);
+    }
+
     /// <summary>Map a friendly sort word to a ModsSort field name; null if unrecognised (the tool reports it — Q3).</summary>
     static string? MapSort(string s) => s.Trim().ToLowerInvariant() switch
     {
@@ -289,6 +342,70 @@ static class Render
             sb.Append("\n  - ").Append(f.Name).Append("  v").Append(f.Version ?? "?")
               .Append("  (").Append(f.Date > 0 ? Day(f.Date) : "?").Append(')');
             shown++;
+        }
+    }
+
+    /// <summary>Render a batch update check: a one-line summary (how many differ / current / not-found / …) then the mods
+    /// grouped by verdict, ACTIONABLE first (differ → latest-only → no-main → current → not-found → error). Unreadable
+    /// input tokens are listed back at the end (Q3 — a skipped entry is never silently dropped).</summary>
+    public static string Updates(IReadOnlyList<NexusUpdateStatus> results, IReadOnlyList<string> unreadable)
+    {
+        var sb = new StringBuilder();
+        int differ = results.Count(r => r.Verdict == UpdateVerdict.Differs);
+        int current = results.Count(r => r.Verdict == UpdateVerdict.Current);
+        int latest = results.Count(r => r.Verdict == UpdateVerdict.LatestOnly);
+        int noMain = results.Count(r => r.Verdict == UpdateVerdict.NoMainFile);
+        int notFound = results.Count(r => r.Verdict == UpdateVerdict.NotFound);
+        int errored = results.Count(r => r.Verdict == UpdateVerdict.Error);
+
+        sb.Append("update check — ").Append(results.Count).Append(" mod(s): ")
+          .Append(differ).Append(" differ · ").Append(current).Append(" current · ")
+          .Append(latest).Append(" latest-only · ").Append(noMain).Append(" no-main · ")
+          .Append(notFound).Append(" not-found");
+        if (errored > 0) sb.Append(" · ").Append(errored).Append(" error");
+
+        AppendUpdateGroup(sb, "DIFFER — installed ≠ newest MAIN (check the changelog before updating)", results, UpdateVerdict.Differs);
+        AppendUpdateGroup(sb, "latest version (no installed version was given to compare)", results, UpdateVerdict.LatestOnly);
+        AppendUpdateGroup(sb, "no MAIN file — the header version may lag, so UNKNOWN", results, UpdateVerdict.NoMainFile);
+        AppendUpdateGroup(sb, "current", results, UpdateVerdict.Current);
+        AppendUpdateGroup(sb, "not found on Skyrim SE (wrong id, or an LE/other-game mod)", results, UpdateVerdict.NotFound);
+        AppendUpdateGroup(sb, "check FAILED (surface, don't assume current)", results, UpdateVerdict.Error);
+
+        if (unreadable.Count > 0)
+            sb.Append("\n\nunreadable entries (skipped): ").Append(string.Join(", ", unreadable));
+        return sb.ToString();
+    }
+
+    static void AppendUpdateGroup(StringBuilder sb, string label, IReadOnlyList<NexusUpdateStatus> all, UpdateVerdict v)
+    {
+        var rows = all.Where(r => r.Verdict == v).ToList();
+        if (rows.Count == 0) return;
+        sb.Append("\n\n").Append(label).Append(" (").Append(rows.Count).Append("):");
+        foreach (var r in rows)
+        {
+            sb.Append("\n  [").Append(r.ModId).Append("] ").Append(r.Name ?? "?");
+            switch (r.Verdict)
+            {
+                case UpdateVerdict.Differs:
+                    sb.Append(" — installed v").Append(r.Installed).Append(", newest MAIN v").Append(r.LatestMainVersion ?? "?");
+                    if (r.LatestMainDate > 0) sb.Append(" (").Append(Day(r.LatestMainDate)).Append(')');
+                    break;
+                case UpdateVerdict.Current:
+                    sb.Append(" — v").Append(r.Installed).Append(" (current)");
+                    break;
+                case UpdateVerdict.LatestOnly:
+                    sb.Append(" — newest MAIN v").Append(r.LatestMainVersion ?? "?");
+                    if (r.LatestMainDate > 0) sb.Append(" (").Append(Day(r.LatestMainDate)).Append(')');
+                    break;
+                case UpdateVerdict.NoMainFile:
+                    sb.Append(" — no MAIN file; header v").Append(r.HeaderVersion ?? "?");
+                    break;
+                case UpdateVerdict.Error:
+                    sb.Append(" — ").Append(r.Note ?? "check failed");
+                    break;
+                case UpdateVerdict.NotFound:
+                    break;   // the group label already says it
+            }
         }
     }
 

--- a/src/housecarl-mcp/Program.cs
+++ b/src/housecarl-mcp/Program.cs
@@ -138,10 +138,16 @@ static void AddMcp(IServiceCollection services, bool stdio)
             "houseCARL exposes the Skyrim Special Edition load order at the data layer. Reads return the TRUE " +
             "load-order winner and, on request, the conflict tree; writes go to a NEW plugin, leaving originals " +
             "untouched. FormIDs are 'XXXXXX:Plugin.esp' (6 hex digits, then the defining master's filename). " +
-            "Beyond the local load order, houseCARL also reaches Nexus Mods directly: housecarl_nexus_search " +
-            "(find a mod by name) and housecarl_nexus_mod (fetch a mod page — requirements, recommended INI " +
-            "settings, accurate latest version, full description, by id or URL). Prefer these over a browser or " +
-            "generic web search for any Nexus Mods lookup.";
+            "Beyond the local load order, houseCARL reaches Nexus Mods directly and KEYLESSLY (no API key): " +
+            "housecarl_nexus_search (find a mod by name); housecarl_nexus_mod (a mod's requirements, recommended INI " +
+            "settings, accurate latest version and full page description, plus files=true for the complete per-file " +
+            "list and changelog=true / since= for the per-version CHANGELOG and update delta, by id or URL); " +
+            "housecarl_nexus_check_updates (batch behind/current check across many mods in one call); and " +
+            "housecarl_nexus_identify (trace a file to its source mod by MD5 hash). For mod updates, start with " +
+            "housecarl_update_status — it reads MO2's OWN local update cache with NO network to narrow the list — then " +
+            "verify the flagged mods live. Prefer these over a browser or generic web search for any Nexus lookup: " +
+            "houseCARL can already read changelogs, file lists, and update status directly, so never hand-roll scripts " +
+            "around a rendered Nexus page.";
     });
     // Stateless HTTP: each request is independent (no MCP session affinity); the resolver singleton persists across
     // requests regardless. Stdio is inherently a single long-lived session over the pipe.

--- a/src/housecarl-mcp/Program.cs
+++ b/src/housecarl-mcp/Program.cs
@@ -114,6 +114,11 @@ static (LoadOrderService svc, bool explicitMode, string? instanceDir, string ins
     {
         c.Timeout = TimeSpan.FromSeconds(20);
         c.DefaultRequestHeaders.UserAgent.ParseAdd("houseCARL (+https://github.com/Avick3110/houseCARL)");
+        // Nexus API Acceptable-Use Policy requires Application-Name + Application-Version on API traffic
+        // (article 114). We send them on every request regardless of tier — cheap, compliant, and it identifies
+        // houseCARL honestly to Nexus. The version is the exe's stamped release (ServerVersion), 0.0.0-dev unstamped.
+        c.DefaultRequestHeaders.Add("Application-Name", "houseCARL");
+        c.DefaultRequestHeaders.Add("Application-Version", ServerVersion());
     });
 
     return (svc, explicitMode, instanceDir, instanceSource, configNote);

--- a/src/housecarl-mcp/UpdateStatusTools.cs
+++ b/src/housecarl-mcp/UpdateStatusTools.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using System.Text;
 using ModelContextProtocol.Server;
-using HousecarlCore;
 
 namespace HousecarlMcp;
 

--- a/src/housecarl-mcp/UpdateStatusTools.cs
+++ b/src/housecarl-mcp/UpdateStatusTools.cs
@@ -1,0 +1,106 @@
+using System.ComponentModel;
+using System.Text;
+using ModelContextProtocol.Server;
+using HousecarlCore;
+
+namespace HousecarlMcp;
+
+/// <summary>
+/// houseCARL's LOCAL mod-update reader (no network). Reads MO2's OWN Nexus update cache — the modid / version /
+/// newestVersion fields MO2 writes into each mod's meta.ini — and reports which installed mods MO2 already believes have
+/// a newer version. This is the cheap FIRST pass of update triage: it narrows a big modlist to the handful worth
+/// verifying online (housecarl_nexus_check_updates), reading only files MO2 has already populated. Works fully offline;
+/// it does NOT touch Nexus and does NOT modify anything. Sits in the MO2-static-read lane beside housecarl_load_order_status.
+/// </summary>
+[McpServerToolType]
+public static class UpdateStatusTools
+{
+    [McpServerTool(Name = "housecarl_update_status", ReadOnly = true, Title = "MO2's local mod-update cache (no network)"),
+     Description(
+         "Report which of your installed mods MO2 already thinks have a newer version — read from MO2's OWN local cache " +
+         "(each mod's meta.ini), with NO network and NO API key. For every Nexus-linked mod it compares the installed " +
+         "version against the newest version MO2 last learned and lists the ones that DIFFER (plus any you told MO2 to " +
+         "ignore, and how many were never checked or are current). This is the cheap FIRST pass of update triage — it " +
+         "narrows a big modlist to the handful worth checking online — but it is only as fresh as MO2's last Nexus check, " +
+         "and a 'never checked' mod is NOT 'up to date' (Q3). To verify live, pass the flagged mod ids to " +
+         "housecarl_nexus_check_updates; use housecarl_nexus_mod changelog=true to see what changed. READ-ONLY, works " +
+         "OFFLINE, and modifies/updates NOTHING. Needs a configured MO2 instance (housecarl_set_mo2_instance).")]
+    public static string UpdateStatus(
+        LoadOrderService svc,
+        [Description("Optional. Max characters before the mod lists are cut with an explicit notice. 0 = the server default (~40k).")]
+            int max_chars = 0) => Guard.Tool("housecarl_update_status", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        var data = svc.UpdateCache();
+        return UpdateStatusWire.Render(data, max_chars > 0 ? max_chars : 40_000);
+    });
+}
+
+/// <summary>Renders <see cref="UpdateCacheData"/>: a summary line, then the mods MO2 has a newer version cached for
+/// (the actionable set), then the ignored set. Current / never-checked mods are counted, not listed (the point is the
+/// FILTER). Every render ends with the Q3 honesty note — this is MO2's cached view, not a live Nexus check.</summary>
+static class UpdateStatusWire
+{
+    public static string Render(UpdateCacheData d, int cap)
+    {
+        var sb = new StringBuilder();
+        sb.Append("MO2 update cache (LOCAL, no network) — instance: ")
+          .Append(d.InstanceDir ?? "explicit-paths mode").Append('\n');
+
+        var flagged = new List<ModUpdateEntry>();
+        var ignored = new List<ModUpdateEntry>();
+        int current = 0, neverChecked = 0;
+        foreach (var e in d.Entries)
+        {
+            if (string.IsNullOrWhiteSpace(e.Newest)) { neverChecked++; continue; }   // MO2 never learned a newer version
+            bool differs = !string.Equals(e.Newest.Trim(), (e.Installed ?? "").Trim(), StringComparison.OrdinalIgnoreCase);
+            if (!differs) { current++; continue; }
+            if (e.Ignored is not null && string.Equals(e.Newest.Trim(), e.Ignored.Trim(), StringComparison.OrdinalIgnoreCase))
+                ignored.Add(e);
+            else flagged.Add(e);
+        }
+
+        sb.Append(d.Entries.Count).Append(" Nexus-linked mod(s): ")
+          .Append(flagged.Count).Append(" with a newer version cached · ")
+          .Append(ignored.Count).Append(" ignored · ")
+          .Append(current).Append(" current · ")
+          .Append(neverChecked).Append(" never checked");
+        if (d.UntrackedCount > 0) sb.Append("  (+").Append(d.UntrackedCount).Append(" non-Nexus mods/separators skipped)");
+        sb.Append('\n');
+        foreach (var p in d.Problems) sb.Append("[!] ").Append(p).Append('\n');
+
+        AppendEntries(sb, "UPDATE cached — MO2 learned a newer version (verify live before updating)", flagged, cap);
+        AppendEntries(sb, "ignored — you told MO2 to skip this newer version", ignored, cap);
+
+        sb.Append("\nnote: this is MO2's OWN cached view — only as fresh as MO2's last Nexus check, and 'never checked' is ")
+          .Append("NOT 'up to date'. To verify against Nexus right now, feed the flagged mod ids to ")
+          .Append("housecarl_nexus_check_updates.");
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    static void AppendEntries(StringBuilder sb, string label, IReadOnlyList<ModUpdateEntry> rows, int cap)
+    {
+        sb.Append('\n').Append(label).Append(" (").Append(rows.Count).Append("):");
+        if (rows.Count == 0) { sb.Append(" none\n"); return; }
+        sb.Append('\n');
+        int shown = 0;
+        foreach (var e in rows)
+        {
+            if (sb.Length >= cap) { sb.Append("  ... [").Append(rows.Count - shown).Append(" more omitted at max_chars=").Append(cap).Append("]\n"); break; }
+            sb.Append("  - ").Append(e.Folder);
+            if (e.Enabled == false) sb.Append("  [disabled]");
+            sb.Append("  [id ").Append(e.ModId).Append("]  v").Append(e.Installed ?? "?").Append(" → v").Append(e.Newest ?? "?");
+            var checkedOn = StaleDay(e.LastUpdate);
+            if (checkedOn is not null) sb.Append("  (checked ").Append(checkedOn).Append(')');
+            sb.Append('\n'); shown++;
+        }
+    }
+
+    /// <summary>Unix-seconds string → yyyy-MM-dd, or null if it isn't a usable timestamp.</summary>
+    static string? StaleDay(string? unix)
+    {
+        if (long.TryParse(unix, out var s) && s > 0)
+            try { return DateTimeOffset.FromUnixTimeSeconds(s).ToString("yyyy-MM-dd"); } catch { }
+        return null;
+    }
+}

--- a/src/housecarl-mcp/UpdateStatusTools.cs
+++ b/src/housecarl-mcp/UpdateStatusTools.cs
@@ -17,10 +17,11 @@ public static class UpdateStatusTools
 {
     [McpServerTool(Name = "housecarl_update_status", ReadOnly = true, Title = "MO2's local mod-update cache (no network)"),
      Description(
-         "Report which of your installed mods MO2 already thinks have a newer version — read from MO2's OWN local cache " +
-         "(each mod's meta.ini), with NO network and NO API key. For every Nexus-linked mod it compares the installed " +
-         "version against the newest version MO2 last learned and lists the ones that DIFFER (plus any you told MO2 to " +
-         "ignore, and how many were never checked or are current). This is the cheap FIRST pass of update triage — it " +
+         "Report which installed mods have a version DIFFERENT from MO2's cached 'newest' — read from MO2's OWN local " +
+         "cache (each mod's meta.ini), with NO network and NO API key. For every Nexus-linked mod it compares the " +
+         "installed version against the newest version MO2 last learned and lists the ones that DIFFER (candidates only — " +
+         "MO2's cache can be stale or a different version scheme, so direction isn't assured), plus any you told MO2 to " +
+         "ignore, and how many were never checked or match. This is the cheap FIRST pass of update triage — it " +
          "narrows a big modlist to the handful worth checking online — but it is only as fresh as MO2's last Nexus check, " +
          "and a 'never checked' mod is NOT 'up to date' (Q3). To verify live, pass the flagged mod ids to " +
          "housecarl_nexus_check_updates; use housecarl_nexus_mod changelog=true to see what changed. READ-ONLY, works " +
@@ -61,20 +62,22 @@ static class UpdateStatusWire
         }
 
         sb.Append(d.Entries.Count).Append(" Nexus-linked mod(s): ")
-          .Append(flagged.Count).Append(" with a newer version cached · ")
+          .Append(flagged.Count).Append(" differ from MO2's cached newest · ")
           .Append(ignored.Count).Append(" ignored · ")
-          .Append(current).Append(" current · ")
+          .Append(current).Append(" match · ")
           .Append(neverChecked).Append(" never checked");
         if (d.UntrackedCount > 0) sb.Append("  (+").Append(d.UntrackedCount).Append(" non-Nexus mods/separators skipped)");
         sb.Append('\n');
         foreach (var p in d.Problems) sb.Append("[!] ").Append(p).Append('\n');
 
-        AppendEntries(sb, "UPDATE cached — MO2 learned a newer version (verify live before updating)", flagged, cap);
-        AppendEntries(sb, "ignored — you told MO2 to skip this newer version", ignored, cap);
+        AppendEntries(sb, "installed ≠ MO2's cached newest — CANDIDATES to verify (direction not assured)", flagged, cap);
+        AppendEntries(sb, "ignored — you told MO2 to skip this version", ignored, cap);
 
-        sb.Append("\nnote: this is MO2's OWN cached view — only as fresh as MO2's last Nexus check, and 'never checked' is ")
-          .Append("NOT 'up to date'. To verify against Nexus right now, feed the flagged mod ids to ")
-          .Append("housecarl_nexus_check_updates.");
+        sb.Append("\nnote: this is MO2's OWN cached view, not a live check. A 'differ' is only a CANDIDATE — MO2's cached ")
+          .Append("'newest' can be stale or a different version scheme (some installed versions here are actually NEWER than ")
+          .Append("the cached value), so the direction is not assured and 'never checked' is NOT 'up to date'. To confirm ")
+          .Append("what's genuinely behind, feed these mod ids to housecarl_nexus_check_updates (authoritative newest MAIN " )
+          .Append("file), then housecarl_nexus_mod changelog=true to see what changed.");
         return sb.ToString().TrimEnd('\n');
     }
 
@@ -89,7 +92,8 @@ static class UpdateStatusWire
             if (sb.Length >= cap) { sb.Append("  ... [").Append(rows.Count - shown).Append(" more omitted at max_chars=").Append(cap).Append("]\n"); break; }
             sb.Append("  - ").Append(e.Folder);
             if (e.Enabled == false) sb.Append("  [disabled]");
-            sb.Append("  [id ").Append(e.ModId).Append("]  v").Append(e.Installed ?? "?").Append(" → v").Append(e.Newest ?? "?");
+            sb.Append("  [id ").Append(e.ModId).Append("]  installed v").Append(e.Installed ?? "?")
+              .Append(" · MO2 cached v").Append(e.Newest ?? "?");
             var checkedOn = StaleDay(e.LastUpdate);
             if (checkedOn is not null) sb.Append("  (checked ").Append(checkedOn).Append(')');
             sb.Append('\n'); shown++;


### PR DESCRIPTION
Implements the **Tier 0 (keyless) charter** from `dev/plans/NEXUS_FULL_API_SCOPING_2026-07-13.md` — Aaron-GO, Opus build session. Everything here is on the anonymous v2 GraphQL surface `NexusClient` already uses (no API key); Tiers 1–2 (keyed/OAuth, downloads, registration email) stay bucketed and are untouched.

This is the **capability PR**. The `update-triage` skill (charter item 7) is deliberately a separate fresh session.

## Charter items (8 commits)
- **6 — AUP headers**: send `Application-Name`/`-Version` on all Nexus traffic (AUP article 114).
- **1 — `files=true`** on `housecarl_nexus_mod`: render the full per-file list (already fetched) grouped by category — fixes the FOMOD/modular "can't pin a variant's version" gap.
- **2 — `changelog=true` + `since=`** on `housecarl_nexus_mod`: per-version changelog, folded across each release's files; `since` deltas to releases newer than the installed one, keyed by upload **date** (freeform version strings aren't comparable). No changelog → UNKNOWN, never "no change".
- **3 — `housecarl_nexus_check_updates`** (new): batch behind/current/no-main/not-found across many mods; one combined query per 25 (OR-batched `mods` + aliased `modFiles`). modIds are ints (injection-safe); installed version compared locally. DIFFERS doesn't assert direction.
- **5 — `housecarl_nexus_identify`** (new): MD5 → source mod/file via `fileHashes`; non-SSE matches flagged by gameId, not mis-attributed. Un-parks the roadmap fileHash item.
- **4 — `housecarl_update_status`** (new, **no network**): reads MO2's own `meta.ini` update cache; the cheap first-pass filter (MO2-static-read lane). `Mo2ModMeta` parser added to core.
- **8 — surface docs**: server instruction block + every tool description state the full keyless reach, so a session never again assumes houseCARL "can't read changelogs" and hand-rolls scripts (charter goal (b)).

Plus one evidence-driven fix: `update_status` reports a **candidate difference**, not an asserted "newer version" (real-data run showed MO2's cache is often stale / a different version scheme).

## Scope
- **37 → 40 tools** (check_updates, identify, update_status). Skills unchanged (12). `+760 / -11`, 6 files.
- GraphQL shapes all confirmed against live Nexus before wiring (changelog, gameId-per-branch batch filter, `fileHashes` return shape).

## Validation
- `dotnet build` clean; **`ci-all` 85/85, no regressions**.
- End-to-end live run (throwaway probe, real Nexus + a real 3303-mod MO2 instance, not committed):
  - nexus_mod: 19-file list; caught header v6.9 vs newest MAIN v6.11; `since=6.9` → just v6.11 + v6.10.
  - check_updates: SkyUI DIFFER, USSEP current, LE/bogus → not-found.
  - update_status: 3303 Nexus mods → 895 candidate-differs, at scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)