### PR TITLE
fix(read): container hint names a knob the surface actually has (Q3 doc-bug)

### DIFF
--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -165,7 +165,16 @@ public static class ReadEngine
     /// proven internal <see cref="ReadLeaf"/> (the round-trip oracle drives it), so the server's reads inherit the
     /// read-proof by construction. Per-leaf fault isolation (Q3): an unreadable field names itself in its
     /// <see cref="FieldValue.Note"/>, never throws out of the record read.</summary>
-    public static RecordFields ReadFields(IMajorRecordGetter record, IReadOnlyList<string>? paths = null, int depth = 1)
+    /// <summary>The depth-1 container hint (HCBR-2026-07-12): appended to an unexpanded container/substruct summary so
+    /// an agent turns the depth= knob instead of inventing a param or hand-rolling a parser. It names <c>depth=2</c>,
+    /// which is only honest on a surface that HAS a depth= parameter (read_record / batch_record_detail /
+    /// read_plugin_file / the CLI) — a caller whose surface has no depth= passes its own redirect via
+    /// <c>containerHint</c> (cross_plugin_query names the batch-read hop) or null to suppress (write read-backs,
+    /// where the count IS the confirmation and there is no knob to turn).</summary>
+    public const string DepthExpandHint = " — pass depth=2 to expand";
+
+    public static RecordFields ReadFields(IMajorRecordGetter record, IReadOnlyList<string>? paths = null, int depth = 1,
+                                          string? containerHint = DepthExpandHint)
     {
         var typeName = RecordNaming.StripGetterInterface(WriteEngine.PrimaryGetter(record.GetType())?.Name ?? "I?Getter");
         var targets = paths is { Count: > 0 } ? (IEnumerable<string>)paths : ModeledFieldNames(typeName, record.GetType());
@@ -186,7 +195,8 @@ public static class ReadEngine
                 // (HCBR-2026-07-12). No-value NOTES are parenthesized ("(absent)", "(null link)"), so the leading-'['
                 // test targets exactly the container/substruct summaries. Depth-1 only (this branch) — the deep read
                 // FieldsDiff runs never sees the hint (it reads at expansion depth, a different summary path).
-                if (note is { Length: > 0 } && note[0] == '[') note += " — pass depth=2 to expand";
+                // The hint text is the caller's (containerHint): depth=2 is only a real knob on some surfaces.
+                if (note is { Length: > 0 } && note[0] == '[' && !string.IsNullOrEmpty(containerHint)) note += containerHint;
                 fields.Add(new FieldValue(p, r.HasValue, r.HasValue ? r.Token : null, note, FlagSlotDisplay(r)));
             }
         }

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -159,12 +159,6 @@ public static class ReadEngine
         return 0;
     }
 
-    /// <summary>Read a located record's fields as round-trippable tokens — the public, structured entry the MCP
-    /// server consumes (the §8.4 read cleave; <c>RunRead</c> is the CLI sibling). With <paramref name="paths"/>:
-    /// exactly those leaves (the get_field primitive). Without: a one-level dump of every modeled field. Wraps the
-    /// proven internal <see cref="ReadLeaf"/> (the round-trip oracle drives it), so the server's reads inherit the
-    /// read-proof by construction. Per-leaf fault isolation (Q3): an unreadable field names itself in its
-    /// <see cref="FieldValue.Note"/>, never throws out of the record read.</summary>
     /// <summary>The depth-1 container hint (HCBR-2026-07-12): appended to an unexpanded container/substruct summary so
     /// an agent turns the depth= knob instead of inventing a param or hand-rolling a parser. It names <c>depth=2</c>,
     /// which is only honest on a surface that HAS a depth= parameter (read_record / batch_record_detail /
@@ -173,6 +167,12 @@ public static class ReadEngine
     /// where the count IS the confirmation and there is no knob to turn).</summary>
     public const string DepthExpandHint = " — pass depth=2 to expand";
 
