### PR TITLE
fix(write): report the true count for a composes= Add of N in the read-back (#259)

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,14 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**`housecarl_bulk_apply` read-back now reports the true count for a `composes=` Add of N — no more misleading `(+1)` (#259).**
+Appending N elements to a list field in one op via `composes=` rendered a verify line that reported only the last element,
+as if a single element was added — `✓ … Add Conditions: now 37 (+1), new [36] = [ConditionFloat]` for a six-element
+compose — because the Add read-back hardcoded a `+1` delta and the single last index. The data on disk was correct (the
+list total was the only clue all six landed), but the summary contradicted the op and cost real mid-session doubt. The
+read-back now carries the op's appended count and reports the whole run: `now 37 (+6), new [31..36]`. A single-element
+Add is unchanged (`now 29 (+1), new [28] = …`).
+
 **A `[Flags]` enum field with unknown bits now decodes the known bits instead of collapsing to a bare decimal (#255).**
 When a flags field carries a bit the record catalog doesn't name (a modded slot, or a game-version bit houseCARL's
 Mutagen build predates), `.NET`'s `[Flags].ToString()` abandons the name list and renders the whole value as one

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -488,14 +488,16 @@ public static class ReadEngine
     }
 
     /// <summary>Best-effort COMPACT identity of the element a list/dict verb just acted on — the write-verify's
-    /// "what landed" line (HCBR-2026-06-28-01, the compact in-place readback). For a list <c>Add</c>, the new last
-    /// element + the new count (<c>now 29 (+1), new [28] = …</c>); for a keyed <c>SetAtIndex</c>/<c>Remove</c>, the
-    /// touched key + new count; else the new count. Names the element as specifically as the model allows — a
+    /// "what landed" line (HCBR-2026-06-28-01, the compact in-place readback). For a single list <c>Add</c>, the new
+    /// last element + the new count (<c>now 29 (+1), new [28] = …</c>); for a batch <c>composes=</c> Add of N, the
+    /// whole appended run (<c>now 34 (+6), new [28..33]</c> — <paramref name="added"/> carries how many the op
+    /// appended, #259); for a keyed <c>SetAtIndex</c>/<c>Remove</c>, the touched key + new count; else the new count.
+    /// Names the element as specifically as the model allows — a
     /// formlink element renders its FormKey, an identity-bearing struct its Name/EditorID, an anonymous struct (a
     /// condition) its <c>[Type]</c>. Read-only; NEVER throws (null on any difficulty) — a display nicety on an
     /// ALREADY-succeeded write, never load-bearing. <paramref name="leafPath"/> is the verb's path to the collection
     /// (the engine's <see cref="WriteRequest.Path"/>); <paramref name="key"/> its list index / dict key, if any.</summary>
-    internal static string? TouchedElement(object record, string[] leafPath, string verb, string? key)
+    internal static string? TouchedElement(object record, string[] leafPath, string verb, string? key, int added = 1)
     {
         try
         {
@@ -505,7 +507,7 @@ public static class ReadEngine
             foreach (var e in en) { count++; last = e; }
             return verb switch
             {
-                "Add"        => last is null ? $"now {count} item(s)" : $"now {count} (+1), new [{count - 1}] = {ElementId(last, record)}",
+                "Add"        => AddLanded(record, count, last, added),
                 "ReplaceAll" => $"now {count} item(s) (replaced)",
                 "SetAtIndex" => key is not null ? $"now {count} item(s), set [{key}]" : $"now {count} item(s)",
                 "Remove"     => key is not null ? $"now {count} item(s), removed [{key}]" : $"now {count} item(s) (-1)",
@@ -513,6 +515,21 @@ public static class ReadEngine
             };
         }
         catch { return null; }
+    }
+
+    /// <summary>The list-<c>Add</c> "what landed" line, honest about the appended count. A SINGLE append names the
+    /// new element (<c>now 29 (+1), new [28] = …</c>); a BATCH <c>composes=</c> Add of N names the whole appended run
+    /// of indices (<c>now 34 (+6), new [28..33]</c>) instead of reporting only the last element as a "(+1)" — the
+    /// #259 misleading-output bug, where a 6-element compose read as "(+1), new [36]" and cost real mid-session doubt
+    /// that all six landed. <paramref name="added"/> is the op's appended count (composes.Count, else 1), clamped to
+    /// the live count so a display nicety on an already-succeeded write can never throw or under-run the range.</summary>
+    static string AddLanded(object record, int count, object? last, int added)
+    {
+        if (last is null) return $"now {count} item(s)";
+        int n = Math.Clamp(added, 1, count);
+        return n <= 1
+            ? $"now {count} (+1), new [{count - 1}] = {ElementId(last, record)}"
+            : $"now {count} (+{n}), new [{count - n}..{count - 1}]";
     }
 
     /// <summary>The compact identity of ONE element for <see cref="TouchedElement"/>: a value/formlink element via its

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -2501,8 +2501,11 @@ public static class WritePatchBuilder
             var f = read.Fields.FirstOrDefault(x => x.Path == leaf) ?? read.Fields.FirstOrDefault();
             if (f is null) return (null, null);
             var after = f.HasValue ? f.Token : f.Note;
-            // Scalar: Landed reuses the token just read. List/dict: name the touched element (+ new count); else the summary.
-            var landed = f.HasValue ? f.Token : (ReadEngine.TouchedElement(ov, req.Path, req.Verb, req.Key) ?? f.Note);
+            // Scalar: Landed reuses the token just read. List/dict: name the touched element (+ new count); else the
+            // summary. An Add carries how many elements it appended (composes= → Structs.Count, else 1) so a batch
+            // compose reports the whole appended run, never "(+1)" for N (#259).
+            int added = req.Verb == "Add" ? (req.Structs?.Count ?? 1) : 1;
+            var landed = f.HasValue ? f.Token : (ReadEngine.TouchedElement(ov, req.Path, req.Verb, req.Key, added) ?? f.Note);
             return (after, landed);
         }
         catch { return (null, null); }

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -240,6 +240,11 @@ public static class CiAll
         // whole-record dump that overflowed the host token cap and spilled to a file (reading as "only some ops applied").
         // full_readback=true still gives the deep dump, now bounded under the host limit with an explicit truncation note.
         ("compact-readback-guard", CompactReadbackProbe.RunGuard),
