### PR TITLE
fix(provenance): say WHY a plugin is not active, everywhere it comes up

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -48,9 +48,11 @@ every time. Two things changed:
 - **Refusals explain themselves.** A tool that reads *through* the load order still refuses on a plugin the game does
   not load — that guard is the point — but instead of a flat "not in the load order", it now says the plugin is
   installed and unticked (or that its mod is off), and points at `read_plugin_file` for a raw read. This covers
-  `read_record`, `check_errors`, `validate_scripts`, `merge_plugins`, every in-place write target, and the
-  `CopyFrom`/forward source checks. A genuine typo still gets its "did you mean" — the explanation replaces the
-  spelling guess only when there is a real cause to state.
+  `read_record`, `check_errors`, `validate_scripts`, `merge_plugins`, every in-place write target, and the forward
+  source check. A genuine typo still gets its "did you mean" — the explanation replaces the spelling guess only when
+  there is a real cause to state. The four not-loaded causes each carry their own remedy, and the two that look
+  alike from outside — a mod switched **off** versus a folder MO2 has **never registered** (where there is nothing
+  to switch on) — are told apart from MO2's own mod list rather than guessed.
 
 **The `read_plugin_file` banner no longer overclaims.** It read `OUT-OF-LOAD-ORDER (raw file read; the game does not
 load this file)` — true of the read, false about the file whenever the one you passed IS the live plugin. It now reads

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -55,7 +55,8 @@ every time. Two things changed:
 **The `read_plugin_file` banner no longer overclaims.** It read `OUT-OF-LOAD-ORDER (raw file read; the game does not
 load this file)` — true of the read, false about the file whenever the one you passed IS the live plugin. It now reads
 `(raw file read — not resolved through the load order)`, which holds in every case; what the game does with the file
-is stated separately, per file, with its reason.
+is stated separately, per file, with its reason. The same sentence is gone from `read_plugin_file`'s own tool
+description and from `copy_npc_appearance`'s donor line, where it was asserted even for a donor the game does load.
 
 **The Codex umbrella router now covers the whole tool surface, and a CI guard keeps it that way (Codex parity).**
 The Codex packaging ships one umbrella routing skill (`plugin/codex/housecarl/SKILL.md`); it had drifted to naming

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -30,9 +30,32 @@ now means one thing in every lane: **the game loads this file**. That needs both
   `plugins.txt`, still count as active. This half applies to the filename and `mod=` lanes too, so all three now
   state the same fact.
 
-`read_plugin_file`'s `OUT-OF-LOAD-ORDER` banner is unchanged and still stamps every read — note its "the game does not
-load this file" wording is inaccurate when the file you passed IS the live plugin; that wording, and whether this flag
-should split into two, are tracked in #271. Reported by a houseCARL user.
+Reported by a houseCARL user. (The banner wording and the one-flag-many-causes question this left open are resolved by
+the next entry.)
+
+**Every "not active" now says WHY, and so does every refusal that turns one away (#271).**
+`NOT active` / `disabled` named the state but never the cause — and the causes have different fixes: the plugin is
+unticked in `plugins.txt`, its mod is switched off, a higher-priority mod shadows this copy, or MO2 has not registered
+it. Reading `[mod 'X' (enabled); NOT active]`, you could not tell which, so the answer had to be rediscovered by hand
+every time. Two things changed:
+
+- **The located-plugin flag became two facts** — *is this the copy the install serves* and *is this plugin ticked* —
+  carried separately so each renderer can explain rather than classify. `read_plugin_file`, `diff_record`'s off-order
+  pole, and `copy_npc_appearance`'s donor line now state the cause, from one shared composer so they cannot drift
+  apart; the JSON lane gains a `why_not_active` field beside `enabled`. A file the game *does* load now says so
+  positively instead of saying nothing. Vocabulary is consistent throughout: a **mod** is enabled/disabled, a
+  **plugin** is active/inactive — `diff_record` no longer calls an unticked plugin "disabled".
+- **Refusals explain themselves.** A tool that reads *through* the load order still refuses on a plugin the game does
+  not load — that guard is the point — but instead of a flat "not in the load order", it now says the plugin is
+  installed and unticked (or that its mod is off), and points at `read_plugin_file` for a raw read. This covers
+  `read_record`, `check_errors`, `validate_scripts`, `merge_plugins`, every in-place write target, and the
+  `CopyFrom`/forward source checks. A genuine typo still gets its "did you mean" — the explanation replaces the
+  spelling guess only when there is a real cause to state.
+
+**The `read_plugin_file` banner no longer overclaims.** It read `OUT-OF-LOAD-ORDER (raw file read; the game does not
+load this file)` — true of the read, false about the file whenever the one you passed IS the live plugin. It now reads
+`(raw file read — not resolved through the load order)`, which holds in every case; what the game does with the file
+is stated separately, per file, with its reason.
 
 **The Codex umbrella router now covers the whole tool surface, and a CI guard keeps it that way (Codex parity).**
 The Codex packaging ships one umbrella routing skill (`plugin/codex/housecarl/SKILL.md`); it had drifted to naming

--- a/src/housecarl-core/ErrorCheck.cs
+++ b/src/housecarl-core/ErrorCheck.cs
@@ -72,7 +72,7 @@ public static class ErrorCheck
             foreach (var name in scope)
             {
                 if (!view.ContainsPlugin(name))
-                    return ErrorCheckResult.Fail($"plugin not in the load order: {name}");
+                    return ErrorCheckResult.Fail($"plugin not in the load order: {name}.{view.AbsenceClause(name)}");
                 if (view.ExcludedPlugins.TryGetValue(name, out var why))
                     return ErrorCheckResult.Fail(
                         $"plugin '{name}' was excluded from this session because it could not be parsed ({why}) — fix or remove it upstream; it cannot be checked.");

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -83,7 +83,10 @@ public sealed class LoadOrderResolver : IDisposable
     /// sits unticked in MO2's right pane, and a flat not-found sends an agent searching for a file that is right there
     /// (#271). The resolver cannot answer that itself and must not learn how: it is built from a bare ordered path list
     /// and knows nothing of MO2 — explicit-paths mode has no profile at all. So the ANSWER is injected by whoever does
-    /// know (the MCP service, from the MO2 profile), and null here simply restores the previous wording.</summary>
+    /// know (the MCP service, from the MO2 profile), and null here simply restores the previous wording. Null is what
+    /// the direct <c>Build(paths)</c> callers get — the guard seam and the probes; BOTH service modes (MO2-instance and
+    /// explicit-paths) supply an explainer, since explicit-paths mode is given a profile directory too and it is the
+    /// explainer's own missing-profile guard, not the wiring, that handles a profile it cannot read.</summary>
     readonly Func<string, string?>? _explainAbsence;
 
     /// <summary>One index build's ENTIRE output, swapped in as a SINGLE reference write. The service refreshes the

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -77,6 +77,15 @@ public sealed class LoadOrderResolver : IDisposable
     DateTime[] _mtimes;                                // last-write at the last index build, per path (freshness baseline)
     readonly string? _dataDir;                         // real game-Data folder (Skyrim.esm's dir) — localized-strings fallback source (OpenOverlay)
 
+    /// <summary>Optional: given a plugin filename this index does NOT contain, a clause saying WHY it isn't in the
+    /// active order — or null if the injector can't say. Every "not in the load order" refusal below is a dead end for
+    /// the reader as it stands: the commonest cause by far is a plugin that IS installed and IS in an enabled mod but
+    /// sits unticked in MO2's right pane, and a flat not-found sends an agent searching for a file that is right there
+    /// (#271). The resolver cannot answer that itself and must not learn how: it is built from a bare ordered path list
+    /// and knows nothing of MO2 — explicit-paths mode has no profile at all. So the ANSWER is injected by whoever does
+    /// know (the MCP service, from the MO2 profile), and null here simply restores the previous wording.</summary>
+    readonly Func<string, string?>? _explainAbsence;
+
     /// <summary>One index build's ENTIRE output, swapped in as a SINGLE reference write. The service refreshes the
     /// index under its own gate, but READERS run outside that gate (concurrent tool calls hold the resolver while a
     /// sibling call's freshness check may rebuild) — when the per-build state lived in five separate fields, a reader
@@ -232,11 +241,27 @@ public sealed class LoadOrderResolver : IDisposable
         }
     }
 
-    LoadOrderResolver(string[] paths, string[] names, Dictionary<string, int> nameToIdx, DateTime[] mtimes)
+    LoadOrderResolver(string[] paths, string[] names, Dictionary<string, int> nameToIdx, DateTime[] mtimes,
+                      Func<string, string?>? explainAbsence)
     {
         _paths = paths; _names = names; _nameToIdx = nameToIdx; _mtimes = mtimes;
+        _explainAbsence = explainAbsence;
         _dataDir = ComputeDataDir(nameToIdx, paths);
         _snap = BuildIndex();
+    }
+
+    /// <summary>The trailing clause for a refusal naming a plugin this order does not contain. Prefers the injected
+    /// EXPLANATION (<see cref="_explainAbsence"/>) — a real cause with a real remedy — and falls back to the
+    /// did-you-mean suggester when nothing can be explained, which is the right split: a name that resolves to a real
+    /// installed plugin should never be answered with a spelling guess, and a genuine typo has no cause to state.
+    /// One home, so the refusal sites below cannot drift apart on the wording.</summary>
+    internal string AbsenceClause(string pluginName)
+    {
+        string? why = null;
+        try { why = _explainAbsence?.Invoke(pluginName); }
+        catch { /* an explainer that throws (an unreadable profile mid-call) must never turn a clean refusal into a
+                   crash — fall through to the suggester, which is exactly the pre-injection behaviour (Q3). */ }
+        return why is null ? PluginNameSuggest.DidYouMean(pluginName, _names) : " " + why;
     }
 
     /// <summary>The real game-Data directory — the folder holding the vanilla BSAs (<c>Skyrim - Interface.bsa</c> et al.,
@@ -301,7 +326,10 @@ public sealed class LoadOrderResolver : IDisposable
     /// name="orderedPluginPaths"/> = masters → … → highest priority (the order is INJECTED; §8.5 supplies the true
     /// active order). Per-plugin open failures are collected into <see cref="LoadFailures"/> at index time (Q3), never
     /// silently skipped.</summary>
-    public static LoadOrderResolver Build(IReadOnlyList<string> orderedPluginPaths)
+    /// <param name="explainAbsence">Optional injected answer to "why is this name not in the order?" — see
+    /// <see cref="_explainAbsence"/>. Omit (the default) and refusals read exactly as they did before.</param>
+    public static LoadOrderResolver Build(IReadOnlyList<string> orderedPluginPaths,
+                                          Func<string, string?>? explainAbsence = null)
     {
         var paths = new string[orderedPluginPaths.Count];
         var names = new string[orderedPluginPaths.Count];
@@ -320,7 +348,7 @@ public sealed class LoadOrderResolver : IDisposable
             mtimes[i] = SafeMtime(p);
         }
 
-        return new LoadOrderResolver(paths, names, nameToIdx, mtimes);
+        return new LoadOrderResolver(paths, names, nameToIdx, mtimes, explainAbsence);
     }
 
     /// <summary>Enumerate every plugin once (low→high), ONE AT A TIME (open → enumerate → dispose), building the
@@ -453,6 +481,12 @@ public sealed class LoadOrderResolver : IDisposable
         /// for both (HCBR-2026-06-11-02 verify-loop wave (a)).</summary>
         public bool ContainsPlugin(string pluginName) => _r._nameToIdx.ContainsKey(pluginName);
 
+        /// <summary>The trailing clause for a refusal naming a plugin <see cref="ContainsPlugin"/> just returned false
+        /// for: WHY it isn't in the order (injected — typically "installed, but UNTICKED in plugins.txt"), else a
+        /// did-you-mean. Always safe to append; returns "" when there is nothing to add. Every ContainsPlugin-false
+        /// refusal should carry it — a bare not-found makes the reader re-derive a fact the tool already had (#271).</summary>
+        public string AbsenceClause(string pluginName) => _r.AbsenceClause(pluginName);
+
         /// <summary>The on-disk PATH of the active plugin named <paramref name="pluginName"/> (a filename like
         /// "MyMod.esp"), or null if no such plugin is in the order. The minimal name→path exposure the dialogue
         /// validator's SEQ lint needs to stat the quest's defining plugin (mtime) and read its master list; the
