### PR TITLE
feat(write): bulk_apply from_file= ops manifest (#224)

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,18 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**`housecarl_bulk_apply` learns manifest files — `from_file=` (#224).** A big write job used to mean pasting the
+whole ops array inline (the 745-record stress test generated 20 local `ops_*.json` chunk files and fed them through
+piecewise). Now `from_file=<absolute path>` reads the SAME operations array as a JSON manifest on disk: generate
+the manifest once, validate the **whole file** with `dry_run=true` before the first write, apply it in one call —
+and re-run the same manifest to recover an interrupted write (overrides are idempotent). The parsed ops ride the
+identical pipeline as inline ones (every lane and `dry_run` compose by construction; the dry-run report is
+string-identical to the same ops inline). The file contract is all named refusals (Q3): `operations` XOR
+`from_file`, absolute path required, invalid JSON named with line+column, a non-array root, an empty array, and —
+stricter than inline binding, which silently drops unknown members — a misspelled op member (`feild_path`) is
+refused **by name at its element** instead of becoming a null-field op whose downstream error points away from the
+typo.
+
 **Dry-run mode for the write tools (#225).** `housecarl_set_field`, `housecarl_bulk_apply`, and
 `housecarl_forward_record` gain `dry_run=true`: the **full real write pipeline** runs — winner resolve, schema
 pre-flight, every op applied to the in-memory would-be plugin, a reference-resolution check that pre-empts the

--- a/src/housecarl-generator/BindingShimProbe.cs
+++ b/src/housecarl-generator/BindingShimProbe.cs
@@ -130,6 +130,17 @@ public static class BindingShimProbe
                 !d.text.Contains(GenericError) && d.text.Contains("required parameter") && d.text.Contains("formids"),
                 d.Describe());
 
+            // -- D2: #224 — bulk_apply's 'operations' moved OFF the schema's required list (operations XOR
+            //    from_file is judged in the tool BODY; dry-run-guard arm L proves that refusal named). Through the
+            //    full binding/shim stack an empty {} must still BIND cleanly — no required check fires, no binder
+            //    throw on the absent complex array — and reach the tool body (the config prompt here, since this
+            //    server is unconfigured and the body's config check runs first), never the generic error. RED if
+            //    optionalizing the parameter ever breaks {} binding (PR #241 review NOTE 4).
+            var d2 = Call(stdin, stdout, 38, "housecarl_bulk_apply", "{}");
+            failures += Check("D2 #224: bulk_apply {} binds with no required refusal and reaches the tool body",
+                !d2.text.Contains(GenericError) && !d2.text.Contains("required parameter") && d2.text.Contains(ConfigPrompt),
+                d2.Describe());
+
             // -- E: quoted number — same obvious-intent class as B. Must bind and run.
             var e = Call(stdin, stdout, 6, "housecarl_cross_plugin_query",
                 """{"type":"CELL","plugins":["Synthetic.esp"],"limit":"100"}""");

--- a/src/housecarl-generator/DryRunProbe.cs
+++ b/src/housecarl-generator/DryRunProbe.cs
@@ -300,6 +300,9 @@ internal static class DryRunProbe
                 var emptyInline = WriteTools.BulkApply(svc, operations: Array.Empty<BulkOp>());
                 Check(emptyInline.StartsWith("error:") && emptyInline.Contains("operations is empty"),
                     "an explicit empty INLINE array keeps its existing refusal");
+                var blank = WriteTools.BulkApply(svc, from_file: "   ");
+                Check(blank.StartsWith("error:") && blank.Contains("from_file is empty"),
+                    $"an explicit blank from_file refuses NAMED, never silently reinterpreted as absent  [{Snip(blank)}]");
                 var rel = WriteTools.BulkApply(svc, from_file: "ops.json");
                 Check(rel.StartsWith("error:") && rel.Contains("ABSOLUTE"), $"a relative path refuses  [{Snip(rel)}]");
                 var unreadable = WriteTools.BulkApply(svc, from_file: Path.Combine(root, "no-such-manifest.json"));

--- a/src/housecarl-generator/DryRunProbe.cs
+++ b/src/housecarl-generator/DryRunProbe.cs
@@ -35,6 +35,12 @@ namespace HousecarlGenerator;
 ///                         never the opaque bare NRE; the real call refuses too (arm I). RED if either lies.
 ///   FORWARD IN-PLACE    — the consent-bypass logic is DUPLICATED in ForwardRecordsInPlace; arm K guards that copy
 ///                         (arm F guards the ApplyEdits copy), so an edit to either alone goes RED.
+///   FROM_FILE PARITY    — a bulk_apply ops manifest (#224 from_file=) parses to the SAME BulkOp[] and rides the
+///                         SAME ApplyEdits call as inline ops: manifest + dry_run renders IDENTICALLY to the same
+///                         ops inline (the issue's stated pairing needs zero extra code — arm L proves it), a real
+///                         manifest write lands, and the file contract (operations XOR from_file, absolute path,
+///                         readable, valid JSON with line+column on failure, array root, non-empty, no unknown op
+///                         members) refuses NAMED with nothing written. RED on any divergence or silent drop.
 ///
 /// Self-contained: synthesizes a master + a user override in a synthetic MO2 instance in TEMP (the WriteMutexProbe
 /// pattern — the full SERVICE path runs: ResolveOutputPath, the write gate, the in-place consent store) and generates
@@ -264,6 +270,65 @@ internal static class DryRunProbe
                     target: "HcDryUser.esp", inPlace: true);
                 Check(real.NeedsAcknowledge,
                     "a REAL in-place forward afterwards still shows the first-touch prompt (no dry run recorded consent)");
+            }
+
+            // ---- L: #224 from_file ops manifest — the SAME pipeline as inline ops, file contract refuses named ----
+            Console.WriteLine("--- L: bulk_apply from_file manifest (#224) ---");
+            {
+                string ManifestFile(string name, string content)
+                {
+                    var p = Path.Combine(root, name);
+                    File.WriteAllText(p, content);
+                    return p;
+                }
+                string manifest = ManifestFile("ops-manifest.json",
+                    $"[{{\"formid\": \"{fid}\", \"field_path\": \"BasicStats.Damage\", \"verb\": \"Set\", \"value\": \"73\"}}]");
+
+                // parity — the issue's stated pairing: manifest + dry_run reports IDENTICALLY to the same ops inline
+                var before = ModFolders();
+                var dryFile = WriteTools.BulkApply(svc, from_file: manifest, patch_name: "DryL", dry_run: true);
+                var dryInline = WriteTools.BulkApply(svc, operations: new[] { DamageOp(fid, 73) }, patch_name: "DryL", dry_run: true);
+                Check(dryFile == dryInline, "manifest + dry_run renders IDENTICALLY to the same ops inline (same ApplyEdits by construction)");
+                Check(dryFile.Contains("DRY RUN") && before.SequenceEqual(ModFolders()), "the manifest dry run wrote nothing");
+
+                // contract refusals — each named, nothing written
+                var both = WriteTools.BulkApply(svc, operations: new[] { DamageOp(fid, 1) }, from_file: manifest);
+                var neither = WriteTools.BulkApply(svc);
+                Check(both.StartsWith("error:") && both.Contains("mutually exclusive")
+                   && neither.StartsWith("error:") && neither.Contains("operations") && neither.Contains("from_file"),
+                    $"operations XOR from_file (both and neither refuse named)  [{Snip(neither)}]");
+                var emptyInline = WriteTools.BulkApply(svc, operations: Array.Empty<BulkOp>());
+                Check(emptyInline.StartsWith("error:") && emptyInline.Contains("operations is empty"),
+                    "an explicit empty INLINE array keeps its existing refusal");
+                var rel = WriteTools.BulkApply(svc, from_file: "ops.json");
+                Check(rel.StartsWith("error:") && rel.Contains("ABSOLUTE"), $"a relative path refuses  [{Snip(rel)}]");
+                var unreadable = WriteTools.BulkApply(svc, from_file: Path.Combine(root, "no-such-manifest.json"));
+                Check(unreadable.StartsWith("error:") && unreadable.Contains("could not read") && unreadable.Contains("no-such-manifest.json"),
+                    "an unreadable file refuses naming the path");
+                var badJson = WriteTools.BulkApply(svc, from_file: ManifestFile("bad.json", "[{\"formid\": }]"));
+                Check(badJson.StartsWith("error:") && badJson.Contains("bad.json") && badJson.Contains("line "),
+                    $"invalid JSON refuses naming the file + position  [{Snip(badJson)}]");
+                var objRoot = WriteTools.BulkApply(svc, from_file: ManifestFile("obj.json", "{\"operations\": []}"));
+                Check(objRoot.StartsWith("error:") && objRoot.Contains("JSON ARRAY"),
+                    $"a non-array root refuses naming the expected shape  [{Snip(objRoot)}]");
+                var emptyArr = WriteTools.BulkApply(svc, from_file: ManifestFile("empty.json", "[]"));
+                Check(emptyArr.StartsWith("error:") && emptyArr.Contains("empty array") && emptyArr.Contains("empty.json"),
+                    "an empty manifest array refuses like empty operations, naming the file");
+                var nullEl = WriteTools.BulkApply(svc, from_file: ManifestFile("nullel.json",
+                    $"[null, {{\"formid\": \"{fid}\", \"field_path\": \"BasicStats.Damage\", \"value\": \"1\"}}]"));
+                Check(nullEl.StartsWith("error:") && nullEl.Contains("[0]"),
+                    $"a null element refuses naming its index  [{Snip(nullEl)}]");
+                var typo = WriteTools.BulkApply(svc, from_file: ManifestFile("typo.json",
+                    $"[{{\"formid\": \"{fid}\", \"feild_path\": \"BasicStats.Damage\", \"value\": \"5\"}}]"));
+                Check(typo.StartsWith("error:") && typo.Contains("feild_path"),
+                    $"a misspelled op member refuses BY NAME (never the inline binder's silent drop)  [{Snip(typo)}]");
+                Check(before.SequenceEqual(ModFolders()), "none of the refusals left anything behind");
+
+                // the real write from the manifest lands
+                var real = WriteTools.BulkApply(svc, from_file: manifest, patch_name: "DryL");
+                Check(!real.StartsWith("error:") && real.Contains("wrote DryL.esp")
+                   && ModFolders().Except(before).Any(f => f.Contains("DryL")),
+                    $"a real manifest write lands (a new DryL mod folder + the wrote confirmation)  [{Snip(real)}]");
             }
 
             Console.WriteLine();

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using ModelContextProtocol.Server;
 using HousecarlCore;