+        // bulk_apply composes= Add read-back count (#259): appending N elements in ONE composes= op reported the
+        // verify line as "(+1), new [last]" (the Add renderer hardcoded a +1 delta); it now carries the op's
+        // appended count and reports the whole run "(+N), new [a..b]". Drives the real in-place write; a 1-element
+        // compose still reads (+1), new [0] = <element> (count wired from Structs.Count, not a constant).
+        ("readback-count-guard", ReadbackCountProbe.RunGuard),
         // STANDALONE-COPY CHAIN Stage 1 — housecarl_read_plugin_file: a RAW, out-of-load-order read of ONE plugin file
         // straight off disk (INCLUDING one DISABLED in MO2), the enabler for forking a donor you're removing from the
         // order. Pins: locate+read a disabled plugin by filename, enumerate a type, whole-file summary, direct-path

--- a/src/housecarl-generator/ReadbackCountProbe.cs
+++ b/src/housecarl-generator/ReadbackCountProbe.cs
@@ -52,6 +52,7 @@ public static class ReadbackCountProbe
             FormKey weapFk = w.FormKey;
             var llBatch = mod.LeveledItems.AddNew(); llBatch.EditorID = "hcRbBatchLL"; FormKey batchFk = llBatch.FormKey;
             var llSingle = mod.LeveledItems.AddNew(); llSingle.EditorID = "hcRbSingleLL"; FormKey singleFk = llSingle.FormKey;
+            var llNew = mod.LeveledItems.AddNew(); llNew.EditorID = "hcRbNewLaneLL"; FormKey newFk = llNew.FormKey;
             mod.BeginWrite.ToPath(pluginPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
 
             using var resolver = LoadOrderResolver.Build(new[] { pluginPath });
@@ -71,6 +72,27 @@ public static class ReadbackCountProbe
                     new() { RecordType = "LeveledItemEntry", Path = new[] { "Data", "Reference" }, Verb = "Set", Value = weapFid },
                 },
             };
