### PR TITLE
feat(shim): the 2.0 alias layer - ToolCallShim inverted, SPEC 5.3 as config (W0)

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,9 +13,12 @@ first-guess parameter misses (`plugin=` for `plugins=`, `form_id` for `formid`) 
 naming dictionary instead of two hard-wired synonym pairs. Visible today: several new-vocabulary spellings bind on
 the current tools (`patch=` for `patch_name=`, `ops=` for `operations=`, `readback=` for `full_readback=`,
 `filter=` for load-order-status's `lookup=`, `types=` for `type=`), and `patch_name=` now also binds on
-`remove_record` (whose parameter was always the odd one out, bare `patch`). Everything else in the dictionary
-stays dormant by construction until the 2.0 build waves rename the tools it describes; behaviour of well-formed
-calls is byte-identical.
+`remove_record` (whose parameter was always the odd one out, bare `patch`). A rename never fires into a type
+mismatch: a spelling whose value can't bind to its would-be target (say, an array `types=` where a single
+`type=` string is declared) keeps its own name in the refusal, alongside the tool's supported-parameter list.
+Everything else in the dictionary stays dormant by construction until the 2.0 build waves rename the tools it
+describes; behaviour of well-formed calls — and of every 1.x tolerated spelling, `plugin=`/`plugin_name=`
+cross-bindings included — is unchanged.
 
 **Skill descriptions no longer overflow the context budget — every one compressed and re-validated (#294).** The 13
 skill descriptions cost ~12,150 characters (~3,040 est. tokens) of always-resident context in every session — about

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -12,8 +12,11 @@ when it changes.
 first-guess parameter misses (`plugin=` for `plugins=`, `form_id` for `formid`) now works from the houseCARL 2.0
 naming dictionary instead of two hard-wired synonym pairs. Visible today: several new-vocabulary spellings bind on
 the current tools (`patch=` for `patch_name=`, `ops=` for `operations=`, `readback=` for `full_readback=`,
-`filter=` for load-order-status's `lookup=`, `types=` for `type=`), and `patch_name=` now also binds on
-`remove_record` (whose parameter was always the odd one out, bare `patch`). A rename never fires into a type
+`filter=` for load-order-status's `lookup=`, `types=` for `type=`), and `remove_record` (whose parameter was
+always the odd one out, bare `patch`) now binds every artifact-name spelling — `patch_name=`, `plugin_name=`,
+`archive_name=`, `output=`. On tools declaring several output names, `patch=` lands on the ARTIFACT: the merged
+plugin (`output`) on `merge_plugins`, the repacked archive (`archive_name`) on `bsa_repack`, the mod-folder
+name elsewhere. A rename never fires into a type
 mismatch: a spelling whose value can't bind to its would-be target (say, an array `types=` where a single
 `type=` string is declared) keeps its own name in the refusal, alongside the tool's supported-parameter list.
 Everything else in the dictionary stays dormant by construction until the 2.0 build waves rename the tools it

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,15 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**Parameter-name tolerance is now dictionary-driven (the 2.0 alias layer, W0).** The shim that already fixed
+first-guess parameter misses (`plugin=` for `plugins=`, `form_id` for `formid`) now works from the houseCARL 2.0
+naming dictionary instead of two hard-wired synonym pairs. Visible today: several new-vocabulary spellings bind on
+the current tools (`patch=` for `patch_name=`, `ops=` for `operations=`, `readback=` for `full_readback=`,
+`filter=` for load-order-status's `lookup=`, `types=` for `type=`), and `patch_name=` now also binds on
+`remove_record` (whose parameter was always the odd one out, bare `patch`). Everything else in the dictionary
+stays dormant by construction until the 2.0 build waves rename the tools it describes; behaviour of well-formed
+calls is byte-identical.
+
 **Skill descriptions no longer overflow the context budget — every one compressed and re-validated (#294).** The 13
 skill descriptions cost ~12,150 characters (~3,040 est. tokens) of always-resident context in every session — about
 1.5× the budget Claude Code gives the *entire* skill listing across all installed sources. Past that budget, entries

--- a/src/housecarl-generator/AliasLayerProbe.cs
+++ b/src/housecarl-generator/AliasLayerProbe.cs
@@ -1,0 +1,229 @@
+using System.Text.Json;
+using HousecarlMcp;
+using ModelContextProtocol.Protocol;
+
+namespace HousecarlGenerator;
+
+// ======================================================================
+//  AliasLayerProbe — CI guard for the 2.0 alias layer (tool-surface-2.0 W0):
+//  ToolCallShim's rename pass inverted from hand-wired SynonymGroups into
+//  AliasTable, the SPEC §5.3 old → new dictionary.
+//
+//  WHY UNIT-LEVEL (synthetic schemas, internals via InternalsVisibleTo), where
+//  BindingShimProbe drives the real exe: most §5.3 rows are DORMANT on today's
+//  surface by design — a rename fires only when a build wave has landed the new
+//  canonical name in a tool's schema. The behaviours this guard pins (plugin= →
+//  source= priority, the in_place naming correction, dissolution hints) have no
+//  live tool to fire on until W2/W3 land — exactly why they must be proven
+//  against synthetic 2.0-shaped schemas NOW, so each wave lands on a mechanism
+//  already known to catch its callers. BindingShimProbe stays the end-to-end
+//  regression proof that today's surface is byte-identical (its J1–J5 arms).
+//
+//  Retirement note: AliasTable is build scaffolding, deleted at 2.0.0 (clean
+//  cut, CHARTER_PHASE4 §3.4a). This guard's table-driven arms retire with it;
+//  the normalization-bridge and no-clobber arms describe permanent mechanism.
+// ======================================================================
+public static class AliasLayerProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("[alias-layer-guard] the §5.3 alias layer (tool-surface-2.0 W0)");
+        int failures = 0;
+
+        // ---- schemas: today-shaped and 2.0-shaped -------------------------------------------
+        var scanToday   = Schema("""{"plugins":{"type":["array","null"]},"type":{"type":["string","null"]}}""");
+        var records20   = Schema("""{"formids":{"type":["array","null"]},"types":{"type":["array","null"]},"plugins":{"type":["array","null"]},"source":{"type":["string","null"]},"where":{"type":["array","null"]},"fields_source":{"type":["string","null"]}}""");
+        var readToday   = Schema("""{"formid":{"type":"string"},"depth":{"type":["integer","null"]}}""", required: """["formid"]""");
+        var batchToday  = Schema("""{"formids":{"type":"array"}}""", required: """["formids"]""");
+        var placeAsset  = Schema("""{"formid":{"type":["string","null"]},"asset_path":{"type":["string","null"]},"source":{"type":["string","null"]},"patch_name":{"type":["string","null"]},"into":{"type":["string","null"]}}""");
+        var write20     = Schema("""{"formids":{"type":"array"},"ops":{"type":["array","null"]},"patch":{"type":["string","null"]},"in_place":{"type":["string","null"]},"acknowledge":{"type":["boolean","null"]}}""", required: """["formids"]""");
+        var writeToday  = Schema("""{"formid":{"type":"string"},"operations":{"type":["array","null"]},"patch_name":{"type":["string","null"]},"in_place":{"type":["boolean","null"]},"target":{"type":["string","null"]}}""", required: """["formid"]""");
+        var nifSet20    = Schema("""{"paths":{"type":"array"},"element":{"type":["string","null"]},"op":{"type":["string","null"]},"in_place":{"type":["string","null"]}}""", required: """["paths"]""");
+        var removeToday = Schema("""{"formid":{"type":"string"},"patch":{"type":["string","null"]}}""", required: """["formid"]""");
+
+        // ---- A: the load-bearing §5.3 row — plugin= → source=, by priority, on a tool declaring BOTH
+        //      source and plugins (2.0's records). The amended-row contract: source, never a file form,
+        //      never the scan scope.
+        var a = P("housecarl_records", ("plugin", "\"Requiem.esp\""));
+        ToolCallShim.ResolveAliases(a, records20);
+        failures += Check("A §5.3 priority: plugin= renames to source= when both source and plugins are declared",
+            Has(a, "source", "\"Requiem.esp\"") && !a.Arguments!.ContainsKey("plugin") && !Has(a, "plugins", null),
+            Dump(a));
+
+        // ---- B: today's #221 tolerance preserved — plugin= → plugins= on a scan tool that declares
+        //      only plugins (the old SynonymGroups behaviour, now a table row; BindingShimProbe J1
+        //      proves the same end-to-end over the real exe).
+        var b = P("housecarl_cross_plugin_query", ("plugin", "\"Synthetic.esp\""));
+        ToolCallShim.ResolveAliases(b, scanToday);
+        failures += Check("B #221 preserved: plugin= renames to plugins= on a plugins-only tool",
+            Has(b, "plugins", "\"Synthetic.esp\"") && !b.Arguments!.ContainsKey("plugin"), Dump(b));
+
+        // ---- C: the place_asset exception — its source= is a file-path operand (the copy to place),
+        //      NOT the version pole, so a stray plugin= must NOT silently become a path; it stays for
+        //      UnknownParameters to name.
+        var c = P("housecarl_place_asset", ("plugin", "\"Some.esp\""), ("asset_path", "\"textures/t.dds\""));
+        ToolCallShim.ResolveAliases(c, placeAsset);
+        failures += Check("C exception: plugin= is NOT renamed to place_asset's source=",
+            c.Arguments!.ContainsKey("plugin") && !c.Arguments!.ContainsKey("source"), Dump(c));
+        var cRefusal = ToolCallShim.UnknownParameters(c, placeAsset);
+        failures += Check("C2 …and is then refused by name", Text(cRefusal).Contains("unknown parameter") && Text(cRefusal).Contains("plugin"),
+            Text(cRefusal));
+
+        // ---- D: formid ↔ formids, both directions (the build window is symmetric).
+        var d1 = P("housecarl_batch_record_detail", ("formid", "\"0F1AC1:Skyrim.esm\""));
+        ToolCallShim.ResolveAliases(d1, batchToday);
+        failures += Check("D1 formid= renames to a declared formids=", Has(d1, "formids", null), Dump(d1));
+        var d2 = P("housecarl_read_record", ("formids", "\"0F1AC1:Skyrim.esm\""));
+        ToolCallShim.ResolveAliases(d2, readToday);
+        failures += Check("D2 formids= renames to a declared formid=", Has(d2, "formid", null), Dump(d2));
+
+        // ---- E: stop-not-fall-through — with source= explicitly supplied, a stray plugin= must NOT be
+        //      reinterpreted onto the lower-priority plugins= (a different axis); it stays and is named.
+        var e = P("housecarl_records", ("plugin", "\"A.esp\""), ("source", "\"B.esp\""));
+        ToolCallShim.ResolveAliases(e, records20);
+        failures += Check("E stop: plugin= with source= supplied does not fall through to plugins=",
+            e.Arguments!.ContainsKey("plugin") && !e.Arguments!.ContainsKey("plugins") && Has(e, "source", "\"B.esp\""), Dump(e));
+
+        // ---- F: the normalization bridge (permanent mechanism) — form_id= → formid=.
+        var f = P("housecarl_read_record", ("form_id", "\"0F1AC1:Skyrim.esm\""));
+        ToolCallShim.ResolveAliases(f, readToday);
+        failures += Check("F bridge: form_id= renames to formid=", Has(f, "formid", null), Dump(f));
+
+        // ---- G: active drift fix — patch_name= binds on a tool that declares bare patch= (remove_record
+        //      today; the §5 census's seventh spelling), and the reverse patch= binds on patch_name tools.
+        var g1 = P("housecarl_remove_record", ("formid", "\"800:X.esp\""), ("patch_name", "\"Out.esp\""));
+        ToolCallShim.ResolveAliases(g1, removeToday);
+        failures += Check("G1 drift: patch_name= renames to a declared patch=", Has(g1, "patch", "\"Out.esp\""), Dump(g1));
+        var g2 = P("housecarl_set_field", ("formid", "\"800:X.esp\""), ("patch", "\"Out.esp\""));
+        ToolCallShim.ResolveAliases(g2, writeToday);
+        failures += Check("G2 reverse: patch= renames to a declared patch_name=", Has(g2, "patch_name", "\"Out.esp\""), Dump(g2));
+
+        // ---- H: ops/operations both directions.
+        var h1 = P("housecarl_bulk_apply", ("formid", "\"800:X.esp\""), ("ops", "[]"));
+        ToolCallShim.ResolveAliases(h1, writeToday);
+        failures += Check("H1 ops= renames to a declared operations=", h1.Arguments!.ContainsKey("operations"), Dump(h1));
+        var h2 = P("housecarl_apply", ("formids", "[\"800:X.esp\"]"), ("operations", "[]"));
+        ToolCallShim.ResolveAliases(h2, write20);
+        failures += Check("H2 operations= renames to a declared ops=", h2.Arguments!.ContainsKey("ops"), Dump(h2));
+
+        // ---- I: LaneCorrections — dormant on the 1.x bool (today's surface byte-identical).
+        var i1 = P("housecarl_set_field", ("formid", "\"800:X.esp\""), ("in_place", "true"), ("target", "\"X.esp\""));
+        var i1r = ToolCallShim.LaneCorrections(i1, writeToday);
+        failures += Check("I1 dormant: bool-declared in_place=true passes untouched (no refusal, no rewrite)",
+            i1r is null && Has(i1, "in_place", "true") && Has(i1, "target", "\"X.esp\""), Dump(i1) + " " + Text(i1r));
+
+        // ---- I2: the COMPLETE 1.x pair on a 2.0 string in_place — auto-mapped, old callers keep working.
+        var i2 = P("housecarl_apply", ("formids", "[\"800:X.esp\"]"), ("in_place", "true"), ("target", "\"X.esp\""));
+        var i2r = ToolCallShim.LaneCorrections(i2, write20);
+        failures += Check("I2 auto-map: in_place=true + target=\"X.esp\" becomes in_place=\"X.esp\"",
+            i2r is null && Has(i2, "in_place", "\"X.esp\"") && !i2.Arguments!.ContainsKey("target"), Dump(i2) + " " + Text(i2r));
+
+        // ---- I3: the BARE bool — the §5.2 naming correction, never a type error.
+        var i3 = P("housecarl_apply", ("formids", "[\"800:X.esp\"]"), ("in_place", "true"));
+        var i3r = ToolCallShim.LaneCorrections(i3, write20);
+        failures += Check("I3 correction: bare in_place=true is refused with the naming correction",
+            Text(i3r).Contains("in_place=\"X.esp\"") && Text(i3r).Contains("FILE"), Text(i3r));
+
+        // ---- I4: the quoted spelling — in_place="true" is the same mistake, not a file named true.
+        var i4 = P("housecarl_apply", ("formids", "[\"800:X.esp\"]"), ("in_place", "\"true\""));
+        var i4r = ToolCallShim.LaneCorrections(i4, write20);
+        failures += Check("I4 correction: quoted in_place=\"true\" gets the same naming correction, never binds as a file",
+            Text(i4r).Contains("in_place=\"X.esp\""), Text(i4r));
+
+        // ---- I5: in_place=false = the 1.x default-lane spelling — dropped, call proceeds on the default.
+        var i5 = P("housecarl_apply", ("formids", "[\"800:X.esp\"]"), ("in_place", "false"));
+        var i5r = ToolCallShim.LaneCorrections(i5, write20);
+        failures += Check("I5 default: bare in_place=false is dropped (the 2.0 default lane)",
+            i5r is null && !i5.Arguments!.ContainsKey("in_place"), Dump(i5) + " " + Text(i5r));
+
+        // ---- I6: false + stray target is contradictory — refused by name, not guessed at.
+        var i6 = P("housecarl_apply", ("formids", "[\"800:X.esp\"]"), ("in_place", "false"), ("target", "\"X.esp\""));
+        var i6r = ToolCallShim.LaneCorrections(i6, write20);
+        failures += Check("I6 contradiction: in_place=false + target= is refused by name",
+            Text(i6r).Contains("contradictory"), Text(i6r));
+
+        // ---- I7: a real file name is this parameter's 2.0 meaning — untouched.
+        var i7 = P("housecarl_apply", ("formids", "[\"800:X.esp\"]"), ("in_place", "\"X.esp\""));
+        var i7r = ToolCallShim.LaneCorrections(i7, write20);
+        failures += Check("I7 control: in_place=\"X.esp\" passes untouched", i7r is null && Has(i7, "in_place", "\"X.esp\""), Dump(i7));
+
+        // ---- J: the full old nif_set spelling on the 2.0 schema — target= is the ELEMENT there (§5.2:
+        //      element outranks in_place in the target entry), and the leftover bare in_place=true then
+        //      gets the naming correction (the subject-implicit tools' in_place must NAME the subject).
+        var j = P("housecarl_nif_set", ("paths", "[\"meshes/a.nif\"]"), ("target", "\"HeadParts\""), ("in_place", "true"));
+        ToolCallShim.ResolveAliases(j, nifSet20);
+        var jr = ToolCallShim.LaneCorrections(j, nifSet20);
+        failures += Check("J nif_set: old target= becomes element=, and the bare in_place=true is then corrected by name",
+            Has(j, "element", "\"HeadParts\"") && !j.Arguments!.ContainsKey("target") && Text(jr).Contains("in_place=\"X.esp\""),
+            Dump(j) + " " + Text(jr));
+
+        // ---- K: dissolution hints — gated on the replacement grammar's carrier being declared.
+        var k1 = P("housecarl_records", ("formids", "[\"800:X.esp\"]"), ("editorid_contains", "\"Iron\""));
+        var k1r = ToolCallShim.UnknownParameters(k1, records20);
+        failures += Check("K1 hint: editorid_contains on a where-bearing tool carries the where=[…] migration hint",
+            Text(k1r).Contains("unknown parameter") && Text(k1r).Contains("editorid contains"), Text(k1r));
+        var k2 = P("housecarl_read_plugin_file", ("formid", "\"800:X.esp\""), ("editorid_contains", "\"Iron\""));
+        var k2r = ToolCallShim.UnknownParameters(k2, readToday);
+        failures += Check("K2 gate: the same stray on a tool with NO where= gets the plain unknown refusal, no hint",
+            Text(k2r).Contains("unknown parameter") && !Text(k2r).Contains("editorid contains"), Text(k2r));
+        var k3 = P("housecarl_records", ("formids", "[\"800:X.esp\"]"), ("winner_fields", "true"));
+        var k3r = ToolCallShim.UnknownParameters(k3, records20);
+        failures += Check("K3 hint: winner_fields on a fields_source-bearing tool points at the pole",
+            Text(k3r).Contains("fields_source"), Text(k3r));
+
+        // ---- L: a declared parameter is never treated as an alias (mechanism guard, J4's unit twin).
+        var l = P("housecarl_read_plugin_file", ("formid", "\"800:X.esp\""));
+        ToolCallShim.ResolveAliases(l, readToday);
+        failures += Check("L declared: a real formid= is untouched", Has(l, "formid", "\"800:X.esp\""), Dump(l));
+
+        Console.WriteLine(failures == 0
+            ? "[alias-layer-guard] PASS — the §5.3 alias layer renames, corrects, and hints as chartered."
+            : $"[alias-layer-guard] FAIL — {failures} case(s) regressed.");
+        return failures == 0 ? 0 : 1;
+    }
+
+    // ---- helpers --------------------------------------------------------------------------------
+
+    static int Check(string what, bool ok, string detail)
+    {
+        Console.WriteLine($"{(ok ? "PASS" : "FAIL")}  {what}");
+        if (!ok) Console.WriteLine($"      got: {detail}");
+        return ok ? 0 : 1;
+    }
+
+    /// <summary>A published-schema-shaped InputSchema: object + properties + additionalProperties:false.</summary>
+    static JsonElement Schema(string propertiesJson, string required = "[]")
+    {
+        using var doc = JsonDocument.Parse(
+            $$"""{"type":"object","properties":{{propertiesJson}},"required":{{required}},"additionalProperties":false}""");
+        return doc.RootElement.Clone();
+    }
+
+    /// <summary>A CallToolRequestParams with raw-JSON argument values.</summary>
+    static CallToolRequestParams P(string tool, params (string Key, string RawJson)[] args)
+    {
+        var dict = new Dictionary<string, JsonElement>();
+        foreach (var (key, raw) in args)
+        {
+            using var doc = JsonDocument.Parse(raw);
+            dict[key] = doc.RootElement.Clone();
+        }
+        return new CallToolRequestParams { Name = tool, Arguments = dict };
+    }
+
+    /// <summary>Whether an argument exists (and, when rawJson is non-null, equals that raw JSON).</summary>
+    static bool Has(CallToolRequestParams p, string key, string? rawJson)
+        => p.Arguments is { } a && a.TryGetValue(key, out var v) && (rawJson is null || v.GetRawText() == rawJson);
+
+    static string Dump(CallToolRequestParams p)
+        => p.Arguments is not { Count: > 0 } a ? "(no arguments)"
+           : string.Join(", ", a.Select(kv => $"{kv.Key}={kv.Value.GetRawText()}"));
+
+    static string Text(CallToolResult? r)
+    {
+        if (r?.Content is not { } content) return "(null)";
+        foreach (var block in content)
+            if (block is TextContentBlock t) return t.Text;
+        return "(no text block)";
+    }
+}

