### PR TITLE
bulk-primitives Wave 2 — the output contract (resolve / resolve_names / format=json / winner_fields)

### DIFF
--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -17,8 +17,15 @@ namespace HousecarlCore;
 /// drives the internal <c>LeafRead</c>, and <c>FieldsDiff</c> compares Token/Note), so it is invisible to write,
 /// read-proof, and diff. Used to decode a value that is correct but opaque — a biped-slot bitmask into its slot
 /// numbers (HCBR-2026-07-12) — without disturbing the token that must round-trip. Null on every leaf that needs
-/// no annotation.</para></summary>
-public sealed record FieldValue(string Path, bool HasValue, string? Token, string? Note, string? Display = null);
+/// no annotation.</para>
+///
+/// <para><see cref="Link"/> is the resolve_names annotation (Wave 2 / P7): when a leaf's <see cref="Token"/> is a
+/// form reference (a token that round-trips to a FormKey), the SERVICE layer resolves its target's identity
+/// (editorid/name) against the load order and hangs it here. Like <see cref="Display"/> it is DISPLAY-ONLY — never
+/// part of the round-trip <see cref="Token"/>, so it is invisible to write, read-proof, and diff. Populated by the
+/// service (which holds the resolver), never by the core read (which reads one record's bytes and cannot resolve a
+/// target). Null unless resolve_names was requested and the leaf carries a resolvable FormKey.</para></summary>
+public sealed record FieldValue(string Path, bool HasValue, string? Token, string? Note, string? Display = null, ResolvedRef? Link = null);
 
 /// <summary>The resolved identity of a form reference — the shared contract behind housecarl_resolve (P3, a full
 /// row) and the resolve_names field annotation (P7). <see cref="Resolved"/> false ⇒ the FormKey is valid but not

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -20,6 +20,15 @@ namespace HousecarlCore;
 /// no annotation.</para></summary>
 public sealed record FieldValue(string Path, bool HasValue, string? Token, string? Note, string? Display = null);
 
+/// <summary>The resolved identity of a form reference — the shared contract behind housecarl_resolve (P3, a full
+/// row) and the resolve_names field annotation (P7). <see cref="Resolved"/> false ⇒ the FormKey is valid but not
+/// present in the active order (a dangling target — named, never dropped or guessed, Q3). <see cref="Error"/> is set
+/// only on the housecarl_resolve path when the INPUT string is not a legal FormID at all. When used for the P7
+/// annotation it is DISPLAY-ONLY: it never replaces the leaf's round-trip <see cref="FieldValue.Token"/>.</summary>
+public sealed record ResolvedRef(
+    string Token, bool Resolved, string? Type = null, string? EditorId = null,
+    string? Name = null, string? Winner = null, string? Error = null);
+
 /// <summary>A located record read out as structured fields — the public (params)->(result) result the MCP
 /// server's read tools return (the §8.4 read cleave). Identity (<see cref="Type"/> / <see cref="FormKey"/> /
 /// <see cref="EditorId"/>) plus the requested (or all modeled) field reads.</summary>

