### PR TITLE
fix(cross_plugin_query): deleted records are a clean non-match, not an untyped skip (#276)

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -15,8 +15,10 @@ A deleted record carries no body by engine rule, but the scan still tried to rea
 engine-authored deleted body can leave just enough behind to NullRef on that read. The skip was accounted (not
 silent), but its *cause* read as a parser hole — which means a genuine match hiding in a "skipped" record looks
 possible when it isn't (Q3). A deleted record is now excluded from the content filters up front: it links to nothing
-and has no field to test, so it is a clean non-match, not an unscannable skip. `editorid_contains=` is unaffected —
-EditorID is a header field, present and safe on a deleted record. Reported by DrHeisen.
+live and has no field to test, so it is a clean non-match, not an unscannable skip. This also means a deleted record
+that *does* parse and carries a link to the target is no longer returned by `references=` — treating a deleted record
+as referencing nothing, the resolution the report itself proposed. `editorid_contains=` is unaffected (EditorID reads
+from the early EDID subrecord, before the body parse that throws). Reported by DrHeisen.
 
 **A plugin addressed by its file path is no longer mislabeled off-order and disabled (#269).**
 `diff_record` stamped `OUT-OF-LOAD-ORDER (direct path, disabled)` on a plugin that is enabled and winning whenever it

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,16 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**`cross_plugin_query` no longer trips over deleted records and reports them as an unexplained skip (#276).**
+A `references=` (or `where=`) scan over a load order holding *deleted* records — the wild case was deleted `Package`
+records in a follower mod — ended with a raw `NullReferenceException … could not be scanned and were skipped` note.
+A deleted record carries no body by engine rule, but the scan still tried to read its form links, and an
+engine-authored deleted body can leave just enough behind to NullRef on that read. The skip was accounted (not
+silent), but its *cause* read as a parser hole — which means a genuine match hiding in a "skipped" record looks
+possible when it isn't (Q3). A deleted record is now excluded from the content filters up front: it links to nothing
+and has no field to test, so it is a clean non-match, not an unscannable skip. `editorid_contains=` is unaffected —
+EditorID is a header field, present and safe on a deleted record. Reported by DrHeisen.
+
 **A plugin addressed by its file path is no longer mislabeled off-order and disabled (#269).**
 `diff_record` stamped `OUT-OF-LOAD-ORDER (direct path, disabled)` on a plugin that is enabled and winning whenever it
 was passed as an absolute path instead of a filename — the diff values were right, but the provenance line said the

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -93,6 +93,7 @@ public static class CiAll
         ("inplace-guard", InPlaceProbe.RunGuard),
         ("subclass-remove-guard", SubclassRemoveGuardProbe.RunGuard),
         ("perk-refs-guard", PerkRefsProbe.RunGuard),
+        ("deleted-record-scan-guard", PerkRefsProbe.RunDeletedGuard),
         ("conflict-diff-guard", ConflictDiffProbe.RunGuard),
         ("formid-floor-guard", FormIdFloorProbe.RunGuard),
         ("esl-formid-guard", EslFormIdProbe.RunGuard),

--- a/src/housecarl-generator/PerkRefsProbe.cs
+++ b/src/housecarl-generator/PerkRefsProbe.cs
@@ -110,6 +110,131 @@ public static class PerkRefsProbe
         return pass ? 0 : 1;
     }
 
+    /// <summary>REGRESSION GUARD (<c>deleted-record-scan-guard</c>, standing CI instrument, self-contained) for #276 —
+    /// a DELETED record with a residual, malformed body made a references=/where= scan end in a raw
+    /// "NullReferenceException … could not be scanned and were skipped" note (the wild repro: deleted PACKs in a
+    /// follower mod). A deleted record carries no live body by engine rule, so the fix EXCLUDES it from the content
+    /// filters before the reference walk — it should be a clean non-match, not an "unscannable" skip whose cause
+    /// reads as a parser hole (Q3).
+    ///
+    /// Reproduces the wild shape by the same corruption path as <see cref="RunGuard"/> (a perk whose EPFT byte is
+    /// corrupted so a lazy Effects parse throws) PLUS setting the record's Deleted header flag ON DISK — Mutagen
+    /// serialises a model-deleted record with an EMPTY body, so the flag is byte-patched onto a normally-written
+    /// (still-bodied) record to get "deleted but still carrying a throwing body". A CONTROL proves the bad perk
+    /// reads as Deleted AND still throws from EnumerateFormLinks, so a GREEN means the scan SKIPPED a record that
+    /// WOULD have thrown, not a clean one. The discriminator: the deleted record's FormKey is ABSENT from the
+    /// ScanNote — RED before the fix (it threw and was accounted there), GREEN after (excluded before the walk).
+    ///
+    /// Run: <c>dotnet run --project src/housecarl-generator deleted-record-scan-guard</c></summary>
+    public static int RunDeletedGuard(string[] args)
+    {
+        Console.WriteLine("################  REGRESSION GUARD — a DELETED record is excluded from a references= scan, not accounted as unscannable (#276)  ################");
+        Console.WriteLine();
+
+        var tmpDir = Path.Combine(Path.GetTempPath(), "hc-deleted-scan-guard");
+        if (Directory.Exists(tmpDir)) Directory.Delete(tmpDir, recursive: true);
+        Directory.CreateDirectory(tmpDir);
+        var modKey = new ModKey("HcDeletedScanGuard", ModType.Plugin);
+        string espPath = Path.Combine(tmpDir, modKey.FileName.String);
+
+        // Same fixture shape as perk-refs-guard: target + a GOOD referencing perk + a BAD perk with an entry-point
+        // effect. The BAD perk gets the lower FormID so it enumerates BEFORE the good match (a stop-at-fault
+        // regression would drop the good one). It is then made BOTH malformed (EPFT corrupted → lazy parse throws)
+        // AND Deleted-on-disk — the exact wild shape #276 saw on deleted PACKs.
+        FormKey targetFk, goodFk, badFk;
+        {
+            var mod = new SkyrimMod(modKey, SkyrimRelease.SkyrimSE);
+            var target = mod.Perks.AddNew(); target.EditorID = "HcDeletedScanGuard_Target"; targetFk = target.FormKey;
+            var bad = mod.Perks.AddNew(); bad.EditorID = "HcDeletedScanGuard_Bad"; badFk = bad.FormKey;
+            bad.Effects.Add(new PerkEntryPointModifyActorValue
+            {
+                EntryPoint = APerkEntryPointEffect.EntryType.CalculateWeaponDamage,
+                ActorValue = ActorValue.OneHanded,
+                Value = 1f,
+                Modification = PerkEntryPointModifyActorValue.ModificationType.AddAVMult,
+            });
+            var good = mod.Perks.AddNew(); good.EditorID = "HcDeletedScanGuard_Good"; goodFk = good.FormKey;
+            good.NextPerk.SetTo(targetFk);
+            mod.BeginWrite.ToPath(espPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+        }
+        int corrupted = CorruptEpftBytes(espPath);
+        int deleted = SetDeletedFlag(espPath, "PERK", badFk);
+        Console.WriteLine($"-- setup: wrote {modKey.FileName}; corrupted {corrupted} EPFT byte(s); flagged {deleted} record Deleted on disk --");
+        if (corrupted != 1 || deleted != 1)
+        {
+            Console.WriteLine($"=== deleted-record-scan-guard: FAIL (expected 1 EPFT + 1 deleted flag, got {corrupted}/{deleted}) ===");
+            return 1;
+        }
+
+        // CONTROL: the fixture must reproduce BOTH conditions — the bad perk reads as Deleted AND still throws from
+        // EnumerateFormLinks. If it doesn't throw, a GREEN below would be meaningless (the guard would be skipping a
+        // record the scan handles fine anyway).
+        bool isDeleted = false, throws = false; string ctlMsg = "(no throw)";
+        using (var ov = SkyrimMod.CreateFromBinaryOverlay(espPath, SkyrimRelease.SkyrimSE))
+        {
+            var badOv = ov.Perks.First(p => p.FormKey == badFk);
+            isDeleted = badOv.IsDeleted;
+            try { _ = ((IFormLinkContainerGetter)badOv).EnumerateFormLinks().Count(); }
+            catch (Exception ex) { throws = true; ctlMsg = $"{ex.GetType().Name}: {ex.Message}"; }
+        }
+        Console.WriteLine($"   CONTROL: bad perk reads as Deleted                    : {(isDeleted ? "PASS" : "FAIL")}");
+        Console.WriteLine($"   CONTROL: bad perk STILL throws from EnumerateFormLinks : {(throws ? "PASS" : "FAIL")}  [{ctlMsg}]");
+
+        // Drive the REAL service-layer references= scan. WITHOUT the fix the deleted+throwing perk lands in the
+        // ScanNote as an unscannable skip (its cause a raw exception — the #276 report). WITH the fix it's excluded
+        // as deleted BEFORE the reference walk, so it never throws, is absent from the ScanNote, and the good match
+        // still returns.
+        using var resolver = LoadOrderResolver.Build(new[] { espPath });
+        var svc = LoadOrderService.ForGuard(resolver, new UserConfigStore(Path.Combine(tmpDir, "houseCARL.user.json")));
+        CrossQueryOutcome q;
+        try { q = svc.CrossQuery(type: null, references: new[] { targetFk }, editoridContains: null, conflictsOnly: false,
+                                 plugins: new[] { modKey.FileName.String }, where: null, limit: 500); }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"   scan call completed (no escape)                       : FAIL — the call THREW: {ex.GetType().Name}: {ex.Message}");
+            Console.WriteLine("=== deleted-record-scan-guard: FAIL ===");
+            return 1;
+        }
+
+        bool noError = q.Error is null;
+        bool foundGood = q.Total == 1 && q.Keys.Count == 1 && q.Keys[0] == goodFk;
+        // The discriminator: the deleted record is EXCLUDED, so its FormKey is NOT accounted in the ScanNote (with
+        // no other unscannable record, the note is null). RED before the fix — the deleted perk threw and was
+        // accounted; GREEN after — excluded before the walk.
+        bool notAccounted = !(q.ScanNote?.Contains(badFk.ToString(), StringComparison.OrdinalIgnoreCase) ?? false);
+
+        Console.WriteLine($"   scan call completed (no escape, no error)             : {(noError ? "PASS" : $"FAIL [{q.Error}]")}");
+        Console.WriteLine($"   good referencing perk still matched                   : {(foundGood ? "PASS" : $"FAIL (total={q.Total})")}");
+        Console.WriteLine($"   deleted record EXCLUDED, not in ScanNote (Q3)         : {(notAccounted ? "PASS" : $"FAIL [{q.ScanNote}]")}");
+        Console.WriteLine();
+
+        bool pass = isDeleted && throws && noError && foundGood && notAccounted;
+        Console.WriteLine($"=== deleted-record-scan-guard: {(pass ? "PASS" : "FAIL")} ===");
+        return pass ? 0 : 1;
+    }
+
+    /// <summary>Set the record-header Deleted flag (0x20) on the record of signature <paramref name="sig"/> whose
+    /// on-disk FormID equals <paramref name="fk"/>'s object ID (own record ⇒ master index 0), by locating its
+    /// 24-byte header (sig at +0, flags word at +8, FormID at +12) and OR-ing the flags' low byte. The FormID match
+    /// skips the top-GRUP label of the same 4 chars. Returns how many headers matched (caller asserts exactly 1).</summary>
+    static int SetDeletedFlag(string espPath, string sig, FormKey fk)
+    {
+        var bytes = File.ReadAllBytes(espPath);
+        var s = System.Text.Encoding.ASCII.GetBytes(sig);
+        uint id = fk.ID;
+        int hits = 0;
+        for (int i = 0; i + 24 <= bytes.Length; i++)
+        {
+            if (bytes[i] != s[0] || bytes[i + 1] != s[1] || bytes[i + 2] != s[2] || bytes[i + 3] != s[3]) continue;
+            uint formId = (uint)(bytes[i + 12] | (bytes[i + 13] << 8) | (bytes[i + 14] << 16) | (bytes[i + 15] << 24));
+            if (formId != id) continue;
+            bytes[i + 8] |= 0x20;   // SkyrimMajorRecordFlag.Deleted, the flags word's low byte
+            hits++;
+        }
+        if (hits > 0) File.WriteAllBytes(espPath, bytes);
+        return hits;
+    }
+
     /// <summary>REAL-DATA proof (manual; needs an MO2 instance + a generated corpus.json): drive the SERVICE-layer
     /// scan with the report's exact failing call — <c>type=Perk references=01CEAD:Skyrim.esm</c> (KYWD
     /// MagicDamageFire) — over the live order. Before the fix the whole call threw; after, it must return with no

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2588,8 +2588,8 @@ public sealed class LoadOrderService : IDisposable
                         // body that NullRefs when EnumerateFormLinks (references=) / the where= predicate lazily
                         // parse it — which then lands in the unscannable bucket below as an untyped skip, reading
                         // as a parser hole, so a genuine match hiding in a "skipped" record looks possible when it
-                        // isn't (Q3). editorid_contains= stays live: EditorID is a header field, present and safe
-                        // on a deleted record.
+                        // isn't (Q3). editorid_contains= stays live: EditorID reads from the record's early EDID
+                        // subrecord, before the deep body parse that can throw — safe on a deleted record.
                         if (filterBody.IsDeleted && (refSet is not null || predicate is not null)) continue;
                         if (!string.IsNullOrEmpty(editoridContains)
                             && (filterBody.EditorID is null || filterBody.EditorID.IndexOf(editoridContains, StringComparison.OrdinalIgnoreCase) < 0))

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2580,6 +2580,17 @@ public sealed class LoadOrderService : IDisposable
                             }
                             filterBody = wb;
                         }
