### PR TITLE
fix(read): decode [Flags] enums with unknown bits instead of a bare decimal (#255)

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,16 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**A `[Flags]` enum field with unknown bits now decodes the known bits instead of collapsing to a bare decimal (#255).**
+When a flags field carries a bit the record catalog doesn't name (a modded slot, a game-version bit houseCARL's Mutagen
+build predates), `.NET`'s `[Flags].ToString()` abandons the name list and renders the whole value as one decimal — e.g.
+`Configuration.Flags = 2490402` on Dawnguard vampire NPCs — silently losing even the *known* bits (Female, Unique,
+IsGhost) a consumer needs. A read now appends a display-only decode: `2490402   (Female, Unique, BleedoutOverride
+(+unknown bits 0x260000))` — the known bits by name, the unnamed remainder as an explicit hex mask, so the common bits
+stay directly consumable and the presence of unknown bits is stated rather than hidden. The round-trip token is
+unchanged (the bare decimal still round-trips through `Enum.Parse`, so write / read-proof / diff are untouched) — the
+decode rides the same display channel as the existing biped-slot annotation, which keeps its slot-number decode.
+
 **`housecarl_read_record` / `housecarl_batch_record_detail` `depth=2` now surfaces an owned-record list element's own FormID (#252).**
 A list whose elements are themselves owned records — most commonly a DIAL topic's `Responses` (each element an INFO record) —
 surfaced no FormID at `depth=2`: an element rendered a bare `[DialogResponses]` (or `[DialogResponses] EditorID=…` when the INFO

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -9,14 +9,16 @@ when it changes.
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
 **A `[Flags]` enum field with unknown bits now decodes the known bits instead of collapsing to a bare decimal (#255).**
-When a flags field carries a bit the record catalog doesn't name (a modded slot, a game-version bit houseCARL's Mutagen
-build predates), `.NET`'s `[Flags].ToString()` abandons the name list and renders the whole value as one decimal — e.g.
-`Configuration.Flags = 2490402` on Dawnguard vampire NPCs — silently losing even the *known* bits (Female, Unique,
-IsGhost) a consumer needs. A read now appends a display-only decode: `2490402   (Female, Unique, BleedoutOverride
-(+unknown bits 0x260000))` — the known bits by name, the unnamed remainder as an explicit hex mask, so the common bits
-stay directly consumable and the presence of unknown bits is stated rather than hidden. The round-trip token is
-unchanged (the bare decimal still round-trips through `Enum.Parse`, so write / read-proof / diff are untouched) — the
-decode rides the same display channel as the existing biped-slot annotation, which keeps its slot-number decode.
+When a flags field carries a bit the record catalog doesn't name (a modded slot, or a game-version bit houseCARL's
+Mutagen build predates), `.NET`'s `[Flags].ToString()` abandons the name list and renders the whole value as one
+decimal — e.g. `Configuration.Flags = 2490402` on Dawnguard vampire NPCs — silently losing even the *known* bits
+(gender, uniqueness, ghost state) a consumer needs. A read now appends a display-only decode of the form
+`2490402   (<known flag names> (+unknown bits 0x…))` — the known bits by name, the unnamed remainder as an explicit hex
+mask, so the common bits stay directly consumable and the presence of unknown bits is stated rather than hidden. The
+known bits are peeled the way `[Flags].ToString()` itself names them (fully-contained members, combos before their
+constituent bits), so the name slot is never itself a bare decimal. The round-trip token is unchanged (the bare decimal
+still round-trips through `Enum.Parse`, so write / read-proof / diff are untouched) — the decode rides the same display
+channel as the existing biped-slot annotation, which keeps its slot-number decode.
 
 **`housecarl_read_record` / `housecarl_batch_record_detail` `depth=2` now surfaces an owned-record list element's own FormID (#252).**
 A list whose elements are themselves owned records — most commonly a DIAL topic's `Responses` (each element an INFO record) —

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -759,11 +759,11 @@ public static class ReadEngine
     internal static string? FlagDisplay(LeafRead leaf) => FlagSlotDisplay(leaf) ?? FlagBitsDisplay(leaf);
 
     /// <summary>The DISPLAY-ONLY decode for a <c>[Flags]</c> enum leaf carrying bits the catalog does NOT name — the
-    /// case where <c>[Flags].ToString()</c> abandons the name list and renders a bare decimal (e.g.
-    /// <c>Configuration.Flags = 2490402</c> on a Dawnguard vampire NPC), silently losing even the KNOWN bits a
-    /// consumer needs (Female / Unique / IsGhost — #255). This surfaces the known bits by NAME plus the unnamed
-    /// remainder as an explicit hex mask — <c>Female, Unique, BleedoutOverride (+unknown bits 0x260000)</c> — so the
-    /// common bits stay directly consumable and the presence of unknown bits is STATED, not hidden. Rides
+    /// case where <c>[Flags].ToString()</c> abandons the name list and renders a bare decimal (e.g. an NPC
+    /// <c>Configuration.Flags</c> whose value includes an unnamed modder/game-version bit), silently losing even the
+    /// KNOWN bits a consumer needs (gender / uniqueness / ghost state — #255). This surfaces the known bits by NAME
+    /// plus the unnamed remainder as an explicit hex mask — <c>&lt;known flag names&gt; (+unknown bits 0x…)</c> — so
+    /// the common bits stay directly consumable and the presence of unknown bits is STATED, not hidden. Rides
     /// <see cref="FieldValue.Display"/>, so the round-trip <see cref="LeafRead.Token"/> (the bare decimal, which
     /// <c>Enum.Parse</c> re-accepts) is untouched — write / read-proof / diff never see it, exactly like the
     /// biped-slot decode. Null when the leaf is not a flags enum OR every set bit is already named (ToString gave
@@ -771,19 +771,26 @@ public static class ReadEngine
     internal static string? FlagBitsDisplay(LeafRead leaf)
     {
         if (!leaf.HasValue || leaf.Flags is not { } fb) return null;
-        // The union of every defined member's bits = the NAMED mask; anything set outside it is an unnamed bit.
-        ulong known = 0;
+        // Peel the NAMEABLE bits exactly the way .NET's [Flags].ToString() does: greedily apply each named member that
+        // is FULLY contained (largest value first, so a multi-bit COMBO member wins over its constituent bits), and
+        // whatever bits no member can cover are the unknown remainder. Do NOT just OR every member's bits into one
+        // "known" mask: a bit that exists ONLY inside a multi-bit combo member (e.g. Package.Flag.WearSleepOutfit)
+        // would count as "known" yet ToString can't name it on its own, so the "known names" slot would itself render
+        // a bare decimal — the very thing this decode exists to avoid (PR #261 review).
+        var members = new List<ulong>();
         foreach (var member in Enum.GetValues(fb.EnumType))
-            if (TryEnumBits(member, fb.EnumType, out var mb)) known |= mb;
-        ulong unknown = fb.Bits & ~known;
-        if (unknown == 0) return null;   // every set bit is named — ToString already rendered the full name list
-        // Render the KNOWN portion through the enum's own ToString (fully named → a clean comma list, never a
-        // decimal), then state the unnamed remainder as an explicit hex mask so nothing is silently dropped.
-        ulong knownSet = fb.Bits & known;
-        var names = knownSet == 0 ? null : Enum.ToObject(fb.EnumType, knownSet).ToString();
+            if (TryEnumBits(member, fb.EnumType, out var mb) && mb != 0) members.Add(mb);
+        members.Sort((a, b) => b.CompareTo(a));   // descending (unsigned) — a combo before its constituent bits
+        ulong remainder = fb.Bits;
+        foreach (var mb in members) if ((remainder & mb) == mb) remainder &= ~mb;
+        if (remainder == 0) return null;   // every set bit is nameable — ToString already gave the full name list
+        // The nameable bits are exactly a union of whole members, so ToString renders them as clean names (never a
+        // decimal); state the remainder as an explicit hex mask so nothing is silently dropped.
+        ulong nameable = fb.Bits & ~remainder;
+        var names = nameable == 0 ? null : Enum.ToObject(fb.EnumType, nameable).ToString();
         return string.IsNullOrEmpty(names) || names == "0"
-            ? $"unknown bits 0x{unknown:X}"
-            : $"{names} (+unknown bits 0x{unknown:X})";
+            ? $"unknown bits 0x{remainder:X}"
+            : $"{names} (+unknown bits 0x{remainder:X})";
     }
 
     // -- primitive family (mirror TryPrimitive) --------------------------------

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -204,7 +204,7 @@ public static class ReadEngine
                 // FieldsDiff runs never sees the hint (it reads at expansion depth, a different summary path).
                 // The hint text is the caller's (containerHint): depth=2 is only a real knob on some surfaces.
                 if (note is { Length: > 0 } && note[0] == '[' && !string.IsNullOrEmpty(containerHint)) note += containerHint;
-                fields.Add(new FieldValue(p, r.HasValue, r.HasValue ? r.Token : null, note, FlagSlotDisplay(r)));
+                fields.Add(new FieldValue(p, r.HasValue, r.HasValue ? r.Token : null, note, FlagDisplay(r)));
             }
         }
         else
