### PR TITLE
fix: the enable-boundary batch — verify/finish a not-yet-enabled patch (HCBR-2026-07-14-02 gaps 3+4)

### DIFF
--- a/src/housecarl-core/ErrorCheck.cs
+++ b/src/housecarl-core/ErrorCheck.cs
@@ -1,5 +1,6 @@
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
 
 namespace HousecarlCore;
 
@@ -45,8 +46,15 @@ public static class ErrorCheck
     /// plugins) over the order <paramref name="resolver"/> holds. One <see cref="LoadOrderResolver.Capture"/> pins the
     /// whole sweep. <paramref name="limit"/> caps the number of dangling refs collected across the sweep (the true
     /// total is always counted); missing-master findings are few and never capped. A bad/excluded scope name fails
-    /// LOUD (Q3) with no partial result.</summary>
-    public static ErrorCheckResult Run(LoadOrderResolver resolver, IReadOnlyList<string>? scope, int limit)
+    /// LOUD (Q3) with no partial result.
+    /// <para><paramref name="offOrder"/> — plugin FILES to sweep that are NOT in the active order (name + on-disk path;
+    /// the caller located them), the pre-enable verify lane (HCBR-2026-07-14-02 gap 3: a patch houseCARL just wrote is
+    /// not in plugins.txt until the MO2 refresh, yet its pre-ship dangling-ref sweep is exactly when check_errors is
+    /// wanted). Each is opened as its OWN overlay; its links resolve against the active order PLUS the file's own
+    /// records (a patch's link to its own new record is not dangling), and a declared master absent from the active
+    /// order is a MISSING MASTER finding — same classes, same rendering, plus an OFF-ORDER stamp in the result.</para></summary>
+    public static ErrorCheckResult Run(LoadOrderResolver resolver, IReadOnlyList<string>? scope, int limit,
+                                       IReadOnlyList<(string Name, string Path)>? offOrder = null)
     {
         var view = resolver.Capture();
 
@@ -64,6 +72,10 @@ public static class ErrorCheck
                         $"plugin '{name}' was excluded from this session because it could not be parsed ({why}) — fix or remove it upstream; it cannot be checked.");
                 targets.Add(name);
             }
+        }
+        else if (offOrder is { Count: > 0 })
+        {
+            targets = new List<string>();   // the caller's explicit scope resolved ENTIRELY off-order — don't widen to the whole order
         }
         else
         {
@@ -143,8 +155,89 @@ public static class ErrorCheck
                 reports.Add(new PluginErrors(plugin, dangling, missingMasters, unscannable, unscannableSamples, scanError));
         }
 
-        return new ErrorCheckResult(reports, targets.Count, totalDangling, totalMissing,
-                                    totalUnscannable, capped, view.ExcludedPlugins, null);
+        // --- off-order files (the pre-enable verify lane): the file's OWN overlay, links resolved against the active
+        //     order PLUS the file's own records. Same fault-isolation contract as the active loop (Q3).
+        var offOrderScanned = new List<string>();
+        if (offOrder is { Count: > 0 })
+        {
+            foreach (var (name, path) in offOrder)
+            {
+                offOrderScanned.Add(name);
+                string? scanError = null;
+                var missingMasters = new List<string>();
+                var dangling = new List<DanglingRef>();
+                int unscannable = 0;
+                var unscannableSamples = new List<string>();
+
+                ISkyrimModGetter? ov = null;
+                try
+                {
+                    ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE);
+
+                    foreach (var m in ov.ModHeader.MasterReferences)
+                        if (!view.ContainsPlugin(m.Master.FileName)) missingMasters.Add(m.Master.FileName);
+                    missingMasters.Sort(StringComparer.OrdinalIgnoreCase);
+
+                    // Pass 1 — the file's OWN FormKeys: a link into a record this same file defines is satisfied the
+                    // moment the plugin is enabled, so it must not read as dangling (the patch-links-its-own-new-record
+                    // case). An enumeration abort leaves a PARTIAL set — named below, and pass 2 aborts the same way.
+                    var selfKeys = new HashSet<FormKey>();
+                    try { foreach (var r in ov.EnumerateMajorRecords()) selfKeys.Add(r.FormKey); }
+                    catch (Exception ex) { scanError = $"record enumeration aborted partway: {ex.GetType().Name}: {ex.Message}"; }
+
+                    // Pass 2 — the link walk, per-record fault isolation (the active loop's exact contract).
+                    try
+                    {
+                        foreach (var rec in ov.EnumerateMajorRecords())
+                        {
+                            try
+                            {
+                                if (rec is not IFormLinkContainerGetter flc) continue;
+                                foreach (var link in flc.EnumerateFormLinks())
+                                {
+                                    var target = link.FormKey;
+                                    if (target.IsNull) continue;
+                                    if (view.ResolveWinner(target) is not null) continue;
+                                    if (selfKeys.Contains(target)) continue;            // defined by this very file
+                                    if (EngineImplicit.IsImplicit(target)) continue;
+                                    totalDangling++;
+                                    if (danglingBudget > 0)
+                                    {
+                                        dangling.Add(new DanglingRef(rec.FormKey, RecordNaming.StripOverlay(rec.GetType().Name), rec.EditorID, target));
+                                        danglingBudget--;
+                                    }
+                                    else capped = true;
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                unscannable++;
+                                if (unscannableSamples.Count < 3) unscannableSamples.Add($"{rec.FormKey} — {ex.GetType().Name}: {ex.Message}");
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        scanError = (scanError is null ? "" : scanError + "; ")
+                                  + $"record enumeration aborted partway: {ex.GetType().Name}: {ex.Message}";
+                    }
+                }
+                catch (Exception ex)
+                {
+                    scanError = $"could not open '{path}' as a Skyrim plugin: {ex.GetType().Name}: {ex.Message}";
+                }
+                finally { (ov as IDisposable)?.Dispose(); }
+
+                totalMissing += missingMasters.Count;
+                totalUnscannable += unscannable;
+
+                if (dangling.Count > 0 || missingMasters.Count > 0 || unscannable > 0 || scanError is not null)
+                    reports.Add(new PluginErrors(name, dangling, missingMasters, unscannable, unscannableSamples, scanError));
+            }
+        }
+
+        return new ErrorCheckResult(reports, targets.Count + offOrderScanned.Count, totalDangling, totalMissing,
+                                    totalUnscannable, capped, view.ExcludedPlugins, null, offOrderScanned);
     }
 }
 
@@ -175,7 +268,8 @@ public sealed record ErrorCheckResult(
     int TotalUnscannableRecords,
     bool Capped,
     IReadOnlyDictionary<string, string> ExcludedPlugins,
-    string? Error)
+    string? Error,
+    IReadOnlyList<string>? OffOrderScanned = null)
 {
     public bool Success => Error is null;
     public static ErrorCheckResult Fail(string error) =>

--- a/src/housecarl-core/Mo2LoadOrder.cs
+++ b/src/housecarl-core/Mo2LoadOrder.cs
@@ -236,14 +236,18 @@ public static class Mo2LoadOrder
     }
 
     /// <summary>Locate every on-disk copy of a plugin FILENAME across the WHOLE MO2 install — the overwrite layer,
