### PR TITLE
feat(nif): set_shader_value — write a mesh's six shader lighting values

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -14,8 +14,9 @@ strength, specular colour, emissive colour, emissive multiple,* and *alpha*. Pas
 number for a scalar (`glossiness` `55`), three comma-separated components for a colour (`specular_color`
 `1,0.5,0.25`). Colours and alpha are conventionally 0–1 rather than 0–255 — a value outside that range is still
 written (the format stores the number it is given, and real meshes do carry out-of-range values), but the result
-says so, which is what catches a `255,255,255` pasted out of NifSkope's colour picker. It rides the same lanes and the same two verification gates as every other op: by default the edited
-mesh lands in a new MO2 mod folder with the original untouched, and a write that did not actually persist is refused
+says so, which is what catches a `255,255,255` pasted out of NifSkope's colour picker. It rides the same lanes and
+the same two verification gates as every other op: by default the edited mesh lands in a new MO2 mod folder with the
+original untouched, and a write that did not actually persist is refused
 rather than reported as success. This is the fix for an armour that reads shiny and plastic because its specular
 strength came in wrong, a glow mesh whose emissive multiple is off by an order of magnitude, or a folder of BodySlide
 output sharing one bad glossiness — previously NifSkope, by hand, one mesh at a time. Note it is **not** `set_alpha`,

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -11,8 +11,10 @@ when it changes.
 **`nif_set` can now write a mesh's shader lighting values — the read/write asymmetry #287 opened is closed (#291).**
 A new `op=set_shader_value` sets any of the six values `nif_inspect sections=shader` reports: *glossiness, specular
 strength, specular colour, emissive colour, emissive multiple,* and *alpha*. Pass `shader_value=` and `value=` — one
-number for a scalar (`glossiness` `55`), three comma-separated 0–1 components for a colour (`specular_color`
-`1,0.5,0.25`). It rides the same lanes and the same two verification gates as every other op: by default the edited
+number for a scalar (`glossiness` `55`), three comma-separated components for a colour (`specular_color`
+`1,0.5,0.25`). Colours and alpha are conventionally 0–1 rather than 0–255 — a value outside that range is still
+written (the format stores the number it is given, and real meshes do carry out-of-range values), but the result
+says so, which is what catches a `255,255,255` pasted out of NifSkope's colour picker. It rides the same lanes and the same two verification gates as every other op: by default the edited
 mesh lands in a new MO2 mod folder with the original untouched, and a write that did not actually persist is refused
 rather than reported as success. This is the fix for an armour that reads shiny and plastic because its specular
 strength came in wrong, a glow mesh whose emissive multiple is off by an order of magnitude, or a folder of BodySlide

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,26 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**`nif_set` can now write a mesh's shader lighting values — the read/write asymmetry #287 opened is closed (#291).**
+A new `op=set_shader_value` sets any of the six values `nif_inspect sections=shader` reports: *glossiness, specular
+strength, specular colour, emissive colour, emissive multiple,* and *alpha*. Pass `shader_value=` and `value=` — one
+number for a scalar (`glossiness` `55`), three comma-separated 0–1 components for a colour (`specular_color`
+`1,0.5,0.25`). It rides the same lanes and the same two verification gates as every other op: by default the edited
+mesh lands in a new MO2 mod folder with the original untouched, and a write that did not actually persist is refused
+rather than reported as success. This is the fix for an armour that reads shiny and plastic because its specular
+strength came in wrong, a glow mesh whose emissive multiple is off by an order of magnitude, or a folder of BodySlide
+output sharing one bad glossiness — previously NifSkope, by hand, one mesh at a time. Note it is **not** `set_alpha`,
+which remains the separate `NiAlphaProperty` blend/test word; `set_shader_value alpha` is the shader's own opacity
+scalar.
+**It refuses rather than pretending on a block that cannot carry the value.** The library implements these six on a
+`BSLightingShaderProperty` and answers them from a do-nothing stub on other shader blocks — so writing to, say, a
+`BSEffectShaderProperty` would have accepted the value, reported success, and left the mesh unchanged. houseCARL
+checks whether the specific block genuinely accepts the write, and where it does not, refuses and names the block
+type. Which blocks those are is read out of the bundled library rather than kept as a list, so the answer tracks the
+library across future updates instead of going stale — the same by-construction approach the read side already uses,
+though it necessarily asks a different question, since the values are read-only on the shared interface and settable
+only on the concrete block.
+
 **The bundled mesh library moves to NiflySharp 1.1.0 — `nif_inspect` gains five shader values, and mesh reads pick up
 upstream's crash/corruption fixes (#287).**
 The pinned 1.0.0 was published from a commit 52 changes behind upstream, and the gap was costing two different things.

--- a/src/housecarl-core/NifService.cs
+++ b/src/housecarl-core/NifService.cs
@@ -324,23 +324,55 @@ public static class NifService
     /// the vocabulary <c>set_shader_value</c> accepts, and exactly the six <see cref="NifShader"/> reports. The property
     /// names come through <c>nameof</c>, so an upstream rename is a COMPILE error here rather than a runtime "unknown
     /// value" a caller would read as "houseCARL can't do that yet".</summary>
-    internal static readonly IReadOnlyList<(string Wire, string Property)> ShaderValueNames = new[]
+    /// <para><c>Normalized</c> marks the values Skyrim's shader treats as 0–1 — a CONVENTION, and deliberately not
+    /// enforced. Scanning 40,000 workspace meshes (190,298 SK lighting shaders) found the format carries whatever it is
+    /// given and real meshes exceed the convention: 261 shapes with <c>alpha</c> above 1 (max 100), 155 emissive-colour
+    /// components above 1 (and 10 NEGATIVE), 4 specular-colour components above 1. Refusing those would refuse edits to
+    /// meshes that exist. So an out-of-convention write WARNS on the report and proceeds — enough to catch the likely
+    /// mistake (NifSkope shows colours 0–255, so <c>255,255,255</c> is the natural wrong input) without houseCARL
+    /// asserting a bound the format does not have. The other three are legitimately unbounded: the same scan saw
+    /// glossiness to 900,000 and specular strength to 100.</para>
+    internal static readonly IReadOnlyList<(string Wire, string Property, bool Normalized)> ShaderValueNames = new[]
     {
-        ("emissive_color",    nameof(INiShader.EmissiveColor)),
-        ("emissive_multiple", nameof(INiShader.EmissiveMultiple)),
-        ("glossiness",        nameof(INiShader.Glossiness)),
-        ("specular_strength", nameof(INiShader.SpecularStrength)),
-        ("specular_color",    nameof(INiShader.SpecularColor)),
-        ("alpha",             nameof(INiShader.Alpha)),
+        ("emissive_color",    nameof(INiShader.EmissiveColor),    true),
+        ("emissive_multiple", nameof(INiShader.EmissiveMultiple), false),
+        ("glossiness",        nameof(INiShader.Glossiness),       false),
+        ("specular_strength", nameof(INiShader.SpecularStrength), false),
+        ("specular_color",    nameof(INiShader.SpecularColor),    true),
+        ("alpha",             nameof(INiShader.Alpha),            true),
     };
+
+    /// <summary>A WARN-and-proceed note when a write lands outside the 0–1 convention on a value that follows it, or
+    /// null. Never a refusal — see the note on <see cref="ShaderValueNames"/>: real meshes carry out-of-range values, so
+    /// blocking would refuse legitimate edits. It names the NifSkope 0–255 confusion because that is the mistake this
+    /// actually catches (review of PR #292 — the 0–1 range had been asserted in three places and enforced in none).</summary>
+    internal static string? ShaderRangeWarning(string wire, IReadOnlyList<float> nums)
+    {
+        var prop = ShaderValueProperty(wire);
+        if (prop is null) return null;
+        bool normalized = false;
+        foreach (var (_, p, n) in ShaderValueNames) if (p == prop) normalized = n;
+        if (!normalized) return null;
+        var bad = nums.Where(v => v < 0f || v > 1f).ToList();
+        if (bad.Count == 0) return null;
+        return $"{WireName(prop)} was set to {string.Join(", ", bad.Select(v => v.ToString(System.Globalization.CultureInfo.InvariantCulture)))} "
+             + "— outside the 0-1 range Skyrim's shader treats this value as. Written as asked (the format stores the "
+             + "float given, and real meshes do carry out-of-range values), but if this came from NifSkope's 0-255 "
+             + "colour picker, divide by 255.";
+    }
 
     /// <summary>Resolve a caller's value name to its library property, or null. Accepts the British spelling too
     /// (<c>specular_colour</c>) — the renderer says "colour" while the library says "Color", and a caller reading one
