### PR TITLE
fix(skypatcher): bracket-label + skin-donor reader honesty; merge README wording (#180/#181/#182)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ models — by construction, not a hand-maintained subset.
   new-patch lane above stays the default.
 - **Compact and merge plugins** — ESL-compact a plugin into the light-master FormID window, carrying its
   FormID-keyed assets (facegen, voice) along so a compacted mod's faces don't go dark; or merge several
-  plugins into one, renumbering only on collision and dropping now-unused masters — with the donor mods
-  swapped out at the MO2 layer, originals intact.
+  plugins into one, renumbering only on collision and dropping now-unused masters — then guides the MO2
+  swap: enable the merged output, deactivate the donor plugins, and keep their asset folders enabled;
+  originals remain intact.
 - **Copy an NPC's appearance into a standalone** — lift a face (head parts, tints, the FaceGen mesh and
   textures) from a donor NPC into a fresh record that carries no dependency on the donor's plugin — the
   build behind a portable follower or a face transplanted between mods.

--- a/src/housecarl-core/SkyPatcherFieldMap.cs
+++ b/src/housecarl-core/SkyPatcherFieldMap.cs
@@ -222,6 +222,7 @@ public sealed class SkyPatcherFieldMap
             SourcePath: OptStr(el, "sourcePath"),
             Flag: OptStr(el, "flag"),
             FormType: OptStr(el, "formType"),
+            DonorType: OptStr(el, "donorType"),
             EqPacked: el.TryGetProperty("pack", out var pk) && pk.ValueKind == JsonValueKind.String && pk.GetString() == "eq",
             ValueMap: valueMap,
             Element: element,
@@ -407,7 +408,13 @@ public sealed record FilterSpec(
 }
 
 /// <summary>One operation's mapping. <see cref="Unmapped"/> non-null ⇒ the op is EXPLICITLY not