@@ -339,7 +339,7 @@ public static class ReadEngine
     {
         if (budget < 0) return;
         var leaf = EmitToken(val, declaredType, parent);
-        if (leaf.HasValue) { Emit(sink, ref budget, new FieldValue(path, true, leaf.Token, null, FlagSlotDisplay(leaf))); return; }
+        if (leaf.HasValue) { Emit(sink, ref budget, new FieldValue(path, true, leaf.Token, null, FlagDisplay(leaf))); return; }
         if (val is null) { Emit(sink, ref budget, new FieldValue(path, false, null, leaf.Note)); return; }
         // a link (incl. a null FormKey, or an FLOI) is a note, not an openable container/substruct.
         if (val is IFormLinkGetter || WriteEngine.IsFormLinkOrIndex(Nullable.GetUnderlyingType(declaredType) ?? declaredType))
@@ -747,6 +747,43 @@ public static class ReadEngine
         for (int i = 0; i < 32; i++) if ((fb.Bits & (1UL << i)) != 0) slots.Add(30 + i);
         if (slots.Count == 0) return null;
         return (slots.Count == 1 ? "slot " : "slots ") + string.Join(", ", slots);
+    }
+
+    /// <summary>The DISPLAY-ONLY annotation for a <c>[Flags]</c> enum leaf — the human-readable decode that rides
+    /// <see cref="FieldValue.Display"/> without touching the round-trip <see cref="LeafRead.Token"/>. A biped-slot
+    /// flags leaf gets the slot-number decode (<see cref="FlagSlotDisplay"/>); every OTHER flags enum gets the
+    /// unknown-bits decode (<see cref="FlagBitsDisplay"/>), which fires only when unnamed bits are present. The two
+    /// are mutually exclusive by construction — a biped leaf with any bit set already yields a slot decode, and one
+    /// with no bit set has no unknown bits either — so the <c>??</c> never double-annotates. Null when neither
+    /// applies (a non-flags leaf, or a flags leaf whose every set bit is already named).</summary>
+    internal static string? FlagDisplay(LeafRead leaf) => FlagSlotDisplay(leaf) ?? FlagBitsDisplay(leaf);
+
+    /// <summary>The DISPLAY-ONLY decode for a <c>[Flags]</c> enum leaf carrying bits the catalog does NOT name — the
+    /// case where <c>[Flags].ToString()</c> abandons the name list and renders a bare decimal (e.g.
+    /// <c>Configuration.Flags = 2490402</c> on a Dawnguard vampire NPC), silently losing even the KNOWN bits a
+    /// consumer needs (Female / Unique / IsGhost — #255). This surfaces the known bits by NAME plus the unnamed
+    /// remainder as an explicit hex mask — <c>Female, Unique, BleedoutOverride (+unknown bits 0x260000)</c> — so the
+    /// common bits stay directly consumable and the presence of unknown bits is STATED, not hidden. Rides
+    /// <see cref="FieldValue.Display"/>, so the round-trip <see cref="LeafRead.Token"/> (the bare decimal, which
+    /// <c>Enum.Parse</c> re-accepts) is untouched — write / read-proof / diff never see it, exactly like the
+    /// biped-slot decode. Null when the leaf is not a flags enum OR every set bit is already named (ToString gave
+    /// the full name list — nothing to recover).</summary>
+    internal static string? FlagBitsDisplay(LeafRead leaf)
+    {
+        if (!leaf.HasValue || leaf.Flags is not { } fb) return null;
+        // The union of every defined member's bits = the NAMED mask; anything set outside it is an unnamed bit.
+        ulong known = 0;
+        foreach (var member in Enum.GetValues(fb.EnumType))
+            if (TryEnumBits(member, fb.EnumType, out var mb)) known |= mb;
+        ulong unknown = fb.Bits & ~known;
+        if (unknown == 0) return null;   // every set bit is named — ToString already rendered the full name list
+        // Render the KNOWN portion through the enum's own ToString (fully named → a clean comma list, never a
+        // decimal), then state the unnamed remainder as an explicit hex mask so nothing is silently dropped.
+        ulong knownSet = fb.Bits & known;
+        var names = knownSet == 0 ? null : Enum.ToObject(fb.EnumType, knownSet).ToString();
+        return string.IsNullOrEmpty(names) || names == "0"
+            ? $"unknown bits 0x{unknown:X}"
+            : $"{names} (+unknown bits 0x{unknown:X})";
     }
 
     // -- primitive family (mirror TryPrimitive) --------------------------------

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -51,6 +51,10 @@ public static class CiAll
         // (DIAL Responses → DialogResponses/INFO) surfaces its OWN FormKey (+ EditorID when present) instead of a
         // bare [DialogResponses] — the #198 family carried to records (FormKey is the identity, not a lone link).
         ("owned-record-identity-guard", OwnedRecordIdentityProbe.RunGuard),
