### PR TITLE
feat(2.0/W1): epoch fingerprints - every index-backed response names the build it read

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,12 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**Fixed: `check_errors` / `validate_scripts` refusals in `format=json` returned an empty string.** Both sweeps'
+json renders returned before flushing the JSON writer on their error path, so any refusal — a scope naming a plugin
+not in the order, an excluded plugin, a bad filter — rendered as `""` instead of an `{"error": …}` document. Text
+mode was unaffected. Latent since the json sweeps shipped; surfaced by the epoch guard's refusal-render arm and now
+pinned by it.
+
 **Every record-lane response now names the load-order build it was answered from (the 2.0 epoch fingerprint, W1).**
 Each index build gets a deterministic 16-hex fingerprint of the world-state it was built from (plugin set + order +
 file mtimes) — unchanged order means an identical fingerprint, across rebuilds and server restarts alike. Bulk reads

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,16 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**Every record-lane response now names the load-order build it was answered from (the 2.0 epoch fingerprint, W1).**
+Each index build gets a deterministic 16-hex fingerprint of the world-state it was built from (plugin set + order +
+file mtimes) — unchanged order means an identical fingerprint, across rebuilds and server restarts alike. Bulk reads
+(`cross_plugin_query` in all three formats and under `group_by=`, `batch_record_detail`, `resolve`, `effect_chain`,
+`check_errors`, `validate_scripts`), `read_record`, and `diff_record` carry it in-band as `epoch=<hex>` (text) or an
+`"epoch"` field (json), and `load_order_status` names the current build's fingerprint on its resolver line. The
+point: paged reads (`offset=` windows) that silently straddled a mid-session load-order change were previously
+indistinguishable from coherent ones — now the stamps disagree and the drift is visible. Also the foundation for the
+2.0 artifact disposition, whose saved result files will be validated against the live build by this fingerprint.
+
 **Parameter-name tolerance is now dictionary-driven (the 2.0 alias layer, W0).** The shim that already fixed
 first-guess parameter misses (`plugin=` for `plugins=`, `form_id` for `formid`) now works from the houseCARL 2.0
 naming dictionary instead of two hard-wired synonym pairs. Visible today: several new-vocabulary spellings bind on

--- a/src/housecarl-core/EffectChain.cs
+++ b/src/housecarl-core/EffectChain.cs
@@ -145,7 +145,7 @@ public static class EffectChain
               + (unscannable > samples.Count ? $"; and {unscannable - samples.Count} more" : "")
               + ". Inspect one with read_record (per-field fault isolation applies).";
 
-        return new EffectChainResult(mgef, mgefEid, rows, total, total > rows.Count, null, scanNote);
+        return new EffectChainResult(mgef, mgefEid, rows, total, total > rows.Count, null, scanNote, view.Epoch);
     }
 }
 
@@ -161,7 +161,8 @@ public sealed record EffectChainRow(
 /// scan note, and — on the Q3 gate — a recoverable <see cref="Error"/> with no rows.</summary>
 public sealed record EffectChainResult(
     FormKey Mgef, string MgefEditorId, IReadOnlyList<EffectChainRow> Rows,
-    int Total, bool Capped, string? Error, string? ScanNote)
+    int Total, bool Capped, string? Error, string? ScanNote,
+    string? Epoch = null)   // the scanned build's fingerprint (SPEC §2.1.1); null only on the pre-scan refusals
 {
     public bool Success => Error is null;
     public static EffectChainResult Fail(string error) =>

--- a/src/housecarl-core/EffectChain.cs
+++ b/src/housecarl-core/EffectChain.cs
@@ -85,21 +85,25 @@ public static class EffectChain
     public static EffectChainResult Resolve(LoadOrderResolver resolver, FormKey mgef, IReadOnlyList<Type> scope, int limit)
     {
         var view = resolver.Capture();
+        // Post-capture refusals are STAMPED (PR #305 review): "not in the load order" / "not an MGEF" are answers
+        // ABOUT this build — the same refusal contract read_record's stamped refusals follow. Only the service's
+        // pre-capture type-narrow gate refuses without an epoch.
+        EffectChainResult FailStamped(string msg) => EffectChainResult.Fail(msg) with { Epoch = view.Epoch };
 
         // --- Q3 typed-match gate: the target must be an MGEF. Cheap — one winner-body fetch off this view. ---
         var w = view.ResolveWinner(mgef);
         if (w is null)
-            return EffectChainResult.Fail(
+            return FailStamped(
                 $"no record with FormID {mgef} in the load order. effect_chain needs a MagicEffect (MGEF) the active order defines.");
         string mgefEid;
         using (var session = resolver.OpenSession())
         {
             var mbody = view.GetRecord(session, w.Value.WinnerPlugin, mgef);
             if (mbody is null)
-                return EffectChainResult.Fail(
+                return FailStamped(
                     $"winner '{w.Value.WinnerPlugin}' did not yield {mgef} on fetch — cannot confirm it is a MagicEffect.");
             if (mbody is not IMagicEffectGetter mr)
-                return EffectChainResult.Fail(
+                return FailStamped(
                     $"{mgef} resolves to a {RecordNaming.StripOverlay(mbody.GetType().Name)}, not a MagicEffect — effect_chain " +
                     "needs an MGEF. (To find what references an arbitrary record, use cross_plugin_query references=.)");
             mgefEid = mr.EditorID ?? "<none>";
@@ -137,7 +141,7 @@ public static class EffectChain
         }
         // Anything escaping the stream itself (a bad scope type, a build fault) gets a NAMED failure — never the
         // MCP layer's generic "An error occurred invoking …" as the terminal diagnostic for a data failure (Q3).
-        catch (Exception ex) { return EffectChainResult.Fail($"scan aborted: {ex.GetType().Name}: {ex.Message}"); }
+        catch (Exception ex) { return FailStamped($"scan aborted: {ex.GetType().Name}: {ex.Message}"); }
 
         string? scanNote = unscannable == 0 ? null
             : $"note: {unscannable} record instance(s) could not be scanned (Mutagen could not parse their content) and were skipped: "
@@ -162,7 +166,7 @@ public sealed record EffectChainRow(
 public sealed record EffectChainResult(
     FormKey Mgef, string MgefEditorId, IReadOnlyList<EffectChainRow> Rows,
     int Total, bool Capped, string? Error, string? ScanNote,
-    string? Epoch = null)   // the scanned build's fingerprint (SPEC §2.1.1); null only on the pre-scan refusals
+    string? Epoch = null)   // the build's fingerprint (SPEC §2.1.1) — success AND every post-capture refusal; null only on the service's pre-capture type-narrow gate
 {
     public bool Success => Error is null;
     public static EffectChainResult Fail(string error) =>

--- a/src/housecarl-core/ErrorCheck.cs
+++ b/src/housecarl-core/ErrorCheck.cs
@@ -429,7 +429,7 @@ public sealed record ErrorCheckResult(
     ErrorFindingClass Classes = ErrorFindingClass.All,
     IReadOnlyList<SweepCount>? Histogram = null,
     bool CountsOnly = false,
-    string? Epoch = null)   // the swept build's fingerprint (SPEC §2.1.1); null only on the pre-sweep refusals
+    string? Epoch = null)   // the swept INDEXED build's fingerprint (SPEC §2.1.1). Stamped on success and on refusals decided against a captured build (membership/locate); null on parse-level refusals that consulted none. OffOrderScanned files are located OUTSIDE the index — their content is not under this fingerprint (the renders qualify the stamp when any were swept; PR #305 review)
 {
     public bool Success => Error is null;
     public static ErrorCheckResult Fail(string error) =>

--- a/src/housecarl-core/ErrorCheck.cs
+++ b/src/housecarl-core/ErrorCheck.cs
@@ -329,7 +329,7 @@ public static class ErrorCheck
         return new ErrorCheckResult(reports, targets.Count + offOrderScanned.Count, totalDangling, totalMissing,
                                     totalUnscannable, capped, view.ExcludedPlugins, null, offOrderScanned,
                                     filterNote, classes, histogram is null ? null : SweepFindings.Histogram(histogram),
-                                    countsOnly);
+                                    countsOnly, view.Epoch);
     }
 
     /// <summary>The off-order file's record stream, type-scoped when the caller asked for one (#282) — the overlay
@@ -428,7 +428,8 @@ public sealed record ErrorCheckResult(
     string? FilterNote = null,
     ErrorFindingClass Classes = ErrorFindingClass.All,
     IReadOnlyList<SweepCount>? Histogram = null,
-    bool CountsOnly = false)
+    bool CountsOnly = false,
+    string? Epoch = null)   // the swept build's fingerprint (SPEC §2.1.1); null only on the pre-sweep refusals
 {
     public bool Success => Error is null;
     public static ErrorCheckResult Fail(string error) =>

--- a/src/housecarl-core/ErrorCheck.cs
+++ b/src/housecarl-core/ErrorCheck.cs
@@ -76,8 +76,17 @@ public static class ErrorCheck
                                        IReadOnlyList<(string Name, string Path)>? offOrder = null,
                                        SweepScope? recordScope = null,
                                        ErrorFindingClass classes = ErrorFindingClass.All, bool countsOnly = false)
+        => Run(resolver, resolver.Capture(), scope, limit, offOrder, recordScope, classes, countsOnly);
+
+    /// <summary>The view-threaded body (PR #305 re-review): a caller that already captured — the service, which
+    /// vets the scope and stamps refusals off ITS view — hands that view in, so the membership gate, the sweep,
+    /// and the epoch stamp all name ONE build. The convenience overload above captures for direct callers.</summary>
+    public static ErrorCheckResult Run(LoadOrderResolver resolver, LoadOrderResolver.IndexView view,
+                                       IReadOnlyList<string>? scope, int limit,
+                                       IReadOnlyList<(string Name, string Path)>? offOrder = null,
+                                       SweepScope? recordScope = null,
+                                       ErrorFindingClass classes = ErrorFindingClass.All, bool countsOnly = false)
     {
-        var view = resolver.Capture();
         bool wantDangling = classes.HasFlag(ErrorFindingClass.Dangling);
         bool wantMasters = classes.HasFlag(ErrorFindingClass.MissingMasters);
         // The missing-master count comes off the plugin's master TABLE, so a RECORD scope cannot narrow it. Saying
@@ -106,11 +115,15 @@ public static class ErrorCheck
             targets = new List<string>(scope.Count);
             foreach (var name in scope)
             {
+                // Membership refusals are decided against THIS view — stamped (PR #305 re-review: the same logical
+                // refusal must not stamp through one tool frame and not another).
                 if (!view.ContainsPlugin(name))
-                    return ErrorCheckResult.Fail($"plugin not in the load order: {name}.{view.AbsenceClause(name)}");
+                    return ErrorCheckResult.Fail($"plugin not in the load order: {name}.{view.AbsenceClause(name)}")
+                           with { Epoch = view.Epoch };
                 if (view.ExcludedPlugins.TryGetValue(name, out var why))
                     return ErrorCheckResult.Fail(
-                        $"plugin '{name}' was excluded from this session because it could not be parsed ({why}) — fix or remove it upstream; it cannot be checked.");
+                        $"plugin '{name}' was excluded from this session because it could not be parsed ({why}) — fix or remove it upstream; it cannot be checked.")
+                           with { Epoch = view.Epoch };
                 targets.Add(name);
             }
         }

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Binary.Parameters;
@@ -105,10 +106,11 @@ public sealed class LoadOrderResolver : IDisposable
         public readonly HashSet<int> Excluded;                                // overlay indices excluded this build — never re-touched by any path
         public readonly Dictionary<string, string> ExcludedPlugins;           // excluded plugin name → reason (Q3)
         public readonly int MaxDepth;
+        public readonly string Epoch;                                         // this build's fingerprint (SPEC §2.1.1) — immutable with the snapshot
 
         public IndexSnapshot(Dictionary<FormKey, (int winner, int count)> index, Dictionary<FormKey, int[]> overriders,
-                             List<string> loadFailures, HashSet<int> excluded, Dictionary<string, string> excludedPlugins, int maxDepth)
-        { Index = index; Overriders = overriders; LoadFailures = loadFailures; Excluded = excluded; ExcludedPlugins = excludedPlugins; MaxDepth = maxDepth; }
+                             List<string> loadFailures, HashSet<int> excluded, Dictionary<string, string> excludedPlugins, int maxDepth, string epoch)
+        { Index = index; Overriders = overriders; LoadFailures = loadFailures; Excluded = excluded; ExcludedPlugins = excludedPlugins; MaxDepth = maxDepth; Epoch = epoch; }
     }
 
     volatile IndexSnapshot _snap;
@@ -127,6 +129,10 @@ public sealed class LoadOrderResolver : IDisposable
     public int RecordCount => _snap.Index.Count;            // distinct FormKeys across the order
     public int ConflictCount => _snap.Overriders.Count;     // FormKeys overridden by >1 plugin
     public int MaxDepth => _snap.MaxDepth;
+
+    /// <summary>The CURRENT build's epoch fingerprint. Single-shot convenience — a multi-read operation should
+    /// Capture() and use the view's <see cref="IndexView.Epoch"/> so the stamp names the build it actually read.</summary>
+    public string Epoch => _snap.Epoch;
 
     /// <summary>Every plugin's filename, in priority order (PURE DATA — no handles). The known-name list the write
     /// harnesses scan to decide which masters are in the order; replaces the old held-overlay ModKey enumeration.</summary>
@@ -431,7 +437,23 @@ public sealed class LoadOrderResolver : IDisposable
         return new IndexSnapshot(
             index,
             overriders.ToDictionary(kv => kv.Key, kv => kv.Value.ToArray()),  // trim List overhead → int[]
-            failures, excluded, excludedPlugins, maxDepth);
+            failures, excluded, excludedPlugins, maxDepth, ComputeEpoch(_names, _mtimes));
+    }
+
+    /// <summary>The epoch fingerprint: a compact, deterministic identity for ONE index build, derived from the
+    /// world-state the build was made from — every plugin's filename + last-write time, in priority order. Two
+    /// builds over an unchanged order fingerprint IDENTICALLY (a server restart does not invalidate anything);
+    /// any content edit, reorder, or set change fingerprints differently. Stamped into every bulk response's
+    /// in-band accounting (SPEC §2.1.1) so cross-page drift is detectable instead of silently incoherent, and
+    /// checked on artifact re-entry (a mismatch refuses loud, naming both epochs). Opaque to consumers — 16 hex
+    /// chars of SHA-256, compared only for equality.</summary>
+    static string ComputeEpoch(string[] names, DateTime[] mtimes)
+    {
+        var sb = new StringBuilder(names.Length * 48);
+        for (int i = 0; i < names.Length; i++)
+            sb.Append(names[i]).Append('|').Append(mtimes[i].Ticks).Append('\n');
+        var hash = System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes(sb.ToString()));
+        return Convert.ToHexString(hash.AsSpan(0, 8)).ToLowerInvariant();
     }
 
     /// <summary>Record one plugin's exclusion from the index build (Q3): into the human-readable failure list, the
@@ -486,6 +508,10 @@ public sealed class LoadOrderResolver : IDisposable
         public int MaxDepth => _s.MaxDepth;
         public IReadOnlyList<string> LoadFailures => _s.LoadFailures;
         public IReadOnlyDictionary<string, string> ExcludedPlugins => _s.ExcludedPlugins;
+
+        /// <summary>THIS captured build's epoch fingerprint — the stamp a bulk response computed off this view
+        /// must carry (SPEC §2.1.1). Immutable with the snapshot: a concurrent rebuild changes nothing here.</summary>
+        public string Epoch => _s.Epoch;
 
         /// <summary>Whether a plugin filename is in the indexed load order — the same OrdinalIgnoreCase name table
         /// <see cref="LoadOrderResolver.GetRecord"/> resolves against (fixed for the resolver's lifetime, like

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -437,25 +437,41 @@ public sealed class LoadOrderResolver : IDisposable
         return new IndexSnapshot(
             index,
             overriders.ToDictionary(kv => kv.Key, kv => kv.Value.ToArray()),  // trim List overhead → int[]
-            failures, excluded, excludedPlugins, maxDepth, ComputeEpoch(_names, _paths, _mtimes));
+            failures, excluded, excludedPlugins, maxDepth, ComputeEpoch(_names, _paths, _mtimes, excludedPlugins));
     }
 
     /// <summary>The epoch fingerprint: a compact, deterministic identity for ONE index build, derived from the
     /// world-state the build was made from — every plugin's filename, RESOLVED PATH, and last-write time, in
-    /// priority order. The path matters (PR #305 review): under MO2 two enabled mods can ship the same-named
-    /// plugin, and a left-pane reorder swaps WHICH file wins the slot without changing name or (if the copies
-    /// share a last-write tick — same base archive, or a move rather than a copy) mtime — names+mtimes alone
-    /// would give the new build the old epoch while resolving different winners. Two builds over an unchanged
-    /// order fingerprint IDENTICALLY (a server restart does not invalidate anything; the resolved paths are as
-    /// restart-stable as the names); any content edit, reorder, or set change fingerprints differently. Stamped
-    /// into every bulk response's in-band accounting (SPEC §2.1.1) so cross-page drift is detectable instead of
+    /// priority order, PLUS which plugins this build EXCLUDED. The path matters (PR #305 review): under MO2 two
+    /// enabled mods can ship the same-named plugin, and a left-pane reorder swaps WHICH file wins the slot without
+    /// changing name or (if the copies share a last-write tick — same base archive, or a move rather than a copy)
+    /// mtime — names+mtimes alone would give the new build the old epoch while resolving different winners. The
+    /// exclusion set matters just as much (PR #305 third round, BLOCKING): an OPEN failure is transient (xEdit/MO2
+    /// holding an exclusive handle, an AV scan), so a build that skipped a locked plugin resolves materially
+    /// different winners than the healthy build over the same names/paths/mtimes — without this term the two
+    /// fingerprint identically, and an artifact saved under the degraded build would pass epoch-checked re-entry
+    /// against the healthy one. Two builds over an unchanged order that INDEXED the same set fingerprint
+    /// IDENTICALLY (a server restart does not invalidate anything; the resolved paths are as restart-stable as the
+    /// names); any content edit, reorder, set change, or exclusion change fingerprints differently. Stamped into
+    /// every bulk response's in-band accounting (SPEC §2.1.1) so cross-page drift is detectable instead of
     /// silently incoherent, and checked on artifact re-entry (a mismatch refuses loud, naming both epochs).
-    /// Opaque to consumers — 16 hex chars of SHA-256, compared only for equality.</summary>
-    static string ComputeEpoch(string[] names, string[] paths, DateTime[] mtimes)
+    /// Opaque to consumers — 16 hex chars of SHA-256, compared only for equality.
+    ///
+    /// <para>Known approximations, inherited rather than introduced: an unstattable-but-openable file collapses to
+    /// <see cref="SafeMtime"/>'s MinValue sentinel (distinct world-states, one mtime term — vanishingly rare since
+    /// a file that can't be statted rarely opens); and <see cref="RefreshIfStale"/> stamps mtimes BEFORE re-reading
+    /// the files, so a plugin rewritten mid-rebuild can pair its new mtime with old content until its next change —
+    /// the pre-existing freshness-baseline race, which this fingerprint shares by construction.</para></summary>
+    static string ComputeEpoch(string[] names, string[] paths, DateTime[] mtimes, Dictionary<string, string> excludedPlugins)
     {
         var sb = new StringBuilder(names.Length * 96);
         for (int i = 0; i < names.Length; i++)
             sb.Append(names[i]).Append('|').Append(paths[i]).Append('|').Append(mtimes[i].Ticks).Append('\n');
+        // Sorted, names only: the exclusion REASON often embeds exception text (message wording, paths) that can
+        // vary between identical world-states — WHICH plugins were skipped is the deterministic fact that changes
+        // what the index resolves.
+        foreach (var name in excludedPlugins.Keys.OrderBy(n => n, StringComparer.OrdinalIgnoreCase))
+            sb.Append("excluded|").Append(name).Append('\n');
         var hash = System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes(sb.ToString()));
         return Convert.ToHexString(hash.AsSpan(0, 8)).ToLowerInvariant();
     }

