### PR TITLE
fix(query): case-fold group_by plugin keys so case-variant spellings merge (#248)

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,14 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**`housecarl_cross_plugin_query` `group_by=` now case-folds plugin keys — case-variant spellings of one plugin no
+longer split into separate groups (#248).** A load-order-wide `group_by=defined_in` (or `=winner`) counted the same
+plugin twice when different plugins spelled a shared master with different casing — e.g. `ccBGSSSE025-AdvDSGS.esm = 40`
+*and* `ccbgssse025-advdsgs.esm = 35` as two rows — so any consumer summing per-plugin counts silently double-grouped.
+Plugin filenames are case-insensitive identifiers everywhere else in houseCARL (and in the game); group keys now match,
+merging the counts (first-seen casing is displayed). `group_by=type` is unaffected (record-type names never differ only
+by case).
+
 **`housecarl_cross_plugin_query` gains `where_source=winner` — filter on the live winner, not the scoped body (#233).**
 Under a `plugins=` scope the body filters (`where=`, `references=`, `editorid_contains=`) decided the match against
 each match's *scoped* plugin body, even with `winner_fields=true` — so a post-patch audit like "Bruma-defined NPCs

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -9,12 +9,14 @@ when it changes.
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
 **`housecarl_cross_plugin_query` `group_by=` now case-folds plugin keys — case-variant spellings of one plugin no
-longer split into separate groups (#248).** A load-order-wide `group_by=defined_in` (or `=winner`) counted the same
-plugin twice when different plugins spelled a shared master with different casing — e.g. `ccBGSSSE025-AdvDSGS.esm = 40`
-*and* `ccbgssse025-advdsgs.esm = 35` as two rows — so any consumer summing per-plugin counts silently double-grouped.
-Plugin filenames are case-insensitive identifiers everywhere else in houseCARL (and in the game); group keys now match,
-merging the counts (first-seen casing is displayed). `group_by=type` is unaffected (record-type names never differ only
-by case).
+longer split into separate groups (#248).** A load-order-wide `group_by=defined_in` counted the same plugin twice when
+different plugins spelled a shared master with different casing — e.g. `ccBGSSSE025-AdvDSGS.esm = 40` *and*
+`ccbgssse025-advdsgs.esm = 35` as two rows — because a defining-plugin key carries each plugin's own master-list
+spelling. Any consumer summing per-plugin counts silently double-grouped. Plugin filenames are case-insensitive
+identifiers everywhere else in houseCARL (and in the game); group keys now match, merging the counts (first-seen casing
+is displayed). The same case-fold covers `group_by=winner` for consistency (its keys come from one canonical name array,
+so they don't vary in casing the way `defined_in` keys do); `group_by=type` is unaffected (record-type names never
+differ only by case).
 
 **`housecarl_cross_plugin_query` gains `where_source=winner` — filter on the live winner, not the scoped body (#233).**
 Under a `plugins=` scope the body filters (`where=`, `references=`, `editorid_contains=`) decided the match against

--- a/src/housecarl-generator/BulkQueryPrimitivesProbe.cs
+++ b/src/housecarl-generator/BulkQueryPrimitivesProbe.cs
@@ -177,6 +177,57 @@ public static class BulkQueryPrimitivesProbe
             var badKey = svc.CrossQuery("Weapon", null, null, false, null, null, 500, groupBy: "bogus");
             Check("group_by=<unknown key> is REFUSED loud", badKey.Error is not null && badKey.Error.Contains("group_by", StringComparison.OrdinalIgnoreCase));
 
+            // ================= #248 — group_by keys are CASE-FOLDED (case-variant plugin spellings merge) =================
+            // A load-order-wide group_by=defined_in split case-variant spellings of the SAME master into two rows
+            // (ccBGSSSE025-AdvDSGS.esm=40 AND ccbgssse025-advdsgs.esm=35) because the group dictionary keyed Ordinal —
+            // any consumer summing per-plugin counts silently double-groups. Plugin filenames are case-insensitive
+            // identifiers everywhere else in houseCARL (and in the game), so the counts must merge (#248).
+            // Reproduced FAITHFULLY: two overrider plugins whose OWN masters lists spell the shared master with
+            // different casing. The scan reads each plugin's own body (LoadOrderService.RecordsIn), so the origin
+            // ModKey it reports for a record carries THAT plugin's master spelling — the exact real-world source of
+            // the split. A(mixed) overrides one master weapon, B(lower) overrides a different one → 2 distinct FKs,
+            // same master, variant casing. Ordinal → two groups of 1; OrdinalIgnoreCase → one group of 2.
+            Console.WriteLine();
+            Console.WriteLine("── #248: group_by keys are case-folded (case-variant plugin names merge into one group) ──");
+            const string cfMasterName = "hcbpcfMaster.esp", cfAName = "hcbpcfA.esp", cfBName = "hcbpcfB.esp";
+            var cfMasterPath = Path.Combine(dir, cfMasterName);
+            var cfAPath = Path.Combine(dir, cfAName);
+            var cfBPath = Path.Combine(dir, cfBName);
+
+            var cfMaster = new SkyrimMod(ModKey.FromNameAndExtension(cfMasterName), SkyrimRelease.SkyrimSE);
+            var cw1 = cfMaster.Weapons.AddNew(); cw1.EditorID = "hcbpcfSword1"; cw1.BasicStats = new WeaponBasicStats { Damage = 10 };
+            var cw2 = cfMaster.Weapons.AddNew(); cw2.EditorID = "hcbpcfSword2"; cw2.BasicStats = new WeaponBasicStats { Damage = 20 };
+            cfMaster.BeginWrite.ToPath(cfMasterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+            // A overrides cw1, listing the master with its ON-DISK (mixed) casing.
+            var cfA = new SkyrimMod(ModKey.FromNameAndExtension(cfAName), SkyrimRelease.SkyrimSE);
+            _ = WriteEngine.GenericGetOrAddAsOverride(cfA, cw1);
+            cfA.BeginWrite.ToPath(cfAPath).WithLoadOrder(new ISkyrimModGetter[] { cfMaster }).Write();
+
+            // B overrides cw2 through a LOWERCASE-cased handle of the same master (ModKey equality is case-insensitive,
+            // so it still resolves to the on-disk file) — so B's masters entry, and the origin ModKey the scan reports
+            // for B's records, is lowercase.
+            var cfMasterLc = new SkyrimMod(ModKey.FromNameAndExtension(cfMasterName.ToLowerInvariant()), SkyrimRelease.SkyrimSE);
+            var cw2Lc = new Weapon(new FormKey(cfMasterLc.ModKey, cw2.FormKey.ID), SkyrimRelease.SkyrimSE) { EditorID = "hcbpcfSword2" };
+            var cfB = new SkyrimMod(ModKey.FromNameAndExtension(cfBName), SkyrimRelease.SkyrimSE);
+            _ = WriteEngine.GenericGetOrAddAsOverride(cfB, cw2Lc);
+            cfB.BeginWrite.ToPath(cfBPath).WithLoadOrder(new ISkyrimModGetter[] { cfMasterLc }).Write();
+
+            using (var cfResolver = LoadOrderResolver.Build(new[] { cfMasterPath, cfAPath, cfBPath }))
+            {
+                var cfSvc = LoadOrderService.ForGuard(cfResolver, new UserConfigStore(Path.Combine(dir, "houseCARL.cf.user.json")));
+                var byDef248 = cfSvc.CrossQuery(null, null, null, false, new[] { cfAName, cfBName }, null, 500, groupBy: "defined_in");
+                // Setup sanity: the two overrides ARE seen (2 touched records) — the variance test has something to fold.
+                Check($"#248 setup: plugins=[A,B] group_by=defined_in sees 2 touched records — got total {byDef248.Total}",
+                      byDef248.Total == 2);
+                // The fix: ONE merged group of count 2, not two case-variant rows of 1 each (the Ordinal-comparer bug).
+                Check($"#248: case-variant master spellings MERGE into one group of count 2 — got {byDef248.Groups?.Count ?? 0} group(s)",
+                      byDef248.Groups is { Count: 1 } && byDef248.Groups[0].Count == 2);
+                // And the merged display key is a REAL spelling of the master (first-seen), never blank or mangled.
+                Check("#248: the merged group key is a real (case-folded) master spelling",
+                      byDef248.Groups is { Count: 1 } && string.Equals(byDef248.Groups[0].Key, cfMasterName, StringComparison.OrdinalIgnoreCase));
+            }
+
             // ================= tool-layer refusal — group_by cannot combine with fields=/conflict_tree= =================
             Console.WriteLine();
             Console.WriteLine("── tool-layer guard: group_by= vs fields=/conflict_tree= ──");

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2395,7 +2395,12 @@ public sealed class LoadOrderService : IDisposable
         var sources = new List<string?>();                                    // parallel to keys: the plugin whose body matched (null ⇒ winner), so the render displays the SAME body it filtered
         List<string?>? matched = multiTarget ? new() : null;                  // parallel to keys: which target(s) each hit referenced (multi-target references= un-merge); null when 0/1 target
         List<RecordSummary>? prefilled = (hasType || hasPlugins) ? new() : null;   // parallel to keys; null = renderer fills lazily
-        Dictionary<string, int>? groups = groupBy is not null ? new(StringComparer.Ordinal) : null;   // group_by= aggregation (bumped per match, over ALL matches — not limit-capped)
+        // OrdinalIgnoreCase so case-variant spellings of the SAME plugin — a master listed as `ccBGSSSE025-AdvDSGS.esm`
+        // in one plugin's masters and `ccbgssse025-advdsgs.esm` in another's — merge into ONE group instead of splitting
+        // the count (#248). Plugin filenames are case-insensitive identifiers everywhere else in houseCARL (and in the
+        // game); first-seen casing becomes the display key. Harmless for group_by=type (record type names never differ
+        // only by case), so this one comparer correctly covers all three keys (winner / type / defined_in).
+        Dictionary<string, int>? groups = groupBy is not null ? new(StringComparer.OrdinalIgnoreCase) : null;   // group_by= aggregation (bumped per match, over ALL matches — not limit-capped)
         int total = 0;
         int unscannable = 0;                                                  // records whose body tests THREW (Mutagen-unparseable content) — excluded + accounted, never silent (Q3)
         var unscannableSamples = new List<string>();


### PR DESCRIPTION
## What & why

`cross_plugin_query` `group_by=defined_in` / `=winner` keyed its aggregation dictionary with `StringComparer.Ordinal`, so a load-order-wide count **split case-variant spellings of the same plugin into separate rows** — observed live:

- `ccBGSSSE025-AdvDSGS.esm = 40` **and** `ccbgssse025-advdsgs.esm = 35` as two groups
- `ccBGSSSE001-Fish.esm = 10` **and** `ccbgssse001-fish.esm = 15` as two groups

Plugin filenames are case-insensitive identifiers everywhere else in houseCARL (and in the game), so any consumer summing per-plugin counts **silently double-grouped** — a Q3 silent-wrong-answer.

## The fix

One line: key the group dictionary `OrdinalIgnoreCase` (`LoadOrderService.cs`). Both scan paths (body-bearing and conflicts-only) and all three `group_by` modes funnel into this one dictionary, so the single comparer covers them all — first-seen casing displays, counts merge. `group_by=type` is unaffected (record-type names never differ only by case). Default behavior for correctly-cased orders is unchanged.

## Guard

`bulk-query-primitives-guard` **82 → 85**. The new arm reproduces the split **faithfully**: two overrider plugins whose own masters lists spell a shared master with different casing, so the scan (`RecordsIn`, which reads each plugin's own body) reports variant-cased origin ModKeys — the exact real-world source of the split. It asserts one merged group of count 2.

Verified as a real regression guard: it **FAILS on the old `Ordinal` comparer** (2 groups) and **passes on `OrdinalIgnoreCase`** (1 merged group of 2). `ci-all` **100/100**.

## Scope note

The issue's "Ask" also says to *audit* `group_by=winner` for the same behavior — done: `winner` keys the same dictionary, so it's fixed by the same change (and the guard's `defined_in` arm exercises the shared comparer).

Fixes #248
