### PR TITLE
fix(core): DLBR Flags (DNAM) CK-parity auto-fill — an absent DNAM reads as TopLevel in game (#212)

### DIFF
--- a/src/housecarl-core/DialogueCkParity.cs
+++ b/src/housecarl-core/DialogueCkParity.cs
@@ -43,6 +43,14 @@ namespace HousecarlCore;
 //    • QUST QuestAlias       Flags      (FNAM)     → 0 (no flags), materialised per alias
 //    • QUST QuestAlias       VoiceTypes (VTCK)     → null-link (0x00000000), materialised per alias
 //
+//  SCOPE (S3 — the in-game-behavior tier). The same omitted-subrecord asymmetry, but the consequence is neither a
+//  CK-editor crash (S1) nor a byte-only mismatch the game shrugs off (S2): the RUNNING GAME behaves WRONG (#212).
+//    • DLBR (DialogBranch)   Flags      (DNAM)     → 0 (no flags)
+//  An ABSENT DNAM is read by the engine as TopLevel, so a branch the author never marked top-level is published to
+//  the player's dialogue menu anyway — a nameless Say()-only topic surfaces as a selectable "..." that fires its
+//  lines on click. The output is byte-valid and passes validate_dialogue, so nothing catches it before the game
+//  does; that combination (valid-looking, silently wrong) is what makes this the sharpest tier, not the mildest.
+//
 //  ONE S2 FIELD IS NOT NULLABLE — DIAL Priority is a plain float that defaults to 0, so "the author left it unset"
 //  can't be read off is-null the way every other field here is. The create path detects it from the AUTHOR'S OP LIST
 //  (did any edit touch the Priority path?) and passes that in; a fill happens only when Priority was never mentioned,
@@ -237,16 +245,34 @@ public static class DialogueCkParity
     /// Command appears on just 2 vanilla branches, both deliberately authored. Pinned by the guard.</summary>
     public const DialogBranch.CategoryType BranchCategoryDefault = DialogBranch.CategoryType.Player;
 
+    /// <summary>DLBR Flags (DNAM) CK-parity default — 0 (none of TopLevel/Blocking/Exclusive set), the CK's value for
+    /// a branch whose flag checkboxes the author never ticked. UNLIKE <see cref="BranchCategoryDefault"/>, the
+    /// zero-value is NOT the dominant vanilla value — and that divergence is the whole point, so it is stated here
+    /// rather than left to look like an oversight. Over the 3061 DialogBranches defined in Skyrim.esm (measured
+    /// 2026-07-17): ALL 3061 carry DNAM (none omit it — the CK writes it unconditionally, the #131 asymmetry);
+    /// 2117 are TopLevel, 728 Blocking, 30 Exclusive, and 203 carry it as exactly 0. Those 203 are the proof this
+    /// default is ATTESTED, not invented: a present-but-zero DNAM is a normal CK-authored shape. The 2117 TopLevel
+    /// branches are branches an author deliberately ticked top-level — an authored choice non-override preserves,
+    /// exactly as Category=Command is preserved above. Pinned by the guard.</summary>
+    public const DialogBranch.Flag BranchFlagsDefault = (DialogBranch.Flag)0;
+
     /// <summary>DLBR (DialogBranch) CK-parity default — the Category (TNAM) enum, nullable and omitted by Mutagen when
     /// unset; a CK-authored DialogBranch always carries it. Fill Player (the near-universal value + the enum's
     /// zero-value) UNCONDITIONALLY when the author left it null. A Command branch (a bribe/intimidate speech-challenge
     /// — the only 2 vanilla cases) is a deliberate authored choice that sets Category=Command explicitly, so
     /// non-override leaves it untouched (Aaron-decided 2026-07-04 after the vanilla data falsified the earlier
     /// TopLevel-gated plan: TopLevel doesn't distinguish Player from Command — both Command cases are TopLevel — and
-    /// non-TopLevel branches are reliably Player). Returns the fills applied (empty when the author set a Category).</summary>
+    /// non-TopLevel branches are reliably Player).
+    ///
+    /// ALSO fills the Flags (DNAM) enum — same nullable-and-omitted shape, but S3 (in-game behavior, #212): an absent
+    /// DNAM is read by the engine as TopLevel, publishing a branch the author never marked top-level into the player's
+    /// dialogue menu. Fill 0 (no flags) when the author left it null; an explicit Flags — INCLUDING an explicit
+    /// TopLevel — always wins.
+    ///
+    /// Returns the fills applied (empty when the author set both).</summary>
     public static IReadOnlyList<CkParityFill> ApplyBranchDefaults(IDialogBranch branch)
     {
-        var fills = new List<CkParityFill>(1);
+        var fills = new List<CkParityFill>(2);
 
         if (!HasCategory(branch))
         {
@@ -260,27 +286,55 @@ public static class DialogueCkParity
                 + "untouched. CK-parity default-populate, in-model (#131 pattern)."));
         }
 
