### PR TITLE
fix(check_errors, remap): a deleted record links to nothing — the #276 rule, shared by all three link walkers

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,18 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**`check_errors` and the compact/merge dependency scan now treat a deleted record the same way (#279).**
+The #276 fix taught `cross_plugin_query` that a deleted record links to nothing; the two sibling walkers that ride the
+same form-link enumeration — `check_errors`' dangling-reference sweep and the external-dependency scan behind
+`compact_plugin` / `merge_plugins` — still walked them. Two consequences, both now fixed. A deleted record's links
+were reported as findings: `check_errors` flagged one as a *dangling reference*, and the compact scan counted one as
+an external *referencer*, which could refuse a compaction over a dependency that isn't live. And a deleted record with
+an engine-authored malformed body threw on the walk and landed in the "could not be scanned" bucket with a raw
+exception cause — the same untyped skip #276 removed, in two more places. The rule now lives in one place shared by
+all three walkers, so they cannot drift apart on it again. Deliberately unchanged: the compact scan still warns about
+a deleted record that *overrides* something being renumbered — that test reads the record's own identity, not its
+body, and such an override is still a dependent worth naming. Surfaced by the independent review of the #276 fix.
+
 **`cross_plugin_query` no longer trips over deleted records and reports them as an unexplained skip (#276).**
 A `references=` (or `where=`) scan over a load order holding *deleted* records — the wild case was deleted `Package`
 records in a follower mod — ended with a raw `NullReferenceException … could not be scanned and were skipped` note.

--- a/src/housecarl-core/DeletedRecordRule.cs
+++ b/src/housecarl-core/DeletedRecordRule.cs
@@ -1,0 +1,45 @@
+using Mutagen.Bethesda.Plugins.Records;
+
+namespace HousecarlCore;
+
+/// <summary>
+/// The ONE place the "a DELETED record has no live body" rule lives, so the load order's link walkers can't drift
+/// apart on it (#279). Three walkers ride Mutagen's <see cref="IFormLinkContainerGetter.EnumerateFormLinks"/> over
+/// every record in an order, and all three must treat a deleted record the same way:
+///   • <c>cross_plugin_query</c>'s references= / where= scan (<c>LoadOrderService.CrossQuery</c>) — #276, the first site.
+///   • <see cref="ErrorCheck"/>'s dangling-ref sweep (housecarl_check_errors), active AND off-order passes.
+///   • <see cref="RemapEngine.IdentifyExternalReferencers"/>'s compact/merge dependency scan.
+///
+/// THE RULE: a major record flagged Deleted carries no content by engine rule — the game reads the header, sees the
+/// flag, and never looks at a body. So its outgoing links are not live: it references nothing, and there is no field
+/// to test. Every walker excludes it BEFORE the link walk.
+///
+/// WHY IT IS ALSO THE CRASH GUARD (#276, and the reason this is not merely cosmetic): an ENGINE-authored deleted
+/// record can leave a content-free-but-not-clean residual body behind (the wild repro was deleted PACKs in a follower
+/// mod). Mutagen's lazy parse then throws on that residual when the walk reaches for its links, and the per-record
+/// fault isolation each walker has accounts it as an UNSCANNABLE skip with a raw exception cause — a deleted record
+/// reading as a parser hole, so a genuine finding hiding in a "skipped" record looks possible when it isn't (Q3).
+/// Skipping it as deleted is the same answer arrived at honestly, with nothing left in the unscannable bucket.
+/// (A Mutagen-AUTHORED deleted record is clean — Mutagen serialises an empty body — so this only bites on records
+/// the engine or another tool wrote.)
+///
+/// SCOPE — this governs the LINK WALK and the body-content filters ONLY. Anything read from the record HEADER stays
+/// live on a deleted record, because the header is parsed eagerly and is not what throws:
+///   • its FormKey — <see cref="RemapEngine.IdentifyExternalReferencers"/>'s external-OVERRIDER test is identity-only
+///     (a deleted override of a record about to be renumbered is still a dependent worth warning about), so it runs
+///     BEFORE this guard, not behind it.
+///   • its EditorID — cross_plugin_query's editoridContains= filter stays live (EDID is an early subrecord, read
+///     before the deep body parse that can throw).
+///
+/// ACKNOWLEDGED BEHAVIOR CHANGE (stated, not implied): a deleted record whose body DOES parse and DOES link to a
+/// searched target is no longer returned by references=, no longer reported as dangling by check_errors, and no
+/// longer listed as an external referencer by the compact/merge scan. That is the "treat a deleted record as
+/// referencing nothing" resolution, applied consistently rather than only where a crash forced it.
+/// </summary>
+public static class DeletedRecordRule
+{
+    /// <summary>True when <paramref name="body"/> is a DELETED major record — so its content, and every FormLink in
+    /// it, is not live and must not be walked. Reads the record header's Deleted flag only; never touches the body,
+    /// so it is safe on exactly the malformed records the walk would throw on.</summary>
+    public static bool HasNoLiveBody(IMajorRecordGetter body) => body.IsDeleted;
+}

--- a/src/housecarl-core/DeletedRecordRule.cs
+++ b/src/housecarl-core/DeletedRecordRule.cs
@@ -3,22 +3,27 @@ using Mutagen.Bethesda.Plugins.Records;
 namespace HousecarlCore;
 
 /// <summary>
-/// The ONE place the "a DELETED record has no live body" rule lives, so the load order's link walkers can't drift
-/// apart on it (#279). Three walkers ride Mutagen's <see cref="IFormLinkContainerGetter.EnumerateFormLinks"/> over
-/// every record in an order, and all three must treat a deleted record the same way:
-///   • <c>cross_plugin_query</c>'s references= / where= scan (<c>LoadOrderService.CrossQuery</c>) — #276, the first site.
+/// The ONE place the "a DELETED record has no live body" rule lives, so the scans that read a record's content can't
+/// drift apart on it (#279). Three walk Mutagen's <see cref="IFormLinkContainerGetter.EnumerateFormLinks"/> over every
+/// record in an order, and all three must treat a deleted record the same way:
+///   • <c>cross_plugin_query</c>'s references= scan (<c>LoadOrderService.CrossQuery</c>) — #276, the first site.
 ///   • <see cref="ErrorCheck"/>'s dangling-ref sweep (housecarl_check_errors), active AND off-order passes.
 ///   • <see cref="RemapEngine.IdentifyExternalReferencers"/>'s compact/merge dependency scan.
+/// <c>cross_plugin_query</c>'s where= arm is guarded alongside its references= arm, but it is NOT one of the link
+/// walks: it reads a field leaf (<c>FieldPredicateSet.Matches</c> → <c>ReadEngine.ReadLeaf</c>), which already
+/// catches its own read faults and answers "(unreadable: …)". It is here on the SEMANTIC ground below only — a
+/// deleted record has no live field to test — never the crash ground.
 ///
 /// THE RULE: a major record flagged Deleted carries no content by engine rule — the game reads the header, sees the
 /// flag, and never looks at a body. So its outgoing links are not live: it references nothing, and there is no field
 /// to test. Every walker excludes it BEFORE the link walk.
 ///
-/// WHY IT IS ALSO THE CRASH GUARD (#276, and the reason this is not merely cosmetic): an ENGINE-authored deleted
-/// record can leave a content-free-but-not-clean residual body behind (the wild repro was deleted PACKs in a follower
-/// mod). Mutagen's lazy parse then throws on that residual when the walk reaches for its links, and the per-record
-/// fault isolation each walker has accounts it as an UNSCANNABLE skip with a raw exception cause — a deleted record
-/// reading as a parser hole, so a genuine finding hiding in a "skipped" record looks possible when it isn't (Q3).
+/// WHY IT IS ALSO THE CRASH GUARD FOR THE THREE LINK WALKS (#276, and the reason this is not merely cosmetic): an
+/// ENGINE-authored deleted record can leave a content-free-but-not-clean residual body behind (the wild repro was
+/// deleted PACKs in a follower mod). Mutagen's lazy parse then throws on that residual when the walk reaches for its
+/// links, and the per-record fault isolation each walker has accounts it as an UNSCANNABLE skip with a raw exception
+/// cause — a deleted record reading as a parser hole, so a genuine finding hiding in a "skipped" record looks
+/// possible when it isn't (Q3).
 /// Skipping it as deleted is the same answer arrived at honestly, with nothing left in the unscannable bucket.
 /// (A Mutagen-AUTHORED deleted record is clean — Mutagen serialises an empty body — so this only bites on records
 /// the engine or another tool wrote.)

--- a/src/housecarl-core/ErrorCheck.cs
+++ b/src/housecarl-core/ErrorCheck.cs
@@ -40,7 +40,9 @@ namespace HousecarlCore;
 /// clean result is never read as byte-for-byte xEdit parity. It also exempts an <see cref="IUntypedOwnerGetter"/>'s
 /// ambiguous "variable" word (#207 — see <see cref="UntypedOwnerVariableData"/>); the one thing that gives up is a
 /// genuinely-dangling Global on an NPC-OWNED item whose owner NPC lives in a master (vanishingly rare, and that owner
-/// NPC is still checked), which we trade for never false-flagging the far commoner faction-owner rank.
+/// NPC is still checked), which we trade for never false-flagging the far commoner faction-owner rank. DELETED records
+/// are excluded from the link walk entirely (#279 — see <see cref="DeletedRecordRule"/>): their content is not live,
+/// so a link one carries is not a dangling reference, and a malformed deleted body no longer reads as a parse hole.
 ///
 /// Composes existing primitives only — no new dependency (audit A1 "Verified 2026-06-25"): the per-plugin record stream
 /// (<c>RecordsIn</c>), the O(1) resolution test (<c>ResolveWinner</c>), presence (<c>ContainsPlugin</c>), the declared-
@@ -123,6 +125,11 @@ public static class ErrorCheck
                     // + accounted, never an opaque whole-call abort and never a silent skip (Q3).
                     try
                     {
+                        // A DELETED record links to nothing (#279 — the shared rule, see DeletedRecordRule): its
+                        // content is not live, so none of its FormLinks can be a dangling reference, and an
+                        // engine-authored deleted body can throw on the walk below and land here as an untyped
+                        // unscannable skip (Q3). Excluded before the walk, at all three walkers alike.
+                        if (DeletedRecordRule.HasNoLiveBody(body)) continue;
                         if (body is not IFormLinkContainerGetter flc) continue;
                         Dictionary<FormKey, int>? ownerVarExempt = null;   // #207: built lazily on this record's first otherwise-dangling link (see UntypedOwnerVariableData)
                         foreach (var link in flc.EnumerateFormLinks())
@@ -201,6 +208,7 @@ public static class ErrorCheck
                         {
                             try
                             {
+                                if (DeletedRecordRule.HasNoLiveBody(rec)) continue;   // #279 — same rule as the active pass above
                                 if (rec is not IFormLinkContainerGetter flc) continue;
                                 Dictionary<FormKey, int>? ownerVarExempt = null;   // #207 (see UntypedOwnerVariableData)
                                 foreach (var link in flc.EnumerateFormLinks())

--- a/src/housecarl-core/RemapEngine.cs
+++ b/src/housecarl-core/RemapEngine.cs
@@ -142,6 +142,13 @@ public static class RemapEngine
                             if (!pluginListedOverride) { externalOverriders.Add(plugin); pluginListedOverride = true; }
                         }
                         // REFERENCER: an outgoing link whose target is being remapped (after the transform it dangles).
+                        // A DELETED record links to nothing (#279 — the shared rule, see DeletedRecordRule): its
+                        // content is not live, so it is not a referencer to repoint, and an engine-authored deleted
+                        // body can throw on the walk below and land in the unscannable bucket as an untyped skip (Q3).
+                        // Deliberately AFTER the overrider test above: that one is identity-only (the record's own
+                        // FormKey, read from the header), and a deleted override of a record about to be renumbered is
+                        // still a dependent worth warning about — this guard scopes to the link walk, nothing else.
+                        if (DeletedRecordRule.HasNoLiveBody(body)) continue;
                         if (body is not IFormLinkContainerGetter flc) continue;
                         foreach (var link in flc.EnumerateFormLinks())
                         {

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -94,6 +94,12 @@ public static class CiAll
         ("subclass-remove-guard", SubclassRemoveGuardProbe.RunGuard),
         ("perk-refs-guard", PerkRefsProbe.RunGuard),
         ("deleted-record-scan-guard", PerkRefsProbe.RunDeletedGuard),
+        // #279 — the SAME deleted-record rule in the two SIBLING link walkers (check_errors' dangling sweep and the
+        // compact/merge dependency scan), now all three routed through DeletedRecordRule. Two arms per walker: the
+        // SEMANTIC one (an intact deleted body's link is not a finding) and the CRASH-CLASS one (a throwing deleted
+        // body is not an untyped unscannable skip), plus a SCOPE arm pinning the guard behind remap's identity-only
+        // overrider test. Controls prove each fixture still exhibits the pre-fix hazard.
+        ("deleted-link-walk-guard", DeletedLinkWalkProbe.RunGuard),
         ("conflict-diff-guard", ConflictDiffProbe.RunGuard),
         ("formid-floor-guard", FormIdFloorProbe.RunGuard),
         ("esl-formid-guard", EslFormIdProbe.RunGuard),

--- a/src/housecarl-generator/DeletedLinkWalkProbe.cs
+++ b/src/housecarl-generator/DeletedLinkWalkProbe.cs
@@ -1,0 +1,263 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SELF-CONTAINED CI REGRESSION GUARD (<c>deleted-link-walk-guard</c>) for #279 — the DELETED-record rule in the two
+/// link walkers that <c>deleted-record-scan-guard</c> (#276, cross_plugin_query) does NOT cover:
+///   • <see cref="ErrorCheck.Run"/> — housecarl_check_errors' dangling-ref sweep.
+///   • <see cref="RemapEngine.IdentifyExternalReferencers"/> — the compact/merge dependency scan.
+/// All three now route through <see cref="DeletedRecordRule.HasNoLiveBody"/>; this pins the two new ones so the set
+/// can't drift back apart.
+///
+/// TWO FAILURE MODES PER WALKER, so a GREEN means the whole rule holds, not just the crash half:
+///   SEMANTIC — a deleted record with a PERFECTLY INTACT body that carries a link. Its content is not live, so that
+///     link is not a dangling reference and not a dependency to repoint. Before the fix it was reported as both.
+///     This arm needs no corruption at all: the discriminator is a wrong FINDING, not an exception.
+///   CRASH-CLASS — a deleted record with a residual body whose LAZY parse throws (the wild #276 shape). Before the
+///     fix it landed in the unscannable bucket with a raw exception cause — a deleted record reading as a parse hole,
+///     so a genuine finding hiding in a "skipped" record looks possible when it isn't (Q3).
+///
+/// FIXTURES — Mutagen cannot author either shape (it writes only well-formed records, and serialises a model-deleted
+/// record with an EMPTY body — the clean case, not the wild one), so both are written normally and then patched on
+/// disk via <see cref="ProbeBytes"/>: the Deleted header flag OR-ed on, and (crash arm) one EPFT byte corrupted.
+///
+///   check_errors — HcDlwGhost.esm (on disk, NOT loaded → every ref into it fails to resolve) + HcDlwErr.esp:
+///     LiveDangler (NPC, Race → the ghost race)  — CONTROL: a live dangling ref the sweep must STILL report.
+///     DeadDangler (NPC, same link, Deleted)     — SEMANTIC arm: must NOT be reported dangling.
+///     DeadThrower (PERK, EPFT corrupt, Deleted) — CRASH arm: must NOT be accounted unscannable.
+///
+///   remap — HcDlwTarget.esp (defines the weapon being renumbered) + HcDlwDep.esp, outside the transform set:
+///     LiveRef  (FormList → the target weapon)          — CONTROL: still detected as an external referencer.
+///     DeadRef  (FormList → same target, Deleted)       — SEMANTIC arm: must NOT be listed as a referencer.
+///     DeadOverride (Weapon at the TARGET's FormKey, Deleted) — SCOPE arm: must STILL be listed as an external
+///       OVERRIDER. The overrider test is identity-only (the record's own FormKey, read from the header), so the
+///       guard belongs behind it, not at the top of the try — this arm is what fails if a future edit moves it.
+///
+/// CONTROLS make each GREEN meaningful (the #276 lesson: an arm that passes with the fix reverted proves nothing).
+/// Before asserting anything, the probe reads each patched record back through a bare overlay and requires it to
+/// (a) report IsDeleted, and (b) STILL exhibit the pre-fix hazard — the intact bodies must still YIELD their link
+/// from EnumerateFormLinks, and the corrupted body must still THROW from it.
+///
+/// Run: dotnet run --project src/housecarl-generator -- deleted-link-walk-guard
+/// </summary>
+public static class DeletedLinkWalkProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("################  REGRESSION GUARD — a DELETED record links to nothing, in check_errors and the compact/merge scan (#279)  ################");
+        Console.WriteLine();
+
+        var tmpDir = Path.Combine(Path.GetTempPath(), "hc-deleted-link-walk-guard-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tmpDir);
+        int fail = 0;
+        void Check(string label, bool ok, string? detail = null)
+        {
+            Console.WriteLine($"  {(ok ? "PASS" : "FAIL")}  {label}{(ok || detail is null ? "" : $"\n        -> {detail}")}");
+            if (!ok) fail++;
+        }
+
+        try
+        {
+            // Sequenced deliberately: `fail += Arms(...)` would read `fail` BEFORE the call and then overwrite
+            // every increment the Check closure made inside it — a probe that reports PASS while arms print FAIL.
+            int errAbort = CheckErrorsArms(tmpDir, Check);
+            fail += errAbort;
+            Console.WriteLine();
+            int remapAbort = RemapArms(tmpDir, Check);
+            fail += remapAbort;
+        }
+        finally { try { Directory.Delete(tmpDir, recursive: true); } catch { /* best-effort */ } }
+
+        Console.WriteLine();
+        Console.WriteLine($"=== deleted-link-walk-guard: {(fail == 0 ? "PASS" : $"FAIL ({fail})")} ===");
+        return fail == 0 ? 0 : 1;
+    }
+
+    // =====================================================================================
+    //  housecarl_check_errors — ErrorCheck.Run
+    // =====================================================================================
+    static int CheckErrorsArms(string tmpDir, Action<string, bool, string?> Check)
+    {
+        Console.WriteLine("-- housecarl_check_errors (ErrorCheck.Run) --");
+
+        string ghostPath = Path.Combine(tmpDir, "HcDlwGhost.esm");
+        string errPath = Path.Combine(tmpDir, "HcDlwErr.esp");
+        var errKey = new ModKey("HcDlwErr", ModType.Plugin);
+        FormKey ghostRaceFk, liveNpcFk, deadNpcFk, deadPerkFk;
+        {
+            var ghost = new SkyrimMod(new ModKey("HcDlwGhost", ModType.Master), SkyrimRelease.SkyrimSE);
+            var gRace = ghost.Races.AddNew(); gRace.EditorID = "HcDlwGhostRace"; ghostRaceFk = gRace.FormKey;
+            ghost.BeginWrite.ToPath(ghostPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+            var err = new SkyrimMod(errKey, SkyrimRelease.SkyrimSE);
+            var live = err.Npcs.AddNew(); live.EditorID = "HcDlwLiveDangler"; live.Race.SetTo(ghostRaceFk); liveNpcFk = live.FormKey;
+            var dead = err.Npcs.AddNew(); dead.EditorID = "HcDlwDeadDangler"; dead.Race.SetTo(ghostRaceFk); deadNpcFk = dead.FormKey;
+            var thrower = err.Perks.AddNew(); thrower.EditorID = "HcDlwDeadThrower"; deadPerkFk = thrower.FormKey;
+            thrower.Effects.Add(new PerkEntryPointModifyActorValue
+            {
+                EntryPoint = APerkEntryPointEffect.EntryType.CalculateWeaponDamage,
+                ActorValue = ActorValue.OneHanded,
+                Value = 1f,
+                Modification = PerkEntryPointModifyActorValue.ModificationType.AddAVMult,
+            });
+            // Declares HcDlwGhost.esm as its one master (the NPCs link into it), so this plugin's OWN records sit at
+            // master index 1 on disk — the raw FormID the byte patcher matches, not the bare object id.
+            err.BeginWrite.ToPath(errPath).WithLoadOrder(new ISkyrimModGetter[] { ghost }).Write();
+        }
+        const uint ownIndex = 1u << 24;      // one declared master ⇒ own records are index 1
+        int corrupted = ProbeBytes.CorruptEpftBytes(errPath);
+        int delNpc = ProbeBytes.SetDeletedFlag(errPath, "NPC_", ownIndex | deadNpcFk.ID);
+        int delPerk = ProbeBytes.SetDeletedFlag(errPath, "PERK", ownIndex | deadPerkFk.ID);
+        Console.WriteLine($"   setup: corrupted {corrupted} EPFT byte(s); flagged {delNpc} NPC_ + {delPerk} PERK Deleted on disk");
+        if (corrupted != 1 || delNpc != 1 || delPerk != 1)
+        {
+            Console.WriteLine($"  FAIL  SETUP — expected 1 EPFT + 1 NPC_ + 1 PERK patched, got {corrupted}/{delNpc}/{delPerk} (fixture layout assumption wrong)");
+            return 1;
+        }
+
+        // CONTROL — the fixture must still exhibit the PRE-FIX hazard, or a GREEN below is vacuous.
+        bool npcDeleted = false, npcStillLinks = false, perkDeleted = false, perkThrows = false;
+        string throwMsg = "(no throw)";
+        using (var ov = SkyrimMod.CreateFromBinaryOverlay(errPath, SkyrimRelease.SkyrimSE))
+        {
+            var deadNpc = ov.Npcs.First(n => n.FormKey == deadNpcFk);
+            npcDeleted = deadNpc.IsDeleted;
+            npcStillLinks = ((IFormLinkContainerGetter)deadNpc).EnumerateFormLinks().Any(l => l.FormKey == ghostRaceFk);
+            var deadPerk = ov.Perks.First(p => p.FormKey == deadPerkFk);
+            perkDeleted = deadPerk.IsDeleted;
+            try { _ = ((IFormLinkContainerGetter)deadPerk).EnumerateFormLinks().Count(); }
+            catch (Exception ex) { perkThrows = true; throwMsg = $"{ex.GetType().Name}: {ex.Message}"; }
+        }
+        Check("CONTROL — the deleted NPC reads as Deleted and its intact body STILL yields the ghost link", npcDeleted && npcStillLinks,
+              $"IsDeleted={npcDeleted}, link still enumerated={npcStillLinks}");
+        Check("CONTROL — the deleted perk reads as Deleted and STILL throws from EnumerateFormLinks", perkDeleted && perkThrows,
+              $"IsDeleted={perkDeleted}, throws={perkThrows} [{throwMsg}]");
+
+        // Drive the REAL sweep. HcDlwGhost.esm is on disk but NOT in the order, so every ref into it fails to resolve.
+        using var resolver = LoadOrderResolver.Build(new[] { errPath });
+        var r = ErrorCheck.Run(resolver, null, limit: 100);
+
+        var dangling = r.Reports.SelectMany(p => p.Dangling).ToList();
+        Check("sweep completed with no Q3 error", r.Success, r.Error);
+        Check("CONTROL — the LIVE dangling ref is still reported (no false clean)",
+              dangling.Any(d => d.Source == liveNpcFk && d.Target == ghostRaceFk),
+              $"dangling = [{string.Join(", ", dangling.Select(d => $"{d.SourceEditorId}→{d.Target}"))}]");
+        // SEMANTIC arm — RED before the fix (the deleted NPC's intact body was walked, so TotalDangling was 2).
+        Check("SEMANTIC — the DELETED record's link is NOT reported dangling (#279)",
+              r.TotalDangling == 1 && dangling.All(d => d.Source != deadNpcFk),
+              $"TotalDangling={r.TotalDangling}, sources = [{string.Join(", ", dangling.Select(d => d.SourceEditorId))}]");
+        // CRASH-CLASS arm — RED before the fix (the deleted perk threw and was accounted as an untyped skip).
+        var samples = r.Reports.SelectMany(p => p.UnscannableSamples).ToList();
+        Check("CRASH-CLASS — the DELETED throwing record is NOT accounted unscannable (#279)",
+              r.TotalUnscannableRecords == 0 && !samples.Any(s => s.Contains(deadPerkFk.ToString(), StringComparison.OrdinalIgnoreCase)),
+              $"TotalUnscannableRecords={r.TotalUnscannableRecords}, samples = [{string.Join(" | ", samples)}]");
+
+        return 0;   // every assertion above reports through Check (which owns the failure count); this returns only the hard SETUP abort
+    }
+
+    // =====================================================================================
+    //  compact/merge dependency scan — RemapEngine.IdentifyExternalReferencers
+    // =====================================================================================
+    static int RemapArms(string tmpDir, Action<string, bool, string?> Check)
+    {
+        Console.WriteLine("-- compact/merge dependency scan (RemapEngine.IdentifyExternalReferencers) --");
+
+        var tKey = new ModKey("HcDlwTarget", ModType.Plugin);
+        var dKey = new ModKey("HcDlwDep", ModType.Plugin);
+        string targetPath = Path.Combine(tmpDir, tKey.FileName.String);
+        string depPath = Path.Combine(tmpDir, dKey.FileName.String);
+        var targetWeapFk = new FormKey(tKey, 0xA01);          // the record about to be renumbered
+        var liveRefFk = new FormKey(dKey, 0xB01);
+        var deadRefFk = new FormKey(dKey, 0xB02);
+        var deadPerkFk = new FormKey(dKey, 0xB03);
+
+        {
+            var t = new SkyrimMod(tKey, SkyrimRelease.SkyrimSE);
+            t.Weapons.Add(new Weapon(targetWeapFk, SkyrimRelease.SkyrimSE) { EditorID = "HcDlwTargetWeap", BasicStats = new WeaponBasicStats { Damage = 7 } });
+            t.BeginWrite.ToPath(targetPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).NoNextFormIDProcessing().Write();
+
+            using var tOv = SkyrimMod.CreateFromBinaryOverlay(targetPath, SkyrimRelease.SkyrimSE);
+            var d = new SkyrimMod(dKey, SkyrimRelease.SkyrimSE);
+            var liveList = new FormList(liveRefFk, SkyrimRelease.SkyrimSE) { EditorID = "HcDlwLiveRef" };
+            liveList.Items.Add(new FormLink<ISkyrimMajorRecordGetter>(targetWeapFk));
+            d.FormLists.Add(liveList);
+            var deadList = new FormList(deadRefFk, SkyrimRelease.SkyrimSE) { EditorID = "HcDlwDeadRef" };
+            deadList.Items.Add(new FormLink<ISkyrimMajorRecordGetter>(targetWeapFk));
+            d.FormLists.Add(deadList);
+            // A pure OVERRIDE of the target's weapon — same FormKey, no outgoing link into the transform set.
+            d.Weapons.Add(new Weapon(targetWeapFk, SkyrimRelease.SkyrimSE) { EditorID = "HcDlwDeadOverride", BasicStats = new WeaponBasicStats { Damage = 9 } });
+            // The CRASH-CLASS fixture for this walker: a perk whose lazy Effects parse throws, flagged Deleted.
+            var thrower = new Perk(deadPerkFk, SkyrimRelease.SkyrimSE) { EditorID = "HcDlwDeadThrower" };
+            thrower.Effects.Add(new PerkEntryPointModifyActorValue
+            {
+                EntryPoint = APerkEntryPointEffect.EntryType.CalculateWeaponDamage,
+                ActorValue = ActorValue.OneHanded,
+                Value = 1f,
+                Modification = PerkEntryPointModifyActorValue.ModificationType.AddAVMult,
+            });
+            d.Perks.Add(thrower);
+            d.ModHeader.Stats.NextFormID = 0xB04;
+            d.BeginWrite.ToPath(depPath).WithLoadOrder(new[] { tOv }).NoNextFormIDProcessing().Write();
+        }
+        // HcDlwDep declares HcDlwTarget as its one master, so its OWN records sit at index 1 on disk while the
+        // OVERRIDE keeps the master's index 0 — the two raw FormIDs the byte patcher must match.
+        int corrupted = ProbeBytes.CorruptEpftBytes(depPath);
+        int delRef = ProbeBytes.SetDeletedFlag(depPath, "FLST", (1u << 24) | deadRefFk.ID);
+        int delPerk = ProbeBytes.SetDeletedFlag(depPath, "PERK", (1u << 24) | deadPerkFk.ID);
+        int delOvr = ProbeBytes.SetDeletedFlag(depPath, "WEAP", targetWeapFk.ID);
+        Console.WriteLine($"   setup: corrupted {corrupted} EPFT byte(s); flagged {delRef} FLST + {delPerk} PERK + {delOvr} WEAP Deleted on disk");
+        if (corrupted != 1 || delRef != 1 || delPerk != 1 || delOvr != 1)
+        {
+            Console.WriteLine($"  FAIL  SETUP — expected 1 EPFT + 1 FLST + 1 PERK + 1 WEAP patched, got {corrupted}/{delRef}/{delPerk}/{delOvr} (fixture layout assumption wrong)");
+            return 1;
+        }
+
+        // CONTROL — the deleted FormList must read as Deleted AND still yield its link, or the SEMANTIC arm is vacuous.
+        bool refDeleted = false, refStillLinks = false, ovrDeleted = false, perkDeleted = false, perkThrows = false;
+        string throwMsg = "(no throw)";
+        using (var ov = SkyrimMod.CreateFromBinaryOverlay(depPath, SkyrimRelease.SkyrimSE))
+        {
+            var deadList = ov.FormLists.First(f => f.FormKey == deadRefFk);
+            refDeleted = deadList.IsDeleted;
+            refStillLinks = ((IFormLinkContainerGetter)deadList).EnumerateFormLinks().Any(l => l.FormKey == targetWeapFk);
+            ovrDeleted = ov.Weapons.First(w => w.FormKey == targetWeapFk).IsDeleted;
+            var deadPerk = ov.Perks.First(p => p.FormKey == deadPerkFk);
+            perkDeleted = deadPerk.IsDeleted;
+            try { _ = ((IFormLinkContainerGetter)deadPerk).EnumerateFormLinks().Count(); }
+            catch (Exception ex) { perkThrows = true; throwMsg = $"{ex.GetType().Name}: {ex.Message}"; }
+        }
+        Check("CONTROL — the deleted FormList reads as Deleted and its intact body STILL yields the target link", refDeleted && refStillLinks,
+              $"IsDeleted={refDeleted}, link still enumerated={refStillLinks}");
+        Check("CONTROL — the external override reads as Deleted (the scope arm's premise)", ovrDeleted, $"IsDeleted={ovrDeleted}");
+        Check("CONTROL — the deleted perk reads as Deleted and STILL throws from EnumerateFormLinks", perkDeleted && perkThrows,
+              $"IsDeleted={perkDeleted}, throws={perkThrows} [{throwMsg}]");
+
+        using var resolver = LoadOrderResolver.Build(new[] { targetPath, depPath });
+        var r = RemapEngine.IdentifyExternalReferencers(
+            resolver,
+            new HashSet<FormKey> { targetWeapFk },
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { tKey.FileName.String });
+
+        Check("CONTROL — the LIVE referencer is still detected (no false clean)",
+              r.Refs.Any(x => x.Source == liveRefFk) && r.HasExternalReferencers,
+              $"refs = [{string.Join(", ", r.Refs.Select(x => x.Source.ToString()))}]");
+        // SEMANTIC arm — RED before the fix (the deleted FormList's intact body was walked, so Refs held 2).
+        Check("SEMANTIC — the DELETED record is NOT listed as an external referencer (#279)",
+              r.Refs.Count == 1 && r.Refs.All(x => x.Source != deadRefFk),
+              $"Refs.Count={r.Refs.Count}, sources = [{string.Join(", ", r.Refs.Select(x => x.Source.ToString()))}]");
+        // SCOPE arm — the guard must sit BEHIND the identity-only overrider test, not at the top of the try.
+        Check("SCOPE — a DELETED external OVERRIDE is still warned (identity test unaffected by the link-walk guard)",
+              r.Overrides.Any(x => x.Record == targetWeapFk) && r.HasExternalOverriders,
+              $"overrides = [{string.Join(", ", r.Overrides.Select(x => $"{x.Plugin}:{x.Record}"))}]");
+        // CRASH-CLASS arm — RED before the fix (the deleted perk threw and was accounted as an untyped skip).
+        Check("CRASH-CLASS — the DELETED throwing record is NOT accounted unscannable (#279)", r.UnscannableRecords == 0,
+              $"UnscannableRecords={r.UnscannableRecords}, samples = [{string.Join(" | ", r.UnscannableSamples)}]");
+
+        return 0;   // as above — Check owns the count; a non-zero return here means the fixture never got built
+    }
+}

--- a/src/housecarl-generator/PerkRefsProbe.cs
+++ b/src/housecarl-generator/PerkRefsProbe.cs
@@ -64,7 +64,7 @@ public static class PerkRefsProbe
             good.NextPerk.SetTo(targetFk);
             mod.BeginWrite.ToPath(espPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
         }
-        int corrupted = CorruptEpftBytes(espPath);
+        int corrupted = ProbeBytes.CorruptEpftBytes(espPath);
         Console.WriteLine($"-- setup: wrote {modKey.FileName} (target + referencing + entry-point perks); corrupted {corrupted} EPFT flag byte(s) --");
         if (corrupted != 1) { Console.WriteLine($"=== perk-refs-guard: FAIL (expected exactly 1 EPFT subrecord to corrupt, found {corrupted}) ==="); return 1; }
 
@@ -157,8 +157,8 @@ public static class PerkRefsProbe
             good.NextPerk.SetTo(targetFk);
             mod.BeginWrite.ToPath(espPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
         }
-        int corrupted = CorruptEpftBytes(espPath);
-        int deleted = SetDeletedFlag(espPath, "PERK", badFk);
+        int corrupted = ProbeBytes.CorruptEpftBytes(espPath);
+        int deleted = ProbeBytes.SetDeletedFlag(espPath, "PERK", badFk.ID);   // master-less fixture ⇒ the on-disk FormID IS the object id
         Console.WriteLine($"-- setup: wrote {modKey.FileName}; corrupted {corrupted} EPFT byte(s); flagged {deleted} record Deleted on disk --");
         if (corrupted != 1 || deleted != 1)
         {
@@ -213,28 +213,6 @@ public static class PerkRefsProbe
         return pass ? 0 : 1;
     }
 
-    /// <summary>Set the record-header Deleted flag (0x20) on the record of signature <paramref name="sig"/> whose
-    /// on-disk FormID equals <paramref name="fk"/>'s object ID (own record ⇒ master index 0), by locating its
-    /// 24-byte header (sig at +0, flags word at +8, FormID at +12) and OR-ing the flags' low byte. The FormID match
-    /// skips the top-GRUP label of the same 4 chars. Returns how many headers matched (caller asserts exactly 1).</summary>
-    static int SetDeletedFlag(string espPath, string sig, FormKey fk)
-    {
-        var bytes = File.ReadAllBytes(espPath);
-        var s = System.Text.Encoding.ASCII.GetBytes(sig);
-        uint id = fk.ID;
-        int hits = 0;
-        for (int i = 0; i + 24 <= bytes.Length; i++)
-        {
-            if (bytes[i] != s[0] || bytes[i + 1] != s[1] || bytes[i + 2] != s[2] || bytes[i + 3] != s[3]) continue;
-            uint formId = (uint)(bytes[i + 12] | (bytes[i + 13] << 8) | (bytes[i + 14] << 16) | (bytes[i + 15] << 24));
-            if (formId != id) continue;
-            bytes[i + 8] |= 0x20;   // SkyrimMajorRecordFlag.Deleted, the flags word's low byte
-            hits++;
-        }
-        if (hits > 0) File.WriteAllBytes(espPath, bytes);
-        return hits;
-    }
-
     /// <summary>REAL-DATA proof (manual; needs an MO2 instance + a generated corpus.json): drive the SERVICE-layer
     /// scan with the report's exact failing call — <c>type=Perk references=01CEAD:Skyrim.esm</c> (KYWD
     /// MagicDamageFire) — over the live order. Before the fix the whole call threw; after, it must return with no
@@ -281,23 +259,6 @@ public static class PerkRefsProbe
         bool pass = q.Error is null;
         Console.WriteLine($"=== perk-refs-proof: {(pass ? "PASS" : "FAIL")} ===");
         return pass ? 0 : 1;
-    }
-
-    /// <summary>Corrupt every EPFT subrecord's parameter-type flag byte in the written plugin (sig + len(2) + 1-byte
-    /// payload → payload at +6), returning how many were hit. The guard writes exactly one entry-point effect, so
-    /// exactly one EPFT is expected — asserted by the caller.</summary>
-    static int CorruptEpftBytes(string espPath)
-    {
-        var bytes = File.ReadAllBytes(espPath);
-        int hits = 0;
-        for (int i = 0; i + 6 < bytes.Length; i++)
-        {
-            if (bytes[i] != (byte)'E' || bytes[i + 1] != (byte)'P' || bytes[i + 2] != (byte)'F' || bytes[i + 3] != (byte)'T') continue;
-            bytes[i + 6] = 0x63;   // not a legal parameter-type flag → ParseEffect throws on lazy Effects parse
-            hits++;
-        }
-        if (hits > 0) File.WriteAllBytes(espPath, bytes);
-        return hits;
     }
 
     public static int RunDiagnose(string[] args)

--- a/src/housecarl-generator/ProbeBytes.cs
+++ b/src/housecarl-generator/ProbeBytes.cs
@@ -1,0 +1,59 @@
+namespace HousecarlGenerator;
+
+/// <summary>
+/// On-disk byte surgery for probe FIXTURES — the small set of edits that produce record shapes Mutagen's writer
+/// cannot author, shared so the guards that need them can't drift apart on the technique (#279).
+///
+/// Both of these exist for the same reason: a probe that needs "a record Mutagen chokes on" or "a deleted record that
+/// still carries a body" cannot get there through the write API. Mutagen writes only well-formed records, and it
+/// serialises a model-deleted record with an EMPTY body — which is exactly the clean case, not the wild one. So the
+/// fixture is written normally and then patched on disk.
+/// </summary>
+public static class ProbeBytes
+{
+    /// <summary>Set the record-header Deleted flag (0x20) on the record of signature <paramref name="sig"/> whose
+    /// on-disk FormID equals <paramref name="rawFormId"/>, by locating its 24-byte header (sig at +0, flags word at
+    /// +8, FormID at +12) and OR-ing the flags' low byte. Returns how many headers matched — the caller asserts the
+    /// expected count, so a fixture whose layout assumption is wrong fails LOUD at setup rather than passing vacuously.
+    ///
+    /// <para><paramref name="rawFormId"/> is the ON-DISK dword, NOT <c>FormKey.ID</c>: the high byte is the record's
+    /// index into its plugin's declared master list, so a plugin's OWN record is <c>(masterCount &lt;&lt; 24) | id</c>
+    /// (masterCount 0 for a master-less plugin) and an OVERRIDE carries the index of the master it overrides. Passing
+    /// the object ID alone works only in the master-less case. The FormID match also skips the top-GRUP label of the
+    /// same 4 chars, which carries the signature but not a matching FormID.</para></summary>
+    public static int SetDeletedFlag(string espPath, string sig, uint rawFormId)
+    {
+        var bytes = File.ReadAllBytes(espPath);
+        var s = System.Text.Encoding.ASCII.GetBytes(sig);
+        int hits = 0;
+        for (int i = 0; i + 24 <= bytes.Length; i++)
+        {
+            if (bytes[i] != s[0] || bytes[i + 1] != s[1] || bytes[i + 2] != s[2] || bytes[i + 3] != s[3]) continue;
+            uint formId = (uint)(bytes[i + 12] | (bytes[i + 13] << 8) | (bytes[i + 14] << 16) | (bytes[i + 15] << 24));
+            if (formId != rawFormId) continue;
+            bytes[i + 8] |= 0x20;   // SkyrimMajorRecordFlag.Deleted, the flags word's low byte
+            hits++;
+        }
+        if (hits > 0) File.WriteAllBytes(espPath, bytes);
+        return hits;
+    }
+
+    /// <summary>Corrupt every EPFT subrecord's parameter-type flag byte in the written plugin (sig + len(2) + 1-byte
+    /// payload → payload at +6), returning how many were hit. This is the suite's canonical "a body whose LAZY parse
+    /// throws" fixture: a perk with one entry-point effect, its EPFT byte set to a value that is not a legal parameter
+    /// type, so <c>ParseEffect</c> throws the moment anything reaches for the perk's Effects. Callers write exactly one
+    /// entry-point effect and assert exactly one hit.</summary>
+    public static int CorruptEpftBytes(string espPath)
+    {
+        var bytes = File.ReadAllBytes(espPath);
+        int hits = 0;
+        for (int i = 0; i + 6 < bytes.Length; i++)
+        {
+            if (bytes[i] != (byte)'E' || bytes[i + 1] != (byte)'P' || bytes[i + 2] != (byte)'F' || bytes[i + 3] != (byte)'T') continue;
+            bytes[i + 6] = 0x63;   // not a legal parameter-type flag → ParseEffect throws on lazy Effects parse
+            hits++;
+        }
+        if (hits > 0) File.WriteAllBytes(espPath, bytes);
+        return hits;
+    }
+}

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2584,8 +2584,10 @@ public sealed class LoadOrderService : IDisposable
                         // DELETED records carry no body to scan (#276; the rule + its full rationale now live in
                         // DeletedRecordRule, shared with check_errors and the compact/merge scan — #279): the
                         // CONTENT filters cannot match one, so exclude it as a clean non-match here, before the
-                        // scan touches its body — which is also what stops the reported crash on an engine-authored
-                        // deleted record's residual body. editorid_contains= stays live: EditorID reads from the
+                        // scan touches its body — which, on the references= arm, is also what stops the reported
+                        // crash on an engine-authored deleted record's residual body (the where= arm's leaf read
+                        // isolates its own faults, so it is excluded on the semantic ground alone — see
+                        // DeletedRecordRule). editorid_contains= stays live: EditorID reads from the
                         // record's early EDID subrecord, before the deep body parse that can throw.
                         if (DeletedRecordRule.HasNoLiveBody(filterBody) && (refSet is not null || predicate is not null)) continue;
                         if (!string.IsNullOrEmpty(editoridContains)

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2581,17 +2581,13 @@ public sealed class LoadOrderService : IDisposable
                             }
                             filterBody = wb;
                         }
-                        // DELETED records carry no body to scan (#276): a Deleted major record's content is
-                        // empty by engine rule, so the CONTENT filters cannot match it — references= links to
-                        // nothing, where= has no field to test. So exclude it as a clean non-match here, before
-                        // the scan touches its body. This is also what stops the reported crash: engine-authored
-                        // deleted records (the wild repro was deleted PACKs) can leave a content-free-but-not-clean
-                        // body that NullRefs when EnumerateFormLinks (references=) / the where= predicate lazily
-                        // parse it — which then lands in the unscannable bucket below as an untyped skip, reading
-                        // as a parser hole, so a genuine match hiding in a "skipped" record looks possible when it
-                        // isn't (Q3). editorid_contains= stays live: EditorID reads from the record's early EDID
-                        // subrecord, before the deep body parse that can throw — safe on a deleted record.
-                        if (filterBody.IsDeleted && (refSet is not null || predicate is not null)) continue;
+                        // DELETED records carry no body to scan (#276; the rule + its full rationale now live in
+                        // DeletedRecordRule, shared with check_errors and the compact/merge scan — #279): the
+                        // CONTENT filters cannot match one, so exclude it as a clean non-match here, before the
+                        // scan touches its body — which is also what stops the reported crash on an engine-authored
+                        // deleted record's residual body. editorid_contains= stays live: EditorID reads from the
+                        // record's early EDID subrecord, before the deep body parse that can throw.
+                        if (DeletedRecordRule.HasNoLiveBody(filterBody) && (refSet is not null || predicate is not null)) continue;
                         if (!string.IsNullOrEmpty(editoridContains)
                             && (filterBody.EditorID is null || filterBody.EditorID.IndexOf(editoridContains, StringComparison.OrdinalIgnoreCase) < 0))
                             continue;


### PR DESCRIPTION
Fixes #279

## What

#276 (PR #277) taught `cross_plugin_query`'s scan that a **deleted** major record carries no live body — so it links to nothing, and reaching for its form links can NullRef on an engine-authored residual body, landing it in the unscannable bucket as an *untyped* skip (a deleted record reading as a parser hole, Q3). The independent review of that PR found the same `EnumerateFormLinks` walk, **without** the deleted-record recognition, in two siblings:

- `ErrorCheck` — `housecarl_check_errors`' dangling-ref sweep (both the active and the off-order pass)
- `RemapEngine.IdentifyExternalReferencers` — the compact/merge dependency scan

Both failure modes were live there:

| | Before | After |
|---|---|---|
| **Semantic** | `check_errors` reported a deleted record's link as a **dangling reference**; the compact scan counted a deleted record as an external **referencer** — which can refuse a compaction over a dependency that isn't live | Neither: a deleted record links to nothing |
| **Crash-class** | A malformed deleted body threw on the walk and was accounted as an unscannable skip with a raw exception cause | Excluded before the walk; nothing left in the bucket |

The rule now has **one home** — `DeletedRecordRule.HasNoLiveBody`, carrying the full rationale — and all three walkers route through it, per the issue's "worth a shared helper so the three walkers can't drift." `cross_plugin_query`'s site is rewired to it; its behavior is unchanged.

## Scope, stated because it's easy to get wrong

This governs the **link walk only**. Anything read from the record **header** stays live on a deleted record. In particular the guard sits deliberately **behind** `RemapEngine`'s external-**overrider** test, which is identity-only (the record's own FormKey) — a deleted override of a record about to be renumbered is still a dependent worth warning about, and hoisting the guard above it would silently drop that warning. There is a probe arm whose only job is to fail if a future edit does that.

## Acknowledged behavior change

Same as #276's, now applied consistently: a deleted record whose body *does* parse and *does* carry a matching link is no longer reported dangling and no longer listed as an external referencer. That is the "treat a deleted record as referencing nothing" resolution the report proposed — stated, not implied. Landed as an `## Unreleased` CHANGELOG entry.

## Proof — `deleted-link-walk-guard`, verified biting

New self-contained CI guard, registered in `CiAll`. **Two discriminators per walker**, so a GREEN means the whole rule holds rather than just the crash half:

- **SEMANTIC** — a deleted record with a *perfectly intact* body carrying a link. No corruption needed; the discriminator is a wrong **finding**, not an exception.
- **CRASH-CLASS** — a deleted record whose lazy parse throws (the wild #276 shape).

**Verified RED, not assumed.** With both guards reverted the probe fails on all four discriminators (`check_errors` `TotalDangling=2` + 1 unscannable; remap `Refs.Count=2` + 1 unscannable) while every CONTROL and the SCOPE arm stay green. The controls are the #276 lesson applied up front: before asserting anything, the probe reads each patched record back and requires it to still exhibit the pre-fix hazard — intact bodies must still *yield* their link, the corrupted one must still *throw*.

`ci-all` — **108/108** (was 107).

## Fixture note

Mutagen cannot author either shape (it writes only well-formed records, and serialises a model-deleted record with an *empty* body — the clean case, not the wild one), so fixtures are written normally then patched on disk. Those two byte edits move out of `PerkRefsProbe` into a shared `ProbeBytes` so the technique does not get copy-pasted either. `SetDeletedFlag` now takes the **raw on-disk FormID** rather than `FormKey.ID`, because the new fixtures have declared masters (own records at index 1, an override at the master's index 0) where the bare object id would silently match nothing. Every call site asserts its expected hit count, so a wrong layout assumption fails loud at setup instead of passing vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
