### PR TITLE
deps(nif): bump NiflySharp 1.0.0 → 1.1.0 — twelve unreadable meshes become readable, and five shader values stop being unread

### DIFF
--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -47,7 +47,7 @@ GPL-3.0-only   (copyleft — the same license as houseCARL; see the LICENSE file
   GameFinder.StoreHandlers.Steam   4.4.0    github.com/erri120/GameFinder
   GameFinder.StoreHandlers.Xbox    4.4.0    github.com/erri120/GameFinder
   GameFinder.Wine                  4.4.0    github.com/erri120/GameFinder
-  NiflySharp                       1.0.0    github.com/ousnius/NiflySharp
+  NiflySharp                       1.1.0    github.com/ousnius/NiflySharp
 
   NiflySharp (NuGet package "Nifly", by ousnius / the nifly project) is the
   asset-internal mesh reader the NIF layer is built on — pure C#, source-generated

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -75,7 +75,7 @@ takes). Slot naming is a **Skyrim** convention, so it declines entirely on a mes
 an unconverted Fallout 4 mesh shipped inside a Skyrim mod gets bare indices, and the output says so rather than
 leaving "unnamed" to read as "undetermined".
 **Lighting values** — *emissive colour and multiple, glossiness, specular strength, specular colour, alpha* — are
-reported for a lighting shader (see the mesh-library bump below; they were unreadable when this section was first
+reported for a lighting shader (see the mesh-library bump above; they were unreadable when this section was first
 built, and never shipped that way). On an **effect** shader the library still answers them from a stub that returns a
 constant, so houseCARL prints nothing for them there and names them as not read, rather than a number it cannot vouch
 for. Which values are readable is detected from the library itself, not a hard-coded list, so this tracks the bundled

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -20,7 +20,7 @@ the wrong buffer, a file-handle leak, block-array resizing). Every mesh read and
 code. Nothing in the tool surface changed shape — the shader section detects which values the library genuinely reads
 by inspecting the library, so the five started reporting with no change to the reporting logic, and an effect shader
 (where upstream still stubs them) correctly keeps saying so.
-**One value is withheld on purpose, and it is a scope decision rather than a library one.** On a mesh read as another
+**One group of values is withheld on purpose, and it is a scope decision rather than a library one.** On a mesh read as another
 game's layout — an unconverted Fallout 4 or Fallout 3 mesh shipped inside a Skyrim mod — houseCARL now declines *all*
 the lighting values and says so. The reason is that some of these accessors read a field the other layout's stream
 never carried, and answer a fixed constant rather than the mesh's own number (glossiness on a lighting shader is the

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,26 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**The bundled mesh library moves to NiflySharp 1.1.0 — `nif_inspect` gains five shader values, and mesh reads pick up
+upstream's crash/corruption fixes (#287).**
+The pinned 1.0.0 was published from a commit 52 changes behind upstream, and the gap was costing two different things.
+The visible one: `sections=shader` could not report *glossiness, specular strength, specular colour, emissive multiple*
+or *alpha* — 1.0.0's accessors returned a constant regardless of what the mesh held, so houseCARL named them as unread
+rather than print a wrong number. 1.1.0 implements all five, and they now report their real values on any lighting
+shader. The less visible one, and the reason the bump is worth taking on its own: upstream's most recent work is a code
+audit fixing *crashes, hangs, data corruption and leaks*, alongside a batch of community fixes (UV writes landing in
+the wrong buffer, a file-handle leak, block-array resizing). Every mesh read and write houseCARL does now runs on that
+code. Nothing in the tool surface changed shape — the shader section detects which values the library genuinely reads
+by inspecting the library, so the five started reporting with no change to the reporting logic, and an effect shader
+(where upstream still stubs them) correctly keeps saying so.
+Parse fidelity was **re-proven, not assumed to carry over** — both versions were run back to back over the same
+91,601 workspace meshes and compared file by file, not by headline percentage. **Nine meshes that houseCARL could not
+read at all now read**: 1.0.0 threw on a malformed boolean byte in them, taking Glorious Doors of Skyrim, Golden
+Dwemer Pipeworks and every door in Reimperialized Abandoned Prison with it. Three more that parsed but carried blocks
+1.0.0 did not recognise now parse fully. The single mesh still unreadable now *refuses* cleanly instead of throwing.
+**Nothing regressed**: no mesh that parsed stopped parsing, no mesh that round-tripped byte-identical stopped, and the
+18,862 vanilla Bethesda meshes came out verdict-for-verdict identical on both versions.
+
 **The two sweep tools can now be scoped, filtered, counted, and returned as JSON (#282).**
 `check_errors` and `validate_scripts` had exactly one scope knob between them — `plugins=` — and on a script-heavy
 plugin that was not enough to get an answer at all: ~183 scripted records render past the tool-result size cap, and
@@ -54,11 +74,12 @@ rather than getting a plausible wrong label, and the index is always kept (it is
 takes). Slot naming is a **Skyrim** convention, so it declines entirely on a mesh read as another game's layout —
 an unconverted Fallout 4 mesh shipped inside a Skyrim mod gets bare indices, and the output says so rather than
 leaving "unnamed" to read as "undetermined".
-**Known limit, stated rather than papered over:** the underlying mesh library answers *glossiness, specular strength,
-specular colour, emissive multiple* and *alpha* from a stub that returns a constant, no matter what the mesh holds.
-houseCARL will not print a number it cannot vouch for, so the section names them as not read — and, where the block
-carries them (a lighting shader does; an effect shader has no such fields at all), points you at NifSkope. Emissive
-**colour** is read for real. Reported externally.
+**Lighting values** — *emissive colour and multiple, glossiness, specular strength, specular colour, alpha* — are
+reported for a lighting shader (see the mesh-library bump below; they were unreadable when this section was first
+built, and never shipped that way). On an **effect** shader the library still answers them from a stub that returns a
+constant, so houseCARL prints nothing for them there and names them as not read, rather than a number it cannot vouch
+for. Which values are readable is detected from the library itself, not a hard-coded list, so this tracks the bundled
+version automatically in both directions.
 
 **`check_errors` and the compact/merge dependency scan now treat a deleted record the same way (#279).**
 The #276 fix taught `cross_plugin_query` that a deleted record links to nothing; the two sibling walkers that ride the

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,13 +13,22 @@ upstream's crash/corruption fixes (#287).**
 The pinned 1.0.0 was published from a commit 52 changes behind upstream, and the gap was costing two different things.
 The visible one: `sections=shader` could not report *glossiness, specular strength, specular colour, emissive multiple*
 or *alpha* — 1.0.0's accessors returned a constant regardless of what the mesh held, so houseCARL named them as unread
-rather than print a wrong number. 1.1.0 implements all five, and they now report their real values on any lighting
-shader. The less visible one, and the reason the bump is worth taking on its own: upstream's most recent work is a code
+rather than print a wrong number. 1.1.0 implements all five, and they now report their real values on any **Skyrim-layout**
+lighting shader. The less visible one, and the reason the bump is worth taking on its own: upstream's most recent work is a code
 audit fixing *crashes, hangs, data corruption and leaks*, alongside a batch of community fixes (UV writes landing in
 the wrong buffer, a file-handle leak, block-array resizing). Every mesh read and write houseCARL does now runs on that
 code. Nothing in the tool surface changed shape — the shader section detects which values the library genuinely reads
 by inspecting the library, so the five started reporting with no change to the reporting logic, and an effect shader
 (where upstream still stubs them) correctly keeps saying so.
+**One value is withheld on purpose, and it is a scope decision rather than a library one.** On a mesh read as another
+game's layout — an unconverted Fallout 4 or Fallout 3 mesh shipped inside a Skyrim mod — houseCARL now declines *all*
+the lighting values and says so. The reason is that some of these accessors read a field the other layout's stream
+never carried, and answer a fixed constant rather than the mesh's own number (glossiness on a lighting shader is the
+live case: it reads the same value whatever the file holds). Rather than interpret the ones that survive the layout
+change and guess at the rest, the whole group is declined there. That withholds up to four values that *would* have
+been correct, which is a deliberate trade — houseCARL models the Skyrim shader layout, the same reason it already
+declines to name texture slots on a foreign-layout mesh. Unlike the library detection above, this half does **not**
+track the bundled version; it is houseCARL's own boundary.
 Parse fidelity was **re-proven, not assumed to carry over** — both versions were run back to back over the same
 91,601 workspace meshes and compared file by file, not by headline percentage. **Nine meshes that houseCARL could not
 read at all now read**: 1.0.0 threw on a malformed boolean byte in them, taking Glorious Doors of Skyrim, Golden
@@ -75,11 +84,12 @@ takes). Slot naming is a **Skyrim** convention, so it declines entirely on a mes
 an unconverted Fallout 4 mesh shipped inside a Skyrim mod gets bare indices, and the output says so rather than
 leaving "unnamed" to read as "undetermined".
 **Lighting values** — *emissive colour and multiple, glossiness, specular strength, specular colour, alpha* — are