-    /// EVERY mod folder (enabled AND disabled), and the game Data folder — NOT just the active order's winner map
-    /// (<see cref="Build"/>, which resolves enabled mods only). This is what lets a read of an INACTIVE plugin reach a
-    /// DISABLED donor's file — the realistic standalone-copy case (you standalone-ize a follower you're REMOVING from
-    /// the active order). Priority-ordered like the active map (overwrite → enabled by modlist priority → disabled →
-    /// Data), but ALL hits are returned, not just the first: a filename several folders provide is reported so the
-    /// caller can ask WHICH rather than silently pick one (Q3). Pure disk existence checks (one stat per candidate
-    /// folder — no folder enumeration, opens no plugin). <paramref name="filename"/> is reduced to a bare name so a
-    /// caller's stray path parts can't escape a folder; the direct-path case is the caller's to handle before here.</summary>
+    /// EVERY mod folder (enabled, disabled, AND unlisted), and the game Data folder — NOT just the active order's
+    /// winner map (<see cref="Build"/>, which resolves enabled mods only). This is what lets a read of an INACTIVE
+    /// plugin reach a DISABLED donor's file — the realistic standalone-copy case (you standalone-ize a follower you're
+    /// REMOVING from the active order). UNLISTED = a mod folder on disk that modlist.txt does not mention at all —
+    /// exactly the state of a patch houseCARL just wrote, before the MO2 refresh registers it (HCBR-2026-07-14-02
+    /// gap 3: writes resolved the fresh patch by filename while this read-side locate missed it). Priority-ordered
+    /// like the active map (overwrite → enabled by modlist priority → disabled → unlisted → Data), but ALL hits are
+    /// returned, not just the first: a filename several folders provide is reported so the caller can ask WHICH
+    /// rather than silently pick one (Q3). One stat per LISTED candidate folder plus one directory listing of ModsDir
+    /// for the unlisted sweep (no per-folder enumeration, opens no plugin). <paramref name="filename"/> is reduced to
+    /// a bare name so a caller's stray path parts can't escape a folder; the direct-path case is the caller's to
+    /// handle before here.</summary>
     public static IReadOnlyList<PluginFileHit> LocatePlugin(
         string profileDir, string modsDir, string dataDir, string overwriteDir, string filename)
         => LocatePlugin(ReadComposition(profileDir), modsDir, dataDir, overwriteDir, filename);
@@ -267,8 +271,27 @@ public static class Mo2LoadOrder
         TryDir(overwriteDir, "overwrite", enabled: true);             // MO2's overwrite layer (top of the VFS)
         foreach (var mod in comp.EnabledMods) TryDir(Path.Combine(modsDir, mod), $"mod '{mod}' (enabled)", enabled: true);
         foreach (var mod in comp.DisabledMods) TryDir(Path.Combine(modsDir, mod), $"mod '{mod}' (DISABLED)", enabled: false);
+        foreach (var dir in UnlistedModFolders(comp, modsDir))        // on disk but not in modlist.txt (a fresh houseCARL patch pre-refresh)
+            TryDir(dir, $"mod '{Path.GetFileName(dir)}' (UNLISTED — not in modlist.txt yet; refresh MO2 to register it)", enabled: false);
         TryDir(dataDir, "game Data", enabled: true);                  // vanilla / base — lowest priority
         return hits;
+    }
+
+    /// <summary>Mod folders that exist under <paramref name="modsDir"/> on disk but that modlist.txt mentions in
+    /// NEITHER list — the state of a mod folder created since MO2 last rewrote the profile (houseCARL's own fresh
+    /// patches live here until the refresh). One directory listing; a missing/inaccessible ModsDir yields nothing
+    /// (never a false hit — Q3).</summary>
+    static IEnumerable<string> UnlistedModFolders(Mo2Composition comp, string modsDir)
+    {
+        if (string.IsNullOrWhiteSpace(modsDir) || !Directory.Exists(modsDir)) yield break;
+        var listed = new HashSet<string>(comp.EnabledMods, StringComparer.OrdinalIgnoreCase);
+        listed.UnionWith(comp.DisabledMods);
+        IEnumerable<string> dirs;
+        try { dirs = Directory.EnumerateDirectories(modsDir); }
+        catch { yield break; }
+        foreach (var dir in dirs)
+            if (!listed.Contains(Path.GetFileName(dir)))
+                yield return dir;
     }
 
     /// <summary>True iff SOME on-disk copy of <paramref name="filename"/> exists anywhere in the install (overwrite,
@@ -288,6 +311,7 @@ public static class Mo2LoadOrder
         if (Has(overwriteDir)) return true;
         foreach (var mod in comp.EnabledMods) if (Has(Path.Combine(modsDir, mod))) return true;
         foreach (var mod in comp.DisabledMods) if (Has(Path.Combine(modsDir, mod))) return true;
+        foreach (var dir in UnlistedModFolders(comp, modsDir)) if (Has(dir)) return true;   // pre-refresh houseCARL patches — pays only on a miss above
         return Has(dataDir);
     }
 }

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -37,6 +37,11 @@ namespace HousecarlGenerator;
 ///   SCOPE           — scope=[HcCeBad.esp] reports only Bad (1 plugin scanned), Clean absent.
 ///   SCOPE-Q3        — scope=[a name not in the order] fails LOUD ("not in the load order"), no reports (never a silent skip).
 ///   CAP             — limit=1 over Bad's 2 dangling refs returns 1 but reports the TRUE total (2) and Capped.
+///   OFF-ORDER-SELF   — an off-order file's link to a record IT DEFINES is not dangling (the patch-links-its-own-new-record case).
+///   OFF-ORDER-DANGLE — its truly-dead refs DO dangle and its absent declared master IS a missing-master finding.
+///   OFF-ORDER-STAMP  — the result stamps the off-order names (OffOrderScanned) and counts them in PluginsScanned;
+///                      mixing an active scope name with an off-order file reports both (HCBR-2026-07-14-02 gap 3:
+///                      the pre-enable verify sweep of a patch houseCARL just wrote).
 ///   PLAYERREF-WHITELIST — engine-implicit refs (000014 PlayerRef, 000007 Player, in Skyrim.esm) are NOT flagged dangling
 ///                     (HCBR checkerrors-playerref-dangling-false-positive: check_errors was reporting 531/531 false → 000014).
 ///   PLAYERREF-CONTROL   — a DIFFERENT sub-0x800 form (000015:Skyrim.esm) IS still flagged and the plugin totals 1 dangling:
@@ -190,6 +195,48 @@ public static class CheckErrorsProbe
             capped.TotalDangling == 2 && capped.Capped
             && capped.Reports.Count == 1 && capped.Reports[0].Dangling.Count == 1,
             $"total={capped.TotalDangling} capped={capped.Capped} collected={(capped.Reports.Count > 0 ? capped.Reports[0].Dangling.Count : -1)}");
