### PR TITLE
fix(provenance): compute a direct path's load-order standing instead of assuming it

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -15,14 +15,24 @@ live file wasn't live, which is exactly the claim a diff is consulted for. Two c
 locate asserted "not enabled" for every direct path instead of computing it, and `diff_record` routed poles by plugin
 NAME only, so a path could never match the active order. Enabled-ness now comes from the same enumerator the filename
 lane uses (so the two can't disagree about one file), and a path that IS the copy the order loads resolves back to its
-plugin name and diffs as `active order`. The flag answers "is this file the copy the install provides", judged against
-the same priority-ordered winner the filename lane uses — so a full-path compare, never a filename one: an archived
-backup that shares a name with the live plugin stays `OUT-OF-LOAD-ORDER` (the old-version-vs-live diff is unchanged),
-and a shadowed copy in a lower-priority enabled mod is not reported as active merely because its mod is enabled.
-`read_plugin_file` inherits the honest flag, so it no longer adds `NOT active` to an enabled plugin's own file. Its
-`OUT-OF-LOAD-ORDER` banner is unchanged and still stamps every read — note that the banner's "the game does not load
-this file" wording is inaccurate when the file you passed IS the live plugin; the wording is tracked in #271 with the
-rest of this flag's semantics. Reported by a houseCARL user.
+plugin name and diffs as `active order`.
+
+The flag a located plugin carries — what `read_plugin_file` renders as `NOT active` and `diff_record` as `disabled` —
+now means one thing in every lane: **the game loads this file**. That needs both halves, and each was wrong before:
+
+- **The right copy.** Judged by full path against the copy the install actually serves (the first hit from an enabled
+  layer — the same rule that builds the real load order). An archived backup sharing a filename stays
+  `OUT-OF-LOAD-ORDER`, so the old-version-vs-live diff is unchanged; a copy shadowed by a higher-priority mod is not
+  called active merely because its own mod is enabled; and a plugin served from game `Data` is not called inactive
+  merely because some disabled mod holds the same filename.
+- **Ticked.** A plugin sitting in an *enabled mod* but *unchecked in MO2's right pane* is no longer reported as
+  active — the game does not load it. Implicit base/CC masters, which are force-loaded and never listed in
+  `plugins.txt`, still count as active. This half applies to the filename and `mod=` lanes too, so all three now
+  state the same fact.
+
+`read_plugin_file`'s `OUT-OF-LOAD-ORDER` banner is unchanged and still stamps every read — note its "the game does not
+load this file" wording is inaccurate when the file you passed IS the live plugin; that wording, and whether this flag
+should split into two, are tracked in #271. Reported by a houseCARL user.
 
 **The Codex umbrella router now covers the whole tool surface, and a CI guard keeps it that way (Codex parity).**
 The Codex packaging ships one umbrella routing skill (`plugin/codex/housecarl/SKILL.md`); it had drifted to naming

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,18 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**A plugin addressed by its file path is no longer mislabeled off-order and disabled (#269).**
+`diff_record` stamped `OUT-OF-LOAD-ORDER (direct path, disabled)` on a plugin that is enabled and winning whenever it
+was passed as an absolute path instead of a filename — the diff values were right, but the provenance line said the
+live file wasn't live, which is exactly the claim a diff is consulted for. Two causes, both fixed: the shared on-disk
+locate asserted "not enabled" for every direct path instead of computing it, and `diff_record` routed poles by plugin
+NAME only, so a path could never match the active order. Enabled-ness now comes from the same enumerator the filename
+lane uses (so the two can't disagree about one file), and a path that IS the copy the order loads resolves back to its
+plugin name and diffs as `active order`. The comparison is by full path, never by filename: an archived backup that
+shares a name with the live plugin stays `OUT-OF-LOAD-ORDER` — the old-version-vs-live diff is unchanged.
+`read_plugin_file` inherits the honest flag (it still stamps every read OUT-OF-LOAD-ORDER by contract, but no longer
+adds `NOT active` to an enabled plugin's own file). Reported by a houseCARL user.
+
 **The Codex umbrella router now covers the whole tool surface, and a CI guard keeps it that way (Codex parity).**
 The Codex packaging ships one umbrella routing skill (`plugin/codex/housecarl/SKILL.md`); it had drifted to naming
 only 9 of the ~45 MCP tools and 5 of the 13 helper skills, so a Codex user asking about facegen, Nexus, BSA

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -15,10 +15,14 @@ live file wasn't live, which is exactly the claim a diff is consulted for. Two c
 locate asserted "not enabled" for every direct path instead of computing it, and `diff_record` routed poles by plugin
 NAME only, so a path could never match the active order. Enabled-ness now comes from the same enumerator the filename
 lane uses (so the two can't disagree about one file), and a path that IS the copy the order loads resolves back to its
-plugin name and diffs as `active order`. The comparison is by full path, never by filename: an archived backup that
-shares a name with the live plugin stays `OUT-OF-LOAD-ORDER` — the old-version-vs-live diff is unchanged.
-`read_plugin_file` inherits the honest flag (it still stamps every read OUT-OF-LOAD-ORDER by contract, but no longer
-adds `NOT active` to an enabled plugin's own file). Reported by a houseCARL user.
+plugin name and diffs as `active order`. The flag answers "is this file the copy the install provides", judged against
+the same priority-ordered winner the filename lane uses — so a full-path compare, never a filename one: an archived
+backup that shares a name with the live plugin stays `OUT-OF-LOAD-ORDER` (the old-version-vs-live diff is unchanged),
+and a shadowed copy in a lower-priority enabled mod is not reported as active merely because its mod is enabled.
+`read_plugin_file` inherits the honest flag, so it no longer adds `NOT active` to an enabled plugin's own file. Its
+`OUT-OF-LOAD-ORDER` banner is unchanged and still stamps every read — note that the banner's "the game does not load
+this file" wording is inaccurate when the file you passed IS the live plugin; the wording is tracked in #271 with the
+rest of this flag's semantics. Reported by a houseCARL user.
 
 **The Codex umbrella router now covers the whole tool surface, and a CI guard keeps it that way (Codex parity).**
 The Codex packaging ships one umbrella routing skill (`plugin/codex/housecarl/SKILL.md`); it had drifted to naming

--- a/src/housecarl-generator/BulkPrimitivesWave3Probe.cs
+++ b/src/housecarl-generator/BulkPrimitivesWave3Probe.cs
@@ -606,6 +606,17 @@ public static class BulkPrimitivesWave3Probe
         var rpfUntickedByName = svc.ReadPluginFile(Path.GetFileName(untickedPath), uwFid, null, null, null, 1, null, 10);
         Check("read_plugin_file: the same plugin BY FILENAME agrees — the lanes state one fact, not two",
               rpfUntickedByName.Error is null && !rpfUntickedByName.Enabled);
+        // The mod= lane is the third address form for one file, and it must answer identically. The shadow mod is
+        // ENABLED, so a lane testing only "is this mod switched on" would call its shadowed copy live.
+        var rpfModShadow = svc.ReadPluginFile(rKey.FileName.String, wFid, null, "DiffReplShadow", new[] { "BasicStats.Damage" }, 1, null, 10);
+        Check("read_plugin_file mod=: a shadowed copy in an ENABLED mod reports enabled=false, as the path lane does",
+              rpfModShadow.Error is null && !rpfModShadow.Enabled);
+        var rpfModServing = svc.ReadPluginFile(rKey.FileName.String, wFid, null, "DiffRepl", new[] { "BasicStats.Damage" }, 1, null, 10);
+        Check("read_plugin_file mod=: the SERVING mod's copy of the same name reports enabled=true",
+              rpfModServing.Error is null && rpfModServing.Enabled);
+        var rpfModUnticked = svc.ReadPluginFile(unKey.FileName.String, uwFid, null, "DiffUnticked", null, 1, null, 10);
+        Check("read_plugin_file mod=: the serving mod's copy of an UNTICKED plugin still reports enabled=false",
+              rpfModUnticked.Error is null && !rpfModUnticked.Enabled);
 
         // IDENTICAL — same plugin on both sides
         var dSame = svc.DiffRecord(wFid, replName, replName, null);

--- a/src/housecarl-generator/BulkPrimitivesWave3Probe.cs
+++ b/src/housecarl-generator/BulkPrimitivesWave3Probe.cs
@@ -502,6 +502,12 @@ public static class BulkPrimitivesWave3Probe
               && dOff.Diff!.Deltas.Any(x => x.Contains("77") && x.Contains("99")));
 
         // BY PATH (#269) — provenance is COMPUTED from the file, not assumed from how it was addressed.
+        // COVERAGE NOTE (Q3 — name the gap rather than imply completeness): the path-to-active routing also has to
+        // NOT capture a plugin EXCLUDED from the index (Mutagen can't parse it) — reading its file directly is the
+        // escape hatch, so it must stay on the off-order lane. That branch is uncovered here for the same reason
+        // forward-from-plugin-guard leaves it uncovered: synthesizing an unparseable plugin duplicates
+        // pkcu-regression's malformed-record machinery for one reject path. It is a plain ExcludedPlugins lookup on
+        // the same OrdinalIgnoreCase table the armed checks use; if it earns a test, model it on pkcu-regression.
         // (a) the ACTIVE plugin's own file, passed as a path: it IS what the order loads → active pole, never
         //     "OUT-OF-LOAD-ORDER … disabled". (b) the same-named archive backup: a different file → still off-order.
         var dPathActive = svc.DiffRecord(wFid, "DiffDonor.esp", replPath, new[] { "BasicStats.Damage" });
@@ -511,6 +517,13 @@ public static class BulkPrimitivesWave3Probe
         Check("diff: an active-by-path pole resolves back to its PLUGIN NAME, and still diffs (77 vs 99)",
               dPathActive.Error is null && dPathActive.B!.Plugin == replName
               && dPathActive.Diff!.Deltas.Any(x => x.Contains("77") && x.Contains("99")));
+
+        // (c) a DISABLED mod's copy, addressed by path: INSIDE an install root, but its mod is off. The flag has to
+        //     come from the located copy — "is it under a root at all" would call this one enabled.
+        var dPathDisabled = svc.DiffRecord(wFid, donorPath, replName, new[] { "BasicStats.Damage" });
+        Check("diff: a DISABLED mod's plugin addressed BY PATH stays OUT-OF-LOAD-ORDER and disabled",
+              dPathDisabled.Error is null && !dPathDisabled.A!.InOrder
+              && dPathDisabled.A.Where.Contains("OUT-OF-LOAD-ORDER") && dPathDisabled.A.Where.Contains("disabled"));
 
         var dPathArchive = svc.DiffRecord(wFid, archivePath, replPath, new[] { "BasicStats.Damage" });
         Check("diff: a same-named backup OUTSIDE the install stays OUT-OF-LOAD-ORDER (55 vs 99) — name never decides",

--- a/src/housecarl-generator/BulkPrimitivesWave3Probe.cs
+++ b/src/housecarl-generator/BulkPrimitivesWave3Probe.cs
@@ -464,6 +464,14 @@ public static class BulkPrimitivesWave3Probe
         ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(dmod, w)).BasicStats = new WeaponBasicStats { Damage = 77 };
         dmod.BeginWrite.ToPath(donorPath).WithLoadOrder(new ISkyrimModGetter[] { m }).Write();
 
+        // ARCHIVE backup: the SAME filename as the active replacer (55), parked OUTSIDE every MO2/game root — the
+        // old-version-vs-live diff (#269's reporter's actual job). Same name, different file: it must stay off-order.
+        var archivePath = Path.Combine(dir, "archive", rKey.FileName.String);
+        Directory.CreateDirectory(Path.GetDirectoryName(archivePath)!);
+        var amod = new SkyrimMod(rKey, SkyrimRelease.SkyrimSE);
+        ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(amod, w)).BasicStats = new WeaponBasicStats { Damage = 55 };
+        amod.BeginWrite.ToPath(archivePath).WithLoadOrder(new ISkyrimModGetter[] { m }).Write();
+
         File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + mKey.FileName + "\r\n" + rKey.FileName + "\r\n");
         File.WriteAllText(Path.Combine(profiles, "plugins.txt"), "*" + mKey.FileName + "\r\n*" + rKey.FileName + "\r\n");
         File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+DiffRepl\r\n+DiffMaster\r\n-DiffDonor\r\n");
@@ -492,6 +500,31 @@ public static class BulkPrimitivesWave3Probe
         Check("diff OFF-ORDER (disabled DiffDonor) vs repl: 77 vs 99, pole a OUT-OF-LOAD-ORDER",
               dOff.Error is null && !dOff.A!.InOrder && dOff.A.Where.Contains("OUT-OF-LOAD-ORDER")
               && dOff.Diff!.Deltas.Any(x => x.Contains("77") && x.Contains("99")));
+
+        // BY PATH (#269) — provenance is COMPUTED from the file, not assumed from how it was addressed.
+        // (a) the ACTIVE plugin's own file, passed as a path: it IS what the order loads → active pole, never
+        //     "OUT-OF-LOAD-ORDER … disabled". (b) the same-named archive backup: a different file → still off-order.
+        var dPathActive = svc.DiffRecord(wFid, "DiffDonor.esp", replPath, new[] { "BasicStats.Damage" });
+        Check("diff: the ACTIVE plugin passed BY PATH reports the active order (not OUT-OF-LOAD-ORDER/disabled)",
+              dPathActive.Error is null && dPathActive.B!.InOrder && dPathActive.B.Where == "active order"
+              && !dPathActive.B.Where.Contains("disabled"));
+        Check("diff: an active-by-path pole resolves back to its PLUGIN NAME, and still diffs (77 vs 99)",
+              dPathActive.Error is null && dPathActive.B!.Plugin == replName
+              && dPathActive.Diff!.Deltas.Any(x => x.Contains("77") && x.Contains("99")));
+
+        var dPathArchive = svc.DiffRecord(wFid, archivePath, replPath, new[] { "BasicStats.Damage" });
+        Check("diff: a same-named backup OUTSIDE the install stays OUT-OF-LOAD-ORDER (55 vs 99) — name never decides",
+              dPathArchive.Error is null && !dPathArchive.A!.InOrder && dPathArchive.A.Where.Contains("OUT-OF-LOAD-ORDER")
+              && dPathArchive.Diff!.Deltas.Any(x => x.Contains("55") && x.Contains("99")));
+
+        // The same computed provenance through read_plugin_file: the enabled plugin's file, addressed by path, is
+        // NOT flagged inactive (the second consumer of the shared locate's enabled flag — #269).
+        var rpfPath = svc.ReadPluginFile(replPath, wFid, null, null, new[] { "BasicStats.Damage" }, 1, null, 10);
+        Check("read_plugin_file: an ENABLED plugin addressed by path reports enabled=true (still OUT-OF-LOAD-ORDER by contract)",
+              rpfPath.Error is null && rpfPath.Where == "direct path" && rpfPath.Enabled);
+        var rpfArchive = svc.ReadPluginFile(archivePath, wFid, null, null, new[] { "BasicStats.Damage" }, 1, null, 10);
+        Check("read_plugin_file: the same-named backup outside the install reports enabled=false",
+              rpfArchive.Error is null && rpfArchive.Where == "direct path" && !rpfArchive.Enabled);
 
         // IDENTICAL — same plugin on both sides
         var dSame = svc.DiffRecord(wFid, replName, replName, null);

--- a/src/housecarl-generator/BulkPrimitivesWave3Probe.cs
+++ b/src/housecarl-generator/BulkPrimitivesWave3Probe.cs
@@ -488,6 +488,17 @@ public static class BulkPrimitivesWave3Probe
         Directory.CreateDirectory(Path.GetDirectoryName(decoyPath)!);
         File.Copy(dataServedPath, decoyPath, overwrite: true);
 
+        // UNTICKED plugin: sole copy, in an ENABLED mod folder, but listed in plugins.txt WITHOUT the `*`. MO2's left
+        // pane says yes, its right pane says no, and the game does not load it — the exact state a mod-folder-only
+        // flag reports backwards.
+        var unKey = new ModKey("HcW3Unticked", ModType.Plugin);
+        var untickedPath = Path.Combine(mods, "DiffUnticked", unKey.FileName.String);
+        Directory.CreateDirectory(Path.GetDirectoryName(untickedPath)!);
+        var unMod = new SkyrimMod(unKey, SkyrimRelease.SkyrimSE);
+        var uw = unMod.Weapons.AddNew(); uw.EditorID = "UntickedW"; uw.BasicStats = new WeaponBasicStats { Damage = 22 };
+        var uwFk = uw.FormKey;
+        unMod.BeginWrite.ToPath(untickedPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
         // ARCHIVE backup: the SAME filename as the active replacer (55), parked OUTSIDE every MO2/game root — the
         // old-version-vs-live diff (#269's reporter's actual job). Same name, different file: it must stay off-order.
         var archivePath = Path.Combine(dir, "archive", rKey.FileName.String);
@@ -496,9 +507,15 @@ public static class BulkPrimitivesWave3Probe
         ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(amod, w)).BasicStats = new WeaponBasicStats { Damage = 55 };
         amod.BeginWrite.ToPath(archivePath).WithLoadOrder(new ISkyrimModGetter[] { m }).Write();
 
-        File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + mKey.FileName + "\r\n" + rKey.FileName + "\r\n");
-        File.WriteAllText(Path.Combine(profiles, "plugins.txt"), "*" + mKey.FileName + "\r\n*" + rKey.FileName + "\r\n");
-        File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+DiffRepl\r\n+DiffReplShadow\r\n+DiffMaster\r\n-DiffDonor\r\n-DataServedDecoy\r\n");
+        // The Data-served plugin is CHECKED and in the order: its arm isolates WHICH COPY is served, so its tick state
+        // must not be the thing that decides it (leave it unticked and the tick gate answers first, and the
+        // served-copy rule goes untested).
+        File.WriteAllText(Path.Combine(profiles, "loadorder.txt"),
+            "# header\r\n" + mKey.FileName + "\r\n" + dsKey.FileName + "\r\n" + rKey.FileName + "\r\n");
+        // plugins.txt: master + Data-served + replacer CHECKED; HcW3Unticked listed WITHOUT the `*` (present but unchecked).
+        File.WriteAllText(Path.Combine(profiles, "plugins.txt"),
+            "*" + mKey.FileName + "\r\n*" + dsKey.FileName + "\r\n*" + rKey.FileName + "\r\n" + unKey.FileName + "\r\n");
+        File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+DiffRepl\r\n+DiffReplShadow\r\n+DiffMaster\r\n+DiffUnticked\r\n-DiffDonor\r\n-DataServedDecoy\r\n");
 
         var genDir = Path.Combine(dir, "corpus-gen");
         try { _ = CorpusRulebook.LoadCorpus(); }
@@ -580,6 +597,15 @@ public static class BulkPrimitivesWave3Probe
         var rpfDecoy = svc.ReadPluginFile(decoyPath, dswFid, null, null, new[] { "BasicStats.Damage" }, 1, null, 10);
         Check("read_plugin_file: that disabled copy itself reports enabled=false",
               rpfDecoy.Error is null && rpfDecoy.Where == "direct path" && !rpfDecoy.Enabled);
+        string uwFid = $"{uwFk.ID:X6}:{uwFk.ModKey.FileName}";
+        // UNTICKED: the served copy, in an ENABLED mod, but unchecked in plugins.txt — the game does not load it.
+        // The mod's switch and the plugin's tick are separate facts and the flag has to carry both (#271).
+        var rpfUnticked = svc.ReadPluginFile(untickedPath, uwFid, null, null, new[] { "BasicStats.Damage" }, 1, null, 10);
+        Check("read_plugin_file: a plugin in an ENABLED mod but UNTICKED in plugins.txt reports enabled=false",
+              rpfUnticked.Error is null && rpfUnticked.Where == "direct path" && !rpfUnticked.Enabled);
+        var rpfUntickedByName = svc.ReadPluginFile(Path.GetFileName(untickedPath), uwFid, null, null, null, 1, null, 10);
+        Check("read_plugin_file: the same plugin BY FILENAME agrees — the lanes state one fact, not two",
+              rpfUntickedByName.Error is null && !rpfUntickedByName.Enabled);
 
         // IDENTICAL — same plugin on both sides
         var dSame = svc.DiffRecord(wFid, replName, replName, null);

--- a/src/housecarl-generator/BulkPrimitivesWave3Probe.cs
+++ b/src/housecarl-generator/BulkPrimitivesWave3Probe.cs
@@ -473,6 +473,21 @@ public static class BulkPrimitivesWave3Probe
         ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(smod, w)).BasicStats = new WeaponBasicStats { Damage = 66 };
         smod.BeginWrite.ToPath(shadowPath).WithLoadOrder(new ISkyrimModGetter[] { m }).Write();
 
+        // DATA-SERVED plugin, with a DISABLED mod folder holding the same filename. The real order
+        // (Mo2LoadOrder.BuildFilenameMap) walks overwrite → enabled mods → game Data and never looks at disabled
+        // folders, so Data serves this file — but LocatePlugin DOES walk disabled folders and lists that copy FIRST.
+        // Judging against the first hit rather than the first ENABLED hit stamps this LIVE plugin inactive: #269's
+        // symptom again, reached from the other side. Deliberately in NO enabled mod, or Data would never serve it.
+        var dsKey = new ModKey("HcW3DataServed", ModType.Master);
+        var dataServedPath = Path.Combine(dir, "game", "Data", dsKey.FileName.String);
+        var dsMod = new SkyrimMod(dsKey, SkyrimRelease.SkyrimSE);
+        var dsw = dsMod.Weapons.AddNew(); dsw.EditorID = "DataServedW"; dsw.BasicStats = new WeaponBasicStats { Damage = 11 };
+        var dswFk = dsw.FormKey;
+        dsMod.BeginWrite.ToPath(dataServedPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+        var decoyPath = Path.Combine(mods, "DataServedDecoy", dsKey.FileName.String);
+        Directory.CreateDirectory(Path.GetDirectoryName(decoyPath)!);
+        File.Copy(dataServedPath, decoyPath, overwrite: true);
+
         // ARCHIVE backup: the SAME filename as the active replacer (55), parked OUTSIDE every MO2/game root — the
         // old-version-vs-live diff (#269's reporter's actual job). Same name, different file: it must stay off-order.
         var archivePath = Path.Combine(dir, "archive", rKey.FileName.String);
@@ -483,7 +498,7 @@ public static class BulkPrimitivesWave3Probe
 
         File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + mKey.FileName + "\r\n" + rKey.FileName + "\r\n");
         File.WriteAllText(Path.Combine(profiles, "plugins.txt"), "*" + mKey.FileName + "\r\n*" + rKey.FileName + "\r\n");
-        File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+DiffRepl\r\n+DiffReplShadow\r\n+DiffMaster\r\n-DiffDonor\r\n");
+        File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+DiffRepl\r\n+DiffReplShadow\r\n+DiffMaster\r\n-DiffDonor\r\n-DataServedDecoy\r\n");
 
         var genDir = Path.Combine(dir, "corpus-gen");
         try { _ = CorpusRulebook.LoadCorpus(); }
@@ -556,6 +571,15 @@ public static class BulkPrimitivesWave3Probe
               rpfShadow.Error is null && rpfShadow.Where == "direct path" && !rpfShadow.Enabled);
         Check("read_plugin_file: the shadowed copy still READS (66) — it is unreachable to the game, not to the tool",
               rpfShadow.Error is null && rpfShadow.Record is not null);