--- a/src/housecarl-core/LoadOrderResolver.cs
+++ b/src/housecarl-core/LoadOrderResolver.cs
@@ -437,21 +437,25 @@ public sealed class LoadOrderResolver : IDisposable
         return new IndexSnapshot(
             index,
             overriders.ToDictionary(kv => kv.Key, kv => kv.Value.ToArray()),  // trim List overhead → int[]
-            failures, excluded, excludedPlugins, maxDepth, ComputeEpoch(_names, _mtimes));
+            failures, excluded, excludedPlugins, maxDepth, ComputeEpoch(_names, _paths, _mtimes));
     }
 
     /// <summary>The epoch fingerprint: a compact, deterministic identity for ONE index build, derived from the
-    /// world-state the build was made from — every plugin's filename + last-write time, in priority order. Two
-    /// builds over an unchanged order fingerprint IDENTICALLY (a server restart does not invalidate anything);
-    /// any content edit, reorder, or set change fingerprints differently. Stamped into every bulk response's
-    /// in-band accounting (SPEC §2.1.1) so cross-page drift is detectable instead of silently incoherent, and
-    /// checked on artifact re-entry (a mismatch refuses loud, naming both epochs). Opaque to consumers — 16 hex
-    /// chars of SHA-256, compared only for equality.</summary>
-    static string ComputeEpoch(string[] names, DateTime[] mtimes)
+    /// world-state the build was made from — every plugin's filename, RESOLVED PATH, and last-write time, in
+    /// priority order. The path matters (PR #305 review): under MO2 two enabled mods can ship the same-named
+    /// plugin, and a left-pane reorder swaps WHICH file wins the slot without changing name or (if the copies
+    /// share a last-write tick — same base archive, or a move rather than a copy) mtime — names+mtimes alone
+    /// would give the new build the old epoch while resolving different winners. Two builds over an unchanged
+    /// order fingerprint IDENTICALLY (a server restart does not invalidate anything; the resolved paths are as
+    /// restart-stable as the names); any content edit, reorder, or set change fingerprints differently. Stamped
+    /// into every bulk response's in-band accounting (SPEC §2.1.1) so cross-page drift is detectable instead of
+    /// silently incoherent, and checked on artifact re-entry (a mismatch refuses loud, naming both epochs).
+    /// Opaque to consumers — 16 hex chars of SHA-256, compared only for equality.</summary>
+    static string ComputeEpoch(string[] names, string[] paths, DateTime[] mtimes)
     {
-        var sb = new StringBuilder(names.Length * 48);
+        var sb = new StringBuilder(names.Length * 96);
         for (int i = 0; i < names.Length; i++)
-            sb.Append(names[i]).Append('|').Append(mtimes[i].Ticks).Append('\n');
+            sb.Append(names[i]).Append('|').Append(paths[i]).Append('|').Append(mtimes[i].Ticks).Append('\n');
         var hash = System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes(sb.ToString()));
         return Convert.ToHexString(hash.AsSpan(0, 8)).ToLowerInvariant();
     }
@@ -581,6 +585,11 @@ public sealed class LoadOrderResolver : IDisposable
         /// (Q3) on a name not in the order or excluded this build. The integrity sweep diffs this against the masters a
         /// plugin's records actually reference; judged against THIS view's build (same exclusion set as the scan).</summary>
         public IReadOnlyList<string> DeclaredMasters(string pluginName) => _r.DeclaredMasters(pluginName, _s);
+
+        /// <summary>The full conflict tree (<see cref="LoadOrderResolver.ResolveTree(OverlaySession, FormKey)"/>),
+        /// pinned to THIS view's build — so a render that stamps this view's epoch fills its trees from the same
+        /// build the stamp names (PR #305 review).</summary>
+        public ConflictTree? ResolveTree(OverlaySession session, FormKey fk) => _r.ResolveTree(session, fk, _s);
     }
 
     // ---- Queries -------------------------------------------------------
@@ -601,9 +610,13 @@ public sealed class LoadOrderResolver : IDisposable
     /// <summary>The full conflict tree: every touching plugin's body, in priority order (winner last). Bodies are
     /// fetched on demand into <paramref name="session"/> (which keeps the touched plugins open until the caller has
     /// materialised them, then disposes them). null if the FormKey isn't in the order.</summary>
-    public ConflictTree? ResolveTree(OverlaySession session, FormKey fk)
+    public ConflictTree? ResolveTree(OverlaySession session, FormKey fk) => ResolveTree(session, fk, _snap);
+
+    /// <summary>The snapshot-pinned body of <see cref="ResolveTree(OverlaySession, FormKey)"/> — taken by
+    /// <see cref="IndexView.ResolveTree"/> so a caller that already pinned a build (a cross-query render filling
+    /// conflict trees per match, PR #305 review) reads the tree off the SAME build its epoch stamp names.</summary>
+    internal ConflictTree? ResolveTree(OverlaySession session, FormKey fk, IndexSnapshot s)
     {
-        var s = _snap;                                                 // ONE build — Index and Overriders can't disagree
         if (!s.Index.TryGetValue(fk, out var e)) return null;
         var overlayIdxs = e.count == 1 ? new[] { e.winner } : s.Overriders[fk];
         var nodes = new ConflictNode[overlayIdxs.Length];

--- a/src/housecarl-core/ScriptPropertyCheck.cs
+++ b/src/housecarl-core/ScriptPropertyCheck.cs
@@ -76,6 +76,17 @@ public static class ScriptPropertyCheck
                                         IReadOnlyList<string>? scope, int limit,
                                         SweepScope? recordScope = null, string? propertyContains = null,
                                         ScriptFindingClass classes = ScriptFindingClass.All, bool countsOnly = false)
+        => Run(resolver, resolver.Capture(), assets, scope, limit, recordScope, propertyContains, classes, countsOnly);
+
+    /// <summary>The view-threaded body (PR #305 re-review) — same contract as <see cref="ErrorCheck"/>'s: the
+    /// caller's captured view decides membership, drives the sweep, and stamps success AND refusals, so one call
+    /// never mixes builds between its gate and its scan. (The ASSET capture stays internal: .pex lookups are the
+    /// asset substrate, outside the record epoch — <see cref="ScriptCheckResult.ReadIncomplete"/> carries its
+    /// honesty separately.)</summary>
+    public static ScriptCheckResult Run(LoadOrderResolver resolver, LoadOrderResolver.IndexView view, AssetResolver assets,
+                                        IReadOnlyList<string>? scope, int limit,
+                                        SweepScope? recordScope = null, string? propertyContains = null,
+                                        ScriptFindingClass classes = ScriptFindingClass.All, bool countsOnly = false)
     {
         var propFilter = string.IsNullOrWhiteSpace(propertyContains) ? null : propertyContains.Trim();
         bool PropOk(string name) => propFilter is null || name.Contains(propFilter, StringComparison.OrdinalIgnoreCase);
@@ -92,7 +103,6 @@ public static class ScriptPropertyCheck
             recordScope?.Label,
             SweepFindings.Describe(classes),
             propFilter is null ? null : $"property_contains='{propFilter}'");
-        var view = resolver.Capture();
         var av = assets.Capture();          // ONE asset build → every .pex lookup + ReadIncomplete describe the same build
 
         // --- resolve the plugin set to scan (Q3: a bad or excluded explicit scope name fails loud, never a silent skip). ---
@@ -102,11 +112,15 @@ public static class ScriptPropertyCheck
             targets = new List<string>(scope.Count);
             foreach (var name in scope)
             {
+                // Membership refusals are decided against THIS view — stamped (PR #305 re-review; without this the
+                // renders' error-path epoch was unreachable dead code: no ScriptCheckResult refusal carried one).
                 if (!view.ContainsPlugin(name))
-                    return ScriptCheckResult.Fail($"plugin not in the load order: {name}.{view.AbsenceClause(name)}");
+                    return ScriptCheckResult.Fail($"plugin not in the load order: {name}.{view.AbsenceClause(name)}")
+                           with { Epoch = view.Epoch };
                 if (view.ExcludedPlugins.TryGetValue(name, out var why))
                     return ScriptCheckResult.Fail(
-                        $"plugin '{name}' was excluded from this session because it could not be parsed ({why}) — fix or remove it upstream; it cannot be checked.");
+                        $"plugin '{name}' was excluded from this session because it could not be parsed ({why}) — fix or remove it upstream; it cannot be checked.")
+                           with { Epoch = view.Epoch };
                 targets.Add(name);
             }
         }

--- a/src/housecarl-core/ScriptPropertyCheck.cs
+++ b/src/housecarl-core/ScriptPropertyCheck.cs
@@ -260,7 +260,7 @@ public static class ScriptPropertyCheck
         return new ScriptCheckResult(reports, targets.Count, recordsWithScripts, totalUnbound, totalNull,
                                      totalUnverifiable, capped, av.ReadIncomplete, view.ExcludedPlugins, null,
                                      filterNote, histogram is null ? null : SweepFindings.Histogram(histogram), countsOnly,
-                                     classes, totalUnboundObject, totalUnboundScalar, propFilter);
+                                     classes, totalUnboundObject, totalUnboundScalar, propFilter, view.Epoch);
     }
 
     /// <summary>Every script attachment on the record: the adapter's own <see cref="IAVirtualMachineAdapterGetter.Scripts"/>
@@ -453,7 +453,8 @@ public sealed record ScriptCheckResult(
     ScriptFindingClass Classes = ScriptFindingClass.All,
     int TotalUnboundObject = 0,
     int TotalUnboundScalar = 0,
-    string? PropertyContains = null)
+    string? PropertyContains = null,
+    string? Epoch = null)   // the swept build's fingerprint (SPEC §2.1.1); null only on the pre-sweep refusals
 {
     public bool Success => Error is null;
     public static ScriptCheckResult Fail(string error) =>

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -118,6 +118,12 @@ public static class CiAll
         ("binding-shim-guard", BindingShimProbe.RunGuard),
         ("alias-layer-guard", AliasLayerProbe.RunGuard),
         ("snapshot-view-guard", SnapshotViewProbe.RunGuard),
+        // Epoch fingerprint (tool-surface 2.0 W1, SPEC §2.1.1): the captured-index build identity — deterministic
+        // over (names, mtimes, order), sensitive to content/order/set changes (backdated included), stamped by every
+        // index-backed lane at its Capture() boundary, carried by the text AND json renders (D2), re-stamped on a
+        // mid-session rebuild so cross-page drift is visible. Refusals answered off a build carry it; refusals that
+        // never consulted one stay null.
+        ("epoch-guard", EpochGuardProbe.RunGuard),
         ("verify-loop-guard", VerifyLoopProbe.RunGuard),
         ("vmad-poly-guard", VmadPolyProbe.RunGuard),
         ("poly-field-descend-guard", PolyFieldDescendProbe.RunGuard),

--- a/src/housecarl-generator/EpochGuardProbe.cs
+++ b/src/housecarl-generator/EpochGuardProbe.cs
@@ -81,12 +81,17 @@ internal static class EpochGuardProbe
             Directory.CreateDirectory(Path.Combine(mods, "MasterMod"));
             Directory.CreateDirectory(Path.Combine(mods, "OverrideMod"));
             Directory.CreateDirectory(Path.Combine(mods, "OldMod"));
+            Directory.CreateDirectory(Path.Combine(mods, "BadMod"));
             var masterFile = Path.Combine(mods, "MasterMod", masterName);
             var ovFile = Path.Combine(mods, "OverrideMod", ovName);
             var oldFile = Path.Combine(mods, "OldMod", oldName);
             master.BeginWrite.ToPath(masterFile).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
             ovMod.BeginWrite.ToPath(ovFile).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
             oldMod.BeginWrite.ToPath(oldFile).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
+            // An UNPARSEABLE plugin, ENABLED — the index build excludes it, so a scope naming it hits the CORE
+            // sweep frame's excluded-plugin refusal (PR #305 re-review finding 1).
+            const string badName = "HcEpochBad.esp";
+            File.WriteAllText(Path.Combine(mods, "BadMod", badName), "this is not a bethesda plugin");
 
             string Fid(FormKey fk) => $"{fk.ID:X6}:{fk.ModKey.FileName}";
 
@@ -147,9 +152,9 @@ internal static class EpochGuardProbe
                     + Path.Combine(root, "game").Replace(@"\", @"\\") + ")\r\n");
                 var prof = Path.Combine(inst, "profiles", "Default");
                 Directory.CreateDirectory(prof);
-                File.WriteAllText(Path.Combine(prof, "loadorder.txt"), "# header\r\n" + masterName + "\r\n" + ovName + "\r\n");
-                File.WriteAllText(Path.Combine(prof, "plugins.txt"), "*" + masterName + "\r\n*" + ovName + "\r\n");
-                File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n-OldMod\r\n+OverrideMod\r\n+MasterMod\r\n");
+                File.WriteAllText(Path.Combine(prof, "loadorder.txt"), "# header\r\n" + masterName + "\r\n" + ovName + "\r\n" + badName + "\r\n");
+                File.WriteAllText(Path.Combine(prof, "plugins.txt"), "*" + masterName + "\r\n*" + ovName + "\r\n*" + badName + "\r\n");
+                File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n-OldMod\r\n+BadMod\r\n+OverrideMod\r\n+MasterMod\r\n");
 
                 var store = new UserConfigStore(Path.Combine(root, "user.json"));
                 using var svc = LoadOrderService.WithInstance(inst, 0, store);
@@ -230,6 +235,23 @@ internal static class EpochGuardProbe
                 var ceMiss = svc.CheckErrors(new[] { "Nope.esp" }, 1000);
                 Check(ceMiss.Error is not null && ceMiss.Epoch == current, "check_errors' locate refusal is stamped");
                 Check(Wire.RenderCheckErrors(ceMiss, 0).Contains($"epoch={current}"), "…and rendered");
+                // Latent bug surfaced by this arm: both sweep json refusal paths returned INSIDE the writer's using
+                // without a Flush — every json-mode sweep refusal rendered as an EMPTY STRING (pre-existing, silent).
+                Check(JsonWire.RenderCheckErrors(ceMiss, 0).Contains("\"error\"") && JsonWire.RenderCheckErrors(ceMiss, 0).Contains($"\"epoch\": \"{current}\""),
+                      "…check_errors' JSON refusal is a real document with the stamp (the empty-refusal flush bug is dead)");
+
+                // Re-review finding 1: the CORE sweep frame's own refusals — one frame deeper than the service's.
+                var ceExcl = svc.CheckErrors(new[] { badName }, 1000);
+                Check(ceExcl.Error is not null && ceExcl.Error.Contains("excluded") && ceExcl.Epoch == current,
+                      "check_errors' CORE-frame excluded-plugin refusal is stamped (the frame the first fold missed)");
+                Check(Wire.RenderCheckErrors(ceExcl, 0).Contains($"epoch={current}"), "…and rendered");
+                var vsMiss = svc.ValidateScripts(new[] { "Nope.esp" }, 1000);
+                Check(vsMiss.Error is not null && vsMiss.Epoch == current,
+                      "validate_scripts' not-in-order refusal is stamped (previously NO ScriptCheckResult refusal could be)");
+                Check(Wire.RenderScriptCheck(vsMiss, 0).Contains($"epoch={current}"),
+                      "…and the TEXT refusal render carries it — no longer dead code");
+                Check(JsonWire.RenderScriptCheck(vsMiss, 0).Contains($"\"epoch\": \"{current}\""),
+                      "…and the JSON refusal render carries it");
 
                 // ---- PR #305 fold: off-order coverage is QUALIFIED, never overclaimed (finding 3) ----
                 Console.WriteLine();
@@ -249,6 +271,16 @@ internal static class EpochGuardProbe
                       "…and its text stamp is qualified");
                 Check(!Wire.RenderCheckErrors(ce, 0).Contains("(indexed plugins only"),
                       "…while the all-indexed sweep carries NO qualifier (control)");
+                // Re-review finding 4: the coverage fact rides the JSON as DATA, not prose — the machine consumer
+                // comparing epochs is the one that needs it.
+                Check(JsonWire.RenderDiffRecord(dOld, 0).Contains("\"epoch_covers_all_inputs\": false"),
+                      "diff json carries epoch_covers_all_inputs=false for the off-order pole");
+                Check(JsonWire.RenderDiffRecord(dInOrder, 0).Contains("\"epoch_covers_all_inputs\": true"),
+                      "…and true for the all-active control");
+                Check(JsonWire.RenderCheckErrors(ceOld, 0).Contains("\"epoch_covers_all_inputs\": false"),
+                      "check_errors json: false when off-order files were swept");
+                Check(JsonWire.RenderCheckErrors(ce, 0).Contains("\"epoch_covers_all_inputs\": true"),
+                      "…and true for the all-indexed control");
 
                 // ---- 4: the pin + the re-stamp (PR #305 fold, finding 2) ----
                 Console.WriteLine();
@@ -259,6 +291,13 @@ internal static class EpochGuardProbe
                 // stamped with the old epoch — the affirmative single-build claim the response didn't satisfy.
                 var qPin = svc.CrossQuery("WEAP", null, null, false, null, null, 500);
                 Check(qPin.Epoch == current, "pin arm: scan stamped at the current build");
+                // Re-review finding 3 (structural): every ReadOutcome carries the ViewPin its epoch names, so the
+                // conflict-tree fill on single reads / batch items reads the stamped build through the SAME
+                // ResolveTreePinned path the behavioural arm below exercises for the scan.
+                Check(qPin.Pin is not null
+                      && svc.ResolveRead(FormKey.Factory(Fid(weapons[0])), null, null, true).Pin is not null
+                      && svc.ResolveBatch(new[] { Fid(weapons[0]) }, null, true)[0].Pin is not null,
+                      "scan, single read, and batch outcomes all carry the ViewPin their stamp names (tree fills read it)");
                 var ovMod2 = new SkyrimMod(ovKey, SkyrimRelease.SkyrimSE);
                 ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(ovMod2, master.Weapons.First()))
                     .BasicStats = new WeaponBasicStats { Damage = 20, Weight = 1 };

--- a/src/housecarl-generator/EpochGuardProbe.cs
+++ b/src/housecarl-generator/EpochGuardProbe.cs
@@ -68,14 +68,25 @@ internal static class EpochGuardProbe
             ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(ovMod, master.Weapons.First()))
                 .BasicStats = new WeaponBasicStats { Damage = 20, Weight = 1 };
 