+        if (!HasFlags(branch))
+        {
+            branch.Flags = BranchFlagsDefault;
+            fills.Add(new CkParityFill(
+                "Flags (DNAM subrecord) auto-set to 0 (no flags — not top-level, not blocking, not exclusive)",
+                "0 — every CK-authored DialogBranch carries the DNAM (Flags) subrecord, and a branch whose flag "
+                + "checkboxes the author never ticked carries it as 0 (203 of Skyrim.esm's 3061 branches do exactly "
+                + "that). A branch written WITHOUT DNAM is read by the engine as TopLevel, so its topics are published "
+                + "to the player's dialogue menu — a nameless Say()-only topic shows up as a selectable \"...\". This "
+                + "materialises the subrecord only; TopLevel/Blocking/Exclusive stay an explicit authoring choice a "
+                + "0-fill does NOT set, and an explicit Flags always wins. CK-parity default-populate, in-model."));
+        }
+
         return fills;
     }
 
-    // --- DLBR presence predicate: the single home for "does this DialogBranch carry TNAM?", consulted by BOTH
-    //     ApplyBranchDefaults (fills when absent) and MissingBranchDefaults (flags when absent) — no drift (Q3). ---
+    // --- DLBR presence predicates: the single home for "does this DialogBranch carry the CK-parity subrecord?",
+    //     consulted by BOTH ApplyBranchDefaults (fills when absent) and MissingBranchDefaults (flags when absent) —
+    //     no drift (Q3). Flags is an enum-typed nullable (DialogBranch.Flag?), so the null read distinguishes "author
+    //     set no flags" (null → fill 0) from "author set 0 explicitly" (non-null → keep) — the same is-null signal
+    //     every field here uses EXCEPT the non-nullable DIAL Priority (see ApplyTopicPriorityDefault). ---
     static bool HasCategory(IDialogBranchGetter branch) => branch.Category is not null;   // TNAM
+    static bool HasFlags(IDialogBranchGetter branch) => branch.Flags is not null;         // DNAM
 
     /// <summary>The CK-parity subrecord a DLBR (DialogBranch) is MISSING — the read-only counterpart of
     /// <see cref="ApplyBranchDefaults"/>, for the on-demand dialogue validator's DialogBranch input. Shares the exact
-    /// presence predicate the fill path uses, so fill and check can never disagree. S2 (byte-parity only — no
-    /// confirmed crash): a missing TNAM is a structural mismatch vs a CK-authored branch, not a known failure.
-    /// Empty when the branch carries a Category. Reads only the getter; NEVER mutates.</summary>
+    /// presence predicates the fill path uses, so fill and check can never disagree. The two gaps sit in DIFFERENT
+    /// tiers: a missing TNAM is S2 (byte-parity only — a structural mismatch vs a CK-authored branch, not a known
+    /// failure), while a missing DNAM is S3 (#212) — the engine reads it as TopLevel and publishes the branch to the
+    /// player's dialogue menu, a real in-game defect the byte-valid output hides. Empty when the branch carries both.
+    /// Reads only the getter; NEVER mutates.</summary>
     public static IReadOnlyList<CkParityGap> MissingBranchDefaults(IDialogBranchGetter branch)
     {
-        var gaps = new List<CkParityGap>(1);
+        var gaps = new List<CkParityGap>(2);
 
         if (!HasCategory(branch))
             gaps.Add(new CkParityGap("TNAM (Category)",
                 "every CK-authored DialogBranch carries the TNAM (Category) subrecord (~all vanilla branches carry "
                 + "Player); a branch missing it differs structurally from a CK-authored one (byte-parity only — no "
                 + "confirmed crash). houseCARL's create tools auto-fill it — set Category (e.g. Player) to populate it."));
+
+        if (!HasFlags(branch))
+            gaps.Add(new CkParityGap("DNAM (Flags)",
+                "every CK-authored DialogBranch carries the DNAM (Flags) subrecord — as 0 when no flag is ticked (203 "
+                + "of Skyrim.esm's 3061 branches). A branch missing it is read by the ENGINE as TopLevel, so its topics "
+                + "are published to the player's dialogue menu — a nameless Say()-only topic renders as a selectable "
+                + "\"...\". This is an in-game defect, not a byte-parity nit: the record is byte-valid and only "
+                + "misbehaves once loaded. houseCARL's create tools auto-fill it — set Flags (0 for a hidden branch, "
+                + "TopLevel for a player-facing one) to populate it."));
 
         return gaps;
     }

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -2121,7 +2121,7 @@ public static class WritePatchBuilder
                 foreach (var fill in DialogueCkParity.ApplyViewDefaults(viewRec))
                     ops.Add(new OpResult(rec.FormKey, s.RecordType, fill.Label, true, null, fill.Reason));
             }
