### PR TITLE
compile_script: discover the modlist's Papyrus sources, narrowed to what the script references

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -29,7 +29,13 @@ takes the **whole list, every call**. A script built on the usual frameworks (SK
 JContainers, RaceMenu, UIExtensions…) meant retyping eight or ten folder paths for each compile, and getting one
 wrong produced an avalanche of errors that read like bugs in your code. houseCARL now **scans your enabled mods**
 for the source folders they already ship and puts them on the path for you, in MO2 priority order — so a mod's own
-extended copy of a script wins over the vanilla one exactly as it does everywhere else. Anything the scan can't
+extended copy of a script wins over the vanilla one exactly as it does everywhere else. It does **not** hand the
+compiler all of them: a big modlist ships far more script folders than you'd guess (501 on a 3,617-mod order, whose
+combined length a Windows command line cannot even carry), and nearly all belong to quest and follower mods shipping
+their own scripts that nothing else ever calls. So houseCARL keeps the folders your script actually **references** —
+by name, followed onward through those scripts, since the compiler loads your dependencies' dependencies too. In
+practice that turns 501 folders into eight or ten, and it reports both numbers so a folder that was left out reads as
+*dropped as unreferenced*, not *missed*. Anything the scan can't
 reach (your own stubs, a dev project folder, sources you had to extract out of a BSA — the Creation Kit's compiler
 cannot read archives) still goes in `import_dirs=`, and you can now **save that list under a name** with
 `save_import_set=` and recall it later with `import_set=`, so it is typed once rather than once per call. Pass

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -23,6 +23,24 @@ keeps the artifact names (`PGPatcher.esp`, `Reqtificated` patches, `NPC_Token.js
 its first eval set. The authoring standard's length rules were amended to match, so future skills are written to the
 budget instead of re-discovering it.
 
+**`compile_script` now finds your script's dependencies itself, instead of making you list them every time (#200).**
+Compiling a Papyrus script means telling the compiler every folder its dependencies' source code lives in — and it
+takes the **whole list, every call**. A script built on the usual frameworks (SKSE, SkyUI, PapyrusUtil, PO3,
+JContainers, RaceMenu, UIExtensions…) meant retyping eight or ten folder paths for each compile, and getting one
+wrong produced an avalanche of errors that read like bugs in your code. houseCARL now **scans your enabled mods**
+for the source folders they already ship and puts them on the path for you, in MO2 priority order — so a mod's own
+extended copy of a script wins over the vanilla one exactly as it does everywhere else. Anything the scan can't
+reach (your own stubs, a dev project folder, sources you had to extract out of a BSA — the Creation Kit's compiler
+cannot read archives) still goes in `import_dirs=`, and you can now **save that list under a name** with
+`save_import_set=` and recall it later with `import_set=`, so it is typed once rather than once per call. Pass
+`auto_imports=false` to skip the modlist scan entirely. **The folders actually searched are now reported on every
+compile** — a summary on success, the full ordered list on failure. That was previously invisible, which made the
+two ways a compile goes wrong impossible to tell apart from the output: a dependency that was never on the path, and
+a dependency found in the *wrong* folder because something earlier in the order shadowed it. Relatedly, a failure
+that looks like missing dependencies now gives you the right next step for your situation: if the scan already ran,
+it points at the causes a scan cannot fix (the mod isn't enabled, its sources are inside a BSA, or they sit one
+folder deeper) rather than repeating "list every dependency".
+
 **`validate_dialogue` now reports a topic's EFFECTIVE line order — and which mod moved a line (#275).** A dialogue
 topic is a list of possible lines, and the game plays the **first** one whose conditions pass. That list is not held
 by any single record: every mod that touches the topic contributes its own list, and the real order is the merge of

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -39,7 +39,7 @@ practice that turns 501 folders into eight or ten, and it reports both numbers s
 reach (your own stubs, a dev project folder, sources you had to extract out of a BSA — the Creation Kit's compiler
 cannot read archives) still goes in `import_dirs=`, and you can now **save that list under a name** with
 `save_import_set=` and recall it later with `import_set=`, so it is typed once rather than once per call. Pass
-`auto_imports=false` to skip the modlist scan entirely. **The folders actually searched are now reported on every
+`auto_imports=false` to leave your enabled mods off the import path. **The folders actually searched are now reported on every
 compile** — a summary on success, the full ordered list on failure. That was previously invisible, which made the
 two ways a compile goes wrong impossible to tell apart from the output: a dependency that was never on the path, and
 a dependency found in the *wrong* folder because something earlier in the order shadowed it. Relatedly, a failure

--- a/src/housecarl-core/AssetResolver.cs
+++ b/src/housecarl-core/AssetResolver.cs
@@ -125,6 +125,14 @@ public sealed class AssetResolver : IDisposable
 
     volatile Snapshot _snap;
 
+    /// <summary>The loose roots this resolver was built over, in PRECEDENCE order (overwrite → enabled mods
+    /// highest-priority-first → Data) — see <see cref="BuildLooseRoots"/>. Fixed for the resolver's lifetime (the set
+    /// only changes with the profile, which rebuilds the whole resolver), so unlike the archive tables it needs no
+    /// snapshot. Exposed for consumers that need the VFS ORDER itself rather than a resolved file:
+    /// <see cref="PapyrusSourceRoots.Discover"/> reads it to put a modlist's shipped .psc source folders on the
+    /// Papyrus compiler's import path in the same precedence the modlist applies to everything else.</summary>
+    public IReadOnlyList<(string Name, string Dir)> LooseRoots => _looseRoots;
+
     /// <summary>Archives that could not be read this build (path: reason) — surfaced, never silently treated as empty (Q3).</summary>
     public IReadOnlyList<string> BsaFailures => _snap.Failures;
 

--- a/src/housecarl-core/PapyrusDependencyFilter.cs
+++ b/src/housecarl-core/PapyrusDependencyFilter.cs
@@ -4,12 +4,18 @@ namespace HousecarlCore;
 
 /// <summary>What <see cref="PapyrusDependencyFilter.Relevant"/> concluded: the candidate folders this script actually
 /// reaches (in the order they were offered), plus the numbers the render discloses — how many scripts were indexed,
-/// how many source files were read chasing transitive references, and whether a bound cut the walk short.</summary>
+/// how many source files were read chasing transitive references, and whether a bound cut the walk short.
+/// <para>BOTH degraded outcomes are FLAGGED, never left to look like a clean empty answer.
+/// <see cref="BudgetExhausted"/> means the walk was truncated; <see cref="TargetUnreadable"/> means the target's own
+/// source could not be read at all, so an empty <see cref="Folders"/> says nothing about what the script references —
+/// without it the render would state "0 of 501 … referenced by this script", a positive claim about contents that were
+/// never examined (Q3: a degraded answer must not be indistinguishable from a confident one).</para></summary>
 public sealed record PapyrusDependencyScan(
     IReadOnlyList<string> Folders,
     int Indexed,
     int FilesRead,
-    bool BudgetExhausted);
+    bool BudgetExhausted,
+    bool TargetUnreadable = false);
 
 /// <summary>
 /// Narrows a modlist's Papyrus source folders to the ones a specific script can actually reach (issue #200).
@@ -85,8 +91,13 @@ public static class PapyrusDependencyFilter
 
         int filesRead = 0;
         bool exhausted = false;
+        // The target is re-read here, after CompileScript's own File.Exists — it can be locked by an editor mid-save
+        // or moved in between. Returning empty is right (a throw would cost the compile, and the compiler's own error
+        // is the better one), but it must be DISTINGUISHABLE from a walk that ran and reached nothing: the render turns
+        // an empty result into "your script references none of these", which here would be asserting the contents of a
+        // file that was never opened.
         try { foreach (var id in Names(File.ReadAllText(targetScript))) queue.Enqueue(id); filesRead++; }
-        catch { return new PapyrusDependencyScan(Array.Empty<string>(), folderOf.Count, 0, false); }
+        catch { return new PapyrusDependencyScan(Array.Empty<string>(), folderOf.Count, 0, false, TargetUnreadable: true); }
 
         while (queue.Count > 0)
         {

--- a/src/housecarl-core/PapyrusDependencyFilter.cs
+++ b/src/housecarl-core/PapyrusDependencyFilter.cs
@@ -1,0 +1,119 @@
+using System.Text.RegularExpressions;
+
+namespace HousecarlCore;
+
+/// <summary>What <see cref="PapyrusDependencyFilter.Relevant"/> concluded: the candidate folders this script actually
+/// reaches (in the order they were offered), plus the numbers the render discloses — how many scripts were indexed,
+/// how many source files were read chasing transitive references, and whether a bound cut the walk short.</summary>
+public sealed record PapyrusDependencyScan(
+    IReadOnlyList<string> Folders,
+    int Indexed,
+    int FilesRead,
+    bool BudgetExhausted);
+
+/// <summary>
+/// Narrows a modlist's Papyrus source folders to the ones a specific script can actually reach (issue #200).
+///
+/// WHY THIS EXISTS, measured rather than assumed: on a real 3617-mod order (ARR 2.0, 2026-07-28) the modlist scan
+/// finds <b>501</b> source folders — about one mod in seven — whose joined <c>-i=</c> value is <b>~40,200 characters</b>.
+/// Windows caps a process command line near 32,767, so handing the compiler every folder does not merely waste effort,
+/// it cannot be executed at all. And the size is the symptom, not the disease: nearly all of those folders belong to
+/// quest and follower mods shipping <i>their own</i> scripts, which no other script ever references. A folder that
+/// provides only names this script never mentions contributes nothing to this compile — so filtering to the reachable
+/// set is the CORRECT semantics, not a size workaround that happens to fit.
+///
+/// The walk mirrors what the compiler itself does. The compiler resolves a referenced script by NAME against the
+/// import path and takes the FIRST match, so a name is indexed to exactly one folder — the highest-precedence provider
+/// — and that is the only folder that name can ever justify. From the target's own text, every identifier-shaped token
+/// is looked up; each that resolves pulls in its folder AND is followed into that script's text, until nothing new
+/// appears. Following matters: type-checking loads a dependency's own dependencies, so the closure is transitive, not
+/// one level.
+///
+/// DELIBERATELY OVER-INCLUSIVE. Every <c>[A-Za-z_][A-Za-z0-9_]*</c> token is treated as a possible script name —
+/// keywords, locals, comment and string text included. A token that names nothing costs one dictionary miss; the
+/// failure that matters is the other direction, a folder wrongly dropped, which costs a compile that used to work.
+/// The vanilla sources are deliberately NOT indexed by the caller: they are always on the import path anyway, so
+/// excluding them both keeps the closure from walking the whole base game and cannot lose a folder.
+/// </summary>
+public static class PapyrusDependencyFilter
+{
+    /// <summary>Ceiling on source files READ while chasing transitive references. A bound this generous is a runaway
+    /// stop, not a policy — the real closure of a framework-heavy script is orders of magnitude smaller (the whole
+    /// index on the order measured above is 13,235 scripts). Hitting it is REPORTED, never absorbed (Q3).</summary>
+    public const int MaxFilesRead = 5000;
+
+    static readonly Regex Identifier = new(@"[A-Za-z_][A-Za-z0-9_]*", RegexOptions.Compiled);
+
+    /// <summary>The subset of <paramref name="candidateFolders"/> that <paramref name="targetScript"/> reaches.
+    /// <para><paramref name="seedFolders"/> — the script's own folder and the caller's explicit import_dirs= — are
+    /// INDEXED but never returned: the caller adds them unconditionally (an explicitly passed folder is not something
+    /// to second-guess), and indexing them is what lets the walk hop THROUGH a local script into the framework it
+    /// uses. Precedence runs seeds first, then candidates in the given order, which is the same order the compiler
+    /// will search, so each name indexes to the provider that would actually win.</para>
+    /// <para>Returns candidates in their GIVEN order (MO2 precedence). An unreadable script is skipped rather than
+    /// thrown on — one missed hop degrades to a folder the user can pass by hand, whereas a throw would cost the
+    /// compile outright.</para></summary>
+    public static PapyrusDependencyScan Relevant(
+        string targetScript, IReadOnlyList<string> seedFolders, IReadOnlyList<string> candidateFolders)
+    {
+        // name -> the folder + file of its FIRST (highest-precedence) provider, exactly as the compiler would resolve it.
+        var folderOf = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var fileOf = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var folder in seedFolders.Concat(candidateFolders))
+        {
+            IEnumerable<string> files;
+            try { files = Directory.EnumerateFiles(folder, "*.psc"); }
+            catch { continue; }
+            try
+            {
+                foreach (var f in files)
+                {
+                    if (!f.EndsWith(".psc", StringComparison.OrdinalIgnoreCase)) continue;
+                    var name = Path.GetFileNameWithoutExtension(f);
+                    if (folderOf.ContainsKey(name)) continue;      // first provider wins — the one the compiler would take
+                    folderOf[name] = folder;
+                    fileOf[name] = f;
+                }
+            }
+            catch { /* the folder vanished mid-walk — it just contributes nothing */ }
+        }
+
+        var candidateSet = new HashSet<string>(candidateFolders, StringComparer.OrdinalIgnoreCase);
+        var reached = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var queue = new Queue<string>();
+
+        int filesRead = 0;
+        bool exhausted = false;
+        try { foreach (var id in Names(File.ReadAllText(targetScript))) queue.Enqueue(id); filesRead++; }
+        catch { return new PapyrusDependencyScan(Array.Empty<string>(), folderOf.Count, 0, false); }
+
+        while (queue.Count > 0)
+        {
+            var name = queue.Dequeue();
+            if (!seen.Add(name)) continue;
+            if (!folderOf.TryGetValue(name, out var folder)) continue;   // names nothing on the path — a free miss
+            if (candidateSet.Contains(folder)) reached.Add(folder);
+
+            // Past the budget, keep RESOLVING (a dictionary hit still earns its folder) but stop READING, so a runaway
+            // closure degrades to a shorter path that is reported rather than to a hung compile.
+            if (filesRead >= MaxFilesRead) { exhausted = true; continue; }
+            string text;
+            try { text = File.ReadAllText(fileOf[name]); filesRead++; }
+            catch { continue; }
+            foreach (var id in Names(text))
+                if (!seen.Contains(id)) queue.Enqueue(id);
+        }
+
+        var kept = candidateFolders.Where(reached.Contains).ToList();
+        return new PapyrusDependencyScan(kept, folderOf.Count, filesRead, exhausted);
+    }
+
+    /// <summary>Every identifier-shaped token in a Papyrus source. No attempt is made to tell a type reference from a
+    /// local, a keyword, or a word inside a comment — see the class summary: an extra token is a dictionary miss, a
+    /// missing one is a failed compile.</summary>
+    static IEnumerable<string> Names(string text)
+    {
+        foreach (Match m in Identifier.Matches(text)) yield return m.Value;
+    }
+}

--- a/src/housecarl-core/PapyrusSourceRoots.cs
+++ b/src/housecarl-core/PapyrusSourceRoots.cs
@@ -1,0 +1,82 @@
+namespace HousecarlCore;
+
+/// <summary>One discovered Papyrus source folder in the MO2 VFS: which loose root PROVIDED it
+/// (<paramref name="Provider"/> — an enabled mod's folder name, "overwrite", or "Data", exactly the name
+/// <c>AssetResolver</c> gives that root), the absolute folder to hand the compiler, and which of the two
+/// on-disk <see cref="PapyrusSourceRoots.Layouts"/> it matched.</summary>
+public sealed record PapyrusSourceRoot(string Provider, string Dir, string Layout);
+
+/// <summary>
+/// Finds the Papyrus SOURCE folders an MO2 modlist already contains, so housecarl_compile_script can put them on
+/// the compiler's import path instead of making the caller retype them on every call (issue #200).
+///
+/// The issue framed this as "read the import paths configured for the MO2 instance". There are none: MO2 stores no
+/// Papyrus import list, and SkyrimEditor.ini's <c>sScriptSourceFolder</c> is a SINGLE folder, not a list. What does
+/// exist is the mods themselves — a framework that expects to be compiled against ships its .psc sources inside its
+/// own mod folder. So the pickup is a scan of the VFS loose roots, not a config read.
+///
+/// Two layouts are recognised, both seen in shipped mods:
+///   • <c>Source\Scripts</c> — the SE/CK convention (the vanilla sources live at <c>Data\Source\Scripts</c>);
+///   • <c>Scripts\Source</c> — the LE convention, still carried by ported and older mods.
+/// A folder counts only if it actually holds a top-level <c>.psc</c>; an empty or scripts-only folder contributes
+/// nothing (a mod shipping compiled .pex with no sources must not widen the import path for nothing).
+///
+/// ORDER IS SEMANTICS. The compiler resolves each referenced script to the FIRST match across the import path, so
+/// the roots are walked in the caller's given order and emitted in it — handed the AssetResolver's loose roots, that
+/// is MO2's own precedence (overwrite → enabled mods highest-priority-first → Data), which is the same tie-break the
+/// modlist applies to every other file. Pure + I/O-only-on-probe: no MO2 knowledge lives here, which is what lets the
+/// guard drive it against a fabricated tree.
+/// </summary>
+public static class PapyrusSourceRoots
+{
+    /// <summary>The recognised on-disk source layouts, relative to a loose root, in preference order.</summary>
+    public static readonly string[] Layouts = { @"Source\Scripts", @"Scripts\Source" };
+
+    /// <summary>Walk <paramref name="looseRoots"/> IN THE GIVEN ORDER and return every folder that holds Papyrus
+    /// sources. Deduped by absolute path (case-insensitive), FIRST occurrence kept — so the higher-precedence root
+    /// keeps the slot when two roots resolve to the same folder. Unreadable roots are skipped, never thrown on: this
+    /// feeds an ergonomic default, so a permission-denied folder must cost the caller one import dir, not the compile
+    /// (Q3 — the count and the provider names are rendered, so a short list is visible rather than silent).</summary>
+    public static IReadOnlyList<PapyrusSourceRoot> Discover(IReadOnlyList<(string Name, string Dir)> looseRoots)
+    {
+        var found = new List<PapyrusSourceRoot>();
+        if (looseRoots is null) return found;
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (name, dir) in looseRoots)
+        {
+            if (string.IsNullOrWhiteSpace(dir)) continue;
+            foreach (var layout in Layouts)
+            {
+                string candidate;
+                try { candidate = Path.GetFullPath(Path.Combine(dir, layout)); }
+                catch { continue; }                       // an un-rootable root (bad chars) costs one candidate, not the scan
+                if (!HasSources(candidate)) continue;
+                if (!seen.Add(candidate)) continue;       // same folder reached twice → the FIRST (higher-precedence) slot wins
+                found.Add(new PapyrusSourceRoot(name, candidate, layout));
+            }
+        }
+        return found;
+    }
+
+    /// <summary>True iff <paramref name="dir"/> exists and holds at least one top-level <c>.psc</c>. Enumerates
+    /// lazily and returns on the FIRST hit, so the check costs one directory entry on a populated folder rather than
+    /// a full listing — this runs once per loose root, and a big modlist has thousands.
+    /// <para>The explicit <c>EndsWith(".psc")</c> re-check is CHEAP INSURANCE, not a proven necessity: a
+    /// three-character extension pattern can also match longer extensions on Windows via the 8.3 short-name rule, but
+    /// that depends on 8.3 name generation being enabled for the volume. Falsified 2026-07-28 — removing the re-check
+    /// did NOT make the guard's <c>.pscx</c> arm go red on this machine, so the quirk did not reproduce here and that
+    /// arm is a shape-check rather than a proof. The re-check stays because it costs one string compare and the
+    /// failure it guards against (a non-source folder widening every compile's import path) is silent.</para>
+    /// Any I/O failure (denied, vanished mid-walk) reads as "no sources" — best-effort by design.</summary>
+    public static bool HasSources(string dir)
+    {
+        try
+        {
+            if (!Directory.Exists(dir)) return false;
+            foreach (var f in Directory.EnumerateFiles(dir, "*.psc"))
+                if (f.EndsWith(".psc", StringComparison.OrdinalIgnoreCase)) return true;
+            return false;
+        }
+        catch { return false; }
+    }
+}

--- a/src/housecarl-core/PapyrusSourceRoots.cs
+++ b/src/housecarl-core/PapyrusSourceRoots.cs
@@ -58,6 +58,29 @@ public static class PapyrusSourceRoots
         return found;
     }
 
+    /// <summary>Drop the roots that are the GAME's own vanilla sources — <c>&lt;data&gt;\Source\Scripts</c> and its LE
+    /// twin — from a <see cref="Discover"/> result. They are not a mod, and the compile rider appends the vanilla
+    /// sources last unconditionally, so leaving them in the mod candidates would rank the base game as an ordinary
+    /// mod and let the reference walk chase the whole of it.
+    /// <para>This CANNOT be left to "the caller will notice the folder matches the compiler's vanilla dir". On a
+    /// Wabbajack Stock Game setup those are different folders by design — the CK compiler lives in the real Steam
+    /// install (this rider's own tool-path hints exist for exactly that), while MO2's data dir is the Stock Game copy —
+    /// so a compiler-relative comparison silently never fires on the setup it most needs to. Matching is EXACT against
+    /// the folders <see cref="Discover"/> would have produced for this data dir, not a path-prefix guess.</para>
+    /// <para>A blank <paramref name="dataDir"/> (explicit-paths or unconfigured mode) drops nothing: <c>Path.Combine</c>
+    /// would otherwise resolve the layouts against the process CWD and could exclude an unrelated folder.</para></summary>
+    public static IReadOnlyList<PapyrusSourceRoot> ExcludeGameData(IReadOnlyList<PapyrusSourceRoot> found, string? dataDir)
+    {
+        if (string.IsNullOrWhiteSpace(dataDir)) return found;
+        var vanilla = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var layout in Layouts)
+        {
+            try { vanilla.Add(Path.GetFullPath(Path.Combine(dataDir, layout))); }
+            catch { /* an un-rootable data dir excludes nothing — the same best-effort posture as the scan */ }
+        }
+        return found.Where(r => !vanilla.Contains(r.Dir)).ToList();
+    }
+
     /// <summary>True iff <paramref name="dir"/> exists and holds at least one top-level <c>.psc</c>. Enumerates
     /// lazily and returns on the FIRST hit, so the check costs one directory entry on a populated folder rather than
     /// a full listing — this runs once per loose root, and a big modlist has thousands.

--- a/src/housecarl-core/PapyrusSourceRoots.cs
+++ b/src/housecarl-core/PapyrusSourceRoots.cs
@@ -58,27 +58,39 @@ public static class PapyrusSourceRoots
         return found;
     }
 
-    /// <summary>Drop the roots that are the GAME's own vanilla sources — <c>&lt;data&gt;\Source\Scripts</c> and its LE
-    /// twin — from a <see cref="Discover"/> result. They are not a mod, and the compile rider appends the vanilla
-    /// sources last unconditionally, so leaving them in the mod candidates would rank the base game as an ordinary
-    /// mod and let the reference walk chase the whole of it.
-    /// <para>This CANNOT be left to "the caller will notice the folder matches the compiler's vanilla dir". On a
+    /// <summary>Separate the GAME's own vanilla sources — <c>&lt;data&gt;\Source\Scripts</c> and its LE twin — from the
+    /// mod roots in a <see cref="Discover"/> result. Returns the mod candidates, plus the game-Data source folder that
+    /// was taken out (null if there is none).
+    /// <para>Splitting rather than merely DROPPING is load-bearing. The base game is not a mod: left among the
+    /// candidates it ranks as one, renders as one, and — being last in precedence, hence the fallback provider for
+    /// every unshadowed vanilla name — drags the reference walk through the whole of it. But the rider only appends a
+    /// vanilla slot when the COMPILER-relative folder resolves, so a silent drop can leave a path with no vanilla
+    /// sources at all. Handing the folder back lets the caller use it as the vanilla slot when the compiler-relative
+    /// one is missing, which is the only thing that keeps both properties true at once.</para>
+    /// <para>The split CANNOT be left to "the caller will notice the folder matches the compiler's vanilla dir". On a
     /// Wabbajack Stock Game setup those are different folders by design — the CK compiler lives in the real Steam
     /// install (this rider's own tool-path hints exist for exactly that), while MO2's data dir is the Stock Game copy —
     /// so a compiler-relative comparison silently never fires on the setup it most needs to. Matching is EXACT against
     /// the folders <see cref="Discover"/> would have produced for this data dir, not a path-prefix guess.</para>
-    /// <para>A blank <paramref name="dataDir"/> (explicit-paths or unconfigured mode) drops nothing: <c>Path.Combine</c>
-    /// would otherwise resolve the layouts against the process CWD and could exclude an unrelated folder.</para></summary>
-    public static IReadOnlyList<PapyrusSourceRoot> ExcludeGameData(IReadOnlyList<PapyrusSourceRoot> found, string? dataDir)
+    /// <para>A blank <paramref name="dataDir"/> (explicit-paths or unconfigured mode) splits nothing:
+    /// <c>Path.Combine</c> would otherwise resolve the layouts against the process CWD and could exclude an unrelated
+    /// folder.</para></summary>
+    public static (IReadOnlyList<PapyrusSourceRoot> Mods, string? GameDataSources) SplitGameData(
+        IReadOnlyList<PapyrusSourceRoot> found, string? dataDir)
     {
-        if (string.IsNullOrWhiteSpace(dataDir)) return found;
-        var vanilla = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (string.IsNullOrWhiteSpace(dataDir)) return (found, null);
+        var vanilla = new List<string>();
         foreach (var layout in Layouts)
         {
             try { vanilla.Add(Path.GetFullPath(Path.Combine(dataDir, layout))); }
-            catch { /* an un-rootable data dir excludes nothing — the same best-effort posture as the scan */ }
+            catch { /* an un-rootable data dir splits nothing — the same best-effort posture as the scan */ }
         }
-        return found.Where(r => !vanilla.Contains(r.Dir)).ToList();
+        var set = new HashSet<string>(vanilla, StringComparer.OrdinalIgnoreCase);
+        var mods = found.Where(r => !set.Contains(r.Dir)).ToList();
+        // Prefer the layouts' own order (SE before LE), not discovery order, so the answer is stable when a data dir
+        // somehow carries both.
+        var gameData = vanilla.FirstOrDefault(v => found.Any(r => r.Dir.Equals(v, StringComparison.OrdinalIgnoreCase)));
+        return (mods, gameData);
     }
 
     /// <summary>True iff <paramref name="dir"/> exists and holds at least one top-level <c>.psc</c>. Enumerates

--- a/src/housecarl-core/UserConfig.cs
+++ b/src/housecarl-core/UserConfig.cs
@@ -29,6 +29,14 @@ public sealed class UserConfig
     /// like the other two it is read-modify-written ONLY through <see cref="UserConfigStore.Update"/> so it can never
     /// clobber (or be clobbered by) the MO2 instance / tool paths.</summary>
     public List<string>? InPlaceAcknowledged { get; set; }
+
+    /// <summary>Named Papyrus import-directory sets (housecarl_compile_script's <c>save_import_set=</c> /
+    /// <c>import_set=</c>) — a project's dependency source folders supplied ONCE and referenced by name thereafter
+    /// (issue #200's second half; the auto-scan covers frameworks that ship sources inside a mod, this covers the rest —
+    /// local stubs, a dev project tree, sources extracted out of a BSA). Name → the ordered dirs. Null/absent until the
+    /// first save. The fourth independent concern in this file, read-modify-written ONLY through
+    /// <see cref="UserConfigStore.Update"/> so it can never clobber (or be clobbered by) the other three.</summary>
+    public Dictionary<string, List<string>>? ImportSets { get; set; }
 }
 
 /// <summary>
@@ -149,6 +157,48 @@ public sealed class UserConfigStore
             cfg.InPlaceAcknowledged ??= new List<string>();
             if (!cfg.InPlaceAcknowledged.Any(p => string.Equals(NormalizePath(p), key, StringComparison.Ordinal)))
                 cfg.InPlaceAcknowledged.Add(key);
+        });
+        return (ok, error);
+    }
+
+    /// <summary>The saved import-set names, sorted, for a "did you mean" on an unknown name (Q3 — an unknown set names
+    /// what DOES exist rather than failing blank). Empty when none are saved or the file can't be read.</summary>
+    public IReadOnlyList<string> ImportSetNames()
+    {
+        var sets = Load().ImportSets;
+        if (sets is null) return Array.Empty<string>();
+        return sets.Keys.OrderBy(k => k, StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    /// <summary>The dirs saved under <paramref name="name"/>, or null if no such set. Matched CASE-INSENSITIVELY and
+    /// on the trimmed name: the dictionary comes back from JSON with the DEFAULT (ordinal) comparer, so a plain
+    /// indexer lookup would miss a set the user saved as "MyProject" and recalled as "myproject".</summary>
+    public IReadOnlyList<string>? GetImportSet(string name)
+    {
+        var sets = Load().ImportSets;
+        if (sets is null || string.IsNullOrWhiteSpace(name)) return null;
+        var key = name.Trim();
+        foreach (var kv in sets)
+            if (string.Equals(kv.Key, key, StringComparison.OrdinalIgnoreCase))
+                return kv.Value ?? new List<string>();
+        return null;
+    }
+
+    /// <summary>Save (or replace) the import set <paramref name="name"/> through the same atomic read-modify-write as
+    /// every other field, so it can never clobber the MO2 instance / tool paths / in-place acknowledgements sharing
+    /// this file. Replacing is case-insensitive AND removes the old key before adding the trimmed one, so re-saving
+    /// "MyProject" as "myproject" leaves ONE set rather than two that <see cref="GetImportSet"/> would then resolve
+    /// between arbitrarily. Returns (ok, error): a write failure is RETURNED, not thrown (Q3 — the caller can say the
+    /// compile ran but the set won't survive a restart).</summary>
+    public (bool ok, string? error) SaveImportSet(string name, IReadOnlyList<string> dirs)
+    {
+        var key = name.Trim();
+        var (ok, error, _) = Update(cfg =>
+        {
+            cfg.ImportSets ??= new Dictionary<string, List<string>>();
+            foreach (var existing in cfg.ImportSets.Keys.Where(k => string.Equals(k, key, StringComparison.OrdinalIgnoreCase)).ToList())
+                cfg.ImportSets.Remove(existing);
+            cfg.ImportSets[key] = dirs.ToList();
         });
         return (ok, error);
     }

--- a/src/housecarl-generator/CompileErgonomicsProbe.cs
+++ b/src/housecarl-generator/CompileErgonomicsProbe.cs
@@ -253,7 +253,7 @@ internal static class CompileErgonomicsProbe
         var okMsg = CompileTools.Render(ok, Plan(autoCount: 3, callerCount: 1, scanned: 501), userChoseOutputDir: false);
         Check(okMsg.Contains("imports: 6 dir(s) searched"),
               "success renders the import summary with the TOTAL (own + 1 caller + 3 auto + vanilla = 6)");
-        Check(okMsg.Contains("1 from import_dirs=") && okMsg.Contains("3 of 501 scanned mod source folder(s) referenced by this script"),
+        Check(okMsg.Contains("1 from import_dirs=") && okMsg.Contains("the modlist scan matched 3 of 501 scanned mod source folder(s) referenced by this script"),
               "the summary splits caller dirs from the scan, and reports BOTH scan numbers (kept AND scanned)");
         Check(okMsg.Contains("modA") && okMsg.Contains("modC"), "the summary NAMES the providing mods");
         Check(okMsg.Contains("vanilla sources last"), "the summary states that vanilla ranks last");
@@ -265,7 +265,7 @@ internal static class CompileErgonomicsProbe
 
         // E3: the display cap NAMES what it dropped — a truncated provider list must never read as the whole list.
         var manyMsg = CompileTools.Render(ok, Plan(autoCount: 12), userChoseOutputDir: false);
-        Check(manyMsg.Contains("12 of 12 scanned mod source folder(s)") && manyMsg.Contains("+4 more"),
+        Check(manyMsg.Contains("matched 12 of 12 scanned mod source folder(s)") && manyMsg.Contains("+4 more"),
               "over 8 providers: the full COUNT is stated and the tail is named '+4 more' (no silent truncation)");
 
         // E3b: hitting the reference-walk ceiling is DISCLOSED — a shortened path must never look like a complete one.
@@ -319,7 +319,7 @@ internal static class CompileErgonomicsProbe
         // fix (not installed / sources inside a BSA / nested a level down).
         var scanned = CompileTools.Render(missingImports, Plan(autoCount: 3, scanned: 501), userChoseOutputDir: false);
         var unscanned = CompileTools.Render(missingImports, Plan(autoEnabled: false), userChoseOutputDir: false);
-        Check(scanned.Contains("inside a BSA") && scanned.Contains("found 501 mod source folder(s) and kept the 3"),
+        Check(scanned.Contains("inside a BSA") && scanned.Contains("found 501 mod source folder(s) and matched the 3"),
               "auto_imports ON: the banner names what the scan found AND kept, plus the causes it cannot fix (never named / not installed / BSA / subfolder)");
         Check(unscanned.Contains("auto_imports=false") && unscanned.Contains("re-run with auto_imports=true"),
               "auto_imports OFF: the banner's first remedy is to turn the scan ON");
@@ -451,13 +451,21 @@ internal static class CompileErgonomicsProbe
             };
             var withData = PapyrusSourceRoots.Discover(stockRoots);
             Check(withData.Any(r => r.Dir == stockData), "control: the scan DOES find the game's own Data sources (they hold .psc)");
-            var noData = PapyrusSourceRoots.ExcludeGameData(withData, Path.Combine(gRoot, "StockGameData"));
+            var (noData, gameData) = PapyrusSourceRoots.SplitGameData(withData, Path.Combine(gRoot, "StockGameData"));
             Check(noData.All(r => r.Dir != stockData) && noData.Count == withData.Count - 1,
-                  "ExcludeGameData drops the game's Data sources by PATH — no dependence on them coinciding with the compiler's vanilla dir");
-            Check(noData.Any(r => r.Provider == "SKSE"), "…and drops nothing else");
-            Check(PapyrusSourceRoots.ExcludeGameData(withData, null).Count == withData.Count
-                  && PapyrusSourceRoots.ExcludeGameData(withData, "  ").Count == withData.Count,
-                  "a blank data dir drops NOTHING (Path.Combine would otherwise resolve the layouts against the process CWD)");
+                  "SplitGameData takes the game's Data sources out of the MOD candidates by PATH — no dependence on them coinciding with the compiler's vanilla dir");
+            Check(noData.Any(r => r.Provider == "SKSE"), "…and takes nothing else");
+            // The re-review regression: dropping it is only half right. Handed back, it can stand in as the vanilla
+            // slot when the compiler-relative folder is missing; discarded, the path can end up with NO vanilla at all.
+            Check(gameData == stockData, "…and HANDS IT BACK, so the caller can use it as the vanilla slot rather than losing it");
+            var (blankMods, blankGame) = PapyrusSourceRoots.SplitGameData(withData, null);
+            Check(blankMods.Count == withData.Count && blankGame is null,
+                  "a blank data dir splits NOTHING (Path.Combine would otherwise resolve the layouts against the process CWD)");
+            var (noneMods, noneGame) = PapyrusSourceRoots.SplitGameData(
+                PapyrusSourceRoots.Discover(new (string, string)[] { ("SKSE", Path.Combine(gRoot, "SKSE")) }),
+                Path.Combine(gRoot, "StockGameData"));
+            Check(noneMods.Count == 1 && noneGame is null,
+                  "a data dir whose sources the scan never found yields no game-Data folder (no phantom vanilla path)");
 
             // Best-effort by contract: a missing / nonsense root costs one candidate, never the scan.
             bool threw = false;
@@ -559,9 +567,14 @@ internal static class CompileErgonomicsProbe
     {
         var e = new List<(string Dir, string Origin)> { (@"C:\work", CompileTools.ImportPlan.OwnFolder) };
         for (int i = 0; i < callerCount; i++) e.Add(($@"C:\caller{i}", CompileTools.ImportPlan.CallerDirs));
+        var referenced = new List<string>();
         for (int i = 0; i < autoCount; i++)
-            e.Add(($@"C:\MO2\mods\mod{(char)('A' + i)}\Source\Scripts", CompileTools.ImportPlan.AutoPrefix + "mod" + (char)('A' + i)));
+        {
+            var mod = "mod" + (char)('A' + i);
+            e.Add(($@"C:\MO2\mods\{mod}\Source\Scripts", CompileTools.ImportPlan.AutoPrefix + mod));
+            referenced.Add(mod);   // the ordinary case: every folder the walk matched also took an auto SLOT
+        }
         e.Add((@"C:\Game\Data\Source\Scripts", CompileTools.ImportPlan.Vanilla));
-        return new CompileTools.ImportPlan(e, autoEnabled, setName, warning, scanned < 0 ? autoCount : scanned, scan);
+        return new CompileTools.ImportPlan(e, autoEnabled, setName, warning, scanned < 0 ? autoCount : scanned, scan, referenced);
     }
 }

--- a/src/housecarl-generator/CompileErgonomicsProbe.cs
+++ b/src/housecarl-generator/CompileErgonomicsProbe.cs
@@ -378,27 +378,71 @@ internal static class CompileErgonomicsProbe
         Check(realZero.Contains("matched 0 of 501") && realZero.Contains("referenced by this script"),
               "a scan that ran and matched nothing DOES report that conclusion (no false alarm)");
 
-        // CLOSURE over the degraded-scan flags, not another one-off. Three consecutive review passes found the same
-        // shape — a path where the scan did not run, or did not finish, rendering as a scan that ran and concluded —
-        // each time in a NEW flag (TargetUnreadable, then VanillaMissing's cause, then ScanFailed). Per-flag arms only
-        // ever pin the flags that already exist. This asserts the RULE: no state that means "the scan's answer is not
-        // authoritative" may print the conclusion phrase. A fourth such flag added without gating the wording fails
-        // here rather than in a fifth review.
-        (string Name, CompileTools.ImportPlan P)[] degraded =
+        // CLOSURE over the render's boolean state, REFLECTED rather than hand-listed. Three consecutive review passes
+        // found the same shape — a path where the scan did not run, or did not finish, rendering as one that ran and
+        // concluded — each time in a NEW flag. A hand-written array of the flags that already exist cannot catch the
+        // next one, which is precisely the manual step it claims to remove (PR #296, 4th pass: the first version of
+        // this block said it asserted the rule for any future flag while being a pair selected to pass).
+        //
+        // So: every bool on ImportPlan and PapyrusDependencyScan must be CLASSIFIED here. Adding one without a
+        // decision fails the first arm — that is the part no hand-list can do. The classification then says what the
+        // render owes that state, and both answers are asserted, so an exemption is a recorded judgement rather than
+        // an omission that looks like one.
+        //
+        // SUPPRESS = the scan's answer is not authoritative, so the conclusion phrase must not be printed at all.
+        // EXEMPT   = it may print, WITH the stated reason. Not every degraded state is a false claim: a truncated
+        //            walk really did match the folders it names, so "referenced by this script" is a true lower
+        //            bound, and only the set's completeness is in doubt — which its ⚠ states one line down.
+        var classification = new Dictionary<string, (bool Suppress, string Why, CompileTools.ImportPlan? Sample)>
         {
-            ("ScanFailed", failedScan),
-            ("TargetUnreadable", Plan(autoCount: 0, scanned: 501, scan: new PapyrusDependencyScan(
-                Array.Empty<string>(), Indexed: 13235, FilesRead: 0, BudgetExhausted: false, TargetUnreadable: true))),
+            ["ScanFailed"] = (true,
+                "the modlist read threw — there is no conclusion, and an empty root list looks exactly like a modlist with no source folders",
+                failedScan),
+            ["TargetUnreadable"] = (true,
+                "the target's source was never opened, so nothing was resolved from its contents",
+                Plan(autoCount: 0, scanned: 501, scan: new PapyrusDependencyScan(
+                    Array.Empty<string>(), Indexed: 13235, FilesRead: 0, BudgetExhausted: false, TargetUnreadable: true))),
+            ["BudgetExhausted"] = (false,
+                "the walk DID match the folders it names — the claim is a true lower bound; only completeness is in doubt, and the ⚠ says so",
+                Plan(autoCount: 2, scanned: 501, scan: new PapyrusDependencyScan(
+                    Array.Empty<string>(), Indexed: 13235, FilesRead: PapyrusDependencyFilter.MaxFilesRead, BudgetExhausted: true))),
+            ["VanillaMissing"] = (false,
+                "a different axis — the vanilla SLOT, not the scan's answer; it carries its own ⚠ and says nothing about what the script references",
+                null),
+            ["AutoEnabled"] = (false,
+                "not a degradation at all — it records what the caller asked for, and its own summary branch already replaces the phrase",
+                null),
         };
-        foreach (var (name, plan) in degraded)
+
+        var stateFlags = typeof(CompileTools.ImportPlan).GetProperties()
+            .Concat(typeof(PapyrusDependencyScan).GetProperties())
+            .Where(pi => pi.PropertyType == typeof(bool))
+            .Select(pi => pi.Name)
+            .Distinct()
+            .ToList();
+        Check(stateFlags.Count >= 5, $"reflection found the state flags to classify (got {stateFlags.Count}: {string.Join(", ", stateFlags)})");
+        foreach (var name in stateFlags)
+            Check(classification.ContainsKey(name),
+                  $"closure: bool state '{name}' is CLASSIFIED suppress-or-exempt — a new flag cannot reach the render undecided");
+
+        foreach (var (name, (suppress, why, sample)) in classification)
         {
-            var okText = CompileTools.Render(ok, plan, userChoseOutputDir: false);
-            var failText = CompileTools.Render(missingImports, plan, userChoseOutputDir: false);
-            Check(!okText.Contains("referenced by this script"),
-                  $"closure [{name}]: a non-authoritative scan never prints the conclusion phrase (success render)");
-            Check(!failText.Contains("REFERENCES BY NAME"),
-                  $"closure [{name}]: …nor does the missing-imports banner assert it (failure render)");
-            Check(okText.Contains("⚠"), $"closure [{name}]: …and it always carries a ⚠ caveat saying why");
+            if (sample is null) continue;                    // classified by judgement; no render shape of its own
+            var okText = CompileTools.Render(ok, sample, userChoseOutputDir: false);
+            var failText = CompileTools.Render(missingImports, sample, userChoseOutputDir: false);
+            if (suppress)
+            {
+                Check(!okText.Contains("referenced by this script"),
+                      $"closure [{name}] SUPPRESS: the conclusion phrase is withheld on the success render — {why}");
+                Check(!failText.Contains("REFERENCES BY NAME"),
+                      $"closure [{name}] SUPPRESS: …and the banner does not assert it either");
+            }
+            else
+            {
+                Check(okText.Contains("referenced by this script"),
+                      $"closure [{name}] EXEMPT: the conclusion phrase still prints, deliberately — {why}");
+            }
+            Check(okText.Contains("⚠"), $"closure [{name}]: carries a ⚠ caveat either way");
         }
 
         // ---------------------------------------------------------- F: named import sets persist and coexist (#200)

--- a/src/housecarl-generator/CompileErgonomicsProbe.cs
+++ b/src/housecarl-generator/CompileErgonomicsProbe.cs
@@ -164,8 +164,8 @@ internal static class CompileErgonomicsProbe
         var ok = new HousecarlCore.CompileResult(
             Success: true, ObjectName: "MyScript", PexPath: @"C:\out\Scripts\MyScript.pex",
             Diagnostics: Array.Empty<HousecarlCore.PapyrusDiagnostic>(), Stdout: "", Stderr: "", ExitCode: 0, RunError: null);
-        var defaultMsg = CompileTools.Render(ok, Array.Empty<string>(), userChoseOutputDir: false);
-        var outDirMsg = CompileTools.Render(ok, Array.Empty<string>(), userChoseOutputDir: true);
+        var defaultMsg = CompileTools.Render(ok, Plan(), userChoseOutputDir: false);
+        var outDirMsg = CompileTools.Render(ok, Plan(), userChoseOutputDir: true);
         Check(defaultMsg.Contains("houseCARL patch-mod folder") && defaultMsg.Contains("enable it in MO2"),
               "default destination: success names the houseCARL patch-mod folder + the MO2-enable step");
         Check(outDirMsg.Contains("output folder you chose") && !outDirMsg.Contains("houseCARL patch-mod folder"),
@@ -199,9 +199,9 @@ internal static class CompileErgonomicsProbe
                 Diag("variable JMap is undefined"),
             },
             Stdout: "", Stderr: "", ExitCode: 0, RunError: null);
-        var miMsg = CompileTools.Render(missingImports, Array.Empty<string>(), userChoseOutputDir: false);
-        Check(miMsg.Contains("INCOMPLETE import_dirs"), "dominated failure LEADS with the 'INCOMPLETE import_dirs' banner");
-        Check(miMsg.Contains("6 of 6") && miMsg.IndexOf("INCOMPLETE import_dirs", StringComparison.Ordinal) < miMsg.IndexOf("diagnostic(s)", StringComparison.Ordinal),
+        var miMsg = CompileTools.Render(missingImports, Plan(), userChoseOutputDir: false);
+        Check(miMsg.Contains("INCOMPLETE import path"), "dominated failure LEADS with the 'INCOMPLETE import path' banner");
+        Check(miMsg.Contains("6 of 6") && miMsg.IndexOf("INCOMPLETE import path", StringComparison.Ordinal) < miMsg.IndexOf("diagnostic(s)", StringComparison.Ordinal),
               "the banner names the count (6 of 6) and precedes the diagnostic list");
 
         // D3: a SYNTAX failure (the real captured broken-script wording) must NOT mislabel a code bug as a missing import —
@@ -216,8 +216,8 @@ internal static class CompileErgonomicsProbe
                 Diag("missing EOF at 'EndFunction'"),
             },
             Stdout: "", Stderr: "", ExitCode: 0, RunError: null);
-        var synMsg = CompileTools.Render(syntaxFail, Array.Empty<string>(), userChoseOutputDir: false);
-        Check(!synMsg.Contains("INCOMPLETE import_dirs"), "a syntax-only failure does NOT trigger the missing-imports banner (no false positive)");
+        var synMsg = CompileTools.Render(syntaxFail, Plan(), userChoseOutputDir: false);
+        Check(!synMsg.Contains("INCOMPLETE import path"), "a syntax-only failure does NOT trigger the missing-imports banner (no false positive)");
         Check(synMsg.Contains("import path") && synMsg.Contains("import_dirs="), "a syntax-only failure keeps the generic import-path tail as the fallback hint");
 
         // Helper: build a failed compile from N unresolved + M syntax diagnostics, to pin the gate boundary exactly.
@@ -229,7 +229,7 @@ internal static class CompileErgonomicsProbe
             return new HousecarlCore.CompileResult(false, "HCBoundary", null, ds, "", "", 0, null);
         }
         bool Banner(HousecarlCore.CompileResult r) =>
-            CompileTools.Render(r, Array.Empty<string>(), userChoseOutputDir: false).Contains("INCOMPLETE import_dirs");
+            CompileTools.Render(r, Plan(), userChoseOutputDir: false).Contains("INCOMPLETE import path");
 
         // D4: COUNT floor — 2 unresolved is below the >=3 minimum regardless of ratio, so no banner (a 1-2 error typo).
         Check(!Banner(Fail(unresolved: 2, syntax: 0)), "2 unresolved (100% but < 3) → no banner (the >=3 count floor)");
@@ -243,10 +243,180 @@ internal static class CompileErgonomicsProbe
         // …and just over keeps firing (the overwhelming real signature: ~all unresolved).
         Check(Banner(Fail(unresolved: 5, syntax: 1)), "5-of-6 (>2/3) → banner fires");
 
+        // ---------------------------------------------------------- E: the import path is REPORTED (#200)
+        Console.WriteLine();
+        Console.WriteLine("--- E: Render prints WHAT WAS SEARCHED — summary on success, full ordered path on failure (#200) ---");
+
+        // E1: a success no longer drops the import list on the floor (the pre-#200 render took it and never used it).
+        var okMsg = CompileTools.Render(ok, Plan(autoCount: 3, callerCount: 1), userChoseOutputDir: false);
+        Check(okMsg.Contains("imports: 6 dir(s) searched"),
+              "success renders the import summary with the TOTAL (own + 1 caller + 3 auto + vanilla = 6)");
+        Check(okMsg.Contains("1 from import_dirs=") && okMsg.Contains("3 auto-discovered from MO2"),
+              "the summary splits caller dirs from auto-discovered ones");
+        Check(okMsg.Contains("modA") && okMsg.Contains("modC"), "the summary NAMES the providing mods");
+        Check(okMsg.Contains("vanilla sources last"), "the summary states that vanilla ranks last");
+
+        // E2: counts are DERIVED from the entries — a plan whose auto block is empty must not claim providers.
+        var offMsg = CompileTools.Render(ok, Plan(autoEnabled: false), userChoseOutputDir: false);
+        Check(offMsg.Contains("auto_imports=false") && !offMsg.Contains("auto-discovered from MO2"),
+              "auto_imports=false is stated, and no auto-discovery is claimed");
+
+        // E3: the display cap NAMES what it dropped — a truncated provider list must never read as the whole list.
+        var manyMsg = CompileTools.Render(ok, Plan(autoCount: 12), userChoseOutputDir: false);
+        Check(manyMsg.Contains("12 auto-discovered from MO2") && manyMsg.Contains("+4 more"),
+              "over 8 providers: the full COUNT is stated and the tail is named '+4 more' (no silent truncation)");
+
+        // E4: a FAILURE prints the full ordered path with provenance — the summary line cannot answer "in what order".
+        var failPlan = Plan(autoCount: 2, callerCount: 1);
+        var failMsg = CompileTools.Render(syntaxFail, failPlan, userChoseOutputDir: false);
+        Check(failMsg.Contains("import path searched, in order"), "a failure prints the full ordered import path");
+        Check(failPlan.Entries.All(e => failMsg.Contains(e.Dir, StringComparison.Ordinal)),
+              "failure detail lists EVERY dir on the path");
+        Check(failMsg.Contains("[the script's own folder]") && failMsg.Contains("[MO2: modA]")
+              && failMsg.Contains("[import_dirs=]") && failMsg.Contains("[vanilla sources]"),
+              "every entry carries its provenance label (own / MO2:<mod> / import_dirs= / vanilla)");
+        Check(failMsg.IndexOf("[the script's own folder]", StringComparison.Ordinal)
+              < failMsg.IndexOf("[import_dirs=]", StringComparison.Ordinal)
+              && failMsg.IndexOf("[import_dirs=]", StringComparison.Ordinal)
+              < failMsg.IndexOf("[MO2: modA]", StringComparison.Ordinal)
+              && failMsg.IndexOf("[MO2: modA]", StringComparison.Ordinal)
+              < failMsg.IndexOf("[vanilla sources]", StringComparison.Ordinal),
+              "the printed order IS the search order: own > import_dirs= > MO2 > vanilla");
+
+        // E5: the missing-imports banner's REMEDY tracks whether the modlist was scanned. Telling someone to "list every
+        // dependency" when 30 folders are already on the path is the wrong instruction and hides the causes a scan can't
+        // fix (not installed / sources inside a BSA / nested a level down).
+        var scanned = CompileTools.Render(missingImports, Plan(autoCount: 3), userChoseOutputDir: false);
+        var unscanned = CompileTools.Render(missingImports, Plan(autoEnabled: false), userChoseOutputDir: false);
+        Check(scanned.Contains("inside a BSA") && scanned.Contains("3 mod source folder(s)"),
+              "auto_imports ON: the banner names the scan's reach and the causes it cannot fix (BSA / not installed / subfolder)");
+        Check(unscanned.Contains("auto_imports=false") && unscanned.Contains("re-run with auto_imports=true"),
+              "auto_imports OFF: the banner's first remedy is to turn the scan ON");
+        Check(!unscanned.Contains("inside a BSA"),
+              "the two remedies are exclusive — the OFF branch does not also claim a scan happened");
+
+        // E6: a discovery WARNING (unreadable profile) rides the output — losing the ergonomic default is never silent (Q3).
+        var warned = CompileTools.Render(ok, Plan(warning: "auto_imports: could not read the MO2 modlist (boom)"), userChoseOutputDir: false);
+        Check(warned.Contains("could not read the MO2 modlist"), "an auto-discovery warning is surfaced on a SUCCESSFUL compile too");
+
+        // ---------------------------------------------------------- F: named import sets persist and coexist (#200)
+        Console.WriteLine();
+        Console.WriteLine("--- F: UserConfigStore import sets — round-trip, case handling, and the no-clobber contract ---");
+        var fStore = Path.Combine(Path.GetTempPath(), "hc-importset-" + Guid.NewGuid().ToString("N") + ".json");
+        try
+        {
+            var store = new UserConfigStore(fStore);
+            Check(store.GetImportSet("nope") is null, "an unknown set reads as null (never an empty set that would compile short)");
+            Check(store.ImportSetNames().Count == 0, "no sets saved yet → no names");
+
+            // The file's whole point is that four independent concerns share it. Seed the other three FIRST, so a save
+            // that clobbered any of them fails here rather than in a user's config months later.
+            store.Update(c => { c.Mo2InstanceDir = @"C:\MO2"; c.ToolPaths = new Dictionary<string, string> { ["papyrus_compiler"] = @"C:\CK\PapyrusCompiler.exe" }; });
+            store.RecordInPlaceAcknowledged(@"C:\MO2\mods\X\Y.esp");
+
+            var dirs = new[] { @"C:\proj\stubs", @"C:\proj\src" };
+            var (savedOk, savedErr) = store.SaveImportSet("MyProject", dirs);
+            Check(savedOk, $"a set saves ({savedErr})");
+            var back = store.GetImportSet("MyProject");
+            Check(back is not null && back.SequenceEqual(dirs), "the set round-trips in ORDER (order is compiler semantics)");
+            Check(store.GetImportSet("myproject") is not null, "lookup is case-INSENSITIVE (JSON hands the dictionary back with an ordinal comparer)");
+            Check(store.GetImportSet(" MyProject ") is not null, "lookup trims the name");
+
+            var after = store.Load();
+            Check(after.Mo2InstanceDir == @"C:\MO2", "saving a set does NOT clobber the MO2 instance dir");
+            Check(after.ToolPaths is not null && after.ToolPaths.ContainsKey("papyrus_compiler"), "…nor the saved tool paths");
+            Check(after.InPlaceAcknowledged is { Count: 1 }, "…nor the in-place acknowledgements");
+
+            // Re-saving under a different CASE must REPLACE, not add a second set the case-insensitive read would then
+            // pick between arbitrarily.
+            store.SaveImportSet("myproject", new[] { @"C:\other" });
+            Check(store.Load().ImportSets!.Count == 1, "re-saving with different case REPLACES (one set, not two)");
+            var replaced = store.GetImportSet("MYPROJECT");
+            Check(replaced is not null && replaced.Count == 1 && replaced[0] == @"C:\other", "the replacement's dirs win");
+
+            store.SaveImportSet("alpha", new[] { @"C:\a" });
+            Check(store.ImportSetNames().SequenceEqual(new[] { "alpha", "myproject" }), "names come back sorted (for the unknown-name 'saved sets:' list)");
+        }
+        finally { try { File.Delete(fStore); } catch { /* non-fatal */ } }
+
+        // ---------------------------------------------------------- G: PapyrusSourceRoots — the modlist scan (#200)
+        Console.WriteLine();
+        Console.WriteLine("--- G: PapyrusSourceRoots.Discover — both layouts, .psc-gated, precedence-ordered, deduped ---");
+        var gRoot = Path.Combine(Path.GetTempPath(), "hc-pyroots-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            // A fabricated MO2 loose-root tree: an SE-layout mod, an LE-layout mod, a mod with the folder but no .psc,
+            // a mod with no source folder at all, and a root whose folder holds ONLY a longer-extension file.
+            string Mk(string mod, string layout, params string[] files)
+            {
+                var d = Path.Combine(gRoot, mod, layout);
+                Directory.CreateDirectory(d);
+                foreach (var f in files) File.WriteAllText(Path.Combine(d, f), "Scriptname X\n");
+                return d;
+            }
+            var seDir = Mk("SKSE", @"Source\Scripts", "Actor.psc", "Game.psc");
+            var leDir = Mk("OldMod", @"Scripts\Source", "Legacy.psc");
+            var emptyDir = Mk("PexOnly", @"Source\Scripts");                       // folder exists, no sources
+            var longExt = Mk("LongExt", @"Source\Scripts", "NotASource.pscx");     // 8.3 pattern-match trap
+            Directory.CreateDirectory(Path.Combine(gRoot, "NoSources"));
+
+            var roots = new (string, string)[]
+            {
+                ("overwrite", Path.Combine(gRoot, "overwrite")),                   // does not exist at all
+                ("SKSE", Path.Combine(gRoot, "SKSE")),
+                ("PexOnly", Path.Combine(gRoot, "PexOnly")),
+                ("OldMod", Path.Combine(gRoot, "OldMod")),
+                ("LongExt", Path.Combine(gRoot, "LongExt")),
+                ("NoSources", Path.Combine(gRoot, "NoSources")),
+            };
+            var found = PapyrusSourceRoots.Discover(roots);
+            Check(found.Count == 2, $"only the two roots that actually HOLD .psc are returned (got {found.Count})");
+            Check(found[0].Dir == seDir && found[0].Provider == "SKSE" && found[0].Layout == @"Source\Scripts",
+                  "the SE layout (Source\\Scripts) is found and tagged with its providing mod");
+            Check(found[1].Dir == leDir && found[1].Layout == @"Scripts\Source",
+                  "the LE layout (Scripts\\Source) is found too");
+            Check(found.All(f => f.Dir != emptyDir), "a source folder with NO .psc contributes nothing (would widen the path for free)");
+            // NO TEETH HERE, and said so rather than left to look like a proof: removing HasSources' explicit
+            // EndsWith re-check did NOT turn this arm red (falsified 2026-07-28), i.e. this machine's pattern matcher
+            // never returned the .pscx in the first place — the 8.3 short-name quirk the re-check guards is
+            // volume-dependent. Kept as a shape-check: it fails loudly if the .psc gate is ever dropped entirely.
+            Check(!PapyrusSourceRoots.HasSources(longExt),
+                  "a folder holding only '.pscx' is NOT a source folder (shape-check — the 8.3 quirk this guards did not reproduce here)");
+            Check(found.Select(f => f.Provider).SequenceEqual(new[] { "SKSE", "OldMod" }),
+                  "the GIVEN root order is preserved — that order IS MO2 precedence, and precedence decides which copy wins");
+
+            // A root reached twice (an MO2 setup can point two roots at one folder) must occupy ONE slot: the first.
+            var dupRoots = new (string, string)[] { ("SKSE", Path.Combine(gRoot, "SKSE")), ("Clone", Path.Combine(gRoot, "SKSE")) };
+            var deduped = PapyrusSourceRoots.Discover(dupRoots);
+            Check(deduped.Count == 1 && deduped[0].Provider == "SKSE", "the same folder twice → ONE entry, the higher-precedence root keeps it");
+
+            // Best-effort by contract: a missing / nonsense root costs one candidate, never the scan.
+            bool threw = false;
+            try { PapyrusSourceRoots.Discover(new (string, string)[] { ("bad", "\0not a path"), ("gone", Path.Combine(gRoot, "nope")), ("blank", "") }); }
+            catch { threw = true; }
+            Check(!threw, "an unusable root is skipped, never thrown on (a lost import dir must not cost the compile)");
+        }
+        finally { try { Directory.Delete(gRoot, recursive: true); } catch { /* non-fatal */ } }
+
         Console.WriteLine();
         Console.WriteLine(fail == 0
             ? "================ ALL PASS ================"
             : $"================ {fail} CHECK(S) FAILED ================");
         return fail == 0 ? 0 : 1;
+    }
+
+    /// <summary>A synthetic <see cref="CompileTools.ImportPlan"/> for the render arms — a real one needs a compiler on
+    /// disk and an MO2 profile, and these arms are about what Render PRINTS, not about how the path was assembled
+    /// (<see cref="ImportOrderProbe"/> owns the assembly contract). Shaped exactly like a real plan: the script's own
+    /// folder first, then caller dirs, then auto-discovered mods, then vanilla last.</summary>
+    static CompileTools.ImportPlan Plan(bool autoEnabled = true, int autoCount = 0, int callerCount = 0,
+                                        string? setName = null, string? warning = null)
+    {
+        var e = new List<(string Dir, string Origin)> { (@"C:\work", CompileTools.ImportPlan.OwnFolder) };
+        for (int i = 0; i < callerCount; i++) e.Add(($@"C:\caller{i}", CompileTools.ImportPlan.CallerDirs));
+        for (int i = 0; i < autoCount; i++)
+            e.Add(($@"C:\MO2\mods\mod{(char)('A' + i)}\Source\Scripts", CompileTools.ImportPlan.AutoPrefix + "mod" + (char)('A' + i)));
+        e.Add((@"C:\Game\Data\Source\Scripts", CompileTools.ImportPlan.Vanilla));
+        return new CompileTools.ImportPlan(e, autoEnabled, setName, warning);
     }
 }

--- a/src/housecarl-generator/CompileErgonomicsProbe.cs
+++ b/src/housecarl-generator/CompileErgonomicsProbe.cs
@@ -248,23 +248,33 @@ internal static class CompileErgonomicsProbe
         Console.WriteLine("--- E: Render prints WHAT WAS SEARCHED — summary on success, full ordered path on failure (#200) ---");
 
         // E1: a success no longer drops the import list on the floor (the pre-#200 render took it and never used it).
-        var okMsg = CompileTools.Render(ok, Plan(autoCount: 3, callerCount: 1), userChoseOutputDir: false);
+        // The 3-of-501 shape is the real one, measured on ARR 2.0 — reporting only the survivors would read as
+        // "your modlist ships 3 source folders", wrong by two orders of magnitude.
+        var okMsg = CompileTools.Render(ok, Plan(autoCount: 3, callerCount: 1, scanned: 501), userChoseOutputDir: false);
         Check(okMsg.Contains("imports: 6 dir(s) searched"),
               "success renders the import summary with the TOTAL (own + 1 caller + 3 auto + vanilla = 6)");
-        Check(okMsg.Contains("1 from import_dirs=") && okMsg.Contains("3 auto-discovered from MO2"),
-              "the summary splits caller dirs from auto-discovered ones");
+        Check(okMsg.Contains("1 from import_dirs=") && okMsg.Contains("3 of 501 scanned mod source folder(s) referenced by this script"),
+              "the summary splits caller dirs from the scan, and reports BOTH scan numbers (kept AND scanned)");
         Check(okMsg.Contains("modA") && okMsg.Contains("modC"), "the summary NAMES the providing mods");
         Check(okMsg.Contains("vanilla sources last"), "the summary states that vanilla ranks last");
 
         // E2: counts are DERIVED from the entries — a plan whose auto block is empty must not claim providers.
         var offMsg = CompileTools.Render(ok, Plan(autoEnabled: false), userChoseOutputDir: false);
-        Check(offMsg.Contains("auto_imports=false") && !offMsg.Contains("auto-discovered from MO2"),
-              "auto_imports=false is stated, and no auto-discovery is claimed");
+        Check(offMsg.Contains("auto_imports=false") && !offMsg.Contains("scanned mod source folder"),
+              "auto_imports=false is stated, and no scan is claimed");
 
         // E3: the display cap NAMES what it dropped — a truncated provider list must never read as the whole list.
         var manyMsg = CompileTools.Render(ok, Plan(autoCount: 12), userChoseOutputDir: false);
-        Check(manyMsg.Contains("12 auto-discovered from MO2") && manyMsg.Contains("+4 more"),
+        Check(manyMsg.Contains("12 of 12 scanned mod source folder(s)") && manyMsg.Contains("+4 more"),
               "over 8 providers: the full COUNT is stated and the tail is named '+4 more' (no silent truncation)");
+
+        // E3b: hitting the reference-walk ceiling is DISCLOSED — a shortened path must never look like a complete one.
+        var cappedMsg = CompileTools.Render(ok, Plan(autoCount: 2, scan: new PapyrusDependencyScan(
+                Array.Empty<string>(), Indexed: 13235, FilesRead: PapyrusDependencyFilter.MaxFilesRead, BudgetExhausted: true)),
+            userChoseOutputDir: false);
+        Check(cappedMsg.Contains("reference walk stopped") && cappedMsg.Contains(PapyrusDependencyFilter.MaxFilesRead.ToString()),
+              "an exhausted reference-walk budget is surfaced with its ceiling (Q3 — no silently shortened import path)");
+        Check(!okMsg.Contains("reference walk stopped"), "…and a completed walk says nothing (no false alarm)");
 
         // E4: a FAILURE prints the full ordered path with provenance — the summary line cannot answer "in what order".
         var failPlan = Plan(autoCount: 2, callerCount: 1);
@@ -286,10 +296,10 @@ internal static class CompileErgonomicsProbe
         // E5: the missing-imports banner's REMEDY tracks whether the modlist was scanned. Telling someone to "list every
         // dependency" when 30 folders are already on the path is the wrong instruction and hides the causes a scan can't
         // fix (not installed / sources inside a BSA / nested a level down).
-        var scanned = CompileTools.Render(missingImports, Plan(autoCount: 3), userChoseOutputDir: false);
+        var scanned = CompileTools.Render(missingImports, Plan(autoCount: 3, scanned: 501), userChoseOutputDir: false);
         var unscanned = CompileTools.Render(missingImports, Plan(autoEnabled: false), userChoseOutputDir: false);
-        Check(scanned.Contains("inside a BSA") && scanned.Contains("3 mod source folder(s)"),
-              "auto_imports ON: the banner names the scan's reach and the causes it cannot fix (BSA / not installed / subfolder)");
+        Check(scanned.Contains("inside a BSA") && scanned.Contains("found 501 mod source folder(s) and kept the 3"),
+              "auto_imports ON: the banner names what the scan found AND kept, plus the causes it cannot fix (never named / not installed / BSA / subfolder)");
         Check(unscanned.Contains("auto_imports=false") && unscanned.Contains("re-run with auto_imports=true"),
               "auto_imports OFF: the banner's first remedy is to turn the scan ON");
         Check(!unscanned.Contains("inside a BSA"),
@@ -398,6 +408,77 @@ internal static class CompileErgonomicsProbe
         }
         finally { try { Directory.Delete(gRoot, recursive: true); } catch { /* non-fatal */ } }
 
+        // ---------------------------------------------------------- H: the reference walk (#200's load-bearing narrowing)
+        Console.WriteLine();
+        Console.WriteLine("--- H: PapyrusDependencyFilter.Relevant — direct, TRANSITIVE, precedence, and the unreferenced drop ---");
+        var hRoot = Path.Combine(Path.GetTempPath(), "hc-pydeps-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            string Folder(string name, params (string File, string Body)[] scripts)
+            {
+                var d = Path.Combine(hRoot, name);
+                Directory.CreateDirectory(d);
+                foreach (var (f, b) in scripts) File.WriteAllText(Path.Combine(d, f + ".psc"), b);
+                return d;
+            }
+
+            // own ──references──> Framework ──references──> Deep.  Unrelated is named by nobody.
+            var own = Folder("own", ("Target", "Scriptname Target extends Quest\n\nFunction Go()\n    Framework.Ping()\nEndFunction\n"));
+            var framework = Folder("framework", ("Framework", "Scriptname Framework\n\nDeep Function Get() global\n    return None\nEndFunction\n"));
+            var deep = Folder("deep", ("Deep", "Scriptname Deep\n"));
+            var unrelated = Folder("unrelated", ("Unrelated", "Scriptname Unrelated\n"));
+            var target = Path.Combine(own, "Target.psc");
+            var candidates = new[] { framework, deep, unrelated };
+
+            var scan = PapyrusDependencyFilter.Relevant(target, new[] { own }, candidates);
+            Check(scan.Folders.Contains(framework), "a folder the target names DIRECTLY is kept");
+            Check(scan.Folders.Contains(deep),
+                  "a folder reached only THROUGH that dependency is kept — the walk is transitive, because type-checking " +
+                  "loads a dependency's own dependencies (one level would compile-fail on Deep)");
+            Check(!scan.Folders.Contains(unrelated), "a folder nothing references is DROPPED");
+            Check(scan.Folders.SequenceEqual(new[] { framework, deep }),
+                  "kept folders come back in the CANDIDATE order (MO2 precedence), not discovery order");
+            Check(!scan.Folders.Contains(own), "a SEED folder is indexed but never returned (the caller adds it unconditionally)");
+            // 4 reads, not 3: the seed read, then Target again (its own `Scriptname Target` token resolves back to its
+            // own folder), then Framework and Deep. The re-read is harmless — `seen` stops each NAME once — and costs
+            // one file, so it is not worth special-casing; the number is asserted as what actually happens.
+            Check(scan.Indexed == 4 && scan.FilesRead == 4 && !scan.BudgetExhausted,
+                  $"the disclosed numbers are real: 4 indexed, 4 read (seed, Target, Framework, Deep) (got {scan.Indexed}/{scan.FilesRead})");
+
+            // PRECEDENCE: two folders provide the same script NAME. The compiler takes the first match on the path, so
+            // only that folder can ever be justified by that name — indexing both would put a shadowed copy on the path.
+            var winner = Folder("winner", ("Shared", "Scriptname Shared\n"));
+            var loser = Folder("loser", ("Shared", "Scriptname Shared\n"));
+            var shTarget = Path.Combine(Folder("shOwn", ("ShTarget", "Scriptname ShTarget\n\nShared s\n")), "ShTarget.psc");
+            var shScan = PapyrusDependencyFilter.Relevant(shTarget, new[] { Path.Combine(hRoot, "shOwn") }, new[] { winner, loser });
+            Check(shScan.Folders.SequenceEqual(new[] { winner }),
+                  "a name provided twice resolves to the HIGHER-precedence folder only — the loser's copy never joins the path");
+
+            // Over-inclusion is the deliberate bias: a name mentioned in a COMMENT still earns its folder, because the
+            // cost is one extra import dir and the opposite error is a compile that used to work and now doesn't.
+            var cmtTarget = Path.Combine(Folder("cmtOwn", ("CmtTarget", "Scriptname CmtTarget\n; TODO: wire up Framework later\n")), "CmtTarget.psc");
+            var cmtScan = PapyrusDependencyFilter.Relevant(cmtTarget, new[] { Path.Combine(hRoot, "cmtOwn") }, new[] { framework, deep, unrelated });
+            Check(cmtScan.Folders.Contains(framework),
+                  "a name appearing only in a comment still earns its folder (deliberate over-inclusion — a wrongly DROPPED folder is the costly error)");
+
+            // A target that cannot be read yields nothing rather than throwing: the compile still runs and fails with
+            // the compiler's own message, which is a better error than the filter's.
+            bool blewUp = false;
+            PapyrusDependencyScan? missing = null;
+            try { missing = PapyrusDependencyFilter.Relevant(Path.Combine(hRoot, "no-such.psc"), new[] { own }, candidates); }
+            catch { blewUp = true; }
+            Check(!blewUp && missing is not null && missing.Folders.Count == 0,
+                  "an unreadable target returns an empty set, never a throw (the compiler's own error is the better one)");
+
+            // A cycle (A references B references A) must terminate — scripts reference each other routinely.
+            var cycA = Folder("cycA", ("CycA", "Scriptname CycA\n\nCycB b\n"));
+            var cycB = Folder("cycB", ("CycB", "Scriptname CycB\n\nCycA a\n"));
+            var cycTarget = Path.Combine(Folder("cycOwn", ("CycTarget", "Scriptname CycTarget\n\nCycA a\n")), "CycTarget.psc");
+            var cycScan = PapyrusDependencyFilter.Relevant(cycTarget, new[] { Path.Combine(hRoot, "cycOwn") }, new[] { cycA, cycB });
+            Check(cycScan.Folders.SequenceEqual(new[] { cycA, cycB }), "a reference CYCLE terminates and keeps both folders");
+        }
+        finally { try { Directory.Delete(hRoot, recursive: true); } catch { /* non-fatal */ } }
+
         Console.WriteLine();
         Console.WriteLine(fail == 0
             ? "================ ALL PASS ================"
@@ -410,13 +491,14 @@ internal static class CompileErgonomicsProbe
     /// (<see cref="ImportOrderProbe"/> owns the assembly contract). Shaped exactly like a real plan: the script's own
     /// folder first, then caller dirs, then auto-discovered mods, then vanilla last.</summary>
     static CompileTools.ImportPlan Plan(bool autoEnabled = true, int autoCount = 0, int callerCount = 0,
-                                        string? setName = null, string? warning = null)
+                                        string? setName = null, string? warning = null, int scanned = -1,
+                                        PapyrusDependencyScan? scan = null)
     {
         var e = new List<(string Dir, string Origin)> { (@"C:\work", CompileTools.ImportPlan.OwnFolder) };
         for (int i = 0; i < callerCount; i++) e.Add(($@"C:\caller{i}", CompileTools.ImportPlan.CallerDirs));
         for (int i = 0; i < autoCount; i++)
             e.Add(($@"C:\MO2\mods\mod{(char)('A' + i)}\Source\Scripts", CompileTools.ImportPlan.AutoPrefix + "mod" + (char)('A' + i)));
         e.Add((@"C:\Game\Data\Source\Scripts", CompileTools.ImportPlan.Vanilla));
-        return new CompileTools.ImportPlan(e, autoEnabled, setName, warning);
+        return new CompileTools.ImportPlan(e, autoEnabled, setName, warning, scanned < 0 ? autoCount : scanned, scan);
     }
 }

--- a/src/housecarl-generator/CompileErgonomicsProbe.cs
+++ b/src/housecarl-generator/CompileErgonomicsProbe.cs
@@ -276,6 +276,27 @@ internal static class CompileErgonomicsProbe
               "an exhausted reference-walk budget is surfaced with its ceiling (Q3 — no silently shortened import path)");
         Check(!okMsg.Contains("reference walk stopped"), "…and a completed walk says nothing (no false alarm)");
 
+        // E3c (PR #296 review): the caveat is written FOR the failing run — its own text ends "if the compile fails on
+        // unresolved symbols, pass that folder via import_dirs=" — yet it lived only in ImportSummary, which Render
+        // calls only when the compile SUCCEEDED. The failing run got the confident banner and no disclosure at all.
+        var cappedPlan = Plan(autoCount: 2, scanned: 501, scan: new PapyrusDependencyScan(
+            Array.Empty<string>(), Indexed: 13235, FilesRead: PapyrusDependencyFilter.MaxFilesRead, BudgetExhausted: true));
+        var cappedFail = CompileTools.Render(missingImports, cappedPlan, userChoseOutputDir: false);
+        Check(cappedFail.Contains("reference walk stopped"),
+              "the truncation caveat reaches the FAILED render too — the run it was written for");
+        Check(!cappedFail.Contains("REFERENCES BY NAME") && cappedFail.Contains("START WITH THE ⚠ NOTE BELOW"),
+              "…and the banner stops asserting a complete narrowing, pointing at the caveat instead of at causes that exclude it");
+
+        // E3d: the same for an UNREADABLE target. An empty result must not be rendered as a claim about the source's
+        // contents when the source was never opened.
+        var unreadPlan = Plan(autoCount: 0, scanned: 501, scan: new PapyrusDependencyScan(
+            Array.Empty<string>(), Indexed: 13235, FilesRead: 0, BudgetExhausted: false, TargetUnreadable: true));
+        var unreadOk = CompileTools.Render(ok, unreadPlan, userChoseOutputDir: false);
+        Check(unreadOk.Contains("could not be READ") && !unreadOk.Contains("referenced by this script"),
+              "an unreadable target is SAID, and the summary drops the 'referenced by this script' claim it never earned");
+        Check(CompileTools.Render(missingImports, unreadPlan, userChoseOutputDir: false).Contains("could not be READ"),
+              "…on the failed render too");
+
         // E4: a FAILURE prints the full ordered path with provenance — the summary line cannot answer "in what order".
         var failPlan = Plan(autoCount: 2, callerCount: 1);
         var failMsg = CompileTools.Render(syntaxFail, failPlan, userChoseOutputDir: false);
@@ -306,8 +327,23 @@ internal static class CompileErgonomicsProbe
               "the two remedies are exclusive — the OFF branch does not also claim a scan happened");
 
         // E6: a discovery WARNING (unreadable profile) rides the output — losing the ergonomic default is never silent (Q3).
-        var warned = CompileTools.Render(ok, Plan(warning: "auto_imports: could not read the MO2 modlist (boom)"), userChoseOutputDir: false);
+        var warnPlan = Plan(warning: "auto_imports: could not read the MO2 modlist (boom)");
+        var warned = CompileTools.Render(ok, warnPlan, userChoseOutputDir: false);
         Check(warned.Contains("could not read the MO2 modlist"), "an auto-discovery warning is surfaced on a SUCCESSFUL compile too");
+        Check(CompileTools.Render(syntaxFail, warnPlan, userChoseOutputDir: false).Contains("could not read the MO2 modlist"),
+              "…and on a failure WITH diagnostics");
+
+        // E6b (PR #296 review): the third render branch — a failure the diagnostic parser cannot split — appended the
+        // import path but NOT the warning, so "houseCARL could not LOOK at your modlist" was discarded and the reader
+        // was left to read a two-entry path as "nothing is installed".
+        var unparseable = new HousecarlCore.CompileResult(
+            Success: false, ObjectName: "HCRaw", PexPath: null,
+            Diagnostics: Array.Empty<HousecarlCore.PapyrusDiagnostic>(),
+            Stdout: "something the parser cannot split", Stderr: "", ExitCode: 1, RunError: null);
+        var rawMsg = CompileTools.Render(unparseable, warnPlan, userChoseOutputDir: false);
+        Check(rawMsg.Contains("no per-line diagnostics were parsed"), "control: this really is the raw-output branch");
+        Check(rawMsg.Contains("could not read the MO2 modlist"),
+              "the discovery warning survives the no-parseable-diagnostics branch too (every branch that prints a path prints its caveats)");
 
         // ---------------------------------------------------------- F: named import sets persist and coexist (#200)
         Console.WriteLine();
@@ -400,6 +436,29 @@ internal static class CompileErgonomicsProbe
             var deduped = PapyrusSourceRoots.Discover(dupRoots);
             Check(deduped.Count == 1 && deduped[0].Provider == "SKSE", "the same folder twice → ONE entry, the higher-precedence root keeps it");
 
+            // ExcludeGameData (PR #296 review): the game's own Data root is not a mod. The rider ALSO drops whatever
+            // matches the COMPILER's vanilla dir — but on a Wabbajack Stock Game setup those are different folders by
+            // design (the CK compiler lives in the real Steam install), so that check never fires there and the base
+            // game would rank as an ordinary mod: labelled [MO2: Data], counted in the summary, and — because Data is
+            // last in precedence, hence the fallback provider for every unshadowed vanilla name — dragging the
+            // reference walk through the whole base game. The arm is built with the data dir DELIBERATELY unrelated to
+            // any compiler path, which is the case the old check could not see.
+            var stockData = Mk("StockGameData", @"Source\Scripts", "Form.psc", "Quest.psc");
+            var stockRoots = new (string, string)[]
+            {
+                ("SKSE", Path.Combine(gRoot, "SKSE")),
+                ("Data", Path.Combine(gRoot, "StockGameData")),
+            };
+            var withData = PapyrusSourceRoots.Discover(stockRoots);
+            Check(withData.Any(r => r.Dir == stockData), "control: the scan DOES find the game's own Data sources (they hold .psc)");
+            var noData = PapyrusSourceRoots.ExcludeGameData(withData, Path.Combine(gRoot, "StockGameData"));
+            Check(noData.All(r => r.Dir != stockData) && noData.Count == withData.Count - 1,
+                  "ExcludeGameData drops the game's Data sources by PATH — no dependence on them coinciding with the compiler's vanilla dir");
+            Check(noData.Any(r => r.Provider == "SKSE"), "…and drops nothing else");
+            Check(PapyrusSourceRoots.ExcludeGameData(withData, null).Count == withData.Count
+                  && PapyrusSourceRoots.ExcludeGameData(withData, "  ").Count == withData.Count,
+                  "a blank data dir drops NOTHING (Path.Combine would otherwise resolve the layouts against the process CWD)");
+
             // Best-effort by contract: a missing / nonsense root costs one candidate, never the scan.
             bool threw = false;
             try { PapyrusSourceRoots.Discover(new (string, string)[] { ("bad", "\0not a path"), ("gone", Path.Combine(gRoot, "nope")), ("blank", "") }); }
@@ -469,6 +528,10 @@ internal static class CompileErgonomicsProbe
             catch { blewUp = true; }
             Check(!blewUp && missing is not null && missing.Folders.Count == 0,
                   "an unreadable target returns an empty set, never a throw (the compiler's own error is the better one)");
+            // PR #296 review: empty-because-unreadable must be DISTINGUISHABLE from empty-because-nothing-matched, or
+            // the render turns it into "0 of 501 referenced by this script" — a claim about contents never examined.
+            Check(missing is { TargetUnreadable: true }, "…and it is FLAGGED unreadable, not passed off as a walk that found nothing");
+            Check(!scan.TargetUnreadable, "…while a real walk is not flagged (no false alarm)");
 
             // A cycle (A references B references A) must terminate — scripts reference each other routinely.
             var cycA = Folder("cycA", ("CycA", "Scriptname CycA\n\nCycB b\n"));

--- a/src/housecarl-generator/CompileErgonomicsProbe.cs
+++ b/src/housecarl-generator/CompileErgonomicsProbe.cs
@@ -345,6 +345,62 @@ internal static class CompileErgonomicsProbe
         Check(rawMsg.Contains("could not read the MO2 modlist"),
               "the discovery warning survives the no-parseable-diagnostics branch too (every branch that prints a path prints its caveats)");
 
+        // E7 (PR #296 re-review, 3rd pass): a FAILED modlist read must not render as a scan that ran and concluded.
+        // An empty root list from a read that threw is indistinguishable from a modlist with no source folders, and
+        // the three statements collided: a "matched 0 of 0 … referenced by this script" conclusion, a claim that
+        // houseCARL had looked under the MO2 data folder, and a tail asserting vanilla was on a single-entry path.
+        var failWarning = "modlist scan: could not read the MO2 modlist to discover Papyrus source folders (boom) — " +
+                          "none of your installed mods' source folders are on the import path for this compile.";
+        var failedScan = new CompileTools.ImportPlan(
+            new[] { (@"C:\work", CompileTools.ImportPlan.OwnFolder) },
+            AutoEnabled: true, ImportSetName: null, Warning: failWarning,
+            AutoScanned: 0, Scan: null, ReferencedProviders: null, VanillaMissing: true, ScanFailed: true);
+        var failedText = CompileTools.Render(ok, failedScan, userChoseOutputDir: false);
+        Check(!failedText.Contains("referenced by this script") && !failedText.Contains("matched 0 of 0"),
+              "a failed modlist read draws NO scan conclusion — 'matched 0 of 0 … referenced by this script' is a verdict a read that threw never reached");
+        Check(failedText.Contains("modlist could NOT be read"), "…it says the read failed instead");
+        Check(failedText.Contains("could not read your MO2 modlist to look under the data folder")
+              && !failedText.Contains("and none under your MO2 data folder"),
+              "the vanilla caveat stops claiming houseCARL LOOKED under the data folder — which of the two it is changes the fix");
+        Check(!failedText.Contains("vanilla sources are on the import path"),
+              "…and no tail asserts a vanilla slot two lines under a caveat saying there is none");
+        Check(!failedText.Contains("auto_imports:"),
+              "the warning is labelled 'modlist scan', not 'auto_imports' — the rider reaches this read with auto_imports OFF too");
+
+        // …and the same on the failure render, where the banner would otherwise blame the script.
+        var failedBanner = CompileTools.Render(missingImports, failedScan, userChoseOutputDir: false);
+        Check(failedBanner.Contains("The modlist could NOT be read") && !failedBanner.Contains("REFERENCES BY NAME"),
+              "the missing-imports banner leads with the failed read, not with causes that presuppose a scan happened");
+
+        // Control: a scan that RAN and genuinely matched nothing still says so — the flag must not swallow the real
+        // zero, which is a legitimate conclusion.
+        var realZero = CompileTools.Render(ok, Plan(autoCount: 0, scanned: 501), userChoseOutputDir: false);
+        Check(realZero.Contains("matched 0 of 501") && realZero.Contains("referenced by this script"),
+              "a scan that ran and matched nothing DOES report that conclusion (no false alarm)");
+
+        // CLOSURE over the degraded-scan flags, not another one-off. Three consecutive review passes found the same
+        // shape — a path where the scan did not run, or did not finish, rendering as a scan that ran and concluded —
+        // each time in a NEW flag (TargetUnreadable, then VanillaMissing's cause, then ScanFailed). Per-flag arms only
+        // ever pin the flags that already exist. This asserts the RULE: no state that means "the scan's answer is not
+        // authoritative" may print the conclusion phrase. A fourth such flag added without gating the wording fails
+        // here rather than in a fifth review.
+        (string Name, CompileTools.ImportPlan P)[] degraded =
+        {
+            ("ScanFailed", failedScan),
+            ("TargetUnreadable", Plan(autoCount: 0, scanned: 501, scan: new PapyrusDependencyScan(
+                Array.Empty<string>(), Indexed: 13235, FilesRead: 0, BudgetExhausted: false, TargetUnreadable: true))),
+        };
+        foreach (var (name, plan) in degraded)
+        {
+            var okText = CompileTools.Render(ok, plan, userChoseOutputDir: false);
+            var failText = CompileTools.Render(missingImports, plan, userChoseOutputDir: false);
+            Check(!okText.Contains("referenced by this script"),
+                  $"closure [{name}]: a non-authoritative scan never prints the conclusion phrase (success render)");
+            Check(!failText.Contains("REFERENCES BY NAME"),
+                  $"closure [{name}]: …nor does the missing-imports banner assert it (failure render)");
+            Check(okText.Contains("⚠"), $"closure [{name}]: …and it always carries a ⚠ caveat saying why");
+        }
+
         // ---------------------------------------------------------- F: named import sets persist and coexist (#200)
         Console.WriteLine();
         Console.WriteLine("--- F: UserConfigStore import sets — round-trip, case handling, and the no-clobber contract ---");

--- a/src/housecarl-generator/ImportOrderProbe.cs
+++ b/src/housecarl-generator/ImportOrderProbe.cs
@@ -186,6 +186,56 @@ internal static class ImportOrderProbe
                 new[] { Root("SKSE", autoA) }, autoEnabled: true, importSetName: null, warning: null);
             Check(overlap3.CallerCount == 1 && overlap3.AutoProviders.Count == 0,
                   "a KEPT candidate the caller also passed counts as the caller's — it would be on the path with the scan switched off");
+            // …and the mirror of that (PR #296 re-review): taking the caller SLOT must not erase the fact that the
+            // WALK matched it. AutoProviders answers "why is this folder on the path"; Referenced answers "what does
+            // this script reference" — the number the summary and the banner quote. One field doing both made a
+            // genuine match render as "matched the 0 this script REFERENCES BY NAME".
+            var overlapRef = CompileTools.PlanImports(
+                targetPsc, scriptDir, fakeCompiler, new[] { autoA },
+                new[] { Root("SKSE", autoA), Root("PapyrusUtil", autoB) },
+                autoEnabled: true, importSetName: null, warning: null);
+            Check(overlapRef.Referenced.SequenceEqual(new[] { "SKSE" }),
+                  "a folder the walk matched stays in the REFERENCED count even when the caller also passed it (slot ≠ reference)");
+            Check(overlapRef.AutoProviders.Count == 0 && overlapRef.CallerCount == 1,
+                  "…while the SLOT attribution still credits the caller (the two questions answered separately)");
+            Check(CompileTools.ImportSummary(overlapRef).Contains("matched 1 of 2"),
+                  "…and the summary quotes the walk's number, not the slot's");
+
+            // THE REGRESSION THE RE-REVIEW CAUGHT. Splitting the game's Data sources out of the mod candidates is only
+            // safe if something still fills the vanilla slot. With a compiler whose own <game>\Data\Source\Scripts does
+            // not exist — a hand-set compiler path, or a Stock Game whose sources live under MO2's data dir — the fold
+            // left the path with NO vanilla at all, and every compile would fail on Form/Quest/ObjectReference while
+            // the banner blamed a missing mod.
+            var noSrcCompiler = Path.Combine(fake, "nogame", "Papyrus Compiler", "PapyrusCompiler.exe");
+            Directory.CreateDirectory(Path.GetDirectoryName(noSrcCompiler)!);
+            Check(CompileTools.VanillaSourceDir(noSrcCompiler) is null, "control: this compiler has no vanilla sources beside it");
+            var rescued = CompileTools.PlanImports(
+                targetPsc, scriptDir, noSrcCompiler, Array.Empty<string>(),
+                new[] { Root("SKSE", autoA) }, autoEnabled: true, importSetName: null, warning: null,
+                gameDataSources: fakeVanilla);
+            Check(rescued.Dirs.Any(d => d.Equals(fakeVanilla, StringComparison.OrdinalIgnoreCase)),
+                  "the modlist's own Data sources fill the vanilla slot when the compiler-relative folder is missing");
+            Check(rescued.Entries[^1].Dir.Equals(fakeVanilla, StringComparison.OrdinalIgnoreCase)
+                  && rescued.Entries[^1].Origin == CompileTools.ImportPlan.Vanilla,
+                  "…in the vanilla slot: LAST, and labelled vanilla rather than as a mod");
+            Check(!rescued.VanillaMissing, "…and the plan does not claim vanilla is missing");
+            // ONE decision, not two: the plan's VanillaMissing and the assembled path must be the same answer. They
+            // were computed by two copies of the same expression, so a change to either could have left the plan
+            // reporting a vanilla slot the path did not carry.
+            Check(rescued.VanillaMissing == !rescued.Entries.Any(e => e.Origin == CompileTools.ImportPlan.Vanilla),
+                  "VanillaMissing agrees with the assembled path (the vanilla dir is resolved ONCE and handed down)");
+            Check(CompileTools.BuildImports(scriptDir, noSrcCompiler, null, null, fakeVanilla)[^1]
+                      .Equals(fakeVanilla, StringComparison.OrdinalIgnoreCase),
+                  "BuildImports takes the caller's RESOLVED vanilla dir rather than re-deriving its own");
+
+            var stranded = CompileTools.PlanImports(
+                targetPsc, scriptDir, noSrcCompiler, Array.Empty<string>(),
+                new[] { Root("SKSE", autoA) }, autoEnabled: true, importSetName: null, warning: null,
+                gameDataSources: null);
+            Check(stranded.VanillaMissing && !stranded.Dirs.Any(d => d.Equals(fakeVanilla, StringComparison.OrdinalIgnoreCase)),
+                  "with vanilla sources genuinely nowhere, the plan says so rather than shipping a silently vanilla-less path");
+            Check(CompileTools.ImportSummary(stranded).Contains("NO vanilla Papyrus sources"),
+                  "…and the render leads with it (Q3 — otherwise the missing-imports banner blames a mod)");
         }
         finally { try { Directory.Delete(fake, recursive: true); } catch { /* temp scratch; non-fatal */ } }
 

--- a/src/housecarl-generator/ImportOrderProbe.cs
+++ b/src/housecarl-generator/ImportOrderProbe.cs
@@ -138,10 +138,22 @@ internal static class ImportOrderProbe
             // Source\Scripts (own folder == an auto root), and the scan always reaches the game's Data folder
             // (an auto root == vanilla). Driven through the REAL PlanImports, not a hand-built plan.
             PapyrusSourceRoot Root(string provider, string dir) => new(provider, dir, @"Source\Scripts");
+            // PlanImports narrows the scan to what the target REFERENCES, so the arm needs a real target: it names a
+            // script that autoA provides and says nothing about autoB, which must therefore be dropped.
+            var targetPsc = Path.Combine(scriptDir, "HCPlanTarget.psc");
+            File.WriteAllText(targetPsc, "Scriptname HCPlanTarget extends Quest\n\nFunction Go()\n    HCSkseHelper.Ping()\nEndFunction\n");
+            File.WriteAllText(Path.Combine(autoA, "HCSkseHelper.psc"), "Scriptname HCSkseHelper\n");
+            File.WriteAllText(Path.Combine(autoB, "HCUnrelated.psc"), "Scriptname HCUnrelated\n");
             var labelled = CompileTools.PlanImports(
-                scriptDir, fakeCompiler, new[] { userB },
-                new[] { Root("Data", fakeVanilla), Root("SKSE", autoA), Root("Me", scriptDir) },
+                targetPsc, scriptDir, fakeCompiler, new[] { userB },
+                new[] { Root("Data", fakeVanilla), Root("SKSE", autoA), Root("PapyrusUtil", autoB), Root("Me", scriptDir) },
                 autoEnabled: true, importSetName: null, warning: null);
+            Check(labelled.Dirs.Any(d => d.Equals(autoA, StringComparison.OrdinalIgnoreCase)),
+                  "a scanned folder the script REFERENCES is kept");
+            Check(!labelled.Dirs.Any(d => d.Equals(autoB, StringComparison.OrdinalIgnoreCase)),
+                  "a scanned folder the script never references is DROPPED (the narrowing that makes the scan usable at modlist scale)");
+            Check(labelled.AutoScanned == 3 && labelled.AutoProviders.Count == 1,
+                  "the plan reports BOTH numbers — 3 folders scanned, 1 kept — so a dropped dependency reads as dropped, not overlooked");
             string LabelOf(string dir) => labelled.Entries.First(e => e.Dir.Equals(dir, StringComparison.OrdinalIgnoreCase)).Origin;
             Check(LabelOf(scriptDir) == CompileTools.ImportPlan.OwnFolder,
                   "a dir that is BOTH the script's own folder and a scanned mod is labelled the own folder (it holds that slot)");
@@ -151,7 +163,7 @@ internal static class ImportOrderProbe
             Check(LabelOf(userB) == CompileTools.ImportPlan.CallerDirs, "a caller dir is labelled import_dirs=");
             Check(labelled.Dirs.SequenceEqual(CompileTools.BuildImports(scriptDir, fakeCompiler, userB,
                       new[] { fakeVanilla, autoA, scriptDir }), StringComparer.OrdinalIgnoreCase),
-                  "PlanImports' dirs ARE BuildImports' output — the labels describe the path that actually ran");
+                  "PlanImports' dirs ARE BuildImports' output over the KEPT folders — the labels describe the path that actually ran");
             Check(labelled.CallerCount == 1 && labelled.AutoProviders.SequenceEqual(new[] { "SKSE" }),
                   "the summary counts are derived from the FINAL entries: 1 caller, 1 auto (Data and the own folder are not counted as mods)");
         }

--- a/src/housecarl-generator/ImportOrderProbe.cs
+++ b/src/housecarl-generator/ImportOrderProbe.cs
@@ -228,6 +228,26 @@ internal static class ImportOrderProbe
                       .Equals(fakeVanilla, StringComparison.OrdinalIgnoreCase),
                   "BuildImports takes the caller's RESOLVED vanilla dir rather than re-deriving its own");
 
+            // NeedsModlistScan — auto_imports=false must actually SKIP the scan. Fetching the vanilla fallback made
+            // the call unconditional for one commit, which quietly cost the flag its only real use (the scan forces
+            // the asset build and probes two layouts under every enabled mod) while three render strings still said
+            // the mods had not been scanned. The vanilla-only branch is the single exception, and it is narrow.
+            Check(CompileTools.NeedsModlistScan(true, fakeCompiler), "auto_imports=true scans");
+            Check(CompileTools.NeedsModlistScan(true, noSrcCompiler), "…scans regardless of whether the compiler has vanilla beside it");
+            Check(!CompileTools.NeedsModlistScan(false, fakeCompiler),
+                  "auto_imports=false with the compiler's vanilla present does NOT touch the modlist — the flag's promise, and its whole point");
+            Check(CompileTools.NeedsModlistScan(false, noSrcCompiler),
+                  "auto_imports=false WITHOUT compiler vanilla still reads the modlist — the only place left to find any (a vanilla-less path resolves nothing)");
+
+            // …and the strings printed on that path must not claim a scan verdict they no longer hold. The old
+            // "your enabled mods were NOT scanned" was printed at the very moment the scan had just run.
+            var offPlan = CompileTools.PlanImports(
+                targetPsc, scriptDir, fakeCompiler, Array.Empty<string>(),
+                Array.Empty<PapyrusSourceRoot>(), autoEnabled: false, importSetName: null, warning: null);
+            var offText = CompileTools.ImportSummary(offPlan);
+            Check(!offText.Contains("NOT scanned") && offText.Contains("NOT on the import path"),
+                  "the auto_imports=false line states where the mods ARE NOT (the path), not what houseCARL did or didn't read");
+
             var stranded = CompileTools.PlanImports(
                 targetPsc, scriptDir, noSrcCompiler, Array.Empty<string>(),
                 new[] { Root("SKSE", autoA) }, autoEnabled: true, importSetName: null, warning: null,

--- a/src/housecarl-generator/ImportOrderProbe.cs
+++ b/src/housecarl-generator/ImportOrderProbe.cs
@@ -166,6 +166,26 @@ internal static class ImportOrderProbe
                   "PlanImports' dirs ARE BuildImports' output over the KEPT folders — the labels describe the path that actually ran");
             Check(labelled.CallerCount == 1 && labelled.AutoProviders.SequenceEqual(new[] { "SKSE" }),
                   "the summary counts are derived from the FINAL entries: 1 caller, 1 auto (Data and the own folder are not counted as mods)");
+
+            // PR #296 review: a folder the caller passed EXPLICITLY must keep its caller identity even when the scan
+            // also knows it. This is the recovery path the tool itself prints — a failure says "pass that folder via
+            // import_dirs=", the user does, and the next run must not report it back as one the script references.
+            // Both derived counts went wrong at once before this: CallerCount missed it, AutoProviders claimed it.
+            var overlap2 = CompileTools.PlanImports(
+                targetPsc, scriptDir, fakeCompiler, new[] { userB, autoB },
+                new[] { Root("SKSE", autoA), Root("PapyrusUtil", autoB) },
+                autoEnabled: true, importSetName: null, warning: null);
+            string Label2(string dir) => overlap2.Entries.First(e => e.Dir.Equals(dir, StringComparison.OrdinalIgnoreCase)).Origin;
+            Check(Label2(autoB) == CompileTools.ImportPlan.CallerDirs,
+                  "a DROPPED candidate that the caller passed is labelled import_dirs=, not MO2:<mod> (it reached the path only because the caller asked)");
+            Check(overlap2.CallerCount == 2 && overlap2.AutoProviders.SequenceEqual(new[] { "SKSE" }),
+                  "…and the counts follow: 2 caller dirs, 1 from the scan — the 'kept the N this script REFERENCES BY NAME' number no longer over-counts by the overlap");
+
+            var overlap3 = CompileTools.PlanImports(
+                targetPsc, scriptDir, fakeCompiler, new[] { autoA },
+                new[] { Root("SKSE", autoA) }, autoEnabled: true, importSetName: null, warning: null);
+            Check(overlap3.CallerCount == 1 && overlap3.AutoProviders.Count == 0,
+                  "a KEPT candidate the caller also passed counts as the caller's — it would be on the path with the scan switched off");
         }
         finally { try { Directory.Delete(fake, recursive: true); } catch { /* temp scratch; non-fatal */ } }
 

--- a/src/housecarl-generator/ImportOrderProbe.cs
+++ b/src/housecarl-generator/ImportOrderProbe.cs
@@ -1,10 +1,12 @@
+using HousecarlCore;
 using HousecarlMcp;
 
 namespace HousecarlGenerator;
 
 /// <summary>
-/// Import-order guard — locks in the rule that caller-passed import_dirs OUTRANK the auto-added
-/// vanilla source folder in housecarl_compile_script's import list.
+/// Import-order guard — locks in housecarl_compile_script's import-path RANKING: the script's own
+/// folder, then caller-passed import_dirs=/import_set=, then the modlist's auto-discovered source
+/// folders (#200), then the vanilla sources LAST.
 ///
 /// Why it matters: the CK compiler resolves every referenced script to the FIRST matching .psc
 /// across the import dirs, and mods routinely ship EXTENDED copies of vanilla sources (SKSE's
@@ -16,13 +18,16 @@ namespace HousecarlGenerator;
 /// Two arms:
 ///   1. PURE (always runs, CI-safe) — fabricates a fake game layout in temp (compiler path + a
 ///      Data\Source\Scripts dir), drives the REAL <see cref="CompileTools.BuildImports"/>, and
-///      asserts the order contract: script's own folder FIRST, caller dirs NEXT, vanilla LAST,
-///      case-insensitive dedup, quote-trim.
+///      asserts the order contract: script's own folder FIRST, caller dirs NEXT, auto-discovered
+///      modlist dirs AFTER those, vanilla LAST, case-insensitive dedup, quote-trim — including the
+///      Data-root case, where the modlist scan hands the vanilla folder back as an ordinary auto dir
+///      and it must be pulled to the end anyway.
 ///   2. END-TO-END (self-skips without the real CK compiler) — the SKSE-shadow proof: an import
 ///      dir carries a copy of vanilla Form.psc extended with a marker global function; a target
 ///      script calls it. Compiled with the EXACT list BuildImports produced, the compile succeeds
-///      only if the user's dir outranks vanilla. A control compile WITHOUT the import dir must
-///      fail (proves the marker really resolves from the user's copy, not from vanilla).
+///      only if that dir outranks vanilla. Driven for BOTH ranks that must beat vanilla (a caller
+///      import_dirs= and an auto-discovered mod), with a control compile WITHOUT the dir that must
+///      fail (proving the marker really resolves from the extended copy, not from vanilla).
 ///
 /// Run: dotnet run --project src/housecarl-generator import-order-guard ["&lt;PapyrusCompiler.exe&gt;"]
 /// </summary>
@@ -81,6 +86,74 @@ internal static class ImportOrderProbe
             var inVan = CompileTools.BuildImports(fakeVanilla, fakeCompiler, userB);
             Check(inVan.Count == 2 && inVan[0].Equals(fakeVanilla, StringComparison.OrdinalIgnoreCase),
                   "script inside the vanilla folder keeps its own-folder slot first");
+
+            // ---- AUTO-DISCOVERED modlist dirs (#200): a THIRD rank, between the caller and vanilla ----
+            var autoA = Path.Combine(fake, "mods", "SKSE", "Source", "Scripts");
+            var autoB = Path.Combine(fake, "mods", "PapyrusUtil", "Source", "Scripts");
+            foreach (var d in new[] { autoA, autoB }) Directory.CreateDirectory(d);
+
+            var withAuto = CompileTools.BuildImports(scriptDir, fakeCompiler, userB, new[] { autoA, autoB });
+            Check(withAuto.Count == 5, $"5 dirs assembled with 2 auto dirs (got {withAuto.Count})");
+            var iAutoA = withAuto.FindIndex(d => d.Equals(autoA, StringComparison.OrdinalIgnoreCase));
+            var iAutoB = withAuto.FindIndex(d => d.Equals(autoB, StringComparison.OrdinalIgnoreCase));
+            var iUserB = withAuto.FindIndex(d => d.Equals(userB, StringComparison.OrdinalIgnoreCase));
+            var iVan2 = withAuto.FindIndex(d => d.Equals(fakeVanilla, StringComparison.OrdinalIgnoreCase));
+            Check(withAuto[0].Equals(scriptDir, StringComparison.OrdinalIgnoreCase), "own folder still FIRST with auto dirs in play");
+            Check(iUserB < iAutoA, "the CALLER's import_dirs outrank the auto-discovered modlist dirs");
+            Check(iAutoA < iAutoB, "auto dirs keep the order they were given — that order is MO2 priority, which decides which copy wins");
+            Check(iAutoB < iVan2 && iVan2 == withAuto.Count - 1, "the auto dirs outrank vanilla, and vanilla is still LAST");
+
+            // THE Data-ROOT CASE, and the reason the vanilla re-slot had to survive this change: the game's Data folder
+            // is itself a VFS loose root, so the modlist scan finds Data\Source\Scripts and hands it in as an ordinary
+            // auto dir — ahead of every mod that follows it. If it kept that slot, the vanilla copy of Actor.psc would
+            // shadow SKSE's and every extended call would fail, which is exactly the bug the vanilla-last rule exists
+            // to stop. It must be pulled back to LAST.
+            var withData = CompileTools.BuildImports(scriptDir, fakeCompiler, null, new[] { fakeVanilla, autoA });
+            Check(withData.Count == 3 && withData[^1].Equals(fakeVanilla, StringComparison.OrdinalIgnoreCase)
+                  && withData[1].Equals(autoA, StringComparison.OrdinalIgnoreCase),
+                  "an auto dir that IS the vanilla folder (the Data loose root) is re-slotted to LAST, behind the mods");
+
+            // A dir in BOTH the caller list and the scan keeps its CALLER slot (dedup keeps the first occurrence) —
+            // otherwise defensively re-passing a folder you already have installed would demote it below the modlist.
+            var overlap = CompileTools.BuildImports(scriptDir, fakeCompiler, autoA, new[] { autoB, autoA });
+            Check(overlap.Count == 4 && overlap[1].Equals(autoA, StringComparison.OrdinalIgnoreCase)
+                  && overlap[2].Equals(autoB, StringComparison.OrdinalIgnoreCase),
+                  "a dir passed BOTH by the caller and by the scan keeps the caller slot");
+
+            // Null/empty auto list ⇒ byte-identical to the pre-#200 behaviour (the default-off path and every old call).
+            var noAuto = CompileTools.BuildImports(scriptDir, fakeCompiler, userB, null);
+            var emptyAuto = CompileTools.BuildImports(scriptDir, fakeCompiler, userB, Array.Empty<string>());
+            Check(noAuto.SequenceEqual(emptyAuto, StringComparer.OrdinalIgnoreCase) && noAuto.Count == 3,
+                  "no auto dirs (null or empty) → the original three-rank list, unchanged");
+
+            // VanillaSourceDir is the SINGLE definition both the assembly and the render's labelling read. Derived
+            // twice they could disagree, and the render would then label the vanilla slot as a mod.
+            Check(CompileTools.VanillaSourceDir(fakeCompiler) == fakeVanilla, "VanillaSourceDir resolves <game>\\Data\\Source\\Scripts");
+            Check(CompileTools.VanillaSourceDir(Path.Combine(fake, "nogame", "Papyrus Compiler", "PapyrusCompiler.exe")) is null,
+                  "VanillaSourceDir returns null when the folder isn't there (no phantom import dir)");
+
+            // ---- PlanImports: the LABELS the render prints, on the real assembled path ----
+            // A dir can belong to two origins at once, and the label decides what the user is told about a shadowed
+            // script. Both collisions are ordinary, not exotic: you routinely compile a .psc sitting in a mod's own
+            // Source\Scripts (own folder == an auto root), and the scan always reaches the game's Data folder
+            // (an auto root == vanilla). Driven through the REAL PlanImports, not a hand-built plan.
+            PapyrusSourceRoot Root(string provider, string dir) => new(provider, dir, @"Source\Scripts");
+            var labelled = CompileTools.PlanImports(
+                scriptDir, fakeCompiler, new[] { userB },
+                new[] { Root("Data", fakeVanilla), Root("SKSE", autoA), Root("Me", scriptDir) },
+                autoEnabled: true, importSetName: null, warning: null);
+            string LabelOf(string dir) => labelled.Entries.First(e => e.Dir.Equals(dir, StringComparison.OrdinalIgnoreCase)).Origin;
+            Check(LabelOf(scriptDir) == CompileTools.ImportPlan.OwnFolder,
+                  "a dir that is BOTH the script's own folder and a scanned mod is labelled the own folder (it holds that slot)");
+            Check(LabelOf(fakeVanilla) == CompileTools.ImportPlan.Vanilla,
+                  "the game's Data root comes back from the scan as a mod, but is labelled VANILLA (it is the vanilla slot)");
+            Check(LabelOf(autoA) == CompileTools.ImportPlan.AutoPrefix + "SKSE", "a scanned mod is labelled with its providing mod folder");
+            Check(LabelOf(userB) == CompileTools.ImportPlan.CallerDirs, "a caller dir is labelled import_dirs=");
+            Check(labelled.Dirs.SequenceEqual(CompileTools.BuildImports(scriptDir, fakeCompiler, userB,
+                      new[] { fakeVanilla, autoA, scriptDir }), StringComparer.OrdinalIgnoreCase),
+                  "PlanImports' dirs ARE BuildImports' output — the labels describe the path that actually ran");
+            Check(labelled.CallerCount == 1 && labelled.AutoProviders.SequenceEqual(new[] { "SKSE" }),
+                  "the summary counts are derived from the FINAL entries: 1 caller, 1 auto (Data and the own folder are not counted as mods)");
         }
         finally { try { Directory.Delete(fake, recursive: true); } catch { /* temp scratch; non-fatal */ } }
 
@@ -123,6 +196,15 @@ internal static class ImportOrderProbe
                 var ctl = HousecarlCore.PapyrusCompile.CompileObject(compiler, "HCImportOrderTarget", ctlImports, outDir);
                 Check(ctl.Ran && !ctl.Success,
                       "control without import_dirs FAILS (the marker resolves only from the caller's copy)");
+
+                // #200: the same proof for an AUTO-DISCOVERED dir. The modlist scan feeds dirs through a different
+                // parameter and a LOWER rank than import_dirs=, so "caller beats vanilla" does not transitively prove
+                // "a scanned mod beats vanilla" — and that is the case the new default actually relies on.
+                var autoImports = CompileTools.BuildImports(work, compiler, null, new[] { extDir });
+                var auto = HousecarlCore.PapyrusCompile.CompileObject(compiler, "HCImportOrderTarget", autoImports, outDir);
+                Check(auto.Success && auto.PexPath is not null,
+                      "an AUTO-DISCOVERED mod's extended copy also beats vanilla" +
+                      (auto.Success ? "" : $" (first error: {(auto.Diagnostics.Count > 0 ? auto.Diagnostics[0].ToString() : auto.Stderr.Trim())})"));
             }
             finally { try { Directory.Delete(work, recursive: true); } catch { /* in-dir scratch; non-fatal */ } }
         }

--- a/src/housecarl-mcp/CompileTools.cs
+++ b/src/housecarl-mcp/CompileTools.cs
@@ -31,7 +31,8 @@ public static class CompileTools
         int AutoScanned = 0,
         PapyrusDependencyScan? Scan = null,
         IReadOnlyList<string>? ReferencedProviders = null,
-        bool VanillaMissing = false)
+        bool VanillaMissing = false,
+        bool ScanFailed = false)
     {
         /// <summary>Provenance labels — the exact strings <see cref="ImportDetail"/> prints, and the keys the counts group on.</summary>
         public const string OwnFolder = "the script's own folder";
@@ -167,16 +168,17 @@ public static class CompileTools
         // alternative is a path with no vanilla at all.
         IReadOnlyList<PapyrusSourceRoot> autoRoots = Array.Empty<PapyrusSourceRoot>();
         string? gameDataSources = null, autoWarning = null;
+        bool scanFailed = false;
         if (NeedsModlistScan(auto_imports, compilerExe!))
         {
-            (autoRoots, gameDataSources, autoWarning) = svc.PapyrusSourceImportDirs();
+            (autoRoots, gameDataSources, autoWarning, scanFailed) = svc.PapyrusSourceImportDirs();
             if (!auto_imports) autoRoots = Array.Empty<PapyrusSourceRoot>();   // read for the vanilla fallback only
         }
         // The warning rides along whenever the scan actually ran: with auto_imports on it explains missing mods, and on
         // the vanilla-only branch it explains a missing vanilla slot, which the VanillaMissing caveat would otherwise
         // report without the cause the code already has in hand.
         var plan = PlanImports(script, scriptDir, compilerExe!, callerExtras, autoRoots, auto_imports, importSetName,
-                               autoWarning, gameDataSources);
+                               autoWarning, gameDataSources, scanFailed);
 
         // The whole path travels as ONE `-i=` argument and Windows caps a process command line (~32k chars), so a modlist
         // with hundreds of source folders could cross it. Refuse LOUDLY with the way out rather than letting the process
@@ -308,7 +310,7 @@ public static class CompileTools
     internal static ImportPlan PlanImports(
         string targetScript, string scriptDir, string compilerExe, IReadOnlyList<string> callerExtras,
         IReadOnlyList<PapyrusSourceRoot> autoRoots, bool autoEnabled, string? importSetName, string? warning,
-        string? gameDataSources = null)
+        string? gameDataSources = null, bool scanFailed = false)
     {
         // The compiler's own game dir first — its sources are the ones matching the flags file it will use — then the
         // modlist's Data\Source\Scripts, which the scan split out precisely so it could stand in here.
@@ -368,7 +370,7 @@ public static class CompileTools
             : scan.Folders.Select(f => providers.TryGetValue(f, out var m) ? m : Path.GetFileName(f)).ToList();
 
         return new ImportPlan(entries, autoEnabled, importSetName, warning, candidates.Count, scan, referenced,
-                              VanillaMissing: vanilla is null);
+                              VanillaMissing: vanilla is null, ScanFailed: scanFailed);
     }
 
     /// <summary>The one-line "what was actually searched" summary printed on EVERY call (#200 — the old render took the
@@ -386,6 +388,11 @@ public static class CompileTools
         }
         if (!p.AutoEnabled)
             sb.Append("; auto_imports=false (your enabled mods are NOT on the import path)");
+        else if (p.ScanFailed)
+            // "matched 0 of 0" is a CONCLUSION, and a read that threw never reached one. An empty root list from a
+            // failure looks exactly like a modlist with no source folders, which is why the failure is flagged rather
+            // than inferred from the count.
+            sb.Append("; the modlist could NOT be read, so none of your installed mods' source folders were scanned");
         else
         {
             // Report the NARROWING, not just the survivors: "12 auto-discovered" reads as "your modlist ships 12
@@ -445,9 +452,14 @@ public static class CompileTools
         // split dropped the only copy on the machine and nothing replaced it (PR #296 re-review).
         if (p.VanillaMissing)
             sb.Append("\n⚠ NO vanilla Papyrus sources are on the import path — houseCARL found none beside the compiler " +
-                      "(<game>\\Data\\Source\\Scripts) and none under your MO2 data folder. Every vanilla type will fail " +
-                      "to resolve until you unpack them (the CK ships them as Scripts.zip) or pass their folder via " +
-                      "import_dirs=.");
+                      "(<game>\\Data\\Source\\Scripts)")
+              // "found none under your MO2 data folder" would be a second claim about a place the failed read never
+              // reached. Which of the two it is changes the fix, so it is said rather than smoothed over.
+              .Append(p.ScanFailed
+                          ? " and could not read your MO2 modlist to look under the data folder (see below)."
+                          : " and none under your MO2 data folder.")
+              .Append(" Every vanilla type will fail to resolve until you unpack them (the CK ships them as " +
+                      "Scripts.zip) or pass their folder via import_dirs=.");
         if (p.Scan is { TargetUnreadable: true })
             sb.Append("\n⚠ the script's own source could not be READ when the import path was assembled (locked or moved " +
                       "after houseCARL first checked it), so NOTHING was resolved from its contents and the modlist scan " +
@@ -515,6 +527,10 @@ public static class CompileTools
                     ? " auto_imports=false, so your enabled mods are NOT on the import path — re-run with auto_imports=true, or pass " +
                       "EVERY dependency's source folder via import_dirs= (SKSE, SkyUI, PapyrusUtil, PO3, JContainers, …; " +
                       "';'-separated) — the same set your project's compile .bat passes via -i=."
+                    : plan.ScanFailed
+                    ? " The modlist could NOT be read (see the ⚠ note below), so NONE of your installed mods' source folders " +
+                      "reached the path — that is the most likely cause here, ahead of anything about this script. Fix the " +
+                      "modlist read, or pass the dependency's source folder via import_dirs= for now."
                     : narrowingIncomplete
                     ? " START WITH THE ⚠ NOTE BELOW: the modlist scan did not complete, so the " + plan.Referenced.Count +
                       " folder(s) it matched out of " + plan.AutoScanned + " scanned are NOT the full set this script " +

--- a/src/housecarl-mcp/CompileTools.cs
+++ b/src/housecarl-mcp/CompileTools.cs
@@ -289,15 +289,27 @@ public static class CompileTools
         }
 
         var dirs = BuildImports(scriptDir, compilerExe, string.Join(";", callerExtras), autoDirs);
+
+        // Providers are indexed from the KEPT folders only. A candidate the filter DROPPED can still reach the final
+        // list — but only because the caller passed it — so indexing every discovered root would label it as one the
+        // scan contributed.
+        var keptSet = new HashSet<string>(autoDirs, StringComparer.OrdinalIgnoreCase);
         var providers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var r in autoRoots) providers.TryAdd(r.Dir, r.Provider);
+        foreach (var r in candidates) if (keptSet.Contains(r.Dir)) providers.TryAdd(r.Dir, r.Provider);
+        var callerSet = new HashSet<string>(callerExtras, StringComparer.OrdinalIgnoreCase);
 
         var entries = new List<(string Dir, string Origin)>(dirs.Count);
         foreach (var d in dirs)
         {
+            // CALLER outranks the scan here, mirroring the slot BuildImports gave it. A dir the caller passed keeps
+            // its caller identity even when the scan also found it — otherwise the two derived counts both go wrong
+            // at once (CallerCount misses it, AutoProviders claims it), and the number the reader is asked to audit
+            // ("kept the N this script REFERENCES BY NAME") over-counts by the overlap. That overlap is not exotic: it
+            // is the recovery path this tool prints, where a failure tells the user to pass a folder via import_dirs=.
             string origin =
                 d.Equals(scriptDir, StringComparison.OrdinalIgnoreCase) ? ImportPlan.OwnFolder
                 : vanilla is not null && d.Equals(vanilla, StringComparison.OrdinalIgnoreCase) ? ImportPlan.Vanilla
+                : callerSet.Contains(d) ? ImportPlan.CallerDirs
                 : providers.TryGetValue(d, out var mod) ? ImportPlan.AutoPrefix + mod
                 : ImportPlan.CallerDirs;
             entries.Add((d, origin));
@@ -327,7 +339,12 @@ public static class CompileTools
             // dependency turns up missing — that the other 489 were dropped as unreferenced, not overlooked.
             var provs = p.AutoProviders;
             sb.Append("; ").Append(provs.Count).Append(" of ").Append(p.AutoScanned)
-              .Append(" scanned mod source folder(s) referenced by this script");
+              // "referenced by this script" is a claim about the source's CONTENTS. It is only earned when the source
+              // was actually read: an unreadable target yields the same empty result, and asserting it there would be
+              // a confident wrong answer rather than a degraded one.
+              .Append(p.Scan is { TargetUnreadable: true }
+                          ? " scanned mod source folder(s) kept (the script could NOT be read — see below)"
+                          : " scanned mod source folder(s) referenced by this script");
             if (provs.Count > 0)
             {
                 const int Show = 8;
@@ -339,11 +356,7 @@ public static class CompileTools
         if (p.Entries.Count > 0 && p.Entries[^1].Origin == ImportPlan.Vanilla)
             sb.Append("; vanilla sources last");
         sb.Append('.');
-        if (p.Scan is { BudgetExhausted: true } s)
-            sb.Append("\n⚠ the reference walk stopped at its ").Append(PapyrusDependencyFilter.MaxFilesRead)
-              .Append("-file ceiling, so a dependency reached only through the unread tail may be missing from the path — " +
-                      "if the compile fails on unresolved symbols, pass that folder via import_dirs=.");
-        if (p.Warning is not null) sb.Append('\n').Append(p.Warning);
+        sb.Append(ImportCaveats(p));
         return sb.ToString();
     }
 
@@ -355,6 +368,29 @@ public static class CompileTools
         for (int i = 0; i < p.Entries.Count; i++)
             sb.Append("\n  ").Append((i + 1).ToString().PadLeft(2)).Append(". ")
               .Append(p.Entries[i].Dir).Append("   [").Append(p.Entries[i].Origin).Append(']');
+        sb.Append(ImportCaveats(p));
+        return sb.ToString();
+    }
+
+    /// <summary>Everything that makes the printed path LESS than a complete answer. Emitted by BOTH
+    /// <see cref="ImportSummary"/> and <see cref="ImportDetail"/> — i.e. on success and on failure — because these
+    /// caveats are written for the failing run: the truncation note literally ends "if the compile fails on unresolved
+    /// symbols, pass that folder via import_dirs=", and it previously could only print on a compile that succeeded.
+    /// Living inside the two import blocks (rather than being appended per branch) is what makes that structural: every
+    /// path that prints an import path prints its caveats, including the no-parseable-diagnostics branch that used to
+    /// drop the discovery warning entirely.</summary>
+    internal static string ImportCaveats(ImportPlan p)
+    {
+        var sb = new StringBuilder();
+        if (p.Scan is { TargetUnreadable: true })
+            sb.Append("\n⚠ the script's own source could not be READ when the import path was assembled (locked or moved " +
+                      "after houseCARL first checked it), so NOTHING was resolved from its contents and the modlist scan " +
+                      "contributed nothing — this is not a statement that the script references none of your mods.");
+        if (p.Scan is { BudgetExhausted: true })
+            sb.Append("\n⚠ the reference walk stopped at its ").Append(PapyrusDependencyFilter.MaxFilesRead)
+              .Append("-file ceiling, so a dependency reached only through the unread tail may be missing from the path — " +
+                      "if the compile fails on unresolved symbols, pass that folder via import_dirs=.");
+        if (p.Warning is not null) sb.Append('\n').Append(p.Warning);
         return sb.ToString();
     }
 
@@ -405,24 +441,32 @@ public static class CompileTools
                           "folder is missing makes ALL its calls and types fail.");
                 // The remedy DIFFERS once the modlist has already been scanned: "list every dependency's folder" is the
                 // wrong instruction when dozens are already on the path, and it hides the causes the scan cannot fix (#200).
-                sb.Append(plan.AutoEnabled
-                    ? " The modlist scan found " + plan.AutoScanned + " mod source folder(s) and kept the " +
+                // When the narrowing was itself INCOMPLETE — the source unreadable, or the walk truncated — the cause
+                // is most likely the narrowing, and saying "kept the N this script references" would assert a complete
+                // job and then list causes that exclude the real one. The caveats print with the path below.
+                bool narrowingIncomplete = plan.Scan is { TargetUnreadable: true } or { BudgetExhausted: true };
+                sb.Append(!plan.AutoEnabled
+                    ? " auto_imports=false, so your enabled mods were NOT scanned — re-run with auto_imports=true, or pass " +
+                      "EVERY dependency's source folder via import_dirs= (SKSE, SkyUI, PapyrusUtil, PO3, JContainers, …; " +
+                      "';'-separated) — the same set your project's compile .bat passes via -i=."
+                    : narrowingIncomplete
+                    ? " START WITH THE ⚠ NOTE BELOW: the modlist scan did not complete, so the " + plan.AutoProviders.Count +
+                      " folder(s) it contributed out of " + plan.AutoScanned + " scanned are NOT the full set this script " +
+                      "needs — the missing dependency was most likely dropped by that, not by anything wrong with your setup. " +
+                      "Pass its source folder via import_dirs= (and save_import_set= to keep it for next time)."
+                    : " The modlist scan found " + plan.AutoScanned + " mod source folder(s) and kept the " +
                       plan.AutoProviders.Count + " this script REFERENCES BY NAME (listed below). So the missing dependency " +
                       "is most likely one the source never names outright, or one that is not installed as an enabled mod, " +
                       "or one shipping its sources inside a BSA (the CK compiler cannot read archives — extract them first, " +
                       "e.g. with housecarl_bsa_extract), or one keeping them in a SUBFOLDER of a listed dir. Pass that folder " +
-                      "via import_dirs= (and save_import_set= to keep it for next time)."
-                    : " auto_imports=false, so your enabled mods were NOT scanned — re-run with auto_imports=true, or pass " +
-                      "EVERY dependency's source folder via import_dirs= (SKSE, SkyUI, PapyrusUtil, PO3, JContainers, …; " +
-                      "';'-separated) — the same set your project's compile .bat passes via -i=.");
+                      "via import_dirs= (and save_import_set= to keep it for next time).");
             }
 
             // "diagnostic(s)", not "error(s)": the CK compiler mixes warnings into a failed run's output and the
             // parser doesn't split severities — labelling them all errors over-claims (2026-06-12 hunt render wave).
             sb.Append('\n').Append(r.Diagnostics.Count).Append(" diagnostic(s) (errors and possibly warnings — the CK compiler mixes them):");
             foreach (var d in r.Diagnostics) sb.Append("\n  ").Append(d);
-            sb.Append('\n').Append(ImportDetail(plan));
-            if (plan.Warning is not null) sb.Append('\n').Append(plan.Warning);
+            sb.Append('\n').Append(ImportDetail(plan));   // carries the caveats (ImportCaveats), warning included
             // The generic tail stays for the NON-dominated case (a few resolution errors mixed with real ones); when we
             // already led with the strong missing-imports banner, don't repeat the import line.
             sb.Append("\nfix the .psc and recompile (look unfamiliar functions/types up with the papyrus-reference skill).");

--- a/src/housecarl-mcp/CompileTools.cs
+++ b/src/housecarl-mcp/CompileTools.cs
@@ -27,7 +27,9 @@ public static class CompileTools
         IReadOnlyList<(string Dir, string Origin)> Entries,
         bool AutoEnabled,
         string? ImportSetName,
-        string? Warning)
+        string? Warning,
+        int AutoScanned = 0,
+        PapyrusDependencyScan? Scan = null)
     {
         /// <summary>Provenance labels — the exact strings <see cref="ImportDetail"/> prints, and the keys the counts group on.</summary>
         public const string OwnFolder = "the script's own folder";
@@ -54,7 +56,8 @@ public static class CompileTools
          "folder you choose (houseCARL appends Scripts\\ so MO2 deploys it). Pass script= the full path to the " +
          ".psc to compile. IMPORT PATH: houseCARL adds the script's own folder, then AUTO-DISCOVERS the Papyrus source " +
          "folders your enabled MO2 mods already ship (Source\\Scripts / Scripts\\Source, in MO2 priority order — so SKSE, " +
-         "PapyrusUtil, PO3, SkyUI, JContainers and friends need no retyping), then the vanilla sources LAST; pass " +
+         "PapyrusUtil, PO3, SkyUI, JContainers and friends need no retyping), NARROWED to the folders this script actually " +
+         "references (directly or transitively), then the vanilla sources LAST; pass " +
          "auto_imports=false to skip the modlist scan. Add anything the scan can't reach (local stubs, a dev project tree, " +
          "sources you extracted from a BSA — the CK compiler cannot read archives) via import_dirs= (';'-separated), and " +
          "save_import_set=<name> to persist that list so later calls just pass import_set=<name>. Precedence is your " +
@@ -73,7 +76,7 @@ public static class CompileTools
             string script,
         [Description("Optional. Extra import directories where dependency sources (.psc) live — separated by ';'. The script's own folder, your enabled mods' source folders (unless auto_imports=false), and the vanilla source folder are added automatically; these directories outrank all of those (first match wins), so extended copies of vanilla scripts take precedence.")]
             string? import_dirs = null,
-        [Description("Optional (default true). Scan the enabled MO2 mods for Papyrus source folders (Source\\Scripts / Scripts\\Source) and put every one that holds .psc files on the import path, in MO2 priority order — so installed frameworks need no retyping. Pass false to compile against only the script's own folder, your import_dirs=/import_set=, and the vanilla sources.")]
+        [Description("Optional (default true). Scan the enabled MO2 mods for Papyrus source folders (Source\\Scripts / Scripts\\Source) and put the ones this script references — by name, followed transitively through those scripts — on the import path, in MO2 priority order, so installed frameworks need no retyping. The narrowing is not optional: a big modlist ships hundreds of source folders (measured: 501 on a 3617-mod order), which together exceed what a Windows command line can carry. Pass false to compile against only the script's own folder, your import_dirs=/import_set=, and the vanilla sources.")]
             bool auto_imports = true,
         [Description("Optional. Name of a SAVED import-directory set (see save_import_set=) to add to the import path. Its dirs rank after import_dirs= and before the auto-discovered mods. An unknown name is refused, and the saved names are listed.")]
             string? import_set = null,
@@ -148,7 +151,7 @@ public static class CompileTools
         var (autoRoots, autoWarning) = auto_imports
             ? svc.PapyrusSourceImportDirs()
             : ((IReadOnlyList<PapyrusSourceRoot>)Array.Empty<PapyrusSourceRoot>(), null);
-        var plan = PlanImports(scriptDir, compilerExe!, callerExtras, autoRoots, auto_imports, importSetName, autoWarning);
+        var plan = PlanImports(script, scriptDir, compilerExe!, callerExtras, autoRoots, auto_imports, importSetName, autoWarning);
 
         // The whole path travels as ONE `-i=` argument and Windows caps a process command line (~32k chars), so a modlist
         // with hundreds of source folders could cross it. Refuse LOUDLY with the way out rather than letting the process
@@ -263,12 +266,29 @@ public static class CompileTools
     /// mod's own Source\Scripts, and it holds the first slot), then vanilla (the game's Data folder is also a loose root,
     /// so the scan finds it — that is the vanilla slot, not a mod), then a discovered mod, then the caller.</summary>
     internal static ImportPlan PlanImports(
-        string scriptDir, string compilerExe, IReadOnlyList<string> callerExtras,
+        string targetScript, string scriptDir, string compilerExe, IReadOnlyList<string> callerExtras,
         IReadOnlyList<PapyrusSourceRoot> autoRoots, bool autoEnabled, string? importSetName, string? warning)
     {
-        var dirs = BuildImports(scriptDir, compilerExe, string.Join(";", callerExtras),
-                                autoRoots.Select(r => r.Dir).ToList());
         var vanilla = VanillaSourceDir(compilerExe);
+
+        // NARROW the scan to what this script reaches. Handing over every folder a modlist ships is not a heavier
+        // version of the same thing — measured on a real 3617-mod order it is 501 folders / ~40,200 chars, past the
+        // ~32,767 a Windows command line can carry, so the compile could not run at all. It is also wrong on the
+        // merits: those folders are overwhelmingly quest and follower mods shipping their own scripts, which nothing
+        // else references. See PapyrusDependencyFilter. Vanilla is held OUT of the candidates (it is appended last
+        // unconditionally, so indexing it could only make the closure walk the base game for no gain).
+        var candidates = autoRoots.Where(r => vanilla is null || !r.Dir.Equals(vanilla, StringComparison.OrdinalIgnoreCase)).ToList();
+        PapyrusDependencyScan? scan = null;
+        IReadOnlyList<string> autoDirs = Array.Empty<string>();
+        if (candidates.Count > 0)
+        {
+            var seeds = new List<string> { scriptDir };
+            seeds.AddRange(callerExtras);
+            scan = PapyrusDependencyFilter.Relevant(targetScript, seeds, candidates.Select(c => c.Dir).ToList());
+            autoDirs = scan.Folders;
+        }
+
+        var dirs = BuildImports(scriptDir, compilerExe, string.Join(";", callerExtras), autoDirs);
         var providers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var r in autoRoots) providers.TryAdd(r.Dir, r.Provider);
 
@@ -282,7 +302,7 @@ public static class CompileTools
                 : ImportPlan.CallerDirs;
             entries.Add((d, origin));
         }
-        return new ImportPlan(entries, autoEnabled, importSetName, warning);
+        return new ImportPlan(entries, autoEnabled, importSetName, warning, candidates.Count, scan);
     }
 
     /// <summary>The one-line "what was actually searched" summary printed on EVERY call (#200 — the old render took the
@@ -302,8 +322,12 @@ public static class CompileTools
             sb.Append("; auto_imports=false (your enabled mods were NOT scanned)");
         else
         {
+            // Report the NARROWING, not just the survivors: "12 auto-discovered" reads as "your modlist ships 12
+            // source folders", which is wrong by a factor of forty and hides the one decision worth auditing when a
+            // dependency turns up missing — that the other 489 were dropped as unreferenced, not overlooked.
             var provs = p.AutoProviders;
-            sb.Append("; ").Append(provs.Count).Append(" auto-discovered from MO2");
+            sb.Append("; ").Append(provs.Count).Append(" of ").Append(p.AutoScanned)
+              .Append(" scanned mod source folder(s) referenced by this script");
             if (provs.Count > 0)
             {
                 const int Show = 8;
@@ -315,6 +339,10 @@ public static class CompileTools
         if (p.Entries.Count > 0 && p.Entries[^1].Origin == ImportPlan.Vanilla)
             sb.Append("; vanilla sources last");
         sb.Append('.');
+        if (p.Scan is { BudgetExhausted: true } s)
+            sb.Append("\n⚠ the reference walk stopped at its ").Append(PapyrusDependencyFilter.MaxFilesRead)
+              .Append("-file ceiling, so a dependency reached only through the unread tail may be missing from the path — " +
+                      "if the compile fails on unresolved symbols, pass that folder via import_dirs=.");
         if (p.Warning is not null) sb.Append('\n').Append(p.Warning);
         return sb.ToString();
     }
@@ -378,11 +406,12 @@ public static class CompileTools
                 // The remedy DIFFERS once the modlist has already been scanned: "list every dependency's folder" is the
                 // wrong instruction when dozens are already on the path, and it hides the causes the scan cannot fix (#200).
                 sb.Append(plan.AutoEnabled
-                    ? " The modlist scan already put " + plan.AutoProviders.Count + " mod source folder(s) on the path (listed " +
-                      "below), so the missing dependency is most likely NOT installed as an enabled mod, ships its sources " +
-                      "inside a BSA (the CK compiler cannot read archives — extract them first, e.g. with housecarl_bsa_extract), " +
-                      "or keeps them in a SUBFOLDER of one of the listed dirs. Pass that folder via import_dirs= (and " +
-                      "save_import_set= to keep it for next time)."
+                    ? " The modlist scan found " + plan.AutoScanned + " mod source folder(s) and kept the " +
+                      plan.AutoProviders.Count + " this script REFERENCES BY NAME (listed below). So the missing dependency " +
+                      "is most likely one the source never names outright, or one that is not installed as an enabled mod, " +
+                      "or one shipping its sources inside a BSA (the CK compiler cannot read archives — extract them first, " +
+                      "e.g. with housecarl_bsa_extract), or one keeping them in a SUBFOLDER of a listed dir. Pass that folder " +
+                      "via import_dirs= (and save_import_set= to keep it for next time)."
                     : " auto_imports=false, so your enabled mods were NOT scanned — re-run with auto_imports=true, or pass " +
                       "EVERY dependency's source folder via import_dirs= (SKSE, SkyUI, PapyrusUtil, PO3, JContainers, …; " +
                       "';'-separated) — the same set your project's compile .bat passes via -i=.");

--- a/src/housecarl-mcp/CompileTools.cs
+++ b/src/housecarl-mcp/CompileTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text;
+using HousecarlCore;
 using ModelContextProtocol.Server;
 
 namespace HousecarlMcp;
@@ -15,15 +16,51 @@ namespace HousecarlMcp;
 [McpServerToolType]
 public static class CompileTools
 {
+    /// <summary>The compiler's import path plus the PROVENANCE of every entry — assembled once by
+    /// <see cref="PlanImports"/> and carried to <see cref="Render"/>, which prints it (issue #200: the old signature
+    /// took the dir list and dropped it on the floor, so the caller was never told what was actually searched — the one
+    /// fact that explains both a missing dependency and a shadowed script).
+    /// <para>The summary counts are DERIVED from <see cref="Entries"/>, never tracked alongside it: dedup and the
+    /// vanilla-last re-slot both change what survives, so a count computed from the inputs would quietly disagree with
+    /// the list printed beneath it.</para></summary>
+    public sealed record ImportPlan(
+        IReadOnlyList<(string Dir, string Origin)> Entries,
+        bool AutoEnabled,
+        string? ImportSetName,
+        string? Warning)
+    {
+        /// <summary>Provenance labels — the exact strings <see cref="ImportDetail"/> prints, and the keys the counts group on.</summary>
+        public const string OwnFolder = "the script's own folder";
+        public const string Vanilla = "vanilla sources";
+        public const string CallerDirs = "import_dirs=";
+        public const string AutoPrefix = "MO2: ";
+
+        /// <summary>The ordered list handed to the compiler.</summary>
+        public IReadOnlyList<string> Dirs { get; } = Entries.Select(e => e.Dir).ToList();
+
+        /// <summary>Dirs that came from the caller (import_dirs= / import_set=) and survived into the final path.</summary>
+        public int CallerCount => Entries.Count(e => e.Origin == CallerDirs);
+
+        /// <summary>The providing mod folders behind the auto-discovered entries, in path order.</summary>
+        public IReadOnlyList<string> AutoProviders =>
+            Entries.Where(e => e.Origin.StartsWith(AutoPrefix, StringComparison.Ordinal))
+                   .Select(e => e.Origin[AutoPrefix.Length..]).ToList();
+    }
+
     [McpServerTool(Name = "housecarl_compile_script", Title = "Compile a Papyrus script (.psc → .pex)"),
      Description(
          "Compile a Papyrus script (.psc) to .pex using the Creation Kit's PapyrusCompiler.exe, landing the .pex in a NEW " +
          "houseCARL patch-mod folder you review and enable in MO2 (originals untouched) — or pass output_dir= to land it in a " +
          "folder you choose (houseCARL appends Scripts\\ so MO2 deploys it). Pass script= the full path to the " +
-         ".psc to compile; houseCARL adds the script's own folder and the vanilla source folder (derived from the compiler's " +
-         "game dir) to the import path automatically — pass import_dirs= (';'-separated) for any extra dependency sources " +
-         "(SKSE, other mods); your folders are searched BEFORE the vanilla sources, so mod-extended copies of vanilla " +
-         "scripts (SKSE's Actor.psc etc.) win. On a compile FAILURE it returns the per-line errors as 'name(line,col): message' so you can fix " +
+         ".psc to compile. IMPORT PATH: houseCARL adds the script's own folder, then AUTO-DISCOVERS the Papyrus source " +
+         "folders your enabled MO2 mods already ship (Source\\Scripts / Scripts\\Source, in MO2 priority order — so SKSE, " +
+         "PapyrusUtil, PO3, SkyUI, JContainers and friends need no retyping), then the vanilla sources LAST; pass " +
+         "auto_imports=false to skip the modlist scan. Add anything the scan can't reach (local stubs, a dev project tree, " +
+         "sources you extracted from a BSA — the CK compiler cannot read archives) via import_dirs= (';'-separated), and " +
+         "save_import_set=<name> to persist that list so later calls just pass import_set=<name>. Precedence is your " +
+         "import_dirs=/import_set= > the auto-discovered mods > vanilla, so mod-extended copies of vanilla scripts " +
+         "(SKSE's Actor.psc etc.) win. The import path searched is REPORTED on every call. On a compile FAILURE it returns " +
+         "the per-line errors as 'name(line,col): message' so you can fix " +
          "the .psc and recompile (look unfamiliar functions up with the papyrus-reference skill); on SUCCESS it returns the " +
          ".pex path. Needs houseCARL pointed at your MO2 instance (for the output folder) and the Papyrus compiler path — if " +
          "the compiler isn't set yet, houseCARL tells you exactly what to ask for and how to set it. The CK compiler ships " +
@@ -31,10 +68,17 @@ public static class CompileTools
     public static string CompileScript(
         LoadOrderService svc,
         ToolPathResolver bridge,
+        UserConfigStore store,
         [Description("Full path to the .psc source file to compile.")]
             string script,
-        [Description("Optional. Extra import directories where dependency sources (.psc) live — SKSE, other mods — separated by ';'. The script's own folder and the vanilla source folder are added automatically; your directories are searched before vanilla (first match wins), so extended copies of vanilla scripts take precedence.")]
+        [Description("Optional. Extra import directories where dependency sources (.psc) live — separated by ';'. The script's own folder, your enabled mods' source folders (unless auto_imports=false), and the vanilla source folder are added automatically; these directories outrank all of those (first match wins), so extended copies of vanilla scripts take precedence.")]
             string? import_dirs = null,
+        [Description("Optional (default true). Scan the enabled MO2 mods for Papyrus source folders (Source\\Scripts / Scripts\\Source) and put every one that holds .psc files on the import path, in MO2 priority order — so installed frameworks need no retyping. Pass false to compile against only the script's own folder, your import_dirs=/import_set=, and the vanilla sources.")]
+            bool auto_imports = true,
+        [Description("Optional. Name of a SAVED import-directory set (see save_import_set=) to add to the import path. Its dirs rank after import_dirs= and before the auto-discovered mods. An unknown name is refused, and the saved names are listed.")]
+            string? import_set = null,
+        [Description("Optional. Save this call's import_dirs= (plus any import_set= it loaded) under this name for reuse via import_set=. Persisted in houseCARL's user config, so it survives restarts; re-saving an existing name replaces it.")]
+            string? save_import_set = null,
         [Description("Optional. Base name for the NEW patch-mod folder the .pex lands in (default 'houseCARL_Scripts'); auto-suffixed if taken.")]
             string? patch_name = null,
         [Description("Optional. Filename of an existing houseCARL patch mod to add the .pex into instead of creating a fresh folder (accumulate compiled scripts). Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead (folder & plugin names need not match).")]
@@ -63,10 +107,59 @@ public static class CompileTools
         // install, not the copy MO2 points at) both resolve with no prompt; a total miss names where houseCARL looked (6.2).
         if (bridge.RequireOrPrompt(ToolDependency.PapyrusCompiler, out var compilerExe, svc.CompilerGameDirHints()) is { } toolPrompt) return toolPrompt;
 
-        // 4) import dirs — assembled by BuildImports (the guard-probed seam).
-        var imports = BuildImports(scriptDir, compilerExe!, import_dirs);
+        // 4) CALLER extras = import_dirs= then the named set (#200). An unknown set is REFUSED and names the saved sets
+        // rather than silently compiling with a shorter path — not having to check is the whole point of a named set.
+        var callerExtras = SplitDirs(import_dirs).ToList();
+        string? importSetName = null;
+        if (!string.IsNullOrWhiteSpace(import_set))
+        {
+            importSetName = import_set.Trim();
+            var saved = store.GetImportSet(importSetName);
+            if (saved is null)
+            {
+                var known = store.ImportSetNames();
+                return $"error: no saved import set named '{importSetName}'. " + (known.Count == 0
+                    ? "None are saved yet — pass import_dirs= once together with save_import_set= to create one."
+                    : "Saved sets: " + string.Join(", ", known) + ".");
+            }
+            callerExtras.AddRange(saved);
+        }
+        callerExtras = callerExtras.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
 
-        // 5) output folder — output_dir= names a USER-OWNED location (append Scripts\, never a houseCARL patch folder; 6.3),
+        // 5) persist the set BEFORE compiling: a set is a path list, worth keeping whether or not this particular script
+        // compiles. A save FAILURE is reported, never swallowed (Q3 — "it worked this session, it won't survive a restart").
+        string? saveNote = null;
+        if (!string.IsNullOrWhiteSpace(save_import_set))
+        {
+            var setName = save_import_set.Trim();
+            if (callerExtras.Count == 0)
+                saveNote = $"note: save_import_set='{setName}' was ignored — there were no import_dirs=/import_set= dirs to save " +
+                           "(the auto-discovered and vanilla folders are re-derived every call, so a set of them would be meaningless).";
+            else
+            {
+                var (ok, err) = store.SaveImportSet(setName, callerExtras);
+                saveNote = ok
+                    ? $"saved import set '{setName}' ({callerExtras.Count} dir(s)) — later calls can pass import_set={setName}."
+                    : $"warning: import set '{setName}' could NOT be saved ({err}) — its dirs apply to this compile but will not survive a restart.";
+            }
+        }
+
+        // 6) the import path — the script's own folder, the caller's extras, the modlist's own source folders, vanilla last.
+        var (autoRoots, autoWarning) = auto_imports
+            ? svc.PapyrusSourceImportDirs()
+            : ((IReadOnlyList<PapyrusSourceRoot>)Array.Empty<PapyrusSourceRoot>(), null);
+        var plan = PlanImports(scriptDir, compilerExe!, callerExtras, autoRoots, auto_imports, importSetName, autoWarning);
+
+        // The whole path travels as ONE `-i=` argument and Windows caps a process command line (~32k chars), so a modlist
+        // with hundreds of source folders could cross it. Refuse LOUDLY with the way out rather than letting the process
+        // start fail with something unreadable (Q3).
+        var joinedLength = string.Join(";", plan.Dirs).Length;
+        if (joinedLength > 30_000)
+            return $"error: the assembled import path is too long for one compiler command line ({plan.Dirs.Count} dirs, " +
+                   $"{joinedLength} chars; the limit is about 32000). Re-run with auto_imports=false and pass only the " +
+                   "dependencies this script needs via import_dirs= (save_import_set= will keep that list for next time).";
+
+        // 7) output folder — output_dir= names a USER-OWNED location (append Scripts\, never a houseCARL patch folder; 6.3),
         // else the default folder-per-patch with its Scripts\ subdir. output_dir= wins; patch_name=/into= are then ignored
         // (surfaced, not silent — Q3).
         LoadOrderService.RiderFolder rf;
@@ -84,9 +177,9 @@ public static class CompileTools
             catch (InvalidOperationException ex) { return "error: " + ex.Message; }
         }
 
-        // 6) compile + render.
-        var result = HousecarlCore.PapyrusCompile.CompileObject(compilerExe!, objectName, imports, rf.OutputDir);
-        var rendered = Render(result, imports, userChoseOutputDir: !string.IsNullOrWhiteSpace(output_dir));
+        // 8) compile + render.
+        var result = HousecarlCore.PapyrusCompile.CompileObject(compilerExe!, objectName, plan.Dirs, rf.OutputDir);
+        var rendered = Render(result, plan, userChoseOutputDir: !string.IsNullOrWhiteSpace(output_dir));
         if (result.Success)
         {
             // Q3: never report a clean "done" for a .pex that won't deploy from where output_dir= put it.
@@ -101,46 +194,143 @@ public static class CompileTools
             if (left is not null)
                 rendered += $"\nThe freshly created mod folder at '{left}' still holds partial output — delete it or retry with into=.";
         }
+        if (saveNote is not null) rendered = saveNote + "\n" + rendered;
         if (outputNote is not null) rendered = outputNote + "\n" + rendered;
         return rendered;
     });
 
+    /// <summary>Split a ';'-separated import-dir spec into trimmed, unquoted directories, dropping blanks.</summary>
+    internal static IEnumerable<string> SplitDirs(string? spec)
+    {
+        if (string.IsNullOrWhiteSpace(spec)) yield break;
+        foreach (var raw in spec.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var d = raw.Trim('"').Trim();
+            if (d.Length > 0) yield return d;
+        }
+    }
+
+    /// <summary>The vanilla Papyrus sources shipped with the game the COMPILER belongs to
+    /// (&lt;game&gt;\Papyrus Compiler\PapyrusCompiler.exe → &lt;game&gt;\Data\Source\Scripts, which also holds the flags
+    /// file), or null if that folder isn't there. ONE definition, used both by <see cref="BuildImports"/> (which pins it
+    /// last) and by the labelling in <see cref="PlanImports"/> (which must recognise the same folder) — derived twice they
+    /// could disagree, and the render would then label the vanilla slot as a mod.</summary>
+    public static string? VanillaSourceDir(string compilerExe)
+    {
+        var gameRoot = Path.GetDirectoryName(Path.GetDirectoryName(compilerExe));
+        if (gameRoot is null) return null;
+        var vanilla = Path.Combine(gameRoot, "Data", "Source", "Scripts");
+        return Directory.Exists(vanilla) ? vanilla : null;
+    }
+
     /// <summary>
     /// Assemble the compiler's import-directory list. The CK compiler resolves each referenced script
     /// to the FIRST matching .psc across these directories in order, so order is semantics: the
-    /// script's own folder first, then CALLER extras, then the vanilla sources LAST (derived from the
-    /// compiler's game dir: &lt;game&gt;\Papyrus Compiler\PapyrusCompiler.exe → &lt;game&gt;\Data\Source\Scripts,
-    /// which also holds the flags file). Vanilla last is load-bearing: mods ship EXTENDED copies of
+    /// script's own folder first, then CALLER extras, then the modlist's own AUTO-DISCOVERED source
+    /// folders (#200 — passed in MO2 priority order, so a higher-priority mod's copy wins exactly as it
+    /// does for every other file in the VFS), then the vanilla sources LAST.
+    /// Vanilla last is load-bearing: mods ship EXTENDED copies of
     /// vanilla sources (SKSE's Actor.psc/Game.psc/Form.psc above all) — ranked above the caller's
     /// dirs, the vanilla copy wins and every call to an extended function fails "not a function or
     /// does not exist" despite the user passing the right folder (the PEX bulk gate hit this twice;
     /// spike findings §5.12). Exposed as the import-order-guard probe's seam.
     /// </summary>
-    public static List<string> BuildImports(string scriptDir, string compilerExe, string? import_dirs)
+    public static List<string> BuildImports(string scriptDir, string compilerExe, string? import_dirs,
+                                            IReadOnlyList<string>? autoDirs = null)
     {
         var imports = new List<string> { scriptDir };
-        if (!string.IsNullOrWhiteSpace(import_dirs))
-            foreach (var d in import_dirs.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-                imports.Add(d.Trim('"'));
-        var gameRoot = Path.GetDirectoryName(Path.GetDirectoryName(compilerExe));
-        if (gameRoot is not null)
+        imports.AddRange(SplitDirs(import_dirs));
+        if (autoDirs is not null) imports.AddRange(autoDirs);
+        var vanilla = VanillaSourceDir(compilerExe);
+        if (vanilla is not null)
         {
-            var vanilla = Path.Combine(gameRoot, "Data", "Source", "Scripts");
-            if (Directory.Exists(vanilla))
-            {
-                // The auto-added vanilla dir is authoritative-LAST: a caller re-passing it (defensively,
-                // not knowing it's auto-added) must not pin it into the caller slot and resurrect the
-                // shadowing — Distinct keeps the FIRST occurrence. (When the script ITSELF lives in the
-                // vanilla folder, that slot is the own-folder slot and stays.)
-                imports.RemoveAll(d => d.Equals(vanilla, StringComparison.OrdinalIgnoreCase)
-                                       && !d.Equals(scriptDir, StringComparison.OrdinalIgnoreCase));
-                imports.Add(vanilla);
-            }
+            // The auto-added vanilla dir is authoritative-LAST: a caller re-passing it (defensively, not
+            // knowing it's auto-added) — or the modlist scan reaching it, since the game's Data folder is
+            // itself a VFS loose root and Data\Source\Scripts IS this folder — must not pin it into an
+            // earlier slot and resurrect the shadowing; Distinct keeps the FIRST occurrence. (When the
+            // script ITSELF lives in the vanilla folder, that slot is the own-folder slot and stays.)
+            imports.RemoveAll(d => d.Equals(vanilla, StringComparison.OrdinalIgnoreCase)
+                                   && !d.Equals(scriptDir, StringComparison.OrdinalIgnoreCase));
+            imports.Add(vanilla);
         }
         return imports.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
     }
 
-    internal static string Render(HousecarlCore.CompileResult r, IReadOnlyList<string> imports, bool userChoseOutputDir)
+    /// <summary>Drive <see cref="BuildImports"/> and LABEL each surviving dir with where it came from, so the render can
+    /// print the searched path with provenance. Labelling reads the FINAL list, not the inputs — dedup and the vanilla
+    /// re-slot both drop entries, and labels built from the inputs would describe a path that wasn't used.
+    /// Label precedence matters wherever a dir belongs to two origins: the script's own folder wins (it is routinely a
+    /// mod's own Source\Scripts, and it holds the first slot), then vanilla (the game's Data folder is also a loose root,
+    /// so the scan finds it — that is the vanilla slot, not a mod), then a discovered mod, then the caller.</summary>
+    internal static ImportPlan PlanImports(
+        string scriptDir, string compilerExe, IReadOnlyList<string> callerExtras,
+        IReadOnlyList<PapyrusSourceRoot> autoRoots, bool autoEnabled, string? importSetName, string? warning)
+    {
+        var dirs = BuildImports(scriptDir, compilerExe, string.Join(";", callerExtras),
+                                autoRoots.Select(r => r.Dir).ToList());
+        var vanilla = VanillaSourceDir(compilerExe);
+        var providers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var r in autoRoots) providers.TryAdd(r.Dir, r.Provider);
+
+        var entries = new List<(string Dir, string Origin)>(dirs.Count);
+        foreach (var d in dirs)
+        {
+            string origin =
+                d.Equals(scriptDir, StringComparison.OrdinalIgnoreCase) ? ImportPlan.OwnFolder
+                : vanilla is not null && d.Equals(vanilla, StringComparison.OrdinalIgnoreCase) ? ImportPlan.Vanilla
+                : providers.TryGetValue(d, out var mod) ? ImportPlan.AutoPrefix + mod
+                : ImportPlan.CallerDirs;
+            entries.Add((d, origin));
+        }
+        return new ImportPlan(entries, autoEnabled, importSetName, warning);
+    }
+
+    /// <summary>The one-line "what was actually searched" summary printed on EVERY call (#200 — the old render took the
+    /// import list and never showed it, so neither a missing dependency nor a shadowed script could be diagnosed from
+    /// the output). Provider names are display-capped at 8 with a "+N more" tail; the TOTAL is always stated, so a long
+    /// list reads as abbreviated rather than as everything there was.</summary>
+    internal static string ImportSummary(ImportPlan p)
+    {
+        var sb = new StringBuilder();
+        sb.Append("imports: ").Append(p.Dirs.Count).Append(" dir(s) searched — the script's own folder");
+        if (p.CallerCount > 0)
+        {
+            sb.Append("; ").Append(p.CallerCount).Append(" from import_dirs=");
+            if (p.ImportSetName is not null) sb.Append("/import_set=").Append(p.ImportSetName);
+        }
+        if (!p.AutoEnabled)
+            sb.Append("; auto_imports=false (your enabled mods were NOT scanned)");
+        else
+        {
+            var provs = p.AutoProviders;
+            sb.Append("; ").Append(provs.Count).Append(" auto-discovered from MO2");
+            if (provs.Count > 0)
+            {
+                const int Show = 8;
+                sb.Append(" (").Append(string.Join(", ", provs.Take(Show)));
+                if (provs.Count > Show) sb.Append(", +").Append(provs.Count - Show).Append(" more");
+                sb.Append(')');
+            }
+        }
+        if (p.Entries.Count > 0 && p.Entries[^1].Origin == ImportPlan.Vanilla)
+            sb.Append("; vanilla sources last");
+        sb.Append('.');
+        if (p.Warning is not null) sb.Append('\n').Append(p.Warning);
+        return sb.ToString();
+    }
+
+    /// <summary>The FULL ordered import path with provenance — printed on a FAILURE, where "which folders did it look
+    /// in, in what order" is exactly the question the diagnostics raise and the summary line cannot answer.</summary>
+    internal static string ImportDetail(ImportPlan p)
+    {
+        var sb = new StringBuilder("import path searched, in order (the compiler takes the FIRST match):");
+        for (int i = 0; i < p.Entries.Count; i++)
+            sb.Append("\n  ").Append((i + 1).ToString().PadLeft(2)).Append(". ")
+              .Append(p.Entries[i].Dir).Append("   [").Append(p.Entries[i].Origin).Append(']');
+        return sb.ToString();
+    }
+
+    internal static string Render(HousecarlCore.CompileResult r, ImportPlan plan, bool userChoseOutputDir)
     {
         var sb = new StringBuilder();
         if (!r.Ran) return "error: " + r.RunError;   // the compiler couldn't be run at all
@@ -154,6 +344,7 @@ public static class CompileTools
             sb.Append(userChoseOutputDir
                 ? "the .pex is in the output folder you chose (path above)."
                 : "the .pex is in a houseCARL patch-mod folder — enable it in MO2 to use it.");
+            sb.Append('\n').Append(ImportSummary(plan));
             if (r.Diagnostics.Count > 0)   // a .pex WAS produced but the compiler emitted notes → surface them as warnings
             {
                 sb.Append('\n').Append(r.Diagnostics.Count).Append(" warning(s) (the .pex compiled anyway):");
@@ -167,7 +358,7 @@ public static class CompileTools
         if (r.Diagnostics.Count > 0)
         {
             // MISSING-IMPORTS LEAD (HCBR-2026-06-25): when the failure is DOMINATED by unresolved-symbol/type errors, the
-            // overwhelmingly likely cause is an incomplete import_dirs — NOT a bug in the script (a single missing framework
+            // overwhelmingly likely cause is an incomplete import path — NOT a bug in the script (a single missing framework
             // header cascades into dozens of "unknown type / is undefined" lines, plus secondary type-mismatch noise, that
             // read like code errors). Surface that FIRST so the AI fixes the import path instead of "fixing" correct code.
             // Gated on a >=2/3 SUPERMAJORITY of the diagnostics AND a real count (>=3): a genuine missing import is
@@ -178,23 +369,36 @@ public static class CompileTools
             foreach (var d in r.Diagnostics) if (HousecarlCore.PapyrusCompile.IsUnresolvedSymbol(d.Message)) unresolved++;
             bool dominatedByMissingImports = unresolved >= 3 && unresolved * 3 >= r.Diagnostics.Count * 2;
             if (dominatedByMissingImports)
-                sb.Append("\n⚠ This looks like INCOMPLETE import_dirs, not a bug in the script: ")
+            {
+                sb.Append("\n⚠ This looks like an INCOMPLETE import path, not a bug in the script: ")
                   .Append(unresolved).Append(" of ").Append(r.Diagnostics.Count)
                   .Append(" diagnostics are unresolved-symbol/type errors (e.g. 'unknown type …', '… is undefined'). The CK " +
-                          "compiler resolves every referenced script against the import path, so a dependency whose Source\\Scripts " +
-                          "folder is missing makes ALL its calls/types fail. Re-run with import_dirs= listing EVERY dependency's " +
-                          "source folder (SKSE, SkyUI, PapyrusUtil, PO3, JContainers, …; ';'-separated) — the same set your " +
-                          "project's compile .bat passes via -i=.");
+                          "compiler resolves every referenced script against the import path, so a dependency whose source " +
+                          "folder is missing makes ALL its calls and types fail.");
+                // The remedy DIFFERS once the modlist has already been scanned: "list every dependency's folder" is the
+                // wrong instruction when dozens are already on the path, and it hides the causes the scan cannot fix (#200).
+                sb.Append(plan.AutoEnabled
+                    ? " The modlist scan already put " + plan.AutoProviders.Count + " mod source folder(s) on the path (listed " +
+                      "below), so the missing dependency is most likely NOT installed as an enabled mod, ships its sources " +
+                      "inside a BSA (the CK compiler cannot read archives — extract them first, e.g. with housecarl_bsa_extract), " +
+                      "or keeps them in a SUBFOLDER of one of the listed dirs. Pass that folder via import_dirs= (and " +
+                      "save_import_set= to keep it for next time)."
+                    : " auto_imports=false, so your enabled mods were NOT scanned — re-run with auto_imports=true, or pass " +
+                      "EVERY dependency's source folder via import_dirs= (SKSE, SkyUI, PapyrusUtil, PO3, JContainers, …; " +
+                      "';'-separated) — the same set your project's compile .bat passes via -i=.");
+            }
 
             // "diagnostic(s)", not "error(s)": the CK compiler mixes warnings into a failed run's output and the
             // parser doesn't split severities — labelling them all errors over-claims (2026-06-12 hunt render wave).
             sb.Append('\n').Append(r.Diagnostics.Count).Append(" diagnostic(s) (errors and possibly warnings — the CK compiler mixes them):");
             foreach (var d in r.Diagnostics) sb.Append("\n  ").Append(d);
+            sb.Append('\n').Append(ImportDetail(plan));
+            if (plan.Warning is not null) sb.Append('\n').Append(plan.Warning);
             // The generic tail stays for the NON-dominated case (a few resolution errors mixed with real ones); when we
             // already led with the strong missing-imports banner, don't repeat the import line.
             sb.Append("\nfix the .psc and recompile (look unfamiliar functions/types up with the papyrus-reference skill).");
             if (!dominatedByMissingImports)
-                sb.Append(" If a dependency type is 'not found', its source folder may be missing from the import path — pass it via import_dirs=.");
+                sb.Append(" If a dependency type is 'not found', its source folder may be missing from the import path listed above — pass it via import_dirs=.");
         }
         else
         {
@@ -202,6 +406,7 @@ public static class CompileTools
             sb.Append("\nthe compiler reported failure but no per-line diagnostics were parsed. Raw output:");
             if (r.Stderr.Trim().Length > 0) sb.Append("\n[stderr] ").Append(r.Stderr.Trim());
             if (r.Stdout.Trim().Length > 0) sb.Append("\n[stdout] ").Append(r.Stdout.Trim());
+            sb.Append('\n').Append(ImportDetail(plan));
         }
         return sb.ToString();
     }

--- a/src/housecarl-mcp/CompileTools.cs
+++ b/src/housecarl-mcp/CompileTools.cs
@@ -29,7 +29,9 @@ public static class CompileTools
         string? ImportSetName,
         string? Warning,
         int AutoScanned = 0,
-        PapyrusDependencyScan? Scan = null)
+        PapyrusDependencyScan? Scan = null,
+        IReadOnlyList<string>? ReferencedProviders = null,
+        bool VanillaMissing = false)
     {
         /// <summary>Provenance labels — the exact strings <see cref="ImportDetail"/> prints, and the keys the counts group on.</summary>
         public const string OwnFolder = "the script's own folder";
@@ -43,10 +45,20 @@ public static class CompileTools
         /// <summary>Dirs that came from the caller (import_dirs= / import_set=) and survived into the final path.</summary>
         public int CallerCount => Entries.Count(e => e.Origin == CallerDirs);
 
-        /// <summary>The providing mod folders behind the auto-discovered entries, in path order.</summary>
+        /// <summary>The providing mod folders behind the entries that occupy an auto-discovered SLOT — i.e. that are
+        /// on the path because the scan put them there. A folder the caller also passed takes the caller slot instead
+        /// and is absent here by design.</summary>
         public IReadOnlyList<string> AutoProviders =>
             Entries.Where(e => e.Origin.StartsWith(AutoPrefix, StringComparison.Ordinal))
                    .Select(e => e.Origin[AutoPrefix.Length..]).ToList();
+
+        /// <summary>The mods the reference WALK matched — the scan's own conclusion, independent of which slot each
+        /// folder ended up in. This is the number the summary and the missing-imports banner quote, because the
+        /// question they ask ("what does this script reference?") is not the question the slots answer ("why is this
+        /// folder on the path?"). Deriving it from <see cref="Entries"/> instead made a folder the caller had also
+        /// passed drop out of the count, so a genuine match rendered as "matched the 0 this script REFERENCES BY NAME".
+        /// The one count in this record NOT derived from the entries, and deliberately so.</summary>
+        public IReadOnlyList<string> Referenced { get; } = ReferencedProviders ?? Array.Empty<string>();
     }
 
     [McpServerTool(Name = "housecarl_compile_script", Title = "Compile a Papyrus script (.psc → .pex)"),
@@ -148,10 +160,12 @@ public static class CompileTools
         }
 
         // 6) the import path — the script's own folder, the caller's extras, the modlist's own source folders, vanilla last.
-        var (autoRoots, autoWarning) = auto_imports
-            ? svc.PapyrusSourceImportDirs()
-            : ((IReadOnlyList<PapyrusSourceRoot>)Array.Empty<PapyrusSourceRoot>(), null);
-        var plan = PlanImports(script, scriptDir, compilerExe!, callerExtras, autoRoots, auto_imports, importSetName, autoWarning);
+        // auto_imports=false still asks for the game-Data sources: they are the vanilla FALLBACK, not a scan result,
+        // and a compiler whose own Data\Source\Scripts is missing needs them just as much with the scan switched off.
+        var (autoRoots, gameDataSources, autoWarning) = svc.PapyrusSourceImportDirs();
+        if (!auto_imports) autoRoots = Array.Empty<PapyrusSourceRoot>();
+        var plan = PlanImports(script, scriptDir, compilerExe!, callerExtras, autoRoots, auto_imports, importSetName,
+                               auto_imports ? autoWarning : null, gameDataSources);
 
         // The whole path travels as ONE `-i=` argument and Windows caps a process command line (~32k chars), so a modlist
         // with hundreds of source folders could cross it. Refuse LOUDLY with the way out rather than letting the process
@@ -239,12 +253,17 @@ public static class CompileTools
     /// spike findings §5.12). Exposed as the import-order-guard probe's seam.
     /// </summary>
     public static List<string> BuildImports(string scriptDir, string compilerExe, string? import_dirs,
-                                            IReadOnlyList<string>? autoDirs = null)
+                                            IReadOnlyList<string>? autoDirs = null, string? resolvedVanilla = null)
     {
         var imports = new List<string> { scriptDir };
         imports.AddRange(SplitDirs(import_dirs));
         if (autoDirs is not null) imports.AddRange(autoDirs);
-        var vanilla = VanillaSourceDir(compilerExe);
+        // resolvedVanilla, when given, IS the vanilla dir — already decided by the caller, not a second opinion to
+        // reconcile. PlanImports resolves it once (compiler-relative first, else the modlist's own Data\Source\Scripts,
+        // which the scan split out precisely to stand in here) and hands the answer down. Deriving it independently in
+        // both places is exactly the drift VanillaSourceDir's own summary warns about: they would disagree, and the
+        // plan would then report a vanilla slot the assembled path does not have — or the reverse.
+        var vanilla = resolvedVanilla ?? VanillaSourceDir(compilerExe);
         if (vanilla is not null)
         {
             // The auto-added vanilla dir is authoritative-LAST: a caller re-passing it (defensively, not
@@ -267,9 +286,12 @@ public static class CompileTools
     /// so the scan finds it — that is the vanilla slot, not a mod), then a discovered mod, then the caller.</summary>
     internal static ImportPlan PlanImports(
         string targetScript, string scriptDir, string compilerExe, IReadOnlyList<string> callerExtras,
-        IReadOnlyList<PapyrusSourceRoot> autoRoots, bool autoEnabled, string? importSetName, string? warning)
+        IReadOnlyList<PapyrusSourceRoot> autoRoots, bool autoEnabled, string? importSetName, string? warning,
+        string? gameDataSources = null)
     {
-        var vanilla = VanillaSourceDir(compilerExe);
+        // The compiler's own game dir first — its sources are the ones matching the flags file it will use — then the
+        // modlist's Data\Source\Scripts, which the scan split out precisely so it could stand in here.
+        var vanilla = VanillaSourceDir(compilerExe) ?? gameDataSources;
 
         // NARROW the scan to what this script reaches. Handing over every folder a modlist ships is not a heavier
         // version of the same thing — measured on a real 3617-mod order it is 501 folders / ~40,200 chars, past the
@@ -288,7 +310,7 @@ public static class CompileTools
             autoDirs = scan.Folders;
         }
 
-        var dirs = BuildImports(scriptDir, compilerExe, string.Join(";", callerExtras), autoDirs);
+        var dirs = BuildImports(scriptDir, compilerExe, string.Join(";", callerExtras), autoDirs, vanilla);
 
         // Providers are indexed from the KEPT folders only. A candidate the filter DROPPED can still reach the final
         // list — but only because the caller passed it — so indexing every discovered root would label it as one the
@@ -314,7 +336,18 @@ public static class CompileTools
                 : ImportPlan.CallerDirs;
             entries.Add((d, origin));
         }
-        return new ImportPlan(entries, autoEnabled, importSetName, warning, candidates.Count, scan);
+
+        // The scan's OWN answer, kept separate from the slot labels. A folder can be both matched by the walk and
+        // passed explicitly by the caller; it then takes the caller SLOT (it would be on the path with the scan off),
+        // but it is still something the script references — deriving the referenced count from the labels made that
+        // folder vanish from it, so a genuine match rendered as "matched the 0 this script REFERENCES BY NAME". The
+        // two questions are answered by two fields rather than one doing double duty.
+        var referenced = scan is null
+            ? (IReadOnlyList<string>)Array.Empty<string>()
+            : scan.Folders.Select(f => providers.TryGetValue(f, out var m) ? m : Path.GetFileName(f)).ToList();
+
+        return new ImportPlan(entries, autoEnabled, importSetName, warning, candidates.Count, scan, referenced,
+                              VanillaMissing: vanilla is null);
     }
 
     /// <summary>The one-line "what was actually searched" summary printed on EVERY call (#200 — the old render took the
@@ -337,13 +370,16 @@ public static class CompileTools
             // Report the NARROWING, not just the survivors: "12 auto-discovered" reads as "your modlist ships 12
             // source folders", which is wrong by a factor of forty and hides the one decision worth auditing when a
             // dependency turns up missing — that the other 489 were dropped as unreferenced, not overlooked.
-            var provs = p.AutoProviders;
-            sb.Append("; ").Append(provs.Count).Append(" of ").Append(p.AutoScanned)
+            // The WALK's count, not the slot count — a folder the caller also passed is still one the script
+            // references. No arithmetic is claimed between this and the import_dirs= clause: a folder can be in both,
+            // and the only total stated is the dir count at the front.
+            var provs = p.Referenced;
+            sb.Append("; the modlist scan matched ").Append(provs.Count).Append(" of ").Append(p.AutoScanned)
               // "referenced by this script" is a claim about the source's CONTENTS. It is only earned when the source
               // was actually read: an unreadable target yields the same empty result, and asserting it there would be
               // a confident wrong answer rather than a degraded one.
               .Append(p.Scan is { TargetUnreadable: true }
-                          ? " scanned mod source folder(s) kept (the script could NOT be read — see below)"
+                          ? " scanned mod source folder(s) (the script could NOT be read — see below)"
                           : " scanned mod source folder(s) referenced by this script");
             if (provs.Count > 0)
             {
@@ -382,6 +418,15 @@ public static class CompileTools
     internal static string ImportCaveats(ImportPlan p)
     {
         var sb = new StringBuilder();
+        // No vanilla sources ANYWHERE — neither beside the compiler nor under the modlist's data dir. Every vanilla
+        // type (Form, Quest, ObjectReference…) will fail to resolve, and the missing-imports banner would otherwise
+        // send the reader hunting for a mod. This state was reachable silently for one commit, when the game-Data
+        // split dropped the only copy on the machine and nothing replaced it (PR #296 re-review).
+        if (p.VanillaMissing)
+            sb.Append("\n⚠ NO vanilla Papyrus sources are on the import path — houseCARL found none beside the compiler " +
+                      "(<game>\\Data\\Source\\Scripts) and none under your MO2 data folder. Every vanilla type will fail " +
+                      "to resolve until you unpack them (the CK ships them as Scripts.zip) or pass their folder via " +
+                      "import_dirs=.");
         if (p.Scan is { TargetUnreadable: true })
             sb.Append("\n⚠ the script's own source could not be READ when the import path was assembled (locked or moved " +
                       "after houseCARL first checked it), so NOTHING was resolved from its contents and the modlist scan " +
@@ -450,12 +495,12 @@ public static class CompileTools
                       "EVERY dependency's source folder via import_dirs= (SKSE, SkyUI, PapyrusUtil, PO3, JContainers, …; " +
                       "';'-separated) — the same set your project's compile .bat passes via -i=."
                     : narrowingIncomplete
-                    ? " START WITH THE ⚠ NOTE BELOW: the modlist scan did not complete, so the " + plan.AutoProviders.Count +
-                      " folder(s) it contributed out of " + plan.AutoScanned + " scanned are NOT the full set this script " +
+                    ? " START WITH THE ⚠ NOTE BELOW: the modlist scan did not complete, so the " + plan.Referenced.Count +
+                      " folder(s) it matched out of " + plan.AutoScanned + " scanned are NOT the full set this script " +
                       "needs — the missing dependency was most likely dropped by that, not by anything wrong with your setup. " +
                       "Pass its source folder via import_dirs= (and save_import_set= to keep it for next time)."
-                    : " The modlist scan found " + plan.AutoScanned + " mod source folder(s) and kept the " +
-                      plan.AutoProviders.Count + " this script REFERENCES BY NAME (listed below). So the missing dependency " +
+                    : " The modlist scan found " + plan.AutoScanned + " mod source folder(s) and matched the " +
+                      plan.Referenced.Count + " this script REFERENCES BY NAME (listed below). So the missing dependency " +
                       "is most likely one the source never names outright, or one that is not installed as an enabled mod, " +
                       "or one shipping its sources inside a BSA (the CK compiler cannot read archives — extract them first, " +
                       "e.g. with housecarl_bsa_extract), or one keeping them in a SUBFOLDER of a listed dir. Pass that folder " +

--- a/src/housecarl-mcp/CompileTools.cs
+++ b/src/housecarl-mcp/CompileTools.cs
@@ -70,7 +70,7 @@ public static class CompileTools
          "folders your enabled MO2 mods already ship (Source\\Scripts / Scripts\\Source, in MO2 priority order — so SKSE, " +
          "PapyrusUtil, PO3, SkyUI, JContainers and friends need no retyping), NARROWED to the folders this script actually " +
          "references (directly or transitively), then the vanilla sources LAST; pass " +
-         "auto_imports=false to skip the modlist scan. Add anything the scan can't reach (local stubs, a dev project tree, " +
+         "auto_imports=false to leave your enabled mods off the import path. Add anything the scan can't reach (local stubs, a dev project tree, " +
          "sources you extracted from a BSA — the CK compiler cannot read archives) via import_dirs= (';'-separated), and " +
          "save_import_set=<name> to persist that list so later calls just pass import_set=<name>. Precedence is your " +
          "import_dirs=/import_set= > the auto-discovered mods > vanilla, so mod-extended copies of vanilla scripts " +
@@ -160,12 +160,23 @@ public static class CompileTools
         }
 
         // 6) the import path — the script's own folder, the caller's extras, the modlist's own source folders, vanilla last.
-        // auto_imports=false still asks for the game-Data sources: they are the vanilla FALLBACK, not a scan result,
-        // and a compiler whose own Data\Source\Scripts is missing needs them just as much with the scan switched off.
-        var (autoRoots, gameDataSources, autoWarning) = svc.PapyrusSourceImportDirs();
-        if (!auto_imports) autoRoots = Array.Empty<PapyrusSourceRoot>();
+        // The scan is skipped when auto_imports=false — which is what that flag PROMISES, and its only real use: it is
+        // what you reach for when the scan is slow or the profile is pathological, and an unconditional call would take
+        // that away while three render strings still said it hadn't run. The one exception is the rare branch where the
+        // compiler has no vanilla sources beside it: then the modlist is read purely to LOCATE them, because the
+        // alternative is a path with no vanilla at all.
+        IReadOnlyList<PapyrusSourceRoot> autoRoots = Array.Empty<PapyrusSourceRoot>();
+        string? gameDataSources = null, autoWarning = null;
+        if (NeedsModlistScan(auto_imports, compilerExe!))
+        {
+            (autoRoots, gameDataSources, autoWarning) = svc.PapyrusSourceImportDirs();
+            if (!auto_imports) autoRoots = Array.Empty<PapyrusSourceRoot>();   // read for the vanilla fallback only
+        }
+        // The warning rides along whenever the scan actually ran: with auto_imports on it explains missing mods, and on
+        // the vanilla-only branch it explains a missing vanilla slot, which the VanillaMissing caveat would otherwise
+        // report without the cause the code already has in hand.
         var plan = PlanImports(script, scriptDir, compilerExe!, callerExtras, autoRoots, auto_imports, importSetName,
-                               auto_imports ? autoWarning : null, gameDataSources);
+                               autoWarning, gameDataSources);
 
         // The whole path travels as ONE `-i=` argument and Windows caps a process command line (~32k chars), so a modlist
         // with hundreds of source folders could cross it. Refuse LOUDLY with the way out rather than letting the process
@@ -226,6 +237,16 @@ public static class CompileTools
             if (d.Length > 0) yield return d;
         }
     }
+
+    /// <summary>Whether the rider must read the MO2 modlist at all. True when the scan was asked for, and — even when
+    /// it was declined — when the compiler has no vanilla sources beside it, because the modlist's own
+    /// <c>Data\Source\Scripts</c> is then the only place left to find them and a path with no vanilla resolves nothing.
+    /// <para>A NAMED rule rather than an inline condition because it is the difference between honouring
+    /// <c>auto_imports=false</c> and quietly ignoring it: the scan forces the asset build and probes two layouts under
+    /// every enabled mod (~7,200 directory probes on the 3,617-mod order this work measured), which is exactly the cost
+    /// that flag exists to let a caller avoid.</para></summary>
+    internal static bool NeedsModlistScan(bool autoImports, string compilerExe)
+        => autoImports || VanillaSourceDir(compilerExe) is null;
 
     /// <summary>The vanilla Papyrus sources shipped with the game the COMPILER belongs to
     /// (&lt;game&gt;\Papyrus Compiler\PapyrusCompiler.exe → &lt;game&gt;\Data\Source\Scripts, which also holds the flags
@@ -364,7 +385,7 @@ public static class CompileTools
             if (p.ImportSetName is not null) sb.Append("/import_set=").Append(p.ImportSetName);
         }
         if (!p.AutoEnabled)
-            sb.Append("; auto_imports=false (your enabled mods were NOT scanned)");
+            sb.Append("; auto_imports=false (your enabled mods are NOT on the import path)");
         else
         {
             // Report the NARROWING, not just the survivors: "12 auto-discovered" reads as "your modlist ships 12
@@ -491,7 +512,7 @@ public static class CompileTools
                 // job and then list causes that exclude the real one. The caveats print with the path below.
                 bool narrowingIncomplete = plan.Scan is { TargetUnreadable: true } or { BudgetExhausted: true };
                 sb.Append(!plan.AutoEnabled
-                    ? " auto_imports=false, so your enabled mods were NOT scanned — re-run with auto_imports=true, or pass " +
+                    ? " auto_imports=false, so your enabled mods are NOT on the import path — re-run with auto_imports=true, or pass " +
                       "EVERY dependency's source folder via import_dirs= (SKSE, SkyUI, PapyrusUtil, PO3, JContainers, …; " +
                       "';'-separated) — the same set your project's compile .bat passes via -i=."
                     : narrowingIncomplete

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -291,6 +291,37 @@ public sealed class LoadOrderService : IDisposable
     /// none is built (a pure-record session never pays for the asset resolver). Caller holds <see cref="_gate"/>.</summary>
     void InvalidateAssetResolver() { _assetResolver?.Dispose(); _assetResolver = null; }
 
+    /// <summary>The Papyrus SOURCE folders this modlist already ships (housecarl_compile_script's auto-import, #200):
+    /// every enabled mod's <c>Source\Scripts</c> / <c>Scripts\Source</c>, in MO2's own VFS precedence, so a framework
+    /// the modder already has installed (SKSE, PapyrusUtil, PO3, SkyUI, JContainers, …) lands on the compiler's import
+    /// path without being retyped per call.
+    /// <para>Reads the ORDER off <see cref="AssetResolver.LooseRoots"/> rather than re-deriving it: the precedence a
+    /// shadowed script resolves through must be the SAME list every other asset answer uses, and a second derivation
+    /// is a second thing to drift. The cost is that a compile-only session now builds the asset resolver (BSA file
+    /// tables — cheap next to the record index, and cached for the process/profile).</para>
+    /// <para>BEST-EFFORT BY CONTRACT (Q3): an unconfigured/unreadable profile returns an EMPTY list plus a warning the
+    /// rider renders, never an exception — losing the ergonomic default must not lose the compile, and the rendered
+    /// import summary makes a short list visible rather than silent.</para></summary>
+    public (IReadOnlyList<PapyrusSourceRoot> Roots, string? Warning) PapyrusSourceImportDirs()
+    {
+        IReadOnlyList<(string Name, string Dir)> roots;
+        try { lock (_gate) { roots = Assets.LooseRoots; } }
+        catch (Exception ex)
+        {
+            return (Array.Empty<PapyrusSourceRoot>(),
+                    "auto_imports: could not read the MO2 modlist to discover Papyrus source folders " +
+                    $"({ex.Message}) — only the script's own folder, your import_dirs=/import_set=, and the vanilla " +
+                    "sources are on the import path.");
+        }
+        try { return (PapyrusSourceRoots.Discover(roots), null); }
+        catch (Exception ex)
+        {
+            return (Array.Empty<PapyrusSourceRoot>(),
+                    $"auto_imports: scanning the modlist for Papyrus source folders failed ({ex.Message}) — " +
+                    "pass the dependency source folders via import_dirs=/import_set= for this compile.");
+        }
+    }
+
     /// <summary>Resolve a batch of Data-relative asset paths through the MO2 VFS (housecarl_asset_status): for each,
     /// which source provides it and which copy WINS (loose beats BSA; among BSAs the higher plugin rank). ONE
     /// <see cref="AssetResolver.Capture"/> for the whole batch, so every path AND the build-level BsaFailures /

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -302,17 +302,25 @@ public sealed class LoadOrderService : IDisposable
     /// <para>BEST-EFFORT BY CONTRACT (Q3): an unconfigured/unreadable profile returns an EMPTY list plus a warning the
     /// rider renders, never an exception — losing the ergonomic default must not lose the compile, and the rendered
     /// import summary makes a short list visible rather than silent.</para></summary>
-    public (IReadOnlyList<PapyrusSourceRoot> Roots, string? GameDataSources, string? Warning) PapyrusSourceImportDirs()
+    /// <para>A FAILURE is flagged, not just warned about (<c>Failed</c>): an empty root list from a read that threw is
+    /// otherwise indistinguishable from a modlist that genuinely ships no source folders, and the rider renders the
+    /// two very differently — "the scan matched 0 of 0" is a conclusion, and a scan that never ran has not reached
+    /// one. Same shape as the scan's own TargetUnreadable / BudgetExhausted flags.</para>
+    public (IReadOnlyList<PapyrusSourceRoot> Roots, string? GameDataSources, string? Warning, bool Failed) PapyrusSourceImportDirs()
     {
         IReadOnlyList<(string Name, string Dir)> roots;
         string dataDir;
         try { lock (_gate) { roots = Assets.LooseRoots; dataDir = _dataDir; } }
         catch (Exception ex)
         {
+            // Says what failed and what it costs — and nothing about vanilla. The old tail ("…and the vanilla sources
+            // are on the import path") was a claim this method has no way to check, and it could print directly under
+            // a caveat stating there are none. Labelled "modlist scan", not "auto_imports", because the rider also
+            // reaches here with auto_imports OFF, purely to locate the vanilla fallback.
             return (Array.Empty<PapyrusSourceRoot>(), null,
-                    "auto_imports: could not read the MO2 modlist to discover Papyrus source folders " +
-                    $"({ex.Message}) — only the script's own folder, your import_dirs=/import_set=, and the vanilla " +
-                    "sources are on the import path.");
+                    "modlist scan: could not read the MO2 modlist to discover Papyrus source folders " +
+                    $"({ex.Message}) — none of your installed mods' source folders are on the import path for this compile.",
+                    true);
         }
         // The game's own Data root is SPLIT OUT here, where the data dir is known, rather than left to the rider's
         // compiler-relative vanilla check: on a Stock Game setup those are deliberately different folders (the CK
@@ -323,13 +331,14 @@ public sealed class LoadOrderService : IDisposable
         try
         {
             var (mods, gameData) = PapyrusSourceRoots.SplitGameData(PapyrusSourceRoots.Discover(roots), dataDir);
-            return (mods, gameData, null);
+            return (mods, gameData, null, false);
         }
         catch (Exception ex)
         {
             return (Array.Empty<PapyrusSourceRoot>(), null,
-                    $"auto_imports: scanning the modlist for Papyrus source folders failed ({ex.Message}) — " +
-                    "pass the dependency source folders via import_dirs=/import_set= for this compile.");
+                    $"modlist scan: scanning the modlist for Papyrus source folders failed ({ex.Message}) — " +
+                    "pass the dependency source folders via import_dirs=/import_set= for this compile.",
+                    true);
         }
     }
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -302,26 +302,32 @@ public sealed class LoadOrderService : IDisposable
     /// <para>BEST-EFFORT BY CONTRACT (Q3): an unconfigured/unreadable profile returns an EMPTY list plus a warning the
     /// rider renders, never an exception — losing the ergonomic default must not lose the compile, and the rendered
     /// import summary makes a short list visible rather than silent.</para></summary>
-    public (IReadOnlyList<PapyrusSourceRoot> Roots, string? Warning) PapyrusSourceImportDirs()
+    public (IReadOnlyList<PapyrusSourceRoot> Roots, string? GameDataSources, string? Warning) PapyrusSourceImportDirs()
     {
         IReadOnlyList<(string Name, string Dir)> roots;
         string dataDir;
         try { lock (_gate) { roots = Assets.LooseRoots; dataDir = _dataDir; } }
         catch (Exception ex)
         {
-            return (Array.Empty<PapyrusSourceRoot>(),
+            return (Array.Empty<PapyrusSourceRoot>(), null,
                     "auto_imports: could not read the MO2 modlist to discover Papyrus source folders " +
                     $"({ex.Message}) — only the script's own folder, your import_dirs=/import_set=, and the vanilla " +
                     "sources are on the import path.");
         }
-        // The game's own Data root is dropped HERE, where the data dir is known, rather than left to the rider's
+        // The game's own Data root is SPLIT OUT here, where the data dir is known, rather than left to the rider's
         // compiler-relative vanilla check: on a Stock Game setup those are deliberately different folders (the CK
         // compiler lives in the real Steam install), so that check would never fire and the base game would rank as
-        // an ordinary mod. See PapyrusSourceRoots.ExcludeGameData.
-        try { return (PapyrusSourceRoots.ExcludeGameData(PapyrusSourceRoots.Discover(roots), dataDir), null); }
+        // an ordinary mod. It is handed BACK rather than discarded — the rider uses it as the vanilla slot when the
+        // compiler-relative folder doesn't resolve, which is the only way both properties hold at once. See
+        // PapyrusSourceRoots.SplitGameData.
+        try
+        {
+            var (mods, gameData) = PapyrusSourceRoots.SplitGameData(PapyrusSourceRoots.Discover(roots), dataDir);
+            return (mods, gameData, null);
+        }
         catch (Exception ex)
         {
-            return (Array.Empty<PapyrusSourceRoot>(),
+            return (Array.Empty<PapyrusSourceRoot>(), null,
                     $"auto_imports: scanning the modlist for Papyrus source folders failed ({ex.Message}) — " +
                     "pass the dependency source folders via import_dirs=/import_set= for this compile.");
         }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -305,7 +305,8 @@ public sealed class LoadOrderService : IDisposable
     public (IReadOnlyList<PapyrusSourceRoot> Roots, string? Warning) PapyrusSourceImportDirs()
     {
         IReadOnlyList<(string Name, string Dir)> roots;
-        try { lock (_gate) { roots = Assets.LooseRoots; } }
+        string dataDir;
+        try { lock (_gate) { roots = Assets.LooseRoots; dataDir = _dataDir; } }
         catch (Exception ex)
         {
             return (Array.Empty<PapyrusSourceRoot>(),
@@ -313,7 +314,11 @@ public sealed class LoadOrderService : IDisposable
                     $"({ex.Message}) — only the script's own folder, your import_dirs=/import_set=, and the vanilla " +
                     "sources are on the import path.");
         }
-        try { return (PapyrusSourceRoots.Discover(roots), null); }
+        // The game's own Data root is dropped HERE, where the data dir is known, rather than left to the rider's
+        // compiler-relative vanilla check: on a Stock Game setup those are deliberately different folders (the CK
+        // compiler lives in the real Steam install), so that check would never fire and the base game would rank as
+        // an ordinary mod. See PapyrusSourceRoots.ExcludeGameData.
+        try { return (PapyrusSourceRoots.ExcludeGameData(PapyrusSourceRoots.Discover(roots), dataDir), null); }
         catch (Exception ex)
         {
             return (Array.Empty<PapyrusSourceRoot>(),


### PR DESCRIPTION
Closes #200.

`housecarl_compile_script` took the caller's complete `import_dirs=` list on **every** call — a framework-heavy project retyped its `compile.bat`'s `-i=` list verbatim each time. This builds both halves the issue parked, plus the render gap that hid them.

## The issue's premise was wrong, and the correction matters

#200 framed this as "read the import paths configured for the MO2 instance." **There are none.** MO2 stores no Papyrus import list, and `SkyrimEditor.ini`'s `sScriptSourceFolder` is a single folder, not a list. What does exist is the mods: a framework meant to be compiled against ships its `.psc` sources inside its own folder. So the pickup is a scan of the VFS loose roots, not a config read — same goal, real mechanism.

## What landed

**1. Modlist source discovery** (`PapyrusSourceRoots`) — scans the enabled mods' `Source\Scripts` / `Scripts\Source` for folders holding real `.psc`. The **order** is read off `AssetResolver.LooseRoots` rather than re-derived: the precedence a shadowed script resolves through must be the same list every other asset answer uses. On by default; `auto_imports=false` opts out. Best-effort by contract — losing the ergonomic default must never lose the compile.

**2. Named import sets** — `save_import_set=` / `import_set=`, persisted in `houseCARL.user.json`, for what the scan can't reach: local stubs, a dev tree, sources extracted out of a BSA. Fourth concern in a file whose whole point is that its concerns never clobber each other; a guard arm seeds the other three and proves a save leaves them intact.

**3. The render** — `Render()` took the import list as an argument and *dropped it on the floor*. The caller was never told what was searched, which is the one fact separating "the dependency was never on the path" from "it was found in the wrong folder." Now a summary on success and the full ordered path with provenance on failure, with counts **derived from the final entries** so they cannot disagree with the list beneath them.

## The measurement that changed the design

Pointing the scan at the real order immediately falsified the approved default:

| | |
|---|---|
| Enabled mods (ARR 2.0) | 3,617 |
| Source folders found | **501** — one mod in seven |
| Joined `-i=` length | **~40,200 chars** |
| Windows command-line cap | ~32,767 |

Default-ON would have **refused every compile on that machine** via its own too-long guard. The size was the symptom: those 501 are overwhelmingly quest and follower mods carrying their own scripts, which nothing else references. Handing them over was never right, only unnoticed.

`PapyrusDependencyFilter` walks what the compiler walks — a name resolves to its **first** provider on the path, so each name indexes to exactly one folder, and every identifier-shaped token in the target is looked up then followed **into** each resolved script, transitively (type-checking loads a dependency's own dependencies). Deliberately over-inclusive: keywords, locals and comment text are all treated as possible script names, because a token naming nothing costs a dictionary miss while a wrongly dropped folder costs a compile that used to work. Vanilla is held out of the index — always appended anyway, so indexing it could only walk the base game for no gain.

Driven through the real code against the live order:

| Script | Before | After | Time |
|---|---|---|---|
| `SSv3Config.psc` (OStim) | 501 folders / 40,200 chars | **8 / 595** | 122 ms |
| `AmorousAdvAelaQst.psc` | 501 / 40,200 | **11 / 830** | 131 ms |
| `AlchemyScript.psc` | 501 / 40,200 | **3 / 209** | 59 ms |

Kept sets are SKSE, PapyrusUtil, JContainers, ConsoleUtilSSE, OStim, MCM Recorder, the mod's own folder, and the Authoria script-fix replacers that shadow them. Index is 12,868 scripts in 74 ms; no budget exhaustion.

The summary reports **both** numbers ("8 of 501 scanned … referenced by this script") — naming only the survivors would read as "your modlist ships 8 source folders," wrong by two orders of magnitude, and would hide the one decision worth auditing when a dependency turns up missing.

## Guards

`import-order-guard` gains the third rank, the **Data-root re-slot** (the scan hands the vanilla folder back as an ordinary auto dir; unslotted, SKSE's `Actor.psc` would lose to vanilla's), the caller/scan overlap, `PlanImports`' label precedence, and an **end-to-end arm against the real CK compiler** proving a *scanned* mod's extended copy beats vanilla — the caller-rank proof does not transitively cover it.

`compile-ergonomics-guard` gains the render contract, the import-set store, the discovery scan, and the reference walk (direct, transitive, the unreferenced drop, first-provider-wins, comment over-inclusion, unreadable target, reference cycle).

**Every new claim was falsified** — broken in the source, rebuilt, and confirmed to turn the arms that name it red: the auto/caller ordering, the vanilla re-slot, the label precedence, the derived counts, the import-set case-replace, the transitive hop, first-wins, and the drop.

**One exception, disclosed rather than papered over.** The `.pscx` extension re-check did **not** go red when removed: the 8.3 short-name quirk it guards is volume-dependent and did not reproduce here. That arm is labelled a shape-check, not a proof, and the code comment says so instead of claiming a measurement it doesn't have.

## Notes for review

- `auto_imports` is a bool, not a mode — there is no "scan everything unfiltered" option, because on a real order that path cannot execute. The escape hatch for a missed folder is `import_dirs=`.
- The filter's failure mode is **under-inclusion**: a dependency the source never names outright. The missing-imports banner now leads with exactly that cause.
- The ~30,000-char refusal stays as a backstop. After filtering it should never fire; it is there so a pathological case fails legibly rather than at `CreateProcess`.

110/110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)