### PR TITLE
feat(nif): mesh_paths batch on housecarl_nif_inspect — one call for a whole facegen sweep

### DIFF
--- a/.claude/skills/facegen-diagnostics/SKILL.md
+++ b/.claude/skills/facegen-diagnostics/SKILL.md
@@ -215,10 +215,11 @@ bulk_place**:
 4. `housecarl_asset_status` each path. Three batch signatures: (i) *every* path resolves to nothing/vanilla
    → ESLify/merge FormID desync (Cause F/G, the "universal" case); (ii) record winner ≠ file winner
    consistently → record-vs-asset desync; (iii) only a subset dark → per-NPC missing/incompatible facegen.
-   For (iii)'s *incompatible* half — a file wins but the face is still wrong — `housecarl_nif_inspect` on a
-   sample of the subset separates "wrong content baked in" (shape names / tint path ≠ record → mode ii) from
-   "genuinely absent" (asset_status already said so), so you don't `bulk_place` a copy that was never the
-   problem.
+   For (iii)'s *incompatible* half — a file wins but the face is still wrong — `housecarl_nif_inspect` with
+   `mesh_paths` = **the whole flagged subset in one call** (it batches like `asset_status`: results in input
+   order, a per-path failure never aborts the rest — no sampling needed) separates "wrong content baked in"
+   (shape names / tint path ≠ record → mode ii) from "genuinely absent" (asset_status already said so), so
+   you don't `bulk_place` a copy that was never the problem.
 5. `housecarl_bulk_place_asset` the correct copies into one fresh reviewable mod.
 
 **Boundary:** houseCARL can batch-detect and batch-relocate/rename existing correct facegen (covers Cause

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -14,8 +14,11 @@ path is simply a batch of one). One call resolves the whole flagged subset — *
 entire batch** instead of one per mesh — with results in input order, `sections=` / `mod=` / `max_chars` applying
 batch-wide, and every per-path failure (ABSENT, bad path, a `mod=` that doesn't provide it, unreadable bytes, a
 parse refusal) reported LOUD on **that** path without aborting the rest (Q3). The batch-level caveats (unreadable
-archives, discovery warnings) render once, first, so a long batch can't truncate them away; an over-cap output is
-cut with the omitted-mesh count named, never silently. The `facegen-diagnostics` batch flow no longer needs to
+archives, discovery warnings) render once, first, so a long batch can't truncate them away — and every ABSENT is
+additionally **hedged at point of use** when the scan behind it was incomplete (`asset_status` parity: a bare
+"absent" is never over-trusted just because the top-of-output alarm scrolled away). An over-cap output is cut with
+the omitted-mesh count named, never silently — and `max_chars` can never starve a single-path call of its core
+answer (the first mesh's resolution/error always renders). The `facegen-diagnostics` batch flow no longer needs to
 sample the flagged subset — inspect all of it in one call.
 
 **`resolve_names` / `housecarl_resolve` no longer call PlayerRef "unresolved" (#230).** The engine-implicit forms —

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,16 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**`housecarl_nif_inspect` goes batch — `mesh_paths` takes one or many (#229).** The last per-file loop in a
+load-order-wide dark-face scan is gone: `mesh_path` is now `mesh_paths`, an `asset_status`-style array (a single
+path is simply a batch of one). One call resolves the whole flagged subset — **one load-order resolution for the
+entire batch** instead of one per mesh — with results in input order, `sections=` / `mod=` / `max_chars` applying
+batch-wide, and every per-path failure (ABSENT, bad path, a `mod=` that doesn't provide it, unreadable bytes, a
+parse refusal) reported LOUD on **that** path without aborting the rest (Q3). The batch-level caveats (unreadable
+archives, discovery warnings) render once, first, so a long batch can't truncate them away; an over-cap output is
+cut with the omitted-mesh count named, never silently. The `facegen-diagnostics` batch flow no longer needs to
+sample the flagged subset — inspect all of it in one call.
+
 **`resolve_names` / `housecarl_resolve` no longer call PlayerRef "unresolved" (#230).** The engine-implicit forms —
 PlayerRef (`000014:Skyrim.esm`) and the Player base NPC (`000007:Skyrim.esm`) — are hardcoded engine references no
 plugin defines, so the identity resolver flagged every condition or link pointing at them as

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -174,6 +174,10 @@ public static class CiAll
         // RED-prove they catch a collateral/no-op write, and every can't-do is a named refusal. Self-contained; the
         // set_path success arm is corpus-gated (nifly's read-only TextureSetRef blocks synthesizing a texture set).
         ("nif-set-guard", NifSetGuardProbe.RunGuard),
+        // nif_inspect batch wire (#229 — mesh_paths array, asset_status parity): input order, per-path error
+        // isolation (one bad path never aborts the batch), batch-level alarms once + first, explicit omitted-mesh
+        // cut notice. Self-contained (constructed results through the real NifWire renderer).
+        ("nif-inspect-batch-guard", NifInspectBatchGuardProbe.RunGuard),
         ("strings-decision-guard", StringsDecisionProbe.RunGuard),
         ("assetlink-write-guard", AssetLinkWriteProbe.RunGuard),
         // The two coercion COMPLETENESS proofs, now CI guards (were manual-only — the coerce-audit blind spot that

--- a/src/housecarl-generator/NifInspectBatchGuardProbe.cs
+++ b/src/housecarl-generator/NifInspectBatchGuardProbe.cs
@@ -5,9 +5,10 @@ using HousecarlMcp;
 namespace HousecarlGenerator;
 
 /// <summary>
-/// nif-inspect batch-wire guard (#229 — mesh_paths array on housecarl_nif_inspect) — locks the four batch contracts
-/// of NifWire.Render over NifInspectBatchData, fully self-contained (constructed per-path results through the REAL
-/// renderer via InternalsVisibleTo — no game data, no MO2 instance, no file I/O).
+/// nif-inspect batch-wire guard (#229 — mesh_paths array on housecarl_nif_inspect; hardened by the PR #243 review) —
+/// locks the six batch contracts of NifWire.Render over NifInspectBatchData, fully self-contained (constructed
+/// per-path results through the REAL renderer via InternalsVisibleTo — no game data, no MO2 instance, no file I/O).
+/// The synthetic mesh model is NifServiceGuardProbe.FakeInspect — ONE builder for both render guards, not a fork.
 ///
 /// Arms:
 ///   1. INPUT ORDER — three results render as three per-mesh blocks in the order passed, never re-sorted.
@@ -19,17 +20,23 @@ namespace HousecarlGenerator;
 ///      3-mesh batch doesn't repeat it 3 times.
 ///   4. EXPLICIT CUT — a max_chars smaller than the batch cuts with the omitted-MESH count named ("N more mesh(es)
 ///      omitted at max_chars=..."), never a silent truncation; the alarms from arm 3 survive the cut.
+///   5. ABSENT HEDGED AT POINT OF USE — an ABSENT result in a batch whose scan was incomplete (BSA read failures /
+///      discovery warnings) carries BOTH per-path hedge lines right under its ABSENT line (asset_status parity —
+///      the top-of-output alarm alone scrolls away in a long batch), and a non-ABSENT error is NOT hedged.
+///   6. FIRST MESH ALWAYS ANSWERS — max_chars never starves a single-path call of its core answer: even when the
+///      alarms alone exhaust the cap, the first mesh's block still renders (and no bogus omitted notice appears).
 ///
 /// Teeth (mutation-RED, verified at authoring): early-return from the render loop on the first Error result →
 /// arm 2 FAILS; move AppendReadFailures inside the per-mesh loop → arm 3 FAILS; drop the omitted-count notice on
-/// the cap break → arm 4 FAILS.
+/// the cap break → arm 4 FAILS; drop the per-path hedge in AppendMesh → arm 5 FAILS; drop the shown &gt; 0 guard on
+/// the cap check → arm 6 FAILS.
 /// </summary>
 internal static class NifInspectBatchGuardProbe
 {
     public static int RunGuard(string[] args)
     {
         Console.WriteLine("================================================================");
-        Console.WriteLine(" nif-inspect batch-wire guard — input order, per-path errors, one-shot alarms, explicit cut");
+        Console.WriteLine(" nif-inspect batch-wire guard — order, isolation, one-shot alarms, explicit cut, ABSENT hedge, first-mesh answer");
         Console.WriteLine("================================================================");
         Console.WriteLine();
         int fail = 0;
@@ -51,9 +58,9 @@ internal static class NifInspectBatchGuardProbe
 
         // Arm 2 — per-path error isolation: B fails ABSENT between two clean reads; both neighbors keep their
         // summaries and B carries its named error.
-        var mixed = Batch(new[] { Ok(PathA, "ShapeA"), NifInspectData.Fail(PathB, "ABSENT — no active mod or BSA provides this mesh path."), Ok(PathC, "ShapeC") });
+        var mixed = Batch(new[] { Ok(PathA, "ShapeA"), Absent(PathB), Ok(PathC, "ShapeC") });
         var o2 = NifWire.Render(mixed, none, noUnknown, BigCap);
-        Check(o2.Contains("ABSENT") && o2.Contains("'ShapeA'") && o2.Contains("'ShapeC'"),
+        Check(o2.Contains("ABSENT") && o2.Contains("'ShapeA0'") && o2.Contains("'ShapeC0'"),
             "2. per-path error: the middle path's ABSENT is loud and both neighbors still render");
         Check(Regex.Matches(o2, Regex.Escape("read from:")).Count == 2,
             "2b. per-path error: exactly the two clean reads carry a 'read from:' resolution");
@@ -76,6 +83,30 @@ internal static class NifInspectBatchGuardProbe
         Check(o4.Contains("could NOT be read"),
             "4b. explicit cut: the batch-level alarm still renders under the cut (alarms-first)");
 
+        // Arm 5 — ABSENT hedged at point of use: with BOTH batch caveats present, the ABSENT result carries both
+        // per-path hedge lines; the neighboring non-ABSENT parse error is NOT hedged (the hedge is ABSENT-specific).
+        var caveated = new NifInspectBatchData(
+            new[] { Absent(PathA), NifInspectData.Fail(PathB, "NiflySharp refused this mesh — not a NIF.") },
+            new[] { "Broken - Textures.bsa (header refused)" }, new[] { "Skyrim.ini not found — base archives unscanned" }, "TestProfile");
+        var o5 = NifWire.Render(caveated, none, noUnknown, BigCap);
+        Check(o5.Contains("the mesh could live in the unreadable archive") && o5.Contains("BSAs that weren't enumerated"),
+            "5. ABSENT hedge: both per-path hedge lines render under the ABSENT (read-failure + discovery)");
+        Check(o5.IndexOf("ABSENT", StringComparison.Ordinal) < o5.IndexOf("could live in the unreadable archive", StringComparison.Ordinal),
+            "5b. ABSENT hedge: the hedge sits at POINT OF USE (under the ABSENT line, not only in the top alarm)");
+        Check(Regex.Matches(o5, Regex.Escape("may be incomplete")).Count == 2,
+            "5c. ABSENT hedge: the non-ABSENT error is NOT hedged (exactly one hedged path, two hedge lines)");
+
+        // Arm 6 — first mesh always answers: a cap smaller than the header+alarms still renders the sole mesh's
+        // core block (resolution line), and no omitted notice fires for a fully-rendered batch.
+        var soloAlarmed = new NifInspectBatchData(
+            new[] { Ok(PathA, "ShapeA") },
+            new[] { "Broken - Textures.bsa (header refused)" }, Array.Empty<string>(), "TestProfile");
+        var o6 = NifWire.Render(soloAlarmed, none, noUnknown, 50);
+        Check(o6.Contains("read from:") && o6.Contains(PathA),
+            "6. first-mesh answer: a tiny max_chars cannot starve a single-path call of its resolution");
+        Check(!o6.Contains("more mesh(es) omitted"),
+            "6b. first-mesh answer: no bogus omitted notice when every mesh rendered");
+
         Console.WriteLine();
         Console.WriteLine(fail == 0 ? "ALL PASS" : $"{fail} FAILED");
         return fail;
@@ -85,16 +116,14 @@ internal static class NifInspectBatchGuardProbe
     static NifInspectBatchData Batch(IReadOnlyList<NifInspectData> results)
         => new(results, Array.Empty<string>(), Array.Empty<string>(), "TestProfile");
 
-    /// <summary>A clean per-path result: one loose provider, a minimal 2-block SE mesh with one named shape.</summary>
-    static NifInspectData Ok(string rel, string shapeName)
-        => new(rel, new NifProvider("ModA", "loose"), new[] { new NifProvider("ModA", "loose") }, false, false, Mesh(shapeName), null);
+    /// <summary>A clean per-path result: one loose provider, a minimal 1-shape SE mesh named
+    /// <paramref name="shapePrefix"/>0 (via the shared NifServiceGuardProbe.FakeInspect builder).</summary>
+    static NifInspectData Ok(string rel, string shapePrefix)
+        => new(rel, new NifProvider("ModA", "loose"), new[] { new NifProvider("ModA", "loose") }, false, false,
+            NifServiceGuardProbe.FakeInspect(1, 0, false, Array.Empty<string>(), namePrefix: shapePrefix), null);
 
-    /// <summary>A minimal, valid-shaped SE inspect model — enough for the summary renderer (version line, block
-    /// census, shape-name list, node count).</summary>
-    static NifInspect Mesh(string shapeName) => new(
-        "20.2.0.7", 12, 100, true, 2,
-        new[] { new NifBlockTypeCount("NiNode", 1), new NifBlockTypeCount("BSTriShape", 1) },
-        false, Array.Empty<string>(),
-        new[] { new NifShape(shapeName, 0, 1f, "BSTriShape", null, null, Array.Empty<NifPartition>(), null, Array.Empty<NifTexture>(), Array.Empty<string>()) },
-        Array.Empty<NifNode>(), Array.Empty<string>());
+    /// <summary>An ABSENT per-path result — the no-provider outcome the renderer hedges at point of use.</summary>
+    static NifInspectData Absent(string rel)
+        => new(rel, null, Array.Empty<NifProvider>(), false, Absent: true, null,
+            "ABSENT — no active mod or BSA provides this mesh path.");
 }

--- a/src/housecarl-generator/NifInspectBatchGuardProbe.cs
+++ b/src/housecarl-generator/NifInspectBatchGuardProbe.cs
@@ -1,0 +1,100 @@
+using System.Text.RegularExpressions;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// nif-inspect batch-wire guard (#229 — mesh_paths array on housecarl_nif_inspect) — locks the four batch contracts
+/// of NifWire.Render over NifInspectBatchData, fully self-contained (constructed per-path results through the REAL
+/// renderer via InternalsVisibleTo — no game data, no MO2 instance, no file I/O).
+///
+/// Arms:
+///   1. INPUT ORDER — three results render as three per-mesh blocks in the order passed, never re-sorted.
+///   2. PER-PATH ERROR ISOLATION — a failing path in the middle of the batch renders ITS named error line while
+///      both neighbors still render their full summaries (a batch is never aborted by one bad path — Q3 per-path
+///      loudness, batch-level resilience).
+///   3. BATCH ALARMS ONCE, FIRST — the BSA read-failure alarm (batch-level: one asset capture pins every path)
+///      renders exactly once, BEFORE the first per-mesh block, so a long batch can't truncate it away and a
+///      3-mesh batch doesn't repeat it 3 times.
+///   4. EXPLICIT CUT — a max_chars smaller than the batch cuts with the omitted-MESH count named ("N more mesh(es)
+///      omitted at max_chars=..."), never a silent truncation; the alarms from arm 3 survive the cut.
+///
+/// Teeth (mutation-RED, verified at authoring): early-return from the render loop on the first Error result →
+/// arm 2 FAILS; move AppendReadFailures inside the per-mesh loop → arm 3 FAILS; drop the omitted-count notice on
+/// the cap break → arm 4 FAILS.
+/// </summary>
+internal static class NifInspectBatchGuardProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" nif-inspect batch-wire guard — input order, per-path errors, one-shot alarms, explicit cut");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        var none = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var noUnknown = Array.Empty<string>();
+        const int BigCap = 80_000;
+
+        const string PathA = "meshes\\a\\first.nif";
+        const string PathB = "meshes\\b\\second.nif";
+        const string PathC = "meshes\\c\\third.nif";
+
+        // Arm 1 — input order: three OK results must appear as blocks in the order passed.
+        var ordered = Batch(new[] { Ok(PathA, "ShapeA"), Ok(PathB, "ShapeB"), Ok(PathC, "ShapeC") });
+        var o1 = NifWire.Render(ordered, none, noUnknown, BigCap);
+        int ia = o1.IndexOf(PathA, StringComparison.Ordinal), ib = o1.IndexOf(PathB, StringComparison.Ordinal), ic = o1.IndexOf(PathC, StringComparison.Ordinal);
+        Check(ia >= 0 && ib > ia && ic > ib, "1. input order: three meshes render in the order passed");
+
+        // Arm 2 — per-path error isolation: B fails ABSENT between two clean reads; both neighbors keep their
+        // summaries and B carries its named error.
+        var mixed = Batch(new[] { Ok(PathA, "ShapeA"), NifInspectData.Fail(PathB, "ABSENT — no active mod or BSA provides this mesh path."), Ok(PathC, "ShapeC") });
+        var o2 = NifWire.Render(mixed, none, noUnknown, BigCap);
+        Check(o2.Contains("ABSENT") && o2.Contains("'ShapeA'") && o2.Contains("'ShapeC'"),
+            "2. per-path error: the middle path's ABSENT is loud and both neighbors still render");
+        Check(Regex.Matches(o2, Regex.Escape("read from:")).Count == 2,
+            "2b. per-path error: exactly the two clean reads carry a 'read from:' resolution");
+
+        // Arm 3 — batch alarms once, before the per-mesh blocks.
+        var alarmed = new NifInspectBatchData(
+            new[] { Ok(PathA, "ShapeA"), Ok(PathB, "ShapeB"), Ok(PathC, "ShapeC") },
+            new[] { "Broken - Textures.bsa (header refused)" }, Array.Empty<string>(), "TestProfile");
+        var o3 = NifWire.Render(alarmed, none, noUnknown, BigCap);
+        Check(Regex.Matches(o3, Regex.Escape("could NOT be read")).Count == 1,
+            "3. batch alarms: the BSA read-failure alarm renders exactly once for a 3-mesh batch");
+        Check(o3.IndexOf("could NOT be read", StringComparison.Ordinal) < o3.IndexOf(PathA, StringComparison.Ordinal),
+            "3b. batch alarms: the alarm renders BEFORE the first per-mesh block");
+
+        // Arm 4 — explicit cut: a cap the header + alarm + first mesh exhausts must name the omitted-mesh count
+        // (and the arm-3 alarm, rendered first, must survive the cut).
+        var o4 = NifWire.Render(alarmed, none, noUnknown, 400);
+        Check(o4.Contains("more mesh(es) omitted at max_chars=400"),
+            "4. explicit cut: a small max_chars names the omitted-mesh count, never a silent truncation");
+        Check(o4.Contains("could NOT be read"),
+            "4b. explicit cut: the batch-level alarm still renders under the cut (alarms-first)");
+
+        Console.WriteLine();
+        Console.WriteLine(fail == 0 ? "ALL PASS" : $"{fail} FAILED");
+        return fail;
+    }
+
+    /// <summary>A batch with no batch-level alarms.</summary>
+    static NifInspectBatchData Batch(IReadOnlyList<NifInspectData> results)
+        => new(results, Array.Empty<string>(), Array.Empty<string>(), "TestProfile");
+
+    /// <summary>A clean per-path result: one loose provider, a minimal 2-block SE mesh with one named shape.</summary>
+    static NifInspectData Ok(string rel, string shapeName)
+        => new(rel, new NifProvider("ModA", "loose"), new[] { new NifProvider("ModA", "loose") }, false, false, Mesh(shapeName), null);
+
+    /// <summary>A minimal, valid-shaped SE inspect model — enough for the summary renderer (version line, block
+    /// census, shape-name list, node count).</summary>
+    static NifInspect Mesh(string shapeName) => new(
+        "20.2.0.7", 12, 100, true, 2,
+        new[] { new NifBlockTypeCount("NiNode", 1), new NifBlockTypeCount("BSTriShape", 1) },
+        false, Array.Empty<string>(),
+        new[] { new NifShape(shapeName, 0, 1f, "BSTriShape", null, null, Array.Empty<NifPartition>(), null, Array.Empty<NifTexture>(), Array.Empty<string>()) },
+        Array.Empty<NifNode>(), Array.Empty<string>());
+}

--- a/src/housecarl-generator/NifServiceGuardProbe.cs
+++ b/src/housecarl-generator/NifServiceGuardProbe.cs
@@ -134,6 +134,13 @@ internal static class NifServiceGuardProbe
         Check(cut.Contains("more omitted") && !cut.Contains("3 more omitted") && !cut.Contains("4 more omitted"),
               $"a filtered-section cut counts the FILTERED remainder, not the total shape count — {(cut.Contains("more omitted") ? "cut fired, remainder bounded" : "NO CUT (retune)")}");
 
+        // PR #243 review: RenderShapesDetail obeys the same rule — a mid-list cut counts the REMAINING shapes, never
+        // the total. 6 shapes at cap 600: the cut fires after ≥1 shape rendered, so "6 more omitted" is the bug.
+        var wantShapesCut = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "shapes" };
+        var cutShapes = NifWire.Render(FakeData(FakeInspect(6, 0, false, Array.Empty<string>()), null), wantShapesCut, Array.Empty<string>(), 600);
+        Check(cutShapes.Contains("more omitted") && !cutShapes.Contains("6 more omitted"),
+              $"a shapes-detail cut counts the REMAINDER, not the total shape count — {(cutShapes.Contains("more omitted") ? "cut fired, remainder bounded" : "NO CUT (retune)")}");
+
         // finding #3: HasUnknownBlocks true but no named types → 'present', never a bare '0 type(s) —'.
         var ue = NifWire.Render(FakeData(FakeInspect(1, 0, true, Array.Empty<string>()), null), summaryOnly, Array.Empty<string>(), 80_000);
         Check(ue.Contains("unknown blocks: present") && !ue.Contains("0 type(s)"), "HasUnknownBlocks with no named types renders 'present', not '0 type(s)'");
@@ -195,8 +202,10 @@ internal static class NifServiceGuardProbe
     static bool CensusHas(NifInspect nif, string type, int count) => nif.BlockTypes.Any(t => t.Type == type && t.Count == count);
 
     /// <summary>A synthetic inspect model for the render-layer arms (no file needed): <paramref name="totalShapes"/>
-    /// shapes, the first <paramref name="withPartitions"/> of them carrying <paramref name="partsPerShape"/> partitions.</summary>
-    static NifInspect FakeInspect(int totalShapes, int withPartitions, bool hasUnknown, IReadOnlyList<string> unknownTypes, int partsPerShape = 2)
+    /// shapes named <paramref name="namePrefix"/>0.., the first <paramref name="withPartitions"/> of them carrying
+    /// <paramref name="partsPerShape"/> partitions. Internal: NifInspectBatchGuardProbe reuses this builder (one
+    /// synthetic-model shape for both render guards, PR #243 review) rather than growing a divergent copy.</summary>
+    internal static NifInspect FakeInspect(int totalShapes, int withPartitions, bool hasUnknown, IReadOnlyList<string> unknownTypes, int partsPerShape = 2, string namePrefix = "Shape")
     {
         var shapes = new List<NifShape>();
         for (int i = 0; i < totalShapes; i++)
@@ -205,7 +214,7 @@ internal static class NifServiceGuardProbe
             if (i < withPartitions)
                 for (int p = 0; p < partsPerShape; p++)
                     parts.Add(new NifPartition(30 + p, "SBP_" + (30 + p) + "_PART", 257));
-            shapes.Add(new NifShape("Shape" + i, 0x400000E, 1f, "BSTriShape", 0x8000E, "BSTriShape", parts, null, new List<NifTexture>(), new List<string>()));
+            shapes.Add(new NifShape(namePrefix + i, 0x400000E, 1f, "BSTriShape", 0x8000E, "BSTriShape", parts, null, new List<NifTexture>(), new List<string>()));
         }
         return new NifInspect("20.2.0.7", 12, 100, true, totalShapes + 1,
             new List<NifBlockTypeCount> { new("BSTriShape", totalShapes), new("NiNode", 1) },

--- a/src/housecarl-generator/NifServiceGuardProbe.cs
+++ b/src/housecarl-generator/NifServiceGuardProbe.cs
@@ -213,13 +213,14 @@ internal static class NifServiceGuardProbe
             shapes, new List<NifNode> { new(0, "Root", 0xE, "NiNode", 0xE, "NiNode") }, new List<string> { "Root", "Shape0" });
     }
 
-    /// <summary>Wrap an inspect model (or an error) in the service-layer <see cref="NifInspectData"/> with a two-provider
-    /// winner→loser chain — the input to <see cref="NifWire.Render"/>.</summary>
-    static NifInspectData FakeData(NifInspect? inspect, string? error, bool ambiguous = false, IReadOnlyList<string>? bsaFailures = null)
+    /// <summary>Wrap an inspect model (or an error) in the service-layer batch (a batch of ONE — #229 made the wire
+    /// batch-shaped) with a two-provider winner→loser chain — the input to <see cref="NifWire.Render"/>. The batch
+    /// contracts themselves (order, per-path isolation, one-shot alarms, omitted-mesh cut) are NifInspectBatchGuardProbe's.</summary>
+    static NifInspectBatchData FakeData(NifInspect? inspect, string? error, bool ambiguous = false, IReadOnlyList<string>? bsaFailures = null)
     {
         var provs = new List<NifProvider> { new("ModA", "loose"), new("Base.bsa", "BSA") };
-        return new NifInspectData("meshes\\test.nif", inspect is null ? null : provs[0], provs, ambiguous,
-            bsaFailures ?? Array.Empty<string>(), false, Array.Empty<string>(), "Default", inspect, error);
+        var one = new NifInspectData("meshes\\test.nif", inspect is null ? null : provs[0], provs, ambiguous, false, inspect, error);
+        return new NifInspectBatchData(new[] { one }, bsaFailures ?? Array.Empty<string>(), Array.Empty<string>(), "Default");
     }
 
     /// <summary>Author a minimal but genuine Skyrim SE mesh in-memory (the spike's CreateAndSave_SE recipe): an SE

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1141,7 +1141,13 @@ public sealed class LoadOrderService : IDisposable
         // concurrent refresh into wrongness and doesn't block other tools behind our file reads.
         var results = new List<NifInspectData>(relPaths.Count);
         foreach (var raw in relPaths)
-            results.Add(NifInspectOne(view, (raw ?? "").Trim(), mod));
+        {
+            var rel = (raw ?? "").Trim();
+            // The isolation contract holds by CONSTRUCTION, not by callee audit (PR #243 review): anything unexpected
+            // from ONE path's resolve/read/parse becomes THAT path's named error, never the whole batch's (Q3).
+            try { results.Add(NifInspectOne(view, rel, mod)); }
+            catch (Exception ex) { results.Add(NifInspectData.Fail(rel, $"unexpected error inspecting this path — {ex.GetType().Name}: {ex.Message}")); }
+        }
         return new NifInspectBatchData(results, view.BsaFailures, warnings, profileName);
     }
 
