### PR TITLE
feat(skse): housecarl_skse_config_audit — SKSE config references vs the load order (tier B, #199)

### DIFF
--- a/src/housecarl-core/FormIdRange.cs
+++ b/src/housecarl-core/FormIdRange.cs
@@ -47,4 +47,38 @@ public static class FormIdRange
     /// allocator — each keeps its OWN error surface (a throw at the create boundary vs a graceful Fail outcome in the
     /// copy flow), only the ceiling comparison is single-sourced here.</summary>
     public static bool ObjectIdSpaceExhausted(uint nextFormId) => nextFormId > ObjectIdMax;
+
+    /// <summary>The high-byte signature of a light-master (ESL) RUNTIME FormID (0xFE000000). At load the engine gives every
+    /// light master the shared <c>0xFE</c> index and packs a 12-bit light-order index into the next 12 bits, leaving the
+    /// record its low 12 bits (<see cref="LightObjectIdMask"/>). A full plugin never loads at 0xFE (that slot is reserved
+    /// for the light block; 0xFF is the runtime-dynamic block), so <c>(id &amp; 0xFF000000) == LightMasterIndexPrefix</c> is
+    /// the unambiguous "this token is a light-prefixed runtime FormID" test.</summary>
+    public const uint LightMasterIndexPrefix = 0xFE000000;
+
+    /// <summary>The 12-bit object-ID mask (0xFFF) for a light-master (ESL) record — its local object ID relative to the
+    /// light master, once the shared <c>0xFE</c> index and the 12-bit light-order index are masked off. Same value as
+    /// <see cref="EslWindowCeiling"/> (the ESL window is 0x000–0xFFF); named for the masking use so a call site reads
+    /// "mask off to the light local id", not "compare against the window ceiling".</summary>
+    public const uint LightObjectIdMask = EslWindowCeiling;
+
+    /// <summary>Strip a config-token / runtime FormID down to the record's LOCAL object ID relative to its named plugin —
+    /// the low 12 bits for a light-prefixed (<see cref="LightMasterIndexPrefix"/>) token (the light index is not part of the
+    /// id), the low 24 bits (<see cref="ObjectIdMask"/>) otherwise (the high byte is the load-order master index, which the
+    /// plugin name — not the token — supplies). This is the SINGLE home for the distributor-config FormID normalization the
+    /// SkyPatcher overlay and the SKSE config audit both apply: a full load-indexed light FormID (<c>FExxxYYY</c> — the
+    /// xEdit copy the grammar references treat as always legal) keeps only its <c>YYY</c>. Getting the light-vs-full split
+    /// wrong inverts every resolve verdict, so both consumers read it here rather than restating the hex.
+    ///
+    /// <para>VERIFIED against DSD's own parser (SkyHorizon3/SSE-Dynamic-String-Distributor, <c>src/Utils.cpp</c>
+    /// <c>getRuntimeFormID</c>: <c>(raw &amp; 0xFFF)</c> when the named plugin <c>IsLight()</c>, else <c>(raw &amp; 0xFFFFFF)</c>).
+    /// DSD's authority is the NAMED PLUGIN's light flag; this token-prefix rule (0xFE top byte ⇒ light) produces the
+    /// IDENTICAL local id for every shape DSD emits — the <c>FExxxYYY</c> full-runtime copy and the 0x-/bare-hex full forms.
+    /// The ONE divergence is a bare ≤6-hex token that carries a light index but no 0xFE prefix (e.g. <c>800123</c>): DSD
+    /// masks it to 0x123 via the flag, this rule keeps 0x800123. DSD never EMITS that shape (its export trims ESL to
+    /// ≤0xFFF), so it can only arise from a hand-authored config — the documented Wave-1 residual; a plugin-flag mask would
+    /// close it (a possible refinement, deliberately not adopted under the locked plan).</para></summary>
+    public static uint LocalObjectId(uint runtimeFormId) =>
+        (runtimeFormId & 0xFF000000) == LightMasterIndexPrefix
+            ? runtimeFormId & LightObjectIdMask       // FExxxYYY light runtime FormID → the 12-bit local id (YYY)
+            : runtimeFormId & ObjectIdMask;           // else the high byte is the master index → keep the low 24 bits
 }