-            else if (rec is IDialogBranch branchRec)   // S2 — DLBR Category (TNAM)
+            else if (rec is IDialogBranch branchRec)   // S2 — DLBR Category (TNAM); S3 — DLBR Flags (DNAM), #212
             {
                 foreach (var fill in DialogueCkParity.ApplyBranchDefaults(branchRec))
                     ops.Add(new OpResult(rec.FormKey, s.RecordType, fill.Label, true, null, fill.Reason));

--- a/src/housecarl-generator/DialogueCkParityGuardProbe.cs
+++ b/src/housecarl-generator/DialogueCkParityGuardProbe.cs
@@ -12,7 +12,9 @@ namespace HousecarlGenerator;
 /// null optional subrecord on write; the Creation Kit writes it unconditionally — so an INFO created without CNAM
 /// (FavorLevel) / ENAM (Flags) crashes the CK when its topic is opened, and a bare DLVW crashes the CK Dialogue Views
 /// editor (S1); the S2 fields (DLBR Category, DIAL Priority, QUST NextAliasID + objective Flags) are byte-parity only
-/// (no crash) but complete the write the same way. This guard pins the whole surface so it can't drift:
+/// (no crash) but complete the write the same way; the S3 field (DLBR Flags/DNAM, #212) is neither — an absent DNAM is
+/// read by the ENGINE as TopLevel, so a byte-valid branch that passes every check misbehaves in the running game.
+/// This guard pins the whole surface so it can't drift:
 ///   • the create-path AUTO-FILL — create the record through the service and read the written subrecords back off disk,
 ///   • the create-path NON-OVERRIDE — an explicit value is never clobbered,
 ///   • the QUALIFYING VALUES — FavorLevel=None, materialized Flags, DNAM=00, ENAM=00000000 (S1); Category=Player,
@@ -32,7 +34,7 @@ namespace HousecarlGenerator;
 ///                       gaps, and after the fill reports none (a field in one path but not the other breaks this).
 ///   DLVW-GAP-PROBE    — same anti-drift tie for the DLVW: a bare DialogView reports exactly the DNAM+ENAM gaps
 ///                       via MissingViewDefaults, none after ApplyViewDefaults (shared presence predicates).
-///   DLBR-GAP-PROBE    — same tie for the DLBR: a bare DialogBranch reports exactly the TNAM gap via
+///   DLBR-GAP-PROBE    — same tie for the DLBR: a bare DialogBranch reports exactly the TNAM + DNAM gaps via
 ///                       MissingBranchDefaults, none after ApplyBranchDefaults.
 ///   QUST-GAP-PROBE    — same tie for the QUST: a bare quest with one Flags-less objective AND one bare alias reports
 ///                       exactly the ANAM + objective-FNAM + alias-FNAM + alias-VTCK gaps via MissingQuestDefaults,
@@ -43,6 +45,11 @@ namespace HousecarlGenerator;
 ///                       Custom topic WITH a branch raises no such Warning.
 ///   DLBR-TNAM-AUTOFILL — create a bare DialogBranch → written Category=Player (TNAM), REPORTED.
 ///   DLBR-TNAM-WINS     — an explicit Category=Command is NOT overridden to Player.
+///   DLBR-DNAM-AUTOFILL — (S3, #212) create a bare DialogBranch → Flags=0 (DNAM) PRESENT on disk, REPORTED. Presence
+///                       is the assertion, not value: an absent DNAM reads as TopLevel in the ENGINE and publishes the
+///                       branch to the player's dialogue menu, while the fill's value is the zero-value — so only a
+///                       null-vs-zero read distinguishes fixed from broken (the QUST-ALIAS VTCK round-trip lesson).
+///   DLBR-DNAM-WINS     — an explicit Flags=TopLevel is NOT overridden to 0 (a real top-level branch stays visible).
 ///   DIAL-PNAM-AUTOFILL — create a Custom topic with no Priority → written Priority=50 (PNAM), REPORTED.
 ///   DIAL-PNAM-WINS     — an explicit Priority=10 is NOT overridden to 50, AND an explicit Priority=0 STAYS 0 (the
 ///                       non-nullable-float edge: author-set-0 is distinguished from unset, no fill, no op).
@@ -74,6 +81,13 @@ internal static class DialogueCkParityGuardProbe
         // ---- CONST-SHAPE (S2): the pinned seed values are the CK-authored/vanilla defaults (byte-verified 2026-07-04). ----
         Check(DialogueCkParity.TopicPrioritySeed == 50f && DialogueCkParity.BranchCategoryDefault == DialogBranch.CategoryType.Player,
             $"CONST-SHAPE S2 seeds — DIAL Priority=50, DLBR Category=Player — priority={DialogueCkParity.TopicPrioritySeed} category={DialogueCkParity.BranchCategoryDefault}");
+
+        // ---- CONST-SHAPE (S3): the DLBR Flags seed is 0 — NO flag set. The value matters in a way the others don't:
+        //      any non-zero seed here would set TopLevel/Blocking/Exclusive on every authored branch, which is the
+        //      #212 defect with a different sign. Pinned explicitly so a "helpful" default can't drift in. ----
+        Check(DialogueCkParity.BranchFlagsDefault == default(DialogBranch.Flag)
+            && !DialogueCkParity.BranchFlagsDefault.HasFlag(DialogBranch.Flag.TopLevel),
+            $"CONST-SHAPE S3 seed — DLBR Flags=0 (no TopLevel/Blocking/Exclusive) — flags={DialogueCkParity.BranchFlagsDefault} raw={(int)DialogueCkParity.BranchFlagsDefault}");
 
         var root = Path.Combine(Path.GetTempPath(), "hc-dial-ckparity-guard-" + Guid.NewGuid().ToString("N"));
         try
@@ -213,11 +227,13 @@ internal static class DialogueCkParityGuardProbe
             {
                 var br = new DialogBranch(FormKey.Factory("000802:HcCkpGapProbe.esm"), SkyrimRelease.SkyrimSE);
                 var before = DialogueCkParity.MissingBranchDefaults(br);
-                bool flagged = before.Count == 1 && before[0].Subrecord.Contains("TNAM", StringComparison.OrdinalIgnoreCase);
+                bool flagged = before.Count == 2
+                    && before.Any(g => g.Subrecord.Contains("TNAM", StringComparison.OrdinalIgnoreCase))
+                    && before.Any(g => g.Subrecord.Contains("DNAM", StringComparison.OrdinalIgnoreCase));
                 DialogueCkParity.ApplyBranchDefaults(br);
                 int after = DialogueCkParity.MissingBranchDefaults(br).Count;
                 Check(flagged && after == 0,
-                    $"DLBR-GAP-PROBE bare DialogBranch → TNAM gap (before={before.Count}), none after fill (after={after}) — check/fill share one predicate");
+                    $"DLBR-GAP-PROBE bare DialogBranch → TNAM+DNAM gaps (before={before.Count}), none after fill (after={after}) — check/fill share one predicate");
             }
 
             // ---- QUST-GAP-PROBE: the same tie for the Quest — a bare quest with one Flags-less objective AND one bare