--- a/src/housecarl-generator/AliasLayerProbe.cs
+++ b/src/housecarl-generator/AliasLayerProbe.cs
@@ -40,6 +40,10 @@ public static class AliasLayerProbe
         var writeToday  = Schema("""{"formid":{"type":"string"},"operations":{"type":["array","null"]},"patch_name":{"type":["string","null"]},"in_place":{"type":["boolean","null"]},"target":{"type":["string","null"]}}""", required: """["formid"]""");
         var nifSet20    = Schema("""{"paths":{"type":"array"},"element":{"type":["string","null"]},"op":{"type":["string","null"]},"in_place":{"type":["string","null"]}}""", required: """["paths"]""");
         var removeToday = Schema("""{"formid":{"type":"string"},"patch":{"type":["string","null"]}}""", required: """["formid"]""");
+        var createPluginToday = Schema("""{"plugin_name":{"type":"string"},"esl":{"type":["boolean","null"]},"author":{"type":["string","null"]},"description":{"type":["string","null"]}}""", required: """["plugin_name"]""");
+        var readPluginToday = Schema("""{"plugin":{"type":"string"},"formid":{"type":["string","null"]},"mod":{"type":["string","null"]}}""", required: """["plugin"]""");
+        var compactToday = Schema("""{"plugin":{"type":"string"},"esl":{"type":["boolean","null"]},"in_place":{"type":["boolean","null"]},"repoint_externals":{"type":["boolean","null"]},"acknowledge":{"type":["string","null"]},"patch_name":{"type":["string","null"]}}""", required: """["plugin"]""");
+        var copy20 = Schema("""{"assignments":{"type":"array"},"patch":{"type":["string","null"]},"walk":{"type":["object","null"]}}""", required: """["assignments"]""");
 
         // ---- A: the load-bearing §5.3 row — plugin= → source=, by priority, on a tool declaring BOTH
         //      source and plugins (2.0's records). The amended-row contract: source, never a file form,
@@ -175,6 +179,72 @@ public static class AliasLayerProbe
         var l = P("housecarl_read_plugin_file", ("formid", "\"800:X.esp\""));
         ToolCallShim.ResolveAliases(l, readToday);
         failures += Check("L declared: a real formid= is untouched", Has(l, "formid", "\"800:X.esp\""), Dump(l));