+        // The served copy is the first ENABLED-layer hit, not the first hit: a DISABLED folder holding the same
+        // filename is listed ahead of game Data, and must not decide the live plugin's provenance.
+        string dswFid = $"{dswFk.ID:X6}:{dswFk.ModKey.FileName}";
+        var rpfData = svc.ReadPluginFile(dataServedPath, dswFid, null, null, new[] { "BasicStats.Damage" }, 1, null, 10);
+        Check("read_plugin_file: a game-Data-served plugin listed BEHIND a disabled copy still reports enabled=true",
+              rpfData.Error is null && rpfData.Where == "direct path" && rpfData.Enabled);
+        var rpfDecoy = svc.ReadPluginFile(decoyPath, dswFid, null, null, new[] { "BasicStats.Damage" }, 1, null, 10);
+        Check("read_plugin_file: that disabled copy itself reports enabled=false",
+              rpfDecoy.Error is null && rpfDecoy.Where == "direct path" && !rpfDecoy.Enabled);
 
         // IDENTICAL — same plugin on both sides
         var dSame = svc.DiffRecord(wFid, replName, replName, null);

--- a/src/housecarl-generator/BulkPrimitivesWave3Probe.cs
+++ b/src/housecarl-generator/BulkPrimitivesWave3Probe.cs
@@ -464,6 +464,15 @@ public static class BulkPrimitivesWave3Probe
         ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(dmod, w)).BasicStats = new WeaponBasicStats { Damage = 77 };
         dmod.BeginWrite.ToPath(donorPath).WithLoadOrder(new ISkyrimModGetter[] { m }).Write();
 
