### PR TITLE
feat(nexus): raw graphql passthrough backstop + tags lift into nexus_mod

### DIFF
--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -107,6 +107,9 @@ public static class CiAll
         // archived→outdated+same-name pointer, missing→file-gone, no-fileid→loud fallback), the id#fileid parse, and the
         // same-modId-across-folders fileid MERGE (never dedup-drop). Pure, network-free; synthetic AMON-shaped fixtures.
         ("nexus-file-check-guard", NexusFileCheckProbe.RunGuard),
+        // The raw GraphQL passthrough backstop: read-only mutation/subscription refusal (an op keyword at doc start or
+        // after a prior '}', never a field that merely contains the word) + BOUNDED pretty-printed output. Pure, no network.
+        ("nexus-graphql-guard", NexusGraphqlProbe.RunGuard),
         ("atomic-commit-guard", AtomicCommitProbe.RunGuard),
         ("place-asset-guard", PlaceAssetProbe.RunGuard),
         // NIF layer Wave 1: NifService.Inspect decodes an authored SE mesh's N2-whitelist values (version, census, node

--- a/src/housecarl-generator/NexusGraphqlProbe.cs
+++ b/src/housecarl-generator/NexusGraphqlProbe.cs
@@ -45,6 +45,16 @@ internal static class NexusGraphqlProbe
             Check(outp.Length < 41000, "oversize payload -> bounded near the cap");
         }
 
+        // EXACT-OUTPUT fidelity — the backstop must show what the graph returned, not a \uXXXX-escaped view of it. The
+        // default encoder would mangle '+', '&', and non-ASCII (a version '1.0+SE', an accented author name); the relaxed
+        // encoder keeps them literal.
+        using (var raw = JsonDocument.Parse("{\"version\":\"1.0+SE\",\"name\":\"Brivé & Co\"}"))
+        {
+            var outp = Render.Graphql(raw.RootElement);
+            Check(outp.Contains("1.0+SE") && !outp.Contains("\\u002B"), "'+' rendered literal, not escaped (exact-output fidelity)");
+            Check(outp.Contains("Brivé & Co") && !outp.Contains("\\u00e9") && !outp.Contains("\\u0026"), "non-ASCII and '&' rendered literal, not escaped");
+        }
+
         Console.WriteLine(fail == 0
             ? "[nexus-graphql] PASS - read-only refusal + bounded output hold."
             : $"[nexus-graphql] FAIL ({fail})");

--- a/src/housecarl-generator/NexusGraphqlProbe.cs
+++ b/src/housecarl-generator/NexusGraphqlProbe.cs
@@ -1,0 +1,53 @@
+using System.Text.Json;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// nexus-graphql-guard — locks the RAW GraphQL passthrough backstop's two pure, offline pieces:
+///   • NexusClient.IsMutatingQuery — the READ-ONLY contract. A mutation/subscription OPERATION (the keyword at document
+///     start, or after a prior operation's closing '}') is refused; a field that merely CONTAINS the word (a selection
+///     like 'mutationCount') is NOT — a legitimate read is never falsely refused.
+///   • Render.Graphql — pretty-printed + BOUNDED output (Q3: an oversize payload is truncated with an explicit marker,
+///     never silently cut).
+/// Both are network-free — the live query path is exercised by hand, not CI. Self-contained; no game data, no network.
+/// </summary>
+internal static class NexusGraphqlProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" nexus-graphql guard — read-only mutation refusal + bounded raw output");
+        Console.WriteLine("================================================================");
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        // READ-ONLY contract — a mutation/subscription OPERATION is refused …
+        Check(NexusClient.IsMutatingQuery("mutation { endorse(modId:1) { ok } }"), "mutation at doc start -> refused");
+        Check(NexusClient.IsMutatingQuery("  \n  subscription { x }"), "subscription (leading whitespace) -> refused");
+        Check(NexusClient.IsMutatingQuery("query{ mod{ name } } mutation{ x }"), "mutation as a SECOND operation (after '}') -> refused");
+        // … but a legitimate READ is never falsely refused, even when a field/word contains 'mutation'/'subscription'.
+        Check(!NexusClient.IsMutatingQuery("query{ mod(modId:\"1\"){ name tags{ name } } }"), "named read query -> allowed");
+        Check(!NexusClient.IsMutatingQuery("{ mod{ name } }"), "anonymous read query -> allowed");
+        Check(!NexusClient.IsMutatingQuery("query{ mod{ mutationCount subscriptionState } }"), "fields merely CONTAINING the words -> allowed (no false refusal)");
+
+        // BOUNDED raw output (Q3) — a small payload renders whole + indented; an oversize one is truncated with a marker.
+        using (var small = JsonDocument.Parse("{\"mod\":{\"name\":\"X\",\"tags\":[{\"name\":\"Gameplay\"}]}}"))
+        {
+            var outp = Render.Graphql(small.RootElement);
+            Check(outp.Contains("\"Gameplay\"") && outp.Contains("\n  "), "small payload -> rendered whole + pretty-printed");
+            Check(!outp.Contains("truncated"), "small payload -> no truncation marker");
+        }
+        using (var big = JsonDocument.Parse("{\"blob\":\"" + new string('x', 60000) + "\"}"))
+        {
+            var outp = Render.Graphql(big.RootElement);
+            Check(outp.Contains("truncated"), "oversize payload -> explicit truncation marker (Q3, never silent)");
+            Check(outp.Length < 41000, "oversize payload -> bounded near the cap");
+        }
+
+        Console.WriteLine(fail == 0
+            ? "[nexus-graphql] PASS - read-only refusal + bounded output hold."
+            : $"[nexus-graphql] FAIL ({fail})");
+        return fail;
+    }
+}