@@ -1157,12 +1163,12 @@ public sealed class LoadOrderService : IDisposable
         catch (ArgumentException ex) { return NifInspectData.Fail(rel, $"invalid path — {ex.Message}"); }
 
         var providers = place.Sources.Select(s => new NifProvider(s.ProviderName, KindLabel(s.Kind))).ToList();
-        bool readIncomplete = place.ReadIncomplete || view.ReadIncomplete;
 
         if (place.Sources.Count == 0)
-            return new NifInspectData(rel, null, providers, place.Ambiguous, readIncomplete, null,
-                "ABSENT — no active mod or BSA provides this mesh path" +
-                (readIncomplete ? " (and an archive failed to read this build, so this may be incomplete — see the read-failure note)." : "."));
+            // Absent=true lets the renderer hedge this at POINT OF USE on the batch-level caveats (read failures /
+            // discovery warnings) — asset_status parity; the top-of-output alarm alone scrolls away in a long batch.
+            return new NifInspectData(rel, null, providers, place.Ambiguous, Absent: true, null,
+                "ABSENT — no active mod or BSA provides this mesh path.");
 
         // Pick the copy to read: the VFS winner by default, or a specific provider when mod= names one.
         PlacementSource chosen;
@@ -1170,7 +1176,7 @@ public sealed class LoadOrderService : IDisposable
         {
             var pick = place.Sources.FirstOrDefault(s => s.ProviderName.Equals(mod!.Trim(), StringComparison.OrdinalIgnoreCase));
             if (pick is null)
-                return new NifInspectData(rel, null, providers, place.Ambiguous, readIncomplete, null,
+                return new NifInspectData(rel, null, providers, place.Ambiguous, false, null,
                     $"mod '{mod!.Trim()}' does not provide this path. Providers (winner first): {string.Join(", ", providers.Select(p => p.Name + " (" + p.Kind + ")"))}.");
             chosen = pick;
         }
@@ -1179,11 +1185,11 @@ public sealed class LoadOrderService : IDisposable
         var (bytes, readErr) = AssetResolver.ReadPlacementSource(chosen);
         if (bytes is null)
             return new NifInspectData(rel, new NifProvider(chosen.ProviderName, KindLabel(chosen.Kind)), providers, place.Ambiguous,
-                readIncomplete, null, readErr ?? "could not read the resolved mesh bytes.");
+                false, null, readErr ?? "could not read the resolved mesh bytes.");
 
         var outcome = NifService.Inspect(bytes);
         return new NifInspectData(rel, new NifProvider(chosen.ProviderName, KindLabel(chosen.Kind)), providers, place.Ambiguous,
-            readIncomplete, outcome.Inspect, outcome.Error);
+            false, outcome.Inspect, outcome.Error);
     }
 
     /// <summary>Render an <see cref="AssetKind"/> as the tool-facing label ("loose" / "BSA"). An explicit switch (not a