+
+        // ---- OFF-ORDER: a plugin FILE not in the order, swept via the offOrder lane (the pre-enable verify sweep of a
+        //      patch houseCARL just wrote — HCBR-2026-07-14-02 gap 3). The fixture patch masters [Master, Ghost] and
+        //      carries: a NEW race of its own; an NPC → that own race (self-link, must NOT dangle); an NPC → the dead id
+        //      (must dangle); an NPC → Ghost's race (missing master + dangling). ----
+        string patchPath = Path.Combine(tmpDir, "HcCePatch.esp");
+        FormKey patchRaceFk;
+        try
+        {
+            using var masterOv = SkyrimMod.CreateFromBinaryOverlay(masterPath, SkyrimRelease.SkyrimSE);
+            using var ghostOv = SkyrimMod.CreateFromBinaryOverlay(ghostPath, SkyrimRelease.SkyrimSE);
+            var patch = new SkyrimMod(new ModKey("HcCePatch", ModType.Plugin), SkyrimRelease.SkyrimSE);
+            var ownRace = patch.Races.AddNew(); ownRace.EditorID = "HcCePatchRace"; patchRaceFk = ownRace.FormKey;
+            var selfNpc = patch.Npcs.AddNew(); selfNpc.EditorID = "HcCePatchSelfNpc"; selfNpc.Race.SetTo(patchRaceFk);
+            var deadNpc = patch.Npcs.AddNew(); deadNpc.EditorID = "HcCePatchDeadNpc"; deadNpc.Race.SetTo(deadFk);
+            var ghostNpc = patch.Npcs.AddNew(); ghostNpc.EditorID = "HcCePatchGhostNpc"; ghostNpc.Race.SetTo(ghostRaceFk);
+            patch.BeginWrite.ToPath(patchPath).WithLoadOrder(new ISkyrimModGetter[] { masterOv, ghostOv }).Write();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"error: could not synthesize the off-order fixture: {ex.GetType().Name}: {(ex.InnerException ?? ex).Message}");
+            return 1;
+        }
+
+        var off = ErrorCheck.Run(r, new[] { "HcCeBad.esp" }, 1000, new[] { ("HcCePatch.esp", patchPath) });
+        var patch2 = off.Reports.FirstOrDefault(p => p.Plugin == "HcCePatch.esp");
+
+        Check("OFF-ORDER-SELF: the off-order file's link to a record IT DEFINES is not dangling",
+            off.Success && patch2 is not null && !patch2.Dangling.Any(d => d.Target == patchRaceFk),
+            patch2 is null ? "<no report>" : string.Join(",", patch2.Dangling.Select(d => d.Target.ToString())));
+
+        Check("OFF-ORDER-DANGLE: its dead ref + absent-master ref DO dangle; the absent declared master IS missing (present master is not)",
+            patch2 is not null
+            && patch2.Dangling.Any(d => d.Target == deadFk) && patch2.Dangling.Any(d => d.Target == ghostRaceFk)
+            && patch2.MissingMasters.Contains("HcCeGhost.esm", StringComparer.OrdinalIgnoreCase)
+            && !patch2.MissingMasters.Contains("HcCeMaster.esm", StringComparer.OrdinalIgnoreCase),
+            patch2 is null ? "<no report>" : $"dangling=[{string.Join(",", patch2.Dangling.Select(d => d.Target.ToString()))}] missing=[{string.Join(",", patch2.MissingMasters)}]");
+
+        Check("OFF-ORDER-STAMP: OffOrderScanned names the file; PluginsScanned counts active scope + off-order; Bad's report is ALSO present (mixed scope)",
+            off.OffOrderScanned is { Count: 1 } oos && oos[0] == "HcCePatch.esp"
+            && off.PluginsScanned == 2 && off.Reports.Any(p => p.Plugin == "HcCeBad.esp"),
+            $"offOrder=[{string.Join(",", off.OffOrderScanned ?? Array.Empty<string>())}] scanned={off.PluginsScanned} reports=[{string.Join(",", off.Reports.Select(p => p.Plugin))}]");
 
         // ---- PLAYERREF: engine-implicit whitelist (its own order; Skyrim.esm on disk but NOT loaded). ----
         using var rp = LoadOrderResolver.Build(new[] { playerPath });

--- a/src/housecarl-generator/CompactServiceGuardProbe.cs
+++ b/src/housecarl-generator/CompactServiceGuardProbe.cs
@@ -19,7 +19,10 @@ namespace HousecarlGenerator;
 ///               cell at its master FormID while the new child renumbers (the realistic patch case; copied 2 / renum 1).
 ///   REFUSE-EXT— a mod another plugin references is REFUSED (the external referencer named), nothing written.
 ///   GATE      — repoint_externals without in_place is REFUSED (the coherence gate; review #1).
-///   NOT-ACTIVE— an unknown plugin is refused.
+///   NOT-ACTIVE— a plugin found nowhere on disk is refused (an inactive one FOUND on disk now compacts — see OFF-ORDER).
+///   OFF-ORDER — a plugin in an UNLISTED mod folder (a fresh houseCARL patch pre-MO2-refresh; HCBR-2026-07-14-02 gap 3)
+///               resolves by filename and compacts normally, with the OFF-ORDER note.
+///   FLAG-ONLY — an override-only plugin: esl=true copies verbatim + sets the light flag (renum 0); esl=false refuses.
 ///   CONSENT   — in_place + repoint without acknowledge returns the CONFIRM prompt (no write); WITH acknowledge it
 ///               compacts the target IN PLACE and repoints the external referencer to the new key (the full opt-in path).
 /// Run: dotnet run --project src/housecarl-generator compact-service-guard
@@ -161,11 +164,66 @@ public static class CompactServiceGuardProbe
                     $"GATE repoint_externals requires in_place ({o.Error?.Split('.')[0]})");
             }
 
