### PR TITLE
feat(query): dense columnar output + offset= pagination for cross_plugin_query

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -57,7 +57,8 @@ whole-mod enumeration used to be the context-budget drain: `format="json"` repea
 offset, paging meant slicing by `editorid_contains`. Now:
 
 - **`format="dense"`** renders one columnar document — a `columns` array once, then one positional row per match
-  (`[formid, editorid, field values…]`; summary rows are `[formid, type, editorid, winner, override_depth]`). Same
+  (`[formid, editorid, field values…]`; summary rows are `[formid, type, editorid, winner, override_depth]`; under
+  a `plugins=` scope, detail rows gain a `source` column naming the body each row's values came from). Same
   read path and accounting as the other formats; a no-value field shows its note (`"(absent)"`) in-cell, a failed
   row lands in a separate `errors` array, and `resolve_names` annotations still work. In the probe's own
   measurement the same one-field query renders **2.6× smaller** than `format="json"` — and the gap widens with

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -51,6 +51,23 @@ absolute-path file of FormIDs, comma- or newline-separated). `formid in` is the 
 AND with the existing value predicates. The list is fully validated before any scan — a malformed FormID, an
 unreadable or relative file path, or an empty list refuses the call by name, never a silent wrong result.
 
+**`cross_plugin_query` learns bulk-enumeration economy — `format="dense"` + `offset=` pagination (#223).** A
+whole-mod enumeration used to be the context-budget drain: `format="json"` repeated the identity envelope and a
+`{path, value}` object per field on every match (~80 records per 40k chars at two fields), and with `limit` but no
+offset, paging meant slicing by `editorid_contains`. Now:
+
+- **`format="dense"`** renders one columnar document — a `columns` array once, then one positional row per match
+  (`[formid, editorid, field values…]`; summary rows are `[formid, type, editorid, winner, override_depth]`). Same
+  read path and accounting as the other formats; a no-value field shows its note (`"(absent)"`) in-cell, a failed
+  row lands in a separate `errors` array, and `resolve_names` annotations still work. In the probe's own
+  measurement the same one-field query renders **2.6× smaller** than `format="json"` — and the gap widens with
+  more fields.
+- **`offset=`** skips the first N matches, so `offset=0/500/1000…` + `limit=` pages an enumeration in windows that
+  tile exactly (scan order is deterministic while the load order is unchanged). The true total always counts all
+  matches; the text header names the window and the next offset (`showing matches 501–1000; continue with
+  offset=1000`), and json/dense carry `offset` in-band. Negative offsets and `offset=` under `group_by=` (a count
+  table has no window) are refused by name.
+
 ## 1.9.0 — 2026-07-17
 
 houseCARL's view of the **SKSE-plugin layer** grows from *inventory* into *diagnosis*: two new audit tools

--- a/src/housecarl-generator/BulkQueryPrimitivesProbe.cs
+++ b/src/housecarl-generator/BulkQueryPrimitivesProbe.cs
@@ -280,6 +280,51 @@ public static class BulkQueryPrimitivesProbe
             Check($"dense detail is materially smaller than json for the same query ({sDenseF.Length} vs {sJsonF.Length} chars)",
                   sDenseF.Length < sJsonF.Length);
 
+            // Tiling on the OTHER two collect paths (PR #239 review: type= never fires the de-dup, and conflicts_only
+            // collects in its own branch — a branch-confined offset regression must not pass the guard).
+            var fullP = svc.CrossQuery(null, null, null, false, new[] { masterName, replName }, null, 5000);   // 7 records, de-dup ACTIVE
+            var pagedP = new List<FormKey>();
+            for (int off = 0; off < fullP.Total; off += 3)
+            {
+                var win = svc.CrossQuery(null, null, null, false, new[] { masterName, replName }, null, 3, offset: off);
+                Check($"plugins-scope window offset={off} limit=3: sources stay parallel to keys",
+                      win.Sources is not null && win.Sources.Count == win.Keys.Count);
+                pagedP.AddRange(win.Keys);
+            }
+            Check($"plugins=[master,Repl] windows tile the de-dup'd enumeration EXACTLY ({fullP.Total} records)",
+                  pagedP.SequenceEqual(fullP.Keys));
+            var fullC = svc.CrossQuery(null, null, null, true, null, null, 500);                                // conflicts_only branch
+            var winC0 = svc.CrossQuery(null, null, null, true, null, null, 500, offset: 0);
+            var winC1 = svc.CrossQuery(null, null, null, true, null, null, 500, offset: 1);
+            Check("conflicts_only offset: window 0 = the 1 contested record; offset=1 = honest empty window, not capped",
+                  fullC.Total == 1 && winC0.Keys.SequenceEqual(fullC.Keys) && winC1.Keys.Count == 0 && winC1.Total == 1 && !winC1.Capped);
+
+            // total==0 with offset>0: the header must blame the FILTER, not the paging (PR #239 review).
+            var sNoMatch = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: "zzz-no-such-record",
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: null,
+                fields: null, conflict_tree: false, limit: 500, offset: 5, max_chars: 0);
+            Check("text render: total==0 + offset>0 says 'NO records match at any offset' (not 'lower offset=')",
+                  sNoMatch.Contains("NO records match at any offset") && !sNoMatch.Contains("lower offset="));
+
+            // Dense under a plugins= scope carries the per-row SOURCE provenance (PR #239 review, MEDIUM): the row's
+            // values are the scoped plugin's OWN body — W1 reads master's damage 10 (not the winner's 15), and the
+            // source cell names master so that value can never read as live truth unattributed.
+            var sDenseScoped = ReadTools.CrossPluginQuery(svc, type: null, references: null, editorid_contains: null,
+                conflicts_only: false, plugins: new[] { masterName, replName }, defined_in: false, where: null, group_by: null,
+                fields: new[] { "BasicStats.Damage" }, conflict_tree: false, limit: 500, max_chars: 0, format: "dense");
+            using (var doc = JsonDocument.Parse(sDenseScoped))
+            {
+                var root = doc.RootElement;
+                var cols = root.GetProperty("columns").EnumerateArray().Select(c => c.GetString()).ToArray();
+                Check("dense scoped detail: columns gain 'source' = [formid,editorid,BasicStats.Damage,source]",
+                      cols.SequenceEqual(new[] { "formid", "editorid", "BasicStats.Damage", "source" }));
+                var w1row = root.GetProperty("rows").EnumerateArray().FirstOrDefault(r => r[0].GetString() == w1Fk.ToString());
+                Check("dense scoped detail: W1's row = master's OWN damage 10 WITH source=master (provenance in-row)",
+                      w1row.ValueKind == JsonValueKind.Array && w1row[2].GetString() == "10" && w1row[3].GetString() == masterName);
+                Check("dense scoped detail: the P5 scoped-vs-winner note still rides in-band",
+                      root.TryGetProperty("notes", out var notes) && notes.EnumerateArray().Any(n => (n.GetString() ?? "").Contains("winner_fields=true")));
+            }
+
             // dense + offset compose: the in-band offset field + the windowed rows.
             var sDenseOff = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
                 conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: null,

