### PR TITLE
fix(mcp): name the offending parameter on a wrong-type argument (#222)

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -23,6 +23,15 @@ own unpack (uncompressed *and* compressed). Consequences:
 - A per-entry size ceiling and a header-vs-reader file-count cross-check keep a corrupt or hostile archive to a
   **loud, named failure** rather than an out-of-memory or a silent empty extract.
 
+**Wrong-type arguments are now named (#222).** Passing an argument of the wrong type — an object where a number
+is expected, a string where a boolean is — used to surface as a raw `JsonException … BytePositionInLine: 34`: a
+byte offset with no parameter name, forcing you to bisect which argument was at fault. The argument-binding shim
+now catches the type mismatch *before* binding and names the offender, its expected type, and the kind received
+(e.g. `parameter whose type could not be bound: conflicts_only (expects boolean, received string)`) — the same
+named-and-actionable style the missing-parameter and unknown-parameter paths already use. Obvious-intent shapes
+(a bare string for an array, a quoted number or boolean) are still auto-coerced, so well-formed calls are
+unaffected.
+
 ## 1.9.0 — 2026-07-17
 
 houseCARL's view of the **SKSE-plugin layer** grows from *inventory* into *diagnosis*: two new audit tools

--- a/src/housecarl-generator/BindingShimProbe.cs
+++ b/src/housecarl-generator/BindingShimProbe.cs
@@ -142,12 +142,24 @@ public static class BindingShimProbe
             failures += Check("F coerce: quoted bool conflicts_only binds and runs the tool body",
                 !f.text.Contains(GenericError) && f.text.Contains(ConfigPrompt), f.Describe());
 
-            // -- G: an UNCOERCIBLE shape (an object where a number is declared) must still fail — but
-            //    NAMED, telling the caller it's an argument-shape problem, never the bare generic text.
+            // -- G: an UNCOERCIBLE wrong-TYPE shape (an object where a number is declared) must still fail — but
+            //    NAMED, and (#222) naming the OFFENDING PARAMETER (limit) + its received kind, caught BEFORE
+            //    binding, not a bare byte-offset error over the whole received list.
             var g = Call(stdin, stdout, 8, "housecarl_cross_plugin_query",
                 """{"type":"CELL","plugins":["Synthetic.esp"],"limit":{"oops":1}}""");
-            failures += Check("G rewrite: an uncoercible argument fails NAMED, not generic",
-                !g.text.Contains(GenericError) && g.text.Contains("could not be bound"), g.Describe());
+            failures += Check("G type-mismatch: an uncoercible wrong-type arg fails NAMED, naming the parameter",
+                !g.text.Contains(GenericError) && g.text.Contains("could not be bound")
+                && g.text.Contains("limit") && g.text.Contains("object"), g.Describe());
+
+            // -- G2: #222 — a wrong-TYPE value for a declared BOOLEAN parameter (the report's exact class: a bad
+            //    conflicts_only threw "could not be converted to System.Boolean" with a byte offset but NO
+            //    parameter name). Must now be refused NAMED, identifying the parameter AND its expected type,
+            //    before binding — never the generic error and never a silent run (no ConfigPrompt = body ran).
+            var g2 = Call(stdin, stdout, 32, "housecarl_cross_plugin_query",
+                """{"type":"CELL","conflicts_only":"CELL"}""");
+            failures += Check("G2 type-mismatch: a wrong-type boolean arg is named with its parameter and expected type",
+                !g2.text.Contains(GenericError) && !g2.text.Contains(ConfigPrompt)
+                && g2.text.Contains("conflicts_only") && g2.text.Contains("boolean"), g2.Describe());
 
             // -- H: an EXPLICIT JSON null for a REQUIRED parameter (2026-06-12 hunt, proven over stdio on
             //    nexus_mod): ContainsKey saw it as supplied, the SDK bound null, and the tool body

--- a/src/housecarl-mcp/ToolCallShim.cs
+++ b/src/housecarl-mcp/ToolCallShim.cs
@@ -20,6 +20,10 @@ namespace HousecarlMcp;
 /// number where a string is declared becomes its text. Anything else is left for binding to judge.</item>
 /// <item><b>Refuse missing REQUIRED parameters by name</b> — the audit's <c>{}</c> call gets
 /// "required parameter missing: formids", not the generic text.</item>
+/// <item><b>Name a mistyped parameter</b> — an argument whose JSON kind can't bind to its declared schema type
+/// (e.g. an object where a number is declared) is refused BEFORE binding, naming the offender, its expected
+/// type, and the kind received (#222) — so the caller never has to bisect a byte-offset binding error across
+/// the whole argument list.</item>
 /// <item><b>Name what still fails</b> — if binding still throws (an uncoercible shape), the exception passes
 /// through this filter on its way to the SDK's catch (which sits ABOVE the filter pipeline and would genericize
 /// it — measured: AIFunctionMcpServerTool.InvokeAsync doesn't catch; McpServerImpl's outermost wrapper does).
@@ -50,6 +54,7 @@ internal static class ToolCallShim
                 CoerceObviousShapes(p, schema);
                 if (MissingRequired(p, schema) is { } refusal) return refusal;
                 if (UnknownParameters(p, schema) is { } unknownRefusal) return unknownRefusal;
+                if (TypeMismatches(p, schema) is { } typeRefusal) return typeRefusal;
             }
             return await next(request, cancellationToken);
         }
@@ -218,6 +223,59 @@ internal static class ToolCallShim
             $"{string.Join(", ", supported)}. An unrecognized argument is IGNORED (it does not change behavior), so " +
             $"the call would otherwise run with that intent silently dropped — fix the name{knobHint} and retry.");
     }