+        // unknown-bits flag decode (#255): a [Flags] enum leaf carrying unnamed bits (ToString falls back to a bare
+        // decimal, losing the known bits) now hangs a DISPLAY-ONLY "<names> (+unknown bits 0x…)" decode — the token
+        // (bare decimal, Enum.Parse-round-trippable) is untouched; biped-slot flags keep their own slot decode.
+        ("flag-bits-display-guard", FlagBitsDisplayProbe.RunGuard),
         ("floi-read-guard", FloiReadProbe.RunGuard),
         ("floi-fields-guard", FloiFieldsProbe.RunGuard),
         ("forward-from-plugin-guard", ForwardFromPluginProbe.RunGuard),

--- a/src/housecarl-generator/FlagBitsDisplayProbe.cs
+++ b/src/housecarl-generator/FlagBitsDisplayProbe.cs
@@ -1,0 +1,132 @@
+using System.Globalization;
+using System.Runtime.InteropServices;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SELF-CONTAINED CI REGRESSION GUARD for the unknown-bits flag decode (#255). When a <c>[Flags]</c> enum leaf
+/// carries bits the catalog does NOT name, <c>[Flags].ToString()</c> abandons the name list and renders a bare
+/// decimal (the real case: <c>Configuration.Flags = 2490402</c> on Dawnguard vampire NPCs), silently losing even the
+/// KNOWN bits (Female / Unique / IsGhost). The read now hangs a DISPLAY-ONLY decode off such a leaf —
+/// <c>Female, … (+unknown bits 0x…)</c> — so the common bits stay directly consumable and the unnamed remainder is
+/// stated, not hidden. The round-trip Token (the bare decimal, which <c>Enum.Parse</c> re-accepts) is untouched.
+///
+/// The fixture is enum-AGNOSTIC: it reflects the NPC <c>Configuration.Flags</c> enum, picks a real named single-bit
+/// member and a genuinely-unnamed bit position, and sets that combination — so it stays correct if Mutagen's flag
+/// set changes. Arms, all driving the PRODUCT read path (<see cref="ReadEngine.ReadFields"/>):
+///   * DECODE       — a named-bit | unnamed-bit value surfaces a Display of "&lt;name&gt; (+unknown bits 0x&lt;bit&gt;)".
+///     RED before the fix (no Display / decimal only), GREEN after.
+///   * TOKEN-INTACT — the leaf's round-trip Token is still the bare decimal, DISTINCT from the Display (the decode
+///     rides Display only; write / read-proof / diff never see it).
+///   * ALL-NAMED-NULL — a value with ONLY named bits gets NO decode Display (ToString already names it — nothing to
+///     recover), so the annotation fires exactly when it adds information.
+///   * BIPED-ROUTED — a <c>BodyTemplate.FirstPersonFlags</c> leaf still gets the SLOT decode ("slot 32"), NOT the
+///     unknown-bits decode — the dispatcher routes biped flags to their own annotation, unchanged.
+///
+/// Run: dotnet run --project src/housecarl-generator -- flag-bits-display-guard
+/// </summary>
+public static class FlagBitsDisplayProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  REGRESSION GUARD — unknown-bits flag decode (#255)  ################");
+        Console.WriteLine();
+
+        var mod = new SkyrimMod(new ModKey("hc_flagbits", ModType.Plugin), SkyrimRelease.SkyrimSE);
+
+        // Reflect the NPC Configuration.Flags enum (the reported field) without hardcoding its type.
+        var npc = mod.Npcs.AddNew();
+        var cfg = npc.Configuration!;
+        var flagsProp = cfg.GetType().GetProperty("Flags")!;
+        var enumType = flagsProp.PropertyType;
+
+        // A real NAMED single-bit (power of two) member → its name is the decode we expect.
+        object? namedMember = null; ulong namedBit = 0;
+        foreach (var m in Enum.GetValues(enumType))
+        {
+            var b = Bits(m, enumType);
+            if (b != 0 && (b & (b - 1)) == 0) { namedMember = m; namedBit = b; break; }
+        }
+        // Union of every member's bits = the NAMED mask; the lowest CLEAR bit in-width is a genuinely-unnamed bit.
+        ulong known = 0;
+        foreach (var m in Enum.GetValues(enumType)) known |= Bits(m, enumType);
+        int width = Marshal.SizeOf(Enum.GetUnderlyingType(enumType)) * 8;
+        ulong unknownBit = 0;
+        for (int i = 0; i < width; i++) if ((known & (1UL << i)) == 0) { unknownBit = 1UL << i; break; }
+
+        if (namedMember is null || unknownBit == 0)
+        {
+            Console.WriteLine($"   FIXTURE UNAVAILABLE — {enumType.Name} lacks a named single-bit and/or a free bit; cannot build the case.");
+            Console.WriteLine("=== flag-bits-display-guard: FAIL ===");
+            return 1;
+        }
+        var namedName = namedMember.ToString();
+
+        // --- DECODE + TOKEN-INTACT: named bit | unnamed bit → ToString goes decimal, Display recovers the name. ---
+        flagsProp.SetValue(cfg, Enum.ToObject(enumType, namedBit | unknownBit));
+        var mixed = Leaf(ReadEngine.ReadFields(npc, new[] { "Configuration.Flags" }), "Configuration.Flags");
+
+        // --- ALL-NAMED-NULL: only the named bit set → ToString names it, no decode Display needed. ---
+        flagsProp.SetValue(cfg, Enum.ToObject(enumType, namedBit));
+        var named = Leaf(ReadEngine.ReadFields(npc, new[] { "Configuration.Flags" }), "Configuration.Flags");
+
+        // --- BIPED-ROUTED: a biped-slot flags leaf still gets the slot decode, not the unknown-bits one. ---
+        var armo = mod.Armors.AddNew();
+        armo.BodyTemplate = new BodyTemplate { FirstPersonFlags = BipedObjectFlag.Body };
+        var biped = Leaf(ReadEngine.ReadFields(armo, new[] { "BodyTemplate.FirstPersonFlags" }), "BodyTemplate.FirstPersonFlags");
+
+        Console.WriteLine($"   fixture: {enumType.Name}  named={namedName}(0x{namedBit:X})  unknown=0x{unknownBit:X}");
+        Console.WriteLine($"   mixed  : token={Tok(mixed)}  display={Disp(mixed)}");
+        Console.WriteLine($"   named  : token={Tok(named)}  display={Disp(named)}");
+        Console.WriteLine($"   biped  : token={Tok(biped)}  display={Disp(biped)}");
+        Console.WriteLine();
+
+        var mixedDisp = mixed?.Display ?? "";
+        bool decode = mixed is { HasValue: true }
+                   && mixedDisp.Contains(namedName!, StringComparison.Ordinal)
+                   && mixedDisp.Contains("unknown bits", StringComparison.Ordinal)
+                   && mixedDisp.Contains($"0x{unknownBit:X}", StringComparison.Ordinal);
+        // Token is the bare decimal ToString of the raw value — unchanged by the decode, and NOT the display text.
+        bool tokenIntact = mixed is { HasValue: true }
+                   && mixed.Token == Enum.ToObject(enumType, namedBit | unknownBit).ToString()
+                   && mixed.Token != mixed.Display;
+        bool allNamedNull = named is { HasValue: true } && named.Display is null
+                   && named.Token == Enum.ToObject(enumType, namedBit).ToString();   // ToString gave the name
+        bool bipedRouted = biped is { HasValue: true }
+                   && (biped.Display ?? "").Contains("slot", StringComparison.Ordinal)
+                   && !(biped.Display ?? "").Contains("unknown bits", StringComparison.Ordinal);
+
+        bool pass = decode && tokenIntact && allNamedNull && bipedRouted;
+
+        Console.WriteLine($"   DECODE        (known name + unnamed hex remainder)   : {(decode ? "PASS" : "FAIL")}");
+        Console.WriteLine($"   TOKEN-INTACT  (round-trip token = bare decimal)      : {(tokenIntact ? "PASS" : "FAIL")}");
+        Console.WriteLine($"   ALL-NAMED-NULL(no decode when every bit is named)    : {(allNamedNull ? "PASS" : "FAIL")}");
+        Console.WriteLine($"   BIPED-ROUTED  (biped leaf keeps its slot decode)     : {(bipedRouted ? "PASS" : "FAIL")}");
+        Console.WriteLine();
+        Console.WriteLine($"=== flag-bits-display-guard: {(pass ? "PASS" : "FAIL")} ===");
+        return pass ? 0 : 1;
+    }
+
+    /// <summary>The unsigned bit pattern of a boxed enum member, robust across signed/unsigned underlying types —
+    /// mirrors ReadEngine.TryEnumBits so the fixture reads bits the same way the product does.</summary>
+    static ulong Bits(object member, Type enumType)
+    {
+        var u = Convert.ChangeType(member, Enum.GetUnderlyingType(enumType), CultureInfo.InvariantCulture);
+        return u switch
+        {
+            ulong x => x, long x => unchecked((ulong)x), uint x => x, int x => unchecked((ulong)(long)x),
+            ushort x => x, short x => unchecked((ulong)(long)x), byte x => x, sbyte x => unchecked((ulong)(long)x),
+            _ => Convert.ToUInt64(u, CultureInfo.InvariantCulture),
+        };
+    }
+
+    static FieldValue? Leaf(RecordFields rf, string suffix) =>
+        rf.Fields.FirstOrDefault(f => f.Path.EndsWith(suffix, StringComparison.Ordinal));
+
+    static string Tok(FieldValue? f) => f is null ? "(missing)" : (f.HasValue ? f.Token ?? "(null)" : "(no-value)");
+    static string Disp(FieldValue? f) => f?.Display ?? "(none)";
+}