--- a/src/housecarl-generator/BulkQueryPrimitivesProbe.cs
+++ b/src/housecarl-generator/BulkQueryPrimitivesProbe.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Records;
@@ -15,6 +16,9 @@ namespace HousecarlGenerator;
 ///   • P2 list-valued <c>references=</c> — OR over many targets in ONE scan (was one scan per target), each match
 ///     recording WHICH target(s) it hit (matches=…) so a multi-target reverse lookup can be un-merged.
 ///   • P4 <c>group_by=</c> winner|type|defined_in — a count table over ALL matches (not limit-capped) instead of lines.
+///   • #223 <c>offset=</c> pagination (windows tile the enumeration exactly; refusals for negative / group_by) and
+///     <c>format=dense</c> (the columnar render: columns once + positional rows, cross-checked against the plain
+///     summaries and the known winner field values, and materially smaller than format=json for the same query).
 ///
 /// Synthesizes a 2-plugin order ON DISK (a master + a replacer that OVERRIDES one weapon and DEFINES new ones, with
 /// keyword links so references= has something to reverse) and drives the REAL service-layer scan
@@ -198,6 +202,112 @@ public static class BulkQueryPrimitivesProbe
                 group_by: null, fields: new[] { "BasicStats.Damage" }, conflict_tree: false, limit: 500, max_chars: 0);
             Check("detail-mode (fields=) multi-target references= renders the matches= line (W3 → both targets)",
                   sDetail.Contains("matches=") && sDetail.Contains($"matches={kaFk}, {kbFk}"));