+        // SHADOWED copy: the same filename in a LOWER-priority ENABLED mod (66). Its folder is enabled, but a
+        // higher-priority folder provides the name, so the game never loads THIS file — "the mod is enabled" and
+        // "this file is what loads" are different questions, and only the second one is honest to report.
+        var shadowPath = Path.Combine(mods, "DiffReplShadow", rKey.FileName.String);
+        Directory.CreateDirectory(Path.GetDirectoryName(shadowPath)!);
+        var smod = new SkyrimMod(rKey, SkyrimRelease.SkyrimSE);
+        ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(smod, w)).BasicStats = new WeaponBasicStats { Damage = 66 };
+        smod.BeginWrite.ToPath(shadowPath).WithLoadOrder(new ISkyrimModGetter[] { m }).Write();
+
         // ARCHIVE backup: the SAME filename as the active replacer (55), parked OUTSIDE every MO2/game root — the
         // old-version-vs-live diff (#269's reporter's actual job). Same name, different file: it must stay off-order.
         var archivePath = Path.Combine(dir, "archive", rKey.FileName.String);
@@ -474,7 +483,7 @@ public static class BulkPrimitivesWave3Probe
 
         File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + mKey.FileName + "\r\n" + rKey.FileName + "\r\n");
         File.WriteAllText(Path.Combine(profiles, "plugins.txt"), "*" + mKey.FileName + "\r\n*" + rKey.FileName + "\r\n");
