### PR TITLE
SKSE tier D — static peek (imports + strings) + the pairing audit's debug-build blocker

### DIFF
--- a/src/housecarl-core/SksePeek.cs
+++ b/src/housecarl-core/SksePeek.cs
@@ -28,9 +28,15 @@ public sealed record SksePeekResult(
     long BytesScanned,
     string? Note)
 {
-    /// <summary>True when nothing was scanned at all (an unreadable image) — the caller must not render this as a clean
-    /// "embeds nothing" (Q3). <see cref="Note"/> carries the reason.</summary>
-    public bool Failed => Note is not null && BytesScanned == 0;
+    /// <summary>Why the scan produced nothing — set ONLY on failure (unreadable image / past the size cap), null on
+    /// every successful scan. There is deliberately no partial-scan state: an image past <see cref="SksePeek.SizeCap"/>
+    /// is refused and NAMED rather than half-read, because a half-read image's "nothing embedded" would be a silent
+    /// lie. So <see cref="Note"/> is exactly the failure channel, and <see cref="Failed"/> reads off it.</summary>
+    public string? Note { get; init; } = Note;
+
+    /// <summary>True when the scan did not happen — the caller must not render this as a clean "embeds nothing" (Q3).
+    /// <see cref="Note"/> carries the reason.</summary>
+    public bool Failed => Note is not null;
 }
 
 public static class SksePeek
@@ -121,16 +127,26 @@ public static class SksePeek
 
     /// <summary>The plugin FILENAME a run references, or null. Returns the filename alone (not the whole run) because the
     /// load-order cross-check keys on it — "Data\Dawnguard.esm" and "Dawnguard.esm" are the same reference. A run is a
-    /// plugin ref only when the name ENDS the run: a .esp mid-string is a format template or a substring, not a name.</summary>
+    /// plugin ref only when the name ENDS the run: a .esp mid-string is a format template or a substring, not a name.
+    ///
+    /// This classifier is held to a STRICTER bar than <see cref="IsConfigPath"/>, and deliberately: a config path is only
+    /// ever SHOWN ("suggestive of its config surface"), whereas a plugin name is ADJUDICATED against the load order and
+    /// can come back "[!] NOT in your load order". A false positive here is therefore a false ALARM, not just noise — so
+    /// anything that isn't shaped like a real filename is dropped rather than guessed at.</summary>
     static string? PluginRefIn(string run)
     {
         if (!PluginExts.Any(e => run.EndsWith(e, StringComparison.OrdinalIgnoreCase))) return null;
         int cut = run.LastIndexOfAny(['\\', '/']);
         string name = cut >= 0 ? run[(cut + 1)..] : run;
         if (name.Length <= 4) return null;                        // ".esp" alone — an extension constant, not a reference
-        // A plugin filename is a filename: a run carrying separators/quotes past the last slash is a sentence about a
-        // plugin, not the name of one. Bethesda names allow spaces, dashes, apostrophes, parens.
-        return name.Any(ch => ch is '"' or '\'' or '<' or '>' or '|' or '*' or '?' or ':' or '%') ? null : name;
+        // A plugin filename is a filename: a run carrying quotes/separators past the last slash is a sentence about a
+        // plugin, not the name of one. Bethesda names allow spaces, dashes, apostrophes, parens — so the shape check is
+        // this forbidden-char set, and it must carry BOTH format-string dialects:
+        //   %  → printf ("%s.esp")
+        //   {} → fmt / spdlog / std::format ("{}.esp", "loading {}.esp") — the DOMINANT modern shape, because
+        //        CommonLibSSE-NG plugins log through spdlog. Missing these would adjudicate a log template against the
+        //        load order and flag it ABSENT on every healthy install.
+        return name.Any(ch => ch is '"' or '\'' or '<' or '>' or '|' or '*' or '?' or ':' or '%' or '{' or '}') ? null : name;
     }
 
     /// <summary>Whether a run is path-shaped enough to be part of the DLL's CONFIG surface — the "which files does this
@@ -147,6 +163,10 @@ public static class SksePeek
         // Drop the compiler's own noise: a bare extension, and the C++ type/format soup that trips the extension test
         // ("%s.json", "basic_string<...>.ini"). A real config path has a separator or is a plain filename.
         if (run.Length <= 5) return false;
+        // NOTE the asymmetry with PluginRefIn, which also rejects fmt's {} placeholder: a {}-bearing path is a TEMPLATE
+        // the DLL fills in, and it is still real config-surface signal — "Data/SKSE/Plugins/versionlib-{}.bin" tells you
+        // this plugin reads Address Library, which is worth showing. A config path is only ever SHOWN, so a template
+        // costs nothing; a plugin name is ADJUDICATED, so a template would become a false "NOT in your load order".
         return !run.Contains('%') && !run.Contains('<') && !run.Contains('"');
     }
 }

--- a/src/housecarl-core/SksePeek.cs
+++ b/src/housecarl-core/SksePeek.cs
@@ -1,0 +1,152 @@
+using System.Text;
+
+namespace HousecarlCore;
+
+// ======================================================================
+//  SksePeek — the STRING half of the SKSE tier-D static peek
+//  (housecarl_skse_inventory peek=true; plan dev/plans/SKSE_TIER_D_STATIC_PEEK_PLAN_2026-07-16.md).
+//
+//  Tier D answers "what does this unfamiliar DLL's IMAGE statically contain" — its imports (which ride
+//  the manifest read in SksePluginReader, because they're free there) and the high-signal strings it
+//  embeds, which live here because scanning a whole image is NOT free and so stays opt-in per-DLL.
+//
+//  The honest frame, and the reason this file filters instead of dumping: a string in an image is what
+//  the image CONTAINS, never what the code DOES (tier E is the ceiling), and ABSENCE PROVES NOTHING —
+//  RequiemLP.dll and YASTM.dll embed no plugin names at all, because their form references live in
+//  configs or are built at runtime. "Nothing embedded" is therefore a fact about the image; it is never
+//  "no dependencies". Every renderer of this data must carry that framing.
+// ======================================================================
+
+/// <summary>What one DLL's image statically embeds, filtered to the extraction classes worth reading (tier D).
+/// <see cref="RunsScanned"/> vs the list sizes is the Q3 accounting: the classes are a FILTER over the haystack, and the
+/// cut is stated rather than implied. A raw full-strings dump is deliberately not offered — it is the noisy 95% these
+/// classes exist to remove, and anyone who needs it has real <c>strings</c> tooling.</summary>
+public sealed record SksePeekResult(
+    IReadOnlyList<string> ConfigPaths,
+    IReadOnlyList<string> PluginRefs,
+    int RunsScanned,
+    long BytesScanned,
+    string? Note)
+{
+    /// <summary>True when nothing was scanned at all (an unreadable image) — the caller must not render this as a clean
+    /// "embeds nothing" (Q3). <see cref="Note"/> carries the reason.</summary>
+    public bool Failed => Note is not null && BytesScanned == 0;
+}
+
+public static class SksePeek
+{
+    /// <summary>Per-image byte cap for the string scan. SKSE plugin DLLs are single-digit MB; 64 MB is far above any real
+    /// one, so the cap trips only on the pathological case it exists to NAME (a scan cut is reported, never silent).</summary>
+    public const long SizeCap = 64L * 1024 * 1024;
+
+    /// <summary>Shortest run counted as a string. 4 is the <c>strings(1)</c> convention: shorter runs are overwhelmingly
+    /// code bytes that happen to be printable, and every extraction class here needs more than 4 chars anyway.</summary>
+    const int MinRun = 4;
+
+    static readonly string[] PluginExts = [".esp", ".esm", ".esl"];
+    static readonly string[] ConfigExts = [".ini", ".toml", ".json", ".yaml", ".yml"];
+
+    /// <summary>Peek one DLL off disk. Never throws — an unreadable image returns a <see cref="SksePeekResult.Failed"/>
+    /// result carrying the reason, never an empty-but-clean-looking one (Q3). Read-share + closed before return, the
+    /// no-handle-at-rest discipline <see cref="SksePluginReader"/> holds.</summary>
+    public static SksePeekResult Scan(string filePath)
+    {
+        try
+        {
+            var fi = new FileInfo(filePath);
+            if (fi.Length > SizeCap)
+                return new SksePeekResult([], [], 0, 0,
+                    $"image is {fi.Length / (1024 * 1024)} MB — past the {SizeCap / (1024 * 1024)} MB peek cap; NOT scanned");
+            return ScanBytes(File.ReadAllBytes(filePath));
+        }
+        catch (Exception ex)
+        {
+            return new SksePeekResult([], [], 0, 0, $"could not read the image: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>The pure scan over image bytes — PURE so the skse-peek-guard can pin extraction against planted fixtures
+    /// with no real DLL. Walks the bytes for printable runs in BOTH encodings (ASCII and UTF-16LE: modern C++ plugins use
+    /// wide strings, so scanning only ASCII would silently halve coverage — the exact class of silent gap Q3 forbids),
+    /// then keeps only the runs matching an extraction class.</summary>
+    public static SksePeekResult ScanBytes(ReadOnlySpan<byte> bytes)
+    {
+        var configs = new List<string>();
+        var plugins = new List<string>();
+        var seenCfg = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var seenPlg = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        int runs = 0;
+
+        foreach (var run in Runs(bytes))
+        {
+            runs++;
+            // Plugin-ref FIRST: "Data\Skyrim.esm" is both path-shaped and a plugin reference, and the plugin reference is
+            // the sharper signal (it cross-checks against the load order), so it wins the classification.
+            if (PluginRefIn(run) is { } p) { if (seenPlg.Add(p)) plugins.Add(p); }
+            else if (IsConfigPath(run) && seenCfg.Add(run)) configs.Add(run);
+        }
+        return new SksePeekResult(configs, plugins, runs, bytes.Length, null);
+    }
+
+    /// <summary>Every printable run of at least <see cref="MinRun"/> chars, ASCII then UTF-16LE. UTF-16 is scanned at both
+    /// byte alignments (an image's wide strings are usually 2-aligned, but nothing guarantees it); the two encodings can't
+    /// double-count, because a wide string's interleaved NULs break every ASCII run at length 1.</summary>
+    static IEnumerable<string> Runs(ReadOnlySpan<byte> b)
+    {
+        // A span can't cross an iterator boundary, so collect eagerly — bounded by SizeCap.
+        var outp = new List<string>();
+        var sb = new StringBuilder(64);
+
+        for (int i = 0; i <= b.Length; i++)                       // <= : the final iteration flushes a run ending AT the buffer end
+        {
+            if (i < b.Length && IsPrintable(b[i])) { sb.Append((char)b[i]); continue; }
+            if (sb.Length >= MinRun) outp.Add(sb.ToString());
+            sb.Clear();
+        }
+
+        for (int align = 0; align < 2; align++)
+        {
+            sb.Clear();
+            for (int i = align; i <= b.Length; i += 2)
+            {
+                if (i + 1 < b.Length && IsPrintable(b[i]) && b[i + 1] == 0) { sb.Append((char)b[i]); continue; }
+                if (sb.Length >= MinRun) outp.Add(sb.ToString());
+                sb.Clear();
+            }
+        }
+        return outp;
+    }
+
+    static bool IsPrintable(byte c) => c is >= 0x20 and < 0x7F;
+
+    /// <summary>The plugin FILENAME a run references, or null. Returns the filename alone (not the whole run) because the
+    /// load-order cross-check keys on it — "Data\Dawnguard.esm" and "Dawnguard.esm" are the same reference. A run is a
+    /// plugin ref only when the name ENDS the run: a .esp mid-string is a format template or a substring, not a name.</summary>
+    static string? PluginRefIn(string run)
+    {
+        if (!PluginExts.Any(e => run.EndsWith(e, StringComparison.OrdinalIgnoreCase))) return null;
+        int cut = run.LastIndexOfAny(['\\', '/']);
+        string name = cut >= 0 ? run[(cut + 1)..] : run;
+        if (name.Length <= 4) return null;                        // ".esp" alone — an extension constant, not a reference
+        // A plugin filename is a filename: a run carrying separators/quotes past the last slash is a sentence about a
+        // plugin, not the name of one. Bethesda names allow spaces, dashes, apostrophes, parens.
+        return name.Any(ch => ch is '"' or '\'' or '<' or '>' or '|' or '*' or '?' or ':' or '%') ? null : name;
+    }
+
+    /// <summary>Whether a run is path-shaped enough to be part of the DLL's CONFIG surface — the "which files does this
+    /// image reach for" signal that complements tier B from the other side (tier B audits what a config DECLARES; this
+    /// shows the folder a DLL actually embeds). Suggestive, never a claim the DLL reads it — it is a string in an image.</summary>
+    static bool IsConfigPath(string run)
+    {
+        bool hasCfgExt = ConfigExts.Any(e => run.EndsWith(e, StringComparison.OrdinalIgnoreCase));
+        bool underData = run.Contains("Data\\", StringComparison.OrdinalIgnoreCase)
+                      || run.Contains("Data/", StringComparison.OrdinalIgnoreCase)
+                      || run.Contains("SKSE\\Plugins", StringComparison.OrdinalIgnoreCase)
+                      || run.Contains("SKSE/Plugins", StringComparison.OrdinalIgnoreCase);
+        if (!hasCfgExt && !underData) return false;
+        // Drop the compiler's own noise: a bare extension, and the C++ type/format soup that trips the extension test
+        // ("%s.json", "basic_string<...>.ini"). A real config path has a separator or is a plain filename.
+        if (run.Length <= 5) return false;
+        return !run.Contains('%') && !run.Contains('<') && !run.Contains('"');
+    }
+}

--- a/src/housecarl-core/SksePluginReader.cs
+++ b/src/housecarl-core/SksePluginReader.cs
@@ -77,7 +77,22 @@ public static class SksePluginReader
         SksePluginKind Kind,
         bool? Is64Bit,
         SkseVersionInfo? Version,
-        string? Note);
+        string? Note,
+        IReadOnlyList<string>? Imports = null)
+    {
+        /// <summary>The DLL names this image statically imports — import AND delay-load directories, lower-cased and
+        /// deduplicated (tier D). Tri-state on purpose, the <see cref="Is64Bit"/> discipline: a NON-EMPTY list is what it
+        /// imports; EMPTY means the directories were walked and it genuinely imports nothing; <c>null</c> means the walk
+        /// never happened or FAILED (no optional header / corrupt directory) — an UNKNOWN that must never render as
+        /// "imports nothing" (Q3). Populated on EVERY read because it rides the PE open the manifest read already pays
+        /// for — measured free against the inventory's per-file VFS resolve — which is what lets the Debug-CRT check run
+        /// over the whole layer. The STRING half of tier D is far dearer and stays opt-in per-DLL: see <see cref="SksePeek"/>.</summary>
+        public IReadOnlyList<string>? Imports { get; init; } = Imports;
+
+        /// <summary>The debug-CRT DLLs this image imports — empty when it imports none, or when the walk failed (check
+        /// <see cref="Imports"/> for null before reading absence as proof). See <see cref="DebugCrtImportsOf"/>.</summary>
+        public IReadOnlyList<string> DebugCrtImports => DebugCrtImportsOf(this);
+    }
 
     /// <summary>Read one DLL's static SKSE manifest off disk. Never throws for a bad/odd file — an unreadable image is
     /// reported as <see cref="SksePluginKind.Unreadable"/> with the reason (Q3). Reads the file with a plain read-share
@@ -132,9 +147,13 @@ public static class SksePluginReader
         if (pe.PEHeaders.PEHeader is null)
             return new SksePluginInfo(file, SksePluginKind.Unreadable, is64, null, "no PE optional header");
 
+        // Tier D: walk the imports BEFORE the export classification, so even a DLL we go on to call Unreadable (corrupt
+        // EAT) still reports what it imports — the Debug-CRT verdict doesn't depend on the SKSE manifest being readable.
+        var imports = ReadImportNames(pe);
+
         var exports = ReadExportRvas(pe);
         if (exports is null)   // export directory present but CORRUPT — a parse failure, NOT "no exports" (Q3: don't misclassify a corrupt DLL as a bundled dependency)
-            return new SksePluginInfo(file, SksePluginKind.Unreadable, is64, null, "corrupt PE export directory — could not enumerate exports");
+            return new SksePluginInfo(file, SksePluginKind.Unreadable, is64, null, "corrupt PE export directory — could not enumerate exports", imports);
 
         bool hasVersion = exports.TryGetValue("SKSEPlugin_Version", out int versionRva) && versionRva != 0;
         bool hasQuery = exports.ContainsKey("SKSEPlugin_Query");
@@ -142,11 +161,11 @@ public static class SksePluginReader
 
         if (!hasVersion && !hasQuery && !hasLoad)
             return new SksePluginInfo(file, SksePluginKind.NotSkse, is64, null,
-                "no SKSE export (SKSEPlugin_Version/Query/Load) — a bundled dependency DLL, not a plugin");
+                "no SKSE export (SKSEPlugin_Version/Query/Load) — a bundled dependency DLL, not a plugin", imports);
 
         if (!hasVersion)
             return new SksePluginInfo(file, SksePluginKind.LegacyQuery, is64, null,
-                "legacy SE/VR plugin: exports SKSEPlugin_Query (metadata is filled at runtime), so name/version are not statically readable");
+                "legacy SE/VR plugin: exports SKSEPlugin_Query (metadata is filled at runtime), so name/version are not statically readable", imports);
 
         // Modern: slice the version blob out of its section and decode. A real SKSEPluginVersionData is a FULL
         // 0x350-byte struct whose dataVersion (0x000) is kVersion (>= 1); a version export whose RVA maps to no
