### PR TITLE
polish(skse): config_audit — BROKEN vs INERT summary + wider filter did-you-mean pool

### DIFF
--- a/src/housecarl-generator/SkseConfigAuditProbe.cs
+++ b/src/housecarl-generator/SkseConfigAuditProbe.cs
@@ -26,6 +26,9 @@ namespace HousecarlGenerator;
 ///   * Unparseable overflow hex — CAPTURED loud (Q3), never silently dropped.
 ///   * Comment-embedded token — still surfaced (§4d: "references this file declares", not "the DLL will use").
 ///
+/// Also drives the SERVICE adjudicator (Part 2 — verdicts vs a synthetic order) and the WIRE renderer (Part 3 — the
+/// broken/inert summary framing + the filter= did-you-mean pool, the tier-B PR #206 review residuals).
+///
 /// Run: dotnet run --project src/housecarl-generator -- skse-config-audit-guard
 /// </summary>
 public static class SkseConfigAuditProbe
@@ -151,6 +154,10 @@ public static class SkseConfigAuditProbe
         VerdictArms(Check);
 
         Console.WriteLine();
+        Console.WriteLine("-- render framing (② broken/inert summary · ③ filter did-you-mean pool) --");
+        RenderArms(Check);
+
+        Console.WriteLine();
         Console.WriteLine($"=== skse-config-audit-guard: {(fails == 0 ? "PASS" : "FAIL")} ({fails} failing) ===");
         return fails == 0 ? 0 : 1;
     }
@@ -206,6 +213,69 @@ public static class SkseConfigAuditProbe
         }
         finally { try { Directory.Delete(dir, recursive: true); } catch { } }
     }