-    /// and typing it at the other should not get "unknown value".</summary>
+    /// and typing it at the other should not get "unknown value".
+    ///
+    /// ORDER MATTERS: the case fold runs BEFORE the colour→color rewrite. <c>string.Replace</c> is ordinal and
+    /// case-sensitive, so rewriting first would leave <c>Specular_Colour</c> untouched and then fail to match —
+    /// the alias would serve only callers who already typed it in lower case, i.e. fail exactly the two names it
+    /// exists for while every American spelling resolved at any case (review of PR #292).</summary>
     public static string? ShaderValueProperty(string wire)
     {
-        var w = (wire ?? "").Trim().Replace('-', '_').Replace("colour", "color").ToLowerInvariant();
-        foreach (var (n, p) in ShaderValueNames) if (n == w) return p;
+        var w = (wire ?? "").Trim().Replace('-', '_').ToLowerInvariant().Replace("colour", "color");
+        foreach (var (n, p, _) in ShaderValueNames) if (n == w) return p;
         return null;
     }
 
@@ -367,12 +399,19 @@ public static class NifService
     /// The COMPONENT COUNT is likewise read off the library's own property type rather than declared: a Single takes
     /// one number, a Color3/Color4 takes three (detected by the R/G/B fields, so a future widening or narrowing of the
     /// colour struct doesn't silently change the arity houseCARL enforces).</summary>
-    internal static (bool CanWrite, int Components) ReallyWrites(Type blockType, string property)
+    internal static NifShaderWritability ReallyWrites(Type blockType, string property)
     {
         var p = blockType.GetProperty(property, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
-        if (p is null || !p.CanWrite) return (false, 0);
-        if (p.PropertyType == typeof(float)) return (true, 1);
-        return HasRgbFields(p.PropertyType) ? (true, 3) : (false, 0);
+        if (p is null || !p.CanWrite) return NifShaderWritability.NoSetter();
+        if (p.PropertyType == typeof(float)) return NifShaderWritability.Ok(1);
+        if (HasRgbFields(p.PropertyType)) return NifShaderWritability.Ok(3);
+        // SETTABLE, but of a shape houseCARL has no marshalling for. A DIFFERENT fact from "no setter", and it must
+        // not borrow that one's sentence: a future library that exposes the colour components as properties rather
+        // than public fields, or widens a scalar past Single, lands here with a perfectly writable property — and
+        // "not settable on that block type" would then be a confident false claim about the library, in the very
+        // message whose job is naming the real reason. The refusal is still right; only the reason differs
+        // (review of PR #292 — the same two-axes conflation #290's review caught, one layer down).
+        return NifShaderWritability.UnknownType(p.PropertyType.Name);
     }
 
     static bool HasRgbFields(Type t)
@@ -386,7 +425,7 @@ public static class NifService
     /// vocabulary, not the library's.</summary>
     static string WireName(string property)
     {
-        foreach (var (w, p) in ShaderValueNames) if (p == property) return w;
+        foreach (var (w, p, _) in ShaderValueNames) if (p == property) return w;
         return property;
     }
 
@@ -599,9 +638,19 @@ public static class NifService
         var g2 = VerifyReadBack(edited, pre, ops, out var warnings);
         if (g2 is not null) return NifSetOutcome.Fail(g2);
 
+        // WARN-and-proceed notes raised by the ops themselves (an out-of-convention shader value), ahead of the
+        // read-back's own. Gathered only now: a warning about a write that then failed verification would be noise
+        // about something that never happened.
+        var allWarnings = new List<string>();
+        foreach (var op in ops)
+            if (op.Kind == NifSetOpKind.SetShaderValue && op.ShaderValue is { } sv
+                && ShaderRangeWarning(sv, op.ShaderNumbers ?? Array.Empty<float>()) is { } rw)
+                allWarnings.Add(rw);
+        allWarnings.AddRange(warnings);
+
         var report = new NifSetReport(applied,
             expectedBlocks.OrderBy(i => i).ToList(), expectHeader,
-            edited.Length - bytes.Length, warnings);
+            edited.Length - bytes.Length, allWarnings);
         return new NifSetOutcome(edited, report, null);
     }
 
@@ -730,14 +779,20 @@ public static class NifService
                 // (which is get-only throughout), so this reflects the block's own property. A block whose accessor
                 // the library only stubs is named in the refusal, exactly as sections=shader names its unread values.
                 var bt = shader.GetType();
-                var (canWrite, components) = ReallyWrites(bt, prop);
-                if (!canWrite)
+                var w = ReallyWrites(bt, prop);
+                if (!w.Writable && w.UnknownTypeName is { } badType)
+                    return ($"this NiflySharp version exposes {WireName(prop)} on a {bt.Name} as a {badType}, which houseCARL has no "
+                          + "marshalling for — the value IS settable, but houseCARL will not write a shape it cannot convert "
+                          + "correctly. Refusing rather than guess (Q3). Please file this: it means the bundled library changed "
+                          + "the value's type. Nothing was written.", null, null, null, null, false);
+                if (!w.Writable)
                     return ($"this NiflySharp version cannot write {WireName(prop)} on a {bt.Name} — the value is not settable on that "
                           + "block type, so the write would be accepted and change nothing. Refusing (Q3). "
                           + $"housecarl_nif_inspect sections=shader names what it can and cannot see on this block. Nothing was written.", null, null, null, null, false);
+                var components = w.Components;
                 if (nums.Count != components)
                     return ($"{WireName(prop)} on a {bt.Name} takes {components} number{(components == 1 ? "" : "s")}"
-                          + $"{(components == 3 ? " (r,g,b — each 0-1)" : "")}; got {nums.Count}. Nothing was written.", null, null, null, null, false);
+                          + $"{(components == 3 ? " (r,g,b — conventionally 0-1)" : "")}; got {nums.Count}. Nothing was written.", null, null, null, null, false);
 
                 var pi = bt.GetProperty(prop, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)!;
                 string before = DescribeShaderValue(pi.GetValue(shader), components);
@@ -1011,8 +1066,9 @@ public static class NifService
                 if (shader is null) return (false, "(no shader)");
                 if (op.ShaderValue is null || ShaderValueProperty(op.ShaderValue) is not { } prop) return (false, "(no value name)");
                 var bt = shader.GetType();
-                var (canWrite, components) = ReallyWrites(bt, prop);
-                var pi = canWrite ? bt.GetProperty(prop, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance) : null;
+                var w = ReallyWrites(bt, prop);
+                int components = w.Components;
+                var pi = w.Writable ? bt.GetProperty(prop, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance) : null;
                 if (pi is null) return (false, $"(not readable back on {bt.Name})");
                 var actual = pi.GetValue(shader);
                 var want = op.ShaderNumbers ?? Array.Empty<float>();
@@ -1143,6 +1199,24 @@ public sealed record NifNode(int Depth, string Name, uint Flags, string BlockTyp
 // ======================================================================
 //  NIF-layer WRITE model — the N2 whitelist op(s) and the verified outcome (Wave 2).
 // ======================================================================
+
+/// <summary>Whether a shader lighting value can be WRITTEN on a given block, and if not, WHY — three states, because
+/// two different facts refuse the write and each needs its own sentence (review of PR #292).
+/// <list type="bullet">
+/// <item><see cref="Writable"/> with <see cref="Components"/> — the library really carries a setter, taking that many
+/// float components (read off the property's own type: 1 for a scalar, 3 for a colour).</item>
+/// <item>no setter — the block only inherits <c>INiShader</c>'s do-nothing stub; a write there would silently no-op.
+/// This is the live case (<c>BSEffectShaderProperty</c>).</item>
+/// <item><see cref="UnknownTypeName"/> — a setter EXISTS but its type is not one houseCARL marshals. Not reachable on
+/// NiflySharp 1.1.0; it exists so a future library change produces an honest refusal instead of the no-setter
+/// claim.</item>
+/// </list></summary>
+internal readonly record struct NifShaderWritability(bool Writable, int Components, string? UnknownTypeName)
+{
+    public static NifShaderWritability Ok(int components) => new(true, components, null);
+    public static NifShaderWritability NoSetter() => new(false, 0, null);
+    public static NifShaderWritability UnknownType(string typeName) => new(false, 0, typeName);
+}
 
 /// <summary>The N2-whitelist write op kinds. Renames edit the header string table; the others edit one block.</summary>
 public enum NifSetOpKind { RenameShape, RenameNode, SetFlags, SetScale, SetPartition, SetAlpha, SetPath, SetShaderValue }

--- a/src/housecarl-core/NifService.cs
+++ b/src/housecarl-core/NifService.cs
@@ -320,6 +320,92 @@ public static class NifService
         return real.Contains(property);
     }
 