--- a/src/housecarl-generator/BulkPrimitivesWave2Probe.cs
+++ b/src/housecarl-generator/BulkPrimitivesWave2Probe.cs
@@ -1,0 +1,152 @@
+using System.Text.Json;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// REGRESSION GUARD (standing CI instrument, self-contained) for bulk-primitives WAVE 2 — the OUTPUT CONTRACT
+/// (PLAN.md P3/P5/P6/P7):
+///   • P3 <c>housecarl_resolve</c> — bulk FormID → identity (type/editorid/name/winner), per-item error isolation.
+///   • P5 <c>winner_fields=</c> on cross_plugin_query — render the load-order WINNER's body under a plugins= scope,
+///     plus the loud scoped-values note when plugins=-scoped fields render WITHOUT it.
+///   • P6 <c>format="json"</c> across the read surfaces — the SAME data as text (round-trip token parity), Q3
+///     accounting carried in-band, always-valid JSON.
+///   • P7 <c>resolve_names=</c> — every FormLink token in a field dump annotated with its target's identity,
+///     display-only (never replaces the round-trip token).
+///
+/// Synthesizes a small on-disk order (a master + a replacer that overrides one NAMED weapon and defines others, with
+/// keyword links) and drives the REAL service layer (<see cref="LoadOrderService"/> via the ForGuard seam) + the
+/// tool layer (<see cref="ReadTools"/>). Self-contained: a corpus is generated in-process if none is configured.
+///
+/// Run: <c>dotnet run --project src/housecarl-generator bulk-primitives-wave2-guard</c>
+/// </summary>
+public static class BulkPrimitivesWave2Probe
+{
+    static int _pass, _fail;
+
+    public static int RunGuard(string[] args)
+    {
+        _pass = _fail = 0;
+        Console.WriteLine("################  REGRESSION GUARD — bulk-primitives Wave 2 (output contract: resolve / winner_fields / format=json / resolve_names)  ################");
+        Console.WriteLine();
+
+        var dir = Path.Combine(Path.GetTempPath(), "hc_bulk_primitives_wave2_guard_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+
+        try { _ = CorpusRulebook.LoadCorpus(); }
+        catch
+        {
+            var gen = Path.Combine(dir, "generated");
+            CorpusGenerator.GenerateAll(gen, Path.Combine(dir, "refs"));
+            CorpusRulebook.CorpusPath = Path.Combine(gen, "corpus.json");
+            Console.WriteLine($"-- generated a corpus for type= resolution: {CorpusRulebook.CorpusPath} --");
+        }
+
+        const string masterName = "hcw2Master.esp", replName = "hcw2Repl.esp";
+        var masterPath = Path.Combine(dir, masterName);
+        var replPath = Path.Combine(dir, replName);
+
+        try
+        {
+            // ---- MASTER: keyword KA (no Name), two NAMED weapons. W1 carries KA and will be OVERRIDDEN by the replacer. ----
+            var master = new SkyrimMod(ModKey.FromNameAndExtension(masterName), SkyrimRelease.SkyrimSE);
+            var ka = master.Keywords.AddNew(); ka.EditorID = "hcw2KwA"; var kaFk = ka.FormKey;
+            var w1 = master.Weapons.AddNew(); w1.EditorID = "hcw2Sword1"; w1.Name = "Iron Sword"; w1.BasicStats = new WeaponBasicStats { Damage = 10 };
+            w1.Keywords = new Noggog.ExtendedList<IFormLinkGetter<IKeywordGetter>> { new FormLink<IKeywordGetter>(kaFk) };
+            var w1Fk = w1.FormKey;
+            var w2 = master.Weapons.AddNew(); w2.EditorID = "hcw2Sword2"; w2.Name = "Steel Sword"; w2.BasicStats = new WeaponBasicStats { Damage = 20 };
+            var w2Fk = w2.FormKey;
+            master.BeginWrite.ToPath(masterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+            // ---- REPLACER (masters [master]): OVERRIDE W1 (so its WINNER is the replacer), DEFINE a new NAMED weapon W3[KA]. ----
+            var repl = new SkyrimMod(ModKey.FromNameAndExtension(replName), SkyrimRelease.SkyrimSE);
+            ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(repl, w1)).BasicStats = new WeaponBasicStats { Damage = 15 };
+            var w3 = repl.Weapons.AddNew(); w3.EditorID = "hcw2Sword3"; w3.Name = "Ebony Sword"; w3.BasicStats = new WeaponBasicStats { Damage = 30 };
+            w3.Keywords = new Noggog.ExtendedList<IFormLinkGetter<IKeywordGetter>> { new FormLink<IKeywordGetter>(kaFk) };
+            var w3Fk = w3.FormKey;
+            repl.BeginWrite.ToPath(replPath).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
+
+            Console.WriteLine($"-- synthesized {masterName} (KA; W1[KA]'Iron Sword',W2'Steel Sword') < {replName} (override W1; W3[KA]'Ebony Sword') --");
+            Console.WriteLine();
+
+            using var resolver = LoadOrderResolver.Build(new[] { masterPath, replPath });
+            var svc = LoadOrderService.ForGuard(resolver, new UserConfigStore(Path.Combine(dir, "houseCARL.user.json")));
+
+            // ================= P3 — housecarl_resolve (bulk FormID → identity) =================
+            Console.WriteLine("── P3: housecarl_resolve — type/editorid/name/winner, per-item error isolation ──");
+            const string absentFid = "000800:Nonexist.esp";   // a valid FormID string whose plugin isn't in the order
+            const string badFid = "not-a-formid";
+            var refs = svc.ResolveRefs(new[] { w1Fk.ToString(), kaFk.ToString(), w3Fk.ToString(), absentFid, badFid });
+            Check($"resolve returns one row per input, in order — got {refs.Count}", refs.Count == 5);
+
+            var r0 = refs[0];
+            Check($"W1 → Weapon/hcw2Sword1/name 'Iron Sword'/winner {replName} (winner is the OVERRIDE, not the master)",
+                  r0.Resolved && r0.Type == "Weapon" && r0.EditorId == "hcw2Sword1" && r0.Name == "Iron Sword" && r0.Winner == replName);
+            var r1 = refs[1];
+            Check("keyword KA → Keyword/hcw2KwA with name=null (KYWD has no Name — reflection-generic, not guessed)",
+                  r1.Resolved && r1.Type == "Keyword" && r1.EditorId == "hcw2KwA" && r1.Name is null);
+            var r2 = refs[2];
+            Check("W3 → Weapon/hcw2Sword3/name 'Ebony Sword'", r2.Resolved && r2.Type == "Weapon" && r2.EditorId == "hcw2Sword3" && r2.Name == "Ebony Sword");
+            var r3 = refs[3];
+            Check("a valid-but-absent FormID → Resolved=false with NO malformed-input error (named, not dropped — Q3)",
+                  !r3.Resolved && r3.Error is null && r3.Token == absentFid);
+            var r4 = refs[4];
+            Check("a malformed FormID → per-item error, the batch still returns the other 4 rows (Q3)",
+                  !r4.Resolved && r4.Error is not null && r4.Error.Contains("bad FormID", StringComparison.OrdinalIgnoreCase));
+
+            // A recurring target resolves consistently (the batch memo returns the same identity).
+            var dup = svc.ResolveRefs(new[] { kaFk.ToString(), kaFk.ToString() });
+            Check("a target repeated in one batch resolves identically (memoised)",
+                  dup.Count == 2 && dup[0].EditorId == dup[1].EditorId && dup[0].EditorId == "hcw2KwA");
+
+            // ---- tool layer: text render ----
+            Console.WriteLine();
+            Console.WriteLine("── P3 tool layer: text + json render, bad-format refusal ──");
+            var txt = ReadTools.Resolve(svc, new[] { w1Fk.ToString(), kaFk.ToString(), badFid }, format: null, max_chars: 0);
+            Check("text render carries the identity line (type=Weapon, name=\"Iron Sword\")",
+                  txt.Contains("type=Weapon") && txt.Contains("name=\"Iron Sword\"") && txt.Contains("editorid=hcw2KwA"));
+            Check("text render carries the per-item error for the bad input", txt.Contains("error="));
+
+            // ---- tool layer: json render (must be VALID json, carrying the same data) ----
+            var js = ReadTools.Resolve(svc, new[] { w1Fk.ToString(), badFid }, format: "json", max_chars: 0);
+            bool jsonValid = true; JsonDocument? doc = null;
+            try { doc = JsonDocument.Parse(js); } catch { jsonValid = false; }
+            Check("json render is VALID json", jsonValid && doc is not null);
+            if (doc is not null)
+            {
+                var root = doc.RootElement;
+                var arr = root.GetProperty("resolved");
+                Check("json: 'resolved' array has one row per input", arr.GetArrayLength() == 2);
+                var j0 = arr[0];
+                Check("json row 0 carries {type,editorid,name,winner} matching text",
+                      j0.GetProperty("type").GetString() == "Weapon" && j0.GetProperty("editorid").GetString() == "hcw2Sword1"
+                      && j0.GetProperty("name").GetString() == "Iron Sword" && j0.GetProperty("winner").GetString() == replName);
+                var j1 = arr[1];
+                Check("json row 1 (bad input) carries an 'error' field, not identity",
+                      j1.TryGetProperty("error", out _) && !j1.TryGetProperty("winner", out _));
+                doc.Dispose();
+            }
+
+            var badFmt = ReadTools.Resolve(svc, new[] { w1Fk.ToString() }, format: "bogus", max_chars: 0);
+            Check("an unrecognized format= is REFUSED loud (never a silent fall-through to text — Q3)",
+                  badFmt.StartsWith("error:", StringComparison.OrdinalIgnoreCase) && badFmt.Contains("format", StringComparison.OrdinalIgnoreCase));
+
+            Console.WriteLine();
+            Console.WriteLine($"=== bulk-primitives-wave2-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
+            return _fail == 0 ? 0 : 1;
+        }
+        catch (Exception ex) { Console.WriteLine($"   FAIL (unexpected): {ex.GetType().Name}: {ex.Message}\n{ex.StackTrace}"); return 1; }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
+
+    static void Check(string label, bool ok)
+    {
+        Console.WriteLine($"   [{(ok ? "PASS" : "FAIL")}] {label}");
+        if (ok) _pass++; else _fail++;
+    }
+}

--- a/src/housecarl-generator/BulkPrimitivesWave2Probe.cs
+++ b/src/housecarl-generator/BulkPrimitivesWave2Probe.cs
@@ -212,6 +212,15 @@ public static class BulkPrimitivesWave2Probe
                 linkDoc.Dispose();
             }
 
+            // field-level json truncation stays VALID json (Q3): a whole-record dump under a tiny cap emits a
+            // sentinel field, never a malformed (string-cut) document.
+            var clipJson = ReadTools.ReadRecord(svc, w1Fk.ToString(), plugin: null, fields: null, depth: 1,
+                conflict_tree: false, resolve_names: false, format: "json", max_chars: 200);
+            var clipDoc = ParseOrNull(clipJson);
+            Check("read_record json under a tiny max_chars is STILL valid json, field-truncated with a sentinel (not string-cut — Q3)",
+                  clipDoc is not null && FindField(clipDoc.RootElement, "…") is not null);
+            clipDoc?.Dispose();
+
             // conflict_tree + json is REFUSED loud (a text-only diff view — never silently dropped, Q3).
             var ctJson = ReadTools.ReadRecord(svc, w1Fk.ToString(), plugin: null, fields: null, depth: 1,
                 conflict_tree: true, resolve_names: false, format: "json", max_chars: 0);

--- a/src/housecarl-generator/BulkPrimitivesWave2Probe.cs
+++ b/src/housecarl-generator/BulkPrimitivesWave2Probe.cs
@@ -56,8 +56,10 @@ public static class BulkPrimitivesWave2Probe
             // ---- MASTER: keyword KA (no Name), two NAMED weapons. W1 carries KA and will be OVERRIDDEN by the replacer. ----
             var master = new SkyrimMod(ModKey.FromNameAndExtension(masterName), SkyrimRelease.SkyrimSE);
             var ka = master.Keywords.AddNew(); ka.EditorID = "hcw2KwA"; var kaFk = ka.FormKey;
+            var ghostFk = new FormKey(master.ModKey, 0x000FFF);   // a keyword link to a FormID NOTHING defines (a dangling ref, in the master's own space so no missing-master)
             var w1 = master.Weapons.AddNew(); w1.EditorID = "hcw2Sword1"; w1.Name = "Iron Sword"; w1.BasicStats = new WeaponBasicStats { Damage = 10 };
-            w1.Keywords = new Noggog.ExtendedList<IFormLinkGetter<IKeywordGetter>> { new FormLink<IKeywordGetter>(kaFk) };
+            w1.Keywords = new Noggog.ExtendedList<IFormLinkGetter<IKeywordGetter>>
+                { new FormLink<IKeywordGetter>(kaFk), new FormLink<IKeywordGetter>(ghostFk) };
             var w1Fk = w1.FormKey;
             var w2 = master.Weapons.AddNew(); w2.EditorID = "hcw2Sword2"; w2.Name = "Steel Sword"; w2.BasicStats = new WeaponBasicStats { Damage = 20 };
             var w2Fk = w2.FormKey;
@@ -135,6 +137,35 @@ public static class BulkPrimitivesWave2Probe
             var badFmt = ReadTools.Resolve(svc, new[] { w1Fk.ToString() }, format: "bogus", max_chars: 0);
             Check("an unrecognized format= is REFUSED loud (never a silent fall-through to text — Q3)",
                   badFmt.StartsWith("error:", StringComparison.OrdinalIgnoreCase) && badFmt.Contains("format", StringComparison.OrdinalIgnoreCase));
+
+            // ================= P7 — resolve_names (FormLink token → target identity, DISPLAY-ONLY) =================
+            Console.WriteLine();
+            Console.WriteLine("── P7: resolve_names annotates FormLink tokens with target identity, NEVER replacing the token ──");
+            var named = svc.ResolveRead(w1Fk, null, new[] { "Keywords" }, false, depth: 2, resolveNames: true);
+            var kwFields = named.Record!.Fields.Where(f => f.Path.StartsWith("Keywords[", StringComparison.Ordinal)).ToList();
+            Check($"resolve_names read surfaced the 2 keyword elements — got {kwFields.Count}", kwFields.Count == 2);
+            var kaField = kwFields.FirstOrDefault(f => f.Token == kaFk.ToString());
+            Check("the KA element's ROUND-TRIP TOKEN is unchanged (still the raw FormKey a write can reuse)",
+                  kaField is { HasValue: true } && kaField.Token == kaFk.ToString());
+            Check("... and its Link annotation resolves to the keyword identity (editorid hcw2KwA) — ADDED, not substituted",
+                  kaField?.Link is { Resolved: true, EditorId: "hcw2KwA" });
+            var ghostField = kwFields.FirstOrDefault(f => f.Token == ghostFk.ToString());
+            Check("a link whose target no active plugin defines is annotated UNRESOLVED (named, not dropped/guessed — Q3), token still intact",
+                  ghostField is { HasValue: true } && ghostField.Token == ghostFk.ToString() && ghostField.Link is { Resolved: false });
+
+            var plainRead = svc.ResolveRead(w1Fk, null, new[] { "Keywords" }, false, depth: 2, resolveNames: false);
+            Check("without resolve_names, NO leaf carries a Link annotation (default behavior unchanged)",
+                  plainRead.Record!.Fields.All(f => f.Link is null));
+
+            var tRec = ReadTools.ReadRecord(svc, w1Fk.ToString(), plugin: null, fields: new[] { "Keywords" }, depth: 2,
+                conflict_tree: false, resolve_names: true, max_chars: 0);
+            Check("text render carries BOTH the raw token AND the → identity parenthetical",
+                  tRec.Contains(kaFk.ToString()) && tRec.Contains("→ hcw2KwA"));
+            Check("text render marks the dangling target 'unresolved'", tRec.Contains("unresolved"));
+
+            var tBatch = ReadTools.BatchRecordDetail(svc, new[] { w1Fk.ToString() }, fields: new[] { "Keywords" }, depth: 2,
+                conflict_tree: false, resolve_names: true, max_chars: 0);
+            Check("batch_record_detail resolve_names annotates too (shared batch memo)", tBatch.Contains("→ hcw2KwA"));
 
             Console.WriteLine();
             Console.WriteLine($"=== bulk-primitives-wave2-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");

--- a/src/housecarl-generator/BulkPrimitivesWave2Probe.cs
+++ b/src/housecarl-generator/BulkPrimitivesWave2Probe.cs
@@ -138,6 +138,14 @@ public static class BulkPrimitivesWave2Probe
             Check("an unrecognized format= is REFUSED loud (never a silent fall-through to text — Q3)",
                   badFmt.StartsWith("error:", StringComparison.OrdinalIgnoreCase) && badFmt.Contains("format", StringComparison.OrdinalIgnoreCase));
 
+            // resolve json honors max_chars too (review cleanup #2): row-drop truncation, valid json, exact count.
+            var resClip = ReadTools.Resolve(svc, new[] { w1Fk.ToString(), kaFk.ToString(), w3Fk.ToString() }, format: "json", max_chars: 60);
+            var resClipDoc = ParseOrNull(resClip);
+            Check("housecarl_resolve json honors max_chars: valid json, truncated=true, rendered<count (row-drop — Q3)",
+                  resClipDoc is not null && resClipDoc.RootElement.GetProperty("truncated").GetBoolean()
+                  && resClipDoc.RootElement.GetProperty("rendered").GetInt32() < resClipDoc.RootElement.GetProperty("count").GetInt32());
+            resClipDoc?.Dispose();
+
             // ================= P7 — resolve_names (FormLink token → target identity, DISPLAY-ONLY) =================
             Console.WriteLine();
             Console.WriteLine("── P7: resolve_names annotates FormLink tokens with target identity, NEVER replacing the token ──");

--- a/src/housecarl-generator/BulkPrimitivesWave2Probe.cs
+++ b/src/housecarl-generator/BulkPrimitivesWave2Probe.cs
@@ -279,6 +279,66 @@ public static class BulkPrimitivesWave2Probe
             Check("cross_plugin_query unrecognized format= is REFUSED loud (shared parser, Q3)",
                   cqBadFmt.StartsWith("error:", StringComparison.OrdinalIgnoreCase) && cqBadFmt.Contains("format", StringComparison.OrdinalIgnoreCase));
 
+            // ================= P5 — winner_fields= (scoped body vs live winner) + the loud scoped-values note =================
+            Console.WriteLine();
+            Console.WriteLine("── P5: plugins=-scoped fields are the plugin's OWN body; winner_fields= reads the winner; the trap is named loud ──");
+            // W1 is defined in master (damage 10) and OVERRIDDEN in Repl (damage 15 = the live winner). Scope to [master].
+            var scopedText = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: new[] { masterName }, defined_in: false, where: null, group_by: null,
+                resolve_names: false, winner_fields: false, fields: new[] { "BasicStats.Damage" }, conflict_tree: false,
+                format: "text", limit: 500, max_chars: 0);
+            Check("plugins=[master] fields= shows the MASTER's OWN W1 value (damage 10), NOT the live winner",
+                  scopedText.Contains("BasicStats.Damage = 10") && !scopedText.Contains("BasicStats.Damage = 15"));
+            Check("... and the silent-wrong trap is named LOUD (scoped-values note pointing at winner_fields=true)",
+                  scopedText.Contains("SCOPED plugin's OWN version") && scopedText.Contains("winner_fields=true"));
+
+            var winnerText = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: new[] { masterName }, defined_in: false, where: null, group_by: null,
+                resolve_names: false, winner_fields: true, fields: new[] { "BasicStats.Damage" }, conflict_tree: false,
+                format: "text", limit: 500, max_chars: 0);
+            Check("winner_fields=true shows the LIVE WINNER's W1 value (damage 15) instead of the master's 10",
+                  winnerText.Contains("BasicStats.Damage = 15") && !winnerText.Contains("BasicStats.Damage = 10"));
+            Check("... and the header truthfully says the values are the WINNER's",
+                  winnerText.Contains("field values are the load-order WINNER's"));
+
+            // type= scope (no plugins=) already shows the winner — no scoped-values note (winner_fields is a no-op there).
+            var typeScoped = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: null,
+                resolve_names: false, winner_fields: false, fields: new[] { "BasicStats.Damage" }, conflict_tree: false,
+                format: "text", limit: 500, max_chars: 0);
+            Check("type= scope (no plugins=) already shows winners — no scoped-values note, and W1=15 (the winner)",
+                  !typeScoped.Contains("SCOPED plugin's OWN version") && typeScoped.Contains("BasicStats.Damage = 15"));
+
+            // json parity: the scoped note rides notes[], and each match's source/winner fields carry the truth.
+            var scopedJson = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: new[] { masterName }, defined_in: false, where: null, group_by: null,
+                resolve_names: false, winner_fields: false, fields: new[] { "BasicStats.Damage" }, conflict_tree: false,
+                format: "json", limit: 500, max_chars: 0);
+            var sjDoc = ParseOrNull(scopedJson);
+            Check("json (scoped, no winner_fields) carries the scoped-values note in notes[]",
+                  sjDoc is not null && HasNoteContaining(sjDoc.RootElement, "SCOPED plugin's OWN version"));
+            if (sjDoc is not null)
+            {
+                var w1Row = FindMatch(sjDoc.RootElement, w1Fk.ToString());
+                Check("json scoped W1 row: source=master and value=10 (the scoped body — machine-readable truth)",
+                      w1Row is not null && w1Row.Value.GetProperty("source").GetString() == masterName
+                      && FindField(w1Row.Value, "BasicStats.Damage")?.GetProperty("value").GetString() == "10");
+                sjDoc.Dispose();
+            }
+            var winnerJson = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: new[] { masterName }, defined_in: false, where: null, group_by: null,
+                resolve_names: false, winner_fields: true, fields: new[] { "BasicStats.Damage" }, conflict_tree: false,
+                format: "json", limit: 500, max_chars: 0);
+            var wjDoc = ParseOrNull(winnerJson);
+            if (wjDoc is not null)
+            {
+                var w1Row = FindMatch(wjDoc.RootElement, w1Fk.ToString());
+                Check("json winner_fields W1 row: source=Repl (the winner) and value=15",
+                      w1Row is not null && w1Row.Value.GetProperty("source").GetString() == replName
+                      && FindField(w1Row.Value, "BasicStats.Damage")?.GetProperty("value").GetString() == "15");
+                wjDoc.Dispose();
+            }
+
             Console.WriteLine();
             Console.WriteLine($"=== bulk-primitives-wave2-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
             return _fail == 0 ? 0 : 1;
@@ -307,5 +367,23 @@ public static class BulkPrimitivesWave2Probe
         foreach (var f in fields.EnumerateArray())
             if (f.TryGetProperty("path", out var p) && p.GetString() == path) return f;
         return null;
+    }
+
+    /// <summary>Find a cross_plugin_query match object by its "formid" in the "matches" array (null if absent).</summary>
+    static JsonElement? FindMatch(JsonElement root, string formid)
+    {
+        if (!root.TryGetProperty("matches", out var matches)) return null;
+        foreach (var m in matches.EnumerateArray())
+            if (m.TryGetProperty("formid", out var f) && f.GetString() == formid) return m;
+        return null;
+    }
+
+    /// <summary>True if the document's "notes" array carries a note containing the given substring.</summary>
+    static bool HasNoteContaining(JsonElement root, string needle)
+    {
+        if (!root.TryGetProperty("notes", out var notes)) return false;
+        foreach (var n in notes.EnumerateArray())
+            if (n.GetString() is { } s && s.Contains(needle, StringComparison.Ordinal)) return true;
+        return false;
     }
 }

--- a/src/housecarl-generator/BulkPrimitivesWave2Probe.cs
+++ b/src/housecarl-generator/BulkPrimitivesWave2Probe.cs
@@ -167,6 +167,118 @@ public static class BulkPrimitivesWave2Probe
                 conflict_tree: false, resolve_names: true, max_chars: 0);
             Check("batch_record_detail resolve_names annotates too (shared batch memo)", tBatch.Contains("→ hcw2KwA"));
 
