### PR TITLE
docs(codex): refresh the umbrella router to full coverage + guard it by construction

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,16 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**The Codex umbrella router now covers the whole tool surface, and a CI guard keeps it that way (Codex parity).**
+The Codex packaging ships one umbrella routing skill (`plugin/codex/housecarl/SKILL.md`); it had drifted to naming
+only 9 of the ~45 MCP tools and 5 of the 13 helper skills, so a Codex user asking about facegen, Nexus, BSA
+archives, dialogue, SKSE audits, or plugin compaction got no routing from it. It now carries a capability-grouped
+map of **all 45 tools** and routes to **all 13 helper skills** (the discrete skills themselves already install to
+Codex under `~/.agents/skills/`, so this restores the router, not the skills). A new `codex-umbrella-coverage`
+CI guard reflects the real `[McpServerTool]` names and the `.claude/skills/*` folders and fails if any is unrouted
+by the umbrella (or explicitly allow-listed) — so the drift cannot silently recur: adding a tool or skill without
+updating the Codex router turns CI red. Codex packaging + CI only; no change to Claude Code behavior.
+
 **The `bulk-record-jobs` skill now teaches how to get a big enumeration out — paging vs. persist-to-file (#249).**
 A new section distinguishes the two independent caps a bulk read hits — the row cap (`limit=` → `capped`) and the
 per-call output cap (`max_chars` → `truncated`) — and names the two lanes for clearing them: `offset=` paging on

--- a/plugin/codex/housecarl/SKILL.md
+++ b/plugin/codex/housecarl/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: housecarl
-description: Work with Skyrim Special Edition load-order records through the houseCARL MCP server — set or switch the MO2 instance, inspect active plugins and conflict trees, read records, query across plugins, author reviewable patch ESPs, create or remove records, and edit leveled lists or composed structs. Also the routing skill for the bundled Skyrim helpers (mutagen-reference, papyrus-reference, skypatcher-authoring, spid-authoring, kid-authoring). Use whenever the user mentions houseCARL, an MO2 modlist, plugins, load order, conflicts, ESP patches, overrides, a record type (ARMO/WEAP/NPC_/LVLI/MGEF/…), leveled lists, keywords, or a no-ESP runtime distribution — even when the task looks like a single edit, load this first to pick the right tool and read before you write.
+description: Work with Skyrim Special Edition load-order records and assets through the houseCARL MCP server — set or switch the MO2 instance, inspect active or disabled plugins and conflict trees, read records, query across plugins, author reviewable patch ESPs, create or remove records, edit leveled lists and composed structs, diff and resolve, edit NIF meshes and facegen, author dialogue, audit the SkyPatcher and SKSE runtime layers, compact or merge plugins, drive Papyrus compile/decompile and BSA archives, and look mods up on Nexus. Also the router for the bundled Skyrim helper skills (mutagen-reference, papyrus-reference, biped-slot-reference, skypatcher-authoring, spid-authoring, kid-authoring, dialogue-authoring, facegen-diagnostics, oar-authoring, skse-plugin-authoring, papyrus-optimization, tool-output-awareness, bulk-record-jobs). Use whenever the user mentions houseCARL, an MO2 modlist, plugins, load order, conflicts, ESP patches, overrides, a record type (ARMO/WEAP/NPC_/LVLI/MGEF/…), leveled lists, keywords, facegen or dark faces, dialogue, SKSE plugins, Papyrus, BSA archives, Nexus, or a no-ESP runtime distribution — even when the task looks like a single edit, load this first to pick the right tool and read before you write.
 ---
 
 # houseCARL
 
-Use this skill for data-layer Skyrim Special Edition modding through the configured houseCARL MCP server. houseCARL reads a Mod Organizer 2 instance, resolves the true load-order winner, and writes changes into reviewable patch plugins; original source mods are never edited.
+Use this skill for data-layer Skyrim Special Edition modding through the configured houseCARL MCP server. houseCARL reads a Mod Organizer 2 instance, resolves the true load-order winner, and writes changes into reviewable patch plugins; original source mods are never edited. Beyond the record read/write core it reaches the whole data layer — assets and NIF meshes, the SkyPatcher and SKSE runtime layers, dialogue, plugin operations, Papyrus compile/decompile, BSA archives, and keyless Nexus lookups — plus the 13 focused helper skills below for the specialist grammars and workflows.
 
-## Core workflow
+## Core workflow (read before you write)
 
 1. Confirm context when it matters:
    - `housecarl_load_order_status` for profile/plugin status, or to check whether a mod or plugin is active.
@@ -15,18 +15,57 @@ Use this skill for data-layer Skyrim Special Edition modding through the configu
 2. Read before any record write:
    - `mutagen-reference` to verify field names, writability, enum values, and composed-struct shapes.
    - `housecarl_read_record` or `housecarl_batch_record_detail` to inspect the current winner. Add `conflict_tree=true` for contested records or when winner provenance matters.
-   - `housecarl_cross_plugin_query` to locate records or references across the load order.
+   - `housecarl_cross_plugin_query` to locate records or references across the load order (page big results with `offset=`).
 3. Pick the narrowest write tool:
    - `housecarl_set_field` for a single scalar or simple-collection edit.
    - `housecarl_bulk_apply` for several edits in one patch, dict merges, leveled-list entries, effects, or other composed structs.
-   - `housecarl_create_record` for a new top-level record (it needs an EditorID).
+   - `housecarl_create_record` (or `housecarl_bulk_create` for many at once) for a new top-level record — it needs an EditorID.
    - `housecarl_remove_record` only to drop a record or override from a houseCARL-owned patch — never from a source mod.
 4. Accumulate related edits into one patch with `into=<patch filename>` after the first write returns a patch name.
-5. Prefer runtime, no-ESP INI systems when they fit the user's intent:
-   - `skypatcher-authoring` for SkyPatcher record edits.
-   - `spid-authoring` for distributing spells, perks, items, factions, outfits, or packages to NPCs.
-   - `kid-authoring` for distributing keywords onto items.
-6. `papyrus-reference` before answering any Papyrus or SKSE function-signature question.
+5. Prefer runtime, no-ESP INI systems when they fit the user's intent — `skypatcher-authoring`, `spid-authoring`, `kid-authoring` (see the helper skills below).
+
+## The full tool surface
+
+Beyond the core workflow, reach for the right group. Depth for the specialist areas lives in the helper skills (next section) — load the skill before composing in that area.
+
+**Read / query / resolve**
+- `housecarl_read_record`, `housecarl_batch_record_detail` — read one or many records at the true winner (`conflict_tree=true` for provenance).
+- `housecarl_read_plugin_file` — read a plugin directly, even one that is disabled or not active.
+- `housecarl_cross_plugin_query` — query and filter records or references across the whole order; page with `offset=`, count with `group_by=`.
+- `housecarl_resolve` — resolve a list of FormIDs to identity; `housecarl_diff_record` — diff two plugins' versions of a record.
+- `housecarl_effect_chain` — trace a magic effect to every spell / enchantment / potion / scroll / ingredient that carries it.
+- `housecarl_load_order_status` — enabled/disabled mods & plugins; `housecarl_check_errors` — dangling refs, missing masters, broken links.
+
+**Runtime layers (what xEdit can't see)**
+- `housecarl_skypatcher_read` — a record's true state after the SkyPatcher INI layer replays; `housecarl_skypatcher_layer` — the INIs, apply order, conflicts.
+- `housecarl_skse_inventory` — SKSE-plugin DLLs, configs, provider/metadata; `housecarl_skse_config_audit` — config references vs the load order; `housecarl_native_pairing_audit` — native Papyrus declarations vs the DLLs implementing them.
+
+**Write / author**
+- `housecarl_set_field`, `housecarl_bulk_apply`, `housecarl_create_record`, `housecarl_bulk_create`, `housecarl_create_plugin` (header-only trigger plugin), `housecarl_remove_record`, `housecarl_forward_record` (copy-as-override, or revert to another plugin's version), `housecarl_validate_scripts` (unbound script properties).
+
+**Dialogue** — `housecarl_validate_dialogue`, `housecarl_write_seq` (the start-game-enabled quest `.seq`). Depth: `dialogue-authoring`.
+
+**Assets / NIF / facegen** — `housecarl_asset_status` (which mod/BSA wins a Data-relative path), `housecarl_place_asset` / `housecarl_bulk_place_asset` (make a chosen copy win MO2's VFS), `housecarl_nif_inspect` / `housecarl_nif_set` (read/write mesh data values). Depth: `facegen-diagnostics`.
+
+**Plugin operations** — `housecarl_compact_plugin` (ESL-renumber, carries FormID-keyed facegen/voice along), `housecarl_merge_plugins`, `housecarl_copy_npc_appearance` (standalone appearance, no donor master).
+
+**Papyrus / SKSE code** — `housecarl_compile_script` (`.psc` → `.pex`), `housecarl_decompile_script` (`.pex` → `.psc`). Depth: `papyrus-reference`, `papyrus-optimization`, `skse-plugin-authoring`.
+
+**BSA archives** — `housecarl_bsa_list`, `housecarl_bsa_extract`, `housecarl_bsa_repack`.
+
+**Nexus (keyless, no browser)** — `housecarl_nexus_search`, `housecarl_nexus_mod`, `housecarl_nexus_check_updates`, `housecarl_nexus_identify`, `housecarl_nexus_graphql`. For a whole-order update check, start with `housecarl_update_status` (MO2's local update cache, no network), then confirm with `housecarl_nexus_check_updates`.
+
+**Setup** — `housecarl_set_mo2_instance`, `housecarl_set_tool_path` (point houseCARL at an external tool: the Papyrus compiler, BSArch, or the crash / Papyrus log folders).
+
+## Bundled helper skills
+
+Load the specialist skill before composing in its domain:
+
+- **Reference** — `mutagen-reference` (record schemas), `papyrus-reference` (Papyrus / SKSE function signatures), `biped-slot-reference` (armor by biped slot).
+- **Runtime distribution grammars** — `skypatcher-authoring` (record edits), `spid-authoring` (spells / perks / items / factions / outfits → NPCs), `kid-authoring` (keywords → items).
+- **Content authoring / investigation** — `dialogue-authoring`, `facegen-diagnostics` (the dark-face NPC bug), `oar-authoring` (Open Animation Replacer), `skse-plugin-authoring` (C++ SKSE plugin DLLs).
+- **Performance & guardrail** — `papyrus-optimization` (script cost review), `tool-output-awareness` (keep generated tool output out of authored patches).
+- **Bulk planning** — `bulk-record-jobs` (catalogues, audits, link graphs, conflict surveys, fan-out extraction — many records into one structured deliverable).
 
 ## FormID notes
 
@@ -37,3 +76,4 @@ houseCARL tools use `XXXXXX:Plugin.esp` FormIDs — six hex digits, then the fil
 - houseCARL patches are reviewable output mods. Tell the user which patch was created or extended.
 - Don't invent schemas or field paths. If `mutagen-reference` has no entry for a type, say so directly rather than guessing.
 - Don't reach for record edits when the user explicitly wants a no-ESP / runtime distribution file — use SkyPatcher, SPID, or KID instead.
+- Never edit a source mod in place unless the user has explicitly opted into the in-place lane.

--- a/plugin/codex/housecarl/agents/openai.yaml
+++ b/plugin/codex/housecarl/agents/openai.yaml
@@ -1,4 +1,6 @@
-# Codex skill metadata for the houseCARL umbrella skill (schema reviewed by Codex, 2026-06-04).
+# Codex skill metadata for the houseCARL umbrella skill. Schema first reviewed 2026-06-04; re-verified
+# 2026-07-21 against Codex's Build-skills docs (interface/policy/dependencies fields, ~/.agents/skills
+# discovery, MCP-via-config.toml) — still current.
 interface:
   display_name: "houseCARL"
   short_description: "Skyrim SE / MO2 data-layer modding."

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -115,6 +115,10 @@ public static class CiAll
         ("sameshape-agree-guard", SameShapeAgreeProbe.RunGuard),
         ("corpus-hygiene-guard", CorpusHygieneProbe.RunGuard),
         ("plugin-validate-guard", PluginValidateProbe.RunGuard),
+        // Codex umbrella coverage: the single hand-maintained Codex router (plugin/codex/housecarl/SKILL.md) must
+        // reference every current MCP tool (reflected off [McpServerTool]) and every .claude/skills/* folder, or
+        // allow-list the omission — turns the silent 45→9 drift into a RED arm naming exactly what's unrouted.
+        ("codex-umbrella-coverage-guard", CodexUmbrellaCoverageProbe.RunGuard),
         ("nullarm-guard", NullArmGuardProbe.RunGuard),
         ("formlink-null-guard", FormLinkNullProbe.RunGuard),
         ("formlink-remove-guard", FormLinkRemoveProbe.RunGuard),

--- a/src/housecarl-generator/CodexUmbrellaCoverageProbe.cs
+++ b/src/housecarl-generator/CodexUmbrellaCoverageProbe.cs
@@ -1,0 +1,136 @@
+using System.Reflection;
+using ModelContextProtocol.Server;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// REGRESSION GUARD (standing CI instrument, self-contained) — CODEX UMBRELLA COVERAGE.
+///
+/// The Codex packaging ships ONE umbrella routing skill (plugin/codex/housecarl/SKILL.md) that hand-lists
+/// houseCARL's MCP tools and helper skills. Unlike the 13 Claude Code skills — each its own trigger — the
+/// umbrella is Codex's single hand-maintained router, so nothing forced it to track the tool/skill surface: it
+/// silently drifted from full coverage to 9 of ~45 tools over ~2 months because adding a tool never touched it.
+///
+/// This guard makes that drift impossible by construction. It reflects the REAL [McpServerTool] names off the
+/// housecarl-mcp assembly (immune to the source line-wrapping that hides a tool from a grep) and reads the REAL
+/// .claude/skills/* folders, then asserts EVERY one is referenced in the umbrella — or explicitly allow-listed as
+/// a deliberate omission. A session that adds housecarl_foo or a new skill and forgets the Codex router now gets
+/// a RED CI arm naming exactly what to add. Same "green only if the checker has teeth" shape as the other guards:
+/// RED arms feed a synthetic omission and assert it fires; the allow-list is proven to actually suppress.
+///
+///   INV1 — every current MCP tool name is referenced in the umbrella (or allow-listed).
+///   INV2 — every bundled skill slug is referenced in the umbrella (or allow-listed).
+///
+/// Run: dotnet run --project src/housecarl-generator -- codex-umbrella-coverage-guard
+/// </summary>
+public static class CodexUmbrellaCoverageProbe
+{
+    static int _pass, _fail;
+
+    // Deliberate omissions from the Codex umbrella router. EMPTY by design — the umbrella covers the whole
+    // surface today. Add a name here ONLY with a one-line reason when a tool/skill is intentionally not routed by
+    // the umbrella; that keeps "not in the router" a conscious choice recorded here, never silent drift.
+    static readonly HashSet<string> Allow = new(StringComparer.Ordinal)
+    {
+        // (none)
+    };
+
+    static readonly string UmbrellaPath = Path.Combine("plugin", "codex", "housecarl", "SKILL.md");
+
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  REGRESSION GUARD — Codex umbrella coverage (tools + skills referenced)  ################");
+        Console.WriteLine();
+        try
+        {
+            // A missing/empty router must never read as "all covered" (Q3).
+            Check($"GREEN umbrella router resolves ('{UmbrellaPath.Replace('\\', '/')}', run from repo root)", File.Exists(UmbrellaPath),
+                new() { $"'{Path.GetFullPath(UmbrellaPath)}' not found — CWD must be the repo root" });
+            var umbrella = File.Exists(UmbrellaPath) ? File.ReadAllText(UmbrellaPath) : "";
+
+            // Authoritative tool set — reflected off the shipped [McpServerTool] attributes.
+            var tools = McpToolNames();
+            Check($"GREEN reflected a non-empty MCP tool set ({tools.Count})", tools.Count > 0,
+                new() { "no [McpServerTool] names reflected off the housecarl-mcp assembly — wrong assembly, or the attribute type moved" });
+
+            // Authoritative skill set — the real .claude/skills/* folders.
+            var skills = SkillSlugs();
+            Check($"GREEN found bundled skill folders ({skills.Count})", skills.Count > 0,
+                new() { "no folders under .claude/skills — wrong CWD or empty tree" });
+
+            // INV1 — every tool referenced.
+            var missTools = MissingRefs(umbrella, tools, Allow);
+            Check("INV1-GREEN every MCP tool is referenced in the umbrella router", missTools.Count == 0,
+                missTools.Select(t => $"tool not routed by the Codex umbrella: {t} — add it to {UmbrellaPath.Replace('\\', '/')} (or Allow with a reason)").ToList());
+
+            // INV2 — every skill referenced.
+            var missSkills = MissingRefs(umbrella, skills, Allow);
+            Check("INV2-GREEN every bundled skill is referenced in the umbrella router", missSkills.Count == 0,
+                missSkills.Select(s => $"skill not routed by the Codex umbrella: {s} — add it to {UmbrellaPath.Replace('\\', '/')} (or Allow with a reason)").ToList());
+
+            // RED arms — the checker must catch an omission, or it is toothless.
+            var redTool = MissingRefs("router text that mentions no tools", new[] { "housecarl_read_record" }, Empty());
+            Check("INV1-RED  a missing tool reference is caught", redTool.Contains("housecarl_read_record"), redTool, redArm: true);
+
+            var redSkill = MissingRefs("router text that mentions no skills", new[] { "facegen-diagnostics" }, Empty());
+            Check("INV2-RED  a missing skill reference is caught", redSkill.Contains("facegen-diagnostics"), redSkill, redArm: true);
+
+            // The allow-list must actually suppress — else an Allow entry would be a lie.
+            var allowed = MissingRefs("router text that mentions no tools", new[] { "housecarl_read_record" },
+                new HashSet<string>(StringComparer.Ordinal) { "housecarl_read_record" });
+            Check("ALLOW     an allow-listed name is NOT reported missing", allowed.Count == 0, allowed, redArm: true);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"   FAIL (unexpected): {ex.GetType().Name}: {ex.Message}");
+            _fail++;
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"=== codex-umbrella-coverage-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
+        return _fail == 0 ? 0 : 1;
+    }
+
+    static HashSet<string> Empty() => new(StringComparer.Ordinal);
+
+    /// <summary>Reflect every [McpServerTool] Name off the housecarl-mcp assembly (anchored via a known tool type).</summary>
+    static HashSet<string> McpToolNames()
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var t in typeof(ReadTools).Assembly.GetTypes())
+            foreach (var m in t.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+            {
+                var a = m.GetCustomAttribute<McpServerToolAttribute>(inherit: false);
+                if (a?.Name is { Length: > 0 } n) names.Add(n);
+            }
+        return names;
+    }
+
+    static List<string> SkillSlugs()
+    {
+        var dir = Path.Combine(".claude", "skills");
+        return Directory.Exists(dir)
+            ? Directory.GetDirectories(dir).Select(d => Path.GetFileName(d)!).Where(s => !string.IsNullOrEmpty(s))
+                       .OrderBy(s => s, StringComparer.Ordinal).ToList()
+            : new();
+    }
+
+    /// <summary>Required names not present in the umbrella text and not allow-listed. Ordinal substring match — no
+    /// tool or skill name is a substring of another, so a plain Contains is unambiguous.</summary>
+    static List<string> MissingRefs(string umbrella, IEnumerable<string> required, ISet<string> allow)
+        => required.Where(r => !allow.Contains(r) && !umbrella.Contains(r, StringComparison.Ordinal))
+                   .OrderBy(r => r, StringComparer.Ordinal).ToList();
+
+    static void Check(string label, bool ok, List<string> detail, bool redArm = false)
+    {
+        Console.WriteLine($"   {label,-72}: {(ok ? "PASS" : "FAIL")}");
+        if (!ok)
+        {
+            if (detail.Count == 0)
+                Console.WriteLine(redArm ? "        - (the checker reported NO violation — it is toothless)" : "        - (no detail)");
+            foreach (var d in detail.Take(20)) Console.WriteLine($"        - {d}");
+        }
+        if (ok) _pass++; else _fail++;
+    }
+}

--- a/src/housecarl-generator/CodexUmbrellaCoverageProbe.cs
+++ b/src/housecarl-generator/CodexUmbrellaCoverageProbe.cs
@@ -13,8 +13,8 @@ namespace HousecarlGenerator;
 /// silently drifted from full coverage to 9 of ~45 tools over ~2 months because adding a tool never touched it.
 ///
 /// This guard makes that drift impossible by construction. It reflects the REAL [McpServerTool] names off the
-/// housecarl-mcp assembly (immune to the source line-wrapping that hides a tool from a grep) and reads the REAL
-/// .claude/skills/* folders, then asserts EVERY one is referenced in the umbrella — or explicitly allow-listed as
+/// housecarl-mcp assembly — the authoritative registered set, not a source-text pattern a brittle grep can miss —
+/// and reads the REAL .claude/skills/* folders, then asserts EVERY one is referenced in the umbrella — or allow-listed as
 /// a deliberate omission. A session that adds housecarl_foo or a new skill and forgets the Codex router now gets
 /// a RED CI arm naming exactly what to add. Same "green only if the checker has teeth" shape as the other guards:
 /// RED arms feed a synthetic omission and assert it fires; the allow-list is proven to actually suppress.
@@ -58,6 +58,17 @@ public static class CodexUmbrellaCoverageProbe
             var skills = SkillSlugs();
             Check($"GREEN found bundled skill folders ({skills.Count})", skills.Count > 0,
                 new() { "no folders under .claude/skills — wrong CWD or empty tree" });
+
+            // The Contains() coverage check below is only sound if no required name is a substring of ANOTHER
+            // required name — else referencing the longer one would falsely satisfy the shorter one being missing.
+            // Assert that invariant instead of trusting it: a future prefix-named tool (housecarl_read ⊂
+            // housecarl_read_record) trips THIS arm rather than silently passing unrouted.
+            var required = tools.Concat(skills).ToList();
+            var subsumed = required
+                .Where(a => required.Any(b => b != a && b.Contains(a, StringComparison.Ordinal)))
+                .OrderBy(a => a, StringComparer.Ordinal).ToList();
+            Check("GUARD-SELF no required name is a substring of another (Contains match is unambiguous)", subsumed.Count == 0,
+                subsumed.Select(a => $"'{a}' is a substring of another required name — the Contains coverage check could false-pass it; use a boundary match or rename").ToList());
 
             // INV1 — every tool referenced.
             var missTools = MissingRefs(umbrella, tools, Allow);


### PR DESCRIPTION
## What

Brings the Codex packaging's umbrella router (`plugin/codex/housecarl/SKILL.md`) to **full tool/skill coverage**, and adds a **CI guard that keeps it there by construction**. Closes the *"Codex routing skill is stale"* item in `dev/BACKLOG.md` (no GH issue).

## Context — the Codex structure was verified, not assumed

Before touching content I checked the Codex packaging against OpenAI's current [Build-skills docs](https://learn.chatgpt.com/docs/build-skills.md):
- Skill shape (`SKILL.md` + optional `agents/openai.yaml`), frontmatter (`name`/`description`), and `openai.yaml` schema (`interface`/`policy`/`dependencies.tools`) — **all current**.
- Discovery path: the installer copies skills to **`~/.agents/skills/`** — matches the authoritative user-scope location (not the stale `~/.codex/skills/`).
- The installer copies **all 13 discrete skills + the umbrella** flat into `~/.agents/skills/`, so Codex already has **skill parity** with Claude — `facegen-diagnostics` et al. weren't invisible.

So the genuine staleness was narrower than the BACKLOG framed: the **umbrella router** (Codex's single hand-maintained router for the ~30 "loose" tools no domain skill owns) had drifted to **9 of ~45 tools** and **5 of 13 skills**.

## The refresh

- Capability-grouped map of **all 45 tools** (read/query · runtime layers · write · dialogue · assets/NIF · plugin ops · Papyrus/SKSE · BSA · Nexus · setup), keeping the record read→write spine.
- Routes to **all 13 helper skills**.
- Broadened the frontmatter trigger keywords (facegen/dialogue/SKSE/Papyrus/BSA/Nexus/NIF) so Codex routes those to the skill; `openai.yaml` provenance note re-verified.

## The guard (recurrence prevention — the real ask)

A new **`codex-umbrella-coverage`** probe (`CodexUmbrellaCoverageProbe`, wired into `ci-all`):
- Reflects the real `[McpServerTool]` names off the `housecarl-mcp` assembly (immune to the source line-wrapping that hid `set_mo2_instance` from a grep) and reads the real `.claude/skills/*` folders.
- **INV1/INV2-GREEN:** every tool and every skill is referenced in the umbrella (or in an explicit, currently-empty allow-list).
- **RED arms:** proves it catches a missing tool and a missing skill, and that the allow-list actually suppresses.

Adding a tool/skill without updating the Codex router now **turns CI red naming exactly what's unrouted** — the silent 45→9 drift becomes impossible.

## Verification

Ran the guard locally against the branch — **8/8 PASS**: reflected **45 tools** + **13 skills**, both GREEN (umbrella covers all), RED arms fire, allow-list suppresses.

```
GREEN reflected a non-empty MCP tool set (45)                : PASS
GREEN found bundled skill folders (13)                       : PASS
INV1-GREEN every MCP tool is referenced in the umbrella      : PASS
INV2-GREEN every bundled skill is referenced in the umbrella : PASS
INV1-RED / INV2-RED / ALLOW                                  : PASS
```

Codex packaging + CI only — no change to Claude Code behavior. `## Unreleased` CHANGELOG entry included. Independent review next; I'll prune the BACKLOG line on merge.