### PR TITLE
feat(query): depth= on cross_plugin_query — nested list contents in a scan (#231)

### DIFF
--- a/.claude/skills/bulk-record-jobs/SKILL.md
+++ b/.claude/skills/bulk-record-jobs/SKILL.md
@@ -90,11 +90,12 @@ run before the primitive existed:
        fields=["Name", "ArmorRating"], winner_fields=true, format="json")
    ```
 
-3. **Expand list-bearing rows in a second, batched pass.** `housecarl_cross_plugin_query` has no
-   `depth=` — a list field renders as a count note (`[list: 5 item(s)]`). Feed the enumerated
-   FormIDs to `housecarl_batch_record_detail` with `depth=2`, `resolve_names=true`,
-   `format="json"`: each list element comes back indexed (`Keywords[0]`…) with a structured
-   `link` sibling (`{resolved, type, editorid, name}`) beside the raw token.
+3. **Expand list-bearing rows in the same scan.** Pass `depth=` with `fields=` —
+   `fields=["Keywords"], depth=2` returns each element indexed (`Keywords[0]`…) across every
+   match, and `resolve_names=true` adds the structured `link` sibling
+   (`{resolved, type, editorid, name}`) beside the raw token. `format="dense"` stays depth-1
+   (its columnar cells are positional) — use `format="json"` for expanded scans, or hop the
+   flagged subset to `housecarl_batch_record_detail` when only a few matches need expanding.
 4. **Respect the accounting.** Every JSON document carries `total` / `rendered` / `capped` /
    `truncated` / `notes` in-band. `capped=true` means raise `limit=` or page by narrowing scope —
    never ship a deliverable whose `total` exceeds its row count without saying so.
@@ -283,9 +284,10 @@ For crafting-graph jobs specifically, the blessed per-recipe entry:
 
 ## Notes
 
-- `housecarl_cross_plugin_query` has no `depth=` — list expansion always goes through
-  `housecarl_batch_record_detail` (or `housecarl_read_record` for one record). Budget the second
-  call into any list-bearing catalogue plan.
+- `housecarl_cross_plugin_query` takes `depth=` (with `fields=`; text/json formats) — list
+  expansion rides the scan itself, no second call. `housecarl_batch_record_detail` remains the
+  lever when only a subset of matches needs expanding, and under `format="dense"` (depth-1 by
+  design — positional cells).
 - `where=` accepts FormLink equality against a wire token (e.g.
   `"WorkbenchKeyword = 088108:Skyrim.esm"`) — a station filter is one predicate, no post-filtering.
 - Off-order (disabled, on-disk) plugins are first-class poles for `housecarl_diff_record`,

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,17 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**`housecarl_cross_plugin_query` learns `depth=` (#231).** Nested list contents were unreachable in a scan:
+`fields=["Effects"]` rendered only `[list: N item(s)]`, and the workaround — hand-written bracket paths like
+`Effects[2].Data.Magnitude` — meant guessing the longest list up front and eating an out-of-bounds error triple
+for every shorter record (66 spells → hundreds of wasted lines, twice past the token cap). Now `depth=` rides the
+scan with the same semantics as `housecarl_read_record` / `batch_record_detail`: `fields=["Effects"], depth=4`
+expands every match's per-effect Data in one call — each record shows exactly its OWN elements, no index guessing,
+no out-of-bounds noise — and `resolve_names=` composes with the expansion. Works in `format=text` and `json`;
+`dense` refuses `depth>1` loud (its columnar cells align 1:1 with the requested paths — the container cells name
+the text/json hop), and `depth=` without `fields=` is refused loud too. The old container hint ("cross_plugin_query
+has no depth=; expand via batch_record_detail") is retired with the gap it described.
+
 **`housecarl_nif_inspect` goes batch — `mesh_paths` takes one or many (#229).** The last per-file loop in a
 load-order-wide dark-face scan is gone: `mesh_path` is now `mesh_paths`, an `asset_status`-style array (a single
 path is simply a batch of one). One call resolves the whole flagged subset — **one load-order resolution for the

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -168,9 +168,10 @@ public static class ReadEngine
     /// <summary>The depth-1 container hint (HCBR-2026-07-12): appended to an unexpanded container/substruct summary so
     /// an agent turns the depth= knob instead of inventing a param or hand-rolling a parser. It names <c>depth=2</c>,
     /// which is only honest on a surface that HAS a depth= parameter (read_record / batch_record_detail /
-    /// read_plugin_file / the CLI) — a caller whose surface has no depth= passes its own redirect via
-    /// <c>containerHint</c> (cross_plugin_query names the batch-read hop) or null to suppress (write read-backs,
-    /// where the count IS the confirmation and there is no knob to turn).</summary>
+    /// read_plugin_file / cross_plugin_query text+json (#231) / the CLI) — a caller whose surface refuses depth
+    /// passes its own redirect via <c>containerHint</c> (cross_plugin_query's DENSE render names the text/json
+    /// format hop — its positional cells refuse depth&gt;1) or null to suppress (write read-backs, where the count
+    /// IS the confirmation and there is no knob to turn).</summary>
     public const string DepthExpandHint = " — pass depth=2 to expand";
 
     /// <summary>Read a located record's fields as round-trippable tokens — the public, structured entry the MCP

--- a/src/housecarl-generator/BulkPrimitivesWave2Probe.cs
+++ b/src/housecarl-generator/BulkPrimitivesWave2Probe.cs
@@ -439,27 +439,29 @@ public static class BulkPrimitivesWave2Probe
             }
 
             // ================= container hint — the depth= knob is hinted only where it EXISTS =================
-            // The depth-1 container note self-documents the expansion lever (HCBR-2026-07-12). cross_plugin_query
-            // has NO depth= (its unknown-param guard refuses it), so its note must redirect to the batch-read hop
-            // instead of naming a knob the tool refuses — while read_record (which HAS depth=) keeps the classic
-            // hint, and a write read-back (no knob at all) carries a bare count.
+            // The depth-1 container note self-documents the expansion lever (HCBR-2026-07-12). Since #231
+            // cross_plugin_query HAS depth= (text/json), so its containers carry the SAME generic hint as
+            // read_record — the old "no depth=; expand via batch_record_detail" redirect must be GONE (it named a
+            // gap that no longer exists). The dense render still refuses depth>1 (positional cells), so ITS hint
+            // names the format hop — that arm lives in bulk-query-primitives-guard. A write read-back (no knob at
+            // all) keeps the bare count.
             Console.WriteLine();
-            Console.WriteLine("── container hint: cross_plugin_query names the batch hop (no depth= here); read tools keep depth=2; write read-backs stay bare ──");
+            Console.WriteLine("── container hint: cross_plugin_query text/json now hint depth=2 directly (#231); write read-backs stay bare ──");
             var cqList = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
                 conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: null,
                 resolve_names: false, winner_fields: false, fields: new[] { "Keywords" }, conflict_tree: false,
                 format: "text", limit: 500, max_chars: 0);
-            Check("cross_plugin_query container note redirects to housecarl_batch_record_detail depth=2",
-                  cqList.Contains("housecarl_batch_record_detail depth=2"));
-            Check("... and does NOT hint 'pass depth=2 to expand' — a knob this tool refuses",
-                  !cqList.Contains("pass depth=2 to expand"));
+            Check("cross_plugin_query container note hints the tool's OWN depth= (' — pass depth=2 to expand', #231)",
+                  cqList.Contains("pass depth=2 to expand"));
+            Check("... and the retired batch_record_detail redirect is GONE (it described the closed gap)",
+                  !cqList.Contains("housecarl_batch_record_detail depth=2"));
 
             var cqListJson = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
                 conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: null,
                 resolve_names: false, winner_fields: false, fields: new[] { "Keywords" }, conflict_tree: false,
                 format: "json", limit: 500, max_chars: 0);
-            Check("json parity: the redirect note rides the json render too, never the depth= hint",
-                  cqListJson.Contains("housecarl_batch_record_detail depth=2") && !cqListJson.Contains("pass depth=2 to expand"));
+            Check("json parity: the depth= hint rides the json render too, never the retired redirect",
+                  cqListJson.Contains("pass depth=2 to expand") && !cqListJson.Contains("housecarl_batch_record_detail depth=2"));
 
             var rrHint = svc.ResolveRead(w1Fk, null, new[] { "Keywords" }, false);
             var rrNote = rrHint.Record?.Fields.FirstOrDefault(f => f.Path == "Keywords")?.Note;

--- a/src/housecarl-generator/BulkQueryPrimitivesProbe.cs
+++ b/src/housecarl-generator/BulkQueryPrimitivesProbe.cs
@@ -402,6 +402,23 @@ public static class BulkQueryPrimitivesProbe
                 fields: null, depth: 2, conflict_tree: false, limit: 500, max_chars: 0);
             Check("depth=2 WITHOUT fields= is REFUSED loud (never silently ignored)",
                   sDNoF.StartsWith("error:", StringComparison.OrdinalIgnoreCase) && sDNoF.Contains("fields=", StringComparison.OrdinalIgnoreCase));
+
+            // conflict_tree=true without fields= is a WHOLE-RECORD dump (PR #244 review, MEDIUM): its containers
+            // hint 'pass depth=2', so that exact call must WORK — read_record's no-fields depth semantics.
+            var sDTree = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: null,
+                fields: null, depth: 2, conflict_tree: true, limit: 500, max_chars: 0);
+            Check("depth=2 + conflict_tree (no fields=) WORKS — the whole-record dump expands (its own hint led here)",
+                  !sDTree.StartsWith("error:", StringComparison.OrdinalIgnoreCase) && sDTree.Contains("Keywords[0]"));
+
+            // depth under group_by gets its OWN refusal (PR #244 review, LOW): the old fields-refusal advised
+            // 'pass fields=' — a dead end group_by itself refuses. The message must name group_by, not that trap.
+            var sDGroup = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: "winner",
+                fields: null, depth: 2, conflict_tree: false, limit: 500, max_chars: 0);
+            Check("depth=2 + group_by is REFUSED naming group_by's count table (never the 'pass fields=' dead end)",
+                  sDGroup.StartsWith("error:", StringComparison.OrdinalIgnoreCase) && sDGroup.Contains("group_by", StringComparison.OrdinalIgnoreCase)
+                  && sDGroup.Contains("count table", StringComparison.OrdinalIgnoreCase));
             var sDDense = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
                 conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: null,
                 fields: new[] { "Keywords" }, depth: 2, conflict_tree: false, limit: 500, max_chars: 0, format: "dense");

--- a/src/housecarl-generator/BulkQueryPrimitivesProbe.cs
+++ b/src/housecarl-generator/BulkQueryPrimitivesProbe.cs
@@ -19,6 +19,9 @@ namespace HousecarlGenerator;
 ///   • #223 <c>offset=</c> pagination (windows tile the enumeration exactly; refusals for negative / group_by) and
 ///     <c>format=dense</c> (the columnar render: columns once + positional rows, cross-checked against the plain
 ///     summaries and the known winner field values, and materially smaller than format=json for the same query).
+///   • #231 <c>depth=</c> — expand list/dict contents of fields= paths per match (read_record's semantics, applied
+///     to the scan; text+json, resolve_names composes); refused loud without fields= and under format=dense
+///     (positional cells), whose container cells hint the text/json hop instead of a blind knob.
 ///
 /// Synthesizes a 2-plugin order ON DISK (a master + a replacer that OVERRIDES one weapon and DEFINES new ones, with
 /// keyword links so references= has something to reverse) and drives the REAL service-layer scan
@@ -353,6 +356,66 @@ public static class BulkQueryPrimitivesProbe
                 fields: null, conflict_tree: false, limit: 500, max_chars: 0, format: "csv");
             Check("format=csv is REFUSED naming text/json/dense",
                   sBadFmt.StartsWith("error:", StringComparison.OrdinalIgnoreCase) && sBadFmt.Contains("dense", StringComparison.OrdinalIgnoreCase));
+
+            // ================= #231 — depth= expands fields= containers per match =================
+            Console.WriteLine();
+            Console.WriteLine("── #231: depth= expands list/dict contents in the scan; refusals keep summary/dense honest ──");
+
+            // Default depth=1: a container renders the count + the GENERIC 'pass depth=2' hint — the old
+            // "cross_plugin_query has no depth=; expand via batch_record_detail" redirect must be GONE.
+            var sD1 = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: null,
+                fields: new[] { "Keywords" }, conflict_tree: false, limit: 500, max_chars: 0);
+            Check("depth default (1): Keywords renders as a count with the generic 'pass depth=2 to expand' hint",
+                  sD1.Contains("pass depth=2 to expand") && !sD1.Contains("has no depth="));
+
+            // depth=2 (text): elements expand across ALL matches — W1 (1 keyword) and W3 (2 keywords) each show
+            // exactly their OWN indices, with none of the out-of-bounds noise the hand-written bracket paths caused.
+            var sD2 = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: null,
+                fields: new[] { "Keywords" }, depth: 2, conflict_tree: false, limit: 500, max_chars: 0);
+            Check("depth=2 text: expanded elements appear (Keywords[0] everywhere, Keywords[1] on W3) with NO out-of-bounds noise",
+                  sD2.Contains("Keywords[0]") && sD2.Contains("Keywords[1]") && !sD2.Contains("out of bounds", StringComparison.OrdinalIgnoreCase));
+            Check("depth=2 text: the expanded leaf carries its round-trip FormKey token", sD2.Contains(kaFk.ToString()));
+
+            // resolve_names composes with the expansion — the #231 use case ('Effects with identities in one scan').
+            var sD2n = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: null,
+                fields: new[] { "Keywords" }, depth: 2, conflict_tree: false, resolve_names: true, limit: 500, max_chars: 0);
+            Check("depth=2 + resolve_names: expanded elements annotate → their target's editorid", sD2n.Contains("→ hcbpKwA"));
+
+            // json parity: depth=2 emits the SAME expanded paths in the json document's field objects.
+            var sD2j = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: null,
+                fields: new[] { "Keywords" }, depth: 2, conflict_tree: false, limit: 500, max_chars: 0, format: "json");
+            using (var doc = JsonDocument.Parse(sD2j))
+            {
+                bool found = doc.RootElement.GetProperty("matches").EnumerateArray().Any(m =>
+                    m.TryGetProperty("fields", out var fs) && fs.EnumerateArray().Any(f => f.GetProperty("path").GetString() == "Keywords[0]"));
+                Check("depth=2 json: matches carry the expanded field paths (Keywords[0])", found);
+            }
+
+            // refusals (Q3): depth>1 without fields= (summary lines have nothing to expand); depth>1 under
+            // format=dense (positional cells align 1:1 with the requested paths).
+            var sDNoF = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: null,
+                fields: null, depth: 2, conflict_tree: false, limit: 500, max_chars: 0);
+            Check("depth=2 WITHOUT fields= is REFUSED loud (never silently ignored)",
+                  sDNoF.StartsWith("error:", StringComparison.OrdinalIgnoreCase) && sDNoF.Contains("fields=", StringComparison.OrdinalIgnoreCase));
+            var sDDense = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: null,
+                fields: new[] { "Keywords" }, depth: 2, conflict_tree: false, limit: 500, max_chars: 0, format: "dense");
+            Check("depth=2 + format=dense is REFUSED loud, naming the text/json hop",
+                  sDDense.StartsWith("error:", StringComparison.OrdinalIgnoreCase) && sDDense.Contains("dense", StringComparison.OrdinalIgnoreCase)
+                  && sDDense.Contains("json", StringComparison.OrdinalIgnoreCase));
+
+            // dense at depth=1 still renders — its container cells hint the FORMAT hop with the knob, so the
+            // "pass depth=2" advice never sends a dense caller into a blind refusal.
+            var sDenseKw = ReadTools.CrossPluginQuery(svc, type: "Weapon", references: null, editorid_contains: null,
+                conflicts_only: false, plugins: null, defined_in: false, where: null, group_by: null,
+                fields: new[] { "Keywords" }, conflict_tree: false, limit: 500, max_chars: 0, format: "dense");
+            Check("dense (depth=1) container cells carry the format-hop hint ('pass depth=2 with format=text/json')",
+                  sDenseKw.Contains("pass depth=2 with format=text/json"));
 
             Console.WriteLine();
             Console.WriteLine($"=== bulk-query-primitives-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -251,7 +251,7 @@ static class JsonWire
     /// (<c>{formid,type,editorid,winner,override_depth}</c>). Q3 accounting (total/capped/notes/truncated) rides
     /// in-band. The detail path threads resolve_names through the SAME ResolveRead the text render uses, so the two
     /// modes read one path.</summary>
-    public static string RenderCrossQuery(LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields, int maxChars, bool resolveNames, bool winnerFields)
+    public static string RenderCrossQuery(LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields, int maxChars, bool resolveNames, bool winnerFields, int depth = 1)
     {
         int cap = Cap(maxChars);
         using var ms = new MemoryStream();
@@ -301,8 +301,7 @@ static class JsonWire
                     {
                         // winner_fields=: read the WINNER's body (source=null) regardless of scan scope; the record's
                         // "source" field still names the body read, so the json carries the same source/winner truth.
-                        var o = svc.ResolveRead(fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false, resolveNames: resolveNames, linkMemo: linkMemo,
-                                                containerHint: Wire.CrossQueryContainerHint);   // no depth= on this tool — same redirect as the text render
+                        var o = svc.ResolveRead(fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false, depth, resolveNames: resolveNames, linkMemo: linkMemo);
                         if (o.Error is not null) { w.WriteStartObject(); w.WriteString("formid", fk.ToString()); w.WriteString("error", o.Error); if (matches is not null) w.WriteString("matches", matches); w.WriteEndObject(); }
                         else WriteReadRecord(w, o, ms, cap, matches);
                     }
@@ -389,7 +388,7 @@ static class JsonWire
                     if (detail)
                     {
                         var o = svc.ResolveRead(fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false,
-                                                resolveNames: resolveNames, linkMemo: linkMemo, containerHint: Wire.CrossQueryContainerHint);
+                                                resolveNames: resolveNames, linkMemo: linkMemo, containerHint: Wire.DenseContainerHint);   // dense refuses depth>1 — hint the format hop with the knob (#231)
                         if (o.Error is not null) { (errors ??= new()).Add((fk.ToString(), o.Error)); rendered++; continue; }
                         var r = o.Record!;
                         w.WriteStartArray();

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -167,7 +167,7 @@ public static class ReadTools
             string? group_by = null,
         [Description("Optional. Dotted field paths to show for each match (e.g. 'BasicStats.Damage'). Omit for a one-line summary per match. Pair with depth= to expand list/dict contents (fields=['Effects'], depth=4 shows every effect's Data in the scan — no hand-written 'Effects[0].Data.Magnitude' index guessing).")]
             string[]? fields = null,
-        [Description("Optional. With fields=: expansion depth for list/dict/substruct CONTENTS (#231; default 1 = a container shown as just a count like '[list: 3 item(s)]'), same semantics as housecarl_read_record / housecarl_batch_record_detail — depth=2 enumerates each element with index + identity, higher opens deeper (fields=['Effects'], depth=4 reaches every effect's Magnitude/Area/Duration). Applies to EVERY match in the scan. Requires fields= (refused loud without it — summary lines have nothing to expand). Not carried in format='dense' (columnar cells align 1:1 with the requested paths) — use format=text/json for depth expansion.")]
+        [Description("Optional. With fields= (or conflict_tree=true's whole-record dump): expansion depth for list/dict/substruct CONTENTS (#231; default 1 = a container shown as just a count like '[list: 3 item(s)]'), same semantics as housecarl_read_record / housecarl_batch_record_detail — depth=2 enumerates each element with index + identity, higher opens deeper (fields=['Effects'], depth=4 reaches every effect's Magnitude/Area/Duration). Applies to EVERY match in the scan. Refused loud on a surface with nothing to expand: bare summary lines (no fields=/conflict_tree) and group_by= (a count table has no field values). Not carried in format='dense' (columnar cells align 1:1 with the requested paths) — use format=text/json for depth expansion.")]
             int depth = 1,
         [Description("When true, include each match's touching-plugin list (winner last) + winner-relative field diff.")]
             bool conflict_tree = false,
@@ -191,8 +191,10 @@ public static class ReadTools
         if (group_by is not null && ((fields is { Length: > 0 }) || conflict_tree))
             return "error: group_by aggregates matches into a count table and cannot be combined with fields= or conflict_tree=true (those expand each match to full detail — pick one). Drop fields=/conflict_tree, or drop group_by.";
         if (depth <= 0) depth = 1;
-        if (depth > 1 && fields is not { Length: > 0 })
-            return "error: depth= expands the list/dict contents of fields= paths, and no fields= was passed — summary lines have nothing to expand. Pass fields= (e.g. fields=['Effects'], depth=4), or drop depth=.";
+        if (depth > 1 && group_by is not null)
+            return "error: depth= expands per-match field contents, and group_by= renders a count table with no field values — depth= never applies there. Drop depth= (or drop group_by= and pass fields= for per-match detail).";
+        if (depth > 1 && fields is not { Length: > 0 } && !conflict_tree)
+            return "error: depth= expands the list/dict contents of fields= paths, and no fields= was passed — summary lines have nothing to expand. Pass fields= (e.g. fields=['Effects'], depth=4) or conflict_tree=true (the whole-record dump), or drop depth=.";
         if (depth > 1 && fmt is Wire.QueryFormat.Dense)
             return "error: depth>1 is not carried in format='dense' — dense rows are positional (one cell per requested fields= path), and depth expansion emits extra sub-paths that would break the column alignment. Use format=text or format=json for depth expansion, or drop depth= for the dense summary cells.";
         IReadOnlyList<FormKey>? refFks = null;

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -165,8 +165,10 @@ public static class ReadTools
             string[]? where = null,
         [Description("Optional. Aggregate matches into a count table (sorted desc) instead of listing them: 'winner' (by load-order-winning plugin), 'type' (by record type — needs type= or plugins=), or 'defined_in' (by defining plugin). Counts ALL matches (not capped by limit=). Cannot combine with fields= or conflict_tree=.")]
             string? group_by = null,
-        [Description("Optional. Dotted field paths to show for each match (e.g. 'BasicStats.Damage'). Omit for a one-line summary per match.")]
+        [Description("Optional. Dotted field paths to show for each match (e.g. 'BasicStats.Damage'). Omit for a one-line summary per match. Pair with depth= to expand list/dict contents (fields=['Effects'], depth=4 shows every effect's Data in the scan — no hand-written 'Effects[0].Data.Magnitude' index guessing).")]
             string[]? fields = null,
+        [Description("Optional. With fields=: expansion depth for list/dict/substruct CONTENTS (#231; default 1 = a container shown as just a count like '[list: 3 item(s)]'), same semantics as housecarl_read_record / housecarl_batch_record_detail — depth=2 enumerates each element with index + identity, higher opens deeper (fields=['Effects'], depth=4 reaches every effect's Magnitude/Area/Duration). Applies to EVERY match in the scan. Requires fields= (refused loud without it — summary lines have nothing to expand). Not carried in format='dense' (columnar cells align 1:1 with the requested paths) — use format=text/json for depth expansion.")]
+            int depth = 1,
         [Description("When true, include each match's touching-plugin list (winner last) + winner-relative field diff.")]
             bool conflict_tree = false,
         [Description("When true (with fields=), annotate every FormLink field value with its target's identity (→ editorid \"Name\"), resolved against the load order and cached across all matches. Display-only; the token is unchanged. No effect on summary lines or group_by (there are no field tokens to annotate).")]
@@ -188,6 +190,11 @@ public static class ReadTools
         if (fmt is not Wire.QueryFormat.Text && conflict_tree) return $"error: conflict_tree=true is a text-only diff view and is not carried in {(fmt is Wire.QueryFormat.Json ? "json" : "dense")} mode — use format=text for the conflict tree, or drop conflict_tree for the field data.";
         if (group_by is not null && ((fields is { Length: > 0 }) || conflict_tree))
             return "error: group_by aggregates matches into a count table and cannot be combined with fields= or conflict_tree=true (those expand each match to full detail — pick one). Drop fields=/conflict_tree, or drop group_by.";
+        if (depth <= 0) depth = 1;
+        if (depth > 1 && fields is not { Length: > 0 })
+            return "error: depth= expands the list/dict contents of fields= paths, and no fields= was passed — summary lines have nothing to expand. Pass fields= (e.g. fields=['Effects'], depth=4), or drop depth=.";
+        if (depth > 1 && fmt is Wire.QueryFormat.Dense)
+            return "error: depth>1 is not carried in format='dense' — dense rows are positional (one cell per requested fields= path), and depth expansion emits extra sub-paths that would break the column alignment. Use format=text or format=json for depth expansion, or drop depth= for the dense summary cells.";
         IReadOnlyList<FormKey>? refFks = null;
         if (references is { Length: > 0 })
         {
@@ -206,8 +213,8 @@ public static class ReadTools
         return fmt switch
         {
             Wire.QueryFormat.Dense when group_by is null => JsonWire.RenderCrossQueryDense(svc, outcome, fields, max_chars, resolve_names, winner_fields),
-            Wire.QueryFormat.Dense or Wire.QueryFormat.Json => JsonWire.RenderCrossQuery(svc, outcome, fields, max_chars, resolve_names, winner_fields),
-            _ => Wire.RenderCrossQuery(svc, outcome, fields, conflict_tree, max_chars, resolve_names, winner_fields),
+            Wire.QueryFormat.Dense or Wire.QueryFormat.Json => JsonWire.RenderCrossQuery(svc, outcome, fields, max_chars, resolve_names, winner_fields, depth),
+            _ => Wire.RenderCrossQuery(svc, outcome, fields, conflict_tree, max_chars, resolve_names, winner_fields, depth),
         };
     });
 
@@ -542,13 +549,15 @@ static class Wire
 
     // ---- housecarl_cross_plugin_query ---------------------------------------------------------------
 
-    /// <summary>The container hint for cross_plugin_query field expansions: this tool has NO depth= parameter, so the
-    /// generic " — pass depth=2 to expand" would name a knob the tool refuses (the unknown-param guard rejects depth=)
-    /// — the honest redirect is the batch-read hop. Shared by the text render (here) and <see cref="JsonWire"/>.</summary>
-    internal const string CrossQueryContainerHint = " — cross_plugin_query has no depth=; expand these via housecarl_batch_record_detail depth=2";
+    /// <summary>The container hint for the DENSE render's field cells: dense refuses depth&gt;1 (positional cells align
+    /// 1:1 with the requested paths — #231), so the generic " — pass depth=2 to expand" alone would send the caller
+    /// into that refusal blind. Name the format hop with the knob. Used only by
+    /// <see cref="JsonWire.RenderCrossQueryDense"/>; the text/json renders take depth= directly and use the generic
+    /// <see cref="HousecarlCore.ReadEngine.DepthExpandHint"/>.</summary>
+    internal const string DenseContainerHint = " — pass depth=2 with format=text/json to expand (dense cells are positional)";
 
     public static string RenderCrossQuery(LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields, bool conflictTree, int maxChars,
-                                          bool resolveNames = false, bool winnerFields = false)
+                                          bool resolveNames = false, bool winnerFields = false, int depth = 1)
     {
         if (q.Error is not null) return "error: " + q.Error;
         int cap = Cap(maxChars);
@@ -596,8 +605,7 @@ static class Wire
             {
                 // winner_fields=: read the load-order WINNER's body (source=null) regardless of scan scope; else the
                 // body the scan filtered (scoped plugin under plugins=, else winner) — so display never contradicts filter.
-                var o = svc.ResolveRead(fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, conflictTree, resolveNames: resolveNames, linkMemo: linkMemo,
-                                        containerHint: CrossQueryContainerHint);   // this tool has no depth= — don't hint a knob it refuses
+                var o = svc.ResolveRead(fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, conflictTree, depth, resolveNames: resolveNames, linkMemo: linkMemo);
                 sb.Append('\n');
                 if (matches is not null) sb.Append("  ").Append(fk).Append("  matches=").Append(matches).Append('\n');
                 if (o.Error is not null) sb.Append(fk).Append(": error: ").Append(o.Error).Append('\n');


### PR DESCRIPTION
## What

`housecarl_cross_plugin_query` gains **`depth=`** (#231) with the same semantics as `housecarl_read_record` / `batch_record_detail`, applied to every match in the scan: `fields=["Effects"], depth=4` expands each record's per-effect Data in one call. Each match shows exactly its **own** elements — no guessing the longest list, none of the out-of-bounds error triples that blew the reporting session's 66-spell scan past the token cap twice. `resolve_names=` composes with the expansion.

## How

Deliberately thin: `LoadOrderService.ResolveRead` already took `depth` — the tool now validates it and threads it through `Wire.RenderCrossQuery` (text) and `JsonWire.RenderCrossQuery` (json) to the existing per-match `ResolveRead` calls. No service/scan changes; `where=` predicates were already depth-independent.

## Decisions surfaced (flagging per convention)

1. **`depth>1` + `format=dense` is a loud refusal**, not a rendering attempt. Dense rows are positional — one cell per requested `fields=` path (the documented columnar contract from #223). Depth expansion emits *extra* sub-paths per record (`Keywords[0]`, `Keywords[1]`, …, varying per row), which has no honest positional encoding. The refusal names the hop: use `format=text/json` for depth expansion. A future "dense subtree cells" design is possible but out of scope here — shout if you want it filed.
2. **`depth>1` without `fields=` is a loud refusal** — cross_plugin_query has no whole-record dump mode (summary lines have nothing to expand), so silently ignoring depth would be a Q3 violation.
3. **Hint retirement**: `CrossQueryContainerHint` ("cross_plugin_query has no depth=; expand these via housecarl_batch_record_detail depth=2") described exactly the gap this PR closes — retired. Text/json container notes now carry the generic `— pass depth=2 to expand`; dense containers carry a new format-hop hint (`— pass depth=2 with format=text/json to expand (dense cells are positional)`) so the advice never routes a dense caller into the refusal blind.

## Gates

- `bulk-query-primitives-guard`: **58 → 66 asserts**, all PASS — default-depth hint swap (old redirect gone), text expansion with no out-of-bounds noise, round-trip token intact, `resolve_names` composition, json path parity, both refusals, dense format-hop hint.
- `bulk-primitives-wave2-guard`'s container-hint arms (still 60 asserts) **inverted to the new contract** — they guarded "the tool has no depth=, so redirect to batch_record_detail"; that's now false by design, so the same arms assert text/json carry the generic depth hint and the retired redirect is gone. (ci-all caught this drift on the first run — the arms weren't deleted, they now guard the opposite truth.)
- ci-all: 100/100 PASS (the count grew to 100 when #229 landed its probe on main).
- `plugin/CHANGELOG.md` `## Unreleased` entry included.

Fixes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)