--- a/src/housecarl-generator/FlagBitsDisplayProbe.cs
+++ b/src/housecarl-generator/FlagBitsDisplayProbe.cs
@@ -26,6 +26,10 @@ namespace HousecarlGenerator;
 ///     recover), so the annotation fires exactly when it adds information.
 ///   * BIPED-ROUTED — a <c>BodyTemplate.FirstPersonFlags</c> leaf still gets the SLOT decode ("slot 32"), NOT the
 ///     unknown-bits decode — the dispatcher routes biped flags to their own annotation, unchanged.
+///   * COMBO-ALONE / COMBO-MIXED (PR #261 review) — a bit that lives ONLY inside a multi-bit COMBO member
+///     (Package.Flag.WearSleepOutfit) is NOT nameable on its own: alone it decodes to "unknown bits 0x100" (never a
+///     dropped display or a bare decimal), and mixed with a genuinely-unnamed bit it stays all-remainder
+///     ("unknown bits 0x102") — never "256 (+unknown bits 0x2)" with a decimal masquerading as the name slot.
 ///
 /// Run: dotnet run --project src/housecarl-generator -- flag-bits-display-guard
 /// </summary>
@@ -79,10 +83,44 @@ public static class FlagBitsDisplayProbe
         armo.BodyTemplate = new BodyTemplate { FirstPersonFlags = BipedObjectFlag.Body };
         var biped = Leaf(ReadEngine.ReadFields(armo, new[] { "BodyTemplate.FirstPersonFlags" }), "BodyTemplate.FirstPersonFlags");
 