+    /// <summary>The six shader LIGHTING VALUES by their wire name, paired with the library property each addresses —
+    /// the vocabulary <c>set_shader_value</c> accepts, and exactly the six <see cref="NifShader"/> reports. The property
+    /// names come through <c>nameof</c>, so an upstream rename is a COMPILE error here rather than a runtime "unknown
+    /// value" a caller would read as "houseCARL can't do that yet".</summary>
+    internal static readonly IReadOnlyList<(string Wire, string Property)> ShaderValueNames = new[]
+    {
+        ("emissive_color",    nameof(INiShader.EmissiveColor)),
+        ("emissive_multiple", nameof(INiShader.EmissiveMultiple)),
+        ("glossiness",        nameof(INiShader.Glossiness)),
+        ("specular_strength", nameof(INiShader.SpecularStrength)),
+        ("specular_color",    nameof(INiShader.SpecularColor)),
+        ("alpha",             nameof(INiShader.Alpha)),
+    };
+
+    /// <summary>Resolve a caller's value name to its library property, or null. Accepts the British spelling too
+    /// (<c>specular_colour</c>) — the renderer says "colour" while the library says "Color", and a caller reading one
+    /// and typing it at the other should not get "unknown value".</summary>
+    public static string? ShaderValueProperty(string wire)
+    {
+        var w = (wire ?? "").Trim().Replace('-', '_').Replace("colour", "color").ToLowerInvariant();
+        foreach (var (n, p) in ShaderValueNames) if (n == w) return p;
+        return null;
+    }
+
+    /// <summary>Whether <paramref name="blockType"/> can really be WRITTEN at <paramref name="property"/> — and if so,
+    /// how many float components the value takes (1 for a scalar, 3 for a colour).
+    ///
+    /// THE READ GATE CANNOT ANSWER THIS, and that is the whole reason this method exists rather than reusing
+    /// <see cref="ReallyReads"/> (which #291 assumed it could). <see cref="INiShader"/> declares all six values
+    /// GET-ONLY, so there is no <c>set_</c> accessor on the interface map to detect: on the write side the interface
+    /// map is uniformly empty and would refuse everything. The setters live on the CONCRETE block class instead, so
+    /// that is what gets reflected — still by construction off the library, never a hand-kept list of "the block types
+    /// that work" (which moved once already between 1.0.0 and 1.1.0, and will move again).
+    ///
+    /// Getter-real and setter-present are INDEPENDENT FACTS that merely happen to agree today (verified across all 17
+    /// INiShader implementers on 1.1.0: BSLightingShaderProperty carries all six, BSShaderPPLightingProperty and
+    /// Lighting30ShaderProperty carry EmissiveColor, the other 14 carry none). Each path therefore checks its own —
+    /// asking the read gate about writability would be the same type-vs-layout style conflation PR #290's review
+    /// caught, one axis over.
+    ///
+    /// Without this gate the failure is a Q3 silent no-op: <c>BSEffectShaderProperty</c> answers all six from the
+    /// interface's default-implementation stub, so a write through the interface would discard the value, return
+    /// success, and leave the mesh unchanged.
+    ///
+    /// The COMPONENT COUNT is likewise read off the library's own property type rather than declared: a Single takes
+    /// one number, a Color3/Color4 takes three (detected by the R/G/B fields, so a future widening or narrowing of the
+    /// colour struct doesn't silently change the arity houseCARL enforces).</summary>
+    internal static (bool CanWrite, int Components) ReallyWrites(Type blockType, string property)
+    {
+        var p = blockType.GetProperty(property, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+        if (p is null || !p.CanWrite) return (false, 0);
+        if (p.PropertyType == typeof(float)) return (true, 1);
+        return HasRgbFields(p.PropertyType) ? (true, 3) : (false, 0);
+    }
+
+    static bool HasRgbFields(Type t)
+        => t.GetField("R") is not null && t.GetField("G") is not null && t.GetField("B") is not null;
+
+    /// <summary>The accepted shader_value names as one comma-separated list — built from the table, so a value added
+    /// there shows up in every refusal message with no second place to update.</summary>
+    public static string ShaderValueList => string.Join(", ", ShaderValueNames.Select(v => v.Wire));
+
+    /// <summary>The WIRE name for a library property — refusals and the before/after audit speak the caller's
+    /// vocabulary, not the library's.</summary>
+    static string WireName(string property)
+    {
+        foreach (var (w, p) in ShaderValueNames) if (p == property) return w;
+        return property;
+    }
+
+    /// <summary>A shader value rendered for the before/after audit: a scalar as itself, a colour as its rgb triple —
+    /// never any component past b, which the format does not carry (see the read-modify-write note in ApplyOp).</summary>
+    static string DescribeShaderValue(object? v, int components)
+    {
+        if (v is null) return "(null)";
+        if (components == 1) return Convert.ToSingle(v).ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var t = v.GetType();
+        var (r, g, b) = ReadRgb(v, t);
+        return $"rgb({r.ToString(System.Globalization.CultureInfo.InvariantCulture)},"
+             + $"{g.ToString(System.Globalization.CultureInfo.InvariantCulture)},"
+             + $"{b.ToString(System.Globalization.CultureInfo.InvariantCulture)})";
+    }
+
+    static (float R, float G, float B) ReadRgb(object v, Type t)
+        => ((float)t.GetField("R")!.GetValue(v)!, (float)t.GetField("G")!.GetValue(v)!, (float)t.GetField("B")!.GetValue(v)!);
+
     /// <summary>Decode one shader flag word into its NAMED bits plus the unnamed remainder. The names come from
     /// <see cref="Enum.GetValues(Type)"/> over nifly's own enum, so coverage is the library's coverage — no hand-kept
     /// bit table to drift. Members are peeled largest-first so a multi-bit combo member wins over its constituent bits
@@ -617,6 +703,63 @@ public static class NifService
                 tex.Content = op.Path; ts.Textures[slot] = tex;
                 return (null, op.Target, $"tex[{slot}]={before}", $"tex[{slot}]={op.Path}", BlockIndexOf(nif, ts), false);
             }
