### PR TITLE
fix(assets): an ABSENT path missing its meshes\ root now says so — verified, not guessed

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -19,6 +19,17 @@ exception cause — the same untyped skip #276 removed, in two more places. The 
 all three walkers, so they cannot drift apart on it again. Deliberately unchanged: the compact scan still warns about
 a deleted record that *overrides* something being renumbered — that test reads the record's own identity, not its
 body, and such an override is still a dependent worth naming. Surfaced by the independent review of the #276 fix.
+**An asset path that's missing its `meshes\` / `textures\` root now says so, instead of a bare ABSENT (#273).**
+A model path read straight off a record — `Model.File` on an NPC, ARMA, STAT — is stored relative to `meshes\`, but
+every asset tool wants it Data-relative. So the *normal* way one arrives at a mesh produced a flat, hint-free
+`ABSENT — no active mod or BSA provides this mesh path`: a true answer for the string as given, but a dead end unless
+you already knew the convention. `nif_inspect`, `nif_set` and `asset_status` now retry the root-prefixed form and,
+when it hits, name it — `did you mean 'meshes\Actors\…\wolf.nif'?`. The suggestion is **verified, not guessed**: it
+comes from actually re-resolving the candidate through the same VFS, so a path it names is always one a mod or BSA
+really provides, and when nothing resolves nothing is suggested. `asset_status` tries both roots (it can't know a
+path's kind) and stays silent otherwise — `sound\`, `scripts\` and the rest get no lecture. The mesh tools, which
+only ever deal in meshes, add one weaker note when the prefixed form misses too: it names the convention and the
+form the path would take, and says plainly that form isn't provided either. Reported externally.
 
 **`cross_plugin_query` no longer trips over deleted records and reports them as an unexplained skip (#276).**
 A `references=` (or `where=`) scan over a load order holding *deleted* records — the wild case was deleted `Package`

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -24,7 +24,7 @@ A model path read straight off a record — `Model.File` on an NPC, ARMA, STAT �
 every asset tool wants it Data-relative. So the *normal* way one arrives at a mesh produced a flat, hint-free
 `ABSENT — no active mod or BSA provides this mesh path`: a true answer for the string as given, but a dead end unless
 you already knew the convention. `nif_inspect`, `nif_set` and `asset_status` now retry the root-prefixed form and,
-when it hits, name it — `did you mean 'meshes\Actors\…\wolf.nif'?`. The suggestion is **verified, not guessed**: it
+when it hits, name it — ``did you mean `meshes\Actors\…\wolf.nif`?``. The suggestion is **verified, not guessed**: it
 comes from actually re-resolving the candidate through the same VFS, so a path it names is always one a mod or BSA
 really provides, and when nothing resolves nothing is suggested. `asset_status` tries both roots (it can't know a
 path's kind) and stays silent otherwise — `sound\`, `scripts\` and the rest get no lecture. The mesh tools, which

--- a/src/housecarl-core/AssetPathHint.cs
+++ b/src/housecarl-core/AssetPathHint.cs
@@ -65,10 +65,14 @@ public static class AssetPathHint
         if (norm.Length == 0) return null;
         if (norm.StartsWith(@"meshes\", StringComparison.OrdinalIgnoreCase)) return null;   // already Data-relative — the prefix isn't what's wrong
 
+        // BACKTICK-delimited, not single-quoted — the same reason PluginNameSuggest.DidYouMean moved to backticks
+        // (commit 7c5dfe1): the thing being quoted is author-controlled text that routinely carries an apostrophe
+        // (a mod's "Sanguine's Trade" folder, a "Dragon's Reach" mesh subtree), which collides with a wrapping '
+        // and reads as a broken quote. Backticks never collide with the path's own characters.
         var hits = VerifiedPrefixes(view, norm, MeshRoot);
         if (hits.Count > 0)
-            return $"Did you mean '{hits[0]}'? A record's Model.File is stored relative to meshes\\, so it needs the meshes\\ prefix to be Data-relative.";
+            return $"Did you mean `{hits[0]}`? A record's Model.File is stored relative to meshes\\, so it needs the meshes\\ prefix to be Data-relative.";
         return $"This path is not under meshes\\ — if it came from a record's Model.File, that field is stored relative to meshes\\, "
-             + $"so the Data-relative form would be 'meshes\\{norm}' (not provided by any active mod or BSA either).";
+             + $"so the Data-relative form would be `meshes\\{norm}` (not provided by any active mod or BSA either).";
     }
 }

--- a/src/housecarl-core/AssetPathHint.cs
+++ b/src/housecarl-core/AssetPathHint.cs
@@ -1,0 +1,74 @@
+namespace HousecarlCore;
+
+/// <summary>
+/// The "you probably dropped the root folder" suggestion for an asset path that resolved to nothing (#273).
+///
+/// THE PAPERCUT: a model path read straight off a record — <c>Model.File</c> on an NPC / ARMA / STAT — is stored
+/// relative to <c>meshes\</c>, but every asset tool wants it Data-relative. Passing the record's own value verbatim
+/// is therefore the NORMAL way one arrives at a mesh, and it returns a flat ABSENT with nothing saying why. The
+/// answer is true for the string as given, so this is not a wrong answer — but the caller has to already know the
+/// convention to get past it, and spends a round trip discovering it.
+///
+/// VERIFIED, NEVER GUESSED — the house posture for suggestions (<see cref="PluginNameSuggest"/>: a wrong "did you
+/// mean" is worse than none). This does not pattern-match the path or reason about what it looks like; it RE-RESOLVES
+/// the prefixed candidate through the same asset view and returns it only if a real active mod or BSA provides it.
+/// A suggestion that comes back therefore always names a file that exists. If nothing hits, nothing is suggested,
+/// and the caller is free to say the weaker, honest thing instead ("that field is stored relative to meshes\")
+/// without claiming any file exists.
+///
+/// Cost: one extra snapshot lookup per already-failed path, on a path that is by definition not in the hot loop.
+/// </summary>
+public static class AssetPathHint
+{
+    /// <summary>The root a record's model path is relative to — the whole reason this helper exists.</summary>
+    public static readonly string[] MeshRoot = { @"meshes\" };
+
+    /// <summary>Both asset roots a bare record-relative path could belong under, for the generic asset lane where the
+    /// path's kind isn't known from the tool (a mesh path and a texture path arrive through the same door).</summary>
+    public static readonly string[] AssetRoots = { @"meshes\", @"textures\" };
+
+    /// <summary>Every <paramref name="prefixes"/> candidate that a real provider supplies for <paramref name="rel"/>
+    /// — i.e. the paths the caller probably meant. EMPTY when there is nothing honest to suggest, which is the common
+    /// case and the safe default:
+    ///   • <paramref name="rel"/> already starts with one of the roots → the missing prefix is not the problem here.
+    ///   • no prefixed candidate resolves → the file genuinely isn't there under any of them.
+    ///   • the path is empty, or so malformed that even the prefixed form is rejected (drive-rooted, '..'-escaping).
+    /// Never throws: a rejected candidate is simply not a suggestion.</summary>
+    public static IReadOnlyList<string> VerifiedPrefixes(AssetResolver.AssetView view, string rel, IReadOnlyList<string> prefixes)
+    {
+        var norm = (rel ?? "").Trim().Replace('/', '\\').TrimStart('\\');
+        if (norm.Length == 0) return Array.Empty<string>();
+        foreach (var p in prefixes)
+            if (norm.StartsWith(p, StringComparison.OrdinalIgnoreCase))
+                return Array.Empty<string>();
+
+        List<string>? hits = null;
+        foreach (var p in prefixes)
+        {
+            var candidate = p + norm;
+            try
+            {
+                if (view.Resolve(candidate).Exists) (hits ??= new List<string>()).Add(candidate);
+            }
+            catch (ArgumentException) { /* the prefixed form is still not a legal Data-relative path — nothing to suggest */ }
+        }
+        return (IReadOnlyList<string>?)hits ?? Array.Empty<string>();
+    }
+
+    /// <summary>The sentence to append to an ABSENT message for a MESH tool, or null when there is nothing to add.
+    /// Two strengths, and the difference between them is load-bearing (Q3): a VERIFIED hit names the file and says
+    /// "did you mean"; a miss names only the CONVENTION and the form the path would take, explicitly stating that
+    /// form isn't provided either — so the weaker note can never be read as "the file is over there".</summary>
+    public static string? MeshHint(AssetResolver.AssetView view, string rel)
+    {
+        var norm = (rel ?? "").Trim().Replace('/', '\\').TrimStart('\\');
+        if (norm.Length == 0) return null;
+        if (norm.StartsWith(@"meshes\", StringComparison.OrdinalIgnoreCase)) return null;   // already Data-relative — the prefix isn't what's wrong
+
+        var hits = VerifiedPrefixes(view, norm, MeshRoot);
+        if (hits.Count > 0)
+            return $"Did you mean '{hits[0]}'? A record's Model.File is stored relative to meshes\\, so it needs the meshes\\ prefix to be Data-relative.";
+        return $"This path is not under meshes\\ — if it came from a record's Model.File, that field is stored relative to meshes\\, "
+             + $"so the Data-relative form would be 'meshes\\{norm}' (not provided by any active mod or BSA either).";
+    }
+}

--- a/src/housecarl-generator/AssetPrefixHintProbe.cs
+++ b/src/housecarl-generator/AssetPrefixHintProbe.cs
@@ -74,14 +74,14 @@ internal static class AssetPrefixHintProbe
             var rPrefixed = batch.Results[2];
             var rReal = batch.Results[3];
 
-            Check(rRecord.Absent && (rRecord.Error?.Contains("Did you mean '" + MeshRel + "'", StringComparison.OrdinalIgnoreCase) ?? false),
+            Check(rRecord.Absent && (rRecord.Error?.Contains("Did you mean `" + MeshRel + "`", StringComparison.OrdinalIgnoreCase) ?? false),
                   "FIRES — the record-relative path is ABSENT, and the answer names the meshes\\-prefixed path that IS provided",
                   rRecord.Error);
             // The teeth against a string heuristic: this path LOOKS exactly as record-relative as the one above.
             // Only a real re-resolve can tell them apart, so a "did you mean" here would be a wrong suggestion.
             Check(rNoHit.Absent
                   && !(rNoHit.Error?.Contains("Did you mean", StringComparison.OrdinalIgnoreCase) ?? true)
-                  && (rNoHit.Error?.Contains(@"'meshes\nowhere\ghost.nif'", StringComparison.OrdinalIgnoreCase) ?? false)
+                  && (rNoHit.Error?.Contains(@"`meshes\nowhere\ghost.nif`", StringComparison.OrdinalIgnoreCase) ?? false)
                   && (rNoHit.Error?.Contains("not provided", StringComparison.OrdinalIgnoreCase) ?? false),
                   "NOT-A-GUESS — a record-relative path whose prefixed form ALSO misses gets no 'did you mean', only the convention note (which claims no file)",
                   rNoHit.Error);
@@ -100,7 +100,7 @@ internal static class AssetPrefixHintProbe
             Console.WriteLine("--- nif_set ---");
             var set = svc.NifSet(RecordRel, new[] { new NifSetOp(NifSetOpKind.RenameShape, "Old", NewName: "New") },
                                  null, null, null, false, false);
-            Check(set.Error is not null && (set.Error?.Contains("Did you mean '" + MeshRel + "'", StringComparison.OrdinalIgnoreCase) ?? false),
+            Check(set.Error is not null && (set.Error?.Contains("Did you mean `" + MeshRel + "`", StringComparison.OrdinalIgnoreCase) ?? false),
                   "NIF-SET — the same verified suggestion rides the nif_set ABSENT refusal", set.Error);
 
             // ---------- asset_status (both roots; verified-only, no speculative note) ----------

--- a/src/housecarl-generator/AssetPrefixHintProbe.cs
+++ b/src/housecarl-generator/AssetPrefixHintProbe.cs
@@ -1,0 +1,167 @@
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// SELF-CONTAINED CI REGRESSION GUARD (<c>asset-prefix-hint-guard</c>) for #273 — the missing-root suggestion on an
+/// ABSENT asset path. A model path read straight off a record (<c>Model.File</c>) is stored relative to
+/// <c>meshes\</c>, so passing it verbatim — the NORMAL way one arrives at a mesh — used to return a flat, hint-free
+/// ABSENT. Now the tools RE-RESOLVE the root-prefixed form and say so when it hits.
+///
+/// Drives the REAL service (<see cref="LoadOrderService.NifInspect"/> / <see cref="LoadOrderService.NifSet"/> /
+/// <see cref="LoadOrderService.AssetStatus"/>) over a synthetic MO2 instance with loose assets — no game data, no
+/// BSArch. The instance holds <c>meshes\actors\canine\wolf.nif</c> and <c>textures\actors\canine\wolf.dds</c>, so a
+/// record-relative <c>actors\canine\wolf.nif</c> is exactly the reported repro.
+///
+/// The arms are deliberately paired — the SUGGESTION and its ABSENCE are equally load-bearing, because the failure
+/// mode a bad "did you mean" introduces (sending a caller to a file that isn't there) is worse than the papercut it
+/// fixes (<see cref="PluginNameSuggest"/>'s posture, which this follows):
+///   FIRES        — nif_inspect on the record-relative path names the meshes\-prefixed path that really is provided.
+///   NOT-A-GUESS  — a record-relative path whose prefixed form ALSO misses gets NO "did you mean" (only the weaker
+///                  convention note, which names no file). This is the arm a string-heuristic implementation fails.
+///   NO-NOISE     — a path already under meshes\ that is simply absent gets no hint at all: the prefix isn't wrong.
+///   NIF-SET      — the same suggestion rides the nif_set refusal (the sibling site, same input mistake).
+///   ASSET-MESH / ASSET-TEX — asset_status tries BOTH roots, since that lane can't know the path's kind.
+///   ASSET-QUIET  — asset_status stays silent for a genuinely-absent path AND for a non-asset-root path
+///                  (sound\, scripts\ … legitimately live there; a meshes\ lecture would be noise), and prints
+///                  nothing at all when the path resolves.
+///
+/// Run: dotnet run --project src/housecarl-generator -- asset-prefix-hint-guard
+/// </summary>
+internal static class AssetPrefixHintProbe
+{
+    const string MeshRel = @"meshes\actors\canine\wolf.nif";      // what the file really is, Data-relative
+    const string RecordRel = @"actors\canine\wolf.nif";           // what the RECORD's Model.File holds — the repro
+    const string TexRel = @"textures\actors\canine\wolf.dds";
+    const string TexRecordRel = @"actors\canine\wolf.dds";
+
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" asset-prefix-hint guard — a record-relative path gets a VERIFIED root suggestion, never a guess (#273)");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label, string? detail = null)
+        {
+            Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label + (c || detail is null ? "" : $"\n        -> {detail}"));
+            if (!c) fail++;
+        }
+
+        var root = Path.Combine(Path.GetTempPath(), "hc-asset-prefix-hint-guard-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var inst = Path.Combine(root, "inst");
+            var mods = Path.Combine(inst, "mods");
+            var data = Path.Combine(inst, "game", "Data");
+            var prof = Path.Combine(inst, "profiles", "Default");
+            var modA = Path.Combine(mods, "WolfMod");
+            foreach (var d in new[] { data, prof, modA }) Directory.CreateDirectory(d);
+            WriteLoose(modA, MeshRel);
+            WriteLoose(modA, TexRel);
+            WriteProfile(prof, Array.Empty<string>(), Array.Empty<string>(), new[] { "+WolfMod" });
+            WriteSkyrimIni(prof);
+            WriteIni(inst, "Default", Path.Combine(inst, "game"));
+
+            using var svc = LoadOrderService.WithInstance(inst, 0, new UserConfigStore(Path.Combine(root, "user.json")));
+
+            // ---------- nif_inspect ----------
+            Console.WriteLine("--- nif_inspect ---");
+            var batch = svc.NifInspect(new[] { RecordRel, @"nowhere\ghost.nif", @"meshes\nowhere\ghost.nif", MeshRel }, null);
+            var rRecord = batch.Results[0];
+            var rNoHit = batch.Results[1];
+            var rPrefixed = batch.Results[2];
+            var rReal = batch.Results[3];
+
+            Check(rRecord.Absent && (rRecord.Error?.Contains("Did you mean '" + MeshRel + "'", StringComparison.OrdinalIgnoreCase) ?? false),
+                  "FIRES — the record-relative path is ABSENT, and the answer names the meshes\\-prefixed path that IS provided",
+                  rRecord.Error);
+            // The teeth against a string heuristic: this path LOOKS exactly as record-relative as the one above.
+            // Only a real re-resolve can tell them apart, so a "did you mean" here would be a wrong suggestion.
+            Check(rNoHit.Absent
+                  && !(rNoHit.Error?.Contains("Did you mean", StringComparison.OrdinalIgnoreCase) ?? true)
+                  && (rNoHit.Error?.Contains(@"'meshes\nowhere\ghost.nif'", StringComparison.OrdinalIgnoreCase) ?? false)
+                  && (rNoHit.Error?.Contains("not provided", StringComparison.OrdinalIgnoreCase) ?? false),
+                  "NOT-A-GUESS — a record-relative path whose prefixed form ALSO misses gets no 'did you mean', only the convention note (which claims no file)",
+                  rNoHit.Error);
+            bool prefixedQuiet = rPrefixed.Error is { } prefErr
+                                 && !prefErr.Contains("Did you mean", StringComparison.OrdinalIgnoreCase)
+                                 && !prefErr.Contains("stored relative to", StringComparison.OrdinalIgnoreCase);
+            Check(rPrefixed.Absent && prefixedQuiet,
+                  "NO-NOISE — a path already under meshes\\ that is simply absent gets no prefix hint at all",
+                  rPrefixed.Error);
+            Check(!rReal.Absent && rReal.Providers.Count == 1,
+                  "CONTROL — the real Data-relative path still resolves (the hint path never touches a hit)",
+                  rReal.Error);
+
+            // ---------- nif_set (the sibling site) ----------
+            Console.WriteLine();
+            Console.WriteLine("--- nif_set ---");
+            var set = svc.NifSet(RecordRel, new[] { new NifSetOp(NifSetOpKind.RenameShape, "Old", NewName: "New") },
+                                 null, null, null, false, false);
+            Check(set.Error is not null && (set.Error?.Contains("Did you mean '" + MeshRel + "'", StringComparison.OrdinalIgnoreCase) ?? false),
+                  "NIF-SET — the same verified suggestion rides the nif_set ABSENT refusal", set.Error);
+
+            // ---------- asset_status (both roots; verified-only, no speculative note) ----------
+            Console.WriteLine();
+            Console.WriteLine("--- asset_status ---");
+            var st = svc.AssetStatus(new[] { RecordRel, TexRecordRel, @"nowhere\ghost.nif", @"sound\fx\ghost.wav", MeshRel });
+            var sMesh = st.Results[0];
+            var sTex = st.Results[1];
+            var sMiss = st.Results[2];
+            var sOther = st.Results[3];
+            var sHit = st.Results[4];
+
+            Check(sMesh.Hit is { Exists: false } && (sMesh.PrefixSuggestions?.Contains(MeshRel) ?? false),
+                  "ASSET-MESH — a record-relative mesh path suggests its meshes\\ form",
+                  string.Join(",", sMesh.PrefixSuggestions ?? Array.Empty<string>()));
+            Check(sTex.Hit is { Exists: false } && (sTex.PrefixSuggestions?.Contains(TexRel) ?? false),
+                  "ASSET-TEX — a record-relative texture path suggests its textures\\ form (this lane can't know the kind, so it tries both)",
+                  string.Join(",", sTex.PrefixSuggestions ?? Array.Empty<string>()));
+            Check(sMiss.Hit is { Exists: false } && (sMiss.PrefixSuggestions?.Count ?? 0) == 0,
+                  "ASSET-QUIET — a genuinely absent path suggests nothing",
+                  string.Join(",", sMiss.PrefixSuggestions ?? Array.Empty<string>()));
+            Check(sOther.Hit is { Exists: false } && (sOther.PrefixSuggestions?.Count ?? 0) == 0,
+                  "ASSET-QUIET — a non-asset-root path (sound\\) gets no meshes\\ lecture",
+                  string.Join(",", sOther.PrefixSuggestions ?? Array.Empty<string>()));
+            Check(sHit.Hit is { Exists: true } && (sHit.PrefixSuggestions?.Count ?? 0) == 0,
+                  "ASSET-QUIET — a path that RESOLVES carries no suggestion");
+
+            // The rendered surface is what the user actually reads — a data-only fix would be invisible.
+            var rendered = AssetWire.Render(st, 20000);
+            Check(rendered.Contains("did you mean", StringComparison.OrdinalIgnoreCase) && rendered.Contains(MeshRel, StringComparison.OrdinalIgnoreCase),
+                  "RENDER — the suggestion reaches the rendered asset_status output, not just the data record");
+        }
+        finally { try { Directory.Delete(root, recursive: true); } catch { /* best-effort */ } }
+
+        Console.WriteLine();
+        Console.WriteLine(fail == 0 ? "================ ALL PASS ================" : $"================ {fail} CHECK(S) FAILED ================");
+        return fail == 0 ? 0 : 1;
+    }
+
+    // ---- synthetic MO2 layout helpers (the asset-status guard's shape) ----
+
+    static void WriteProfile(string profDir, string[] loadorder, string[] plugins, string[] modlist)
+    {
+        Directory.CreateDirectory(profDir);
+        File.WriteAllText(Path.Combine(profDir, "loadorder.txt"), "# header\r\n" + string.Join("\r\n", loadorder) + "\r\n");
+        File.WriteAllText(Path.Combine(profDir, "plugins.txt"), string.Join("\r\n", plugins) + "\r\n");
+        File.WriteAllText(Path.Combine(profDir, "modlist.txt"), "# header\r\n" + string.Join("\r\n", modlist) + "\r\n");
+    }
+
+    static void WriteSkyrimIni(string profDir) =>
+        File.WriteAllText(Path.Combine(profDir, "Skyrim.ini"), "[Archive]\r\nsResourceArchiveList=\r\n");
+
+    static void WriteIni(string inst, string profile, string gameDir) =>
+        File.WriteAllText(Path.Combine(inst, "ModOrganizer.ini"),
+            "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(" + profile + ")\r\ngamePath=@ByteArray("
+            + gameDir.Replace(@"\", @"\\") + ")\r\n");
+
+    static void WriteLoose(string baseDir, string rel)
+    {
+        var p = Path.Combine(baseDir, rel);
+        Directory.CreateDirectory(Path.GetDirectoryName(p)!);
+        File.WriteAllText(p, "x");
+    }
+}

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -166,6 +166,11 @@ public static class CiAll
         ("overwrite-resolve-guard", OverwriteResolveProbe.RunGuard),
         ("asset-resolver-guard", AssetResolverProbe.RunGuard),
         ("asset-status-guard", AssetStatusProbe.RunGuard),
+        // #273 — the missing-root suggestion on an ABSENT asset path (a record's Model.File is stored relative to
+        // meshes\, so passing it verbatim is the normal way one arrives at a mesh). Drives the real nif_inspect /
+        // nif_set / asset_status over a synthetic instance. Paired arms: the suggestion FIRES on a re-resolvable
+        // path, and is ABSENT for a look-alike that doesn't resolve — the teeth against a string heuristic.
+        ("asset-prefix-hint-guard", AssetPrefixHintProbe.RunGuard),
         // SKSE-plugin-layer visibility (gap 2026-06-08, tier C): pins the SKSEPlugin_Version decode contract (the
         // reverse-engineered offset map — supportEmail is 252, not 256 — + the flag/version/compat interpretation) and
         // the honest-degrade paths (real-PE Read → NotSkse; non-PE / missing → Unreadable, never a throw).

--- a/src/housecarl-mcp/AssetTools.cs
+++ b/src/housecarl-mcp/AssetTools.cs
@@ -95,8 +95,10 @@ static class AssetWire
             // #273 — a path taken straight off a record is missing its root folder (a model path is stored relative
             // to meshes\, a texture path to textures\). Every suggestion here was VERIFIED by re-resolving the
             // prefixed form, so it names a file that really is provided; when nothing resolved, nothing is printed.
+            // Backticks, not single quotes — an asset path carries the mod author's own apostrophes (PluginNameSuggest's
+            // lesson, commit 7c5dfe1: a wrapping ' collides with the quoted text and reads as a broken quote).
             if (r.PrefixSuggestions is { Count: > 0 } sug)
-                sb.Append("  did you mean ").Append(string.Join(" or ", sug.Select(s => "'" + s + "'")))
+                sb.Append("  did you mean ").Append(string.Join(" or ", sug.Select(s => "`" + s + "`")))
                   .Append("?  (a path read off a record is relative to its root folder, not to Data)\n");
             // Both "the scan was incomplete" conditions hedge an ABSENT at the POINT OF USE (Q3 — symmetric honesty),
             // not just at the top-of-output note: an archive that failed to READ, AND base archives that were never

--- a/src/housecarl-mcp/AssetTools.cs
+++ b/src/housecarl-mcp/AssetTools.cs
@@ -92,6 +92,12 @@ static class AssetWire
         if (!hit.Exists)
         {
             sb.Append("  ABSENT — no active mod or BSA provides this path\n");
+            // #273 — a path taken straight off a record is missing its root folder (a model path is stored relative
+            // to meshes\, a texture path to textures\). Every suggestion here was VERIFIED by re-resolving the
+            // prefixed form, so it names a file that really is provided; when nothing resolved, nothing is printed.
+            if (r.PrefixSuggestions is { Count: > 0 } sug)
+                sb.Append("  did you mean ").Append(string.Join(" or ", sug.Select(s => "'" + s + "'")))
+                  .Append("?  (a path read off a record is relative to its root folder, not to Data)\n");
             // Both "the scan was incomplete" conditions hedge an ABSENT at the POINT OF USE (Q3 — symmetric honesty),
             // not just at the top-of-output note: an archive that failed to READ, AND base archives that were never
             // DISCOVERED (a Skyrim.ini we couldn't find → vanilla "Skyrim - Textures*.bsa" unscanned). Either means the

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -305,7 +305,18 @@ public sealed class LoadOrderService : IDisposable
             foreach (var raw in relPaths)
             {
                 var p = (raw ?? "").Trim();
-                try { results.Add(new AssetPathResult(p, view.Resolve(p), null)); }
+                try
+                {
+                    var hit = view.Resolve(p);
+                    // ABSENT only: a path taken off a record is stored relative to its ROOT folder (a model path to
+                    // meshes\, a texture path to textures\), so the flat ABSENT was a dead end for the normal way
+                    // one arrives at an asset (#273). Both roots are tried because this lane, unlike nif_inspect,
+                    // doesn't know the path's kind. VERIFIED only here — no speculative note: asset_status legitimately
+                    // answers for sound\, scripts\, interface\ and the rest, where a meshes\ lecture would be noise.
+                    var suggest = hit.Exists ? Array.Empty<string>()
+                                             : AssetPathHint.VerifiedPrefixes(view, p, AssetPathHint.AssetRoots);
+                    results.Add(new AssetPathResult(p, hit, null, suggest));
+                }
                 catch (ArgumentException ex) { results.Add(new AssetPathResult(p, null, ex.Message)); }   // bad path → per-path Q3 note
             }
             return new AssetStatusData(results, view.BsaFailures, view.ReadIncomplete, _assetWarnings, _profileName);
@@ -1233,10 +1244,17 @@ public sealed class LoadOrderService : IDisposable
         var providers = place.Sources.Select(s => new NifProvider(s.ProviderName, KindLabel(s.Kind))).ToList();
 
         if (place.Sources.Count == 0)
+        {
+            // A model path taken straight off a record is stored relative to meshes\, so the flat ABSENT was a dead
+            // end for the NORMAL way one arrives at a mesh (#273). The hint is RE-RESOLVED, never guessed — see
+            // AssetPathHint: a "did you mean" always names a file that exists, and the weaker fallback names only
+            // the convention, never a file.
+            var hint = AssetPathHint.MeshHint(view, rel);
             // Absent=true lets the renderer hedge this at POINT OF USE on the batch-level caveats (read failures /
             // discovery warnings) — asset_status parity; the top-of-output alarm alone scrolls away in a long batch.
             return new NifInspectData(rel, null, providers, place.Ambiguous, Absent: true, null,
-                "ABSENT — no active mod or BSA provides this mesh path.");
+                "ABSENT — no active mod or BSA provides this mesh path." + (hint is null ? "" : " " + hint));
+        }
 
         // Pick the copy to read: the VFS winner by default, or a specific provider when mod= names one.
         PlacementSource chosen;
@@ -1300,7 +1318,12 @@ public sealed class LoadOrderService : IDisposable
 
             var providers = place.Sources.Select(s => new NifProvider(s.ProviderName, KindLabel(s.Kind))).ToList();
             if (place.Sources.Count == 0)
-                return NifSetResult.Fail($"ABSENT — no active mod or BSA provides '{rel}', so there is no copy to edit.", providers, profileName);
+            {
+                var hint = AssetPathHint.MeshHint(view, rel);   // #273 — same verified re-resolve as nif_inspect's ABSENT
+                return NifSetResult.Fail(
+                    $"ABSENT — no active mod or BSA provides '{rel}', so there is no copy to edit." + (hint is null ? "" : " " + hint),
+                    providers, profileName);
+            }
 
             // pick the copy to read/edit: the VFS winner, or a specific provider when mod= names one.
             PlacementSource chosen;
@@ -5874,8 +5897,12 @@ public sealed record NamedProfileResult(
 /// <summary>One queried asset path's resolution behind housecarl_asset_status: the resolver's <see cref="AssetHit"/>
 /// (which sources have it + which wins + an ambiguity flag), or an <see cref="Error"/> when the path was rejected (a
 /// drive-rooted or '..'-escaping path — per-path Q3, never fails the batch). <see cref="Hit"/> is null iff
-/// <see cref="Error"/> is set.</summary>
-public sealed record AssetPathResult(string RelPath, AssetHit? Hit, string? Error);
+/// <see cref="Error"/> is set.
+/// <para><see cref="PrefixSuggestions"/> (#273) — on an ABSENT answer only, the root-prefixed forms of this path that
+/// a real active mod or BSA DOES provide (<see cref="AssetPathHint"/>), for the common case of a path taken straight
+/// off a record and therefore missing its <c>meshes\</c> / <c>textures\</c> root. Verified by re-resolution, so a
+/// suggestion always names a file that exists; empty when there is nothing honest to offer.</para></summary>
+public sealed record AssetPathResult(string RelPath, AssetHit? Hit, string? Error, IReadOnlyList<string>? PrefixSuggestions = null);
 
 /// <summary>The data behind housecarl_asset_status: one <see cref="AssetPathResult"/> per queried path, plus the
 /// build-level Q3 caveats — <see cref="BsaFailures"/> (archives that couldn't be read) and <see cref="ReadIncomplete"/>


### PR DESCRIPTION
Fixes #273

## What

A model path read straight off a record — `Model.File` on an NPC / ARMA / STAT — is stored relative to `meshes\`, but every asset tool wants it Data-relative. So the **normal** way one arrives at a mesh returned a flat, hint-free ABSENT:

```
housecarl_nif_inspect(mesh_path="Actors\Canine\Character Assets Wolf\wolf.nif")
→ ABSENT — no active mod or BSA provides this mesh path.
```

True for the string as given — and a dead end unless the caller already knew the convention. Now `nif_inspect`, `nif_set` and `asset_status` **re-resolve** the root-prefixed candidate through the same asset view and name it when it hits.

## Verified, not guessed

The suggestion never comes from a string heuristic. It comes from actually re-resolving the candidate, which is strictly stronger: **a path it names always exists**, and when nothing resolves nothing is suggested. That follows the posture `PluginNameSuggest` already encodes — a wrong "did you mean" is worse than none. The probe's `NOT-A-GUESS` arm exists specifically to fail a heuristic implementation: it feeds a path that *looks* exactly as record-relative as the working one but whose prefixed form also misses, and requires no "did you mean".

## The three lanes differ where their knowledge does

That difference is the design, not an inconsistency:

| Lane | Behavior on ABSENT |
|---|---|
| `nif_inspect` / `nif_set` | Deals only in meshes. Verified `did you mean 'meshes\…'` when the retry hits; when it misses, **one weaker note** naming the convention and the form the path would take, stating plainly that form isn't provided either. It claims no file. |
| `asset_status` | Can't know a path's kind, so it tries `meshes\` **and** `textures\` — and emits **verified suggestions only**. No speculative note: `sound\`, `scripts\`, `interface\` legitimately live there, and a `meshes\` lecture would be noise. |

A path already under its root gets nothing at all — the prefix isn't what's wrong there. The rule lives in one place (`AssetPathHint`) rather than three.

## Proof — `asset-prefix-hint-guard`, verified biting

New self-contained CI guard driving the **real** `NifInspect` / `NifSet` / `AssetStatus` over a synthetic MO2 instance holding a loose `meshes\actors\canine\wolf.nif` + `textures\actors\canine\wolf.dds` — no game data, no BSArch. Eleven arms, deliberately paired: the suggestion **firing** and its **absence** are equally load-bearing, since a bad suggestion is a worse failure than the papercut it fixes. One arm asserts the hint reaches the **rendered** `asset_status` output, not just the data record — a data-only fix would be invisible.

**Verified RED, not assumed:** with `AssetPathHint` neutered, 6 arms fail (`FIRES`, `NOT-A-GUESS`, `NIF-SET`, `ASSET-MESH`, `ASSET-TEX`, `RENDER`) while every quiet-path and control arm stays green.

`ci-all` — **108/108** (was 107).

## One correction to the issue

The issue expected `NifInspectBatchGuardProbe.cs:128` to need updating because it "asserts the exact ABSENT string." It doesn't couple to the service — it's a pure renderer guard that builds its own fixture string — so it needed no change and still passes. The positive/negative coverage the issue asked for lives in the new guard instead, where a real asset view makes it meaningful.

## Scope note

The issue split `asset_status` out as a sibling site needing a two-prefix trial. It's included here rather than left open: it's the same input mistake through the same door, the mechanism is shared, and fixing only the `nif_*` half would leave the papercut on the tool most likely to be reached for first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