+            // An OFF-ORDER plugin: in a DISABLED mod folder (modlist '-OldMod'), overriding weapons[0] — the
+            // documented diff-against-a-disabled-old-patch case, for the F3 coverage-qualifier arms (PR #305 fold).
+            var oldKey = new ModKey("HcEpochOld", ModType.Plugin);
+            string oldName = oldKey.FileName.String;
+            var oldMod = new SkyrimMod(oldKey, SkyrimRelease.SkyrimSE);
+            ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(oldMod, master.Weapons.First()))
+                .BasicStats = new WeaponBasicStats { Damage = 15, Weight = 1 };
+
             var inst = Path.Combine(root, "inst");
             var mods = Path.Combine(inst, "mods");
             Directory.CreateDirectory(Path.Combine(mods, "MasterMod"));
             Directory.CreateDirectory(Path.Combine(mods, "OverrideMod"));
+            Directory.CreateDirectory(Path.Combine(mods, "OldMod"));
             var masterFile = Path.Combine(mods, "MasterMod", masterName);
             var ovFile = Path.Combine(mods, "OverrideMod", ovName);
+            var oldFile = Path.Combine(mods, "OldMod", oldName);
             master.BeginWrite.ToPath(masterFile).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
             ovMod.BeginWrite.ToPath(ovFile).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
+            oldMod.BeginWrite.ToPath(oldFile).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
 
             string Fid(FormKey fk) => $"{fk.ID:X6}:{fk.ModKey.FileName}";
 
@@ -108,6 +119,19 @@ internal static class EpochGuardProbe
                 Check(rSwap.Epoch != e1, "a REORDER fingerprints differently (winner identity depends on it)");
                 using var rOne = LoadOrderResolver.Build(new[] { masterFile });            // different set
                 Check(rOne.Epoch != e1 && rOne.Epoch != rSwap.Epoch, "a SET change fingerprints differently");
+
+                // PR #305 review: the MO2 same-name conflict — two mods ship the SAME-NAMED plugin; a left-pane
+                // reorder swaps WHICH file wins the slot with no name change and (move, or same base archive) no
+                // mtime change. Names+mtimes alone gave the new build the OLD epoch; the path term catches it.
+                var dirA = Path.Combine(root, "same-name-a"); var dirB = Path.Combine(root, "same-name-b");
+                Directory.CreateDirectory(dirA); Directory.CreateDirectory(dirB);
+                var copyA = Path.Combine(dirA, ovName); var copyB = Path.Combine(dirB, ovName);
+                File.Copy(ovFile, copyA); File.Copy(ovFile, copyB);
+                var tick = DateTime.UtcNow.AddHours(-1);
+                File.SetLastWriteTimeUtc(copyA, tick); File.SetLastWriteTimeUtc(copyB, tick);   // identical name + mtime
+                using var rA = LoadOrderResolver.Build(new[] { masterFile, copyA });
+                using var rB = LoadOrderResolver.Build(new[] { masterFile, copyB });
+                Check(rA.Epoch != rB.Epoch, "a DIFFERENT FILE winning a same-named slot (same name, same mtime) fingerprints differently — the path term");
             }
 
             // ---- 3+4: stamps + renders, on the real service over a synthetic MO2 instance ----
@@ -125,7 +149,7 @@ internal static class EpochGuardProbe
                 Directory.CreateDirectory(prof);
                 File.WriteAllText(Path.Combine(prof, "loadorder.txt"), "# header\r\n" + masterName + "\r\n" + ovName + "\r\n");
                 File.WriteAllText(Path.Combine(prof, "plugins.txt"), "*" + masterName + "\r\n*" + ovName + "\r\n");
-                File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n+OverrideMod\r\n+MasterMod\r\n");
+                File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n-OldMod\r\n+OverrideMod\r\n+MasterMod\r\n");
 
                 var store = new UserConfigStore(Path.Combine(root, "user.json"));
                 using var svc = LoadOrderService.WithInstance(inst, 0, store);
@@ -184,13 +208,72 @@ internal static class EpochGuardProbe
                 Check(Wire.RenderScriptCheck(vs, 0).Contains($"epoch={current}") && JsonWire.RenderScriptCheck(vs, 0).Contains($"\"epoch\": \"{current}\""),
                       "…both renders carry it");
 
-                // ---- 4: the point of it all — a rebuild between two queries changes the STAMP ----
+                // ---- PR #305 fold: the refusal contract ON THE WIRE (finding 1) ----
                 Console.WriteLine();
-                Console.WriteLine("--- 4: a mid-session rebuild re-stamps — cross-page drift becomes visible ---");
-                File.SetLastWriteTimeUtc(ovFile, DateTime.UtcNow.AddMinutes(-30));
+                Console.WriteLine("--- 3b (PR #305 fold): stamped refusals render their stamp; pre-capture refusals stay null ---");
+                var miss = svc.ResolveRead(FormKey.Factory("0ABC12:" + masterName), null, null, false);
+                Check(miss.Error is not null && miss.Epoch == current, "an absent-record read refusal is stamped on the DTO");
+                Check(Wire.RenderRecord(svc, miss, null, false, 0).Contains($"epoch={current}"), "…and the TEXT refusal carries it");
+                Check(JsonWire.RenderRecord(miss, 0).Contains($"\"epoch\": \"{current}\""), "…and the JSON refusal carries it");
+
+                // finding 4: effect_chain / diff / check_errors post-capture refusals stamped; pre-capture null.
+                var ecMiss = svc.ResolveEffectChain(FormKey.Factory("0ABC12:" + masterName), null, 500);
+                Check(ecMiss.Error is not null && ecMiss.Epoch == current, "effect_chain's not-in-order refusal is stamped");
+                Check(Wire.RenderEffectChain(ecMiss, 0).Contains($"epoch={current}"), "…and rendered");
+                Check(svc.ResolveEffectChain(mgef.FormKey, new[] { "WEAP" }, 500).Epoch is null,
+                      "…its PRE-capture type-narrow refusal stays null");
+                var dMiss = svc.DiffRecord(Fid(weapons[0]), masterName, "Nope.esp", null);
+                Check(dMiss.Error is not null && dMiss.Epoch == current, "diff_record's unresolvable-pole refusal is stamped");
+                Check(Wire.RenderDiffRecord(dMiss, 0).Contains($"epoch={current}"), "…and rendered");
+                Check(svc.DiffRecord("notaformid", masterName, ovName, null).Epoch is null,
+                      "…its PRE-capture bad-FormID refusal stays null");
+                var ceMiss = svc.CheckErrors(new[] { "Nope.esp" }, 1000);
+                Check(ceMiss.Error is not null && ceMiss.Epoch == current, "check_errors' locate refusal is stamped");
+                Check(Wire.RenderCheckErrors(ceMiss, 0).Contains($"epoch={current}"), "…and rendered");
+
+                // ---- PR #305 fold: off-order coverage is QUALIFIED, never overclaimed (finding 3) ----
+                Console.WriteLine();
+                Console.WriteLine("--- 3c (PR #305 fold): an off-order input qualifies the stamp — the fingerprint covers the index only ---");
+                var dOld = svc.DiffRecord(Fid(weapons[0]), masterName, oldName, null);
+                Check(dOld.Error is null && dOld.Epoch == current && !dOld.B!.InOrder,
+                      "an off-order diff pole resolves (10 vs 15) and still stamps the INDEX build");
+                Check(Wire.RenderDiffRecord(dOld, 0).Contains("(active-order inputs only"),
+                      "…and the text stamp is QUALIFIED — the off-order file's content is outside the fingerprint");
+                var dInOrder = svc.DiffRecord(Fid(weapons[0]), masterName, ovName, null);
+                Check(!Wire.RenderDiffRecord(dInOrder, 0).Contains("(active-order inputs only"),
+                      "…while an all-active diff carries NO qualifier (control)");
+                var ceOld = svc.CheckErrors(new[] { oldName }, 1000);
+                Check(ceOld.Error is null && ceOld.Epoch == current && ceOld.OffOrderScanned is { Count: > 0 },
+                      "an off-order sweep resolves and still stamps the INDEX build");
+                Check(Wire.RenderCheckErrors(ceOld, 0).Contains("(indexed plugins only"),
+                      "…and its text stamp is qualified");
+                Check(!Wire.RenderCheckErrors(ce, 0).Contains("(indexed plugins only"),
+                      "…while the all-indexed sweep carries NO qualifier (control)");
+
+                // ---- 4: the pin + the re-stamp (PR #305 fold, finding 2) ----
+                Console.WriteLine();
+                Console.WriteLine("--- 4: detail fills read the SCANNED build (the pin); the NEXT query re-stamps ---");
+                // Scan at the current build, THEN rewrite the override plugin to also override weapons[1]. The
+                // pinned render must fill its rows off the SCANNED build (override wins exactly ONE record); the
+                // pre-fold code re-captured per row, so the rewrite's build leaked into rows under a header
+                // stamped with the old epoch — the affirmative single-build claim the response didn't satisfy.
+                var qPin = svc.CrossQuery("WEAP", null, null, false, null, null, 500);
+                Check(qPin.Epoch == current, "pin arm: scan stamped at the current build");
+                var ovMod2 = new SkyrimMod(ovKey, SkyrimRelease.SkyrimSE);
+                ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(ovMod2, master.Weapons.First()))
+                    .BasicStats = new WeaponBasicStats { Damage = 20, Weight = 1 };
+                ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(ovMod2, master.Weapons.Skip(1).First()))
+                    .BasicStats = new WeaponBasicStats { Damage = 99, Weight = 1 };
+                ovMod2.BeginWrite.ToPath(ovFile).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
+                var pinned = JsonWire.RenderCrossQuery(svc, qPin, new[] { "EditorID" }, 0, false, false);
+                Check(pinned.Contains($"\"epoch\": \"{current}\""), "the pinned render still stamps the scanned build");
+                int ovWins = System.Text.RegularExpressions.Regex.Matches(
+                    pinned, "\"winner\": \"" + System.Text.RegularExpressions.Regex.Escape(ovName) + "\"").Count;
+                Check(ovWins == 1,
+                      $"…and its fills read the SCANNED build's winners — the override wins exactly its one record ({ovWins}/1), not the mid-render rewrite's two");
                 var q2 = svc.CrossQuery("WEAP", null, null, false, null, null, 500);
                 Check(q2.Epoch is not null && q2.Epoch != current,
-                      $"page 2 after a content change carries a DIFFERENT epoch ({current} → {q2.Epoch}) — the incoherent-assembly tell");
+                      $"the NEXT query re-stamps ({current} → {q2.Epoch}) — cross-page drift visible");
                 Check(svc.Stats().epoch == q2.Epoch, "…and status agrees with the new build");
             }
         }

--- a/src/housecarl-generator/EpochGuardProbe.cs
+++ b/src/housecarl-generator/EpochGuardProbe.cs
@@ -1,0 +1,206 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// REGRESSION GUARD for the epoch fingerprint (tool-surface 2.0, W1 — SPEC §2.1.1): every index-backed response
+/// stamps the identity of the build it was answered from, so cross-page drift is DETECTABLE instead of silently
+/// incoherent, and a future artifact re-entry can be epoch-checked. Arms:
+///
+///   1  IDENTITY — the fingerprint is a deterministic function of the world-state (plugin names + mtimes, in
+///      order): same order twice = same epoch, a SECOND resolver over the same files (the restart case) = same
+///      epoch, and the resolver/view/format contracts hold (16 lowercase hex; view epoch == resolver epoch).
+///   2  SENSITIVITY — a content edit (mtime change, NEWER or OLDER — the restored-backup case must not be
+///      invisible), a reorder, and a set change each produce a DIFFERENT epoch; RefreshIfStale over an
+///      unchanged order keeps it.
+///   3  STAMPS — every index-backed lane carries the capture's epoch: cross_plugin_query (incl. the Fail path
+///      staying null — a refusal that never consulted a build must not invent one), batch (ONE epoch for the
+///      whole batch; a malformed-formid row carries none), single read (refusals INCLUDED — "not present" is an
+///      answer about a build), resolve (out-epoch), diff, effect_chain, check_errors, validate_scripts, status.
+///   4  RENDERS — the text and json renders both emit it (D2: the two may differ only in formatting), and a
+///      freshness rebuild between two queries changes the STAMP, not just the index (the cross-page detection
+///      this exists for).
+///
+/// Self-contained: synthetic MO2 instance + synthesized plugins in temp. No game data.
+/// </summary>
+internal static class EpochGuardProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" epoch guard — every index-backed response names the build it read (SPEC §2.1.1)");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+        static bool IsEpochToken(string? e) => e is { Length: 16 } && e.All(ch => ch is (>= '0' and <= '9') or (>= 'a' and <= 'f'));
+
+        var root = Path.Combine(Path.GetTempPath(), "hc-epoch-guard-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root, "game", "Data"));
+
+            // ---- synthesized plugins: a master (weapons + an MGEF/spell pair) and an override ----
+            var masterKey = new ModKey("HcEpochMaster", ModType.Master);
+            var ovKey = new ModKey("HcEpochOverride", ModType.Plugin);
+            string masterName = masterKey.FileName.String, ovName = ovKey.FileName.String;
+
+            var master = new SkyrimMod(masterKey, SkyrimRelease.SkyrimSE);
+            var weapons = new List<FormKey>();
+            for (int i = 0; i < 3; i++)
+            {
+                var w = master.Weapons.AddNew(); w.EditorID = $"HcEpW{i}";
+                w.BasicStats = new WeaponBasicStats { Damage = 10, Weight = 1 };
+                weapons.Add(w.FormKey);
+            }
+            var mgef = master.MagicEffects.AddNew(); mgef.EditorID = "HcEpMgef";
+            var spell = master.Spells.AddNew(); spell.EditorID = "HcEpSpell";
+            var eff = new Effect(); eff.BaseEffect.SetTo(mgef.FormKey);
+            eff.Data = new EffectData { Magnitude = 5 };
+            spell.Effects.Add(eff);
+
+            var ovMod = new SkyrimMod(ovKey, SkyrimRelease.SkyrimSE);
+            ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(ovMod, master.Weapons.First()))
+                .BasicStats = new WeaponBasicStats { Damage = 20, Weight = 1 };
+
+            var inst = Path.Combine(root, "inst");
+            var mods = Path.Combine(inst, "mods");
+            Directory.CreateDirectory(Path.Combine(mods, "MasterMod"));
+            Directory.CreateDirectory(Path.Combine(mods, "OverrideMod"));
+            var masterFile = Path.Combine(mods, "MasterMod", masterName);
+            var ovFile = Path.Combine(mods, "OverrideMod", ovName);
+            master.BeginWrite.ToPath(masterFile).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            ovMod.BeginWrite.ToPath(ovFile).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
+
+            string Fid(FormKey fk) => $"{fk.ID:X6}:{fk.ModKey.FileName}";
+
+            // ---- 1: identity — deterministic over the world-state; stable across resolver instances ----
+            Console.WriteLine("--- 1: identity — a deterministic function of (names, mtimes, order) ---");
+            {
+                var paths = new[] { masterFile, ovFile };
+                using var r1 = LoadOrderResolver.Build(paths);
+                using var r2 = LoadOrderResolver.Build(paths);          // the restart case: a fresh process over unchanged files
+                Check(IsEpochToken(r1.Epoch), $"epoch is an opaque 16-hex token — '{r1.Epoch}'");
+                Check(r1.Epoch == r2.Epoch, "a SECOND resolver over the same files fingerprints IDENTICALLY (restart invalidates nothing)");
+                Check(r1.Capture().Epoch == r1.Epoch, "view epoch == resolver epoch (one build, one identity)");
+                Check(!r1.RefreshIfStale() && r1.Capture().Epoch == r2.Epoch, "RefreshIfStale over an UNCHANGED order keeps the epoch");
+            }
+
+            // ---- 2: sensitivity — content, order, and set changes each re-fingerprint ----
+            Console.WriteLine();
+            Console.WriteLine("--- 2: sensitivity — content/order/set changes re-fingerprint; backdating is not invisible ---");
+            {
+                var paths = new[] { masterFile, ovFile };
+                using var r = LoadOrderResolver.Build(paths);
+                var e0 = r.Epoch;
+
+                File.SetLastWriteTimeUtc(ovFile, DateTime.UtcNow.AddHours(-2));   // OLDER mtime — the restored-backup case
+                Check(r.RefreshIfStale(), "a BACKDATED content change is seen (value-compare, not newer-than)");
+                var e1 = r.Capture().Epoch;
+                Check(e1 != e0, $"…and the epoch changed with it ({e0} → {e1})");
+
+                using var rSwap = LoadOrderResolver.Build(new[] { ovFile, masterFile });   // same set, different order
+                Check(rSwap.Epoch != e1, "a REORDER fingerprints differently (winner identity depends on it)");
+                using var rOne = LoadOrderResolver.Build(new[] { masterFile });            // different set
+                Check(rOne.Epoch != e1 && rOne.Epoch != rSwap.Epoch, "a SET change fingerprints differently");
+            }
+
+            // ---- 3+4: stamps + renders, on the real service over a synthetic MO2 instance ----
+            Console.WriteLine();
+            Console.WriteLine("--- 3: every index-backed lane stamps the capture's epoch ---");
+            {
+                var genDir = Path.Combine(root, "corpus-gen");
+                CorpusGenerator.GenerateAll(genDir, Path.Combine(root, "corpus-ref"));
+                CorpusRulebook.CorpusPath = Path.Combine(genDir, "corpus.json");
+
+                File.WriteAllText(Path.Combine(inst, "ModOrganizer.ini"),
+                    "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+                    + Path.Combine(root, "game").Replace(@"\", @"\\") + ")\r\n");
+                var prof = Path.Combine(inst, "profiles", "Default");
+                Directory.CreateDirectory(prof);
+                File.WriteAllText(Path.Combine(prof, "loadorder.txt"), "# header\r\n" + masterName + "\r\n" + ovName + "\r\n");
+                File.WriteAllText(Path.Combine(prof, "plugins.txt"), "*" + masterName + "\r\n*" + ovName + "\r\n");
+                File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n+OverrideMod\r\n+MasterMod\r\n");
+
+                var store = new UserConfigStore(Path.Combine(root, "user.json"));
+                using var svc = LoadOrderService.WithInstance(inst, 0, store);
+                var current = svc.Stats().epoch;
+                Check(IsEpochToken(current), $"Stats() names the current build epoch — '{current}'");
+                Check(svc.StatusData().Epoch == current, "StatusData carries the same epoch (the status line's source)");
+
+                // cross_plugin_query — outcome stamp + all three renders + the Fail path
+                var q = svc.CrossQuery("WEAP", null, null, false, null, null, 500);
+                Check(q.Epoch == current, "cross_plugin_query outcome stamps the scanned build");
+                Check(Wire.RenderCrossQuery(svc, q, null, false, 0).Contains($"epoch={current}"), "…text render carries epoch=<hex> in the header");
+                Check(JsonWire.RenderCrossQuery(svc, q, null, 0, false, false).Contains($"\"epoch\": \"{current}\""), "…json render carries the epoch field");
+                Check(JsonWire.RenderCrossQueryDense(svc, q, null, 0, false, false).Contains($"\"epoch\": \"{current}\""), "…dense render carries it too");
+                var g = svc.CrossQuery("WEAP", null, null, false, null, null, 500, groupBy: "winner");
+                Check(g.Epoch == current && Wire.RenderCrossQuery(svc, g, null, false, 0).Contains($"epoch={current}"),
+                      "…group_by count table carries it (aggregations page too)");
+                Check(svc.CrossQuery(null, null, null, false, null, null, 500).Epoch is null,
+                      "…a REFUSED query (no filter) stays unstamped — a refusal that consulted no build invents none");
+
+                // batch — ONE epoch for the whole batch; refusal rows answered off the build carry it; parse failures don't
+                var batch = svc.ResolveBatch(new[] { Fid(weapons[0]), Fid(weapons[1]), "notaformid", "ABC123:Absent.esp" }, null, false);
+                var stamped = batch.Where(o => o.Epoch is not null).Select(o => o.Epoch).Distinct().ToList();
+                Check(stamped.Count == 1 && stamped[0] == current, "batch: every consulted row carries the batch's ONE epoch");
+                Check(batch[2].Epoch is null, "…the malformed-formid row (no view consulted) carries none");
+                Check(batch[3].Error is not null && batch[3].Epoch == current,
+                      "…the absent-record REFUSAL is stamped ('not present' is an answer about a build)");
+                Check(Wire.RenderBatch(svc, batch, null, false, 0).Contains($"epoch={current}"), "…text header carries it once, response-level");
+                Check(JsonWire.RenderBatch(batch, 0).Contains($"\"epoch\": \"{current}\""), "…json carries it once, response-level");
+
+                // single read — text tail + json top-level
+                var one = svc.ResolveRead(FormKey.Factory(Fid(weapons[0])), null, null, false);
+                Check(one.Epoch == current, "read_record outcome stamps its capture");
+                Check(Wire.RenderRecord(svc, one, null, false, 0).Contains($"epoch={current}"), "…text render carries it");
+                Check(JsonWire.RenderRecord(one, 0).Contains($"\"epoch\": \"{current}\""), "…json render carries it");
+
+                // resolve — the out-epoch overload feeds both renders
+                var rows = svc.ResolveRefs(new[] { Fid(weapons[0]), Fid(mgef.FormKey) }, out var resolveEpoch);
+                Check(resolveEpoch == current, "resolve hands back the batch's epoch");
+                Check(Wire.RenderResolve(rows, 0, resolveEpoch).Contains($"epoch={current}"), "…text render carries it");
+                Check(JsonWire.RenderResolve(rows, 0, resolveEpoch).Contains($"\"epoch\": \"{current}\""), "…json render carries it");
+
+                // diff / effect_chain / sweeps
+                var d = svc.DiffRecord(Fid(weapons[0]), masterName, ovName, null);
+                Check(d.Error is null && d.Epoch == current, "diff_record stamps the ONE build both poles resolved against");
+                Check(Wire.RenderDiffRecord(d, 0).Contains($"epoch={current}"), "…text render carries it");
+                Check(JsonWire.RenderDiffRecord(d, 0).Contains($"\"epoch\": \"{current}\""), "…json render carries it");
+                var ec = svc.ResolveEffectChain(mgef.FormKey, null, 500);
+                Check(ec.Error is null && ec.Epoch == current && Wire.RenderEffectChain(ec, 0).Contains($"epoch={current}"),
+                      "effect_chain stamps + renders it");
+                var ce = svc.CheckErrors(null, 1000);
+                Check(ce.Error is null && ce.Epoch == current, "check_errors stamps the swept build");
+                Check(Wire.RenderCheckErrors(ce, 0).Contains($"epoch={current}") && JsonWire.RenderCheckErrors(ce, 0).Contains($"\"epoch\": \"{current}\""),
+                      "…both renders carry it");
+                var vs = svc.ValidateScripts(null, 1000);
+                Check(vs.Error is null && vs.Epoch == current, "validate_scripts stamps the swept build");
+                Check(Wire.RenderScriptCheck(vs, 0).Contains($"epoch={current}") && JsonWire.RenderScriptCheck(vs, 0).Contains($"\"epoch\": \"{current}\""),
+                      "…both renders carry it");
+
+                // ---- 4: the point of it all — a rebuild between two queries changes the STAMP ----
+                Console.WriteLine();
+                Console.WriteLine("--- 4: a mid-session rebuild re-stamps — cross-page drift becomes visible ---");
+                File.SetLastWriteTimeUtc(ovFile, DateTime.UtcNow.AddMinutes(-30));
+                var q2 = svc.CrossQuery("WEAP", null, null, false, null, null, 500);
+                Check(q2.Epoch is not null && q2.Epoch != current,
+                      $"page 2 after a content change carries a DIFFERENT epoch ({current} → {q2.Epoch}) — the incoherent-assembly tell");
+                Check(svc.Stats().epoch == q2.Epoch, "…and status agrees with the new build");
+            }
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { /* best-effort temp cleanup */ }
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"[epoch-guard] {(fail == 0 ? "PASS — every index-backed answer names its build." : $"FAIL — {fail} check(s) failed.")}");
+        return fail == 0 ? 0 : 1;
+    }
+}