+
+            // ================= #223 — offset= pagination + format=dense =================
+            Console.WriteLine();
+            Console.WriteLine("── #223: offset= pages exact windows; format=dense renders columnar rows ──");
+
+            // Service-level paging: limit=1 windows at offset 0/1/2 tile the FULL Weapon enumeration exactly.
+            var full = svc.CrossQuery("Weapon", null, null, false, null, null, 500);
+            var paged = new List<FormKey>();
+            for (int off = 0; off < 3; off++)
+            {
+                var win = svc.CrossQuery("Weapon", null, null, false, null, null, 1, offset: off);
+                Check($"window offset={off} limit=1: 1 row, total still {full.Total}, offset in the outcome",
+                      win.Keys.Count == 1 && win.Total == full.Total && win.Offset == off);
+                Check($"  ... capped={(off < 2).ToString().ToLowerInvariant()} (matches beyond the WINDOW {(off < 2 ? "exist" : "don't")} — skipped-before-offset never reads as capped)",
+                      win.Capped == (off < 2));
+                paged.AddRange(win.Keys);
+            }
+            Check("the 3 windows tile the full enumeration EXACTLY (no gap, no overlap, same order)", paged.SequenceEqual(full.Keys));
+
+            // offset past the end: an honest empty window — exact total, not capped (nothing beyond the window).
+            var past = svc.CrossQuery("Weapon", null, null, false, null, null, 500, offset: 10);
+            Check("offset past the last match: 0 rows, exact total, not capped", past.Keys.Count == 0 && past.Total == full.Total && !past.Capped);
+
+            // refusals (Q3): negative offset; offset under group_by (a count table has no window to page).
+            var neg = svc.CrossQuery("Weapon", null, null, false, null, null, 500, offset: -1);
+            Check("offset=-1 is REFUSED loud", neg.Error is not null && neg.Error.Contains("offset", StringComparison.OrdinalIgnoreCase));
+            var offGroup = svc.CrossQuery("Weapon", null, null, false, null, null, 500, groupBy: "winner", offset: 5);
+            Check("offset + group_by is REFUSED loud (never silently ignored)",
+                  offGroup.Error is not null && offGroup.Error.Contains("group_by", StringComparison.OrdinalIgnoreCase));
+
+            // Text render names the window and the NEXT offset while paging.
+            var sPage = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: null,
+                fields: null, conflict_tree: false, limit: 1, offset: 1, max_chars: 0);
+            Check("text render: 'showing matches 2–2' + 'continue with offset=2'",
+                  sPage.Contains("showing matches 2–2") && sPage.Contains("continue with offset=2"));
+
+            // format=dense summary rows: columnar shape, values cross-checked against the known records.
+            var sDense = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: null,
+                fields: null, conflict_tree: false, limit: 500, max_chars: 0, format: "dense");
+            using (var doc = JsonDocument.Parse(sDense))
+            {
+                var root = doc.RootElement;
+                var cols = root.GetProperty("columns").EnumerateArray().Select(c => c.GetString()).ToArray();
+                Check("dense summary: columns = [formid,type,editorid,winner,override_depth]",
+                      cols.SequenceEqual(new[] { "formid", "type", "editorid", "winner", "override_depth" }));
+                var rows = root.GetProperty("rows").EnumerateArray().ToList();
+                Check("dense summary: 3 positional rows of 5 cells, rendered=3, not truncated",
+                      rows.Count == 3 && rows.All(r => r.ValueKind == JsonValueKind.Array && r.GetArrayLength() == 5)
+                      && root.GetProperty("rendered").GetInt32() == 3 && !root.GetProperty("truncated").GetBoolean());
+                var w1row = rows.FirstOrDefault(r => r[0].GetString() == w1Fk.ToString());
+                Check("dense summary: W1's row shows type=Weapon, winner=Repl (the override wins)",
+                      w1row.ValueKind == JsonValueKind.Array && w1row[1].GetString() == "Weapon" && w1row[3].GetString() == replName);
+            }
+
+            // format=dense detail rows (fields=): [formid, editorid, value…]; winner values under type= scope; and
+            // the whole point — materially smaller than format=json for the SAME query.
+            var sDenseF = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: null,
+                fields: new[] { "BasicStats.Damage" }, conflict_tree: false, limit: 500, max_chars: 0, format: "dense");
+            var sJsonF = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: null,
+                fields: new[] { "BasicStats.Damage" }, conflict_tree: false, limit: 500, max_chars: 0, format: "json");
+            using (var doc = JsonDocument.Parse(sDenseF))
+            {
+                var root = doc.RootElement;
+                var cols = root.GetProperty("columns").EnumerateArray().Select(c => c.GetString()).ToArray();
+                Check("dense detail: columns = [formid,editorid,BasicStats.Damage]",
+                      cols.SequenceEqual(new[] { "formid", "editorid", "BasicStats.Damage" }));
+                var vals = root.GetProperty("rows").EnumerateArray().ToDictionary(r => r[0].GetString()!, r => r[2].GetString());
+                Check("dense detail: damage cells carry the WINNER values (W1=15 override, W2=20, W3=30)",
+                      vals.GetValueOrDefault(w1Fk.ToString()) == "15" && vals.GetValueOrDefault(w2Fk.ToString()) == "20"
+                      && vals.GetValueOrDefault(w3Fk.ToString()) == "30");
+            }
+            Check($"dense detail is materially smaller than json for the same query ({sDenseF.Length} vs {sJsonF.Length} chars)",
+                  sDenseF.Length < sJsonF.Length);
+
+            // dense + offset compose: the in-band offset field + the windowed rows.
+            var sDenseOff = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: null,
+                fields: null, conflict_tree: false, limit: 1, offset: 1, max_chars: 0, format: "dense");
+            using (var doc = JsonDocument.Parse(sDenseOff))
+                Check("dense + offset=1 limit=1: offset in-band, 1 row, capped=true",
+                      doc.RootElement.GetProperty("offset").GetInt32() == 1
+                      && doc.RootElement.GetProperty("rows").GetArrayLength() == 1
+                      && doc.RootElement.GetProperty("capped").GetBoolean());
+
+            // dense + group_by renders the SAME count table as json (documented on format= — not a refusal).
+            var sDenseGroup = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: "winner",
+                fields: null, conflict_tree: false, limit: 500, max_chars: 0, format: "dense");
+            Check("dense + group_by renders the json count table (groups in-band, no refusal)",
+                  !sDenseGroup.StartsWith("error", StringComparison.OrdinalIgnoreCase) && sDenseGroup.Contains("\"groups\""));
+
+            // dense + conflict_tree refused (text-only view); an unknown format names all three (Q3).
+            var sDenseTree = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: null,
+                fields: null, conflict_tree: true, limit: 500, max_chars: 0, format: "dense");
+            Check("dense + conflict_tree=true is REFUSED loud",
+                  sDenseTree.StartsWith("error:", StringComparison.OrdinalIgnoreCase) && sDenseTree.Contains("dense", StringComparison.OrdinalIgnoreCase));
+            var sBadFmt = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: null,
+                fields: null, conflict_tree: false, limit: 500, max_chars: 0, format: "csv");
+            Check("format=csv is REFUSED naming text/json/dense",
+                  sBadFmt.StartsWith("error:", StringComparison.OrdinalIgnoreCase) && sBadFmt.Contains("dense", StringComparison.OrdinalIgnoreCase));
 
             Console.WriteLine();
             Console.WriteLine($"=== bulk-query-primitives-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -282,12 +282,10 @@ static class JsonWire
             {
                 bool detail = fields is { Count: > 0 };
                 bool anyScoped = detail && q.Sources is { } ss && ss.Take(q.Keys.Count).Any(s => s is not null);   // P5
-                string? p5 = anyScoped
-                    ? (winnerFields ? "field values are the load-order WINNER's (winner_fields=true); each match was SELECTED on its scoped plugin's body."
-                                    : "field values are each match's SCOPED plugin's OWN version, NOT the live load-order winner — pass winner_fields=true for load-order truth.")
-                    : null;
+                string? p5 = anyScoped ? ScopedFieldsNote(winnerFields) : null;
                 w.WriteNumber("total", q.Total);
                 w.WriteBoolean("capped", q.Capped);
+                if (q.Offset > 0) w.WriteNumber("offset", q.Offset);        // #223 pagination — the window's start, in-band
                 if (q.ScopeLabel is not null) w.WriteString("scope", q.ScopeLabel);
                 WriteNotes(w, q, p5);
                 var linkMemo = resolveNames && detail ? new Dictionary<FormKey, ResolvedRef>() : null;
@@ -322,6 +320,122 @@ static class JsonWire
             w.WriteEndObject();
         }
         return Finish(ms);
+    }
+
+    /// <summary>The P5 scoped-vs-winner fields note, shared verbatim by the json and dense renders (D2 — one wording,
+    /// two renders that can't drift).</summary>
+    static string ScopedFieldsNote(bool winnerFields) => winnerFields
+        ? "field values are the load-order WINNER's (winner_fields=true); each match was SELECTED on its scoped plugin's body."
+        : "field values are each match's SCOPED plugin's OWN version, NOT the live load-order winner — pass winner_fields=true for load-order truth.";
+
+    // ---- housecarl_cross_plugin_query format=dense (#223) -------------------------------------------
+    /// <summary>The COLUMNAR render: a <c>columns</c> array once, then ONE positional row array per match —
+    /// <c>[formid, editorid, field values…]</c> under fields=, <c>[formid, type, editorid, winner, override_depth]</c>
+    /// for summaries — killing the per-field {path,value} envelopes and repeated identity keys that made format=json
+    /// the context-budget drain in bulk enumerations (#223: ~80 records per 40k chars at two fields). Reads the SAME
+    /// path as the other renders (ResolveRead / Prefilled — D2), and cells use the SAME display vocabulary as the
+    /// text render: the round-trip token, else the parenthetical note (an absent field is "(absent)", never a silent
+    /// hole), with Display/resolve_names annotations appended. Q3 accounting (total/capped/offset/notes/truncated)
+    /// rides in-band; a row whose read FAILS lands in a separate <c>errors</c> array — never a silently missing row.
+    /// group_by= never reaches here (the tool renders its count table via <see cref="RenderCrossQuery"/>).</summary>
+    public static string RenderCrossQueryDense(LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields, int maxChars, bool resolveNames, bool winnerFields)
+    {
+        int cap = Cap(maxChars);
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            if (q.Error is not null) w.WriteString("error", q.Error);
+            else
+            {
+                bool detail = fields is { Count: > 0 };
+                bool anyScoped = detail && q.Sources is { } ss && ss.Take(q.Keys.Count).Any(s => s is not null);   // P5
+                w.WriteNumber("total", q.Total);
+                w.WriteBoolean("capped", q.Capped);
+                if (q.Offset > 0) w.WriteNumber("offset", q.Offset);
+                if (q.ScopeLabel is not null) w.WriteString("scope", q.ScopeLabel);
+                WriteNotes(w, q, anyScoped ? ScopedFieldsNote(winnerFields) : null);
+
+                bool hasMatches = q.MatchedTargets is not null;               // multi-target references= → one extra column
+                w.WriteStartArray("columns");
+                if (detail)
+                {
+                    w.WriteStringValue("formid"); w.WriteStringValue("editorid");
+                    foreach (var f in fields!) w.WriteStringValue(f);         // cells align positionally: ReadFields returns exactly one value per requested path, in order
+                }
+                else
+                    foreach (var c in new[] { "formid", "type", "editorid", "winner", "override_depth" }) w.WriteStringValue(c);
+                if (hasMatches) w.WriteStringValue("matches");
+                w.WriteEndArray();
+
+                var linkMemo = resolveNames && detail ? new Dictionary<FormKey, ResolvedRef>() : null;
+                List<(string Formid, string Error)>? errors = null;
+                int rendered = 0; bool truncated = false;
+                w.WriteStartArray("rows");
+                for (int i = 0; i < q.Keys.Count; i++)
+                {
+                    w.Flush();
+                    if (ms.Length >= cap) { truncated = true; break; }
+                    var fk = q.Keys[i];
+                    string? matches = q.MatchedTargets is { } mt && i < mt.Count ? mt[i] : null;
+                    if (detail)
+                    {
+                        var o = svc.ResolveRead(fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false,
+                                                resolveNames: resolveNames, linkMemo: linkMemo, containerHint: Wire.CrossQueryContainerHint);
+                        if (o.Error is not null) { (errors ??= new()).Add((fk.ToString(), o.Error)); rendered++; continue; }
+                        var r = o.Record!;
+                        w.WriteStartArray();
+                        w.WriteStringValue(r.FormKey);
+                        WriteCell(w, r.EditorId);
+                        foreach (var f in r.Fields) WriteCell(w, DenseCell(f));
+                        if (hasMatches) WriteCell(w, matches);
+                        w.WriteEndArray();
+                    }
+                    else
+                    {
+                        var m = q.Prefilled is not null ? q.Prefilled[i] : svc.ResolveSummary(fk);
+                        if (m.Error is not null) { (errors ??= new()).Add((m.FormKey.ToString(), m.Error)); rendered++; continue; }
+                        w.WriteStartArray();
+                        w.WriteStringValue(m.FormKey.ToString());
+                        w.WriteStringValue(m.Type);
+                        WriteCell(w, m.EditorId);
+                        w.WriteStringValue(m.Winner);
+                        w.WriteNumberValue(m.OverrideDepth);
+                        if (hasMatches) WriteCell(w, matches);
+                        w.WriteEndArray();
+                    }
+                    rendered++;
+                }
+                w.WriteEndArray();
+                if (errors is not null)
+                {
+                    w.WriteStartArray("errors");
+                    foreach (var (efk, err) in errors)
+                    { w.WriteStartObject(); w.WriteString("formid", efk); w.WriteString("error", err); w.WriteEndObject(); }
+                    w.WriteEndArray();
+                }
+                w.WriteNumber("rendered", rendered);
+                w.WriteBoolean("truncated", truncated);
+            }
+            w.WriteEndObject();
+        }
+        return Finish(ms);
+    }
+
+    /// <summary>One dense cell: the round-trip token, else the leaf's parenthetical note ("(absent)", "(no field …)")
+    /// so a no-value field is VISIBLE in its cell, never a silent hole (Q3) — with the Display and resolve_names
+    /// annotations appended in the text render's exact vocabulary.</summary>
+    static string? DenseCell(HousecarlCore.FieldValue f)
+    {
+        var s = f.HasValue ? f.Token : f.Note;
+        if (f.Display is not null) s = $"{s}   ({f.Display})";
+        if (f.Link is not null) s = $"{s}   ({Wire.LinkText(f.Link)})";
+        return s;
+    }
+
+    static void WriteCell(Utf8JsonWriter w, string? v)
+    {
+        if (v is null) w.WriteNullValue(); else w.WriteStringValue(v);
     }
 
     static void WriteSummaryRow(Utf8JsonWriter w, RecordSummary m, string? matches)

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -330,7 +330,9 @@ static class JsonWire
 
     // ---- housecarl_cross_plugin_query format=dense (#223) -------------------------------------------
     /// <summary>The COLUMNAR render: a <c>columns</c> array once, then ONE positional row array per match —