-            // ---- NOT-ACTIVE: unknown plugin -> refused ----
+            // ---- NOT-ACTIVE: a plugin found NOWHERE on disk -> still refused (the gate now falls through to a locate) ----
             {
                 var o = svc.CompactPlugin("HcCsNope.esp");
-                Check(!o.Success && (o.Error?.Contains("not an active plugin", StringComparison.OrdinalIgnoreCase) ?? false),
-                    $"NOT-ACTIVE unknown plugin refused ({o.Error?.Split('—')[0].Trim()})");
+                Check(!o.Success && (o.Error?.Contains("not an active plugin", StringComparison.OrdinalIgnoreCase) ?? false)
+                                 && (o.Error?.Contains("no on-disk copy", StringComparison.OrdinalIgnoreCase) ?? false),
+                    $"NOT-ACTIVE nowhere-on-disk plugin refused ({o.Error?.Split('—')[0].Trim()})");
+            }
+
+            // ---- OFF-ORDER: a plugin in an UNLISTED mod folder (not in modlist/plugins/loadorder — the fresh houseCARL
+            //      patch before the MO2 refresh, HCBR-2026-07-14-02 gap 3) resolves by filename and compacts normally ----
+            {
+                var offKey = new ModKey("HcCsOff", ModType.Plugin);
+                var owOld = new FormKey(offKey, 0xA01);
+                WriteMod(mods, "OffOrderMod", offKey, Array.Empty<string>(), m =>
+                    m.Weapons.Add(new Weapon(owOld, SkyrimRelease.SkyrimSE) { EditorID = "HcCsOffWeap", BasicStats = new WeaponBasicStats { Damage = 3 } }));
+                var o = svc.CompactPlugin("HcCsOff.esp");
+                bool lightOk = false;
+                if (o.Success && File.Exists(o.OutputPath))
+                {
+                    using var pp = SkyrimMod.CreateFromBinaryOverlay(o.OutputPath, SkyrimRelease.SkyrimSE);
+                    lightOk = pp.IsSmallMaster && pp.EnumerateMajorRecords().All(r => r.FormKey.ID >= RemapEngine.EslFloor && r.FormKey.ID <= RemapEngine.EslCeiling);
+                }
+                Check(o.Success && o.RecordsRenumbered == 1 && lightOk && (o.Note?.Contains("OFF-ORDER") ?? false),
+                    $"OFF-ORDER unlisted-folder plugin compacts, noted (renum {o.RecordsRenumbered}, light {lightOk}, note {(o.Note?.Contains("OFF-ORDER") ?? false)}{(o.Success ? "" : "; ERR " + o.Error)})");
+            }
+
+            // ---- FLAG-ONLY: an override-only plugin (nothing to renumber). esl=true sets the light flag on a verbatim
+            //      copy (the all-override compatibility patch's ESL endgame); esl=false refuses (nothing to do) ----
+            {
+                var flagKey = new ModKey("HcCsFlag", ModType.Plugin);
+                using (var libOv = SkyrimMod.CreateFromBinaryOverlay(Path.Combine(mods, "LibMod", libKey.FileName.String), SkyrimRelease.SkyrimSE))
+                {
+                    var libCache = libOv.ToImmutableLinkCache();
+                    var modDir = Path.Combine(mods, "FlagOnlyMod"); Directory.CreateDirectory(modDir);   // deliberately UNLISTED too
+                    var f = new SkyrimMod(flagKey, SkyrimRelease.SkyrimSE);
+                    var ow = (IWeapon)WriteEngine.GenericGetOrAddAsOverride(f, libOv.Weapons.First(), libCache);
+                    ow.BasicStats!.Damage = 42;                                          // an actual override delta
+                    f.BeginWrite.ToPath(Path.Combine(modDir, flagKey.FileName.String)).WithLoadOrder(new[] { libOv }).Write();
+                }
+                // esl=false FIRST — the esl=true success below writes a second on-disk copy of the basename (the
+                // compacted output folder), after which a bare-filename locate is legitimately AMBIGUOUS.
+                var oNo = svc.CompactPlugin("HcCsFlag.esp", esl: false);
+                Check(!oNo.Success && (oNo.Error?.Contains("nothing to compact", StringComparison.OrdinalIgnoreCase) ?? false),
+                    $"FLAG-ONLY esl=false: refused, nothing to do ({oNo.Error?.Split('.')[0]})");
+                var o = svc.CompactPlugin("HcCsFlag.esp");
+                bool lightOk = false, verbatim = false;
+                if (o.Success && File.Exists(o.OutputPath))
+                {
+                    using var pp = SkyrimMod.CreateFromBinaryOverlay(o.OutputPath, SkyrimRelease.SkyrimSE);
+                    lightOk = pp.IsSmallMaster;
+                    var w = pp.EnumerateMajorRecords<IWeaponGetter>().FirstOrDefault();
+                    verbatim = w is not null && w.FormKey == lwOld && w.BasicStats?.Damage == 42;   // override kept at the master key, delta intact
+                }
+                Check(o.Success && o.RecordsRenumbered == 0 && lightOk && verbatim && (o.Note?.Contains("no originating records") ?? false),
+                    $"FLAG-ONLY esl=true: verbatim copy + light flag (renum {o.RecordsRenumbered}, light {lightOk}, verbatim {verbatim}{(o.Success ? "" : "; ERR " + o.Error)})");
+                // …and NOW the bare name resolves to TWO on-disk copies (the unlisted fixture + the compacted output) —
+                // the off-order locate must surface the ambiguity, never guess (Q3).
+                var oAmb = svc.CompactPlugin("HcCsFlag.esp");
+                Check(!oAmb.Success && (oAmb.Error?.Contains("ambiguous", StringComparison.OrdinalIgnoreCase) ?? false),
+                    $"OFF-ORDER-AMBIGUOUS: a basename two folders provide is refused, named ({oAmb.Error?.Split('—')[0].Trim()})");
             }
 
             // ---- CONSENT: in_place + repoint WITHOUT acknowledge -> confirm prompt (no write); WITH it -> in-place compact + repoint ----

--- a/src/housecarl-generator/ForwardFromPluginProbe.cs
+++ b/src/housecarl-generator/ForwardFromPluginProbe.cs
@@ -40,6 +40,8 @@ namespace HousecarlGenerator;
 ///   ALREADY-WINNER    — forward ModB's X (already winning): succeeds, Dmg 30, flagged WasAlreadyWinner (redundant — surfaced, not silent Q3).
 ///   MULTI             — forward [X,Y] from ModA in ONE call: both land (20, 200).
 ///   EXTEND            — forward X (fresh) then Y into the SAME patch (into=): both present (20, 200).
+///   FORWARD-THEN-EDIT — forward ModA's X then bulk_apply into= the same patch: the op edits the FORWARDED copy
+///                       (Dmg stays 20, the edit lands) — never re-resolves the stale winner (HCBR-2026-07-14-02 gap 4).
 ///   REPLACE           — forward X again from ModB into the same patch: the existing override is REPLACED (30, not 20),
 ///                       flagged ReplacedExisting, and the header grows from the NEW body (+ModB via its keyword) —
 ///                       HCBR-2026-07-08-01 F1 (the pre-fix GetOrAdd kept the old body, skipped the copy AND the
@@ -260,6 +262,35 @@ public static class ForwardFromPluginProbe
             Check("REPLACE: re-forwarding a FormKey the patch already carries replaces the body (X=30, not 20), flags it, grows masters (+ModB)",
                 firstOk && o2.Success && dmg == 30 && flagged && masterGrown,
                 $"first={firstOk} second={o2.Success} dmg={dmg} (want 30) flagged={flagged} masterGrown={masterGrown} masters=[{(o2.Success ? string.Join(",", o2.Masters) : "")}] err=[{Trim(o2.Error)}]");
+        }
+
+        // ---- FORWARD-THEN-EDIT (HCBR-2026-07-14-02 gap 4 — THE stale-winner bypass recipe, pinned): forward ModA's X
+        //      (Dmg 20; the LIVE winner is ModB's 30), then a bulk_apply-shaped Apply into= the same patch editing a
+        //      DIFFERENT field (Weight). The op must land on the patch's ALREADY-FORWARDED copy (override get-semantics
+        //      on the re-imported patch) — NOT re-resolve the load-order winner and rebuild the record from ModB's body.
+        //      Contract: Damage stays 20 (the forwarded body survives) AND Weight lands 7 (the edit applied). ----
+        {
+            string pPath = Path.Combine(tmpDir, "HcFwdThenEdit.esp");
+            bool firstOk; WritePatchBuilder.PatchOutcome o2;
+            using (var r = LoadOrderResolver.Build(orderPaths))
+                firstOk = WritePatchBuilder.ForwardRecords(r,
+                    new[] { new WritePatchBuilder.ForwardSpec { Target = xFk, FromPlugin = ModAName } }, pPath, extend: false).Success;
+            using (var r = LoadOrderResolver.Build(orderPaths))
+            {
+                var rulebook = CorpusRulebook.Load();
+                var edit = new WritePatchBuilder.PatchEdit { Target = xFk, Path = new[] { "BasicStats", "Weight" }, Verb = "Set", Value = "7" };
+                o2 = WritePatchBuilder.Apply(r, rulebook, new[] { edit }, pPath, extend: true);
+            }
+            ushort? dmg = null; float? weight = null;
+            if (firstOk && o2.Success)
+            {
+                dmg = ReadWeaponDamage(pPath, xFk);
+                using var pp = SkyrimMod.CreateFromBinaryOverlay(pPath, SkyrimRelease.SkyrimSE);
+                weight = pp.EnumerateMajorRecords<IWeaponGetter>().FirstOrDefault(w => w.FormKey == xFk)?.BasicStats?.Weight;
+            }
+            Check("FORWARD-THEN-EDIT: bulk_apply into= edits the patch's FORWARDED copy (Dmg stays 20 + Weight lands 7) — never re-resolves the stale winner (30)",
+                firstOk && o2.Success && dmg == 20 && weight == 7f,
+                $"first={firstOk} second={o2.Success} dmg={dmg} (want 20) weight={weight} (want 7) err=[{Trim(o2.Error)}]");
         }
 
         // ---- Q3 rejects (whole call refused, NO file written, named reason). ----

