### PR TITLE
release: 1.9.0 — SKSE layer diagnosis (native_pairing_audit + skse_config_audit) + skse_inventory peek=

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -8,7 +8,7 @@ body:
     attributes:
       label: houseCARL version
       description: Fixes often land on `main` before a release — the version tells us whether you're hitting a known-fixed gap.
-      placeholder: "1.8.0"
+      placeholder: "1.9.0"
     validations:
       required: true
   - type: textarea

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ models — by construction, not a hand-maintained subset.
 - **See the SKSE-plugin layer** — inventory the DLLs and their config files under `Data\SKSE\Plugins`, each
   resolved to the mod that wins it (with the full conflict chain), and read each winning DLL's declared version
   metadata — name, author, target runtime, Address-Library flag — statically, without loading it.
+- **Audit that layer for what's actually broken** — cross-check the native Papyrus functions your scripts
+  declare against the DLLs that must implement them (catching a mod whose scripts are installed but whose DLL
+  is missing, 32-bit, built for the wrong game version, or a debug build that won't load — so its calls
+  silently no-op), and cross-check the form references your SKSE configs declare against your real load order
+  (a dangling FormID caught here, instead of by a silent in-game failure). Or peek inside a single DLL's
+  image — its imports and the config paths and plugin names it embeds — to see what an unfamiliar plugin
+  touches. Static and report-only.
 - **See through the SkyPatcher layer** — inventory every SkyPatcher INI in your load order at once (apply
   order, VFS shadows, INI-vs-INI conflicts, and dead / duplicate / no-op writes), or read one record's
   *true* state after the whole SkyPatcher layer has replayed over it — so a runtime INI edit is as visible
@@ -100,7 +107,7 @@ models — by construction, not a hand-maintained subset.
 
 ### Download — recommended (modders)
 
