### PR TITLE
release: 1.8.0 — Nexus update-checking + bulk/fleet data surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ models — by construction, not a hand-maintained subset.
   build behind a portable follower or a face transplanted between mods.
 - **Trace a magic effect** — resolve a MagicEffect to every spell, enchantment, potion, scroll, and
   ingredient that carries it, with each one's magnitude, in a single call.
+- **Answer bulk / fleet questions** — resolve many FormIDs to their identity in one call, diff two plugins'
+  versions of a record down to just the changed fields, and aggregate a cross-plugin query (define-vs-touch
+  scope, multi-target reverse lookups, group-by counts, winner-value columns, JSON output) — the surface a
+  catalogue, conflict survey, or patch rebuild runs on.
 - **VFS asset layer** — read which copy of any Data-relative file (mesh, texture, script, sound,
   interface) actually wins your load order (the overwrite folder, a specific mod, Data, or inside a BSA),
   and place a file as a winning override into a new MO2 mod folder; loose-vs-BSA aware, with FaceGen as the
@@ -64,14 +68,18 @@ models — by construction, not a hand-maintained subset.
   no external tool needed), measured at 98.8% byte-exact recompile round-trips across every provable
   script in a 3,400-plugin load order; anything it can't prove fails loudly in the output, never
   silently wrong.
-- **Look mods up on Nexus** — search the Skyrim SE catalogue and pull any mod's version, requirements,
-  and *true* latest release straight from Nexus Mods, without opening a browser. Read-only: it finds
-  and informs; downloading stays your mod manager's "Mod Manager Download" handoff.
-- **Look things up, author distributor files, and review scripts** through 12 bundled, namespaced skills:
+- **Look mods up on Nexus — and check your load order for updates.** Search the Skyrim SE catalogue and
+  pull any mod's version, requirements, file list, per-version changelog, and *true* latest release straight
+  from Nexus Mods, without opening a browser. Check your whole load order for updates **at the exact-file
+  level** — reading MO2's own local cache first to narrow the list, then confirming live — so an old-version
+  compatibility patch installed on purpose isn't misread as out of date; trace a file to its mod by MD5
+  hash; and a raw GraphQL backstop reaches any field the curated tools don't surface yet. All keyless and
+  read-only: it finds and informs; downloading stays your mod manager's "Mod Manager Download" handoff.
+- **Look things up, author distributor files, and review scripts** through 13 bundled, namespaced skills:
   record schemas (every type Mutagen models), Papyrus / SKSE signatures, SkyPatcher / SPID / KID
   distributor grammars, Skyrim dialogue authoring, Open Animation Replacer config authoring, SKSE plugin
   (C++/CommonLibSSE-NG) authoring, Papyrus performance review, dark-face NPC diagnosis, equip-slot lookup,
-  and tool-output awareness.
+  tool-output awareness, and bulk record-job planning.
 
 ## Requirements
 
@@ -92,7 +100,7 @@ models — by construction, not a hand-maintained subset.
 
 ### Download — recommended (modders)
 
