### PR TITLE
fix(nexus): check updates at the FILE level via fileid, not mod-level newest-MAIN

### DIFF
--- a/src/housecarl-core/Mo2ModMeta.cs
+++ b/src/housecarl-core/Mo2ModMeta.cs
@@ -23,12 +23,24 @@ namespace HousecarlCore;
 //  doubled, and string values can be surrounded by double quotes. The
 //  [installedFiles] section uses prefixed keys (1\modid=...) so a plain
 //  first-match on "modid" reads the [General] one, which is written first.
+//
+//  That same [installedFiles] section ALSO records the exact Nexus FILE id(s)
+//  MO2 installed (1\fileid=..., 2\fileid=..., a size= count key in any order),
+//  which is the join key for a FILE-level currency check — "is the file I have
+//  still a current file, or did Nexus retire it to OLD_VERSION/ARCHIVED?" —
+//  immune to the multi-file-page confusion a mod-level version compare falls
+//  into (a Nexus page hosts many independently-versioned files). A FOMOD /
+//  merged / hand-installed mod has size=0 with no fileid, so the check must
+//  degrade LOUDLY there rather than guess (Q3).
 // ======================================================================
 
 /// <summary>The Nexus update-cache fields from one mod's meta.ini. <see cref="ModId"/> is 0 when the mod has no Nexus
-/// id (a hand-installed mod / separator). <see cref="NewestVersion"/> empty ⇒ MO2 never learned a newer version.</summary>
+/// id (a hand-installed mod / separator). <see cref="NewestVersion"/> empty ⇒ MO2 never learned a newer version.
+/// <see cref="InstalledFileIds"/> are the <c>[installedFiles] N\fileid</c> values — the exact Nexus file(s) installed,
+/// the FILE-level currency join key; empty for a FOMOD/manual install (<c>size=0</c>, no fileid).</summary>
 public sealed record ModMetaIni(
-    int ModId, string? Version, string? NewestVersion, string? IgnoredVersion, string? LastNexusUpdate);
+    int ModId, string? Version, string? NewestVersion, string? IgnoredVersion, string? LastNexusUpdate,
+    IReadOnlyList<int> InstalledFileIds);
 
 public static class Mo2ModMeta
 {
@@ -47,7 +59,42 @@ public static class Mo2ModMeta
             Clean(FindValue(lines, "version")),
             Clean(FindValue(lines, "newestVersion")),
             Clean(FindValue(lines, "ignoredVersion")),
-            Clean(FindValue(lines, "lastNexusUpdate")));
+            Clean(FindValue(lines, "lastNexusUpdate")),
+            ReadInstalledFileIds(lines));
+    }
+
+    /// <summary>The <c>N\fileid</c> values from the <c>[installedFiles]</c> section, in index (N) order — the exact Nexus
+    /// file(s) MO2 recorded as installed for this mod. A mod can have several (<c>1\fileid</c>, <c>2\fileid</c>, …); a
+    /// FOMOD/manual install has <c>size=0</c> and none (⇒ empty list). Scoped to the section (a stray <c>fileid=</c>
+    /// elsewhere is ignored) and tolerant of the <c>size=</c> / <c>N\modid</c> siblings and any key ordering. Empty,
+    /// never null, so the caller can treat "no fileids" as the loud no-fileid-fallback case, not a crash.</summary>
+    static IReadOnlyList<int> ReadInstalledFileIds(string[] lines)
+    {
+        List<(int idx, int fileId)>? found = null;
+        bool inSection = false;
+        foreach (var raw in lines)
+        {
+            var line = raw.Trim();
+            if (line.Length == 0) continue;
+            if (line[0] == '[')   // a new section header ends [installedFiles]
+            {
+                inSection = line.Equals("[installedFiles]", StringComparison.OrdinalIgnoreCase);
+                continue;
+            }
+            if (!inSection) continue;
+            int eq = line.IndexOf('=');
+            if (eq < 0) continue;
+            var key = line.AsSpan(0, eq).TrimEnd();
+            int bs = key.IndexOf('\\');                                   // key is "<N>\fileid"; split on the QSettings group sep
+            if (bs < 0) continue;                                         // e.g. the section's own "size=" key — no '\'
+            if (!key[(bs + 1)..].Trim().Equals("fileid", StringComparison.OrdinalIgnoreCase)) continue;   // skip N\modid etc.
+            if (!int.TryParse(key[..bs].Trim(), out var idx)) continue;
+            var val = Clean(line[(eq + 1)..]);
+            if (val is not null && int.TryParse(val, out var fid) && fid > 0)
+                (found ??= new()).Add((idx, fid));
+        }
+        if (found is null) return Array.Empty<int>();
+        return found.OrderBy(t => t.idx).Select(t => t.fileId).ToList();
     }
 
     /// <summary>First <c>key=</c> line's raw value, key matched case-insensitively and EXACTLY (so "modid" never matches

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -100,8 +100,13 @@ public static class CiAll
         ("skse-reader-guard", SkseReaderProbe.RunGuard),
         ("mo2instance-probe", Mo2InstanceProbe.RunProbe),
         // meta.ini Nexus-update-cache parse (Tier 0 PR review fold): the QSettings quirks + exact-key vs [installedFiles]
-        // 1\modid, the fiddliest OFFLINE logic behind housecarl_update_status — locked with synthetic fixtures.
+        // 1\modid, the fiddliest OFFLINE logic behind housecarl_update_status — locked with synthetic fixtures. Now also
+        // pins the [installedFiles] N\fileid capture (single / multi / size=0 no-fileid) the file-level check joins on.
         ("mo2-modmeta-guard", Mo2ModMetaProbe.RunGuard),
+        // FILE-LEVEL Nexus update check (fixes the multi-file-page false positive): ComputeStatus verdicts (live→current,
+        // archived→outdated+same-name pointer, missing→file-gone, no-fileid→loud fallback), the id#fileid parse, and the
+        // same-modId-across-folders fileid MERGE (never dedup-drop). Pure, network-free; synthetic AMON-shaped fixtures.
+        ("nexus-file-check-guard", NexusFileCheckProbe.RunGuard),
         ("atomic-commit-guard", AtomicCommitProbe.RunGuard),
         ("place-asset-guard", PlaceAssetProbe.RunGuard),
         // NIF layer Wave 1: NifService.Inspect decodes an authored SE mesh's N2-whitelist values (version, census, node

--- a/src/housecarl-generator/Mo2ModMetaProbe.cs
+++ b/src/housecarl-generator/Mo2ModMetaProbe.cs
@@ -43,6 +43,7 @@ internal static class Mo2ModMetaProbe
             Check(ma.NewestVersion == "6.11", "A: newestVersion = 6.11");
             Check(ma.IgnoredVersion == "6.10", "A: ignoredVersion = 6.10");
             Check(ma.LastNexusUpdate == "1778020881", "A: lastNexusUpdate raw unix seconds");
