### PR TITLE
feat(skills): bulk-primitives Wave 4 - bulk-record-jobs skill (D7, skill #13)

### DIFF
--- a/.claude/skills/bulk-record-jobs/SKILL.md
+++ b/.claude/skills/bulk-record-jobs/SKILL.md
@@ -1,0 +1,295 @@
+---
+name: bulk-record-jobs
+description: >-
+  Plan and run bulk record jobs over the Skyrim load order via houseCARL — catalogues, audits, item/recipe/link graphs, conflict surveys, and batch patch rebuilds: any job that turns MANY records into ONE structured deliverable. Routes per-record loops to the bulk primitives (defined_in= scope, list-valued references=, group_by= counts, winner_fields=, resolve_names=, format=json, housecarl_resolve, housecarl_diff_record, CopyFrom/composes= batch writes) and standardizes the deliverable on one canonical JSON shape instead of an invented schema. Use when the user wants a catalogue, index, spreadsheet, audit, or book of armors/weapons/NPCs/recipes/spells, asks what crafts or references what across plugins, who wins contested records, wants a compatibility patch rebuilt against a new mod version — and in ANY fan-out subagent task told to "extract X and return JSON/a table". Load this BEFORE the first query or the first line of an output schema — per-record loops and schema drift are locked in by the first call, not discovered at the end.
+---
+
+# Bulk Record Jobs
+
+## Overview
+
+A bulk record job is any task shaped "many records in, one structured deliverable out": a gear
+catalogue, a crafting-graph, a conflict survey, a whole-mod audit, a compatibility-patch rebuild,
+a fan-out extraction returning JSON. The houseCARL tool surface has one primitive for every loop
+these jobs used to improvise — this skill maps job shapes to those primitives, carries the few
+game-level conventions the binary format doesn't (what a crafting-station keyword means, how a
+temper recipe differs structurally from a craft recipe), and defines the one canonical deliverable
+shape so ten agents extracting in parallel produce one schema, not ten.
+
+Two costs dominate badly-planned bulk jobs, and both are locked in by the first call: per-record
+loops (a reverse lookup run 548 times instead of once; ~400 one-element list ops instead of ~40
+batched ones) and schema drift (each extractor inventing its own output encoding). Plan the calls
+and fix the output shape before touching a record.
+
+## First step — size the job, then fix the shape
+
+Before the first detail read:
+
+1. **Size the scope with a count, not a dump.** `group_by=` on `housecarl_cross_plugin_query`
+   aggregates ALL matches into a count table in one cheap call:
+
+   ```
+   housecarl_cross_plugin_query(type="ARMO", plugins=["SomeMod.esp"], group_by="defined_in")
+   ```
+
+   `group_by="winner"` opens a conflict survey ("who wins the contested records, by plugin");
+   `"type"` profiles a plugin's contents; `"defined_in"` splits definitions from overrides.
+   The counts tell you whether the job is 40 records or 4,000 before you commit to a per-row plan.
+
+2. **Write the deliverable schema down** (see "The canonical deliverable shape" below) before any
+   extraction starts — especially before handing work to subagents. The schema is the contract;
+   extraction fills it.
+
+## Scope truth — two flags that decide what your numbers mean
+
+These two are the proven silent-wrong traps of bulk work. Neither errors when missed; both
+corrupt the deliverable.
+
+- **`defined_in=true` — definitions, not touches.** `plugins=["X.esp"]` alone matches every
+  record X.esp *touches* — its own definitions AND its overrides of other plugins' records. A
+  catalogue scope ("the items this mod adds") means *defined in*. A replacer or patch plugin can
+  return dozens of matches on a bare `plugins=` scope, every one an override that double-counts
+  into your catalogue under the wrong mod. Pass `defined_in=true` whenever the question is "what
+  does this plugin add"; leave it off only when overrides are genuinely part of the question.
+
+- **`winner_fields=true` — live values, not the scoped plugin's era.** Under a `plugins=` scope,
+  `fields=` renders the *scoped plugin's own* version of each value — the defining esp's original
+  armor rating, not the number the game uses after later overrides. The output says so in a note,
+  but a bulk consumer that never reads notes ships plausible stats from the wrong era. For any
+  deliverable claiming live stats, pass `winner_fields=true`; the scoped-values default exists for
+  the other question ("what did THIS plugin set").
+
+## The loop-killer map
+
+Reach for the primitive, never the loop. Each row below was a real improvisation in a real fleet
+run before the primitive existed:
+
+| About to… | Use instead |
+|---|---|
+| Run `references=` once per target record | ONE call — `references=` takes a LIST (OR semantics; each match reports which target(s) it hit via `matches=`) |
+| Post-filter FormIDs by `:Plugin.esp` suffix | `defined_in=true` on the query |
+| Dump all matches and tally winners by hand | `group_by="winner"` (counts ALL matches, not capped by `limit=`) |
+| Read records one call each | `housecarl_batch_record_detail` with the whole FormID list |
+| Read full records just to label FormIDs with names | `housecarl_resolve` — one identity line per FormID (type, editorid, name, winner), per-item error isolation |
+| Maintain a FormID→name cache by hand | `resolve_names=true` on the read — every FormLink annotated inline, cached server-side across the batch |
+| Parse `path = token` text back into JSON | `format="json"` on the read/query — same tokens, stable document, accounting in-band |
+| Read two plugin versions and subtract by hand | `housecarl_diff_record(formid, plugin_a, plugin_b)` — either side may be an on-disk, not-enabled plugin |
+| Re-type another version's field values into ops | `verb:"CopyFrom"` with `from_plugin=` in `housecarl_bulk_apply` — transplants the field, source may be off-order |
+| Add list elements one op at a time | `composes=[...]` — one op appends N elements (`verb:"Add"`) or replaces the whole list (`verb:"ReplaceAll"`; `composes=[]` clears it) |
+
+## Recipe: the catalogue
+
+"Enumerate everything of type T that mod set S adds, with live stats and resolved names."
+
+1. **Size**: `group_by="defined_in"` over the scope (First step).
+2. **Enumerate + flat fields in one pass** (scalar fields only — Name, ArmorRating, weights…):
+
+   ```
+   housecarl_cross_plugin_query(
+       type="ARMO", plugins=["ModA.esp", "ModB.esp"], defined_in=true,
+       fields=["Name", "ArmorRating"], winner_fields=true, format="json")
+   ```
+
+3. **Expand list-bearing rows in a second, batched pass.** `housecarl_cross_plugin_query` has no
+   `depth=` — a list field renders as a count note (`[list: 5 item(s)]`). Feed the enumerated
+   FormIDs to `housecarl_batch_record_detail` with `depth=2`, `resolve_names=true`,
+   `format="json"`: each list element comes back indexed (`Keywords[0]`…) with a structured
+   `link` sibling (`{resolved, type, editorid, name}`) beside the raw token.
+4. **Respect the accounting.** Every JSON document carries `total` / `rendered` / `capped` /
+   `truncated` / `notes` in-band. `capped=true` means raise `limit=` or page by narrowing scope —
+   never ship a deliverable whose `total` exceeds its row count without saying so.
+
+## Recipe: the link graph
+
+"For each record, what points at it / what does it point at, as names not hex." Works for any
+link-shaped question — crafting recipes, outfits, leveled lists, dialogue — because the reflection
+layer knows every FormLink on every type. One graph level = two batched calls:
+
+1. **Reverse edge** (who points at these?): `references=[...]` with the whole target list, bounded
+   by `type=` — e.g. every recipe involving a list of items is ONE call with `type="COBJ"`.
+2. **Contents + identity**: `housecarl_batch_record_detail` on the matches, `depth=` deep enough
+   for the paths you need, `resolve_names=true` so every link is labeled inline.
+
+Worked example — the crafting graph for one weapon (verified live; vanilla data):
+
+```
+housecarl_cross_plugin_query(type="COBJ", references=["012EB7:Skyrim.esm"])
+→ TemperWeaponIronSword, RecipeWeaponIronSword, … (every recipe touching Iron Sword, one scan)
+
+housecarl_batch_record_detail(
+    formids=[…those COBJs…], depth=5, resolve_names=true, format="json",
+    fields=["EditorID", "Items", "WorkbenchKeyword", "CreatedObject", "CreatedObjectCount", "Conditions"])
+```
+
+The load-bearing COBJ paths (only visible at depth ≥ 4–5):
+
+- materials: `Items[i].Item.Item` (the ingredient link) + `Items[i].Item.Count`
+- station: `WorkbenchKeyword` (a Keyword link — see conventions below)
+- product: `CreatedObject` + `CreatedObjectCount`
+- gates: `Conditions[i].Data.Function` names the condition kind; `Conditions[i].Data.Perk`
+  carries the perk link when the function is `HasPerk`
+
+`resolve_names` annotations resolve against the **live load order**: reading a vanilla body on a
+modded order can label a link with a mod's renamed identity for that FormID. That's the truthful
+in-game identity — but if the deliverable documents the *original* plugin's era, resolve names
+from that era's values instead of assuming the annotation matches the source.
+
+## Crafting-station conventions (what the format doesn't say)
+
+The binary format stores `WorkbenchKeyword` as just a Keyword link; which station it is and what
+the recipe *means* there is Creation-Kit convention:
+
+- **Enumerate stations from data, don't hardcode**: crafting-station keywords are vanilla KYWD
+  records — `housecarl_cross_plugin_query(type="KYWD", editorid_contains="Crafting",
+  plugins=["Skyrim.esm"], defined_in=true)` lists them live (forge, skyforge, sharpening wheel,
+  armor table, smelter, tanning rack, cookpot…). Ignore the `WICrafting*` ones — those are
+  radiant-story event keywords, not stations. Mods add their own station keywords; the same query
+  without the plugin scope finds them.
+- **Craft vs temper is structural, not naming.** A *craft* recipe (forge/smelter/tanning/cookpot):
+  `CreatedObject` = the item produced from the materials. A *temper* recipe (sharpening wheel for
+  weapons, armor table for armor): `CreatedObject` = the very item being *improved*, count 1, and
+  the canonical vanilla condition pair is `EPTemperingItemIsEnchanted != 1` (OR-flagged) +
+  `HasPerk(<arcane-smithing-class perk>)`. Classify by `WorkbenchKeyword` + this shape.
+- **Conventions are conventions — the data can be dirty.** Vanilla itself ships
+  `TemperWeaponSkyforgeBow` whose `CreatedObject` is a *battleaxe*. Classify from the fields you
+  read, and let an EditorID that disagrees with the structure raise a flag in the deliverable
+  rather than win the argument.
+- **A recipe that appears at no station** (null/odd `WorkbenchKeyword`, or gated by an
+  impossible condition) is a common *mod-specific* disablement idiom — whose meaning belongs to
+  that mod's own skill lane, not here. Report the structure; don't guess the intent.
+
+## Recipe: the patch rebuild
+
+"Re-derive an old compatibility patch against a new version of its target mod." The job is
+delta-analysis then batched re-application; the old patch is usually *disabled*, which is fine —
+the diff and copy primitives read on-disk plugins that aren't in the load order.
+
+1. **Survey the contest**: `group_by="winner"` over the target mod's records — one call says how
+   much of the mod is contested and by whom.
+2. **Extract the old delta per record**: `housecarl_diff_record(formid, plugin_a="OldPatch.esp",
+   plugin_b="TargetMod.esp")` — field-level deltas, each labeled by plugin_b's name; `fields=`
+   scopes the comparison; a truncated read reports itself rather than claiming "identical".
+3. **Forward the new baseline** (`housecarl_forward_record`), then **re-apply the still-valid
+   deltas** with `housecarl_bulk_apply into=` on the forwarded copies — ops target the patch's
+   own already-forwarded body, not the stale winner (the forward-then-edit precedence both tools'
+   docs state).
+4. **Batch the re-application**: whole-field transplants use `verb:"CopyFrom"` +
+   `from_plugin="OldPatch.esp"` (works from a disabled plugin on disk); list rebuilds use
+   `composes=[...]` — N perk placements in one op, `ReplaceAll` + `composes` to rebuild a modeled
+   list wholesale, `ReplaceAll` + `composes=[]` to empty it. All-or-nothing per call: one bad
+   element refuses the whole call with per-element reasons.
+5. **Verify before enabling**: `housecarl_check_errors` and `housecarl_compact_plugin` accept the
+   not-yet-enabled patch; `housecarl_diff_record` with the new patch as a pole confirms the
+   deltas landed.
+
+## Recipe: the fan-out
+
+When the job fans out to subagents, schema drift is the failure mode — N agents told "extract X,
+return JSON" will invent N schemas unless the orchestrator pins one. In every subagent prompt:
+
+- **Hand the agent the deliverable schema** (below), filled with the job's field list — not a
+  prose description of it. Agents hardwire against what you show them.
+- Name the exact calls: the scope flags (`defined_in`, `winner_fields`), `format="json"`,
+  `resolve_names=true`, and the field paths with their depths. A recipe the orchestrator verified
+  once beats eight agents re-deriving it.
+- Require the accounting fields in each agent's return, so a truncated extraction surfaces at
+  merge time instead of shipping silently incomplete.
+
+## The canonical deliverable shape
+
+One blessed shape for "many records → one document". Use it as the return contract for subagents
+and the final deliverable alike; add job-specific keys rather than restructuring.
+
+```json
+{
+  "job": "one line: what this deliverable is",
+  "scope": {"type": "ARMO", "plugins": ["ModA.esp"], "defined_in": true, "winner_fields": true},
+  "total": 548,
+  "complete": true,
+  "notes": ["tool notes + job caveats carried here, never dropped"],
+  "records": [
+    {
+      "formid": "012EB7:Skyrim.esm",
+      "type": "Weapon",
+      "editorid": "IronSword",
+      "name": "Iron Sword",
+      "winner": "SomePlugin.esp",
+      "fields": {"ArmorRating": "135"}
+    }
+  ]
+}
+```
+
+The rules that make it a contract:
+
+- **`formid` is the full wire token** (`XXXXXX:Plugin.esp`), verbatim from tool output — never
+  bare hex (collides across plugins), never reformatted (a token read is a token a write can reuse).
+- **Identity is four keys**: `type`, `editorid`, `name`, `winner` — straight from
+  `housecarl_resolve` / the read header. `name` is `null` where the type has none; don't substitute
+  the editorid.
+- **A resolved link is an object, not a replacement**: `{"formid": "…", "editorid": "…",
+  "name": "…"}` — keep the token AND the identity; a name-only column can't be queried again.
+- **Field values are wire tokens verbatim.** Reformatting (unit conversion, rounding, splitting)
+  happens in a separate presentation layer, never in the extraction rows.
+- **Accounting is mandatory**: `total` (true match count), `complete` (every row present?), and
+  `notes` travel with the document. A partial deliverable that says so is fine; one that doesn't
+  is a silent wrong answer.
+- **Closed enums for classifications**, declared in the deliverable (e.g. a recipe `kind` of
+  `craft` / `temper` / `other`) — free-text classification is where eight agents drift eight ways.
+
+For crafting-graph jobs specifically, the blessed per-recipe entry:
+
+```json
+{
+  "recipe": "0DA769:Skyrim.esm",
+  "kind": "craft",
+  "station": "CraftingSmithingForge",
+  "creates": {"formid": "012EB7:Skyrim.esm", "editorid": "IronSword", "name": "Iron Sword", "count": 1},
+  "materials": [{"formid": "05ACE4:Skyrim.esm", "editorid": "IngotIron", "name": "Iron Ingot", "count": 2}],
+  "requires_perks": [{"formid": "…", "editorid": "…", "name": "…"}],
+  "other_conditions": 1
+}
+```
+
+## Common mistakes
+
+- **Looping a primitive that takes a list.** `references=`, `housecarl_resolve`,
+  `housecarl_batch_record_detail`, `composes=` — all batch. The single-item call in a loop is
+  the old world.
+- **Shipping scoped values as live stats.** The `plugins=` + `fields=` default renders that
+  plugin's own era; a catalogue built without `winner_fields=true` is plausibly-wrong everywhere
+  a later plugin rebalanced.
+- **Counting overrides as content.** A bare `plugins=` scope on a patch/replacer returns
+  overrides; without `defined_in=true` they double-count into the catalogue under the wrong mod.
+- **Parsing text output when `format="json"` exists.** Hand-parsing is where schema variance
+  creeps in; the JSON document carries the same tokens plus the accounting.
+- **Dropping the accounting.** `capped`, `truncated`, `rendered < total`, and `notes` exist to be
+  propagated. A deliverable that silently ignores them claims completeness it doesn't have.
+- **Trusting names over structure.** EditorIDs and display names are conventions; classify from
+  fields (station keyword, `CreatedObject` relationship, condition functions) and flag
+  disagreements — vanilla itself contains miswired records.
+- **Re-typing what `CopyFrom` can transplant.** Reading a value out of one plugin and composing it
+  back by hand re-introduces transcription risk the primitive exists to remove.
+
+## Sub-topic routing
+
+| The question is really… | Go to |
+|---|---|
+| "What fields does record type X have / what are the legal enum values?" | `mutagen-reference` |
+| "Which armors sit on biped slot N?" | `biped-slot-reference` |
+| What a specific mod's keywords/conventions *mean* (any per-mod semantics) | that mod's own skill lane (e.g. a Requiem companion skill), never encoded here |
+| One record to read or edit | the tools directly — no bulk planning needed |
+| Distributing spells/keywords/items at runtime instead of cataloguing them | `spid-authoring` / `kid-authoring` / `skypatcher-authoring` |
+
+## Notes
+
+- `housecarl_cross_plugin_query` has no `depth=` — list expansion always goes through
+  `housecarl_batch_record_detail` (or `housecarl_read_record` for one record). Budget the second
+  call into any list-bearing catalogue plan.
+- `where=` accepts FormLink equality against a wire token (e.g.
+  `"WorkbenchKeyword = 088108:Skyrim.esm"`) — a station filter is one predicate, no post-filtering.
+- Off-order (disabled, on-disk) plugins are first-class poles for `housecarl_diff_record`,
+  sources for `CopyFrom`, and targets for `housecarl_read_plugin_file` / `housecarl_check_errors`
+  / `housecarl_compact_plugin` — "the old patch is disabled" blocks nothing.
+- Aggregation (`group_by=`) counts ALL matches regardless of `limit=`; only row *rendering* is
+  capped. Use counts freely for sizing.

