### PR TITLE
fix(read): resolve_names / resolve answer PlayerRef's identity, not "unresolved" (#230)

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,15 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**`resolve_names` / `housecarl_resolve` no longer call PlayerRef "unresolved" (#230).** The engine-implicit forms —
+PlayerRef (`000014:Skyrim.esm`) and the Player base NPC (`000007:Skyrim.esm`) — are hardcoded engine references no
+plugin defines, so the identity resolver flagged every condition or link pointing at them as
+`unresolved: target not in the active order` (67 false suspects in one 67-record audit), while `check_errors`
+correctly called the same links clean. The resolver now applies the same precise two-form exemption the integrity
+sweep and dialogue lints already share: those links annotate `→ PlayerRef` / `→ Player` (winner `<engine>` in a
+`housecarl_resolve` row), and any OTHER sub-0x800 form still reports unresolved — the exemption is the two known
+forms, never the whole reserved range.
+
 **`housecarl_bulk_apply` learns manifest files — `from_file=` (#224).** A big write job used to mean pasting the
 whole ops array inline (the 745-record stress test generated 20 local `ops_*.json` chunk files and fed them through
 piecewise). Now `from_file=<absolute path>` reads the SAME operations array as a JSON manifest on disk: generate

--- a/src/housecarl-core/EngineImplicit.cs
+++ b/src/housecarl-core/EngineImplicit.cs
@@ -8,8 +8,10 @@ namespace HousecarlCore;
 /// reference — the target of HasSpell / actor-value player-state gates and countless script, package, and condition
 /// links) and the Player base NPC_ (a GetIsID Player form param). Any tool that flags "target not in the active load
 /// order" must exempt them or it false-warns on the standard player-state pattern — so the SINGLE source of truth lives
-/// here, shared by BOTH the dialogue condition lints (<see cref="DialogueValidate"/>) and the integrity sweep
-/// (<see cref="ErrorCheck"/>), keeping their exemptions in lockstep.
+/// here, shared by the dialogue condition lints (<see cref="DialogueValidate"/>), the integrity sweep
+/// (<see cref="ErrorCheck"/>), AND the identity resolver behind housecarl_resolve / resolve_names (issue #230 — the
+/// same false positive resurfaced there as "unresolved: target not in the active order"), keeping every exemption in
+/// lockstep. Public because that resolver lives in the MCP server assembly, not this core.
 ///
 /// Evidence: Junti 2026-07-03 — xEdit resolves 000014 as PlayerRef and the gates are proven working in game (the
 /// validate_dialogue manifestation, fixed in PR #139); the identical class then surfaced in check_errors, which
@@ -19,18 +21,29 @@ namespace HousecarlCore;
 /// Scoped to the two the reports prove — a PRECISE set, NOT the whole reserved sub-0x800 range, so a genuinely-typo'd
 /// low FormID still surfaces as a real error. Skyrim.esm is the SSE base master (houseCARL is SSE-only). Extend the set
 /// here if more engine-implicit forms surface — one edit updates every tool.</summary>
-internal static class EngineImplicit
+public static class EngineImplicit
 {
     static readonly ModKey SkyrimBaseMaster = new("Skyrim", ModType.Master);
 
-    /// <summary>The precise engine-implicit reference set (see the type doc). Add a form here — never widen to a range.</summary>
-    static readonly HashSet<FormKey> Forms = new()
+    /// <summary>The precise engine-implicit reference set, each with its known engine identity (Mutagen-style type
+    /// name + the EditorID xEdit reports) so the resolver can answer WHAT the form is, not just that it's exempt
+    /// (see the type doc). Add a form here — never widen to a range.</summary>
+    static readonly Dictionary<FormKey, (string Type, string EditorId)> Forms = new()
     {
-        new FormKey(SkyrimBaseMaster, 0x14),   // PlayerRef — the player's placed reference (a Run On Reference / FormLink target)
-        new FormKey(SkyrimBaseMaster, 0x07),   // Player    — the player base NPC_ (a GetIsID / form-param target)
+        [new FormKey(SkyrimBaseMaster, 0x14)] = ("PlacedNpc", "PlayerRef"),   // PlayerRef — the player's placed reference (a Run On Reference / FormLink target)
+        [new FormKey(SkyrimBaseMaster, 0x07)] = ("Npc", "Player"),            // Player    — the player base NPC_ (a GetIsID / form-param target)
     };
 
     /// <summary>True when <paramref name="fk"/> is one of the engine-implicit <see cref="Forms"/> — a hardcoded engine
     /// reference the index can't resolve, so a reference-resolution check must not mistake it for a dangling reference.</summary>
-    internal static bool IsImplicit(FormKey fk) => Forms.Contains(fk);
+    public static bool IsImplicit(FormKey fk) => Forms.ContainsKey(fk);
+
+    /// <summary>The engine-implicit form's known identity (type + EditorID from <see cref="Forms"/>), for a resolver
+    /// that must report WHAT the hardcoded form is rather than merely skip it. False for every other form — callers
+    /// keep their normal dangling-target path.</summary>
+    public static bool TryDescribe(FormKey fk, out string type, out string editorId)
+    {
+        if (Forms.TryGetValue(fk, out var d)) { (type, editorId) = d; return true; }
+        type = editorId = ""; return false;
+    }
 }

--- a/src/housecarl-generator/BulkPrimitivesWave2Probe.cs
+++ b/src/housecarl-generator/BulkPrimitivesWave2Probe.cs
@@ -20,6 +20,9 @@ namespace HousecarlGenerator;
 ///     display-only (never replaces the round-trip token).
 ///   • HCBR-2026-07-15 <c>batch_record_detail plugin=</c> — bulk-read a NAMED plugin's version (an override, not
 ///     the winner), the batch twin of read_record's plugin=, with a per-item error for a record it doesn't touch.
+///   • #230 — the engine-implicit forms (PlayerRef 000014 / Player 000007) resolve to their hardcoded identity
+///     (winner <c>&lt;engine&gt;</c>), never "unresolved", in BOTH housecarl_resolve rows and resolve_names
+///     annotations; the very next sub-0x800 form (000015) still dangles, proving the exemption stays precise.
 ///
 /// Synthesizes a small on-disk order (a master + a replacer that overrides one NAMED weapon and defines others, with
 /// keyword links) and drives the REAL service layer (<see cref="LoadOrderService"/> via the ForGuard seam) + the
@@ -108,6 +111,19 @@ public static class BulkPrimitivesWave2Probe
             Check("a target repeated in one batch resolves identically (memoised)",
                   dup.Count == 2 && dup[0].EditorId == dup[1].EditorId && dup[0].EditorId == "hcw2KwA");
 
+            // Engine-implicit forms (#230): PlayerRef 000014 / Player 000007 are hardcoded engine references no
+            // plugin defines — the resolver must answer their identity (the same EngineImplicit exemption
+            // check_errors and the dialogue lints apply), while the NEXT sub-0x800 form still dangles (precision).
+            Console.WriteLine();
+            Console.WriteLine("── P3 #230: engine-implicit forms resolve to their hardcoded identity; the exemption stays precise ──");
+            var ei = svc.ResolveRefs(new[] { "000014:Skyrim.esm", "000007:Skyrim.esm", "000015:Skyrim.esm" });
+            Check("PlayerRef (000014:Skyrim.esm) → Resolved, PlacedNpc/PlayerRef, winner <engine> (#230 — was 'unresolved')",
+                  ei[0] is { Resolved: true, Type: "PlacedNpc", EditorId: "PlayerRef", Winner: "<engine>" });
+            Check("Player (000007:Skyrim.esm) → Resolved, Npc/Player, winner <engine>",
+                  ei[1] is { Resolved: true, Type: "Npc", EditorId: "Player", Winner: "<engine>" });
+            Check("a NON-implicit sub-0x800 form (000015:Skyrim.esm) is STILL unresolved — the exemption is the 2-form set, not the reserved range",
+                  ei[2] is { Resolved: false, Error: null });
+
             // ---- tool layer: text render ----
             Console.WriteLine();
             Console.WriteLine("── P3 tool layer: text + json render, bad-format refusal ──");
@@ -176,6 +192,38 @@ public static class BulkPrimitivesWave2Probe
             var tBatch = ReadTools.BatchRecordDetail(svc, new[] { w1Fk.ToString() }, fields: new[] { "Keywords" }, depth: 2,
                 conflict_tree: false, resolve_names: true, max_chars: 0);
             Check("batch_record_detail resolve_names annotates too (shared batch memo)", tBatch.Contains("→ hcw2KwA"));
+
+            // ---- #230 end-to-end: a record LINKING to PlayerRef annotates '→ PlayerRef', not 'unresolved'. ----
+            // Own mini-order, the CheckErrorsProbe PLAYERREF pattern: a stub Skyrim.esm written for the master table
+            // but NOT loaded — so 000014/000015 both fail ResolveWinner and only the EngineImplicit carve-out differs.
+            Console.WriteLine();
+            Console.WriteLine("── P7 #230: resolve_names annotates a PlayerRef link with its identity (the issue's manifestation) ──");
+            {
+                var stubSkyrimPath = Path.Combine(dir, "Skyrim.esm");
+                var eiPluginPath = Path.Combine(dir, "hcw2Player.esp");
+                var stubSkyrim = new SkyrimMod(new ModKey("Skyrim", ModType.Master), SkyrimRelease.SkyrimSE);
+                stubSkyrim.Races.AddNew();   // one throwaway record so the stub is a valid, non-empty master
+                stubSkyrim.BeginWrite.ToPath(stubSkyrimPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+                var eiMod = new SkyrimMod(ModKey.FromNameAndExtension("hcw2Player.esp"), SkyrimRelease.SkyrimSE);
+                var eiW = eiMod.Weapons.AddNew(); eiW.EditorID = "hcw2EiSword";
+                eiW.Keywords = new Noggog.ExtendedList<IFormLinkGetter<IKeywordGetter>>
+                {
+                    new FormLink<IKeywordGetter>(FormKey.Factory("000014:Skyrim.esm")),   // PlayerRef — engine-implicit, must annotate '→ PlayerRef'
+                    new FormLink<IKeywordGetter>(FormKey.Factory("000015:Skyrim.esm")),   // control — must still annotate 'unresolved'
+                };
+                var eiWFk = eiW.FormKey;
+                eiMod.BeginWrite.ToPath(eiPluginPath).WithLoadOrder(new ISkyrimModGetter[] { stubSkyrim }).Write();
+
+                using var eiResolver = LoadOrderResolver.Build(new[] { eiPluginPath });   // Skyrim.esm on disk, NOT loaded
+                var eiSvc = LoadOrderService.ForGuard(eiResolver, new UserConfigStore(Path.Combine(dir, "houseCARL.ei.user.json")));
+                var eiText = ReadTools.ReadRecord(eiSvc, eiWFk.ToString(), plugin: null, fields: new[] { "Keywords" }, depth: 2,
+                    conflict_tree: false, resolve_names: true, max_chars: 0);
+                Check("the PlayerRef link annotates '→ PlayerRef' (#230 — was 'unresolved: target not in the active order')",
+                      eiText.Contains("000014:Skyrim.esm") && eiText.Contains("→ PlayerRef"));
+                Check("the control link (000015) STILL annotates 'unresolved' — the annotation exemption is precise too",
+                      eiText.Contains("000015:Skyrim.esm") && eiText.Contains("unresolved: target not in the active order"));
+            }
 
             // ================= P6 — format="json" (same data as text, valid JSON, accounting in-band) =================
             Console.WriteLine();

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2103,8 +2103,11 @@ public sealed class LoadOrderService : IDisposable
 
     /// <summary>Resolve ONE FormKey to its load-order identity (type/editorid/name/winner) off a captured view + open
     /// session, memoised so a target that recurs across a batch (the SAME keyword on 500 items) resolves once. A
-    /// FormKey not in the order is a NAMED unresolved result (Resolved=false), never dropped or guessed (Q3). Shared
-    /// by housecarl_resolve (P3) and the resolve_names field annotation (P7).</summary>
+    /// FormKey not in the order is a NAMED unresolved result (Resolved=false), never dropped or guessed (Q3) — except
+    /// the engine-implicit forms (PlayerRef 000014 / Player 000007), which the index can't resolve but are real: those
+    /// answer with their hardcoded identity and winner "&lt;engine&gt;", the same precise <see cref="EngineImplicit"/>
+    /// exemption check_errors and the dialogue lints apply (#230). Shared by housecarl_resolve (P3) and the
+    /// resolve_names field annotation (P7).</summary>
     static ResolvedRef ResolveRefOne(LoadOrderResolver.IndexView view, LoadOrderResolver.OverlaySession session,
                                      FormKey fk, Dictionary<FormKey, ResolvedRef> memo)
     {
@@ -2112,7 +2115,9 @@ public sealed class LoadOrderService : IDisposable
         ResolvedRef result;
         var w = view.ResolveWinner(fk);
         if (w is null)
-            result = new ResolvedRef(fk.ToString(), Resolved: false);   // valid FormKey, but no active plugin defines it (a dangling target)
+            result = EngineImplicit.TryDescribe(fk, out var eiType, out var eiEditorId)
+                ? new ResolvedRef(fk.ToString(), Resolved: true, Type: eiType, EditorId: eiEditorId, Winner: "<engine>")   // engine-implicit: hardcoded, real, defined by no plugin
+                : new ResolvedRef(fk.ToString(), Resolved: false);   // valid FormKey, but no active plugin defines it (a dangling target)
         else
         {
             var body = view.GetRecord(session, w.Value.WinnerPlugin, fk);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2035,7 +2035,8 @@ public sealed class LoadOrderService : IDisposable
     /// reference (FormLinks and condition-target FLOIs both emit a bare FormKey token; scalars never do), so this
     /// inherits coverage from the read surface with no per-type wiring. Resolution rides the SAME captured view +
     /// open session the read used, memoised so a keyword that recurs across a whole record (or batch) resolves once.
-    /// An unresolvable target is a NAMED unresolved <see cref="ResolvedRef"/> (Resolved=false), never dropped (Q3).
+    /// An unresolvable target is a NAMED unresolved <see cref="ResolvedRef"/> (Resolved=false), never dropped (Q3) —
+    /// bar the engine-implicit forms, which <see cref="ResolveRefOne"/> answers with their hardcoded identity (#230).
     /// Copy-on-first-write: a record with no form-reference leaves returns the SAME instance.</summary>
     static RecordFields AnnotateLinks(RecordFields rf, LoadOrderResolver.IndexView view,
                                       LoadOrderResolver.OverlaySession session, Dictionary<FormKey, ResolvedRef> memo)

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -36,7 +36,7 @@ public static class ReadTools
             int depth = 1,
         [Description("When true, also return the ordered list of every plugin that touches this record (winner last) and the winner-relative field diff for each.")]
             bool conflict_tree = false,
-        [Description("When true, annotate every FormLink field value with its target's identity (→ editorid \"Name\"), resolved against the load order — so a Keywords/Template/DeathItem token reads as what it points AT, not just a FormID. Display-only: the token itself is unchanged (a write can still reuse it). A target no active plugin defines is marked 'unresolved'.")]
+        [Description("When true, annotate every FormLink field value with its target's identity (→ editorid \"Name\"), resolved against the load order — so a Keywords/Template/DeathItem token reads as what it points AT, not just a FormID. Display-only: the token itself is unchanged (a write can still reuse it). A target no active plugin defines is marked 'unresolved' — except the engine-implicit forms (PlayerRef 000014 / Player 000007), which annotate their hardcoded identity.")]
             bool resolve_names = false,
         [Description("Optional. 'text' (default) or 'json' — a machine-readable {formid,type,editorid,winner,override_depth,source,fields[]} document (field values are the SAME tokens as text). conflict_tree is a text-only diff view.")]
             string? format = null,
@@ -218,7 +218,9 @@ public static class ReadTools
          "every record (fields, override depth, per-record header), this returns one compact identity line (or JSON " +
          "row) per FormID and nothing else — the cheap way to label a list of material/perk/keyword FormIDs. Resolved " +
          "in order; a bad or absent FormID yields a per-item error without failing the batch (never a silent drop — " +
-         "Q3). Winners only (the load-order-effective identity of each target). Deliberately minimal: no fields=, no " +
+         "Q3). Winners only (the load-order-effective identity of each target). The engine-implicit forms (PlayerRef " +
+         "000014:Skyrim.esm / Player 000007:Skyrim.esm) resolve to their hardcoded identity with winner '<engine>' — " +
+         "no plugin defines them, but they are real, never dangling. Deliberately minimal: no fields=, no " +
          "depth, no conflict_tree — for those use housecarl_batch_record_detail. Does NOT modify anything.")]
     public static string Resolve(
         LoadOrderService svc,
@@ -359,7 +361,7 @@ public static class ReadTools
             string? editorid_contains = null,
         [Description("Optional. With type=: max rows to return (default 500). The TRUE total is always reported; over the cap it says 'showing first N'.")]
             int limit = 500,
-        [Description("Optional. With formid=: annotate every FormLink field value with its target's identity (→ editorid \"Name\"), resolved against the ACTIVE load order (the only identity frame — this file may itself be inactive). Display-only; the token is unchanged. A target the active order doesn't define is marked 'unresolved'. Forces the load-order build (opt-in), unlike the default cheap raw read.")]
+        [Description("Optional. With formid=: annotate every FormLink field value with its target's identity (→ editorid \"Name\"), resolved against the ACTIVE load order (the only identity frame — this file may itself be inactive). Display-only; the token is unchanged. A target the active order doesn't define is marked 'unresolved' — except the engine-implicit forms (PlayerRef 000014 / Player 000007), which annotate their hardcoded identity. Forces the load-order build (opt-in), unlike the default cheap raw read.")]
             bool resolve_names = false,
         [Description("Optional. 'text' (default) or 'json' — a machine-readable document (always stamped out_of_load_order:true; the file's masters context, then the record/records/type_counts payload). Field values are the SAME tokens as text.")]
             string? format = null,


### PR DESCRIPTION
## What

`housecarl_resolve` and the `resolve_names=` annotation reported the engine-implicit forms — PlayerRef (`000014:Skyrim.esm`) and the Player base NPC_ (`000007:Skyrim.esm`) — as `unresolved: target not in the active order`, while `housecarl_check_errors` correctly called the same links clean. On the reporting session's 67-record COBJ audit that manufactured 67 false suspects (every `HasSpell` condition with RunOnType=Reference points at PlayerRef).

## Why it happened

The engine-implicit exemption already exists as the shared `EngineImplicit` set in `housecarl-core`, consumed by `ErrorCheck` and `DialogueValidate` — but `ResolveRefOne` in `LoadOrderService.cs` (the shared identity resolver behind both reporting paths) resolved purely via `view.ResolveWinner(fk)`, which returns null for hardcoded engine forms no plugin defines.

## The fix

- **`EngineImplicit`** grows a per-form identity table — `0x14 → (PlacedNpc, PlayerRef)`, `0x07 → (Npc, Player)` — and a `TryDescribe()` beside `IsImplicit()`. The class goes **public**: its consumers now span core and the MCP server assembly, and it remains the single source of truth ("one edit updates every tool").
- **`ResolveRefOne`** consults it on the ResolveWinner-null path: an engine-implicit form answers `Resolved=true` with its hardcoded identity and winner `<engine>` — honest about the fact that no plugin defines it — so annotations render `→ PlayerRef` and a resolve row renders `type=PlacedNpc editorid=PlayerRef winner=<engine>`. Every other absent form keeps the named unresolved result (Q3).
- **Precision preserved**: the exemption is the two proven forms, never the reserved sub-0x800 range — `000015:Skyrim.esm` still reports unresolved.

## Decision surfaced (flagging per convention)

The `winner` column for an engine-implicit row is the sentinel **`<engine>`** (text: `winner=<engine>`; JSON: `"winner": "<engine>"`). Claiming `Skyrim.esm` would be false (the form isn't a record in it); omitting winner entirely would render an empty cell. The angle-bracket form matches the renderer's existing `<none>` vocabulary. Shout if you'd rather have a different sentinel — it's one string.

## Gates

- `bulk-primitives-wave2-guard`: **55 → 60 asserts**, all PASS —
  - P3 arm: both forms resolve with exact identity + `<engine>` winner; `000015` still dangles (precision).
  - P7 end-to-end arm (the issue's manifestation): its own mini-order (stub `Skyrim.esm` on disk, NOT loaded — the `CheckErrorsProbe` PLAYERREF pattern) with a weapon linking `000014` + `000015`; the render annotates `→ PlayerRef` for the first and `unresolved: target not in the active order` for the second.
- ci-all: 99/99 PASS.
- `plugin/CHANGELOG.md` `## Unreleased` entry included.

Fixes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)