-/// modelable, with the reason the overlay surfaces loud (all other members are then unset).</summary>
+/// modelable, with the reason the overlay surfaces loud (all other members are then unset).
+/// <para><see cref="DonorType"/> (optional) names a SECOND record kind the op's value may legitimately be
+/// — the runtime "copy from a donor of type X" reading of an otherwise form-valued op. NPC <c>skin</c> is
+/// the case: <c>skin=&lt;Armor&gt;</c> sets WornArmor directly, but the NPC-Replacer-Converter shape
+/// <c>skin=&lt;donor NPC&gt;</c> copies that NPC's worn armor at load. When the value fails to resolve as
+/// <see cref="FormType"/> but DOES resolve as DonorType, the overlay names it an unmodeled donor-copy
+/// (like copyVisualStyle) instead of throwing a malformed-FormKey — issue #181.</para></summary>
 public sealed record OpMap(
     SkyPatcherOpSemantic Semantic,
     string Path,
@@ -415,6 +422,7 @@ public sealed record OpMap(
     string? SourcePath,
     string? Flag,
     string? FormType,
+    string? DonorType,
     bool EqPacked,
     IReadOnlyDictionary<string, string>? ValueMap,
     ElementMap? Element,
@@ -423,7 +431,7 @@ public sealed record OpMap(
     string? Unmapped)
 {
     internal static OpMap MakeUnmapped(string reason)
-        => new(SkyPatcherOpSemantic.Set, "", null, null, null, null, false, null, null, null, null, reason);
+        => new(SkyPatcherOpSemantic.Set, "", null, null, null, null, null, false, null, null, null, null, reason);
     /// <summary>True when this op is explicitly declared un-modelable (loud in the overlay).</summary>
     public bool IsUnmapped => Unmapped is not null;
 }

--- a/src/housecarl-core/SkyPatcherOverlay.cs
+++ b/src/housecarl-core/SkyPatcherOverlay.cs
@@ -1162,8 +1162,32 @@ public static class SkyPatcherOverlay
         if (v.IsNameLiteral) token = v.NameText!;                       // rename literal, wrapper stripped
         else if (v.Address is { IsFormId: true } a && TryFormKey(a, out var fk1)) token = fk1.ToString();
         else if (map.ValueMap is { } vm && vm.TryGetValue(v.Raw, out var mapped)) token = mapped;
-        else if (map.FormType is not null && ResolveFormValue(v, map.FormType, resolver) is { } rk) token = rk.ToString();
-        else token = v.Raw;                                             // scalar / enum member (ignore-case coercion downstream)
+        else if (map.FormType is not null)
+        {
+            // A form-valued target: the value MUST resolve to a form. A bare non-form string must NOT fall
+            // through to the engine as a raw FormKey — that throws "Malformed FormKey" and mislabels a
+            // VALID INI as broken (issue #181, Q3). The real-world case is an NPC-replacer's
+            // 'skin=<donor NPC EditorID>', where the value is an NPC, not the Armor the field expects.
+            if (ResolveFormValue(v, map.FormType, resolver) is { } rk) token = rk.ToString();
+            else
+            {
+                // Didn't resolve as FormType. If the op declares a donor kind (NPC skin's donorType=Npc)
+                // and the value DOES resolve as that kind, it is a runtime donor-copy the static model
+                // doesn't cover ('skin=<donor NPC>' copies the donor's worn armor at load — like
+                // copyVisualStyle): name it honestly. Otherwise the form is genuinely missing/typo'd —
+                // loud, named. Either path: never a thrown malformed-FormKey.
+                if (map.DonorType is { } dt && v.Address is not { IsFormId: true }
+                    && resolver.ResolveEditorId(v.Raw, dt) is not null)
+                    warnings.Add($"{where}: '{opKey}={v.Raw}' — '{v.Raw}' is a {dt}, not a {map.FormType}. " +
+                        $"'{opKey}=<donor {dt}>' copies the donor's {map.Path} at runtime — a donor-copy houseCARL does not " +
+                        $"statically model (like copyVisualStyle); the INI line is valid, but its post-state is NOT computed here.");
+                else
+                    warnings.Add($"{where}: '{opKey}={v.Raw}' — does not resolve to a {map.FormType} in the active order; " +
+                        $"not applied (named gap, never a malformed-form guess).");
+                return;
+            }
+        }
+        else token = v.Raw;                                             // scalar / enum member on a non-form field (ignore-case coercion downstream)
 
         WriteEngine.ApplyVerb(record, new WriteRequest { RecordType = fieldMap.RecordType, Path = segs, Verb = "Set", Value = token });
         applied.Add(new SkyPatcherAppliedOp(line.File, line.LineNumber, opKey, v.Raw, map.Path, before, LeafToken(record, segs), map.Note));

--- a/src/housecarl-core/SkyPatcherParse.cs
+++ b/src/housecarl-core/SkyPatcherParse.cs
@@ -64,6 +64,16 @@ public static class SkyPatcherParse
         if (trimmed[0] == ';')
             return new SkyPatcherLine(raw, SkyPatcherLineKind.Comment, Array.Empty<SkyPatcherSegment>(), null);
 
+        // An INI-style section/label line — a trimmed line wrapped in '[' … ']' (e.g. a converter's
+        // '[Vernaccus]' human label above the real lines). It carries no key=value segment and cannot
+        // target or mutate a record, so it is INERT — no segments, no note. Without this it parsed as a
+        // malformed no-'=' Patch, and the overlay then warned it as a possible unresolved filter AND
+        // counted it (issue #180). A real patch line always leads with a key, never '[', so the whole-line
+        // bracket wrap is an unambiguous label. Every downstream consumer keys off Patch, so a Label line
+        // is skipped and uncounted everywhere, and its physical position is preserved for later real lines.
+        if (trimmed.Length >= 2 && trimmed[0] == '[' && trimmed[^1] == ']')
+            return new SkyPatcherLine(raw, SkyPatcherLineKind.Label, Array.Empty<SkyPatcherSegment>(), null);
+
         var segments = new List<SkyPatcherSegment>();
         string? note = null;
 
@@ -192,6 +202,11 @@ public enum SkyPatcherLineKind
     Comment,
     /// <summary>A patch line (one or more key=value segments).</summary>
     Patch,
+    /// <summary>An INI-style section/label line — a trimmed line wrapped in '[' … ']' (e.g. a converter's
+    /// '[NpcName]' human label). INERT: it carries no key=value operation, so it holds no segments and no
+    /// note, and every consumer (which all key off <see cref="Patch"/>) skips it — it is neither a patch
+    /// line nor a malformed one (issue #180). Appended last so the earlier members keep their ordinals.</summary>
+    Label,
 }
 
 /// <summary>One parsed SkyPatcher line. <see cref="Note"/> carries any loud parse warning (Q3).</summary>

--- a/src/housecarl-core/skypatcher-fieldmap.json
+++ b/src/housecarl-core/skypatcher-fieldmap.json
@@ -534,7 +534,8 @@
                                  "semantic":  "set",
                                  "path":  "WornArmor",
                                  "formType":  "Armor",
-                                 "note":  "null disables (field is nullable in Mutagen); NPC \u0027skin\u0027 is the WNAM worn-armor link"
+                                 "donorType":  "Npc",
+                                 "note":  "null disables (field is nullable in Mutagen); NPC \u0027skin\u0027 is the WNAM worn-armor link. skin=<Armor> sets it directly; the NPC-Replacer-Converter shape skin=<donor NPC> copies that donor NPC worn-armor at runtime (donorType=Npc) — an unmodeled donor-copy, not a malformed FormKey (issue #181)"
                              },
                     "deathItem":  {
                                       "semantic":  "set",

--- a/src/housecarl-generator/SkyPatcherFieldMapProbe.cs
+++ b/src/housecarl-generator/SkyPatcherFieldMapProbe.cs
@@ -171,6 +171,13 @@ public static class SkyPatcherFieldMapProbe
                     && asm.GetType("Mutagen.Bethesda.Skyrim.I" + ft + "Getter") is null)
                     problems.Add($"{ctx}: formType '{ft}' is neither a Mutagen.Bethesda.Skyrim record class nor a link interface (I{ft}Getter).");
 