+            Check(Seq(ma.InstalledFileIds, 749043), "A: [installedFiles] 1\\fileid → [749043] (NOT the 1\\modid 99999)");
 
             // B — QSettings quirks: @ByteArray wrap, @Invalid unset, surrounding quotes, doubled backslash.
             var b = Write(dir, "b.ini",
@@ -56,12 +57,41 @@ internal static class Mo2ModMetaProbe
             Check(mb.Version == "5.2SE", "B: surrounding quotes stripped → 5.2SE");
             Check(mb.NewestVersion is null, "B: @Invalid() → null");
             Check(mb.IgnoredVersion == "a\\b", "B: doubled backslash unescaped → a\\b");
+            Check(mb.InstalledFileIds.Count == 0, "B: no [installedFiles] section → empty fileids (never null)");
 
             // C — no/invalid modid → ModId 0; absent fields → null (still returns a record, never throws).
             var c = Write(dir, "c.ini", "[General]", "version=1.0", "modid=notanumber");
             var mc = Mo2ModMeta.Read(c);
             Check(mc is not null && mc.ModId == 0, "C: non-integer modid → 0");
             Check(mc!.NewestVersion is null && mc.IgnoredVersion is null && mc.LastNexusUpdate is null, "C: absent fields → null");
+            Check(mc.InstalledFileIds.Count == 0, "C: no [installedFiles] → empty fileids");
+
+            // E — MULTIPLE installed files, with the size= key BETWEEN the indexed keys and the indices OUT OF ORDER
+            //     (real meta.ini writes them in any order — AMON's live file even puts size= between 1\modid and 1\fileid).
+            //     Must return every fileid, ordered by index N, ignoring the size= and N\modid siblings.
+            var e = Write(dir, "e.ini",
+                "[General]",
+                "modid=126608",
+                "[installedFiles]",
+                "2\\fileid=222",
+                "1\\modid=126608",
+                "size=2",
+                "2\\modid=126608",
+                "1\\fileid=111");
+            var me = Mo2ModMeta.Read(e);
+            Check(Seq(me!.InstalledFileIds, 111, 222), "E: multi fileid, size= interleaved, out-of-order N → [111,222] by index");
+
+            // F — a FOMOD/manual install: [installedFiles] size=0 with NO fileid (City Trees is the live example). Must be
+            //     empty (⇒ the loud no-fileid fallback), never a guess. Also proves a section AFTER installedFiles doesn't leak.
+            var f = Write(dir, "f.ini",
+                "[General]",
+                "modid=35546",
+                "[installedFiles]",
+                "size=0",
+                "[Plugins]",
+                "1\\fileid=999");                 // a fileid OUTSIDE [installedFiles] must be ignored (scoped scan)
+            var mf = Mo2ModMeta.Read(f);
+            Check(mf!.InstalledFileIds.Count == 0, "F: [installedFiles] size=0 → empty fileids (FOMOD/manual); stray fileid in [Plugins] ignored");
 
             // D — a file that doesn't exist → null, never a throw (the caller keeps walking the mods folder).
             Check(Mo2ModMeta.Read(Path.Combine(dir, "does-not-exist.ini")) is null, "D: missing file → null, no throw");
@@ -77,5 +107,13 @@ internal static class Mo2ModMetaProbe
         var p = Path.Combine(dir, name);
         File.WriteAllLines(p, lines);
         return p;
+    }
+
+    /// <summary>True iff the actual fileid list equals the expected ints in order.</summary>
+    static bool Seq(IReadOnlyList<int> actual, params int[] expected)
+    {
+        if (actual.Count != expected.Length) return false;
+        for (int i = 0; i < expected.Length; i++) if (actual[i] != expected[i]) return false;
+        return true;
     }
 }

--- a/src/housecarl-generator/NexusFileCheckProbe.cs
+++ b/src/housecarl-generator/NexusFileCheckProbe.cs
@@ -1,0 +1,129 @@
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// FILE-LEVEL Nexus update-check guard (the fix for the shipped multi-file-page false positive: a mod-level
+/// "installed == newest MAIN" compare is confidently WRONG when a page hosts many independently-versioned files).
+/// Locks the three pure pieces of the fix — none touch the network:
+///   • NexusClient.ComputeStatus — the currency verdict from an installed fileid + the mod's file list: a live-category
+///     file ⇒ Current, an OLD_VERSION/ARCHIVED file ⇒ Outdated (pointing to the newest SAME-NAME live file, not the
+///     page's global newest), an absent fileid ⇒ FileGone (loud), no fileid ⇒ NoFileId/LatestOnly (loud fallback,
+///     never a confident mod-level verdict), plus multi-file aggregation and the not-found state.
+///   • NexusTools.ParseUpdatePairs — the 'id#fileid' input grammar (file-level vs version vs bare, junk surfaced).
+///   • NexusClient.GroupRequests — same-modId-across-folders MERGES fileids (the Xtudo multi-folder case), never
+///     dedup-drops a folder.
+/// Synthetic data mirrors the real AMON ENB (99786) page Aaron caught. Self-contained; no game data, no network.
+/// </summary>
+internal static class NexusFileCheckProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" nexus-file-check guard — file-level currency verdicts + id#fileid parse + modId grouping");
+        Console.WriteLine("================================================================");
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        // Synthetic file list mirroring AMON ENB (99786): a MULTI-MAIN page — the exact shape that produced the shipped
+        // false positive. 585300 is the LIVE MAIN "Esp Fix v2" Aaron actually installed; 775265 is the v10 preset the old
+        // mod-level compare wrongly measured him against; 585294/483794 are ARCHIVED "Esp Fix" copies.
+        var files = new List<(int fileId, string name, string? version, string category, long date)>
+        {
+            (585300, "Amon NAT III Esp Fix",       "2",  "MAIN",     1737000000L),
+            (775265, "AMON ENB For NAT III 2026",   "10", "MAIN",     1751000000L),
+            (474157, "Fix for Sub Surface Scattering", "1", "MAIN",   1600000000L),
+            (585294, "Amon NAT III Esp Fix",       "2",  "ARCHIVED", 1736000000L),
+            (483794, "Amon NAT III Esp Fix",       "1",  "ARCHIVED", 1700000000L),
+        };
+
+        // A — THE false-positive kill: installed 585300 (a LIVE MAIN) ⇒ Current, NOT "behind, latest v10".
+        var a = NexusClient.ComputeStatus(99786, true, "AMON ENB", "2.0.0.0", "2.0.0.0", new[] { 585300 }, files);
+        Check(a.Verdict == UpdateVerdict.Current, "A: installed file in a LIVE category → Current (NOT compared to the v10 preset)");
+        Check(a.Files.Count == 1 && a.Files[0].Verdict == FileVerdict.Live, "A: the installed file is reported Live");
+
+        // B — an installed file the author RETIRED ⇒ Outdated, pointing to the newest SAME-NAME live file (585300 v2),
+        //     never the page's global newest (the v10 preset is a different variant line).
+        var b = NexusClient.ComputeStatus(99786, true, "AMON ENB", "2.0.0.0", "1", new[] { 483794 }, files);
+        Check(b.Verdict == UpdateVerdict.Outdated, "B: installed file in ARCHIVED → Outdated");
+        Check(b.Files.Count == 1 && b.Files[0].Verdict == FileVerdict.Superseded, "B: the installed file is reported Superseded");
+        Check(b.Files[0].NewestSameName == "Amon NAT III Esp Fix" && b.Files[0].NewestSameVersion == "2",
+              "B: points to the newest SAME-NAME live file (Esp Fix v2), not the v10 preset");
+
+        // C — an installed fileid no longer on the page ⇒ FileGone (loud unknown), never silently "current".
+        var c = NexusClient.ComputeStatus(99786, true, "AMON ENB", "2.0.0.0", null, new[] { 999999 }, files);
+        Check(c.Verdict == UpdateVerdict.FileGone, "C: installed fileid absent from the file list → FileGone (loud)");
+        Check(c.Files.Count == 1 && c.Files[0].Verdict == FileVerdict.Missing, "C: the installed file is reported Missing");
+
+        // D — MULTIPLE installed files (the Xtudo case), one live + one retired ⇒ Outdated headline, both detailed.
+        var d = NexusClient.ComputeStatus(99786, true, "AMON ENB", null, null, new[] { 585300, 483794 }, files);
+        Check(d.Verdict == UpdateVerdict.Outdated, "D: multi-file, ≥1 retired → Outdated headline");
+        Check(d.Files.Count == 2, "D: both installed files detailed");
+
+        // D2 — MULTIPLE installed files, all live ⇒ Current.
+        var d2 = NexusClient.ComputeStatus(99786, true, "AMON ENB", null, null, new[] { 585300, 775265 }, files);
+        Check(d2.Verdict == UpdateVerdict.Current, "D2: multi-file, all live → Current");
+
+        // E — NO fileid but a version, on a MULTI-main page ⇒ NoFileId (loud); LiveMainCount surfaces the ambiguity.
+        var e = NexusClient.ComputeStatus(99786, true, "AMON ENB", "2.0.0.0", "2.0.0.0", Array.Empty<int>(), files);
+        Check(e.Verdict == UpdateVerdict.NoFileId, "E: no fileid + version → NoFileId (loud, never a confident mod-level verdict)");
+        Check(e.LiveMainCount == 3, "E: LiveMainCount counts every live MAIN (3) — the multi-main ambiguity signal");
+
+        // F — bare id (no version, no fileid) ⇒ LatestOnly.
+        var f = NexusClient.ComputeStatus(3863, true, "Some Mod", "1.0", null, Array.Empty<int>(), files);
+        Check(f.Verdict == UpdateVerdict.LatestOnly, "F: bare id (no version, no fileid) → LatestOnly");
+
+        // G — mod not found on SSE ⇒ NotFound (never folded into current).
+        var g = NexusClient.ComputeStatus(1, false, null, null, "1.0", new[] { 123 }, files);
+        Check(g.Verdict == UpdateVerdict.NotFound, "G: mod not found → NotFound");
+
+        // H — single-main page, no fileid + version ⇒ NoFileId with LiveMainCount==1 (the labeled version-compare case).
+        var single = new List<(int, string, string?, string, long)>
+        {
+            (10, "Solo", "3.1", "MAIN", 100L),
+            (11, "Solo", "3.0", "OLD_VERSION", 90L),
+        };
+        var h = NexusClient.ComputeStatus(266, true, "Solo Mod", "3.0", "3.0", Array.Empty<int>(), single);
+        Check(h.Verdict == UpdateVerdict.NoFileId && h.LiveMainCount == 1 && h.LatestMainVersion == "3.1",
+              "H: no fileid, single live MAIN → NoFileId + LiveMainCount 1 + newest MAIN surfaced");
+
+        // I — an UNKNOWN/new category on the installed file is treated as LIVE (superseded is the CLOSED OLD/ARCHIVED
+        //     set), and the category is carried through so it's visible (Q3), never silently bucketed as retired.
+        var unk = new List<(int, string, string?, string, long)> { (20, "New", "1", "PENDING_REVIEW", 100L) };
+        var iRes = NexusClient.ComputeStatus(500, true, "New Cat", "1", null, new[] { 20 }, unk);
+        Check(iRes.Verdict == UpdateVerdict.Current && iRes.Files[0].Verdict == FileVerdict.Live && iRes.Files[0].Category == "PENDING_REVIEW",
+              "I: unknown category → treated Live, category carried through (not mis-retired)");
+
+        // ---- id#fileid PARSE (ParseUpdatePairs) ----
+        var (pairs, bad) = NexusTools.ParseUpdatePairs("99786#585300, 126608#533265#533266, 12604=6.9, 266 4.3.8a, 3863, 99786#, abc#1, junk");
+        Check(pairs.Count == 5, "parse: 5 readable entries");
+        Check(pairs.Any(p => p.modId == 99786 && p.installed is null && p.fileIds.Count == 1 && p.fileIds[0] == 585300),
+              "parse: '99786#585300' → file-level [585300]");
+        Check(pairs.Any(p => p.modId == 126608 && p.fileIds.Count == 2 && p.fileIds[0] == 533265 && p.fileIds[1] == 533266),
+              "parse: '126608#533265#533266' → two fileids");
+        Check(pairs.Any(p => p.modId == 12604 && p.installed == "6.9" && p.fileIds.Count == 0), "parse: '12604=6.9' → version, no fileid");
+        Check(pairs.Any(p => p.modId == 266 && p.installed == "4.3.8a"), "parse: '266 4.3.8a' → space-separated version");
+        Check(pairs.Any(p => p.modId == 3863 && p.installed is null && p.fileIds.Count == 0), "parse: bare '3863' → latest-only");
+        Check(bad.Contains("99786#") && bad.Any(x => x.StartsWith("abc#")) && bad.Contains("junk"),
+              "parse: '99786#' (no fileid), 'abc#1' (bad modid), 'junk' → surfaced as bad, not silently dropped");
+
+        // ---- modId GROUPING (GroupRequests) — the multi-folder Xtudo case: same modid across folders MERGES, never drops ----
+        var grouped = NexusClient.GroupRequests(new (int, string?, IReadOnlyList<int>)[]
+        {
+            (126608, "1.3", new[] { 533265 }),
+            (126608, "1.1", new[] { 533266 }),
+            (99786, null, new[] { 585300 }),
+            (126608, null, new[] { 533265 }),   // duplicate fileid — must dedupe
+        });
+        Check(grouped.order.Count == 2 && grouped.order[0] == 126608 && grouped.order[1] == 99786, "group: 2 modIds, first-seen order");
+        var g126 = grouped.map[126608];
+        Check(g126.fileIds.Count == 2 && g126.fileIds.Contains(533265) && g126.fileIds.Contains(533266),
+              "group: same modId across folders MERGES fileids (never dedup-drops a folder), dedupes repeats");
+        Check(g126.installed == "1.3", "group: keeps the FIRST non-empty installed version");
+
+        Console.WriteLine(fail == 0
+            ? "[nexus-file-check] PASS — file-level verdicts + parse + grouping hold."
+            : $"[nexus-file-check] FAIL ({fail})");
+        return fail;
+    }
+}

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1060,7 +1060,8 @@ public sealed class LoadOrderService : IDisposable
             if (meta is null || meta.ModId == 0) { untracked++; continue; }   // not a Nexus-linked mod → not update-checkable
             bool? state = enabled.Contains(folder) ? true : disabled.Contains(folder) ? false : (bool?)null;
             entries.Add(new ModUpdateEntry(
-                folder, state, meta.ModId, meta.Version, meta.NewestVersion, meta.IgnoredVersion, meta.LastNexusUpdate));
+                folder, state, meta.ModId, meta.Version, meta.NewestVersion, meta.IgnoredVersion, meta.LastNexusUpdate,
+                meta.InstalledFileIds));
         }
         entries.Sort((a, b) => string.Compare(a.Folder, b.Folder, StringComparison.OrdinalIgnoreCase));
         return new UpdateCacheData(modsDir, instanceDir, entries, Array.Empty<string>(), untracked);