-reported for a lighting shader (see the mesh-library bump above; they were unreadable when this section was first
-built, and never shipped that way). On an **effect** shader the library still answers them from a stub that returns a
-constant, so houseCARL prints nothing for them there and names them as not read, rather than a number it cannot vouch
-for. Which values are readable is detected from the library itself, not a hard-coded list, so this tracks the bundled
-version automatically in both directions.
+reported for a Skyrim-layout lighting shader (see the mesh-library bump above; they were unreadable when this section
+was first built, and never shipped that way). Two cases report nothing instead, each saying which it is: on an
+**effect** shader the library answers them from a stub returning a constant, and on a **non-Skyrim layout** houseCARL
+declines them as a matter of its own scope. Either way you get a named reason, never a number houseCARL cannot vouch
+for. The first is detected from the library itself rather than a hard-coded list, so it tracks the bundled version
+automatically in both directions; the second is houseCARL's own boundary and does not.
 
 **`check_errors` and the compact/merge dependency scan now treat a deleted record the same way (#279).**
 The #276 fix taught `cross_plugin_query` that a deleted record links to nothing; the two sibling walkers that ride the

--- a/plugin/THIRD-PARTY-NOTICES.txt
+++ b/plugin/THIRD-PARTY-NOTICES.txt
@@ -47,7 +47,7 @@ GPL-3.0-only   (copyleft — the same license as houseCARL; see the LICENSE file
   GameFinder.StoreHandlers.Steam   4.4.0    github.com/erri120/GameFinder
   GameFinder.StoreHandlers.Xbox    4.4.0    github.com/erri120/GameFinder
   GameFinder.Wine                  4.4.0    github.com/erri120/GameFinder
-  NiflySharp                       1.0.0    github.com/ousnius/NiflySharp
+  NiflySharp                       1.1.0    github.com/ousnius/NiflySharp
 
   NiflySharp (NuGet package "Nifly", by ousnius / the nifly project) is the
   asset-internal mesh reader the NIF layer is built on — pure C#, source-generated

--- a/src/housecarl-core/NifService.cs
+++ b/src/housecarl-core/NifService.cs
@@ -12,16 +12,23 @@ namespace HousecarlCore;
 /// which mod won (that seam is <see cref="LoadOrderService"/>, which resolves the winning bytes and hands them here),
 /// so it is fully testable off a synthetic in-memory mesh with no live workspace (nif-service-guard).
 ///
-/// Reads ride NiflySharp 1.0.0 (NuGet <c>Nifly</c>) — pure C#, source-generated from nifxml, spike-proven over 87,937
-/// workspace nifs (SPIKE_NIF_LAYER_2026-07-08: 99.98% loose / 100.00% vanilla parse, zero unknown blocks in any SE
-/// mesh). Library quirks coded around per the spike: the alpha/shader/skin refs are read DIRECTLY
+/// Reads ride NiflySharp 1.1.0 (NuGet <c>Nifly</c>) — pure C#, source-generated from nifxml. Re-proven on the 1.0.0 →
+/// 1.1.0 bump rather than carried over (#287): both versions scanned back to back over the same 72,739 loose + 18,862
+/// vanilla workspace nifs and diffed FILE BY FILE — 100.00% parse on both corpora, zero unknown blocks in any SE mesh,
+/// zero regressions. (The superseded 1.0.0 baseline — 87,937 nifs, 99.98% loose — is SPIKE_NIF_LAYER_2026-07-08; those
+/// figures are a property of THAT library build and do not describe this one.) Library quirks coded around per the
+/// spike: the alpha/shader/skin refs are read DIRECTLY
 /// (<see cref="INiShape.AlphaPropertyRef"/> etc.) — NEVER via <c>NifFile.GetPropertyOfType&lt;T&gt;</c>, which NREs on
 /// SE-style shapes whose legacy <c>Properties</c> list is null.
 ///
 /// Fail-loud (Q3, PRFAQ N6): a parse failure is a NAMED, recoverable outcome (<see cref="NifInspectOutcome.Error"/>),
-/// not a throw or a half-model — including NiflySharp's one strict-boolean rejection class, which houseCARL surfaces
-/// with the NifSkope remedy rather than hand-patching around. Unknown blocks are REPORTED (count + their real on-disk
-/// type names) and left intact — the model tells the truth about what it could and could not model.
+/// not a throw or a half-model. Unknown blocks are REPORTED (count + their real on-disk type names) and left intact —
+/// the model tells the truth about what it could and could not model.
+///
+/// The strict-boolean rejection class this file used to describe as live behaviour is GONE as of 1.1.0: upstream
+/// stopped throwing on a non-0/1 boolean byte, the 9 workspace meshes that hit it now parse, and the message string
+/// is absent from the 1.1.0 assembly (present in 1.0.0's). <see cref="DescribeLoadException"/>'s arm for it is
+/// therefore believed unreachable and kept only as belt-and-braces — it is NOT an outcome to advertise to a caller.
 /// </summary>
 public static class NifService
 {
@@ -92,7 +99,12 @@ public static class NifService
         }
     }
 
-    /// <summary>Turn a load exception into a named, actionable error. NiflySharp's one strict-boolean rejection class
+    /// <summary>Turn a load exception into a named, actionable error. The strict-boolean arm below is BELIEVED DEAD as
+    /// of NiflySharp 1.1.0 (#287 / PR #290) — upstream stopped throwing on it, the workspace meshes that hit it now
+    /// parse, and the message string is gone from the assembly. It is kept because a wrong-but-specific message costs
+    /// nothing if it never fires and a missing one costs a diagnosis if the class ever returns; it is deliberately no
+    /// longer advertised in the tool description as an outcome to expect. Original note follows.
+    /// NiflySharp's one strict-boolean rejection class
     /// (the spike's 13 loud failures — "Byte value for boolean is > 2!", a nonstandard byte some exporters write) is
     /// called out by name with the NifSkope remedy, so the tool never reads as a silent "absent" and houseCARL never
     /// hand-patches around the strict read.</summary>
@@ -213,9 +225,29 @@ public static class NifService
         // on disk, and the interface widens it to Color4, so its 4th component is a synthetic 0 that would render as
         // "fully transparent emissive" — a fabricated value, the one thing worse than a missing one (Q3). Specular is
         // a Color3 both on disk and on the interface, so it needs no such narrowing — the same RGB shape either way.
+        //
+        // SECOND GATE — THE LAYOUT (review of PR #290). ReallyReads keys on the block TYPE, and that is one axis too
+        // narrow: some of these accessors are LAYOUT-dispatched, reading a field the stream only carries on some
+        // games. Glossiness is the live case — nifly documents it as "the material specular power, or glossiness
+        // (BEFORE FO4)", with a separate Smoothness "(starting with FO4)". So on an FO4 / FO76-SF layout the field is
+        // never deserialized and the accessor hands back its nif.xml constructor default: an authored 30 and an
+        // authored 55 both read back as 80. That is "returns a constant regardless of what the mesh holds" — exactly
+        // what ReallyReads exists to suppress — but at LAYOUT granularity, which a type-level interface-map check
+        // structurally cannot see (1.0.0 hid it by not overriding Glossiness at all; the 1.1.0 bump exposed it).
+        //
+        // The gate is by LAYOUT rather than by a declared list of "the layout-dispatched values" on purpose. A list is
+        // a hand-kept fact about the library's internals — the exact per-type hand-mapping the coverage cornerstone
+        // exists to keep out, unverifiable by a guard that can only mirror the same belief, and already wrong once for
+        // any layout nobody thought to probe. "houseCARL interprets a SKYRIM shader" is instead a claim about
+        // houseCARL's own scope, true whatever nifly does internally, and it is the posture this file already takes
+        // twice over: ShaderTypeName picks its field BY LAYOUT, and slot naming declines entirely off the SK layout.
+        // The cost is the four values that do read correctly elsewhere (specular strength/colour, emissive multiple,
+        // alpha) going unreported on a non-Skyrim mesh — and the renderer states that decline as its own distinct
+        // reason, never as "the library stubs these", because it isn't.
         var t = shader.GetType();
-        NifColor? Rgb3(string prop, Func<NifColor> read) => ReallyReads(t, prop) ? read() : null;
-        float? Scalar(string prop, Func<float> read) => ReallyReads(t, prop) ? read() : null;
+        var skyrimLayout = game == ShaderHelper.ShaderGameType.SK;
+        NifColor? Rgb3(string prop, Func<NifColor> read) => skyrimLayout && ReallyReads(t, prop) ? read() : null;
+        float? Scalar(string prop, Func<float> read) => skyrimLayout && ReallyReads(t, prop) ? read() : null;
 
         return new NifShader(
             blockType, game.ToString(), ShaderTypeName(shader, blockType, game),

--- a/src/housecarl-core/NifService.cs
+++ b/src/housecarl-core/NifService.cs
@@ -211,30 +211,20 @@ public static class NifService
         // Each lighting value is reported ONLY if this block really reads it (see ReallyReads) — otherwise null, and
         // the renderer names it as unread. RGB, never RGBA: a lighting shader's emissive is a THREE-component colour
         // on disk, and the interface widens it to Color4, so its 4th component is a synthetic 0 that would render as
-        // "fully transparent emissive" — a fabricated value, the one thing worse than a missing one (Q3).
+        // "fully transparent emissive" — a fabricated value, the one thing worse than a missing one (Q3). Specular is
+        // a Color3 both on disk and on the interface, so it needs no such narrowing — the same RGB shape either way.
         var t = shader.GetType();
-        NifColor? Rgb3(string prop, Func<System.Numerics.Vector3> read)
-        {
-            if (!ReallyReads(t, prop)) return null;
-            var v = read();
-            return new NifColor(v.X, v.Y, v.Z);
-        }
+        NifColor? Rgb3(string prop, Func<NifColor> read) => ReallyReads(t, prop) ? read() : null;
         float? Scalar(string prop, Func<float> read) => ReallyReads(t, prop) ? read() : null;
 
-        NifColor? emissive = null;
-        if (ReallyReads(t, nameof(INiShader.EmissiveColor)))
-        {
-            var e = shader.EmissiveColor;
-            emissive = new NifColor(e.R, e.G, e.B);
-        }
         return new NifShader(
             blockType, game.ToString(), ShaderTypeName(shader, blockType, game),
             f1, f2,
-            emissive,
+            Rgb3(nameof(INiShader.EmissiveColor), () => { var e = shader.EmissiveColor; return new NifColor(e.R, e.G, e.B); }),
             Scalar(nameof(INiShader.EmissiveMultiple), () => shader.EmissiveMultiple),
             Scalar(nameof(INiShader.Glossiness), () => shader.Glossiness),
             Scalar(nameof(INiShader.SpecularStrength), () => shader.SpecularStrength),
-            Rgb3(nameof(INiShader.SpecularColor), () => shader.SpecularColor),
+            Rgb3(nameof(INiShader.SpecularColor), () => { var s = shader.SpecularColor; return new NifColor(s.R, s.G, s.B); }),
             Scalar(nameof(INiShader.Alpha), () => shader.Alpha));
     }
 
@@ -267,17 +257,20 @@ public static class NifService
     /// <summary>Whether <paramref name="blockType"/> REALLY reads <paramref name="property"/>, or merely inherits
     /// <see cref="INiShader"/>'s DEFAULT INTERFACE IMPLEMENTATION for it.
     ///
-    /// This is not defensive noise — it is a live upstream gap. In NiflySharp 1.0.0, <c>BSLightingShaderProperty</c>
-    /// overrides <c>EmissiveColor</c> but NOT <c>Glossiness</c>, <c>SpecularStrength</c>, <c>SpecularColor</c>,
-    /// <c>EmissiveMultiple</c> or <c>Alpha</c>; those fall through to the interface's stub, which returns a CONSTANT
-    /// (0, or 1 for Alpha) no matter what the mesh holds. The values are genuinely on disk — the block's private
-    /// fields round-trip a save/load intact — the library just doesn't surface them. Reporting the stub would be a
-    /// confident wrong number on every mesh: exactly the silent-wrong-answer the no-silent-failure rule forbids, and
-    /// the "fail loud about the library's delta, never silently around it" posture the coverage cornerstone names.
+    /// This is not defensive noise — it is a live upstream gap, and it MOVES between releases. In NiflySharp 1.0.0,
+    /// <c>BSLightingShaderProperty</c> overrode <c>EmissiveColor</c> but NOT <c>Glossiness</c>,
+    /// <c>SpecularStrength</c>, <c>SpecularColor</c>, <c>EmissiveMultiple</c> or <c>Alpha</c>. 1.1.0 (issue #287)
+    /// implements all five there — while <c>BSEffectShaderProperty</c> still answers <c>EmissiveColor</c>,
+    /// <c>SpecularColor</c>, <c>Glossiness</c>, <c>SpecularStrength</c>, <c>EmissiveMultiple</c> and <c>Alpha</c>
+    /// from the interface's default-implementation stub, which returns a CONSTANT (0, or 1 for Alpha) no matter what
+    /// the mesh holds. The values are genuinely on disk — the block's private fields round-trip a save/load intact —
+    /// the library just doesn't surface them for that block. Reporting the stub would be a confident wrong number on
+    /// every mesh carrying one: exactly the silent-wrong-answer the no-silent-failure rule forbids, and the "fail
+    /// loud about the library's delta, never silently around it" posture the coverage cornerstone names.
     ///
-    /// Doing it BY CONSTRUCTION rather than by a hand-kept list of "the five nifly stubs" means the day upstream
-    /// implements one, houseCARL starts reporting it with no code change — and if upstream ever stubs another, that
-    /// one goes quiet on its own instead of turning into a wrong answer.</summary>
+    /// Doing it BY CONSTRUCTION rather than by a hand-kept list of "nifly's stubs" is what let the 1.0.0 → 1.1.0 bump
+    /// start reporting five values with no change to this method: the day upstream implements one, houseCARL reports
+    /// it; the day upstream stubs one, that one goes quiet on its own instead of turning into a wrong answer.</summary>
     static bool ReallyReads(Type blockType, string property)
     {
         var real = RealReads.GetOrAdd(blockType, static t =>
@@ -910,10 +903,11 @@ public sealed record NifTexture(int Slot, string Path, string? SlotName = null);
 /// FaceTint, HairTint, Parallax, MultiLayerParallax, …) and is null for any block that does not serialize one — an
 /// effect shader reports NO type rather than a default-valued wrong one. <see cref="Flags1"/> / <see cref="Flags2"/>
 /// are null when the game layout carries no flag word this library names.
-/// <para>Every LIGHTING VALUE below is nullable, and null means "this library version does not read it off this block"
-/// — NOT "the mesh doesn't have it" (see <c>NifService.ReallyReads</c>: NiflySharp 1.0.0 answers several of them from
-/// an interface stub that returns a constant). The renderer names the unread ones explicitly, so a caller is never
-/// handed a stub value as if it were the mesh's.</para></summary>
+/// <para>Every LIGHTING VALUE below is nullable, and null means "this library version does not read it off THIS BLOCK
+/// TYPE" — NOT "the mesh doesn't have it" (see <c>NifService.ReallyReads</c>: NiflySharp answers several of them from
+/// an interface stub that returns a constant, and which ones moves between releases — 1.1.0 reads all of them off a
+/// BSLightingShaderProperty and none off a BSEffectShaderProperty). The renderer names the unread ones explicitly, so
+/// a caller is never handed a stub value as if it were the mesh's.</para></summary>
 public sealed record NifShader(
     string BlockType,
     string GameType,

--- a/src/housecarl-core/housecarl-core.csproj
+++ b/src/housecarl-core/housecarl-core.csproj
@@ -28,9 +28,15 @@
     <!-- The reflection target the extracted cores bind against. Pinned 0.53.1 (spike-proven), matching both consumers. -->
     <PackageReference Include="Mutagen.Bethesda.Skyrim" Version="0.53.1" />
     <!-- The NIF layer's asset-internal reader/writer. Pure C#, GPL-3.0 (compatible with our GPL-3.0-only), source-
-         generated from nifxml = coverage by construction. Pinned 1.0.0 (spike-proven over 87,937 workspace nifs —
-         SPIKE_NIF_LAYER_2026-07-08); bump deliberately. Notices: THIRD-PARTY-NOTICES.txt (GPL-3.0 block). -->
-    <PackageReference Include="Nifly" Version="1.0.0" />
+         generated from nifxml = coverage by construction. Pinned 1.1.0 (2026-07-26, issue #287): carries the shader
+         accessors 1.0.0 only stubbed, a settable TextureSetRef, and the upstream code-audit crash/corruption fixes.
+         RE-PROVEN on bump, not assumed to carry over — 1.0.0 and 1.1.0 scanned back to back over the same 72,739
+         loose + 18,862 vanilla meshes and diffed FILE BY FILE (spike-nif `scan` + diff_ab.py, ~35 min/leg): 12 loose
+         meshes 1.0.0 could not fully read now read, 1 refuses cleanly instead of throwing, vanilla verdict-identical,
+         zero regressions. A percentage matching is NOT the check — two runs can hit the same totals while disagreeing
+         about which files. Bump deliberately, and re-run that diff when you do.
+         Notices: THIRD-PARTY-NOTICES.txt (GPL-3.0 block). -->
+    <PackageReference Include="Nifly" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/housecarl-generator/NifServiceGuardProbe.cs
+++ b/src/housecarl-generator/NifServiceGuardProbe.cs
@@ -117,17 +117,21 @@ internal static class NifServiceGuardProbe
                           && Math.Abs(e.R - 0.25f) < 1e-6f && Math.Abs(e.G - 0.5f) < 1e-6f && Math.Abs(e.B - 0.75f) < 1e-6f,
                           "emissive colour round-trips exactly — "
                           + (sh.EmissiveColor is { } ec ? $"rgb({ec.R},{ec.G},{ec.B})" : "UNREAD (the override is gone?)"));
-                    // THE UPSTREAM-GAP ARM. Each scalar was authored to a DISTINCT non-zero value and each one
-                    // round-trips in the block's private field (proven by the fixture writing them) — yet NiflySharp
-                    // 1.0.0 answers Glossiness / SpecularStrength / SpecularColor / EmissiveMultiple / Alpha from
-                    // INiShader's default-interface STUB, which returns a constant. So houseCARL must report NOTHING
-                    // for them. An implementation that trusted the accessor would report "glossiness 0, alpha 1" for
-                    // every mesh in the world and pass any arm that only checked the field was populated.
-                    Check(sh.Glossiness is null && sh.SpecularStrength is null && sh.SpecularColor is null
-                          && sh.EmissiveMultiple is null && sh.Alpha is null,
-                          $"a value this library only STUBS is reported as unread, never as its constant — "
+                    // THE FORMER UPSTREAM-GAP ARM, FLIPPED (#287). Through NiflySharp 1.0.0 these five fell through to
+                    // INiShader's default-interface STUB, which returns a constant, so the arm asserted houseCARL
+                    // reported NOTHING for them. 1.1.0 implements all five on BSLightingShaderProperty, so the arm now
+                    // asserts the REAL round-tripped values — and it is the same tripwire read the other way: each was
+                    // authored to a value DISTINCT from the stub constant it replaced (0, or 1 for Alpha), so a
+                    // regression to the stub fails here loudly instead of printing a confident wrong number.
+                    Check(sh.Glossiness is { } gl && Math.Abs(gl - 30f) < 1e-6f
+                          && sh.SpecularStrength is { } sst && Math.Abs(sst - 1.5f) < 1e-6f
+                          && sh.EmissiveMultiple is { } em && Math.Abs(em - 2.5f) < 1e-6f
+                          && sh.Alpha is { } al && Math.Abs(al - 0.5f) < 1e-6f
+                          && sh.SpecularColor is { } spc
+                          && Math.Abs(spc.R - 1f) < 1e-6f && Math.Abs(spc.G - 0.5f) < 1e-6f && Math.Abs(spc.B - 0.25f) < 1e-6f,
+                          $"every lighting value round-trips its authored value, none of them the old stub constant — "
                           + $"glossiness={Fmt(sh.Glossiness)} specularStrength={Fmt(sh.SpecularStrength)} "
-                          + $"specularColor={(sh.SpecularColor is null ? "unread" : "REPORTED")} "
+                          + $"specularColor={(sh.SpecularColor is { } c ? $"rgb({c.R},{c.G},{c.B})" : "UNREAD (the override is gone?)")} "
                           + $"emissiveMultiple={Fmt(sh.EmissiveMultiple)} alpha={Fmt(sh.Alpha)}");
                 }
 
@@ -245,13 +249,47 @@ internal static class NifServiceGuardProbe
               "the shader section renders: block, TYPE, layout, decoded flag names, emissive values");
         // The index is KEPT alongside the name (nif_set's texture_slot= takes the index), and an undetermined slot
         // renders bare — the render half of the Q3 arm above.
-        // The unread values are NAMED in the render, so the gap is visible to the caller and not just absent.
-        Check(shRender.Contains("NOT READ by this NiflySharp version") && shRender.Contains("glossiness")
-              && shRender.Contains("alpha") && !shRender.Contains("glossiness 0") && !shRender.Contains("alpha 1"),
-              "the values this library only stubs are NAMED as unread, not printed as their constant");
+        // The read half of #287: on 1.1.0 every lighting value reaches the WIRE with its authored number, and the
+        // unread-caveat line is ABSENT because there is nothing left unread on this block. Both halves are asserted —
+        // a render that printed the values AND kept claiming they were unread would be a Q3 failure of its own.
+        Check(shRender.Contains("glossiness 30") && shRender.Contains("specular 1.5 rgb(1,0.5,0.25)")
+              && shRender.Contains("alpha 0.5") && shRender.Contains("emissive rgb(0.25,0.5,0.75) x2.5")
+              && !shRender.Contains("NOT READ by this NiflySharp version"),
+              "every lighting value reaches the render with its real number, and no unread caveat is left over");
         Check(shRender.Contains("tex[2] (SoftLighting): ") && shRender.Contains("tex[7] (Specular): ")
               && shRender.Contains("tex[4]: ") && !shRender.Contains("tex[4] ("),
               "named slots render as 'tex[N] (Name)' and an undetermined slot stays bare 'tex[N]'");
+
+        // ---- THE DECLINE ARM (#287): a block this library STILL stubs reports nothing, and says so ----
+        // The arm above proves ReallyReads says YES where upstream implements. This proves it says NO where upstream
+        // does not — on 1.1.0 a BSEffectShaderProperty answers all six lighting values from the interface stub. Delete
+        // the check, or make it answer true unconditionally, and THIS is the arm that fails; every other one stays
+        // green while houseCARL starts printing "glossiness 0, alpha 1" on every effect-shader mesh in the load order.
+        Console.WriteLine();
+        Console.WriteLine("--- a value this library STILL stubs is reported as unread, never as its constant ---");
+        var eff = NifService.Inspect(BuildSyntheticEffectShader());
+        Check(eff.Error is null && eff.Inspect is not null, $"the effect-shader mesh parses clean — {eff.Error ?? "ok"}");
+        var effSh = eff.Inspect?.Shapes.FirstOrDefault(s => s.Name == "EffectShape")?.Shader;
+        Check(effSh is { BlockType: "BSEffectShaderProperty", GameType: "SK", ShaderType: null },
+              $"the fixture really is an SK-layout effect shader, and it reports NO shader type — "
+              + $"{(effSh is null ? "(no shader)" : $"{effSh.BlockType}/{effSh.GameType}/{effSh.ShaderType ?? "(none)"}")}");
+        if (effSh is not null)
+        {
+            Check(effSh.EmissiveColor is null && effSh.EmissiveMultiple is null && effSh.Glossiness is null
+                  && effSh.SpecularStrength is null && effSh.SpecularColor is null && effSh.Alpha is null,
+                  "every lighting value this block only STUBS is reported as unread — "
+                  + $"emissive={(effSh.EmissiveColor is null ? "unread" : "REPORTED")} "
+                  + $"emissiveMultiple={Fmt(effSh.EmissiveMultiple)} glossiness={Fmt(effSh.Glossiness)} "
+                  + $"specularStrength={Fmt(effSh.SpecularStrength)} "
+                  + $"specularColor={(effSh.SpecularColor is null ? "unread" : "REPORTED")} alpha={Fmt(effSh.Alpha)}");
+            // And the gap is STATED on the wire, not merely absent from it — the caller has to be able to tell
+            // "we can't see it" from "the mesh says 0". The negative half pins that no stub constant leaked through.
+            var effRender = NifWire.Render(FakeData(eff.Inspect, null), wantShader, Array.Empty<string>(), 80_000);
+            Check(effRender.Contains("NOT READ by this NiflySharp version")
+                  && effRender.Contains("glossiness") && effRender.Contains("alpha")
+                  && !effRender.Contains("glossiness 0") && !effRender.Contains("alpha 1"),
+                  "the unread values are NAMED on the wire, and none of them printed as its constant");
+        }
 
         // ---- the unnamed-bit path (#255's posture, carried to the shader words) ----
         // Every flag word nifly names today (SLSF1/2, F4SPF1/2, BSShaderFlags1/2) covers all 32 bits, so a real mesh
@@ -384,6 +422,46 @@ internal static class NifServiceGuardProbe
         return new NifInspectBatchData(new[] { one }, bsaFailures ?? Array.Empty<string>(), Array.Empty<string>(), "Default");
     }
 
+    /// <summary>Author a minimal SE mesh whose one shape carries a <c>BSEffectShaderProperty</c> — the block NiflySharp
+    /// 1.1.0 still answers EVERY lighting value on from <see cref="INiShader"/>'s default-interface STUB. It is the
+    /// subject of the DECLINE arm, and it exists as its own fixture rather than as a second shape on the main one so
+    /// the census / block-count arms there stay pinned to what they were written for.
+    ///
+    /// Why it must exist at all: #287 flipped the main fixture's arm from "these five are reported as unread" to "these
+    /// five carry their real values", because 1.1.0 implements them on BSLightingShaderProperty. That left every arm in
+    /// this probe exercising only <c>ReallyReads</c>'s YES branch — so a change that deleted the check, or made it
+    /// answer true unconditionally, would go green here while making an effect shader report "glossiness 0, alpha 1" on
+    /// every such mesh in the world. That is the exact silent-wrong-answer #272 was built to prevent, so the NO branch
+    /// gets its own subject rather than riding on whatever upstream happens not to have implemented this month.</summary>
+    static byte[] BuildSyntheticEffectShader()
+    {
+        var ver = new NiVersion { FileVersion = NiVersion.ToFile("20.2.0.7"), UserVersion = 12, StreamVersion = 100 };
+        var f = new NifFile();
+        f.Create(ver, withRootNode: true);
+        var root = f.GetRootNodes().First();
+        root.Name = new NiStringRef("EffectRoot");
+        root.Flags_ui = 0xE;
+
+        var shape = new BSTriShape { Name = new NiStringRef("EffectShape"), Flags_ui = 0xE, Scale = 1f };
+        root.Children.AddBlockRef(f.AddBlock(shape));
+
+        // Authored on the SK layout so the block is read the same way the main fixture's is — the difference under
+        // test is the BLOCK TYPE, not the layout (that decline is the NOT-SKYRIM arm's job, and conflating the two
+        // would let either one pass for the wrong reason).
+        var shader = new BSEffectShaderProperty
+        {
+            Type = NiflySharp.Helpers.ShaderHelper.ShaderGameType.SK,
+            ShaderFlags_SSPF1 = NiflySharp.Enums.SkyrimShaderPropertyFlags1.Specular,
+            ShaderFlags_SSPF2 = NiflySharp.Enums.SkyrimShaderPropertyFlags2.ZBuffer_Write,
+            SourceTexture = new NiString4(@"textures\guard\effect.dds", false),
+        };
+        shape.ShaderPropertyRef = new NiBlockRef<BSShaderProperty>(f.AddBlock(shader));
+
+        using var ms = new MemoryStream();
+        if (f.Save(ms) != 0) throw new InvalidOperationException("nif-service-guard: authoring the synthetic effect-shader mesh failed to save");
+        return ms.ToArray();
+    }
+
     /// <summary>Author a minimal but genuine Skyrim SE mesh in-memory (the spike's CreateAndSave_SE recipe): an SE
     /// header, a 3-level NiNode tree with names + flags, and one BSTriShape carrying a name/flags/scale, two BSDismember
     /// partitions, and an alpha property. Every block is REFERENCED (parented / ref'd) so NiflySharp's save-time
@@ -427,6 +505,14 @@ internal static class NifServiceGuardProbe
                               | NiflySharp.Enums.SkyrimShaderPropertyFlags2.Double_Sided
                               | NiflySharp.Enums.SkyrimShaderPropertyFlags2.Soft_Lighting,
             EmissiveColor = new NiflySharp.Structs.Color4 { R = 0.25f, G = 0.5f, B = 0.75f, A = 1f },
+            // Each lighting scalar gets a DISTINCT non-zero value, so no arm below can pass on a coincidence with the
+            // constant (0, or 1 for Alpha) the interface stub used to hand back. Settable as plain properties since
+            // NiflySharp 1.1.0 (#287); before that the fixture had to reach the private backing fields.
+            EmissiveMultiple = 2.5f,
+            Glossiness = 30f,
+            SpecularStrength = 1.5f,
+            Alpha = 0.5f,
+            SpecularColor = new NiflySharp.Structs.Color3 { R = 1f, G = 0.5f, B = 0.25f },
         };
         var texSet = new BSShaderTextureSet
         {
@@ -440,14 +526,7 @@ internal static class NifServiceGuardProbe
             },
         };
         texSet.NumTextures = (uint)texSet.Textures.Count;