@@ -278,7 +294,7 @@ internal static class DialogueCkParityGuardProbe
             // ---- DLBR-TNAM-AUTOFILL: create a bare DialogBranch → written Category=Player (TNAM), REPORTED. ----
             {
                 var o = svc.CreateRecords("DialogBranch", "HcCkpBr", Array.Empty<BulkOp>(), "HcCkpBr", null);
-                var cat = o.Success ? ReadBranch(o.OutputPath, o.Created[0].FormKey) : null;
+                var (cat, _) = o.Success ? ReadBranch(o.OutputPath, o.Created[0].FormKey) : (null, null);
                 bool reported = o.Success && o.Created[0].Ops.Any(op => op.Label.Contains("Category (TNAM", StringComparison.OrdinalIgnoreCase));
                 Check(o.Success && cat == DialogBranch.CategoryType.Player && reported,
                     $"DLBR-TNAM-AUTOFILL bare DialogBranch → Category=Player, reported — {(o.Success ? $"category={cat} reported={reported}" : "err=[" + o.Error + "]")}");
@@ -288,9 +304,35 @@ internal static class DialogueCkParityGuardProbe
             {
                 var ops = new[] { new BulkOp { FieldPath = "Category", Verb = "Set", Value = "Command" } };
                 var o = svc.CreateRecords("DialogBranch", "HcCkpBrCmd", ops, "HcCkpBrCmd", null);
-                var cat = o.Success ? ReadBranch(o.OutputPath, o.Created[0].FormKey) : null;
+                var (cat, _) = o.Success ? ReadBranch(o.OutputPath, o.Created[0].FormKey) : (null, null);
                 Check(o.Success && cat == DialogBranch.CategoryType.Command,
                     $"DLBR-TNAM-WINS explicit Category=Command kept (not overridden to Player) — {(o.Success ? $"category={cat}" : "err=[" + o.Error + "]")}");
+            }
+
+            // ================================  S3 — the in-game-behavior tier (#212)  ================================
+
+            // ---- DLBR-DNAM-AUTOFILL: create a bare DialogBranch → written Flags=0 (DNAM), REPORTED. The empirical
+            //      crux mirrors the QUST alias VTCK arm: the fill's value IS the zero-value, so "filled correctly" and
+            //      "omitted entirely" are indistinguishable by value alone — only PRESENCE on disk separates the fix
+            //      from the bug (absent → engine reads TopLevel → the branch is published to the player's dialogue
+            //      menu, which is the whole defect). Assert the round-tripped Flags is NON-NULL *and* zero. ----
+            {
+                var o = svc.CreateRecords("DialogBranch", "HcCkpBrFl", Array.Empty<BulkOp>(), "HcCkpBrFl", null);
+                var (_, flags) = o.Success ? ReadBranch(o.OutputPath, o.Created[0].FormKey) : (null, null);
+                bool reported = o.Success && o.Created[0].Ops.Any(op => op.Label.Contains("Flags (DNAM", StringComparison.OrdinalIgnoreCase));
+                Check(o.Success && flags is not null && flags == default(DialogBranch.Flag) && reported,
+                    $"DLBR-DNAM-AUTOFILL bare DialogBranch → Flags=0 PRESENT on disk (not omitted), reported — {(o.Success ? $"flags={(flags is null ? "(absent)" : flags.ToString())} reported={reported}" : "err=[" + o.Error + "]")}");
+            }
+
+            // ---- DLBR-DNAM-WINS: an explicit Flags=TopLevel is NOT overridden to 0. The non-override arm that matters
+            //      most here — a player-facing branch is authored by TICKING TopLevel, and a fill that clobbered it
+            //      would hide dialogue that is supposed to show (the #212 defect inverted). Category still auto-fills. ----
+            {
+                var ops = new[] { new BulkOp { FieldPath = "Flags", Verb = "Set", Value = "TopLevel" } };
+                var o = svc.CreateRecords("DialogBranch", "HcCkpBrTop", ops, "HcCkpBrTop", null);
+                var (cat, flags) = o.Success ? ReadBranch(o.OutputPath, o.Created[0].FormKey) : (null, null);
+                Check(o.Success && flags == DialogBranch.Flag.TopLevel && cat == DialogBranch.CategoryType.Player,
+                    $"DLBR-DNAM-WINS explicit Flags=TopLevel kept (not overridden to 0), Category still filled — {(o.Success ? $"flags={flags} category={cat}" : "err=[" + o.Error + "]")}");
             }
 
             // ---- DIAL-PNAM-AUTOFILL: create a Custom topic with no Priority → written Priority=50 (PNAM), REPORTED. ----
@@ -490,17 +532,21 @@ internal static class DialogueCkParityGuardProbe
         finally { (ov as IDisposable)?.Dispose(); }
     }
 