@@ -4242,9 +4243,12 @@ public sealed record UpdateCacheData(
 /// <summary>One Nexus-linked mod's update-cache row. <see cref="Newest"/> empty ⇒ MO2 never learned a newer version.
 /// MO2's own "update available" rule: <see cref="Newest"/> is set, non-empty, != <see cref="Installed"/>, and !=
 /// <see cref="Ignored"/>. <see cref="Enabled"/> is null when the mod isn't in the active profile (state unknown).
-/// <see cref="LastUpdate"/> is unix-seconds of MO2's last Nexus check (staleness signal).</summary>
+/// <see cref="LastUpdate"/> is unix-seconds of MO2's last Nexus check (staleness signal). <see cref="InstalledFileIds"/>
+/// are the exact Nexus file id(s) MO2 installed (from meta.ini <c>[installedFiles]</c>) — the FILE-level currency join
+/// key that makes a live check immune to the multi-file-page false positive; empty for a FOMOD/manual install.</summary>
 public sealed record ModUpdateEntry(
-    string Folder, bool? Enabled, int ModId, string? Installed, string? Newest, string? Ignored, string? LastUpdate);
+    string Folder, bool? Enabled, int ModId, string? Installed, string? Newest, string? Ignored, string? LastUpdate,
+    IReadOnlyList<int> InstalledFileIds);
 
 /// <summary>The result of <see cref="LoadOrderService.NamedProfileComposition"/> — the profiles affordance behind
 /// housecarl_load_order_status' profile= param. <see cref="InstanceMode"/> is false in explicit-paths mode (no profiles

--- a/src/housecarl-mcp/NexusClient.cs
+++ b/src/housecarl-mcp/NexusClient.cs
@@ -113,34 +113,40 @@ public sealed class NexusClient
             Bool(m, "directDownloadEnabled"), reqs, files));
     }
 