-        SetPrivate(shader, "_textureSet", new NiBlockRef<BSShaderTextureSet>(f.AddBlock(texSet)));
-        // The lighting scalars are serialized fields with no public setter, so the fixture writes them the same way.
-        // Without this they'd all author as 0 and the value arms would be unfalsifiable — a guard that cannot fail.
-        SetPrivate(shader, "_emissiveMultiple", 2.5f);
-        SetPrivate(shader, "_glossiness", 30f);
-        SetPrivate(shader, "_specularStrength", 1.5f);
-        SetPrivate(shader, "_alpha", 0.5f);
-        SetPrivate(shader, "_specularColor", new NiflySharp.Structs.Color3 { R = 1f, G = 0.5f, B = 0.25f });
+        shader.TextureSetRef = new NiBlockRef<BSShaderTextureSet>(f.AddBlock(texSet));
         shape.ShaderPropertyRef = new NiBlockRef<BSShaderProperty>(f.AddBlock(shader));
 
         var skin = new BSDismemberSkinInstance
@@ -466,18 +545,4 @@ internal static class NifServiceGuardProbe
         return ms.ToArray();
     }
 
-    /// <summary>Write one of NiflySharp's serialized-but-read-only shader fields, for the FIXTURE only. The texture-set
-    /// ref and every lighting scalar are populated on PARSE and exposed get-only (there is no NifFile helper to author
-    /// them), so a probe that needs a mesh carrying real shader values has to reach the backing field. Confined here —
-    /// product code only ever reads these — and it throws LOUD if a library update renames one, rather than quietly
-    /// authoring a shader full of zeros and leaving the value and slot-name arms passing vacuously (Q3: a guard that
-    /// cannot guard must say so, not go green).</summary>
-    static void SetPrivate(object block, string field, object value)
-    {
-        var f = block.GetType().GetField(field, System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
-            ?? throw new InvalidOperationException(
-                $"nif-service-guard: NiflySharp's {block.GetType().Name} no longer has a '{field}' field — the shader " +
-                "fixture needs updating before its arms mean anything (#272).");
-        f.SetValue(block, value);
-    }
 }