+
+            // NEW-PLUGIN LANE (the lane #259 was reported on) — the SAME composes= Add of Batch onto an empty LL, but
+            // producing a NEW override patch instead of editing in place. Both lanes route the read-back through the
+            // same DescribeApplied, so the count fix must hold here too. Run BEFORE the in-place edit (which mutates the
+            // source file) so this reads llNew's Entries still empty.
+            var patchPath = Path.Combine(dir, "hcReadbackPatch.esp");
+            var newLane = WritePatchBuilder.Apply(resolver, rulebook, new[]
+            {
+                new WritePatchBuilder.PatchEdit
+                {
+                    Target = newFk, Path = new[] { "Entries" }, Verb = "Add",
+                    Structs = Enumerable.Range(1, Batch).Select(Entry).ToArray(),
+                },
+            }, patchPath, extend: false);
+            var newLaneLanded = newLane.Ops.FirstOrDefault(o => o.Target == newFk)?.Landed ?? "";
+            Check($"NEW-PLUGIN LANE: composes= Add of {Batch} into a new patch also reports (+{Batch}), new [0..{Batch - 1}]  [{newLane.Error ?? "ok"}]",
+                  newLane.Success
+                  && newLaneLanded.Contains($"(+{Batch})", StringComparison.Ordinal)
+                  && newLaneLanded.Contains($"new [0..{Batch - 1}]", StringComparison.Ordinal));
+            Console.WriteLine($"   NEW-PLUGIN landed: {newLaneLanded}");
+            Console.WriteLine();
 
             // ONE in-place call, two edits: a composes= Add of 6, and a composes= Add of 1.
             var edits = new[]
@@ -105,7 +127,9 @@ public static class ReadbackCountProbe
             Check($"BATCH: reports the appended index RANGE [0..{Batch - 1}]",
                   batchLanded.Contains($"new [0..{Batch - 1}]", StringComparison.Ordinal));
 