+            // ================= P6 — format="json" (same data as text, valid JSON, accounting in-band) =================
+            Console.WriteLine();
+            Console.WriteLine("── P6: format=json — token parity with text, stable DTO shape, Q3 accounting in-band ──");
+
+            // read_record: text and json emit the SAME field token (round-trip parity). W1's winner (override) damage = 15.
+            var recText = ReadTools.ReadRecord(svc, w1Fk.ToString(), plugin: null, fields: new[] { "BasicStats.Damage", "Name" }, depth: 1,
+                conflict_tree: false, resolve_names: false, format: "text", max_chars: 0);
+            var recJsonStr = ReadTools.ReadRecord(svc, w1Fk.ToString(), plugin: null, fields: new[] { "BasicStats.Damage", "Name" }, depth: 1,
+                conflict_tree: false, resolve_names: false, format: "json", max_chars: 0);
+            var recDoc = ParseOrNull(recJsonStr);
+            Check("read_record json is VALID json", recDoc is not null);
+            if (recDoc is not null)
+            {
+                var root = recDoc.RootElement;
+                // DTO shape pin: the record object carries exactly the contracted keys.
+                Check("read_record json DTO carries {formid,type,editorid,winner,override_depth,source,fields}",
+                      root.TryGetProperty("formid", out _) && root.TryGetProperty("type", out _) && root.TryGetProperty("editorid", out _)
+                      && root.TryGetProperty("winner", out _) && root.TryGetProperty("override_depth", out _)
+                      && root.TryGetProperty("source", out _) && root.TryGetProperty("fields", out _));
+                Check("read_record json identity matches (Weapon/hcw2Sword1/winner=Repl)",
+                      root.GetProperty("type").GetString() == "Weapon" && root.GetProperty("editorid").GetString() == "hcw2Sword1"
+                      && root.GetProperty("winner").GetString() == replName);
+                var dmg = FindField(root, "BasicStats.Damage");
+                Check("read_record json field VALUE is the SAME token text emits (damage 15, the winner override)",
+                      dmg is not null && dmg.Value.GetProperty("value").GetString() == "15" && recText.Contains("BasicStats.Damage = 15"));
+                recDoc.Dispose();
+            }
+
+            // read_record json + resolve_names: the link sibling is STRUCTURED, the value is still the raw token.
+            var linkJson = ReadTools.ReadRecord(svc, w1Fk.ToString(), plugin: null, fields: new[] { "Keywords" }, depth: 2,
+                conflict_tree: false, resolve_names: true, format: "json", max_chars: 0);
+            var linkDoc = ParseOrNull(linkJson);
+            Check("read_record json+resolve_names is VALID json", linkDoc is not null);
+            if (linkDoc is not null)
+            {
+                var kaEl = FindField(linkDoc.RootElement, "Keywords[0]");
+                bool ok = kaEl is not null
+                          && kaEl.Value.GetProperty("value").GetString() == kaFk.ToString()          // round-trip token intact
+                          && kaEl.Value.TryGetProperty("link", out var link)                          // structured sibling, not a mangled token
+                          && link.GetProperty("resolved").GetBoolean()
+                          && link.GetProperty("editorid").GetString() == "hcw2KwA";
+                Check("read_record json resolve_names: value is the raw token, link:{resolved,editorid} is a STRUCTURED sibling (P7 in json)", ok);
+                linkDoc.Dispose();
+            }
+
+            // conflict_tree + json is REFUSED loud (a text-only diff view — never silently dropped, Q3).
+            var ctJson = ReadTools.ReadRecord(svc, w1Fk.ToString(), plugin: null, fields: null, depth: 1,
+                conflict_tree: true, resolve_names: false, format: "json", max_chars: 0);
+            Check("conflict_tree=true + format=json is REFUSED loud (text-only diff, not silently dropped — Q3)",
+                  ctJson.StartsWith("error:", StringComparison.OrdinalIgnoreCase) && ctJson.Contains("conflict_tree", StringComparison.OrdinalIgnoreCase));
+
+            // batch json: {count, records, rendered, truncated}; records carry the same record objects.
+            var batchJson = ReadTools.BatchRecordDetail(svc, new[] { w1Fk.ToString(), "not-a-formid" }, fields: new[] { "Name" }, depth: 1,
+                conflict_tree: false, resolve_names: false, format: "json", max_chars: 0);
+            var batchDoc = ParseOrNull(batchJson);
+            Check("batch_record_detail json is VALID json with {count,records,rendered,truncated}",
+                  batchDoc is not null && batchDoc.RootElement.TryGetProperty("count", out _)
+                  && batchDoc.RootElement.TryGetProperty("records", out _) && batchDoc.RootElement.TryGetProperty("truncated", out _));
+            if (batchDoc is not null)
+            {
+                var records = batchDoc.RootElement.GetProperty("records");
+                Check("batch json: good record resolves, bad formid is a per-item {formid,error} (batch survives — Q3)",
+                      records.GetArrayLength() == 2 && records[0].GetProperty("type").GetString() == "Weapon"
+                      && records[1].TryGetProperty("error", out _));
+                batchDoc.Dispose();
+            }
+
+            // cross_plugin_query json — summary rows, group_by table, and Q3 notes survival.
+            var cqSummary = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: null, resolve_names: false,
+                fields: null, conflict_tree: false, format: "json", limit: 500, max_chars: 0);
+            var cqDoc = ParseOrNull(cqSummary);
+            Check("cross_plugin_query json summary is VALID json {total,capped,matches}",
+                  cqDoc is not null && cqDoc.RootElement.GetProperty("total").GetInt32() == 3
+                  && cqDoc.RootElement.GetProperty("matches").GetArrayLength() == 3);
+            cqDoc?.Dispose();
+
+            var cqGroup = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: "winner", resolve_names: false,
+                fields: null, conflict_tree: false, format: "json", limit: 500, max_chars: 0);
+            var cqgDoc = ParseOrNull(cqGroup);
+            Check("cross_plugin_query json group_by is VALID json {group_by,total,groups}",
+                  cqgDoc is not null && cqgDoc.RootElement.GetProperty("group_by").GetString() == "winner"
+                  && cqgDoc.RootElement.GetProperty("total").GetInt32() == 3
+                  && cqgDoc.RootElement.GetProperty("groups").GetArrayLength() == 2);
+            cqgDoc?.Dispose();
+
+            // Q3 accounting parity: a where= wrong-path note must survive INTO json (json is never a degraded mode).
+            const string badWhere = "NoSuchField = 5";
+            var noteText = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: new[] { badWhere }, group_by: null, resolve_names: false,
+                fields: null, conflict_tree: false, format: "text", limit: 500, max_chars: 0);
+            var noteJsonStr = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: new[] { badWhere }, group_by: null, resolve_names: false,
+                fields: null, conflict_tree: false, format: "json", limit: 500, max_chars: 0);
+            var noteDoc = ParseOrNull(noteJsonStr);
+            bool jsonHasNotes = false; string? firstNote = null;
+            if (noteDoc is not null && noteDoc.RootElement.TryGetProperty("notes", out var notesEl) && notesEl.GetArrayLength() > 0)
+            { jsonHasNotes = true; firstNote = notesEl[0].GetString(); }
+            // The real parity check: the where= accounting note is present in json AND its EXACT text also appears in
+            // the text render — the same Q3 note reaches both surfaces, so json is not a silently degraded mode.
+            Check("a where= accounting note is carried in json AND its exact text is in the text render (json is not a degraded mode — Q3)",
+                  jsonHasNotes && firstNote is not null && noteText.Contains(firstNote, StringComparison.Ordinal));
+            noteDoc?.Dispose();
+
+            // read_plugin_file json is exercised in ReadPluginFileProbe's own order; here confirm bad-format refusal is shared.
+            var cqBadFmt = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: null, resolve_names: false,
+                fields: null, conflict_tree: false, format: "xml", limit: 500, max_chars: 0);
+            Check("cross_plugin_query unrecognized format= is REFUSED loud (shared parser, Q3)",
+                  cqBadFmt.StartsWith("error:", StringComparison.OrdinalIgnoreCase) && cqBadFmt.Contains("format", StringComparison.OrdinalIgnoreCase));
+
             Console.WriteLine();
             Console.WriteLine($"=== bulk-primitives-wave2-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
             return _fail == 0 ? 0 : 1;
@@ -179,5 +291,21 @@ public static class BulkPrimitivesWave2Probe
     {
         Console.WriteLine($"   [{(ok ? "PASS" : "FAIL")}] {label}");
         if (ok) _pass++; else _fail++;
+    }
+
+    /// <summary>Parse a JSON string, returning null (not throwing) on malformed input — so an assertion can report
+    /// "invalid json" as a FAIL rather than crashing the whole guard.</summary>
+    static JsonDocument? ParseOrNull(string s)
+    {
+        try { return JsonDocument.Parse(s); } catch { return null; }
+    }
+
+    /// <summary>Find a field object by its "path" in a record object's "fields" array (null if absent).</summary>
+    static JsonElement? FindField(JsonElement record, string path)
+    {
+        if (!record.TryGetProperty("fields", out var fields)) return null;
+        foreach (var f in fields.EnumerateArray())
+            if (f.TryGetProperty("path", out var p) && p.GetString() == path) return f;
+        return null;
     }
 }

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -53,6 +53,11 @@ public static class CiAll
         // defined_in count table). Drives the real service scan + the tool-layer group_by/fields guard on a synthetic
         // master+replacer order; group_by counts are cross-checked against a hand tally; both loud refusals asserted.
         ("bulk-query-primitives-guard", BulkQueryPrimitivesProbe.RunGuard),
+        // WAVE 2 output contract — housecarl_resolve (P3), winner_fields= (P5), format=json (P6), resolve_names= (P7).
+        // Drives the real service + tool layer on a synthetic order with NAMED weapons; asserts identity resolution,
+        // per-item error isolation, always-valid JSON with token parity, the winner-vs-scoped body choice, and the
+        // display-only link annotation.
+        ("bulk-primitives-wave2-guard", BulkPrimitivesWave2Probe.RunGuard),
         ("writelock-guard", WriteLockProbe.RunGuard),
         ("inplace-guard", InPlaceProbe.RunGuard),
         ("subclass-remove-guard", SubclassRemoveGuardProbe.RunGuard),

--- a/src/housecarl-generator/ReadPluginFileProbe.cs
+++ b/src/housecarl-generator/ReadPluginFileProbe.cs
@@ -123,7 +123,7 @@ internal static class ReadPluginFileProbe
 
             // 5 — render stamps OUT-OF-LOAD-ORDER (end-to-end through the tool)
             Console.WriteLine("\n--- 5: render stamps OUT-OF-LOAD-ORDER ---");
-            var render = ReadTools.ReadPluginFile(svc, "Donor.esp", swordFk.ToString(), null, null, new[] { "BasicStats.Damage" }, 1, null, 500, 0);
+            var render = ReadTools.ReadPluginFile(svc, "Donor.esp", swordFk.ToString(), null, null, new[] { "BasicStats.Damage" }, 1, null, limit: 500, max_chars: 0);
             Check(render.Contains("OUT-OF-LOAD-ORDER"), "the rendered read is stamped OUT-OF-LOAD-ORDER (the load-bearing requirement)");
             Check(render.Contains("BasicStats.Damage = 12"), "…and shows the field line in read_record's `path = token` format");
 
@@ -168,7 +168,7 @@ internal static class ReadPluginFileProbe
                   $"6b the disabled-mod-only master is INACTIVE, NOT satisfied (the fixed false-negative) — inactive=[{string.Join(", ", mm.InactiveMasters)}]");
             Check(!mm.MissingMasters.Concat(mm.InactiveMasters).Any(x => x.Equals("HcRpfActive.esm", StringComparison.OrdinalIgnoreCase)),
                   "6c the enabled+checked master is satisfied — in neither list");
-            var mmRender = ReadTools.ReadPluginFile(svc, "Dependent.esp", null, null, null, null, 1, null, 500, 0);
+            var mmRender = ReadTools.ReadPluginFile(svc, "Dependent.esp", null, null, null, null, 1, null, limit: 500, max_chars: 0);
             Check(mmRender.Contains("NOT installed anywhere") && mmRender.Contains("NOT ACTIVE"),
                   "…and the render shows BOTH the not-installed and the not-active advisory lines");
 
@@ -197,7 +197,7 @@ internal static class ReadPluginFileProbe
             }
             var amb = svc.ReadPluginFile("Dup.esp", null, "Weapon", null, null, 1, null, 500);
             Check(amb.Mode == "ambiguous" && amb.Ambiguous.Count == 2, $"a name in 2 folders is AMBIGUOUS, not guessed — mode={amb.Mode}, hits={amb.Ambiguous.Count}");
-            var ambRender = ReadTools.ReadPluginFile(svc, "Dup.esp", null, "Weapon", null, null, 1, null, 500, 0);
+            var ambRender = ReadTools.ReadPluginFile(svc, "Dup.esp", null, "Weapon", null, null, 1, null, limit: 500, max_chars: 0);
             Check(ambRender.Contains("mod="), "…and the render tells the caller to pass mod=");
             var disamb = svc.ReadPluginFile("Dup.esp", null, "Weapon", "DupModB", null, 1, null, 500);
             Check(disamb.Mode == "enumerate" && disamb.Rows.Count == 1 && disamb.Rows[0].EditorId == "DupDisabledW",

--- a/src/housecarl-generator/ReadPluginFileProbe.cs
+++ b/src/housecarl-generator/ReadPluginFileProbe.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Records;
@@ -126,6 +127,24 @@ internal static class ReadPluginFileProbe
             var render = ReadTools.ReadPluginFile(svc, "Donor.esp", swordFk.ToString(), null, null, new[] { "BasicStats.Damage" }, 1, null, limit: 500, max_chars: 0);
             Check(render.Contains("OUT-OF-LOAD-ORDER"), "the rendered read is stamped OUT-OF-LOAD-ORDER (the load-bearing requirement)");
             Check(render.Contains("BasicStats.Damage = 12"), "…and shows the field line in read_record's `path = token` format");
+
+            // 5b — json render (P6): a valid document stamped out_of_load_order, same field token as the text render.
+            var renderJson = ReadTools.ReadPluginFile(svc, "Donor.esp", swordFk.ToString(), null, null, new[] { "BasicStats.Damage" }, 1, null, limit: 500, format: "json", max_chars: 0);
+            JsonDocument? pfDoc = null;
+            try { pfDoc = JsonDocument.Parse(renderJson); } catch { }
+            Check(pfDoc is not null, "read_plugin_file format=json is VALID json (P6)");
+            if (pfDoc is not null)
+            {
+                var pfRoot = pfDoc.RootElement;
+                bool okShape = pfRoot.TryGetProperty("out_of_load_order", out var ool) && ool.GetBoolean()
+                               && pfRoot.TryGetProperty("mode", out var m) && m.GetString() == "read";
+                string? dmg = null;
+                if (pfRoot.TryGetProperty("record", out var rec) && rec.TryGetProperty("fields", out var flds))
+                    foreach (var f in flds.EnumerateArray())
+                        if (f.TryGetProperty("path", out var p) && p.GetString() == "BasicStats.Damage" && f.TryGetProperty("value", out var v)) dmg = v.GetString();
+                Check(okShape && dmg == "12", $"read_plugin_file json: out_of_load_order + mode=read + the SAME field token as text (damage={dmg ?? "?"})");
+                pfDoc.Dispose();
+            }
 
             // 6 — master advisory (Q3): each declared master classified by whether it will actually LOAD.
             //   6a missing  — installed NOWHERE in the install

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1,0 +1,68 @@
+using System.Text;
+using System.Text.Json;
+using HousecarlCore;
+
+namespace HousecarlMcp;
+
+/// <summary>The machine-readable (format="json") twin of the text <see cref="Wire"/> renderer (Wave 2 / P6). ONE
+/// serializer per read tool, each consuming the SAME outcome objects the text Wire consumes — so text and JSON can
+/// only differ in FORMATTING, never in DATA (decision D2: one read path, two renders). Field VALUES are the SAME wire
+/// tokens the text mode emits (round-trip parity: a token read out of JSON is still a value a write can reuse
+/// verbatim). Q3 accounting (total / capped / truncated / notes) rides INSIDE the document, so JSON is never a
+/// silently degraded mode.
+///
+/// <para>Truncation drops trailing ROWS and flags it (<c>truncated:true</c> + <c>rendered</c>) — the emitted
+/// document ALWAYS stays valid JSON. Cutting the serialized string at a byte budget the way the text render cuts its
+/// StringBuilder would emit malformed JSON, itself a silent-degrade Q3 break, so the JSON path never does that.</para>
+///
+/// <para>The resolve_names annotation (P7) rides as a STRUCTURED sibling on each field object
+/// (<c>resolved:{editorid,name,type}</c>), never a mangled token — the JSON counterpart of the text render's
+/// parenthetical.</para></summary>
+static class JsonWire
+{
+    static readonly JsonWriterOptions Opts = new() { Indented = true };
+
+    static string Finish(MemoryStream ms) => Encoding.UTF8.GetString(ms.ToArray());
+
+    static void WriteNullable(Utf8JsonWriter w, string name, string? v)
+    {
+        if (v is null) w.WriteNull(name); else w.WriteString(name, v);
+    }
+
+    // ---- housecarl_resolve (P3) ---------------------------------------------------------------------
+    /// <summary>Render the bulk name-resolution result as JSON: <c>{count, resolved:[…]}</c> — one
+    /// <c>{formid,type,editorid,name,winner}</c> row per resolvable input, or <c>{formid,error}</c> for a
+    /// bad/absent one (per-item, the batch survives — Q3). Rows are one small object each; the input count bounds
+    /// the document, so no row truncation is needed here.</summary>
+    public static string RenderResolve(IReadOnlyList<ResolvedRef> rows)
+    {
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            w.WriteNumber("count", rows.Count);
+            w.WriteStartArray("resolved");
+            foreach (var r in rows) WriteResolvedRow(w, r);
+            w.WriteEndArray();
+            w.WriteEndObject();
+        }
+        return Finish(ms);
+    }
+
+    /// <summary>One housecarl_resolve row. Resolved ⇒ the identity fields; not resolved ⇒ a single <c>error</c>
+    /// (the malformed-FormID reason, or "not present in the active order" for a valid-but-absent FormKey).</summary>
+    static void WriteResolvedRow(Utf8JsonWriter w, ResolvedRef r)
+    {
+        w.WriteStartObject();
+        w.WriteString("formid", r.Token);
+        if (r.Resolved)
+        {
+            WriteNullable(w, "type", r.Type);
+            WriteNullable(w, "editorid", r.EditorId);
+            WriteNullable(w, "name", r.Name);
+            WriteNullable(w, "winner", r.Winner);
+        }
+        else w.WriteString("error", r.Error ?? "not present in the active order");
+        w.WriteEndObject();
+    }
+}

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -175,7 +175,7 @@ static class JsonWire
     /// (<c>{formid,type,editorid,winner,override_depth}</c>). Q3 accounting (total/capped/notes/truncated) rides
     /// in-band. The detail path threads resolve_names through the SAME ResolveRead the text render uses, so the two
     /// modes read one path.</summary>
