### PR TITLE
fix(nexus): check_updates resolves manager-only (nxm) mods, not "not found"

### DIFF
--- a/src/housecarl-generator/NexusFileCheckProbe.cs
+++ b/src/housecarl-generator/NexusFileCheckProbe.cs
@@ -99,6 +99,12 @@ internal static class NexusFileCheckProbe
         var jNo = NexusClient.ComputeStatus(90696, false, null, null, "2.0.0.0", Array.Empty<int>(), files);
         Check(jNo.Verdict == UpdateVerdict.NoFileId, "J3: found=false, files present, no fileid → NoFileId fallback (exists), not NotFound");
 
+        // J4 — the SAFETY-relevant nxm combination: a search-absent mod (found=false) whose modFiles DID come back, but the
+        //      exact installed fileid is NO LONGER in that list (a hidden/pulled file) ⇒ FileGone (loud unknown), never
+        //      NotFound and never a silent "current". 999999 isn't in the synthetic list.
+        var jGone = NexusClient.ComputeStatus(90696, false, null, null, "1.0", new[] { 999999 }, files);
+        Check(jGone.Verdict == UpdateVerdict.FileGone, "J4: found=false + files present + installed fileid absent → FileGone (loud), not NotFound");
+
         // H — single-main page, no fileid + version ⇒ NoFileId with LiveMainCount==1 (the labeled version-compare case).
         var single = new List<(int, string, string?, string, long)>
         {

--- a/src/housecarl-generator/NexusFileCheckProbe.cs
+++ b/src/housecarl-generator/NexusFileCheckProbe.cs
@@ -9,7 +9,9 @@ namespace HousecarlGenerator;
 ///   • NexusClient.ComputeStatus — the currency verdict from an installed fileid + the mod's file list: a live-category
 ///     file ⇒ Current, an OLD_VERSION/ARCHIVED file ⇒ Outdated (pointing to the newest SAME-NAME live file, not the
 ///     page's global newest), an absent fileid ⇒ FileGone (loud), no fileid ⇒ NoFileId/LatestOnly (loud fallback,
-///     never a confident mod-level verdict), plus multi-file aggregation and the not-found state.
+///     never a confident mod-level verdict), plus multi-file aggregation and the not-found state. A mod hidden from the
+///     mods() SEARCH but resolvable via its direct modFiles lookup (the manager-only/nxm class) is still checked from
+///     its files, never mis-stamped NotFound — the search's "found" flag no longer vetoes already-fetched data (G/J).
 ///   • NexusTools.ParseUpdatePairs — the 'id#fileid' input grammar (file-level vs version vs bare, junk surfaced).
 ///   • NexusClient.GroupRequests — same-modId-across-folders MERGES fileids (the Xtudo multi-folder case), never
 ///     dedup-drops a folder.
@@ -73,9 +75,29 @@ internal static class NexusFileCheckProbe
         var f = NexusClient.ComputeStatus(3863, true, "Some Mod", "1.0", null, Array.Empty<int>(), files);
         Check(f.Verdict == UpdateVerdict.LatestOnly, "F: bare id (no version, no fileid) → LatestOnly");
 
-        // G — mod not found on SSE ⇒ NotFound (never folded into current).
-        var g = NexusClient.ComputeStatus(1, false, null, null, "1.0", new[] { 123 }, files);
-        Check(g.Verdict == UpdateVerdict.NotFound, "G: mod not found → NotFound");
+        // G — GENUINELY not found: absent from the mods() search AND the modFiles lookup returned NOTHING (a missing mod
+        //     comes back as an empty file list, never an error). The EMPTY list is what makes it genuine — contrast J,
+        //     where files DID come back for a search-absent mod and it must still be checked.
+        var g = NexusClient.ComputeStatus(1, false, null, null, "1.0", new[] { 123 }, new List<(int, string, string?, string, long)>());
+        Check(g.Verdict == UpdateVerdict.NotFound, "G: not in search AND no files returned → NotFound (genuinely gone/wrong-id)");
+
+        // J — the nxm-only BLIND SPOT this guard was extended to lock. Nexus EXCLUDES manager-only (direct-download-
+        //     disabled) mods from the mods() search collection, so found=false — but their direct modFiles lookup resolves
+        //     fine and returned files. The installed file MUST be checked from that list, never stamped NotFound (a
+        //     confidently-wrong "not found" for a real, checkable mod — the same false-answer class the file-level fix
+        //     exists to kill). 585300 is a LIVE MAIN in the synthetic list ⇒ Current, and the mod reports Found (exists).
+        var jLive = NexusClient.ComputeStatus(90696, false, null, null, null, new[] { 585300 }, files);
+        Check(jLive.Verdict == UpdateVerdict.Current, "J: found=false but modFiles returned files → check them (Current), NOT NotFound (nxm-only)");
+        Check(jLive.Found, "J: a mod resolved via its file list is reported Found — it exists (a null friendly name is fine)");
+
+        // J2 — same blind spot, installed file RETIRED ⇒ Outdated (still checked from the file list, not NotFound).
+        var jOut = NexusClient.ComputeStatus(132337, false, null, null, "1", new[] { 483794 }, files);
+        Check(jOut.Verdict == UpdateVerdict.Outdated, "J2: found=false + retired installed file → Outdated (checked, not NotFound)");
+
+        // J3 — a search-absent mod with NO fileid (FOMOD/manual) can't be file-checked, but we now know it EXISTS (files
+        //      came back), so it degrades to the LOUD NoFileId fallback — never NotFound.
+        var jNo = NexusClient.ComputeStatus(90696, false, null, null, "2.0.0.0", Array.Empty<int>(), files);
+        Check(jNo.Verdict == UpdateVerdict.NoFileId, "J3: found=false, files present, no fileid → NoFileId fallback (exists), not NotFound");
 
         // H — single-main page, no fileid + version ⇒ NoFileId with LiveMainCount==1 (the labeled version-compare case).
         var single = new List<(int, string, string?, string, long)>

--- a/src/housecarl-mcp/NexusClient.cs
+++ b/src/housecarl-mcp/NexusClient.cs
@@ -226,6 +226,9 @@ public sealed class NexusClient
         // modFiles lookup resolves fine; gating NotFound on the search alone would discard those already-fetched files and
         // stamp a real, checkable mod "not found" (the same confidently-wrong class this whole check exists to kill). Files
         // present ⇒ the mod exists: fall through and check them (the friendly name may be null — the file rows carry names).
+        // Load-bearing assumption: a genuinely-absent mod (wrong id / LE-only / hidden) returns an EMPTY modFiles list here
+        // (not an error, not cross-game files) — that empty list is what makes NotFound genuine. Even if that ever broke and
+        // files came back for a non-SSE mod, its installed fileid won't match one → FileGone (loud), never a silent "current".
         if (!found && files.Count == 0)
             return new NexusUpdateStatus(modId, false, name, header, installed, UpdateVerdict.NotFound, NoFiles, null, 0, 0);
 

--- a/src/housecarl-mcp/NexusClient.cs
+++ b/src/housecarl-mcp/NexusClient.cs
@@ -214,11 +214,20 @@ public sealed class NexusClient
     static bool IsSuperseded(string category) => category is "OLD_VERSION" or "ARCHIVED";
 
     /// <summary>Resolve one mod's file-level currency from its installed file id(s) and its full file list. See
-    /// <see cref="CheckUpdatesAsync"/> for what each verdict means. Internal (pure) for the CI guard.</summary>
+    /// <see cref="CheckUpdatesAsync"/> for what each verdict means. Internal (pure) for the CI guard. A mod absent from
+    /// the mods() SEARCH (<paramref name="found"/> false) but whose direct modFiles lookup returned files — the
+    /// manager-only (nxm) class Nexus hides from its search collection — is still resolved FROM those files, never
+    /// stamped NotFound; only a mod that is both search-absent AND fileless is genuinely not found.</summary>
     internal static NexusUpdateStatus ComputeStatus(int modId, bool found, string? name, string? header, string? installed,
         IReadOnlyList<int> fileIds, List<(int fileId, string name, string? version, string category, long date)> files)
     {
-        if (!found) return new NexusUpdateStatus(modId, false, name, header, installed, UpdateVerdict.NotFound, NoFiles, null, 0, 0);
+        // NotFound only when the mod is BOTH absent from the mods() search AND returned no files from the direct modFiles
+        // lookup. The search collection silently EXCLUDES manager-only (nxm) mods — a large, mainstream class — yet their
+        // modFiles lookup resolves fine; gating NotFound on the search alone would discard those already-fetched files and
+        // stamp a real, checkable mod "not found" (the same confidently-wrong class this whole check exists to kill). Files
+        // present ⇒ the mod exists: fall through and check them (the friendly name may be null — the file rows carry names).
+        if (!found && files.Count == 0)
+            return new NexusUpdateStatus(modId, false, name, header, installed, UpdateVerdict.NotFound, NoFiles, null, 0, 0);
 
         // Newest live MAIN + how many — context for LatestOnly and the no-file-id fallback (LiveMainCount>1 ⇒ a multi-main
         // page a version compare can't safely resolve: the false-positive root cause).

--- a/src/housecarl-mcp/NexusTools.cs
+++ b/src/housecarl-mcp/NexusTools.cs
@@ -484,7 +484,7 @@ static class Render
         AppendUpdateGroup(sb, "NO FILEID — couldn't verify at file level (FOMOD/manual install); best-effort only, not a verdict", results, UpdateVerdict.NoFileId);
         AppendUpdateGroup(sb, "current — the exact file you installed is still a live file on the page", results, UpdateVerdict.Current);
         AppendUpdateGroup(sb, "latest version (no installed version/fileid was given to compare)", results, UpdateVerdict.LatestOnly);
-        AppendUpdateGroup(sb, "not found on Skyrim SE (wrong id, or an LE/other-game mod)", results, UpdateVerdict.NotFound);
+        AppendUpdateGroup(sb, "not found on Skyrim SE (wrong id, an LE/other-game mod, or a hidden/deleted page)", results, UpdateVerdict.NotFound);
         AppendUpdateGroup(sb, "check FAILED (surface, don't assume current)", results, UpdateVerdict.Error);
 
         if (unreadable.Count > 0)


### PR DESCRIPTION
## What

`housecarl_nexus_check_updates` wrongly reported a large, mainstream class of mods as **`not found`** when they are real, checkable Skyrim SE mods.

The tool runs two things in one query: a plural `mods(filter:{OR})` **search** (for the friendly name/header) and a per-mod `modFiles(...)` **direct lookup** (the actual file data). It set the `found` flag **only** from the search results, then `ComputeStatus` did `if (!found) return NotFound` — **discarding the `modFiles` data it had already fetched**. Nexus excludes **manager-only (direct-download-disabled / nxm) mods** from that search collection, but their direct `modFiles` lookup resolves fine. So any nxm-only mod was stamped `not found (wrong id / LE-other-game)` — the same confidently-wrong class the file-level fix exists to kill, in a shipped tool (Q3).

## Why it matters

Measured on a real modlist (ARR 2.0, 3303 Nexus mods): in a 40-mod calibration batch, **8 came back `not found` and 6 of those were real, published mods** (A Lovely Letter, automaton mesh improvements, Airgetlam, Allow Dialogue Progress Bugfix, Arc's Dawn Breaker Redux, Armors of the Velothi Pt II) — every false one carrying the "author disabled direct download" flag; the 2 genuine ones (Ancient Dwemer Metal, Auri Replacer) did not. That's ~15% of a scan silently unchecked (~100+ mods across the full candidate set).

## Discovery

Surfaced live while running an update-triage sweep on the fixed `1.8.0-dev` build. The prior fileid file-level fix (#177) was confirmed working (the AMON ENB false positive now reads `current`); this was the residual it exposed.

## The fix

`ComputeStatus` now returns `NotFound` **only** when the mod is *both* absent from the search *and* returned no files (a genuinely missing mod comes back as an empty file list, never an error). When files are present, the mod exists and is checked from the file list — the friendly name may be null, but the per-file rows carry the names.

- `NexusClient.ComputeStatus` — gate `NotFound` on `!found && files.Count == 0`.
- `NexusTools` — the not-found bucket label now also names hidden/deleted pages (what genuinely lands there post-fix).
- `nexus-file-check-guard` — case **G** reworked to the genuine (fileless) not-found; new **J/J2/J3** lock the nxm-only path (`found=false` + files → Current / Outdated / NoFileId fallback, never NotFound).

## Proof

`ci-all` **87/87** green (incl. the reworked + 4 new guard assertions). No public version bump — `main` stays `1.7.1`; the `1.8.0-dev` package rebuild is a separate post-merge step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