-        File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+DiffRepl\r\n+DiffMaster\r\n-DiffDonor\r\n");
+        File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+DiffRepl\r\n+DiffReplShadow\r\n+DiffMaster\r\n-DiffDonor\r\n");
 
         var genDir = Path.Combine(dir, "corpus-gen");
         try { _ = CorpusRulebook.LoadCorpus(); }
@@ -504,16 +513,17 @@ public static class BulkPrimitivesWave3Probe
         // BY PATH (#269) — provenance is COMPUTED from the file, not assumed from how it was addressed.
         // COVERAGE NOTE (Q3 — name the gap rather than imply completeness): the path-to-active routing also has to
         // NOT capture a plugin EXCLUDED from the index (Mutagen can't parse it) — reading its file directly is the
-        // escape hatch, so it must stay on the off-order lane. That branch is uncovered here for the same reason
-        // forward-from-plugin-guard leaves it uncovered: synthesizing an unparseable plugin duplicates
-        // pkcu-regression's malformed-record machinery for one reject path. It is a plain ExcludedPlugins lookup on
-        // the same OrdinalIgnoreCase table the armed checks use; if it earns a test, model it on pkcu-regression.
+        // escape hatch, so it must stay on the off-order lane. That branch is uncovered HERE — not because a
+        // malformed plugin is expensive to synthesize (it isn't), but because arming it means putting an
+        // index-excluded plugin into THIS fixture's active order, which perturbs every other arm above that reads
+        // through the same view. It is a plain ExcludedPlugins lookup on the same OrdinalIgnoreCase table the armed
+        // checks use; if it earns a test it wants its own fixture, modelled on pkcu-regression's malformed plugin
+        // (forward-from-plugin-guard leaves the same branch unarmed and records the same lookup rationale).
         // (a) the ACTIVE plugin's own file, passed as a path: it IS what the order loads → active pole, never
         //     "OUT-OF-LOAD-ORDER … disabled". (b) the same-named archive backup: a different file → still off-order.
         var dPathActive = svc.DiffRecord(wFid, "DiffDonor.esp", replPath, new[] { "BasicStats.Damage" });
         Check("diff: the ACTIVE plugin passed BY PATH reports the active order (not OUT-OF-LOAD-ORDER/disabled)",
-              dPathActive.Error is null && dPathActive.B!.InOrder && dPathActive.B.Where == "active order"
-              && !dPathActive.B.Where.Contains("disabled"));
+              dPathActive.Error is null && dPathActive.B!.InOrder && dPathActive.B.Where == "active order");
         Check("diff: an active-by-path pole resolves back to its PLUGIN NAME, and still diffs (77 vs 99)",
               dPathActive.Error is null && dPathActive.B!.Plugin == replName
               && dPathActive.Diff!.Deltas.Any(x => x.Contains("77") && x.Contains("99")));