+
+    /// <summary>RENDER-LAYER guard for the framing residuals landed with this PR (tier-B PR #206 review, dev/BACKLOG.md):
+    /// ② the summary separates BROKEN (DANGLING/UNPARSEABLE — a reference that should resolve and doesn't) from INERT
+    /// (PLUGIN MISSING — the plugin isn't installed) instead of calling every non-OK ref "DEAD"; ③ the filter= "did you
+    /// mean" pool includes REFERENCED-plugin (and winning-provider) names, not just folders/filenames. Renders synthetic
+    /// <see cref="SkseConfigAuditData"/> through the REAL wire (<see cref="SkseConfigAuditWire.Render"/>) — the layer
+    /// ci-all didn't exercise before (Render ran only in the live harness, never in the guard).</summary>
+    static void RenderArms(Action<string, bool> check)
+    {
+        // ② a healthy order that still carries inert refs → ✓ (no broken), reframed as optional support, and NEVER "DEAD".
+        {
+            var txt = SkseConfigAuditWire.Render(MkData(
+                MkFile(@"SKSE\Plugins\Foo\ok.ini", "Foo", "ModA", MkRef("Skyrim.esm", SkseRefVerdict.Ok)),
+                MkFile(@"SKSE\Plugins\Bar\opt.ini", "Bar", "ModB", MkRef("NotInstalled.esp", SkseRefVerdict.PluginMissing))), null, 80_000);
+            check("② healthy+inert: no 'DEAD', shows ✓ no-broken + inert/optional-support framing",
+                !txt.Contains("DEAD") && txt.Contains("no broken references") && txt.Contains("inert") && txt.Contains("optional support"));
+        }
+        // ② a real broken ref (DANGLING) → 'BROKEN reference(s)' headline with the dangling count, still no "DEAD".
+        {
+            var txt = SkseConfigAuditWire.Render(MkData(
+                MkFile(@"SKSE\Plugins\Foo\x.ini", "Foo", "ModA", MkRef("Skyrim.esm", SkseRefVerdict.Dangling))), null, 80_000);
+            check("② broken: 'BROKEN reference(s)' headline + '1 dangling', no 'DEAD'",
+                txt.Contains("BROKEN reference(s)") && txt.Contains("1 dangling") && !txt.Contains("DEAD"));
+        }
+        // ② broken AND inert together → the BROKEN headline notes the inert remainder separately.
+        {
+            var txt = SkseConfigAuditWire.Render(MkData(
+                MkFile(@"SKSE\Plugins\Foo\x.ini", "Foo", "ModA", MkRef("Skyrim.esm", SkseRefVerdict.Dangling)),
+                MkFile(@"SKSE\Plugins\Bar\y.ini", "Bar", "ModB", MkRef("Absent.esp", SkseRefVerdict.PluginMissing))), null, 80_000);
+            check("② broken+inert: BROKEN headline + 'more inert' note",
+                txt.Contains("BROKEN reference(s)") && txt.Contains("more inert"));
+        }
+        // ② reconciliation (Q3): a MIXED file (OK + DANGLING) → the OK ref is still counted in 'accounted for' (notOk math intact).
+        {
+            var txt = SkseConfigAuditWire.Render(MkData(
+                MkFile(@"SKSE\Plugins\Foo\mix.ini", "Foo", "ModA",
+                    MkRef("Skyrim.esm", SkseRefVerdict.Ok), MkRef("Skyrim.esm", SkseRefVerdict.Dangling))), null, 80_000);
+            check("② reconciliation: mixed file's OK ref counted in 'accounted for' (okInMixed via notOk)",
+                txt.Contains("1 more OK ref(s) in files that also carry a non-OK reference"));
+        }
+        // ③ did-you-mean: a typo of a REFERENCED plugin (matches nothing) → the suggestion now includes the ref plugin
+        //    (before this PR the pool was folders+filenames only, so a mistyped plugin filter got no plugin suggestion).
+        {
+            var txt = SkseConfigAuditWire.Render(MkData(
+                MkFile(@"SKSE\Plugins\Foo\x.ini", "Foo", "ModA", MkRef("ZzTestRefPlugin.esp", SkseRefVerdict.Ok))),
+                "ZzTestRefPlugni", 80_000);   // transposed stem: no substring match → falls to the DidYouMean path
+            check("③ filter typo of a referenced plugin → 'Did you mean' offers ZzTestRefPlugin.esp",
+                txt.Contains("nothing under SKSE\\Plugins matched") && txt.Contains("ZzTestRefPlugin.esp"));
+        }
+    }
+
+    // Synthetic SkseConfigAuditData builders for RenderArms — the render is pure over the data record, so no load order
+    // or disk is needed (unlike VerdictArms, which must resolve real FormKeys). A form-token ref with a fixed 0x1 id is
+    // enough: the render keys on Verdict + Shape, never the id value.
+    static SkseAuditedRef MkRef(string plugin, SkseRefVerdict v)
+        => new(new SkseConfigRef($"0x1|{plugin}", SkseRefShape.FormToken, plugin, 0x1, "0x1", 1, null), v, null);
+
+    static SkseConfigFileAudit MkFile(string rel, string group, string? provider, params SkseAuditedRef[] refs)
+        => new(rel, Path.GetFileName(rel), group, provider, provider is null ? 0 : 1,
+               Array.Empty<SkseProvider>(), refs, null);
+
+    static SkseConfigAuditData MkData(params SkseConfigFileAudit[] files)
+        => new(files, files.Length, Array.Empty<string>(), false, Array.Empty<string>(), "TestProfile");
 
     /// <summary>MANUAL real-data harness (the tier-B LIVE GATE): run the WHOLE audit against a live MO2 instance and print
     /// exactly what housecarl_skse_config_audit would return, plus a timing line — the empirical re-check Aaron drives (the

--- a/src/housecarl-generator/SkseConfigAuditProbe.cs
+++ b/src/housecarl-generator/SkseConfigAuditProbe.cs
@@ -253,6 +253,13 @@ public static class SkseConfigAuditProbe
             check("② reconciliation: mixed file's OK ref counted in 'accounted for' (okInMixed via notOk)",
                 txt.Contains("1 more OK ref(s) in files that also carry a non-OK reference"));
         }
+        // ② all-clear (broken == 0 && inert == 0): a lone OK ref → the clean ✓ line, no dead/broken/inert alarm.
+        {
+            var txt = SkseConfigAuditWire.Render(MkData(
+                MkFile(@"SKSE\Plugins\Foo\ok.ini", "Foo", "ModA", MkRef("Skyrim.esm", SkseRefVerdict.Ok))), null, 80_000);
+            check("② all-clear: clean ✓ line, no 'dead'/'BROKEN' alarm",
+                txt.Contains("nothing broken, nothing inert") && !txt.Contains("dead") && !txt.Contains("BROKEN"));
+        }
         // ③ did-you-mean: a typo of a REFERENCED plugin (matches nothing) → the suggestion now includes the ref plugin
         //    (before this PR the pool was folders+filenames only, so a mistyped plugin filter got no plugin suggestion).
         {

--- a/src/housecarl-mcp/SkseTools.cs
+++ b/src/housecarl-mcp/SkseTools.cs
@@ -48,16 +48,18 @@ public static class SkseTools
         return SkseInventoryWire.Render(data, filter, max_chars > 0 ? max_chars : 80_000);
     });
 
