### PR TITLE
fix(assets): place_asset's auto-resolve dead end now names the root-prefixed copy (#283)

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -31,6 +31,16 @@ path's kind) and stays silent otherwise — `sound\`, `scripts\` and the rest ge
 only ever deal in meshes, add one weaker note when the prefixed form misses too: it names the convention and the
 form the path would take, and says plainly that form isn't provided either. Reported externally.
 
+**`place_asset` / `bulk_place_asset` carry that same missing-root suggestion (#283).**
+The fourth lane with the same dead end: asked to auto-place a path taken straight off a record, the refusal
+(`nothing in the active load order provides '…'`) named no way forward. It now retries both roots and, when a real
+mod or BSA provides the prefixed form, names it — the same **verified, never guessed** suggestion, so it always
+points at a copy that exists and stays silent when there is nothing honest to offer. It fires only on the
+auto-resolve arm: with `source=` named, a destination nothing currently provides is the normal case (you are placing
+a brand-new file), not a mistake to correct. A placement batch now also answers from one pinned asset build, so two
+assets in the same call can never describe two different states of the VFS. Surfaced by the independent review of
+the #273 fix.
+
 **`cross_plugin_query` no longer trips over deleted records and reports them as an unexplained skip (#276).**
 A `references=` (or `where=`) scan over a load order holding *deleted* records — the wild case was deleted `Package`
 records in a follower mod — ended with a raw `NullReferenceException … could not be scanned and were skipped` note.

--- a/src/housecarl-core/AssetPathHint.cs
+++ b/src/housecarl-core/AssetPathHint.cs
@@ -75,4 +75,19 @@ public static class AssetPathHint
         return $"This path is not under meshes\\ — if it came from a record's Model.File, that field is stored relative to meshes\\, "
              + $"so the Data-relative form would be `meshes\\{norm}` (not provided by any active mod or BSA either).";
     }
+
+    /// <summary>The sentence to append for the GENERIC asset lane — a tool that can't know the path's kind, so it tries
+    /// both roots. Null when there is nothing to add, which is the common case: VERIFIED-ONLY, with no weaker convention
+    /// note. That asymmetry with <see cref="MeshHint"/> is deliberate and matches asset_status — a mesh tool knows every
+    /// path it is handed is a mesh path, so naming the convention is always relevant; this lane legitimately answers for
+    /// <c>sound\</c>, <c>scripts\</c>, <c>interface\</c> and the rest, where a <c>meshes\</c> lecture would be noise.
+    /// Wording (backticks, the "or" join) matches the rendered asset_status line so the same mistake reads the same way
+    /// whichever door the caller came through.</summary>
+    public static string? AssetRootHint(AssetResolver.AssetView view, string rel)
+    {
+        var hits = VerifiedPrefixes(view, rel, AssetRoots);
+        if (hits.Count == 0) return null;
+        return $"Did you mean {string.Join(" or ", hits.Select(h => "`" + h + "`"))}? "
+             + "A path read off a record is relative to its root folder (meshes\\ / textures\\), not to Data.";
+    }
 }

--- a/src/housecarl-generator/AssetPrefixHintProbe.cs
+++ b/src/housecarl-generator/AssetPrefixHintProbe.cs
@@ -30,6 +30,9 @@ namespace HousecarlGenerator;
 ///                  carries the same both-roots verified suggestion, stays silent when there's nothing honest to
 ///                  say, and — the arm that pins the scope — leaves the explicit-source= lane alone, where an
 ///                  unprovided destination is the NORMAL case (placing a brand-new file), not a mistake.
+///   PLACE-ORDER  — the hint PRECEDES the "Pass source=" fallback. Unlike the sibling lanes, this message carries
+///                  an imperative about a DIFFERENT argument, so a hint trailing it reads as a source= value and
+///                  sends the caller to "source file not found" for a copy just verified as provided.
 ///
 /// Run: dotnet run --project src/housecarl-generator -- asset-prefix-hint-guard
 /// </summary>
@@ -138,6 +141,14 @@ internal static class AssetPrefixHintProbe
             var pRecord = svc.PlaceAssets(new[] { new PlaceRequest(RecordRel, null) }, null, null).Results[0];
             Check(!pRecord.Placed && (pRecord.Error?.Contains("Did you mean `" + MeshRel + "`", StringComparison.OrdinalIgnoreCase) ?? false),
                   "PLACE — the auto-resolve refusal names the meshes\\-prefixed copy that IS provided", pRecord.Error);