-    /// <summary>Read a created DialogBranch's Category (TNAM) back off the written patch — null when the subrecord is
-    /// absent (Mutagen omits it when Category is unset), else the CategoryType the bytes carry.</summary>
-    static DialogBranch.CategoryType? ReadBranch(string patchPath, FormKey branchFk)
+    /// <summary>Read a created DialogBranch's CK-parity fields back off the written patch: (Category/TNAM, Flags/DNAM).
+    /// Each is null when its subrecord is ABSENT (Mutagen omits it when unset), else the value the bytes carry. The
+    /// null-vs-zero distinction is load-bearing for the DNAM arms: an absent DNAM and a present DNAM=0 are DIFFERENT
+    /// records that the engine reads differently (absent → TopLevel; 0 → no flags, #212), so a Flags of null and a
+    /// Flags of (Flag)0 must never be conflated — which is exactly why this returns the nullable, not a raw value.</summary>
+    static (DialogBranch.CategoryType? category, DialogBranch.Flag? flags) ReadBranch(string patchPath, FormKey branchFk)
     {
         ISkyrimModGetter? ov = null;
         try
         {
             ov = SkyrimMod.CreateFromBinaryOverlay(patchPath, SkyrimRelease.SkyrimSE);
-            return ov.DialogBranches.FirstOrDefault(x => x.FormKey == branchFk)?.Category;
+            var br = ov.DialogBranches.FirstOrDefault(x => x.FormKey == branchFk);
+            return (br?.Category, br?.Flags);
         }
-        catch { return null; }
+        catch { return (null, null); }
         finally { (ov as IDisposable)?.Dispose(); }
     }
 