-    [McpServerTool(Name = "housecarl_skse_config_audit", ReadOnly = true, Title = "SKSE config references vs the load order (dead-reference audit)"),
+    [McpServerTool(Name = "housecarl_skse_config_audit", ReadOnly = true, Title = "SKSE config references vs the load order (reference-validity audit)"),
      Description(
          "Cross-check the form references SKSE-plugin CONFIGS declare against the real records of the ACTIVE load order — so a " +
-         "DEAD reference (a FormID pointing at a plugin that isn't installed, or at a record that doesn't exist in it) is caught " +
-         "by houseCARL instead of by a silent in-game failure. Scans the full depth of Data\\SKSE\\Plugins for .ini/.toml/.json/" +
+         "BROKEN reference (a FormID pointing at a record that doesn't exist in a plugin you DO have) is caught by houseCARL " +
+         "instead of by a silent in-game failure, and kept apart from a merely INERT one (a plugin you don't have installed — " +
+         "usually optional support for a mod you aren't running). Scans the full depth of Data\\SKSE\\Plugins for .ini/.toml/.json/" +
          ".yaml/.yml configs, reads the WINNING copy of each (the copy the DLL actually reads), and extracts every form-shaped " +
          "reference — a hex FormID paired with a plugin filename in EITHER order (0xFORM|Plugin.esp as DSD/CDF/po3 write it, " +
          "Plugin.esp|0xFORM as SkyPatcher writes it, the ~ tilde form) plus plugin-named folder gates (DynamicStringDistributor\\" +
          "Plugin.esp\\...) — then resolves each to a verdict: OK, PLUGIN MISSING (plugin not in the order), DANGLING (plugin " +
-         "present but no such record), or UNPARSEABLE (a shape-matched token that can't be normalized). It is the generic, " +
+         "present but no such record), or UNPARSEABLE (a shape-matched token that can't be normalized) — the summary groups " +
+         "these as BROKEN (dangling/unparseable, actionable) vs INERT (plugin-missing, usually optional support). It is the generic, " +
          "framework-AGNOSTIC twin of the SkyPatcher reader's first half: it checks reference VALIDITY, never what a reference is " +
          "FOR (that's per-framework skill territory) and never what the DLL DOES with it (the honest ceiling). Extraction is a " +
          "heuristic over token SHAPES, so a token in a comment or disabled block still surfaces — the framing is 'references this " +
@@ -70,7 +72,7 @@ public static class SkseTools
         LoadOrderService svc,
         [Description("Optional. A config FOLDER, providing-mod, filename, or REFERENCED-plugin substring (case-insensitive). " +
             "Audits just the matching configs and lists every reference with its verdict, OKs included. Omit for the whole-layer " +
-            "audit (diagnostics — dead references — first, then the accounted-for remainder).")]
+            "audit (diagnostics — broken & inert references — first, then the accounted-for remainder).")]
             string? filter = null,
         [Description("Optional. Max characters before lists are cut with an explicit notice. 0 = the server default (~80k).")]
             int max_chars = 0) => Guard.Tool("housecarl_skse_config_audit", () =>
@@ -395,7 +397,7 @@ static class SkseConfigAuditWire
           .Append(d.ConfigCount).Append(" config(s) scanned, ").Append(filesWithRefs).Append(" carry references, ")
           .Append(refsChecked).Append(" reference(s) checked\n");
         if (broken == 0 && inert == 0)
-            sb.Append("✓ every reference resolves against the active load order — no dead references found.\n");
+            sb.Append("✓ every reference resolves against the active load order — nothing broken, nothing inert.\n");
         else if (broken == 0)
             sb.Append("✓ no broken references — every reference to an installed plugin resolves. (")
               .Append(inert).Append(" reference(s) point at plugins not in your load order — inert, usually optional support for a mod you don't have.)\n");

--- a/src/housecarl-mcp/SkseTools.cs
+++ b/src/housecarl-mcp/SkseTools.cs
@@ -353,8 +353,10 @@ static class SkseInventoryWire
 }
 
 /// <summary>Renders <see cref="SkseConfigAuditData"/> as compact, scannable text (housecarl_skse_config_audit, tier B).
