### PR TITLE
feat(query): bulk-primitives Wave 1 — defined_in / list references= / group_by on cross_plugin_query

### DIFF
--- a/src/housecarl-generator/BulkQueryPrimitivesProbe.cs
+++ b/src/housecarl-generator/BulkQueryPrimitivesProbe.cs
@@ -1,0 +1,208 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// REGRESSION GUARD (standing CI instrument, self-contained) for bulk-primitives WAVE 1 — the three type-agnostic
+/// additions to <c>housecarl_cross_plugin_query</c> (PLAN.md P1/P2/P4):
+///   • P1 <c>defined_in=</c> — narrow a plugins= scope from 'records this plugin TOUCHES' (definitions AND overrides)
+///     to 'records DEFINED in this plugin' (origin FormKey), the catalogue-scope semantics; refused loud without plugins=.
+///   • P2 list-valued <c>references=</c> — OR over many targets in ONE scan (was one scan per target), each match
+///     recording WHICH target(s) it hit (matches=…) so a multi-target reverse lookup can be un-merged.
+///   • P4 <c>group_by=</c> winner|type|defined_in — a count table over ALL matches (not limit-capped) instead of lines.
+///
+/// Synthesizes a 2-plugin order ON DISK (a master + a replacer that OVERRIDES one weapon and DEFINES new ones, with
+/// keyword links so references= has something to reverse) and drives the REAL service-layer scan
+/// (<see cref="LoadOrderService.CrossQuery"/> via the ForGuard seam) + the tool-layer guard
+/// (<see cref="ReadTools.CrossPluginQuery"/>). Asserts each primitive's contract AND both loud refusals
+/// (defined_in without plugins=; group_by with fields=/conflict_tree). group_by counts are cross-checked against a
+/// hand tally of the same scope's per-match summaries. Self-contained: a corpus is generated in-process if none is
+/// configured (in ci-all the runner pre-sets it), so type= resolution works standalone too.
+///
+/// Run: <c>dotnet run --project src/housecarl-generator bulk-query-primitives-guard</c>
+/// </summary>
+public static class BulkQueryPrimitivesProbe
+{
+    static int _pass, _fail;
+
+    public static int RunGuard(string[] args)
+    {
+        _pass = _fail = 0;
+        Console.WriteLine("################  REGRESSION GUARD — bulk-primitives Wave 1 (cross_plugin_query defined_in / list references= / group_by)  ################");
+        Console.WriteLine();
+
+        var dir = Path.Combine(Path.GetTempPath(), "hc_bulk_query_primitives_guard_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+
+        // type= resolution reads the schema corpus. In ci-all the runner pre-sets CorpusRulebook.CorpusPath; standalone
+        // it may be unset — generate one in-process so this guard is genuinely self-contained (self-skips nothing).
+        try { _ = CorpusRulebook.LoadCorpus(); }
+        catch
+        {
+            var gen = Path.Combine(dir, "generated");
+            CorpusGenerator.GenerateAll(gen, Path.Combine(dir, "refs"));
+            CorpusRulebook.CorpusPath = Path.Combine(gen, "corpus.json");
+            Console.WriteLine($"-- generated a corpus for type= resolution: {CorpusRulebook.CorpusPath} --");
+        }
+
+        const string masterName = "hcbpMaster.esp", replName = "hcbpRepl.esp";
+        var masterPath = Path.Combine(dir, masterName);
+        var replPath = Path.Combine(dir, replName);
+
+        try
+        {
+            // ---- 1. MASTER: two keywords, two weapons (each carrying one keyword), one armor. Masterless (CI has no
+            //         game files). W1 will be OVERRIDDEN by the replacer; W2/A1 stay master-only. ----
+            var master = new SkyrimMod(ModKey.FromNameAndExtension(masterName), SkyrimRelease.SkyrimSE);
+            var ka = master.Keywords.AddNew(); ka.EditorID = "hcbpKwA"; var kaFk = ka.FormKey;
+            var kb = master.Keywords.AddNew(); kb.EditorID = "hcbpKwB"; var kbFk = kb.FormKey;
+            var w1 = master.Weapons.AddNew(); w1.EditorID = "hcbpSword1"; w1.BasicStats = new WeaponBasicStats { Damage = 10 };
+            w1.Keywords = new Noggog.ExtendedList<IFormLinkGetter<IKeywordGetter>> { new FormLink<IKeywordGetter>(kaFk) };
+            var w1Fk = w1.FormKey;
+            var w2 = master.Weapons.AddNew(); w2.EditorID = "hcbpSword2"; w2.BasicStats = new WeaponBasicStats { Damage = 20 };
+            w2.Keywords = new Noggog.ExtendedList<IFormLinkGetter<IKeywordGetter>> { new FormLink<IKeywordGetter>(kbFk) };
+            var w2Fk = w2.FormKey;
+            var a1 = master.Armors.AddNew(); a1.EditorID = "hcbpArmor1"; var a1Fk = a1.FormKey;
+            master.BeginWrite.ToPath(masterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+            // ---- 2. REPLACER (masters [master]): OVERRIDE W1 (so it's a record Repl TOUCHES but does NOT define),
+            //         plus DEFINE a new weapon W3 (keywords KA+KB — references BOTH targets) and a new armor A2. ----
+            var repl = new SkyrimMod(ModKey.FromNameAndExtension(replName), SkyrimRelease.SkyrimSE);
+            ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(repl, w1)).BasicStats = new WeaponBasicStats { Damage = 15 }; // W1 override wins
+            var w3 = repl.Weapons.AddNew(); w3.EditorID = "hcbpSword3"; w3.BasicStats = new WeaponBasicStats { Damage = 30 };
+            w3.Keywords = new Noggog.ExtendedList<IFormLinkGetter<IKeywordGetter>>
+                { new FormLink<IKeywordGetter>(kaFk), new FormLink<IKeywordGetter>(kbFk) };
+            var w3Fk = w3.FormKey;
+            var a2 = repl.Armors.AddNew(); a2.EditorID = "hcbpArmor2"; var a2Fk = a2.FormKey;
+            repl.BeginWrite.ToPath(replPath).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
+
+            Console.WriteLine($"-- synthesized {masterName} (KA,KB; W1[KA],W2[KB],A1) < {replName} (override W1; W3[KA,KB],A2) --");
+            Console.WriteLine();
+
+            using var resolver = LoadOrderResolver.Build(new[] { masterPath, replPath });
+            var svc = LoadOrderService.ForGuard(resolver, new UserConfigStore(Path.Combine(dir, "houseCARL.user.json")));
+
+            // ================= P1 — defined_in= (definitions vs touches) =================
+            Console.WriteLine("── P1: defined_in= narrows plugins= from TOUCHES to DEFINITIONS ──");
+            var touches = svc.CrossQuery("Weapon", null, null, false, new[] { replName }, null, 500);
+            Check($"plugins=[Repl] type=Weapon TOUCHES 2 (W1 override + W3 def) — got {touches.Total}", touches.Total == 2 && touches.Keys.Count == 2);
+            Check("  ... and the override W1 is among the touched", touches.Keys.Contains(w1Fk));
+
+            var defd = svc.CrossQuery("Weapon", null, null, false, new[] { replName }, null, 500, definedIn: true);
+            Check($"plugins=[Repl] type=Weapon defined_in=true DEFINES 1 (only W3) — got {defd.Total}", defd.Total == 1 && defd.Keys.Count == 1);
+            Check("  ... the one defined record is W3 (origin=Repl)", defd.Keys.Count == 1 && defd.Keys[0] == w3Fk);
+            Check("  ... the override W1 (origin=master) is EXCLUDED", !defd.Keys.Contains(w1Fk));
+            Check($"  ... the header names the scope explicitly (ScopeLabel='{replName}')", defd.ScopeLabel == replName);
+
+            var defRefusal = svc.CrossQuery("Weapon", null, null, false, null, null, 500, definedIn: true);
+            Check("defined_in=true WITHOUT plugins= is REFUSED loud (not silently ignored)",
+                  defRefusal.Error is not null && defRefusal.Error.Contains("plugins=", StringComparison.OrdinalIgnoreCase));
+
+            // ================= P2 — list-valued references= (OR + matches= un-merge) =================
+            Console.WriteLine();
+            Console.WriteLine("── P2: references= is a LIST — OR over targets, each match records WHICH it hit ──");
+            var multi = svc.CrossQuery("Weapon", new[] { kaFk, kbFk }, null, false, null, null, 500);
+            Check($"references=[KA,KB] over Weapons matches 3 (W1→KA, W2→KB, W3→KA,KB) — got {multi.Total}", multi.Total == 3);
+            Check("  ... MatchedTargets is populated for a multi-target lookup", multi.MatchedTargets is not null && multi.MatchedTargets.Count == multi.Keys.Count);
+            if (multi.MatchedTargets is not null)
+            {
+                var matchOf = new Dictionary<FormKey, string?>();
+                for (int i = 0; i < multi.Keys.Count; i++) matchOf[multi.Keys[i]] = multi.MatchedTargets[i];
+                Check($"  ... W1 matches=KA only", matchOf.TryGetValue(w1Fk, out var m1) && m1 == kaFk.ToString());
+                Check($"  ... W2 matches=KB only", matchOf.TryGetValue(w2Fk, out var m2) && m2 == kbFk.ToString());
+                Check($"  ... W3 matches=KA, KB (both, in input order)", matchOf.TryGetValue(w3Fk, out var m3) && m3 == $"{kaFk}, {kbFk}");
+            }
+            var oneKa = svc.CrossQuery("Weapon", new[] { kaFk }, null, false, null, null, 500);
+            Check($"references=[KA] alone matches 2 (W1,W3) — got {oneKa.Total}", oneKa.Total == 2 && oneKa.Keys.Contains(w1Fk) && oneKa.Keys.Contains(w3Fk));
+            Check("  ... single-target references= adds NO matches= noise (MatchedTargets null)", oneKa.MatchedTargets is null);
+            var oneKb = svc.CrossQuery("Weapon", new[] { kbFk }, null, false, null, null, 500);
+            Check($"references=[KB] alone matches 2 (W2,W3) — the OR union of [KA]+[KB] is the 3 above", oneKb.Total == 2 && oneKb.Keys.Contains(w2Fk) && oneKb.Keys.Contains(w3Fk));
+
+            // ================= P4 — group_by= aggregation =================
+            Console.WriteLine();
+            Console.WriteLine("── P4: group_by= winner|type|defined_in → a count table over ALL matches ──");
+            var byWinner = svc.CrossQuery("Weapon", null, null, false, null, null, 500, groupBy: "winner");
+            var gw = GroupMap(byWinner);
+            Check($"group_by=winner over Weapons: total 3, Repl=2 (W1,W3) & master=1 (W2) — got total {byWinner.Total}",
+                  byWinner.Total == 3 && byWinner.GroupBy == "winner" && gw.GetValueOrDefault(replName) == 2 && gw.GetValueOrDefault(masterName) == 1);
+            Check("  ... groups are sorted by count desc (Repl(2) before master(1))",
+                  byWinner.Groups is { Count: 2 } && byWinner.Groups[0].Key == replName && byWinner.Groups[1].Key == masterName);
+
+            var byDef = svc.CrossQuery("Weapon", null, null, false, null, null, 500, groupBy: "defined_in");
+            var gd = GroupMap(byDef);
+            Check($"group_by=defined_in over Weapons: master=2 (W1,W2 defined there) & Repl=1 (W3) — got total {byDef.Total}",
+                  byDef.Total == 3 && gd.GetValueOrDefault(masterName) == 2 && gd.GetValueOrDefault(replName) == 1);
+
+            // group_by=type over a broad (all-touched) scope, cross-checked against a hand tally of the same scope.
+            var byType = svc.CrossQuery(null, null, null, false, new[] { masterName, replName }, null, 500, groupBy: "type");
+            var gt = GroupMap(byType);
+            var plain = svc.CrossQuery(null, null, null, false, new[] { masterName, replName }, null, 5000);   // same scope, no group_by
+            var handTally = new Dictionary<string, int>(StringComparer.Ordinal);
+            foreach (var s in plain.Prefilled ?? Array.Empty<RecordSummary>()) handTally[s.Type] = handTally.GetValueOrDefault(s.Type) + 1;
+            Check($"group_by=type over plugins=[master,Repl]: Weapon=3, Armor=2, Keyword=2, total 7 — got total {byType.Total}",
+                  byType.Total == 7 && gt.GetValueOrDefault("Weapon") == 3 && gt.GetValueOrDefault("Armor") == 2 && gt.GetValueOrDefault("Keyword") == 2);
+            Check("  ... group_by=type counts MATCH a hand tally of the same scope's per-match summaries",
+                  plain.Total == byType.Total && gt.Count == handTally.Count && gt.All(kv => handTally.GetValueOrDefault(kv.Key) == kv.Value));
+
+            // conflicts_only + group_by=winner: the pure-index branch (NO body) still aggregates by winner.
+            var conflictWinner = svc.CrossQuery(null, null, null, true, null, null, 500, groupBy: "winner");
+            var cw = GroupMap(conflictWinner);
+            Check($"conflicts_only + group_by=winner (no body scope): the 1 contested record (W1) → Repl=1 — got total {conflictWinner.Total}",
+                  conflictWinner.Total == 1 && cw.GetValueOrDefault(replName) == 1);
+
+            // group_by=type WITHOUT a body-bearing scope is refused (type isn't known without a per-record fetch).
+            var typeNoBody = svc.CrossQuery(null, null, null, true, null, null, 500, groupBy: "type");
+            Check("group_by=type without type=/plugins= is REFUSED loud (no body to name the type)",
+                  typeNoBody.Error is not null && typeNoBody.Error.Contains("group_by=type", StringComparison.OrdinalIgnoreCase));
+
+            // group_by with an unknown key is refused before any scan.
+            var badKey = svc.CrossQuery("Weapon", null, null, false, null, null, 500, groupBy: "bogus");
+            Check("group_by=<unknown key> is REFUSED loud", badKey.Error is not null && badKey.Error.Contains("group_by", StringComparison.OrdinalIgnoreCase));
+
+            // ================= tool-layer refusal — group_by cannot combine with fields=/conflict_tree= =================
+            Console.WriteLine();
+            Console.WriteLine("── tool-layer guard: group_by= vs fields=/conflict_tree= ──");
+            var sFields = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: "winner",
+                fields: new[] { "BasicStats.Damage" }, conflict_tree: false, limit: 500, max_chars: 0);
+            Check("group_by + fields= is REFUSED loud at the tool layer",
+                  sFields.StartsWith("error:", StringComparison.OrdinalIgnoreCase) && sFields.Contains("group_by", StringComparison.OrdinalIgnoreCase));
+            var sTree = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: "winner",
+                fields: null, conflict_tree: true, limit: 500, max_chars: 0);
+            Check("group_by + conflict_tree=true is REFUSED loud at the tool layer",
+                  sTree.StartsWith("error:", StringComparison.OrdinalIgnoreCase) && sTree.Contains("group_by", StringComparison.OrdinalIgnoreCase));
+
+            // A positive tool-layer render sanity check: group_by=winner renders a count table (not per-match lines).
+            var sGroup = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: "winner",
+                fields: null, conflict_tree: false, limit: 500, max_chars: 0);
+            Check("group_by=winner renders a 'grouped by winner' count table",
+                  sGroup.Contains("grouped by winner") && sGroup.Contains($"{replName} = 2"));
+
+            Console.WriteLine();
+            Console.WriteLine($"=== bulk-query-primitives-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
+            return _fail == 0 ? 0 : 1;
+        }
+        catch (Exception ex) { Console.WriteLine($"   FAIL (unexpected): {ex.GetType().Name}: {ex.Message}\n{ex.StackTrace}"); return 1; }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
+
+    static Dictionary<string, int> GroupMap(CrossQueryOutcome q)
+    {
+        var d = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var g in q.Groups ?? Array.Empty<GroupCount>()) d[g.Key] = g.Count;
+        return d;
+    }
+
+    static void Check(string label, bool ok)
+    {
+        Console.WriteLine($"   [{(ok ? "PASS" : "FAIL")}] {label}");
+        if (ok) _pass++; else _fail++;
+    }
+}