@@ -156,9 +175,9 @@ public static class SksePluginReader
         byte[] blob = block.GetReader().ReadBytes(Math.Min(0x350, block.Length));
         if (blob.Length < 0x350 || BitConverter.ToUInt32(blob, 0) == 0)
             return new SksePluginInfo(file, SksePluginKind.Unreadable, is64, null,
-                "exports SKSEPlugin_Version but its RVA does not resolve to a readable version blob (a forwarded or corrupt export)");
+                "exports SKSEPlugin_Version but its RVA does not resolve to a readable version blob (a forwarded or corrupt export)", imports);
         var ver = DecodeVersionBlob(blob);
-        return new SksePluginInfo(file, SksePluginKind.Modern, is64, ver, null);
+        return new SksePluginInfo(file, SksePluginKind.Modern, is64, ver, null, imports);
     }
 
     /// <summary>Decode the raw <c>SKSEPlugin_Version</c> blob bytes into the manifest. PURE + bounds-checked so the CI
@@ -225,6 +244,63 @@ public static class SksePluginReader
         return maj > 1 || (maj == 1 && min >= 6);
     }
 
+    /// <summary>The DEBUG C-runtime DLLs — a plugin importing any of these was built in a Debug configuration and shipped
+    /// that way. CURATED, and curated on purpose: the D-suffix is a naming CONVENTION, not a loader rule, so "ends in d.dll"
+    /// would sweep in innocents (dinput8.dll, d3d11.dll, and every mod DLL ending in 'd'). This is the exact
+    /// Microsoft debug-CRT family — the same posture as the version-blob offset map: a pinned list with its provenance,
+    /// never a guessed pattern. Pinned by the skse-peek-guard.
+    ///
+    /// Why it is load-bearing: these DLLs are NOT redistributable — they ship only with Visual Studio, and are absent from
+    /// a stock Windows install. A plugin importing one fails to load with error 126 (ERROR_MOD_NOT_FOUND) on any machine
+    /// without VS. It is the "Debug-CRT load-126" failure the skse-plugin-authoring corpus records (PR #149): the plugin
+    /// works perfectly for its author (who has VS) and is dead for every user.</summary>
+    public static readonly IReadOnlyList<string> DebugCrtDlls =
+    [
+        "ucrtbased.dll",                                                   // the debug universal CRT
+        "vcruntime140d.dll", "vcruntime140_1d.dll",                        // VC++ 2015-2022 debug runtime (_1 = the x64 EH half)
+        "msvcp140d.dll", "msvcp140_1d.dll", "msvcp140_2d.dll",             // debug C++ standard library
+        "msvcp140d_atomic_wait.dll", "msvcp140_codecvt_ids_d.dll",         // its split-out debug companions
+        "concrt140d.dll",                                                  // debug Concurrency Runtime
+        "mfc140d.dll", "mfc140ud.dll",                                     // debug MFC (rare in plugins, real in tooling DLLs)
+        "msvcr120d.dll", "msvcp120d.dll",                                  // VC++ 2013 debug runtime (pre-CommonLib-era plugins)
+        "msvcr110d.dll", "msvcp110d.dll",                                  // VC++ 2012
+        "msvcr100d.dll", "msvcp100d.dll",                                  // VC++ 2010
+    ];
+
+    /// <summary>The debug-CRT DLLs <paramref name="info"/> imports, in the order the image lists them. EMPTY when it
+    /// imports none — and ALSO empty when <see cref="SksePluginInfo.Imports"/> is null (the walk failed), because absence
+    /// of evidence is not evidence of absence: a caller rendering a "clean" verdict must check <c>Imports is not null</c>
+    /// first (Q3). Pure.</summary>
+    public static IReadOnlyList<string> DebugCrtImportsOf(SksePluginInfo info) =>
+        info.Imports is null ? []
+            : info.Imports.Where(i => DebugCrtDlls.Contains(i, StringComparer.OrdinalIgnoreCase)).ToList();
+
+    /// <summary>Whether <paramref name="dll"/> is resolvable by the Windows loader ON THIS MACHINE — the honest other half
+    /// of the Debug-CRT verdict. "Imports the debug CRT ⇒ will not load" is true only where the debug CRT is ABSENT, which
+    /// is every stock machine but NOT a developer's (Visual Studio installs it). houseCARL runs on the modder's own box, so
+    /// it can check instead of assuming: a flat "will NOT load" on a machine that has the runtime would be exactly the
+    /// confident-wrong answer Q3 forbids — and a modder who authors SKSE plugins is precisely the user who has VS.
+    ///
+    /// Approximates the loader's search order for a DLL loaded from the game root: System32, then the PATH directories.
+    /// (The debug CRT is never in the game root and never side-by-side for a mod DLL.) Conservative by construction — it
+    /// answers "is this findable here", and a false NEGATIVE only downgrades a claim to the safer machine-specific one.</summary>
+    public static bool IsSystemDllResolvable(string dll)
+    {
+        try
+        {
+            string sys = Environment.GetFolderPath(Environment.SpecialFolder.System);
+            if (sys.Length > 0 && File.Exists(Path.Combine(sys, dll))) return true;
+            foreach (var dir in (Environment.GetEnvironmentVariable("PATH") ?? "").Split(Path.PathSeparator))
+            {
+                if (dir.Length == 0) continue;
+                try { if (File.Exists(Path.Combine(dir.Trim(), dll))) return true; }
+                catch { /* a malformed PATH entry is not an answer — keep looking */ }
+            }
+        }
+        catch { /* environment unreadable → fall through to "not resolvable", the machine-specific (safer) claim */ }
+        return false;
+    }
+
     /// <summary>Numeric dotted-version equality with zero-padding ("1.6.1170" == "1.6.1170.0"). A non-numeric
     /// segment ⇒ NOT equal (never guessed equal — a garbage compat entry must not accidentally PASS a lock, Q3).</summary>
     public static bool VersionsEqual(string a, string b)
@@ -270,6 +346,74 @@ public static class SksePluginReader
             sb.Append(c is >= 0x20 and < 0x7F ? (char)c : ' ');   // printable ASCII only; others → space (Q3: no control chars leak into output)
         }
         return sb.ToString().Trim();
+    }
+
+    /// <summary>Walk the PE IMPORT + DELAY-LOAD directories and return the imported DLL names, lower-cased + deduplicated,
+    /// in image order (tier D). Same posture as <see cref="ReadExportRvas"/>: an ABSENT directory yields an empty list (a
+    /// real, if odd, "imports nothing"), while a PRESENT-but-CORRUPT one yields <c>null</c> — a parse failure the caller
+    /// renders as UNKNOWN, never as "imports nothing" (Q3: a corrupt import table must not read as a clean bill of health).
+    /// Never throws.
+    ///
+    /// Both directories are arrays of fixed-size descriptors terminated by an all-zero entry, each carrying an RVA to the
+    /// imported DLL's ASCII name. Delay-load descriptors predate the RVA convention: bit0 of their Attributes is
+    /// <c>RvaBased</c>, and a (long-obsolete) VA-based table is SKIPPED rather than misread as an RVA.</summary>
+    static List<string>? ReadImportNames(PEReader pe)
+    {
+        var names = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var hdr = pe.PEHeaders.PEHeader!;
+        // Bound the descriptor count against corruption BEFORE looping: a real DLL imports from at most a few hundred
+        // modules, so a table that never terminates is corrupt — refuse it rather than spin (the export-walk lesson).
+        const int MaxDescriptors = 4096;
+
+        bool ok = Walk(hdr.ImportTableDirectory.RelativeVirtualAddress, hdr.ImportTableDirectory.Size, 20, 0x0C, delay: false)
+               && Walk(hdr.DelayImportTableDirectory.RelativeVirtualAddress, hdr.DelayImportTableDirectory.Size, 32, 0x04, delay: true);
+        return ok ? names : null;
+
+        bool Walk(int dirRva, int dirSize, int stride, int nameOff, bool delay)
+        {
+            if (dirSize == 0 || dirRva == 0) return true;              // directory genuinely absent → nothing to add
+            try
+            {
+                var block = pe.GetSectionData(dirRva);
+                if (block.Length == 0) return false;                   // directory declared but maps to no section → corrupt
+                var rd = block.GetReader();
+                for (int i = 0; i < MaxDescriptors; i++)
+                {
+                    if ((i + 1) * stride > block.Length) return false; // table runs past its section without terminating → corrupt
+                    rd.Offset = i * stride;
+                    uint attributes = delay ? rd.ReadUInt32() : 0;     // delay-load: Attributes precedes the name RVA
+                    rd.Offset = i * stride + nameOff;
+                    int nameRva = rd.ReadInt32();
+                    // The all-zero descriptor terminates the array. A delay-load table whose bit0 (RvaBased) is clear is
+                    // VA-based (pre-VS2015); its "RVA" is an absolute address we must NOT resolve — skip, don't guess.
+                    if (nameRva == 0) return true;
+                    if (delay && (attributes & 1) == 0) continue;
+                    if (ReadAsciiAt(pe, nameRva) is { Length: > 0 } n && seen.Add(n)) names.Add(n);
+                }
+                return false;                                          // never hit the terminator inside the bound → corrupt
+            }
+            catch { return false; /* bad RVA / truncated table / unterminated string → parse failure, not an empty answer */ }
+        }
+    }
+
+    /// <summary>Read a null-terminated ASCII string at an RVA (an imported DLL's name), lower-cased for comparison.
+    /// Bounded — a name is short, and an unterminated run means corruption, so it stops rather than reading a section.</summary>
+    static string? ReadAsciiAt(PEReader pe, int rva)
+    {
+        var block = pe.GetSectionData(rva);
+        if (block.Length == 0) return null;
+        var rd = block.GetReader();
+        var sb = new StringBuilder(24);
+        const int MaxName = 260;                                       // MAX_PATH; a real module name is far shorter
+        for (int i = 0; i < MaxName && i < block.Length; i++)
+        {
+            byte c = rd.ReadByte();
+            if (c == 0) return sb.ToString().ToLowerInvariant();
+            if (c is < 0x20 or > 0x7E) return null;                    // a non-printable inside a module name ⇒ not a real name
+            sb.Append((char)c);
+        }
+        return null;                                                   // unterminated → corrupt, never a truncated guess
     }
 
     /// <summary>Walk the PE export directory and return name → export RVA (data exports point AT the data). Minimal by

--- a/src/housecarl-core/SksePluginReader.cs
+++ b/src/housecarl-core/SksePluginReader.cs
@@ -284,22 +284,26 @@ public static class SksePluginReader
     /// Approximates the loader's search order for a DLL loaded from the game root: System32, then the PATH directories.
     /// (The debug CRT is never in the game root and never side-by-side for a mod DLL.) Conservative by construction — it
     /// answers "is this findable here", and a false NEGATIVE only downgrades a claim to the safer machine-specific one.</summary>
-    public static bool IsSystemDllResolvable(string dll)
+    public static bool IsSystemDllResolvable(string dll) => _resolvableMemo.GetOrAdd(dll, static d =>
     {
         try
         {
             string sys = Environment.GetFolderPath(Environment.SpecialFolder.System);
-            if (sys.Length > 0 && File.Exists(Path.Combine(sys, dll))) return true;
+            if (sys.Length > 0 && File.Exists(Path.Combine(sys, d))) return true;
             foreach (var dir in (Environment.GetEnvironmentVariable("PATH") ?? "").Split(Path.PathSeparator))
             {
                 if (dir.Length == 0) continue;
-                try { if (File.Exists(Path.Combine(dir.Trim(), dll))) return true; }
+                try { if (File.Exists(Path.Combine(dir.Trim(), d))) return true; }
                 catch { /* a malformed PATH entry is not an answer — keep looking */ }
             }
         }
         catch { /* environment unreadable → fall through to "not resolvable", the machine-specific (safer) claim */ }
         return false;
-    }
+    });
+
+    /// <summary>Memo for <see cref="IsSystemDllResolvable"/>: System32 + PATH are machine-static for the process's life,
+    /// so the stat walk is worth exactly one run per name. (Concurrent because tool calls are.)</summary>
+    static readonly System.Collections.Concurrent.ConcurrentDictionary<string, bool> _resolvableMemo = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>Numeric dotted-version equality with zero-padding ("1.6.1170" == "1.6.1170.0"). A non-numeric
     /// segment ⇒ NOT equal (never guessed equal — a garbage compat entry must not accidentally PASS a lock, Q3).</summary>
@@ -377,10 +381,13 @@ public static class SksePluginReader
             {
                 var block = pe.GetSectionData(dirRva);
                 if (block.Length == 0) return false;                   // directory declared but maps to no section → corrupt
+                // Bound by what the HEADER declares, not merely by the section remainder: an unterminated table would
+                // otherwise read on into adjacent .rdata and invent descriptors out of unrelated bytes.
+                int limit = Math.Min(dirSize, block.Length);
                 var rd = block.GetReader();
                 for (int i = 0; i < MaxDescriptors; i++)
                 {
-                    if ((i + 1) * stride > block.Length) return false; // table runs past its section without terminating → corrupt
+                    if ((i + 1) * stride > limit) return false;        // table runs past its declared size without terminating → corrupt
                     rd.Offset = i * stride;
                     uint attributes = delay ? rd.ReadUInt32() : 0;     // delay-load: Attributes precedes the name RVA
                     rd.Offset = i * stride + nameOff;
@@ -389,7 +396,12 @@ public static class SksePluginReader
                     // VA-based (pre-VS2015); its "RVA" is an absolute address we must NOT resolve — skip, don't guess.
                     if (nameRva == 0) return true;
                     if (delay && (attributes & 1) == 0) continue;
-                    if (ReadAsciiAt(pe, nameRva) is { Length: > 0 } n && seen.Add(n)) names.Add(n);
+                    // An unresolvable name is CORRUPTION, and skipping it would hand back a short list that renders as a
+                    // complete "imports (N): …" — a silent partial answer, which is worse here than no answer: if the
+                    // entry we dropped were vcruntime140d.dll, the Debug-CRT check would report a clean bill of health.
+                    // Fail the whole walk (→ null → UNKNOWN), consistent with this method's directory-level posture.
+                    if (ReadAsciiAt(pe, nameRva) is not { Length: > 0 } n) return false;
+                    if (seen.Add(n)) names.Add(n);                     // a DUPLICATE name is normal dedup, not a failure
                 }
                 return false;                                          // never hit the terminator inside the bound → corrupt
             }