-1. Download **`houseCARL-1.8.0.zip`** from the [latest release](https://github.com/Avick3110/houseCARL/releases).
+1. Download **`houseCARL-1.9.0.zip`** from the [latest release](https://github.com/Avick3110/houseCARL/releases).
 2. Unzip it and run **`houseCARL-Setup.exe`**.
 3. Pick your host — **`[1] Claude Code`**, **`[2] Codex`**, or **`[3] Both`**. The installer wires
    everything up:
@@ -130,7 +137,7 @@ cd houseCARL
 
 The script regenerates the reflection rulebook, publishes the server framework-dependent (trimming **off**
 — houseCARL is reflection-driven, so trimming would strip types and silently lose coverage), bundles the
-skills, builds the setup utility, and packs `release/houseCARL-1.8.0.zip`. Install the output with
+skills, builds the setup utility, and packs `release/houseCARL-1.9.0.zip`. Install the output with
 `houseCARL-Setup.exe`, `claude --plugin-dir ./dist/housecarl`, or the bundled local-marketplace
 descriptor — see the script header for details.
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "housecarl",
   "displayName": "houseCARL",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "Comprehensive data-layer access to your Skyrim SE load order — read any record, author patches into a new plugin, look mods up on Nexus, and look up record schemas, Papyrus signatures, performance reviews, and distributor grammars — in plain English.",
   "author": { "name": "Avick3110" },
   "homepage": "https://github.com/Avick3110/houseCARL",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -4,6 +4,55 @@ All notable changes to houseCARL are documented here. Versioning is [semantic](h
 the `version` in `.claude-plugin/plugin.json` is bumped on each release, so installed users update only
 when it changes.
 
+## 1.9.0 — 2026-07-17
+
+houseCARL's view of the **SKSE-plugin layer** grows from *inventory* into *diagnosis*: two new audit tools
+that catch a broken native pairing or a dead config reference statically — before the game fails silently on
+it — completing the SKSE layer-visibility ladder (tiers A→D, #199). **Two new tools (→ 45), no new skills
+(still 13).**
+
+**SKSE layer diagnosis — two new audit tools**
+
+- **`housecarl_native_pairing_audit` — the native functions your scripts declare vs the DLLs that must
+  implement them.** A native Papyrus function is one thing declared in two files that ship and fail
+  independently: a `.pex` class flags the function, and an SKSE DLL registers the implementation at runtime.
+  When the halves don't meet, the engine logs a cryptic "unable to bind" and the calls silently no-op. This
+  scans the winning copy of every compiled script (loose + BSA) and pairs each native-declaring class to the
+  DLLs its mod ships under `SKSE\Plugins`, leading with the findings: **PAIRED-BUT-DEAD** — scripts installed,
+  but every candidate DLL statically will not load (wrong game runtime for a version-locked plugin, BSA-only,
+  shipped in a subfolder, 32-bit, unreadable, or built against the debug CRT) — and **UNPAIRED** — no DLL in
+  sight, a VERIFY flag, typically a declaration copy of a framework you don't have. It keeps the engine
+  baseline honest by construction (a class carried by an official archive is the engine's, even when an SKSE
+  loose override wins the file), and answers "is the pairing plausible and healthy", never "does the DLL
+  register exactly these functions" — runtime behaviour, the honest tier-E ceiling it never crosses.
+- **`housecarl_skse_config_audit` — the form references your SKSE configs declare vs your real load order.**
+  Reads the winning copy of every `.ini` / `.toml` / `.json` / `.yaml` config across the full depth of
+  `Data\SKSE\Plugins`, extracts every form-shaped reference (a hex FormID paired with a plugin name in either
+  order — the DSD/po3, SkyPatcher, and tilde forms — plus plugin-named folder gates), and resolves each to a
+  verdict: **OK**, **PLUGIN MISSING**, **DANGLING** (plugin present but no such record), or **UNPARSEABLE**.
+  The summary separates **BROKEN** (dangling / unparseable — actionable) from **INERT** (a plugin you don't
+  have installed — usually optional support), so a genuinely broken patch is caught by houseCARL instead of by
+  a silent in-game failure. Framework-agnostic: it checks reference *validity*, never what a reference is
+  *for* (that's per-framework skill territory) or what the DLL *does* with it (the honest ceiling).
+
+**Enhancement**
+
+- **`housecarl_skse_inventory` gains `peek=` — a static peek inside a specific DLL's image.** With `filter=`
+  naming a DLL, `peek=true` reports the DLL's imports and the config paths and plugin names it embeds —
+  answering "what does this unfamiliar DLL touch" without loading it. Per-DLL by design (a whole-layer peek
+  would read every image and drown signal in noise), so a bare `peek=true` fails loud asking for a filter.
+
+**Fixes**
+
+- **`check_errors` no longer false-flags a faction owner's required rank as a dangling reference.** A record
+  owned by a faction at a required rank was misread as carrying a broken link; the rank is a valid part of the
+  ownership structure, not a form reference, and is now recognized. (#207)
+- **`bulk_create` / `create_record` now fill a dialogue branch's `Flags` (DNAM).** Mutagen omits a null
+  optional subrecord, and the engine reads an absent DNAM as **top-level** — so a `DialogBranch` you never
+  marked top-level was silently published to the player's dialogue menu: byte-valid, passing every check, wrong
+  only once the game loaded it. The CK-parity auto-fill now seeds `Flags` (matching how it already handles
+  `Category`), surfaced as an explicit op, and `validate_dialogue` warns when a branch carries no DNAM. (#212)
+
 ## 1.8.1 — 2026-07-16
 
 A small read/query-surface patch: two refinements that let a whole-plugin audit and a record read land the

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -50,6 +50,12 @@ It can:
 - **See the SKSE-plugin layer** — inventory the DLLs and their configs under `Data\SKSE\Plugins`, each
   resolved to the mod that wins it (with the conflict chain), and read each winning DLL's version metadata
   (name, author, target runtime, Address-Library flag) statically, without loading it.
+- **Audit that layer for what's broken** — cross-check the native Papyrus functions your scripts declare
+  against the DLLs that must implement them (a mod whose scripts are installed but whose DLL is missing,
+  32-bit, built for the wrong runtime, or a debug build that won't load — its calls silently no-op), and
+  cross-check the form references your SKSE configs declare against your real load order (a dangling FormID
+  caught here, not by a silent in-game failure). Or peek inside one DLL's image — its imports and the config
+  paths and plugin names it embeds — to see what an unfamiliar plugin touches. Static, report-only.
 - **See through the SkyPatcher layer** — inventory every SkyPatcher INI in your load order at once (apply
   order, VFS shadows, INI-vs-INI conflicts, and dead / duplicate / no-op writes), or read one record's *true*
   state after the whole SkyPatcher layer has replayed over it — a runtime INI edit made as visible as a plugin


### PR DESCRIPTION
## 1.9.0 — MINOR cut

**Source-verified scope** (McpServerTool registration diff `v1.8.1..main`): **43 → 45 tools**, **13 skills** unchanged. Completes the SKSE layer-visibility ladder (tiers A→D, #199 CLOSED).

The `v1.8.1..main` range is **23 commits** — the two new tools plus two user-facing fixes the last handoff's "10 commits" summary had missed (the entire tier-B `config_audit` wave, and #207). A full commit-audit caught them; all are in the changelog.

### What ships
**New tools**
- `housecarl_native_pairing_audit` — native Papyrus declarations vs the DLLs that must implement them; leads with PAIRED-BUT-DEAD / UNPAIRED (tier D).
- `housecarl_skse_config_audit` — SKSE config form references vs the real load order; BROKEN (dangling/unparseable) vs INERT (plugin-missing) (tier B).

**Enhancement**
- `housecarl_skse_inventory` gains `peek=` — a per-DLL static image peek (imports + embedded config paths / plugin names).

**Fixes folded in since v1.8.1**
- `check_errors` no longer false-flags a faction owner's required rank as a dangling reference (#207).
- `bulk_create` / `create_record` fill a dialogue branch's `Flags` (DNAM) so it isn't silently published as top-level in game (#212).

### Commits
- `docs:` staleness sweep — both READMEs' SKSE bullets described only *inventory* (silent on the two audit tools + `peek=`); refreshed, plus the root README's stale `houseCARL-1.8.0.zip` filename (missed at the 1.8.1 PATCH cut) and the bug-report version placeholder.
- `release:` 1.9.0 — `plugin.json` bump + CHANGELOG section.

### Gates (all green)
- **Build** via `scripts/build-plugin.ps1`: v1.9.0, **335 entries / 16.83 MB**, 13 skills, **leak-check clean**, corpus 133 types no anomalies.
- **`claude plugin validate --strict`: ✓ passed.**
- **`ci-all`: 97/97.**
- Release zip SHA256 `56349058CDF6A090D2029DEDF283DB0AAA66A13DDD9560864BDCEECCED376947` (17,647,713 B). Zip is not byte-deterministic; branch is based on `main` tip so the merged tree == the built tree.

### Empirical gate — waived (consistent with every cut since 1.5.0)
Both new tools were already live-gated on ARR 2.0 (297-DLL layer, 47,950 scripts). The sharpest synthetic paths (Debug-CRT DEAD, delay-load) are unreproducible on this box, so a local gate can't walk them — they're pinned by guards.

### Nexus note
The Nexus page is still on **1.8.0** (the 1.8.1 upload never went live), so the Nexus changelog rolls **1.8.1 + 1.9.0** — drafted at `dev/plans/nexus-changelog-1.9.0.txt` (Aaron's manual upload lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)