+    /// <summary>Read a located record's fields as round-trippable tokens — the public, structured entry the MCP
+    /// server consumes (the §8.4 read cleave; <c>RunRead</c> is the CLI sibling). With <paramref name="paths"/>:
+    /// exactly those leaves (the get_field primitive). Without: a one-level dump of every modeled field. Wraps the
+    /// proven internal <see cref="ReadLeaf"/> (the round-trip oracle drives it), so the server's reads inherit the
+    /// read-proof by construction. Per-leaf fault isolation (Q3): an unreadable field names itself in its
+    /// <see cref="FieldValue.Note"/>, never throws out of the record read.</summary>
     public static RecordFields ReadFields(IMajorRecordGetter record, IReadOnlyList<string>? paths = null, int depth = 1,
                                           string? containerHint = DepthExpandHint)
     {

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -2330,7 +2330,7 @@ public static class WritePatchBuilder
         try
         {
             var leaf = string.Join('.', req.Path);
-            var read = ReadEngine.ReadFields(ov, new[] { leaf });
+            var read = ReadEngine.ReadFields(ov, new[] { leaf }, containerHint: null);   // a write confirmation has no depth= knob — the count IS the read-back
             var f = read.Fields.FirstOrDefault(x => x.Path == leaf) ?? read.Fields.FirstOrDefault();
             return f is null ? null : (f.HasValue ? f.Token : f.Note);
         }
@@ -2350,7 +2350,7 @@ public static class WritePatchBuilder
         try
         {
             var leaf = string.Join('.', req.Path);
-            var read = ReadEngine.ReadFields(ov, new[] { leaf });
+            var read = ReadEngine.ReadFields(ov, new[] { leaf }, containerHint: null);   // same: no depth= on the write surface, don't hint it
             var f = read.Fields.FirstOrDefault(x => x.Path == leaf) ?? read.Fields.FirstOrDefault();
             if (f is null) return (null, null);
             var after = f.HasValue ? f.Token : f.Note;

--- a/src/housecarl-generator/BulkPrimitivesWave2Probe.cs
+++ b/src/housecarl-generator/BulkPrimitivesWave2Probe.cs
@@ -356,6 +356,39 @@ public static class BulkPrimitivesWave2Probe
                 wjDoc.Dispose();
             }
 
+            // ================= container hint — the depth= knob is hinted only where it EXISTS =================
+            // The depth-1 container note self-documents the expansion lever (HCBR-2026-07-12). cross_plugin_query
+            // has NO depth= (its unknown-param guard refuses it), so its note must redirect to the batch-read hop
+            // instead of naming a knob the tool refuses — while read_record (which HAS depth=) keeps the classic
+            // hint, and a write read-back (no knob at all) carries a bare count.
+            Console.WriteLine();
+            Console.WriteLine("── container hint: cross_plugin_query names the batch hop (no depth= here); read tools keep depth=2; write read-backs stay bare ──");
+            var cqList = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: null,
+                resolve_names: false, winner_fields: false, fields: new[] { "Keywords" }, conflict_tree: false,
+                format: "text", limit: 500, max_chars: 0);
+            Check("cross_plugin_query container note redirects to housecarl_batch_record_detail depth=2",
+                  cqList.Contains("housecarl_batch_record_detail depth=2"));
+            Check("... and does NOT hint 'pass depth=2 to expand' — a knob this tool refuses",
+                  !cqList.Contains("pass depth=2 to expand"));
+
+            var cqListJson = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: null,
+                resolve_names: false, winner_fields: false, fields: new[] { "Keywords" }, conflict_tree: false,
+                format: "json", limit: 500, max_chars: 0);
+            Check("json parity: the redirect note rides the json render too, never the depth= hint",
+                  cqListJson.Contains("housecarl_batch_record_detail depth=2") && !cqListJson.Contains("pass depth=2 to expand"));
+
+            var rrHint = svc.ResolveRead(w1Fk, null, new[] { "Keywords" }, false);
+            var rrNote = rrHint.Record?.Fields.FirstOrDefault(f => f.Path == "Keywords")?.Note;
+            Check("read_record (HAS depth=) keeps the classic ' — pass depth=2 to expand' hint (default preserved)",
+                  rrNote is not null && rrNote.Contains("pass depth=2 to expand"));
+
+            var bareNote = ReadEngine.ReadFields(w1, new[] { "Keywords" }, containerHint: null)
+                .Fields.FirstOrDefault()?.Note;
+            Check("containerHint:null (the write read-back lane) renders the bare count — no hint at all",
+                  bareNote is not null && bareNote.StartsWith("[list:") && !bareNote.Contains("depth"));
+
             Console.WriteLine();
             Console.WriteLine($"=== bulk-primitives-wave2-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
             return _fail == 0 ? 0 : 1;

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -303,7 +303,8 @@ static class JsonWire
                     {
                         // winner_fields=: read the WINNER's body (source=null) regardless of scan scope; the record's
                         // "source" field still names the body read, so the json carries the same source/winner truth.
-                        var o = svc.ResolveRead(fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false, resolveNames: resolveNames, linkMemo: linkMemo);
+                        var o = svc.ResolveRead(fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false, resolveNames: resolveNames, linkMemo: linkMemo,
+                                                containerHint: Wire.CrossQueryContainerHint);   // no depth= on this tool — same redirect as the text render
                         if (o.Error is not null) { w.WriteStartObject(); w.WriteString("formid", fk.ToString()); w.WriteString("error", o.Error); if (matches is not null) w.WriteString("matches", matches); w.WriteEndObject(); }
                         else WriteReadRecord(w, o, ms, cap, matches);
                     }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1375,10 +1375,11 @@ public sealed class LoadOrderService : IDisposable
     /// touching-plugin list. Honest, recoverable errors (Q3): not-in-order, plugin-doesn't-touch, fetch
     /// inconsistency — never a silent empty result.</summary>
     public ReadOutcome ResolveRead(FormKey fk, string? plugin, IReadOnlyList<string>? fields, bool conflictTree, int depth = 1,
-                                   bool resolveNames = false, Dictionary<FormKey, ResolvedRef>? linkMemo = null)
+                                   bool resolveNames = false, Dictionary<FormKey, ResolvedRef>? linkMemo = null,
+                                   string? containerHint = ReadEngine.DepthExpandHint)
     {
         var resolver = Resolver;
-        return ResolveRead(resolver, resolver.Capture(), fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo);
+        return ResolveRead(resolver, resolver.Capture(), fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo, containerHint);
     }
 
     /// <summary>Layer B unit C2 — the on-demand whole-topic dialogue-graph validator (housecarl_validate_dialogue):