+                // donorType (optional — the runtime 'copy from a donor of type X' reading, e.g. NPC skin's
+                // donorType=Npc) resolves as a form SCOPE the same way formType does (issue #181).
+                if (m.DonorType is { } dtv
+                    && asm.GetType("Mutagen.Bethesda.Skyrim." + dtv) is null
+                    && asm.GetType("Mutagen.Bethesda.Skyrim.I" + dtv + "Getter") is null)
+                    problems.Add($"{ctx}: donorType '{dtv}' is neither a Mutagen.Bethesda.Skyrim record class nor a link interface (I{dtv}Getter).");
+
                 var leaf = WalkPath(rootType, m.Path, ctx, problems);
                 if (leaf is null) continue;
 

--- a/src/housecarl-generator/SkyPatcherOverlayProbe.cs
+++ b/src/housecarl-generator/SkyPatcherOverlayProbe.cs
@@ -200,8 +200,37 @@ public static class SkyPatcherOverlayProbe
         failures += FormListArm(catalog, fieldMap, mod);
         failures += Wave2FilterArm(catalog, fieldMap, mod);
         failures += Wave2OpClosuresArm(catalog, fieldMap, mod);
+        failures += BracketLabelArm(catalog, fieldMap, mod);
 
         return Done(failures);
+    }
+
+    /// <summary>Issue #180: an INI section/label line ('[Name]') is INERT — it must produce no warning and
+    /// no unresolved-skip, and the real patch line right below it must still apply. (Before the fix the
+    /// label parsed as a malformed no-'=' Patch, drew the "unrecognized key may be a filter … UNRESOLVED"
+    /// warning, and inflated the skip count.)</summary>
+    static int BracketLabelArm(SkyPatcherCatalog catalog, SkyPatcherFieldMap fieldMap, SkyrimMod mod)
+    {
+        Console.WriteLine("  --- bracket-label arm (issue #180: '[Name]' is inert, the next line still applies) ---");
+        int failures = 0;
+        var resolver = new StubResolver();
+        var w = mod.Weapons.AddNew();
+        w.EditorID = "HcLabelSword";
+        w.BasicStats = new WeaponBasicStats { Damage = 10, Weight = 1, Value = 1 };
+        var me = $"HcSpOv.esp|{w.FormKey.ID:X}";
+        SkyPatcherOverlay.OrderedLine L(int n, string text) => new("lbl.ini", n, SkyPatcherParse.ParseLine(text));
+        var r = SkyPatcherOverlay.Apply(w, w.FormKey, w.EditorID, catalog, catalog.ForSubfolder("weapon")!,
+            fieldMap.For("weapon", "Weapon"), new[]
+            {
+                L(1, "[Vernaccus]"),                              // an inert human label (converter output)
+                L(2, $"filterByWeapons={me}:attackDamage=42"),    // the real line directly below it
+            }, resolver);
+        failures += Check("the '[Name]' label produced NO warning and NO unresolved-skip",
+            !r.Warnings.Any(x => x.Contains("Vernaccus")) && r.LinesSkippedUnresolvedFilter == 0,
+            $"skips={r.LinesSkippedUnresolvedFilter} warns=[{string.Join(" ; ", r.Warnings)}]");
+        failures += Check("the patch line below the label still applied (damage=42)",
+            w.BasicStats!.Damage == 42, $"got {w.BasicStats.Damage}");
+        return failures;
     }
 
     /// <summary>The Wave-2 unmapped-op CLOSURES — the five semantics that turn 47 explicitly-unmapped

