### PR TITLE
Store 2026-07-15: flags bit-verbs (Q3 fix) + batch_record_detail plugin=

### DIFF
--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -577,13 +577,23 @@ public sealed class CorpusRulebook
         // (step 4-flags) Add/Remove on a [Flags] enum are bit-SET / bit-CLEAR (HCBR-2026-07-15): the value is the
         // flag(s) to OR in or AND-NOT out. VerbLegality already admitted the verb for a [Flags] leaf; validate the
         // flag NAME/bits here with the SAME CheckValue recognizer a Set uses (the field's real enum AQ), so a bogus
-        // flag fails LOUD at the gate instead of throwing Enum.Parse at apply (Q3 accept-then-throw). Value PRESENCE
-        // mirrors Set's "requires a value". Gated ahead of the collection branches (which are list/dict-scoped and
-        // would ignore an enum leaf anyway) so it can't fall through to the terminal `return null` accept.
+        // flag fails LOUD at the gate instead of throwing Enum.Parse at apply (Q3 accept-then-throw). Gated ahead of
+        // the collection branches (which are list/dict-scoped and would ignore an enum leaf anyway) so it can't fall
+        // through to the terminal `return null` accept.
         if (req.Verb is "Add" or "Remove" && IsFlagsEnumLeaf(leaf))
         {
             if (req.Value is null)
-                return $"{req.Verb} on flags field '{leaf.Name}' requires a flag value (the bit to {(req.Verb == "Add" ? "set" : "clear")}).";
+            {
+                // Add always needs the bit to set. A VALUELESS Remove keeps its pre-bit-verb meaning — the WHOLE-CLEAR
+                // of a nullable scalar (the ONLY path to make a nullable flags field ABSENT/null) — preserved by
+                // construction so the bit verbs ADD capability without removing any (no silent trade-away): allowed iff
+                // the field is nullable, else refused with the turn-all-off redirect (Set '0'), never a dead end (Q3).
+                if (req.Verb == "Add")
+                    return $"Add on flags field '{leaf.Name}' requires a flag value (the bit to set).";
+                return leaf.Nullable ? null
+                    : $"Remove on flags field '{leaf.Name}' needs the flag to clear (value=<flag>) — a non-nullable flags " +
+                      "field can't be whole-cleared; to turn ALL bits off, Set it to '0'.";
+            }
             return CheckValue(leaf.Type, req.Value, $"flag value for '{leaf.Name}'",
                 leaf.MutableTypeAssemblyQualified ?? leaf.GetterTypeAssemblyQualified);
         }

--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -273,6 +273,22 @@ public sealed class CorpusRulebook
         return inner.Length == 0 ? null : inner;
     }
 
+    /// <summary>True iff the leaf is a <c>[Flags]</c>-attributed enum — the ONLY scalar/enum kind the bit verbs
+    /// <c>Add</c>/<c>Remove</c> operate on (a single-value enum like CastType has no bits to OR/clear, so it stays
+    /// refused). Resolved from the field's OWN assembly-qualified type — never the simple-name catalog, which
+    /// collides on shared enum names ("Flags", "MajorFlags", …) — checking <see cref="FlagsAttribute"/>. False when
+    /// the AQ won't resolve (Q3 — never ASSUME flags-ness, so a bit verb is refused rather than accepted-then-thrown).
+    /// The SAME resolution the apply path keys on (WriteEngine.ApplyScalarVerb's [Flags] gate), so gate and apply
+    /// can't drift on which leaves accept a bit verb.</summary>
+    static bool IsFlagsEnumLeaf(FieldSchema leaf)
+    {
+        if (leaf.Cardinality != "enum") return false;
+        var aq = leaf.MutableTypeAssemblyQualified ?? leaf.GetterTypeAssemblyQualified;
+        if (WriteEngine.ResolveType(aq) is not { } rt) return false;
+        var u = Nullable.GetUnderlyingType(rt) ?? rt;
+        return u.IsEnum && u.IsDefined(typeof(FlagsAttribute), false);
+    }
+
     // ---- verb × cardinality (plan §3 P-VERBS) ----
     static string? VerbLegality(FieldSchema leaf, WriteRequest req)
     {
@@ -289,13 +305,24 @@ public sealed class CorpusRulebook
                 // MISSING key reaches apply and throws UNNAMED (Coerce(null)). A list Add appends — no key. Gate dict-Add
                 // key PRESENCE here, the structural twin of Set-on-dict above (key VALUE-shape is ValueLegality's step-4-key).
                 if (c == "dict") return hasKey ? null : $"Add on dict field '{leaf.Name}' requires a key.";
-                return c == "list" ? null : $"Add is only valid on list/dict; '{leaf.Name}' is {c}.";
+                if (c == "list") return null;
+                // A [Flags] enum accepts Add as a bit-SET (OR the flag in, other bits preserved) — the fix for the
+                // silent-clobber a whole-value Set caused (HCBR-2026-07-15). A bit verb takes no key (it is not a
+                // collection); the flag VALUE is gated in ValueLegality. Non-flags scalars/enums still refuse below.
+                if (IsFlagsEnumLeaf(leaf))
+                    return hasKey ? $"Add on flags field '{leaf.Name}' takes no key — the value IS the flag to set." : null;
+                return $"Add is only valid on a list/dict or a [Flags] enum; '{leaf.Name}' is {c}.";
             case "Remove":
                 // A dict Remove identifies the entry to drop BY KEY (ApplyDictVerb -> Coerce(req.Key!, kType)); a MISSING
                 // key throws UNNAMED at apply. A list Remove is by-index-OR-by-value (ApplyListVerb): a null key legally
                 // falls back to remove-by-value, so list Remove needs NO key — gate dict-Remove key PRESENCE only.
                 if (c == "dict") return hasKey ? null : $"Remove on dict field '{leaf.Name}' requires a key.";
                 if (c == "list") return null;
+                // A [Flags] enum accepts Remove as a bit-CLEAR (AND-NOT the flag out, other bits preserved) — the
+                // Remove twin of the flags Add above (HCBR-2026-07-15). Distinct from the nullable-scalar whole-clear
+                // below: it clears ONE bit, not the whole field. No key; the flag VALUE is gated in ValueLegality.
+                if (IsFlagsEnumLeaf(leaf))
+                    return hasKey ? $"Remove on flags field '{leaf.Name}' takes no key — the value IS the flag to clear." : null;
                 return leaf.Nullable ? null : $"Remove on non-nullable {c} field '{leaf.Name}' is not valid.";
             case "ReplaceAll":
                 return c is "list" or "dict" ? null : $"ReplaceAll is only valid on list/dict; '{leaf.Name}' is {c}.";
@@ -545,6 +572,19 @@ public sealed class CorpusRulebook
                 return CoercibilityReject(leaf);
             }
             return CheckValue(leaf.Type, req.Value, $"value for '{leaf.Name}'",
+                leaf.MutableTypeAssemblyQualified ?? leaf.GetterTypeAssemblyQualified);
+        }
+        // (step 4-flags) Add/Remove on a [Flags] enum are bit-SET / bit-CLEAR (HCBR-2026-07-15): the value is the
+        // flag(s) to OR in or AND-NOT out. VerbLegality already admitted the verb for a [Flags] leaf; validate the
+        // flag NAME/bits here with the SAME CheckValue recognizer a Set uses (the field's real enum AQ), so a bogus
+        // flag fails LOUD at the gate instead of throwing Enum.Parse at apply (Q3 accept-then-throw). Value PRESENCE
+        // mirrors Set's "requires a value". Gated ahead of the collection branches (which are list/dict-scoped and
+        // would ignore an enum leaf anyway) so it can't fall through to the terminal `return null` accept.
+        if (req.Verb is "Add" or "Remove" && IsFlagsEnumLeaf(leaf))
+        {
+            if (req.Value is null)
+                return $"{req.Verb} on flags field '{leaf.Name}' requires a flag value (the bit to {(req.Verb == "Add" ? "set" : "clear")}).";
+            return CheckValue(leaf.Type, req.Value, $"flag value for '{leaf.Name}'",
                 leaf.MutableTypeAssemblyQualified ?? leaf.GetterTypeAssemblyQualified);
         }
         // (step 4-pre) ELEMENT-VALUE PRESENCE — the collection twin of the singular Set "requires a value" reject

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -642,9 +642,10 @@ public static class ReadEngine
     }
 
     /// <summary>The unsigned bit pattern of a boxed enum value, robust across every underlying integer type
