### PR TITLE
feat(skse): housecarl_native_pairing_audit — native declarations vs the DLLs that implement them (tool #45)

### DIFF
--- a/src/housecarl-core/ArchiveDiscovery.cs
+++ b/src/housecarl-core/ArchiveDiscovery.cs
@@ -44,6 +44,11 @@ public sealed record ArchiveDiscoveryResult(IReadOnlyList<ActiveArchive> Archive
 
 public static class ArchiveDiscovery
 {
+    /// <summary>The <see cref="ActiveArchive.OwningPlugin"/> marker for a BASE archive (loaded via Skyrim.ini's
+    /// [Archive] list, not bound to a plugin). Single-sourced: consumers that discriminate "official base archive"
+    /// (the native-pairing audit's ENGINE carve-out) key on THIS const, never a re-typed literal.</summary>
+    public const string IniArchiveOwner = "Skyrim.ini [Archive]";
+
     /// <summary>Discover the active BSAs for the MO2 profile at <paramref name="profileDir"/>, resolving each
     /// through the same overwrite &gt; mods(priority) &gt; Data VFS the loose/plugin layers use. The roots are the
     /// ones <see cref="Mo2LoadOrder.Build"/> already receives; <paramref name="gamePath"/> is only the game-dir
@@ -71,7 +76,7 @@ public static class ArchiveDiscovery
         foreach (var fn in ReadBaseArchiveNames(profileDir, gamePath, warnings))
         {
             if (archiveMap.TryGetValue(fn, out var path))
-                archives.Add(new ActiveArchive(path, "Skyrim.ini [Archive]", rank));
+                archives.Add(new ActiveArchive(path, IniArchiveOwner, rank));
             rank++;   // a distinct rank per INI entry (later in the list = later loaded); absent-on-disk just isn't added
         }
 

--- a/src/housecarl-core/AssetResolver.cs
+++ b/src/housecarl-core/AssetResolver.cs
@@ -252,6 +252,32 @@ public sealed class AssetResolver : IDisposable
         finally { (reader as IDisposable)?.Dispose(); }           // INERT in 0.53.1 — belt-and-braces, see ReadArchiveTable
     }
 
+    /// <summary>Read MANY entries' bytes out of ONE archive in a single table walk — the batch sibling of
+    /// <see cref="TryReadArchiveEntry"/> (native-pairing review finding: reading K entries via the single-entry call
+    /// costs K archive opens × a full linear table scan each — O(K·M) against Skyrim - Misc.bsa's ~10k scripts, the
+    /// dominant wall-clock of a whole-order .pex sweep). One reader, one pass over <c>Files</c>, wanted paths matched
+    /// via a normalized set. Returns entryPath → bytes for the entries FOUND (keyed by the caller's own strings);
+    /// a wanted entry absent from the archive is simply absent from the result (the caller Q3-names it). Same
+    /// zero-handle-at-rest contract; an unopenable archive still THROWS (loud), never a silent empty map.</summary>
+    public static Dictionary<string, byte[]> TryReadArchiveEntries(string archivePath, IReadOnlyCollection<string> entryPaths)
+    {
+        var wanted = new Dictionary<string, string>(entryPaths.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (var p in entryPaths) wanted[Normalize(p)] = p;                 // normalized key → the caller's original string
+        var result = new Dictionary<string, byte[]>(entryPaths.Count, StringComparer.OrdinalIgnoreCase);
+        var reader = Archive.CreateReader(GameRelease.SkyrimSE, archivePath);
+        try
+        {
+            foreach (var file in reader.Files)
+            {
+                if (result.Count == wanted.Count) break;                        // everything found — stop walking the table
+                if (wanted.TryGetValue(Normalize(file.Path), out var original) && !result.ContainsKey(original))
+                    result[original] = file.GetBytes();
+            }
+            return result;
+        }
+        finally { (reader as IDisposable)?.Dispose(); }
+    }
+
     /// <summary>Read the bytes of ONE resolved provider — a loose file off disk, or a single BSA entry via
     /// <see cref="TryReadArchiveEntry"/>. THE shared home for the loose-vs-BSA winner read (review finding: this
     /// logic had grown three near-verbatim copies — AssetRenameService.ReadWinner and the NPC-copy asset carry now

--- a/src/housecarl-core/NativePairing.cs
+++ b/src/housecarl-core/NativePairing.cs
@@ -1,0 +1,62 @@
+using Mutagen.Bethesda.Pex;
+
+namespace HousecarlCore;
+
+// ======================================================================
+//  NativePairing — the PURE half of the native-function pairing audit
+//  (housecarl_native_pairing_audit; plan dev/plans/SKSE_NATIVE_PAIRING_AUDIT_PLAN_2026-07-16.md).
+//
+//  A native Papyrus function is ONE thing declared in TWO places: a .pex script class carrying a
+//  native-flagged function (what quests/MCMs/effects compile against) and a DLL that registers the
+//  implementation at runtime. The halves ship as separate files and fail INDEPENDENTLY — scripts
+//  installed, DLL absent / wrong-runtime / 32-bit — and the engine's response is "unable to bind" +
+//  silent no-op calls. This file extracts the DECLARATION side from a compiled .pex: which script
+//  objects declare native functions, and which functions those are.
+//
+//  Pure over Mutagen's PexFile model (the PapyrusDecompiler/ScriptPropertyCheck lineage) so the CI
+//  probe can pin it against fixture .pex files with no live order. The sweep, provenance
+//  classification, and pairing ladder live in LoadOrderService (they need the VFS + archive
+//  provenance); the honest ceiling stays tier E — this reads what a script DECLARES, never what a
+//  DLL actually registers at runtime.
+// ======================================================================
+
+/// <summary>One script object (class) in a <c>.pex</c> that declares ≥1 native-flagged function, with the declared
+/// native function names (named state functions; a native-flagged property accessor surfaces as <c>Prop.Get</c>/
+/// <c>Prop.Set</c>). <see cref="ClassName"/> is the pex object's own name — the class identity scripts compile
+/// against, which for a namespaced script includes the namespace (<c>Ns:Script</c>).</summary>
+public sealed record NativeClassDecl(string ClassName, IReadOnlyList<string> NativeFunctions);
+
+public static class NativePairing
+{
+    /// <summary>The native flag on <see cref="PexObjectFunction.Flags"/>: raw bit1 (bit0 = Global). Mutagen's enum
+    /// names sit one off from the file format — the documented off-by-one (PapyrusDecompiler header) — so the raw
+    /// bit is the truth, pinned by the native-pairing guard's fixture arm.</summary>
+    const uint NativeFlagBit = 0x2;
+
+    /// <summary>Extract every script object in <paramref name="pex"/> that declares native functions. An object with
+    /// no native functions yields nothing (the common case — most scripts are pure Papyrus). Pure; never throws on a
+    /// model Mutagen managed to parse (an UNPARSEABLE .pex fails at <c>PexFile.Create*</c> in the caller, which names
+    /// it — Q3).</summary>
+    public static IReadOnlyList<NativeClassDecl> ExtractNativeClasses(PexFile pex)
+    {
+        var result = new List<NativeClassDecl>();
+        foreach (var obj in pex.Objects)
+        {
+            var natives = new List<string>();
+            foreach (var st in obj.States)
+                foreach (var f in st.Functions.Cast<PexObjectNamedFunction>())
+                    if (IsNative(f.Function)) natives.Add(f.FunctionName ?? "(unnamed)");
+            // Property accessors are functions too; a native-flagged one is rare but real — count it, never drop it.
+            foreach (var p in obj.Properties)
+            {
+                if (p.ReadHandler is { } get && IsNative(get)) natives.Add($"{p.Name}.Get");
+                if (p.WriteHandler is { } set && IsNative(set)) natives.Add($"{p.Name}.Set");
+            }
+            if (natives.Count > 0)
+                result.Add(new NativeClassDecl(obj.Name ?? "(unnamed object)", natives));
+        }
+        return result;
+    }
+
+    static bool IsNative(PexObjectFunction f) => ((uint)f.Flags & NativeFlagBit) != 0;
+}

--- a/src/housecarl-core/SksePluginReader.cs
+++ b/src/housecarl-core/SksePluginReader.cs
@@ -89,41 +89,7 @@ public static class SksePluginReader
         try
         {
             using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
-            using var pe = new PEReader(fs);
-            // The COFF machine field is available as soon as the PE opened — read the real bitness even when the optional
-            // header is missing, so an Unreadable-with-no-optional-header still reports a TRUE x64/x86 rather than a
-            // fabricated one. Only the catch paths below (which never got this far) leave bitness null = UNKNOWN.
-            bool is64 = pe.PEHeaders.CoffHeader.Machine == Machine.Amd64;
-            if (pe.PEHeaders.PEHeader is null)
-                return new SksePluginInfo(file, SksePluginKind.Unreadable, is64, null, "no PE optional header");
-
-            var exports = ReadExportRvas(pe);
-            if (exports is null)   // export directory present but CORRUPT — a parse failure, NOT "no exports" (Q3: don't misclassify a corrupt DLL as a bundled dependency)
-                return new SksePluginInfo(file, SksePluginKind.Unreadable, is64, null, "corrupt PE export directory — could not enumerate exports");
-
-            bool hasVersion = exports.TryGetValue("SKSEPlugin_Version", out int versionRva) && versionRva != 0;
-            bool hasQuery = exports.ContainsKey("SKSEPlugin_Query");
-            bool hasLoad = exports.ContainsKey("SKSEPlugin_Load") || exports.ContainsKey("SKSEPlugin_Preload");
-
-            if (!hasVersion && !hasQuery && !hasLoad)
-                return new SksePluginInfo(file, SksePluginKind.NotSkse, is64, null,
-                    "no SKSE export (SKSEPlugin_Version/Query/Load) — a bundled dependency DLL, not a plugin");
-
-            if (!hasVersion)
-                return new SksePluginInfo(file, SksePluginKind.LegacyQuery, is64, null,
-                    "legacy SE/VR plugin: exports SKSEPlugin_Query (metadata is filled at runtime), so name/version are not statically readable");
-
-            // Modern: slice the version blob out of its section and decode. A real SKSEPluginVersionData is a FULL
-            // 0x350-byte struct whose dataVersion (0x000) is kVersion (>= 1); a version export whose RVA maps to no
-            // section, a forwarder, or a corrupt EAT yields a short or all-zero blob — degrade honestly rather than
-            // present a phantom "" v0.0.0 plugin (Q3).
-            var block = pe.GetSectionData(versionRva);
-            byte[] blob = block.GetReader().ReadBytes(Math.Min(0x350, block.Length));
-            if (blob.Length < 0x350 || BitConverter.ToUInt32(blob, 0) == 0)
-                return new SksePluginInfo(file, SksePluginKind.Unreadable, is64, null,
-                    "exports SKSEPlugin_Version but its RVA does not resolve to a readable version blob (a forwarded or corrupt export)");
-            var ver = DecodeVersionBlob(blob);
-            return new SksePluginInfo(file, SksePluginKind.Modern, is64, ver, null);
+            return ReadStream(file, fs);
         }
         catch (BadImageFormatException ex)
         {
@@ -133,6 +99,66 @@ public static class SksePluginReader
         {
             return new SksePluginInfo(file, SksePluginKind.Unreadable, null, null, $"could not read: {ex.GetType().Name}: {ex.Message}");
         }
+    }
+
+    /// <summary>Read a DLL's static SKSE manifest from in-memory bytes — the BSA-packed twin of <see cref="Read"/>
+    /// (the native-pairing audit PE-screens archive-shipped DLLs so a packed non-SKSE dependency never counts as an
+    /// implementation candidate). Same never-throws contract.</summary>
+    public static SksePluginInfo ReadBytes(string fileName, byte[] bytes)
+    {
+        try
+        {
+            using var ms = new MemoryStream(bytes, writable: false);
+            return ReadStream(fileName, ms);
+        }
+        catch (BadImageFormatException ex)
+        {
+            return new SksePluginInfo(fileName, SksePluginKind.Unreadable, null, null, $"not a valid PE image: {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            return new SksePluginInfo(fileName, SksePluginKind.Unreadable, null, null, $"could not read: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>The shared decode over any seekable stream (the two entry points above own the never-throws catch).</summary>
+    static SksePluginInfo ReadStream(string file, Stream stream)
+    {
+        using var pe = new PEReader(stream);
+        // The COFF machine field is available as soon as the PE opened — read the real bitness even when the optional
+        // header is missing, so an Unreadable-with-no-optional-header still reports a TRUE x64/x86 rather than a
+        // fabricated one. Only the catch paths below (which never got this far) leave bitness null = UNKNOWN.
+        bool is64 = pe.PEHeaders.CoffHeader.Machine == Machine.Amd64;
+        if (pe.PEHeaders.PEHeader is null)
+            return new SksePluginInfo(file, SksePluginKind.Unreadable, is64, null, "no PE optional header");
+
+        var exports = ReadExportRvas(pe);
+        if (exports is null)   // export directory present but CORRUPT — a parse failure, NOT "no exports" (Q3: don't misclassify a corrupt DLL as a bundled dependency)
+            return new SksePluginInfo(file, SksePluginKind.Unreadable, is64, null, "corrupt PE export directory — could not enumerate exports");
+
+        bool hasVersion = exports.TryGetValue("SKSEPlugin_Version", out int versionRva) && versionRva != 0;
+        bool hasQuery = exports.ContainsKey("SKSEPlugin_Query");
+        bool hasLoad = exports.ContainsKey("SKSEPlugin_Load") || exports.ContainsKey("SKSEPlugin_Preload");
+
+        if (!hasVersion && !hasQuery && !hasLoad)
+            return new SksePluginInfo(file, SksePluginKind.NotSkse, is64, null,
+                "no SKSE export (SKSEPlugin_Version/Query/Load) — a bundled dependency DLL, not a plugin");
+
+        if (!hasVersion)
+            return new SksePluginInfo(file, SksePluginKind.LegacyQuery, is64, null,
+                "legacy SE/VR plugin: exports SKSEPlugin_Query (metadata is filled at runtime), so name/version are not statically readable");
+
+        // Modern: slice the version blob out of its section and decode. A real SKSEPluginVersionData is a FULL
+        // 0x350-byte struct whose dataVersion (0x000) is kVersion (>= 1); a version export whose RVA maps to no
+        // section, a forwarder, or a corrupt EAT yields a short or all-zero blob — degrade honestly rather than
+        // present a phantom "" v0.0.0 plugin (Q3).
+        var block = pe.GetSectionData(versionRva);
+        byte[] blob = block.GetReader().ReadBytes(Math.Min(0x350, block.Length));
+        if (blob.Length < 0x350 || BitConverter.ToUInt32(blob, 0) == 0)
+            return new SksePluginInfo(file, SksePluginKind.Unreadable, is64, null,
+                "exports SKSEPlugin_Version but its RVA does not resolve to a readable version blob (a forwarded or corrupt export)");
+        var ver = DecodeVersionBlob(blob);
+        return new SksePluginInfo(file, SksePluginKind.Modern, is64, ver, null);
     }
 
     /// <summary>Decode the raw <c>SKSEPlugin_Version</c> blob bytes into the manifest. PURE + bounds-checked so the CI
@@ -186,6 +212,18 @@ public static class SksePluginReader
     /// the exe resource 4). Pure; pinned by the native-pairing guard.</summary>
     public static bool RuntimeCompatible(SkseVersionInfo v, string installedRuntime)
         => v.VersionIndependent || v.CompatibleVersions.Any(cv => VersionsEqual(cv, installedRuntime));
+
+    /// <summary>True when the dotted runtime version is AE-era (1.6 or later). Load-bearing for LegacyQuery
+    /// adjudication: the AE SKSE loader loads ONLY plugins exporting the <c>SKSEPlugin_Version</c> data blob (the
+    /// type doc's first bullet), so a query-only SE/VR-era plugin will NOT load on an AE runtime. A non-numeric or
+    /// short version returns FALSE — unknown never becomes a "won't load" claim (Q3).</summary>
+    public static bool IsAeRuntime(string runtime)
+    {
+        var seg = runtime.Split('.');
+        if (seg.Length < 2 || !int.TryParse(seg[0].Trim(), out var maj) || !int.TryParse(seg[1].Trim(), out var min))
+            return false;
+        return maj > 1 || (maj == 1 && min >= 6);
+    }
 
     /// <summary>Numeric dotted-version equality with zero-padding ("1.6.1170" == "1.6.1170.0"). A non-numeric
     /// segment ⇒ NOT equal (never guessed equal — a garbage compat entry must not accidentally PASS a lock, Q3).</summary>

--- a/src/housecarl-core/SksePluginReader.cs
+++ b/src/housecarl-core/SksePluginReader.cs
@@ -179,6 +179,29 @@ public static class SksePluginReader
             MinimumXseVersion: xseMin == 0 ? null : UnpackVersion(xseMin));
     }
 
+    /// <summary>Whether a MODERN plugin can load on <paramref name="installedRuntime"/> (a dotted game version, e.g.
+    /// "1.6.1170.0" from the executable's version resource). Version-independent plugins load anywhere → true;
+    /// a version-LOCKED plugin loads only when a listed compatible runtime matches numerically. Numeric,
+    /// zero-padded segment compare — "1.6.1170" and "1.6.1170.0" are the SAME version (the blob lists 3 segments,
+    /// the exe resource 4). Pure; pinned by the native-pairing guard.</summary>
+    public static bool RuntimeCompatible(SkseVersionInfo v, string installedRuntime)
+        => v.VersionIndependent || v.CompatibleVersions.Any(cv => VersionsEqual(cv, installedRuntime));
+
+    /// <summary>Numeric dotted-version equality with zero-padding ("1.6.1170" == "1.6.1170.0"). A non-numeric
+    /// segment ⇒ NOT equal (never guessed equal — a garbage compat entry must not accidentally PASS a lock, Q3).</summary>
+    public static bool VersionsEqual(string a, string b)
+    {
+        var sa = a.Split('.'); var sb = b.Split('.');
+        for (int i = 0; i < Math.Max(sa.Length, sb.Length); i++)
+        {
+            int va = 0, vb = 0;
+            if (i < sa.Length && !int.TryParse(sa[i].Trim(), out va)) return false;
+            if (i < sb.Length && !int.TryParse(sb[i].Trim(), out vb)) return false;
+            if (va != vb) return false;
+        }
+        return true;
+    }
+
     /// <summary>Unpack a <c>REL::Version</c> uint32 to "maj.min.patch[.build]" — the exact CommonLib packing
     /// (maj 8b &lt;&lt; 24 | min 8b &lt;&lt; 16 | patch 12b &lt;&lt; 4 | build 4b). Trailing .build is shown only when non-zero
     /// (most plugins declare only maj[.min.patch]).</summary>

--- a/src/housecarl-generator/AssetStatusProbe.cs
+++ b/src/housecarl-generator/AssetStatusProbe.cs
@@ -85,7 +85,7 @@ internal static class AssetStatusProbe
 
                 var res = ArchiveDiscovery.Discover(prof, mods, data, "", Path.Combine(a, "game"));
                 var arc = res.Archives;
-                var baseA = arc.Where(x => x.OwningPlugin == "Skyrim.ini [Archive]").ToList();
+                var baseA = arc.Where(x => x.OwningPlugin == ArchiveDiscovery.IniArchiveOwner).ToList();
                 var aArc = arc.Where(x => x.OwningPlugin == "PluginA.esp").ToList();
                 var bArc = arc.Where(x => x.OwningPlugin == "PluginB.esp").ToList();
 
@@ -141,7 +141,7 @@ internal static class AssetStatusProbe
                 var res = ArchiveDiscovery.Discover(prof, mods, data, "", Path.Combine(c, "game"));
                 Check(res.Warnings.Any(w => w.Contains("Skyrim.ini", StringComparison.OrdinalIgnoreCase) && w.Contains("base", StringComparison.OrdinalIgnoreCase)),
                       "a missing Skyrim.ini base list is a LOUD warning (Q3 — 'absent' isn't over-trusted)");
-                Check(res.Archives.All(x => x.OwningPlugin != "Skyrim.ini [Archive]") && res.Archives.Any(x => x.OwningPlugin == "PluginA.esp"),
+                Check(res.Archives.All(x => x.OwningPlugin != ArchiveDiscovery.IniArchiveOwner) && res.Archives.Any(x => x.OwningPlugin == "PluginA.esp"),
                       "no base archive is invented, but plugin co-name discovery still works");
             }
 

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -113,6 +113,10 @@ public static class CiAll
         // overflow/no-ref accounting) PLUS the service VERDICTS (OK/PLUGIN-MISSING/DANGLING/UNPARSEABLE + ESL FE-prefix
         // resolve) driven through LoadOrderService.Adjudicate over a synthetic full+light order. Self-contained.
         ("skse-config-audit-guard", SkseConfigAuditProbe.RunGuard),
+        // Native-function pairing audit guard: the pure pex native-class extractor (raw-bit1 off-by-one pin), the
+        // provenance anchor (official archives / chain presence), the §4c ladder, the runtime compare, and the wire
+        // renderer arms (dead-vs-verify adjudication, unpaired framing, baseline accounting, filter + did-you-mean).
+        ("native-pairing-guard", NativePairingProbe.RunGuard),
         ("compile-ergonomics-guard", CompileErgonomicsProbe.RunGuard),
         ("setup-update-lock-guard", SetupUpdateLockProbe.RunGuard),
         ("import-order-guard", ImportOrderProbe.RunGuard),

--- a/src/housecarl-generator/NativePairingProbe.cs
+++ b/src/housecarl-generator/NativePairingProbe.cs
@@ -1,0 +1,269 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Pex;
+using Mutagen.Bethesda.Plugins;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SELF-CONTAINED CI REGRESSION GUARD for the native-function pairing audit (plan
+/// dev/plans/SKSE_NATIVE_PAIRING_AUDIT_PLAN_2026-07-16.md, Wave 1.4). Three parts, no live order:
+///
+///   Part 1 — the PURE extractor (<see cref="NativePairing.ExtractNativeClasses"/>) over a synthetic PexFile:
+///   the native flag is RAW BIT1 (Mutagen's enum names sit one off — the documented trap this arm exists to pin),
+///   Global (bit0) alone is NOT native, both-bits counts, a native property accessor surfaces as Prop.Get, and an
+///   object with no natives yields NOTHING (the common case).
+///
+///   Part 2 — the classification + pairing primitives (service internals via InternalsVisibleTo):
+///   IsOfficialArchive (ini-base marker / BaseMaster owner / third-party owner), HasOfficialProvider (an official
+///   BSA anywhere in the chain marks ENGINE even under a winning loose override — the SKSE-overrides-Actor.pex
+///   fixture), the §4c ladder (same-mod / chain-mod / unpaired), and the runtime compare
+///   (<see cref="SksePluginReader.RuntimeCompatible"/> — zero-padded numeric equality, garbage never PASSES a lock).
+///
+///   Part 3 — the WIRE renderer (<c>NativePairingWire.Render</c>) over synthetic
+///   <see cref="NativePairingAuditData"/>: PAIRED-BUT-DEAD leads and adjudicates a locked mismatch when the runtime
+///   is known, the runtime-unknown degrade says 'verify', UNPAIRED is framed a verify flag (never 'broken'),
+///   the baseline accounting carries the no-loader sanity note, the all-clear branch, filter= full detail, and the
+///   did-you-mean pool spanning every Match axis (the tier-B lesson).
+///
+/// Run: dotnet run --project src/housecarl-generator -- native-pairing-guard
+/// </summary>
+public static class NativePairingProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  REGRESSION GUARD — native-function pairing audit  ################");
+        Console.WriteLine();
+
+        int fails = 0;
+        void Check(string label, bool ok) { Console.WriteLine($"   {(ok ? "PASS" : "FAIL")}  {label}"); if (!ok) fails++; }
+
+        // ════ Part 1 — the pure .pex native-class extractor ════
+        Console.WriteLine("── Part 1: ExtractNativeClasses over a synthetic PexFile ──");
+        {
+            var pex = new PexFile(GameCategory.Skyrim);
+            var obj = new PexObject { Name = "StorageUtil" };
+            var st = new PexObjectState();
+            st.Functions.Add(Fn("SetIntValue", flags: 0x3));   // Global|Native — both bits
+            st.Functions.Add(Fn("GetIntValue", flags: 0x2));   // Native only (bit1 — THE off-by-one pin)
+            st.Functions.Add(Fn("LocalHelper", flags: 0x1));   // Global only — NOT native
+            st.Functions.Add(Fn("PlainFunc", flags: 0x0));     // neither
+            obj.States.Add(st);
+            pex.Objects.Add(obj);
+
+            var plain = new PexObject { Name = "PlainQuestScript" };
+            var pst = new PexObjectState();
+            pst.Functions.Add(Fn("OnInit", flags: 0x0));
+            plain.States.Add(pst);
+            pex.Objects.Add(plain);
+
+            var decls = NativePairing.ExtractNativeClasses(pex);
+            Check("one native class extracted (the all-Papyrus object yields nothing)",
+                decls.Count == 1 && decls[0].ClassName == "StorageUtil");
+            Check("native = raw bit1: SetIntValue + GetIntValue in, Global-only + plain OUT",
+                decls.Count == 1 && decls[0].NativeFunctions.Count == 2
+                && decls[0].NativeFunctions.Contains("SetIntValue") && decls[0].NativeFunctions.Contains("GetIntValue"));
+        }
+        {
+            // A native-flagged property accessor is a native declaration too — surfaced as Prop.Get, never dropped.
+            var pex = new PexFile(GameCategory.Skyrim);
+            var obj = new PexObject { Name = "NativeProps" };
+            obj.Properties.Add(new PexObjectProperty { Name = "Version", ReadHandler = new PexObjectFunction { Flags = (FunctionFlags)0x2 } });
+            pex.Objects.Add(obj);
+            var decls = NativePairing.ExtractNativeClasses(pex);
+            Check("native property accessor → 'Version.Get' declared",
+                decls.Count == 1 && decls[0].NativeFunctions.SequenceEqual(new[] { "Version.Get" }));
+        }
+
+        // ════ Part 2 — classification + pairing primitives ════
+        Console.WriteLine();
+        Console.WriteLine("── Part 2: provenance anchor, ladder, runtime compare ──");
+        {
+            var baseMasters = Mutagen.Bethesda.Plugins.Implicits.Get(Mutagen.Bethesda.GameRelease.SkyrimSE).BaseMasters;
+            Check("ini-base archive (Skyrim - Misc.bsa) is OFFICIAL",
+                LoadOrderService.IsOfficialArchive(new ActiveArchive(@"D:\g\Data\Skyrim - Misc.bsa", ArchiveDiscovery.IniArchiveOwner, 0), baseMasters));
+            Check("Dawnguard.esm-owned archive is OFFICIAL (BaseMasters, by construction)",
+                LoadOrderService.IsOfficialArchive(new ActiveArchive(@"D:\g\Data\Dawnguard.bsa", "Dawnguard.esm", 5), baseMasters));
+            Check("a mod plugin's archive is NOT official",
+                !LoadOrderService.IsOfficialArchive(new ActiveArchive(@"D:\m\Campfire.bsa", "Campfire.esm", 40), baseMasters));
+
+            var official = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Skyrim - Misc.bsa" };
+            // THE fixture: SKSE's loose Actor.pex WINS over the vanilla archive copy — still ENGINE.
+            Check("loose override winning over an official BSA copy → still ENGINE (chain presence)",
+                LoadOrderService.HasOfficialProvider(new[]
+                {
+                    new SkseProvider("Skyrim Script Extender (SKSE64)", "loose"),
+                    new SkseProvider("Skyrim - Misc.bsa", "BSA"),
+                }, official));
+            Check("loose-only chain (StringUtil.pex) → NOT engine",
+                !LoadOrderService.HasOfficialProvider(new[] { new SkseProvider("Skyrim Script Extender (SKSE64)", "loose") }, official));
+            Check("a mod BSA in the chain is not mistaken for official",
+                !LoadOrderService.HasOfficialProvider(new[] { new SkseProvider("Campfire.bsa", "BSA") }, official));
+        }
+        {
+            var dll = new NativePairedDll(@"SKSE\Plugins\PapyrusUtil.dll", "PapyrusUtil.dll", "", "PapyrusUtil AE", null, null);
+            var modDlls = new Dictionary<string, List<NativePairedDll>>(StringComparer.OrdinalIgnoreCase)
+            { ["PapyrusUtil AE"] = new() { dll } };
+
+            var (r1, m1, d1) = LoadOrderService.Ladder(new[] { new SkseProvider("PapyrusUtil AE", "loose") }, modDlls);
+            Check("rung 1: winning provider ships the DLL → SameMod",
+                r1 == NativePairingRung.SameMod && m1 == "PapyrusUtil AE" && d1.Count == 1);
+
+            // The Campfire fixture: a bundler wins nothing here — PapyrusUtil wins, but flip it: Campfire wins the
+            // script, PapyrusUtil (with the DLL) sits beneath in the chain → ChainMod.
+            var (r2, m2, _) = LoadOrderService.Ladder(new[]
+            {
+                new SkseProvider("Campfire", "loose"),
+                new SkseProvider("PapyrusUtil AE", "loose"),
+            }, modDlls);
+            Check("rung 2: framework beneath the winner in the chain → ChainMod (the bundling case)",
+                r2 == NativePairingRung.ChainMod && m2 == "PapyrusUtil AE");
+
+            var (r3, m3, d3) = LoadOrderService.Ladder(new[] { new SkseProvider("Some Scripts-Only Mod", "loose") }, modDlls);
+            Check("rung 3: nobody in the chain ships a DLL → Unpaired",
+                r3 == NativePairingRung.Unpaired && m3 is null && d3.Count == 0);
+        }
+        {
+            Check("versions equal under zero-padding: 1.6.1170 == 1.6.1170.0",
+                SksePluginReader.VersionsEqual("1.6.1170", "1.6.1170.0"));
+            Check("versions differ: 1.6.640 != 1.6.1170.0",
+                !SksePluginReader.VersionsEqual("1.6.640", "1.6.1170.0"));
+            Check("garbage segment never PASSES a lock (Q3)",
+                !SksePluginReader.VersionsEqual("1.6.x", "1.6.0"));
+            var locked = Ver(independent: false, compat: new[] { "1.5.97", "1.6.640" });
+            Check("locked plugin + unlisted runtime → NOT compatible",
+                !SksePluginReader.RuntimeCompatible(locked, "1.6.1170.0"));
+            Check("locked plugin + listed runtime (padded) → compatible",
+                SksePluginReader.RuntimeCompatible(locked, "1.6.640.0"));
+            Check("version-independent plugin → compatible anywhere",
+                SksePluginReader.RuntimeCompatible(Ver(independent: true, compat: Array.Empty<string>()), "9.9.9"));
+        }
+
+        // ════ Part 3 — the wire renderer over synthetic data ════
+        Console.WriteLine();
+        Console.WriteLine("── Part 3: NativePairingWire.Render arms ──");
+
+        var lockedInfo = new SksePluginReader.SksePluginInfo("OldPlugin.dll", SksePluginReader.SksePluginKind.Modern, true,
+            Ver(independent: false, compat: new[] { "1.5.97" }), null);
+        var indepInfo = new SksePluginReader.SksePluginInfo("PapyrusUtil.dll", SksePluginReader.SksePluginKind.Modern, true,
+            Ver(independent: true, compat: Array.Empty<string>()), null);
+
+        NativeClassEntry Cls(string name, NativeProvenance prov, NativePairingRung? rung, string? pairedMod,
+            IReadOnlyList<NativePairedDll>? dlls = null, string? winner = "SomeMod") =>
+            new($@"Scripts\{name}.pex", name, 2, new[] { "FnA", "FnB" }, winner, "loose", 1,
+                new[] { new SkseProvider(winner ?? "(none)", "loose") }, prov, rung, pairedMod, dlls ?? Array.Empty<NativePairedDll>());
+
+        NativePairingAuditData Data(IReadOnlyList<NativeClassEntry> classes, string? runtime, bool loaderSeen = true,
+            IReadOnlyList<NativeUnreadablePex>? unreadable = null) =>
+            new(classes, 1000, unreadable ?? Array.Empty<NativeUnreadablePex>(), loaderSeen, runtime,
+                Array.Empty<string>(), false, Array.Empty<string>(), "TestProfile");
+
+        {
+            // Arm A: locked mismatch with the runtime KNOWN → PAIRED BUT DEAD leads, adjudicated.
+            var deadDll = new NativePairedDll(@"SKSE\Plugins\OldPlugin.dll", "OldPlugin.dll", "", "OldMod", lockedInfo, null);
+            var s = Render(Data(new[] { Cls("OldUtil", NativeProvenance.ThirdParty, NativePairingRung.SameMod, "OldMod", new[] { deadDll }) }, "1.6.1170.0"));
+            Check("A: locked-mismatch + known runtime → 'PAIRED BUT DEAD' + 'will NOT load' + both versions named",
+                s.Contains("PAIRED BUT DEAD") && s.Contains("will NOT load") && s.Contains("1.5.97") && s.Contains("1.6.1170.0"));
+        }
+        {
+            // Arm B: same data, runtime UNKNOWN → the honest degrade ('verify'), NOT a dead claim.
+            var deadDll = new NativePairedDll(@"SKSE\Plugins\OldPlugin.dll", "OldPlugin.dll", "", "OldMod", lockedInfo, null);
+            var s = Render(Data(new[] { Cls("OldUtil", NativeProvenance.ThirdParty, NativePairingRung.SameMod, "OldMod", new[] { deadDll }) }, runtime: null));
+            Check("B: runtime unknown → degrades to 'verify', never claims dead",
+                !s.Contains("PAIRED BUT DEAD") && s.Contains("verify") && s.Contains("could not be resolved"));
+        }
+        {
+            // Arm C: a static blocker (BSA-only) is dead regardless of runtime knowledge.
+            var bsaDll = new NativePairedDll(@"SKSE\Plugins\X.dll", "X.dll", "", "XMod", null,
+                "provided only inside a BSA — the SKSE loader scans loose DLLs only, so it will not load");
+            var s = Render(Data(new[] { Cls("XUtil", NativeProvenance.ThirdParty, NativePairingRung.SameMod, "XMod", new[] { bsaDll }) }, runtime: null));
+            Check("C: static blocker (BSA-only) → DEAD even with runtime unknown",
+                s.Contains("PAIRED BUT DEAD") && s.Contains("[DEAD]") && s.Contains("loose DLLs only"));
+        }
+        {
+            // Arm D: UNPAIRED is a verify flag, framed as such; healthy + baseline accounting present; no-loader note.
+            var okDll = new NativePairedDll(@"SKSE\Plugins\PapyrusUtil.dll", "PapyrusUtil.dll", "", "PapyrusUtil AE", indepInfo, null);
+            var s = Render(Data(new[]
+            {
+                Cls("Actor", NativeProvenance.Engine, null, null, winner: "Skyrim Script Extender (SKSE64)"),
+                Cls("StringUtil", NativeProvenance.SkseCore, null, null, winner: "Skyrim Script Extender (SKSE64)"),
+                Cls("StorageUtil", NativeProvenance.ThirdParty, NativePairingRung.SameMod, "PapyrusUtil AE", new[] { okDll }, winner: "PapyrusUtil AE"),
+                Cls("OrphanUtil", NativeProvenance.ThirdParty, NativePairingRung.Unpaired, null, winner: "Scripts Only Mod"),
+            }, "1.6.1170.0", loaderSeen: false));
+            Check("D: UNPAIRED framed as verify (explicitly NOT 'broken'), with the declaration-copy explanation",
+                s.Contains("UNPAIRED") && s.Contains("VERIFY flag") && s.Contains("not 'broken'") && s.Contains("declaration copy"));
+            Check("D: baseline accounting (1 engine + 1 SKSE-core) + paired-healthy group",
+                s.Contains("1 engine class(es)") && s.Contains("1 SKSE-core class(es)") && s.Contains("PapyrusUtil AE: StorageUtil"));
+            Check("D: no-loader sanity note fires when SKSE-core classes exist without a visible loader",
+                s.Contains("no skse64 loader is visible"));
+        }
+        {
+            // Arm E: the all-clear branch + unreadable pex is a named note.
+            var okDll = new NativePairedDll(@"SKSE\Plugins\PapyrusUtil.dll", "PapyrusUtil.dll", "", "PapyrusUtil AE", indepInfo, null);
+            var s = Render(Data(new[] { Cls("StorageUtil", NativeProvenance.ThirdParty, NativePairingRung.SameMod, "PapyrusUtil AE", new[] { okDll }) }, "1.6.1170.0",
+                unreadable: new[] { new NativeUnreadablePex(@"Scripts\Broken.pex", "BadMod", "Mutagen cannot read it (EndOfStreamException)") }));
+            Check("E: all third-party healthy → the ✓ all-clear headline",
+                s.Contains("✓ every third-party native class pairs"));
+            Check("E: unreadable .pex is a NAMED note, not counted clean",
+                s.Contains("Broken.pex") && s.Contains("NOT counted as native-free"));
+        }
+        {
+            // Arm F: filter= full detail + the did-you-mean pool spans class/mod/DLL axes.
+            var okDll = new NativePairedDll(@"SKSE\Plugins\PapyrusUtil.dll", "PapyrusUtil.dll", "", "PapyrusUtil AE", indepInfo, null);
+            var data = Data(new[] { Cls("StorageUtil", NativeProvenance.ThirdParty, NativePairingRung.SameMod, "PapyrusUtil AE", new[] { okDll }, winner: "PapyrusUtil AE") }, "1.6.1170.0");
+            var s = Render(data, "storageutil");
+            Check("F: filter= shows full detail (functions, rung, DLL verdict)",
+                s.Contains("FnA, FnB") && s.Contains("paired to its own provider") && s.Contains("[LOADS]"));
+            var miss = Render(data, "StorageUtl");   // typo'd CLASS name (edit distance 1) → suggestion from the pool
+            Check("F: typo'd filter → did-you-mean from the multi-axis pool",
+                miss.Contains("no native-declaring class matched") && miss.Contains("did you mean", StringComparison.OrdinalIgnoreCase)
+                && miss.Contains("StorageUtil", StringComparison.OrdinalIgnoreCase));
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"=== native-pairing-guard: {(fails == 0 ? "PASS" : "FAIL")} ({fails} failing) ===");
+        return fails == 0 ? 0 : 1;
+    }
+
+    /// <summary>The MANUAL real-data harness (the live gate, tier-B RunReal pattern): runs the whole pairing audit
+    /// against a live MO2 instance and prints the render + factual timing. NOT part of ci-all.</summary>
+    public static int RunReal(string[] args)
+    {
+        string? mo2 = ArgVal(args, "--mo2");
+        string? filter = ArgVal(args, "--filter");
+        int max = int.TryParse(ArgVal(args, "--max"), out var m) ? m : 80_000;
+        if (mo2 is null) { Console.WriteLine("native-pairing-real needs --mo2 <MO2 instance folder>"); return 2; }
+
+        var store = new UserConfigStore(Path.Combine(Path.GetTempPath(), "hc-native-pairing-" + Guid.NewGuid().ToString("N") + ".json"));
+        using var svc = LoadOrderService.WithInstance(mo2, 0, store);
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var data = svc.NativePairingAudit();
+        sw.Stop();
+
+        Console.WriteLine(NativePairingWire.Render(data, filter, max));
+        Console.WriteLine($"\n[timing] NativePairingAudit over {data.PexScanned} compiled scripts " +
+            $"({data.Classes.Count} native classes, {data.Unreadable.Count} unreadable, runtime {data.InstalledRuntime ?? "(unresolved)"}) " +
+            $"in {sw.ElapsedMilliseconds} ms");
+        return 0;
+    }
+
+    static string? ArgVal(string[] a, string key)
+    {
+        int i = Array.IndexOf(a, key);
+        return i >= 0 && i + 1 < a.Length ? a[i + 1] : null;
+    }
+
+    static PexObjectNamedFunction Fn(string name, uint flags) =>
+        new() { FunctionName = name, Function = new PexObjectFunction { Flags = (FunctionFlags)flags } };
+
+    static SksePluginReader.SkseVersionInfo Ver(bool independent, IReadOnlyList<string> compat) =>
+        new("Test Plugin", "tester", "", "1.0.0",
+            UsesAddressLibrary: independent, UsesSignatureScanning: false,
+            UsesUpdatedStructs: false, DeclaresNoStructs: false,
+            CompatibleVersions: compat, MinimumXseVersion: null);
+
+    // The REAL renderer, internal to housecarl-mcp — reachable via InternalsVisibleTo("housecarl-generator")
+    // (the PR #208 Part-3 mechanism).
+    static string Render(NativePairingAuditData d, string? filter = null) => NativePairingWire.Render(d, filter, 80_000);
+}

--- a/src/housecarl-generator/NativePairingProbe.cs
+++ b/src/housecarl-generator/NativePairingProbe.cs
@@ -125,6 +125,18 @@ public static class NativePairingProbe
                 r3 == NativePairingRung.Unpaired && m3 is null && d3.Count == 0);
         }
         {
+            // BSA→shipper translation (live-gate finding: moreHUD's scripts ride its BSA while the DLL is loose in
+            // the SAME mod — the archive filename must translate to the mod for pairing identity).
+            Check("archive under mods\\<mod>\\ → that mod",
+                LoadOrderService.ShipperOfArchivePath(@"E:\mo2\mods\moreHUD SE\AHZmoreHUD.bsa", @"E:\mo2\mods", @"E:\mo2\overwrite", @"D:\g\Data") == "moreHUD SE");
+            Check("archive in the overwrite layer → 'overwrite'",
+                LoadOrderService.ShipperOfArchivePath(@"E:\mo2\overwrite\X.bsa", @"E:\mo2\mods", @"E:\mo2\overwrite", @"D:\g\Data") == "overwrite");
+            Check("archive in game Data → 'Data'",
+                LoadOrderService.ShipperOfArchivePath(@"D:\g\Data\Skyrim - Misc.bsa", @"E:\mo2\mods", @"E:\mo2\overwrite", @"D:\g\Data") == "Data");
+            Check("archive nowhere under the roots → null (no translation)",
+                LoadOrderService.ShipperOfArchivePath(@"C:\elsewhere\X.bsa", @"E:\mo2\mods", @"E:\mo2\overwrite", @"D:\g\Data") is null);
+        }
+        {
             Check("versions equal under zero-padding: 1.6.1170 == 1.6.1170.0",
                 SksePluginReader.VersionsEqual("1.6.1170", "1.6.1170.0"));
             Check("versions differ: 1.6.640 != 1.6.1170.0",

--- a/src/housecarl-generator/NativePairingProbe.cs
+++ b/src/housecarl-generator/NativePairingProbe.cs
@@ -89,40 +89,64 @@ public static class NativePairingProbe
                 !LoadOrderService.IsOfficialArchive(new ActiveArchive(@"D:\m\Campfire.bsa", "Campfire.esm", 40), baseMasters));
 
             var official = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Skyrim - Misc.bsa" };
-            // THE fixture: SKSE's loose Actor.pex WINS over the vanilla archive copy — still ENGINE.
+            static PlacementSource Loose(string mod) => new(mod, AssetKind.Loose, @"D:\x", null, "");
+            static PlacementSource Bsa(string archive) => new(archive, AssetKind.Bsa, null, @"D:\x.bsa", "");
+            // THE fixture: SKSE's loose Actor.pex WINS over the vanilla archive copy — still ENGINE. Keys on the
+            // AssetKind ENUM, never the render label (review finding).
             Check("loose override winning over an official BSA copy → still ENGINE (chain presence)",
-                LoadOrderService.HasOfficialProvider(new[]
-                {
-                    new SkseProvider("Skyrim Script Extender (SKSE64)", "loose"),
-                    new SkseProvider("Skyrim - Misc.bsa", "BSA"),
-                }, official));
+                LoadOrderService.HasOfficialSource(new[] { Loose("Skyrim Script Extender (SKSE64)"), Bsa("Skyrim - Misc.bsa") }, official));
             Check("loose-only chain (StringUtil.pex) → NOT engine",
-                !LoadOrderService.HasOfficialProvider(new[] { new SkseProvider("Skyrim Script Extender (SKSE64)", "loose") }, official));
+                !LoadOrderService.HasOfficialSource(new[] { Loose("Skyrim Script Extender (SKSE64)") }, official));
             Check("a mod BSA in the chain is not mistaken for official",
-                !LoadOrderService.HasOfficialProvider(new[] { new SkseProvider("Campfire.bsa", "BSA") }, official));
+                !LoadOrderService.HasOfficialSource(new[] { Bsa("Campfire.bsa") }, official));
+
+            var shipper = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["AHZmoreHUD.bsa"] = "moreHUD SE" };
+            Check("BSA source translates to its shipping mod (pairing identity)",
+                LoadOrderService.PairingIdentity(Bsa("AHZmoreHUD.bsa"), shipper) == "moreHUD SE");
+            Check("loose source's identity is its provider name",
+                LoadOrderService.PairingIdentity(Loose("PapyrusUtil AE"), shipper) == "PapyrusUtil AE");
+            Check("an untranslatable archive keeps its own name",
+                LoadOrderService.PairingIdentity(Bsa("Unknown.bsa"), shipper) == "Unknown.bsa");
         }
         {
-            var dll = new NativePairedDll(@"SKSE\Plugins\PapyrusUtil.dll", "PapyrusUtil.dll", "", "PapyrusUtil AE", null, null);
+            var okDll = new NativePairedDll(@"SKSE\Plugins\PapyrusUtil.dll", "PapyrusUtil.dll", "", "PapyrusUtil AE", null, null);
+            var deadDll = new NativePairedDll(@"SKSE\Plugins\Helper\junk.dll", "junk.dll", "Helper", "Bundler",
+                null, "in subfolder 'Helper' — not on SKSE's loader path");
             var modDlls = new Dictionary<string, List<NativePairedDll>>(StringComparer.OrdinalIgnoreCase)
-            { ["PapyrusUtil AE"] = new() { dll } };
+            { ["PapyrusUtil AE"] = new() { okDll }, ["Bundler"] = new() { deadDll } };
 
-            var (r1, m1, d1) = LoadOrderService.Ladder(new[] { new SkseProvider("PapyrusUtil AE", "loose") }, modDlls);
-            Check("rung 1: winning provider ships the DLL → SameMod",
+            var (r1, m1, d1) = LoadOrderService.Ladder(new[] { "PapyrusUtil AE" }, modDlls);
+            Check("rung 1: winning identity ships the DLL → SameMod",
                 r1 == NativePairingRung.SameMod && m1 == "PapyrusUtil AE" && d1.Count == 1);
 
-            // The Campfire fixture: a bundler wins nothing here — PapyrusUtil wins, but flip it: Campfire wins the
-            // script, PapyrusUtil (with the DLL) sits beneath in the chain → ChainMod.
-            var (r2, m2, _) = LoadOrderService.Ladder(new[]
-            {
-                new SkseProvider("Campfire", "loose"),
-                new SkseProvider("PapyrusUtil AE", "loose"),
-            }, modDlls);
+            var (r2, m2, _) = LoadOrderService.Ladder(new[] { "Campfire", "PapyrusUtil AE" }, modDlls);
             Check("rung 2: framework beneath the winner in the chain → ChainMod (the bundling case)",
                 r2 == NativePairingRung.ChainMod && m2 == "PapyrusUtil AE");
 
-            var (r3, m3, d3) = LoadOrderService.Ladder(new[] { new SkseProvider("Some Scripts-Only Mod", "loose") }, modDlls);
+            var (r3, m3, d3) = LoadOrderService.Ladder(new[] { "Some Scripts-Only Mod" }, modDlls);
             Check("rung 3: nobody in the chain ships a DLL → Unpaired",
                 r3 == NativePairingRung.Unpaired && m3 is null && d3.Count == 0);
+
+            // Review finding: a bundler whose only candidate is statically DEAD must not mask the loadable framework
+            // beneath it (the false PAIRED-BUT-DEAD class); with no loadable candidate anywhere, the shallowest pairs.
+            var (r4, m4, _) = LoadOrderService.Ladder(new[] { "Bundler", "PapyrusUtil AE" }, modDlls);
+            Check("dead-candidate bundler does NOT mask the loadable framework beneath → ChainMod to the framework",
+                r4 == NativePairingRung.ChainMod && m4 == "PapyrusUtil AE");
+            var (r5, m5, _) = LoadOrderService.Ladder(new[] { "Bundler", "Scriptless" }, modDlls);
+            Check("no loadable candidate anywhere → the shallowest with ANY candidate pairs (its deadness is the finding)",
+                r5 == NativePairingRung.SameMod && m5 == "Bundler");
+
+            // The Classify decision order: engine wins outright; pairing beats the SKSE-CORE rescue; the rescue takes
+            // an UNPAIRED class whose WINNING identity ships an engine-class copy; a non-pool winner stays third-party.
+            var pool = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Skyrim Script Extender (SKSE64)" };
+            Check("Classify: engine short-circuits everything",
+                LoadOrderService.Classify(true, new[] { "PapyrusUtil AE" }, modDlls, pool).Provenance == NativeProvenance.Engine);
+            Check("Classify: pairing evidence beats the rescue",
+                LoadOrderService.Classify(false, new[] { "PapyrusUtil AE" }, modDlls, pool) is { Provenance: NativeProvenance.ThirdParty, Rung: NativePairingRung.SameMod });
+            Check("Classify: unpaired + winner in the engine-provider pool → SKSE CORE (the StringUtil rescue)",
+                LoadOrderService.Classify(false, new[] { "Skyrim Script Extender (SKSE64)" }, modDlls, pool).Provenance == NativeProvenance.SkseCore);
+            Check("Classify: unpaired + winner NOT in the pool → stays UNPAIRED third-party",
+                LoadOrderService.Classify(false, new[] { "Scripts Only Mod" }, modDlls, pool) is { Provenance: NativeProvenance.ThirdParty, Rung: NativePairingRung.Unpaired });
         }
         {
             // BSA→shipper translation (live-gate finding: moreHUD's scripts ride its BSA while the DLL is loose in
@@ -150,6 +174,8 @@ public static class NativePairingProbe
                 SksePluginReader.RuntimeCompatible(locked, "1.6.640.0"));
             Check("version-independent plugin → compatible anywhere",
                 SksePluginReader.RuntimeCompatible(Ver(independent: true, compat: Array.Empty<string>()), "9.9.9"));
+            Check("AE runtime boundary: 1.6.1170 IS AE, 1.5.97 is NOT, garbage is NOT (unknown never claims)",
+                SksePluginReader.IsAeRuntime("1.6.1170.0") && !SksePluginReader.IsAeRuntime("1.5.97.0") && !SksePluginReader.IsAeRuntime("bogus"));
         }
 
         // ════ Part 3 — the wire renderer over synthetic data ════