--- a/src/housecarl-generator/SkyPatcherOverlayProbe.cs
+++ b/src/housecarl-generator/SkyPatcherOverlayProbe.cs
@@ -26,9 +26,19 @@ public static class SkyPatcherOverlayProbe
     sealed class StubResolver : SkyPatcherOverlay.IFormResolver
     {
         public Dictionary<string, FormKey> EditorIds = new(StringComparer.OrdinalIgnoreCase);
+        // (optional) eid → its Mutagen record type; when set, a type-scoped lookup for a DIFFERENT type
+        // misses — the same per-type scoping the real resolver enforces (an NPC EditorID is invisible to
+        // an 'Armor' lookup). An unregistered eid matches any scope (keeps the type-agnostic fixtures green).
+        public Dictionary<string, string> EditorIdTypes = new(StringComparer.OrdinalIgnoreCase);
         public HashSet<string> Plugins = new(StringComparer.OrdinalIgnoreCase);
         public FormKey? ResolveEditorId(string editorId, string? mutagenType)
-            => EditorIds.TryGetValue(editorId, out var fk) ? fk : null;
+        {
+            if (!EditorIds.TryGetValue(editorId, out var fk)) return null;
+            if (EditorIdTypes.TryGetValue(editorId, out var t) && mutagenType is not null
+                && !t.Equals(mutagenType, StringComparison.OrdinalIgnoreCase))
+                return null;
+            return fk;
+        }
         public Dictionary<FormKey, string> WinnerLeafs = new();       // (donor) → the one leaf the test reads
         public Dictionary<FormKey, IReadOnlyList<FormKey>> Keywords = new();
         public Dictionary<FormKey, string> Winners = new();
@@ -201,6 +211,7 @@ public static class SkyPatcherOverlayProbe
         failures += Wave2FilterArm(catalog, fieldMap, mod);
         failures += Wave2OpClosuresArm(catalog, fieldMap, mod);
         failures += BracketLabelArm(catalog, fieldMap, mod);
+        failures += NpcSkinDonorArm(catalog, fieldMap, mod);
 
         return Done(failures);
     }
@@ -230,6 +241,71 @@ public static class SkyPatcherOverlayProbe
             $"skips={r.LinesSkippedUnresolvedFilter} warns=[{string.Join(" ; ", r.Warnings)}]");
         failures += Check("the patch line below the label still applied (damage=42)",
             w.BasicStats!.Damage == 42, $"got {w.BasicStats.Damage}");