-1. Download **`houseCARL-1.7.1.zip`** from the [latest release](https://github.com/Avick3110/houseCARL/releases).
+1. Download **`houseCARL-1.8.0.zip`** from the [latest release](https://github.com/Avick3110/houseCARL/releases).
 2. Unzip it and run **`houseCARL-Setup.exe`**.
 3. Pick your host — **`[1] Claude Code`**, **`[2] Codex`**, or **`[3] Both`**. The installer wires
    everything up:
@@ -122,7 +130,7 @@ cd houseCARL
 
 The script regenerates the reflection rulebook, publishes the server framework-dependent (trimming **off**
 — houseCARL is reflection-driven, so trimming would strip types and silently lose coverage), bundles the
-skills, builds the setup utility, and packs `release/houseCARL-1.7.1.zip`. Install the output with
+skills, builds the setup utility, and packs `release/houseCARL-1.8.0.zip`. Install the output with
 `houseCARL-Setup.exe`, `claude --plugin-dir ./dist/housecarl`, or the bundled local-marketplace
 descriptor — see the script header for details.
 
@@ -187,6 +195,12 @@ Namespaced under `/housecarl:` in Claude (and reachable via `$housecarl` in Code
   native Papyrus functions from C++, target SE + AE + VR from one DLL, or read an open-source plugin's source
   to explain what it does. Distinct from ESP/record work and from `.psc` Papyrus (owned by `papyrus-reference`);
   its runtime claims still await an in-game validation pass.
+- **`bulk-record-jobs`** — plan a "many records → one structured deliverable" job (a catalogue, a link or
+  recipe graph, a conflict survey, a patch rebuild, a fan-out extraction) onto the bulk primitives — scoped
+  queries, `group_by`, `housecarl_resolve`, `housecarl_diff_record`, batch writes — instead of per-record
+  loops, with the game-generic Creation-Kit conventions those jobs need and one canonical deliverable schema
+  so a fleet of subagents doesn't invent a different output shape each. Game-generic only — a specific mod's
+  own conventions stay in that mod's skill.
 
 ## License
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "housecarl",
   "displayName": "houseCARL",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Comprehensive data-layer access to your Skyrim SE load order — read any record, author patches into a new plugin, look mods up on Nexus, and look up record schemas, Papyrus signatures, performance reviews, and distributor grammars — in plain English.",
   "author": { "name": "Avick3110" },
   "homepage": "https://github.com/Avick3110/houseCARL",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -4,6 +4,101 @@ All notable changes to houseCARL are documented here. Versioning is [semantic](h
 the `version` in `.claude-plugin/plugin.json` is bumped on each release, so installed users update only
 when it changes.
 
+## 1.8.0 — 2026-07-15
+
+houseCARL gains two capability layers at once: a **keyless Nexus update-checking** stack — know which of
+your installed files are actually out of date, at the exact-file level, trace a file to its mod by hash,
+with a raw GraphQL backstop under it — and a **bulk / fleet data surface** — resolve many FormIDs to
+identity, diff two plugins' versions of a record, and a batch of aggregation flags on the query, write, and
+read surfaces, fronted by a new planning skill. **Six new tools (→ 43) and one new skill (→ 13).**
+
+**Nexus update checking — four new tools and a wider `nexus_mod`**
+
+- **`housecarl_update_status` — read MO2's own update cache, with no network.** MO2 already records, per
+  mod, the newest file it last saw on Nexus; this reads that local cache (each mod's `meta.ini`) and reports
+  every installed mod whose cached "newest" differs from what's installed — narrowing a whole-order update
+  pass to just the candidates before a single network call — and prints each mod's `id#fileid` verify token
+  for the live check below. It reports a *difference to verify*, never an asserted "a newer version exists"
+  (the cache can lag or lead), and sets the mods with no fileid (FOMOD / manual installs) aside as their own
+  manual-verify bucket instead of folding them into "fine".
+- **`housecarl_nexus_check_updates` — batch, file-level "is this the current file?".** Pass each mod as
+  `id#fileid` and it tells CURRENT from OUTDATED for the **exact file you installed**, not the mod's newest
+  MAIN file — the distinction that matters on a multi-file page, where an old-version compatibility patch and
+  the current main file share one mod id and a mod-level version compare lies. It resolves manager-only
+  (`nxm`, "author disabled direct download") mods that the Nexus search collection excludes — reading them
+  through their file data rather than stamping them "not found" — and calls out a genuinely hidden / deleted
+  page, and an installed file that's since been pulled, as their own distinct, loud outcomes.
+- **`housecarl_nexus_identify` — trace a file to its mod by MD5 hash.** Give it one or more file MD5 hashes
+  (the fingerprint a mod manager matches an unknown download by) and it names the source mod, file, and
+  version straight from Nexus — keyless — for a file whose origin you've lost.
+- **`housecarl_nexus_graphql` — raw, read-only query over the keyless GraphQL.** The completeness backstop
+  beneath the curated Nexus tools: when you need a field they don't surface yet (a mod's page tags, say),
+  this passes a read-only query through the same public keyless API, so nothing on Nexus is permanently out
+  of reach. Prefer the curated tools; this is the escape hatch, not the front door.
+- **`housecarl_nexus_mod` reads more of a page.** `files=true` lists every uploaded file; `changelog=true`
+  (with an optional `since=`) returns the per-version changelog and the delta between your version and the
+  latest; and a mod's page tags now come through — so "what changed since my version, and what kind of mod
+  is this?" is answered without a browser. All Nexus traffic now identifies houseCARL by name and version,
+  per Nexus's Acceptable Use Policy.
+
+**Bulk / fleet data surface — two new tools, plus query, write, and read flags**
+
+The tool surface was shaped for one record at a time; heavy fan-out runs used it as a bulk data API and had
+to improvise the aggregation themselves. This wave adds that aggregation as type-agnostic primitives —
+coverage still inherited from the reflection layer, so there are no per-record-type tools.
+
+- **`housecarl_resolve` — many FormIDs → identity, in one call.** Hand it a list of FormIDs and it returns
+  each one's record type, EditorID, display name, and load-order winner, with a malformed entry isolated as
+  its own per-item error instead of failing the batch. The bulk answer to "what *are* all these forms?".
+- **`housecarl_diff_record` — a field-level diff between two plugins' versions of a record.** Point it at a
+  FormID and two plugins (`plugin_a` vs `plugin_b`) and it returns only what differs between their two
+  versions — either pole active in the load order or read off-order from a plugin sitting on disk — each
+  delta self-labeled by the plugin it came from, so a patch rebuild reads the change instead of re-deriving
+  it from two full reads and hand subtraction.
+- **`housecarl_cross_plugin_query` gains aggregation.** `defined_in=` narrows a `plugins=` scope from every
+  record a plugin *touches* (definitions plus overrides) to only the ones it *defines*; a list-valued
+  `references=` runs N reverse-lookups in one scan (each hit labeled with which target it matched);
+  `group_by=winner|type|defined_in` returns a count table over **all** matches instead of a capped list; and
+  `winner_fields=` reads each match's field values from the true load-order winner — with a loud note when a
+  `plugins=` scope is otherwise showing scoped-not-winner values, closing a subtle "these numbers don't
+  match what I see in game" trap.
+- **`resolve_names=` and `format="json"` across the read surfaces.** `resolve_names=true` annotates every
+  FormLink in a read with its EditorID and name inline (display-only — the underlying wire token is
+  untouched); `format="json"` returns the same outcomes as a machine-readable document with the accounting
+  (truncation, no-value leaves) carried in-band, so a fan-out consumer parses the result instead of scraping
+  the text.
+- **Batch writes — `composes=` and `CopyFrom`.** A write op can now carry `composes=`: a list of
+  build-from-parts elements applied in one operation (`Add` appends each, `ReplaceAll` replaces the whole
+  modeled list — and `ReplaceAll composes=[]` clears it). And a new **`CopyFrom`** verb transplants a
+  field's value from another plugin's version of the record — active or off-order, any field the reflection
+  layer models — the reflection-generic generalization of copying an appearance or a stat block across
+  plugins.
+
+**New skill (→ 13)**
+
+- **`bulk-record-jobs` — plan "many records → one structured deliverable" jobs.** Catalogues, link and
+  recipe graphs, conflict surveys, patch rebuilds, and any fan-out that extracts structured data: this skill
+  routes them onto the bulk primitives above (scoped queries, `group_by`, `resolve`, `diff_record`, batch
+  writes) instead of per-record loops, carries the game-generic Creation-Kit conventions those jobs need
+  (craft vs temper, what a workbench keyword means structurally), and pins one canonical deliverable schema
+  so a fleet of subagents stops inventing eight different output shapes. Game-generic only — a specific mod's
+  own conventions stay in that mod's skill.
+
+**Finishing an unenabled plugin, and fixes**
+
+- **A pre-enable finishing lane.** `housecarl_check_errors` and `housecarl_compact_plugin` now accept a
+  plugin that isn't enabled yet, and `housecarl_read_plugin_file` locates a mod folder that isn't in your
+  load order (a freshly-authored houseCARL patch, found by filename) — so you can sweep, compact, or read a
+  just-authored plugin before enabling and sorting it in MO2.
+- **SkyPatcher interpretation reads more INIs honestly.** A `skin=<donor NPC>` directive is now classified
+  rather than throwing, and a bracketed `[Label]` line is treated as the inert grouping label it is, not a
+  malformed patch.
+- **New-patch naming is collision-safe and un-doubled.** The default patch stem is now `Patch` — dropping
+  the doubled `houseCARL - houseCARL_Patch` — and it is checked against the active load order so a fresh
+  patch can't collide with an existing plugin's name.
+- **A container-read hint now names a knob that actually exists** (it had pointed at a parameter the tool
+  doesn't take).
+
 ## 1.7.1 — 2026-07-13
 
 A maintenance release: sharper, louder tool feedback and a write-lane fix. No new tools (still 37) or

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -35,6 +35,9 @@ It can:
   a portable follower or a face moved between mods.
 - **Trace a magic effect** — resolve a MagicEffect to every spell, enchantment, potion, scroll, and
   ingredient that carries it, with each one's magnitude, in a single call.
+- **Answer bulk / fleet questions** — resolve many FormIDs to their identity in one call, diff two plugins'
+  versions of a record down to the changed fields, and aggregate a cross-plugin query (define-vs-touch
+  scope, multi-target reverse lookups, group-by counts, winner-value columns, JSON output).
 - **VFS asset layer** — read which copy of any Data-relative file (mesh, texture, script, sound,
   interface) actually wins your load order (the overwrite folder, a specific mod, Data, or inside a BSA),
   and place a file as a winning override into a new MO2 mod folder; loose-vs-BSA aware, with FaceGen as the
@@ -56,19 +59,22 @@ It can:
 - **Decompile compiled scripts** — reconstruct reviewable `.psc` source from any `.pex` (Mutagen-native,
   no external tool needed), measured at 98.8% byte-exact recompile round-trips across every provable
   script in a 3,400-plugin load order; anything it can't prove fails loudly, never silently wrong.
-- **Look mods up on Nexus** — search the Skyrim SE catalogue and read any mod's version, requirements,
-  and latest release straight from Nexus Mods, no browser needed. Read-only; downloading stays your mod
-  manager's job.
+- **Look mods up on Nexus — and check your load order for updates** — search the catalogue and read any
+  mod's version, requirements, file list, and per-version changelog straight from Nexus Mods, no browser
+  needed; check your installed mods for updates at the **exact-file level** (MO2's local cache first, then a
+  live confirm) so a deliberately-old compatibility patch isn't misread as outdated; trace a file to its mod
+  by MD5 hash; and a raw GraphQL backstop reaches any field the curated tools don't surface yet. Keyless and
+  read-only; downloading stays your mod manager's job.
 - Look up **record schemas** (every type Mutagen models) and **Papyrus / SKSE signatures**, author
   **SkyPatcher**, **SPID**, and **KID** distributor files, **author Skyrim dialogue** and **Open Animation
   Replacer configs**, **author SKSE plugins in C++** (CommonLibSSE-NG), **review Papyrus scripts for
-  performance**, **diagnose the dark / grey / black-face NPC bug**, **find armor by equip slot**, and
-  **recognize generated tool output** — through 12 bundled,
+  performance**, **diagnose the dark / grey / black-face NPC bug**, **find armor by equip slot**,
+  **recognize generated tool output**, and **plan bulk record-jobs** — through 13 bundled,
   namespaced skills (`/housecarl:mutagen-reference`, `/housecarl:papyrus-reference`,
   `/housecarl:skypatcher-authoring`, `/housecarl:spid-authoring`, `/housecarl:kid-authoring`,
   `/housecarl:dialogue-authoring`, `/housecarl:papyrus-optimization`, `/housecarl:facegen-diagnostics`,
   `/housecarl:oar-authoring`, `/housecarl:skse-plugin-authoring`, `/housecarl:tool-output-awareness`,
-  `/housecarl:biped-slot-reference`).
+  `/housecarl:biped-slot-reference`, `/housecarl:bulk-record-jobs`).
 
 Coverage is **reflection-driven**: the set of record types houseCARL understands *is* the set Mutagen
 models, by construction — not a hand-maintained subset.


### PR DESCRIPTION
Cuts **1.8.0**, bundling the two sub-projects that landed on `main` since `v1.7.1`: **Nexus Tier-0 (keyless update checking)** and **bulk-primitives**.

**Scope (verified from source, not memory):**
- **Tools 37 → 43** (6 new): `housecarl_resolve`, `housecarl_diff_record` (bulk-primitives); `housecarl_update_status`, `housecarl_nexus_check_updates`, `housecarl_nexus_identify`, `housecarl_nexus_graphql` (Nexus Tier-0)
- **Skills 12 → 13** (1 new): `bulk-record-jobs`
- Plus enhancements — `nexus_mod` `files=`/`changelog=`/`since=`/tags; `cross_plugin_query` `defined_in=`/list-`references=`/`group_by=`/`winner_fields=`/`format=json`; `resolve_names=`; batch `composes=` + `CopyFrom`; the pre-enable finishing lane — and fixes (SkyPatcher read classification, collision-safe patch stem, container-hint doc-bug).

**What's in this PR (release mechanics only — no code):**
- `plugin/CHANGELOG.md` — the `## 1.8.0` section (doubles as the GitHub release body)
- `plugin/.claude-plugin/plugin.json` — version `1.7.1` → `1.8.0`
- `README.md` + `plugin/README.md` — staleness sweep: 12 → 13 skills, Nexus + bulk/fleet capability, version strings

**Package (built from this branch via `scripts/build-plugin.ps1`):**
- `release/houseCARL-1.8.0.zip` — **335 entries, 16.78 MB**, SHA256 `B724B2CFAA1F4110ADEDB7206BAA6CEF16F3BF62D6BE471283182EDBE6EC330A`
- **K1 `claude plugin validate --strict` GREEN**; leak-check clean; 13 skills, corpus "no anomalies"; build dirtied only the 4 intended files (regenerated `mutagen-reference` shards byte-identical)
- The `1.8.0-dev` package (zip + folder) is deleted from local `release/`

**Empirical gate:** early-tester posture carried from 1.5–1.7.1 (pre-cut in-game gate waived). Both sub-projects were already live-gated on ARR 2.0 — the bulk-primitives PLAN §5 gate MET, the Nexus tools verified on the live update sweep.

**Gated on Aaron's explicit go (not automatic):** merge → tag `v1.8.0` on the release commit → GitHub Release → **Nexus upload (Aaron's manual lane)**. Nexus one-line changelog is drafted at `dev/plans/nexus-changelog-1.8.0.txt`.
