### PR TITLE
feat(mcp): resolve obvious parameter aliases at the binding layer (#221)

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -32,6 +32,16 @@ named-and-actionable style the missing-parameter and unknown-parameter paths alr
 (a bare string for an array, a quoted number or boolean) are still auto-coerced, so well-formed calls are
 unaffected.
 
+**Obvious parameter aliases now bind (#221).** Tool parameters aren't uniformly named — one tool takes `plugins`,
+another `plugin`, another `plugin_name` — so a first-guess miss (`form_id` for `formid`, `plugin` for a tool's
+`plugins`) cost a round-trip. The argument-binding shim now recognizes an obvious synonym of a declared parameter
+and renames it to the canonical one, so the call binds instead of erroring. It's deliberately conservative: it
+resolves an underscore/case variant (`form_id` ≡ `formid`) or a known singular/plural synonym, and **only** when
+exactly one declared, not-already-supplied parameter matches — an ambiguous or unmatched name still gets the named
+unknown-parameter error, a declared parameter is never treated as an alias (a tool's real `plugin=` is untouched),
+and an explicit canonical value is never overwritten. The published schema still advertises only the canonical
+name.
+
 ## 1.9.0 — 2026-07-17
 
 houseCARL's view of the **SKSE-plugin layer** grows from *inventory* into *diagnosis*: two new audit tools

--- a/src/housecarl-generator/BindingShimProbe.cs
+++ b/src/housecarl-generator/BindingShimProbe.cs
@@ -190,6 +190,48 @@ public static class BindingShimProbe
                 """{"formid":"0F1AC1:Skyrim.esm"}""");
             failures += Check("I2 control: the same call without the stray param binds and runs the tool body",
                 !i2.text.Contains(GenericError) && i2.text.Contains(ConfigPrompt), i2.Describe());
+
+            // -- J1: #221 — the alias 'plugin' for a tool whose declared parameter is 'plugins' (singular↔plural
+            //    synonym group). Must be RENAMED to plugins, then shape-coerced (string → one-element array) and
+            //    reach the tool body — no unknown-parameter refusal, no generic error.
+            var j1 = Call(stdin, stdout, 33, "housecarl_cross_plugin_query",
+                """{"type":"CELL","plugin":"Synthetic.esp"}""");
+            failures += Check("J1 alias: 'plugin' is resolved to 'plugins' and the call binds and runs",
+                !j1.text.Contains(GenericError) && !j1.text.Contains("unknown parameter") && j1.text.Contains(ConfigPrompt),
+                j1.Describe());
+
+            // -- J2: #221 — the alias 'form_id' for 'formid' (an underscore/case variant, resolved by
+            //    normalization alone). Must be renamed to formid and reach the body.
+            var j2 = Call(stdin, stdout, 34, "housecarl_read_record",
+                """{"form_id":"0F1AC1:Skyrim.esm"}""");
+            failures += Check("J2 alias: 'form_id' is resolved to 'formid' and the call binds and runs",
+                !j2.text.Contains(GenericError) && !j2.text.Contains("unknown parameter") && j2.text.Contains(ConfigPrompt),
+                j2.Describe());
+
+            // -- J3: #221 — the alias 'plugin_name' for 'plugins' (normalizes to "pluginname"; resolved via the
+            //    synonym group, not by normalization equality). Must be renamed and reach the body.
+            var j3 = Call(stdin, stdout, 35, "housecarl_cross_plugin_query",
+                """{"type":"CELL","plugin_name":"Synthetic.esp"}""");
+            failures += Check("J3 alias: 'plugin_name' is resolved to 'plugins' and the call binds and runs",
+                !j3.text.Contains(GenericError) && !j3.text.Contains("unknown parameter") && j3.text.Contains(ConfigPrompt),
+                j3.Describe());
+
+            // -- J4: #221 GUARD — a tool whose REAL parameter is 'plugin' (read_plugin_file) must NOT have it
+            //    treated as an alias: a declared parameter is always left alone, so the call binds normally.
+            var j4 = Call(stdin, stdout, 36, "housecarl_read_plugin_file",
+                """{"plugin":"Skyrim.esm","formid":"0F1AC1:Skyrim.esm"}""");
+            failures += Check("J4 alias-guard: a tool's REAL 'plugin=' is untouched (binds and runs, not refused)",
+                !j4.text.Contains(GenericError) && !j4.text.Contains("unknown parameter") && j4.text.Contains(ConfigPrompt),
+                j4.Describe());
+
+            // -- J5: #221 GUARD — an explicit canonical value is never clobbered: with 'plugins' supplied, the
+            //    stray alias 'plugin' has no free target, so it is left for the unknown-parameter path (named),
+            //    never silently merged over the caller's canonical value.
+            var j5 = Call(stdin, stdout, 37, "housecarl_cross_plugin_query",
+                """{"type":"CELL","plugins":["Synthetic.esp"],"plugin":"Other.esp"}""");
+            failures += Check("J5 alias-guard: alias does not clobber an explicit canonical; the extra is named",
+                !j5.text.Contains(GenericError) && j5.text.Contains("unknown parameter") && j5.text.Contains("plugin"),
+                j5.Describe());
         }
         catch (Exception ex)
         {

--- a/src/housecarl-mcp/ToolCallShim.cs
+++ b/src/housecarl-mcp/ToolCallShim.cs
@@ -12,9 +12,16 @@ namespace HousecarlMcp;
 /// genericizes to "An error occurred invoking '&lt;tool&gt;'." — an opaque dead end the live audit agent could not
 /// self-correct from (it abandoned the documented query path; see the bug report's transcripts).
 ///
-/// Three moves, all schema-driven off the tool's own published InputSchema (so every current and future tool
+/// Its moves, all schema-driven off the tool's own published InputSchema (so every current and future tool
 /// parameter is covered by construction — no per-tool wiring):
 /// <list type="number">
+/// <item><b>Resolve obvious aliases</b> — a parameter named by an obvious synonym of a declared one
+/// (<c>form_id</c> for <c>formid</c>; <c>plugin</c>/<c>plugin_name</c> for a tool's <c>plugins</c>; any
+/// underscore/case variant) is renamed to the canonical parameter when the mapping is unambiguous — exactly one
+/// declared, not-already-supplied synonym target — so a first-guess miss BINDS instead of costing a round-trip
+/// (#221). A synonym that resolves to nothing (or to more than one target) is left for the unknown-parameter
+/// path. The published schema still advertises only the canonical name, and a declared parameter is never
+/// treated as an alias (so a tool's real <c>plugin=</c> is untouched).</item>
 /// <item><b>Coerce obvious intent</b> — a bare string where an array is declared becomes a one-element array
 /// (the live failing shape: <c>plugins="A.esp"</c>); quoted numbers/booleans become numbers/booleans; a bare
 /// number where a string is declared becomes its text. Anything else is left for binding to judge.</item>
@@ -51,6 +58,7 @@ internal static class ToolCallShim
             if (p is not null && request.MatchedPrimitive is McpServerTool tool)
             {
                 var schema = tool.ProtocolTool.InputSchema;
+                ResolveAliases(p, schema);
                 CoerceObviousShapes(p, schema);
                 if (MissingRequired(p, schema) is { } refusal) return refusal;
                 if (UnknownParameters(p, schema) is { } unknownRefusal) return unknownRefusal;
@@ -75,6 +83,74 @@ internal static class ToolCallShim
                 "argument and retry.");
         }
     };