@@ -5716,17 +5722,18 @@ public sealed record NifProvider(string Name, string Kind);
 /// <summary>The per-path data behind housecarl_nif_inspect: the VFS resolution of ONE mesh path joined to the
 /// format-level <see cref="HousecarlCore.NifInspect"/> of the copy that was read. <see cref="Inspected"/> is the
 /// provider whose bytes were parsed (the winner, or the <c>mod=</c>-named copy); <see cref="Providers"/> is the FULL
-/// winner→loser chain (asset-tool parity), <see cref="Ambiguous"/> flags file-layer contention, and
-/// <see cref="ReadIncomplete"/> hedges an ABSENT when the scan behind it was incomplete. Exactly one of
-/// <see cref="Inspect"/> (the mesh model) and <see cref="Error"/> (ABSENT / bad path / unreadable / parse-refused —
-/// all named, Q3) is set on any given result. The batch-level Q3 caveats (BSA failures, discovery warnings, profile)
-/// live on <see cref="NifInspectBatchData"/> — captured once for the whole batch.</summary>
+/// winner→loser chain (asset-tool parity), <see cref="Ambiguous"/> flags file-layer contention. <see cref="Absent"/>
+/// marks the no-provider outcome specifically, so the renderer can hedge THAT error at point of use on the
+/// batch-level scan caveats (an ABSENT is only authoritative when the scan was complete — asset_status parity).
+/// Exactly one of <see cref="Inspect"/> (the mesh model) and <see cref="Error"/> (ABSENT / bad path / unreadable /
+/// parse-refused — all named, Q3) is set on any given result. The batch-level Q3 caveats (BSA failures, discovery
+/// warnings, profile) live on <see cref="NifInspectBatchData"/> — captured once for the whole batch.</summary>
 public sealed record NifInspectData(
     string RelPath,
     NifProvider? Inspected,
     IReadOnlyList<NifProvider> Providers,
     bool Ambiguous,
-    bool ReadIncomplete,
+    bool Absent,
     HousecarlCore.NifInspect? Inspect,
     string? Error)
 {

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1110,36 +1110,48 @@ public sealed class LoadOrderService : IDisposable
         }
     }
 