--- a/src/housecarl-generator/EpochGuardProbe.cs
+++ b/src/housecarl-generator/EpochGuardProbe.cs
@@ -137,6 +137,21 @@ internal static class EpochGuardProbe
                 using var rA = LoadOrderResolver.Build(new[] { masterFile, copyA });
                 using var rB = LoadOrderResolver.Build(new[] { masterFile, copyB });
                 Check(rA.Epoch != rB.Epoch, "a DIFFERENT FILE winning a same-named slot (same name, same mtime) fingerprints differently — the path term");
+
+                // Third-round BLOCKER: an open failure is TRANSIENT (xEdit/MO2 holding an exclusive handle) and
+                // excludes the plugin wholesale — a build that skipped it resolves materially different winners
+                // than the healthy build over identical names/paths/mtimes, so the exclusion set is a fingerprint
+                // term. Locked here exactly the way a real editor locks it (FileShare.None), mtimes untouched.
+                string lockedEpoch;
+                using (new FileStream(copyA, FileMode.Open, FileAccess.Read, FileShare.None))
+                {
+                    using var rLocked = LoadOrderResolver.Build(new[] { masterFile, copyA });
+                    Check(rLocked.ExcludedPlugins.Count == 1, "a LOCKED plugin is excluded from the build (the transient degraded state)");
+                    lockedEpoch = rLocked.Epoch;
+                }
+                using var rHealthy = LoadOrderResolver.Build(new[] { masterFile, copyA });
+                Check(rHealthy.ExcludedPlugins.Count == 0 && lockedEpoch != rHealthy.Epoch,
+                      $"…and the degraded and healthy builds fingerprint DIFFERENTLY over identical names/paths/mtimes ({lockedEpoch} vs {rHealthy.Epoch}) — an artifact saved degraded can never pass re-entry against healthy");
             }
 
             // ---- 3+4: stamps + renders, on the real service over a synthetic MO2 instance ----
@@ -230,6 +245,10 @@ internal static class EpochGuardProbe
                 var dMiss = svc.DiffRecord(Fid(weapons[0]), masterName, "Nope.esp", null);
                 Check(dMiss.Error is not null && dMiss.Epoch == current, "diff_record's unresolvable-pole refusal is stamped");
                 Check(Wire.RenderDiffRecord(dMiss, 0).Contains($"epoch={current}"), "…and rendered");
+                // Third-round finding 2: a refusal's poles/inputs were never resolved — the coverage bool is a
+                // success-path assertion and must NOT ride refusal documents (it claimed true on null poles).
+                Check(!JsonWire.RenderDiffRecord(dMiss, 0).Contains("epoch_covers_all_inputs"),
+                      "…its json refusal carries the bare stamp, NO coverage claim");
                 Check(svc.DiffRecord("notaformid", masterName, ovName, null).Epoch is null,
                       "…its PRE-capture bad-FormID refusal stays null");
                 var ceMiss = svc.CheckErrors(new[] { "Nope.esp" }, 1000);
@@ -239,6 +258,8 @@ internal static class EpochGuardProbe
                 // without a Flush — every json-mode sweep refusal rendered as an EMPTY STRING (pre-existing, silent).
                 Check(JsonWire.RenderCheckErrors(ceMiss, 0).Contains("\"error\"") && JsonWire.RenderCheckErrors(ceMiss, 0).Contains($"\"epoch\": \"{current}\""),
                       "…check_errors' JSON refusal is a real document with the stamp (the empty-refusal flush bug is dead)");
+                Check(!JsonWire.RenderCheckErrors(ceMiss, 0).Contains("epoch_covers_all_inputs"),
+                      "…and it carries NO coverage claim (a refusal swept nothing — third-round finding 2)");
 
                 // Re-review finding 1: the CORE sweep frame's own refusals — one frame deeper than the service's.
                 var ceExcl = svc.CheckErrors(new[] { badName }, 1000);

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -91,10 +91,10 @@ static class JsonWire
         {
             w.WriteStartObject();
             w.WriteString("formid", o.Formid);
-            if (o.Error is not null) { w.WriteString("error", o.Error); WriteNullable(w, "epoch", o.Epoch); }
+            if (o.Error is not null) { w.WriteString("error", o.Error); WriteEpochWithCoverage(w, o); }
             else
             {
-                WriteNullable(w, "epoch", o.Epoch);   // §2.1.1: the INDEX build — an off-order pole's file content is outside the fingerprint (each pole's in_order/where carries that fact)
+                WriteEpochWithCoverage(w, o);   // §2.1.1: the INDEX build + whether it covers every input
                 WriteDiffPole(w, "a", o.A!);
                 WriteDiffPole(w, "b", o.B!);
                 var d = o.Diff!;
@@ -118,6 +118,20 @@ static class JsonWire
             w.WriteEndObject();
         }
         return Finish(ms);
+    }
+
+    /// <summary>The diff stamp + its coverage AS DATA (PR #305 re-review): the epoch names the INDEX build, and an
+    /// OUT-OF-LOAD-ORDER pole's file content is outside that fingerprint — so a machine consumer comparing epochs
+    /// for "same inputs ⇒ same answer" gets told in-band, not in a C# comment. <c>epoch_covers_all_inputs</c> is
+    /// false exactly when an off-order pole contributed (derivable from the poles' <c>in_order</c>, emitted as a
+    /// sibling so equality checks need no join); the text render's "(active-order inputs only …)" qualifier is this
+    /// same fact's prose form (D2 — one datum, two renders). Omitted with the epoch on unstamped refusals.</summary>
+    static void WriteEpochWithCoverage(Utf8JsonWriter w, LoadOrderService.DiffRecordOutcome o)
+    {
+        if (o.Epoch is null) return;
+        w.WriteString("epoch", o.Epoch);
+        w.WriteBoolean("epoch_covers_all_inputs",
+                       o.A is null or { InOrder: true } && o.B is null or { InOrder: true });
     }
 
     static void WriteDiffPole(Utf8JsonWriter w, string name, LoadOrderService.DiffPole p)
@@ -518,10 +532,13 @@ static class JsonWire
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
             w.WriteStartObject();
-            if (r.Error is not null) { w.WriteString("error", r.Error); WriteNullable(w, "epoch", r.Epoch); w.WriteEndObject(); return Finish(ms); }
+            // w.Flush() before Finish: this early return sits INSIDE the using, so without it the writer's buffered
+            // bytes never reach the stream and the refusal rendered as an EMPTY STRING — a latent, pre-existing Q3
+            // break on every json-mode sweep refusal, surfaced by the epoch guard's refusal-render arm (PR #305).
+            if (r.Error is not null) { w.WriteString("error", r.Error); WriteSweepEpoch(w, r); w.WriteEndObject(); w.Flush(); return Finish(ms); }
 
             w.WriteNumber("scanned_plugins", r.PluginsScanned);
-            WriteNullable(w, "epoch", r.Epoch);   // §2.1.1: the swept INDEXED build — off_order_scanned file content is outside the fingerprint
+            WriteSweepEpoch(w, r);   // §2.1.1: the swept INDEXED build + whether it covers every swept input
             // null (not 0) for a class nobody looked for — see the summary.
             if (didDangling) { w.WriteNumber("dangling", r.TotalDangling); w.WriteNumber("unscannable_records", r.TotalUnscannableRecords); }
             else { w.WriteNull("dangling"); w.WriteNull("unscannable_records"); }
@@ -580,6 +597,17 @@ static class JsonWire
         return Finish(ms);
     }
 
+    /// <summary>check_errors' stamp + coverage as data (PR #305 re-review) — the sweep twin of
+    /// <see cref="WriteEpochWithCoverage"/>: <c>epoch_covers_all_inputs</c> is false exactly when off-order files
+    /// were swept beside the index (their content is outside the fingerprint; <c>off_order_scanned</c> names them).
+    /// validate_scripts needs no twin — it has no off-order lane, so its stamp always covers everything swept.</summary>
+    static void WriteSweepEpoch(Utf8JsonWriter w, ErrorCheckResult r)
+    {
+        if (r.Epoch is null) return;
+        w.WriteString("epoch", r.Epoch);
+        w.WriteBoolean("epoch_covers_all_inputs", r.OffOrderScanned is not { Count: > 0 });
+    }
+
     // ---- housecarl_validate_scripts (#282) ---------------------------------------------------------
     /// <summary>The script-property sweep as JSON: <c>{scanned_plugins, records_with_scripts, unbound, unbound_object,
     /// unbound_scalar, bound_but_null, unverifiable, classes_checked, filter_note, read_incomplete, excluded_plugins,
@@ -596,7 +624,8 @@ static class JsonWire
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
             w.WriteStartObject();