-    /// <c>[formid, editorid, field values…]</c> under fields=, <c>[formid, type, editorid, winner, override_depth]</c>
+    /// <c>[formid, editorid, field values…]</c> under fields= (plus a <c>source</c> column under a plugins= scope,
+    /// naming the body each row's values were read from — the per-row P5 provenance text and json carry),
+    /// <c>[formid, type, editorid, winner, override_depth]</c>
     /// for summaries — killing the per-field {path,value} envelopes and repeated identity keys that made format=json
     /// the context-budget drain in bulk enumerations (#223: ~80 records per 40k chars at two fields). Reads the SAME
     /// path as the other renders (ResolveRead / Prefilled — D2), and cells use the SAME display vocabulary as the
@@ -362,6 +364,12 @@ static class JsonWire
                 {
                     w.WriteStringValue("formid"); w.WriteStringValue("editorid");
                     foreach (var f in fields!) w.WriteStringValue(f);         // cells align positionally: ReadFields returns exactly one value per requested path, in order
+                    // Under a plugins= scope each row's values are SOME scoped plugin's own body — with 2+ scoped
+                    // plugins the caller can't reconstruct WHICH from the row alone, and that's the P5 silent-wrong
+                    // trap (a defining esp's stale value read as live truth). Carry the provenance per row, exactly
+                    // like text ("fields (from X):") and json ("source") do — D2, renders must not drift. (PR #239
+                    // review, MEDIUM.)
+                    if (anyScoped) w.WriteStringValue("source");
                 }
                 else
                     foreach (var c in new[] { "formid", "type", "editorid", "winner", "override_depth" }) w.WriteStringValue(c);