-    // ---- NIF layer Wave 1: read the data values inside a mesh (housecarl_nif_inspect) ----
+    // ---- NIF layer Wave 1: read the data values inside one or many meshes (housecarl_nif_inspect) ----
 
-    /// <summary>Inspect the data values inside a Skyrim mesh (housecarl_nif_inspect): resolve the Data-relative
-    /// <paramref name="relPath"/> through the MO2 VFS to the WINNING copy (or a specific loser when <paramref name="mod"/>
-    /// is named), read that copy's bytes IN PROCESS (a loose file, or a single entry out of a BSA via native Mutagen — no
-    /// disk extraction), and hand them to <see cref="NifService.Inspect"/> for the header / block census / shapes /
-    /// partitions / alpha / textures / node tree / string table. Read-only. The asset-tool parity is carried through:
-    /// the full winner→loser provider chain (each tagged loose/BSA), the ambiguity flag, and the build-level Q3 caveats
-    /// (<see cref="AssetView.BsaFailures"/> / ReadIncomplete) ride along, so an ABSENT answer is never over-trusted. ONE
-    /// asset capture pins the whole call; the resolve + byte read + NIF parse run OUTSIDE <see cref="_gate"/> on the
-    /// handle-free captured view, so an inspect never serializes other tool calls behind its file I/O. A parse failure is
-    /// a NAMED outcome (<see cref="NifInspectData.Error"/>), never a throw or a half-model (Q3).</summary>
-    public NifInspectData NifInspect(string relPath, string? mod)
+    /// <summary>Inspect the data values inside one or many Skyrim meshes (housecarl_nif_inspect): capture the asset
+    /// resolver ONCE under <see cref="_gate"/>, then — per Data-relative path, OUTSIDE the gate on the pinned
+    /// handle-free view — resolve through the MO2 VFS to the WINNING copy (or the <paramref name="mod"/>-named
+    /// provider), read that copy's bytes IN PROCESS (a loose file, or a single entry out of a BSA via native Mutagen —
+    /// no disk extraction), and hand them to <see cref="NifService.Inspect"/> for the header / block census / shapes /
+    /// partitions / alpha / textures / node tree / string table. Read-only. Results come back in INPUT ORDER, one per
+    /// path; a per-path failure (empty/invalid path, ABSENT, a mod= that doesn't provide it, unreadable bytes, a parse
+    /// refusal) is a NAMED per-path <see cref="NifInspectData.Error"/> that never aborts the rest of the batch (Q3).
+    /// The asset-tool parity is carried through per path — the full winner→loser provider chain (each tagged
+    /// loose/BSA) and the ambiguity flag — while the build-level Q3 caveats (<see cref="AssetView.BsaFailures"/>,
+    /// discovery warnings) ride ONCE on the batch, so an ABSENT answer is never over-trusted. The single capture is
+    /// what makes a load-order-wide facegen sweep one call instead of one per mesh (issue #229); a single-path call is
+    /// simply a batch of one.</summary>
+    public NifInspectBatchData NifInspect(IReadOnlyList<string> relPaths, string? mod)
     {
-        var rel = (relPath ?? "").Trim();
-        if (rel.Length == 0)
-            return NifInspectData.Fail("", "no mesh path given. Pass a Data-relative path, e.g. 'meshes\\actors\\character\\facegendata\\facegeom\\Skyrim.esm\\00000007.nif'.");
-
         AssetResolver.AssetView view;
         IReadOnlyList<string> warnings;
         string profileName;
         lock (_gate)
         {
-            view = Assets.Capture();                              // build/refresh the asset resolver under the gate, ONCE
+            view = Assets.Capture();                              // build/refresh the asset resolver under the gate, ONCE per batch
             warnings = _assetWarnings;
             profileName = _profileName;
         }
 
         // OUTSIDE the gate: the captured view is pinned + handle-free, so resolving + reading + parsing here can't race a
         // concurrent refresh into wrongness and doesn't block other tools behind our file reads.
+        var results = new List<NifInspectData>(relPaths.Count);
+        foreach (var raw in relPaths)
+            results.Add(NifInspectOne(view, (raw ?? "").Trim(), mod));
+        return new NifInspectBatchData(results, view.BsaFailures, warnings, profileName);
+    }
+
+    /// <summary>One path's inspect against the already-captured view — the per-path body of <see cref="NifInspect"/>.
+    /// Every failure is a NAMED per-path outcome, never a throw (Q3).</summary>
+    static NifInspectData NifInspectOne(AssetResolver.AssetView view, string rel, string? mod)
+    {
+        if (rel.Length == 0)
+            return NifInspectData.Fail("", "empty mesh path. Pass a Data-relative path, e.g. 'meshes\\actors\\character\\facegendata\\facegeom\\Skyrim.esm\\00000007.nif'.");
+
         PlacementResolution place;
         try { place = view.ResolveForPlacement(rel); }
         catch (ArgumentException ex) { return NifInspectData.Fail(rel, $"invalid path — {ex.Message}"); }
@@ -1148,7 +1160,7 @@ public sealed class LoadOrderService : IDisposable
         bool readIncomplete = place.ReadIncomplete || view.ReadIncomplete;
 
         if (place.Sources.Count == 0)
-            return new NifInspectData(rel, null, providers, place.Ambiguous, view.BsaFailures, readIncomplete, warnings, profileName, null,
+            return new NifInspectData(rel, null, providers, place.Ambiguous, readIncomplete, null,
                 "ABSENT — no active mod or BSA provides this mesh path" +
                 (readIncomplete ? " (and an archive failed to read this build, so this may be incomplete — see the read-failure note)." : "."));
 
@@ -1158,7 +1170,7 @@ public sealed class LoadOrderService : IDisposable
         {
             var pick = place.Sources.FirstOrDefault(s => s.ProviderName.Equals(mod!.Trim(), StringComparison.OrdinalIgnoreCase));
             if (pick is null)
-                return new NifInspectData(rel, null, providers, place.Ambiguous, view.BsaFailures, readIncomplete, warnings, profileName, null,
+                return new NifInspectData(rel, null, providers, place.Ambiguous, readIncomplete, null,
                     $"mod '{mod!.Trim()}' does not provide this path. Providers (winner first): {string.Join(", ", providers.Select(p => p.Name + " (" + p.Kind + ")"))}.");
             chosen = pick;
         }
@@ -1167,11 +1179,11 @@ public sealed class LoadOrderService : IDisposable
         var (bytes, readErr) = AssetResolver.ReadPlacementSource(chosen);
         if (bytes is null)
             return new NifInspectData(rel, new NifProvider(chosen.ProviderName, KindLabel(chosen.Kind)), providers, place.Ambiguous,
-                view.BsaFailures, readIncomplete, warnings, profileName, null, readErr ?? "could not read the resolved mesh bytes.");
+                readIncomplete, null, readErr ?? "could not read the resolved mesh bytes.");
 
         var outcome = NifService.Inspect(bytes);
         return new NifInspectData(rel, new NifProvider(chosen.ProviderName, KindLabel(chosen.Kind)), providers, place.Ambiguous,
-            view.BsaFailures, readIncomplete, warnings, profileName, outcome.Inspect, outcome.Error);
+            readIncomplete, outcome.Inspect, outcome.Error);
     }
 
     /// <summary>Render an <see cref="AssetKind"/> as the tool-facing label ("loose" / "BSA"). An explicit switch (not a