-    /// (signed or unsigned) — the bits a <c>has</c> predicate ANDs against. Read through the declared underlying
-    /// type so a high-bit-set signed enum yields its two's-complement pattern rather than overflowing.</summary>
-    static bool TryEnumBits(object val, Type enumType, out ulong bits)
+    /// (signed or unsigned) — the bits a <c>has</c> predicate ANDs against, and the write engine's flags
+    /// Add/Remove OR/AND-NOT operand. Read through the declared underlying type so a high-bit-set signed enum
+    /// yields its two's-complement pattern rather than overflowing.</summary>
+    internal static bool TryEnumBits(object val, Type enumType, out ulong bits)
     {
         bits = 0;
         try

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1959,13 +1959,14 @@ public static class WriteEngine
         // §E.1). Recognised by the generic definition (IsFormLinkOrIndex) — no per-record-type wiring.
         if (req.Verb == "Set" && IsFormLinkOrIndex(prop.PropertyType)) { SetFloi(parent, prop, req.Value!); return; }
 
-        // Add/Remove on a [Flags] enum are BIT operations (HCBR-2026-07-15), NOT whole-value Set/clear: Add ORs the
-        // operand's bit(s) into the current value, Remove ANDs them out — so a single flag flips without the caller
-        // re-listing every OTHER bit (the silent-clobber this closes: a literal Set dropped every unlisted bit). Gated
-        // to [Flags] enums; Remove on any other scalar stays the whole-field clear below, and Add on a non-flags scalar
-        // still hits the default reject. Pre-flight (CorpusRulebook's flags-enum branch) already validated the operand
-        // as a legal flag name / bit value, but we fail LOUD here for a pre-flight-bypassing direct/CLI caller (Q3).
-        if (req.Verb is "Add" or "Remove")
+        // Add / valued-Remove on a [Flags] enum are BIT operations (HCBR-2026-07-15), NOT whole-value Set/clear: Add
+        // ORs the operand's bit(s) into the current value, Remove ANDs them out — so a single flag flips without the
+        // caller re-listing every OTHER bit (the silent-clobber this closes: a literal Set dropped every unlisted bit).
+        // Gated to [Flags] enums. A VALUELESS Remove is NOT a bit op — it keeps its pre-bit-verb meaning (the whole-field
+        // clear of a nullable scalar, the case below), so it falls through here; that preserves the only path to make a
+        // nullable flags field absent (pre-flight admits it only when nullable). Add on a non-flags scalar still hits the
+        // default reject. Pre-flight validated the operand, but we fail LOUD here for a pre-flight-bypassing caller (Q3).
+        if (req.Verb == "Add" || (req.Verb == "Remove" && req.Value is not null))
         {
             var ut = Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType;
             if (ut.IsEnum && ut.IsDefined(typeof(FlagsAttribute), false)) { ApplyFlagsBitVerb(parent, prop, ut, req); return; }

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1959,6 +1959,18 @@ public static class WriteEngine
         // §E.1). Recognised by the generic definition (IsFormLinkOrIndex) — no per-record-type wiring.
         if (req.Verb == "Set" && IsFormLinkOrIndex(prop.PropertyType)) { SetFloi(parent, prop, req.Value!); return; }
 
+        // Add/Remove on a [Flags] enum are BIT operations (HCBR-2026-07-15), NOT whole-value Set/clear: Add ORs the
+        // operand's bit(s) into the current value, Remove ANDs them out — so a single flag flips without the caller
+        // re-listing every OTHER bit (the silent-clobber this closes: a literal Set dropped every unlisted bit). Gated
+        // to [Flags] enums; Remove on any other scalar stays the whole-field clear below, and Add on a non-flags scalar
+        // still hits the default reject. Pre-flight (CorpusRulebook's flags-enum branch) already validated the operand
+        // as a legal flag name / bit value, but we fail LOUD here for a pre-flight-bypassing direct/CLI caller (Q3).
+        if (req.Verb is "Add" or "Remove")
+        {
+            var ut = Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType;
+            if (ut.IsEnum && ut.IsDefined(typeof(FlagsAttribute), false)) { ApplyFlagsBitVerb(parent, prop, ut, req); return; }
+        }
+
         switch (req.Verb)
         {
             case "Set":
@@ -1987,6 +1999,33 @@ public static class WriteEngine
             default:
                 throw new InvalidOperationException($"Verb '{req.Verb}' is not valid on scalar/substruct '{prop.Name}'.");
         }
+    }
+
+    /// <summary>Flags-enum bit op (HCBR-2026-07-15): OR (<c>Add</c>) or AND-NOT (<c>Remove</c>) the operand's bit(s)
+    /// into the leaf's CURRENT value, so one flag flips while every other bit is preserved — the fix for the
+    /// silent-clobber a literal <see cref="Coerce"/> Set caused (an unlisted bit was dropped). The operand is resolved
+    /// through the SAME enum coercion a Set uses (<see cref="Coerce"/> → <c>Enum.Parse</c>: a flag NAME, a
+    /// case-insensitive comma-combo, or a decimal literal) so pre-flight (CheckValue → TryCoerce) and apply can't
+    /// disagree on a legal operand; its bits and the current value's bits are read through
+    /// <see cref="ReadEngine.TryEnumBits"/> (robust across every underlying integer type). The combined pattern is
+    /// re-boxed to the enum type via <c>Enum.ToObject</c>. Called only for a confirmed <c>[Flags]</c> leaf.</summary>
+    static void ApplyFlagsBitVerb(object parent, PropertyInfo prop, Type enumType, WriteRequest req)
+    {
+        if (!prop.CanWrite) throw new InvalidOperationException($"Property '{prop.Name}' is not writable");
+        if (req.Value is null)
+            throw new InvalidOperationException($"Flags {req.Verb} on '{prop.Name}' requires a flag value (the bit to {(req.Verb == "Add" ? "set" : "clear")}).");
+
+        var current = prop.GetValue(parent);
+        ulong curBits = 0;
+        if (current is not null && !ReadEngine.TryEnumBits(current, enumType, out curBits))
+            throw new InvalidOperationException($"Flags {req.Verb} on '{prop.Name}': could not read the current {enumType.Name} value as bits.");
+
+        var opVal = Coerce(req.Value, enumType);   // Enum.Parse via the enum coercion family — fail-loud on a bad flag
+        if (opVal is null || !ReadEngine.TryEnumBits(opVal, enumType, out var opBits))
+            throw new InvalidOperationException($"Flags {req.Verb} on '{prop.Name}': '{req.Value}' is not a legal {enumType.Name} flag name or bit value.");
+
+        ulong combined = req.Verb == "Add" ? (curBits | opBits) : (curBits & ~opBits);
+        prop.SetValue(parent, Enum.ToObject(enumType, combined));
     }
 
     /// <summary>

--- a/src/housecarl-generator/BulkPrimitivesWave2Probe.cs
+++ b/src/housecarl-generator/BulkPrimitivesWave2Probe.cs
@@ -18,6 +18,8 @@ namespace HousecarlGenerator;
 ///     accounting carried in-band, always-valid JSON.
 ///   • P7 <c>resolve_names=</c> — every FormLink token in a field dump annotated with its target's identity,
 ///     display-only (never replaces the round-trip token).
+///   • HCBR-2026-07-15 <c>batch_record_detail plugin=</c> — bulk-read a NAMED plugin's version (an override, not
+///     the winner), the batch twin of read_record's plugin=, with a per-item error for a record it doesn't touch.
 ///
 /// Synthesizes a small on-disk order (a master + a replacer that overrides one NAMED weapon and defines others, with
 /// keyword links) and drives the REAL service layer (<see cref="LoadOrderService"/> via the ForGuard seam) + the
@@ -250,6 +252,38 @@ public static class BulkPrimitivesWave2Probe
                       && records[1].TryGetProperty("error", out _));
                 batchDoc.Dispose();
             }