@@ -388,6 +396,7 @@ static class JsonWire
                         w.WriteStringValue(r.FormKey);
                         WriteCell(w, r.EditorId);
                         foreach (var f in r.Fields) WriteCell(w, DenseCell(f));
+                        if (anyScoped) WriteCell(w, o.SourcePlugin);          // the body this row's values were read from (winner_fields=true → the winner)
                         if (hasMatches) WriteCell(w, matches);
                         w.WriteEndArray();
                     }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2273,11 +2273,13 @@ public sealed class LoadOrderService : IDisposable
     /// un-merge). <paramref name="definedIn"/> keeps only matches whose FormKey ORIGINATES in a scoped plugin
     /// (definitions, not overrides) — requires plugins=, refused loud otherwise. <paramref name="groupBy"/>
     /// ("winner"|"type"|"defined_in") replaces per-match lines with a count table over ALL matches (not capped by
-    /// limit=). Returns pre-built match summaries (capped at <paramref name="limit"/>, with the true total), a group
-    /// table, or a recoverable Q3 error. Holds nothing.</summary>
+    /// limit=). <paramref name="offset"/> skips the first N post-filter matches before collecting (#223 pagination —
+    /// scan order is deterministic for an unchanged load order, so offset=/limit= windows tile without gaps or
+    /// overlap; the true total still counts ALL matches). Returns pre-built match summaries (capped at
+    /// <paramref name="limit"/>, with the true total), a group table, or a recoverable Q3 error. Holds nothing.</summary>
     public CrossQueryOutcome CrossQuery(string? type, IReadOnlyList<FormKey>? references, string? editoridContains,
                                         bool conflictsOnly, IReadOnlyList<string>? plugins, IReadOnlyList<string>? where, int limit,
-                                        bool definedIn = false, string? groupBy = null)
+                                        bool definedIn = false, string? groupBy = null, int offset = 0)
     {
         var resolver = Resolver;
         var view = resolver.Capture();          // ONE build for the SCAN and every per-match fill it makes (HCBR-2026-06-11-02)
@@ -2305,6 +2307,14 @@ public sealed class LoadOrderService : IDisposable
                 try { scopedModKeys.Add(ModKey.FromFileName(p.Trim())); }
                 catch (Exception ex) { return CrossQueryOutcome.Fail($"defined_in: '{p}' is not a valid plugin filename: {ex.Message}"); }
         }
+
+        // offset= pages the match window (#223). Validated up front (Q3): negative is meaningless, and under
+        // group_by= there is no match window to page (the aggregation counts ALL matches, never limit-capped) —
+        // silently ignoring it would misrepresent what the caller asked for.
+        if (offset < 0)
+            return CrossQueryOutcome.Fail($"offset={offset} — offset must be >= 0 (it skips that many matches before returning rows).");
+        if (offset > 0 && groupBy is not null)
+            return CrossQueryOutcome.Fail("group_by= aggregates ALL matches into a count table (never capped by limit=), so offset= has nothing to page — drop offset=, or drop group_by= for per-match rows.");
 
         // group_by= aggregates matches into a count table. Validated up front (an unknown key refuses BEFORE any scan,
         // Q3). group_by=type needs the matched body to name the type, so it requires a body-bearing scope (type= or
@@ -2401,7 +2411,7 @@ public sealed class LoadOrderService : IDisposable
                                    : view.ResolveWinner(fk)?.WinnerPlugin ?? "?";  // "winner"
                             groups[gk] = groups.GetValueOrDefault(gk) + 1;
                         }
