### PR TITLE
feat(write): dry_run= on set_field / bulk_apply / forward_record (#225)

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,17 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**Dry-run mode for the write tools (#225).** `housecarl_set_field`, `housecarl_bulk_apply`, and
+`housecarl_forward_record` gain `dry_run=true`: the **full real write pipeline** runs — winner resolve, schema
+pre-flight, every op applied to the in-memory would-be plugin, a reference-resolution check that pre-empts the
+serialize's missing-master failure — and stops at the point of no return, so **nothing touches disk** (no patch
+file, no mod folder, no in-place rewrite). The report says what *would* change (per-op would-be values, the
+expected master set, `full_readback=true` for the full in-memory record preview), and a bad batch gets **exactly
+the all-or-nothing refusal the real call would give** — so a wrong field path in a 700-op batch is caught before
+the first write, not diagnosed after the last. Works on every lane: fresh patch, `into=`, and `in_place` (an
+in-place dry run needs no `acknowledge` and never records consent — it's read-only; the pending consent is noted
+so the real write's one-time prompt isn't a surprise).
+
 **BSA reads move in-process — `housecarl_bsa_list` / `housecarl_bsa_extract` (#217).** Listing and extracting a
 `.bsa` no longer shell out to BSArch; they read through Mutagen's own in-process BSA reader. This fixes an archive
 class BSArch's *unpacker* rejected: an archive written by a non-BSArch tool could list and load in-game yet extract

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1657,7 +1657,7 @@ public static class WriteEngine
     /// <see cref="WritePatch(SkyrimMod, IReadOnlyList{ISkyrimModGetter},string)"/> via WithExtraIncludedMasters so even a
     /// self-contained created record yields a valid, conventionally-mastered plugin. Both ship with SE → always present in
     /// the order, so this never fails; the load order sorts them (Skyrim.esm before Update.esm). Proven by master-probe.</summary>
-    static readonly ModKey[] BaselineMasters = { new("Skyrim", ModType.Master), new("Update", ModType.Master) };
+    internal static readonly ModKey[] BaselineMasters = { new("Skyrim", ModType.Master), new("Update", ModType.Master) };   // internal: the dry-run master preview mirrors the force-include (#225)
 
     // ======================================================================
     //  PATH NAVIGATION + VERBS  (plan §4.2 / §3 P-VERBS; the highest-risk delta)

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -91,6 +91,14 @@ public static class WritePatchBuilder
         /// marker couldn't be written). Null when there's nothing to add.</summary>
         public string? Note { get; init; }
 
+        /// <summary>True ⇒ this Success came from a DRY RUN (#225): the REAL pipeline ran — winner resolve, pre-flight,
+        /// every verb applied to the in-memory mod, the reference-resolution check — and STOPPED at the point of no
+        /// return (the Phase-4 serialize), so NOTHING was written (no file, no folder). <see cref="Ops"/> carries what
+        /// WOULD change; <see cref="Masters"/> is the EXPECTED master set (link-derived preview — the real write derives
+        /// its own lean header); <see cref="Bytes"/> is 0; <see cref="ReadBack"/> (if requested) is read from the
+        /// in-memory mod, not a file. Drives the distinct "DRY RUN — nothing written" confirmation.</summary>
+        public bool DryRun { get; init; }
+
         public static PatchOutcome Fail(string error) =>
             new(false, error, "", false, Array.Empty<string>(), Array.Empty<OpResult>(), 0);
 
@@ -269,11 +277,14 @@ public static class WritePatchBuilder
     /// patch at <paramref name="outPath"/> mutably and adds to it (the <c>into=</c> path). All-or-nothing: any
     /// resolve/pre-flight rejection refuses the whole call with no file written (Q3). <paramref name="fullReadback"/>
     /// additionally reads every touched record back IN FULL off the re-opened written file (the pre-enable verify
-    /// loop — see <see cref="FullReadback"/>).</summary>
+    /// loop — see <see cref="FullReadback"/>). <paramref name="dryRun"/> (#225) runs this SAME pipeline — winner
+    /// resolve, pre-flight, every verb applied to the in-memory mod — and stops at the point of no return (the
+    /// Phase-4 serialize), returning what WOULD change with NOTHING written; it is the real path halted, never a
+    /// parallel validate-lite that could drift from the write it predicts.</summary>
     public static PatchOutcome Apply(
         LoadOrderResolver resolver, CorpusRulebook rulebook,
         IReadOnlyList<PatchEdit> edits, string outPath, bool extend, bool fullReadback = false,
-        IReadOnlyDictionary<PatchEdit, IMajorRecordGetter>? copyFromSources = null)
+        IReadOnlyDictionary<PatchEdit, IMajorRecordGetter>? copyFromSources = null, bool dryRun = false)
     {
         if (edits.Count == 0) return PatchOutcome.Fail("no edits supplied.");
 
@@ -451,6 +462,20 @@ public static class WritePatchBuilder
         if (SyncEditedTopicMarkers(patchMod, edits, ops) is { } syncErr)
             return PatchOutcome.Fail($"refused — {syncErr} (no patch written).");
 
+        // --- #225 DRY RUN: stop AT the point of no return. Everything above ran for real — the same resolve,
+        //     pre-flight, and in-memory apply the write uses — so the report below can't drift from what a real call
+        //     would do. The one Phase-4 hazard the halt skips (a reference to a plugin not in the serialize's
+        //     resolution context → MissingModException) is re-checked here by the same membership test, so a dry run
+        //     that says "would apply" doesn't hide a write that would fail at serialize (Q3). ---
+        if (dryRun)
+        {
+            if (DryRunMastersPreview(patchMod, resolver, patchLane: true, out var wouldMasters) is { } dryErr)
+                return PatchOutcome.Fail(dryErr);
+            IReadOnlyList<FullReadback>? dryBack = fullReadback
+                ? ReadBackInFull(patchMod, resolved.Select(r => r.edit.Target), inMemory: true) : null;
+            return new PatchOutcome(true, null, outPath, extend, wouldMasters, ops, 0) { DryRun = true, ReadBack = dryBack };
+        }
+
         // --- Phase 4: serialize ONCE with the FULL known-master set (multi-master). Mutagen keeps the header lean
         //     (only-referenced); a referenced master genuinely absent from the order still fails loud (Q3). ---
         // Two-part active-patch self-lock guard (Heisen 2026-06-08 + PR #24 review): no mapped handle on the file we're
@@ -547,7 +572,8 @@ public static class WritePatchBuilder
     /// </summary>
     public static PatchOutcome ApplyInPlace(
         LoadOrderResolver resolver, CorpusRulebook rulebook,
-        IReadOnlyList<PatchEdit> edits, string targetPath, string targetName, bool fullReadback = true)
+        IReadOnlyList<PatchEdit> edits, string targetPath, string targetName, bool fullReadback = true,
+        bool dryRun = false)
     {
         if (edits.Count == 0) return PatchOutcome.Fail("no edits supplied.");
 
@@ -648,6 +674,25 @@ public static class WritePatchBuilder
         if (SyncEditedTopicMarkers(targetMod, edits, ops) is { } syncErr)
             return PatchOutcome.Fail($"refused — {syncErr} ('{fileName}' is UNTOUCHED).");
 
+        // --- #225 DRY RUN: stop AT the point of no return (see Apply's twin block). patchLane:false — in-place
+        //     serializes via WriteInPlace (no Skyrim.esm/Update.esm baseline force-include), so the master preview
+        //     must not add one. The would-grow re-sort note is phrased predictively (nothing was added yet). ---
+        if (dryRun)
+        {
+            if (DryRunMastersPreview(targetMod, resolver, patchLane: false, out var wouldMasters) is { } dryErr)
+                return PatchOutcome.Fail(dryErr);
+            var wouldGrow = wouldMasters.Where(m => !mastersBefore.Contains(m)).ToList();
+            IReadOnlyList<FullReadback>? dryBack = fullReadback
+                ? ReadBackInFull(targetMod, resolved.Select(r => r.edit.Target), inMemory: true) : null;
+            return new PatchOutcome(true, null, targetPath, false, wouldMasters, ops, 0)
+            {
+                DryRun = true, InPlace = true, ReadBack = dryBack,
+                Note = wouldGrow.Count == 0 ? null :
+                    $"the real write would ADD {string.Join(", ", wouldGrow)} as master(s) of '{fileName}' — a plugin " +
+                    "loads only if its masters load BEFORE it, so re-sort your load order (LOOT / MO2) after the real write.",
+            };
+        }
+
         // --- Phase 4: re-serialize the WHOLE target back over itself (model C — the probe's incantation via WriteInPlace,
         //     NOT WritePatch). Release the target overlay first (the winner-IS-the-target common case made common — the
         //     two-part self-lock guard, here on a FOREIGN target: ReleaseOverlay disposes every session overlay on the
@@ -703,6 +748,56 @@ public static class WritePatchBuilder
         if (grown.Count == 0) return null;
         return $"{string.Join(", ", grown)} {(grown.Count == 1 ? "was" : "were")} added as a master of '{fileName}' — " +
                "a plugin loads only if its masters load BEFORE it, so re-sort your load order (LOOT / MO2) before playing.";
+    }
+
+    /// <summary>#225 dry run — the pre-serialize reference-resolution check + expected-master preview, run INSTEAD of
+    /// Phase 4. Walks every record the in-memory mod holds and collects each referenced ModKey (a contained record's
+    /// ORIGIN plugin + every FormLink's plugin, minus the mod itself — the same link surface Mutagen lean-derives the
+    /// real header from). A referenced plugin NOT in the active order is the EXACT condition the real serialize fails
+    /// on (its WithLoadOrder resolution context is the active order minus the output — MissingModException), so it is
+    /// a Q3 refusal here too: a dry run must never say "would apply" about a write that would fail. On success,
+    /// <paramref name="masters"/> is the expected master set in load order — link-derived, PLUS the Skyrim.esm/Update.esm
+    /// baseline the patch lane's <c>WritePatch</c> force-includes (<paramref name="patchLane"/>; the in-place lane's
+    /// <c>WriteInPlace</c> deliberately adds none) — a labeled PREVIEW: the real write derives its own lean header.</summary>
+    static string? DryRunMastersPreview(SkyrimMod mod, LoadOrderResolver resolver, bool patchLane, out IReadOnlyList<string> masters)
+    {
+        masters = Array.Empty<string>();
+        var priority = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        for (int i = 0; i < resolver.PluginNames.Count; i++) priority[resolver.PluginNames[i]] = i;
+
+        var referenced = new Dictionary<ModKey, FormKey>();   // referenced plugin -> first record referencing it (for the refusal)
+        foreach (var rec in mod.EnumerateMajorRecords())
+        {
+            if (rec.FormKey.ModKey != mod.ModKey) referenced.TryAdd(rec.FormKey.ModKey, rec.FormKey);
+            try
+            {
+                foreach (var link in rec.EnumerateFormLinks())
+                    if (!link.FormKey.IsNull && link.FormKey.ModKey != mod.ModKey)
+                        referenced.TryAdd(link.FormKey.ModKey, rec.FormKey);
+            }
+            catch (Exception ex)
+            {
+                // The link walk parses subrecord content lazily — a throw means the would-be content itself is
+                // malformed, which the real serialize would also hit. Named, never a silent partial preview (Q3).
+                return $"dry run: enumerating {rec.FormKey}'s references threw ({ex.GetType().Name}: {ex.Message}) — " +
+                       "the would-be content could not be fully checked; the real write would hit the same data. Nothing was written.";
+            }
+        }
+
+        var missing = referenced.Where(kv => !priority.ContainsKey(kv.Key.FileName.String))
+                                .Select(kv => $"{kv.Key.FileName} (referenced by {kv.Value})").ToList();
+        if (missing.Count > 0)
+            return $"dry run caught what the real write would fail on: the would-be content references " +
+                   $"{missing.Count} plugin(s) NOT active in the load order — a reference into an inactive plugin " +
+                   $"can't resolve in game, and the real serialize refuses it (MissingModException): " +
+                   $"{string.Join("; ", missing)}. Enable the plugin(s) in MO2 (or reference active ones). Nothing was written.";
+
+        var set = new HashSet<string>(referenced.Keys.Select(mk => mk.FileName.String), StringComparer.OrdinalIgnoreCase);
+        if (patchLane)
+            foreach (var bm in WriteEngine.BaselineMasters)
+                if (priority.ContainsKey(bm.FileName.String)) set.Add(bm.FileName.String);
+        masters = set.OrderBy(n => priority[n]).ToList();
+        return null;
     }
 
     /// <summary>Resolve the target's OWN declared masters to on-disk overlays in declared order — the load order
@@ -1071,7 +1166,7 @@ public static class WritePatchBuilder
     /// </summary>
     public static ForwardOutcome ForwardRecordsInPlace(
         LoadOrderResolver resolver, IReadOnlyList<ForwardSpec> specs, string targetPath, string targetName,
-        bool fullReadback = true)
+        bool fullReadback = true, bool dryRun = false)
     {
         if (specs.Count == 0) return ForwardOutcome.Fail("no records to forward supplied.");
 
@@ -1140,6 +1235,24 @@ public static class WritePatchBuilder
                     $"engine error forwarding {spec.Target} from '{spec.FromPlugin}': the source resolved but the " +
                     $"override-copy threw — a real inconsistency, surfaced not swallowed (Q3): {ex.GetType().Name}: {ex.Message}. Your original is UNTOUCHED.");
             }