+            case NifSetOpKind.SetShaderValue:
+            {
+                if (string.IsNullOrWhiteSpace(op.ShaderValue)) return ($"set_shader_value needs a shader_value name ({ShaderValueList}).", null, null, null, null, false);
+                if (ShaderValueProperty(op.ShaderValue) is not { } prop)
+                    return ($"unknown shader_value '{op.ShaderValue}'. Use one of: {ShaderValueList}.", null, null, null, null, false);
+                var nums = op.ShaderNumbers ?? Array.Empty<float>();
+                var (shape, err) = ResolveShape(nif, op.Target);
+                if (err is not null) return (err, null, null, null, null, false);
+                if (nif.GetShader(shape!) is not { } shader)
+                    return ($"shape '{op.Target}' has no shader property — no lighting value to set. Nothing was written.", null, null, null, null, false);
+
+                // GATE A — THE LAYOUT. Same scope claim the read path makes (BuildShader): houseCARL interprets a
+                // SKYRIM shader. Several of these accessors are layout-dispatched — Glossiness reads a field the FO4+
+                // stream never carries — so on a foreign layout the write would land in a field that is never
+                // serialized: value accepted, mesh unchanged. Today Set() already refuses any non-SE-stream file
+                // before reaching here and an SE stream always parses as SK, so this is a SECOND gate rather than one
+                // catching a live case — stated as such, because Type is a settable property and the header-to-layout
+                // coupling is nifly's internal, not a guarantee houseCARL is owed. It can only refuse, never fabricate.
+                if (shader.Type != ShaderHelper.ShaderGameType.SK)
+                    return ($"shape '{op.Target}' carries a {shader.Type} shader layout, not Skyrim's — houseCARL models the Skyrim "
+                          + $"shader layout only, and some of these values address a field a {shader.Type} stream never carries "
+                          + "(the write would be accepted and change nothing). Refusing. Nothing was written.", null, null, null, null, false);
+
+                // GATE B — THE BLOCK TYPE. See ReallyWrites: the setters are on the concrete class, NOT on INiShader
+                // (which is get-only throughout), so this reflects the block's own property. A block whose accessor
+                // the library only stubs is named in the refusal, exactly as sections=shader names its unread values.
+                var bt = shader.GetType();
+                var (canWrite, components) = ReallyWrites(bt, prop);
+                if (!canWrite)
+                    return ($"this NiflySharp version cannot write {WireName(prop)} on a {bt.Name} — the value is not settable on that "
+                          + "block type, so the write would be accepted and change nothing. Refusing (Q3). "
+                          + $"housecarl_nif_inspect sections=shader names what it can and cannot see on this block. Nothing was written.", null, null, null, null, false);
+                if (nums.Count != components)
+                    return ($"{WireName(prop)} on a {bt.Name} takes {components} number{(components == 1 ? "" : "s")}"
+                          + $"{(components == 3 ? " (r,g,b — each 0-1)" : "")}; got {nums.Count}. Nothing was written.", null, null, null, null, false);
+
+                var pi = bt.GetProperty(prop, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)!;
+                string before = DescribeShaderValue(pi.GetValue(shader), components);
+                object boxed;
+                if (components == 1) boxed = nums[0];
+                else
+                {
+                    // READ-MODIFY-WRITE on the colour struct, for the same reason set_alpha does it: the value is a
+                    // STRUCT, so it must be rebuilt and re-assigned. Any component BEYOND rgb is carried over from the
+                    // current value rather than invented — EmissiveColor is a Color4 on the interface but a Color3 on
+                    // disk, so its A never round-trips (empirically always 0 after a save/load); writing a made-up A
+                    // would be fabricating a component the format does not carry.
+                    boxed = pi.GetValue(shader)!;
+                    var t = boxed.GetType();
+                    t.GetField("R")!.SetValue(boxed, nums[0]);
+                    t.GetField("G")!.SetValue(boxed, nums[1]);
+                    t.GetField("B")!.SetValue(boxed, nums[2]);
+                }
+                pi.SetValue(shader, boxed);
+                return (null, op.Target, $"{WireName(prop)}={before}",
+                        $"{WireName(prop)}={DescribeShaderValue(pi.GetValue(shader), components)}", BlockIndexOf(nif, shader), false);
+            }
             default:
                 return ($"unsupported op '{op.Kind}'.", null, null, null, null, false);
         }
@@ -856,6 +999,35 @@ public static class NifService
                 if (ts is null || op.TextureSlot is not { } slot || slot < 0 || slot >= ts.Textures.Count) return (false, "(no texset/slot)");
                 return ((ts.Textures[slot]?.Content ?? "") == op.Path, $"tex[{slot}]={ts.Textures[slot]?.Content}");
             }
+            case NifSetOpKind.SetShaderValue:
+            {
+                // The gate that matters most for THIS op. ApplyOp refuses a block whose setter the library only stubs,
+                // but that check believes the library about its own reflection surface; this one re-reads the SAVED
+                // AND RELOADED mesh, so a value that was accepted in memory and never serialized is caught here even
+                // if the gate ever mis-answers. Reading it back off the CONCRETE property (not INiShader) is what makes
+                // that true — the interface would hand back a stub constant and could false-pass.
+                var s = nif.GetShapes().FirstOrDefault(x => (x.Name?.String ?? "") == op.Target);
+                var shader = s is not null ? nif.GetShader(s) : null;
+                if (shader is null) return (false, "(no shader)");
+                if (op.ShaderValue is null || ShaderValueProperty(op.ShaderValue) is not { } prop) return (false, "(no value name)");
+                var bt = shader.GetType();
+                var (canWrite, components) = ReallyWrites(bt, prop);
+                var pi = canWrite ? bt.GetProperty(prop, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance) : null;
+                if (pi is null) return (false, $"(not readable back on {bt.Name})");
+                var actual = pi.GetValue(shader);
+                var want = op.ShaderNumbers ?? Array.Empty<float>();
+                if (want.Count != components) return (false, DescribeShaderValue(actual, components));
+                bool ok;
+                if (components == 1) ok = Math.Abs(Convert.ToSingle(actual) - want[0]) < 1e-6f;
+                else
+                {
+                    // RGB ONLY. A Color4's A is synthetic here — it is not on disk and reads back 0 whatever was
+                    // written — so comparing it would fail every colour write for a component the format never stored.
+                    var (r, g, b) = ReadRgb(actual!, actual!.GetType());
+                    ok = Math.Abs(r - want[0]) < 1e-6f && Math.Abs(g - want[1]) < 1e-6f && Math.Abs(b - want[2]) < 1e-6f;
+                }
+                return (ok, DescribeShaderValue(actual, components));
+            }
             default: return (false, "(unknown op)");
         }
     }
@@ -972,14 +1144,20 @@ public sealed record NifNode(int Depth, string Name, uint Flags, string BlockTyp
 //  NIF-layer WRITE model — the N2 whitelist op(s) and the verified outcome (Wave 2).
 // ======================================================================
 
-/// <summary>The six N2-whitelist write op kinds. Renames edit the header string table; the others edit one block.</summary>
-public enum NifSetOpKind { RenameShape, RenameNode, SetFlags, SetScale, SetPartition, SetAlpha, SetPath }
+/// <summary>The N2-whitelist write op kinds. Renames edit the header string table; the others edit one block.</summary>
+public enum NifSetOpKind { RenameShape, RenameNode, SetFlags, SetScale, SetPartition, SetAlpha, SetPath, SetShaderValue }
 
 /// <summary>One write op. <see cref="Target"/> is the shape/node name it addresses (the CURRENT name, for a rename).
 /// The value fields are read per <see cref="Kind"/> and are otherwise null: <see cref="NewName"/> (rename), <see
 /// cref="Flags"/> (set_flags), <see cref="Scale"/> (set_scale), <see cref="BodyPartId"/> + optional
 /// <see cref="PartitionIndex"/> (set_partition), <see cref="AlphaFlags"/> and/or <see cref="AlphaThreshold"/>
-/// (set_alpha), <see cref="TextureSlot"/> + <see cref="Path"/> (set_path — a BSShaderTextureSet slot).</summary>
+/// (set_alpha), <see cref="TextureSlot"/> + <see cref="Path"/> (set_path — a BSShaderTextureSet slot),
+/// <see cref="ShaderValue"/> + <see cref="ShaderNumbers"/> (set_shader_value — a shader lighting value; see
+/// <see cref="NifService.ShaderValueNames"/>).
+/// <para><see cref="ShaderNumbers"/> is deliberately an ARITY-FREE list rather than a scalar-or-colour pair: how many
+/// components a given value takes is a fact about the library's own property type (Single vs Color3 vs Color4), and
+/// keeping it there means one place decides it. A caller passing the wrong count gets a named refusal from
+/// <c>ApplyOp</c>, not a silently-truncated write.</para></summary>
 public sealed record NifSetOp(
     NifSetOpKind Kind,
     string Target,
@@ -991,7 +1169,9 @@ public sealed record NifSetOp(
     ushort? AlphaFlags = null,
     byte? AlphaThreshold = null,
     int? TextureSlot = null,
-    string? Path = null);
+    string? Path = null,
+    string? ShaderValue = null,
+    IReadOnlyList<float>? ShaderNumbers = null);
 
 /// <summary>The outcome of <see cref="NifService.Set"/>: exactly one of <see cref="WrittenBytes"/>+<see cref="Report"/>
 /// (success — the VERIFIED edited mesh bytes for the service layer to place) or <see cref="Error"/> (a named refusal,

--- a/src/housecarl-generator/NifSetGuardProbe.cs
+++ b/src/housecarl-generator/NifSetGuardProbe.cs
@@ -148,6 +148,98 @@ internal static class NifSetGuardProbe
             Check(real is null, $"gate 2 PASSES when read-back matches the request — {real ?? "ok"}");
         }
 