+
+        // ---- M (review F1): the 1.x four-spelling clique is a full set of edges, as SynonymGroups had it —
+        //      plugin= binds on create_plugin's plugin_name, and plugin_name= on the bare-plugin tools.
+        var m1 = P("housecarl_create_plugin", ("plugin", "\"MyTrigger\""));
+        ToolCallShim.ResolveAliases(m1, createPluginToday);
+        failures += Check("M1 clique: plugin= renames to create_plugin's declared plugin_name=",
+            Has(m1, "plugin_name", "\"MyTrigger\""), Dump(m1));
+        var m2 = P("housecarl_read_plugin_file", ("plugin_name", "\"Skyrim.esm\""), ("formid", "\"0F1AC1:Skyrim.esm\""));
+        ToolCallShim.ResolveAliases(m2, readPluginToday);
+        failures += Check("M2 clique: plugin_name= renames to read_plugin_file's declared plugin=",
+            Has(m2, "plugin", "\"Skyrim.esm\""), Dump(m2));
+        var m3 = P("housecarl_create_plugin", ("plugins", "\"MyTrigger\""));
+        ToolCallShim.ResolveAliases(m3, createPluginToday);
+        failures += Check("M3 clique: plugins= renames to create_plugin's declared plugin_name=",
+            Has(m3, "plugin_name", "\"MyTrigger\""), Dump(m3));
+
+        // ---- N (review F2): a BARE stray target= on a 2.0 write tool must NOT be renamed onto in_place
+        //      (that would engage the opt-in overwrite lane from a call that never spelled it) — it gets
+        //      the naming correction instead.
+        var n1 = P("housecarl_apply", ("formids", "[\"800:X.esp\"]"), ("target", "\"CoolWeapons.esp\""));
+        ToolCallShim.ResolveAliases(n1, write20);
+        failures += Check("N1 lane-safety: bare target= is not renamed onto in_place",
+            n1.Arguments!.ContainsKey("target") && !n1.Arguments!.ContainsKey("in_place"), Dump(n1));
+        var n1r = ToolCallShim.LaneCorrections(n1, write20);
+        failures += Check("N1b …and is refused with the naming correction, not silently laned",
+            Text(n1r).Contains("in_place=\"X.esp\"") && Text(n1r).Contains("does not select the lane"), Text(n1r));
+
+        // ---- N2 (review F3): on today's compact_plugin (no target=, 1.x bool in_place=) the target row
+        //      must not fire at all — the pre-PR named-unknown with the supported list is the answer.
+        var n2 = P("housecarl_compact_plugin", ("plugin", "\"X.esp\""), ("target", "\"X.esp\""));
+        ToolCallShim.ResolveAliases(n2, compactToday);
+        var n2Lane = ToolCallShim.LaneCorrections(n2, compactToday);
+        var n2r = ToolCallShim.UnknownParameters(n2, compactToday);
+        failures += Check("N2 today-dormant: compact_plugin target= stays a named unknown (no rename, no lane pass)",
+            Has(n2, "in_place", null) == false && n2Lane is null
+            && Text(n2r).Contains("unknown parameter") && Text(n2r).Contains("target") && Text(n2r).Contains("repoint_externals"),
+            Dump(n2) + " " + Text(n2r));
+
+        // ---- O (review F5): a rename never fires into a guaranteed kind mismatch — the incompatible
+        //      stray keeps its OWN name in the refusal, with the supported list intact.
+        var o1 = P("housecarl_cross_plugin_query", ("types", "[\"ARMO\",\"WEAP\"]"));
+        ToolCallShim.ResolveAliases(o1, scanToday);
+        var o1r = ToolCallShim.UnknownParameters(o1, scanToday);
+        failures += Check("O1 kind-gate: array types= is NOT renamed onto string type=; refusal names types",
+            o1.Arguments!.ContainsKey("types") && Text(o1r).Contains("types"), Dump(o1) + " " + Text(o1r));
+        var o2 = P("housecarl_read_record", ("formids", "[\"A\",\"B\"]"));
+        ToolCallShim.ResolveAliases(o2, readToday);
+        failures += Check("O2 kind-gate: array formids= is NOT renamed onto string formid=",
+            o2.Arguments!.ContainsKey("formids") && !o2.Arguments!.ContainsKey("formid"), Dump(o2));
+        var o3 = P("housecarl_records", ("plugin", "[\"A.esp\",\"B.esp\"]"));
+        ToolCallShim.ResolveAliases(o3, records20);
+        failures += Check("O3 kind fall-through: array plugin= skips the string source pole and lands on plugins=",
+            Has(o3, "plugins", null) && !o3.Arguments!.ContainsKey("source"), Dump(o3));
+
+        // ---- Q (review F6): target_formid is NOT a mechanical rename while target= means the in-place
+        //      filename on the 1.x write tools; on the 2.0 copy shape it rides the assignments-gated hint.
+        var q1 = P("housecarl_set_field", ("formid", "\"800:X.esp\""), ("target_formid", "\"0F1AC1:Skyrim.esm\""));
+        ToolCallShim.ResolveAliases(q1, writeToday);
+        var q1r = ToolCallShim.UnknownParameters(q1, writeToday);
+        failures += Check("Q1 no-rename: target_formid= stays its own named unknown on a target-bearing write tool",
+            q1.Arguments!.ContainsKey("target_formid") && !Has(q1, "target", "\"0F1AC1:Skyrim.esm\"")
+            && Text(q1r).Contains("target_formid"), Dump(q1) + " " + Text(q1r));
+        var q2 = P("housecarl_copy", ("target_formid", "\"0F1AC1:Skyrim.esm\""));
+        var q2r = ToolCallShim.UnknownParameters(q2, copy20);
+        failures += Check("Q2 hint: on the assignments-bearing copy shape, target_formid= carries the zip hint",
+            Text(q2r).Contains("assignments"), Text(q2r));
 
         Console.WriteLine(failures == 0
             ? "[alias-layer-guard] PASS — the §5.3 alias layer renames, corrects, and hints as chartered."

--- a/src/housecarl-generator/AliasLayerProbe.cs
+++ b/src/housecarl-generator/AliasLayerProbe.cs
@@ -31,7 +31,7 @@ public static class AliasLayerProbe
         int failures = 0;
 
         // ---- schemas: today-shaped and 2.0-shaped -------------------------------------------
-        var scanToday   = Schema("""{"plugins":{"type":["array","null"]},"type":{"type":["string","null"]}}""");
+        var scanToday   = Schema("""{"plugins":{"type":["array","null"]},"type":{"type":["string","null"]},"conflicts_only":{"type":["boolean","null"]}}""");
         var records20   = Schema("""{"formids":{"type":["array","null"]},"types":{"type":["array","null"]},"plugins":{"type":["array","null"]},"source":{"type":["string","null"]},"where":{"type":["array","null"]},"fields_source":{"type":["string","null"]}}""");
         var readToday   = Schema("""{"formid":{"type":"string"},"depth":{"type":["integer","null"]}}""", required: """["formid"]""");
         var batchToday  = Schema("""{"formids":{"type":"array"}}""", required: """["formids"]""");
@@ -42,7 +42,7 @@ public static class AliasLayerProbe
         var removeToday = Schema("""{"formid":{"type":"string"},"patch":{"type":["string","null"]}}""", required: """["formid"]""");
         var createPluginToday = Schema("""{"plugin_name":{"type":"string"},"esl":{"type":["boolean","null"]},"author":{"type":["string","null"]},"description":{"type":["string","null"]}}""", required: """["plugin_name"]""");
         var readPluginToday = Schema("""{"plugin":{"type":"string"},"formid":{"type":["string","null"]},"mod":{"type":["string","null"]}}""", required: """["plugin"]""");
-        var compactToday = Schema("""{"plugin":{"type":"string"},"esl":{"type":["boolean","null"]},"in_place":{"type":["boolean","null"]},"repoint_externals":{"type":["boolean","null"]},"acknowledge":{"type":["string","null"]},"patch_name":{"type":["string","null"]}}""", required: """["plugin"]""");
+        var compactToday = Schema("""{"plugin":{"type":"string"},"esl":{"type":["boolean","null"]},"in_place":{"type":["boolean","null"]},"repoint_externals":{"type":["boolean","null"]},"acknowledge":{"type":"boolean"},"patch_name":{"type":["string","null"]}}""", required: """["plugin"]""");
         var copy20 = Schema("""{"assignments":{"type":"array"},"patch":{"type":["string","null"]},"walk":{"type":["object","null"]}}""", required: """["assignments"]""");
 
         // ---- A: the load-bearing §5.3 row — plugin= → source=, by priority, on a tool declaring BOTH
@@ -172,8 +172,10 @@ public static class AliasLayerProbe
             Text(k2r).Contains("unknown parameter") && !Text(k2r).Contains("editorid contains"), Text(k2r));
         var k3 = P("housecarl_records", ("formids", "[\"800:X.esp\"]"), ("winner_fields", "true"));
         var k3r = ToolCallShim.UnknownParameters(k3, records20);
+        // Assert on wording unique to the HINT (review R2): records20 declares fields_source, so the
+        // supported-parameter list alone would satisfy a Contains("fields_source") even with the hint gone.
         failures += Check("K3 hint: winner_fields on a fields_source-bearing tool points at the pole",
-            Text(k3r).Contains("fields_source"), Text(k3r));
+            Text(k3r).Contains("display pole spells it"), Text(k3r));
 
         // ---- L: a declared parameter is never treated as an alias (mechanism guard, J4's unit twin).
         var l = P("housecarl_read_plugin_file", ("formid", "\"800:X.esp\""));
@@ -243,8 +245,18 @@ public static class AliasLayerProbe
             && Text(q1r).Contains("target_formid"), Dump(q1) + " " + Text(q1r));
         var q2 = P("housecarl_copy", ("target_formid", "\"0F1AC1:Skyrim.esm\""));
         var q2r = ToolCallShim.UnknownParameters(q2, copy20);