-/// Default: a health summary, then the DIAGNOSTICS first and in full (dead references — PLUGIN MISSING gates + tokens,
-/// DANGLING, UNPARSEABLE — and read errors, each with file:line provenance and its winning provider), then the
+/// Default: a health summary that separates BROKEN references (DANGLING + UNPARSEABLE — a reference that should resolve
+/// and doesn't) from INERT ones (PLUGIN MISSING — the named plugin simply isn't installed, usually optional support for
+/// a mod you don't have), then the DIAGNOSTICS first and in full (PLUGIN MISSING gates + tokens, DANGLING, UNPARSEABLE —
+/// and read errors, each with file:line provenance and its winning provider), then the
 /// accounted-for remainder (healthy files counted; no-reference files grouped by folder — the OStim bulk). Bounded by
 /// max_chars with an explicit cut notice (Q3 — never silent truncation). filter= audits one group and lists EVERY
 /// reference with its verdict, OKs included (the positive-confirmation / verifier role).</summary>
@@ -378,20 +380,32 @@ static class SkseConfigAuditWire
         var readErrors   = d.Files.Where(f => f.ReadError is not null).ToList();
 
         int refsChecked = flat.Count;
-        int dead = missingGates.Count + missingToks.Count + dangling.Count + unparseable.Count;
+        // Two distinct signals, kept apart in the headline (framing fix). BROKEN = a reference that SHOULD resolve and
+        // doesn't (DANGLING: plugin present, record absent; UNPARSEABLE: a token we can't read) — the actionable one.
+        // INERT = PLUGIN MISSING (gate or token): the named plugin simply isn't installed, so the entry/file does nothing.
+        // For a config shipping optional support for a mod you don't have that's expected, not a fault — lumping it into
+        // "DEAD" made a healthy order read as thousands of dead references, which is the whole point of this reframe.
+        int broken = dangling.Count + unparseable.Count;
+        int inert  = missingGates.Count + missingToks.Count;
+        int notOk  = broken + inert;                       // every non-OK ref (kept for the accounted-for reconciliation below)
         int filesWithRefs = d.Files.Count(f => f.Refs.Count > 0);
 
         var sb = new StringBuilder();
         sb.Append("SKSE config audit — profile '").Append(d.ProfileName).Append("' — ")
           .Append(d.ConfigCount).Append(" config(s) scanned, ").Append(filesWithRefs).Append(" carry references, ")
           .Append(refsChecked).Append(" reference(s) checked\n");
-        if (dead == 0)
+        if (broken == 0 && inert == 0)
             sb.Append("✓ every reference resolves against the active load order — no dead references found.\n");
+        else if (broken == 0)
+            sb.Append("✓ no broken references — every reference to an installed plugin resolves. (")
+              .Append(inert).Append(" reference(s) point at plugins not in your load order — inert, usually optional support for a mod you don't have.)\n");
         else
         {
-            sb.Append("[!] ").Append(dead).Append(" DEAD reference(s): ")
-              .Append(missingGates.Count + missingToks.Count).Append(" plugin-missing · ")
-              .Append(dangling.Count).Append(" dangling · ").Append(unparseable.Count).Append(" unparseable\n");
+            sb.Append("[!] ").Append(broken).Append(" BROKEN reference(s): ")
+              .Append(dangling.Count).Append(" dangling · ").Append(unparseable.Count).Append(" unparseable");
+            if (inert > 0)
+                sb.Append("   ·   ").Append(inert).Append(" more inert (plugin not installed — usually optional support)");
+            sb.Append('\n');
         }
 
         // ── Diagnostics FIRST, in full (the point of the tool). ──
@@ -437,11 +451,11 @@ static class SkseConfigAuditWire
         // ── Accounted-for remainder — everything that ISN'T a diagnostic, so nothing is silently dropped (Q3). ──
         var healthyFiles = d.Files.Where(f => f.ReadError is null && f.Refs.Count > 0 && f.Refs.All(r => r.Verdict == SkseRefVerdict.Ok)).ToList();
         int healthyRefs = healthyFiles.Sum(f => f.Refs.Count);
-        int okInMixed = (refsChecked - dead) - healthyRefs;   // OK refs living in a file that ALSO has a dead ref — so every ref reconciles: refsChecked = dead + healthyRefs + okInMixed
+        int okInMixed = (refsChecked - notOk) - healthyRefs;   // OK refs living in a file that ALSO has a non-OK ref — so every ref reconciles: refsChecked = notOk + healthyRefs + okInMixed
         var noRefFiles = d.Files.Where(f => f.ReadError is null && f.Refs.Count == 0).ToList();
         sb.Append("\naccounted for: ").Append(healthyFiles.Count).Append(" file(s) with ").Append(healthyRefs)
           .Append(" reference(s) all OK");