-    /// <summary>Batch "is each of these mods behind?" — for a list of (modId, installedVersion) pairs, resolve each mod's
-    /// name + newest MAIN file (the accurate version of record; a mod's version HEADER can lag its newest file) in as few
-    /// requests as possible. One combined query PER CHUNK: an OR-batched <c>mods()</c> for names/headers + one aliased
-    /// <c>modFiles()</c> per mod for the newest MAIN. modIds are integers (the tool parses them), so inlining them in the
-    /// query text is injection-safe — no user STRING is concatenated in, and the installed version is compared LOCALLY,
-    /// never sent to Nexus. A chunk that fails marks only its own mods Verdict=Error (with the reason) instead of sinking
-    /// the whole batch; the call fails loud only if EVERY chunk failed (Q3).</summary>
+    /// <summary>Batch FILE-LEVEL currency check — "is the exact file each of these mods installed still a current file?"
+    /// For each (modId, installedVersion?, installedFileIds) it resolves every installed file id to its live category in
+    /// the mod's file list: still a live file (MAIN/UPDATE/OPTIONAL/MISCELLANEOUS) ⇒ CURRENT; moved to OLD_VERSION/
+    /// ARCHIVED ⇒ OUTDATED (and it points to the newest same-name file to update to); no longer on the page ⇒ FileGone (a
+    /// loud UNKNOWN). This is immune to the multi-file-page false positive a mod-level "installed == newest MAIN" compare
+    /// falls into — a Nexus page hosts many independently-versioned files, and the version of record is the file you
+    /// actually installed, not the page's single newest main. When NO file id is available (a FOMOD/manual install) it
+    /// degrades LOUDLY to NoFileId (never the old confidently-wrong mod-level compare — the very bug this fixes).
+    /// Entries are GROUPED by modId (a page split across several mod folders — e.g. one Xtudo pack per creature — shares a
+    /// modId; their file ids MERGE, so the page is queried ONCE and each installed file checked, never dropped). One
+    /// combined query per chunk: an OR-batched <c>mods()</c> for names/headers + one aliased <c>modFiles()</c> per mod.
+    /// modIds/fileIds are integers (parsed by the tool), so inlining them is injection-safe; the installed version is only
+    /// ever compared LOCALLY. A chunk that fails marks only its own mods Error; the call fails loud only if EVERY chunk
+    /// failed (Q3).</summary>
     public async Task<(bool ok, string? error, IReadOnlyList<NexusUpdateStatus> results)> CheckUpdatesAsync(
-        IReadOnlyList<(int modId, string? installed)> mods, CancellationToken ct)
+        IReadOnlyList<(int modId, string? installed, IReadOnlyList<int> fileIds)> mods, CancellationToken ct)
     {
-        // Dedupe by modId (keep the first installed), preserving order — a duplicate alias would collide in the query.
-        var seen = new HashSet<int>();
-        var ordered = new List<(int modId, string? installed)>();
-        foreach (var m in mods) if (m.modId > 0 && seen.Add(m.modId)) ordered.Add(m);
-        if (ordered.Count == 0) return (false, "no valid mod ids to check.", Array.Empty<NexusUpdateStatus>());
+        var (order, map) = GroupRequests(mods);
+        if (order.Count == 0) return (false, "no valid mod ids to check.", Array.Empty<NexusUpdateStatus>());
 
         const int ChunkSize = 25;   // OR-branches + modFiles aliases per request; conservative vs an unknown complexity cap
-        var results = new List<NexusUpdateStatus>(ordered.Count);
+        var results = new List<NexusUpdateStatus>(order.Count);
         string? firstError = null;
 
-        for (int i = 0; i < ordered.Count; i += ChunkSize)
+        for (int i = 0; i < order.Count; i += ChunkSize)
         {
-            var chunk = ordered.Skip(i).Take(ChunkSize).ToList();
+            var chunk = order.Skip(i).Take(ChunkSize).ToList();
             var g = SkyrimSeGameId;
-            var branches = string.Join(",", chunk.Select(c =>
-                $"{{gameId:{{value:\"{g}\",op:EQUALS}},modId:{{value:\"{c.modId}\",op:EQUALS}}}}"));
-            var aliases = string.Join(" ", chunk.Select(c =>
-                $"f{c.modId}:modFiles(modId:\"{c.modId}\",gameId:\"{g}\"){{ version category date }}"));
+            var branches = string.Join(",", chunk.Select(id =>
+                $"{{gameId:{{value:\"{g}\",op:EQUALS}},modId:{{value:\"{id}\",op:EQUALS}}}}"));
+            // The alias now selects fileId + name too (was version/category/date) — the fields a FILE-level check needs to
+            // join the installed file id to its live category and name.
+            var aliases = string.Join(" ", chunk.Select(id =>
+                $"f{id}:modFiles(modId:\"{id}\",gameId:\"{g}\"){{ fileId name version category date }}"));
             // count MUST be >= the chunk size: the mods field defaults to a 20-item page, so without it any chunk of 21+
             // silently drops the overflow from nodes — and the verdict path reads an absent mod as NotFound, a confidently
             // WRONG answer at the tool's intended scale (live-proven: 21 matches → 20 nodes without count, 21 with).
@@ -150,8 +156,9 @@ public sealed class NexusClient
             if (!ok)
             {
                 firstError ??= error;
-                foreach (var c in chunk)
-                    results.Add(new NexusUpdateStatus(c.modId, false, null, null, null, 0, c.installed, UpdateVerdict.Error, error));
+                foreach (var id in chunk)
+                    results.Add(new NexusUpdateStatus(id, false, null, null, map[id].installed, UpdateVerdict.Error,
+                        NoFiles, null, 0, 0, error));
                 continue;
             }
 
@@ -161,18 +168,11 @@ public sealed class NexusClient
                 foreach (var n in nodes.EnumerateArray())
                     nodeById[Int(n, "modId")] = (Str(n, "name"), Str(n, "version"));
 
-            foreach (var c in chunk)
+            foreach (var id in chunk)
             {
-                bool found = nodeById.TryGetValue(c.modId, out var meta);
-                var (mainVer, mainDate) = NewestMainFromAlias(data, $"f{c.modId}");
-                UpdateVerdict verdict =
-                    !found                                     ? UpdateVerdict.NotFound :
-                    mainVer is null                            ? UpdateVerdict.NoMainFile :
-                    string.IsNullOrWhiteSpace(c.installed)     ? UpdateVerdict.LatestOnly :
-                    string.Equals(c.installed.Trim(), mainVer.Trim(), StringComparison.OrdinalIgnoreCase)
-                                                               ? UpdateVerdict.Current : UpdateVerdict.Differs;
-                results.Add(new NexusUpdateStatus(
-                    c.modId, found, meta.name, meta.version, mainVer, mainDate, c.installed, verdict));
+                bool found = nodeById.TryGetValue(id, out var meta);
+                var files = FilesFromAlias(data, $"f{id}");
+                results.Add(ComputeStatus(id, found, meta.name, meta.version, map[id].installed, map[id].fileIds, files));
             }
         }
 
@@ -182,19 +182,91 @@ public sealed class NexusClient
         return (true, null, results);
     }
 