--- a/src/housecarl-core/SkseConfigReferenceExtractor.cs
+++ b/src/housecarl-core/SkseConfigReferenceExtractor.cs
@@ -1,0 +1,137 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace HousecarlCore;
+
+/// <summary>
+/// The catalog-FREE, framework-AGNOSTIC extractor for the SKSE config audit (tier B — plan
+/// dev/plans/SKSE_TIER_B_CONFIG_AUDIT_PLAN_2026-07-16.md). It scans one config file's TEXT for the two
+/// things that can be validated against the load order without knowing what any framework MEANS:
+/// <list type="number">
+///   <item><b>Form-shaped tokens</b> — a hex FormID paired with a plugin filename by <c>|</c> or <c>~</c>,
+///     in EITHER order (<c>0xHEX|Plugin.esp</c> as DSD/CDF/po3-lineage write it, <c>Plugin.esp|0xHEX</c> as
+///     SkyPatcher writes it, and the <c>~</c> tilde form). The 8-hex light-runtime FormID (<c>FExxxYYY</c>) is
+///     normalized to its local object id through the ONE shared home, <see cref="FormIdRange.LocalObjectId"/>.</item>
+///   <item><b>Path-segment plugin gates</b> — a directory component that is itself a plugin filename
+///     (<c>DynamicStringDistributor\Plugin.esp\file.json</c>): the folder gates the whole file on that plugin's
+///     presence.</item>
+/// </list>
+///
+/// <para><b>Pure + line-local (Q3, §4d/§4e).</b> Extraction is a HEURISTIC over token SHAPES, not a per-framework
+/// parse: a hex+plugin token in a comment or a disabled block still surfaces (we don't model enabled/disabled
+/// semantics — the framing is "references this file declares", never "references the DLL will use"). No JSON/TOML
+/// object model is built; references are line-local, so the scan is one regex pass per line. What a reference is
+/// FOR — a filter, a swap target, an AV alias — is framework semantics and stays at the skill layer (§4a).</para>
+///
+/// <para><b>Scope boundary.</b> This finds explicit form-SHAPED references only. Bare EditorID / name strings
+/// (<c>"LocSetNordicRuin"</c>) and name-grammars (AVG alias names) are NOT validated here — a JSON string is not
+/// unambiguously an EditorID, and validating every string would drown the signal (Wave 2, §4a/§7). The verdict
+/// (OK / PLUGIN MISSING / DANGLING / UNPARSEABLE) is the SERVICE layer's job: this stage produces the references;
+/// resolving them against the active order is <c>LoadOrderService</c>'s.</para>
+/// </summary>
+public static class SkseConfigReferenceExtractor
+{
+    // A form-shaped reference: a hex FormID and a plugin filename joined by '|' or '~', in EITHER order. The plugin
+    // side is any run (spaces/dashes/APOSTROPHES/'&' allowed — "kryptopyr's ... .esp", "Dynamic Activation Key -
+    // Addons Collection.esp") that ends in .esl/.esm/.esp and contains none of the delimiters / double-quote / path
+    // separators / PARENTHESES / JSON-INI structure that would mark a token boundary. Two deliberate charset choices, both
+    // forced by the live gate: (1) apostrophe is ALLOWED — excluding it truncated real names mid-word at the ' (the
+    // false-MISSING on kryptopyr's / Sanguine's mods); a leading TOML single-quote that rides in is stripped in
+    // BuildTokenRef. (2) parentheses are EXCLUDED — a config COMMENT/description embedding a token in prose ("will cast
+    // fireball (Skyrim.esm|0x5)") otherwise grabbed the whole prose prefix as the plugin name; the '(' now bounds it to the
+    // real name. Cost: a plugin file literally named "Mod (v2).esp" is missed — rare, and the honest tradeoff for killing
+    // prose false-positives. The hex side is up to 16 digits so an OVERFLOW token is CAPTURED (as UNPARSEABLE) not silently
+    // missed. The alnum look-around stops a token gluing onto an adjacent identifier.
+    const string PluginRun = @"[^|~""=,:{}()\[\]/\\\r\n]*?\.es[lmp]";
+    const string HexRun = @"(?:0x)?[0-9A-Fa-f]{1,16}";
+    static readonly Regex FormToken = new(
+        @"(?<![0-9A-Za-z])(?:" +
+            $@"(?<hexA>{HexRun})\s*(?<delimA>[|~])\s*(?<pluginA>{PluginRun})" + "|" +
+            $@"(?<pluginB>{PluginRun})\s*(?<delimB>[|~])\s*(?<hexB>{HexRun})" +
+        @")(?![0-9A-Za-z])",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    /// <summary>Extract every form-shaped reference and path-segment plugin gate a config declares. <paramref name="relPath"/>
+    /// is the file's path under Data (e.g. <c>SKSE\Plugins\DynamicStringDistributor\Plugin.esp\file.json</c>) — its directory
+    /// components are checked for plugin-named gates; <paramref name="text"/> is the file's decoded content. Pure: no I/O, no
+    /// load-order knowledge. Faithful: every occurrence is returned (the service dedupes for rendering), duplicates included.</summary>
+    public static IReadOnlyList<SkseConfigRef> Extract(string relPath, string text)
+    {
+        var refs = new List<SkseConfigRef>();
+
+        // 1) Path-segment plugin gates: any DIRECTORY component (every segment but the final filename) that is a plugin
+        //    filename gates the whole file on that plugin. Deduped — one folder named Plugin.esp is one gate for the file.
+        var segs = (relPath ?? "").Split('\\', '/');
+        var seenGate = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (int i = 0; i < segs.Length - 1; i++)   // exclude the last segment (the file itself)
+        {
+            var seg = segs[i];
+            if (EndsInPlugin(seg) && seenGate.Add(seg))
+                refs.Add(new SkseConfigRef(seg, SkseRefShape.PathSegmentGate, seg, null, null, 0, null));
+        }
+
+        // 2) Form-shaped tokens, one regex pass per physical line (references are line-local — §4e).
+        if (!string.IsNullOrEmpty(text))
+        {
+            int line = 0;
+            foreach (var raw in text.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n'))
+            {
+                line++;
+                if (raw.IndexOf('|') < 0 && raw.IndexOf('~') < 0) continue;   // no possible delimiter → skip the regex
+                foreach (Match m in FormToken.Matches(raw))
+                {
+                    bool altA = m.Groups["hexA"].Success;
+                    string rawHex = (altA ? m.Groups["hexA"] : m.Groups["hexB"]).Value;
+                    // Strip a leading TOML single-quote / whitespace that rode in with the plugin name (the match ends at
+                    // .esX, so only a LEADING delimiter is possible — a real filename never starts with a quote/space).
+                    string plugin = (altA ? m.Groups["pluginA"] : m.Groups["pluginB"]).Value.Trim().Trim('\'');
+                    refs.Add(BuildTokenRef(m.Value, plugin, rawHex, line));
+                }
+            }
+        }
+        return refs;
+    }
+
+    /// <summary>Normalize one matched token into a reference — strip <c>0x</c>, reject an over-wide / unparseable hex LOUDLY
+    /// (never guessed), else mask to the local object id via the shared <see cref="FormIdRange.LocalObjectId"/> home.</summary>
+    static SkseConfigRef BuildTokenRef(string rawMatch, string plugin, string rawHex, int line)
+    {
+        string digits = rawHex.StartsWith("0x", StringComparison.OrdinalIgnoreCase) ? rawHex[2..] : rawHex;
+        if (digits.Length == 0 || digits.Length > 8 || !uint.TryParse(digits, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var runtimeId))
+            return new SkseConfigRef(rawMatch, SkseRefShape.FormToken, plugin, null, rawHex, line,
+                $"'{rawHex}' is not a 32-bit FormID (needs 1–8 hex digits) — cannot normalize");
+        return new SkseConfigRef(rawMatch, SkseRefShape.FormToken, plugin, FormIdRange.LocalObjectId(runtimeId), rawHex, line, null);
+    }
+
+    /// <summary>True when a path/name segment ends in a plugin extension (.esl/.esm/.esp), case-insensitively.</summary>
+    static bool EndsInPlugin(string s) =>
+        s.EndsWith(".esp", StringComparison.OrdinalIgnoreCase) ||
+        s.EndsWith(".esm", StringComparison.OrdinalIgnoreCase) ||
+        s.EndsWith(".esl", StringComparison.OrdinalIgnoreCase);
+}
+
+/// <summary>Whether a <see cref="SkseConfigRef"/> is a hex FormID token or a plugin-named directory gate.</summary>
+public enum SkseRefShape
+{
+    /// <summary>A hex FormID paired with a plugin filename (<c>0xHEX|Plugin.esp</c> / <c>Plugin.esp|0xHEX</c> / tilde form).</summary>
+    FormToken,
+    /// <summary>A directory component that is a plugin filename — gates the whole file on that plugin's presence.</summary>
+    PathSegmentGate,
+}
+
+/// <summary>
+/// One reference a config file declares, as extracted (pre-verdict). <see cref="Plugin"/> is the named plugin filename;
+/// <see cref="LocalId"/> is the normalized local object id (null for a <see cref="SkseRefShape.PathSegmentGate"/>, which
+/// is plugin-presence only, and null when <see cref="Unparseable"/> is set); <see cref="RawHex"/> is the hex as written;
+/// <see cref="Line"/> is the 1-based source line (0 for a path gate); <see cref="Unparseable"/> carries the loud reason a
+/// shape-matched token could not be normalized (Q3 — never a silent guess). The OK / PLUGIN MISSING / DANGLING verdict is
+/// assigned by the service against the load order.
+/// </summary>
+public sealed record SkseConfigRef(
+    string Raw,
+    SkseRefShape Shape,
+    string Plugin,
+    uint? LocalId,
+    string? RawHex,
+    int Line,
+    string? Unparseable);

--- a/src/housecarl-core/SkyPatcherOverlay.cs
+++ b/src/housecarl-core/SkyPatcherOverlay.cs
@@ -805,9 +805,9 @@ public static class SkyPatcherOverlay
         fk = default;
         if (a.Plugin is null || a.FormId is null) return false;
         if (!ModKey.TryFromNameAndExtension(a.Plugin, out var mk)) return false;
-        var id = a.FormId.Value;
-        id = (id & 0xFF000000) == 0xFE000000 ? id & 0xFFF : id & 0xFFFFFF;
-        fk = new FormKey(mk, id);
+        // The FExxxYYY-light-vs-low-24 normalization lives in one tested home (FormIdRange) so it can't drift between the
+        // SkyPatcher overlay and the SKSE config audit, which both apply it (getting it wrong inverts every verdict).
+        fk = new FormKey(mk, FormIdRange.LocalObjectId(a.FormId.Value));
         return true;
     }
 

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -108,6 +108,11 @@ public static class CiAll
         ("flags-bit-verb-guard", FlagsBitVerbProbe.RunGuard),
         ("gendered-nav-guard", GenderedNavProbe.RunGuard),
         ("loadorder-status-guard", LoadOrderStatusProbe.RunGuard),
+        // SKSE config audit (tier B, #199): the reference EXTRACTOR pinned against every §3 evidence shape (both token
+        // orders, ESL FExxxYYY vs low-24 masking via the shared FormIdRange home, tilde form, path-segment gate, comment/
+        // overflow/no-ref accounting) PLUS the service VERDICTS (OK/PLUGIN-MISSING/DANGLING/UNPARSEABLE + ESL FE-prefix
+        // resolve) driven through LoadOrderService.Adjudicate over a synthetic full+light order. Self-contained.
+        ("skse-config-audit-guard", SkseConfigAuditProbe.RunGuard),
         ("compile-ergonomics-guard", CompileErgonomicsProbe.RunGuard),
         ("setup-update-lock-guard", SetupUpdateLockProbe.RunGuard),
         ("import-order-guard", ImportOrderProbe.RunGuard),

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -242,6 +242,11 @@ if (args.Length > 0 && args[0] == "remap-wave2-nested-mech") return RemapWave2Ne
 // MO2 instance and print the render + timing (the CI skse-reader-guard pins the decode; this proves the full inventory).
 if (args.Length > 0 && args[0] == "skse-inventory-real") return SkseInventoryProbe.RunReal(args[1..]);
 
+// SKSE config audit (tier B, #199) reference-extractor + verdict CI guard, and the manual real-data harness (the live gate:
+// runs the whole audit against a live MO2 instance and prints the audit + timing).
+if (args.Length > 0 && args[0] == "skse-config-audit-guard") return SkseConfigAuditProbe.RunGuard(args[1..]);
+if (args.Length > 0 && args[0] == "skse-config-audit-real") return SkseConfigAuditProbe.RunReal(args[1..]);
+
 var outputDir = Path.GetFullPath(args.Length > 0 ? args[0] : "generated");
 // The slim reference tree ships INSIDE the skill (tracked); corpus.json + summary stay in generated/.
 // Default assumes the generator is run from the repo root (as `dotnet run --project src/housecarl-generator`).

--- a/src/housecarl-generator/SkseConfigAuditProbe.cs
+++ b/src/housecarl-generator/SkseConfigAuditProbe.cs
@@ -1,0 +1,250 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SELF-CONTAINED CI REGRESSION GUARD for the SKSE config-audit reference EXTRACTOR (tier B — plan
+/// dev/plans/SKSE_TIER_B_CONFIG_AUDIT_PLAN_2026-07-16.md, Wave 1.4). Pins the extractor
+/// (<see cref="SkseConfigReferenceExtractor"/>) against every reference SHAPE the §3 evidence sample
+/// established — the piece where a wrong parse silently changes what the audit thinks a file references
+/// (a false DANGLING is the tool's worst failure mode). No load order needed: extraction is pure.
+///
+/// Shapes pinned:
+///   * CDF/po3-lineage <c>0xHEX|Plugin.esp</c> inside JSONC (with // comments) — formid-FIRST.
+///   * DSD 8-hex ESL-prefixed <c>FExxxYYY|Plugin.esp</c> — masks to the 12-bit local id (the load-bearing rule).
+///   * 8-hex NON-ESL <c>XXyyyyyy|Plugin.esp</c> — masks to the low 24 bits (the OTHER arm of the split).
+///   * SkyPatcher <c>Plugin.esp|0xHEX</c> — plugin-FIRST (opposite order).
+///   * Tilde form <c>0xHEX~Plugin.esp</c> (KID/SPID shape).
+///   * Comma-separated list on one line — each ref its own match.
+///   * Plugin name with spaces + dashes ("Dynamic Activation Key - Addons Collection.esp").
+///   * Path-segment plugin gate (DSD <c>\Plugin.esp\</c> folder).
+///   * No-reference file — zero refs, the common OStim case (must be a clean empty, never a warning).
+///   * Unparseable overflow hex — CAPTURED loud (Q3), never silently dropped.
+///   * Comment-embedded token — still surfaced (§4d: "references this file declares", not "the DLL will use").
+///
+/// Run: dotnet run --project src/housecarl-generator -- skse-config-audit-guard
+/// </summary>
+public static class SkseConfigAuditProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  REGRESSION GUARD — SKSE config-audit reference extractor (tier B, #199)  ################");
+        Console.WriteLine();
+
+        int fails = 0;
+        void Check(string label, bool ok) { Console.WriteLine($"   {(ok ? "PASS" : "FAIL")}  {label}"); if (!ok) fails++; }
+
+        // ── 1. CDF JSONC, formid-first, with // comments (top byte 0x00 → low-24 mask is identity). ──
+        {
+            var r = Ex(@"SKSE\Plugins\ContainerDistributionFramework\C.O.I.N.json", @"{
+  // COIN distribution
+  ""form"": ""0x4FDAF|Skyrim.esm"",
+}");
+            Check("CDF JSONC 0x4FDAF|Skyrim.esm → Skyrim.esm / 0x4FDAF",
+                One(r, out var a) && a.Shape == SkseRefShape.FormToken && a.Plugin == "Skyrim.esm" && a.LocalId == 0x4FDAF && a.Unparseable is null);
+        }
+
+        // ── 2. DSD 8-hex ESL-prefixed, plugin name with spaces + dashes → 12-bit local id (THE load-bearing mask). ──
+        {
+            var r = Ex(@"SKSE\Plugins\DynamicStringDistributor\x.json",
+                @"  ""form_id"": ""FE007800|Dynamic Activation Key - Addons Collection.esp"",");
+            Check("DSD FE007800|<spaced name>.esp → 12-bit local 0x800 (ESL mask)",
+                One(r, out var a) && a.Plugin == "Dynamic Activation Key - Addons Collection.esp" && a.LocalId == 0x800);
+        }
+
+        // ── 2b. Plugin name with an APOSTROPHE — must NOT truncate at the ' (the live-gate false-MISSING regression). ──
+        {
+            var r = Ex(@"SKSE\Plugins\Foo\x.json", @"""form"": ""0x800|kryptopyr's Trade & Barter.esp""");
+            Check("apostrophe name → full 'kryptopyr's Trade & Barter.esp' kept",
+                One(r, out var a) && a.Plugin == "kryptopyr's Trade & Barter.esp" && a.LocalId == 0x800);
+        }
+
+        // ── 2c. TOML single-quoted plugin-first ref → the leading ' delimiter is stripped from the plugin name. ──
+        {
+            var r = Ex(@"SKSE\Plugins\Foo\x.toml", "form = 'Foo.esp|0x1'");
+            Check("TOML 'Foo.esp|0x1' → leading-quote stripped to 'Foo.esp'",
+                One(r, out var a) && a.Plugin == "Foo.esp" && a.LocalId == 0x1);
+        }
+
+        // ── 2d. Parenthetical PROSE in a comment → the '(' bounds the token to the real plugin (live-gate false-MISSING). ──
+        {
+            var r = Ex(@"SKSE\Plugins\Foo\x.ini", "; this will cast fireball (Skyrim.esm|0x5) on the target");
+            Check("prose '(Skyrim.esm|0x5)' → plugin bounded to Skyrim.esm (not the prose prefix)",
+                One(r, out var a) && a.Plugin == "Skyrim.esm" && a.LocalId == 0x5);
+        }
+
+        // ── 3. 8-hex NON-ESL (full plugin load-index prefix) → low-24 mask keeps 0x04FDAF (the other arm). ──
+        {
+            var r = Ex(@"SKSE\Plugins\Foo\bar.ini", "target = 1204FDAF|Skyrim.esm");
+            Check("NON-ESL 1204FDAF|Skyrim.esm → low-24 local 0x04FDAF",
+                One(r, out var a) && a.Plugin == "Skyrim.esm" && a.LocalId == 0x04FDAF);
+        }
+
+        // ── 4. SkyPatcher plugin-FIRST order. ──
+        {
+            var r = Ex(@"SKSE\Plugins\SkyPatcher\weapons\x.ini", "filterByWeapons=Skyrim.esm|0x01397E:attackDamage=20");
+            Check("SkyPatcher Skyrim.esm|0x01397E (plugin-first) → Skyrim.esm / 0x1397E",
+                One(r, out var a) && a.Plugin == "Skyrim.esm" && a.LocalId == 0x1397E);
+        }
+
+        // ── 5. Tilde form (KID/SPID shape), leading-zero local id. ──
+        {
+            var r = Ex(@"SKSE\Plugins\Foo\x.ini", "Spell = 0x000FE2~Dawnguard.esm");
+            Check("tilde 0x000FE2~Dawnguard.esm → Dawnguard.esm / 0xFE2",
+                One(r, out var a) && a.Plugin == "Dawnguard.esm" && a.LocalId == 0xFE2);
+        }
+
+        // ── 6. Comma-separated list on one line → each ref its own match. ──
+        {
+            var r = Ex(@"SKSE\Plugins\Foo\x.json", @"""forms"": [""0x1|Skyrim.esm"", ""0x2|Update.esm""]");
+            var toks = r.Where(x => x.Shape == SkseRefShape.FormToken).ToList();
+            Check("comma list → 2 tokens (Skyrim.esm/0x1, Update.esm/0x2)",
+                toks.Count == 2 && toks[0].Plugin == "Skyrim.esm" && toks[0].LocalId == 0x1
+                                && toks[1].Plugin == "Update.esm" && toks[1].LocalId == 0x2);
+        }
+
+        // ── 7. Path-segment plugin gate (DSD \Plugin.esp\ folder), file itself has no tokens. ──
+        {
+            var r = Ex(@"SKSE\Plugins\DynamicStringDistributor\Dawnguard.esm\names.json", @"{ ""strings"": [ ""Hi"" ] }");
+            var gates = r.Where(x => x.Shape == SkseRefShape.PathSegmentGate).ToList();
+            Check("path gate \\Dawnguard.esm\\ → 1 gate, 0 tokens",
+                gates.Count == 1 && gates[0].Plugin == "Dawnguard.esm" && gates[0].LocalId is null
+                && !r.Any(x => x.Shape == SkseRefShape.FormToken));
+        }
+
+        // ── 8. No references at all (OStim-like) → clean empty (the MOST COMMON per-file outcome; never a warning). ──
+        {
+            var r = Ex(@"SKSE\Plugins\OStim\scenes\x.json", @"{ ""duration"": 4.0, ""actors"": 2, ""anim"": ""idle_a"" }");
+            Check("no-reference file → 0 refs (clean empty)", r.Count == 0);
+        }
+
+        // ── 9. Unparseable overflow hex (9 digits) → CAPTURED loud, LocalId null (Q3). ──
+        {
+            var r = Ex(@"SKSE\Plugins\Foo\x.ini", "form = 0x1FFFFFFFF|Skyrim.esm");
+            Check("overflow 0x1FFFFFFFF|Skyrim.esm → unparseable, LocalId null",
+                One(r, out var a) && a.Shape == SkseRefShape.FormToken && a.Unparseable is not null && a.LocalId is null && a.Plugin == "Skyrim.esm");
+        }
+
+        // ── 10. Comment-embedded token still surfaced (§4d honesty — declared, not necessarily used). ──
+        {
+            var r = Ex(@"SKSE\Plugins\Foo\x.ini", "; see 0x5|Skyrim.esm for the base record");
+            Check("comment-embedded 0x5|Skyrim.esm → still extracted (declared refs)",
+                One(r, out var a) && a.Plugin == "Skyrim.esm" && a.LocalId == 0x5);
+        }
+
+        // ── 11. Bare local id under an ESL plugin, no FE prefix (documented residual: low-24 mask is identity). ──
+        {
+            var r = Ex(@"SKSE\Plugins\Foo\x.ini", "x = 0x800|SomeMod.esl");
+            Check("bare 0x800|SomeMod.esl → 0x800 (no FE prefix, low-24 identity)",
+                One(r, out var a) && a.Plugin == "SomeMod.esl" && a.LocalId == 0x800);
+        }
+
+        // ══ Part 2 — VERDICTS against a real (synthetic) load order: extract → resolve → OK/MISSING/DANGLING/UNPARSEABLE.
+        //    Drives the SERVICE adjudicator (LoadOrderService.Adjudicate) over a LoadOrderResolver.IndexView, so the whole
+        //    chain (extractor mask → ContainsPlugin → ResolveWinner) is proven, not just the pure extractor. ══
+        Console.WriteLine();
+        Console.WriteLine("-- verdicts vs a synthetic order (hcAudit.esp full + hcAuditEsl.esl light) --");
+        VerdictArms(Check);
+
+        Console.WriteLine();
+        Console.WriteLine($"=== skse-config-audit-guard: {(fails == 0 ? "PASS" : "FAIL")} ({fails} failing) ===");
+        return fails == 0 ? 0 : 1;
+    }
+
+    /// <summary>Build a synthetic order with a full plugin and a LIGHT plugin, then adjudicate hand-shaped references
+    /// through the REAL service adjudicator (<see cref="LoadOrderService.Adjudicate"/>) over a real
+    /// <see cref="LoadOrderResolver.IndexView"/> — pinning OK / PLUGIN MISSING / DANGLING / UNPARSEABLE and the ESL
+    /// FE-prefix masking end-to-end (the DSD FExxxYYY shape must resolve to the light record). Reports via <paramref name="check"/>.</summary>
+    static void VerdictArms(Action<string, bool> check)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "hc-skse-audit-guard-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var fullPath = Path.Combine(dir, "hcAudit.esp");
+            var full = new SkyrimMod(ModKey.FromNameAndExtension("hcAudit.esp"), SkyrimRelease.SkyrimSE);
+            var fac = full.Factions.AddNew(); fac.EditorID = "hcAuditFac";
+            var facFk = fac.FormKey;
+            full.BeginWrite.ToPath(fullPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+            // A LIGHT (ESL) master with its record explicitly in the 0x800 window — the proven EslFormIdProbe idiom
+            // (IsSmallMaster + explicit FormKey + NoNextFormIDProcessing), so the FE-prefix mask has a real target.
+            const uint eslId = 0x800;
+            var eslKey = ModKey.FromNameAndExtension("hcAuditEsl.esl");
+            var eslPath = Path.Combine(dir, "hcAuditEsl.esl");
+            var esl = new SkyrimMod(eslKey, SkyrimRelease.SkyrimSE) { IsSmallMaster = true };
+            esl.Factions.Add(new Faction(new FormKey(eslKey, eslId), SkyrimRelease.SkyrimSE) { EditorID = "hcAuditEslFac" });
+            esl.BeginWrite.ToPath(eslPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).NoNextFormIDProcessing().Write();
+
+            using var resolver = LoadOrderResolver.Build(new[] { fullPath, eslPath });
+            var index = resolver.Capture();
+
+            SkseRefVerdict V(string relPath, string text)
+            {
+                var refs = SkseConfigReferenceExtractor.Extract(relPath, text);
+                return refs.Count == 1 ? LoadOrderService.Adjudicate(refs[0], index).Verdict : SkseRefVerdict.Unparseable;
+            }
+
+            check("OK: 0x<real>|hcAudit.esp → OK",
+                V(@"SKSE\Plugins\Foo\x.json", $@"""form"": ""0x{facFk.ID:X}|hcAudit.esp""") == SkseRefVerdict.Ok);
+            check($"OK: FE007{eslId:X3}|hcAuditEsl.esl (ESL FE-prefix mask) → OK",
+                V(@"SKSE\Plugins\DynamicStringDistributor\x.json", $@"""form_id"": ""FE007{eslId:X3}|hcAuditEsl.esl""") == SkseRefVerdict.Ok);
+            check("DANGLING: 0xABCDEF|hcAudit.esp (no such record) → DANGLING",
+                V(@"SKSE\Plugins\Foo\x.ini", "target = 0xABCDEF|hcAudit.esp") == SkseRefVerdict.Dangling);
+            check("MISSING: 0x1|NotInstalled.esp → PLUGIN MISSING",
+                V(@"SKSE\Plugins\Foo\x.ini", "target = 0x1|NotInstalled.esp") == SkseRefVerdict.PluginMissing);
+            check("GATE OK: \\hcAudit.esp\\ folder (present) → OK",
+                V(@"SKSE\Plugins\DynamicStringDistributor\hcAudit.esp\names.json", "{}") == SkseRefVerdict.Ok);
+            check("GATE MISSING: \\NotInstalled.esp\\ folder (absent) → PLUGIN MISSING",
+                V(@"SKSE\Plugins\DynamicStringDistributor\NotInstalled.esp\names.json", "{}") == SkseRefVerdict.PluginMissing);
+            check("UNPARSEABLE: overflow token → UNPARSEABLE verdict",
+                V(@"SKSE\Plugins\Foo\x.ini", "x = 0x1FFFFFFFF|hcAudit.esp") == SkseRefVerdict.Unparseable);
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
+
+    /// <summary>MANUAL real-data harness (the tier-B LIVE GATE): run the WHOLE audit against a live MO2 instance and print
+    /// exactly what housecarl_skse_config_audit would return, plus a timing line — the empirical re-check Aaron drives (the
+    /// CI guard pins the extractor + verdict logic; this proves the full scan over real configs). NOT in ci-all (needs a
+    /// real instance + game install). Read-only; touches nothing but a temp user.json.
+    /// Usage: dotnet run --project src/housecarl-generator -- skse-config-audit-real --mo2 "&lt;MO2 instance&gt;" [--filter &lt;substr&gt;]</summary>
+    public static int RunReal(string[] args)
+    {
+        string? mo2 = ArgVal(args, "--mo2");
+        string? filter = ArgVal(args, "--filter");
+        int max = int.TryParse(ArgVal(args, "--max"), out var m) ? m : 80_000;
+        if (mo2 is null) { Console.WriteLine("skse-config-audit-real needs --mo2 <MO2 instance folder>"); return 2; }
+
+        var store = new UserConfigStore(Path.Combine(Path.GetTempPath(), "hc-skse-cfgaudit-" + Guid.NewGuid().ToString("N") + ".json"));
+        using var svc = LoadOrderService.WithInstance(mo2, 0, store);
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var data = svc.SkseConfigAudit();
+        sw.Stop();
+
+        Console.WriteLine(SkseConfigAuditWire.Render(data, filter, max));
+        int refs = data.Files.Sum(f => f.Refs.Count);
+        int dead = data.Files.Sum(f => f.Refs.Count(r => r.Verdict != SkseRefVerdict.Ok));
+        Console.WriteLine($"\n[timing] SkseConfigAudit over {data.ConfigCount} configs ({refs} references, {dead} dead) in {sw.ElapsedMilliseconds} ms");
+        return 0;
+    }
+
+    static string? ArgVal(string[] a, string key)
+    {
+        int i = Array.IndexOf(a, key);
+        return i >= 0 && i + 1 < a.Length ? a[i + 1] : null;
+    }
+
+    static IReadOnlyList<SkseConfigRef> Ex(string relPath, string text) => SkseConfigReferenceExtractor.Extract(relPath, text);
+
+    /// <summary>True when exactly one FORM-TOKEN ref was extracted; binds it out for assertion.</summary>
+    static bool One(IReadOnlyList<SkseConfigRef> refs, out SkseConfigRef only)
+    {
+        var toks = refs.Where(r => r.Shape == SkseRefShape.FormToken).ToList();
+        only = toks.Count == 1 ? toks[0] : null!;
+        return toks.Count == 1;
+    }
+}

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -319,6 +319,107 @@ public sealed class LoadOrderService : IDisposable
         return slash < 0 ? "" : rel.Substring(pre.Length, slash - pre.Length);
     }
 
+    // ---- SKSE config audit (tier B, issue #199): cross-check the form references SKSE-plugin configs DECLARE against the
+    //      real records of the active load order. Plan: dev/plans/SKSE_TIER_B_CONFIG_AUDIT_PLAN_2026-07-16.md. ----
+
+    /// <summary>Per-file byte cap for the config scan: a config larger than this is a NAMED skip (Q3), not fed to the token
+    /// scanner. Real distributor configs are KB-scale; a multi-MB "config" is content mislabeled or a runaway, and scanning
+    /// it would waste the whole-layer walk. 16 MB is far above any real config, so the cap trips only on the pathological
+    /// case it exists to name.</summary>
+    const long SkseConfigSizeCap = 16L * 1024 * 1024;
+
+    /// <summary>Audit the SKSE-plugin config layer against the load order (housecarl_skse_config_audit, tier B). For every
+    /// .ini/.toml/.json/.yaml under Data\SKSE\Plugins, read the WINNING copy (VFS truth — losers are never read by the DLL),
+    /// extract the form-shaped references + path-segment plugin gates it declares (<see cref="SkseConfigReferenceExtractor"/>),
+    /// and resolve each against the active order into a verdict: OK, PLUGIN MISSING, DANGLING, or UNPARSEABLE. The generic,
+    /// framework-AGNOSTIC half of the SkyPatcher reader (inventory + reference validity) for the other config folders — it
+    /// never interprets what a reference is FOR (that's per-framework skill territory). ONE asset capture + ONE resolver
+    /// index pin the whole scan (the SkseInventory discipline); the enumerate + read + resolve run OUTSIDE the gate (the
+    /// captured view is handle-free, the index a pure snapshot read). "No references found" is a NORMAL per-file outcome,
+    /// accounted for, never a warning (Q3).</summary>
+    public SkseConfigAuditData SkseConfigAudit()
+    {
+        AssetResolver.AssetView view;
+        IReadOnlyList<string> warnings;
+        string profileName;
+        lock (_gate)
+        {
+            view = Assets.Capture();
+            warnings = _assetWarnings;
+            profileName = _profileName;
+        }
+        var index = Resolver.Capture();   // pure snapshot: ContainsPlugin / ResolveWinner read only this build
+
+        const string pre = "SKSE\\Plugins\\";
+        var files = new List<SkseConfigFileAudit>();
+        foreach (var rel in view.EnumerateUnder("SKSE\\Plugins").OrderBy(p => p, StringComparer.OrdinalIgnoreCase))
+        {
+            var ext = Path.GetExtension(rel).ToLowerInvariant();
+            if (ext is not (".ini" or ".toml" or ".json" or ".yaml" or ".yml")) continue;   // configs only (DLLs/content are SkseInventory's)
+
+            string group = SkseGroupOf(rel, pre);
+            var place = view.ResolveForPlacement(rel);
+            var winner = place.Sources.Count > 0 ? place.Sources[0] : null;
+            var providers = place.Sources.Select(s => new SkseProvider(s.ProviderName, KindLabel(s.Kind))).ToList();
+
+            string? readError = null;
+            string text = "";
+            if (winner is null)
+                readError = "no active mod provides this config";   // shouldn't happen for an enumerated file — named, not assumed (Q3)
+            else if (winner.Kind == AssetKind.Loose && winner.LooseFilePath is { } lp && File.Exists(lp) && new FileInfo(lp).Length > SkseConfigSizeCap)
+                readError = $"config is {new FileInfo(lp).Length / (1024 * 1024)} MB (> {SkseConfigSizeCap / (1024 * 1024)} MB cap) — not scanned";
+            else
+            {
+                var (bytes, err) = AssetResolver.ReadPlacementSource(winner);
+                if (err is not null) readError = err;
+                else if (bytes!.Length > SkseConfigSizeCap) readError = $"config is {bytes.Length / (1024 * 1024)} MB (> {SkseConfigSizeCap / (1024 * 1024)} MB cap) — not scanned";
+                else text = DecodeConfigText(bytes);
+            }
+
+            // Path-segment gates come from the relPath, so they surface even when the file couldn't be READ (the gate is a
+            // property of WHERE the file lives, not its content). Only the token scan needs the text.
+            var extracted = SkseConfigReferenceExtractor.Extract(rel, readError is null ? text : "");
+            var audited = new List<SkseAuditedRef>(extracted.Count);
+            foreach (var r in extracted) audited.Add(Adjudicate(r, index));
+
+            files.Add(new SkseConfigFileAudit(rel, Path.GetFileName(rel), group,
+                winner?.ProviderName, providers.Count, providers, audited, readError));
+        }
+        return new SkseConfigAuditData(files, files.Count, view.BsaFailures, view.ReadIncomplete, warnings, profileName);
+    }
+
+    /// <summary>Resolve one extracted reference into a verdict against the load-order index. A path-segment gate is
+    /// plugin-presence only (OK / PLUGIN MISSING); a form token additionally checks the record exists (DANGLING when the
+    /// plugin is present but the masked FormID resolves to nothing). Never speculates about runtime behavior (Q3).</summary>
+    internal static SkseAuditedRef Adjudicate(SkseConfigRef r, LoadOrderResolver.IndexView index)   // internal: the config-audit guard drives it over a synthetic order
+    {
+        if (r.Unparseable is not null)
+            return new SkseAuditedRef(r, SkseRefVerdict.Unparseable, r.Unparseable);
+
+        if (!index.ContainsPlugin(r.Plugin))
+            return new SkseAuditedRef(r, SkseRefVerdict.PluginMissing, $"'{r.Plugin}' is not in the active load order");
+
+        if (r.Shape == SkseRefShape.PathSegmentGate)
+            return new SkseAuditedRef(r, SkseRefVerdict.Ok, null);   // gate satisfied — the plugin is present
+
+        // Form token: the plugin is present; does the (masked) FormID resolve to a record in the order?
+        if (!ModKey.TryFromNameAndExtension(r.Plugin, out var mk))
+            return new SkseAuditedRef(r, SkseRefVerdict.Unparseable, $"'{r.Plugin}' is not a valid plugin name");
+        var fk = new FormKey(mk, r.LocalId!.Value);
+        return index.ResolveWinner(fk) is not null
+            ? new SkseAuditedRef(r, SkseRefVerdict.Ok, fk.ToString())
+            : new SkseAuditedRef(r, SkseRefVerdict.Dangling, $"{fk} resolves to no record in '{r.Plugin}'");
+    }
+
+    /// <summary>Decode a config file's bytes to text, honoring a BOM (UTF-8/16) when present (real shipped configs carry
+    /// one), defaulting to UTF-8 otherwise — the config formats (.ini/.toml/.json/.yaml) are all UTF-8 in practice.</summary>
+    static string DecodeConfigText(byte[] bytes)
+    {
+        using var ms = new MemoryStream(bytes);
+        using var sr = new StreamReader(ms, System.Text.Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+        return sr.ReadToEnd();
+    }
+
     // ---- SkyPatcher distributor Wave 1: the per-record TRUE post-SkyPatcher state (plan
     //      dev/plans/SKYPATCHER_DISTRIBUTOR_TOOL_PLAN_2026-07-08.md — reader-only scope, 2026-07-09). ----
 
@@ -4839,6 +4940,47 @@ public sealed record SkseInventoryData(
     IReadOnlyList<SkseFileEntry> Dlls,
     IReadOnlyList<SkseFileEntry> Configs,
     int OtherFileCount,
+    IReadOnlyList<string> BsaFailures,
+    bool ReadIncomplete,
+    IReadOnlyList<string> Warnings,
+    string ProfileName);
+
+/// <summary>The load-order verdict for one reference an SKSE config declares (housecarl_skse_config_audit, tier B).</summary>
+public enum SkseRefVerdict
+{
+    /// <summary>Plugin in the active order, and (for a form token) the FormID resolves to a record in it.</summary>
+    Ok,
+    /// <summary>The named plugin is not in the active load order — the whole entry (or, for a path-segment gate, the whole file) is inert.</summary>
+    PluginMissing,
+    /// <summary>Plugin present, but no record with that (masked) FormID exists in it — a dead reference.</summary>
+    Dangling,
+    /// <summary>The token matched the reference SHAPE but couldn't be normalized (hex overflow, unusable plugin name) — flagged loud, never guessed.</summary>
+    Unparseable,
+}
+
+/// <summary>One reference a config declares (<see cref="HousecarlCore.SkseConfigRef"/>) paired with its load-order
+/// <see cref="Verdict"/> and a Q3 <see cref="Detail"/> line (the resolved FormKey for OK; the reason for a dead/unparseable verdict).</summary>
+public sealed record SkseAuditedRef(HousecarlCore.SkseConfigRef Ref, SkseRefVerdict Verdict, string? Detail);
+
+/// <summary>One config file's audit: its VFS provenance (winning provider + the full winner-first conflict chain — only the
+/// WINNER is read, the losers are shown for transparency), every reference it declares with a verdict, and a Q3
+/// <see cref="ReadError"/> when the winning copy couldn't be read/decoded or was over the size cap.</summary>
+public sealed record SkseConfigFileAudit(
+    string RelPath,
+    string FileName,
+    string Group,
+    string? WinningProvider,
+    int ProviderCount,
+    IReadOnlyList<SkseProvider> Providers,
+    IReadOnlyList<SkseAuditedRef> Refs,
+    string? ReadError);
+
+/// <summary>The data behind housecarl_skse_config_audit (tier B, #199): every SKSE-plugin config with the references it
+/// declares resolved to OK / PLUGIN MISSING / DANGLING / UNPARSEABLE, plus the build-level Q3 caveats
+/// (<see cref="BsaFailures"/> / <see cref="ReadIncomplete"/> / <see cref="Warnings"/>) and the active <see cref="ProfileName"/>.</summary>
+public sealed record SkseConfigAuditData(
+    IReadOnlyList<SkseConfigFileAudit> Files,
+    int ConfigCount,
     IReadOnlyList<string> BsaFailures,
     bool ReadIncomplete,
     IReadOnlyList<string> Warnings,

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -340,15 +340,20 @@ public sealed class LoadOrderService : IDisposable
     public SkseConfigAuditData SkseConfigAudit()
     {
         AssetResolver.AssetView view;
+        LoadOrderResolver.IndexView index;
         IReadOnlyList<string> warnings;
         string profileName;
+        // Capture the asset view AND the record index under ONE gate hold, so a freshness rebuild can't interleave and pair
+        // a config read from asset-build-N against a record index from build-N+1 (both share _gate; the Resolver getter
+        // reenters it, doing its own per-call freshness inside our hold). Both are handle-free snapshots — the enumerate +
+        // read + resolve below then run OUTSIDE the gate without serializing other tools behind our file I/O.
         lock (_gate)
         {
             view = Assets.Capture();
+            index = Resolver.Capture();   // pure snapshot: ContainsPlugin / ResolveWinner read only this build
             warnings = _assetWarnings;
             profileName = _profileName;
         }
-        var index = Resolver.Capture();   // pure snapshot: ContainsPlugin / ResolveWinner read only this build
 
         const string pre = "SKSE\\Plugins\\";
         var files = new List<SkseConfigFileAudit>();
@@ -367,12 +372,12 @@ public sealed class LoadOrderService : IDisposable
             if (winner is null)
                 readError = "no active mod provides this config";   // shouldn't happen for an enumerated file — named, not assumed (Q3)
             else if (winner.Kind == AssetKind.Loose && winner.LooseFilePath is { } lp && File.Exists(lp) && new FileInfo(lp).Length > SkseConfigSizeCap)
-                readError = $"config is {new FileInfo(lp).Length / (1024 * 1024)} MB (> {SkseConfigSizeCap / (1024 * 1024)} MB cap) — not scanned";
+                readError = OverCapNote(new FileInfo(lp).Length);
             else
             {
                 var (bytes, err) = AssetResolver.ReadPlacementSource(winner);
                 if (err is not null) readError = err;
-                else if (bytes!.Length > SkseConfigSizeCap) readError = $"config is {bytes.Length / (1024 * 1024)} MB (> {SkseConfigSizeCap / (1024 * 1024)} MB cap) — not scanned";
+                else if (bytes!.Length > SkseConfigSizeCap) readError = OverCapNote(bytes.Length);
                 else text = DecodeConfigText(bytes);
             }
 
@@ -419,6 +424,11 @@ public sealed class LoadOrderService : IDisposable
         using var sr = new StreamReader(ms, System.Text.Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
         return sr.ReadToEnd();
     }
+
+    /// <summary>The over-size-cap skip note — the actual size to ONE decimal MB so a 16.4 MB file reads "16.4 MB (> 16 MB
+    /// cap)", never the self-contradictory "16 MB (> 16 MB cap)" an integer-MB divide produced.</summary>
+    static string OverCapNote(long len) =>
+        $"config is {len / (1024.0 * 1024):0.0} MB (> {SkseConfigSizeCap / (1024 * 1024)} MB cap) — not scanned";
 
     // ---- SkyPatcher distributor Wave 1: the per-record TRUE post-SkyPatcher state (plan
     //      dev/plans/SKYPATCHER_DISTRIBUTOR_TOOL_PLAN_2026-07-08.md — reader-only scope, 2026-07-09). ----

--- a/src/housecarl-mcp/SkseTools.cs
+++ b/src/housecarl-mcp/SkseTools.cs
@@ -53,7 +53,7 @@ public static class SkseTools
          "Cross-check the form references SKSE-plugin CONFIGS declare against the real records of the ACTIVE load order — so a " +
          "DEAD reference (a FormID pointing at a plugin that isn't installed, or at a record that doesn't exist in it) is caught " +
          "by houseCARL instead of by a silent in-game failure. Scans the full depth of Data\\SKSE\\Plugins for .ini/.toml/.json/" +
-         ".yaml configs, reads the WINNING copy of each (the copy the DLL actually reads), and extracts every form-shaped " +
+         ".yaml/.yml configs, reads the WINNING copy of each (the copy the DLL actually reads), and extracts every form-shaped " +
          "reference — a hex FormID paired with a plugin filename in EITHER order (0xFORM|Plugin.esp as DSD/CDF/po3 write it, " +
          "Plugin.esp|0xFORM as SkyPatcher writes it, the ~ tilde form) plus plugin-named folder gates (DynamicStringDistributor\\" +
          "Plugin.esp\\...) — then resolves each to a verdict: OK, PLUGIN MISSING (plugin not in the order), DANGLING (plugin " +
@@ -437,9 +437,12 @@ static class SkseConfigAuditWire
         // ── Accounted-for remainder — everything that ISN'T a diagnostic, so nothing is silently dropped (Q3). ──
         var healthyFiles = d.Files.Where(f => f.ReadError is null && f.Refs.Count > 0 && f.Refs.All(r => r.Verdict == SkseRefVerdict.Ok)).ToList();
         int healthyRefs = healthyFiles.Sum(f => f.Refs.Count);
+        int okInMixed = (refsChecked - dead) - healthyRefs;   // OK refs living in a file that ALSO has a dead ref — so every ref reconciles: refsChecked = dead + healthyRefs + okInMixed
         var noRefFiles = d.Files.Where(f => f.ReadError is null && f.Refs.Count == 0).ToList();
         sb.Append("\naccounted for: ").Append(healthyFiles.Count).Append(" file(s) with ").Append(healthyRefs)
-          .Append(" reference(s) all OK · ").Append(noRefFiles.Count).Append(" file(s) declare no form-shaped references\n");
+          .Append(" reference(s) all OK");
+        if (okInMixed > 0) sb.Append(" · ").Append(okInMixed).Append(" more OK ref(s) in files that also have dead references");
+        sb.Append(" · ").Append(noRefFiles.Count).Append(" file(s) declare no form-shaped references\n");
         if (noRefFiles.Count > 0)
         {
             var groups = noRefFiles.GroupBy(f => f.Group, StringComparer.OrdinalIgnoreCase)

--- a/src/housecarl-mcp/SkseTools.cs
+++ b/src/housecarl-mcp/SkseTools.cs
@@ -47,6 +47,38 @@ public static class SkseTools
         var data = svc.SkseInventory();
         return SkseInventoryWire.Render(data, filter, max_chars > 0 ? max_chars : 80_000);
     });
+
+    [McpServerTool(Name = "housecarl_skse_config_audit", ReadOnly = true, Title = "SKSE config references vs the load order (dead-reference audit)"),
+     Description(
+         "Cross-check the form references SKSE-plugin CONFIGS declare against the real records of the ACTIVE load order — so a " +
+         "DEAD reference (a FormID pointing at a plugin that isn't installed, or at a record that doesn't exist in it) is caught " +
+         "by houseCARL instead of by a silent in-game failure. Scans the full depth of Data\\SKSE\\Plugins for .ini/.toml/.json/" +
+         ".yaml configs, reads the WINNING copy of each (the copy the DLL actually reads), and extracts every form-shaped " +
+         "reference — a hex FormID paired with a plugin filename in EITHER order (0xFORM|Plugin.esp as DSD/CDF/po3 write it, " +
+         "Plugin.esp|0xFORM as SkyPatcher writes it, the ~ tilde form) plus plugin-named folder gates (DynamicStringDistributor\\" +
+         "Plugin.esp\\...) — then resolves each to a verdict: OK, PLUGIN MISSING (plugin not in the order), DANGLING (plugin " +
+         "present but no such record), or UNPARSEABLE (a shape-matched token that can't be normalized). It is the generic, " +
+         "framework-AGNOSTIC twin of the SkyPatcher reader's first half: it checks reference VALIDITY, never what a reference is " +
+         "FOR (that's per-framework skill territory) and never what the DLL DOES with it (the honest ceiling). Extraction is a " +
+         "heuristic over token SHAPES, so a token in a comment or disabled block still surfaces — the framing is 'references this " +
+         "file DECLARES', not 'references the DLL will use'. 'No references found' is the most common per-file outcome and is " +
+         "accounted for, never a warning. Bare EditorID / name strings are NOT validated (Wave 2). Pass filter= a folder, mod, " +
+         "filename, or referenced-plugin substring to audit just that group and list EVERY reference with its verdict (the OKs " +
+         "included — positive confirmation of a patch you just authored). Distributor INIs in Data\\ root (SPID *_DISTR, KID " +
+         "*_KID) are out of scope — owned by their authoring skills. Read-only.")]
+    public static string SkseConfigAudit(
+        LoadOrderService svc,
+        [Description("Optional. A config FOLDER, providing-mod, filename, or REFERENCED-plugin substring (case-insensitive). " +
+            "Audits just the matching configs and lists every reference with its verdict, OKs included. Omit for the whole-layer " +
+            "audit (diagnostics — dead references — first, then the accounted-for remainder).")]
+            string? filter = null,
+        [Description("Optional. Max characters before lists are cut with an explicit notice. 0 = the server default (~80k).")]
+            int max_chars = 0) => Guard.Tool("housecarl_skse_config_audit", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        var data = svc.SkseConfigAudit();
+        return SkseConfigAuditWire.Render(data, filter, max_chars > 0 ? max_chars : 80_000);
+    });
 }
 
 /// <summary>Renders <see cref="SkseInventoryData"/> as compact, scannable text. Default: summary + compat, the diagnostic
@@ -315,6 +347,192 @@ static class SkseInventoryWire
     {
         if (d.ReadIncomplete)
             sb.Append("[!] a BSA failed to read this build, so a file present only in it may be missing from this inventory (Q3).\n");
+        foreach (var w in d.Warnings) sb.Append("[!] ").Append(w).Append('\n');
+        foreach (var f in d.BsaFailures) sb.Append("[!] archive read failure: ").Append(f).Append('\n');
+    }
+}
+
+/// <summary>Renders <see cref="SkseConfigAuditData"/> as compact, scannable text (housecarl_skse_config_audit, tier B).
+/// Default: a health summary, then the DIAGNOSTICS first and in full (dead references — PLUGIN MISSING gates + tokens,
+/// DANGLING, UNPARSEABLE — and read errors, each with file:line provenance and its winning provider), then the
+/// accounted-for remainder (healthy files counted; no-reference files grouped by folder — the OStim bulk). Bounded by
+/// max_chars with an explicit cut notice (Q3 — never silent truncation). filter= audits one group and lists EVERY
+/// reference with its verdict, OKs included (the positive-confirmation / verifier role).</summary>
+static class SkseConfigAuditWire
+{
+    // (file, ref) pair — a dead reference and where it was declared.
+    readonly record struct Hit(SkseConfigFileAudit File, SkseAuditedRef Audited)
+    {
+        public HousecarlCore.SkseConfigRef Ref => Audited.Ref;
+    }
+
+    public static string Render(SkseConfigAuditData d, string? filter, int cap)
+    {
+        if (filter is { Length: > 0 }) return RenderFiltered(d, filter.Trim(), cap);
+
+        var flat = d.Files.SelectMany(f => f.Refs.Select(r => new Hit(f, r))).ToList();
+        var missingGates = flat.Where(h => h.Audited.Verdict == SkseRefVerdict.PluginMissing && h.Ref.Shape == HousecarlCore.SkseRefShape.PathSegmentGate).ToList();
+        var missingToks  = flat.Where(h => h.Audited.Verdict == SkseRefVerdict.PluginMissing && h.Ref.Shape == HousecarlCore.SkseRefShape.FormToken).ToList();
+        var dangling     = flat.Where(h => h.Audited.Verdict == SkseRefVerdict.Dangling).ToList();
+        var unparseable  = flat.Where(h => h.Audited.Verdict == SkseRefVerdict.Unparseable).ToList();
+        var readErrors   = d.Files.Where(f => f.ReadError is not null).ToList();
+
+        int refsChecked = flat.Count;
+        int dead = missingGates.Count + missingToks.Count + dangling.Count + unparseable.Count;
+        int filesWithRefs = d.Files.Count(f => f.Refs.Count > 0);
+
+        var sb = new StringBuilder();
+        sb.Append("SKSE config audit — profile '").Append(d.ProfileName).Append("' — ")
+          .Append(d.ConfigCount).Append(" config(s) scanned, ").Append(filesWithRefs).Append(" carry references, ")
+          .Append(refsChecked).Append(" reference(s) checked\n");
+        if (dead == 0)
+            sb.Append("✓ every reference resolves against the active load order — no dead references found.\n");
+        else
+        {
+            sb.Append("[!] ").Append(dead).Append(" DEAD reference(s): ")
+              .Append(missingGates.Count + missingToks.Count).Append(" plugin-missing · ")
+              .Append(dangling.Count).Append(" dangling · ").Append(unparseable.Count).Append(" unparseable\n");
+        }
+
+        // ── Diagnostics FIRST, in full (the point of the tool). ──
+        AppendHits(sb, "PLUGIN MISSING — folder gates (the plugin isn't installed, so the WHOLE file is inert)", missingGates, cap,
+            h => $"  - {h.File.RelPath}: folder '{h.Ref.Plugin}' not in the load order{Prov(h.File)}");
+        // Token-level plugin-missing is GROUPED by the target plugin — a whole-layer scan yields tens of thousands of
+        // individual inert refs (a config shipping optional support for a mod you don't have contributes hundreds each),
+        // so a per-ref list is an unreadable wall; the count-per-plugin table is the actionable shape. filter= a plugin to
+        // see its individual refs.
+        if (missingToks.Count > 0)
+        {
+            var byPlugin = missingToks.GroupBy(h => h.Ref.Plugin, StringComparer.OrdinalIgnoreCase)
+                .Select(g => (Plugin: g.Key, Refs: g.Count(),
+                              Files: g.Select(h => h.File.RelPath).Distinct(StringComparer.OrdinalIgnoreCase).Count(),
+                              Example: g.First().File.RelPath))
+                .OrderByDescending(g => g.Refs).ThenBy(g => g.Plugin, StringComparer.OrdinalIgnoreCase).ToList();
+            sb.Append("\nPLUGIN MISSING — target plugin not in the load order (inert; often a config shipping optional support for a mod you don't have) — by plugin (")
+              .Append(byPlugin.Count).Append(" plugins, ").Append(missingToks.Count).Append(" refs):\n");
+            int shown = 0;
+            foreach (var g in byPlugin)
+            {
+                if (sb.Length >= cap) { sb.Append("  ... [showing ").Append(shown).Append(" of ").Append(byPlugin.Count).Append(" plugins; raise max_chars or use filter=]\n"); break; }
+                sb.Append("  - ").Append(g.Plugin).Append(": ").Append(g.Refs).Append(" ref(s)");
+                if (g.Files > 1) sb.Append(" across ").Append(g.Files).Append(" file(s)");
+                sb.Append("  (e.g. ").Append(g.Example).Append(")\n"); shown++;
+            }
+        }
+        AppendHits(sb, "DANGLING — plugin present but no such record (a dead reference)", dangling, cap,
+            h => $"  - {Loc(h)}: '{h.Ref.Raw}' → {h.Audited.Detail}{Prov(h.File)}");
+        AppendHits(sb, "UNPARSEABLE — shape-matched tokens that can't be normalized (flagged, never guessed)", unparseable, cap,
+            h => $"  - {Loc(h)}: '{h.Ref.Raw}' → {h.Audited.Detail}{Prov(h.File)}");
+        if (readErrors.Count > 0)
+        {
+            sb.Append("\nread errors — configs that could not be read/decoded (NOT counted as clean) (").Append(readErrors.Count).Append("):\n");
+            int shown = 0;
+            foreach (var f in readErrors)
+            {
+                if (sb.Length >= cap) { sb.Append("  ... [").Append(shown).Append(" of ").Append(readErrors.Count).Append("; raise max_chars]\n"); break; }
+                sb.Append("  - ").Append(f.RelPath).Append(": ").Append(f.ReadError).Append(Prov(f)).Append('\n'); shown++;
+            }
+        }
+
+        // ── Accounted-for remainder — everything that ISN'T a diagnostic, so nothing is silently dropped (Q3). ──
+        var healthyFiles = d.Files.Where(f => f.ReadError is null && f.Refs.Count > 0 && f.Refs.All(r => r.Verdict == SkseRefVerdict.Ok)).ToList();
+        int healthyRefs = healthyFiles.Sum(f => f.Refs.Count);
+        var noRefFiles = d.Files.Where(f => f.ReadError is null && f.Refs.Count == 0).ToList();
+        sb.Append("\naccounted for: ").Append(healthyFiles.Count).Append(" file(s) with ").Append(healthyRefs)
+          .Append(" reference(s) all OK · ").Append(noRefFiles.Count).Append(" file(s) declare no form-shaped references\n");
+        if (noRefFiles.Count > 0)
+        {
+            var groups = noRefFiles.GroupBy(f => f.Group, StringComparer.OrdinalIgnoreCase)
+                .Select(g => (Name: g.Key.Length == 0 ? "(top level)" : g.Key, Count: g.Count()))
+                .OrderByDescending(g => g.Count).ThenBy(g => g.Name, StringComparer.OrdinalIgnoreCase).ToList();
+            sb.Append("  no-reference configs by folder (").Append(groups.Count).Append("):\n");
+            int shown = 0;
+            foreach (var g in groups)
+            {
+                if (sb.Length >= cap) { sb.Append("    ... [").Append(shown).Append(" of ").Append(groups.Count).Append(" folders; raise max_chars]\n"); break; }
+                sb.Append("    - ").Append(g.Name).Append(": ").Append(g.Count).Append('\n'); shown++;
+            }
+        }
+
+        sb.Append("\n(scope: form-shaped references only — a hex FormID + plugin filename, or a plugin-named folder gate. Bare " +
+                  "EditorID/name strings are not validated (Wave 2). Extraction is heuristic over token shapes: a token in a comment " +
+                  "or disabled block still counts — 'references this file declares', not 'the DLL will use'. A folder that SHOULD carry " +
+                  "references but shows none may use a reference shape not yet recognized.)\n");
+        AppendCaveats(sb, d);
+        sb.Append("\n→ filter='<folder/mod/filename/plugin>' to audit one group and see every reference (OKs included).");
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    /// <summary>filter= : audit just the matching configs (by folder, provider, filename, or a REFERENCED plugin) and list
+    /// every reference with its verdict — OKs included, for positive confirmation (the SkyPatcher-reader verifier role).</summary>
+    static string RenderFiltered(SkseConfigAuditData d, string filter, int cap)
+    {
+        bool In(string? s) => s is not null && s.Contains(filter, StringComparison.OrdinalIgnoreCase);
+        bool Match(SkseConfigFileAudit f) =>
+            In(f.FileName) || In(f.Group) || In(f.WinningProvider) || In(f.RelPath)
+            || f.Refs.Any(r => In(r.Ref.Plugin));
+        var hits = d.Files.Where(Match)
+            .OrderBy(f => f.Group, StringComparer.OrdinalIgnoreCase).ThenBy(f => f.RelPath, StringComparer.OrdinalIgnoreCase).ToList();
+
+        var sb = new StringBuilder();
+        sb.Append("SKSE config audit — filter '").Append(filter).Append("' — ")
+          .Append(hits.Count).Append(" config(s) match [profile '").Append(d.ProfileName).Append("']\n");
+        if (hits.Count == 0)
+        {
+            sb.Append("\nnothing under SKSE\\Plugins matched. ")
+              .Append(HousecarlCore.PluginNameSuggest.DidYouMean(filter,
+                  d.Files.Select(f => f.Group).Where(g => g.Length > 0).Concat(d.Files.Select(f => f.FileName)).Distinct()));
+            return sb.ToString().TrimEnd('\n');
+        }
+
+        int shownFiles = 0;
+        foreach (var f in hits)
+        {
+            if (sb.Length >= cap) { sb.Append("\n  ... [showing ").Append(shownFiles).Append(" of ").Append(hits.Count).Append(" files; raise max_chars]\n"); break; }
+            sb.Append('\n').Append(f.RelPath).Append("  ← ").Append(f.WinningProvider ?? "(no active provider)").Append('\n');
+            if (f.ProviderCount > 1)
+                sb.Append("  [!] contested by ").Append(f.ProviderCount).Append(" mods (winner audited): ")
+                  .Append(string.Join(" › ", f.Providers.Select(p => $"{p.Name} ({p.Kind})"))).Append('\n');
+            if (f.ReadError is not null) { sb.Append("  [!] ").Append(f.ReadError).Append('\n'); continue; }
+            if (f.Refs.Count == 0) { sb.Append("  (no form-shaped references)\n"); continue; }
+            foreach (var r in f.Refs)
+                sb.Append("  ").Append(Tag(r.Verdict)).Append(' ')
+                  .Append(r.Ref.Shape == HousecarlCore.SkseRefShape.PathSegmentGate ? $"folder gate '{r.Ref.Plugin}'" : $"'{r.Ref.Raw}'")
+                  .Append(r.Ref.Line > 0 ? $" (line {r.Ref.Line})" : "")
+                  .Append(r.Detail is null ? "" : " → " + r.Detail).Append('\n');
+            shownFiles++;
+        }
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    static string Tag(SkseRefVerdict v) => v switch
+    {
+        SkseRefVerdict.Ok => "[OK]",
+        SkseRefVerdict.PluginMissing => "[MISSING]",
+        SkseRefVerdict.Dangling => "[DANGLING]",
+        SkseRefVerdict.Unparseable => "[UNPARSEABLE]",
+        _ => "[?]",
+    };
+
+    static string Loc(Hit h) => h.Ref.Line > 0 ? $"{h.File.RelPath}:{h.Ref.Line}" : h.File.RelPath;
+    static string Prov(SkseConfigFileAudit f) => f.WinningProvider is null ? "" : $"  [← {f.WinningProvider}]";
+
+    static void AppendHits(StringBuilder sb, string label, IReadOnlyList<Hit> items, int cap, Func<Hit, string> line)
+    {
+        if (items.Count == 0) return;
+        sb.Append('\n').Append(label).Append(" (").Append(items.Count).Append("):\n");
+        int shown = 0;
+        foreach (var h in items)
+        {
+            if (sb.Length >= cap) { sb.Append("  ... [showing ").Append(shown).Append(" of ").Append(items.Count).Append("; raise max_chars or use filter=]\n"); break; }
+            sb.Append(line(h)).Append('\n'); shown++;
+        }
+    }
+
+    static void AppendCaveats(StringBuilder sb, SkseConfigAuditData d)
+    {
+        if (d.ReadIncomplete)
+            sb.Append("[!] a BSA failed to read this build, so a config present only in it may be missing from this audit (Q3).\n");
         foreach (var w in d.Warnings) sb.Append("[!] ").Append(w).Append('\n');
         foreach (var f in d.BsaFailures) sb.Append("[!] archive read failure: ").Append(f).Append('\n');
     }


### PR DESCRIPTION
Closes the **tier-B** half of #199 (SKSE-plugin-layer visibility — tiers A+C shipped in PR #146). Built from the locked plan `dev/plans/SKSE_TIER_B_CONFIG_AUDIT_PLAN_2026-07-16.md`.

## What it does
New read-only tool **`housecarl_skse_config_audit`**: cross-checks the form references SKSE-plugin configs *declare* against the real records of the active load order, so a dead reference is caught by houseCARL instead of by a silent in-game failure. Scans the full depth of `Data\SKSE\Plugins` (`.ini/.toml/.json/.yaml`), reads the **winning** copy of each, extracts every form-shaped reference — `0xFORM|Plugin.esp` (DSD/CDF/po3), `Plugin.esp|0xFORM` (SkyPatcher), the `~` tilde form, and plugin-named folder gates (`DynamicStringDistributor\Plugin.esp\...`) — and resolves each to **OK / PLUGIN MISSING / DANGLING / UNPARSEABLE**.

Framework-**agnostic** (keys on token *shape*, no hardcoded framework list); never interprets what a reference is *for* (skill territory) or what the DLL *does* with it (the honest ceiling, tier E). Default view leads with diagnostics; `filter=` audits one group and lists every reference incl. OKs (the verifier role).

## Design notes
- **Extractor** (`SkseConfigReferenceExtractor`, core) — pure, line-local regex over token shapes; fixture-testable with no load order.
- **Masking single-homed** — the `FExxxYYY` light-vs-low-24 normalization moved to `FormIdRange.LocalObjectId`, shared with the (previously inline) SkyPatcher `TryFormKey`. Getting the light/full split wrong inverts every verdict, so it lives in one tested home.
- **[BUILD-TEST] — DSD masking VERIFIED against source.** Traced DSD's own parser (`SkyHorizon3/SSE-Dynamic-String-Distributor`, `src/Utils.cpp` `getRuntimeFormID`): `(raw & 0xFFF)` when the named plugin `IsLight()`, else `(raw & 0xFFFFFF)`. Our token-prefix rule (0xFE ⇒ light) yields the **identical** local id for every shape DSD emits. Sole divergence = the plan §7 documented bare-≤6-hex-ESL residual, which DSD never itself writes.

## Live gate — ARR 2.0 (the empirical proof)
Whole-layer scan: **5,017 configs / 23,525 references / ~45–52 s** (this is the datapoint the pairing-audit §7 and tier-D §8.3 plans consume — their re-review markers ask for it).

Result: **9,841 dead** (9,690 plugin-missing · 151 dangling · 0 unparseable); 130 files with 6,165 refs all OK. **Every verdict class hand-verified against the shipped `housecarl_resolve` / `housecarl_load_order_status` oracle — zero false DANGLING/MISSING:**
- MISSING — `Sanguine's Trade...esp` (inactive/unchecked), `konahrik_accoutrements.esp` (absent) ✓
- DANGLING — Apocalypse/Keytrace/CBBE-Beasts/CustomRaces: plugins **active**, records genuinely absent per oracle ✓
- OK — resolve to real records (`013745:Skyrim.esm` = KhajiitRace, …) ✓

**The gate caught two extractor false-positives, now fixed + pinned by fixtures:**
1. Apostrophe plugin names (kryptopyr's / Sanguine's) were truncated at the `'` → false MISSING.
2. Parenthetical prose in a comment (`"will cast fireball (Skyrim.esm|0x5)"`) grabbed the prose prefix as the plugin name.

## Tests
- `skse-config-audit-guard` added to `ci-all` — **ci-all 95/95 green.** Covers every §3 shape, both token orders, ESL/non-ESL masking, apostrophe/paren/comment/overflow edges, PLUS the service verdicts driven through the real adjudicator over a synthetic full+light order.
- Manual live harness: `dotnet run --project src/housecarl-generator -- skse-config-audit-real --mo2 "<instance>" [--filter x] [--max n]`.

## For your decision (surfaced, not silently actioned)
1. **Plugin-flag masking refinement (optional).** DSD's *authoritative* rule masks by the named plugin's `IsLight()`; ours uses the token's 0xFE prefix. They agree on all real shapes. Adopting the flag rule would close the bare-≤6-hex-ESL residual entirely but needs a new `IsLight(plugin)` resolver accessor + diverges from SkyPatcher's approach. Left as-is per the locked plan; charter if you want it.
2. **`PLUGIN MISSING` is mostly optional-support-by-design** (a config shipping support for a mod you don't have — e.g. DynamicArmorVariants: `1nivWICCloaks.esp: 837 refs`). Grouped by target plugin in the default view (227 plugins) so it reads as a table, not a 9,641-line wall. **DANGLING (plugin present, record gone) is the sharper signal.** Framing tweakable if you'd like.

Wave 2 (EditorID/name-graph validation) parked per plan §7. `#199` stays open for tier D.