-            if (r.Error is not null) { w.WriteString("error", r.Error); WriteNullable(w, "epoch", r.Epoch); w.WriteEndObject(); return Finish(ms); }
+            // w.Flush() before Finish — same latent empty-refusal bug as RenderCheckErrors' early return (see there).
+            if (r.Error is not null) { w.WriteString("error", r.Error); WriteNullable(w, "epoch", r.Epoch); w.WriteEndObject(); w.Flush(); return Finish(ms); }
 
             bool didObject = r.Classes.HasFlag(ScriptFindingClass.UnboundObject);
             bool didScalar = r.Classes.HasFlag(ScriptFindingClass.UnboundScalar);

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -91,7 +91,10 @@ static class JsonWire
         {
             w.WriteStartObject();
             w.WriteString("formid", o.Formid);
-            if (o.Error is not null) { w.WriteString("error", o.Error); WriteEpochWithCoverage(w, o); }
+            // Refusals carry the bare stamp only — coverage is an assertion about RESOLVED inputs, and a refusal's
+            // poles were never resolved (emitting true there claimed full coverage on e.g. an off-order-path
+            // refusal; PR #305 third round, finding 2). Text refusals carry no qualifier either — D2 restored.
+            if (o.Error is not null) { w.WriteString("error", o.Error); WriteNullable(w, "epoch", o.Epoch); }
             else
             {
                 WriteEpochWithCoverage(w, o);   // §2.1.1: the INDEX build + whether it covers every input
@@ -125,7 +128,8 @@ static class JsonWire
     /// for "same inputs ⇒ same answer" gets told in-band, not in a C# comment. <c>epoch_covers_all_inputs</c> is
     /// false exactly when an off-order pole contributed (derivable from the poles' <c>in_order</c>, emitted as a
     /// sibling so equality checks need no join); the text render's "(active-order inputs only …)" qualifier is this
-    /// same fact's prose form (D2 — one datum, two renders). Omitted with the epoch on unstamped refusals.</summary>
+    /// same fact's prose form (D2 — one datum, two renders). SUCCESS path only: a refusal's poles were never
+    /// resolved, so it carries the bare stamp without a coverage claim (third-round finding 2).</summary>
     static void WriteEpochWithCoverage(Utf8JsonWriter w, LoadOrderService.DiffRecordOutcome o)
     {
         if (o.Epoch is null) return;
@@ -535,7 +539,8 @@ static class JsonWire
             // w.Flush() before Finish: this early return sits INSIDE the using, so without it the writer's buffered
             // bytes never reach the stream and the refusal rendered as an EMPTY STRING — a latent, pre-existing Q3
             // break on every json-mode sweep refusal, surfaced by the epoch guard's refusal-render arm (PR #305).
-            if (r.Error is not null) { w.WriteString("error", r.Error); WriteSweepEpoch(w, r); w.WriteEndObject(); w.Flush(); return Finish(ms); }
+            // Bare stamp only: coverage is an assertion about SWEPT inputs, and a refusal swept none (finding 2).
+            if (r.Error is not null) { w.WriteString("error", r.Error); WriteNullable(w, "epoch", r.Epoch); w.WriteEndObject(); w.Flush(); return Finish(ms); }
 
             w.WriteNumber("scanned_plugins", r.PluginsScanned);
             WriteSweepEpoch(w, r);   // §2.1.1: the swept INDEXED build + whether it covers every swept input
@@ -600,7 +605,8 @@ static class JsonWire
     /// <summary>check_errors' stamp + coverage as data (PR #305 re-review) — the sweep twin of
     /// <see cref="WriteEpochWithCoverage"/>: <c>epoch_covers_all_inputs</c> is false exactly when off-order files
     /// were swept beside the index (their content is outside the fingerprint; <c>off_order_scanned</c> names them).
-    /// validate_scripts needs no twin — it has no off-order lane, so its stamp always covers everything swept.</summary>
+    /// validate_scripts needs no twin — it has no off-order lane, so its stamp always covers everything swept.
+    /// SUCCESS path only — a refusal swept nothing, so it carries the bare stamp (third-round finding 2).</summary>
     static void WriteSweepEpoch(Utf8JsonWriter w, ErrorCheckResult r)
     {
         if (r.Epoch is null) return;

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -35,7 +35,7 @@ static class JsonWire
     /// one <c>{formid,type,editorid,name,winner}</c> row per resolvable input, or <c>{formid,error}</c> for a
     /// bad/absent one (per-item, the batch survives — Q3). Budget-aware like the other JSON renders: over max_chars it
     /// drops trailing rows and flags <c>truncated</c>, keeping the document valid JSON with an exact <c>count</c>.</summary>
-    public static string RenderResolve(IReadOnlyList<ResolvedRef> rows, int maxChars)
+    public static string RenderResolve(IReadOnlyList<ResolvedRef> rows, int maxChars, string epoch)
     {
         int cap = Cap(maxChars);
         using var ms = new MemoryStream();
@@ -43,6 +43,7 @@ static class JsonWire
         {
             w.WriteStartObject();
             w.WriteNumber("count", rows.Count);
+            w.WriteString("epoch", epoch);   // §2.1.1: the ONE captured build the whole batch resolved against
             w.WriteStartArray("resolved");
             int rendered = 0; bool truncated = false;
             foreach (var r in rows)
@@ -93,6 +94,7 @@ static class JsonWire
             if (o.Error is not null) w.WriteString("error", o.Error);
             else
             {
+                WriteNullable(w, "epoch", o.Epoch);   // §2.1.1: both poles resolved against this build
                 WriteDiffPole(w, "a", o.A!);
                 WriteDiffPole(w, "b", o.B!);
                 var d = o.Diff!;
@@ -185,10 +187,11 @@ static class JsonWire
     /// <summary>Serialize a resolved record: identity + winner/override_depth/source + the fields array. Shared by
     /// read_record, batch_record_detail, and the cross_plugin_query detail path (one shape, no drift). <paramref
     /// name="matches"/> carries the multi-target references= un-merge when present.</summary>
-    static void WriteReadRecord(Utf8JsonWriter w, ReadOutcome o, MemoryStream ms, int cap, string? matches = null)
+    static void WriteReadRecord(Utf8JsonWriter w, ReadOutcome o, MemoryStream ms, int cap, string? matches = null, string? epoch = null)
     {
         var r = o.Record!;
         w.WriteStartObject();
+        if (epoch is not null) w.WriteString("epoch", epoch);   // single-read top level ONLY — see RenderRecord
         w.WriteString("formid", r.FormKey);
         w.WriteString("type", r.Type);
         WriteNullable(w, "editorid", r.EditorId);
@@ -202,7 +205,9 @@ static class JsonWire
 
     // ---- housecarl_read_record (P6) -----------------------------------------------------------------
     /// <summary>read_record as JSON: the record object at top level, or <c>{error}</c>. conflict_tree is refused at
-    /// the tool layer for json (a text-only diff view), so only the field data reaches here.</summary>
+    /// the tool layer for json (a text-only diff view), so only the field data reaches here. The single-read record
+    /// object carries <c>epoch</c> top-level (it IS the response); batch/query rows never repeat it per row — there
+    /// the epoch is response-level accounting.</summary>
     public static string RenderRecord(ReadOutcome o, int maxChars)
     {
         int cap = Cap(maxChars);
@@ -210,7 +215,7 @@ static class JsonWire
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
             if (o.Error is not null) { w.WriteStartObject(); w.WriteString("error", o.Error); w.WriteEndObject(); }
-            else WriteReadRecord(w, o, ms, cap);
+            else WriteReadRecord(w, o, ms, cap, epoch: o.Epoch);
         }
         return Finish(ms);
     }
@@ -227,6 +232,9 @@ static class JsonWire
         {
             w.WriteStartObject();
             w.WriteNumber("count", outcomes.Count);
+            // The whole batch reads ONE captured build (ResolveBatch) — response-level accounting, first non-null
+            // (a malformed-FormID row never consulted a view and carries none).
+            WriteNullable(w, "epoch", outcomes.FirstOrDefault(o => o.Epoch is not null)?.Epoch);
             w.WriteStartArray("records");
             int rendered = 0; bool truncated = false;
             foreach (var o in outcomes)
@@ -263,6 +271,7 @@ static class JsonWire
             {
                 WriteNullable(w, "group_by", q.GroupBy);
                 w.WriteNumber("total", q.Total);
+                WriteNullable(w, "epoch", q.Epoch);
                 if (q.ScopeLabel is not null) w.WriteString("scope", q.ScopeLabel);
                 WriteNotes(w, q);
                 w.WriteStartArray("groups");
@@ -285,6 +294,7 @@ static class JsonWire
                 string? p5 = anyScoped ? ScopedFieldsNote(winnerFields, q.WhereWinner) : null;
                 w.WriteNumber("total", q.Total);
                 w.WriteBoolean("capped", q.Capped);
+                WriteNullable(w, "epoch", q.Epoch);                         // §2.1.1: offset= windows tile ONLY within one epoch
                 if (q.Offset > 0) w.WriteNumber("offset", q.Offset);        // #223 pagination — the window's start, in-band
                 if (q.ScopeLabel is not null) w.WriteString("scope", q.ScopeLabel);
                 WriteNotes(w, q, p5);
@@ -364,6 +374,7 @@ static class JsonWire
                 bool anyScoped = detail && q.Sources is { } ss && ss.Take(q.Keys.Count).Any(s => s is not null);   // P5
                 w.WriteNumber("total", q.Total);
                 w.WriteBoolean("capped", q.Capped);
+                WriteNullable(w, "epoch", q.Epoch);                           // §2.1.1
                 if (q.Offset > 0) w.WriteNumber("offset", q.Offset);
                 if (q.ScopeLabel is not null) w.WriteString("scope", q.ScopeLabel);
                 WriteNotes(w, q, anyScoped ? ScopedFieldsNote(winnerFields, q.WhereWinner) : null);
@@ -505,6 +516,7 @@ static class JsonWire
             if (r.Error is not null) { w.WriteString("error", r.Error); w.WriteEndObject(); return Finish(ms); }
 
             w.WriteNumber("scanned_plugins", r.PluginsScanned);
+            WriteNullable(w, "epoch", r.Epoch);   // §2.1.1: the swept build
             // null (not 0) for a class nobody looked for — see the summary.
             if (didDangling) { w.WriteNumber("dangling", r.TotalDangling); w.WriteNumber("unscannable_records", r.TotalUnscannableRecords); }
             else { w.WriteNull("dangling"); w.WriteNull("unscannable_records"); }
@@ -586,6 +598,7 @@ static class JsonWire
             bool didNull = r.Classes.HasFlag(ScriptFindingClass.BoundNull);
 
             w.WriteNumber("scanned_plugins", r.PluginsScanned);
+            WriteNullable(w, "epoch", r.Epoch);   // §2.1.1: the swept build
             w.WriteNumber("records_with_scripts", r.RecordsWithScripts);
             // null, NOT 0, for a class the caller excluded — a 0 here is parsed as "looked, found none" about a class
             // nobody looked for (PR #288 review, finding 1). The per-class keys make each number's scope self-evident

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -91,10 +91,10 @@ static class JsonWire
         {
             w.WriteStartObject();
             w.WriteString("formid", o.Formid);
-            if (o.Error is not null) w.WriteString("error", o.Error);
+            if (o.Error is not null) { w.WriteString("error", o.Error); WriteNullable(w, "epoch", o.Epoch); }
             else
             {
-                WriteNullable(w, "epoch", o.Epoch);   // §2.1.1: both poles resolved against this build
+                WriteNullable(w, "epoch", o.Epoch);   // §2.1.1: the INDEX build — an off-order pole's file content is outside the fingerprint (each pole's in_order/where carries that fact)
                 WriteDiffPole(w, "a", o.A!);
                 WriteDiffPole(w, "b", o.B!);
                 var d = o.Diff!;
@@ -214,7 +214,11 @@ static class JsonWire
         using var ms = new MemoryStream();
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
-            if (o.Error is not null) { w.WriteStartObject(); w.WriteString("error", o.Error); w.WriteEndObject(); }
+            if (o.Error is not null)
+            {
+                // A stamped refusal carries its stamp on the wire too (PR #305 review) — same contract as text.
+                w.WriteStartObject(); w.WriteString("error", o.Error); WriteNullable(w, "epoch", o.Epoch); w.WriteEndObject();
+            }
             else WriteReadRecord(w, o, ms, cap, epoch: o.Epoch);
         }
         return Finish(ms);
@@ -311,13 +315,14 @@ static class JsonWire
                     {
                         // winner_fields=: read the WINNER's body (source=null) regardless of scan scope; the record's
                         // "source" field still names the body read, so the json carries the same source/winner truth.
-                        var o = svc.ResolveRead(fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false, depth, resolveNames: resolveNames, linkMemo: linkMemo);
+                        // Pinned to the scan's build (PR #305 review) — the document's epoch names ONE build.
+                        var o = svc.ResolveReadOn(q, fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false, depth, resolveNames: resolveNames, linkMemo: linkMemo);
                         if (o.Error is not null) { w.WriteStartObject(); w.WriteString("formid", fk.ToString()); w.WriteString("error", o.Error); if (matches is not null) w.WriteString("matches", matches); w.WriteEndObject(); }
                         else WriteReadRecord(w, o, ms, cap, matches);
                     }
                     else
                     {
-                        var m = q.Prefilled is not null ? q.Prefilled[i] : svc.ResolveSummary(fk);
+                        var m = q.Prefilled is not null ? q.Prefilled[i] : svc.ResolveSummaryOn(q, fk);   // pinned to the scan's build
                         WriteSummaryRow(w, m, matches);
                     }
                     rendered++;
@@ -409,8 +414,8 @@ static class JsonWire
                     string? matches = q.MatchedTargets is { } mt && i < mt.Count ? mt[i] : null;
                     if (detail)
                     {
-                        var o = svc.ResolveRead(fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false,
-                                                resolveNames: resolveNames, linkMemo: linkMemo, containerHint: Wire.DenseContainerHint);   // dense refuses depth>1 — hint the format hop with the knob (#231)
+                        var o = svc.ResolveReadOn(q, fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false,
+                                                  resolveNames: resolveNames, linkMemo: linkMemo, containerHint: Wire.DenseContainerHint);   // dense refuses depth>1 — hint the format hop with the knob (#231); pinned to the scan's build
                         if (o.Error is not null) { (errors ??= new()).Add((fk.ToString(), o.Error)); rendered++; continue; }
                         var r = o.Record!;
                         w.WriteStartArray();
@@ -423,7 +428,7 @@ static class JsonWire
                     }
                     else
                     {
-                        var m = q.Prefilled is not null ? q.Prefilled[i] : svc.ResolveSummary(fk);
+                        var m = q.Prefilled is not null ? q.Prefilled[i] : svc.ResolveSummaryOn(q, fk);   // pinned to the scan's build
                         if (m.Error is not null) { (errors ??= new()).Add((m.FormKey.ToString(), m.Error)); rendered++; continue; }
                         w.WriteStartArray();
                         w.WriteStringValue(m.FormKey.ToString());
@@ -513,10 +518,10 @@ static class JsonWire
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
             w.WriteStartObject();
-            if (r.Error is not null) { w.WriteString("error", r.Error); w.WriteEndObject(); return Finish(ms); }
+            if (r.Error is not null) { w.WriteString("error", r.Error); WriteNullable(w, "epoch", r.Epoch); w.WriteEndObject(); return Finish(ms); }
 
             w.WriteNumber("scanned_plugins", r.PluginsScanned);
-            WriteNullable(w, "epoch", r.Epoch);   // §2.1.1: the swept build
+            WriteNullable(w, "epoch", r.Epoch);   // §2.1.1: the swept INDEXED build — off_order_scanned file content is outside the fingerprint
             // null (not 0) for a class nobody looked for — see the summary.
             if (didDangling) { w.WriteNumber("dangling", r.TotalDangling); w.WriteNumber("unscannable_records", r.TotalUnscannableRecords); }
             else { w.WriteNull("dangling"); w.WriteNull("unscannable_records"); }
@@ -591,7 +596,7 @@ static class JsonWire
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
             w.WriteStartObject();
-            if (r.Error is not null) { w.WriteString("error", r.Error); w.WriteEndObject(); return Finish(ms); }
+            if (r.Error is not null) { w.WriteString("error", r.Error); WriteNullable(w, "epoch", r.Epoch); w.WriteEndObject(); return Finish(ms); }
 
             bool didObject = r.Classes.HasFlag(ScriptFindingClass.UnboundObject);
             bool didScalar = r.Classes.HasFlag(ScriptFindingClass.UnboundScalar);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -988,6 +988,10 @@ public sealed class LoadOrderService : IDisposable
     /// </summary>
     public SkyPatcherPostStateData SkyPatcherPostState(FormKey fk)
     {
+        // EPOCH: deliberately NOT stamped (PR #305 third round, named not silent) — this lane answers off the
+        // captured index PLUS the SkyPatcher INI layer, whose files are outside the fingerprint; a bare index
+        // epoch would overclaim exactly the way the off-order diff pole did. The S6 `layer` wave (W5) owns its
+        // epoch treatment, which needs an INI-layer term to be honest.
         var resolver = Resolver;
         var view = resolver.Capture();
         AssetResolver.AssetView assets;
@@ -1093,6 +1097,8 @@ public sealed class LoadOrderService : IDisposable
     /// </summary>
     public SkyPatcherLayerData SkyPatcherLayer()
     {
+        // EPOCH: deliberately NOT stamped — same posture and reason as SkyPatcherPostState above (the INI layer is
+        // outside the index fingerprint; the S6 wave owns an honest, layer-aware stamp).
         var view = Resolver.Capture();
         AssetResolver.AssetView assets;
         IReadOnlyList<string> assetWarnings;
@@ -2158,6 +2164,9 @@ public sealed class LoadOrderService : IDisposable
     /// enrichers — here it just hands core the live record resolver + the VFS asset resolver. NEVER throws over a
     /// verify step: a mid-run resolve/asset failure rides <see cref="DialogueValidationReport.CheckError"/>, and a
     /// not-in-order / not-a-DIAL-or-QUST input is a NAMED <see cref="DialogueValidationReport.Error"/> (Q3).</summary>
+    // EPOCH: deliberately NOT stamped (PR #305 third round, named not silent) — the report is one build's answer
+    // (core pins a view) but half its verdicts come off the ASSET substrate (.fuz/.pex presence), outside the
+    // record fingerprint; the dialogue-fold wave (W3) owns an honest stamp for it.
     public DialogueValidationReport ValidateDialogue(FormKey fk) => DialogueValidate.Run(Resolver, Assets, fk);
 
     /// <summary>The read body, answered entirely off ONE captured view (HCBR-2026-06-11-02): excluded-check, winner,
@@ -2279,13 +2288,7 @@ public sealed class LoadOrderService : IDisposable
     public ConflictTreeView? ResolveTree(FormKey fk, IReadOnlyList<string>? fields)
     {
         var resolver = Resolver;
-        using var session = resolver.OpenSession();
-        var tree = resolver.ResolveTree(session, fk);
-        if (tree is null) return null;
-        var nodes = new List<ConflictNodeView>(tree.Nodes.Count);
-        foreach (var n in tree.Nodes)
-            nodes.Add(new ConflictNodeView(n.Plugin, ReadEngine.ReadFields(n.Record, fields, ConflictDiffDepth)));   // materialise while open
-        return new ConflictTreeView(nodes);
+        return ResolveTreePinned(new ViewPin(resolver, resolver.Capture()), fk, fields);   // one body, two entries (third-round note)
     }
 
     /// <summary>A header-only summary for one record (winner + type + editorid, no field dump) — the compact
@@ -5578,6 +5581,9 @@ public sealed class LoadOrderService : IDisposable
                     // (the only identity frame houseCARL holds) — honest, and a target the active order doesn't define
                     // is marked 'unresolved', not guessed. Opt-in only, so the deliberate no-resolver cheapness of the
                     // default path is untouched; a caller asking for identities accepts the resolver build.
+                    // EPOCH: deliberately NOT stamped even on this arm (PR #305 third round, named not silent) — the
+                    // response's SUBJECT is the raw file, outside the fingerprint; only display annotations touch the
+                    // build. The W2 named() pole that absorbs this tool owns its honest stamp.
                     var view = Resolver.Capture();
                     using var session = Resolver.OpenSession();
                     rf = AnnotateLinks(rf, view, session, new());
@@ -6088,7 +6094,7 @@ public sealed record LoadOrderStatusData(
     string ProfileName,         // the ACTIVE profile (instance mode: MO2's selected_profile; explicit: the dir name) — captured under the gate, not re-derived at render
     string? InstanceDir,        // the resolved MO2 instance folder houseCARL is pointed at; null ⇒ explicit-paths / unconfigured mode
     IReadOnlyDictionary<string, string> ExcludedPlugins,
-    string Epoch = "");         // the resolver's current build fingerprint (SPEC §2.1.1) — the status line names it so a caller can match responses/artifacts to the build
+    string? Epoch = null);      // the resolver's current build fingerprint (SPEC §2.1.1) — the status line names it so a caller can match responses/artifacts to the build; nullable like every other carrier
 
 /// <summary>The data behind housecarl_update_status: MO2's own local Nexus update cache read from meta.ini, with no
 /// network. <see cref="Entries"/> is one row per Nexus-linked mod (installed vs newest version, modid, enabled state);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2164,9 +2164,11 @@ public sealed class LoadOrderService : IDisposable
     /// and touching-plugin list all describe the SAME build — a freshness rebuild landing mid-read can no longer make
     /// a record's reported winner disagree with its own TOUCHING LIST. (The body fetch reads the file on disk through
     /// the session; a mid-read file edit surfaces as the existing named fetch-inconsistency error, never torn values.
-    /// Known residue, review #1: the conflict-tree DIFF the render layer adds is a separate <see cref="ResolveTree"/>
-    /// call with its own capture, so one rendered response can still pair this read's build with an adjacent build's
-    /// diff — same low-severity class, named for the next wave rather than threaded through the render API here.)</summary>
+    /// Known residue, review #1, NARROWED by PR #305's fold: inside a cross-query detail render the tree fill is now
+    /// PINNED to the scan's build (<see cref="ResolveTreeOn"/> via <see cref="CrossQueryOutcome.Pin"/>), so that
+    /// response's epoch stamp holds for its trees too. The single-read/batch conflict-tree renders still take their
+    /// own <see cref="ResolveTree"/> capture — one rendered response there can still pair this read's build with an
+    /// adjacent build's diff; low-severity, named for the wave that reworks those renders.)</summary>
     ReadOutcome ResolveRead(LoadOrderResolver resolver, LoadOrderResolver.IndexView view,
                             FormKey fk, string? plugin, IReadOnlyList<string>? fields, bool conflictTree, int depth,
                             bool resolveNames = false, Dictionary<FormKey, ResolvedRef>? linkMemo = null,
@@ -2290,7 +2292,11 @@ public sealed class LoadOrderService : IDisposable
     public RecordSummary ResolveSummary(FormKey fk)
     {
         var resolver = Resolver;
-        var view = resolver.Capture();                  // one capture per summary (winner + depth + fetch from one build)
+        return ResolveSummary(resolver, resolver.Capture(), fk);   // one capture per summary (winner + depth + fetch from one build)
+    }
+
+    static RecordSummary ResolveSummary(LoadOrderResolver resolver, LoadOrderResolver.IndexView view, FormKey fk)
+    {
         var w = view.ResolveWinner(fk);
         if (w is null) return new RecordSummary(fk, "?", null, "?", 0, $"{fk} not in the load order");
         using var session = resolver.OpenSession();
@@ -2300,6 +2306,47 @@ public sealed class LoadOrderService : IDisposable
                 $"winner '{w.Value.WinnerPlugin}' did not yield {fk} on fetch");
         return new RecordSummary(fk, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID,
                                  w.Value.WinnerPlugin, w.Value.OverrideDepth, null);
+    }
+
+    // ---- pinned per-match fills (PR #305 review) --------------------------------------------------------
+
+    /// <summary>The scan's pinned (resolver, view), carried on <see cref="CrossQueryOutcome.Pin"/> so the render's
+    /// per-match fills read the build the scan matched and the stamped epoch names. Pure data, no handles.</summary>
+    internal sealed record ScanPin(LoadOrderResolver Resolver, LoadOrderResolver.IndexView View);
+
+    /// <summary>The cross-query detail fill, PINNED to the scan's build when the outcome carries one (PR #305
+    /// review): the render loop used to call the public <see cref="ResolveRead(FormKey, string?, IReadOnlyList{string}?, bool, int, bool, Dictionary{FormKey, ResolvedRef}?, string?)"/>,
+    /// which re-gates + re-captures PER ROW — so a freshness rebuild landing mid-render filled the remaining rows
+    /// from a build the header's epoch does not name. Pinning also drops the per-row stat sweep. Bodies are still
+    /// fetched from disk at fill time (Option B holds none) — the pin freezes winner IDENTITY, and a file that
+    /// changed under a pinned fetch surfaces as the named fetch-inconsistency error, never as a silently re-resolved
+    /// winner. Falls back to the public path when the outcome carries no pin (a hand-built outcome in guards).</summary>
+    internal ReadOutcome ResolveReadOn(CrossQueryOutcome q, FormKey fk, string? plugin, IReadOnlyList<string>? fields,
+                                       bool conflictTree, int depth = 1, bool resolveNames = false,
+                                       Dictionary<FormKey, ResolvedRef>? linkMemo = null,
+                                       string? containerHint = ReadEngine.DepthExpandHint)
+        => q.Pin is { } p
+            ? ResolveRead(p.Resolver, p.View, fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo, containerHint)
+              with { Epoch = p.View.Epoch }
+            : ResolveRead(fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo, containerHint);
+
+    /// <summary>The summary twin of <see cref="ResolveReadOn"/> — the conflicts-only lazy fill, pinned to the scan's
+    /// build when the outcome carries one.</summary>
+    internal RecordSummary ResolveSummaryOn(CrossQueryOutcome q, FormKey fk)
+        => q.Pin is { } p ? ResolveSummary(p.Resolver, p.View, fk) : ResolveSummary(fk);
+
+    /// <summary>The conflict-tree twin — the detail render's tree + diff blocks, pinned to the scan's build when the
+    /// outcome carries one (the tree's touching list and the header's epoch then name the same build).</summary>
+    internal ConflictTreeView? ResolveTreeOn(CrossQueryOutcome q, FormKey fk, IReadOnlyList<string>? fields)
+    {
+        if (q.Pin is not { } p) return ResolveTree(fk, fields);
+        using var session = p.Resolver.OpenSession();
+        var tree = p.View.ResolveTree(session, fk);
+        if (tree is null) return null;
+        var nodes = new List<ConflictNodeView>(tree.Nodes.Count);
+        foreach (var n in tree.Nodes)
+            nodes.Add(new ConflictNodeView(n.Plugin, ReadEngine.ReadFields(n.Record, fields, ConflictDiffDepth)));   // materialise while open
+        return new ConflictTreeView(nodes);
     }
 
     /// <summary>The best-effort display Name of a record body — reflection-generic via Mutagen's <c>INamedGetter</c>
@@ -2392,10 +2439,12 @@ public sealed class LoadOrderService : IDisposable
         var view = resolver.Capture();
         using var session = resolver.OpenSession();
 
+        // Post-capture refusals are STAMPED (PR #305 review): an unresolvable pole is an answer about THIS build
+        // (membership, exclusion, on-disk locate against its composition). Pre-capture refusals above carry none.
         var a = ResolveDiffPole(view, session, fk, pluginA.Trim(), modA, fields);
-        if (a.Error is not null) return DiffRecordOutcome.Fail(fidLabel, $"plugin_a: {a.Error}");
+        if (a.Error is not null) return DiffRecordOutcome.Fail(fidLabel, $"plugin_a: {a.Error}") with { Epoch = view.Epoch };
         var b = ResolveDiffPole(view, session, fk, pluginB.Trim(), modB, fields);
-        if (b.Error is not null) return DiffRecordOutcome.Fail(fidLabel, $"plugin_b: {b.Error}");
+        if (b.Error is not null) return DiffRecordOutcome.Fail(fidLabel, $"plugin_b: {b.Error}") with { Epoch = view.Epoch };
 
         // Label the reference side with what the pole RESOLVED to, not the raw argument — a pole addressed by path
         // renders its plugin name in the header, and delta lines quoting the path back would read as a second,
@@ -2487,8 +2536,13 @@ public sealed class LoadOrderService : IDisposable
     /// field-level delta of <see cref="A"/> vs <see cref="B"/> (B the reference side), truncation-honest via Complete.</summary>
     public sealed record DiffRecordOutcome(string Formid, DiffPole? A, DiffPole? B, FieldsDiff.Result? Diff, string? Error)
     {
-        /// <summary>The captured build BOTH poles resolved against (SPEC §2.1.1 epoch fingerprint — a comparison never
-        /// spans two builds, §4.1). Null on the pre-resolve refusals.</summary>
+        /// <summary>The captured INDEX build this call resolved against (SPEC §2.1.1 epoch fingerprint) — one build
+        /// for the whole call (§4.1), stamped on success and on every post-capture refusal; null only on the
+        /// pre-capture refusals (bad FormID / missing pole name). COVERAGE (PR #305 review): the fingerprint
+        /// describes the ACTIVE ORDER only. An OUT-OF-LOAD-ORDER pole's file is located on disk outside the index,
+        /// so its content is NOT under this fingerprint — an edit to that file changes the deltas without changing
+        /// the epoch. The per-pole <see cref="DiffPole.InOrder"/>/<see cref="DiffPole.Where"/> carry which pole
+        /// that is, and the renders qualify the stamp when one applies.</summary>
         public string? Epoch { get; init; }
 
         public static DiffRecordOutcome Fail(string formid, string error) => new(formid, null, null, null, error);
@@ -2799,7 +2853,8 @@ public sealed class LoadOrderService : IDisposable
         return new CrossQueryOutcome(keys, prefilled, total, groups is null && total > offset + keys.Count, null,
                                      predicate?.AccountingNote(), sources, scanNote,
                                      matched, groupRows, groupBy, definedIn ? string.Join(", ", plugins!) : null, offset,
-                                     whereWinner, whereSourceNote) { Epoch = view.Epoch };
+                                     whereWinner, whereSourceNote)
+               { Epoch = view.Epoch, Pin = new ScanPin(resolver, view) };
     }
 
     // ---- effect-chain resolver (housecarl_effect_chain — gap 2026-06-08) --------------------------------
@@ -2875,13 +2930,17 @@ public sealed class LoadOrderService : IDisposable
                 if (view.ContainsPlugin(n)) { active.Add(n); continue; }
                 comp ??= Mo2LoadOrder.ReadComposition(profileDir);
                 var loc = LocatePluginFileOnDisk(comp, modsDir, dataDir, overwriteDir, n, null);
+                // Membership/locate refusals are decided against THIS captured build + its composition — stamped
+                // (PR #305 review, the refusal contract). The parse refusals above consulted no build and stay null.
                 if (loc.Error is not null)
-                    return ErrorCheckResult.Fail($"plugin not in the load order: {n} — and no on-disk copy was found either ({loc.Error})");
+                    return ErrorCheckResult.Fail($"plugin not in the load order: {n} — and no on-disk copy was found either ({loc.Error})")
+                           with { Epoch = view.Epoch };
                 if (loc.Ambiguous is not null)
                     return ErrorCheckResult.Fail(
                         $"plugin '{n}' is not in the active load order and {loc.Ambiguous.Count} mod folders provide a file with that name " +
                         $"({string.Join(", ", loc.Ambiguous.Select(h => h.Where))}) — ambiguous, refusing to guess which to sweep. " +
-                        "Enable the one you mean in MO2, or remove the duplicates.");
+                        "Enable the one you mean in MO2, or remove the duplicates.")
+                           with { Epoch = view.Epoch };
                 offOrder.Add((n, loc.Path!));
             }
             return ErrorCheck.Run(Resolver, active, limit, offOrder.Count > 0 ? offOrder : null,
@@ -5922,6 +5981,13 @@ public sealed record CrossQueryOutcome(
     /// <summary>The captured build the SCAN ran over (SPEC §2.1.1 epoch fingerprint) — the render stamps it into the
     /// in-band accounting so paged windows (offset=) are checkably from the SAME build. Null on the pre-scan refusals.</summary>
     public string? Epoch { get; init; }
+
+    /// <summary>The scan's pinned (resolver, view) — carried so the RENDER's per-match fills (detail bodies,
+    /// summaries, conflict trees) read off the SAME build the scan matched and <see cref="Epoch"/> names (PR #305
+    /// review: the fills used to re-capture per row through the public read path, so a freshness rebuild landing
+    /// mid-render made the response an affirmative single-build claim it didn't satisfy). Pure data — an immutable
+    /// snapshot reference, no handles held. Internal: a render implementation detail, never serialized.</summary>
+    internal LoadOrderService.ScanPin? Pin { get; init; }
 
     public static CrossQueryOutcome Fail(string error) => new(Array.Empty<FormKey>(), null, 0, false, error);
 }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1680,10 +1680,10 @@ public sealed class LoadOrderService : IDisposable
         : $"'{s.LooseFilePath}'";
 
     /// <summary>Whole-order stats (forces the lazy build). For the server's stand-up / health check.</summary>
-    public (int plugins, int records, int conflicts, int maxDepth, IReadOnlyList<string> loadFailures) Stats()
+    public (int plugins, int records, int conflicts, int maxDepth, IReadOnlyList<string> loadFailures, string epoch) Stats()
     {
         var view = Resolver.Capture();          // ONE build for every counter in the line (HCBR-2026-06-11-02)
-        return (view.PluginCount, view.RecordCount, view.ConflictCount, view.MaxDepth, view.LoadFailures);
+        return (view.PluginCount, view.RecordCount, view.ConflictCount, view.MaxDepth, view.LoadFailures, view.Epoch);
     }
 
     /// <summary>Diagnostic snapshot for housecarl_load_order_status: the CURRENT enabled/disabled composition (read fresh
@@ -1709,7 +1709,8 @@ public sealed class LoadOrderService : IDisposable
         }
         var comp = Mo2LoadOrder.ReadComposition(profileDir);       // FRESH composition (always current)
         return new LoadOrderStatusData(
-            comp, warnings, view.PluginCount, _maxPlugins, profileChanged, profileDir, profileName, instanceDir, view.ExcludedPlugins);
+            comp, warnings, view.PluginCount, _maxPlugins, profileChanged, profileDir, profileName, instanceDir, view.ExcludedPlugins,
+            view.Epoch);
     }
 
     /// <summary>Read MO2's OWN local Nexus update cache — the modid / version / newestVersion / ignoredVersion /
@@ -2142,7 +2143,9 @@ public sealed class LoadOrderService : IDisposable
                                    string? containerHint = ReadEngine.DepthExpandHint)
     {
         var resolver = Resolver;
-        return ResolveRead(resolver, resolver.Capture(), fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo, containerHint);
+        var view = resolver.Capture();
+        return ResolveRead(resolver, view, fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo, containerHint)
+               with { Epoch = view.Epoch };   // stamped HERE, off the view actually read — never off a post-read re-capture
     }
 
     /// <summary>Layer B unit C2 — the on-demand whole-topic dialogue-graph validator (housecarl_validate_dialogue):
@@ -2340,10 +2343,17 @@ public sealed class LoadOrderService : IDisposable
     /// yields a per-item result carrying its reason (Error for a malformed string, Resolved=false for a valid-but-absent
     /// FormKey) without failing the whole batch (Q3, the batch_record_detail convention). Deliberately minimal — no
     /// fields/depth/conflict_tree; anything richer is housecarl_batch_record_detail's job.</summary>
-    public IReadOnlyList<ResolvedRef> ResolveRefs(IReadOnlyList<string> formids)
+    public IReadOnlyList<ResolvedRef> ResolveRefs(IReadOnlyList<string> formids) => ResolveRefs(formids, out _);
+
+    /// <summary>As above, also handing back the captured build's <paramref name="epoch"/> fingerprint — the batch is
+    /// ONE capture, and the render stamps that identity into the response's in-band accounting (SPEC §2.1.1).
+    /// <see cref="ResolvedRef"/> itself stays epoch-free: it is core's per-row identity DTO, reused as the
+    /// resolve_names annotation, where a per-row stamp would be noise.</summary>
+    public IReadOnlyList<ResolvedRef> ResolveRefs(IReadOnlyList<string> formids, out string epoch)
     {
         var resolver = Resolver;
         var view = resolver.Capture();                  // ONE build for the whole batch (HCBR-2026-06-11-02)
+        epoch = view.Epoch;
         using var session = resolver.OpenSession();
         var memo = new Dictionary<FormKey, ResolvedRef>();
         var results = new List<ResolvedRef>(formids.Count);
@@ -2391,7 +2401,7 @@ public sealed class LoadOrderService : IDisposable
         // renders its plugin name in the header, and delta lines quoting the path back would read as a second,
         // different plugin.
         var diff = FieldsDiff.Compare(a.Fields!, b.Fields!, referenceLabel: b.Pole!.Plugin);
-        return new DiffRecordOutcome(fidLabel, a.Pole!, b.Pole!, diff, null);
+        return new DiffRecordOutcome(fidLabel, a.Pole!, b.Pole!, diff, null) { Epoch = view.Epoch };
     }
 
     /// <summary>Resolve ONE diff pole: the named plugin's version of <paramref name="fk"/> + its deep-read fields. An
@@ -2477,6 +2487,10 @@ public sealed class LoadOrderService : IDisposable
     /// field-level delta of <see cref="A"/> vs <see cref="B"/> (B the reference side), truncation-honest via Complete.</summary>
     public sealed record DiffRecordOutcome(string Formid, DiffPole? A, DiffPole? B, FieldsDiff.Result? Diff, string? Error)
     {
+        /// <summary>The captured build BOTH poles resolved against (SPEC §2.1.1 epoch fingerprint — a comparison never
+        /// spans two builds, §4.1). Null on the pre-resolve refusals.</summary>
+        public string? Epoch { get; init; }
+
         public static DiffRecordOutcome Fail(string formid, string error) => new(formid, null, null, null, error);
     }
 
@@ -2500,7 +2514,8 @@ public sealed class LoadOrderService : IDisposable
             FormKey fk;
             try { fk = FormKey.Factory(raw.Trim()); }
             catch (Exception ex) { outcomes.Add(ReadOutcome.Fail(default, $"bad FormID '{raw}': {ex.Message}")); continue; }
-            outcomes.Add(ResolveRead(resolver, view, fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo));
+            outcomes.Add(ResolveRead(resolver, view, fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo)
+                         with { Epoch = view.Epoch });   // the batch's ONE build, stamped per item (SPEC §2.1.1)
         }
         return outcomes;
     }
@@ -2784,7 +2799,7 @@ public sealed class LoadOrderService : IDisposable
         return new CrossQueryOutcome(keys, prefilled, total, groups is null && total > offset + keys.Count, null,
                                      predicate?.AccountingNote(), sources, scanNote,
                                      matched, groupRows, groupBy, definedIn ? string.Join(", ", plugins!) : null, offset,
-                                     whereWinner, whereSourceNote);
+                                     whereWinner, whereSourceNote) { Epoch = view.Epoch };
     }
 
     // ---- effect-chain resolver (housecarl_effect_chain — gap 2026-06-08) --------------------------------
@@ -5881,6 +5896,11 @@ public sealed record ReadOutcome(
     IReadOnlyList<string>? TouchingPlugins,
     string? Error)
 {
+    /// <summary>The captured build this outcome was answered from (SPEC §2.1.1 epoch fingerprint) — stamped at the
+    /// Capture() boundary (the public ResolveRead / ResolveBatch), so refusals carry it too: a "not present" is an
+    /// answer ABOUT a build. Null only where no view was ever consulted (a malformed-FormID parse failure).</summary>
+    public string? Epoch { get; init; }
+
     public static ReadOutcome Fail(FormKey fk, string error) => new(fk, null, null, null, 0, null, error);
 }
 
@@ -5899,6 +5919,10 @@ public sealed record CrossQueryOutcome(
     string? GroupBy = null, string? ScopeLabel = null, int Offset = 0,
     bool WhereWinner = false, string? WhereSourceNote = null)   // #233: WhereWinner ⇒ the match decided on the live winner; WhereSourceNote carries the type=-scope redundancy note
 {
+    /// <summary>The captured build the SCAN ran over (SPEC §2.1.1 epoch fingerprint) — the render stamps it into the
+    /// in-band accounting so paged windows (offset=) are checkably from the SAME build. Null on the pre-scan refusals.</summary>
+    public string? Epoch { get; init; }
+
     public static CrossQueryOutcome Fail(string error) => new(Array.Empty<FormKey>(), null, 0, false, error);
 }
 
@@ -5980,7 +6004,8 @@ public sealed record LoadOrderStatusData(
     string ProfileDir,
     string ProfileName,         // the ACTIVE profile (instance mode: MO2's selected_profile; explicit: the dir name) — captured under the gate, not re-derived at render
     string? InstanceDir,        // the resolved MO2 instance folder houseCARL is pointed at; null ⇒ explicit-paths / unconfigured mode
-    IReadOnlyDictionary<string, string> ExcludedPlugins);
+    IReadOnlyDictionary<string, string> ExcludedPlugins,
+    string Epoch = "");         // the resolver's current build fingerprint (SPEC §2.1.1) — the status line names it so a caller can match responses/artifacts to the build
 
 /// <summary>The data behind housecarl_update_status: MO2's own local Nexus update cache read from meta.ini, with no
 /// network. <see cref="Entries"/> is one row per Nexus-linked mod (installed vs newest version, modid, enabled state);

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2145,7 +2145,7 @@ public sealed class LoadOrderService : IDisposable
         var resolver = Resolver;
         var view = resolver.Capture();
         return ResolveRead(resolver, view, fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo, containerHint)
-               with { Epoch = view.Epoch };   // stamped HERE, off the view actually read — never off a post-read re-capture
+               with { Epoch = view.Epoch, Pin = new ViewPin(resolver, view) };   // stamped + pinned HERE, off the view actually read
     }
 
     /// <summary>Layer B unit C2 — the on-demand whole-topic dialogue-graph validator (housecarl_validate_dialogue):