+        }
+
+        // --- #225 DRY RUN: stop AT the point of no return (see Apply's twin block). patchLane:false — WriteInPlace
+        //     adds no baseline masters. The would-grow re-sort note is phrased predictively. ---
+        if (dryRun)
+        {
+            if (DryRunMastersPreview(targetMod, resolver, patchLane: false, out var wouldMasters) is { } dryErr)
+                return ForwardOutcome.Fail(dryErr);
+            var wouldGrow = wouldMasters.Where(m => !mastersBefore.Contains(m)).ToList();
+            IReadOnlyList<FullReadback>? dryBack = fullReadback
+                ? ReadBackInFull(targetMod, resolved.Select(r => r.spec.Target), inMemory: true) : null;
+            return new ForwardOutcome(true, null, targetPath, false, forwarded, wouldMasters, 0)
+            {
+                DryRun = true, InPlace = true, ReadBack = dryBack,
+                Note = wouldGrow.Count == 0 ? null :
+                    $"the real write would ADD {string.Join(", ", wouldGrow)} as master(s) of '{fileName}' — a plugin " +
+                    "loads only if its masters load BEFORE it, so re-sort your load order (LOOT / MO2) after the real write.",
+            };
         }
 
         // --- Phase 4: model-C re-serialize over the original (WriteInPlace, whole known-master set — the copied
@@ -1221,6 +1334,12 @@ public static class WritePatchBuilder
         /// <summary>An optional Q3 honesty note appended to a SUCCESSFUL outcome — a side effect that didn't land cleanly
         /// even though the write did. Null when there's nothing to add. Mirrors <see cref="PatchOutcome.Note"/>.</summary>
         public string? Note { get; init; }
+
+        /// <summary>True ⇒ this Success came from a DRY RUN (#225): the real forward pipeline ran (source resolve,
+        /// replace-or-copy into the in-memory mod, the reference-resolution check) and STOPPED before the serialize —
+        /// NOTHING was written. <see cref="Forwarded"/> is what WOULD be copied; <see cref="Masters"/> is the expected
+        /// (link-derived, preview) master set; <see cref="Bytes"/> is 0. Mirrors <see cref="PatchOutcome.DryRun"/>.</summary>
+        public bool DryRun { get; init; }
 
         public static ForwardOutcome Fail(string error) =>
             new(false, error, "", false, Array.Empty<ForwardedRecord>(), Array.Empty<string>(), 0);
@@ -1337,7 +1456,8 @@ public static class WritePatchBuilder
     /// verify loop — see <see cref="FullReadback"/>).</para>
     /// </summary>
     public static ForwardOutcome ForwardRecords(
-        LoadOrderResolver resolver, IReadOnlyList<ForwardSpec> specs, string outPath, bool extend, bool fullReadback = false)
+        LoadOrderResolver resolver, IReadOnlyList<ForwardSpec> specs, string outPath, bool extend, bool fullReadback = false,
+        bool dryRun = false)
     {
         if (specs.Count == 0) return ForwardOutcome.Fail("no records to forward supplied.");
 
@@ -1418,6 +1538,17 @@ public static class WritePatchBuilder
                     $"engine error forwarding {spec.Target} from '{spec.FromPlugin}': the source resolved but the " +
                     $"override-copy threw — a real inconsistency, surfaced not swallowed (Q3): {ex.GetType().Name}: {ex.Message}");
             }
+        }
+
+        // --- #225 DRY RUN: stop AT the point of no return (see Apply's twin block) — the copies above landed in the
+        //     in-memory mod only; report what WOULD be forwarded + the expected masters, write nothing. ---
+        if (dryRun)
+        {
+            if (DryRunMastersPreview(patchMod, resolver, patchLane: true, out var wouldMasters) is { } dryErr)
+                return ForwardOutcome.Fail(dryErr);
+            IReadOnlyList<FullReadback>? dryBack = fullReadback
+                ? ReadBackInFull(patchMod, resolved.Select(r => r.spec.Target), inMemory: true) : null;
+            return new ForwardOutcome(true, null, outPath, extend, forwarded, wouldMasters, 0) { DryRun = true, ReadBack = dryBack };
         }
 
         // --- Phase 4: serialize ONCE with the FULL known-master set (identical to Apply Phase 4 — release any overlay
@@ -2196,7 +2327,7 @@ public static class WritePatchBuilder
     /// runs (serialize done, masters confirmed), so a read-back failure must not convert the outcome to Fail —
     /// that would read as "my write was lost" and invite re-issuing the ops (the duplicate-Add trap this read-back
     /// exists to close). Every degraded path is named per-record on <see cref="FullReadback.Error"/> (Q3).</summary>
-    static IReadOnlyList<FullReadback> ReadBackInFull(ISkyrimModGetter back, IEnumerable<FormKey> targets)
+    static IReadOnlyList<FullReadback> ReadBackInFull(ISkyrimModGetter back, IEnumerable<FormKey> targets, bool inMemory = false)
     {
         var order = new List<FormKey>();                                   // caller order, de-duped (several ops may hit one record)
         var want = new HashSet<FormKey>();
@@ -2217,8 +2348,12 @@ public static class WritePatchBuilder
             result.Add(found.TryGetValue(fk, out var rf)
                 ? new FullReadback(fk, rf, null)
                 : new FullReadback(fk, null, walkError is not null
-                    ? $"{walkError} — the WRITE ITSELF SUCCEEDED (the patch was serialized and re-opened); inspect the patch in xEdit; do not re-issue the ops."
-                    : $"the written file did not yield {fk} on re-open — a real inconsistency, surfaced not swallowed (Q3); inspect the patch in xEdit."));
+                    ? (inMemory
+                        ? $"{walkError} — this was a DRY RUN read of the in-memory would-be content; nothing was written."
+                        : $"{walkError} — the WRITE ITSELF SUCCEEDED (the patch was serialized and re-opened); inspect the patch in xEdit; do not re-issue the ops.")
+                    : (inMemory
+                        ? $"the in-memory would-be content did not yield {fk} — a real inconsistency, surfaced not swallowed (Q3); nothing was written."
+                        : $"the written file did not yield {fk} on re-open — a real inconsistency, surfaced not swallowed (Q3); inspect the patch in xEdit.")));
         return result;
     }
 

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -777,8 +777,20 @@ public static class WritePatchBuilder
             }
             catch (Exception ex)
             {
-                // The link walk parses subrecord content lazily — a throw means the would-be content itself is
-                // malformed, which the real serialize would also hit. Named, never a silent partial preview (Q3).
+                // A throw here derefs the IN-MEMORY would-be content (already materialized — nothing lazy about a
+                // mutable SkyrimMod). The dominant cause is the SAME class the real serialize re-stamps loud
+                // (HCBR-2026-06-15-01): a COMPOSED record whose REQUIRED polymorphic sub-field was left null (a
+                // Condition without its Data arm) — the walk hits the null exactly as Mutagen's writer would. Detect
+                // it via the SHARED WriteEngine.RootNullArm (so the two paths can't drift) and refuse with the same
+                // named framing, not the opaque bare NRE (PR #240 review). Anything else is named raw (Q3). NOTE the
+                // honest boundary: a required-null sub-field containing NO FormLinks doesn't cross this walk — that
+                // class still surfaces only at the real serialize, which the dry-run footer discloses.
+                if (WriteEngine.RootNullArm(ex) is not null)
+                    return $"dry run caught what the real write would fail on: {rec.FormKey} carries a required modeled " +
+                           "sub-field left null (the same null-dereference Mutagen's writer refuses at serialize). The " +
+                           "cause is a COMPOSED record that left a required polymorphic sub-field unset — e.g. a Condition " +
+                           "composed without its Data arm, or a leveled-list / effect element missing a required part. " +
+                           "Compose that sub-field too (select the arm via compose). Nothing was written.";
                 return $"dry run: enumerating {rec.FormKey}'s references threw ({ex.GetType().Name}: {ex.Message}) — " +
                        "the would-be content could not be fully checked; the real write would hit the same data. Nothing was written.";
             }

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -73,6 +73,10 @@ public static class CiAll
         // equality across field kinds + named non-transplantable refusals, and the two-pole diff incl. an off-order side.
         ("bulk-primitives-wave3-guard", BulkPrimitivesWave3Probe.RunGuard),
         ("writelock-guard", WriteLockProbe.RunGuard),