+        // Hint-unique wording (review R2): copy20's supported list already prints "assignments", so that
+        // substring proves nothing about the Dissolutions row.
         failures += Check("Q2 hint: on the assignments-bearing copy shape, target_formid= carries the zip hint",
-            Text(q2r).Contains("assignments"), Text(q2r));
+            Text(q2r).Contains("zip carries target="), Text(q2r));
+
+        // ---- R (re-review R1): the kind gate must NOT reach the normalization bridge — a case/underscore
+        //      variant names the RIGHT parameter, so even an unbindable value renames, letting the type
+        //      refusal name the real fault (the value) instead of denying the parameter exists.
+        var r1 = P("housecarl_cross_plugin_query", ("conflicts_Only", "\"yes\""));
+        ToolCallShim.ResolveAliases(r1, scanToday);
+        failures += Check("R1 bridge ungated: conflicts_Only=\"yes\" still renames to conflicts_only despite the unbindable value",
+            Has(r1, "conflicts_only", "\"yes\"") && !r1.Arguments!.ContainsKey("conflicts_Only"), Dump(r1));
 
         Console.WriteLine(failures == 0
             ? "[alias-layer-guard] PASS — the §5.3 alias layer renames, corrects, and hints as chartered."

--- a/src/housecarl-generator/AliasLayerProbe.cs
+++ b/src/housecarl-generator/AliasLayerProbe.cs
@@ -88,6 +88,14 @@ public static class AliasLayerProbe
         failures += Check("E stop: plugin= with source= supplied does not fall through to plugins=",
             e.Arguments!.ContainsKey("plugin") && !e.Arguments!.ContainsKey("plugins") && Has(e, "source", "\"B.esp\""), Dump(e));
 
+        // ---- E2 (final review finding 7): the kind check precedes the supplied-stop — an array plugin=
+        //      could never have meant the supplied string source=, so it falls through to plugins= instead
+        //      of stopping the entry.
+        var e2 = P("housecarl_records", ("plugin", "[\"A.esp\"]"), ("source", "\"B.esp\""));
+        ToolCallShim.ResolveAliases(e2, records20);
+        failures += Check("E2 kind-before-stop: array plugin= with source= supplied still lands on plugins=",
+            Has(e2, "plugins", "[\"A.esp\"]") && Has(e2, "source", "\"B.esp\""), Dump(e2));
+
         // ---- F: the normalization bridge (permanent mechanism) — form_id= → formid=.
         var f = P("housecarl_read_record", ("form_id", "\"0F1AC1:Skyrim.esm\""));
         ToolCallShim.ResolveAliases(f, readToday);

--- a/src/housecarl-generator/BindingShimProbe.cs
+++ b/src/housecarl-generator/BindingShimProbe.cs
@@ -284,6 +284,17 @@ public static class BindingShimProbe
             failures += Check("J10 bridge ungated: a case-variant key with a bad value gets the TYPE refusal, not unknown-parameter",
                 !j10.text.Contains(GenericError) && !j10.text.Contains("unknown parameter")
                 && j10.text.Contains("conflicts_only") && j10.text.Contains("boolean"), j10.Describe());
+
+            // -- CENSUS: PR #304 final review finding 3 — the executable form of "dormant by construction".
+            //    AliasLayerProbe proves the MECHANISM against synthetic schemas; this arm pins the TABLE
+            //    against the REAL published schemas: for every rename row and dissolution hint, the exact
+            //    set of tools where it activates today. A row that silently fails to fire (a mistyped
+            //    candidate), or fires somewhere unintended (a schema this table's author didn't check),
+            //    changes this set and goes RED — which is precisely how final-review findings 1 and 5 were
+            //    found by hand. Value-dependent guards (supplied-stop, the kind gate) are deliberately
+            //    outside the census: activation here means "the row CAN fire on this tool for some value".
+            //    On any schema or table change: eyeball the printed diff, then update CensusExpected.
+            failures += CensusArm(tools);
         }
         catch (Exception ex)
         {
@@ -307,6 +318,172 @@ public static class BindingShimProbe
     {
         Console.WriteLine($"{(ok ? "PASS" : "FAIL")}  {what}");
         if (!ok) Console.WriteLine($"      got: {detail}");
+        return ok ? 0 : 1;
+    }
+
+    // ---- the alias-table activation census ------------------------------------------------------
+
+    /// <summary>Every (tool, old spelling) pair where an AliasTable row can fire on TODAY's published
+    /// schemas — renames as "tool: old -> target", dissolution hints as "tool: old => hint". Baked from
+    /// an eyeballed run; any schema or table change that shifts activation must be re-eyeballed here.</summary>
+    static readonly string[] CensusExpected =
+    {
+        // Eyeballed 2026-08-01 (PR #304, the W0 alias layer). Notable negatives this list certifies:
+        // NO dissolution hint is active on today's surface (no "=> hint" lines — every gate misses),
+        // nothing fires on S8 Nexus / S9 session tools, source-> only lands on the whose-version
+        // plugin= tools and the two NIF mod= tools, and patch= lands on the §5.3 ARTIFACT per tool
+        // (output on merge_plugins, archive_name on bsa_repack, patch_name elsewhere).
+        "housecarl_asset_status: paths -> asset_paths",
+        "housecarl_batch_record_detail: formid -> formids",
+        "housecarl_batch_record_detail: pluginname -> plugin",
+        "housecarl_batch_record_detail: pluginnames -> plugin",
+        "housecarl_batch_record_detail: plugins -> plugin",
+        "housecarl_batch_record_detail: source -> plugin",
+        "housecarl_bsa_extract: outpath -> dest",
+        "housecarl_bsa_extract: outputdir -> dest",
+        "housecarl_bsa_repack: fromfolder -> source_folder",
+        "housecarl_bsa_repack: patch -> archive_name",
+        "housecarl_bulk_apply: ops -> operations",
+        "housecarl_bulk_apply: patch -> patch_name",
+        "housecarl_bulk_apply: readback -> full_readback",
+        "housecarl_bulk_create: patch -> patch_name",
+        "housecarl_bulk_create: readback -> full_readback",
+        "housecarl_bulk_place_asset: patch -> patch_name",
+        "housecarl_check_errors: formid -> formids",
+        "housecarl_check_errors: plugin -> plugins",
+        "housecarl_check_errors: pluginname -> plugins",
+        "housecarl_check_errors: pluginnames -> plugins",
+        "housecarl_check_errors: types -> type",
+        "housecarl_compact_plugin: patch -> patch_name",
+        "housecarl_compact_plugin: pluginname -> plugin",
+        "housecarl_compact_plugin: pluginnames -> plugin",
+        "housecarl_compact_plugin: plugins -> plugin",
+        "housecarl_compact_plugin: source -> plugin",
+        "housecarl_compile_script: dest -> output_dir",
+        "housecarl_compile_script: outpath -> output_dir",
+        "housecarl_compile_script: patch -> patch_name",
+        "housecarl_compile_script: paths -> script",
+        "housecarl_copy_npc_appearance: patch -> patch_name",
+        "housecarl_create_plugin: patch -> plugin_name",
+        "housecarl_create_plugin: plugin -> plugin_name",
+        "housecarl_create_plugin: pluginnames -> plugin_name",
+        "housecarl_create_plugin: plugins -> plugin_name",
+        "housecarl_create_record: ops -> operations",
+        "housecarl_create_record: patch -> patch_name",
+        "housecarl_create_record: readback -> full_readback",
+        "housecarl_cross_plugin_query: plugin -> plugins",
+        "housecarl_cross_plugin_query: pluginname -> plugins",
+        "housecarl_cross_plugin_query: pluginnames -> plugins",
+        "housecarl_cross_plugin_query: types -> type",
+        "housecarl_decompile_script: patch -> patch_name",
+        "housecarl_decompile_script: paths -> pex",
+        "housecarl_diff_record: formids -> formid",
+        "housecarl_effect_chain: type -> types",
+        "housecarl_forward_record: formid -> formids",
+        "housecarl_forward_record: patch -> patch_name",
+        "housecarl_forward_record: readback -> full_readback",
+        "housecarl_load_order_status: filter -> lookup",
+        "housecarl_merge_plugins: patch -> output",
+        "housecarl_merge_plugins: plugin -> plugins",
+        "housecarl_merge_plugins: pluginname -> plugins",
+        "housecarl_merge_plugins: pluginnames -> plugins",
+        "housecarl_native_pairing_audit: lookup -> filter",
+        "housecarl_nif_inspect: paths -> mesh_paths",
+        "housecarl_nif_inspect: source -> mod",
+        "housecarl_nif_set: patch -> patch_name",
+        "housecarl_nif_set: paths -> mesh_path",
+        "housecarl_nif_set: source -> mod",
+        "housecarl_nif_set: verb -> op",
+        "housecarl_place_asset: formids -> formid",
+        "housecarl_place_asset: patch -> patch_name",
+        "housecarl_read_plugin_file: formids -> formid",
+        "housecarl_read_plugin_file: pluginname -> plugin",
+        "housecarl_read_plugin_file: pluginnames -> plugin",
+        "housecarl_read_plugin_file: plugins -> plugin",
+        "housecarl_read_plugin_file: source -> plugin",
+        "housecarl_read_plugin_file: types -> type",
+        "housecarl_read_record: formids -> formid",
+        "housecarl_read_record: pluginname -> plugin",
+        "housecarl_read_record: pluginnames -> plugin",
+        "housecarl_read_record: plugins -> plugin",
+        "housecarl_read_record: source -> plugin",
+        "housecarl_remove_record: archivename -> patch",
+        "housecarl_remove_record: formids -> formid",
+        "housecarl_remove_record: output -> patch",
+        "housecarl_remove_record: patchname -> patch",
+        "housecarl_remove_record: pluginname -> patch",
+        "housecarl_resolve: formid -> formids",
+        "housecarl_set_field: formids -> formid",
+        "housecarl_set_field: op -> verb",
+        "housecarl_set_field: patch -> patch_name",
+        "housecarl_set_field: readback -> full_readback",
+        "housecarl_skse_config_audit: lookup -> filter",
+        "housecarl_skse_inventory: lookup -> filter",
+        "housecarl_skypatcher_layer: lookup -> filter",
+        "housecarl_skypatcher_read: formids -> formid",
+        "housecarl_validate_dialogue: formids -> formid",
+        "housecarl_validate_scripts: formid -> formids",
+        "housecarl_validate_scripts: plugin -> plugins",
+        "housecarl_validate_scripts: pluginname -> plugins",
+        "housecarl_validate_scripts: pluginnames -> plugins",
+        "housecarl_validate_scripts: types -> type",
+        "housecarl_write_seq: patch -> patch_name",
+        "housecarl_write_seq: pluginname -> plugin",
+        "housecarl_write_seq: pluginnames -> plugin",
+        "housecarl_write_seq: plugins -> plugin",
+        "housecarl_write_seq: source -> plugin",
+    };
+
+    /// <summary>Compute the activation census from the served tools/list and diff it against
+    /// <see cref="CensusExpected"/>. Mirrors ResolveAliases' value-independent gates: a row is active on
+    /// a tool when NO declared parameter normalizes to the old spelling (else the call is declared, or
+    /// the bridge owns it) and the first non-excluded candidate IS declared; a hint is active when the
+    /// old spelling is undeclared and every gate parameter is declared.</summary>
+    static int CensusArm(JsonElement toolsList)
+    {
+        var actual = new List<string>();
+        foreach (var t in toolsList.GetProperty("tools").EnumerateArray())
+        {
+            var name = t.GetProperty("name").GetString()!;
+            if (!t.TryGetProperty("inputSchema", out var schema) || schema.ValueKind != JsonValueKind.Object) continue;
+            if (!schema.TryGetProperty("properties", out var props) || props.ValueKind != JsonValueKind.Object) continue;
+            var declared = new List<string>();
+            foreach (var pr in props.EnumerateObject()) declared.Add(pr.Name);
+            var declaredNorm = new HashSet<string>(declared.Select(HousecarlMcp.ToolCallShim.Normalize));
+
+            foreach (var row in HousecarlMcp.AliasTable.AllRenames)
+            {
+                if (declaredNorm.Contains(row.Old)) continue;
+                foreach (var candidate in row.Candidates)
+                {
+                    if (HousecarlMcp.AliasTable.IsExcluded(row, candidate, name)) continue;
+                    var target = declared.FirstOrDefault(d => HousecarlMcp.ToolCallShim.Normalize(d) == candidate);
+                    if (target is null) continue;
+                    actual.Add($"{name}: {row.Old} -> {target}");
+                    break;
+                }
+            }
+            foreach (var d in HousecarlMcp.AliasTable.AllDissolutions)
+            {
+                if (declaredNorm.Contains(d.Old)) continue;
+                if (d.GateParams.All(declaredNorm.Contains)) actual.Add($"{name}: {d.Old} => hint");
+            }
+        }
+        actual.Sort(StringComparer.Ordinal);
+
+        var expected = new HashSet<string>(CensusExpected, StringComparer.Ordinal);
+        var got = new HashSet<string>(actual, StringComparer.Ordinal);
+        var missing = expected.Except(got).OrderBy(s => s, StringComparer.Ordinal).ToList();
+        var surplus = got.Except(expected).OrderBy(s => s, StringComparer.Ordinal).ToList();
+        bool ok = missing.Count == 0 && surplus.Count == 0;
+        Console.WriteLine($"{(ok ? "PASS" : "FAIL")}  CENSUS: alias-table activation over the real schemas matches the eyeballed expectation ({actual.Count} activations)");
+        if (!ok)
+        {
+            foreach (var m in missing) Console.WriteLine($"      expected but absent: {m}");
+            foreach (var s in surplus) Console.WriteLine($"      active but unexpected: {s}");
+            Console.WriteLine("      full actual census:");
+            foreach (var a in actual) Console.WriteLine($"        \"{a}\",");
+        }
         return ok ? 0 : 1;
     }
 

--- a/src/housecarl-generator/BindingShimProbe.cs
+++ b/src/housecarl-generator/BindingShimProbe.cs
@@ -243,6 +243,37 @@ public static class BindingShimProbe
             failures += Check("J5 alias-guard: alias does not clobber an explicit canonical; the extra is named",
                 !j5.text.Contains(GenericError) && j5.text.Contains("unknown parameter") && j5.text.Contains("plugin"),
                 j5.Describe());
+
+            // -- J6/J7: PR #304 review F1 — the 1.x plugin/plugins/plugin_name/plugin_names clique must stay a
+            //    full set of edges under the table-driven layer, ON TOOLS OUTSIDE the J1–J5 pair: plugin= binds
+            //    on create_plugin (whose declared parameter is plugin_name), and plugin_name= binds on
+            //    read_plugin_file (whose declared parameter is bare plugin). Both bound before the alias
+            //    inversion; both must reach the tool body (the config prompt), never an unknown-parameter refusal.
+            var j6 = Call(stdin, stdout, 39, "housecarl_create_plugin", """{"plugin":"MyTrigger"}""");
+            failures += Check("J6 clique: create_plugin binds plugin= onto its plugin_name= and runs the tool body",
+                !j6.text.Contains(GenericError) && !j6.text.Contains("unknown parameter") && j6.text.Contains(ConfigPrompt),
+                j6.Describe());
+            var j7 = Call(stdin, stdout, 40, "housecarl_read_plugin_file",
+                """{"plugin_name":"Skyrim.esm","formid":"0F1AC1:Skyrim.esm"}""");
+            failures += Check("J7 clique: read_plugin_file binds plugin_name= onto its plugin= and runs the tool body",
+                !j7.text.Contains(GenericError) && !j7.text.Contains("unknown parameter") && j7.text.Contains(ConfigPrompt),
+                j7.Describe());
+
+            // -- J8: PR #304 review F3 — a stray target= on compact_plugin (which has no target=, and whose
+            //    in_place= is the 1.x bool) must stay the pre-PR named unknown WITH the supported list — never a
+            //    rename onto in_place that answers with a type error about a key the caller never sent.
+            var j8 = Call(stdin, stdout, 41, "housecarl_compact_plugin", """{"plugin":"X.esp","target":"X.esp"}""");
+            failures += Check("J8 lane-dormant: compact_plugin target= is a named unknown, not an in_place type error",
+                !j8.text.Contains(GenericError) && j8.text.Contains("unknown parameter") && j8.text.Contains("target")
+                && !j8.text.Contains("could not be bound"), j8.Describe());
+
+            // -- J9: PR #304 review F5 — a plural spelling carrying an ARRAY must not be renamed onto a scalar
+            //    parameter: read_record(formids=[…]) keeps the caller's own key in the refusal (here the
+            //    missing-required message, whose Supplied list names formids), never a type error about formid=.
+            var j9 = Call(stdin, stdout, 42, "housecarl_read_record", """{"formids":["A","B"]}""");
+            failures += Check("J9 kind-gate: array formids= on read_record fails naming the caller's own key",
+                !j9.text.Contains(GenericError) && j9.text.Contains("formids") && !j9.text.Contains("could not be bound"),
+                j9.Describe());
         }
         catch (Exception ex)
         {

--- a/src/housecarl-generator/BindingShimProbe.cs
+++ b/src/housecarl-generator/BindingShimProbe.cs
@@ -274,6 +274,16 @@ public static class BindingShimProbe
             failures += Check("J9 kind-gate: array formids= on read_record fails naming the caller's own key",
                 !j9.text.Contains(GenericError) && j9.text.Contains("formids") && !j9.text.Contains("could not be bound"),
                 j9.Describe());
+
+            // -- J10: re-review R1 — the kind gate must not reach the NORMALIZATION bridge: conflicts_Only is
+            //    the same parameter as conflicts_only (case variant), so even with an unbindable value the
+            //    rename proceeds and the TYPE refusal names the real parameter and fault — never an
+            //    unknown-parameter refusal denying that the parameter exists.
+            var j10 = Call(stdin, stdout, 43, "housecarl_cross_plugin_query",
+                """{"type":"CELL","conflicts_Only":"CELL"}""");
+            failures += Check("J10 bridge ungated: a case-variant key with a bad value gets the TYPE refusal, not unknown-parameter",
+                !j10.text.Contains(GenericError) && !j10.text.Contains("unknown parameter")
+                && j10.text.Contains("conflicts_only") && j10.text.Contains("boolean"), j10.Describe());
         }
         catch (Exception ex)
         {

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -116,6 +116,7 @@ public static class CiAll
         ("bulk-create-guard", BulkCreateGuardProbe.RunGuard),
         ("create-abstract-group-guard", CreateGlobalProbe.RunGuard),
         ("binding-shim-guard", BindingShimProbe.RunGuard),
+        ("alias-layer-guard", AliasLayerProbe.RunGuard),
         ("snapshot-view-guard", SnapshotViewProbe.RunGuard),
         ("verify-loop-guard", VerifyLoopProbe.RunGuard),
         ("vmad-poly-guard", VmadPolyProbe.RunGuard),

--- a/src/housecarl-mcp/AliasTable.cs
+++ b/src/housecarl-mcp/AliasTable.cs
@@ -48,11 +48,14 @@ internal static class AliasTable
         // this is #221's plugin→plugins tolerance, unchanged. EXCEPTION: place_asset's source= is a
         // file-path operand (the copy to place), not the version pole — a stray plugin= there must stay
         // a named unknown, not silently become a path.
-        new("plugin",  new[] { "source", "plugins" },
+        // The four 1.x spellings remain a full clique among themselves (PR #304 review F1: the old
+        // SynonymGroups tolerated every pairing — plugin= bound on create_plugin's plugin_name, and
+        // plugin_name= on the bare-plugin tools; dropping those edges was a live regression, restored here).
+        new("plugin",  new[] { "source", "plugins", "pluginname", "pluginnames" },
             ExceptTools: new[] { ("housecarl_place_asset", "source") }),
-        new("plugins", new[] { "plugin" }),                       // reverse: today's read_plugin_file / write_seq / compact_plugin
-        new("pluginname",  new[] { "patch", "plugins" }),         // §5.3 — create_plugin's plugin_name → patch; today's guess-miss → plugins (#221 J3)
-        new("pluginnames", new[] { "plugins" }),
+        new("plugins", new[] { "plugin", "pluginname", "pluginnames" }),
+        new("pluginname",  new[] { "patch", "plugins", "plugin", "pluginnames" }),   // §5.3 — create_plugin's plugin_name → patch; today's guess-miss → plugins (#221 J3) or the bare-plugin tools
+        new("pluginnames", new[] { "plugins", "plugin", "pluginname" }),
         new("source", new[] { "plugin", "mod" }),                 // reverse: the new pole spelling on not-yet-renamed tools (read tools' plugin=, the NIF tools' mod=)
 
         // §5.3 — type/types (SELECT is set-valued types; record_type stays a create operand — distinct
@@ -85,12 +88,18 @@ internal static class AliasTable
         new("lookup", new[] { "filter" }),
         new("filter", new[] { "lookup" }),
 
-        // §5.2 — the target collision. Old target= becomes the NIF element (nif_set) or the in-place
-        // file name (the six write tools) — order matters: nif_set's 2.0 schema declares BOTH element
-        // and in_place, and its old target= meant the element. Dormant until W3/W4 (every current
-        // target-tool still declares target). target_formid → target is §5.2(3).
-        new("target", new[] { "element", "inplace" }),
-        new("targetformid", new[] { "target" }),
+        // §5.2 — the target collision. Old nif_set target= becomes the NIF element. Deliberately NOT
+        // mapped to in_place (PR #304 review F2/F3): a rename onto in_place would let a BARE target=
+        // silently engage the opt-in in-place lane on a 2.0 write tool (the lane must never be entered
+        // by a call that didn't spell it), and would fire today on compact_plugin (no target=, bool
+        // in_place=), turning its named-unknown refusal into a type error about a key the caller never
+        // sent. The 1.x in-place spellings are LaneCorrections' job instead: the complete pair
+        // auto-maps, anything partial gets a naming correction (see ToolCallShim.LaneCorrections).
+        // target_formid → target (§5.2(3)) is likewise NOT a mechanical rename (review F6): until the
+        // copy successor ships, six write tools declare target= as the in-place FILENAME — renaming a
+        // FormID onto it would answer with the in-place lane's refusal for a caller who never mentioned
+        // that lane. It rides the assignments-gated hint below, like its source_formid siblings.
+        new("target", new[] { "element" }),
 
         // §5.3 — forward_record's from_plugin and the S2/S3 mod= disambiguator both become source.
         // mod= carries the same place_asset exception as plugin= (its source= is a file-path operand).
@@ -132,25 +141,31 @@ internal static class AliasTable
     /// Each hint is GATED on the replacement grammar's carrier parameter being declared by the tool,
     /// so it fires exactly when the tool's wave has landed (and never as noise on an unrelated tool
     /// that simply never had the old parameter). Names normalized.
+    /// Wording contract (PR #304 review F4): a hint may fire on a 1.x tool that happens to declare the
+    /// carrier (e.g. a validate_scripts spelling strayed onto where-bearing cross_plugin_query), so it
+    /// must never claim the old parameter "was retired" — it states where the job lives, concretely,
+    /// and the refusal's supported-parameter list does the rest. No bare ellipses: every hint spells a
+    /// usable form.
     /// (conflict_tree's hint is deliberately absent at W0: whether the tree is a parameter or a
     /// projection shape is §6's per-wave call — W2 adds the entry when the carrier exists.)</summary>
     internal readonly record struct Dissolution(string Old, string GateParam, string Hint);
 
     static readonly Dissolution[] Dissolutions =
     {
-        new("editoridcontains", "where", "retired in 2.0 — dissolved into the predicate grammar: where=[\"editorid contains …\"]"),
-        new("propertycontains", "where", "retired in 2.0 — dissolved into the predicate grammar: where=[…]"),
-        new("mgefformid",   "walk", "retired in 2.0 — dissolved into the walk construct: seed the walk with the MGEF"),
-        new("closure",      "walk", "retired in 2.0 — the closure copy IS the walk construct"),
-        new("winnerfields", "fieldssource", "retired in 2.0 — dissolved into the display pole: fields_source=\"winner\""),
-        new("fromfile",     "ops", "retired in 2.0 — dissolved into the @file convention: ops=\"@<path>\""),
-        new("plugina", "versus", "retired in 2.0 — the comparison poles are source= (subject) and versus= (reference)"),
-        new("pluginb", "versus", "retired in 2.0 — the comparison poles are source= (subject) and versus= (reference)"),
-        new("moda",    "versus", "retired in 2.0 — structured poles carry mod: source= / versus="),
-        new("modb",    "versus", "retired in 2.0 — structured poles carry mod: source= / versus="),
-        new("sourceformid", "assignments", "retired in 2.0 — dissolved into the assignments zip: from= per assignment"),
-        new("sourceplugin", "assignments", "retired in 2.0 — dissolved into the assignments zip: from_source= per assignment"),
-        new("sourcemod",    "assignments", "retired in 2.0 — dissolved into the assignments zip: from_source= per assignment"),
+        new("editoridcontains", "where", "not a parameter here — this job is the where= predicate grammar: where=[\"editorid contains <text>\"]"),
+        new("propertycontains", "where", "not a parameter here — script-property predicates belong to the where= grammar on tools that support them: where=[\"<property path> contains <text>\"]"),
+        new("mgefformid",   "walk", "not a parameter here — seed the walk= construct with the MGEF's FormID instead"),
+        new("closure",      "walk", "not a parameter here — the closure copy is expressed as the walk= construct"),
+        new("winnerfields", "fieldssource", "not a parameter here — the display pole spells it: fields_source=\"winner\""),
+        new("fromfile",     "ops", "not a parameter here — pass the file with the @file convention: ops=\"@<path>\""),
+        new("plugina", "versus", "not a parameter here — the comparison poles are source= (subject) and versus= (reference)"),
+        new("pluginb", "versus", "not a parameter here — the comparison poles are source= (subject) and versus= (reference)"),
+        new("moda",    "versus", "not a parameter here — structured source=/versus= poles carry the mod disambiguator"),
+        new("modb",    "versus", "not a parameter here — structured source=/versus= poles carry the mod disambiguator"),
+        new("sourceformid", "assignments", "not a parameter here — the assignments= zip carries from= per assignment"),
+        new("sourceplugin", "assignments", "not a parameter here — the assignments= zip carries from_source= per assignment"),
+        new("sourcemod",    "assignments", "not a parameter here — the assignments= zip carries from_source= per assignment"),
+        new("targetformid", "assignments", "not a parameter here — the assignments= zip carries target= per assignment (§5.2's record pole)"),
     };
 
     /// <summary>The migration hint for a normalized unknown key, or null — gated on the replacement

--- a/src/housecarl-mcp/AliasTable.cs
+++ b/src/housecarl-mcp/AliasTable.cs
@@ -1,0 +1,164 @@
+using System.Text.Json;
+
+namespace HousecarlMcp;
+
+/// <summary>
+/// The 2.0 alias layer's configuration — SPEC §5.3's old → new table, inverted out of
+/// <see cref="ToolCallShim"/>'s hand-wired SynonymGroups (tool-surface-2.0 W0, CHARTER_PHASE4 §4).
+///
+/// <para><b>BUILD SCAFFOLDING — REMOVED AT 2.0.0 (clean cut, CHARTER_PHASE4 §3.4a).</b> During the
+/// 2.0 build waves (W0→W6) this table lets each wave land its renames on <c>main</c> non-breaking:
+/// old spellings keep binding on renamed tools, new spellings already bind on not-yet-renamed ones.
+/// At 2.0.0 this file is deleted (the old → new table ships in the changelog instead); the
+/// schema-driven machinery in <see cref="ToolCallShim"/> — underscore/case normalization, shape
+/// coercion, named refusals — is permanent and stays.</para>
+///
+/// <para>Every entry is <b>schema-gated by construction</b>: a rename fires only when the old
+/// spelling is NOT declared by the tool and the candidate IS declared and not already supplied
+/// (see <see cref="ToolCallShim"/>.ResolveAliases). So a row whose new name no wave has shipped yet
+/// is dormant — the table can carry the whole §5.3 census from day one without changing any
+/// current tool's behaviour, and each wave "activates" its rows simply by renaming parameters.</para>
+/// </summary>
+internal static class AliasTable
+{
+    /// <summary>One directed rename: an old spelling → the canonical candidates it may become, in
+    /// priority order (the FIRST candidate the tool declares decides; if that candidate is declared
+    /// but already supplied, the entry deliberately does NOT fall through to a lower-priority
+    /// candidate — reinterpreting a stray onto a different axis than its primary meaning is how a
+    /// wrong guess binds silently). Names are stored normalized (lowercase, underscores stripped —
+    /// <see cref="ToolCallShim"/>.Normalize); underscore/case variants need no entry at all.
+    /// <paramref name="ExceptTools"/> suppresses a specific candidate on tools where the canonical
+    /// word already means something else (registered tool name → suppressed candidate).</summary>
+    internal readonly record struct Rename(string Old, string[] Candidates, (string Tool, string Candidate)[]? ExceptTools = null);
+
+    /// <summary>The §5.3 rename rows (both directions where the row is a pure rename: old callers
+    /// must keep binding on renamed tools, and new-vocabulary callers should already bind on
+    /// not-yet-renamed ones — the build window is symmetric). Rows that DISSOLVE a parameter into
+    /// grammar (§5.3's ⤳ rows) are not renames — they live in <see cref="Dissolutions"/>.</summary>
+    static readonly Rename[] Renames =
+    {
+        // §5.3 row 1 — formid/formids: set-valued everywhere on 2.0; symmetric during the build
+        // (today's singular tools keep accepting a plural guess and vice versa — the old SynonymGroups pair).
+        new("formid",  new[] { "formids" }),
+        new("formids", new[] { "formid" }),
+
+        // §5.3 — plugin (whose-version, read tools) → source (the §4.2 pole). LOAD-BEARING (amended row,
+        // Aaron-go 2026-07-29): maps to source, never to a {file, mod} form. On a tool declaring BOTH
+        // source and plugins (2.0's records), source wins by order; on today's scan tools (plugins only)
+        // this is #221's plugin→plugins tolerance, unchanged. EXCEPTION: place_asset's source= is a
+        // file-path operand (the copy to place), not the version pole — a stray plugin= there must stay
+        // a named unknown, not silently become a path.
+        new("plugin",  new[] { "source", "plugins" },
+            ExceptTools: new[] { ("housecarl_place_asset", "source") }),
+        new("plugins", new[] { "plugin" }),                       // reverse: today's read_plugin_file / write_seq / compact_plugin
+        new("pluginname",  new[] { "patch", "plugins" }),         // §5.3 — create_plugin's plugin_name → patch; today's guess-miss → plugins (#221 J3)
+        new("pluginnames", new[] { "plugins" }),
+        new("source", new[] { "plugin", "mod" }),                 // reverse: the new pole spelling on not-yet-renamed tools (read tools' plugin=, the NIF tools' mod=)
+
+        // §5.3 — type/types (SELECT is set-valued types; record_type stays a create operand — distinct
+        // normalization, no entry needed).
+        new("type",  new[] { "types" }),
+        new("types", new[] { "type" }),
+
+        // §5.3 — ONE name for "the new artifact": patch. Forward rows fire today on remove_record
+        // (bare patch already declared there — the drift instance §5's census found); reverse row
+        // lets patch= bind on today's patch_name / plugin_name / archive_name / output spellings.
+        new("patchname",   new[] { "patch" }),
+        new("archivename", new[] { "patch" }),
+        new("output",      new[] { "patch" }),
+        new("patch",       new[] { "patchname", "pluginname", "archivename", "output" }),
+
+        // §5.3 — unmanaged filesystem output: out_path.
+        new("outputdir", new[] { "outpath" }),
+        new("dest",      new[] { "outpath" }),
+        new("outpath",   new[] { "outputdir", "dest" }),
+
+        // §5.3 — one verb-name (op) and the bulk list (ops).
+        new("verb", new[] { "op" }),
+        new("op",   new[] { "verb" }),
+        new("operations", new[] { "ops" }),
+        new("ops",        new[] { "operations" }),
+
+        // §5.3 — readback absorbs full_readback; filter absorbs load_order_status's lookup.
+        new("fullreadback", new[] { "readback" }),
+        new("readback",     new[] { "fullreadback" }),
+        new("lookup", new[] { "filter" }),
+        new("filter", new[] { "lookup" }),
+
+        // §5.2 — the target collision. Old target= becomes the NIF element (nif_set) or the in-place
+        // file name (the six write tools) — order matters: nif_set's 2.0 schema declares BOTH element
+        // and in_place, and its old target= meant the element. Dormant until W3/W4 (every current
+        // target-tool still declares target). target_formid → target is §5.2(3).
+        new("target", new[] { "element", "inplace" }),
+        new("targetformid", new[] { "target" }),
+
+        // §5.3 — forward_record's from_plugin and the S2/S3 mod= disambiguator both become source.
+        // mod= carries the same place_asset exception as plugin= (its source= is a file-path operand).
+        new("fromplugin", new[] { "source" }),
+        new("mod", new[] { "source" },
+            ExceptTools: new[] { ("housecarl_place_asset", "source") }),
+
+        // §5.3 — set-valued file SELECT per substrate: paths. Forward rows dormant until W4; the
+        // reverse row lets paths= bind on today's per-tool spellings (disjoint — schema-gating picks).
+        new("assetpaths", new[] { "paths" }),
+        new("meshpaths",  new[] { "paths" }),
+        new("meshpath",   new[] { "paths" }),
+        new("paths", new[] { "assetpaths", "meshpaths", "meshpath", "script", "pex" }),
+
+        // §5.3 — bsa_repack's repack input (provisional pending §6's S5 verdict).
+        new("sourcefolder", new[] { "fromfolder" }),
+        new("fromfolder",   new[] { "sourcefolder" }),
+    };
+
+    /// <summary>Directed lookup: the candidates for a normalized old spelling, or null.</summary>
+    internal static Rename? RenameFor(string normalizedKey)
+    {
+        foreach (var r in Renames)
+            if (r.Old == normalizedKey) return r;
+        return null;
+    }
+
+    /// <summary>Whether a rename entry suppresses a candidate on this registered tool.</summary>
+    internal static bool IsExcluded(in Rename entry, string candidate, string? toolName)
+    {
+        if (entry.ExceptTools is null || toolName is null) return false;
+        foreach (var (tool, cand) in entry.ExceptTools)
+            if (cand == candidate && tool == toolName) return true;
+        return false;
+    }
+
+    /// <summary>A §5.3 ⤳ dissolution: the old parameter became GRAMMAR (a pole, a predicate, the walk),
+    /// so no rename can express it — instead the unknown-parameter refusal carries a migration hint.
+    /// Each hint is GATED on the replacement grammar's carrier parameter being declared by the tool,
+    /// so it fires exactly when the tool's wave has landed (and never as noise on an unrelated tool
+    /// that simply never had the old parameter). Names normalized.
+    /// (conflict_tree's hint is deliberately absent at W0: whether the tree is a parameter or a
+    /// projection shape is §6's per-wave call — W2 adds the entry when the carrier exists.)</summary>
+    internal readonly record struct Dissolution(string Old, string GateParam, string Hint);
+
+    static readonly Dissolution[] Dissolutions =
+    {
+        new("editoridcontains", "where", "retired in 2.0 — dissolved into the predicate grammar: where=[\"editorid contains …\"]"),
+        new("propertycontains", "where", "retired in 2.0 — dissolved into the predicate grammar: where=[…]"),
+        new("mgefformid",   "walk", "retired in 2.0 — dissolved into the walk construct: seed the walk with the MGEF"),
+        new("closure",      "walk", "retired in 2.0 — the closure copy IS the walk construct"),
+        new("winnerfields", "fieldssource", "retired in 2.0 — dissolved into the display pole: fields_source=\"winner\""),
+        new("fromfile",     "ops", "retired in 2.0 — dissolved into the @file convention: ops=\"@<path>\""),
+        new("plugina", "versus", "retired in 2.0 — the comparison poles are source= (subject) and versus= (reference)"),
+        new("pluginb", "versus", "retired in 2.0 — the comparison poles are source= (subject) and versus= (reference)"),
+        new("moda",    "versus", "retired in 2.0 — structured poles carry mod: source= / versus="),
+        new("modb",    "versus", "retired in 2.0 — structured poles carry mod: source= / versus="),
+        new("sourceformid", "assignments", "retired in 2.0 — dissolved into the assignments zip: from= per assignment"),
+        new("sourceplugin", "assignments", "retired in 2.0 — dissolved into the assignments zip: from_source= per assignment"),
+        new("sourcemod",    "assignments", "retired in 2.0 — dissolved into the assignments zip: from_source= per assignment"),
+    };
+
+    /// <summary>The migration hint for a normalized unknown key, or null — gated on the replacement
+    /// grammar's carrier parameter being declared in <paramref name="declaredNormalized"/>.</summary>
+    internal static string? DissolutionHint(string normalizedKey, IReadOnlySet<string> declaredNormalized)
+    {
+        foreach (var d in Dissolutions)
+            if (d.Old == normalizedKey && declaredNormalized.Contains(d.GateParam)) return d.Hint;
+        return null;
+    }
+}

--- a/src/housecarl-mcp/AliasTable.cs
+++ b/src/housecarl-mcp/AliasTable.cs
@@ -56,7 +56,11 @@ internal static class AliasTable
         new("plugins", new[] { "plugin", "pluginname", "pluginnames" }),
         new("pluginname",  new[] { "patch", "plugins", "plugin", "pluginnames" }),   // §5.3 — create_plugin's plugin_name → patch; today's guess-miss → plugins (#221 J3) or the bare-plugin tools
         new("pluginnames", new[] { "plugins", "plugin", "pluginname" }),
-        new("source", new[] { "plugin", "mod" }),                 // reverse: the new pole spelling on not-yet-renamed tools (read tools' plugin=, the NIF tools' mod=)
+        // Reverse: the new pole spelling on not-yet-renamed tools (read tools' plugin=, the NIF tools'
+        // mod=). nexus_mod excepted (census catch): its mod= is a Nexus mod ID, not the S2/S3 provider
+        // disambiguator — S8 is chartered untouched (§6.4), so nothing renames onto it.
+        new("source", new[] { "plugin", "mod" },
+            ExceptTools: new[] { ("housecarl_nexus_mod", "mod") }),
 
         // §5.3 — type/types (SELECT is set-valued types; record_type stays a create operand — distinct
         // normalization, no entry needed).
@@ -66,14 +70,22 @@ internal static class AliasTable
         // §5.3 — ONE name for "the new artifact": patch. Forward rows fire today on remove_record
         // (bare patch already declared there — the drift instance §5's census found); reverse row
         // lets patch= bind on today's patch_name / plugin_name / archive_name / output spellings.
+        // Candidate order carries §5.3's "the new ARTIFACT" on tools declaring several output names
+        // (final review finding 5, generalized by the census arm): merge_plugins declares patch_name
+        // (mod-folder base) AND output (the merged plugin) — patch= must land on output; bsa_repack
+        // declares patch_name AND archive_name (the repacked .bsa, §5.3's artifact there) — patch=
+        // must land on archive_name. Hence output, then archivename, before patchname; everywhere
+        // else the earlier candidates are undeclared and the order is inert.
         new("patchname",   new[] { "patch" }),
         new("archivename", new[] { "patch" }),
         new("output",      new[] { "patch" }),
-        new("patch",       new[] { "patchname", "pluginname", "archivename", "output" }),
+        new("patch",       new[] { "output", "archivename", "patchname", "pluginname" }),
 
-        // §5.3 — unmanaged filesystem output: out_path.
-        new("outputdir", new[] { "outpath" }),
-        new("dest",      new[] { "outpath" }),
+        // §5.3 — unmanaged filesystem output: out_path. The two 1.x spellings are also each other's
+        // candidates (final review finding 6, the F1 clique logic): output_dir= on bsa_extract and
+        // dest= on compile_script name the same concept and must keep binding during the build.
+        new("outputdir", new[] { "outpath", "dest" }),
+        new("dest",      new[] { "outpath", "outputdir" }),
         new("outpath",   new[] { "outputdir", "dest" }),
 
         // §5.3 — one verb-name (op) and the bulk list (ops).
@@ -102,8 +114,11 @@ internal static class AliasTable
         new("target", new[] { "element" }),
 
         // §5.3 — forward_record's from_plugin and the S2/S3 mod= disambiguator both become source.
-        // mod= carries the same place_asset exception as plugin= (its source= is a file-path operand).
-        new("fromplugin", new[] { "source" }),
+        // All three plugin-naming spellings carry the place_asset exception (its source= is a
+        // file-path operand, not the version pole — final review finding 1: place_asset is the ONLY
+        // tool declaring bare source today, so an unexcepted row is live exactly where it's wrong).
+        new("fromplugin", new[] { "source" },
+            ExceptTools: new[] { ("housecarl_place_asset", "source") }),
         new("mod", new[] { "source" },
             ExceptTools: new[] { ("housecarl_place_asset", "source") }),
 
@@ -118,6 +133,12 @@ internal static class AliasTable
         new("sourcefolder", new[] { "fromfolder" }),
         new("fromfolder",   new[] { "sourcefolder" }),
     };
+
+    /// <summary>The full tables, for the activation census (binding-shim-guard's CENSUS arm): the guard
+    /// enumerates the REAL published schemas and asserts, per row, exactly where it activates — the
+    /// executable form of "dormant by construction".</summary>
+    internal static IReadOnlyList<Rename> AllRenames => Renames;
+    internal static IReadOnlyList<Dissolution> AllDissolutions => Dissolutions;
 
     /// <summary>Directed lookup: the candidates for a normalized old spelling, or null.</summary>
     internal static Rename? RenameFor(string normalizedKey)
@@ -147,33 +168,38 @@ internal static class AliasTable
     /// and the refusal's supported-parameter list does the rest. No bare ellipses: every hint spells a
     /// usable form.
     /// (conflict_tree's hint is deliberately absent at W0: whether the tree is a parameter or a
-    /// projection shape is §6's per-wave call — W2 adds the entry when the carrier exists.)</summary>
-    internal readonly record struct Dissolution(string Old, string GateParam, string Hint);
+    /// projection shape is §6's per-wave call — W2 adds the entry when the carrier exists.)
+    /// A hint may carry SEVERAL gate params — ALL must be declared. property_contains is gated on
+    /// where AND findings: no 1.x tool declares both, and W3's check (its true successor) declares
+    /// both, so the hint activates exactly at its wave. Its single-gate form fired today on
+    /// cross_plugin_query, pointing at a script-property where= spelling nothing establishes that
+    /// tool's grammar can resolve (final review finding 2 — held back the same way as conflict_tree).</summary>
+    internal readonly record struct Dissolution(string Old, string[] GateParams, string Hint);
 
     static readonly Dissolution[] Dissolutions =
     {
-        new("editoridcontains", "where", "not a parameter here — this job is the where= predicate grammar: where=[\"editorid contains <text>\"]"),
-        new("propertycontains", "where", "not a parameter here — script-property predicates belong to the where= grammar on tools that support them: where=[\"<property path> contains <text>\"]"),
-        new("mgefformid",   "walk", "not a parameter here — seed the walk= construct with the MGEF's FormID instead"),
-        new("closure",      "walk", "not a parameter here — the closure copy is expressed as the walk= construct"),
-        new("winnerfields", "fieldssource", "not a parameter here — the display pole spells it: fields_source=\"winner\""),
-        new("fromfile",     "ops", "not a parameter here — pass the file with the @file convention: ops=\"@<path>\""),
-        new("plugina", "versus", "not a parameter here — the comparison poles are source= (subject) and versus= (reference)"),
-        new("pluginb", "versus", "not a parameter here — the comparison poles are source= (subject) and versus= (reference)"),
-        new("moda",    "versus", "not a parameter here — structured source=/versus= poles carry the mod disambiguator"),
-        new("modb",    "versus", "not a parameter here — structured source=/versus= poles carry the mod disambiguator"),
-        new("sourceformid", "assignments", "not a parameter here — the assignments= zip carries from= per assignment"),
-        new("sourceplugin", "assignments", "not a parameter here — the assignments= zip carries from_source= per assignment"),
-        new("sourcemod",    "assignments", "not a parameter here — the assignments= zip carries from_source= per assignment"),
-        new("targetformid", "assignments", "not a parameter here — the assignments= zip carries target= per assignment (§5.2's record pole)"),
+        new("editoridcontains", new[] { "where" }, "not a parameter here — this job is the where= predicate grammar: where=[\"editorid contains <text>\"]"),
+        new("propertycontains", new[] { "where", "findings" }, "not a parameter here — script-property predicates belong to the where= grammar: where=[\"<property path> contains <text>\"]"),
+        new("mgefformid",   new[] { "walk" }, "not a parameter here — seed the walk= construct with the MGEF's FormID instead"),
+        new("closure",      new[] { "walk" }, "not a parameter here — the closure copy is expressed as the walk= construct"),
+        new("winnerfields", new[] { "fieldssource" }, "not a parameter here — the display pole spells it: fields_source=\"winner\""),
+        new("fromfile",     new[] { "ops" }, "not a parameter here — pass the file with the @file convention: ops=\"@<path>\""),
+        new("plugina", new[] { "versus" }, "not a parameter here — the comparison poles are source= (subject) and versus= (reference)"),
+        new("pluginb", new[] { "versus" }, "not a parameter here — the comparison poles are source= (subject) and versus= (reference)"),
+        new("moda",    new[] { "versus" }, "not a parameter here — structured source=/versus= poles carry the mod disambiguator"),
+        new("modb",    new[] { "versus" }, "not a parameter here — structured source=/versus= poles carry the mod disambiguator"),
+        new("sourceformid", new[] { "assignments" }, "not a parameter here — the assignments= zip carries from= per assignment"),
+        new("sourceplugin", new[] { "assignments" }, "not a parameter here — the assignments= zip carries from_source= per assignment"),
+        new("sourcemod",    new[] { "assignments" }, "not a parameter here — the assignments= zip carries from_source= per assignment"),
+        new("targetformid", new[] { "assignments" }, "not a parameter here — the assignments= zip carries target= per assignment (§5.2's record pole)"),
     };
 
-    /// <summary>The migration hint for a normalized unknown key, or null — gated on the replacement
-    /// grammar's carrier parameter being declared in <paramref name="declaredNormalized"/>.</summary>
+    /// <summary>The migration hint for a normalized unknown key, or null — gated on EVERY one of the
+    /// entry's carrier parameters being declared in <paramref name="declaredNormalized"/>.</summary>
     internal static string? DissolutionHint(string normalizedKey, IReadOnlySet<string> declaredNormalized)
     {
         foreach (var d in Dissolutions)
-            if (d.Old == normalizedKey && declaredNormalized.Contains(d.GateParam)) return d.Hint;
+            if (d.Old == normalizedKey && d.GateParams.All(declaredNormalized.Contains)) return d.Hint;
         return null;
     }
 }