@@ -538,6 +548,14 @@ public static class BulkPrimitivesWave3Probe
         var rpfArchive = svc.ReadPluginFile(archivePath, wFid, null, null, new[] { "BasicStats.Damage" }, 1, null, 10);
         Check("read_plugin_file: the same-named backup outside the install reports enabled=false",
               rpfArchive.Error is null && rpfArchive.Where == "direct path" && !rpfArchive.Enabled);
+        // The flag tracks WHICH COPY the install provides, not merely "is this folder enabled" — a shadowed copy in
+        // a lower-priority ENABLED mod is not what loads, and reporting it enabled would be worse than the pre-#269
+        // hardcoded false (which was accidentally right here).
+        var rpfShadow = svc.ReadPluginFile(shadowPath, wFid, null, null, new[] { "BasicStats.Damage" }, 1, null, 10);
+        Check("read_plugin_file: a SHADOWED copy in a lower-priority enabled mod reports enabled=false",
+              rpfShadow.Error is null && rpfShadow.Where == "direct path" && !rpfShadow.Enabled);
+        Check("read_plugin_file: the shadowed copy still READS (66) — it is unreachable to the game, not to the tool",
+              rpfShadow.Error is null && rpfShadow.Record is not null);
 
         // IDENTICAL — same plugin on both sides
         var dSame = svc.DiffRecord(wFid, replName, replName, null);

--- a/src/housecarl-generator/ReadPluginFileProbe.cs
+++ b/src/housecarl-generator/ReadPluginFileProbe.cs
@@ -19,6 +19,9 @@ namespace HousecarlGenerator;
 ///   4  a DIRECT PATH read ("inspect any file")
 ///   5  the render stamps OUT-OF-LOAD-ORDER (the single load-bearing requirement) + read_record's `path = token` format
 ///   6  the declared-master-not-installed advisory (Q3)
+///      (the ENABLED-flag arms for a DIRECT PATH — an enabled plugin's own file must not read as inactive, a
+///       same-named backup outside the install must — live in bulk-primitives-wave3-guard's diff arm, which is
+///       where the fixture with a real active order + an out-of-install backup already exists; #269)
 ///   7  Q3 refusals: missing filename, bad FormID, a FormID the file doesn't define, formid=+type= together, and an
 ///      AMBIGUOUS filename (surfaced + mod= disambiguates, never guessed)
 ///

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2200,7 +2200,10 @@ public sealed class LoadOrderService : IDisposable
         var b = ResolveDiffPole(view, session, fk, pluginB.Trim(), modB, fields);
         if (b.Error is not null) return DiffRecordOutcome.Fail(fidLabel, $"plugin_b: {b.Error}");
 
-        var diff = FieldsDiff.Compare(a.Fields!, b.Fields!, referenceLabel: pluginB.Trim());
+        // Label the reference side with what the pole RESOLVED to, not the raw argument — a pole addressed by path
+        // renders its plugin name in the header, and delta lines quoting the path back would read as a second,
+        // different plugin.
+        var diff = FieldsDiff.Compare(a.Fields!, b.Fields!, referenceLabel: b.Pole!.Plugin);
         return new DiffRecordOutcome(fidLabel, a.Pole!, b.Pole!, diff, null);
     }
 
@@ -2265,6 +2268,11 @@ public sealed class LoadOrderService : IDisposable
         try { full = Path.GetFullPath(path.Trim()); } catch { return null; }
         var name = Path.GetFileName(full);
         if (name.Length == 0 || !view.ContainsPlugin(name)) return null;
+        // An EXCLUDED plugin is still in the name table (exclusion is a separate set), and the active lane can only
+        // refuse it. Reading its file DIRECTLY is the escape hatch for exactly that case — records ahead of the
+        // unparseable one still come back — so a path to one must keep taking the off-order lane, not get routed
+        // into a refusal it was addressed by path to avoid.
+        if (view.ExcludedPlugins.ContainsKey(name)) return null;
         var active = view.PluginPath(name);
         return !string.IsNullOrEmpty(active) && SamePluginFile(active, full) ? name : null;
     }
@@ -5292,7 +5300,11 @@ public sealed class LoadOrderService : IDisposable
             // and a hardcoded `false` here stamped that copy "disabled" (#269). The answer comes from the SAME
             // enumerator the filename lane below uses, so the two lanes can never disagree about one file: if a
             // located copy of this filename IS this exact file, that hit's enabled-ness is this file's. Compared by
