### PR TITLE
fix(nif): accept sections= JSON-array form + fail loud on all-unrecognized (#247)

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,16 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**`housecarl_nif_inspect` `sections=` now accepts the JSON-array form and fails loud on an all-unrecognized value (#247).**
+Passing `sections` as a JSON array — the natural MCP way to send a list — arrived as the literal string
+`["shapes","paths"]`, and, split only on comma/space, tokenized to `["shapes` / `"paths"]` (brackets and quotes glued
+on), read as unrecognized, and the tool **quietly fell back to rendering the default summary** — so a batch could run
+with the wrong sections while the warning scrolled off the top of a large persisted file. The tokenizer now treats
+bracket and quote as delimiters too, so `["shapes","paths"]` parses; and a `sections=` in which **nothing** is
+recognized is now a loud error naming the tokens, never a silent summary (a partial request still renders the valid
+sections plus a warning). The unrecognized-section message — and the tool description — now also point out there is no
+`textures` section: a mesh's embedded texture-set slot paths appear under `shapes` (per-shape detail) and `paths`.
+
 **`housecarl_bulk_apply` read-back now reports the true count for a `composes=` Add of N — no more misleading `(+1)` (#259).**
 Appending N elements to a list field in one op via `composes=` rendered a verify line that reported only the last element,
 as if a single element was added — `✓ … Add Conditions: now 37 (+1), new [36] = [ConditionFloat]` for a six-element

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -191,6 +191,11 @@ public static class CiAll
         // isolation (one bad path never aborts the batch), batch-level alarms once + first, explicit omitted-mesh
         // cut notice. Self-contained (constructed results through the real NifWire renderer).
         ("nif-inspect-batch-guard", NifInspectBatchGuardProbe.RunGuard),
+        // nif_inspect sections= parsing (#247): the JSON-array-as-string form (["shapes","paths"]) now parses (bracket
+        // + quote are delimiters too) instead of tokenizing to garbage and QUIETLY rendering the default summary; an
+        // all-unrecognized sections= is a LOUD error, not a silent fallback; the known-sections hint points texture-set
+        // slot paths at where they live ('shapes'/'paths'). Drives NifTools.ParseSections/SectionsError/hint directly.
+        ("nif-sections-guard", NifSectionsProbe.RunGuard),
         ("strings-decision-guard", StringsDecisionProbe.RunGuard),
         ("assetlink-write-guard", AssetLinkWriteProbe.RunGuard),
         // The two coercion COMPLETENESS proofs, now CI guards (were manual-only — the coerce-audit blind spot that

--- a/src/housecarl-generator/NifSectionsProbe.cs
+++ b/src/housecarl-generator/NifSectionsProbe.cs
@@ -1,0 +1,86 @@
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SELF-CONTAINED CI REGRESSION GUARD for the nif_inspect <c>sections=</c> parsing (#247). Passing <c>sections</c> as a
+/// JSON array — the natural MCP way to send a list — arrived as the literal string <c>["shapes","paths"]</c> and, split
+/// only on comma/space, tokenized to <c>["shapes</c> / <c>"paths"]</c> (brackets+quotes glued on), read as
+/// UNRECOGNIZED, so the tool QUIETLY fell back to rendering the default SUMMARY (a Q3 silent-degrade: the batch ran with
+/// the wrong sections and the warning scrolled off the top of a 95 KB file). The tokenizer now treats bracket+quote as
+/// delimiters too (the array form parses), and an all-unrecognized <c>sections=</c> is a LOUD error, never a silent
+/// summary.
+///
+/// Exercises the real parsing seams (<see cref="NifTools.ParseSections"/> / <see cref="NifTools.SectionsError"/> /
+/// <see cref="NifTools.KnownSectionsHint"/>):
+///   * ARRAY-FORM  — <c>["shapes","paths"]</c> parses to {shapes, paths} with NO unknowns (the core fix; RED before).
+///   * PLAIN       — <c>shapes, paths</c> still parses the same (the comma/space form is unchanged).
+///   * ALL         — <c>all</c> expands to every known section.
+///   * PARTIAL     — <c>["shapes","textures"]</c> → {shapes} + unknown {textures}: NOT an error (renders shapes + warns).
+///   * ALL-UNKNOWN — <c>["textures"]</c> → no recognized section → a LOUD error naming the token + the hint (not a summary).
+///   * EMPTY       — <c>""</c> → nothing requested → NOT an error (the summary is the intended default).
+///   * HINT        — the shared known-sections hint points at where texture-set slot paths live ('shapes' / 'paths').
+///
+/// Run: dotnet run --project src/housecarl-generator -- nif-sections-guard
+/// </summary>
+public static class NifSectionsProbe
+{
+    static int _pass, _fail;
+
+    public static int RunGuard(string[] args)
+    {
+        _pass = _fail = 0;
+        Console.WriteLine("################  REGRESSION GUARD — nif_inspect sections= parsing (#247)  ################");
+        Console.WriteLine();
+
+        // ARRAY-FORM (the #247 fix): the JSON-array-as-string parses to the sections, no unknowns.
+        var (arr, arrUnknown) = NifTools.ParseSections("[\"shapes\",\"paths\"]");
+        Check("ARRAY-FORM: [\"shapes\",\"paths\"] → {shapes, paths}, no unknown tokens",
+              arr.SetEquals(new[] { "shapes", "paths" }) && arrUnknown.Count == 0);
+
+        // PLAIN: the comma/space form is unchanged.
+        var (plain, plainUnknown) = NifTools.ParseSections("shapes, paths");
+        Check("PLAIN: 'shapes, paths' → {shapes, paths}, no unknown",
+              plain.SetEquals(new[] { "shapes", "paths" }) && plainUnknown.Count == 0);
+
+        // ALL: expands to every known section.
+        var (all, _) = NifTools.ParseSections("all");
+        Check("ALL: 'all' expands to the 7 known sections",
+              all.SetEquals(new[] { "shapes", "partitions", "alpha", "paths", "strings", "nodes", "bones" }));
+
+        // PARTIAL: some valid, some not → NOT an error (renders the valid + a warning).
+        var (partial, partialUnknown) = NifTools.ParseSections("[\"shapes\",\"textures\"]");
+        Check("PARTIAL: [\"shapes\",\"textures\"] → {shapes} + unknown {textures}, NOT an error",
+              partial.SetEquals(new[] { "shapes" }) && partialUnknown.Count == 1 && partialUnknown[0] == "textures"
+              && NifTools.SectionsError(partial, partialUnknown) is null);
+
+        // ALL-UNKNOWN: nothing valid → a LOUD error naming the token + the hint (Q3, not a silent summary).
+        var (none, noneUnknown) = NifTools.ParseSections("[\"textures\"]");
+        var allUnknownErr = NifTools.SectionsError(none, noneUnknown);
+        Check("ALL-UNKNOWN: [\"textures\"] → loud error naming the token, never a silent summary fallback",
+              none.Count == 0 && allUnknownErr is not null
+              && allUnknownErr.Contains("textures", StringComparison.Ordinal)
+              && allUnknownErr.Contains("shapes", StringComparison.Ordinal));
+
+        // EMPTY: nothing requested → NOT an error (summary is the intended default).
+        var (empty, emptyUnknown) = NifTools.ParseSections("");
+        Check("EMPTY: '' → nothing requested → NOT an error (summary default)",
+              empty.Count == 0 && emptyUnknown.Count == 0 && NifTools.SectionsError(empty, emptyUnknown) is null);
+
+        // HINT: the shared hint points texture-set slot paths at where they actually live.
+        Check("HINT: the known-sections hint points texture-set slot paths at 'shapes'/'paths'",
+              NifTools.KnownSectionsHint.Contains("texture-set", StringComparison.OrdinalIgnoreCase)
+              && NifTools.KnownSectionsHint.Contains("shapes", StringComparison.Ordinal)
+              && NifTools.KnownSectionsHint.Contains("paths", StringComparison.Ordinal));
+
+        Console.WriteLine();
+        Console.WriteLine($"=== nif-sections-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
+        return _fail == 0 ? 0 : 1;
+    }
+
+    static void Check(string label, bool ok)
+    {
+        Console.WriteLine($"   [{(ok ? "PASS" : "FAIL")}] {label}");
+        if (ok) _pass++; else _fail++;
+    }
+}

--- a/src/housecarl-generator/NifSectionsProbe.cs
+++ b/src/housecarl-generator/NifSectionsProbe.cs
@@ -38,6 +38,11 @@ public static class NifSectionsProbe
         Check("ARRAY-FORM: [\"shapes\",\"paths\"] → {shapes, paths}, no unknown tokens",
               arr.SetEquals(new[] { "shapes", "paths" }) && arrUnknown.Count == 0);
 
+        // ARRAY-FORM with a space after the comma (how a client's JSON serializer usually renders it).
+        var (arrSp, arrSpUnknown) = NifTools.ParseSections("[\"shapes\", \"paths\"]");
+        Check("ARRAY-FORM(spaced): [\"shapes\", \"paths\"] → {shapes, paths}, no unknown tokens",
+              arrSp.SetEquals(new[] { "shapes", "paths" }) && arrSpUnknown.Count == 0);
+
         // PLAIN: the comma/space form is unchanged.
         var (plain, plainUnknown) = NifTools.ParseSections("shapes, paths");
         Check("PLAIN: 'shapes, paths' → {shapes, paths}, no unknown",

--- a/src/housecarl-mcp/NifTools.cs
+++ b/src/housecarl-mcp/NifTools.cs
@@ -21,6 +21,14 @@ public static class NifTools
 {
     static readonly string[] KnownSections = { "shapes", "partitions", "alpha", "paths", "strings", "nodes", "bones" };
 
+    /// <summary>The "(known: …)" hint shared by the unrecognized-section warning and the all-unrecognized loud error
+    /// (#247): the legal tokens PLUS the pointer that there is NO 'textures' section — a mesh's embedded texture-set
+    /// slot paths live under 'shapes' (per-shape detail) and 'paths', the two places a caller reaching for "textures"
+    /// actually wants.</summary>
+    internal const string KnownSectionsHint =
+        "known: shapes, partitions, alpha, paths, strings, nodes, bones, all — no 'textures' section; " +
+        "embedded texture-set slot paths are under 'shapes' (detail) and 'paths'";
+
     [McpServerTool(Name = "housecarl_nif_inspect", ReadOnly = true, Title = "Inspect the data values inside one or many Skyrim meshes (.nif)"),
      Description(
          "Read the DATA VALUES inside one or many Skyrim meshes (.nif) at the data layer, beneath NifSkope. Resolve each " +
@@ -51,8 +59,11 @@ public static class NifTools
                      "order. Relative to the game's Data folder (forward or back slashes both fine).")]
             string[] mesh_paths,
         [Description("Optional. Which detail sections to show beyond the summary — any of 'shapes', 'partitions', 'alpha', " +
-                     "'paths', 'strings', 'nodes', 'bones', or 'all'. Comma- or space-separated. Applies to every mesh in " +
-                     "the batch. Empty = summary only (header + block census + shape names).")]
+                     "'paths', 'strings', 'nodes', 'bones', or 'all'. Comma-, space-, or JSON-array-separated (e.g. " +
+                     "[\"shapes\",\"paths\"]). There is NO 'textures' section — a mesh's embedded texture-set slot paths " +
+                     "appear under 'shapes' (per-shape detail) and 'paths'. Applies to every mesh in the batch; " +
+                     "unrecognized tokens are reported loud, and an all-unrecognized sections= is an error (never a " +
+                     "silent fallback to the summary). Empty = summary only (header + block census + shape names).")]
             string sections = "",
         [Description("Optional. Inspect a specific provider's copy instead of the VFS winner — the mod folder " +
                      "name, 'overwrite', 'Data', or a BSA filename as listed in the providers chain. Applies to every mesh " +
@@ -68,17 +79,25 @@ public static class NifTools
             return "error: mesh_paths contains only empty/blank entries. Pass Data-relative mesh paths (e.g. 'meshes\\armor\\iron\\cuirass_1.nif').";
 
         var (want, unknownTokens) = ParseSections(sections);
+        // Q3 (#247): sections were requested but NONE resolved — do NOT run the inspect and silently render the summary
+        // as if that were the answer (the reported quiet-fallback-to-defaults). Fail loud. (A PARTIAL request proceeds
+        // — it renders the valid sections + a loud warning.)
+        if (SectionsError(want, unknownTokens) is { } sectionsErr) return sectionsErr;
+
         var data = svc.NifInspect(mesh_paths, string.IsNullOrWhiteSpace(mod) ? null : mod);
         return NifWire.Render(data, want, unknownTokens, max_chars > 0 ? max_chars : 80_000);
     });
 
     /// <summary>Parse the sections argument into the recognized set + a list of any UNRECOGNIZED tokens (surfaced, never
-    /// silently ignored — Q3). 'all' expands to every known section.</summary>
-    static (HashSet<string> Want, IReadOnlyList<string> Unknown) ParseSections(string sections)
+    /// silently ignored — Q3). 'all' expands to every known section. Tolerates the JSON-array-as-string form an MCP
+    /// client naturally sends for a list: <c>sections=["shapes","paths"]</c> arrives here as the literal string
+    /// <c>["shapes","paths"]</c>, so the bracket and quote characters are split delimiters too — otherwise they glue
+    /// onto the first/last token (<c>["shapes</c>) and the whole array reads as unrecognized, the #247 quiet-fallback.</summary>
+    internal static (HashSet<string> Want, IReadOnlyList<string> Unknown) ParseSections(string sections)
     {
         var want = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var unknown = new List<string>();
-        foreach (var raw in (sections ?? "").Split(new[] { ',', ' ', ';', '\t' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        foreach (var raw in (sections ?? "").Split(new[] { ',', ' ', ';', '\t', '[', ']', '"', '\'' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
         {
             if (raw.Equals("all", StringComparison.OrdinalIgnoreCase)) { foreach (var s in KnownSections) want.Add(s); }
             else if (Array.Exists(KnownSections, s => s.Equals(raw, StringComparison.OrdinalIgnoreCase))) want.Add(raw.ToLowerInvariant());
@@ -86,6 +105,16 @@ public static class NifTools
         }
         return (want, unknown);
     }
+
+    /// <summary>The #247 all-unrecognized guard as a testable seam: sections were REQUESTED but NONE resolved (a typo,
+    /// or the non-existent 'textures') → the loud error string that replaces the silent fallback to the summary. Null
+    /// when the request is fine — nothing requested (summary is the intended answer), or at least one section resolved
+    /// (a partial request renders the valid ones + a warning, never an error).</summary>
+    internal static string? SectionsError(HashSet<string> want, IReadOnlyList<string> unknown)
+        => want.Count == 0 && unknown.Count > 0
+            ? $"error: no recognized section(s) in sections — unrecognized: {string.Join(", ", unknown)}  " +
+              $"({KnownSectionsHint}). Pass one or more known sections, or omit sections= for the summary only."
+            : null;
 
     [McpServerTool(Name = "housecarl_nif_set", Title = "Write a whitelisted data value into a Skyrim mesh (.nif)"),
      Description(
@@ -215,7 +244,7 @@ static class NifWire
         AppendDiscoveryWarnings(sb, d.Warnings, cap);
         if (unknownSections.Count > 0)
             sb.Append("\n[!] unrecognized section(s) ignored: ").Append(string.Join(", ", unknownSections))
-              .Append("  (known: ").Append(string.Join(", ", new[] { "shapes", "partitions", "alpha", "paths", "strings", "nodes", "bones", "all" })).Append(")\n");
+              .Append("  (").Append(NifTools.KnownSectionsHint).Append(")\n");
 
         bool readIncomplete = d.BsaFailures.Count > 0, discoveryIncomplete = d.Warnings.Count > 0;
         int shown = 0;

--- a/src/housecarl-mcp/NifTools.cs
+++ b/src/housecarl-mcp/NifTools.cs
@@ -25,8 +25,8 @@ public static class NifTools
     /// (#247): the legal tokens PLUS the pointer that there is NO 'textures' section — a mesh's embedded texture-set
     /// slot paths live under 'shapes' (per-shape detail) and 'paths', the two places a caller reaching for "textures"
     /// actually wants.</summary>
-    internal const string KnownSectionsHint =
-        "known: shapes, partitions, alpha, paths, strings, nodes, bones, all — no 'textures' section; " +
+    internal static readonly string KnownSectionsHint =
+        "known: " + string.Join(", ", KnownSections) + ", all — no 'textures' section; " +
         "embedded texture-set slot paths are under 'shapes' (detail) and 'paths'";
 
     [McpServerTool(Name = "housecarl_nif_inspect", ReadOnly = true, Title = "Inspect the data values inside one or many Skyrim meshes (.nif)"),


### PR DESCRIPTION
Fixes #247

Phase 1 deck-clearing — the standalone `nif_inspect` sections= papercut.

## The papercut
Passing `sections` as a JSON array — the natural MCP way to send a list — was **not** an error: the call succeeded and printed
```
[!] unrecognized section(s) ignored: ["shapes", "textures"]  (known: …)
```
then rendered the **default** sections. `["shapes","textures"]` arrived as the literal string and, split only on comma/space, tokenized to `["shapes` / `"textures"]` (brackets and quotes glued on) → both unrecognized → quiet fallback to the summary. In a batch pipeline the warning sat at the top of a 95 KB persisted file and was easy to miss — the first 3 batches (337 meshes) ran with the wrong sections before it was noticed. Second problem: the `known:` list didn't help someone reaching for texture-slot paths (there is no `textures` section, and nothing said the `tex[i]` slots live under `shapes`/`paths`).

## The fix
- **`ParseSections` accepts the array form** — `[`, `]`, `"`, `'` are split delimiters too, so `["shapes","paths"]` parses to `{shapes, paths}`.
- **All-unrecognized is a loud error, not a silent summary** (new testable `SectionsError` seam). A `sections=` in which nothing resolves returns an error naming the tokens; a **partial** request still renders the valid sections + a warning (the caller gets what it asked for that exists, and is told what didn't).
- **The hint points at texture-slot paths.** One shared `KnownSectionsHint` (used by both the warning and the error) and the `sections=` description now state there is no `textures` section — embedded texture-set slot paths appear under `shapes` (per-shape detail) and `paths`.

## Guard (correctness-by-construction)
`nif-sections-guard` drives the real parsing seams (`NifTools.ParseSections` / `SectionsError` / `KnownSectionsHint`, reachable via the existing `InternalsVisibleTo`):
- **ARRAY-FORM** — `["shapes","paths"]` → `{shapes, paths}`, no unknowns (RED before the fix).
- **PLAIN / ALL** — the comma/space form and `all` are unchanged.
- **PARTIAL** — `["shapes","textures"]` → `{shapes}` + unknown `{textures}`, NOT an error.
- **ALL-UNKNOWN** — `["textures"]` → a loud error naming the token, never a silent summary.
- **EMPTY** — `""` → not an error (summary is the intended default).
- **HINT** — the shared hint points texture-set slot paths at `shapes`/`paths`.

`ci-all`: **103/103 pass**.

## CHANGELOG
One `## Unreleased` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)