+        return failures;
+    }
+
+    /// <summary>Issue #181: an NPC-replacer's <c>skin=&lt;donor NPC&gt;</c> (the SkyPatcher NPC Replacer
+    /// Converter's shape, paired with <c>copyVisualStyle</c>) must NEVER throw a "Malformed FormKey" — it
+    /// classifies as a runtime donor-copy the static model doesn't cover (like copyVisualStyle), naming the
+    /// donor. The CLEAN <c>skin=&lt;Armor&gt;</c> direct set, <c>skin=null</c> clear, and a genuinely-missing
+    /// donor's loud-and-named skip all still hold.</summary>
+    static int NpcSkinDonorArm(SkyPatcherCatalog catalog, SkyPatcherFieldMap fieldMap, SkyrimMod mod)
+    {
+        Console.WriteLine("  --- NPC skin-donor arm (issue #181: skin=<donor NPC> never throws) ---");
+        int failures = 0;
+        var npcCat = catalog.ForSubfolder("npc")!;
+        var npcMap = fieldMap.For("npc", "Npc");
+        if (npcMap is null) return Check("npc field map present", false);
+
+        var armorFk = new FormKey(new ModKey("HcArm", ModType.Plugin), 0xF01);
+        var donorNpcFk = new FormKey(new ModKey("LRemiel Re", ModType.Plugin), 0x800);
+        var existingSkin = new FormKey(new ModKey("HcArm", ModType.Plugin), 0xE00);
+        var resolver = new StubResolver();
+        resolver.EditorIds["HcWornArmor"] = armorFk;      resolver.EditorIdTypes["HcWornArmor"] = "Armor";
+        resolver.EditorIds["012_HLIORemi"] = donorNpcFk;  resolver.EditorIdTypes["012_HLIORemi"] = "Npc";
+        SkyPatcherOverlay.OrderedLine L(int n, string text) => new("skin.ini", n, SkyPatcherParse.ParseLine(text));
+
+        // (a) the reported real-world shape — skin=<donor NPC EditorID> alongside copyVisualStyle.
+        var target = mod.Npcs.AddNew();
+        target.EditorID = "HLIORemi";
+        target.WornArmor.SetTo(existingSkin);
+        var me = $"HcSpOv.esp|{target.FormKey.ID:X}";
+        var rA = SkyPatcherOverlay.Apply(target, target.FormKey, target.EditorID, catalog, npcCat, npcMap, new[]
+        { L(1, $"filterByNpcs={me}:copyVisualStyle=012_HLIORemi:skin=012_HLIORemi") }, resolver);
+        failures += Check("skin=<donor NPC> does NOT throw a malformed-FormKey",
+            !rA.Warnings.Any(w => w.Contains("Malformed FormKey")), string.Join(" ; ", rA.Warnings));
+        failures += Check("skin=<donor NPC> classifies as an unmodeled donor-copy, naming donor + copyVisualStyle",
+            rA.Warnings.Any(w => w.Contains("skin=012_HLIORemi") && w.Contains("donor") && w.Contains("copyVisualStyle")),
+            string.Join(" ; ", rA.Warnings));
+        failures += Check("skin=<donor NPC> left the target's WornArmor UNCHANGED (not applied)",
+            target.WornArmor.FormKey == existingSkin, target.WornArmor.FormKey.ToString());
+        failures += Check("copyVisualStyle is still surfaced as a HARD directive (tiered honesty intact)",
+            rA.Directives.Any(d => d.Op == "copyVisualStyle"));
+
+        // (b) the CLEAN direct case is unbroken — skin=<Armor EditorID> sets WornArmor.
+        var t2 = mod.Npcs.AddNew(); t2.EditorID = "HcDirectSkin";
+        var me2 = $"HcSpOv.esp|{t2.FormKey.ID:X}";
+        SkyPatcherOverlay.Apply(t2, t2.FormKey, t2.EditorID, catalog, npcCat, npcMap, new[]
+        { L(1, $"filterByNpcs={me2}:skin=HcWornArmor") }, resolver);
+        failures += Check("skin=<Armor> still sets WornArmor directly (CLEAN path unbroken)",
+            t2.WornArmor.FormKey == armorFk, t2.WornArmor.FormKey.ToString());
+
+        // (c) skin=null still clears.
+        var t3 = mod.Npcs.AddNew(); t3.EditorID = "HcClearSkin"; t3.WornArmor.SetTo(armorFk);
+        var me3 = $"HcSpOv.esp|{t3.FormKey.ID:X}";
+        SkyPatcherOverlay.Apply(t3, t3.FormKey, t3.EditorID, catalog, npcCat, npcMap, new[]
+        { L(1, $"filterByNpcs={me3}:skin=null") }, resolver);
+        failures += Check("skin=null still clears WornArmor", t3.WornArmor.IsNull, t3.WornArmor.FormKey.ToString());
+
+        // (d) a genuinely-missing donor stays loud and names the token — never a malformed-FormKey throw.
+        var t4 = mod.Npcs.AddNew(); t4.EditorID = "HcMissingSkin";
+        var me4 = $"HcSpOv.esp|{t4.FormKey.ID:X}";
+        var rD = SkyPatcherOverlay.Apply(t4, t4.FormKey, t4.EditorID, catalog, npcCat, npcMap, new[]
+        { L(1, $"filterByNpcs={me4}:skin=NoSuchThing") }, resolver);
+        failures += Check("a missing skin donor is loud + names the token (never a malformed-FormKey throw)",
+            !rD.Warnings.Any(w => w.Contains("Malformed FormKey"))
+            && rD.Warnings.Any(w => w.Contains("NoSuchThing") && w.Contains("does not resolve")),
+            string.Join(" ; ", rD.Warnings));
         return failures;
     }
 