@@ -5701,28 +5713,36 @@ public sealed record SkyPatcherFolderOutcome(
 /// or a "BSA" entry. Winner-first ordering lives in <see cref="NifInspectData.Providers"/>.</summary>
 public sealed record NifProvider(string Name, string Kind);
 
-/// <summary>The data behind housecarl_nif_inspect: the VFS resolution of a mesh path joined to the format-level
-/// <see cref="HousecarlCore.NifInspect"/> of the copy that was read. <see cref="Inspected"/> is the provider whose bytes
-/// were parsed (the winner, or the <c>mod=</c>-named copy); <see cref="Providers"/> is the FULL winner→loser chain
-/// (asset-tool parity), <see cref="Ambiguous"/> flags file-layer contention. The build-level Q3 caveats
-/// <see cref="BsaFailures"/> / <see cref="ReadIncomplete"/> and discovery <see cref="Warnings"/> ride along;
-/// <see cref="ProfileName"/> names the active profile. Exactly one of <see cref="Inspect"/> (the mesh model) and
-/// <see cref="Error"/> (ABSENT / bad path / unreadable / parse-refused — all named, Q3) is set on any given result.</summary>
+/// <summary>The per-path data behind housecarl_nif_inspect: the VFS resolution of ONE mesh path joined to the
+/// format-level <see cref="HousecarlCore.NifInspect"/> of the copy that was read. <see cref="Inspected"/> is the
+/// provider whose bytes were parsed (the winner, or the <c>mod=</c>-named copy); <see cref="Providers"/> is the FULL
+/// winner→loser chain (asset-tool parity), <see cref="Ambiguous"/> flags file-layer contention, and
+/// <see cref="ReadIncomplete"/> hedges an ABSENT when the scan behind it was incomplete. Exactly one of
+/// <see cref="Inspect"/> (the mesh model) and <see cref="Error"/> (ABSENT / bad path / unreadable / parse-refused —
+/// all named, Q3) is set on any given result. The batch-level Q3 caveats (BSA failures, discovery warnings, profile)
+/// live on <see cref="NifInspectBatchData"/> — captured once for the whole batch.</summary>
 public sealed record NifInspectData(
     string RelPath,
     NifProvider? Inspected,
     IReadOnlyList<NifProvider> Providers,
     bool Ambiguous,
-    IReadOnlyList<string> BsaFailures,
     bool ReadIncomplete,
-    IReadOnlyList<string> Warnings,
-    string ProfileName,
     HousecarlCore.NifInspect? Inspect,
     string? Error)
 {
     public static NifInspectData Fail(string relPath, string error)
-        => new(relPath, null, Array.Empty<NifProvider>(), false, Array.Empty<string>(), false, Array.Empty<string>(), "", null, error);
+        => new(relPath, null, Array.Empty<NifProvider>(), false, false, null, error);
 }
+
+/// <summary>The batch behind housecarl_nif_inspect: per-path <see cref="Results"/> in INPUT ORDER, plus the
+/// build-level Q3 caveats shared by the whole batch (one asset capture pins every path): <see cref="BsaFailures"/>
+/// (archives that couldn't be read this build — an ABSENT result may be incomplete), discovery
+/// <see cref="Warnings"/>, and the active <see cref="ProfileName"/>.</summary>
+public sealed record NifInspectBatchData(
+    IReadOnlyList<NifInspectData> Results,
+    IReadOnlyList<string> BsaFailures,
+    IReadOnlyList<string> Warnings,
+    string ProfileName);
 
 /// <summary>The data behind housecarl_nif_set: the VFS resolution joined to the verified write outcome. Exactly one of
 /// {<see cref="Report"/> (a verified write happened)}, {<see cref="Error"/> (a named refusal — NOTHING written, Q3)},

--- a/src/housecarl-mcp/NifTools.cs
+++ b/src/housecarl-mcp/NifTools.cs
@@ -64,6 +64,8 @@ public static class NifTools
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         if (mesh_paths is null || mesh_paths.Length == 0)
             return "error: mesh_paths is empty. Pass one or more Data-relative mesh paths (e.g. 'meshes\\armor\\iron\\cuirass_1.nif').";
+        if (mesh_paths.All(string.IsNullOrWhiteSpace))
+            return "error: mesh_paths contains only empty/blank entries. Pass Data-relative mesh paths (e.g. 'meshes\\armor\\iron\\cuirass_1.nif').";
 
         var (want, unknownTokens) = ParseSections(sections);
         var data = svc.NifInspect(mesh_paths, string.IsNullOrWhiteSpace(mod) ? null : mod);
@@ -215,24 +217,31 @@ static class NifWire
             sb.Append("\n[!] unrecognized section(s) ignored: ").Append(string.Join(", ", unknownSections))
               .Append("  (known: ").Append(string.Join(", ", new[] { "shapes", "partitions", "alpha", "paths", "strings", "nodes", "bones", "all" })).Append(")\n");
 
+        bool readIncomplete = d.BsaFailures.Count > 0, discoveryIncomplete = d.Warnings.Count > 0;
         int shown = 0;
         foreach (var r in d.Results)
         {
-            if (sb.Length >= cap)
+            // shown > 0: the FIRST mesh always renders its core answer (resolution/error/summary) even when the
+            // alarms alone exhausted the cap — max_chars bounds the batch tail and detail lists, it never starves a
+            // single-path call of the very answer it asked for (PR #243 review).
+            if (shown > 0 && sb.Length >= cap)
             {
                 sb.Append("\n… [").Append(d.Results.Count - shown)
                   .Append(" more mesh(es) omitted at max_chars=").Append(cap).Append("; raise max_chars to see all]\n");
                 break;
             }
-            AppendMesh(sb, r, want, cap);
+            AppendMesh(sb, r, want, cap, readIncomplete, discoveryIncomplete);
             shown++;
         }
         return sb.ToString().TrimEnd('\n');
     }
 
     /// <summary>One mesh's block: the path line, then either its named error (+ provider chain when we have one) or the