-            // SINGLE: the single-append form is unchanged, and a 1-element compose is (+1) (count wired, not hardcoded).
+            // SINGLE: the single-append form is unchanged — (+1), new [0] = <element>. (It's the BATCH arm that proves
+            // the count is WIRED from Structs.Count rather than a constant; this arm pins that a 1-element compose keeps
+            // the element-naming single form, not the range form.)
             Check("SINGLE: a 1-element compose still reports (+1), new [0] = <element>",
                   singleLanded.Contains("(+1)", StringComparison.Ordinal)
                   && singleLanded.Contains("new [0] = ", StringComparison.Ordinal)

--- a/src/housecarl-generator/ReadbackCountProbe.cs
+++ b/src/housecarl-generator/ReadbackCountProbe.cs
@@ -1,0 +1,150 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SELF-CONTAINED CI REGRESSION GUARD for the bulk_apply composes= Add read-back count (#259). Appending N elements
+/// to a list field in ONE op via <c>composes=</c> used to render a verify line that reported only the LAST element as
+/// if a single element was added — <c>now 37 (+1), new [36] = …</c> for a 6-element compose — because
+/// <c>ReadEngine.TouchedElement</c>'s Add arm hardcoded a <c>+1</c> delta and the single last index. It cost real
+/// mid-session doubt ("did only 1 of 6 land?"). The renderer now carries the op's appended count (composes.Count,
+/// wired from <c>WritePatchBuilder.DescribeApplied</c>) and reports the whole appended run: <c>now 6 (+6), new [0..5]</c>.
+///
+/// Drives the REAL in-place write path (<see cref="WritePatchBuilder.ApplyInPlace"/>, the bulk_apply in_place surface)
+/// over a masterless plugin with a LeveledItem, in the CompactReadbackProbe pattern, and inspects the per-op
+/// <c>Landed</c> descriptor. Arms:
+///   * BATCH   — a composes= Add of 6 LeveledItemEntry onto an empty list reports <c>(+6), new [0..5]</c>, NOT (+1).
+///     RED before the fix (reported (+1), new [5]), GREEN after.
+///   * SINGLE  — a composes= Add of 1 still reports <c>(+1), new [0] = …</c> with the element named (the single-append
+///     form is unchanged, and it proves the appended count is 1 for a 1-element compose, not a hardcoded constant).
+///   * GROUND TRUTH — re-opening the file, the lists actually hold 6 and 1 entries (the writes were always correct;
+///     only the summary text was wrong).
+///
+/// Run: dotnet run --project src/housecarl-generator -- readback-count-guard
+/// </summary>
+public static class ReadbackCountProbe
+{
+    static int _pass, _fail;
+
+    public static int RunGuard(string[] args)
+    {
+        _pass = 0; _fail = 0;
+        Console.WriteLine("################  REGRESSION GUARD — bulk_apply composes= Add read-back count (#259)  ################");
+        Console.WriteLine();
+
+        var dir = Path.Combine(Path.GetTempPath(), "hc_readback_count_guard");
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); } catch { }
+        Directory.CreateDirectory(dir);
+
+        const string pluginName = "hcReadbackCount.esp";
+        var pluginPath = Path.Combine(dir, pluginName);
+        const int Batch = 6;
+
+        try
+        {
+            // ---- A masterless plugin: a weapon to reference, and two LeveledItems with EMPTY Entries lists — one for
+            //      the batch compose, one for the single-element control. ----
+            var mod = new SkyrimMod(ModKey.FromNameAndExtension(pluginName), SkyrimRelease.SkyrimSE);
+            var w = mod.Weapons.AddNew(); w.EditorID = "hcRbWeap"; w.BasicStats = new WeaponBasicStats { Damage = 10 };
+            FormKey weapFk = w.FormKey;
+            var llBatch = mod.LeveledItems.AddNew(); llBatch.EditorID = "hcRbBatchLL"; FormKey batchFk = llBatch.FormKey;
+            var llSingle = mod.LeveledItems.AddNew(); llSingle.EditorID = "hcRbSingleLL"; FormKey singleFk = llSingle.FormKey;
+            mod.BeginWrite.ToPath(pluginPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+            using var resolver = LoadOrderResolver.Build(new[] { pluginPath });
+            var rulebook = CorpusRulebook.Load(GenerateCorpus(dir));
+            string weapFid = $"{weapFk.ID:X6}:{weapFk.ModKey.FileName}";
+            Console.WriteLine($"-- masterless '{pluginName}': composing {Batch} entries onto one empty LL, 1 onto another, IN PLACE --");
+            Console.WriteLine();
+
+            // A LeveledItemEntry compose spec (the plan's canonical composable element), built from parts.
+            StructSpec Entry(int level) => new()
+            {
+                Type = "LeveledItemEntry",
+                Sets = new List<WriteRequest>
+                {
+                    new() { RecordType = "LeveledItemEntry", Path = new[] { "Data", "Level" },     Verb = "Set", Value = level.ToString() },
+                    new() { RecordType = "LeveledItemEntry", Path = new[] { "Data", "Count" },     Verb = "Set", Value = "1" },
+                    new() { RecordType = "LeveledItemEntry", Path = new[] { "Data", "Reference" }, Verb = "Set", Value = weapFid },
+                },
+            };
+
+            // ONE in-place call, two edits: a composes= Add of 6, and a composes= Add of 1.
+            var edits = new[]
+            {
+                new WritePatchBuilder.PatchEdit
+                {
+                    Target = batchFk, Path = new[] { "Entries" }, Verb = "Add",
+                    Structs = Enumerable.Range(1, Batch).Select(Entry).ToArray(),
+                },
+                new WritePatchBuilder.PatchEdit
+                {
+                    Target = singleFk, Path = new[] { "Entries" }, Verb = "Add",
+                    Structs = new[] { Entry(1) },
+                },
+            };
+
+            var outcome = WritePatchBuilder.ApplyInPlace(resolver, rulebook, edits, pluginPath, pluginName, fullReadback: false);
+            Check($"SETUP: in-place ApplyInPlace succeeded  [{outcome.Error ?? "ok"}]", outcome.Success);
+
+            var batchOp = outcome.Ops.FirstOrDefault(o => o.Target == batchFk);
+            var singleOp = outcome.Ops.FirstOrDefault(o => o.Target == singleFk);
+            var batchLanded = batchOp?.Landed ?? "";
+            var singleLanded = singleOp?.Landed ?? "";
+
+            Console.WriteLine($"   BATCH  landed: {batchLanded}");
+            Console.WriteLine($"   SINGLE landed: {singleLanded}");
+            Console.WriteLine();
+
+            // BATCH: the whole appended run, never "(+1)" for six.
+            Check($"BATCH: reports the full appended count (+{Batch}), not (+1)",
+                  batchLanded.Contains($"(+{Batch})", StringComparison.Ordinal) && !batchLanded.Contains("(+1)", StringComparison.Ordinal));
+            Check($"BATCH: reports the appended index RANGE [0..{Batch - 1}]",
+                  batchLanded.Contains($"new [0..{Batch - 1}]", StringComparison.Ordinal));
+
+            // SINGLE: the single-append form is unchanged, and a 1-element compose is (+1) (count wired, not hardcoded).
+            Check("SINGLE: a 1-element compose still reports (+1), new [0] = <element>",
+                  singleLanded.Contains("(+1)", StringComparison.Ordinal)
+                  && singleLanded.Contains("new [0] = ", StringComparison.Ordinal)
+                  && !singleLanded.Contains("..", StringComparison.Ordinal));
+
+            // GROUND TRUTH: the writes themselves were always correct — only the summary text was at issue.
+            Check($"GROUND TRUTH: on disk the batch LL holds {Batch} entries and the single LL holds 1",
+                  EntryCount(pluginPath, batchFk) == Batch && EntryCount(pluginPath, singleFk) == 1);
+
+            Console.WriteLine();
+            Console.WriteLine($"=== readback-count-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
+            return _fail == 0 ? 0 : 1;
+        }
+        catch (Exception ex) { Console.WriteLine($"   FAIL (unexpected): {ex.GetType().Name}: {ex.Message}\n{ex.StackTrace}"); return 1; }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
+
+    static int? EntryCount(string path, FormKey llFk)
+    {
+        ISkyrimModGetter? ov = null;
+        try
+        {
+            ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE);
+            return ov.LeveledItems.FirstOrDefault(x => x.FormKey == llFk)?.Entries?.Count ?? 0;
+        }
+        catch { return null; }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    static string GenerateCorpus(string dir)
+    {
+        var genDir = Path.Combine(dir, "corpus-gen");
+        CorpusGenerator.GenerateAll(genDir, Path.Combine(dir, "corpus-ref"));
+        return Path.Combine(genDir, "corpus.json");
+    }
+
+    static void Check(string label, bool ok)
+    {
+        Console.WriteLine($"   [{(ok ? "PASS" : "FAIL")}] {label}");
+        if (ok) _pass++; else _fail++;
+    }
+}


### PR DESCRIPTION
Fixes #259

Phase 1 deck-clearing — the second of the misleading-output pair (sibling of #255).

## The bug
Appending N elements to a list field in ONE op via `composes=` produced a verify/read-back line that reported only the **last** element, as if a single element was added:
```
✓ … Add Conditions: now 37 (+1), new [36] = [ConditionFloat]   ← six were appended
```
The data on disk was correct (the list total 31→37 was the only clue all six landed), but the summary contradicted the op and cost real mid-session doubt ("did only 1 of 6 land?"). Root cause: `ReadEngine.TouchedElement`'s `Add` arm hardcoded a `+1` delta and the single last index — it was written for a single-element append and never accounted for the `composes=` batch form.

## The fix
`TouchedElement` now takes the op's appended count and, via a new `AddLanded` helper, reports the whole run for a batch:
```
now 37 (+6), new [31..36]
```
A single append is unchanged (`now 29 (+1), new [28] = <element>`). The count is wired from `WritePatchBuilder.DescribeApplied` as `req.Structs?.Count ?? 1` — a `composes=` Add carries its N elements in `Structs`; every other verb passes 1. It's clamped to the live count (a display nicety on an already-succeeded write — never load-bearing, never throws).

## Guard (correctness-by-construction)
`readback-count-guard` drives the **real** in-place write path (`WritePatchBuilder.ApplyInPlace`, the `bulk_apply in_place` surface) over a masterless plugin with a `LeveledItem`:
- **BATCH** — a `composes=` Add of 6 reports `(+6), new [0..5]`, not `(+1)` (RED before the fix, GREEN after).
- **SINGLE** — a `composes=` Add of 1 still reports `(+1), new [0] = <element>` (proves the count is wired from `Structs.Count`, not a hardcoded constant).
- **GROUND TRUTH** — re-opening the file, the lists actually hold 6 and 1 entries (the writes were always correct).

`ci-all`: **103/103 pass**.

## CHANGELOG
One `## Unreleased` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)