### PR TITLE
feat(sweeps): scope, filter, count, and JSON the two sweep tools (#282)

### DIFF
--- a/.claude/skills/bulk-record-jobs/SKILL.md
+++ b/.claude/skills/bulk-record-jobs/SKILL.md
@@ -333,3 +333,9 @@ For crafting-graph jobs specifically, the blessed per-recipe entry:
   / `housecarl_compact_plugin` — "the old patch is disabled" blocks nothing.
 - Aggregation (`group_by=`) counts ALL matches regardless of `limit=`; only row *rendering* is
   capped. Use counts freely for sizing.
+- The sweep tools (`housecarl_check_errors`, `housecarl_validate_scripts`) are scopeable like any
+  other bulk read: `type=` / `formids=` / `editorid_contains=`, a `findings=` class filter,
+  `format="json"`, and `counts_only=true` for exact totals plus a histogram (unbound-by-property /
+  dangling-by-target-plugin) with no per-record listing. For a multi-pass job — edit, re-check,
+  prove the count moved — `counts_only=true` is the pass-to-pass comparison; `limit=` caps
+  *findings*, not the record roster, so it will not shrink a script-heavy plugin's output on its own.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -22,12 +22,13 @@ my order" from a full sweep into a master-table read.
 properties by NAME for `validate_scripts`, dangling refs by TARGET plugin for `check_errors` (which plugin the broken
 refs point *into*, i.e. the one absent dependency behind a wall of findings). It is the pass-to-pass comparison for a
 multi-pass edit: did this property's count drop, and did anything new appear.
-A **record** scope narrows the **counts**, exactly as `plugins=` always did, and the response says so on its own line, so
-a scoped number can't be misread as a whole-plugin one. That claim is made precisely rather than blanket-fashion, in both
-directions: a `findings=` class filter does *not* trigger it, because each number it leaves standing is complete for what
-it names (`check_errors findings=["dangling"]` reports the true whole-order dangling total); and `check_errors`'
-missing-master count comes off the plugin's master *table*, so a record scope cannot narrow it — under a record scope the
-response marks that number plugin-level explicitly instead of sweeping it into the claim.
+**Every number states its own scope.** A **record** scope narrows all of a sweep's counts, exactly as `plugins=` always
+did, and the response says so on its own line. Nothing else carries that blanket claim, because nothing else narrows
+*every* number: a `findings=` class filter self-labels instead (an excluded class reads `NOT CHECKED`), and
+`property_contains=` labels the two counts it does narrow — `4 unbound matching 'MySpell'` — while records-with-scripts
+and unverifiable stay plugin-wide and unlabelled, because it does not narrow them. `check_errors`' missing-master count
+comes off the plugin's master *table*, so even a record scope cannot narrow it; there the response marks that one number
+plugin-level explicitly rather than sweeping it into the claim.
 Two things are deliberately *not* filterable: unscannable records and unverifiable script attachments always report,
 under every filter — a suppressed "could not check" would read as a clean result, and an unreadable `.pex` may be the
 very one declaring the property you filtered for. A finding class you excluded renders as `NOT CHECKED` (and `null` in

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -23,10 +23,14 @@ properties by NAME for `validate_scripts`, dangling refs by TARGET plugin for `c
 refs point *into*, i.e. the one absent dependency behind a wall of findings). It is the pass-to-pass comparison for a
 multi-pass edit: did this property's count drop, and did anything new appear.
 Narrowing narrows the **counts**, exactly as `plugins=` always did, and a narrowed response says so on its own line, so
-a scoped number can't be misread as a whole-plugin one. Two things are deliberately *not* filterable: unscannable
-records and unverifiable script attachments always report, under every filter — a suppressed "could not check" would
-read as a clean result, and an unreadable `.pex` may be the very one declaring the property you filtered for. An error
-class you excluded renders as `NOT CHECKED` (and `null` in JSON), never as `0`.
+a scoped number can't be misread as a whole-plugin one. The one exception is stated rather than glossed: `check_errors`'
+missing-master count comes off the plugin's master *table*, so a **record** scope cannot narrow it — under a record scope
+the response marks that number plugin-level explicitly instead of sweeping it into the blanket claim.
+Two things are deliberately *not* filterable: unscannable records and unverifiable script attachments always report,
+under every filter — a suppressed "could not check" would read as a clean result, and an unreadable `.pex` may be the
+very one declaring the property you filtered for. A finding class you excluded renders as `NOT CHECKED` (and `null` in
+JSON) on **both** tools, never as a `0`; `validate_scripts` also reports `unbound_object` / `unbound_scalar`
+separately, so a partial filter's count can't be mistaken for the whole unbound population.
 Also fixed: the truncation notice on both tools advised *"scope `plugins=`"* — the one scope the caller had already
 applied. It now names the knobs that exist.
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,28 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**The two sweep tools can now be scoped, filtered, counted, and returned as JSON (#282).**
+`check_errors` and `validate_scripts` had exactly one scope knob between them — `plugins=` — and on a script-heavy
+plugin that was not enough to get an answer at all: ~183 scripted records render past the tool-result size cap, and
+`limit=` does not help because it caps *findings*, not the record roster, so even `limit=1` still printed a header line
+for all 183. Both tools now take a record scope — `type=` (applied at the record stream, so skipped records cost
+nothing), `formids=`, `editorid_contains=` — plus a `findings=` class filter, `counts_only=true`, and
+`format="json"`. `validate_scripts` additionally takes `property_contains=` for chasing one property across a plugin.
+On `validate_scripts`, `findings=["unbound_object"]` narrows to the HIGH silent-`None` class; on `check_errors`,
+`findings=["missing_masters"]` **skips the per-record link walk entirely**, turning "is any master missing anywhere in
+my order" from a full sweep into a master-table read.
+`counts_only=true` returns the exact totals plus a histogram and builds no per-record listing at all — unbound
+properties by NAME for `validate_scripts`, dangling refs by TARGET plugin for `check_errors` (which plugin the broken
+refs point *into*, i.e. the one absent dependency behind a wall of findings). It is the pass-to-pass comparison for a
+multi-pass edit: did this property's count drop, and did anything new appear.
+Narrowing narrows the **counts**, exactly as `plugins=` always did, and a narrowed response says so on its own line, so
+a scoped number can't be misread as a whole-plugin one. Two things are deliberately *not* filterable: unscannable
+records and unverifiable script attachments always report, under every filter — a suppressed "could not check" would
+read as a clean result, and an unreadable `.pex` may be the very one declaring the property you filtered for. An error
+class you excluded renders as `NOT CHECKED` (and `null` in JSON), never as `0`.
+Also fixed: the truncation notice on both tools advised *"scope `plugins=`"* — the one scope the caller had already
+applied. It now names the knobs that exist.
+
 **`nif_inspect` can read a shape's SHADER — `sections=shader`, plus named texture slots (#272).**
 The one question every visual diagnosis actually asks — *how is this shape shaded, and does it emit or scatter light?*
 — was unanswerable. `nif_inspect` reached the shader block only to hop to its texture set, then threw it away, so you

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -22,10 +22,12 @@ my order" from a full sweep into a master-table read.
 properties by NAME for `validate_scripts`, dangling refs by TARGET plugin for `check_errors` (which plugin the broken
 refs point *into*, i.e. the one absent dependency behind a wall of findings). It is the pass-to-pass comparison for a
 multi-pass edit: did this property's count drop, and did anything new appear.
-Narrowing narrows the **counts**, exactly as `plugins=` always did, and a narrowed response says so on its own line, so
-a scoped number can't be misread as a whole-plugin one. The one exception is stated rather than glossed: `check_errors`'
-missing-master count comes off the plugin's master *table*, so a **record** scope cannot narrow it — under a record scope
-the response marks that number plugin-level explicitly instead of sweeping it into the blanket claim.
+A **record** scope narrows the **counts**, exactly as `plugins=` always did, and the response says so on its own line, so
+a scoped number can't be misread as a whole-plugin one. That claim is made precisely rather than blanket-fashion, in both
+directions: a `findings=` class filter does *not* trigger it, because each number it leaves standing is complete for what
+it names (`check_errors findings=["dangling"]` reports the true whole-order dangling total); and `check_errors`'
+missing-master count comes off the plugin's master *table*, so a record scope cannot narrow it — under a record scope the
+response marks that number plugin-level explicitly instead of sweeping it into the claim.
 Two things are deliberately *not* filterable: unscannable records and unverifiable script attachments always report,
 under every filter — a suppressed "could not check" would read as a clean result, and an unreadable `.pex` may be the
 very one declaring the property you filtered for. A finding class you excluded renders as `NOT CHECKED` (and `null` in

--- a/src/housecarl-core/ErrorCheck.cs
+++ b/src/housecarl-core/ErrorCheck.cs
@@ -83,11 +83,15 @@ public static class ErrorCheck
         // The missing-master count comes off the plugin's master TABLE, so a RECORD scope cannot narrow it. Saying
         // "every count below is for this narrowed scope" directly under a plugin-level number is a false claim about the
         // number printed above it, so the claim is qualified whenever both are in play (PR #288 review, finding 3).
+        // The claim fires only under a RECORD scope — that is the one thing here that makes a reported count a subset of
+        // its own label. A findings= class filter leaves every number complete for what it names (an excluded class
+        // renders "NOT CHECKED"), so claiming otherwise over a true whole-order total would be false (re-review finding 3).
         var filterNote = SweepFindings.FilterNote(
-            recordScope is not null && wantMasters
-                ? "the dangling / unscannable counts below are for THIS narrowed scope; the missing-master count is "
-                  + "PLUGIN-level (read off the master table) and is NOT narrowed by it."
-                : null,
+            recordScope is null ? null
+                : wantMasters
+                    ? "the dangling / unscannable counts below are for THIS narrowed scope; the missing-master count is "
+                      + "PLUGIN-level (read off the master table) and is NOT narrowed by it."
+                    : SweepFindings.ScopedCountsClaim,
             recordScope?.Label, SweepFindings.Describe(classes));
         // counts_only=: the dangling-by-target-plugin tally, over EVERY dangling ref in scope (never limit-capped).
         // Built only when the walk that fills it actually RUNS — with 'dangling' excluded there is nothing to tally, and

--- a/src/housecarl-core/ErrorCheck.cs
+++ b/src/housecarl-core/ErrorCheck.cs
@@ -60,11 +60,30 @@ public static class ErrorCheck
     /// not in plugins.txt until the MO2 refresh, yet its pre-ship dangling-ref sweep is exactly when check_errors is
     /// wanted). Each is opened as its OWN overlay; its links resolve against the active order PLUS the file's own
     /// records (a patch's link to its own new record is not dangling), and a declared master absent from the active
-    /// order is a MISSING MASTER finding — same classes, same rendering, plus an OFF-ORDER stamp in the result.</para></summary>
+    /// order is a MISSING MASTER finding — same classes, same rendering, plus an OFF-ORDER stamp in the result.</para>
+    ///
+    /// <para>#282 — the narrowing knobs. <paramref name="recordScope"/> restricts WHICH records the link walk visits
+    /// (<see cref="SweepScope"/>: type at the stream, formids / editorid_contains per record), and
+    /// <paramref name="classes"/> restricts which error classes are looked for at all — excluding
+    /// <see cref="ErrorFindingClass.Dangling"/> SKIPS the per-record walk entirely, which is what makes "is any master
+    /// missing anywhere in my order" a master-table read instead of a full sweep. Both narrow the reported TOTALS as
+    /// well as the listing; <see cref="ErrorCheckResult.FilterNote"/> says so in words, and the render prints an
+    /// excluded class as "not checked", never as a zero (Q3 — a skipped check must not read as a clean one).
+    /// <paramref name="countsOnly"/> collects no per-plugin reports (bar scan errors) and returns a
+    /// dangling-by-TARGET-plugin <see cref="ErrorCheckResult.Histogram"/> — which plugin the broken refs point INTO,
+    /// the answer the per-plugin grouping never gave.</para></summary>
     public static ErrorCheckResult Run(LoadOrderResolver resolver, IReadOnlyList<string>? scope, int limit,
-                                       IReadOnlyList<(string Name, string Path)>? offOrder = null)
+                                       IReadOnlyList<(string Name, string Path)>? offOrder = null,
+                                       SweepScope? recordScope = null,
+                                       ErrorFindingClass classes = ErrorFindingClass.All, bool countsOnly = false)
     {
         var view = resolver.Capture();
+        bool wantDangling = classes.HasFlag(ErrorFindingClass.Dangling);
+        bool wantMasters = classes.HasFlag(ErrorFindingClass.MissingMasters);
+        var filterNote = SweepFindings.FilterNote(recordScope?.Label, SweepFindings.Describe(classes));
+        // counts_only=: the dangling-by-target-plugin tally, over EVERY dangling ref in scope (never limit-capped).
+        // Built only in that mode — a null histogram means "not computed", never "empty".
+        var histogram = countsOnly ? new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase) : null;
 
         // --- resolve the plugin set to scan (Q3: a bad or excluded explicit scope name fails loud, never a silent skip). ---
         List<string> targets;
@@ -104,27 +123,38 @@ public static class ErrorCheck
             // Missing masters: a declared master not present in the active order (the dependency is not installed /
             // enabled). Read independently of the record walk so a record-walk fault still reports the master state.
             var missingMasters = new List<string>();
-            try
+            if (wantMasters)
             {
-                foreach (var m in view.DeclaredMasters(plugin))
-                    if (!view.ContainsPlugin(m)) missingMasters.Add(m);
+                try
+                {
+                    foreach (var m in view.DeclaredMasters(plugin))
+                        if (!view.ContainsPlugin(m)) missingMasters.Add(m);
+                }
+                catch (Exception ex) { scanError = $"could not read the master list: {ex.GetType().Name}: {ex.Message}"; }
+                missingMasters.Sort(StringComparer.OrdinalIgnoreCase);
             }
-            catch (Exception ex) { scanError = $"could not read the master list: {ex.GetType().Name}: {ex.Message}"; }
-            missingMasters.Sort(StringComparer.OrdinalIgnoreCase);
 
             var dangling = new List<DanglingRef>();
             int unscannable = 0;
             var unscannableSamples = new List<string>();
 
+            // findings= excluded 'dangling' ⇒ the per-record link walk is skipped WHOLESALE (the sweep's entire cost).
+            // The render must then print the dangling AND unscannable lines as "not checked" rather than 0 — a skipped
+            // check that reads as a clean one is the Q3 break this whole tool exists to avoid.
             try
             {
-                foreach (var (fk, _, body, _) in view.RecordsIn(new[] { plugin }, null))
+                foreach (var (fk, _, body, _) in wantDangling
+                             ? view.RecordsIn(new[] { plugin }, recordScope?.Types)
+                             : Enumerable.Empty<(FormKey, int, IMajorRecordGetter, string)>())
                 {
                     // PER-RECORD FAULT ISOLATION (twin of the cross_plugin_query scan, HCBR-2026-06-09-03):
                     // EnumerateFormLinks lazily parses subrecord content, so ONE record Mutagen can't parse is excluded
                     // + accounted, never an opaque whole-call abort and never a silent skip (Q3).
                     try
                     {
+                        // #282 record scope, tested BEFORE the deleted-record rule and the link walk — the two things
+                        // this sweep actually spends its time on.
+                        if (recordScope is not null && !recordScope.Matches(fk, body)) continue;
                         // A DELETED record links to nothing (#279 — the shared rule, see DeletedRecordRule): its
                         // content is not live, so none of its FormLinks can be a dangling reference, and an
                         // engine-authored deleted body can throw on the walk below and land here as an untyped
@@ -141,6 +171,7 @@ public static class ErrorCheck
                             ownerVarExempt ??= UntypedOwnerVariableData(body);      // #207: an UntypedOwner's VariableData word is a RequiredRank int (esp. -1 → FFFFFFFF), not a reference
                             if (ownerVarExempt.TryGetValue(target, out int rank) && rank > 0) { ownerVarExempt[target] = rank - 1; continue; }
                             totalDangling++;
+                            if (histogram is not null) { BumpTarget(histogram, target); continue; }   // counts_only=: tally, list nothing
                             if (danglingBudget > 0)
                             {
                                 dangling.Add(new DanglingRef(fk, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID, target));
@@ -167,7 +198,16 @@ public static class ErrorCheck
             totalMissing += missingMasters.Count;
             totalUnscannable += unscannable;
 
-            if (dangling.Count > 0 || missingMasters.Count > 0 || unscannable > 0 || scanError is not null)
+            // counts_only=: the reports list carries the HONESTY LAYER only — a plugin whose records could not be read.
+            // Findings themselves live in the totals + histogram, so the render has no per-plugin body to size (and no
+            // second place where the two modes could drift).
+            if (countsOnly)
+            {
+                if (unscannable > 0 || scanError is not null)
+                    reports.Add(new PluginErrors(plugin, Array.Empty<DanglingRef>(), Array.Empty<string>(),
+                                                 unscannable, unscannableSamples, scanError));
+            }
+            else if (dangling.Count > 0 || missingMasters.Count > 0 || unscannable > 0 || scanError is not null)
                 reports.Add(new PluginErrors(plugin, dangling, missingMasters, unscannable, unscannableSamples, scanError));
         }
 
@@ -190,24 +230,33 @@ public static class ErrorCheck
                 {
                     ov = SkyrimMod.CreateFromBinaryOverlay(path, SkyrimRelease.SkyrimSE);
 
-                    foreach (var m in ov.ModHeader.MasterReferences)
-                        if (!view.ContainsPlugin(m.Master.FileName)) missingMasters.Add(m.Master.FileName);
-                    missingMasters.Sort(StringComparer.OrdinalIgnoreCase);
+                    if (wantMasters)
+                    {
+                        foreach (var m in ov.ModHeader.MasterReferences)
+                            if (!view.ContainsPlugin(m.Master.FileName)) missingMasters.Add(m.Master.FileName);
+                        missingMasters.Sort(StringComparer.OrdinalIgnoreCase);
+                    }
 
                     // Pass 1 — the file's OWN FormKeys: a link into a record this same file defines is satisfied the
                     // moment the plugin is enabled, so it must not read as dangling (the patch-links-its-own-new-record
                     // case). An enumeration abort leaves a PARTIAL set — named below, and pass 2 aborts the same way.
+                    // Deliberately NOT record-scoped (#282): a link into a record the file defines is satisfied whether
+                    // or not that record is inside the caller's scope, so scoping this set would manufacture dangling refs.
                     var selfKeys = new HashSet<FormKey>();
-                    try { foreach (var r in ov.EnumerateMajorRecords()) selfKeys.Add(r.FormKey); }
-                    catch (Exception ex) { scanError = $"record enumeration aborted partway: {ex.GetType().Name}: {ex.Message}"; }
+                    if (wantDangling)
+                    {
+                        try { foreach (var r in ov.EnumerateMajorRecords()) selfKeys.Add(r.FormKey); }
+                        catch (Exception ex) { scanError = $"record enumeration aborted partway: {ex.GetType().Name}: {ex.Message}"; }
+                    }
 
                     // Pass 2 — the link walk, per-record fault isolation (the active loop's exact contract).
                     try
                     {
-                        foreach (var rec in ov.EnumerateMajorRecords())
+                        foreach (var rec in wantDangling ? OffOrderRecords(ov, recordScope) : Enumerable.Empty<IMajorRecordGetter>())
                         {
                             try
                             {
+                                if (recordScope is not null && !recordScope.Matches(rec.FormKey, rec)) continue;   // #282
                                 if (DeletedRecordRule.HasNoLiveBody(rec)) continue;   // #279 — same rule as the active pass above
                                 if (rec is not IFormLinkContainerGetter flc) continue;
                                 Dictionary<FormKey, int>? ownerVarExempt = null;   // #207 (see UntypedOwnerVariableData)
@@ -221,6 +270,7 @@ public static class ErrorCheck
                                     ownerVarExempt ??= UntypedOwnerVariableData(rec);   // #207: RequiredRank int mis-exposed as a FormLink
                                     if (ownerVarExempt.TryGetValue(target, out int rank) && rank > 0) { ownerVarExempt[target] = rank - 1; continue; }
                                     totalDangling++;
+                                    if (histogram is not null) { BumpTarget(histogram, target); continue; }   // counts_only=
                                     if (danglingBudget > 0)
                                     {
                                         dangling.Add(new DanglingRef(rec.FormKey, RecordNaming.StripOverlay(rec.GetType().Name), rec.EditorID, target));
@@ -251,13 +301,38 @@ public static class ErrorCheck
                 totalMissing += missingMasters.Count;
                 totalUnscannable += unscannable;
 
-                if (dangling.Count > 0 || missingMasters.Count > 0 || unscannable > 0 || scanError is not null)
+                if (countsOnly)                                   // the honesty layer only — see the active loop above
+                {
+                    if (unscannable > 0 || scanError is not null)
+                        reports.Add(new PluginErrors(name, Array.Empty<DanglingRef>(), Array.Empty<string>(),
+                                                     unscannable, unscannableSamples, scanError));
+                }
+                else if (dangling.Count > 0 || missingMasters.Count > 0 || unscannable > 0 || scanError is not null)
                     reports.Add(new PluginErrors(name, dangling, missingMasters, unscannable, unscannableSamples, scanError));
             }
         }
 
         return new ErrorCheckResult(reports, targets.Count + offOrderScanned.Count, totalDangling, totalMissing,
-                                    totalUnscannable, capped, view.ExcludedPlugins, null, offOrderScanned);
+                                    totalUnscannable, capped, view.ExcludedPlugins, null, offOrderScanned,
+                                    filterNote, classes, histogram is null ? null : SweepFindings.Histogram(histogram),
+                                    countsOnly);
+    }
+
+    /// <summary>The off-order file's record stream, type-scoped when the caller asked for one (#282) — the overlay
+    /// counterpart of <c>RecordsIn</c>'s getter-type filter, so a <c>type=</c> scope costs nothing per skipped record on
+    /// this lane either.</summary>
+    static IEnumerable<IMajorRecordGetter> OffOrderRecords(ISkyrimModGetter ov, SweepScope? scope)
+        => scope?.Types is { Count: > 0 } types
+            ? types.SelectMany(t => ov.EnumerateMajorRecords(t, throwIfUnknown: true)).Cast<IMajorRecordGetter>()
+            : ov.EnumerateMajorRecords();
+
+    /// <summary>Bump the <c>counts_only=</c> dangling histogram for one broken target: keyed by the PLUGIN the target
+    /// form lives in, which is the diagnostic the per-source-plugin grouping never gave — "480 of these point into
+    /// SomeMissingMod.esp" names the one absent dependency behind a wall of findings.</summary>
+    static void BumpTarget(Dictionary<string, int> acc, FormKey target)
+    {
+        var key = target.ModKey.FileName.String;
+        acc[key] = acc.TryGetValue(key, out var c) ? c + 1 : 1;
     }
 
     /// <summary>Every FormKey carried in an <see cref="IUntypedOwnerGetter.VariableData"/> slot in <paramref name="body"/>,
@@ -319,7 +394,13 @@ public sealed record PluginErrors(
 /// <summary>The result of <see cref="ErrorCheck.Run"/>: the per-plugin reports (only plugins WITH findings; clean
 /// plugins are counted in <paramref name="PluginsScanned"/> but omitted), the sweep totals, whether the dangling list
 /// was capped at the caller's limit, the plugins the index build excluded as unparseable, and — on a Q3 scope error —
-/// a recoverable <see cref="Error"/> with no reports.</summary>
+/// a recoverable <see cref="Error"/> with no reports.
+/// <para><paramref name="FilterNote"/> (#282) names every narrowing the caller applied and states that the totals above
+/// are for that narrowed scope; null when nothing was narrowed. <paramref name="Classes"/> is the finding-class filter
+/// that was in force — the render reads it to print an EXCLUDED class as "not checked" instead of as a zero (a class
+/// nobody looked for must not read as a class that came back clean). <paramref name="Histogram"/> is the
+/// dangling-by-target-plugin tally, present ONLY under <paramref name="CountsOnly"/> (null = not computed, never "none
+/// found"), under which <paramref name="Reports"/> carries only plugins whose records could not be read.</para></summary>
 public sealed record ErrorCheckResult(
     IReadOnlyList<PluginErrors> Reports,
     int PluginsScanned,
@@ -329,7 +410,11 @@ public sealed record ErrorCheckResult(
     bool Capped,
     IReadOnlyDictionary<string, string> ExcludedPlugins,
     string? Error,
-    IReadOnlyList<string>? OffOrderScanned = null)
+    IReadOnlyList<string>? OffOrderScanned = null,
+    string? FilterNote = null,
+    ErrorFindingClass Classes = ErrorFindingClass.All,
+    IReadOnlyList<SweepCount>? Histogram = null,
+    bool CountsOnly = false)
 {
     public bool Success => Error is null;
     public static ErrorCheckResult Fail(string error) =>

--- a/src/housecarl-core/ErrorCheck.cs
+++ b/src/housecarl-core/ErrorCheck.cs
@@ -80,10 +80,20 @@ public static class ErrorCheck
         var view = resolver.Capture();
         bool wantDangling = classes.HasFlag(ErrorFindingClass.Dangling);
         bool wantMasters = classes.HasFlag(ErrorFindingClass.MissingMasters);
-        var filterNote = SweepFindings.FilterNote(recordScope?.Label, SweepFindings.Describe(classes));
+        // The missing-master count comes off the plugin's master TABLE, so a RECORD scope cannot narrow it. Saying
+        // "every count below is for this narrowed scope" directly under a plugin-level number is a false claim about the
+        // number printed above it, so the claim is qualified whenever both are in play (PR #288 review, finding 3).
+        var filterNote = SweepFindings.FilterNote(
+            recordScope is not null && wantMasters
+                ? "the dangling / unscannable counts below are for THIS narrowed scope; the missing-master count is "
+                  + "PLUGIN-level (read off the master table) and is NOT narrowed by it."
+                : null,
+            recordScope?.Label, SweepFindings.Describe(classes));
         // counts_only=: the dangling-by-target-plugin tally, over EVERY dangling ref in scope (never limit-capped).
-        // Built only in that mode — a null histogram means "not computed", never "empty".
-        var histogram = countsOnly ? new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase) : null;
+        // Built only when the walk that fills it actually RUNS — with 'dangling' excluded there is nothing to tally, and
+        // an empty-but-present histogram would render as "nothing found" for a walk that never happened (PR #288 review,
+        // finding 2). A null histogram means "not computed", never "empty".
+        var histogram = countsOnly && wantDangling ? new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase) : null;
 
         // --- resolve the plugin set to scan (Q3: a bad or excluded explicit scope name fails loud, never a silent skip). ---
         List<string> targets;

--- a/src/housecarl-core/ScriptPropertyCheck.cs
+++ b/src/housecarl-core/ScriptPropertyCheck.cs
@@ -79,12 +79,16 @@ public static class ScriptPropertyCheck
     {
         var propFilter = string.IsNullOrWhiteSpace(propertyContains) ? null : propertyContains.Trim();
         bool PropOk(string name) => propFilter is null || name.Contains(propFilter, StringComparison.OrdinalIgnoreCase);
-        // Every count this sweep reports is per-RECORD, so the blanket claim needs no exemption clause here (unlike
-        // check_errors' plugin-level master count). It fires when a record scope OR property_contains= is in force —
-        // both make a reported count a SUBSET of its own label. A findings= class filter alone does not: each remaining
-        // number is complete for what it names, and an excluded class already renders "NOT CHECKED" (re-review finding 3).
+        // ONE claim rule: the subset claim fires for a RECORD SCOPE and nothing else, because a record scope is the only
+        // narrowing here that touches every reported number. property_contains= does NOT qualify — it narrows the unbound
+        // and bound-but-null counts but leaves RecordsWithScripts (incremented before any property filtering) and
+        // TotalUnverifiable (deliberately never property-gated, so an unread .pex can't be filtered into a false clean)
+        // at their full plugin-wide values (round-3 review). Those two numbers under a blanket subset claim is the same
+        // defect as round-1 finding 3. Instead of a third bespoke claim clause, the two counts property_contains= DOES
+        // narrow now SELF-LABEL in the header — the same way an excluded findings= class self-labels "NOT CHECKED" — so
+        // every number states its own scope and one claim rule covers the sweep.
         var filterNote = SweepFindings.FilterNote(
-            recordScope is not null || propFilter is not null ? SweepFindings.ScopedCountsClaim : null,
+            recordScope is not null ? SweepFindings.ScopedCountsClaim : null,
             recordScope?.Label,
             SweepFindings.Describe(classes),
             propFilter is null ? null : $"property_contains='{propFilter}'");
@@ -256,7 +260,7 @@ public static class ScriptPropertyCheck
         return new ScriptCheckResult(reports, targets.Count, recordsWithScripts, totalUnbound, totalNull,
                                      totalUnverifiable, capped, av.ReadIncomplete, view.ExcludedPlugins, null,
                                      filterNote, histogram is null ? null : SweepFindings.Histogram(histogram), countsOnly,
-                                     classes, totalUnboundObject, totalUnboundScalar);
+                                     classes, totalUnboundObject, totalUnboundScalar, propFilter);
     }
 
     /// <summary>Every script attachment on the record: the adapter's own <see cref="IAVirtualMachineAdapterGetter.Scripts"/>
@@ -427,7 +431,11 @@ public sealed record RecordScriptFindings(
 /// renders read these to report an EXCLUDED class as not-checked rather than as a 0 — a class nobody looked for must not
 /// read as a class that came back clean, which is the same rule <see cref="ErrorCheckResult.Classes"/> serves for the
 /// integrity sweep (PR #288 review, finding 1). <paramref name="TotalUnbound"/> stays the sum of the classes that WERE
-/// checked.</para></summary>
+/// checked.</para>
+/// <para><paramref name="PropertyContains"/> is the property-name filter that was in force, carried so the renders can
+/// LABEL the two counts it narrows (unbound, bound-but-null) — <paramref name="RecordsWithScripts"/> and
+/// <paramref name="TotalUnverifiable"/> are NOT narrowed by it and stay plugin-wide, which is why they carry no label
+/// and why a blanket "everything below is narrowed" claim would be false (PR #288 round-3 review).</para></summary>
 public sealed record ScriptCheckResult(
     IReadOnlyList<RecordScriptFindings> Reports,
     int PluginsScanned,
@@ -444,7 +452,8 @@ public sealed record ScriptCheckResult(
     bool CountsOnly = false,
     ScriptFindingClass Classes = ScriptFindingClass.All,
     int TotalUnboundObject = 0,
-    int TotalUnboundScalar = 0)
+    int TotalUnboundScalar = 0,
+    string? PropertyContains = null)
 {
     public bool Success => Error is null;
     public static ScriptCheckResult Fail(string error) =>

--- a/src/housecarl-core/ScriptPropertyCheck.cs
+++ b/src/housecarl-core/ScriptPropertyCheck.cs
@@ -58,10 +58,31 @@ public static class ScriptPropertyCheck
     /// plugins) over the order <paramref name="resolver"/> holds, resolving each attached script's <c>.pex</c> through
     /// <paramref name="assets"/>. <paramref name="limit"/> caps the number of property FINDINGS collected across the
     /// sweep (the true totals are always counted). A bad/excluded scope name fails LOUD (Q3) with no partial result —
-    /// the <see cref="ErrorCheck"/> contract, verbatim.</summary>
+    /// the <see cref="ErrorCheck"/> contract, verbatim.
+    ///
+    /// <para>#282 — the narrowing knobs. <paramref name="recordScope"/> restricts WHICH records are swept
+    /// (<see cref="SweepScope"/>: type at the stream, formids / editorid_contains per record);
+    /// <paramref name="propertyContains"/> keeps only findings whose PROPERTY NAME contains that substring; and
+    /// <paramref name="classes"/> keeps only the named finding classes. All four narrow the reported TOTALS as well as
+    /// the listing — the result's <see cref="ScriptCheckResult.FilterNote"/> says so in words, so a narrowed count is
+    /// never read as a whole-plugin count (Q3). <paramref name="countsOnly"/> collects no per-record reports at all
+    /// (bar scan errors) and instead returns an unbound-by-property-name <see cref="ScriptCheckResult.Histogram"/> —
+    /// the before/after-a-fix comparison the whole-listing render could not fit in a tool result.</para>
+    ///
+    /// <para>UNVERIFIABLE attachments ride through every filter untouched. A script whose <c>.pex</c> could not be read
+    /// might be the very one declaring the property being filtered for, so dropping the note under a filter would turn
+    /// "could not check" into a clean answer — the exact Q3 break the sweep's unverifiable class exists to prevent.</para></summary>
     public static ScriptCheckResult Run(LoadOrderResolver resolver, AssetResolver assets,
-                                        IReadOnlyList<string>? scope, int limit)
+                                        IReadOnlyList<string>? scope, int limit,
+                                        SweepScope? recordScope = null, string? propertyContains = null,
+                                        ScriptFindingClass classes = ScriptFindingClass.All, bool countsOnly = false)
     {
+        var propFilter = string.IsNullOrWhiteSpace(propertyContains) ? null : propertyContains.Trim();
+        bool PropOk(string name) => propFilter is null || name.Contains(propFilter, StringComparison.OrdinalIgnoreCase);
+        var filterNote = SweepFindings.FilterNote(
+            recordScope?.Label,
+            SweepFindings.Describe(classes),
+            propFilter is null ? null : $"property_contains='{propFilter}'");
         var view = resolver.Capture();
         var av = assets.Capture();          // ONE asset build → every .pex lookup + ReadIncomplete describe the same build
 
@@ -95,18 +116,24 @@ public static class ScriptPropertyCheck
         int recordsWithScripts = 0, totalUnbound = 0, totalNull = 0, totalUnverifiable = 0;
         int findingBudget = limit;
         bool capped = false;
+        // counts_only=: the unbound-by-property-name tally, over EVERY unbound finding in scope (never limit-capped —
+        // the whole point is an exact before/after comparison). Built only in that mode, so the normal path's work is
+        // unchanged and a null histogram means "not computed", never "empty".
+        var histogram = countsOnly ? new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase) : null;
 
         foreach (var plugin in targets)
         {
             string? scanError = null;
             try
             {
-                foreach (var (fk, _, body, _) in view.RecordsIn(new[] { plugin }, null))
+                foreach (var (fk, _, body, _) in view.RecordsIn(new[] { plugin }, recordScope?.Types))
                 {
                     // PER-RECORD FAULT ISOLATION (the ErrorCheck / cross_plugin_query idiom): a VMAD Mutagen can't parse
                     // is excluded + accounted per record, never an opaque whole-call abort and never a silent skip (Q3).
                     try
                     {
+                        // #282 record scope, tested BEFORE the VMAD/.pex work so a narrow scope is cheap as well as small.
+                        if (recordScope is not null && !recordScope.Matches(fk, body)) continue;
                         if (body is not IHaveVirtualMachineAdapterGetter have) continue;
                         if (have.VirtualMachineAdapter is not { } vmad) continue;
                         var scriptEntries = CollectScriptEntries(vmad);
@@ -131,9 +158,13 @@ public static class ScriptPropertyCheck
                             // it is NOT bound to a quest alias instead (Alias >= 0). A ScriptObjectProperty binds EITHER an
                             // Object FormLink OR a quest Alias index (Alias -1 = unset) — an alias-bound property has a null
                             // Object by design, so flagging it as bound-but-null is a false positive (PR #145 review finding 2).
-                            foreach (var p in entry.Properties)
-                                if (p is IScriptObjectPropertyGetter op && op.Object.FormKey.IsNull && op.Alias < 0 && !string.IsNullOrWhiteSpace(p.Name))
-                                    nulls.Add(new NullObjectProperty(scriptClass, p.Name!.Trim()));
+                            if (classes.HasFlag(ScriptFindingClass.BoundNull))
+                                foreach (var p in entry.Properties)
+                                    if (p is IScriptObjectPropertyGetter op && op.Object.FormKey.IsNull && op.Alias < 0 && !string.IsNullOrWhiteSpace(p.Name))
+                                    {
+                                        var pname = p.Name!.Trim();
+                                        if (PropOk(pname)) nulls.Add(new NullObjectProperty(scriptClass, pname));
+                                    }
 
                             var chain = ResolveChain(av, chainCache, scriptClass);
                             if (chain.OwnLoadError is not null)
@@ -152,6 +183,9 @@ public static class ScriptPropertyCheck
                                 // A scalar with a baked initializer has the author's intended default — leaving it
                                 // unbound is correct, so it is NOT a finding (keeps the scalar signal from crying wolf).
                                 if (!d.IsObjectType && d.HasInitializer) continue;
+                                // #282: the caller's class + property-name narrowing.
+                                if (!classes.HasFlag(d.IsObjectType ? ScriptFindingClass.UnboundObject : ScriptFindingClass.UnboundScalar)) continue;
+                                if (!PropOk(d.Name)) continue;
                                 unbound.Add(new UnboundProperty(scriptClass, d.DeclaringScript, d.Name, d.TypeName, d.IsObjectType));
                             }
 
@@ -166,6 +200,15 @@ public static class ScriptPropertyCheck
                         totalUnbound += unbound.Count;
                         totalNull += nulls.Count;
                         totalUnverifiable += unver.Count;
+
+                        // counts_only=: tally and move on — no per-record report is built at all, so the record ROSTER
+                        // that overflowed the token cap (#282: 183 header lines for 1 requested finding) never forms.
+                        if (histogram is not null)
+                        {
+                            foreach (var u in unbound)
+                                histogram[u.PropertyName] = histogram.TryGetValue(u.PropertyName, out var c) ? c + 1 : 1;
+                            continue;
+                        }
 
                         var keptUnbound = new List<UnboundProperty>();
                         var keptNull = new List<NullObjectProperty>();
@@ -196,7 +239,8 @@ public static class ScriptPropertyCheck
         }
 
         return new ScriptCheckResult(reports, targets.Count, recordsWithScripts, totalUnbound, totalNull,
-                                     totalUnverifiable, capped, av.ReadIncomplete, view.ExcludedPlugins, null);
+                                     totalUnverifiable, capped, av.ReadIncomplete, view.ExcludedPlugins, null,
+                                     filterNote, histogram is null ? null : SweepFindings.Histogram(histogram), countsOnly);
     }
 
     /// <summary>Every script attachment on the record: the adapter's own <see cref="IAVirtualMachineAdapterGetter.Scripts"/>
@@ -356,7 +400,12 @@ public sealed record RecordScriptFindings(
 /// <summary>The result of <see cref="ScriptPropertyCheck.Run"/>: the per-record findings (only records WITH findings;
 /// clean scripted records are counted in <paramref name="RecordsWithScripts"/> but omitted), the sweep totals, whether
 /// the finding list was capped, whether a BSA failed to read this build (so a "not on disk" may be unscanned), the
-/// plugins the index build excluded, and — on a Q3 scope error — a recoverable <see cref="Error"/> with no reports.</summary>
+/// plugins the index build excluded, and — on a Q3 scope error — a recoverable <see cref="Error"/> with no reports.
+/// <para><paramref name="FilterNote"/> (#282) names every narrowing the caller applied, and states that the totals above
+/// are for that narrowed scope; null when nothing was narrowed. <paramref name="Histogram"/> is the unbound-by-property
+/// tally, present ONLY under <paramref name="CountsOnly"/> (null = not computed, never "none found"). Under
+/// <paramref name="CountsOnly"/> <paramref name="Reports"/> carries scan-error entries ONLY — the totals are exact and
+/// <paramref name="Capped"/> is false, because nothing was listed to cap.</para></summary>
 public sealed record ScriptCheckResult(
     IReadOnlyList<RecordScriptFindings> Reports,
     int PluginsScanned,
@@ -367,7 +416,10 @@ public sealed record ScriptCheckResult(
     bool Capped,
     bool ReadIncomplete,
     IReadOnlyDictionary<string, string> ExcludedPlugins,
-    string? Error)
+    string? Error,
+    string? FilterNote = null,
+    IReadOnlyList<SweepCount>? Histogram = null,
+    bool CountsOnly = false)
 {
     public bool Success => Error is null;
     public static ScriptCheckResult Fail(string error) =>

--- a/src/housecarl-core/ScriptPropertyCheck.cs
+++ b/src/housecarl-core/ScriptPropertyCheck.cs
@@ -79,10 +79,12 @@ public static class ScriptPropertyCheck
     {
         var propFilter = string.IsNullOrWhiteSpace(propertyContains) ? null : propertyContains.Trim();
         bool PropOk(string name) => propFilter is null || name.Contains(propFilter, StringComparison.OrdinalIgnoreCase);
-        // Every count this sweep reports (records-with-scripts, unbound, bound-but-null, unverifiable) is per-RECORD, so
-        // the blanket scope claim is accurate here — unlike check_errors, whose master count is plugin-level.
+        // Every count this sweep reports is per-RECORD, so the blanket claim needs no exemption clause here (unlike
+        // check_errors' plugin-level master count). It fires when a record scope OR property_contains= is in force —
+        // both make a reported count a SUBSET of its own label. A findings= class filter alone does not: each remaining
+        // number is complete for what it names, and an excluded class already renders "NOT CHECKED" (re-review finding 3).
         var filterNote = SweepFindings.FilterNote(
-            null,
+            recordScope is not null || propFilter is not null ? SweepFindings.ScopedCountsClaim : null,
             recordScope?.Label,
             SweepFindings.Describe(classes),
             propFilter is null ? null : $"property_contains='{propFilter}'");
@@ -123,9 +125,12 @@ public static class ScriptPropertyCheck
         int findingBudget = limit;
         bool capped = false;
         // counts_only=: the unbound-by-property-name tally, over EVERY unbound finding in scope (never limit-capped —
-        // the whole point is an exact before/after comparison). Built only in that mode, so the normal path's work is
-        // unchanged and a null histogram means "not computed", never "empty".
-        var histogram = countsOnly ? new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase) : null;
+        // the whole point is an exact before/after comparison). Built only when a class that FEEDS it is actually being
+        // collected: with both unbound classes excluded nothing can ever be tallied, and an empty-but-present histogram
+        // would render "nothing to tally" for a count that was never taken — "not computed" reading as "nothing found",
+        // the twin of the check_errors case (re-review finding 1). Null means "not computed", never "empty".
+        bool tallyable = classes.HasFlag(ScriptFindingClass.UnboundObject) || classes.HasFlag(ScriptFindingClass.UnboundScalar);
+        var histogram = countsOnly && tallyable ? new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase) : null;
 
         foreach (var plugin in targets)
         {
@@ -210,10 +215,13 @@ public static class ScriptPropertyCheck
 
                         // counts_only=: tally and move on — no per-record report is built at all, so the record ROSTER
                         // that overflowed the token cap (#282: 183 header lines for 1 requested finding) never forms.
-                        if (histogram is not null)
+                        // Gated on countsOnly, NOT on the histogram: with both unbound classes excluded the histogram is
+                        // deliberately null (above) and the roster must still not be built.
+                        if (countsOnly)
                         {
-                            foreach (var u in unbound)
-                                histogram[u.PropertyName] = histogram.TryGetValue(u.PropertyName, out var c) ? c + 1 : 1;
+                            if (histogram is not null)
+                                foreach (var u in unbound)
+                                    histogram[u.PropertyName] = histogram.TryGetValue(u.PropertyName, out var c) ? c + 1 : 1;
                             continue;
                         }
 

--- a/src/housecarl-core/ScriptPropertyCheck.cs
+++ b/src/housecarl-core/ScriptPropertyCheck.cs
@@ -79,7 +79,10 @@ public static class ScriptPropertyCheck
     {
         var propFilter = string.IsNullOrWhiteSpace(propertyContains) ? null : propertyContains.Trim();
         bool PropOk(string name) => propFilter is null || name.Contains(propFilter, StringComparison.OrdinalIgnoreCase);
+        // Every count this sweep reports (records-with-scripts, unbound, bound-but-null, unverifiable) is per-RECORD, so
+        // the blanket scope claim is accurate here — unlike check_errors, whose master count is plugin-level.
         var filterNote = SweepFindings.FilterNote(
+            null,
             recordScope?.Label,
             SweepFindings.Describe(classes),
             propFilter is null ? null : $"property_contains='{propFilter}'");
@@ -114,6 +117,9 @@ public static class ScriptPropertyCheck
 
         var reports = new List<RecordScriptFindings>();
         int recordsWithScripts = 0, totalUnbound = 0, totalNull = 0, totalUnverifiable = 0;
+        // Split by class so each number's SCOPE is self-evident in the render: a class the caller excluded is reported as
+        // not-checked rather than as a 0 that reads like "looked, found none" (PR #288 review, finding 1).
+        int totalUnboundObject = 0, totalUnboundScalar = 0;
         int findingBudget = limit;
         bool capped = false;
         // counts_only=: the unbound-by-property-name tally, over EVERY unbound finding in scope (never limit-capped —
@@ -198,6 +204,7 @@ public static class ScriptPropertyCheck
                         // Apply the shared finding budget (unbound + null are the capped population; unverifiable notes
                         // are few and always kept). The true totals are counted regardless of the cap.
                         totalUnbound += unbound.Count;
+                        foreach (var u in unbound) { if (u.IsObjectType) totalUnboundObject++; else totalUnboundScalar++; }
                         totalNull += nulls.Count;
                         totalUnverifiable += unver.Count;
 
@@ -240,7 +247,8 @@ public static class ScriptPropertyCheck
 
         return new ScriptCheckResult(reports, targets.Count, recordsWithScripts, totalUnbound, totalNull,
                                      totalUnverifiable, capped, av.ReadIncomplete, view.ExcludedPlugins, null,
-                                     filterNote, histogram is null ? null : SweepFindings.Histogram(histogram), countsOnly);
+                                     filterNote, histogram is null ? null : SweepFindings.Histogram(histogram), countsOnly,
+                                     classes, totalUnboundObject, totalUnboundScalar);
     }
 
     /// <summary>Every script attachment on the record: the adapter's own <see cref="IAVirtualMachineAdapterGetter.Scripts"/>
@@ -405,7 +413,13 @@ public sealed record RecordScriptFindings(
 /// are for that narrowed scope; null when nothing was narrowed. <paramref name="Histogram"/> is the unbound-by-property
 /// tally, present ONLY under <paramref name="CountsOnly"/> (null = not computed, never "none found"). Under
 /// <paramref name="CountsOnly"/> <paramref name="Reports"/> carries scan-error entries ONLY — the totals are exact and
-/// <paramref name="Capped"/> is false, because nothing was listed to cap.</para></summary>
+/// <paramref name="Capped"/> is false, because nothing was listed to cap.</para>
+/// <para><paramref name="Classes"/> is the finding-class filter that was in force, with
+/// <paramref name="TotalUnboundObject"/> / <paramref name="TotalUnboundScalar"/> splitting the unbound total by it. The
+/// renders read these to report an EXCLUDED class as not-checked rather than as a 0 — a class nobody looked for must not
+/// read as a class that came back clean, which is the same rule <see cref="ErrorCheckResult.Classes"/> serves for the
+/// integrity sweep (PR #288 review, finding 1). <paramref name="TotalUnbound"/> stays the sum of the classes that WERE
+/// checked.</para></summary>
 public sealed record ScriptCheckResult(
     IReadOnlyList<RecordScriptFindings> Reports,
     int PluginsScanned,
@@ -419,7 +433,10 @@ public sealed record ScriptCheckResult(
     string? Error,
     string? FilterNote = null,
     IReadOnlyList<SweepCount>? Histogram = null,
-    bool CountsOnly = false)
+    bool CountsOnly = false,
+    ScriptFindingClass Classes = ScriptFindingClass.All,
+    int TotalUnboundObject = 0,
+    int TotalUnboundScalar = 0)
 {
     public bool Success => Error is null;
     public static ScriptCheckResult Fail(string error) =>

--- a/src/housecarl-core/SweepScope.cs
+++ b/src/housecarl-core/SweepScope.cs
@@ -1,0 +1,220 @@
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+
+namespace HousecarlCore;
+
+/// <summary>
+/// The RECORD-level narrowing the two sweep tools share (housecarl_check_errors, housecarl_validate_scripts — #282).
+/// Both had exactly one scope knob, <c>plugins=</c>, and one script-heavy plugin (~183 scripted records, 711 unbound
+/// findings) renders past the tool-result token cap — so the common follow-up question ("did the unbound count for
+/// THESE few records change?") had no call that could ask it. This is that missing scope, in the vocabulary the sibling
+/// read tools already speak: <see cref="Types"/> (cross_plugin_query's <c>type=</c>), <see cref="Formids"/>
+/// (batch_record_detail's <c>formids=</c>), and <see cref="EditorIdContains"/> (cross_plugin_query's
+/// <c>editorid_contains=</c>).
+///
+/// <para><b>Narrowing narrows the NUMBERS.</b> A scoped sweep's totals are the totals FOR THE SCOPE, exactly as
+/// <c>plugins=</c> already behaves (scoping to one plugin reports that plugin's counts, not the order's). The
+/// render therefore carries <see cref="Label"/> on its own line whenever anything is applied, so a count can never be
+/// read as a wider claim than it is (Q3).</para>
+///
+/// <para><see cref="Types"/> is handed to the record STREAM (<c>RecordsIn</c>'s getter-type filter), so a type scope
+/// costs nothing per skipped record; <see cref="Formids"/> and <see cref="EditorIdContains"/> are per-record tests
+/// applied before any expensive work (the link walk / the .pex chain read).</para>
+/// </summary>
+public sealed class SweepScope
+{
+    /// <summary>The exact records to sweep, or null for "any". Set ⇒ every other record is skipped.</summary>
+    public IReadOnlySet<FormKey>? Formids { get; }
+
+    /// <summary>A case-insensitive substring the record's EditorID must contain, or null for "any". A record with NO
+    /// EditorID never matches a non-null filter (an absent id cannot contain a substring — the honest answer, not a
+    /// free pass).</summary>
+    public string? EditorIdContains { get; }
+
+    /// <summary>The getter Type(s) to stream, or null for every record type. Resolved by the caller from the user's
+    /// <c>type=</c> string (the shared TypeLookup), so an unknown type fails loud before the sweep starts.</summary>
+    public IReadOnlyList<Type>? Types { get; }
+
+    /// <summary>The user-facing spelling of <see cref="Types"/> (the raw <c>type=</c> string), for <see cref="Label"/>.</summary>
+    public string? TypeLabel { get; }
+
+    public SweepScope(IReadOnlySet<FormKey>? formids, string? editorIdContains,
+                      IReadOnlyList<Type>? types, string? typeLabel)
+    {
+        Formids = formids is { Count: > 0 } ? formids : null;
+        EditorIdContains = string.IsNullOrWhiteSpace(editorIdContains) ? null : editorIdContains.Trim();
+        Types = types is { Count: > 0 } ? types : null;
+        TypeLabel = Types is null ? null : typeLabel;
+    }
+
+    /// <summary>True when nothing is actually narrowed (every knob absent) — the caller can then pass null and keep the
+    /// unscoped path byte-identical.</summary>
+    public bool IsEmpty => Formids is null && EditorIdContains is null && Types is null;
+
+    /// <summary>Does this record fall inside the scope? <see cref="Types"/> is NOT re-tested here — it is applied at the
+    /// stream, so a body reaching this call is already of a scoped type.</summary>
+    public bool Matches(FormKey fk, IMajorRecordGetter body)
+    {
+        if (Formids is not null && !Formids.Contains(fk)) return false;
+        if (EditorIdContains is not null)
+        {
+            var eid = body.EditorID;
+            if (eid is null || !eid.Contains(EditorIdContains, StringComparison.OrdinalIgnoreCase)) return false;
+        }
+        return true;
+    }
+
+    /// <summary>The applied narrowing, spelled for the render, or null when nothing is applied.</summary>
+    public string? Label
+    {
+        get
+        {
+            if (IsEmpty) return null;
+            var parts = new List<string>(3);
+            if (Types is not null) parts.Add($"type={TypeLabel}");
+            if (Formids is not null) parts.Add($"{Formids.Count} formid(s)");
+            if (EditorIdContains is not null) parts.Add($"editorid_contains='{EditorIdContains}'");
+            return string.Join(", ", parts);
+        }
+    }
+}
+
+/// <summary>One row of a <c>counts_only=true</c> histogram: a key (a property name, a target plugin) and how many
+/// findings in the swept scope carry it.</summary>
+public sealed record SweepCount(string Key, int Count);
+
+/// <summary>The error classes housecarl_check_errors can be filtered to (<c>findings=</c>). Excluding a class SKIPS the
+/// work that finds it — <see cref="Dangling"/> off skips the per-record link walk entirely, which is what turns "is any
+/// master missing anywhere in my order" from a full sweep into a master-table read. Parse failures are deliberately NOT
+/// a member: "houseCARL could not read this" is the honesty layer, not a finding class, and must never be filterable
+/// away (Q3).</summary>
+[Flags]
+public enum ErrorFindingClass
+{
+    None = 0,
+    /// <summary>A non-null FormLink no active plugin defines.</summary>
+    Dangling = 1,
+    /// <summary>A master a plugin declares that is not present in the active order.</summary>
+    MissingMasters = 2,
+    All = Dangling | MissingMasters,
+}
+
+/// <summary>The finding classes housecarl_validate_scripts can be filtered to (<c>findings=</c>), in severity order:
+/// an unbound OBJECT property is the silent-<c>None</c> footgun (HIGH), an unbound uninitialized SCALAR silently
+/// defaults (MEDIUM), a bound-but-null object property is advisory. Unverifiable attachments are deliberately NOT a
+/// member — same reason as the parse class above: an attachment houseCARL could not read must stay visible under every
+/// filter, or the filter manufactures a false clean (Q3).</summary>
+[Flags]
+public enum ScriptFindingClass
+{
+    None = 0,
+    /// <summary>Declared but not bound, of a form/object type ⇒ None at runtime. HIGH.</summary>
+    UnboundObject = 1,
+    /// <summary>Declared but not bound, an uninitialized scalar ⇒ 0/false/"". MEDIUM.</summary>
+    UnboundScalar = 2,
+    /// <summary>Present in the VMAD with a null Object link. Advisory.</summary>
+    BoundNull = 4,
+    All = UnboundObject | UnboundScalar | BoundNull,
+}
+
+/// <summary>Parsers for the sweep tools' <c>findings=</c> vocabularies. A name outside the vocabulary is a NAMED
+/// refusal listing every legal value (never a silent drop to "all", which would answer a different question than the
+/// one asked — Q3). An empty/omitted list means "every class", the unfiltered default.</summary>
+public static class SweepFindings
+{
+    /// <summary>housecarl_check_errors' <c>findings=</c>: <c>dangling</c> / <c>missing_masters</c>.</summary>
+    public static bool TryParseErrorClasses(IReadOnlyList<string>? names, out ErrorFindingClass classes, out string? error)
+    {
+        classes = ErrorFindingClass.All; error = null;
+        if (names is not { Count: > 0 }) return true;
+        var acc = ErrorFindingClass.None;
+        foreach (var raw in names)
+        {
+            switch (Normalize(raw))
+            {
+                case "dangling": acc |= ErrorFindingClass.Dangling; break;
+                case "missing_masters": acc |= ErrorFindingClass.MissingMasters; break;
+                default:
+                    error = $"findings='{raw}' is not a check_errors finding class — use 'dangling' and/or 'missing_masters'. " +
+                            "Unscannable records and scan errors are ALWAYS reported and cannot be filtered out (a suppressed " +
+                            "'could not read' would read as a clean result).";
+                    classes = ErrorFindingClass.All;
+                    return false;
+            }
+        }
+        classes = acc;
+        return true;
+    }
+
+    /// <summary>housecarl_validate_scripts' <c>findings=</c>: <c>unbound_object</c> / <c>unbound_scalar</c> /
+    /// <c>bound_null</c>, plus the convenience alias <c>unbound</c> (both unbound classes).</summary>
+    public static bool TryParseScriptClasses(IReadOnlyList<string>? names, out ScriptFindingClass classes, out string? error)
+    {
+        classes = ScriptFindingClass.All; error = null;
+        if (names is not { Count: > 0 }) return true;
+        var acc = ScriptFindingClass.None;
+        foreach (var raw in names)
+        {
+            switch (Normalize(raw))
+            {
+                case "unbound_object": acc |= ScriptFindingClass.UnboundObject; break;
+                case "unbound_scalar": acc |= ScriptFindingClass.UnboundScalar; break;
+                case "unbound": acc |= ScriptFindingClass.UnboundObject | ScriptFindingClass.UnboundScalar; break;
+                case "bound_null": acc |= ScriptFindingClass.BoundNull; break;
+                default:
+                    error = $"findings='{raw}' is not a validate_scripts finding class — use 'unbound_object' (the HIGH " +
+                            "silent-None class), 'unbound_scalar', 'unbound' (both), and/or 'bound_null'. Unverifiable " +
+                            "attachments are ALWAYS reported and cannot be filtered out (a suppressed 'could not check' " +
+                            "would read as a clean result).";
+                    classes = ScriptFindingClass.All;
+                    return false;
+            }
+        }
+        classes = acc;
+        return true;
+    }
+
+    /// <summary>The applied class filter spelled for the render, or null when every class is included.</summary>
+    public static string? Describe(ErrorFindingClass c)
+        => c == ErrorFindingClass.All ? null : $"findings=[{string.Join(", ", Names(c))}]";
+
+    /// <summary>The applied class filter spelled for the render, or null when every class is included.</summary>
+    public static string? Describe(ScriptFindingClass c)
+        => c == ScriptFindingClass.All ? null : $"findings=[{string.Join(", ", Names(c))}]";
+
+    static IEnumerable<string> Names(ErrorFindingClass c)
+    {
+        if (c.HasFlag(ErrorFindingClass.Dangling)) yield return "dangling";
+        if (c.HasFlag(ErrorFindingClass.MissingMasters)) yield return "missing_masters";
+        if (c == ErrorFindingClass.None) yield return "none";
+    }
+
+    static IEnumerable<string> Names(ScriptFindingClass c)
+    {
+        if (c.HasFlag(ScriptFindingClass.UnboundObject)) yield return "unbound_object";
+        if (c.HasFlag(ScriptFindingClass.UnboundScalar)) yield return "unbound_scalar";
+        if (c.HasFlag(ScriptFindingClass.BoundNull)) yield return "bound_null";
+        if (c == ScriptFindingClass.None) yield return "none";
+    }
+
+    /// <summary>Join the scope label and the finding-filter clauses into the ONE render line that states, in words, that
+    /// every count in the result is scope-relative. Null when nothing was narrowed — then the counts are the plain
+    /// <c>plugins=</c> totals and need no caveat.</summary>
+    public static string? FilterNote(params string?[] clauses)
+    {
+        var kept = clauses.Where(c => !string.IsNullOrEmpty(c)).ToList();
+        return kept.Count == 0 ? null
+            : "NARROWED to " + string.Join(" · ", kept) + " — every count below is for THIS narrowed scope, not the whole plugin(s).";
+    }
+
+    static string Normalize(string? s) => (s ?? "").Trim().Replace('-', '_').ToLowerInvariant();
+
+    /// <summary>Order a <c>counts_only=true</c> histogram for display: commonest first, ties broken by key so the output
+    /// is stable across runs (a before/after diff of two histograms is the motivating use — an unstable order would
+    /// make every run diff).</summary>
+    public static List<SweepCount> Histogram(Dictionary<string, int> acc)
+        => acc.Select(kv => new SweepCount(kv.Key, kv.Value))
+              .OrderByDescending(c => c.Count)
+              .ThenBy(c => c.Key, StringComparer.OrdinalIgnoreCase)
+              .ToList();
+}

--- a/src/housecarl-core/SweepScope.cs
+++ b/src/housecarl-core/SweepScope.cs
@@ -197,19 +197,28 @@ public static class SweepFindings
         if (c == ScriptFindingClass.None) yield return "none";
     }
 
-    /// <summary>Join the scope label and the finding-filter clauses into the ONE render line that states, in words, which
-    /// of the result's counts are scope-relative. Null when nothing was narrowed — then the counts are the plain
-    /// <c>plugins=</c> totals and need no caveat.
-    /// <para><paramref name="claimOverride"/> replaces the default blanket claim for a sweep where some count is NOT
-    /// scope-relative. check_errors needs it: its missing-master count is read off the plugin's master TABLE, so a
-    /// record scope cannot narrow it, and the blanket sentence would assert otherwise about the number printed directly
-    /// above it (PR #288 review, finding 3). Pass null for the default.</para></summary>
-    public static string? FilterNote(string? claimOverride, params string?[] clauses)
+    /// <summary>The default subset-claim sentence, shared so the two sweeps cannot word it differently.</summary>
+    public const string ScopedCountsClaim =
+        "every count below is for THIS narrowed scope, not the whole plugin(s).";
+
+    /// <summary>Join the applied-narrowing clauses into the ONE render line, optionally followed by
+    /// <paramref name="claim"/> — the sentence saying the counts above are a SUBSET of what their labels name. Null when
+    /// nothing was narrowed at all.
+    ///
+    /// <para>The claim is the caller's call, not automatic, because narrowing a sweep and narrowing its COUNTS are
+    /// different things (PR #288 re-review, finding 3). A <c>findings=</c> class filter narrows which findings are
+    /// counted but leaves every reported number COMPLETE for what it names — an excluded class already renders
+    /// "NOT CHECKED" — so <c>check_errors findings=["dangling"]</c> with no record scope reports the true whole-order
+    /// dangling total, and appending "not the whole plugin(s)" to it would be false. A record scope, or
+    /// <c>property_contains=</c>, genuinely does make each count a subset of its own label, and there the claim belongs.
+    /// Pass <see cref="ScopedCountsClaim"/> for the default wording, a bespoke string where some count is exempt
+    /// (check_errors' plugin-level master count — round-1 finding 3), or null for no claim.</para></summary>
+    public static string? FilterNote(string? claim, params string?[] clauses)
     {
         var kept = clauses.Where(c => !string.IsNullOrEmpty(c)).ToList();
-        return kept.Count == 0 ? null
-            : "NARROWED to " + string.Join(" · ", kept) + " — "
-              + (claimOverride ?? "every count below is for THIS narrowed scope, not the whole plugin(s).");
+        if (kept.Count == 0) return null;
+        var prefix = "NARROWED to " + string.Join(" · ", kept);
+        return claim is null ? prefix + "." : prefix + " — " + claim;
     }
 
     static string Normalize(string? s) => (s ?? "").Trim().Replace('-', '_').ToLowerInvariant();

--- a/src/housecarl-core/SweepScope.cs
+++ b/src/housecarl-core/SweepScope.cs
@@ -197,14 +197,19 @@ public static class SweepFindings
         if (c == ScriptFindingClass.None) yield return "none";
     }
 
-    /// <summary>Join the scope label and the finding-filter clauses into the ONE render line that states, in words, that
-    /// every count in the result is scope-relative. Null when nothing was narrowed — then the counts are the plain
-    /// <c>plugins=</c> totals and need no caveat.</summary>
-    public static string? FilterNote(params string?[] clauses)
+    /// <summary>Join the scope label and the finding-filter clauses into the ONE render line that states, in words, which
+    /// of the result's counts are scope-relative. Null when nothing was narrowed — then the counts are the plain
+    /// <c>plugins=</c> totals and need no caveat.
+    /// <para><paramref name="claimOverride"/> replaces the default blanket claim for a sweep where some count is NOT
+    /// scope-relative. check_errors needs it: its missing-master count is read off the plugin's master TABLE, so a
+    /// record scope cannot narrow it, and the blanket sentence would assert otherwise about the number printed directly
+    /// above it (PR #288 review, finding 3). Pass null for the default.</para></summary>
+    public static string? FilterNote(string? claimOverride, params string?[] clauses)
     {
         var kept = clauses.Where(c => !string.IsNullOrEmpty(c)).ToList();
         return kept.Count == 0 ? null
-            : "NARROWED to " + string.Join(" · ", kept) + " — every count below is for THIS narrowed scope, not the whole plugin(s).";
+            : "NARROWED to " + string.Join(" · ", kept) + " — "
+              + (claimOverride ?? "every count below is for THIS narrowed scope, not the whole plugin(s).");
     }
 
     static string Normalize(string? s) => (s ?? "").Trim().Replace('-', '_').ToLowerInvariant();

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -1,7 +1,9 @@
+using System.Text.Json;
 using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Skyrim;
 using HousecarlCore;
+using HousecarlMcp;
 
 namespace HousecarlGenerator;
 
@@ -53,6 +55,17 @@ namespace HousecarlGenerator;
 ///                     master (the exemption drops ONLY the ambiguous rank word, never the owner reference).
 ///   OWNER-RANK-TOTAL    — exactly 1 dangling across the owner order (both chests' rank words exempt; only the broken owner form) —
 ///                     without the fix the same order totals 3 (two FFFFFF rank artifacts + the ghost owner).
+///   NARROW-FORMIDS  — formids=[one dangling SOURCE] narrows the sweep AND its totals to that record (#282).
+///   NARROW-EDITORID — editorid_contains= narrows case-insensitively to the other one.
+///   NARROW-TYPE     — type=NPC_ keeps both findings, type=RACE keeps none (the scope rides the record STREAM).
+///   NARROW-NOTE     — a narrowed result carries a FilterNote saying the counts are scope-relative; an unnarrowed one doesn't.
+///   CLASS-MASTERS-ONLY — findings=[missing_masters] skips the link walk; the render says dangling "NOT CHECKED", NOT 0
+///                     (a skipped check that reads as a clean one is the Q3 break this tool exists to catch).
+///   CLASS-DANGLING-ONLY — findings=[dangling] skips the master read; the render says missing masters "NOT CHECKED".
+///   CLASS-Q3        — an unrecognized findings= value fails LOUD, names the legal set, and says the unread class is unfilterable.
+///   COUNTS-ONLY     — counts_only=true keeps the totals exact, builds NO per-plugin body, and tallies dangling refs by TARGET plugin.
+///   COUNTS-ONLY-NOT-COMPUTED — a normal sweep leaves Histogram null: "not computed" ≠ "nothing found".
+///   JSON-PARITY     — format=json PARSES, agrees with the text totals, and emits null (not 0) for an unchecked class.
 ///
 /// OWNER FIXTURE (#207, its own order): HcCeMaster.esm also defines a Faction; HcCeOwner.esp masters [HcCeMaster, HcCeGhost]
 ///   and carries two owned containers — one owned by the PRESENT master's faction (rank -1 → must not dangle) and one owned by a
@@ -103,6 +116,7 @@ public static class CheckErrorsProbe
         var sub800Fk     = FormKey.Factory("000015:Skyrim.esm");  // a DIFFERENT sub-0x800 form — NOT whitelisted (MUST dangle: proves precision)
         var ghostOwnerFactionFk = FormKey.Factory("000D0F:HcCeGhost.esm");  // #207: an owner-faction id in the ABSENT master (proves OwnerData is still swept)
         FormKey masterRaceFk, ghostRaceFk, ownerFactionFk;
+        FormKey badGhostNpcFk, badDeadNpcFk;   // #282: the two dangling SOURCES, for the formids= / editorid_contains= scope arms
         try
         {
             var master = new SkyrimMod(new ModKey("HcCeMaster", ModType.Master), SkyrimRelease.SkyrimSE);
@@ -124,6 +138,7 @@ public static class CheckErrorsProbe
             var bad = new SkyrimMod(new ModKey("HcCeBad", ModType.Plugin), SkyrimRelease.SkyrimSE);
             var bGhost = bad.Npcs.AddNew(); bGhost.EditorID = "HcCeBadGhostNpc"; bGhost.Race.SetTo(ghostRaceFk);
             var bDead  = bad.Npcs.AddNew(); bDead.EditorID  = "HcCeBadDeadNpc";  bDead.Race.SetTo(deadFk);
+            badGhostNpcFk = bGhost.FormKey; badDeadNpcFk = bDead.FormKey;
             bad.BeginWrite.ToPath(badPath).WithLoadOrder(new ISkyrimModGetter[] { master, ghost }).Write();
 
             // PlayerRef whitelist fixture (HCBR checkerrors-playerref-dangling-false-positive). A stub Skyrim.esm base
@@ -208,6 +223,80 @@ public static class CheckErrorsProbe
             capped.TotalDangling == 2 && capped.Capped
             && capped.Reports.Count == 1 && capped.Reports[0].Dangling.Count == 1,
             $"total={capped.TotalDangling} capped={capped.Capped} collected={(capped.Reports.Count > 0 ? capped.Reports[0].Dangling.Count : -1)}");
+
+        // ---- #282: the record scope / class filter / counts_only knobs. ONE plugin was the narrowest scope the tool
+        //      had, and its whole per-plugin body overflowed the tool-result cap with no way to ask a smaller question. ----
+        var byFormid = ErrorCheck.Run(r, new[] { "HcCeBad.esp" }, 1000, null,
+            new SweepScope(new HashSet<FormKey> { badGhostNpcFk }, null, null, null));
+        Check("NARROW-FORMIDS: formids=[the ghost-ref NPC] narrows the sweep to that record — 1 dangling, and it is the ghost ref",
+            byFormid.Success && byFormid.TotalDangling == 1
+            && byFormid.Reports.Count == 1 && byFormid.Reports[0].Dangling.Single().Target == ghostRaceFk,
+            $"success={byFormid.Success} total={byFormid.TotalDangling} targets=[{string.Join(",", byFormid.Reports.SelectMany(p => p.Dangling).Select(d => d.Target.ToString()))}]");
+
+        var byEditorId = ErrorCheck.Run(r, new[] { "HcCeBad.esp" }, 1000, null,
+            new SweepScope(null, "deadnpc", null, null));   // case-insensitive by contract
+        Check("NARROW-EDITORID: editorid_contains='deadnpc' (case-insensitive) narrows to the dead-ref NPC — 1 dangling, the dead id",
+            byEditorId.Success && byEditorId.TotalDangling == 1
+            && byEditorId.Reports.Count == 1 && byEditorId.Reports[0].Dangling.Single().Target == deadFk,
+            $"success={byEditorId.Success} total={byEditorId.TotalDangling} targets=[{string.Join(",", byEditorId.Reports.SelectMany(p => p.Dangling).Select(d => d.Target.ToString()))}]");
+
+        var byNpcType = ErrorCheck.Run(r, null, 1000, null, new SweepScope(null, null, new[] { typeof(INpcGetter) }, "NPC_"));
+        var byRaceType = ErrorCheck.Run(r, null, 1000, null, new SweepScope(null, null, new[] { typeof(IRaceGetter) }, "RACE"));
+        Check("NARROW-TYPE: type=NPC_ keeps both dangling refs (both sources are NPCs); type=RACE keeps NONE — the scope rides the record STREAM",
+            byNpcType.Success && byNpcType.TotalDangling == 2 && byRaceType.Success && byRaceType.TotalDangling == 0,
+            $"npc={byNpcType.TotalDangling} race={byRaceType.TotalDangling}");
+
+        Check("NARROW-NOTE: a narrowed sweep carries a FilterNote saying the counts are scope-relative; an unnarrowed one carries none (Q3)",
+            byFormid.FilterNote is not null && byFormid.FilterNote.Contains("NARROWED", StringComparison.Ordinal)
+            && all.FilterNote is null,
+            $"narrowed=[{byFormid.FilterNote}] unnarrowed=[{all.FilterNote}]");
+
+        // findings= excluding 'dangling' must SKIP the link walk, and the render must say NOT CHECKED — not 0. A skipped
+        // check that renders as a clean one is precisely the Q3 break this tool exists to catch in other people's data.
+        var mastersOnly = ErrorCheck.Run(r, null, 1000, null, null, ErrorFindingClass.MissingMasters);
+        var mastersText = Wire.RenderCheckErrors(mastersOnly, 0);
+        Check("CLASS-MASTERS-ONLY: findings=[missing_masters] still finds HcCeGhost.esm, reports 0 dangling, and RENDERS dangling as 'NOT CHECKED' (never as 0)",
+            mastersOnly.Success && mastersOnly.TotalMissingMasters == 1 && mastersOnly.TotalDangling == 0
+            && !mastersOnly.Classes.HasFlag(ErrorFindingClass.Dangling)
+            && mastersText.Contains("dangling refs NOT CHECKED", StringComparison.Ordinal)
+            && !mastersText.Contains("0 dangling ref(s)", StringComparison.Ordinal),
+            $"missing={mastersOnly.TotalMissingMasters} dangling={mastersOnly.TotalDangling} header=[{mastersText.Split('\n').Skip(1).FirstOrDefault()}]");
+
+        var danglingOnly = ErrorCheck.Run(r, null, 1000, null, null, ErrorFindingClass.Dangling);
+        var danglingText = Wire.RenderCheckErrors(danglingOnly, 0);
+        Check("CLASS-DANGLING-ONLY: findings=[dangling] skips the master read (0 missing) and RENDERS missing masters as 'NOT CHECKED'",
+            danglingOnly.Success && danglingOnly.TotalDangling == 2 && danglingOnly.TotalMissingMasters == 0
+            && danglingOnly.Reports.All(p => p.MissingMasters.Count == 0)
+            && danglingText.Contains("missing masters NOT CHECKED", StringComparison.Ordinal),
+            $"dangling={danglingOnly.TotalDangling} missing={danglingOnly.TotalMissingMasters}");
+
+        Check("CLASS-Q3: an unrecognized findings= value fails LOUD, names the legal set, and says the unread class can't be filtered out",
+            !SweepFindings.TryParseErrorClasses(new[] { "danglign" }, out _, out var ceClassErr)
+            && ceClassErr is not null && ceClassErr.Contains("'dangling'", StringComparison.Ordinal)
+            && ceClassErr.Contains("missing_masters", StringComparison.Ordinal)
+            && ceClassErr.Contains("cannot be filtered out", StringComparison.Ordinal),
+            $"err=[{ceClassErr}]");
+
+        // counts_only=: exact totals + a dangling-by-TARGET-plugin histogram, with NO per-plugin body built at all.
+        var countsOnly = ErrorCheck.Run(r, null, 1000, null, null, ErrorFindingClass.All, countsOnly: true);
+        var histo = countsOnly.Histogram;
+        Check("COUNTS-ONLY: totals stay exact (2 dangling), NO per-plugin listing is built, and the histogram keys the refs by TARGET plugin",
+            countsOnly.Success && countsOnly.TotalDangling == 2 && countsOnly.CountsOnly
+            && countsOnly.Reports.Count == 0 && !countsOnly.Capped
+            && histo is not null && histo.Sum(h => h.Count) == 2
+            && histo.Any(h => h.Key.Equals("HcCeGhost.esm", StringComparison.OrdinalIgnoreCase) && h.Count == 1)
+            && histo.Any(h => h.Key.Equals("HcCeMaster.esm", StringComparison.OrdinalIgnoreCase) && h.Count == 1),
+            $"total={countsOnly.TotalDangling} reports={countsOnly.Reports.Count} histo=[{(histo is null ? "<null>" : string.Join(",", histo.Select(h => $"{h.Key}={h.Count}")))}]");
+
+        Check("COUNTS-ONLY-NOT-COMPUTED: a normal sweep leaves Histogram NULL — 'not computed' and 'nothing found' must not look alike (Q3)",
+            all.Histogram is null && !all.CountsOnly, $"histo={(all.Histogram is null ? "null" : all.Histogram.Count.ToString())}");
+
+        // The json twin must carry the same data off the same result object (D2) and stay parseable in BOTH modes.
+        Check("JSON-PARITY: format=json parses, reports the same dangling total, and emits null (not 0) for a class that was NOT checked",
+            JsonMatches(JsonWire.RenderCheckErrors(all, 0), "dangling", 2)
+            && JsonNull(JsonWire.RenderCheckErrors(mastersOnly, 0), "dangling")
+            && JsonHasHistogram(JsonWire.RenderCheckErrors(countsOnly, 0), "dangling_by_target_plugin"),
+            "see the three json renders");
 
         // ---- OFF-ORDER: a plugin FILE not in the order, swept via the offOrder lane (the pre-enable verify sweep of a
         //      patch houseCARL just wrote — HCBR-2026-07-14-02 gap 3). The fixture patch masters [Master, Ghost] and
@@ -330,5 +419,33 @@ public static class CheckErrorsProbe
         Console.WriteLine();
         Console.WriteLine(failures == 0 ? "check-errors-guard: ALL PASS" : $"check-errors-guard: {failures} FAILURE(S)");
         return failures == 0 ? 0 : 1;
+    }
+
+    // ---- #282 json-parity helpers: parse the emitted document, so a malformed render fails the guard rather than
+    //      passing a substring match. Shared with script-property-check-guard.
+    internal static bool JsonMatches(string json, string prop, int expected)
+    {
+        try { return JsonDocument.Parse(json).RootElement.TryGetProperty(prop, out var v) && v.GetInt32() == expected; }
+        catch { return false; }
+    }
+
+    internal static bool JsonNull(string json, string prop)
+    {
+        try
+        {
+            return JsonDocument.Parse(json).RootElement.TryGetProperty(prop, out var v)
+                && v.ValueKind == JsonValueKind.Null;
+        }
+        catch { return false; }
+    }
+
+    internal static bool JsonHasHistogram(string json, string prop)
+    {
+        try
+        {
+            return JsonDocument.Parse(json).RootElement.TryGetProperty(prop, out var h)
+                && h.TryGetProperty("rows", out var rows) && rows.GetArrayLength() > 0;
+        }
+        catch { return false; }
     }
 }

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -66,6 +66,12 @@ namespace HousecarlGenerator;
 ///   COUNTS-ONLY     — counts_only=true keeps the totals exact, builds NO per-plugin body, and tallies dangling refs by TARGET plugin.
 ///   COUNTS-ONLY-NOT-COMPUTED — a normal sweep leaves Histogram null: "not computed" ≠ "nothing found".
 ///   JSON-PARITY     — format=json PARSES, agrees with the text totals, and emits null (not 0) for an unchecked class.
+///   COUNTS-ONLY-NO-WALK — findings=[missing_masters]+counts_only leaves Histogram NULL and says the walk was not run,
+///                     rather than rendering an empty histogram as "nothing to tally" (PR #288 review, finding 2).
+///   MASTER-COUNT-PLUGIN-LEVEL — under a record scope the note marks the missing-master count plugin-level and NOT
+///                     narrowed; the plain claim returns when there is no plugin-level number to caveat (finding 3).
+///   UNREAD-TRUNC-FLAG — a budget-cut counts_only json flags the shortened `unread` honesty list (finding 4).
+///   COUNTS-ONLY-EXCLUDED-NAMED — counts_only text NAMES the unparseable plugins, not just the header count (finding 5).
 ///
 /// OWNER FIXTURE (#207, its own order): HcCeMaster.esm also defines a Faction; HcCeOwner.esp masters [HcCeMaster, HcCeGhost]
 ///   and carries two owned containers — one owned by the PRESENT master's faction (rank -1 → must not dangle) and one owned by a
@@ -298,6 +304,63 @@ public static class CheckErrorsProbe
             && JsonHasHistogram(JsonWire.RenderCheckErrors(countsOnly, 0), "dangling_by_target_plugin"),
             "see the three json renders");
 
+        // #288 review finding 2: with 'dangling' excluded the link walk never runs, so there is nothing to tally. An
+        // empty-but-PRESENT histogram rendered "nothing to tally — no findings in the swept scope", i.e. invariant #4
+        // inverted: "not computed" reading as "nothing found", for the one combination COUNTS-ONLY did not exercise.
+        var countsNoWalk = ErrorCheck.Run(r, null, 1000, null, null, ErrorFindingClass.MissingMasters, countsOnly: true);
+        var noWalkText = Wire.RenderCheckErrors(countsNoWalk, 0);
+        var noWalkJson = JsonWire.RenderCheckErrors(countsNoWalk, 0);
+        Check("COUNTS-ONLY-NO-WALK: findings=[missing_masters]+counts_only leaves Histogram NULL, says the walk was not run, and never claims 'nothing to tally'",
+            countsNoWalk.Success && countsNoWalk.Histogram is null
+            && noWalkText.Contains("the link walk was not run", StringComparison.Ordinal)
+            && !noWalkText.Contains("nothing to tally", StringComparison.Ordinal)
+            && !noWalkJson.Contains("dangling_by_target_plugin", StringComparison.Ordinal),
+            $"histo={(countsNoWalk.Histogram is null ? "null" : countsNoWalk.Histogram.Count.ToString())}");
+
+        // #288 review finding 3: missing masters come off the plugin's master TABLE, so a RECORD scope cannot narrow
+        // that count — the blanket "every count below is for THIS narrowed scope" was a false claim about the number
+        // printed directly above it.
+        var scopedWithMasters = ErrorCheck.Run(r, new[] { "HcCeBad.esp" }, 1000, null,
+            new SweepScope(new HashSet<FormKey> { badGhostNpcFk }, null, null, null));
+        Check("MASTER-COUNT-PLUGIN-LEVEL: under a record scope the note marks the missing-master count PLUGIN-level and NOT narrowed, instead of claiming every count is scoped",
+            scopedWithMasters.FilterNote is not null
+            && scopedWithMasters.FilterNote.Contains("PLUGIN-level", StringComparison.Ordinal)
+            && scopedWithMasters.FilterNote.Contains("NOT narrowed", StringComparison.Ordinal)
+            && !scopedWithMasters.FilterNote.Contains("every count below is for THIS narrowed scope", StringComparison.Ordinal)
+            // …and with masters NOT in scope there is no plugin-level number to caveat, so the plain claim returns.
+            && ErrorCheck.Run(r, null, 1000, null, new SweepScope(null, null, new[] { typeof(INpcGetter) }, "NPC_"),
+                              ErrorFindingClass.Dangling).FilterNote is { } dOnlyNote
+            && dOnlyNote.Contains("every count below is for THIS narrowed scope", StringComparison.Ordinal),
+            $"note=[{scopedWithMasters.FilterNote}]");
+
+        // #288 review finding 4: the counts_only json `unread` honesty list dropped trailing rows at the budget with NO
+        // flag, while the TEXT render said "truncated" for the same result — a consumer iterating the array believed it
+        // had the complete set of what could not be checked.
+        var manyUnread = countsOnly with
+        {
+            Reports = Enumerable.Range(0, 40)
+                .Select(i => new PluginErrors($"HcCeUnread{i}.esp", Array.Empty<DanglingRef>(), Array.Empty<string>(),
+                                              3, new[] { "some record — could not parse" }, null))
+                .ToList(),
+        };
+        var unreadJson = JsonWire.RenderCheckErrors(manyUnread, 1500);
+        Check("UNREAD-TRUNC-FLAG: a budget-cut counts_only json flags the shortened 'unread' list (total/rendered/truncated), never hands back a silently short honesty set",
+            JsonUnreadTruncated(unreadJson, expectTotal: 40)
+            && JsonUnreadTruncated(JsonWire.RenderCheckErrors(manyUnread, 0), expectTotal: 40, expectTruncated: false),
+            $"json head=[{unreadJson.Split('\n').FirstOrDefault(l => l.Contains("truncated", StringComparison.Ordinal))}]");
+
+        // #288 review finding 5: counts_only text returned before the excluded-plugins block.
+        var countsExcluded = countsOnly with
+        {
+            ExcludedPlugins = new Dictionary<string, string> { ["HcCeBroken.esp"] = "header could not be parsed" },
+        };
+        Check("COUNTS-ONLY-EXCLUDED-NAMED: counts_only text still NAMES the unparseable plugins and their reasons, not just the header count",
+            Wire.RenderCheckErrors(countsExcluded, 0) is var cxt
+            && cxt.Contains("excluded plugins (could not be parsed", StringComparison.Ordinal)
+            && cxt.Contains("HcCeBroken.esp", StringComparison.Ordinal)
+            && cxt.Contains("header could not be parsed", StringComparison.Ordinal),
+            $"line=[{Wire.RenderCheckErrors(countsExcluded, 0).Split('\n').FirstOrDefault(l => l.Contains("HcCeBroken", StringComparison.Ordinal)) ?? "<absent>"}]");
+
         // ---- OFF-ORDER: a plugin FILE not in the order, swept via the offOrder lane (the pre-enable verify sweep of a
         //      patch houseCARL just wrote — HCBR-2026-07-14-02 gap 3). The fixture patch masters [Master, Ghost] and
         //      carries: a NEW race of its own; an NPC → that own race (self-link, must NOT dangle); an NPC → the dead id
@@ -435,6 +498,21 @@ public static class CheckErrorsProbe
         {
             return JsonDocument.Parse(json).RootElement.TryGetProperty(prop, out var v)
                 && v.ValueKind == JsonValueKind.Null;
+        }
+        catch { return false; }
+    }
+
+    /// <summary>The counts_only json's <c>unread</c> must be the wrapped, budget-flagged shape — total + rows + rendered
+    /// + truncated — not a bare array that can silently shorten (#288 review finding 4).</summary>
+    static bool JsonUnreadTruncated(string json, int expectTotal, bool expectTruncated = true)
+    {
+        try
+        {
+            var u = JsonDocument.Parse(json).RootElement.GetProperty("unread");
+            return u.GetProperty("total").GetInt32() == expectTotal
+                && u.GetProperty("truncated").GetBoolean() == expectTruncated
+                && u.GetProperty("rendered").GetInt32() == u.GetProperty("rows").GetArrayLength()
+                && (!expectTruncated || u.GetProperty("rendered").GetInt32() < expectTotal);
         }
         catch { return false; }
     }

--- a/src/housecarl-generator/CheckErrorsProbe.cs
+++ b/src/housecarl-generator/CheckErrorsProbe.cs
@@ -72,6 +72,9 @@ namespace HousecarlGenerator;
 ///                     narrowed; the plain claim returns when there is no plugin-level number to caveat (finding 3).
 ///   UNREAD-TRUNC-FLAG — a budget-cut counts_only json flags the shortened `unread` honesty list (finding 4).
 ///   COUNTS-ONLY-EXCLUDED-NAMED — counts_only text NAMES the unparseable plugins, not just the header count (finding 5).
+///   CLAIM-ONLY-WHEN-SCOPED — findings= alone lists the filter WITHOUT the not-the-whole-plugin claim: that total IS the
+///                     complete whole-order figure, so the claim would be false about the number it sits under. A record
+///                     scope brings the claim back (PR #288 RE-review, finding 3).
 ///
 /// OWNER FIXTURE (#207, its own order): HcCeMaster.esm also defines a Faction; HcCeOwner.esp masters [HcCeMaster, HcCeGhost]
 ///   and carries two owned containers — one owned by the PRESENT master's faction (rank -1 → must not dangle) and one owned by a
@@ -348,6 +351,17 @@ public static class CheckErrorsProbe
             JsonUnreadTruncated(unreadJson, expectTotal: 40)
             && JsonUnreadTruncated(JsonWire.RenderCheckErrors(manyUnread, 0), expectTotal: 40, expectTruncated: false),
             $"json head=[{unreadJson.Split('\n').FirstOrDefault(l => l.Contains("truncated", StringComparison.Ordinal))}]");
+
+        // #288 RE-REVIEW finding 3: findings= alone narrows which findings are COUNTED, not which records were swept —
+        // the dangling total under findings=["dangling"] IS the complete whole-order figure, so the
+        // "not the whole plugin(s)" claim would be false about the very number it sits under.
+        Check("CLAIM-ONLY-WHEN-SCOPED: findings= alone lists the filter WITHOUT the not-the-whole-plugin claim; a record scope brings it back",
+            danglingOnly.FilterNote is { } dNote
+            && dNote.Contains("NARROWED to findings=[dangling]", StringComparison.Ordinal)
+            && !dNote.Contains("not the whole plugin(s)", StringComparison.Ordinal)
+            && !dNote.Contains("PLUGIN-level", StringComparison.Ordinal)
+            && byFormid.FilterNote is { } sNote && sNote.Contains("NOT narrowed", StringComparison.Ordinal),
+            $"class-only=[{danglingOnly.FilterNote}] scoped=[{byFormid.FilterNote}]");
 
         // #288 review finding 5: counts_only text returned before the excluded-plugins block.
         var countsExcluded = countsOnly with

--- a/src/housecarl-generator/ScriptPropertyCheckProbe.cs
+++ b/src/housecarl-generator/ScriptPropertyCheckProbe.cs
@@ -51,6 +51,9 @@ namespace HousecarlGenerator;
 ///   NARROW-NOTE          — a narrowed result carries a FilterNote saying the counts are scope-relative; an unnarrowed one doesn't.
 ///   FILTER-PROPERTY      — property_contains='myspell' keeps MySpell, drops MyChance + InheritedThing.
 ///   FILTER-CLASS         — findings=[unbound_object] keeps MySpell, drops the scalar AND the bound-but-null advisory.
+///   CLASS-NOT-CHECKED-PARTIAL / -TOTAL — an EXCLUDED class renders "NOT CHECKED" and nulls in json, never 0 (PR #288
+///                          review, finding 1: this guard previously asserted the 0 and so locked the bug in).
+///   COUNTS-ONLY-EXCLUDED-NAMED — counts_only text NAMES the unparseable plugins, not just the header count (finding 5).
 ///   UNVERIFIABLE-SURVIVES-FILTER — under a filter matching NOTHING, wNoPex is STILL reported unverifiable. The
 ///                          load-bearing Q3 arm: that unread .pex might declare the very property being filtered for,
 ///                          so letting a filter hide it would turn "could not check" into a clean answer.
@@ -284,8 +287,33 @@ public static class ScriptPropertyCheckProbe
             objectsOnly.Success && objFoot is not null
             && objFoot.Unbound.Any(u => u.PropertyName == "MySpell")
             && !objFoot.Unbound.Any(u => u.PropertyName == "MyChance")
-            && objFoot.NullObjects.Count == 0 && objectsOnly.TotalNullObject == 0,
+            && objFoot.NullObjects.Count == 0,
             objFoot is null ? "<no report>" : $"unbound=[{string.Join(",", objFoot.Unbound.Select(u => u.PropertyName))}] null={objFoot.NullObjects.Count}");
+
+        // #288 review finding 1: an EXCLUDED class must render as not-checked, never as a 0 that reads "looked, found
+        // none". This arm previously asserted `TotalNullObject == 0` and so LOCKED IN the bug — it now asserts the
+        // not-checked marker in both renders, in the partial case as well as the total one.
+        var objText = Wire.RenderScriptCheck(objectsOnly, 0);
+        var objJson = JsonWire.RenderScriptCheck(objectsOnly, 0);
+        Check("CLASS-NOT-CHECKED-PARTIAL: findings=[unbound_object] renders 'unbound_scalar NOT CHECKED' + 'bound-but-null NOT CHECKED', and nulls both in json (never 0)",
+            objText.Contains("object only — unbound_scalar NOT CHECKED", StringComparison.Ordinal)
+            && objText.Contains("bound-but-null NOT CHECKED", StringComparison.Ordinal)
+            && !objText.Contains("0 bound-but-null", StringComparison.Ordinal)
+            && CheckErrorsProbe.JsonNull(objJson, "unbound_scalar")
+            && CheckErrorsProbe.JsonNull(objJson, "bound_but_null")
+            && CheckErrorsProbe.JsonMatches(objJson, "unbound_object", objectsOnly.TotalUnboundObject),
+            $"header=[{objText.Split('\n').Skip(1).FirstOrDefault()}]");
+
+        var nullOnly = ScriptPropertyCheck.Run(resolver, assets, null, 1000, null, null, ScriptFindingClass.BoundNull);
+        var nullText = Wire.RenderScriptCheck(nullOnly, 0);
+        var nullJson = JsonWire.RenderScriptCheck(nullOnly, 0);
+        Check("CLASS-NOT-CHECKED-TOTAL: findings=[bound_null] renders 'unbound NOT CHECKED' and nulls unbound in json — the HIGH class nobody looked for never reads as 0",
+            nullText.Contains("unbound NOT CHECKED", StringComparison.Ordinal)
+            && !nullText.Contains("0 unbound", StringComparison.Ordinal)
+            && CheckErrorsProbe.JsonNull(nullJson, "unbound")
+            && CheckErrorsProbe.JsonNull(nullJson, "unbound_object")
+            && nullOnly.TotalNullObject == 1,
+            $"header=[{nullText.Split('\n').Skip(1).FirstOrDefault()}]");
 
         // THE LOAD-BEARING Q3 ARM: a filter that matches NOTHING must still surface the record whose .pex could not be
         // read — that script might be the very one declaring the property being filtered for, so hiding it would turn
@@ -327,6 +355,19 @@ public static class ScriptPropertyCheckProbe
             && CheckErrorsProbe.JsonMatches(JsonWire.RenderScriptCheck(counts, 0), "unbound", res.TotalUnbound)
             && CheckErrorsProbe.JsonHasHistogram(JsonWire.RenderScriptCheck(counts, 0), "unbound_by_property"),
             "see the two json renders");
+
+        // #288 review finding 5: counts_only used to return before the excluded-plugins block, so the header's bare
+        // count was all you got and you had to re-run without counts_only to learn WHICH plugin went unchecked.
+        var withExcluded = counts with
+        {
+            ExcludedPlugins = new Dictionary<string, string> { ["HcSpBroken.esp"] = "header could not be parsed" },
+        };
+        Check("COUNTS-ONLY-EXCLUDED-NAMED: counts_only text still NAMES the unparseable plugins and their reasons, not just the header count",
+            Wire.RenderScriptCheck(withExcluded, 0) is var xt
+            && xt.Contains("excluded plugins (could not be parsed", StringComparison.Ordinal)
+            && xt.Contains("HcSpBroken.esp", StringComparison.Ordinal)
+            && xt.Contains("header could not be parsed", StringComparison.Ordinal),
+            $"tail=[{Wire.RenderScriptCheck(withExcluded, 0).Split('\n').FirstOrDefault(l => l.Contains("HcSpBroken", StringComparison.Ordinal)) ?? "<absent>"}]");
 
         // The truncation notice used to advise "scope plugins=" — the one scope the caller had already applied. It must
         // now name knobs that exist (#282), or the tool tells you to do the thing that did not work.

--- a/src/housecarl-generator/ScriptPropertyCheckProbe.cs
+++ b/src/housecarl-generator/ScriptPropertyCheckProbe.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Skyrim;
@@ -59,8 +60,12 @@ namespace HousecarlGenerator;
 ///                          gate landed on check_errors and not on this twin).
 ///   CAPPED-TAIL-CLASS-AWARE / -SYMMETRIC — the capped tail restates the totals, so it needs the header's class-awareness
 ///                          or a small limit= reintroduces the "0 unbound" the header dropped (re-review, finding 2).
-///   CLAIM-ONLY-WHEN-SUBSET — findings= alone lists the filter WITHOUT the not-the-whole-plugin claim (the number under
-///                          it is complete); property_contains= alone keeps the claim (re-review, finding 3).
+///   CLAIM-ONLY-WHEN-SCOPED — ONE claim rule: only a RECORD SCOPE carries the not-the-whole-plugin claim. Neither
+///                          findings= nor property_contains= does, because neither narrows every reported number
+///                          (re-review finding 3, extended by the round-3 review).
+///   PROP-FILTER-SELF-LABELS / -IN-JSON — since the claim is gone, the two counts property_contains= DOES narrow label
+///                          themselves ("N unbound matching 'x'"), while records-with-scripts and unverifiable stay
+///                          unlabelled and plugin-wide — the asymmetry that made the blanket claim false (round-3 review).
 ///   UNVERIFIABLE-SURVIVES-FILTER — under a filter matching NOTHING, wNoPex is STILL reported unverifiable. The
 ///                          load-bearing Q3 arm: that unread .pex might declare the very property being filtered for,
 ///                          so letting a filter hide it would turn "could not check" into a clean answer.
@@ -404,12 +409,39 @@ public static class ScriptPropertyCheckProbe
         // #288 RE-REVIEW finding 3: a class filter narrows which findings are COUNTED, not which records were swept, so
         // the "not the whole plugin(s)" claim must not fire on findings= alone — the number it sits under is complete.
         // property_contains= DOES make a count a subset of its own label, so there the claim stays.
-        Check("CLAIM-ONLY-WHEN-SUBSET: findings= alone lists the filter WITHOUT the not-the-whole-plugin claim; property_contains= alone keeps it",
+        // ROUND-3 review: property_contains= narrows the unbound and bound-but-null counts but NOT
+        // records-with-scripts (incremented before any property filtering) or unverifiable (never property-gated, by
+        // design). The blanket claim over those two was round-1 finding 3 again, one layer in — this arm previously
+        // asserted the claim WAS present and so pinned it. ONE claim rule now: record scope only.
+        Check("CLAIM-ONLY-WHEN-SCOPED: neither findings= nor property_contains= carries the not-the-whole-plugin claim; a record scope does",
             objectsOnly.FilterNote is { } cf && cf.Contains("NARROWED to findings=", StringComparison.Ordinal)
             && !cf.Contains("not the whole plugin(s)", StringComparison.Ordinal)
             && byProp.FilterNote is { } pf && pf.Contains("property_contains=", StringComparison.Ordinal)
-            && pf.Contains("not the whole plugin(s)", StringComparison.Ordinal),
-            $"class-only=[{objectsOnly.FilterNote}] prop-only=[{byProp.FilterNote}]");
+            && !pf.Contains("not the whole plugin(s)", StringComparison.Ordinal)
+            && byFormid.FilterNote is { } sf && sf.Contains("not the whole plugin(s)", StringComparison.Ordinal),
+            $"class-only=[{objectsOnly.FilterNote}] prop-only=[{byProp.FilterNote}] scoped=[{byFormid.FilterNote}]");
+
+        // …and because the claim is gone, the two counts property_contains= DOES narrow must say so themselves — while
+        // the two it does not narrow must stay unlabelled, or the label would assert a narrowing that never happened.
+        var propText = Wire.RenderScriptCheck(byProp, 0);
+        var propHeader = propText.Split('\n').Skip(1).FirstOrDefault() ?? "";
+        Check("PROP-FILTER-SELF-LABELS: unbound + bound-but-null carry \"matching 'myspell'\"; records-with-scripts and unverifiable do NOT (they are plugin-wide)",
+            propHeader.Contains("unbound matching 'myspell'", StringComparison.OrdinalIgnoreCase)
+            && propHeader.Contains("bound-but-null matching 'myspell'", StringComparison.OrdinalIgnoreCase)
+            && !propHeader.Contains("record(s) with scripts matching", StringComparison.OrdinalIgnoreCase)
+            && !propHeader.Contains("unverifiable matching", StringComparison.OrdinalIgnoreCase)
+            // records-with-scripts stays the FULL count — the number the claim used to misrepresent
+            && byProp.RecordsWithScripts == res.RecordsWithScripts
+            && byProp.TotalUnverifiable == res.TotalUnverifiable
+            && CheckErrorsProbe.JsonMatches(JsonWire.RenderScriptCheck(byProp, 0), "records_with_scripts", res.RecordsWithScripts),
+            $"header=[{propHeader}]");
+
+        Check("PROP-FILTER-IN-JSON: the property filter rides as DATA (property_contains), so a consumer can read which counts it narrowed",
+            JsonDocument.Parse(JsonWire.RenderScriptCheck(byProp, 0)).RootElement
+                .GetProperty("property_contains").GetString() == "myspell"
+            && JsonDocument.Parse(JsonWire.RenderScriptCheck(res, 0)).RootElement
+                .GetProperty("property_contains").ValueKind == JsonValueKind.Null,
+            "see the two json renders");
 
         // #288 review finding 5: counts_only used to return before the excluded-plugins block, so the header's bare
         // count was all you got and you had to re-run without counts_only to learn WHICH plugin went unchecked.

--- a/src/housecarl-generator/ScriptPropertyCheckProbe.cs
+++ b/src/housecarl-generator/ScriptPropertyCheckProbe.cs
@@ -54,6 +54,13 @@ namespace HousecarlGenerator;
 ///   CLASS-NOT-CHECKED-PARTIAL / -TOTAL — an EXCLUDED class renders "NOT CHECKED" and nulls in json, never 0 (PR #288
 ///                          review, finding 1: this guard previously asserted the 0 and so locked the bug in).
 ///   COUNTS-ONLY-EXCLUDED-NAMED — counts_only text NAMES the unparseable plugins, not just the header count (finding 5).
+///   COUNTS-ONLY-NO-TALLY — counts_only + findings=[bound_null] leaves Histogram NULL and says nothing was tallied; the
+///                          roster contract still holds without a histogram (PR #288 RE-review, finding 1: the round-1
+///                          gate landed on check_errors and not on this twin).
+///   CAPPED-TAIL-CLASS-AWARE / -SYMMETRIC — the capped tail restates the totals, so it needs the header's class-awareness
+///                          or a small limit= reintroduces the "0 unbound" the header dropped (re-review, finding 2).
+///   CLAIM-ONLY-WHEN-SUBSET — findings= alone lists the filter WITHOUT the not-the-whole-plugin claim (the number under
+///                          it is complete); property_contains= alone keeps the claim (re-review, finding 3).
 ///   UNVERIFIABLE-SURVIVES-FILTER — under a filter matching NOTHING, wNoPex is STILL reported unverifiable. The
 ///                          load-bearing Q3 arm: that unread .pex might declare the very property being filtered for,
 ///                          so letting a filter hide it would turn "could not check" into a clean answer.
@@ -355,6 +362,54 @@ public static class ScriptPropertyCheckProbe
             && CheckErrorsProbe.JsonMatches(JsonWire.RenderScriptCheck(counts, 0), "unbound", res.TotalUnbound)
             && CheckErrorsProbe.JsonHasHistogram(JsonWire.RenderScriptCheck(counts, 0), "unbound_by_property"),
             "see the two json renders");
+
+        // #288 RE-REVIEW finding 1: the round-1 histogram gate landed on check_errors and not on its twin here. With
+        // both unbound classes excluded nothing can ever be tallied, so an empty-but-present histogram rendered
+        // "nothing to tally" — and json emitted a machine-readable zero-unbound-properties next to "unbound": null.
+        var countsNoTally = ScriptPropertyCheck.Run(resolver, assets, null, 1000, null, null,
+            ScriptFindingClass.BoundNull, countsOnly: true);
+        var noTallyText = Wire.RenderScriptCheck(countsNoTally, 0);
+        var noTallyJson = JsonWire.RenderScriptCheck(countsNoTally, 0);
+        Check("COUNTS-ONLY-NO-TALLY: counts_only + findings=[bound_null] leaves Histogram NULL, says nothing was tallied, and never claims 'nothing to tally'",
+            countsNoTally.Success && countsNoTally.Histogram is null
+            && countsNoTally.Reports.Count == 0                                   // the roster contract still holds without a histogram
+            && noTallyText.Contains("excluded both unbound classes, so nothing was tallied", StringComparison.Ordinal)
+            && !noTallyText.Contains("nothing to tally", StringComparison.Ordinal)
+            && !noTallyJson.Contains("unbound_by_property", StringComparison.Ordinal),
+            $"histo={(countsNoTally.Histogram is null ? "null" : countsNoTally.Histogram.Count.ToString())} reports={countsNoTally.Reports.Count}");
+
+        // #288 RE-REVIEW finding 2: the header gained class-awareness; the capped tail restated the totals in its own
+        // words and so reintroduced the literal "0 unbound" the header no longer prints. CLASS-NOT-CHECKED-TOTAL missed
+        // it only because it runs at limit=1000 and never trips Capped.
+        // Capped is forced rather than provoked: the fixture carries exactly ONE bound-but-null finding, so no limit=
+        // can trip the cap on this arm's class. The contract under test is the RENDER's wording, which this reaches
+        // directly. (CAPPED-TAIL-SYMMETRIC below trips the real cap, so the natural path is covered too.)
+        var cappedNullOnly = nullOnly with { Capped = true };
+        var cappedText = Wire.RenderScriptCheck(cappedNullOnly, 0);
+        Check("CAPPED-TAIL-CLASS-AWARE: the capped tail says 'unbound NOT CHECKED' too — a small limit must not reintroduce the 0 the header dropped",
+            cappedNullOnly.Capped
+            && cappedText.Contains("finding list capped at limit", StringComparison.Ordinal)
+            && cappedText.Contains("unbound NOT CHECKED", StringComparison.Ordinal)
+            && !cappedText.Contains("0 unbound", StringComparison.Ordinal),
+            $"tail=[{cappedText.Split('\n').FirstOrDefault(l => l.Contains("capped at limit", StringComparison.Ordinal))}]");
+
+        var cappedObjOnly = ScriptPropertyCheck.Run(resolver, assets, null, 1, null, null, ScriptFindingClass.UnboundObject);
+        var cappedObjText = Wire.RenderScriptCheck(cappedObjOnly, 0);
+        Check("CAPPED-TAIL-SYMMETRIC: the same holds the other way — findings=[unbound_object] under a small limit never prints '0 bound-but-null'",
+            cappedObjOnly.Capped
+            && cappedObjText.Contains("bound-but-null NOT CHECKED", StringComparison.Ordinal)
+            && !cappedObjText.Contains("0 bound-but-null", StringComparison.Ordinal),
+            $"tail=[{cappedObjText.Split('\n').FirstOrDefault(l => l.Contains("capped at limit", StringComparison.Ordinal))}]");
+
+        // #288 RE-REVIEW finding 3: a class filter narrows which findings are COUNTED, not which records were swept, so
+        // the "not the whole plugin(s)" claim must not fire on findings= alone — the number it sits under is complete.
+        // property_contains= DOES make a count a subset of its own label, so there the claim stays.
+        Check("CLAIM-ONLY-WHEN-SUBSET: findings= alone lists the filter WITHOUT the not-the-whole-plugin claim; property_contains= alone keeps it",
+            objectsOnly.FilterNote is { } cf && cf.Contains("NARROWED to findings=", StringComparison.Ordinal)
+            && !cf.Contains("not the whole plugin(s)", StringComparison.Ordinal)
+            && byProp.FilterNote is { } pf && pf.Contains("property_contains=", StringComparison.Ordinal)
+            && pf.Contains("not the whole plugin(s)", StringComparison.Ordinal),
+            $"class-only=[{objectsOnly.FilterNote}] prop-only=[{byProp.FilterNote}]");
 
         // #288 review finding 5: counts_only used to return before the excluded-plugins block, so the header's bare
         // count was all you got and you had to re-run without counts_only to learn WHICH plugin went unchecked.

--- a/src/housecarl-generator/ScriptPropertyCheckProbe.cs
+++ b/src/housecarl-generator/ScriptPropertyCheckProbe.cs
@@ -3,6 +3,7 @@ using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Skyrim;
 using Mutagen.Bethesda.Pex;
 using HousecarlCore;
+using HousecarlMcp;
 
 namespace HousecarlGenerator;
 
@@ -44,6 +45,21 @@ namespace HousecarlGenerator;
 ///   UNVERIFIABLE         — wNoPex names HcSpNoPex unverifiable ("not on disk"), never a silent clean (Q3).
 ///   RECORDS-COUNT        — exactly 4 records carry scripts (footgun, clean, noPex, aliasQuest — noVmad excluded).
 ///   SCOPE-Q3             — scope=[a name not in the order] fails LOUD ("not in the load order"), no reports.
+///   NARROW-FORMIDS       — formids=[wFootgun] sweeps that record alone; the roster holds only it (#282).
+///   NARROW-EDITORID      — editorid_contains= narrows case-insensitively to the QUST.
+///   NARROW-TYPE          — type=QUST keeps only the quest; the scripted WEAPs never have their .pex chain read.
+///   NARROW-NOTE          — a narrowed result carries a FilterNote saying the counts are scope-relative; an unnarrowed one doesn't.
+///   FILTER-PROPERTY      — property_contains='myspell' keeps MySpell, drops MyChance + InheritedThing.
+///   FILTER-CLASS         — findings=[unbound_object] keeps MySpell, drops the scalar AND the bound-but-null advisory.
+///   UNVERIFIABLE-SURVIVES-FILTER — under a filter matching NOTHING, wNoPex is STILL reported unverifiable. The
+///                          load-bearing Q3 arm: that unread .pex might declare the very property being filtered for,
+///                          so letting a filter hide it would turn "could not check" into a clean answer.
+///   FILTER-Q3            — an unrecognized findings= value fails LOUD, names the legal set, and says unverifiable is unfilterable.
+///   COUNTS-ONLY          — counts_only=true matches the full sweep's totals, builds NO roster, and tallies unbound by property NAME.
+///   COUNTS-ONLY-NOT-COMPUTED — a normal sweep leaves Histogram null: "not computed" ≠ "nothing found".
+///   JSON-PARITY          — format=json PARSES and agrees with the text totals in both modes (D2).
+///   TRUNCATION-HINT      — the max_chars cut names knobs that EXIST; it no longer advises "scope plugins=", the one
+///                          scope the caller had already applied (the misdirection half of #282).
 ///
 /// Run: dotnet run --project src/housecarl-generator -- script-property-check-guard
 /// </summary>
@@ -222,6 +238,105 @@ public static class ScriptPropertyCheckProbe
             !q3.Success && q3.Reports.Count == 0 && q3.Error is not null
             && q3.Error.Contains("not in the load order", StringComparison.Ordinal),
             $"success={q3.Success} reports={q3.Reports.Count} err=[{q3.Error}]");
+
+        // ---- #282: the record scope / property filter / class filter / counts_only knobs. limit= caps FINDINGS, not the
+        //      record ROSTER, so a script-heavy plugin printed one header line per record and overflowed the tool-result
+        //      cap no matter how low limit went — these are the narrower questions that had no call. ----
+        var byFormid = ScriptPropertyCheck.Run(resolver, assets, null, 1000,
+            new SweepScope(new HashSet<FormKey> { footgunFk }, null, null, null));
+        Check("NARROW-FORMIDS: formids=[wFootgun] sweeps that record ALONE — 1 record with scripts, and the roster holds only it",
+            byFormid.Success && byFormid.RecordsWithScripts == 1
+            && byFormid.Reports.Count == 1 && byFormid.Reports[0].Record == footgunFk,
+            $"success={byFormid.Success} withScripts={byFormid.RecordsWithScripts} reports={byFormid.Reports.Count}");
+
+        var byEditorId = ScriptPropertyCheck.Run(resolver, assets, null, 1000,
+            new SweepScope(null, "aliasquest", null, null));   // case-insensitive by contract
+        Check("NARROW-EDITORID: editorid_contains='aliasquest' (case-insensitive) narrows to the QUST alone",
+            byEditorId.Success && byEditorId.RecordsWithScripts == 1
+            && byEditorId.Reports.Count == 1 && byEditorId.Reports[0].Record == aliasQuestFk,
+            $"withScripts={byEditorId.RecordsWithScripts} reports={byEditorId.Reports.Count}");
+
+        var byType = ScriptPropertyCheck.Run(resolver, assets, null, 1000,
+            new SweepScope(null, null, new[] { typeof(IQuestGetter) }, "QUST"));
+        Check("NARROW-TYPE: type=QUST keeps only the quest — the 3 scripted WEAPs never have their .pex chain read at all",
+            byType.Success && byType.RecordsWithScripts == 1
+            && byType.Reports.Count == 1 && byType.Reports[0].Record == aliasQuestFk,
+            $"withScripts={byType.RecordsWithScripts} reports=[{string.Join(",", byType.Reports.Select(x => x.EditorId))}]");
+
+        Check("NARROW-NOTE: a narrowed sweep carries a FilterNote saying the counts are scope-relative; an unnarrowed one carries none (Q3)",
+            byFormid.FilterNote is not null && byFormid.FilterNote.Contains("NARROWED", StringComparison.Ordinal)
+            && res.FilterNote is null,
+            $"narrowed=[{byFormid.FilterNote}] unnarrowed=[{res.FilterNote}]");
+
+        // property_contains=: chase ONE property. MySpell survives; the scalar MyChance and the ancestor's InheritedThing drop.
+        var byProp = ScriptPropertyCheck.Run(resolver, assets, null, 1000, null, "myspell");
+        var propFoot = byProp.Reports.FirstOrDefault(x => x.Record == footgunFk);
+        Check("FILTER-PROPERTY: property_contains='myspell' keeps MySpell and drops MyChance + InheritedThing (case-insensitive)",
+            byProp.Success && propFoot is not null
+            && propFoot.Unbound.Any(u => u.PropertyName == "MySpell")
+            && !propFoot.Unbound.Any(u => u.PropertyName is "MyChance" or "InheritedThing"),
+            propFoot is null ? "<no report>" : string.Join(",", propFoot.Unbound.Select(u => u.PropertyName)));
+
+        // findings=: the roster-cutting filter. unbound_object drops the scalar AND the bound-but-null advisory.
+        var objectsOnly = ScriptPropertyCheck.Run(resolver, assets, null, 1000, null, null, ScriptFindingClass.UnboundObject);
+        var objFoot = objectsOnly.Reports.FirstOrDefault(x => x.Record == footgunFk);
+        Check("FILTER-CLASS: findings=[unbound_object] keeps MySpell (HIGH), drops the MyChance scalar and the MyNullSpell advisory",
+            objectsOnly.Success && objFoot is not null
+            && objFoot.Unbound.Any(u => u.PropertyName == "MySpell")
+            && !objFoot.Unbound.Any(u => u.PropertyName == "MyChance")
+            && objFoot.NullObjects.Count == 0 && objectsOnly.TotalNullObject == 0,
+            objFoot is null ? "<no report>" : $"unbound=[{string.Join(",", objFoot.Unbound.Select(u => u.PropertyName))}] null={objFoot.NullObjects.Count}");
+
+        // THE LOAD-BEARING Q3 ARM: a filter that matches NOTHING must still surface the record whose .pex could not be
+        // read — that script might be the very one declaring the property being filtered for, so hiding it would turn
+        // "could not check" into a clean answer.
+        var filteredToNothing = ScriptPropertyCheck.Run(resolver, assets, null, 1000, null, "ZZZnoSuchProperty",
+            ScriptFindingClass.UnboundObject);
+        var filteredNoPex = filteredToNothing.Reports.FirstOrDefault(x => x.Record == noPexFk);
+        Check("UNVERIFIABLE-SURVIVES-FILTER: under a filter matching NOTHING, wNoPex is STILL reported unverifiable — a filter must never manufacture a clean (Q3)",
+            filteredToNothing.Success && filteredToNothing.TotalUnbound == 0
+            && filteredToNothing.TotalUnverifiable == 1
+            && filteredNoPex is not null && filteredNoPex.Unverifiable.Any(u =>
+                string.Equals(u.Script, "HcSpNoPex", StringComparison.OrdinalIgnoreCase)),
+            $"unbound={filteredToNothing.TotalUnbound} unverifiable={filteredToNothing.TotalUnverifiable} noPexReport={(filteredNoPex is not null)}");
+
+        Check("FILTER-Q3: an unrecognized findings= value fails LOUD, names the legal set, and says the unverifiable class is unfilterable",
+            !SweepFindings.TryParseScriptClasses(new[] { "unbund_object" }, out _, out var spClassErr)
+            && spClassErr is not null && spClassErr.Contains("'unbound_object'", StringComparison.Ordinal)
+            && spClassErr.Contains("bound_null", StringComparison.Ordinal)
+            && spClassErr.Contains("cannot be filtered out", StringComparison.Ordinal),
+            $"err=[{spClassErr}]");
+
+        // counts_only=: exact totals + an unbound-by-property-NAME histogram, with NO per-record roster built at all —
+        // the reporter's shell pipeline (grep -oE '^  [!·] \w+' | sort | uniq -c) as one call.
+        var counts = ScriptPropertyCheck.Run(resolver, assets, null, 1000, null, null, ScriptFindingClass.All, countsOnly: true);
+        var histo = counts.Histogram;
+        Check("COUNTS-ONLY: totals match the full sweep, NO per-record roster is built, and the histogram tallies unbound by property NAME",
+            counts.Success && counts.CountsOnly && counts.TotalUnbound == res.TotalUnbound
+            && counts.Reports.Count == 0 && !counts.Capped
+            && histo is not null && histo.Sum(h => h.Count) == res.TotalUnbound
+            && histo.Any(h => h.Key == "MySpell") && histo.Any(h => h.Key == "InheritedThing")
+            && !histo.Any(h => h.Key == "MyDefaulted"),
+            $"unbound={counts.TotalUnbound} (full={res.TotalUnbound}) reports={counts.Reports.Count} histo=[{(histo is null ? "<null>" : string.Join(",", histo.Select(h => $"{h.Key}={h.Count}")))}]");
+
+        Check("COUNTS-ONLY-NOT-COMPUTED: a normal sweep leaves Histogram NULL — 'not computed' and 'nothing found' must not look alike (Q3)",
+            res.Histogram is null && !res.CountsOnly, $"histo={(res.Histogram is null ? "null" : res.Histogram.Count.ToString())}");
+
+        Check("JSON-PARITY: format=json parses and reports the same unbound total in both the listing and counts_only modes (D2 — one result, two renders)",
+            CheckErrorsProbe.JsonMatches(JsonWire.RenderScriptCheck(res, 0), "unbound", res.TotalUnbound)
+            && CheckErrorsProbe.JsonMatches(JsonWire.RenderScriptCheck(counts, 0), "unbound", res.TotalUnbound)
+            && CheckErrorsProbe.JsonHasHistogram(JsonWire.RenderScriptCheck(counts, 0), "unbound_by_property"),
+            "see the two json renders");
+
+        // The truncation notice used to advise "scope plugins=" — the one scope the caller had already applied. It must
+        // now name knobs that exist (#282), or the tool tells you to do the thing that did not work.
+        var tinyCap = Wire.RenderScriptCheck(res, 400);
+        Check("TRUNCATION-HINT: the max_chars cut names the narrowing knobs that EXIST, and no longer advises 'scope plugins='",
+            tinyCap.Contains("truncated at max_chars", StringComparison.Ordinal)
+            && tinyCap.Contains("formids=", StringComparison.Ordinal)
+            && tinyCap.Contains("counts_only=true", StringComparison.Ordinal)
+            && !tinyCap.Contains("scope plugins=", StringComparison.Ordinal),
+            $"tail=[{tinyCap.Split('\n').LastOrDefault(l => l.Contains("truncated", StringComparison.Ordinal))}]");
 
         Console.WriteLine();
         Console.WriteLine(failures == 0 ? "script-property-check-guard: ALL PASS" : $"script-property-check-guard: {failures} FAILURE(S)");

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -564,10 +564,14 @@ static class JsonWire
     }
 
     // ---- housecarl_validate_scripts (#282) ---------------------------------------------------------
-    /// <summary>The script-property sweep as JSON: <c>{scanned_plugins, records_with_scripts, unbound, bound_but_null,
-    /// unverifiable, filter_note, read_incomplete, excluded_plugins, records:[…], capped, rendered, truncated,
-    /// boundary}</c>, or the <c>counts_only</c> shape with <c>histogram</c> in place of <c>records</c>. Same data as the
-    /// text render off the same result object (D2 — the two can differ only in formatting).</summary>
+    /// <summary>The script-property sweep as JSON: <c>{scanned_plugins, records_with_scripts, unbound, unbound_object,
+    /// unbound_scalar, bound_but_null, unverifiable, classes_checked, filter_note, read_incomplete, excluded_plugins,
+    /// records:[…], capped, rendered, truncated, boundary}</c>, or the <c>counts_only</c> shape with
+    /// <c>unbound_by_property</c> in place of <c>records</c>. A finding CLASS the caller excluded is emitted as
+    /// <c>null</c>, NOT as 0 — the json counterpart of the text render's "NOT CHECKED", so a class nobody looked for
+    /// cannot be parsed as one that came back clean (PR #288 review, finding 1). <c>unverifiable</c> is never null: it
+    /// cannot be filtered out. Same data as the text render off the same result object (D2 — the two can differ only in
+    /// formatting).</summary>
     public static string RenderScriptCheck(ScriptCheckResult r, int maxChars, int histogramLimit = 1000)
     {
         int cap = Cap(maxChars);
@@ -577,11 +581,21 @@ static class JsonWire
             w.WriteStartObject();
             if (r.Error is not null) { w.WriteString("error", r.Error); w.WriteEndObject(); return Finish(ms); }
 
+            bool didObject = r.Classes.HasFlag(ScriptFindingClass.UnboundObject);
+            bool didScalar = r.Classes.HasFlag(ScriptFindingClass.UnboundScalar);
+            bool didNull = r.Classes.HasFlag(ScriptFindingClass.BoundNull);
+
             w.WriteNumber("scanned_plugins", r.PluginsScanned);
             w.WriteNumber("records_with_scripts", r.RecordsWithScripts);
-            w.WriteNumber("unbound", r.TotalUnbound);
-            w.WriteNumber("bound_but_null", r.TotalNullObject);
-            w.WriteNumber("unverifiable", r.TotalUnverifiable);
+            // null, NOT 0, for a class the caller excluded — a 0 here is parsed as "looked, found none" about a class
+            // nobody looked for (PR #288 review, finding 1). The per-class keys make each number's scope self-evident
+            // rather than something the consumer has to cross-reference against classes_checked.
+            if (didObject || didScalar) w.WriteNumber("unbound", r.TotalUnbound); else w.WriteNull("unbound");
+            if (didObject) w.WriteNumber("unbound_object", r.TotalUnboundObject); else w.WriteNull("unbound_object");
+            if (didScalar) w.WriteNumber("unbound_scalar", r.TotalUnboundScalar); else w.WriteNull("unbound_scalar");
+            if (didNull) w.WriteNumber("bound_but_null", r.TotalNullObject); else w.WriteNull("bound_but_null");
+            w.WriteNumber("unverifiable", r.TotalUnverifiable);   // never filterable — always a real count
+            WriteStringArray(w, "classes_checked", ScriptClassNames(r.Classes));
             WriteNullable(w, "filter_note", r.FilterNote);
             w.WriteBoolean("read_incomplete", r.ReadIncomplete);
             WriteExcluded(w, r.ExcludedPlugins);
@@ -590,11 +604,24 @@ static class JsonWire
             if (r.CountsOnly)
             {
                 WriteHistogram(w, "unbound_by_property", r.Histogram, histogramLimit);
-                w.WriteStartArray("scan_errors");
-                foreach (var rec in r.Reports)
-                    if (rec.ScanError is not null)
-                    { w.WriteStartObject(); w.WriteString("plugin", rec.Plugin); w.WriteString("scan_error", rec.ScanError); w.WriteEndObject(); }
+                // Wrapped + budget-flagged for the same reason check_errors' `unread` is (#288 review finding 4): a
+                // silently short honesty list reads as a complete one.
+                var scanErrors = r.Reports.Where(x => x.ScanError is not null).ToList();
+                w.WriteStartObject("scan_errors");
+                w.WriteNumber("total", scanErrors.Count);
+                w.WriteStartArray("rows");
+                int seRendered = 0; bool seTruncated = false;
+                foreach (var rec in scanErrors)
+                {
+                    w.Flush();
+                    if (ms.Length >= cap) { seTruncated = true; break; }
+                    w.WriteStartObject(); w.WriteString("plugin", rec.Plugin); w.WriteString("scan_error", rec.ScanError!); w.WriteEndObject();
+                    seRendered++;
+                }
                 w.WriteEndArray();
+                w.WriteNumber("rendered", seRendered);
+                w.WriteBoolean("truncated", seTruncated);
+                w.WriteEndObject();
             }
             else
             {
@@ -679,22 +706,32 @@ static class JsonWire
     }
 
     /// <summary>Under counts_only, check_errors' reports carry the honesty layer only — plugins whose records could not
-    /// be read. Emitted so a counts-only answer still names what it could not check (Q3).</summary>
+    /// be read. Emitted so a counts-only answer still names what it could not check (Q3).
+    /// <para>Wrapped in <c>{total, rows, rendered, truncated}</c> rather than a bare array: a budget cut used to drop
+    /// trailing rows with NO flag, so a consumer iterating the array believed it had the complete set of what went
+    /// unchecked — and the text render said "truncated" for the same result (PR #288 review, finding 4).</para></summary>
     static void WriteUnreadPlugins(Utf8JsonWriter w, IReadOnlyList<PluginErrors> reports, MemoryStream ms, int cap)
     {
-        w.WriteStartArray("unread");
+        w.WriteStartObject("unread");
+        w.WriteNumber("total", reports.Count);
+        w.WriteStartArray("rows");
+        int rendered = 0; bool truncated = false;
         foreach (var p in reports)
         {
             w.Flush();
-            if (ms.Length >= cap) break;
+            if (ms.Length >= cap) { truncated = true; break; }
             w.WriteStartObject();
             w.WriteString("plugin", p.Plugin);
             WriteNullable(w, "scan_error", p.ScanError);
             w.WriteNumber("unscannable_records", p.UnscannableRecords);
             WriteStringArray(w, "unscannable_samples", p.UnscannableSamples);
             w.WriteEndObject();
+            rendered++;
         }
         w.WriteEndArray();
+        w.WriteNumber("rendered", rendered);
+        w.WriteBoolean("truncated", truncated);
+        w.WriteEndObject();
     }
 
     static void WriteExcluded(Utf8JsonWriter w, IReadOnlyDictionary<string, string> excluded)
@@ -710,6 +747,15 @@ static class JsonWire
         var names = new List<string>(2);
         if (c.HasFlag(ErrorFindingClass.Dangling)) names.Add("dangling");
         if (c.HasFlag(ErrorFindingClass.MissingMasters)) names.Add("missing_masters");
+        return names;
+    }
+
+    static List<string> ScriptClassNames(ScriptFindingClass c)
+    {
+        var names = new List<string>(3);
+        if (c.HasFlag(ScriptFindingClass.UnboundObject)) names.Add("unbound_object");
+        if (c.HasFlag(ScriptFindingClass.UnboundScalar)) names.Add("unbound_scalar");
+        if (c.HasFlag(ScriptFindingClass.BoundNull)) names.Add("bound_null");
         return names;
     }
 

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -596,6 +596,10 @@ static class JsonWire
             if (didNull) w.WriteNumber("bound_but_null", r.TotalNullObject); else w.WriteNull("bound_but_null");
             w.WriteNumber("unverifiable", r.TotalUnverifiable);   // never filterable — always a real count
             WriteStringArray(w, "classes_checked", ScriptClassNames(r.Classes));
+            // The property filter rides as DATA, not just prose in filter_note: `unbound` / `bound_but_null` count only
+            // matching findings, while `records_with_scripts` and `unverifiable` are plugin-wide regardless of it — a
+            // consumer needs to be able to read that asymmetry off the document (round-3 review).
+            WriteNullable(w, "property_contains", r.PropertyContains);
             WriteNullable(w, "filter_note", r.FilterNote);
             w.WriteBoolean("read_incomplete", r.ReadIncomplete);
             WriteExcluded(w, r.ExcludedPlugins);

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -486,6 +486,233 @@ static class JsonWire
         w.WriteEndArray();
     }
 
+    // ---- housecarl_check_errors (#282) --------------------------------------------------------------
+    /// <summary>The integrity sweep as JSON: <c>{scanned_plugins, dangling, missing_masters, unscannable, classes,
+    /// filter_note, off_order_scanned, excluded_plugins, plugins:[…], capped, rendered, truncated, boundary}</c>, or the
+    /// <c>counts_only</c> shape with <c>histogram</c> in place of <c>plugins</c>. An error CLASS the caller excluded is
+    /// emitted as <c>null</c>, NOT as 0 — the json counterpart of the text render's "NOT CHECKED", so a skipped check
+    /// cannot be parsed as a clean one (Q3). Budget-aware: drops trailing rows and flags <c>truncated</c>, always
+    /// leaving valid JSON.</summary>
+    public static string RenderCheckErrors(ErrorCheckResult r, int maxChars, int histogramLimit = 1000)
+    {
+        int cap = Cap(maxChars);
+        bool didDangling = r.Classes.HasFlag(ErrorFindingClass.Dangling);
+        bool didMasters = r.Classes.HasFlag(ErrorFindingClass.MissingMasters);
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            if (r.Error is not null) { w.WriteString("error", r.Error); w.WriteEndObject(); return Finish(ms); }
+
+            w.WriteNumber("scanned_plugins", r.PluginsScanned);
+            // null (not 0) for a class nobody looked for — see the summary.
+            if (didDangling) { w.WriteNumber("dangling", r.TotalDangling); w.WriteNumber("unscannable_records", r.TotalUnscannableRecords); }
+            else { w.WriteNull("dangling"); w.WriteNull("unscannable_records"); }
+            if (didMasters) w.WriteNumber("missing_masters", r.TotalMissingMasters); else w.WriteNull("missing_masters");
+            WriteStringArray(w, "classes_checked", ClassNames(r.Classes));
+            WriteNullable(w, "filter_note", r.FilterNote);
+            WriteStringArray(w, "off_order_scanned", r.OffOrderScanned ?? Array.Empty<string>());
+            WriteExcluded(w, r.ExcludedPlugins);
+            w.WriteBoolean("counts_only", r.CountsOnly);
+
+            if (r.CountsOnly)
+            {
+                WriteHistogram(w, "dangling_by_target_plugin", r.Histogram, histogramLimit);
+                WriteUnreadPlugins(w, r.Reports, ms, cap);
+            }
+            else
+            {
+                w.WriteBoolean("capped", r.Capped);
+                w.WriteStartArray("plugins");
+                int rendered = 0; bool truncated = false;
+                foreach (var p in r.Reports)
+                {
+                    w.Flush();
+                    if (ms.Length >= cap) { truncated = true; break; }
+                    w.WriteStartObject();
+                    w.WriteString("plugin", p.Plugin);
+                    WriteNullable(w, "scan_error", p.ScanError);
+                    WriteStringArray(w, "missing_masters", p.MissingMasters);
+                    w.WriteStartArray("dangling");
+                    foreach (var d in p.Dangling)
+                    {
+                        w.WriteStartObject();
+                        w.WriteString("source", d.Source.ToString());
+                        w.WriteString("source_type", d.SourceType);
+                        WriteNullable(w, "source_editorid", d.SourceEditorId);
+                        w.WriteString("target", d.Target.ToString());
+                        w.WriteEndObject();
+                    }
+                    w.WriteEndArray();
+                    w.WriteNumber("unscannable_records", p.UnscannableRecords);
+                    WriteStringArray(w, "unscannable_samples", p.UnscannableSamples);
+                    w.WriteEndObject();
+                    rendered++;
+                }
+                w.WriteEndArray();
+                w.WriteNumber("rendered", rendered);
+                w.WriteBoolean("truncated", truncated);
+            }
+
+            w.WriteString("boundary",
+                "checks FormLink resolution, missing masters, and parse failures. Does NOT verify navmesh/terrain spatial " +
+                "integrity (CRC/grid), flag required-but-null fields, list unused-master cleanup, or link-check an owned " +
+                "item's ownership 'variable' word; a null FormLink is a legal optional.");
+            w.WriteEndObject();
+        }
+        return Finish(ms);
+    }
+
+    // ---- housecarl_validate_scripts (#282) ---------------------------------------------------------
+    /// <summary>The script-property sweep as JSON: <c>{scanned_plugins, records_with_scripts, unbound, bound_but_null,
+    /// unverifiable, filter_note, read_incomplete, excluded_plugins, records:[…], capped, rendered, truncated,
+    /// boundary}</c>, or the <c>counts_only</c> shape with <c>histogram</c> in place of <c>records</c>. Same data as the
+    /// text render off the same result object (D2 — the two can differ only in formatting).</summary>
+    public static string RenderScriptCheck(ScriptCheckResult r, int maxChars, int histogramLimit = 1000)
+    {
+        int cap = Cap(maxChars);
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            if (r.Error is not null) { w.WriteString("error", r.Error); w.WriteEndObject(); return Finish(ms); }
+
+            w.WriteNumber("scanned_plugins", r.PluginsScanned);
+            w.WriteNumber("records_with_scripts", r.RecordsWithScripts);
+            w.WriteNumber("unbound", r.TotalUnbound);
+            w.WriteNumber("bound_but_null", r.TotalNullObject);
+            w.WriteNumber("unverifiable", r.TotalUnverifiable);
+            WriteNullable(w, "filter_note", r.FilterNote);
+            w.WriteBoolean("read_incomplete", r.ReadIncomplete);
+            WriteExcluded(w, r.ExcludedPlugins);
+            w.WriteBoolean("counts_only", r.CountsOnly);
+
+            if (r.CountsOnly)
+            {
+                WriteHistogram(w, "unbound_by_property", r.Histogram, histogramLimit);
+                w.WriteStartArray("scan_errors");
+                foreach (var rec in r.Reports)
+                    if (rec.ScanError is not null)
+                    { w.WriteStartObject(); w.WriteString("plugin", rec.Plugin); w.WriteString("scan_error", rec.ScanError); w.WriteEndObject(); }
+                w.WriteEndArray();
+            }
+            else
+            {
+                w.WriteBoolean("capped", r.Capped);
+                w.WriteStartArray("records");
+                int rendered = 0; bool truncated = false;
+                foreach (var rec in r.Reports)
+                {
+                    w.Flush();
+                    if (ms.Length >= cap) { truncated = true; break; }
+                    w.WriteStartObject();
+                    if (rec.ScanError is not null)
+                    {
+                        w.WriteString("plugin", rec.Plugin);
+                        w.WriteString("scan_error", rec.ScanError);
+                        w.WriteEndObject();
+                        rendered++;
+                        continue;
+                    }
+                    w.WriteString("formid", rec.Record.ToString());
+                    w.WriteString("type", rec.RecordType);
+                    WriteNullable(w, "editorid", rec.EditorId);
+                    w.WriteString("plugin", rec.Plugin);
+                    w.WriteStartArray("unbound");
+                    // Object/form types first — the same severity ordering the text render applies (D2).
+                    foreach (var u in rec.Unbound.OrderByDescending(u => u.IsObjectType))
+                    {
+                        w.WriteStartObject();
+                        w.WriteString("property", u.PropertyName);
+                        w.WriteString("pex_type", u.PexTypeName);
+                        w.WriteString("script", u.Script);
+                        w.WriteString("declared_in", u.DeclaringScript);
+                        w.WriteString("class", u.IsObjectType ? "unbound_object" : "unbound_scalar");
+                        w.WriteString("severity", u.IsObjectType ? "high" : "medium");
+                        w.WriteEndObject();
+                    }
+                    w.WriteEndArray();
+                    w.WriteStartArray("bound_but_null");
+                    foreach (var n in rec.NullObjects)
+                    { w.WriteStartObject(); w.WriteString("property", n.PropertyName); w.WriteString("script", n.Script); w.WriteEndObject(); }
+                    w.WriteEndArray();
+                    w.WriteStartArray("unverifiable");
+                    foreach (var uv in rec.Unverifiable)
+                    { w.WriteStartObject(); w.WriteString("script", uv.Script); w.WriteString("reason", uv.Reason); w.WriteEndObject(); }
+                    w.WriteEndArray();
+                    w.WriteEndObject();
+                    rendered++;
+                }
+                w.WriteEndArray();
+                w.WriteNumber("rendered", rendered);
+                w.WriteBoolean("truncated", truncated);
+            }
+
+            w.WriteString("boundary",
+                "checks Auto (CK-editable) properties across the extends chain — not code-driven full properties. An " +
+                "unbound object property is the silent-None footgun but CAN be intentional (filled at runtime) — a finding " +
+                "is a flag to VERIFY. A script whose .pex is not on disk is reported unverifiable, never passed clean.");
+            w.WriteEndObject();
+        }
+        return Finish(ms);
+    }
+
+    // ---- shared sweep writers (#282) ---------------------------------------------------------------
+    /// <summary>A counts_only histogram: <c>{distinct, rows:[{key,count}], rendered}</c>. Absent when the mode was not
+    /// requested; PRESENT with an empty <c>rows</c> when the sweep genuinely found nothing — the two must not look alike.</summary>
+    static void WriteHistogram(Utf8JsonWriter w, string name, IReadOnlyList<SweepCount>? rows, int rowLimit)
+    {
+        if (rows is null) return;
+        w.WriteStartObject(name);
+        w.WriteNumber("distinct", rows.Count);
+        w.WriteStartArray("rows");
+        int shown = 0;
+        foreach (var row in rows)
+        {
+            if (shown >= rowLimit) break;
+            w.WriteStartObject(); w.WriteString("key", row.Key); w.WriteNumber("count", row.Count); w.WriteEndObject();
+            shown++;
+        }
+        w.WriteEndArray();
+        w.WriteNumber("rendered", shown);
+        w.WriteEndObject();
+    }
+
+    /// <summary>Under counts_only, check_errors' reports carry the honesty layer only — plugins whose records could not
+    /// be read. Emitted so a counts-only answer still names what it could not check (Q3).</summary>
+    static void WriteUnreadPlugins(Utf8JsonWriter w, IReadOnlyList<PluginErrors> reports, MemoryStream ms, int cap)
+    {
+        w.WriteStartArray("unread");
+        foreach (var p in reports)
+        {
+            w.Flush();
+            if (ms.Length >= cap) break;
+            w.WriteStartObject();
+            w.WriteString("plugin", p.Plugin);
+            WriteNullable(w, "scan_error", p.ScanError);
+            w.WriteNumber("unscannable_records", p.UnscannableRecords);
+            WriteStringArray(w, "unscannable_samples", p.UnscannableSamples);
+            w.WriteEndObject();
+        }
+        w.WriteEndArray();
+    }
+
+    static void WriteExcluded(Utf8JsonWriter w, IReadOnlyDictionary<string, string> excluded)
+    {
+        w.WriteStartArray("excluded_plugins");
+        foreach (var kv in excluded)
+        { w.WriteStartObject(); w.WriteString("plugin", kv.Key); w.WriteString("reason", kv.Value); w.WriteEndObject(); }
+        w.WriteEndArray();
+    }
+
+    static List<string> ClassNames(ErrorFindingClass c)
+    {
+        var names = new List<string>(2);
+        if (c.HasFlag(ErrorFindingClass.Dangling)) names.Add("dangling");
+        if (c.HasFlag(ErrorFindingClass.MissingMasters)) names.Add("missing_masters");
+        return names;
+    }
+
     // ---- housecarl_read_plugin_file (P6) ------------------------------------------------------------
     /// <summary>read_plugin_file as JSON — always stamped <c>out_of_load_order:true</c> (the load-bearing raw-file
     /// caveat), then the file/masters context and the mode payload: <c>record</c> (the FILE's own record — no winner,

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2780,9 +2780,20 @@ public sealed class LoadOrderService : IDisposable
     /// (<see cref="LocatePluginFileOnDisk"/> — enabled, disabled, AND unlisted mod folders) and swept OFF-ORDER: its
     /// own overlay, links resolved against the active order + the file's own records. This is the pre-enable verify
     /// lane (HCBR-2026-07-14-02 gap 3) — the pre-ship dangling-ref sweep of a patch houseCARL just wrote, BEFORE the
-    /// MO2 refresh puts it in plugins.txt. A name found nowhere, or in several folders, still fails loud (Q3).</para></summary>
-    public ErrorCheckResult CheckErrors(IReadOnlyList<string>? plugins, int limit)
+    /// MO2 refresh puts it in plugins.txt. A name found nowhere, or in several folders, still fails loud (Q3).</para>
+    /// <para>#282 — the record-scope / class-filter / counts-only knobs are parsed here (a bad FormID, an unknown record
+    /// type, or an unrecognized finding class refuses the call BEFORE any sweep runs) and handed to the core as typed
+    /// values, so the self-contained guard drives the same narrowing the tool does.</para></summary>
+    public ErrorCheckResult CheckErrors(IReadOnlyList<string>? plugins, int limit,
+                                        IReadOnlyList<string>? formids = null, string? editoridContains = null,
+                                        string? type = null, IReadOnlyList<string>? findings = null,
+                                        bool countsOnly = false)
     {
+        var (recordScope, scopeErr) = BuildSweepScope(formids, editoridContains, type);
+        if (scopeErr is not null) return ErrorCheckResult.Fail(scopeErr);
+        if (!SweepFindings.TryParseErrorClasses(findings, out var classes, out var classErr))
+            return ErrorCheckResult.Fail(classErr!);
+
         if (plugins is { Count: > 0 })
         {
             var view = Resolver.Capture();
@@ -2807,9 +2818,41 @@ public sealed class LoadOrderService : IDisposable
                         "Enable the one you mean in MO2, or remove the duplicates.");
                 offOrder.Add((n, loc.Path!));
             }
-            return ErrorCheck.Run(Resolver, active, limit, offOrder.Count > 0 ? offOrder : null);
+            return ErrorCheck.Run(Resolver, active, limit, offOrder.Count > 0 ? offOrder : null,
+                                  recordScope, classes, countsOnly);
         }
-        return ErrorCheck.Run(Resolver, plugins, limit);
+        return ErrorCheck.Run(Resolver, plugins, limit, null, recordScope, classes, countsOnly);
+    }
+
+    /// <summary>Parse the two sweep tools' shared record-scope params (#282) into a <see cref="SweepScope"/>: FormID
+    /// tokens, an EditorID substring, and a record type resolved through the SAME TypeLookup cross_plugin_query uses.
+    /// Every malformed input is a NAMED refusal returned BEFORE the sweep starts (Q3 — never a scope that silently
+    /// matched nothing). Returns (null, null) when nothing was narrowed, so the unscoped path stays untouched.</summary>
+    (SweepScope? Scope, string? Error) BuildSweepScope(IReadOnlyList<string>? formids, string? editoridContains, string? type)
+    {
+        HashSet<FormKey>? keys = null;
+        if (formids is { Count: > 0 })
+        {
+            keys = new HashSet<FormKey>();
+            foreach (var raw in formids)
+            {
+                var t = raw?.Trim() ?? "";
+                if (t.Length == 0) return (null, "a blank entry in formids= — pass FormID tokens (e.g. '0BCC84:Skyrim.esm').");
+                try { keys.Add(FormKey.Factory(t)); }
+                catch (Exception ex) { return (null, $"bad FormID '{raw}' in formids=: {ex.Message}. Expected 'XXXXXX:Plugin.esp', e.g. '0BCC84:Skyrim.esm'."); }
+            }
+        }
+
+        IReadOnlyList<Type>? types = null;
+        var typeLabel = type?.Trim();
+        if (!string.IsNullOrEmpty(typeLabel))
+        {
+            try { types = ResolveTypeFilter(typeLabel); }
+            catch (ArgumentException ex) { return (null, ex.Message); }
+        }
+
+        var scope = new SweepScope(keys, editoridContains, types, typeLabel);
+        return (scope.IsEmpty ? null : scope, null);
     }
 
     // ---- script-property sweep (housecarl_validate_scripts) --------------------------------------------
@@ -2819,9 +2862,20 @@ public sealed class LoadOrderService : IDisposable
     /// <c>None</c> (housecarl_validate_scripts). Thin wiring over the core <see cref="ScriptPropertyCheck.Run"/>, which
     /// holds all the cross-check logic + Q3 teeth so the self-contained guard drives this same path over synthetic
     /// records + a planted .pex. Passes the live <see cref="Assets"/> resolver (the same one the dialogue validator and
-    /// facegen use) so a script's .pex is found loose OR BSA-packed. Read-only; composes existing primitives.</summary>
-    public ScriptCheckResult ValidateScripts(IReadOnlyList<string>? plugins, int limit)
-        => ScriptPropertyCheck.Run(Resolver, Assets, plugins, limit);
+    /// facegen use) so a script's .pex is found loose OR BSA-packed. Read-only; composes existing primitives.
+    /// <para>#282 — the record-scope / property-name / class-filter / counts-only knobs are parsed here (a bad FormID,
+    /// unknown record type, or unrecognized finding class refuses the call before any sweep runs).</para></summary>
+    public ScriptCheckResult ValidateScripts(IReadOnlyList<string>? plugins, int limit,
+                                             IReadOnlyList<string>? formids = null, string? editoridContains = null,
+                                             string? type = null, string? propertyContains = null,
+                                             IReadOnlyList<string>? findings = null, bool countsOnly = false)
+    {
+        var (recordScope, scopeErr) = BuildSweepScope(formids, editoridContains, type);
+        if (scopeErr is not null) return ScriptCheckResult.Fail(scopeErr);
+        if (!SweepFindings.TryParseScriptClasses(findings, out var classes, out var classErr))
+            return ScriptCheckResult.Fail(classErr!);
+        return ScriptPropertyCheck.Run(Resolver, Assets, plugins, limit, recordScope, propertyContains, classes, countsOnly);
+    }
 
     // ---- writes (§8.4 Beat C: housecarl_set_field / housecarl_bulk_apply) -------------------------------
 

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -918,15 +918,9 @@ static class Wire
           .Append(r.RecordsWithScripts).Append(" record(s) with scripts · ")
           // A class the caller excluded reads as NOT CHECKED, never as a 0 — a 0 would say "looked, found none" about
           // the HIGH silent-None class nobody looked for (PR #288 review, finding 1).
-          .Append(!didObject && !didScalar
-                      ? "unbound NOT CHECKED (findings= excluded both unbound classes)"
-                      : didObject && didScalar
-                          ? $"{r.TotalUnbound} unbound"
-                          : didObject
-                              ? $"{r.TotalUnboundObject} unbound (object only — unbound_scalar NOT CHECKED)"
-                              : $"{r.TotalUnboundScalar} unbound (scalar only — unbound_object NOT CHECKED)")
+          .Append(UnboundTotalText(r, didObject, didScalar))
           .Append(" · ")
-          .Append(didNull ? $"{r.TotalNullObject} bound-but-null" : "bound-but-null NOT CHECKED (findings= excluded 'bound_null')")
+          .Append(NullTotalText(r, didNull))
           .Append(" · ")
           .Append(r.TotalUnverifiable).Append(" unverifiable");
         if (r.ExcludedPlugins.Count > 0)
@@ -939,7 +933,8 @@ static class Wire
         if (r.CountsOnly)
         {
             AppendHistogram(sb, r.Histogram, histogramLimit, "unbound properties by NAME",
-                            "counts_only=true — totals above are exact; no per-record listing was built.");
+                            "counts_only=true — totals above are exact; no per-record listing was built.",
+                            notComputed: "no unbound histogram — findings= excluded both unbound classes, so nothing was tallied.");
             foreach (var rec in r.Reports)   // the honesty layer: plugins whose record enumeration faulted
             {
                 if (sb.Length >= cap) { sb.Append("\n... [truncated at max_chars]\n"); break; }
@@ -993,15 +988,30 @@ static class Wire
             }
         }
 
+        // The capped tail restates the totals, so it needs the SAME class-awareness as the header — otherwise a small
+        // limit= reintroduces the literal "0 unbound" that the header no longer prints (re-review finding 2).
         if (r.Capped)
-            sb.Append("\n[finding list capped at limit; true totals = ").Append(r.TotalUnbound).Append(" unbound + ")
-              .Append(r.TotalNullObject).Append(" bound-but-null — raise limit= to see all]\n");
+            sb.Append("\n[finding list capped at limit; true totals = ").Append(UnboundTotalText(r, didObject, didScalar))
+              .Append(" + ").Append(NullTotalText(r, didNull)).Append(" — raise limit= to see all]\n");
 
         if (!truncated) AppendExcludedPlugins(sb, r.ExcludedPlugins, cap);
 
         AppendScriptCheckBoundary(sb);
         return sb.ToString().TrimEnd('\n');
     }
+
+    /// <summary>The unbound total, spelled so it can never claim a class nobody checked. ONE definition, used by both
+    /// the header and the capped tail — the tail restating the numbers in its own words is how "0 unbound" survived the
+    /// header fix (re-review finding 2).</summary>
+    static string UnboundTotalText(ScriptCheckResult r, bool didObject, bool didScalar)
+        => !didObject && !didScalar ? "unbound NOT CHECKED (findings= excluded both unbound classes)"
+         : didObject && didScalar   ? $"{r.TotalUnbound} unbound"
+         : didObject                ? $"{r.TotalUnboundObject} unbound (object only — unbound_scalar NOT CHECKED)"
+                                    : $"{r.TotalUnboundScalar} unbound (scalar only — unbound_object NOT CHECKED)";
+
+    /// <summary>The bound-but-null total, same contract as <see cref="UnboundTotalText"/>.</summary>
+    static string NullTotalText(ScriptCheckResult r, bool didNull)
+        => didNull ? $"{r.TotalNullObject} bound-but-null" : "bound-but-null NOT CHECKED (findings= excluded 'bound_null')";
 
     static void AppendScriptCheckBoundary(StringBuilder sb)
         => sb.Append("\nboundary: checks Auto (CK-editable) properties across the extends chain — not code-driven full ")

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -297,19 +297,38 @@ public static class ReadTools
          "NOT verify navmesh or terrain spatial integrity (CRC/grid — a Mutagen-delta residual), does NOT flag a required " +
          "field left null (a null FormLink is a legal optional, not an error), does NOT list unused-master cleanup " +
          "(a FormLink scan cannot prove a master is unused), and does NOT link-check an owned item's ownership 'variable' " +
-         "word (a rank/global Mutagen cannot type on an override without a link cache). Results cap at limit= and max_chars (both overruns explicit).")]
+         "word (a rank/global Mutagen cannot type on an override without a link cache). NARROWING: beyond plugins= it takes " +
+         "a record scope (type= / formids= / editorid_contains=), a findings= class filter, counts_only=true for just the " +
+         "totals plus a dangling-by-TARGET-plugin histogram, and format='json'. Narrowing narrows the COUNTS too — they are " +
+         "always the counts for the scope actually swept, and the response says so. Results cap at limit= and max_chars (both overruns explicit).")]
     public static string CheckErrorsTool(
         LoadOrderService svc,
         [Description("Optional. Plugin filenames to check (e.g. 'MyMod.esp'). A name not in the active order is resolved on disk (a fresh houseCARL patch, a disabled mod) and swept OFF-ORDER; found nowhere (or in several folders) it is an error. Omit to sweep the WHOLE active order (every non-excluded plugin) — thorough but heavier; scope to one plugin for a fast, focused check like the CK's per-plugin 'Check For Errors'.")]
             string[]? plugins = null,
-        [Description("Optional. Max dangling references to list across the whole sweep (default 1000). The TRUE total is always reported; over the cap it says so. Master-table findings are always listed in full (they are few).")]
+        [Description("Optional. Record type to sweep — a 4-char signature ('WEAP') or catalog name ('Weapon'). Applied at the record STREAM, so it is the CHEAPEST scope: skipped records cost nothing. An unknown type is refused, naming what is expected.")]
+            string? type = null,
+        [Description("Optional. Sweep ONLY these records ('0BCC84:Skyrim.esm', …) — the re-check-these-few pass after a fix. A malformed token refuses the call before the sweep runs.")]
+            string[]? formids = null,
+        [Description("Optional. Sweep only records whose EditorID contains this substring (case-insensitive). A record with no EditorID never matches.")]
+            string? editorid_contains = null,
+        [Description("Optional. Which error classes to look for: 'dangling' and/or 'missing_masters' (default both). Excluding 'dangling' SKIPS the per-record link walk entirely — that is how you ask 'is any master missing anywhere in my order' without paying for a full sweep. An excluded class renders as 'not checked', never as 0. Unscannable records and scan errors are ALWAYS reported and cannot be filtered out (a suppressed 'could not read' would read as clean).")]
+            string[]? findings = null,
+        [Description("Optional. true = return ONLY the header totals plus a dangling-by-TARGET-plugin histogram (which plugin the broken refs point INTO — the one absent dependency behind a wall of findings), with no per-plugin listing. The cheap before/after-a-fix comparison; totals stay exact (never limit-capped) and limit= caps the histogram ROWS instead.")]
+            bool counts_only = false,
+        [Description("Optional. 'text' (default) or 'json' — the machine-readable twin carrying the same data, with the totals/capped/truncated accounting in-band.")]
+            string? format = null,
+        [Description("Optional. Max dangling references to list across the whole sweep (default 1000). The TRUE total is always reported; over the cap it says so. Master-table findings are always listed in full (they are few). Under counts_only=true this caps the histogram ROWS instead.")]
             int limit = 1000,
         [Description("Optional. Max characters before the response stops with an explicit notice. 0 = the server default (~80k).")]
             int max_chars = 0) => Guard.Tool("housecarl_check_errors", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-        var result = svc.CheckErrors(plugins, limit <= 0 ? 1000 : limit);
-        return Wire.RenderCheckErrors(result, max_chars);
+        bool json = Wire.WantsJson(format, out var fmtErr);
+        if (fmtErr is not null) return fmtErr;
+        int lim = limit <= 0 ? 1000 : limit;
+        var result = svc.CheckErrors(plugins, lim, formids, editorid_contains, type, findings, counts_only);
+        return json ? JsonWire.RenderCheckErrors(result, max_chars, lim)
+                    : Wire.RenderCheckErrors(result, max_chars, lim);
     });
 
     [McpServerTool(Name = "housecarl_validate_scripts", ReadOnly = true, Title = "Check scripted records for unbound script properties"),
@@ -325,20 +344,42 @@ public static class ReadTools
          "runtime). Read-only. BOUNDARY (never a silent claim of more — Q3): it checks Auto (CK-editable) properties " +
          "only, not code-driven full properties; 'unbound may be intentional' (a runtime-filled link), so a finding is " +
          "a flag to VERIFY; and if a script's .pex is not on disk (uncompiled / not in the order) the attachment is " +
-         "reported UNVERIFIABLE, never passed clean. Scope to one plugin for a fast focused check, or omit to sweep the " +
-         "whole active order. Results cap at limit= and max_chars (both overruns explicit).")]
+         "reported UNVERIFIABLE, never passed clean. NARROWING: beyond plugins= it takes a record scope (type= / formids= / " +
+         "editorid_contains=), property_contains=, a findings= class filter, counts_only=true for just the totals plus an " +
+         "unbound-by-PROPERTY-NAME histogram, and format='json' — a script-heavy plugin (~180 scripted records) does not " +
+         "fit a tool result unnarrowed, and limit= alone will not help because it caps FINDINGS, not the record roster. " +
+         "Narrowing narrows the COUNTS too — they are always the counts for the scope actually swept, and the response " +
+         "says so. Results cap at limit= and max_chars (both overruns explicit).")]
     public static string ValidateScriptsTool(
         LoadOrderService svc,
         [Description("Optional. Plugin filenames to check (e.g. 'MyMod.esp'). A name not in the load order is an error. Omit to sweep the WHOLE active order (every scripted record in every non-excluded plugin) — thorough but heavier; scope to one plugin for a fast, focused check.")]
             string[]? plugins = null,
-        [Description("Optional. Max property findings (unbound + bound-but-null) to list across the whole sweep (default 1000). The TRUE totals are always reported; over the cap it says so. Unverifiable notes are always listed in full (they are few).")]
+        [Description("Optional. Record type to sweep — a 4-char signature ('QUST') or catalog name ('Quest'). Applied at the record STREAM, so it is the CHEAPEST scope: skipped records never have their .pex chain read. An unknown type is refused, naming what is expected.")]
+            string? type = null,
+        [Description("Optional. Sweep ONLY these records ('0BCC84:Skyrim.esm', …) — the re-check-these-few pass after editing a script's properties, which is what limit= cannot do. A malformed token refuses the call before the sweep runs.")]
+            string[]? formids = null,
+        [Description("Optional. Sweep only records whose EditorID contains this substring (case-insensitive). A record with no EditorID never matches.")]
+            string? editorid_contains = null,
+        [Description("Optional. Report only findings whose PROPERTY NAME contains this substring (case-insensitive) — chasing one property across a plugin. A record left with no matching finding drops out of the listing entirely.")]
+            string? property_contains = null,
+        [Description("Optional. Which finding classes to report, in severity order: 'unbound_object' (HIGH — the silent-None footgun), 'unbound_scalar' (MEDIUM), 'unbound' (both), 'bound_null' (advisory). Default all. Filtering to 'unbound_object' is the way to cut the record roster down to the records that actually matter. UNVERIFIABLE attachments are ALWAYS reported and cannot be filtered out — a script whose .pex could not be read might be the one declaring the property you are filtering for, so suppressing it would manufacture a clean answer.")]
+            string[]? findings = null,
+        [Description("Optional. true = return ONLY the header totals plus an unbound-by-PROPERTY-NAME histogram, with no per-record listing — the cheap before/after comparison for a multi-pass script edit ('did the unbound count for this property drop, and did anything new appear'). Totals stay exact (never limit-capped) and limit= caps the histogram ROWS instead.")]
+            bool counts_only = false,
+        [Description("Optional. 'text' (default) or 'json' — the machine-readable twin carrying the same data, with the totals/capped/truncated accounting in-band.")]
+            string? format = null,
+        [Description("Optional. Max property findings (unbound + bound-but-null) to list across the whole sweep (default 1000). The TRUE totals are always reported; over the cap it says so. Unverifiable notes are always listed in full (they are few). Under counts_only=true this caps the histogram ROWS instead.")]
             int limit = 1000,
         [Description("Optional. Max characters before the response stops with an explicit notice. 0 = the server default (~80k).")]
             int max_chars = 0) => Guard.Tool("housecarl_validate_scripts", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
-        var result = svc.ValidateScripts(plugins, limit <= 0 ? 1000 : limit);
-        return Wire.RenderScriptCheck(result, max_chars);
+        bool json = Wire.WantsJson(format, out var fmtErr);
+        if (fmtErr is not null) return fmtErr;
+        int lim = limit <= 0 ? 1000 : limit;
+        var result = svc.ValidateScripts(plugins, lim, formids, editorid_contains, type, property_contains, findings, counts_only);
+        return json ? JsonWire.RenderScriptCheck(result, max_chars, lim)
+                    : Wire.RenderScriptCheck(result, max_chars, lim);
     });
 
     [McpServerTool(Name = "housecarl_read_plugin_file", ReadOnly = true, Title = "Read a plugin file directly (active or not)"),
@@ -713,23 +754,38 @@ static class Wire
     }
 
     // ---- housecarl_check_errors ---------------------------------------------------------------------
-    public static string RenderCheckErrors(ErrorCheckResult r, int maxChars)
+    /// <summary>Render the integrity sweep. <paramref name="histogramLimit"/> (#282) caps the <c>counts_only=</c>
+    /// histogram rows — the one thing <c>limit=</c> means in that mode, since nothing else is listed. An error class the
+    /// caller EXCLUDED renders as "NOT CHECKED", never as a 0, so a skipped check can never be read as a clean one (Q3).</summary>
+    public static string RenderCheckErrors(ErrorCheckResult r, int maxChars, int histogramLimit = 1000)
     {
         if (r.Error is not null) return "error: " + r.Error;
         int cap = Cap(maxChars);
+        bool didDangling = r.Classes.HasFlag(ErrorFindingClass.Dangling);
+        bool didMasters = r.Classes.HasFlag(ErrorFindingClass.MissingMasters);
         var sb = new StringBuilder();
 
         sb.Append("check_errors — load-order integrity sweep\n");
         sb.Append("scanned ").Append(r.PluginsScanned).Append(r.PluginsScanned == 1 ? " plugin · " : " plugins · ")
-          .Append(r.TotalDangling).Append(" dangling ref(s) · ")
-          .Append(r.TotalMissingMasters).Append(" missing master(s) · ")
-          .Append(r.TotalUnscannableRecords).Append(" unscannable record(s)");
+          .Append(didDangling ? $"{r.TotalDangling} dangling ref(s)" : "dangling refs NOT CHECKED (findings= excluded 'dangling')").Append(" · ")
+          .Append(didMasters ? $"{r.TotalMissingMasters} missing master(s)" : "missing masters NOT CHECKED (findings= excluded 'missing_masters')").Append(" · ")
+          .Append(didDangling ? $"{r.TotalUnscannableRecords} unscannable record(s)" : "unscannable records NOT COUNTED (the record walk was skipped)");
         if (r.ExcludedPlugins.Count > 0)
             sb.Append(" · ").Append(r.ExcludedPlugins.Count).Append(" plugin(s) excluded (unparseable)");
         sb.Append('\n');
+        if (r.FilterNote is not null) sb.Append(r.FilterNote).Append('\n');
         if (r.OffOrderScanned is { Count: > 0 } off)
             sb.Append("swept OFF-ORDER (on disk, not in the active load order): ").Append(string.Join(", ", off))
               .Append("   [the file's own records; links resolved against the active order + the file's own definitions]\n");
+
+        if (r.CountsOnly)
+        {
+            AppendHistogram(sb, r.Histogram, histogramLimit, "dangling ref(s) by TARGET plugin (the plugin the broken refs point INTO)",
+                            "counts_only=true — totals above are exact; no per-plugin listing was built.");
+            AppendScanErrorTail(sb, r.Reports, cap);
+            AppendCheckErrorsBoundary(sb);
+            return sb.ToString().TrimEnd('\n');
+        }
 
         if (r.Reports.Count == 0 && r.ExcludedPlugins.Count == 0)
             sb.Append("\nNo errors found in the scanned scope.\n");
@@ -739,7 +795,7 @@ static class Wire
         {
             if (sb.Length >= cap)
             {
-                sb.Append("\n... [truncated at max_chars=").Append(cap).Append("; scope plugins= or raise max_chars to see the rest]\n");
+                sb.Append("\n... [truncated at max_chars=").Append(cap).Append("; ").Append(SweepNarrowHint).Append("]\n");
                 truncated = true;
                 break;
             }
@@ -781,14 +837,64 @@ static class Wire
             }
         }
 
-        sb.Append("\nboundary: checks FormLink resolution, missing masters, and parse failures. Does NOT verify navmesh/terrain ")
-          .Append("spatial integrity (CRC/grid), flag required-but-null fields, list unused-master cleanup, or link-check an owned ")
-          .Append("item's ownership 'variable' word (a rank/global Mutagen can't type on an override); a null FormLink is a legal optional.\n");
+        AppendCheckErrorsBoundary(sb);
         return sb.ToString().TrimEnd('\n');
     }
 
+    static void AppendCheckErrorsBoundary(StringBuilder sb)
+        => sb.Append("\nboundary: checks FormLink resolution, missing masters, and parse failures. Does NOT verify navmesh/terrain ")
+             .Append("spatial integrity (CRC/grid), flag required-but-null fields, list unused-master cleanup, or link-check an owned ")
+             .Append("item's ownership 'variable' word (a rank/global Mutagen can't type on an override); a null FormLink is a legal optional.\n");
+
+    // ---- shared sweep-render pieces (#282) ----------------------------------------------------------
+    /// <summary>The truncation/overflow hint the two sweep tools share. The old wording told the caller to "scope
+    /// plugins=" when plugins= was already the narrowest scope either tool had — advice that could not be taken. It now
+    /// names the knobs that actually exist.</summary>
+    const string SweepNarrowHint =
+        "narrow with type= / formids= / editorid_contains= / findings=, ask counts_only=true for just the totals, or raise max_chars";
+
+    /// <summary>Render a <c>counts_only=</c> histogram, capped at <paramref name="rowLimit"/> with the true distinct-key
+    /// count always stated. A null histogram means the mode was not requested; an EMPTY one means the sweep genuinely
+    /// found nothing, and the two read differently (Q3).</summary>
+    static void AppendHistogram(StringBuilder sb, IReadOnlyList<SweepCount>? rows, int rowLimit, string title, string note)
+    {
+        sb.Append('\n').Append(note).Append('\n');
+        if (rows is null) return;
+        if (rows.Count == 0) { sb.Append("\nnothing to tally — no findings in the swept scope.\n"); return; }
+        sb.Append('\n').Append(title).Append(" (").Append(rows.Count).Append(" distinct):\n");
+        int shown = 0;
+        foreach (var row in rows)
+        {
+            if (shown >= rowLimit) break;
+            sb.Append("  ").Append(row.Count.ToString().PadLeft(6)).Append("  ").Append(row.Key).Append('\n');
+            shown++;
+        }
+        if (shown < rows.Count)
+            sb.Append("  ... [").Append(rows.Count - shown).Append(" more row(s) — raise limit= to see them]\n");
+    }
+
+    /// <summary>Under <c>counts_only=</c> the reports list carries the honesty layer only (records/plugins houseCARL
+    /// could not read). Emit it verbatim so a counts-only answer still names what it could not check (Q3).</summary>
+    static void AppendScanErrorTail(StringBuilder sb, IReadOnlyList<PluginErrors> reports, int cap)
+    {
+        foreach (var p in reports)
+        {
+            if (sb.Length >= cap) { sb.Append("\n... [truncated at max_chars]\n"); break; }
+            sb.Append("\n[UNREAD] ").Append(p.Plugin).Append(": ");
+            if (p.ScanError is not null) sb.Append(p.ScanError).Append(' ');
+            if (p.UnscannableRecords > 0)
+            {
+                sb.Append(p.UnscannableRecords).Append(" record(s) could not be scanned");
+                if (p.UnscannableSamples.Count > 0) sb.Append(": ").Append(string.Join("; ", p.UnscannableSamples));
+            }
+            sb.Append('\n');
+        }
+    }
+
     // ---- housecarl_validate_scripts -----------------------------------------------------------------
-    public static string RenderScriptCheck(ScriptCheckResult r, int maxChars)
+    /// <summary>Render the script-property sweep. <paramref name="histogramLimit"/> (#282) caps the
+    /// <c>counts_only=</c> histogram rows.</summary>
+    public static string RenderScriptCheck(ScriptCheckResult r, int maxChars, int histogramLimit = 1000)
     {
         if (r.Error is not null) return "error: " + r.Error;
         int cap = Cap(maxChars);
@@ -803,8 +909,22 @@ static class Wire
         if (r.ExcludedPlugins.Count > 0)
             sb.Append(" · ").Append(r.ExcludedPlugins.Count).Append(" plugin(s) excluded (unparseable)");
         sb.Append('\n');
+        if (r.FilterNote is not null) sb.Append(r.FilterNote).Append('\n');
         if (r.ReadIncomplete)
             sb.Append("note: a BSA failed to read this build — a '.pex not on disk' below may merely be unscanned, not truly absent (Q3).\n");
+
+        if (r.CountsOnly)
+        {
+            AppendHistogram(sb, r.Histogram, histogramLimit, "unbound properties by NAME",
+                            "counts_only=true — totals above are exact; no per-record listing was built.");
+            foreach (var rec in r.Reports)   // the honesty layer: plugins whose record enumeration faulted
+            {
+                if (sb.Length >= cap) { sb.Append("\n... [truncated at max_chars]\n"); break; }
+                if (rec.ScanError is not null) sb.Append("\n[SCAN ERROR] ").Append(rec.Plugin).Append(": ").Append(rec.ScanError).Append('\n');
+            }
+            AppendScriptCheckBoundary(sb);
+            return sb.ToString().TrimEnd('\n');
+        }
 
         if (r.Reports.Count == 0 && r.ExcludedPlugins.Count == 0)
             sb.Append("\nNo unbound script properties found in the scanned scope.\n");
@@ -814,7 +934,8 @@ static class Wire
         {
             if (sb.Length >= cap)
             {
-                sb.Append("\n... [truncated at max_chars=").Append(cap).Append("; scope plugins= or raise max_chars to see the rest]\n");
+                sb.Append("\n... [truncated at max_chars=").Append(cap).Append("; ").Append(SweepNarrowHint)
+                  .Append(", or property_contains= to chase one property]\n");
                 truncated = true;
                 break;
             }
@@ -862,11 +983,14 @@ static class Wire
             }
         }
 
-        sb.Append("\nboundary: checks Auto (CK-editable) properties across the extends chain — not code-driven full ")
-          .Append("properties. An unbound object property is the silent-None footgun, but CAN be intentional (filled at runtime) — a ")
-          .Append("finding is a flag to VERIFY. A script whose .pex is not on disk is reported unverifiable, never passed clean.\n");
+        AppendScriptCheckBoundary(sb);
         return sb.ToString().TrimEnd('\n');
     }
+
+    static void AppendScriptCheckBoundary(StringBuilder sb)
+        => sb.Append("\nboundary: checks Auto (CK-editable) properties across the extends chain — not code-driven full ")
+             .Append("properties. An unbound object property is the silent-None footgun, but CAN be intentional (filled at runtime) — a ")
+             .Append("finding is a flag to VERIFY. A script whose .pex is not on disk is reported unverifiable, never passed clean.\n");
 
     // ---- shared building blocks ---------------------------------------------------------------------
 

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -781,8 +781,10 @@ static class Wire
         if (r.CountsOnly)
         {
             AppendHistogram(sb, r.Histogram, histogramLimit, "dangling ref(s) by TARGET plugin (the plugin the broken refs point INTO)",
-                            "counts_only=true — totals above are exact; no per-plugin listing was built.");
+                            "counts_only=true — totals above are exact; no per-plugin listing was built.",
+                            notComputed: "no dangling histogram — the link walk was not run (findings= excluded 'dangling').");
             AppendScanErrorTail(sb, r.Reports, cap);
+            AppendExcludedPlugins(sb, r.ExcludedPlugins, cap);   // #288 review finding 5: the NAMES, not just the header count
             AppendCheckErrorsBoundary(sb);
             return sb.ToString().TrimEnd('\n');
         }
@@ -827,15 +829,7 @@ static class Wire
         if (r.Capped)
             sb.Append("\n[dangling list capped at limit; true total = ").Append(r.TotalDangling).Append(" — raise limit= to see all]\n");
 
-        if (!truncated && r.ExcludedPlugins.Count > 0)
-        {
-            sb.Append("\nexcluded plugins (could not be parsed — NOT checked):\n");
-            foreach (var kv in r.ExcludedPlugins)
-            {
-                if (sb.Length >= cap) break;
-                sb.Append("  ").Append(kv.Key).Append(": ").Append(kv.Value).Append('\n');
-            }
-        }
+        if (!truncated) AppendExcludedPlugins(sb, r.ExcludedPlugins, cap);
 
         AppendCheckErrorsBoundary(sb);
         return sb.ToString().TrimEnd('\n');
@@ -856,10 +850,11 @@ static class Wire
     /// <summary>Render a <c>counts_only=</c> histogram, capped at <paramref name="rowLimit"/> with the true distinct-key
     /// count always stated. A null histogram means the mode was not requested; an EMPTY one means the sweep genuinely
     /// found nothing, and the two read differently (Q3).</summary>
-    static void AppendHistogram(StringBuilder sb, IReadOnlyList<SweepCount>? rows, int rowLimit, string title, string note)
+    static void AppendHistogram(StringBuilder sb, IReadOnlyList<SweepCount>? rows, int rowLimit, string title, string note,
+                                string? notComputed = null)
     {
         sb.Append('\n').Append(note).Append('\n');
-        if (rows is null) return;
+        if (rows is null) { if (notComputed is not null) sb.Append(notComputed).Append('\n'); return; }
         if (rows.Count == 0) { sb.Append("\nnothing to tally — no findings in the swept scope.\n"); return; }
         sb.Append('\n').Append(title).Append(" (").Append(rows.Count).Append(" distinct):\n");
         int shown = 0;
@@ -871,6 +866,20 @@ static class Wire
         }
         if (shown < rows.Count)
             sb.Append("  ... [").Append(rows.Count - shown).Append(" more row(s) — raise limit= to see them]\n");
+    }
+
+    /// <summary>The named, reasoned list of plugins the index build could not parse. Shared by the listing and
+    /// <c>counts_only=</c> paths — counts_only used to return before it, leaving the header's bare count with no way to
+    /// learn WHICH plugin went unchecked without re-running (PR #288 review, finding 5).</summary>
+    static void AppendExcludedPlugins(StringBuilder sb, IReadOnlyDictionary<string, string> excluded, int cap)
+    {
+        if (excluded.Count == 0) return;
+        sb.Append("\nexcluded plugins (could not be parsed — NOT checked):\n");
+        foreach (var kv in excluded)
+        {
+            if (sb.Length >= cap) { sb.Append("  ... [truncated at max_chars]\n"); break; }
+            sb.Append("  ").Append(kv.Key).Append(": ").Append(kv.Value).Append('\n');
+        }
     }
 
     /// <summary>Under <c>counts_only=</c> the reports list carries the honesty layer only (records/plugins houseCARL
@@ -900,11 +909,25 @@ static class Wire
         int cap = Cap(maxChars);
         var sb = new StringBuilder();
 
+        bool didObject = r.Classes.HasFlag(ScriptFindingClass.UnboundObject);
+        bool didScalar = r.Classes.HasFlag(ScriptFindingClass.UnboundScalar);
+        bool didNull = r.Classes.HasFlag(ScriptFindingClass.BoundNull);
+
         sb.Append("validate_scripts — VMAD script-property binding sweep\n");
         sb.Append("scanned ").Append(r.PluginsScanned).Append(r.PluginsScanned == 1 ? " plugin · " : " plugins · ")
           .Append(r.RecordsWithScripts).Append(" record(s) with scripts · ")
-          .Append(r.TotalUnbound).Append(" unbound · ")
-          .Append(r.TotalNullObject).Append(" bound-but-null · ")
+          // A class the caller excluded reads as NOT CHECKED, never as a 0 — a 0 would say "looked, found none" about
+          // the HIGH silent-None class nobody looked for (PR #288 review, finding 1).
+          .Append(!didObject && !didScalar
+                      ? "unbound NOT CHECKED (findings= excluded both unbound classes)"
+                      : didObject && didScalar
+                          ? $"{r.TotalUnbound} unbound"
+                          : didObject
+                              ? $"{r.TotalUnboundObject} unbound (object only — unbound_scalar NOT CHECKED)"
+                              : $"{r.TotalUnboundScalar} unbound (scalar only — unbound_object NOT CHECKED)")
+          .Append(" · ")
+          .Append(didNull ? $"{r.TotalNullObject} bound-but-null" : "bound-but-null NOT CHECKED (findings= excluded 'bound_null')")
+          .Append(" · ")
           .Append(r.TotalUnverifiable).Append(" unverifiable");
         if (r.ExcludedPlugins.Count > 0)
             sb.Append(" · ").Append(r.ExcludedPlugins.Count).Append(" plugin(s) excluded (unparseable)");
@@ -922,6 +945,7 @@ static class Wire
                 if (sb.Length >= cap) { sb.Append("\n... [truncated at max_chars]\n"); break; }
                 if (rec.ScanError is not null) sb.Append("\n[SCAN ERROR] ").Append(rec.Plugin).Append(": ").Append(rec.ScanError).Append('\n');
             }
+            AppendExcludedPlugins(sb, r.ExcludedPlugins, cap);   // #288 review finding 5
             AppendScriptCheckBoundary(sb);
             return sb.ToString().TrimEnd('\n');
         }
@@ -973,15 +997,7 @@ static class Wire
             sb.Append("\n[finding list capped at limit; true totals = ").Append(r.TotalUnbound).Append(" unbound + ")
               .Append(r.TotalNullObject).Append(" bound-but-null — raise limit= to see all]\n");
 
-        if (!truncated && r.ExcludedPlugins.Count > 0)
-        {
-            sb.Append("\nexcluded plugins (could not be parsed — NOT checked):\n");
-            foreach (var kv in r.ExcludedPlugins)
-            {
-                if (sb.Length >= cap) break;
-                sb.Append("  ").Append(kv.Key).Append(": ").Append(kv.Value).Append('\n');
-            }
-        }
+        if (!truncated) AppendExcludedPlugins(sb, r.ExcludedPlugins, cap);
 
         AppendScriptCheckBoundary(sb);
         return sb.ToString().TrimEnd('\n');

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -1002,16 +1002,24 @@ static class Wire
 
     /// <summary>The unbound total, spelled so it can never claim a class nobody checked. ONE definition, used by both
     /// the header and the capped tail — the tail restating the numbers in its own words is how "0 unbound" survived the
-    /// header fix (re-review finding 2).</summary>
+    /// header fix (re-review finding 2).
+    /// <para>It also carries the <c>property_contains=</c> label when one is in force, so this number states its own
+    /// scope rather than leaning on a blanket claim the sweep's other counts would not satisfy (round-3 review).</para></summary>
     static string UnboundTotalText(ScriptCheckResult r, bool didObject, bool didScalar)
         => !didObject && !didScalar ? "unbound NOT CHECKED (findings= excluded both unbound classes)"
-         : didObject && didScalar   ? $"{r.TotalUnbound} unbound"
-         : didObject                ? $"{r.TotalUnboundObject} unbound (object only — unbound_scalar NOT CHECKED)"
-                                    : $"{r.TotalUnboundScalar} unbound (scalar only — unbound_object NOT CHECKED)";
+         : didObject && didScalar   ? $"{r.TotalUnbound} unbound{PropLabel(r)}"
+         : didObject                ? $"{r.TotalUnboundObject} unbound{PropLabel(r)} (object only — unbound_scalar NOT CHECKED)"
+                                    : $"{r.TotalUnboundScalar} unbound{PropLabel(r)} (scalar only — unbound_object NOT CHECKED)";
 
     /// <summary>The bound-but-null total, same contract as <see cref="UnboundTotalText"/>.</summary>
     static string NullTotalText(ScriptCheckResult r, bool didNull)
-        => didNull ? $"{r.TotalNullObject} bound-but-null" : "bound-but-null NOT CHECKED (findings= excluded 'bound_null')";
+        => didNull ? $"{r.TotalNullObject} bound-but-null{PropLabel(r)}"
+                   : "bound-but-null NOT CHECKED (findings= excluded 'bound_null')";
+
+    /// <summary>The per-number <c>property_contains=</c> label, on exactly the two counts that filter narrows. Absent
+    /// from records-with-scripts and unverifiable, which it does not narrow — that asymmetry is the whole point.</summary>
+    static string PropLabel(ScriptCheckResult r)
+        => r.PropertyContains is null ? "" : $" matching '{r.PropertyContains}'";
 
     static void AppendScriptCheckBoundary(StringBuilder sb)
         => sb.Append("\nboundary: checks Auto (CK-editable) properties across the extends chain — not code-driven full ")


### PR DESCRIPTION
Fixes #282

## The gap

`housecarl_check_errors` and `housecarl_validate_scripts` had exactly one scope knob between them — `plugins=` — and on the motivating case that was not enough to get an answer **at all**. A script-heavy plugin (~183 scripted records, 711 unbound findings) renders ~131k characters and overflows the tool-result token cap; `limit=` does not help, because it caps *findings*, not the record roster, so even `limit=1` still printed a `[CHECK]` header line for all 183 records. The reporter fell back to running the full sweep twice, letting both overflow to disk, and shell-grepping the two spill files.

## What this adds

On **both** tools:

| Param | What it does |
|---|---|
| `type=` | Record type scope — applied at the record **stream** (`RecordsIn`'s getter-type filter), so skipped records cost nothing |
| `formids=` | Sweep only these records — the re-check-these-few pass after a fix |
| `editorid_contains=` | Case-insensitive EditorID substring scope |
| `findings=` | Finding-class filter (per-tool vocabulary) |
| `counts_only=true` | Exact totals + a histogram, no per-record listing built at all |
| `format="json"` | The machine-readable twin, accounting in-band |

On `validate_scripts` additionally: **`property_contains=`** — chase one property across a plugin.

Two things beyond the issue's literal ask, both cheap and load-bearing:

- **`findings=["missing_masters"]` on `check_errors` skips the per-record link walk wholesale.** That turns *"is any master missing anywhere in my order"* from a full sweep into a master-table read.
- **The `counts_only` histograms are keyed to answer something**, not merely tallied: unbound-by-property-**NAME** for `validate_scripts` (the reporter's `grep -oE … | sort | uniq -c` pipeline as one call), and dangling-by-**TARGET**-plugin for `check_errors` — which plugin the broken refs point *into*, i.e. the one absent dependency behind a wall of findings. Per-source-plugin was already the report's grouping, so it would have added nothing.

## Q3 posture — the decisions worth reviewing

Each of these is pinned by a guard arm, not just asserted here.

1. **Narrowing narrows the COUNTS.** A scoped sweep's totals are the totals for the scope, exactly as `plugins=` already behaved. A narrowed response carries a `NARROWED to … — every count below is for THIS narrowed scope` line, so a scoped number cannot be misread as a whole-plugin one.
2. **Unscannable records and unverifiable script attachments are NOT filterable**, deliberately — they are the honesty layer, not a finding class. An unreadable `.pex` may be the very one declaring the property you are filtering for, so letting a filter hide it would convert *"could not check"* into a clean answer. Guard arm `UNVERIFIABLE-SURVIVES-FILTER` drives a filter that matches **nothing** and asserts `wNoPex` still reports.
3. **An excluded error class renders `NOT CHECKED`, never `0`** — and `null`, not `0`, in JSON. A check nobody ran must not parse as a check that came back clean. Guard arms `CLASS-MASTERS-ONLY` / `CLASS-DANGLING-ONLY` assert on the rendered string, not just the result object.
4. **`Histogram == null` means "not computed", never "nothing found"** — an empty histogram is a real answer and must not look like an absent one.
5. **Every malformed input refuses before the sweep runs** — a bad FormID token, an unknown record type, an unrecognized `findings=` value. The refusal names the legal set and states that the unread class cannot be filtered out.

## Design notes

- **Filtering lives in core, not the render.** That is what makes the totals *be* the filtered totals, lets `counts_only` skip building the roster entirely, and lets the self-contained CI guards drive the same narrowing the tools do.
- **New shared core type** `SweepScope` + `ErrorFindingClass` / `ScriptFindingClass` + `SweepFindings` parsers (`src/housecarl-core/SweepScope.cs`), so both sweeps speak one vocabulary and the parsers are guard-drivable.
- **The off-order lane is covered too.** Its self-key pass is deliberately *not* record-scoped: a link into a record the file defines is satisfied whether or not that record is in the caller's scope, so scoping it would manufacture dangling refs.
- **No cornerstone conflict.** This conforms two outlier tools to the generic read surface (six of nine read tools already took `format=`; `editorid_contains=` / `type=` / `group_by=`-style counts all exist on siblings). It is scoping params in house vocabulary, not a job-shaped verb.

Also fixed, cheaply: the truncation notice on both tools advised *"scope `plugins=` or raise max_chars"* — recommending the one scope the caller had already applied. It now names the knobs that exist.

## Verification

- **16 new guard arms** across `check-errors-guard` (11) and `script-property-check-guard` (12 — arm lists updated in both class docs).
- **`ci-all` 109/109 passed.**
- Text and JSON renders eyeballed in all three modes (listing / narrowed / `counts_only`) via a temporary print, since a render that only assertions have seen is where formatting bugs hide. Print reverted; not in the diff.

## Not code

- `plugin/CHANGELOG.md` `## Unreleased` entry.
- One line added to the `bulk-record-jobs` skill, so it stops planning per-record loops over these two tools and knows `limit=` will not shrink a script-heavy plugin's output on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