@@ -1402,7 +1403,8 @@ public sealed class LoadOrderService : IDisposable
     /// diff — same low-severity class, named for the next wave rather than threaded through the render API here.)</summary>
     ReadOutcome ResolveRead(LoadOrderResolver resolver, LoadOrderResolver.IndexView view,
                             FormKey fk, string? plugin, IReadOnlyList<string>? fields, bool conflictTree, int depth,
-                            bool resolveNames = false, Dictionary<FormKey, ResolvedRef>? linkMemo = null)
+                            bool resolveNames = false, Dictionary<FormKey, ResolvedRef>? linkMemo = null,
+                            string? containerHint = ReadEngine.DepthExpandHint)
     {
         // An explicitly-requested plugin that was EXCLUDED this session (unparseable/unopenable) → say so (Q3),
         // rather than fall through to a misleading "does not define this record".
@@ -1442,7 +1444,7 @@ public sealed class LoadOrderService : IDisposable
                 ? $"Winner '{winner.Value.WinnerPlugin}' did not yield {fk} on fetch — a load-order inconsistency."
                 : $"Plugin '{plugin}' does not define {fk} (it does not touch this record). The winner is '{winner.Value.WinnerPlugin}'.");
 
-        var record = ReadEngine.ReadFields(rec, fields, depth);           // materialise while the session (overlay) is open
+        var record = ReadEngine.ReadFields(rec, fields, depth, containerHint);   // materialise while the session (overlay) is open
         if (resolveNames) record = AnnotateLinks(record, view, session, linkMemo ?? new());   // P7: identity of every FormLink token, DISPLAY-ONLY (same open session)
         var touching = conflictTree ? view.TouchingPlugins(fk) : null;
         return new ReadOutcome(fk, record, source, winner.Value.WinnerPlugin, winner.Value.OverrideDepth, touching, null);

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -509,6 +509,12 @@ static class Wire
     }
 
     // ---- housecarl_cross_plugin_query ---------------------------------------------------------------
