### PR TITLE
docs(claude-md): §2 pointer to dev/BACKLOG.md for standing follow-ups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,8 @@ A session picking up work reads:
 2. **The latest handoff** in `dev/session-handoffs/` — what the last session did and what to pick up. The most important transition read; start here for "where are we."
 3. **The PRFAQ corpus** (`dev/PRFAQ/`) — read once when new to the project, then consult on demand (it's ~60k tokens — not a per-session read). Product: P1 + P2. Direction: P7 + rebuild plan v1. Proof: spike findings (code at `dev/references/spike/`). Deeper, on demand: FAQs (P3/P4), Housecarl-HEAD eval (P5), pivot doc (§5's source).
 
+**Standing follow-ups.** `dev/BACKLOG.md` is the durable home for small, dev-noticed follow-ups — tool ergonomics, doc gaps, minor papercuts spotted mid-session but not done inline — that would otherwise get lost in a superseded handoff. Skim it when picking up work; append when you notice one, prune when done. It is *not* the bug lane: live-session bug reports from Aaron live in the external gap/bug store, and chartered work lives in `dev/plans/` or `dev/projects/`.
+
 **Sub-project sessions.** Some work runs as a self-contained sub-project under `dev/projects/<name>/` (its own tracking, walled off from the main gap/bug/release lane — see `dev/projects/README.md`). If a session is for one, the user will name it ("the follower skill", "the `<name>` project"); then read `dev/projects/<name>/STATUS.md` **instead of** the latest `dev/session-handoffs/` handoff (item 2), and stay in that lane. Absent that, boot normally — the default is unchanged.
 
 The cornerstone (§3) and revalidation protocol (§4) are restated in this file, so you operate correctly from CLAUDE.md alone — the corpus is the authority you re-read when the protocol sends you there, not a tax every session pays.


### PR DESCRIPTION
## What

Adds a **standing home for small, dev-noticed follow-ups** and a §2 boot-read pointer to it.

- **New (not in this PR — gitignored working doc):** `dev/BACKLOG.md` — the durable ledger for tool ergonomics, doc gaps, and minor papercuts a session spots mid-work but doesn't do inline. Seeded with the first entry: the union-arm `where=` presence-test ergonomic from HCBR-2026-07-14-03 (the authoria-requiem `01ab413` fix flagged it "tracked separately in that repo" and it was never captured).
- **This PR (one line):** CLAUDE.md §2 gains a **"Standing follow-ups"** note so a booting session actually reads `dev/BACKLOG.md`.

## Why

These items are the middle ground the three existing lanes miss:
- too small for `dev/plans/` or `dev/projects/`,
- self-noticed (not Aaron's live-session bug reports → those stay in the external gap/bug store),
- too durable for a handoff that gets superseded next session.

So they floated across sessions and got lost. This gives them one in-repo, boot-visible home.

## Scope

Documentation only — one 2-line insertion into the operating manual. No code, tools, or skills touched. `dev/BACKLOG.md` itself is gitignored (local working doc), so it's not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)