+        // ---- set_shader_value (#291): the six lighting values, gated on the BLOCK's own setter ----
+        Console.WriteLine();
+        Console.WriteLine("--- set_shader_value: writes where the block really carries the value, refuses loud where it doesn't ---");
+        {
+            var shBytes = BuildShaderSe();
+
+            // The DETECTION FACT this whole op rests on, pinned first (#291). The read gate (ReallyReads) walks the
+            // INiShader interface map; that CANNOT answer writability, because the interface declares all six
+            // GET-ONLY — there is no set_ accessor to find, so an interface-map write gate would refuse everything.
+            // If upstream ever adds interface setters, this arm fires and the write gate should be revisited.
+            var noIfaceSetters = new[] { "EmissiveColor", "EmissiveMultiple", "Glossiness", "SpecularStrength", "SpecularColor", "Alpha" }
+                .All(n => typeof(INiShader).GetProperty(n) is { CanWrite: false });
+            Check(noIfaceSetters, "INiShader still declares all six lighting values GET-ONLY — the reason the write gate reflects the CONCRETE block, not the interface map");
+
+            // The gate itself, on both branches. These are the two facts the refusal messages assert.
+            Check(NifService.ReallyWrites(typeof(BSLightingShaderProperty), "Glossiness") == (true, 1)
+                  && NifService.ReallyWrites(typeof(BSLightingShaderProperty), "SpecularColor") == (true, 3),
+                  "ReallyWrites says YES on BSLightingShaderProperty, with the component count read off the property TYPE (scalar 1 / colour 3)");
+            Check(NifService.ReallyWrites(typeof(BSEffectShaderProperty), "Glossiness") == (false, 0)
+                  && NifService.ReallyWrites(typeof(BSEffectShaderProperty), "Alpha") == (false, 0),
+                  "ReallyWrites says NO on BSEffectShaderProperty — the block whose accessor is the interface stub (a write there would silently no-op)");
+
+            // YES branch — every one of the six writes, survives the save/reload, and reads back as the NEW value.
+            // Each expected value is distinct from BOTH the fixture's authored value and the block's constructor
+            // default, so neither a dropped write nor a stub constant can pass.
+            foreach (var (name, nums, read) in new (string, float[], Func<NifShader, string>)[]
+            {
+                ("glossiness",        new[] { 55f },              s => Fmt2(s.Glossiness)),
+                ("specular_strength", new[] { 3.25f },            s => Fmt2(s.SpecularStrength)),
+                ("emissive_multiple", new[] { 7.5f },             s => Fmt2(s.EmissiveMultiple)),
+                ("alpha",             new[] { 0.125f },           s => Fmt2(s.Alpha)),
+                ("emissive_color",    new[] { 0.1f, 0.2f, 0.3f }, s => Rgb2(s.EmissiveColor)),
+                ("specular_color",    new[] { 0.4f, 0.6f, 0.8f }, s => Rgb2(s.SpecularColor)),
+            })
+            {
+                var o = NifService.Set(shBytes, new[] { new NifSetOp(NifSetOpKind.SetShaderValue, "LitShape", ShaderValue: name, ShaderNumbers: nums) });
+                var sh = ShapeOf(o.WrittenBytes, "LitShape")?.Shader;
+                string want = nums.Length == 1 ? Fmt2(nums[0]) : $"rgb({Fmt2(nums[0])},{Fmt2(nums[1])},{Fmt2(nums[2])})";
+                Check(o.Error is null && sh is not null && read(sh) == want,
+                      $"set_shader_value {name} -> {want} lands and reads back — {(o.Error ?? (sh is null ? "(no shader)" : read(sh)))}");
+            }
+
+            // A write changes ONLY the value it names — the other five survive untouched.
+            {
+                var o = NifService.Set(shBytes, new[] { new NifSetOp(NifSetOpKind.SetShaderValue, "LitShape", ShaderValue: "glossiness", ShaderNumbers: new[] { 55f }) });
+                var sh = ShapeOf(o.WrittenBytes, "LitShape")?.Shader;
+                Check(sh is not null && Fmt2(sh.SpecularStrength) == "1.5" && Fmt2(sh.EmissiveMultiple) == "2.5" && Fmt2(sh.Alpha) == "0.5"
+                      && Rgb2(sh.EmissiveColor) == "rgb(0.25,0.5,0.75)" && Rgb2(sh.SpecularColor) == "rgb(1,0.5,0.25)",
+                      "a glossiness write preserved the other five lighting values");
+                Check(o.Report is { Ops.Count: 1, HeaderChanged: false, ChangedBlocks.Count: 1 },
+                      "the report says: 1 op, header untouched, exactly ONE block changed (the shader)");
+            }
+
+            // NO/TYPE branch — the Q3 case this op exists to not commit. All six refuse on the effect shader, and the
+            // refusal NAMES the block type rather than failing vaguely.
+            foreach (var name in new[] { "glossiness", "specular_strength", "emissive_multiple", "alpha", "emissive_color", "specular_color" })
+            {
+                var nums = name.EndsWith("_color") ? new[] { 0.1f, 0.2f, 0.3f } : new[] { 1f };
+                var o = NifService.Set(shBytes, new[] { new NifSetOp(NifSetOpKind.SetShaderValue, "EffShape", ShaderValue: name, ShaderNumbers: nums) });
+                // Pin the CLAIM, not merely the wording. Naming the block type alone is too weak to be falsifiable:
+                // the arity refusal names it too (a non-writable value reports 0 components), so an arm checking only
+                // for "BSEffectShaderProperty" still passes with this gate deleted — it would ratify the right answer
+                // arriving for the wrong reason. Requiring the settability sentence makes deleting the gate fail here.
+                Check(o.Error is { } e && e.Contains("BSEffectShaderProperty") && e.Contains("not settable on that block type") && o.WrittenBytes is null,
+                      $"set_shader_value {name} on a BSEffectShaderProperty → refused AS UNSETTABLE, block type NAMED, nothing written — {o.Error ?? "WROTE ANYWAY"}");
+            }
+
+            // ARITY comes from the library's property type, so a wrong count is a named refusal — never a truncated
+            // or zero-padded write.
+            Check(NifService.Set(shBytes, new[] { new NifSetOp(NifSetOpKind.SetShaderValue, "LitShape", ShaderValue: "glossiness", ShaderNumbers: new[] { 1f, 2f, 3f }) }).Error is { } ea1 && ea1.Contains("takes 1 number"),
+                  "a scalar given 3 numbers → named refusal");
+            Check(NifService.Set(shBytes, new[] { new NifSetOp(NifSetOpKind.SetShaderValue, "LitShape", ShaderValue: "specular_color", ShaderNumbers: new[] { 1f }) }).Error is { } ea2 && ea2.Contains("takes 3 numbers"),
+                  "a colour given 1 number → named refusal");
+
+            // Vocabulary: unknown names refuse WITH the list; the British spelling resolves (the renderer says
+            // "colour", the library says "Color" — a caller reading one and typing it at the other is not an error).
+            Check(NifService.Set(shBytes, new[] { new NifSetOp(NifSetOpKind.SetShaderValue, "LitShape", ShaderValue: "shininess", ShaderNumbers: new[] { 1f }) }).Error is { } ev && ev.Contains("glossiness"),
+                  "an unknown shader_value → named refusal listing the accepted names");
+            Check(NifService.ShaderValueProperty("specular_colour") == "SpecularColor" && NifService.ShaderValueProperty("Glossiness") == "Glossiness",
+                  "the British spelling and mixed case both resolve");
+            Check(NifService.Set(shBytes, new[] { new NifSetOp(NifSetOpKind.SetShaderValue, "NoShaderShape", ShaderValue: "glossiness", ShaderNumbers: new[] { 1f }) }).Error is { } ens && ens.Contains("no shader property"),
+                  "set_shader_value on a shape with NO shader → named refusal");
+
+            // THE LAYOUT GATE's premise. ApplyOp declines any non-Skyrim shader layout, the same scope claim the read
+            // path makes — but Set() refuses a non-SE stream before ApplyOp is reached, and an SE stream always parses
+            // as the SK layout, so that gate is a SECOND one rather than one catching a live case. It is guarded by
+            // pinning exactly that premise: if an SE-stream mesh ever parses as some other layout, this fires and the
+            // gate stops being redundant. (Type is a settable property — the coupling is nifly's, not a guarantee.)
+            Check(ShapeOf(shBytes, "LitShape")?.Shader is { GameType: "SK" } && NifService.Inspect(shBytes).Inspect is { IsSkyrimSE: true },
+                  "an SE-stream mesh still parses its shader as the SK layout — the premise that makes the layout gate redundant rather than dead");
+        }
+
         // ---- refusal arms (Q3) ----
         Console.WriteLine();
         Console.WriteLine("--- refusals: a can't-do is named, nothing written ---");
@@ -290,6 +382,12 @@ internal static class NifSetGuardProbe
     static NifShape? ShapeOf(byte[]? bytes, string name)
         => bytes is null ? null : NifService.Inspect(bytes).Inspect?.Shapes.FirstOrDefault(s => s.Name == name);
 