--- a/src/housecarl-generator/BulkQueryPrimitivesProbe.cs
+++ b/src/housecarl-generator/BulkQueryPrimitivesProbe.cs
@@ -185,6 +185,20 @@ public static class BulkQueryPrimitivesProbe
             Check("group_by=winner renders a 'grouped by winner' count table",
                   sGroup.Contains("grouped by winner") && sGroup.Contains($"{replName} = 2"));
 
+            // Group-table max_chars truncation: a tiny cap clips the ROW list but the header total stays EXACT (Q3).
+            var sGroupClip = ReadTools.CrossPluginQuery(svc, type: null, references: null, editorid_contains: null,
+                conflicts_only: false, plugins: new[] { masterName, replName }, defined_in: false, where: null,
+                group_by: "type", fields: null, conflict_tree: false, limit: 500, max_chars: 60);
+            Check("group_by table truncates the ROW list under max_chars but keeps the exact total (Q3)",
+                  sGroupClip.Contains("7 matches across 3 groups") && sGroupClip.Contains("before hitting max_chars=") && sGroupClip.Contains("the total above is exact"));
+
+            // Detail-mode (fields=) multi-target references= still renders the per-match matches= un-merge line.
+            var sDetail = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: new[] { $"{kaFk}", $"{kbFk}" },
+                editorid_contains: null, conflicts_only: false, plugins: null, defined_in: false, where: null,
+                group_by: null, fields: new[] { "BasicStats.Damage" }, conflict_tree: false, limit: 500, max_chars: 0);
+            Check("detail-mode (fields=) multi-target references= renders the matches= line (W3 → both targets)",
+                  sDetail.Contains("matches=") && sDetail.Contains($"matches={kaFk}, {kbFk}"));
+
             Console.WriteLine();
             Console.WriteLine($"=== bulk-query-primitives-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
             return _fail == 0 ? 0 : 1;

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -48,6 +48,11 @@ public static class CiAll
         ("check-errors-guard", CheckErrorsProbe.RunGuard),
         ("script-property-check-guard", ScriptPropertyCheckProbe.RunGuard),
         ("source-display-guard", SourceDisplayProbe.RunGuard),
+        // BULK-PRIMITIVES Wave 1 — the three type-agnostic cross_plugin_query additions (PLAN P1/P2/P4): defined_in=
+        // (definitions vs touches), list-valued references= (OR + matches= un-merge), group_by= (winner|type|
+        // defined_in count table). Drives the real service scan + the tool-layer group_by/fields guard on a synthetic
+        // master+replacer order; group_by counts are cross-checked against a hand tally; both loud refusals asserted.
+        ("bulk-query-primitives-guard", BulkQueryPrimitivesProbe.RunGuard),
         ("writelock-guard", WriteLockProbe.RunGuard),
         ("inplace-guard", InPlaceProbe.RunGuard),
         ("subclass-remove-guard", SubclassRemoveGuardProbe.RunGuard),

--- a/src/housecarl-generator/PerkRefsProbe.cs
+++ b/src/housecarl-generator/PerkRefsProbe.cs
@@ -83,7 +83,7 @@ public static class PerkRefsProbe
         using var resolver = LoadOrderResolver.Build(new[] { espPath });
         var svc = LoadOrderService.ForGuard(resolver, new UserConfigStore(Path.Combine(tmpDir, "houseCARL.user.json")));
         CrossQueryOutcome q;
-        try { q = svc.CrossQuery(type: null, references: targetFk, editoridContains: null, conflictsOnly: false,
+        try { q = svc.CrossQuery(type: null, references: new[] { targetFk }, editoridContains: null, conflictsOnly: false,
                                  plugins: new[] { modKey.FileName.String }, where: null, limit: 500); }
         catch (Exception ex)
         {
@@ -137,7 +137,7 @@ public static class PerkRefsProbe
 
         CrossQueryOutcome q;
         var sw = System.Diagnostics.Stopwatch.StartNew();
-        try { q = svc.CrossQuery(type: "Perk", references: refFk, editoridContains: null, conflictsOnly: false,
+        try { q = svc.CrossQuery(type: "Perk", references: new[] { refFk }, editoridContains: null, conflictsOnly: false,
                                  plugins: null, where: null, limit: 500); }
         catch (Exception ex)
         {

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1511,22 +1511,57 @@ public sealed class LoadOrderService : IDisposable
     /// pass with the matching record's body in hand (no per-candidate re-fetch): type= streams the WINNER body
     /// (effective truth) via typed group enumeration; plugins= streams each scoped plugin's OWN body (a content
     /// audit); conflicts_only= alone reads the index. Body filters (editorid_contains/references) test the
-    /// in-hand body and so require type= or plugins= to bound them. Returns pre-built match summaries (capped at
-    /// <paramref name="limit"/>, with the true total) or a recoverable Q3 error. Holds nothing.</summary>
-    public CrossQueryOutcome CrossQuery(string? type, FormKey? references, string? editoridContains,
-                                        bool conflictsOnly, IReadOnlyList<string>? plugins, IReadOnlyList<string>? where, int limit)
+    /// in-hand body and so require type= or plugins= to bound them. <paramref name="references"/> is a LIST — a
+    /// record matches if it references ANY target (OR), and each match records which target(s) it hit (multi-target
+    /// un-merge). <paramref name="definedIn"/> keeps only matches whose FormKey ORIGINATES in a scoped plugin
+    /// (definitions, not overrides) — requires plugins=, refused loud otherwise. <paramref name="groupBy"/>
+    /// ("winner"|"type"|"defined_in") replaces per-match lines with a count table over ALL matches (not capped by
+    /// limit=). Returns pre-built match summaries (capped at <paramref name="limit"/>, with the true total), a group
+    /// table, or a recoverable Q3 error. Holds nothing.</summary>
+    public CrossQueryOutcome CrossQuery(string? type, IReadOnlyList<FormKey>? references, string? editoridContains,
+                                        bool conflictsOnly, IReadOnlyList<string>? plugins, IReadOnlyList<string>? where, int limit,
+                                        bool definedIn = false, string? groupBy = null)
     {
         var resolver = Resolver;
         var view = resolver.Capture();          // ONE build for the SCAN and every per-match fill it makes (HCBR-2026-06-11-02)
         bool hasPlugins = plugins is { Count: > 0 };
         bool hasType = type is not null;
         bool hasWhere = where is { Count: > 0 };
-        bool bodyFilter = references is not null || !string.IsNullOrEmpty(editoridContains) || hasWhere;
+        bool hasReferences = references is { Count: > 0 };
+        bool bodyFilter = hasReferences || !string.IsNullOrEmpty(editoridContains) || hasWhere;
 
         if (!hasType && !conflictsOnly && !hasPlugins && !bodyFilter)
             return CrossQueryOutcome.Fail("cross_plugin_query needs at least one of: type=, conflicts_only=true, editorid_contains=, references=, where=, or plugins=.");
         if (bodyFilter && !hasType && !hasPlugins)
             return CrossQueryOutcome.Fail("editorid_contains/references/where is a body scan and must be combined with type= or plugins= to bound it (conflicts_only= alone is not enough — an unbounded body scan over the whole order is refused). A global reverse-reference index is a future capability.");
+
+        // defined_in= keeps only records DEFINED in the scoped plugins (origin FormKey), the catalogue-scope semantics
+        // distinct from plugins='everything this plugin TOUCHES'. It needs a plugins= scope to mean anything — refused
+        // loud otherwise, never silently ignored (Q3).
+        if (definedIn && !hasPlugins)
+            return CrossQueryOutcome.Fail("defined_in=true keeps only records DEFINED in a scoped plugin, so it requires plugins= to name that scope. Add plugins=, or drop defined_in= (a bare scan already reports each match's defining plugin via its FormID suffix).");
+        HashSet<ModKey>? scopedModKeys = null;
+        if (definedIn)
+        {
+            scopedModKeys = new();
+            foreach (var p in plugins!)
+                try { scopedModKeys.Add(ModKey.FromFileName(p.Trim())); }
+                catch (Exception ex) { return CrossQueryOutcome.Fail($"defined_in: '{p}' is not a valid plugin filename: {ex.Message}"); }
+        }
+
+        // group_by= aggregates matches into a count table. Validated up front (an unknown key refuses BEFORE any scan,
+        // Q3). group_by=type needs the matched body to name the type, so it requires a body-bearing scope (type= or
+        // plugins=); winner/defined_in are derivable from the FormKey alone and work with conflicts_only= too.
+        if (groupBy is not null)
+        {
+            groupBy = groupBy.Trim().ToLowerInvariant();
+            if (groupBy is not ("winner" or "type" or "defined_in"))
+                return CrossQueryOutcome.Fail($"group_by='{groupBy}' is not a known aggregation key — use 'winner', 'type', or 'defined_in'.");
+            if (groupBy == "type" && !hasType && !hasPlugins)
+                return CrossQueryOutcome.Fail("group_by=type needs each match's type, which requires a body-bearing scope — add type= or plugins= (winner/defined_in group without a body).");
+        }
+        var refSet = hasReferences ? new HashSet<FormKey>(references!) : null;
+        bool multiTarget = references is { Count: >= 2 };
 
         // where= → the field-value predicate set. Parsed up front so a malformed predicate refuses the call BEFORE
         // any scan (Q3). The predicate reuses the read engine's path-walk, so its reach == the read surface's reach.
@@ -1544,7 +1579,9 @@ public sealed class LoadOrderService : IDisposable
 
         var keys = new List<FormKey>();
         var sources = new List<string?>();                                    // parallel to keys: the plugin whose body matched (null ⇒ winner), so the render displays the SAME body it filtered
+        List<string?>? matched = multiTarget ? new() : null;                  // parallel to keys: which target(s) each hit referenced (multi-target references= un-merge); null when 0/1 target
         List<RecordSummary>? prefilled = (hasType || hasPlugins) ? new() : null;   // parallel to keys; null = renderer fills lazily
+        Dictionary<string, int>? groups = groupBy is not null ? new(StringComparer.Ordinal) : null;   // group_by= aggregation (bumped per match, over ALL matches — not limit-capped)
         int total = 0;
         int unscannable = 0;                                                  // records whose body tests THREW (Mutagen-unparseable content) — excluded + accounted, never silent (Q3)
         var unscannableSamples = new List<string>();
@@ -1565,6 +1602,9 @@ public sealed class LoadOrderService : IDisposable
                 foreach (var (fk, depth, body, source) in stream)
                 {
                     if (conflictsOnly && depth <= 1) continue;
+                    // defined_in=: keep only records whose ORIGIN FormKey is a scoped plugin (a DEFINITION here, not
+                    // an override this plugin merely touches). A FormKey test — no body needed, so it runs before the try.
+                    if (definedIn && !scopedModKeys!.Contains(fk.ModKey)) continue;
                     // PER-RECORD FAULT ISOLATION (HCBR-2026-06-09-03): the body tests lazily parse subrecord
                     // content (references= walks Effects etc. via Mutagen's EnumerateFormLinks), so ONE record
                     // Mutagen can't parse used to abort the WHOLE call as an opaque transport error — the
@@ -1575,9 +1615,18 @@ public sealed class LoadOrderService : IDisposable
                         if (!string.IsNullOrEmpty(editoridContains)
                             && (body.EditorID is null || body.EditorID.IndexOf(editoridContains, StringComparison.OrdinalIgnoreCase) < 0))
                             continue;
-                        if (references is { } target
-                            && !(body is IFormLinkContainerGetter flc && flc.EnumerateFormLinks().Any(l => l.FormKey == target)))
-                            continue;
+                        // references= (LIST, OR semantics): a record matches if it links to ANY target. One
+                        // EnumerateFormLinks pass collects the intersection so a multi-target lookup can be un-merged
+                        // (matches=<which target(s)>) — the same single pass, membership-in-a-set instead of ==.
+                        List<FormKey>? hitTargets = null;
+                        if (refSet is not null)
+                        {
+                            if (body is not IFormLinkContainerGetter flc) continue;
+                            var hitSet = new HashSet<FormKey>();
+                            foreach (var l in flc.EnumerateFormLinks()) if (refSet.Contains(l.FormKey)) hitSet.Add(l.FormKey);
+                            if (hitSet.Count == 0) continue;
+                            if (multiTarget) hitTargets = references!.Where(hitSet.Contains).Distinct().ToList();   // in input order, deterministic
+                        }
                         if (predicate is not null && !predicate.Matches(body))    // value filter — same in-hand body, no extra fetch
                         {
                             if (predicate.FatalError is not null) break;          // numeric op vs non-numeric field — abort + surface (Q3)
@@ -1588,10 +1637,18 @@ public sealed class LoadOrderService : IDisposable
                         // array order) whose body PASSED the filters — deterministic, and it's the body we'll display.
                         if (!seen.Add(fk)) continue;
                         total++;
-                        if (keys.Count < limit)                                   // in-hand body → fill the summary for free
+                        if (groups is not null)                                   // group_by=: aggregate over ALL matches, no keys/prefill, no limit cap
+                        {
+                            var gk = groupBy == "type" ? RecordNaming.StripOverlay(body.GetType().Name)
+                                   : groupBy == "defined_in" ? fk.ModKey.FileName.ToString()
+                                   : view.ResolveWinner(fk)?.WinnerPlugin ?? "?";  // "winner"
+                            groups[gk] = groups.GetValueOrDefault(gk) + 1;
+                        }
+                        else if (keys.Count < limit)                              // in-hand body → fill the summary for free
                         {
                             keys.Add(fk);
                             sources.Add(source);                                  // the body we filtered IS the body we'll display (null ⇒ winner)
+                            matched?.Add(hitTargets is not null ? string.Join(", ", hitTargets) : null);   // parallel to keys (multi-target only)
                             // winner= off the SAME view the scan runs on — a rebuild landing mid-scan can no longer
                             // make a row's winner reflect a newer build than the depth beside it (HCBR-2026-06-11-02).
                             prefilled!.Add(new RecordSummary(fk, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID,
@@ -1616,10 +1673,16 @@ public sealed class LoadOrderService : IDisposable
         {
             // Summaries here would each need a winner-body fetch; leaving them to the renderer (which stops at
             // max_chars) means a big limit with a small max_chars doesn't fetch bodies it will never show.
+            // group_by= here can only be winner/defined_in (type was refused up front — no body to name the type).
             foreach (var fk in view.ConflictKeys())
             {
                 total++;
-                if (keys.Count < limit) { keys.Add(fk); sources.Add(null); }   // no scoped plugin → display the winner
+                if (groups is not null)
+                {
+                    var gk = groupBy == "defined_in" ? fk.ModKey.FileName.ToString() : view.ResolveWinner(fk)?.WinnerPlugin ?? "?";
+                    groups[gk] = groups.GetValueOrDefault(gk) + 1;
+                }
+                else if (keys.Count < limit) { keys.Add(fk); sources.Add(null); }   // no scoped plugin → display the winner
             }
         }
         // Unscannable accounting (Q3): name the count, the first few offenders with Mutagen's reason, and what
@@ -1631,7 +1694,12 @@ public sealed class LoadOrderService : IDisposable
               + string.Join("; ", unscannableSamples)
               + (unscannable > unscannableSamples.Count ? $"; and {unscannable - unscannableSamples.Count} more" : "")
               + ". Inspect one with read_record (per-field fault isolation applies).";
-        return new CrossQueryOutcome(keys, prefilled, total, total > keys.Count, null, predicate?.AccountingNote(), sources, scanNote);
+        // group_by= aggregation isn't limit-capped (cheap), so Capped is a match-line concern only.
+        var groupRows = groups?.Select(kv => new GroupCount(kv.Key, kv.Value))
+                              .OrderByDescending(g => g.Count).ThenBy(g => g.Key, StringComparer.Ordinal).ToList();
+        return new CrossQueryOutcome(keys, prefilled, total, groups is null && total > keys.Count, null,
+                                     predicate?.AccountingNote(), sources, scanNote,
+                                     matched, groupRows, groupBy, definedIn ? string.Join(", ", plugins!) : null);
     }
 
     // ---- effect-chain resolver (housecarl_effect_chain — gap 2026-06-08) --------------------------------
@@ -4236,10 +4304,16 @@ public sealed record ReadOutcome(
 /// <see cref="Total"/> is the true match count; <see cref="Capped"/> is true when Total exceeded what was returned.</summary>
 public sealed record CrossQueryOutcome(
     IReadOnlyList<FormKey> Keys, IReadOnlyList<RecordSummary>? Prefilled, int Total, bool Capped, string? Error,
-    string? PredicateNote = null, IReadOnlyList<string?>? Sources = null, string? ScanNote = null)
+    string? PredicateNote = null, IReadOnlyList<string?>? Sources = null, string? ScanNote = null,
+    IReadOnlyList<string?>? MatchedTargets = null, IReadOnlyList<GroupCount>? Groups = null,
+    string? GroupBy = null, string? ScopeLabel = null)
 {
     public static CrossQueryOutcome Fail(string error) => new(Array.Empty<FormKey>(), null, 0, false, error);
 }
+
+/// <summary>One row of a cross_plugin_query <c>group_by=</c> aggregation: a group key (winner plugin / record type /
+/// defining plugin) and how many matches fell in it. Emitted instead of per-match lines when group_by is set.</summary>
+public sealed record GroupCount(string Key, int Count);
 
 /// <summary>A compact, header-only record summary (no field dump) — the per-match line cross_plugin_query emits
 /// by default. <see cref="Error"/> non-null ⇒ the winner couldn't be summarised (named, recoverable — Q3).</summary>

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1625,7 +1625,7 @@ public sealed class LoadOrderService : IDisposable
                             var hitSet = new HashSet<FormKey>();
                             foreach (var l in flc.EnumerateFormLinks()) if (refSet.Contains(l.FormKey)) hitSet.Add(l.FormKey);
                             if (hitSet.Count == 0) continue;
-                            if (multiTarget) hitTargets = references!.Where(hitSet.Contains).Distinct().ToList();   // in input order, deterministic
+                            if (multiTarget && groups is null) hitTargets = references!.Where(hitSet.Contains).Distinct().ToList();   // in input order; only the match-line path consumes it (group_by ignores it)
                         }
                         if (predicate is not null && !predicate.Matches(body))    // value filter — same in-hand body, no extra fetch
                         {
@@ -1679,6 +1679,9 @@ public sealed class LoadOrderService : IDisposable
                 total++;
                 if (groups is not null)
                 {
+                    // group_by=winner here does an index-level ResolveWinner PER conflict key — a resolve, not a body
+                    // parse, and unavoidable for the aggregate (the non-group path defers winner= to the renderer, which
+                    // only fetches the capped rows). Intentional under accuracy-over-perf; don't "optimize" it away.
                     var gk = groupBy == "defined_in" ? fk.ModKey.FileName.ToString() : view.ResolveWinner(fk)?.WinnerPlugin ?? "?";
                     groups[gk] = groups.GetValueOrDefault(gk) + 1;
                 }

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -80,29 +80,36 @@ public static class ReadTools
          "Find records across the whole load order matching a filter — returns matches only, each as a compact " +
          "summary line (FormID, type, editorid, winner, override depth). Filters (combine freely): type= a record " +
          "signature ('WEAP') or catalog name ('Weapon'); conflicts_only=true for records >1 plugin touches; " +
-         "editorid_contains= a substring of the EditorID; references= a FormID the record points at (reverse lookup, " +
-         "e.g. 'what uses this keyword'); where= filters by a field's VALUE (e.g. 'MagicSkill = Destruction', " +
+         "editorid_contains= a substring of the EditorID; references= one or more FormIDs the record points at " +
+         "(reverse lookup, e.g. 'what uses this keyword' — OR over the list, and each match shows which target(s) it " +
+         "hit); where= filters by a field's VALUE (e.g. 'MagicSkill = Destruction', " +
          "'BasicStats.Damage >= 50' — any scalar field, ANDed); plugins= limits the scan to records those plugins " +
-         "touch (a bare plugins= is 'everything this plugin touches'). At least one filter or plugins= is required. " +
-         "editorid_contains/references/where " +
+         "touch (a bare plugins= is 'everything this plugin touches'); defined_in=true narrows a plugins= scope to " +
+         "records DEFINED in those plugins (not overrides they merely touch). At least one filter or plugins= is " +
+         "required. editorid_contains/references/where " +
          "are body scans and MUST be combined with type= or plugins= to bound the work (conflicts_only= alone is not " +
          "enough). Pass fields= " +
-         "or conflict_tree=true to expand each match from a summary line to full detail. Results cap at limit= matches " +
-         "and max_chars; both overruns are reported explicitly (never silent). Does NOT modify anything.")]
+         "or conflict_tree=true to expand each match from a summary line to full detail; or group_by= " +
+         "(winner|type|defined_in) for a count table over ALL matches instead of per-match lines. Results cap at " +
+         "limit= matches and max_chars; both overruns are reported explicitly (never silent). Does NOT modify anything.")]
     public static string CrossPluginQuery(
         LoadOrderService svc,
         [Description("Optional. A record signature ('WEAP', 'NPC_') or catalog name ('Weapon', 'Npc'). Cheap — uses typed group enumeration.")]
             string? type = null,
-        [Description("Optional. A FormID 'XXXXXX:Plugin.esp'; matches records whose winner references it (deep link scan). Must be combined with type= or plugins= (conflicts_only= alone is not enough).")]
-            string? references = null,
+        [Description("Optional. One or more FormIDs 'XXXXXX:Plugin.esp'; matches records that reference ANY of them (OR, deep link scan). Each match line shows matches=<which target(s)> when you pass 2+. Must be combined with type= or plugins= (conflicts_only= alone is not enough).")]
+            string[]? references = null,
         [Description("Optional. Case-insensitive substring of the EditorID. Body scan — must be combined with type= or plugins= (conflicts_only= alone is not enough).")]
             string? editorid_contains = null,
         [Description("When true, restrict to records more than one plugin touches (the contested set).")]
             bool conflicts_only = false,
         [Description("Optional. Plugin filenames to scope the scan to (records those plugins touch). A name not in the load order is an error. Omit to scan the whole order.")]
             string[]? plugins = null,
+        [Description("When true, narrow a plugins= scope to records DEFINED in those plugins (origin FormID), not overrides they merely touch — the catalogue-scope semantics. Requires plugins= (refused loud otherwise).")]
+            bool defined_in = false,
         [Description("Optional. Field-VALUE predicates, each \"<path> <op> <value>\" — e.g. 'MagicSkill = Destruction', 'BasicStats.Damage >= 50', 'Archetype.ActorValue = Infamy'. Operators: = != > >= < <= (>/< numeric) and contains (case-insensitive substring); multiple are ANDed. Filters on ANY scalar field the read tools can read (any type, any depth). A body scan — MUST be combined with type= or plugins=. A wrong or container/list path is reported, never a silent '0 matches'.")]
             string[]? where = null,
+        [Description("Optional. Aggregate matches into a count table (sorted desc) instead of listing them: 'winner' (by load-order-winning plugin), 'type' (by record type — needs type= or plugins=), or 'defined_in' (by defining plugin). Counts ALL matches (not capped by limit=). Cannot combine with fields= or conflict_tree=.")]
+            string? group_by = null,
         [Description("Optional. Dotted field paths to show for each match (e.g. 'BasicStats.Damage'). Omit for a one-line summary per match.")]
             string[]? fields = null,
         [Description("When true, include each match's touching-plugin list (winner last) + winner-relative field diff.")]
@@ -113,13 +120,21 @@ public static class ReadTools
             int max_chars = 0) => Guard.Tool("housecarl_cross_plugin_query", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-        FormKey? refFk = null;
-        if (!string.IsNullOrWhiteSpace(references))
+        if (group_by is not null && ((fields is { Length: > 0 }) || conflict_tree))
+            return "error: group_by aggregates matches into a count table and cannot be combined with fields= or conflict_tree=true (those expand each match to full detail — pick one). Drop fields=/conflict_tree, or drop group_by.";
+        IReadOnlyList<FormKey>? refFks = null;
+        if (references is { Length: > 0 })
         {
-            try { refFk = FormKey.Factory(references.Trim()); }
-            catch (Exception ex) { return $"error: bad references FormID '{references}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."; }
+            var list = new List<FormKey>();
+            foreach (var r in references)
+            {
+                if (string.IsNullOrWhiteSpace(r)) continue;
+                try { list.Add(FormKey.Factory(r.Trim())); }
+                catch (Exception ex) { return $"error: bad references FormID '{r}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."; }
+            }
+            if (list.Count > 0) refFks = list.Distinct().ToList();   // preserve input order, drop dupes
         }
-        var outcome = svc.CrossQuery(type, refFk, editorid_contains, conflicts_only, plugins, where, limit <= 0 ? 500 : limit);
+        var outcome = svc.CrossQuery(type, refFks, editorid_contains, conflicts_only, plugins, where, limit <= 0 ? 500 : limit, defined_in, group_by);
         return Wire.RenderCrossQuery(svc, outcome, fields, conflict_tree, max_chars);
     });
 
@@ -311,9 +326,11 @@ static class Wire
     {
         if (q.Error is not null) return "error: " + q.Error;
         int cap = Cap(maxChars);
+        if (q.Groups is not null) return RenderCrossQueryGroups(q, cap);   // group_by= → a count table, not per-match lines
         bool detail = (fields is { Count: > 0 }) || conflictTree;          // expand matches, vs. one-line summaries
         var sb = new StringBuilder();
         sb.Append("cross_plugin_query: ").Append(q.Total).Append(q.Total == 1 ? " match" : " matches");
+        if (q.ScopeLabel is not null) sb.Append(" DEFINED IN ").Append(q.ScopeLabel);   // P1: explicit scope — NOT the 'touches' default
         if (q.Capped) sb.Append(" (showing first ").Append(q.Keys.Count).Append("; raise limit= or narrow to see more)");
         sb.Append('\n');
         if (q.PredicateNote is not null) sb.Append(q.PredicateNote).Append('\n');   // where= Q3 accounting (wrong-path/no-value surface)
@@ -330,10 +347,12 @@ static class Wire
                 break;
             }
             var fk = q.Keys[i];
+            string? matches = q.MatchedTargets is { } mt && i < mt.Count ? mt[i] : null;   // multi-target references= un-merge
             if (detail)
             {
                 var o = svc.ResolveRead(fk, q.Sources is { } src ? src[i] : null, fields, conflictTree);   // display the body the scan filtered: scoped plugin under plugins=, else winner
                 sb.Append('\n');
+                if (matches is not null) sb.Append("  ").Append(fk).Append("  matches=").Append(matches).Append('\n');
                 if (o.Error is not null) sb.Append(fk).Append(": error: ").Append(o.Error).Append('\n');
                 else { AppendRecord(sb, o, cap); if (conflictTree) AppendConflictTree(sb, svc, o, fields, cap); }
             }
@@ -342,10 +361,43 @@ static class Wire
                 var m = q.Prefilled is not null ? q.Prefilled[i] : svc.ResolveSummary(fk);   // lazy fill for conflicts-only
                 sb.Append("  ").Append(m.FormKey);
                 if (m.Error is not null) sb.Append("  error=").Append(m.Error).Append('\n');
-                else sb.Append("  type=").Append(m.Type).Append("  editorid=").Append(m.EditorId ?? "<none>")
-                       .Append("  winner=").Append(m.Winner).Append("  override_depth=").Append(m.OverrideDepth).Append('\n');
+                else
+                {
+                    sb.Append("  type=").Append(m.Type).Append("  editorid=").Append(m.EditorId ?? "<none>")
+                      .Append("  winner=").Append(m.Winner).Append("  override_depth=").Append(m.OverrideDepth);
+                    if (matches is not null) sb.Append("  matches=").Append(matches);
+                    sb.Append('\n');
+                }
             }
             rendered++;
+        }
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    /// <summary>Render a cross_plugin_query <c>group_by=</c> aggregation: a header naming the key + true total + group
+    /// count, then one "  &lt;key&gt; = &lt;count&gt;" row per group (already sorted desc by the core). Q3 accounting
+    /// (where= / unscannable notes) survives the aggregation. Over max_chars it stops with the explicit truncation
+    /// notice — the count is exact even when the row LIST is clipped (aggregation isn't limit-capped; only rendering is).</summary>
+    static string RenderCrossQueryGroups(CrossQueryOutcome q, int cap)
+    {
+        var groups = q.Groups!;
+        var sb = new StringBuilder();
+        sb.Append("cross_plugin_query: grouped by ").Append(q.GroupBy).Append(" — ")
+          .Append(q.Total).Append(q.Total == 1 ? " match" : " matches")
+          .Append(" across ").Append(groups.Count).Append(groups.Count == 1 ? " group" : " groups");
+        if (q.ScopeLabel is not null) sb.Append(" (DEFINED IN ").Append(q.ScopeLabel).Append(')');
+        sb.Append('\n');
+        if (q.PredicateNote is not null) sb.Append(q.PredicateNote).Append('\n');
+        if (q.ScanNote is not null) sb.Append(q.ScanNote).Append('\n');
+        for (int i = 0; i < groups.Count; i++)
+        {
+            if (sb.Length >= cap)
+            {
+                sb.Append("... [truncated: rendered ").Append(i).Append(" of ").Append(groups.Count)
+                  .Append(" groups before hitting max_chars=").Append(cap).Append("; raise max_chars — the total above is exact]\n");
+                break;
+            }
+            sb.Append("  ").Append(groups[i].Key).Append(" = ").Append(groups[i].Count).Append('\n');
         }
         return sb.ToString().TrimEnd('\n');
     }


### PR DESCRIPTION
Wave 1 of the **bulk-primitives** sub-project — three type-agnostic additions to `housecarl_cross_plugin_query` (PLAN P1/P2/P4). All inside `CrossQuery` + `RenderCrossQuery`, all **additive** (no existing call changes behavior).

## Primitives

- **P1 `defined_in=true`** — narrows a `plugins=` scope from "records this plugin *touches*" (definitions + overrides) to "records *defined* in it" (origin FormKey) — the catalogue scope. A FormKey-origin test; refused loud without `plugins=` (Q3). Header states the scope explicitly (`DEFINED IN <plugins>`), never the silent touches default.
- **P2 list-valued `references=`** — OR over N targets in **one** scan (was one full scan per target). Same single `EnumerateFormLinks` pass, set membership instead of `==`. A multi-target lookup records `matches=<which target(s)>` (input order) so it can be un-merged. Param widened `string` → `string[]` per decision **D4**; single-value callers unchanged.
- **P4 `group_by=winner|type|defined_in`** — a count table over **all** matches (not `limit`-capped) instead of per-match lines. `winner`/`defined_in` derive from the FormKey (work with `conflicts_only=` too); `type` needs a body-bearing scope. Refused loud alongside `fields=`/`conflict_tree=` (tool layer) and on an unknown key.

DTO `CrossQueryOutcome` gained `MatchedTargets` / `Groups`+`GroupBy` / `ScopeLabel`; new `GroupCount` record. The 4 in-tree `CrossQuery` callers were updated (2 `PerkRefsProbe` call-sites; the null-passing callers needed no change).

## Testing

- New probe **`bulk-query-primitives-guard`** (registered in `ci-all`): a synthetic master+replacer order drives the real service scan + the tool-layer guard — defined-in vs touches, multi-target `references=` grouping, `group_by` counts cross-checked against a hand tally, and both loud refusals. **26/26 assertions pass.**
- Full **`ci-all`: 89/89 pass** — no regression in the other `CrossQuery` consumers (`perk-refs`, `source-display`, `snapshot-view`).

## Two flags for review

1. **`matches=` is emitted only for multi-target (2+) `references=`** — single-target adds no noise (a single target is trivially every hit). PLAN P2 reads "each match line gains matches="; the 2+ gate is the honest un-merge reading, documented in the tool description. Trivial to flip to always-annotate if preferred.
2. **Stale-server caveat (for the merge, not this PR):** once merged, the *running* MCP server serves the old `cross_plugin_query` until rebuilt + re-pointed. Empirical exercise of the new flags on a live order is Aaron's lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)