@@ -163,10 +189,10 @@ public static class NativePairingProbe
 
         NativeClassEntry Cls(string name, NativeProvenance prov, NativePairingRung? rung, string? pairedMod,
             IReadOnlyList<NativePairedDll>? dlls = null, string? winner = "SomeMod") =>
-            new($@"Scripts\{name}.pex", name, 2, new[] { "FnA", "FnB" }, winner, "loose", 1,
+            new($@"Scripts\{name}.pex", name, new[] { "FnA", "FnB" },
                 new[] { new SkseProvider(winner ?? "(none)", "loose") }, prov, rung, pairedMod, dlls ?? Array.Empty<NativePairedDll>());
 
-        NativePairingAuditData Data(IReadOnlyList<NativeClassEntry> classes, string? runtime, bool loaderSeen = true,
+        NativePairingAuditData Data(IReadOnlyList<NativeClassEntry> classes, string? runtime, bool? loaderSeen = true,
             IReadOnlyList<NativeUnreadablePex>? unreadable = null) =>
             new(classes, 1000, unreadable ?? Array.Empty<NativeUnreadablePex>(), loaderSeen, runtime,
                 Array.Empty<string>(), false, Array.Empty<string>(), "TestProfile");
@@ -211,6 +237,22 @@ public static class NativePairingProbe
                 s.Contains("no skse64 loader is visible"));
         }
         {
+            // Arm C2 (review finding): a LegacyQuery pairing on an AE runtime is DEAD (the AE loader loads only
+            // version-data plugins); on an SE runtime it loads; with the runtime unknown it is a VERIFY, never a claim.
+            var legacyInfo = new SksePluginReader.SksePluginInfo("OldSe.dll", SksePluginReader.SksePluginKind.LegacyQuery, true, null, "legacy");
+            var legacyDll = new NativePairedDll(@"SKSE\Plugins\OldSe.dll", "OldSe.dll", "", "OldSeMod", legacyInfo, null);
+            var cls = Cls("OldSeUtil", NativeProvenance.ThirdParty, NativePairingRung.SameMod, "OldSeMod", new[] { legacyDll });
+            var ae = Render(Data(new[] { cls }, "1.6.1170.0"));
+            Check("C2: LegacyQuery + AE runtime → PAIRED BUT DEAD (query-only plugins don't load on AE)",
+                ae.Contains("PAIRED BUT DEAD") && ae.Contains("query-only"));
+            var se = Render(Data(new[] { cls }, "1.5.97.0"));
+            Check("C2: LegacyQuery + SE runtime → healthy (loads on SE)",
+                se.Contains("✓") && se.Contains("OldSeMod: OldSeUtil"));
+            var unk = Render(Data(new[] { cls }, runtime: null));
+            Check("C2: LegacyQuery + unknown runtime → verify, never a dead claim",
+                !unk.Contains("PAIRED BUT DEAD") && unk.Contains("verify"));
+        }
+        {
             // Arm E: the all-clear branch + unreadable pex is a named note.
             var okDll = new NativePairedDll(@"SKSE\Plugins\PapyrusUtil.dll", "PapyrusUtil.dll", "", "PapyrusUtil AE", indepInfo, null);
             var s = Render(Data(new[] { Cls("StorageUtil", NativeProvenance.ThirdParty, NativePairingRung.SameMod, "PapyrusUtil AE", new[] { okDll }) }, "1.6.1170.0",
@@ -219,6 +261,19 @@ public static class NativePairingProbe
                 s.Contains("✓ every third-party native class pairs"));
             Check("E: unreadable .pex is a NAMED note, not counted clean",
                 s.Contains("Broken.pex") && s.Contains("NOT counted as native-free"));
+            Check("E: the all-clear headline is QUALIFIED by the unexamined unreadables (review finding)",
+                s.Contains("1 unreadable .pex NOT examined"));
+        }
+        {
+            // Arm G (review finding): the loader note is tri-state — false = the definite checked-and-absent note,
+            // null = "could not check", never the definite claim off a failed check (Q3).
+            var core = Cls("StringUtil", NativeProvenance.SkseCore, null, null, winner: "Skyrim Script Extender (SKSE64)");
+            var absent = Render(Data(new[] { core }, "1.6.1170.0", loaderSeen: false));
+            Check("G: loaderSeen=false → the definite no-loader note",
+                absent.Contains("no skse64 loader is visible"));
+            var unchecked_ = Render(Data(new[] { core }, "1.6.1170.0", loaderSeen: null));
+            Check("G: loaderSeen=null → 'could not be checked', never the definite absence claim",
+                !unchecked_.Contains("no skse64 loader is visible") && unchecked_.Contains("could not be checked"));
         }
         {
             // Arm F: filter= full detail + the did-you-mean pool spans class/mod/DLL axes.

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -247,6 +247,11 @@ if (args.Length > 0 && args[0] == "skse-inventory-real") return SkseInventoryPro
 if (args.Length > 0 && args[0] == "skse-config-audit-guard") return SkseConfigAuditProbe.RunGuard(args[1..]);
 if (args.Length > 0 && args[0] == "skse-config-audit-real") return SkseConfigAuditProbe.RunReal(args[1..]);
 
+// Native-function pairing audit: the CI guard (pure extractor + classification + ladder + renderer arms) and the
+// manual real-data harness (the live gate: the whole audit against a live MO2 instance, render + timing).
+if (args.Length > 0 && args[0] == "native-pairing-guard") return NativePairingProbe.RunGuard(args[1..]);
+if (args.Length > 0 && args[0] == "native-pairing-real") return NativePairingProbe.RunReal(args[1..]);
+
 var outputDir = Path.GetFullPath(args.Length > 0 ? args[0] : "generated");
 // The slim reference tree ships INSIDE the skill (tracked); corpus.json + summary stay in generated/.
 // Default assumes the generator is run from the repo root (as `dotnet run --project src/housecarl-generator`).

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -307,7 +307,7 @@ public sealed class LoadOrderService : IDisposable
             else
                 configs.Add(new SkseFileEntry(rel, Path.GetFileName(rel), group, providers, null, null));
         }
-        return new SkseInventoryData(dlls, configs, otherFiles, view.BsaFailures, view.ReadIncomplete, warnings, profileName);
+        return new SkseInventoryData(dlls, configs, otherFiles, InstalledGameRuntime(), view.BsaFailures, view.ReadIncomplete, warnings, profileName);
     }
 
     /// <summary>The immediate subfolder under SKSE\Plugins a file sits in ("" = directly at top level) — the DERIVED,