--- a/.claude/skills/bulk-record-jobs/SKILL.md
+++ b/.claude/skills/bulk-record-jobs/SKILL.md
@@ -203,7 +203,7 @@ and the final deliverable alike; add job-specific keys rather than restructuring
 ```json
 {
   "job": "one line: what this deliverable is",
-  "scope": {"type": "ARMO", "plugins": ["ModA.esp"], "defined_in": true, "winner_fields": true},
+  "scope": {"type": "WEAP", "plugins": ["ModA.esp"], "defined_in": true, "winner_fields": true},
   "total": 548,
   "complete": true,
   "notes": ["tool notes + job caveats carried here, never dropped"],
@@ -214,7 +214,7 @@ and the final deliverable alike; add job-specific keys rather than restructuring
       "editorid": "IronSword",
       "name": "Iron Sword",
       "winner": "SomePlugin.esp",
-      "fields": {"ArmorRating": "135"}
+      "fields": {"Damage": "7"}
     }
   ]
 }

--- a/.claude/skills/bulk-record-jobs/evals/eval_results_2026-07-15.md
+++ b/.claude/skills/bulk-record-jobs/evals/eval_results_2026-07-15.md
@@ -1,0 +1,23 @@
+# bulk-record-jobs — trigger fan-out results (2026-07-15)
+
+Method: HOUSECARL_SKILL_AUTHORING §6.5 — one fresh-context agent per query, anonymized
+capability statement (no skill name, no tool names), pure relevance question, adjudicated from
+each agent's REASONING (not the bare verdict token). Eval set: `eval_set.json` (9 should-trigger,
+10 should-not-trigger near-misses).
+
+## Scores (description as shipped in this PR)
+
+- **Recall: 9/9 = 100%** (threshold ≥ 80%) — all catalogue / conflict-survey / patch-rebuild /
+  fan-out / JSON-extraction phrasings judged in-scope with correct reasoning, including the
+  casual/typo variant and the subagent-orchestration phrasing.
+- **Specificity: 9/10 = 90%** (threshold ≥ 50%).
+
+## The one miss
+
+"Which armors sit on biped slot 52 in my load order?" fired (expected quiet — `biped-slot-reference`'s
+lane). The judging agent's reasoning was honest: the request IS many-records → one-list, so it
+pattern-matches the capability. Accepted per the asymmetric-cost rule (§3.3: over-trigger wastes
+~100 words; under-trigger loses the session) — and the skill body's Sub-topic routing table hands
+the slot question to `biped-slot-reference` on load, so the cost of the false fire is one hop.
+
+Re-measure on any description change (§6.5 step 6).

--- a/.claude/skills/bulk-record-jobs/evals/eval_set.json
+++ b/.claude/skills/bulk-record-jobs/evals/eval_set.json
@@ -1,0 +1,21 @@
+[
+  {"query": "Build me a catalogue of every piece of armour the exotic armour plugins add — name, armor rating, slots, and how you craft each one. I want it as a spreadsheet eventually.", "should_trigger": true},
+  {"query": "which mods win the contested Apocalypse spell records? there are like 800 of them, i just want a breakdown by plugin", "should_trigger": true},
+  {"query": "I need to rebuild the old Requiem-Apocalypse patch against Apocalypse 10.2.3 — the old patch is disabled in MO2 but still on disk. Figure out what deltas it applied and re-apply the still-valid ones onto the new baseline.", "should_trigger": true},
+  {"query": "Extract every weapon defined in Heavy Armory.esp with its damage, reach, speed and material keywords, and return the results as JSON rows.", "should_trigger": true},
+  {"query": "can you list all the smithing recipes that use ebony ingots across my whole load order and which perks gate them", "should_trigger": true},
+  {"query": "Aaron wants an in-game book listing every craftable jewelry piece with materials and stations - can you pull that data together?", "should_trigger": true},
+  {"query": "audit Immersive Weapons for me - what does it actually add vs just override, and are its stats still live after all my patches?", "should_trigger": true},
+  {"query": "I'm fanning this out to 6 subagents, each takes a plugin group and extracts the NPC data. What should I tell them so the outputs merge cleanly?", "should_trigger": true},
+  {"query": "make me a table of all requiem heavy armors w/ live AR values, the ones in the esp are stale i think", "should_trigger": true},
+  {"query": "What fields does the COBJ record type have? Is WorkbenchKeyword writable?", "should_trigger": false},
+  {"query": "Why does my character's face turn grey when I install this NPC replacer mod?", "should_trigger": false},
+  {"query": "Change the damage on Chillrend to 25 in a new patch plugin", "should_trigger": false},
+  {"query": "Write a SPID ini that distributes this cloak spell to all bandit NPCs", "should_trigger": false},
+  {"query": "Which armors sit on biped slot 52 in my load order?", "should_trigger": false},
+  {"query": "What does REQ_DisableRecipe mean when it's the workbench keyword on a recipe record?", "should_trigger": false},
+  {"query": "My game CTDs when I open the smithing menu at the forge, can you check the crash logs?", "should_trigger": false},
+  {"query": "read me the stats of the iron sword real quick", "should_trigger": false},
+  {"query": "Compact my new patch plugin to ESL and run the error check on it", "should_trigger": false},
+  {"query": "what changed between the two versions of this one perk record, 0A1B2C in the old esp vs the new one?", "should_trigger": false}
+]

--- a/scripts/build-plugin.ps1
+++ b/scripts/build-plugin.ps1
@@ -47,8 +47,8 @@ $PackagingSrc = Join-Path $RepoRoot 'packaging'        # tracked source for pack
 $ReleaseDir   = Join-Path $RepoRoot 'release'          # output dir for the shippable zip (gitignored)
 $PluginManifest = Join-Path $PluginSrc '.claude-plugin\plugin.json'   # single source of truth for the version
 
-# the 12 shipped skills (the modlist-authoring cluster was removed; tool-surface skills wait)
-$Skills = @('mutagen-reference','papyrus-reference','skypatcher-authoring','spid-authoring','kid-authoring','papyrus-optimization','facegen-diagnostics','dialogue-authoring','oar-authoring','tool-output-awareness','biped-slot-reference','skse-plugin-authoring')
+# the 13 shipped skills (the modlist-authoring cluster was removed; tool-surface skills wait)
+$Skills = @('mutagen-reference','papyrus-reference','skypatcher-authoring','spid-authoring','kid-authoring','papyrus-optimization','facegen-diagnostics','dialogue-authoring','oar-authoring','tool-output-awareness','biped-slot-reference','skse-plugin-authoring','bulk-record-jobs')
 
 function Step($n,$msg) { Write-Host "`n=== [$n] $msg ===" -ForegroundColor Cyan }
 