+        // #225 dry_run= on the write tools — the real pipeline HALTED before serialize, nothing written: refusal
+        // parity with the real call, prediction parity (path/After/masters), the pre-empted missing-master failure,
+        // the read-only in-place consent axis, and the DRY RUN render honesty.
+        ("dry-run-guard", DryRunProbe.RunGuard),
         ("inplace-guard", InPlaceProbe.RunGuard),
         ("subclass-remove-guard", SubclassRemoveGuardProbe.RunGuard),
         ("perk-refs-guard", PerkRefsProbe.RunGuard),

--- a/src/housecarl-generator/DryRunProbe.cs
+++ b/src/housecarl-generator/DryRunProbe.cs
@@ -28,7 +28,13 @@ namespace HousecarlGenerator;
 ///                         consent. RED if it prompts, records, or stays silent.
 ///   CONTRACT UNCHANGED  — the in_place/target/into mutual-exclusion refusals fire identically under dry_run.
 ///   RENDER HONESTY      — the rendered confirmation for a dry outcome leads with DRY RUN/nothing-written and never
-///                         reads like a write ("wrote ..."), incl. the forward renderer's would-be phrasing.
+///                         reads like a write ("wrote ..."), incl. the forward renderer's would-be phrasing and the
+///                         full_readback deep dump labeled as the IN-MEMORY preview (arm J).
+///   NULL-ARM PARITY     — a composed record missing a required polymorphic arm (a Condition without its Data arm)
+///                         refuses through dry_run with the NAMED null-arm framing the real serialize re-stamp gives,
+///                         never the opaque bare NRE; the real call refuses too (arm I). RED if either lies.
+///   FORWARD IN-PLACE    — the consent-bypass logic is DUPLICATED in ForwardRecordsInPlace; arm K guards that copy
+///                         (arm F guards the ApplyEdits copy), so an edit to either alone goes RED.
 ///
 /// Self-contained: synthesizes a master + a user override in a synthetic MO2 instance in TEMP (the WriteMutexProbe
 /// pattern — the full SERVICE path runs: ResolveOutputPath, the write gate, the in-place consent store) and generates
@@ -63,12 +69,13 @@ internal static class DryRunProbe
             var masterDir = Path.Combine(mods, "MasterMod");
             var userDir = Path.Combine(mods, "UserMod");
             Directory.CreateDirectory(masterDir); Directory.CreateDirectory(userDir);
-            FormKey weapFk, weap2Fk;
+            FormKey weapFk, weap2Fk, mgefFk;
             {
                 var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
                 var w = m.Weapons.AddNew(); w.EditorID = "HcDryWeap"; w.BasicStats = new WeaponBasicStats { Damage = 10, Weight = 1 };
                 var w2 = m.Weapons.AddNew(); w2.EditorID = "HcDryWeap2"; w2.BasicStats = new WeaponBasicStats { Damage = 5 };
-                weapFk = w.FormKey; weap2Fk = w2.FormKey;
+                var mg = m.MagicEffects.AddNew(); mg.EditorID = "HcDryMgef";   // hosts a Conditions list (the null-arm compose arm I)
+                weapFk = w.FormKey; weap2Fk = w2.FormKey; mgefFk = mg.FormKey;
                 m.BeginWrite.ToPath(Path.Combine(masterDir, mKey.FileName.String)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
             }
             string userPath = Path.Combine(userDir, "HcDryUser.esp");
@@ -89,6 +96,7 @@ internal static class DryRunProbe
 
             string fid = $"{weapFk.ID:X6}:{mKey.FileName}";
             string fid2 = $"{weap2Fk.ID:X6}:{mKey.FileName}";
+            string fidMg = $"{mgefFk.ID:X6}:{mKey.FileName}";
             var store = new UserConfigStore(Path.Combine(root, "houseCARL.user.json"));
             using var svc = LoadOrderService.WithInstance(instance, 0, store);
             svc.Stats();                                                       // warm the lazy index once, off the clock
@@ -162,7 +170,8 @@ internal static class DryRunProbe
                 Check(!dry.Success && (dry.Error?.Contains("Ghost.esp") ?? false) && (dry.Error?.Contains("NOT active") ?? false),
                     $"dry run refuses, naming the missing plugin  [{Snip(dry.Error)}]");
                 var real = svc.ApplyEdits(ghost, "DryE", null);
-                Check(!real.Success, $"the real write does fail (at serialize) — the dry refusal predicts a real failure  [{Snip(real.Error)}]");
+                Check(!real.Success && (real.Error?.Contains("MissingModException") ?? false),
+                    $"the real write fails AT the serialize boundary (MissingModException) — the exact condition the dry refusal pre-empts  [{Snip(real.Error)}]");
                 Check(!Directory.Exists(Path.Combine(mods, "DryE")), "neither attempt left a folder behind");
             }
 
@@ -212,6 +221,49 @@ internal static class DryRunProbe
                 var realMiss = svc.ForwardRecords(new[] { fid2 }, "HcDryUser.esp", "DryH2", null);
                 Check(!dryMiss.Success && dryMiss.Error == realMiss.Error,
                     $"a source that doesn't define the record refuses identically  [{Snip(dryMiss.Error)}]");
+            }
+
+            // ---- I: composed null-arm (a Condition without its Data arm) — the serialize-only refusal class the
+            //      dry run's link walk catches; both must refuse, and the dry refusal must carry the NAMED null-arm
+            //      framing, not the opaque bare NRE (PR #240 review MEDIUM 1) ----
+            Console.WriteLine("--- I: compose missing a required arm — dry refuses NAMED; real refuses at serialize ---");
+            {
+                var op = new[] { new BulkOp { Formid = fidMg, FieldPath = "Conditions", Verb = "Add",
+                    Compose = new StructInput { Type = "ConditionFloat", Fields = new() { ["ComparisonValue"] = "1" } } } };
+                var dry = svc.ApplyEdits(op, "DryI", null, dryRun: true);
+                Check(!dry.Success && (dry.Error?.Contains("Data arm") ?? false) && (dry.Error?.Contains("required") ?? false),
+                    $"dry run refuses with the named null-arm framing  [{Snip(dry.Error)}]");
+                var real = svc.ApplyEdits(op, "DryI", null);
+                Check(!real.Success, $"the real write refuses too (the serialize null-arm re-stamp) — the dry refusal predicts a real failure  [{Snip(real.Error)}]");
+                Check(!Directory.Exists(Path.Combine(mods, "DryI")), "neither attempt left a folder behind");
+            }
+
+            // ---- J: full_readback + dry_run — the in-memory preview path, rendered honestly ----
+            Console.WriteLine("--- J: full_readback dry run reads the in-memory would-be record ---");
+            {
+                var o = svc.ApplyEdits(new[] { DamageOp(fid, 91) }, "DryJ", null, fullReadback: true, dryRun: true);
+                Check(o.Success && o.DryRun && o.ReadBack is { Count: 1 } && o.ReadBack[0].Record is not null,
+                    $"in-memory read-back present and clean  [{o.Error ?? o.ReadBack?[0].Error ?? "ok"}]");
+                var text = WriteTools.Render(o, 0, fullDump: true);
+                Check(text.Contains("full preview") && text.Contains("nothing is on disk") && text.Contains("91"),
+                    "render labels the deep dump as the in-memory preview (never implying a file exists) and carries the would-be value");
+                Check(!Directory.Exists(Path.Combine(mods, "DryJ")), "no folder appeared despite the deep read-back");
+            }
+
+            // ---- K: forward IN-PLACE dry run — the DUPLICATED consent-bypass copy in ForwardRecordsInPlace
+            //      (PR #240 review MEDIUM 2: arm F guards only the ApplyEdits copy) ----
+            Console.WriteLine("--- K: forward in-place dry run (no prompt, no consent recorded, file untouched) ---");
+            {
+                var fileBefore = File.ReadAllBytes(userPath);
+                var dry = svc.ForwardRecords(new[] { fid }, mKey.FileName.String, null, null,
+                    target: "HcDryUser.esp", inPlace: true, dryRun: true);
+                Check(dry.Success && dry.DryRun && dry.InPlace && !dry.NeedsAcknowledge && (dry.Note?.Contains("PENDING") ?? false),
+                    $"dry forward succeeds without the prompt AND notes the pending consent  [{dry.Error ?? Snip(dry.Note)}]");
+                Check(File.ReadAllBytes(userPath).AsSpan().SequenceEqual(fileBefore), "the target file is byte-identical");
+                var real = svc.ForwardRecords(new[] { fid }, mKey.FileName.String, null, null,
+                    target: "HcDryUser.esp", inPlace: true);
+                Check(real.NeedsAcknowledge,
+                    "a REAL in-place forward afterwards still shows the first-touch prompt (no dry run recorded consent)");
             }
 
             Console.WriteLine();