--- a/src/housecarl-generator/NifServiceGuardProbe.cs
+++ b/src/housecarl-generator/NifServiceGuardProbe.cs
@@ -255,10 +255,19 @@ internal static class NifServiceGuardProbe
         // the six read correctly on FO4 — so the layout sentence must appear and the library sentence must not, and
         // no lighting number may survive into the render (review of PR #290).
         Check(fo4Render.Contains("lighting values: NOT INTERPRETED for this block")
-              && fo4Render.Contains("glossiness is a constant 80 there")
+              && fo4Render.Contains("this layout's stream never carried")
               && !fo4Render.Contains("NOT READ by this NiflySharp version")
               && !fo4Render.Contains("glossiness 80") && !fo4Render.Contains("glossiness 30"),
               "NOT-SKYRIM-RENDER — the lighting decline states the LAYOUT as its reason, not the library, and prints no value");
+        // The decline sentence must make no NUMERIC claim about the block in hand. "constant 80" is a fact about
+        // BSLightingShaderProperty — the only one of the 17 INiShader blocks carrying Glossiness — so asserting it for
+        // "the FO3NV layout" would name a field an FO3NV lighting block does not have, while declining the emissive
+        // colour it genuinely reads. This arm exists because the previous revision PINNED that wrong sentence, which
+        // is how a guard locks a claim in instead of catching it (re-review of PR #290).
+        Check(!fo4Render.Contains("constant 80") && !System.Text.RegularExpressions.Regex.IsMatch(
+                  fo4Render, @"glossiness is a constant \d"),
+              "NOT-SKYRIM-RENDER — the decline asserts NO number about this block, since the one it used to name "
+              + "belongs to a single block type and not to any layout");
         var skRender = NifWire.Render(FakeData(outcome.Inspect, null), fo4Sections, Array.Empty<string>(), 80_000);
         Check(!skRender.Contains("NOT DERIVED"),
               "NOT-SKYRIM-RENDER — an ordinary Skyrim mesh carries none of that noise");