@@ -544,7 +578,7 @@ public sealed class LoadOrderResolver : IDisposable
     {
         var s = _snap;                                                 // ONE build, captured for the whole enumeration
         if (!_nameToIdx.TryGetValue(pluginName, out int idx))
-            throw new ArgumentException($"plugin not in the load order: {pluginName}.{PluginNameSuggest.DidYouMean(pluginName, _names)}");
+            throw new ArgumentException($"plugin not in the load order: {pluginName}.{AbsenceClause(pluginName)}");
         if (s.Excluded.Contains(idx))
             throw new ArgumentException($"plugin '{pluginName}' was excluded from this session: {s.ExcludedPlugins[pluginName]}");
         var ov = OpenOverlay(_paths[idx], _dataDir);
@@ -590,7 +624,7 @@ public sealed class LoadOrderResolver : IDisposable
     IReadOnlyList<string> DeclaredMasters(string pluginName, IndexSnapshot s)
     {
         if (!_nameToIdx.TryGetValue(pluginName, out int idx))
-            throw new ArgumentException($"plugin not in the load order: {pluginName}.{PluginNameSuggest.DidYouMean(pluginName, _names)}");
+            throw new ArgumentException($"plugin not in the load order: {pluginName}.{AbsenceClause(pluginName)}");
         if (s.Excluded.Contains(idx))
             throw new ArgumentException($"plugin '{pluginName}' was excluded from this session: {s.ExcludedPlugins[pluginName]}");
         var ov = OpenOverlay(_paths[idx], _dataDir);
@@ -684,7 +718,7 @@ public sealed class LoadOrderResolver : IDisposable
         foreach (var name in scopePlugins)
         {
             if (!_nameToIdx.TryGetValue(name, out int i))
-                throw new ArgumentException($"plugin not in the load order: {name}.{PluginNameSuggest.DidYouMean(name, _names)}");
+                throw new ArgumentException($"plugin not in the load order: {name}.{AbsenceClause(name)}");
             if (s.Excluded.Contains(i))                                    // explicitly scoped to an excluded plugin → fail loud with the reason (Q3), don't silently scan nothing
                 throw new ArgumentException($"plugin '{name}' was excluded from this session: {s.ExcludedPlugins[name]}");
             idxs.Add(i);

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -256,13 +256,23 @@ public sealed class LoadOrderResolver : IDisposable
     /// installed plugin should never be answered with a spelling guess, and a genuine typo has no cause to state.
     /// One home, so the refusal sites below cannot drift apart on the wording.</summary>
     internal string AbsenceClause(string pluginName)
+        => ExplainAbsence(pluginName) is { } why ? " " + why : NameSuggestion(pluginName);
+
+    /// <summary>ONLY the injected explanation, or null when there is none — the half a caller needs when the presence
+    /// of a real CAUSE changes more than one sentence (read_record drops its generic posture tail once a specific cause
+    /// has been stated, and the did-you-mean is not a cause). Kept separate from <see cref="AbsenceClause"/> because
+    /// that one deliberately returns a non-empty string in BOTH cases, so its length says nothing about which
+    /// happened.</summary>
+    internal string? ExplainAbsence(string pluginName)
     {
-        string? why = null;
-        try { why = _explainAbsence?.Invoke(pluginName); }
-        catch { /* an explainer that throws (an unreadable profile mid-call) must never turn a clean refusal into a
-                   crash — fall through to the suggester, which is exactly the pre-injection behaviour (Q3). */ }
-        return why is null ? PluginNameSuggest.DidYouMean(pluginName, _names) : " " + why;
+        try { return _explainAbsence?.Invoke(pluginName); }
+        catch { return null; }   /* an explainer that throws (an unreadable profile mid-call) must never turn a clean
+                                    refusal into a crash — fall through to the suggester, the pre-injection behaviour (Q3). */
     }
+
+    /// <summary>The did-you-mean for a name nothing can explain — the fallback half of <see cref="AbsenceClause"/>,
+    /// exposed so a caller that already asked for the explanation need not re-invoke the explainer to get it.</summary>
+    internal string NameSuggestion(string pluginName) => PluginNameSuggest.DidYouMean(pluginName, _names);
 
     /// <summary>The real game-Data directory — the folder holding the vanilla BSAs (<c>Skyrim - Interface.bsa</c> et al.,
     /// which carry the base AND DLC <c>.STRINGS</c>). Derived as the folder of the resolved <c>Skyrim.esm</c>: the base
@@ -486,6 +496,14 @@ public sealed class LoadOrderResolver : IDisposable
         /// did-you-mean. Always safe to append; returns "" when there is nothing to add. Every ContainsPlugin-false
         /// refusal should carry it — a bare not-found makes the reader re-derive a fact the tool already had (#271).</summary>
         public string AbsenceClause(string pluginName) => _r.AbsenceClause(pluginName);
+
+        /// <summary>Only the injected CAUSE (null when there is none) — see
+        /// <see cref="LoadOrderResolver.ExplainAbsence"/>; pair with <see cref="NameSuggestion"/> to rebuild the full
+        /// clause without invoking the explainer twice.</summary>
+        public string? ExplainAbsence(string pluginName) => _r.ExplainAbsence(pluginName);
+
+        /// <summary>The did-you-mean fallback — see <see cref="LoadOrderResolver.NameSuggestion"/>.</summary>
+        public string NameSuggestion(string pluginName) => _r.NameSuggestion(pluginName);
 
         /// <summary>The on-disk PATH of the active plugin named <paramref name="pluginName"/> (a filename like
         /// "MyMod.esp"), or null if no such plugin is in the order. The minimal name→path exposure the dialogue

--- a/src/housecarl-core/Mo2LoadOrder.cs
+++ b/src/housecarl-core/Mo2LoadOrder.cs
@@ -272,7 +272,12 @@ public static class Mo2LoadOrder
         foreach (var mod in comp.EnabledMods) TryDir(Path.Combine(modsDir, mod), $"mod '{mod}' (enabled)", enabled: true);
         foreach (var mod in comp.DisabledMods) TryDir(Path.Combine(modsDir, mod), $"mod '{mod}' (DISABLED)", enabled: false);
         foreach (var dir in UnlistedModFolders(comp, modsDir))        // on disk but not in modlist.txt (a fresh houseCARL patch pre-refresh)
-            TryDir(dir, $"mod '{Path.GetFileName(dir)}' (UNLISTED — not in modlist.txt yet; refresh MO2 to register it)", enabled: false);
+            // The label IDENTIFIES the layer and its state; it does NOT carry a remedy. It used to end "— not in
+            // modlist.txt yet; refresh MO2 to register it", which read fine alone but printed the same instruction
+            // twice once the caller's own cause line began stating remedies ("refresh MO2, then tick the plugin and
+            // sort") — a milder form of the duplication that #271 exists to remove, and one only a live run surfaced.
+            // Labels identify, causes explain: the remedy belongs to whoever is explaining, not to the identifier.
+            TryDir(dir, $"mod '{Path.GetFileName(dir)}' (UNLISTED)", enabled: false);
         TryDir(dataDir, "game Data", enabled: true);                  // vanilla / base — lowest priority
         return hits;
     }

--- a/src/housecarl-core/RemapEngine.cs
+++ b/src/housecarl-core/RemapEngine.cs
@@ -853,7 +853,7 @@ public static class RemapEngine
         if (dict.Count == 0) return RepointResult.Fail("no remap entries supplied — nothing to repoint.");
         var view = resolver.Capture();
         if (!view.ContainsPlugin(pluginName))
-            return RepointResult.Fail($"repoint target '{pluginName}' is not an active plugin in the load order.");
+            return RepointResult.Fail($"repoint target '{pluginName}' is not an active plugin in the load order.{view.AbsenceClause(pluginName)}");
         if (view.ExcludedPlugins.TryGetValue(pluginName, out var excluded))
             return RepointResult.Fail(
                 $"cannot repoint '{pluginName}' in place: it was EXCLUDED from this session ({excluded}) — houseCARL won't " +

--- a/src/housecarl-core/ScriptPropertyCheck.cs
+++ b/src/housecarl-core/ScriptPropertyCheck.cs
@@ -73,7 +73,7 @@ public static class ScriptPropertyCheck
             foreach (var name in scope)
             {
                 if (!view.ContainsPlugin(name))
-                    return ScriptCheckResult.Fail($"plugin not in the load order: {name}");
+                    return ScriptCheckResult.Fail($"plugin not in the load order: {name}.{view.AbsenceClause(name)}");
                 if (view.ExcludedPlugins.TryGetValue(name, out var why))
                     return ScriptCheckResult.Fail(
                         $"plugin '{name}' was excluded from this session because it could not be parsed ({why}) — fix or remove it upstream; it cannot be checked.");

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -379,7 +379,13 @@ public static class WritePatchBuilder
                 else if (string.Equals(e.FromPlugin, fileName, StringComparison.OrdinalIgnoreCase))
                 { problems.Add($"{e.Target}: CopyFrom from_plugin '{e.FromPlugin}' is the output patch itself — name the OTHER plugin whose version to copy from."); continue; }
                 else if (!view.ContainsPlugin(e.FromPlugin))
-                { problems.Add($"{e.Target}: CopyFrom source '{e.FromPlugin}' is not in the load order (and no plugin file by that name was located on disk) — name an active plugin, or a plugin file present on disk.{view.AbsenceClause(e.FromPlugin)}"); continue; }
+                // Deliberately NO AbsenceClause here (review of PR #274): the service pre-resolves every off-order
+                // CopyFrom source before Apply — a source that is merely unticked / in a disabled mod / shadowed is
+                // LOCATED and supplied via copyFromSources above, and one that cannot be located aborts the whole call
+                // earlier. So the only name reaching this arm has no on-disk copy at all, which is exactly the case the
+                // explainer cannot explain — it would pay a profile parse plus a whole-install sweep, per edit, to
+                // return the did-you-mean the message would have got anyway. The sentence already says what is known.
+                { problems.Add($"{e.Target}: CopyFrom source '{e.FromPlugin}' is not in the load order (and no plugin file by that name was located on disk) — name an active plugin, or a plugin file present on disk."); continue; }
                 else if (view.ExcludedPlugins.TryGetValue(e.FromPlugin, out var why))
                 { problems.Add($"{e.Target}: CopyFrom source '{e.FromPlugin}' was excluded from this session ({why}) — its records aren't resolvable."); continue; }
                 else
@@ -1131,6 +1137,17 @@ public static class WritePatchBuilder
         var resolved = new List<(ForwardSpec spec, IMajorRecordGetter body, string priorWinner, bool wasWinner)>(specs.Count);
         var problems = new List<string>();
         var seen = new HashSet<FormKey>();
+        // AbsenceClause costs a profile parse plus (for anything not already unticked) a whole-install folder sweep, and
+        // `specs` is unbounded — a batch naming the same bad from_plugin 500 times would pay it 500 times for one
+        // answer. Memoized per CALL, not per resolver: the explainer reads the profile fresh by design, and a cache
+        // living longer than one refusal batch is exactly the staleness it refuses to have (review of PR #274).
+        var absenceMemo = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        string Absence(string plugin)
+        {
+            if (!absenceMemo.TryGetValue(plugin, out var clause)) absenceMemo[plugin] = clause = view.AbsenceClause(plugin);
+            return clause;
+        }
+
         foreach (var s in specs)
         {
             if (!seen.Add(s.Target))
@@ -1143,7 +1160,7 @@ public static class WritePatchBuilder
                 continue;
             }
             if (!view.ContainsPlugin(s.FromPlugin))
-            { problems.Add($"{s.Target}: source plugin '{s.FromPlugin}' is not in the load order — name an active plugin that defines or overrides this record.{view.AbsenceClause(s.FromPlugin)}"); continue; }
+            { problems.Add($"{s.Target}: source plugin '{s.FromPlugin}' is not in the load order — name an active plugin that defines or overrides this record.{Absence(s.FromPlugin)}"); continue; }
             if (view.ExcludedPlugins.TryGetValue(s.FromPlugin, out var why))
             { problems.Add($"{s.Target}: source plugin '{s.FromPlugin}' was excluded from this session ({why}) — its records aren't resolvable."); continue; }
             var body = view.GetRecord(session, s.FromPlugin, s.Target);

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -379,7 +379,7 @@ public static class WritePatchBuilder
                 else if (string.Equals(e.FromPlugin, fileName, StringComparison.OrdinalIgnoreCase))
                 { problems.Add($"{e.Target}: CopyFrom from_plugin '{e.FromPlugin}' is the output patch itself — name the OTHER plugin whose version to copy from."); continue; }
                 else if (!view.ContainsPlugin(e.FromPlugin))
-                { problems.Add($"{e.Target}: CopyFrom source '{e.FromPlugin}' is not in the load order (and no plugin file by that name was located on disk) — name an active plugin, or a plugin file present on disk."); continue; }
+                { problems.Add($"{e.Target}: CopyFrom source '{e.FromPlugin}' is not in the load order (and no plugin file by that name was located on disk) — name an active plugin, or a plugin file present on disk.{view.AbsenceClause(e.FromPlugin)}"); continue; }
                 else if (view.ExcludedPlugins.TryGetValue(e.FromPlugin, out var why))
                 { problems.Add($"{e.Target}: CopyFrom source '{e.FromPlugin}' was excluded from this session ({why}) — its records aren't resolvable."); continue; }
                 else
@@ -586,7 +586,7 @@ public static class WritePatchBuilder
         //     content-source guard. ONE captured view answers every edit (the hunt-F5 one-view discipline). ---
         var view = resolver.Capture();
         if (!view.ContainsPlugin(targetName))
-            return PatchOutcome.Fail($"in-place target '{targetName}' is not an active plugin in the load order.");
+            return PatchOutcome.Fail($"in-place target '{targetName}' is not an active plugin in the load order.{view.AbsenceClause(targetName)}");
         if (view.ExcludedPlugins.TryGetValue(targetName, out var excluded))
             return PatchOutcome.Fail(
                 $"cannot edit '{targetName}' in place: it was EXCLUDED from this session ({excluded}) — houseCARL won't " +
@@ -1009,7 +1009,7 @@ public static class WritePatchBuilder
         //     plugin Mutagen excluded, which would risk dropping the record it couldn't read on the rewrite, Q3). ---
         var view = resolver.Capture();
         if (!view.ContainsPlugin(targetName))
-            return RemovalOutcome.Fail($"in-place target '{targetName}' is not an active plugin in the load order.");
+            return RemovalOutcome.Fail($"in-place target '{targetName}' is not an active plugin in the load order.{view.AbsenceClause(targetName)}");
         if (view.ExcludedPlugins.TryGetValue(targetName, out var excluded))
             return RemovalOutcome.Fail(
                 $"cannot remove from '{targetName}' in place: it was EXCLUDED from this session ({excluded}) — houseCARL won't " +
@@ -1143,7 +1143,7 @@ public static class WritePatchBuilder
                 continue;
             }
             if (!view.ContainsPlugin(s.FromPlugin))
-            { problems.Add($"{s.Target}: source plugin '{s.FromPlugin}' is not in the load order — name an active plugin that defines or overrides this record."); continue; }
+            { problems.Add($"{s.Target}: source plugin '{s.FromPlugin}' is not in the load order — name an active plugin that defines or overrides this record.{view.AbsenceClause(s.FromPlugin)}"); continue; }
             if (view.ExcludedPlugins.TryGetValue(s.FromPlugin, out var why))
             { problems.Add($"{s.Target}: source plugin '{s.FromPlugin}' was excluded from this session ({why}) — its records aren't resolvable."); continue; }
             var body = view.GetRecord(session, s.FromPlugin, s.Target);
@@ -1190,7 +1190,7 @@ public static class WritePatchBuilder
         //     parse) + source resolution off ONE captured view. ---
         var view = resolver.Capture();
         if (!view.ContainsPlugin(targetName))
-            return ForwardOutcome.Fail($"in-place target '{targetName}' is not an active plugin in the load order.");
+            return ForwardOutcome.Fail($"in-place target '{targetName}' is not an active plugin in the load order.{view.AbsenceClause(targetName)}");
         if (view.ExcludedPlugins.TryGetValue(targetName, out var excluded))
             return ForwardOutcome.Fail(
                 $"cannot forward into '{targetName}' in place: it was EXCLUDED from this session ({excluded}) — houseCARL won't " +
@@ -1953,7 +1953,7 @@ public static class WritePatchBuilder
             // The target must be an active, fully-parseable plugin (the excluded-plugin guard, same as ApplyInPlace):
             // houseCARL won't re-serialize a plugin it can't fully parse — that would risk DROPPING a record it couldn't read (Q3).
             if (!view.ContainsPlugin(inPlaceTarget!))
-                return CreateOutcome.Fail($"in-place target '{inPlaceTarget}' is not an active plugin in the load order.");
+                return CreateOutcome.Fail($"in-place target '{inPlaceTarget}' is not an active plugin in the load order.{view.AbsenceClause(inPlaceTarget!)}");
             if (view.ExcludedPlugins.TryGetValue(inPlaceTarget!, out var excluded))
                 return CreateOutcome.Fail(
                     $"cannot create into '{inPlaceTarget}' in place: it was EXCLUDED from this session ({excluded}) — houseCARL won't " +

--- a/src/housecarl-generator/BulkPrimitivesWave3Probe.cs
+++ b/src/housecarl-generator/BulkPrimitivesWave3Probe.cs
@@ -519,6 +519,18 @@ public static class BulkPrimitivesWave3Probe
         var urwFk = urw.FormKey;
         unregMod.BeginWrite.ToPath(unregPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
 
+        // UNLISTED folder: on disk under ModsDir but mentioned NOWHERE in modlist.txt. This is the state of a patch
+        // houseCARL has just written, before the MO2 refresh — by far the most common way a real session reaches a
+        // "not in the load order" refusal, and the one the fixtures never modelled (review of PR #274, round 2).
+        // Its remedy is a refresh; "switch the mod on" names an action MO2 cannot offer for it.
+        var unlKey = new ModKey("HcW3Unlisted", ModType.Plugin);
+        var unlistedPath = Path.Combine(mods, "DiffUnlistedFresh", unlKey.FileName.String);
+        Directory.CreateDirectory(Path.GetDirectoryName(unlistedPath)!);
+        var unlMod = new SkyrimMod(unlKey, SkyrimRelease.SkyrimSE);
+        var ulw = unlMod.Weapons.AddNew(); ulw.EditorID = "UnlistedW"; ulw.BasicStats = new WeaponBasicStats { Damage = 44 };
+        var ulwFk = ulw.FormKey;
+        unlMod.BeginWrite.ToPath(unlistedPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
         // ARCHIVE backup: the SAME filename as the active replacer (55), parked OUTSIDE every MO2/game root — the
         // old-version-vs-live diff (#269's reporter's actual job). Same name, different file: it must stay off-order.
         var archivePath = Path.Combine(dir, "archive", rKey.FileName.String);
@@ -594,7 +606,7 @@ public static class BulkPrimitivesWave3Probe
         // four different remedies — and the wrong word for a plugin (a MOD is disabled; a PLUGIN is inactive).
         Check("diff: the off-order pole NAMES the cause — the DISABLED mod folder that provides the copy",
               dPathDisabled.Error is null && dPathDisabled.A!.Where.Contains("DiffDonor")
-              && dPathDisabled.A.Where.Contains("DISABLED"));
+              && dPathDisabled.A.Where.Contains("switched OFF"));
 
         var dPathArchive = svc.DiffRecord(wFid, archivePath, replPath, new[] { "BasicStats.Damage" });
         Check("diff: a same-named backup OUTSIDE the install stays OUT-OF-LOAD-ORDER (55 vs 99) — name never decides",
@@ -668,10 +680,10 @@ public static class BulkPrimitivesWave3Probe
         // A copy in a switched-off mod: the remedy is the LEFT pane, and the label must say so rather than blame the
         // plugin's tick (the decoy is not listed in plugins.txt at all, so a naive renderer would say "unticked").
         Check("#271 why: a copy in a DISABLED mod blames the MOD FOLDER, and never claims the plugin is unticked",
-              rpfDecoy.WhyNotActive is { } wD && wD.Contains("DataServedDecoy") && wD.Contains("DISABLED")
+              rpfDecoy.WhyNotActive is { } wD && wD.Contains("DataServedDecoy") && wD.Contains("switched OFF")
               && !wD.Contains("UNTICKED"));
         Check("#271 why: a same-named backup OUTSIDE the install says it is not an install copy — not 'disabled'",
-              rpfArchive.WhyNotActive is { } wA && wA.Contains("not a copy the MO2 install provides"));
+              rpfArchive.WhyNotActive is { } wA && wA.Contains("no MO2 layer was found providing this exact path"));
         // The other direction, and the one #269 was actually about: when the game DOES load the file, there must be
         // no cause at all — a leftover explanation would re-assert the very falsehood this issue set out to remove.
         Check("#271 why: the three ACTIVE lanes carry NO cause (null), so nothing contradicts the live file",
@@ -696,16 +708,44 @@ public static class BulkPrimitivesWave3Probe
         // the same thing twice in one sentence — output strictly worse than the "NOT active" it replaced. The path-lane
         // arms above cannot catch it: their Where is the constant "direct path", where the restatement is the only way
         // the layer gets named at all. Armed on the lane where the bug can actually appear (review of PR #274).
+        Console.WriteLine("DBG byname=[" + (svc.ReadPluginFile(dKey.FileName.String, wFid, null, null, null, 1, null, 10).WhyNotActive ?? "<null>") + "]");
+        Console.WriteLine("DBG bymod=[" + (svc.ReadPluginFile(dKey.FileName.String, wFid, null, "DiffDonor", null, 1, null, 10).WhyNotActive ?? "<null>") + "]");
+        Console.WriteLine("DBG bypath=[" + (rpfDecoy.WhyNotActive ?? "<null>") + "]");
+        Console.WriteLine("DBG archive=[" + (rpfArchive.WhyNotActive ?? "<null>") + "]");
+        Console.WriteLine("DBG json=[" + JsonWire.RenderPluginFile(rpfUntickedByName, 8000) + "]");
+        // ALL THREE address forms, not the one that was reported. Round 1 flagged this duplication, the fix was tested
+        // by comparing the two labels for equality, and that test silently failed in the mod= lane — whose Where names
+        // the mod but omits its state — so the identical defect survived a round of review in an unarmed lane. Each
+        // lane is now armed for the SAME cause: the mod name must appear exactly once in every rendered form.
         var rpfDisabledByName = svc.ReadPluginFile(dKey.FileName.String, wFid, null, null, null, 1, null, 10);
+        var rpfDisabledByMod = svc.ReadPluginFile(dKey.FileName.String, wFid, null, "DiffDonor", null, 1, null, 10);
         var renderDisabledByName = Wire.RenderPluginFile(rpfDisabledByName, 8000);
-        Check("#271 render: a disabled-mod copy BY FILENAME names its layer exactly once, not twice",
-              rpfDisabledByName.Error is null
-              && CountOf(renderDisabledByName, "mod 'DiffDonor' (DISABLED)") == 1
+        var renderDisabledByMod = Wire.RenderPluginFile(rpfDisabledByMod, 8000);
+        Check("#271 render: a disabled-mod copy BY FILENAME names its mod exactly once",
+              rpfDisabledByName.Error is null && CountOf(renderDisabledByName, "mod 'DiffDonor'") == 1
               && renderDisabledByName.Contains("the game does NOT load this file"));
-        // ...while the PATH lane, whose Where is "direct path", must STILL name the layer — dropping the restatement
-        // outright would lose the only mention of which mod provides the file.
-        Check("#271 render: the same copy BY PATH still names the layer, since its Where cannot",
+        Check("#271 render: BY MOD= too — the lane whose label omits the state, where the equality test failed",
+              rpfDisabledByMod.Error is null && CountOf(renderDisabledByMod, "mod 'DiffDonor'") == 1
+              && renderDisabledByMod.Contains("the game does NOT load this file"));
+        // ...while the PATH lane, whose Where identifies nothing, must STILL name the mod — suppressing it everywhere
+        // would lose the only mention of which mod provides the file.
+        Check("#271 render: the same copy BY PATH still names the mod, since its Where cannot",
               rpfDecoy.WhyNotActive is { } wD2 && wD2.Contains("DataServedDecoy"));
+        // The two layer-off causes carry DIFFERENT remedies and must never render alike: an UNLISTED folder has nothing
+        // in MO2's list to switch on. Both are flagged not-enabled by the locate, so a fix reading that flag alone
+        // cannot tell them apart — the standing is decided from modlist.txt membership instead.
+        string ulwFid = $"{ulwFk.ID:X6}:{ulwFk.ModKey.FileName}";
+        var rpfUnlisted = svc.ReadPluginFile(unlKey.FileName.String, ulwFid, null, null, null, 1, null, 10);
+        Check("#271 why: a DISABLED mod says switch it on; an UNLISTED folder says refresh — never swapped",
+              rpfDisabledByName.WhyNotActive is { } wDis && wDis.Contains("switched OFF") && wDis.Contains("switch it on")
+              && rpfUnlisted.Error is null && rpfUnlisted.WhyNotActive is { } wUn
+              && wUn.Contains("not registered") && !wUn.Contains("switch it on"));
+        // The JSON lane carries the cause too — advertised in the changelog, previously unarmed.
+        var jsonUnticked = JsonWire.RenderPluginFile(rpfUntickedByName, 8000);
+        var jsonLive = JsonWire.RenderPluginFile(rpfPath, 8000);
+        Check("#271 json: why_not_active rides beside enabled, and is explicitly null when the game loads the file",
+              jsonUnticked.Contains("\"why_not_active\"") && jsonUnticked.Contains("UNTICKED")
+              && jsonLive.Contains("\"why_not_active\": null"));
 
         // ---- #271 item 2: the REFUSAL sweep. A tool that reads THROUGH the load order still refuses on an unticked
         //      plugin (correctly — Q3: a plugin the game does not load must never masquerade as load-order truth), but
@@ -752,20 +792,34 @@ public static class BulkPrimitivesWave3Probe
         // found by review. That is the "fixed the reported site, missed the rule's other lanes" shape #270 kept
         // repeating, so this arm sweeps the WHOLE shipped surface by reflection rather than the two sites that were
         // reported. A tool description added tomorrow with the same sentence turns CI red.
+        // Case-SENSITIVE, deliberately: the shipped banner legitimately writes "the game does NOT load this file: <why>"
+        // as a per-file report, and an ordinal-ignore-case match would read that correct sentence as the defect. What is
+        // banned is the flat lower-case assertion (review of PR #274, round 2).
         const string overclaim = "the game does not load this file";
-        var descs = typeof(HousecarlMcp.ReadTools).Assembly.GetTypes()
-            .SelectMany(t => t.GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic
-                                          | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Instance
-                                          | System.Reflection.BindingFlags.DeclaredOnly))
-            .SelectMany(m => m.GetCustomAttributes(typeof(System.ComponentModel.DescriptionAttribute), false)
-                              .Cast<System.ComponentModel.DescriptionAttribute>()
-                              .Concat(m.GetParameters().SelectMany(p =>
-                                  p.GetCustomAttributes(typeof(System.ComponentModel.DescriptionAttribute), false)
-                                   .Cast<System.ComponentModel.DescriptionAttribute>())))
-            .Select(d => d.Description ?? "")
+        var mcpTypes = typeof(HousecarlMcp.ReadTools).Assembly.GetTypes();
+        const System.Reflection.BindingFlags AllDeclared =
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic
+            | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Instance
+            | System.Reflection.BindingFlags.DeclaredOnly;
+        static IEnumerable<string> DescsOf(System.Reflection.ICustomAttributeProvider p) =>
+            p.GetCustomAttributes(typeof(System.ComponentModel.DescriptionAttribute), false)
+             .Cast<System.ComponentModel.DescriptionAttribute>().Select(d => d.Description ?? "");
+        var descs = mcpTypes.SelectMany(t => DescsOf(t)                                   // type-level too, not just methods
+                .Concat(t.GetMethods(AllDeclared).SelectMany(m => DescsOf(m)
+                    .Concat(m.GetParameters().SelectMany(pp => DescsOf(pp))))))
             .ToList();
-        Check($"#271 sweep: no MCP tool/parameter description asserts the overclaim ({descs.Count} descriptions swept)",
-              descs.Count > 50 && !descs.Any(d => d.Contains(overclaim, StringComparison.OrdinalIgnoreCase)));
+        Check($"#271 sweep: no MCP type/tool/parameter description asserts the overclaim ({descs.Count} descriptions swept)",
+              descs.Count > 50 && !descs.Any(d => d.Contains(overclaim, StringComparison.Ordinal)));
+        // The shipped prose that describes this banner lives outside the assembly; sweep it in the same breath so a doc
+        // re-asserting what the code stopped claiming cannot drift back in unnoticed.
+        foreach (var doc in new[] { Path.Combine("plugin", "README.md"), Path.Combine("plugin", "codex", "housecarl", "SKILL.md") })
+        {
+            // Repo-relative from the run CWD, the same convention codex-umbrella-coverage-guard uses. A MISSING file
+            // fails rather than silently passing — a sweep that quietly checks nothing is worse than no sweep (Q3).
+            if (!File.Exists(doc)) { Check($"#271 sweep: shipped doc present to sweep ({doc})", false); continue; }
+            Check($"#271 sweep: {doc} does not assert the overclaim either",
+                  !File.ReadAllText(doc).Contains(overclaim, StringComparison.Ordinal));
+        }
 
         // The third renderer named by the issue. Its bracket is gated on a flag the file lane sets UNCONDITIONALLY, so
         // it asserted the overclaim even for a donor the game does load — armed here through the real render.
@@ -777,6 +831,22 @@ public static class BulkPrimitivesWave3Probe
         Check("#271 sweep: copy_npc_appearance's donor bracket states the READ, not a claim about the file",
               !npcRender.Contains(overclaim, StringComparison.OrdinalIgnoreCase)
               && npcRender.Contains("OUT-OF-LOAD-ORDER"));
+
+        // FINDING 1: the fresh-patch refusal. houseCARL writes patches into an unlisted folder, so this is the refusal
+        // a real session hits most, and the explainer now answers it — which is exactly why the "cause stated ⇒ drop
+        // the legacy tail" rule silently took the full_readback verify path away from it. That guidance is a fact about
+        // the tool, not a guess about the cause, so it must survive whether or not a cause was stated.
+        var readFreshPatch = svc.ResolveRead(ulwFk, unlKey.FileName.String, null, false);
+        Check("#271 refusal: a just-written (unlisted) patch keeps the full_readback verify path",
+              readFreshPatch.Error is { } eF && eF.Contains("full_readback=true"));
+        Check("#271 refusal: ...and is told to REFRESH MO2, not to switch on a mod MO2 has never listed",
+              readFreshPatch.Error is { } eF2 && eF2.Contains("refresh MO2", StringComparison.OrdinalIgnoreCase)
+              && !eF2.Contains("Switch that mod on"));
+        Check("#271 refusal: the retained verify sentence names the plugin, so it has a subject standing alone",
+              readFreshPatch.Error is { } eF3 && eF3.Contains($"prior write into '{unlKey.FileName}'"));
+        // ...and the unexplained case keeps BOTH halves, so nothing was lost for it either.
+        Check("#271 refusal: an unexplained name keeps the posture line AND the verify path",
+              readTypo.Error is { } eT3 && eT3.Contains("does not open disabled") && eT3.Contains("full_readback=true"));
 
         // A SECOND refusal lane. All the arms above ride ResolveRead, and every other site got the same clause with no
         // coverage — which is why a dropped space in merge_plugins' refusal shipped unnoticed (review of PR #274).

--- a/src/housecarl-generator/BulkPrimitivesWave3Probe.cs
+++ b/src/housecarl-generator/BulkPrimitivesWave3Probe.cs
@@ -563,9 +563,14 @@ public static class BulkPrimitivesWave3Probe
         // (c) a DISABLED mod's copy, addressed by path: INSIDE an install root, but its mod is off. The flag has to
         //     come from the located copy — "is it under a root at all" would call this one enabled.
         var dPathDisabled = svc.DiffRecord(wFid, donorPath, replName, new[] { "BasicStats.Damage" });
-        Check("diff: a DISABLED mod's plugin addressed BY PATH stays OUT-OF-LOAD-ORDER and disabled",
+        Check("diff: a DISABLED mod's plugin addressed BY PATH stays OUT-OF-LOAD-ORDER and NOT active",
               dPathDisabled.Error is null && !dPathDisabled.A!.InOrder
-              && dPathDisabled.A.Where.Contains("OUT-OF-LOAD-ORDER") && dPathDisabled.A.Where.Contains("disabled"));
+              && dPathDisabled.A.Where.Contains("OUT-OF-LOAD-ORDER") && dPathDisabled.A.Where.Contains("NOT active"));
+        // #271: the pole must state the CAUSE, not just the state. "disabled" was one word for four situations with
+        // four different remedies — and the wrong word for a plugin (a MOD is disabled; a PLUGIN is inactive).
+        Check("diff: the off-order pole NAMES the cause — the DISABLED mod folder that provides the copy",
+              dPathDisabled.Error is null && dPathDisabled.A!.Where.Contains("DiffDonor")
+              && dPathDisabled.A.Where.Contains("DISABLED"));
 
         var dPathArchive = svc.DiffRecord(wFid, archivePath, replPath, new[] { "BasicStats.Damage" });
         Check("diff: a same-named backup OUTSIDE the install stays OUT-OF-LOAD-ORDER (55 vs 99) — name never decides",
@@ -617,6 +622,52 @@ public static class BulkPrimitivesWave3Probe
         var rpfModUnticked = svc.ReadPluginFile(unKey.FileName.String, uwFid, null, "DiffUnticked", null, 1, null, 10);
         Check("read_plugin_file mod=: the serving mod's copy of an UNTICKED plugin still reports enabled=false",
               rpfModUnticked.Error is null && !rpfModUnticked.Enabled);
+
+        // ---- #271: the flag now EXPLAINS. Every not-active lane above must name its own cause, and the three causes
+        //      must be distinguishable — an agent that reads "NOT active" and cannot tell unticked from shadowed from
+        //      switched-off burns a search rediscovering what the tool already computed. Armed on EVERY address form,
+        //      because "armed the reported lane, missed its twin" is the mistake that cost #270 four review rounds. ----
+        Check("#271 why: an UNTICKED plugin by PATH says UNTICKED and names plugins.txt (not its mod's switch)",
+              rpfUnticked.WhyNotActive is { } wU && wU.Contains("UNTICKED") && wU.Contains("plugins.txt")
+              && wU.Contains(unKey.FileName.String));
+        Check("#271 why: the same plugin BY FILENAME gives the SAME cause — one fact, however addressed",
+              rpfUntickedByName.WhyNotActive == rpfUnticked.WhyNotActive);
+        Check("#271 why: and via mod= too — all three address lanes agree on the cause, not just on the boolean",
+              rpfModUnticked.WhyNotActive == rpfUnticked.WhyNotActive);
+        // A shadowed copy's remedy is the OPPOSITE of an unticked one's, so the two must never render alike: this mod
+        // is enabled and this plugin is ticked — what's wrong is WHICH copy, and the useful pointer is the winner.
+        Check("#271 why: a SHADOWED copy says SHADOWED and points at the mod that serves the winning copy",
+              rpfShadow.WhyNotActive is { } wS && wS.Contains("SHADOWED") && wS.Contains("DiffRepl")
+              && !wS.Contains("UNTICKED"));
+        Check("#271 why: mod= reaches the same shadowed copy and states the same cause",
+              rpfModShadow.WhyNotActive is { } wMS && wMS.Contains("SHADOWED"));
+        // A copy in a switched-off mod: the remedy is the LEFT pane, and the label must say so rather than blame the
+        // plugin's tick (the decoy is not listed in plugins.txt at all, so a naive renderer would say "unticked").
+        Check("#271 why: a copy in a DISABLED mod blames the MOD FOLDER, and never claims the plugin is unticked",
+              rpfDecoy.WhyNotActive is { } wD && wD.Contains("DataServedDecoy") && wD.Contains("DISABLED")
+              && !wD.Contains("UNTICKED"));
+        Check("#271 why: a same-named backup OUTSIDE the install says it is not an install copy — not 'disabled'",
+              rpfArchive.WhyNotActive is { } wA && wA.Contains("not a copy the MO2 install provides"));
+        // The other direction, and the one #269 was actually about: when the game DOES load the file, there must be
+        // no cause at all — a leftover explanation would re-assert the very falsehood this issue set out to remove.
+        Check("#271 why: the three ACTIVE lanes carry NO cause (null), so nothing contradicts the live file",
+              rpfPath.WhyNotActive is null && rpfData.WhyNotActive is null && rpfModServing.WhyNotActive is null);
+
+        // The RENDERED header, end to end — the banner's old parenthetical ("the game does not load this file") was
+        // false for exactly this call, where the file passed IS the live plugin (#269/#271 item 3), and the
+        // "[mod 'X' (enabled); NOT active]" pairing named a folder and a file in one breath without saying which was
+        // which (item 4). Assert on the rendered string, since the wording IS the deliverable here.
+        var renderLive = Wire.RenderPluginFile(rpfPath, 8000);
+        Check("#271 banner: the stamp describes the READ, never claiming the game does not load the file",
+              renderLive.Contains("OUT-OF-LOAD-ORDER") && renderLive.Contains("not resolved through the load order")
+              && !renderLive.Contains("the game does not load this file"));
+        Check("#271 render: a live file addressed by path says so positively — #269's symptom, inverted",
+              renderLive.Contains("the game loads this file"));
+        var renderUnticked = Wire.RenderPluginFile(rpfUntickedByName, 8000);
+        Check("#271 render: the mod-vs-plugin pairing is disambiguated in words, and carries the cause",
+              renderUnticked.Contains("mod 'DiffUnticked' (enabled)")
+              && renderUnticked.Contains("the game does NOT load this file")
+              && renderUnticked.Contains("UNTICKED in plugins.txt"));
 
         // IDENTICAL — same plugin on both sides
         var dSame = svc.DiffRecord(wFid, replName, replName, null);

--- a/src/housecarl-generator/BulkPrimitivesWave3Probe.cs
+++ b/src/housecarl-generator/BulkPrimitivesWave3Probe.cs
@@ -31,6 +31,15 @@ public static class BulkPrimitivesWave3Probe
         if (ok) _pass++; else _fail++;
     }
 
+    /// <summary>Non-overlapping occurrences of <paramref name="needle"/> — a rendered label appearing TWICE is a real
+    /// output defect that a Contains() check reads as a pass.</summary>
+    static int CountOf(string haystack, string needle)
+    {
+        int n = 0, i = 0;
+        while ((i = haystack.IndexOf(needle, i, StringComparison.Ordinal)) >= 0) { n++; i += needle.Length; }
+        return n;
+    }
+
     public static int RunGuard(string[] args)
     {
         _pass = _fail = 0;
@@ -499,6 +508,17 @@ public static class BulkPrimitivesWave3Probe
         var uwFk = uw.FormKey;
         unMod.BeginWrite.ToPath(untickedPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
 
+        // UNREGISTERED plugin: sole copy, in an ENABLED mod folder, and therefore the SERVED copy — but MO2 has not
+        // written it into loadorder.txt/plugins.txt at all (a mod installed, or a patch written, before the refresh).
+        // Serves + Unregistered is a distinct pair from Serves + Unticked: nothing to tick, the remedy is a refresh.
+        var unregKey = new ModKey("HcW3Unregistered", ModType.Plugin);
+        var unregPath = Path.Combine(mods, "DiffUnregistered", unregKey.FileName.String);
+        Directory.CreateDirectory(Path.GetDirectoryName(unregPath)!);
+        var unregMod = new SkyrimMod(unregKey, SkyrimRelease.SkyrimSE);
+        var urw = unregMod.Weapons.AddNew(); urw.EditorID = "UnregW"; urw.BasicStats = new WeaponBasicStats { Damage = 33 };
+        var urwFk = urw.FormKey;
+        unregMod.BeginWrite.ToPath(unregPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
         // ARCHIVE backup: the SAME filename as the active replacer (55), parked OUTSIDE every MO2/game root — the
         // old-version-vs-live diff (#269's reporter's actual job). Same name, different file: it must stay off-order.
         var archivePath = Path.Combine(dir, "archive", rKey.FileName.String);
@@ -510,12 +530,16 @@ public static class BulkPrimitivesWave3Probe
         // The Data-served plugin is CHECKED and in the order: its arm isolates WHICH COPY is served, so its tick state
         // must not be the thing that decides it (leave it unticked and the tick gate answers first, and the
         // served-copy rule goes untested).
+        // HcW3Ghost.esp is TICKED and in the order but exists in NO folder — the stale-profile state (MO2 rewrote the
+        // profile, then the mod was removed). It is the one case the explainer must NOT answer with "unticked".
+        const string ghostName = "HcW3Ghost.esp";
         File.WriteAllText(Path.Combine(profiles, "loadorder.txt"),
-            "# header\r\n" + mKey.FileName + "\r\n" + dsKey.FileName + "\r\n" + rKey.FileName + "\r\n");
-        // plugins.txt: master + Data-served + replacer CHECKED; HcW3Unticked listed WITHOUT the `*` (present but unchecked).
+            "# header\r\n" + mKey.FileName + "\r\n" + dsKey.FileName + "\r\n" + rKey.FileName + "\r\n" + ghostName + "\r\n");
+        // plugins.txt: master + Data-served + replacer + ghost CHECKED; HcW3Unticked listed WITHOUT the `*` (present but
+        // unchecked). HcW3Unregistered is in NEITHER file — its mod folder is enabled, but MO2 has never seen the plugin.
         File.WriteAllText(Path.Combine(profiles, "plugins.txt"),
-            "*" + mKey.FileName + "\r\n*" + dsKey.FileName + "\r\n*" + rKey.FileName + "\r\n" + unKey.FileName + "\r\n");
-        File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+DiffRepl\r\n+DiffReplShadow\r\n+DiffMaster\r\n+DiffUnticked\r\n-DiffDonor\r\n-DataServedDecoy\r\n");
+            "*" + mKey.FileName + "\r\n*" + dsKey.FileName + "\r\n*" + rKey.FileName + "\r\n" + unKey.FileName + "\r\n*" + ghostName + "\r\n");
+        File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+DiffRepl\r\n+DiffReplShadow\r\n+DiffMaster\r\n+DiffUnticked\r\n+DiffUnregistered\r\n-DiffDonor\r\n-DataServedDecoy\r\n");
 
         var genDir = Path.Combine(dir, "corpus-gen");
         try { _ = CorpusRulebook.LoadCorpus(); }
@@ -668,6 +692,20 @@ public static class BulkPrimitivesWave3Probe
               renderUnticked.Contains("mod 'DiffUnticked' (enabled)")
               && renderUnticked.Contains("the game does NOT load this file")
               && renderUnticked.Contains("UNTICKED in plugins.txt"));
+        // The FILENAME lane's Where is the located hit's OWN label, so a LayerOff cause that restates the layer says
+        // the same thing twice in one sentence — output strictly worse than the "NOT active" it replaced. The path-lane
+        // arms above cannot catch it: their Where is the constant "direct path", where the restatement is the only way
+        // the layer gets named at all. Armed on the lane where the bug can actually appear (review of PR #274).
+        var rpfDisabledByName = svc.ReadPluginFile(dKey.FileName.String, wFid, null, null, null, 1, null, 10);
+        var renderDisabledByName = Wire.RenderPluginFile(rpfDisabledByName, 8000);
+        Check("#271 render: a disabled-mod copy BY FILENAME names its layer exactly once, not twice",
+              rpfDisabledByName.Error is null
+              && CountOf(renderDisabledByName, "mod 'DiffDonor' (DISABLED)") == 1
+              && renderDisabledByName.Contains("the game does NOT load this file"));
+        // ...while the PATH lane, whose Where is "direct path", must STILL name the layer — dropping the restatement
+        // outright would lose the only mention of which mod provides the file.
+        Check("#271 render: the same copy BY PATH still names the layer, since its Where cannot",
+              rpfDecoy.WhyNotActive is { } wD2 && wD2.Contains("DataServedDecoy"));
 
         // ---- #271 item 2: the REFUSAL sweep. A tool that reads THROUGH the load order still refuses on an unticked
         //      plugin (correctly — Q3: a plugin the game does not load must never masquerade as load-order truth), but
@@ -687,6 +725,70 @@ public static class BulkPrimitivesWave3Probe
         var readTypo = svc.ResolveRead(wFk, "HcW3DiffRep.esp", null, false);   // a real near-miss: one character dropped
         Check("#271 refusal: a genuine typo still gets the did-you-mean (the explainer adds, never removes)",
               readTypo.Error is { } eT && eT.Contains("Did you mean") && eT.Contains(replName));
+        // Once a concrete cause IS stated, the legacy "houseCARL does not open disabled plugins off disk" tail
+        // contradicts the escape-hatch sentence right before it; it survives only where nothing could be explained.
+        Check("#271 refusal: the explained case drops the generic posture tail, the unexplained one keeps it",
+              readUnticked.Error is { } eU3 && !eU3.Contains("does not open disabled")
+              && readTypo.Error is { } eT2 && eT2.Contains("does not open disabled"));
+
+        // Serves + Unregistered: the served copy of a plugin MO2 has never written into its profile. Distinct from
+        // unticked (there is nothing to untick) and from a switched-off mod (the folder is on), so it must say neither.
+        string urwFid = $"{urwFk.ID:X6}:{urwFk.ModKey.FileName}";
+        var rpfUnreg = svc.ReadPluginFile(unregKey.FileName.String, urwFid, null, null, null, 1, null, 10);
+        Check("#271 why: the SERVED copy of an unregistered plugin says so, blaming neither the tick nor the mod",
+              rpfUnreg.Error is null && !rpfUnreg.Enabled && rpfUnreg.WhyNotActive is { } wR
+              && wR.Contains("not registered in MO2's load order") && !wR.Contains("UNTICKED")
+              && !wR.Contains("which the game does not load"));
+        // The explainer's stale-profile branch: TICKED, but no layer provides the file. "Unticked" would be a lie and
+        // "not on disk anywhere" is the actual remedy-bearing fact.
+        var readGhost = svc.ResolveRead(wFk, ghostName, null, false);
+        Check("#271 refusal: a ticked-but-missing plugin is called stale-profile, never unticked",
+              readGhost.Error is { } eG && eG.Contains("ticked in plugins.txt") && eG.Contains("stale")
+              && !eG.Contains("UNTICKED"));
+
+        // The overclaim SWEEP. "the game does not load this file" is an assertion about the FILE that had lodged in
+        // places describing the READ — and fixing the banner alone left it live in read_plugin_file's own tool
+        // DESCRIPTION (where the model meets it before any output) and in copy_npc_appearance's donor bracket, both
+        // found by review. That is the "fixed the reported site, missed the rule's other lanes" shape #270 kept
+        // repeating, so this arm sweeps the WHOLE shipped surface by reflection rather than the two sites that were
+        // reported. A tool description added tomorrow with the same sentence turns CI red.
+        const string overclaim = "the game does not load this file";
+        var descs = typeof(HousecarlMcp.ReadTools).Assembly.GetTypes()
+            .SelectMany(t => t.GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic
+                                          | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Instance
+                                          | System.Reflection.BindingFlags.DeclaredOnly))
+            .SelectMany(m => m.GetCustomAttributes(typeof(System.ComponentModel.DescriptionAttribute), false)
+                              .Cast<System.ComponentModel.DescriptionAttribute>()
+                              .Concat(m.GetParameters().SelectMany(p =>
+                                  p.GetCustomAttributes(typeof(System.ComponentModel.DescriptionAttribute), false)
+                                   .Cast<System.ComponentModel.DescriptionAttribute>())))
+            .Select(d => d.Description ?? "")
+            .ToList();
+        Check($"#271 sweep: no MCP tool/parameter description asserts the overclaim ({descs.Count} descriptions swept)",
+              descs.Count > 50 && !descs.Any(d => d.Contains(overclaim, StringComparison.OrdinalIgnoreCase)));
+
+        // The third renderer named by the issue. Its bracket is gated on a flag the file lane sets UNCONDITIONALLY, so
+        // it asserted the overclaim even for a donor the game does load — armed here through the real render.
+        var npcRender = NpcCopyTools.Render(new NpcCopyOutcome(
+            true, null, "apply", wFk, "file 'X.esp' (mod 'M' (enabled))", /*DonorOutOfLoadOrder:*/ true, wFk,
+            "X.esp", false, Array.Empty<InternalizedRecord>(), Array.Empty<string>(), 0, Array.Empty<string>(),
+            Array.Empty<NpcAppearanceCopy.StripReport>(), Array.Empty<string>(), false, false,
+            Array.Empty<string>(), null, 0, null));
+        Check("#271 sweep: copy_npc_appearance's donor bracket states the READ, not a claim about the file",
+              !npcRender.Contains(overclaim, StringComparison.OrdinalIgnoreCase)
+              && npcRender.Contains("OUT-OF-LOAD-ORDER"));
+
+        // A SECOND refusal lane. All the arms above ride ResolveRead, and every other site got the same clause with no
+        // coverage — which is why a dropped space in merge_plugins' refusal shipped unnoticed (review of PR #274).
+        // Rendering the whole message, not just the clause, is the point: this arm exists to read the sentence.
+        // Two donors minimum; the unticked one is named first so its refusal is the one that fires.
+        var mergeUnticked = svc.MergePlugins(new[] { unKey.FileName.String, replName }, "HcW3MergeOut.esp");
+        Check("#271 refusal: merge_plugins explains an UNTICKED donor rather than a flat not-active",
+              !mergeUnticked.Success && mergeUnticked.Error is { } eM && eM.Contains("UNTICKED")
+              && eM.Contains("plugins.txt"));
+        Check("#271 refusal: and the merge refusal reads as whole words (no lost space at the splice)",
+              mergeUnticked.Error is { } eM2 && eM2.Contains("records and conflict position from the ACTIVE order")
+              && !eM2.Contains("conflictposition"));
 
         // IDENTICAL — same plugin on both sides
         var dSame = svc.DiffRecord(wFid, replName, replName, null);

--- a/src/housecarl-generator/BulkPrimitivesWave3Probe.cs
+++ b/src/housecarl-generator/BulkPrimitivesWave3Probe.cs
@@ -736,6 +736,11 @@ public static class BulkPrimitivesWave3Probe
         // cannot tell them apart — the standing is decided from modlist.txt membership instead.
         string ulwFid = $"{ulwFk.ID:X6}:{ulwFk.ModKey.FileName}";
         var rpfUnlisted = svc.ReadPluginFile(unlKey.FileName.String, ulwFid, null, null, null, 1, null, 10);
+        // The layer LABEL must not carry a remedy of its own, or the rendered line instructs twice — the same
+        // duplication class, one step milder. Only the cause line explains (live-check finding, #274).
+        Check("#271 render: an UNLISTED layer's label identifies only; the remedy is stated exactly once",
+              rpfUnlisted.Error is null && Wire.RenderPluginFile(rpfUnlisted, 4000) is { } rUnl
+              && CountOf(rUnl, "refresh MO2") == 1 && rUnl.Contains("(UNLISTED)"));
         Check("#271 why: a DISABLED mod says switch it on; an UNLISTED folder says refresh — never swapped",
               rpfDisabledByName.WhyNotActive is { } wDis && wDis.Contains("switched OFF") && wDis.Contains("switch it on")
               && rpfUnlisted.Error is null && rpfUnlisted.WhyNotActive is { } wUn

--- a/src/housecarl-generator/BulkPrimitivesWave3Probe.cs
+++ b/src/housecarl-generator/BulkPrimitivesWave3Probe.cs
@@ -669,6 +669,25 @@ public static class BulkPrimitivesWave3Probe
               && renderUnticked.Contains("the game does NOT load this file")
               && renderUnticked.Contains("UNTICKED in plugins.txt"));
 
+        // ---- #271 item 2: the REFUSAL sweep. A tool that reads THROUGH the load order still refuses on an unticked
+        //      plugin (correctly — Q3: a plugin the game does not load must never masquerade as load-order truth), but
+        //      the refusal has to say WHY. This is a second mechanism from the flag above: these paths never call the
+        //      locate contract at all, they just miss the index's name table. ----
+        var readUnticked = svc.ResolveRead(uwFk, unKey.FileName.String, null, false);
+        Check("#271 refusal: read_record on an UNTICKED plugin explains it is installed-but-unticked, not 'not found'",
+              readUnticked.Error is { } eU && eU.Contains("not in the load order") && eU.Contains("UNTICKED")
+              && eU.Contains("plugins.txt"));
+        Check("#271 refusal: and points at the raw-read escape hatch rather than leaving a dead end",
+              readUnticked.Error is { } eU2 && eU2.Contains("housecarl_read_plugin_file"));
+        var readDisabledMod = svc.ResolveRead(wFk, dKey.FileName.String, null, false);
+        Check("#271 refusal: a plugin whose MOD is switched off says so — a different cause, a different remedy",
+              readDisabledMod.Error is { } eD && eD.Contains("DiffDonor") && eD.Contains("not active"));
+        // The fallback must survive: a name that explains nothing still gets the did-you-mean it always got. The
+        // explainer REPLACES the suggester only when it has something real to say.
+        var readTypo = svc.ResolveRead(wFk, "HcW3DiffRep.esp", null, false);   // a real near-miss: one character dropped
+        Check("#271 refusal: a genuine typo still gets the did-you-mean (the explainer adds, never removes)",
+              readTypo.Error is { } eT && eT.Contains("Did you mean") && eT.Contains(replName));
+
         // IDENTICAL — same plugin on both sides
         var dSame = svc.DiffRecord(wFid, replName, replName, null);
         Check("diff same plugin both sides → identical (0 deltas, complete)", dSame.Error is null && dSame.Diff!.Deltas.Count == 0 && dSame.Diff.Complete);

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -514,7 +514,8 @@ static class JsonWire
                 w.WriteBoolean("enabled", o.Enabled);
                 // The JSON lane surfaces this state too, so it gets the cause as well (#271) — a consumer reading
                 // enabled=false here would otherwise have to go re-derive WHY, which is the whole cost this fixes.
-                // Emitted only when there IS one, so `why_not_active` absent == the game loads this file.
+                // Always PRESENT, explicitly null when the game loads the file (the WriteNullable house style), so a
+                // consumer can tell "no cause" from "field not emitted by an older build".
                 WriteNullable(w, "why_not_active", o.WhyNotActive);
                 WriteStringArray(w, "masters", o.Masters);
                 WriteStringArray(w, "missing_masters", o.MissingMasters);

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -512,6 +512,10 @@ static class JsonWire
                 WriteNullable(w, "file", o.FilePath);
                 WriteNullable(w, "where", o.Where);
                 w.WriteBoolean("enabled", o.Enabled);
+                // The JSON lane surfaces this state too, so it gets the cause as well (#271) — a consumer reading
+                // enabled=false here would otherwise have to go re-derive WHY, which is the whole cost this fixes.
+                // Emitted only when there IS one, so `why_not_active` absent == the game loads this file.
+                WriteNullable(w, "why_not_active", o.WhyNotActive);
                 WriteStringArray(w, "masters", o.Masters);
                 WriteStringArray(w, "missing_masters", o.MissingMasters);
                 WriteStringArray(w, "inactive_masters", o.InactiveMasters);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2252,7 +2252,9 @@ public sealed class LoadOrderService : IDisposable
             if (rec is null)
                 return (null, null, $"file '{plugin}' (OUT-OF-LOAD-ORDER, {loc.Where}) does not define or override {fk} — no version to diff.");
             return (ReadEngine.ReadFields(rec, fields, ConflictDiffDepth),   // materialised here → the overlay can close
-                    new DiffPole(plugin, $"OUT-OF-LOAD-ORDER ({loc.Where}{(loc.Enabled ? "" : ", disabled")})", false,
+                    // "disabled" was the wrong word twice over: a MOD is disabled, a PLUGIN is inactive — and the one
+                    // word covered four causes with four different remedies. Name the cause the locate already knows.
+                    new DiffPole(plugin, $"OUT-OF-LOAD-ORDER ({loc.Where}{(loc.WhyNotActive is { } why ? $"; NOT active — {why}" : "")})", false,
                                  RecordNaming.StripOverlay(rec.GetType().Name), rec.EditorID), null);
         }
         finally { (ov as IDisposable)?.Dispose(); }
@@ -3689,7 +3691,7 @@ public sealed class LoadOrderService : IDisposable
             {
                 if (!view.ContainsPlugin(d))
                     return WritePatchBuilder.MergeOutcome.Fail(
-                        $"donor '{d}' is not an active plugin in your load order — merge reads each donor's records and conflict " +
+                        $"donor '{d}' is not an active plugin in your load order — merge reads each donor's records and conflict" +
                         "position from the ACTIVE order. Enable it in MO2 first (pass the exact filename, e.g. 'CoolMod.esp').");
                 if (view.ExcludedPlugins.TryGetValue(d, out var excluded))
                     return WritePatchBuilder.MergeOutcome.Fail(
@@ -3898,7 +3900,9 @@ public sealed class LoadOrderService : IDisposable
                     if (loc.Error is not null) return NpcCopyOutcome.Fail(loc.Error);
                     if (loc.Ambiguous is not null)
                         return NpcCopyOutcome.Fail($"'{sp}' exists in {loc.Ambiguous.Count} places ({string.Join(" | ", loc.Ambiguous.Select(h => h.Where))}) — pass source_mod= to pick one.");
-                    static string Located(PluginLocateResult l) => $"{l.Where}{(l.Enabled ? "" : ", DISABLED")}";
+                    // Same vocabulary fix as the diff pole: the donor line said ", DISABLED" for an unticked or shadowed
+                    // donor whose mod is perfectly enabled. State the cause the locate contract computed (#271).
+                    static string Located(PluginLocateResult l) => $"{l.Where}{(l.WhyNotActive is { } why ? $"; NOT active — {why}" : "")}";
                     static NpcAppearanceCopy.DonorFetch CacheFetch(Mutagen.Bethesda.Plugins.Cache.ILinkCache c) =>
                         fk2 => { try { return c.TryResolve(fk2, out var b) ? b : null; } catch { return null; } };
 
@@ -5182,7 +5186,7 @@ public sealed class LoadOrderService : IDisposable
         var loc = LocatePluginFileOnDisk(comp, modsDir, dataDir, overwriteDir, plugin, mod);
         if (loc.Error is not null) return PluginFileOutcome.Fail(plugin, loc.Error);
         if (loc.Ambiguous is not null) return PluginFileOutcome.AmbiguousHits(plugin, loc.Ambiguous);
-        string path = loc.Path!, where = loc.Where; bool enabled = loc.Enabled;
+        string path = loc.Path!, where = loc.Where; bool enabled = loc.Enabled; string? whyNotActive = loc.WhyNotActive;
 
         // Open OUR OWN overlay (OpenOverlay wires localized-string resolution), read, then DISPOSE — zero handles at rest.
         ISkyrimModGetter ov;
@@ -5211,7 +5215,7 @@ public sealed class LoadOrderService : IDisposable
             }
             var baseOut = new PluginFileOutcome
             {
-                Requested = plugin, FilePath = path, Where = where, Enabled = enabled,
+                Requested = plugin, FilePath = path, Where = where, Enabled = enabled, WhyNotActive = whyNotActive,
                 Masters = masters, MissingMasters = missing, InactiveMasters = inactive,
             };
 
@@ -5280,9 +5284,123 @@ public sealed class LoadOrderService : IDisposable
         finally { (ov as IDisposable)?.Dispose(); }
     }
 
-    /// <summary>One located plugin file, or why not. Exactly one of Path / Ambiguous / Error is set.</summary>
+    /// <summary>Is a located file the copy the MO2 install SERVES for its filename — and if not, WHY not? One half of
+    /// "does the game load this file"; the other is <see cref="TickStanding"/>. The two are INDEPENDENT: a copy can be
+    /// both shadowed and unticked, and each has its own remedy, so collapsing them to one cause would always drop one
+    /// (#271). NotAnInstallCopy is deliberately the zero value: a default-constructed result must read NOT-loaded, never
+    /// accidentally loaded.</summary>
+    internal enum ServedStanding
+    {
+        /// <summary>The path is outside every install root, or no MO2 layer provides this exact file (a backup, an
+        /// arbitrary path, or a copy reached through a junction the string compare can't match).</summary>
+        NotAnInstallCopy = 0,
+        /// <summary>THIS file is the copy the install serves — the first hit from an enabled layer.</summary>
+        Serves,
+        /// <summary>This copy's own layer is enabled, but a HIGHER-priority layer provides the same filename, so the
+        /// game loads that one instead. Remedy: raise this mod's priority, or address the copy that wins.</summary>
+        Shadowed,
+        /// <summary>This copy sits in a layer the real order never consults — a DISABLED mod folder, or one MO2 has not
+        /// registered yet. Remedy: switch the mod on, or refresh MO2.</summary>
+        LayerOff,
+    }
+
+    /// <summary>Is a plugin FILENAME ticked to load — the other half of "does the game load this file". A plugin's tick
+    /// state is a DIFFERENT fact from its mod folder's switch (MO2's right pane vs its left), which is the confusion
+    /// this split exists to end. Unregistered is the zero value for the same conservative-default reason as
+    /// <see cref="ServedStanding"/>.</summary>
+    internal enum TickStanding
+    {
+        /// <summary>plugins.txt and loadorder.txt do not mention this filename at all — MO2 has not registered it.</summary>
+        Unregistered = 0,
+        /// <summary>`*`-prefixed in plugins.txt — checked.</summary>
+        Ticked,
+        /// <summary>A base-game/CC master: force-loaded and never listed in plugins.txt, so absence there means loaded,
+        /// not unloaded.</summary>
+        Implicit,
+        /// <summary>Listed in plugins.txt WITHOUT the `*` — present but unchecked. The game does not load it.</summary>
+        Unticked,
+    }
+
+    /// <summary>One located plugin file, or why not. Exactly one of Path / Ambiguous / Error is set.
+    /// <para>The two standings are carried SEPARATELY rather than pre-collapsed into one boolean, so a renderer can
+    /// EXPLAIN rather than merely classify (#271): "NOT active" names the state but not the cause, and the causes —
+    /// unticked, mod switched off, shadowed, unregistered — have different remedies. <see cref="Enabled"/> keeps the
+    /// single "the game loads this file" boolean every existing consumer reads, now derived rather than stored.</para></summary>
     internal readonly record struct PluginLocateResult(
-        string? Path, string Where, bool Enabled, IReadOnlyList<PluginFileHit>? Ambiguous, string? Error);
+        string? Path, string Where, ServedStanding Served, TickStanding Tick, string? CauseDetail,
+        IReadOnlyList<PluginFileHit>? Ambiguous, string? Error)
+    {
+        /// <summary>The game loads THIS file: it is the served copy AND its plugin is ticked (implicit masters count —
+        /// force-loaded, never listed). Both halves, or the same physical file answers differently depending on how it
+        /// was addressed.</summary>
+        public bool Enabled => Served == ServedStanding.Serves && Tick is TickStanding.Ticked or TickStanding.Implicit;
+
+        /// <summary>WHY the game does not load this file — null exactly when <see cref="Enabled"/>. Composed HERE, once,
+        /// so the three renderers that state this (read_plugin_file's header, diff_record's off-order pole,
+        /// copy_npc_appearance's donor line) cannot drift apart on the wording; the shared locate contract exists
+        /// because an inline copy had already diverged on this very flag. Both clauses are emitted when both apply —
+        /// a shadowed copy of an unticked plugin needs two fixes, and naming one would send the reader to do half the
+        /// job. The unregistered clause is suppressed when the served half already failed: "in a DISABLED mod" explains
+        /// the absence from plugins.txt, and repeating it as a second cause reads as a second problem.</summary>
+        public string? WhyNotActive
+        {
+            get
+            {
+                if (Enabled || Path is null) return null;
+                var name = System.IO.Path.GetFileName(Path);
+                var parts = new List<string>(2);
+                switch (Served)
+                {
+                    case ServedStanding.Shadowed:
+                        parts.Add(CauseDetail is null
+                            ? "this is not the copy the install serves for this filename"
+                            : $"this copy is SHADOWED — {CauseDetail} provides the copy the game loads");
+                        break;
+                    case ServedStanding.LayerOff:
+                        parts.Add($"it is provided by {CauseDetail}, which the game does not load");
+                        break;
+                    case ServedStanding.NotAnInstallCopy:
+                        parts.Add("this file is not a copy the MO2 install provides");
+                        break;
+                }
+                if (Tick == TickStanding.Unticked)
+                    parts.Add($"'{name}' is UNTICKED in plugins.txt (MO2's right pane)");
+                else if (Tick == TickStanding.Unregistered && Served == ServedStanding.Serves)
+                    parts.Add($"'{name}' is not registered in MO2's load order (refresh MO2 to pick it up)");
+                return parts.Count == 0 ? null : string.Join("; and ", parts);
+            }
+        }
+    }
+
+    /// <summary>Judge the SERVED half for one located file: is <paramref name="fullPath"/> the copy the install provides
+    /// for its filename, and if not, which of the three distinct not-served states is it? Judged against the first hit
+    /// from an ENABLED layer — precisely the rule <see cref="Mo2LoadOrder.BuildFilenameMap"/> uses to build the real
+    /// order. NOT merely the first hit: <see cref="Mo2LoadOrder.LocatePlugin"/> also walks disabled and unlisted folders
+    /// that the order never consults. Compared by FULL PATH — a backup and the live copy share a filename and are
+    /// different files.</summary>
+    static (ServedStanding Served, string? Detail) JudgeServed(IReadOnlyList<PluginFileHit> located, string fullPath)
+    {
+        var served = located.FirstOrDefault(h => h.Enabled);
+        if (served is not null && SamePluginFile(served.Path, fullPath)) return (ServedStanding.Serves, null);
+        var own = located.FirstOrDefault(h => SamePluginFile(h.Path, fullPath));
+        if (own is null) return (ServedStanding.NotAnInstallCopy, null);          // outside the install, or unreachable by string compare
+        // Its own layer is off (disabled / unlisted) ⇒ name THAT layer — the remedy is about this copy. Its own layer is
+        // on but something else serves the name ⇒ shadowed, and the useful pointer is the copy that WINS, not this one.
+        return own.Enabled ? (ServedStanding.Shadowed, served?.Where) : (ServedStanding.LayerOff, own.Where);
+    }
+
+    /// <summary>Judge the TICK half for one plugin filename, from the profile text files. Kept beside
+    /// <see cref="JudgeServed"/> so the two halves can never be computed by different rules in different lanes — the
+    /// exact divergence that cost #270 four review rounds.</summary>
+    static TickStanding JudgeTick(Mo2Composition comp, string fileName)
+    {
+        if (comp.ActivePluginNames.Contains(fileName)) return TickStanding.Ticked;
+        foreach (var x in comp.ImplicitPluginNames)
+            if (x.Equals(fileName, StringComparison.OrdinalIgnoreCase)) return TickStanding.Implicit;
+        foreach (var x in comp.InactivePluginNames)
+            if (x.Equals(fileName, StringComparison.OrdinalIgnoreCase)) return TickStanding.Unticked;
+        return TickStanding.Unregistered;
+    }
 
     /// <summary>THE on-disk plugin-locate contract, shared by read_plugin_file and the copy-npc-appearance donor
     /// lane (review finding: a second inline copy had already diverged — the mod= lane forgot the enabled flag). A
@@ -5294,62 +5412,54 @@ public sealed class LoadOrderService : IDisposable
         Mo2Composition comp, string modsDir, string dataDir, string overwriteDir, string plugin, string? mod)
     {
         // A plugin's TICK state is a DIFFERENT fact from its mod folder's switch: a plugin can sit in an enabled mod
-        // and be unchecked in MO2's right pane, and the game then does not load it. Every lane below returns a flag
-        // the renderers state as "active" / "NOT active", so the flag has to mean "the game loads THIS file" — which
-        // needs both halves: the file is the copy the install serves, AND the plugin is ticked. Implicit base/CC
-        // masters are force-loaded and never listed in plugins.txt, so they count as ticked. This is the same test
-        // read_plugin_file already applies to a file's declared MASTERS, now applied to the file itself (#271).
-        bool Ticked(string fileName) =>
-            comp.ActivePluginNames.Contains(fileName)
-            || comp.ImplicitPluginNames.Any(x => x.Equals(fileName, StringComparison.OrdinalIgnoreCase));
-
+        // and be unchecked in MO2's right pane, and the game then does not load it. Every lane below returns the pair
+        // (served, tick) the renderers state as "active" / "NOT active — <why>", so BOTH halves are judged in every
+        // lane, by the SAME two helpers (JudgeServed / JudgeTick) — a lane computing one of them its own way is the
+        // divergence that cost #270 four review rounds. Implicit base/CC masters are force-loaded and never listed in
+        // plugins.txt, so they count as ticked. This is the same test read_plugin_file already applies to a file's
+        // declared MASTERS, now applied to the file itself, and carrying its cause (#271).
         if (LooksLikePath(plugin))
         {
-            if (!File.Exists(plugin)) return new(null, "", false, null, $"no file at path '{plugin}'.");
+            if (!File.Exists(plugin))
+                return new(null, "", ServedStanding.NotAnInstallCopy, TickStanding.Unregistered, null, null, $"no file at path '{plugin}'.");
             var full = Path.GetFullPath(plugin);
-            // Enabled is COMPUTED for a direct path, never assumed. Addressing a file BY PATH says nothing about
+            // The standing is COMPUTED for a direct path, never assumed. Addressing a file BY PATH says nothing about
             // whether the install provides it — a path can perfectly well name the live copy of an enabled plugin,
-            // and a hardcoded `false` here stamped that copy "disabled" (#269). The question the flag answers is
-            // "is THIS file the copy the install SERVES for this filename?", so it is judged against the first hit
-            // from an ENABLED layer — precisely the rule Mo2LoadOrder.BuildFilenameMap uses to build the real order
-            // (overwrite → enabled mods by priority → game Data). NOT merely the first hit: LocatePlugin also walks
-            // disabled and unlisted folders, which the order never consults, so a vanilla plugin served from Data
-            // while some DISABLED mod happens to hold the same filename would judge itself against that disabled
-            // copy and stamp the LIVE plugin inactive — #269's own symptom, reintroduced. Nor any matching hit: a
-            // copy in a LOWER-priority enabled mod is shadowed, and its folder being enabled says nothing about
-            // whether the game loads THAT file. Compared by
-            // FULL PATH — an archived backup and the live copy share a filename and are different files. Two costs
-            // accepted: this pays the same folder sweep the filename lane does (one stat per candidate folder), which
-            // is why a path no install root contains skips it outright; and a path reaching the install through a
-            // junction/symlink won't string-match, so it stays flagged not-enabled — the pre-fix answer, conservative
-            // in the same direction rather than newly wrong in the other.
+            // and a hardcoded `false` here stamped that copy "disabled" (#269). JudgeServed answers "is THIS file the
+            // copy the install SERVES?" against the first ENABLED-layer hit; see its own doc for why neither the first
+            // hit nor any matching hit is the right comparand. Two costs accepted: this pays the same folder sweep the
+            // filename lane does (one stat per candidate folder), which is why a path no install root contains skips it
+            // outright; and a path reaching the install through a junction/symlink won't string-match, so it reads as
+            // NotAnInstallCopy — the pre-fix answer, conservative in the same direction rather than newly wrong in the
+            // other. The tick half needs no path at all, so it is judged for EVERY direct path, junction or not.
+            var fnPath = Path.GetFileName(full);
             var located = IsUnderAnyInstallRoot(full, modsDir, dataDir, overwriteDir)   // outside every root ⇒ can't be the install's copy; skip the scan
-                ? Mo2LoadOrder.LocatePlugin(comp, modsDir, dataDir, overwriteDir, Path.GetFileName(full))
+                ? Mo2LoadOrder.LocatePlugin(comp, modsDir, dataDir, overwriteDir, fnPath)
                 : Array.Empty<PluginFileHit>();
-            var served = located.FirstOrDefault(h => h.Enabled);
-            bool isServedCopy = served is not null && SamePluginFile(served.Path, full);
-            return new(full, "direct path", isServedCopy && Ticked(Path.GetFileName(full)), null, null);
+            var (servedStanding, detail) = JudgeServed(located, full);
+            return new(full, "direct path", servedStanding, JudgeTick(comp, fnPath), detail, null, null);
         }
         if (!string.IsNullOrWhiteSpace(mod))
         {
             var fn = Path.GetFileName(plugin);
             var cand = Path.Combine(modsDir, mod.Trim(), fn);
-            if (!File.Exists(cand)) return new(null, "", false, null, $"mod folder '{mod.Trim()}' under ModsDir does not provide '{fn}'.");
+            if (!File.Exists(cand))
+                return new(null, "", ServedStanding.NotAnInstallCopy, TickStanding.Unregistered, null, null,
+                           $"mod folder '{mod.Trim()}' under ModsDir does not provide '{fn}'.");
             // Both halves here too, or the same physical file answers differently depending on how it was addressed.
             // "The named mod is enabled" is NOT enough: a lower-priority enabled mod's copy is shadowed, and the game
-            // loads the serving copy instead. Being the served hit subsumes the enabled-folder test — the served hit
-            // is by definition drawn from an enabled layer.
-            var servedForName = Mo2LoadOrder.LocatePlugin(comp, modsDir, dataDir, overwriteDir, fn)
-                                            .FirstOrDefault(h => h.Enabled);
-            bool candIsLive = servedForName is not null && SamePluginFile(servedForName.Path, cand) && Ticked(fn);
-            return new(cand, $"mod '{mod.Trim()}'", candIsLive, null, null);
+            // loads the serving copy instead.
+            var (modServed, modDetail) = JudgeServed(
+                Mo2LoadOrder.LocatePlugin(comp, modsDir, dataDir, overwriteDir, fn), cand);
+            return new(cand, $"mod '{mod.Trim()}'", modServed, JudgeTick(comp, fn), modDetail, null, null);
         }
         var hits = Mo2LoadOrder.LocatePlugin(comp, modsDir, dataDir, overwriteDir, plugin);
         if (hits.Count == 0)
-            return new(null, "", false, null,
+            return new(null, "", ServedStanding.NotAnInstallCopy, TickStanding.Unregistered, null, null,
                 $"'{Path.GetFileName(plugin)}' is in no mod folder (enabled, disabled, or not-yet-listed in MO2), the overwrite folder, or the game Data folder. Check the filename, pass an absolute path, or (if it's an MO2 mod) the exact folder via mod=.");
-        if (hits.Count > 1) return new(null, "", false, hits, null);
-        return new(hits[0].Path, hits[0].Where, hits[0].Enabled && Ticked(Path.GetFileName(plugin)), null, null);
+        if (hits.Count > 1) return new(null, "", ServedStanding.NotAnInstallCopy, TickStanding.Unregistered, null, hits, null);
+        var (oneServed, oneDetail) = JudgeServed(hits, hits[0].Path);
+        return new(hits[0].Path, hits[0].Where, oneServed, JudgeTick(comp, Path.GetFileName(plugin)), oneDetail, null, null);
     }
 
     /// <summary>Does the user's `plugin` argument denote a PATH (use verbatim — the "inspect any file" case) rather
@@ -5521,6 +5631,10 @@ public sealed record PluginFileOutcome
     public string? FilePath { get; init; }
     public string? Where { get; init; }
     public bool Enabled { get; init; }
+    /// <summary>WHY the game does not load this file — null exactly when <see cref="Enabled"/>. Composed once by the
+    /// shared locate contract (<see cref="LoadOrderService.PluginLocateResult.WhyNotActive"/>) so every renderer of this
+    /// state says the same thing; naming the CAUSE is what lets a reader act without re-deriving it (#271).</summary>
+    public string? WhyNotActive { get; init; }
     public IReadOnlyList<string> Masters { get; init; } = Array.Empty<string>();
     public IReadOnlyList<string> MissingMasters { get; init; } = Array.Empty<string>();     // declared but installed NOWHERE
     public IReadOnlyList<string> InactiveMasters { get; init; } = Array.Empty<string>();    // installed but NOT active (disabled/unchecked)

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -137,7 +137,7 @@ public sealed class LoadOrderService : IDisposable
                             $"No active plugins resolved from the MO2 profile. ProfileDir='{_profileDir}', " +
                             $"ModsDir='{_modsDir}', DataDir='{_dataDir}'. {order.Warnings.Count} warning(s). Check " +
                             "HouseCarl config and that MO2 has written loadorder.txt/modlist.txt (a refresh/re-sort in MO2).");
-                    _resolver = LoadOrderResolver.Build(paths, PluginAbsenceExplainer(_profileDir, _modsDir, _dataDir, _overwriteDir));
+                    _resolver = LoadOrderResolver.Build(paths, ExplainPluginAbsence);
                     _resolvedPaths = paths;
                     _profileMtimes = profileMtimes;
                 }
@@ -213,13 +213,19 @@ public sealed class LoadOrderService : IDisposable
     /// then reads exactly as it did before (a did-you-mean).
     /// <para>Reads the profile FRESH on each call rather than closing over a parsed composition: the composition is a
     /// cheap three-file text parse, this runs only on a REFUSAL (never on a hot path), and a stale answer here would be
-    /// the precise failure this whole issue is about — telling someone a plugin is unticked after they ticked it. The
-    /// roots are captured by value at build time; they cannot change without the service rebuilding anyway.</para>
+    /// the precise failure this whole issue is about — telling someone a plugin is unticked after they ticked it.</para>
+    /// <para>The ROOTS are read live from the service's own fields for the same reason, NOT captured when the resolver
+    /// was built: a profile switch reassigns them (RederiveIfIniChanged) but only rebuilds the resolver when the
+    /// resolved PATH LIST changed, so two profiles with identical active sets and different UNTICKED lists would leave
+    /// a captured closure reading the old profile's plugins.txt — answering "not registered" for a plugin that is
+    /// merely unticked, which is precisely the confusion this explainer exists to end (review of PR #274).</para>
     /// <para>Vocabulary is deliberate throughout: a MOD is enabled/disabled (MO2's left pane), a PLUGIN is
     /// active/inactive (its right pane). Conflating the two is what made the old output unreadable.</para></summary>
-    static Func<string, string?> PluginAbsenceExplainer(string profileDir, string modsDir, string dataDir, string overwriteDir)
-        => name =>
+    string? ExplainPluginAbsence(string name)
         {
+            // Snapshot the roots together under the gate so the four cannot be read across a mid-switch reassignment.
+            string profileDir, modsDir, dataDir, overwriteDir;
+            lock (_gate) { profileDir = _profileDir; modsDir = _modsDir; dataDir = _dataDir; overwriteDir = _overwriteDir; }
             if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(profileDir)) return null;
             var fn = Path.GetFileName(name.Trim());
             if (fn.Length == 0) return null;
@@ -254,11 +260,16 @@ public sealed class LoadOrderService : IDisposable
             if (hits.Length == 0) return null;           // nothing on disk by that name → a typo; let the suggester answer
 
             // On disk but the profile never mentions it: the mod is switched off, or MO2 hasn't registered it. Its
-            // layer label already carries which (and, for an unlisted folder, the refresh remedy).
+            // layer label already carries which (and, for an unlisted folder, the refresh remedy). The remedy is
+            // branched on that layer's own state — telling someone to switch on a mod that is ALREADY on (every hit
+            // enabled, so the plugin is merely unregistered) sends them to do the one thing that cannot help.
             var pick = hits.FirstOrDefault(h => !h.Enabled) ?? hits[0];
+            var remedy = pick.Enabled
+                ? "Refresh MO2 so it registers the plugin, then re-sort"
+                : "Switch the mod on in MO2 (or refresh MO2 if it is not registered yet) and re-sort";
             return $"'{fn}' is on disk in {pick.Where}, but MO2's load order does not list it, so it is not active. " +
-                   "Switch the mod on (or refresh MO2) and re-sort — or read the file as-is with housecarl_read_plugin_file.";
-        };
+                   $"{remedy} — or read the file as-is with housecarl_read_plugin_file.";
+        }
 
     AssetResolver BuildAssetResolverLocked()
     {
@@ -1803,7 +1814,7 @@ public sealed class LoadOrderService : IDisposable
                 // The rebuild must carry the explainer too, or a profile change (the very act that creates an unticked
                 // plugin) would silently drop every refusal back to the flat not-found — the exact "armed the reported
                 // lane, missed its twin" mistake #270 kept making.
-                var rebuilt = LoadOrderResolver.Build(paths, PluginAbsenceExplainer(_profileDir, _modsDir, _dataDir, _overwriteDir));
+                var rebuilt = LoadOrderResolver.Build(paths, ExplainPluginAbsence);
                 _resolver.Dispose();
                 _resolver = rebuilt;
             }
@@ -2070,17 +2081,31 @@ public sealed class LoadOrderService : IDisposable
         // patch). Name the true condition + the working verify paths instead. Aaron-decided Option A: houseCARL does
         // NOT read disabled plugins off disk (non-winner content masquerading as load-order truth is the Q3 hazard).
         if (plugin is not null && !view.ContainsPlugin(plugin))
+        {
+            // AbsenceClause subsumes the did-you-mean: it states the CAUSE when there is one (the plugin is installed
+            // but unticked / its mod is off) and falls back to the suggester when there isn't, so a real installed
+            // plugin is never answered with a spelling guess (#271).
+            // ExplainAbsence, NOT AbsenceClause: the latter returns a non-empty string for a typo too (the did-you-mean),
+            // so its length cannot tell "a cause was stated" from "a spelling was guessed" — and only the first should
+            // change the tail below.
+            var cause = view.ExplainAbsence(plugin);
+            var why = cause is not null ? " " + cause : view.NameSuggestion(plugin);
+            // The legacy tail explains the general POSTURE ("load-order truth only, does not open disabled plugins off
+            // disk") and pointed at the freshly-written-patch case as the likely reason. Once a specific cause has been
+            // stated — including the raw-read escape hatch — that generality reads as a contradiction of the sentence
+            // before it, so it is dropped in favour of the concrete answer (review of PR #274).
+            var tail = cause is not null
+                ? " If a prior write into this patch reported success, the edits DID land — do not re-issue them " +
+                  "(re-running list Adds would duplicate entries)."
+                : " houseCARL reads load-order truth only and does not open disabled " +
+                  "plugins off disk. If this is a freshly written houseCARL patch, it isn't enabled yet: enable + sort it in " +
+                  "MO2, then re-read. To verify a write BEFORE enabling, use the write call's own read-back " +
+                  "(full_readback=true returns the whole written record). If a prior write into this patch reported success, " +
+                  "the edits DID land — do not re-issue them (re-running list Adds would duplicate entries).";
             return ReadOutcome.Fail(fk,
                 $"Plugin '{plugin}' is not in the load order ({view.PluginCount} plugins; names match the plugin FILENAME " +
-                // AbsenceClause subsumes the did-you-mean: it states the CAUSE when there is one (the plugin is
-                // installed but unticked / its mod is off) and falls back to the suggester when there isn't, so a real
-                // installed plugin is never answered with a spelling guess (#271).
-                "incl. .esp/.esm, case-insensitively)." + view.AbsenceClause(plugin) +
-                " houseCARL reads load-order truth only and does not open disabled " +
-                "plugins off disk. If this is a freshly written houseCARL patch, it isn't enabled yet: enable + sort it in " +
-                "MO2, then re-read. To verify a write BEFORE enabling, use the write call's own read-back " +
-                "(full_readback=true returns the whole written record). If a prior write into this patch reported success, " +
-                "the edits DID land — do not re-issue them (re-running list Adds would duplicate entries).");
+                "incl. .esp/.esm, case-insensitively)." + why + tail);
+        }
 
         var winner = view.ResolveWinner(fk);
         if (winner is null)
@@ -3750,7 +3775,7 @@ public sealed class LoadOrderService : IDisposable
             {
                 if (!view.ContainsPlugin(d))
                     return WritePatchBuilder.MergeOutcome.Fail(
-                        $"donor '{d}' is not an active plugin in your load order.{view.AbsenceClause(d)} Merge reads each donor's records and conflict" +
+                        $"donor '{d}' is not an active plugin in your load order.{view.AbsenceClause(d)} Merge reads each donor's records and conflict " +
                         "position from the ACTIVE order. Enable it in MO2 first (pass the exact filename, e.g. 'CoolMod.esp').");
                 if (view.ExcludedPlugins.TryGetValue(d, out var excluded))
                     return WritePatchBuilder.MergeOutcome.Fail(
@@ -5394,7 +5419,8 @@ public sealed class LoadOrderService : IDisposable
         /// was addressed.</summary>
         public bool Enabled => Served == ServedStanding.Serves && Tick is TickStanding.Ticked or TickStanding.Implicit;
 
-        /// <summary>WHY the game does not load this file — null exactly when <see cref="Enabled"/>. Composed HERE, once,
+        /// <summary>WHY the game does not load this file — null when <see cref="Enabled"/>, and also when no file was
+        /// located at all (the error and ambiguous results, which no renderer of this state reaches). Composed HERE, once,
         /// so the three renderers that state this (read_plugin_file's header, diff_record's off-order pole,
         /// copy_npc_appearance's donor line) cannot drift apart on the wording; the shared locate contract exists
         /// because an inline copy had already diverged on this very flag. Both clauses are emitted when both apply —
@@ -5411,12 +5437,19 @@ public sealed class LoadOrderService : IDisposable
                 switch (Served)
                 {
                     case ServedStanding.Shadowed:
-                        parts.Add(CauseDetail is null
-                            ? "this is not the copy the install serves for this filename"
-                            : $"this copy is SHADOWED — {CauseDetail} provides the copy the game loads");
+                        // CauseDetail is always set here: JudgeServed returns Shadowed only when this copy's OWN layer
+                        // is enabled, which means a served hit exists to name.
+                        parts.Add($"this copy is SHADOWED — {CauseDetail} provides the copy the game loads");
                         break;
                     case ServedStanding.LayerOff:
-                        parts.Add($"it is provided by {CauseDetail}, which the game does not load");
+                        // Don't restate the layer when Where ALREADY named it: the filename lane's Where is the hit's
+                        // own label, so "mod 'X' (DISABLED) — ... it is provided by mod 'X' (DISABLED)" said the same
+                        // thing twice in one sentence, which is worse than the bare "NOT active" it replaced. The path
+                        // lane's Where is the constant "direct path" and genuinely needs the layer named — an exact
+                        // comparison tells the two apart without parsing either label.
+                        parts.Add(string.Equals(Where, CauseDetail, StringComparison.Ordinal)
+                            ? "that layer is not one the game loads"
+                            : $"it is provided by {CauseDetail}, which the game does not load");
                         break;
                     case ServedStanding.NotAnInstallCopy:
                         parts.Add("this file is not a copy the MO2 install provides");
@@ -5690,9 +5723,10 @@ public sealed record PluginFileOutcome
     public string? FilePath { get; init; }
     public string? Where { get; init; }
     public bool Enabled { get; init; }
-    /// <summary>WHY the game does not load this file — null exactly when <see cref="Enabled"/>. Composed once by the
-    /// shared locate contract (<see cref="LoadOrderService.PluginLocateResult.WhyNotActive"/>) so every renderer of this
-    /// state says the same thing; naming the CAUSE is what lets a reader act without re-deriving it (#271).</summary>
+    /// <summary>WHY the game does not load this file — null when <see cref="Enabled"/> (and on the error/ambiguous
+    /// outcomes, which carry no file). Composed once by the shared locate contract
+    /// (<see cref="LoadOrderService.PluginLocateResult.WhyNotActive"/>) so every renderer of this state says the same
+    /// thing; naming the CAUSE is what lets a reader act without re-deriving it (#271).</summary>
     public string? WhyNotActive { get; init; }
     public IReadOnlyList<string> Masters { get; init; } = Array.Empty<string>();
     public IReadOnlyList<string> MissingMasters { get; init; } = Array.Empty<string>();     // declared but installed NOWHERE

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -203,10 +203,6 @@ public sealed class LoadOrderService : IDisposable
         }
     }
 
-    /// <summary>Build the asset resolver from the current roots: discover the active BSAs (co-name + Skyrim.ini base
-    /// archives, VFS-resolved + ranked — <see cref="ArchiveDiscovery"/>) and read the enabled-mod priority list, both
-    /// from the same cheap static profile read the record path uses. The gamePath (for the game-dir Skyrim.ini fallback)
-    /// is DataDir's parent (DataDir = gamePath\Data). Caller holds <see cref="_gate"/>.</summary>
     /// <summary>The injected answer to "why is this plugin filename NOT in the active order?" — handed to every
     /// <see cref="LoadOrderResolver"/> this service builds, so a refusal names the cause and its remedy instead of a
     /// flat not-found the reader has to go re-derive (#271). Returns null when nothing can be said, and the refusal
@@ -222,55 +218,63 @@ public sealed class LoadOrderService : IDisposable
     /// <para>Vocabulary is deliberate throughout: a MOD is enabled/disabled (MO2's left pane), a PLUGIN is
     /// active/inactive (its right pane). Conflating the two is what made the old output unreadable.</para></summary>
     string? ExplainPluginAbsence(string name)
-        {
-            // Snapshot the roots together under the gate so the four cannot be read across a mid-switch reassignment.
-            string profileDir, modsDir, dataDir, overwriteDir;
-            lock (_gate) { profileDir = _profileDir; modsDir = _modsDir; dataDir = _dataDir; overwriteDir = _overwriteDir; }
-            if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(profileDir)) return null;
-            var fn = Path.GetFileName(name.Trim());
-            if (fn.Length == 0) return null;
-            Mo2Composition comp;
-            try { comp = Mo2LoadOrder.ReadComposition(profileDir); }
-            catch { return null; }                       // unreadable profile → say nothing rather than guess (Q3)
+    {
+        // Snapshot the roots together under the gate so the four cannot be read across a mid-switch reassignment.
+        string profileDir, modsDir, dataDir, overwriteDir;
+        lock (_gate) { profileDir = _profileDir; modsDir = _modsDir; dataDir = _dataDir; overwriteDir = _overwriteDir; }
+        if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(profileDir)) return null;
+        var fn = Path.GetFileName(name.Trim());
+        if (fn.Length == 0) return null;
+        Mo2Composition comp;
+        try { comp = Mo2LoadOrder.ReadComposition(profileDir); }
+        catch { return null; }                       // unreadable profile → say nothing rather than guess (Q3)
 
-            bool ticked = comp.ActivePluginNames.Contains(fn);
-            bool unticked = comp.InactivePluginNames.Any(x => x.Equals(fn, StringComparison.OrdinalIgnoreCase));
+        bool ticked = comp.ActivePluginNames.Contains(fn);
+        bool unticked = comp.InactivePluginNames.Any(x => x.Equals(fn, StringComparison.OrdinalIgnoreCase));
 
-            // The headline case, and the reason this explainer exists: MO2's left pane says yes, its right pane says no.
-            // The file is sitting right there, so a bare "not in the load order" reads as "missing" and sends the reader
-            // hunting for something that is installed and one click from working.
-            if (unticked)
-                return $"'{fn}' IS installed, but it is UNTICKED in plugins.txt (MO2's right pane), so the game does not " +
-                       "load it and houseCARL does not read it. Tick it in MO2 and re-sort — or, to read the file as-is " +
-                       "without loading it, use housecarl_read_plugin_file (a raw, out-of-load-order read).";
+        // The headline case, and the reason this explainer exists: MO2's left pane says yes, its right pane says no.
+        // The file is sitting right there, so a bare "not in the load order" reads as "missing" and sends the reader
+        // hunting for something that is installed and one click from working.
+        if (unticked)
+            return $"'{fn}' IS installed, but it is UNTICKED in plugins.txt (MO2's right pane), so the game does not " +
+                   "load it and houseCARL does not read it. Tick it in MO2 and re-sort — or, to read the file as-is " +
+                   "without loading it, use housecarl_read_plugin_file (a raw, out-of-load-order read).";
 
-            // Ticked but absent from the index: the file itself couldn't be resolved. Locate it to say which.
-            PluginFileHit[] hits;
-            try { hits = Mo2LoadOrder.LocatePlugin(comp, modsDir, dataDir, overwriteDir, fn).ToArray(); }
-            catch { hits = Array.Empty<PluginFileHit>(); }
+        // Ticked but absent from the index: the file itself couldn't be resolved. Locate it to say which.
+        PluginFileHit[] hits;
+        try { hits = Mo2LoadOrder.LocatePlugin(comp, modsDir, dataDir, overwriteDir, fn).ToArray(); }
+        catch { hits = Array.Empty<PluginFileHit>(); }
 
-            if (ticked)
-                // Ticked AND provided by an enabled layer, yet not indexed — nothing honest left to say (the plugin cap
-                // in probe mode reaches here). Saying "no folder provides it" would be flatly false, so say nothing.
-                return hits.Any(h => h.Enabled)
-                    ? null
-                    : $"'{fn}' is ticked in plugins.txt, but no enabled mod, the overwrite folder, or the game Data folder " +
-                      "provides the file — the profile is stale (trigger an MO2 refresh / re-sort so it rewrites the profile files).";
+        if (ticked)
+            // Ticked AND provided by an enabled layer, yet not indexed — nothing honest left to say (the plugin cap
+            // in probe mode reaches here). Saying "no folder provides it" would be flatly false, so say nothing.
+            return hits.Any(h => h.Enabled)
+                ? null
+                : $"'{fn}' is ticked in plugins.txt, but no enabled mod, the overwrite folder, or the game Data folder " +
+                  "provides the file — the profile is stale (trigger an MO2 refresh / re-sort so it rewrites the profile files).";
 
-            if (hits.Length == 0) return null;           // nothing on disk by that name → a typo; let the suggester answer
+        if (hits.Length == 0) return null;           // nothing on disk by that name → a typo; let the suggester answer
 
-            // On disk but the profile never mentions it: the mod is switched off, or MO2 hasn't registered it. Its
-            // layer label already carries which (and, for an unlisted folder, the refresh remedy). The remedy is
-            // branched on that layer's own state — telling someone to switch on a mod that is ALREADY on (every hit
-            // enabled, so the plugin is merely unregistered) sends them to do the one thing that cannot help.
-            var pick = hits.FirstOrDefault(h => !h.Enabled) ?? hits[0];
-            var remedy = pick.Enabled
-                ? "Refresh MO2 so it registers the plugin, then re-sort"
-                : "Switch the mod on in MO2 (or refresh MO2 if it is not registered yet) and re-sort";
-            return $"'{fn}' is on disk in {pick.Where}, but MO2's load order does not list it, so it is not active. " +
-                   $"{remedy} — or read the file as-is with housecarl_read_plugin_file.";
-        }
+        // On disk but the profile never mentions it. The remedy turns on WHICH layer holds it, read from the mod
+        // list rather than guessed from the hit's Enabled flag: an UNLISTED folder is flagged not-enabled exactly
+        // like a disabled one, but there is nothing in MO2 to switch on — and houseCARL's own just-written patches
+        // live in an unlisted folder, so "switch the mod on" was the wrong first instruction for the single most
+        // common way to reach this message (review of PR #274, round 2).
+        var pick = hits.FirstOrDefault(h => !h.Enabled) ?? hits[0];
+        var folder = Path.GetFileName(Path.GetDirectoryName(pick.Path) ?? "") ?? "";
+        var remedy =
+            pick.Enabled                                                              ? "Refresh MO2 so it registers the plugin, then tick it and sort"
+            : comp.DisabledMods.Any(m => m.Equals(folder, StringComparison.OrdinalIgnoreCase))
+                                                                                      ? "Switch that mod on in MO2, then tick the plugin and sort"
+                                                                                      : "MO2 has not registered that folder yet — refresh MO2, then tick the plugin and sort";
+        return $"'{fn}' is on disk in {pick.Where}, but MO2's load order does not list it, so it is not active. " +
+               $"{remedy} — or read the file as-is with housecarl_read_plugin_file.";
+    }
 
+    /// <summary>Build the asset resolver from the current roots: discover the active BSAs (co-name + Skyrim.ini base
+    /// archives, VFS-resolved + ranked — <see cref="ArchiveDiscovery"/>) and read the enabled-mod priority list, both
+    /// from the same cheap static profile read the record path uses. The gamePath (for the game-dir Skyrim.ini fallback)
+    /// is DataDir's parent (DataDir = gamePath\Data). Caller holds <see cref="_gate"/>.</summary>
     AssetResolver BuildAssetResolverLocked()
     {
         var comp = Mo2LoadOrder.ReadComposition(_profileDir);                       // EnabledMods (priority) — cheap text parse
@@ -2090,18 +2094,21 @@ public sealed class LoadOrderService : IDisposable
             // change the tail below.
             var cause = view.ExplainAbsence(plugin);
             var why = cause is not null ? " " + cause : view.NameSuggestion(plugin);
-            // The legacy tail explains the general POSTURE ("load-order truth only, does not open disabled plugins off
-            // disk") and pointed at the freshly-written-patch case as the likely reason. Once a specific cause has been
-            // stated — including the raw-read escape hatch — that generality reads as a contradiction of the sentence
-            // before it, so it is dropped in favour of the concrete answer (review of PR #274).
-            var tail = cause is not null
-                ? " If a prior write into this patch reported success, the edits DID land — do not re-issue them " +
-                  "(re-running list Adds would duplicate entries)."
+            // Only ONE sentence of the legacy tail actually contradicts a stated cause: the posture line ("does not open
+            // disabled plugins off disk"), which fights the explainer's raw-read pointer. Round 1 dropped the whole
+            // paragraph with it — and houseCARL writes its own patches into an UNLISTED mod folder, which the explainer
+            // now explains, so the freshly-written-patch case (the commonest reason to hit this refusal at all) lost the
+            // full_readback verify path that is the only way to check a write without touching MO2. The write-verify
+            // guidance is a fact about the tool, not a guess about the cause, so it is now unconditional; only the
+            // contradicting posture line and the cause-guessing sentence are conditional (review of PR #274, round 2).
+            var verify = $" To verify a write BEFORE enabling, use the write call's own read-back (full_readback=true " +
+                         $"returns the whole written record). If a prior write into '{plugin}' reported success, the edits " +
+                         "DID land — do not re-issue them (re-running list Adds would duplicate entries).";
+            var tail = (cause is not null
+                ? ""
                 : " houseCARL reads load-order truth only and does not open disabled " +
                   "plugins off disk. If this is a freshly written houseCARL patch, it isn't enabled yet: enable + sort it in " +
-                  "MO2, then re-read. To verify a write BEFORE enabling, use the write call's own read-back " +
-                  "(full_readback=true returns the whole written record). If a prior write into this patch reported success, " +
-                  "the edits DID land — do not re-issue them (re-running list Adds would duplicate entries).";
+                  "MO2, then re-read.") + verify;
             return ReadOutcome.Fail(fk,
                 $"Plugin '{plugin}' is not in the load order ({view.PluginCount} plugins; names match the plugin FILENAME " +
                 "incl. .esp/.esm, case-insensitively)." + why + tail);
@@ -3774,9 +3781,18 @@ public sealed class LoadOrderService : IDisposable
             foreach (var d in donorsRaw)
             {
                 if (!view.ContainsPlugin(d))
+                {
+                    // Same trim as read_record's: once a cause is stated it carries its own remedy, and the legacy
+                    // "Enable it in MO2 first (pass the exact filename)" both conflates the vocabulary this change is
+                    // fixing (a MOD is enabled; a PLUGIN is activated) and asks for a filename that has already
+                    // resolved to a real installed plugin (review of PR #274, round 2).
+                    var dWhy = view.ExplainAbsence(d);
                     return WritePatchBuilder.MergeOutcome.Fail(
-                        $"donor '{d}' is not an active plugin in your load order.{view.AbsenceClause(d)} Merge reads each donor's records and conflict " +
-                        "position from the ACTIVE order. Enable it in MO2 first (pass the exact filename, e.g. 'CoolMod.esp').");
+                        $"donor '{d}' is not an active plugin in your load order." +
+                        (dWhy is not null ? " " + dWhy : view.NameSuggestion(d)) +
+                        " Merge reads each donor's records and conflict position from the ACTIVE order." +
+                        (dWhy is not null ? "" : " Activate it in MO2 first (pass the exact plugin filename, e.g. 'CoolMod.esp')."));
+                }
                 if (view.ExcludedPlugins.TryGetValue(d, out var excluded))
                     return WritePatchBuilder.MergeOutcome.Fail(
                         $"cannot merge '{d}': it was EXCLUDED from this session ({excluded}) — houseCARL won't merge a plugin it " +
@@ -5383,9 +5399,13 @@ public sealed class LoadOrderService : IDisposable
         /// <summary>This copy's own layer is enabled, but a HIGHER-priority layer provides the same filename, so the
         /// game loads that one instead. Remedy: raise this mod's priority, or address the copy that wins.</summary>
         Shadowed,
-        /// <summary>This copy sits in a layer the real order never consults — a DISABLED mod folder, or one MO2 has not
-        /// registered yet. Remedy: switch the mod on, or refresh MO2.</summary>
-        LayerOff,
+        /// <summary>This copy sits in a mod folder MO2 knows about and has switched OFF. Remedy: switch it on, re-sort.</summary>
+        ModDisabled,
+        /// <summary>This copy sits in a folder modlist.txt does not mention at all — MO2 has not registered it (the state
+        /// of a patch houseCARL just wrote, before the refresh). Remedy: refresh MO2. DISTINCT from
+        /// <see cref="ModDisabled"/> because "switch the mod on" is not an available action here — there is nothing in
+        /// MO2's list to switch (review of PR #274, round 2).</summary>
+        ModUnregisteredLayer,
     }
 
     /// <summary>Is a plugin FILENAME ticked to load — the other half of "does the game load this file". A plugin's tick
@@ -5410,8 +5430,19 @@ public sealed class LoadOrderService : IDisposable
     /// EXPLAIN rather than merely classify (#271): "NOT active" names the state but not the cause, and the causes —
     /// unticked, mod switched off, shadowed, unregistered — have different remedies. <see cref="Enabled"/> keeps the
     /// single "the game loads this file" boolean every existing consumer reads, now derived rather than stored.</para></summary>
+    /// <param name="CauseDetail">For <see cref="ServedStanding.Shadowed"/>, the WHERE-label of the copy that IS served
+    /// (a different copy, so it never collides with <paramref name="Where"/>). For the two layer-off standings, the mod
+    /// FOLDER NAME alone — never the full hit label, whose text varies per lane and carries its own remedy, which is
+    /// what made the composed sentence say the same thing twice (review of PR #274).</param>
+    /// <param name="WhereNamesLayer">Does <paramref name="Where"/> already identify WHICH layer holds this copy? Set by
+    /// each lane from what it knows — the filename lane's Where IS the hit's label and the mod= lane's names the mod,
+    /// while the direct-path lane's is the constant "direct path" and identifies nothing. Carried as a fact rather than
+    /// re-derived by string-comparing the two labels: that comparison held for the filename lane and silently failed for
+    /// mod= (whose label omits the state qualifier), so the duplication it was meant to stop survived in a lane nobody
+    /// had armed. A flag the lane sets cannot drift the way a heuristic over two hand-built strings does.</param>
     internal readonly record struct PluginLocateResult(
         string? Path, string Where, ServedStanding Served, TickStanding Tick, string? CauseDetail,
+        bool WhereNamesLayer,
         IReadOnlyList<PluginFileHit>? Ambiguous, string? Error)
     {
         /// <summary>The game loads THIS file: it is the served copy AND its plugin is ticked (implicit masters count —
@@ -5438,21 +5469,30 @@ public sealed class LoadOrderService : IDisposable
                 {
                     case ServedStanding.Shadowed:
                         // CauseDetail is always set here: JudgeServed returns Shadowed only when this copy's OWN layer
-                        // is enabled, which means a served hit exists to name.
+                        // is enabled, which means a served hit exists to name. That hit is a DIFFERENT copy, so naming
+                        // it never duplicates Where whichever lane asked.
                         parts.Add($"this copy is SHADOWED — {CauseDetail} provides the copy the game loads");
                         break;
-                    case ServedStanding.LayerOff:
-                        // Don't restate the layer when Where ALREADY named it: the filename lane's Where is the hit's
-                        // own label, so "mod 'X' (DISABLED) — ... it is provided by mod 'X' (DISABLED)" said the same
-                        // thing twice in one sentence, which is worse than the bare "NOT active" it replaced. The path
-                        // lane's Where is the constant "direct path" and genuinely needs the layer named — an exact
-                        // comparison tells the two apart without parsing either label.
-                        parts.Add(string.Equals(Where, CauseDetail, StringComparison.Ordinal)
-                            ? "that layer is not one the game loads"
-                            : $"it is provided by {CauseDetail}, which the game does not load");
+                    // The two layer-off standings name the folder ONLY when Where does not (WhereNamesLayer), and state
+                    // the layer's condition + remedy in words rather than echoing a label — the label is what got
+                    // printed twice. Their remedies are genuinely different, which is why they are separate standings:
+                    // an unregistered folder has nothing in MO2's list to switch on.
+                    case ServedStanding.ModDisabled:
+                        parts.Add(WhereNamesLayer
+                            ? "that mod folder is switched OFF in MO2 — switch it on, then re-sort"
+                            : $"it is provided by mod '{CauseDetail}', which is switched OFF in MO2 — switch it on, then re-sort");
+                        break;
+                    case ServedStanding.ModUnregisteredLayer:
+                        parts.Add(WhereNamesLayer
+                            ? "MO2 has not registered that mod folder — refresh MO2, then tick the plugin and sort"
+                            : $"it is provided by mod '{CauseDetail}', which MO2 has not registered — refresh MO2, then tick the plugin and sort");
                         break;
                     case ServedStanding.NotAnInstallCopy:
-                        parts.Add("this file is not a copy the MO2 install provides");
+                        // States what was CHECKED, not a verdict on the file. This arm is also reached when the path
+                        // string-compares miss (a junction, a subst drive, a UNC route to the same install), where "not
+                        // a copy the install provides" would be a confident sentence that is simply false — the class
+                        // of overclaim this whole change exists to delete (review of PR #274, round 2).
+                        parts.Add("no MO2 layer was found providing this exact path");
                         break;
                 }
                 if (Tick == TickStanding.Unticked)
@@ -5470,15 +5510,22 @@ public sealed class LoadOrderService : IDisposable
     /// order. NOT merely the first hit: <see cref="Mo2LoadOrder.LocatePlugin"/> also walks disabled and unlisted folders
     /// that the order never consults. Compared by FULL PATH — a backup and the live copy share a filename and are
     /// different files.</summary>
-    static (ServedStanding Served, string? Detail) JudgeServed(IReadOnlyList<PluginFileHit> located, string fullPath)
+    static (ServedStanding Served, string? Detail) JudgeServed(
+        Mo2Composition comp, IReadOnlyList<PluginFileHit> located, string fullPath)
     {
         var served = located.FirstOrDefault(h => h.Enabled);
         if (served is not null && SamePluginFile(served.Path, fullPath)) return (ServedStanding.Serves, null);
         var own = located.FirstOrDefault(h => SamePluginFile(h.Path, fullPath));
         if (own is null) return (ServedStanding.NotAnInstallCopy, null);          // outside the install, or unreachable by string compare
-        // Its own layer is off (disabled / unlisted) ⇒ name THAT layer — the remedy is about this copy. Its own layer is
-        // on but something else serves the name ⇒ shadowed, and the useful pointer is the copy that WINS, not this one.
-        return own.Enabled ? (ServedStanding.Shadowed, served?.Where) : (ServedStanding.LayerOff, own.Where);
+        // Its own layer is ON but something else serves the name ⇒ shadowed, and the useful pointer is the copy that
+        // WINS, not this one.
+        if (own.Enabled) return (ServedStanding.Shadowed, served?.Where);
+        // Its own layer is off. WHICH kind decides the remedy, and it is read from the profile's own mod list rather
+        // than by pattern-matching the hit's label text — the label is display prose that can be reworded, while
+        // modlist.txt membership is the actual fact ("switched off" vs "never registered").
+        var folder = Path.GetFileName(Path.GetDirectoryName(own.Path) ?? "") ?? "";
+        bool listedOff = comp.DisabledMods.Any(m => m.Equals(folder, StringComparison.OrdinalIgnoreCase));
+        return (listedOff ? ServedStanding.ModDisabled : ServedStanding.ModUnregisteredLayer, folder);
     }
 
     /// <summary>Judge the TICK half for one plugin filename, from the profile text files. Kept beside
@@ -5513,7 +5560,7 @@ public sealed class LoadOrderService : IDisposable
         if (LooksLikePath(plugin))
         {
             if (!File.Exists(plugin))
-                return new(null, "", ServedStanding.NotAnInstallCopy, TickStanding.Unregistered, null, null, $"no file at path '{plugin}'.");
+                return new(null, "", ServedStanding.NotAnInstallCopy, TickStanding.Unregistered, null, false, null, $"no file at path '{plugin}'.");
             var full = Path.GetFullPath(plugin);
             // The standing is COMPUTED for a direct path, never assumed. Addressing a file BY PATH says nothing about
             // whether the install provides it — a path can perfectly well name the live copy of an enabled plugin,
@@ -5528,30 +5575,34 @@ public sealed class LoadOrderService : IDisposable
             var located = IsUnderAnyInstallRoot(full, modsDir, dataDir, overwriteDir)   // outside every root ⇒ can't be the install's copy; skip the scan
                 ? Mo2LoadOrder.LocatePlugin(comp, modsDir, dataDir, overwriteDir, fnPath)
                 : Array.Empty<PluginFileHit>();
-            var (servedStanding, detail) = JudgeServed(located, full);
-            return new(full, "direct path", servedStanding, JudgeTick(comp, fnPath), detail, null, null);
+            var (servedStanding, detail) = JudgeServed(comp, located, full);
+            // WhereNamesLayer: FALSE — "direct path" identifies no layer, so a layer-off cause must name the folder.
+            return new(full, "direct path", servedStanding, JudgeTick(comp, fnPath), detail, false, null, null);
         }
         if (!string.IsNullOrWhiteSpace(mod))
         {
             var fn = Path.GetFileName(plugin);
             var cand = Path.Combine(modsDir, mod.Trim(), fn);
             if (!File.Exists(cand))
-                return new(null, "", ServedStanding.NotAnInstallCopy, TickStanding.Unregistered, null, null,
+                return new(null, "", ServedStanding.NotAnInstallCopy, TickStanding.Unregistered, null, false, null,
                            $"mod folder '{mod.Trim()}' under ModsDir does not provide '{fn}'.");
             // Both halves here too, or the same physical file answers differently depending on how it was addressed.
             // "The named mod is enabled" is NOT enough: a lower-priority enabled mod's copy is shadowed, and the game
             // loads the serving copy instead.
             var (modServed, modDetail) = JudgeServed(
-                Mo2LoadOrder.LocatePlugin(comp, modsDir, dataDir, overwriteDir, fn), cand);
-            return new(cand, $"mod '{mod.Trim()}'", modServed, JudgeTick(comp, fn), modDetail, null, null);
+                comp, Mo2LoadOrder.LocatePlugin(comp, modsDir, dataDir, overwriteDir, fn), cand);
+            // WhereNamesLayer: TRUE — "mod 'X'" names the folder (it carries no STATE qualifier, which is exactly why
+            // the old label-equality test failed here and let the duplication through).
+            return new(cand, $"mod '{mod.Trim()}'", modServed, JudgeTick(comp, fn), modDetail, true, null, null);
         }
         var hits = Mo2LoadOrder.LocatePlugin(comp, modsDir, dataDir, overwriteDir, plugin);
         if (hits.Count == 0)
-            return new(null, "", ServedStanding.NotAnInstallCopy, TickStanding.Unregistered, null, null,
+            return new(null, "", ServedStanding.NotAnInstallCopy, TickStanding.Unregistered, null, false, null,
                 $"'{Path.GetFileName(plugin)}' is in no mod folder (enabled, disabled, or not-yet-listed in MO2), the overwrite folder, or the game Data folder. Check the filename, pass an absolute path, or (if it's an MO2 mod) the exact folder via mod=.");
-        if (hits.Count > 1) return new(null, "", ServedStanding.NotAnInstallCopy, TickStanding.Unregistered, null, hits, null);
-        var (oneServed, oneDetail) = JudgeServed(hits, hits[0].Path);
-        return new(hits[0].Path, hits[0].Where, oneServed, JudgeTick(comp, Path.GetFileName(plugin)), oneDetail, null, null);
+        if (hits.Count > 1) return new(null, "", ServedStanding.NotAnInstallCopy, TickStanding.Unregistered, null, false, hits, null);
+        var (oneServed, oneDetail) = JudgeServed(comp, hits, hits[0].Path);
+        // WhereNamesLayer: TRUE — Where IS the located hit's own label, folder and state both.
+        return new(hits[0].Path, hits[0].Where, oneServed, JudgeTick(comp, Path.GetFileName(plugin)), oneDetail, true, null, null);
     }
 
     /// <summary>Does the user's `plugin` argument denote a PATH (use verbatim — the "inspect any file" case) rather

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -137,7 +137,7 @@ public sealed class LoadOrderService : IDisposable
                             $"No active plugins resolved from the MO2 profile. ProfileDir='{_profileDir}', " +
                             $"ModsDir='{_modsDir}', DataDir='{_dataDir}'. {order.Warnings.Count} warning(s). Check " +
                             "HouseCarl config and that MO2 has written loadorder.txt/modlist.txt (a refresh/re-sort in MO2).");
-                    _resolver = LoadOrderResolver.Build(paths);
+                    _resolver = LoadOrderResolver.Build(paths, PluginAbsenceExplainer(_profileDir, _modsDir, _dataDir, _overwriteDir));
                     _resolvedPaths = paths;
                     _profileMtimes = profileMtimes;
                 }
@@ -207,6 +207,59 @@ public sealed class LoadOrderService : IDisposable
     /// archives, VFS-resolved + ranked — <see cref="ArchiveDiscovery"/>) and read the enabled-mod priority list, both
     /// from the same cheap static profile read the record path uses. The gamePath (for the game-dir Skyrim.ini fallback)
     /// is DataDir's parent (DataDir = gamePath\Data). Caller holds <see cref="_gate"/>.</summary>
+    /// <summary>The injected answer to "why is this plugin filename NOT in the active order?" — handed to every
+    /// <see cref="LoadOrderResolver"/> this service builds, so a refusal names the cause and its remedy instead of a
+    /// flat not-found the reader has to go re-derive (#271). Returns null when nothing can be said, and the refusal
+    /// then reads exactly as it did before (a did-you-mean).
+    /// <para>Reads the profile FRESH on each call rather than closing over a parsed composition: the composition is a
+    /// cheap three-file text parse, this runs only on a REFUSAL (never on a hot path), and a stale answer here would be
+    /// the precise failure this whole issue is about — telling someone a plugin is unticked after they ticked it. The
+    /// roots are captured by value at build time; they cannot change without the service rebuilding anyway.</para>
+    /// <para>Vocabulary is deliberate throughout: a MOD is enabled/disabled (MO2's left pane), a PLUGIN is
+    /// active/inactive (its right pane). Conflating the two is what made the old output unreadable.</para></summary>
+    static Func<string, string?> PluginAbsenceExplainer(string profileDir, string modsDir, string dataDir, string overwriteDir)
+        => name =>
+        {
+            if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(profileDir)) return null;
+            var fn = Path.GetFileName(name.Trim());
+            if (fn.Length == 0) return null;
+            Mo2Composition comp;
+            try { comp = Mo2LoadOrder.ReadComposition(profileDir); }
+            catch { return null; }                       // unreadable profile → say nothing rather than guess (Q3)
+
+            bool ticked = comp.ActivePluginNames.Contains(fn);
+            bool unticked = comp.InactivePluginNames.Any(x => x.Equals(fn, StringComparison.OrdinalIgnoreCase));
+
+            // The headline case, and the reason this explainer exists: MO2's left pane says yes, its right pane says no.
+            // The file is sitting right there, so a bare "not in the load order" reads as "missing" and sends the reader
+            // hunting for something that is installed and one click from working.
+            if (unticked)
+                return $"'{fn}' IS installed, but it is UNTICKED in plugins.txt (MO2's right pane), so the game does not " +
+                       "load it and houseCARL does not read it. Tick it in MO2 and re-sort — or, to read the file as-is " +
+                       "without loading it, use housecarl_read_plugin_file (a raw, out-of-load-order read).";
+
+            // Ticked but absent from the index: the file itself couldn't be resolved. Locate it to say which.
+            PluginFileHit[] hits;
+            try { hits = Mo2LoadOrder.LocatePlugin(comp, modsDir, dataDir, overwriteDir, fn).ToArray(); }
+            catch { hits = Array.Empty<PluginFileHit>(); }
+
+            if (ticked)
+                // Ticked AND provided by an enabled layer, yet not indexed — nothing honest left to say (the plugin cap
+                // in probe mode reaches here). Saying "no folder provides it" would be flatly false, so say nothing.
+                return hits.Any(h => h.Enabled)
+                    ? null
+                    : $"'{fn}' is ticked in plugins.txt, but no enabled mod, the overwrite folder, or the game Data folder " +
+                      "provides the file — the profile is stale (trigger an MO2 refresh / re-sort so it rewrites the profile files).";
+
+            if (hits.Length == 0) return null;           // nothing on disk by that name → a typo; let the suggester answer
+
+            // On disk but the profile never mentions it: the mod is switched off, or MO2 hasn't registered it. Its
+            // layer label already carries which (and, for an unlisted folder, the refresh remedy).
+            var pick = hits.FirstOrDefault(h => !h.Enabled) ?? hits[0];
+            return $"'{fn}' is on disk in {pick.Where}, but MO2's load order does not list it, so it is not active. " +
+                   "Switch the mod on (or refresh MO2) and re-sort — or read the file as-is with housecarl_read_plugin_file.";
+        };
+
     AssetResolver BuildAssetResolverLocked()
     {
         var comp = Mo2LoadOrder.ReadComposition(_profileDir);                       // EnabledMods (priority) — cheap text parse
@@ -1747,7 +1800,10 @@ public sealed class LoadOrderService : IDisposable
             InvalidateAssetResolver();   // the active-mod/archive set changed → the asset resolver rebuilds lazily
             if (_resolver is not null)
             {
-                var rebuilt = LoadOrderResolver.Build(paths);
+                // The rebuild must carry the explainer too, or a profile change (the very act that creates an unticked
+                // plugin) would silently drop every refusal back to the flat not-found — the exact "armed the reported
+                // lane, missed its twin" mistake #270 kept making.
+                var rebuilt = LoadOrderResolver.Build(paths, PluginAbsenceExplainer(_profileDir, _modsDir, _dataDir, _overwriteDir));
                 _resolver.Dispose();
                 _resolver = rebuilt;
             }
@@ -2016,7 +2072,10 @@ public sealed class LoadOrderService : IDisposable
         if (plugin is not null && !view.ContainsPlugin(plugin))
             return ReadOutcome.Fail(fk,
                 $"Plugin '{plugin}' is not in the load order ({view.PluginCount} plugins; names match the plugin FILENAME " +
-                "incl. .esp/.esm, case-insensitively)." + HousecarlCore.PluginNameSuggest.DidYouMean(plugin, resolver.PluginNames) +
+                // AbsenceClause subsumes the did-you-mean: it states the CAUSE when there is one (the plugin is
+                // installed but unticked / its mod is off) and falls back to the suggester when there isn't, so a real
+                // installed plugin is never answered with a spelling guess (#271).
+                "incl. .esp/.esm, case-insensitively)." + view.AbsenceClause(plugin) +
                 " houseCARL reads load-order truth only and does not open disabled " +
                 "plugins off disk. If this is a freshly written houseCARL patch, it isn't enabled yet: enable + sort it in " +
                 "MO2, then re-read. To verify a write BEFORE enabling, use the write call's own read-back " +
@@ -3691,7 +3750,7 @@ public sealed class LoadOrderService : IDisposable
             {
                 if (!view.ContainsPlugin(d))
                     return WritePatchBuilder.MergeOutcome.Fail(
-                        $"donor '{d}' is not an active plugin in your load order — merge reads each donor's records and conflict" +
+                        $"donor '{d}' is not an active plugin in your load order.{view.AbsenceClause(d)} Merge reads each donor's records and conflict" +
                         "position from the ACTIVE order. Enable it in MO2 first (pass the exact filename, e.g. 'CoolMod.esp').");
                 if (view.ExcludedPlugins.TryGetValue(d, out var excluded))
                     return WritePatchBuilder.MergeOutcome.Fail(

--- a/src/housecarl-mcp/NpcCopyTools.cs
+++ b/src/housecarl-mcp/NpcCopyTools.cs
@@ -64,7 +64,11 @@ public static class NpcCopyTools
         sb.AppendLine(o.Mode == "clone"
             ? $"CLONED {o.DonorKey} → new NPC {o.NewNpcKey} in {Path.GetFileName(o.OutPath!)}{(o.Extended ? " (extended)" : " (new patch)")}."
             : $"APPLIED {o.DonorKey}'s appearance onto {o.NewNpcKey} in {Path.GetFileName(o.OutPath!)}{(o.Extended ? " (extended)" : " (new patch)")}.");
-        sb.AppendLine($"donor read from: {o.DonorReadFrom}{(o.DonorOutOfLoadOrder ? "  [OUT-OF-LOAD-ORDER — the game does not load this file; the copy is what makes it live]" : "")}");
+        // The stamp is about THIS READ (the file lane bypasses load-order resolution), which is why it is set for the
+        // whole lane. It used to add "the game does not load this file" — false whenever the donor named IS the live
+        // plugin, and unconditional here, so it asserted it for every file-lane copy (#271). Whether the game loads the
+        // donor is a per-file fact and DonorReadFrom already carries it, with its cause.
+        sb.AppendLine($"donor read from: {o.DonorReadFrom}{(o.DonorOutOfLoadOrder ? "  [OUT-OF-LOAD-ORDER — not resolved through the load order; the copy is what makes the appearance live]" : "")}");
         sb.AppendLine($"plugin: {o.OutPath} ({o.Bytes:N0} bytes)");
         // When the post-write read-back failed, the masters/standalone facts are UNVERIFIED — asserting them from
         // default-empty values would report a donor-mastered patch as standalone on exactly the path where

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -348,7 +348,8 @@ public static class ReadTools
          "reaches an inactive/arbitrary plugin: give it a filename (located even inside a DISABLED mod folder) or an " +
          "absolute path. Modes: formid= reads one record's fields (compact `path = token`, same format as read_record); " +
          "type= enumerates the records of that type the file defines/overrides; neither returns a record-type summary " +
-         "(what's in the file). EVERY result is labeled OUT-OF-LOAD-ORDER — the game does not load this file. It emits " +
+         "(what's in the file). EVERY result is labeled OUT-OF-LOAD-ORDER — the read did not go through load-order " +
+         "resolution; whether the game loads the file is reported separately, per file, with its reason. It emits " +
          "FormLinks as FormKey tokens (does NOT follow links), so it needs no masters present; a declared master that " +
          "is not installed is flagged. Read-only — writes nothing: read an inactive donor here, then author into a NEW " +
          "active patch with the write tools. Primary use: fork/borrow an existing NPC's appearance records (the " +

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -1016,10 +1016,21 @@ static class Wire
             return sb.ToString().TrimEnd('\n');
         }
 
-        // The banner — OUT-OF-LOAD-ORDER first, always (the single load-bearing requirement).
-        sb.Append("read_plugin_file — OUT-OF-LOAD-ORDER (raw file read; the game does not load this file)\n");
+        // The banner — OUT-OF-LOAD-ORDER first, always (the single load-bearing requirement). The stamp describes THIS
+        // READ (it bypassed load-order resolution), which is true of every call; the old parenthetical went further and
+        // asserted "the game does not load this file", which is FALSE whenever the file passed is the live, winning
+        // plugin — exactly #269's case. The wording below says only what the stamp actually knows (#271); what the game
+        // does with the file is the separate, per-file question the bracket on the next line answers.
+        sb.Append("read_plugin_file — OUT-OF-LOAD-ORDER (raw file read — not resolved through the load order)\n");
         sb.Append("file: ").Append(o.FilePath);
-        if (!string.IsNullOrEmpty(o.Where)) sb.Append("  [").Append(o.Where).Append(o.Enabled ? "" : "; NOT active").Append(']');
+        // Where reports the LAYER the file was found in (a mod folder's switch); the standing reports the FILE. Read
+        // together, "mod 'X' (enabled)" beside a bare "NOT active" looked self-contradictory, so the two subjects are
+        // now named explicitly and the not-loaded case carries its CAUSE — the reader should never have to infer which
+        // of the two facts changed, nor go searching for a remedy the tool already knows (#271).
+        if (!string.IsNullOrEmpty(o.Where))
+            sb.Append("  [").Append(o.Where)
+              .Append(o.WhyNotActive is { } why ? $" — but the game does NOT load this file: {why}" : " — the game loads this file")
+              .Append(']');
         sb.Append('\n');
         sb.Append("masters: ").Append(o.Masters.Count == 0 ? "none" : string.Join(", ", o.Masters)).Append('\n');
         if (o.MissingMasters.Count > 0)


### PR DESCRIPTION
Fixes #271

`NOT active` / `disabled` named the state but never the cause — and the causes have different fixes: the plugin is unticked in `plugins.txt`, its mod is switched off, a higher-priority mod shadows this copy, or MO2 has not registered it. Reading `[mod 'X' (enabled); NOT active]` you could not tell which, so the answer had to be rediscovered by hand every time. Aaron's framing, which set the shape of the work: **every level should state the cause explicitly rather than return a generic not-found, or an agent burns a search rediscovering a fact the tool already had.** That is an economics argument, not a cosmetic one.

*Six commits, each independently green — three for the change, three addressing two rounds of independent review.*

### Two mechanisms, not one

The issue reads as one class, but it lands on two separate paths, and conflating them would have left half the surface untouched:

1. **The located-plugin flag** (`read_plugin_file`, `diff_record`'s off-order pole, `copy_npc_appearance`'s donor line) — goes through the shared locate contract.
2. **Refusals** (`read_record`, `check_errors`, in-place writes, …) — these **never call the locate contract at all**. They miss the index's name table, and the index deliberately holds only plugins the game loads.

### 1. The flag became two facts (#271 items 1, 3, 4, 5)

`PluginLocateResult` carries `ServedStanding` and `TickStanding` as cause enums instead of one pre-collapsed bool. `Enabled` is derived, so every existing consumer is unchanged; `WhyNotActive` composes the explanation **once**, in the locate contract, so the three renderers cannot drift apart — the same reason that contract was unified in the first place. Both halves are judged by shared helpers called from all three address lanes, so no lane can compute one its own way.

Both clauses are emitted when both apply: a shadowed copy of an unticked plugin needs two fixes, and naming one would send the reader to do half the job. Each enum's zero value is the conservative one, so a default-constructed result reads NOT-loaded.

- **item 3** — the banner read `OUT-OF-LOAD-ORDER (raw file read; the game does not load this file)`: true of the read, **false about the file** whenever the one passed IS the live plugin (#269's own case). Now `(raw file read — not resolved through the load order)`, which holds always.
- **item 4** — `Where` reports the folder, the flag reports the file. Both subjects are now named explicitly, and a file the game *does* load says so positively instead of saying nothing.
- **vocabulary** — a MOD is enabled/disabled, a PLUGIN is active/inactive. `diff_record` no longer calls an unticked plugin "disabled".
- the JSON lane gains `why_not_active` beside `enabled`.

### 2. Refusals explain themselves (#271 item 2)

The commonest cause — installed, in an enabled mod, unticked in MO2's right pane — arrived as a flat "plugin not in the load order". Worse: the did-you-mean suggester matches **active** names only, so the one case with an exactly-correct name got no help at all. The reader is told a file that is sitting right there does not exist.

The refusal itself is correct and stays (Q3 — a plugin the game does not load must never masquerade as load-order truth). Only the explanation was missing.

`LoadOrderResolver` cannot answer this and **must not learn how**: it is built from a bare ordered path list and knows nothing of MO2 (explicit-paths mode has no profile). So the answer is **injected** — an optional `Func` the MCP service supplies from the profile, surfaced as `AbsenceClause`. Omit it and every message reads exactly as before, which is what the ~50 probe call sites and explicit-paths mode get. Applied to **13** refusal sites. The explainer replaces the did-you-mean only when it has a real cause to state, and returns null rather than assert something false where it cannot speak honestly.

Deliberately **not** applied to the SKSE audit's `PluginMissing` verdict: a batch classification over many refs, where a per-ref profile parse is a real cost for a report that already explains itself.

### Guard

34 new wave3 arms (**56 → 90**), extending the existing fixture. #270's recurring mistake was arming the case that had just been reported instead of every lane the changed RULE touches, so each cause is armed on every address form that can reach it: unticked by path / by filename / via `mod=` (and the three asserted **equal**); shadowed by path and `mod=`, asserted to name the serving mod and *not* to say "unticked"; a copy in a disabled mod asserted to blame the mod folder and *not* the plugin's tick (it is absent from `plugins.txt`, so a naive renderer says "unticked" — that arm catches it); a backup outside the install; the three ACTIVE lanes asserted to carry **no** cause; the rendered banner and pairing; and the refusal lane including the surviving typo fallback.

**Teeth verified** by substituting each implementation, and in every case *only* the expected arms failed:

| Substitution | Arms that failed |
|---|---|
| drop the injected explainer | exactly the 3 refusal arms |
| collapse the cause to a constant | exactly the 7 cause/render arms |
| merge `LayerOff` into `Shadowed` | exactly the 2 arms distinguishing them |
| restore the old banner wording | exactly the banner arm |

### Checks

- `ci-all` — **106/106**; `bulk-primitives-wave3-guard` — **72/72**
- Build clean; warning census identical to `main` (19)

### Carried caveat

**Still not confirmed against a real load order.** All evidence here and in #269/#270 is synthetic fixtures; the reporting user's setup was unavailable. Aaron deferred live confirmation to release, and four green review passes on #270 did not substitute for it — nor do these guards (§5 #1). The unticked-plugin case is cheap to check live on any MO2 install: untick one plugin, then `read_plugin_file` it and `read_record` from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