--- a/src/housecarl-core/SksePluginReader.cs
+++ b/src/housecarl-core/SksePluginReader.cs
@@ -275,6 +275,29 @@ public static class SksePluginReader
         info.Imports is null ? []
             : info.Imports.Where(i => DebugCrtDlls.Contains(i, StringComparer.OrdinalIgnoreCase)).ToList();
 
+    /// <summary>The load-blocker reason when <paramref name="info"/> is a DEBUG build whose debug runtime is ABSENT from
+    /// this machine — else <c>null</c>. The seventh static way an SKSE DLL fails to load, alongside BSA-only / subfolder /
+    /// 32-bit / unreadable / version-locked / query-only-on-AE, and the one the native-pairing audit was blind to: a
+    /// debug-built DLL is loose, top-level, x64, readable and often version-INDEPENDENT, so every existing check passes it
+    /// as healthy while the loader refuses it with error 126. Scripts declaring its natives are then silently no-ops —
+    /// exactly the audit's PAIRED-BUT-DEAD class.
+    ///
+    /// Returns null when the runtime IS present (a developer's box): there the DLL genuinely loads, so there is no
+    /// blocker and no claim to make — the inventory still names it as broken for everyone else. Also null when the import
+    /// walk failed (<see cref="SksePluginInfo.Imports"/> is null) — absence of evidence is never evidence of absence (Q3).
+    ///
+    /// <paramref name="resolvable"/> is injected so the decision is pinnable BOTH ways in one run: CI has no Visual
+    /// Studio and a dev box does, so a hard-wired probe would leave whichever half the current machine can't produce
+    /// unpinned — and that is the half that rots. Pure.</summary>
+    public static string? DebugCrtBlocker(SksePluginInfo info, Func<string, bool> resolvable)
+    {
+        if (info.Imports is null) return null;
+        var missing = DebugCrtImportsOf(info).Where(c => !resolvable(c)).ToList();
+        return missing.Count == 0 ? null
+            : $"a DEBUG build — it imports {string.Join(", ", missing)}, which ships only with Visual Studio and is not " +
+              "present on this machine, so the loader fails with error 126 (ERROR_MOD_NOT_FOUND)";
+    }
+
     /// <summary>Whether <paramref name="dll"/> is resolvable by the Windows loader ON THIS MACHINE — the honest other half
     /// of the Debug-CRT verdict. "Imports the debug CRT ⇒ will not load" is true only where the debug CRT is ABSENT, which
     /// is every stock machine but NOT a developer's (Visual Studio installs it). houseCARL runs on the modder's own box, so

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -136,6 +136,12 @@ public static class CiAll
         // reverse-engineered offset map — supportEmail is 252, not 256 — + the flag/version/compat interpretation) and
         // the honest-degrade paths (real-PE Read → NotSkse; non-PE / missing → Unreadable, never a throw).
         ("skse-reader-guard", SkseReaderProbe.RunGuard),
+        // SKSE tier D (static peek): the string extraction (ASCII *and* UTF-16LE — an ASCII-only scan is a confident
+        // half-blind answer), the classification filter that keeps compiler noise out of a DLL's "config surface", the
+        // PE import walk + its empty-vs-unknown tri-state, the CURATED Debug-CRT list (a d-suffix is a convention, not a
+        // loader rule), and the render arms — load-order cross-check, the machine-checked "will not load" wording, the
+        // framing line, and the bare-peek loud error.
+        ("skse-peek-guard", SksePeekProbe.RunGuard),
         ("mo2instance-probe", Mo2InstanceProbe.RunProbe),
         // meta.ini Nexus-update-cache parse (Tier 0 PR review fold): the QSettings quirks + exact-key vs [installedFiles]
         // 1\modid, the fiddliest OFFLINE logic behind housecarl_update_status — locked with synthetic fixtures. Now also

--- a/src/housecarl-generator/NativePairingProbe.cs
+++ b/src/housecarl-generator/NativePairingProbe.cs
@@ -227,7 +227,11 @@ public static class NativePairingProbe
                 crtBlocker is { Length: > 0 });
             Check("A2b: …and on a box WITH the debug runtime the same chain blocks nothing (it truly loads there)",
                 LoadOrderService.LooseDllBlocker(dbgInfo, _ => true) is null);
-            var dbgDll = new NativePairedDll(@"SKSE\Plugins\Dbg.dll", "Dbg.dll", "", "DbgMod", indepInfo, crtBlocker);
+            // dbgInfo, NOT indepInfo: the rendered candidate must carry the SAME info the blocker was derived from.
+            // They are equivalent today (both version-independent) and the verdict reads LoadBlocker, so the arm passes
+            // either way — but if Judge ever re-derived from Info instead of trusting the blocker, an indepInfo fixture
+            // would keep passing while production broke. The fixture should not be the reason a regression hides.
+            var dbgDll = new NativePairedDll(@"SKSE\Plugins\Dbg.dll", "Dbg.dll", "", "DbgMod", dbgInfo, crtBlocker);
             var s = Render(Data(new[] { Cls("DbgUtil", NativeProvenance.ThirdParty, NativePairingRung.SameMod, "DbgMod", new[] { dbgDll }) }, "1.6.1170.0"));
             Check("A2: a DEBUG-built version-INDEPENDENT DLL → 'PAIRED BUT DEAD', not healthy (the tier-D blind spot)",
                 s.Contains("PAIRED BUT DEAD") && s.Contains("DEBUG build") && s.Contains("error 126")

--- a/src/housecarl-generator/NativePairingProbe.cs
+++ b/src/housecarl-generator/NativePairingProbe.cs
@@ -212,6 +212,28 @@ public static class NativePairingProbe
                 !s.Contains("PAIRED BUT DEAD") && s.Contains("verify") && s.Contains("could not be resolved"));
         }
         {
+            // Arm A2 (tier D, Aaron-go 2026-07-17): the DEBUG-build blocker — the audit's 7th, and the one that used to
+            // read as healthy. This DLL is loose, top-level, x64, readable and version-INDEPENDENT: every other check
+            // passes it, so before this the audit rendered [LOADS] while skse_inventory called the same DLL broken.
+            // The blocker rides LoadBlocker, so it lands in PAIRED-BUT-DEAD by construction — no Judge arm needed.
+            // Drives the REAL service chain (LoadOrderService.LooseDllBlocker), not a hand-built blocker — the wiring is
+            // the one link no live gate can reach here (ARR has zero debug plugins; the dev box HAS the debug runtime,
+            // so it can't produce the dead path either), and a hand-built fixture would pin the render while leaving
+            // the production line uncovered. The probe is injected because no single machine exercises both halves.
+            var dbgInfo = new SksePluginReader.SksePluginInfo("Dbg.dll", SksePluginReader.SksePluginKind.Modern, true,
+                Ver(independent: true, compat: Array.Empty<string>()), null, new[] { "kernel32.dll", "vcruntime140d.dll" });
+            var crtBlocker = LoadOrderService.LooseDllBlocker(dbgInfo, _ => false);
+            Check("A2a: the service's loose-DLL chain blocks a debug build (the production wiring, not a fixture)",
+                crtBlocker is { Length: > 0 });
+            Check("A2b: …and on a box WITH the debug runtime the same chain blocks nothing (it truly loads there)",
+                LoadOrderService.LooseDllBlocker(dbgInfo, _ => true) is null);
+            var dbgDll = new NativePairedDll(@"SKSE\Plugins\Dbg.dll", "Dbg.dll", "", "DbgMod", indepInfo, crtBlocker);
+            var s = Render(Data(new[] { Cls("DbgUtil", NativeProvenance.ThirdParty, NativePairingRung.SameMod, "DbgMod", new[] { dbgDll }) }, "1.6.1170.0"));
+            Check("A2: a DEBUG-built version-INDEPENDENT DLL → 'PAIRED BUT DEAD', not healthy (the tier-D blind spot)",
+                s.Contains("PAIRED BUT DEAD") && s.Contains("DEBUG build") && s.Contains("error 126")
+                && !s.Contains("paired healthy (1"));
+        }
+        {
             // Arm C: a static blocker (BSA-only) is dead regardless of runtime knowledge.
             var bsaDll = new NativePairedDll(@"SKSE\Plugins\X.dll", "X.dll", "", "XMod", null,
                 "provided only inside a BSA — the SKSE loader scans loose DLLs only, so it will not load");

--- a/src/housecarl-generator/Program.cs
+++ b/src/housecarl-generator/Program.cs
@@ -242,6 +242,10 @@ if (args.Length > 0 && args[0] == "remap-wave2-nested-mech") return RemapWave2Ne
 // MO2 instance and print the render + timing (the CI skse-reader-guard pins the decode; this proves the full inventory).
 if (args.Length > 0 && args[0] == "skse-inventory-real") return SkseInventoryProbe.RunReal(args[1..]);
 
+// SKSE tier D (static peek, #199): the CI guard for the import walk / string extraction / Debug-CRT verdict / render.
+// The real-data side needs no harness of its own — skse-inventory-real --peek --filter <dll> drives the live peek.
+if (args.Length > 0 && args[0] == "skse-peek-guard") return SksePeekProbe.RunGuard(args[1..]);
+
 // SKSE config audit (tier B, #199) reference-extractor + verdict CI guard, and the manual real-data harness (the live gate:
 // runs the whole audit against a live MO2 instance and prints the audit + timing).
 if (args.Length > 0 && args[0] == "skse-config-audit-guard") return SkseConfigAuditProbe.RunGuard(args[1..]);

--- a/src/housecarl-generator/SkseInventoryProbe.cs
+++ b/src/housecarl-generator/SkseInventoryProbe.cs
@@ -31,6 +31,16 @@ internal static class SkseInventoryProbe
         int peeked = data.Dlls.Count(e => e.Peek is not null);
         Console.WriteLine($"\n[timing] SkseInventory over {data.Dlls.Count} DLLs + {data.Configs.Count} configs" +
                           $"{(peek ? $" (peeked {peeked})" : "")} in {sw.ElapsedMilliseconds} ms");
+
+        // Tier-D import-walk accounting over the REAL layer. A DLL that opened as a PE but whose import walk came back
+        // UNKNOWN is either genuinely corrupt or a bug in the walk's corruption bounds — either way it silently
+        // suppresses the Debug-CRT check for that DLL, so the count is worth stating rather than discovering later.
+        var withInfo = data.Dlls.Where(e => e.Plugin is not null).ToList();
+        var unknown = withInfo.Where(e => e.Plugin!.Imports is null).ToList();
+        var empty = withInfo.Where(e => e.Plugin!.Imports is { Count: 0 }).ToList();
+        Console.WriteLine($"[imports] {withInfo.Count - unknown.Count}/{withInfo.Count} PE-read DLLs walked" +
+                          $" · {unknown.Count} UNKNOWN (walk failed) · {empty.Count} genuinely import-free");
+        foreach (var u in unknown) Console.WriteLine($"    UNKNOWN: {u.FileName} ({u.Plugin!.Kind})");
         return 0;
     }
 

--- a/src/housecarl-generator/SkseInventoryProbe.cs
+++ b/src/housecarl-generator/SkseInventoryProbe.cs
@@ -17,16 +17,20 @@ internal static class SkseInventoryProbe
     {
         string? mo2 = ArgVal(args, "--mo2");
         string? filter = ArgVal(args, "--filter");
+        bool peek = Array.IndexOf(args, "--peek") >= 0;             // tier D: peek the filter-matched DLLs (needs --filter)
         if (mo2 is null) { Console.WriteLine("skse-inventory-real needs --mo2 <MO2 instance folder>"); return 2; }
+        if (peek && filter is null) { Console.WriteLine("--peek needs --filter (a peek is per-DLL)"); return 2; }
 
         var store = new UserConfigStore(Path.Combine(Path.GetTempPath(), "hc-skse-real-" + Guid.NewGuid().ToString("N") + ".json"));
         using var svc = LoadOrderService.WithInstance(mo2, 0, store);
         var sw = Stopwatch.StartNew();
-        var data = svc.SkseInventory();
+        var data = svc.SkseInventory(peek ? filter : null);
         sw.Stop();
 
         Console.WriteLine(SkseInventoryWire.Render(data, filter, 80_000));
-        Console.WriteLine($"\n[timing] SkseInventory over {data.Dlls.Count} DLLs + {data.Configs.Count} configs in {sw.ElapsedMilliseconds} ms");
+        int peeked = data.Dlls.Count(e => e.Peek is not null);
+        Console.WriteLine($"\n[timing] SkseInventory over {data.Dlls.Count} DLLs + {data.Configs.Count} configs" +
+                          $"{(peek ? $" (peeked {peeked})" : "")} in {sw.ElapsedMilliseconds} ms");
         return 0;
     }
 

--- a/src/housecarl-generator/SksePeekProbe.cs
+++ b/src/housecarl-generator/SksePeekProbe.cs
@@ -201,6 +201,16 @@ internal static class SksePeekProbe
             var got = LoadOrderService.PeekPluginSet(healthy);
             Check(got is not null && got.Contains("Skyrim.esm") && got.Contains("Dawnguard.esm"),
                   "a real composition resolves, implicit force-loaded masters included (Dawnguard.esm is never ABSENT)");
+
+            // THE RESIDUAL (re-review): loadorder.txt missing, plugins.txt PRESENT. `implicit` is derived by iterating
+            // `ordered`, so it collapses to empty while `active` stays non-empty — a merged-set-non-empty gate returns
+            // an active-only set with the force-loaded masters silently gone, and SeranaMultiformNG's embedded
+            // Dawnguard.esm reads ABSENT on a healthy install. The gate must key on `ordered`, the input `implicit`
+            // comes FROM. This arm fails against `set.Count > 0`.
+            var noOrderFile = new Mo2Composition([], [], [],                       // ordered: [] — no loadorder.txt
+                new HashSet<string>(["SomeMod.esp"], StringComparer.OrdinalIgnoreCase), [], []);
+            Check(LoadOrderService.PeekPluginSet(noOrderFile) is null,
+                  "no loadorder.txt + a NON-EMPTY plugins.txt ⇒ still null — the implicit masters are UNKNOWABLE, not absent");
         }
         finally { try { Directory.Delete(prof, true); } catch { /* temp scratch */ } }
 
@@ -210,8 +220,27 @@ internal static class SksePeekProbe
         string noPeek = SkseInventoryWire.Render(
             new SkseInventoryData([bsaOnly], [], 0, "1.6.1170.0", [], false, [], "TestProfile", null, PeekRequested: true),
             "Bsa", 80_000);
-        Check(noPeek.Contains("peek=true matched no loose DLL"),
-              "a peek that matched only a BSA-only DLL SAYS nothing was peeked (never a silent no-op)");
+        Check(noPeek.Contains("not peeked"),
+              "a matched-but-unpeekable DLL SAYS it wasn't peeked, on its own entry (never a silent no-op)");
+        // The notice is PER-ENTRY, so a MIXED match (one peeked, one not) reports both — the all-or-nothing check this
+        // replaced stayed silent whenever any hit happened to be peekable.
+        string mixed = SkseInventoryWire.Render(
+            new SkseInventoryData([bsaOnly, Entry("Ok.dll", peek, Info(["kernel32.dll"]))], [], 0, "1.6.1170.0", [], false,
+                [], "TestProfile", null, PeekRequested: true), ".dll", 80_000);
+        Check(mixed.Contains("not peeked") && mixed.Contains("── peek (what the image contains) ──"),
+              "a MIXED match renders the peek AND names the entry that had no image to read");
+        // No DLL matched at all ⇒ no entry exists to carry the notice, so the summary carries it.
+        string noDll = SkseInventoryWire.Render(
+            new SkseInventoryData([], [new SkseFileEntry("a.ini", "a.ini", "Grp", [new SkseProvider("M", "loose")], null, null)],
+                0, "1.6.1170.0", [], false, [], "TestProfile", null, PeekRequested: true), "Grp", 80_000);
+        Check(noDll.Contains("matched no DLL at all"), "a config-only filter with peek=true says no DLL matched");
+
+        // ---- I4: the whole-layer Debug-CRT line uses the SAME injected seam as the detail view. ----
+        Console.WriteLine("\n--- I4: whole-layer Debug-CRT verdict seam ---");
+        Check(SkseInventoryWire.DebugCrtLayerVerdict(["vcruntime140d.dll"], _ => false).Contains("will NOT load"),
+              "layer line, runtime ABSENT ⇒ 'will NOT load'");
+        Check(SkseInventoryWire.DebugCrtLayerVerdict(["vcruntime140d.dll"], _ => true).Contains("loads on THIS machine"),
+              "layer line, runtime PRESENT ⇒ the author-facing wording (both halves pinned in ONE run)");
 
         // ---- J: the Debug-CRT verdict wording — the one peek line allowed "will not load". ----
         Console.WriteLine("\n--- J: Debug-CRT render ---");