--- a/src/housecarl-generator/NifServiceGuardProbe.cs
+++ b/src/housecarl-generator/NifServiceGuardProbe.cs
@@ -225,6 +225,22 @@ internal static class NifServiceGuardProbe
         Check(fo4Shape is not null && fo4Shape.Textures.Count > 0 && fo4Shape.Textures.All(t => t.SlotName is null),
               "NOT-SKYRIM — every slot is UNNAMED on a non-SK layout, including the ones nifly's helpers answer "
               + $"'true' for — [{string.Join(", ", fo4Shape?.Textures.Select(t => $"tex[{t.Slot}]{(t.SlotName is null ? "" : " (" + t.SlotName + ")")}") ?? Array.Empty<string>())}]");
+        // THE LAYOUT GATE (review of PR #290). This fixture authors Glossiness=30 exactly as the SK one does, but on
+        // the FO4 layout that field is never serialized, so nifly's accessor answers its constructor default 80 — the
+        // same 80 whatever the mesh holds. ReallyReads keys on block TYPE and cannot see it: BSLightingShaderProperty
+        // really does implement Glossiness, just against a field this layout never carried. Before the gate this leg
+        // asserted slot naming only, so all 109 guards passed while `glossiness 80` shipped as a confident number.
+        // Pinned on the VALUE, not just on null-ness: 80 named here is what a regression would print.
+        var fo4Sh = fo4Shape?.Shader;
+        Check(fo4Sh is not null && fo4Sh.Glossiness is null && fo4Sh.SpecularStrength is null
+              && fo4Sh.SpecularColor is null && fo4Sh.EmissiveColor is null
+              && fo4Sh.EmissiveMultiple is null && fo4Sh.Alpha is null,
+              "NOT-SKYRIM — every lighting value is DECLINED on a non-SK layout, so the layout-dispatched constant "
+              + $"(glossiness 80, never the mesh's) cannot ship as a number — glossiness={Dec(fo4Sh?.Glossiness)} "
+              + $"specularStrength={Dec(fo4Sh?.SpecularStrength)} emissiveMultiple={Dec(fo4Sh?.EmissiveMultiple)} "
+              + $"alpha={Dec(fo4Sh?.Alpha)} "
+              + $"specularColor={(fo4Sh?.SpecularColor is null ? "declined" : "REPORTED")} "
+              + $"emissive={(fo4Sh?.EmissiveColor is null ? "declined" : "REPORTED")}");
 
         // The decline must reach the WIRE, not just the data model: a bare tex[2] on an SK mesh means "this shader
         // doesn't determine slot 2", and on an FO4 mesh it means "we don't model this layout" — byte-identical output,