-    public static string RenderCrossQuery(LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields, int maxChars, bool resolveNames)
+    public static string RenderCrossQuery(LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields, int maxChars, bool resolveNames, bool winnerFields)
     {
         int cap = Cap(maxChars);
         using var ms = new MemoryStream();
@@ -205,10 +205,15 @@ static class JsonWire
             else                                                            // per-match: detail (fields=) or summary
             {
                 bool detail = fields is { Count: > 0 };
+                bool anyScoped = detail && q.Sources is { } ss && ss.Take(q.Keys.Count).Any(s => s is not null);   // P5
+                string? p5 = anyScoped
+                    ? (winnerFields ? "field values are the load-order WINNER's (winner_fields=true); each match was SELECTED on its scoped plugin's body."
+                                    : "field values are each match's SCOPED plugin's OWN version, NOT the live load-order winner — pass winner_fields=true for load-order truth.")
+                    : null;
                 w.WriteNumber("total", q.Total);
                 w.WriteBoolean("capped", q.Capped);
                 if (q.ScopeLabel is not null) w.WriteString("scope", q.ScopeLabel);
-                WriteNotes(w, q);
+                WriteNotes(w, q, p5);
                 var linkMemo = resolveNames && detail ? new Dictionary<FormKey, ResolvedRef>() : null;
                 w.WriteStartArray("matches");
                 int rendered = 0; bool truncated = false;
@@ -220,7 +225,9 @@ static class JsonWire
                     string? matches = q.MatchedTargets is { } mt && i < mt.Count ? mt[i] : null;
                     if (detail)
                     {
-                        var o = svc.ResolveRead(fk, q.Sources is { } src ? src[i] : null, fields, false, resolveNames: resolveNames, linkMemo: linkMemo);
+                        // winner_fields=: read the WINNER's body (source=null) regardless of scan scope; the record's
+                        // "source" field still names the body read, so the json carries the same source/winner truth.
+                        var o = svc.ResolveRead(fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false, resolveNames: resolveNames, linkMemo: linkMemo);
                         if (o.Error is not null) { w.WriteStartObject(); w.WriteString("formid", fk.ToString()); w.WriteString("error", o.Error); if (matches is not null) w.WriteString("matches", matches); w.WriteEndObject(); }
                         else WriteReadRecord(w, o, matches);
                     }
@@ -258,12 +265,13 @@ static class JsonWire
 
     /// <summary>Q3 accounting notes (where= predicate note, unscannable-record note) carried IN the JSON document —
     /// so json is never a silently degraded mode vs text. Omitted when there are none.</summary>
-    static void WriteNotes(Utf8JsonWriter w, CrossQueryOutcome q)
+    static void WriteNotes(Utf8JsonWriter w, CrossQueryOutcome q, string? extra = null)
     {
-        if (q.PredicateNote is null && q.ScanNote is null) return;
+        if (q.PredicateNote is null && q.ScanNote is null && extra is null) return;
         w.WriteStartArray("notes");
         if (q.PredicateNote is not null) w.WriteStringValue(q.PredicateNote);
         if (q.ScanNote is not null) w.WriteStringValue(q.ScanNote);
+        if (extra is not null) w.WriteStringValue(extra);   // P5 scoped-vs-winner fields note
         w.WriteEndArray();
     }
 

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -80,11 +80,24 @@ static class JsonWire
     /// <summary>Serialize one field leaf: <c>{path, value}</c> for a round-trippable leaf (value = the SAME wire
     /// token the text mode emits) or <c>{path, note}</c> for a no-value leaf; the display-only <c>display</c> (biped
     /// slots) and the resolve_names <c>link</c> sibling (P7) ride alongside, never in place of the token.</summary>
-    static void WriteFieldsArray(Utf8JsonWriter w, RecordFields r)
+    /// <summary>Serialize the fields array, BUDGET-AWARE: a fat record (deep list expansion) is field-truncated the
+    /// same way the text render caps field lines — a sentinel field names the cut and the array closes, so the
+    /// document stays valid JSON (never silently over budget — Q3).</summary>
+    static void WriteFieldsArray(Utf8JsonWriter w, RecordFields r, MemoryStream ms, int cap)
     {
         w.WriteStartArray("fields");
-        foreach (var f in r.Fields)
+        for (int i = 0; i < r.Fields.Count; i++)
         {
+            w.Flush();
+            if (ms.Length >= cap)
+            {
+                w.WriteStartObject();
+                w.WriteString("path", "…");   // …
+                w.WriteString("note", $"[truncated at max_chars: {i} of {r.Fields.Count} fields shown; narrow with fields=, lower depth=, or raise max_chars]");
+                w.WriteEndObject();
+                break;
+            }
+            var f = r.Fields[i];
             w.WriteStartObject();
             w.WriteString("path", f.Path);
             if (f.HasValue) w.WriteString("value", f.Token);   // round-trip parity: identical token to the text render
@@ -110,7 +123,7 @@ static class JsonWire
     /// <summary>Serialize a resolved record: identity + winner/override_depth/source + the fields array. Shared by
     /// read_record, batch_record_detail, and the cross_plugin_query detail path (one shape, no drift). <paramref
     /// name="matches"/> carries the multi-target references= un-merge when present.</summary>
-    static void WriteReadRecord(Utf8JsonWriter w, ReadOutcome o, string? matches = null)
+    static void WriteReadRecord(Utf8JsonWriter w, ReadOutcome o, MemoryStream ms, int cap, string? matches = null)
     {
         var r = o.Record!;
         w.WriteStartObject();
@@ -121,7 +134,7 @@ static class JsonWire
         w.WriteNumber("override_depth", o.OverrideDepth);
         WriteNullable(w, "source", o.SourcePlugin);   // the body these field VALUES came from (scoped plugin vs winner)
         if (matches is not null) w.WriteString("matches", matches);
-        WriteFieldsArray(w, r);
+        WriteFieldsArray(w, r, ms, cap);
         w.WriteEndObject();
     }
 
@@ -130,11 +143,12 @@ static class JsonWire
     /// the tool layer for json (a text-only diff view), so only the field data reaches here.</summary>
     public static string RenderRecord(ReadOutcome o, int maxChars)
     {
+        int cap = Cap(maxChars);
         using var ms = new MemoryStream();
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
             if (o.Error is not null) { w.WriteStartObject(); w.WriteString("error", o.Error); w.WriteEndObject(); }
-            else WriteReadRecord(w, o);
+            else WriteReadRecord(w, o, ms, cap);
         }
         return Finish(ms);
     }
@@ -158,7 +172,7 @@ static class JsonWire
                 w.Flush();
                 if (ms.Length >= cap) { truncated = true; break; }
                 if (o.Error is not null) { w.WriteStartObject(); w.WriteString("formid", o.FormKey.ToString()); w.WriteString("error", o.Error); w.WriteEndObject(); }
-                else WriteReadRecord(w, o);
+                else WriteReadRecord(w, o, ms, cap);
                 rendered++;
             }
             w.WriteEndArray();
@@ -229,7 +243,7 @@ static class JsonWire
                         // "source" field still names the body read, so the json carries the same source/winner truth.
                         var o = svc.ResolveRead(fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false, resolveNames: resolveNames, linkMemo: linkMemo);
                         if (o.Error is not null) { w.WriteStartObject(); w.WriteString("formid", fk.ToString()); w.WriteString("error", o.Error); if (matches is not null) w.WriteString("matches", matches); w.WriteEndObject(); }
-                        else WriteReadRecord(w, o, matches);
+                        else WriteReadRecord(w, o, ms, cap, matches);
                     }
                     else
                     {
@@ -312,7 +326,7 @@ static class JsonWire
                     w.WriteString("formid", rf.FormKey);
                     w.WriteString("type", rf.Type);
                     WriteNullable(w, "editorid", rf.EditorId);
-                    WriteFieldsArray(w, rf);
+                    WriteFieldsArray(w, rf, ms, cap);
                     w.WriteEndObject();
                 }
                 else if (o.Mode == "enumerate")

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Json;
 using HousecarlCore;
+using Mutagen.Bethesda.Plugins;
 
 namespace HousecarlMcp;
 
@@ -64,5 +65,275 @@ static class JsonWire
         }
         else w.WriteString("error", r.Error ?? "not present in the active order");
         w.WriteEndObject();