--- a/src/housecarl-generator/DialogueValidateGuardProbe.cs
+++ b/src/housecarl-generator/DialogueValidateGuardProbe.cs
@@ -515,7 +515,8 @@ public static class DialogueValidateGuardProbe
             all &= Pass("BRANCH-CKPARITY-GAP warns TNAM+DNAM", ok, $"kind={r.InputKind} issues={InputIssues(r)}");
         }
 
-        // ---------- BRANCH-CKPARITY-OK: a Category-set DLBR reports NO input issues — the no-false-positive lock ----------
+        // ---------- BRANCH-CKPARITY-OK: a CK-parity-complete DLBR (ApplyBranchDefaults-filled: TNAM + DNAM) reports
+        //            NO input issues — the no-false-positive lock ----------
         {
             var r = DialogueValidate.Run(resolver, assets, brOkFk);
             bool ok = r.InputKind == "branch" && r.Error is null && r.InputIssues.Count == 0;

--- a/src/housecarl-generator/DialogueValidateGuardProbe.cs
+++ b/src/housecarl-generator/DialogueValidateGuardProbe.cs
@@ -35,9 +35,10 @@ namespace HousecarlGenerator;
 ///   VIEW-CKPARITY-GAP— a bare DLVW input → kind "view", zero topics, and Warnings naming DNAM + ENAM (the CK Dialogue
 ///                  Views crash shape) — end-to-end through the new DialogView input path (shared MissingViewDefaults probe).
 ///   VIEW-CKPARITY-OK — a CK-parity-complete DLVW (ApplyViewDefaults-filled) reports NO input issues — no-false-positive lock.
-///   BRANCH-CKPARITY-GAP— a bare DLBR input → kind "branch" and a Warning naming TNAM (S2 byte-parity) — end-to-end
-///                  through the new DialogBranch input path (shared MissingBranchDefaults probe).
-///   BRANCH-CKPARITY-OK— a Category-set DLBR reports NO input issues — no-false-positive lock.
+///   BRANCH-CKPARITY-GAP— a bare DLBR input → kind "branch" and Warnings naming TNAM (S2 byte-parity) + DNAM (S3
+///                  in-game behavior, #212 — an absent Flags reads as TopLevel and publishes the branch to the player's
+///                  dialogue menu) — end-to-end through the DialogBranch input path (shared MissingBranchDefaults probe).
+///   BRANCH-CKPARITY-OK— a CK-parity-complete DLBR (ApplyBranchDefaults-filled) reports NO input issues — no-false-positive lock.
 ///   QUST-CKPARITY-GAP— a QUEST input whose quest lacks ANAM and has a Flags-less objective → InputIssues warns BOTH,
 ///                  ONCE at quest level (never per topic) — the shared MissingQuestDefaults probe end-to-end.
 ///   QUST-CKPARITY-OK — a CK-parity-complete quest (ApplyQuestDefaults-filled) reports NO input issues — no-false-positive lock.
@@ -385,11 +386,14 @@ public static class DialogueValidateGuardProbe
             var vOk = m.DialogViews.AddNew(); vOk.EditorID = "HcDvViewOk";
             DialogueCkParity.ApplyViewDefaults(vOk); viewOkFk = vOk.FormKey;
 
-            // BRANCH-CKPARITY (the new DLBR input kind): a BARE DialogBranch (no Category/TNAM) vs one with an
-            // explicit Category. (The shared `branch` fixture above is only ever a Branch TARGET, never an input.)
+            // BRANCH-CKPARITY (the new DLBR input kind): a BARE DialogBranch (no Category/TNAM, no Flags/DNAM) vs a
+            // CK-parity-COMPLETE one. (The shared `branch` fixture above is only ever a Branch TARGET, never an input.)
+            // The OK fixture is filled via the SAME ApplyBranchDefaults the create path runs (the DLVW/QUST OK-fixture
+            // pattern) rather than hand-setting each field — so a field added to the fill can't leave this fixture
+            // half-built and quietly turn the no-false-positive lock into a failure that looks like a real gap.
             var brGap = m.DialogBranches.AddNew(); brGap.EditorID = "HcDvBrGap"; brGapFk = brGap.FormKey;
             var brOk = m.DialogBranches.AddNew(); brOk.EditorID = "HcDvBrOk";
-            brOk.Category = DialogBranch.CategoryType.Player; brOkFk = brOk.FormKey;
+            DialogueCkParity.ApplyBranchDefaults(brOk); brOkFk = brOk.FormKey;
 
             // QUST-CKPARITY (quest-level InputIssues): a quest lacking ANAM with one Flags-less objective (both
             // gaps) vs a CK-parity-complete quest (ApplyQuestDefaults-filled). Neither owns any topics — the arms
@@ -500,12 +504,15 @@ public static class DialogueValidateGuardProbe
             all &= Pass("VIEW-CKPARITY-OK not flagged", ok, $"kind={r.InputKind} issues={InputIssues(r)}");
         }
 