@@ -235,6 +251,14 @@ internal static class NifServiceGuardProbe
         Check(fo4Render.Contains("NOT DERIVED for this block") && fo4Render.Contains("unmodelled, not undetermined")
               && System.Text.RegularExpressions.Regex.Matches(fo4Render, "NOT DERIVED").Count >= 3,
               "NOT-SKYRIM-RENDER — the decline is STATED in the shader section and caveated on both slot-listing sections");
+        // The lighting decline needs its OWN reason on the wire. Blaming the library here would be false — four of
+        // the six read correctly on FO4 — so the layout sentence must appear and the library sentence must not, and
+        // no lighting number may survive into the render (review of PR #290).
+        Check(fo4Render.Contains("lighting values: NOT INTERPRETED for this block")
+              && fo4Render.Contains("glossiness is a constant 80 there")
+              && !fo4Render.Contains("NOT READ by this NiflySharp version")
+              && !fo4Render.Contains("glossiness 80") && !fo4Render.Contains("glossiness 30"),
+              "NOT-SKYRIM-RENDER — the lighting decline states the LAYOUT as its reason, not the library, and prints no value");
         var skRender = NifWire.Render(FakeData(outcome.Inspect, null), fo4Sections, Array.Empty<string>(), 80_000);
         Check(!skRender.Contains("NOT DERIVED"),
               "NOT-SKYRIM-RENDER — an ordinary Skyrim mesh carries none of that noise");
@@ -368,6 +392,10 @@ internal static class NifServiceGuardProbe
     /// <summary>A nullable float for a probe DETAIL string — "unread" is the answer being asserted, so it has to be
     /// visible in the output rather than rendering as an empty string that reads like a zero.</summary>
     static string Fmt(float? f) => f is { } v ? v.ToString(System.Globalization.CultureInfo.InvariantCulture) : "unread";