--- a/src/housecarl-mcp/NexusClient.cs
+++ b/src/housecarl-mcp/NexusClient.cs
@@ -107,11 +107,19 @@ public sealed class NexusClient
                     Int(f, "fileId"), Str(f, "name") ?? "", Str(f, "version"),
                     Str(f, "category") ?? "", Long(f, "date"), Str(f, "description"), StrList(f, "changelogText")));
 
+        // Page tags — author/community labels (Gameplay, Lore-Friendly, SKSE, …), a list of { name } objects (so not the
+        // plain-string StrList). A cross-cutting, multi-valued facet the single `category` can't capture. First field
+        // "lifted" from the raw-graphql backstop into a curated tool.
+        var tags = new List<string>();
+        if (m.TryGetProperty("tags", out var tg) && tg.ValueKind == JsonValueKind.Array)
+            foreach (var t in tg.EnumerateArray())
+            { var n = Str(t, "name"); if (!string.IsNullOrWhiteSpace(n)) tags.Add(n!); }
+
         return (true, null, new NexusModDetail(
             Int(m, "modId"), Str(m, "name") ?? "", Str(m, "version"), Str(m, "summary"), Str(m, "description"),
             Str(m, "author"), Str(m, "category") ?? "", Int(m, "endorsements"), Int(m, "downloads"),
             Str(m, "updatedAt"), Str(m, "createdAt"), Bool(m, "adultContent"), Str(m, "status") ?? "",
-            Bool(m, "directDownloadEnabled"), reqs, files));
+            Bool(m, "directDownloadEnabled"), reqs, files, tags));
     }
 
     /// <summary>Run a RAW keyless query against the Nexus v2 endpoint — the COMPLETENESS BACKSTOP behind the curated
@@ -430,6 +438,7 @@ public sealed class NexusClient
             mod(modId: $modId, gameId: $gameId) {
               modId name version summary description author category endorsements downloads
               updatedAt createdAt adultContent status directDownloadEnabled
+              tags { name }
               modRequirements { nexusRequirements { nodes { modId modName url notes externalRequirement } } }
             }
             modFiles(modId: $modId, gameId: $gameId) {
@@ -471,7 +480,8 @@ public sealed record NexusFile(
 public sealed record NexusModDetail(
     int ModId, string Name, string? Version, string? Summary, string? Description, string? Author, string Category,
     int Endorsements, int Downloads, string? UpdatedAt, string? CreatedAt, bool AdultContent, string Status,
-    bool DirectDownloadEnabled, IReadOnlyList<NexusRequirement> NexusRequirements, IReadOnlyList<NexusFile> Files);
+    bool DirectDownloadEnabled, IReadOnlyList<NexusRequirement> NexusRequirements, IReadOnlyList<NexusFile> Files,
+    IReadOnlyList<string> Tags);
 
 /// <summary>Whether one installed file is still a LIVE file on its mod's page, has been SUPERSEDED (the author moved it
 /// to OLD_VERSION/ARCHIVED), or is MISSING entirely (hidden/deleted — can't determine). The file-level currency signal a

--- a/src/housecarl-mcp/NexusClient.cs
+++ b/src/housecarl-mcp/NexusClient.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 
 namespace HousecarlMcp;
 
@@ -112,6 +113,29 @@ public sealed class NexusClient
             Str(m, "updatedAt"), Str(m, "createdAt"), Bool(m, "adultContent"), Str(m, "status") ?? "",
             Bool(m, "directDownloadEnabled"), reqs, files));
     }