--- a/src/housecarl-generator/SksePeekProbe.cs
+++ b/src/housecarl-generator/SksePeekProbe.cs
@@ -67,6 +67,17 @@ internal static class SksePeekProbe
               "a plugin ref inside a PATH yields the FILENAME (what the load-order cross-check keys on)");
         Check(cPath.ConfigPaths.Count == 0, "a path that IS a plugin ref classifies as the plugin ref, not double-counted");
 
+        // fmt/spdlog placeholders — the DOMINANT modern format shape (CommonLibSSE-NG logs through spdlog), so a
+        // classifier that only knows printf's % adjudicates a log template against the load order and flags it ABSENT.
+        var cFmt = SksePeek.ScanBytes(Image(Ascii("{}.esp"), Ascii("loading {}.esm"), Ascii("%s.esp")));
+        Check(cFmt.PluginRefs.Count == 0,
+              $"fmt/spdlog {{}} and printf %s templates are NOT plugin names (got [{string.Join("|", cFmt.PluginRefs)}])");
+        // …but a {}-bearing PATH stays config-surface signal: it is only ever SHOWN, never adjudicated, and
+        // "versionlib-{}.bin" genuinely tells you the plugin reads Address Library (live-gate evidence, SkyPatcher).
+        var cTmpl = SksePeek.ScanBytes(Image(Ascii("Data/SKSE/Plugins/versionlib-{}.bin")));
+        Check(cTmpl.ConfigPaths.Contains("Data/SKSE/Plugins/versionlib-{}.bin"),
+              "a {}-template PATH is still config surface (shown, not adjudicated — the deliberate asymmetry)");
+
         // ---- D: absence is a fact about the image, never a clean bill of health. ----
         Console.WriteLine("\n--- D: an image embedding nothing ---");
         var d = SksePeek.ScanBytes(Image(Junk(512)));
@@ -91,6 +102,26 @@ internal static class SksePeekProbe
             Check(e.Kind == SksePluginReader.SksePluginKind.NotSkse, "a system DLL is still classified NotSkse (no SKSE export)");
         }
         else Check(false, $"expected a system kernel32.dll to walk at '{k32}'");
+
+        // ---- E2: an unresolvable import NAME fails the whole walk (review finding #3). ----
+        // Take a real PE and point its first import descriptor's Name RVA at nothing. Skipping the bad entry (the
+        // original behavior) returned a SHORT list that still renders as a complete "imports (N): …" — and if the
+        // dropped entry were vcruntime140d.dll, the Debug-CRT check would report a clean bill of health. Corruption
+        // must reach the caller as UNKNOWN, matching this walk's directory-level posture.
+        Console.WriteLine("\n--- E2: a corrupt import name is UNKNOWN, not a short list ---");
+        if (File.Exists(k32))
+        {
+            var raw = File.ReadAllBytes(k32);
+            int nameOff = FirstImportNameOffset(raw);
+            if (nameOff > 0)
+            {
+                Check(SksePluginReader.ReadBytes("k32.dll", raw).Imports is { Count: > 0 }, "control: the unpatched image walks");
+                BitConverter.GetBytes(0x7FFFFFFF).CopyTo(raw, nameOff);      // an RVA that maps to no section
+                Check(SksePluginReader.ReadBytes("k32-corrupt.dll", raw).Imports is null,
+                      "an unresolvable import-name RVA fails the WHOLE walk → null (UNKNOWN), never a silent short list");
+            }
+            else Check(false, "expected to locate the first import descriptor's Name RVA in a real PE");
+        }
 
         // ---- F: the tri-state. A managed assembly has no import directory → EMPTY (walked), never null (unknown). ----
         Console.WriteLine("\n--- F: the imports tri-state (empty ≠ unknown) ---");
@@ -143,6 +174,45 @@ internal static class SksePeekProbe
         Check(!noOrder.Contains("NOT in your load order"),
               "with no resolved order, NO name is called absent — an unasked question has no answer (Q3)");
 
+        // ---- I2: the SERVICE must actually be able to PRODUCE that null. ----
+        // The review's finding #1: the renderer honored the null contract, but nothing could emit it —
+        // ReadComposition never throws on a missing plugins.txt/loadorder.txt, and the asset resolver needs only
+        // modlist.txt, so a half-readable profile yielded an EMPTY-but-non-null set and flagged every embedded name
+        // (Dawnguard.esm included) ABSENT. Arm I pinned the renderer and missed it because it hand-built the null.
+        // This arm drives the REAL producer over a profile whose plugin lists don't exist.
+        Console.WriteLine("\n--- I2: the empty-composition → null contract, through the real service ---");
+        string prof = Path.Combine(Path.GetTempPath(), "hc-peek-prof-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(prof);
+            File.WriteAllText(Path.Combine(prof, "modlist.txt"), "+SomeMod\n");   // readable; NO plugins.txt / loadorder.txt
+            var warn = new List<string>();
+            var comp = Mo2LoadOrder.ReadComposition(prof, warn);
+            Check(comp.ActivePluginNames.Count == 0 && comp.ImplicitPluginNames.Count == 0,
+                  "a profile with no plugins.txt/loadorder.txt yields an EMPTY composition (no throw — the bug's premise)");
+            Check(warn.Count > 0, "…and the read SURFACES why (the warning the peek path must not discard)");
+            // THE REAL PRODUCER, not a copy of its rule — the whole reason the original bug survived arm I is that the
+            // arm hand-built the null instead of exercising the code that has to emit one.
+            Check(LoadOrderService.PeekPluginSet(comp) is null,
+                  "…so the peek path hands the renderer NULL, never an empty set that would flag every name ABSENT (Q3)");
+            // …and the healthy direction still resolves, including a force-loaded master absent from plugins.txt.
+            var healthy = new Mo2Composition([], [], ["Skyrim.esm", "Dawnguard.esm"],
+                new HashSet<string>(["Skyrim.esm"], StringComparer.OrdinalIgnoreCase), [], ["Dawnguard.esm"]);
+            var got = LoadOrderService.PeekPluginSet(healthy);
+            Check(got is not null && got.Contains("Skyrim.esm") && got.Contains("Dawnguard.esm"),
+                  "a real composition resolves, implicit force-loaded masters included (Dawnguard.esm is never ABSENT)");
+        }
+        finally { try { Directory.Delete(prof, true); } catch { /* temp scratch */ } }
+
+        // ---- I3: peek honored with nothing to show is still an unanswered question. ----
+        Console.WriteLine("\n--- I3: peek= matched nothing peekable ---");
+        var bsaOnly = new SkseFileEntry("Bsa.dll", "Bsa.dll", "", [new SkseProvider("Archive.bsa", "BSA")], null, "BSA-only");
+        string noPeek = SkseInventoryWire.Render(
+            new SkseInventoryData([bsaOnly], [], 0, "1.6.1170.0", [], false, [], "TestProfile", null, PeekRequested: true),
+            "Bsa", 80_000);
+        Check(noPeek.Contains("peek=true matched no loose DLL"),
+              "a peek that matched only a BSA-only DLL SAYS nothing was peeked (never a silent no-op)");
+
         // ---- J: the Debug-CRT verdict wording — the one peek line allowed "will not load". ----
         Console.WriteLine("\n--- J: Debug-CRT render ---");
         // A debug CRT that is certainly NOT on the machine (a fabricated name in the pinned family shape would not be
@@ -156,6 +226,18 @@ internal static class SksePeekProbe
               $"the verdict matches THIS machine (debug runtime resolvable = {present}) — never a machine-blind claim");
         Check(crtOut.Contains("error 126"), "…and names the actual loader failure (error 126)");
 
+        // BOTH wordings, in ONE run, via the injected machine probe. Without this seam CI (no Visual Studio) only ever
+        // pins the "will NOT load" arm and a dev box only the other — leaving whichever half the current machine can't
+        // produce free to rot. The machine-dependence IS the finding, so both halves have to be pinned.
+        string absent = SkseTools_DebugCrtVerdict(["vcruntime140d.dll"], _ => false);
+        string here = SkseTools_DebugCrtVerdict(["vcruntime140d.dll"], _ => true);
+        Check(absent.Contains("will NOT load") && absent.Contains("error 126"),
+              "debug runtime ABSENT ⇒ the flat 'will NOT load' verdict");
+        Check(here.Contains("loads on THIS machine") && here.Contains("for anyone who doesn't"),
+              "debug runtime PRESENT ⇒ the author-facing 'loads for you, breaks for everyone else' verdict");
+        Check(!here.Contains("will NOT load"),
+              "…and the present case NEVER makes the flat claim (the wrong answer on a dev box — the whole point)");
+
         // The whole-layer escalation (plan §8.3): the flag rides an UNFILTERED inventory, no peek= needed.
         string layer = Render(Data(crtEntry, active: null), filter: null);
         Check(layer.Contains("DEBUG-BUILD plugins"), "a debug build surfaces on the UNFILTERED inventory (§8.3 escalation)");
@@ -168,6 +250,28 @@ internal static class SksePeekProbe
     }
 
     // ---- fixture helpers ----
+
+    /// <summary>The renderer's pure Debug-CRT verdict with the machine probe injected (internal via InternalsVisibleTo).</summary>
+    static string SkseTools_DebugCrtVerdict(IReadOnlyList<string> crt, Func<string, bool> resolvable) =>
+        SkseInventoryWire.DebugCrtVerdict(crt, resolvable);
+
+    /// <summary>File offset of the FIRST <c>IMAGE_IMPORT_DESCRIPTOR</c>'s Name RVA field (descriptor + 0x0C) in a raw PE
+    /// image, or -1. Walks the section table to map the directory RVA to a file offset — the probe's own mapping, kept
+    /// independent of the reader it is testing (a fixture that reused the code under test would prove nothing).</summary>
+    static int FirstImportNameOffset(byte[] raw)
+    {
+        try
+        {
+            using var pe = new System.Reflection.PortableExecutable.PEReader(new MemoryStream(raw, writable: false));
+            int rva = pe.PEHeaders.PEHeader!.ImportTableDirectory.RelativeVirtualAddress;
+            if (rva == 0) return -1;
+            foreach (var s in pe.PEHeaders.SectionHeaders)
+                if (rva >= s.VirtualAddress && rva < s.VirtualAddress + Math.Max(s.VirtualSize, s.SizeOfRawData))
+                    return s.PointerToRawData + (rva - s.VirtualAddress) + 0x0C;
+        }
+        catch { /* fixture setup only — the arm reports a failure if this can't locate the table */ }
+        return -1;
+    }
 
     /// <summary>A synthetic PE-ish image: the parts concatenated. The scanner is a byte walker, so real PE structure is
     /// irrelevant to extraction — the real-PE paths are covered by arms E/F against actual images.</summary>