+
+    /// <summary>Sets of interchangeable parameter names (normalized: lowercased, underscores stripped) — the
+    /// synonyms that differ by more than an underscore/case variant, so <see cref="Normalize"/> alone can't
+    /// bridge them: singular↔plural and the <c>plugin_name</c> spelling. Underscore/case variants
+    /// (<c>form_id</c>≡<c>formid</c>) need no entry here — <see cref="Normalize"/> equality catches those.</summary>
+    static readonly string[][] SynonymGroups =
+    {
+        new[] { "plugin", "plugins", "pluginname", "pluginnames" },
+        new[] { "formid", "formids" },
+    };
+
+    /// <summary>Rename an argument keyed by an obvious synonym of a declared parameter to that canonical parameter,
+    /// so a first-guess miss (<c>form_id</c> for <c>formid</c>, <c>plugin</c> for a tool's <c>plugins</c>) binds
+    /// instead of costing a round-trip (#221). Conservative by construction: only a key the schema does NOT declare
+    /// is considered, it is renamed ONLY when EXACTLY ONE declared, not-already-supplied parameter is its synonym
+    /// (zero or ambiguous → left for <see cref="UnknownParameters"/> to name), and a declared parameter is never
+    /// touched — so a tool's real <c>plugin=</c> stays its own, an explicit canonical value is never clobbered, and
+    /// a well-formed call is byte-identical. Runs BEFORE <see cref="CoerceObviousShapes"/> so the renamed value is
+    /// then shape-coerced (a bare-string <c>plugin</c> → <c>plugins</c> → a one-element array) as usual.</summary>
+    static void ResolveAliases(CallToolRequestParams p, JsonElement schema)
+    {
+        if (p.Arguments is not { Count: > 0 } args) return;
+        if (schema.ValueKind != JsonValueKind.Object) return;
+        // Respect an explicit opt-in to extra properties (mirrors UnknownParameters): if a tool accepts free-form
+        // args, an undeclared key may be intentional data — never rewrite it. None of houseCARL's tools do today.
+        if (schema.TryGetProperty("additionalProperties", out var ap) && ap.ValueKind != JsonValueKind.False) return;
+        if (!schema.TryGetProperty("properties", out var props) || props.ValueKind != JsonValueKind.Object) return;
+
+        Dictionary<string, JsonElement>? rewritten = null;
+        foreach (var kv in args)
+        {
+            var key = kv.Key;
+            if (key.Length > 0 && key[0] == '_') continue;            // MCP/JSON-RPC metadata — never an alias
+            if (props.TryGetProperty(key, out _)) continue;           // already a real parameter of this tool
+
+            string? target = null; bool ambiguous = false;
+            foreach (var prop in props.EnumerateObject())
+            {
+                var declaredName = prop.Name;
+                if (args.ContainsKey(declaredName)) continue;                                 // caller already supplied the canonical — don't clobber
+                if (rewritten is not null && rewritten.ContainsKey(declaredName)) continue;   // an earlier rename already produced it
+                if (!AreSynonyms(key, declaredName)) continue;
+                if (target is null) target = declaredName; else { ambiguous = true; break; }
+            }
+            if (ambiguous || target is null) continue;                // nothing unambiguous — leave for UnknownParameters
+
+            rewritten ??= new Dictionary<string, JsonElement>(args);
+            rewritten.Remove(key);
+            rewritten[target] = kv.Value;
+        }
+        if (rewritten is not null) p.Arguments = rewritten;
+    }
+
+    /// <summary>Whether two parameter names denote the same concept: equal once normalized (an underscore/case
+    /// variant, <c>form_id</c>≡<c>formid</c>) or listed together in a <see cref="SynonymGroups"/> entry
+    /// (singular↔plural, <c>plugin_name</c>↔<c>plugins</c>).</summary>
+    static bool AreSynonyms(string a, string b)
+    {
+        var na = Normalize(a);
+        var nb = Normalize(b);
+        if (na == nb) return true;
+        foreach (var g in SynonymGroups)
+            if (Array.IndexOf(g, na) >= 0 && Array.IndexOf(g, nb) >= 0) return true;
+        return false;
+    }
+
+    /// <summary>A parameter name reduced to its comparison form: lowercased with underscores removed.</summary>
+    static string Normalize(string s) => s.Replace("_", "").ToLowerInvariant();
 
     /// <summary>Rewrite arguments whose JSON kind mismatches the declared schema type but whose intent is
     /// unambiguous. Only ever REPLACES values for keys the schema declares — unknown keys and already-correct