+        // --- COMBO-MEMBER (PR #261 review): a [Flags] enum with a multi-bit COMBO member whose constituent bits have
+        //     no single-bit member of their own (Package.Flag.WearSleepOutfit). A naive "OR every member's bits into a
+        //     known mask" wrongly treats a combo-only bit as nameable — so ToString of that lone bit yields a DECIMAL in
+        //     the name slot ("256 (+unknown bits 0x2)"), or drops the decode entirely. The correct decode peels only
+        //     FULLY-contained members, so a combo-only bit falls into the unknown remainder. Reflect Package.Flags,
+        //     isolate one combo-only bit + one genuinely-unnamed bit, and verify the honest rendering. ---
+        var pack = mod.Packages.AddNew();
+        var packFlagsProp = pack.GetType().GetProperty("Flags");
+        ulong comboOnlyBit = 0, packUnnamedBit = 0;
+        FieldValue? comboAlone = null, comboMixed = null;
+        if (packFlagsProp is not null)
+        {
+            var packEnum = packFlagsProp.PropertyType;
+            ulong packSingleMask = 0, packAllMask = 0;
+            foreach (var m in Enum.GetValues(packEnum))
+            {
+                var b = Bits(m, packEnum);
+                packAllMask |= b;
+                if (b != 0 && (b & (b - 1)) == 0) packSingleMask |= b;   // single-bit members only
+            }
+            ulong comboOnly = packAllMask & ~packSingleMask;             // bits that appear ONLY inside multi-bit combos
+            comboOnlyBit = comboOnly & (0UL - comboOnly);                // lowest such bit
+            int packWidth = Marshal.SizeOf(Enum.GetUnderlyingType(packEnum)) * 8;
+            for (int i = 0; i < packWidth; i++) if ((packAllMask & (1UL << i)) == 0) { packUnnamedBit = 1UL << i; break; }
+            if (comboOnlyBit != 0 && packUnnamedBit != 0)
+            {
+                packFlagsProp.SetValue(pack, Enum.ToObject(packEnum, comboOnlyBit));
+                comboAlone = Leaf(ReadEngine.ReadFields(pack, new[] { "Flags" }), "Flags");
+                packFlagsProp.SetValue(pack, Enum.ToObject(packEnum, comboOnlyBit | packUnnamedBit));
+                comboMixed = Leaf(ReadEngine.ReadFields(pack, new[] { "Flags" }), "Flags");
+            }
+        }
+
         Console.WriteLine($"   fixture: {enumType.Name}  named={namedName}(0x{namedBit:X})  unknown=0x{unknownBit:X}");
         Console.WriteLine($"   mixed  : token={Tok(mixed)}  display={Disp(mixed)}");
         Console.WriteLine($"   named  : token={Tok(named)}  display={Disp(named)}");
         Console.WriteLine($"   biped  : token={Tok(biped)}  display={Disp(biped)}");