-            // FULL PATH — an archived backup and the live copy share a filename and are different files.
+            // FULL PATH — an archived backup and the live copy share a filename and are different files. Two costs
+            // accepted: this pays the same folder sweep the filename lane does (one stat per candidate folder), which
+            // is why a path no install root contains skips it outright; and a path reaching the install through a
+            // junction/symlink won't string-match, so it stays flagged not-enabled — the pre-fix answer, conservative
+            // in the same direction rather than newly wrong in the other.
             var self = IsUnderAnyInstallRoot(full, modsDir, dataDir, overwriteDir)   // outside every root ⇒ can't be the install's copy; skip the scan
                 ? Mo2LoadOrder.LocatePlugin(comp, modsDir, dataDir, overwriteDir, Path.GetFileName(full))
                               .FirstOrDefault(h => SamePluginFile(h.Path, full))

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2213,6 +2213,12 @@ public sealed class LoadOrderService : IDisposable
         LoadOrderResolver.IndexView view, LoadOrderResolver.OverlaySession session, FormKey fk,
         string plugin, string? mod, IReadOnlyList<string>? fields)
     {
+        // A pole may be addressed by PATH. Routing on the name table alone can't recognise the active plugin that
+        // way — a path never matches a filename key, so the live, load-order-winning copy fell through to the
+        // off-order branch and got stamped OUT-OF-LOAD-ORDER (#269). Resolve a path that IS the file the order
+        // loads back to its plugin NAME first; everything else still takes the off-order lane below.
+        if (LooksLikePath(plugin) && ActiveNameForPath(view, plugin) is { } activeName) plugin = activeName;
+
         if (view.ContainsPlugin(plugin))
         {
             if (view.ExcludedPlugins.TryGetValue(plugin, out var why))
@@ -2247,6 +2253,20 @@ public sealed class LoadOrderService : IDisposable
                                  RecordNaming.StripOverlay(rec.GetType().Name), rec.EditorID), null);
         }
         finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    /// <summary>If <paramref name="path"/> is the EXACT file the active order loads for its filename, the plugin name
+    /// the order knows it by; else null. The full-path compare is the whole point: a backup that shares the filename
+    /// is a different file and must keep reading as off-order (that same-name/different-file pair is the ordinary
+    /// old-version-vs-live diff). Costs nothing — the index already carries each active plugin's path.</summary>
+    static string? ActiveNameForPath(LoadOrderResolver.IndexView view, string path)
+    {
+        string full;
+        try { full = Path.GetFullPath(path.Trim()); } catch { return null; }
+        var name = Path.GetFileName(full);
+        if (name.Length == 0 || !view.ContainsPlugin(name)) return null;
+        var active = view.PluginPath(name);
+        return !string.IsNullOrEmpty(active) && SamePluginFile(active, full) ? name : null;
     }
 
     /// <summary>One side of a housecarl_diff_record comparison: the plugin named, WHERE its version was found (active
