### PR TITLE
fix(conflict-diff): flag a pure list reorder instead of "identical to winner" (#275, partial)

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -20,6 +20,17 @@ that *does* parse and carries a link to the target is no longer returned by `ref
 as referencing nothing, the resolution the report itself proposed. `editorid_contains=` is unaffected (EditorID reads
 from the early EDID subrecord, before the body parse that throws). Reported by DrHeisen.
 
+**A pure list reorder no longer reads as "identical to winner" in a conflict diff (#275, partial).**
+The `conflict_tree` / `diff_record` content compare is order-insensitive by design — the same relations stored in a
+different order (the USSEP case that motivated it) shouldn't over-report. But for a list where order IS the
+semantics — a DIAL's INFO children decide which line the game plays — folding a reorder into "no delta" is a silent
+wrong answer: the record reads "identical to winner" when the very thing that changed is invisible. Now, when two
+lists hold the same contents in a different order, the diff emits an explicit `Field: same N item(s), ORDER DIFFERS
+from winner` note instead of silence — type-agnostic, so it fires for any reordered list (over-reporting a noise
+reorder is the safe direction; silently equating a semantic one is not). No-delta renders no longer claim "list
+order ignored," since order is now compared. Reported by DrHeisen. *(This closes the diff-honesty half of #275; the
+larger ask — an effective, merged INFO-order view for a topic, xEdit INOM/INOA parity — remains open.)*
+
 **A plugin addressed by its file path is no longer mislabeled off-order and disabled (#269).**
 `diff_record` stamped `OUT-OF-LOAD-ORDER (direct path, disabled)` on a plugin that is enabled and winning whenever it
 was passed as an absolute path instead of a filename — the diff values were right, but the provenance line said the

--- a/src/housecarl-core/FieldsDiff.cs
+++ b/src/housecarl-core/FieldsDiff.cs
@@ -17,7 +17,11 @@ namespace HousecarlCore;
 ///   • positional LIST contents — order-INSENSITIVE multiset comparison of whole elements keyed on their
 ///     content (the report's case: USSEP and the winner store the same relations in different orders, so
 ///     an index-wise comparison would over-report; element identity is content-based). Elements present
-///     on only one side are reported with identifying leaf values. Nested list reordering INSIDE an
+///     on only one side are reported with identifying leaf values. When the multisets are EQUAL but the
+    ///     positional order differs, an ORDER-DIFFERS note is emitted (#275) — for record types where list
+    ///     order IS the semantics (a DIAL's INFO children decide which line plays), a pure reorder must not
+    ///     read as identical; contents-equal means no element deltas, so the note stands alone. Nested list
+    ///     reordering INSIDE an
 ///     element is not canonicalised (v1) — it can over-report as a content delta, never under-report;
 ///   • honesty (Q3) — if either side's deep read hit the expansion cap, <see cref="Result.Complete"/> is
 ///     false: list comparison and one-sided-presence deltas are SUPPRESSED (where the two caps fell would
@@ -154,7 +158,21 @@ public static class FieldsDiff
                 var tElems = ElementsOf(tLines, root);
                 var wElems = ElementsOf(wLines, root);
                 var (onlyT, onlyW) = MultisetDiff(tElems, wElems);
-                if (onlyT.Count == 0 && onlyW.Count == 0) continue;    // same contents (possibly reordered) — no delta
+                if (onlyT.Count == 0 && onlyW.Count == 0)
+                {
+                    // Equal multisets ⇒ same CONTENTS. For most list fields order is noise (the report that
+                    // motivated the multiset compare: USSEP stores the same relations in a different order), but
+                    // for some it IS the semantics — a DIAL's INFO children decide which line the game plays, so a
+                    // pure reorder is the whole delta (#275). Folding it into "no delta" makes such a record read
+                    // "identical to winner" — a silent wrong. Detect it generically: ElementsOf returns elements in
+                    // positional (index) order, so an ordered fingerprint-sequence mismatch IS a reorder. Surface it
+                    // as an ORDER-DIFFERS note — never element deltas, the contents ARE equal. Type-agnostic by
+                    // design: over-reporting a noise reorder is the safe direction; silently equating a semantic one
+                    // is not (the whole module's posture — over-report, never under-report).
+                    if (!tElems.Select(e => e.Fingerprint).SequenceEqual(wElems.Select(e => e.Fingerprint)))
+                        deltas.Add($"{root}: same {tElems.Count} item(s), ORDER DIFFERS from {referenceLabel}");
+                    continue;
+                }
                 deltas.Add(DescribeListDelta(root, tElems.Count, wElems.Count, onlyT, onlyW, referenceLabel));
             }
         }

--- a/src/housecarl-core/FieldsDiff.cs
+++ b/src/housecarl-core/FieldsDiff.cs
@@ -18,10 +18,10 @@ namespace HousecarlCore;
 ///     content (the report's case: USSEP and the winner store the same relations in different orders, so
 ///     an index-wise comparison would over-report; element identity is content-based). Elements present
 ///     on only one side are reported with identifying leaf values. When the multisets are EQUAL but the
-    ///     positional order differs, an ORDER-DIFFERS note is emitted (#275) — for record types where list
-    ///     order IS the semantics (a DIAL's INFO children decide which line plays), a pure reorder must not
-    ///     read as identical; contents-equal means no element deltas, so the note stands alone. Nested list
-    ///     reordering INSIDE an
+///     positional order differs, an ORDER-DIFFERS note is emitted (#275) — for record types where list
+///     order IS the semantics (a DIAL's INFO children decide which line plays), a pure reorder must not
+///     read as identical; contents-equal means no element deltas, so the note stands alone. Nested list
+///     reordering INSIDE an
 ///     element is not canonicalised (v1) — it can over-report as a content delta, never under-report;
 ///   • honesty (Q3) — if either side's deep read hit the expansion cap, <see cref="Result.Complete"/> is
 ///     false: list comparison and one-sided-presence deltas are SUPPRESSED (where the two caps fell would

--- a/src/housecarl-generator/ConflictDiffProbe.cs
+++ b/src/housecarl-generator/ConflictDiffProbe.cs
@@ -16,7 +16,8 @@ namespace HousecarlGenerator;
 /// ForGuard seam) + <see cref="FieldsDiff.Compare"/> (the new content comparison) — and asserts:
 ///   A. equal-count, different-content Relations → a DELTA naming the element only in each side (RED before
 ///      the fix: depth-1 reads gave the comparator nothing but equal count tokens);
-///   B. same contents merely REORDERED → NO delta (content-keyed comparison; an index-wise diff over-reports);
+///   B. same contents merely REORDERED → an ORDER-DIFFERS note (#275), NOT element deltas (content-keyed, so
+///      the elements match; but silence would hide a reorder that IS the semantics for a DIAL's INFO children);
 ///   C. different counts → still a delta (the case the old diff did catch);
 ///   D. a scalar field delta → still reported (the old behavior, preserved at depth);
 ///   E. a read that hits the expansion cap → Complete=false (the render must NOT claim "identical"; Q3).
@@ -112,8 +113,13 @@ public static class ConflictDiffProbe
               dA.Deltas.Any(d => d.Contains(t[3].ToString())));
 
         var dB = DiffOf(svc, fB.FormKey);
-        Check("B: reordered-only list reports NO delta (content-keyed, order-insensitive)",
-              dB.Deltas.Count == 0 && dB.Complete);
+        // #275: a pure reorder is no longer folded into "no delta" — for an order-significant list (a DIAL's INFO
+        // children) that silence is a wrong answer. It surfaces as an ORDER-DIFFERS note and NOTHING else (the
+        // contents are equal, so no element-presence deltas). This assertion supersedes the pre-#275 "NO delta".
+        Check("B: a reordered-only list reports an ORDER-DIFFERS note (#275), not silence and not element deltas",
+              dB.Complete
+              && dB.Deltas.Count == 1
+              && dB.Deltas[0].StartsWith("Relations: same 3 item(s), ORDER DIFFERS", StringComparison.Ordinal));
 
         var dC = DiffOf(svc, fC.FormKey);
         Check("C: count delta still reported",
@@ -308,7 +314,7 @@ public static class ConflictDiffProbe
             {
                 var diff = FieldsDiff.Compare(tree.Nodes[n].Record, winner.Record);
                 var line = diff.Deltas.Count > 0 ? string.Join("; ", diff.Deltas)
-                         : diff.Complete ? "(identical to winner — full modeled content compared, list order ignored)"
+                         : diff.Complete ? "(identical to winner — full modeled content compared)"
                                          : "(comparison truncated — not a verified ITM)";
                 Console.WriteLine($"   {tree.Nodes[n].Plugin}: {line}");
             }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2270,7 +2270,8 @@ public sealed class LoadOrderService : IDisposable
     /// disk not in the load order — the report's case diffs a DISABLED old patch against the mod that supersedes it, via
     /// the shared <see cref="LocatePluginFileOnDisk"/>). Both sides are deep-read (<see cref="ConflictDiffDepth"/>) with
     /// the SAME fields= so line sets correspond, then compared by <see cref="FieldsDiff.Compare"/> — the SAME
-    /// order-insensitive, truncation-honest engine the conflict tree uses, with plugin_b as the reference label. A bad
+    /// content-keyed (list reorders flagged), truncation-honest engine the conflict tree uses, with plugin_b as the
+    /// reference label. A bad
     /// FormID, an unresolvable pole, or a plugin that doesn't define the record is a NAMED refusal (Q3).</summary>
     public DiffRecordOutcome DiffRecord(string formid, string pluginA, string pluginB, IReadOnlyList<string>? fields,
                                         string? modA = null, string? modB = null)

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -96,7 +96,7 @@ public static class ReadTools
          "Field-level diff between TWO plugins' versions of ONE record — plugin_a vs plugin_b. Each plugin may be an " +
          "ACTIVE plugin OR a plugin FILE on disk that isn't in the load order (e.g. a DISABLED old patch): the classic " +
          "use is diffing a disabled OLD patch against the mod that supersedes it, to see exactly what changed. Both " +
-         "sides are deep-read and compared by the SAME order-insensitive, truncation-honest engine the conflict tree " +
+         "sides are deep-read and compared by the SAME content-keyed (list reorders flagged), truncation-honest engine the conflict tree " +
          "uses; each delta line shows plugin_a's value with plugin_b's (the reference) value labeled by plugin_b's " +
          "filename. A FormID is 'XXXXXX:Plugin.esp'. Read-only. Unlike housecarl_read_record conflict_tree (which diffs " +
          "every toucher against the load-order WINNER), this compares TWO explicit plugins with no winner pole — use it " +
@@ -933,12 +933,13 @@ static class Wire
         var winnerNode = tree.Winner;                                       // Nodes[^1] = highest priority = the winner
 
         // CONTENT diff (HCBR-2026-06-09-01): each node's DEEP read vs the winner's, compared by FieldsDiff —
-        // scalar leaves exact-path, list contents order-insensitively by whole element. The old depth-1 token
+        // scalar leaves exact-path, list contents order-insensitively by whole element (a reorder of equal
+        // contents surfaces as an explicit ORDER-DIFFERS note, #275). The old depth-1 token
         // comparison called equal-count lists with different contents "identical to winner" — an affirmative
         // false ITM that masked a real override regression. "Identical" is now only claimed when the FULL
         // modeled content compared clean; a truncated comparison says so instead (Q3).
         sb.Append("diff (field deltas vs winner ").Append(winnerNode.Plugin)
-          .Append("; identical fields omitted; list contents compared order-insensitively):\n");
+          .Append("; identical fields omitted; list contents compared by content, element reorders flagged):\n");
         for (int n = 0; n < tree.Nodes.Count - 1; n++)                      // every node except the winner
         {
             if (sb.Length >= cap)
@@ -981,15 +982,15 @@ static class Wire
     /// non-nullable subrecord bit the read can't prove).</summary>
     static string IdenticalWholeRecord(FieldsDiff.Result diff) =>
         diff.AgreedCount > 0
-            ? $"(no field deltas; {diff.AgreedCount} modeled field(s) read identical to the winner ({SampleOf(diff)}) — list order ignored)"
-            : "(identical to winner — full modeled content compared, list order ignored)";
+            ? $"(no field deltas; {diff.AgreedCount} modeled field(s) read identical to the winner ({SampleOf(diff)}))"
+            : "(identical to winner — full modeled content compared)";
 
     /// <summary>No-delta render for a fields=-narrowed compare — node-neutral, and the identity claim must not
     /// outrun the compared paths (PR #28 review #2).</summary>
     static string IdenticalAcrossFields(FieldsDiff.Result diff) =>
         diff.AgreedCount > 0
-            ? $"(no deltas across the requested fields; {diff.AgreedCount} of them read identical to the winner ({SampleOf(diff)}) — other fields NOT compared, list order ignored)"
-            : "(identical to winner across the requested fields, list order ignored — other fields NOT compared)";
+            ? $"(no deltas across the requested fields; {diff.AgreedCount} of them read identical to the winner ({SampleOf(diff)}) — other fields NOT compared)"
+            : "(identical to winner across the requested fields — other fields NOT compared)";
 
     static string SampleOf(FieldsDiff.Result diff)
     {


### PR DESCRIPTION
## What

The winner-relative content compare behind `conflict_tree` / `diff_record` keys list elements by content and compares **multisets**, so a reorder of equal contents reports no delta — correct for lists where order is noise (the USSEP relations case that motivated it). But for a list where order **is** the semantics — a DIAL's INFO children decide which line the game plays — that silence is a wrong answer: the record reads *"identical to winner"* while the one thing that changed is invisible (#275).

## Fix

When the multisets are equal but the positional fingerprint **sequence** differs, emit an explicit `Field: same N item(s), ORDER DIFFERS from winner` note — never element deltas (contents ARE equal). Type-agnostic by design (`FieldsDiff` has no per-record-type wiring): over-reporting a noise reorder is the safe direction, silently equating a semantic one is not — the module's standing posture.

Render wording reconciled so it can't contradict the new note:
- no-delta renders no longer say *"list order ignored"* (order is now compared; the diff header discloses *"element reorders flagged"* once);
- `diff_record`'s description drops *"order-insensitive"* for *"content-keyed (list reorders flagged)"*.

## Testing

- `ConflictDiffProbe` **arm B** — which set up the exact reorder scenario and asserted *"NO delta"* — is updated to assert the ORDER-DIFFERS note. **Verified biting:** fails 19/20 with the check disabled, passes 20/20 with it.
- Full `ci-all`: **106/106**.

## Scope / bookkeeping

This closes the **diff-honesty half** of #275. The larger ask — an effective, *merged* INFO-order view for a topic (xEdit INOM/INOA parity) + the sibling "dropped INFOs" gap — remains open, so this is **`Refs #275`, not `Closes`**. Suggest splitting #275 into (a) this diff fix [done] and (b) a new "effective topic view" issue.

## A tradeoff worth a look

The ORDER-DIFFERS note is generic, so a genuinely-*noise* reorder (e.g. USSEP reordering `Relations`) now shows an order-differs line where before it showed nothing. Per Q3 (loud-beats-silent) and `FieldsDiff`'s over-report-never-under-report posture, that's the right direction — but if you'd rather scope it to order-significant record types, that needs type context threaded into the type-agnostic engine (a design change). Flagging so you can veto at review.

Reported by DrHeisen.

Refs #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)