+        Console.WriteLine($"   combo  : only=0x{comboOnlyBit:X} unnamed=0x{packUnnamedBit:X}  alone={Disp(comboAlone)}  mixed={Disp(comboMixed)}");
         Console.WriteLine();
 
         var mixedDisp = mixed?.Display ?? "";
@@ -100,12 +138,27 @@ public static class FlagBitsDisplayProbe
                    && (biped.Display ?? "").Contains("slot", StringComparison.Ordinal)
                    && !(biped.Display ?? "").Contains("unknown bits", StringComparison.Ordinal);
 
-        bool pass = decode && tokenIntact && allNamedNull && bipedRouted;
+        // COMBO arms (Mutagen is version-pinned, so Package.Flag's combo member is stable; a loud fail here on a bump
+        // signals the fixture must move to another combo enum, never a silent coverage drop).
+        bool comboAvailable = comboOnlyBit != 0 && packUnnamedBit != 0 && comboAlone is not null && comboMixed is not null;
+        // A combo-only bit ALONE: not individually nameable → the honest decode is "unknown bits 0x<bit>", NOT a
+        // dropped display (the old miss) and NOT a decimal masquerading as a name.
+        bool comboAloneOk = comboAlone is { HasValue: true } && (comboAlone.Display ?? "") == $"unknown bits 0x{comboOnlyBit:X}";
+        // A combo-only bit | a genuinely-unnamed bit: both unnameable, so the whole thing is the unknown remainder —
+        // NEVER "256 (+unknown bits 0x2)" with a bare decimal in the name slot (the review's case 2).
+        bool comboMixedOk = comboMixed is { HasValue: true }
+                   && (comboMixed.Display ?? "") == $"unknown bits 0x{(comboOnlyBit | packUnnamedBit):X}"
+                   && !(comboMixed.Display ?? "").Contains("(+", StringComparison.Ordinal);
+
+        bool pass = decode && tokenIntact && allNamedNull && bipedRouted && comboAvailable && comboAloneOk && comboMixedOk;
 
         Console.WriteLine($"   DECODE        (known name + unnamed hex remainder)   : {(decode ? "PASS" : "FAIL")}");
         Console.WriteLine($"   TOKEN-INTACT  (round-trip token = bare decimal)      : {(tokenIntact ? "PASS" : "FAIL")}");
         Console.WriteLine($"   ALL-NAMED-NULL(no decode when every bit is named)    : {(allNamedNull ? "PASS" : "FAIL")}");
         Console.WriteLine($"   BIPED-ROUTED  (biped leaf keeps its slot decode)     : {(bipedRouted ? "PASS" : "FAIL")}");