@@ -601,7 +601,7 @@ public sealed class LoadOrderService : IDisposable
 
         return new NativePairingAuditData(classes, pexPaths.Count,
             unreadable.OrderBy(u => u.RelPath, StringComparer.OrdinalIgnoreCase).ToList(),
-            loaderSeen, InstalledRuntime: null,
+            loaderSeen, InstalledGameRuntime(),
             view.BsaFailures, view.ReadIncomplete, warnings, profileName);
     }
 
@@ -1580,6 +1580,49 @@ public sealed class LoadOrderService : IDisposable
     /// when the instance is unusable (EnsurePathsDerived throws naming the missing piece — the rider's own config gate
     /// reports that; here it's just "no hint"), or when DataDir hasn't been derived yet. Takes <see cref="_gate"/> like the
     /// other derived-root reads; works in explicit mode too (DataDir is set directly, EnsurePathsDerived no-ops).</summary>
+    /// <summary>The INSTALLED game runtime version — the dotted file version of the game executable the load order
+    /// actually runs (e.g. "1.6.1170.0") — or null when it can't be resolved. This is what turns a version-LOCKED
+    /// SKSE plugin's compat list from "verify against your game version" into PASS/FAIL (native-pairing audit §4d +
+    /// skse_inventory's locked diagnostic). Preference is the OPPOSITE of <see cref="CompilerGameDirHints"/>: the
+    /// load-order's OWN game dir comes FIRST — an MO2 "Stock Game" setup launches the stock copy's exe, so ITS
+    /// version is the truth — with the located real install (<see cref="GameDirOrNull"/>'s locator twin) only as a
+    /// fallback. BEST-EFFORT + NULL-SAFE end to end (the CompilerGameDirHints contract): a miss degrades the finding
+    /// wording, never fails the audit.</summary>
+    public string? InstalledGameRuntime()
+    {
+        foreach (var dir in GameRuntimeDirCandidates())
+        {
+            try
+            {
+                var exe = Path.Combine(dir, "SkyrimSE.exe");
+                if (!File.Exists(exe)) continue;
+                var fv = System.Diagnostics.FileVersionInfo.GetVersionInfo(exe);
+                // FileVersion can carry vendor noise; the numeric parts are the truth. Prefer them when present.
+                if (fv.FileMajorPart > 0 || fv.FileMinorPart > 0 || fv.FileBuildPart > 0 || fv.FilePrivatePart > 0)
+                    return $"{fv.FileMajorPart}.{fv.FileMinorPart}.{fv.FileBuildPart}.{fv.FilePrivatePart}";
+                if (!string.IsNullOrWhiteSpace(fv.FileVersion)) return fv.FileVersion!.Trim();
+            }
+            catch { /* unreadable exe → try the next candidate (best-effort) */ }
+        }
+        return null;
+    }
+
+    /// <summary>The game-dir candidates for the runtime-version read, LOAD-ORDER dir first (see
+    /// <see cref="InstalledGameRuntime"/> for why the preference inverts CompilerGameDirHints).</summary>
+    IEnumerable<string> GameRuntimeDirCandidates()
+    {
+        if (GameDirOrNull() is { Length: > 0 } own) yield return own;
+        string? located = null;
+        try
+        {
+            if (new Mutagen.Bethesda.Installs.GameLocator().TryGetGameDirectory(
+                    Mutagen.Bethesda.GameRelease.SkyrimSE, out var dir) && !string.IsNullOrWhiteSpace(dir.Path))
+                located = NormalizeGameDir(dir.Path);
+        }
+        catch { /* locator hiccup → just the load-order candidate */ }
+        if (located is not null) yield return located;
+    }
+
     public string? GameDirOrNull()
     {
         lock (_gate)
@@ -5152,6 +5195,7 @@ public sealed record SkseInventoryData(
     IReadOnlyList<SkseFileEntry> Dlls,
     IReadOnlyList<SkseFileEntry> Configs,
     int OtherFileCount,
+    string? InstalledRuntime,
     IReadOnlyList<string> BsaFailures,
     bool ReadIncomplete,
     IReadOnlyList<string> Warnings,

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -721,7 +721,12 @@ public sealed class LoadOrderService : IDisposable
     /// LoadBlocker does not stop the descent when a deeper identity has a loadable candidate (review finding: a
     /// bundler shipping one dead helper DLL must not mask the real framework beneath it into a false PAIRED-BUT-DEAD);
     /// if no identity has a loadable candidate, the shallowest with ANY candidate pairs (its deadness is then the
-    /// finding). Structural (file co-location + VFS chains), never semantic — which DLL implements which class is
+    /// finding). Known residual (PR #210 review #2): "loadable" here means no STATIC blocker — version-locked-vs-
+    /// runtime deadness is adjudicated later by the renderer (deadness has one owner, and the ladder deliberately has
+    /// no runtime), so a chain-top mod shipping a locked-MISMATCHED DLL still pairs over a loadable framework beneath
+    /// it and renders a false PAIRED-BUT-DEAD. Contrived (two chain members implementing the same class, the top one
+    /// version-mismatched) and fails toward a false alarm, never a missed problem — accepted, not solved.
+    /// Structural (file co-location + VFS chains), never semantic — which DLL implements which class is
     /// tier-E territory. internal for the guard.</summary>
     internal static (NativePairingRung Rung, string? PairedMod, IReadOnlyList<NativePairedDll> Dlls) Ladder(
         IReadOnlyList<string> identities, IReadOnlyDictionary<string, List<NativePairedDll>> modDlls)
@@ -1627,6 +1632,7 @@ public sealed class LoadOrderService : IDisposable
                         || !PathEq(p.OverwriteDir, _overwriteDir);
         if (!switched) return false;                             // ini touched but nothing we resolve from changed
         _profileDir = p.ProfileDir; _modsDir = p.ModsDir; _dataDir = p.DataDir; _profileName = p.ProfileName; _overwriteDir = p.OverwriteDir;
+        System.Threading.Interlocked.Increment(ref _gameRootsGen);   // the game roots moved → the runtime memo re-probes (PR #210 review #1)
         InvalidateClassParents();                                // the mods tree may have moved — drop the cached hierarchy with it
         ReResolve();                                             // a new profile ⇒ the order differs ⇒ ReResolve deep-re-indexes
         return true;
@@ -1731,8 +1737,15 @@ public sealed class LoadOrderService : IDisposable
     /// (which usually has none). Keying sources off the data dir would re-break exactly the Stock-Game case this fixes.</para></summary>
     // InstalledGameRuntime's memo: the resolved exe re-validated by a cheap mtime stat per call; a probed MISS is
     // session-stable (no re-paying the GameLocator registry/Steam walk per tool call for a permanently-null answer).
+    // _gameRootsGen is the memo's INVALIDATION signal (PR #210 review finding #1): every site that re-points the game
+    // roots (SetInstance, RederiveIfIniChanged's switch) bumps it, and a memo cached at an older generation re-probes —
+    // otherwise an instance switch could keep adjudicating version-LOCKED plugins against the PREVIOUS install's exe
+    // (a silently wrong PASS/FAIL), or stay stuck at a prior instance's null forever. A lock-free Interlocked counter,
+    // NOT a locked reset: the bump sites hold _gate, and taking _runtimeGate under _gate would invert the
+    // _runtimeGate → _gate order InstalledGameRuntime establishes (deadlock), so the roots side never takes _runtimeGate.
     readonly object _runtimeGate = new();
-    bool _runtimeProbed;
+    int _gameRootsGen;
+    int _runtimeGen = -1;   // generation the memo was cached at; -1 = never probed
     string? _runtimeExe, _runtimeVersion;
     DateTime _runtimeExeMtime;
 
@@ -1750,9 +1763,10 @@ public sealed class LoadOrderService : IDisposable
     {
         lock (_runtimeGate)
         {
-            if (_runtimeProbed)
+            int gen = System.Threading.Volatile.Read(ref _gameRootsGen);
+            if (_runtimeGen == gen)                     // cached at the CURRENT roots generation (else: re-probe — the instance moved)
             {
-                if (_runtimeExe is null) return null;   // session-stable miss
+                if (_runtimeExe is null) return null;   // generation-stable miss
                 try
                 {
                     if (File.Exists(_runtimeExe) && File.GetLastWriteTimeUtc(_runtimeExe) == _runtimeExeMtime)
@@ -1760,7 +1774,7 @@ public sealed class LoadOrderService : IDisposable
                 }
                 catch { return _runtimeVersion; }       // stat hiccup → the cached answer beats a re-probe mid-hiccup
             }
-            _runtimeProbed = true; _runtimeExe = null; _runtimeVersion = null;
+            _runtimeGen = gen; _runtimeExe = null; _runtimeVersion = null;
             foreach (var dir in CompilerGameDirHints())
             {
                 try
@@ -1833,6 +1847,7 @@ public sealed class LoadOrderService : IDisposable
             _profileMtimes = new DateTime[ProfileFileNames.Length];   // unset — the next build records fresh baselines against the new profile
             _orderWarnings = Array.Empty<string>();
             InvalidateClassParents();                            // every sibling cache drops on a switch — the hierarchy too (PR #47 review)
+            System.Threading.Interlocked.Increment(ref _gameRootsGen);   // new instance = possibly a different game install — the runtime memo must re-probe, never adjudicate B's locked plugins against A's exe (PR #210 review #1)
         }
         var (persisted, persistError, persistNote) = PersistInstanceDir(paths.InstanceDir);
         return (paths, persisted, persistError, persistNote);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -56,6 +56,7 @@ public sealed class LoadOrderService : IDisposable
     // project_facegen_diagnostics_resolver.
     AssetResolver? _assetResolver;
     IReadOnlyList<string> _assetWarnings = Array.Empty<string>();   // discovery warnings from the asset build (e.g. a Skyrim.ini we couldn't find → base BSAs unscanned)
+    IReadOnlyList<ActiveArchive> _activeArchives = Array.Empty<ActiveArchive>();   // the discovered active-BSA list behind the CURRENT asset build (archive → owning plugin — the native-pairing audit's provenance anchor); swapped with _assetResolver
     // Freshness baselines are the files' LAST-SEEN MTIMES compared by VALUE (!=), the same model the resolver itself
     // uses — NOT wall-clock stamps compared by ORDER (2026-06-12 hunt F8: `mtime > builtUtc` was blind to an mtime
     // REGRESSION, so MO2's "Restore Backup" — which restores a profile file with an OLDER mtime — stayed invisible
@@ -211,6 +212,7 @@ public sealed class LoadOrderService : IDisposable
         var gamePath = _dataDir.Length > 0 ? Path.GetDirectoryName(_dataDir.TrimEnd('\\', '/')) ?? "" : "";
         var discovery = ArchiveDiscovery.Discover(_profileDir, _modsDir, _dataDir, _overwriteDir, gamePath);
         _assetWarnings = discovery.Warnings;
+        _activeArchives = discovery.Archives;   // kept alongside the resolver: archive filename → owning plugin (native-pairing provenance)
         return AssetResolver.Build(_overwriteDir, _modsDir, _dataDir, comp.EnabledMods, discovery.Archives);
     }
 
@@ -429,6 +431,206 @@ public sealed class LoadOrderService : IDisposable
     /// cap)", never the self-contradictory "16 MB (> 16 MB cap)" an integer-MB divide produced.</summary>
     static string OverCapNote(long len) =>
         $"config is {len / (1024.0 * 1024):0.0} MB (> {SkseConfigSizeCap / (1024 * 1024)} MB cap) — not scanned";
+
+    // ---- Native-function pairing audit (housecarl_native_pairing_audit; plan
+    //      dev/plans/SKSE_NATIVE_PAIRING_AUDIT_PLAN_2026-07-16.md): cross-check the native Papyrus functions the
+    //      order's SCRIPTS declare against the DLLs that must implement them — the seam none of validate_scripts
+    //      (property binding), skse_inventory (DLL layer), or skse_config_audit (config layer) sees across. ----
+
+    /// <summary>Audit the declaration↔implementation pairing of every native Papyrus class in the active order. One
+    /// pass over the winning <c>.pex</c> files (loose + BSA, the ScriptPropertyCheck resolution), extracting native-
+    /// flagged declarations (<see cref="HousecarlCore.NativePairing"/>); one pass over SKSE\Plugins for the DLL
+    /// candidates each mod ships; then per third-party class the evidence ladder — same-mod DLL, conflict-chain DLL,
+    /// or UNPAIRED (a verify flag, never "broken": registration is runtime behavior, the tier-E ceiling).
+    ///
+    /// The baseline carve-out (§4b — the whole ballgame): a class whose provider CHAIN includes an OFFICIAL archive
+    /// (Skyrim.ini base block or a BaseMaster-owned BSA) is ENGINE — implemented by the executable — even when a mod's
+    /// loose copy WINS it (SKSE overrides Actor/Game/… with native additions; the official-archive presence still marks
+    /// the class baseline, fixture-verified on ARR 2.0). A rung-3 class whose winning provider ALSO provides an
+    /// ENGINE class is SKSE CORE — the skse64 scripts payload structurally co-ships ~100+ vanilla overrides with its
+    /// new classes (StringUtil/UI/…), and its implementation is the game-root loader, not anything under SKSE\Plugins.
+    /// Residual edges, documented not smuggled: an INI-injected third-party BSA reads official (over-baseline), a
+    /// paid-CC archive isn't BaseMaster-owned (its engine-native classes read third-party → a verify flag), and a mod
+    /// co-shipping a vanilla-script override with a declaration copy of an absent framework gets its copy rescued into
+    /// SKSE CORE (visible in the accounting, unflagged) — all three watched at the live gate.
+    ///
+    /// ONE gate hold captures the asset view + the archive list + warnings (the SkseInventory discipline); the
+    /// enumerate + parse + classify run OUTSIDE the gate over the pinned, handle-free view. The per-file Pex parses are
+    /// parallelized (thousands of files; the view's caches are concurrency-safe by design) with deterministic output
+    /// ordering. An unreadable .pex is a NAMED entry, never a silent skip (Q3).</summary>
+    public NativePairingAuditData NativePairingAudit()
+    {
+        AssetResolver.AssetView view;
+        IReadOnlyList<ActiveArchive> archives;
+        IReadOnlyList<string> warnings;
+        string profileName, dataDir;
+        lock (_gate)
+        {
+            view = Assets.Capture();
+            archives = _activeArchives;   // the SAME build as the view (both swapped under _gate)
+            warnings = _assetWarnings;
+            profileName = _profileName;
+            dataDir = _dataDir;
+        }
+
+        // ---- the official-archive set: the ENGINE anchor. Filenames, because a BSA provider's name IS the archive filename. ----
+        var officialArchives = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var baseMasters = Mutagen.Bethesda.Plugins.Implicits.Get(Mutagen.Bethesda.GameRelease.SkyrimSE).BaseMasters;
+        foreach (var a in archives)
+            if (IsOfficialArchive(a, baseMasters))
+                officialArchives.Add(Path.GetFileName(a.Path));
+
+        // ---- DLL candidates: one SKSE\Plugins pass. A mod "ships" a DLL when it appears ANYWHERE in that file's
+        //      chain (the bundling case pairs through the chain); the health verdict describes the WINNING copy. A
+        //      loose winner that PE-reads as NotSkse is a bundled dependency, not an implementation candidate. ----
+        const string skseRootPre = "SKSE\\Plugins\\";
+        var modDlls = new Dictionary<string, List<NativePairedDll>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var rel in view.EnumerateUnder("SKSE\\Plugins").OrderBy(p => p, StringComparer.OrdinalIgnoreCase))
+        {
+            if (!Path.GetExtension(rel).Equals(".dll", StringComparison.OrdinalIgnoreCase)) continue;
+            string group = SkseGroupOf(rel, skseRootPre);
+            var place = view.ResolveForPlacement(rel);
+            var winner = place.Sources.Count > 0 ? place.Sources[0] : null;
+
+            SksePluginReader.SksePluginInfo? info = null;
+            string? blocker = null;
+            if (winner is null) blocker = "no active mod provides it";
+            else if (winner.Kind != AssetKind.Loose)
+                blocker = "provided only inside a BSA — the SKSE loader scans loose DLLs only, so it will not load";
+            else
+            {
+                info = SksePluginReader.Read(winner.LooseFilePath!);
+                if (info.Kind == SksePluginReader.SksePluginKind.NotSkse) continue;   // bundled dependency — not a candidate
+                if (info.Kind == SksePluginReader.SksePluginKind.Unreadable) blocker = $"not a readable SKSE plugin ({info.Note})";
+                else if (info.Is64Bit == false) blocker = "a 32-bit image — cannot load in Skyrim SE/AE";
+            }
+            if (blocker is null && group.Length > 0)
+                blocker = $"in subfolder '{group}' — not on SKSE's loader path (scans SKSE\\Plugins\\*.dll top-level only)";
+
+            var dll = new NativePairedDll(rel, Path.GetFileName(rel), group, winner?.ProviderName, info, blocker);
+            foreach (var src in place.Sources)
+            {
+                if (!modDlls.TryGetValue(src.ProviderName, out var list)) modDlls[src.ProviderName] = list = new();
+                if (!list.Any(d => d.RelPath.Equals(rel, StringComparison.OrdinalIgnoreCase))) list.Add(dll);
+            }
+        }
+
+        // ---- the .pex sweep: winning copy of every compiled script, native classes extracted. Parallel parse
+        //      (the corpus is thousands of files; the captured view's caches are concurrency-safe), deterministic
+        //      output order restored by the final sorts. Per-file fault isolation: an unreadable .pex is a NAMED
+        //      entry (Q3), never a silent skip. ----
+        var pexPaths = view.EnumerateUnder("Scripts")
+            .Where(p => Path.GetExtension(p).Equals(".pex", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(p => p, StringComparer.OrdinalIgnoreCase).ToList();
+
+        var scanned = new System.Collections.Concurrent.ConcurrentBag<(string Rel, IReadOnlyList<SkseProvider> Providers, string? WinningProvider, string ProviderKind, IReadOnlyList<HousecarlCore.NativeClassDecl> Decls)>();
+        var unreadable = new System.Collections.Concurrent.ConcurrentBag<NativeUnreadablePex>();
+        System.Threading.Tasks.Parallel.ForEach(pexPaths, rel =>
+        {
+            var place = view.ResolveForPlacement(rel);
+            var providers = place.Sources.Select(s => new SkseProvider(s.ProviderName, KindLabel(s.Kind))).ToList();
+            var winner = place.Sources.Count > 0 ? place.Sources[0] : null;
+            if (winner is null) { unreadable.Add(new NativeUnreadablePex(rel, null, "enumerated but no active source provides it")); return; }
+            try
+            {
+                Mutagen.Bethesda.Pex.PexFile pex;
+                if (winner.LooseFilePath is { } lp)
+                    pex = Mutagen.Bethesda.Pex.PexFile.CreateFromFile(lp, Mutagen.Bethesda.GameCategory.Skyrim);
+                else
+                {
+                    var bytes = AssetResolver.TryReadArchiveEntry(winner.ArchivePath!, winner.EntryPath);
+                    if (bytes is null) { unreadable.Add(new NativeUnreadablePex(rel, winner.ProviderName, $"vanished from '{Path.GetFileName(winner.ArchivePath!)}' between listing and read")); return; }
+                    using var ms = new MemoryStream(bytes);
+                    pex = Mutagen.Bethesda.Pex.PexFile.CreateFromStream(ms, Mutagen.Bethesda.GameCategory.Skyrim);
+                }
+                scanned.Add((rel, providers, winner.ProviderName, KindLabel(winner.Kind), HousecarlCore.NativePairing.ExtractNativeClasses(pex)));
+            }
+            catch (Exception ex)
+            {
+                unreadable.Add(new NativeUnreadablePex(rel, winner.ProviderName, $"Mutagen cannot read it ({ex.GetType().Name}: {ex.Message}) — the known unreadable-pex class"));
+            }
+        });
+
+        // ---- classify + pair (sequential — cheap set lookups over the parallel parse's output). ----
+        // Pass 1: provenance for every native class; collect the providers of ENGINE classes (the SKSE-CORE rescue pool).
+        var native = scanned.Where(s => s.Decls.Count > 0).OrderBy(s => s.Rel, StringComparer.OrdinalIgnoreCase).ToList();
+        var engineProviders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var s in native)
+            if (HasOfficialProvider(s.Providers, officialArchives))
+                foreach (var p in s.Providers)
+                    if (!(p.Kind == "BSA" && officialArchives.Contains(p.Name)))
+                        engineProviders.Add(p.Name);   // a mod (or Data/overwrite) shipping a copy of an ENGINE class
+
+        // Pass 2: build the entries. SKSE-CORE = an otherwise-UNPAIRED third-party class whose winning provider also
+        // provides an ENGINE class (the skse64 payload's structural co-shipment signal). Pairing evidence beats the
+        // rescue: a class that pairs to a DLL stays third-party/paired regardless of its provider's other files.
+        var classes = new List<NativeClassEntry>();
+        foreach (var s in native)
+        {
+            bool engine = HasOfficialProvider(s.Providers, officialArchives);
+            foreach (var d in s.Decls)
+            {
+                if (engine)
+                {
+                    classes.Add(new NativeClassEntry(s.Rel, d.ClassName, d.NativeFunctions.Count, d.NativeFunctions,
+                        s.WinningProvider, s.ProviderKind, s.Providers.Count, s.Providers,
+                        NativeProvenance.Engine, null, null, Array.Empty<NativePairedDll>()));
+                    continue;
+                }
+                var (rung, pairedMod, pairedDlls) = Ladder(s.Providers, modDlls);
+                var prov = rung == NativePairingRung.Unpaired && s.WinningProvider is { } wp && engineProviders.Contains(wp)
+                    ? NativeProvenance.SkseCore
+                    : NativeProvenance.ThirdParty;
+                classes.Add(new NativeClassEntry(s.Rel, d.ClassName, d.NativeFunctions.Count, d.NativeFunctions,
+                    s.WinningProvider, s.ProviderKind, s.Providers.Count, s.Providers,
+                    prov, prov == NativeProvenance.ThirdParty ? rung : null, pairedMod, pairedDlls));
+            }
+        }
+
+        // SKSE-CORE sanity input: is a game-root skse64 loader visible at all? (§4b's optional note — best-effort,
+        // null-safe; a miss just means the renderer can't add the note, never an audit failure.)
+        bool loaderSeen = false;
+        try
+        {
+            var gameDir = dataDir.Length > 0 ? Path.GetDirectoryName(dataDir.TrimEnd('\\', '/')) : null;
+            loaderSeen = gameDir is { Length: > 0 } && Directory.Exists(gameDir)
+                && (File.Exists(Path.Combine(gameDir, "skse64_loader.exe"))
+                    || Directory.EnumerateFiles(gameDir, "skse64_*.dll").Any());
+        }
+        catch { /* best-effort */ }
+
+        return new NativePairingAuditData(classes, pexPaths.Count,
+            unreadable.OrderBy(u => u.RelPath, StringComparer.OrdinalIgnoreCase).ToList(),
+            loaderSeen, InstalledRuntime: null,
+            view.BsaFailures, view.ReadIncomplete, warnings, profileName);
+    }
+
+    /// <summary>An archive is OFFICIAL — its scripts' natives are the engine's own — when it loads from Skyrim.ini's
+    /// base [Archive] block or is owned by a base master (Mutagen's implicit list, by construction — never a name
+    /// list). internal: the native-pairing guard pins it over synthetic archives.</summary>
+    internal static bool IsOfficialArchive(ActiveArchive a, IReadOnlyList<ModKey> baseMasters) =>
+        a.OwningPlugin.Equals(ArchiveDiscovery.IniArchiveOwner, StringComparison.Ordinal)
+        || (ModKey.TryFromNameAndExtension(a.OwningPlugin, out var mk) && baseMasters.Contains(mk));
+
+    /// <summary>True when any provider in a file's chain is an official archive — the ENGINE provenance test. Keys on
+    /// the BSA kind + archive filename (a BSA provider's name IS its archive filename), so a LOOSE override winning the
+    /// file (SKSE's Actor.pex over Skyrim - Misc.bsa's) still leaves the class baseline. internal for the guard.</summary>
+    internal static bool HasOfficialProvider(IReadOnlyList<SkseProvider> providers, HashSet<string> officialArchives) =>
+        providers.Any(p => p.Kind == "BSA" && officialArchives.Contains(p.Name));
+
+    /// <summary>The pairing-evidence ladder (§4c) for one third-party class: rung 1 — the WINNING provider ships ≥1
+    /// candidate DLL; rung 2 — a mod elsewhere in the conflict CHAIN does (the bundling case: a patch wins the script,
+    /// the framework beneath ships the DLL); rung 3 — nobody in sight does → UNPAIRED, a verify flag. Structural
+    /// (file co-location + VFS chains), never semantic — which DLL implements which class is tier-E territory.
+    /// internal for the guard.</summary>
+    internal static (NativePairingRung Rung, string? PairedMod, IReadOnlyList<NativePairedDll> Dlls) Ladder(
+        IReadOnlyList<SkseProvider> providers, IReadOnlyDictionary<string, List<NativePairedDll>> modDlls)
+    {
+        for (int i = 0; i < providers.Count; i++)
+            if (modDlls.TryGetValue(providers[i].Name, out var dlls) && dlls.Count > 0)
+                return (i == 0 ? NativePairingRung.SameMod : NativePairingRung.ChainMod, providers[i].Name, dlls);
+        return (NativePairingRung.Unpaired, null, Array.Empty<NativePairedDll>());
+    }
 
     // ---- SkyPatcher distributor Wave 1: the per-record TRUE post-SkyPatcher state (plan
     //      dev/plans/SKYPATCHER_DISTRIBUTOR_TOOL_PLAN_2026-07-08.md — reader-only scope, 2026-07-09). ----
@@ -4991,6 +5193,86 @@ public sealed record SkseConfigFileAudit(
 public sealed record SkseConfigAuditData(
     IReadOnlyList<SkseConfigFileAudit> Files,
     int ConfigCount,
+    IReadOnlyList<string> BsaFailures,
+    bool ReadIncomplete,
+    IReadOnlyList<string> Warnings,
+    string ProfileName);
+
+/// <summary>Who implements a native class's declarations (housecarl_native_pairing_audit).</summary>
+public enum NativeProvenance
+{
+    /// <summary>The class's provider chain includes an OFFICIAL archive — implemented by the game executable. Baseline;
+    /// accounting only (this holds even when a mod's loose copy WINS the file — SKSE overrides vanilla classes).</summary>
+    Engine,
+    /// <summary>An skse64-scripts-payload class (StringUtil, UI, …) — implemented by the game-root skse64 loader, not
+    /// anything under SKSE\Plugins. Detected structurally: an otherwise-unpaired class whose winning provider also
+    /// provides an ENGINE class (the payload co-ships vanilla overrides with its new classes). Baseline.</summary>
+    SkseCore,
+    /// <summary>Anything else — the pairing ladder runs.</summary>
+    ThirdParty,
+}
+
+/// <summary>The §4c pairing-evidence rung a THIRD-PARTY class landed on, by evidence strength.</summary>
+public enum NativePairingRung
+{
+    /// <summary>The winning .pex's own provider mod ships ≥1 candidate DLL — the strong co-shipment signal.</summary>
+    SameMod,
+    /// <summary>A mod elsewhere in the .pex's conflict chain ships the DLL — the bundling case (a patch mod wins the
+    /// script file; the framework mod beneath ships the implementation).</summary>
+    ChainMod,
+    /// <summary>No mod shipping this class's file (winner or chain) ships any candidate DLL. A VERIFY flag, never
+    /// "broken" — a declaration copy of an absent framework lands here, but registration is runtime behavior (tier E).</summary>
+    Unpaired,
+}
+
+/// <summary>One candidate DLL a paired mod ships: its VFS identity, the winning copy's tier-C manifest (loose winners
+/// only), and <see cref="LoadBlocker"/> — the static reason it will NOT load (BSA-only / subfolder / 32-bit /
+/// unreadable), null when no static check rules it out. version-LOCKED-vs-runtime is adjudicated at render time
+/// against <see cref="NativePairingAuditData.InstalledRuntime"/> (it needs the game version, which may be unknown).</summary>
+public sealed record NativePairedDll(
+    string RelPath,
+    string FileName,
+    string Group,
+    string? WinningProvider,
+    SksePluginReader.SksePluginInfo? Info,
+    string? LoadBlocker);
+
+/// <summary>One script class declaring native functions, with its VFS provenance, its <see cref="Provenance"/> class,
+/// and — for a third-party class — the pairing <see cref="Rung"/>, the paired mod, and that mod's candidate DLLs.
+/// <see cref="Rung"/>/<see cref="PairedMod"/> are null for baseline (ENGINE / SKSE CORE) classes.</summary>
+public sealed record NativeClassEntry(
+    string RelPath,
+    string ClassName,
+    int NativeCount,
+    IReadOnlyList<string> NativeFunctions,
+    string? WinningProvider,
+    string ProviderKind,
+    int ProviderCount,
+    IReadOnlyList<SkseProvider> Providers,
+    NativeProvenance Provenance,
+    NativePairingRung? Rung,
+    string? PairedMod,
+    IReadOnlyList<NativePairedDll> PairedDlls)
+{
+    /// <summary>Candidate DLLs exist and EVERY one carries a static <see cref="NativePairedDll.LoadBlocker"/> — the
+    /// audit's sharpest finding: the scripts are installed and paired, and nothing that could implement them loads.</summary>
+    public bool PairedAllDead => PairedDlls.Count > 0 && PairedDlls.All(d => d.LoadBlocker is not null);
+}
+
+/// <summary>A .pex whose winning copy could not be parsed — a NAMED note (Q3), never a silent skip.</summary>
+public sealed record NativeUnreadablePex(string RelPath, string? WinningProvider, string Reason);
+
+/// <summary>The data behind housecarl_native_pairing_audit: every native-declaring class classified and (for third
+/// parties) paired, the scan accounting (<see cref="PexScanned"/> total compiled scripts examined), the unreadable
+/// notes, whether a game-root skse64 loader is visible (<see cref="SkseLoaderSeen"/> — the SKSE-CORE sanity note), the
+/// installed game runtime when resolvable (<see cref="InstalledRuntime"/>, null = unknown → version-LOCKED findings
+/// degrade to "verify"), and the build-level Q3 caveats.</summary>
+public sealed record NativePairingAuditData(
+    IReadOnlyList<NativeClassEntry> Classes,
+    int PexScanned,
+    IReadOnlyList<NativeUnreadablePex> Unreadable,
+    bool SkseLoaderSeen,
+    string? InstalledRuntime,
     IReadOnlyList<string> BsaFailures,
     bool ReadIncomplete,
     IReadOnlyList<string> Warnings,

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -463,7 +463,7 @@ public sealed class LoadOrderService : IDisposable
         AssetResolver.AssetView view;
         IReadOnlyList<ActiveArchive> archives;
         IReadOnlyList<string> warnings;
-        string profileName, dataDir;
+        string profileName, dataDir, modsDir, overwriteDir, profileDir;
         lock (_gate)
         {
             view = Assets.Capture();
@@ -471,6 +471,9 @@ public sealed class LoadOrderService : IDisposable
             warnings = _assetWarnings;
             profileName = _profileName;
             dataDir = _dataDir;
+            modsDir = _modsDir;
+            overwriteDir = _overwriteDir;
+            profileDir = _profileDir;
         }
 
         // ---- the official-archive set: the ENGINE anchor. Filenames, because a BSA provider's name IS the archive filename. ----
@@ -479,6 +482,15 @@ public sealed class LoadOrderService : IDisposable
         foreach (var a in archives)
             if (IsOfficialArchive(a, baseMasters))
                 officialArchives.Add(Path.GetFileName(a.Path));
+
+        // A BSA provider's NAME is the archive filename — pairing identity needs the MOD that ships the archive
+        // (live-gate finding: moreHUD's scripts ride AHZmoreHUD.bsa while its DLL is loose in the SAME mod folder;
+        // untranslated, the ladder saw two unrelated providers and called it UNPAIRED). The winning physical path of
+        // each active archive names its shipper: mods\<mod>\X.bsa → that mod; overwrite\ → "overwrite"; Data → "Data".
+        var archiveShipper = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var a in archives)
+            if (ShipperOfArchivePath(a.Path, modsDir, overwriteDir, dataDir) is { } shipper)
+                archiveShipper[Path.GetFileName(a.Path)] = shipper;
 
         // ---- DLL candidates: one SKSE\Plugins pass. A mod "ships" a DLL when it appears ANYWHERE in that file's
         //      chain (the bundling case pairs through the chain); the health verdict describes the WINNING copy. A
@@ -510,7 +522,8 @@ public sealed class LoadOrderService : IDisposable
             var dll = new NativePairedDll(rel, Path.GetFileName(rel), group, winner?.ProviderName, info, blocker);
             foreach (var src in place.Sources)
             {
-                if (!modDlls.TryGetValue(src.ProviderName, out var list)) modDlls[src.ProviderName] = list = new();
+                var mod = src.Kind == AssetKind.Bsa && archiveShipper.TryGetValue(src.ProviderName, out var s) ? s : src.ProviderName;
+                if (!modDlls.TryGetValue(mod, out var list)) modDlls[mod] = list = new();
                 if (!list.Any(d => d.RelPath.Equals(rel, StringComparison.OrdinalIgnoreCase))) list.Add(dll);
             }
         }
@@ -554,12 +567,15 @@ public sealed class LoadOrderService : IDisposable
         // ---- classify + pair (sequential — cheap set lookups over the parallel parse's output). ----
         // Pass 1: provenance for every native class; collect the providers of ENGINE classes (the SKSE-CORE rescue pool).
         var native = scanned.Where(s => s.Decls.Count > 0).OrderBy(s => s.Rel, StringComparer.OrdinalIgnoreCase).ToList();
+        // Pairing identity: a provider translated to the MOD it means (a BSA provider → the mod shipping the archive).
+        SkseProvider Identity(SkseProvider p) =>
+            p.Kind == "BSA" && archiveShipper.TryGetValue(p.Name, out var s) ? p with { Name = s } : p;
         var engineProviders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var s in native)
             if (HasOfficialProvider(s.Providers, officialArchives))
                 foreach (var p in s.Providers)
                     if (!(p.Kind == "BSA" && officialArchives.Contains(p.Name)))
-                        engineProviders.Add(p.Name);   // a mod (or Data/overwrite) shipping a copy of an ENGINE class
+                        engineProviders.Add(Identity(p).Name);   // a mod (or Data/overwrite) shipping a copy of an ENGINE class
 
         // Pass 2: build the entries. SKSE-CORE = an otherwise-UNPAIRED third-party class whose winning provider also
         // provides an ENGINE class (the skse64 payload's structural co-shipment signal). Pairing evidence beats the
@@ -577,8 +593,9 @@ public sealed class LoadOrderService : IDisposable
                         NativeProvenance.Engine, null, null, Array.Empty<NativePairedDll>()));
                     continue;
                 }