--- a/src/housecarl-generator/SkyPatcherParseProbe.cs
+++ b/src/housecarl-generator/SkyPatcherParseProbe.cs
@@ -27,6 +27,17 @@ public static class SkyPatcherParseProbe
         failures += Check("';'-led line ⇒ Comment", SkyPatcherParse.ParseLine("  ; a note").Kind == SkyPatcherLineKind.Comment);
         failures += Check("key=value line ⇒ Patch", SkyPatcherParse.ParseLine("attackDamage=99").Kind == SkyPatcherLineKind.Patch);
 
+        // -- INI section/label line ('[Name]') ⇒ inert Label kind, no segments, no note (issue #180) -----
+        var lbl = SkyPatcherParse.ParseLine("[Vernaccus]");
+        failures += Check("'[Name]' ⇒ Label (inert): no segments, no note",
+            lbl.Kind == SkyPatcherLineKind.Label && lbl.Segments.Count == 0 && lbl.Note is null,
+            $"kind={lbl.Kind} segs={lbl.Segments.Count} note={lbl.Note ?? "<null>"}");
+        failures += Check("a whitespace-padded '[Name]' still ⇒ Label",
+            SkyPatcherParse.ParseLine("  [Deathbringer Vorla]  ").Kind == SkyPatcherLineKind.Label);
+        failures += Check("a real patch line is NOT mistaken for a label (leads with a key, not '[')",
+            SkyPatcherParse.ParseLine("filterByNpcs=Vigilant.esm|1D0ECCB3:shoutsToRemove=Vigilant.esm|020ECCB9").Kind
+                == SkyPatcherLineKind.Patch);
+
         // -- the canonical weapon patch (grammar-core §3 worked example) ------------------------
         var w = SkyPatcherParse.ParseLine("filterByWeapons=Skyrim.esm|00012EB7:attackDamage=99:weight=0");
         failures += Check("weapon patch ⇒ 3 segments", w.Segments.Count == 3, $"got {w.Segments.Count}");
@@ -121,14 +132,17 @@ public static class SkyPatcherParseProbe
         // -- whole-file parse: counts by kind ----------------------------------------------------
         var file = SkyPatcherParse.ParseFile(
             "; header comment\n" +
+            "[Some NPC]\n" +
             "filterByWeapons=Skyrim.esm|12EB7:attackDamage=99\n" +
             "\n" +
             "filterByArmors=Skyrim.esm|12E49:armorRating=40\n");
         int patches = file.Count(l => l.Kind == SkyPatcherLineKind.Patch);
         int comments = file.Count(l => l.Kind == SkyPatcherLineKind.Comment);
         int blanks = file.Count(l => l.Kind == SkyPatcherLineKind.Blank);