-    /// <summary>Newest MAIN file (version + unix-seconds date) from an aliased <c>f&lt;modId&gt;</c> modFiles array in a
-    /// batch response; (null, 0) when the mod has no MAIN file. The MAIN file is the accurate version of record.</summary>
-    static (string? version, long date) NewestMainFromAlias(JsonElement data, string alias)
+    static readonly IReadOnlyList<InstalledFileCurrency> NoFiles = Array.Empty<InstalledFileCurrency>();
+
+    /// <summary>Group the check-update requests by modId — NOT dedupe-drop. A Nexus page split across several MO2 mod
+    /// folders (e.g. one Xtudo pack per creature) shares a modId, and each folder installed a DIFFERENT file; keeping only
+    /// the first would silently un-check the rest (the multi-folder-page silent-drop class). So merge every entry's file
+    /// ids (order-preserving, deduped) under its modId, and keep the FIRST non-empty installed version for the
+    /// no-file-id fallback display. Returns the modId order (first-seen) + the per-modId merged state. Internal for the CI
+    /// guard.</summary>
+    internal static (List<int> order, Dictionary<int, (string? installed, List<int> fileIds)> map) GroupRequests(
+        IReadOnlyList<(int modId, string? installed, IReadOnlyList<int> fileIds)> mods)
     {
-        if (!data.TryGetProperty(alias, out var arr) || arr.ValueKind != JsonValueKind.Array) return (null, 0);
-        string? bestVer = null; long bestDate = 0;
-        foreach (var f in arr.EnumerateArray())
+        var order = new List<int>();
+        var map = new Dictionary<int, (string? installed, List<int> fileIds)>();
+        foreach (var m in mods)
         {
-            if (Str(f, "category") != "MAIN") continue;
-            var d = Long(f, "date");
-            if (bestVer is null || d > bestDate) { bestVer = Str(f, "version") ?? "?"; bestDate = d; }
+            if (m.modId <= 0) continue;
+            if (!map.TryGetValue(m.modId, out var grp)) { grp = (null, new List<int>()); order.Add(m.modId); }
+            if (grp.installed is null && !string.IsNullOrWhiteSpace(m.installed)) grp.installed = m.installed;
+            if (m.fileIds is not null)
+                foreach (var fid in m.fileIds) if (fid > 0 && !grp.fileIds.Contains(fid)) grp.fileIds.Add(fid);
+            map[m.modId] = grp;
         }
-        return (bestVer, bestDate);
+        return (order, map);
+    }
+
+    /// <summary>Whether a file category is one of Nexus's two RETIREMENT buckets (OLD_VERSION / ARCHIVED) — the CLOSED
+    /// superseded set. Every other category (MAIN/UPDATE/OPTIONAL/MISCELLANEOUS, or one Nexus adds later) is treated as
+    /// live/offered, and the category string is always carried into the output, so an unfamiliar one is visible rather
+    /// than silently mis-bucketed (Q3).</summary>
+    static bool IsSuperseded(string category) => category is "OLD_VERSION" or "ARCHIVED";
+
+    /// <summary>Resolve one mod's file-level currency from its installed file id(s) and its full file list. See
+    /// <see cref="CheckUpdatesAsync"/> for what each verdict means. Internal (pure) for the CI guard.</summary>
+    internal static NexusUpdateStatus ComputeStatus(int modId, bool found, string? name, string? header, string? installed,
+        IReadOnlyList<int> fileIds, List<(int fileId, string name, string? version, string category, long date)> files)
+    {
+        if (!found) return new NexusUpdateStatus(modId, false, name, header, installed, UpdateVerdict.NotFound, NoFiles, null, 0, 0);
+
+        // Newest live MAIN + how many — context for LatestOnly and the no-file-id fallback (LiveMainCount>1 ⇒ a multi-main
+        // page a version compare can't safely resolve: the false-positive root cause).
+        string? mainVer = null; long mainDate = 0; int mainCount = 0;
+        foreach (var f in files)
+            if (f.category == "MAIN") { mainCount++; if (mainVer is null || f.date > mainDate) { mainVer = f.version ?? "?"; mainDate = f.date; } }
+
+        // FILE-LEVEL — the exact installed file id(s) are the honest currency key.
+        if (fileIds.Count > 0)
+        {
+            var detail = new List<InstalledFileCurrency>(fileIds.Count);
+            foreach (var fid in fileIds)
+            {
+                int idx = files.FindIndex(f => f.fileId == fid);
+                if (idx < 0) { detail.Add(new InstalledFileCurrency(fid, null, null, null, FileVerdict.Missing, null, null, 0)); continue; }
+                var hit = files[idx];
+                if (IsSuperseded(hit.category))
+                {
+                    // Point to the newest LIVE file with the SAME name (the variant line's replacement); left null if the
+                    // author renamed it or dropped the variant — then the report says so rather than guess the wrong file.
+                    string? rn = null, rv = null; long rd = 0;
+                    foreach (var f in files)
+                        if (!IsSuperseded(f.category) && string.Equals(f.name, hit.name, StringComparison.OrdinalIgnoreCase) && (rn is null || f.date > rd))
+                            { rn = f.name; rv = f.version ?? "?"; rd = f.date; }
+                    detail.Add(new InstalledFileCurrency(fid, hit.name, hit.version, hit.category, FileVerdict.Superseded, rn, rv, rd));
+                }
+                else detail.Add(new InstalledFileCurrency(fid, hit.name, hit.version, hit.category, FileVerdict.Live, null, null, 0));
+            }
+            var verdict = detail.Any(d => d.Verdict == FileVerdict.Superseded) ? UpdateVerdict.Outdated
+                        : detail.Any(d => d.Verdict == FileVerdict.Missing)    ? UpdateVerdict.FileGone
+                        :                                                        UpdateVerdict.Current;
+            return new NexusUpdateStatus(modId, true, name, header, installed, verdict, detail, mainVer, mainDate, mainCount);
+        }
+
+        // NO FILE ID — degrade LOUDLY (never the old mod-level compare). Bare id (no version either) ⇒ just list newest.
+        var fallback = string.IsNullOrWhiteSpace(installed) ? UpdateVerdict.LatestOnly : UpdateVerdict.NoFileId;
+        return new NexusUpdateStatus(modId, true, name, header, installed, fallback, NoFiles, mainVer, mainDate, mainCount);
+    }
+
+    /// <summary>Parse an aliased <c>f&lt;modId&gt;</c> modFiles array from a batch response into (fileId, name, version,
+    /// category, date) tuples; empty when the alias is absent or not an array.</summary>
+    static List<(int fileId, string name, string? version, string category, long date)> FilesFromAlias(JsonElement data, string alias)
+    {
+        var list = new List<(int, string, string?, string, long)>();
+        if (!data.TryGetProperty(alias, out var arr) || arr.ValueKind != JsonValueKind.Array) return list;
+        foreach (var f in arr.EnumerateArray())
+            list.Add((Int(f, "fileId"), Str(f, "name") ?? "", Str(f, "version"), Str(f, "category") ?? "", Long(f, "date")));
+        return list;
     }
 
     /// <summary>Identify uploaded files by MD5 hash — bulk (v2 <c>fileHashes(md5s: [String!]!)</c>, keyless). For each
@@ -365,19 +437,42 @@ public sealed record NexusModDetail(
     int Endorsements, int Downloads, string? UpdatedAt, string? CreatedAt, bool AdultContent, string Status,
     bool DirectDownloadEnabled, IReadOnlyList<NexusRequirement> NexusRequirements, IReadOnlyList<NexusFile> Files);
 
-/// <summary>The verdict for one mod in a batch update check. <see cref="Differs"/> deliberately does NOT assert a
-/// direction (behind vs ahead) — a freeform version string like '6.9' vs '6.11' isn't safely comparable, so the tool
-/// reports both versions and lets the reader (or the triage skill) judge; asserting "you're behind" could be wrong when
-/// the user is on a hotfix. <see cref="NoMainFile"/> / <see cref="NotFound"/> / <see cref="Error"/> are the Q3 honest
-/// "couldn't decide" states, never silently folded into "current".</summary>
-public enum UpdateVerdict { NotFound, NoMainFile, Current, Differs, LatestOnly, Error }
+/// <summary>Whether one installed file is still a LIVE file on its mod's page, has been SUPERSEDED (the author moved it
+/// to OLD_VERSION/ARCHIVED), or is MISSING entirely (hidden/deleted — can't determine). The file-level currency signal a
+/// mod-level version compare can't give: Nexus itself retires a file, so its category IS the honest "is my exact file
+/// current" answer — immune to the multi-file-page confusion.</summary>
+public enum FileVerdict { Live, Superseded, Missing }
 
-/// <summary>One mod's batch update-check result. <paramref name="LatestMainVersion"/>/<paramref name="LatestMainDate"/>
-/// are the newest MAIN file (the accurate version of record); <paramref name="HeaderVersion"/> is the mod's version
-/// header (which can lag). <paramref name="Note"/> carries the failure reason when <paramref name="Verdict"/> is Error.</summary>
+/// <summary>One installed file's currency: the file (resolved from its id) and its verdict, plus — when
+/// <see cref="Verdict"/> is <see cref="FileVerdict.Superseded"/> — the newest LIVE file with the SAME name (the same
+/// variant line's replacement to update to; null when the author renamed/dropped that variant). <see cref="Name"/>/
+/// <see cref="Version"/>/<see cref="Category"/> are null only for a <see cref="FileVerdict.Missing"/> file (not on the
+/// page to resolve).</summary>
+public sealed record InstalledFileCurrency(
+    int FileId, string? Name, string? Version, string? Category, FileVerdict Verdict,
+    string? NewestSameName, string? NewestSameVersion, long NewestSameDate);
+
+/// <summary>The verdict for one mod in a batch FILE-LEVEL update check — "is the exact file I installed still current?"
+/// <see cref="Current"/> = every installed file is still a live file; <see cref="Outdated"/> = at least one was retired
+/// to OLD_VERSION/ARCHIVED (the per-file detail points to its same-name replacement); <see cref="FileGone"/> = an
+/// installed file id is no longer on the page (hidden/deleted) — a loud UNKNOWN, never "current". <see cref="NoFileId"/>
+/// = no file id was available (a FOMOD/manual install) so a file-level check can't run — a LOUD best-effort fallback,
+/// never the old confidently-wrong mod-level compare. <see cref="LatestOnly"/> = only a mod id was given (no version, no
+/// file id) → newest listed, no verdict. <see cref="NotFound"/> / <see cref="Error"/> are the Q3 honest "couldn't
+/// decide" states, never silently folded into "current".</summary>
+public enum UpdateVerdict { Current, Outdated, FileGone, NoFileId, LatestOnly, NotFound, Error }
+
+/// <summary>One mod's batch update-check result. <paramref name="Files"/> is the per-installed-file currency detail
+/// (present for the file-level verdicts Current/Outdated/FileGone; empty otherwise). <paramref name="LatestMainVersion"/>
+/// /<paramref name="LatestMainDate"/> + <paramref name="LiveMainCount"/> are the newest live MAIN file — context for
+/// LatestOnly and the NoFileId fallback (LiveMainCount &gt; 1 ⇒ a multi-main page a version compare can't safely
+/// resolve). <paramref name="HeaderVersion"/> is the mod's version header (can lag). <paramref name="Installed"/> is the
+/// caller's installed version string (for the NoFileId display). <paramref name="Note"/> carries the failure reason when
+/// <paramref name="Verdict"/> is Error.</summary>
 public sealed record NexusUpdateStatus(
-    int ModId, bool Found, string? Name, string? HeaderVersion,
-    string? LatestMainVersion, long LatestMainDate, string? Installed, UpdateVerdict Verdict, string? Note = null);
+    int ModId, bool Found, string? Name, string? HeaderVersion, string? Installed, UpdateVerdict Verdict,
+    IReadOnlyList<InstalledFileCurrency> Files, string? LatestMainVersion, long LatestMainDate, int LiveMainCount,
+    string? Note = null);
 
 /// <summary>One MD5-hash match: the Nexus file (name/type/size) and the mod it belongs to (id + name), plus the file's
 /// version + category and the <paramref name="GameId"/> — a match on a non-Skyrim-SE game is flagged, not mis-attributed.</summary>