--- a/src/housecarl-generator/SksePeekProbe.cs
+++ b/src/housecarl-generator/SksePeekProbe.cs
@@ -1,0 +1,205 @@
+using System.Text;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SKSE tier-D static-peek guard (issue #199 tier D; plan dev/plans/SKSE_TIER_D_STATIC_PEEK_PLAN_2026-07-16.md).
+/// Pins the three things tier D can silently get WRONG, in the direction where wrong looks clean:
+///
+///   Part 1 — <see cref="SksePeek"/> extraction. The UTF-16LE arm is the load-bearing one: modern C++ plugins use wide
+///     strings, so an ASCII-only scanner would return a confident, half-blind "nothing embedded". The negative arms pin
+///     the classification filter against the compiler noise (format strings, type soup, bare extensions) that would
+///     otherwise be rendered as a DLL's config surface.
+///   Part 2 — the import walk + the Debug-CRT verdict. <see cref="SksePluginReader.DebugCrtDlls"/> is a CURATED list
+///     (the D-suffix is a convention, not a loader rule) pinned here with its provenance, the same posture as the
+///     version-blob offset map. The tri-state arms pin that a FAILED walk never renders as "imports nothing".
+///   Part 3 — the renderer arms over synthetic data: the load-order cross-check (present / ABSENT / no-answer), the
+///     Debug-CRT "will not load" wording, the framing line, and the bare-peek loud error.
+///
+/// ARR 2.0 carries ZERO debug-build plugins (live gate, authoring time), so the sharpest check in tier D has no real
+/// specimen to ride — which is exactly why it is pinned synthetically here rather than trusted to a live run.
+/// Self-contained: planted byte fixtures + the runner's own PEs; no MO2 instance, no game data.
+/// </summary>
+internal static class SksePeekProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" skse-peek guard — tier D: imports, strings, Debug-CRT, render");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        // ══ Part 1: SksePeek extraction ══
+        Console.WriteLine("── Part 1: string extraction (ASCII + UTF-16LE + the classification filter) ──");
+
+        // ---- A: ASCII runs — a config path and a plugin name are extracted from image-like noise. ----
+        Console.WriteLine("\n--- A: ASCII extraction ---");
+        var a = SksePeek.ScanBytes(Image(Ascii("Data\\SKSE\\Plugins\\SkyPatcher\\armor\\"), Junk(64),
+                                        Ascii("Dawnguard.esm"), Junk(32), Ascii("nope")));
+        Check(a.ConfigPaths.Contains("Data\\SKSE\\Plugins\\SkyPatcher\\armor\\"), "an embedded config path is extracted");
+        Check(a.PluginRefs.Contains("Dawnguard.esm"), "an embedded plugin name is extracted");
+        Check(!a.Failed && a.Note is null, "a clean scan carries no failure note");
+        Check(a.RunsScanned >= 3, $"accounting counts every run scanned, not just the shown ones (got {a.RunsScanned})");
+
+        // ---- B: UTF-16LE runs — THE coverage arm. An ASCII-only scanner returns a confident half-blind answer. ----
+        Console.WriteLine("\n--- B: UTF-16LE extraction (the silent-half-coverage guard) ---");
+        var b = SksePeek.ScanBytes(Image(Wide("Data\\SKSE\\Plugins\\Trails\\config.json"), Junk(16), Wide("Skyrim.esm")));
+        Check(b.ConfigPaths.Contains("Data\\SKSE\\Plugins\\Trails\\config.json"), "a WIDE config path is extracted");
+        Check(b.PluginRefs.Contains("Skyrim.esm"), "a WIDE plugin name is extracted");
+        var bMixed = SksePeek.ScanBytes(Image(Ascii("Data\\a.ini"), Wide("Data\\b.toml")));
+        Check(bMixed.ConfigPaths.Count == 2, $"ASCII and WIDE strings in ONE image are both found (got {bMixed.ConfigPaths.Count})");
+
+        // ---- C: the classification filter — the noise that must NOT read as a DLL's config surface. ----
+        Console.WriteLine("\n--- C: classification negatives (compiler noise is not a finding) ---");
+        var c = SksePeek.ScanBytes(Image(
+            Ascii("%s.json"),                                   // a format string, not a path
+            Ascii(".esp"),                                      // a bare extension constant, not a reference
+            Ascii("class std::basic_string<char>.ini"),         // C++ type soup that trips a naive extension test
+            Ascii("\"quoted.esm\"")));                          // a quoted token — a sentence about a plugin, not a name
+        Check(c.ConfigPaths.Count == 0, $"format strings + type soup are NOT config paths (got [{string.Join("|", c.ConfigPaths)}])");
+        Check(c.PluginRefs.Count == 0, $"a bare extension + a quoted token are NOT plugin refs (got [{string.Join("|", c.PluginRefs)}])");
+        var cPath = SksePeek.ScanBytes(Image(Ascii("Data\\Dawnguard.esm")));
+        Check(cPath.PluginRefs.Contains("Dawnguard.esm"),
+              "a plugin ref inside a PATH yields the FILENAME (what the load-order cross-check keys on)");
+        Check(cPath.ConfigPaths.Count == 0, "a path that IS a plugin ref classifies as the plugin ref, not double-counted");
+
+        // ---- D: absence is a fact about the image, never a clean bill of health. ----
+        Console.WriteLine("\n--- D: an image embedding nothing ---");
+        var d = SksePeek.ScanBytes(Image(Junk(512)));
+        Check(d.ConfigPaths.Count == 0 && d.PluginRefs.Count == 0, "an image with no strings yields nothing");
+        Check(!d.Failed, "…and that is a SUCCESSFUL scan (absence proves nothing, but the scan still ran)");
+        var dFail = SksePeek.Scan(Path.Combine(Path.GetTempPath(), "hc-peek-missing-" + Guid.NewGuid().ToString("N") + ".dll"));
+        Check(dFail.Failed && dFail.Note is { Length: > 0 },
+              "a missing image is a FAILED peek with a reason — never an empty-but-clean-looking result (Q3)");
+
+        // ══ Part 2: import walk + Debug-CRT ══
+        Console.WriteLine("\n── Part 2: import walk + the Debug-CRT verdict ──");
+
+        // ---- E: the walk on a REAL native PE with a real import table. ----
+        Console.WriteLine("\n--- E: import walk on a real native PE ---");
+        string k32 = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "kernel32.dll");
+        if (File.Exists(k32))
+        {
+            var e = SksePluginReader.Read(k32);
+            Check(e.Imports is not null, "a real native PE's import directory WALKS (non-null = the walk succeeded)");
+            Check(e.Imports is { Count: > 0 }, $"…and yields its imports (got {e.Imports?.Count ?? 0})");
+            Check(e.Imports?.All(i => i == i.ToLowerInvariant()) ?? false, "import names are normalized lower-case for comparison");
+            Check(e.Kind == SksePluginReader.SksePluginKind.NotSkse, "a system DLL is still classified NotSkse (no SKSE export)");
+        }
+        else Check(false, $"expected a system kernel32.dll to walk at '{k32}'");
+
+        // ---- F: the tri-state. A managed assembly has no import directory → EMPTY (walked), never null (unknown). ----
+        Console.WriteLine("\n--- F: the imports tri-state (empty ≠ unknown) ---");
+        var f = SksePluginReader.Read(typeof(SksePluginReader).Assembly.Location);
+        Check(f.Imports is not null, "a managed assembly's (absent) import directory is a SUCCESSFUL walk → empty, not null");
+        Check(f.DebugCrtImports.Count == 0, "…and it imports no debug CRT");
+
+        // ---- G: the Debug-CRT list + verdict semantics. ----
+        Console.WriteLine("\n--- G: Debug-CRT classification ---");
+        Check(SksePluginReader.DebugCrtDlls.Contains("vcruntime140d.dll") &&
+              SksePluginReader.DebugCrtDlls.Contains("msvcp140d.dll") &&
+              SksePluginReader.DebugCrtDlls.Contains("ucrtbased.dll"),
+              "the curated list pins the modern debug-CRT family (vcruntime140d / msvcp140d / ucrtbased)");
+        Check(!SksePluginReader.DebugCrtDlls.Contains("vcruntime140.dll") &&
+              !SksePluginReader.DebugCrtDlls.Contains("d3d11.dll") &&
+              !SksePluginReader.DebugCrtDlls.Contains("dinput8.dll"),
+              "…and NOT their release twins or the d-suffixed innocents (the list is curated, not a 'ends in d' pattern)");
+        Check(SksePluginReader.DebugCrtImportsOf(Info(["kernel32.dll", "VCRUNTIME140D.dll"])).Count == 1,
+              "a debug-CRT import is caught case-INSENSITIVELY (image tables are not case-normalized)");
+        Check(SksePluginReader.DebugCrtImportsOf(Info(["kernel32.dll", "vcruntime140.dll"])).Count == 0,
+              "a RELEASE runtime import is not a debug finding");
+        Check(SksePluginReader.DebugCrtImportsOf(Info(null)).Count == 0,
+              "a FAILED walk yields no debug-CRT claim — absence of evidence is not evidence of absence (Q3)");
+
+        // ══ Part 3: renderer ══
+        Console.WriteLine("\n── Part 3: SkseInventoryWire render arms ──");
+
+        // ---- H: the bare-peek loud error (plan §3a). ----
+        Console.WriteLine("\n--- H: peek= argument check ---");
+        Check(SkseInventoryWire.PeekArgError(peek: true, filter: null) is { Length: > 0 },
+              "a bare peek=true FAILS LOUD (never a silent whole-layer image dump)");
+        Check(SkseInventoryWire.PeekArgError(peek: true, filter: "   ") is { Length: > 0 }, "…a blank filter too");
+        Check(SkseInventoryWire.PeekArgError(peek: true, filter: "SkyPatcher") is null, "peek + filter is valid");
+        Check(SkseInventoryWire.PeekArgError(peek: false, filter: null) is null, "no peek, no filter = the normal inventory");
+
+        // ---- I: the load-order cross-check — present / ABSENT / no-answer. ----
+        Console.WriteLine("\n--- I: embedded-plugin cross-check ---");
+        var peek = new SksePeekResult(["Data\\SKSE\\Plugins\\Thing\\x.json"], ["Dawnguard.esm", "GhostMod.esp"], 40, 4096, null);
+        string withOrder = Render(Data(Entry("Thing.dll", peek, Info(["kernel32.dll"])), active: ["Dawnguard.esm"]), "Thing");
+        Check(withOrder.Contains("Dawnguard.esm") && withOrder.Contains("(in your load order)"),
+              "an embedded name present in the order renders as present");
+        Check(withOrder.Contains("GhostMod.esp") && withOrder.Contains("NOT in your load order"),
+              "an embedded name ABSENT from the order is flagged (the verify signal)");
+        Check(withOrder.Contains("Data\\SKSE\\Plugins\\Thing\\x.json"), "the embedded config surface renders");
+        Check(withOrder.Contains("CONTAINS") && withOrder.Contains("Absence proves nothing"),
+              "the framing line always rides a peek (image contents ≠ behavior; absence proves nothing)");
+        Check(withOrder.Contains("40 string run"), "the scan accounting states the cut (filter, not the whole haystack)");
+
+        string noOrder = Render(Data(Entry("Thing.dll", peek, Info(["kernel32.dll"])), active: null), "Thing");
+        Check(!noOrder.Contains("NOT in your load order"),
+              "with no resolved order, NO name is called absent — an unasked question has no answer (Q3)");
+
+        // ---- J: the Debug-CRT verdict wording — the one peek line allowed "will not load". ----
+        Console.WriteLine("\n--- J: Debug-CRT render ---");
+        // A debug CRT that is certainly NOT on the machine (a fabricated name in the pinned family shape would not be
+        // findable) — use the real name and assert against what the machine actually reports, so the arm is honest on a
+        // CI box (no VS → will NOT load) and on a developer's (VS → the author-facing wording) alike.
+        var crtEntry = Entry("Debug.dll", peek, Info(["kernel32.dll", "vcruntime140d.dll"]));
+        string crtOut = Render(Data(crtEntry, active: ["Dawnguard.esm"]), "Debug");
+        Check(crtOut.Contains("DEBUG BUILD") && crtOut.Contains("vcruntime140d.dll"), "a debug-CRT import is flagged with the culprit named");
+        bool present = SksePluginReader.IsSystemDllResolvable("vcruntime140d.dll");
+        Check(present ? crtOut.Contains("loads on THIS machine") : crtOut.Contains("will NOT load"),
+              $"the verdict matches THIS machine (debug runtime resolvable = {present}) — never a machine-blind claim");
+        Check(crtOut.Contains("error 126"), "…and names the actual loader failure (error 126)");
+
+        // The whole-layer escalation (plan §8.3): the flag rides an UNFILTERED inventory, no peek= needed.
+        string layer = Render(Data(crtEntry, active: null), filter: null);
+        Check(layer.Contains("DEBUG-BUILD plugins"), "a debug build surfaces on the UNFILTERED inventory (§8.3 escalation)");
+        string clean = Render(Data(Entry("Fine.dll", null, Info(["kernel32.dll"])), active: null), filter: null);
+        Check(!clean.Contains("DEBUG-BUILD plugins"), "…and a clean layer says nothing about debug builds");
+
+        Console.WriteLine();
+        Console.WriteLine(fail == 0 ? "skse-peek guard: ALL PASS" : $"skse-peek guard: {fail} FAILURE(S)");
+        return fail == 0 ? 0 : 1;
+    }
+
+    // ---- fixture helpers ----
+
+    /// <summary>A synthetic PE-ish image: the parts concatenated. The scanner is a byte walker, so real PE structure is
+    /// irrelevant to extraction — the real-PE paths are covered by arms E/F against actual images.</summary>
+    static byte[] Image(params byte[][] parts)
+    {
+        var ms = new MemoryStream();
+        foreach (var p in parts) ms.Write(p, 0, p.Length);
+        return ms.ToArray();
+    }
+
+    static byte[] Ascii(string s) => [.. Encoding.ASCII.GetBytes(s), 0];
+    static byte[] Wide(string s) => [.. Encoding.Unicode.GetBytes(s), 0, 0];
+
+    /// <summary>Non-printable filler — code bytes. Deterministic (no RNG: a probe that varies can't pin anything).</summary>
+    static byte[] Junk(int n)
+    {
+        var b = new byte[n];
+        for (int i = 0; i < n; i++) b[i] = (byte)(i % 0x1F);   // all < 0x20 ⇒ never a printable run
+        return b;
+    }
+
+    static SksePluginReader.SksePluginInfo Info(IReadOnlyList<string>? imports) =>
+        new("x.dll", SksePluginReader.SksePluginKind.Modern, true,
+            new SksePluginReader.SkseVersionInfo("Test", "Tester", "", "1.0.0", true, false, false, false, [], null),
+            null, imports);
+
+    static SkseFileEntry Entry(string file, SksePeekResult? peek, SksePluginReader.SksePluginInfo info) =>
+        new(file, file, "", [new SkseProvider("TestMod", "loose")], info, null, peek);
+
+    static SkseInventoryData Data(SkseFileEntry dll, IEnumerable<string>? active) =>
+        new([dll], [], 0, "1.6.1170.0", [], false, [], "TestProfile",
+            active is null ? null : new HashSet<string>(active, StringComparer.OrdinalIgnoreCase));
+
+    static string Render(SkseInventoryData d, string? filter) => SkseInventoryWire.Render(d, filter, 80_000);
+}

--- a/src/housecarl-generator/SksePeekProbe.cs
+++ b/src/housecarl-generator/SksePeekProbe.cs
@@ -146,6 +146,23 @@ internal static class SksePeekProbe
         Check(SksePluginReader.DebugCrtImportsOf(Info(null)).Count == 0,
               "a FAILED walk yields no debug-CRT claim — absence of evidence is not evidence of absence (Q3)");
 
+        // ---- G2: DebugCrtBlocker — the pairing audit's seventh load blocker (Aaron-go 2026-07-17). ----
+        // Pinned BOTH ways via the injected probe, because NO machine can exercise both: CI has no Visual Studio and a
+        // dev box does. This is also the ONLY gate this capability gets — ARR carries zero debug-built plugins, and
+        // Aaron's machine HAS the debug runtime, so the DEAD path cannot be reproduced live on either. Synthetic by
+        // necessity, and said so rather than implied.
+        Console.WriteLine("\n--- G2: DebugCrtBlocker (the pairing audit's 7th blocker) ---");
+        var dbg = Info(["kernel32.dll", "vcruntime140d.dll"]);
+        var blocked = SksePluginReader.DebugCrtBlocker(dbg, _ => false);
+        Check(blocked is { Length: > 0 } && blocked.Contains("vcruntime140d.dll") && blocked.Contains("error 126"),
+              "debug runtime ABSENT ⇒ a load blocker naming the culprit and the loader failure");
+        Check(SksePluginReader.DebugCrtBlocker(dbg, _ => true) is null,
+              "debug runtime PRESENT (a dev box) ⇒ NO blocker — it genuinely loads there, so there is no claim to make");
+        Check(SksePluginReader.DebugCrtBlocker(Info(["kernel32.dll", "vcruntime140.dll"]), _ => false) is null,
+              "a RELEASE runtime is never a blocker");
+        Check(SksePluginReader.DebugCrtBlocker(Info(null), _ => false) is null,
+              "a FAILED import walk is never a blocker — an unknown must not become a DEAD verdict (Q3)");
+
         // ══ Part 3: renderer ══
         Console.WriteLine("\n── Part 3: SkseInventoryWire render arms ──");
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -339,20 +339,24 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>The plugin names a tier-D peek adjudicates an embedded reference against — active PLUS the force-loaded
     /// implicit masters (which load despite never appearing in plugins.txt; omitting them would flag Dawnguard.esm
-    /// ABSENT on an install that has it). Returns <c>null</c> — never an EMPTY set — when the composition yielded no
-    /// plugins at all, because that means "the question could not be answered", NOT "your load order is empty".
+    /// ABSENT on an install that has it). Returns <c>null</c> — never a partial set — when the answer is UNKNOWABLE,
+    /// because "I could not determine your order" and "your order is empty" must never render the same (Q3).
     ///
-    /// That distinction is the whole point, and the empty case is REACHABLE: <see cref="Mo2LoadOrder.ReadComposition"/>
-    /// never throws on a missing/unreadable plugins.txt or loadorder.txt, while the asset resolver needs only
-    /// modlist.txt — so a half-readable profile enumerates every DLL perfectly and still produces an empty plugin set.
-    /// Handing the renderer an empty-but-non-null set there would flag EVERY embedded name as "NOT in your load order":
-    /// a confident wrong answer, which is the one thing this tool must never do (Q3). A real order always carries at
-    /// least Skyrim.esm, so empty means the read failed, never a genuinely plugin-free profile.
+    /// The gate is <see cref="Mo2Composition.OrderedPluginNames"/>, and that exact choice is load-bearing: the implicit
+    /// set is DERIVED by iterating <c>ordered</c>, so with loadorder.txt missing it collapses to empty while
+    /// plugins.txt can still hand back a perfectly non-empty <c>active</c>. Gating on the MERGED set being non-empty
+    /// therefore looks safe and isn't — it returns an active-only set whose force-loaded masters are silently gone, and
+    /// every embedded Dawnguard.esm reads "[!] NOT in your load order" on a healthy install. Keying on the input the
+    /// implicit half is derived FROM covers both states (both-files-missing is just the sub-case where active is empty
+    /// too). Reachable in practice: <see cref="Mo2LoadOrder.ReadComposition"/> never throws on a missing profile file,
+    /// the asset resolver needs only modlist.txt, and houseCARL already models the three profile files as
+    /// independently mutable (it stats each for freshness) — a mid-re-sort or a fresh profile is enough.
     ///
     /// internal + pure so the skse-peek guard pins THIS decision rather than a copy of it — the arm that missed the
     /// original bug tested a hand-built null instead of the code that has to produce one.</summary>
     internal static IReadOnlySet<string>? PeekPluginSet(Mo2Composition comp)
     {
+        if (comp.OrderedPluginNames.Count == 0) return null;   // no loadorder.txt ⇒ the implicit masters are UNKNOWABLE, not absent
         var set = new HashSet<string>(comp.ActivePluginNames, StringComparer.OrdinalIgnoreCase);
         set.UnionWith(comp.ImplicitPluginNames);
         return set.Count > 0 ? set : null;

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -337,6 +337,28 @@ public sealed class LoadOrderService : IDisposable
             warnings, profileName, activePlugins, peekFilter is { Length: > 0 });
     }
 
