### PR TITLE
fix(write): G8 base-compose refusal names the dotted-subfield lane on a concrete base (#211)

### DIFF
--- a/src/housecarl-core/CorpusRulebook.cs
+++ b/src/housecarl-core/CorpusRulebook.cs
@@ -916,11 +916,25 @@ public sealed class CorpusRulebook
         // base instance. Filter the base (leaf.TypeRef — this method is only reached for a polymorphic field) out of the
         // legal set, and reject composing the base itself. Symmetric with StructElementLegality; closes the SECOND
         // composition entry point so the poly-base-by-own-name class is shut at both, by construction.
+        // A concrete base is ALSO the one shape where "no listed arm fits" is real — the field's live type can BE the
+        // base (DialogResponses' ScriptFragments: only arm is the SCENE one), so the refusal must name the working
+        // lane (dotted-subfield Sets, pre-flight-descended since the poly-field-descend fix) or it dead-ends the
+        // caller (#211). Recognizer: the field's MUTABLE AQ resolves to a concrete CLASS (the emitted arm lists have
+        // the base's self-listing stripped, so arms can't tell). An abstract base resolves abstract — there a listed
+        // arm always fits, so the hint stays off.
         var baseName = leaf.TypeRef;
         var legal = (leaf.Arms ?? (baseName is { } tr ? Type(tr)?.Arms : null) ?? new()).Where(a => a != baseName).ToList();
         if (baseName is not null && arm.Type == baseName)
+        {
+            var dottedLane = leaf.MutableTypeAssemblyQualified is { } aq
+                             && WriteEngine.ResolveType(aq) is { IsAbstract: false, IsInterface: false }
+                ? $" If no listed arm fits this record (the field's live type is the base itself), skip the compose " +
+                  $"and Set the base's subfields by dotted path instead ('{leaf.Name}.<subfield>' — the field " +
+                  $"auto-instantiates on first Set)."
+                : "";
             return $"'{arm.Type}' is the polymorphic base of '{leaf.Name}' — the base itself cannot be composed; " +
-                   $"choose a concrete arm. Legal arms: {string.Join(", ", legal)}.";
+                   $"choose a concrete arm. Legal arms: {string.Join(", ", legal)}.{dottedLane}";
+        }
         if (!legal.Contains(arm.Type))
             return $"Illegal arm '{arm.Type}' for '{leaf.Name}'. Legal arms: {string.Join(", ", legal)}.";
         var armSchema = Type(arm.Type);

--- a/src/housecarl-generator/NestedCreateGuardProbe.cs
+++ b/src/housecarl-generator/NestedCreateGuardProbe.cs
@@ -1886,8 +1886,25 @@ public static class NestedCreateGuardProbe
             var reject = rulebook.Validate(req);
             gap3RejBaseArmFieldOk = reject is not null
                 && reject.Contains("polymorphic base", StringComparison.OrdinalIgnoreCase)
-                && reject.Contains("SceneScriptFragments", StringComparison.Ordinal);   // a real arm is offered instead
-            Console.WriteLine($"   GAP3-REJ-BASEARM-FIELD poly field  : {(gap3RejBaseArmFieldOk ? "PASS — a standalone poly-FIELD Set composing the base 'ScriptFragments' refuses via ArmLegality (RED before: accepted, then silent-write)" : $"FAIL — reject=[{reject}]")}");
+                && reject.Contains("SceneScriptFragments", StringComparison.Ordinal)    // a real arm is offered instead
+                && reject.Contains("dotted path", StringComparison.Ordinal);            // #211: the CONCRETE-base refusal names the working dotted-subfield lane, not just a dead-end arm list
+            Console.WriteLine($"   GAP3-REJ-BASEARM-FIELD poly field  : {(gap3RejBaseArmFieldOk ? "PASS — a standalone poly-FIELD Set composing the base 'ScriptFragments' refuses via ArmLegality AND names the dotted-subfield lane (RED before: accepted, then silent-write; #211: arm-list-only dead end)" : $"FAIL — reject=[{reject}]")}");
+        }
+
+        // ---------- GAP3-REJ-BASEARM-FIELD-ABS: the hint is NARROW — an ABSTRACT base's refusal carries NO dotted-lane hint ----
+        // The #211 hint keys on the field's mutable AQ resolving to a concrete CLASS (the emitted arm lists have the
+        // base's self-listing stripped, so arms can't tell). An abstract base (ANpcLevel on NpcConfiguration.Level)
+        // resolves abstract and a listed arm always fits, so its refusal must stay hint-free — the negative control
+        // proving the hint doesn't leak into cases where "compose a real arm" is the right answer.
+        bool gap3RejBaseArmFieldAbsOk;
+        {
+            var req = new WriteRequest { RecordType = "Npc", Path = new[] { "Configuration", "Level" },
+                Verb = "Set", Struct = new StructSpec { Type = "ANpcLevel" } };
+            var reject = rulebook.Validate(req);
+            gap3RejBaseArmFieldAbsOk = reject is not null
+                && reject.Contains("polymorphic base", StringComparison.OrdinalIgnoreCase)
+                && !reject.Contains("dotted path", StringComparison.Ordinal);
+            Console.WriteLine($"   GAP3-REJ-BASEARM-FIELD-ABS abstract: {(gap3RejBaseArmFieldAbsOk ? "PASS — an ABSTRACT base ('ANpcLevel') still refuses with NO dotted-lane hint (the #211 hint is scoped to concrete bases)" : $"FAIL — reject=[{reject}]")}");
         }
 
         // ---------- GAP3-OK-ARMFIELD-UNCHANGED: a REAL arm on the same poly field still accepts (no over-reject) ----------
@@ -2664,7 +2681,7 @@ public static class NestedCreateGuardProbe
                     && gap4OkSetIdxComposeOk && gap4RejSetIdxNoStructOk && gap4OkSetIdxComposeE2eOk
                     && gap3OkE2eOk && gap3OkE2eSetOk && gap3RejDupOk
                     && gap3RejBaseArmOk && gap3RejBaseArmListOk && gap3OkBaseNoOverRejectOk && gap3RejBaseArmE2eOk
-                    && gap3RejBaseArmFieldOk && gap3OkArmFieldUnchangedOk
+                    && gap3RejBaseArmFieldOk && gap3RejBaseArmFieldAbsOk && gap3OkArmFieldUnchangedOk
                     && expectedRejSetIdxOobOk && expectedRejRemoveIdxOobOk && expectedOkSetIdxInRangeOk && expectedNavTypeOk
                     && expectedRejNavE2eOk
                     && malformedNavTypeOk


### PR DESCRIPTION
Closes the residual from #211 (the capability was already live; the refusal message was the leftover).

## What
The `ArmLegality` reject for composing a polymorphic base by its own name said only "choose a concrete arm. Legal arms: …" — a dead end when no listed arm fits the record. The canonical case is `DialogResponses` → `VirtualMachineAdapter.ScriptFragments`: the only concrete arm is `SceneScriptFragments` (the SCENE shape), wrong for a TopicInfo fragment, so the refusal steered away from the fix.

Now, when the field's mutable AQ resolves to a **concrete class** — the one shape where the field's live type can *be* the base — the refusal appends the working lane:

> … Legal arms: SceneScriptFragments. If no listed arm fits this record (the field's live type is the base itself), skip the compose and Set the base's subfields by dotted path instead ('ScriptFragments.\<subfield\>' — the field auto-instantiates on first Set).

## Why the concreteness recognizer
The emitted arm lists have the base's self-listing stripped (since `01269e0`), so arms can't distinguish concrete from abstract bases. Resolving the field's mutable AQ can: a concrete base (`ScriptFragments`) → hint on; an abstract base (`ANpcLevel`) → hint off, because there a listed arm always fits and the hint would mislead.

## Guards
- `GAP3-REJ-BASEARM-FIELD` tightened: now also requires the dotted-lane hint (RED against the old arm-list-only message — verified: the first recognizer attempt failed exactly this assertion).
- New `GAP3-REJ-BASEARM-FIELD-ABS`: negative control — an abstract base's refusal carries **no** hint.
- ci-all: **97/97 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)