+    }
+
+    static int Cap(int maxChars) => maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+
+    static void WriteStringArray(Utf8JsonWriter w, string name, IReadOnlyList<string> items)
+    {
+        w.WriteStartArray(name);
+        foreach (var s in items) w.WriteStringValue(s);
+        w.WriteEndArray();
+    }
+
+    // ---- shared record + field writers (P6/P7) ------------------------------------------------------
+    /// <summary>Serialize one field leaf: <c>{path, value}</c> for a round-trippable leaf (value = the SAME wire
+    /// token the text mode emits) or <c>{path, note}</c> for a no-value leaf; the display-only <c>display</c> (biped
+    /// slots) and the resolve_names <c>link</c> sibling (P7) ride alongside, never in place of the token.</summary>
+    static void WriteFieldsArray(Utf8JsonWriter w, RecordFields r)
+    {
+        w.WriteStartArray("fields");
+        foreach (var f in r.Fields)
+        {
+            w.WriteStartObject();
+            w.WriteString("path", f.Path);
+            if (f.HasValue) w.WriteString("value", f.Token);   // round-trip parity: identical token to the text render
+            else WriteNullable(w, "note", f.Note);
+            if (f.Display is not null) w.WriteString("display", f.Display);
+            if (f.Link is { } link)
+            {
+                w.WriteStartObject("link");
+                w.WriteBoolean("resolved", link.Resolved);
+                if (link.Resolved)
+                {
+                    WriteNullable(w, "type", link.Type);
+                    WriteNullable(w, "editorid", link.EditorId);
+                    WriteNullable(w, "name", link.Name);
+                }
+                w.WriteEndObject();
+            }
+            w.WriteEndObject();
+        }
+        w.WriteEndArray();
+    }
+
+    /// <summary>Serialize a resolved record: identity + winner/override_depth/source + the fields array. Shared by
+    /// read_record, batch_record_detail, and the cross_plugin_query detail path (one shape, no drift). <paramref
+    /// name="matches"/> carries the multi-target references= un-merge when present.</summary>
+    static void WriteReadRecord(Utf8JsonWriter w, ReadOutcome o, string? matches = null)
+    {
+        var r = o.Record!;
+        w.WriteStartObject();
+        w.WriteString("formid", r.FormKey);
+        w.WriteString("type", r.Type);
+        WriteNullable(w, "editorid", r.EditorId);
+        WriteNullable(w, "winner", o.WinnerPlugin);
+        w.WriteNumber("override_depth", o.OverrideDepth);
+        WriteNullable(w, "source", o.SourcePlugin);   // the body these field VALUES came from (scoped plugin vs winner)
+        if (matches is not null) w.WriteString("matches", matches);
+        WriteFieldsArray(w, r);
+        w.WriteEndObject();
+    }
+
+    // ---- housecarl_read_record (P6) -----------------------------------------------------------------
+    /// <summary>read_record as JSON: the record object at top level, or <c>{error}</c>. conflict_tree is refused at
+    /// the tool layer for json (a text-only diff view), so only the field data reaches here.</summary>
+    public static string RenderRecord(ReadOutcome o, int maxChars)
+    {
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            if (o.Error is not null) { w.WriteStartObject(); w.WriteString("error", o.Error); w.WriteEndObject(); }
+            else WriteReadRecord(w, o);
+        }
+        return Finish(ms);
+    }
+
+    // ---- housecarl_batch_record_detail (P6) ---------------------------------------------------------
+    /// <summary>batch_record_detail as JSON: <c>{count, records:[…], rendered, truncated}</c>. A bad/absent formid is
+    /// a per-item <c>{formid,error}</c> (the batch survives). Truncation drops trailing records and flags it — the
+    /// document stays valid JSON (Q3), and count is exact.</summary>
+    public static string RenderBatch(IReadOnlyList<ReadOutcome> outcomes, int maxChars)
+    {
+        int cap = Cap(maxChars);
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            w.WriteNumber("count", outcomes.Count);
+            w.WriteStartArray("records");
+            int rendered = 0; bool truncated = false;
+            foreach (var o in outcomes)
+            {
+                w.Flush();
+                if (ms.Length >= cap) { truncated = true; break; }
+                if (o.Error is not null) { w.WriteStartObject(); w.WriteString("formid", o.FormKey.ToString()); w.WriteString("error", o.Error); w.WriteEndObject(); }
+                else WriteReadRecord(w, o);
+                rendered++;
+            }
+            w.WriteEndArray();
+            w.WriteNumber("rendered", rendered);
+            w.WriteBoolean("truncated", truncated);
+            w.WriteEndObject();
+        }
+        return Finish(ms);
+    }
+
+    // ---- housecarl_cross_plugin_query (P6) ----------------------------------------------------------
+    /// <summary>cross_plugin_query as JSON — three shapes matching the text render: group_by count table
+    /// (<c>{group_by, total, groups:[…]}</c>), detail rows (full record objects with fields), or summary rows
+    /// (<c>{formid,type,editorid,winner,override_depth}</c>). Q3 accounting (total/capped/notes/truncated) rides
+    /// in-band. The detail path threads resolve_names through the SAME ResolveRead the text render uses, so the two
+    /// modes read one path.</summary>
+    public static string RenderCrossQuery(LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields, int maxChars, bool resolveNames)
+    {
+        int cap = Cap(maxChars);
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            if (q.Error is not null) w.WriteString("error", q.Error);
+            else if (q.Groups is not null)                                   // group_by= → count table
+            {
+                WriteNullable(w, "group_by", q.GroupBy);
+                w.WriteNumber("total", q.Total);
+                if (q.ScopeLabel is not null) w.WriteString("scope", q.ScopeLabel);
+                WriteNotes(w, q);
+                w.WriteStartArray("groups");
+                int gRendered = 0; bool gTrunc = false;
+                foreach (var g in q.Groups)
+                {
+                    w.Flush();
+                    if (ms.Length >= cap) { gTrunc = true; break; }
+                    w.WriteStartObject(); w.WriteString("key", g.Key); w.WriteNumber("count", g.Count); w.WriteEndObject();
+                    gRendered++;
+                }
+                w.WriteEndArray();
+                w.WriteNumber("rendered", gRendered);
+                w.WriteBoolean("truncated", gTrunc);
+            }
+            else                                                            // per-match: detail (fields=) or summary
+            {
+                bool detail = fields is { Count: > 0 };
+                w.WriteNumber("total", q.Total);
+                w.WriteBoolean("capped", q.Capped);
+                if (q.ScopeLabel is not null) w.WriteString("scope", q.ScopeLabel);
+                WriteNotes(w, q);
+                var linkMemo = resolveNames && detail ? new Dictionary<FormKey, ResolvedRef>() : null;
+                w.WriteStartArray("matches");
+                int rendered = 0; bool truncated = false;
+                for (int i = 0; i < q.Keys.Count; i++)
+                {
+                    w.Flush();
+                    if (ms.Length >= cap) { truncated = true; break; }
+                    var fk = q.Keys[i];
+                    string? matches = q.MatchedTargets is { } mt && i < mt.Count ? mt[i] : null;
+                    if (detail)
+                    {
+                        var o = svc.ResolveRead(fk, q.Sources is { } src ? src[i] : null, fields, false, resolveNames: resolveNames, linkMemo: linkMemo);
+                        if (o.Error is not null) { w.WriteStartObject(); w.WriteString("formid", fk.ToString()); w.WriteString("error", o.Error); if (matches is not null) w.WriteString("matches", matches); w.WriteEndObject(); }
+                        else WriteReadRecord(w, o, matches);
+                    }
+                    else
+                    {
+                        var m = q.Prefilled is not null ? q.Prefilled[i] : svc.ResolveSummary(fk);
+                        WriteSummaryRow(w, m, matches);
+                    }
+                    rendered++;
+                }
+                w.WriteEndArray();
+                w.WriteNumber("rendered", rendered);
+                w.WriteBoolean("truncated", truncated);
+            }
+            w.WriteEndObject();
+        }
+        return Finish(ms);
+    }
+
+    static void WriteSummaryRow(Utf8JsonWriter w, RecordSummary m, string? matches)
+    {
+        w.WriteStartObject();
+        w.WriteString("formid", m.FormKey.ToString());
+        if (m.Error is not null) w.WriteString("error", m.Error);
+        else
+        {
+            w.WriteString("type", m.Type);
+            WriteNullable(w, "editorid", m.EditorId);
+            w.WriteString("winner", m.Winner);
+            w.WriteNumber("override_depth", m.OverrideDepth);
+        }
+        if (matches is not null) w.WriteString("matches", matches);
+        w.WriteEndObject();
+    }
+
+    /// <summary>Q3 accounting notes (where= predicate note, unscannable-record note) carried IN the JSON document —
+    /// so json is never a silently degraded mode vs text. Omitted when there are none.</summary>
+    static void WriteNotes(Utf8JsonWriter w, CrossQueryOutcome q)
+    {
+        if (q.PredicateNote is null && q.ScanNote is null) return;
+        w.WriteStartArray("notes");
+        if (q.PredicateNote is not null) w.WriteStringValue(q.PredicateNote);
+        if (q.ScanNote is not null) w.WriteStringValue(q.ScanNote);
+        w.WriteEndArray();
+    }
+
+    // ---- housecarl_read_plugin_file (P6) ------------------------------------------------------------
+    /// <summary>read_plugin_file as JSON — always stamped <c>out_of_load_order:true</c> (the load-bearing raw-file
+    /// caveat), then the file/masters context and the mode payload: <c>record</c> (the FILE's own record — no winner,
+    /// it's not resolved), <c>records</c> (enumerate), or <c>type_counts</c> (summary). <c>error</c>/<c>ambiguous</c>
+    /// on failure.</summary>
+    public static string RenderPluginFile(PluginFileOutcome o, int maxChars)
+    {
+        int cap = Cap(maxChars);
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            if (o.Mode == "error") { w.WriteString("error", o.Error); }
+            else if (o.Mode == "ambiguous")
+            {
+                w.WriteString("error", $"'{Path.GetFileName(o.Requested)}' is provided by {o.Ambiguous.Count} locations — specify which with mod= (or pass an absolute path).");
+                w.WriteStartArray("ambiguous");
+                foreach (var h in o.Ambiguous) { w.WriteStartObject(); w.WriteString("where", h.Where); w.WriteString("path", h.Path); w.WriteEndObject(); }
+                w.WriteEndArray();
+            }
+            else
+            {
+                w.WriteBoolean("out_of_load_order", true);
+                WriteNullable(w, "file", o.FilePath);
+                WriteNullable(w, "where", o.Where);
+                w.WriteBoolean("enabled", o.Enabled);
+                WriteStringArray(w, "masters", o.Masters);
+                WriteStringArray(w, "missing_masters", o.MissingMasters);
+                WriteStringArray(w, "inactive_masters", o.InactiveMasters);
+                w.WriteString("mode", o.Mode);
+                if (o.Mode == "read" && o.Record is { } rf)
+                {
+                    w.WritePropertyName("record");
+                    w.WriteStartObject();
+                    w.WriteString("formid", rf.FormKey);
+                    w.WriteString("type", rf.Type);
+                    WriteNullable(w, "editorid", rf.EditorId);
+                    WriteFieldsArray(w, rf);
+                    w.WriteEndObject();
+                }
+                else if (o.Mode == "enumerate")
+                {
+                    w.WriteNumber("total", o.RowTotal);
+                    w.WriteBoolean("capped", o.Capped);
+                    w.WriteStartArray("records");
+                    int rendered = 0; bool truncated = false;
+                    foreach (var row in o.Rows)
+                    {
+                        w.Flush();
+                        if (ms.Length >= cap) { truncated = true; break; }
+                        w.WriteStartObject(); w.WriteString("formid", row.FormKey); w.WriteString("type", row.Type); WriteNullable(w, "editorid", row.EditorId); w.WriteEndObject();
+                        rendered++;
+                    }
+                    w.WriteEndArray();
+                    w.WriteNumber("rendered", rendered);
+                    w.WriteBoolean("truncated", truncated);
+                }
+                else   // summary
+                {
+                    w.WriteNumber("total", o.RecordTotal);
+                    w.WriteStartArray("type_counts");
+                    foreach (var tc in o.TypeCounts) { w.WriteStartObject(); w.WriteString("type", tc.Type); w.WriteNumber("count", tc.Count); w.WriteEndObject(); }
+                    w.WriteEndArray();
+                }
+            }
+            w.WriteEndObject();
+        }
+        return Finish(ms);
     }
 }

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -31,20 +31,30 @@ static class JsonWire
     }
 
     // ---- housecarl_resolve (P3) ---------------------------------------------------------------------
-    /// <summary>Render the bulk name-resolution result as JSON: <c>{count, resolved:[…]}</c> — one
-    /// <c>{formid,type,editorid,name,winner}</c> row per resolvable input, or <c>{formid,error}</c> for a
-    /// bad/absent one (per-item, the batch survives — Q3). Rows are one small object each; the input count bounds
-    /// the document, so no row truncation is needed here.</summary>
-    public static string RenderResolve(IReadOnlyList<ResolvedRef> rows)
+    /// <summary>Render the bulk name-resolution result as JSON: <c>{count, resolved:[…], rendered, truncated}</c> —
+    /// one <c>{formid,type,editorid,name,winner}</c> row per resolvable input, or <c>{formid,error}</c> for a
+    /// bad/absent one (per-item, the batch survives — Q3). Budget-aware like the other JSON renders: over max_chars it
+    /// drops trailing rows and flags <c>truncated</c>, keeping the document valid JSON with an exact <c>count</c>.</summary>
+    public static string RenderResolve(IReadOnlyList<ResolvedRef> rows, int maxChars)
     {
+        int cap = Cap(maxChars);
         using var ms = new MemoryStream();
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
             w.WriteStartObject();
             w.WriteNumber("count", rows.Count);
             w.WriteStartArray("resolved");
-            foreach (var r in rows) WriteResolvedRow(w, r);
+            int rendered = 0; bool truncated = false;
+            foreach (var r in rows)
+            {
+                w.Flush();
+                if (ms.Length >= cap) { truncated = true; break; }
+                WriteResolvedRow(w, r);
+                rendered++;
+            }
             w.WriteEndArray();
+            w.WriteNumber("rendered", rendered);
+            w.WriteBoolean("truncated", truncated);
             w.WriteEndObject();
         }
         return Finish(ms);
@@ -77,12 +87,12 @@ static class JsonWire
     }
 
     // ---- shared record + field writers (P6/P7) ------------------------------------------------------
-    /// <summary>Serialize one field leaf: <c>{path, value}</c> for a round-trippable leaf (value = the SAME wire
-    /// token the text mode emits) or <c>{path, note}</c> for a no-value leaf; the display-only <c>display</c> (biped
-    /// slots) and the resolve_names <c>link</c> sibling (P7) ride alongside, never in place of the token.</summary>
-    /// <summary>Serialize the fields array, BUDGET-AWARE: a fat record (deep list expansion) is field-truncated the
-    /// same way the text render caps field lines — a sentinel field names the cut and the array closes, so the
-    /// document stays valid JSON (never silently over budget — Q3).</summary>
+    /// <summary>Serialize the fields array. Each leaf is <c>{path, value}</c> for a round-trippable leaf (value = the
+    /// SAME wire token the text mode emits) or <c>{path, note}</c> for a no-value leaf; the display-only <c>display</c>
+    /// (biped slots) and the resolve_names <c>link</c> sibling (P7) ride alongside, never in place of the token.
+    /// BUDGET-AWARE: a fat record (deep list expansion) is field-truncated the same way the text render caps field
+    /// lines — a sentinel field names the cut and the array closes, so the document stays valid JSON (never silently
+    /// over budget — Q3).</summary>
     static void WriteFieldsArray(Utf8JsonWriter w, RecordFields r, MemoryStream ms, int cap)
     {
         w.WriteStartArray("fields");

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1,4 +1,5 @@
 using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Aspects;
 using Mutagen.Bethesda.Plugins.Records;
 using Mutagen.Bethesda.Skyrim;
 
@@ -1483,6 +1484,60 @@ public sealed class LoadOrderService : IDisposable
                 $"winner '{w.Value.WinnerPlugin}' did not yield {fk} on fetch");
         return new RecordSummary(fk, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID,
                                  w.Value.WinnerPlugin, w.Value.OverrideDepth, null);