--- a/scripts/build-plugin.ps1
+++ b/scripts/build-plugin.ps1
@@ -91,7 +91,7 @@ Get-ChildItem $ServerDir -Filter 'appsettings*.json' -ErrorAction SilentlyContin
 Step '3/10' 'Copy corpus.json beside the exe'
 Copy-Item $CorpusSrc (Join-Path $ServerDir 'corpus.json') -Force
 
-# ---- 4. bundle the 12 skills (exclude evals/ + _CORPUS_STATUS.md; KEEP all .jsonl) ----
+# ---- 4. bundle the 13 skills (exclude evals/ + _CORPUS_STATUS.md; KEEP all .jsonl) ----
 Step '4/10' 'Bundle skills'
 New-Item -ItemType Directory -Path $SkillsDir -Force | Out-Null
 foreach ($s in $Skills) {


### PR DESCRIPTION
## What

**Wave 4 of the bulk-primitives sub-project — the last piece.** One new bundled skill, `bulk-record-jobs` (13th in the set), the game-generic understanding layer on top of the Wave 1–3 primitives (P1–P8c). No server code changes; the only code touch is registering the skill in `scripts/build-plugin.ps1` (`$Skills`, 12 → 13).

**Proposed slug: `bulk-record-jobs`** — kebab, ≤30 chars, topic-based per HOUSECARL_NAMING §5. Aaron confirms or renames at review (a rename is a folder + `name:` + build-script three-liner).

## What the skill carries (and what it refuses to)

Every fact was run through the D7 three-gate sieve (Aaron-ruled 2026-07-14):

- **IN — query recipes**: the catalogue, link-graph, patch-rebuild, and fan-out job shapes, each rewritten against the shipped surface and **verified live on the ARR 2.0 order this session** (exact calls, depths, field paths — COBJ materials at `Items[i].Item.Item`/`.Count`, perk gates at `Conditions[i].Data.Perk`).
- **IN — CK structural conventions** the binary format doesn't carry: crafting-station keyword meaning, craft-vs-temper classification (verified against the 158-recipe vanilla temper sweep; includes the vanilla `TemperWeaponSkyforgeBow`→battleaxe miswire as the "trust structure, not names" example).
- **IN — the canonical deliverable shape**: the blessed many-records→one-document JSON contract on top of the P6 wire (wire-token formids, identity quads, link objects, mandatory accounting, closed enums) — the schema-drift killer from the two source reports.
- **OUT — anything reflection derives** (routed to `mutagen-reference`) and **all mod-specific conventions** (routed to the mod's own skill lane; `REQ_*` appears nowhere in the skill).

## Firing design (settled with Aaron 2026-07-15)

Fires on "many records → one structured deliverable" BEFORE the first call — catalogues, graph questions, bulk patch rebuilds, and ANY fan-out subagent told to "extract X and return JSON/a table". Quiet on single-record work, schema questions, mod-specific interpretation.

## Trigger fan-out (the gate for a skill wave — no ci-all probe)

Per HOUSECARL_SKILL_AUTHORING §6.5: 19 fresh-context agents, anonymized capability statement, adjudicated from reasoning. **Recall 9/9 (100%), specificity 9/10 (90%)** — both thresholds pass. The one false fire is the biped-slot near-miss ("armors on slot 52"), accepted per the asymmetric-cost rule; the body's routing table hands it to `biped-slot-reference` on load. Eval set + results archived under `evals/` (pruned from the shipped package by the build script).

## Reviewer notes (surfaced, not silent)

1. **A small Q3-flavored doc bug found while verifying (NOT fixed here — out of scope for a skill wave):** `housecarl_cross_plugin_query`'s list-field note says "pass depth=2 to expand", but the tool has no `depth=` parameter (the unknown-param refusal correctly rejects it). The note text is shared with the read tools that do have `depth=`. The skill documents the correct two-step (enumerate → `batch_record_detail depth=2`); the note wants a follow-up fix.
2. **D3 evidence log (for the deferred `expand_links=N`):** post-waves-1–3, one graph level = two batched calls (reverse `references=` list → `batch_record_detail`), and list expansion under a query = the same second call. Neither was painful at catalogue scale this session — no flip evidence found; D3 deferral stands.
3. The description's word/char budget: 152 words / 1,054 chars (cap 1,536).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