+
+            // ===== HCBR-2026-07-15 — batch_record_detail plugin= (a specific override's version, in BULK) =====
+            // The batch twin of housecarl_read_record's plugin=. W1 is DEFINED in master (damage 10) and OVERRIDDEN
+            // in Repl (damage 15 = the live winner). A bulk read AS THE MASTER's version must read 10 (not the winner's
+            // 15); AS THE REPLACER's must read 15; and a record the named plugin doesn't touch (W2, master-only) gets a
+            // per-item error under plugin=Repl while the batch survives — the coverage this closes (a validation run
+            // fell back to SAMPLING because the batch couldn't scope to a mod's own version).
+            Console.WriteLine();
+            Console.WriteLine("── HCBR-2026-07-15: batch_record_detail plugin= reads a NAMED plugin's version in bulk ──");
+            var bMaster = ReadTools.BatchRecordDetail(svc, new[] { w1Fk.ToString(), w2Fk.ToString() }, plugin: masterName,
+                fields: new[] { "BasicStats.Damage" }, depth: 1, conflict_tree: false, resolve_names: false, format: null, max_chars: 0);
+            Check("plugin=master: W1 reads the MASTER's OWN value (damage 10), NOT the live winner's 15",
+                  bMaster.Contains("BasicStats.Damage = 10") && !bMaster.Contains("BasicStats.Damage = 15"));
+            Check("plugin=master: W2 (master-only) reads its master value (damage 20) in the SAME batch",
+                  bMaster.Contains("BasicStats.Damage = 20"));
+
+            var bRepl = ReadTools.BatchRecordDetail(svc, new[] { w1Fk.ToString() }, plugin: replName,
+                fields: new[] { "BasicStats.Damage" }, depth: 1, conflict_tree: false, resolve_names: false, format: null, max_chars: 0);
+            Check("plugin=Repl: W1 reads the REPLACER's version (damage 15) — the override, on demand",
+                  bRepl.Contains("BasicStats.Damage = 15") && !bRepl.Contains("BasicStats.Damage = 10"));
+
+            var bMiss = ReadTools.BatchRecordDetail(svc, new[] { w2Fk.ToString(), w1Fk.ToString() }, plugin: replName,
+                fields: new[] { "BasicStats.Damage" }, depth: 1, conflict_tree: false, resolve_names: false, format: null, max_chars: 0);
+            Check("plugin=Repl: W2 (untouched by Repl) is a per-item 'does not define' error, W1 still reads (batch survives — Q3)",
+                  bMiss.Contains("does not define") && bMiss.Contains("BasicStats.Damage = 15"));
+
+            var bJson = ReadTools.BatchRecordDetail(svc, new[] { w1Fk.ToString() }, plugin: masterName,
+                fields: new[] { "BasicStats.Damage" }, depth: 1, conflict_tree: false, resolve_names: false, format: "json", max_chars: 0);
+            var bJsonDoc = ParseOrNull(bJson);
+            Check("plugin= json: the record's source is the NAMED plugin (master), not the winner (Repl)",
+                  bJsonDoc is not null && bJsonDoc.RootElement.GetProperty("records")[0].GetProperty("source").GetString() == masterName);
+            bJsonDoc?.Dispose();
 
             // cross_plugin_query json — summary rows, group_by table, and Q3 notes survival.
             var cqSummary = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -97,6 +97,11 @@ public static class CiAll
         ("nullarm-guard", NullArmGuardProbe.RunGuard),
         ("formlink-null-guard", FormLinkNullProbe.RunGuard),
         ("formlink-remove-guard", FormLinkRemoveProbe.RunGuard),