--- a/src/housecarl-mcp/NexusTools.cs
+++ b/src/housecarl-mcp/NexusTools.cs
@@ -106,23 +106,31 @@ public static class NexusTools
         return Render.Mod(detail!, description, files, changelog, since);
     }, ct);
 
-    [McpServerTool(Name = "housecarl_nexus_check_updates", ReadOnly = true, Title = "Batch-check Nexus mods for updates"),
+    [McpServerTool(Name = "housecarl_nexus_check_updates", ReadOnly = true, Title = "Batch-check Nexus mods for updates (file-level)"),
      Description(
-         "Check MANY Skyrim Special Edition mods for available updates in ONE call — without a browser and without an API " +
-         "key. Give a list of mods (each a numeric Nexus mod id, optionally with your installed version); houseCARL " +
-         "resolves each mod's newest MAIN file — the accurate 'latest version', because a mod's version header can lag its " +
-         "newest file — and reports per mod: CURRENT, DIFFERS (your version ≠ the newest MAIN; both are shown and the " +
-         "direction is NOT asserted, since freeform version strings aren't safely comparable), no-main-file, or not-found " +
-         "(wrong id, or an LE/other-game mod). Batched into few requests (dozens of mods per call). READ-ONLY, needs an " +
-         "internet connection (local tools work offline). Does NOT download or update anything — it is a REPORT. Build the " +
-         "list cheaply with housecarl_update_status (reads MO2's own local update cache, no network), then use " +
-         "housecarl_nexus_mod changelog=true on anything that DIFFERS to see what actually changed.")]
+         "Check MANY Skyrim Special Edition mods for updates in ONE call — at the FILE level, without a browser or an API " +
+         "key. The accurate question is 'is the exact FILE I installed still current?', NOT 'does my version match the " +
+         "page's newest main' — a Nexus page hosts many independently-versioned files (patch hubs, ENB pages, Xtudo " +
+         "mega-packs), so comparing your file to the page's single newest main is confidently WRONG for those. Pass each " +
+         "mod as 'id#fileid' — the fileid MO2 recorded for what you installed, which housecarl_update_status prints per " +
+         "row as a 'verify:' token (several files installed from one page → 'id#fileid1#fileid2'). houseCARL resolves each " +
+         "installed file to its live status and reports per mod: CURRENT (your file is still a live file on the page), " +
+         "OUTDATED (your file was RETIRED to OLD_VERSION/ARCHIVED — it names the newest same-name file to grab), FILE-GONE " +
+         "(your file is no longer on the page — hidden/deleted, a loud unknown), or not-found (wrong id / LE/other-game). " +
+         "If you pass only 'id=version' with NO fileid (a FOMOD/manual install), it degrades LOUDLY to a best-effort " +
+         "'no-fileid' note — never a confident verdict, because the mod-level compare lies for multi-file pages. Batched " +
+         "(dozens of mods per call). READ-ONLY, needs an internet connection (local tools work offline). Does NOT download " +
+         "or update anything — it is a REPORT. Build the list cheaply with housecarl_update_status (reads MO2's own local " +
+         "cache, no network, and prints each mod's fileid), then housecarl_nexus_mod changelog=true on anything OUTDATED " +
+         "to see what actually changed.")]
     public static Task<string> NexusCheckUpdates(
         NexusClient nexus,
-        [Description("The mods to check — one entry per mod, separated by commas or newlines. Each entry is a numeric " +
-            "Nexus mod id, optionally followed by your installed version after '=' (or a space or ':'): e.g. " +
-            "'12604=6.9, 266=4.3.8a, 3863'. An entry with no version is reported with its latest version only (no " +
-            "current/behind verdict). Non-numeric junk is skipped and listed back to you.")]
+        [Description("The mods to check — one entry per mod, separated by commas or newlines. Preferred (FILE-LEVEL) form: " +
+            "'id#fileid', the mod id then '#' then the Nexus file id MO2 recorded for what you installed (housecarl_update_status " +
+            "prints this as the 'verify:' token); if you installed several files from one page, add more with '#': " +
+            "'126608#533265, 99786#585300#585301'. Without a fileid you can pass 'id=version' (or 'id version') for a LOUD " +
+            "best-effort no-fileid note, or a bare 'id' for its latest version only — e.g. '12604=6.9, 3863'. The " +
+            "intra-fileid separator is '#', because ',' separates entries. Non-numeric junk is skipped and listed back to you.")]
             string mods,
         CancellationToken ct = default) => Guard.Tool("housecarl_nexus_check_updates", async () =>
     {
@@ -136,23 +144,41 @@ public static class NexusTools
         return Render.Updates(results, bad);
     }, ct);
 
-    /// <summary>Parse the check-updates input — comma/newline/semicolon-separated entries, each a numeric mod id with an
-    /// OPTIONAL installed version after '=', ':' or whitespace (e.g. '12604=6.9', '266 4.3.8a', '3863'). Returns the
-    /// (modId, installedVersion|null) pairs plus the tokens it couldn't read (surfaced back, never silently dropped — Q3).</summary>
-    static (List<(int modId, string? installed)> pairs, List<string> bad) ParseUpdatePairs(string input)
+    /// <summary>Parse the check-updates input — comma/newline/semicolon-separated entries. Two forms per entry:
+    /// FILE-LEVEL <c>&lt;modid&gt;#&lt;fileid&gt;[#&lt;fileid&gt;…]</c> (the honest check — the fileid(s) MO2 recorded,
+    /// several installed files on one page joined with more '#'), or VERSION/bare <c>&lt;modid&gt;[=&lt;version&gt;]</c>
+    /// (a '#'-less entry — the no-fileid FOMOD/manual fallback, or a bare id for latest-only). Returns
+    /// (modId, installedVersion|null, fileIds) triples plus the tokens it couldn't read (surfaced back, never silently
+    /// dropped — Q3). The intra-fileid separator is '#', not ',', because ',' already splits ENTRIES. Internal for the CI guard.</summary>
+    internal static (List<(int modId, string? installed, IReadOnlyList<int> fileIds)> pairs, List<string> bad) ParseUpdatePairs(string input)
     {
-        var pairs = new List<(int, string?)>();
+        var pairs = new List<(int, string?, IReadOnlyList<int>)>();
         var bad = new List<string>();
         if (string.IsNullOrWhiteSpace(input)) return (pairs, bad);
         foreach (var raw in input.Split(new[] { ',', '\n', ';', '\r' }, StringSplitOptions.RemoveEmptyEntries))
         {
             var entry = raw.Trim();
             if (entry.Length == 0) continue;
+
+            // FILE-LEVEL form: <modid>#<fileid>[#<fileid>...]
+            int hash = entry.IndexOf('#');
+            if (hash >= 0)
+            {
+                if (!int.TryParse(entry[..hash].Trim(), out var mid) || mid <= 0) { bad.Add(entry); continue; }
+                var fids = new List<int>();
+                foreach (var tok in entry[(hash + 1)..].Split('#', StringSplitOptions.RemoveEmptyEntries))
+                    if (int.TryParse(tok.Trim(), out var fid) && fid > 0) fids.Add(fid);
+                if (fids.Count == 0) { bad.Add(entry); continue; }   // a '#' with no readable fileid — surface, don't downgrade to a silent no-fileid verdict
+                pairs.Add((mid, null, fids));
+                continue;
+            }
+
+            // VERSION / bare form: <modid>[ (= | : | space) <version> ]
             var m = Regex.Match(entry, @"^(\d+)\s*[:=\s]?\s*(.*)$");
             if (m.Success && int.TryParse(m.Groups[1].Value, out var id) && id > 0)
             {
                 var ver = m.Groups[2].Value.Trim();
-                pairs.Add((id, ver.Length == 0 ? null : ver));
+                pairs.Add((id, ver.Length == 0 ? null : ver, Array.Empty<int>()));
             }
             else bad.Add(entry);
         }
@@ -432,29 +458,32 @@ static class Render
         return bytes + " B";
     }
 