@@ -2164,11 +2164,12 @@ public sealed class LoadOrderService : IDisposable
     /// and touching-plugin list all describe the SAME build — a freshness rebuild landing mid-read can no longer make
     /// a record's reported winner disagree with its own TOUCHING LIST. (The body fetch reads the file on disk through
     /// the session; a mid-read file edit surfaces as the existing named fetch-inconsistency error, never torn values.
-    /// Known residue, review #1, NARROWED by PR #305's fold: inside a cross-query detail render the tree fill is now
-    /// PINNED to the scan's build (<see cref="ResolveTreeOn"/> via <see cref="CrossQueryOutcome.Pin"/>), so that
-    /// response's epoch stamp holds for its trees too. The single-read/batch conflict-tree renders still take their
-    /// own <see cref="ResolveTree"/> capture — one rendered response there can still pair this read's build with an
-    /// adjacent build's diff; low-severity, named for the wave that reworks those renders.)</summary>
+    /// The review-#1 residue is CLOSED by PR #305's fold + re-review fold: every <see cref="ReadOutcome"/> — single
+    /// read, batch item, cross-query detail row — carries the <see cref="ViewPin"/> it was answered from, and the
+    /// render's conflict-tree fill (<see cref="ResolveTreePinned"/>) reads through it, so one rendered response's
+    /// tree, touching list, and epoch stamp all name the same build. What Option B still leaves open, uniformly and
+    /// by design: bodies are fetched from disk at fill time, so a file edited mid-render surfaces as the named
+    /// fetch-inconsistency error — never as a silently re-resolved winner.)</summary>
     ReadOutcome ResolveRead(LoadOrderResolver resolver, LoadOrderResolver.IndexView view,
                             FormKey fk, string? plugin, IReadOnlyList<string>? fields, bool conflictTree, int depth,
                             bool resolveNames = false, Dictionary<FormKey, ResolvedRef>? linkMemo = null,
@@ -2310,9 +2311,11 @@ public sealed class LoadOrderService : IDisposable
 
     // ---- pinned per-match fills (PR #305 review) --------------------------------------------------------
 
-    /// <summary>The scan's pinned (resolver, view), carried on <see cref="CrossQueryOutcome.Pin"/> so the render's
-    /// per-match fills read the build the scan matched and the stamped epoch names. Pure data, no handles.</summary>
-    internal sealed record ScanPin(LoadOrderResolver Resolver, LoadOrderResolver.IndexView View);
+    /// <summary>A pinned (resolver, view) pair, carried on <see cref="CrossQueryOutcome.Pin"/> and
+    /// <see cref="ReadOutcome.Pin"/> so the RENDER-time fills a response makes (cross-query detail bodies, lazy
+    /// summaries, conflict-tree blocks) read the build the outcome's epoch names — never a fresh capture of an
+    /// adjacent build (PR #305 review + re-review). Pure data, no handles.</summary>
+    internal sealed record ViewPin(LoadOrderResolver Resolver, LoadOrderResolver.IndexView View);
 
     /// <summary>The cross-query detail fill, PINNED to the scan's build when the outcome carries one (PR #305
     /// review): the render loop used to call the public <see cref="ResolveRead(FormKey, string?, IReadOnlyList{string}?, bool, int, bool, Dictionary{FormKey, ResolvedRef}?, string?)"/>,
@@ -2327,7 +2330,7 @@ public sealed class LoadOrderService : IDisposable
                                        string? containerHint = ReadEngine.DepthExpandHint)
         => q.Pin is { } p
             ? ResolveRead(p.Resolver, p.View, fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo, containerHint)