--- a/src/housecarl-generator/ReadPluginFileProbe.cs
+++ b/src/housecarl-generator/ReadPluginFileProbe.cs
@@ -11,6 +11,9 @@ namespace HousecarlGenerator;
 /// read_plugin_file guard — the standalone-copy chain's Stage-1 tool: a RAW, OUT-OF-LOAD-ORDER read of ONE plugin
 /// file straight off disk, INCLUDING a plugin DISABLED in MO2. Proves the load-bearing behaviours:
 ///   1  locate + READ a plugin inside a DISABLED mod folder, by filename (the whole point — reach an inactive donor)
+///   1b locate + READ a plugin in an UNLISTED mod folder — on disk but absent from modlist.txt, the state of a patch
+///      houseCARL just wrote before the MO2 refresh registers it (HCBR-2026-07-14-02 gap 3: the write lane resolved
+///      the fresh patch by bare filename while the read lane demanded an absolute path)
 ///   2  ENUMERATE a type the file defines (+ editorid_contains), and 3 the whole-file record-type SUMMARY
 ///   4  a DIRECT PATH read ("inspect any file")
 ///   5  the render stamps OUT-OF-LOAD-ORDER (the single load-bearing requirement) + read_record's `path = token` format
@@ -78,6 +81,24 @@ internal static class ReadPluginFileProbe
             Check(rd.Record is not null && rd.Record.Fields.Count == 1 && rd.Record.Fields[0].Token == "12",
                   $"field token round-trips like read_record — {(rd.Record is { Fields.Count: > 0 } ? rd.Record.Fields[0].Token : "?")}");
             Check(rd.Where is not null && rd.Where.Contains("DISABLED") && !rd.Enabled, $"located in a DISABLED mod, flagged not-active — where='{rd.Where}', enabled={rd.Enabled}");