+        // Flags-enum bit verbs (HCBR-2026-07-15): Add/Remove on a [Flags] enum are bit-SET / bit-CLEAR, preserving the
+        // OTHER bits — closing the silent-clobber a whole-value Set caused. Pre-flight admits the verb + validates the
+        // flag (gate), apply ORs/AND-NOTs the bit (WriteEngine), the two keyed off the SAME FlagsAttribute test; the
+        // anti-clobber Add + scoped-not-universal controls are the teeth. Self-contained (Quest.Flags, no Skyrim.esm).
+        ("flags-bit-verb-guard", FlagsBitVerbProbe.RunGuard),
         ("gendered-nav-guard", GenderedNavProbe.RunGuard),
         ("loadorder-status-guard", LoadOrderStatusProbe.RunGuard),
         ("compile-ergonomics-guard", CompileErgonomicsProbe.RunGuard),

--- a/src/housecarl-generator/FlagsBitVerbProbe.cs
+++ b/src/housecarl-generator/FlagsBitVerbProbe.cs
@@ -1,0 +1,223 @@
+using System.Linq;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// REGRESSION GUARD (standing CI instrument) for HCBR-2026-07-15 — a [Flags]-enum write was whole-value-replace only,
+/// so a literal <c>Set</c> silently CLEARED every bit the caller didn't re-list, and <c>Add</c>/<c>Remove</c> were
+/// refused as collection-only. There was no way to flip ONE flag while preserving the rest.
+///
+/// THE DAMAGE (measured in the S4 Gray Fox Cowl validation run): lane-derived Flags tokens applied by literal Set
+/// clobbered unlisted bits on 10+ records — ManualCostCalc dropped on 6 authored-cost spells (their authored BaseCost
+/// thereby ignored), and Essential / Female / IsGhost / Invulnerable / Unique dropped on named NPCs (a ghost made
+/// vulnerable, two quest NPCs made killable). The worst kind of write error: pre-flight ACCEPTED it, the read-back
+/// CONFIRMED it, and it was wrong — caught only by a post-hoc oracle diff.
+///
+/// THE FIX (by construction, no per-type wiring): <c>Add</c>/<c>Remove</c> are admitted on a <c>[Flags]</c> enum leaf
+/// as BIT operations — Add ORs the operand's bit(s) into the current value, Remove ANDs them out — so one flag flips
+/// while every OTHER bit is preserved. The gate (<see cref="CorpusRulebook"/>: <c>IsFlagsEnumLeaf</c> in VerbLegality
+/// + a step-4-flags value check) and the apply (<see cref="WriteEngine"/>.<c>ApplyScalarVerb</c>'s [Flags] branch →
+/// <c>ApplyFlagsBitVerb</c>) key off the SAME FlagsAttribute-on-the-field's-real-AQ test, so they can't drift. The
+/// operand resolves through the SAME enum coercion a Set uses (Enum.Parse: name / comma-combo / decimal), so a bogus
+/// flag fails LOUD at the gate, never Enum.Parse-throws at apply.
+///
+/// RED-&gt;GREEN teeth: A1 (apply Add ORs a bit and PRESERVES the pre-existing one — the anti-clobber core; RED before
+/// the fix, when Add was refused outright), A2 (apply Remove clears ONLY its bit), E2E (Set+Add survives serialize +
+/// re-read as the UNION). CONTROLS: S0 (Quest.Flags really is a [Flags] enum — a Mutagen reshape can't pass green
+/// silently), PRE-ACCEPT (pre-flight now ADMITS flags Add/Remove — was the report's refusal), PRE-BADFLAG (a bogus
+/// flag is REFUSED at the gate, not accepted-then-thrown — Q3), PRE-KEY (a stray key is refused — a bit verb takes
+/// none), PRE-SCALAR / APPLY-SCALAR (a plain scalar still REFUSES Add at BOTH gate and apply — the acceptance is
+/// scoped to [Flags], it did not go universal).
+///
+/// Self-contained: the apply/E2E teeth are pure in-memory Mutagen (no plugin file, no Skyrim.esm); the PRE-* checks
+/// use the GENERATED corpus.json (built into a unique temp dir on a fresh checkout, exactly as formlink-remove-guard).
+///
+/// Run: <c>dotnet run --project src/housecarl-generator flags-bit-verb-guard</c>
+/// </summary>
+public static class FlagsBitVerbProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        // CI-safe corpus: corpus.json is GENERATED, not tracked — on a fresh checkout build it into a UNIQUE temp
+        // dir and point the rulebook there (the pre-flight checks need it), leaving the working tree untouched.
+        string? tmp = null;
+        if (!File.Exists(CorpusRulebook.CorpusPath))
+        {
+            tmp = Path.Combine(Path.GetTempPath(), "housecarl-flags-bit-verb-guard-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tmp);
+            Console.WriteLine($"corpus.json absent — generating into {tmp} (CI / fresh checkout)…");
+            var rc = CorpusGenerator.GenerateAll(Path.Combine(tmp, "generated"), Path.Combine(tmp, "refs"));
+            if (rc != 0) { Console.Error.WriteLine("error: corpus generation failed"); return rc; }
+            CorpusRulebook.CorpusPath = Path.Combine(tmp, "generated", "corpus.json");
+        }
+        try { return RunChecks(); }
+        finally { if (tmp is not null) { try { Directory.Delete(tmp, recursive: true); } catch { /* best-effort */ } } }
+    }
+
+    static int RunChecks()
+    {
+        int failures = 0;
+        void Check(string label, bool ok, string? detail = null)
+        {
+            Console.WriteLine($"  {(ok ? "PASS" : "FAIL")}  {label}{(ok || detail is null ? "" : $"\n        -> {detail}")}");
+            if (!ok) failures++;
+        }
+
+        Console.WriteLine("flags-bit-verb-guard — Add/Remove flip ONE bit on a [Flags] enum, other bits preserved (HCBR-2026-07-15)");
+        Console.WriteLine();
+
+        // ---- S0 (control): Quest.Flags is a [Flags] enum at runtime; pick TWO distinct single-bit members to test with.
+        //      Members are read from the live enum (not hardcoded), so a Mutagen rename can't silently pass green.
+        var flagType = typeof(Quest.Flag);
+        var isFlags = flagType.IsEnum && flagType.IsDefined(typeof(FlagsAttribute), false);
+        var singleBits = new List<(string Name, ulong Bits)>();
+        foreach (var v in Enum.GetValues(flagType))
+        {
+            ulong b; try { b = Convert.ToUInt64(v!); } catch { continue; }   // skip any high-bit/negative member
+            if (b != 0 && (b & (b - 1)) == 0) singleBits.Add((v!.ToString()!, b));
+        }
+        var members = singleBits.GroupBy(m => m.Bits).Select(g => g.First()).OrderBy(m => m.Bits).ToList();
+        Check("S0: Quest.Flags is a [Flags] enum with >=2 distinct single-bit members", isFlags && members.Count >= 2,
+            $"isFlags={isFlags} singleBitMembers={members.Count}");
+        if (!isFlags || members.Count < 2)
+        {
+            Console.WriteLine("\nflags-bit-verb-guard: ABORT (test enum shape changed) — treated as FAILURE");
+            return 1;
+        }
+        var (aName, aBits) = members[0];
+        var (bName, bBits) = members[1];
+        Console.WriteLine($"  using flags A={aName} (0x{aBits:X}) B={bName} (0x{bBits:X})");
+        Console.WriteLine();
+
+        static Quest FreshQuest() =>
+            new SkyrimMod(new ModKey("hc_flags_bit", ModType.Plugin), SkyrimRelease.SkyrimSE).Quests.AddNew();
+        static ulong FlagBits(Quest q) => Convert.ToUInt64(q.Flags);
+        static WriteRequest FReq(string verb, string? value, string? key = null) =>
+            new() { RecordType = "Quest", Path = new[] { "Flags" }, Verb = verb, Value = value, Key = key };
+
+        var rb = CorpusRulebook.Load();
+
+        // ---- PRE-ACCEPT (the report's refusal, now admitted): pre-flight ACCEPTS flags Add and Remove.
+        var preAdd = rb.Validate(FReq("Add", aName));
+        Check("PRE-ACCEPT: pre-flight ACCEPTS Add of a flag on Quest.Flags", preAdd is null, preAdd);
+        var preRem = rb.Validate(FReq("Remove", aName));
+        Check("PRE-ACCEPT: pre-flight ACCEPTS Remove of a flag on Quest.Flags", preRem is null, preRem);
+
+        // ---- PRE-BADFLAG (Q3): a bogus flag NAME is REFUSED at the gate, never accepted-then-thrown at apply.
+        var preBad = rb.Validate(FReq("Add", "NotARealQuestFlag"));
+        Check("PRE-BADFLAG: pre-flight REFUSES Add of a bogus flag value (no accept-then-throw)", preBad is not null,
+            preBad ?? "ACCEPTED — a bogus flag would Enum.Parse-throw at apply");
+
+        // ---- PRE-KEY: a bit verb takes NO key (it is not a collection) — a stray key is refused, naming 'key'.
+        var preKey = rb.Validate(FReq("Add", aName, key: "0"));
+        Check("PRE-KEY: pre-flight REFUSES a flags Add with a stray key", preKey is not null && preKey.Contains("key", StringComparison.OrdinalIgnoreCase),
+            preKey ?? "ACCEPTED — a flags bit verb takes no key");
+
+        // ---- PRE-SCALAR (control): a plain scalar STILL refuses Add — the acceptance is scoped to [Flags], not universal.
+        var preScalar = rb.Validate(new WriteRequest { RecordType = "Weapon", Path = new[] { "BasicStats", "Damage" }, Verb = "Add", Value = "5" });
+        Check("PRE-SCALAR: pre-flight still REFUSES Add on a plain scalar (Weapon.BasicStats.Damage), names '[Flags]'",
+            preScalar is not null && preScalar.Contains("[Flags]", StringComparison.Ordinal),
+            preScalar ?? "ACCEPTED — Add must NOT be universal");
+
+        // ---- A1 (apply TOOTH — the anti-clobber core): Set flag A, then Add flag B -> BOTH bits set. RED before the
+        //      fix: Add on a flags enum was refused outright, so the only path was a Set that dropped A.
+        bool a1Ok; string? a1Detail;
+        try
+        {
+            var q = FreshQuest();
+            WriteEngine.ApplyVerb(q, FReq("Set", aName));               // establish A only
+            bool setTook = FlagBits(q) == aBits;
+            WriteEngine.ApplyVerb(q, FReq("Add", bName));               // <- the tooth: OR B in, A must survive
+            ulong after = FlagBits(q);
+            a1Ok = setTook && (after & aBits) != 0 && (after & bBits) != 0 && after == (aBits | bBits);
+            a1Detail = $"setTook={setTook} afterBits=0x{after:X} expected=0x{aBits | bBits:X}";
+        }
+        catch (Exception ex) { a1Ok = false; a1Detail = $"{ex.GetType().Name}: {ex.Message}"; }
+        Check("A1: Add ORs a bit in and PRESERVES the pre-existing bit (no silent clobber)", a1Ok, a1Detail);
+
+        // ---- A2 (apply TOOTH): from A|B, Remove B -> ONLY B cleared, A survives.
+        bool a2Ok; string? a2Detail;
+        try
+        {
+            var q = FreshQuest();
+            WriteEngine.ApplyVerb(q, FReq("Set", $"{aName}, {bName}"));  // A|B via a comma-combo Set
+            bool bothSet = FlagBits(q) == (aBits | bBits);
+            WriteEngine.ApplyVerb(q, FReq("Remove", bName));            // clear only B
+            ulong after = FlagBits(q);
+            a2Ok = bothSet && (after & bBits) == 0 && (after & aBits) != 0 && after == aBits;
+            a2Detail = $"bothSet={bothSet} afterBits=0x{after:X} expected=0x{aBits:X}";
+        }
+        catch (Exception ex) { a2Ok = false; a2Detail = $"{ex.GetType().Name}: {ex.Message}"; }
+        Check("A2: Remove clears ONLY its bit, other bits preserved", a2Ok, a2Detail);
+
+        // ---- A3 (idempotence): Add an already-set bit / Remove an unset bit are no-ops (pure bit math, not a toggle).
+        bool a3Ok; string? a3Detail;
+        try
+        {
+            var q = FreshQuest();
+            WriteEngine.ApplyVerb(q, FReq("Set", aName));
+            WriteEngine.ApplyVerb(q, FReq("Add", aName));               // already set -> unchanged
+            bool addNoop = FlagBits(q) == aBits;
+            WriteEngine.ApplyVerb(q, FReq("Remove", bName));           // not set -> unchanged
+            bool remNoop = FlagBits(q) == aBits;
+            a3Ok = addNoop && remNoop;
+            a3Detail = $"addNoop={addNoop} remNoop={remNoop} bits=0x{FlagBits(q):X}";
+        }
+        catch (Exception ex) { a3Ok = false; a3Detail = $"{ex.GetType().Name}: {ex.Message}"; }
+        Check("A3: Add of a set bit / Remove of an unset bit are no-ops (OR/AND-NOT, not toggle)", a3Ok, a3Detail);
+
+        // ---- APPLY-SCALAR (control): Add on a plain scalar, driven straight through apply (bypassing pre-flight),
+        //      STILL throws — the [Flags] branch did not swallow non-flags scalars.
+        bool ctrlOk; string? ctrlDetail;
+        try
+        {
+            var w = new SkyrimMod(new ModKey("hc_flags_ctrl", ModType.Plugin), SkyrimRelease.SkyrimSE).Weapons.AddNew();
+            try
+            {
+                WriteEngine.ApplyVerb(w, new WriteRequest { RecordType = "Weapon", Path = new[] { "BasicStats", "Damage" }, Verb = "Add", Value = "5" });
+                ctrlOk = false; ctrlDetail = "NO throw — Add was wrongly applied to a plain scalar";
+            }
+            catch (InvalidOperationException ex) { ctrlOk = true; ctrlDetail = ex.Message; }
+        }
+        catch (Exception ex) { ctrlOk = false; ctrlDetail = $"setup threw {ex.GetType().Name}: {ex.Message}"; }
+        Check("APPLY-SCALAR: Add on a plain scalar still throws at apply (the [Flags] branch is scoped)", ctrlOk, ctrlDetail);
+
+        // ---- E2E: Set A, Add B, SERIALIZE, re-read -> Flags came back as the UNION A|B (the clear/set PERSISTS).
+        bool e2eOk; string? e2eDetail;
+        var e2ePath = OutPath("hc_flags_bit_e2e");
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(e2ePath)!);
+            var mod = new SkyrimMod(new ModKey(Path.GetFileNameWithoutExtension(e2ePath), ModType.Plugin), SkyrimRelease.SkyrimSE);
+            var q = mod.Quests.AddNew();
+            WriteEngine.ApplyVerb(q, FReq("Set", aName));
+            WriteEngine.ApplyVerb(q, FReq("Add", bName));
+            WriteEngine.WritePatch(mod, new ISkyrimModGetter[] { mod }, e2ePath);
+            using var back = SkyrimMod.CreateFromBinaryOverlay(e2ePath, SkyrimRelease.SkyrimSE);
+            var re = back.Quests.First();
+            ulong reBits = Convert.ToUInt64(re.Flags);
+            e2eOk = reBits == (aBits | bBits);
+            e2eDetail = $"re-read Flags bits = 0x{reBits:X} expected 0x{aBits | bBits:X} ({re.Flags})";
+        }
+        catch (Exception ex) { e2eOk = false; e2eDetail = $"{ex.GetType().Name}: {ex.Message}"; }
+        finally { CleanOut(e2ePath); }
+        Check("E2E: Set+Add serializes AND re-reads as the UNION of both flags (persists through serialization)", e2eOk, e2eDetail);
+
+        Console.WriteLine();
+        Console.WriteLine(failures == 0 ? "flags-bit-verb-guard: ALL PASS" : $"flags-bit-verb-guard: {failures} FAILURE(S)");
+        return failures == 0 ? 0 : 1;
+    }
+
+    static string OutPath(string stem) =>
+        Path.Combine(Path.GetTempPath(), stem + "-" + Guid.NewGuid().ToString("N"), stem + ".esp");
+
+    static void CleanOut(string outPath)
+    {
+        try { var dir = Path.GetDirectoryName(outPath); if (dir is not null && Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+        catch { /* best-effort */ }
+    }
+}

--- a/src/housecarl-generator/FlagsBitVerbProbe.cs
+++ b/src/housecarl-generator/FlagsBitVerbProbe.cs
@@ -31,7 +31,10 @@ namespace HousecarlGenerator;
 /// silently), PRE-ACCEPT (pre-flight now ADMITS flags Add/Remove — was the report's refusal), PRE-BADFLAG (a bogus
 /// flag is REFUSED at the gate, not accepted-then-thrown — Q3), PRE-KEY (a stray key is refused — a bit verb takes
 /// none), PRE-SCALAR / APPLY-SCALAR (a plain scalar still REFUSES Add at BOTH gate and apply — the acceptance is
-/// scoped to [Flags], it did not go universal).
+/// scoped to [Flags], it did not go universal), and NONNULL-VALUELESS / NULLABLE-VALUELESS (PR #202 review: a
+/// VALUELESS Remove keeps its pre-bit-verb whole-clear meaning — accepted on a nullable flags field, refused with a
+/// Set-'0' redirect on a non-nullable one — so the bit verbs ADD capability without removing the only path to null a
+/// nullable flags field; the scan also reports the live nullable-flags blast radius).
 ///
 /// Self-contained: the apply/E2E teeth are pure in-memory Mutagen (no plugin file, no Skyrim.esm); the PRE-* checks
 /// use the GENERATED corpus.json (built into a unique temp dir on a fresh checkout, exactly as formlink-remove-guard).
@@ -123,6 +126,37 @@ public static class FlagsBitVerbProbe
             preScalar is not null && preScalar.Contains("[Flags]", StringComparison.Ordinal),
             preScalar ?? "ACCEPTED — Add must NOT be universal");
 