-                var (rung, pairedMod, pairedDlls) = Ladder(s.Providers, modDlls);
-                var prov = rung == NativePairingRung.Unpaired && s.WinningProvider is { } wp && engineProviders.Contains(wp)
+                var (rung, pairedMod, pairedDlls) = Ladder(s.Providers.Select(Identity).ToList(), modDlls);
+                var prov = rung == NativePairingRung.Unpaired && s.Providers.Count > 0
+                           && engineProviders.Contains(Identity(s.Providers[0]).Name)
                     ? NativeProvenance.SkseCore
                     : NativeProvenance.ThirdParty;
                 classes.Add(new NativeClassEntry(s.Rel, d.ClassName, d.NativeFunctions.Count, d.NativeFunctions,
@@ -587,15 +604,24 @@ public sealed class LoadOrderService : IDisposable
             }
         }
 
-        // SKSE-CORE sanity input: is a game-root skse64 loader visible at all? (§4b's optional note — best-effort,
-        // null-safe; a miss just means the renderer can't add the note, never an audit failure.)
+        // SKSE-CORE sanity input: is an skse64 loader visible at all? Two places to look (§4b's optional note,
+        // best-effort + null-safe — a miss just means the renderer can't add the note, never an audit failure):
+        // the game ROOT (a manual install), and each enabled mod's Root\ folder — the MO2 Root Builder layout,
+        // where the loader lives at mods\<mod>\Root\skse64_loader.exe and only materializes in the game root at
+        // launch (live-gate finding: ARR ships SKSE exactly this way, and the root-only check false-noted it).
         bool loaderSeen = false;
         try
         {
+            static bool LoaderIn(string dir) => Directory.Exists(dir)
+                && (File.Exists(Path.Combine(dir, "skse64_loader.exe"))
+                    || Directory.EnumerateFiles(dir, "skse64_*.dll").Any());
             var gameDir = dataDir.Length > 0 ? Path.GetDirectoryName(dataDir.TrimEnd('\\', '/')) : null;
-            loaderSeen = gameDir is { Length: > 0 } && Directory.Exists(gameDir)
-                && (File.Exists(Path.Combine(gameDir, "skse64_loader.exe"))
-                    || Directory.EnumerateFiles(gameDir, "skse64_*.dll").Any());
+            loaderSeen = gameDir is { Length: > 0 } && LoaderIn(gameDir);
+            if (!loaderSeen && modsDir.Length > 0 && profileDir.Length > 0)
+            {
+                var comp = Mo2LoadOrder.ReadComposition(profileDir);   // cheap static profile read (the discovery pattern)
+                loaderSeen = comp.EnabledMods.Any(m => LoaderIn(Path.Combine(modsDir, m, "Root")));
+            }
         }
         catch { /* best-effort */ }
 
