### PR TITLE
fix(core): check_errors stops false-flagging a faction-owner RequiredRank as dangling (#207)

### DIFF
--- a/src/housecarl-core/ErrorCheck.cs
+++ b/src/housecarl-core/ErrorCheck.cs
@@ -132,7 +132,7 @@ public static class ErrorCheck
                             if (view.ResolveWinner(target) is not null) continue;   // resolves → fine
                             if (EngineImplicit.IsImplicit(target)) continue;        // engine-implicit (PlayerRef 000014 / Player 000007): the index can't resolve these hardcoded forms, but they are real, never dangling — same precise exemption the dialogue lints use (HCBR: was 531/531 false dangling → 000014)
                             ownerVarExempt ??= UntypedOwnerVariableData(body);      // #207: an UntypedOwner's VariableData word is a RequiredRank int (esp. -1 → FFFFFFFF), not a reference
-                            if (ownerVarExempt.TryGetValue(target, out int ov) && ov > 0) { ownerVarExempt[target] = ov - 1; continue; }
+                            if (ownerVarExempt.TryGetValue(target, out int rank) && rank > 0) { ownerVarExempt[target] = rank - 1; continue; }
                             totalDangling++;
                             if (danglingBudget > 0)
                             {
@@ -211,7 +211,7 @@ public static class ErrorCheck
                                     if (selfKeys.Contains(target)) continue;            // defined by this very file
                                     if (EngineImplicit.IsImplicit(target)) continue;
                                     ownerVarExempt ??= UntypedOwnerVariableData(rec);   // #207: RequiredRank int mis-exposed as a FormLink
-                                    if (ownerVarExempt.TryGetValue(target, out int rk) && rk > 0) { ownerVarExempt[target] = rk - 1; continue; }
+                                    if (ownerVarExempt.TryGetValue(target, out int rank) && rank > 0) { ownerVarExempt[target] = rank - 1; continue; }
                                     totalDangling++;
                                     if (danglingBudget > 0)
                                     {

--- a/src/housecarl-core/ErrorCheck.cs
+++ b/src/housecarl-core/ErrorCheck.cs
@@ -13,6 +13,9 @@ namespace HousecarlCore;
 ///     is null): a broken reference in the resolvable order. Engine-implicit forms (PlayerRef 000014, Player 000007 —
 ///     hardcoded refs the index can't resolve but that are never actually broken) are exempted via <see cref="EngineImplicit"/>,
 ///     so the standard player-state pattern doesn't false-flag (HCBR: 531/531 dangling all → 000014 before this exemption).
+///     A container/leveled-list item's OWNERSHIP "variable" word (an <see cref="IUntypedOwnerGetter.VariableData"/> — a
+///     RequiredRank int, not a reference, that Mutagen exposes AS a FormLink whenever it can't type the owner; #207) is
+///     exempted too, so a rank of -1 (0xFFFFFFFF) is not read as a dangling ref — see <see cref="UntypedOwnerVariableData"/>.
 ///   • MISSING MASTER — a plugin DECLARES a master that is not present in the active order
 ///     (<see cref="LoadOrderResolver.IndexView.ContainsPlugin"/> is false): the plugin's dependency is not installed /
 ///     enabled, the most common load-order break (and the root cause behind a cluster of that master's refs dangling).
@@ -34,7 +37,10 @@ namespace HousecarlCore;
 /// / parse class. It does NOT verify navmesh or terrain SPATIAL integrity (the CrcHash / NavmeshGrid recompute — a known
 /// Mutagen-delta residual), does NOT flag a REQUIRED field left null (needs per-field requiredness; a null FormLink is a
 /// legal optional here), and does NOT list unused-master cleanup (see above). All named in the rendered footer so a
-/// clean result is never read as byte-for-byte xEdit parity.
+/// clean result is never read as byte-for-byte xEdit parity. It also exempts an <see cref="IUntypedOwnerGetter"/>'s
+/// ambiguous "variable" word (#207 — see <see cref="UntypedOwnerVariableData"/>); the one thing that gives up is a
+/// genuinely-dangling Global on an NPC-OWNED item whose owner NPC lives in a master (vanishingly rare, and that owner
+/// NPC is still checked), which we trade for never false-flagging the far commoner faction-owner rank.
 ///
 /// Composes existing primitives only — no new dependency (audit A1 "Verified 2026-06-25"): the per-plugin record stream
 /// (<c>RecordsIn</c>), the O(1) resolution test (<c>ResolveWinner</c>), presence (<c>ContainsPlugin</c>), the declared-
@@ -118,12 +124,15 @@ public static class ErrorCheck
                     try
                     {
                         if (body is not IFormLinkContainerGetter flc) continue;
+                        Dictionary<FormKey, int>? ownerVarExempt = null;   // #207: built lazily on this record's first otherwise-dangling link (see UntypedOwnerVariableData)
                         foreach (var link in flc.EnumerateFormLinks())
                         {
                             var target = link.FormKey;
                             if (target.IsNull) continue;            // a null FormLink is a legal optional — not an error (see the class-doc boundary)
                             if (view.ResolveWinner(target) is not null) continue;   // resolves → fine
                             if (EngineImplicit.IsImplicit(target)) continue;        // engine-implicit (PlayerRef 000014 / Player 000007): the index can't resolve these hardcoded forms, but they are real, never dangling — same precise exemption the dialogue lints use (HCBR: was 531/531 false dangling → 000014)
+                            ownerVarExempt ??= UntypedOwnerVariableData(body);      // #207: an UntypedOwner's VariableData word is a RequiredRank int (esp. -1 → FFFFFFFF), not a reference
+                            if (ownerVarExempt.TryGetValue(target, out int ov) && ov > 0) { ownerVarExempt[target] = ov - 1; continue; }
                             totalDangling++;
                             if (danglingBudget > 0)
                             {
@@ -193,6 +202,7 @@ public static class ErrorCheck
                             try
                             {
                                 if (rec is not IFormLinkContainerGetter flc) continue;
+                                Dictionary<FormKey, int>? ownerVarExempt = null;   // #207 (see UntypedOwnerVariableData)
                                 foreach (var link in flc.EnumerateFormLinks())
                                 {
                                     var target = link.FormKey;
@@ -200,6 +210,8 @@ public static class ErrorCheck
                                     if (view.ResolveWinner(target) is not null) continue;
                                     if (selfKeys.Contains(target)) continue;            // defined by this very file
                                     if (EngineImplicit.IsImplicit(target)) continue;
+                                    ownerVarExempt ??= UntypedOwnerVariableData(rec);   // #207: RequiredRank int mis-exposed as a FormLink
+                                    if (ownerVarExempt.TryGetValue(target, out int rk) && rk > 0) { ownerVarExempt[target] = rk - 1; continue; }
                                     totalDangling++;
                                     if (danglingBudget > 0)
                                     {
@@ -238,6 +250,46 @@ public static class ErrorCheck
 
         return new ErrorCheckResult(reports, targets.Count + offOrderScanned.Count, totalDangling, totalMissing,
                                     totalUnscannable, capped, view.ExcludedPlugins, null, offOrderScanned);
+    }
+
+    /// <summary>Every FormKey carried in an <see cref="IUntypedOwnerGetter.VariableData"/> slot in <paramref name="body"/>,
+    /// as a MULTISET (FormKey → occurrence count) — the FormKeys the dangling sweep must NOT flag (#207).
+    ///
+    /// <para>WHY (Mutagen 0.53.1, confirmed at source — <c>ExtraDataBinaryCreateTranslation.GetBinaryOwner</c> +
+    /// <c>RecordTypeInfoCacheReader.IsOfRecordType</c>): a container / leveled-list item's ownership is a COED block — an
+    /// owner FormID plus a SECOND 4-byte word that is a <c>RequiredRank</c> int when the owner is a FACTION, or a Global
+    /// FormLink when it is an NPC. Mutagen picks the arm by resolving the owner form's record TYPE; when the owner lives
+    /// in a MASTER and the overlay carries no link cache — which is EVERY override this sweep reads — that resolution
+    /// throws <c>LinkCacheMissingException</c> and the arm falls back to <see cref="IUntypedOwnerGetter"/>, which exposes
+    /// BOTH words as <c>FormLink&lt;ISkyrimMajorRecordGetter&gt;</c>. <c>EnumerateFormLinks</c> then walks the second word;
+    /// for the common faction case it is a rank, and a rank of -1 (0xFFFFFFFF → FFFFFF:&lt;self&gt;) resolves to nothing and
+    /// was reported as a false dangling reference — the same COED reads correctly (as FactionOwner + RequiredRank) only
+    /// when the owner faction lives in the very plugin being parsed.</para>
+    ///
+    /// <para>So we drop ONLY that second (VariableData) word from the scan. The owner form itself
+    /// (<see cref="IUntypedOwnerGetter.OwnerData"/> — the FIRST word) is still checked, so a genuinely broken owner still
+    /// surfaces. Exemption is per-record and by exact FormKey with a count, so it can never mask an unrelated dangling
+    /// link elsewhere in the record. Owner targets live ONLY on <see cref="IExtraDataGetter.Owner"/>, carried by exactly
+    /// these four record types (by the generated schema — a fifth would be an upstream Mutagen change, caught by the
+    /// schema regen), so this switch is the complete surface.</para></summary>
+    static Dictionary<FormKey, int> UntypedOwnerVariableData(IMajorRecordGetter body)
+    {
+        var acc = new Dictionary<FormKey, int>();
+        void Add(IExtraDataGetter? ed)
+        {
+            if (ed?.Owner is not IUntypedOwnerGetter uo) return;
+            var vk = uo.VariableData.FormKey;
+            if (vk.IsNull) return;                                     // a null second word is a legal optional anyway (never flagged)
+            acc[vk] = acc.TryGetValue(vk, out var c) ? c + 1 : 1;
+        }
+        switch (body)
+        {
+            case IContainerGetter cont:    if (cont.Items   is { } items)   foreach (var it in items) Add(it.Data);      break;
+            case ILeveledItemGetter lvli:  if (lvli.Entries is { } liEnts)  foreach (var e in liEnts) Add(e.ExtraData);  break;
+            case ILeveledNpcGetter lvln:   if (lvln.Entries is { } lnEnts)  foreach (var e in lnEnts) Add(e.ExtraData);  break;
+            case ILeveledSpellGetter lvsp: if (lvsp.Entries is { } lsEnts)  foreach (var e in lsEnts) Add(e.ExtraData);  break;
+        }
+        return acc;
     }
 }
 

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -46,6 +46,17 @@ namespace HousecarlGenerator;
 ///                     (HCBR checkerrors-playerref-dangling-false-positive: check_errors was reporting 531/531 false → 000014).
 ///   PLAYERREF-CONTROL   — a DIFFERENT sub-0x800 form (000015:Skyrim.esm) IS still flagged and the plugin totals 1 dangling:
 ///                     the exemption is a PRECISE 2-form set, not the whole reserved range, so a real typo'd low FormID surfaces.
+///   OWNER-RANK          — a faction-owned container item's COED RequiredRank -1 (0xFFFFFFFF → id FFFFFF) is NOT a dangling ref
+///                     (#207): when the owner faction lives in a master, a bare overlay mis-types the owner to UntypedOwner and
+///                     exposes the rank word AS a FormLink; the sweep exempts that word (ErrorCheck.UntypedOwnerVariableData).
+///   OWNER-DATA-CHECKED  — the owner FORM itself is still swept — a faction owner in an ABSENT master DOES dangle + is a missing
+///                     master (the exemption drops ONLY the ambiguous rank word, never the owner reference).
+///   OWNER-RANK-TOTAL    — exactly 1 dangling across the owner order (both chests' rank words exempt; only the broken owner form) —
+///                     without the fix the same order totals 3 (two FFFFFF rank artifacts + the ghost owner).
+///
+/// OWNER FIXTURE (#207, its own order): HcCeMaster.esm also defines a Faction; HcCeOwner.esp masters [HcCeMaster, HcCeGhost]
+///   and carries two owned containers — one owned by the PRESENT master's faction (rank -1 → must not dangle) and one owned by a
+///   faction id in the ABSENT ghost master (rank -1 → the owner form dangles, the rank word does not). Built as [Master, Owner].
 ///
 /// PLAYERREF FIXTURE (its own order, engine-implicit whitelist): a stub Skyrim.esm base master, on disk but NOT loaded
 ///   (the absent-master shape again, so every ref into it fails ResolveWinner), and HcCePlayer.esp mastering [Skyrim] with
@@ -90,11 +101,13 @@ public static class CheckErrorsProbe
         var playerRefFk  = FormKey.Factory("000014:Skyrim.esm");  // PlayerRef — engine-implicit, whitelisted (must NOT dangle)
         var playerBaseFk = FormKey.Factory("000007:Skyrim.esm");  // Player base NPC_ — engine-implicit, whitelisted (must NOT dangle)
         var sub800Fk     = FormKey.Factory("000015:Skyrim.esm");  // a DIFFERENT sub-0x800 form — NOT whitelisted (MUST dangle: proves precision)
-        FormKey masterRaceFk, ghostRaceFk;
+        var ghostOwnerFactionFk = FormKey.Factory("000D0F:HcCeGhost.esm");  // #207: an owner-faction id in the ABSENT master (proves OwnerData is still swept)
+        FormKey masterRaceFk, ghostRaceFk, ownerFactionFk;
         try
         {
             var master = new SkyrimMod(new ModKey("HcCeMaster", ModType.Master), SkyrimRelease.SkyrimSE);
             var mRace = master.Races.AddNew(); mRace.EditorID = "HcCeMasterRace"; masterRaceFk = mRace.FormKey;
+            var mFac = master.Factions.AddNew(); mFac.EditorID = "HcCeMasterFaction"; ownerFactionFk = mFac.FormKey;  // #207 owner-target fixture: a faction that lives in a MASTER
             master.BeginWrite.ToPath(masterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
 
             var ghost = new SkyrimMod(new ModKey("HcCeGhost", ModType.Master), SkyrimRelease.SkyrimSE);
@@ -253,6 +266,66 @@ public static class CheckErrorsProbe
         Check("PLAYERREF-CONTROL: a non-whitelisted sub-0x800 form (000015) IS still flagged; the plugin totals 1 dangling (exemption is precise, not the whole range)",
             player2 is not null && player2.Dangling.Any(d => d.Target == sub800Fk) && pl.TotalDangling == 1,
             player2 is null ? "<no report>" : $"total={pl.TotalDangling} targets=[{string.Join(",", player2.Dangling.Select(d => d.Target.ToString()))}]");
+
+        // ---- OWNER-RANK (#207): a container item owned by a FACTION carries a COED "required rank" word. When the
+        //      owner faction lives in a MASTER (every override), a bare overlay cannot type the owner arm and Mutagen
+        //      falls back to UntypedOwner, exposing that rank word AS a FormLink — so a rank of -1 (0xFFFFFFFF → id
+        //      FFFFFF) was reported as a false dangling ref. HcCeOwner.esp carries two owned chests:
+        //        • HcCeOwnedChest      — owner = a faction in the PRESENT master, rank -1 → must produce NO dangling.
+        //        • HcCeGhostOwnedChest — owner = a faction in the ABSENT ghost master, rank -1 → the OWNER FORM must
+        //          STILL dangle (only the rank word is exempt) + HcCeGhost is a missing master.
+        //      Without the fix the order totals 3 dangling (two FFFFFF rank artifacts + the ghost owner); with it, 1. ----
+        string ownerPath = Path.Combine(tmpDir, "HcCeOwner.esp");
+        try
+        {
+            using var masterOv = SkyrimMod.CreateFromBinaryOverlay(masterPath, SkyrimRelease.SkyrimSE);
+            using var ghostOv = SkyrimMod.CreateFromBinaryOverlay(ghostPath, SkyrimRelease.SkyrimSE);
+            var ownerMod = new SkyrimMod(new ModKey("HcCeOwner", ModType.Plugin), SkyrimRelease.SkyrimSE);
+
+            var goodChest = ownerMod.Containers.AddNew(); goodChest.EditorID = "HcCeOwnedChest";
+            goodChest.Items = new()
+            {
+                new ContainerEntry
+                {
+                    Item = new ContainerItem { Count = 1 },
+                    Data = new ExtraData { ItemCondition = 1f, Owner = new FactionOwner { Faction = new FormLink<IFactionGetter>(ownerFactionFk), RequiredRank = -1 } },
+                },
+            };
+
+            var ghostChest = ownerMod.Containers.AddNew(); ghostChest.EditorID = "HcCeGhostOwnedChest";
+            ghostChest.Items = new()
+            {
+                new ContainerEntry
+                {
+                    Item = new ContainerItem { Count = 1 },
+                    Data = new ExtraData { ItemCondition = 1f, Owner = new FactionOwner { Faction = new FormLink<IFactionGetter>(ghostOwnerFactionFk), RequiredRank = -1 } },
+                },
+            };
+
+            ownerMod.BeginWrite.ToPath(ownerPath).WithLoadOrder(new ISkyrimModGetter[] { masterOv, ghostOv }).Write();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"error: could not synthesize the owner-target fixture: {ex.GetType().Name}: {(ex.InnerException ?? ex).Message}");
+            return 1;
+        }
+
+        using var ro = LoadOrderResolver.Build(new[] { masterPath, ownerPath });   // ghost NOT loaded — the missing master again
+        var ownerRes = ErrorCheck.Run(ro, null, 1000);
+        if (!ownerRes.Success) { Console.Error.WriteLine($"error: owner-target sweep failed: {ownerRes.Error}"); return 1; }
+        var ownerRep = ownerRes.Reports.FirstOrDefault(p => p.Plugin == "HcCeOwner.esp");
+
+        Check("OWNER-RANK: a faction-owned item's RequiredRank -1 (0xFFFFFFFF) is NOT reported as a dangling ref (#207)",
+            ownerRep is null || !ownerRep.Dangling.Any(d => d.Target.ID == 0xFFFFFF),
+            ownerRep is null ? "<no report>" : $"targets=[{string.Join(",", ownerRep.Dangling.Select(d => d.Target.ToString()))}]");
+
+        Check("OWNER-DATA-CHECKED: the owner FORM is still swept — a faction owner in an absent master DOES dangle + is a missing master",
+            ownerRep is not null && ownerRep.Dangling.Any(d => d.Target == ghostOwnerFactionFk)
+            && ownerRep.MissingMasters.Contains("HcCeGhost.esm", StringComparer.OrdinalIgnoreCase),
+            ownerRep is null ? "<no report>" : $"dangling=[{string.Join(",", ownerRep.Dangling.Select(d => d.Target.ToString()))}] missing=[{string.Join(",", ownerRep.MissingMasters)}]");
+
+        Check("OWNER-RANK-TOTAL: exactly 1 dangling across the owner order (both RequiredRank words exempt; only the broken owner form)",
+            ownerRes.TotalDangling == 1, $"total={ownerRes.TotalDangling}");
 
         Console.WriteLine();
         Console.WriteLine(failures == 0 ? "check-errors-guard: ALL PASS" : $"check-errors-guard: {failures} FAILURE(S)");

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -271,8 +271,9 @@ public static class ReadTools
          "for a patch houseCARL just wrote. Read-only — writes nothing. BOUNDARY " +
          "(never a silent claim of more — Q3): this covers the FormLink-resolution / missing-master / parse class. It does " +
          "NOT verify navmesh or terrain spatial integrity (CRC/grid — a Mutagen-delta residual), does NOT flag a required " +
-         "field left null (a null FormLink is a legal optional, not an error), and does NOT list unused-master cleanup " +
-         "(a FormLink scan cannot prove a master is unused). Results cap at limit= and max_chars (both overruns explicit).")]
+         "field left null (a null FormLink is a legal optional, not an error), does NOT list unused-master cleanup " +
+         "(a FormLink scan cannot prove a master is unused), and does NOT link-check an owned item's ownership 'variable' " +
+         "word (a rank/global Mutagen cannot type on an override without a link cache). Results cap at limit= and max_chars (both overruns explicit).")]
     public static string CheckErrorsTool(
         LoadOrderService svc,
         [Description("Optional. Plugin filenames to check (e.g. 'MyMod.esp'). A name not in the active order is resolved on disk (a fresh houseCARL patch, a disabled mod) and swept OFF-ORDER; found nowhere (or in several folders) it is an error. Omit to sweep the WHOLE active order (every non-excluded plugin) — thorough but heavier; scope to one plugin for a fast, focused check like the CK's per-plugin 'Check For Errors'.")]
@@ -726,7 +727,8 @@ static class Wire
         }
 
         sb.Append("\nboundary: checks FormLink resolution, missing masters, and parse failures. Does NOT verify navmesh/terrain ")
-          .Append("spatial integrity (CRC/grid), flag required-but-null fields, or list unused-master cleanup; a null FormLink is a legal optional.\n");
+          .Append("spatial integrity (CRC/grid), flag required-but-null fields, list unused-master cleanup, or link-check an owned ")
+          .Append("item's ownership 'variable' word (a rank/global Mutagen can't type on an override); a null FormLink is a legal optional.\n");
         return sb.ToString().TrimEnd('\n');
     }
 


### PR DESCRIPTION
Fixes #207.

## The bug (confirmed at the Mutagen 0.53.1 source, not just the report's hunch)

`housecarl_check_errors` reported a false `[ERROR] dangling reference` for a container / leveled-list item whose faction owner carries `RequiredRank = -1` (`0xFFFFFFFF`).

A COED ownership block is an **owner form** plus a **second 4-byte word** — a `RequiredRank` int when the owner is a FACTION, or a `Global` FormLink when it's an NPC. Mutagen types the owner arm by resolving the owner form's record type (`ExtraDataBinaryCreateTranslation.GetBinaryOwner` → `RecordTypeInfoCacheReader.IsOfRecordType`). A bare binary overlay carries **no link cache**, so when the owner faction lives in a **master** — i.e. for essentially every override this sweep reads — that resolution throws `LinkCacheMissingException` and the arm falls back to `UntypedOwner`, which exposes **both** words as `FormLink`. `EnumerateFormLinks` then walks the rank word, and `-1` (`0xFFFFFFFF` → `FFFFFF:<self>`) resolves to nothing → false dangling. Reading the origin plugin directly types it correctly (`FactionOwner`) only because the faction lives in that same plugin.

## The fix

The dangling sweep exempts an `UntypedOwner`'s `VariableData` word (the ambiguous second COED word) in both the active-order and off-order lanes. The owner form itself (`OwnerData`) is still checked, so a genuinely broken owner still surfaces.

**Honest boundary (Q3):** the one thing given up is a truly-dangling `Global` on an NPC-owned item whose owner NPC lives in a master — vanishingly rare, and that owner NPC is still checked. Owner targets live only on `ExtraData.Owner`, carried by exactly `Container` / `LeveledItem` / `LeveledNpc` / `LeveledSpell` by the generated schema, so the switch is the complete surface.

## Tests

- Adds 3 arms to `check-errors-guard`: `OWNER-RANK`, `OWNER-DATA-CHECKED`, `OWNER-RANK-TOTAL`.
- **Proven to have teeth:** with the fix temporarily disabled, `OWNER-RANK` and `OWNER-RANK-TOTAL` fail (the `FFFFFF` artifact reappears, order totals 3 dangling vs 1). `OWNER-DATA-CHECKED` passes either way (the owner form is always swept).
- Full `ci-all`: **95/95**.

No version/changelog edit — folds into the next release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)