### PR TITLE
feat(nif): sections=shader — shader type, decoded SLSF flags, named texture slots (#272)

### DIFF
--- a/.claude/skills/facegen-diagnostics/references/facegen-causes-and-fixes.md
+++ b/.claude/skills/facegen-diagnostics/references/facegen-causes-and-fixes.md
@@ -304,14 +304,20 @@ surfacing that limit IS the Q3-honest move.
 ## 6. Embedded `.nif` texture references — now READABLE *and* WRITABLE
 
 The head `.nif`'s `BSShaderTextureSet` carries TWO logically distinct texture references in ONE block.
-**`housecarl_nif_inspect` READS both** (as `tex[<slot>]: <path>` under `sections=paths` / `shapes`;
+**`housecarl_nif_inspect` READS both** (as `tex[<slot>] (<Name>): <path>` under `sections=paths` / `shapes`;
 the slot number it prints is the **binary** index), and **`housecarl_nif_set set_path` REWRITES either**
 (pass `texture_slot` + the new `path`; verified before it lands) — both the old "can read neither" and the
 "can read, can't write" boundaries are retired:
 
+> **The `(<Name>)` is derived, the number is addressable.** The name comes from the shape's SHADER — its type
+> plus its SLSF flags (`sections=shader`), not from the index, because slot 2 is glow *or* skin-subsurface *or*
+> soft-lighting and slot 7 backlight *or* specular depending on them. A slot the shader doesn't determine prints
+> bare (`tex[4]:`), and on a non-Skyrim layout no slot is named at all. Always pass `nif_set` the **number**.
+
 1. **The per-NPC FaceTint `.dds`** — **binary slot 6** (NifSkope slot 7, the subsurface/tint slot). This is
-   the FaceGenEslify target. `nif_inspect` prints it as `tex[6]: …\facetint\<DefiningMaster>\<00…ID>.dds` —
-   e.g. the real Lucien read: `tex[6]: textures\...\facetint\lucien.esp\00005900.dds` — and `nif_set
+   the FaceGenEslify target. `nif_inspect` prints it as `tex[6] (TintMask): …\facetint\<DefiningMaster>\<00…ID>.dds`
+   — e.g. the real Lucien read: `tex[6] (TintMask): textures\...\facetint\lucien.esp\00005900.dds` (the head's
+   shader type is `FaceTint`, which is what names the slot) — and `nif_set
    op=set_path target=<shape> texture_slot=6 path=<new>` rewrites it.
 2. **The base SKIN texture set** — race/body diffuse (`tex[0]`), normal (`tex[1]`), etc. This is the NPC
    Facegen Patcher target (it rewrites skin slots `fti-6, fti-5, fti-4, fti-3, fti+1` and deliberately

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -22,7 +22,8 @@ Texture slots now also carry their **semantic name** wherever the shader determi
 Slot 2 is glow *or* skin-subsurface *or* soft-lighting and slot 7 backlight *or* specular depending on type and flags,
 so the name is derived from those, never from the index; a slot the shader doesn't determine stays a bare `tex[N]`
 rather than getting a plausible wrong label, and the index is always kept (it is what `nif_set`'s `texture_slot=`
-takes). **Known limit, stated rather than papered over:** the underlying mesh library answers *glossiness, specular
+takes). Slot naming is a **Skyrim** convention, so it declines entirely on a mesh read as another game's layout —
+an unconverted Fallout 4 mesh shipped inside a Skyrim mod gets bare indices rather than Skyrim labels. **Known limit, stated rather than papered over:** the underlying mesh library answers *glossiness, specular
 strength, specular colour, emissive multiple* and *alpha* from a stub that returns a constant, no matter what the mesh
 holds. Those values are in the file, but houseCARL will not print a number it cannot vouch for — the section names them
 as not read and points you at NifSkope. Emissive **colour** is read for real. Reported externally.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,25 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**`nif_inspect` can read a shape's SHADER — `sections=shader`, plus named texture slots (#272).**
+The one question every visual diagnosis actually asks — *how is this shape shaded, and does it emit or scatter light?*
+— was unanswerable. `nif_inspect` reached the shader block only to hop to its texture set, then threw it away, so you
+got slot paths and nothing about the shader itself. The new section reports, per shape: the shader block type
+(`BSLightingShaderProperty` / `BSEffectShaderProperty`), the shader **type** enum (`SkinTint`, `FaceTint`, `HairTint`,
+`EnvironmentMap`, `Parallax`, `MultiLayerParallax`, …), and the **SLSF1 / SLSF2 flags decoded to their names** —
+`Soft_Lighting`, `Glow_Map`, `Model_Space_Normals`, `Double_Sided` and the rest. The flag names come from the mesh
+library's own enums, so they are the library's coverage rather than a hand-kept bit table, and any bit no member names
+is stated as an explicit `(+unknown bits 0x…)` mask instead of vanishing.
+Texture slots now also carry their **semantic name** wherever the shader determines it — `tex[2] (SoftLighting)`,
+`tex[6] (TintMask)`, `tex[7] (Specular)` — in `sections=paths` and `sections=shapes` too, not just the new section.
+Slot 2 is glow *or* skin-subsurface *or* soft-lighting and slot 7 backlight *or* specular depending on type and flags,
+so the name is derived from those, never from the index; a slot the shader doesn't determine stays a bare `tex[N]`
+rather than getting a plausible wrong label, and the index is always kept (it is what `nif_set`'s `texture_slot=`
+takes). **Known limit, stated rather than papered over:** the underlying mesh library answers *glossiness, specular
+strength, specular colour, emissive multiple* and *alpha* from a stub that returns a constant, no matter what the mesh
+holds. Those values are in the file, but houseCARL will not print a number it cannot vouch for — the section names them
+as not read and points you at NifSkope. Emissive **colour** is read for real. Reported externally.
+
 **`check_errors` and the compact/merge dependency scan now treat a deleted record the same way (#279).**
 The #276 fix taught `cross_plugin_query` that a deleted record links to nothing; the two sibling walkers that ride the
 same form-link enumeration — `check_errors`' dangling-reference sweep and the external-dependency scan behind

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -23,10 +23,13 @@ Slot 2 is glow *or* skin-subsurface *or* soft-lighting and slot 7 backlight *or*
 so the name is derived from those, never from the index; a slot the shader doesn't determine stays a bare `tex[N]`
 rather than getting a plausible wrong label, and the index is always kept (it is what `nif_set`'s `texture_slot=`
 takes). Slot naming is a **Skyrim** convention, so it declines entirely on a mesh read as another game's layout —
-an unconverted Fallout 4 mesh shipped inside a Skyrim mod gets bare indices rather than Skyrim labels. **Known limit, stated rather than papered over:** the underlying mesh library answers *glossiness, specular
-strength, specular colour, emissive multiple* and *alpha* from a stub that returns a constant, no matter what the mesh
-holds. Those values are in the file, but houseCARL will not print a number it cannot vouch for — the section names them
-as not read and points you at NifSkope. Emissive **colour** is read for real. Reported externally.
+an unconverted Fallout 4 mesh shipped inside a Skyrim mod gets bare indices, and the output says so rather than
+leaving "unnamed" to read as "undetermined".
+**Known limit, stated rather than papered over:** the underlying mesh library answers *glossiness, specular strength,
+specular colour, emissive multiple* and *alpha* from a stub that returns a constant, no matter what the mesh holds.
+houseCARL will not print a number it cannot vouch for, so the section names them as not read — and, where the block
+carries them (a lighting shader does; an effect shader has no such fields at all), points you at NifSkope. Emissive
+**colour** is read for real. Reported externally.
 
 **`check_errors` and the compact/merge dependency scan now treat a deleted record the same way (#279).**
 The #276 fix taught `cross_plugin_query` that a deleted record links to nothing; the two sibling walkers that ride the

--- a/src/housecarl-core/NifService.cs
+++ b/src/housecarl-core/NifService.cs
@@ -228,8 +228,7 @@ public static class NifService
             emissive = new NifColor(e.R, e.G, e.B);
         }
         return new NifShader(
-            blockType, game.ToString(),
-            blockType == nameof(BSLightingShaderProperty) ? shader.ShaderType_SK_FO4.ToString() : null,
+            blockType, game.ToString(), ShaderTypeName(shader, blockType, game),
             f1, f2,
             emissive,
             Scalar(nameof(INiShader.EmissiveMultiple), () => shader.EmissiveMultiple),
@@ -237,6 +236,28 @@ public static class NifService
             Scalar(nameof(INiShader.SpecularStrength), () => shader.SpecularStrength),
             Rgb3(nameof(INiShader.SpecularColor), () => shader.SpecularColor),
             Scalar(nameof(INiShader.Alpha), () => shader.Alpha));
+    }
+
+    /// <summary>The shader's TYPE enum name, or null when this block doesn't carry one we can read honestly.
+    ///
+    /// TWO independent ways to get this wrong, and both produce a confident DEFAULT rather than a blank:
+    ///   • WRONG BLOCK — a BSEffectShaderProperty never serializes a shader type at all, but the property sits on the
+    ///     shared base, so reading it there yields 0 → a confident "Default".
+    ///   • WRONG FIELD — the type property is LAYOUT-DISPATCHED, not shared. A block read as FO76/SF answers its real
+    ///     type on <c>ShaderType_FO76_SF</c> while <c>ShaderType_SK_FO4</c> reads 0 ("Default"); on an SK block the
+    ///     reverse holds and <c>ShaderType_FO76_SF</c> is garbage. So the field must be picked by the LAYOUT, which is
+    ///     what the block was actually parsed as — not by the block's type name (review of PR #286).
+    /// A layout with no type field of its own reports null, and the renderer says so plainly.</summary>
+    static string? ShaderTypeName(INiShader shader, string blockType, ShaderHelper.ShaderGameType game)
+    {
+        if (blockType == nameof(BSEffectShaderProperty)) return null;   // serializes no shader type on any layout
+        return game switch
+        {
+            ShaderHelper.ShaderGameType.SK or ShaderHelper.ShaderGameType.FO4 => shader.ShaderType_SK_FO4.ToString(),
+            ShaderHelper.ShaderGameType.FO76SF => shader.ShaderType_FO76_SF.ToString(),
+            ShaderHelper.ShaderGameType.FO3NV => shader.ShaderType_FO3_NV.ToString(),
+            _ => null,
+        };
     }
 
     // Which INiShader value accessors a concrete shader block ACTUALLY implements — cached per block type (a mesh has
@@ -308,10 +329,20 @@ public static class NifService
     /// flag or type that decides it, in the same posture as <c>effect_chain</c>.
     ///
     /// Q3 — returns NULL rather than a best guess whenever the deciding flag/type isn't set. An unnamed slot renders
-    /// as bare <c>tex[N]</c>: "this shader doesn't tell us", never a confident wrong label. The conditions are read
-    /// through nifly's own <c>Has*</c>/<c>IsType*</c> helpers, which resolve against whichever game's flag word the
-    /// block actually carries — so this doesn't hard-code Skyrim's bit positions either.</summary>
-    internal static string? SlotName(int slot, INiShader shader) => slot switch
+    /// as bare <c>tex[N]</c>: "this shader doesn't tell us", never a confident wrong label.
+    ///
+    /// SKYRIM LAYOUT ONLY, and that gate is load-bearing rather than tidiness. The conditions read nifly's
+    /// <c>Has*</c>/<c>IsType*</c> helpers, which DISPATCH on the block's game layout — and for a layout where nifly
+    /// doesn't model the concept they return <c>true</c> unconditionally, not false. On an FO4-layout block with an
+    /// all-zero flag word <c>HasSoftlight</c>, <c>HasBacklight</c> and <c>Parallax</c> are all true; on FO3NV every
+    /// one of the seven helpers is. Left ungated, slots 2/3/7 (and on FO3NV 4/5) would take a confident label derived
+    /// from nothing the mesh carries — precisely the plausible-wrong-label this interpreter exists to refuse, and it
+    /// would ride <c>sections=paths</c> and <c>sections=shapes</c> too. nif_inspect reads non-SE meshes on purpose
+    /// (an unconverted FO4 mesh shipped inside a Skyrim mod is a thing people bring here), so this is reachable, not
+    /// theoretical. These slot semantics are a SKYRIM engine convention; on any other layout the honest answer is
+    /// that we don't model it. (Review of PR #286.)</summary>
+    internal static string? SlotName(int slot, INiShader shader) =>
+        shader.Type != ShaderHelper.ShaderGameType.SK ? null : slot switch
     {
         0 => "Diffuse",                                          // universal across every shader type
         1 => "Normal",                                           // universal (model-space when the MSN flag is set — the flag list says which)

--- a/src/housecarl-core/NifService.cs
+++ b/src/housecarl-core/NifService.cs
@@ -1,5 +1,6 @@
 using NiflySharp;
 using NiflySharp.Blocks;
+using NiflySharp.Helpers;   // ShaderHelper.ShaderGameType — which game's flag layout a shader block was read as (#272)
 
 namespace HousecarlCore;
 
@@ -168,16 +169,173 @@ public static class NifService
 
         var textures = new List<NifTexture>();
         var shader = nif.GetShader(shape);
+        var shaderInfo = shader is null ? null : BuildShader(shader);
         if (shader?.TextureSetRef is not null && nif.GetBlock(shader.TextureSetRef) is BSShaderTextureSet ts)
             for (int i = 0; i < ts.Textures.Count; i++)
             {
                 var c = ts.Textures[i]?.Content;
-                if (!string.IsNullOrEmpty(c)) textures.Add(new NifTexture(i, c));
+                if (!string.IsNullOrEmpty(c)) textures.Add(new NifTexture(i, c, SlotName(i, shader)));
             }
 
         var bones = nif.GetShapeBoneNames(shape) ?? new List<string>();
-        return new NifShape(name, flags, scale, shape.GetType().Name, defVal, defType, partitions, alpha, textures, bones);
+        return new NifShape(name, flags, scale, shape.GetType().Name, defVal, defType, partitions, alpha, textures, bones, shaderInfo);
     }
+
+    /// <summary>Read the shape's SHADER PROPERTY (#272) — the block every visual diagnosis actually asks about: which
+    /// shader is on this shape, and does it emit / scatter / env-map light. Read off <see cref="INiShader"/>, the
+    /// interface <c>NifFile.GetShader</c> already returns, so this covers BSLightingShaderProperty and
+    /// BSEffectShaderProperty (and anything else nifly models as a shader) with no per-block-type wiring.
+    ///
+    /// TWO Q3 calls live here. (1) <see cref="NifShader.ShaderType"/> is reported ONLY for a lighting shader: the
+    /// <c>ShaderType_SK_FO4</c> property sits on the shared base, but a BSEffectShaderProperty never serializes a
+    /// shader type, so reading it there yields a default 0 that renders as a confident "Default" — a wrong answer, not
+    /// a missing one. (2) The flag WORDS are chosen by the shader's own <c>Type</c> (which game's layout the block was
+    /// read as), never assumed to be Skyrim's — decoding an FO4 word against Skyrim names would mislabel every bit.</summary>
+    static NifShader BuildShader(INiShader shader)
+    {
+        var blockType = shader.GetType().Name;
+        var game = shader.Type;
+
+        // The flag pair that is REAL for this block's game layout. nifly models each game's word as its own named enum,
+        // so the decode below is reflection over that enum — the set of flag names IS the library's, by construction.
+        (NifShaderFlagWord? f1, NifShaderFlagWord? f2) = game switch
+        {
+            ShaderHelper.ShaderGameType.SK    => (DecodeFlagWord("SLSF1", shader.ShaderFlags_SSPF1), DecodeFlagWord("SLSF2", shader.ShaderFlags_SSPF2)),
+            ShaderHelper.ShaderGameType.FO4   => (DecodeFlagWord("F4SPF1", shader.ShaderFlags_F4SPF1), DecodeFlagWord("F4SPF2", shader.ShaderFlags_F4SPF2)),
+            ShaderHelper.ShaderGameType.FO3NV => (DecodeFlagWord("ShaderFlags", shader.ShaderFlags), DecodeFlagWord("ShaderFlags2", shader.ShaderFlags2)),
+            // FO76/SF (and None) carry no flag word this library exposes as a named enum — report the game type and no
+            // flags, rather than decoding some other game's word and labelling it as this one's (Q3).
+            _ => (null, null),
+        };
+
+        // Each lighting value is reported ONLY if this block really reads it (see ReallyReads) — otherwise null, and
+        // the renderer names it as unread. RGB, never RGBA: a lighting shader's emissive is a THREE-component colour
+        // on disk, and the interface widens it to Color4, so its 4th component is a synthetic 0 that would render as
+        // "fully transparent emissive" — a fabricated value, the one thing worse than a missing one (Q3).
+        var t = shader.GetType();
+        NifColor? Rgb3(string prop, Func<System.Numerics.Vector3> read)
+        {
+            if (!ReallyReads(t, prop)) return null;
+            var v = read();
+            return new NifColor(v.X, v.Y, v.Z);
+        }
+        float? Scalar(string prop, Func<float> read) => ReallyReads(t, prop) ? read() : null;
+
+        NifColor? emissive = null;
+        if (ReallyReads(t, nameof(INiShader.EmissiveColor)))
+        {
+            var e = shader.EmissiveColor;
+            emissive = new NifColor(e.R, e.G, e.B);
+        }
+        return new NifShader(
+            blockType, game.ToString(),
+            blockType == nameof(BSLightingShaderProperty) ? shader.ShaderType_SK_FO4.ToString() : null,
+            f1, f2,
+            emissive,
+            Scalar(nameof(INiShader.EmissiveMultiple), () => shader.EmissiveMultiple),
+            Scalar(nameof(INiShader.Glossiness), () => shader.Glossiness),
+            Scalar(nameof(INiShader.SpecularStrength), () => shader.SpecularStrength),
+            Rgb3(nameof(INiShader.SpecularColor), () => shader.SpecularColor),
+            Scalar(nameof(INiShader.Alpha), () => shader.Alpha));
+    }
+
+    // Which INiShader value accessors a concrete shader block ACTUALLY implements — cached per block type (a mesh has
+    // many shapes; the interface map is walked once each).
+    static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, HashSet<string>> RealReads = new();
+
+    /// <summary>Whether <paramref name="blockType"/> REALLY reads <paramref name="property"/>, or merely inherits
+    /// <see cref="INiShader"/>'s DEFAULT INTERFACE IMPLEMENTATION for it.
+    ///
+    /// This is not defensive noise — it is a live upstream gap. In NiflySharp 1.0.0, <c>BSLightingShaderProperty</c>
+    /// overrides <c>EmissiveColor</c> but NOT <c>Glossiness</c>, <c>SpecularStrength</c>, <c>SpecularColor</c>,
+    /// <c>EmissiveMultiple</c> or <c>Alpha</c>; those fall through to the interface's stub, which returns a CONSTANT
+    /// (0, or 1 for Alpha) no matter what the mesh holds. The values are genuinely on disk — the block's private
+    /// fields round-trip a save/load intact — the library just doesn't surface them. Reporting the stub would be a
+    /// confident wrong number on every mesh: exactly the silent-wrong-answer the no-silent-failure rule forbids, and
+    /// the "fail loud about the library's delta, never silently around it" posture the coverage cornerstone names.
+    ///
+    /// Doing it BY CONSTRUCTION rather than by a hand-kept list of "the five nifly stubs" means the day upstream
+    /// implements one, houseCARL starts reporting it with no code change — and if upstream ever stubs another, that
+    /// one goes quiet on its own instead of turning into a wrong answer.</summary>
+    static bool ReallyReads(Type blockType, string property)
+    {
+        var real = RealReads.GetOrAdd(blockType, static t =>
+        {
+            var set = new HashSet<string>(StringComparer.Ordinal);
+            var map = t.GetInterfaceMap(typeof(INiShader));
+            for (int i = 0; i < map.InterfaceMethods.Length; i++)
+            {
+                var name = map.InterfaceMethods[i].Name;
+                if (name.StartsWith("get_", StringComparison.Ordinal) && map.TargetMethods[i].DeclaringType != typeof(INiShader))
+                    set.Add(name[4..]);
+            }
+            return set;
+        });
+        return real.Contains(property);
+    }
+
+    /// <summary>Decode one shader flag word into its NAMED bits plus the unnamed remainder. The names come from
+    /// <see cref="Enum.GetValues(Type)"/> over nifly's own enum, so coverage is the library's coverage — no hand-kept
+    /// bit table to drift. Members are peeled largest-first so a multi-bit combo member wins over its constituent bits
+    /// (the <c>ReadEngine.FlagBitsDisplay</c> algorithm, #255), and whatever no member covers is returned as
+    /// <see cref="NifShaderFlagWord.UnknownBits"/> — surfaced explicitly by the renderer, never silently dropped, which
+    /// is the whole point: an unnamed bit is a real thing the mesh carries.</summary>
+    internal static NifShaderFlagWord DecodeFlagWord(string label, Enum value)
+    {
+        uint raw = Convert.ToUInt32(value);
+        var members = new List<(uint Bits, string Name)>();
+        foreach (Enum m in Enum.GetValues(value.GetType()))
+        {
+            uint mb = Convert.ToUInt32(m);
+            if (mb != 0) members.Add((mb, m.ToString()));
+        }
+        members.Sort((a, b) => b.Bits.CompareTo(a.Bits));        // descending — a combo before its constituent bits
+
+        uint remainder = raw;
+        var hit = new List<(uint Bits, string Name)>();
+        foreach (var m in members)
+            if ((remainder & m.Bits) == m.Bits) { hit.Add(m); remainder &= ~m.Bits; }
+        hit.Sort((a, b) => a.Bits.CompareTo(b.Bits));            // report in bit order — how the word reads on disk
+        return new NifShaderFlagWord(label, raw, hit.Select(h => h.Name).ToList(), remainder);
+    }
+
+    /// <summary>The SEMANTIC name of a BSShaderTextureSet slot, or null when this shape's shader doesn't determine one.
+    ///
+    /// Slot 2 is glow OR skin-subsurface OR soft-lighting; slot 7 is backlight OR specular — the meaning comes from the
+    /// shader TYPE and FLAGS, not from the index. nifly models the slots as a bare path list (the semantics are a
+    /// Skyrim engine convention, not something nif.xml names), so unlike the flag decode above this cannot be
+    /// reflected out of the library — it is a small, explicit interpreter of engine semantics, each arm keyed to the
+    /// flag or type that decides it, in the same posture as <c>effect_chain</c>.
+    ///
+    /// Q3 — returns NULL rather than a best guess whenever the deciding flag/type isn't set. An unnamed slot renders
+    /// as bare <c>tex[N]</c>: "this shader doesn't tell us", never a confident wrong label. The conditions are read
+    /// through nifly's own <c>Has*</c>/<c>IsType*</c> helpers, which resolve against whichever game's flag word the
+    /// block actually carries — so this doesn't hard-code Skyrim's bit positions either.</summary>
+    internal static string? SlotName(int slot, INiShader shader) => slot switch
+    {
+        0 => "Diffuse",                                          // universal across every shader type
+        1 => "Normal",                                           // universal (model-space when the MSN flag is set — the flag list says which)
+        2 => shader.HasGlowmap ? "GlowMap"
+           : shader.HasSoftlight ? "SoftLighting"
+           : shader.IsTypeSkinTint || shader.IsTypeFaceTint ? "SubsurfaceTint"
+           : null,
+        3 => shader.Parallax || shader.IsTypeParallax || shader.IsTypeParallaxOcclusion ? "Height" : null,
+        4 => EnvMapped(shader) ? "Environment" : null,
+        5 => EnvMapped(shader) ? "EnvironmentMask" : null,
+        6 => shader.IsTypeMultiLayerParallax ? "InnerLayer"
+           : shader.IsTypeFaceTint || shader.IsTypeSkinTint || shader.IsTypeHairTint ? "TintMask"
+           : null,
+        7 => shader.HasBacklight ? "BacklightMask"
+           : shader.ModelSpace ? "Specular"                      // MSN meshes carry specular in 7 (the normal's alpha is used up)
+           : null,
+        _ => null,                                               // beyond the Skyrim slot set — say nothing
+    };
+
+    /// <summary>Whether this shader environment-maps at all — the condition slots 4 and 5 both hang on (a plain env
+    /// map, an eye env map, or the shader type that implies it).</summary>
+    static bool EnvMapped(INiShader shader)
+        => shader.HasEnvironmentMapping || shader.HasEyeEnvironmentMapping
+        || shader.IsTypeEnvironmentMap || shader.IsTypeEyeEnvironmentMap;
 
     /// <summary>Pre-order the NiNode hierarchy from the root(s), depth-annotated, each node with its NiAVObject flags.
     /// Only NiNode children are walked (shapes are covered by <see cref="NifInspect.Shapes"/>). A reference-identity
@@ -676,7 +834,8 @@ public sealed record NifBlockTypeCount(string Type, int Count);
 
 /// <summary>One shape and its N2-whitelist values. <see cref="Partitions"/> is empty unless the shape has a
 /// BSDismember skin instance; <see cref="Alpha"/> is null unless it carries an alpha property; <see cref="Textures"/>
-/// lists only non-empty texture-set slots. <see cref="FlagsDefault"/> is the nif.xml-documented SSE default for the
+/// lists only non-empty texture-set slots; <see cref="Shader"/> is null unless the shape carries a shader property.
+/// <see cref="FlagsDefault"/> is the nif.xml-documented SSE default for the
 /// block's type (via <see cref="FlagsDefaultType"/>, the ancestor it came from), or null when none is documented / the
 /// mesh isn't SE — the renderer decodes <see cref="Flags"/> by deviation from it (nif.xml doesn't name the bits).</summary>
 public sealed record NifShape(
@@ -689,7 +848,8 @@ public sealed record NifShape(
     IReadOnlyList<NifPartition> Partitions,
     NifAlpha? Alpha,
     IReadOnlyList<NifTexture> Textures,
-    IReadOnlyList<string> Bones);
+    IReadOnlyList<string> Bones,
+    NifShader? Shader = null);
 
 /// <summary>One BSDismember partition: the body-part id, its decoded enum name (e.g. SBP_30_HEAD), and the part flags.</summary>
 public sealed record NifPartition(int BodyPartId, string BodyPartName, int PartFlags);
@@ -705,8 +865,46 @@ public sealed record NifAlpha(
     string TestFunction,
     byte Threshold);
 
-/// <summary>One embedded texture path at its BSShaderTextureSet slot index (0 diffuse, 1 normal, … 6 tint/detail, …).</summary>
-public sealed record NifTexture(int Slot, string Path);
+/// <summary>One embedded texture path at its BSShaderTextureSet slot index (0 diffuse, 1 normal, … 6 tint/detail, …).
+/// <see cref="SlotName"/> is the slot's SEMANTIC name where the shape's shader determines it (#272) — slot 2 is glow
+/// vs skin-subsurface vs soft-lighting depending on type/flags, slot 7 backlight vs specular — and null when it
+/// doesn't. The index is always kept alongside, so an unnamed slot degrades to the old <c>tex[N]</c> form rather than
+/// to a confident wrong name (Q3). See <c>NifService.SlotName</c>.</summary>
+public sealed record NifTexture(int Slot, string Path, string? SlotName = null);
+
+/// <summary>One shape's SHADER PROPERTY (#272) — the block that answers "how is this shape shaded, and does it emit or
+/// scatter light". <see cref="BlockType"/> is the on-disk block name (BSLightingShaderProperty / BSEffectShaderProperty
+/// / …); <see cref="GameType"/> is which game's layout nifly read it as (SK / FO4 / FO3NV / …), which is what selects
+/// the flag words. <see cref="ShaderType"/> is the BSLightingShaderType enum name (Default, EnvironmentMap, SkinTint,
+/// FaceTint, HairTint, Parallax, MultiLayerParallax, …) and is null for any block that does not serialize one — an
+/// effect shader reports NO type rather than a default-valued wrong one. <see cref="Flags1"/> / <see cref="Flags2"/>
+/// are null when the game layout carries no flag word this library names.
+/// <para>Every LIGHTING VALUE below is nullable, and null means "this library version does not read it off this block"
+/// — NOT "the mesh doesn't have it" (see <c>NifService.ReallyReads</c>: NiflySharp 1.0.0 answers several of them from
+/// an interface stub that returns a constant). The renderer names the unread ones explicitly, so a caller is never
+/// handed a stub value as if it were the mesh's.</para></summary>
+public sealed record NifShader(
+    string BlockType,
+    string GameType,
+    string? ShaderType,
+    NifShaderFlagWord? Flags1,
+    NifShaderFlagWord? Flags2,
+    NifColor? EmissiveColor,
+    float? EmissiveMultiple,
+    float? Glossiness,
+    float? SpecularStrength,
+    NifColor? SpecularColor,
+    float? Alpha);
+
+/// <summary>One decoded shader flag word: its on-disk <see cref="Label"/> (SLSF1 / SLSF2 / F4SPF1 / …), the
+/// <see cref="Raw"/> value, the <see cref="Names"/> of every set bit the library's enum names (in bit order), and
+/// <see cref="UnknownBits"/> — the bits NO enum member covers, kept as an explicit mask so an unnamed bit is stated
+/// rather than dropped (#255's posture, carried to the shader words).</summary>
+public sealed record NifShaderFlagWord(string Label, uint Raw, IReadOnlyList<string> Names, uint UnknownBits);
+
+/// <summary>A shader colour — RGB, because that is what the format actually carries for both colours reported here
+/// (emissive and specular are each a Color3 on disk). Opacity is a separate scalar, <see cref="NifShader.Alpha"/>.</summary>
+public sealed record NifColor(float R, float G, float B);
 
 /// <summary>One node in the pre-order NiNode tree: its depth (0 = root), name, NiAVObject flags, block type, and the
 /// nif.xml-documented SSE flag default for that type (via <see cref="FlagsDefaultType"/>) — null when none is documented

--- a/src/housecarl-generator/NifSectionsProbe.cs
+++ b/src/housecarl-generator/NifSectionsProbe.cs
@@ -50,8 +50,8 @@ public static class NifSectionsProbe
 
         // ALL: expands to every known section.
         var (all, _) = NifTools.ParseSections("all");
-        Check("ALL: 'all' expands to the 7 known sections",
-              all.SetEquals(new[] { "shapes", "partitions", "alpha", "paths", "strings", "nodes", "bones" }));
+        Check("ALL: 'all' expands to the 8 known sections",
+              all.SetEquals(new[] { "shapes", "partitions", "alpha", "paths", "shader", "strings", "nodes", "bones" }));
 
         // PARTIAL: some valid, some not → NOT an error (renders the valid + a warning).
         var (partial, partialUnknown) = NifTools.ParseSections("[\"shapes\",\"textures\"]");

--- a/src/housecarl-generator/NifServiceGuardProbe.cs
+++ b/src/housecarl-generator/NifServiceGuardProbe.cs
@@ -222,6 +222,19 @@ internal static class NifServiceGuardProbe
               "NOT-SKYRIM — every slot is UNNAMED on a non-SK layout, including the ones nifly's helpers answer "
               + $"'true' for — [{string.Join(", ", fo4Shape?.Textures.Select(t => $"tex[{t.Slot}]{(t.SlotName is null ? "" : " (" + t.SlotName + ")")}") ?? Array.Empty<string>())}]");
 
+        // The decline must reach the WIRE, not just the data model: a bare tex[2] on an SK mesh means "this shader
+        // doesn't determine slot 2", and on an FO4 mesh it means "we don't model this layout" — byte-identical output,
+        // opposite meanings. The header's [NOT an SE stream] marker can't disambiguate them either, since an LE mesh
+        // trips it yet still parses as SK and DOES get named slots (re-review of PR #286).
+        var fo4Sections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "shader", "paths", "shapes" };
+        var fo4Render = NifWire.Render(FakeData(fo4.Inspect, null), fo4Sections, Array.Empty<string>(), 80_000);
+        Check(fo4Render.Contains("NOT DERIVED for this block") && fo4Render.Contains("unmodelled, not undetermined")
+              && System.Text.RegularExpressions.Regex.Matches(fo4Render, "NOT DERIVED").Count >= 3,
+              "NOT-SKYRIM-RENDER — the decline is STATED in the shader section and caveated on both slot-listing sections");
+        var skRender = NifWire.Render(FakeData(outcome.Inspect, null), fo4Sections, Array.Empty<string>(), 80_000);
+        Check(!skRender.Contains("NOT DERIVED"),
+              "NOT-SKYRIM-RENDER — an ordinary Skyrim mesh carries none of that noise");
+
         // ---- shader section + named slots reach the RENDER, not just the data model (#272) ----
         var wantShader = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "shader", "paths" };
         var shRender = NifWire.Render(FakeData(outcome.Inspect, null), wantShader, Array.Empty<string>(), 80_000);

--- a/src/housecarl-generator/NifServiceGuardProbe.cs
+++ b/src/housecarl-generator/NifServiceGuardProbe.cs
@@ -20,6 +20,14 @@ namespace HousecarlGenerator;
 ///   • shape — name, NiAVObject flags (0x400000E), and scale (1.25) read exactly.
 ///   • partitions — BSDismember body parts decode to their SBP_* enum names with the right part flags (30 HEAD, 31 HAIR).
 ///   • alpha — the alpha property decodes: raw flags 0x12ED, blend + test on, threshold 128.
+///   • shader (#272) — the shader block, its game layout, the BSLightingShaderType enum, and the SLSF1/SLSF2 words
+///     decoded to the LIBRARY's own bit names (in bit order); the emissive colour round-trips as RGB.
+///   • slot names (#272) — texture slots carry the SEMANTIC name the shader's type+flags determine (Soft_Lighting
+///     ⇒ slot 2 is SoftLighting; model-space normals with no backlight ⇒ slot 7 is Specular) — AND the paired Q3
+///     arm: a slot nothing determines (slot 4, nothing env-maps) stays UNNAMED rather than getting a plausible
+///     wrong label. An index-only implementation passes the first and fails the second.
+///   • unnamed bits (#272/#255) — pinned on a synthetic gapped enum, since every flag word nifly names today covers
+///     all 32 bits: the residual is surfaced as a hex mask, and a multi-bit combo member peels before its parts.
 ///   • refusal — empty bytes and non-NIF garbage each return a NAMED error (Q3), never a throw or a half-model.
 ///
 /// Corpus smoke (existence-gated — a REAL facegen mesh, the spike §5 regression truths for the values the synthetic
@@ -54,9 +62,10 @@ internal static class NifServiceGuardProbe
                   $"header identity: SE stream, user 12 / stream 100 — got user {nif.UserVersion} / stream {nif.StreamVersion}, SE={nif.IsSkyrimSE}");
             Check(nif.VersionString.Contains("20.2.0.7"), $"version string is 20.2.0.7 — '{nif.VersionString}'");
             Check(!nif.HasUnknownBlocks && nif.UnknownBlockTypes.Count == 0, "no unknown blocks in an authored SE mesh");
-            Check(nif.BlockCount == 6, $"block count 6 — {nif.BlockCount}");
+            Check(nif.BlockCount == 8, $"block count 8 — {nif.BlockCount}");
             Check(CensusHas(nif, "NiNode", 3) && CensusHas(nif, "BSTriShape", 1)
-                  && CensusHas(nif, "BSDismemberSkinInstance", 1) && CensusHas(nif, "NiAlphaProperty", 1),
+                  && CensusHas(nif, "BSDismemberSkinInstance", 1) && CensusHas(nif, "NiAlphaProperty", 1)
+                  && CensusHas(nif, "BSLightingShaderProperty", 1) && CensusHas(nif, "BSShaderTextureSet", 1),
                   $"block census matches what was authored — {string.Join(", ", nif.BlockTypes.Select(t => t.Type + " x" + t.Count))}");
 
             // node tree — pre-order depth + names + flags
@@ -84,6 +93,50 @@ internal static class NifServiceGuardProbe
                       $"alpha property decodes (0x12ED, blend+test, thr 128) — {(shape.Alpha is null ? "NONE" : $"0x{shape.Alpha.Flags:X4} blend={shape.Alpha.Blend} test={shape.Alpha.Test} thr={shape.Alpha.Threshold}")}");
                 Check(shape.BlockType == "BSTriShape" && shape.FlagsDefault == 0x8000E && shape.FlagsDefaultType == "BSTriShape",
                       $"shape flag default resolved from nif.xml (BSTriShape → 0x8000E) — {shape.BlockType}/{(shape.FlagsDefault is { } fd ? "0x" + fd.ToString("X") : "none")}");
+
+                // ---- shader property (#272) ----
+                var sh = shape.Shader;
+                Check(sh is { BlockType: "BSLightingShaderProperty", GameType: "SK", ShaderType: "SkinTint" },
+                      $"shader block + game layout + TYPE enum read — {(sh is null ? "NO SHADER" : $"{sh.BlockType}/{sh.GameType}/{sh.ShaderType ?? "(none)"}")}");
+                if (sh is not null)
+                {
+                    // The flag names come from nifly's own enum, so this pins the DECODE, not a transcription:
+                    // 0x1|0x2|0x1000 = Specular|Skinned|Model_Space_Normals, reported in bit order.
+                    Check(sh.Flags1 is { Label: "SLSF1", Raw: 0x1003, UnknownBits: 0 }
+                          && sh.Flags1.Names.SequenceEqual(new[] { "Specular", "Skinned", "Model_Space_Normals" }),
+                          $"SLSF1 decodes to its named bits, in bit order — {(sh.Flags1 is null ? "NONE" : $"0x{sh.Flags1.Raw:X} [{string.Join(", ", sh.Flags1.Names)}]")}");
+                    Check(sh.Flags2 is { Label: "SLSF2", Raw: 0x2000011, UnknownBits: 0 }
+                          && sh.Flags2.Names.SequenceEqual(new[] { "ZBuffer_Write", "Double_Sided", "Soft_Lighting" }),
+                          $"SLSF2 decodes to its named bits — {(sh.Flags2 is null ? "NONE" : $"0x{sh.Flags2.Raw:X} [{string.Join(", ", sh.Flags2.Names)}]")}");
+                    // RGB, not RGBA — a lighting shader's emissive is a Color3 on disk, so there is no alpha to
+                    // round-trip and none is reported (the interface's synthetic 4th component is deliberately dropped).
+                    Check(Math.Abs(sh.EmissiveColor.R - 0.25f) < 1e-6f && Math.Abs(sh.EmissiveColor.G - 0.5f) < 1e-6f
+                          && Math.Abs(sh.EmissiveColor.B - 0.75f) < 1e-6f,
+                          $"emissive colour round-trips exactly — rgb({sh.EmissiveColor.R},{sh.EmissiveColor.G},{sh.EmissiveColor.B})");
+                    // THE UPSTREAM-GAP ARM. Each scalar was authored to a DISTINCT non-zero value and each one
+                    // round-trips in the block's private field (proven by the fixture writing them) — yet NiflySharp
+                    // 1.0.0 answers Glossiness / SpecularStrength / SpecularColor / EmissiveMultiple / Alpha from
+                    // INiShader's default-interface STUB, which returns a constant. So houseCARL must report NOTHING
+                    // for them. An implementation that trusted the accessor would report "glossiness 0, alpha 1" for
+                    // every mesh in the world and pass any arm that only checked the field was populated.
+                    Check(sh.Glossiness is null && sh.SpecularStrength is null && sh.SpecularColor is null
+                          && sh.EmissiveMultiple is null && sh.Alpha is null,
+                          $"a value this library only STUBS is reported as unread, never as its constant — "
+                          + $"glossiness={Fmt(sh.Glossiness)} specularStrength={Fmt(sh.SpecularStrength)} "
+                          + $"specularColor={(sh.SpecularColor is null ? "unread" : "REPORTED")} "
+                          + $"emissiveMultiple={Fmt(sh.EmissiveMultiple)} alpha={Fmt(sh.Alpha)}");
+                }
+
+                // Slot names are DERIVED from that type+flags, not from the index. Soft_Lighting (and NOT Glow_Map)
+                // makes slot 2 SoftLighting — the exact finding the reporter needed pynifly for; Model_Space_Normals
+                // with no backlight makes slot 7 Specular.
+                string? Slot(int n) => shape.Textures.FirstOrDefault(t => t.Slot == n)?.SlotName;
+                Check(Slot(0) == "Diffuse" && Slot(1) == "Normal" && Slot(2) == "SoftLighting" && Slot(7) == "Specular",
+                      $"texture slots carry their SEMANTIC names, derived from shader type + flags — [{string.Join(", ", shape.Textures.Select(t => $"tex[{t.Slot}]{(t.SlotName is null ? "" : " (" + t.SlotName + ")")}"))}]");
+                // The Q3 arm: nothing env-maps this shader, so slot 4 is genuinely undetermined. An implementation that
+                // named it from the index alone ("Environment") would pass every arm above and fail only this one.
+                Check(shape.Textures.Any(t => t.Slot == 4) && Slot(4) is null,
+                      $"an UNDETERMINED slot stays unnamed rather than getting a confident wrong label — tex[4] name = {Slot(4) ?? "(none)"}");
             }
             var childA = nif.Nodes.FirstOrDefault(n => n.Name == "GuardChildA");
             Check(childA is { BlockType: "NiNode", FlagsDefault: 0xE, FlagsDefaultType: "NiNode" },
@@ -148,6 +201,36 @@ internal static class NifServiceGuardProbe
         var unkSec = NifWire.Render(FakeData(FakeInspect(1, 0, false, Array.Empty<string>()), null), summaryOnly, new[] { "bogus" }, 80_000);
         Check(unkSec.Contains("unrecognized section"), "an unrecognized sections= token is surfaced, never silently ignored");
 
+        // ---- shader section + named slots reach the RENDER, not just the data model (#272) ----
+        var wantShader = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "shader", "paths" };
+        var shRender = NifWire.Render(FakeData(outcome.Inspect, null), wantShader, Array.Empty<string>(), 80_000);
+        Check(shRender.Contains("--- shader") && shRender.Contains("BSLightingShaderProperty")
+              && shRender.Contains("type SkinTint") && shRender.Contains("[SK layout]")
+              && shRender.Contains("SLSF2 0x02000011") && shRender.Contains("Soft_Lighting")
+              && shRender.Contains("emissive rgb(0.25,0.5,0.75)"),
+              "the shader section renders: block, TYPE, layout, decoded flag names, emissive values");
+        // The index is KEPT alongside the name (nif_set's texture_slot= takes the index), and an undetermined slot
+        // renders bare — the render half of the Q3 arm above.
+        // The unread values are NAMED in the render, so the gap is visible to the caller and not just absent.
+        Check(shRender.Contains("NOT READ by this NiflySharp version") && shRender.Contains("glossiness")
+              && shRender.Contains("alpha") && !shRender.Contains("glossiness 0") && !shRender.Contains("alpha 1"),
+              "the values this library only stubs are NAMED as unread, not printed as their constant");
+        Check(shRender.Contains("tex[2] (SoftLighting): ") && shRender.Contains("tex[7] (Specular): ")
+              && shRender.Contains("tex[4]: ") && !shRender.Contains("tex[4] ("),
+              "named slots render as 'tex[N] (Name)' and an undetermined slot stays bare 'tex[N]'");
+
+        // ---- the unnamed-bit path (#255's posture, carried to the shader words) ----
+        // Every flag word nifly names today (SLSF1/2, F4SPF1/2, BSShaderFlags1/2) covers all 32 bits, so a real mesh
+        // can never produce a residual — the decode is pinned here on a synthetic enum WITH gaps instead, so the
+        // behaviour is proven rather than assumed if an upstream enum ever loses a member. It also pins the
+        // combo-before-constituent peel: Combo (0x9) must win over Alpha (0x1), which is then left uncounted.
+        var gap = NifService.DecodeFlagWord("TEST", (GappedFlags)0x1D);
+        Check(gap.Raw == 0x1D && gap.UnknownBits == 0x10 && gap.Names.SequenceEqual(new[] { "Beta", "Combo" }),
+              $"an unnamed bit is surfaced as a residual mask, and a combo member peels before its constituent bits — 0x{gap.Raw:X} [{string.Join(", ", gap.Names)}] +0x{gap.UnknownBits:X}");
+        var gapRender = NifWire.Render(FakeData(FakeShaderInspect(gap), null), wantShader, Array.Empty<string>(), 80_000);
+        Check(gapRender.Contains("(+unknown bits 0x10)"),
+              "the residual reaches the rendered flag line — an unnamed bit is stated, never silently dropped");
+
         // flag decode: a shape at 0x400000E vs the BSTriShape default 0x8000E → 0x80000 clear (missing), +0x4000000 extra.
         var shapesSec = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "shapes" };
         var decoded = NifWire.Render(FakeData(FakeInspect(1, 0, false, Array.Empty<string>()), null), shapesSec, Array.Empty<string>(), 80_000);
@@ -181,6 +264,17 @@ internal static class NifServiceGuardProbe
                     Check(head.Textures.Any(t => t.Slot == 6 && t.Path.Contains(@"facetint\lucien.esp\00005900.dds", StringComparison.OrdinalIgnoreCase)),
                           "LucienHead texture slot 6 is the facetint path (the RaceMenu tint case)");
                     Check(head.Bones.Contains("NPC Head [Head]") && head.Bones.Contains("NPC Spine2 [Spn2]"), "LucienHead bone list reads (NPC Head / NPC Spine2)");
+                    // #272 end-to-end on REAL data: the synthetic fixture proves the decode, this proves it survives a
+                    // mesh nobody authored for the test. Asserts only what is true of ANY SE facegen head (a lighting
+                    // shader read as the SK layout, with both flag words present) and PRINTS the derived type + slot
+                    // names, so a wrong derivation is visible to a human even where it isn't assertable.
+                    Check(head.Shader is { BlockType: "BSLightingShaderProperty", GameType: "SK" }
+                          && head.Shader.Flags1 is not null && head.Shader.Flags2 is not null,
+                          "LucienHead's shader reads on real data — " + (head.Shader is null ? "NO SHADER"
+                              : $"{head.Shader.BlockType}/{head.Shader.GameType} type {head.Shader.ShaderType ?? "(none)"} "
+                                + $"SLSF1[{string.Join("|", head.Shader.Flags1?.Names ?? Array.Empty<string>())}] "
+                                + $"SLSF2[{string.Join("|", head.Shader.Flags2?.Names ?? Array.Empty<string>())}] "
+                                + $"slots: {string.Join(", ", head.Textures.Select(t => $"{t.Slot}{(t.SlotName is null ? "" : "=" + t.SlotName)}"))}"));
                 }
                 if (hair is not null) Check(hair.Alpha is { Flags: 0x12ED, Blend: true }, $"LucienHair alpha 0x12ED blend=true — {(hair.Alpha is null ? "NONE" : $"0x{hair.Alpha.Flags:X4} blend={hair.Alpha.Blend}")}");
                 if (hairline is not null) Check(hairline.Alpha is { Flags: 0x12EE, Blend: false, Test: true, Threshold: 180 },
@@ -199,7 +293,31 @@ internal static class NifServiceGuardProbe
         return fail == 0 ? 0 : 1;
     }
 
+    /// <summary>A nullable float for a probe DETAIL string — "unread" is the answer being asserted, so it has to be
+    /// visible in the output rather than rendering as an empty string that reads like a zero.</summary>
+    static string Fmt(float? f) => f is { } v ? v.ToString(System.Globalization.CultureInfo.InvariantCulture) : "unread";
+
     static bool CensusHas(NifInspect nif, string type, int count) => nif.BlockTypes.Any(t => t.Type == type && t.Count == count);
+
+    /// <summary>A flags enum with DELIBERATE GAPS (bits 0x2, 0x10 … are unnamed) and one multi-bit COMBO member — the
+    /// shape no real nifly shader word has, since every one of those names all 32 bits. Exists solely so the residual
+    /// and combo-peel behaviour of <see cref="NifService.DecodeFlagWord"/> is proven rather than assumed.</summary>
+    enum GappedFlags : uint { Alpha = 0x1, Beta = 0x4, Combo = 0x9 }
+
+    /// <summary>A one-shape inspect model carrying <paramref name="word"/> as its shader's first flag word — the
+    /// render-layer input for the unnamed-bit arm.</summary>
+    static NifInspect FakeShaderInspect(NifShaderFlagWord word)
+    {
+        var shader = new NifShader("BSLightingShaderProperty", "SK", "Default", word, null,
+                                   new NifColor(0f, 0f, 0f), 1f, 30f, 1f, new NifColor(1f, 1f, 1f), 1f);
+        var shape = new NifShape("GapShape", 0xE, 1f, "BSTriShape", 0x8000E, "BSTriShape",
+                                 new List<NifPartition>(), null, new List<NifTexture>(), new List<string>(), shader);
+        return new NifInspect("20.2.0.7", 12, 100, true, 2,
+            new List<NifBlockTypeCount> { new("BSTriShape", 1), new("NiNode", 1) },
+            false, Array.Empty<string>(),
+            new List<NifShape> { shape }, new List<NifNode> { new(0, "Root", 0xE, "NiNode", 0xE, "NiNode") },
+            new List<string> { "Root", "GapShape" });
+    }
 
     /// <summary>A synthetic inspect model for the render-layer arms (no file needed): <paramref name="totalShapes"/>
     /// shapes named <paramref name="namePrefix"/>0.., the first <paramref name="withPartitions"/> of them carrying
@@ -257,6 +375,46 @@ internal static class NifServiceGuardProbe
         alpha.Flags.Value = 0x12ED;
         shape.AlphaPropertyRef = new NiBlockRef<NiAlphaProperty>(f.AddBlock(alpha));
 
+        // A real shader property + texture set (#272). The values are chosen to exercise every SLOT-NAME arm at once:
+        // Soft_Lighting (not Glow_Map) makes slot 2 SoftLighting — the reporter's wolf finding; Model_Space_Normals
+        // (with no backlight) makes slot 7 Specular; nothing env-maps, so slot 4 must stay UNNAMED.
+        var shader = new BSLightingShaderProperty
+        {
+            // Mark the block as the SKYRIM layout up front: nifly's shader accessors DISPATCH on Type, and a
+            // block constructed in memory (rather than parsed) starts at None, where the SK-only scalars neither
+            // read nor serialize. Without this the fixture would author a shader full of zeros.
+            Type = NiflySharp.Helpers.ShaderHelper.ShaderGameType.SK,
+            ShaderType_SK_FO4 = NiflySharp.Enums.BSLightingShaderType.SkinTint,
+            ShaderFlags_SSPF1 = NiflySharp.Enums.SkyrimShaderPropertyFlags1.Specular
+                              | NiflySharp.Enums.SkyrimShaderPropertyFlags1.Skinned
+                              | NiflySharp.Enums.SkyrimShaderPropertyFlags1.Model_Space_Normals,
+            ShaderFlags_SSPF2 = NiflySharp.Enums.SkyrimShaderPropertyFlags2.ZBuffer_Write
+                              | NiflySharp.Enums.SkyrimShaderPropertyFlags2.Double_Sided
+                              | NiflySharp.Enums.SkyrimShaderPropertyFlags2.Soft_Lighting,
+            EmissiveColor = new NiflySharp.Structs.Color4 { R = 0.25f, G = 0.5f, B = 0.75f, A = 1f },
+        };
+        var texSet = new BSShaderTextureSet
+        {
+            Textures = new List<NiString4>
+            {
+                new(@"textures\guard\diffuse.dds", false), new(@"textures\guard\normal.dds", false),
+                new(@"textures\guard\soft.dds", false),    new("", false),
+                new(@"textures\guard\slot4.dds", false),   new("", false),
+                new("", false),                            new(@"textures\guard\slot7.dds", false),
+                new("", false),
+            },
+        };
+        texSet.NumTextures = (uint)texSet.Textures.Count;
+        SetPrivate(shader, "_textureSet", new NiBlockRef<BSShaderTextureSet>(f.AddBlock(texSet)));
+        // The lighting scalars are serialized fields with no public setter, so the fixture writes them the same way.
+        // Without this they'd all author as 0 and the value arms would be unfalsifiable — a guard that cannot fail.
+        SetPrivate(shader, "_emissiveMultiple", 2.5f);
+        SetPrivate(shader, "_glossiness", 30f);
+        SetPrivate(shader, "_specularStrength", 1.5f);
+        SetPrivate(shader, "_alpha", 0.5f);
+        SetPrivate(shader, "_specularColor", new NiflySharp.Structs.Color3 { R = 1f, G = 0.5f, B = 0.25f });
+        shape.ShaderPropertyRef = new NiBlockRef<BSShaderProperty>(f.AddBlock(shader));
+
         var skin = new BSDismemberSkinInstance
         {
             Partitions = new List<NiflySharp.Structs.BodyPartList>
@@ -271,5 +429,20 @@ internal static class NifServiceGuardProbe
         using var ms = new MemoryStream();
         if (f.Save(ms) != 0) throw new InvalidOperationException("nif-service-guard: authoring the synthetic SE mesh failed to save");
         return ms.ToArray();
+    }
+
+    /// <summary>Write one of NiflySharp's serialized-but-read-only shader fields, for the FIXTURE only. The texture-set
+    /// ref and every lighting scalar are populated on PARSE and exposed get-only (there is no NifFile helper to author
+    /// them), so a probe that needs a mesh carrying real shader values has to reach the backing field. Confined here —
+    /// product code only ever reads these — and it throws LOUD if a library update renames one, rather than quietly
+    /// authoring a shader full of zeros and leaving the value and slot-name arms passing vacuously (Q3: a guard that
+    /// cannot guard must say so, not go green).</summary>
+    static void SetPrivate(object block, string field, object value)
+    {
+        var f = block.GetType().GetField(field, System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException(
+                $"nif-service-guard: NiflySharp's {block.GetType().Name} no longer has a '{field}' field — the shader " +
+                "fixture needs updating before its arms mean anything (#272).");
+        f.SetValue(block, value);
     }
 }

--- a/src/housecarl-generator/NifServiceGuardProbe.cs
+++ b/src/housecarl-generator/NifServiceGuardProbe.cs
@@ -110,9 +110,13 @@ internal static class NifServiceGuardProbe
                           $"SLSF2 decodes to its named bits — {(sh.Flags2 is null ? "NONE" : $"0x{sh.Flags2.Raw:X} [{string.Join(", ", sh.Flags2.Names)}]")}");
                     // RGB, not RGBA — a lighting shader's emissive is a Color3 on disk, so there is no alpha to
                     // round-trip and none is reported (the interface's synthetic 4th component is deliberately dropped).
-                    Check(Math.Abs(sh.EmissiveColor.R - 0.25f) < 1e-6f && Math.Abs(sh.EmissiveColor.G - 0.5f) < 1e-6f
-                          && Math.Abs(sh.EmissiveColor.B - 0.75f) < 1e-6f,
-                          $"emissive colour round-trips exactly — rgb({sh.EmissiveColor.R},{sh.EmissiveColor.G},{sh.EmissiveColor.B})");
+                    // Matched through the NULLABLE, not dereferenced: if a library bump ever drops the EmissiveColor
+                    // override, ReallyReads correctly returns false and this must print a FAIL — not throw an NRE and
+                    // take the whole probe with it. Goes quiet, doesn't go wrong (review of PR #286).
+                    Check(sh.EmissiveColor is { } e
+                          && Math.Abs(e.R - 0.25f) < 1e-6f && Math.Abs(e.G - 0.5f) < 1e-6f && Math.Abs(e.B - 0.75f) < 1e-6f,
+                          "emissive colour round-trips exactly — "
+                          + (sh.EmissiveColor is { } ec ? $"rgb({ec.R},{ec.G},{ec.B})" : "UNREAD (the override is gone?)"));
                     // THE UPSTREAM-GAP ARM. Each scalar was authored to a DISTINCT non-zero value and each one
                     // round-trips in the block's private field (proven by the fixture writing them) — yet NiflySharp
                     // 1.0.0 answers Glossiness / SpecularStrength / SpecularColor / EmissiveMultiple / Alpha from
@@ -200,6 +204,23 @@ internal static class NifServiceGuardProbe
 
         var unkSec = NifWire.Render(FakeData(FakeInspect(1, 0, false, Array.Empty<string>()), null), summaryOnly, new[] { "bogus" }, 80_000);
         Check(unkSec.Contains("unrecognized section"), "an unrecognized sections= token is surfaced, never silently ignored");
+
+        // ---- NON-SKYRIM LAYOUT: the slot interpreter DECLINES rather than fabricating (review of PR #286) ----
+        // The same fixture at stream 130 parses as the FO4 layout. Its shader carries an all-zero F4SPF word, yet
+        // nifly's HasSoftlight / HasBacklight / Parallax helpers all answer TRUE there — they return true for a layout
+        // where the concept isn't modelled, not false. So an ungated interpreter labels slots 2/3/7 from nothing the
+        // mesh carries, and it rides sections=paths and sections=shapes too. This is the arm that catches that; every
+        // other slot arm in this probe is SK and stays green through the bug.
+        Console.WriteLine();
+        Console.WriteLine("--- non-Skyrim layout: slot naming declines (it models a SKYRIM convention) ---");
+        var fo4 = NifService.Inspect(BuildSyntheticSe(streamVersion: 130));
+        Check(fo4.Error is null && fo4.Inspect is not null, $"the FO4-layout mesh parses clean — {fo4.Error ?? "ok"}");
+        var fo4Shape = fo4.Inspect?.Shapes.FirstOrDefault(s => s.Name == "GuardShape");
+        Check(fo4Shape?.Shader is { GameType: "FO4" },
+              $"the fixture really is read as the FO4 layout — {fo4Shape?.Shader?.GameType ?? "(no shader)"}");
+        Check(fo4Shape is not null && fo4Shape.Textures.Count > 0 && fo4Shape.Textures.All(t => t.SlotName is null),
+              "NOT-SKYRIM — every slot is UNNAMED on a non-SK layout, including the ones nifly's helpers answer "
+              + $"'true' for — [{string.Join(", ", fo4Shape?.Textures.Select(t => $"tex[{t.Slot}]{(t.SlotName is null ? "" : " (" + t.SlotName + ")")}") ?? Array.Empty<string>())}]");
 
         // ---- shader section + named slots reach the RENDER, not just the data model (#272) ----
         var wantShader = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "shader", "paths" };
@@ -354,9 +375,9 @@ internal static class NifServiceGuardProbe
     /// header, a 3-level NiNode tree with names + flags, and one BSTriShape carrying a name/flags/scale, two BSDismember
     /// partitions, and an alpha property. Every block is REFERENCED (parented / ref'd) so NiflySharp's save-time
     /// unreferenced-block prune keeps them. Returns the saved bytes — the exact input shape housecarl_nif_inspect reads.</summary>
-    static byte[] BuildSyntheticSe()
+    static byte[] BuildSyntheticSe(uint streamVersion = 100)
     {
-        var ver = new NiVersion { FileVersion = NiVersion.ToFile("20.2.0.7"), UserVersion = 12, StreamVersion = 100 };
+        var ver = new NiVersion { FileVersion = NiVersion.ToFile("20.2.0.7"), UserVersion = 12, StreamVersion = streamVersion };
         var f = new NifFile();
         f.Create(ver, withRootNode: true);
         var root = f.GetRootNodes().First();
@@ -383,7 +404,8 @@ internal static class NifServiceGuardProbe
             // Mark the block as the SKYRIM layout up front: nifly's shader accessors DISPATCH on Type, and a
             // block constructed in memory (rather than parsed) starts at None, where the SK-only scalars neither
             // read nor serialize. Without this the fixture would author a shader full of zeros.
-            Type = NiflySharp.Helpers.ShaderHelper.ShaderGameType.SK,
+            Type = streamVersion == 100 ? NiflySharp.Helpers.ShaderHelper.ShaderGameType.SK
+                                        : NiflySharp.Helpers.ShaderHelper.ShaderGameType.FO4,
             ShaderType_SK_FO4 = NiflySharp.Enums.BSLightingShaderType.SkinTint,
             ShaderFlags_SSPF1 = NiflySharp.Enums.SkyrimShaderPropertyFlags1.Specular
                               | NiflySharp.Enums.SkyrimShaderPropertyFlags1.Skinned

--- a/src/housecarl-mcp/NifTools.cs
+++ b/src/housecarl-mcp/NifTools.cs
@@ -19,7 +19,7 @@ namespace HousecarlMcp;
 [McpServerToolType]
 public static class NifTools
 {
-    static readonly string[] KnownSections = { "shapes", "partitions", "alpha", "paths", "strings", "nodes", "bones" };
+    static readonly string[] KnownSections = { "shapes", "partitions", "alpha", "paths", "shader", "strings", "nodes", "bones" };
 
     /// <summary>The "(known: …)" hint shared by the unrecognized-section warning and the all-unrecognized loud error
     /// (#247): the legal tokens PLUS the pointer that there is NO 'textures' section — a mesh's embedded texture-set
@@ -37,16 +37,20 @@ public static class NifTools
          "stream; the block census (every block type and count); any UNKNOWN blocks (named + preserved, never silently " +
          "dropped); and per shape — the shape name, the NiAVObject flags (hex, decoded by deviation from the type's " +
          "documented default plus the 0x80000 bit) and scale, the BSDismember body-part " +
-         "partitions (decoded to their SBP_* names), the alpha property (decoded blend / test / threshold), the embedded " +
-         "texture-set paths, and the bone list; plus the node tree and the header string table. Use it to answer 'what " +
-         "shapes / bones / textures / partitions / alpha does this mesh have', to read a facegen mesh's baked shape names " +
+         "partitions (decoded to their SBP_* names), the alpha property (decoded blend / test / threshold), the SHADER " +
+         "property (block type, the shader TYPE enum — SkinTint / FaceTint / HairTint / EnvironmentMap / Parallax / … — " +
+         "the SLSF1+SLSF2 flags decoded to their names, and the emissive colour; any lighting value the underlying mesh " +
+         "library only stubs is NAMED as unread rather than reported as a wrong constant), the embedded " +
+         "texture-set paths with their semantic slot names where the shader determines them, and the bone list; plus the node tree and the header string table. Use it to answer 'what " +
+         "shapes / bones / textures / partitions / alpha does this mesh have', 'does this mesh glow / use soft lighting / " +
+         "subsurface skin / env-mapping', to read a facegen mesh's baked shape names " +
          "and tint path, to check a skeleton's bone names, or to see a dark-face mesh's flags/alpha/partitions — the " +
          "asset-INTERNAL companion to housecarl_asset_status (which mod wins) once you know the winning file. Pass " +
          "mesh_paths = one or more paths (asset_status parity — a whole facegen sweep's flagged subset is ONE call, one " +
          "load-order resolution for the batch); results return in input order, and a failing path is reported LOUD on THAT " +
          "path without aborting the rest. Output is a " +
          "SUMMARY per mesh by default (header + census + shape names); pass sections to expand ('shapes','partitions','alpha'," +
-         "'paths','strings','nodes','bones', or 'all'). Pass mod= to inspect a specific provider instead of the winner; " +
+         "'paths','shader','strings','nodes','bones', or 'all'). Pass mod= to inspect a specific provider instead of the winner; " +
          "sections, mod and max_chars apply to the whole batch. An " +
          "unreadable archive, an absent path, or a mesh NiflySharp refuses (e.g. its strict non-0/1 boolean class) is " +
          "reported LOUD by name — never a silent 'absent' or a half-answer. Read-only: resolves nothing to disk, writes " +
@@ -59,9 +63,11 @@ public static class NifTools
                      "order. Relative to the game's Data folder (forward or back slashes both fine).")]
             string[] mesh_paths,
         [Description("Optional. Which detail sections to show beyond the summary — any of 'shapes', 'partitions', 'alpha', " +
-                     "'paths', 'strings', 'nodes', 'bones', or 'all'. Comma-, space-, or JSON-array-separated (e.g. " +
-                     "[\"shapes\",\"paths\"]). There is NO 'textures' section — a mesh's embedded texture-set slot paths " +
-                     "appear under 'shapes' (per-shape detail) and 'paths'. Applies to every mesh in the batch; " +
+                     "'paths', 'shader', 'strings', 'nodes', 'bones', or 'all'. Comma-, space-, or JSON-array-separated (e.g. " +
+                     "[\"shapes\",\"shader\"]). There is NO 'textures' section — a mesh's embedded texture-set slot paths " +
+                     "appear under 'shapes' (per-shape detail) and 'paths'. 'shader' is the per-shape shader property: " +
+                     "block type, shader TYPE enum, decoded SLSF1/SLSF2 flag names, and the lighting values that are readable. " +
+                     "Applies to every mesh in the batch; " +
                      "unrecognized tokens are reported loud, and an all-unrecognized sections= is an error (never a " +
                      "silent fallback to the summary). Empty = summary only (header + block census + shape names).")]
             string sections = "",
@@ -325,6 +331,7 @@ static class NifWire
         if (want.Contains("alpha")) RenderPerShape(sb, nif, cap, "alpha", s => s.Alpha is not null,
             s => AlphaLine(s.Alpha!));
         if (want.Contains("paths")) RenderPaths(sb, nif, cap);
+        if (want.Contains("shader")) RenderShader(sb, nif, cap);
         if (want.Contains("bones")) RenderPerShape(sb, nif, cap, "bones", s => s.Bones.Count > 0,
             s => string.Join(", ", s.Bones));
         if (want.Contains("nodes")) RenderNodes(sb, nif, cap);
@@ -355,8 +362,7 @@ static class NifWire
                 sb.Append("    partitions: ").Append(string.Join(", ", s.Partitions.Select(p => $"{p.BodyPartId} ({p.BodyPartName}, flags {p.PartFlags})"))).Append('\n');
             if (s.Alpha is not null)
                 sb.Append("    alpha: ").Append(AlphaLine(s.Alpha)).Append('\n');
-            foreach (var t in s.Textures)
-                sb.Append("    tex[").Append(t.Slot).Append("]: ").Append(t.Path).Append('\n');
+            foreach (var t in s.Textures) AppendTexture(sb, t);
             if (s.Bones.Count > 0)
                 sb.Append("    bones: ").Append(string.Join(", ", s.Bones)).Append('\n');
             shown++;
@@ -386,11 +392,90 @@ static class NifWire
         {
             if (Cut(sb, cap, textured.Count - shown)) return;
             sb.Append("  '").Append(s.Name).Append("':\n");
-            foreach (var t in s.Textures) sb.Append("    tex[").Append(t.Slot).Append("]: ").Append(t.Path).Append('\n');
+            foreach (var t in s.Textures) AppendTexture(sb, t);
             shown++;
         }
         if (shown == 0) sb.Append("  (no embedded texture paths)\n");
     }
+
+    /// <summary>One texture slot line, shared by the shapes and paths sections. The INDEX is always printed — the
+    /// semantic name (#272) rides ALONGSIDE it, never replaces it, because the index is what nif_set's texture_slot=
+    /// takes. A slot whose meaning the shape's shader doesn't determine (slot 2 with no glow/soft-light/skin-tint
+    /// signal, say) prints bare, so "unnamed" reads as "this shader doesn't say" rather than a confident wrong label.</summary>
+    static void AppendTexture(StringBuilder sb, NifTexture t)
+    {
+        sb.Append("    tex[").Append(t.Slot).Append(']');
+        if (t.SlotName is not null) sb.Append(" (").Append(t.SlotName).Append(')');
+        sb.Append(": ").Append(t.Path).Append('\n');
+    }
+
+    /// <summary>The shader section (#272): per shape, the block type + shader TYPE enum, the decoded flag words, and
+    /// the lighting values. Multi-line per shape rather than one long line — this is the section a visual diagnosis
+    /// reads top to bottom (does it glow, does it scatter, is it env-mapped).</summary>
+    static void RenderShader(StringBuilder sb, NifInspect nif, int cap)
+    {
+        sb.Append("\n--- shader (per shape; slot names above come from these type+flags) ---\n");
+        var shaded = nif.Shapes.Where(s => s.Shader is not null).ToList();   // omitted remainder counts the FILTERED subset
+        int shown = 0;
+        foreach (var s in shaded)
+        {
+            if (Cut(sb, cap, shaded.Count - shown)) return;
+            var sh = s.Shader!;
+            sb.Append("  '").Append(s.Name).Append("': ").Append(sh.BlockType);
+            // A block that doesn't serialize a shader type says so, rather than reporting a default-valued one (Q3).
+            sb.Append(sh.ShaderType is null ? "  (no shader type on this block)" : "  type " + sh.ShaderType);
+            sb.Append("  [").Append(sh.GameType).Append(" layout]\n");
+            AppendFlagWord(sb, sh.Flags1);
+            AppendFlagWord(sb, sh.Flags2);
+            if (sh.Flags1 is null && sh.Flags2 is null)
+                sb.Append("    flags: none decoded — this library models no named flag word for the ")
+                  .Append(sh.GameType).Append(" layout (the raw block is intact; nothing is being hidden)\n");
+            AppendShaderValues(sb, sh);
+            shown++;
+        }
+        if (shown == 0) sb.Append("  (no shape carries a shader property)\n");
+    }
+
+    /// <summary>One decoded flag word. Unnamed bits are stated as an explicit hex mask — the #255 posture, carried
+    /// here: a bit the library's enum doesn't name is a real thing the mesh carries, so it is surfaced, never dropped
+    /// and never rolled silently into the named list.</summary>
+    static void AppendFlagWord(StringBuilder sb, NifShaderFlagWord? w)
+    {
+        if (w is null) return;
+        sb.Append("    ").Append(w.Label).Append(" 0x").Append(w.Raw.ToString("X8")).Append(": ")
+          .Append(w.Names.Count > 0 ? string.Join(", ", w.Names) : "(no named bit set)");
+        if (w.UnknownBits != 0) sb.Append("  (+unknown bits 0x").Append(w.UnknownBits.ToString("X")).Append(')');
+        sb.Append('\n');
+    }
+
+    /// <summary>The shader's lighting values — only the ones this NiflySharp version genuinely reads off the block.
+    /// The rest are NAMED as unread on their own line rather than printed as the constant the library's interface stub
+    /// would hand back (Q3: a caller must be able to tell "the mesh says 0" from "we can't see it"). The line also
+    /// says the values ARE on disk, so the answer points somewhere — this is a reader gap, not a missing field.</summary>
+    static void AppendShaderValues(StringBuilder sb, NifShader sh)
+    {
+        var have = new List<string>(5);
+        if (sh.EmissiveColor is { } ec) have.Add("emissive " + ColorText(ec) + (sh.EmissiveMultiple is { } m ? " x" + Fmt(m) : ""));
+        if (sh.Glossiness is { } g) have.Add("glossiness " + Fmt(g));
+        if (sh.SpecularStrength is { } ss) have.Add("specular " + Fmt(ss) + (sh.SpecularColor is { } sc ? " " + ColorText(sc) : ""));
+        else if (sh.SpecularColor is { } sc2) have.Add("specular " + ColorText(sc2));
+        if (sh.Alpha is { } a) have.Add("alpha " + Fmt(a));
+        if (have.Count > 0) sb.Append("    ").Append(string.Join("  ", have)).Append('\n');
+
+        var missing = new List<string>(5);
+        if (sh.EmissiveColor is null) missing.Add("emissive colour");
+        if (sh.EmissiveMultiple is null) missing.Add("emissive multiple");
+        if (sh.Glossiness is null) missing.Add("glossiness");
+        if (sh.SpecularStrength is null) missing.Add("specular strength");
+        if (sh.SpecularColor is null) missing.Add("specular colour");
+        if (sh.Alpha is null) missing.Add("alpha");
+        if (missing.Count > 0)
+            sb.Append("    NOT READ by this NiflySharp version (the values ARE in the file — its accessor returns a ")
+              .Append("constant for them, so houseCARL reports nothing rather than a wrong number): ")
+              .Append(string.Join(", ", missing)).Append(". Read them in NifSkope.\n");
+    }
+
+    static string ColorText(NifColor c) => $"rgb({Fmt(c.R)},{Fmt(c.G)},{Fmt(c.B)})";
 
     static void RenderNodes(StringBuilder sb, NifInspect nif, int cap)
     {

--- a/src/housecarl-mcp/NifTools.cs
+++ b/src/housecarl-mcp/NifTools.cs
@@ -450,12 +450,19 @@ static class NifWire
 
     /// <summary>The shader's lighting values — only the ones this NiflySharp version genuinely reads off the block.
     /// The rest are NAMED as unread on their own line rather than printed as the constant the library's interface stub
-    /// would hand back (Q3: a caller must be able to tell "the mesh says 0" from "we can't see it"). The line also
-    /// says the values ARE on disk, so the answer points somewhere — this is a reader gap, not a missing field.</summary>
+    /// would hand back (Q3: a caller must be able to tell "the mesh says 0" from "we can't see it").
+    ///
+    /// EVERY value has both a read form and an unread form, with no shared condition between them, so a value can
+    /// never fall through both and vanish. The emissive multiple is the one that could: it reads most naturally as a
+    /// suffix of the emissive colour, but if upstream ever implements it WITHOUT the colour (it maps onto
+    /// BSEffectShaderProperty's <c>_baseColorScale</c>) a suffix-only form would print it nowhere and name it nowhere
+    /// — the one hole in the "implemented upstream ⇒ reported here, no code change" promise. It gets its own entry
+    /// when the colour is unread (review of PR #286).</summary>
     static void AppendShaderValues(StringBuilder sb, NifShader sh)
     {
         var have = new List<string>(5);
         if (sh.EmissiveColor is { } ec) have.Add("emissive " + ColorText(ec) + (sh.EmissiveMultiple is { } m ? " x" + Fmt(m) : ""));
+        else if (sh.EmissiveMultiple is { } m2) have.Add("emissive multiple x" + Fmt(m2));   // read, but no colour to hang it off
         if (sh.Glossiness is { } g) have.Add("glossiness " + Fmt(g));
         if (sh.SpecularStrength is { } ss) have.Add("specular " + Fmt(ss) + (sh.SpecularColor is { } sc ? " " + ColorText(sc) : ""));
         else if (sh.SpecularColor is { } sc2) have.Add("specular " + ColorText(sc2));
@@ -470,9 +477,14 @@ static class NifWire
         if (sh.SpecularColor is null) missing.Add("specular colour");
         if (sh.Alpha is null) missing.Add("alpha");
         if (missing.Count > 0)
-            sb.Append("    NOT READ by this NiflySharp version (the values ARE in the file — its accessor returns a ")
-              .Append("constant for them, so houseCARL reports nothing rather than a wrong number): ")
-              .Append(string.Join(", ", missing)).Append(". Read them in NifSkope.\n");
+            // "WHERE THIS BLOCK CARRIES THEM" is doing real work: for a lighting shader the values genuinely are on
+            // disk and NifSkope shows them, but a BSEffectShaderProperty has no glossiness / specular-strength /
+            // specular-colour field AT ALL, so an unconditional "the values ARE in the file" would send the reader
+            // hunting in NifSkope for fields that don't exist (review of PR #286).
+            sb.Append("    NOT READ by this NiflySharp version — its accessor returns a constant for these, so ")
+              .Append("houseCARL reports nothing rather than a wrong number: ")
+              .Append(string.Join(", ", missing))
+              .Append(". Where this block carries them, NifSkope shows the real values.\n");
     }
 
     static string ColorText(NifColor c) => $"rgb({Fmt(c.R)},{Fmt(c.G)},{Fmt(c.B)})";

--- a/src/housecarl-mcp/NifTools.cs
+++ b/src/housecarl-mcp/NifTools.cs
@@ -352,6 +352,7 @@ static class NifWire
     static void RenderShapesDetail(StringBuilder sb, NifInspect nif, int cap)
     {
         sb.Append("\n--- shapes (").Append(nif.Shapes.Count).Append(") ---\n");
+        if (SlotNamingCaveat(nif) is { } shapesCaveat) sb.Append(shapesCaveat);
         int shown = 0;   // the cut notice counts the REMAINDER, not the total (PR #243 review — the RenderPerShape rule)
         foreach (var s in nif.Shapes)
         {
@@ -386,6 +387,7 @@ static class NifWire
     static void RenderPaths(StringBuilder sb, NifInspect nif, int cap)
     {
         sb.Append("\n--- paths (embedded texture-set slots; material/.tri/physics-xml refs appear under sections=strings) ---\n");
+        if (SlotNamingCaveat(nif) is { } pathsCaveat) sb.Append(pathsCaveat);
         var textured = nif.Shapes.Where(s => s.Textures.Count > 0).ToList();   // omitted remainder counts the FILTERED subset, not total shapes
         int shown = 0;
         foreach (var s in textured)
@@ -425,6 +427,14 @@ static class NifWire
             // A block that doesn't serialize a shader type says so, rather than reporting a default-valued one (Q3).
             sb.Append(sh.ShaderType is null ? "  (no shader type on this block)" : "  type " + sh.ShaderType);
             sb.Append("  [").Append(sh.GameType).Append(" layout]\n");
+            // The DECLINE is stated, not just performed. Slot naming models a Skyrim convention, so on any other
+            // layout every slot prints bare — which is byte-identical to "this Skyrim shader doesn't determine that
+            // slot" and means something entirely different. Left unsaid, the caller reads "no glow map here" off a
+            // mesh houseCARL simply didn't interpret (review of PR #286).
+            if (!IsSkyrimLayout(sh))
+                sb.Append("    slot names: NOT DERIVED for this block — the slot semantics houseCARL models are a "
+                          + "Skyrim convention, and this reads as the ").Append(sh.GameType)
+                  .Append(" layout, so its slots print bare (unnamed here means unmodelled, not undetermined)\n");
             AppendFlagWord(sb, sh.Flags1);
             AppendFlagWord(sb, sh.Flags2);
             if (sh.Flags1 is null && sh.Flags2 is null)
@@ -488,6 +498,25 @@ static class NifWire
     }
 
     static string ColorText(NifColor c) => $"rgb({Fmt(c.R)},{Fmt(c.G)},{Fmt(c.B)})";
+
+    /// <summary>Whether this shader was read as the SKYRIM layout — the only one whose texture-slot semantics
+    /// houseCARL models, so the only one where a slot name can be derived at all.</summary>
+    static bool IsSkyrimLayout(NifShader sh) => sh.GameType == "SK";
+
+    /// <summary>The one-line caveat for a section that shows slot paths on a mesh whose shader(s) houseCARL does not
+    /// interpret — or null when every shader here is the Skyrim layout (the overwhelmingly common case, which stays
+    /// unannotated). Without it a bare <c>tex[2]:</c> is ambiguous between "this Skyrim shader doesn't determine slot
+    /// 2" and "we don't model this layout at all". The header's <c>[NOT an SE stream]</c> marker does NOT disambiguate
+    /// it: an LE mesh trips that marker but still parses as the SK layout and DOES get named slots (review of #286).</summary>
+    static string? SlotNamingCaveat(NifInspect nif)
+    {
+        var layouts = nif.Shapes.Select(s => s.Shader).OfType<NifShader>().Where(sh => !IsSkyrimLayout(sh))
+                         .Select(sh => sh.GameType).Distinct().OrderBy(g => g, StringComparer.Ordinal).ToList();
+        if (layouts.Count == 0) return null;
+        return "  [!] slot names are NOT DERIVED for shader(s) read as the " + string.Join(" / ", layouts)
+             + " layout — houseCARL models Skyrim's slot semantics only, so those slots print bare. Unnamed there "
+             + "means UNMODELLED, not undetermined; pass sections=shader for each shape's layout.\n";
+    }
 
     static void RenderNodes(StringBuilder sb, NifInspect nif, int cap)
     {


### PR DESCRIPTION
Closes #272.

`nif_inspect` already had the shader block in hand — `BuildShape` fetched it purely to hop to the texture set, then
discarded it. So the one question every visual diagnosis actually asks (*does this shape emit or scatter light, and
how is it shaded?*) was unanswerable, and the reporter fell back to an external pynifly script to find
`soft_lighting`.

## What `sections=shader` reports

```
--- shader (per shape; slot names above come from these type+flags) ---
  'GuardShape': BSLightingShaderProperty  type SkinTint  [SK layout]
    SLSF1 0x00001003: Specular, Skinned, Model_Space_Normals
    SLSF2 0x02000011: ZBuffer_Write, Double_Sided, Soft_Lighting
    emissive rgb(0.25,0.5,0.75)
    NOT READ by this NiflySharp version (…): glossiness, specular strength, specular colour, alpha. Read them in NifSkope.
```

Named texture slots ride `sections=paths` and `sections=shapes` too — the sections callers look at first:

```
    tex[0] (Diffuse): …    tex[2] (SoftLighting): …    tex[4]: …    tex[7] (Specular): …
```

## By construction where the library models it

Read off `INiShader` — what `NifFile.GetShader` already returns — so `BSLightingShaderProperty` and
`BSEffectShaderProperty` are both covered with no per-block-type wiring. Flag names come from `Enum.GetValues` over
nifly's own enums (the peel-largest-first algorithm `ReadEngine.FlagBitsDisplay` uses, #255), so the name set **is**
the library's, and any bit no member covers is stated as `(+unknown bits 0x…)`. Which flag word gets decoded is chosen
by the block's own `Type` — an FO4 word is never decoded against Skyrim names.

Slot semantics are the one part nifly does *not* model (they are a Skyrim engine convention, not something nif.xml
names), so slot naming is a small explicit interpreter keyed to the deciding type/flag — the `effect_chain` posture —
that returns **null** rather than a guess. No cornerstone conflict: the reflectable half is reflected, the engine-
semantics half is thin, typed, and probe-pinned.

## Three Q3 calls, each with a paired guard arm

1. **An undetermined slot stays bare `tex[N]`.** Slot 2 is glow *or* skin-subsurface *or* soft-lighting; slot 7 is
   backlight *or* specular. The name comes from type+flags, never the index, and "we can't tell" prints nothing. The
   fixture's slot 4 (nothing env-maps) pins it — an index-only implementation passes every other slot arm and fails
   only that one. The index is always kept alongside the name: it is what `nif_set`'s `texture_slot=` takes.
2. **`ShaderType` only for a block that serializes one.** `ShaderType_SK_FO4` sits on the shared base, but an effect
   shader never writes one — reading it there yields a default 0 that renders as a confident `Default`.
3. **The lighting scalars are deliberately NOT reported — please read this one.** NiflySharp 1.0.0 answers
   `Glossiness`, `SpecularStrength`, `SpecularColor`, `EmissiveMultiple` and `Alpha` from `INiShader`'s
   **default-interface stub**, which returns a constant no matter what the mesh holds; `BSLightingShaderProperty`
   overrides only `EmissiveColor`. Verified two ways: the interface map shows `get_Glossiness -> INiShader.get_…`,
   and a fixture that writes those fields sees them round-trip a save/load intact while the accessor still answers
   `0` / `1`. Reporting them would have shipped **"glossiness 0, alpha 1" for every mesh in the world**. The section
   names them as unread and points at NifSkope instead. Detected **by construction** off the interface map, so the day
   upstream implements one it starts being reported with no code change — and if upstream ever stubs another, that one
   goes quiet rather than turning into a wrong answer.

That last point is a partial trim of the issue's ask (it listed `EmissiveMultiple` under "feasibility", which is true
of the property name but not of the read). Emissive **colour** is a real read and is reported — as RGB, since the
format carries three components and the interface widens it to `Color4` with a synthetic zero alpha. Worth a separate
`[NOTE]` issue to revisit if NiflySharp implements them; happy to file it.

## Verification

`nif-service-guard` gains arms for the shader block/type/layout, both decoded flag words, the emissive round-trip, the
stub-detection, the slot names **and** the undetermined-slot arm, the render of all of it, and the unnamed-bit residual
— the last pinned on a synthetic gapped enum, because every flag word nifly names today covers all 32 bits, so a real
mesh can never produce a residual. `nif-sections-guard` updated for the 8th section.

The existence-gated corpus smoke passes on a real facegen mesh and prints the derived answer end-to-end:

```
LucienHead's shader — BSLightingShaderProperty/SK type FaceTint
  SLSF1[Specular|Skinned|Recieve_Shadows|Cast_Shadows|Facegen_Detail_Map|Model_Space_Normals|Own_Emit|Remappable_Textures|ZBuffer_Test]
  SLSF2[ZBuffer_Write|Packed_Tangent|EnvMap_Light_Fade|Soft_Lighting]
  slots: 0=Diffuse, 1=Normal, 2=SoftLighting, 6=TintMask, 7=Specular
```

```
dotnet run --project src/housecarl-generator -- ci-all   → ALL PASS (109 probes)
```

`plugin/CHANGELOG.md` carries an `## Unreleased` entry, including the stated limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