+    /// <summary>A nullable shader scalar as invariant text — "(unread)" when the reader withheld it, which is a
+    /// DIFFERENT outcome from any number and must never compare equal to one.</summary>
+    static string Fmt2(float? v) => v is { } f ? f.ToString(System.Globalization.CultureInfo.InvariantCulture) : "(unread)";
+
+    static string Rgb2(NifColor? c) => c is { } k ? $"rgb({Fmt2(k.R)},{Fmt2(k.G)},{Fmt2(k.B)})" : "(unread)";
+
     /// <summary>Author a synthetic SE mesh: root → GuardChildA node; a full GuardShape (flags/scale/alpha/2 partitions);
     /// and a BareShape carrying nothing (for the not-applicable refusal arms). The spike CreateAndSave_SE recipe.</summary>
     static byte[] BuildSyntheticSe()
@@ -323,6 +421,46 @@ internal static class NifSetGuardProbe
 
         using var ms = new MemoryStream();
         if (f.Save(ms) != 0) throw new InvalidOperationException("nif-set-guard: authoring the synthetic SE mesh failed to save");
+        return ms.ToArray();
+    }
+
+    /// <summary>A synthetic SE mesh carrying BOTH shader block types (#291): 'LitShape' with a
+    /// BSLightingShaderProperty — the one block NiflySharp 1.1.0 makes all six lighting values settable on — and
+    /// 'EffShape' with a BSEffectShaderProperty, which answers all six from <c>INiShader</c>'s get-only stub and can
+    /// write none of them. Separate from <see cref="BuildSyntheticSe"/> so the shader arms cannot perturb the block
+    /// indices the gate-1 arms above depend on.
+    ///
+    /// Every value is authored AWAY from its constructor default, so a write arm that read the default back would
+    /// fail rather than coincidentally match (the stub-constant trap, one axis over).</summary>
+    static byte[] BuildShaderSe()
+    {
+        var ver = new NiVersion { FileVersion = NiVersion.ToFile("20.2.0.7"), UserVersion = 12, StreamVersion = 100 };
+        var f = new NifFile();
+        f.Create(ver, withRootNode: true);
+        var root = f.GetRootNodes().First(); root.Name = new NiStringRef("ShaderRoot"); root.Flags_ui = 0xE;
+
+        var lit = new BSTriShape { Name = new NiStringRef("LitShape"), Flags_ui = 0x400000E, Scale = 1f };
+        root.Children.AddBlockRef(f.AddBlock(lit));
+        var lsp = new BSLightingShaderProperty
+        {
+            Glossiness = 30f,
+            SpecularStrength = 1.5f,
+            EmissiveMultiple = 2.5f,
+            Alpha = 0.5f,
+            EmissiveColor = new NiflySharp.Structs.Color4(0.25f, 0.5f, 0.75f, 0f),
+            SpecularColor = new NiflySharp.Structs.Color3(1f, 0.5f, 0.25f),
+        };
+        lit.ShaderPropertyRef = new NiBlockRef<BSShaderProperty>(f.AddBlock(lsp));
+
+        var eff = new BSTriShape { Name = new NiStringRef("EffShape"), Flags_ui = 0x400000E, Scale = 1f };
+        root.Children.AddBlockRef(f.AddBlock(eff));
+        eff.ShaderPropertyRef = new NiBlockRef<BSShaderProperty>(f.AddBlock(new BSEffectShaderProperty()));
+
+        var noShader = new BSTriShape { Name = new NiStringRef("NoShaderShape"), Flags_ui = 0x400000E, Scale = 1f };
+        root.Children.AddBlockRef(f.AddBlock(noShader));
+
+        using var ms = new MemoryStream();
+        if (f.Save(ms) != 0) throw new InvalidOperationException("nif-set-guard: authoring the shader mesh failed to save");
         return ms.ToArray();
     }
 

--- a/src/housecarl-generator/NifSetGuardProbe.cs
+++ b/src/housecarl-generator/NifSetGuardProbe.cs
@@ -163,12 +163,19 @@ internal static class NifSetGuardProbe
             Check(noIfaceSetters, "INiShader still declares all six lighting values GET-ONLY — the reason the write gate reflects the CONCRETE block, not the interface map");
 
             // The gate itself, on both branches. These are the two facts the refusal messages assert.
