### PR TITLE
feat(2.0/W1): the artifact disposition - to_file, auto-spill naming its file, epoch-checked @file re-entry

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -22,8 +22,10 @@ spelling — `formids=["@<path>"]` on `batch_record_detail`/`resolve`, `where=["
 `cross_plugin_query` — yielding the file's identity column ("scan once, project forever"), and re-entry is
 **epoch-checked**: if the load order changed since the artifact was written, the call refuses loudly naming both
 fingerprints (there is deliberately no stale-override switch; plain formid-list files keep working unchanged, and
-unchanged worlds fingerprint identically across restarts, so artifacts survive them). Guarded by the new
-`artifact-guard` (45 checks) in CI.
+unchanged worlds fingerprint identically across restarts, so artifacts survive them). A truncated
+`conflict_tree` view is the one shape that does **not** auto-spill (its trees have no row form) — the response says
+so and names the alternatives, and a spill of a `limit=`-windowed result says it holds the *window*, never claiming
+the full result. Guarded by the new `artifact-guard` (59 checks) in CI.
 
 **Fixed: `check_errors` / `validate_scripts` refusals in `format=json` returned an empty string.** Both sweeps'
 json renders returned before flushing the JSON writer on their error path, so any refusal — a scope naming a plugin

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,23 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**Big results now come back whole, as a file — truncation stops losing data on the record-bulk reads (the 2.0
+artifact disposition, W1).** `cross_plugin_query`, `batch_record_detail`, and `resolve` gain the §2.1.1 artifact
+lane. Pass `to_file=<absolute .jsonl path>` to write the **complete** result — never limit-windowed — as one
+self-contained JSONL file (line 1 is a manifest: the query that produced it, row count and schema, per-type counts,
+and the build's epoch fingerprint; then one JSON row per record, the same rows `format=json` emits), with only the
+manifest rendered into context. And when an ordinary response hits its `max_chars` ceiling, the complete requested
+result is now **auto-spilled** to a server-managed results folder (pruned by age after 7 days) and the response says
+exactly where it went — a `spilled:` block in text, a `"spilled"` object in json/dense, always naming the file. If
+the spill itself cannot be written, the response says *that* instead — a truncated response never again implies the
+tail is simply gone, or silently lacks the file it promised. Artifacts **re-enter** through the existing `@file`
+spelling — `formids=["@<path>"]` on `batch_record_detail`/`resolve`, `where=["formid in @<path>"]` on
+`cross_plugin_query` — yielding the file's identity column ("scan once, project forever"), and re-entry is
+**epoch-checked**: if the load order changed since the artifact was written, the call refuses loudly naming both
+fingerprints (there is deliberately no stale-override switch; plain formid-list files keep working unchanged, and
+unchanged worlds fingerprint identically across restarts, so artifacts survive them). Guarded by the new
+`artifact-guard` (45 checks) in CI.
+
 **Fixed: `check_errors` / `validate_scripts` refusals in `format=json` returned an empty string.** Both sweeps'
 json renders returned before flushing the JSON writer on their error path, so any refusal — a scope naming a plugin
 not in the order, an excluded plugin, a bad filter — rendered as `""` instead of an `{"error": …}` document. Text

--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -237,7 +237,6 @@ public sealed class FieldPredicateSet
     static (HashSet<FormKey>?, ArtifactDemand?, string?) ParseFormIdList(string raw, string operand)
     {
         string content;
-        ArtifactDemand? artifact = null;
         bool fromFile = operand[0] == '@';
         if (fromFile)
         {
@@ -259,6 +258,9 @@ public sealed class FieldPredicateSet
                 var aset = new HashSet<FormKey>();
                 foreach (var tok in tokens!)
                 {
+                    // Error rows were already excluded by ReadIdentity (they carry raw failed inputs, not record
+                    // identities — PR #306 re-review), so a non-FormID here is a GENUINE mismatch: server-written
+                    // success rows always carry valid formids.
                     try { aset.Add(FormKey.Factory(tok)); }
                     catch (Exception ex)
                     {

--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -62,9 +62,11 @@ public sealed class FieldPredicateSet
     /// the operator, the raw operand, and — for a numeric operator — the operand pre-parsed to a double (validated
     /// at parse, so a non-numeric operand under <c>&gt;</c>/<c>&lt;</c> fails the whole call before any scan).
     /// <paramref name="FormIds"/> is the pre-parsed membership set for <see cref="Op.In"/>/<see cref="Op.NotIn"/>
-    /// (file already read + every token validated at parse — the scan never does IO), null for every other op.</summary>
+    /// (file already read + every token validated at parse — the scan never does IO), null for every other op.
+    /// <paramref name="Artifact"/> is non-null when the list came from a §2.1.1 result ARTIFACT: the epoch
+    /// obligation the consuming scan must check against the build it captures (see <see cref="ArtifactDemands"/>).</summary>
     sealed record Predicate(string Text, string[] PathSegments, string PathDisplay, Op Op, string Operand, double NumericOperand,
-                            HashSet<FormKey>? FormIds = null);
+                            HashSet<FormKey>? FormIds = null, ArtifactDemand? Artifact = null);
 
     readonly IReadOnlyList<Predicate> _predicates;
     readonly long[] _valueRead;   // per-predicate: candidates whose path read SOME value
@@ -89,6 +91,13 @@ public sealed class FieldPredicateSet
     /// candidate — a typed predicate error. The scan checks this and aborts, surfacing it as a recoverable error
     /// (never a silent skip). Null while the predicate is well-typed.</summary>
     public string? FatalError => _fatal;
+
+    /// <summary>The epoch obligations this predicate set carries (SPEC §2.1.1): one per <c>in</c>/<c>not in</c>
+    /// list that came from a result ARTIFACT (vs a plain formid-list file, which claims nothing). The consuming
+    /// scan compares each against the build it captures — AFTER its own Capture(), so the check and the answer
+    /// read the same build — and refuses loud on mismatch, naming both epochs. Empty for plain-list predicates.</summary>
+    public IReadOnlyList<ArtifactDemand> ArtifactDemands =>
+        _predicates.Where(p => p.Artifact is not null).Select(p => p.Artifact!).ToList();
 
     /// <summary>Candidate bodies tested so far — the denominator the Q3 accounting reports against.</summary>
     public long Scanned => _scanned;
@@ -202,9 +211,9 @@ public sealed class FieldPredicateSet
                 return (null, $"predicate '{raw}': '{OpStr(op)}' tests the record's IDENTITY and takes the path 'formid' only " +
                               $"(got '{path}') — write \"formid {OpStr(op)} <list>\". Membership over a field's VALUE is not supported (yet); " +
                               $"use '=' per value, or references= for list→FormID membership.");
-            var (set, lerr) = ParseFormIdList(raw, operand);
+            var (set, artifact, lerr) = ParseFormIdList(raw, operand);
             if (lerr is not null) return (null, lerr);
-            return (new Predicate(text, segs, path, op, operand, 0, set), null);
+            return (new Predicate(text, segs, path, op, operand, 0, set, artifact), null);
         }
 
         // 5. a numeric operator demands a numeric operand — fail fast at parse (before any scan).
@@ -221,20 +230,44 @@ public sealed class FieldPredicateSet
     /// grammar: FormIDs separated by commas and/or newlines — NEVER bare spaces, because a plugin filename can
     /// contain them (<c>123456:My Mod.esp</c>) — with optional surrounding brackets and quotes stripped per token,
     /// so a pasted JSON array (<c>["123456:A.esp", "234567:B.esp"]</c>) parses as-is. Every token must be a valid
-    /// FormID and the set must be non-empty; any violation names itself and refuses the call (Q3).</summary>
-    static (HashSet<FormKey>?, string?) ParseFormIdList(string raw, string operand)
+    /// FormID and the set must be non-empty; any violation names itself and refuses the call (Q3).
+    /// <para>An <c>@file</c> whose target is a §2.1.1 result ARTIFACT (line 1 = manifest) yields its IDENTITY
+    /// column as the list instead of raw tokens, and hands back the artifact's epoch obligation — the scan-once
+    /// re-entry lane. A plain list file stays exactly what it was (no manifest, no epoch claim).</para></summary>
+    static (HashSet<FormKey>?, ArtifactDemand?, string?) ParseFormIdList(string raw, string operand)
     {
         string content;
+        ArtifactDemand? artifact = null;
         bool fromFile = operand[0] == '@';
         if (fromFile)
         {
             var path = operand.Substring(1).Trim().Trim('"', '\'');   // both quote kinds, matching the inline token trim
             if (path.Length == 0)
-                return (null, $"predicate '{raw}': '@' names a formid-list file but no path follows it.");
+                return (null, null, $"predicate '{raw}': '@' names a formid-list file but no path follows it.");
             if (!Path.IsPathRooted(path))
-                return (null, $"predicate '{raw}': formid-list file '{path}' must be an ABSOLUTE path — the server resolves relative paths against its OWN working directory, not yours.");
+                return (null, null, $"predicate '{raw}': formid-list file '{path}' must be an ABSOLUTE path — the server resolves relative paths against its OWN working directory, not yours.");
             try { content = File.ReadAllText(path); }
-            catch (Exception ex) { return (null, $"predicate '{raw}': could not read formid-list file '{path}' — {ex.GetType().Name}: {ex.Message}"); }
+            catch (Exception ex) { return (null, null, $"predicate '{raw}': could not read formid-list file '{path}' — {ex.GetType().Name}: {ex.Message}"); }
+
+            if (ResultArtifact.LooksLikeArtifact(content))
+            {
+                var (manifest, tokens, aerr) = ResultArtifact.ReadIdentity(path, content);
+                if (aerr is not null) return (null, null, $"predicate '{raw}': {aerr}");
+                if (!manifest!.Identity!.Equals("formid", StringComparison.OrdinalIgnoreCase))
+                    return (null, null, $"predicate '{raw}': artifact '{path}' (from {manifest.Tool}) carries '{manifest.Identity}' " +
+                                        $"identities, not FormIDs — there is no formid list in it to test membership against.");
+                var aset = new HashSet<FormKey>();
+                foreach (var tok in tokens!)
+                {
+                    try { aset.Add(FormKey.Factory(tok)); }
+                    catch (Exception ex)
+                    {
+                        return (null, null, $"predicate '{raw}': artifact '{path}' identity value '{tok}' is not a FormID ({ex.Message}) — " +
+                                            "the file does not match its own manifest (was it edited?). Regenerate it from the producing query.");
+                    }
+                }
+                return (aset, new ArtifactDemand(path, manifest.Epoch), null);
+            }
         }
         else content = operand;
 
@@ -254,14 +287,14 @@ public sealed class FieldPredicateSet
                 bool shearShape = tok.Contains(':') && !tok.EndsWith(".esp", StringComparison.OrdinalIgnoreCase)
                                                     && !tok.EndsWith(".esm", StringComparison.OrdinalIgnoreCase)
                                                     && !tok.EndsWith(".esl", StringComparison.OrdinalIgnoreCase);
-                return (null, $"predicate '{raw}': list entry '{tok}'{(fromFile ? $" (in the @file)" : "")} is not a FormID ({ex.Message}). " +
-                              "Expected 'XXXXXX:Plugin.esp' entries separated by commas or newlines." +
-                              (shearShape ? " If the plugin's filename itself contains a comma, it cannot be written in this list — commas always separate entries; rename the plugin or filter another way." : ""));
+                return (null, null, $"predicate '{raw}': list entry '{tok}'{(fromFile ? $" (in the @file)" : "")} is not a FormID ({ex.Message}). " +
+                                    "Expected 'XXXXXX:Plugin.esp' entries separated by commas or newlines." +
+                                    (shearShape ? " If the plugin's filename itself contains a comma, it cannot be written in this list — commas always separate entries; rename the plugin or filter another way." : ""));
             }
         }
         if (set.Count == 0)
-            return (null, $"predicate '{raw}': the formid list{(fromFile ? " file" : "")} is empty — give at least one 'XXXXXX:Plugin.esp'.");
-        return (set, null);
+            return (null, null, $"predicate '{raw}': the formid list{(fromFile ? " file" : "")} is empty — give at least one 'XXXXXX:Plugin.esp'.");
+        return (set, null, null);
     }
 
     /// <summary>Commas and newlines ONLY — a bare space is a legal character inside a plugin filename

--- a/src/housecarl-core/ResultArtifact.cs
+++ b/src/housecarl-core/ResultArtifact.cs
@@ -1,0 +1,263 @@
+using System.Text.Json;
+
+namespace HousecarlCore;
+
+/// <summary>The §2.1.1 result artifact (tool-surface 2.0, W1): ONE self-contained file that decouples result size
+/// from render size. Line 1 is the MANIFEST (what query produced it, what shape its rows are, and — load-bearing —
+/// the EPOCH fingerprint of the build it was read from); lines 2+ are one JSON row per line (JSONL). Immutable once
+/// written: the server never appends to or mutates an artifact — a re-run writes a NEW file (or overwrites a
+/// caller-named to_file= target wholesale). Line-addressable and greppable by design: the traversal ergonomics are
+/// the client's own file tools, inherited, not built.
+///
+/// <para>Re-entry contract (SPEC §2.1.1): an <c>@&lt;path&gt;</c> list input whose target is an artifact yields its
+/// IDENTITY column as the list — scan once, project forever — and server-side consumption is EPOCH-CHECKED against
+/// the current build: mismatch is a loud refusal naming both epochs, with deliberately NO stale-override parameter
+/// (fresh re-projection goes through the server; honest-snapshot traversal of the file is the client's own lane,
+/// which the server cannot and should not police).</para></summary>
+public static class ResultArtifact
+{
+    /// <summary>The manifest-format version stamped as the <c>housecarl_artifact</c> value — bumped only if line 1's
+    /// schema ever changes incompatibly. Its PRESENCE is what marks a file as an artifact (vs a plain formid list).</summary>
+    public const int ManifestVersion = 1;
+
+    /// <summary>Leading characters stripped before sniffing/parsing line 1: a UTF-8 BOM (a file round-tripped
+    /// through a BOM-writing editor is still the same artifact) and ordinary indentation.</summary>
+    static readonly char[] LineNoise = { '\uFEFF', ' ', '\t' };
+
+    // ---- writing ------------------------------------------------------------------------------------
+
+    /// <summary>Accumulates JSONL rows for one artifact, then <see cref="Save"/> writes manifest + rows atomically
+    /// (temp file + move). Rows buffer in memory: an artifact is written in one call's scope and even a very large
+    /// result (100k+ rows) is tens of MB transiently — no server-side state survives the call (the retired-daemon
+    /// posture stays retired; the STATE is the file).</summary>
+    public sealed class Writer : IDisposable
+    {
+        readonly MemoryStream _rows = new();
+        readonly Dictionary<string, int> _typeCounts = new(StringComparer.Ordinal);
+        int _rowCount;
+
+        /// <summary>Append one row: <paramref name="write"/> emits exactly one JSON value (an object) into the
+        /// writer; a newline is appended after it. <paramref name="type"/> — when the row has a record type —
+        /// feeds the manifest's per-type counts. The row stream is handed in too so budget-aware row writers
+        /// shared with the inline renders can take their (stream, cap) pair — the artifact passes an unreachable
+        /// cap, because an artifact row is NEVER truncated (the file being complete is the §2.1.1 contract).</summary>
+        public void WriteRow(Action<Utf8JsonWriter, MemoryStream> write, string? type = null)
+        {
+            using (var w = new Utf8JsonWriter(_rows))   // deliberately NOT indented — one row, one line
+            {
+                write(w, _rows);
+                w.Flush();
+            }
+            _rows.WriteByte((byte)'\n');
+            _rowCount++;
+            if (type is not null) _typeCounts[type] = _typeCounts.GetValueOrDefault(type) + 1;
+        }
+
+        public int RowCount => _rowCount;
+
+        /// <summary>Write the finished artifact: line 1 = manifest, lines 2+ = the accumulated rows. Returns the
+        /// manifest it stamped (echoed into the response's spilled marker) or a named error — never throws for an
+        /// IO failure (the caller renders it; Q3). <paramref name="total"/> is the TRUE result total; it equals
+        /// <see cref="RowCount"/> unless the producing lane deliberately windowed (an auto-spill of an explicit
+        /// limit= window writes the window and says so via total &gt; row_count).</summary>
+        public (Manifest? Manifest, string? Error) Save(
+            string path, string tool, IReadOnlyList<KeyValuePair<string, string>> query, string? identity,
+            IReadOnlyList<string> rowSchema, string sort, int total, string epoch)
+        {
+            var manifest = new Manifest(tool, query, identity, rowSchema, sort, _rowCount, total,
+                                        _typeCounts.Count > 0 ? _typeCounts : null, epoch,
+                                        DateTime.UtcNow.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'"));
+            try
+            {
+                var dir = Path.GetDirectoryName(path);
+                if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+                // Temp-then-move so a crash mid-write never leaves a half artifact that could pass for a whole one
+                // (line 1's row_count would not match, but why leave the hazard). Same-directory temp keeps the
+                // move atomic on NTFS.
+                var tmp = path + ".tmp-" + Guid.NewGuid().ToString("N")[..8];
+                using (var fs = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None))
+                {
+                    using (var w = new Utf8JsonWriter(fs)) { manifest.WriteTo(w); w.Flush(); }
+                    fs.WriteByte((byte)'\n');
+                    _rows.Position = 0;
+                    _rows.CopyTo(fs);
+                }
+                File.Move(tmp, path, overwrite: true);
+                return (manifest, null);
+            }
+            catch (Exception ex)
+            {
+                return (null, $"could not write the result artifact to '{path}' — {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+
+        public void Dispose() => _rows.Dispose();
+    }
+
+    /// <summary>Line 1 of an artifact, parsed. <see cref="Identity"/> names the row column an <c>@file</c> re-entry
+    /// extracts (the §2.1.1 "identity column" — <c>formid</c> on every record lane); null means the rows carry no
+    /// per-record identity (a group_by count table) and re-entry refuses by name. <see cref="Total"/> vs
+    /// <see cref="RowCount"/>: equal unless the producing lane windowed (see <see cref="Writer.Save"/>).</summary>
+    public sealed record Manifest(
+        string Tool,
+        IReadOnlyList<KeyValuePair<string, string>> Query,
+        string? Identity,
+        IReadOnlyList<string> RowSchema,
+        string Sort,
+        int RowCount,
+        int Total,
+        IReadOnlyDictionary<string, int>? TypeCounts,
+        string Epoch,
+        string Created)
+    {
+        internal void WriteTo(Utf8JsonWriter w)
+        {
+            w.WriteStartObject();
+            w.WriteNumber("housecarl_artifact", ManifestVersion);   // the marker: presence = "this file is an artifact"
+            w.WriteString("tool", Tool);
+            w.WriteStartObject("query");
+            foreach (var kv in Query) w.WriteString(kv.Key, kv.Value);
+            w.WriteEndObject();
+            if (Identity is null) w.WriteNull("identity"); else w.WriteString("identity", Identity);
+            w.WriteStartArray("row_schema");
+            foreach (var c in RowSchema) w.WriteStringValue(c);
+            w.WriteEndArray();
+            w.WriteString("sort", Sort);
+            w.WriteNumber("row_count", RowCount);
+            w.WriteNumber("total", Total);
+            if (TypeCounts is not null)
+            {
+                w.WriteStartObject("type_counts");
+                foreach (var kv in TypeCounts.OrderByDescending(kv => kv.Value).ThenBy(kv => kv.Key, StringComparer.Ordinal))
+                    w.WriteNumber(kv.Key, kv.Value);
+                w.WriteEndObject();
+            }
+            w.WriteString("epoch", Epoch);
+            w.WriteString("created", Created);
+            w.WriteEndObject();
+        }
+    }
+
+    // ---- reading (the @file re-entry) ---------------------------------------------------------------
+
+    /// <summary>Cheap artifact sniff on a file's already-read content: is the FIRST LINE a manifest? Used by the
+    /// list-input readers to route between "plain formid list" and "artifact → identity column". Robust to a
+    /// leading BOM; anything that fails to parse as a manifest is NOT an artifact (a plain list whose first entry
+    /// happens to start with '{' would fail the marker check, not crash).</summary>
+    public static bool LooksLikeArtifact(string content)
+    {
+        var firstLine = FirstLine(content).TrimStart(LineNoise);
+        if (!firstLine.StartsWith("{", StringComparison.Ordinal)) return false;
+        try
+        {
+            using var doc = JsonDocument.Parse(firstLine);
+            return doc.RootElement.ValueKind == JsonValueKind.Object
+                && doc.RootElement.TryGetProperty("housecarl_artifact", out _);
+        }
+        catch (JsonException) { return false; }
+    }
+
+    /// <summary>Parse an artifact's manifest + extract its identity-column tokens, in row order. A named error
+    /// (never a throw, never a silent partial list — Q3) on: a malformed manifest, a manifest declaring NO identity
+    /// column (a count-table artifact has no per-record identity to re-enter with), a row missing the column, or a
+    /// row that isn't valid JSON. <paramref name="content"/> is the file's full text (the callers already hold it —
+    /// one read, two uses).</summary>
+    public static (Manifest? Manifest, List<string>? Tokens, string? Error) ReadIdentity(string path, string content)
+    {
+        Manifest? manifest;
+        {
+            var (m, err) = ParseManifest(path, FirstLine(content));
+            if (err is not null) return (null, null, err);
+            manifest = m;
+        }
+        if (manifest!.Identity is null)
+            return (null, null, $"artifact '{path}' (from {manifest.Tool}) declares NO identity column — its rows are " +
+                                $"aggregate/count rows, not per-record rows, so there is no formid list to re-enter with. " +
+                                $"Re-run the producing query without group_by= (or with to_file=) to get a per-record artifact.");
+
+        var tokens = new List<string>(manifest.RowCount);
+        int lineNo = 1;
+        foreach (var line in EnumerateLines(content))
+        {
+            lineNo++;
+            if (line.Length == 0) continue;
+            try
+            {
+                using var doc = JsonDocument.Parse(line);
+                if (!doc.RootElement.TryGetProperty(manifest.Identity, out var idProp) || idProp.ValueKind != JsonValueKind.String)
+                    return (null, null, $"artifact '{path}': row on line {lineNo} carries no '{manifest.Identity}' identity value — " +
+                                        $"the file does not match its own manifest (was it edited?). Regenerate it from the producing query.");
+                tokens.Add(idProp.GetString()!);
+            }
+            catch (JsonException ex)
+            {
+                return (null, null, $"artifact '{path}': line {lineNo} is not a valid JSON row ({ex.Message}) — " +
+                                    $"the file does not match its own manifest (was it edited?). Regenerate it from the producing query.");
+            }
+        }
+        if (tokens.Count == 0)
+            return (null, null, $"artifact '{path}' has a manifest but no rows — the producing query matched nothing; there is no list to re-enter with.");
+        return (manifest, tokens, null);
+    }
+
+    static (Manifest? M, string? Error) ParseManifest(string path, string firstLine)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(firstLine.TrimStart(LineNoise));
+            var r = doc.RootElement;
+            var query = new List<KeyValuePair<string, string>>();
+            if (r.TryGetProperty("query", out var q) && q.ValueKind == JsonValueKind.Object)
+                foreach (var p in q.EnumerateObject()) query.Add(new(p.Name, p.Value.ToString()));
+            var schema = new List<string>();
+            if (r.TryGetProperty("row_schema", out var rs) && rs.ValueKind == JsonValueKind.Array)
+                foreach (var c in rs.EnumerateArray()) schema.Add(c.ToString());
+            Dictionary<string, int>? typeCounts = null;
+            if (r.TryGetProperty("type_counts", out var tc) && tc.ValueKind == JsonValueKind.Object)
+            {
+                typeCounts = new(StringComparer.Ordinal);
+                foreach (var p in tc.EnumerateObject()) typeCounts[p.Name] = p.Value.GetInt32();
+            }
+            return (new Manifest(
+                        r.TryGetProperty("tool", out var t) ? t.GetString() ?? "?" : "?",
+                        query,
+                        r.TryGetProperty("identity", out var id) && id.ValueKind == JsonValueKind.String ? id.GetString() : null,
+                        schema,
+                        r.TryGetProperty("sort", out var s) ? s.GetString() ?? "?" : "?",
+                        r.TryGetProperty("row_count", out var rc) ? rc.GetInt32() : 0,
+                        r.TryGetProperty("total", out var tot) ? tot.GetInt32() : 0,
+                        typeCounts,
+                        r.TryGetProperty("epoch", out var e) ? e.GetString() ?? "?" : "?",
+                        r.TryGetProperty("created", out var cr) ? cr.GetString() ?? "?" : "?"),
+                    null);
+        }
+        catch (Exception ex) when (ex is JsonException or FormatException or InvalidOperationException)
+        {
+            return (null, $"artifact '{path}': line 1 looked like a manifest but did not parse as one ({ex.Message}) — " +
+                          $"was the file edited? Regenerate it from the producing query.");
+        }
+    }
+
+    static string FirstLine(string content)
+    {
+        int nl = content.IndexOfAny(new[] { '\r', '\n' });
+        return nl < 0 ? content : content[..nl];
+    }
+
+    static IEnumerable<string> EnumerateLines(string content)
+    {
+        bool first = true;
+        using var reader = new StringReader(content);
+        for (string? line = reader.ReadLine(); line is not null; line = reader.ReadLine())
+        {
+            if (first) { first = false; continue; }   // line 1 = the manifest
+            yield return line.Trim();
+        }
+    }
+}
+
+/// <summary>An epoch obligation carried by an artifact-backed list input: the artifact at <see cref="Path"/> was
+/// captured at <see cref="Epoch"/>, and the consuming call must compare that against the build it actually captures
+/// — AFTER its own Capture(), inside the service, so the check and the answer read the same build (one view per
+/// call; a tool-layer pre-check would race a freshness rebuild). Mismatch = loud refusal naming both epochs.</summary>
+public sealed record ArtifactDemand(string Path, string Epoch);

--- a/src/housecarl-core/ResultArtifact.cs
+++ b/src/housecarl-core/ResultArtifact.cs
@@ -67,6 +67,7 @@ public static class ResultArtifact
             var manifest = new Manifest(tool, query, identity, rowSchema, sort, _rowCount, total,
                                         _typeCounts.Count > 0 ? _typeCounts : null, epoch,
                                         DateTime.UtcNow.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'"));
+            string? tmp = null;
             try
             {
                 var dir = Path.GetDirectoryName(path);
@@ -74,7 +75,7 @@ public static class ResultArtifact
                 // Temp-then-move so a crash mid-write never leaves a half artifact that could pass for a whole one
                 // (line 1's row_count would not match, but why leave the hazard). Same-directory temp keeps the
                 // move atomic on NTFS.
-                var tmp = path + ".tmp-" + Guid.NewGuid().ToString("N")[..8];
+                tmp = path + ".tmp-" + Guid.NewGuid().ToString("N")[..8];
                 using (var fs = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None))
                 {
                     using (var w = new Utf8JsonWriter(fs)) { manifest.WriteTo(w); w.Flush(); }
@@ -87,6 +88,10 @@ public static class ResultArtifact
             }
             catch (Exception ex)
             {
+                // The temp is full artifact size and a failed write is likeliest exactly when the volume is tight
+                // (PR #306 review) — never leave it behind. Best-effort: the named error below is the contract; a
+                // second failure deleting the temp must not mask it.
+                if (tmp is not null) try { File.Delete(tmp); } catch (Exception) { }
                 return (null, $"could not write the result artifact to '{path}' — {ex.GetType().Name}: {ex.Message}");
             }
         }

--- a/src/housecarl-core/ResultArtifact.cs
+++ b/src/housecarl-core/ResultArtifact.cs
@@ -164,9 +164,17 @@ public static class ResultArtifact
 
     /// <summary>Parse an artifact's manifest + extract its identity-column tokens, in row order. A named error
     /// (never a throw, never a silent partial list — Q3) on: a malformed manifest, a manifest declaring NO identity
-    /// column (a count-table artifact has no per-record identity to re-enter with), a row missing the column, or a
-    /// row that isn't valid JSON. <paramref name="content"/> is the file's full text (the callers already hold it —
-    /// one read, two uses).</summary>
+    /// column (a count-table artifact has no per-record identity to re-enter with), a non-error row missing the
+    /// column, or a row that isn't valid JSON. <paramref name="content"/> is the file's full text (the callers
+    /// already hold it — one read, two uses).
+    /// <para><b>Error rows are not identity-bearing (PR #306 re-review).</b> A row carrying an <c>error</c> member
+    /// documents a failure — a malformed input token, an absent record — it does not name a record: resolve/batch
+    /// write the caller's RAW token (or the null FormKey) into such rows, so their identity values are legitimately
+    /// not FormIDs. Extraction SKIPS them by contract: re-entering an artifact means "the records this file
+    /// resolved", and treating a failure row's raw token as a record identity is how the reconciliation subtraction
+    /// would go wrong, not right. An all-error artifact refuses by name (nothing resolvable to re-enter). The
+    /// was-it-edited refusal below is reserved for genuine mismatches — a SUCCESS row without the identity column —
+    /// which a server-written artifact never contains.</para></summary>
     public static (Manifest? Manifest, List<string>? Tokens, string? Error) ReadIdentity(string path, string content)
     {
         Manifest? manifest;
@@ -181,7 +189,7 @@ public static class ResultArtifact
                                 $"Re-run the producing query without group_by= (or with to_file=) to get a per-record artifact.");
 
         var tokens = new List<string>(manifest.RowCount);
-        int lineNo = 1;
+        int lineNo = 1, errorRows = 0;
         foreach (var line in EnumerateLines(content))
         {
             lineNo++;
@@ -189,6 +197,7 @@ public static class ResultArtifact
             try
             {
                 using var doc = JsonDocument.Parse(line);
+                if (doc.RootElement.TryGetProperty("error", out _)) { errorRows++; continue; }   // not identity-bearing — see the doc
                 if (!doc.RootElement.TryGetProperty(manifest.Identity, out var idProp) || idProp.ValueKind != JsonValueKind.String)
                     return (null, null, $"artifact '{path}': row on line {lineNo} carries no '{manifest.Identity}' identity value — " +
                                         $"the file does not match its own manifest (was it edited?). Regenerate it from the producing query.");
@@ -201,7 +210,9 @@ public static class ResultArtifact
             }
         }
         if (tokens.Count == 0)
-            return (null, null, $"artifact '{path}' has a manifest but no rows — the producing query matched nothing; there is no list to re-enter with.");
+            return (null, null, errorRows > 0
+                ? $"artifact '{path}': all {errorRows} row(s) are ERROR rows (failed inputs of the producing call) — nothing resolved, so there is no formid list to re-enter with."
+                : $"artifact '{path}' has a manifest but no rows — the producing query matched nothing; there is no list to re-enter with.");
         return (manifest, tokens, null);
     }
 

--- a/src/housecarl-generator/ArtifactGuardProbe.cs
+++ b/src/housecarl-generator/ArtifactGuardProbe.cs
@@ -30,6 +30,12 @@ namespace HousecarlGenerator;
 ///      (no epoch claim to violate). Re-materializing via to_file against the new build re-enters cleanly.
 ///   6  RESULTS STORE — prune-by-age deletes old spills at write time; a to_file target overwrites wholesale
 ///      (a re-run is a NEW artifact, not an append).
+///   7  PR #306 REVIEW FOLDS — a truncated conflict_tree render refuses to spill thinner rows and says why
+///      (no row form); a limit-windowed spill says WINDOW, never "complete result" (json complete=false); a
+///      post-scan to_file failure keeps the format contract ({error,epoch} under json); a whitespace list
+///      element stays a per-item error; path reservation is atomic (same-second spills can't collide) and a
+///      failed spill releases its reservation; orphaned Writer temps prune on age; to_file into the pruned
+///      results dir refuses naming the hazard.
 ///
 /// Self-contained: synthetic MO2 instance + synthesized plugins in temp. No game data.
 /// </summary>
@@ -279,6 +285,79 @@ internal static class ArtifactGuardProbe
                 ResultsStore.NextPath("housecarl_cross_plugin_query", "0123456789abcdef");
                 Check(!File.Exists(old), $"a spill older than {ResultsStore.PruneAfterDays} days is pruned at the next write");
                 Check(File.Exists(fresh), "…while a fresh spill survives");
+            }
+
+            // ---- 7: PR #306 review folds — honesty at the edges ----
+            Console.WriteLine();
+            Console.WriteLine("--- 7 (PR #306 fold): no-row-form honesty, windowed wording, format-kept failures, races, hygiene ---");
+            {
+                var epochNow = svc.Stats().epoch;
+                int SpillCount(string prefix) => Directory.GetFiles(resultsDir, prefix + "_*.jsonl").Length;
+
+                // F1 — a truncated conflict_tree render is NOT auto-spilled into thinner rows; it says why.
+                int before = SpillCount("cross_plugin_query");
+                var ct = ReadTools.CrossPluginQuery(svc, type: "WEAP", conflict_tree: true, max_chars: 250);
+                Check(ct.Contains("[truncated:") && ct.Contains("NOT auto-spilled") && ct.Contains("conflict_tree"),
+                      "a truncated conflict_tree query names its no-row-form instead of spilling thinner rows");
+                Check(SpillCount("cross_plugin_query") == before, "…and no artifact was written for it");
+                int bBefore = SpillCount("batch_record_detail");
+                var bct = ReadTools.BatchRecordDetail(svc, weapons.Select(Fid).ToArray(), conflict_tree: true, max_chars: 300);
+                Check(bct.Contains("NOT auto-spilled") && SpillCount("batch_record_detail") == bBefore,
+                      "…batch twin: same honesty, no artifact");
+
+                // F3 — a limit-windowed auto-spill never claims the complete result.
+                var win = ReadTools.CrossPluginQuery(svc, type: "WEAP", limit: 3, max_chars: 250);
+                Check(win.Contains("the returned WINDOW (3 rows of 8 total matches)") && !win.Contains("complete result"),
+                      "a windowed spill says WINDOW (3 of 8), never 'complete result'");
+                Check(win.Contains("beyond limit= are in NO file"), "…and names where the missing matches are (nowhere)");
+                var winJson = ReadTools.CrossPluginQuery(svc, type: "WEAP", limit: 3, format: "json", max_chars: 250);
+                using (var doc = Parse(winJson))
+                {
+                    var sp = doc.RootElement.GetProperty("spilled");
+                    Check(!sp.GetProperty("complete").GetBoolean() && sp.GetProperty("row_count").GetInt32() == 3 && sp.GetProperty("total").GetInt32() == 8,
+                          "…json: spilled.complete=false with row_count/total as data");
+                }
+                var whole = ReadTools.CrossPluginQuery(svc, type: "WEAP", format: "json", max_chars: 250);
+                using (var doc = Parse(whole))
+                    Check(doc.RootElement.GetProperty("spilled").GetProperty("complete").GetBoolean(),
+                          "…control: an un-windowed spill is complete=true");
+
+                // F4 — a POST-scan to_file write failure keeps the format contract.
+                var blocked = Path.Combine(root, "blocked-tofile");
+                File.WriteAllText(blocked, "a file where a directory should be");
+                var tfj = ReadTools.CrossPluginQuery(svc, type: "WEAP", format: "json", to_file: Path.Combine(blocked, "sub", "x.jsonl"));
+                using (var doc = Parse(tfj))
+                    Check(doc.RootElement.GetProperty("error").GetString()!.Contains("could not write")
+                          && doc.RootElement.GetProperty("epoch").GetString() == epochNow,
+                          "a failed to_file under format=json returns a PARSEABLE {error, epoch} document");
+                var tfb = ReadTools.BatchRecordDetail(svc, new[] { Fid(weapons[0]) }, format: "json", to_file: Path.Combine(blocked, "sub", "y.jsonl"));
+                using (var doc = Parse(tfb))
+                    Check(doc.RootElement.TryGetProperty("error", out _), "…batch twin parses too");
+
+                // F5 — a whitespace-only list element is a per-item error, never a fake internal failure.
+                var ws = ReadTools.BatchRecordDetail(svc, new[] { Fid(weapons[0]), "  " });
+                Check(ws.StartsWith("batch: 2 records") && ws.Contains("bad FormID") && !ws.Contains("failed unexpectedly"),
+                      "a whitespace-only formids element stays a per-item error (the batch survives)");
+
+                // F2 — path reservation is atomic: two same-second reservations get DIFFERENT names, both created.
+                var p1 = ResultsStore.NextPath("housecarl_cross_plugin_query", epochNow);
+                var p2 = ResultsStore.NextPath("housecarl_cross_plugin_query", epochNow);
+                Check(p1 != p2 && File.Exists(p1) && File.Exists(p2),
+                      "same-second reservations get distinct names because reserving CREATES the file");
+                ResultsStore.Release(p1); ResultsStore.Release(p2);
+                Check(!File.Exists(p1) && !File.Exists(p2), "…and Release cleans a failed spill's reservation");
+
+                // F6 — orphaned Writer temps are swept by the age prune.
+                var orphan = Path.Combine(resultsDir, "cross_plugin_query_x.jsonl.tmp-deadbeef");
+                File.WriteAllText(orphan, "half-written");
+                File.SetLastWriteTimeUtc(orphan, DateTime.UtcNow.AddDays(-(ResultsStore.PruneAfterDays + 1)));
+                ResultsStore.Release(ResultsStore.NextPath("housecarl_resolve", epochNow));   // any write-time prune pass
+                Check(!File.Exists(orphan), "an old orphaned .jsonl.tmp-* is pruned like any stale spill");
+
+                // F7 — to_file may not point into the pruned results dir.
+                var collide = ReadTools.CrossPluginQuery(svc, type: "WEAP", to_file: Path.Combine(resultsDir, "mine.jsonl"));
+                Check(collide.StartsWith("error:") && collide.Contains("pruned by age"),
+                      "to_file into the server results dir refuses naming the prune hazard");
             }
         }
         finally

--- a/src/housecarl-generator/ArtifactGuardProbe.cs
+++ b/src/housecarl-generator/ArtifactGuardProbe.cs
@@ -36,6 +36,10 @@ namespace HousecarlGenerator;
 ///      element stays a per-item error; path reservation is atomic (same-second spills can't collide) and a
 ///      failed spill releases its reservation; orphaned Writer temps prune on age; to_file into the pruned
 ///      results dir refuses naming the hazard.
+///   8  PR #306 RE-REVIEW FOLD — error rows are not identity-bearing: a legitimately-produced artifact whose
+///      inputs included garbage (resolve keeps the raw token; batch keeps the null FormKey) still re-enters
+///      cleanly on its RESOLVED rows, and an all-error artifact refuses naming the real cause — never the
+///      was-it-edited misdiagnosis, which is reserved for genuine file/manifest mismatches.
 ///
 /// Self-contained: synthetic MO2 instance + synthesized plugins in temp. No game data.
 /// </summary>
@@ -358,6 +362,37 @@ internal static class ArtifactGuardProbe
                 var collide = ReadTools.CrossPluginQuery(svc, type: "WEAP", to_file: Path.Combine(resultsDir, "mine.jsonl"));
                 Check(collide.StartsWith("error:") && collide.Contains("pruned by age"),
                       "to_file into the server results dir refuses naming the prune hazard");
+            }
+
+            // ---- 8: PR #306 re-review fold — error rows are not identity-bearing ----
+            Console.WriteLine();
+            Console.WriteLine("--- 8 (PR #306 re-review): a legitimately-produced artifact with error rows re-enters on its RESOLVED rows ---");
+            {
+                // A resolve artifact whose inputs included garbage: the error row keeps the caller's RAW token as
+                // its formid — a legitimate, manifest-matching artifact whose identity column is not all FormIDs.
+                var mixed = Path.Combine(work, "mixed.jsonl");
+                ReadTools.Resolve(svc, new[] { "garbage", Fid(weapons[0]), Fid(weapons[1]) }, to_file: mixed);
+                var (mm, mtoks, merr) = ResultArtifact.ReadIdentity(mixed, File.ReadAllText(mixed));
+                Check(merr is null && mm!.RowCount == 3 && mtoks!.Count == 2,
+                      "the artifact keeps its error row (rows=3) while identity extraction yields the 2 RESOLVED formids");
+                Check(ReadTools.BatchRecordDetail(svc, new[] { "@" + mixed }).StartsWith("batch: 2 records"),
+                      "…formids=@mixed-artifact re-enters on the resolved rows — no was-it-edited misdiagnosis");
+                var qm = ReadTools.CrossPluginQuery(svc, type: "WEAP", where: new[] { $"formid in @{mixed}" });
+                Check(qm.Contains("2 matches"), "…and the where-grammar membership test agrees (2 of 8 weapons)");
+
+                // batch's parse-failure rows (the null FormKey) are error rows too — same skip, same clean re-entry.
+                var bmixed = Path.Combine(work, "bmixed.jsonl");
+                ReadTools.BatchRecordDetail(svc, new[] { "notaformid", Fid(weapons[2]) }, to_file: bmixed);
+                var (bm, btoks, berr) = ResultArtifact.ReadIdentity(bmixed, File.ReadAllText(bmixed));
+                Check(berr is null && bm!.RowCount == 2 && btoks is [var only] && only == Fid(weapons[2]),
+                      "a batch artifact's parse-failure row (null FormKey) is skipped the same way");
+
+                // All-error artifact: refuse by the REAL cause, not tampering.
+                var allErr = Path.Combine(work, "allerr.jsonl");
+                ReadTools.Resolve(svc, new[] { "garbage1", "garbage2" }, to_file: allErr);
+                var reenter = ReadTools.BatchRecordDetail(svc, new[] { "@" + allErr });
+                Check(reenter.StartsWith("error:") && reenter.Contains("ERROR rows") && !reenter.Contains("was it edited"),
+                      "an all-error artifact refuses naming the real cause (failed inputs), never accusing the file");
             }
         }
         finally

--- a/src/housecarl-generator/ArtifactGuardProbe.cs
+++ b/src/housecarl-generator/ArtifactGuardProbe.cs
@@ -1,0 +1,297 @@
+using System.Text.Json;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// REGRESSION GUARD for the §2.1.1 artifact disposition (tool-surface 2.0, W1 PR 2): bulk output decouples result
+/// size from render size via ONE self-contained JSONL file — manifest line 1, one row per line — and re-enters
+/// through the @file convention, epoch-checked. Arms:
+///
+///   1  ROUND-TRIP — the core writer/reader pair: manifest fields survive, identity tokens come back in row
+///      order, the artifact sniff says yes to a manifest and no to a plain list.
+///   2  TO_FILE — the forced disposition on all three wired lanes: the COMPLETE result lands in the caller's
+///      file, only the manifest renders inline (no rows), the spilled marker names the file in BOTH formats
+///      (D2), and the doomed-disposition refusals (relative path, wrong extension, conflict_tree, offset) fire
+///      BEFORE any scan.
+///   3  AUTO-SPILL — a render that hits max_chars ALWAYS leaves a complete artifact in the server results dir
+///      and says so in-band (text, json, dense; cross-query, batch, resolve). Truncation without a named
+///      complete artifact is the E4.2 failure this kills. A FAILED spill write is named loud in both formats —
+///      never a truncated response silently missing its promised file.
+///   4  RE-ENTRY — formids=@artifact (batch, resolve) and where=["formid in @artifact"] (cross-query) yield the
+///      identity column against the SAME build; a plain @file list keeps working with no epoch claim; @ mixed
+///      with inline entries refuses named; a no-identity (group_by) artifact refuses named.
+///   5  EPOCH CHECK — after the load order changes, artifact re-entry refuses LOUD naming BOTH epochs on every
+///      consuming lane, the refusal is stamped (it consulted the build), and the plain-list control still works
+///      (no epoch claim to violate). Re-materializing via to_file against the new build re-enters cleanly.
+///   6  RESULTS STORE — prune-by-age deletes old spills at write time; a to_file target overwrites wholesale
+///      (a re-run is a NEW artifact, not an append).
+///
+/// Self-contained: synthetic MO2 instance + synthesized plugins in temp. No game data.
+/// </summary>
+internal static class ArtifactGuardProbe
+{
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" artifact guard — §2.1.1: results decouple from renders; artifacts re-enter epoch-checked");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        int fail = 0;
+        void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) fail++; }
+
+        var root = Path.Combine(Path.GetTempPath(), "hc-artifact-guard-" + Guid.NewGuid().ToString("N"));
+        var savedOverride = ResultsStore.OverrideDirForTests;
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root, "game", "Data"));
+
+            // ---- synthesized plugins: a master with 8 weapons, and an override ----
+            var masterKey = new ModKey("HcArtMaster", ModType.Master);
+            var ovKey = new ModKey("HcArtOverride", ModType.Plugin);
+            string masterName = masterKey.FileName.String, ovName = ovKey.FileName.String;
+
+            var master = new SkyrimMod(masterKey, SkyrimRelease.SkyrimSE);
+            var weapons = new List<FormKey>();
+            for (int i = 0; i < 8; i++)
+            {
+                var w = master.Weapons.AddNew(); w.EditorID = $"HcArtW{i}";
+                w.BasicStats = new WeaponBasicStats { Damage = (ushort)(10 + i), Weight = 1 };
+                weapons.Add(w.FormKey);
+            }
+            var ovMod = new SkyrimMod(ovKey, SkyrimRelease.SkyrimSE);
+            ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(ovMod, master.Weapons.First()))
+                .BasicStats = new WeaponBasicStats { Damage = 99, Weight = 1 };
+
+            var inst = Path.Combine(root, "inst");
+            var mods = Path.Combine(inst, "mods");
+            Directory.CreateDirectory(Path.Combine(mods, "MasterMod"));
+            Directory.CreateDirectory(Path.Combine(mods, "OverrideMod"));
+            var masterFile = Path.Combine(mods, "MasterMod", masterName);
+            var ovFile = Path.Combine(mods, "OverrideMod", ovName);
+            master.BeginWrite.ToPath(masterFile).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            ovMod.BeginWrite.ToPath(ovFile).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
+
+            var genDir = Path.Combine(root, "corpus-gen");
+            CorpusGenerator.GenerateAll(genDir, Path.Combine(root, "corpus-ref"));
+            CorpusRulebook.CorpusPath = Path.Combine(genDir, "corpus.json");
+
+            File.WriteAllText(Path.Combine(inst, "ModOrganizer.ini"),
+                "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+                + Path.Combine(root, "game").Replace(@"\", @"\\") + ")\r\n");
+            var prof = Path.Combine(inst, "profiles", "Default");
+            Directory.CreateDirectory(prof);
+            File.WriteAllText(Path.Combine(prof, "loadorder.txt"), "# header\r\n" + masterName + "\r\n" + ovName + "\r\n");
+            File.WriteAllText(Path.Combine(prof, "plugins.txt"), "*" + masterName + "\r\n*" + ovName + "\r\n");
+            File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n+OverrideMod\r\n+MasterMod\r\n");
+
+            var store = new UserConfigStore(Path.Combine(root, "user.json"));
+            using var svc = LoadOrderService.WithInstance(inst, 0, store);
+            var epoch0 = svc.Stats().epoch;
+
+            var resultsDir = Path.Combine(root, "results");
+            ResultsStore.OverrideDirForTests = resultsDir;
+
+            string Fid(FormKey fk) => $"{fk.ID:X6}:{fk.ModKey.FileName}";
+            var work = Path.Combine(root, "work");
+            Directory.CreateDirectory(work);
+
+            static JsonDocument Parse(string s) => JsonDocument.Parse(s);
+
+            // ---- 1: the core writer/reader round-trip ----
+            Console.WriteLine("--- 1: writer/reader round-trip — manifest line 1, identity column back in row order ---");
+            {
+                var p = Path.Combine(work, "roundtrip.jsonl");
+                using (var w = new ResultArtifact.Writer())
+                {
+                    w.WriteRow((jw, _) => { jw.WriteStartObject(); jw.WriteString("formid", "000001:A.esp"); jw.WriteString("type", "Weapon"); jw.WriteEndObject(); }, "Weapon");
+                    w.WriteRow((jw, _) => { jw.WriteStartObject(); jw.WriteString("formid", "000002:A.esp"); jw.WriteString("type", "Armor"); jw.WriteEndObject(); }, "Armor");
+                    var (m, err) = w.Save(p, "housecarl_test", new List<KeyValuePair<string, string>> { new("type", "WEAP") },
+                                          "formid", new[] { "formid", "type" }, "input order", 2, "abcdef0123456789");
+                    Check(err is null && m is not null, $"writer saves manifest+rows ({err ?? "ok"})");
+                }
+                var content = File.ReadAllText(p);
+                Check(ResultArtifact.LooksLikeArtifact(content), "the sniff recognizes a manifest on line 1");
+                Check(!ResultArtifact.LooksLikeArtifact("000001:A.esp\n000002:A.esp\n"), "…and says NO to a plain formid list");
+                var (rm, tokens, rerr) = ResultArtifact.ReadIdentity(p, content);
+                Check(rerr is null && rm is not null && rm.Epoch == "abcdef0123456789" && rm.Tool == "housecarl_test"
+                      && rm.RowCount == 2 && rm.Identity == "formid" && rm.TypeCounts is { Count: 2 },
+                      "manifest fields survive the round-trip (tool, epoch, row_count, identity, type_counts)");
+                Check(tokens is ["000001:A.esp", "000002:A.esp"], "identity tokens come back in row order");
+            }
+
+            // ---- 2: to_file — the forced disposition ----
+            Console.WriteLine();
+            Console.WriteLine("--- 2: to_file — complete result to the caller's file, manifest-only inline, refusals pre-scan ---");
+            var artifactPath = Path.Combine(work, "weapons.jsonl");
+            {
+                var text = ReadTools.CrossPluginQuery(svc, type: "WEAP", to_file: artifactPath);
+                Check(File.Exists(artifactPath), "to_file writes the artifact where asked");
+                var (m, toks, err) = ResultArtifact.ReadIdentity(artifactPath, File.ReadAllText(artifactPath));
+                Check(err is null && m!.RowCount == 8 && m.Total == 8 && m.Epoch == epoch0 && toks!.Count == 8,
+                      $"…the artifact is COMPLETE (8/8 rows) and stamped with the scanned build ({m?.Epoch})");
+                Check(m!.TypeCounts is { Count: 1 } tc && tc["Weapon"] == 8, "…manifest type_counts count the rows");
+                Check(text.Contains("spilled:") && text.Contains(artifactPath), "…the text response's spilled marker NAMES the file (contract)");
+                Check(text.Contains("8 matches") && !text.Contains(Fid(weapons[0])), "…and renders the manifest ONLY — no inline rows");
+
+                var json = ReadTools.CrossPluginQuery(svc, type: "WEAP", format: "json", to_file: Path.Combine(work, "weapons-j.jsonl"));
+                using var doc = Parse(json);
+                Check(doc.RootElement.TryGetProperty("spilled", out var sp) && sp.GetProperty("path").GetString()!.EndsWith("weapons-j.jsonl")
+                      && sp.GetProperty("reason").GetString() == "to_file",
+                      "json mode: the spilled marker rides IN the document with the path (D2)");
+                Check(doc.RootElement.GetProperty("matches").GetArrayLength() == 0 && doc.RootElement.GetProperty("total").GetInt32() == 8,
+                      "…json rows omitted, true total intact");
+
+                // group_by to_file: a count-table artifact carries NO identity column.
+                var gPath = Path.Combine(work, "groups.jsonl");
+                ReadTools.CrossPluginQuery(svc, type: "WEAP", group_by: "winner", to_file: gPath);
+                var (gm, _, gerr) = ResultArtifact.ReadIdentity(gPath, File.ReadAllText(gPath));
+                Check(gerr is not null && gerr.Contains("NO identity column"), "a group_by artifact refuses identity re-entry by name");
+
+                // Doomed dispositions refuse BEFORE any scan.
+                Check(ReadTools.CrossPluginQuery(svc, type: "WEAP", to_file: "relative.jsonl").Contains("ABSOLUTE"),
+                      "to_file refuses a relative path, named");
+                Check(ReadTools.CrossPluginQuery(svc, type: "WEAP", to_file: Path.Combine(work, "x.csv")).Contains(".jsonl"),
+                      "…and a non-.jsonl name (the file must say what it is)");
+                Check(ReadTools.CrossPluginQuery(svc, type: "WEAP", conflict_tree: true, to_file: Path.Combine(work, "x.jsonl")).Contains("conflict_tree"),
+                      "…and conflict_tree (a text-only view with no row form)");
+                Check(ReadTools.CrossPluginQuery(svc, type: "WEAP", offset: 2, to_file: Path.Combine(work, "y.jsonl")).Contains("offset"),
+                      "…and offset= (the artifact is never a window)");
+            }
+
+            // ---- 3: auto-spill at the inline ceiling ----
+            Console.WriteLine();
+            Console.WriteLine("--- 3: auto-spill — a truncated render ALWAYS leaves a complete, named artifact ---");
+            {
+                var text = ReadTools.CrossPluginQuery(svc, type: "WEAP", max_chars: 250);
+                Check(text.Contains("[truncated:"), "control: max_chars=250 truncates the inline text render");
+                Check(text.Contains("spilled: complete result (8 rows)"), "…and the spilled marker says the artifact is COMPLETE (8 rows, not the rendered prefix)");
+                var spillPath = Directory.GetFiles(resultsDir, "cross_plugin_query_*.jsonl").SingleOrDefault();
+                Check(spillPath is not null && text.Contains(spillPath), "…naming the results-dir file that actually exists");
+                var (sm, stoks, serr) = ResultArtifact.ReadIdentity(spillPath!, File.ReadAllText(spillPath!));
+                Check(serr is null && sm!.RowCount == 8 && stoks!.Count == 8 && sm.Epoch == epoch0,
+                      "…whose rows are the complete window, stamped with the scanned build");
+
+                var json = ReadTools.CrossPluginQuery(svc, type: "WEAP", format: "json", max_chars: 250);
+                using (var doc = Parse(json))
+                    Check(doc.RootElement.GetProperty("truncated").GetBoolean()
+                          && doc.RootElement.GetProperty("spilled").GetProperty("path").GetString() is { } jp && File.Exists(jp),
+                          "json mode: truncated=true AND spilled.path names a real file (D2)");
+                var dense = ReadTools.CrossPluginQuery(svc, type: "WEAP", format: "dense", max_chars: 250);
+                using (var doc = Parse(dense))
+                    Check(doc.RootElement.TryGetProperty("spilled", out var dsp) && File.Exists(dsp.GetProperty("path").GetString()!),
+                          "dense mode: the spilled marker rides too");
+
+                var allFids = weapons.Select(Fid).ToArray();
+                var bt = ReadTools.BatchRecordDetail(svc, allFids, max_chars: 300);
+                Check(bt.Contains("spilled:") && Directory.GetFiles(resultsDir, "batch_record_detail_*.jsonl").Length == 1,
+                      "batch: a truncated batch auto-spills its complete rows");
+                var rt = ReadTools.Resolve(svc, allFids, max_chars: 250);
+                Check(rt.Contains("spilled:") && Directory.GetFiles(resultsDir, "resolve_*.jsonl").Length == 1,
+                      "resolve: same contract");
+
+                // A FAILED spill write is named loud — never a truncated response silently missing its artifact.
+                var blocker = Path.Combine(root, "results-blocked");
+                File.WriteAllText(blocker, "a file where the results DIR should be");
+                ResultsStore.OverrideDirForTests = Path.Combine(blocker, "sub");   // un-creatable: parent is a file
+                var failText = ReadTools.CrossPluginQuery(svc, type: "WEAP", max_chars: 250);
+                Check(failText.Contains("[truncated:") && failText.Contains("could NOT be written") && failText.Contains("exists NOWHERE"),
+                      "a failed auto-spill is named in the text response (the truncation keeps rendering)");
+                var failJson = ReadTools.CrossPluginQuery(svc, type: "WEAP", format: "json", max_chars: 250);
+                using (var doc = Parse(failJson))
+                    Check(doc.RootElement.TryGetProperty("spill_error", out _), "…and in the json document (spill_error)");
+                ResultsStore.OverrideDirForTests = resultsDir;
+            }
+
+            // ---- 4: @file re-entry against the same build ----
+            Console.WriteLine();
+            Console.WriteLine("--- 4: @file re-entry — artifact yields its identity column; plain lists unchanged; misuse named ---");
+            {
+                var bt = ReadTools.BatchRecordDetail(svc, new[] { "@" + artifactPath });
+                Check(bt.StartsWith("batch: 8 records") && bt.Contains($"epoch={epoch0}"), "formids=@artifact reads all 8 identities (batch)");
+                var rt = ReadTools.Resolve(svc, new[] { "@" + artifactPath });
+                Check(rt.StartsWith("resolve: 8 formids"), "…and resolve");
+                var qt = ReadTools.CrossPluginQuery(svc, type: "WEAP", where: new[] { $"formid in @{artifactPath}" });
+                Check(qt.Contains("8 matches"), "…and the where-grammar membership test (cross-query)");
+
+                var plainPath = Path.Combine(work, "plain.txt");
+                File.WriteAllText(plainPath, string.Join("\r\n", weapons.Take(3).Select(Fid)));
+                Check(ReadTools.BatchRecordDetail(svc, new[] { "@" + plainPath }).StartsWith("batch: 3 records"),
+                      "a PLAIN @file list still works (no manifest, no epoch claim)");
+
+                Check(ReadTools.BatchRecordDetail(svc, new[] { "@" + plainPath, Fid(weapons[0]) }).Contains("IN PLACE OF the whole list"),
+                      "@ mixed with inline entries refuses named");
+                Check(ReadTools.BatchRecordDetail(svc, new[] { "@relative.txt" }).Contains("ABSOLUTE"),
+                      "a relative @path refuses named");
+                Check(ReadTools.BatchRecordDetail(svc, new[] { "@" + gArtifactPathFor(work) }).Contains("NO identity column"),
+                      "a no-identity (group_by) artifact refuses named at the formids= door too");
+            }
+
+            // ---- 5: the epoch check — the load order changes, re-entry refuses loud ----
+            Console.WriteLine();
+            Console.WriteLine("--- 5: epoch check — a stale artifact refuses LOUD naming both epochs; plain lists don't claim ---");
+            {
+                File.SetLastWriteTimeUtc(ovFile, DateTime.UtcNow.AddHours(1));   // content-change signal → next capture re-fingerprints
+                var epoch1 = svc.Stats().epoch;
+                Check(epoch1 != epoch0, $"control: the build re-fingerprinted ({epoch0} -> {epoch1})");
+
+                var bt = ReadTools.BatchRecordDetail(svc, new[] { "@" + artifactPath });
+                Check(bt.StartsWith("error:") && bt.Contains(epoch0) && bt.Contains(epoch1) && bt.Contains("no stale-override"),
+                      "batch re-entry refuses naming BOTH epochs and the no-override posture");
+                Check(bt.Contains($"epoch={epoch1}"), "…and the refusal is STAMPED with the build it consulted");
+                var bj = ReadTools.BatchRecordDetail(svc, new[] { "@" + artifactPath }, format: "json");
+                using (var doc = Parse(bj))
+                    Check(doc.RootElement.TryGetProperty("error", out _) && doc.RootElement.GetProperty("epoch").GetString() == epoch1,
+                          "…json refusal: {error, epoch} (D2)");
+
+                var qt = ReadTools.CrossPluginQuery(svc, type: "WEAP", where: new[] { $"formid in @{artifactPath}" });
+                Check(qt.StartsWith("error:") && qt.Contains(epoch0) && qt.Contains(epoch1) && qt.Contains($"epoch={epoch1}"),
+                      "cross-query predicate re-entry refuses the same way, stamped");
+                var rt = ReadTools.Resolve(svc, new[] { "@" + artifactPath });
+                Check(rt.StartsWith("error:") && rt.Contains(epoch0) && rt.Contains(epoch1), "resolve re-entry refuses too");
+
+                var plainPath = Path.Combine(work, "plain.txt");
+                Check(ReadTools.BatchRecordDetail(svc, new[] { "@" + plainPath }).StartsWith("batch: 3 records"),
+                      "control: the PLAIN list still enters — it never claimed a build");
+
+                // Re-materialize against the new build → re-entry is clean again (and to_file overwrites wholesale).
+                var text = ReadTools.CrossPluginQuery(svc, type: "WEAP", to_file: artifactPath);
+                var (m2, _, err2) = ResultArtifact.ReadIdentity(artifactPath, File.ReadAllText(artifactPath));
+                Check(err2 is null && m2!.Epoch == epoch1 && text.Contains(artifactPath),
+                      "to_file OVERWRITES the stale artifact with the new build's result");
+                Check(ReadTools.BatchRecordDetail(svc, new[] { "@" + artifactPath }).StartsWith("batch: 8 records"),
+                      "…and re-entry is clean against the re-materialized artifact");
+            }
+
+            // ---- 6: the results store — prune-by-age at write ----
+            Console.WriteLine();
+            Console.WriteLine("--- 6: results store — old spills prune at write time ---");
+            {
+                var old = Path.Combine(resultsDir, "cross_plugin_query_old.jsonl");
+                File.WriteAllText(old, "{}");
+                File.SetLastWriteTimeUtc(old, DateTime.UtcNow.AddDays(-(ResultsStore.PruneAfterDays + 1)));
+                var fresh = Path.Combine(resultsDir, "resolve_fresh.jsonl");
+                File.WriteAllText(fresh, "{}");
+                ResultsStore.NextPath("housecarl_cross_plugin_query", "0123456789abcdef");
+                Check(!File.Exists(old), $"a spill older than {ResultsStore.PruneAfterDays} days is pruned at the next write");
+                Check(File.Exists(fresh), "…while a fresh spill survives");
+            }
+        }
+        finally
+        {
+            ResultsStore.OverrideDirForTests = savedOverride;
+            try { Directory.Delete(root, recursive: true); } catch { /* best-effort temp cleanup */ }
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"[artifact-guard] {(fail == 0 ? "PASS — results decouple from renders, and artifacts re-enter honestly." : $"FAIL — {fail} check(s) failed.")}");
+        return fail == 0 ? 0 : 1;
+    }
+
+    /// <summary>The group_by artifact arm 2 wrote — one place for the path so arms 2 and 4 can't drift.</summary>
+    static string gArtifactPathFor(string work) => Path.Combine(work, "groups.jsonl");
+}

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -124,6 +124,12 @@ public static class CiAll
         // mid-session rebuild so cross-page drift is visible. Refusals answered off a build carry it; refusals that
         // never consulted one stay null.
         ("epoch-guard", EpochGuardProbe.RunGuard),
+        // Artifact disposition (tool-surface 2.0 W1 PR 2, SPEC §2.1.1): bulk results decouple from renders via ONE
+        // JSONL file (manifest line 1 with the epoch fingerprint); to_file forces it, a max_chars truncation ALWAYS
+        // auto-spills the complete result to the server results dir with the spilled marker naming its file in both
+        // formats, and @file re-entry yields the identity column epoch-checked against the consuming call's own
+        // capture — a stale artifact refuses loud naming both epochs, with no override switch by design.
+        ("artifact-guard", ArtifactGuardProbe.RunGuard),
         ("verify-loop-guard", VerifyLoopProbe.RunGuard),
         ("vmad-poly-guard", VmadPolyProbe.RunGuard),
         ("poly-field-descend-guard", PolyFieldDescendProbe.RunGuard),

--- a/src/housecarl-mcp/Artifacts.cs
+++ b/src/housecarl-mcp/Artifacts.cs
@@ -22,7 +22,20 @@ internal sealed record SpillInfo(string Path, ResultArtifact.Manifest Manifest, 
 internal sealed record SpillState(SpillInfo? Spill, string? Failure, bool ManifestOnly)
 {
     public static SpillState Spilled(SpillInfo s, bool manifestOnly) => new(s, null, manifestOnly);
-    public static SpillState Failed(string failure) => new(null, failure, false);
+
+    /// <summary>The spill WRITE failed: the artifact was promised and could not be produced — say so, loud, with
+    /// the recovery moves (PR #306 review: the emitters render this verbatim, so the message is the whole story).</summary>
+    public static SpillState WriteFailed(string error) => new(null,
+        "the response is truncated and the auto-spill artifact could NOT be written — " + error +
+        " The complete result exists NOWHERE; re-run with a narrower filter, a higher max_chars, or to_file= at a writable path.", false);
+
+    /// <summary>The result HAS no spillable row form (conflict_tree — the same reason to_file= refuses it), so no
+    /// artifact was attempted: writing thinner summary rows under a completeness claim would be the silent-substitution
+    /// Q3 case (PR #306 review, finding 1).</summary>
+    public static SpillState NoRowForm() => new(null,
+        "the response is truncated and was NOT auto-spilled: conflict_tree=true has no JSONL row form (the same reason " +
+        "to_file= refuses it), and spilling thinner tree-less rows under a completeness claim would misrepresent the file. " +
+        "The complete trees exist only inline — raise max_chars, narrow the set, or drop conflict_tree (plain rows spill fine).", false);
 }
 
 /// <summary>The §2.1.1 artifact layer for the bulk read lanes (tool-surface 2.0, W1): per-lane artifact BUILDERS
@@ -46,14 +59,22 @@ internal static class Artifacts
     public static void AppendSpillText(StringBuilder sb, SpillInfo s)
     {
         var m = s.Manifest;
+        // "complete result" is claimed ONLY when the file holds every match (PR #306 review, finding 3): an
+        // auto-spill of a limit= window is complete AS A WINDOW — the matches beyond limit= are in no file, and
+        // saying otherwise is exactly the silent data-loss claim this PR exists to kill.
+        bool whole = m.Total == m.RowCount;
         sb.Append('\n')
-          .Append("spilled: complete result (").Append(m.RowCount).Append(m.RowCount == 1 ? " row" : " rows")
+          .Append(whole ? "spilled: complete result (" : "spilled: the returned WINDOW (")
+          .Append(m.RowCount).Append(m.RowCount == 1 ? " row" : " rows")
+          .Append(whole ? "" : $" of {m.Total} total matches")
           .Append(") -> ").Append(s.Path).Append('\n')
           .Append(s.ToFile
               ? "  written at your request (to_file=): only this manifest is rendered inline.\n"
-              : "  the inline render hit max_chars, so the COMPLETE result was auto-spilled (nothing is lost; the rows above are a prefix).\n")
+              : whole
+                  ? "  the inline render hit max_chars, so the COMPLETE result was auto-spilled (nothing is lost; the rows above are a prefix).\n"
+                  : $"  the inline render hit max_chars; the spilled WINDOW is complete in the file, but the {m.Total - m.RowCount} matches beyond limit= are in NO file — page with offset=, raise limit=, or use to_file= for the full result.\n")
           .Append("  manifest: rows=").Append(m.RowCount)
-          .Append(m.Total != m.RowCount ? $" of total={m.Total}" : "")
+          .Append(whole ? "" : $" of total={m.Total}")
           .Append("  identity=").Append(m.Identity ?? "<none>")
           .Append("  epoch=").Append(m.Epoch).Append('\n')
           .Append("  row_schema: ").Append(string.Join(", ", m.RowSchema)).Append('\n')
@@ -80,6 +101,9 @@ internal static class Artifacts
         w.WriteString("reason", s.ToFile ? "to_file" : "over_inline_ceiling");
         w.WriteNumber("row_count", m.RowCount);
         w.WriteNumber("total", m.Total);
+        // Explicit, not derivable-only (finding 3's json half): false = the file is a WINDOW, matches beyond
+        // limit= are in no file.
+        w.WriteBoolean("complete", m.Total == m.RowCount);
         if (m.Identity is null) w.WriteNull("identity"); else w.WriteString("identity", m.Identity);
         w.WriteStartArray("row_schema");
         foreach (var c in m.RowSchema) w.WriteStringValue(c);
@@ -207,20 +231,14 @@ internal static class Artifacts
     {
         if (s.Spill is not null) AppendSpillText(sb, s.Spill);
         else if (s.Failure is not null)
-            sb.Append('\n')
-              .Append("WARNING: the response is truncated and the auto-spill artifact could NOT be written — ")
-              .Append(s.Failure).Append('\n')
-              .Append("  The complete result exists NOWHERE; re-run with a narrower filter, a higher max_chars, or to_file= at a writable path.\n");
+            sb.Append('\n').Append("WARNING: ").Append(s.Failure).Append('\n');
     }
 
     /// <summary>The json twin of <see cref="AppendSpillStateText"/> — written into an OPEN object (D2 pairing).</summary>
     public static void WriteSpillStateJson(Utf8JsonWriter w, SpillState s)
     {
         if (s.Spill is not null) WriteSpillJson(w, s.Spill);
-        else if (s.Failure is not null)
-            w.WriteString("spill_error",
-                "the response is truncated and the auto-spill artifact could NOT be written — " + s.Failure +
-                ". The complete result exists NOWHERE; re-run with a narrower filter, a higher max_chars, or to_file= at a writable path.");
+        else if (s.Failure is not null) w.WriteString("spill_error", s.Failure);
     }
 
     /// <summary>Split a PLAIN list file's content into tokens — the same grammar the where-grammar's @file uses:
@@ -246,7 +264,9 @@ internal static class Artifacts
     /// for inline).</summary>
     public static (string[]? Tokens, ArtifactDemand? Demand, string? EchoSource, string? Error) ExpandListInput(string[] items, string paramName)
     {
-        int atCount = items.Count(i => i is { Length: > 0 } && i.TrimStart()[0] == '@');
+        // `is not null && TrimStart() is { Length: > 0 }` — a whitespace-only element must fall through to the
+        // per-item "not a FormID" path, not throw on [0] and surface as a fake internal failure (PR #306 review).
+        int atCount = items.Count(i => i is not null && i.TrimStart() is { Length: > 0 } t && t[0] == '@');
         if (atCount == 0) return (items, null, null, null);
         if (items.Length > 1)
             return (null, null, null, $"error: {paramName}= mixes an '@file' entry with inline entries — '@<path>' stands IN PLACE OF the whole list. " +
@@ -279,8 +299,10 @@ internal static class Artifacts
     // ---- to_file validation -------------------------------------------------------------------------
 
     /// <summary>Validate a caller-named <c>to_file=</c> target: absolute, .jsonl-suffixed (the artifact IS jsonl —
-    /// a .csv/.txt name would promise a format the file doesn't have), and not colliding with the auto-spill
-    /// directory's naming authority. Null = fine; else the named refusal.</summary>
+    /// a .csv/.txt name would promise a format the file doesn't have), and NOT inside the auto-spill results
+    /// directory — the server prunes that folder by age, so a caller-named artifact there would be silently
+    /// destroyed by hygiene (PR #306 review: the check the doc claimed, now real). Null = fine; else the named
+    /// refusal.</summary>
     public static string? ValidateToFile(string toFile)
     {
         var p = toFile.Trim();
@@ -288,6 +310,16 @@ internal static class Artifacts
         if (!Path.IsPathRooted(p)) return $"error: to_file='{toFile}' must be an ABSOLUTE path — the server resolves relative paths against its OWN working directory, not yours.";
         if (!p.EndsWith(".jsonl", StringComparison.OrdinalIgnoreCase))
             return $"error: to_file='{toFile}' — the artifact is a JSONL file (line 1 = manifest, one JSON row per line); name it with a .jsonl extension so the file says what it is.";
+        try
+        {
+            var dir = Path.GetFullPath(Path.GetDirectoryName(p) ?? "");
+            var results = Path.GetFullPath(ResultsStore.Dir);
+            if (string.Equals(dir.TrimEnd('\\', '/'), results.TrimEnd('\\', '/'), StringComparison.OrdinalIgnoreCase))
+                return $"error: to_file='{toFile}' points into the server's auto-spill results directory ('{results}'), " +
+                       $"which is pruned by age after {ResultsStore.PruneAfterDays} days — your artifact would be silently deleted by that hygiene. " +
+                       "Name a path outside it; the server owns that folder's lifecycle.";
+        }
+        catch (Exception) { /* an unnormalizable path fails later with the writer's own named error */ }
         return null;
     }
 }

--- a/src/housecarl-mcp/Artifacts.cs
+++ b/src/housecarl-mcp/Artifacts.cs
@@ -1,0 +1,293 @@
+using System.Text;
+using System.Text.Json;
+using HousecarlCore;
+using Mutagen.Bethesda.Plugins;
+
+namespace HousecarlMcp;
+
+/// <summary>What the response says when its full result lives in a §2.1.1 artifact: the file, its parsed-back
+/// manifest, and WHY it was written — <c>to_file</c> (the caller forced the disposition) or <c>ceiling</c>
+/// (auto-spill: the inline render hit max_chars). Threaded into the renders so the <c>spilled</c> marker rides
+/// IN-BAND in both formats (a marker appended outside the json document would be invisible to a json consumer —
+/// the D2 pairing rule).</summary>
+internal sealed record SpillInfo(string Path, ResultArtifact.Manifest Manifest, string Reason)
+{
+    public bool ToFile => Reason == "to_file";
+}
+
+/// <summary>How a render learns its call's artifact disposition, as ONE value: a successful spill (with whether
+/// the rows are omitted — the to_file manifest-only render), or a FAILED auto-spill (the write refused — the
+/// response must then say its truncation has NO complete artifact behind it, because "truncation never loses data"
+/// is §2.1.1's promise and a silently broken promise is the Q3 case). Null = ordinary inline response.</summary>
+internal sealed record SpillState(SpillInfo? Spill, string? Failure, bool ManifestOnly)
+{
+    public static SpillState Spilled(SpillInfo s, bool manifestOnly) => new(s, null, manifestOnly);
+    public static SpillState Failed(string failure) => new(null, failure, false);
+}
+
+/// <summary>The §2.1.1 artifact layer for the bulk read lanes (tool-surface 2.0, W1): per-lane artifact BUILDERS
+/// (each writes the SAME rows its json render emits — shared row writers, so the file and the wire can only differ
+/// in formatting, never in data) and the shared in-band ACCOUNTING EMITTER for the <c>spilled</c> marker (one
+/// wording for text, one shape for json, used by every wired lane — the drift-killer the epoch stamps already
+/// established).
+///
+/// <para>Wired lanes (W1): cross_plugin_query (all three formats + group_by), batch_record_detail, resolve —
+/// the record-bulk lanes where unbounded output actually bites. The sweep lanes (check_errors/validate_scripts)
+/// get their artifacts when W2 folds them into the findings= family: their JSONL row shape IS that redesign, and
+/// wiring a throwaway nested shape now would ship a second schema W2 immediately retires.</para></summary>
+internal static class Artifacts
+{
+    // ---- the shared spilled-marker emitter (text) ---------------------------------------------------
+
+    /// <summary>Append the <c>spilled</c> block to a text response. Contract (SPEC §2.1.1): the marker MUST name
+    /// the artifact path — a pathless spill makes well-behaved callers refuse, re-pay the scan, or fabricate a
+    /// path (E4.2 run 1). The block also carries the manifest facts a caller needs to decide its next move
+    /// without opening the file: row count, schema, identity column, epoch.</summary>
+    public static void AppendSpillText(StringBuilder sb, SpillInfo s)
+    {
+        var m = s.Manifest;
+        sb.Append('\n')
+          .Append("spilled: complete result (").Append(m.RowCount).Append(m.RowCount == 1 ? " row" : " rows")
+          .Append(") -> ").Append(s.Path).Append('\n')
+          .Append(s.ToFile
+              ? "  written at your request (to_file=): only this manifest is rendered inline.\n"
+              : "  the inline render hit max_chars, so the COMPLETE result was auto-spilled (nothing is lost; the rows above are a prefix).\n")
+          .Append("  manifest: rows=").Append(m.RowCount)
+          .Append(m.Total != m.RowCount ? $" of total={m.Total}" : "")
+          .Append("  identity=").Append(m.Identity ?? "<none>")
+          .Append("  epoch=").Append(m.Epoch).Append('\n')
+          .Append("  row_schema: ").Append(string.Join(", ", m.RowSchema)).Append('\n')
+          .Append("  sort: ").Append(m.Sort).Append('\n');
+        if (m.TypeCounts is { Count: > 0 })
+            sb.Append("  type_counts: ")
+              .Append(string.Join(", ", m.TypeCounts.OrderByDescending(kv => kv.Value).ThenBy(kv => kv.Key, StringComparer.Ordinal)
+                                                    .Select(kv => $"{kv.Key}={kv.Value}"))).Append('\n');
+        sb.Append("  the file is JSONL (line 1 = this manifest, one row per line) — grep/read it with your own file tools, ")
+          .Append(m.Identity is null
+              ? "or re-run the producing query for fresh values.\n"
+              : $"or re-enter it server-side via formids=@{s.Path} / where=[\"formid in @{s.Path}\"] (epoch-checked against the current build).\n");
+    }
+
+    // ---- the shared spilled-marker emitter (json) ---------------------------------------------------
+
+    /// <summary>Write the <c>spilled</c> member into an OPEN json object — the same facts as the text block
+    /// (D2: one datum, two renders). The path is the value of <c>spilled.path</c>; its presence IS the marker.</summary>
+    public static void WriteSpillJson(Utf8JsonWriter w, SpillInfo s)
+    {
+        var m = s.Manifest;
+        w.WriteStartObject("spilled");
+        w.WriteString("path", s.Path);
+        w.WriteString("reason", s.ToFile ? "to_file" : "over_inline_ceiling");
+        w.WriteNumber("row_count", m.RowCount);
+        w.WriteNumber("total", m.Total);
+        if (m.Identity is null) w.WriteNull("identity"); else w.WriteString("identity", m.Identity);
+        w.WriteStartArray("row_schema");
+        foreach (var c in m.RowSchema) w.WriteStringValue(c);
+        w.WriteEndArray();
+        w.WriteString("sort", m.Sort);
+        if (m.TypeCounts is { Count: > 0 })
+        {
+            w.WriteStartObject("type_counts");
+            foreach (var kv in m.TypeCounts.OrderByDescending(kv => kv.Value).ThenBy(kv => kv.Key, StringComparer.Ordinal))
+                w.WriteNumber(kv.Key, kv.Value);
+            w.WriteEndObject();
+        }
+        w.WriteString("epoch", m.Epoch);
+        w.WriteEndObject();
+    }
+
+    // ---- per-lane artifact builders -----------------------------------------------------------------
+
+    /// <summary>Build + save the artifact for a cross_plugin_query result: group_by count rows, detail rows
+    /// (fields=), or summary rows — the SAME row shapes the json render emits, via the SAME row writers, filled
+    /// off the SAME pinned view the response's epoch names (ResolveReadOn/ResolveSummaryOn — a spill must never
+    /// mix builds the header claims it didn't). Returns the SpillInfo for the response marker, or a named error
+    /// the caller renders (an unwritable path must fail LOUD, not produce a response claiming a file — Q3).</summary>
+    public static (SpillInfo? Spill, string? Error) WriteCrossQuery(
+        LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields,
+        bool resolveNames, bool winnerFields, int depth,
+        string path, string reason, IReadOnlyList<KeyValuePair<string, string>> query)
+    {
+        using var writer = new ResultArtifact.Writer();
+        string[] schema;
+        string? identity;
+        string sort;
+
+        if (q.Groups is not null)                                             // group_by= → count-table rows
+        {
+            identity = null;                                                  // aggregate rows carry no per-record identity
+            schema = new[] { "key", "count" };
+            sort = "count desc, then key asc";
+            foreach (var g in q.Groups)
+                writer.WriteRow((w, _) => { w.WriteStartObject(); w.WriteString("key", g.Key); w.WriteNumber("count", g.Count); w.WriteEndObject(); });
+        }
+        else if (fields is { Count: > 0 })                                    // detail rows — full record objects
+        {
+            identity = "formid";
+            schema = new[] { "formid", "type", "editorid", "winner", "override_depth", "source", "matches?", "fields" };
+            sort = "load-order scan order (deterministic within one epoch)";
+            var linkMemo = resolveNames ? new Dictionary<FormKey, ResolvedRef>() : null;
+            for (int i = 0; i < q.Keys.Count; i++)
+            {
+                var fk = q.Keys[i];
+                string? matches = q.MatchedTargets is { } mt && i < mt.Count ? mt[i] : null;
+                var o = svc.ResolveReadOn(q, fk, winnerFields ? null : (q.Sources is { } src ? src[i] : null), fields, false, depth,
+                                          resolveNames: resolveNames, linkMemo: linkMemo);
+                if (o.Error is not null)
+                    writer.WriteRow((w, _) =>
+                    {
+                        w.WriteStartObject(); w.WriteString("formid", fk.ToString()); w.WriteString("error", o.Error);
+                        if (matches is not null) w.WriteString("matches", matches);
+                        w.WriteEndObject();
+                    });
+                else
+                    writer.WriteRow((w, ms) => JsonWire.WriteReadRecord(w, o, ms, int.MaxValue, matches), o.Record!.Type);
+            }
+        }
+        else                                                                  // summary rows
+        {
+            identity = "formid";
+            schema = new[] { "formid", "type", "editorid", "winner", "override_depth", "matches?" };
+            sort = "load-order scan order (deterministic within one epoch)";
+            for (int i = 0; i < q.Keys.Count; i++)
+            {
+                var fk = q.Keys[i];
+                string? matches = q.MatchedTargets is { } mt && i < mt.Count ? mt[i] : null;
+                var m = q.Prefilled is not null ? q.Prefilled[i] : svc.ResolveSummaryOn(q, fk);   // pinned to the scan's build
+                writer.WriteRow((w, _) => JsonWire.WriteSummaryRow(w, m, matches), m.Error is null ? m.Type : null);
+            }
+        }
+
+        var (manifest, err) = writer.Save(path, "housecarl_cross_plugin_query", query, identity, schema, sort,
+                                          q.Groups is not null ? q.Groups.Count : q.Total, q.Epoch ?? "");
+        return err is not null ? (null, err) : (new SpillInfo(path, manifest!, reason), null);
+    }
+
+    /// <summary>Build + save the artifact for a batch_record_detail result — one row per input, in input order,
+    /// exactly the rows the json render emits (per-item errors included: the artifact is the complete answer, and
+    /// a dropped error row would make the file claim a cleaner batch than the call returned).</summary>
+    public static (SpillInfo? Spill, string? Error) WriteBatch(
+        IReadOnlyList<ReadOutcome> outcomes, string path, string reason, IReadOnlyList<KeyValuePair<string, string>> query)
+    {
+        using var writer = new ResultArtifact.Writer();
+        foreach (var o in outcomes)
+        {
+            if (o.Error is not null)
+                writer.WriteRow((w, _) => { w.WriteStartObject(); w.WriteString("formid", o.FormKey.ToString()); w.WriteString("error", o.Error); w.WriteEndObject(); });
+            else
+                writer.WriteRow((w, ms) => JsonWire.WriteReadRecord(w, o, ms, int.MaxValue), o.Record!.Type);
+        }
+        // The batch's ONE build (first consulted row). A batch of pure parse-failures never consulted a build and
+        // carries "" — such an artifact refuses epoch-checked re-entry against ANY build, which is the honest answer.
+        var epoch = outcomes.FirstOrDefault(o => o.Epoch is not null)?.Epoch ?? "";
+        var (manifest, err) = writer.Save(path, "housecarl_batch_record_detail", query, "formid",
+                                          new[] { "formid", "type", "editorid", "winner", "override_depth", "source", "fields" },
+                                          "input order", outcomes.Count, epoch);
+        return err is not null ? (null, err) : (new SpillInfo(path, manifest!, reason), null);
+    }
+
+    /// <summary>Build + save the artifact for a resolve result — one identity row per input, in input order,
+    /// the json render's exact rows (per-item errors included).</summary>
+    public static (SpillInfo? Spill, string? Error) WriteResolve(
+        IReadOnlyList<ResolvedRef> rows, string epoch, string path, string reason, IReadOnlyList<KeyValuePair<string, string>> query)
+    {
+        using var writer = new ResultArtifact.Writer();
+        foreach (var r in rows)
+            writer.WriteRow((w, _) => JsonWire.WriteResolvedRow(w, r), r.Resolved ? r.Type : null);
+        var (manifest, err) = writer.Save(path, "housecarl_resolve", query, "formid",
+                                          new[] { "formid", "type", "editorid", "name", "winner" },
+                                          "input order", rows.Count, epoch);
+        return err is not null ? (null, err) : (new SpillInfo(path, manifest!, reason), null);
+    }
+
+    /// <summary>Append the whole SpillState to a text response: the spilled block, or the failed-spill warning
+    /// (a truncated response whose promised artifact could NOT be written must say so — the §2.1.1 "nothing is
+    /// ever lost silently" promise would otherwise break exactly when the disk does).</summary>
+    public static void AppendSpillStateText(StringBuilder sb, SpillState s)
+    {
+        if (s.Spill is not null) AppendSpillText(sb, s.Spill);
+        else if (s.Failure is not null)
+            sb.Append('\n')
+              .Append("WARNING: the response is truncated and the auto-spill artifact could NOT be written — ")
+              .Append(s.Failure).Append('\n')
+              .Append("  The complete result exists NOWHERE; re-run with a narrower filter, a higher max_chars, or to_file= at a writable path.\n");
+    }
+
+    /// <summary>The json twin of <see cref="AppendSpillStateText"/> — written into an OPEN object (D2 pairing).</summary>
+    public static void WriteSpillStateJson(Utf8JsonWriter w, SpillState s)
+    {
+        if (s.Spill is not null) WriteSpillJson(w, s.Spill);
+        else if (s.Failure is not null)
+            w.WriteString("spill_error",
+                "the response is truncated and the auto-spill artifact could NOT be written — " + s.Failure +
+                ". The complete result exists NOWHERE; re-run with a narrower filter, a higher max_chars, or to_file= at a writable path.");
+    }
+
+    /// <summary>Split a PLAIN list file's content into tokens — the same grammar the where-grammar's @file uses:
+    /// commas/newlines separate (never bare spaces — plugin filenames contain them), brackets/quotes stripped per
+    /// token so a pasted JSON array parses as-is.</summary>
+    public static IEnumerable<string> SplitListTokens(string content)
+    {
+        foreach (var t in content.Split(ListSeparators, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var tok = t.Trim('[', ']', '"', '\'', ' ', '\t');
+            if (tok.Length > 0) yield return tok;
+        }
+    }
+
+    static readonly char[] ListSeparators = { ',', '\r', '\n' };
+
+    /// <summary>Expand a list-valued tool input under the <c>@file</c> convention (SPEC §5.1): a single
+    /// <c>"@&lt;absolute path&gt;"</c> element IN PLACE OF the inline list reads the file — a §2.1.1 ARTIFACT
+    /// yields its identity column (formids) plus the epoch demand the consuming call must check; a plain file
+    /// yields its comma/newline-separated tokens (no epoch claim). Mixing an @ element WITH inline entries is a
+    /// named refusal (one spelling for the whole list, not a splice grammar). Non-@ input passes through
+    /// untouched. <c>EchoSource</c> is what the query echo / manifest should say the list WAS ("@path" or null
+    /// for inline).</summary>
+    public static (string[]? Tokens, ArtifactDemand? Demand, string? EchoSource, string? Error) ExpandListInput(string[] items, string paramName)
+    {
+        int atCount = items.Count(i => i is { Length: > 0 } && i.TrimStart()[0] == '@');
+        if (atCount == 0) return (items, null, null, null);
+        if (items.Length > 1)
+            return (null, null, null, $"error: {paramName}= mixes an '@file' entry with inline entries — '@<path>' stands IN PLACE OF the whole list. " +
+                                      $"Pass {paramName}=[\"@<path>\"] alone, or put every entry in the file.");
+        var path = items[0].TrimStart().Substring(1).Trim().Trim('"', '\'');
+        if (path.Length == 0)
+            return (null, null, null, $"error: {paramName}= '@' names a list file but no path follows it.");
+        if (!Path.IsPathRooted(path))
+            return (null, null, null, $"error: {paramName}= list file '{path}' must be an ABSOLUTE path — the server resolves relative paths against its OWN working directory, not yours.");
+        string content;
+        try { content = File.ReadAllText(path); }
+        catch (Exception ex) { return (null, null, null, $"error: could not read {paramName}= list file '{path}' — {ex.GetType().Name}: {ex.Message}"); }
+
+        if (ResultArtifact.LooksLikeArtifact(content))
+        {
+            var (manifest, tokens, aerr) = ResultArtifact.ReadIdentity(path, content);
+            if (aerr is not null) return (null, null, null, "error: " + aerr);
+            if (!manifest!.Identity!.Equals("formid", StringComparison.OrdinalIgnoreCase))
+                return (null, null, null, $"error: artifact '{path}' (from {manifest.Tool}) carries '{manifest.Identity}' identities, " +
+                                          $"not FormIDs — there is no formid list in it for {paramName}=.");
+            return (tokens!.ToArray(), new ArtifactDemand(path, manifest.Epoch), "@" + path, null);
+        }
+
+        var plain = SplitListTokens(content).ToArray();
+        if (plain.Length == 0)
+            return (null, null, null, $"error: {paramName}= list file '{path}' is empty — give one entry per line (or comma-separated).");
+        return (plain, null, "@" + path, null);
+    }
+
+    // ---- to_file validation -------------------------------------------------------------------------
+
+    /// <summary>Validate a caller-named <c>to_file=</c> target: absolute, .jsonl-suffixed (the artifact IS jsonl —
+    /// a .csv/.txt name would promise a format the file doesn't have), and not colliding with the auto-spill
+    /// directory's naming authority. Null = fine; else the named refusal.</summary>
+    public static string? ValidateToFile(string toFile)
+    {
+        var p = toFile.Trim();
+        if (p.Length == 0) return "error: to_file= is empty — give the ABSOLUTE path the artifact should be written to (e.g. 'C:\\work\\weapons.jsonl').";
+        if (!Path.IsPathRooted(p)) return $"error: to_file='{toFile}' must be an ABSOLUTE path — the server resolves relative paths against its OWN working directory, not yours.";
+        if (!p.EndsWith(".jsonl", StringComparison.OrdinalIgnoreCase))
+            return $"error: to_file='{toFile}' — the artifact is a JSONL file (line 1 = manifest, one JSON row per line); name it with a .jsonl extension so the file says what it is.";
+        return null;
+    }
+}

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -36,8 +36,13 @@ static class JsonWire
     /// bad/absent one (per-item, the batch survives — Q3). Budget-aware like the other JSON renders: over max_chars it
     /// drops trailing rows and flags <c>truncated</c>, keeping the document valid JSON with an exact <c>count</c>.</summary>
     public static string RenderResolve(IReadOnlyList<ResolvedRef> rows, int maxChars, string epoch)
+        => RenderResolve(rows, maxChars, epoch, null, out _);
+
+    public static string RenderResolve(IReadOnlyList<ResolvedRef> rows, int maxChars, string epoch, SpillState? spill, out bool truncated)
     {
+        truncated = false;
         int cap = Cap(maxChars);
+        bool manifestOnly = spill?.ManifestOnly ?? false;
         using var ms = new MemoryStream();
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
@@ -45,17 +50,20 @@ static class JsonWire
             w.WriteNumber("count", rows.Count);
             w.WriteString("epoch", epoch);   // §2.1.1: the ONE captured build the whole batch resolved against
             w.WriteStartArray("resolved");
-            int rendered = 0; bool truncated = false;
+            int rendered = 0; bool rowsTruncated = false;
             foreach (var r in rows)
             {
+                if (manifestOnly) break;   // to_file: the rows are the FILE
                 w.Flush();
-                if (ms.Length >= cap) { truncated = true; break; }
+                if (ms.Length >= cap) { rowsTruncated = true; break; }
                 WriteResolvedRow(w, r);
                 rendered++;
             }
             w.WriteEndArray();
             w.WriteNumber("rendered", rendered);
-            w.WriteBoolean("truncated", truncated);
+            w.WriteBoolean("truncated", rowsTruncated);
+            truncated = rowsTruncated;
+            if (spill is not null) Artifacts.WriteSpillStateJson(w, spill);
             w.WriteEndObject();
         }
         return Finish(ms);
@@ -63,7 +71,7 @@ static class JsonWire
 
     /// <summary>One housecarl_resolve row. Resolved ⇒ the identity fields; not resolved ⇒ a single <c>error</c>
     /// (the malformed-FormID reason, or "not present in the active order" for a valid-but-absent FormKey).</summary>
-    static void WriteResolvedRow(Utf8JsonWriter w, ResolvedRef r)
+    internal static void WriteResolvedRow(Utf8JsonWriter w, ResolvedRef r)
     {
         w.WriteStartObject();
         w.WriteString("formid", r.Token);
@@ -151,6 +159,23 @@ static class JsonWire
 
     static int Cap(int maxChars) => maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
 
+    /// <summary>A bare whole-call refusal document: <c>{error, epoch?}</c> — for tool-layer refusals that have no
+    /// outcome object to render (e.g. the §2.1.1 artifact epoch-mismatch handed back beside the batch), matching
+    /// the outcome-borne refusal shape so json consumers see ONE refusal grammar. The stamp rides when the refusal
+    /// consulted a build (the PR #305 contract).</summary>
+    internal static string RenderError(string error, string? epoch)
+    {
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            w.WriteString("error", error);
+            WriteNullable(w, "epoch", epoch);
+            w.WriteEndObject();
+        }
+        return Finish(ms);
+    }
+
     static void WriteStringArray(Utf8JsonWriter w, string name, IReadOnlyList<string> items)
     {
         w.WriteStartArray(name);
@@ -205,7 +230,7 @@ static class JsonWire
     /// <summary>Serialize a resolved record: identity + winner/override_depth/source + the fields array. Shared by
     /// read_record, batch_record_detail, and the cross_plugin_query detail path (one shape, no drift). <paramref
     /// name="matches"/> carries the multi-target references= un-merge when present.</summary>
-    static void WriteReadRecord(Utf8JsonWriter w, ReadOutcome o, MemoryStream ms, int cap, string? matches = null, string? epoch = null)
+    internal static void WriteReadRecord(Utf8JsonWriter w, ReadOutcome o, MemoryStream ms, int cap, string? matches = null, string? epoch = null)
     {
         var r = o.Record!;
         w.WriteStartObject();
@@ -247,8 +272,13 @@ static class JsonWire
     /// a per-item <c>{formid,error}</c> (the batch survives). Truncation drops trailing records and flags it — the
     /// document stays valid JSON (Q3), and count is exact.</summary>
     public static string RenderBatch(IReadOnlyList<ReadOutcome> outcomes, int maxChars)
+        => RenderBatch(outcomes, maxChars, null, out _);
+
+    public static string RenderBatch(IReadOnlyList<ReadOutcome> outcomes, int maxChars, SpillState? spill, out bool truncated)
     {
+        truncated = false;
         int cap = Cap(maxChars);
+        bool manifestOnly = spill?.ManifestOnly ?? false;
         using var ms = new MemoryStream();
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
@@ -258,18 +288,21 @@ static class JsonWire
             // (a malformed-FormID row never consulted a view and carries none).
             WriteNullable(w, "epoch", outcomes.FirstOrDefault(o => o.Epoch is not null)?.Epoch);
             w.WriteStartArray("records");
-            int rendered = 0; bool truncated = false;
+            int rendered = 0; bool rowsTruncated = false;
             foreach (var o in outcomes)
             {
+                if (manifestOnly) break;   // to_file: the rows are the FILE
                 w.Flush();
-                if (ms.Length >= cap) { truncated = true; break; }
+                if (ms.Length >= cap) { rowsTruncated = true; break; }
                 if (o.Error is not null) { w.WriteStartObject(); w.WriteString("formid", o.FormKey.ToString()); w.WriteString("error", o.Error); w.WriteEndObject(); }
                 else WriteReadRecord(w, o, ms, cap);
                 rendered++;
             }
             w.WriteEndArray();
             w.WriteNumber("rendered", rendered);
-            w.WriteBoolean("truncated", truncated);
+            w.WriteBoolean("truncated", rowsTruncated);
+            truncated = rowsTruncated;
+            if (spill is not null) Artifacts.WriteSpillStateJson(w, spill);
             w.WriteEndObject();
         }
         return Finish(ms);
@@ -282,13 +315,24 @@ static class JsonWire
     /// in-band. The detail path threads resolve_names through the SAME ResolveRead the text render uses, so the two
     /// modes read one path.</summary>
     public static string RenderCrossQuery(LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields, int maxChars, bool resolveNames, bool winnerFields, int depth = 1)
+        => RenderCrossQuery(svc, q, fields, maxChars, resolveNames, winnerFields, depth, null, out _);
+
+    /// <summary>The §2.1.1-aware render — see the text twin: <paramref name="spill"/> rides IN the document (a
+    /// marker outside the json body would be invisible to a json consumer), <paramref name="truncated"/> is the
+    /// auto-spill trigger handed back to the tool layer.</summary>
+    public static string RenderCrossQuery(LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields, int maxChars, bool resolveNames, bool winnerFields, int depth,
+                                          SpillState? spill, out bool truncated)
     {
+        truncated = false;
         int cap = Cap(maxChars);
+        bool manifestOnly = spill?.ManifestOnly ?? false;
         using var ms = new MemoryStream();
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
             w.WriteStartObject();
-            if (q.Error is not null) w.WriteString("error", q.Error);
+            // Post-capture refusals are stamped (PR #305 contract — e.g. the artifact epoch-mismatch refusal);
+            // pre-capture validation refusals carry null and render bare, same as the text twin.
+            if (q.Error is not null) { w.WriteString("error", q.Error); if (q.Epoch is not null) w.WriteString("epoch", q.Epoch); }
             else if (q.Groups is not null)                                   // group_by= → count table
             {
                 WriteNullable(w, "group_by", q.GroupBy);
@@ -300,6 +344,7 @@ static class JsonWire
                 int gRendered = 0; bool gTrunc = false;
                 foreach (var g in q.Groups)
                 {
+                    if (manifestOnly) break;   // to_file: the rows are the FILE
                     w.Flush();
                     if (ms.Length >= cap) { gTrunc = true; break; }
                     w.WriteStartObject(); w.WriteString("key", g.Key); w.WriteNumber("count", g.Count); w.WriteEndObject();
@@ -308,6 +353,7 @@ static class JsonWire
                 w.WriteEndArray();
                 w.WriteNumber("rendered", gRendered);
                 w.WriteBoolean("truncated", gTrunc);
+                truncated = gTrunc;
             }
             else                                                            // per-match: detail (fields=) or summary
             {
@@ -322,11 +368,11 @@ static class JsonWire
                 WriteNotes(w, q, p5);
                 var linkMemo = resolveNames && detail ? new Dictionary<FormKey, ResolvedRef>() : null;
                 w.WriteStartArray("matches");
-                int rendered = 0; bool truncated = false;
-                for (int i = 0; i < q.Keys.Count; i++)
+                int rendered = 0; bool rowsTruncated = false;
+                for (int i = 0; i < q.Keys.Count && !manifestOnly; i++)      // to_file: the rows are the FILE
                 {
                     w.Flush();
-                    if (ms.Length >= cap) { truncated = true; break; }
+                    if (ms.Length >= cap) { rowsTruncated = true; break; }
                     var fk = q.Keys[i];
                     string? matches = q.MatchedTargets is { } mt && i < mt.Count ? mt[i] : null;
                     if (detail)
@@ -347,8 +393,10 @@ static class JsonWire
                 }
                 w.WriteEndArray();
                 w.WriteNumber("rendered", rendered);
-                w.WriteBoolean("truncated", truncated);
+                w.WriteBoolean("truncated", rowsTruncated);
+                truncated = rowsTruncated;
             }
+            if (spill is not null && q.Error is null) Artifacts.WriteSpillStateJson(w, spill);
             w.WriteEndObject();
         }
         return Finish(ms);
@@ -384,13 +432,20 @@ static class JsonWire
     /// rides in-band; a row whose read FAILS lands in a separate <c>errors</c> array — never a silently missing row.
     /// group_by= never reaches here (the tool renders its count table via <see cref="RenderCrossQuery"/>).</summary>
     public static string RenderCrossQueryDense(LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields, int maxChars, bool resolveNames, bool winnerFields)
+        => RenderCrossQueryDense(svc, q, fields, maxChars, resolveNames, winnerFields, null, out _);
+
+    public static string RenderCrossQueryDense(LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields, int maxChars, bool resolveNames, bool winnerFields,
+                                               SpillState? spill, out bool truncated)
     {
+        truncated = false;
         int cap = Cap(maxChars);
+        bool manifestOnly = spill?.ManifestOnly ?? false;
         using var ms = new MemoryStream();
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
             w.WriteStartObject();
-            if (q.Error is not null) w.WriteString("error", q.Error);
+            // Post-capture refusals are stamped (PR #305 contract); pre-capture validation refusals stay bare.
+            if (q.Error is not null) { w.WriteString("error", q.Error); if (q.Epoch is not null) w.WriteString("epoch", q.Epoch); }
             else
             {
                 bool detail = fields is { Count: > 0 };
@@ -422,12 +477,12 @@ static class JsonWire
 
                 var linkMemo = resolveNames && detail ? new Dictionary<FormKey, ResolvedRef>() : null;
                 List<(string Formid, string Error)>? errors = null;
-                int rendered = 0; bool truncated = false;
+                int rendered = 0; bool rowsTruncated = false;
                 w.WriteStartArray("rows");
-                for (int i = 0; i < q.Keys.Count; i++)
+                for (int i = 0; i < q.Keys.Count && !manifestOnly; i++)      // to_file: the rows are the FILE
                 {
                     w.Flush();
-                    if (ms.Length >= cap) { truncated = true; break; }
+                    if (ms.Length >= cap) { rowsTruncated = true; break; }
                     var fk = q.Keys[i];
                     string? matches = q.MatchedTargets is { } mt && i < mt.Count ? mt[i] : null;
                     if (detail)
@@ -468,8 +523,10 @@ static class JsonWire
                     w.WriteEndArray();
                 }
                 w.WriteNumber("rendered", rendered);
-                w.WriteBoolean("truncated", truncated);
+                w.WriteBoolean("truncated", rowsTruncated);
+                truncated = rowsTruncated;
             }
+            if (spill is not null && q.Error is null) Artifacts.WriteSpillStateJson(w, spill);
             w.WriteEndObject();
         }
         return Finish(ms);
@@ -491,7 +548,7 @@ static class JsonWire
         if (v is null) w.WriteNullValue(); else w.WriteStringValue(v);
     }
 
-    static void WriteSummaryRow(Utf8JsonWriter w, RecordSummary m, string? matches)
+    internal static void WriteSummaryRow(Utf8JsonWriter w, RecordSummary m, string? matches)
     {
         w.WriteStartObject();
         w.WriteString("formid", m.FormKey.ToString());

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2398,15 +2398,39 @@ public sealed class LoadOrderService : IDisposable
     /// fields/depth/conflict_tree; anything richer is housecarl_batch_record_detail's job.</summary>
     public IReadOnlyList<ResolvedRef> ResolveRefs(IReadOnlyList<string> formids) => ResolveRefs(formids, out _);
 
+    public IReadOnlyList<ResolvedRef> ResolveRefs(IReadOnlyList<string> formids, out string epoch)
+        => ResolveRefs(formids, null, out epoch, out _);
+
+    /// <summary>The §2.1.1 artifact-epoch mismatch refusal — ONE wording for every consuming lane (cross-query
+    /// predicates, batch, resolve), naming BOTH epochs and the two legitimate next moves. Deliberately no
+    /// stale-override parameter: fresh re-projection goes through the server; honest-snapshot traversal of the
+    /// file is the client's own lane.</summary>
+    internal static string ArtifactEpochMismatch(ArtifactDemand d, string current) =>
+        $"artifact '{d.Path}' was captured at epoch={d.Epoch}, but the CURRENT load-order build is epoch={current} — " +
+        "the load order changed since the artifact was written, so its rows may resolve differently now. " +
+        "Re-run the producing query (with to_file= to re-materialize) against the current build; the old file stays " +
+        "readable with your own tools as an honest snapshot of ITS build. There is deliberately no stale-override switch.";
+
     /// <summary>As above, also handing back the captured build's <paramref name="epoch"/> fingerprint — the batch is
     /// ONE capture, and the render stamps that identity into the response's in-band accounting (SPEC §2.1.1).
     /// <see cref="ResolvedRef"/> itself stays epoch-free: it is core's per-row identity DTO, reused as the
-    /// resolve_names annotation, where a per-row stamp would be noise.</summary>
-    public IReadOnlyList<ResolvedRef> ResolveRefs(IReadOnlyList<string> formids, out string epoch)
+    /// resolve_names annotation, where a per-row stamp would be noise.
+    /// <para><paramref name="artifactDemand"/> — when the formid list came from a §2.1.1 artifact — is checked
+    /// against THIS capture's epoch (the same build that answers), and a mismatch hands back
+    /// <paramref name="artifactRefusal"/> with no rows: the refusal consulted the build, so the caller renders it
+    /// stamped with <paramref name="epoch"/>.</para></summary>
+    public IReadOnlyList<ResolvedRef> ResolveRefs(IReadOnlyList<string> formids, ArtifactDemand? artifactDemand,
+                                                  out string epoch, out string? artifactRefusal)
     {
+        artifactRefusal = null;
         var resolver = Resolver;
         var view = resolver.Capture();                  // ONE build for the whole batch (HCBR-2026-06-11-02)
         epoch = view.Epoch;
+        if (artifactDemand is not null && artifactDemand.Epoch != view.Epoch)
+        {
+            artifactRefusal = ArtifactEpochMismatch(artifactDemand, view.Epoch);
+            return Array.Empty<ResolvedRef>();
+        }
         using var session = resolver.OpenSession();
         var memo = new Dictionary<FormKey, ResolvedRef>();
         var results = new List<ResolvedRef>(formids.Count);
@@ -2564,9 +2588,25 @@ public sealed class LoadOrderService : IDisposable
     /// its own per-item error (ResolveRead's "does not define this record"), never failing the batch.</summary>
     public IReadOnlyList<ReadOutcome> ResolveBatch(IReadOnlyList<string> formids, IReadOnlyList<string>? fields, bool conflictTree, int depth = 1,
                                                    bool resolveNames = false, string? plugin = null)
+        => ResolveBatch(formids, fields, conflictTree, depth, resolveNames, plugin, null, out _, out _);
+
+    /// <summary>The §2.1.1-aware overload: <paramref name="artifactDemand"/> (a formids=@artifact input) is
+    /// checked against THIS capture's epoch — the same build that would answer — and a mismatch hands back
+    /// <paramref name="artifactRefusal"/> + <paramref name="refusalEpoch"/> with no rows (a build-consulting
+    /// refusal renders stamped, per the PR #305 contract).</summary>
+    public IReadOnlyList<ReadOutcome> ResolveBatch(IReadOnlyList<string> formids, IReadOnlyList<string>? fields, bool conflictTree, int depth,
+                                                   bool resolveNames, string? plugin, ArtifactDemand? artifactDemand,
+                                                   out string? artifactRefusal, out string? refusalEpoch)
     {
+        artifactRefusal = null; refusalEpoch = null;
         var resolver = Resolver;                // build/refresh ONCE for the batch
         var view = resolver.Capture();          // ONE build for every item — the whole batch is one logical operation (HCBR-2026-06-11-02)
+        if (artifactDemand is not null && artifactDemand.Epoch != view.Epoch)
+        {
+            artifactRefusal = ArtifactEpochMismatch(artifactDemand, view.Epoch);
+            refusalEpoch = view.Epoch;
+            return Array.Empty<ReadOutcome>();
+        }
         var pin = new ViewPin(resolver, view);
         var linkMemo = resolveNames ? new Dictionary<FormKey, ResolvedRef>() : null;   // P7: one link-resolution cache across the WHOLE batch
         var outcomes = new List<ReadOutcome>(formids.Count);
@@ -2598,7 +2638,8 @@ public sealed class LoadOrderService : IDisposable
     /// <paramref name="limit"/>, with the true total), a group table, or a recoverable Q3 error. Holds nothing.</summary>
     public CrossQueryOutcome CrossQuery(string? type, IReadOnlyList<FormKey>? references, string? editoridContains,
                                         bool conflictsOnly, IReadOnlyList<string>? plugins, IReadOnlyList<string>? where, int limit,
-                                        bool definedIn = false, string? groupBy = null, int offset = 0, string? whereSource = null)
+                                        bool definedIn = false, string? groupBy = null, int offset = 0, string? whereSource = null,
+                                        IReadOnlyList<ArtifactDemand>? artifactDemands = null)
     {
         var resolver = Resolver;
         var view = resolver.Capture();          // ONE build for the SCAN and every per-match fill it makes (HCBR-2026-06-11-02)
@@ -2681,6 +2722,16 @@ public sealed class LoadOrderService : IDisposable
             if (perr is not null) return CrossQueryOutcome.Fail(perr);
             predicate = set;
         }
+
+        // §2.1.1 artifact re-entry: every artifact-backed list input (a references=@artifact expansion passed in,
+        // or a where=["formid in @artifact"] predicate) carries the epoch its rows were captured at. Checked HERE,
+        // against the view this scan will answer from — not at the tool layer, where a freshness rebuild between
+        // check and scan would let a stale artifact through. Mismatch refuses LOUD naming both epochs, and the
+        // refusal is stamped: it consulted this build to compare (PR #305 refusal contract).
+        foreach (var demand in (artifactDemands ?? Array.Empty<ArtifactDemand>()).Concat(
+                     predicate?.ArtifactDemands ?? (IReadOnlyList<ArtifactDemand>)Array.Empty<ArtifactDemand>()))
+            if (demand.Epoch != view.Epoch)
+                return CrossQueryOutcome.Fail(ArtifactEpochMismatch(demand, view.Epoch)) with { Epoch = view.Epoch };
 
         IReadOnlyList<Type>? types;
         try { types = hasType ? ResolveTypeFilter(type!) : null; }

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -82,15 +82,68 @@ public static class ReadTools
         [Description("Optional. 'text' (default) or 'json' — a machine-readable {count, records:[…], rendered, truncated} document (each record like read_record's json; field values are the SAME tokens as text). conflict_tree is a text-only diff view.")]
             string? format = null,
         [Description("Optional. Max characters before the response stops with an explicit 'rendered X of N' notice. 0 = the server default (~80k).")]
-            int max_chars = 0) => Guard.Tool("housecarl_batch_record_detail", () =>
+            int max_chars = 0,
+        [Description("Optional. Write the COMPLETE batch to this ABSOLUTE .jsonl path as a §2.1.1 artifact (line 1 = manifest with the epoch fingerprint; then one JSON record-row per input, per-item errors included) and render only the manifest inline. Re-enter it later via formids=[\"@<path>\"] — epoch-checked against the then-current build. Not combinable with conflict_tree (a text-only view with no row form).")]
+            string? to_file = null) => Guard.Tool("housecarl_batch_record_detail", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         if (formids is null || formids.Length == 0) return "error: formids is empty. Pass one or more 'XXXXXX:Plugin.esp' FormIDs.";
         bool json = Wire.WantsJson(format, out var ferr);
         if (ferr is not null) return ferr;
         if (json && conflict_tree) return "error: conflict_tree=true is a text-only diff view and is not carried in json mode — use format=text for the conflict tree, or drop conflict_tree for the json field data.";
-        var outcomes = svc.ResolveBatch(formids, fields, conflict_tree, depth <= 0 ? 1 : depth, resolve_names, plugin?.Trim());
-        return json ? JsonWire.RenderBatch(outcomes, max_chars) : Wire.RenderBatch(svc, outcomes, fields, conflict_tree, max_chars);
+
+        // formids= under the @file convention (§5.1): a single "@<path>" element stands for the whole list — a
+        // plain file's tokens, or a §2.1.1 artifact's identity column + its epoch demand (checked in the batch's
+        // own capture: scan once, project forever, never against a build the artifact didn't come from).
+        var (toks, demand, echoSrc, xerr) = Artifacts.ExpandListInput(formids, "formids");
+        if (xerr is not null) return xerr;
+        formids = toks!;
+
+        var toFile = to_file?.Trim();
+        bool wantFile = !string.IsNullOrEmpty(toFile);
+        if (wantFile)
+        {
+            if (Artifacts.ValidateToFile(toFile!) is { } verr) return verr;
+            if (conflict_tree) return "error: to_file= writes the result as JSONL rows, and conflict_tree=true is a text-only diff view with no row form — drop one of the two.";
+        }
+
+        var outcomes = svc.ResolveBatch(formids, fields, conflict_tree, depth <= 0 ? 1 : depth, resolve_names, plugin?.Trim(),
+                                        demand, out var artifactRefusal, out var refusalEpoch);
+        if (artifactRefusal is not null)
+            return json ? JsonWire.RenderError(artifactRefusal, refusalEpoch)
+                        : "error: " + artifactRefusal + (refusalEpoch is not null ? $"\nepoch={refusalEpoch}" : "");
+
+        List<KeyValuePair<string, string>> Echo()
+        {
+            var e = new List<KeyValuePair<string, string>> { new("formids", echoSrc ?? $"{formids.Length} inline formid(s)") };
+            void Add(string k, string? v) { if (!string.IsNullOrEmpty(v)) e.Add(new(k, v!)); }
+            Add("plugin", plugin?.Trim());
+            Add("fields", fields is { Length: > 0 } ? string.Join(", ", fields) : null);
+            if (depth > 1) Add("depth", depth.ToString());
+            return e;
+        }
+
+        SpillState? spill = null;
+        if (wantFile)
+        {
+            var (s, aerr) = Artifacts.WriteBatch(outcomes, toFile!, "to_file", Echo());
+            if (aerr is not null) return "error: " + aerr;
+            spill = SpillState.Spilled(s!, manifestOnly: true);
+        }
+
+        string Render(SpillState? sp, out bool trunc) => json
+            ? JsonWire.RenderBatch(outcomes, max_chars, sp, out trunc)
+            : Wire.RenderBatch(svc, outcomes, fields, conflict_tree, max_chars, sp, out trunc);
+        var rendered = Render(spill, out var truncated);
+        if (spill is null && truncated)
+        {
+            // AUTO-SPILL (§2.1.1): the complete batch goes to the server results dir; the response re-renders
+            // with the spilled marker in-band. See cross_plugin_query's twin for the contract notes.
+            var path = ResultsStore.NextPath("housecarl_batch_record_detail", outcomes.FirstOrDefault(o => o.Epoch is not null)?.Epoch ?? "none");
+            var (s, aerr) = Artifacts.WriteBatch(outcomes, path, "ceiling", Echo());
+            rendered = Render(aerr is null ? SpillState.Spilled(s!, manifestOnly: false) : SpillState.Failed(aerr), out _);
+        }
+        return rendered;
     });
 
     [McpServerTool(Name = "housecarl_diff_record", ReadOnly = true, Title = "Diff two plugins' versions of a record"),
@@ -187,7 +240,9 @@ public static class ReadTools
         [Description("Optional. Skip the first N post-filter matches before returning rows (#223 pagination) — combine with limit= to page a big enumeration in windows (offset=0/500/1000…). Scan order is deterministic while the load order is unchanged, so windows tile exactly. The true total always counts ALL matches. Not valid with group_by= (a count table has no window). Every response carries epoch=<hex> in-band — the identity of the load-order build it was answered from: windows tile ONLY within one epoch, so if two pages' epochs differ, the load order changed mid-pagination and the pages must not be stitched (re-run from offset=0).")]
             int offset = 0,
         [Description("Optional. Max characters before the response stops with an explicit notice. 0 = the server default (~80k).")]
-            int max_chars = 0) => Guard.Tool("housecarl_cross_plugin_query", () =>
+            int max_chars = 0,
+        [Description("Optional. Write the COMPLETE result to this ABSOLUTE .jsonl path as a §2.1.1 artifact (line 1 = a manifest carrying the query echo, row count/schema, and the epoch fingerprint; then one JSON row per match) and render only the manifest inline. The artifact is never windowed: limit=/offset= do not apply to it (offset= is refused with to_file=). Re-enter it later via where=[\"formid in @<path>\"] — epoch-checked against the then-current build. Not combinable with conflict_tree (a text-only view with no row form).")]
+            string? to_file = null) => Guard.Tool("housecarl_cross_plugin_query", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         var fmt = Wire.CrossQueryFormat(format, out var ferr);
@@ -202,6 +257,16 @@ public static class ReadTools
             return "error: depth= expands the list/dict contents of fields= paths, and no fields= was passed — summary lines have nothing to expand. Pass fields= (e.g. fields=['Effects'], depth=4) or conflict_tree=true (the whole-record dump), or drop depth=.";
         if (depth > 1 && fmt is Wire.QueryFormat.Dense)
             return "error: depth>1 is not carried in format='dense' — dense rows are positional (one cell per requested fields= path), and depth expansion emits extra sub-paths that would break the column alignment. Use format=text or format=json for depth expansion, or drop depth= for the dense summary cells.";
+        // references= may itself be an @file / @artifact list (the §5.1 @file convention) — expanded BEFORE the
+        // FormKey parse; an artifact target contributes its epoch demand, checked inside the scan's own capture.
+        HousecarlCore.ArtifactDemand? refDemand = null;
+        string? refEcho = null;
+        if (references is { Length: > 0 })
+        {
+            var (toks, demand, echoSrc, xerr) = Artifacts.ExpandListInput(references, "references");
+            if (xerr is not null) return xerr;
+            references = toks!; refDemand = demand; refEcho = echoSrc;
+        }
         IReadOnlyList<FormKey>? refFks = null;
         if (references is { Length: > 0 })
         {
@@ -214,15 +279,71 @@ public static class ReadTools
             }
             if (list.Count > 0) refFks = list.Distinct().ToList();   // preserve input order, drop dupes
         }
-        var outcome = svc.CrossQuery(type, refFks, editorid_contains, conflicts_only, plugins, where, limit <= 0 ? 500 : limit, defined_in, group_by, offset, where_source);
+
+        // to_file= (§2.1.1): validated BEFORE the scan — a doomed disposition must not pay a scan first.
+        var toFile = to_file?.Trim();
+        bool wantFile = !string.IsNullOrEmpty(toFile);
+        if (wantFile)
+        {
+            if (Artifacts.ValidateToFile(toFile!) is { } verr) return verr;
+            if (conflict_tree) return "error: to_file= writes the result as JSONL rows, and conflict_tree=true is a text-only diff view with no row form — drop one of the two.";
+            if (offset > 0) return "error: to_file= captures the COMPLETE result (the artifact is never a window), so offset= has nothing to page — drop offset=.";
+        }
+
+        var outcome = svc.CrossQuery(type, refFks, editorid_contains, conflicts_only, plugins, where,
+                                     wantFile ? int.MaxValue : (limit <= 0 ? 500 : limit),   // to_file: the artifact is the FULL result, never limit-windowed
+                                     defined_in, group_by, offset, where_source,
+                                     refDemand is null ? null : new[] { refDemand });
+
+        // The query echo the manifest carries — what produced this artifact, readable without this conversation.
+        List<KeyValuePair<string, string>> Echo()
+        {
+            var e = new List<KeyValuePair<string, string>>();
+            void Add(string k, string? v) { if (!string.IsNullOrEmpty(v)) e.Add(new(k, v!)); }
+            Add("type", type);
+            Add("references", refEcho ?? (references is { Length: > 0 } ? string.Join(", ", references) : null));
+            Add("editorid_contains", editorid_contains);
+            if (conflicts_only) Add("conflicts_only", "true");
+            Add("plugins", plugins is { Length: > 0 } ? string.Join(", ", plugins) : null);
+            if (defined_in) Add("defined_in", "true");
+            Add("where", where is { Length: > 0 } ? string.Join(" AND ", where) : null);
+            Add("group_by", group_by);
+            Add("fields", fields is { Length: > 0 } ? string.Join(", ", fields) : null);
+            if (depth > 1) Add("depth", depth.ToString());
+            if (winner_fields) Add("winner_fields", "true");
+            Add("where_source", where_source);
+            return e;
+        }
+
+        SpillState? spill = null;
+        if (wantFile && outcome.Error is null)
+        {
+            var (s, aerr) = Artifacts.WriteCrossQuery(svc, outcome, fields, resolve_names, winner_fields, depth, toFile!, "to_file", Echo());
+            if (aerr is not null) return "error: " + aerr;
+            spill = SpillState.Spilled(s!, manifestOnly: true);
+        }
+
         // dense + group_by: the count table is already columnar — render it exactly as json (documented on format=),
         // so dense is never a refusal there and the two renders can't drift.
-        return fmt switch
+        string Render(SpillState? sp, out bool trunc) => fmt switch
         {
-            Wire.QueryFormat.Dense when group_by is null => JsonWire.RenderCrossQueryDense(svc, outcome, fields, max_chars, resolve_names, winner_fields),
-            Wire.QueryFormat.Dense or Wire.QueryFormat.Json => JsonWire.RenderCrossQuery(svc, outcome, fields, max_chars, resolve_names, winner_fields, depth),
-            _ => Wire.RenderCrossQuery(svc, outcome, fields, conflict_tree, max_chars, resolve_names, winner_fields, depth),
+            Wire.QueryFormat.Dense when group_by is null => JsonWire.RenderCrossQueryDense(svc, outcome, fields, max_chars, resolve_names, winner_fields, sp, out trunc),
+            Wire.QueryFormat.Dense or Wire.QueryFormat.Json => JsonWire.RenderCrossQuery(svc, outcome, fields, max_chars, resolve_names, winner_fields, depth, sp, out trunc),
+            _ => Wire.RenderCrossQuery(svc, outcome, fields, conflict_tree, max_chars, resolve_names, winner_fields, depth, sp, out trunc),
         };
+        var rendered = Render(spill, out var truncated);
+        if (spill is null && truncated && outcome.Error is null)
+        {
+            // AUTO-SPILL (§2.1.1, decided over refuse-and-redirect): the inline render hit max_chars, so the
+            // complete requested window goes to the server results dir and the response re-renders with the
+            // spilled marker IN-BAND (both formats). The rows are re-filled off the SAME pinned view the scan
+            // stamped, so the file cannot mix builds the header didn't claim. A failed write re-renders with the
+            // failure named — a truncated response silently missing its promised artifact is the Q3 case.
+            var path = ResultsStore.NextPath("housecarl_cross_plugin_query", outcome.Epoch ?? "none");
+            var (s, aerr) = Artifacts.WriteCrossQuery(svc, outcome, fields, resolve_names, winner_fields, depth, path, "ceiling", Echo());
+            rendered = Render(aerr is null ? SpillState.Spilled(s!, manifestOnly: false) : SpillState.Failed(aerr), out _);
+        }
+        return rendered;
     });
 
     [McpServerTool(Name = "housecarl_resolve", ReadOnly = true, Title = "Resolve FormIDs to their identity"),
@@ -245,14 +366,50 @@ public static class ReadTools
         [Description("Optional. 'text' (default) — one compact identity line per FormID — or 'json' for a machine-readable document (one {formid,type,editorid,name,winner} row per input; a bad/absent input carries {formid,error}).")]
             string? format = null,
         [Description("Optional. Max characters before the response stops with an explicit notice (text) or drops trailing rows with truncated=true (json). 0 = the server default (~80k).")]
-            int max_chars = 0) => Guard.Tool("housecarl_resolve", () =>
+            int max_chars = 0,
+        [Description("Optional. Write the COMPLETE identity table to this ABSOLUTE .jsonl path as a §2.1.1 artifact (line 1 = manifest with the epoch fingerprint; then one identity row per input, per-item errors included) and render only the manifest inline. Re-enter it later via formids=[\"@<path>\"] — epoch-checked against the then-current build.")]
+            string? to_file = null) => Guard.Tool("housecarl_resolve", () =>
     {
         if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
         if (formids is null || formids.Length == 0) return "error: formids is empty. Pass one or more 'XXXXXX:Plugin.esp' FormIDs.";
         bool json = Wire.WantsJson(format, out var ferr);
         if (ferr is not null) return ferr;
-        var rows = svc.ResolveRefs(formids, out var epoch);
-        return json ? JsonWire.RenderResolve(rows, max_chars, epoch) : Wire.RenderResolve(rows, max_chars, epoch);
+
+        // formids= under the @file convention — see batch_record_detail's twin.
+        var (toks, demand, echoSrc, xerr) = Artifacts.ExpandListInput(formids, "formids");
+        if (xerr is not null) return xerr;
+        formids = toks!;
+
+        var toFile = to_file?.Trim();
+        bool wantFile = !string.IsNullOrEmpty(toFile);
+        if (wantFile && Artifacts.ValidateToFile(toFile!) is { } verr) return verr;
+
+        var rows = svc.ResolveRefs(formids, demand, out var epoch, out var artifactRefusal);
+        if (artifactRefusal is not null)
+            return json ? JsonWire.RenderError(artifactRefusal, epoch)
+                        : "error: " + artifactRefusal + $"\nepoch={epoch}";
+
+        var echo = new List<KeyValuePair<string, string>> { new("formids", echoSrc ?? $"{formids.Length} inline formid(s)") };
+        SpillState? spill = null;
+        if (wantFile)
+        {
+            var (s, aerr) = Artifacts.WriteResolve(rows, epoch, toFile!, "to_file", echo);
+            if (aerr is not null) return "error: " + aerr;
+            spill = SpillState.Spilled(s!, manifestOnly: true);
+        }
+
+        string Render(SpillState? sp, out bool trunc) => json
+            ? JsonWire.RenderResolve(rows, max_chars, epoch, sp, out trunc)
+            : Wire.RenderResolve(rows, max_chars, epoch, sp, out trunc);
+        var rendered = Render(spill, out var truncated);
+        if (spill is null && truncated)
+        {
+            // AUTO-SPILL (§2.1.1) — see cross_plugin_query's twin for the contract notes.
+            var path = ResultsStore.NextPath("housecarl_resolve", epoch);
+            var (s, aerr) = Artifacts.WriteResolve(rows, epoch, path, "ceiling", echo);
+            rendered = Render(aerr is null ? SpillState.Spilled(s!, manifestOnly: false) : SpillState.Failed(aerr), out _);
+        }
+        return rendered;
     });
 
     [McpServerTool(Name = "housecarl_effect_chain", ReadOnly = true, Title = "Resolve an effect's carriers + magnitudes"),
@@ -547,15 +704,20 @@ static class Wire
     /// FormID (type/editorid/name/winner), or <c>error=</c> for a bad/absent input (per-item, the batch survives — Q3).
     /// Budget-bounded with the same explicit cut the other reads use.</summary>
     public static string RenderResolve(IReadOnlyList<ResolvedRef> rows, int maxChars, string epoch)
+        => RenderResolve(rows, maxChars, epoch, null, out _);
+
+    public static string RenderResolve(IReadOnlyList<ResolvedRef> rows, int maxChars, string epoch, SpillState? spill, out bool truncated)
     {
+        truncated = false;
         int cap = Cap(maxChars);
         var sb = new StringBuilder();
         sb.Append("resolve: ").Append(rows.Count).Append(rows.Count == 1 ? " formid" : " formids")
           .Append("  epoch=").Append(epoch).Append('\n');
-        for (int i = 0; i < rows.Count; i++)
+        for (int i = 0; i < rows.Count && !(spill?.ManifestOnly ?? false); i++)
         {
             if (sb.Length >= cap)
             {
+                truncated = true;
                 sb.Append("... [truncated: rendered ").Append(i).Append(" of ").Append(rows.Count)
                   .Append(" at max_chars=").Append(cap).Append("; request fewer formids or raise max_chars]\n");
                 break;
@@ -571,6 +733,7 @@ static class Wire
             else sb.Append("  error=").Append(r.Error ?? "not present in the active order");
             sb.Append('\n');
         }
+        if (spill is not null) Artifacts.AppendSpillStateText(sb, spill);
         return sb.ToString().TrimEnd('\n');
     }
 
@@ -591,7 +754,12 @@ static class Wire
 
     // ---- housecarl_batch_record_detail --------------------------------------------------------------
     public static string RenderBatch(LoadOrderService svc, IReadOnlyList<ReadOutcome> outcomes, IReadOnlyList<string>? fields, bool conflictTree, int maxChars)
+        => RenderBatch(svc, outcomes, fields, conflictTree, maxChars, null, out _);
+
+    public static string RenderBatch(LoadOrderService svc, IReadOnlyList<ReadOutcome> outcomes, IReadOnlyList<string>? fields, bool conflictTree, int maxChars,
+                                     SpillState? spill, out bool truncated)
     {
+        truncated = false;
         int cap = Cap(maxChars);
         var sb = new StringBuilder();
         sb.Append("batch: ").Append(outcomes.Count).Append(outcomes.Count == 1 ? " record" : " records");
@@ -602,8 +770,10 @@ static class Wire
         int rendered = 0;
         foreach (var o in outcomes)
         {
+            if (spill?.ManifestOnly ?? false) break;   // to_file: only the manifest renders — the rows are the FILE
             if (sb.Length >= cap)
             {
+                truncated = true;
                 sb.Append("... [truncated: rendered ").Append(rendered).Append(" of ").Append(outcomes.Count)
                   .Append(" records before hitting max_chars=").Append(cap)
                   .Append("; request fewer formids, pass fields= to slim each, or raise max_chars]\n");
@@ -614,6 +784,7 @@ static class Wire
             else { AppendRecord(sb, o, cap); if (conflictTree) AppendConflictTree(sb, svc, o, fields, cap); }
             rendered++;
         }
+        if (spill is not null) Artifacts.AppendSpillStateText(sb, spill);
         return sb.ToString().TrimEnd('\n');
     }
 
@@ -628,10 +799,20 @@ static class Wire
 
     public static string RenderCrossQuery(LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields, bool conflictTree, int maxChars,
                                           bool resolveNames = false, bool winnerFields = false, int depth = 1)
+        => RenderCrossQuery(svc, q, fields, conflictTree, maxChars, resolveNames, winnerFields, depth, null, out _);
+
+    /// <summary>The §2.1.1-aware render: <paramref name="spill"/> carries the call's artifact disposition (the
+    /// spilled marker / to_file manifest-only mode / failed-spill warning), and <paramref name="truncated"/> hands
+    /// the row-level max_chars cut back to the tool layer — the auto-spill trigger.</summary>
+    public static string RenderCrossQuery(LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields, bool conflictTree, int maxChars,
+                                          bool resolveNames, bool winnerFields, int depth, SpillState? spill, out bool truncated)
     {
-        if (q.Error is not null) return "error: " + q.Error;
+        truncated = false;
+        // A post-capture refusal is stamped (PR #305 contract) — e.g. the artifact epoch-mismatch refusal, which
+        // consulted the build to compare against it. Pre-capture validation refusals carry null and render bare.
+        if (q.Error is not null) return "error: " + q.Error + (q.Epoch is not null ? $"\nepoch={q.Epoch}" : "");
         int cap = Cap(maxChars);
-        if (q.Groups is not null) return RenderCrossQueryGroups(q, cap);   // group_by= → a count table, not per-match lines
+        if (q.Groups is not null) return RenderCrossQueryGroups(q, cap, spill, out truncated);   // group_by= → a count table, not per-match lines
         bool detail = (fields is { Count: > 0 }) || conflictTree;          // expand matches, vs. one-line summaries
         var linkMemo = resolveNames && detail ? new Dictionary<FormKey, ResolvedRef>() : null;   // P7: one link cache across all rendered matches
         bool anyScoped = detail && q.Sources is { } ss && ss.Take(q.Keys.Count).Any(s => s is not null);   // P5: plugins= scope shows a plugin's OWN body
@@ -662,10 +843,11 @@ static class Wire
         if (anyScoped) sb.Append("note: ").Append(JsonWire.ScopedFieldsNote(winnerFields, q.WhereWinner)).Append('\n');
 
         int rendered = 0;
-        for (int i = 0; i < q.Keys.Count; i++)
+        for (int i = 0; i < q.Keys.Count && !(spill?.ManifestOnly ?? false); i++)   // to_file: only the manifest renders — the rows are the FILE
         {
             if (sb.Length >= cap)
             {
+                truncated = true;
                 sb.Append("... [truncated: rendered ").Append(rendered).Append(" of ").Append(q.Keys.Count)
                   .Append(" returned matches before hitting max_chars=").Append(cap)
                   .Append("; lower limit=, drop fields=/conflict_tree, or raise max_chars]\n");
@@ -700,6 +882,7 @@ static class Wire
             }
             rendered++;
         }
+        if (spill is not null) Artifacts.AppendSpillStateText(sb, spill);
         return sb.ToString().TrimEnd('\n');
     }
 
@@ -707,8 +890,9 @@ static class Wire
     /// count, then one "  &lt;key&gt; = &lt;count&gt;" row per group (already sorted desc by the core). Q3 accounting
     /// (where= / unscannable notes) survives the aggregation. Over max_chars it stops with the explicit truncation
     /// notice — the count is exact even when the row LIST is clipped (aggregation isn't limit-capped; only rendering is).</summary>
-    static string RenderCrossQueryGroups(CrossQueryOutcome q, int cap)
+    static string RenderCrossQueryGroups(CrossQueryOutcome q, int cap, SpillState? spill, out bool truncated)
     {
+        truncated = false;
         var groups = q.Groups!;
         var sb = new StringBuilder();
         sb.Append("cross_plugin_query: grouped by ").Append(q.GroupBy).Append(" — ")
@@ -719,16 +903,18 @@ static class Wire
         sb.Append('\n');
         if (q.PredicateNote is not null) sb.Append(q.PredicateNote).Append('\n');
         if (q.ScanNote is not null) sb.Append(q.ScanNote).Append('\n');
-        for (int i = 0; i < groups.Count; i++)
+        for (int i = 0; i < groups.Count && !(spill?.ManifestOnly ?? false); i++)   // to_file: rows live in the file
         {
             if (sb.Length >= cap)
             {
+                truncated = true;
                 sb.Append("... [truncated: rendered ").Append(i).Append(" of ").Append(groups.Count)
                   .Append(" groups before hitting max_chars=").Append(cap).Append("; raise max_chars — the total above is exact]\n");
                 break;
             }
             sb.Append("  ").Append(groups[i].Key).Append(" = ").Append(groups[i].Count).Append('\n');
         }
+        if (spill is not null) Artifacts.AppendSpillStateText(sb, spill);
         return sb.ToString().TrimEnd('\n');
     }
 

--- a/src/housecarl-mcp/ReadTools.cs
+++ b/src/housecarl-mcp/ReadTools.cs
@@ -127,7 +127,9 @@ public static class ReadTools
         if (wantFile)
         {
             var (s, aerr) = Artifacts.WriteBatch(outcomes, toFile!, "to_file", Echo());
-            if (aerr is not null) return "error: " + aerr;
+            if (aerr is not null)
+                // Post-scan failure keeps the format contract (review finding 4) — never bare text under json.
+                return json ? JsonWire.RenderError(aerr, outcomes.FirstOrDefault(o => o.Epoch is not null)?.Epoch) : "error: " + aerr;
             spill = SpillState.Spilled(s!, manifestOnly: true);
         }
 
@@ -139,9 +141,17 @@ public static class ReadTools
         {
             // AUTO-SPILL (§2.1.1): the complete batch goes to the server results dir; the response re-renders
             // with the spilled marker in-band. See cross_plugin_query's twin for the contract notes.
-            var path = ResultsStore.NextPath("housecarl_batch_record_detail", outcomes.FirstOrDefault(o => o.Epoch is not null)?.Epoch ?? "none");
-            var (s, aerr) = Artifacts.WriteBatch(outcomes, path, "ceiling", Echo());
-            rendered = Render(aerr is null ? SpillState.Spilled(s!, manifestOnly: false) : SpillState.Failed(aerr), out _);
+            if (conflict_tree)
+                // WriteBatch rows carry no conflict tree — same no-row-form honesty as the cross-query twin
+                // (review finding 1).
+                rendered = Render(SpillState.NoRowForm(), out _);
+            else
+            {
+                var path = ResultsStore.NextPath("housecarl_batch_record_detail", outcomes.FirstOrDefault(o => o.Epoch is not null)?.Epoch ?? "none");
+                var (s, aerr) = Artifacts.WriteBatch(outcomes, path, "ceiling", Echo());
+                if (aerr is not null) ResultsStore.Release(path);
+                rendered = Render(aerr is null ? SpillState.Spilled(s!, manifestOnly: false) : SpillState.WriteFailed(aerr), out _);
+            }
         }
         return rendered;
     });
@@ -319,7 +329,10 @@ public static class ReadTools
         if (wantFile && outcome.Error is null)
         {
             var (s, aerr) = Artifacts.WriteCrossQuery(svc, outcome, fields, resolve_names, winner_fields, depth, toFile!, "to_file", Echo());
-            if (aerr is not null) return "error: " + aerr;
+            if (aerr is not null)
+                // A POST-scan failure must keep the format contract — a bare text "error:" under format=json/dense
+                // hands a json consumer a non-document (review finding 4).
+                return fmt is Wire.QueryFormat.Text ? "error: " + aerr : JsonWire.RenderError(aerr, outcome.Epoch);
             spill = SpillState.Spilled(s!, manifestOnly: true);
         }
 
@@ -339,9 +352,17 @@ public static class ReadTools
             // spilled marker IN-BAND (both formats). The rows are re-filled off the SAME pinned view the scan
             // stamped, so the file cannot mix builds the header didn't claim. A failed write re-renders with the
             // failure named — a truncated response silently missing its promised artifact is the Q3 case.
-            var path = ResultsStore.NextPath("housecarl_cross_plugin_query", outcome.Epoch ?? "none");
-            var (s, aerr) = Artifacts.WriteCrossQuery(svc, outcome, fields, resolve_names, winner_fields, depth, path, "ceiling", Echo());
-            rendered = Render(aerr is null ? SpillState.Spilled(s!, manifestOnly: false) : SpillState.Failed(aerr), out _);
+            if (conflict_tree)
+                // No row form for the trees (to_file refuses on the same ground) — spilling thinner tree-less rows
+                // under a completeness claim would silently substitute the shape (review finding 1). Say so instead.
+                rendered = Render(SpillState.NoRowForm(), out _);
+            else
+            {
+                var path = ResultsStore.NextPath("housecarl_cross_plugin_query", outcome.Epoch ?? "none");
+                var (s, aerr) = Artifacts.WriteCrossQuery(svc, outcome, fields, resolve_names, winner_fields, depth, path, "ceiling", Echo());
+                if (aerr is not null) ResultsStore.Release(path);   // don't leave the empty reservation behind
+                rendered = Render(aerr is null ? SpillState.Spilled(s!, manifestOnly: false) : SpillState.WriteFailed(aerr), out _);
+            }
         }
         return rendered;
     });
@@ -394,7 +415,9 @@ public static class ReadTools
         if (wantFile)
         {
             var (s, aerr) = Artifacts.WriteResolve(rows, epoch, toFile!, "to_file", echo);
-            if (aerr is not null) return "error: " + aerr;
+            if (aerr is not null)
+                // Post-scan failure keeps the format contract (review finding 4).
+                return json ? JsonWire.RenderError(aerr, epoch) : "error: " + aerr;
             spill = SpillState.Spilled(s!, manifestOnly: true);
         }
 
@@ -407,7 +430,8 @@ public static class ReadTools
             // AUTO-SPILL (§2.1.1) — see cross_plugin_query's twin for the contract notes.
             var path = ResultsStore.NextPath("housecarl_resolve", epoch);
             var (s, aerr) = Artifacts.WriteResolve(rows, epoch, path, "ceiling", echo);
-            rendered = Render(aerr is null ? SpillState.Spilled(s!, manifestOnly: false) : SpillState.Failed(aerr), out _);
+            if (aerr is not null) ResultsStore.Release(path);
+            rendered = Render(aerr is null ? SpillState.Spilled(s!, manifestOnly: false) : SpillState.WriteFailed(aerr), out _);
         }
         return rendered;
     });

--- a/src/housecarl-mcp/ResultsStore.cs
+++ b/src/housecarl-mcp/ResultsStore.cs
@@ -1,0 +1,73 @@
+namespace HousecarlMcp;
+
+/// <summary>The server-managed results directory for AUTO-SPILLED §2.1.1 artifacts (a caller-named
+/// <c>to_file=</c> target never comes here). Decisions this class pins (Phase-4 detail the SPEC delegated):
+///
+/// <list type="bullet">
+/// <item><b>Location:</b> <c>&lt;HOUSECARL_DATA_DIR&gt;\results</c> — the plugin's own persistent data folder,
+/// falling back to the server binary's folder when the env var is absent (the same resolution Program.cs uses for
+/// user config, so results live beside the config that produced them, never inside the MO2 instance).</item>
+/// <item><b>Naming:</b> <c>&lt;tool&gt;_&lt;utc yyyyMMdd-HHmmss&gt;_&lt;epoch&gt;.jsonl</c> (tool minus the
+/// <c>housecarl_</c> prefix; epoch = the build fingerprint the result was read from) — sortable by time, and the
+/// epoch is visible in a directory listing before a single file is opened. A same-second collision appends a
+/// counter rather than overwriting: artifacts are immutable once written.</item>
+/// <item><b>Prune-by-age at write:</b> spilled artifacts older than <see cref="PruneAfterDays"/> days are deleted
+/// (best-effort, per-file) each time a new spill is written — no daemon, no timer, no state; write time is the one
+/// moment the server is already touching the directory. 7 days: an artifact outlives any working session that
+/// produced it, while a stale one is already refusing epoch-checked re-entry long before it's pruned. Only
+/// <c>*.jsonl</c> in THIS directory is ever touched.</item>
+/// </list></summary>
+static class ResultsStore
+{
+    public const int PruneAfterDays = 7;
+
+    /// <summary>The results directory (created on demand). Overridable for tests via
+    /// <see cref="OverrideDirForTests"/> — production resolution is env-var → binary folder.</summary>
+    public static string Dir
+    {
+        get
+        {
+            if (OverrideDirForTests is { } o) return o;
+            var dataDir = Environment.GetEnvironmentVariable("HOUSECARL_DATA_DIR");
+            var root = string.IsNullOrWhiteSpace(dataDir) ? AppContext.BaseDirectory : dataDir;
+            return Path.Combine(root, "results");
+        }
+    }
+
+    /// <summary>Test seam: point the store at a temp directory. Never set in production code paths.</summary>
+    public static string? OverrideDirForTests;
+
+    /// <summary>Reserve a fresh artifact path for an auto-spill from <paramref name="tool"/> at build
+    /// <paramref name="epoch"/>, pruning old spills on the way (the write-time prune). Returns a path that does
+    /// not yet exist; a same-second collision gets a counter suffix.</summary>
+    public static string NextPath(string tool, string epoch)
+    {
+        var dir = Dir;
+        // Best-effort here: if the directory cannot be created, the Writer's Save on the returned path produces
+        // the NAMED write failure, which flows into the response as the failed-spill warning — a throw here would
+        // instead surface as a generic tool error and eat the (valid, truncated) response entirely.
+        try { Directory.CreateDirectory(dir); Prune(dir); } catch (Exception) { }
+        var shortTool = tool.StartsWith("housecarl_", StringComparison.Ordinal) ? tool["housecarl_".Length..] : tool;
+        var stamp = DateTime.UtcNow.ToString("yyyyMMdd-HHmmss");
+        var basePath = Path.Combine(dir, $"{shortTool}_{stamp}_{epoch}");
+        var path = basePath + ".jsonl";
+        for (int n = 2; File.Exists(path); n++) path = $"{basePath}-{n}.jsonl";
+        return path;
+    }
+
+    /// <summary>Delete spilled artifacts older than <see cref="PruneAfterDays"/> days. Best-effort per file — a
+    /// locked or vanished file is skipped, never fatal (pruning is hygiene, not correctness; epoch-checked
+    /// re-entry is what protects against staleness).</summary>
+    static void Prune(string dir)
+    {
+        var cutoff = DateTime.UtcNow.AddDays(-PruneAfterDays);
+        try
+        {
+            foreach (var f in Directory.EnumerateFiles(dir, "*.jsonl"))
+                try { if (File.GetLastWriteTimeUtc(f) < cutoff) File.Delete(f); }
+                catch (IOException) { /* locked/raced — next write retries */ }
+                catch (UnauthorizedAccessException) { /* same */ }
+        }
+        catch (Exception) { /* enumeration failure — hygiene only, never blocks the spill */ }
+    }
+}

--- a/src/housecarl-mcp/ResultsStore.cs
+++ b/src/housecarl-mcp/ResultsStore.cs
@@ -38,8 +38,12 @@ static class ResultsStore
     public static string? OverrideDirForTests;
 
     /// <summary>Reserve a fresh artifact path for an auto-spill from <paramref name="tool"/> at build
-    /// <paramref name="epoch"/>, pruning old spills on the way (the write-time prune). Returns a path that does
-    /// not yet exist; a same-second collision gets a counter suffix.</summary>
+    /// <paramref name="epoch"/>, pruning old spills on the way (the write-time prune). The reservation is ATOMIC —
+    /// the file is CREATED (empty) here with <c>FileMode.CreateNew</c>, not merely probed with File.Exists, because
+    /// parallel tool calls are a normal client pattern and a check-then-write race would hand two same-second
+    /// spills the same path, one silently overwriting the other (PR #306 review). The Writer's temp-then-move
+    /// replaces the empty reservation wholesale; a spill that later FAILS deletes its reservation via
+    /// <see cref="Release"/>. A same-second collision gets a counter suffix.</summary>
     public static string NextPath(string tool, string epoch)
     {
         var dir = Dir;
@@ -50,20 +54,38 @@ static class ResultsStore
         var shortTool = tool.StartsWith("housecarl_", StringComparison.Ordinal) ? tool["housecarl_".Length..] : tool;
         var stamp = DateTime.UtcNow.ToString("yyyyMMdd-HHmmss");
         var basePath = Path.Combine(dir, $"{shortTool}_{stamp}_{epoch}");
-        var path = basePath + ".jsonl";
-        for (int n = 2; File.Exists(path); n++) path = $"{basePath}-{n}.jsonl";
-        return path;
+        for (int n = 1; ; n++)
+        {
+            var path = n == 1 ? basePath + ".jsonl" : $"{basePath}-{n}.jsonl";
+            try
+            {
+                using (new FileStream(path, FileMode.CreateNew, FileAccess.Write, FileShare.None)) { }
+                return path;   // reserved: this call owns the name
+            }
+            catch (IOException) when (File.Exists(path)) { /* taken — try the next counter */ }
+            catch (Exception) { return path; }   // non-collision failure (bad dir, permissions) — Save names it loud
+        }
     }
 
-    /// <summary>Delete spilled artifacts older than <see cref="PruneAfterDays"/> days. Best-effort per file — a
-    /// locked or vanished file is skipped, never fatal (pruning is hygiene, not correctness; epoch-checked
-    /// re-entry is what protects against staleness).</summary>
+    /// <summary>Delete a reservation whose spill FAILED — best-effort (the failure is already named in the
+    /// response; an empty leftover would otherwise linger until the age prune).</summary>
+    public static void Release(string path)
+    {
+        try { File.Delete(path); } catch (Exception) { }
+    }
+
+    /// <summary>Delete spilled artifacts older than <see cref="PruneAfterDays"/> days — and orphaned Writer temps
+    /// (<c>*.jsonl.tmp-*</c>) on the same clock: a failed Save deletes its own temp best-effort, but a crash
+    /// mid-write can still strand one, and full-size strays in the server's own data dir are exactly what this
+    /// hygiene pass exists for (PR #306 review). Best-effort per file — a locked or vanished file is skipped,
+    /// never fatal (pruning is hygiene, not correctness; epoch-checked re-entry is what protects against
+    /// staleness).</summary>
     static void Prune(string dir)
     {
         var cutoff = DateTime.UtcNow.AddDays(-PruneAfterDays);
         try
         {
-            foreach (var f in Directory.EnumerateFiles(dir, "*.jsonl"))
+            foreach (var f in Directory.EnumerateFiles(dir, "*.jsonl").Concat(Directory.EnumerateFiles(dir, "*.jsonl.tmp-*")))
                 try { if (File.GetLastWriteTimeUtc(f) < cutoff) File.Delete(f); }
                 catch (IOException) { /* locked/raced — next write retries */ }
                 catch (UnauthorizedAccessException) { /* same */ }


### PR DESCRIPTION
## What this is

**houseCARL 2.0, Wave 1 (foundations), PR 2 of 2** — the §2.1.1 **artifact disposition**, end-to-end, consuming PR 1's epoch fingerprint (#305). Bulk output decouples **result size from render size**: any result can materialize as ONE self-contained JSONL file — line 1 a manifest (query echo · row count · row schema · sort · per-type counts · **epoch**), lines 2+ one JSON row per line — and re-enters through the existing `@file` spelling, epoch-checked. No server-side result state: the handle IS the file (the retired-daemon posture stays retired).

Wired lanes (W1): `cross_plugin_query` (text/json/dense + `group_by`), `batch_record_detail`, `resolve`.

## The three behaviours

**1. `to_file=<absolute .jsonl path>`** — forces the disposition: the **COMPLETE** result to the caller's file, manifest-only inline. The artifact is never a window: the scan runs un-limit-capped, `offset=` is refused, and `limit=` does not apply (schema-documented; an explicit `limit=500` is indistinguishable from the default, so the artifact is defined as always-complete rather than sometimes-windowed). Doomed dispositions refuse **before any scan**: relative path, non-`.jsonl` extension (the file must say what it is), `conflict_tree` (text-only view, no row form).

**2. Auto-spill at the inline ceiling** (decided over refuse-and-redirect, Aaron-go 2026-07-29) — a render that hits `max_chars` ALWAYS writes the complete **requested window** to the server results dir and re-renders with the `spilled` marker **in-band in both formats** — text block and `"spilled"` json object, each naming the file (contract — the E4.2 pathless-spill evidence: 2 refusals, 3 re-paid scans, 2 fabricated paths). Truncation thereby stops existing as a data-loss mode on these lanes. If the spill write itself fails, the response says THAT, loud, in both formats (`spill_error` / the text warning "exists NOWHERE") — never a truncated response silently missing its promised file.

**3. `@file` re-entry, epoch-checked** — `formids=["@<path>"]` (batch/resolve), `references=["@<path>"]`, and the existing `where=["formid in @<path>"]` all take an artifact target: it yields the **identity column** as the list (scan once, project forever). The epoch check runs **inside the consuming call's own `Capture()`** — a tool-layer pre-check would race a freshness rebuild landing between check and scan. Mismatch = loud refusal naming BOTH epochs, stamped (it consulted the build — the #305 refusal contract), **no stale-override switch by design** (SPEC: fresh re-projection through the server, or honest-snapshot traversal client-side). Plain formid-list files keep working unchanged — they never claimed a build.

## Phase-4 details decided here (SPEC delegated "naming/location/prune" to the build)

| Decision | Value | Why |
|---|---|---|
| Results dir | `HOUSECARL_DATA_DIR\results` (fallback: server binary dir) | beside the config that produced it, never inside the MO2 instance |
| Spill naming | `<tool>_<utc-stamp>_<epoch>.jsonl`, counter on collision | time-sortable; the epoch visible in a dir listing before any file opens |
| Prune | by age, **7 days**, at write time, `*.jsonl` in this dir only | no daemon/timer/state; stale artifacts already refuse re-entry long before pruning |
| Spill scope | auto-spill writes the **requested window** (complete); `to_file` writes the **full result** | the window is what the response promised; going past `limit` would silently re-price the call. Manifest carries `row_count` AND `total`, so a windowed file says so |
| `spilled` marker | ONE marker for both dispositions, `reason: to_file \| over_inline_ceiling` | one grammar for consumers and the guard |
| to_file overwrite | wholesale (temp+move) | a re-run is a NEW artifact; "immutable" means the server never appends/mutates |
| Sweep lanes | **deliberately not wired** (`check_errors`/`validate_scripts`) | their artifact needs a flat per-finding row shape — which IS the W2 findings-family fold; wiring a throwaway nested shape now ships a second schema W2 immediately retires |

## Construction properties

- **File and wire cannot drift:** artifact rows are emitted by the SAME row writers the json renders use (`JsonWire.WriteReadRecord`/`WriteSummaryRow`/`WriteResolvedRow`, made internal), with an unreachable cap — an artifact row is never truncated.
- **One build per response, file included:** artifact detail fills read the outcome's pinned view (`ViewPin`, #305) — a mid-write rebuild cannot make the file disagree with the header's stamp. The auto-spill's re-render re-runs pinned fills; same build by construction.
- **Batch of pure parse-failures** (no view ever consulted) writes epoch `""` — such an artifact refuses re-entry against ANY build, which is the honest answer.
- Alias-layer CENSUS: **unchanged, 99 activations** — `to_file` is a new param, no rename rows fire on it (binding-shim-guard green).

## Known bounds (stated, not hidden)

- The spill trigger is the **row-level** max_chars cut. A single record whose FIELD list is internally truncated as the last row does not trigger a spill (its own truncation note names the cut; `to_file` is the recovery). W2's merged `records` tool is where per-record budgets get redesigned.
- `to_file` with `fields=` over a huge match set pays a per-row read — the declared §2 rule-1 cost class; the artifact is why it is paid once.

## Verification

- **New `artifact-guard` in CiAll: 45 checks, six arms** — core round-trip · to_file (complete file, manifest-only inline, marker-names-file in BOTH formats, 4 pre-scan refusals) · auto-spill (3 formats × 3 lanes, complete file, failed-spill named in both formats) · @file re-entry (3 lanes + plain-list control + misuse refusals) · epoch check (real re-fingerprint; both epochs named; stamped; plain-list control; re-materialize-and-re-enter) · prune.
- **ci-all: 113/113 PASS** (epoch-guard, alias-layer-guard, binding-shim-guard + census all green, unchanged).

## Milestone

houseCARL 2.0 / W1. No closing keyword — milestone issues close when the shipped 2.0 surface closes them (charter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)