### PR TITLE
release: 1.8.1 — where= presence predicate (#197) + depth-2 lone-FormLink identity (#198)

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "housecarl",
   "displayName": "houseCARL",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Comprehensive data-layer access to your Skyrim SE load order — read any record, author patches into a new plugin, look mods up on Nexus, and look up record schemas, Papyrus signatures, performance reviews, and distributor grammars — in plain English.",
   "author": { "name": "Avick3110" },
   "homepage": "https://github.com/Avick3110/houseCARL",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to houseCARL are documented here. Versioning is [semantic](h
 the `version` in `.claude-plugin/plugin.json` is bumped on each release, so installed users update only
 when it changes.
 
+## 1.8.1 — 2026-07-16
+
+A small read/query-surface patch: two refinements that let a whole-plugin audit and a record read land the
+answer in one call instead of a workaround. No new tools or skills (still 43 tools / 13 skills).
+
+- **`cross_plugin_query where=` gains `exists` / `missing` — presence filtering on whole fields.** The value
+  operators (`=`, `>=`, `contains`, the bitwise `has`, …) test a *scalar* leaf, so "which records actually
+  CARRY a script adapter / an effects list / conditions" meant a sweep-then-filter, one call per record
+  type. `where=["VirtualMachineAdapter exists"]` now returns exactly the records that carry that field, and
+  `missing` is its complement. "Present" means present **and non-empty** — a non-null substruct or a list
+  with at least one element — so an empty list reads as absent, not carried. A mistyped field still fails
+  loud, never a silent "0 matches". (#197)
+- **A struct's lone FormLink now renders as its identity at `depth=2`.** Reading an NPC's `Perks` at depth 2
+  showed each entry as a bare `[PerkPlacement]` with no perk FormID, so the links read as "not surfaced".
+  Any struct that has no name-like identity but exactly one FormLink now surfaces it —
+  `Perks[0] = [PerkPlacement] Perk=03AF81:Skyrim.esm` — matching what script properties already do with
+  `Name=`. Two or more links stay opaque (ambiguous — not guessed). (#198)
+
 ## 1.8.0 — 2026-07-15
 
 houseCARL gains two capability layers at once: a **keyless Nexus update-checking** stack — know which of


### PR DESCRIPTION
Patch release over 1.8.0. Bumps `plugin.json` → **1.8.1** and adds the CHANGELOG entry for the two read/query-surface fixes that already landed on `main` (#197, #198). No new tools or skills (still 43 / 13).

**Package cut + gated:**
- `houseCARL-1.8.1.zip` — 335 entries, 330 files, 13 skills, 16.78 MB
- `claude plugin validate ./dist/housecarl --strict` — **GREEN**

**Contents (already merged as code):**
- **#197** — `cross_plugin_query where=` gains no-operand `exists` / `missing` presence operators: "which records CARRY a substruct/list field" in one call (present *and non-empty*), replacing per-record-type sweep-then-filter.
- **#198** — a struct's lone FormLink renders as its `depth=2` identity (`[PerkPlacement] Perk=03AF81:Skyrim.esm`), matching `ScriptObjectProperty`'s `Name=`.

On merge: tag `v1.8.1` → GitHub Release with the zip asset. Nexus (mod 181738) is the manual lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)