-        // ---------- BRANCH-CKPARITY-GAP: a bare DLBR input → kind "branch", a Warning naming TNAM ----------
+        // ---------- BRANCH-CKPARITY-GAP: a bare DLBR input → kind "branch", Warnings naming TNAM + DNAM ----------
+        // DNAM is the #212 arm: an absent Flags subrecord is read by the engine as TopLevel, so the validator must
+        // say so on a branch that LOOKS fine (byte-valid, no other finding) — the whole point of the lint.
         {
             var r = DialogueValidate.Run(resolver, assets, brGapFk);
             bool ok = r.InputKind == "branch" && r.Error is null && r.Topics.Count == 0
-                && r.InputIssues.Any(i => i.Severity == DialogueIssueSeverity.Warning && i.Message.Contains("TNAM", StringComparison.Ordinal));
-            all &= Pass("BRANCH-CKPARITY-GAP warns TNAM", ok, $"kind={r.InputKind} issues={InputIssues(r)}");
+                && r.InputIssues.Any(i => i.Severity == DialogueIssueSeverity.Warning && i.Message.Contains("TNAM", StringComparison.Ordinal))
+                && r.InputIssues.Any(i => i.Severity == DialogueIssueSeverity.Warning && i.Message.Contains("DNAM", StringComparison.Ordinal));
+            all &= Pass("BRANCH-CKPARITY-GAP warns TNAM+DNAM", ok, $"kind={r.InputKind} issues={InputIssues(r)}");
         }
 
         // ---------- BRANCH-CKPARITY-OK: a Category-set DLBR reports NO input issues — the no-false-positive lock ----------