-            Check(NifService.ReallyWrites(typeof(BSLightingShaderProperty), "Glossiness") == (true, 1)
-                  && NifService.ReallyWrites(typeof(BSLightingShaderProperty), "SpecularColor") == (true, 3),
+            Check(NifService.ReallyWrites(typeof(BSLightingShaderProperty), "Glossiness") is { Writable: true, Components: 1 }
+                  && NifService.ReallyWrites(typeof(BSLightingShaderProperty), "SpecularColor") is { Writable: true, Components: 3 },
                   "ReallyWrites says YES on BSLightingShaderProperty, with the component count read off the property TYPE (scalar 1 / colour 3)");
-            Check(NifService.ReallyWrites(typeof(BSEffectShaderProperty), "Glossiness") == (false, 0)
-                  && NifService.ReallyWrites(typeof(BSEffectShaderProperty), "Alpha") == (false, 0),
-                  "ReallyWrites says NO on BSEffectShaderProperty — the block whose accessor is the interface stub (a write there would silently no-op)");
+            // NO-SETTER vs UNKNOWN-TYPE are separate states, and the effect shader is specifically the FORMER. Checking
+            // only 'not writable' would let the two collapse again — and the refusal messages assert different facts.
+            Check(NifService.ReallyWrites(typeof(BSEffectShaderProperty), "Glossiness") is { Writable: false, UnknownTypeName: null }
+                  && NifService.ReallyWrites(typeof(BSEffectShaderProperty), "Alpha") is { Writable: false, UnknownTypeName: null },
+                  "ReallyWrites says NO-SETTER (not unknown-type) on BSEffectShaderProperty — the block whose accessor is the interface stub (a write there would silently no-op)");
+            // The unknown-type arm is unreachable through any real shader block on 1.1.0, so it is pinned on a stand-in
+            // with a settable property of a type houseCARL does not marshal. Without this, the third state ships
+            // unexercised and the branch that keeps its message honest is never proven to fire.
+            Check(NifService.ReallyWrites(typeof(UnmarshalableShaderStandIn), nameof(UnmarshalableShaderStandIn.Glossiness)) is { Writable: false, UnknownTypeName: "String" },
+                  "a SETTABLE property of an unmarshalable type reports unknown-type — a distinct state from no-setter, so the refusal cannot claim 'not settable'");
 
             // YES branch — every one of the six writes, survives the save/reload, and reads back as the NEW value.
             // Each expected value is distinct from BOTH the fixture's authored value and the block's constructor
@@ -226,10 +233,42 @@ internal static class NifSetGuardProbe
             // "colour", the library says "Color" — a caller reading one and typing it at the other is not an error).
             Check(NifService.Set(shBytes, new[] { new NifSetOp(NifSetOpKind.SetShaderValue, "LitShape", ShaderValue: "shininess", ShaderNumbers: new[] { 1f }) }).Error is { } ev && ev.Contains("glossiness"),
                   "an unknown shader_value → named refusal listing the accepted names");
-            Check(NifService.ShaderValueProperty("specular_colour") == "SpecularColor" && NifService.ShaderValueProperty("Glossiness") == "Glossiness",
-                  "the British spelling and mixed case both resolve");
+            // BOTH AXES AT ONCE, and that is the point. The first version of this arm tested British-lowercase and
+            // American-mixed-case separately, so it passed while 'Specular_Colour' — the combination, and the obvious
+            // thing a caller actually types — resolved to nothing: the rewrite ran before the case fold and could not
+            // match. An arm that never exercises the combination its wording claims is the "pins the wording, not the
+            // claim" shape (review of PR #292).
+            Check(NifService.ShaderValueProperty("Specular_Colour") == "SpecularColor"
+                  && NifService.ShaderValueProperty("EMISSIVE_COLOUR") == "EmissiveColor"
+                  && NifService.ShaderValueProperty("specular_colour") == "SpecularColor"
+                  && NifService.ShaderValueProperty("Glossiness") == "Glossiness"
+                  && NifService.ShaderValueProperty("specular-strength") == "SpecularStrength",
+                  "the British spelling resolves AT ANY CASE (not just lower), alongside mixed case and the hyphen form");
             Check(NifService.Set(shBytes, new[] { new NifSetOp(NifSetOpKind.SetShaderValue, "NoShaderShape", ShaderValue: "glossiness", ShaderNumbers: new[] { 1f }) }).Error is { } ens && ens.Contains("no shader property"),
                   "set_shader_value on a shape with NO shader → named refusal");
+
+            // THE 0-1 CONVENTION — warned, never enforced, and the choice is empirical rather than tidy. A scan of
+            // 40,000 workspace meshes (190,298 SK lighting shaders) found 261 shapes with alpha above 1 (max 100), 155
+            // emissive-colour components above 1, and 4 specular-colour components above 1 — so refusing out-of-range
+            // would refuse edits to meshes that exist. The write lands; the report says the number looks wrong. Before
+            // this, the 0-1 bound was asserted in three places and enforced in none (review of PR #292).
+            {
+                var o = NifService.Set(shBytes, new[] { new NifSetOp(NifSetOpKind.SetShaderValue, "LitShape", ShaderValue: "specular_color", ShaderNumbers: new[] { 255f, 255f, 255f }) });
+                var sh = ShapeOf(o.WrittenBytes, "LitShape")?.Shader;
+                Check(o.Error is null && Rgb2(sh?.SpecularColor) == "rgb(255,255,255)",
+                      $"an out-of-convention colour is WRITTEN, not refused (real meshes carry them) — {o.Error ?? Rgb2(sh?.SpecularColor)}");
+                Check(o.Report is { } rep && rep.Warnings.Any(x => x.Contains("outside the 0-1 range") && x.Contains("255")),
+                      $"…and the report WARNS, naming the NifSkope 0-255 confusion — {(o.Report is null ? "(no report)" : string.Join(" | ", o.Report.Warnings))}");
+                // The warning is scoped to the values the convention applies to: glossiness 900000 is real (the same
+                // scan saw exactly that), so warning about it would be crying wolf on a legitimate write.
+                var g = NifService.Set(shBytes, new[] { new NifSetOp(NifSetOpKind.SetShaderValue, "LitShape", ShaderValue: "glossiness", ShaderNumbers: new[] { 900f }) });
+                Check(g.Error is null && g.Report is { } grep2 && !grep2.Warnings.Any(x => x.Contains("outside the 0-1 range")),
+                      "an unbounded value (glossiness 900) is NOT warned about — the convention is per-value, not blanket");
+                // And a normalized value INSIDE the range stays quiet, so the warning means something when it appears.
+                var a = NifService.Set(shBytes, new[] { new NifSetOp(NifSetOpKind.SetShaderValue, "LitShape", ShaderValue: "alpha", ShaderNumbers: new[] { 0.25f }) });
+                Check(a.Error is null && a.Report is { } arep && !arep.Warnings.Any(x => x.Contains("outside the 0-1 range")),
+                      "an in-range alpha is not warned about");
+            }
 
             // THE LAYOUT GATE's premise. ApplyOp declines any non-Skyrim shader layout, the same scope claim the read
             // path makes — but Set() refuses a non-SE stream before ApplyOp is reached, and an SE stream always parses
@@ -381,6 +420,11 @@ internal static class NifSetGuardProbe
 
     static NifShape? ShapeOf(byte[]? bytes, string name)
         => bytes is null ? null : NifService.Inspect(bytes).Inspect?.Shapes.FirstOrDefault(s => s.Name == name);
+
+    /// <summary>A stand-in for the one <see cref="NifService.ReallyWrites"/> state no real NiflySharp 1.1.0 shader block
+    /// can produce: a lighting value that IS settable, of a type houseCARL has no marshalling for. It exists so that
+    /// state's refusal — which must NOT claim the value is unsettable — is exercised rather than shipped on trust.</summary>
+    sealed class UnmarshalableShaderStandIn { public string Glossiness { get; set; } = ""; }
 
     /// <summary>A nullable shader scalar as invariant text — "(unread)" when the reader withheld it, which is a
     /// DIFFERENT outcome from any number and must never compare equal to one.</summary>

--- a/src/housecarl-mcp/NifTools.cs
+++ b/src/housecarl-mcp/NifTools.cs
@@ -131,11 +131,14 @@ public static class NifTools
          "the edit before anything lands. Resolve the Data-relative mesh_path through Mod Organizer 2's VFS to the winning " +
          "copy (or mod=), apply the op, and pass it two offset-immune verification gates (only the block/value the op " +
          "claims to touch changed; a reload re-reads the new value; census + SE-stream intact) — a failure writes NOTHING " +
-         "and says why. The six ops (op=): rename_shape / rename_node (retitle a baked shape/node — the HDPT-EDID facegen " +
+         "and says why. The ops (op=): rename_shape / rename_node (retitle a baked shape/node — the HDPT-EDID facegen " +
          "case), set_flags (NiAVObject flags on a shape/node — the 0x80000 head/hair-class bit), set_scale, set_partition " +
          "(a BSDismember body-part id — pass body_part_id [+ partition_index]), set_alpha (alpha_flags word and/or " +
          "alpha_threshold — the hair 0x12ED / hairline 0x12EE class), set_path (swap a BSShaderTextureSet slot — pass " +
-         "texture_slot + path; e.g. the FaceTint slot 6 or skin slots 0/1). target= is the shape or node NAME the op edits " +
+         "texture_slot + path; e.g. the FaceTint slot 6 or skin slots 0/1), set_shader_value (a shader LIGHTING value — " +
+         "pass shader_value + value: glossiness, specular_strength, specular_color, emissive_color, emissive_multiple, " +
+         "alpha; the plastic-looking armour or over-bright glow fix. NOT set_alpha — that is the separate NiAlphaProperty). " +
+         "target= is the shape or node NAME the op edits " +
          "(from housecarl_nif_inspect). By DEFAULT the verified mesh is written into a NEW houseCARL MO2 mod folder at the " +
          "same path (originals untouched) — enable it and sort it ABOVE the current winner so the edit wins; a BSA-packed " +
          "source becomes a loose winning override this way. in_place=true instead OVERWRITES the winning LOOSE file where " +
@@ -159,6 +162,8 @@ public static class NifTools
         [Description("set_alpha: the alpha test threshold, 0-255. Optional if only changing the flags word.")] string alpha_threshold = "",
         [Description("set_path: the BSShaderTextureSet slot index (0 diffuse, 1 normal, 6 tint/skin/detail, ...).")] string texture_slot = "",
         [Description("set_path: the new texture path (Data-relative, e.g. 'textures\\...\\facetint\\Mod.esp\\00000ABC.dds').")] string path = "",
+        [Description("set_shader_value: which lighting value — 'glossiness', 'specular_strength', 'specular_color', 'emissive_color', 'emissive_multiple', or 'alpha'.")] string shader_value = "",
+        [Description("set_shader_value: the new value — one number for a scalar ('30'), or three comma-separated 0-1 components for a colour ('1,0.5,0.25').")] string value = "",
         [Description("Optional. Edit a specific provider's copy instead of the VFS winner — the mod folder name, 'overwrite', 'Data', or a BSA filename from the providers chain. Empty = the winner.")]
             string mod = "",
         [Description("Optional. Base name for the NEW mod folder the edited mesh is written into (default lane; auto-suffixed if taken). Ignored with in_place=true.")]
@@ -172,10 +177,10 @@ public static class NifTools
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         if (string.IsNullOrWhiteSpace(mesh_path)) return "error: mesh_path is empty. Pass a Data-relative mesh path.";
-        if (string.IsNullOrWhiteSpace(op)) return "error: op is empty. Pass one of: rename_shape, rename_node, set_flags, set_scale, set_partition, set_alpha, set_path.";
+        if (string.IsNullOrWhiteSpace(op)) return "error: op is empty. Pass one of: " + OpList + ".";
         if (string.IsNullOrWhiteSpace(target)) return "error: target is empty. Pass the shape/node NAME the op edits (from housecarl_nif_inspect).";
 
-        var (built, buildErr) = BuildOp(op.Trim(), target.Trim(), new_name, flags, scale, body_part_id, partition_index, alpha_flags, alpha_threshold, texture_slot, path);
+        var (built, buildErr) = BuildOp(op.Trim(), target.Trim(), new_name, flags, scale, body_part_id, partition_index, alpha_flags, alpha_threshold, texture_slot, path, shader_value, value);
         if (buildErr is not null) return "error: " + buildErr;
 
         var data = svc.NifSet(mesh_path, new[] { built! },
@@ -190,7 +195,8 @@ public static class NifTools
     /// or an unparseable value — before the value ever reaches the service. Numeric params are strings so an omitted one is
     /// distinguishable from a real 0 (partition_index 0 is valid).</summary>
     static (NifSetOp? Op, string? Error) BuildOp(string op, string target,
-        string newName, string flags, string scale, string bodyPartId, string partitionIndex, string alphaFlags, string alphaThreshold, string textureSlot, string path)
+        string newName, string flags, string scale, string bodyPartId, string partitionIndex, string alphaFlags, string alphaThreshold, string textureSlot, string path,
+        string shaderValue, string value)
     {
         switch (op.ToLowerInvariant())
         {
@@ -218,10 +224,33 @@ public static class NifTools
                 if (!int.TryParse(textureSlot, out var slot)) return (null, $"set_path needs a numeric texture_slot; got '{textureSlot}'.");
                 if (string.IsNullOrWhiteSpace(path)) return (null, "set_path needs a path.");
                 return (new NifSetOp(NifSetOpKind.SetPath, target, TextureSlot: slot, Path: path), null);
+            case "set_shader_value":
+            {
+                if (string.IsNullOrWhiteSpace(shaderValue)) return (null, $"set_shader_value needs a shader_value ({NifService.ShaderValueList}).");
+                if (NifService.ShaderValueProperty(shaderValue) is null)
+                    return (null, $"unknown shader_value '{shaderValue}'. Use one of: {NifService.ShaderValueList}.");
+                if (string.IsNullOrWhiteSpace(value)) return (null, "set_shader_value needs a value — one number for a scalar, or 'r,g,b' for a colour.");
+                // Parsed to a bare list here; the ARITY is checked in the core against the library's own property type,
+                // so "how many components does this value take" has exactly one owner (see NifSetOp.ShaderNumbers).
+                var parts = value.Split(new[] { ',', ' ', ';', '[', ']' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                var nums = new List<float>(parts.Length);
+                foreach (var p in parts)
+                {
+                    if (!float.TryParse(p, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var f))
+                        return (null, $"set_shader_value: '{p}' in value is not a number. Pass one number for a scalar, or 'r,g,b' for a colour.");
+                    nums.Add(f);
+                }
+                if (nums.Count == 0) return (null, "set_shader_value needs a value — one number for a scalar, or 'r,g,b' for a colour.");
+                return (new NifSetOp(NifSetOpKind.SetShaderValue, target, ShaderValue: shaderValue.Trim(), ShaderNumbers: nums), null);
+            }
             default:
-                return (null, $"unknown op '{op}'. Use one of: rename_shape, rename_node, set_flags, set_scale, set_partition, set_alpha, set_path.");
+                return (null, $"unknown op '{op}'. Use one of: {OpList}.");
         }
     }
+
+    /// <summary>The op names, in one place — every "unknown op" / "op is empty" refusal reads from it, so adding an op
+    /// cannot leave a stale list behind in a message.</summary>
+    internal const string OpList = "rename_shape, rename_node, set_flags, set_scale, set_partition, set_alpha, set_path, set_shader_value";
 
     /// <summary>Parse a uint from hex ('0x...') or decimal.</summary>
     static bool TryParseUInt(string s, out uint value)

--- a/src/housecarl-mcp/NifTools.cs
+++ b/src/housecarl-mcp/NifTools.cs
@@ -149,7 +149,10 @@ public static class NifTools
         LoadOrderService svc,
         [Description("The Data-relative mesh path to edit, e.g. 'meshes\\actors\\character\\facegendata\\facegeom\\Skyrim.esm\\00000007.nif'.")]
             string mesh_path,
-        [Description("The write op: 'rename_shape', 'rename_node', 'set_flags', 'set_scale', 'set_partition', 'set_alpha', or 'set_path'.")]
+        // Built from OpList (a const, so it is legal in an attribute) rather than spelled out: this is the string a
+        // caller actually READS TO CHOOSE an op, so a stale list here is worse than a stale refusal — it makes a
+        // shipped op invisible in the tool schema, and the caller concludes houseCARL cannot do the thing.
+        [Description("The write op — one of: " + OpList + ".")]
             string op,
         [Description("The NAME of the shape or node the op edits (the current name; from housecarl_nif_inspect). For a rename this is the OLD name.")]
             string target,
@@ -163,7 +166,7 @@ public static class NifTools
         [Description("set_path: the BSShaderTextureSet slot index (0 diffuse, 1 normal, 6 tint/skin/detail, ...).")] string texture_slot = "",
         [Description("set_path: the new texture path (Data-relative, e.g. 'textures\\...\\facetint\\Mod.esp\\00000ABC.dds').")] string path = "",
         [Description("set_shader_value: which lighting value — 'glossiness', 'specular_strength', 'specular_color', 'emissive_color', 'emissive_multiple', or 'alpha'.")] string shader_value = "",
-        [Description("set_shader_value: the new value — one number for a scalar ('30'), or three comma-separated 0-1 components for a colour ('1,0.5,0.25').")] string value = "",
+        [Description("set_shader_value: the new value — one number for a scalar ('30'), or three comma-separated components for a colour ('1,0.5,0.25'). Colours and alpha are conventionally 0-1 (NOT 0-255); a value outside that is written as asked but WARNED about.")] string value = "",
         [Description("Optional. Edit a specific provider's copy instead of the VFS winner — the mod folder name, 'overwrite', 'Data', or a BSA filename from the providers chain. Empty = the winner.")]
             string mod = "",
         [Description("Optional. Base name for the NEW mod folder the edited mesh is written into (default lane; auto-suffixed if taken). Ignored with in_place=true.")]


### PR DESCRIPTION
Closes #291.

`nif_inspect sections=shader` has read all six shader lighting values since the NiflySharp 1.1.0 bump (#287 / PR #290); nothing could write any of them. This adds `op=set_shader_value` to `housecarl_nif_set` — `shader_value=` names the value, `value=` carries one number (scalar) or three comma-separated components (colour).

## The issue specified a gate that cannot be built

#291 said to gate on `NifService.ReallyReads` — the read path's interface-map check — and flagged "whether the *setter* being present is separately detectable from the *getter* being real" as the one thing to check first. Checked, empirically:

**`INiShader` declares all six values `canWrite=False`.** There is no `set_` accessor on the interface to find, so an interface-map write gate would refuse every block, including the one that works. The setters exist only on the **concrete** class.

Resolution — `ReallyWrites` reflects the concrete block's own property instead. Still purely by construction off the bundled library, still never a hand-kept list of "the block types that work". Getter-real and setter-present are independent facts that happen to agree today; each path now asks its own question rather than one standing in for the other.

Verified across all 17 `INiShader` implementers on 1.1.0:

| | writable |
|---|---|
| `BSLightingShaderProperty` | all six |
| `BSShaderPPLightingProperty`, `Lighting30ShaderProperty` | `EmissiveColor` only |
| the other 14 | none |

Without the gate, a write to a `BSEffectShaderProperty` is accepted, reports success, and leaves the mesh unchanged — the Q3 silent failure the issue named. It refuses and names the block type.

## Other calls, and what is *not* claimed

- **Arity from the library's property type** (`Single` → 1, `Color3`/`Color4` → 3), not declared — a colour struct that changes width cannot silently change the arity enforced.
- **Colour writes are read-modify-write and preserve any component past rgb.** `EmissiveColor` is `Color4` on the interface but `Color3` on disk: its `A` reads back 0 whatever was written (probed). Inventing one would fabricate a component the format does not carry; read-back compares rgb only for the same reason.
- **The layout gate is a second gate, not one catching a live case.** `ApplyOp` declines a non-Skyrim shader layout — the scope claim the read path makes, and real: an authored `Glossiness 33` on a stream-130 file reads back `80`. But `Set()` refuses any non-SE stream first, and an SE stream always parses as SK, so nothing reaches it today. Commented as such rather than credited with catching something, and guarded by pinning the premise it rests on (`Type` is a *settable* property, so the header↔layout coupling is nifly's internal, not a guarantee).

## Guard

`nif-set-guard` 62 → 84 arms. **109/109 `ci-all`.**

Every new arm verified falsifiable by breaking what it guards — and that caught a bad arm before it landed. The effect-shader refusal arms initially **passed with the gate deleted**: a non-writable value reports 0 components, so the arity refusal names the block type too, and an arm checking only for `BSEffectShaderProperty` ratified the right answer arriving for the wrong reason. Exactly the "guard pins the wording rather than the claim" shape PR #290's review caught. They now require the settability sentence, and deleting the gate fails all six.

Also pinned: that `INiShader` still declares the six get-only — if upstream ever adds interface setters, that arm fires and the gate should be revisited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