+                        // DELETED records carry no body to scan (#276): a Deleted major record's content is
+                        // empty by engine rule, so the CONTENT filters cannot match it — references= links to
+                        // nothing, where= has no field to test. So exclude it as a clean non-match here, before
+                        // the scan touches its body. This is also what stops the reported crash: engine-authored
+                        // deleted records (the wild repro was deleted PACKs) can leave a content-free-but-not-clean
+                        // body that NullRefs when EnumerateFormLinks (references=) / the where= predicate lazily
+                        // parse it — which then lands in the unscannable bucket below as an untyped skip, reading
+                        // as a parser hole, so a genuine match hiding in a "skipped" record looks possible when it
+                        // isn't (Q3). editorid_contains= stays live: EditorID is a header field, present and safe
+                        // on a deleted record.
+                        if (filterBody.IsDeleted && (refSet is not null || predicate is not null)) continue;
                         if (!string.IsNullOrEmpty(editoridContains)
                             && (filterBody.EditorID is null || filterBody.EditorID.IndexOf(editoridContains, StringComparison.OrdinalIgnoreCase) < 0))
                             continue;


### PR DESCRIPTION
## What

A `references=` / `where=` scan in `cross_plugin_query` over a load order holding **deleted** records ended with a raw `NullReferenceException … could not be scanned and were skipped` note. The wild repro (issue #276, DrHeisen): deleted `Package` records in a follower mod.

A deleted major record carries no live body by engine rule, but the scan still reached for its form links / fields, and an engine-authored deleted body can leave just enough behind to throw on that lazy read. The skip was **accounted** (not silent), but its *cause* read as a parser hole — so a genuine match hiding in a "skipped" record looks possible when it isn't (Q3).

## Fix

One guard in the scan loop: a deleted `filterBody` is excluded from the content filters up front — it links to nothing live and has no field to test, so it's a clean non-match, never scanned. `editorid_contains=` is unaffected (EditorID is the early EDID subrecord, read before the body parse that throws).

**Acknowledged behavior change:** a deleted record that *does* parse and carries a link to the target is no longer returned by `references=`. This is the "treat a deleted record as referencing nothing" resolution the report itself proposed, and it fits houseCARL's live-state posture — but it diverges from xEdit (which shows the raw link), so it's called out explicitly rather than left implicit.

## Testing

- **`deleted-record-scan-guard`** (new, in `ci-all`) — reproduces the wild shape: a perk whose EPFT byte is corrupted (lazy parse throws) **and** whose Deleted header flag is byte-patched on disk (Mutagen strips a model-deleted body, so the flag is patched onto a still-bodied record). A **control arm** confirms the record reads as Deleted *and* still throws from `EnumerateFormLinks`, so a GREEN is meaningful. Discriminator: the deleted record's FormKey is **absent** from the `ScanNote`. **Verified biting** — RED with the fix reverted (it lands in the note as unscannable), GREEN with the fix (excluded before the walk).
- Full `ci-all`: **107/107**.

> **Correction (post-review).** An earlier revision of this PR claimed a regression probe was *impossible* because "a Mutagen-authored deleted record is clean." Independent review correctly refuted that — my "arm passed either way" was an artifact of testing a *clean* deleted record; the sibling `perk-refs-guard` already shows how to author a throwing record on disk. The guard above is the result. Thanks to the reviewer for the catch.

## Related (out of scope, flagged)

The same unguarded `EnumerateFormLinks`-on-a-deleted-body pattern may exist in other tools (e.g. the error-check / remap paths). Not touched here to keep this atomic — filed as #279.

Reported by DrHeisen (external; triaged + locally reproduced before filing).

Fixes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)