--- a/src/housecarl-mcp/ToolCallShim.cs
+++ b/src/housecarl-mcp/ToolCallShim.cs
@@ -125,14 +125,13 @@ internal static class ToolCallShim
             bool Supplied(string declaredName) => args.ContainsKey(declaredName)              // caller already supplied the canonical — don't clobber
                 || (rewritten is not null && rewritten.ContainsKey(declaredName));            // an earlier rename already produced it
 
-            // A TABLE rename must never fire into a guaranteed kind mismatch (PR #304 review F5): renaming
-            // types=["A","B"] onto a string-typed type= would produce a type error about a key the caller
-            // never sent, and lose the supported-parameter list that would have corrected them. An
-            // incompatible stray stays put for UnknownParameters to name under the caller's OWN spelling.
-            // Source 1 is deliberately NOT gated (review R1, the re-review): under the normalization bridge
-            // the caller named the RIGHT parameter (conflicts_Only IS conflicts_only) — the rename must
-            // proceed so TypeMismatches can name the real fault (the value), instead of an unknown-parameter
-            // refusal claiming a parameter that exists doesn't.
+            // A TABLE rename must never fire into a guaranteed kind mismatch: renaming types=["A","B"]
+            // onto a string-typed type= would produce a type error about a key the caller never sent, and
+            // lose the supported-parameter list that would have corrected them. An incompatible stray stays
+            // put for UnknownParameters to name under the caller's OWN spelling. The bridge (source 1) is
+            // deliberately NOT gated: an underscore/case variant names the RIGHT parameter, so the rename
+            // must proceed even for an unbindable value — TypeMismatches then names the real fault (the
+            // value), where an unknown-parameter refusal would deny a parameter that exists.
             bool CanBind(JsonElement value, JsonElement propSchema)
             {
                 var types = DeclaredTypes(propSchema);
@@ -160,8 +159,8 @@ internal static class ToolCallShim
                     foreach (var prop in props.EnumerateObject())
                         if (Normalize(prop.Name) == candidate) { declared = prop.Name; declaredSchema = prop.Value; break; }
                     if (declared is null) continue;                    // candidate not on this tool — try the next
-                    if (Supplied(declared)) break;                     // primary meaning already in use — stop the entry
-                    if (!CanBind(kv.Value, declaredSchema)) continue;  // the value's kind says the caller didn't mean this one — try the next (an array plugin= is the scan scope, not the string pole)
+                    if (!CanBind(kv.Value, declaredSchema)) continue;  // the value's kind says the caller didn't mean this one — try the next (an array plugin= is the scan scope, not the string pole) — judged BEFORE the supplied-stop, so a kind the candidate couldn't take never stops the entry
+                    if (Supplied(declared)) break;                     // primary (kind-compatible) meaning already in use — stop the entry
                     target = declared;
                     break;
                 }