+            // WHERE the hint sits is load-bearing, not cosmetic: it names a DESTINATION, and the only imperative in
+            // this message names source= and lists "a loose file path" as a legal form. Trailing that imperative
+            // invited a retry as source=`meshes\…`, which resolves against the process CWD and comes back "source
+            // file not found" — for the very copy the hint verified as provided (review of this PR).
+            int iHint = pRecord.Error?.IndexOf("Did you mean", StringComparison.OrdinalIgnoreCase) ?? -1;
+            int iSrc = pRecord.Error?.IndexOf("Pass source=", StringComparison.OrdinalIgnoreCase) ?? -1;
+            Check(iHint >= 0 && iSrc >= 0 && iHint < iSrc,
+                  "PLACE-ORDER — the hint precedes the 'Pass source=' fallback, so it can't be read as a source= value", pRecord.Error);
             var pTex = svc.PlaceAssets(new[] { new PlaceRequest(TexRecordRel, null) }, null, null).Results[0];
             Check(!pTex.Placed && (pTex.Error?.Contains("Did you mean `" + TexRel + "`", StringComparison.OrdinalIgnoreCase) ?? false),
                   "PLACE-TEX — both roots are tried here too (place_asset can't know the path's kind)", pTex.Error);

--- a/src/housecarl-generator/AssetPrefixHintProbe.cs
+++ b/src/housecarl-generator/AssetPrefixHintProbe.cs
@@ -26,6 +26,10 @@ namespace HousecarlGenerator;
 ///   ASSET-QUIET  — asset_status stays silent for a genuinely-absent path AND for a non-asset-root path
 ///                  (sound\, scripts\ … legitimately live there; a meshes\ lecture would be noise), and prints
 ///                  nothing at all when the path resolves.
+///   PLACE / PLACE-TEX / PLACE-QUIET / PLACE-SOURCE (#283) — the fourth lane: place_asset's auto-resolve refusal
+///                  carries the same both-roots verified suggestion, stays silent when there's nothing honest to
+///                  say, and — the arm that pins the scope — leaves the explicit-source= lane alone, where an
+///                  unprovided destination is the NORMAL case (placing a brand-new file), not a mistake.
 ///
 /// Run: dotnet run --project src/housecarl-generator -- asset-prefix-hint-guard
 /// </summary>
@@ -127,6 +131,30 @@ internal static class AssetPrefixHintProbe
                   string.Join(",", sOther.PrefixSuggestions ?? Array.Empty<string>()));
             Check(sHit.Hit is { Exists: true } && (sHit.PrefixSuggestions?.Count ?? 0) == 0,
                   "ASSET-QUIET — a path that RESOLVES carries no suggestion");
+
+            // ---------- place_asset (the fourth lane, #283) ----------
+            Console.WriteLine();
+            Console.WriteLine("--- place_asset ---");
+            var pRecord = svc.PlaceAssets(new[] { new PlaceRequest(RecordRel, null) }, null, null).Results[0];
+            Check(!pRecord.Placed && (pRecord.Error?.Contains("Did you mean `" + MeshRel + "`", StringComparison.OrdinalIgnoreCase) ?? false),
+                  "PLACE — the auto-resolve refusal names the meshes\\-prefixed copy that IS provided", pRecord.Error);
+            var pTex = svc.PlaceAssets(new[] { new PlaceRequest(TexRecordRel, null) }, null, null).Results[0];
+            Check(!pTex.Placed && (pTex.Error?.Contains("Did you mean `" + TexRel + "`", StringComparison.OrdinalIgnoreCase) ?? false),
+                  "PLACE-TEX — both roots are tried here too (place_asset can't know the path's kind)", pTex.Error);
+            // Same teeth as NOT-A-GUESS above, and the quiet arms: verified-only means silence is the default.
+            var pMiss = svc.PlaceAssets(new[] { new PlaceRequest(@"nowhere\ghost.nif", null) }, null, null).Results[0];
+            Check(!pMiss.Placed && !(pMiss.Error?.Contains("Did you mean", StringComparison.OrdinalIgnoreCase) ?? true),
+                  "PLACE-QUIET — a path whose prefixed form ALSO misses gets no 'did you mean'", pMiss.Error);
+            var pOther = svc.PlaceAssets(new[] { new PlaceRequest(@"sound\fx\ghost.wav", null) }, null, null).Results[0];
+            Check(!pOther.Placed && !(pOther.Error?.Contains("Did you mean", StringComparison.OrdinalIgnoreCase) ?? true),
+                  "PLACE-QUIET — a non-asset-root path (sound\\) gets no meshes\\ lecture", pOther.Error);
+            // The hint rides the AUTO-RESOLVE arm only. With source= named, an unprovided destination is the NORMAL
+            // case (placing a brand-new file), so it must still place cleanly and say nothing about roots.
+            var newSrc = Path.Combine(root, "brand-new.nif");
+            File.WriteAllText(newSrc, "y");
+            var pNew = svc.PlaceAssets(new[] { new PlaceRequest(RecordRel, newSrc) }, null, null).Results[0];
+            Check(pNew.Placed && pNew.Error is null,
+                  "PLACE-SOURCE — an explicit source= still places at a path nothing provides (the hint never fires on that arm)", pNew.Error);
 
             // The rendered surface is what the user actually reads — a data-only fix would be invisible.
             var rendered = AssetWire.Render(st, 20000);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1454,8 +1454,11 @@ public sealed class LoadOrderService : IDisposable
             catch (InvalidOperationException ex) { return PlaceOutcome.Fail(ex.Message); }
 
             // ONE asset build for the whole batch (auto-resolve sources + the post-write winner report), reentrant on _gate.