--- a/src/housecarl-generator/DryRunProbe.cs
+++ b/src/housecarl-generator/DryRunProbe.cs
@@ -1,0 +1,228 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SELF-CONTAINED CI REGRESSION GUARD for the write tools' DRY-RUN mode (#225: set_field / bulk_apply /
+/// forward_record with dry_run=true). The design claim under guard: a dry run is the REAL write pipeline HALTED at
+/// the point of no return (the Phase-4 serialize) — never a parallel validate-lite that could drift from the write
+/// it predicts. Each property is RED-provable:
+///
+///   NOTHING WRITTEN     — a successful fresh-lane dry run leaves the mods dir WITHOUT a new folder (ResolveOutputPath
+///                         create:false), an into= dry run leaves the extended patch byte-identical, an in-place dry
+///                         run leaves the target byte-identical. RED if any file/folder appears or changes.
+///   SAME REFUSAL        — a malformed op refuses through dry_run with the EXACT string the real call gives (same
+///                         resolve + pre-flight code path, by construction). RED if the texts diverge.
+///   PREDICTION HOLDS    — a dry run's would-be output path, per-op After value, and expected-master preview all
+///                         match what the subsequent REAL write of the same op produces. RED on any mismatch.
+///   SERIALIZE PRE-EMPT  — an op composing a FormLink into a plugin NOT in the load order: the real write fails only
+///                         AT the serialize (MissingModException); the dry run must refuse the same call with the
+///                         missing plugin NAMED (the membership test is the serialize's own condition). RED if the
+///                         dry run says "would apply" about a write that then fails.
+///   CONSENT READ-ONLY   — an in-place dry run needs NO acknowledge (nothing is touched), NEVER records consent
+///                         (a real write afterwards still shows the first-touch prompt), and NOTES the pending
+///                         consent. RED if it prompts, records, or stays silent.
+///   CONTRACT UNCHANGED  — the in_place/target/into mutual-exclusion refusals fire identically under dry_run.
+///   RENDER HONESTY      — the rendered confirmation for a dry outcome leads with DRY RUN/nothing-written and never
+///                         reads like a write ("wrote ..."), incl. the forward renderer's would-be phrasing.
+///
+/// Self-contained: synthesizes a master + a user override in a synthetic MO2 instance in TEMP (the WriteMutexProbe
+/// pattern — the full SERVICE path runs: ResolveOutputPath, the write gate, the in-place consent store) and generates
+/// the validator corpus BY CONSTRUCTION in-process.
+/// Run: dotnet run --project src/housecarl-generator dry-run-guard
+/// </summary>
+internal static class DryRunProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" dry-run guard — the real pipeline halted, nothing written (#225)");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        var root = Path.Combine(Path.GetTempPath(), "hc-dry-run-guard-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            // ---- synthetic MO2 instance (the established synth-instance pattern): one master + one user override ----
+            string instance = Path.Combine(root, "instance");
+            string profiles = Path.Combine(instance, "profiles", "Default");
+            string mods = Path.Combine(instance, "mods");
+            Directory.CreateDirectory(profiles); Directory.CreateDirectory(mods);
+            Directory.CreateDirectory(Path.Combine(root, "game", "Data"));
+            File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+                "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+                + Path.Combine(root, "game").Replace(@"\", @"\\") + ")\r\n");
+
+            var mKey = new ModKey("HcDryMaster", ModType.Master);
+            var masterDir = Path.Combine(mods, "MasterMod");
+            var userDir = Path.Combine(mods, "UserMod");
+            Directory.CreateDirectory(masterDir); Directory.CreateDirectory(userDir);
+            FormKey weapFk, weap2Fk;
+            {
+                var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
+                var w = m.Weapons.AddNew(); w.EditorID = "HcDryWeap"; w.BasicStats = new WeaponBasicStats { Damage = 10, Weight = 1 };
+                var w2 = m.Weapons.AddNew(); w2.EditorID = "HcDryWeap2"; w2.BasicStats = new WeaponBasicStats { Damage = 5 };
+                weapFk = w.FormKey; weap2Fk = w2.FormKey;
+                m.BeginWrite.ToPath(Path.Combine(masterDir, mKey.FileName.String)).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            }
+            string userPath = Path.Combine(userDir, "HcDryUser.esp");
+            using (var mOv = SkyrimMod.CreateFromBinaryOverlay(Path.Combine(masterDir, mKey.FileName.String), SkyrimRelease.SkyrimSE))
+            {
+                var u = new SkyrimMod(new ModKey("HcDryUser", ModType.Plugin), SkyrimRelease.SkyrimSE);
+                var uw = u.Weapons.GetOrAddAsOverride(mOv.Weapons.First(x => x.FormKey == weapFk));
+                uw.BasicStats!.Damage = 20;
+                u.BeginWrite.ToPath(userPath).WithLoadOrder(new ISkyrimModGetter[] { mOv }).Write();
+            }
+            File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + mKey.FileName + "\r\nHcDryUser.esp\r\n");
+            File.WriteAllText(Path.Combine(profiles, "plugins.txt"), "*" + mKey.FileName + "\r\n*HcDryUser.esp\r\n");
+            File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+UserMod\r\n+MasterMod\r\n");
+
+            var genDir = Path.Combine(root, "corpus-gen");
+            CorpusGenerator.GenerateAll(genDir, Path.Combine(root, "corpus-ref"));
+            CorpusRulebook.CorpusPath = Path.Combine(genDir, "corpus.json");
+
+            string fid = $"{weapFk.ID:X6}:{mKey.FileName}";
+            string fid2 = $"{weap2Fk.ID:X6}:{mKey.FileName}";
+            var store = new UserConfigStore(Path.Combine(root, "houseCARL.user.json"));
+            using var svc = LoadOrderService.WithInstance(instance, 0, store);
+            svc.Stats();                                                       // warm the lazy index once, off the clock
+
+            static BulkOp DamageOp(string fid, int dmg) =>
+                new() { Formid = fid, FieldPath = "BasicStats.Damage", Verb = "Set", Value = dmg.ToString() };
+            string[] ModFolders() => Directory.GetDirectories(mods).Select(p => Path.GetFileName(p)!).OrderBy(x => x).ToArray();
+
+            // ---- A: fresh-lane dry run — success report, NOTHING on disk, honest preview ----
+            Console.WriteLine("--- A: fresh-patch dry run writes nothing ---");
+            {
+                var before = ModFolders();
+                var o = svc.ApplyEdits(new[] { DamageOp(fid, 77) }, "DryA", null, dryRun: true);
+                var after = ModFolders();
+                Check(o.Success && o.DryRun && !o.InPlace, $"dry run succeeds with DryRun flagged  [{o.Error ?? "ok"}]");
+                Check(before.SequenceEqual(after), $"no mod folder appeared (mods dir: {before.Length} -> {after.Length} entries)");
+                Check(o.Bytes == 0, $"bytes=0 (nothing serialized), got {o.Bytes}");
+                Check(o.Ops.Count == 1 && (o.Ops[0].After?.Contains("77") ?? false),
+                    $"per-op After carries the would-be value  [{o.Ops[0].After ?? "<null>"}]");
+                Check(o.Masters.Count == 1 && o.Masters[0].Equals(mKey.FileName.String, StringComparison.OrdinalIgnoreCase),
+                    $"expected-master preview = [{string.Join(",", o.Masters)}] (want only {mKey.FileName})");
+                var text = WriteTools.Render(o);
+                Check(text.Contains("DRY RUN") && text.Contains("NOTHING was written") && !text.Contains("wrote "),
+                    "render leads with DRY RUN / nothing-written and never reads like a write");
+            }
+
+            // ---- B: a malformed op refuses with the EXACT string the real call gives ----
+            Console.WriteLine("--- B: dry refusal == real refusal (same pipeline by construction) ---");
+            {
+                var bad = new[] { new BulkOp { Formid = fid, FieldPath = "BasicStats.Nope", Verb = "Set", Value = "1" } };
+                var dry = svc.ApplyEdits(bad, "DryB", null, dryRun: true);
+                var real = svc.ApplyEdits(bad, "DryB", null);
+                Check(!dry.Success && !real.Success && dry.Error == real.Error,
+                    $"identical refusal text  [dry: {Snip(dry.Error)}]");
+                Check(!Directory.Exists(Path.Combine(mods, "DryB")), "neither attempt left a folder behind");
+            }
+
+            // ---- C: the dry run's predictions hold against the subsequent REAL write ----
+            Console.WriteLine("--- C: prediction parity (path, After value, masters) ---");
+            {
+                var op = new[] { DamageOp(fid, 88) };
+                var dry = svc.ApplyEdits(op, "DryC", null, dryRun: true);
+                var real = svc.ApplyEdits(op, "DryC", null);
+                Check(dry.Success && real.Success, $"both succeed  [dry: {dry.Error ?? "ok"} | real: {real.Error ?? "ok"}]");
+                Check(dry.OutputPath == real.OutputPath,
+                    $"would-be path == real path  [{Path.GetFileName(dry.OutputPath)} vs {Path.GetFileName(real.OutputPath)}]");
+                Check(dry.Ops[0].After == real.Ops[0].After,
+                    $"would-be After == real After  [{dry.Ops[0].After} vs {real.Ops[0].After}]");
+                Check(dry.Masters.SequenceEqual(real.Masters, StringComparer.OrdinalIgnoreCase),
+                    $"expected masters == real lean header  [{string.Join(",", dry.Masters)} vs {string.Join(",", real.Masters)}]");
+            }
+
+            // ---- D: into= extend dry run — the on-disk patch stays byte-identical ----
+            Console.WriteLine("--- D: into= dry run leaves the extended patch untouched ---");
+            {
+                var seed = svc.ApplyEdits(new[] { DamageOp(fid, 50) }, "DryD", null);
+                Check(seed.Success, $"seed patch written  [{seed.Error ?? "ok"}]");
+                var bytesBefore = File.ReadAllBytes(seed.OutputPath);
+                var o = svc.ApplyEdits(new[] { new BulkOp { Formid = fid, FieldPath = "BasicStats.Weight", Verb = "Set", Value = "9" } },
+                    null, "DryD", dryRun: true);
+                Check(o.Success && o.DryRun && o.Extended, $"extend dry run succeeds with Extended flagged  [{o.Error ?? "ok"}]");
+                Check(File.ReadAllBytes(seed.OutputPath).AsSpan().SequenceEqual(bytesBefore),
+                    "the extended patch's on-disk bytes are unchanged");
+            }
+
+            // ---- E: the serialize's missing-master failure is PRE-EMPTED, named, by the dry run ----
+            Console.WriteLine("--- E: unresolvable FormLink — dry refuses named; real fails only at serialize ---");
+            {
+                var ghost = new[] { new BulkOp { Formid = fid, FieldPath = "Keywords", Verb = "Add", Value = "000ABC:Ghost.esp" } };
+                var dry = svc.ApplyEdits(ghost, "DryE", null, dryRun: true);
+                Check(!dry.Success && (dry.Error?.Contains("Ghost.esp") ?? false) && (dry.Error?.Contains("NOT active") ?? false),
+                    $"dry run refuses, naming the missing plugin  [{Snip(dry.Error)}]");
+                var real = svc.ApplyEdits(ghost, "DryE", null);
+                Check(!real.Success, $"the real write does fail (at serialize) — the dry refusal predicts a real failure  [{Snip(real.Error)}]");
+                Check(!Directory.Exists(Path.Combine(mods, "DryE")), "neither attempt left a folder behind");
+            }
+
+            // ---- F: in-place dry run — read-only on the consent axis AND the file ----
+            Console.WriteLine("--- F: in-place dry run (no prompt, no consent recorded, file untouched) ---");
+            {
+                var fileBefore = File.ReadAllBytes(userPath);
+                var dryAck = svc.ApplyEdits(new[] { DamageOp(fid, 61) }, null, null,
+                    target: "HcDryUser.esp", inPlace: true, acknowledge: true, dryRun: true);
+                Check(dryAck.Success && dryAck.DryRun && dryAck.InPlace && !dryAck.NeedsAcknowledge,
+                    $"dry run + acknowledge=true succeeds without the prompt  [{dryAck.Error ?? "ok"}]");
+                var dry = svc.ApplyEdits(new[] { DamageOp(fid, 62) }, null, null,
+                    target: "HcDryUser.esp", inPlace: true, dryRun: true);
+                Check(dry.Success && !dry.NeedsAcknowledge && (dry.Note?.Contains("PENDING") ?? false),
+                    $"dry run without acknowledge succeeds AND notes the pending consent  [{Snip(dry.Note)}]");
+                Check(File.ReadAllBytes(userPath).AsSpan().SequenceEqual(fileBefore), "the target file is byte-identical");
+                var real = svc.ApplyEdits(new[] { DamageOp(fid, 63) }, null, null, target: "HcDryUser.esp", inPlace: true);
+                Check(real.NeedsAcknowledge,
+                    "a REAL in-place write afterwards still shows the first-touch prompt (no dry run recorded consent)");
+            }
+
+            // ---- G: the lane contract refuses identically under dry_run ----
+            Console.WriteLine("--- G: contract refusals unchanged under dry_run ---");
+            {
+                var op = new[] { DamageOp(fid, 1) };
+                var noTarget = svc.ApplyEdits(op, null, null, inPlace: true, dryRun: true);
+                var withInto = svc.ApplyEdits(op, null, "DryD", target: "HcDryUser.esp", inPlace: true, dryRun: true);
+                Check(!noTarget.Success && (noTarget.Error?.Contains("requires target=") ?? false)
+                   && !withInto.Success && (withInto.Error?.Contains("mutually exclusive") ?? false),
+                    "in_place⇔target and in_place⊥into= refusals fire as on the real path");
+            }
+
+            // ---- H: forward_record dry run — would-copy report, nothing on disk, same refusal as real ----
+            Console.WriteLine("--- H: forward dry run ---");
+            {
+                var before = ModFolders();
+                var o = svc.ForwardRecords(new[] { fid }, mKey.FileName.String, "DryH", null, dryRun: true);
+                Check(o.Success && o.DryRun && o.Forwarded.Count == 1
+                   && o.Forwarded[0].FromPlugin.Equals(mKey.FileName.String, StringComparison.OrdinalIgnoreCase)
+                   && !o.Forwarded[0].WasAlreadyWinner,
+                    $"dry forward reports the would-be copy (source={o.Forwarded.FirstOrDefault()?.FromPlugin}, priorWinner={o.Forwarded.FirstOrDefault()?.PriorWinner})  [{o.Error ?? "ok"}]");
+                Check(before.SequenceEqual(ModFolders()), "no mod folder appeared");
+                var text = WriteTools.RenderForward(o);
+                Check(text.Contains("DRY RUN") && text.Contains("would be copied from") && !text.Contains("\nmasters:"),
+                    "forward render uses the would-be phrasing (+ the expected-masters preview, not a real header)");
+                var dryMiss = svc.ForwardRecords(new[] { fid2 }, "HcDryUser.esp", "DryH2", null, dryRun: true);
+                var realMiss = svc.ForwardRecords(new[] { fid2 }, "HcDryUser.esp", "DryH2", null);
+                Check(!dryMiss.Success && dryMiss.Error == realMiss.Error,
+                    $"a source that doesn't define the record refuses identically  [{Snip(dryMiss.Error)}]");
+            }
+
+            Console.WriteLine();
+            Console.WriteLine(fail == 0 ? "ALL PASS" : $"{fail} FAILURE(S)");
+            return fail == 0 ? 0 : 1;
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { /* best-effort temp cleanup */ }
+        }
+    }
+
+    static string Snip(string? s) => s is null ? "<null>" : s.Length <= 140 ? s.Replace('\n', ' ') : s[..140].Replace('\n', ' ') + "…";
+}

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2573,7 +2573,8 @@ public sealed class LoadOrderService : IDisposable
     /// <paramref name="fullReadback"/> additionally reads every touched record back IN FULL off the written file
     /// (the pre-enable verify loop — wishlist #3 re-scoped / HCBR-2026-06-11-02 wave (b)).</summary>
     public WritePatchBuilder.PatchOutcome ApplyEdits(IReadOnlyList<BulkOp> ops, string? patchName, string? into,
-        bool fullReadback = false, string? target = null, bool inPlace = false, bool acknowledge = false)
+        bool fullReadback = false, string? target = null, bool inPlace = false, bool acknowledge = false,
+        bool dryRun = false)
     {
         if (ops.Count == 0)
             return WritePatchBuilder.PatchOutcome.Fail("no operations supplied.");
@@ -2611,10 +2612,13 @@ public sealed class LoadOrderService : IDisposable
             var rulebook = Rulebook;
 
             if (inPlace)
-                return ApplyEditsInPlace(resolver, rulebook, edits, target!.Trim(), acknowledge);
+                return ApplyEditsInPlace(resolver, rulebook, edits, target!.Trim(), acknowledge, dryRun);
 
+            // #225: a dry run resolves the would-be output path WITHOUT creating the mod folder (create:false) — the
+            // one disk side effect the pre-serialize pipeline otherwise has. The fresh-lane name is a preview: the
+            // real write re-picks a free stem, so a concurrent write can shift the auto-suffix.
             string outPath; bool extend, created;
-            try { outPath = ResolveOutputPath(patchName, into, out extend, out created); }
+            try { outPath = ResolveOutputPath(patchName, into, out extend, out created, create: !dryRun); }
             catch (Exception ex) { return WritePatchBuilder.PatchOutcome.Fail(ex.Message); }
 
             // P8b: pre-resolve any CopyFrom source that is OFF-ORDER (from_plugin on disk but NOT in the active order —
@@ -2632,7 +2636,7 @@ public sealed class LoadOrderService : IDisposable
             }
             try
             {
-                var outcome = WritePatchBuilder.Apply(resolver, rulebook, edits, outPath, extend, fullReadback, copyFromSources);
+                var outcome = WritePatchBuilder.Apply(resolver, rulebook, edits, outPath, extend, fullReadback, copyFromSources, dryRun);
                 if (!outcome.Success && created) RemoveFolderCreatedThisCall(outPath);   // hunt F4: a refused write leaves no orphan
                 return outcome;
             }