+    }
+
+    /// <summary>The best-effort display Name of a record body — reflection-generic via Mutagen's <c>INamedGetter</c>
+    /// aspect, so it inherits coverage from the model (no per-record-type wiring): every named record answers, a
+    /// type with no Name (KYWD, most references) returns null. A translated Name resolves to its default-language
+    /// string. Used by housecarl_resolve (P3) and the resolve_names annotation (P7).</summary>
+    static string? ReadDisplayName(IMajorRecordGetter body) =>
+        body is INamedGetter named && !string.IsNullOrEmpty(named.Name) ? named.Name : null;
+
+    /// <summary>Resolve ONE FormKey to its load-order identity (type/editorid/name/winner) off a captured view + open
+    /// session, memoised so a target that recurs across a batch (the SAME keyword on 500 items) resolves once. A
+    /// FormKey not in the order is a NAMED unresolved result (Resolved=false), never dropped or guessed (Q3). Shared
+    /// by housecarl_resolve (P3) and the resolve_names field annotation (P7).</summary>
+    static ResolvedRef ResolveRefOne(LoadOrderResolver.IndexView view, LoadOrderResolver.OverlaySession session,
+                                     FormKey fk, Dictionary<FormKey, ResolvedRef> memo)
+    {
+        if (memo.TryGetValue(fk, out var hit)) return hit;
+        ResolvedRef result;
+        var w = view.ResolveWinner(fk);
+        if (w is null)
+            result = new ResolvedRef(fk.ToString(), Resolved: false);   // valid FormKey, but no active plugin defines it (a dangling target)
+        else
+        {
+            var body = view.GetRecord(session, w.Value.WinnerPlugin, fk);
+            result = body is null
+                ? new ResolvedRef(fk.ToString(), Resolved: false, Winner: w.Value.WinnerPlugin)   // winner named but the fetch didn't yield it
+                : new ResolvedRef(fk.ToString(), Resolved: true, Type: RecordNaming.StripOverlay(body.GetType().Name),
+                                  EditorId: body.EditorID, Name: ReadDisplayName(body), Winner: w.Value.WinnerPlugin);
+        }
+        memo[fk] = result;
+        return result;
+    }
+
+    /// <summary>Bulk name resolution (housecarl_resolve — P3): turn a list of FormIDs into their load-order identity
+    /// (type/editorid/name/winner) in ONE call over ONE captured view, memoised across the batch. A bad/absent FormID
+    /// yields a per-item result carrying its reason (Error for a malformed string, Resolved=false for a valid-but-absent
+    /// FormKey) without failing the whole batch (Q3, the batch_record_detail convention). Deliberately minimal — no
+    /// fields/depth/conflict_tree; anything richer is housecarl_batch_record_detail's job.</summary>
+    public IReadOnlyList<ResolvedRef> ResolveRefs(IReadOnlyList<string> formids)
+    {
+        var resolver = Resolver;
+        var view = resolver.Capture();                  // ONE build for the whole batch (HCBR-2026-06-11-02)
+        using var session = resolver.OpenSession();
+        var memo = new Dictionary<FormKey, ResolvedRef>();
+        var results = new List<ResolvedRef>(formids.Count);
+        foreach (var raw in formids)
+        {
+            var t = raw?.Trim() ?? "";
+            FormKey fk;
+            try { fk = FormKey.Factory(t); }
+            catch (Exception ex) { results.Add(new ResolvedRef(t, Resolved: false, Error: $"bad FormID: {ex.Message}. Expected 'XXXXXX:Plugin.esp'.")); continue; }
+            results.Add(ResolveRefOne(view, session, fk, memo));
+        }
+        return results;
     }
 
     // ---- batch (Q4.9) -----------------------------------------------------------------------------------

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1374,10 +1374,11 @@ public sealed class LoadOrderService : IDisposable
     /// named <paramref name="plugin"/>'s version; with <paramref name="conflictTree"/> also returns the ordered
     /// touching-plugin list. Honest, recoverable errors (Q3): not-in-order, plugin-doesn't-touch, fetch
     /// inconsistency — never a silent empty result.</summary>
-    public ReadOutcome ResolveRead(FormKey fk, string? plugin, IReadOnlyList<string>? fields, bool conflictTree, int depth = 1)
+    public ReadOutcome ResolveRead(FormKey fk, string? plugin, IReadOnlyList<string>? fields, bool conflictTree, int depth = 1,
+                                   bool resolveNames = false, Dictionary<FormKey, ResolvedRef>? linkMemo = null)
     {
         var resolver = Resolver;
-        return ResolveRead(resolver, resolver.Capture(), fk, plugin, fields, conflictTree, depth);
+        return ResolveRead(resolver, resolver.Capture(), fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo);
     }
 
     /// <summary>Layer B unit C2 — the on-demand whole-topic dialogue-graph validator (housecarl_validate_dialogue):
@@ -1400,7 +1401,8 @@ public sealed class LoadOrderService : IDisposable
     /// call with its own capture, so one rendered response can still pair this read's build with an adjacent build's
     /// diff — same low-severity class, named for the next wave rather than threaded through the render API here.)</summary>
     ReadOutcome ResolveRead(LoadOrderResolver resolver, LoadOrderResolver.IndexView view,
-                            FormKey fk, string? plugin, IReadOnlyList<string>? fields, bool conflictTree, int depth)
+                            FormKey fk, string? plugin, IReadOnlyList<string>? fields, bool conflictTree, int depth,
+                            bool resolveNames = false, Dictionary<FormKey, ResolvedRef>? linkMemo = null)
     {
         // An explicitly-requested plugin that was EXCLUDED this session (unparseable/unopenable) → say so (Q3),
         // rather than fall through to a misleading "does not define this record".
@@ -1441,8 +1443,33 @@ public sealed class LoadOrderService : IDisposable
                 : $"Plugin '{plugin}' does not define {fk} (it does not touch this record). The winner is '{winner.Value.WinnerPlugin}'.");
 
         var record = ReadEngine.ReadFields(rec, fields, depth);           // materialise while the session (overlay) is open
+        if (resolveNames) record = AnnotateLinks(record, view, session, linkMemo ?? new());   // P7: identity of every FormLink token, DISPLAY-ONLY (same open session)
         var touching = conflictTree ? view.TouchingPlugins(fk) : null;
         return new ReadOutcome(fk, record, source, winner.Value.WinnerPlugin, winner.Value.OverrideDepth, touching, null);
+    }
+
+    /// <summary>resolve_names (P7): annotate every field whose <see cref="FieldValue.Token"/> is a form reference (a
+    /// token that round-trips to a FormKey) with its target's load-order identity, hung on <see cref="FieldValue.Link"/>
+    /// — DISPLAY-ONLY, never touching the round-trip Token. Type-agnostic: a token that parses as a FormKey IS a form
+    /// reference (FormLinks and condition-target FLOIs both emit a bare FormKey token; scalars never do), so this
+    /// inherits coverage from the read surface with no per-type wiring. Resolution rides the SAME captured view +
+    /// open session the read used, memoised so a keyword that recurs across a whole record (or batch) resolves once.
+    /// An unresolvable target is a NAMED unresolved <see cref="ResolvedRef"/> (Resolved=false), never dropped (Q3).
+    /// Copy-on-first-write: a record with no form-reference leaves returns the SAME instance.</summary>
+    static RecordFields AnnotateLinks(RecordFields rf, LoadOrderResolver.IndexView view,
+                                      LoadOrderResolver.OverlaySession session, Dictionary<FormKey, ResolvedRef> memo)
+    {
+        List<FieldValue>? rebuilt = null;
+        for (int i = 0; i < rf.Fields.Count; i++)
+        {
+            var f = rf.Fields[i];
+            if (f.HasValue && f.Token is { } tok && FormKey.TryFactory(tok, out var fk) && !fk.IsNull)
+            {
+                rebuilt ??= new List<FieldValue>(rf.Fields);
+                rebuilt[i] = f with { Link = ResolveRefOne(view, session, fk, memo) };
+            }
+        }
+        return rebuilt is null ? rf : rf with { Fields = rebuilt };
     }
 
     /// <summary>How deep the conflict diff reads each touching body. The diff must compare CONTENT, not the
@@ -1545,17 +1572,19 @@ public sealed class LoadOrderService : IDisposable
     /// <summary>Resolve+read many records in one call (housecarl_batch_record_detail). Each formid runs the same
     /// <see cref="ResolveRead"/> path, so a bad/absent formid yields a per-item recoverable error (Q3) without
     /// failing the batch. Returns one <see cref="ReadOutcome"/> per input, in order.</summary>
-    public IReadOnlyList<ReadOutcome> ResolveBatch(IReadOnlyList<string> formids, IReadOnlyList<string>? fields, bool conflictTree, int depth = 1)
+    public IReadOnlyList<ReadOutcome> ResolveBatch(IReadOnlyList<string> formids, IReadOnlyList<string>? fields, bool conflictTree, int depth = 1,
+                                                   bool resolveNames = false)
     {
         var resolver = Resolver;                // build/refresh ONCE for the batch
         var view = resolver.Capture();          // ONE build for every item — the whole batch is one logical operation (HCBR-2026-06-11-02)
+        var linkMemo = resolveNames ? new Dictionary<FormKey, ResolvedRef>() : null;   // P7: one link-resolution cache across the WHOLE batch
         var outcomes = new List<ReadOutcome>(formids.Count);
         foreach (var raw in formids)
         {
             FormKey fk;
             try { fk = FormKey.Factory(raw.Trim()); }
             catch (Exception ex) { outcomes.Add(ReadOutcome.Fail(default, $"bad FormID '{raw}': {ex.Message}")); continue; }
-            outcomes.Add(ResolveRead(resolver, view, fk, null, fields, conflictTree, depth));
+            outcomes.Add(ResolveRead(resolver, view, fk, null, fields, conflictTree, depth, resolveNames, linkMemo));
         }
         return outcomes;
     }
@@ -4109,7 +4138,8 @@ public sealed class LoadOrderService : IDisposable
     /// <para>Read-only. Q3: a missing/ambiguous filename, a bad or absent FormID, or a record Mutagen cannot parse is
     /// NAMED, never a silent wrong answer.</para></summary>
     public PluginFileOutcome ReadPluginFile(string plugin, string? formid, string? type, string? mod,
-                                            IReadOnlyList<string>? fields, int depth, string? editoridContains, int limit)
+                                            IReadOnlyList<string>? fields, int depth, string? editoridContains, int limit,
+                                            bool resolveNames = false)
     {
         if (string.IsNullOrWhiteSpace(plugin))
             return PluginFileOutcome.Fail(plugin ?? "", "plugin is required — a plugin filename (e.g. 'Vivace.esp') or an absolute path to a .esp/.esm/.esl.");
@@ -4179,7 +4209,18 @@ public sealed class LoadOrderService : IDisposable
                 catch (Exception ex) { return baseOut with { Mode = "error", Error = $"'{Path.GetFileName(path)}' could not be fully read — a record Mutagen cannot parse before reaching {fk}: {ex.Message}" }; }
                 if (rec is null)
                     return baseOut with { Mode = "error", Error = $"file '{Path.GetFileName(path)}' does not define or override {fk}. This reads the FILE's OWN records only — it does not resolve across masters or report a load-order winner; use housecarl_read_record for the winner." };
-                return baseOut with { Mode = "read", Record = ReadEngine.ReadFields(rec, fields, depth <= 0 ? 1 : depth) };
+                var rf = ReadEngine.ReadFields(rec, fields, depth <= 0 ? 1 : depth);
+                if (resolveNames)
+                {
+                    // resolve_names on a RAW file read: the FILE's link tokens are resolved against the ACTIVE order
+                    // (the only identity frame houseCARL holds) — honest, and a target the active order doesn't define
+                    // is marked 'unresolved', not guessed. Opt-in only, so the deliberate no-resolver cheapness of the
+                    // default path is untouched; a caller asking for identities accepts the resolver build.
+                    var view = Resolver.Capture();
+                    using var session = Resolver.OpenSession();
+                    rf = AnnotateLinks(rf, view, session, new());
+                }
+                return baseOut with { Mode = "read", Record = rf };
             }
 
             if (hasType)

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -38,16 +38,21 @@ public static class ReadTools
             bool conflict_tree = false,
         [Description("When true, annotate every FormLink field value with its target's identity (→ editorid \"Name\"), resolved against the load order — so a Keywords/Template/DeathItem token reads as what it points AT, not just a FormID. Display-only: the token itself is unchanged (a write can still reuse it). A target no active plugin defines is marked 'unresolved'.")]
             bool resolve_names = false,
+        [Description("Optional. 'text' (default) or 'json' — a machine-readable {formid,type,editorid,winner,override_depth,source,fields[]} document (field values are the SAME tokens as text). conflict_tree is a text-only diff view.")]
+            string? format = null,
         [Description("Optional. Max characters before the diff is cut with an explicit notice (never silent). 0 = the server default (~80k). Raise to see a very deep conflict tree in full.")]
             int max_chars = 0) => Guard.Tool("housecarl_read_record", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        bool json = Wire.WantsJson(format, out var ferr);
+        if (ferr is not null) return ferr;
+        if (json && conflict_tree) return "error: conflict_tree=true is a text-only diff view and is not carried in json mode — use format=text for the conflict tree, or drop conflict_tree for the json field data.";
         FormKey fk;
         try { fk = FormKey.Factory(formid.Trim()); }
         catch (Exception ex) { return $"error: bad FormID '{formid}': {ex.Message}. Expected 'XXXXXX:Plugin.esp', e.g. '0F1AC1:Skyrim.esm'."; }
 
         var outcome = svc.ResolveRead(fk, plugin?.Trim(), fields, conflict_tree, depth <= 0 ? 1 : depth, resolve_names);
-        return Wire.RenderRecord(svc, outcome, fields, conflict_tree, max_chars);
+        return json ? JsonWire.RenderRecord(outcome, max_chars) : Wire.RenderRecord(svc, outcome, fields, conflict_tree, max_chars);
     });
 
     [McpServerTool(Name = "housecarl_batch_record_detail", ReadOnly = true, Title = "Read many records"),
@@ -70,13 +75,18 @@ public static class ReadTools
             bool conflict_tree = false,
         [Description("When true, annotate every FormLink field value across every record with its target's identity (→ editorid \"Name\"), resolved against the load order and cached across the whole batch. Display-only: the token itself is unchanged. Unresolvable targets are marked.")]
             bool resolve_names = false,
+        [Description("Optional. 'text' (default) or 'json' — a machine-readable {count, records:[…], rendered, truncated} document (each record like read_record's json; field values are the SAME tokens as text). conflict_tree is a text-only diff view.")]
+            string? format = null,
         [Description("Optional. Max characters before the response stops with an explicit 'rendered X of N' notice. 0 = the server default (~80k).")]
             int max_chars = 0) => Guard.Tool("housecarl_batch_record_detail", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         if (formids is null || formids.Length == 0) return "error: formids is empty. Pass one or more 'XXXXXX:Plugin.esp' FormIDs.";
+        bool json = Wire.WantsJson(format, out var ferr);
+        if (ferr is not null) return ferr;
+        if (json && conflict_tree) return "error: conflict_tree=true is a text-only diff view and is not carried in json mode — use format=text for the conflict tree, or drop conflict_tree for the json field data.";
         var outcomes = svc.ResolveBatch(formids, fields, conflict_tree, depth <= 0 ? 1 : depth, resolve_names);
-        return Wire.RenderBatch(svc, outcomes, fields, conflict_tree, max_chars);
+        return json ? JsonWire.RenderBatch(outcomes, max_chars) : Wire.RenderBatch(svc, outcomes, fields, conflict_tree, max_chars);
     });
 
     [McpServerTool(Name = "housecarl_cross_plugin_query", ReadOnly = true, Title = "Query records across the load order"),
@@ -120,12 +130,17 @@ public static class ReadTools
             bool conflict_tree = false,
         [Description("When true (with fields=), annotate every FormLink field value with its target's identity (→ editorid \"Name\"), resolved against the load order and cached across all matches. Display-only; the token is unchanged. No effect on summary lines or group_by (there are no field tokens to annotate).")]
             bool resolve_names = false,
+        [Description("Optional. 'text' (default) or 'json' — a machine-readable document (group_by count table, detail record objects with fields, or summary rows), with total/capped/notes/truncated accounting in-band. conflict_tree is a text-only diff view.")]
+            string? format = null,
         [Description("Optional. Max matches to return (default 500). The TRUE total is always reported; over the cap it says 'showing first N'.")]
             int limit = 500,
         [Description("Optional. Max characters before the response stops with an explicit notice. 0 = the server default (~80k).")]
             int max_chars = 0) => Guard.Tool("housecarl_cross_plugin_query", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        bool json = Wire.WantsJson(format, out var ferr);
+        if (ferr is not null) return ferr;
+        if (json && conflict_tree) return "error: conflict_tree=true is a text-only diff view and is not carried in json mode — use format=text for the conflict tree, or drop conflict_tree for the json field data.";
         if (group_by is not null && ((fields is { Length: > 0 }) || conflict_tree))
             return "error: group_by aggregates matches into a count table and cannot be combined with fields= or conflict_tree=true (those expand each match to full detail — pick one). Drop fields=/conflict_tree, or drop group_by.";
         IReadOnlyList<FormKey>? refFks = null;
@@ -141,7 +156,8 @@ public static class ReadTools
             if (list.Count > 0) refFks = list.Distinct().ToList();   // preserve input order, drop dupes
         }
         var outcome = svc.CrossQuery(type, refFks, editorid_contains, conflicts_only, plugins, where, limit <= 0 ? 500 : limit, defined_in, group_by);