--- a/src/housecarl-mcp/DialogueTools.cs
+++ b/src/housecarl-mcp/DialogueTools.cs
@@ -96,7 +96,7 @@ static class DialogueWire
             if (r.InputIssues.Count == 0)
                 sb.Append("  CK-parity: OK — ").Append(r.InputKind == "view"
                     ? "the DNAM and ENAM byte subrecords the Creation Kit always writes are both present.\n"
-                    : "the TNAM (Category) subrecord the Creation Kit always writes is present.\n");
+                    : "the TNAM (Category) and DNAM (Flags) subrecords the Creation Kit always writes are both present.\n");
             else
                 AppendIssues(sb, r.InputIssues, "  ", cap);
             sb.Append("scope: this is a record-level CK-parity check only — it does not validate any dialogue graph, "


### PR DESCRIPTION
Closes #212.

## The defect

`bulk_create`'s CK-parity auto-fill covered DLBR `Category` (TNAM) but not `Flags` (DNAM). Mutagen omits a null optional subrecord on write; the **engine reads an absent DNAM as TopLevel**. So a branch the author never marked top-level was published to the player's dialogue menu anyway — a nameless `Say()`-only afterglow topic surfaced as a selectable `"..."` that fired its lines on click.

The output was byte-valid and `validate_dialogue` passed it. Nothing caught it before the game did.

## The fix

Both of the report's asks land off the two shared methods in the one authority (`DialogueCkParity`):

- `ApplyBranchDefaults` fills `Flags → 0` when the author left it null — surfaced as an `OpResult` via `WritePatchBuilder`, so the fill is never silent (Q3).
- `MissingBranchDefaults` flags an absent DNAM — a `validate_dialogue` Warning.

Both read **one shared presence predicate** (`HasFlags`), so the fill side and the check side cannot drift.

## A new tier: S3

This fits neither existing tier, and calling it S2 would have understated it:

| Tier | Consequence |
|---|---|
| S1 | Confirmed CK-editor crash |
| S2 | Byte-parity mismatch the game tolerates |
| **S3** | **Byte-valid, passes every check, misbehaves in the running game** |

Filed in the same authority per the header's standing instruction ("Add S3+ defaults here too — do not fork a parallel path").

## The default value is measured, not invented

Invariant #3 requires defaults be byte-verified against vanilla. Over the **3061** DialogBranches defined in `Skyrim.esm`:

- **All 3061 carry DNAM** — none omit it (the #131 asymmetry, confirmed).
- 2117 TopLevel · 728 Blocking · 30 Exclusive
- **203 carry it as exactly 0.**

Those 203 are the attestation: a present-but-zero DNAM is a normal CK-authored shape, and it is exactly what the reporter's CK-authored twin (`ST_Vesyra_AfterglowBranch`) carried.

**Reviewer's attention here** — this **diverges from the Category precedent** and the divergence is documented in the constant's doc rather than left to look like an oversight. For Category, `Player` was *both* the enum zero-value *and* the dominant vanilla value (3059/3061). For Flags they part company: 0 is 203/3061, while TopLevel is 2117. Filling 0 is still correct — the 2117 TopLevel branches are ones an author *deliberately ticked*, an authored choice non-override preserves, exactly as `Category=Command` is preserved.

## Guard arms

- **`DLBR-DNAM-AUTOFILL`** — asserts **presence on disk, not value**. The fill *is* the zero-value, so "filled correctly" and "omitted entirely" are indistinguishable by value alone; only a null-vs-zero read separates the fix from the bug. (The QUST-ALIAS VTCK round-trip lesson — and it confirms a present-but-zero DNAM does survive serialisation.)
- **`DLBR-DNAM-WINS`** — an explicit `Flags=TopLevel` is never clobbered. The inverse defect would *hide* dialogue meant to show.
- **`CONST-SHAPE (S3)`** — pins the seed at 0; any non-zero default would be #212 with a different sign.
- **`DLBR-GAP-PROBE`** — now expects TNAM+DNAM.
- **`RENDER-SCOPE-PIN`** — did its job unprompted: it failed until the validator's "CK-parity: OK" prose named DNAM (it derives the checked set by construction, never hand-listed).
- **`BRANCH-CKPARITY-OK`** — fixture now builds via `ApplyBranchDefaults` rather than hand-setting fields, so a future field can't leave it half-built and turn the no-false-positive lock into a failure that looks like a real gap.

## Behavior change worth naming

A create that previously produced an absent DNAM (→ engine reads TopLevel) now produces an explicit `Flags=0` (→ hidden). That is the point of the fix, but it does mean a branch authored to be player-facing must now say so — `Flags = TopLevel` — which is what `dialogue-branch.md` already instructs, and what `DLBR-DNAM-WINS` pins. Create-lane only; no existing plugin is touched.

## Evidence

`ci-all` **96/96**. Empirical gate (in-game) not yet walked — the reporter's live workaround (`Set Flags = 0`) is the same value this now fills automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