@@ -5266,7 +5286,18 @@ public sealed class LoadOrderService : IDisposable
         if (LooksLikePath(plugin))
         {
             if (!File.Exists(plugin)) return new(null, "", false, null, $"no file at path '{plugin}'.");
-            return new(Path.GetFullPath(plugin), "direct path", false, null, null);
+            var full = Path.GetFullPath(plugin);
+            // Enabled is COMPUTED for a direct path, never assumed. Addressing a file BY PATH says nothing about
+            // whether the install provides it — a path can perfectly well name the live copy of an enabled plugin,
+            // and a hardcoded `false` here stamped that copy "disabled" (#269). The answer comes from the SAME
+            // enumerator the filename lane below uses, so the two lanes can never disagree about one file: if a
+            // located copy of this filename IS this exact file, that hit's enabled-ness is this file's. Compared by
+            // FULL PATH — an archived backup and the live copy share a filename and are different files.
+            var self = IsUnderAnyInstallRoot(full, modsDir, dataDir, overwriteDir)   // outside every root ⇒ can't be the install's copy; skip the scan
+                ? Mo2LoadOrder.LocatePlugin(comp, modsDir, dataDir, overwriteDir, Path.GetFileName(full))
+                              .FirstOrDefault(h => SamePluginFile(h.Path, full))
+                : null;
+            return new(full, "direct path", self?.Enabled ?? false, null, null);
         }
         if (!string.IsNullOrWhiteSpace(mod))
         {
@@ -5287,6 +5318,33 @@ public sealed class LoadOrderService : IDisposable
     /// than a bare filename (locate in the MO2 folders)? True if rooted or carrying a directory separator: 'C:\..\X.esp'
     /// or 'mods\M\X.esp' is a path; a bare 'X.esp' is a filename.</summary>
     static bool LooksLikePath(string s) => Path.IsPathRooted(s) || s.Contains('\\') || s.Contains('/');
+
+    /// <summary>Do two paths denote the SAME plugin file? A FULL-PATH compare (case-insensitive, as Windows paths
+    /// are) — never a filename compare: an archived backup and the live copy share a name and are different files,
+    /// which is exactly the distinction a provenance label gets wrong when it guesses.</summary>
+    static bool SamePluginFile(string a, string b)
+    {
+        try { return string.Equals(Path.GetFullPath(a), Path.GetFullPath(b), StringComparison.OrdinalIgnoreCase); }
+        catch { return false; }
+    }
+
+    /// <summary>Is <paramref name="fullPath"/> inside any MO2/game root? Used ONLY to skip work — a file outside
+    /// every root cannot be a copy the install provides — so the enabled/disabled CLASSIFICATION itself stays with
+    /// the one shared locate, never re-derived here.</summary>
+    static bool IsUnderAnyInstallRoot(string fullPath, params string[] roots)
+    {
+        foreach (var root in roots)
+        {
+            if (string.IsNullOrWhiteSpace(root)) continue;
+            try
+            {
+                var r = Path.GetFullPath(root).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                if (fullPath.StartsWith(r + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)) return true;
+            }
+            catch { /* an unparseable root simply isn't a match — never a false 'inside' (Q3) */ }
+        }
+        return false;
+    }
 
     // ---- corpus-backed type resolution (signature "WEAP" / catalog name "Weapon" → getter Type(s)) -------
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -5293,6 +5293,16 @@ public sealed class LoadOrderService : IDisposable
     internal static PluginLocateResult LocatePluginFileOnDisk(
         Mo2Composition comp, string modsDir, string dataDir, string overwriteDir, string plugin, string? mod)
     {
+        // A plugin's TICK state is a DIFFERENT fact from its mod folder's switch: a plugin can sit in an enabled mod
+        // and be unchecked in MO2's right pane, and the game then does not load it. Every lane below returns a flag
+        // the renderers state as "active" / "NOT active", so the flag has to mean "the game loads THIS file" — which
+        // needs both halves: the file is the copy the install serves, AND the plugin is ticked. Implicit base/CC
+        // masters are force-loaded and never listed in plugins.txt, so they count as ticked. This is the same test
+        // read_plugin_file already applies to a file's declared MASTERS, now applied to the file itself (#271).
+        bool Ticked(string fileName) =>
+            comp.ActivePluginNames.Contains(fileName)
+            || comp.ImplicitPluginNames.Any(x => x.Equals(fileName, StringComparison.OrdinalIgnoreCase));
+
         if (LooksLikePath(plugin))
         {
             if (!File.Exists(plugin)) return new(null, "", false, null, $"no file at path '{plugin}'.");
@@ -5317,21 +5327,23 @@ public sealed class LoadOrderService : IDisposable
                 ? Mo2LoadOrder.LocatePlugin(comp, modsDir, dataDir, overwriteDir, Path.GetFileName(full))
                 : Array.Empty<PluginFileHit>();
             var served = located.FirstOrDefault(h => h.Enabled);
-            return new(full, "direct path", served is not null && SamePluginFile(served.Path, full), null, null);
+            bool isServedCopy = served is not null && SamePluginFile(served.Path, full);
+            return new(full, "direct path", isServedCopy && Ticked(Path.GetFileName(full)), null, null);
         }
         if (!string.IsNullOrWhiteSpace(mod))
         {
             var fn = Path.GetFileName(plugin);
             var cand = Path.Combine(modsDir, mod.Trim(), fn);
             if (!File.Exists(cand)) return new(null, "", false, null, $"mod folder '{mod.Trim()}' under ModsDir does not provide '{fn}'.");
-            return new(cand, $"mod '{mod.Trim()}'", comp.EnabledMods.Contains(mod.Trim(), StringComparer.OrdinalIgnoreCase), null, null);
+            return new(cand, $"mod '{mod.Trim()}'",
+                       comp.EnabledMods.Contains(mod.Trim(), StringComparer.OrdinalIgnoreCase) && Ticked(fn), null, null);
         }
         var hits = Mo2LoadOrder.LocatePlugin(comp, modsDir, dataDir, overwriteDir, plugin);
         if (hits.Count == 0)
             return new(null, "", false, null,
                 $"'{Path.GetFileName(plugin)}' is in no mod folder (enabled, disabled, or not-yet-listed in MO2), the overwrite folder, or the game Data folder. Check the filename, pass an absolute path, or (if it's an MO2 mod) the exact folder via mod=.");
         if (hits.Count > 1) return new(null, "", false, hits, null);
-        return new(hits[0].Path, hits[0].Where, hits[0].Enabled, null, null);
+        return new(hits[0].Path, hits[0].Where, hits[0].Enabled && Ticked(Path.GetFileName(plugin)), null, null);
     }
 
     /// <summary>Does the user's `plugin` argument denote a PATH (use verbatim — the "inspect any file" case) rather

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -5300,10 +5300,14 @@ public sealed class LoadOrderService : IDisposable
             // Enabled is COMPUTED for a direct path, never assumed. Addressing a file BY PATH says nothing about
             // whether the install provides it — a path can perfectly well name the live copy of an enabled plugin,
             // and a hardcoded `false` here stamped that copy "disabled" (#269). The question the flag answers is
-            // "is THIS file the copy the install provides for this filename?", so it is judged against the SAME
-            // priority-ordered winner (hits[0]) the filename lane below returns — the two lanes then agree about one
-            // file by construction. Matching ANY hit would not do: a copy sitting in a lower-priority enabled mod is
-            // shadowed, so its folder being enabled says nothing about whether the game loads THAT file. Compared by
+            // "is THIS file the copy the install SERVES for this filename?", so it is judged against the first hit
+            // from an ENABLED layer — precisely the rule Mo2LoadOrder.BuildFilenameMap uses to build the real order
+            // (overwrite → enabled mods by priority → game Data). NOT merely the first hit: LocatePlugin also walks
+            // disabled and unlisted folders, which the order never consults, so a vanilla plugin served from Data
+            // while some DISABLED mod happens to hold the same filename would judge itself against that disabled
+            // copy and stamp the LIVE plugin inactive — #269's own symptom, reintroduced. Nor any matching hit: a
+            // copy in a LOWER-priority enabled mod is shadowed, and its folder being enabled says nothing about
+            // whether the game loads THAT file. Compared by
             // FULL PATH — an archived backup and the live copy share a filename and are different files. Two costs
             // accepted: this pays the same folder sweep the filename lane does (one stat per candidate folder), which
             // is why a path no install root contains skips it outright; and a path reaching the install through a
@@ -5312,8 +5316,8 @@ public sealed class LoadOrderService : IDisposable
             var located = IsUnderAnyInstallRoot(full, modsDir, dataDir, overwriteDir)   // outside every root ⇒ can't be the install's copy; skip the scan
                 ? Mo2LoadOrder.LocatePlugin(comp, modsDir, dataDir, overwriteDir, Path.GetFileName(full))
                 : Array.Empty<PluginFileHit>();
-            bool providesThisFile = located.Count > 0 && SamePluginFile(located[0].Path, full);
-            return new(full, "direct path", providesThisFile && located[0].Enabled, null, null);
+            var served = located.FirstOrDefault(h => h.Enabled);
+            return new(full, "direct path", served is not null && SamePluginFile(served.Path, full), null, null);
         }
         if (!string.IsNullOrWhiteSpace(mod))
         {

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -5335,8 +5335,14 @@ public sealed class LoadOrderService : IDisposable
             var fn = Path.GetFileName(plugin);
             var cand = Path.Combine(modsDir, mod.Trim(), fn);
             if (!File.Exists(cand)) return new(null, "", false, null, $"mod folder '{mod.Trim()}' under ModsDir does not provide '{fn}'.");
-            return new(cand, $"mod '{mod.Trim()}'",
-                       comp.EnabledMods.Contains(mod.Trim(), StringComparer.OrdinalIgnoreCase) && Ticked(fn), null, null);
+            // Both halves here too, or the same physical file answers differently depending on how it was addressed.
+            // "The named mod is enabled" is NOT enough: a lower-priority enabled mod's copy is shadowed, and the game
+            // loads the serving copy instead. Being the served hit subsumes the enabled-folder test — the served hit
+            // is by definition drawn from an enabled layer.
+            var servedForName = Mo2LoadOrder.LocatePlugin(comp, modsDir, dataDir, overwriteDir, fn)
+                                            .FirstOrDefault(h => h.Enabled);
+            bool candIsLive = servedForName is not null && SamePluginFile(servedForName.Path, cand) && Ticked(fn);
+            return new(cand, $"mod '{mod.Trim()}'", candIsLive, null, null);
         }
         var hits = Mo2LoadOrder.LocatePlugin(comp, modsDir, dataDir, overwriteDir, plugin);
         if (hits.Count == 0)

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2261,7 +2261,9 @@ public sealed class LoadOrderService : IDisposable
     /// <summary>If <paramref name="path"/> is the EXACT file the active order loads for its filename, the plugin name
     /// the order knows it by; else null. The full-path compare is the whole point: a backup that shares the filename
     /// is a different file and must keep reading as off-order (that same-name/different-file pair is the ordinary