-    /// <summary>Render a batch update check: a one-line summary (how many differ / current / not-found / …) then the mods
-    /// grouped by verdict, ACTIONABLE first (differ → latest-only → no-main → current → not-found → error). Unreadable
+    /// <summary>Render a batch FILE-LEVEL update check: a one-line summary then the mods grouped by verdict, ACTIONABLE
+    /// first (outdated → file-gone → no-fileid → current → latest-only → not-found → error). Each file-level row lists its
+    /// installed file(s) with the live/retired/missing verdict; a retired file names the same-name replacement. Unreadable
     /// input tokens are listed back at the end (Q3 — a skipped entry is never silently dropped).</summary>
     public static string Updates(IReadOnlyList<NexusUpdateStatus> results, IReadOnlyList<string> unreadable)
     {
         var sb = new StringBuilder();
-        int differ = results.Count(r => r.Verdict == UpdateVerdict.Differs);
+        int outdated = results.Count(r => r.Verdict == UpdateVerdict.Outdated);
         int current = results.Count(r => r.Verdict == UpdateVerdict.Current);
+        int fileGone = results.Count(r => r.Verdict == UpdateVerdict.FileGone);
+        int noFileId = results.Count(r => r.Verdict == UpdateVerdict.NoFileId);
         int latest = results.Count(r => r.Verdict == UpdateVerdict.LatestOnly);
-        int noMain = results.Count(r => r.Verdict == UpdateVerdict.NoMainFile);
         int notFound = results.Count(r => r.Verdict == UpdateVerdict.NotFound);
         int errored = results.Count(r => r.Verdict == UpdateVerdict.Error);
 
-        sb.Append("update check — ").Append(results.Count).Append(" mod(s): ")
-          .Append(differ).Append(" differ · ").Append(current).Append(" current · ")
-          .Append(latest).Append(" latest-only · ").Append(noMain).Append(" no-main · ")
-          .Append(notFound).Append(" not-found");
+        sb.Append("update check (file-level) — ").Append(results.Count).Append(" mod(s): ")
+          .Append(outdated).Append(" outdated · ").Append(current).Append(" current · ")
+          .Append(fileGone).Append(" file-gone · ").Append(noFileId).Append(" no-fileid · ")
+          .Append(latest).Append(" latest-only · ").Append(notFound).Append(" not-found");
         if (errored > 0) sb.Append(" · ").Append(errored).Append(" error");
 
-        AppendUpdateGroup(sb, "DIFFER — installed ≠ newest MAIN (check the changelog before updating)", results, UpdateVerdict.Differs);
-        AppendUpdateGroup(sb, "latest version (no installed version was given to compare)", results, UpdateVerdict.LatestOnly);
-        AppendUpdateGroup(sb, "no MAIN file — the header version may lag, so UNKNOWN", results, UpdateVerdict.NoMainFile);
-        AppendUpdateGroup(sb, "current", results, UpdateVerdict.Current);
+        AppendUpdateGroup(sb, "OUTDATED — an installed file was RETIRED to OLD/ARCHIVED (grab the newest same-name file)", results, UpdateVerdict.Outdated);
+        AppendUpdateGroup(sb, "FILE GONE — your installed file is no longer on the page (hidden/deleted) — verify by hand, don't assume", results, UpdateVerdict.FileGone);
+        AppendUpdateGroup(sb, "NO FILEID — couldn't verify at file level (FOMOD/manual install); best-effort only, not a verdict", results, UpdateVerdict.NoFileId);
+        AppendUpdateGroup(sb, "current — the exact file you installed is still a live file on the page", results, UpdateVerdict.Current);
+        AppendUpdateGroup(sb, "latest version (no installed version/fileid was given to compare)", results, UpdateVerdict.LatestOnly);
         AppendUpdateGroup(sb, "not found on Skyrim SE (wrong id, or an LE/other-game mod)", results, UpdateVerdict.NotFound);
         AppendUpdateGroup(sb, "check FAILED (surface, don't assume current)", results, UpdateVerdict.Error);
 
@@ -473,19 +502,27 @@ static class Render
             sb.Append("\n  [").Append(r.ModId).Append("] ").Append(r.Name ?? "?");
             switch (r.Verdict)
             {
-                case UpdateVerdict.Differs:
-                    sb.Append(" — installed v").Append(r.Installed).Append(", newest MAIN v").Append(r.LatestMainVersion ?? "?");
-                    if (r.LatestMainDate > 0) sb.Append(" (").Append(Day(r.LatestMainDate)).Append(')');
-                    break;
+                case UpdateVerdict.Outdated:
+                case UpdateVerdict.FileGone:
                 case UpdateVerdict.Current:
-                    sb.Append(" — v").Append(r.Installed).Append(" (current)");
+                    foreach (var f in r.Files) AppendFileCurrency(sb, f);
+                    break;
+                case UpdateVerdict.NoFileId:
+                    sb.Append(" — installed v").Append(r.Installed ?? "?");
+                    if (r.LiveMainCount == 1)
+                        sb.Append("; newest MAIN v").Append(r.LatestMainVersion ?? "?")
+                          .Append(r.LatestMainDate > 0 ? " (" + Day(r.LatestMainDate) + ")" : "")
+                          .Append(" — VERSION compare only (single-main page; no fileid to verify the exact file)");
+                    else if (r.LiveMainCount > 1)
+                        sb.Append("; this page has ").Append(r.LiveMainCount)
+                          .Append(" current MAIN files — can't tell which you have without a fileid (open the page)");
+                    else
+                        sb.Append("; no MAIN file listed — can't verify at file level without a fileid");
                     break;
                 case UpdateVerdict.LatestOnly:
                     sb.Append(" — newest MAIN v").Append(r.LatestMainVersion ?? "?");
                     if (r.LatestMainDate > 0) sb.Append(" (").Append(Day(r.LatestMainDate)).Append(')');
-                    break;
-                case UpdateVerdict.NoMainFile:
-                    sb.Append(" — no MAIN file; header v").Append(r.HeaderVersion ?? "?");
+                    if (r.LiveMainCount > 1) sb.Append(" [+").Append(r.LiveMainCount - 1).Append(" other current MAIN file(s)]");
                     break;
                 case UpdateVerdict.Error:
                     sb.Append(" — ").Append(r.Note ?? "check failed");
@@ -493,6 +530,30 @@ static class Render
                 case UpdateVerdict.NotFound:
                     break;   // the group label already says it
             }
+        }
+    }
+
+    /// <summary>Render one installed file's currency line under its mod: id, then (unless the file is gone) its name /
+    /// version / category and the live/retired verdict; a RETIRED file names the newest same-name replacement (or says
+    /// there isn't one). The category is always shown, so an unfamiliar Nexus category is visible, not hidden (Q3).</summary>
+    static void AppendFileCurrency(StringBuilder sb, InstalledFileCurrency f)
+    {
+        sb.Append("\n      · file #").Append(f.FileId);
+        if (f.Verdict == FileVerdict.Missing)
+        {
+            sb.Append(" — not on the page anymore (hidden/deleted; can't determine currency)");
+            return;
+        }
+        sb.Append(" '").Append(f.Name ?? "?").Append("' v").Append(f.Version ?? "?").Append(" [").Append(f.Category ?? "?").Append(']');
+        if (f.Verdict == FileVerdict.Live) sb.Append(" — current");
+        else
+        {
+            sb.Append(" — RETIRED");
+            if (f.NewestSameName is not null)
+                sb.Append("; newest '").Append(f.NewestSameName).Append("' v").Append(f.NewestSameVersion ?? "?")
+                  .Append(f.NewestSameDate > 0 ? " (" + Day(f.NewestSameDate) + ")" : "");
+            else
+                sb.Append("; no current file with that exact name — open the page to pick the replacement");
         }
     }
 