-    /// resolution + summary + requested detail sections.</summary>
-    static void AppendMesh(StringBuilder sb, NifInspectData d, HashSet<string> want, int cap)
+    /// resolution + summary + requested detail sections. An ABSENT is hedged at POINT OF USE on both batch-level scan
+    /// caveats (an archive that failed to READ; archives never DISCOVERED) — the top-of-output alarm alone scrolls away
+    /// in a long batch, and "absent → the mesh is fine/missing" is exactly the over-trust the hedge exists to stop (Q3,
+    /// asset_status parity).</summary>
+    static void AppendMesh(StringBuilder sb, NifInspectData d, HashSet<string> want, int cap, bool readIncomplete, bool discoveryIncomplete)
     {
         sb.Append('\n').Append(d.RelPath.Length > 0 ? d.RelPath : "(empty path)").Append('\n');
 
@@ -240,6 +249,15 @@ static class NifWire
         if (d.Inspect is null)
         {
             sb.Append("  ").Append(d.Error ?? "unknown error").Append('\n');
+            if (d.Absent)
+            {
+                if (readIncomplete)
+                    sb.Append("  [!] but an archive failed to read this build (see the read-failure note above), so " +
+                              "\"ABSENT\" may be incomplete — the mesh could live in the unreadable archive.\n");
+                if (discoveryIncomplete)
+                    sb.Append("  [!] some archives were not scanned this build (see the discovery note above), so " +
+                              "\"ABSENT\" may be incomplete — base-game meshes live in BSAs that weren't enumerated.\n");
+            }
             if (d.Providers.Count > 0) AppendProviders(sb, d.Providers);
             return;
         }
@@ -298,9 +316,10 @@ static class NifWire
     static void RenderShapesDetail(StringBuilder sb, NifInspect nif, int cap)
     {
         sb.Append("\n--- shapes (").Append(nif.Shapes.Count).Append(") ---\n");
+        int shown = 0;   // the cut notice counts the REMAINDER, not the total (PR #243 review — the RenderPerShape rule)
         foreach (var s in nif.Shapes)
         {
-            if (Cut(sb, cap, nif.Shapes.Count)) return;
+            if (Cut(sb, cap, nif.Shapes.Count - shown)) return;
             sb.Append("  '").Append(s.Name).Append("'  flags ").Append(DescribeFlags(s.Flags, s.FlagsDefault, s.FlagsDefaultType, s.BlockType))
               .Append("  scale ").Append(Fmt(s.Scale)).Append('\n');
             if (s.Partitions.Count > 0)
@@ -311,6 +330,7 @@ static class NifWire
                 sb.Append("    tex[").Append(t.Slot).Append("]: ").Append(t.Path).Append('\n');
             if (s.Bones.Count > 0)
                 sb.Append("    bones: ").Append(string.Join(", ", s.Bones)).Append('\n');
+            shown++;
         }
     }
 

--- a/src/housecarl-mcp/NifTools.cs
+++ b/src/housecarl-mcp/NifTools.cs
@@ -6,10 +6,11 @@ using ModelContextProtocol.Server;
 namespace HousecarlMcp;
 
 /// <summary>
-/// houseCARL NIF tool. Read-only. Reads the DATA VALUES inside a Skyrim mesh (.nif) — header/version, the block census,
-/// each shape's name + NiAVObject flags + scale, its BSDismember partitions, its alpha property, its texture-set paths
-/// and bone list, the node tree, and the header string table — resolving the Data-relative path through MO2's VFS to the
-/// WINNING copy first (loose beats BSA), the same file-layer precedence the asset tools use. Rides NiflySharp
+/// houseCARL NIF tool. Read-only. Reads the DATA VALUES inside one or many Skyrim meshes (.nif) — header/version, the
+/// block census, each shape's name + NiAVObject flags + scale, its BSDismember partitions, its alpha property, its
+/// texture-set paths and bone list, the node tree, and the header string table — resolving each Data-relative path
+/// through MO2's VFS to the WINNING copy first (loose beats BSA), the same file-layer precedence the asset tools use,
+/// with ONE load-order resolution for the whole batch (issue #229 — a facegen sweep is one call). Rides NiflySharp
 /// (source-generated from nifxml = coverage by construction); reads BSA-packed meshes straight from archive bytes with
 /// no disk extraction, and holds no file handles at rest. This is the asset-INTERNAL counterpart to housecarl_asset_status
 /// (which answers WHICH file wins): once you know the winning mesh, this answers WHAT IS INSIDE it. Data values in; geometry
@@ -20,11 +21,11 @@ public static class NifTools
 {
     static readonly string[] KnownSections = { "shapes", "partitions", "alpha", "paths", "strings", "nodes", "bones" };
 
-    [McpServerTool(Name = "housecarl_nif_inspect", ReadOnly = true, Title = "Inspect the data values inside a Skyrim mesh (.nif)"),
+    [McpServerTool(Name = "housecarl_nif_inspect", ReadOnly = true, Title = "Inspect the data values inside one or many Skyrim meshes (.nif)"),
      Description(
-         "Read the DATA VALUES inside a Skyrim mesh (.nif) at the data layer, beneath NifSkope. Resolve the Data-relative " +
-         "mesh_path through Mod Organizer 2's virtual file system to the copy the game actually uses (loose beats BSA; among " +
-         "BSAs the later-loaded plugin wins) and report, from that mesh: its header version + whether it is a Skyrim SE " +
+         "Read the DATA VALUES inside one or many Skyrim meshes (.nif) at the data layer, beneath NifSkope. Resolve each " +
+         "Data-relative path in mesh_paths through Mod Organizer 2's virtual file system to the copy the game actually uses " +
+         "(loose beats BSA; among BSAs the later-loaded plugin wins) and report, per mesh: its header version + whether it is a Skyrim SE " +
          "stream; the block census (every block type and count); any UNKNOWN blocks (named + preserved, never silently " +
          "dropped); and per shape — the shape name, the NiAVObject flags (hex, decoded by deviation from the type's " +
          "documented default plus the 0x80000 bit) and scale, the BSDismember body-part " +
@@ -32,34 +33,40 @@ public static class NifTools
          "texture-set paths, and the bone list; plus the node tree and the header string table. Use it to answer 'what " +
          "shapes / bones / textures / partitions / alpha does this mesh have', to read a facegen mesh's baked shape names " +
          "and tint path, to check a skeleton's bone names, or to see a dark-face mesh's flags/alpha/partitions — the " +
-         "asset-INTERNAL companion to housecarl_asset_status (which mod wins) once you know the winning file. Output is a " +
-         "SUMMARY by default (header + census + shape names); pass sections to expand ('shapes','partitions','alpha'," +
-         "'paths','strings','nodes','bones', or 'all'). Pass mod= to inspect a specific provider instead of the winner. An " +
+         "asset-INTERNAL companion to housecarl_asset_status (which mod wins) once you know the winning file. Pass " +
+         "mesh_paths = one or more paths (asset_status parity — a whole facegen sweep's flagged subset is ONE call, one " +
+         "load-order resolution for the batch); results return in input order, and a failing path is reported LOUD on THAT " +
+         "path without aborting the rest. Output is a " +
+         "SUMMARY per mesh by default (header + census + shape names); pass sections to expand ('shapes','partitions','alpha'," +
+         "'paths','strings','nodes','bones', or 'all'). Pass mod= to inspect a specific provider instead of the winner; " +
+         "sections, mod and max_chars apply to the whole batch. An " +
          "unreadable archive, an absent path, or a mesh NiflySharp refuses (e.g. its strict non-0/1 boolean class) is " +
          "reported LOUD by name — never a silent 'absent' or a half-answer. Read-only: resolves nothing to disk, writes " +
          "nothing, changes no load order. Scope: data values only; it does not read or edit geometry / visual content.")]
     public static string NifInspect(
         LoadOrderService svc,
-        [Description("The Data-relative mesh path to inspect, e.g. " +
+        [Description("The Data-relative mesh path(s) to inspect, e.g. " +
                      "'meshes\\actors\\character\\facegendata\\facegeom\\Skyrim.esm\\00000007.nif' or " +
-                     "'meshes\\armor\\iron\\cuirass_1.nif'. Relative to the game's Data folder (forward or back slashes both fine).")]
-            string mesh_path,
+                     "'meshes\\armor\\iron\\cuirass_1.nif'. One or many; inspected in order, results returned in the same " +
+                     "order. Relative to the game's Data folder (forward or back slashes both fine).")]
+            string[] mesh_paths,
         [Description("Optional. Which detail sections to show beyond the summary — any of 'shapes', 'partitions', 'alpha', " +
-                     "'paths', 'strings', 'nodes', 'bones', or 'all'. Comma- or space-separated. Empty = summary only " +
-                     "(header + block census + shape names).")]
+                     "'paths', 'strings', 'nodes', 'bones', or 'all'. Comma- or space-separated. Applies to every mesh in " +
+                     "the batch. Empty = summary only (header + block census + shape names).")]
             string sections = "",
-        [Description("Optional. Inspect a specific provider's copy of the mesh instead of the VFS winner — the mod folder " +
-                     "name, 'overwrite', 'Data', or a BSA filename as listed in the providers chain. Empty = the winner.")]
+        [Description("Optional. Inspect a specific provider's copy instead of the VFS winner — the mod folder " +
+                     "name, 'overwrite', 'Data', or a BSA filename as listed in the providers chain. Applies to every mesh " +
+                     "in the batch. Empty = the winner.")]
             string mod = "",
-        [Description("Optional. Max characters before a detail list is cut with an explicit notice. 0 = the server default (~80k).")]
+        [Description("Optional. Max characters before the output is cut with an explicit notice. 0 = the server default (~80k).")]
             int max_chars = 0) => Guard.Tool("housecarl_nif_inspect", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-        if (string.IsNullOrWhiteSpace(mesh_path))
-            return "error: mesh_path is empty. Pass a Data-relative mesh path (e.g. 'meshes\\armor\\iron\\cuirass_1.nif').";
+        if (mesh_paths is null || mesh_paths.Length == 0)
+            return "error: mesh_paths is empty. Pass one or more Data-relative mesh paths (e.g. 'meshes\\armor\\iron\\cuirass_1.nif').";
 
         var (want, unknownTokens) = ParseSections(sections);
-        var data = svc.NifInspect(mesh_path, string.IsNullOrWhiteSpace(mod) ? null : mod);
+        var data = svc.NifInspect(mesh_paths, string.IsNullOrWhiteSpace(mod) ? null : mod);
         return NifWire.Render(data, want, unknownTokens, max_chars > 0 ? max_chars : 80_000);
     });
 