-    /// old-version-vs-live diff). Costs nothing — the index already carries each active plugin's path.</summary>
+    /// old-version-vs-live diff). Costs nothing — the index already carries each active plugin's path. Same junction
+    /// caveat as the on-disk locate: a path reaching the file through a junction won't string-match, so it keeps the
+    /// off-order lane — the pre-fix answer, never a wrong claim in the other direction.</summary>
     static string? ActiveNameForPath(LoadOrderResolver.IndexView view, string path)
     {
         string full;
@@ -5297,19 +5299,21 @@ public sealed class LoadOrderService : IDisposable
             var full = Path.GetFullPath(plugin);
             // Enabled is COMPUTED for a direct path, never assumed. Addressing a file BY PATH says nothing about
             // whether the install provides it — a path can perfectly well name the live copy of an enabled plugin,
-            // and a hardcoded `false` here stamped that copy "disabled" (#269). The answer comes from the SAME
-            // enumerator the filename lane below uses, so the two lanes can never disagree about one file: if a
-            // located copy of this filename IS this exact file, that hit's enabled-ness is this file's. Compared by
+            // and a hardcoded `false` here stamped that copy "disabled" (#269). The question the flag answers is
+            // "is THIS file the copy the install provides for this filename?", so it is judged against the SAME
+            // priority-ordered winner (hits[0]) the filename lane below returns — the two lanes then agree about one
+            // file by construction. Matching ANY hit would not do: a copy sitting in a lower-priority enabled mod is
+            // shadowed, so its folder being enabled says nothing about whether the game loads THAT file. Compared by
             // FULL PATH — an archived backup and the live copy share a filename and are different files. Two costs
             // accepted: this pays the same folder sweep the filename lane does (one stat per candidate folder), which
             // is why a path no install root contains skips it outright; and a path reaching the install through a
             // junction/symlink won't string-match, so it stays flagged not-enabled — the pre-fix answer, conservative
             // in the same direction rather than newly wrong in the other.
-            var self = IsUnderAnyInstallRoot(full, modsDir, dataDir, overwriteDir)   // outside every root ⇒ can't be the install's copy; skip the scan
+            var located = IsUnderAnyInstallRoot(full, modsDir, dataDir, overwriteDir)   // outside every root ⇒ can't be the install's copy; skip the scan
                 ? Mo2LoadOrder.LocatePlugin(comp, modsDir, dataDir, overwriteDir, Path.GetFileName(full))
-                              .FirstOrDefault(h => SamePluginFile(h.Path, full))
-                : null;
-            return new(full, "direct path", self?.Enabled ?? false, null, null);
+                : Array.Empty<PluginFileHit>();
+            bool providesThisFile = located.Count > 0 && SamePluginFile(located[0].Path, full);
+            return new(full, "direct path", providesThisFile && located[0].Enabled, null, null);
         }
         if (!string.IsNullOrWhiteSpace(mod))
         {


### PR DESCRIPTION
Fixes #269

A plugin addressed by its absolute path was labeled `OUT-OF-LOAD-ORDER (direct path, disabled)` even when it was the enabled, load-order-winning copy the game actually loads. The diff *values* were correct; only the provenance line lied — in the one direction that matters, since it said the live file wasn't live.

*Six commits: the original fix, then fixes for each of four independent reviews. This description is rewritten against the branch as it now stands.*

### Root cause

Two independent contributions, both in the direct-path lane:

1. `LocatePluginFileOnDisk` returned `Enabled: false` as a constant for every direct path. The filename and `mod=` lanes beside it at least attempted an answer — the path lane was the one branch the shared locate never answered at all. (Its own doc comment records that this contract was unified *because* an inline copy had diverged on exactly this flag.)
2. `ResolveDiffPole` routed poles through `view.ContainsPlugin` — a plugin-NAME lookup a path can never match — so the live plugin fell through to the off-order branch before its label was even composed.

### What the flag now means

The flag a located plugin carries — rendered by `read_plugin_file` as `NOT active` and by `diff_record` as `disabled` — means one thing in all three address lanes (path, `mod=`, filename): **the game loads this file.** That needs two halves, and each was wrong somewhere before:

- **This is the served copy.** Judged by full path against the copy the install actually serves — the first hit from an *enabled layer*, which is exactly the rule `Mo2LoadOrder.BuildFilenameMap` uses to build the real order. Three distinct failures fixed: an archived backup sharing a filename stays `OUT-OF-LOAD-ORDER` (the old-version-vs-live diff is unchanged); a copy shadowed by a higher-priority mod is not called live merely because its own mod is enabled; and a plugin served from game `Data` is not called inactive merely because a *disabled* mod holds the same filename (`LocatePlugin` lists disabled and unlisted folders that the real order never consults).
- **The plugin is ticked.** A plugin in an enabled mod but unchecked in MO2's right pane is not reported as active — the game does not load it. Implicit base/CC masters, force-loaded and never listed in `plugins.txt`, count as active. This is the same test `read_plugin_file` already applied to a file's declared *masters*, now applied to the file itself.

### Other changes

- `ResolveDiffPole` resolves a path that IS the file the order loads back to its plugin name, then takes the active branch. An **excluded** plugin (one Mutagen cannot parse) is deliberately *not* captured: reading its file directly is the escape hatch that addressing by path exists to provide, so it stays on the off-order lane.
- `FieldsDiff` labels the reference side from the resolved pole, so a by-path pole no longer prints its plugin name in the header and its full path in every delta line.

### Behaviour change beyond #269's symptom

The tick half and the served-copy half both change answers the `mod=` and filename lanes previously gave, so this is **not** a pure bug fix confined to direct paths. In particular `copy_npc_appearance`'s donor line renders this flag for those two lanes, so its `, DISABLED` suffix now appears for an unticked or shadowed donor where it previously did not. (Its *direct-path* arm renders `direct path '<path>'` and never reaches that suffix, so that arm is unaffected — an earlier revision of this description overstated the exemption to the whole tool.)

`read_plugin_file`'s `OUT-OF-LOAD-ORDER` banner is unchanged and still stamps every read — note its *"the game does not load this file"* wording is inaccurate when the file passed IS the live plugin. That wording, the `[mod 'X' (enabled); NOT active]` pairing (folder state and file state in one line), and whether this flag should become two fields are all tracked in **#271**, which is scoped to take that whole class in one PR.

### Guard

Twelve new arms on the wave3 diff probe (**56/56**), across every address form: the active-by-path pole and its resolution to a plugin name; a disabled-mod copy; a shadowed copy in a lower-priority *enabled* mod; a game-`Data`-served plugin listed behind a disabled copy; an out-of-install backup; an unticked plugin by path, by filename, and by `mod=`; and the `mod=` lane's shadowed and serving copies.

Every positive arm was verified to fail against the implementation it guards — the original constant, `IsUnderAnyInstallRoot`, the any-hit lookup, `hits[0]`, and the enabled-folder test respectively. The excluded-plugin branch is verified by hand but deliberately unarmed: putting an index-excluded plugin into this fixture's active order perturbs every other arm reading through the same view, so it wants its own fixture. That is recorded as a COVERAGE NOTE in the probe.

### Checks

- `ci-all` — **106/106**
- Build clean; warning census identical to `main`

**Not empirically confirmed on a live load order.** The reporting user's order is not available here, so that confirmation is deferred to release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