+    /// <summary>Why a LOOSE, loader-scoped SKSE plugin DLL statically cannot load — or null when nothing stops it. The
+    /// native-pairing audit's blocker chain for the winning loose copy, in severity order; a non-null result makes the
+    /// pairing PAIRED-BUT-DEAD by construction (it rides <see cref="NativePairedDll.LoadBlocker"/>, which
+    /// <c>NativePairingWire.Judge</c> already treats as dead — no new verdict arm).
+    ///
+    /// The DEBUG-build arm is tier D's addition (Aaron-go 2026-07-17) and the reason this is a named function rather
+    /// than three inline branches: it is the audit's SEVENTH blocker and the one that read as healthy, because a
+    /// debug-built DLL is loose, top-level, x64, readable and usually version-INDEPENDENT — every other check passes it
+    /// while the loader refuses it with error 126. Before it, this audit said [LOADS] about the same DLL
+    /// <c>skse_inventory</c> called broken: two tools, one file, opposite answers.
+    ///
+    /// <paramref name="resolvable"/> is injected so the chain is pinnable without a live order or a live machine. That
+    /// matters more here than usual: this capability gets NO empirical gate — ARR carries zero debug-built plugins, and
+    /// the dev machine HAS the debug runtime (so the dead path cannot be reproduced there either). The guard is the only
+    /// evidence, which is exactly why the wiring is a testable function instead of a line inside a 100-line sweep.</summary>
+    internal static string? LooseDllBlocker(SksePluginReader.SksePluginInfo info, Func<string, bool> resolvable)
+    {
+        if (info.Kind == SksePluginReader.SksePluginKind.Unreadable) return $"not a readable SKSE plugin ({info.Note})";
+        if (info.Is64Bit == false) return "a 32-bit image — cannot load in Skyrim SE/AE";
+        return SksePluginReader.DebugCrtBlocker(info, resolvable);
+    }
+
     /// <summary>The plugin names a tier-D peek adjudicates an embedded reference against — active PLUS the force-loaded
     /// implicit masters (which load despite never appearing in plugins.txt; omitting them would flag Dawnguard.esm
     /// ABSENT on an install that has it). Returns <c>null</c> — never a partial set — when the answer is UNKNOWABLE,
@@ -578,8 +600,7 @@ public sealed class LoadOrderService : IDisposable
             {
                 info = SksePluginReader.Read(winner.LooseFilePath!);
                 if (info.Kind == SksePluginReader.SksePluginKind.NotSkse) continue;   // bundled dependency — not a candidate
-                if (info.Kind == SksePluginReader.SksePluginKind.Unreadable) blocker = $"not a readable SKSE plugin ({info.Note})";
-                else if (info.Is64Bit == false) blocker = "a 32-bit image — cannot load in Skyrim SE/AE";
+                blocker = LooseDllBlocker(info, SksePluginReader.IsSystemDllResolvable);
             }
             if (blocker is null && group.Length > 0)
                 blocker = $"in subfolder '{group}' — not on SKSE's loader path (scans SKSE\\Plugins\\*.dll top-level only)";

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -261,16 +261,35 @@ public sealed class LoadOrderService : IDisposable
     /// enumerate + resolve + PE reads run OUTSIDE the gate (the captured view is a handle-free immutable snapshot), so an
     /// inventory never serializes other tool calls behind its file I/O. Distributor INIs (SPID <c>*_DISTR</c>, KID
     /// <c>*_KID</c>) live in Data\ ROOT, not here, and are owned by their authoring skills — out of this scope by design.</summary>
-    public SkseInventoryData SkseInventory()
+    /// <param name="peekFilter">Tier D. When non-null, every DLL entry matching it (<see cref="SkseFileEntry.MatchesDll"/> —
+    /// the same predicate the renderer filters on) also gets its image string-scanned into <see cref="SkseFileEntry.Peek"/>.
+    /// Null = no scan. Per-DLL by design: the scan reads the WHOLE image, unlike the import walk, which rides the manifest
+    /// read every DLL already gets.</param>
+    public SkseInventoryData SkseInventory(string? peekFilter = null)
     {
         AssetResolver.AssetView view;
         IReadOnlyList<string> warnings;
-        string profileName;
+        string profileName, profileDir;
         lock (_gate)
         {
+            EnsurePathsDerived();
             view = Assets.Capture();                              // build/refresh the asset resolver under the gate, ONCE
             warnings = _assetWarnings;
             profileName = _profileName;
+            profileDir = _profileDir;
+        }
+        // Tier D only: the plugin names a peek's embedded-reference cross-check adjudicates against. A cheap three-file
+        // text parse (no index build), skipped entirely without peek= so a normal inventory pays nothing for it. The set
+        // is what the game actually LOADS: plugins.txt `*` entries PLUS the force-loaded base/CC masters, which load
+        // despite never appearing there — omitting the implicit ones would flag "Dawnguard.esm" ABSENT on an install
+        // that has it, exactly the false alarm this cross-check exists to prevent (Q3).
+        IReadOnlySet<string>? activePlugins = null;
+        if (peekFilter is { Length: > 0 })
+        {
+            var comp = Mo2LoadOrder.ReadComposition(profileDir);
+            var set = new HashSet<string>(comp.ActivePluginNames, StringComparer.OrdinalIgnoreCase);
+            set.UnionWith(comp.ImplicitPluginNames);
+            activePlugins = set;
         }
         // OUTSIDE the gate: the view is pinned + handle-free (AssetResolver.Dispose is a no-op; Resolve reads only the
         // captured snapshot + readonly roots), so enumerating + resolving + PE-reading here can't race a concurrent
@@ -304,12 +323,18 @@ public sealed class LoadOrderService : IDisposable
                 else note = "provided ONLY inside a BSA — the SKSE loader scans loose Data\\SKSE\\Plugins only, so this DLL will not load";
                 if (group.Length > 0 && note is null)
                     note = $"in subfolder '{group}' — NOT on SKSE's loader path (scans SKSE\\Plugins\\*.dll top-level only); a bundled/parent-loaded DLL, not a plugin SKSE loads";
-                dlls.Add(new SkseFileEntry(rel, Path.GetFileName(rel), group, providers, info, note));
+                var entry = new SkseFileEntry(rel, Path.GetFileName(rel), group, providers, info, note);
+                // Tier D string peek — ONLY for a filter-matched DLL with a loose winner (the copy SKSE would load; a
+                // BSA-only DLL never loads, so peeking it would describe an image the game never reads).
+                if (peekFilter is { Length: > 0 } && entry.MatchesDll(peekFilter)
+                    && winner is { Kind: AssetKind.Loose, LooseFilePath: { } peekPath })
+                    entry = entry with { Peek = SksePeek.Scan(peekPath) };
+                dlls.Add(entry);
             }
             else
                 configs.Add(new SkseFileEntry(rel, Path.GetFileName(rel), group, providers, null, null));
         }
-        return new SkseInventoryData(dlls, configs, otherFiles, InstalledGameRuntime(), view.BsaFailures, view.ReadIncomplete, warnings, profileName);
+        return new SkseInventoryData(dlls, configs, otherFiles, InstalledGameRuntime(), view.BsaFailures, view.ReadIncomplete, warnings, profileName, activePlugins);
     }
 
     /// <summary>The immediate subfolder under SKSE\Plugins a file sits in ("" = directly at top level) — the DERIVED,
@@ -5326,8 +5351,25 @@ public sealed record SkseFileEntry(
     string Group,
     IReadOnlyList<SkseProvider> Providers,
     SksePluginReader.SksePluginInfo? Plugin,
-    string? Note)
+    string? Note,
+    SksePeekResult? Peek = null)
 {
+    /// <summary>The tier-D string peek of this DLL's image (<c>peek=true</c>), or null when not requested / not a loose
+    /// DLL. Computed ONLY for entries the peek filter matched — the scan reads the whole image, so it is opt-in per-DLL
+    /// by design. The IMPORT half of tier D needs no flag and lives on <see cref="SksePluginReader.SksePluginInfo.Imports"/>.</summary>
+    public SksePeekResult? Peek { get; init; } = Peek;
+
+    /// <summary>Whether this DLL entry matches a user <c>filter=</c> — the ONE predicate, shared by the renderer's
+    /// filtered view and the service's peek gate. Shared on purpose: two hand-kept copies would drift, and a drift here
+    /// means peeking a different DLL than the one rendered (the exact class the pairing review caught in its per-DLL
+    /// line). Matches filename, winning provider, subfolder, or the declared plugin name/author, case-insensitively.</summary>
+    public bool MatchesDll(string filter)
+    {
+        bool In(string? s) => s is not null && s.Contains(filter, StringComparison.OrdinalIgnoreCase);
+        return In(FileName) || In(WinningProvider) || In(Group)
+            || (Plugin?.Version is { } v && (In(v.Name) || In(v.Author)));
+    }
+
     /// <summary>The VFS winner (first provider), or null if nothing active provides the file.</summary>
     public SkseProvider? Winner => Providers.Count > 0 ? Providers[0] : null;
     /// <summary>The winning provider's name (mod / overwrite / Data / BSA), or null.</summary>
@@ -5351,7 +5393,14 @@ public sealed record SkseInventoryData(
     IReadOnlyList<string> BsaFailures,
     bool ReadIncomplete,
     IReadOnlyList<string> Warnings,
-    string ProfileName);
+    string ProfileName,
+    IReadOnlySet<string>? ActivePlugins = null)
+{
+    /// <summary>The plugin filenames the game actually loads (active + force-loaded implicit) — resolved ONLY for a
+    /// tier-D peek, which cross-checks a DLL's embedded plugin names against it. <c>null</c> ⇒ not resolved, so a
+    /// renderer must NOT call any embedded name "absent from the load order" (Q3: an unasked question has no answer).</summary>
+    public IReadOnlySet<string>? ActivePlugins { get; init; } = ActivePlugins;
+}
 
 /// <summary>The load-order verdict for one reference an SKSE config declares (housecarl_skse_config_audit, tier B).</summary>
 public enum SkseRefVerdict

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -286,10 +286,9 @@ public sealed class LoadOrderService : IDisposable
         IReadOnlySet<string>? activePlugins = null;
         if (peekFilter is { Length: > 0 })
         {
-            var comp = Mo2LoadOrder.ReadComposition(profileDir);
-            var set = new HashSet<string>(comp.ActivePluginNames, StringComparer.OrdinalIgnoreCase);
-            set.UnionWith(comp.ImplicitPluginNames);
-            activePlugins = set;
+            var compWarnings = new List<string>();
+            activePlugins = PeekPluginSet(Mo2LoadOrder.ReadComposition(profileDir, compWarnings));
+            if (compWarnings.Count > 0) warnings = [.. warnings, .. compWarnings];
         }
         // OUTSIDE the gate: the view is pinned + handle-free (AssetResolver.Dispose is a no-op; Resolve reads only the
         // captured snapshot + readonly roots), so enumerating + resolving + PE-reading here can't race a concurrent
@@ -334,7 +333,29 @@ public sealed class LoadOrderService : IDisposable
             else
                 configs.Add(new SkseFileEntry(rel, Path.GetFileName(rel), group, providers, null, null));
         }
-        return new SkseInventoryData(dlls, configs, otherFiles, InstalledGameRuntime(), view.BsaFailures, view.ReadIncomplete, warnings, profileName, activePlugins);
+        return new SkseInventoryData(dlls, configs, otherFiles, InstalledGameRuntime(), view.BsaFailures, view.ReadIncomplete,
+            warnings, profileName, activePlugins, peekFilter is { Length: > 0 });
+    }
+
+    /// <summary>The plugin names a tier-D peek adjudicates an embedded reference against — active PLUS the force-loaded
+    /// implicit masters (which load despite never appearing in plugins.txt; omitting them would flag Dawnguard.esm
+    /// ABSENT on an install that has it). Returns <c>null</c> — never an EMPTY set — when the composition yielded no
+    /// plugins at all, because that means "the question could not be answered", NOT "your load order is empty".
+    ///
+    /// That distinction is the whole point, and the empty case is REACHABLE: <see cref="Mo2LoadOrder.ReadComposition"/>
+    /// never throws on a missing/unreadable plugins.txt or loadorder.txt, while the asset resolver needs only
+    /// modlist.txt — so a half-readable profile enumerates every DLL perfectly and still produces an empty plugin set.
+    /// Handing the renderer an empty-but-non-null set there would flag EVERY embedded name as "NOT in your load order":
+    /// a confident wrong answer, which is the one thing this tool must never do (Q3). A real order always carries at
+    /// least Skyrim.esm, so empty means the read failed, never a genuinely plugin-free profile.
+    ///
+    /// internal + pure so the skse-peek guard pins THIS decision rather than a copy of it — the arm that missed the
+    /// original bug tested a hand-built null instead of the code that has to produce one.</summary>
+    internal static IReadOnlySet<string>? PeekPluginSet(Mo2Composition comp)
+    {
+        var set = new HashSet<string>(comp.ActivePluginNames, StringComparer.OrdinalIgnoreCase);
+        set.UnionWith(comp.ImplicitPluginNames);
+        return set.Count > 0 ? set : null;
     }
 
     /// <summary>The immediate subfolder under SKSE\Plugins a file sits in ("" = directly at top level) — the DERIVED,
@@ -5394,12 +5415,19 @@ public sealed record SkseInventoryData(
     bool ReadIncomplete,
     IReadOnlyList<string> Warnings,
     string ProfileName,
-    IReadOnlySet<string>? ActivePlugins = null)
+    IReadOnlySet<string>? ActivePlugins = null,
+    bool PeekRequested = false)
 {
     /// <summary>The plugin filenames the game actually loads (active + force-loaded implicit) — resolved ONLY for a
-    /// tier-D peek, which cross-checks a DLL's embedded plugin names against it. <c>null</c> ⇒ not resolved, so a
-    /// renderer must NOT call any embedded name "absent from the load order" (Q3: an unasked question has no answer).</summary>
+    /// tier-D peek, which cross-checks a DLL's embedded plugin names against it. <c>null</c> ⇒ NOT RESOLVED (the
+    /// profile's plugin lists were missing or unreadable), so a renderer must NOT call any embedded name "absent from
+    /// the load order" (Q3: an unasked question has no answer). Never handed over EMPTY — see the producer.</summary>
     public IReadOnlySet<string>? ActivePlugins { get; init; } = ActivePlugins;
+
+    /// <summary>Whether the caller asked for a tier-D peek. Distinct from "any entry HAS a peek": a filter can match
+    /// only configs, or only BSA-only DLLs, and then the flag was honored with nothing to show — which the renderer
+    /// must SAY rather than silently drop (Q3).</summary>
+    public bool PeekRequested { get; init; } = PeekRequested;
 }
 
 /// <summary>The load-order verdict for one reference an SKSE config declares (housecarl_skse_config_audit, tier B).</summary>

--- a/src/housecarl-mcp/SkseTools.cs
+++ b/src/housecarl-mcp/SkseTools.cs
@@ -189,11 +189,8 @@ static class SkseInventoryWire
             AppendCapped(sb, debugCrt, cap, x =>
             {
                 var crt = x.Plugin!.DebugCrtImports;
-                bool loadsHere = crt.All(SksePluginReader.IsSystemDllResolvable);
-                string verdict = loadsHere
-                    ? "  loads on THIS machine (you have the debug runtime) — but error 126 for anyone without Visual Studio"
-                    : "  ≠ this machine — will NOT load (error 126: the debug runtime isn't here)";
-                return $"  - {x.FileName} → needs {string.Join(", ", crt)}{verdict}{Provider(x)}";
+                return $"  - {x.FileName} → needs {string.Join(", ", crt)}" +
+                       $"{DebugCrtLayerVerdict(crt, SksePluginReader.IsSystemDllResolvable)}{Provider(x)}";
             });
         }
 
@@ -311,17 +308,10 @@ static class SkseInventoryWire
         }
 
         // peek= honored with NOTHING to show is still an unanswered question — say so. A bare peek=true already fails