+        // ---- NULLABLE-FLAGS whole-clear PRESERVATION (PR #202 review): the bit verbs must ADD capability without
+        //      removing any. A VALUELESS Remove keeps its pre-bit-verb meaning — the whole-field clear of a NULLABLE
+        //      scalar, the only path to make a nullable flags field absent (null) — so it is still accepted on a
+        //      nullable flags field and refused (with a turn-all-off redirect) only on a NON-nullable one.
+        Console.WriteLine();
+        Console.WriteLine("── NULLABLE flags: valueless Remove still whole-clears (nullable) / refused w/ redirect (non-nullable) ──");
+        var preNoVal = rb.Validate(FReq("Remove", null));
+        Check("NONNULL-VALUELESS: valueless Remove on non-nullable Quest.Flags is REFUSED, names the Set '0' redirect (not a dead end)",
+            preNoVal is not null && preNoVal.Contains("'0'", StringComparison.Ordinal),
+            preNoVal ?? "ACCEPTED — a non-nullable flags field can't be whole-cleared");
+
+        // Discover the ACTUAL nullable [Flags] surface from the live corpus (measures the change's blast radius, and if
+        // any ROOT-record one exists, proves the gate still ACCEPTS its valueless whole-clear).
+        var corpus = CorpusRulebook.LoadCorpus();
+        var nullableFlags = new List<(string Type, string Field, bool Root)>();
+        foreach (var ts in corpus.Types.Values)
+            foreach (var f in ts.Fields)
+                if (f.Cardinality == "enum" && f.Nullable && ResolvesToFlags(f.MutableTypeAssemblyQualified ?? f.GetterTypeAssemblyQualified))
+                    nullableFlags.Add((ts.Name, f.Name, ts.Kind == "record"));
+        Console.WriteLine($"  corpus nullable [Flags] fields: {nullableFlags.Count}" +
+            (nullableFlags.Count > 0 ? " — e.g. " + string.Join(", ", nullableFlags.Take(6).Select(x => $"{x.Type}.{x.Field}")) : " (none — whole-clear preservation is vacuously safe, kept by construction)"));
+        var rootNullable = nullableFlags.FirstOrDefault(x => x.Root);
+        if (rootNullable.Type is not null)
+        {
+            var preNullClear = rb.Validate(new WriteRequest { RecordType = rootNullable.Type, Path = new[] { rootNullable.Field }, Verb = "Remove", Value = null });
+            Check($"NULLABLE-VALUELESS: valueless Remove on a nullable flags field ({rootNullable.Type}.{rootNullable.Field}) is ACCEPTED (whole-clear preserved)",
+                preNullClear is null, preNullClear);
+        }
+        else
+            Console.WriteLine("  (no ROOT-record nullable flags field to gate-test; the leaf.Nullable branch is still exercised by the non-nullable refusal above)");
+
         // ---- A1 (apply TOOTH — the anti-clobber core): Set flag A, then Add flag B -> BOTH bits set. RED before the
         //      fix: Add on a flags enum was refused outright, so the only path was a Set that dropped A.
         bool a1Ok; string? a1Detail;