+
+    /// <summary>As <see cref="Fmt"/>, but for the LAYOUT decline — where null means houseCARL declined to interpret,
+    /// not that the library stubs the accessor. Two different reasons, so two different words in the detail line.</summary>
+    static string Dec(float? f) => f is { } v ? v.ToString(System.Globalization.CultureInfo.InvariantCulture) : "declined";
 
     static bool CensusHas(NifInspect nif, string type, int count) => nif.BlockTypes.Any(t => t.Type == type && t.Count == count);
 

--- a/src/housecarl-mcp/NifTools.cs
+++ b/src/housecarl-mcp/NifTools.cs
@@ -504,8 +504,8 @@ static class NifWire
             sb.Append("    lighting values: NOT INTERPRETED for this block — houseCARL models the Skyrim shader "
                       + "layout, and this reads as the ").Append(sh.GameType).Append(" layout. Some of these "
                       + "accessors read a field this layout's stream never carried, so they would answer a constant "
-                      + "rather than this mesh's value (on a lighting shader, glossiness is the live case). Rather "
-                      + "than interpret some and guess at the rest, all are declined: ")
+                      + "rather than this mesh's value (glossiness is the live case, on a block that carries it). "
+                      + "Rather than interpret some and guess at the rest, all are declined: ")
               .Append(string.Join(", ", missing)).Append(". NifSkope reads this mesh's own layout.\n");
             return;
         }

--- a/src/housecarl-mcp/NifTools.cs
+++ b/src/housecarl-mcp/NifTools.cs
@@ -39,8 +39,9 @@ public static class NifTools
          "documented default plus the 0x80000 bit) and scale, the BSDismember body-part " +
          "partitions (decoded to their SBP_* names), the alpha property (decoded blend / test / threshold), the SHADER " +
          "property (block type, the shader TYPE enum — SkinTint / FaceTint / HairTint / EnvironmentMap / Parallax / … — " +
-         "the SLSF1+SLSF2 flags decoded to their names, and the emissive colour; any lighting value the underlying mesh " +
-         "library only stubs is NAMED as unread rather than reported as a wrong constant), the embedded " +
+         "the SLSF1+SLSF2 flags decoded to their names, and the lighting values — emissive colour and multiple, " +
+         "glossiness, specular strength and colour, alpha; any one the underlying mesh library only stubs for that " +
+         "block type is NAMED as unread rather than reported as a wrong constant), the embedded " +
          "texture-set paths with their semantic slot names where the shader determines them, and the bone list; plus the node tree and the header string table. Use it to answer 'what " +
          "shapes / bones / textures / partitions / alpha does this mesh have', 'does this mesh glow / use soft lighting / " +
          "subsurface skin / env-mapping', to read a facegen mesh's baked shape names " +

--- a/src/housecarl-mcp/NifTools.cs
+++ b/src/housecarl-mcp/NifTools.cs
@@ -40,8 +40,8 @@ public static class NifTools
          "partitions (decoded to their SBP_* names), the alpha property (decoded blend / test / threshold), the SHADER " +
          "property (block type, the shader TYPE enum — SkinTint / FaceTint / HairTint / EnvironmentMap / Parallax / … — " +
          "the SLSF1+SLSF2 flags decoded to their names, and the lighting values — emissive colour and multiple, " +
-         "glossiness, specular strength and colour, alpha; any one the underlying mesh library only stubs for that " +
-         "block type is NAMED as unread rather than reported as a wrong constant), the embedded " +
+         "glossiness, specular strength and colour, alpha; any one that would be a constant rather than this mesh's " +
+         "number is NAMED as unreported, with which reason, rather than printed), the embedded " +
          "texture-set paths with their semantic slot names where the shader determines them, and the bone list; plus the node tree and the header string table. Use it to answer 'what " +
          "shapes / bones / textures / partitions / alpha does this mesh have', 'does this mesh glow / use soft lighting / " +
          "subsurface skin / env-mapping', to read a facegen mesh's baked shape names " +
@@ -53,7 +53,7 @@ public static class NifTools
          "SUMMARY per mesh by default (header + census + shape names); pass sections to expand ('shapes','partitions','alpha'," +
          "'paths','shader','strings','nodes','bones', or 'all'). Pass mod= to inspect a specific provider instead of the winner; " +
          "sections, mod and max_chars apply to the whole batch. An " +
-         "unreadable archive, an absent path, or a mesh NiflySharp refuses (e.g. its strict non-0/1 boolean class) is " +
+         "unreadable archive, an absent path, or a mesh the underlying mesh library refuses is " +
          "reported LOUD by name — never a silent 'absent' or a half-answer. Read-only: resolves nothing to disk, writes " +
          "nothing, changes no load order. Scope: data values only; it does not read or edit geometry / visual content.")]
     public static string NifInspect(
@@ -487,15 +487,27 @@ static class NifWire
         if (sh.SpecularStrength is null) missing.Add("specular strength");
         if (sh.SpecularColor is null) missing.Add("specular colour");
         if (sh.Alpha is null) missing.Add("alpha");
-        if (missing.Count > 0)
-            // "WHERE THIS BLOCK CARRIES THEM" is doing real work: for a lighting shader the values genuinely are on
-            // disk and NifSkope shows them, but a BSEffectShaderProperty has no glossiness / specular-strength /
-            // specular-colour field AT ALL, so an unconditional "the values ARE in the file" would send the reader
-            // hunting in NifSkope for fields that don't exist (review of PR #286).
-            sb.Append("    NOT READ by this NiflySharp version — its accessor returns a constant for these, so ")
-              .Append("houseCARL reports nothing rather than a wrong number: ")
-              .Append(string.Join(", ", missing))
-              .Append(". Where this block carries them, NifSkope shows the real values.\n");
+        if (missing.Count == 0) return;
+        // TWO different reasons produce an unreported value, and saying the wrong one is its own wrong answer. On a
+        // non-Skyrim layout houseCARL declines them all as a matter of ITS OWN SCOPE — several read fine there, and
+        // blaming the library would be false — so that decline gets its own sentence (review of PR #290).
+        if (!IsSkyrimLayout(sh))
+        {
+            sb.Append("    lighting values: NOT INTERPRETED for this block — houseCARL models the Skyrim shader "
+                      + "layout, and this reads as the ").Append(sh.GameType).Append(" layout, where some of these "
+                      + "accessors answer a field the stream never carried (glossiness is a constant 80 there, not "
+                      + "the mesh's). Declined rather than guessed which: ")
+              .Append(string.Join(", ", missing)).Append(". NifSkope reads this mesh's own layout.\n");
+            return;
+        }
+        // "WHERE THIS BLOCK CARRIES THEM" is doing real work: for a lighting shader the values genuinely are on
+        // disk and NifSkope shows them, but a BSEffectShaderProperty has no glossiness / specular-strength /
+        // specular-colour field AT ALL, so an unconditional "the values ARE in the file" would send the reader
+        // hunting in NifSkope for fields that don't exist (review of PR #286).
+        sb.Append("    NOT READ by this NiflySharp version — its accessor returns a constant for these, so ")
+          .Append("houseCARL reports nothing rather than a wrong number: ")
+          .Append(string.Join(", ", missing))
+          .Append(". Where this block carries them, NifSkope shows the real values.\n");
     }
 
     static string ColorText(NifColor c) => $"rgb({Fmt(c.R)},{Fmt(c.G)},{Fmt(c.B)})";

--- a/src/housecarl-mcp/NifTools.cs
+++ b/src/housecarl-mcp/NifTools.cs
@@ -39,9 +39,11 @@ public static class NifTools
          "documented default plus the 0x80000 bit) and scale, the BSDismember body-part " +
          "partitions (decoded to their SBP_* names), the alpha property (decoded blend / test / threshold), the SHADER " +
          "property (block type, the shader TYPE enum — SkinTint / FaceTint / HairTint / EnvironmentMap / Parallax / … — " +