+
+            // 1b — locate + read a plugin in an UNLISTED mod folder (a fresh houseCARL patch before the MO2 refresh).
+            //      The folder exists on disk but modlist.txt does NOT mention it — before the fix, the locate missed it
+            //      and the bare-filename read errored "in no mod folder" while into= resolved the same file fine.
+            Console.WriteLine("\n--- 1b: locate + read a plugin in an UNLISTED mod folder (pre-refresh houseCARL patch) ---");
+            var unlistedKey = new ModKey("HcUnlisted", ModType.Plugin);
+            FormKey unlistedFk;
+            {
+                Directory.CreateDirectory(Path.Combine(mods, "UnlistedPatch"));   // deliberately NOT added to modlist.txt
+                var u = new SkyrimMod(unlistedKey, SkyrimRelease.SkyrimSE);
+                var uw = u.Weapons.AddNew(); uw.EditorID = "UnlistedSword"; uw.BasicStats = new WeaponBasicStats { Damage = 9 }; unlistedFk = uw.FormKey;
+                u.BeginWrite.ToPath(Path.Combine(mods, "UnlistedPatch", unlistedKey.FileName.String)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            }
+            var ur = svc.ReadPluginFile("HcUnlisted.esp", unlistedFk.ToString(), null, null, new[] { "BasicStats.Damage" }, 1, null, 500);
+            Check(ur.Error is null && ur.Mode == "read" && ur.Record?.EditorId == "UnlistedSword",
+                  $"reads an UNLISTED-folder plugin by bare filename — mode={ur.Mode}, editorid={ur.Record?.EditorId ?? "?"}, err={ur.Error ?? "none"}");
+            Check(ur.Where is not null && ur.Where.Contains("UNLISTED") && !ur.Enabled,
+                  $"located as UNLISTED, flagged not-active — where='{ur.Where}', enabled={ur.Enabled}");
 
             // 2 — enumerate a type the file defines (+ editorid_contains)
             Console.WriteLine("\n--- 2: enumerate a type the file defines ---");

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1673,9 +1673,42 @@ public sealed class LoadOrderService : IDisposable
     /// <summary>Sweep the active order (or the given <paramref name="plugins"/> scope) for record integrity errors —
     /// dangling FormLinks, missing masters, and parse failures (housecarl_check_errors). Thin wiring over the
     /// core <see cref="ErrorCheck.Run"/>, which holds all the scan logic + Q3 teeth so the self-contained guard drives
-    /// this same path over synthetic plugins. Read-only; composes existing primitives, no new dependency.</summary>
+    /// this same path over synthetic plugins. Read-only; composes existing primitives, no new dependency.
+    /// <para>A scope name NOT in the active order is resolved on disk by the shared plugin-locate contract
+    /// (<see cref="LocatePluginFileOnDisk"/> — enabled, disabled, AND unlisted mod folders) and swept OFF-ORDER: its
+    /// own overlay, links resolved against the active order + the file's own records. This is the pre-enable verify
+    /// lane (HCBR-2026-07-14-02 gap 3) — the pre-ship dangling-ref sweep of a patch houseCARL just wrote, BEFORE the
+    /// MO2 refresh puts it in plugins.txt. A name found nowhere, or in several folders, still fails loud (Q3).</para></summary>
     public ErrorCheckResult CheckErrors(IReadOnlyList<string>? plugins, int limit)
-        => ErrorCheck.Run(Resolver, plugins, limit);
+    {
+        if (plugins is { Count: > 0 })
+        {
+            var view = Resolver.Capture();
+            var active = new List<string>();
+            var offOrder = new List<(string Name, string Path)>();
+            string modsDir, dataDir, overwriteDir, profileDir;
+            lock (_gate) { EnsurePathsDerived(); modsDir = _modsDir; dataDir = _dataDir; overwriteDir = _overwriteDir; profileDir = _profileDir; }
+            Mo2Composition? comp = null;
+            foreach (var name in plugins)
+            {
+                var n = name?.Trim() ?? "";
+                if (n.Length == 0) return ErrorCheckResult.Fail("a blank plugin name in the scope — pass plugin filenames (e.g. 'CoolMod.esp').");
+                if (view.ContainsPlugin(n)) { active.Add(n); continue; }
+                comp ??= Mo2LoadOrder.ReadComposition(profileDir);
+                var loc = LocatePluginFileOnDisk(comp, modsDir, dataDir, overwriteDir, n, null);
+                if (loc.Error is not null)
+                    return ErrorCheckResult.Fail($"plugin not in the load order: {n} — and no on-disk copy was found either ({loc.Error})");
+                if (loc.Ambiguous is not null)
+                    return ErrorCheckResult.Fail(
+                        $"plugin '{n}' is not in the active load order and {loc.Ambiguous.Count} mod folders provide a file with that name " +
+                        $"({string.Join(", ", loc.Ambiguous.Select(h => h.Where))}) — ambiguous, refusing to guess which to sweep. " +
+                        "Enable the one you mean in MO2, or remove the duplicates.");
+                offOrder.Add((n, loc.Path!));
+            }
+            return ErrorCheck.Run(Resolver, active, limit, offOrder.Count > 0 ? offOrder : null);
+        }
+        return ErrorCheck.Run(Resolver, plugins, limit);
+    }
 
     // ---- script-property sweep (housecarl_validate_scripts) --------------------------------------------
 
@@ -2292,7 +2325,11 @@ public sealed class LoadOrderService : IDisposable
     /// <paramref name="acknowledge"/>=true — a first call without it returns a CONFIRM prompt listing exactly what will be
     /// rewritten (never a silent original-file edit).</para>
     ///
-    /// <para>Refuses loud + writes nothing on: the plugin not active / excluded (unparseable) / not on disk; MORE than the
+    /// <para>An INACTIVE target (on disk but not in the load order — the fresh houseCARL patch pre-MO2-refresh, or a
+    /// disabled mod) is resolved by filename via the shared locate contract and compacted OFF-ORDER; its declared
+    /// masters must still be active (HCBR-2026-07-14-02 gap 3). An override-only target with esl=true takes the
+    /// FLAG-ONLY lane (empty remap; the write sets the light flag).</para>
+    /// <para>Refuses loud + writes nothing on: the plugin not found on disk / ambiguous / excluded (unparseable); MORE than the
     /// light window holds (the hard ESL ceiling — named, never truncated); a declared master not active; a serialize fault.
     /// Renumber mechanism + nested coverage: <see cref="RemapEngine.RenumberModInto"/> (remap-wave1/2). Serialized on the
     /// write gate; the identify-pass is one whole-order link walk (~25s at full scale — a deliberate, one-shot operation).</para></summary>
@@ -2311,16 +2348,41 @@ public sealed class LoadOrderService : IDisposable
                 return WritePatchBuilder.CompactOutcome.Fail($"cannot write: ModsDir '{_modsDir}' does not exist. Check HouseCarl:ModsDir.");
 
             var name = pluginName.Trim();
-            if (!view.ContainsPlugin(name))
-                return WritePatchBuilder.CompactOutcome.Fail(
-                    $"'{name}' is not an active plugin in your load order — compact targets an active plugin (so its records, and the plugins that reference it, can be read). Pass the exact filename (e.g. 'CoolMod.esp').");
-            if (view.ExcludedPlugins.TryGetValue(name, out var excluded))
-                return WritePatchBuilder.CompactOutcome.Fail(
-                    $"cannot compact '{name}': it was EXCLUDED from this session ({excluded}) — houseCARL won't renumber a plugin it can't fully parse. The file is untouched.");
-
-            var srcPath = view.PluginPath(name);
-            if (srcPath is null || !File.Exists(srcPath))
-                return WritePatchBuilder.CompactOutcome.Fail($"'{name}' not found on disk at {srcPath ?? "<unresolved>"} — nothing to compact.");
+            string? srcPath;
+            string? offOrderNote = null;
+            if (view.ContainsPlugin(name))
+            {
+                if (view.ExcludedPlugins.TryGetValue(name, out var excluded))
+                    return WritePatchBuilder.CompactOutcome.Fail(
+                        $"cannot compact '{name}': it was EXCLUDED from this session ({excluded}) — houseCARL won't renumber a plugin it can't fully parse. The file is untouched.");
+                srcPath = view.PluginPath(name);
+                if (srcPath is null || !File.Exists(srcPath))
+                    return WritePatchBuilder.CompactOutcome.Fail($"'{name}' not found on disk at {srcPath ?? "<unresolved>"} — nothing to compact.");
+            }
+            else
+            {
+                // NOT in the active order → resolve the FILE on disk (enabled, disabled, AND unlisted mod folders — the
+                // shared locate contract). This is the pre-enable finishing lane (HCBR-2026-07-14-02 gap 3): ESL-flagging
+                // the patch houseCARL just wrote, BEFORE the MO2 refresh puts it in plugins.txt. The requirement that
+                // actually protects correctness is unchanged: every DECLARED MASTER must be active (CompactBuild refuses
+                // otherwise), and the external-referencer scan still runs over the active order — which, for a plugin
+                // nothing active can master, is exactly the right (empty) answer.
+                string modsDir, dataDir, overwriteDir, profileDir;
+                lock (_gate) { EnsurePathsDerived(); modsDir = _modsDir; dataDir = _dataDir; overwriteDir = _overwriteDir; profileDir = _profileDir; }
+                var comp = Mo2LoadOrder.ReadComposition(profileDir);
+                var loc = LocatePluginFileOnDisk(comp, modsDir, dataDir, overwriteDir, name, null);
+                if (loc.Error is not null)
+                    return WritePatchBuilder.CompactOutcome.Fail(
+                        $"'{name}' is not an active plugin in your load order, and no on-disk copy was found either ({loc.Error})");
+                if (loc.Ambiguous is not null)
+                    return WritePatchBuilder.CompactOutcome.Fail(
+                        $"'{name}' is not in the active load order and {loc.Ambiguous.Count} mod folders provide a file with that name " +
+                        $"({string.Join(", ", loc.Ambiguous.Select(h => h.Where))}) — ambiguous, refusing to guess which to compact. " +
+                        "Enable the one you mean in MO2, or remove the duplicates.");
+                srcPath = loc.Path!;
+                offOrderNote = $"'{name}' is not in the active load order (found: {loc.Where}) — compacted OFF-ORDER; " +
+                               "masters resolved from the active order. Enable the result in MO2 to use it.";
+            }
 
             ModKey modKey;
             try { modKey = ModKey.FromFileName(name); }
@@ -2329,19 +2391,38 @@ public sealed class LoadOrderService : IDisposable
             // 1. originating record keys + the remap into the (light, by default) window.
             if (!WritePatchBuilder.TryReadOriginatingKeys(srcPath, modKey, out var keys, out var keyErr))
                 return WritePatchBuilder.CompactOutcome.Fail(keyErr!);
-            if (keys.Count == 0)
-                return WritePatchBuilder.CompactOutcome.Fail(
-                    $"'{name}' defines no originating records to renumber (it carries only overrides, or is empty) — nothing to compact.");
-
+            string? flagOnlyNote = null;
             uint floor = RemapEngine.EslFloor;
-            uint ceiling = esl ? RemapEngine.EslCeiling : FormIdRange.ObjectIdMax;   // light window, or the full 24-bit object-ID range
-            var plan = RemapEngine.BuildSequentialRemap(keys, modKey, floor, ceiling);
-            if (!plan.Success) return WritePatchBuilder.CompactOutcome.Fail(plan.Error!);
+            IReadOnlyDictionary<FormKey, FormKey> remapDict;
+            if (keys.Count == 0)
+            {
+                // Override-only (or empty) plugin: nothing to RENUMBER — but with esl=true the job the caller actually
+                // wants (make it light) is trivially satisfiable, because the light window only constrains ORIGINATING
+                // records. Proceed with an empty remap: every record copies verbatim and the write sets the light flag
+                // (the flag-only lane — the all-override compatibility patch, HCBR-2026-07-14-02 gap 3's ESL endgame).
+                if (!esl)
+                    return WritePatchBuilder.CompactOutcome.Fail(
+                        $"'{name}' defines no originating records to renumber (it carries only overrides, or is empty) — nothing to compact. " +
+                        "(With esl=true this would still set the ESL/light header flag — always valid for an override-only plugin.)");
+                remapDict = new Dictionary<FormKey, FormKey>();
+                flagOnlyNote = $"'{name}' defines no originating records — nothing renumbered; every record copied verbatim with the ESL (light) flag set (always valid for an override-only plugin).";
+            }
+            else
+            {
+                uint ceiling = esl ? RemapEngine.EslCeiling : FormIdRange.ObjectIdMax;   // light window, or the full 24-bit object-ID range
+                var plan = RemapEngine.BuildSequentialRemap(keys, modKey, floor, ceiling);
+                if (!plan.Success) return WritePatchBuilder.CompactOutcome.Fail(plan.Error!);
+                remapDict = plan.Dict;
+            }
 
             // 2. identify-pass — which plugins OUTSIDE the target reference a record being renumbered (the break risk).
-            var targets = plan.Dict.Keys.ToHashSet();
+            //    Nothing being renumbered ⇒ nothing can break ⇒ the scan has nothing to ask (skip the whole-order walk).
+            var targets = remapDict.Keys.ToHashSet();
             var transformSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { name };
-            var id = RemapEngine.IdentifyExternalReferencers(resolver, targets, transformSet);
+            var id = targets.Count == 0
+                ? new RemapEngine.IdentifyResult(Array.Empty<RemapEngine.ExternalRef>(), Array.Empty<string>(), 0, 0,
+                                                 Array.Empty<string>(), Array.Empty<RemapEngine.ExternalOverride>(), Array.Empty<string>())
+                : RemapEngine.IdentifyExternalReferencers(resolver, targets, transformSet);
 
             // 3. external-referencer policy (Q3 — never silently ship a compaction that dangles an external reference).
             if (id.HasExternalReferencers)
@@ -2402,7 +2483,7 @@ public sealed class LoadOrderService : IDisposable
             }
 
             // 6. build + write the compacted plugin.