-              with { Epoch = p.View.Epoch }
+              with { Epoch = p.View.Epoch, Pin = p }
             : ResolveRead(fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo, containerHint);
 
     /// <summary>The summary twin of <see cref="ResolveReadOn"/> — the conflicts-only lazy fill, pinned to the scan's
@@ -2335,11 +2338,11 @@ public sealed class LoadOrderService : IDisposable
     internal RecordSummary ResolveSummaryOn(CrossQueryOutcome q, FormKey fk)
         => q.Pin is { } p ? ResolveSummary(p.Resolver, p.View, fk) : ResolveSummary(fk);
 
-    /// <summary>The conflict-tree twin — the detail render's tree + diff blocks, pinned to the scan's build when the
-    /// outcome carries one (the tree's touching list and the header's epoch then name the same build).</summary>
-    internal ConflictTreeView? ResolveTreeOn(CrossQueryOutcome q, FormKey fk, IReadOnlyList<string>? fields)
+    /// <summary>The conflict-tree fill off a PINNED build (PR #305 review + re-review) — used by the render whenever
+    /// the outcome it is decorating carries a <see cref="ViewPin"/> (single reads, batch items, and cross-query
+    /// detail rows all do), so the tree's membership and the response's epoch stamp name the same build.</summary>
+    internal ConflictTreeView? ResolveTreePinned(ViewPin p, FormKey fk, IReadOnlyList<string>? fields)
     {
-        if (q.Pin is not { } p) return ResolveTree(fk, fields);
         using var session = p.Resolver.OpenSession();
         var tree = p.View.ResolveTree(session, fk);
         if (tree is null) return null;
@@ -2561,6 +2564,7 @@ public sealed class LoadOrderService : IDisposable
     {
         var resolver = Resolver;                // build/refresh ONCE for the batch
         var view = resolver.Capture();          // ONE build for every item — the whole batch is one logical operation (HCBR-2026-06-11-02)
+        var pin = new ViewPin(resolver, view);
         var linkMemo = resolveNames ? new Dictionary<FormKey, ResolvedRef>() : null;   // P7: one link-resolution cache across the WHOLE batch
         var outcomes = new List<ReadOutcome>(formids.Count);
         foreach (var raw in formids)
@@ -2569,7 +2573,7 @@ public sealed class LoadOrderService : IDisposable
             try { fk = FormKey.Factory(raw.Trim()); }
             catch (Exception ex) { outcomes.Add(ReadOutcome.Fail(default, $"bad FormID '{raw}': {ex.Message}")); continue; }
             outcomes.Add(ResolveRead(resolver, view, fk, plugin, fields, conflictTree, depth, resolveNames, linkMemo)
-                         with { Epoch = view.Epoch });   // the batch's ONE build, stamped per item (SPEC §2.1.1)
+                         with { Epoch = view.Epoch, Pin = pin });   // the batch's ONE build, stamped + pinned per item (SPEC §2.1.1)
         }
         return outcomes;
     }
@@ -2854,7 +2858,7 @@ public sealed class LoadOrderService : IDisposable
                                      predicate?.AccountingNote(), sources, scanNote,
                                      matched, groupRows, groupBy, definedIn ? string.Join(", ", plugins!) : null, offset,
                                      whereWinner, whereSourceNote)
-               { Epoch = view.Epoch, Pin = new ScanPin(resolver, view) };
+               { Epoch = view.Epoch, Pin = new ViewPin(resolver, view) };
     }
 
     // ---- effect-chain resolver (housecarl_effect_chain — gap 2026-06-08) --------------------------------
@@ -2915,9 +2919,15 @@ public sealed class LoadOrderService : IDisposable
         if (!SweepFindings.TryParseErrorClasses(findings, out var classes, out var classErr))
             return ErrorCheckResult.Fail(classErr!);
 
+        // ONE resolver + ONE view for the whole call (PR #305 re-review): the scope gate, the refusal stamps, and
+        // the sweep below all name the same build — passing the PROPERTY down would let the core re-gate/refresh
+        // and capture an adjacent build, making a refusal stamp N while the sweep stamped N+1.
+        var resolver = Resolver;
+        var viewAll = resolver.Capture();
+
         if (plugins is { Count: > 0 })
         {
-            var view = Resolver.Capture();
+            var view = viewAll;
             var active = new List<string>();
             var offOrder = new List<(string Name, string Path)>();
             string modsDir, dataDir, overwriteDir, profileDir;
@@ -2943,10 +2953,10 @@ public sealed class LoadOrderService : IDisposable
                            with { Epoch = view.Epoch };
                 offOrder.Add((n, loc.Path!));
             }
-            return ErrorCheck.Run(Resolver, active, limit, offOrder.Count > 0 ? offOrder : null,
+            return ErrorCheck.Run(resolver, viewAll, active, limit, offOrder.Count > 0 ? offOrder : null,
                                   recordScope, classes, countsOnly);
         }
-        return ErrorCheck.Run(Resolver, plugins, limit, null, recordScope, classes, countsOnly);
+        return ErrorCheck.Run(resolver, viewAll, plugins, limit, null, recordScope, classes, countsOnly);
     }
 
     /// <summary>Parse the two sweep tools' shared record-scope params (#282) into a <see cref="SweepScope"/>: FormID
@@ -2999,7 +3009,9 @@ public sealed class LoadOrderService : IDisposable
         if (scopeErr is not null) return ScriptCheckResult.Fail(scopeErr);
         if (!SweepFindings.TryParseScriptClasses(findings, out var classes, out var classErr))
             return ScriptCheckResult.Fail(classErr!);
-        return ScriptPropertyCheck.Run(Resolver, Assets, plugins, limit, recordScope, propertyContains, classes, countsOnly);
+        // ONE resolver + view threaded through, same contract as CheckErrors (PR #305 re-review).
+        var resolver = Resolver;
+        return ScriptPropertyCheck.Run(resolver, resolver.Capture(), Assets, plugins, limit, recordScope, propertyContains, classes, countsOnly);
     }
 
     // ---- writes (§8.4 Beat C: housecarl_set_field / housecarl_bulk_apply) -------------------------------
@@ -5960,6 +5972,11 @@ public sealed record ReadOutcome(
     /// answer ABOUT a build. Null only where no view was ever consulted (a malformed-FormID parse failure).</summary>
     public string? Epoch { get; init; }
 
+    /// <summary>The (resolver, view) this outcome was answered from — carried beside <see cref="Epoch"/> so the
+    /// RENDER's conflict-tree fill reads the SAME build the stamp names (PR #305 re-review; the pin that closed
+    /// the cross-query fills closes the single-read/batch tree fills identically). Internal render plumbing.</summary>
+    internal LoadOrderService.ViewPin? Pin { get; init; }
+
     public static ReadOutcome Fail(FormKey fk, string error) => new(fk, null, null, null, 0, null, error);
 }
 