@@ -97,11 +98,16 @@ public static class WriteTools
          "didn't make), not a patch — pass target=<plugin filename> + in_place=true (opt-in; the default lane leaves originals " +
          "untouched). dry_run=true validates the WHOLE batch through the real pipeline and reports what WOULD change " +
          "without writing anything — the way to catch a bad field path before the first write of a big batch, not after " +
-         "the last. Returns the patch path, masters, and per-op read-back.")]
+         "the last. The ops can come from a FILE instead of inline: from_file=<absolute path> reads the SAME operations " +
+         "array as a JSON manifest on disk — write a big job's ops once, dry-run the file, then apply it, and re-run the " +
+         "same manifest to recover an interrupted write (overrides are idempotent). Returns the patch path, masters, and " +
+         "per-op read-back.")]
     public static string BulkApply(
         LoadOrderService svc,
-        [Description("The edits to apply, all into one patch. Each: {formid, field_path, verb, value?, key?, values?, entries?, compose?}.")]
-            BulkOp[] operations,
+        [Description("The edits to apply, all into one patch. Each: {formid, field_path, verb, value?, key?, values?, entries?, compose?}. Pass this INLINE array or from_file= — exactly one of the two.")]
+            BulkOp[]? operations = null,
+        [Description("Optional. ABSOLUTE path to a JSON manifest FILE holding the operations array — the SAME shape as operations=, just read from disk: [{formid, field_path, verb, ...}, ...]. The big-batch lane: generate the manifest once, validate the WHOLE file with dry_run=true before the first write, then apply it in one call (and re-run the SAME file to recover an interrupted write). Mutually exclusive with operations= (pass exactly one). The path must be ABSOLUTE (the server resolves relative paths against its OWN working directory, not yours). Refused NAMED with nothing written (Q3) if the file is unreadable, not valid JSON (the refusal carries line+column), not a top-level array, an empty array, or any op carries a member the shape doesn't declare (a misspelled 'field_path' is named at its element, never silently dropped).")]
+            string? from_file = null,
         [Description("Optional. Base filename for the new patch (default 'Patch'); auto-suffixed if taken. Ignored if into= is given.")]
             string patch_name = "Patch",
         [Description("Optional. Filename of an existing patch to EXTEND with these edits instead of writing a fresh one (accumulate across calls/sessions). Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead (folder & plugin names need not match).")]
@@ -120,10 +126,76 @@ public static class WriteTools
             bool dry_run = false) => Guard.Tool("housecarl_bulk_apply", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-        if (operations is null || operations.Length == 0)
+        bool hasInline = operations is not null;
+        bool hasFile = !string.IsNullOrWhiteSpace(from_file);
+        if (hasInline && hasFile)
+            return "error: operations and from_file are mutually exclusive — pass the ops INLINE or name a manifest FILE, not both.";
+        if (!hasInline && !hasFile)
+            return "error: no operations given. Pass operations=[{formid, field_path, verb, ...}, ...] inline, or from_file='<absolute path>' naming a JSON manifest file holding that same array.";
+        if (hasFile)
+        {
+            var (fileOps, err) = ReadOpsManifest(from_file!);
+            if (err is not null) return "error: " + err;
+            operations = fileOps;
+        }
+        else if (operations!.Length == 0)
             return "error: operations is empty. Pass one or more {formid, field_path, verb, ...} edits.";
-        return Render(svc.ApplyEdits(operations, patch_name, into, full_readback, target, in_place, acknowledge, dry_run), max_chars, full_readback);
+        return Render(svc.ApplyEdits(operations!, patch_name, into, full_readback, target, in_place, acknowledge, dry_run), max_chars, full_readback);
     });