@@ -210,6 +244,18 @@ public static class FlagsBitVerbProbe
         Console.WriteLine();
         Console.WriteLine(failures == 0 ? "flags-bit-verb-guard: ALL PASS" : $"flags-bit-verb-guard: {failures} FAILURE(S)");
         return failures == 0 ? 0 : 1;
+    }
+
+    /// <summary>Does the field's assembly-qualified type resolve to a <c>[Flags]</c> enum? The probe-side mirror of
+    /// <c>CorpusRulebook.IsFlagsEnumLeaf</c>'s flags test — resolved via <c>Type.GetType(aq)</c> (Mutagen is loaded),
+    /// so the discovery scan classifies exactly what the gate does.</summary>
+    static bool ResolvesToFlags(string? aq)
+    {
+        if (string.IsNullOrEmpty(aq)) return false;
+        var rt = Type.GetType(aq);
+        if (rt is null) return false;
+        var u = Nullable.GetUnderlyingType(rt) ?? rt;
+        return u.IsEnum && u.IsDefined(typeof(FlagsAttribute), false);
     }
 
     static string OutPath(string stem) =>

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1662,9 +1662,12 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>Resolve+read many records in one call (housecarl_batch_record_detail). Each formid runs the same
     /// <see cref="ResolveRead"/> path, so a bad/absent formid yields a per-item recoverable error (Q3) without