@@ -176,7 +175,7 @@ internal static class ToolCallShim
     }
 
     /// <summary>A parameter name reduced to its comparison form: lowercased with underscores removed.</summary>
-    static string Normalize(string s) => s.Replace("_", "").ToLowerInvariant();
+    internal static string Normalize(string s) => s.Replace("_", "").ToLowerInvariant();
 
     /// <summary>Rewrite arguments whose JSON kind mismatches the declared schema type but whose intent is
     /// unambiguous. Only ever REPLACES values for keys the schema declares — unknown keys and already-correct

--- a/src/housecarl-mcp/ToolCallShim.cs
+++ b/src/housecarl-mcp/ToolCallShim.cs
@@ -15,13 +15,18 @@ namespace HousecarlMcp;
 /// Its moves, all schema-driven off the tool's own published InputSchema (so every current and future tool
 /// parameter is covered by construction — no per-tool wiring):
 /// <list type="number">
-/// <item><b>Resolve obvious aliases</b> — a parameter named by an obvious synonym of a declared one
-/// (<c>form_id</c> for <c>formid</c>; <c>plugin</c>/<c>plugin_name</c> for a tool's <c>plugins</c>; any
-/// underscore/case variant) is renamed to the canonical parameter when the mapping is unambiguous — exactly one
-/// declared, not-already-supplied synonym target — so a first-guess miss BINDS instead of costing a round-trip
-/// (#221). A synonym that resolves to nothing (or to more than one target) is left for the unknown-parameter
-/// path. The published schema still advertises only the canonical name, and a declared parameter is never
-/// treated as an alias (so a tool's real <c>plugin=</c> is untouched).</item>
+/// <item><b>Resolve obvious aliases</b> — a parameter named by a known alternate spelling of a declared one is
+/// renamed to the canonical parameter, so a first-guess miss BINDS instead of costing a round-trip (#221).
+/// Two sources, both conservative by construction (a declared parameter is never treated as an alias, an
+/// explicitly-supplied canonical is never clobbered, a well-formed call is byte-identical): the permanent
+/// underscore/case normalization bridge (<c>form_id</c> for <c>formid</c>), and — during the 2.0 build only —
+/// <see cref="AliasTable"/>, the SPEC §5.3 old → new dictionary that lets each build wave land its renames
+/// non-breaking (old spellings bind on renamed tools, new spellings on not-yet-renamed ones). The published
+/// schema still advertises only the canonical name.</item>
+/// <item><b>Correct retired lane spellings by name</b> — 1.x's <c>in_place=true</c> + <c>target="X.esp"</c>
+/// pair, sent to a tool whose 2.0 <c>in_place</c> is the STRING naming the overwritten file (SPEC §5.2), is
+/// auto-mapped when complete and answered with a naming correction when bare — never a generic type error.
+/// Dormant on every tool whose <c>in_place</c> is still the 1.x bool. See <see cref="LaneCorrections"/>.</item>
 /// <item><b>Coerce obvious intent</b> — a bare string where an array is declared becomes a one-element array
 /// (the live failing shape: <c>plugins="A.esp"</c>); quoted numbers/booleans become numbers/booleans; a bare
 /// number where a string is declared becomes its text. Anything else is left for binding to judge.</item>
