### PR TITLE
fix(read): owned-record identity + condition-arm params at the depth floor (#252, #258)

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -10,11 +10,12 @@ when it changes.
 
 **`housecarl_read_record` / `housecarl_batch_record_detail` `depth=2` now surfaces an owned-record list element's own FormID (#252).**
 A list whose elements are themselves owned records — most commonly a DIAL topic's `Responses` (each element an INFO record) —
-rendered each element as a bare `[DialogResponses]` at `depth=2`, with no FormID or EditorID, so mapping topics to their child
-INFOs meant a second call with explicit `[i].FormKey` paths (and you couldn't enumerate those paths without first reading the
-element count). The `depth=2` "index + identity" contract now holds for owned-record elements the way it already did for
-lone-FormLink structs (#198): each renders `[DialogResponses 000ABC:Plugin.esp editorid=…]` — its own FormKey, plus EditorID
-when present. Applies wherever `depth=` expands (text and `format=json`).
+surfaced no FormID at `depth=2`: an element rendered a bare `[DialogResponses]` (or `[DialogResponses] EditorID=…` when the INFO
+carried an EditorID), never the FormKey that is an owned record's canonical identity. Mapping topics to their child INFOs meant a
+second call with explicit `[i].FormKey` paths (and you couldn't enumerate those paths without first reading the element count).
+The `depth=2` "index + identity" contract now holds for owned-record elements the way it already did for lone-FormLink structs
+(#198): each leads with `[DialogResponses 000ABC:Plugin.esp editorid=…]` — its own FormKey, plus EditorID when present. Applies
+wherever `depth=` expands (text and `format=json`).
 
 **`Conditions[].Data` arm parameters now expand in a `Conditions` list dump (#258).** A polymorphic condition-data arm reached by
 expanding a `Conditions` list stopped at its bare `[GetFactionRankConditionData]` type — its parameter fields (`Faction`, `Global`,

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,22 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**`housecarl_read_record` / `housecarl_batch_record_detail` `depth=2` now surfaces an owned-record list element's own FormID (#252).**
+A list whose elements are themselves owned records — most commonly a DIAL topic's `Responses` (each element an INFO record) —
+rendered each element as a bare `[DialogResponses]` at `depth=2`, with no FormID or EditorID, so mapping topics to their child
+INFOs meant a second call with explicit `[i].FormKey` paths (and you couldn't enumerate those paths without first reading the
+element count). The `depth=2` "index + identity" contract now holds for owned-record elements the way it already did for
+lone-FormLink structs (#198): each renders `[DialogResponses 000ABC:Plugin.esp editorid=…]` — its own FormKey, plus EditorID
+when present. Applies wherever `depth=` expands (text and `format=json`).
+
+**`Conditions[].Data` arm parameters now expand in a `Conditions` list dump (#258).** A polymorphic condition-data arm reached by
+expanding a `Conditions` list stopped at its bare `[GetFactionRankConditionData]` type — its parameter fields (`Faction`, `Global`,
+`Reference`, `RunOnType`, …) surfaced only when `Data` was addressed directly (`fields=["Conditions[2].Data"]`) or at an extra depth
+level, so a `fields=["Conditions"] depth=3` dump silently stopped one level short of the params. The depth-floor "open one bounded
+level" exception — previously VMAD-script-property-only — now also opens a condition arm's parameters, so a whole condition stack
+(function + params) reads in one call at the natural depth. Bounded to one level (an arm's members are leaves/links) and
+type-targeted (every other substruct still stops at the floor, unchanged).
+
 **`housecarl_cross_plugin_query` `group_by=` now case-folds plugin keys — case-variant spellings of one plugin no
 longer split into separate groups (#248).** A load-order-wide `group_by=defined_in` counted the same plugin twice when
 different plugins spelled a shared master with different casing — e.g. `ccBGSSSE025-AdvDSGS.esm = 40` *and*

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -538,8 +538,8 @@ public static class ReadEngine
         // way a top-level read does — #252, the #198 family carried to records. Checked BEFORE the Name/EditorID/
         // Title scan: for an owned record the FormKey IS the canonical identity (an INFO has no Name and usually no
         // EditorID — the exact case #198's lone-FormLink path can't reach), and EditorID rides along when present,
-        // so a depth=2 owned-record list reads "[DialogResponses 04D9A74:Plugin.esp editorid=…]" — its own id — not
-        // a bare opaque [Type] one level longer than the depth "index + identity" contract implies.
+        // so a depth=2 owned-record list reads "[DialogResponses 4D9A74:Plugin.esp editorid=…]" — its own id — not
+        // a bare opaque [Type] (or an EditorID-only line) one level longer than the depth "index + identity" implies.
         if (val is IMajorRecordGetter mr)
             return $"[{typeName} {mr.FormKey}{(string.IsNullOrEmpty(mr.EditorID) ? "" : $" editorid={mr.EditorID}")}]";
         foreach (var idName in IdentityFieldNames)

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -358,17 +358,24 @@ public static class ReadEngine
         // a container or substruct — summarise (with an element identity where we can), then maybe open it.
         if (!Emit(sink, ref budget, new FieldValue(path, false, null, ElementSummary(val, isDict)))) return;
 
-        // A VMAD script property normally stops here at its identity summary (e.g. "[ScriptObjectProperty]
-        // Name=DAK_HorseBuyPerk"), hiding its VALUE. Surface that value ONE bounded level deeper even at the
-        // depth floor — the Object FormLink (incl. a declared-but-null link, the signal the quest-fragment
-        // linter keys on), the Data scalar, the Alias — so a read reaches parity with the write surface. A
-        // property's direct members are leaves (a *ListProperty arm shows as a count at the floor; raise
-        // depth= to enumerate it), so this opens exactly one level and never unbounded-descends a fat VMAD
-        // (1.3.1 item 2). EVERY OTHER substruct still stops at the floor, byte-for-byte unchanged.
+        // Two POLYMORPHIC-ARM families normally stop here at their identity summary, hiding their VALUE, and both
+        // surface it ONE bounded level deeper even at the depth floor so a read reaches parity with the write
+        // surface and with a direct per-arm path:
+        //   * a VMAD script property (e.g. "[ScriptObjectProperty] Name=DAK_HorseBuyPerk") — its Object FormLink
+        //     (incl. a declared-but-null link, the signal the quest-fragment linter keys on), Data scalar, Alias
+        //     (1.3.1 item 2);
+        //   * a Conditions[].Data arm (e.g. "[GetFactionRankConditionData]") — its parameter fields (Faction,
+        //     Global, Reference, RunOnType…), which otherwise appear ONLY when Data is addressed directly, never
+        //     via a Conditions-list dump (#258 — the arm consumed a "summary-only" level, so depth=3 stopped at the
+        //     bare arm type and you needed depth=4 or a per-row path).
+        // Each family's direct members are leaves/links (a VMAD *ListProperty arm shows as a count at the floor;
+        // raise depth= to enumerate it), so this opens exactly one level and never unbounded-descends. EVERY OTHER
+        // substruct still stops at the floor, byte-for-byte unchanged — the exception is these two arm families
+        // only, matched by their shared getter interface (no per-arm list).
         int childDepth = depth - 1;
         if (depth <= 1)
         {
-            if (!IsScriptProperty(val.GetType())) return;
+            if (!IsScriptProperty(val.GetType()) && !IsConditionData(val.GetType())) return;
             childDepth = 1;
         }
 
@@ -526,6 +533,15 @@ public static class ReadEngine
         if (val is System.Collections.IEnumerable && val is not string) return SummariseContainer(val, isDict);
         var t = val.GetType();
         var typeName = RecordNaming.StripGetterInterface(RecordNaming.StripOverlay(t.Name));
+        // An owned child RECORD element (an IMajorRecordGetter — a DIAL's Responses hold DialogResponses/INFO
+        // records, a CELL's references hold placed records; each owns its own FormKey) leads with its FormKey the
+        // way a top-level read does — #252, the #198 family carried to records. Checked BEFORE the Name/EditorID/
+        // Title scan: for an owned record the FormKey IS the canonical identity (an INFO has no Name and usually no
+        // EditorID — the exact case #198's lone-FormLink path can't reach), and EditorID rides along when present,
+        // so a depth=2 owned-record list reads "[DialogResponses 04D9A74:Plugin.esp editorid=…]" — its own id — not
+        // a bare opaque [Type] one level longer than the depth "index + identity" contract implies.
+        if (val is IMajorRecordGetter mr)
+            return $"[{typeName} {mr.FormKey}{(string.IsNullOrEmpty(mr.EditorID) ? "" : $" editorid={mr.EditorID}")}]";
         foreach (var idName in IdentityFieldNames)
         {
             var p = t.GetProperty(idName, BindingFlags.Public | BindingFlags.Instance);
@@ -907,9 +923,19 @@ public static class ReadEngine
     /// ScriptInt/Float/Bool/StringProperty arms, and the *ListProperty arms) — recognised by the shared getter
     /// interface, so every arm matches by construction with no per-arm list, on the overlay getter or the
     /// mutable type alike. The depth walker opens such a property's direct value members one bounded level past
-    /// the depth floor (1.3.1 item 2 — read parity with the write surface); every other substruct stops at the
-    /// floor, so this is the one type-targeted exception to the depth gate.</summary>
+    /// the depth floor (1.3.1 item 2 — read parity with the write surface). One of TWO type-targeted exceptions
+    /// to the depth gate (the other is <see cref="IsConditionData"/>); every other substruct stops at the floor.</summary>
     static bool IsScriptProperty(Type t) => typeof(IScriptPropertyGetter).IsAssignableFrom(t);
+
+    /// <summary>True if <paramref name="t"/> is a polymorphic CONDITION-DATA arm (GetActorValueConditionData,
+    /// GetFactionRankConditionData — every <c>ConditionData</c> subtype) — recognised by the shared
+    /// <c>IConditionDataGetter</c> interface, so every arm matches by construction with no per-arm list, on the
+    /// overlay getter or the mutable type alike. Like <see cref="IsScriptProperty"/> the depth walker opens such an
+    /// arm's parameter fields one bounded level past the depth floor so a <c>Conditions</c>-list dump reaches the
+    /// arm's params (Faction/Global/Reference/RunOnType…) without an extra depth level or a per-row <c>Data</c> path
+    /// (#258 — the params surfaced ONLY via a direct arm path before). An arm's direct members are leaves/links, so
+    /// this opens exactly one level and never unbounded-descends; every non-arm substruct still stops at the floor.</summary>
+    static bool IsConditionData(Type t) => typeof(IConditionDataGetter).IsAssignableFrom(t);
 
     static byte[] MemorySliceBytes(object slice)
     {

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -38,10 +38,19 @@ public static class CiAll
         ("pkcu-regression", PkcuProbe.RunRegression),
         ("depth-leak-guard", DepthLeakProbe.RunGuard),
         ("vmad-property-read-guard", VmadPropertyReadProbe.RunGuard),
+        // Conditions[].Data arm expansion (#258): the depth-floor "open one bounded level" exception — VMAD-property-
+        // only until now (vmad-property-read-guard's sibling) — also opens a polymorphic ConditionData arm's params,
+        // so a `Conditions` list dump at depth=3 reaches Data.ActorValue/Faction/… instead of stopping at the bare
+        // arm type. Bounded (one level), depth-not-lowered (depth=2 still suppresses), non-arm substructs still stop.
+        ("condition-arm-expand-guard", ConditionArmExpandProbe.RunGuard),
         // depth-2 element identity (#198): a struct with no Name/EditorID/Title but EXACTLY ONE FormLink surfaces
         // that link as its identity ([PerkPlacement] Perk=…) instead of a bare opaque [PerkPlacement]; name-identity
         // still wins over the lone link (fallback fires only when no name-like identity exists). Self-contained.
         ("element-identity-guard", ElementIdentityProbe.RunGuard),
+        // depth-2 element identity for an OWNED RECORD (#252): a list element that is itself an IMajorRecordGetter
+        // (DIAL Responses → DialogResponses/INFO) surfaces its OWN FormKey (+ EditorID when present) instead of a
+        // bare [DialogResponses] — the #198 family carried to records (FormKey is the identity, not a lone link).
+        ("owned-record-identity-guard", OwnedRecordIdentityProbe.RunGuard),
         ("floi-read-guard", FloiReadProbe.RunGuard),
         ("floi-fields-guard", FloiFieldsProbe.RunGuard),
         ("forward-from-plugin-guard", ForwardFromPluginProbe.RunGuard),

--- a/src/housecarl-generator/ConditionArmExpandProbe.cs
+++ b/src/housecarl-generator/ConditionArmExpandProbe.cs
@@ -1,0 +1,92 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SELF-CONTAINED CI REGRESSION GUARD for the depth-floor expansion of a polymorphic <c>Conditions[].Data</c> ARM
+/// (#258) — the sibling of <c>vmad-property-read-guard</c> on the SAME floor exception (<see cref="ReadEngine"/>'s
+/// Expand). A <c>ConditionData</c> arm reached via LIST expansion used to stop at its bare <c>[Type]</c> summary at
+/// the depth floor — its parameter fields surfaced ONLY when <c>Data</c> was addressed directly — so a
+/// <c>Conditions</c> dump at the natural depth=3 showed <c>[GetActorValueConditionData]</c> but never the params
+/// (you needed depth=4 or a per-row path). The floor now opens a condition arm's parameter fields ONE bounded level,
+/// exactly as it already does for a VMAD script property.
+///
+/// Arms, all driving the PRODUCT read path (<see cref="ReadEngine.ReadFields"/>):
+///   * PARAMS-SURFACE (depth=3)       — a MagicEffect Conditions dump surfaces
+///     <c>Conditions[0].Data.ActorValue = Conjuration</c>. RED before (arm stopped at the floor), GREEN after.
+///   * SUMMARY-KEPT                    — the <c>[GetActorValueConditionData]</c> arm summary line is still present
+///     (params are additive, not a replacement).
+///   * BOUNDED                        — the arm opens EXACTLY one level: no field path is deeper than
+///     <c>Conditions[0].Data.&lt;param&gt;</c>.
+///   * DEPTH-NOT-LOWERED (depth=2)     — the SAME read at depth=2 does NOT surface the arm params (the arm opens only
+///     once it REACHES the floor at depth&gt;=3; the fix didn't shift the whole depth contract down a level).
+///   * FLOOR-UNCHANGED-OFF-ARM (depth=2) — an NPC Perks read (PerkPlacement, a NON-arm substruct) still stops at the
+///     floor: no <c>Perks[0].Perk</c> field line — the one-extra-level is condition-arms + script-properties ONLY.
+///
+/// Run: dotnet run --project src/housecarl-generator -- condition-arm-expand-guard
+/// </summary>
+public static class ConditionArmExpandProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  REGRESSION GUARD — Conditions[].Data arm expansion at the depth floor (#258)  ################");
+        Console.WriteLine();
+
+        var mod = new SkyrimMod(new ModKey("hc_condarm", ModType.Plugin), SkyrimRelease.SkyrimSE);
+
+        // A MagicEffect with one condition whose polymorphic Data arm carries a checkable PARAM (ActorValue).
+        var mgef = new MagicEffect(mod.GetNextFormKey(), SkyrimRelease.SkyrimSE);
+        mgef.Conditions.Add(new ConditionFloat
+        {
+            CompareOperator = CompareOperator.EqualTo,
+            ComparisonValue = 1f,
+            Data = new GetActorValueConditionData { ActorValue = ActorValue.Conjuration },
+        });
+
+        var deep = ReadEngine.ReadFields(mgef, new[] { "Conditions" }, 3);
+        var param = Find(deep.Fields, "Conditions[0].Data.ActorValue");
+        var summary = deep.Fields.FirstOrDefault(f => f.Path.EndsWith("Conditions[0].Data", StringComparison.Ordinal) && !f.HasValue);
+        bool deeperThanParam = deep.Fields.Any(f => f.Path.Contains("Conditions[0].Data.ActorValue.", StringComparison.Ordinal));
+
+        var shallow = ReadEngine.ReadFields(mgef, new[] { "Conditions" }, 2);
+        bool depth2NoParam = !shallow.Fields.Any(f => f.Path.Contains("Conditions[0].Data.", StringComparison.Ordinal));
+
+        // NON-arm control: an NPC's Perks (PerkPlacement) at depth=2 — a plain substruct still stops at the floor.
+        var npc = mod.Npcs.AddNew();
+        var pp = new PerkPlacement { Rank = 1 };
+        pp.Perk.SetTo(FormKey.Factory("03AF81:Skyrim.esm"));
+        npc.Perks = new() { pp };
+        var perks = ReadEngine.ReadFields(npc, new[] { "Perks" }, 2);
+        bool perkFloorHeld = !perks.Fields.Any(f => f.Path == "Perks[0].Perk");
+
+        Console.WriteLine($"   depth=3 Conditions[0].Data.ActorValue : {Show(param)}");
+        Console.WriteLine($"   depth=3 Conditions[0].Data (summary)  : {Show(summary)}");
+        Console.WriteLine($"   depth=2 arm params suppressed         : {depth2NoParam}");
+        Console.WriteLine($"   NPC Perks[0].Perk absent at depth=2   : {perkFloorHeld}");
+        Console.WriteLine();
+
+        bool paramsSurface = param is { HasValue: true } && param.Token == "Conjuration";
+        bool summaryKept = summary is not null && (summary.Note ?? "").Contains("GetActorValueConditionData", StringComparison.Ordinal);
+        bool bounded = !deeperThanParam;
+
+        bool pass = paramsSurface && summaryKept && bounded && depth2NoParam && perkFloorHeld;
+
+        Console.WriteLine($"   PARAMS-SURFACE  (depth=3 shows Data.ActorValue)       : {(paramsSurface ? "PASS" : "FAIL")}");
+        Console.WriteLine($"   SUMMARY-KEPT    (arm [Type] summary still present)    : {(summaryKept ? "PASS" : "FAIL")}");
+        Console.WriteLine($"   BOUNDED         (opens exactly one level)             : {(bounded ? "PASS" : "FAIL")}");
+        Console.WriteLine($"   DEPTH-NOT-LOWERED (depth=2 still suppresses params)   : {(depth2NoParam ? "PASS" : "FAIL")}");
+        Console.WriteLine($"   FLOOR-UNCHANGED-OFF-ARM (Perks substruct still stops) : {(perkFloorHeld ? "PASS" : "FAIL")}");
+        Console.WriteLine();
+        Console.WriteLine($"=== condition-arm-expand-guard: {(pass ? "PASS" : "FAIL")} ===");
+        return pass ? 0 : 1;
+    }
+
+    static FieldValue? Find(IEnumerable<FieldValue> fields, string suffix) =>
+        fields.FirstOrDefault(f => f.Path.EndsWith(suffix, StringComparison.Ordinal));
+
+    static string Show(FieldValue? f) =>
+        f is null ? "(missing)" : $"{f.Path} = {(f.HasValue ? f.Token : f.Note)}";
+}

--- a/src/housecarl-generator/OwnedRecordIdentityProbe.cs
+++ b/src/housecarl-generator/OwnedRecordIdentityProbe.cs
@@ -1,0 +1,75 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SELF-CONTAINED CI REGRESSION GUARD for the depth-2 element-identity render of an OWNED-RECORD element (#252) —
+/// the next member of the #198 family after <c>element-identity-guard</c> (which handles lone-FormLink structs). A
+/// list element that is itself an owned <see cref="Mutagen.Bethesda.Plugins.Records.IMajorRecordGetter"/> — a DIAL's
+/// Responses hold DialogResponses/INFO records, each owning its own FormKey but having NO Name/EditorID/Title and
+/// NOT being a lone FormLink — now renders its OWN FormKey (+ EditorID when present) as its identity line
+/// (<c>[DialogResponses 000800:hc_owned.esp editorid=…]</c>) instead of a bare opaque <c>[DialogResponses]</c>, so a
+/// caller reading a Responses list at the documented depth=2 sees WHICH INFO each element is — without the second
+/// per-<c>[i].FormKey</c> call the #252 report had to fall back to.
+///
+/// Arms, all driving the PRODUCT read path (<see cref="ReadEngine.ReadFields"/>) at depth=2:
+///   * FORMKEY      — an INFO WITH an EditorID renders <c>[DialogResponses &lt;fk&gt; editorid=&lt;edid&gt;]</c>.
+///     RED before the fix (bare <c>[DialogResponses]</c>), GREEN after.
+///   * NO-EDITORID  — an INFO with NO EditorID renders <c>[DialogResponses &lt;fk&gt;]</c> — FormKey still surfaced,
+///     and no dangling <c>editorid=</c> (EditorID rides along ONLY when present).
+///   * TYPE-KEPT    — the <c>[Type]</c> marker stays (the identity is additive, exactly like #198).
+///
+/// Run: dotnet run --project src/housecarl-generator -- owned-record-identity-guard
+/// </summary>
+public static class OwnedRecordIdentityProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  REGRESSION GUARD — depth-2 element identity: owned-record element (#252)  ################");
+        Console.WriteLine();
+
+        var mod = new SkyrimMod(new ModKey("hc_owned", ModType.Plugin), SkyrimRelease.SkyrimSE);
+
+        // A DIAL whose Responses list holds two owned INFO records: one WITH an EditorID, one without. Each owns its
+        // own FormKey — the identity #252 wants surfaced at depth=2 (an INFO has no Name and usually no EditorID, the
+        // exact case the #198 lone-FormLink path can't reach).
+        var withEdid = new DialogResponses(mod.GetNextFormKey(), SkyrimRelease.SkyrimSE) { EditorID = "HcInfoEdid" };
+        var noEdid = new DialogResponses(mod.GetNextFormKey(), SkyrimRelease.SkyrimSE);
+        var dial = mod.DialogTopics.AddNew();
+        dial.Responses.Add(withEdid);
+        dial.Responses.Add(noEdid);
+
+        var rf = ReadEngine.ReadFields(dial, new[] { "Responses" }, 2);
+        var e0 = rf.Fields.FirstOrDefault(f => f.Path.EndsWith("Responses[0]", StringComparison.Ordinal) && !f.HasValue);
+        var e1 = rf.Fields.FirstOrDefault(f => f.Path.EndsWith("Responses[1]", StringComparison.Ordinal) && !f.HasValue);
+
+        Console.WriteLine($"   Responses[0] : {Show(e0)}");
+        Console.WriteLine($"   Responses[1] : {Show(e1)}");
+        Console.WriteLine();
+
+        var n0 = e0?.Note ?? "";
+        var n1 = e1?.Note ?? "";
+        bool formKeyShown = n0.Contains(withEdid.FormKey.ToString(), StringComparison.Ordinal);    // the #252 fix
+        bool edidCarried = n0.Contains("editorid=HcInfoEdid", StringComparison.Ordinal);
+        bool noEdidClean = n1.Contains(noEdid.FormKey.ToString(), StringComparison.Ordinal)
+                        && !n1.Contains("editorid=", StringComparison.Ordinal);                    // no dangling editorid=
+        bool typeKept = n0.Contains("DialogResponses", StringComparison.Ordinal)
+                     && n1.Contains("DialogResponses", StringComparison.Ordinal);
+
+        bool pass = formKeyShown && edidCarried && noEdidClean && typeKept;
+
+        Console.WriteLine($"   FORMKEY      (owned record shows its FormKey)        : {(formKeyShown ? "PASS" : "FAIL")}");
+        Console.WriteLine($"   EDITORID     (EditorID carried when present)         : {(edidCarried ? "PASS" : "FAIL")}");
+        Console.WriteLine($"   NO-EDITORID  (absent EditorID → FormKey only, clean) : {(noEdidClean ? "PASS" : "FAIL")}");
+        Console.WriteLine($"   TYPE-KEPT    (identity is additive, [Type] stays)    : {(typeKept ? "PASS" : "FAIL")}");
+        Console.WriteLine();
+        Console.WriteLine($"=== owned-record-identity-guard: {(pass ? "PASS" : "FAIL")} ===");
+        return pass ? 0 : 1;
+    }
+
+    static string Show(FieldValue? f) =>
+        f is null ? "(missing)" : $"{f.Path} = {(f.HasValue ? f.Token : f.Note)}";
+}


### PR DESCRIPTION
Fixes #252
Fixes #258

Phase 1 deck-clearing — the **ReadEngine depth-expansion pair**. Both are the #198 family (a nested structure rendering one level shallower than the `depth=` contract implies), on the same surface, so they land together.

## #252 — owned-record list elements render no FormID at `depth=2`
A list whose elements are themselves owned records — most commonly a DIAL topic's `Responses` (each element a `DialogResponses`/INFO record that owns its own FormKey) — surfaced **no FormID** at `depth=2`: an element rendered a bare `[DialogResponses]`, or `[DialogResponses] EditorID=…` when the INFO carried an EditorID, but never the FormKey that is an owned record's canonical identity. Mapping topics → child INFOs meant a second call with explicit `[i].FormKey` paths (awkward for variable-length lists you can't enumerate without a prior read).

**Fix:** `ReadEngine.ElementSummary` now leads with the element's own `FormKey` (+ `EditorID` when present) when it `is IMajorRecordGetter`, checked **before** the `Name/EditorID/Title` scan (for an owned record the FormKey is the canonical identity). Mirrors the #198 `LoneFormLinkIdentity` fix, carried to records:
```
Responses[0] = [DialogResponses 000800:Plugin.esp editorid=…]
```

## #258 — `Conditions[].Data` arm params never expand via list expansion
A polymorphic `ConditionData` arm reached by expanding a `Conditions` list stopped at its bare `[GetFactionRankConditionData]` type; the parameter fields (`Faction`, `Global`, `Reference`, `RunOnType`, …) surfaced only when `Data` was addressed directly or at an extra depth level, so `fields=["Conditions"] depth=3` silently stopped one level short.

**Fix:** the depth-floor "open one bounded level" exception (`ReadEngine.Expand`) — previously `IsScriptProperty`-only — now also fires for a condition arm via a new `IsConditionData` (`IConditionDataGetter`). Type-targeted and bounded (an arm's members are leaves/links → exactly one level); every other substruct still stops at the floor.

## Guards (correctness-by-construction)
- **`owned-record-identity-guard`** (#252) — a DIAL's Responses with two INFOs (one with an EditorID, one without) drives the product read path at `depth=2`; asserts FormKey shown, EditorID carried when present / clean when absent, `[Type]` kept.
- **`condition-arm-expand-guard`** (#258) — a MagicEffect condition arm at `depth=3` surfaces `Data.ActorValue`; controls prove **bounded** (one level only), **depth-not-lowered** (`depth=2` still suppresses), and **floor-unchanged-off-arm** (an NPC `Perks` substruct still stops at the floor).

Both registered in `ci-all`: **102/102 pass**, including the sibling `vmad-property-read-guard` (its NON-PROPERTY-UNCHANGED control confirms the condition-arm gate didn't flip the VMAD floor) and `depth-leak-guard`.

## CHANGELOG
Two `## Unreleased` entries (both user-facing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)