-    /// failing the batch. Returns one <see cref="ReadOutcome"/> per input, in order.</summary>
+    /// failing the batch. Returns one <see cref="ReadOutcome"/> per input, in order. <paramref name="plugin"/> —
+    /// when set — reads every formid AS THAT NAMED PLUGIN'S version (its override, not the load-order winner), the
+    /// batch twin of housecarl_read_record's plugin= (HCBR-2026-07-15): a formid that plugin doesn't touch yields
+    /// its own per-item error (ResolveRead's "does not define this record"), never failing the batch.</summary>
     public IReadOnlyList<ReadOutcome> ResolveBatch(IReadOnlyList<string> formids, IReadOnlyList<string>? fields, bool conflictTree, int depth = 1,
-                                                   bool resolveNames = false)
+                                                   bool resolveNames = false, string? plugin = null)
     {
         var resolver = Resolver;                // build/refresh ONCE for the batch
         var view = resolver.Capture();          // ONE build for every item — the whole batch is one logical operation (HCBR-2026-06-11-02)
@@ -1675,7 +1678,7 @@ public sealed class LoadOrderService : IDisposable
             FormKey fk;
             try { fk = FormKey.Factory(raw.Trim()); }
             catch (Exception ex) { outcomes.Add(ReadOutcome.Fail(default, $"bad FormID '{raw}': {ex.Message}")); continue; }
-            outcomes.Add(ResolveRead(resolver, view, fk, null, fields, conflictTree, depth, resolveNames, linkMemo));
+            outcomes.Add(ResolveRead(resolver, view, fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo));
         }
         return outcomes;
     }

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -58,15 +58,17 @@ public static class ReadTools
     [McpServerTool(Name = "housecarl_batch_record_detail", ReadOnly = true, Title = "Read many records"),
      Description(
          "Read many records in ONE call (saves per-record tool-call overhead). Each FormID resolves to its " +
-         "load-order winner and renders like housecarl_read_record; a bad or absent FormID yields a per-item error " +
-         "without failing the batch. With conflict_tree=true each record also gets its touching-plugin list + " +
-         "winner-relative field diff. The combined response is size-estimated: over the cap it stops with an explicit " +
-         "'rendered X of N' notice (never silent truncation) — request fewer formids, pass fields= to slim each, or " +
-         "raise max_chars. Does NOT modify anything.")]
+         "load-order winner (or a named plugin's version via plugin=) and renders like housecarl_read_record; a bad " +
+         "or absent FormID yields a per-item error without failing the batch. With conflict_tree=true each record " +
+         "also gets its touching-plugin list + winner-relative field diff. The combined response is size-estimated: " +
+         "over the cap it stops with an explicit 'rendered X of N' notice (never silent truncation) — request fewer " +
+         "formids, pass fields= to slim each, or raise max_chars. Does NOT modify anything.")]
     public static string BatchRecordDetail(
         LoadOrderService svc,
         [Description("The FormIDs to read, each 'XXXXXX:Plugin.esp'. Resolved in order; results are returned in the same order.")]
             string[] formids,
+        [Description("Optional. Read THIS plugin's version of EVERY record instead of the load-order winner (a filename, e.g. 'Gray Fox Cowl.esm') — the batch twin of housecarl_read_record's plugin=. Use to bulk-read a specific override's version (e.g. a mod's OWN records when something else currently wins). A formid that plugin doesn't touch gets its own per-item error; the rest still read.")]
+            string? plugin = null,
         [Description("Optional. Dotted field paths to read for EVERY record (e.g. 'Name', 'BasicStats.Damage'); index a list/dict element with BRACKETS, e.g. 'Effects[0].Data.Magnitude'. Omit to dump every modeled field one level deep per record.")]
             string[]? fields = null,
         [Description("Optional. Expansion depth for list/dict/substruct CONTENTS per record (default 1). depth=2 enumerates each container's elements with index + identity (see housecarl_read_record). Bounded per record with an explicit truncation note.")]
@@ -85,7 +87,7 @@ public static class ReadTools
         bool json = Wire.WantsJson(format, out var ferr);
         if (ferr is not null) return ferr;
         if (json && conflict_tree) return "error: conflict_tree=true is a text-only diff view and is not carried in json mode — use format=text for the conflict tree, or drop conflict_tree for the json field data.";
-        var outcomes = svc.ResolveBatch(formids, fields, conflict_tree, depth <= 0 ? 1 : depth, resolve_names);
+        var outcomes = svc.ResolveBatch(formids, fields, conflict_tree, depth <= 0 ? 1 : depth, resolve_names, plugin?.Trim());
         return json ? JsonWire.RenderBatch(outcomes, max_chars) : Wire.RenderBatch(svc, outcomes, fields, conflict_tree, max_chars);
     });
 

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -36,7 +36,7 @@ public static class WriteTools
             string formid,
         [Description("Dotted field path to edit, e.g. 'BasicStats.Damage', 'Name', 'Keywords'. Step into a list/dict element MID-PATH with brackets, e.g. 'Effects[0].Data.Magnitude' or 'VirtualMachineAdapter.Aliases[0].Scripts[0].Properties'. At the LEAF, edit a collection element with verb + key (SetAtIndex/Remove by index, Set/Remove by dict key) — not brackets.")]
             string field_path,