-                        else if (keys.Count < limit)                              // in-hand body → fill the summary for free
+                        else if (total > offset && keys.Count < limit)            // in-hand body → fill the summary for free (offset= skips the first N matches — total already counts this one)
                         {
                             keys.Add(fk);
                             sources.Add(source);                                  // the body we filtered IS the body we'll display (null ⇒ winner)
@@ -2442,7 +2452,7 @@ public sealed class LoadOrderService : IDisposable
                     var gk = groupBy == "defined_in" ? fk.ModKey.FileName.ToString() : view.ResolveWinner(fk)?.WinnerPlugin ?? "?";
                     groups[gk] = groups.GetValueOrDefault(gk) + 1;
                 }
-                else if (keys.Count < limit) { keys.Add(fk); sources.Add(null); }   // no scoped plugin → display the winner
+                else if (total > offset && keys.Count < limit) { keys.Add(fk); sources.Add(null); }   // no scoped plugin → display the winner; offset= skips the first N
             }
         }
         // Unscannable accounting (Q3): name the count, the first few offenders with Mutagen's reason, and what
@@ -2457,9 +2467,11 @@ public sealed class LoadOrderService : IDisposable
         // group_by= aggregation isn't limit-capped (cheap), so Capped is a match-line concern only.
         var groupRows = groups?.Select(kv => new GroupCount(kv.Key, kv.Value))
                               .OrderByDescending(g => g.Count).ThenBy(g => g.Key, StringComparer.Ordinal).ToList();
-        return new CrossQueryOutcome(keys, prefilled, total, groups is null && total > keys.Count, null,
+        // Capped = matches exist BEYOND the returned window (total > offset + rows) — the matches offset= skipped
+        // were asked to be skipped, so they don't make a full window read as capped.
+        return new CrossQueryOutcome(keys, prefilled, total, groups is null && total > offset + keys.Count, null,
                                      predicate?.AccountingNote(), sources, scanNote,
-                                     matched, groupRows, groupBy, definedIn ? string.Join(", ", plugins!) : null);
+                                     matched, groupRows, groupBy, definedIn ? string.Join(", ", plugins!) : null, offset);
     }
 
     // ---- effect-chain resolver (housecarl_effect_chain — gap 2026-06-08) --------------------------------
@@ -5245,7 +5257,7 @@ public sealed record CrossQueryOutcome(
     IReadOnlyList<FormKey> Keys, IReadOnlyList<RecordSummary>? Prefilled, int Total, bool Capped, string? Error,
     string? PredicateNote = null, IReadOnlyList<string?>? Sources = null, string? ScanNote = null,
     IReadOnlyList<string?>? MatchedTargets = null, IReadOnlyList<GroupCount>? Groups = null,
-    string? GroupBy = null, string? ScopeLabel = null)
+    string? GroupBy = null, string? ScopeLabel = null, int Offset = 0)
 {
     public static CrossQueryOutcome Fail(string error) => new(Array.Empty<FormKey>(), null, 0, false, error);
 }

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -144,7 +144,9 @@ public static class ReadTools
          "enough). Pass fields= " +
          "or conflict_tree=true to expand each match from a summary line to full detail; or group_by= " +
          "(winner|type|defined_in) for a count table over ALL matches instead of per-match lines. Results cap at " +
-         "limit= matches and max_chars; both overruns are reported explicitly (never silent). Does NOT modify anything.")]
+         "limit= matches and max_chars; both overruns are reported explicitly (never silent), and offset= pages a big " +
+         "enumeration in exact windows (offset=0/500/1000… with format='dense' for the compact columnar rows). " +
+         "Does NOT modify anything.")]
     public static string CrossPluginQuery(
         LoadOrderService svc,
         [Description("Optional. A record signature ('WEAP', 'NPC_') or catalog name ('Weapon', 'Npc'). Cheap — uses typed group enumeration.")]
@@ -171,17 +173,19 @@ public static class ReadTools
             bool resolve_names = false,
         [Description("When true (with fields= under a plugins= scope), expand each match's fields from the load-order WINNER's body instead of the scoped plugin's OWN version. WITHOUT this, plugins=-scoped fields are that plugin's values (e.g. a defining esp's AR 38), NOT the live winner (AR 200) — a note names the source either way. No effect under type= scope (already the winner).")]
             bool winner_fields = false,
-        [Description("Optional. 'text' (default) or 'json' — a machine-readable document (group_by count table, detail record objects with fields, or summary rows), with total/capped/notes/truncated accounting in-band. conflict_tree is a text-only diff view.")]
+        [Description("Optional. 'text' (default), 'json' (a machine-readable document — group_by count table, detail record objects with fields, or summary rows), or 'dense' (#223 — COLUMNAR json: a columns array once, then ONE positional row array per match [formid, editorid, field values…], no per-field envelopes or repeated keys — the compact form for bulk enumeration; ~same data at a fraction of the characters; under group_by it renders the same count table as 'json'). All formats carry total/capped/notes/truncated accounting in-band. conflict_tree is a text-only diff view.")]
             string? format = null,
-        [Description("Optional. Max matches to return (default 500). The TRUE total is always reported; over the cap it says 'showing first N'.")]
+        [Description("Optional. Max matches to return (default 500). The TRUE total is always reported; over the cap it says 'showing first N'. Page with offset=.")]
             int limit = 500,
+        [Description("Optional. Skip the first N post-filter matches before returning rows (#223 pagination) — combine with limit= to page a big enumeration in windows (offset=0/500/1000…). Scan order is deterministic while the load order is unchanged, so windows tile exactly. The true total always counts ALL matches. Not valid with group_by= (a count table has no window).")]
+            int offset = 0,
         [Description("Optional. Max characters before the response stops with an explicit notice. 0 = the server default (~80k).")]
             int max_chars = 0) => Guard.Tool("housecarl_cross_plugin_query", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-        bool json = Wire.WantsJson(format, out var ferr);
+        var fmt = Wire.CrossQueryFormat(format, out var ferr);
         if (ferr is not null) return ferr;
-        if (json && conflict_tree) return "error: conflict_tree=true is a text-only diff view and is not carried in json mode — use format=text for the conflict tree, or drop conflict_tree for the json field data.";
+        if (fmt is not Wire.QueryFormat.Text && conflict_tree) return $"error: conflict_tree=true is a text-only diff view and is not carried in {(fmt is Wire.QueryFormat.Json ? "json" : "dense")} mode — use format=text for the conflict tree, or drop conflict_tree for the field data.";
         if (group_by is not null && ((fields is { Length: > 0 }) || conflict_tree))
             return "error: group_by aggregates matches into a count table and cannot be combined with fields= or conflict_tree=true (those expand each match to full detail — pick one). Drop fields=/conflict_tree, or drop group_by.";
         IReadOnlyList<FormKey>? refFks = null;
@@ -196,9 +200,15 @@ public static class ReadTools
             }
             if (list.Count > 0) refFks = list.Distinct().ToList();   // preserve input order, drop dupes
         }
