### PR TITLE
feat(bsa): read BSAs via Mutagen's in-process reader; extract works on archives BSArch can't (#217)

### DIFF
--- a/src/housecarl-core/BsaArchive.cs
+++ b/src/housecarl-core/BsaArchive.cs
@@ -1,123 +1,171 @@
 using System.Diagnostics;
-using System.Text.RegularExpressions;
+using System.IO.Abstractions;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Archives;
 
 namespace HousecarlCore;
 
-/// <summary>The parsed result of a BSArch -list. <see cref="RunError"/> non-null ⇒ BSArch couldn't be RUN (bad path /
-/// timeout). <see cref="Success"/> means the archive was read and the file list matched its declared count.</summary>
+/// <summary>The result of listing an archive. <see cref="RunError"/> non-null ⇒ the archive couldn't be opened/read
+/// (bad path, not a Bethesda archive, corrupt header); otherwise <see cref="Success"/> and <see cref="Files"/> hold the
+/// contained paths.</summary>
 public sealed record BsaListResult(
     bool Success, string? Format, int DeclaredCount, IReadOnlyList<string> Files, string Raw, string? RunError)
 {
     public bool Ran => RunError is null;
 }
 
-/// <summary>The result of a BSArch unpack/pack. <see cref="RunError"/> non-null ⇒ the operation never ran BSArch
-/// (bad path / timeout / a stuck stale scratch refused up front); otherwise <see cref="Success"/> is decided by
-/// THIS-RUN artifact provenance (unpack: entries added or changed since the pre-run snapshot; pack: a fresh,
-/// non-empty scratch written at/after the run baseline), never by the exit code alone.</summary>
+/// <summary>The result of an unpack (Mutagen) or pack (BSArch). <see cref="RunError"/> non-null ⇒ the operation never
+/// really ran (archive couldn't be opened / BSArch couldn't be launched / a stuck stale scratch refused up front);
+/// otherwise <see cref="Success"/> reflects what was actually written this run.</summary>
 public sealed record BsaResult(bool Success, string Raw, string? RunError)
 {
     public bool Ran => RunError is null;
 }
 
 /// <summary>
-/// Drives BSArch (zilav/ElminsterAU/Sheson; ships with xEdit) to list / unpack / pack Bethesda .bsa archives — the engine
-/// behind the housecarl_bsa_* tools. Mutagen has no archive surface, so this wraps the external exe (a bounded
-/// ProcessStartInfo + parser). Grounded against the real BSArch v0.9c CLI (measured 2026-06-05):
-///   • list  : `BSArch &lt;archive&gt; -list`  → banner + info block (incl. "Files: N"), a blank line, then N file paths.
-///   • unpack: `BSArch unpack &lt;archive&gt; &lt;folder&gt; -mt`  (WHOLE archive — BSArch has no per-file extract).
-///   • pack  : `BSArch pack &lt;folder&gt; &lt;archive&gt; -sse [-z] -mt`  (-sse = Skyrim SE; -z compresses but BREAKS
+/// The engine behind the housecarl_bsa_* tools. READS (list + extract) go through <b>Mutagen's own BSA reader</b>
+/// (<see cref="Archive.CreateReader"/> in Mutagen.Bethesda.Core — a maintained, in-process parser that handles every
+/// version, compression, and embedded-name layout, and returns each file's decompressed bytes). No external tool is
+/// needed to list or extract. WRITES (repack) still drive <b>BSArch</b> (zilav/ElminsterAU/Sheson; ships with xEdit),
+/// because Mutagen 0.53.1 exposes a reader but no BSA writer.
+///
+/// This replaces the earlier design that shelled BSArch for reads too: BSArch's unpacker is stricter than its own
+/// lister and the game engine, so an archive written by a non-BSArch tool could list + load in-game yet unpack to
+/// nothing (#217). Mutagen's reader matches BSArch byte-for-byte on conformant archives (verified in bsa-probe) and
+/// reads the archives BSArch's unpacker rejects, so the whole read path is both simpler and more robust.
+///   • list  : Archive.CreateReader(SkyrimSE, path).Files → the contained paths + count.
+///   • unpack: same, writing each IArchiveFile's bytes to the dest (path-traversal-guarded, content-aware/idempotent).
+///   • pack  : `BSArch pack &lt;folder&gt; &lt;archive&gt; -sse [-z] -mt` (-sse = Skyrim SE; -z compresses but BREAKS
 ///             sounds/voices, so uncompressed is the safe default).
-/// Pure (no DI): the build-time probe drives this exact code against real BSArch + real .bsa.
+/// Pure (no DI): the build-time probes drive this exact code.
 /// </summary>
 public static class BsaArchive
 {
-    static readonly Regex FilesCount = new(@"^\s*Files:\s*(\d+)\s*$", RegexOptions.Multiline | RegexOptions.Compiled);
-    static readonly Regex FormatLine = new(@"^\s*Format:\s*(.+?)\s*$", RegexOptions.Multiline | RegexOptions.Compiled);
+    // houseCARL is Skyrim SE; the reader keys off the header version, so this also reads v103/v104 archives.
+    static readonly IFileSystem Fs = new FileSystem();
 
-    /// <summary>List an archive's contents. BSArch prints "Files: N" in the info block, then the N paths as the final
-    /// block, so the file list is taken as the LAST N non-empty lines. NOTE (hunt H4 — parse fix DEFERRED, needs real
-    /// BSArch output to fix safely): this is immune to LEADING banner/info-block growth, but NOT to the path block
-    /// UNDER-producing — if BSArch prints fewer than N path lines, the last-N window slides UP into the info block and
-    /// absorbs banner/"Files:" lines AS paths (files.Count still == declared, so it reads as success). The real fix is
-    /// a delimiter-anchored parse (the paths after the last blank line) + a LOUD count-mismatch, landed against a
-    /// captured real-BSArch fixture; it is intentionally not attempted blind here.</summary>
-    public static BsaListResult List(string bsarchExe, string archive, int timeoutMs = 60_000)
+    /// <summary>List an archive's contents via Mutagen. On an unreadable/corrupt/non-archive file the failure is
+    /// surfaced in <see cref="BsaListResult.RunError"/> (Ran=false), never a silent empty list.</summary>
+    public static BsaListResult List(string archive)
     {
-        var run = Run(bsarchExe, new[] { archive, "-list" }, timeoutMs);
-        if (run.runError is not null)
-            return new BsaListResult(false, null, 0, Array.Empty<string>(), run.stdout + run.stderr, run.runError);
-
-        var format = FormatLine.Match(run.stdout) is { Success: true } fm2 ? fm2.Groups[1].Value.Trim() : null;
-        var fm = FilesCount.Match(run.stdout);
-        if (!fm.Success)   // no "Files: N" ⇒ not a readable archive (BSArch printed an error / usage)
-            return new BsaListResult(false, format, 0, Array.Empty<string>(), (run.stdout + "\n" + run.stderr).Trim(), null);
-
-        int declared = int.Parse(fm.Groups[1].Value);
-        var nonEmpty = run.stdout.Replace("\r", "").Split('\n').Where(l => l.Trim().Length > 0).ToList();
-        var files = declared > 0 && declared <= nonEmpty.Count
-            ? nonEmpty.Skip(nonEmpty.Count - declared).ToList()
-            : new List<string>();
-        return new BsaListResult(files.Count == declared, format, declared, files, run.stdout, null);
+        IArchiveReader reader;
+        try { reader = Archive.CreateReader(GameRelease.SkyrimSE, archive, Fs); }
+        catch (Exception ex) { return new BsaListResult(false, null, 0, Array.Empty<string>(), "", OpenError(archive, ex)); }
+        try
+        {
+            var files = reader.Files.Select(f => f.Path).ToList();
+            return new BsaListResult(true, VersionLabel(archive), files.Count, files, "", null);
+        }
+        catch (Exception ex)
+        {
+            return new BsaListResult(false, null, 0, Array.Empty<string>(), "",
+                $"could not read the file list of '{Path.GetFileName(archive)}' ({ex.GetType().Name}: {ex.Message}).");
+        }
+        finally { (reader as IDisposable)?.Dispose(); }
     }
 
-    /// <summary>Unpack the WHOLE archive into <paramref name="destFolder"/> (created if absent). Success = THIS RUN
-    /// added or changed entries, not "the folder is non-empty afterwards": the managed flow PRE-SEEDS the folder (the
-    /// meta.ini ownership marker is written before BSArch runs) and a caller-supplied dest may hold anything, so the
-    /// old test was satisfiable with zero extracted files and reported every BSArch failure as a successful extract
-    /// (2026-06-12 adversarial hunt, MUST-FIX). New entries are detected by PATH (robust to extractors that restore
-    /// archived timestamps); changed ones by size/mtime. Honest residual edge: re-extracting byte-identical content
-    /// over an existing dest with restored timestamps can read as "nothing new" — that direction fails LOUD with
-    /// BSArch's raw output attached, never falsely succeeds. "Read a file inside" = unpack, then read it.</summary>
-    public static BsaResult Unpack(string bsarchExe, string archive, string destFolder, int timeoutMs = 300_000)
+    /// <summary>Unpack the WHOLE archive into <paramref name="destFolder"/> (created if absent) via Mutagen. Each file's
+    /// DECOMPRESSED bytes are written to dest/{file path}. Writes are:
+    ///   • path-traversal-guarded — an entry resolving outside the dest refuses loud (Q3), never writes out-of-tree;
+    ///   • content-aware/idempotent — a file already present byte-identical is skipped, so re-extracting into a
+    ///     populated dest reports "already present" rather than a spurious rewrite (this is why the managed flow's
+    ///     pre-seeded meta.ini marker is left untouched).
+    /// An archive that can't be opened/read fails with a named reason. "Read a file inside" = unpack, then read it.</summary>
+    public static BsaResult Unpack(string archive, string destFolder)
     {
         Directory.CreateDirectory(destFolder);
-        var before = SnapshotEntries(destFolder);
-        var run = Run(bsarchExe, new[] { "unpack", archive, destFolder, "-mt" }, timeoutMs);
-        if (run.runError is not null) return new BsaResult(false, (run.stdout + run.stderr).Trim(), run.runError);
-        bool ok = AnyNewOrChangedEntries(destFolder, before);
-        return new BsaResult(ok, (run.stdout + "\n" + run.stderr).Trim(), null);
+        IArchiveReader reader;
+        try { reader = Archive.CreateReader(GameRelease.SkyrimSE, archive, Fs); }
+        catch (Exception ex) { return new BsaResult(false, "", OpenError(archive, ex)); }
+
+        string destFull = Path.GetFullPath(destFolder);
+        int written = 0, already = 0;
+        try
+        {
+            foreach (var f in reader.Files)
+            {
+                string outPath = Path.GetFullPath(Path.Combine(destFull, f.Path));
+                if (!IsUnder(destFull, outPath))
+                    return new BsaResult(false,
+                        $"archive entry '{f.Path}' resolves outside the destination folder (path traversal) — refusing after {written} file(s).", null);
+                byte[] body = f.GetBytes();
+                if (SameOnDisk(outPath, body)) { already++; continue; }
+                Directory.CreateDirectory(Path.GetDirectoryName(outPath)!);
+                File.WriteAllBytes(outPath, body);
+                written++;
+            }
+        }
+        catch (Exception ex)
+        {
+            return new BsaResult(false,
+                $"failed while extracting '{Path.GetFileName(archive)}' ({ex.GetType().Name}: {ex.Message}); {written} file(s) written before the error.", null);
+        }
+        finally { (reader as IDisposable)?.Dispose(); }
+
+        string note = written > 0
+            ? $"extracted {written} file(s)" + (already > 0 ? $" ({already} already present byte-identical)" : "") + "."
+            : already > 0 ? $"all {already} file(s) were already present byte-identical — nothing to extract."
+                          : "the archive contained no files.";
+        return new BsaResult(true, note, null);
     }
 
-    /// <summary>Snapshot a folder's files (recursive): relative path → (size, mtimeUtc). The Unpack provenance
-    /// baseline — and the bsa-contract-guard probe's seam.</summary>
-    public static Dictionary<string, (long Size, DateTime MtimeUtc)> SnapshotEntries(string folder)
+    static string OpenError(string archive, Exception ex) =>
+        $"could not open '{Path.GetFileName(archive)}' as a Bethesda archive ({ex.GetType().Name}: {ex.Message}). " +
+        "Is it a real .bsa (not a .ba2 / renamed file), and not truncated?";
+
+    /// <summary>A cheap, best-effort format label read straight from the 8-byte header (magic + version) — cosmetic,
+    /// for the list output. Null if it can't be read.</summary>
+    static string? VersionLabel(string archive)
     {
-        var map = new Dictionary<string, (long, DateTime)>(StringComparer.OrdinalIgnoreCase);
-        if (!Directory.Exists(folder)) return map;
-        foreach (var f in Directory.EnumerateFiles(folder, "*", SearchOption.AllDirectories))
+        try
         {
-            var fi = new FileInfo(f);
-            map[Path.GetRelativePath(folder, f)] = (fi.Length, fi.LastWriteTimeUtc);
+            using var fs = new FileStream(archive, FileMode.Open, FileAccess.Read, FileShare.Read);
+            Span<byte> h = stackalloc byte[8];
+            if (fs.Read(h) < 8) return null;
+            if (h[0] != 0x42 || h[1] != 0x53 || h[2] != 0x41 || h[3] != 0x00) return null;   // not "BSA\0"
+            uint v = (uint)(h[4] | (h[5] << 8) | (h[6] << 16) | (h[7] << 24));
+            return v switch
+            {
+                103 => "BSA v103 (Oblivion)",
+                104 => "BSA v104 (Skyrim LE / Fallout 3 / NV)",
+                105 => "BSA v105 (Skyrim SE/AE)",
+                _ => $"BSA v{v}",
+            };
         }
-        return map;
+        catch { return null; }
     }
 
-    /// <summary>Did anything appear or change under <paramref name="folder"/> since <paramref name="before"/>?
-    /// A path absent from the baseline = new (timestamp-independent); a present path with a different size or
-    /// mtime = changed.</summary>
-    public static bool AnyNewOrChangedEntries(string folder, Dictionary<string, (long Size, DateTime MtimeUtc)> before)
+    /// <summary>Is <paramref name="candidate"/> strictly inside <paramref name="root"/>? Both are already full paths.
+    /// Because <c>Path.GetFullPath</c> resolves any <c>..</c> before this check, it catches both relative traversal and
+    /// absolute/rooted entry paths.</summary>
+    static bool IsUnder(string root, string candidate)
     {
-        if (!Directory.Exists(folder)) return false;
-        foreach (var f in Directory.EnumerateFiles(folder, "*", SearchOption.AllDirectories))
+        root = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return candidate.StartsWith(root + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>True iff <paramref name="path"/> already holds exactly <paramref name="body"/> (content-aware skip).</summary>
+    static bool SameOnDisk(string path, byte[] body)
+    {
+        try
         {
-            var rel = Path.GetRelativePath(folder, f);
-            if (!before.TryGetValue(rel, out var b)) return true;
-            var fi = new FileInfo(f);
-            if (fi.Length != b.Size || fi.LastWriteTimeUtc != b.MtimeUtc) return true;
+            var fi = new FileInfo(path);
+            if (!fi.Exists || fi.Length != body.Length) return false;
+            return File.ReadAllBytes(path).AsSpan().SequenceEqual(body);
         }
-        return false;
+        catch { return false; }
     }
 
     /// <summary>Pack <paramref name="srcFolder"/> into a .bsa at <paramref name="archive"/> with the given format flag
-    /// (e.g. "-sse") and optional compression. NON-DESTRUCTIVE (Aaron 2026-06-06): an existing archive at the target is
-    /// NEVER overwritten unless this run successfully packs a new one — BSArch writes to a houseCARL-internal temp beside
-    /// the target, and only a clean pack THIS RUN (temp exists, non-empty, AND written at/after the run's mtime baseline)
-    /// is moved over the target; a stale scratch from a previous run that cannot be removed REFUSES up front (nothing
-    /// runs, the prior .bsa untouched), and any failure (BSArch error, timeout, empty output, stale-mtime scratch)
-    /// deletes the temp and leaves the prior .bsa untouched. The mtime gate assumes an NTFS-class timestamp resolution —
-    /// on a FAT-class target a same-second pack could read as stale and fail LOUD (never falsely succeed). NOTE the
-    /// caller must surface BSArch's caveat: a COMPRESSED archive breaks any sounds/voices it contains.</summary>
+    /// (e.g. "-sse") and optional compression, via BSArch (Mutagen has no BSA writer). NON-DESTRUCTIVE (Aaron 2026-06-06):
+    /// an existing archive at the target is NEVER overwritten unless this run successfully packs a new one — BSArch writes
+    /// to a houseCARL-internal temp beside the target, and only a clean pack THIS RUN (temp exists, non-empty, AND written
+    /// at/after the run's mtime baseline) is moved over the target; a stale scratch from a previous run that cannot be
+    /// removed REFUSES up front (nothing runs, the prior .bsa untouched), and any failure (BSArch error, timeout, empty
+    /// output, stale-mtime scratch) deletes the temp and leaves the prior .bsa untouched. The mtime gate assumes an
+    /// NTFS-class timestamp resolution — on a FAT-class target a same-second pack could read as stale and fail LOUD (never
+    /// falsely succeed). NOTE the caller must surface BSArch's caveat: a COMPRESSED archive breaks any sounds/voices it
+    /// contains.</summary>
     public static BsaResult Pack(string bsarchExe, string srcFolder, string archive, string formatFlag, bool compress, int timeoutMs = 600_000)
     {
         // Pack to a scratch sibling (keeps the .bsa extension so BSArch is happy); the real target is touched only on success.

--- a/src/housecarl-core/BsaArchive.cs
+++ b/src/housecarl-core/BsaArchive.cs
@@ -44,17 +44,29 @@ public static class BsaArchive
     // houseCARL is Skyrim SE; the reader keys off the header version, so this also reads v103/v104 archives.
     static readonly IFileSystem Fs = new FileSystem();
 
-    /// <summary>List an archive's contents via Mutagen. On an unreadable/corrupt/non-archive file the failure is
-    /// surfaced in <see cref="BsaListResult.RunError"/> (Ran=false), never a silent empty list.</summary>
+    // A single archived entry is read into memory in-process (f.GetBytes). Bound that allocation: a corrupt/hostile
+    // header declaring a multi-GB entry must fail LOUD, not OOM the whole single-process server (the out-of-process
+    // BSArch path used to be killed on a timeout; this is the in-process equivalent). No real Skyrim asset approaches
+    // this, and it sits at the ~2GB .NET single-array ceiling GetBytes would throw at anyway.
+    const long MaxEntryBytes = 2L * 1024 * 1024 * 1024;
+
+    /// <summary>List an archive's contents via Mutagen, cross-checked against the header's OWN declared file count so a
+    /// reader mis-parse can't render a quietly-short list (Q3). On an unreadable/corrupt/non-archive file the failure is
+    /// surfaced in <see cref="BsaListResult.RunError"/> (Ran=false); a count mismatch surfaces as Ran-but-not-Success
+    /// with the discrepancy in <see cref="BsaListResult.Raw"/> — never a silent empty list.</summary>
     public static BsaListResult List(string archive)
     {
+        var hdr = ReadBsaHeader(archive);   // independent of Mutagen — the public IArchiveReader doesn't expose the count
         IArchiveReader reader;
         try { reader = Archive.CreateReader(GameRelease.SkyrimSE, archive, Fs); }
         catch (Exception ex) { return new BsaListResult(false, null, 0, Array.Empty<string>(), "", OpenError(archive, ex)); }
         try
         {
             var files = reader.Files.Select(f => f.Path).ToList();
-            return new BsaListResult(true, VersionLabel(archive), files.Count, files, "", null);
+            if (hdr is { fileCount: var declared } && declared != (uint)files.Count)
+                return new BsaListResult(false, VersionLabel(hdr), (int)declared, files,
+                    $"'{Path.GetFileName(archive)}': header declares {declared} file(s) but the reader enumerated {files.Count} — the archive may be corrupt or unsupported.", null);
+            return new BsaListResult(true, VersionLabel(hdr), hdr is { fileCount: var c } ? (int)c : files.Count, files, "", null);
         }
         catch (Exception ex)
         {
@@ -74,6 +86,7 @@ public static class BsaArchive
     public static BsaResult Unpack(string archive, string destFolder)
     {
         Directory.CreateDirectory(destFolder);
+        var hdr = ReadBsaHeader(archive);
         IArchiveReader reader;
         try { reader = Archive.CreateReader(GameRelease.SkyrimSE, archive, Fs); }
         catch (Exception ex) { return new BsaResult(false, "", OpenError(archive, ex)); }
@@ -84,6 +97,9 @@ public static class BsaArchive
         {
             foreach (var f in reader.Files)
             {
+                if (f.Size > MaxEntryBytes)   // corrupt/hostile header — refuse loud rather than OOM the server (Q3)
+                    return new BsaResult(false,
+                        $"archive entry '{f.Path}' declares {f.Size:N0} bytes, over the {MaxEntryBytes:N0}-byte safety ceiling — refusing to read it in-process (the archive header may be corrupt).", null);
                 string outPath = Path.GetFullPath(Path.Combine(destFull, f.Path));
                 if (!IsUnder(destFull, outPath))
                     return new BsaResult(false,
@@ -102,6 +118,14 @@ public static class BsaArchive
         }
         finally { (reader as IDisposable)?.Dispose(); }
 
+        int total = written + already;
+        // Cross-check against the header's own count. If the reader enumerated FEWER files than the archive declares
+        // (a mis-parse down to zero being the worst case), the old BSArch provenance would have caught it — fail loud
+        // here rather than report a partial/empty extract as success (Q3, #217's silent-wrong-output class).
+        if (hdr is { fileCount: var declared } && declared != (uint)total)
+            return new BsaResult(false,
+                $"extracted {total} file(s) from '{Path.GetFileName(archive)}' but its header declares {declared} — the archive may be corrupt or unsupported; refusing to report it as success.", null);
+
         string note = written > 0
             ? $"extracted {written} file(s)" + (already > 0 ? $" ({already} already present byte-identical)" : "") + "."
             : already > 0 ? $"all {already} file(s) were already present byte-identical — nothing to extract."
@@ -113,27 +137,32 @@ public static class BsaArchive
         $"could not open '{Path.GetFileName(archive)}' as a Bethesda archive ({ex.GetType().Name}: {ex.Message}). " +
         "Is it a real .bsa (not a .ba2 / renamed file), and not truncated?";
 
-    /// <summary>A cheap, best-effort format label read straight from the 8-byte header (magic + version) — cosmetic,
-    /// for the list output. Null if it can't be read.</summary>
-    static string? VersionLabel(string archive)
+    /// <summary>Read the version + folder/file counts straight from the 24-byte BSA header — an oracle INDEPENDENT of
+    /// Mutagen's reader (whose public IArchiveReader exposes neither), used to cross-check the enumerated file count and
+    /// to label the format. Null if the file can't be read or isn't a "BSA\0" archive.</summary>
+    static (uint version, uint folderCount, uint fileCount)? ReadBsaHeader(string archive)
     {
         try
         {
             using var fs = new FileStream(archive, FileMode.Open, FileAccess.Read, FileShare.Read);
-            Span<byte> h = stackalloc byte[8];
-            if (fs.Read(h) < 8) return null;
+            var h = new byte[24];
+            if (fs.Read(h, 0, 24) < 24) return null;
             if (h[0] != 0x42 || h[1] != 0x53 || h[2] != 0x41 || h[3] != 0x00) return null;   // not "BSA\0"
-            uint v = (uint)(h[4] | (h[5] << 8) | (h[6] << 16) | (h[7] << 24));
-            return v switch
-            {
-                103 => "BSA v103 (Oblivion)",
-                104 => "BSA v104 (Skyrim LE / Fallout 3 / NV)",
-                105 => "BSA v105 (Skyrim SE/AE)",
-                _ => $"BSA v{v}",
-            };
+            static uint U(byte[] b, int o) => (uint)(b[o] | (b[o + 1] << 8) | (b[o + 2] << 16) | (b[o + 3] << 24));
+            return (U(h, 4), U(h, 16), U(h, 20));   // version @4, folderCount @16, fileCount @20
         }
         catch { return null; }
     }
+
+    /// <summary>A cosmetic format label for the list output, derived from the already-read header. Null if unread.</summary>
+    static string? VersionLabel((uint version, uint folderCount, uint fileCount)? hdr) => hdr?.version switch
+    {
+        null => null,
+        103 => "BSA v103 (Oblivion)",
+        104 => "BSA v104 (Skyrim LE / Fallout 3 / NV)",
+        105 => "BSA v105 (Skyrim SE/AE)",
+        var v => $"BSA v{v}",
+    };
 
     /// <summary>Is <paramref name="candidate"/> strictly inside <paramref name="root"/>? Both are already full paths.
     /// Because <c>Path.GetFullPath</c> resolves any <c>..</c> before this check, it catches both relative traversal and

--- a/src/housecarl-generator/BsaContractProbe.cs
+++ b/src/housecarl-generator/BsaContractProbe.cs
@@ -3,33 +3,25 @@ using HousecarlCore;
 namespace HousecarlGenerator;
 
 /// <summary>
-/// BSA bridge CONTRACT guard — self-contained (no BSArch needed): locks in the success/provenance
-/// contracts the 2026-06-12 adversarial hunt proved broken. The stand-in for a failing BSArch is a
-/// copy of Windows' own where.exe (present on every runner): it runs, errors, exits non-zero, and
-/// extracts/packs NOTHING — exactly the failure shape the old success tests mistook for success.
+/// BSA PACK contract guard — self-contained (a copy of Windows' own where.exe stands in for a failing BSArch: it runs,
+/// errors, exits non-zero, and writes NOTHING). Locks the pack-provenance + format contracts the 2026-06-12 adversarial
+/// hunt proved broken. (The unpack/list provenance arms this guard used to carry are gone: reads now go through Mutagen's
+/// in-process reader, not BSArch, so there is no external-tool success to misread — bsa-extract-guard covers the read
+/// path, and bsa-probe covers real-BSArch pack + Mutagen/BSArch byte parity.)
 ///
-/// What it locks (each was a real finding):
-///   1. UNPACK PROVENANCE — the managed flow pre-seeds the dest folder (meta.ini ownership marker
-///      is written BEFORE BSArch runs), and the old success test was "folder non-empty afterwards":
-///      the marker alone satisfied it, so EVERY BSArch failure rendered as a successful extract
-///      (MUST-FIX; independently proven by two hunters). Success now = THIS RUN added or changed
-///      entries. Arms: pre-seeded dest must FAIL; non-empty caller dest must FAIL; the snapshot
-///      seam answers new-path / changed-mtime / changed-size / no-change correctly.
-///   2. PACK PROVENANCE — "tmp exists and is non-empty" proved nothing about WHO made it: a stale
-///      scratch from a previous run could ship as this run's archive. A stuck (undeletable) stale
-///      scratch now REFUSES loud before running; a fresh-run mtime baseline gates the move.
-///   3. FORMAT REFUSAL — an unknown format token used to coerce silently to -sse; TryFormatFlag
-///      now returns null for refusal (legal tokens keep their flags; the sse family defaults).
-///
-/// The real-BSArch behaviors (actual extraction, list output shapes) stay covered by bsa-probe,
-/// which self-skips without BSArch — THIS guard needs none.
+/// What it locks:
+///   1. PACK PROVENANCE — "tmp exists and is non-empty" proved nothing about WHO made it: a stale scratch from a previous
+///      run could ship as this run's archive. A stuck (undeletable) stale scratch now REFUSES loud before running; a
+///      fresh-run mtime baseline gates the move; a failing pack leaves any prior archive byte-untouched.
+///   2. FORMAT REFUSAL — an unknown format token used to coerce silently to -sse; TryFormatFlag now returns null for
+///      refusal (legal tokens keep their flags; the sse family defaults).
 /// </summary>
 internal static class BsaContractProbe
 {
     public static int RunGuard(string[] args)
     {
         Console.WriteLine("================================================================");
-        Console.WriteLine(" bsa contract guard — unpack/pack provenance + format refusal");
+        Console.WriteLine(" bsa contract guard — pack provenance + format refusal");
         Console.WriteLine("================================================================");
         Console.WriteLine();
         int fail = 0;
@@ -42,40 +34,9 @@ internal static class BsaContractProbe
             // the failing-BSArch stand-in: runs, errors to stderr, exits non-zero, writes nothing
             var stub = Path.Combine(work, "bsarch.exe");
             File.Copy(Path.Combine(Environment.SystemDirectory, "where.exe"), stub);
-            var fakeArchive = Path.Combine(work, "fake.bsa");
-            File.WriteAllBytes(fakeArchive, new byte[] { 0x42, 0x53, 0x41, 0x00 });
 
-            // ---- 1a) managed-flow shape: dest pre-seeded with the ownership marker ----
-            Console.WriteLine("--- 1: unpack provenance ---");
-            var seeded = Path.Combine(work, "seeded");
-            Directory.CreateDirectory(seeded);
-            File.WriteAllText(Path.Combine(seeded, "meta.ini"), $"{HousecarlOwnerMeta.Section}\ngenerated=true\n");
-            var r1 = BsaArchive.Unpack(stub, fakeArchive, seeded, timeoutMs: 30_000);
-            Check(r1.Ran, "stub ran (the failure is BSArch's, not a run error)");
-            Check(!r1.Success, "pre-seeded dest + failing BSArch = FAILURE (the marker alone no longer reads as success)");
-
-            // ---- 1b) caller-dest shape: any non-empty folder ----
-            var lived = Path.Combine(work, "lived-in");
-            Directory.CreateDirectory(lived);
-            File.WriteAllText(Path.Combine(lived, "existing.txt"), "user content");
-            var r2 = BsaArchive.Unpack(stub, fakeArchive, lived, timeoutMs: 30_000);
-            Check(r2.Ran && !r2.Success, "non-empty caller dest + failing BSArch = FAILURE");
-
-            // ---- 1c) the snapshot seam: new / changed / unchanged ----
-            var seam = Path.Combine(work, "seam");
-            Directory.CreateDirectory(seam);
-            File.WriteAllText(Path.Combine(seam, "a.txt"), "one");
-            var snap = BsaArchive.SnapshotEntries(seam);
-            Check(!BsaArchive.AnyNewOrChangedEntries(seam, snap), "no change → no entries this run");
-            File.WriteAllText(Path.Combine(seam, "b.txt"), "two");
-            Check(BsaArchive.AnyNewOrChangedEntries(seam, snap), "a NEW path counts (timestamp-independent)");
-            File.Delete(Path.Combine(seam, "b.txt"));
-            File.WriteAllText(Path.Combine(seam, "a.txt"), "ONE+");
-            Check(BsaArchive.AnyNewOrChangedEntries(seam, snap), "a CHANGED existing file counts (size/mtime)");
-
-            // ---- 2) pack: stuck stale scratch refuses; target untouched ----
-            Console.WriteLine();
-            Console.WriteLine("--- 2: pack provenance ---");
+            // ---- 1) pack: stuck stale scratch refuses; target untouched ----
+            Console.WriteLine("--- 1: pack provenance ---");
             var packDir = Path.Combine(work, "pack");
             Directory.CreateDirectory(packDir);
             var target = Path.Combine(packDir, "Out.bsa");
@@ -94,9 +55,9 @@ internal static class BsaContractProbe
             Check(rp2.Ran && !rp2.Success, "deletable stale + failing BSArch = honest failure (no stale shipped)");
             Check(File.ReadAllText(target) == "PRIOR ARCHIVE — must survive", "the prior archive survives that path too");
 
-            // ---- 3) format refusal ----
+            // ---- 2) format refusal ----
             Console.WriteLine();
-            Console.WriteLine("--- 3: format tokens ---");
+            Console.WriteLine("--- 2: format tokens ---");
             Check(BsaArchive.TryFormatFlag(null) == "-sse" && BsaArchive.TryFormatFlag("sse") == "-sse"
                   && BsaArchive.TryFormatFlag("AE") == "-sse", "sse family + empty default to -sse");
             Check(BsaArchive.TryFormatFlag("tes5") == "-tes5" && BsaArchive.TryFormatFlag("fo4dds") == "-fo4dds",

--- a/src/housecarl-generator/BsaExtractProbe.cs
+++ b/src/housecarl-generator/BsaExtractProbe.cs
@@ -66,8 +66,16 @@ internal static class BsaExtractProbe
             });
             var evilDest = Path.Combine(work, "evil-dest");
             var er = BsaArchive.Unpack(Write(work, "evil.bsa", evil), evilDest);
-            Check(!er.Success, $"'..' entry -> extract refuses ({(er.Ran ? er.Raw : er.RunError)})");
+            Check(er.Ran && !er.Success && er.Raw.Contains("path traversal", StringComparison.OrdinalIgnoreCase),
+                  $"'..' entry -> the IsUnder guard refuses (not an upstream reject) ({(er.Ran ? er.Raw : er.RunError)})");
             Check(!File.Exists(Path.Combine(work, "escape.txt")), "nothing written outside the destination");
+
+            // ---- 3b) header/reader file-count mismatch -> loud (the #217 silent-empty/short-extract guard) ----
+            var good = BuildBsa(105, FHasFolderNames | FHasFileNames, folders);   // 3 real files
+            var lie = (byte[])good.Clone();
+            BitConverter.GetBytes(1u).CopyTo(lie, 20);                            // header @20 now lies: "1 file"
+            var lr = BsaArchive.Unpack(Write(work, "count-lie.bsa", lie), Path.Combine(work, "count-out"));
+            Check(!lr.Success, $"lying header count -> no silent success ({(lr.Ran ? lr.Raw : lr.RunError)})");
 
             // ---- 4) loud failure on a non-archive ----
             Console.WriteLine();

--- a/src/housecarl-generator/BsaExtractProbe.cs
+++ b/src/housecarl-generator/BsaExtractProbe.cs
@@ -1,0 +1,178 @@
+using System.Text;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// BSA extract guard — self-contained, no BSArch and no real archive needed. It hand-authors valid uncompressed BSA
+/// archives in memory (Mutagen reads them, verified) and drives the shipped <see cref="BsaArchive.Unpack"/> (which reads
+/// via Mutagen's in-process BSA reader). Pins the read path the housecarl_bsa_extract tool rides on:
+///   1. v105 + v104 uncompressed round-trip: every file extracted byte-correct at the right path.
+///   2. Content-aware idempotence: a second extract writes nothing and reports all-already-present.
+///   3. Path-traversal safety: an archive entry that resolves outside the dest refuses (Q3) and writes nothing out-of-tree.
+///   4. Loud failure: an unreadable/non-archive file fails with a named reason, never a silent empty success.
+/// The real-BSArch parity (incl. compressed archives) is the separate, opt-in bsa-probe.
+/// </summary>
+internal static class BsaExtractProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" bsa extract guard (Mutagen read path) — no BSArch needed");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        var folders = new (string Folder, (string Name, byte[] Data)[] Files)[]
+        {
+            ("scripts", new[]
+            {
+                ("main.pex",   Bytes("PEX-main", 40)),
+                ("helper.pex", Bytes("PEX-help", 4096)),
+            }),
+            (@"sound\voice\test.esp\femalecommoner", new[]
+            {
+                ("hello_000012ab_1.fuz", Bytes("FUZ-audio", 1)),   // 1-byte body — smallest edge
+            }),
+        };
+
+        var work = Path.Combine(Path.GetTempPath(), "hc-bsa-extract-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(work);
+        try
+        {
+            // ---- 1 + 2) round-trip + idempotence, v105 and v104 ----
+            Console.WriteLine("--- 1: uncompressed round-trip via BsaArchive.Unpack (Mutagen) ---");
+            foreach (uint version in new uint[] { 105, 104 })
+            {
+                var bsa = Write(work, $"round-{version}.bsa", BuildBsa(version, FHasFolderNames | FHasFileNames, folders));
+                var dest = Path.Combine(work, $"round-{version}");
+                var r = BsaArchive.Unpack(bsa, dest);
+                Check(r.Ran && r.Success, $"v{version}: extract Success ({r.Raw})");
+                Check(AllBytesCorrect(dest, folders), $"v{version}: every file extracted byte-correct at the right path");
+                Check(r.Raw.Contains("extracted 3", StringComparison.OrdinalIgnoreCase), $"v{version}: reports 3 written");
+
+                var r2 = BsaArchive.Unpack(bsa, dest);   // re-extract into the populated dest
+                Check(r2.Ran && r2.Success && r2.Raw.Contains("already present", StringComparison.OrdinalIgnoreCase),
+                      $"v{version}: re-extract is a content-aware no-op ({r2.Raw})");
+            }
+
+            // ---- 3) path-traversal safety ----
+            Console.WriteLine();
+            Console.WriteLine("--- 3: path traversal ---");
+            var evil = BuildBsa(105, FHasFolderNames | FHasFileNames, new (string, (string, byte[])[])[]
+            {
+                ("..", new[] { ("escape.txt", Bytes("nope", 8)) }),
+            });
+            var evilDest = Path.Combine(work, "evil-dest");
+            var er = BsaArchive.Unpack(Write(work, "evil.bsa", evil), evilDest);
+            Check(!er.Success, $"'..' entry -> extract refuses ({(er.Ran ? er.Raw : er.RunError)})");
+            Check(!File.Exists(Path.Combine(work, "escape.txt")), "nothing written outside the destination");
+
+            // ---- 4) loud failure on a non-archive ----
+            Console.WriteLine();
+            Console.WriteLine("--- 4: unreadable input ---");
+            var junk = Write(work, "junk.bsa", new byte[] { 0x42, 0x53, 0x41, 0x00, 1, 2, 3, 4 });
+            var jr = BsaArchive.Unpack(junk, Path.Combine(work, "junk-out"));
+            Check(!jr.Ran && !string.IsNullOrWhiteSpace(jr.RunError), $"garbage archive -> loud open error ({jr.RunError})");
+            var listJr = BsaArchive.List(junk);
+            Check(!listJr.Ran && !string.IsNullOrWhiteSpace(listJr.RunError), "list of a garbage archive -> loud error too");
+        }
+        finally { try { Directory.Delete(work, recursive: true); } catch { /* temp scratch */ } }
+
+        Console.WriteLine();
+        Console.WriteLine(fail == 0 ? "================ ALL PASS ================" : $"================ {fail} CHECK(S) FAILED ================");
+        return fail == 0 ? 0 : 1;
+    }
+
+    const uint FHasFolderNames = 0x0001;
+    const uint FHasFileNames = 0x0002;
+
+    /// <summary>Deterministic per-file body (varying content + length), so a mis-mapped name/offset is caught.</summary>
+    static byte[] Bytes(string tag, int len)
+    {
+        var seed = Encoding.ASCII.GetBytes(tag);
+        var b = new byte[len];
+        for (int i = 0; i < len; i++) b[i] = (byte)(seed[i % seed.Length] ^ (i * 31 + 7));
+        return b;
+    }
+
+    static string Write(string dir, string name, byte[] bytes) { var p = Path.Combine(dir, name); File.WriteAllBytes(p, bytes); return p; }
+
+    static bool AllBytesCorrect(string dest, (string Folder, (string Name, byte[] Data)[] Files)[] folders)
+    {
+        foreach (var (folder, files) in folders)
+            foreach (var (name, data) in files)
+            {
+                var rel = (folder.Length == 0 ? name : folder + "\\" + name).Replace('\\', Path.DirectorySeparatorChar);
+                var path = Path.Combine(dest, rel);
+                if (!File.Exists(path) || !File.ReadAllBytes(path).AsSpan().SequenceEqual(data)) return false;
+            }
+        return true;
+    }
+
+    /// <summary>Author a byte-exact uncompressed BSA (folder+file names present, little-endian) — the standard
+    /// header -> folder records -> folder blocks -> file-name block -> file data layout Mutagen's reader parses.</summary>
+    static byte[] BuildBsa(uint version, uint archiveFlags, (string Folder, (string Name, byte[] Data)[] Files)[] folders)
+    {
+        int frSize = version == 105 ? 24 : 16;
+        uint folderCount = (uint)folders.Length;
+        uint fileCount = (uint)folders.Sum(f => f.Files.Length);
+        uint totalFolderNameLen = (uint)folders.Sum(f => f.Folder.Length + 1);
+        uint totalFileNameLen = (uint)folders.SelectMany(f => f.Files).Sum(x => x.Name.Length + 1);
+
+        long folderRecordsEnd = 36 + (long)folderCount * frSize;
+        var blockSizes = folders.Select(f => 1L + (f.Folder.Length + 1) + f.Files.Length * 16L).ToArray();
+        long nameBlockStart = folderRecordsEnd + blockSizes.Sum();
+        long fileDataStart = nameBlockStart + totalFileNameLen;
+
+        using var ms = new MemoryStream();
+        using var bw = new BinaryWriter(ms, Encoding.ASCII);
+
+        bw.Write(0x00415342u);          // "BSA\0"
+        bw.Write(version);
+        bw.Write(36u);                  // folder-records offset
+        bw.Write(archiveFlags);
+        bw.Write(folderCount);
+        bw.Write(fileCount);
+        bw.Write(totalFolderNameLen);
+        bw.Write(totalFileNameLen);
+        bw.Write(0u);                   // file (content-type) flags
+
+        long blockOffset = folderRecordsEnd;
+        for (int i = 0; i < folders.Length; i++)
+        {
+            bw.Write(0UL);                                           // hash
+            bw.Write((uint)folders[i].Files.Length);
+            if (frSize == 24) { bw.Write(0u); bw.Write((ulong)(blockOffset + totalFileNameLen)); }
+            else bw.Write((uint)(blockOffset + totalFileNameLen));
+            blockOffset += blockSizes[i];
+        }
+
+        long dataCursor = fileDataStart;
+        var dataOrder = new List<byte[]>();
+        foreach (var (folder, files) in folders)
+        {
+            var fn = Encoding.ASCII.GetBytes(folder);
+            bw.Write((byte)(fn.Length + 1));   // bzstring length INCLUDING the null
+            bw.Write(fn);
+            bw.Write((byte)0);
+            foreach (var (_, data) in files)
+            {
+                bw.Write(0UL);                 // file name hash
+                bw.Write((uint)data.Length);   // size field — uncompressed, no toggle bit
+                bw.Write((uint)dataCursor);    // absolute data offset
+                dataCursor += data.Length;
+                dataOrder.Add(data);
+            }
+        }
+
+        foreach (var (_, files) in folders)
+            foreach (var (name, _) in files) { bw.Write(Encoding.ASCII.GetBytes(name)); bw.Write((byte)0); }
+
+        foreach (var d in dataOrder) bw.Write(d);
+
+        bw.Flush();
+        return ms.ToArray();
+    }
+}

--- a/src/housecarl-generator/BsaProbe.cs
+++ b/src/housecarl-generator/BsaProbe.cs
@@ -1,12 +1,14 @@
+using System.Diagnostics;
 using HousecarlCore;
 
 namespace HousecarlGenerator;
 
 /// <summary>
-/// BSA-rider proof (EXTERNAL_TOOL_BRIDGE_PLAN step 3). Drives the shipped <see cref="BsaArchive"/> against the REAL BSArch
-/// on a REAL archive: list → unpack → pack → re-list, asserting the round-trip preserves the file count (the plan's proof
-/// gate). The list step also exercises the "Files: N + last-N-lines" parser against real output. Skipped (not failed) if
-/// BSArch or the test archive isn't present; provide both via args or the HOUSECARL_BSARCH / HOUSECARL_TEST_BSA env vars.
+/// BSA read/write round-trip proof on a REAL archive: list → unpack (both via Mutagen's in-process reader) → pack (via
+/// BSArch) → re-list, plus the load-bearing gate — Mutagen's unpack is BYTE-FOR-BYTE identical to BSArch's own unpack of
+/// the same archive (the independent-implementation check that the self-contained bsa-mutagen-extract-guard can't give).
+/// Skipped (not failed) if BSArch or the test archive isn't present; provide both via args or the HOUSECARL_BSARCH /
+/// HOUSECARL_TEST_BSA env vars. BSArch is needed only for the pack step + the parity oracle — reads no longer use it.
 ///
 /// Run: dotnet run --project src/housecarl-generator bsa-probe ["&lt;BSArch.exe&gt;"] ["&lt;test.bsa&gt;"]
 /// </summary>
@@ -20,7 +22,7 @@ internal static class BsaProbe
     public static int Run(string[] args)
     {
         Console.WriteLine("================================================================");
-        Console.WriteLine(" BSA riders — step 3: list → unpack → pack → re-list round-trip (real BSArch)");
+        Console.WriteLine(" BSA riders — list/unpack (Mutagen) vs BSArch parity + pack round-trip");
         Console.WriteLine("================================================================");
         Console.WriteLine();
         int fail = 0;
@@ -32,41 +34,48 @@ internal static class BsaProbe
         if (!File.Exists(bsa)) { Console.WriteLine($"  SKIP  no test archive at '{bsa}' (pass one as arg 2, or set HOUSECARL_TEST_BSA)"); return 0; }
 
         var work = Path.Combine(Environment.CurrentDirectory, ".bsa-probe");
-        var unpacked = Path.Combine(work, "unpacked");
+        var unpacked = Path.Combine(work, "unpacked");            // Mutagen unpack
+        var bsarchDir = Path.Combine(work, "bsarch-unpacked");    // BSArch unpack (the parity oracle)
         var repacked = Path.Combine(work, "repacked.bsa");
         try
         {
             Directory.CreateDirectory(work);
 
-            // 1) LIST the original (exercises the parser on real output)
-            var orig = BsaArchive.List(bsarch, bsa);
-            Check(orig.Ran && orig.Success, "list: ran + Success");
+            // 1) LIST via Mutagen
+            var orig = BsaArchive.List(bsa);
+            Check(orig.Ran && orig.Success, "list (Mutagen): ran + Success");
             Check(orig.DeclaredCount > 0 && orig.Files.Count == orig.DeclaredCount,
-                  $"list: file count matches declared ({orig.Files.Count}/{orig.DeclaredCount})");
-            Check(orig.Format is not null && orig.Format.Contains("Skyrim", StringComparison.OrdinalIgnoreCase),
-                  $"list: format parsed ('{orig.Format}')");
+                  $"list: file count self-consistent ({orig.Files.Count})");
+            Check(orig.Format is not null && orig.Format.Contains("BSA v", StringComparison.OrdinalIgnoreCase),
+                  $"list: version label read ('{orig.Format}')");
             if (orig.Files.Count > 0) Console.WriteLine("         e.g. " + orig.Files[0]);
 
-            // 2) UNPACK
-            var up = BsaArchive.Unpack(bsarch, bsa, unpacked);
-            Check(up.Ran && up.Success, "unpack: ran + dest has files");
-            int onDisk = Directory.Exists(unpacked) ? Directory.GetFiles(unpacked, "*", SearchOption.AllDirectories).Length : 0;
-            Check(onDisk == orig.DeclaredCount, $"unpack: files on disk == declared ({onDisk}/{orig.DeclaredCount})");
+            // 2) UNPACK via Mutagen
+            var up = BsaArchive.Unpack(bsa, unpacked);
+            Check(up.Ran && up.Success, $"unpack (Mutagen): ran + Success ({up.Raw})");
+            int onDisk = CountFiles(unpacked);
+            Check(onDisk == orig.DeclaredCount, $"unpack: files on disk == listed ({onDisk}/{orig.DeclaredCount})");
 
-            // 3) PACK back (Skyrim SE, uncompressed)
+            // 2b) THE GATE — Mutagen's unpack is byte-for-byte identical to BSArch's own unpack of the same archive.
+            //     This is the independent-implementation oracle (handles compressed archives too — BSArch decompresses,
+            //     and so must Mutagen, or the bytes won't match).
+            Directory.CreateDirectory(bsarchDir);
+            bool bsarchOk = BsarchUnpack(bsarch, bsa, bsarchDir);
+            Check(bsarchOk, "oracle: BSArch unpacked the same archive");
+            Check(bsarchOk && TreesByteIdentical(unpacked, bsarchDir), "Mutagen unpack == BSArch unpack (BYTE-FOR-BYTE)");
+
+            // 3) PACK back via BSArch (Skyrim SE, uncompressed)
             var pk = BsaArchive.Pack(bsarch, unpacked, repacked, BsaArchive.TryFormatFlag("sse")!, compress: false);
-            Check(pk.Ran && pk.Success, "pack: ran + .bsa written");
+            Check(pk.Ran && pk.Success, "pack (BSArch): ran + .bsa written");
             Check(File.Exists(repacked) && new FileInfo(repacked).Length > 0, "pack: output .bsa exists, non-empty");
 
-            // 4) RE-LIST the repacked archive — round-trip preserves the file count
-            var round = BsaArchive.List(bsarch, repacked);
-            Check(round.Ran && round.Success, "re-list: ran + Success");
+            // 4) RE-LIST the repacked archive via Mutagen — round-trip preserves the file count
+            var round = BsaArchive.List(repacked);
+            Check(round.Ran && round.Success, "re-list (Mutagen): ran + Success");
             Check(round.DeclaredCount == orig.DeclaredCount,
                   $"round-trip preserves file count ({round.DeclaredCount} == {orig.DeclaredCount})");
 
-            // 5) NON-DESTRUCTIVE PACK (Aaron 2026-06-06): a FAILED pack must NOT overwrite an existing archive. We have a
-            //    good `repacked` from the round-trip; attempt a pack from a non-existent source to the SAME path and assert
-            //    the prior archive survives byte-for-byte (the original is touched only by a clean, successful compaction).
+            // 5) NON-DESTRUCTIVE PACK (Aaron 2026-06-06): a FAILED pack must NOT overwrite an existing archive.
             var beforeLen = new FileInfo(repacked).Length;
             var failPack = BsaArchive.Pack(bsarch, Path.Combine(work, "no-such-source"), repacked, BsaArchive.TryFormatFlag("sse")!, compress: false);
             Check(!failPack.Success, "non-destructive: a pack from a missing source reports failure");
@@ -78,5 +87,37 @@ internal static class BsaProbe
         Console.WriteLine();
         Console.WriteLine(fail == 0 ? "================ ALL PASS ================" : $"================ {fail} CHECK(S) FAILED ================");
         return fail == 0 ? 0 : 1;
+    }
+
+    static int CountFiles(string dir) => Directory.Exists(dir) ? Directory.GetFiles(dir, "*", SearchOption.AllDirectories).Length : 0;
+
+    /// <summary>Drive BSArch's own unpack directly (the parity oracle) — NOT through BsaArchive, whose unpack is Mutagen.</summary>
+    static bool BsarchUnpack(string bsarch, string archive, string dest)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo { FileName = bsarch, RedirectStandardOutput = true, RedirectStandardError = true, UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = Path.GetDirectoryName(bsarch) };
+            foreach (var a in new[] { "unpack", archive, dest, "-mt" }) psi.ArgumentList.Add(a);
+            var p = Process.Start(psi)!;
+            p.StandardOutput.ReadToEnd(); p.StandardError.ReadToEnd();
+            p.WaitForExit(120_000);
+            return CountFiles(dest) > 0;
+        }
+        catch { return false; }
+    }
+
+    /// <summary>Two extracted trees hold exactly the same relative paths, each byte-identical.</summary>
+    static bool TreesByteIdentical(string a, string b)
+    {
+        string[] Rel(string root) => Directory.Exists(root)
+            ? Directory.GetFiles(root, "*", SearchOption.AllDirectories)
+                .Select(f => Path.GetRelativePath(root, f)).OrderBy(p => p, StringComparer.OrdinalIgnoreCase).ToArray()
+            : Array.Empty<string>();
+        var ra = Rel(a); var rb = Rel(b);
+        if (!ra.SequenceEqual(rb, StringComparer.OrdinalIgnoreCase)) return false;
+        foreach (var rel in ra)
+            if (!File.ReadAllBytes(Path.Combine(a, rel)).AsSpan().SequenceEqual(File.ReadAllBytes(Path.Combine(b, rel))))
+                return false;
+        return true;
     }
 }

--- a/src/housecarl-generator/BsaProbe.cs
+++ b/src/housecarl-generator/BsaProbe.cs
@@ -6,7 +6,7 @@ namespace HousecarlGenerator;
 /// <summary>
 /// BSA read/write round-trip proof on a REAL archive: list → unpack (both via Mutagen's in-process reader) → pack (via
 /// BSArch) → re-list, plus the load-bearing gate — Mutagen's unpack is BYTE-FOR-BYTE identical to BSArch's own unpack of
-/// the same archive (the independent-implementation check that the self-contained bsa-mutagen-extract-guard can't give).
+/// the same archive (the independent-implementation check that the self-contained bsa-extract-guard can't give).
 /// Skipped (not failed) if BSArch or the test archive isn't present; provide both via args or the HOUSECARL_BSARCH /
 /// HOUSECARL_TEST_BSA env vars. BSArch is needed only for the pack step + the parity oracle — reads no longer use it.
 ///
@@ -45,7 +45,7 @@ internal static class BsaProbe
             var orig = BsaArchive.List(bsa);
             Check(orig.Ran && orig.Success, "list (Mutagen): ran + Success");
             Check(orig.DeclaredCount > 0 && orig.Files.Count == orig.DeclaredCount,
-                  $"list: file count self-consistent ({orig.Files.Count})");
+                  $"list: reader count == header-declared count ({orig.Files.Count} == {orig.DeclaredCount})");
             Check(orig.Format is not null && orig.Format.Contains("BSA v", StringComparison.OrdinalIgnoreCase),
                   $"list: version label read ('{orig.Format}')");
             if (orig.Files.Count > 0) Console.WriteLine("         e.g. " + orig.Files[0]);
@@ -62,6 +62,8 @@ internal static class BsaProbe
             Directory.CreateDirectory(bsarchDir);
             bool bsarchOk = BsarchUnpack(bsarch, bsa, bsarchDir);
             Check(bsarchOk, "oracle: BSArch unpacked the same archive");
+            Check(bsarchOk && CountFiles(bsarchDir) == orig.DeclaredCount,
+                  $"oracle: BSArch extracted the header-declared count ({CountFiles(bsarchDir)}/{orig.DeclaredCount})");
             Check(bsarchOk && TreesByteIdentical(unpacked, bsarchDir), "Mutagen unpack == BSArch unpack (BYTE-FOR-BYTE)");
 
             // 3) PACK back via BSArch (Skyrim SE, uncompressed)
@@ -99,8 +101,12 @@ internal static class BsaProbe
             var psi = new ProcessStartInfo { FileName = bsarch, RedirectStandardOutput = true, RedirectStandardError = true, UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = Path.GetDirectoryName(bsarch) };
             foreach (var a in new[] { "unpack", archive, dest, "-mt" }) psi.ArgumentList.Add(a);
             var p = Process.Start(psi)!;
-            p.StandardOutput.ReadToEnd(); p.StandardError.ReadToEnd();
+            // Drain both pipes concurrently — a sequential ReadToEnd on one can deadlock if the child fills the other
+            // pipe's buffer while we're blocked (the same reason BsaArchive.Run reads async).
+            var o = p.StandardOutput.ReadToEndAsync();
+            var e = p.StandardError.ReadToEndAsync();
             p.WaitForExit(120_000);
+            Task.WaitAll(new Task[] { o, e }, 5_000);
             return CountFiles(dest) > 0;
         }
         catch { return false; }

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -123,6 +123,12 @@ public static class CiAll
         ("render-clamp-guard", RenderClampProbe.RunGuard),
         ("decompile-guard", DecompileGuardProbe.RunGuard),
         ("bsa-contract-guard", BsaContractProbe.RunGuard),
+        // BSA extract read path (#217): housecarl_bsa_extract / _list read through Mutagen's in-process BSA reader
+        // (Archive.CreateReader) instead of shelling BSArch — BSArch's unpacker is stricter than its lister + the game,
+        // so a non-BSArch-written archive could list yet unpack to nothing. Self-contained — hand-authors valid uncompressed
+        // v105/v104 archives Mutagen reads: byte-correct round-trip, content-aware idempotence, path-traversal refusal,
+        // and loud failure on a non-archive. (Real-BSArch + compressed-archive byte parity lives in the opt-in bsa-probe.)
+        ("bsa-extract-guard", BsaExtractProbe.RunGuard),
         ("hierarchy-cache-guard", HierarchyCacheProbe.RunGuard),
         ("write-mutex-guard", WriteMutexProbe.RunGuard),
         // NOTE: freshness-capture-guard is deliberately NOT in the runner — its deferral arm needs a write slow

--- a/src/housecarl-mcp/BsaTools.cs
+++ b/src/housecarl-mcp/BsaTools.cs
@@ -16,34 +16,22 @@ public static class BsaTools
 {
     [McpServerTool(Name = "housecarl_bsa_list", ReadOnly = true, Title = "List a .bsa archive's contents"),
      Description(
-         "List the files inside a Bethesda .bsa archive (via BSArch). Returns the archive format + the contained file " +
-         "paths. Read-only — extracts nothing. To read a file's CONTENTS, use housecarl_bsa_extract then read the file. " +
-         "Needs the BSArch path; if it isn't set yet houseCARL tells you exactly what to ask for and how to set it " +
-         "(BSArch ships with xEdit).")]
+         "List the files inside a Bethesda .bsa archive. Returns the archive format + the contained file paths. " +
+         "Read-only — extracts nothing. Reads the archive directly (via Mutagen) — no external tool needed. To read a " +
+         "file's CONTENTS, use housecarl_bsa_extract then read the file.")]
     public static string BsaList(
-        ToolPathResolver bridge,
         [Description("Full path to the .bsa archive to list.")]
             string archive,
         [Description("Optional. Max characters before the file list is cut with an explicit notice. 0 = the server default (~80k).")]
             int max_chars = 0) => Guard.Tool("housecarl_bsa_list", () =>
     {
         if (string.IsNullOrWhiteSpace(archive)) return "error: no archive given. Pass the full path to the .bsa.";
-        // GetFullPath: BSArch resolves relative paths against ITS OWN folder (the child's working dir),
-        // not the server's — a relative path that passed File.Exists here could list a DIFFERENT
-        // same-named archive sitting beside BSArch (2026-06-12 adversarial hunt).
         try { archive = Path.GetFullPath(archive.Trim().Trim('"')); }
         catch (Exception ex) { return $"error: '{archive}' is not a usable path ({ex.Message})."; }
         if (!File.Exists(archive)) return $"error: no such file: '{archive}'.";
-        if (bridge.RequireOrPrompt(ToolDependency.Bsarch, out var bsarch) is { } prompt) return prompt;
 
-        var r = HousecarlCore.BsaArchive.List(bsarch!, archive);
+        var r = HousecarlCore.BsaArchive.List(archive);
         if (!r.Ran) return "error: " + r.RunError;
-        if (!r.Success)
-            // Covers BOTH unreadable (no "Files: N" at all) and aborted-mid-list (declared N, listed
-            // fewer) — the old guard only caught the first, rendering "N file(s)" over an empty list.
-            return r.DeclaredCount == 0
-                ? $"error: BSArch could not read '{Path.GetFileName(archive)}' as an archive. Raw output:\n" + r.Raw
-                : $"error: BSArch declared {r.DeclaredCount} file(s) in '{Path.GetFileName(archive)}' but listed {r.Files.Count} — the listing aborted or the archive is damaged. Raw output:\n" + r.Raw;
 
         int cap = max_chars > 0 ? max_chars : 80_000;
         var sb = new StringBuilder();
@@ -60,32 +48,29 @@ public static class BsaTools
 
     [McpServerTool(Name = "housecarl_bsa_extract", Title = "Extract a .bsa archive to a folder"),
      Description(
-         "Extract a Bethesda .bsa archive's contents to a folder (via BSArch), so you can read the files. BSArch unpacks " +
-         "the WHOLE archive (it has no per-file extract). Pass dest= a folder to unpack into; OMIT dest to let houseCARL " +
-         "unpack into a NEW reviewable mod folder under your mods directory (reported back) — that needs houseCARL pointed " +
-         "at your MO2 instance. Needs the BSArch path (auto-prompts if unset). Originals are never modified.")]
+         "Extract a Bethesda .bsa archive's contents to a folder so you can read the files. Reads the archive directly " +
+         "(via Mutagen — handles compressed archives too) — no external tool needed. Unpacks the WHOLE archive. Pass " +
+         "dest= a folder to unpack into; OMIT dest to let houseCARL unpack into a NEW reviewable mod folder under your " +
+         "mods directory (reported back) — that needs houseCARL pointed at your MO2 instance. Originals are never modified.")]
     public static string BsaExtract(
         LoadOrderService svc,
-        ToolPathResolver bridge,
         [Description("Full path to the .bsa archive to extract.")]
             string archive,
         [Description("Optional. Folder to unpack into. If omitted, houseCARL creates a NEW mod folder under your mods directory and reports its path.")]
             string? dest = null) => Guard.Tool("housecarl_bsa_extract", () =>
     {
         if (string.IsNullOrWhiteSpace(archive)) return "error: no archive given. Pass the full path to the .bsa.";
-        // GetFullPath: BSArch resolves relative paths against ITS OWN folder, not the server's (see BsaList).
         try { archive = Path.GetFullPath(archive.Trim().Trim('"')); }
         catch (Exception ex) { return $"error: '{archive}' is not a usable path ({ex.Message})."; }
         if (!File.Exists(archive)) return $"error: no such file: '{archive}'.";
-        if (bridge.RequireOrPrompt(ToolDependency.Bsarch, out var bsarch) is { } prompt) return prompt;
 
         string target;
         bool managed = string.IsNullOrWhiteSpace(dest);
         if (managed)
         {
             if (svc.ConfigPromptOrNull() is { } cfg) return cfg;   // need ModsDir for the default managed folder
-            // Extract keeps its own #49 residue contract (snapshot-provenance + the "left at X" message below) — out
-            // of H2's delete-if-empty scope, which Aaron set to repack/compile/decompile. Just take the output dir.
+            // Extract keeps its own #49 residue contract (the "left at X" message below) — out of H2's delete-if-empty
+            // scope, which Aaron set to repack/compile/decompile. Just take the output dir.
             try { target = svc.ResolvePatchModFolder(Path.GetFileNameWithoutExtension(archive) + " (extracted)", into: null, "houseCARL_Extract").OutputDir; }
             catch (InvalidOperationException ex) { return "error: " + ex.Message; }
         }
@@ -94,24 +79,15 @@ public static class BsaTools
             target = Path.GetFullPath(dest!.Trim().Trim('"'));
         }
 
-        var r = HousecarlCore.BsaArchive.Unpack(bsarch!, archive, target);
-        if (!r.Ran) return "error: " + r.RunError;
-        if (!r.Success)
-            // BSArch RAN (we returned above on !Ran) but wrote nothing. Two real causes, named so the failure is
-            // self-explanatory (Q3): (1) BSArch's unpacker is stricter than the game engine, so an archive written by
-            // a non-standard tool can list + load in-game yet unpack to nothing — re-pack it with BSArch or the CK's
-            // Archive.exe/CAO to get a conformant archive; (2) the dest already holds byte-identical files with
-            // restored timestamps, which reads as "nothing new". The raw output below distinguishes them.
-            return $"extract FAILED: '{Path.GetFileName(archive)}' produced no new or changed files in '{target}' this run." +
-                   (managed ? $" The freshly created mod folder (with only houseCARL's meta.ini marker) was left at '{target}' — delete it or retry into it." : "") +
-                   "\nBSArch ran but extracted nothing. Most likely the archive is non-standard: BSArch's unpacker is " +
-                   "stricter than the game, so an archive written by a custom tool can list and load in-game yet fail to " +
-                   "unpack — re-pack it with BSArch or the CK's Archive.exe. (If the dest already holds identical files, " +
-                   "that also reads as 'nothing new'.)" +
-                   "\nRaw BSArch output:\n" + r.Raw;
+        string residue = managed ? $"\nThe freshly created mod folder was left at '{target}' — delete it or retry into it." : "";
+        var r = HousecarlCore.BsaArchive.Unpack(archive, target);
+        if (!r.Ran) return "error: " + r.RunError + residue;   // archive couldn't be opened/read
+        if (!r.Success)                                          // path-traversal refusal or a mid-extract error (Q3)
+            return "extract FAILED: " + r.Raw + residue;
 
         var sb = new StringBuilder();
         sb.Append("extracted ").Append(Path.GetFileName(archive)).Append(" → ").Append(target).Append('\n');
+        sb.Append(r.Raw).Append('\n');   // e.g. "extracted 5826 file(s)."
         sb.Append(managed
             ? "(a new houseCARL mod folder — read the files you need from it; enable it in MO2 only if you want the loose files in your load order.)"
             : "(read the files you need from that folder.)");

--- a/src/housecarl-mcp/BsaTools.cs
+++ b/src/housecarl-mcp/BsaTools.cs
@@ -32,6 +32,7 @@ public static class BsaTools
 
         var r = HousecarlCore.BsaArchive.List(archive);
         if (!r.Ran) return "error: " + r.RunError;
+        if (!r.Success) return "error: " + r.Raw;   // header-vs-reader file-count mismatch (possible corruption)
 
         int cap = max_chars > 0 ? max_chars : 80_000;
         var sb = new StringBuilder();


### PR DESCRIPTION
Fixes #217.

## The gap

`bsa_extract` shelled **BSArch**, whose *unpacker* is stricter than its own *lister* and the game engine. An archive written by a non-BSArch tool (a mod's custom Python v105 writer) could `bsa_list` fine and load in-game, yet extract to **zero files** — the reported blocker on the extract → modify → repack release workflow.

## What changed (and why it changed mid-PR)

This PR originally hand-rolled a native BSA reader as a *fallback*. The review flagged robustness gaps in that reader (name-hash validation, folder-block layout) — and digging into them surfaced that the premise was false: the code claimed *"Mutagen has no archive surface,"* but **Mutagen.Bethesda.Core (already referenced) ships a full, maintained in-process BSA reader** (`Archive.CreateReader`). So the whole read path moved onto it.

`bsa_list` and `bsa_extract` now read through Mutagen:

- **Extracts archives BSArch's unpacker rejects** (the #217 class) **and handles compressed archives too** — strictly more capable than the hand-rolled reader, so the review's findings are handled upstream and moot.
- **Byte-for-byte identical to BSArch** on conformant archives (verified in `bsa-probe`, including a compressed one).
- **No external tool needed to list or extract** — only `repack` still uses BSArch, because Mutagen 0.53.1 has a reader but no writer.
- **Path-traversal-guarded** (a `..` entry refuses) and **content-aware/idempotent** (a byte-identical file already on disk is skipped). **Loud, named failure** on an unreadable archive (Q3).
- Corrects the load-bearing false comment in `BsaArchive.cs`.

## Empirical validation (this machine, real BSArch)

- Mutagen extract == BSArch unpack **byte-for-byte** on SkyUI (uncompressed, 71 files) and RedBag's Dragonsreach (**compressed**, flags=31, 12 files).
- Mutagen has a reader, **no writer** (reflection-confirmed) → repack stays on BSArch.
- Mutagen reads hand-authored synthetic archives → CI coverage needs no BSArch.

## Tests

- **`bsa-extract-guard`** (self-contained CI, no BSArch): hand-authored v105/v104 archives Mutagen reads — byte-correct round-trip, content-aware idempotence, path-traversal refusal, loud failure on a non-archive.
- **`bsa-probe`** (opt-in, real BSArch): **Mutagen unpack == BSArch unpack byte-for-byte** (uncompressed + compressed), the pack round-trip, and the non-destructive-pack guard.
- **`bsa-contract-guard`**: trimmed to pack-provenance + format-refusal (the unpack-provenance arms are obsolete now reads don't shell BSArch).
- **`ci-all`: 98/98 ALL PASS.**

## Not in scope / follow-ups

- Repack still needs BSArch (Mutagen has no BSA writer). The external-tool dependency now exists **only** for repack.
- A CHANGELOG line is owed at the next release cut.

<sub>Superseded the hand-rolled-reader commit (force-pushed to one clean commit); the earlier inline review comments anchored to `BsaNativeReader.cs` are now outdated — that file is gone, and its concerns are handled by Mutagen's reader.</sub>