-        // loud (PeekArgError); this is the other half: the filter was fine but matched no PEEKABLE DLL, and silently
-        // rendering the config matches would leave the user believing the peek came back empty (Q3).
-        if (d.PeekRequested && dllHits.All(e => e.Peek is null))
-        {
-            sb.Append("\n[!] peek=true matched no loose DLL — nothing was peeked");
-            sb.Append(dllHits.Count == 0
-                ? ": this filter matched no DLL at all"
-                : $": the {dllHits.Count} matching DLL(s) have no loose winner — SKSE loads loose DLLs only, so there is " +
-                  "no image the game would read");
-            sb.Append(". Pass filter= the name of a loose DLL to peek it.\n");
-        }
+        // loud (PeekArgError), and a matched-but-unpeekable DLL says so on its own entry (AppendPeek); this is the last
+        // case: the filter matched NO DLL at all, so there is no entry to carry the notice.
+        if (d.PeekRequested && dllHits.Count == 0)
+            sb.Append("\n[!] peek=true matched no DLL at all — nothing was peeked. Pass filter= the name of a loose DLL to peek it.\n");
 
         // Remaining matching configs (not already shown as a DLL's paired config), grouped by folder.
         var rest = cfgHits.Where(e => !shownCfg.Contains(e.RelPath))
@@ -356,7 +346,9 @@ static class SkseInventoryWire
         // Service-level note (subfolder-not-loader-scoped / no active provider / BSA-only) — shown for ANY kind, not just
         // Modern (fix: a bundled-dependency or unreadable DLL in a subfolder also deserves the loader-path flag).
         if (e.Note is { } enote) sb.Append("  [!] ").Append(enote).Append('\n');
-        if (p is null) { if (e.Note is null) sb.Append("  no static metadata\n"); return; }
+        // A null Plugin is the BSA-only / unprovided DLL — which is PRECISELY the entry a peek can't read, so the peek
+        // notice has to ride this branch too. (It didn't, and the notice was unreachable for its own motivating case.)
+        if (p is null) { if (e.Note is null) sb.Append("  no static metadata\n"); AppendPeek(sb, e, d); return; }
 
         switch (p.Kind)
         {
@@ -418,7 +410,15 @@ static class SkseInventoryWire
     /// the code DOES (tier E), and absence of a string proves NOTHING — plenty of DLLs build their references at runtime.</summary>
     static void AppendPeek(StringBuilder sb, SkseFileEntry e, SkseInventoryData d)
     {
-        if (e.Peek is not { } peek) return;
+        if (e.Peek is not { } peek)
+        {
+            // PER-ENTRY, so a MIXED match says it too: a filter hitting two loose DLLs and one BSA-only one used to
+            // render two peeks and nothing at all for the third. "peek was honored, this one had no image to read" is
+            // an answer the user asked for; leaving the entry silent makes them infer an empty peek (Q3).
+            if (d.PeekRequested)
+                sb.Append("  (not peeked: no loose winner — SKSE loads loose DLLs only, so there is no image the game would read)\n");
+            return;
+        }
         sb.Append("  ── peek (what the image contains) ──\n");
         if (peek.Failed) { sb.Append("  [!] ").Append(peek.Note).Append('\n'); return; }
 
@@ -514,6 +514,15 @@ static class SkseInventoryWire
     /// in one run. Without the seam CI (no Visual Studio) could only ever pin the "will NOT load" arm and a dev box only
     /// the other, leaving whichever half the current machine doesn't produce unpinned — which is precisely the half that
     /// would rot unnoticed.</summary>
+    /// <summary>The one-line Debug-CRT verdict for the whole-layer summary — the same machine-dependence as
+    /// <see cref="DebugCrtVerdict"/>, in the terse register the roster needs. Pure with the probe injected for the same
+    /// reason: an inline <c>IsSystemDllResolvable</c> call here would leave whichever wording the current machine can't
+    /// produce unpinned, which is exactly the half that rots.</summary>
+    internal static string DebugCrtLayerVerdict(IReadOnlyList<string> crt, Func<string, bool> resolvable) =>
+        crt.All(resolvable)
+            ? "  loads on THIS machine (you have the debug runtime) — but error 126 for anyone without Visual Studio"
+            : "  ≠ this machine — will NOT load (error 126: the debug runtime isn't here)";
+
     internal static string DebugCrtVerdict(IReadOnlyList<string> crt, Func<string, bool> resolvable)
     {
         var missing = crt.Where(c => !resolvable(c)).ToList();

--- a/src/housecarl-mcp/SkseTools.cs
+++ b/src/housecarl-mcp/SkseTools.cs
@@ -510,10 +510,6 @@ static class SkseInventoryWire
         sb.Append(DebugCrtVerdict(crt, SksePluginReader.IsSystemDllResolvable));
     }
 
-    /// <summary>The Debug-CRT verdict text — PURE, with the machine probe injected, so the guard can pin BOTH wordings
-    /// in one run. Without the seam CI (no Visual Studio) could only ever pin the "will NOT load" arm and a dev box only
-    /// the other, leaving whichever half the current machine doesn't produce unpinned — which is precisely the half that
-    /// would rot unnoticed.</summary>
     /// <summary>The one-line Debug-CRT verdict for the whole-layer summary — the same machine-dependence as
     /// <see cref="DebugCrtVerdict"/>, in the terse register the roster needs. Pure with the probe injected for the same
     /// reason: an inline <c>IsSystemDllResolvable</c> call here would leave whichever wording the current machine can't
@@ -523,6 +519,10 @@ static class SkseInventoryWire
             ? "  loads on THIS machine (you have the debug runtime) — but error 126 for anyone without Visual Studio"
             : "  ≠ this machine — will NOT load (error 126: the debug runtime isn't here)";
 
+    /// <summary>The Debug-CRT verdict text — PURE, with the machine probe injected, so the guard can pin BOTH wordings
+    /// in one run. Without the seam CI (no Visual Studio) could only ever pin the "will NOT load" arm and a dev box only
+    /// the other, leaving whichever half the current machine doesn't produce unpinned — which is precisely the half that
+    /// would rot unnoticed.</summary>
     internal static string DebugCrtVerdict(IReadOnlyList<string> crt, Func<string, bool> resolvable)
     {
         var missing = crt.Where(c => !resolvable(c)).ToList();

--- a/src/housecarl-mcp/SkseTools.cs
+++ b/src/housecarl-mcp/SkseTools.cs
@@ -32,19 +32,30 @@ public static class SkseTools
          "readable), non-plugin DLLs (bundled dependencies), subfolder DLLs (not on SKSE's loader path), and any DLL contested " +
          "by more than one mod. Pass filter= a plugin/mod/DLL name, author, or config FOLDER (e.g. 'SkyPatcher', 'EngineFixes', " +
          "'po3', 'OStim') to expand that group or see a plugin in full (all flags, compatible runtimes, email, providers, " +
-         "configs). It does NOT read DLL behavior (that's the ceiling), and it does NOT cover distributor INIs (SPID *_DISTR, " +
-         "KID *_KID) — those live in Data\\ root and are owned by the spid-authoring / kid-authoring skills. Read-only.")]
+         "configs). Pass peek=true WITH filter= to additionally read what the matching DLL's IMAGE statically contains: the " +
+         "DLLs it imports (with derived flags — graphics/input hooks, network, and which sibling non-plugin DLL is bundled " +
+         "for it), the config paths it embeds (which folder it actually scans), and the plugin names it embeds, each " +
+         "cross-checked against your load order. Debug-build plugins are flagged WITHOUT peek — a DLL importing the debug C " +
+         "runtime fails with error 126 for anyone without Visual Studio. It does NOT read DLL behavior (that's the ceiling; " +
+         "an embedded string is what the image CONTAINS, never what the code DOES, and absence proves nothing), and it does " +
+         "NOT cover distributor INIs (SPID *_DISTR, KID *_KID) — those live in Data\\ root and are owned by the " +
+         "spid-authoring / kid-authoring skills. Read-only.")]
     public static string SkseInventory(
         LoadOrderService svc,
         [Description("Optional. A plugin name, author, DLL filename, providing-mod, or config-FOLDER substring (case-insensitive). " +
             "Expands the matching config folder to its individual files, and shows full per-plugin detail for a matching DLL. " +
             "Omit for the whole-layer overview.")]
             string? filter = null,
+        [Description("Optional. Static peek at the matching DLL's image — its imports, the config paths and plugin names it " +
+            "embeds. REQUIRES filter= (a peek is per-DLL: it reads whole images, and a whole-layer dump would be unreadable " +
+            "noise). Use it to answer 'what does this unfamiliar DLL touch'.")]
+            bool peek = false,
         [Description("Optional. Max characters before lists are cut with an explicit notice. 0 = the server default (~80k).")]
             int max_chars = 0) => Guard.Tool("housecarl_skse_inventory", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-        var data = svc.SkseInventory();
+        if (SkseInventoryWire.PeekArgError(peek, filter) is { } err) return err;
+        var data = svc.SkseInventory(peek ? filter!.Trim() : null);
         return SkseInventoryWire.Render(data, filter, max_chars > 0 ? max_chars : 80_000);
     });
 
@@ -120,6 +131,16 @@ public static class SkseTools
 /// notice (Q3 — never silent truncation). filter= expands a group to its individual configs, or a plugin to full detail.</summary>
 static class SkseInventoryWire
 {
+    /// <summary>The <c>peek=</c> argument check, or null when the call is valid. A peek is per-DLL BY DESIGN (plan §3a):
+    /// peeking all ~290 DLLs would read every image and render a wall that invites misreading noise as signal — the tool's
+    /// central design risk. So a bare <c>peek=true</c> fails LOUD rather than silently ignoring the flag or quietly
+    /// peeking one arbitrary DLL (Q3). Pure + internal so the skse-peek-guard pins it without a live service.</summary>
+    internal static string? PeekArgError(bool peek, string? filter) =>
+        peek && string.IsNullOrWhiteSpace(filter)
+            ? "peek=true needs filter= — a peek is per-DLL, not a whole-layer dump (it reads each matching DLL's whole " +
+              "image). Pass filter='<DLL/plugin/mod name>' to name the DLL to peek, e.g. filter='SkyPatcher' peek=true."
+            : null;
+
     public static string Render(SkseInventoryData d, string? filter, int cap)
     {
         if (filter is { Length: > 0 }) return RenderFiltered(d, filter.Trim(), cap);
@@ -155,6 +176,27 @@ static class SkseInventoryWire
           .Append(locked.Count).Append(" version-LOCKED\n");
 
         // ── Diagnostic subsets, FIRST and in full (the point of the tool). ──
+
+        // Debug-CRT offenders lead: it is the sharpest static verdict in the layer (deterministic breakage, not a
+        // mismatch to verify). Surfaced WITHOUT peek= — plan §8.3, decided on the measured data §9 asked for: the import
+        // walk this needs rides the PE open every DLL's manifest read already pays for, which is noise beside the
+        // inventory's per-file VFS resolve. A user should not have to suspect this to be told about it.
+        var debugCrt = loaded.Where(x => x.Plugin is { Imports: not null } pl && pl.DebugCrtImports.Count > 0).ToList();
+        if (debugCrt.Count > 0)
+        {
+            sb.Append("\n[!] DEBUG-BUILD plugins (").Append(debugCrt.Count)
+              .Append(") — they import the debug C runtime, which ships only with Visual Studio and is NOT redistributable:\n");
+            AppendCapped(sb, debugCrt, cap, x =>
+            {
+                var crt = x.Plugin!.DebugCrtImports;
+                bool loadsHere = crt.All(SksePluginReader.IsSystemDllResolvable);
+                string verdict = loadsHere
+                    ? "  loads on THIS machine (you have the debug runtime) — but error 126 for anyone without Visual Studio"
+                    : "  ≠ this machine — will NOT load (error 126: the debug runtime isn't here)";
+                return $"  - {x.FileName} → needs {string.Join(", ", crt)}{verdict}{Provider(x)}";
+            });
+        }
+
         if (locked.Count > 0)
         {
             // With the installed runtime resolved this is PASS/FAIL per plugin; without it, the honest degrade is
@@ -243,11 +285,10 @@ static class SkseInventoryWire
     static string RenderFiltered(SkseInventoryData d, string filter, int cap)
     {
         bool In(string? s) => s is not null && s.Contains(filter, StringComparison.OrdinalIgnoreCase);
-        bool MatchDll(SkseFileEntry e) => In(e.FileName) || In(e.WinningProvider) || In(e.Group)
-            || (e.Plugin?.Version is { } v && (In(v.Name) || In(v.Author)));
         bool MatchCfg(SkseFileEntry e) => In(e.FileName) || In(e.WinningProvider) || In(e.Group);
 
-        var dllHits = d.Dlls.Where(MatchDll).OrderBy(e => e.FileName, StringComparer.OrdinalIgnoreCase).ToList();
+        // SkseFileEntry.MatchesDll is the ONE DLL predicate — the service peeks exactly the entries this view renders.
+        var dllHits = d.Dlls.Where(e => e.MatchesDll(filter)).OrderBy(e => e.FileName, StringComparer.OrdinalIgnoreCase).ToList();
         var cfgHits = d.Configs.Where(MatchCfg).ToList();
 
         var sb = new StringBuilder();
@@ -311,6 +352,9 @@ static class SkseInventoryWire
             case SksePluginReader.SksePluginKind.Unreadable:
                 sb.Append("  ").Append(p.Note).Append('\n');
                 if (p.Is64Bit == false) sb.Append("  [!] NOT an x64 image — a 32-bit DLL cannot load in Skyrim SE/AE.\n");
+                // Tier D rides EVERY kind: a bundled dependency or an unreadable-manifest DLL still has an import table,
+                // and a debug-CRT build is exactly the sort of thing that shows up as a DLL nobody can classify.
+                AppendPeek(sb, e, d);
                 return;   // Is64Bit == false is EXPLICITLY-determined non-x64; null (unknown) never triggers the claim (finding #1)
         }
 
@@ -352,6 +396,116 @@ static class SkseInventoryWire
                 (c.Group.Length > 0 ? c.Group + "\\" : "") + c.FileName + Provider(c)))).Append('\n');
             foreach (var c in cfgs) shownCfg.Add(c.RelPath);
         }