-        [Description("The value, coerced to the field's type: a number, an enum name (e.g. 'OneHanded'), or a FormID 'XXXXXX:Plugin.esp' for a reference. On a [Flags] enum, the flag(s) to Add/Remove (a name or comma-combo, e.g. 'ManualCostCalc'). Omit only for a Remove that CLEARS a whole scalar/link (a flags Remove still needs the bit to clear).")]
+        [Description("The value, coerced to the field's type: a number, an enum name (e.g. 'OneHanded'), or a FormID 'XXXXXX:Plugin.esp' for a reference. On a [Flags] enum, the flag(s) to Add/Remove (a name or comma-combo, e.g. 'ManualCostCalc'). Omit only for a Remove that whole-clears a NULLABLE field (scalar/link/flags → cleared/absent); a flags Remove WITH a value clears just that bit, and to turn all bits off Set the field to '0'.")]
             string? value = null,
         [Description("Set (default) | Add | Remove | SetAtIndex | ReplaceAll. Set edits a scalar (or a dict element with key=); Add/Remove/SetAtIndex/ReplaceAll edit a collection. On a [Flags] enum (SPEL Flags, NPC Configuration.Flags, WEAP Data.Flags, …), Add SETS a bit and Remove CLEARS one, leaving the OTHER bits untouched — the way to flip one flag WITHOUT a Set re-listing (and silently dropping) every bit you didn't mention.")]
             string verb = "Set",

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -36,9 +36,9 @@ public static class WriteTools
             string formid,
         [Description("Dotted field path to edit, e.g. 'BasicStats.Damage', 'Name', 'Keywords'. Step into a list/dict element MID-PATH with brackets, e.g. 'Effects[0].Data.Magnitude' or 'VirtualMachineAdapter.Aliases[0].Scripts[0].Properties'. At the LEAF, edit a collection element with verb + key (SetAtIndex/Remove by index, Set/Remove by dict key) — not brackets.")]
             string field_path,
-        [Description("The value, coerced to the field's type: a number, an enum name (e.g. 'OneHanded'), or a FormID 'XXXXXX:Plugin.esp' for a reference. Omit only for Remove.")]
+        [Description("The value, coerced to the field's type: a number, an enum name (e.g. 'OneHanded'), or a FormID 'XXXXXX:Plugin.esp' for a reference. On a [Flags] enum, the flag(s) to Add/Remove (a name or comma-combo, e.g. 'ManualCostCalc'). Omit only for a Remove that CLEARS a whole scalar/link (a flags Remove still needs the bit to clear).")]
             string? value = null,
-        [Description("Set (default) | Add | Remove | SetAtIndex | ReplaceAll. Set edits a scalar (or a dict element with key=); Add/Remove/SetAtIndex/ReplaceAll edit a collection.")]
+        [Description("Set (default) | Add | Remove | SetAtIndex | ReplaceAll. Set edits a scalar (or a dict element with key=); Add/Remove/SetAtIndex/ReplaceAll edit a collection. On a [Flags] enum (SPEL Flags, NPC Configuration.Flags, WEAP Data.Flags, …), Add SETS a bit and Remove CLEARS one, leaving the OTHER bits untouched — the way to flip one flag WITHOUT a Set re-listing (and silently dropping) every bit you didn't mention.")]
             string verb = "Set",
         [Description("Optional. The dict key or list index at the leaf (for a dict Set, a SetAtIndex/Remove on a list, etc.).")]
             string? key = null,


### PR DESCRIPTION
Two of the four gaps from the 2026-07-15 Gray Fox Cowl validation run, now tracked as issues (the local store was retired mid-flight and migrated to #195–#201).

**Closes #196** — ① `fix(write)` flags-enum bit verbs.
**Closes #195** — ② `feat(read)` `batch_record_detail plugin=`.

Deferred this session: #197 (③ container-presence `where=`) and #198 (④ PerkPlacement depth=2 identity).

## ① flags-enum Add/Remove flip one bit, not clobber the rest (#196)
The Q3-critical one. A `[Flags]` field was whole-value-replace only: a literal `Set` silently dropped every bit the caller didn't re-list (the run cleared `ManualCostCalc` on 6 spells, `Essential`/`IsGhost`/etc. on named NPCs — pre-flight accepted it, read-back confirmed it). Now `Add`/`Remove` are bit-SET / bit-CLEAR on a `[Flags]` leaf. Gate (`CorpusRulebook.IsFlagsEnumLeaf` + step-4-flags value check) and apply (`WriteEngine.ApplyFlagsBitVerb`) share the same `FlagsAttribute` test; a bogus flag fails loud at the gate; non-flags scalars still refuse the verbs.

**Nullable-flags whole-clear preserved (review response):** a valueless `Remove` keeps its pre-bit-verb whole-clear meaning — accepted on a nullable `[Flags]` field (31 exist in the corpus; it's the only path to null one), refused on a non-nullable one with a `Set '0'` redirect. Bit verbs *add* capability without removing any.

New `flags-bit-verb-guard` (14 checks): anti-clobber Add, scoped-not-universal controls, nullable/non-nullable valueless-Remove, serialize+re-read round-trip.

## ② `batch_record_detail plugin=` (#195)
`read_record` had `plugin=`; the batch sibling didn't, so re-patching an already-patched mod fell to one-call-per-record — and under the response cap, to sampling (12 of 40 records). Threaded through to the existing `ResolveRead` plugin path; a not-touched record is a per-item error, batch survives; json carries `source`. `bulk-primitives-wave2-guard` +5 checks.

## Verification
`ci-all` **93/93 green**. Three atomic commits (② + ① + the nullable-flags review fix). Rebased onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)