@@ -5987,7 +6004,7 @@ public sealed record CrossQueryOutcome(
     /// review: the fills used to re-capture per row through the public read path, so a freshness rebuild landing
     /// mid-render made the response an affirmative single-build claim it didn't satisfy). Pure data — an immutable
     /// snapshot reference, no handles held. Internal: a render implementation detail, never serialized.</summary>
-    internal LoadOrderService.ScanPin? Pin { get; init; }
+    internal LoadOrderService.ViewPin? Pin { get; init; }
 
     public static CrossQueryOutcome Fail(string error) => new(Array.Empty<FormKey>(), null, 0, false, error);
 }

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -486,12 +486,19 @@ static class Wire
     /// TRUNCATED, in which case it says so instead of claiming identical (Q3). On refusal, a single error: line.</summary>
     public static string RenderDiffRecord(LoadOrderService.DiffRecordOutcome o, int maxChars)
     {
-        if (o.Error is not null) return $"error: {o.Error}";
+        if (o.Error is not null) return $"error: {o.Error}" + (o.Epoch is not null ? $"\nepoch={o.Epoch}" : "");
         int cap = Cap(maxChars);
         var a = o.A!; var b = o.B!; var d = o.Diff!;
         var sb = new StringBuilder();
         sb.Append("diff ").Append(o.Formid);
-        if (o.Epoch is not null) sb.Append("  epoch=").Append(o.Epoch);   // §2.1.1: both poles resolved against THIS build
+        if (o.Epoch is not null)
+        {
+            sb.Append("  epoch=").Append(o.Epoch);
+            // The fingerprint covers the ACTIVE ORDER only — an off-order pole's file content sits outside it, so
+            // equal epochs must not be read as "same inputs" across such calls (PR #305 review; the fact itself is
+            // per-pole data: InOrder/Where, rendered on each pole line).
+            if (!a.InOrder || !b.InOrder) sb.Append(" (active-order inputs only — the off-order pole's file is outside the fingerprint)");
+        }
         sb.Append('\n')
           .Append("  a: ").Append(PoleLine(a)).Append('\n')
           .Append("  b: ").Append(PoleLine(b)).Append('\n');
@@ -566,7 +573,9 @@ static class Wire
     // ---- housecarl_read_record ----------------------------------------------------------------------
     public static string RenderRecord(LoadOrderService svc, ReadOutcome o, IReadOnlyList<string>? fields, bool conflictTree, int maxChars)
     {
-        if (o.Error is not null) return "error: " + o.Error;
+        // A stamped refusal renders its stamp (PR #305 review): "not present" is an answer about a build, and the
+        // wire must say WHICH — the DTO carrying it while the render dropped it was the unmet half of the contract.
+        if (o.Error is not null) return "error: " + o.Error + (o.Epoch is not null ? $"\nepoch={o.Epoch}" : "");
         var sb = new StringBuilder();
         AppendRecord(sb, o, Cap(maxChars));
         if (conflictTree) AppendConflictTree(sb, svc, o, fields, Cap(maxChars));
@@ -662,15 +671,17 @@ static class Wire
             {
                 // winner_fields=: read the load-order WINNER's body (source=null) regardless of scan scope; else the
                 // body the scan filtered (scoped plugin under plugins=, else winner) — so display never contradicts filter.
-                var o = svc.ResolveRead(fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, conflictTree, depth, resolveNames: resolveNames, linkMemo: linkMemo);
+                // PINNED to the scan's build (ResolveReadOn / the q-carrying AppendConflictTree): the header's epoch
+                // names ONE build, so every fill must read it (PR #305 review).
+                var o = svc.ResolveReadOn(q, fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, conflictTree, depth, resolveNames: resolveNames, linkMemo: linkMemo);
                 sb.Append('\n');
                 if (matches is not null) sb.Append("  ").Append(fk).Append("  matches=").Append(matches).Append('\n');
                 if (o.Error is not null) sb.Append(fk).Append(": error: ").Append(o.Error).Append('\n');
-                else { AppendRecord(sb, o, cap); if (conflictTree) AppendConflictTree(sb, svc, o, fields, cap); }
+                else { AppendRecord(sb, o, cap); if (conflictTree) AppendConflictTree(sb, svc, o, fields, cap, q); }
             }
             else
             {
-                var m = q.Prefilled is not null ? q.Prefilled[i] : svc.ResolveSummary(fk);   // lazy fill for conflicts-only
+                var m = q.Prefilled is not null ? q.Prefilled[i] : svc.ResolveSummaryOn(q, fk);   // lazy fill for conflicts-only, pinned to the scan's build
                 sb.Append("  ").Append(m.FormKey);
                 if (m.Error is not null) sb.Append("  error=").Append(m.Error).Append('\n');
                 else
@@ -722,7 +733,7 @@ static class Wire
     /// stops with the same explicit notice the other read renders use (Q3 — never silent).</summary>
     public static string RenderEffectChain(EffectChainResult r, int maxChars)
     {
-        if (r.Error is not null) return "error: " + r.Error;
+        if (r.Error is not null) return "error: " + r.Error + (r.Epoch is not null ? $"\nepoch={r.Epoch}" : "");
         int cap = Cap(maxChars);
         var sb = new StringBuilder();
         sb.Append("effect_chain for ").Append(r.Mgef).Append(" (").Append(r.MgefEditorId).Append(", MagicEffect): ")
@@ -770,7 +781,7 @@ static class Wire
     /// caller EXCLUDED renders as "NOT CHECKED", never as a 0, so a skipped check can never be read as a clean one (Q3).</summary>
     public static string RenderCheckErrors(ErrorCheckResult r, int maxChars, int histogramLimit = 1000)
     {
-        if (r.Error is not null) return "error: " + r.Error;
+        if (r.Error is not null) return "error: " + r.Error + (r.Epoch is not null ? $"\nepoch={r.Epoch}" : "");
         int cap = Cap(maxChars);
         bool didDangling = r.Classes.HasFlag(ErrorFindingClass.Dangling);
         bool didMasters = r.Classes.HasFlag(ErrorFindingClass.MissingMasters);
@@ -783,7 +794,7 @@ static class Wire
           .Append(didDangling ? $"{r.TotalUnscannableRecords} unscannable record(s)" : "unscannable records NOT COUNTED (the record walk was skipped)");
         if (r.ExcludedPlugins.Count > 0)
             sb.Append(" · ").Append(r.ExcludedPlugins.Count).Append(" plugin(s) excluded (unparseable)");
-        if (r.Epoch is not null) sb.Append(" · epoch=").Append(r.Epoch);
+        if (r.Epoch is not null) sb.Append(" · epoch=").Append(r.Epoch).Append(EpochOffOrderQualifier(r));
         sb.Append('\n');
         if (r.FilterNote is not null) sb.Append(r.FilterNote).Append('\n');
         if (r.OffOrderScanned is { Count: > 0 } off)
@@ -859,6 +870,18 @@ static class Wire
     const string SweepNarrowHint =
         "narrow with type= / formids= / editorid_contains= / findings=, ask counts_only=true for just the totals, or raise max_chars";
 
+    /// <summary>The epoch stamp's coverage qualifier (PR #305 review): when off-order files were swept beside the
+    /// index, the fingerprint does NOT cover their content (they are located on disk, outside the fingerprinted
+    /// order) — say so next to the stamp, so equal epochs are never read as "same inputs" across such sweeps. The
+    /// fact itself is data (the OffOrderScanned list / the json <c>off_order_scanned</c> array); this qualifier is
+    /// its header-line rendering.</summary>
+    static string EpochOffOrderQualifier(ErrorCheckResult r) =>
+        r.OffOrderScanned is { Count: > 0 } ? " (indexed plugins only — off-order file content is outside the fingerprint)" : "";
+
+    /// <summary>validate_scripts has no off-order lane — its stamp always covers everything it swept. The overload
+    /// exists so the two sweep headers stay textually identical (one shape, no drift).</summary>
+    static string EpochOffOrderQualifier(ScriptCheckResult r) => "";
+
     /// <summary>Render a <c>counts_only=</c> histogram, capped at <paramref name="rowLimit"/> with the true distinct-key
     /// count always stated. A null histogram means the mode was not requested; an EMPTY one means the sweep genuinely
     /// found nothing, and the two read differently (Q3).</summary>
@@ -917,7 +940,7 @@ static class Wire
     /// <c>counts_only=</c> histogram rows.</summary>
     public static string RenderScriptCheck(ScriptCheckResult r, int maxChars, int histogramLimit = 1000)
     {
-        if (r.Error is not null) return "error: " + r.Error;
+        if (r.Error is not null) return "error: " + r.Error + (r.Epoch is not null ? $"\nepoch={r.Epoch}" : "");
         int cap = Cap(maxChars);
         var sb = new StringBuilder();
 
@@ -937,7 +960,7 @@ static class Wire
           .Append(r.TotalUnverifiable).Append(" unverifiable");
         if (r.ExcludedPlugins.Count > 0)
             sb.Append(" · ").Append(r.ExcludedPlugins.Count).Append(" plugin(s) excluded (unparseable)");
-        if (r.Epoch is not null) sb.Append(" · epoch=").Append(r.Epoch);
+        if (r.Epoch is not null) sb.Append(" · epoch=").Append(r.Epoch).Append(EpochOffOrderQualifier(r));
         sb.Append('\n');
         if (r.FilterNote is not null) sb.Append(r.FilterNote).Append('\n');
         if (r.ReadIncomplete)
@@ -1080,7 +1103,11 @@ static class Wire
     /// winner-relative field diff — each other plugin's only-the-fields-that-differ, as `path=theirs (winner X)`.
     /// Bodies come from <see cref="LoadOrderService.ResolveTree"/> (on-demand fetch, held by nothing). The diff
     /// is char-budget-bounded: over <paramref name="cap"/> it stops with an explicit notice (Q3).</summary>
-    static void AppendConflictTree(StringBuilder sb, LoadOrderService svc, ReadOutcome o, IReadOnlyList<string>? fields, int cap)
+    /// <param name="pin">When rendering inside a cross-query detail loop, the outcome whose scan pin the tree fill
+    /// must read from (PR #305 review — the header's epoch names one build; the tree must not re-capture). Null on
+    /// the single-read/batch paths, which keep their own (documented) capture.</param>
+    static void AppendConflictTree(StringBuilder sb, LoadOrderService svc, ReadOutcome o, IReadOnlyList<string>? fields, int cap,
+                                   CrossQueryOutcome? pin = null)
     {
         var tp = o.TouchingPlugins;
         if (tp is null) return;
@@ -1098,7 +1125,8 @@ static class Wire
         }
 
         if (tp.Count <= 1) return;                                         // nothing to diff against
-        var tree = svc.ResolveTree(o.FormKey, fields);                     // materialised (no live overlay) — Option B
+        var tree = pin is not null ? svc.ResolveTreeOn(pin, o.FormKey, fields)
+                                   : svc.ResolveTree(o.FormKey, fields);   // materialised (no live overlay) — Option B
         if (tree is null || tree.Nodes.Count <= 1) return;
 
         var winnerNode = tree.Winner;                                       // Nodes[^1] = highest priority = the winner

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -247,8 +247,8 @@ public static class ReadTools
         if (formids is null || formids.Length == 0) return "error: formids is empty. Pass one or more 'XXXXXX:Plugin.esp' FormIDs.";
         bool json = Wire.WantsJson(format, out var ferr);
         if (ferr is not null) return ferr;
-        var rows = svc.ResolveRefs(formids);
-        return json ? JsonWire.RenderResolve(rows, max_chars) : Wire.RenderResolve(rows, max_chars);
+        var rows = svc.ResolveRefs(formids, out var epoch);
+        return json ? JsonWire.RenderResolve(rows, max_chars, epoch) : Wire.RenderResolve(rows, max_chars, epoch);
     });
 
     [McpServerTool(Name = "housecarl_effect_chain", ReadOnly = true, Title = "Resolve an effect's carriers + magnitudes"),
@@ -490,7 +490,9 @@ static class Wire
         int cap = Cap(maxChars);
         var a = o.A!; var b = o.B!; var d = o.Diff!;
         var sb = new StringBuilder();
-        sb.Append("diff ").Append(o.Formid).Append('\n')
+        sb.Append("diff ").Append(o.Formid);
+        if (o.Epoch is not null) sb.Append("  epoch=").Append(o.Epoch);   // §2.1.1: both poles resolved against THIS build
+        sb.Append('\n')
           .Append("  a: ").Append(PoleLine(a)).Append('\n')
           .Append("  b: ").Append(PoleLine(b)).Append('\n');
 
@@ -533,11 +535,12 @@ static class Wire
     /// <summary>Render the bulk name-resolution result (housecarl_resolve — P3): one compact identity line per input
     /// FormID (type/editorid/name/winner), or <c>error=</c> for a bad/absent input (per-item, the batch survives — Q3).
     /// Budget-bounded with the same explicit cut the other reads use.</summary>
-    public static string RenderResolve(IReadOnlyList<ResolvedRef> rows, int maxChars)
+    public static string RenderResolve(IReadOnlyList<ResolvedRef> rows, int maxChars, string epoch)
     {
         int cap = Cap(maxChars);
         var sb = new StringBuilder();
-        sb.Append("resolve: ").Append(rows.Count).Append(rows.Count == 1 ? " formid\n" : " formids\n");
+        sb.Append("resolve: ").Append(rows.Count).Append(rows.Count == 1 ? " formid" : " formids")
+          .Append("  epoch=").Append(epoch).Append('\n');
         for (int i = 0; i < rows.Count; i++)
         {
             if (sb.Length >= cap)
@@ -567,6 +570,7 @@ static class Wire
         var sb = new StringBuilder();
         AppendRecord(sb, o, Cap(maxChars));
         if (conflictTree) AppendConflictTree(sb, svc, o, fields, Cap(maxChars));
+        if (o.Epoch is not null) sb.Append("epoch=").Append(o.Epoch).Append('\n');   // §2.1.1: the build this read answered from
         return sb.ToString().TrimEnd('\n');
     }
 
@@ -575,7 +579,11 @@ static class Wire
     {
         int cap = Cap(maxChars);
         var sb = new StringBuilder();
-        sb.Append("batch: ").Append(outcomes.Count).Append(outcomes.Count == 1 ? " record\n" : " records\n");
+        sb.Append("batch: ").Append(outcomes.Count).Append(outcomes.Count == 1 ? " record" : " records");
+        // The whole batch reads ONE captured build (ResolveBatch), so its epoch is response-level accounting —
+        // first non-null (a malformed-FormID row never consulted a view and carries none).
+        if (outcomes.FirstOrDefault(o => o.Epoch is not null)?.Epoch is { } epoch) sb.Append("  epoch=").Append(epoch);
+        sb.Append('\n');
         int rendered = 0;
         foreach (var o in outcomes)
         {
@@ -627,6 +635,7 @@ static class Wire
             }
         }
         else if (q.Capped) sb.Append(" (showing first ").Append(q.Keys.Count).Append("; raise limit=, page with offset=, or narrow to see more)");
+        if (q.Epoch is not null) sb.Append("  epoch=").Append(q.Epoch);   // §2.1.1: offset= windows tile ONLY within one epoch
         sb.Append('\n');
         if (q.PredicateNote is not null) sb.Append(q.PredicateNote).Append('\n');   // where= Q3 accounting (wrong-path/no-value surface)
         if (q.ScanNote is not null) sb.Append(q.ScanNote).Append('\n');             // unscannable-record Q3 accounting (Mutagen-unparseable content)
@@ -689,6 +698,7 @@ static class Wire
           .Append(q.Total).Append(q.Total == 1 ? " match" : " matches")
           .Append(" across ").Append(groups.Count).Append(groups.Count == 1 ? " group" : " groups");
         if (q.ScopeLabel is not null) sb.Append(" (DEFINED IN ").Append(q.ScopeLabel).Append(')');
+        if (q.Epoch is not null) sb.Append("  epoch=").Append(q.Epoch);
         sb.Append('\n');
         if (q.PredicateNote is not null) sb.Append(q.PredicateNote).Append('\n');
         if (q.ScanNote is not null) sb.Append(q.ScanNote).Append('\n');
@@ -718,6 +728,7 @@ static class Wire
         sb.Append("effect_chain for ").Append(r.Mgef).Append(" (").Append(r.MgefEditorId).Append(", MagicEffect): ")
           .Append(r.Total).Append(r.Total == 1 ? " carrier row" : " carrier rows");
         if (r.Capped) sb.Append(" (showing first ").Append(r.Rows.Count).Append("; raise limit= or narrow to see more)");
+        if (r.Epoch is not null) sb.Append("  epoch=").Append(r.Epoch);
         sb.Append('\n');
         if (r.Total == 0)
             sb.Append("  none — ").Append(r.MgefEditorId)
@@ -772,6 +783,7 @@ static class Wire
           .Append(didDangling ? $"{r.TotalUnscannableRecords} unscannable record(s)" : "unscannable records NOT COUNTED (the record walk was skipped)");
         if (r.ExcludedPlugins.Count > 0)
             sb.Append(" · ").Append(r.ExcludedPlugins.Count).Append(" plugin(s) excluded (unparseable)");
+        if (r.Epoch is not null) sb.Append(" · epoch=").Append(r.Epoch);
         sb.Append('\n');
         if (r.FilterNote is not null) sb.Append(r.FilterNote).Append('\n');
         if (r.OffOrderScanned is { Count: > 0 } off)
@@ -925,6 +937,7 @@ static class Wire
           .Append(r.TotalUnverifiable).Append(" unverifiable");
         if (r.ExcludedPlugins.Count > 0)
             sb.Append(" · ").Append(r.ExcludedPlugins.Count).Append(" plugin(s) excluded (unparseable)");
+        if (r.Epoch is not null) sb.Append(" · epoch=").Append(r.Epoch);
         sb.Append('\n');
         if (r.FilterNote is not null) sb.Append(r.FilterNote).Append('\n');
         if (r.ReadIncomplete)

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -677,7 +677,7 @@ static class Wire
                 sb.Append('\n');
                 if (matches is not null) sb.Append("  ").Append(fk).Append("  matches=").Append(matches).Append('\n');
                 if (o.Error is not null) sb.Append(fk).Append(": error: ").Append(o.Error).Append('\n');
-                else { AppendRecord(sb, o, cap); if (conflictTree) AppendConflictTree(sb, svc, o, fields, cap, q); }
+                else { AppendRecord(sb, o, cap); if (conflictTree) AppendConflictTree(sb, svc, o, fields, cap); }   // o carries the scan's pin
             }
             else
             {
@@ -1103,11 +1103,7 @@ static class Wire
     /// winner-relative field diff — each other plugin's only-the-fields-that-differ, as `path=theirs (winner X)`.
     /// Bodies come from <see cref="LoadOrderService.ResolveTree"/> (on-demand fetch, held by nothing). The diff
     /// is char-budget-bounded: over <paramref name="cap"/> it stops with an explicit notice (Q3).</summary>
-    /// <param name="pin">When rendering inside a cross-query detail loop, the outcome whose scan pin the tree fill
-    /// must read from (PR #305 review — the header's epoch names one build; the tree must not re-capture). Null on
-    /// the single-read/batch paths, which keep their own (documented) capture.</param>
-    static void AppendConflictTree(StringBuilder sb, LoadOrderService svc, ReadOutcome o, IReadOnlyList<string>? fields, int cap,
-                                   CrossQueryOutcome? pin = null)
+    static void AppendConflictTree(StringBuilder sb, LoadOrderService svc, ReadOutcome o, IReadOnlyList<string>? fields, int cap)
     {
         var tp = o.TouchingPlugins;
         if (tp is null) return;
@@ -1125,8 +1121,12 @@ static class Wire
         }
 
         if (tp.Count <= 1) return;                                         // nothing to diff against
-        var tree = pin is not null ? svc.ResolveTreeOn(pin, o.FormKey, fields)
-                                   : svc.ResolveTree(o.FormKey, fields);   // materialised (no live overlay) — Option B
+        // Pinned to the OUTCOME's own build (PR #305 review + re-review): every ReadOutcome — single read, batch
+        // item, cross-query detail row — carries the (resolver, view) it was answered from, so the tree fill and
+        // the response's epoch stamp name the same build. The unpinned fallback exists only for a hand-built
+        // outcome (guards).
+        var tree = o.Pin is { } p ? svc.ResolveTreePinned(p, o.FormKey, fields)
+                                  : svc.ResolveTree(o.FormKey, fields);    // materialised (no live overlay) — Option B
         if (tree is null || tree.Nodes.Count <= 1) return;
 
         var winnerNode = tree.Winner;                                       // Nodes[^1] = highest priority = the winner

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -62,7 +62,9 @@ public static class ReadTools
          "or absent FormID yields a per-item error without failing the batch. With conflict_tree=true each record " +
          "also gets its touching-plugin list + winner-relative field diff. The combined response is size-estimated: " +
          "over the cap it stops with an explicit 'rendered X of N' notice (never silent truncation) — request fewer " +
-         "formids, pass fields= to slim each, or raise max_chars. Does NOT modify anything.")]
+         "formids, pass fields= to slim each, or raise max_chars. The header carries epoch=<hex> — the load-order " +
+         "build identity the WHOLE batch was answered from; a different epoch on a sibling call means the order " +
+         "changed between them. Does NOT modify anything.")]
     public static string BatchRecordDetail(
         LoadOrderService svc,
         [Description("The FormIDs to read, each 'XXXXXX:Plugin.esp'. Resolved in order; results are returned in the same order.")]
@@ -182,7 +184,7 @@ public static class ReadTools
             string? format = null,
         [Description("Optional. Max matches to return (default 500). The TRUE total is always reported; over the cap it says 'showing first N'. Page with offset=.")]
             int limit = 500,
-        [Description("Optional. Skip the first N post-filter matches before returning rows (#223 pagination) — combine with limit= to page a big enumeration in windows (offset=0/500/1000…). Scan order is deterministic while the load order is unchanged, so windows tile exactly. The true total always counts ALL matches. Not valid with group_by= (a count table has no window).")]
+        [Description("Optional. Skip the first N post-filter matches before returning rows (#223 pagination) — combine with limit= to page a big enumeration in windows (offset=0/500/1000…). Scan order is deterministic while the load order is unchanged, so windows tile exactly. The true total always counts ALL matches. Not valid with group_by= (a count table has no window). Every response carries epoch=<hex> in-band — the identity of the load-order build it was answered from: windows tile ONLY within one epoch, so if two pages' epochs differ, the load order changed mid-pagination and the pages must not be stitched (re-run from offset=0).")]
             int offset = 0,
         [Description("Optional. Max characters before the response stops with an explicit notice. 0 = the server default (~80k).")]
             int max_chars = 0) => Guard.Tool("housecarl_cross_plugin_query", () =>
@@ -233,7 +235,9 @@ public static class ReadTools
          "Q3). Winners only (the load-order-effective identity of each target). The engine-implicit forms (PlayerRef " +
          "000014:Skyrim.esm / Player 000007:Skyrim.esm) resolve to their hardcoded identity with winner '<engine>' — " +
          "no plugin defines them, but they are real, never dangling. Deliberately minimal: no fields=, no " +
-         "depth, no conflict_tree — for those use housecarl_batch_record_detail. Does NOT modify anything.")]
+         "depth, no conflict_tree — for those use housecarl_batch_record_detail. The header carries epoch=<hex> — " +
+         "the load-order build identity the whole batch resolved against (differs across calls only when the order " +
+         "changed between them). Does NOT modify anything.")]
     public static string Resolve(
         LoadOrderService svc,
         [Description("The FormIDs to resolve, each 'XXXXXX:Plugin.esp'. Resolved in order; results are returned in the same order.")]
@@ -577,9 +581,11 @@ static class Wire
         // wire must say WHICH — the DTO carrying it while the render dropped it was the unmet half of the contract.
         if (o.Error is not null) return "error: " + o.Error + (o.Epoch is not null ? $"\nepoch={o.Epoch}" : "");
         var sb = new StringBuilder();
+        // Header line, like every other text lane — and BEFORE the cap-bounded body, so a capped record never
+        // overruns its budget to fit the stamp (third-round note).
+        if (o.Epoch is not null) sb.Append("epoch=").Append(o.Epoch).Append('\n');   // §2.1.1: the build this read answered from
         AppendRecord(sb, o, Cap(maxChars));
         if (conflictTree) AppendConflictTree(sb, svc, o, fields, Cap(maxChars));
-        if (o.Epoch is not null) sb.Append("epoch=").Append(o.Epoch).Append('\n');   // §2.1.1: the build this read answered from
         return sb.ToString().TrimEnd('\n');
     }
 

--- a/src/housecarl-mcp/StatusTools.cs
+++ b/src/housecarl-mcp/StatusTools.cs
@@ -73,6 +73,7 @@ static class StatusWire
         sb.Append("  inactive: ").Append(inactive).Append("  (present but unchecked — houseCARL excludes these)\n");
         sb.Append("resolver: ").Append(d.ResolvedPluginCount).Append(" plugins resolved to real files");
         if (d.MaxPlugins > 0) sb.Append(" [capped at MaxPlugins=").Append(d.MaxPlugins).Append(']');
+        if (d.Epoch.Length > 0) sb.Append("  epoch=").Append(d.Epoch);   // §2.1.1: the current build's fingerprint — bulk responses stamp the build THEY read, matched against this
         sb.Append('\n');
         if (d.ProfileChanged)
             sb.Append("[!] the profile changed mid-call and a refresh is still pending — houseCARL re-reads it " +

--- a/src/housecarl-mcp/StatusTools.cs
+++ b/src/housecarl-mcp/StatusTools.cs
@@ -73,7 +73,7 @@ static class StatusWire
         sb.Append("  inactive: ").Append(inactive).Append("  (present but unchecked — houseCARL excludes these)\n");
         sb.Append("resolver: ").Append(d.ResolvedPluginCount).Append(" plugins resolved to real files");
         if (d.MaxPlugins > 0) sb.Append(" [capped at MaxPlugins=").Append(d.MaxPlugins).Append(']');
-        if (d.Epoch.Length > 0) sb.Append("  epoch=").Append(d.Epoch);   // §2.1.1: the current build's fingerprint — bulk responses stamp the build THEY read, matched against this
+        if (d.Epoch is not null) sb.Append("  epoch=").Append(d.Epoch);   // §2.1.1: the current build's fingerprint — bulk responses stamp the build THEY read, matched against this
         sb.Append('\n');
         if (d.ProfileChanged)
             sb.Append("[!] the profile changed mid-call and a refresh is still pending — houseCARL re-reads it " +


### PR DESCRIPTION
## What this is

**houseCARL 2.0, Wave 1 (foundations), PR 1 of 2** — the epoch fingerprint of SPEC §2.1.1, end-to-end. (PR 2 of the wave brings the artifact disposition: `to_file`, auto-spill naming its file, `@file` re-entry — which consumes this fingerprint for its epoch-checked re-entry.)

Every captured index build (`IndexSnapshot`) now carries a deterministic identity: **16 hex chars of SHA-256 over (plugin filename | mtime ticks) in priority order**, computed at `BuildIndex` time and immutable with the snapshot. Properties this buys by construction:

- **Unchanged world ⇒ identical epoch** — across rebuilds *and server restarts* (a restart invalidates nothing; important for the W1-PR2 artifacts).
- **Any content edit, reorder, or set change ⇒ a new epoch** — including *backdated* mtimes (value-compare, matching the resolver's existing restored-backup posture).
- **Immutable with the snapshot** — a concurrent freshness rebuild never changes what an in-flight operation stamps.

## Why (SPEC §2.1.1)

Paged reads (`offset=` windows) that straddle a mid-session load-order change were silently incoherent — pages of one logical result spanning two builds, indistinguishable from a coherent set (failure mode 3 in the artifact-disposition design). Now every response names its build in-band, so drift is *detectable*: two pages whose `epoch` tokens disagree are provably from different worlds. It is also the identity the §2.1.1 artifact manifest and epoch-checked `@file` re-entry (PR 2) are specified against.

## Where it lands

**Stamped at the `Capture()` boundary** (never a post-read re-capture — the stamp names the build actually read):

| Lane | Outcome carrier | Text | JSON |
|---|---|---|---|
| `cross_plugin_query` (all 3 formats + `group_by`) | `CrossQueryOutcome.Epoch` | header `epoch=<hex>` | `"epoch"` beside `total`/`capped` |
| `batch_record_detail` | per-`ReadOutcome`, ONE build per batch | header, once | top-level, once |
| `read_record` | `ReadOutcome.Epoch` | tail line | top-level |
| `resolve` | `ResolveRefs(…, out epoch)` overload | header | beside `count` |
| `diff_record` | `DiffRecordOutcome.Epoch` | header | beside `formid` |
| `effect_chain` | `EffectChainResult.Epoch` (core) | header | — (text-only tool) |
| `check_errors` / `validate_scripts` | result records (core) | header line | beside `scanned_plugins` |
| `load_order_status` | `LoadOrderStatusData.Epoch` | resolver line | — |

**Refusal contract:** a refusal *answered off a build* ("not present in the load order") is stamped — it is an answer about that build. A refusal that never consulted one (malformed FormID, pre-scan validation) stays null and the renders omit it. The guard pins both directions.

**Deliberately NOT stamped** (named, not silent — each carries a comment at its seam): `read_plugin_file` — the response's subject is the raw out-of-load-order file, outside the fingerprint; even its `resolve_names=true` arm only touches the build for display annotations. The W2 `named()` pole that absorbs it owns its honest stamp. `skypatcher_read` / `skypatcher_layer` — index-backed but half their answer is the SkyPatcher INI layer, whose files are outside the fingerprint; a bare index epoch would overclaim (the S6 `layer` wave owns a layer-aware stamp). `validate_dialogue` — one pinned build, but half its verdicts come off the asset substrate (.fuz/.pex presence); the W3 dialogue fold owns it. Non-index substrates (assets/BSA/SKSE) get their treatment at their waves. Cross-query detail fills, lazy summaries, and ALL conflict-tree fills are pinned to the outcome's own captured view (`ViewPin`), so a response's fills and its stamp name one build; Option B still fetches bodies from disk at fill time — a mid-render file edit surfaces as the named fetch-inconsistency error, never a silently re-resolved winner.

## Guard

New standing CI arm **`epoch-guard`** (registered in CiAll): identity (determinism, restart-stability, format, view==resolver) · sensitivity (content/backdated/reorder/set; unchanged order keeps it) · stamps (every lane above incl. both refusal directions and one-epoch-per-batch) · renders (text/json D2 pairing; a mid-session rebuild re-stamps the next response).

**ci-all: 112/112 PASS** (111 pre-existing + epoch-guard). Changelog `## Unreleased` entry included.

## Review pointers

- The fingerprint deliberately hashes **names + mtimes**, not index content — same inputs the freshness sweep trusts, zero added cost per build (`ComputeEpoch` in `LoadOrderResolver.cs`).
- `ScriptCheckResult`/`ErrorCheckResult`/`EffectChainResult` grow a trailing optional positional; `ReadOutcome`/`CrossQueryOutcome`/`DiffRecordOutcome` grow an init-only property — all construction sites source-compatible, probes untouched.
- `Stats()` tuple gains a trailing `epoch` member (existing `.plugins` accessors unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