-        var outcome = svc.CrossQuery(type, refFks, editorid_contains, conflicts_only, plugins, where, limit <= 0 ? 500 : limit, defined_in, group_by);
-        return json ? JsonWire.RenderCrossQuery(svc, outcome, fields, max_chars, resolve_names, winner_fields)
-                    : Wire.RenderCrossQuery(svc, outcome, fields, conflict_tree, max_chars, resolve_names, winner_fields);
+        var outcome = svc.CrossQuery(type, refFks, editorid_contains, conflicts_only, plugins, where, limit <= 0 ? 500 : limit, defined_in, group_by, offset);
+        // dense + group_by: the count table is already columnar — render it exactly as json (documented on format=),
+        // so dense is never a refusal there and the two renders can't drift.
+        return fmt switch
+        {
+            Wire.QueryFormat.Dense when group_by is null => JsonWire.RenderCrossQueryDense(svc, outcome, fields, max_chars, resolve_names, winner_fields),
+            Wire.QueryFormat.Dense or Wire.QueryFormat.Json => JsonWire.RenderCrossQuery(svc, outcome, fields, max_chars, resolve_names, winner_fields),
+            _ => Wire.RenderCrossQuery(svc, outcome, fields, conflict_tree, max_chars, resolve_names, winner_fields),
+        };
     });
 
     [McpServerTool(Name = "housecarl_resolve", ReadOnly = true, Title = "Resolve FormIDs to their identity"),
@@ -396,6 +406,23 @@ static class Wire
         return false;
     }
 
+    /// <summary>The cross_plugin_query format vocabulary — the one tool with a third format (<c>dense</c>, the #223
+    /// columnar render). Every other tool stays on the two-value <see cref="WantsJson"/>.</summary>
+    internal enum QueryFormat { Text, Json, Dense }
+
+    /// <summary>Parse cross_plugin_query's <c>format=</c>: text (default) / json / dense; anything else is a named
+    /// refusal (Q3) listing all three.</summary>
+    internal static QueryFormat CrossQueryFormat(string? format, out string? error)
+    {
+        error = null;
+        var f = format?.Trim();
+        if (string.IsNullOrEmpty(f) || f.Equals("text", StringComparison.OrdinalIgnoreCase)) return QueryFormat.Text;
+        if (f.Equals("json", StringComparison.OrdinalIgnoreCase)) return QueryFormat.Json;
+        if (f.Equals("dense", StringComparison.OrdinalIgnoreCase)) return QueryFormat.Dense;
+        error = $"error: format='{format}' is not recognized — use 'text' (the default), 'json', or 'dense'.";
+        return QueryFormat.Text;
+    }
+
     // ---- housecarl_diff_record (P8c) ----------------------------------------------------------------
     /// <summary>Render a pairwise record diff (housecarl_diff_record — P8c): a header naming both poles (plugin + where
     /// found + record identity), then one line per delta (plugin_a's value, reference = plugin_b), budget-bounded with an
@@ -530,7 +557,17 @@ static class Wire
         var sb = new StringBuilder();
         sb.Append("cross_plugin_query: ").Append(q.Total).Append(q.Total == 1 ? " match" : " matches");
         if (q.ScopeLabel is not null) sb.Append(" DEFINED IN ").Append(q.ScopeLabel);   // P1: explicit scope — NOT the 'touches' default
-        if (q.Capped) sb.Append(" (showing first ").Append(q.Keys.Count).Append("; raise limit= or narrow to see more)");
+        if (q.Offset > 0)                                                              // #223 pagination — name the window, and the next offset while paging
+        {
+            if (q.Keys.Count == 0) sb.Append(" (offset=").Append(q.Offset).Append(" skipped past the last match — nothing to show; lower offset=)");
+            else
+            {
+                sb.Append(" (showing matches ").Append(q.Offset + 1).Append('–').Append(q.Offset + q.Keys.Count);
+                if (q.Capped) sb.Append("; continue with offset=").Append(q.Offset + q.Keys.Count);
+                sb.Append(')');
+            }
+        }
+        else if (q.Capped) sb.Append(" (showing first ").Append(q.Keys.Count).Append("; raise limit=, page with offset=, or narrow to see more)");
         sb.Append('\n');
         if (q.PredicateNote is not null) sb.Append(q.PredicateNote).Append('\n');   // where= Q3 accounting (wrong-path/no-value surface)
         if (q.ScanNote is not null) sb.Append(q.ScanNote).Append('\n');             // unscannable-record Q3 accounting (Mutagen-unparseable content)
@@ -843,8 +880,9 @@ static class Wire
 
     /// <summary>The resolve_names parenthetical (P7): a FormLink token's target identity as "→ editorid "Name"", or
     /// "unresolved: not in the active order" for a dangling target (named, never dropped — Q3). DISPLAY-ONLY: this