-            var build = WritePatchBuilder.CompactBuild(srcPath, modKey, plan.Dict, view.PluginPath, outPath, esl, floor);
+            var build = WritePatchBuilder.CompactBuild(srcPath, modKey, remapDict, view.PluginPath, outPath, esl, floor);
             if (!build.Success)
             {
                 if (!inPlace && createdFresh) RemoveOrNameRiderResidue(rf);   // a refused build leaves no orphan folder
@@ -2414,7 +2495,7 @@ public sealed class LoadOrderService : IDisposable
             if (willRepoint)
                 foreach (var ext in id.ExternalPlugins)
                 {
-                    var rep = RemapEngine.RepointInPlace(resolver, ext, plan.Dict);
+                    var rep = RemapEngine.RepointInPlace(resolver, ext, remapDict);
                     repointed.Add(new WritePatchBuilder.RepointReport(ext, rep.Success, rep.Error));
                 }
 
@@ -2441,8 +2522,8 @@ public sealed class LoadOrderService : IDisposable
                 var assetView = assetResolver.Capture();
                 seqGate = assetView.ResolveForPlacement(srcSeqRel).Sources.Count > 0;   // VFS-aware (loose roots + active BSAs)
                 var outDir = Path.GetDirectoryName(outPath)!;
-                assetRename = AssetRenameService.CarryFaceGen(outPath, plan.Dict, assetView, outDir);
-                voiceRename = AssetRenameService.CarryVoice(outPath, plan.Dict, assetView, outDir);
+                assetRename = AssetRenameService.CarryFaceGen(outPath, remapDict, assetView, outDir);
+                voiceRename = AssetRenameService.CarryVoice(outPath, remapDict, assetView, outDir);
             }
             catch (Exception ex)
             {
@@ -2479,6 +2560,8 @@ public sealed class LoadOrderService : IDisposable
             //    field-edit ack silently authorize a full renumber. Markers are best-effort (a miss never fails the done
             //    write, Q3) — any miss is surfaced in Note.
             var markerNotes = new List<string>();
+            if (offOrderNote is not null) markerNotes.Add(offOrderNote);
+            if (flagOnlyNote is not null) markerNotes.Add(flagOnlyNote);
             if (inPlace) { var n = MergeEditedInPlaceMarker(Path.GetDirectoryName(srcPath)); if (n is not null) markerNotes.Add(n); }
             foreach (var r in repointed.Where(r => r.Success))
             {

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4045,7 +4045,7 @@ public sealed class LoadOrderService : IDisposable
         var hits = Mo2LoadOrder.LocatePlugin(comp, modsDir, dataDir, overwriteDir, plugin);
         if (hits.Count == 0)
             return new(null, "", false, null,
-                $"'{Path.GetFileName(plugin)}' is in no mod folder (enabled or disabled), the overwrite folder, or the game Data folder. Check the filename, pass an absolute path, or (if it's an MO2 mod) the exact folder via mod=.");
+                $"'{Path.GetFileName(plugin)}' is in no mod folder (enabled, disabled, or not-yet-listed in MO2), the overwrite folder, or the game Data folder. Check the filename, pass an absolute path, or (if it's an MO2 mod) the exact folder via mod=.");
         if (hits.Count > 1) return new(null, "", false, hits, null);
         return new(hits[0].Path, hits[0].Where, hits[0].Enabled, null, null);
     }

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -161,14 +161,17 @@ public static class ReadTools
          "references — a non-null link whose target NO plugin in the ACTIVE order defines (a broken reference); (2) " +
          "MISSING MASTERS — a master a plugin DECLARES that is not present in the active order (its dependency is not " +
          "installed/enabled — the most common load-order break); (3) PARSE failures — records houseCARL/Mutagen could not " +