-            AssetResolver resolver; IReadOnlyList<string> warnings;
-            try { lock (_gate) { resolver = Assets; warnings = _assetWarnings; } }
+            // CAPTURED, not the live resolver: every request in the batch — and the #283 missing-root suggestion's
+            // re-resolve — answers from the SAME snapshot, so a refresh landing mid-batch can't make two placements
+            // describe two builds (the AssetView discipline the other asset lanes already ride).
+            AssetResolver.AssetView view; IReadOnlyList<string> warnings;
+            try { lock (_gate) { view = Assets.Capture(); warnings = _assetWarnings; } }
             catch (Exception ex)
             {
                 var residue = RemoveOrNameRiderResidue(rf);              // nothing placed yet → a fresh folder is an orphan
@@ -1467,7 +1470,7 @@ public sealed class LoadOrderService : IDisposable
             int placed = 0;
             foreach (var req in requests)
             {
-                var r = PlaceOne(req, resolver, rf.OutputDir);
+                var r = PlaceOne(req, view, rf.OutputDir);
                 results.Add(r);
                 if (r.Placed) placed++;
             }
@@ -1484,13 +1487,13 @@ public sealed class LoadOrderService : IDisposable
     /// <paramref name="outDir"/>. Reports the CURRENT VFS winner so the caller knows what to sort the fresh mod above —
     /// the placed file does NOT win until the mod is enabled + sorted (the fresh folder isn't in the active profile yet).
     /// A per-asset failure is a recoverable named error, never a thrown batch abort.</summary>
-    PlaceResult PlaceOne(PlaceRequest req, AssetResolver resolver, string outDir)
+    PlaceResult PlaceOne(PlaceRequest req, AssetResolver.AssetView view, string outDir)
     {
         string rel;
         try { rel = AssetResolver.ValidateRelPath(req.AssetPath); }
         catch (ArgumentException ex) { return PlaceResult.Fail(req.AssetPath, ex.Message); }
 
-        var res = resolver.ResolveForPlacement(rel);                     // rel already validated — won't throw
+        var res = view.ResolveForPlacement(rel);                         // rel already validated — won't throw
         var winner = res.Sources.Count > 0 ? DescribeSource(res.Sources[0]) : null;
 
         // ---- source bytes: explicit source= wins; else auto-resolve the sole provider ----
@@ -1505,11 +1508,21 @@ public sealed class LoadOrderService : IDisposable
         else
         {
             if (res.Sources.Count == 0)
+            {
+                // #283 — the auto-resolve dead end is the same input mistake #273 fixed in the three sibling lanes: a
+                // path taken off a record is stored relative to its ROOT folder, so passing it verbatim is the normal
+                // way one arrives here. Both roots (this lane can't know the path's kind), VERIFIED by re-resolving —
+                // a suggestion always names a copy that really is provided, and silence is the honest default.
+                // NOT on the explicit-source= arm above: placing a NEW file at a path nothing provides is legitimate
+                // there, so an absent destination is not a mistake to correct.
+                var hint = AssetPathHint.AssetRootHint(view, rel);
                 return PlaceResult.Fail(rel,
                     $"nothing in the active load order provides '{rel}', so there is no copy to auto-place. Pass source= the correct copy "
                     + "(a loose file path, or '<archive.bsa>|<entry>', or a '.bsa' path)."
+                    + (hint is null ? "" : " " + hint)
                     + (res.ReadIncomplete ? " NOTE: a BSA failed to read this build, so a source may merely be unscanned (see the warnings)." : ""),
                     winner);
+            }
             if (res.Ambiguous)
                 return PlaceResult.Fail(rel,
                     $"{res.Sources.Count} sources provide '{rel}' — ambiguous, so place_asset will not guess which copy is correct (the skill decides). "

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1516,10 +1516,18 @@ public sealed class LoadOrderService : IDisposable
                 // NOT on the explicit-source= arm above: placing a NEW file at a path nothing provides is legitimate
                 // there, so an absent destination is not a mistake to correct.
                 var hint = AssetPathHint.AssetRootHint(view, rel);
+                // ORDER IS LOAD-BEARING — the hint sits directly after the sentence about the PATH, before the
+                // "Pass source=" fallback (review of this PR). It names a destination, not a source; trailing the
+                // one imperative in the message — an imperative that names source= AND lists "a loose file path"
+                // as a legal form — invited the caller to retry as source=`meshes\...`, which routes through
+                // ReadExplicitSource -> Path.GetFullPath against the process CWD -> "source file not found" for the
+                // very copy this hint just verified as provided. Adjacency to the ABSENT clause is also the shape
+                // the three sibling lanes already have (NifInspect / NifSet append MeshHint to a purely descriptive
+                // sentence; asset_status renders it on its own line), so all four read the same way.
                 return PlaceResult.Fail(rel,
-                    $"nothing in the active load order provides '{rel}', so there is no copy to auto-place. Pass source= the correct copy "
-                    + "(a loose file path, or '<archive.bsa>|<entry>', or a '.bsa' path)."
+                    $"nothing in the active load order provides '{rel}', so there is no copy to auto-place."
                     + (hint is null ? "" : " " + hint)
+                    + " Pass source= the correct copy (a loose file path, or '<archive.bsa>|<entry>', or a '.bsa' path)."
                     + (res.ReadIncomplete ? " NOTE: a BSA failed to read this build, so a source may merely be unscanned (see the warnings)." : ""),
                     winner);
             }


### PR DESCRIPTION
Closes #283.

The fourth lane of the #273 papercut. `nif_inspect`, `nif_set` and `asset_status` learned (PR #281) that a path
which resolved to nothing may simply be missing its root folder — a record's `Model.File` is stored relative to
`meshes\`, so passing it verbatim is the *normal* way one arrives at a mesh. `place_asset` / `bulk_place_asset` had
the same dead end and was filed as a scoped follow-up rather than quiet scope growth in that PR.

## What changed

**`LoadOrderService.PlaceAssets` captures the asset view once for the batch** and hands the `AssetView` to
`PlaceOne` instead of the live `AssetResolver`. That's the shape change #283 named as the reason this didn't ride
PR #281 — `AssetPathHint.VerifiedPrefixes` re-resolves through a captured view. It also makes the method's own
existing comment ("ONE asset build for the whole batch") literally true: two assets in one call can no longer
describe two builds if a refresh lands mid-batch.

**The auto-resolve refusal appends the verified suggestion.** Both roots (`meshes\` + `textures\`), because this
lane — like `asset_status` — can't know a path's kind, and silent otherwise so `sound\` and `scripts\` get no
`meshes\` lecture. The wording lives in a new `AssetPathHint.AssetRootHint`, next to `MeshHint`, backtick-delimited
per the lesson `7c5dfe1` already paid for.

**Scope: the auto-resolve arm only.** With `source=` named, a destination nothing currently provides is the
*normal* case — you are placing a brand-new file — so no root hint fires there. `PLACE-SOURCE` in the guard pins
that boundary rather than leaving it to a reader's inference.

## Posture (settled by #273, not re-litigated)

Verified, never guessed: the hint comes from actually re-resolving the prefixed candidate through the same VFS, so
a path it names is always one a mod or BSA really provides. A wrong "did you mean" is worse than none
(`PluginNameSuggest`'s posture).

## Verification

Four new arms in `asset-prefix-hint-guard`, on the existing synthetic fixture — no game data, no BSArch:

- `PLACE` — the record-relative refusal names the `meshes\`-prefixed copy that IS provided
- `PLACE-TEX` — the texture root is tried too
- `PLACE-QUIET` ×2 — a path whose prefixed form also misses, and a `sound\` path, get no "did you mean"
- `PLACE-SOURCE` — an explicit `source=` still places at a path nothing provides

```
dotnet run --project src/housecarl-generator -- asset-prefix-hint-guard   → ALL PASS (16 checks)
dotnet run --project src/housecarl-generator -- place-asset-guard         → ALL PASS (no regression from the view swap)
```

`plugin/CHANGELOG.md` carries an `## Unreleased` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