@@ -603,6 +629,30 @@ public sealed class LoadOrderService : IDisposable
             unreadable.OrderBy(u => u.RelPath, StringComparer.OrdinalIgnoreCase).ToList(),
             loaderSeen, InstalledGameRuntime(),
             view.BsaFailures, view.ReadIncomplete, warnings, profileName);
+    }
+
+    /// <summary>The MOD a physical archive path belongs to — the pairing identity behind a BSA provider name:
+    /// mods\&lt;mod&gt;\X.bsa → that mod folder; the overwrite layer → "overwrite"; the game Data folder → "Data";
+    /// anywhere else → null (no translation — the archive name stands). internal for the guard.</summary>
+    internal static string? ShipperOfArchivePath(string archivePath, string modsDir, string overwriteDir, string dataDir)
+    {
+        static bool Under(string path, string root, out string remainder)
+        {
+            remainder = "";
+            if (root.Length == 0) return false;
+            var r = root.TrimEnd('\\', '/') + "\\";
+            if (!path.StartsWith(r, StringComparison.OrdinalIgnoreCase)) return false;
+            remainder = path.Substring(r.Length);
+            return true;
+        }
+        if (Under(archivePath, overwriteDir, out _)) return "overwrite";
+        if (Under(archivePath, modsDir, out var rest))
+        {
+            int slash = rest.IndexOfAny(new[] { '\\', '/' });
+            return slash > 0 ? rest[..slash] : null;   // a .bsa directly in mods\ belongs to no mod — no translation
+        }
+        if (Under(archivePath, dataDir, out _)) return "Data";
+        return null;
     }
 
     /// <summary>An archive is OFFICIAL — its scripts' natives are the engine's own — when it loads from Skyrim.ini's

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -57,6 +57,7 @@ public sealed class LoadOrderService : IDisposable
     AssetResolver? _assetResolver;
     IReadOnlyList<string> _assetWarnings = Array.Empty<string>();   // discovery warnings from the asset build (e.g. a Skyrim.ini we couldn't find → base BSAs unscanned)
     IReadOnlyList<ActiveArchive> _activeArchives = Array.Empty<ActiveArchive>();   // the discovered active-BSA list behind the CURRENT asset build (archive → owning plugin — the native-pairing audit's provenance anchor); swapped with _assetResolver
+    IReadOnlyList<string> _enabledModsAtBuild = Array.Empty<string>();             // the enabled-mod list behind the CURRENT asset build (the native-pairing loader scan walks THESE mods' Root\ folders — same capture as the view, never a second unpinned profile read); swapped with _assetResolver
     // Freshness baselines are the files' LAST-SEEN MTIMES compared by VALUE (!=), the same model the resolver itself
     // uses — NOT wall-clock stamps compared by ORDER (2026-06-12 hunt F8: `mtime > builtUtc` was blind to an mtime
     // REGRESSION, so MO2's "Restore Backup" — which restores a profile file with an OLDER mtime — stayed invisible
@@ -213,6 +214,7 @@ public sealed class LoadOrderService : IDisposable
         var discovery = ArchiveDiscovery.Discover(_profileDir, _modsDir, _dataDir, _overwriteDir, gamePath);
         _assetWarnings = discovery.Warnings;
         _activeArchives = discovery.Archives;   // kept alongside the resolver: archive filename → owning plugin (native-pairing provenance)
+        _enabledModsAtBuild = comp.EnabledMods; // same build: the mod set behind this resolver (native-pairing loader scan)
         return AssetResolver.Build(_overwriteDir, _modsDir, _dataDir, comp.EnabledMods, discovery.Archives);
     }
 
@@ -462,18 +464,19 @@ public sealed class LoadOrderService : IDisposable
     {
         AssetResolver.AssetView view;
         IReadOnlyList<ActiveArchive> archives;
+        IReadOnlyList<string> enabledMods;
         IReadOnlyList<string> warnings;
-        string profileName, dataDir, modsDir, overwriteDir, profileDir;
+        string profileName, dataDir, modsDir, overwriteDir;
         lock (_gate)
         {
             view = Assets.Capture();
-            archives = _activeArchives;   // the SAME build as the view (both swapped under _gate)
+            archives = _activeArchives;         // the SAME build as the view (both swapped under _gate)
+            enabledMods = _enabledModsAtBuild;  // ditto — the loader scan below walks the mod set the VIEW describes, never a second unpinned profile read
             warnings = _assetWarnings;
             profileName = _profileName;
             dataDir = _dataDir;
             modsDir = _modsDir;
             overwriteDir = _overwriteDir;
-            profileDir = _profileDir;
         }
 
         // ---- the official-archive set: the ENGINE anchor. Filenames, because a BSA provider's name IS the archive filename. ----
@@ -494,7 +497,8 @@ public sealed class LoadOrderService : IDisposable
 
         // ---- DLL candidates: one SKSE\Plugins pass. A mod "ships" a DLL when it appears ANYWHERE in that file's
         //      chain (the bundling case pairs through the chain); the health verdict describes the WINNING copy. A
-        //      loose winner that PE-reads as NotSkse is a bundled dependency, not an implementation candidate. ----
+        //      winner that PE-reads as NotSkse — loose OR BSA-packed (review finding: an unscreened packed dependency
+        //      fabricated candidacy) — is a bundled dependency, not an implementation candidate. ----
         const string skseRootPre = "SKSE\\Plugins\\";
         var modDlls = new Dictionary<string, List<NativePairedDll>>(StringComparer.OrdinalIgnoreCase);
         foreach (var rel in view.EnumerateUnder("SKSE\\Plugins").OrderBy(p => p, StringComparer.OrdinalIgnoreCase))
@@ -508,7 +512,18 @@ public sealed class LoadOrderService : IDisposable
             string? blocker = null;
             if (winner is null) blocker = "no active mod provides it";
             else if (winner.Kind != AssetKind.Loose)
+            {
                 blocker = "provided only inside a BSA — the SKSE loader scans loose DLLs only, so it will not load";
+                try
+                {
+                    // PE-screen the packed copy too (DLLs are few — the per-entry read is fine here): a packed
+                    // NotSkse dependency must not count as a candidate, or its mod gains phantom pairing evidence.
+                    if (AssetResolver.TryReadArchiveEntry(winner.ArchivePath!, winner.EntryPath) is { } bytes)
+                        info = SksePluginReader.ReadBytes(Path.GetFileName(rel), bytes);
+                }
+                catch { /* unreadable archive rides the view's BsaFailures caveat; the candidate keeps its blocker */ }
+                if (info?.Kind == SksePluginReader.SksePluginKind.NotSkse) continue;
+            }
             else
             {
                 info = SksePluginReader.Read(winner.LooseFilePath!);
@@ -522,108 +537,127 @@ public sealed class LoadOrderService : IDisposable
             var dll = new NativePairedDll(rel, Path.GetFileName(rel), group, winner?.ProviderName, info, blocker);
             foreach (var src in place.Sources)
             {
-                var mod = src.Kind == AssetKind.Bsa && archiveShipper.TryGetValue(src.ProviderName, out var s) ? s : src.ProviderName;
+                var mod = PairingIdentity(src, archiveShipper);
                 if (!modDlls.TryGetValue(mod, out var list)) modDlls[mod] = list = new();
                 if (!list.Any(d => d.RelPath.Equals(rel, StringComparison.OrdinalIgnoreCase))) list.Add(dll);
             }
         }
 
-        // ---- the .pex sweep: winning copy of every compiled script, native classes extracted. Parallel parse
-        //      (the corpus is thousands of files; the captured view's caches are concurrency-safe), deterministic
-        //      output order restored by the final sorts. Per-file fault isolation: an unreadable .pex is a NAMED
-        //      entry (Q3), never a silent skip. ----
+        // ---- the .pex sweep, two phases. Phase 1 (parallel): resolve every path; parse LOOSE winners in place;
+        //      defer BSA winners to a per-archive batch (review finding: per-entry TryReadArchiveEntry re-opens the
+        //      archive and walks its whole table each time — O(K·M) against the ~10k-script vanilla archives, the
+        //      dominant wall-clock). Phase 2: ONE table walk per archive collects all its wanted entries, then the
+        //      parses run parallel over the bytes. Per-file fault isolation throughout: an unreadable .pex is a
+        //      NAMED entry (Q3), never a silent skip. ----
         var pexPaths = view.EnumerateUnder("Scripts")
             .Where(p => Path.GetExtension(p).Equals(".pex", StringComparison.OrdinalIgnoreCase))
             .OrderBy(p => p, StringComparer.OrdinalIgnoreCase).ToList();
 
-        var scanned = new System.Collections.Concurrent.ConcurrentBag<(string Rel, IReadOnlyList<SkseProvider> Providers, string? WinningProvider, string ProviderKind, IReadOnlyList<HousecarlCore.NativeClassDecl> Decls)>();
+        // Only native-declaring files are kept (a ~48k-file order yields ~200 — carrying every file's providers was
+        // pure garbage, review finding); their conflict chains are re-resolved on collection, which is cheap at that count.
+        var natives = new System.Collections.Concurrent.ConcurrentBag<(string Rel, IReadOnlyList<HousecarlCore.NativeClassDecl> Decls)>();
         var unreadable = new System.Collections.Concurrent.ConcurrentBag<NativeUnreadablePex>();
-        System.Threading.Tasks.Parallel.ForEach(pexPaths, rel =>
+        var bsaWanted = new System.Collections.Concurrent.ConcurrentBag<(string Rel, string ArchivePath, string EntryPath, string Provider)>();
+
+        void ParsePex(string rel, string? provider, Func<Mutagen.Bethesda.Pex.PexFile> load)
         {
-            var place = view.ResolveForPlacement(rel);
-            var providers = place.Sources.Select(s => new SkseProvider(s.ProviderName, KindLabel(s.Kind))).ToList();
-            var winner = place.Sources.Count > 0 ? place.Sources[0] : null;
-            if (winner is null) { unreadable.Add(new NativeUnreadablePex(rel, null, "enumerated but no active source provides it")); return; }
             try
             {
-                Mutagen.Bethesda.Pex.PexFile pex;
-                if (winner.LooseFilePath is { } lp)
-                    pex = Mutagen.Bethesda.Pex.PexFile.CreateFromFile(lp, Mutagen.Bethesda.GameCategory.Skyrim);
-                else
-                {
-                    var bytes = AssetResolver.TryReadArchiveEntry(winner.ArchivePath!, winner.EntryPath);
-                    if (bytes is null) { unreadable.Add(new NativeUnreadablePex(rel, winner.ProviderName, $"vanished from '{Path.GetFileName(winner.ArchivePath!)}' between listing and read")); return; }
-                    using var ms = new MemoryStream(bytes);
-                    pex = Mutagen.Bethesda.Pex.PexFile.CreateFromStream(ms, Mutagen.Bethesda.GameCategory.Skyrim);
-                }
-                scanned.Add((rel, providers, winner.ProviderName, KindLabel(winner.Kind), HousecarlCore.NativePairing.ExtractNativeClasses(pex)));
+                var decls = HousecarlCore.NativePairing.ExtractNativeClasses(load());
+                if (decls.Count > 0) natives.Add((rel, decls));
             }
             catch (Exception ex)
             {
-                unreadable.Add(new NativeUnreadablePex(rel, winner.ProviderName, $"Mutagen cannot read it ({ex.GetType().Name}: {ex.Message}) — the known unreadable-pex class"));
-            }
-        });
-
-        // ---- classify + pair (sequential — cheap set lookups over the parallel parse's output). ----
-        // Pass 1: provenance for every native class; collect the providers of ENGINE classes (the SKSE-CORE rescue pool).
-        var native = scanned.Where(s => s.Decls.Count > 0).OrderBy(s => s.Rel, StringComparer.OrdinalIgnoreCase).ToList();
-        // Pairing identity: a provider translated to the MOD it means (a BSA provider → the mod shipping the archive).
-        SkseProvider Identity(SkseProvider p) =>
-            p.Kind == "BSA" && archiveShipper.TryGetValue(p.Name, out var s) ? p with { Name = s } : p;
-        var engineProviders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var s in native)
-            if (HasOfficialProvider(s.Providers, officialArchives))
-                foreach (var p in s.Providers)
-                    if (!(p.Kind == "BSA" && officialArchives.Contains(p.Name)))
-                        engineProviders.Add(Identity(p).Name);   // a mod (or Data/overwrite) shipping a copy of an ENGINE class
-
-        // Pass 2: build the entries. SKSE-CORE = an otherwise-UNPAIRED third-party class whose winning provider also
-        // provides an ENGINE class (the skse64 payload's structural co-shipment signal). Pairing evidence beats the
-        // rescue: a class that pairs to a DLL stays third-party/paired regardless of its provider's other files.
-        var classes = new List<NativeClassEntry>();
-        foreach (var s in native)
-        {
-            bool engine = HasOfficialProvider(s.Providers, officialArchives);
-            foreach (var d in s.Decls)
-            {
-                if (engine)
-                {
-                    classes.Add(new NativeClassEntry(s.Rel, d.ClassName, d.NativeFunctions.Count, d.NativeFunctions,
-                        s.WinningProvider, s.ProviderKind, s.Providers.Count, s.Providers,
-                        NativeProvenance.Engine, null, null, Array.Empty<NativePairedDll>()));
-                    continue;
-                }
-                var (rung, pairedMod, pairedDlls) = Ladder(s.Providers.Select(Identity).ToList(), modDlls);
-                var prov = rung == NativePairingRung.Unpaired && s.Providers.Count > 0
-                           && engineProviders.Contains(Identity(s.Providers[0]).Name)
-                    ? NativeProvenance.SkseCore
-                    : NativeProvenance.ThirdParty;
-                classes.Add(new NativeClassEntry(s.Rel, d.ClassName, d.NativeFunctions.Count, d.NativeFunctions,
-                    s.WinningProvider, s.ProviderKind, s.Providers.Count, s.Providers,
-                    prov, prov == NativeProvenance.ThirdParty ? rung : null, pairedMod, pairedDlls));
+                unreadable.Add(new NativeUnreadablePex(rel, provider, $"Mutagen cannot read it ({ex.GetType().Name}: {ex.Message}) — the known unreadable-pex class"));
             }
         }
 