-         "read (per record), plus whole plugins the index excluded as unparseable. Read-only — writes nothing. BOUNDARY " +
+         "read (per record), plus whole plugins the index excluded as unparseable. A scoped name NOT in the active order " +
+         "is resolved on disk (any mod folder — enabled, disabled, or not yet listed in MO2) and swept OFF-ORDER: its own " +
+         "records, links resolved against the active order PLUS the file's own definitions — the pre-enable verify sweep " +
+         "for a patch houseCARL just wrote. Read-only — writes nothing. BOUNDARY " +
          "(never a silent claim of more — Q3): this covers the FormLink-resolution / missing-master / parse class. It does " +
          "NOT verify navmesh or terrain spatial integrity (CRC/grid — a Mutagen-delta residual), does NOT flag a required " +
          "field left null (a null FormLink is a legal optional, not an error), and does NOT list unused-master cleanup " +
          "(a FormLink scan cannot prove a master is unused). Results cap at limit= and max_chars (both overruns explicit).")]
     public static string CheckErrorsTool(
         LoadOrderService svc,
-        [Description("Optional. Plugin filenames to check (e.g. 'MyMod.esp'). A name not in the load order is an error. Omit to sweep the WHOLE active order (every non-excluded plugin) — thorough but heavier; scope to one plugin for a fast, focused check like the CK's per-plugin 'Check For Errors'.")]
+        [Description("Optional. Plugin filenames to check (e.g. 'MyMod.esp'). A name not in the active order is resolved on disk (a fresh houseCARL patch, a disabled mod) and swept OFF-ORDER; found nowhere (or in several folders) it is an error. Omit to sweep the WHOLE active order (every non-excluded plugin) — thorough but heavier; scope to one plugin for a fast, focused check like the CK's per-plugin 'Check For Errors'.")]
             string[]? plugins = null,
         [Description("Optional. Max dangling references to list across the whole sweep (default 1000). The TRUE total is always reported; over the cap it says so. Master-table findings are always listed in full (they are few).")]
             int limit = 1000,
@@ -410,6 +413,9 @@ static class Wire
         if (r.ExcludedPlugins.Count > 0)
             sb.Append(" · ").Append(r.ExcludedPlugins.Count).Append(" plugin(s) excluded (unparseable)");
         sb.Append('\n');
+        if (r.OffOrderScanned is { Count: > 0 } off)
+            sb.Append("swept OFF-ORDER (on disk, not in the active load order): ").Append(string.Join(", ", off))
+              .Append("   [the file's own records; links resolved against the active order + the file's own definitions]\n");
 
         if (r.Reports.Count == 0 && r.ExcludedPlugins.Count == 0)
             sb.Append("\nNo errors found in the scanned scope.\n");

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -82,7 +82,11 @@ public static class WriteTools
          "masters automatically when edits reference forms across several plugins (cross-master merge). ALL-OR-NOTHING " +
          "(Q3): if ANY operation is malformed or fails pre-flight, the whole call is refused with per-op reasons and " +
          "nothing is written — no partial patches. By default writes a fresh patch named patch_name; pass into= to extend " +
-         "an existing one. To edit an EXISTING plugin IN PLACE instead — rewriting your ORIGINAL file (incl. a mod houseCARL " +
+         "an existing one. PRECEDENCE with into= (pinned): a FormKey the patch ALREADY CARRIES (e.g. from a prior " +
+         "housecarl_forward_record) is edited AS-IS in the patch — the op lands on the patch's own copy; only a FormKey " +
+         "the patch does NOT yet carry copies the load-order winner in first. So forward_record from a source + " +
+         "bulk_apply into= is THE recipe to build on a specific plugin's version while a stale winner sits above it. " +
+         "To edit an EXISTING plugin IN PLACE instead — rewriting your ORIGINAL file (incl. a mod houseCARL " +
          "didn't make), not a patch — pass target=<plugin filename> + in_place=true (opt-in; the default lane leaves originals " +
          "untouched). Returns the patch path, masters, and per-op read-back.")]
     public static string BulkApply(
@@ -273,8 +277,11 @@ public static class WriteTools
          "existing override is REPLACED by from_plugin's body (xEdit's copy-as-override overwrite — flagged per record in the " +
          "response). target= + in_place=true is the opt-in THIRD route: forward INTO an existing plugin's OWN file (incl. one " +
          "houseCARL didn't author) — same replace-on-collision semantics, same one-time acknowledge= consent as the sibling " +
-         "write tools, master header grown from the copied bodies. Returns the patch path, masters, and per-record what was " +
-         "copied + the current winner it will out-rank (a forward whose version is ALREADY winning is flagged redundant).")]
+         "write tools, master header grown from the copied bodies. THE STALE-WINNER BYPASS RECIPE (pinned): forward from " +
+         "the source you want, then bulk_apply into= the same patch — the ops edit the patch's FORWARDED copy, never " +
+         "re-resolve the (stale) load-order winner, so you build on the forwarded body directly. Returns the patch path, " +
+         "masters, and per-record what was copied + the current winner it will out-rank (a forward whose version is " +
+         "ALREADY winning is flagged redundant).")]
     public static string ForwardRecord(
         LoadOrderService svc,
         [Description("The record(s) to forward, each as 'XXXXXX:Plugin.esp' (6 hex digits, the defining master's filename). All are copied from the SAME from_plugin.")]

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -350,13 +350,18 @@ public static class WriteTools
          "houseCARL scans the WHOLE load order for such external referencers (a one-pass walk — can take ~25s on a big order): " +
          "if NONE, it's a clean compaction; if SOME, the call is REFUSED and lists them, UNLESS repoint_externals=true, which " +
          "ALSO rewrites each of them in place to follow the renumber (needs acknowledge=true; no backup of them either). " +
-         "Refuses loud + writes nothing on: the plugin not active / unparseable / not on disk; MORE records than the light " +
+         "The target need NOT be active: a plugin on disk but not (yet) in the load order — e.g. the patch houseCARL just " +
+         "wrote, before the MO2 refresh — is resolved by filename across ALL mod folders and compacted OFF-ORDER (its " +
+         "declared masters must still be active). An override-only plugin with esl=true takes the FLAG-ONLY lane: nothing " +
+         "to renumber, every record copies verbatim, the ESL flag is set (always valid — the light window only constrains " +
+         "originating records). Refuses loud + writes nothing on: the plugin found nowhere on disk / ambiguous across " +
+         "folders / unparseable; an override-only plugin with esl=false (nothing to do); MORE records than the light " +
          "range holds (the hard 2048 ESL ceiling — named, never truncated); a declared master not active; a serialize fault. " +
          "Note: references compiled into Papyrus scripts (.pex hardcoded FormIDs / GetFormFromFile) are NOT remappable — " +
          "verify scripted records after compacting.")]
     public static string CompactPlugin(
         LoadOrderService svc,
-        [Description("The plugin's filename to compact (e.g. 'CoolMod.esp') — must be active in your load order. The compacted output keeps this EXACT basename.")]
+        [Description("The plugin's filename to compact (e.g. 'CoolMod.esp'). Usually active in your load order; a plugin on disk but not in the order (a fresh houseCARL patch, a disabled mod) is resolved by filename and compacted OFF-ORDER — its declared masters must still be active. The compacted output keeps this EXACT basename.")]
             string plugin,
         [Description("When true (default), renumber into the light/ESL range (0x800–0xFFF, 2048 IDs) and flag the result a light master (ESPFE) — the canonical 'compact for ESL'. false = renumber contiguously from 0x800 with no light flag or 2048 ceiling (just closes FormID gaps).")]
             bool esl = true,


### PR DESCRIPTION
## The enable-boundary fix batch (HCBR-2026-07-14-02 gaps 3 + 4)

Three small, independent fixes from the patch-authoring gap report `HCBR-2026-07-14-02` (in the local bug-report store) — the "small unrelated stuff" lane Aaron split off ahead of the bulk-primitives sub-project. All three close the same seam: houseCARL's own not-yet-enabled output was a second-class citizen to its read/verify/finish tools.

### 1. `read_plugin_file` finds a fresh houseCARL patch by bare filename (`4b5e964`)

`LocatePlugin` walked only the mod folders `modlist.txt` lists — a folder created since MO2 last rewrote the profile (exactly the state of a just-written patch) was invisible, so reads demanded an absolute path while `into=` writes resolved the same file by filename. The shared locator (and its existence twin `PluginFileExists`) now sweep **UNLISTED** folders too, ranked after disabled, flagged not-active. Probe arm 1b pins it.

### 2. `check_errors` + `compact_plugin` accept a not-yet-enabled plugin (`a27cb6e`)

The pre-ship dangling-ref sweep and the ESL flag were forced past the enable boundary because both tools gated on *target active* — while the requirement that actually protects correctness is *declared masters active*, which is unchanged and still refuses loud.

- `check_errors`: a scoped name not in the order resolves on disk and is swept **OFF-ORDER** — its own overlay, links resolved against the active order **plus the file's own records** (a patch's link to its own new record is not dangling). Off-order names are stamped in the result.
- `compact_plugin`: same resolution; the external-referencer scan still runs over the active order. Additionally, an override-only plugin with `esl=true` now takes the **FLAG-ONLY lane** (nothing to renumber → verbatim copy + light flag, always valid) instead of refusing "nothing to compact" — the all-override compatibility patch's ESL endgame. `esl=false` still refuses; found-nowhere and ambiguous filenames still refuse loud.

New probe arms: `OFF-ORDER-SELF/-DANGLE/-STAMP` (check-errors-guard), `OFF-ORDER`, `FLAG-ONLY` ×2, `OFF-ORDER-AMBIGUOUS` (compact-service-guard).

### 3. Forward-then-edit precedence named + pinned (`39c67b8`)

The stale-winner bypass (`forward_record` from a source → `bulk_apply into=` the same patch) worked correctly but was undocumented — the tool text implied an `into=` edit might re-resolve the stale winner. The precedence is now a named line in both tools' descriptions (*a FormKey the patch already carries is edited as-is; only an absent one copies the winner in*) and pinned by the `FORWARD-THEN-EDIT` probe arm (forward Dmg 20 under a live winner of 30, edit Weight, assert 20 survives + the edit lands).

### Verification

`ci-all` green from the worktree root (all probes, including the six new/extended arms above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