-        return Wire.RenderCrossQuery(svc, outcome, fields, conflict_tree, max_chars, resolve_names);
+        return json ? JsonWire.RenderCrossQuery(svc, outcome, fields, max_chars, resolve_names)
+                    : Wire.RenderCrossQuery(svc, outcome, fields, conflict_tree, max_chars, resolve_names);
     });
 
     [McpServerTool(Name = "housecarl_resolve", ReadOnly = true, Title = "Resolve FormIDs to their identity"),
@@ -293,12 +309,16 @@ public static class ReadTools
             int limit = 500,
         [Description("Optional. With formid=: annotate every FormLink field value with its target's identity (→ editorid \"Name\"), resolved against the ACTIVE load order (the only identity frame — this file may itself be inactive). Display-only; the token is unchanged. A target the active order doesn't define is marked 'unresolved'. Forces the load-order build (opt-in), unlike the default cheap raw read.")]
             bool resolve_names = false,
+        [Description("Optional. 'text' (default) or 'json' — a machine-readable document (always stamped out_of_load_order:true; the file's masters context, then the record/records/type_counts payload). Field values are the SAME tokens as text.")]
+            string? format = null,
         [Description("Optional. Max characters before the response stops with an explicit notice. 0 = the server default (~80k).")]
             int max_chars = 0) => Guard.Tool("housecarl_read_plugin_file", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        bool json = Wire.WantsJson(format, out var ferr);
+        if (ferr is not null) return ferr;
         var outcome = svc.ReadPluginFile(plugin, formid, type, mod, fields, depth <= 0 ? 1 : depth, editorid_contains, limit <= 0 ? 500 : limit, resolve_names);
-        return Wire.RenderPluginFile(outcome, max_chars);
+        return json ? JsonWire.RenderPluginFile(outcome, max_chars) : Wire.RenderPluginFile(outcome, max_chars);
     });
 }
 

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -36,6 +36,8 @@ public static class ReadTools
             int depth = 1,
         [Description("When true, also return the ordered list of every plugin that touches this record (winner last) and the winner-relative field diff for each.")]
             bool conflict_tree = false,
+        [Description("When true, annotate every FormLink field value with its target's identity (→ editorid \"Name\"), resolved against the load order — so a Keywords/Template/DeathItem token reads as what it points AT, not just a FormID. Display-only: the token itself is unchanged (a write can still reuse it). A target no active plugin defines is marked 'unresolved'.")]
+            bool resolve_names = false,
         [Description("Optional. Max characters before the diff is cut with an explicit notice (never silent). 0 = the server default (~80k). Raise to see a very deep conflict tree in full.")]
             int max_chars = 0) => Guard.Tool("housecarl_read_record", () =>
     {
@@ -44,7 +46,7 @@ public static class ReadTools
         try { fk = FormKey.Factory(formid.Trim()); }
         catch (Exception ex) { return $"error: bad FormID '{formid}': {ex.Message}. Expected 'XXXXXX:Plugin.esp', e.g. '0F1AC1:Skyrim.esm'."; }
 
-        var outcome = svc.ResolveRead(fk, plugin?.Trim(), fields, conflict_tree, depth <= 0 ? 1 : depth);
+        var outcome = svc.ResolveRead(fk, plugin?.Trim(), fields, conflict_tree, depth <= 0 ? 1 : depth, resolve_names);
         return Wire.RenderRecord(svc, outcome, fields, conflict_tree, max_chars);
     });
 
@@ -66,12 +68,14 @@ public static class ReadTools
             int depth = 1,
         [Description("When true, include each record's touching-plugin list (winner last) + winner-relative field diff.")]
             bool conflict_tree = false,
+        [Description("When true, annotate every FormLink field value across every record with its target's identity (→ editorid \"Name\"), resolved against the load order and cached across the whole batch. Display-only: the token itself is unchanged. Unresolvable targets are marked.")]
+            bool resolve_names = false,
         [Description("Optional. Max characters before the response stops with an explicit 'rendered X of N' notice. 0 = the server default (~80k).")]
             int max_chars = 0) => Guard.Tool("housecarl_batch_record_detail", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         if (formids is null || formids.Length == 0) return "error: formids is empty. Pass one or more 'XXXXXX:Plugin.esp' FormIDs.";
-        var outcomes = svc.ResolveBatch(formids, fields, conflict_tree, depth <= 0 ? 1 : depth);
+        var outcomes = svc.ResolveBatch(formids, fields, conflict_tree, depth <= 0 ? 1 : depth, resolve_names);
         return Wire.RenderBatch(svc, outcomes, fields, conflict_tree, max_chars);
     });
 
@@ -114,6 +118,8 @@ public static class ReadTools
             string[]? fields = null,
         [Description("When true, include each match's touching-plugin list (winner last) + winner-relative field diff.")]
             bool conflict_tree = false,
+        [Description("When true (with fields=), annotate every FormLink field value with its target's identity (→ editorid \"Name\"), resolved against the load order and cached across all matches. Display-only; the token is unchanged. No effect on summary lines or group_by (there are no field tokens to annotate).")]
+            bool resolve_names = false,
         [Description("Optional. Max matches to return (default 500). The TRUE total is always reported; over the cap it says 'showing first N'.")]
             int limit = 500,
         [Description("Optional. Max characters before the response stops with an explicit notice. 0 = the server default (~80k).")]
@@ -135,7 +141,7 @@ public static class ReadTools
             if (list.Count > 0) refFks = list.Distinct().ToList();   // preserve input order, drop dupes
         }
         var outcome = svc.CrossQuery(type, refFks, editorid_contains, conflicts_only, plugins, where, limit <= 0 ? 500 : limit, defined_in, group_by);
-        return Wire.RenderCrossQuery(svc, outcome, fields, conflict_tree, max_chars);
+        return Wire.RenderCrossQuery(svc, outcome, fields, conflict_tree, max_chars, resolve_names);
     });
 
     [McpServerTool(Name = "housecarl_resolve", ReadOnly = true, Title = "Resolve FormIDs to their identity"),
@@ -285,11 +291,13 @@ public static class ReadTools
             string? editorid_contains = null,
         [Description("Optional. With type=: max rows to return (default 500). The TRUE total is always reported; over the cap it says 'showing first N'.")]
             int limit = 500,
+        [Description("Optional. With formid=: annotate every FormLink field value with its target's identity (→ editorid \"Name\"), resolved against the ACTIVE load order (the only identity frame — this file may itself be inactive). Display-only; the token is unchanged. A target the active order doesn't define is marked 'unresolved'. Forces the load-order build (opt-in), unlike the default cheap raw read.")]
+            bool resolve_names = false,
         [Description("Optional. Max characters before the response stops with an explicit notice. 0 = the server default (~80k).")]
             int max_chars = 0) => Guard.Tool("housecarl_read_plugin_file", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-        var outcome = svc.ReadPluginFile(plugin, formid, type, mod, fields, depth <= 0 ? 1 : depth, editorid_contains, limit <= 0 ? 500 : limit);
+        var outcome = svc.ReadPluginFile(plugin, formid, type, mod, fields, depth <= 0 ? 1 : depth, editorid_contains, limit <= 0 ? 500 : limit, resolve_names);
         return Wire.RenderPluginFile(outcome, max_chars);
     });
 }
@@ -392,12 +400,14 @@ static class Wire
     }
 
     // ---- housecarl_cross_plugin_query ---------------------------------------------------------------
-    public static string RenderCrossQuery(LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields, bool conflictTree, int maxChars)
+    public static string RenderCrossQuery(LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields, bool conflictTree, int maxChars,
+                                          bool resolveNames = false)
     {
         if (q.Error is not null) return "error: " + q.Error;
         int cap = Cap(maxChars);
         if (q.Groups is not null) return RenderCrossQueryGroups(q, cap);   // group_by= → a count table, not per-match lines
         bool detail = (fields is { Count: > 0 }) || conflictTree;          // expand matches, vs. one-line summaries
+        var linkMemo = resolveNames && detail ? new Dictionary<FormKey, ResolvedRef>() : null;   // P7: one link cache across all rendered matches
         var sb = new StringBuilder();
         sb.Append("cross_plugin_query: ").Append(q.Total).Append(q.Total == 1 ? " match" : " matches");
         if (q.ScopeLabel is not null) sb.Append(" DEFINED IN ").Append(q.ScopeLabel);   // P1: explicit scope — NOT the 'touches' default
@@ -420,7 +430,7 @@ static class Wire
             string? matches = q.MatchedTargets is { } mt && i < mt.Count ? mt[i] : null;   // multi-target references= un-merge
             if (detail)
             {
-                var o = svc.ResolveRead(fk, q.Sources is { } src ? src[i] : null, fields, conflictTree);   // display the body the scan filtered: scoped plugin under plugins=, else winner
+                var o = svc.ResolveRead(fk, q.Sources is { } src ? src[i] : null, fields, conflictTree, resolveNames: resolveNames, linkMemo: linkMemo);   // display the body the scan filtered: scoped plugin under plugins=, else winner
                 sb.Append('\n');
                 if (matches is not null) sb.Append("  ").Append(fk).Append("  matches=").Append(matches).Append('\n');
                 if (o.Error is not null) sb.Append(fk).Append(": error: ").Append(o.Error).Append('\n');
@@ -698,9 +708,18 @@ static class Wire
             var f = r.Fields[i];
             sb.Append("  ").Append(f.Path).Append(" = ").Append(f.HasValue ? f.Token : f.Note);
             if (f.Display is not null) sb.Append("   (").Append(f.Display).Append(')');   // display-only annotation (e.g. decoded biped slots) — never the round-trip token
+            if (f.Link is not null) sb.Append("   (").Append(LinkText(f.Link)).Append(')');   // resolve_names: target identity, DISPLAY-ONLY — never the round-trip token
             sb.Append('\n');
         }
     }
+
+    /// <summary>The resolve_names parenthetical (P7): a FormLink token's target identity as "→ editorid "Name"", or
+    /// "unresolved: not in the active order" for a dangling target (named, never dropped — Q3). DISPLAY-ONLY: this
+    /// is appended AFTER the round-trip token, never in place of it.</summary>
+    static string LinkText(ResolvedRef r) =>
+        !r.Resolved ? "unresolved: target not in the active order"
+        : string.IsNullOrEmpty(r.Name) ? $"→ {r.EditorId ?? "<no editorid>"}"
+        : $"→ {r.EditorId ?? "<no editorid>"} \"{r.Name}\"";
 
     /// <summary>The conflict tree: the ordered touching-plugin list, then (when >1 plugin touches) the
     /// winner-relative field diff — each other plugin's only-the-fields-that-differ, as `path=theirs (winner X)`.
@@ -844,6 +863,7 @@ static class Wire
                 var f = r.Fields[i];
                 sb.Append("  ").Append(f.Path).Append(" = ").Append(f.HasValue ? f.Token : f.Note);
                 if (f.Display is not null) sb.Append("   (").Append(f.Display).Append(')');   // display-only annotation (e.g. decoded biped slots) — never the round-trip token
+                if (f.Link is not null) sb.Append("   (").Append(LinkText(f.Link)).Append(')');   // resolve_names: target identity (resolved against the ACTIVE order), DISPLAY-ONLY
                 sb.Append('\n');
             }
         }

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -177,7 +177,7 @@ public static class ReadTools
             string[] formids,
         [Description("Optional. 'text' (default) — one compact identity line per FormID — or 'json' for a machine-readable document (one {formid,type,editorid,name,winner} row per input; a bad/absent input carries {formid,error}).")]
             string? format = null,
-        [Description("Optional. Max characters before the text response stops with an explicit notice. 0 = the server default (~80k). (JSON is bounded by the input count — each row is one small object.)")]
+        [Description("Optional. Max characters before the response stops with an explicit notice (text) or drops trailing rows with truncated=true (json). 0 = the server default (~80k).")]
             int max_chars = 0) => Guard.Tool("housecarl_resolve", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
@@ -185,7 +185,7 @@ public static class ReadTools
         bool json = Wire.WantsJson(format, out var ferr);
         if (ferr is not null) return ferr;
         var rows = svc.ResolveRefs(formids);
-        return json ? JsonWire.RenderResolve(rows) : Wire.RenderResolve(rows, max_chars);
+        return json ? JsonWire.RenderResolve(rows, max_chars) : Wire.RenderResolve(rows, max_chars);
     });
 
     [McpServerTool(Name = "housecarl_effect_chain", ReadOnly = true, Title = "Resolve an effect's carriers + magnitudes"),

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -138,6 +138,32 @@ public static class ReadTools
         return Wire.RenderCrossQuery(svc, outcome, fields, conflict_tree, max_chars);
     });
 