-        // SKSE-CORE sanity input: is an skse64 loader visible at all? Two places to look (§4b's optional note,
-        // best-effort + null-safe — a miss just means the renderer can't add the note, never an audit failure):
-        // the game ROOT (a manual install), and each enabled mod's Root\ folder — the MO2 Root Builder layout,
-        // where the loader lives at mods\<mod>\Root\skse64_loader.exe and only materializes in the game root at
-        // launch (live-gate finding: ARR ships SKSE exactly this way, and the root-only check false-noted it).
-        bool loaderSeen = false;
+        System.Threading.Tasks.Parallel.ForEach(pexPaths, rel =>
+        {
+            var place = view.ResolveForPlacement(rel);
+            var winner = place.Sources.Count > 0 ? place.Sources[0] : null;
+            if (winner is null) { unreadable.Add(new NativeUnreadablePex(rel, null, "enumerated but no active source provides it")); return; }
+            if (winner.LooseFilePath is { } lp)
+                ParsePex(rel, winner.ProviderName, () => Mutagen.Bethesda.Pex.PexFile.CreateFromFile(lp, Mutagen.Bethesda.GameCategory.Skyrim));
+            else
+                bsaWanted.Add((rel, winner.ArchivePath!, winner.EntryPath, winner.ProviderName));
+        });
+
+        foreach (var g in bsaWanted.GroupBy(w => w.ArchivePath, StringComparer.OrdinalIgnoreCase))
+        {
+            Dictionary<string, byte[]> got;
+            try { got = AssetResolver.TryReadArchiveEntries(g.Key, g.Select(w => w.EntryPath).Distinct(StringComparer.OrdinalIgnoreCase).ToList()); }
+            catch (Exception ex)
+            {
+                foreach (var w in g)
+                    unreadable.Add(new NativeUnreadablePex(w.Rel, w.Provider, $"archive '{Path.GetFileName(g.Key)}' could not be read ({ex.GetType().Name}: {ex.Message})"));
+                continue;
+            }
+            System.Threading.Tasks.Parallel.ForEach(g, w =>
+            {
+                if (!got.TryGetValue(w.EntryPath, out var bytes))
+                    unreadable.Add(new NativeUnreadablePex(w.Rel, w.Provider, $"vanished from '{Path.GetFileName(g.Key)}' between listing and read"));
+                else
+                    ParsePex(w.Rel, w.Provider, () =>
+                    {
+                        using var ms = new MemoryStream(bytes);
+                        return Mutagen.Bethesda.Pex.PexFile.CreateFromStream(ms, Mutagen.Bethesda.GameCategory.Skyrim);
+                    });
+            });
+        }
+
+        // ---- classify + pair (sequential — cheap set lookups over ~200 native files). Provenance and pairing key on
+        //      the enum-typed PlacementSource, never the render label (review finding: "BSA" the display string must
+        //      not double as the semantic discriminator). ----
+        var native = natives.OrderBy(s => s.Rel, StringComparer.OrdinalIgnoreCase)
+            .Select(s => (s.Rel, s.Decls, Sources: view.ResolveForPlacement(s.Rel).Sources))
+            .ToList();
+
+        // Pass 1: the SKSE-CORE rescue pool — every non-official pairing identity shipping a copy of an ENGINE class.
+        var engineProviders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var s in native)
+            if (HasOfficialSource(s.Sources, officialArchives))
+                foreach (var src in s.Sources)
+                    if (!(src.Kind == AssetKind.Bsa && officialArchives.Contains(src.ProviderName)))
+                        engineProviders.Add(PairingIdentity(src, archiveShipper));
+        // "overwrite" is excluded from the rescue: a recompiled vanilla .pex in MO2's overwrite is routine (houseCARL's
+        // own compile lane writes there), and letting it baseline-rescue every orphan declaration copy that also lands
+        // in overwrite would silence exactly the flag this tool exists for (review finding). "Data" stays — the manual
+        // game-folder SKSE install is the layout the rescue must cover; its wider-net residual is documented on Classify.
+        engineProviders.Remove("overwrite");
+
+        // Pass 2: build the entries (Classify carries the decision order: engine → ladder → rescue).
+        var classes = new List<NativeClassEntry>();
+        foreach (var s in native)
+        {
+            bool engine = HasOfficialSource(s.Sources, officialArchives);
+            var identities = s.Sources.Select(src => PairingIdentity(src, archiveShipper)).ToList();
+            var display = s.Sources.Select(src => new SkseProvider(src.ProviderName, KindLabel(src.Kind))).ToList();
+            foreach (var d in s.Decls)
+            {
+                var (prov, rung, pairedMod, pairedDlls) = Classify(engine, identities, modDlls, engineProviders);
+                classes.Add(new NativeClassEntry(s.Rel, d.ClassName, d.NativeFunctions, display,
+                    prov, rung, pairedMod, pairedDlls));
+            }
+        }
+
+        // SKSE-CORE sanity input: is an skse64 loader visible at all? Two places to look (§4b's optional note):
+        // the game ROOT (a manual install), and each enabled mod's Root\ folder — the MO2 Root Builder layout, where
+        // the loader lives at mods\<mod>\Root\skse64_loader.exe and only materializes in the game root at launch
+        // (live-gate finding: ARR ships SKSE exactly this way, and the root-only check false-noted it). The mod list
+        // is the SAME capture as the view (never a second unpinned profile read). Tri-state (Q3, review finding): a
+        // check that THREW yields null — "could not check" — never a false "checked and absent".
+        bool? loaderSeen;
         try
         {
             static bool LoaderIn(string dir) => Directory.Exists(dir)
                 && (File.Exists(Path.Combine(dir, "skse64_loader.exe"))
                     || Directory.EnumerateFiles(dir, "skse64_*.dll").Any());
             var gameDir = dataDir.Length > 0 ? Path.GetDirectoryName(dataDir.TrimEnd('\\', '/')) : null;
-            loaderSeen = gameDir is { Length: > 0 } && LoaderIn(gameDir);
-            if (!loaderSeen && modsDir.Length > 0 && profileDir.Length > 0)
-            {
-                var comp = Mo2LoadOrder.ReadComposition(profileDir);   // cheap static profile read (the discovery pattern)
-                loaderSeen = comp.EnabledMods.Any(m => LoaderIn(Path.Combine(modsDir, m, "Root")));
-            }
+            loaderSeen = (gameDir is { Length: > 0 } && LoaderIn(gameDir))
+                || (modsDir.Length > 0 && enabledMods.Any(m => LoaderIn(Path.Combine(modsDir, m, "Root"))));
         }