@@ -186,36 +193,59 @@ public static class NifTools
     }
 }
 
-/// <summary>Renders <see cref="NifInspectData"/> as compact, scannable text: the build-level Q3 alarms first (archives
-/// that failed to read; discovery warnings), then the resolution (which copy was read + the provider chain), then — on a
-/// clean read — the summary (version, block census, unknown-block report, shape names, node count) and any requested
-/// detail sections. An ABSENT / bad-path / unreadable / parse-refused result is the error line, loud and named. Detail
-/// lists are bounded by max_chars with an explicit cut notice (Q3 — never silent truncation).</summary>
+/// <summary>Renders <see cref="NifInspectBatchData"/> as compact, scannable text: the build-level Q3 alarms first and
+/// ONCE (archives that failed to read; discovery warnings — batch-level, so a long batch can't truncate them away),
+/// then one block per mesh in INPUT ORDER — the resolution (which copy was read + the provider chain), then, on a clean
+/// read, the summary (version, block census, unknown-block report, shape names, node count) and any requested detail
+/// sections. An ABSENT / bad-path / unreadable / parse-refused result is that path's error line, loud and named,
+/// without costing the rest of the batch. Output is bounded by max_chars with an explicit cut notice naming how many
+/// meshes were omitted (Q3 — never silent truncation).</summary>
 static class NifWire
 {
-    public static string Render(NifInspectData d, HashSet<string> want, IReadOnlyList<string> unknownSections, int cap)
+    public static string Render(NifInspectBatchData d, HashSet<string> want, IReadOnlyList<string> unknownSections, int cap)
     {
         var sb = new StringBuilder();
-        sb.Append("nif inspect — ").Append(d.RelPath)
-          .Append("  (profile '").Append(d.ProfileName.Length > 0 ? d.ProfileName : "(unconfigured)").Append("')\n");
+        sb.Append("nif inspect — profile '").Append(d.ProfileName.Length > 0 ? d.ProfileName : "(unconfigured)")
+          .Append("'  (").Append(d.Results.Count).Append(" mesh").Append(d.Results.Count == 1 ? "" : "es").Append(")\n");
 
-        // Q3 alarms FIRST, so a long detail dump can't truncate them away.
+        // Q3 alarms FIRST + ONCE (batch-level), so a long batch can't truncate them away.
         AppendReadFailures(sb, d.BsaFailures, cap);
         AppendDiscoveryWarnings(sb, d.Warnings, cap);
         if (unknownSections.Count > 0)
             sb.Append("\n[!] unrecognized section(s) ignored: ").Append(string.Join(", ", unknownSections))
               .Append("  (known: ").Append(string.Join(", ", new[] { "shapes", "partitions", "alpha", "paths", "strings", "nodes", "bones", "all" })).Append(")\n");
 
+        int shown = 0;
+        foreach (var r in d.Results)
+        {
+            if (sb.Length >= cap)
+            {
+                sb.Append("\n… [").Append(d.Results.Count - shown)
+                  .Append(" more mesh(es) omitted at max_chars=").Append(cap).Append("; raise max_chars to see all]\n");
+                break;
+            }
+            AppendMesh(sb, r, want, cap);
+            shown++;
+        }
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    /// <summary>One mesh's block: the path line, then either its named error (+ provider chain when we have one) or the
+    /// resolution + summary + requested detail sections.</summary>
+    static void AppendMesh(StringBuilder sb, NifInspectData d, HashSet<string> want, int cap)
+    {
+        sb.Append('\n').Append(d.RelPath.Length > 0 ? d.RelPath : "(empty path)").Append('\n');
+
         // Error path (ABSENT / bad path / unreadable / parse-refused). Still show the provider chain when we have one.
         if (d.Inspect is null)
         {
-            sb.Append('\n').Append(d.Error ?? "unknown error").Append('\n');
+            sb.Append("  ").Append(d.Error ?? "unknown error").Append('\n');
             if (d.Providers.Count > 0) AppendProviders(sb, d.Providers);
-            return sb.ToString().TrimEnd('\n');
+            return;
         }
 
         var nif = d.Inspect;
-        sb.Append("\n  read from: ").Append(d.Inspected!.Name).Append(" (").Append(d.Inspected.Kind).Append(")\n");
+        sb.Append("  read from: ").Append(d.Inspected!.Name).Append(" (").Append(d.Inspected.Kind).Append(")\n");
         AppendProviders(sb, d.Providers);
         if (d.Ambiguous)
             sb.Append("  note: more than one source provides this mesh — the winner above was read (loose beats BSA). " +
@@ -252,8 +282,6 @@ static class NifWire
             s => string.Join(", ", s.Bones));
         if (want.Contains("nodes")) RenderNodes(sb, nif, cap);
         if (want.Contains("strings")) RenderStrings(sb, nif, cap);
-
-        return sb.ToString().TrimEnd('\n');
     }
 
     static void AppendProviders(StringBuilder sb, IReadOnlyList<NifProvider> providers)


### PR DESCRIPTION
Fixes #229

## What

`housecarl_nif_inspect`'s `mesh_path` becomes **`mesh_paths`** — an `asset_status`-style array (a single path is simply a batch of one). This closes the last per-file loop in the load-order-wide dark-face scan: the flagged subset of a whole-load-order sweep is now **one call**, not hundreds.

Of the issue's two ideal shapes, this takes the first (array on the existing tool) — it mirrors the `asset_status` precedent exactly and follows the bulk-primitives convention of extending existing tools rather than minting `bulk_*` twins.

## How

- **Service** ([LoadOrderService.cs](../blob/claude/bulk-nif-inspect/src/housecarl-mcp/LoadOrderService.cs)): **one `Assets.Capture()` under the gate pins the whole batch** (this is the real win — the load order resolves once, not per mesh); per-path resolve → byte read → NIF parse runs outside the gate on the pinned handle-free view. Every per-path failure (empty/invalid path, ABSENT, a `mod=` that doesn't provide it, unreadable bytes, a parse refusal) is a **named per-path error that never aborts the rest** (Q3). Batch-level caveats (BSA read failures, discovery warnings, profile) move to a new `NifInspectBatchData`; `NifInspectData` slims to per-path fields.
- **Tool + wire** ([NifTools.cs](../blob/claude/bulk-nif-inspect/src/housecarl-mcp/NifTools.cs)): results render in **input order**, one block per mesh; the Q3 alarms render **once, first**, so a long batch can't truncate them away; an over-cap output cuts with the **omitted-mesh count named** — never silent. `sections=` / `mod=` / `max_chars` apply batch-wide, per the existing bulk conventions.
- **Probe**: new `nif-inspect-batch-guard` locks the four batch contracts (input order; per-path error isolation; one-shot alarms-first; explicit cut). All three teeth verified **mutation-RED at authoring** (abort-on-error → arm 2 fails; alarms-per-mesh → arm 3 fails; silent cut → arm 4 fails). `NifServiceGuardProbe`'s render arms now feed the wire a batch of one — all its arms unchanged and green, including the Lucien corpus smoke.
- **Docs**: CHANGELOG `## Unreleased` entry; `facegen-diagnostics` batch flow step 4 drops the sampling workaround the issue called out ("sampling is exactly the kind of silent coverage cap the batch flow exists to avoid") — inspect the whole flagged subset in one call.

## Verification

- `ci-all`: **100/100 PASS** from the worktree root (includes the new guard).
- Probe teeth: all three mutations turned their arm red, then green on restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)