+    [McpServerTool(Name = "housecarl_resolve", ReadOnly = true, Title = "Resolve FormIDs to their identity"),
+     Description(
+         "Turn a batch of FormIDs into their load-order identity — for EACH: type, editorid, display name, and " +
+         "winning plugin — in ONE call. The bulk name-resolution primitive: where housecarl_batch_record_detail frames " +
+         "every record (fields, override depth, per-record header), this returns one compact identity line (or JSON " +
+         "row) per FormID and nothing else — the cheap way to label a list of material/perk/keyword FormIDs. Resolved " +
+         "in order; a bad or absent FormID yields a per-item error without failing the batch (never a silent drop — " +
+         "Q3). Winners only (the load-order-effective identity of each target). Deliberately minimal: no fields=, no " +
+         "depth, no conflict_tree — for those use housecarl_batch_record_detail. Does NOT modify anything.")]
+    public static string Resolve(
+        LoadOrderService svc,
+        [Description("The FormIDs to resolve, each 'XXXXXX:Plugin.esp'. Resolved in order; results are returned in the same order.")]
+            string[] formids,
+        [Description("Optional. 'text' (default) — one compact identity line per FormID — or 'json' for a machine-readable document (one {formid,type,editorid,name,winner} row per input; a bad/absent input carries {formid,error}).")]
+            string? format = null,
+        [Description("Optional. Max characters before the text response stops with an explicit notice. 0 = the server default (~80k). (JSON is bounded by the input count — each row is one small object.)")]
+            int max_chars = 0) => Guard.Tool("housecarl_resolve", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        if (formids is null || formids.Length == 0) return "error: formids is empty. Pass one or more 'XXXXXX:Plugin.esp' FormIDs.";
+        bool json = Wire.WantsJson(format, out var ferr);
+        if (ferr is not null) return ferr;
+        var rows = svc.ResolveRefs(formids);
+        return json ? JsonWire.RenderResolve(rows) : Wire.RenderResolve(rows, max_chars);
+    });
+
     [McpServerTool(Name = "housecarl_effect_chain", ReadOnly = true, Title = "Resolve an effect's carriers + magnitudes"),
      Description(
          "Given a MagicEffect (MGEF), return every Spell/Enchantment/Potion/Scroll/Ingredient (SPEL/ENCH/ALCH/SCRL/INGR) " +
@@ -286,6 +312,50 @@ static class Wire
     public const int ReadbackMaxChars = 24_000;
 
     static int Cap(int maxChars) => maxChars > 0 ? maxChars : DefaultMaxChars;
+
+    /// <summary>Parse the shared format= param (Wave 2 / P6): null/"text" ⇒ false (the default text render), "json" ⇒
+    /// true, anything else ⇒ false with a NAMED error in <paramref name="error"/> (never a silent fall-through to
+    /// text on a typo — Q3). Case/whitespace-insensitive.</summary>
+    public static bool WantsJson(string? format, out string? error)
+    {
+        error = null;
+        var f = format?.Trim();
+        if (string.IsNullOrEmpty(f) || f.Equals("text", StringComparison.OrdinalIgnoreCase)) return false;
+        if (f.Equals("json", StringComparison.OrdinalIgnoreCase)) return true;
+        error = $"error: format='{format}' is not recognized — use 'text' (the default) or 'json'.";
+        return false;
+    }
+
+    // ---- housecarl_resolve --------------------------------------------------------------------------
+    /// <summary>Render the bulk name-resolution result (housecarl_resolve — P3): one compact identity line per input
+    /// FormID (type/editorid/name/winner), or <c>error=</c> for a bad/absent input (per-item, the batch survives — Q3).
+    /// Budget-bounded with the same explicit cut the other reads use.</summary>
+    public static string RenderResolve(IReadOnlyList<ResolvedRef> rows, int maxChars)
+    {
+        int cap = Cap(maxChars);
+        var sb = new StringBuilder();
+        sb.Append("resolve: ").Append(rows.Count).Append(rows.Count == 1 ? " formid\n" : " formids\n");
+        for (int i = 0; i < rows.Count; i++)
+        {
+            if (sb.Length >= cap)
+            {
+                sb.Append("... [truncated: rendered ").Append(i).Append(" of ").Append(rows.Count)
+                  .Append(" at max_chars=").Append(cap).Append("; request fewer formids or raise max_chars]\n");
+                break;
+            }
+            var r = rows[i];
+            sb.Append("  ").Append(r.Token);
+            if (r.Resolved)
+            {
+                sb.Append("  type=").Append(r.Type).Append("  editorid=").Append(r.EditorId ?? "<none>");
+                if (!string.IsNullOrEmpty(r.Name)) sb.Append("  name=\"").Append(r.Name).Append('"');
+                sb.Append("  winner=").Append(r.Winner);
+            }
+            else sb.Append("  error=").Append(r.Error ?? "not present in the active order");
+            sb.Append('\n');
+        }
+        return sb.ToString().TrimEnd('\n');
+    }
 
     // ---- housecarl_read_record ----------------------------------------------------------------------
     public static string RenderRecord(LoadOrderService svc, ReadOutcome o, IReadOnlyList<string>? fields, bool conflictTree, int maxChars)

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -130,6 +130,8 @@ public static class ReadTools
             bool conflict_tree = false,
         [Description("When true (with fields=), annotate every FormLink field value with its target's identity (→ editorid \"Name\"), resolved against the load order and cached across all matches. Display-only; the token is unchanged. No effect on summary lines or group_by (there are no field tokens to annotate).")]
             bool resolve_names = false,
+        [Description("When true (with fields= under a plugins= scope), expand each match's fields from the load-order WINNER's body instead of the scoped plugin's OWN version. WITHOUT this, plugins=-scoped fields are that plugin's values (e.g. a defining esp's AR 38), NOT the live winner (AR 200) — a note names the source either way. No effect under type= scope (already the winner).")]
+            bool winner_fields = false,
         [Description("Optional. 'text' (default) or 'json' — a machine-readable document (group_by count table, detail record objects with fields, or summary rows), with total/capped/notes/truncated accounting in-band. conflict_tree is a text-only diff view.")]
             string? format = null,
         [Description("Optional. Max matches to return (default 500). The TRUE total is always reported; over the cap it says 'showing first N'.")]
@@ -156,8 +158,8 @@ public static class ReadTools
             if (list.Count > 0) refFks = list.Distinct().ToList();   // preserve input order, drop dupes
         }
         var outcome = svc.CrossQuery(type, refFks, editorid_contains, conflicts_only, plugins, where, limit <= 0 ? 500 : limit, defined_in, group_by);
-        return json ? JsonWire.RenderCrossQuery(svc, outcome, fields, max_chars, resolve_names)
-                    : Wire.RenderCrossQuery(svc, outcome, fields, conflict_tree, max_chars, resolve_names);
+        return json ? JsonWire.RenderCrossQuery(svc, outcome, fields, max_chars, resolve_names, winner_fields)
+                    : Wire.RenderCrossQuery(svc, outcome, fields, conflict_tree, max_chars, resolve_names, winner_fields);
     });
 
     [McpServerTool(Name = "housecarl_resolve", ReadOnly = true, Title = "Resolve FormIDs to their identity"),
@@ -421,13 +423,14 @@ static class Wire
 
     // ---- housecarl_cross_plugin_query ---------------------------------------------------------------
     public static string RenderCrossQuery(LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields, bool conflictTree, int maxChars,
-                                          bool resolveNames = false)
+                                          bool resolveNames = false, bool winnerFields = false)
     {
         if (q.Error is not null) return "error: " + q.Error;
         int cap = Cap(maxChars);
         if (q.Groups is not null) return RenderCrossQueryGroups(q, cap);   // group_by= → a count table, not per-match lines
         bool detail = (fields is { Count: > 0 }) || conflictTree;          // expand matches, vs. one-line summaries
         var linkMemo = resolveNames && detail ? new Dictionary<FormKey, ResolvedRef>() : null;   // P7: one link cache across all rendered matches
+        bool anyScoped = detail && q.Sources is { } ss && ss.Take(q.Keys.Count).Any(s => s is not null);   // P5: plugins= scope shows a plugin's OWN body
         var sb = new StringBuilder();
         sb.Append("cross_plugin_query: ").Append(q.Total).Append(q.Total == 1 ? " match" : " matches");
         if (q.ScopeLabel is not null) sb.Append(" DEFINED IN ").Append(q.ScopeLabel);   // P1: explicit scope — NOT the 'touches' default
@@ -435,6 +438,11 @@ static class Wire
         sb.Append('\n');
         if (q.PredicateNote is not null) sb.Append(q.PredicateNote).Append('\n');   // where= Q3 accounting (wrong-path/no-value surface)
         if (q.ScanNote is not null) sb.Append(q.ScanNote).Append('\n');             // unscannable-record Q3 accounting (Mutagen-unparseable content)
+        // P5: under a plugins= scope the per-match fields are the SCOPED plugin's OWN values, not the live winner's —
+        // the silent-wrong trap (a defining esp's AR 38 vs the winner's live AR 200). Name it loud, once (Q3).
+        if (anyScoped) sb.Append(winnerFields
+            ? "note: field values are the load-order WINNER's (winner_fields=true); each match was SELECTED on its scoped plugin's body.\n"
+            : "note: field values are each match's SCOPED plugin's OWN version, NOT the live load-order winner — pass winner_fields=true for load-order truth.\n");
 
         int rendered = 0;
         for (int i = 0; i < q.Keys.Count; i++)
@@ -450,7 +458,9 @@ static class Wire
             string? matches = q.MatchedTargets is { } mt && i < mt.Count ? mt[i] : null;   // multi-target references= un-merge
             if (detail)
             {
-                var o = svc.ResolveRead(fk, q.Sources is { } src ? src[i] : null, fields, conflictTree, resolveNames: resolveNames, linkMemo: linkMemo);   // display the body the scan filtered: scoped plugin under plugins=, else winner
+                // winner_fields=: read the load-order WINNER's body (source=null) regardless of scan scope; else the
+                // body the scan filtered (scoped plugin under plugins=, else winner) — so display never contradicts filter.
+                var o = svc.ResolveRead(fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, conflictTree, resolveNames: resolveNames, linkMemo: linkMemo);
                 sb.Append('\n');
                 if (matches is not null) sb.Append("  ").Append(fk).Append("  matches=").Append(matches).Append('\n');
                 if (o.Error is not null) sb.Append(fk).Append(": error: ").Append(o.Error).Append('\n');


### PR DESCRIPTION
Wave 2 of the **bulk-primitives** sub-project — the **output contract**. Implements PLAN.md P3/P5/P6/P7 as one wave (D2/D3 interact — the JSON DTO carries the resolve_names annotation shape from day one). All primitives **additive**; nothing existing breaks (default-false flags, `format` defaults to text).

## What lands

- **P3 — `housecarl_resolve`** (new read-only tool, 37 → 38): bulk FormID → identity (type/editorid/**display name**/winner), one compact line or JSON row per input. Reflection-generic `Name` read via Mutagen's `INamedGetter` aspect (no per-type wiring); per-item error isolation (bad/absent FormID never fails the batch).
- **P7 — `resolve_names=`** on read_record / batch_record_detail / cross_plugin_query(with fields=) / read_plugin_file: every FormLink field value annotated with its target's identity (`→ editorid "Name"`). **Display-only** — rides the `FieldValue.Link` channel (sibling to the biped-slot `Display`); the round-trip token is never replaced. Dangling target → named `unresolved`. Memoised per record and per batch.
- **P6 — `format="json"`** across read_record / batch_record_detail / cross_plugin_query / read_plugin_file (resolve got it in 2a): a new `JsonWire` serializer over the **same outcome objects** the text `Wire` consumes (D2 — one read path, two renders), so text/JSON can't diverge on data. Field values are the **identical wire tokens** text emits (round-trip parity). Q3 accounting (total/capped/notes[]/rendered/truncated) rides **in-band**; truncation drops rows/fields and flags it so the document is **always valid JSON**. resolve_names rides JSON as a structured `link:{resolved,type,editorid,name}` sibling. `conflict_tree=true`+`format=json` refused loud (text-only diff view).
- **P5 — `winner_fields=`** on cross_plugin_query (decision D1 — additive flag, **not** a default flip): under a `plugins=` scope, `fields=` render the scoped plugin's OWN values; `winner_fields=true` reads the load-order **winner's** body instead. Without it, a **loud note** names the values as the scoped plugin's own and points at `winner_fields=true` — closes the silent-wrong trap (a defining esp's AR 38 vs the winner's live AR 200) with zero break.

## Verification

- New self-contained guard `bulk-primitives-wave2-guard` (registered in `ci-all`): **44/44 PASS** — identity resolution, winner-is-the-override, per-item errors, token-unchanged-under-annotation, unresolved marking, JSON↔text token parity, DTO shape pin, Q3-notes survival, valid-JSON-under-tiny-max_chars, winner_fields body flip + scoped-values note.
- `read-plugin-file-guard` gains a JSON assertion.
- **Full `ci-all`: 90/90 PASS** (was 89/89; +1 = the new guard). Zero regressions.
- Independent review (high effort): **no correctness defects**. Two by-design items surfaced below.

## Reviewer notes (by-design, non-blocking)

1. **P5 adds a `note:` line to existing `plugins=`+`fields=` text output** — a sanctioned change to a shipped text surface (plan D1: "Loud, zero break"). Robust consumers already handle conditional note lines; flagged for visibility.
2. **read_plugin_file `resolve_names` resolves against the ACTIVE order** (the only identity frame houseCARL holds; the file itself may be inactive) — honestly marked, opt-in, documented at the call site. Surfaced so the active-order frame is a conscious choice.

## ⚠ Stale-server caveat (carry to the merge)
After this lands, the RUNNING MCP server serves the OLD read tools until rebuilt + re-pointed — the exact gap that produced a false report during Wave 1. Empirical live-order exercise of the new flags is Aaron's lane after packaging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)