-        catch { /* best-effort */ }
+        catch { loaderSeen = null; }
 
         return new NativePairingAuditData(classes, pexPaths.Count,
             unreadable.OrderBy(u => u.RelPath, StringComparer.OrdinalIgnoreCase).ToList(),
@@ -636,11 +670,15 @@ public sealed class LoadOrderService : IDisposable
     /// anywhere else → null (no translation — the archive name stands). internal for the guard.</summary>
     internal static string? ShipperOfArchivePath(string archivePath, string modsDir, string overwriteDir, string dataDir)
     {
+        // Full-path-normalize both sides (the IsUnderModsDir precedent) so forward slashes / '..' segments / a
+        // trailing-separator root from config can't make the under-root test disagree with the rest of the plumbing.
+        static string Norm(string p) { try { return Path.GetFullPath(p); } catch { return p; } }
+        archivePath = Norm(archivePath);
         static bool Under(string path, string root, out string remainder)
         {
             remainder = "";
             if (root.Length == 0) return false;
-            var r = root.TrimEnd('\\', '/') + "\\";
+            var r = Norm(root).TrimEnd('\\', '/') + "\\";
             if (!path.StartsWith(r, StringComparison.OrdinalIgnoreCase)) return false;
             remainder = path.Substring(r.Length);
             return true;
@@ -659,27 +697,66 @@ public sealed class LoadOrderService : IDisposable
     /// base [Archive] block or is owned by a base master (Mutagen's implicit list, by construction — never a name
     /// list). internal: the native-pairing guard pins it over synthetic archives.</summary>
     internal static bool IsOfficialArchive(ActiveArchive a, IReadOnlyList<ModKey> baseMasters) =>
-        a.OwningPlugin.Equals(ArchiveDiscovery.IniArchiveOwner, StringComparison.Ordinal)
+        a.OwningPlugin.Equals(ArchiveDiscovery.IniArchiveOwner, StringComparison.OrdinalIgnoreCase)   // ignore-case like every other archive-plumbing compare — the carve-out must not hinge on the marker's casing
         || (ModKey.TryFromNameAndExtension(a.OwningPlugin, out var mk) && baseMasters.Contains(mk));
 
-    /// <summary>True when any provider in a file's chain is an official archive — the ENGINE provenance test. Keys on
-    /// the BSA kind + archive filename (a BSA provider's name IS its archive filename), so a LOOSE override winning the
-    /// file (SKSE's Actor.pex over Skyrim - Misc.bsa's) still leaves the class baseline. internal for the guard.</summary>
-    internal static bool HasOfficialProvider(IReadOnlyList<SkseProvider> providers, HashSet<string> officialArchives) =>
-        providers.Any(p => p.Kind == "BSA" && officialArchives.Contains(p.Name));
+    /// <summary>True when any source in a file's chain is an official archive — the ENGINE provenance test. Keys on
+    /// the <see cref="AssetKind"/> ENUM + archive filename (a BSA source's provider name IS its archive filename), so
+    /// a LOOSE override winning the file (SKSE's Actor.pex over Skyrim - Misc.bsa's) still leaves the class baseline,
+    /// and a render-label change can never silently break the carve-out (review finding: the display string "BSA" must
+    /// not double as the semantic discriminator). internal for the guard.</summary>
+    internal static bool HasOfficialSource(IReadOnlyList<PlacementSource> sources, HashSet<string> officialArchives) =>
+        sources.Any(s => s.Kind == AssetKind.Bsa && officialArchives.Contains(s.ProviderName));
 
-    /// <summary>The pairing-evidence ladder (§4c) for one third-party class: rung 1 — the WINNING provider ships ≥1
-    /// candidate DLL; rung 2 — a mod elsewhere in the conflict CHAIN does (the bundling case: a patch wins the script,
-    /// the framework beneath ships the DLL); rung 3 — nobody in sight does → UNPAIRED, a verify flag. Structural
-    /// (file co-location + VFS chains), never semantic — which DLL implements which class is tier-E territory.
+    /// <summary>One source's PAIRING IDENTITY — the mod it means: a BSA source translates to the mod shipping the
+    /// archive (via the archiveShipper map); everything else is its provider name (mod folder / overwrite / Data).
     /// internal for the guard.</summary>
+    internal static string PairingIdentity(PlacementSource src, IReadOnlyDictionary<string, string> archiveShipper) =>
+        src.Kind == AssetKind.Bsa && archiveShipper.TryGetValue(src.ProviderName, out var mod) ? mod : src.ProviderName;
+
+    /// <summary>The pairing-evidence ladder (§4c) for one third-party class, over the chain's pairing identities
+    /// (winner first): rung 1 — the WINNING identity ships ≥1 candidate DLL; rung 2 — an identity deeper in the chain
+    /// does (the bundling case: a patch mod wins the script, the framework beneath ships the DLL); rung 3 — nobody in
+    /// sight does → UNPAIRED, a verify flag. Within the walk, an identity whose candidates ALL carry a static
+    /// LoadBlocker does not stop the descent when a deeper identity has a loadable candidate (review finding: a
+    /// bundler shipping one dead helper DLL must not mask the real framework beneath it into a false PAIRED-BUT-DEAD);
+    /// if no identity has a loadable candidate, the shallowest with ANY candidate pairs (its deadness is then the
+    /// finding). Structural (file co-location + VFS chains), never semantic — which DLL implements which class is
+    /// tier-E territory. internal for the guard.</summary>
     internal static (NativePairingRung Rung, string? PairedMod, IReadOnlyList<NativePairedDll> Dlls) Ladder(
-        IReadOnlyList<SkseProvider> providers, IReadOnlyDictionary<string, List<NativePairedDll>> modDlls)
+        IReadOnlyList<string> identities, IReadOnlyDictionary<string, List<NativePairedDll>> modDlls)
     {
-        for (int i = 0; i < providers.Count; i++)
-            if (modDlls.TryGetValue(providers[i].Name, out var dlls) && dlls.Count > 0)
-                return (i == 0 ? NativePairingRung.SameMod : NativePairingRung.ChainMod, providers[i].Name, dlls);
+        int firstAny = -1;
+        for (int i = 0; i < identities.Count; i++)
+        {
+            if (!modDlls.TryGetValue(identities[i], out var dlls) || dlls.Count == 0) continue;
+            if (dlls.Any(d => d.LoadBlocker is null))
+                return (i == 0 ? NativePairingRung.SameMod : NativePairingRung.ChainMod, identities[i], dlls);
+            if (firstAny < 0) firstAny = i;
+        }
+        if (firstAny >= 0)
+            return (firstAny == 0 ? NativePairingRung.SameMod : NativePairingRung.ChainMod, identities[firstAny], modDlls[identities[firstAny]]);
         return (NativePairingRung.Unpaired, null, Array.Empty<NativePairedDll>());
+    }
+
+    /// <summary>The full per-class decision (§4b + §4c), in order: ENGINE (official-archive presence) → the pairing
+    /// ladder → the SKSE-CORE rescue for an UNPAIRED class whose WINNING identity also ships an ENGINE-class copy
+    /// (skse64's payload structurally co-ships ~100+ vanilla overrides with its new classes). Pairing evidence beats
+    /// the rescue — a class that pairs to a DLL stays third-party regardless of its provider's other files. Documented
+    /// residual (plan §7, widened by the "Data" identity): a provider that co-ships a vanilla-script override AND a
+    /// declaration copy of an absent framework gets that copy rescued into the unflagged baseline — for a mod folder
+    /// that's the rare bundler; for the game Data folder it covers everything manually installed there ("overwrite" is
+    /// excluded from the pool at the call site for exactly this reason). Visible in the accounting, watched at the
+    /// live gate. internal for the guard.</summary>
+    internal static (NativeProvenance Provenance, NativePairingRung? Rung, string? PairedMod, IReadOnlyList<NativePairedDll> Dlls) Classify(
+        bool engine, IReadOnlyList<string> identities,
+        IReadOnlyDictionary<string, List<NativePairedDll>> modDlls, HashSet<string> engineProviders)
+    {
+        if (engine) return (NativeProvenance.Engine, null, null, Array.Empty<NativePairedDll>());
+        var (rung, pairedMod, dlls) = Ladder(identities, modDlls);
+        if (rung == NativePairingRung.Unpaired && identities.Count > 0 && engineProviders.Contains(identities[0]))
+            return (NativeProvenance.SkseCore, null, null, Array.Empty<NativePairedDll>());
+        return (NativeProvenance.ThirdParty, rung, pairedMod, dlls);
     }
 
     // ---- SkyPatcher distributor Wave 1: the per-record TRUE post-SkyPatcher state (plan
@@ -1630,49 +1707,6 @@ public sealed class LoadOrderService : IDisposable
     /// when the instance is unusable (EnsurePathsDerived throws naming the missing piece — the rider's own config gate
     /// reports that; here it's just "no hint"), or when DataDir hasn't been derived yet. Takes <see cref="_gate"/> like the
     /// other derived-root reads; works in explicit mode too (DataDir is set directly, EnsurePathsDerived no-ops).</summary>
-    /// <summary>The INSTALLED game runtime version — the dotted file version of the game executable the load order
-    /// actually runs (e.g. "1.6.1170.0") — or null when it can't be resolved. This is what turns a version-LOCKED
-    /// SKSE plugin's compat list from "verify against your game version" into PASS/FAIL (native-pairing audit §4d +
-    /// skse_inventory's locked diagnostic). Preference is the OPPOSITE of <see cref="CompilerGameDirHints"/>: the
-    /// load-order's OWN game dir comes FIRST — an MO2 "Stock Game" setup launches the stock copy's exe, so ITS
-    /// version is the truth — with the located real install (<see cref="GameDirOrNull"/>'s locator twin) only as a
-    /// fallback. BEST-EFFORT + NULL-SAFE end to end (the CompilerGameDirHints contract): a miss degrades the finding
-    /// wording, never fails the audit.</summary>
-    public string? InstalledGameRuntime()
-    {
-        foreach (var dir in GameRuntimeDirCandidates())
-        {
-            try
-            {
-                var exe = Path.Combine(dir, "SkyrimSE.exe");
-                if (!File.Exists(exe)) continue;
-                var fv = System.Diagnostics.FileVersionInfo.GetVersionInfo(exe);
-                // FileVersion can carry vendor noise; the numeric parts are the truth. Prefer them when present.
-                if (fv.FileMajorPart > 0 || fv.FileMinorPart > 0 || fv.FileBuildPart > 0 || fv.FilePrivatePart > 0)
-                    return $"{fv.FileMajorPart}.{fv.FileMinorPart}.{fv.FileBuildPart}.{fv.FilePrivatePart}";
-                if (!string.IsNullOrWhiteSpace(fv.FileVersion)) return fv.FileVersion!.Trim();
-            }
-            catch { /* unreadable exe → try the next candidate (best-effort) */ }
-        }
-        return null;
-    }
-
-    /// <summary>The game-dir candidates for the runtime-version read, LOAD-ORDER dir first (see
-    /// <see cref="InstalledGameRuntime"/> for why the preference inverts CompilerGameDirHints).</summary>
-    IEnumerable<string> GameRuntimeDirCandidates()
-    {
-        if (GameDirOrNull() is { Length: > 0 } own) yield return own;
-        string? located = null;
-        try
-        {
-            if (new Mutagen.Bethesda.Installs.GameLocator().TryGetGameDirectory(
-                    Mutagen.Bethesda.GameRelease.SkyrimSE, out var dir) && !string.IsNullOrWhiteSpace(dir.Path))
-                located = NormalizeGameDir(dir.Path);
-        }
-        catch { /* locator hiccup → just the load-order candidate */ }
-        if (located is not null) yield return located;
-    }
-
     public string? GameDirOrNull()
     {
         lock (_gate)
@@ -1695,6 +1729,59 @@ public sealed class LoadOrderService : IDisposable
     /// COMPILER's own game dir (<see cref="CompileTools.BuildImports"/>), NOT from these hints and NOT from the data dir — so
     /// once the compiler resolves to the Steam install, its sibling Data\Source\Scripts is used, never the Stock Game copy's
     /// (which usually has none). Keying sources off the data dir would re-break exactly the Stock-Game case this fixes.</para></summary>
+    // InstalledGameRuntime's memo: the resolved exe re-validated by a cheap mtime stat per call; a probed MISS is
+    // session-stable (no re-paying the GameLocator registry/Steam walk per tool call for a permanently-null answer).
+    readonly object _runtimeGate = new();
+    bool _runtimeProbed;
+    string? _runtimeExe, _runtimeVersion;
+    DateTime _runtimeExeMtime;
+
+    /// <summary>The INSTALLED game runtime version — the dotted file version of the SkyrimSE.exe the load order runs
+    /// (e.g. "1.6.1170.0") — or null when it can't be resolved. This is what turns a version-LOCKED SKSE plugin's
+    /// compat list from "verify against your game version" into PASS/FAIL (native-pairing audit §4d + skse_inventory's
+    /// locked diagnostic). Candidates are exactly <see cref="CompilerGameDirHints"/> — load-order game dir first (an
+    /// MO2 "Stock Game" setup launches THAT copy's exe, and downgrade patchers rewrite it in place, so its version is
+    /// the truth), located install as fallback — one shared derivation, never a re-typed copy. BEST-EFFORT + NULL-SAFE
+    /// end to end: a miss degrades the finding wording, never fails a tool. Memoized: the resolved exe is re-validated
+    /// by mtime per call; a full miss is cached for the session. Residual, documented: if MO2 launches an exe that is
+    /// neither in the load-order game dir nor the located install, the read can describe a different binary — the
+    /// renders name the version they adjudicated against so a wrong baseline is visible, not silent.</summary>
+    public string? InstalledGameRuntime()
+    {
+        lock (_runtimeGate)
+        {
+            if (_runtimeProbed)
+            {
+                if (_runtimeExe is null) return null;   // session-stable miss
+                try
+                {
+                    if (File.Exists(_runtimeExe) && File.GetLastWriteTimeUtc(_runtimeExe) == _runtimeExeMtime)
+                        return _runtimeVersion;         // unchanged exe → cached answer
+                }
+                catch { return _runtimeVersion; }       // stat hiccup → the cached answer beats a re-probe mid-hiccup
+            }
+            _runtimeProbed = true; _runtimeExe = null; _runtimeVersion = null;
+            foreach (var dir in CompilerGameDirHints())
+            {
+                try
+                {
+                    var exe = Path.Combine(dir, "SkyrimSE.exe");
+                    if (!File.Exists(exe)) continue;
+                    var fv = System.Diagnostics.FileVersionInfo.GetVersionInfo(exe);
+                    // FileVersion can carry vendor noise; the numeric parts are the truth. Prefer them when present.
+                    string? v = fv.FileMajorPart > 0 || fv.FileMinorPart > 0 || fv.FileBuildPart > 0 || fv.FilePrivatePart > 0
+                        ? $"{fv.FileMajorPart}.{fv.FileMinorPart}.{fv.FileBuildPart}.{fv.FilePrivatePart}"
+                        : string.IsNullOrWhiteSpace(fv.FileVersion) ? null : fv.FileVersion!.Trim();
+                    if (v is null) continue;
+                    _runtimeExe = exe; _runtimeExeMtime = File.GetLastWriteTimeUtc(exe); _runtimeVersion = v;
+                    return v;
+                }
+                catch { /* unreadable exe → try the next candidate (best-effort) */ }
+            }
+            return null;
+        }
+    }
+
     public IReadOnlyList<string> CompilerGameDirHints()
     {
         var hints = new List<string>();
@@ -5333,24 +5420,28 @@ public sealed record NativePairedDll(
 
 /// <summary>One script class declaring native functions, with its VFS provenance, its <see cref="Provenance"/> class,
 /// and — for a third-party class — the pairing <see cref="Rung"/>, the paired mod, and that mod's candidate DLLs.
-/// <see cref="Rung"/>/<see cref="PairedMod"/> are null for baseline (ENGINE / SKSE CORE) classes.</summary>
+/// <see cref="Rung"/>/<see cref="PairedMod"/> are null for baseline (ENGINE / SKSE CORE) classes. The winner/count
+/// facts are DERIVED from the one <see cref="Providers"/> list (the SkseFileEntry pattern — review finding: carried
+/// copies of a derivable fact can drift). Deadness has exactly ONE owner — the renderer's Judge/BestFate, which also
+/// adjudicates version-locked-vs-runtime — deliberately not a record property.</summary>
 public sealed record NativeClassEntry(
     string RelPath,
     string ClassName,
-    int NativeCount,
     IReadOnlyList<string> NativeFunctions,
-    string? WinningProvider,
-    string ProviderKind,
-    int ProviderCount,
     IReadOnlyList<SkseProvider> Providers,
     NativeProvenance Provenance,
     NativePairingRung? Rung,
     string? PairedMod,
     IReadOnlyList<NativePairedDll> PairedDlls)
 {
-    /// <summary>Candidate DLLs exist and EVERY one carries a static <see cref="NativePairedDll.LoadBlocker"/> — the
-    /// audit's sharpest finding: the scripts are installed and paired, and nothing that could implement them loads.</summary>
-    public bool PairedAllDead => PairedDlls.Count > 0 && PairedDlls.All(d => d.LoadBlocker is not null);
+    /// <summary>How many native functions the class declares — always <see cref="NativeFunctions"/>' count.</summary>
+    public int NativeCount => NativeFunctions.Count;
+    /// <summary>The VFS winner's provider name (first in <see cref="Providers"/>), or null if nothing provides it.</summary>
+    public string? WinningProvider => Providers.Count > 0 ? Providers[0].Name : null;
+    /// <summary>The winner's kind ("loose" | "BSA"), or "none" when unprovided.</summary>
+    public string ProviderKind => Providers.Count > 0 ? Providers[0].Kind : "none";
+    /// <summary>How many sources ship this exact file — &gt; 1 is contention worth surfacing.</summary>
+    public int ProviderCount => Providers.Count;
 }
 
 /// <summary>A .pex whose winning copy could not be parsed — a NAMED note (Q3), never a silent skip.</summary>
@@ -5358,14 +5449,15 @@ public sealed record NativeUnreadablePex(string RelPath, string? WinningProvider
 
 /// <summary>The data behind housecarl_native_pairing_audit: every native-declaring class classified and (for third
 /// parties) paired, the scan accounting (<see cref="PexScanned"/> total compiled scripts examined), the unreadable
-/// notes, whether a game-root skse64 loader is visible (<see cref="SkseLoaderSeen"/> — the SKSE-CORE sanity note), the
-/// installed game runtime when resolvable (<see cref="InstalledRuntime"/>, null = unknown → version-LOCKED findings
-/// degrade to "verify"), and the build-level Q3 caveats.</summary>
+/// notes, whether an skse64 loader is visible (<see cref="SkseLoaderSeen"/> — the SKSE-CORE sanity note; tri-state:
+/// null = the check itself failed, "could not check", never rendered as a definite absence — Q3), the installed game
+/// runtime when resolvable (<see cref="InstalledRuntime"/>, null = unknown → version-LOCKED findings degrade to
+/// "verify"), and the build-level Q3 caveats.</summary>
 public sealed record NativePairingAuditData(
     IReadOnlyList<NativeClassEntry> Classes,
     int PexScanned,
     IReadOnlyList<NativeUnreadablePex> Unreadable,
-    bool SkseLoaderSeen,
+    bool? SkseLoaderSeen,
     string? InstalledRuntime,
     IReadOnlyList<string> BsaFailures,
     bool ReadIncomplete,

--- a/src/housecarl-mcp/SkseTools.cs
+++ b/src/housecarl-mcp/SkseTools.cs
@@ -48,6 +48,37 @@ public static class SkseTools
         return SkseInventoryWire.Render(data, filter, max_chars > 0 ? max_chars : 80_000);
     });
 
+    [McpServerTool(Name = "housecarl_native_pairing_audit", ReadOnly = true, Title = "Native Papyrus declarations vs the DLLs that implement them (pairing audit)"),
+     Description(
+         "Cross-check the native Papyrus functions the ACTIVE order's compiled scripts declare against the SKSE DLLs that must " +
+         "implement them — the seam where 'a mod's scripts are installed but its DLL is missing, won't load on this game version, " +
+         "or is 32-bit/BSA-packed/subfolder-shipped' hides. A native function is ONE thing declared in TWO places (a .pex class " +
+         "with a native-flagged function + a DLL registering the implementation at runtime); the halves ship as separate files and " +
+         "fail INDEPENDENTLY, and the engine's response is a cryptic 'unable to bind' log + calls that silently no-op. Scans the " +
+         "winning copy of EVERY compiled script (loose + BSA), keeps the baseline honest by construction (a class carried by an " +
+         "official archive is the ENGINE's — even when SKSE's loose override wins the file; skse64's own script additions are " +
+         "SKSE CORE, implemented by the game-root loader), then pairs each remaining class to the DLLs its provider mod — or a mod " +
+         "in its conflict chain, the bundling case — ships under SKSE\\Plugins. Leads with the findings: PAIRED-BUT-DEAD (scripts " +
+         "installed, and every candidate DLL statically will not load — wrong game runtime for a version-LOCKED plugin, BSA-only, " +
+         "subfolder, 32-bit, unreadable) and UNPAIRED (no DLL in sight — a VERIFY flag, typically a declaration copy of a framework " +
+         "you don't have; never called 'broken', because registration is runtime behavior — the tier-E ceiling this tool never " +
+         "crosses). It answers 'is the declaration↔implementation pairing plausible and healthy', NEVER 'does the DLL register " +
+         "exactly these functions'. Pass filter= a class, mod, or DLL substring for full detail — the native function names, the " +
+         "pairing evidence, each candidate DLL's manifest and load verdict, the conflict chains. Read-only.")]
+    public static string NativePairingAudit(
+        LoadOrderService svc,
+        [Description("Optional. A script CLASS name, providing-mod, paired-mod, or DLL filename substring (case-insensitive). " +
+            "Shows full detail for every matching class: declared native functions, pairing rung, candidate DLL manifests and " +
+            "load verdicts, conflict chains. Omit for the whole-order audit (findings first, then the accounted-for baseline).")]
+            string? filter = null,
+        [Description("Optional. Max characters before lists are cut with an explicit notice. 0 = the server default (~80k).")]
+            int max_chars = 0) => Guard.Tool("housecarl_native_pairing_audit", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+        var data = svc.NativePairingAudit();
+        return NativePairingWire.Render(data, filter, max_chars > 0 ? max_chars : 80_000);
+    });
+
     [McpServerTool(Name = "housecarl_skse_config_audit", ReadOnly = true, Title = "SKSE config references vs the load order (reference-validity audit)"),
      Description(
          "Cross-check the form references SKSE-plugin CONFIGS declare against the real records of the ACTIVE load order — so a " +
@@ -126,19 +157,30 @@ static class SkseInventoryWire
         // ── Diagnostic subsets, FIRST and in full (the point of the tool). ──
         if (locked.Count > 0)
         {
-            var distinctRuntimes = locked.SelectMany(e => e.Plugin!.Version!.CompatibleVersions)
-                .Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+            // With the installed runtime resolved this is PASS/FAIL per plugin; without it, the honest degrade is
+            // the original "verify each" wording (the native-pairing audit's §4d upgrade, shared here).
             sb.Append("\n[!] version-LOCKED plugins (").Append(locked.Count)
-              .Append(") — load ONLY on their listed runtime(s); a mismatch with your game version = won't load:\n");
+              .Append(") — load ONLY on their listed runtime(s)");
+            sb.Append(d.InstalledRuntime is { } rt0
+                ? $"; installed game runtime is {rt0}:\n"
+                : "; a mismatch with your game version = won't load:\n");
             AppendCapped(sb, locked, cap, e =>
             {
                 var v = e.Plugin!.Version!;
                 string rt = v.CompatibleVersions.Count > 0 ? string.Join(", ", v.CompatibleVersions) : "(none listed!)";
-                return $"  - {e.FileName} → {rt}   [\"{v.Name}\"{Provider(e)}]";
+                string verdict = d.InstalledRuntime is { } inst
+                    ? (SksePluginReader.RuntimeCompatible(v, inst) ? "  = your game, loads" : "  ≠ your game — will NOT load")
+                    : "";
+                return $"  - {e.FileName} → {rt}{verdict}   [\"{v.Name}\"{Provider(e)}]";
             });
-            if (distinctRuntimes.Count > 1)
-                sb.Append("      ↑ these target DIFFERENT runtimes (").Append(string.Join(", ", distinctRuntimes))
-                  .Append(") — verify each matches your game version.\n");
+            if (d.InstalledRuntime is null)
+            {
+                var distinctRuntimes = locked.SelectMany(e => e.Plugin!.Version!.CompatibleVersions)
+                    .Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+                if (distinctRuntimes.Count > 1)
+                    sb.Append("      ↑ these target DIFFERENT runtimes (").Append(string.Join(", ", distinctRuntimes))
+                      .Append(") — verify each matches your game version (the installed version could not be resolved).\n");
+            }
         }
 
         AppendSubset(sb, "legacy query-only (SE/VR-era — metadata set at runtime, not statically readable)", legacy, cap,
@@ -559,6 +601,226 @@ static class SkseConfigAuditWire
     {
         if (d.ReadIncomplete)
             sb.Append("[!] a BSA failed to read this build, so a config present only in it may be missing from this audit (Q3).\n");
+        foreach (var w in d.Warnings) sb.Append("[!] ").Append(w).Append('\n');
+        foreach (var f in d.BsaFailures) sb.Append("[!] archive read failure: ").Append(f).Append('\n');
+    }
+}
+
+/// <summary>Renders <see cref="NativePairingAuditData"/> as compact, scannable text (housecarl_native_pairing_audit).
+/// Default: a health summary, then the DIAGNOSTICS first and in full — PAIRED-BUT-DEAD (the high-confidence class:
+/// every candidate DLL statically won't load, version-LOCKED mismatches included when the installed runtime is known),
+/// locked-but-unverifiable pairings (runtime unknown → honest degrade), UNPAIRED classes (a verify flag, said so), and
+/// unreadable-.pex notes — then the accounted-for baseline (engine / skse-core counts, paired-healthy classes grouped
+/// by their implementing mod). Bounded by max_chars with explicit cut notices (Q3). filter= shows a class in full:
+/// native function names, pairing evidence, per-DLL manifests + load verdicts, conflict chains.</summary>
+static class NativePairingWire
+{
+    /// <summary>One candidate DLL's static load verdict for the render: LOADS / VERIFY (locked, runtime unknown) /
+    /// DEAD (a named static blocker or a locked-runtime mismatch).</summary>
+    enum DllFate { Loads, Verify, Dead }
+
+    static (DllFate Fate, string Detail) Judge(NativePairedDll d, string? runtime)
+    {
+        if (d.LoadBlocker is { } b) return (DllFate.Dead, b);
+        if (d.Info is not { } info) return (DllFate.Verify, "no static manifest read");   // defensive: blocker-less entries carry Info by construction
+        if (info.Kind == SksePluginReader.SksePluginKind.LegacyQuery)
+            return (DllFate.Loads, "legacy SE/VR plugin — loads, but its metadata is set at runtime (not statically verifiable)");
+        var v = info.Version!;
+        if (v.VersionIndependent)
+            return (DllFate.Loads, $"version-independent ({(v.UsesAddressLibrary ? "Address Library" : "signature scanning")})");
+        string locked = v.CompatibleVersions.Count > 0 ? string.Join(", ", v.CompatibleVersions) : "(none listed!)";
+        if (runtime is null)
+            return (DllFate.Verify, $"version-LOCKED → {locked} — installed game version unknown, verify it matches");
+        return SksePluginReader.RuntimeCompatible(v, runtime)
+            ? (DllFate.Loads, $"version-LOCKED → {locked} = installed {runtime}")
+            : (DllFate.Dead, $"version-LOCKED → {locked} ≠ installed {runtime} — will NOT load on this game version");
+    }
+
+    /// <summary>A paired class's verdict = the BEST fate among its candidate DLLs — the audit can't know WHICH DLL
+    /// implements the class (tier E), so one loadable candidate keeps the pairing plausible.</summary>
+    static DllFate BestFate(NativeClassEntry c, string? runtime)
+    {
+        var best = DllFate.Dead;
+        foreach (var d in c.PairedDlls)
+        {
+            var (f, _) = Judge(d, runtime);
+            if (f == DllFate.Loads) return DllFate.Loads;
+            if (f == DllFate.Verify) best = DllFate.Verify;
+        }
+        return best;
+    }
+
+    public static string Render(NativePairingAuditData d, string? filter, int cap)
+    {
+        if (filter is { Length: > 0 }) return RenderFiltered(d, filter.Trim(), cap);
+
+        var engine = d.Classes.Where(c => c.Provenance == NativeProvenance.Engine).ToList();
+        var skseCore = d.Classes.Where(c => c.Provenance == NativeProvenance.SkseCore).ToList();
+        var third = d.Classes.Where(c => c.Provenance == NativeProvenance.ThirdParty).ToList();
+        var unpaired = third.Where(c => c.Rung == NativePairingRung.Unpaired).ToList();
+        var paired = third.Where(c => c.Rung != NativePairingRung.Unpaired).ToList();
+        var dead = paired.Where(c => BestFate(c, d.InstalledRuntime) == DllFate.Dead).ToList();
+        var verify = paired.Where(c => BestFate(c, d.InstalledRuntime) == DllFate.Verify).ToList();
+        var healthy = paired.Where(c => BestFate(c, d.InstalledRuntime) == DllFate.Loads).ToList();
+
+        var sb = new StringBuilder();
+        sb.Append("native pairing audit — profile '").Append(d.ProfileName).Append("' — ")
+          .Append(d.PexScanned).Append(" compiled script(s) scanned, ").Append(d.Classes.Count)
+          .Append(" class(es) declare native functions\n");
+        if (d.InstalledRuntime is { } rt) sb.Append("installed game runtime: ").Append(rt).Append('\n');
+        else sb.Append("installed game runtime: could not be resolved — version-LOCKED findings degrade to 'verify'\n");
+
+        if (dead.Count == 0 && unpaired.Count == 0 && verify.Count == 0)
+            sb.Append("✓ every third-party native class pairs to a mod whose DLL statically loads — nothing dead, nothing unpaired.\n");
+        else
+        {
+            sb.Append(dead.Count > 0 ? "[!] " : "✓ no dead pairings. ");
+            if (dead.Count > 0) sb.Append(dead.Count).Append(" class(es) PAIRED BUT DEAD — scripts installed, nothing that could implement them loads");
+            if (verify.Count > 0) sb.Append(dead.Count > 0 ? "   ·   " : "").Append(verify.Count).Append(" pairing(s) need a version check");
+            if (unpaired.Count > 0) sb.Append(dead.Count > 0 || verify.Count > 0 ? "   ·   " : "").Append(unpaired.Count).Append(" class(es) UNPAIRED (verify)");
+            sb.Append('\n');
+        }
+
+        // ── Diagnostics FIRST, in full (the point of the tool). ──
+        if (dead.Count > 0)
+        {
+            sb.Append("\nPAIRED BUT DEAD — the high-confidence finding: every candidate DLL statically will not load, so every native these scripts declare is a silent no-op in game (").Append(dead.Count).Append("):\n");
+            AppendCapped(sb, dead, cap, c => DeadLine(c, d.InstalledRuntime));
+        }
+        if (verify.Count > 0)
+        {
+            sb.Append("\npaired, version-LOCKED, runtime unknown — verify the listed runtime matches your game (").Append(verify.Count).Append("):\n");
+            AppendCapped(sb, verify, cap, c => DeadLine(c, d.InstalledRuntime));
+        }
+        if (unpaired.Count > 0)
+        {
+            sb.Append("\nUNPAIRED — no mod shipping these scripts (winner or chain) ships any SKSE plugin DLL (").Append(unpaired.Count)
+              .Append("). A VERIFY flag, not 'broken': most often a declaration copy of a framework that isn't installed — the calls will silently no-op if anything uses them:\n");
+            AppendCapped(sb, unpaired, cap, c =>
+                $"  - {c.ClassName} ({c.NativeCount} native fn) ← {c.WinningProvider ?? "(no provider)"} ({c.ProviderKind})");
+        }
+        if (d.Unreadable.Count > 0)
+        {
+            sb.Append("\nunreadable .pex — could not be parsed, NOT counted as native-free (").Append(d.Unreadable.Count).Append("):\n");
+            AppendCapped(sb, d.Unreadable, cap, u => $"  - {u.RelPath}: {u.Reason}{(u.WinningProvider is { } p ? $"  [← {p}]" : "")}");
+        }
+
+        // ── Accounted-for baseline — everything that ISN'T a finding, so nothing is silently dropped (Q3). ──
+        sb.Append("\naccounted for: ").Append(engine.Count).Append(" engine class(es) (carried by an official archive — implemented by the game executable) · ")
+          .Append(skseCore.Count).Append(" SKSE-core class(es) (skse64's script additions — implemented by the game-root loader)");
+        if (skseCore.Count > 0 && !d.SkseLoaderSeen)
+            sb.Append("\n  [!] SKSE-core classes are present but no skse64 loader is visible in the game root — if SKSE isn't actually installed, every one of these is dead");
+        sb.Append("\npaired healthy (").Append(healthy.Count).Append(" class(es)) — implementing mod ← its classes:\n");
+        foreach (var g in healthy.GroupBy(c => c.PairedMod ?? "(?)", StringComparer.OrdinalIgnoreCase)
+                     .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            if (sb.Length >= cap) { sb.Append("  ... [remaining healthy groups omitted; raise max_chars]\n"); break; }
+            sb.Append("  - ").Append(g.Key).Append(": ").Append(string.Join(", ", g.Select(c => c.ClassName).OrderBy(n => n, StringComparer.OrdinalIgnoreCase))).Append('\n');
+        }
+
+        sb.Append("\n(scope: what the winning compiled scripts DECLARE, statically paired to what their mods ship. 'Paired' means the " +
+                  "co-shipment evidence is plausible and a candidate DLL loads — NEVER that the DLL registers exactly these functions " +
+                  "(registration is runtime behavior, the honest ceiling). Which mods CALL an unpaired class is not scanned (a possible Wave 2).)\n");
+        AppendCaveats(sb, d);
+        sb.Append("\n→ filter='<class/mod/DLL>' for full detail: native function names, pairing evidence, per-DLL manifests and load verdicts.");
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    /// <summary>The one-block render of a dead/verify pairing: the class line, then each candidate DLL's fate.</summary>
+    static string DeadLine(NativeClassEntry c, string? runtime)
+    {
+        var sb = new StringBuilder();
+        sb.Append("  - ").Append(c.ClassName).Append(" (").Append(c.NativeCount).Append(" native fn) ← ")
+          .Append(c.WinningProvider ?? "(no provider)")
+          .Append(c.Rung == NativePairingRung.ChainMod ? $" — paired via the conflict chain to {c.PairedMod}" : $" — paired to {c.PairedMod}");
+        foreach (var dll in c.PairedDlls)
+        {
+            var (fate, detail) = Judge(dll, runtime);
+            sb.Append("\n      ").Append(fate switch { DllFate.Dead => "[DEAD] ", DllFate.Verify => "[VERIFY] ", _ => "[LOADS] " })
+              .Append(dll.Group.Length > 0 ? dll.Group + "\\" : "").Append(dll.FileName).Append(" — ").Append(detail);
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>filter= : full detail for every matching class (by class name, path, provider, paired mod, or a
+    /// candidate DLL's filename) — the declared native functions, the pairing evidence rung, each candidate DLL's
+    /// manifest + load verdict, and the conflict chain.</summary>
+    static string RenderFiltered(NativePairingAuditData d, string filter, int cap)
+    {
+        bool In(string? s) => s is not null && s.Contains(filter, StringComparison.OrdinalIgnoreCase);
+        bool Match(NativeClassEntry c) => In(c.ClassName) || In(c.RelPath) || In(c.WinningProvider) || In(c.PairedMod)
+            || c.PairedDlls.Any(x => In(x.FileName)) || c.Providers.Any(p => In(p.Name));
+        var hits = d.Classes.Where(Match).OrderBy(c => c.ClassName, StringComparer.OrdinalIgnoreCase).ToList();
+
+        var sb = new StringBuilder();
+        sb.Append("native pairing audit — filter '").Append(filter).Append("' — ")
+          .Append(hits.Count).Append(" class(es) match [profile '").Append(d.ProfileName).Append("']\n");
+        if (hits.Count == 0)
+        {
+            // The suggestion pool spans EVERY axis Match filters on (the tier-B lesson): class names, providers,
+            // paired mods, and DLL filenames. PluginNameSuggest dedups + skips empties.
+            var pool = d.Classes.Select(c => c.ClassName)
+                .Concat(d.Classes.Select(c => c.WinningProvider).Where(p => !string.IsNullOrEmpty(p)).Select(p => p!))
+                .Concat(d.Classes.Select(c => c.PairedMod).Where(p => !string.IsNullOrEmpty(p)).Select(p => p!))
+                .Concat(d.Classes.SelectMany(c => c.PairedDlls.Select(x => x.FileName)));
+            sb.Append("\nno native-declaring class matched. ").Append(HousecarlCore.PluginNameSuggest.DidYouMean(filter, pool));
+            return sb.ToString().TrimEnd('\n');
+        }
+
+        int shown = 0;
+        foreach (var c in hits)
+        {
+            if (sb.Length >= cap) { sb.Append("\n  ... [showing ").Append(shown).Append(" of ").Append(hits.Count).Append(" classes; raise max_chars]\n"); break; }
+            sb.Append('\n').Append(c.ClassName).Append("  (").Append(c.RelPath).Append(")\n");
+            sb.Append("  provenance: ").Append(c.Provenance switch
+            {
+                NativeProvenance.Engine => "ENGINE — carried by an official archive; implemented by the game executable (baseline)",
+                NativeProvenance.SkseCore => "SKSE CORE — skse64's script additions; implemented by the game-root loader (baseline)",
+                _ => c.Rung switch
+                {
+                    NativePairingRung.SameMod => $"third-party, paired to its own provider ({c.PairedMod})",
+                    NativePairingRung.ChainMod => $"third-party, paired via the conflict chain to {c.PairedMod}",
+                    _ => "third-party, UNPAIRED — no mod in this file's chain ships any SKSE plugin DLL (verify)",
+                },
+            }).Append('\n');
+            if (c.ProviderCount > 1)
+                sb.Append("  [!] contested by ").Append(c.ProviderCount).Append(" sources (winner scanned): ")
+                  .Append(string.Join(" › ", c.Providers.Select(p => $"{p.Name} ({p.Kind})"))).Append('\n');
+            else
+                sb.Append("  provider: ").Append(c.WinningProvider ?? "(none)").Append(" (").Append(c.ProviderKind).Append(")\n");
+            foreach (var dll in c.PairedDlls)
+            {
+                var (fate, detail) = Judge(dll, d.InstalledRuntime);
+                sb.Append("  ").Append(fate switch { DllFate.Dead => "[DEAD]", DllFate.Verify => "[VERIFY]", _ => "[LOADS]" })
+                  .Append(' ').Append(dll.Group.Length > 0 ? dll.Group + "\\" : "").Append(dll.FileName);
+                if (dll.Info?.Version is { } v) sb.Append("  \"").Append(v.Name).Append("\" v").Append(v.PluginVersion);
+                sb.Append(" — ").Append(detail).Append('\n');
+            }
+            sb.Append("  native functions (").Append(c.NativeCount).Append("): ");
+            var fns = string.Join(", ", c.NativeFunctions);
+            if (sb.Length + fns.Length > cap && c.NativeCount > 8)
+                sb.Append(string.Join(", ", c.NativeFunctions.Take(8))).Append(", ... [").Append(c.NativeCount - 8).Append(" more; raise max_chars]");
+            else sb.Append(fns);
+            sb.Append('\n');
+            shown++;
+        }
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    static void AppendCapped<T>(StringBuilder sb, IReadOnlyList<T> items, int cap, Func<T, string> line)
+    {
+        int shown = 0;
+        foreach (var e in items)
+        {
+            if (sb.Length >= cap) { sb.Append("  ... [showing ").Append(shown).Append(" of ").Append(items.Count).Append("; raise max_chars or use filter= to see all]\n"); break; }
+            sb.Append(line(e)).Append('\n'); shown++;
+        }
+    }
+
+    static void AppendCaveats(StringBuilder sb, NativePairingAuditData d)
+    {
+        if (d.ReadIncomplete)
+            sb.Append("[!] a BSA failed to read this build, so a script present only in it may be missing from this audit (Q3).\n");
         foreach (var w in d.Warnings) sb.Append("[!] ").Append(w).Append('\n');
         foreach (var f in d.BsaFailures) sb.Append("[!] archive read failure: ").Append(f).Append('\n');
     }

--- a/src/housecarl-mcp/SkseTools.cs
+++ b/src/housecarl-mcp/SkseTools.cs
@@ -624,7 +624,16 @@ static class NativePairingWire
         if (d.LoadBlocker is { } b) return (DllFate.Dead, b);
         if (d.Info is not { } info) return (DllFate.Verify, "no static manifest read");   // defensive: blocker-less entries carry Info by construction
         if (info.Kind == SksePluginReader.SksePluginKind.LegacyQuery)
-            return (DllFate.Loads, "legacy SE/VR plugin — loads, but its metadata is set at runtime (not statically verifiable)");
+        {
+            // The AE loader loads ONLY version-data plugins (SksePluginReader's first bullet) — a query-only SE/VR-era
+            // plugin will NOT load on a 1.6+ runtime (review finding: rendering these LOADS buried the tool's headline
+            // breakage class, the abandoned SE-era mod on an AE game).
+            if (runtime is { } rt2 && SksePluginReader.IsAeRuntime(rt2))
+                return (DllFate.Dead, $"query-only SE/VR-era plugin — the AE loader (installed game is {rt2}) loads only version-data plugins, so it will NOT load");
+            if (runtime is not null)
+                return (DllFate.Loads, "legacy SE/VR plugin — loads on this SE runtime, but its metadata is set at runtime (not statically verifiable)");
+            return (DllFate.Verify, "legacy SE/VR-era query-only plugin — loads on SE (1.5.x) but NOT on an AE (1.6+) runtime; installed game version unknown, verify");
+        }
         var v = info.Version!;
         if (v.VersionIndependent)
             return (DllFate.Loads, $"version-independent ({(v.UsesAddressLibrary ? "Address Library" : "signature scanning")})");
@@ -658,10 +667,13 @@ static class NativePairingWire
         var skseCore = d.Classes.Where(c => c.Provenance == NativeProvenance.SkseCore).ToList();
         var third = d.Classes.Where(c => c.Provenance == NativeProvenance.ThirdParty).ToList();
         var unpaired = third.Where(c => c.Rung == NativePairingRung.Unpaired).ToList();
-        var paired = third.Where(c => c.Rung != NativePairingRung.Unpaired).ToList();
-        var dead = paired.Where(c => BestFate(c, d.InstalledRuntime) == DllFate.Dead).ToList();
-        var verify = paired.Where(c => BestFate(c, d.InstalledRuntime) == DllFate.Verify).ToList();
-        var healthy = paired.Where(c => BestFate(c, d.InstalledRuntime) == DllFate.Loads).ToList();
+        // ONE fate pass per paired class (review finding: three Where partitions each re-judged every DLL) — the
+        // section split and the per-DLL tags come from the same Judge, so they can never disagree.
+        var byFate = third.Where(c => c.Rung != NativePairingRung.Unpaired)
+            .ToLookup(c => BestFate(c, d.InstalledRuntime));
+        var dead = byFate[DllFate.Dead].ToList();
+        var verify = byFate[DllFate.Verify].ToList();
+        var healthy = byFate[DllFate.Loads].ToList();
 
         var sb = new StringBuilder();
         sb.Append("native pairing audit — profile '").Append(d.ProfileName).Append("' — ")
@@ -671,7 +683,12 @@ static class NativePairingWire
         else sb.Append("installed game runtime: could not be resolved — version-LOCKED findings degrade to 'verify'\n");
 
         if (dead.Count == 0 && unpaired.Count == 0 && verify.Count == 0)
-            sb.Append("✓ every third-party native class pairs to a mod whose DLL statically loads — nothing dead, nothing unpaired.\n");
+        {
+            sb.Append("✓ every third-party native class pairs to a mod whose DLL statically loads — nothing dead, nothing unpaired");
+            // The checkmark must not overclaim a universal the scan didn't verify (review finding): unreadable
+            // .pex files were never examined, and they're where an unpaired class could hide.
+            sb.Append(d.Unreadable.Count > 0 ? $" ({d.Unreadable.Count} unreadable .pex NOT examined — see below).\n" : ".\n");
+        }
         else
         {
             sb.Append(dead.Count > 0 ? "[!] " : "✓ no dead pairings. ");
@@ -708,8 +725,12 @@ static class NativePairingWire
         // ── Accounted-for baseline — everything that ISN'T a finding, so nothing is silently dropped (Q3). ──
         sb.Append("\naccounted for: ").Append(engine.Count).Append(" engine class(es) (carried by an official archive — implemented by the game executable) · ")
           .Append(skseCore.Count).Append(" SKSE-core class(es) (skse64's script additions — implemented by the game-root loader)");
-        if (skseCore.Count > 0 && !d.SkseLoaderSeen)
-            sb.Append("\n  [!] SKSE-core classes are present but no skse64 loader is visible in the game root — if SKSE isn't actually installed, every one of these is dead");
+        // Tri-state (Q3): false = checked, genuinely absent → the definite note; null = the CHECK failed → say that,
+        // never render a failed check as a checked-and-absent verdict (review finding).
+        if (skseCore.Count > 0 && d.SkseLoaderSeen == false)
+            sb.Append("\n  [!] SKSE-core classes are present but no skse64 loader is visible (game root or enabled mods' Root\\ folders) — if SKSE isn't actually installed, every one of these is dead");
+        else if (skseCore.Count > 0 && d.SkseLoaderSeen is null)
+            sb.Append("\n  (skse64 loader visibility could not be checked)");
         sb.Append("\npaired healthy (").Append(healthy.Count).Append(" class(es)) — implementing mod ← its classes:\n");
         foreach (var g in healthy.GroupBy(c => c.PairedMod ?? "(?)", StringComparer.OrdinalIgnoreCase)
                      .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase))
@@ -734,11 +755,20 @@ static class NativePairingWire
           .Append(c.WinningProvider ?? "(no provider)")
           .Append(c.Rung == NativePairingRung.ChainMod ? $" — paired via the conflict chain to {c.PairedMod}" : $" — paired to {c.PairedMod}");
         foreach (var dll in c.PairedDlls)
-        {
-            var (fate, detail) = Judge(dll, runtime);
-            sb.Append("\n      ").Append(fate switch { DllFate.Dead => "[DEAD] ", DllFate.Verify => "[VERIFY] ", _ => "[LOADS] " })
-              .Append(dll.Group.Length > 0 ? dll.Group + "\\" : "").Append(dll.FileName).Append(" — ").Append(detail);
-        }
+            sb.Append("\n      ").Append(DllLine(dll, runtime, withVersion: false));
+        return sb.ToString();
+    }
+
+    /// <summary>ONE per-DLL fate line for BOTH the default and the filter= views (review finding: two hand-kept copies
+    /// of the same line drift): "[FATE] group\file ("name" vX)? — detail".</summary>
+    static string DllLine(NativePairedDll dll, string? runtime, bool withVersion)
+    {
+        var (fate, detail) = Judge(dll, runtime);
+        var sb = new StringBuilder();
+        sb.Append(fate switch { DllFate.Dead => "[DEAD] ", DllFate.Verify => "[VERIFY] ", _ => "[LOADS] " })
+          .Append(dll.Group.Length > 0 ? dll.Group + "\\" : "").Append(dll.FileName);
+        if (withVersion && dll.Info?.Version is { } v) sb.Append("  \"").Append(v.Name).Append("\" v").Append(v.PluginVersion);
+        sb.Append(" — ").Append(detail);
         return sb.ToString();
     }
 
@@ -764,6 +794,8 @@ static class NativePairingWire
                 .Concat(d.Classes.Select(c => c.PairedMod).Where(p => !string.IsNullOrEmpty(p)).Select(p => p!))
                 .Concat(d.Classes.SelectMany(c => c.PairedDlls.Select(x => x.FileName)));
             sb.Append("\nno native-declaring class matched. ").Append(HousecarlCore.PluginNameSuggest.DidYouMean(filter, pool));
+            sb.Append('\n');
+            AppendCaveats(sb, d);   // a "no match" over an incompletely-read build must carry the caveat (Q3)
             return sb.ToString().TrimEnd('\n');
         }
 
@@ -789,13 +821,7 @@ static class NativePairingWire
             else
                 sb.Append("  provider: ").Append(c.WinningProvider ?? "(none)").Append(" (").Append(c.ProviderKind).Append(")\n");
             foreach (var dll in c.PairedDlls)
-            {
-                var (fate, detail) = Judge(dll, d.InstalledRuntime);
-                sb.Append("  ").Append(fate switch { DllFate.Dead => "[DEAD]", DllFate.Verify => "[VERIFY]", _ => "[LOADS]" })
-                  .Append(' ').Append(dll.Group.Length > 0 ? dll.Group + "\\" : "").Append(dll.FileName);
-                if (dll.Info?.Version is { } v) sb.Append("  \"").Append(v.Name).Append("\" v").Append(v.PluginVersion);
-                sb.Append(" — ").Append(detail).Append('\n');
-            }
+                sb.Append("  ").Append(DllLine(dll, d.InstalledRuntime, withVersion: true)).Append('\n');
             sb.Append("  native functions (").Append(c.NativeCount).Append("): ");
             var fns = string.Join(", ", c.NativeFunctions);
             if (sb.Length + fns.Length > cap && c.NativeCount > 8)
@@ -804,6 +830,10 @@ static class NativePairingWire
             sb.Append('\n');
             shown++;
         }
+        // The Q3 caveats ride the FILTERED view too (review finding): "no match" or a partial hit over a build whose
+        // BSA failed to read must never read as a clean answer.
+        sb.Append('\n');
+        AppendCaveats(sb, d);
         return sb.ToString().TrimEnd('\n');
     }
 


### PR DESCRIPTION
## What

The **native-function pairing audit** (plan `dev/plans/SKSE_NATIVE_PAIRING_AUDIT_PLAN_2026-07-16.md`, LOCKED by Aaron; Wave 1 complete). Cross-checks the native Papyrus functions the order's **scripts** declare against the **DLLs** that must implement them — the seam none of `validate_scripts` (property binding), `skse_inventory` (DLL layer), or `skse_config_audit` (config layer) sees across: scripts installed, DLL missing / wrong-runtime / 32-bit / BSA-packed → cryptic "unable to bind" + silent no-op calls.

**Tool count 44 → 45.** Read-only. Commits, in plan order:

1. **`b69c8bc` scanner** — `NativePairing.ExtractNativeClasses` (pure, core; native = raw flag bit1, the documented Mutagen off-by-one) + the service sweep: one-gate capture, parallel winning-pex parse (loose + BSA), the ENGINE carve-out (official archive = Skyrim.ini base block ∪ `Implicits` BaseMasters-owned — by construction, no name list; official presence anywhere in the chain keeps a class baseline even under SKSE's winning loose overrides), the SKSE-CORE rescue (engine-override co-shipment), the §4c same-mod/chain/unpaired ladder.
2. **`8517a25` game runtime resolution** (§8.4, Aaron-locked include) — `InstalledGameRuntime()` reads the exe the order actually runs (load-order dir first — Stock Game truth — locator fallback); `RuntimeCompatible`/`VersionsEqual` zero-padded numeric compare.
3. **`a7c6ee2` tool + renderer** — diagnostics-first render (PAIRED-BUT-DEAD → locked-verify → UNPAIRED → unreadable → baseline accounting), honest ceiling stated in-band; **rides along:** `skse_inventory`'s version-LOCKED section is now PASS/FAIL per plugin when the runtime resolves.
4. **`5e72b92` guard** — `native-pairing-guard` (extractor off-by-one pin, provenance anchor, ladder, runtime compare, 13 render arms via InternalsVisibleTo) + `native-pairing-real` live harness. ci-all **96/96**.
5. **`2dfc2d6` live-gate fixes** — (a) BSA provider names are archive filenames, not mods → `ShipperOfArchivePath` translation (15 false UNPAIRED → 2, both spot-checked true positives); (b) skse64-loader sanity check now sees MO2 **Root Builder** layouts.

## Live gate (ARR 2.0, §6.5 — all bars met)

- **47,950 pex scanned, 217 native classes** — 55 ENGINE + 22 SKSE-CORE, **zero vanilla noise** (the §7 non-negotiable).
- **Zero "will not load" claims** (nothing dead on this healthy order — nothing to falsify); 10 version-LOCKED DLLs all adjudicate `= your game, loads` against the resolved **1.6.1170.0** (`[BUILD-TEST]` PASS — carries to the tier D plan per §9).
- **2 UNPAIRED flags, both spot-checked genuine**: `FakeElixirScript` re-declares vanilla `Actor.DamageActorValue` as its own native (binds to nothing); `VL_Utility` declares 2 natives no DLL implements.
- **Scan cost, factually: ~130 s cold** (parallelized; BSA reads + full Pex parses dominate). Follow-up filed in `dev/BACKLOG.md`: an (mtime,size)-keyed cross-call cache would make repeat calls near-free.
- 8 unreadable `.pex` (the known Mutagen unreadable-pex class: FSMP, MfgFix, QuickLootIE) surface as named notes.

## Release note

No version bump here — the count ripple (45 tools) + changelog land at the next release cut per convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)