+
+    /// <summary>Run a RAW keyless query against the Nexus v2 endpoint — the COMPLETENESS BACKSTOP behind the curated
+    /// tools (search / mod / check-updates). Those render a hand-picked field set with houseCARL's honest semantics; this
+    /// exposes the WHOLE public graph, so a field they don't surface yet (a mod's page <c>tags</c>, other metadata) is
+    /// never invisible. Read-only by CONTRACT: <see cref="IsMutatingQuery"/> refuses mutation/subscription (the keyless
+    /// endpoint can't run them regardless, but the promise is explicit, not incidental). Returns the raw GraphQL
+    /// <c>data</c> element; every transport/GraphQL failure rides back through <see cref="PostAsync"/> as a Q3 message.
+    /// Variables ride the same variable channel the typed queries use (never string-concatenated into the query).</summary>
+    public async Task<(bool ok, string? error, JsonElement data)> RawQueryAsync(string query, JsonElement? variables, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(query)) return (false, "no GraphQL query given.", default);
+        if (IsMutatingQuery(query))
+            return (false, "this tool is READ-ONLY: mutation/subscription operations are refused (the keyless Nexus "
+                + "endpoint can't run them anyway). Pass a query{ ... }.", default);
+        object vars = variables is { ValueKind: JsonValueKind.Object } v ? v : new { };
+        return await PostAsync(query, vars, ct);
+    }
+
+    /// <summary>True when a GraphQL document contains a mutation/subscription operation — the keyword at document start or
+    /// after a prior operation's closing '}'. Deliberately does NOT match a field that merely CONTAINS the word (e.g. a
+    /// selection 'mutationCount'), so a legitimate read is never falsely refused. Internal for the CI guard.</summary>
+    internal static bool IsMutatingQuery(string query) =>
+        Regex.IsMatch(query, @"(^|\})\s*(mutation|subscription)\b", RegexOptions.IgnoreCase);
 
     /// <summary>Batch FILE-LEVEL currency check — "is the exact file each of these mods installed still a current file?"
     /// For each (modId, installedVersion?, installedFileIds) it resolves every installed file id to its live category in

--- a/src/housecarl-mcp/NexusTools.cs
+++ b/src/housecarl-mcp/NexusTools.cs
@@ -132,7 +132,7 @@ public static class NexusTools
         JsonElement? vars = null;
         if (!string.IsNullOrWhiteSpace(variables))
         {
-            try { vars = JsonDocument.Parse(variables).RootElement.Clone(); }
+            try { using var doc = JsonDocument.Parse(variables); vars = doc.RootElement.Clone(); }
             catch (Exception ex) { return $"error: variables= isn't valid JSON ({ex.Message}). Pass a JSON object like '{{\"modId\":\"51614\"}}'."; }
             if (vars.Value.ValueKind != JsonValueKind.Object)
                 return $"error: variables= must be a JSON OBJECT (e.g. '{{\"modId\":\"51614\"}}'), not {vars.Value.ValueKind}.";
@@ -329,7 +329,12 @@ static class Render
         return json;
     }
     const int GraphqlCap = 40000;