+
+    /// <summary>The container hint for cross_plugin_query field expansions: this tool has NO depth= parameter, so the
+    /// generic " — pass depth=2 to expand" would name a knob the tool refuses (the unknown-param guard rejects depth=)
+    /// — the honest redirect is the batch-read hop. Shared by the text render (here) and <see cref="JsonWire"/>.</summary>
+    internal const string CrossQueryContainerHint = " — cross_plugin_query has no depth=; expand these via housecarl_batch_record_detail depth=2";
+
     public static string RenderCrossQuery(LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields, bool conflictTree, int maxChars,
                                           bool resolveNames = false, bool winnerFields = false)
     {
@@ -547,7 +553,8 @@ static class Wire
             {
                 // winner_fields=: read the load-order WINNER's body (source=null) regardless of scan scope; else the
                 // body the scan filtered (scoped plugin under plugins=, else winner) — so display never contradicts filter.
-                var o = svc.ResolveRead(fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, conflictTree, resolveNames: resolveNames, linkMemo: linkMemo);
+                var o = svc.ResolveRead(fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, conflictTree, resolveNames: resolveNames, linkMemo: linkMemo,
+                                        containerHint: CrossQueryContainerHint);   // this tool has no depth= — don't hint a knob it refuses
                 sb.Append('\n');
                 if (matches is not null) sb.Append("  ").Append(fk).Append("  matches=").Append(matches).Append('\n');
                 if (o.Error is not null) sb.Append(fk).Append(": error: ").Append(o.Error).Append('\n');


### PR DESCRIPTION
## What

The Wave-4 follow-up from [PR #187](https://github.com/Avick3110/houseCARL/pull/187)'s reviewer notes: the depth-1 container note ("[list: 5 item(s)] — pass depth=2 to expand", added by HCBR-2026-07-12 so agents turn the depth knob) was appended by `ReadEngine.ReadFields` on **every** surface — including two that have no `depth=` parameter at all. On `housecarl_cross_plugin_query` the note recommended a knob the tool's own unknown-param guard then refuses (found live while verifying the Wave 4 skill recipes); on the per-op write read-backs it hinted a knob no write tool has.

## The fix (additive, single source of truth)

`ReadFields` gains an optional `containerHint` parameter, defaulting to the existing text (now the const `ReadEngine.DepthExpandHint` — depth-bearing surfaces are byte-unchanged). Threaded through both `ResolveRead` overloads with the same default. Two call-site choices:

- **cross_plugin_query** (text + json renders, one shared const `Wire.CrossQueryContainerHint`): the note now reads "— cross_plugin_query has no depth=; expand these via housecarl_batch_record_detail depth=2" — the honest hop, and exactly what the `bulk-record-jobs` skill already teaches, so the two surfaces now agree.
- **write read-backs** (`TryReadAfter` / `DescribeApplied`): hint suppressed — the count IS the confirmation, and there is no knob to turn on a write surface. (`full_readback` reads at depth 16 and never saw the hint.)

Unchanged by default: `read_record`, `batch_record_detail`, `read_plugin_file`, the CLI read (all HAVE `depth=`), the conflict-tree/diff deep reads (never saw the hint), and probes.

## Proof

- `bulk-primitives-wave2-guard` **50/50** (+5 new arms): the redirect in text AND json, the stale hint absent, the classic hint preserved on `read_record`, and the bare count on the suppressed lane.
- Full **ci-all 91/91** from the worktree root — no regression.

## Reviewer note

The first push of this branch was an empty branch head (a PowerShell 5.1 quote-mangling casualty on the commit command); `17994c3` is the real commit. Nothing else rode the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