-        if (okInMixed > 0) sb.Append(" · ").Append(okInMixed).Append(" more OK ref(s) in files that also have dead references");
+        if (okInMixed > 0) sb.Append(" · ").Append(okInMixed).Append(" more OK ref(s) in files that also carry a non-OK reference");
         sb.Append(" · ").Append(noRefFiles.Count).Append(" file(s) declare no form-shaped references\n");
         if (noRefFiles.Count > 0)
         {
@@ -482,9 +496,16 @@ static class SkseConfigAuditWire
           .Append(hits.Count).Append(" config(s) match [profile '").Append(d.ProfileName).Append("']\n");
         if (hits.Count == 0)
         {
+            // The suggestion pool must span EVERY axis Match filters on — else a mistyped plugin/provider filter gets only
+            // folder/filename suggestions. Match keys on filename/group/provider/relpath + referenced-plugin, so the pool
+            // carries filenames, folders, winning-provider mod names, AND the referenced-plugin names (the axis the tool
+            // exists to check). PluginNameSuggest dedups + skips empties, so no Distinct is needed here.
+            var suggestPool = d.Files.Select(f => f.FileName)
+                .Concat(d.Files.Select(f => f.Group).Where(g => g.Length > 0))
+                .Concat(d.Files.Select(f => f.WinningProvider).Where(p => !string.IsNullOrEmpty(p)).Select(p => p!))
+                .Concat(d.Files.SelectMany(f => f.Refs.Select(r => r.Ref.Plugin)));
             sb.Append("\nnothing under SKSE\\Plugins matched. ")
-              .Append(HousecarlCore.PluginNameSuggest.DidYouMean(filter,
-                  d.Files.Select(f => f.Group).Where(g => g.Length > 0).Concat(d.Files.Select(f => f.FileName)).Distinct()));
+              .Append(HousecarlCore.PluginNameSuggest.DidYouMean(filter, suggestPool));
             return sb.ToString().TrimEnd('\n');
         }
 


### PR DESCRIPTION
Two tier-B render residuals from the [PR #206](https://github.com/Avick3110/houseCARL/pull/206) review (tracked in `dev/BACKLOG.md`). Render-only — **no tool/skill count change** (still 44 tools / 13 skills; the tool itself landed in #206).

## ② Split BROKEN vs INERT in the whole-layer summary
The health headline lumped `PLUGIN MISSING` into `N DEAD reference(s)`, so a healthy load order carrying lots of optional-support configs read as *thousands* of dead references (ARR 2.0: 9,690 plugin-missing).

- **BROKEN** = DANGLING + UNPARSEABLE — a reference that *should* resolve and doesn't. The actionable signal.
- **INERT** = PLUGIN MISSING (gate or token) — the named plugin simply isn't installed; usually a config shipping optional support for a mod you don't have. Expected, not a fault.
- New all-clear-with-inert branch keeps a ✓ instead of alarm when nothing is actually broken.
- The diagnostic *detail* sections were already framed this way; this only fixes the headline. Internal `dead` → `notOk` (still the reconciliation total); the `accounted-for` sub-line reworded off "dead references" for consistency.

## ③ Widen the `filter=` did-you-mean pool
`Match` filters configs on filename / group / provider / relpath **and referenced-plugin names**, but the "nothing matched" suggestion pool was built from folders + filenames only — so a mistyped *plugin* filter got folder/file suggestions, never a plugin one. The pool now spans every axis `Match` keys on (adds winning-provider mod names + referenced-plugin names).

## ① was rejected (not in this PR)
The plugin-flag masking residual (bare-≤6-hex-ESL divergence) was **rejected** — it closes a shape no real distributor emits (only a hand-authored mis-write), and the current behavior is a false DANGLING (loud over-report, Q3-safe), never a silent wrong answer. Recorded under "Considered and dropped" in `dev/BACKLOG.md` (private).

## Tests
New **Part-3 (`RenderArms`)** in `skse-config-audit-guard` drives the real `SkseConfigAuditWire.Render` over synthetic `SkseConfigAuditData` — the render layer ci-all didn't exercise before (Render ran only in the live harness). Arms: ② healthy+inert framing, ② broken headline, ② broken+inert, ② mixed-file reconciliation (the `notOk` math), ③ typo'd referenced-plugin → suggestion offered.

- **ci-all 95/95** (extractor + verdict + new render arms all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)