+        AppendPeek(sb, e, d);
+    }
+
+    /// <summary>The tier-D peek block for one DLL (<c>peek=true</c>): what the IMAGE statically contains — its imports
+    /// (with the derived flags), the config paths and plugin names it embeds, and the scan accounting. Renders nothing
+    /// unless a peek ran. Every line here is a fact about bytes in a file, and the framing line says so: this is not what
+    /// the code DOES (tier E), and absence of a string proves NOTHING — plenty of DLLs build their references at runtime.</summary>
+    static void AppendPeek(StringBuilder sb, SkseFileEntry e, SkseInventoryData d)
+    {
+        if (e.Peek is not { } peek) return;
+        sb.Append("  ── peek (what the image contains) ──\n");
+        if (peek.Failed) { sb.Append("  [!] ").Append(peek.Note).Append('\n'); return; }
+
+        // ── imports ──
+        var imports = e.Plugin?.Imports;
+        if (imports is null)
+            sb.Append("  imports: UNKNOWN — the import directory could not be walked (corrupt or absent optional header)\n");
+        else if (imports.Count == 0)
+            sb.Append("  imports: none (walked, genuinely empty)\n");
+        else
+        {
+            sb.Append("  imports (").Append(imports.Count).Append("): ").Append(string.Join(", ", imports)).Append('\n');
+            var hooks = imports.Where(i => HookImports.ContainsKey(i)).ToList();
+            foreach (var h in hooks) sb.Append("    → ").Append(h).Append(": ").Append(HookImports[h]).Append('\n');
+            // Bundled-dependency attribution: an import satisfied by a sibling NON-plugin DLL in the same layer (the
+            // msdia140.dll ← CrashLogger case) — names WHY that stray DLL is installed.
+            var siblings = d.Dlls.Where(x => x.Plugin is { Kind: SksePluginReader.SksePluginKind.NotSkse })
+                .Select(x => x.FileName).Where(f => imports.Contains(f, StringComparer.OrdinalIgnoreCase)).ToList();
+            if (siblings.Count > 0)
+                sb.Append("    → bundled with this plugin (a non-plugin DLL in this layer satisfies it): ")
+                  .Append(string.Join(", ", siblings)).Append('\n');
+        }
+        AppendDebugCrt(sb, e);
+
+        // ── config surface ──
+        if (peek.ConfigPaths.Count > 0)
+        {
+            sb.Append("  config paths embedded (").Append(peek.ConfigPaths.Count).Append("):\n");
+            foreach (var c in peek.ConfigPaths.Take(PeekListCap)) sb.Append("    - ").Append(c).Append('\n');
+            if (peek.ConfigPaths.Count > PeekListCap)
+                sb.Append("    ... [showing ").Append(PeekListCap).Append(" of ").Append(peek.ConfigPaths.Count).Append("]\n");
+        }
+
+        // ── plugin references, cross-checked ──
+        if (peek.PluginRefs.Count > 0)
+        {
+            sb.Append("  plugin names embedded (").Append(peek.PluginRefs.Count).Append("):\n");
+            foreach (var r in peek.PluginRefs.Take(PeekListCap))
+            {
+                string verdict = d.ActivePlugins is null ? ""
+                    : d.ActivePlugins.Contains(r) ? "  (in your load order)"
+                    : "  [!] NOT in your load order";
+                sb.Append("    - ").Append(r).Append(verdict).Append('\n');
+            }
+            if (peek.PluginRefs.Count > PeekListCap)
+                sb.Append("    ... [showing ").Append(PeekListCap).Append(" of ").Append(peek.PluginRefs.Count).Append("]\n");
+        }
+
+        sb.Append("  scanned ").Append(peek.RunsScanned).Append(" string run(s) over ")
+          .Append(peek.BytesScanned / 1024).Append(" KB → showed ")
+          .Append(peek.ConfigPaths.Count + peek.PluginRefs.Count)
+          .Append(" (the classes above are a FILTER over the image, not the whole haystack)\n");
+        if (peek.Note is { } note) sb.Append("  [!] ").Append(note).Append('\n');
+        sb.Append("  (imports/strings are what the image CONTAINS, never what the code DOES — behavior is unreadable by " +
+                  "design. Absence proves nothing: many DLLs build their references at runtime or read them from configs.)\n");
+    }
+
+    /// <summary>Max entries per peek list before an explicit cut — a peek is per-DLL and readability is the point (§6's
+    /// design risk: noise misread as signal). Never a silent truncation.</summary>
+    const int PeekListCap = 40;
+
+    /// <summary>Imports whose presence names a capability the DLL reaches for. FACTS about the import table with a plain
+    /// gloss — never a behavior claim (it hooks the API; what it does with it is tier E).</summary>
+    static readonly Dictionary<string, string> HookImports = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["d3d11.dll"] = "Direct3D 11 — touches graphics/rendering",
+        ["dxgi.dll"] = "DXGI — touches the swapchain/presentation layer",
+        ["d3dcompiler_47.dll"] = "D3D shader compiler — compiles shaders at runtime",
+        ["dinput8.dll"] = "DirectInput — touches input handling",
+        ["xinput1_3.dll"] = "XInput — touches controller input",
+        ["ws2_32.dll"] = "Winsock — opens network sockets",
+        ["winhttp.dll"] = "WinHTTP — makes HTTP requests",
+        ["wininet.dll"] = "WinINet — makes internet requests",
+    };
+
+    /// <summary>The Debug-CRT verdict — tier D's sharpest finding and the ONE peek line allowed "will not load" language,
+    /// because it is a static, deterministic loader fact (the version-LOCKED class). The debug CRT is NOT redistributable:
+    /// it ships with Visual Studio and is absent from a stock Windows, so a plugin importing it dies with error 126.
+    ///
+    /// But "will not load" is only unconditionally true where the runtime is ABSENT — and houseCARL runs on the modder's
+    /// own machine, where it can CHECK rather than assume. A plugin author with VS installed would otherwise be told a DLL
+    /// that loads fine for him "will NOT load": a confident wrong answer, which is worse than no answer (Q3). So the
+    /// verdict splits: absent here ⇒ it will not load, stated flatly; present here ⇒ it loads FOR YOU and is broken for
+    /// everyone else — which is the more useful finding if you are the one shipping it.</summary>
+    static void AppendDebugCrt(StringBuilder sb, SkseFileEntry e)
+    {
+        if (e.Plugin is not { } p || p.Imports is null) return;   // never walked ⇒ no claim either way
+        var crt = p.DebugCrtImports;
+        if (crt.Count == 0) return;
+
+        var missing = crt.Where(c => !SksePluginReader.IsSystemDllResolvable(c)).ToList();
+        sb.Append("  [!] DEBUG BUILD — imports the debug C runtime: ").Append(string.Join(", ", crt)).Append('\n');
+        if (missing.Count > 0)
+            sb.Append("      → will NOT load: ").Append(string.Join(", ", missing))
+              .Append(missing.Count == 1 ? " is" : " are").Append(" not present on this machine, so the loader fails with " +
+                      "error 126 (ERROR_MOD_NOT_FOUND). The debug CRT ships only with Visual Studio and is not redistributable — " +
+                      "this DLL was shipped as a Debug build by mistake. Ask its author for a Release build.\n");
+        else
+            sb.Append("      → it loads on THIS machine (you have the debug runtime installed — Visual Studio), but it will " +
+                      "fail with error 126 for anyone who doesn't. If you built this, ship a Release build.\n");
     }
 
     /// <summary>The compat one-word tag for the terse roster: "AddrLib", "SigScan", or "LOCKED→[runtimes]".</summary>

--- a/src/housecarl-mcp/SkseTools.cs
+++ b/src/housecarl-mcp/SkseTools.cs
@@ -310,6 +310,19 @@ static class SkseInventoryWire
             AppendDetail(sb, e, d, shownCfg);
         }
 
+        // peek= honored with NOTHING to show is still an unanswered question — say so. A bare peek=true already fails
+        // loud (PeekArgError); this is the other half: the filter was fine but matched no PEEKABLE DLL, and silently
+        // rendering the config matches would leave the user believing the peek came back empty (Q3).
+        if (d.PeekRequested && dllHits.All(e => e.Peek is null))
+        {
+            sb.Append("\n[!] peek=true matched no loose DLL — nothing was peeked");
+            sb.Append(dllHits.Count == 0
+                ? ": this filter matched no DLL at all"
+                : $": the {dllHits.Count} matching DLL(s) have no loose winner — SKSE loads loose DLLs only, so there is " +
+                  "no image the game would read");
+            sb.Append(". Pass filter= the name of a loose DLL to peek it.\n");
+        }
+
         // Remaining matching configs (not already shown as a DLL's paired config), grouped by folder.
         var rest = cfgHits.Where(e => !shownCfg.Contains(e.RelPath))
             .OrderBy(e => e.Group, StringComparer.OrdinalIgnoreCase).ThenBy(e => e.FileName, StringComparer.OrdinalIgnoreCase).ToList();
@@ -458,7 +471,6 @@ static class SkseInventoryWire
           .Append(peek.BytesScanned / 1024).Append(" KB → showed ")
           .Append(peek.ConfigPaths.Count + peek.PluginRefs.Count)
           .Append(" (the classes above are a FILTER over the image, not the whole haystack)\n");
-        if (peek.Note is { } note) sb.Append("  [!] ").Append(note).Append('\n');
         sb.Append("  (imports/strings are what the image CONTAINS, never what the code DOES — behavior is unreadable by " +
                   "design. Absence proves nothing: many DLLs build their references at runtime or read them from configs.)\n");
     }
@@ -492,11 +504,20 @@ static class SkseInventoryWire
     /// everyone else — which is the more useful finding if you are the one shipping it.</summary>
     static void AppendDebugCrt(StringBuilder sb, SkseFileEntry e)
     {
-        if (e.Plugin is not { } p || p.Imports is null) return;   // never walked ⇒ no claim either way
+        if (e.Plugin is not { Imports: not null } p) return;      // never walked ⇒ no claim either way
         var crt = p.DebugCrtImports;
         if (crt.Count == 0) return;
+        sb.Append(DebugCrtVerdict(crt, SksePluginReader.IsSystemDllResolvable));
+    }
 
-        var missing = crt.Where(c => !SksePluginReader.IsSystemDllResolvable(c)).ToList();
+    /// <summary>The Debug-CRT verdict text — PURE, with the machine probe injected, so the guard can pin BOTH wordings
+    /// in one run. Without the seam CI (no Visual Studio) could only ever pin the "will NOT load" arm and a dev box only
+    /// the other, leaving whichever half the current machine doesn't produce unpinned — which is precisely the half that
+    /// would rot unnoticed.</summary>
+    internal static string DebugCrtVerdict(IReadOnlyList<string> crt, Func<string, bool> resolvable)
+    {
+        var missing = crt.Where(c => !resolvable(c)).ToList();
+        var sb = new StringBuilder();
         sb.Append("  [!] DEBUG BUILD — imports the debug C runtime: ").Append(string.Join(", ", crt)).Append('\n');
         if (missing.Count > 0)
             sb.Append("      → will NOT load: ").Append(string.Join(", ", missing))
@@ -506,6 +527,7 @@ static class SkseInventoryWire
         else
             sb.Append("      → it loads on THIS machine (you have the debug runtime installed — Visual Studio), but it will " +
                       "fail with error 126 for anyone who doesn't. If you built this, ship a Release build.\n");
+        return sb.ToString();
     }
 
     /// <summary>The compat one-word tag for the terse roster: "AddrLib", "SigScan", or "LOCKED→[runtimes]".</summary>


### PR DESCRIPTION
Closes the last unbuilt read-ladder tier of #199 — **(D) Static peek — imports / strings, opt-in and noisy**. Plan: `dev/plans/SKSE_TIER_D_STATIC_PEEK_PLAN_2026-07-16.md` (LOCKED 2026-07-16, all three §8 recommendations accepted). No new tool: `peek=` rides `housecarl_skse_inventory` (§8.2), so the count stays **45**.

> **Scope note (post-review).** This PR is no longer tier-D-only: on Aaron's go it also gives the already-merged `housecarl_native_pairing_audit` a seventh load blocker (`83d6bc7`), closing the blind spot tier D exposed. Two tools change here, not one.

## §9 re-review (the plan's own gate, done before Wave 1)

The plan was written before either predecessor was built, so §9 required re-checking it against the shipped code. Outcomes:

1. **Renderer/reader assumptions hold.** `SksePluginReader` gained `ReadBytes`/`RuntimeCompatible`/`IsAeRuntime` from pairing; `SkseInventoryWire.AppendDetail` is exactly the §5.3 extension point. §3b's "same class as version-LOCKED" framing rule is now *better* founded — pairing made version-LOCKED a PASS/FAIL verdict, so a deterministic static "will NOT load" has precedent.
2. **§8.3 (whole-layer Debug-CRT escalation) — decided on measured data, and it's ON.** §9 said to decide this on the whole-layer DLL-walk cost. Measured on ARR 2.0: the inventory **already opens and PE-parses all 297 DLLs on every call**, so the import walk rides that open. **34.1s with the walk vs a 33.1–36.0s baseline on identical code** — inside run-to-run noise. The inventory's real cost is the per-file VFS resolve over 7,192 files, not PE reads.
3. **§1's value ranking stands.** Pairing's game-version `[BUILD-TEST]` PASSED, so §9's "re-argue the case for tier D at all" clause did not fire.

## The cost split that falls out of the measurement

- **Imports** ride the PE open every DLL's manifest read already pays → populated always → the §8.3 escalation is affordable.
- **Strings** scan the whole image → opt-in per-DLL (`peek=` **requires** `filter=`, failing loud per §3a).

## Two refinements the plan's flat Debug-CRT claim needed

- **The list is CURATED, not a `ends in d.dll` pattern.** The D-suffix is a naming convention, not a loader rule — a pattern sweeps in `dinput8`/`d3d11` and every mod DLL ending in 'd'. Pinned with provenance (the version-blob offset-map posture).
- **"Will not load" is machine-DEPENDENT.** The debug CRT ships with Visual Studio, so a debug plugin loads fine on a dev box. houseCARL runs on the modder's machine, so it **checks** instead of assuming. **Not theoretical:** this machine has `vcruntime140d`/`msvcp140d`/`ucrtbased` in System32 — the flat claim would have been a confident wrong answer (Q3) on the very box that ships the tool. Present ⇒ *"loads for you, error 126 for everyone else"*, which is the more useful finding if you're the one shipping the DLL.

## Live gate (ARR 2.0) — every §5.5 bar met

| Target | Result |
|---|---|
| **SkyPatcher.dll** | its **entire config tree**, 30 paths — 27,117 runs scanned → 30 shown (the filter is ~99.9% of the value) |
| **SeranaMultiformNG.dll** | `Dawnguard.esm` + `SeranaMultiformNG.esp`, both cross-checked **present**. Imports the *release* runtime → correctly not flagged |
| **CrashLogger.dll** | `dxgi` hook flagged. **Bundled-dep attribution did NOT fire on the plan's own flagship example** — CrashLogger doesn't statically import `msdia140.dll` (DIA SDK is COM-activated). The tool is right to show nothing; §1's evidence expectation was wrong. Filed in BACKLOG. |
| **Debug-CRT offender** | **ARR carries ZERO** — the sharpest check has no live specimen, so it is pinned synthetically (guard arms G/J) rather than trusted to a live run |
| **Cost** | a peek is unmeasurable against baseline (31.3s / 1 peek) |

## Q3 discipline

- `Imports` is **tri-state**: non-empty = imports; empty = walked, genuinely none; **null = the walk failed**. A failed walk never renders as a clean bill of health (`DebugCrtImportsOf(null)` is empty, never a verdict).
- `ActivePlugins` is null when unresolved → **no name is ever called "absent from the load order" when the question wasn't asked**. *(NOT producible as first pushed — review finding #1; the empty-vs-null gate landed in `2f297a7`. See the review comment.)* The set includes **implicit** (force-loaded) masters, else `Dawnguard.esm` would flag ABSENT on an install that has it.
- The framing line always rides a peek: image contents ≠ behavior (tier E), and **absence proves nothing**.
- Strings scan **ASCII *and* UTF-16LE** — an ASCII-only scan is a confident half-blind answer over a modern C++ plugin.

## Tests

**ci-all 97/97** (96 → 97, +`skse-peek-guard`, 33 arms). Import walk pinned on a real native PE (107 imports; CI is windows-latest); extraction pinned on planted ASCII + UTF-16 fixtures; classification negatives pin the compiler noise (`%s.json`, `basic_string<char>.ini`, bare `.esp`) out of a DLL's "config surface".

## Owed / follow-ups (filed in `dev/BACKLOG.md`)

- ~~**Needs an Aaron call:** feed the Debug-CRT blocker into `native_pairing_audit`.~~ **BUILT** on Aaron's go (`83d6bc7`) — see the scope-extension comment. It rides `LoadBlocker` (no new `Judge` arm), so it lands in PAIRED-BUT-DEAD by construction. **This PR therefore changes a second, already-merged tool's verdicts.** It gets **no empirical gate** — ARR has zero debug plugins and the dev box *has* the debug runtime, so the DEAD path is unreproducible on either; the guard is the only evidence. Live re-gate: the audit is identical to baseline, zero new DEAD.
- `skse_inventory` whole-layer cost is now ~33–36s on ARR (was ~7–9s at the A+C ship) — config-count growth, not a regression, and not tier D's doing. Papercut, not a bug.
- Release ripple at the next cut: tool count stays **45**, but TWO capabilities shipped for the README/changelog/Nexus — `peek=` on `skse_inventory`, **and** `native_pairing_audit`'s seventh load blocker (debug builds), which changes that tool's output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