+        Console.WriteLine($"   COMBO-FIXTURE (Package.Flag combo-only + free bit)   : {(comboAvailable ? "PASS" : "FAIL")}");
+        Console.WriteLine($"   COMBO-ALONE   (combo-only bit → 'unknown bits …')    : {(comboAloneOk ? "PASS" : "FAIL")}");
+        Console.WriteLine($"   COMBO-MIXED   (combo-only+unnamed → no decimal name) : {(comboMixedOk ? "PASS" : "FAIL")}");
         Console.WriteLine();
         Console.WriteLine($"=== flag-bits-display-guard: {(pass ? "PASS" : "FAIL")} ===");
         return pass ? 0 : 1;


### PR DESCRIPTION
Fixes #255

Phase 1 deck-clearing — the first of the misleading-output pair.

## The papercut
When a `[Flags]` enum field carries a bit the record catalog doesn't name (a modded slot, or a game-version bit houseCARL's Mutagen build predates), `.NET`'s `[Flags].ToString()` abandons the name list and renders the whole value as one **decimal** — e.g. `Configuration.Flags = 2490402` on Dawnguard vampire NPCs — silently losing even the *known* bits (Female, Unique, IsGhost) a consumer needs. In the 2026-07-19 NPC appearance audit every filter script needed a dual name-token-or-int-decode path, and a consumer that didn't know the fallback existed would misread gender/ghost state — a quiet degraded mode.