+
+    /// <summary>Declared arguments whose JSON kind cannot bind to their declared schema type → a named refusal
+    /// listing each offender with its expected type(s) and the kind received, or null to proceed. THE fix for
+    /// #222: a wrong-TYPE argument (e.g. an object where a number is declared, or a string where a boolean is)
+    /// otherwise threw inside the SDK binder as a bare <c>JsonException … Path: $ | BytePositionInLine: 34</c> —
+    /// a byte offset with NO parameter name, which the catch below could only pass through with the full received
+    /// list, forcing the caller to bisect which argument was wrong. This catches the common kind-mismatch class
+    /// BEFORE binding and names it in the same style as <see cref="MissingRequired"/> / <see cref="UnknownParameters"/>.
+    /// Runs AFTER <see cref="CoerceObviousShapes"/> (so an obvious-intent shape — a bare string for an array, a
+    /// quoted number/bool — is fixed, never flagged) and judges ONLY keys the schema declares with a concrete
+    /// type: an untyped/polymorphic property (empty <see cref="DeclaredTypes"/>) is left for binding, an unknown
+    /// key is <see cref="UnknownParameters"/>' to report, and an explicit JSON null is left alone (optional-unset
+    /// for a non-required parameter; the required-null case is <see cref="MissingRequired"/>'s). So a well-formed
+    /// call is byte-identical to before, and anything this can't foresee (e.g. a non-integral number for an
+    /// integer parameter) still falls to the named catch.</summary>
+    static CallToolResult? TypeMismatches(CallToolRequestParams p, JsonElement schema)
+    {
+        if (p.Arguments is not { Count: > 0 } args) return null;
+        if (schema.ValueKind != JsonValueKind.Object ||
+            !schema.TryGetProperty("properties", out var props) || props.ValueKind != JsonValueKind.Object) return null;
+
+        List<string>? bad = null;
+        foreach (var kv in args)
+        {
+            if (kv.Value.ValueKind == JsonValueKind.Null) continue;          // null = optional-unset; the required-null case is MissingRequired's
+            if (!props.TryGetProperty(kv.Key, out var propSchema)) continue; // an unknown key is UnknownParameters' to report
+            var declared = DeclaredTypes(propSchema);
+            if (declared.Count == 0) continue;                              // untyped/polymorphic — leave for binding to judge
+            if (KindSatisfies(kv.Value.ValueKind, declared)) continue;
+            (bad ??= new()).Add(
+                $"{kv.Key} (expects {string.Join(" or ", declared.Where(t => t != "null"))}, received {KindName(kv.Value.ValueKind)})");
+        }
+        if (bad is null) return null;
+
+        string plural = bad.Count == 1 ? "" : "s";
+        return NamedError(
+            $"error: {p.Name}: parameter{plural} whose type could not be bound: {string.Join("; ", bad)}. " +
+            "Fix the argument's TYPE to match the schema (array parameters take JSON arrays — a single bare string " +
+            "is auto-wrapped; numbers take numbers; booleans take true/false) and retry.");
+    }
+
+    /// <summary>Whether a JSON kind can bind to at least one of a property's declared schema types. A JSON number
+    /// satisfies both "number" and "integer" (an integral check is the binder's, not ours); every other kind maps
+    /// to its one schema type. Null never reaches here (filtered by the caller).</summary>
+    static bool KindSatisfies(JsonValueKind kind, HashSet<string> declared) => kind switch
+    {
+        JsonValueKind.String => declared.Contains("string"),
+        JsonValueKind.Number => declared.Contains("number") || declared.Contains("integer"),
+        JsonValueKind.True or JsonValueKind.False => declared.Contains("boolean"),
+        JsonValueKind.Array => declared.Contains("array"),
+        JsonValueKind.Object => declared.Contains("object"),
+        _ => true,   // an unexpected kind — don't presume a mismatch; let binding judge
+    };
 
     static CallToolResult NamedError(string text) => new()
     {


### PR DESCRIPTION
Fixes #222.

## The problem
A wrong-typed argument surfaced as a raw binding exception with a byte offset but **no parameter name**:

> `JsonException: The JSON value could not be converted to System.Boolean. Path: $ | BytePositionInLine: 34`

The unknown-*name* and missing-*required* paths already name things beautifully; only the wrong-*type* path forced the caller to bisect which argument was at fault (the report clocks it at 2 round-trips misusing `defined_in` on `cross_plugin_query`).

## The fix
A new `TypeMismatches` check in the argument-binding shim (`ToolCallShim`), running **after** coercion and before the SDK binds, walks each declared argument, compares its JSON kind to the schema's declared type, and refuses a mismatch **by name** — same style as `MissingRequired` / `UnknownParameters`:

> `error: housecarl_cross_plugin_query: parameter whose type could not be bound: conflicts_only (expects boolean, received string). Fix the argument's TYPE to match the schema …`

Schema-driven off each tool's own `InputSchema`, so every current and future parameter is covered by construction. It judges **only** keys the schema declares with a concrete type — untyped/polymorphic props are left for binding, unknown keys stay `UnknownParameters`' job, explicit JSON null stays optional-unset. Obvious-intent shapes (bare string → array, quoted number/bool) are still coerced first, so **well-formed calls are byte-identical**. Anything the check can't foresee still falls to the existing named catch.

## Verification
- `BindingShimProbe` (drives the real `housecarl-mcp.exe` over stdio — the exact wire path the failure took): case **G** strengthened to assert the parameter is named; new case **G2** covers the report's exact boolean-mismatch class.
- Build clean (pre-existing warnings only); **ci-all 98/98** (was 97; G2 adds one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)