-         "the SLSF1+SLSF2 flags decoded to their names, and the lighting values — emissive colour and multiple, " +
-         "glossiness, specular strength and colour, alpha; any one that would be a constant rather than this mesh's " +
-         "number is NAMED as unreported, with which reason, rather than printed), the embedded " +
+         "the SLSF1+SLSF2 flags decoded to their names, and the lighting values on a Skyrim-layout shader — emissive " +
+         "colour and multiple, glossiness, specular strength and colour, alpha. Anything not reported is NAMED, with " +
+         "its reason: the library stubs that accessor for that block type, or the mesh reads as another game's " +
+         "layout, where houseCARL declines the group rather than interpret the ones that survive the layout change " +
+         "and guess at the rest), the embedded " +
          "texture-set paths with their semantic slot names where the shader determines them, and the bone list; plus the node tree and the header string table. Use it to answer 'what " +
          "shapes / bones / textures / partitions / alpha does this mesh have', 'does this mesh glow / use soft lighting / " +
          "subsurface skin / env-mapping', to read a facegen mesh's baked shape names " +
@@ -493,10 +495,17 @@ static class NifWire
         // blaming the library would be false — so that decline gets its own sentence (review of PR #290).
         if (!IsSkyrimLayout(sh))
         {
+            // NO NUMBER HERE, and the one example is SCOPED to the block it is true of (re-review of PR #290). The
+            // "constant 80" this sentence used to assert is a fact about BSLightingShaderProperty, not about a layout:
+            // of the 17 blocks implementing INiShader, that is the only one carrying Glossiness at all. On an FO3NV or
+            // Oblivion-era lighting block the claim named a field the block does not have — while declining the
+            // emissive colour it genuinely does read, for a reason that did not apply to it. That is the same
+            // type-vs-layout conflation this decline exists to fix, running the other way.
             sb.Append("    lighting values: NOT INTERPRETED for this block — houseCARL models the Skyrim shader "
-                      + "layout, and this reads as the ").Append(sh.GameType).Append(" layout, where some of these "
-                      + "accessors answer a field the stream never carried (glossiness is a constant 80 there, not "
-                      + "the mesh's). Declined rather than guessed which: ")
+                      + "layout, and this reads as the ").Append(sh.GameType).Append(" layout. Some of these "
+                      + "accessors read a field this layout's stream never carried, so they would answer a constant "
+                      + "rather than this mesh's value (on a lighting shader, glossiness is the live case). Rather "
+                      + "than interpret some and guess at the rest, all are declined: ")
               .Append(string.Join(", ", missing)).Append(". NifSkope reads this mesh's own layout.\n");
             return;
         }


### PR DESCRIPTION
Closes #287.

ousnius cut **NiflySharp 1.1.0** on 2026-07-26, in response to [the release request](https://github.com/ousnius/NiflySharp/issues/30) #287 filed. This takes it.

## What the bump buys

**The visible half — the five shader values.** #272 shipped `sections=shader` *around* an upstream gap: `BSLightingShaderProperty` answered `Glossiness` / `SpecularStrength` / `SpecularColor` / `EmissiveMultiple` / `Alpha` from `INiShader`'s default-interface stub, which returns a constant regardless of what the mesh holds, so houseCARL named them as unread rather than print a wrong number. 1.1.0 implements all five.

`NifService.ReallyReads` detects implementation off the **interface map**, not a hand-kept list — so the five started reporting **with no change to the detection logic at all**. That was the promise #272 made when it chose by-construction over a list of "the five nifly stubs"; this is it being collected.

**The invisible half, and the reason the bump stands on its own.** Upstream's most recent work is a code audit fixing *crashes, hangs, data corruption and leaks*, plus ~13 community fixes (UV writes landing in the wrong buffer, a `Load(string)` handle leak, `NiBlockRefArray.Resize`). Every mesh read and write houseCARL does now runs on that code.

## The #287 gate: parse fidelity re-proven, not assumed

#287 named the gate explicitly — the 99.98% / 100.00% claim is a property of *that library build*, so a bump has to re-earn it.

The July baseline could not serve as the control: the workspace corpus has grown **69,088 → 72,739** meshes since 2026-07-08, so diffing against `fullscan.json` would conflate library delta with corpus drift. Both versions were instead run **back to back over today's corpus** and diffed **file by file** — a percentage matching is not the check, since two runs can hit the same totals while disagreeing about which files.

| | 1.0.0 | 1.1.0 |
|---|---|---|
| loose meshes scanned | 72,739 | 72,739 |
| parsed clean | 72,729 (99.99%) | **72,738 (100.00%)** |
| refused | 10 | **1** |
| carrying unrecognised blocks | 3 | **0** |
| round-trip byte-identical | 53,579 | 53,579 |
| vanilla (18,862 Bethesda meshes) | 100.00% | 100.00%, **0 files changed verdict** |

**14 files changed verdict. Every one is an improvement or neutral; nothing regressed.**

- **9 meshes 1.0.0 threw on now parse.** `Exception: Byte value for boolean is > 2!` — Glorious Doors of Skyrim, Golden Dwemer Pipeworks, and every door in Reimperialized Abandoned Prison among them. These were **unreadable to houseCARL entirely**; they are readable now.
- **3 meshes that parsed but carried `NiUnknown` blocks now parse fully** — BodySlide's Starfield/FO4 skeleton references (1.1.0 adds SF stream 172–175).
- **The 1 remaining unreadable mesh now refuses cleanly** (`Load()=1`) instead of throwing an `OverflowException` — a better failure mode for the same file.
- **One round-trip got closer to source**: an Oblivion skeleton's 72-byte length mismatch went to 0, with fewer differing bytes.
- No mesh that parsed stopped parsing. No mesh that round-tripped byte-identical stopped. Vanilla is verdict-for-verdict identical across all 18,862.

Scan harness: `dev/references/spike-nif` (`scan` mode) plus a new `diff_ab.py` that walks the per-file records rather than the summary lines. ~35 min per leg.

## One API break

`INiShader.SpecularColor` moved `Vector3` → `Color3`. Fixing it let the duplicated emissive branch collapse into the same `Rgb3` helper, since both colours now arrive as nifly colour structs.

## The guard — the tripwire fires, and the other half gets a subject

#287 predicted the guard work exactly: *"only the guard arm in `nif-service-guard` (which currently asserts they are reported as unread) needs flipping to assert real values."* Done — and each authored value is still **distinct from the stub constant it replaced** (`0`, or `1` for Alpha), so the arm is the same tripwire read the other way: a regression to the stub fails loudly instead of printing a confident wrong number. The fixture's six `SetPrivate` reflection calls become plain property sets (1.1.0 makes `TextureSetRef` and the scalars settable), and `SetPrivate` is deleted.

**One thing #287 did not anticipate.** Flipping that arm alone would have left `ReallyReads` exercised only on its **YES** branch. Delete the check, or make it answer true unconditionally, and every arm in the probe stays green — while an effect shader starts reporting `glossiness 0, alpha 1` on every such mesh in the load order. That is precisely the silent-wrong-answer #272 was built to prevent, and nothing would have caught it.

So the **NO** branch gets its own subject rather than riding on whatever upstream happens not to have implemented this month: 1.1.0 still stubs all six on `BSEffectShaderProperty`, and a new fixture pins that houseCARL reports them as unread and **says so on the wire**. Verified falsifiable by neutering `ReallyReads` — it fails with `emissive=REPORTED ... glossiness=0 ... alpha=1`, and no other arm in the probe does.

**109/109 CI guards pass.**

## Not in this PR

The bump also makes those six values **settable** on `BSLightingShaderProperty` — under 1.0.0 a `nif_set` shader-value write op was not merely unbuilt but unbuildable. Filed to the backlog rather than widened into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