-        failures += Check("file parse ⇒ 2 patch, 1 comment, ≥1 blank",
-            patches == 2 && comments == 1 && blanks >= 1, $"patch={patches} comment={comments} blank={blanks}");
+        int labels = file.Count(l => l.Kind == SkyPatcherLineKind.Label);
+        failures += Check("file parse ⇒ 2 patch, 1 comment, 1 label, ≥1 blank (the label is not a patch)",
+            patches == 2 && comments == 1 && labels == 1 && blanks >= 1,
+            $"patch={patches} comment={comments} label={labels} blank={blanks}");
 
         // -- UTF-8 BOM (Wave-1 crux finding: a shipped INI's BOM rode into the first key) --------
         var bomFile = SkyPatcherParse.ParseFile("\uFEFF" + "filterByWeapons=Skyrim.esm|12EB7:weight=0");


### PR DESCRIPTION
Addresses three reports from @WraithFallen. All confirmed against current `main`, fixed here, full `ci-all` green (91/91).

## #180 — bracket `[Label]` lines treated as malformed patches
A converter-style label like `[Vernaccus]` parsed as a malformed no-`=` `Patch`, so the overlay warned it as a possible *unresolved filter* and counted it in the patch/skip totals — a false alarm on an inert line.

**Fix:** new `SkyPatcherLineKind.Label` — `ParseLine` recognizes a whole-line `[…]` wrap as inert (no segments, no note). Every consumer already allowlists `Patch`, so a label is skipped and uncounted everywhere, with physical line numbering preserved. Non-bracket malformed lines keep their loud behavior.

## #181 — `skin=<donor NPC>` threw `Malformed FormKey` instead of classifying honestly
NPC-Replacer-Converter output uses `skin=<donor NPC EditorID>` (with `copyVisualStyle`). The reader modeled `skin` as a direct Armor assignment, so the NPC EditorID missed the Armor scope, fell through to the write engine as a raw FormKey, and threw — mislabeling a **valid** INI as broken (a Q3 no-silent/wrong-failure violation on a common shape).

**Fix:** `ApplySetOne` no longer hands a bare string to a FormLink `Set` — a form-valued target must resolve to a form. An optional, guard-validated `OpMap.DonorType` (NPC `skin` → `Npc`) lets the reader recognize the donor-NPC shape: when the value resolves as the donor kind, it's named an unmodeled runtime donor-copy (like `copyVisualStyle`) rather than throwing; a genuinely missing/typo'd form stays loud and named. `skin=<Armor>` direct set, `skin=null` clear, and the `Plugin|FormID` form are unchanged.

**Scope note (§4):** I took the *honest-classification* lane, not the donor-*modeling* lane the issue lists as preferred — what the DLL actually copies is an empirical fact I haven't confirmed, and we name-not-guess DLL semantics. Modeling the real WornArmor copy is a clean follow-up once confirmed in-game. Also, `skin=Plugin|FormID` pointing at an NPC isn't type-checked (it doesn't throw — it applies the raw link); detecting a FormID's target type needs resolver infra not added here. The reported real-world case (EditorID form) is fully fixed.

## #182 — README implied merge did the MO2 swap automatically
`merge_plugins` writes the new plugin and **guides** the swap; it does not mutate the profile. Reworded the bullet to describe the guided/manual swap, matching the tool's real contract.

## Verification
- Build clean (0 errors).
- New guard coverage: parse-probe (Label kind + file counts), overlay-probe arms (bracket label inert + next line applies; skin donor-NPC no-throw/honest-classification, CLEAN Armor set, null clear, missing donor), fieldmap-guard (`donorType` validated as a form scope).
- Full `ci-all`: **91/91 PASS**.

Closes #180
Closes #181
Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)