+
+    /// <summary>Read + parse a <c>from_file=</c> ops manifest (#224): an ABSOLUTE path to a JSON array of the SAME
+    /// <see cref="BulkOp"/> wire shape as inline <c>operations=</c> — the parsed ops then ride the identical
+    /// <see cref="LoadOrderService.ApplyEdits"/> call, so every lane (fresh patch / into= / in_place) and
+    /// <c>dry_run=</c> compose with a manifest by construction. The file contract mirrors #226's <c>@file</c>
+    /// formid list (FieldPredicate.ParseFormIdList): absolute path required (the server's working directory is not
+    /// the caller's), and every failure names itself (Q3) — unreadable, invalid JSON (with line+column), a
+    /// non-array root, an empty array, a null element, or an op member the wire shape does not declare. That last
+    /// one is DELIBERATELY stricter than inline binding (the SDK binder silently DROPS an unknown member): in a
+    /// hand-generated 700-op manifest a misspelled <c>field_path</c> would otherwise become a null-field op whose
+    /// downstream refusal points away from the typo — the file lane refuses it BY NAME at its element instead.</summary>
+    static (BulkOp[]?, string?) ReadOpsManifest(string fromFile)
+    {
+        var path = fromFile.Trim().Trim('"', '\'');
+        if (path.Length == 0)
+            return (null, "from_file is empty — give the ops manifest's absolute path.");
+        if (!Path.IsPathRooted(path))
+            return (null, $"from_file '{path}' must be an ABSOLUTE path — the server resolves relative paths against its OWN working directory, not yours.");
+        string text;
+        try { text = File.ReadAllText(path); }
+        catch (Exception ex) { return (null, $"could not read ops manifest '{path}' — {ex.GetType().Name}: {ex.Message}"); }
+        if (string.IsNullOrWhiteSpace(text))
+            return (null, $"ops manifest '{path}' is empty. Expected a JSON array of operations, each the same shape as an inline operations= element ({{formid, field_path, verb, ...}}).");
+
+        BulkOp[]? ops;
+        try { ops = JsonSerializer.Deserialize<BulkOp[]>(text, ManifestJson); }
+        catch (JsonException ex)
+        {
+            string at = ex.LineNumber is { } ln ? $" at line {ln + 1}, column {(ex.BytePositionInLine ?? 0) + 1}" : "";
+            string element = ex.Path is { Length: > 2 } p ? $" (element {p})" : "";   // "$[12].foo" — pins the offending op
+            return (null, $"ops manifest '{path}' could not be parsed{at}{element}: {Guard.Flatten(ex.Message)} " +
+                          "Expected a top-level JSON ARRAY of operations, each the same shape as an inline operations= element " +
+                          "({formid, field_path, verb, value?, key?, values?, entries?, compose?, composes?, from_plugin?}).");
+        }
+        if (ops is null)
+            return (null, $"ops manifest '{path}' parsed to JSON null — expected a JSON array of operations.");
+        if (ops.Length == 0)
+            return (null, $"ops manifest '{path}' is an empty array — give at least one {{formid, field_path, verb, ...}} edit.");
+        for (int i = 0; i < ops.Length; i++)
+            if (ops[i] is null)
+                return (null, $"ops manifest '{path}': element [{i}] is null — every element must be an operation object.");
+        return (ops, null);
+    }
+
+    /// <summary>Manifest parse options: property names case-insensitive like the SDK's inline binder (Web defaults),
+    /// comments + trailing commas tolerated (hand-generated files), and an unknown member REFUSED by name — the
+    /// deliberate strictness documented on <see cref="ReadOpsManifest"/>.</summary>
+    static readonly JsonSerializerOptions ManifestJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+    };
 
     [McpServerTool(Name = "housecarl_remove_record", Title = "Remove a whole record from a patch (or a plugin in place)"),
      Description(

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -106,7 +106,7 @@ public static class WriteTools
         LoadOrderService svc,
         [Description("The edits to apply, all into one patch. Each: {formid, field_path, verb, value?, key?, values?, entries?, compose?}. Pass this INLINE array or from_file= — exactly one of the two.")]
             BulkOp[]? operations = null,
-        [Description("Optional. ABSOLUTE path to a JSON manifest FILE holding the operations array — the SAME shape as operations=, just read from disk: [{formid, field_path, verb, ...}, ...]. The big-batch lane: generate the manifest once, validate the WHOLE file with dry_run=true before the first write, then apply it in one call (and re-run the SAME file to recover an interrupted write). Mutually exclusive with operations= (pass exactly one). The path must be ABSOLUTE (the server resolves relative paths against its OWN working directory, not yours). Refused NAMED with nothing written (Q3) if the file is unreadable, not valid JSON (the refusal carries line+column), not a top-level array, an empty array, or any op carries a member the shape doesn't declare (a misspelled 'field_path' is named at its element, never silently dropped).")]
+        [Description("Optional. ABSOLUTE path to a JSON manifest FILE holding the operations array — the SAME shape as operations=, just read from disk: [{formid, field_path, verb, ...}, ...]. The big-batch lane: generate the manifest once, validate the WHOLE file with dry_run=true before the first write, then apply it in one call (and re-run the SAME file to recover an interrupted write). Mutually exclusive with operations= (pass exactly one). The path must be ABSOLUTE (the server resolves relative paths against its OWN working directory, not yours). The file is read at CALL time — a dry run validates the manifest as it is NOW, so if you edit the file afterwards, dry-run it again before the real write. Refused NAMED with nothing written (Q3) if the file is unreadable, not valid JSON (the refusal carries the line + position), not a top-level array, an empty array, or any op carries a member the shape doesn't declare (a misspelled 'field_path' is named at its element, never silently dropped).")]
             string? from_file = null,
         [Description("Optional. Base filename for the new patch (default 'Patch'); auto-suffixed if taken. Ignored if into= is given.")]
             string patch_name = "Patch",
@@ -127,7 +127,10 @@ public static class WriteTools
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         bool hasInline = operations is not null;
-        bool hasFile = !string.IsNullOrWhiteSpace(from_file);
+        // Presence, not content: an explicit blank from_file must reach ReadOpsManifest's named "from_file is
+        // empty" refusal, never be silently reinterpreted as absent (PR #241 review LOW 2 — a silently-dropped
+        // argument is the Q3 class the binding shim's UnknownParameters exists to name).
+        bool hasFile = from_file is not null;
         if (hasInline && hasFile)
             return "error: operations and from_file are mutually exclusive — pass the ops INLINE or name a manifest FILE, not both.";
         if (!hasInline && !hasFile)
@@ -170,9 +173,11 @@ public static class WriteTools
         try { ops = JsonSerializer.Deserialize<BulkOp[]>(text, ManifestJson); }
         catch (JsonException ex)
         {
-            string at = ex.LineNumber is { } ln ? $" at line {ln + 1}, column {(ex.BytePositionInLine ?? 0) + 1}" : "";
+            // "byte N in the line", not "column": BytePositionInLine is a UTF-8 byte offset, which skews from the
+            // visual column on a non-ASCII line (a plugin filename with é) — name what it really is (review LOW 1).
+            string at = ex.LineNumber is { } ln ? $" at line {ln + 1}, byte {(ex.BytePositionInLine ?? 0) + 1} in the line" : "";
             string element = ex.Path is { Length: > 2 } p ? $" (element {p})" : "";   // "$[12].foo" — pins the offending op
-            return (null, $"ops manifest '{path}' could not be parsed{at}{element}: {Guard.Flatten(ex.Message)} " +
+            return (null, $"ops manifest '{path}' could not be parsed{at}{element}: {ShearStjPosition(Guard.Flatten(ex.Message))} " +
                           "Expected a top-level JSON ARRAY of operations, each the same shape as an inline operations= element " +
                           "({formid, field_path, verb, value?, key?, values?, entries?, compose?, composes?, from_plugin?}).");
         }
@@ -184,6 +189,15 @@ public static class WriteTools
             if (ops[i] is null)
                 return (null, $"ops manifest '{path}': element [{i}] is null — every element must be an operation object.");
         return (ops, null);
+    }
+
+    /// <summary>STJ appends its own position block (" Path: $[0].x | LineNumber: 0 | BytePositionInLine: 89.") to a
+    /// JsonException message — 0-based, so it CONTRADICTS the 1-based position the refusal already leads with (PR
+    /// #241 review LOW 1). Shear it; the element path it carried is surfaced separately via <c>ex.Path</c>.</summary>
+    static string ShearStjPosition(string msg)
+    {
+        int i = msg.IndexOf(" Path: ", StringComparison.Ordinal);
+        return i < 0 ? msg : msg[..i].TrimEnd();
     }
 
     /// <summary>Manifest parse options: property names case-insensitive like the SDK's inline binder (Web defaults),


### PR DESCRIPTION
Fixes #224 — the sixth and last report of the 2026-07-17 Apocalypse stress-test DX batch (#221–#226).

## What

`housecarl_bulk_apply` gains **`from_file=<absolute path>`**: read the operations array from a JSON manifest file on disk instead of pasting it inline. The manifest is the SAME `BulkOp` wire shape as `operations=` (`[{formid, field_path, verb, value?, key?, values?, entries?, compose?, composes?, from_plugin?}, ...]`), and the parsed ops ride the **identical `ApplyEdits` call** — so every lane (fresh patch / `into=` / `in_place`) and `dry_run=` compose with a manifest **by construction**. The issue's stated pairing — `from_file= + dry_run=true` to validate a 700-op manifest before the first write — needed zero extra code, and the guard proves it (render parity, string-identical). Re-running the same manifest recovers an interrupted write (idempotent overrides), per the issue.

## The file contract (mirrors #226's `@file` formid list)

All named refusals, nothing written (Q3):

- `operations` XOR `from_file` — both or neither refuses named.
- ABSOLUTE path required (the server's working directory is not the caller's — same wording as `FieldPredicate.ParseFormIdList`).
- Unreadable file → named with the exception; empty file / empty array / JSON-null root / null element → each named (the empty-array refusal names the file).
- Invalid JSON → named with **line + column** and, when inside an element, the **`$[i].member` path** pinning the offending op.

## One decision to ratify (flagged, not silent)

**An unknown op member in the manifest is refused BY NAME — deliberately stricter than inline binding.** The SDK's inline binder silently *drops* an unknown member of a `BulkOp` element; in a hand-generated 700-op manifest a misspelled `feild_path` would then surface as a null-field op whose downstream refusal points away from the typo. The manifest parser uses `JsonUnmappedMemberHandling.Disallow`, so the typo is named at its element instead (`$[12].feild_path`). Property names stay case-insensitive (matching the inline binder's Web defaults) and comments/trailing commas are tolerated. Documented on `ReadOpsManifest` and in the `from_file` param description.

Side effect of the lane: `operations` moves from schema-required to optional (the XOR check names both lanes on an empty call, so `{}` still gets a named refusal, now from the tool body instead of the binding shim).

## Guard

`dry-run-guard` arm L — **13 new asserts (33 → 46)**, each RED-provable:
- manifest + `dry_run` renders **identically** to the same ops inline (the same-pipeline claim);
- a real manifest write lands (new mod folder + wrote-confirmation);
- every contract refusal above fires named with nothing left behind, incl. the misspelled-member refusal and the unchanged empty-INLINE-array message.

Gates: `dotnet build` clean; **ci-all 99/99 ALL PASS** from the worktree root.

## Changelog

`plugin/CHANGELOG.md ## Unreleased` gains the #224 entry (now seven entries pending the next cut: #217, #222, #221, #226, #223, #225, #224).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