-    static readonly JsonSerializerOptions GraphqlJson = new() { WriteIndented = true };
+    // UnsafeRelaxedJsonEscaping: the backstop's whole promise is to show EXACTLY what the graph returned. The DEFAULT
+    // encoder escapes '+', '&', '<', '>' and ALL non-ASCII to \uXXXX — so a version '1.0+SE' or an accented author name
+    // would render mangled, undercutting that promise. "Unsafe" here is about HTML/JS injection sinks; this output is
+    // read as terminal text and never re-parsed into one, so relaxed escaping is the correct call.
+    static readonly JsonSerializerOptions GraphqlJson = new()
+        { WriteIndented = true, Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
 
     public static string Search(string term, string? category, string sort, NexusSearchResult r)
     {

--- a/src/housecarl-mcp/NexusTools.cs
+++ b/src/housecarl-mcp/NexusTools.cs
@@ -379,6 +379,7 @@ static class Render
           .Append(m.Downloads.ToString("N0")).Append(" downloads");
         if (!string.IsNullOrWhiteSpace(m.Category)) sb.Append(" · ").Append(m.Category);
         if (!string.IsNullOrWhiteSpace(m.UpdatedAt)) sb.Append(" · updated ").Append(Day(m.UpdatedAt!));
+        if (m.Tags.Count > 0) sb.Append("\ntags: ").Append(string.Join(", ", m.Tags));
         if (!m.DirectDownloadEnabled)
             sb.Append("\nnote: the author disabled direct download — manager (nxm) download only.");
         if (!string.IsNullOrWhiteSpace(m.Summary)) sb.Append("\n\n").Append(m.Summary);

--- a/src/housecarl-mcp/NexusTools.cs
+++ b/src/housecarl-mcp/NexusTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using ModelContextProtocol.Server;
 
@@ -104,6 +105,41 @@ public static class NexusTools
         var (ok, error, detail) = await nexus.GetModAsync(modId, ct);
         if (!ok) return "error: " + error;
         return Render.Mod(detail!, description, files, changelog, since);
+    }, ct);
+
+    [McpServerTool(Name = "housecarl_nexus_graphql", ReadOnly = true, Title = "Run a raw Nexus GraphQL query"),
+     Description(
+         "The COMPLETENESS BACKSTOP behind houseCARL's curated Nexus tools: run a RAW read-only query against the Nexus " +
+         "Mods public v2 GraphQL API (keyless), so any field the opinionated tools don't surface yet is never invisible. " +
+         "PREFER housecarl_nexus_search / housecarl_nexus_mod / housecarl_nexus_check_updates for the common lookups — " +
+         "they render results with houseCARL's honest semantics (newest-file-vs-header version, changelog UNKNOWN-not-" +
+         "empty, manager-only flags) that a raw dump loses. Reach for THIS only for a field or query they don't cover — " +
+         "e.g. a mod's page tags, or other Mod/File metadata. Pass a GraphQL query string (and optional variables as a " +
+         "JSON object); it returns the raw JSON data, pretty-printed and bounded. READ-ONLY: mutation/subscription is " +
+         "refused, and the keyless endpoint cannot change anything regardless. Needs an internet connection (local tools " +
+         "work offline). The Skyrim SE gameId is 1704. Example: query{ mod(modId:\"51614\", gameId:\"1704\"){ name tags{ name } } }")]
+    public static Task<string> NexusGraphql(
+        NexusClient nexus,
+        [Description("The GraphQL query to run against Nexus's v2 endpoint. Read-only — a query{ ... } document; " +
+            "mutation/subscription is refused. Inline arguments or use variables=. The Skyrim SE gameId is 1704. " +
+            "Example: 'query{ mod(modId:\"51614\", gameId:\"1704\"){ name summary tags{ name } } }'.")]
+            string query,
+        [Description("Optional. GraphQL variables as a JSON OBJECT string, e.g. '{\"modId\":\"51614\"}'. Omit when the " +
+            "query inlines its arguments.")]
+            string? variables = null,
+        CancellationToken ct = default) => Guard.Tool("housecarl_nexus_graphql", async () =>
+    {
+        JsonElement? vars = null;
+        if (!string.IsNullOrWhiteSpace(variables))
+        {
+            try { vars = JsonDocument.Parse(variables).RootElement.Clone(); }
+            catch (Exception ex) { return $"error: variables= isn't valid JSON ({ex.Message}). Pass a JSON object like '{{\"modId\":\"51614\"}}'."; }
+            if (vars.Value.ValueKind != JsonValueKind.Object)
+                return $"error: variables= must be a JSON OBJECT (e.g. '{{\"modId\":\"51614\"}}'), not {vars.Value.ValueKind}.";
+        }
+        var (ok, error, data) = await nexus.RawQueryAsync(query, vars, ct);
+        if (!ok) return "error: " + error;
+        return Render.Graphql(data);
     }, ct);
 
     [McpServerTool(Name = "housecarl_nexus_check_updates", ReadOnly = true, Title = "Batch-check Nexus mods for updates (file-level)"),
@@ -280,6 +316,20 @@ static class Render
     /// can't dominate the response; an over-length body is cut at a word boundary with an explicit marker (Q3 — never a
     /// silent truncation, like <see cref="OneLine"/>).</summary>
     const int DescriptionCap = 6000;
+
+    /// <summary>Render a raw GraphQL <c>data</c> payload for the backstop tool: pretty-printed JSON, BOUNDED with an
+    /// explicit marker so a huge response is never silently truncated (Q3). Deliberately unopinionated — the whole point
+    /// of the backstop is to show EXACTLY what the graph returned, not houseCARL's curated view of it.</summary>
+    public static string Graphql(JsonElement data)
+    {
+        var json = JsonSerializer.Serialize(data, GraphqlJson);
+        if (json.Length > GraphqlCap)
+            return json.Substring(0, GraphqlCap)
+                + $"\n\n… [output truncated at {GraphqlCap:N0} chars — narrow the query (fewer fields, a smaller page/list) to see the rest]";
+        return json;
+    }
+    const int GraphqlCap = 40000;
+    static readonly JsonSerializerOptions GraphqlJson = new() { WriteIndented = true };
 
     public static string Search(string term, string? category, string sort, NexusSearchResult r)
     {

--- a/src/housecarl-mcp/Program.cs
+++ b/src/housecarl-mcp/Program.cs
@@ -144,7 +144,9 @@ static void AddMcp(IServiceCollection services, bool stdio)
             "list and changelog=true / since= for the per-version CHANGELOG and update delta, by id or URL); " +
             "housecarl_nexus_check_updates (batch FILE-LEVEL update check — pass each mod as 'id#fileid' to tell CURRENT " +
             "from OUTDATED for the EXACT file installed, correct for the multi-file pages where a version compare lies); and " +
-            "housecarl_nexus_identify (trace a file to its source mod by MD5 hash). For mod updates, start with " +
+            "housecarl_nexus_identify (trace a file to its source mod by MD5 hash); and housecarl_nexus_graphql (a RAW " +
+            "read-only query over the same keyless GraphQL — the completeness backstop: prefer the curated tools above, and " +
+            "reach for this ONLY for a field they don't surface yet, e.g. a mod's page tags). For mod updates, start with " +
             "housecarl_update_status — it reads MO2's OWN local update cache with NO network to narrow the list AND prints " +
             "each mod's 'id#fileid' verify token — then feed those tokens to housecarl_nexus_check_updates to confirm live. " +
             "Prefer these over a browser or generic web search for any Nexus lookup: " +


### PR DESCRIPTION
## Why

The curated Nexus tools (`nexus_search` / `nexus_mod` / `nexus_check_updates`) render a **hand-picked** field set. That quietly re-imported the exact gap-prone hand-wiring the rebuild exists to escape — page **tags** were invisible until they happened to come up. The cornerstone's by-construction principle is scoped to the Mutagen data layer, so this isn't a rule violation, but it's the same failure-mode DNA.

The fix isn't to dump the raw graph (that throws away the tools' real value — the Q3 semantics: newest-file-vs-header version, changelog UNKNOWN-not-empty, manager-only flags). It's a **completeness backstop**: a raw floor so nothing in the graph is ever invisible, with the curated tools staying the ergonomic front door and **growing by lifting** fields out of the backstop as they prove useful.

## Commit 1 — `housecarl_nexus_graphql` (the backstop) · tool #38

A raw read-only query over the keyless v2 GraphQL.

- `NexusClient.RawQueryAsync` runs the query through the existing `PostAsync` funnel, so every transport/GraphQL failure rides back as a Q3 message; variables go through the same variable channel the typed queries use (never string-concatenated).
- **Read-only by contract:** `IsMutatingQuery` refuses a `mutation`/`subscription` *operation* (keyword at document start or after a prior op's `}`) but never a field that merely *contains* the word (a selection like `mutationCount`), so a legitimate read is never falsely refused. The keyless endpoint can't mutate regardless — the guard just makes the promise explicit.
- `Render.Graphql`: pretty-printed, **bounded** output (Q3 truncation marker, never a silent cut).
- The tool's description steers callers to the curated tools first and frames itself as the escape hatch.

## Commit 2 — page tags in `nexus_mod` (first lift)

The first field promoted out of the backstop into a curated tool. `nexus_mod` now selects `tags { name }`, parses the `{ name }` objects into `NexusModDetail.Tags`, and renders a `tags: …` line (omitted when a mod has none). Demonstrates the backstop→curated loop end-to-end.

Tags are author/community labels — a cross-cutting, **multi-valued** facet the single `category` can't capture (e.g. TDM: `Gameplay, Lore-Friendly, SKSE, Overhaul, Camera, Quality of Life, …`). Availability was confirmed live against the keyless endpoint before building.

## Proof

`ci-all` **88/88** (new `nexus-graphql-guard` locks both pure pieces: the read-only mutation refusal — including the *no-false-refusal* cases — and the bounded output). The live query path is offline-untestable by design; it needs a dev-package rebuild to exercise in the running server. No public version bump — `main` stays 1.7.1. Tool count 37 → **38**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