-    /// is appended AFTER the round-trip token, never in place of it.</summary>
-    static string LinkText(ResolvedRef r) =>
+    /// is appended AFTER the round-trip token, never in place of it. Internal: the dense render's cells reuse the
+    /// SAME display vocabulary (D2 — renders must not drift).</summary>
+    internal static string LinkText(ResolvedRef r) =>
         !r.Resolved ? "unresolved: target not in the active order"
         : string.IsNullOrEmpty(r.Name) ? $"→ {r.EditorId ?? "<no editorid>"}"
         : $"→ {r.EditorId ?? "<no editorid>"} \"{r.Name}\"";

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -173,7 +173,7 @@ public static class ReadTools
             bool resolve_names = false,
         [Description("When true (with fields= under a plugins= scope), expand each match's fields from the load-order WINNER's body instead of the scoped plugin's OWN version. WITHOUT this, plugins=-scoped fields are that plugin's values (e.g. a defining esp's AR 38), NOT the live winner (AR 200) — a note names the source either way. No effect under type= scope (already the winner).")]
             bool winner_fields = false,
-        [Description("Optional. 'text' (default), 'json' (a machine-readable document — group_by count table, detail record objects with fields, or summary rows), or 'dense' (#223 — COLUMNAR json: a columns array once, then ONE positional row array per match [formid, editorid, field values…], no per-field envelopes or repeated keys — the compact form for bulk enumeration; ~same data at a fraction of the characters; under group_by it renders the same count table as 'json'). All formats carry total/capped/notes/truncated accounting in-band. conflict_tree is a text-only diff view.")]
+        [Description("Optional. 'text' (default), 'json' (a machine-readable document — group_by count table, detail record objects with fields, or summary rows), or 'dense' (#223 — COLUMNAR json: a columns array once, then ONE positional row array per match [formid, editorid, field values…] — plus a source column under a plugins= scope naming the body each row read — no per-field envelopes or repeated keys — the compact form for bulk enumeration; ~same data at a fraction of the characters; under group_by it renders the same count table as 'json'). All formats carry total/capped/notes/truncated accounting in-band. conflict_tree is a text-only diff view.")]
             string? format = null,
         [Description("Optional. Max matches to return (default 500). The TRUE total is always reported; over the cap it says 'showing first N'. Page with offset=.")]
             int limit = 500,
@@ -559,7 +559,8 @@ static class Wire
         if (q.ScopeLabel is not null) sb.Append(" DEFINED IN ").Append(q.ScopeLabel);   // P1: explicit scope — NOT the 'touches' default
         if (q.Offset > 0)                                                              // #223 pagination — name the window, and the next offset while paging
         {
-            if (q.Keys.Count == 0) sb.Append(" (offset=").Append(q.Offset).Append(" skipped past the last match — nothing to show; lower offset=)");
+            if (q.Total == 0) sb.Append(" (offset=").Append(q.Offset).Append(" had nothing to skip — NO records match at any offset; check the filter, not the paging)");
+            else if (q.Keys.Count == 0) sb.Append(" (offset=").Append(q.Offset).Append(" skipped past the last match — nothing to show; lower offset=)");
             else
             {
                 sb.Append(" (showing matches ").Append(q.Offset + 1).Append('–').Append(q.Offset + q.Keys.Count);


### PR DESCRIPTION
Fixes #223.

## What

The bulk-enumeration economy pass for `cross_plugin_query` — both asks from the issue:

**(a) `format="dense"`** — a third format: one columnar JSON document. `columns` once, then one positional row array per match:

```json
{"total":373,"capped":false,
 "columns":["formid","editorid","BaseCost","MagicSkill"],
 "rows":[["123456:Apoc.esp","AbcSpell","100","Destruction"], …],
 "rendered":373,"truncated":false}
```

- Summary mode (no `fields=`): `[formid, type, editorid, winner, override_depth]`. Multi-target `references=` appends a `matches` column.
- Same read path as the existing renders (`ResolveRead`/`Prefilled` — decision D2, one read path), same in-band Q3 accounting (`total`/`capped`/`offset`/`notes`/`truncated`).
- Cells use the text render's display vocabulary: the round-trip token, else the parenthetical note — an absent field shows `"(absent)"` in its cell, never a silent hole. `resolve_names`/`Display` annotations append in the text render's exact format (`LinkText` made internal and shared, so the vocabularies can't drift).
- A row whose read fails lands in a separate `errors` array — never a silently missing row.
- `group_by` + dense renders the (already columnar) count table exactly as `format=json` — documented on the param, not a refusal. `conflict_tree` + dense is refused like json.
- **Probe-measured: 2.6× smaller than `format=json` for the same one-field query** (414 vs 1074 chars); the gap widens with more fields since only rows grow.

**(b) `offset=`** — skip the first N post-filter matches before collecting rows:

- `offset=0/500/1000…` + `limit=` pages an enumeration in windows that **tile exactly** — the guard proves no-gap/no-overlap/same-order against the unwindowed enumeration (scan order is deterministic while the load order is unchanged).
- The true total always counts ALL matches. `capped` now means "matches exist beyond the window" (`total > offset + rows`) — skipped-before-offset never reads as capped, and an offset past the last match is an honest empty window, not an error.
- The text header names the window and the next offset (`showing matches 501–1000; continue with offset=1000`); json/dense carry `offset` in-band.
- Refused loud (Q3): negative offset; `offset=` under `group_by=` (a count table has no window to page — silently ignoring it would misrepresent the call).

## Coverage

`bulk-query-primitives-guard` grows 20 asserts: window tiling, past-the-end honesty, both offset refusals, the text pagination header, dense summary + detail shapes cross-checked against the fixture's known winner values (the overridden W1 reads the winner's 15), dense-vs-json size, dense × offset/group_by/conflict_tree composition, and the three-value format vocabulary. `ci-all`: **98/98 PASS** from the worktree root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)