### PR DESCRIPTION
Fixes #221.

## The problem
Tool parameters aren't uniformly named — `read_record` takes `formid=`, `check_errors` takes `plugins=`, `create_plugin` takes `plugin_name=`, `read_plugin_file` takes `plugin=`. A first-guess miss (`form_id`, or `plugin` for a `plugins` tool) is silently ignored or errors, costing a round-trip; the report notes an orchestrator had to inject a per-tool cheat-sheet into every subagent prompt to suppress the class.

## The fix
A new `ResolveAliases` step in the argument-binding shim (`ToolCallShim`), running **before** coercion, renames an undeclared alias key to the canonical parameter when the mapping is unambiguous. Two mechanisms:

1. **Underscore/case normalization** — `form_id` ≡ `formid`, `formID` ≡ `formid`.
2. **Small synonym groups** for the differences normalization can't bridge — singular↔plural and the `plugin_name` spelling: `{plugin, plugins, plugin_name, plugin_names}`, `{formid, formids}`.

**Conservative by construction** — the safety properties the report's trap demands:
- Only a key the schema does **not** declare is ever considered → a tool's real `plugin=` (read_plugin_file) is untouched.
- Renamed only when **exactly one** declared, not-already-supplied parameter matches → ambiguous/unmatched names still get the named unknown-parameter error.
- An explicit canonical value is **never** clobbered (supply both `plugins` and `plugin` → `plugin` is named as unknown, not silently merged).
- The published schema still advertises only the canonical name; **well-formed calls are byte-identical**.

Runs before coercion, so a renamed value is then shape-coerced as usual (bare-string `plugin` → `plugins` → one-element array).

## Verification
`BindingShimProbe` (drives the real `housecarl-mcp.exe` over stdio) gains five cases:
- **J1** `plugin`→`plugins` (synonym, singular→plural) binds and runs
- **J2** `form_id`→`formid` (normalization) binds and runs
- **J3** `plugin_name`→`plugins` (synonym group) binds and runs
- **J4** guard: a tool's real `plugin=` (read_plugin_file) is untouched
- **J5** guard: an alias never clobbers an explicit canonical; the extra is named

Build clean (pre-existing warnings only); **ci-all green** (all binding-shim-guard asserts pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)