## The fix
A read now appends a **display-only** decode to such a leaf:
```
Configuration.Flags = 2490402   (Female, Unique, BleedoutOverride (+unknown bits 0x260000))
```
The known bits by name, the unnamed remainder as an explicit hex mask.

**Round-trip-safe by construction.** The decode rides `FieldValue.Display`, *not* the round-trip `Token`. The token stays the bare decimal — which `Enum.Parse` re-accepts — so write / read-proof / diff never see the decode. This is the same display channel the existing biped-slot annotation uses. A new dispatcher `FlagDisplay` routes biped flags to their slot decode (`FlagSlotDisplay`, unchanged) and every other flags enum to the new `FlagBitsDisplay`, which fires **only** when unnamed bits are present (an all-named value already renders its names, so it gets no decode).

## Guard (correctness-by-construction)
`flag-bits-display-guard` — **enum-agnostic**: it reflects the NPC `Configuration.Flags` enum, picks a real named single-bit member and a genuinely-free (unnamed) bit, and asserts:
- **DECODE** — a named|unnamed value surfaces `<name> (+unknown bits 0x<bit>)`.
- **TOKEN-INTACT** — the leaf's round-trip token is still the bare decimal, distinct from the Display.
- **ALL-NAMED-NULL** — a fully-named value gets no decode Display (fires only when it adds information).
- **BIPED-ROUTED** — a `BodyTemplate.FirstPersonFlags` leaf still gets the slot decode (`slot 32`), not the unknown-bits one.

`ci-all`: **103/103 pass**.

## CHANGELOG
One `## Unreleased` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)