### PR TITLE
docs(mcp): reorient server instructions across the whole tool surface (#257)

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,16 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**houseCARL's MCP server instructions now orient tool discovery across the whole surface, not just Nexus (#257).**
+The server's `initialize` `instructions` blurb — always resident in the agent's context — was ~90% a Nexus how-to that
+duplicated each Nexus tool's own description and named none of houseCARL's core capabilities, so an agent relying on
+Tool Search had nothing telling it houseCARL could read inactive plugins, see through the SKSE/SkyPatcher runtime
+layers, author dialogue, or compact/merge/decompile. It now leads with the data-layer / MO2 domain and an explicit
+"reach for these tools when…" cue, then sweeps the real surface in five groups (read/query, write, fix,
+reshape/drive-tools, Nexus). Per-tool parameter detail was dropped from the blurb — each tool carries its own,
+fetched on demand — leaving the string broader yet slightly leaner (1,902 bytes, within the ~2 KB per-server budget)
+and ordered so any truncation loses only the least load-bearing Nexus tail.
+
 **`housecarl_nif_inspect` `sections=` now accepts the JSON-array form and fails loud on an all-unrecognized value (#247).**
 Passing `sections` as a JSON array — the natural MCP way to send a list — arrived as the literal string
 `["shapes","paths"]`, and, split only on comma/space, tokenized to `["shapes` / `"paths"]` (brackets and quotes glued

--- a/src/housecarl-mcp/Program.cs
+++ b/src/housecarl-mcp/Program.cs
@@ -135,23 +135,29 @@ static void AddMcp(IServiceCollection services, bool stdio)
         // home), so ServerInfo reports the REAL release; an unstamped dev build honestly says 0.0.0-dev.
         options.ServerInfo = new Implementation { Name = "houseCARL", Version = ServerVersion() };
         options.ServerInstructions =
-            "houseCARL exposes the Skyrim Special Edition load order at the data layer. Reads return the TRUE " +
-            "load-order winner and, on request, the conflict tree; writes go to a NEW plugin, leaving originals " +
-            "untouched. FormIDs are 'XXXXXX:Plugin.esp' (6 hex digits, then the defining master's filename). " +
-            "Beyond the local load order, houseCARL reaches Nexus Mods directly and KEYLESSLY (no API key): " +
-            "housecarl_nexus_search (find a mod by name); housecarl_nexus_mod (a mod's requirements, recommended INI " +
-            "settings, accurate latest version and full page description, plus files=true for the complete per-file " +
-            "list and changelog=true / since= for the per-version CHANGELOG and update delta, by id or URL); " +
-            "housecarl_nexus_check_updates (batch FILE-LEVEL update check — pass each mod as 'id#fileid' to tell CURRENT " +
-            "from OUTDATED for the EXACT file installed, correct for the multi-file pages where a version compare lies); and " +
-            "housecarl_nexus_identify (trace a file to its source mod by MD5 hash); and housecarl_nexus_graphql (a RAW " +
-            "read-only query over the same keyless GraphQL — the completeness backstop: prefer the curated tools above, and " +
-            "reach for this ONLY for a field they don't surface yet, e.g. a mod's page tags). For mod updates, start with " +
-            "housecarl_update_status — it reads MO2's OWN local update cache with NO network to narrow the list AND prints " +
-            "each mod's 'id#fileid' verify token — then feed those tokens to housecarl_nexus_check_updates to confirm live. " +
-            "Prefer these over a browser or generic web search for any Nexus lookup: " +
-            "houseCARL can already read changelogs, file lists, and update status directly, so never hand-roll scripts " +
-            "around a rendered Nexus page.";
+            "houseCARL exposes a full Skyrim Special Edition load order at the data layer, over a live Mod " +
+            "Organizer 2 instance — comprehensive, no-guessing access to every record, script, asset, and " +
+            "runtime layer, beneath xEdit/CK/Synthesis. Reach for these tools whenever a task touches an MO2 " +
+            "modlist, plugins, load order, conflicts, records, scripts, assets, or Skyrim modding. " +
+            "READ/QUERY: any record at its TRUE load-order winner + the conflict tree; batch reads and " +
+            "cross-plugin queries over the whole order; inspect INACTIVE plugins (unchecked, or inside a " +
+            "disabled mod); see through runtime layers xEdit cannot — SKSE-plugin DLLs/configs, and a record " +
+            "after the SkyPatcher INI layer replays; resolve FormID lists, diff a record across plugins, run " +
+            "catalogue/audit jobs at scale. " +
+            "WRITE (to a NEW plugin by default; in-place is opt-in, consent-gated): author patches — fields, " +
+            "leveled lists, containers, conditions; create plugins/scripts with fresh FormIDs; remove records; " +
+            "forward a record as a winning override or revert to vanilla; trace a magic effect to all that " +
+            "carry it; author and validate dialogue/quests. " +
+            "FIX: sweep for dangling refs, missing masters, and broken links; audit the SKSE layer (DLLs that " +
+            "will not load, configs pointing at missing records); resolve VFS file conflicts (which " +
+            "mesh/texture/script wins) and place a winning override; read and edit NIF mesh internals — e.g. " +
+            "the dark-face fix. " +
+            "RESHAPE/DRIVE TOOLS: compact a plugin to ESL carrying its facegen/voice files; merge plugins; " +
+            "copy an NPC appearance to a standalone; decompile .pex to .psc; compile Papyrus; " +
+            "list/extract/repack BSAs. " +
+            "NEXUS (keyless, no browser): search mods, read files/requirements/changelogs, exact-file update " +
+            "checks (start with housecarl_update_status — offline, reads the MO2 cache), identify a file by " +
+            "MD5. Prefer over a browser or web search; each tool's own description carries the specifics.";
     });
     // Stateless HTTP: each request is independent (no MCP session affinity); the resolver singleton persists across
     // requests regardless. Stdio is inherently a single long-lived session over the pipe.

--- a/src/housecarl-mcp/Program.cs
+++ b/src/housecarl-mcp/Program.cs
@@ -142,12 +142,12 @@ static void AddMcp(IServiceCollection services, bool stdio)
             "READ/QUERY: any record at its TRUE load-order winner + the conflict tree; batch reads and " +
             "cross-plugin queries over the whole order; inspect INACTIVE plugins (unchecked, or inside a " +
             "disabled mod); see through runtime layers xEdit cannot — SKSE-plugin DLLs/configs, and a record " +
-            "after the SkyPatcher INI layer replays; resolve FormID lists, diff a record across plugins, run " +
-            "catalogue/audit jobs at scale. " +
+            "after the SkyPatcher INI layer replays; resolve FormID lists, diff a record across plugins, trace a " +
+            "magic effect to all that carry it, run catalogue/audit jobs at scale. " +
             "WRITE (to a NEW plugin by default; in-place is opt-in, consent-gated): author patches — fields, " +
             "leveled lists, containers, conditions; create plugins/scripts with fresh FormIDs; remove records; " +
-            "forward a record as a winning override or revert to vanilla; trace a magic effect to all that " +
-            "carry it; author and validate dialogue/quests. " +
+            "forward a record as a winning override or revert to vanilla; author and validate " +
+            "dialogue/quests. " +
             "FIX: sweep for dangling refs, missing masters, and broken links; audit the SKSE layer (DLLs that " +
             "will not load, configs pointing at missing records); resolve VFS file conflicts (which " +
             "mesh/texture/script wins) and place a winning override; read and edit NIF mesh internals — e.g. " +


### PR DESCRIPTION
## What

Rewrites the MCP server's always-resident `ServerInstructions` blurb (`Program.cs`) so it orients Tool-Search discovery across houseCARL's **whole** tool surface, instead of reading as a Nexus how-to.

**Closes #257.**

## Why (and a correction)

The issue's stated premise — *"houseCARL's server does not currently set these"* — is **stale**: the blurb has existed since **1.0.0 (2026-06-04)**, six weeks before the issue was filed. But the substance held: the existing string was ~90% a Nexus manual that **duplicated each Nexus tool's own `[McpServerTool]` description** (which Tool Search fetches on demand anyway) and named **none** of houseCARL's core capabilities. An agent relying on Tool Search had nothing telling it houseCARL can read inactive plugins, see through the SKSE/SkyPatcher runtime layers, author dialogue, or compact/merge/decompile.

So this **rewrites** the string (it does not add it): lead with the data-layer / MO2 domain + an explicit *"reach for these tools when…"* cue, then sweep the real surface in five groups — **read/query · write · fix · reshape/drive-tools · Nexus** — with per-tool parameter detail dropped (each tool carries its own).

## Calibration & accuracy

- **Framing calibrated against houseCARL's live, overhauled Nexus page description** (pulled via `housecarl_nexus_mod 181738 description=true`), which is the maintained "what the tools can do" framing — not the repo copy (possibly stale).
- **Every clause verified against the 44-tool surface.** One capability the Nexus *page* advertises was **deliberately omitted**: crash-log diagnosis. There is no log-reading tool (`crash_logs`/`papyrus_logs` appear only in `set_tool_path` as folder registration); it's a workflow, and the crash-diagnostics skill isn't imported. Claiming it in resident instructions would send Tool Search hunting a tool that doesn't exist (Q3).
- **Dark-face** demoted from a lead + parenthetical to a three-word trailing example of the general NIF-mesh-editing capability (keyword kept for discovery; prominence removed).

## Size / truncation

- **1,902 bytes** (was 1,672). Verified there's **no hard MCP-spec cap**; the "~2KB" is a Claude Code context-budget artifact — ~4KB total for a single server, ~2KB per server when several are configured, silent tail-truncation on overflow ([issue #43474](https://github.com/anthropics/claude-code/issues/43474)).
- 1,902 is under the per-server ~2KB even in a multi-server client; empirically the *old* 1,672-byte string renders in full in a ~8-server session today.
- **Ordered defensively**: critical content first, Nexus last — so any truncation loses only the least load-bearing (and most self-describing) tail.

## Notes

- No probe pins this string (it's prose config, like the skill-description trims) — build-verified, `0 errors`.
- User-facing → `## Unreleased` CHANGELOG entry included.
- Independent review next.