@@ -60,6 +65,7 @@ internal static class ToolCallShim
                 var schema = tool.ProtocolTool.InputSchema;
                 ResolveAliases(p, schema);
                 CoerceObviousShapes(p, schema);
+                if (LaneCorrections(p, schema) is { } laneRefusal) return laneRefusal;
                 if (MissingRequired(p, schema) is { } refusal) return refusal;
                 if (UnknownParameters(p, schema) is { } unknownRefusal) return unknownRefusal;
                 if (TypeMismatches(p, schema) is { } typeRefusal) return typeRefusal;
@@ -84,25 +90,23 @@ internal static class ToolCallShim
         }
     };
 
-    /// <summary>Sets of interchangeable parameter names (normalized: lowercased, underscores stripped) — the
-    /// synonyms that differ by more than an underscore/case variant, so <see cref="Normalize"/> alone can't
-    /// bridge them: singular↔plural and the <c>plugin_name</c> spelling. Underscore/case variants
-    /// (<c>form_id</c>≡<c>formid</c>) need no entry here — <see cref="Normalize"/> equality catches those.</summary>
-    static readonly string[][] SynonymGroups =
-    {
-        new[] { "plugin", "plugins", "pluginname", "pluginnames" },
-        new[] { "formid", "formids" },
-    };
-
-    /// <summary>Rename an argument keyed by an obvious synonym of a declared parameter to that canonical parameter,
-    /// so a first-guess miss (<c>form_id</c> for <c>formid</c>, <c>plugin</c> for a tool's <c>plugins</c>) binds
-    /// instead of costing a round-trip (#221). Conservative by construction: only a key the schema does NOT declare
-    /// is considered, it is renamed ONLY when EXACTLY ONE declared, not-already-supplied parameter is its synonym
-    /// (zero or ambiguous → left for <see cref="UnknownParameters"/> to name), and a declared parameter is never
-    /// touched — so a tool's real <c>plugin=</c> stays its own, an explicit canonical value is never clobbered, and
-    /// a well-formed call is byte-identical. Runs BEFORE <see cref="CoerceObviousShapes"/> so the renamed value is
-    /// then shape-coerced (a bare-string <c>plugin</c> → <c>plugins</c> → a one-element array) as usual.</summary>
-    static void ResolveAliases(CallToolRequestParams p, JsonElement schema)
+    /// <summary>Rename an argument keyed by a known alternate spelling of a declared parameter to that canonical
+    /// parameter, so a first-guess miss binds instead of costing a round-trip (#221). Two sources, tried in order:
+    /// <list type="number">
+    /// <item>the permanent underscore/case <see cref="Normalize"/> bridge (<c>form_id</c> → <c>formid</c>) —
+    /// exactly-one-match conservative, as ever (zero or ambiguous → left for <see cref="UnknownParameters"/>);</item>
+    /// <item><see cref="AliasTable"/> — the SPEC §5.3 old → new dictionary (2.0 build scaffolding). Its candidates
+    /// are tried in the entry's priority order; the FIRST candidate the tool declares decides. If that candidate is
+    /// already supplied the entry deliberately stops (no fall-through to a lower-priority candidate — the caller
+    /// already used the spelling's primary meaning, and reinterpreting the stray onto a different axis is how a
+    /// wrong guess binds silently); the stray is left for <see cref="UnknownParameters"/> to name.</item>
+    /// </list>
+    /// Conservative by construction either way: only a key the schema does NOT declare is considered, and a declared
+    /// parameter is never touched — so a tool's real <c>plugin=</c> stays its own, an explicit canonical value is
+    /// never clobbered, and a well-formed call is byte-identical. Runs BEFORE <see cref="CoerceObviousShapes"/> so
+    /// the renamed value is then shape-coerced (a bare-string <c>plugin</c> → <c>plugins</c> → a one-element array)
+    /// as usual.</summary>
+    internal static void ResolveAliases(CallToolRequestParams p, JsonElement schema)
     {
         if (p.Arguments is not { Count: > 0 } args) return;
         if (schema.ValueKind != JsonValueKind.Object) return;
@@ -118,14 +122,31 @@ internal static class ToolCallShim
             if (key.Length > 0 && key[0] == '_') continue;            // MCP/JSON-RPC metadata — never an alias
             if (props.TryGetProperty(key, out _)) continue;           // already a real parameter of this tool
 
+            bool Supplied(string declaredName) => args.ContainsKey(declaredName)              // caller already supplied the canonical — don't clobber
+                || (rewritten is not null && rewritten.ContainsKey(declaredName));            // an earlier rename already produced it
+
+            // Source 1 — the normalization bridge: an underscore/case variant of exactly one declared parameter.
+            var nkey = Normalize(key);
             string? target = null; bool ambiguous = false;
             foreach (var prop in props.EnumerateObject())
             {
-                var declaredName = prop.Name;
-                if (args.ContainsKey(declaredName)) continue;                                 // caller already supplied the canonical — don't clobber
-                if (rewritten is not null && rewritten.ContainsKey(declaredName)) continue;   // an earlier rename already produced it
-                if (!AreSynonyms(key, declaredName)) continue;
-                if (target is null) target = declaredName; else { ambiguous = true; break; }
+                if (Normalize(prop.Name) != nkey || Supplied(prop.Name)) continue;
+                if (target is null) target = prop.Name; else { ambiguous = true; break; }
+            }
+
+            // Source 2 — the §5.3 table: first declared candidate decides; declared-but-supplied stops the entry.
+            if (target is null && !ambiguous && AliasTable.RenameFor(nkey) is { } entry)
+            {
+                foreach (var candidate in entry.Candidates)
+                {
+                    if (AliasTable.IsExcluded(entry, candidate, p.Name)) continue;
+                    string? declared = null;
+                    foreach (var prop in props.EnumerateObject())
+                        if (Normalize(prop.Name) == candidate) { declared = prop.Name; break; }
+                    if (declared is null) continue;                   // candidate not on this tool — try the next
+                    if (!Supplied(declared)) target = declared;       // else: primary meaning already in use — stop
+                    break;
+                }
             }
             if (ambiguous || target is null) continue;                // nothing unambiguous — leave for UnknownParameters
 
@@ -134,19 +155,6 @@ internal static class ToolCallShim
             rewritten[target] = kv.Value;
         }
         if (rewritten is not null) p.Arguments = rewritten;
-    }
-
-    /// <summary>Whether two parameter names denote the same concept: equal once normalized (an underscore/case
-    /// variant, <c>form_id</c>≡<c>formid</c>) or listed together in a <see cref="SynonymGroups"/> entry
-    /// (singular↔plural, <c>plugin_name</c>↔<c>plugins</c>).</summary>
-    static bool AreSynonyms(string a, string b)
-    {
-        var na = Normalize(a);
-        var nb = Normalize(b);
-        if (na == nb) return true;
-        foreach (var g in SynonymGroups)
-            if (Array.IndexOf(g, na) >= 0 && Array.IndexOf(g, nb) >= 0) return true;
-        return false;
     }
 
     /// <summary>A parameter name reduced to its comparison form: lowercased with underscores removed.</summary>
@@ -230,6 +238,76 @@ internal static class ToolCallShim
         return set;
     }
 
+    /// <summary>The 1.x → 2.0 lane-spelling correction (SPEC §5.2(1); 2.0 build scaffolding like
+    /// <see cref="AliasTable"/>): on a tool whose <c>in_place</c> is the 2.0 STRING (the name of the file being
+    /// overwritten), model priors and 1.x callers WILL still send the old bool spelling — <c>in_place=true</c>,
+    /// usually paired with <c>target="X.esp"</c>. A bool against a string declaration would otherwise fall to
+    /// <see cref="TypeMismatches"/>' generic wording (and the stray <c>target</c> to <see cref="UnknownParameters"/>),
+    /// costing round-trips the §5.2 charter says this exact shape must not cost:
+    /// <list type="bullet">
+    /// <item>the COMPLETE old pair (<c>in_place=true</c> + a string <c>target</c> the tool does not declare) is
+    /// auto-mapped — <c>in_place := target's value</c>, <c>target</c> dropped — so old callers keep WORKING;</item>
+    /// <item>a BARE <c>in_place=true</c> is refused with the naming correction ("name the file:
+    /// in_place=\"X.esp\""), never a type error;</item>
+    /// <item>a bare <c>in_place=false</c> meant (and still means) the default lane — the key is dropped;
+    /// <c>false</c> WITH a stray <c>target</c> is contradictory and refused by name, not guessed at.</item>
+    /// </list>
+    /// The quoted spellings <c>"true"</c>/<c>"false"</c> are treated identically (a file literally named "true"
+    /// does not exist; binding it silently would be the Q3 sin). DORMANT on every tool whose <c>in_place</c> is
+    /// still the 1.x bool (declared boolean → the whole pass is a no-op), so today's surface is byte-identical.
+    /// Runs after <see cref="ResolveAliases"/>/<see cref="CoerceObviousShapes"/> (which never produce these shapes:
+    /// <c>target</c> does not rename onto a supplied <c>in_place</c>, and string-declared values are not coerced)
+    /// and BEFORE the refusal passes, so the correction outranks the generic messages.</summary>
+    internal static CallToolResult? LaneCorrections(CallToolRequestParams p, JsonElement schema)
+    {
+        if (p.Arguments is not { Count: > 0 } args) return null;
+        if (schema.ValueKind != JsonValueKind.Object ||
+            !schema.TryGetProperty("properties", out var props) || props.ValueKind != JsonValueKind.Object) return null;
+
+        // The pass concerns exactly one declared parameter: a STRING-typed in_place (the 2.0 spelling).
+        if (!props.TryGetProperty("in_place", out var inPlaceSchema)) return null;
+        var declared = DeclaredTypes(inPlaceSchema);
+        if (!declared.Contains("string") || declared.Contains("boolean")) return null;   // 1.x bool (or polymorphic) → dormant
+
+        if (!args.TryGetValue("in_place", out var val)) return null;
+        bool? boolish = val.ValueKind switch
+        {
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.String when bool.TryParse(val.GetString(), out var b) => b,
+            _ => null,
+        };
+        if (boolish is null) return null;                                                // a real file name (or another mistake) — not this pass's
+
+        // The old pair's target= — only a STRING value on a tool that does NOT declare target counts.
+        string? targetFile = null;
+        bool hasStrayTarget = args.TryGetValue("target", out var tv) && !props.TryGetProperty("target", out _);
+        if (hasStrayTarget && tv.ValueKind == JsonValueKind.String) targetFile = tv.GetString();
+
+        if (boolish == true && targetFile is { Length: > 0 })
+        {
+            var rewritten = new Dictionary<string, JsonElement>(args);
+            rewritten["in_place"] = Parse(JsonSerializer.Serialize(targetFile));         // the complete 1.x pair → the 2.0 spelling
+            rewritten.Remove("target");
+            p.Arguments = rewritten;
+            return null;
+        }
+        if (boolish == false && !hasStrayTarget)
+        {
+            var rewritten = new Dictionary<string, JsonElement>(args);                   // 1.x "default lane" spelling → absent, the 2.0 default
+            rewritten.Remove("in_place");
+            p.Arguments = rewritten;
+            return null;
+        }
+        return NamedError(boolish == true
+            ? $"error: {p.Name}: in_place names the FILE being overwritten — name the file: in_place=\"X.esp\". " +
+              "(1.x's in_place=true + target=\"X.esp\" became in_place=\"X.esp\"; omit in_place entirely for the " +
+              "default new-patch lane.) Fix the argument and retry."
+            : $"error: {p.Name}: in_place=false alongside target= is contradictory — 1.x's in_place=false meant " +
+              "the default new-patch lane, which ignores target. Either omit both (default lane) or name the file " +
+              "to overwrite: in_place=\"X.esp\". Fix the arguments and retry.");
+    }
+
     /// <summary>Schema-required parameters absent from the call → a named refusal (Q3), or null to proceed.
     /// An EXPLICIT JSON <c>null</c> for a required parameter counts as missing too (unless the schema itself declares
     /// null legal): the SDK binds it and the tool body NullReferences into the generic "internal houseCARL failure"