@@ -2694,7 +2698,7 @@ public sealed class LoadOrderService : IDisposable
     /// the CONSENT axis ONLY — the verify is a corruption-axis fact no acknowledgement overrides.</summary>
     WritePatchBuilder.PatchOutcome ApplyEditsInPlace(
         LoadOrderResolver resolver, CorpusRulebook rulebook, IReadOnlyList<WritePatchBuilder.PatchEdit> edits,
-        string target, bool acknowledge)
+        string target, bool acknowledge, bool dryRun = false)
     {
         // (1) Resolve target -> real on-disk path via the load order (by plugin FILENAME — unique in an order). Refuse
         //     loud if it isn't a real active plugin (closes the coincidental-folder collision the into= lane can hit).
@@ -2708,24 +2712,42 @@ public sealed class LoadOrderService : IDisposable
         // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path. NOT a
         //     sticky mode: each in-place write still names its own target=, so this only stops re-explaining the
         //     trade-off; it never makes an ambiguous request route to in-place.
+        //     #225: a DRY RUN bypasses the handshake and NEVER persists an acknowledgement — consent gates touching
+        //     your original, and a dry run touches nothing; the pending consent is surfaced as a note instead, so the
+        //     report still says the REAL write will prompt.
         bool already = _store.IsInPlaceAcknowledged(targetPath);
-        if (!already && !acknowledge)
-            return WritePatchBuilder.PatchOutcome.NeedsAck(InPlaceHandshakeText(targetName, targetPath));
         string? ackNote = null;
-        if (!already && acknowledge)
+        if (dryRun)
         {
-            var (ok, err) = _store.RecordInPlaceAcknowledged(targetPath);
-            if (!ok) ackNote = $"the in-place acknowledgement could not be saved ({err}) — the edit proceeded, but a future session will re-prompt for this plugin.";
+            if (!already)
+                ackNote = $"in-place consent is still PENDING for '{targetName}' — the REAL write's first touch of this " +
+                          "plugin will show the one-time confirmation (re-call with acknowledge=true); a dry run neither needs nor records it.";
+        }
+        else
+        {
+            if (!already && !acknowledge)
+                return WritePatchBuilder.PatchOutcome.NeedsAck(InPlaceHandshakeText(targetName, targetPath));
+            if (!already && acknowledge)
+            {
+                var (ok, err) = _store.RecordInPlaceAcknowledged(targetPath);
+                if (!ok) ackNote = $"the in-place acknowledgement could not be saved ({err}) — the edit proceeded, but a future session will re-prompt for this plugin.";
+            }
         }
 
         // (3) Writable, same-volume parent pre-flight — refuse rather than degrade (the swap stages a sibling temp in
         //     this dir; AtomicFile.Commit already refuses cross-volume loud, this catches a read-only/locked parent up
-        //     front with a clear message before any work).
+        //     front with a clear message before any work). Kept in the dry run too: an unwritable parent is exactly
+        //     what the real write would refuse on, and predicting that refusal is the dry run's job.
         if (InPlaceParentUnwritable(targetPath, out var why))
             return WritePatchBuilder.PatchOutcome.Fail(why);
 
         // (4) The write — touched-record verify forced ON (the model-C substitute for the dropped whole-plugin floor).
-        var outcome = WritePatchBuilder.ApplyInPlace(resolver, rulebook, edits, targetPath, targetName, fullReadback: true);
+        var outcome = WritePatchBuilder.ApplyInPlace(resolver, rulebook, edits, targetPath, targetName, fullReadback: true, dryRun);
+
+        // (5-dry) #225: a successful dry run stamps NOTHING (no editedInPlace marker, no .seq note — those describe a
+        //     write that happened); only the core's would-grow note + the pending-consent note ride along.
+        if (dryRun)
+            return JoinNotes(outcome.Note, ackNote) is { } dn ? outcome with { Note = dn } : outcome;
 
         // (5) On success, stamp the distinct audit marker + auto-flag a now-stale .seq (both best-effort; neither miss
         //     fails the done edit, Q3-noted). SEQ flag (Track C): an in-place edit can prune a master and shift the own
@@ -3043,7 +3065,8 @@ public sealed class LoadOrderService : IDisposable
     /// write lane; HCBR-2026-07-08-01 F4) — forward INTO an existing plugin's own file, consent-gated like the sibling
     /// write tools — see <see cref="ForwardRecordsInPlace"/>.</summary>
     public WritePatchBuilder.ForwardOutcome ForwardRecords(IReadOnlyList<string> formids, string fromPlugin, string? patchName, string? into,
-        bool fullReadback = false, string? target = null, bool inPlace = false, bool acknowledge = false)
+        bool fullReadback = false, string? target = null, bool inPlace = false, bool acknowledge = false,
+        bool dryRun = false)
     {
         if (string.IsNullOrWhiteSpace(fromPlugin))
             return WritePatchBuilder.ForwardOutcome.Fail(
@@ -3084,13 +3107,14 @@ public sealed class LoadOrderService : IDisposable
             var resolver = Resolver;                                      // builds/refreshes the index (Overlays for the source fetch + serialize)
 
             if (inPlace)
-                return ForwardRecordsInPlace(resolver, specs, target!.Trim(), acknowledge);
+                return ForwardRecordsInPlace(resolver, specs, target!.Trim(), acknowledge, dryRun);
 
+            // #225: a dry run resolves the would-be output path WITHOUT creating the mod folder (see ApplyEdits).
             string outPath; bool extend, created;
-            try { outPath = ResolveOutputPath(patchName, into, out extend, out created); }
+            try { outPath = ResolveOutputPath(patchName, into, out extend, out created, create: !dryRun); }
             catch (Exception ex) { return WritePatchBuilder.ForwardOutcome.Fail(ex.Message); }
 
-            var outcome = WritePatchBuilder.ForwardRecords(resolver, specs, outPath, extend, fullReadback);
+            var outcome = WritePatchBuilder.ForwardRecords(resolver, specs, outPath, extend, fullReadback, dryRun);
             if (!outcome.Success && created) RemoveFolderCreatedThisCall(outPath);   // hunt F4: a refused forward leaves no orphan
             return outcome;
         }
@@ -3106,7 +3130,8 @@ public sealed class LoadOrderService : IDisposable
     /// verify forced ON). <paramref name="acknowledge"/> waives the CONSENT axis ONLY — the verify is a corruption-axis
     /// fact no acknowledgement overrides.</summary>
     WritePatchBuilder.ForwardOutcome ForwardRecordsInPlace(
-        LoadOrderResolver resolver, IReadOnlyList<WritePatchBuilder.ForwardSpec> specs, string target, bool acknowledge)
+        LoadOrderResolver resolver, IReadOnlyList<WritePatchBuilder.ForwardSpec> specs, string target, bool acknowledge,
+        bool dryRun = false)
     {
         // (1) Resolve target -> real on-disk path via the load order (by plugin FILENAME). Refuse loud if it isn't a
         //     real active plugin. Same resolver as the edit + create + remove lanes.
@@ -3119,22 +3144,38 @@ public sealed class LoadOrderService : IDisposable
 
         // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path (shared
         //     with the edit/create/remove lanes: it's the same "touch your original" trade-off).
+        //     #225: a DRY RUN bypasses the handshake and NEVER persists an acknowledgement (see ApplyEditsInPlace) —
+        //     the pending consent is surfaced as a note instead.
         bool already = _store.IsInPlaceAcknowledged(targetPath);
-        if (!already && !acknowledge)
-            return WritePatchBuilder.ForwardOutcome.NeedsAck(InPlaceHandshakeText(targetName, targetPath));
         string? ackNote = null;
-        if (!already && acknowledge)
+        if (dryRun)
         {
-            var (ok, err) = _store.RecordInPlaceAcknowledged(targetPath);
-            if (!ok) ackNote = $"the in-place acknowledgement could not be saved ({err}) — the forward proceeded, but a future session will re-prompt for this plugin.";
+            if (!already)
+                ackNote = $"in-place consent is still PENDING for '{targetName}' — the REAL write's first touch of this " +
+                          "plugin will show the one-time confirmation (re-call with acknowledge=true); a dry run neither needs nor records it.";
+        }
+        else
+        {
+            if (!already && !acknowledge)
+                return WritePatchBuilder.ForwardOutcome.NeedsAck(InPlaceHandshakeText(targetName, targetPath));
+            if (!already && acknowledge)
+            {
+                var (ok, err) = _store.RecordInPlaceAcknowledged(targetPath);
+                if (!ok) ackNote = $"the in-place acknowledgement could not be saved ({err}) — the forward proceeded, but a future session will re-prompt for this plugin.";
+            }
         }
 
-        // (3) Writable, same-volume parent pre-flight — refuse rather than degrade.
+        // (3) Writable, same-volume parent pre-flight — refuse rather than degrade. Kept in the dry run (it predicts
+        //     exactly what the real write would refuse on).
         if (InPlaceParentUnwritable(targetPath, out var why))
             return WritePatchBuilder.ForwardOutcome.Fail(why);
 
         // (4) The write — touched-record verify forced ON (the model-C substitute for the dropped whole-plugin floor).
-        var outcome = WritePatchBuilder.ForwardRecordsInPlace(resolver, specs, targetPath, targetName, fullReadback: true);
+        var outcome = WritePatchBuilder.ForwardRecordsInPlace(resolver, specs, targetPath, targetName, fullReadback: true, dryRun);
+
+        // (5-dry) #225: a successful dry run stamps NOTHING (no editedInPlace marker, no .seq note).
+        if (dryRun)
+            return JoinNotes(outcome.Note, ackNote) is { } dn ? outcome with { Note = dn } : outcome;
 
         // (5) On success, stamp the distinct audit marker + auto-flag a now-stale .seq (both best-effort; neither miss
         //     fails the done forward, Q3-noted).
@@ -4389,7 +4430,7 @@ public sealed class LoadOrderService : IDisposable
     /// check-then-create is only race-free when every folder allocation is serialized on the one gate.
     /// <paramref name="createdFolder"/> reports whether THIS call created the fresh folder, so a refused write can
     /// remove it again (hunt F4 — "NO patch written" must not leave an orphan folder accreting _001/_002 on retry).</summary>
-    string ResolveOutputPath(string? patchName, string? into, out bool extend, out bool createdFolder)
+    string ResolveOutputPath(string? patchName, string? into, out bool extend, out bool createdFolder, bool create = true)
     {
         lock (_gate)
         {
@@ -4417,10 +4458,15 @@ public sealed class LoadOrderService : IDisposable
             var baseStem = PatchStem(string.IsNullOrWhiteSpace(patchName) ? "Patch" : patchName!);
             var freeStem = UniqueStem(baseStem);
             var newFolder = Path.Combine(_modsDir, ModFolderName(freeStem));
-            Directory.CreateDirectory(newFolder);
-            createdFolder = true;
             var plugin = freeStem + ".esp";
-            WriteOwnerMeta(newFolder, plugin);
+            // #225 dry run (create:false): resolve the WOULD-BE path only — no folder, no meta.ini; the disk stays
+            // exactly as it was. The real write re-resolves and creates as before.
+            if (create)
+            {
+                Directory.CreateDirectory(newFolder);
+                createdFolder = true;
+                WriteOwnerMeta(newFolder, plugin);
+            }
             return Path.Combine(newFolder, plugin);
         }
     }

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -57,14 +57,16 @@ public static class WriteTools
         [Description("When true, the read-back is the FULL deep field-by-field dump of the touched record (every field, not just the edited leaf) — confirm the write landed and nothing else was disturbed, WITHOUT enabling the patch in MO2. For an IN-PLACE edit the touched-record verify ALWAYS runs and is shown COMPACTLY by default (re-read-clean + what landed, every record); true expands it to the deep dump. (The read-back is the written file's content, NOT load-order truth — the patch/edit wins nothing until enabled + sorted in MO2.)")]
             bool full_readback = false,
         [Description("Optional. Max characters for the whole response; past it the read-back is cut with an explicit notice (never silent). 0 = a safe default kept under the host's per-response token limit; raise it to widen a full_readback=true dump.")]
-            int max_chars = 0) => Guard.Tool("housecarl_set_field", () =>
+            int max_chars = 0,
+        [Description("Optional, default false. DRY RUN: run the FULL write pipeline — winner resolve, schema pre-flight, the edit applied in memory, the reference-resolution check — and STOP before anything touches disk (no patch file, no mod folder, no in-place rewrite). Returns what WOULD change (the would-be value, the expected masters), or EXACTLY the refusal the real call would give. Works on every lane (fresh patch / into= / in_place; an in-place dry run needs no acknowledge and never records consent). Not a disk guarantee: a serialize/commit fault still surfaces only on the real write.")]
+            bool dry_run = false) => Guard.Tool("housecarl_set_field", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         var op = new BulkOp
         {
             Formid = formid, FieldPath = field_path, Verb = verb, Value = value, Key = key, Values = values,
         };
-        return Render(svc.ApplyEdits(new[] { op }, patch_name, into, full_readback, target, in_place, acknowledge), max_chars, full_readback);
+        return Render(svc.ApplyEdits(new[] { op }, patch_name, into, full_readback, target, in_place, acknowledge, dry_run), max_chars, full_readback);
     });
 
     [McpServerTool(Name = "housecarl_bulk_apply", Title = "Apply many edits in one patch"),
@@ -93,7 +95,9 @@ public static class WriteTools
          "bulk_apply into= is THE recipe to build on a specific plugin's version while a stale winner sits above it. " +
          "To edit an EXISTING plugin IN PLACE instead — rewriting your ORIGINAL file (incl. a mod houseCARL " +
          "didn't make), not a patch — pass target=<plugin filename> + in_place=true (opt-in; the default lane leaves originals " +
-         "untouched). Returns the patch path, masters, and per-op read-back.")]
+         "untouched). dry_run=true validates the WHOLE batch through the real pipeline and reports what WOULD change " +
+         "without writing anything — the way to catch a bad field path before the first write of a big batch, not after " +
+         "the last. Returns the patch path, masters, and per-op read-back.")]
     public static string BulkApply(
         LoadOrderService svc,
         [Description("The edits to apply, all into one patch. Each: {formid, field_path, verb, value?, key?, values?, entries?, compose?}.")]
@@ -111,12 +115,14 @@ public static class WriteTools
         [Description("When true, the read-back is the FULL deep field-by-field dump of every record this call touched (not just the edited leaves) — confirm composed structures (conditions, container entries) landed and nothing else was disturbed, WITHOUT enabling the patch in MO2. For an IN-PLACE edit the touched-record verify ALWAYS runs and is shown COMPACTLY by default (per record: re-read-clean + what landed, covering ALL of them); true expands it to the deep dump. (The read-back is the written file's content, NOT load-order truth — the patch/edit wins nothing until enabled + sorted in MO2.)")]
             bool full_readback = false,
         [Description("Optional. Max characters for the whole response; past it the read-back is cut with an explicit notice (never silent). 0 = a safe default kept under the host's per-response token limit; raise it to widen a full_readback=true dump.")]
-            int max_chars = 0) => Guard.Tool("housecarl_bulk_apply", () =>
+            int max_chars = 0,
+        [Description("Optional, default false. DRY RUN: run the FULL write pipeline over the WHOLE batch — winner resolve, schema pre-flight, every op applied in memory, the reference-resolution check — and STOP before anything touches disk (no patch file, no mod folder, no in-place rewrite). Returns per-op what WOULD change + the expected masters, or EXACTLY the all-or-nothing refusal the real call would give (every bad op named) — validate a big batch's field paths and values BEFORE the first write, not after the last. Works on every lane (fresh patch / into= / in_place; an in-place dry run needs no acknowledge and never records consent). Not a disk guarantee: a serialize/commit fault still surfaces only on the real write.")]
+            bool dry_run = false) => Guard.Tool("housecarl_bulk_apply", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         if (operations is null || operations.Length == 0)
             return "error: operations is empty. Pass one or more {formid, field_path, verb, ...} edits.";
-        return Render(svc.ApplyEdits(operations, patch_name, into, full_readback, target, in_place, acknowledge), max_chars, full_readback);
+        return Render(svc.ApplyEdits(operations, patch_name, into, full_readback, target, in_place, acknowledge, dry_run), max_chars, full_readback);
     });
 
     [McpServerTool(Name = "housecarl_remove_record", Title = "Remove a whole record from a patch (or a plugin in place)"),
@@ -306,14 +312,16 @@ public static class WriteTools
         [Description("Optional, default false. Confirms the one-time in-place trade-off for target (see in_place) — needed only on the FIRST in-place write to a given plugin (edit, create, remove, OR forward), never again for it. Waives the consent to touch your original ONLY; it NEVER skips the record verify.")]
             bool acknowledge = false,
         [Description("Optional. Max characters for the whole response; past it the read-back is cut with an explicit notice (never silent). 0 = a safe default kept under the host's per-response token limit; raise it to widen a full_readback=true dump.")]
-            int max_chars = 0) => Guard.Tool("housecarl_forward_record", () =>
+            int max_chars = 0,
+        [Description("Optional, default false. DRY RUN: resolve every record from from_plugin, copy each into the in-memory would-be patch, and STOP before anything touches disk (no patch file, no mod folder, no in-place rewrite). Returns what WOULD be forwarded (per record: source, the winner it would out-rank, replace/redundant flags) + the expected masters, or EXACTLY the refusal the real call would give. Works on every lane (fresh patch / into= / in_place; an in-place dry run needs no acknowledge and never records consent). Not a disk guarantee: a serialize/commit fault still surfaces only on the real write.")]
+            bool dry_run = false) => Guard.Tool("housecarl_forward_record", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         if (formids is null || formids.Length == 0)
             return "error: formids is empty. Pass one or more 'XXXXXX:Plugin.esp' FormIDs to forward from from_plugin.";
         if (string.IsNullOrWhiteSpace(from_plugin))
             return "error: from_plugin is empty. Name the plugin whose version of the record(s) to forward.";
-        return RenderForward(svc.ForwardRecords(formids, from_plugin, patch_name, into, full_readback, target, in_place, acknowledge), max_chars);
+        return RenderForward(svc.ForwardRecords(formids, from_plugin, patch_name, into, full_readback, target, in_place, acknowledge, dry_run), max_chars);
     });
 
     [McpServerTool(Name = "housecarl_create_plugin", Title = "Create an empty header-only (trigger) plugin"),
@@ -435,6 +443,7 @@ public static class WriteTools
     {
         if (o.NeedsAcknowledge) return o.Error!;            // the first-touch in-place CONSENT prompt — a required confirmation, NOT an error (Q3)
         if (!o.Success) return "error: " + o.Error;
+        if (o.DryRun) return RenderDryRun(o, maxChars, fullDump);
         var file = Path.GetFileName(o.OutputPath);
         var modFolder = Path.GetFileName(Path.GetDirectoryName(o.OutputPath) ?? "");
         var sb = new StringBuilder();
@@ -479,24 +488,58 @@ public static class WriteTools
         return sb.ToString();
     }
 
+    /// <summary>#225 — the dry_run=true confirmation: the SAME pipeline ran (winner resolve, pre-flight, every verb
+    /// applied in memory, the reference-resolution check) and stopped AT the point of no return, so this reports what
+    /// WOULD change with NOTHING on disk. The header says so first (Q3 — a dry run must never read like a write);
+    /// masters are the labeled link-derived PREVIEW; per-op lines carry the would-be values; the optional deep dump is
+    /// the in-memory would-be content. A refusal never reaches here — a dry run refuses EXACTLY like the real call.</summary>
+    static string RenderDryRun(WritePatchBuilder.PatchOutcome o, int maxChars, bool fullDump)
+    {
+        var file = Path.GetFileName(o.OutputPath);
+        var sb = new StringBuilder();
+        sb.Append("DRY RUN — validated only; NOTHING was written (no patch file, no mod folder, originals untouched).\n");
+        if (o.InPlace)
+            sb.Append("the real call would edit ").Append(file).Append(" IN PLACE — your ORIGINAL file rewritten; no houseCARL backup or undo.\n");
+        else if (o.Extended)
+            sb.Append("the real call would EXTEND the existing patch ").Append(file).Append(".\n");
+        else
+            sb.Append("the real call would write a NEW patch ").Append(file)
+              .Append(" (name preview — the real write re-picks a free name, so the auto-suffix can shift if another patch lands first).\n");
+        sb.Append("expected masters: ").Append(o.Masters.Count == 0 ? "(none)" : string.Join(", ", o.Masters))
+          .Append("  [derived from the would-be content; the real write derives its own lean header]\n");
+        sb.Append(o.Ops.Count).Append(o.Ops.Count == 1 ? " edit would apply:\n" : " edits would apply:\n");
+        foreach (var op in o.Ops)
+            sb.Append("  ").Append(op.RecordType).Append(' ').Append(op.Target).Append("  ").Append(op.Label)
+              .Append(op.After is not null ? "  -> would become " + op.After : "  -> would apply").Append('\n');
+        if (fullDump && o.ReadBack is { } rb) AppendFullReadback(sb, rb, maxChars, dryRun: true);
+        if (o.Note is { } note) sb.Append("note: ").Append(note).Append('\n');
+        sb.Append("every op passed resolve + pre-flight; to apply for real, repeat the call without dry_run. ")
+          .Append("(A real write can still fail at serialize/commit — disk faults and data Mutagen refuses to serialize surface only there.)");
+        return sb.ToString();
+    }
+
     /// <summary>The full_readback=true read-back section (HCBR-2026-06-11-02 wave (b)): each touched/created record IN FULL,
     /// re-read from the written file on disk. Labeled as exactly that — the written file's content, NOT load-order
     /// truth (the patch wins nothing until enabled in MO2) — so the caller can't mistake it for a winner read.
     /// Char-budget-bounded with an explicit notice (Q3), same convention as the read tools — now at the LOWER
     /// <see cref="Wire.ReadbackMaxChars"/> default so the cut-off output stays under the host token ceiling and the
     /// truncation note actually reaches the caller (HCBR-2026-06-28-01).</summary>
-    static void AppendFullReadback(StringBuilder sb, IReadOnlyList<WritePatchBuilder.FullReadback> rb, int maxChars)
+    static void AppendFullReadback(StringBuilder sb, IReadOnlyList<WritePatchBuilder.FullReadback> rb, int maxChars,
+        bool dryRun = false)
     {
         int cap = maxChars > 0 ? maxChars : Wire.ReadbackMaxChars;
-        sb.Append("full read-back — the ENTIRE record(s) as written, re-read from the patch file on disk ")
-          .Append("(the written file's content, NOT load-order truth; the patch wins nothing until enabled + sorted in MO2):\n");
+        // #225: a dry run's records are read from the IN-MEMORY would-be content — say so, never imply a file exists.
+        sb.Append(dryRun
+            ? "full preview — the ENTIRE record(s) as they WOULD be written, read from the in-memory would-be content (nothing is on disk):\n"
+            : "full read-back — the ENTIRE record(s) as written, re-read from the patch file on disk " +
+              "(the written file's content, NOT load-order truth; the patch wins nothing until enabled + sorted in MO2):\n");
+        string hint = dryRun ? "; raise max_chars" : "; raise max_chars, or enable the patch in MO2 and use housecarl_read_record";
         for (int i = 0; i < rb.Count; i++)
         {
             if (sb.Length >= cap)
             {
                 sb.Append("  ... [truncated: full read-back rendered ").Append(i).Append(" of ").Append(rb.Count)
-                  .Append(" record(s) at max_chars=").Append(cap)
-                  .Append("; raise max_chars, or enable the patch in MO2 and use housecarl_read_record]\n");
+                  .Append(" record(s) at max_chars=").Append(cap).Append(hint).Append("]\n");
                 return;
             }
             var r = rb[i];
@@ -509,7 +552,7 @@ public static class WriteTools
                 {
                     sb.Append("    ... [truncated: this record's field lines hit max_chars=").Append(cap)
                       .Append("; ").Append(rb.Count - i - 1).Append(" further record(s) not rendered")
-                      .Append("; raise max_chars, or enable the patch in MO2 and use housecarl_read_record]\n");
+                      .Append(hint).Append("]\n");
                     return;
                 }
                 sb.Append("    ").Append(f.Path).Append(" = ").Append(f.HasValue ? f.Token : f.Note).Append('\n');
@@ -594,14 +637,28 @@ public static class WriteTools
     /// source it was copied FROM, and the current winner it out-ranks once enabled — with a redundant-forward NOTE when
     /// the copied version was already winning (Q3 — never silently a no-op). On refusal, the named reason so the caller
     /// can fix and retry. Optional full read-back rides along (the pre-enable verify that the copy is the source's).</summary>
-    static string RenderForward(WritePatchBuilder.ForwardOutcome o, int maxChars = 0)
+    internal static string RenderForward(WritePatchBuilder.ForwardOutcome o, int maxChars = 0)   // internal: the dry-run guard asserts the would-be phrasing
     {
         if (o.NeedsAcknowledge) return o.Error!;            // the first-touch in-place CONSENT prompt — a required confirmation, NOT an error (Q3)
         if (!o.Success) return "error: " + o.Error;
         var file = Path.GetFileName(o.OutputPath);
         var modFolder = Path.GetFileName(Path.GetDirectoryName(o.OutputPath) ?? "");
         var sb = new StringBuilder();
-        if (o.InPlace)
+        if (o.DryRun)
+        {
+            // #225 — mirrors RenderDryRun: say NOTHING was written first, then what the real call would do.
+            sb.Append("DRY RUN — validated only; NOTHING was written (no patch file, no mod folder, originals untouched).\n");
+            if (o.InPlace)
+                sb.Append("the real call would forward into ").Append(file).Append(" IN PLACE — your ORIGINAL file rewritten; no houseCARL backup or undo.\n");
+            else if (o.Extended)
+                sb.Append("the real call would EXTEND the existing patch ").Append(file).Append(".\n");
+            else
+                sb.Append("the real call would write a NEW patch ").Append(file)
+                  .Append(" (name preview — the real write re-picks a free name, so the auto-suffix can shift if another patch lands first).\n");
+            sb.Append("expected masters: ").Append(o.Masters.Count == 0 ? "(none)" : string.Join(", ", o.Masters))
+              .Append("  [derived from the would-be content; the real write derives its own lean header]\n");
+        }
+        else if (o.InPlace)
             sb.Append("forwarded into ").Append(file).Append(" IN PLACE (").Append(o.Bytes)
               .Append(" bytes — your ORIGINAL file was rewritten; no houseCARL backup or undo)\n")
               .Append("mod folder: ").Append(modFolder).Append("  — already active in your load order; re-sort only if a winner changed\n");
@@ -612,25 +669,32 @@ public static class WriteTools
             sb.Append("mod folder: ").Append(modFolder)
               .Append(o.Extended ? "\n" : "  — enable + sort it in MO2 to use the patch\n");
         }
-        sb.Append("masters: ").Append(o.Masters.Count == 0 ? "(none)" : string.Join(", ", o.Masters)).Append('\n');
-        sb.Append("forwarded ").Append(o.Forwarded.Count).Append(o.Forwarded.Count == 1 ? " record:\n" : " records:\n");
+        if (!o.DryRun)
+            sb.Append("masters: ").Append(o.Masters.Count == 0 ? "(none)" : string.Join(", ", o.Masters)).Append('\n');
+        sb.Append(o.DryRun ? "would forward " : "forwarded ").Append(o.Forwarded.Count)
+          .Append(o.Forwarded.Count == 1 ? " record:\n" : " records:\n");
         foreach (var f in o.Forwarded)
         {
             sb.Append("  ").Append(f.RecordType).Append(' ').Append(f.Target).Append("  ").Append(f.EditorId ?? "<no editorid>")
-              .Append("  — copied from ").Append(f.FromPlugin);
+              .Append(o.DryRun ? "  — would be copied from " : "  — copied from ").Append(f.FromPlugin);
             if (f.ReplacedExisting)
-                sb.Append("  [REPLACED the patch's own existing override of this record — the old body is gone (xEdit's copy-as-override-into overwrite)]");
+                sb.Append(o.DryRun
+                    ? "  [would REPLACE the patch's own existing override of this record — the old body would be gone (xEdit's copy-as-override-into overwrite)]"
+                    : "  [REPLACED the patch's own existing override of this record — the old body is gone (xEdit's copy-as-override-into overwrite)]");
             if (f.WasAlreadyWinner)
                 sb.Append("  [NOTE: this source IS already the load-order winner — the override just re-asserts the content that already wins (a no-op in effect)]");
             else
                 sb.Append("  (out-ranks the current winner ").Append(f.PriorWinner).Append(" once this patch is enabled + sorted above it)");
             sb.Append('\n');
         }
-        if (o.ReadBack is { } rb) AppendFullReadback(sb, rb, maxChars);
+        if (o.ReadBack is { } rb) AppendFullReadback(sb, rb, maxChars, dryRun: o.DryRun);
         if (o.Note is { } note) sb.Append("note: ").Append(note).Append('\n');
-        sb.Append(o.InPlace
-            ? $"to forward more into this plugin, pass target=\"{file}\" in_place=true (no further confirmation needed for it)."
-            : $"to forward more into THIS patch (incl. from a different source plugin), pass into=\"{file}\".");
+        sb.Append(o.DryRun
+            ? "every record resolved from its source; to forward for real, repeat the call without dry_run. " +
+              "(A real write can still fail at serialize/commit — disk faults surface only there.)"
+            : o.InPlace
+                ? $"to forward more into this plugin, pass target=\"{file}\" in_place=true (no further confirmation needed for it)."
+                : $"to forward more into THIS patch (incl. from a different source plugin), pass into=\"{file}\".");
         return sb.ToString();
     }
 


### PR DESCRIPTION
Fixes #225

## What

`housecarl_set_field`, `housecarl_bulk_apply`, and `housecarl_forward_record` gain **`dry_run=true`**: validate every op against the schema and the live winner and report what WOULD change, **without writing anything** — the way to catch a bad field path before the first write of a 745-op batch, not after the last.

## How — the real pipeline, halted (not a validate-lite)

The handoff flagged the design risk to watch: a parallel "validate-lite" path that could drift from the real write (D2-class). That fork never materializes, because the write pipeline already has a clean point of no return: everything through Phase 3 — winner resolve, `CorpusRulebook` pre-flight, `ApplyVerb` on the **in-memory** patch mod, the SNAM marker sync — touches no disk; the first byte lands at the Phase-4 serialize. So `dryRun` simply **halts the real path there**:

- **Same refusals by construction** — a malformed batch refuses through dry_run with the *string-identical* error the real call gives (guard-asserted).
- **The one Phase-4 hazard the halt would skip is re-checked**: a FormLink into a plugin not in the active order fails the real serialize with `MissingModException`. The dry run re-runs that same membership test over the would-be content's links (record origins + `EnumerateFormLinks`, the surface Mutagen lean-derives the header from) and refuses with the missing plugin **named** — probe-proven against the real serialize failure (guard arm E runs both).
- **Expected masters** are reported as a labeled link-derived *preview* (+ the patch lane's Skyrim/Update baseline; none for in-place, mirroring `WritePatch` vs `WriteInPlace`), and the guard asserts the preview equals the real write's lean header.
- `full_readback=true` dumps the full in-memory would-be records, labeled as in-memory (never implying a file exists).

## Lane specifics

- **Fresh patch**: the would-be output path is resolved **without creating the mod folder** (`ResolveOutputPath` gains `create:false`) — zero disk side effects; the response notes the auto-suffix is a preview.
- **`into=`**: the existing patch is opened read-only-in-effect (mutated in memory only); guard asserts the on-disk file stays byte-identical.
- **`in_place`** — one deliberate design call, flagged for review: a dry run **bypasses the first-touch consent handshake and never records an acknowledgement**. Rationale: consent gates *touching your original*; a dry run touches nothing, and persisting consent from a call that wrote nothing would silently arm a future real write. The pending consent is surfaced as a **note** ("the REAL write's first touch will show the one-time confirmation"), and the guard asserts a real write afterwards still prompts. The `editedInPlace` marker and `.seq` staleness note are likewise not stamped.

## Guard

New `dry-run-guard` (25 asserts, registered in ci-all → **99/99**): nothing-written across all three lanes (mods-dir snapshot / byte-identical files), refusal parity, prediction parity (path / After value / masters vs the subsequent real write), the pre-empted missing-master failure (real failure empirically reproduced), read-only consent axis, contract refusals unchanged, and render honesty (leads with "DRY RUN — NOTHING was written", never "wrote").

## Out of scope

`create_record` / `bulk_create` / `remove_record` don't get dry_run here — the issue names the three tools above; extending it is mechanical if wanted later. #224 (`bulk_apply from_file=`) is next and inherits this flag by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