--- a/src/housecarl-mcp/Program.cs
+++ b/src/housecarl-mcp/Program.cs
@@ -142,10 +142,12 @@ static void AddMcp(IServiceCollection services, bool stdio)
             "housecarl_nexus_search (find a mod by name); housecarl_nexus_mod (a mod's requirements, recommended INI " +
             "settings, accurate latest version and full page description, plus files=true for the complete per-file " +
             "list and changelog=true / since= for the per-version CHANGELOG and update delta, by id or URL); " +
-            "housecarl_nexus_check_updates (batch behind/current check across many mods in one call); and " +
+            "housecarl_nexus_check_updates (batch FILE-LEVEL update check — pass each mod as 'id#fileid' to tell CURRENT " +
+            "from OUTDATED for the EXACT file installed, correct for the multi-file pages where a version compare lies); and " +
             "housecarl_nexus_identify (trace a file to its source mod by MD5 hash). For mod updates, start with " +
-            "housecarl_update_status — it reads MO2's OWN local update cache with NO network to narrow the list — then " +
-            "verify the flagged mods live. Prefer these over a browser or generic web search for any Nexus lookup: " +
+            "housecarl_update_status — it reads MO2's OWN local update cache with NO network to narrow the list AND prints " +
+            "each mod's 'id#fileid' verify token — then feed those tokens to housecarl_nexus_check_updates to confirm live. " +
+            "Prefer these over a browser or generic web search for any Nexus lookup: " +
             "houseCARL can already read changelogs, file lists, and update status directly, so never hand-roll scripts " +
             "around a rendered Nexus page.";
     });

--- a/src/housecarl-mcp/UpdateStatusTools.cs
+++ b/src/housecarl-mcp/UpdateStatusTools.cs
@@ -74,9 +74,12 @@ static class UpdateStatusWire
 
         sb.Append("\nnote: this is MO2's OWN cached view, not a live check. A 'differ' is only a CANDIDATE — MO2's cached ")
           .Append("'newest' can be stale or a different version scheme (some installed versions here are actually NEWER than ")
-          .Append("the cached value), so the direction is not assured and 'never checked' is NOT 'up to date'. To confirm ")
-          .Append("what's genuinely behind, feed these mod ids to housecarl_nexus_check_updates (authoritative newest MAIN " )
-          .Append("file), then housecarl_nexus_mod changelog=true to see what changed.");
+          .Append("the cached value), so the direction is not assured and 'never checked' is NOT 'up to date'. Many Nexus ")
+          .Append("pages also host several independently-versioned files, so a cached 'differ' is often a false alarm. To ")
+          .Append("confirm, feed these mods to housecarl_nexus_check_updates using the 'id#fileid' form shown per row (the ")
+          .Append("'verify:' token) — it checks each installed FILE's live status directly, clearing the multi-file-page ")
+          .Append("false positive; then housecarl_nexus_mod changelog=true to see what changed. (Rows with no fileid can't ")
+          .Append("be checked at file level — verify those by hand.)");
         return sb.ToString().TrimEnd('\n');
     }
 
@@ -93,6 +96,14 @@ static class UpdateStatusWire
             if (e.Enabled == false) sb.Append("  [disabled]");
             sb.Append("  [id ").Append(e.ModId).Append("]  installed v").Append(e.Installed ?? "?")
               .Append(" · MO2 cached v").Append(e.Newest ?? "?");
+            // Surface the exact installed file id(s): the join key for a FILE-level live check (housecarl_nexus_check_updates
+            // 'id#fileid' form) — the way to clear the multi-file-page false positive this cached diff can't tell from a real
+            // update. A FOMOD/manual mod has none, and that's stated (Q3 — the file-level check can't run there, don't imply it can).
+            if (e.InstalledFileIds.Count > 0)
+                sb.Append("  · verify: ").Append(e.ModId).Append('#')
+                  .Append(string.Join("#", e.InstalledFileIds));   // '#' joins fileids — ',' separates ENTRIES in the check grammar
+            else
+                sb.Append("  · no fileid (FOMOD/manual — file-level check n/a)");
             var checkedOn = StaleDay(e.LastUpdate);
             if (checkedOn is not null) sb.Append("  (checked ").Append(checkedOn).Append(')');
             sb.Append('\n'); shown++;


### PR DESCRIPTION
## The bug (Q3 violation in a shipped tool)

`housecarl_nexus_check_updates` compared the installed **version** against a mod page's single newest MAIN file. A Nexus page hosts many independently-versioned files (patch hubs, ENB pages, Xtudo mega-packs), so when the file you installed isn't that newest MAIN, the check compared apples to oranges and emitted a confidently-wrong "update available."

Aaron caught it live: **AMON ENB (99786)** flagged installed `v2` → "latest `v10`", but his file (fileid `585300`, "Amon NAT III Esp Fix" v2) is a **current MAIN**; the `v10` is a different variant on the same page.

## The fix — file-level via MO2's stored fileid

The honest question is per-**file**: is the exact file I installed still a live file on the page, or did Nexus retire it? Nexus's own file **category** is that signal.

- **`Mo2ModMeta`** now parses the `[installedFiles] N\fileid` value(s) MO2 records (single, multiple, `size=0` = none), surfaced through `housecarl_update_status` as an `id#fileid` **"verify:" token** per row.
- **`CheckUpdatesAsync`** takes installed fileid(s); the aliased `modFiles` query selects `fileId`+`name`; each installed fileid resolves to its category:
  - live (MAIN/UPDATE/OPTIONAL/MISCELLANEOUS) → **CURRENT**
  - OLD_VERSION/ARCHIVED → **OUTDATED** (points to the newest **same-name** live file, not the page's global newest)
  - absent from the list → **FileGone** (loud unknown, never "current")
  - no fileid (FOMOD/manual) → a **loud NoFileId fallback**, never the old mod-level compare
- Entries **group by modId and merge fileids** — a page split across several mod folders (one Xtudo pack per creature) shares a modId; queried once, every installed file checked, never dedup-dropped.
- `ParseUpdatePairs` accepts the `id#fileid` grammar (`#` separates fileids, `,` separates entries).

## Testing

- **VERIFY-FIRST probe:** confirmed the keyless v2 GraphQL returns per-file `fileId`+`category`, joining `meta.ini` exactly (76942→323957, 172480→723784, 99786→585300).
- **New CI guard** `nexus-file-check-guard`: verdict logic (live→current, archived→outdated+same-name pointer, missing→file-gone, no-fileid→loud), the `id#fileid` parse, and the modId merge — on synthetic AMON-shaped fixtures, network-free. `mo2-modmeta-guard` extended for the fileid parse.
- **ci-all: 87/87 green.**
- **End-to-end against live Nexus** (the exact assembled batch query): `99786#585300 → CURRENT` (the false-positive kill), `172480#723784 → CURRENT`.
- **ARR 2.0 measurement:** 82% of Nexus mods (2709/3303) get exact file-level checking; **18% (594, almost all FOMOD `size=0`)** fall to the loud no-fileid fallback.

## Design note

Chose to **enhance `housecarl_nexus_check_updates`** rather than add a new verb (bug lives there, file-level is strictly the same job done right, callers inherit the fix, tool count stays 37). `nexusFileStatus` deferred (enum unknown; fileid join is robust).

**PRFAQ §4 outcome (b):** the goal — accurate keyless Nexus update awareness — holds; the *method* (mod-level version compare) was wrong for multi-file pages; the revision (file-level via fileid) preserves the goal.

## Not landed until Aaron's go
Two atomic commits; independent review + explicit go gate the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