@@ -271,7 +349,7 @@ internal static class ToolCallShim
     /// opts into free-form args (<c>additionalProperties</c> not <c>false</c>); none of houseCARL's tools do today,
     /// but the check does not assume it. Runs AFTER <see cref="CoerceObviousShapes"/> (which only ever rewrites
     /// DECLARED keys) and <see cref="MissingRequired"/>, so a well-formed call is byte-identical to before.</summary>
-    static CallToolResult? UnknownParameters(CallToolRequestParams p, JsonElement schema)
+    internal static CallToolResult? UnknownParameters(CallToolRequestParams p, JsonElement schema)
     {
         if (p.Arguments is not { Count: > 0 } args) return null;
         if (schema.ValueKind != JsonValueKind.Object) return null;
@@ -279,11 +357,18 @@ internal static class ToolCallShim
         if (schema.TryGetProperty("additionalProperties", out var ap) && ap.ValueKind != JsonValueKind.False) return null;
         if (!schema.TryGetProperty("properties", out var props) || props.ValueKind != JsonValueKind.Object) return null;
 
+        // For the §5.3 ⤳ dissolution hints: the declared names, normalized — the gate that scopes each hint to
+        // tools whose build wave has actually landed the replacement grammar (see AliasTable.Dissolutions).
+        var declaredNormalized = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var prop in props.EnumerateObject()) declaredNormalized.Add(Normalize(prop.Name));
+
         List<string>? unknown = null;
         foreach (var kv in args)
         {
             if (kv.Key.Length > 0 && kv.Key[0] == '_') continue;   // MCP/JSON-RPC metadata convention — never a real tool param
-            if (!props.TryGetProperty(kv.Key, out _)) (unknown ??= new()).Add(kv.Key);
+            if (props.TryGetProperty(kv.Key, out _)) continue;
+            var hint = AliasTable.DissolutionHint(Normalize(kv.Key), declaredNormalized);
+            (unknown ??= new()).Add(hint is null ? kv.Key : $"{kv.Key} ({hint})");
         }
         if (unknown is null) return null;
 

--- a/src/housecarl-mcp/ToolCallShim.cs
+++ b/src/housecarl-mcp/ToolCallShim.cs
@@ -125,10 +125,14 @@ internal static class ToolCallShim
             bool Supplied(string declaredName) => args.ContainsKey(declaredName)              // caller already supplied the canonical — don't clobber
                 || (rewritten is not null && rewritten.ContainsKey(declaredName));            // an earlier rename already produced it
 
-            // A rename must never fire into a guaranteed kind mismatch (PR #304 review F5): renaming
+            // A TABLE rename must never fire into a guaranteed kind mismatch (PR #304 review F5): renaming
             // types=["A","B"] onto a string-typed type= would produce a type error about a key the caller
             // never sent, and lose the supported-parameter list that would have corrected them. An
             // incompatible stray stays put for UnknownParameters to name under the caller's OWN spelling.
+            // Source 1 is deliberately NOT gated (review R1, the re-review): under the normalization bridge
+            // the caller named the RIGHT parameter (conflicts_Only IS conflicts_only) — the rename must
+            // proceed so TypeMismatches can name the real fault (the value), instead of an unknown-parameter
+            // refusal claiming a parameter that exists doesn't.
             bool CanBind(JsonElement value, JsonElement propSchema)
             {
                 var types = DeclaredTypes(propSchema);
@@ -142,7 +146,7 @@ internal static class ToolCallShim
             string? target = null; bool ambiguous = false;
             foreach (var prop in props.EnumerateObject())
             {
-                if (Normalize(prop.Name) != nkey || Supplied(prop.Name) || !CanBind(kv.Value, prop.Value)) continue;
+                if (Normalize(prop.Name) != nkey || Supplied(prop.Name)) continue;
                 if (target is null) target = prop.Name; else { ambiguous = true; break; }
             }
 

--- a/src/housecarl-mcp/ToolCallShim.cs
+++ b/src/housecarl-mcp/ToolCallShim.cs
@@ -125,12 +125,24 @@ internal static class ToolCallShim
             bool Supplied(string declaredName) => args.ContainsKey(declaredName)              // caller already supplied the canonical — don't clobber
                 || (rewritten is not null && rewritten.ContainsKey(declaredName));            // an earlier rename already produced it
 
+            // A rename must never fire into a guaranteed kind mismatch (PR #304 review F5): renaming
+            // types=["A","B"] onto a string-typed type= would produce a type error about a key the caller
+            // never sent, and lose the supported-parameter list that would have corrected them. An
+            // incompatible stray stays put for UnknownParameters to name under the caller's OWN spelling.
+            bool CanBind(JsonElement value, JsonElement propSchema)
+            {
+                var types = DeclaredTypes(propSchema);
+                return types.Count == 0                                // untyped/polymorphic — let binding judge
+                    || KindSatisfies(value.ValueKind, types)
+                    || Coerce(value, propSchema) is not null;          // an obvious-intent shape CoerceObviousShapes will fix
+            }
+
             // Source 1 — the normalization bridge: an underscore/case variant of exactly one declared parameter.
             var nkey = Normalize(key);
             string? target = null; bool ambiguous = false;
             foreach (var prop in props.EnumerateObject())
             {
-                if (Normalize(prop.Name) != nkey || Supplied(prop.Name)) continue;
+                if (Normalize(prop.Name) != nkey || Supplied(prop.Name) || !CanBind(kv.Value, prop.Value)) continue;
                 if (target is null) target = prop.Name; else { ambiguous = true; break; }
             }
 
@@ -140,11 +152,13 @@ internal static class ToolCallShim
                 foreach (var candidate in entry.Candidates)
                 {
                     if (AliasTable.IsExcluded(entry, candidate, p.Name)) continue;
-                    string? declared = null;
+                    string? declared = null; JsonElement declaredSchema = default;
                     foreach (var prop in props.EnumerateObject())
-                        if (Normalize(prop.Name) == candidate) { declared = prop.Name; break; }
-                    if (declared is null) continue;                   // candidate not on this tool — try the next
-                    if (!Supplied(declared)) target = declared;       // else: primary meaning already in use — stop
+                        if (Normalize(prop.Name) == candidate) { declared = prop.Name; declaredSchema = prop.Value; break; }
+                    if (declared is null) continue;                    // candidate not on this tool — try the next
+                    if (Supplied(declared)) break;                     // primary meaning already in use — stop the entry
+                    if (!CanBind(kv.Value, declaredSchema)) continue;  // the value's kind says the caller didn't mean this one — try the next (an array plugin= is the scan scope, not the string pole)
+                    target = declared;
                     break;
                 }
             }
@@ -250,7 +264,11 @@ internal static class ToolCallShim
     /// <item>a BARE <c>in_place=true</c> is refused with the naming correction ("name the file:
     /// in_place=\"X.esp\""), never a type error;</item>
     /// <item>a bare <c>in_place=false</c> meant (and still means) the default lane — the key is dropped;
-    /// <c>false</c> WITH a stray <c>target</c> is contradictory and refused by name, not guessed at.</item>
+    /// <c>false</c> WITH a stray <c>target</c> is contradictory and refused by name, not guessed at;</item>
+    /// <item>a stray <c>target="X.esp"</c> with NO <c>in_place</c> at all (PR #304 review F2) is refused
+    /// with the same naming correction — it must NEVER be silently renamed onto <c>in_place</c>, because
+    /// that would engage the opt-in overwrite lane from a call that never spelled it (1.x refuses this
+    /// exact shape too: "target= is only meaningful with in_place=true").</item>
     /// </list>
     /// The quoted spellings <c>"true"</c>/<c>"false"</c> are treated identically (a file literally named "true"
     /// does not exist; binding it silently would be the Q3 sin). DORMANT on every tool whose <c>in_place</c> is
@@ -269,7 +287,19 @@ internal static class ToolCallShim
         var declared = DeclaredTypes(inPlaceSchema);
         if (!declared.Contains("string") || declared.Contains("boolean")) return null;   // 1.x bool (or polymorphic) → dormant
 
-        if (!args.TryGetValue("in_place", out var val)) return null;
+        // The old pair's target= — only a stray (undeclared) key counts; a tool's own target is its own.
+        bool hasStrayTargetKey = args.ContainsKey("target") && !props.TryGetProperty("target", out _);
+
+        if (!args.TryGetValue("in_place", out var val))
+        {
+            // No in_place at all: a stray target= alone is 1.x's half of the pair — refuse with the naming
+            // correction rather than let it near the lane (or fall to a plain unknown that teaches nothing).
+            if (!hasStrayTargetKey) return null;
+            return NamedError(
+                $"error: {p.Name}: target= was 1.x's in-place spelling and does not select the lane by itself — " +
+                "the in-place overwrite lane is spelled in_place=\"X.esp\" (naming the file you intend to " +
+                "overwrite). Omit it entirely for the default new-patch lane. Fix the arguments and retry.");
+        }
         bool? boolish = val.ValueKind switch
         {
             JsonValueKind.True => true,
@@ -279,10 +309,10 @@ internal static class ToolCallShim
         };
         if (boolish is null) return null;                                                // a real file name (or another mistake) — not this pass's
 
-        // The old pair's target= — only a STRING value on a tool that does NOT declare target counts.
+        // The stray target='s value — a string names the file; anything else stays null (correction path).
         string? targetFile = null;
-        bool hasStrayTarget = args.TryGetValue("target", out var tv) && !props.TryGetProperty("target", out _);
-        if (hasStrayTarget && tv.ValueKind == JsonValueKind.String) targetFile = tv.GetString();
+        if (hasStrayTargetKey && args.TryGetValue("target", out var tv) && tv.ValueKind == JsonValueKind.String)
+            targetFile = tv.GetString();
 
         if (boolish == true && targetFile is { Length: > 0 })
         {
@@ -292,7 +322,7 @@ internal static class ToolCallShim
             p.Arguments = rewritten;
             return null;
         }
-        if (boolish == false && !hasStrayTarget)
+        if (boolish == false && !hasStrayTargetKey)
         {
             var rewritten = new Dictionary<string, JsonElement>(args);                   // 1.x "default lane" spelling → absent, the 2.0 default
             rewritten.Remove("in_place");


### PR DESCRIPTION
## What this is

**tool-surface-2.0 W0 — the first build commit of the 2.0 waves** (CHARTER_PHASE4 §4; freeze taken 2026-08-01). The shim's hand-wired `SynonymGroups` pair is inverted into `AliasTable`: the naming dictionary's complete old → new table as configuration, so each build wave lands its renames on `main` non-breaking — old spellings keep binding on renamed tools, new spellings already bind on not-yet-renamed ones.

No linked issue — chartered sub-project work, not the bug/gap lane. The charter and SPEC live in the private `dev/` corpus.

## Mechanism

- **Schema-gated by construction:** a rename fires only when the old spelling is undeclared, the candidate is declared, and not already supplied. Rows whose new names no wave has shipped are dormant — the table carries the whole census from day one without changing any current tool.
- **Directed, priority-ordered candidates** replace the symmetric groups: `plugin=` → `source=` outranks `plugins=` on a tool declaring both (the amended, load-bearing §5.3 row); a declared-but-supplied first candidate **stops** the entry rather than falling through to a different axis.
- **Lane corrections (§5.2):** on a tool whose `in_place` is the 2.0 string, the complete 1.x pair `in_place=true + target="X.esp"` auto-maps; a bare bool gets the naming correction (`name the file: in_place="X.esp"`), never a type error. Dormant everywhere `in_place` is still the 1.x bool.
- **Dissolution hints (§5.3 ⤳):** a retired parameter that became grammar gets a migration hint on the unknown-parameter refusal, gated on the replacement grammar's carrier parameter being declared — so hints activate exactly when a tool's wave lands.
- **Exceptions where the canonical word already means something else:** `place_asset`'s `source=` is a file-path operand, so stray `plugin=`/`mod=` stay named unknowns there instead of silently becoming paths.

## Visible today (small, deliberate)

New-vocabulary spellings bind on current tools (`patch=`, `ops=`, `readback=`, `filter=` on load_order_status, `types=`), and `patch_name=` now binds on `remove_record` (the census's seventh "where output goes" spelling). Changelog carries it under Unreleased.

## Retirement contract

`AliasTable` is build scaffolding, **deleted at 2.0.0** (clean cut, CHARTER_PHASE4 §3.4a — the old → new table ships in the changelog instead). The schema-driven shim machinery (normalization bridge, coercion, named refusals) is permanent.

**Out of W0 scope:** tool-NAME aliasing (old tool names surviving a merge, e.g. the 8 tools `records` absorbs) — that lands with the wave that first retires a name (W2), on top of this parameter layer.

## Verification

- `alias-layer-guard` (new, in CiAll): 24 unit-level cases against synthetic 2.0-shaped schemas via InternalsVisibleTo — the dormant rows proven now, so waves land on a mechanism already known to catch their callers. All PASS.
- `binding-shim-guard` (existing, real exe over stdio): all 19 cases PASS — today's surface byte-identical, #221 J1–J5 tolerance preserved end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
