### PR TITLE
feat(w2): housecarl_records - the 2.0 S1 read surface, core grammar (W2 PR 1)

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,32 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**New tool: `housecarl_records` — the 2.0 read surface, core forms (W2 PR 1).** One read call composes *which
+records* (SELECT: `formids=` incl. `@file`/artifact re-entry · set-valued `types=` · a structured `plugins=` scope
+with `defined_in` inside it · `conflicts_only=` · the `where=` grammar · `references=`) × *whose version* (SOURCE:
+the winner by default, or `source=` naming a plugin **wherever it lives** — active in the order or sitting on disk
+unticked; the response states which arm resolved, a record the plugin doesn't touch is refused naming the plugins
+that DO touch it, and a plugin found in neither place is refused naming both places searched) × *what shape*
+(PROJECT: a form-scoped `project=` object — `identity | summary | fields | everything | aggregate`, each
+sub-parameter living only inside the form that uses it) × transport (`text`/`json`/`dense`, exact windows,
+`counts_only=`, `to_file=` and auto-spill riding the W1 artifact lane). The comparison forms (`delta`/`tree`/
+`chain`/`info_order`), `previous_provider`, the SkyPatcher-overlay source, and `formids=`×scan composition arrive
+in W2 PR 2 — until then those spellings get a **named staging refusal** pointing at the 1.x tool that does the job
+today. The 1.x read tools are unchanged and stay through the build waves (they retire at 2.0.0's clean cut).
+
+**The `where=` grammar grows the chartered 2.0 SELECT terms — on `cross_plugin_query` too.** New everywhere the
+grammar runs: `startswith`; an `editorid` term (`editorid contains/startswith/= …`, `editorid missing` — the
+`editorid_contains=` job as plain grammar, live even on records whose deep body can't parse); the **`winner`
+provenance term** (`where=["winner = X.esp"]` — *which records does X win*; it reads resolution, not content, and
+declares its winner-resolution cost); `in`/`not in` **generalized to any scalar leaf** (`"Race in
+[XXXXXX:A.esm, …]"`, enum names and numbers too, artifact `@file` lists included); and a single **`->` link step**
+(`"Perks->editorid startswith REQ_NULL_"` — the predicate crosses ONE form link and tests the target's winner body,
+ANY-match over list targets, wrong paths still fail loud in the accounting). A stray `conflict_tree=`/`fields=`/
+`depth=`/`group_by=` on the new tool answers with the form-scoping rule by name, and the alias layer maps the 1.x
+spellings (`plugin=`/`mod=`/`from_plugin=` → `source=`, `formid=` → `formids=`, `type=` → `types=`) so first
+guesses bind. Guarded by the new `records-guard` in CI; alias CENSUS re-baked (99 → 113 activations, all on the
+new tool).
+
 **Big results now come back whole, as a file — truncation stops losing data on the record-bulk reads (the 2.0
 artifact disposition, W1).** `cross_plugin_query`, `batch_record_detail`, and `resolve` gain the §2.1.1 artifact
 lane. Pass `to_file=<absolute .jsonl path>` to write the **complete** result — never limit-windowed — as one

--- a/plugin/codex/housecarl/SKILL.md
+++ b/plugin/codex/housecarl/SKILL.md
@@ -29,6 +29,7 @@ Use this skill for data-layer Skyrim Special Edition modding through the configu
 Beyond the core workflow, reach for the right group. Depth for the specialist areas lives in the helper skills (next section) — load the skill before composing in that area.
 
 **Read / query / resolve**
+- `housecarl_records` — the consolidated 2.0 read surface (SELECT × SOURCE × PROJECT in one call): record lists or scans, any plugin's version wherever it lives (active or on disk), form-scoped `project=` shapes. The 1.x read tools below keep working through the 2.0 build.
 - `housecarl_read_record`, `housecarl_batch_record_detail` — read one or many records at the true winner (`conflict_tree=true` for provenance).
 - `housecarl_read_plugin_file` — read a plugin directly, even one that is disabled or not active.
 - `housecarl_cross_plugin_query` — query and filter records or references across the whole order; page with `offset=`, count with `group_by=`.

--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -104,6 +104,13 @@ public sealed class FieldPredicateSet
     /// winner name) — the call site opens an overlay session for the fetch when true.</summary>
     public bool NeedsBodyResolution => _predicates.Any(p => p.LinkPath is not null);
 
+    /// <summary>Whether any predicate reads record BODY content (a leaf walk or a link step) — false when every
+    /// term is header/resolution-only (`editorid`, `winner`, `formid` membership). The scan's deleted-record
+    /// guard keys on this (review fold): a deleted record has no live body for the CONTENT filters, but its
+    /// EditorID and its winner resolution are real facts — a header-only predicate set must still see it, exactly
+    /// as the 1.x `editorid_contains=` deliberately did.</summary>
+    public bool NeedsLiveBody => _predicates.Any(p => p.LinkPath is not null || p.Pseudo == PseudoPath.None);
+
     /// <summary>Bind the scan's resolution context: <paramref name="winnerOf"/> answers "which plugin wins this
     /// FormKey" (the `winner` term), <paramref name="fetchWinnerBody"/> produces a linked target's winner body
     /// (the `-&gt;` link step; null when the target doesn't resolve). Both must come from the SAME captured view
@@ -269,7 +276,7 @@ public sealed class FieldPredicateSet
                 return (null, $"predicate '{raw}': 'winner' is the provenance term (which plugin WINS the record) and takes '=' or '!=' with a plugin filename — e.g. \"winner = Requiem.esp\".");
         }
         if (pseudo == PseudoPath.EditorId && op is Op.Gt or Op.Ge or Op.Lt or Op.Le or Op.Has)
-            return (null, $"predicate '{raw}': 'editorid' is a text term — use = != contains startswith exists missing (got '{OpStr(op)}').");
+            return (null, $"predicate '{raw}': 'editorid' is a text term — use = != contains startswith exists missing in 'not in' (got '{OpStr(op)}').");
 
         // A presence op (exists/missing) takes NO operand — a trailing value is a mistake, refused loud (Q3, never
         // silently ignored). Every other op REQUIRES an operand.
@@ -534,13 +541,18 @@ public sealed class FieldPredicateSet
                 bool present = !string.IsNullOrEmpty(eid);
                 return (p.Op == Op.Exists ? present : !present, EvalKind.Definite);
             }
-            if (eid is null) return (false, EvalKind.Definite);   // no EditorID ⇒ a definite non-match (editorid_contains= semantics, carried)
+            // A null EditorID is a DEFINITE verdict either way, but the polarity must be right per op (review
+            // finding: a blanket non-match silently dropped every no-EditorID record from '!=' — a record with
+            // no EditorID is unambiguously NOT EQUAL to any operand, and NOT IN any list). The positive ops
+            // (=, contains, startswith, in) keep the 1.x editorid_contains= semantics: no EditorID never matches.
             bool ok = p.Op switch
             {
-                Op.Eq => string.Equals(eid, p.Operand, StringComparison.OrdinalIgnoreCase),
-                Op.Ne => !string.Equals(eid, p.Operand, StringComparison.OrdinalIgnoreCase),
-                Op.Contains => eid.Contains(p.Operand, StringComparison.OrdinalIgnoreCase),
-                Op.StartsWith => eid.StartsWith(p.Operand, StringComparison.OrdinalIgnoreCase),
+                Op.Eq => eid is not null && string.Equals(eid, p.Operand, StringComparison.OrdinalIgnoreCase),
+                Op.Ne => eid is null || !string.Equals(eid, p.Operand, StringComparison.OrdinalIgnoreCase),
+                Op.Contains => eid is not null && eid.Contains(p.Operand, StringComparison.OrdinalIgnoreCase),
+                Op.StartsWith => eid is not null && eid.StartsWith(p.Operand, StringComparison.OrdinalIgnoreCase),
+                Op.In => eid is not null && p.RawMembers!.Any(m => string.Equals(eid, m, StringComparison.OrdinalIgnoreCase)),
+                Op.NotIn => eid is null || !p.RawMembers!.Any(m => string.Equals(eid, m, StringComparison.OrdinalIgnoreCase)),
                 _ => false,
             };
             return (ok, EvalKind.Definite);

--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -56,7 +56,7 @@ public sealed class FieldPredicateSet
     /// read cleave where identity sits beside Fields) and a list operand: inline comma-separated FormIDs, or
     /// <c>@&lt;absolute path&gt;</c> naming a file of them. Restricted to <c>formid</c> at parse (a named refusal on any
     /// other path) so a future generalization to leaf-value membership is an extension, not a behavior change.</summary>
-    enum Op { Eq, Ne, Gt, Ge, Lt, Le, Contains, Has, Exists, Missing, In, NotIn }
+    enum Op { Eq, Ne, Gt, Ge, Lt, Le, Contains, StartsWith, Has, Exists, Missing, In, NotIn }
 
     /// <summary>One parsed predicate: the split path segments (fed straight to <see cref="ReadEngine.ReadLeaf"/>),
     /// the operator, the raw operand, and — for a numeric operator — the operand pre-parsed to a double (validated
@@ -66,7 +66,17 @@ public sealed class FieldPredicateSet
     /// <paramref name="Artifact"/> is non-null when the list came from a §2.1.1 result ARTIFACT: the epoch
     /// obligation the consuming scan must check against the build it captures (see <see cref="ArtifactDemands"/>).</summary>
     sealed record Predicate(string Text, string[] PathSegments, string PathDisplay, Op Op, string Operand, double NumericOperand,
-                            HashSet<FormKey>? FormIds = null, ArtifactDemand? Artifact = null);
+                            HashSet<FormKey>? FormIds = null, ArtifactDemand? Artifact = null,
+                            string[]? LinkPath = null, string? LinkPathDisplay = null,
+                            PseudoPath Pseudo = PseudoPath.None, IReadOnlyList<string>? RawMembers = null);
+
+    /// <summary>The identity pseudo-paths a predicate may name instead of a body leaf. <c>editorid</c> reads the
+    /// record's EditorID (always available off the early EDID subrecord — never a reflection walk, and live even on
+    /// records whose deep body Mutagen can't parse). <c>winner</c> is the §2.2 PROVENANCE term: it reads the
+    /// record's load-order RESOLUTION (which plugin wins it), not its content — evaluated via the resolution the
+    /// consuming scan binds (<see cref="BindResolution"/>), so it forces winner resolution over the scanned scope
+    /// (the declared §3.2(c) cost class). <c>formid</c> stays what it was: the membership ops' identity path.</summary>
+    enum PseudoPath { None, EditorId, Winner, FormId }
 
     readonly IReadOnlyList<Predicate> _predicates;
     readonly long[] _valueRead;   // per-predicate: candidates whose path read SOME value
@@ -76,6 +86,33 @@ public sealed class FieldPredicateSet
     readonly long[] _unreadable;  // per-predicate SUBSET of _noValue: the path READ FAULTED (Mutagen-unparseable content) — a fault, NOT an unset value
     long _scanned;
     string? _fatal;
+
+    // Resolution bindings (W2): the `winner` provenance term and the `->` link step read the record's RESOLUTION
+    // (winner plugin; a linked target's winner body), which only the consuming scan's captured view can supply.
+    // Bound by the call site AFTER its own Capture() (so the predicate and the answer read the same build);
+    // evaluating an unbound term is a FatalError, never a silent non-match (Q3).
+    Func<FormKey, string?>? _winnerOf;
+    Func<FormKey, IMajorRecordGetter?>? _fetchWinnerBody;
+    readonly Dictionary<FormKey, IMajorRecordGetter?> _targetCache = new();   // link-step targets recur across candidates — fetch once per scan
+
+    /// <summary>Whether any predicate needs the scan's resolution context (<c>winner</c> term or a <c>-&gt;</c>
+    /// link step) — the call site checks this to bind <see cref="BindResolution"/> (and open the body-fetch
+    /// session the link step needs) before the first <see cref="Matches"/>.</summary>
+    public bool NeedsResolution => _predicates.Any(p => p.Pseudo == PseudoPath.Winner || p.LinkPath is not null);
+
+    /// <summary>Whether any predicate follows a <c>-&gt;</c> link step (needs winner BODY fetches, not just the
+    /// winner name) — the call site opens an overlay session for the fetch when true.</summary>
+    public bool NeedsBodyResolution => _predicates.Any(p => p.LinkPath is not null);
+
+    /// <summary>Bind the scan's resolution context: <paramref name="winnerOf"/> answers "which plugin wins this
+    /// FormKey" (the `winner` term), <paramref name="fetchWinnerBody"/> produces a linked target's winner body
+    /// (the `-&gt;` link step; null when the target doesn't resolve). Both must come from the SAME captured view
+    /// the scan answers from.</summary>
+    public void BindResolution(Func<FormKey, string?> winnerOf, Func<FormKey, IMajorRecordGetter?>? fetchWinnerBody = null)
+    {
+        _winnerOf = winnerOf;
+        _fetchWinnerBody = fetchWinnerBody;
+    }
 
     FieldPredicateSet(IReadOnlyList<Predicate> predicates)
     {
@@ -130,9 +167,11 @@ public sealed class FieldPredicateSet
         var text = (raw ?? "").Trim();
         if (text.Length == 0) return (null, "empty predicate in where= (expected \"<path> <op> <value>\").");
 
-        // 1. path — the leading run of non-whitespace, non-operator-char characters.
+        // 1. path — the leading run of non-whitespace, non-operator-char characters. The ONE exception: a '>'
+        //    immediately after '-' is the LINK-STEP arrow ('Perks->editorid'), part of the path, not an operator.
         int i = 0;
-        while (i < text.Length && !char.IsWhiteSpace(text[i]) && !IsOpChar(text[i])) i++;
+        while (i < text.Length && !char.IsWhiteSpace(text[i])
+               && (!IsOpChar(text[i]) || (text[i] == '>' && i > 0 && text[i - 1] == '-'))) i++;
         var path = text.Substring(0, i);
         if (path.Length == 0)
             return (null, $"predicate '{raw}': no field path before the operator (expected \"<path> <op> <value>\").");
@@ -140,7 +179,7 @@ public sealed class FieldPredicateSet
         // 2. skip whitespace to the operator.
         while (i < text.Length && char.IsWhiteSpace(text[i])) i++;
         if (i >= text.Length)
-            return (null, $"predicate '{raw}': no operator. Use one of = != > >= < <= contains has exists missing in 'not in', e.g. \"{path} = <value>\" or \"{path} exists\".");
+            return (null, $"predicate '{raw}': no operator. Use one of = != > >= < <= contains startswith has exists missing in 'not in', e.g. \"{path} = <value>\" or \"{path} exists\".");
 
         // 3. operator — symbolic (longest match) or the 'contains' word.
         Op op;
@@ -153,7 +192,7 @@ public sealed class FieldPredicateSet
             else if (text[i] == '=') { op = Op.Eq; after = i + 1; }
             else if (text[i] == '>') { op = Op.Gt; after = i + 1; }
             else if (text[i] == '<') { op = Op.Lt; after = i + 1; }
-            else return (null, $"predicate '{raw}': unrecognized operator at '{text.Substring(i)}'. Use = != > >= < <= contains has exists missing in 'not in'.");
+            else return (null, $"predicate '{raw}': unrecognized operator at '{text.Substring(i)}'. Use = != > >= < <= contains startswith has exists missing in 'not in'.");
         }
         else
         {
@@ -161,6 +200,7 @@ public sealed class FieldPredicateSet
             while (w < text.Length && !char.IsWhiteSpace(text[w])) w++;
             var word = text.Substring(i, w - i);
             if (word.Equals("contains", StringComparison.OrdinalIgnoreCase)) op = Op.Contains;
+            else if (word.Equals("startswith", StringComparison.OrdinalIgnoreCase)) op = Op.StartsWith;
             else if (word.Equals("has", StringComparison.OrdinalIgnoreCase)) op = Op.Has;
             else if (word.Equals("exists", StringComparison.OrdinalIgnoreCase)) op = Op.Exists;
             else if (word.Equals("missing", StringComparison.OrdinalIgnoreCase)) op = Op.Missing;
@@ -176,7 +216,7 @@ public sealed class FieldPredicateSet
                 op = Op.NotIn; w = w2;
             }
             else
-                return (null, $"predicate '{raw}': unrecognized operator '{word}'. Use = != > >= < <= contains has exists missing in or 'not in'.");
+                return (null, $"predicate '{raw}': unrecognized operator '{word}'. Use = != > >= < <= contains startswith has exists missing in or 'not in'.");
             after = w;
         }
 
@@ -184,44 +224,149 @@ public sealed class FieldPredicateSet
         //    consumed the operator positionally, so that's fine.)
         var operand = text.Substring(after).Trim();
 
+        // LINK STEP (§2.2, the P3 '->' term — W2): 'Left->Right' reads Right on the record(s) the candidate's
+        // Left path points AT (their load-order-winner bodies, from the same captured view the scan answers
+        // from), ANY-match over the reached targets. Exactly ONE step: chaining arrows is refused — a longer
+        // chain is the walk construct's job, not a predicate's.
+        string[]? linkSegs = null;
+        string? linkDisplay = null;
+        var arrow = path.IndexOf("->", StringComparison.Ordinal);
+        if (arrow >= 0)
+        {
+            var left = path.Substring(0, arrow);
+            var right = path.Substring(arrow + 2);
+            if (left.Length == 0 || right.Length == 0)
+                return (null, $"predicate '{raw}': a link step is '<link path>-><target field>' (e.g. \"Perks->editorid startswith REQ_\") — one side of '->' is empty.");
+            if (right.Contains("->", StringComparison.Ordinal))
+                return (null, $"predicate '{raw}': only ONE '->' link step is supported in a predicate — a longer chain is the walk construct's job (walk= / references=), not a where= term.");
+            linkSegs = left.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (linkSegs.Length == 0)
+                return (null, $"predicate '{raw}': '{left}' is not a usable link path.");
+            linkDisplay = left;
+            path = right;   // the right side is the predicate's own path, evaluated on each reached target
+        }
+
         var segs = path.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
         if (segs.Length == 0)
             return (null, $"predicate '{raw}': '{path}' is not a usable field path.");
+
+        // Pseudo-path classification (W2): 'editorid' (the record's EditorID — a first-class term, so the old
+        // editorid_contains= parameter dissolves into this grammar), 'winner' (the §2.2 PROVENANCE term — which
+        // plugin WINS the record, resolution not content), 'formid' (the membership ops' identity path, as ever).
+        var pseudo = segs.Length == 1 && !path.Contains('[')
+            ? (path.Equals("editorid", StringComparison.OrdinalIgnoreCase) ? PseudoPath.EditorId
+               : path.Equals("winner", StringComparison.OrdinalIgnoreCase) ? PseudoPath.Winner
+               : path.Equals("formid", StringComparison.OrdinalIgnoreCase) ? PseudoPath.FormId
+               : PseudoPath.None)
+            : PseudoPath.None;
+
+        // Op-compatibility, validated at parse so an unusable pairing refuses the CALL, never a silent all-miss.
+        if (pseudo == PseudoPath.Winner)
+        {
+            if (linkSegs is not null)
+                return (null, $"predicate '{raw}': 'winner' is not usable behind a '->' link step — it names the CANDIDATE record's winning plugin. Test the target another way (e.g. '{linkDisplay}->editorid …').");
+            if (op is not (Op.Eq or Op.Ne))
+                return (null, $"predicate '{raw}': 'winner' is the provenance term (which plugin WINS the record) and takes '=' or '!=' with a plugin filename — e.g. \"winner = Requiem.esp\".");
+        }
+        if (pseudo == PseudoPath.EditorId && op is Op.Gt or Op.Ge or Op.Lt or Op.Le or Op.Has)
+            return (null, $"predicate '{raw}': 'editorid' is a text term — use = != contains startswith exists missing (got '{OpStr(op)}').");
 
         // A presence op (exists/missing) takes NO operand — a trailing value is a mistake, refused loud (Q3, never
         // silently ignored). Every other op REQUIRES an operand.
         if (op is Op.Exists or Op.Missing)
         {
+            if (pseudo is PseudoPath.Winner or PseudoPath.FormId)
+                return (null, $"predicate '{raw}': '{path}' always exists (every record has an identity and a winner) — a presence test on it can never filter. Use it with its own operators instead.");
             if (operand.Length != 0)
                 return (null, $"predicate '{raw}': '{OpStr(op)}' is a presence test and takes no value (got '{operand}'). Write it as \"{path} {OpStr(op)}\".");
-            return (new Predicate(text, segs, path, op, "", 0), null);
+            return (new Predicate(text, segs, path, op, "", 0, LinkPath: linkSegs, LinkPathDisplay: linkDisplay, Pseudo: pseudo), null);
         }
 
         if (operand.Length == 0)
             return (null, $"predicate '{raw}': no value after '{OpStr(op)}'.");
 
-        // The membership ops (in / not in) test the record's IDENTITY, not a body leaf, so their path is the fixed
-        // pseudo-path 'formid' — any other path is refused NAMED (never silently read as a leaf), which keeps a
-        // future leaf-value generalization an extension rather than a behavior change. The operand (inline list or
-        // @file) is fully parsed + validated HERE, so a bad token, an unreadable file, or an empty list refuses the
-        // whole call before any scan (Q3) and the per-record test is a pure set lookup (no IO in the scan).
+        // The membership ops (in / not in). On the identity path 'formid' the list must be FormIDs and the test is
+        // the record's own identity (or, behind a link step, each reached target's identity) — the artifact @file
+        // re-entry lane rides this form. On any OTHER path (W2 generalization) the list entries are compared
+        // against the LEAF's token with the same equality vocabulary '=' uses (FormKey-canonical / numeric /
+        // case-insensitive string), so \"Race in [XXXXXX:A.esm, YYYYYY:B.esm]\" keeps exactly the listed races.
+        // Either way the operand (inline list or @file) is fully parsed + validated HERE, so a bad token, an
+        // unreadable file, or an empty list refuses the whole call before any scan (Q3) and the per-record test
+        // does no IO.
         if (op is Op.In or Op.NotIn)
         {
-            if (!path.Equals("formid", StringComparison.OrdinalIgnoreCase))
-                return (null, $"predicate '{raw}': '{OpStr(op)}' tests the record's IDENTITY and takes the path 'formid' only " +
-                              $"(got '{path}') — write \"formid {OpStr(op)} <list>\". Membership over a field's VALUE is not supported (yet); " +
-                              $"use '=' per value, or references= for list→FormID membership.");
-            var (set, artifact, lerr) = ParseFormIdList(raw, operand);
-            if (lerr is not null) return (null, lerr);
-            return (new Predicate(text, segs, path, op, operand, 0, set, artifact), null);
+            if (pseudo == PseudoPath.Winner)
+                return (null, $"predicate '{raw}': 'winner {OpStr(op)} <list>' is not supported (yet) — AND/OR the '=' form per plugin, e.g. \"winner = A.esp\".");
+            if (pseudo == PseudoPath.FormId)
+            {
+                var (set, artifact, lerr) = ParseFormIdList(raw, operand);
+                if (lerr is not null) return (null, lerr);
+                return (new Predicate(text, segs, path, op, operand, 0, set, artifact, LinkPath: linkSegs, LinkPathDisplay: linkDisplay, Pseudo: pseudo), null);
+            }
+            var (members, mset, martifact, merr) = ParseValueList(raw, operand);
+            if (merr is not null) return (null, merr);
+            return (new Predicate(text, segs, path, op, operand, 0, mset, martifact, LinkPath: linkSegs, LinkPathDisplay: linkDisplay, Pseudo: pseudo, RawMembers: members), null);
         }
+        if (pseudo == PseudoPath.FormId)
+            return (null, $"predicate '{raw}': 'formid' takes the membership ops only — \"formid in <list>\" / \"formid not in <list>\" (a single record is \"formid in [XXXXXX:Plugin.esp]\").");
 
         // 5. a numeric operator demands a numeric operand — fail fast at parse (before any scan).
         double num = 0;
         if (IsNumericOp(op) && !TryNum(operand, out num))
             return (null, $"predicate '{raw}': operator '{OpStr(op)}' needs a numeric value, got '{operand}'.");
 
-        return (new Predicate(text, segs, path, op, operand, num), null);
+        return (new Predicate(text, segs, path, op, operand, num, LinkPath: linkSegs, LinkPathDisplay: linkDisplay, Pseudo: pseudo), null);
+    }
+
+    /// <summary>Parse a generalized (non-formid) membership list: same separators/wrapping as the formid grammar,
+    /// but entries are arbitrary VALUE tokens (enum names, numbers, FormKeys) — validated only for non-emptiness.
+    /// When every entry parses as a FormKey the pre-parsed set rides along for the fast identity-canonical test
+    /// (a FormLink leaf against a big artifact list must not be O(n) per record). An @file target may be a plain
+    /// token list or a §2.1.1 artifact (identity column = formids — useful against a FormLink leaf), with the
+    /// artifact's epoch demand carried exactly like the formid form.</summary>
+    static (IReadOnlyList<string>? Members, HashSet<FormKey>? Keys, ArtifactDemand? Artifact, string? Error) ParseValueList(string raw, string operand)
+    {
+        string content;
+        ArtifactDemand? artifact = null;
+        if (operand[0] == '@')
+        {
+            var path = operand.Substring(1).Trim().Trim('"', '\'');
+            if (path.Length == 0)
+                return (null, null, null, $"predicate '{raw}': '@' names a value-list file but no path follows it.");
+            if (!Path.IsPathRooted(path))
+                return (null, null, null, $"predicate '{raw}': value-list file '{path}' must be an ABSOLUTE path — the server resolves relative paths against its OWN working directory, not yours.");
+            try { content = File.ReadAllText(path); }
+            catch (Exception ex) { return (null, null, null, $"predicate '{raw}': could not read value-list file '{path}' — {ex.GetType().Name}: {ex.Message}"); }
+            if (ResultArtifact.LooksLikeArtifact(content))
+            {
+                var (manifest, tokens, aerr) = ResultArtifact.ReadIdentity(path, content);
+                if (aerr is not null) return (null, null, null, $"predicate '{raw}': {aerr}");
+                if (!manifest!.Identity!.Equals("formid", StringComparison.OrdinalIgnoreCase))
+                    return (null, null, null, $"predicate '{raw}': artifact '{path}' (from {manifest.Tool}) carries '{manifest.Identity}' identities, not FormIDs — nothing in it to test a value against.");
+                artifact = new ArtifactDemand(path, manifest.Epoch);
+                content = string.Join("\n", tokens!);
+            }
+        }
+        else content = operand;
+
+        var members = new List<string>();
+        foreach (var t in content.Split(ListSeparators, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var tok = t.Trim('[', ']', '"', '\'', ' ', '\t');
+            if (tok.Length > 0) members.Add(tok);
+        }
+        if (members.Count == 0)
+            return (null, null, null, $"predicate '{raw}': the value list is empty — give at least one entry.");
+
+        HashSet<FormKey>? keys = null;
+        var all = new HashSet<FormKey>();
+        foreach (var m in members)
+        {
+            if (!TryFormKey(m, out var fk)) { all = null!; break; }
+            all.Add(fk);
+        }
+        if (all is { Count: > 0 }) keys = all;
+        return (members, keys, artifact, null);
     }
 
     /// <summary>Parse an <c>in</c>/<c>not in</c> operand into its FormKey set. Two forms: <c>@&lt;path&gt;</c> reads a
@@ -327,63 +472,183 @@ public sealed class FieldPredicateSet
         {
             var p = _predicates[k];
 
-            // Identity-membership ops (in / not in): a pure FormKey set test — no body leaf is read (the 'formid'
-            // pseudo-path is identity, which the read cleave keeps BESIDE the fields). Identity is always present,
-            // so the predicate counts as value-read and the Q3 no-value accounting can never false-alarm on it.
-            if (p.Op is Op.In or Op.NotIn)
+            EvalKind kind;
+            bool sat;
+            if (p.LinkPath is not null)
             {
-                _valueRead[k]++;
-                bool member = p.FormIds!.Contains(body.FormKey);
-                if (p.Op == Op.In ? !member : member) all = false;
-                continue;
+                // LINK STEP (W2): collect the candidate's links under the LEFT path, resolve each target's winner
+                // body from the bound view, evaluate the predicate's own (right) side on each — ANY-match. Targets
+                // are cached across candidates (the same perk/spell recurs), and a per-target fault feeds the
+                // accounting, never a throw out of the scan.
+                (sat, kind) = EvalLinkStep(p, body);
+                if (_fatal is not null) return false;
+            }
+            else
+            {
+                (sat, kind) = EvalCore(p, body);
+                if (_fatal is not null) return false;
             }
 
-            var leaf = ReadEngine.ReadLeaf(body, p.PathSegments);   // internal, same assembly — the by-construction read walk
-
-            // Presence ops (exists/missing) are the ONE case where a no-value CONTAINER leaf is a MATCH, not a miss:
-            // they test whether the path resolves to a present, non-empty value (a scalar OR a carried
-            // substruct/list), the "which records carry a VMAD/Effects/Conditions" query the value ops can't express
-            // (#197). Handled BEFORE the value-predicate no-value classification below. Accounting stays Q3-honest: a
-            // DEFINITE verdict (Present or Absent) counts as read, so "exists returns 0 because the field is
-            // genuinely absent on all" is a true zero (no false alarm); only a no-such-field or a read-fault is a
-            // no-value residue, so a mistyped exists= path still fails LOUD. NoField/Unreadable match NEITHER op —
-            // an unjudgeable record is asserted neither present nor absent.
-            if (p.Op is Op.Exists or Op.Missing)
+            switch (kind)
             {
-                bool present;
-                switch (ClassifyPresence(leaf))
-                {
-                    case Presence.Present: _valueRead[k]++; present = true; break;
-                    case Presence.Absent:  _valueRead[k]++; present = false; break;
-                    case Presence.NoField: _noField[k]++; _noValue[k]++; all = false; continue;    // not a field here — can't judge
-                    default:               _unreadable[k]++; _noValue[k]++; all = false; continue;  // read fault — unjudgeable
-                }
-                if (!(p.Op == Op.Exists ? present : !present)) all = false;
-                continue;
+                case EvalKind.Definite: _valueRead[k]++; if (!sat) all = false; break;
+                case EvalKind.NoField: _noField[k]++; _noValue[k]++; all = false; break;
+                case EvalKind.Container: _container[k]++; _noValue[k]++; all = false; break;
+                case EvalKind.Unreadable: _unreadable[k]++; _noValue[k]++; all = false; break;
+                default: _noValue[k]++; all = false; break;   // Unset — a valid, value-less path
             }
-
-            if (!leaf.HasValue)
-            {
-                // Classify WHY there was no value, so the Q3 accounting can distinguish a MISTYPED path (no such
-                // field anywhere) from a VALID-but-unset field (the path reads fine; there simply are no values in
-                // this scope) — the two look identical in a bare "0 matches", and conflating them sent a reporter
-                // hunting a non-bug (HCBR-2026-07-12: 'Prompt' is a real INFO field, just unset on all 531 scanned).
-                // Reason vocabulary is ReadLeaf's own notes: "(no field …" = mistyped/wrong-type; a leading '[' =
-                // a container/list summary; "(unreadable …" = a Mutagen-parse FAULT (must NOT read as "unset" — that
-                // would confidently assert a valid empty field where the truth is a read fault, Q3); anything else
-                // (absent / null link / unresolved string) = a genuinely-unset valid field.
-                var note = leaf.Note ?? "";
-                if (note.StartsWith("(no field", StringComparison.Ordinal)) _noField[k]++;
-                else if (note.StartsWith("(unreadable", StringComparison.Ordinal)) _unreadable[k]++;
-                else if (note.Length > 0 && note[0] == '[') _container[k]++;
-                _noValue[k]++; all = false; continue;
-            }
-            _valueRead[k]++;
-            var (satisfied, err) = Compare(p, leaf);
-            if (err is not null) { _fatal ??= err; return false; }
-            if (!satisfied) all = false;
         }
         return all;
+    }
+
+    /// <summary>How one predicate's evaluation on one record resolved: a DEFINITE verdict (the value was read and
+    /// compared, or an identity/presence test decided), or one of the no-verdict classes the Q3 accounting keys on
+    /// (mirrors the leaf-note vocabulary: no-such-field / container / read-fault / genuinely-unset).</summary>
+    enum EvalKind { Definite, NoField, Container, Unreadable, Unset }
+
+    /// <summary>Evaluate one predicate's own (non-link) side against one record. Shared by the top-level test and
+    /// the link step's per-target test — so 'Perks-&gt;editorid' and a plain 'editorid' term can't drift. Sets
+    /// <see cref="_fatal"/> on a typed predicate error (numeric op vs non-numeric field, unbound winner term).</summary>
+    (bool Satisfied, EvalKind Kind) EvalCore(Predicate p, IMajorRecordGetter body)
+    {
+        // The provenance term (§2.2 `winner`): reads the record's RESOLUTION off the bound view — never its body.
+        if (p.Pseudo == PseudoPath.Winner)
+        {
+            if (_winnerOf is null)
+            {
+                _fatal = "internal: a 'winner' provenance predicate was evaluated without a bound resolution context — this scan surface does not support it.";
+                return (false, EvalKind.Definite);
+            }
+            var w = _winnerOf(body.FormKey);
+            if (w is null) return (false, EvalKind.Unset);   // off-order body — no winner in the frame (accounted, never guessed)
+            bool eq = string.Equals(w, p.Operand, StringComparison.OrdinalIgnoreCase);
+            return (p.Op == Op.Eq ? eq : !eq, EvalKind.Definite);
+        }
+
+        // The editorid term: always available off the record header (live even where the deep body can't parse).
+        if (p.Pseudo == PseudoPath.EditorId)
+        {
+            var eid = body.EditorID;
+            if (p.Op is Op.Exists or Op.Missing)
+            {
+                bool present = !string.IsNullOrEmpty(eid);
+                return (p.Op == Op.Exists ? present : !present, EvalKind.Definite);
+            }
+            if (eid is null) return (false, EvalKind.Definite);   // no EditorID ⇒ a definite non-match (editorid_contains= semantics, carried)
+            bool ok = p.Op switch
+            {
+                Op.Eq => string.Equals(eid, p.Operand, StringComparison.OrdinalIgnoreCase),
+                Op.Ne => !string.Equals(eid, p.Operand, StringComparison.OrdinalIgnoreCase),
+                Op.Contains => eid.Contains(p.Operand, StringComparison.OrdinalIgnoreCase),
+                Op.StartsWith => eid.StartsWith(p.Operand, StringComparison.OrdinalIgnoreCase),
+                _ => false,
+            };
+            return (ok, EvalKind.Definite);
+        }
+
+        // Identity-membership ops (in / not in) on 'formid': a pure FormKey set test — no body leaf is read.
+        // Identity is always present, so the Q3 no-value accounting can never false-alarm on it.
+        if (p.Pseudo == PseudoPath.FormId)
+        {
+            bool member = p.FormIds!.Contains(body.FormKey);
+            return (p.Op == Op.In ? member : !member, EvalKind.Definite);
+        }
+
+        var leaf = ReadEngine.ReadLeaf(body, p.PathSegments);   // internal, same assembly — the by-construction read walk
+
+        // Presence ops (exists/missing) are the ONE case where a no-value CONTAINER leaf is a MATCH, not a miss:
+        // they test whether the path resolves to a present, non-empty value (a scalar OR a carried
+        // substruct/list), the "which records carry a VMAD/Effects/Conditions" query the value ops can't express
+        // (#197). Accounting stays Q3-honest: a DEFINITE verdict (Present or Absent) counts as read, so "exists
+        // returns 0 because the field is genuinely absent on all" is a true zero (no false alarm); only a
+        // no-such-field or a read-fault is a no-value residue, so a mistyped exists= path still fails LOUD.
+        // NoField/Unreadable match NEITHER op — an unjudgeable record is asserted neither present nor absent.
+        if (p.Op is Op.Exists or Op.Missing)
+        {
+            switch (ClassifyPresence(leaf))
+            {
+                case Presence.Present: return (p.Op == Op.Exists, EvalKind.Definite);
+                case Presence.Absent: return (p.Op == Op.Missing, EvalKind.Definite);
+                case Presence.NoField: return (false, EvalKind.NoField);
+                default: return (false, EvalKind.Unreadable);
+            }
+        }
+
+        if (!leaf.HasValue)
+        {
+            // Classify WHY there was no value, so the Q3 accounting can distinguish a MISTYPED path (no such
+            // field anywhere) from a VALID-but-unset field (the path reads fine; there simply are no values in
+            // this scope) — the two look identical in a bare "0 matches", and conflating them sent a reporter
+            // hunting a non-bug (HCBR-2026-07-12: 'Prompt' is a real INFO field, just unset on all 531 scanned).
+            // Reason vocabulary is ReadLeaf's own notes: "(no field …" = mistyped/wrong-type; a leading '[' =
+            // a container/list summary; "(unreadable …" = a Mutagen-parse FAULT (must NOT read as "unset" — that
+            // would confidently assert a valid empty field where the truth is a read fault, Q3); anything else
+            // (absent / null link / unresolved string) = a genuinely-unset valid field.
+            var note = leaf.Note ?? "";
+            if (note.StartsWith("(no field", StringComparison.Ordinal)) return (false, EvalKind.NoField);
+            if (note.StartsWith("(unreadable", StringComparison.Ordinal)) return (false, EvalKind.Unreadable);
+            if (note.Length > 0 && note[0] == '[') return (false, EvalKind.Container);
+            return (false, EvalKind.Unset);
+        }
+
+        // Generalized membership (in / not in on a LEAF path — W2): the leaf's token against the member list,
+        // '='-vocabulary equality per entry. A FormKey leaf against an all-FormKey list uses the pre-parsed set
+        // (O(1) — the artifact-list case must not be linear per record).
+        if (p.Op is Op.In or Op.NotIn)
+        {
+            bool member;
+            if (p.FormIds is not null && TryFormKey(leaf.Token, out var lfk))
+                member = p.FormIds.Contains(lfk);
+            else
+                member = p.RawMembers!.Any(m => ValueEquals(leaf.Token, m));
+            return (p.Op == Op.In ? member : !member, EvalKind.Definite);
+        }
+
+        var (satisfied, err) = Compare(p, leaf);
+        if (err is not null) { _fatal ??= err; return (false, EvalKind.Definite); }
+        return (satisfied, EvalKind.Definite);
+    }
+
+    /// <summary>The `-&gt;` link step on one candidate: links under the LEFT path → each target's winner body (from
+    /// the bound view, cached across candidates) → <see cref="EvalCore"/> on each — satisfied iff ANY target
+    /// satisfies. No-verdict classification: a left-path miss reuses the leaf-note vocabulary; links that all fail
+    /// to resolve/judge report Unreadable (the filter cannot judge this candidate — never a silent non-match
+    /// dressed as a definite one).</summary>
+    (bool Satisfied, EvalKind Kind) EvalLinkStep(Predicate p, IMajorRecordGetter body)
+    {
+        if (_fetchWinnerBody is null)
+        {
+            _fatal = "internal: a '->' link-step predicate was evaluated without a bound resolution context — this scan surface does not support it.";
+            return (false, EvalKind.Definite);
+        }
+        var (links, note) = ReadEngine.CollectLinksAt(body, p.LinkPath!);
+        if (links is null)
+        {
+            var n = note ?? "";
+            if (n.StartsWith("(no field", StringComparison.Ordinal)) return (false, EvalKind.NoField);
+            if (n.StartsWith("(unreadable", StringComparison.Ordinal)) return (false, EvalKind.Unreadable);
+            if (n.StartsWith("(no links", StringComparison.Ordinal)) return (false, EvalKind.NoField);   // not a link-bearing path — a wrong path for this step
+            return (false, EvalKind.Unset);                                                              // absent optional — no links to follow
+        }
+        if (links.Count == 0) return (false, EvalKind.Unset);   // present but empty — genuinely nothing linked
+
+        bool anyVerdict = false, anyNoField = false;
+        foreach (var fk in links)
+        {
+            if (!_targetCache.TryGetValue(fk, out var target))
+                _targetCache[fk] = target = _fetchWinnerBody(fk);
+            if (target is null) continue;                       // unresolvable target — can't judge through it
+            var (sat, kind) = EvalCore(p, target);
+            if (_fatal is not null) return (false, EvalKind.Definite);
+            if (kind == EvalKind.Definite)
+            {
+                anyVerdict = true;
+                if (sat) return (true, EvalKind.Definite);
+            }
+            else if (kind == EvalKind.NoField) anyNoField = true;
+        }
+        if (anyVerdict) return (false, EvalKind.Definite);
+        return (false, anyNoField ? EvalKind.NoField : EvalKind.Unreadable);
     }
 
     /// <summary>The three-state presence verdict for a leaf under <c>exists</c>/<c>missing</c>: a DEFINITE
@@ -431,6 +696,9 @@ public sealed class FieldPredicateSet
 
             case Op.Contains:
                 return (token.Contains(p.Operand, StringComparison.OrdinalIgnoreCase), null);
+
+            case Op.StartsWith:
+                return (token.StartsWith(p.Operand, StringComparison.OrdinalIgnoreCase), null);
 
             default: // Eq / Ne
                 // On a [Flags] enum, equate by RESOLVED bit pattern so a numeric operand matches a name-rendered
@@ -528,7 +796,8 @@ public sealed class FieldPredicateSet
         List<string>? notes = null;
         for (int k = 0; k < _predicates.Count; k++)
         {
-            var path = _predicates[k].PathDisplay;
+            var pk = _predicates[k];
+            var path = pk.LinkPathDisplay is null ? pk.PathDisplay : pk.LinkPathDisplay + "->" + pk.PathDisplay;
             if (_valueRead[k] == 0)
             {
                 // No candidate read a value — but the CAUSE decides whether this is a wrong path or a correct path
@@ -569,7 +838,7 @@ public sealed class FieldPredicateSet
     static string OpStr(Op op) => op switch
     {
         Op.Eq => "=", Op.Ne => "!=", Op.Gt => ">", Op.Ge => ">=", Op.Lt => "<", Op.Le => "<=",
-        Op.Contains => "contains", Op.Has => "has", Op.Exists => "exists", Op.Missing => "missing",
+        Op.Contains => "contains", Op.StartsWith => "startswith", Op.Has => "has", Op.Exists => "exists", Op.Missing => "missing",
         Op.In => "in", Op.NotIn => "not in", _ => "?",
     };
 

--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -93,7 +93,12 @@ public sealed class FieldPredicateSet
     // evaluating an unbound term is a FatalError, never a silent non-match (Q3).
     Func<FormKey, string?>? _winnerOf;
     Func<FormKey, IMajorRecordGetter?>? _fetchWinnerBody;
-    readonly Dictionary<FormKey, IMajorRecordGetter?> _targetCache = new();   // link-step targets recur across candidates — fetch once per scan
+    // Link-step targets recur across candidates — fetch once per scan. Unbounded BY DESIGN for the set's
+    // lifetime (one call): magnitude is the DISTINCT link-target population of the scanned scope, which for
+    // realistic link paths (Perks, Effects, Keywords) is hundreds-to-low-thousands of record getters — small
+    // beside the scan itself. A pathological whole-order high-fan-out path is bounded by the same scope the
+    // grammar already requires (types=/plugins=) — noted per the PR #307 round-3 review.
+    readonly Dictionary<FormKey, IMajorRecordGetter?> _targetCache = new();
 
     /// <summary>Whether any predicate needs the scan's resolution context (<c>winner</c> term or a <c>-&gt;</c>
     /// link step) — the call site checks this to bind <see cref="BindResolution"/> (and open the body-fetch

--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -303,7 +303,7 @@ public sealed class FieldPredicateSet
                 if (lerr is not null) return (null, lerr);
                 return (new Predicate(text, segs, path, op, operand, 0, set, artifact, LinkPath: linkSegs, LinkPathDisplay: linkDisplay, Pseudo: pseudo), null);
             }
-            var (members, mset, martifact, merr) = ParseValueList(raw, operand);
+            var (members, mset, martifact, merr) = ParseValueList(text, operand);
             if (merr is not null) return (null, merr);
             return (new Predicate(text, segs, path, op, operand, 0, mset, martifact, LinkPath: linkSegs, LinkPathDisplay: linkDisplay, Pseudo: pseudo, RawMembers: members), null);
         }

--- a/src/housecarl-core/FieldPredicate.cs
+++ b/src/housecarl-core/FieldPredicate.cs
@@ -311,7 +311,7 @@ public sealed class FieldPredicateSet
                 return (null, $"predicate '{raw}': 'winner {OpStr(op)} <list>' is not supported (yet) — AND/OR the '=' form per plugin, e.g. \"winner = A.esp\".");
             if (pseudo == PseudoPath.FormId)
             {
-                var (set, artifact, lerr) = ParseFormIdList(raw, operand);
+                var (set, artifact, lerr) = ParseFormIdList(text, operand);
                 if (lerr is not null) return (null, lerr);
                 return (new Predicate(text, segs, path, op, operand, 0, set, artifact, LinkPath: linkSegs, LinkPathDisplay: linkDisplay, Pseudo: pseudo), null);
             }

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -283,6 +283,50 @@ public static class ReadEngine
         return keys;
     }
 
+    /// <summary>Collect every FormKey linked UNDER one field path — the `-&gt;` link-step's left side (W2, SPEC
+    /// §2.2's P3 term). Navigation is the same engine walk reads use (<see cref="NavigateValue"/>), then the value
+    /// yields its links by shape: a FormLink → its key; a list → each element's own links (a direct link element,
+    /// or a link-bearing struct like PerkPlacement via Mutagen's generic <c>EnumerateFormLinks</c>); a link-bearing
+    /// substruct → its links. De-duplicated, null links dropped. Returns (null, note) when the path doesn't reach a
+    /// link-bearing value — the note reuses the read walk's vocabulary ("(no field …", "(absent)", "(unreadable …")
+    /// so callers classify it exactly like a leaf miss; a present-but-empty list returns an EMPTY list (a genuine
+    /// "no links here", distinct from "not a link path").</summary>
+    internal static (List<FormKey>? Links, string? Note) CollectLinksAt(object record, string[] path)
+    {
+        try
+        {
+            var nav = NavigateValue(record, path);
+            if (!nav.ok) return (null, nav.note);
+            if (nav.val is null) return (null, AbsentNote);
+            var keys = new List<FormKey>();
+            var seen = new HashSet<FormKey>();
+            void Add(FormKey fk) { if (!fk.IsNull && seen.Add(fk)) keys.Add(fk); }
+            switch (nav.val)
+            {
+                case IFormLinkGetter link:
+                    Add(link.FormKey);
+                    break;
+                case string:
+                    return (null, $"(no links: '{string.Join(".", path)}' is a string, not a link-bearing field)");
+                case System.Collections.IEnumerable list:
+                    foreach (var item in list)
+                    {
+                        if (item is IFormLinkGetter il) Add(il.FormKey);
+                        else if (item is IFormLinkContainerGetter fc)
+                            foreach (var l in fc.EnumerateFormLinks()) Add(l.FormKey);
+                    }
+                    break;
+                case IFormLinkContainerGetter sub:
+                    foreach (var l in sub.EnumerateFormLinks()) Add(l.FormKey);
+                    break;
+                default:
+                    return (null, $"(no links: '{string.Join(".", path)}' is not a link-bearing field)");
+            }
+            return (keys, null);
+        }
+        catch (Exception ex) { return (null, $"(unreadable: {ex.Message})"); }
+    }
+
     /// <summary>A "no such field" note that, when the owner is a collection, points the caller at bracket
     /// indexing — the common <c>.0</c>-vs-<c>[0]</c> confusion (the read analog of the write pre-flight's
     /// bracket hint in <c>CorpusRulebook</c>). Brackets are how you step into a list/dict element mid-path;

--- a/src/housecarl-generator/BindingShimProbe.cs
+++ b/src/housecarl-generator/BindingShimProbe.cs
@@ -285,6 +285,19 @@ public static class BindingShimProbe
                 !j10.text.Contains(GenericError) && !j10.text.Contains("unknown parameter")
                 && j10.text.Contains("conflicts_only") && j10.text.Contains("boolean"), j10.Describe());
 
+            // -- J11 (W2 PR 1): the STRUCTURED params bind over the real wire — records' form-scoped project=
+            //    object and the polymorphic source= (a bare string) must reach the tool body (⇒ the config
+            //    prompt), never a binding error. This is the one seam records-guard (which calls the C# method
+            //    directly) cannot cover: the SDK's JSON→POCO deserialization of the published nested schema.
+            var j11 = Call(stdin, stdout, 44, "housecarl_records",
+                """{"formids":["0F1AC1:Skyrim.esm"],"source":"winner","project":{"form":"identity"}}""");
+            failures += Check("J11 structured bind: records' nested project= object + string source= bind and reach the body",
+                j11.text.Contains(ConfigPrompt), j11.Describe());
+            var j11b = Call(stdin, stdout, 45, "housecarl_records",
+                """{"types":["WEAP"],"plugins":{"names":["Skyrim.esm"],"defined_in":true}}""");
+            failures += Check("J11b structured bind: the plugins= scope object binds and reaches the body",
+                j11b.text.Contains(ConfigPrompt), j11b.Describe());
+
             // -- CENSUS: PR #304 final review finding 3 — the executable form of "dormant by construction".
             //    AliasLayerProbe proves the MECHANISM against synthetic schemas; this arm pins the TABLE
             //    against the REAL published schemas: for every rename row and dissolution hint, the exact

--- a/src/housecarl-generator/BindingShimProbe.cs
+++ b/src/housecarl-generator/BindingShimProbe.cs
@@ -407,6 +407,26 @@ public static class BindingShimProbe
         "housecarl_read_record: pluginnames -> plugin",
         "housecarl_read_record: plugins -> plugin",
         "housecarl_read_record: source -> plugin",
+        // W2 PR 1 (re-eyeballed 2026-08-02): housecarl_records joins the surface. The 1.x spellings land on
+        // their 2.0 poles (plugin/mod/from_plugin -> source; formid -> formids; type -> types), the first
+        // dissolution hints go LIVE (the form-scoped PROJECT spellings incl. the chartered conflict_tree hint,
+        // editorid_contains -> the where grammar, winner_fields -> fields_source), and pluginname/pluginnames
+        // list plugins= as their schema-level candidate (kind-gated at runtime: a string cannot bind the
+        // structured scope object, so a live stray still refuses named rather than renaming).
+        "housecarl_records: conflicttree => hint",
+        "housecarl_records: depth => hint",
+        "housecarl_records: editoridcontains => hint",
+        "housecarl_records: fields => hint",
+        "housecarl_records: formid -> formids",
+        "housecarl_records: fromplugin -> source",
+        "housecarl_records: groupby => hint",
+        "housecarl_records: mod -> source",
+        "housecarl_records: plugin -> source",
+        "housecarl_records: pluginname -> plugins",
+        "housecarl_records: pluginnames -> plugins",
+        "housecarl_records: resolvenames => hint",
+        "housecarl_records: type -> types",
+        "housecarl_records: winnerfields => hint",
         "housecarl_remove_record: archivename -> patch",
         "housecarl_remove_record: formids -> formid",
         "housecarl_remove_record: output -> patch",

--- a/src/housecarl-generator/BulkPrimitivesWave2Probe.cs
+++ b/src/housecarl-generator/BulkPrimitivesWave2Probe.cs
@@ -323,8 +323,10 @@ public static class BulkPrimitivesWave2Probe
 
             var bMiss = ReadTools.BatchRecordDetail(svc, new[] { w2Fk.ToString(), w1Fk.ToString() }, plugin: replName,
                 fields: new[] { "BasicStats.Damage" }, depth: 1, conflict_tree: false, resolve_names: false, format: null, max_chars: 0);
-            Check("plugin=Repl: W2 (untouched by Repl) is a per-item 'does not define' error, W1 still reads (batch survives — Q3)",
-                  bMiss.Contains("does not define") && bMiss.Contains("BasicStats.Damage = 15"));
+            // W2 UPDATE (SPEC §4.2 untouched contract): the per-item error now says "does not touch" and NAMES
+            // the actual touchers, replacing the old "does not define … the winner is" wording.
+            Check("plugin=Repl: W2 (untouched by Repl) is a per-item 'does not touch' error naming the touchers, W1 still reads (batch survives — Q3)",
+                  bMiss.Contains("does not touch") && bMiss.Contains("Touched by") && bMiss.Contains("BasicStats.Damage = 15"));
 
             var bJson = ReadTools.BatchRecordDetail(svc, new[] { w1Fk.ToString() }, plugin: masterName,
                 fields: new[] { "BasicStats.Damage" }, depth: 1, conflict_tree: false, resolve_names: false, format: "json", max_chars: 0);

--- a/src/housecarl-generator/BulkQueryPrimitivesProbe.cs
+++ b/src/housecarl-generator/BulkQueryPrimitivesProbe.cs
@@ -152,9 +152,9 @@ public static class BulkQueryPrimitivesProbe
                   byDef.Total == 3 && gd.GetValueOrDefault(masterName) == 2 && gd.GetValueOrDefault(replName) == 1);
 
             // group_by=type over a broad (all-touched) scope, cross-checked against a hand tally of the same scope.
-            var byType = svc.CrossQuery(null, null, null, false, new[] { masterName, replName }, null, 500, groupBy: "type");
+            var byType = svc.CrossQuery((string?)null, null, null, false, new[] { masterName, replName }, null, 500, groupBy: "type");
             var gt = GroupMap(byType);
-            var plain = svc.CrossQuery(null, null, null, false, new[] { masterName, replName }, null, 5000);   // same scope, no group_by
+            var plain = svc.CrossQuery((string?)null, null, null, false, new[] { masterName, replName }, null, 5000);   // same scope, no group_by
             var handTally = new Dictionary<string, int>(StringComparer.Ordinal);
             foreach (var s in plain.Prefilled ?? Array.Empty<RecordSummary>()) handTally[s.Type] = handTally.GetValueOrDefault(s.Type) + 1;
             Check($"group_by=type over plugins=[master,Repl]: Weapon=3, Armor=2, Keyword=2, total 7 — got total {byType.Total}",
@@ -163,13 +163,13 @@ public static class BulkQueryPrimitivesProbe
                   plain.Total == byType.Total && gt.Count == handTally.Count && gt.All(kv => handTally.GetValueOrDefault(kv.Key) == kv.Value));
 
             // conflicts_only + group_by=winner: the pure-index branch (NO body) still aggregates by winner.
-            var conflictWinner = svc.CrossQuery(null, null, null, true, null, null, 500, groupBy: "winner");
+            var conflictWinner = svc.CrossQuery((string?)null, null, null, true, null, null, 500, groupBy: "winner");
             var cw = GroupMap(conflictWinner);
             Check($"conflicts_only + group_by=winner (no body scope): the 1 contested record (W1) → Repl=1 — got total {conflictWinner.Total}",
                   conflictWinner.Total == 1 && cw.GetValueOrDefault(replName) == 1);
 
             // group_by=type WITHOUT a body-bearing scope is refused (type isn't known without a per-record fetch).
-            var typeNoBody = svc.CrossQuery(null, null, null, true, null, null, 500, groupBy: "type");
+            var typeNoBody = svc.CrossQuery((string?)null, null, null, true, null, null, 500, groupBy: "type");
             Check("group_by=type without type=/plugins= is REFUSED loud (no body to name the type)",
                   typeNoBody.Error is not null && typeNoBody.Error.Contains("group_by=type", StringComparison.OrdinalIgnoreCase));
 
@@ -216,7 +216,7 @@ public static class BulkQueryPrimitivesProbe
             using (var cfResolver = LoadOrderResolver.Build(new[] { cfMasterPath, cfAPath, cfBPath }))
             {
                 var cfSvc = LoadOrderService.ForGuard(cfResolver, new UserConfigStore(Path.Combine(dir, "houseCARL.cf.user.json")));
-                var byDef248 = cfSvc.CrossQuery(null, null, null, false, new[] { cfAName, cfBName }, null, 500, groupBy: "defined_in");
+                var byDef248 = cfSvc.CrossQuery((string?)null, null, null, false, new[] { cfAName, cfBName }, null, 500, groupBy: "defined_in");
                 // Setup sanity: the two overrides ARE seen (2 touched records) — the variance test has something to fold.
                 Check($"#248 setup: plugins=[A,B] group_by=defined_in sees 2 touched records — got total {byDef248.Total}",
                       byDef248.Total == 2);
@@ -342,20 +342,20 @@ public static class BulkQueryPrimitivesProbe
 
             // Tiling on the OTHER two collect paths (PR #239 review: type= never fires the de-dup, and conflicts_only
             // collects in its own branch — a branch-confined offset regression must not pass the guard).
-            var fullP = svc.CrossQuery(null, null, null, false, new[] { masterName, replName }, null, 5000);   // 7 records, de-dup ACTIVE
+            var fullP = svc.CrossQuery((string?)null, null, null, false, new[] { masterName, replName }, null, 5000);   // 7 records, de-dup ACTIVE
             var pagedP = new List<FormKey>();
             for (int off = 0; off < fullP.Total; off += 3)
             {
-                var win = svc.CrossQuery(null, null, null, false, new[] { masterName, replName }, null, 3, offset: off);
+                var win = svc.CrossQuery((string?)null, null, null, false, new[] { masterName, replName }, null, 3, offset: off);
                 Check($"plugins-scope window offset={off} limit=3: sources stay parallel to keys",
                       win.Sources is not null && win.Sources.Count == win.Keys.Count);
                 pagedP.AddRange(win.Keys);
             }
             Check($"plugins=[master,Repl] windows tile the de-dup'd enumeration EXACTLY ({fullP.Total} records)",
                   pagedP.SequenceEqual(fullP.Keys));
-            var fullC = svc.CrossQuery(null, null, null, true, null, null, 500);                                // conflicts_only branch
-            var winC0 = svc.CrossQuery(null, null, null, true, null, null, 500, offset: 0);
-            var winC1 = svc.CrossQuery(null, null, null, true, null, null, 500, offset: 1);
+            var fullC = svc.CrossQuery((string?)null, null, null, true, null, null, 500);                                // conflicts_only branch
+            var winC0 = svc.CrossQuery((string?)null, null, null, true, null, null, 500, offset: 0);
+            var winC1 = svc.CrossQuery((string?)null, null, null, true, null, null, 500, offset: 1);
             Check("conflicts_only offset: window 0 = the 1 contested record; offset=1 = honest empty window, not capped",
                   fullC.Total == 1 && winC0.Keys.SequenceEqual(fullC.Keys) && winC1.Keys.Count == 0 && winC1.Total == 1 && !winC1.Capped);
 

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -130,6 +130,13 @@ public static class CiAll
         // formats, and @file re-entry yields the identity column epoch-checked against the consuming call's own
         // capture — a stale artifact refuses loud naming both epochs, with no override switch by design.
         ("artifact-guard", ArtifactGuardProbe.RunGuard),
+        // The 2.0 S1 read surface, core forms (tool-surface 2.0 W2 PR 1, SPEC §2.2/§4.2/§6.1): the W2
+        // where-grammar terms (startswith · editorid · winner provenance · generalized membership · the ->
+        // link step) against brute-force oracles, the housecarl_records dispatch (identity/summary/fields/
+        // everything/aggregate over the list + scan lanes), the §4.2 one-pole source (arm always stated,
+        // untouched refusals naming the touchers, neither-place refusals naming both places), form-scoping
+        // + staging refusals by name, and the to_file/@artifact re-entry epoch check.
+        ("records-guard", RecordsGuardProbe.RunGuard),
         ("verify-loop-guard", VerifyLoopProbe.RunGuard),
         ("vmad-poly-guard", VmadPolyProbe.RunGuard),
         ("poly-field-descend-guard", PolyFieldDescendProbe.RunGuard),

--- a/src/housecarl-generator/EpochGuardProbe.cs
+++ b/src/housecarl-generator/EpochGuardProbe.cs
@@ -186,7 +186,7 @@ internal static class EpochGuardProbe
                 var g = svc.CrossQuery("WEAP", null, null, false, null, null, 500, groupBy: "winner");
                 Check(g.Epoch == current && Wire.RenderCrossQuery(svc, g, null, false, 0).Contains($"epoch={current}"),
                       "…group_by count table carries it (aggregations page too)");
-                Check(svc.CrossQuery(null, null, null, false, null, null, 500).Epoch is null,
+                Check(svc.CrossQuery((string?)null, null, null, false, null, null, 500).Epoch is null,
                       "…a REFUSED query (no filter) stays unstamped — a refusal that consulted no build invents none");
 
                 // batch — ONE epoch for the whole batch; refusal rows answered off the build carry it; parse failures don't

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -84,6 +84,9 @@ internal static class RecordsGuardProbe
             var ovMod = new SkyrimMod(ovKey, SkyrimRelease.SkyrimSE);
             ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(ovMod, master.Weapons.First(w => w.FormKey == weapons[0])))
                 .BasicStats = new WeaponBasicStats { Damage = 99, Weight = 1 };
+            // A DELETED override (PR #307 review fold): header/resolution-only where-terms must still see it.
+            ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(ovMod, master.Weapons.First(w => w.FormKey == weapons[2])))
+                .IsDeleted = true;
 
             var oldMod = new SkyrimMod(oldKey, SkyrimRelease.SkyrimSE);
             ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(oldMod, master.Weapons.First(w => w.FormKey == weapons[1])))
@@ -225,7 +228,7 @@ internal static class RecordsGuardProbe
                   "identity form + a named source refuses by contract (identity is the resolution frame)");
 
             // default form (summary) + the ACTIVE one-pole arm + the touchers-named untouched refusal
-            var sumActive = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]), Fid(weapons[2]) }, source: Je($"\"{ovName}\""));
+            var sumActive = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]), Fid(weapons[1]) }, source: Je($"\"{ovName}\""));
             Check(sumActive.Contains("form=summary") && sumActive.Contains("active in the load order"),
                   "one-pole ACTIVE arm: the response STATES the arm (source= name — active)");
             Check(sumActive.Contains("does not touch") && sumActive.Contains(masterName) && sumActive.Contains(ovName),
@@ -286,7 +289,7 @@ internal static class RecordsGuardProbe
             Check(linkStep.Contains("HcRecSpellA") && !linkStep.Contains("HcRecSpellB"),
                   "the -> link step rides where= end to end (spells whose effect target matches)");
             var eidTerm = RecordsTools.Records(svc, types: new[] { "WEAP" }, where: new[] { "editorid startswith HcRecW" });
-            Check(eidTerm.Contains("HcRecW0") && eidTerm.Contains("HcRecW2"),
+            Check(eidTerm.Contains("HcRecW0") && eidTerm.Contains("HcRecW1"),
                   "the editorid term replaces editorid_contains= (startswith works in a scan)");
 
             // form-scoping refusals + staged refusals
@@ -338,6 +341,67 @@ internal static class RecordsGuardProbe
                   "off-order scan: the fields form refuses by name (staged) with the formids= workaround");
 
             // ============================================================================================
+            //  4b — PR #307 review folds
+            // ============================================================================================
+            Console.WriteLine();
+            Console.WriteLine("--- 4b: review folds — null-EditorID polarity, deleted records, pole coherence, empty results ---");
+
+            // editorid '!=' / membership polarity over a no-EditorID record (findings 2 + 7).
+            Check(Run(new[] { "editorid != HcRecW0" }, weapBodies)
+                      .SetEquals(weapBodies.Select(b => b.FormKey).Where(k => k != weapons[0])),
+                  "editorid '!=' KEEPS the no-EditorID record (not-equal is unambiguously true there)");
+            Check(Run(new[] { "editorid in [HcRecW0, HcRecW2]" }, weapBodies).SetEquals(new[] { weapons[0], weapons[2] }),
+                  "editorid membership: 'in [list]' selects exactly the listed EditorIDs");
+            Check(Run(new[] { "editorid not in [HcRecW0]" }, weapBodies)
+                      .SetEquals(weapBodies.Select(b => b.FormKey).Where(k => k != weapons[0])),
+                  "editorid membership: 'not in' keeps the rest INCLUDING the no-EditorID record");
+
+            // Header/resolution-only terms see DELETED records; body terms still skip them (finding 4).
+            var delWin = RecordsTools.Records(svc, types: new[] { "WEAP" }, where: new[] { $"winner = {ovName}" });
+            Check(delWin.Contains(Fid(weapons[2])),
+                  "the winner term SEES a deleted record (resolution is a real fact about it)");
+            var delBody = RecordsTools.Records(svc, types: new[] { "WEAP" }, where: new[] { "BasicStats.Damage > 0" });
+            Check(!delBody.Contains(Fid(weapons[2])),
+                  "…while a body predicate still skips it (no live body to judge)");
+
+            // everything under a plugins= scope reads the SCOPED body — the fields form's pole (finding 3).
+            var evScoped = RecordsTools.Records(svc, plugins: new RecordsTools.RecordsScope { names = new[] { masterName } },
+                                                types: new[] { "WEAP" }, where: new[] { "editorid = HcRecW0" },
+                                                project: new RecordsTools.RecordsProject { form = "everything", depth = 2 });
+            Check(evScoped.Contains("Damage = 10") && !evScoped.Contains("Damage = 99"),
+                  "scan+everything under plugins= dumps the SCOPED body (the matched pole), not the winner");
+            var evScopedW = RecordsTools.Records(svc, plugins: new RecordsTools.RecordsScope { names = new[] { masterName } },
+                                                 types: new[] { "WEAP" }, where: new[] { "editorid = HcRecW0" }, fields_source: "winner",
+                                                 project: new RecordsTools.RecordsProject { form = "everything", depth = 2 });
+            Check(evScopedW.Contains("Damage = 99"),
+                  "…and fields_source='winner' retargets the dump to the winner, same as the fields form");
+
+            // A zero-match scan is an honest EMPTY result, never the mid-call-tear message (finding 1).
+            var evEmpty = RecordsTools.Records(svc, types: new[] { "WEAP" }, where: new[] { "BasicStats.Damage > 9999" },
+                                               source: Je($"\"{ovName}\""),
+                                               project: new RecordsTools.RecordsProject { form = "everything" });
+            Check(!evEmpty.StartsWith("error:") && !evEmpty.Contains("vanished") && evEmpty.Contains("0 match(es)"),
+                  "a zero-match scan + named source + everything renders an honest empty result, not a tear refusal");
+
+            // Off-order scan: offset= and counts_only= refuse by name (finding 5).
+            var offOffset = RecordsTools.Records(svc, types: new[] { "WEAP" }, source: Je($"\"{oldName}\""), offset: 500);
+            Check(offOffset.StartsWith("error:") && offOffset.Contains("offset"),
+                  "off-order scan: offset= refuses by name (no silent same-window paging)");
+            var offCounts = RecordsTools.Records(svc, types: new[] { "WEAP" }, source: Je($"\"{oldName}\""), counts_only: true);
+            Check(offCounts.StartsWith("error:") && offCounts.Contains("counts_only"),
+                  "off-order scan: counts_only= refuses by name");
+
+            // List aggregate carries the source arm + coverage qualifier in BOTH formats (finding 6).
+            var aggOld = RecordsTools.Records(svc, formids: new[] { Fid(weapons[1]) }, source: Je($"\"{oldName}\""),
+                                              project: new RecordsTools.RecordsProject { form = "aggregate", group_by = "winner" });
+            Check(aggOld.Contains("OUT-OF-LOAD-ORDER"),
+                  "list aggregate (text) states the resolved OFF-ORDER arm");
+            var aggOldJson = RecordsTools.Records(svc, formids: new[] { Fid(weapons[1]) }, source: Je($"\"{oldName}\""), format: "json",
+                                                  project: new RecordsTools.RecordsProject { form = "aggregate", group_by = "winner" });
+            Check(aggOldJson.Contains("OUT-OF-LOAD-ORDER") && aggOldJson.Contains("epoch_covers_source"),
+                  "list aggregate (json) carries the arm + the epoch-coverage qualifier in the envelope");
+
+            // ============================================================================================
             //  5 — TRANSPORT: to_file + @artifact re-entry, epoch-checked
             // ============================================================================================
             Console.WriteLine();
@@ -350,7 +414,7 @@ internal static class RecordsGuardProbe
                   "to_file: the artifact is written, the response is manifest-only inline");
             var reenter = RecordsTools.Records(svc, formids: new[] { "@" + artPath },
                                                project: new RecordsTools.RecordsProject { form = "identity" });
-            Check(reenter.Contains("HcRecW0") && reenter.Contains("HcRecW2") && !reenter.StartsWith("error:"),
+            Check(reenter.Contains("HcRecW0") && reenter.Contains("HcRecW1") && !reenter.StartsWith("error:"),
                   "@artifact re-entry: the identity column becomes the list against the SAME build");
             File.SetLastWriteTimeUtc(ovFile, DateTime.UtcNow.AddMinutes(5));   // change the order → new epoch
             var stale = RecordsTools.Records(svc, formids: new[] { "@" + artPath },

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -1,0 +1,372 @@
+using System.Text.Json;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// REGRESSION GUARD for W2 PR 1 — the `housecarl_records` core surface + the W2 where-grammar terms
+/// (tool-surface-2.0; SPEC §2.2 / §4.2 / §6.1). Arms:
+///
+///   1  GRAMMAR — the new predicate terms, in memory over synthesized bodies against brute-force oracles:
+///      `startswith`; the `editorid` pseudo-path (EDID semantics — a no-editorid record is a DEFINITE
+///      non-match, presence tests work); generalized `in`/`not in` over a leaf (enum names AND FormLink
+///      leaves via the pre-parsed FormKey set); the `winner` provenance term (bound-resolver evaluation,
+///      unbound = a typed FatalError, never a silent non-match); the `->` link step (ANY-match over the
+///      targets, per-scan target cache, wrong-left-path fails LOUD via the accounting).
+///   2  PARSE — the new refusals are named at parse, before any scan: startswith in the operator list,
+///      malformed/chained arrows, winner with a non-equality op, editorid with a numeric op, formid with
+///      a value op, presence tests on identity terms.
+///   3  RECORDS/LIST — the formids= lane: identity form (resolve absorption; a named source refused by
+///      contract), summary/fields/everything forms, the §4.2 ONE-POLE source: ACTIVE arm stated, untouched
+///      records refused naming the ACTUAL TOUCHERS; OFF-ORDER arm (a disabled mod's plugin) stated with
+///      the epoch-coverage qualifier; found-in-NEITHER-place refusal names both places searched.
+///   4  RECORDS/SCAN — types= is a SET (union streams); the winner term and link step ride where= end to
+///      end; form-scoping refusals teach the project= structure by name; the W2-PR2 forms/poles refuse by
+///      NAME (staging, never a silent gap); identity-on-scan and dense-on-list refuse with the rule.
+///   5  TRANSPORT — to_file on the list lane writes the §2.1.1 artifact (manifest-only inline) and
+///      formids=@artifact re-enters it epoch-checked: same build passes, a changed order refuses naming
+///      BOTH epochs.
+///
+/// Self-contained: synthetic MO2 instance + synthesized plugins in temp. No game data.
+/// Run: <c>dotnet run --project src/housecarl-generator records-guard</c>
+/// </summary>
+internal static class RecordsGuardProbe
+{
+    static int _fail;
+    static void Check(bool c, string label) { Console.WriteLine((c ? "  PASS  " : "  FAIL  ") + label); if (!c) _fail++; }
+
+    static JsonElement Je(string json) => JsonDocument.Parse(json).RootElement.Clone();
+
+    public static int RunGuard(string[] args)
+    {
+        Console.WriteLine("================================================================");
+        Console.WriteLine(" records guard — the 2.0 S1 read surface, core forms (W2 PR 1)");
+        Console.WriteLine("================================================================");
+        Console.WriteLine();
+        _fail = 0;
+
+        var root = Path.Combine(Path.GetTempPath(), "hc-records-guard-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            // ============================================================================================
+            //  Fixture — a master (weapons, MGEF/spell pair, NPC-ish content), an ACTIVE override, a
+            //  DISABLED old patch (the off-order pole), and a second disabled copy for the ambiguity arm.
+            // ============================================================================================
+            Directory.CreateDirectory(Path.Combine(root, "game", "Data"));
+            var masterKey = new ModKey("HcRecMaster", ModType.Master);
+            var ovKey = new ModKey("HcRecOverride", ModType.Plugin);
+            var oldKey = new ModKey("HcRecOld", ModType.Plugin);
+            string masterName = masterKey.FileName.String, ovName = ovKey.FileName.String, oldName = oldKey.FileName.String;
+
+            var master = new SkyrimMod(masterKey, SkyrimRelease.SkyrimSE);
+            var weapons = new List<FormKey>();
+            for (int i = 0; i < 3; i++)
+            {
+                var w = master.Weapons.AddNew(); w.EditorID = $"HcRecW{i}";
+                w.BasicStats = new WeaponBasicStats { Damage = (ushort)(10 * (i + 1)), Weight = 1 };
+                weapons.Add(w.FormKey);
+            }
+            var noEidWeap = master.Weapons.AddNew();                       // NO EditorID — the editorid-term definite-non-match case
+            noEidWeap.BasicStats = new WeaponBasicStats { Damage = 5, Weight = 1 };
+            var armo = master.Armors.AddNew(); armo.EditorID = "HcRecA0";  // a second TYPE for the union arm
+            var mgefA = master.MagicEffects.AddNew(); mgefA.EditorID = "HcRecMgefFire";
+            var mgefB = master.MagicEffects.AddNew(); mgefB.EditorID = "OtherMgef";
+            var spellA = master.Spells.AddNew(); spellA.EditorID = "HcRecSpellA";
+            { var e = new Effect(); e.BaseEffect.SetTo(mgefA.FormKey); e.Data = new EffectData { Magnitude = 5 }; spellA.Effects.Add(e); }
+            var spellB = master.Spells.AddNew(); spellB.EditorID = "HcRecSpellB";
+            { var e = new Effect(); e.BaseEffect.SetTo(mgefB.FormKey); e.Data = new EffectData { Magnitude = 7 }; spellB.Effects.Add(e); }
+
+            var ovMod = new SkyrimMod(ovKey, SkyrimRelease.SkyrimSE);
+            ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(ovMod, master.Weapons.First(w => w.FormKey == weapons[0])))
+                .BasicStats = new WeaponBasicStats { Damage = 99, Weight = 1 };
+
+            var oldMod = new SkyrimMod(oldKey, SkyrimRelease.SkyrimSE);
+            ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(oldMod, master.Weapons.First(w => w.FormKey == weapons[1])))
+                .BasicStats = new WeaponBasicStats { Damage = 55, Weight = 1 };
+
+            var inst = Path.Combine(root, "inst");
+            var mods = Path.Combine(inst, "mods");
+            foreach (var d in new[] { "MasterMod", "OverrideMod", "OldMod" }) Directory.CreateDirectory(Path.Combine(mods, d));
+            var masterFile = Path.Combine(mods, "MasterMod", masterName);
+            var ovFile = Path.Combine(mods, "OverrideMod", ovName);
+            var oldFile = Path.Combine(mods, "OldMod", oldName);
+            master.BeginWrite.ToPath(masterFile).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            ovMod.BeginWrite.ToPath(ovFile).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
+            oldMod.BeginWrite.ToPath(oldFile).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
+
+            string Fid(FormKey fk) => $"{fk.ID:X6}:{fk.ModKey.FileName}";
+
+            // ============================================================================================
+            //  1 — GRAMMAR, in memory (brute-force oracles over the known literals)
+            // ============================================================================================
+            Console.WriteLine("--- 1: the W2 where-grammar terms (in-memory oracle) ---");
+            var weapBodies = master.Weapons.Select(w => (IMajorRecordGetter)w).ToList();
+            var spellBodies = master.Spells.Select(s => (IMajorRecordGetter)s).ToList();
+            var mgefByKey = master.MagicEffects.ToDictionary(m => m.FormKey, m => (IMajorRecordGetter)m);
+
+            static HashSet<FormKey> Run(string[] where, IEnumerable<IMajorRecordGetter> bodies,
+                                        Func<FormKey, string?>? winnerOf = null, Func<FormKey, IMajorRecordGetter?>? fetch = null)
+            {
+                var (set, err) = FieldPredicateSet.Parse(where);
+                if (err is not null) throw new InvalidOperationException($"unexpected parse error: {err}");
+                if (set!.NeedsResolution) set.BindResolution(winnerOf ?? (_ => null), fetch);
+                return bodies.Where(b => set.Matches(b)).Select(b => b.FormKey).ToHashSet();
+            }
+
+            // startswith — on a leaf token (EditorID via the pseudo-path) and on a field token.
+            Check(Run(new[] { "editorid startswith HcRecW" }, weapBodies).SetEquals(weapons),
+                  "startswith: 'editorid startswith HcRecW' selects exactly the three named weapons (no-editorid record drops out)");
+            Check(Run(new[] { "editorid contains recw1" }, weapBodies).SetEquals(new[] { weapons[1] }),
+                  "editorid term: 'contains' is case-insensitive and selects the one match");
+            Check(Run(new[] { "editorid missing" }, weapBodies).SetEquals(new[] { noEidWeap.FormKey }),
+                  "editorid term: 'missing' selects exactly the no-EditorID record");
+            Check(Run(new[] { "editorid = HcRecW2" }, weapBodies).SetEquals(new[] { weapons[2] }),
+                  "editorid term: '=' exact (case-insensitive) match");
+
+            // generalized membership — enum leaf and numeric leaf.
+            Check(Run(new[] { "BasicStats.Damage in [10, 30]" }, weapBodies).SetEquals(new[] { weapons[0], weapons[2] }),
+                  "membership: a numeric leaf 'in [10, 30]' keeps exactly the listed values");
+            Check(Run(new[] { "BasicStats.Damage not in [10, 30]" }, weapBodies).SetEquals(new[] { weapons[1], noEidWeap.FormKey }),
+                  "membership: 'not in' is its complement over value-bearing records");
+            Check(Run(new[] { $"Effects[0].BaseEffect in [{Fid(mgefA.FormKey)}]" }, spellBodies).SetEquals(new[] { spellA.FormKey }),
+                  "membership: a FormLink leaf against a FormKey list uses identity-canonical equality");
+
+            // the winner provenance term — bound resolver decides; unbound is a typed fatal.
+            {
+                var winnerMap = new Dictionary<FormKey, string> { [weapons[0]] = ovName };
+                string? WinnerOf(FormKey fk) => winnerMap.TryGetValue(fk, out var w) ? w : masterName;
+                Check(Run(new[] { $"winner = {ovName}" }, weapBodies, WinnerOf).SetEquals(new[] { weapons[0] }),
+                      "winner term: 'winner = Override.esp' selects exactly the overridden record");
+                Check(Run(new[] { $"winner != {ovName}" }, weapBodies, WinnerOf)
+                          .SetEquals(weapBodies.Select(b => b.FormKey).Where(k => k != weapons[0])),
+                      "winner term: '!=' is the complement");
+                var (set, _) = FieldPredicateSet.Parse(new[] { $"winner = {ovName}" });
+                Check(set!.NeedsResolution, "winner term: NeedsResolution is true (the call site knows to bind)");
+                set.Matches(weapBodies[0]);   // deliberately UNBOUND
+                Check(set.FatalError is not null && set.FatalError.Contains("winner"),
+                      "winner term: evaluating UNBOUND is a typed FatalError, never a silent non-match");
+            }
+
+            // the -> link step — ANY-match over targets, resolved through the bound fetch.
+            {
+                IMajorRecordGetter? Fetch(FormKey fk) => mgefByKey.GetValueOrDefault(fk);
+                Check(Run(new[] { "Effects->editorid startswith HcRec" }, spellBodies, null, Fetch).SetEquals(new[] { spellA.FormKey }),
+                      "link step: 'Effects->editorid startswith HcRec' selects the spell whose EFFECT TARGET matches");
+                Check(Run(new[] { $"Effects->formid in [{Fid(mgefB.FormKey)}]" }, spellBodies, null, Fetch).SetEquals(new[] { spellB.FormKey }),
+                      "link step: '->formid in [list]' tests the TARGETS' identity");
+                var (set, err) = FieldPredicateSet.Parse(new[] { "NoSuchField->editorid contains x" });
+                Check(err is null, "link step: a wrong LEFT path parses (it is a per-record classification, not a parse error)");
+                set!.BindResolution(_ => null, Fetch);
+                foreach (var b in spellBodies) set.Matches(b);
+                var note = set.AccountingNote();
+                Check(note is not null && note.Contains("NoSuchField->editorid"),
+                      "link step: a wrong left path fails LOUD in the accounting (named with the arrow), never a silent 0-matches");
+            }
+
+            // ============================================================================================
+            //  2 — PARSE refusals (named, before any scan)
+            // ============================================================================================
+            Console.WriteLine();
+            Console.WriteLine("--- 2: parse refusals name themselves ---");
+            static string? ParseErr(string clause) => FieldPredicateSet.Parse(new[] { clause }).Error;
+            Check(ParseErr("EditorID blorp x") is { } e1 && e1.Contains("startswith"),
+                  "the operator list in refusals names startswith");
+            Check(ParseErr("Perks-> startswith x") is { } e2 && e2.Contains("link step"),
+                  "a malformed arrow ('Perks->') is a named link-step refusal");
+            Check(ParseErr("A->B->C = 1") is { } e3 && e3.Contains("ONE"),
+                  "a chained arrow refuses — one link step only, the walk construct owns chains");
+            Check(ParseErr("winner > 5") is { } e4 && e4.Contains("winner"),
+                  "'winner' with a non-equality operator refuses naming the term's grammar");
+            Check(ParseErr("winner exists") is { } e5 && e5.Contains("provenance"),
+                  "a presence test on 'winner' refuses via the term's op grammar ('=' / '!=' only)");
+            Check(ParseErr("formid exists") is { } e5b && e5b.Contains("always exists"),
+                  "a presence test on 'formid' refuses (identity always exists — it can never filter)");
+            Check(ParseErr("editorid > 5") is { } e6 && e6.Contains("text term"),
+                  "'editorid' with a numeric operator refuses naming the text grammar");
+            Check(ParseErr("formid = 000801:X.esp") is { } e7 && e7.Contains("membership"),
+                  "'formid' with a value operator refuses pointing at the membership ops");
+            Check(ParseErr("Effects->winner = X.esp") is { } e8 && e8.Contains("link step"),
+                  "'winner' behind an arrow refuses (it names the CANDIDATE's resolution)");
+
+            // ============================================================================================
+            //  3 — the records tool, LIST lane, over the real service (synthetic MO2 instance)
+            // ============================================================================================
+            Console.WriteLine();
+            Console.WriteLine("--- 3: records / list lane — identity, one-pole source, touchers-named refusals ---");
+
+            var genDir = Path.Combine(root, "corpus-gen");
+            CorpusGenerator.GenerateAll(genDir, Path.Combine(root, "corpus-ref"));
+            CorpusRulebook.CorpusPath = Path.Combine(genDir, "corpus.json");
+            File.WriteAllText(Path.Combine(inst, "ModOrganizer.ini"),
+                "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+                + Path.Combine(root, "game").Replace(@"\", @"\\") + ")\r\n");
+            var prof = Path.Combine(inst, "profiles", "Default");
+            Directory.CreateDirectory(prof);
+            File.WriteAllText(Path.Combine(prof, "loadorder.txt"), "# header\r\n" + masterName + "\r\n" + ovName + "\r\n");
+            File.WriteAllText(Path.Combine(prof, "plugins.txt"), "*" + masterName + "\r\n*" + ovName + "\r\n");
+            File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n-OldMod\r\n+OverrideMod\r\n+MasterMod\r\n");
+            var store = new UserConfigStore(Path.Combine(root, "user.json"));
+            using var svc = LoadOrderService.WithInstance(inst, 0, store);
+            var epoch0 = svc.Stats().epoch;
+
+            // identity form (resolve absorption)
+            var idText = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]), Fid(mgefA.FormKey) },
+                                              project: new RecordsTools.RecordsProject { form = "identity" });
+            Check(idText.Contains("form=identity") && idText.Contains("HcRecW0") && idText.Contains($"epoch={epoch0}"),
+                  "identity form: labels the list, states the form, stamps the epoch");
+            var idNamed = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) }, source: Je($"\"{ovName}\""),
+                                               project: new RecordsTools.RecordsProject { form = "identity" });
+            Check(idNamed.StartsWith("error:") && idNamed.Contains("labeling frame"),
+                  "identity form + a named source refuses by contract (identity is the resolution frame)");
+
+            // default form (summary) + the ACTIVE one-pole arm + the touchers-named untouched refusal
+            var sumActive = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]), Fid(weapons[2]) }, source: Je($"\"{ovName}\""));
+            Check(sumActive.Contains("form=summary") && sumActive.Contains("active in the load order"),
+                  "one-pole ACTIVE arm: the response STATES the arm (source= name — active)");
+            Check(sumActive.Contains("does not touch") && sumActive.Contains(masterName) && sumActive.Contains(ovName),
+                  "…an untouched record is a per-item refusal NAMING THE ACTUAL TOUCHERS (§4.2)");
+            Check(sumActive.Contains("Damage") == false, "…summary rows carry identity facts, not field dumps");
+
+            // OFF-ORDER arm: the disabled old patch — stated, epoch-coverage qualified, winner context carried
+            var sumOld = RecordsTools.Records(svc, formids: new[] { Fid(weapons[1]) }, source: Je($"\"{oldName}\""));
+            Check(sumOld.Contains("OUT-OF-LOAD-ORDER") && sumOld.Contains("form=summary"),
+                  "one-pole OFF-ORDER arm: a disabled mod's plugin resolves and the response states the arm");
+            Check(sumOld.Contains("OUTSIDE the epoch fingerprint"),
+                  "…with the epoch-coverage qualifier (the file's content is outside the fingerprint)");
+            Check(sumOld.Contains($"winner={masterName}"),
+                  "…and the row still carries the ACTIVE winner context for the record");
+            var fieldsOld = RecordsTools.Records(svc, formids: new[] { Fid(weapons[1]) }, source: Je($"\"{oldName}\""),
+                                                 project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "BasicStats.Damage" } });
+            Check(fieldsOld.Contains("55"), "…fields form reads the FILE's own version (Damage=55, not the winner's 20)");
+
+            // found in NEITHER place / ambiguity
+            var nowhere = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) }, source: Je("\"NoSuchPlugin.esp\""));
+            Check(nowhere.Contains("NEITHER place") && nowhere.Contains("not ACTIVE") && nowhere.Contains("on disk"),
+                  "a pole found in NEITHER place refuses naming BOTH places searched (§4.2)");
+            var dupDir = Path.Combine(mods, "OldModCopy");
+            Directory.CreateDirectory(dupDir);
+            File.Copy(oldFile, Path.Combine(dupDir, oldName));
+            var ambiguous = RecordsTools.Records(svc, formids: new[] { Fid(weapons[1]) }, source: Je($"\"{oldName}\""));
+            Check(ambiguous.Contains("SEVERAL mod folders") && ambiguous.Contains("\"mod\""),
+                  "a duplicate filename refuses naming the mod folders + the {file, mod} disambiguator");
+            var disamb = RecordsTools.Records(svc, formids: new[] { Fid(weapons[1]) },
+                                              source: Je($"{{\"file\": \"{oldName}\", \"mod\": \"OldMod\"}}"));
+            Check(disamb.Contains("OUT-OF-LOAD-ORDER") && !disamb.StartsWith("error:"),
+                  "…and the structured {file, mod} pole disambiguates it");
+            Directory.Delete(dupDir, true);
+
+            // list-lane aggregate + counts_only
+            var agg = RecordsTools.Records(svc, formids: weapons.Select(Fid).ToArray(),
+                                           project: new RecordsTools.RecordsProject { form = "aggregate", group_by = "winner" });
+            Check(agg.Contains("group_by=winner") && agg.Contains(masterName) && agg.Contains(ovName),
+                  "list-lane aggregate: counts by winner over the resolved rows");
+            var census = RecordsTools.Records(svc, formids: weapons.Select(Fid).ToArray(), counts_only: true);
+            Check(census.Contains("count=3") && census.Contains("ok=3"),
+                  "counts_only: the cheap census, no rows");
+
+            // ============================================================================================
+            //  4 — the records tool, SCAN lane
+            // ============================================================================================
+            Console.WriteLine();
+            Console.WriteLine("--- 4: records / scan lane — type union, winner term, link step, form-scoping ---");
+
+            var union = RecordsTools.Records(svc, types: new[] { "WEAP", "ARMO" });
+            Check(union.Contains("HcRecW0") && union.Contains("HcRecA0"),
+                  "types= is a SET: the scan streams the union of WEAP + ARMO");
+            var winTerm = RecordsTools.Records(svc, types: new[] { "WEAP" }, where: new[] { $"winner = {ovName}" },
+                                               project: new RecordsTools.RecordsProject { form = "summary" });
+            Check(winTerm.Contains("HcRecW0") && !winTerm.Contains("HcRecW1"),
+                  "the winner provenance term rides where= end to end ('which records does X win')");
+            var linkStep = RecordsTools.Records(svc, types: new[] { "SPEL" }, where: new[] { "Effects->editorid startswith HcRecMgef" });
+            Check(linkStep.Contains("HcRecSpellA") && !linkStep.Contains("HcRecSpellB"),
+                  "the -> link step rides where= end to end (spells whose effect target matches)");
+            var eidTerm = RecordsTools.Records(svc, types: new[] { "WEAP" }, where: new[] { "editorid startswith HcRecW" });
+            Check(eidTerm.Contains("HcRecW0") && eidTerm.Contains("HcRecW2"),
+                  "the editorid term replaces editorid_contains= (startswith works in a scan)");
+
+            // form-scoping refusals + staged refusals
+            var flatDepth = RecordsTools.Records(svc, types: new[] { "WEAP" },
+                                                 project: new RecordsTools.RecordsProject { form = "summary", depth = 3 });
+            Check(flatDepth.StartsWith("error:") && flatDepth.Contains("fields"),
+                  "form-scoping: depth outside the fields/everything forms refuses naming the rule");
+            var gbWrong = RecordsTools.Records(svc, types: new[] { "WEAP" },
+                                               project: new RecordsTools.RecordsProject { form = "summary", group_by = "winner" });
+            Check(gbWrong.StartsWith("error:") && gbWrong.Contains("aggregate"),
+                  "form-scoping: group_by outside the aggregate form refuses naming the rule");
+            var tree = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) },
+                                            project: new RecordsTools.RecordsProject { form = "tree" });
+            Check(tree.StartsWith("error:") && tree.Contains("conflict_tree"),
+                  "staging: form='tree' refuses by NAME pointing at today's working spelling");
+            var prevProv = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) }, source: Je("\"previous_provider\""));
+            Check(prevProv.StartsWith("error:") && prevProv.Contains("PR 2"),
+                  "staging: source='previous_provider' refuses by name");
+            var mixed = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) }, types: new[] { "WEAP" });
+            Check(mixed.StartsWith("error:") && mixed.Contains("W2 PR 2"),
+                  "staging: formids= x scan-terms composition refuses by name with the workaround");
+            var idScan = RecordsTools.Records(svc, types: new[] { "WEAP" },
+                                              project: new RecordsTools.RecordsProject { form = "identity" });
+            Check(idScan.StartsWith("error:") && idScan.Contains("summary"),
+                  "identity on the scan lane refuses (summary rows already carry identity)");
+
+            // scan + everything (selection + body lane, epoch-compared)
+            var ev = RecordsTools.Records(svc, types: new[] { "ARMO" },
+                                          project: new RecordsTools.RecordsProject { form = "everything" });
+            Check(ev.Contains("HcRecA0") && ev.Contains("match(es)"),
+                  "scan + everything: selection via the scan, full bodies via the batch lane");
+
+            // aggregate on scan + json envelope
+            var aggScan = RecordsTools.Records(svc, types: new[] { "WEAP" }, format: "json",
+                                               project: new RecordsTools.RecordsProject { form = "aggregate", group_by = "winner" });
+            Check(aggScan.Contains("\"form\": \"aggregate\"") && aggScan.Contains("\"groups\""),
+                  "scan aggregate in json carries the records envelope (form) in-band");
+            var sumJson = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) }, format: "json");
+            Check(sumJson.Contains("\"form\": \"summary\"") && sumJson.Contains("\"source\": \"winner\""),
+                  "list summary in json carries form + resolved source arm in the envelope");
+
+            // off-order SCAN lane (the file's records as the universe)
+            var offScan = RecordsTools.Records(svc, types: new[] { "WEAP" }, source: Je($"\"{oldName}\""));
+            Check(offScan.Contains("OUT-OF-LOAD-ORDER") && offScan.Contains("HcRecW1"),
+                  "off-order scan: types= enumerates the FILE's own records, arm stated");
+            var offAgg = RecordsTools.Records(svc, source: Je($"\"{oldName}\""), types: new[] { "WEAP" },
+                                              project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "BasicStats.Damage" } });
+            Check(offAgg.StartsWith("error:") && offAgg.Contains("W2 PR 2"),
+                  "off-order scan: the fields form refuses by name (staged) with the formids= workaround");
+
+            // ============================================================================================
+            //  5 — TRANSPORT: to_file + @artifact re-entry, epoch-checked
+            // ============================================================================================
+            Console.WriteLine();
+            Console.WriteLine("--- 5: to_file artifact + @file re-entry, epoch-checked ---");
+            var artPath = Path.Combine(root, "results", "weaps.jsonl");
+            Directory.CreateDirectory(Path.Combine(root, "results"));
+            var toFile = RecordsTools.Records(svc, formids: weapons.Select(Fid).ToArray(), to_file: artPath,
+                                              project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "BasicStats.Damage" } });
+            Check(File.Exists(artPath) && toFile.Contains(artPath) && !toFile.Contains("Damage = 99"),
+                  "to_file: the artifact is written, the response is manifest-only inline");
+            var reenter = RecordsTools.Records(svc, formids: new[] { "@" + artPath },
+                                               project: new RecordsTools.RecordsProject { form = "identity" });
+            Check(reenter.Contains("HcRecW0") && reenter.Contains("HcRecW2") && !reenter.StartsWith("error:"),
+                  "@artifact re-entry: the identity column becomes the list against the SAME build");
+            File.SetLastWriteTimeUtc(ovFile, DateTime.UtcNow.AddMinutes(5));   // change the order → new epoch
+            var stale = RecordsTools.Records(svc, formids: new[] { "@" + artPath },
+                                             project: new RecordsTools.RecordsProject { form = "identity" });
+            Check(stale.StartsWith("error:") && stale.Contains(epoch0!) && stale.Contains("epoch"),
+                  "…after the order changes, re-entry REFUSES naming both epochs (never mixes two worlds)");
+
+            Console.WriteLine();
+            Console.WriteLine(_fail == 0
+                ? "[records-guard] PASS — the 2.0 read surface's core contract holds."
+                : $"[records-guard] FAIL — {_fail} check(s) regressed.");
+            return _fail == 0 ? 0 : 1;
+        }
+        finally
+        {
+            try { Directory.Delete(root, true); } catch { /* temp cleanup best-effort */ }
+        }
+    }
+}

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -401,6 +401,21 @@ internal static class RecordsGuardProbe
             Check(aggOldJson.Contains("OUT-OF-LOAD-ORDER") && aggOldJson.Contains("epoch_covers_source"),
                   "list aggregate (json) carries the arm + the epoch-coverage qualifier in the envelope");
 
+            // Re-review folds: dense refuses the column-less forms by name (never a silent transport switch),
+            // and the list lane refuses fields_source= by name (never accepted-and-dropped).
+            var denseEv = RecordsTools.Records(svc, types: new[] { "WEAP" }, format: "dense",
+                                               project: new RecordsTools.RecordsProject { form = "everything" });
+            Check(denseEv.StartsWith("error:") && denseEv.Contains("column"),
+                  "dense + everything refuses by name (no fixed column set) — never a silent text fallback");
+            var denseAgg = RecordsTools.Records(svc, types: new[] { "WEAP" }, format: "dense",
+                                                project: new RecordsTools.RecordsProject { form = "aggregate", group_by = "winner" });
+            Check(denseAgg.StartsWith("error:") && denseAgg.Contains("json"),
+                  "dense + aggregate refuses by name pointing at json — never a silent json switch");
+            var listFs = RecordsTools.Records(svc, formids: new[] { Fid(weapons[1]) }, source: Je($"\"{oldName}\""), fields_source: "winner",
+                                              project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "BasicStats.Damage" } });
+            Check(listFs.StartsWith("error:") && listFs.Contains("fields_source"),
+                  "fields_source= on the formids= lane refuses by name — never accepted-and-dropped");
+
             // ============================================================================================
             //  5 — TRANSPORT: to_file + @artifact re-entry, epoch-checked
             // ============================================================================================

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -121,9 +121,12 @@ internal static class RecordsGuardProbe
                 return bodies.Where(b => set.Matches(b)).Select(b => b.FormKey).ToHashSet();
             }
 
-            // startswith — on a leaf token (EditorID via the pseudo-path) and on a field token.
+            // startswith — on the editorid pseudo-path AND on a REAL leaf token (round-3 F6: the pseudo-path
+            // short-circuits before Compare(), so only a genuine leaf drives the new Op.StartsWith arm there).
             Check(Run(new[] { "editorid startswith HcRecW" }, weapBodies).SetEquals(weapons),
                   "startswith: 'editorid startswith HcRecW' selects exactly the three named weapons (no-editorid record drops out)");
+            Check(Run(new[] { "BasicStats.Damage startswith 1" }, weapBodies).SetEquals(new[] { weapons[0] }),
+                  "startswith on a REAL leaf token routes through Compare (10 matches '1'; 20/30/5 do not)");
             Check(Run(new[] { "editorid contains recw1" }, weapBodies).SetEquals(new[] { weapons[1] }),
                   "editorid term: 'contains' is case-insensitive and selects the one match");
             Check(Run(new[] { "editorid missing" }, weapBodies).SetEquals(new[] { noEidWeap.FormKey }),
@@ -415,6 +418,33 @@ internal static class RecordsGuardProbe
                                               project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "BasicStats.Damage" } });
             Check(listFs.StartsWith("error:") && listFs.Contains("fields_source"),
                   "fields_source= on the formids= lane refuses by name — never accepted-and-dropped");
+
+            // Round-3 folds: transport params are honored or refused, never accepted-and-dropped.
+            var coToFile = RecordsTools.Records(svc, formids: weapons.Select(Fid).ToArray(), counts_only: true,
+                                                to_file: Path.Combine(root, "never.jsonl"));
+            Check(coToFile.StartsWith("error:") && coToFile.Contains("counts_only"),
+                  "counts_only + to_file refuses by name (used to return the census and silently write nothing)");
+            var idCensus = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]), "notaformid" }, counts_only: true,
+                                                project: new RecordsTools.RecordsProject { form = "identity" });
+            Check(idCensus.Contains("count=2") && idCensus.Contains("errors=1") && !idCensus.Contains("HcRecW0"),
+                  "identity + counts_only returns the census, no rows (was rendered anyway)");
+            var winList = RecordsTools.Records(svc, formids: weapons.Select(Fid).ToArray(), limit: 2, offset: 1);
+            Check(winList.Contains("window: rows 2–3 of 3") && !winList.Contains(Fid(weapons[0])),
+                  "limit/offset WINDOW the formids= render with the note in-band (were accepted-and-dropped)");
+            var depthOne = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) },
+                                                project: new RecordsTools.RecordsProject { form = "summary", depth = 1 });
+            Check(depthOne.StartsWith("error:") && depthOne.Contains("depth"),
+                  "an EXPLICIT depth outside its forms refuses regardless of value (depth:1 was accepted-and-dropped)");
+
+            // Off-order untouched refusal names the touchers (round-3 F3) — oldName touches only W1.
+            var offUntouched = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) }, source: Je($"\"{oldName}\""));
+            Check(offUntouched.Contains("does not define or override") && offUntouched.Contains("Touched by") && offUntouched.Contains(masterName),
+                  "off-order untouched: the per-item refusal names the ACTIVE touchers (was arm-asymmetric)");
+
+            // A PATH-form source on the scan lane resolves back to the plugin name (round-3 F4).
+            var pathScan = RecordsTools.Records(svc, types: new[] { "WEAP" }, source: Je(JsonSerializer.Serialize(ovFile)));
+            Check(pathScan.Contains("active in the load order") && pathScan.Contains("HcRecW0") && !pathScan.StartsWith("error:"),
+                  "a path-form source= on the scan lane resolves to its active plugin and the scan RUNS (was a refusal after a correct arm statement)");
 
             // ============================================================================================
             //  5 — TRANSPORT: to_file + @artifact re-entry, epoch-checked

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -441,6 +441,27 @@ internal static class RecordsGuardProbe
             Check(offUntouched.Contains("does not define or override") && offUntouched.Contains("Touched by") && offUntouched.Contains(masterName),
                   "off-order untouched: the per-item refusal names the ACTIVE touchers (was arm-asymmetric)");
 
+            // Round-3 RE-REVIEW blocker: an off-order pole asked for a FormID whose defining plugin is NOT in
+            // the index must be a per-item honest refusal (TouchingPlugins returns NULL there, not a throw) —
+            // never a whole-call NullReferenceException dressed as an internal failure.
+            var offAlien = RecordsTools.Records(svc, formids: new[] { "000123:NotInOrder.esp" }, source: Je($"\"{oldName}\""));
+            Check(!offAlien.Contains("NullReferenceException") && offAlien.Contains("No active plugin touches it either"),
+                  "off-order pole + out-of-index FormID: a per-item refusal saying nothing touches it (was an NRE)");
+            // Re-review minors: the empty window says so honestly; to_file suppresses the window (the artifact
+            // is complete and the render is manifest-only); aggregate + offset refuses on the list lane too.
+            var pastEnd = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) }, offset: 10);
+            Check(pastEnd.Contains("no rows") && pastEnd.Contains("past the end") && !pastEnd.Contains("rows 11"),
+                  "an offset past the end renders the honest empty-window note (was 'rows 0–10 of N')");
+            var artNoWin = Path.Combine(root, "results", "nowindow.jsonl");
+            var toFileLim = RecordsTools.Records(svc, formids: weapons.Select(Fid).ToArray(), limit: 2, to_file: artNoWin,
+                                                 project: new RecordsTools.RecordsProject { form = "identity" });
+            Check(!toFileLim.Contains("window:") && File.Exists(artNoWin),
+                  "to_file + limit: no window note over the complete artifact (the rows ARE the file)");
+            var aggOffset = RecordsTools.Records(svc, formids: weapons.Select(Fid).ToArray(), offset: 1,
+                                                 project: new RecordsTools.RecordsProject { form = "aggregate", group_by = "winner" });
+            Check(aggOffset.StartsWith("error:") && aggOffset.Contains("offset"),
+                  "aggregate + offset refuses by name on the list lane too (was silently ignored)");
+
             // A PATH-form source on the scan lane resolves back to the plugin name (round-3 F4).
             var pathScan = RecordsTools.Records(svc, types: new[] { "WEAP" }, source: Je(JsonSerializer.Serialize(ovFile)));
             Check(pathScan.Contains("active in the load order") && pathScan.Contains("HcRecW0") && !pathScan.StartsWith("error:"),

--- a/src/housecarl-generator/ValuePredicateProbe.cs
+++ b/src/housecarl-generator/ValuePredicateProbe.cs
@@ -332,8 +332,11 @@ public static class ValuePredicateProbe
         }
 
         // parse refusals — each names itself and refuses the whole call BEFORE any scan (Q3).
-        Check("parse: `in` on a non-formid path refused (identity-only)",
-            FieldPredicateSet.Parse(new[] { $"MagicSkill in [{mgefs[0].Fk}]" }).Error is not null);
+        // W2 UPDATE: `in` on a non-formid path is no longer refused — membership generalized to any scalar
+        // leaf (the extension the old refusal reserved). The leaf-membership CORRECTNESS arms live in
+        // records-guard; here the old refusal arm flips to "parses clean" so a regression to the refusal fails.
+        Check("parse: `in` on a non-formid LEAF path parses (W2 generalized membership)",
+            FieldPredicateSet.Parse(new[] { "MagicSkill in [Destruction, Restoration]" }).Error is null);
         Check("parse: `not` without `in` refused",
             FieldPredicateSet.Parse(new[] { "formid not [123456:X.esp]" }).Error is not null);
         Check("parse: empty list refused (`formid in []`)",

--- a/src/housecarl-generator/VerifyLoopProbe.cs
+++ b/src/housecarl-generator/VerifyLoopProbe.cs
@@ -85,10 +85,12 @@ public static class VerifyLoopProbe
                   miss.Error is not null && miss.Error.Contains("full_readback", StringComparison.OrdinalIgnoreCase));
 
             var noDefine = svc.ResolveRead(w2Fk, ovrName, null, conflictTree: false);
-            Check("TAXONOMY CONTROL: an IN-ORDER plugin that doesn't define the record keeps the true does-not-define message",
+            // W2 UPDATE (SPEC §4.2): the true message is now "does not touch {fk}" + the ACTUAL TOUCHERS named
+            // (load order, winner last) — still unmistakably distinct from the not-in-order taxonomy above.
+            Check("TAXONOMY CONTROL: an IN-ORDER plugin that doesn't define the record keeps the true does-not-touch message, touchers named",
                   noDefine.Error is not null
-                  && noDefine.Error.Contains("does not define", StringComparison.OrdinalIgnoreCase)
-                  && noDefine.Error.Contains("does not touch this record", StringComparison.OrdinalIgnoreCase));
+                  && noDefine.Error.Contains("does not touch", StringComparison.OrdinalIgnoreCase)
+                  && noDefine.Error.Contains("Touched by", StringComparison.OrdinalIgnoreCase));
 
             var defines = svc.ResolveRead(w1Fk, ovrName, null, conflictTree: false);
             Check("TAXONOMY CONTROL: an in-order plugin that DOES define the record still reads clean (source = the named plugin)",

--- a/src/housecarl-mcp/AliasTable.cs
+++ b/src/housecarl-mcp/AliasTable.cs
@@ -167,8 +167,8 @@ internal static class AliasTable
     /// must never claim the old parameter "was retired" — it states where the job lives, concretely,
     /// and the refusal's supported-parameter list does the rest. No bare ellipses: every hint spells a
     /// usable form.
-    /// (conflict_tree's hint is deliberately absent at W0: whether the tree is a parameter or a
-    /// projection shape is §6's per-wave call — W2 adds the entry when the carrier exists.)
+    /// (conflict_tree's hint — deliberately absent at W0 — landed at W2 PR 1 gated on the `project`
+    /// carrier, per the consumer-inventory obligation: the tree is a PROJECT form, not a parameter.)
     /// A hint may carry SEVERAL gate params — ALL must be declared. property_contains is gated on
     /// where AND findings: no 1.x tool declares both, and W3's check (its true successor) declares
     /// both, so the hint activates exactly at its wave. Its single-gate form fired today on
@@ -179,6 +179,18 @@ internal static class AliasTable
     static readonly Dissolution[] Dissolutions =
     {
         new("editoridcontains", new[] { "where" }, "not a parameter here — this job is the where= predicate grammar: where=[\"editorid contains <text>\"]"),
+
+        // W2 PR 1 — the form-scoped PROJECT teachings (SPEC §2.2 F2): the flat 1.x spellings became sub-parameters
+        // of the project= form object on `records`, so a stray flat one gets the form-scoping rule by name. All
+        // gated on `project` — today that is exactly housecarl_records. conflict_tree is the CHARTERED W2 hint
+        // (the most-taught changing spelling — 9+ skills teach conflict_tree=true; consumer-inventory obligation):
+        // its PROJECT form (tree) ships in W2 PR 2, so the hint names both the destination and today's working
+        // spelling, and PR 2 trims the interim clause when the form lands.
+        new("conflicttree", new[] { "project" }, "not a parameter here — the provider tree is a PROJECT form: project={\"form\": \"tree\"} (lands with the W2 comparison forms; until then housecarl_read_record conflict_tree=true renders it)"),
+        new("fields",       new[] { "project" }, "not a parameter here — field paths live inside the form: project={\"form\": \"fields\", \"fields\": [\"<path>\", …]}"),
+        new("depth",        new[] { "project" }, "not a parameter here — depth lives inside the fields/everything forms: project={\"form\": \"fields\", \"fields\": […], \"depth\": <n>}"),
+        new("groupby",      new[] { "project" }, "not a parameter here — aggregation is a PROJECT form: project={\"form\": \"aggregate\", \"group_by\": \"winner\"}"),
+        new("resolvenames", new[] { "project" }, "not a parameter here — display annotation lives inside the fields/everything forms: project={\"form\": \"fields\", \"fields\": […], \"resolve_names\": true}"),
         new("propertycontains", new[] { "where", "findings" }, "not a parameter here — script-property predicates belong to the where= grammar: where=[\"<property path> contains <text>\"]"),
         new("mgefformid",   new[] { "walk" }, "not a parameter here — seed the walk= construct with the MGEF's FormID instead"),
         new("closure",      new[] { "walk" }, "not a parameter here — the closure copy is expressed as the walk= construct"),

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -38,7 +38,17 @@ static class JsonWire
     public static string RenderResolve(IReadOnlyList<ResolvedRef> rows, int maxChars, string epoch)
         => RenderResolve(rows, maxChars, epoch, null, out _);
 
-    public static string RenderResolve(IReadOnlyList<ResolvedRef> rows, int maxChars, string epoch, SpillState? spill, out bool truncated)
+    /// <summary>W2 `records`: optional response-envelope pairs (form=, the resolved source arm, …) written as
+    /// top-level string fields at the START of a json document — so a json consumer sees the same call context
+    /// the text header line states, in-band, without any per-render shape change.</summary>
+    static void WriteEnvelope(Utf8JsonWriter w, IReadOnlyList<KeyValuePair<string, string>>? envelope)
+    {
+        if (envelope is null) return;
+        foreach (var kv in envelope) w.WriteString(kv.Key, kv.Value);
+    }
+
+    public static string RenderResolve(IReadOnlyList<ResolvedRef> rows, int maxChars, string epoch, SpillState? spill, out bool truncated,
+                                       IReadOnlyList<KeyValuePair<string, string>>? envelope = null)
     {
         truncated = false;
         int cap = Cap(maxChars);
@@ -47,6 +57,7 @@ static class JsonWire
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
             w.WriteStartObject();
+            WriteEnvelope(w, envelope);
             w.WriteNumber("count", rows.Count);
             w.WriteString("epoch", epoch);   // §2.1.1: the ONE captured build the whole batch resolved against
             w.WriteStartArray("resolved");
@@ -274,7 +285,8 @@ static class JsonWire
     public static string RenderBatch(IReadOnlyList<ReadOutcome> outcomes, int maxChars)
         => RenderBatch(outcomes, maxChars, null, out _);
 
-    public static string RenderBatch(IReadOnlyList<ReadOutcome> outcomes, int maxChars, SpillState? spill, out bool truncated)
+    public static string RenderBatch(IReadOnlyList<ReadOutcome> outcomes, int maxChars, SpillState? spill, out bool truncated,
+                                     IReadOnlyList<KeyValuePair<string, string>>? envelope = null)
     {
         truncated = false;
         int cap = Cap(maxChars);
@@ -283,6 +295,7 @@ static class JsonWire
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
             w.WriteStartObject();
+            WriteEnvelope(w, envelope);
             w.WriteNumber("count", outcomes.Count);
             // The whole batch reads ONE captured build (ResolveBatch) — response-level accounting, first non-null
             // (a malformed-FormID row never consulted a view and carries none).
@@ -308,6 +321,100 @@ static class JsonWire
         return Finish(ms);
     }
 
+    // ---- housecarl_records (W2 PR 1) ----------------------------------------------------------------
+
+    /// <summary>records counts_only on the list lane: the census document, no rows.</summary>
+    public static string RenderCounts(IReadOnlyList<KeyValuePair<string, string>> envelope, int count, int ok, int errors, string? epoch)
+    {
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            WriteEnvelope(w, envelope);
+            w.WriteNumber("count", count);
+            w.WriteNumber("ok", ok);
+            w.WriteNumber("errors", errors);
+            WriteNullable(w, "epoch", epoch);
+            w.WriteEndObject();
+        }
+        return Finish(ms);
+    }
+
+    /// <summary>records form=summary on the list lane: one identity+winner row per outcome (or its per-item
+    /// error) — the json twin of the text summary lines, spill marker in-band.</summary>
+    public static string RenderRecordsSummary(IReadOnlyList<ReadOutcome> outcomes, int maxChars,
+                                              IReadOnlyList<KeyValuePair<string, string>> envelope,
+                                              SpillState? spill, out bool truncated)
+    {
+        truncated = false;
+        int cap = Cap(maxChars);
+        bool manifestOnly = spill?.ManifestOnly ?? false;
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            WriteEnvelope(w, envelope);
+            w.WriteNumber("count", outcomes.Count);
+            WriteNullable(w, "epoch", outcomes.FirstOrDefault(o => o.Epoch is not null)?.Epoch);
+            w.WriteStartArray("records");
+            int rendered = 0; bool rowsTruncated = false;
+            foreach (var o in outcomes)
+            {
+                if (manifestOnly) break;
+                w.Flush();
+                if (ms.Length >= cap) { rowsTruncated = true; break; }
+                w.WriteStartObject();
+                w.WriteString("formid", o.FormKey.ToString());
+                if (o.Error is not null) w.WriteString("error", o.Error);
+                else
+                {
+                    w.WriteString("type", o.Record!.Type);
+                    WriteNullable(w, "editorid", o.Record.EditorId);
+                    WriteNullable(w, "source", o.SourcePlugin);
+                    WriteNullable(w, "winner", o.WinnerPlugin);
+                    w.WriteNumber("override_depth", o.OverrideDepth);
+                }
+                w.WriteEndObject();
+                rendered++;
+            }
+            w.WriteEndArray();
+            w.WriteNumber("rendered", rendered);
+            w.WriteBoolean("truncated", rowsTruncated);
+            truncated = rowsTruncated;
+            if (spill is not null) Artifacts.WriteSpillStateJson(w, spill);
+            w.WriteEndObject();
+        }
+        return Finish(ms);
+    }
+
+    /// <summary>records form=aggregate on the list lane: the count table over resolved rows, per-item errors
+    /// counted apart (never silently dropped from a census — Q3).</summary>
+    public static string RenderListAggregate(string groupBy, IReadOnlyList<KeyValuePair<string, int>> rows,
+                                             int count, int errors, string? epoch)
+    {
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            w.WriteString("form", "aggregate");
+            w.WriteString("group_by", groupBy);
+            w.WriteNumber("count", count);
+            if (errors > 0) w.WriteNumber("errors", errors);
+            WriteNullable(w, "epoch", epoch);
+            w.WriteStartArray("groups");
+            foreach (var (key, n) in rows.Select(r => (r.Key, r.Value)))
+            {
+                w.WriteStartObject();
+                w.WriteString("key", key);
+                w.WriteNumber("count", n);
+                w.WriteEndObject();
+            }
+            w.WriteEndArray();
+            w.WriteEndObject();
+        }
+        return Finish(ms);
+    }
+
     // ---- housecarl_cross_plugin_query (P6) ----------------------------------------------------------
     /// <summary>cross_plugin_query as JSON — three shapes matching the text render: group_by count table
     /// (<c>{group_by, total, groups:[…]}</c>), detail rows (full record objects with fields), or summary rows
@@ -321,7 +428,8 @@ static class JsonWire
     /// marker outside the json body would be invisible to a json consumer), <paramref name="truncated"/> is the
     /// auto-spill trigger handed back to the tool layer.</summary>
     public static string RenderCrossQuery(LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields, int maxChars, bool resolveNames, bool winnerFields, int depth,
-                                          SpillState? spill, out bool truncated)
+                                          SpillState? spill, out bool truncated,
+                                          IReadOnlyList<KeyValuePair<string, string>>? envelope = null)
     {
         truncated = false;
         int cap = Cap(maxChars);
@@ -330,6 +438,7 @@ static class JsonWire
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
             w.WriteStartObject();
+            WriteEnvelope(w, envelope);
             // Post-capture refusals are stamped (PR #305 contract — e.g. the artifact epoch-mismatch refusal);
             // pre-capture validation refusals carry null and render bare, same as the text twin.
             if (q.Error is not null) { w.WriteString("error", q.Error); if (q.Epoch is not null) w.WriteString("epoch", q.Epoch); }
@@ -435,7 +544,8 @@ static class JsonWire
         => RenderCrossQueryDense(svc, q, fields, maxChars, resolveNames, winnerFields, null, out _);
 
     public static string RenderCrossQueryDense(LoadOrderService svc, CrossQueryOutcome q, IReadOnlyList<string>? fields, int maxChars, bool resolveNames, bool winnerFields,
-                                               SpillState? spill, out bool truncated)
+                                               SpillState? spill, out bool truncated,
+                                               IReadOnlyList<KeyValuePair<string, string>>? envelope = null)
     {
         truncated = false;
         int cap = Cap(maxChars);
@@ -444,6 +554,7 @@ static class JsonWire
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
             w.WriteStartObject();
+            WriteEnvelope(w, envelope);
             // Post-capture refusals are stamped (PR #305 contract); pre-capture validation refusals stay bare.
             if (q.Error is not null) { w.WriteString("error", q.Error); if (q.Epoch is not null) w.WriteString("epoch", q.Epoch); }
             else
@@ -878,13 +989,15 @@ static class JsonWire
     /// caveat), then the file/masters context and the mode payload: <c>record</c> (the FILE's own record — no winner,
     /// it's not resolved), <c>records</c> (enumerate), or <c>type_counts</c> (summary). <c>error</c>/<c>ambiguous</c>
     /// on failure.</summary>
-    public static string RenderPluginFile(PluginFileOutcome o, int maxChars)
+    public static string RenderPluginFile(PluginFileOutcome o, int maxChars,
+                                          IReadOnlyList<KeyValuePair<string, string>>? envelope = null)
     {
         int cap = Cap(maxChars);
         using var ms = new MemoryStream();
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
             w.WriteStartObject();
+            WriteEnvelope(w, envelope);
             if (o.Mode == "error") { w.WriteString("error", o.Error); }
             else if (o.Mode == "ambiguous")
             {

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -390,13 +390,14 @@ static class JsonWire
     /// <summary>records form=aggregate on the list lane: the count table over resolved rows, per-item errors
     /// counted apart (never silently dropped from a census — Q3).</summary>
     public static string RenderListAggregate(string groupBy, IReadOnlyList<KeyValuePair<string, int>> rows,
-                                             int count, int errors, string? epoch)
+                                             int count, int errors, string? epoch,
+                                             IReadOnlyList<KeyValuePair<string, string>>? envelope = null)
     {
         using var ms = new MemoryStream();
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
             w.WriteStartObject();
-            w.WriteString("form", "aggregate");
+            WriteEnvelope(w, envelope);   // form + the resolved source arm + coverage qualifiers (review fold)
             w.WriteString("group_by", groupBy);
             w.WriteNumber("count", count);
             if (errors > 0) w.WriteNumber("errors", errors);

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -40,7 +40,11 @@ static class JsonWire
 
     /// <summary>W2 `records`: optional response-envelope pairs (form=, the resolved source arm, …) written as
     /// top-level string fields at the START of a json document — so a json consumer sees the same call context
-    /// the text header line states, in-band, without any per-render shape change.</summary>
+    /// the text header line states, in-band, without any per-render shape change.
+    /// CONTRACT (PR #307 round 3): envelope keys must not collide with any renderer's own top-level keys
+    /// (count/epoch/records/rendered/truncated/total/…) — Utf8JsonWriter does not dedupe, so a collision would
+    /// emit a duplicate-key document. Today's set (form/source/window/epoch_covers_source/total) is disjoint;
+    /// keep it that way when adding pairs.</summary>
     static void WriteEnvelope(Utf8JsonWriter w, IReadOnlyList<KeyValuePair<string, string>>? envelope)
     {
         if (envelope is null) return;

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2797,8 +2797,10 @@ public sealed class LoadOrderService : IDisposable
                 {
                     // The §4.2 untouched contract holds on THIS arm too (PR #307 round 3): name the plugins that
                     // DO touch the record in the active order — or say plainly that nothing does.
-                    IReadOnlyList<string> touchers;
-                    try { touchers = view.TouchingPlugins(fk); } catch { touchers = Array.Empty<string>(); }
+                    // TouchingPlugins returns NULL (it does not throw) for a FormKey outside the index — e.g. an
+                    // old patch whose master is also disabled (round-3 re-review blocker: the try/catch never
+                    // fired and the null dereferenced into a whole-call generic failure).
+                    IReadOnlyList<string> touchers = view.TouchingPlugins(fk) ?? Array.Empty<string>();
                     results[index] = ReadOutcome.Fail(fk,
                         $"file '{plugin}' ({poleWhere}) does not define or override {fk} — it has no version of this record. " +
                         (touchers.Count > 0

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2243,7 +2243,9 @@ public sealed class LoadOrderService : IDisposable
                 return ReadOutcome.Fail(fk, $"Winner '{winner.Value.WinnerPlugin}' did not yield {fk} on fetch — a load-order inconsistency.");
             // §4.2 (W2): an untouched record under a named pole refuses NAMING THE ACTUAL TOUCHERS — a bare
             // "does not define" reads as "my write was lost"; the touching list is the actionable fact.
-            var touchers = view.TouchingPlugins(fk);
+            // (?? is belt-and-braces here — the non-null winner above proves the fk is in the index — but the
+            // nullable-return shape became a real NRE on the off-order sibling, so the same guard applies.)
+            var touchers = view.TouchingPlugins(fk) ?? Array.Empty<string>();
             return ReadOutcome.Fail(fk,
                 $"Plugin '{plugin}' does not touch {fk} — it has no version of this record. " +
                 $"Touched by (load order, winner last): {string.Join(", ", touchers)}.");

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2639,6 +2639,11 @@ public sealed class LoadOrderService : IDisposable
         /// <summary>The on-disk locate result for the OFF-ORDER arm (null on the active arm) — carried so the
         /// consuming lane can open the file without re-running the locate.</summary>
         internal string? Path { get; init; }
+
+        /// <summary>The epoch of the build the arm was judged against (set by <see cref="ProbeSourceArm"/>) — the
+        /// caller compares it against its dispatch's own stamp, so a load-order change in the probe→dispatch gap
+        /// surfaces as a loud retry refusal instead of an arm statement about a different world (PR #307 round 3).</summary>
+        public string? Epoch { get; init; }
     }
 
     /// <summary>Resolve a `records` source= pole against ONE captured view (the §4.2 one-pole rule): active in the
@@ -2673,14 +2678,15 @@ public sealed class LoadOrderService : IDisposable
     }
 
     /// <summary>The tool-layer probe: WHICH arm would this source= pole resolve to (active / off-order / neither)?
-    /// Uses its own capture; the consuming scan re-captures — the caller compares epochs where a tear would mix
-    /// builds (rare: only a load-order change in the gap).</summary>
+    /// Uses its own capture and stamps its epoch on the <see cref="PoleInfo"/>; the consuming ACTIVE-arm scan
+    /// re-captures and compares stamps (a divergence refuses loud — retry). The OFF-ORDER arm's lane reads the
+    /// file directly and consults no further build, so its arm statement is simply the probe's own build's truth.</summary>
     public PoleInfo? ProbeSourceArm(string plugin, string? mod, out string? error)
     {
         var view = Resolver.Capture();
         var (pole, err) = ResolvePoleArm(view, plugin, mod);
         error = err;
-        return pole;
+        return pole is null ? null : pole with { Epoch = view.Epoch };
     }
 
     /// <summary>The list-driven `records` read under a NAMED source pole (SPEC §4.2): resolve the pole ONCE —
@@ -2789,8 +2795,15 @@ public sealed class LoadOrderService : IDisposable
             {
                 if (!found.TryGetValue(fk, out var rec))
                 {
+                    // The §4.2 untouched contract holds on THIS arm too (PR #307 round 3): name the plugins that
+                    // DO touch the record in the active order — or say plainly that nothing does.
+                    IReadOnlyList<string> touchers;
+                    try { touchers = view.TouchingPlugins(fk); } catch { touchers = Array.Empty<string>(); }
                     results[index] = ReadOutcome.Fail(fk,
-                        $"file '{plugin}' ({poleWhere}) does not define or override {fk} — it has no version of this record.")
+                        $"file '{plugin}' ({poleWhere}) does not define or override {fk} — it has no version of this record. " +
+                        (touchers.Count > 0
+                            ? $"Touched by (active order, winner last): {string.Join(", ", touchers)}."
+                            : "No active plugin touches it either."))
                         with { Epoch = view.Epoch, Pin = pin };
                     continue;
                 }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2759,8 +2759,23 @@ public sealed class LoadOrderService : IDisposable
             var seen = new HashSet<FormKey>();
             // where_source=winner (#233): the match decides on the live WINNER body, fetched via this ONE session
             // (Option B — one session for every per-match winner fetch, not one per record). Opened only when the
-            // scan streams SCOPED bodies (plugins=); a type=-only scan already yields the winner. Disposed with the scan.
-            LoadOrderResolver.OverlaySession? winnerSession = whereWinnerActive ? resolver.OpenSession() : null;
+            // scan streams SCOPED bodies (plugins=); a type=-only scan already yields the winner. Disposed with the
+            // scan. W2: the `->` link-step predicate shares the session for its target-body fetches.
+            LoadOrderResolver.OverlaySession? winnerSession =
+                (whereWinnerActive || predicate is { NeedsBodyResolution: true }) ? resolver.OpenSession() : null;
+            // W2 resolution binding: the `winner` provenance term and the `->` link step read the view's
+            // RESOLUTION (winner name; a target's winner body) — bound off the SAME captured view the scan
+            // answers from, so a predicate can never judge against a different build than the rows (the
+            // Capture() discipline extended to the predicate layer).
+            predicate?.BindResolution(
+                fk => view.ResolveWinner(fk)?.WinnerPlugin,
+                predicate.NeedsBodyResolution
+                    ? fk =>
+                    {
+                        var w = view.ResolveWinner(fk);
+                        return w is null ? null : view.GetRecord(winnerSession!, w.Value.WinnerPlugin, fk);
+                    }
+                    : null);
             try
             {
                 // Carry the SOURCE plugin per record so the render shows the body the scan filtered (not the winner):

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -3032,7 +3032,11 @@ public sealed class LoadOrderService : IDisposable
                         // isolates its own faults, so it is excluded on the semantic ground alone — see
                         // DeletedRecordRule). editorid_contains= stays live: EditorID reads from the
                         // record's early EDID subrecord, before the deep body parse that can throw.
-                        if (DeletedRecordRule.HasNoLiveBody(filterBody) && (refSet is not null || predicate is not null)) continue;
+                        // W2 (PR #307 review): the guard keys on whether the predicates actually READ body
+                        // content — the header/resolution-only terms (`editorid`, `winner`, formid membership)
+                        // must see deleted records exactly as editorid_contains= below deliberately does.
+                        if (DeletedRecordRule.HasNoLiveBody(filterBody)
+                            && (refSet is not null || predicate is { NeedsLiveBody: true })) continue;
                         if (!string.IsNullOrEmpty(editoridContains)
                             && (filterBody.EditorID is null || filterBody.EditorID.IndexOf(editoridContains, StringComparison.OrdinalIgnoreCase) < 0))
                             continue;

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2634,7 +2634,54 @@ public sealed class LoadOrderService : IDisposable
     /// on-disk FILE outside it — the response always STATES which arm, so nothing resolves silently. An off-order
     /// file sits OUTSIDE the epoch fingerprint (the PR #305 coverage rule diff_record already declares) —
     /// <see cref="EpochCoversPole"/> carries that as data for the render.</summary>
-    public sealed record PoleInfo(string Plugin, string Where, bool InOrder, bool EpochCoversPole);
+    public sealed record PoleInfo(string Plugin, string Where, bool InOrder, bool EpochCoversPole)
+    {
+        /// <summary>The on-disk locate result for the OFF-ORDER arm (null on the active arm) — carried so the
+        /// consuming lane can open the file without re-running the locate.</summary>
+        internal string? Path { get; init; }
+    }
+
+    /// <summary>Resolve a `records` source= pole against ONE captured view (the §4.2 one-pole rule): active in the
+    /// order, else located on disk across the whole install. Error non-null ⇒ found in NEITHER place (naming both),
+    /// or ambiguous across mod folders (naming them + the {file, mod} disambiguator).</summary>
+    (PoleInfo? Pole, string? Error) ResolvePoleArm(LoadOrderResolver.IndexView view, string plugin, string? mod)
+    {
+        // A pole addressed by PATH that IS the active order's file resolves back to its plugin name (#269's rule).
+        if (LooksLikePath(plugin) && ActiveNameForPath(view, plugin) is { } activeName) plugin = activeName;
+
+        if (view.ContainsPlugin(plugin))
+            return (new PoleInfo(plugin, "active in the load order", InOrder: true, EpochCoversPole: true), null);
+
+        string modsDir, dataDir, overwriteDir, profileDir;
+        try { lock (_gate) { EnsurePathsDerived(); modsDir = _modsDir; dataDir = _dataDir; overwriteDir = _overwriteDir; profileDir = _profileDir; } }
+        catch (Exception ex)
+        {
+            return (null, $"source '{plugin}' is not active in the load order, and the MO2 roots couldn't be derived to search for it on disk: {ex.Message}");
+        }
+        var comp = Mo2LoadOrder.ReadComposition(profileDir);
+        var loc = LocatePluginFileOnDisk(comp, modsDir, dataDir, overwriteDir, plugin, mod);
+        if (loc.Error is not null)
+            // The §4.2 refusal contract: a pole found in NEITHER place names BOTH places searched.
+            return (null, $"source '{plugin}' resolves in NEITHER place the one-pole rule searches: it is not ACTIVE in " +
+                          $"the load order ({view.PluginCount} plugins), and on disk {loc.Error}");
+        if (loc.Ambiguous is not null)
+            return (null, $"source '{plugin}' is not active in the load order and its filename is provided by SEVERAL mod " +
+                          $"folders on disk: {string.Join(", ", loc.Ambiguous.Select(h => $"'{h.Where}'"))} — disambiguate " +
+                          "with source={\"file\": \"" + plugin + "\", \"mod\": \"<mod folder>\"}.");
+        var poleWhere = $"OUT-OF-LOAD-ORDER ({loc.Where}{(loc.WhyNotActive is { } why ? $"; NOT active — {why}" : "")})";
+        return (new PoleInfo(plugin, poleWhere, InOrder: false, EpochCoversPole: false) { Path = loc.Path }, null);
+    }
+
+    /// <summary>The tool-layer probe: WHICH arm would this source= pole resolve to (active / off-order / neither)?
+    /// Uses its own capture; the consuming scan re-captures — the caller compares epochs where a tear would mix
+    /// builds (rare: only a load-order change in the gap).</summary>
+    public PoleInfo? ProbeSourceArm(string plugin, string? mod, out string? error)
+    {
+        var view = Resolver.Capture();
+        var (pole, err) = ResolvePoleArm(view, plugin, mod);
+        error = err;
+        return pole;
+    }
 
     /// <summary>The list-driven `records` read under a NAMED source pole (SPEC §4.2): resolve the pole ONCE —
     /// active in the order, else a file on disk (enabled, disabled, or unlisted mod folders; the read_plugin_file
@@ -2660,14 +2707,20 @@ public sealed class LoadOrderService : IDisposable
         }
         var pin = new ViewPin(resolver, view);
 
-        // A pole addressed by PATH that IS the active order's file resolves back to its plugin name (#269's rule).
-        if (LooksLikePath(plugin) && ActiveNameForPath(view, plugin) is { } activeName) plugin = activeName;
+        var (arm, armErr) = ResolvePoleArm(view, plugin, mod);
+        if (armErr is not null)
+        {
+            refusal = armErr;
+            refusalEpoch = view.Epoch;
+            return Array.Empty<ReadOutcome>();
+        }
+        pole = arm;
+        plugin = arm!.Plugin;   // a path pole may have resolved back to its active plugin name
 
-        if (view.ContainsPlugin(plugin))
+        if (arm.InOrder)
         {
             // ACTIVE arm — the same per-item reads ResolveBatch(plugin=) does, off the same captured view
             // (excluded-plugin and untouched-record refusals per item, touchers named).
-            pole = new PoleInfo(plugin, "active in the load order", InOrder: true, EpochCoversPole: true);
             var linkMemo = resolveNames ? new Dictionary<FormKey, ResolvedRef>() : null;
             var outcomes = new List<ReadOutcome>(formids.Count);
             foreach (var raw in formids)
@@ -2681,37 +2734,17 @@ public sealed class LoadOrderService : IDisposable
             return outcomes;
         }
 
-        // OFF-ORDER arm (the read_plugin_file reach, absorbed): locate the file across the whole install, open
-        // its overlay ONCE, and pick every requested record in a single enumeration pass.
-        string modsDir, dataDir, overwriteDir, profileDir;
-        try { lock (_gate) { EnsurePathsDerived(); modsDir = _modsDir; dataDir = _dataDir; overwriteDir = _overwriteDir; profileDir = _profileDir; } }
+        // OFF-ORDER arm (the read_plugin_file reach, absorbed): the locate already ran in ResolvePoleArm; open
+        // the overlay ONCE and pick every requested record in a single enumeration pass.
+        string dataDirForOverlay;
+        try { lock (_gate) { EnsurePathsDerived(); dataDirForOverlay = _dataDir; } }
         catch (Exception ex)
         {
-            refusal = $"source '{plugin}' is not active in the load order, and the MO2 roots couldn't be derived to search for it on disk: {ex.Message}";
+            refusal = $"the MO2 roots couldn't be derived to open '{plugin}': {ex.Message}";
             refusalEpoch = view.Epoch;
             return Array.Empty<ReadOutcome>();
         }
-        var comp = Mo2LoadOrder.ReadComposition(profileDir);
-        var loc = LocatePluginFileOnDisk(comp, modsDir, dataDir, overwriteDir, plugin, mod);
-        if (loc.Error is not null)
-        {
-            // The §4.2 refusal contract: a pole found in NEITHER place names BOTH places searched.
-            refusal = $"source '{plugin}' resolves in NEITHER place the one-pole rule searches: it is not ACTIVE in " +
-                      $"the load order ({view.PluginCount} plugins), and on disk {loc.Error}";
-            refusalEpoch = view.Epoch;
-            return Array.Empty<ReadOutcome>();
-        }
-        if (loc.Ambiguous is not null)
-        {
-            refusal = $"source '{plugin}' is not active in the load order and its filename is provided by SEVERAL mod " +
-                      $"folders on disk: {string.Join(", ", loc.Ambiguous.Select(h => $"'{h.Where}'"))} — disambiguate " +
-                      "with source={\"file\": \"" + plugin + "\", \"mod\": \"<mod folder>\"}.";
-            refusalEpoch = view.Epoch;
-            return Array.Empty<ReadOutcome>();
-        }
-
-        var poleWhere = $"OUT-OF-LOAD-ORDER ({loc.Where}{(loc.WhyNotActive is { } why ? $"; NOT active — {why}" : "")})";
-        pole = new PoleInfo(plugin, poleWhere, InOrder: false, EpochCoversPole: false);
+        var poleWhere = arm.Where;
 
         // Parse every FormID first (per-item errors keep their input positions), then one enumeration pass.
         var parsed = new List<(int Index, FormKey Fk)>();
@@ -2723,10 +2756,10 @@ public sealed class LoadOrderService : IDisposable
         }
 
         ISkyrimModGetter ov;
-        try { ov = LoadOrderResolver.OpenOverlay(loc.Path!, string.IsNullOrEmpty(dataDir) ? null : dataDir); }
+        try { ov = LoadOrderResolver.OpenOverlay(arm.Path!, string.IsNullOrEmpty(dataDirForOverlay) ? null : dataDirForOverlay); }
         catch (Exception ex)
         {
-            refusal = $"could not open '{loc.Path}' as a Skyrim plugin: {ex.Message}";
+            refusal = $"could not open '{arm.Path}' as a Skyrim plugin: {ex.Message}";
             refusalEpoch = view.Epoch;
             return Array.Empty<ReadOutcome>();
         }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2238,9 +2238,16 @@ public sealed class LoadOrderService : IDisposable
         using var session = resolver.OpenSession();                       // opens the source plugin; disposed at return (Option B)
         var rec = view.GetRecord(session, source, fk);                    // excluded-check pinned to the SAME view the winner came from (hunt F5 discipline)
         if (rec is null)
-            return ReadOutcome.Fail(fk, plugin is null
-                ? $"Winner '{winner.Value.WinnerPlugin}' did not yield {fk} on fetch — a load-order inconsistency."
-                : $"Plugin '{plugin}' does not define {fk} (it does not touch this record). The winner is '{winner.Value.WinnerPlugin}'.");
+        {
+            if (plugin is null)
+                return ReadOutcome.Fail(fk, $"Winner '{winner.Value.WinnerPlugin}' did not yield {fk} on fetch — a load-order inconsistency.");
+            // §4.2 (W2): an untouched record under a named pole refuses NAMING THE ACTUAL TOUCHERS — a bare
+            // "does not define" reads as "my write was lost"; the touching list is the actionable fact.
+            var touchers = view.TouchingPlugins(fk);
+            return ReadOutcome.Fail(fk,
+                $"Plugin '{plugin}' does not touch {fk} — it has no version of this record. " +
+                $"Touched by (load order, winner last): {string.Join(", ", touchers)}.");
+        }
 
         var record = ReadEngine.ReadFields(rec, fields, depth, containerHint);   // materialise while the session (overlay) is open
         if (resolveNames) record = AnnotateLinks(record, view, session, linkMemo ?? new());   // P7: identity of every FormLink token, DISPLAY-ONLY (same open session)
@@ -2621,6 +2628,151 @@ public sealed class LoadOrderService : IDisposable
         return outcomes;
     }
 
+    // ---- W2 `records`: the §4.2 one-pole batch (source=named, wherever the plugin lives) ----------------
+
+    /// <summary>How a `records` source= pole resolved (SPEC §4.2's ONE-POLE rule): ACTIVE in the order, or an
+    /// on-disk FILE outside it — the response always STATES which arm, so nothing resolves silently. An off-order
+    /// file sits OUTSIDE the epoch fingerprint (the PR #305 coverage rule diff_record already declares) —
+    /// <see cref="EpochCoversPole"/> carries that as data for the render.</summary>
+    public sealed record PoleInfo(string Plugin, string Where, bool InOrder, bool EpochCoversPole);
+
+    /// <summary>The list-driven `records` read under a NAMED source pole (SPEC §4.2): resolve the pole ONCE —
+    /// active in the order, else a file on disk (enabled, disabled, or unlisted mod folders; the read_plugin_file
+    /// reach) — and read every FormID's version from it off ONE captured build. A pole found in NEITHER place is a
+    /// whole-call refusal naming both places searched; a record the pole does not touch is a per-item refusal
+    /// naming the actual touchers (never a silent drop — the §4.2 untouched contract); a bad FormID is a per-item
+    /// error. Off-order reads carry winner context where the record resolves in the active order (so the row still
+    /// says who currently wins), and the pole's file content is declared OUTSIDE the epoch fingerprint.</summary>
+    public IReadOnlyList<ReadOutcome> ResolveBatchFromPole(
+        IReadOnlyList<string> formids, string plugin, string? mod,
+        IReadOnlyList<string>? fields, int depth, bool resolveNames,
+        ArtifactDemand? artifactDemand,
+        out PoleInfo? pole, out string? refusal, out string? refusalEpoch)
+    {
+        pole = null; refusal = null; refusalEpoch = null;
+        var resolver = Resolver;
+        var view = resolver.Capture();          // ONE build for the pole test and every read (§4.1)
+        if (artifactDemand is not null && artifactDemand.Epoch != view.Epoch)
+        {
+            refusal = ArtifactEpochMismatch(artifactDemand, view.Epoch);
+            refusalEpoch = view.Epoch;
+            return Array.Empty<ReadOutcome>();
+        }
+        var pin = new ViewPin(resolver, view);
+
+        // A pole addressed by PATH that IS the active order's file resolves back to its plugin name (#269's rule).
+        if (LooksLikePath(plugin) && ActiveNameForPath(view, plugin) is { } activeName) plugin = activeName;
+
+        if (view.ContainsPlugin(plugin))
+        {
+            // ACTIVE arm — the same per-item reads ResolveBatch(plugin=) does, off the same captured view
+            // (excluded-plugin and untouched-record refusals per item, touchers named).
+            pole = new PoleInfo(plugin, "active in the load order", InOrder: true, EpochCoversPole: true);
+            var linkMemo = resolveNames ? new Dictionary<FormKey, ResolvedRef>() : null;
+            var outcomes = new List<ReadOutcome>(formids.Count);
+            foreach (var raw in formids)
+            {
+                FormKey fk;
+                try { fk = FormKey.Factory(raw.Trim()); }
+                catch (Exception ex) { outcomes.Add(ReadOutcome.Fail(default, $"bad FormID '{raw}': {ex.Message}")); continue; }
+                outcomes.Add(ResolveRead(resolver, view, fk, plugin, fields, false, depth, resolveNames, linkMemo)
+                             with { Epoch = view.Epoch, Pin = pin });
+            }
+            return outcomes;
+        }
+
+        // OFF-ORDER arm (the read_plugin_file reach, absorbed): locate the file across the whole install, open
+        // its overlay ONCE, and pick every requested record in a single enumeration pass.
+        string modsDir, dataDir, overwriteDir, profileDir;
+        try { lock (_gate) { EnsurePathsDerived(); modsDir = _modsDir; dataDir = _dataDir; overwriteDir = _overwriteDir; profileDir = _profileDir; } }
+        catch (Exception ex)
+        {
+            refusal = $"source '{plugin}' is not active in the load order, and the MO2 roots couldn't be derived to search for it on disk: {ex.Message}";
+            refusalEpoch = view.Epoch;
+            return Array.Empty<ReadOutcome>();
+        }
+        var comp = Mo2LoadOrder.ReadComposition(profileDir);
+        var loc = LocatePluginFileOnDisk(comp, modsDir, dataDir, overwriteDir, plugin, mod);
+        if (loc.Error is not null)
+        {
+            // The §4.2 refusal contract: a pole found in NEITHER place names BOTH places searched.
+            refusal = $"source '{plugin}' resolves in NEITHER place the one-pole rule searches: it is not ACTIVE in " +
+                      $"the load order ({view.PluginCount} plugins), and on disk {loc.Error}";
+            refusalEpoch = view.Epoch;
+            return Array.Empty<ReadOutcome>();
+        }
+        if (loc.Ambiguous is not null)
+        {
+            refusal = $"source '{plugin}' is not active in the load order and its filename is provided by SEVERAL mod " +
+                      $"folders on disk: {string.Join(", ", loc.Ambiguous.Select(h => $"'{h.Where}'"))} — disambiguate " +
+                      "with source={\"file\": \"" + plugin + "\", \"mod\": \"<mod folder>\"}.";
+            refusalEpoch = view.Epoch;
+            return Array.Empty<ReadOutcome>();
+        }
+
+        var poleWhere = $"OUT-OF-LOAD-ORDER ({loc.Where}{(loc.WhyNotActive is { } why ? $"; NOT active — {why}" : "")})";
+        pole = new PoleInfo(plugin, poleWhere, InOrder: false, EpochCoversPole: false);
+
+        // Parse every FormID first (per-item errors keep their input positions), then one enumeration pass.
+        var parsed = new List<(int Index, FormKey Fk)>();
+        var results = new ReadOutcome?[formids.Count];
+        for (int i = 0; i < formids.Count; i++)
+        {
+            try { parsed.Add((i, FormKey.Factory(formids[i].Trim()))); }
+            catch (Exception ex) { results[i] = ReadOutcome.Fail(default, $"bad FormID '{formids[i]}': {ex.Message}"); }
+        }
+
+        ISkyrimModGetter ov;
+        try { ov = LoadOrderResolver.OpenOverlay(loc.Path!, string.IsNullOrEmpty(dataDir) ? null : dataDir); }
+        catch (Exception ex)
+        {
+            refusal = $"could not open '{loc.Path}' as a Skyrim plugin: {ex.Message}";
+            refusalEpoch = view.Epoch;
+            return Array.Empty<ReadOutcome>();
+        }
+        try
+        {
+            var wanted = parsed.Select(p => p.Fk).ToHashSet();
+            var found = new Dictionary<FormKey, IMajorRecordGetter>();
+            try
+            {
+                foreach (var r in ov.EnumerateMajorRecords())
+                    if (wanted.Contains(r.FormKey) && !found.ContainsKey(r.FormKey))
+                    {
+                        found[r.FormKey] = r;
+                        if (found.Count == wanted.Count) break;
+                    }
+            }
+            catch (Exception ex)
+            {
+                refusal = $"file '{plugin}' could not be fully read — a record Mutagen cannot parse: {ex.Message}";
+                refusalEpoch = view.Epoch;
+                return Array.Empty<ReadOutcome>();
+            }
+
+            var linkMemo = resolveNames ? new Dictionary<FormKey, ResolvedRef>() : null;
+            using var session = resolveNames ? resolver.OpenSession() : null;   // resolve_names annotates against the ACTIVE order
+            foreach (var (index, fk) in parsed)
+            {
+                if (!found.TryGetValue(fk, out var rec))
+                {
+                    results[index] = ReadOutcome.Fail(fk,
+                        $"file '{plugin}' ({poleWhere}) does not define or override {fk} — it has no version of this record.")
+                        with { Epoch = view.Epoch, Pin = pin };
+                    continue;
+                }
+                var record = ReadEngine.ReadFields(rec, fields, depth);          // materialise while the overlay is open
+                if (resolveNames) record = AnnotateLinks(record, view, session!, linkMemo!);
+                var winner = view.ResolveWinner(fk);                             // winner CONTEXT where the record also lives in the order
+                results[index] = new ReadOutcome(fk, record, plugin, winner?.WinnerPlugin,
+                                                 winner?.OverrideDepth ?? 0, null, null)
+                                 with { Epoch = view.Epoch, Pin = pin };
+            }
+            return results.Select(r => r!).ToList();
+        }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+
     // ---- cross-plugin query (Q4.9) ----------------------------------------------------------------------
 
     /// <summary>Scan the order for records matching a filter (housecarl_cross_plugin_query). A SINGLE enumeration
@@ -2640,11 +2792,21 @@ public sealed class LoadOrderService : IDisposable
                                         bool conflictsOnly, IReadOnlyList<string>? plugins, IReadOnlyList<string>? where, int limit,
                                         bool definedIn = false, string? groupBy = null, int offset = 0, string? whereSource = null,
                                         IReadOnlyList<ArtifactDemand>? artifactDemands = null)
+        => CrossQuery(type is null ? null : new[] { type }, references, editoridContains, conflictsOnly, plugins, where,
+                      limit, definedIn, groupBy, offset, whereSource, artifactDemands);
+
+    /// <summary>The W2 set-valued-types overload (`records` types= is a SET; one is a degenerate set — SPEC §2.2).
+    /// Each entry resolves through the same <see cref="ResolveTypeFilter"/> the singular form used; the scan streams
+    /// the UNION of the resolved type groups.</summary>
+    public CrossQueryOutcome CrossQuery(IReadOnlyList<string>? typeSet, IReadOnlyList<FormKey>? references, string? editoridContains,
+                                        bool conflictsOnly, IReadOnlyList<string>? plugins, IReadOnlyList<string>? where, int limit,
+                                        bool definedIn = false, string? groupBy = null, int offset = 0, string? whereSource = null,
+                                        IReadOnlyList<ArtifactDemand>? artifactDemands = null)
     {
         var resolver = Resolver;
         var view = resolver.Capture();          // ONE build for the SCAN and every per-match fill it makes (HCBR-2026-06-11-02)
         bool hasPlugins = plugins is { Count: > 0 };
-        bool hasType = type is not null;
+        bool hasType = typeSet is { Count: > 0 };
         bool hasWhere = where is { Count: > 0 };
         bool hasReferences = references is { Count: > 0 };
         bool bodyFilter = hasReferences || !string.IsNullOrEmpty(editoridContains) || hasWhere;
@@ -2734,7 +2896,18 @@ public sealed class LoadOrderService : IDisposable
                 return CrossQueryOutcome.Fail(ArtifactEpochMismatch(demand, view.Epoch)) with { Epoch = view.Epoch };
 
         IReadOnlyList<Type>? types;
-        try { types = hasType ? ResolveTypeFilter(type!) : null; }
+        try
+        {
+            if (hasType)
+            {
+                var union = new List<Type>();
+                foreach (var ts in typeSet!)
+                    foreach (var t in ResolveTypeFilter(ts.Trim()))
+                        if (!union.Contains(t)) union.Add(t);
+                types = union;
+            }
+            else types = null;
+        }
         catch (ArgumentException ex) { return CrossQueryOutcome.Fail(ex.Message); }   // unknown type
 
         var keys = new List<FormKey>();

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -1,0 +1,639 @@
+using System.ComponentModel;
+using System.Text;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using Mutagen.Bethesda.Plugins;
+
+namespace HousecarlMcp;
+
+/// <summary>
+/// housecarl_records — the 2.0 S1 read surface (tool-surface-2.0 W2 PR 1; SPEC §2.2/§4.2/§6.1).
+///
+/// ONE read tool: SELECT (which records) × SOURCE (whose version) × PROJECT (what shape) × TRANSPORT compose in a
+/// single call, over the SAME proven engine lanes the 1.x read tools drive (CrossQuery / ResolveBatch /
+/// ResolveRefs / the one-pole batch / the plugin-file overlay) — consolidation of the surface, not a re-implementation
+/// of the engine. This PR ships the CORE forms (identity | summary | fields | everything | aggregate) and the
+/// one-pole named SOURCE; the comparison/traversal forms (delta | tree | chain | info_order, walk=, versus=,
+/// previous_provider, the SkyPatcher overlay source) arrive in W2 PR 2 — until then those spellings get a NAMED
+/// staging refusal pointing at the 1.x tool that does the job today (never a silent gap). The 1.x read tools stay
+/// registered and unchanged through the build waves; they retire at 2.0.0 (clean cut, CHARTER_PHASE4 §3.4a).
+/// </summary>
+[McpServerToolType]
+public static class RecordsTools
+{
+    /// <summary>The plugins= SELECT scope: which records are CONSIDERED (records these plugins touch) — a different
+    /// question from source=, which decides whose VERSION is read. defined_in lives inside the scope because it has
+    /// no meaning without one (SPEC §2.2 form-scoping).</summary>
+    public sealed class RecordsScope
+    {
+        [Description("Plugin filenames to scope the scan to (records those plugins touch), e.g. [\"Requiem.esp\"].")]
+        public string[]? names { get; set; }
+
+        [Description("When true, keep only records DEFINED IN (originating from) the named plugins, dropping records they merely override.")]
+        public bool defined_in { get; set; }
+    }
+
+    /// <summary>PROJECT — the shape of the answer. ONE form; sub-parameters exist only inside the forms that carry
+    /// them (SPEC §2.2: form-scoped and structured — the flat spelling for an illegal pairing does not exist).</summary>
+    public sealed class RecordsProject
+    {
+        [Description("The form: 'identity' (FormID -> type/editorid/name/winner — the labeling form; needs formids=) | 'summary' (identity plus winner/override-depth header facts — the default) | 'fields' (named field values; takes fields= and depth=) | 'everything' (the full record body; takes depth=) | 'aggregate' (a counted table; takes group_by=). The comparison forms (delta | tree | chain | info_order) arrive with the W2 comparison wave and are refused by NAME until then.")]
+        public string? form { get; set; }
+
+        [Description("fields form only: dotted field paths to read, e.g. [\"BasicStats.Damage\", \"Keywords\", \"Effects\"]. Index a list/dict element with BRACKETS ('Effects[0].Data.Magnitude').")]
+        public string[]? fields { get; set; }
+
+        [Description("fields/everything forms: expansion depth for list/dict/substruct CONTENTS (default 1 = a container shown as a count). THIS is the expansion knob: fields=[\"Effects\"], depth=4 reaches every effect's Magnitude/Area/Duration — no hand-written index guessing.")]
+        public int? depth { get; set; }
+
+        [Description("aggregate form only: the count key — 'winner' (by winning plugin), 'type' (by record type; needs types= or plugins=), or 'defined_in' (by defining plugin).")]
+        public string? group_by { get; set; }
+
+        [Description("fields/everything forms: annotate every FormLink value with its target's identity (-> editorid \"Name\"). Display-only — the token itself still round-trips to a write.")]
+        public bool resolve_names { get; set; }
+    }
+
+    [McpServerTool(Name = "housecarl_records", ReadOnly = true, Title = "Read records (the 2.0 read surface)"),
+     Description(
+         "Read Bethesda records from the load order — ONE read surface: which records (SELECT) x whose version " +
+         "(SOURCE) x what shape of answer (PROJECT) compose in a single call.\n\n" +
+         "A FormID is 'XXXXXX:Plugin.esp' — 6 hex digits, a colon, the defining master's filename. Every " +
+         "list-valued parameter is set-valued (one item is a set of one), and formids=/references= accept a single " +
+         "\"@<absolute path>\" element to read the list from a file — including a spilled result artifact from an " +
+         "earlier call (its identity column becomes the list, epoch-checked against the then-current build).\n\n" +
+         "SELECT: formids= | types= | plugins= (scope: which records are considered) | conflicts_only= | where= " +
+         "(body predicates, ANDed: comparisons 'BasicStats.Damage >= 50', 'editorid contains Iron', 'editorid " +
+         "startswith REQ_', flag tests 'BodyTemplate.FirstPersonFlags has Body', presence 'VirtualMachineAdapter " +
+         "exists', membership 'formid not in @<file>' / 'Race in [XXXXXX:A.esm, YYYYYY:B.esm]', ONE '->' link step " +
+         "'Perks->editorid startswith REQ_NULL_', and the provenance term 'winner = X.esp' — which records does X " +
+         "WIN; that term forces winner resolution over the scanned scope, the same declared cost as any winner " +
+         "scan) | references= (reverse, one step — requires a bounding types=/plugins= scope; the reverse-reference " +
+         "index that would lift the bound is a known future capability). UNION-ARM tip: when a field is one of " +
+         "several shapes (an NPC's Configuration.Level is a fixed level OR a PC-level multiplier), a scalar " +
+         "predicate on one arm's sub-field doubles as an ARM-PRESENCE test: where=[\"Configuration.Level.LevelMult " +
+         ">= 0\"] returns exactly the NPCs on a multiplier. In this wave formids= composes with the OTHER select " +
+         "terms in W2 PR 2 — a combined call is refused by name until then.\n\n" +
+         "SOURCE decides WHOSE version you read. Default: the load-order winner. Naming a plugin (source= " +
+         "\"OldPatch.esp\", or {\"file\": \"X.esp\", \"mod\": \"<mod folder>\"} when two mods ship the filename) " +
+         "reads THAT plugin's version wherever the plugin lives — active in your order, or sitting on disk unticked " +
+         "— you do not have to know which, and the response STATES which arm resolved (active, or out-of-load-order " +
+         "and from where). A plugin found in neither place is refused naming both places searched. A record the " +
+         "named plugin does not touch is refused naming the plugins that DO touch it — never silently absent. " +
+         "An off-order file's content sits OUTSIDE the epoch fingerprint and the response says so. " +
+         "('previous_provider' and the SkyPatcher overlay source arrive in W2 PR 2.)\n\n" +
+         "PROJECT is a single form (see project=): identity | summary (default) | fields | everything | aggregate. " +
+         "Sub-parameters live INSIDE the form that uses them (depth belongs to fields/everything, group_by to " +
+         "aggregate) — there is no flat spelling for an illegal pairing.\n\n" +
+         "TRANSPORT: format= 'text' | 'json' | 'dense' (scan lane: positional columnar cells 1:1 with the requested " +
+         "fields — by that definition depth expansion and the everything form are inexpressible in it); limit=/" +
+         "offset= page a scan in exact windows WITHIN one epoch (different epochs across pages ⇒ the order changed " +
+         "— re-run from offset=0, do not stitch); counts_only= returns the accounting without rows; max_chars= caps " +
+         "the RENDER — an over-cap result is not truncated, it SPILLS in full to a server-side JSONL artifact " +
+         "(line 1 = manifest with the query echo, row schema, and epoch) and the response names the file; to_file= " +
+         "forces that disposition to your own path. Every response carries epoch=<hex> — the identity of the index " +
+         "build it was answered from.\n\n" +
+         "This tool never writes. Authoring goes through the write tools (set_field / bulk_apply / create_record / " +
+         "remove_record / forward_record and their successors).")]
+    public static string Records(
+        LoadOrderService svc,
+        [Description("SELECT: records by FormID ('XXXXXX:Plugin.esp'), or [\"@<absolute path>\"] to read the list from a file / spilled artifact. Results return in input order; a bad or absent FormID is a per-item error, never a failed batch.")]
+            string[]? formids = null,
+        [Description("SELECT: record types — signatures ('WEAP') or catalog names ('Weapon'); the scan streams the UNION. types alone enumerates every record of those types in whatever the SOURCE names.")]
+            string[]? types = null,
+        [Description("SELECT: the plugin SCOPE — which records are CONSIDERED (records these plugins touch). Not the same question as source= (whose VERSION is read).")]
+            RecordsScope? plugins = null,
+        [Description("SELECT: keep only records touched by more than one plugin (the contested set).")]
+            bool conflicts_only = false,
+        [Description("SELECT: body predicates, ANDed — see the tool description for the full grammar (comparisons, contains/startswith, has, exists/missing, in/'not in' membership incl. @file and artifact re-entry, the '->' link step, the 'winner' provenance term, and the 'editorid' term that replaces editorid_contains=). A body scan — must be combined with types= or plugins= to bound the work. A wrong path is reported loud, never a silent '0 matches'.")]
+            string[]? where = null,
+        [Description("Which BODY the where= predicates decide the MATCH on: 'scoped' (default — the body the scan streams) or 'winner' (the live load-order winner regardless of scan scope; the post-patch audit answer). Match only — fields_source= independently governs display.")]
+            string? where_source = null,
+        [Description("SELECT: find records that REFERENCE these FormIDs (reverse, one step; OR over the list, each match names which target(s) it hit). Requires a bounding types= or plugins= scope — see the cost declaration in the tool description. Accepts [\"@<path>\"] like formids=.")]
+            string[]? references = null,
+        [Description("SOURCE: whose version to read. Omit or \"winner\" for the load-order winner; a plugin filename (e.g. \"OldPatch.esp\") for that plugin's version WHEREVER it lives — active or on disk out of the order (the response states which); {\"file\": \"X.esp\", \"mod\": \"<mod folder>\"} when two mods ship the same filename. \"previous_provider\" and the runtime overlay arrive in W2 PR 2.")]
+            JsonElement? source = null,
+        [Description("The pole field VALUES display from, when it differs from the matching pole: \"winner\" shows the live winner's values on a plugins=-scoped scan (the old winner_fields=true). Display only — where_source= governs matching.")]
+            string? fields_source = null,
+        [Description("PROJECT: the shape of the answer — a single form plus its own sub-parameters. Omit for summary rows.")]
+            RecordsProject? project = null,
+        [Description("TRANSPORT: 'text' (default) | 'json' (machine-readable document; same accounting in-band) | 'dense' (scan lane: columnar positional rows — the compact bulk-enumeration form).")]
+            string? format = null,
+        [Description("TRANSPORT: max rows to render (default 500). The TRUE total is always reported; page with offset=.")]
+            int limit = 500,
+        [Description("TRANSPORT: skip the first N matches (exact windows: offset=0/500/1000…). Windows tile only within one epoch — if two pages' epochs differ the load order changed mid-pagination; re-run from offset=0.")]
+            int offset = 0,
+        [Description("TRANSPORT: character ceiling on the RENDER. Never truncates the result — an over-ceiling result spills to a JSONL artifact in full and the response names the file. 0 = the server default (~80k).")]
+            int max_chars = 0,
+        [Description("TRANSPORT: return the accounting block and counts only, no rows — the cheap census.")]
+            bool counts_only = false,
+        [Description("TRANSPORT: write the COMPLETE result to this ABSOLUTE .jsonl path as an artifact (line 1 = manifest) and render only the manifest inline. Re-enter it later via formids=[\"@<path>\"] or where=[\"formid in @<path>\"] — epoch-checked. The artifact is never a window: offset= is refused with to_file=.")]
+            string? to_file = null) => Guard.Tool("housecarl_records", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+
+        // ---- TRANSPORT: format --------------------------------------------------------------------------
+        var fmt = Wire.CrossQueryFormat(format, out var ferr);
+        if (ferr is not null) return ferr;
+        bool json = fmt is Wire.QueryFormat.Json;
+        bool dense = fmt is Wire.QueryFormat.Dense;
+
+        // ---- PROJECT: form + form-scoping ---------------------------------------------------------------
+        var form = project?.form?.Trim().ToLowerInvariant() ?? "summary";
+        switch (form)
+        {
+            case "identity" or "summary" or "fields" or "everything" or "aggregate": break;
+            case "delta" or "tree" or "chain" or "info_order":
+                return $"error: project.form='{form}' is a W2 PR 2 form (comparison/traversal) and is not on this surface yet — " +
+                       "meanwhile: delta = housecarl_diff_record; tree = housecarl_read_record conflict_tree=true; chain = " +
+                       "housecarl_effect_chain / references=; info_order = housecarl_validate_dialogue.";
+            default:
+                return $"error: project.form='{project?.form}' is not a form — use identity | summary | fields | everything | aggregate.";
+        }
+        // Sub-parameters exist only inside their forms (SPEC §2.2) — a stray one is refused by name, so the caller
+        // learns the form-scoping rule instead of getting a silently-ignored knob.
+        if (project?.fields is { Length: > 0 } && form != "fields")
+            return $"error: project.fields belongs to the 'fields' form only (got form='{form}'). Set project.form='fields', or drop fields.";
+        if (form == "fields" && project?.fields is not { Length: > 0 })
+            return "error: the 'fields' form names its field paths — pass project.fields=[\"<path>\", …] (or use form='everything' for the full body).";
+        if (project?.depth is { } dv && dv > 1 && form is not ("fields" or "everything"))
+            return $"error: project.depth expands field contents and belongs to the 'fields'/'everything' forms (got form='{form}').";
+        if (project?.group_by is not null && form != "aggregate")
+            return $"error: project.group_by belongs to the 'aggregate' form only (got form='{form}'). Set project.form='aggregate', or drop group_by.";
+        if (form == "aggregate" && string.IsNullOrWhiteSpace(project?.group_by))
+            return "error: the 'aggregate' form names its count key — pass project.group_by='winner' | 'type' | 'defined_in'.";
+        if (project is { resolve_names: true } && form is not ("fields" or "everything"))
+            return $"error: project.resolve_names annotates field values and belongs to the 'fields'/'everything' forms (got form='{form}').";
+        int depth = project?.depth is { } d && d > 0 ? d : 1;
+        var projFields = form == "fields" ? project!.fields : null;
+        bool resolveNames = project?.resolve_names ?? false;
+
+        // ---- SOURCE: the one-pole spelling --------------------------------------------------------------
+        string? srcName = null; string? srcMod = null;
+        if (source is { } se && se.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined)
+        {
+            if (se.ValueKind == JsonValueKind.String)
+            {
+                var s = se.GetString()!.Trim();
+                if (s.Equals("previous_provider", StringComparison.OrdinalIgnoreCase))
+                    return "error: source='previous_provider' is a W2 PR 2 pole (it pairs with the delta/tree comparison forms) — " +
+                           "meanwhile housecarl_read_record conflict_tree=true shows the full provider stack.";
+                if (s.Length > 0 && !s.Equals("winner", StringComparison.OrdinalIgnoreCase)) srcName = s;
+            }
+            else if (se.ValueKind == JsonValueKind.Object)
+            {
+                if (se.TryGetProperty("overlay", out _))
+                    return "error: the runtime-overlay source (SkyPatcher post-state) is a W2 PR 2 pole — meanwhile use housecarl_skypatcher_read.";
+                if (!se.TryGetProperty("file", out var fEl) || fEl.ValueKind != JsonValueKind.String)
+                    return "error: a structured source= names the plugin as {\"file\": \"X.esp\"[, \"mod\": \"<mod folder>\"]} — 'file' is required.";
+                srcName = fEl.GetString()!.Trim();
+                if (se.TryGetProperty("mod", out var mEl) && mEl.ValueKind == JsonValueKind.String) srcMod = mEl.GetString()!.Trim();
+            }
+            else return "error: source= is a string (\"winner\" | a plugin filename) or {\"file\": …, \"mod\": …}.";
+        }
+
+        // ---- fields_source (display pole) ---------------------------------------------------------------
+        bool winnerFields = false;
+        if (!string.IsNullOrWhiteSpace(fields_source))
+        {
+            var fs = fields_source.Trim().ToLowerInvariant();
+            if (fs == "winner") winnerFields = true;
+            else if (fs is not ("scoped" or "scanned"))
+                return $"error: fields_source='{fields_source}' — use 'winner' (display the live winner's values) or omit it (display the matched body). Further poles arrive with the W2 comparison wave.";
+        }
+
+        // ---- lane decision ------------------------------------------------------------------------------
+        bool hasFormids = formids is { Length: > 0 };
+        bool hasScan = types is { Length: > 0 } || plugins?.names is { Length: > 0 } || conflicts_only
+                       || where is { Length: > 0 } || references is { Length: > 0 };
+        if (!hasFormids && !hasScan)
+            return "error: select something — formids= (a record list), or a scan scope: types=, plugins=, conflicts_only=true, where=, references=.";
+        if (hasFormids && hasScan)
+            return "error: formids= composes with the scan terms (types=/plugins=/where=/references=/conflicts_only=) in W2 PR 2 — " +
+                   "not on this surface yet. Meanwhile: run the scan, spill/to_file the result, and re-enter it via where=[\"formid in @<file>\"]; " +
+                   "or filter the formids list client-side.";
+        if (offset < 0) return $"error: offset={offset} — offset must be >= 0.";
+        var toFile = to_file?.Trim();
+        bool wantFile = !string.IsNullOrEmpty(toFile);
+        if (wantFile)
+        {
+            if (Artifacts.ValidateToFile(toFile!) is { } verr) return verr;
+            if (offset > 0) return "error: to_file= captures the COMPLETE result (the artifact is never a window), so offset= has nothing to page — drop offset=.";
+            if (form == "aggregate") return "error: to_file= writes row artifacts, and the aggregate form is a count table with no record rows — drop one of the two.";
+        }
+        if (where_source is not null && where is not { Length: > 0 })
+            return "error: where_source= retargets the where= predicates and needs where= — add predicates, or drop where_source=.";
+
+        // ---- the response envelope (form + resolved source arm) -----------------------------------------
+        // Text renders get it as a header line; json renders carry the same pairs as top-level fields.
+        var envelope = new List<KeyValuePair<string, string>> { new("form", form) };
+        string headerLine = $"records  form={form}";
+        void Arm(string statement) { envelope.Add(new("source", statement)); headerLine += $"  source={statement}"; }
+
+        return hasFormids
+            ? ListLane()
+            : ScanLane();
+
+        // ================================================================================================
+        //  LIST lane — formids= drives; SOURCE picks the read lane.
+        // ================================================================================================
+        string ListLane()
+        {
+            if (dense) return "error: format='dense' is the scan lane's columnar form — a formids= read renders text or json.";
+
+            var (toks, demand, echoSrc, xerr) = Artifacts.ExpandListInput(formids!, "formids");
+            if (xerr is not null) return xerr;
+            var ids = toks!;
+
+            List<KeyValuePair<string, string>> Echo()
+            {
+                var e = new List<KeyValuePair<string, string>> { new("formids", echoSrc ?? $"{ids.Length} inline formid(s)") };
+                e.Add(new("form", form));
+                if (srcName is not null) e.Add(new("source", srcName + (srcMod is not null ? $" (mod '{srcMod}')" : "")));
+                if (projFields is { Length: > 0 }) e.Add(new("fields", string.Join(", ", projFields)));
+                if (depth > 1) e.Add(new("depth", depth.ToString()));
+                return e;
+            }
+
+            // ---- identity form: the labeling lane (absorbs housecarl_resolve). Winner frame by contract. --
+            if (form == "identity")
+            {
+                if (srcName is not null)
+                    return "error: the identity form is the load-order labeling frame (type/editorid/name/WINNER per FormID) — " +
+                           "it does not take a source= pole. Use form='summary' or 'fields' for a named version's view.";
+                var rows = svc.ResolveRefs(ids, demand, out var epoch, out var refusal);
+                if (refusal is not null)
+                    return json ? JsonWire.RenderError(refusal, epoch) : "error: " + refusal + $"\nepoch={epoch}";
+                Arm("winner");
+                SpillState? spill = null;
+                if (wantFile)
+                {
+                    var (s, aerr) = Artifacts.WriteResolve(rows, epoch, toFile!, "to_file", Echo());
+                    if (aerr is not null) return json ? JsonWire.RenderError(aerr, epoch) : "error: " + aerr;
+                    spill = SpillState.Spilled(s!, manifestOnly: true);
+                }
+                string Render(SpillState? sp, out bool trunc) => json
+                    ? JsonWire.RenderResolve(rows, max_chars, epoch, sp, out trunc, envelope)
+                    : headerLine + "\n" + Wire.RenderResolve(rows, max_chars, epoch, sp, out trunc);
+                var rendered = Render(spill, out var truncated);
+                if (spill is null && truncated)
+                {
+                    var path = ResultsStore.NextPath("housecarl_records", epoch);
+                    var (s, aerr) = Artifacts.WriteResolve(rows, epoch, path, "ceiling", Echo());
+                    if (aerr is not null) ResultsStore.Release(path);
+                    rendered = Render(aerr is null ? SpillState.Spilled(s!, manifestOnly: false) : SpillState.WriteFailed(aerr), out _);
+                }
+                return rendered;
+            }
+
+            // ---- summary / fields / everything / aggregate: batch bodies off the source pole. -----------
+            // summary reads ONE cheap leaf (the header facts ride the outcome), fields reads the named paths,
+            // everything dumps the modeled fields (paths=null).
+            IReadOnlyList<string>? readFields = form switch
+            {
+                "fields" => projFields,
+                "summary" or "aggregate" => new[] { "EditorID" },   // cheapest leaf — headers carry the summary facts
+                _ => null,                                          // everything — the full dump
+            };
+            IReadOnlyList<ReadOutcome> outcomes;
+            LoadOrderService.PoleInfo? pole = null;
+            if (srcName is null)
+            {
+                outcomes = svc.ResolveBatch(ids, readFields, false, depth, resolveNames, null, demand, out var refusal, out var refusalEpoch);
+                if (refusal is not null)
+                    return json ? JsonWire.RenderError(refusal, refusalEpoch)
+                                : "error: " + refusal + (refusalEpoch is not null ? $"\nepoch={refusalEpoch}" : "");
+                Arm("winner");
+            }
+            else
+            {
+                outcomes = svc.ResolveBatchFromPole(ids, srcName, srcMod, readFields, depth, resolveNames, demand,
+                                                    out pole, out var refusal, out var refusalEpoch);
+                if (refusal is not null)
+                    return json ? JsonWire.RenderError(refusal, refusalEpoch)
+                                : "error: " + refusal + (refusalEpoch is not null ? $"\nepoch={refusalEpoch}" : "");
+                Arm($"{pole!.Plugin} — {pole.Where}");
+                if (!pole.EpochCoversPole)
+                {
+                    envelope.Add(new("epoch_covers_source", "false"));
+                    headerLine += "\n(the off-order file's content is OUTSIDE the epoch fingerprint — an edit to it changes answers without changing the epoch)";
+                }
+            }
+            var epoch2 = outcomes.FirstOrDefault(o => o.Epoch is not null)?.Epoch;
+
+            if (form == "aggregate")
+                return RenderListAggregate(outcomes, project!.group_by!, json, dense, epoch2);
+
+            if (counts_only)
+            {
+                int ok = outcomes.Count(o => o.Error is null), err = outcomes.Count - outcomes.Count(o => o.Error is null);
+                return json
+                    ? JsonWire.RenderCounts(envelope, outcomes.Count, ok, err, epoch2)
+                    : $"{headerLine}\ncount={outcomes.Count} ok={ok} errors={err}" + (epoch2 is not null ? $"\nepoch={epoch2}" : "");
+            }
+
+            SpillState? spill2 = null;
+            if (wantFile)
+            {
+                var (s, aerr) = Artifacts.WriteBatch(outcomes, toFile!, "to_file", Echo());
+                if (aerr is not null) return json ? JsonWire.RenderError(aerr, epoch2) : "error: " + aerr;
+                spill2 = SpillState.Spilled(s!, manifestOnly: true);
+            }
+            string Render2(SpillState? sp, out bool trunc) => form == "summary"
+                ? RenderRecordsSummary(outcomes, json, headerLine, envelope, max_chars, sp, out trunc)
+                : json ? JsonWire.RenderBatch(outcomes, max_chars, sp, out trunc, envelope)
+                       : headerLine + "\n" + Wire.RenderBatch(svc, outcomes, projFields, false, max_chars, sp, out trunc);
+            var rendered2 = Render2(spill2, out var truncated2);
+            if (spill2 is null && truncated2)
+            {
+                var path = ResultsStore.NextPath("housecarl_records", epoch2 ?? "none");
+                var (s, aerr) = Artifacts.WriteBatch(outcomes, path, "ceiling", Echo());
+                if (aerr is not null) ResultsStore.Release(path);
+                rendered2 = Render2(aerr is null ? SpillState.Spilled(s!, manifestOnly: false) : SpillState.WriteFailed(aerr), out _);
+            }
+            return rendered2;
+        }
+
+        // ================================================================================================
+        //  SCAN lane — types/plugins/where/references/conflicts_only drive; SOURCE picks the universe.
+        // ================================================================================================
+        string ScanLane()
+        {
+            if (form == "identity")
+                return "error: the identity form labels a formids= list; a scan's summary rows already carry each match's identity — use form='summary' (the default).";
+
+            bool hasBodyFilter = where is { Length: > 0 } || references is { Length: > 0 };
+            bool hasTypes = types is { Length: > 0 };
+            bool hasScope = plugins?.names is { Length: > 0 };
+            if (hasBodyFilter && !hasTypes && !hasScope)
+                return "error: where=/references= is a body scan and must be combined with types= or plugins= to bound the work " +
+                       "(conflicts_only= alone is not enough — an unbounded body scan over the whole order is refused; the " +
+                       "reverse-reference index that would lift this is a known future capability).";
+            if (plugins is { defined_in: true } && !hasScope)
+                return "error: plugins.defined_in=true keeps records DEFINED in the scoped plugins, so plugins.names must name that scope.";
+
+            // ---- OFF-ORDER source universe: the file's own records (absorbs read_plugin_file's enumeration).
+            if (srcName is not null)
+            {
+                // Resolve which arm ONCE via a cheap containment probe: the scan below re-captures, and the epoch
+                // stamp on its outcome is compared by the caller reading both — a mid-call order change surfaces
+                // as differing epochs, never a silently mixed answer.
+                var probe = svc.ProbeSourceArm(srcName, srcMod, out var probeErr);
+                if (probeErr is not null) return "error: " + probeErr;
+                if (!probe!.InOrder)
+                    return OffOrderScan(probe);
+                if (hasScope)
+                    return "error: a plugins= scope combined with an ACTIVE named source= (scope-vs-pole streams) lands in W2 PR 2 — " +
+                           "meanwhile: scope to the source plugin itself (plugins.names=[source]) reads its records, or use " +
+                           "fields_source='winner' for winner-value display.";
+                // ACTIVE arm: the pole's records ARE the scan universe — the plugins= stream with the arm stated.
+                Arm($"{probe.Plugin} — active in the load order");
+            }
+            else Arm("winner");
+
+            // references= @file expansion + FormKey parse (mirrors cross_plugin_query).
+            HousecarlCore.ArtifactDemand? refDemand = null; string? refEcho = null;
+            var refs = references;
+            if (refs is { Length: > 0 })
+            {
+                var (toks, demand, echoSrc, xerr) = Artifacts.ExpandListInput(refs, "references");
+                if (xerr is not null) return xerr;
+                refs = toks!; refDemand = demand; refEcho = echoSrc;
+            }
+            IReadOnlyList<FormKey>? refFks = null;
+            if (refs is { Length: > 0 })
+            {
+                var list = new List<FormKey>();
+                foreach (var r in refs)
+                {
+                    if (string.IsNullOrWhiteSpace(r)) continue;
+                    try { list.Add(FormKey.Factory(r.Trim())); }
+                    catch (Exception ex) { return $"error: bad references FormID '{r}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."; }
+                }
+                if (list.Count > 0) refFks = list.Distinct().ToList();
+            }
+
+            var scanPlugins = srcName is not null ? new[] { srcName } : plugins?.names;
+            bool definedIn = plugins?.defined_in ?? false;
+            var groupBy = form == "aggregate" ? project!.group_by!.Trim().ToLowerInvariant() : null;
+            int effLimit = wantFile ? int.MaxValue : counts_only ? 0 : (limit <= 0 ? 500 : limit);
+
+            var outcome = svc.CrossQuery(types, refFks, null, conflicts_only, scanPlugins, where,
+                                         effLimit, definedIn, groupBy, offset, where_source,
+                                         refDemand is null ? null : new[] { refDemand });
+
+            List<KeyValuePair<string, string>> Echo()
+            {
+                var e = new List<KeyValuePair<string, string>>();
+                void Add(string k, string? v) { if (!string.IsNullOrEmpty(v)) e.Add(new(k, v!)); }
+                Add("form", form);
+                Add("types", types is { Length: > 0 } ? string.Join(", ", types) : null);
+                Add("references", refEcho ?? (refs is { Length: > 0 } ? string.Join(", ", refs) : null));
+                if (conflicts_only) Add("conflicts_only", "true");
+                Add("plugins", scanPlugins is { Length: > 0 } ? string.Join(", ", scanPlugins) : null);
+                if (definedIn) Add("defined_in", "true");
+                Add("where", where is { Length: > 0 } ? string.Join(" AND ", where) : null);
+                Add("where_source", where_source);
+                Add("group_by", groupBy);
+                Add("fields", projFields is { Length: > 0 } ? string.Join(", ", projFields) : null);
+                if (depth > 1) Add("depth", depth.ToString());
+                if (winnerFields) Add("fields_source", "winner");
+                Add("source", srcName);
+                return e;
+            }
+
+            // ---- form=everything on a scan: selection here, bodies via the batch lane (window-bounded). --
+            if (form == "everything" && outcome.Error is null && outcome.Groups is null)
+            {
+                var keys = outcome.Keys.Select(k => k.ToString()).ToList();
+                IReadOnlyList<ReadOutcome> bodies = srcName is null
+                    ? svc.ResolveBatch(keys, null, false, depth, resolveNames)
+                    : svc.ResolveBatchFromPole(keys, srcName, srcMod, null, depth, resolveNames, null, out _, out var bref, out _);
+                if (srcName is not null && bodies.Count == 0)
+                    return "error: the source pole vanished between the scan and the body read — the load order changed mid-call; retry.";
+                var bodyEpoch = bodies.FirstOrDefault(o => o.Epoch is not null)?.Epoch;
+                if (bodyEpoch is not null && outcome.Epoch is not null && bodyEpoch != outcome.Epoch)
+                    return $"error: the load order changed between the scan (epoch={outcome.Epoch}) and the body read (epoch={bodyEpoch}) — " +
+                           "the two halves would mix builds. Retry the call.";
+                envelope.Add(new("total", outcome.Total.ToString()));
+                headerLine += $"\n{outcome.Total} match(es); bodies for the {keys.Count}-row window below";
+                string RenderEv(SpillState? sp, out bool trunc) => json
+                    ? JsonWire.RenderBatch(bodies, max_chars, sp, out trunc, envelope)
+                    : headerLine + "\n" + Wire.RenderBatch(svc, bodies, null, false, max_chars, sp, out trunc);
+                SpillState? evSpill = null;
+                if (wantFile)
+                {
+                    var (s, aerr) = Artifacts.WriteBatch(bodies, toFile!, "to_file", Echo());
+                    if (aerr is not null) return json ? JsonWire.RenderError(aerr, bodyEpoch) : "error: " + aerr;
+                    evSpill = SpillState.Spilled(s!, manifestOnly: true);
+                }
+                var evRendered = RenderEv(evSpill, out var evTrunc);
+                if (evSpill is null && evTrunc)
+                {
+                    var path = ResultsStore.NextPath("housecarl_records", bodyEpoch ?? "none");
+                    var (s, aerr) = Artifacts.WriteBatch(bodies, path, "ceiling", Echo());
+                    if (aerr is not null) ResultsStore.Release(path);
+                    evRendered = RenderEv(aerr is null ? SpillState.Spilled(s!, manifestOnly: false) : SpillState.WriteFailed(aerr), out _);
+                }
+                return evRendered;
+            }
+
+            // ---- summary / fields / aggregate: the cross-query renders, envelope-stamped. ----------------
+            SpillState? spill = null;
+            if (wantFile && outcome.Error is null)
+            {
+                var (s, aerr) = Artifacts.WriteCrossQuery(svc, outcome, projFields, resolveNames, winnerFields, depth, toFile!, "to_file", Echo());
+                if (aerr is not null)
+                    return fmt is Wire.QueryFormat.Text ? "error: " + aerr : JsonWire.RenderError(aerr, outcome.Epoch);
+                spill = SpillState.Spilled(s!, manifestOnly: true);
+            }
+            string Render(SpillState? sp, out bool trunc) => fmt switch
+            {
+                Wire.QueryFormat.Dense when groupBy is null => JsonWire.RenderCrossQueryDense(svc, outcome, projFields, max_chars, resolveNames, winnerFields, sp, out trunc, envelope),
+                Wire.QueryFormat.Dense or Wire.QueryFormat.Json => JsonWire.RenderCrossQuery(svc, outcome, projFields, max_chars, resolveNames, winnerFields, depth, sp, out trunc, envelope),
+                _ => headerLine + "\n" + Wire.RenderCrossQuery(svc, outcome, projFields, false, max_chars, resolveNames, winnerFields, depth, sp, out trunc),
+            };
+            var rendered = Render(spill, out var truncated);
+            if (spill is null && truncated && outcome.Error is null)
+            {
+                var path = ResultsStore.NextPath("housecarl_records", outcome.Epoch ?? "none");
+                var (s, aerr) = Artifacts.WriteCrossQuery(svc, outcome, projFields, resolveNames, winnerFields, depth, path, "ceiling", Echo());
+                if (aerr is not null) ResultsStore.Release(path);
+                rendered = Render(aerr is null ? SpillState.Spilled(s!, manifestOnly: false) : SpillState.WriteFailed(aerr), out _);
+            }
+            return rendered;
+        }
+
+        // ================================================================================================
+        //  OFF-ORDER scan: the file's own records are the universe (the read_plugin_file enumeration).
+        // ================================================================================================
+        string OffOrderScan(LoadOrderService.PoleInfo pole)
+        {
+            Arm($"{pole.Plugin} — {pole.Where}");
+            envelope.Add(new("epoch_covers_source", "false"));
+            if (conflicts_only)
+                return "error: conflicts_only= has no meaning on an out-of-load-order file — it is not in the conflict frame. Drop it, or read the winner (source=\"winner\").";
+            if (references is { Length: > 0 } || plugins?.names is { Length: > 0 } || (plugins?.defined_in ?? false))
+                return "error: references=/plugins= over an out-of-load-order file land in W2 PR 2 — this wave reads the file by types= (and an 'editorid contains' where-clause).";
+            if (form is "fields" or "everything")
+                return "error: the fields/everything forms over an out-of-load-order file SCAN land in W2 PR 2 — meanwhile enumerate with form='summary', then read the specific records via formids= (the one-pole batch reads any of the file's records in full).";
+            if (dense) return "error: format='dense' is the in-order scan's columnar form — an off-order file scan renders text or json.";
+            if (wantFile) return "error: to_file= over an out-of-load-order file scan lands in W2 PR 2 — enumerate inline, or batch-read via formids= with to_file=.";
+
+            // The one where-clause this lane carries natively: a single 'editorid contains <text>'.
+            string? eidContains = null;
+            if (where is { Length: > 0 })
+            {
+                if (where.Length == 1 && TryEditorIdContains(where[0], out eidContains)) { }
+                else return "error: over an out-of-load-order file this wave carries exactly one where-clause form: [\"editorid contains <text>\"] — " +
+                            "the full predicate grammar over off-order bodies lands in W2 PR 2.";
+            }
+
+            string? typeArg = null;
+            if (types is { Length: > 1 })
+                return "error: an out-of-load-order file scan reads ONE types= entry at a time in this wave — call per type, or use form='aggregate' group_by='type' for the whole file's census.";
+            if (types is { Length: 1 }) typeArg = types[0];
+            if (form == "aggregate")
+            {
+                var gb = project!.group_by!.Trim().ToLowerInvariant();
+                if (gb != "type")
+                    return $"error: over an out-of-load-order file the aggregate form counts by 'type' (the file's own record census) — group_by='{gb}' has no frame there.";
+                typeArg = null;   // no type filter ⇒ the whole-file record-type summary
+            }
+
+            var o = svc.ReadPluginFile(pole.Plugin, null, typeArg, srcMod, null, 1, eidContains, limit <= 0 ? 500 : limit, false);
+            return json ? JsonWire.RenderPluginFile(o, max_chars, envelope)
+                        : headerLine + "\n" + Wire.RenderPluginFile(o, max_chars);
+        }
+    });
+
+    /// <summary>Recognize the one off-order-lane where-clause: <c>editorid contains &lt;text&gt;</c>.</summary>
+    static bool TryEditorIdContains(string clause, out string? text)
+    {
+        text = null;
+        var c = clause.Trim();
+        const string prefix = "editorid contains ";
+        if (!c.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) return false;
+        var t = c.Substring(prefix.Length).Trim();
+        if (t.Length == 0) return false;
+        text = t;
+        return true;
+    }
+
+    /// <summary>The list-lane summary render: one identity+winner line per outcome (or its per-item error) — the
+    /// batch shape of the scan lane's summary rows. Budget-bounded with the standard explicit cut; the spill marker
+    /// rides in-band in both formats via the shared emitters.</summary>
+    static string RenderRecordsSummary(IReadOnlyList<ReadOutcome> outcomes, bool json, string headerLine,
+                                       List<KeyValuePair<string, string>> envelope, int maxChars, SpillState? spill, out bool truncated)
+    {
+        truncated = false;
+        int cap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        bool manifestOnly = spill?.ManifestOnly ?? false;
+        var epoch = outcomes.FirstOrDefault(o => o.Epoch is not null)?.Epoch;
+        if (json) return JsonWire.RenderRecordsSummary(outcomes, cap, envelope, spill, out truncated);
+
+        var sb = new StringBuilder();
+        sb.Append(headerLine).Append('\n');
+        sb.Append(outcomes.Count).Append(" record(s)");
+        if (epoch is not null) sb.Append("  epoch=").Append(epoch);
+        sb.Append('\n');
+        int rendered = 0;
+        foreach (var o in outcomes)
+        {
+            if (manifestOnly) break;
+            if (sb.Length >= cap)
+            {
+                sb.Append("... [rendered ").Append(rendered).Append(" of ").Append(outcomes.Count)
+                  .Append(" at max_chars=").Append(cap).Append("]\n");
+                truncated = true;
+                break;
+            }
+            if (o.Error is not null) sb.Append(o.FormKey).Append("  error=").Append(o.Error).Append('\n');
+            else
+            {
+                sb.Append(o.FormKey).Append("  ").Append(o.Record!.Type)
+                  .Append("  ").Append(o.Record.EditorId ?? "<no editorid>")
+                  .Append("  source=").Append(o.SourcePlugin ?? "?");
+                if (o.WinnerPlugin is not null) sb.Append("  winner=").Append(o.WinnerPlugin).Append("  depth=").Append(o.OverrideDepth);
+                sb.Append('\n');
+            }
+            rendered++;
+        }
+        if (spill is not null) Artifacts.AppendSpillStateText(sb, spill);
+        return sb.ToString();
+    }
+
+    /// <summary>The list-lane aggregate render: count the resolved rows by winner | type | defined_in — the batch
+    /// twin of the scan lane's count table. Per-item errors are counted and named as their own bucket (never
+    /// silently dropped from a census — Q3).</summary>
+    static string RenderListAggregate(IReadOnlyList<ReadOutcome> outcomes, string groupBy, bool json, bool dense, string? epoch)
+    {
+        var gb = groupBy.Trim().ToLowerInvariant();
+        if (gb is not ("winner" or "type" or "defined_in"))
+            return $"error: project.group_by='{groupBy}' is not a count key — use 'winner', 'type', or 'defined_in'.";
+        var groups = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        int errors = 0;
+        foreach (var o in outcomes)
+        {
+            if (o.Error is not null) { errors++; continue; }
+            var key = gb switch
+            {
+                "type" => o.Record!.Type,
+                "defined_in" => o.FormKey.ModKey.FileName.ToString(),
+                _ => o.WinnerPlugin ?? "?",
+            };
+            groups[key] = groups.GetValueOrDefault(key) + 1;
+        }
+        var rows = groups.OrderByDescending(g => g.Value).ThenBy(g => g.Key, StringComparer.Ordinal).ToList();
+        if (json || dense)
+            return JsonWire.RenderListAggregate(gb, rows, outcomes.Count, errors, epoch);
+        var sb = new StringBuilder();
+        sb.Append("records  form=aggregate  group_by=").Append(gb).Append('\n');
+        sb.Append(outcomes.Count).Append(" record(s)");
+        if (errors > 0) sb.Append("  (").Append(errors).Append(" per-item error(s) — counted apart, listed via form='summary')");
+        if (epoch is not null) sb.Append("  epoch=").Append(epoch);
+        sb.Append('\n');
+        foreach (var (key, count) in rows.Select(r => (r.Key, r.Value)))
+            sb.Append("  ").Append(count.ToString().PadLeft(6)).Append("  ").Append(key).Append('\n');
+        return sb.ToString();
+    }
+}

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -321,7 +321,7 @@ public static class RecordsTools
             var epoch2 = outcomes.FirstOrDefault(o => o.Epoch is not null)?.Epoch;
 
             if (form == "aggregate")
-                return RenderListAggregate(outcomes, project!.group_by!, json, dense, epoch2);
+                return RenderListAggregate(outcomes, project!.group_by!, json, dense, epoch2, headerLine, envelope);
 
             if (counts_only)
             {
@@ -445,15 +445,60 @@ public static class RecordsTools
             if (form == "everything" && outcome.Error is null && outcome.Groups is null)
             {
                 var keys = outcome.Keys.Select(k => k.ToString()).ToList();
-                IReadOnlyList<ReadOutcome> bodies = srcName is null
-                    ? svc.ResolveBatch(keys, null, false, depth, resolveNames)
-                    : svc.ResolveBatchFromPole(keys, srcName, srcMod, null, depth, resolveNames, null, out _, out var bref, out _);
-                if (srcName is not null && bodies.Count == 0)
-                    return "error: the source pole vanished between the scan and the body read — the load order changed mid-call; retry.";
-                var bodyEpoch = bodies.FirstOrDefault(o => o.Epoch is not null)?.Epoch;
-                if (bodyEpoch is not null && outcome.Epoch is not null && bodyEpoch != outcome.Epoch)
-                    return $"error: the load order changed between the scan (epoch={outcome.Epoch}) and the body read (epoch={bodyEpoch}) — " +
-                           "the two halves would mix builds. Retry the call.";
+                IReadOnlyList<ReadOutcome> bodies;
+                if (srcName is not null)
+                {
+                    bodies = svc.ResolveBatchFromPole(keys, srcName, srcMod, null, depth, resolveNames, null,
+                                                      out _, out var bref, out var brefEpoch);
+                    // A refusal is judged on the NAMED cause, never on row count (review: a zero-match scan is an
+                    // honest EMPTY result, and the pole lane's real refusals were being replaced by a generic one).
+                    if (bref is not null)
+                        return json ? JsonWire.RenderError(bref, brefEpoch)
+                                    : "error: " + bref + (brefEpoch is not null ? $"\nepoch={brefEpoch}" : "");
+                }
+                else
+                {
+                    // The scan's per-match SOURCE decides whose body `everything` dumps — the SAME rule the fields
+                    // form renders by (review: this branch read the WINNER under a plugins= scope while the fields
+                    // form read the scoped body — same SELECT, different pole, nothing said so). Keys group by
+                    // their matched source and each group reads off its own plugin; fields_source="winner"
+                    // retargets display to the winner exactly as on the fields form.
+                    var srcs = outcome.Sources;
+                    if (winnerFields || srcs is null || srcs.Take(keys.Count).All(s => s is null))
+                        bodies = svc.ResolveBatch(keys, null, false, depth, resolveNames);
+                    else
+                    {
+                        var byIndex = new ReadOutcome[keys.Count];
+                        var bySource = new Dictionary<string, List<int>>(StringComparer.OrdinalIgnoreCase);
+                        var winnerIdx = new List<int>();
+                        for (int i = 0; i < keys.Count; i++)
+                        {
+                            var s = i < srcs.Count ? srcs[i] : null;
+                            if (s is null) { winnerIdx.Add(i); continue; }
+                            if (!bySource.TryGetValue(s, out var l)) bySource[s] = l = new List<int>();
+                            l.Add(i);
+                        }
+                        if (winnerIdx.Count > 0)
+                        {
+                            var res = svc.ResolveBatch(winnerIdx.Select(i => keys[i]).ToList(), null, false, depth, resolveNames);
+                            for (int i = 0; i < winnerIdx.Count; i++) byIndex[winnerIdx[i]] = res[i];
+                        }
+                        foreach (var kv in bySource)
+                        {
+                            var res = svc.ResolveBatch(kv.Value.Select(i => keys[i]).ToList(), null, false, depth, resolveNames, kv.Key);
+                            for (int i = 0; i < kv.Value.Count; i++) byIndex[kv.Value[i]] = res[i];
+                        }
+                        bodies = byIndex;
+                    }
+                }
+                // The selection and every body read must agree on ONE build (grouped reads capture per batch) —
+                // any divergence refuses loud rather than mixing builds. An empty selection has no body epochs
+                // and passes: it renders as an honest 0-row batch.
+                var bodyEpochs = bodies.Where(o => o.Epoch is not null).Select(o => o.Epoch!).Distinct().ToList();
+                if (outcome.Epoch is not null && bodyEpochs.Any(e => e != outcome.Epoch))
+                    return $"error: the load order changed between the scan (epoch={outcome.Epoch}) and the body read " +
+                           $"(epoch={string.Join(", ", bodyEpochs.Where(e => e != outcome.Epoch))}) — the two halves would mix builds. Retry the call.";
+                var bodyEpoch = bodyEpochs.FirstOrDefault() ?? outcome.Epoch;
                 envelope.Add(new("total", outcome.Total.ToString()));
                 headerLine += $"\n{outcome.Total} match(es); bodies for the {keys.Count}-row window below";
                 string RenderEv(SpillState? sp, out bool trunc) => json
@@ -518,6 +563,8 @@ public static class RecordsTools
                 return "error: the fields/everything forms over an out-of-load-order file SCAN land in W2 PR 2 — meanwhile enumerate with form='summary', then read the specific records via formids= (the one-pole batch reads any of the file's records in full).";
             if (dense) return "error: format='dense' is the in-order scan's columnar form — an off-order file scan renders text or json.";
             if (wantFile) return "error: to_file= over an out-of-load-order file scan lands in W2 PR 2 — enumerate inline, or batch-read via formids= with to_file=.";
+            if (offset > 0) return "error: offset= paging over an out-of-load-order file scan lands in W2 PR 2 — this wave renders the file's first limit= rows (narrow with types= or an 'editorid contains' clause).";
+            if (counts_only) return "error: counts_only= over an out-of-load-order file scan lands in W2 PR 2 — meanwhile form='aggregate' group_by='type' is the whole-file census.";
 
             // The one where-clause this lane carries natively: a single 'editorid contains <text>'.
             string? eidContains = null;
@@ -604,8 +651,11 @@ public static class RecordsTools
 
     /// <summary>The list-lane aggregate render: count the resolved rows by winner | type | defined_in — the batch
     /// twin of the scan lane's count table. Per-item errors are counted and named as their own bucket (never
-    /// silently dropped from a census — Q3).</summary>
-    static string RenderListAggregate(IReadOnlyList<ReadOutcome> outcomes, string groupBy, bool json, bool dense, string? epoch)
+    /// silently dropped from a census — Q3). Carries the SAME response envelope as every other form (review fold:
+    /// this render dropped the resolved source arm + the epoch-coverage qualifier — the one statement the tool
+    /// description promises unconditionally).</summary>
+    static string RenderListAggregate(IReadOnlyList<ReadOutcome> outcomes, string groupBy, bool json, bool dense, string? epoch,
+                                      string headerLine, List<KeyValuePair<string, string>> envelope)
     {
         var gb = groupBy.Trim().ToLowerInvariant();
         if (gb is not ("winner" or "type" or "defined_in"))
@@ -625,9 +675,9 @@ public static class RecordsTools
         }
         var rows = groups.OrderByDescending(g => g.Value).ThenBy(g => g.Key, StringComparer.Ordinal).ToList();
         if (json || dense)
-            return JsonWire.RenderListAggregate(gb, rows, outcomes.Count, errors, epoch);
+            return JsonWire.RenderListAggregate(gb, rows, outcomes.Count, errors, epoch, envelope);
         var sb = new StringBuilder();
-        sb.Append("records  form=aggregate  group_by=").Append(gb).Append('\n');
+        sb.Append(headerLine).Append("  group_by=").Append(gb).Append('\n');
         sb.Append(outcomes.Count).Append(" record(s)");
         if (errors > 0) sb.Append("  (").Append(errors).Append(" per-item error(s) — counted apart, listed via form='summary')");
         if (epoch is not null) sb.Append("  epoch=").Append(epoch);

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -243,6 +243,8 @@ public static class RecordsTools
             return "error: fields_source= is the scan lane's display pole in this wave — on a formids= read the version you want IS the source: name it via source= (source=\"winner\" is the default). The generalized display poles land with the W2 comparison forms.";
 
         if (offset < 0) return $"error: offset={offset} — offset must be >= 0.";
+        if (offset > 0 && form == "aggregate")
+            return "error: the aggregate form counts ALL selected records (a count table has no row window), so offset= has nothing to page — drop offset=, or drop the aggregate form for per-record rows.";
         var toFile = to_file?.Trim();
         bool wantFile = !string.IsNullOrEmpty(toFile);
         if (wantFile)
@@ -267,9 +269,14 @@ public static class RecordsTools
         int lim = limit <= 0 ? 500 : limit;
         IReadOnlyList<T> Windowed<T>(IReadOnlyList<T> rows)
         {
+            // Under to_file= the rows are the FILE (the render is manifest-only) — a window note over a complete
+            // artifact would misdescribe both halves, so the window doesn't apply (round-3 re-review).
+            if (wantFile) return rows;
             if (offset == 0 && rows.Count <= lim) return rows;
             var w = rows.Skip(offset).Take(lim).ToList();
-            var note = $"window: rows {(w.Count == 0 ? 0 : offset + 1)}–{offset + w.Count} of {rows.Count} (limit={lim}, offset={offset})";
+            var note = w.Count == 0
+                ? $"window: no rows — offset={offset} is past the end of the {rows.Count}-row list"
+                : $"window: rows {offset + 1}–{offset + w.Count} of {rows.Count} (limit={lim}, offset={offset})";
             envelope.Add(new("window", note));
             headerLine += "\n" + note;
             return w;
@@ -482,8 +489,12 @@ public static class RecordsTools
             // The probe→scan seam IS epoch-compared (round-3 F5): the arm statement must describe the same
             // build the rows were scanned from.
             if (probeEpoch is not null && outcome.Error is null && outcome.Epoch is not null && outcome.Epoch != probeEpoch)
-                return $"error: the load order changed between resolving the source arm (epoch={probeEpoch}) and the scan " +
-                       $"(epoch={outcome.Epoch}) — the arm statement would describe a different world. Retry the call.";
+            {
+                var tear = $"the load order changed between resolving the source arm (epoch={probeEpoch}) and the scan " +
+                           $"(epoch={outcome.Epoch}) — the arm statement would describe a different world. Retry the call.";
+                // Format-kept like every other refusal on these paths (round-3 re-review minor).
+                return fmt is Wire.QueryFormat.Text ? "error: " + tear : JsonWire.RenderError(tear, outcome.Epoch);
+            }
 
             List<KeyValuePair<string, string>> Echo()
             {
@@ -561,8 +572,11 @@ public static class RecordsTools
                 // and passes: it renders as an honest 0-row batch.
                 var bodyEpochs = bodies.Where(o => o.Epoch is not null).Select(o => o.Epoch!).Distinct().ToList();
                 if (outcome.Epoch is not null && bodyEpochs.Any(e => e != outcome.Epoch))
-                    return $"error: the load order changed between the scan (epoch={outcome.Epoch}) and the body read " +
-                           $"(epoch={string.Join(", ", bodyEpochs.Where(e => e != outcome.Epoch))}) — the two halves would mix builds. Retry the call.";
+                {
+                    var tear = $"the load order changed between the scan (epoch={outcome.Epoch}) and the body read " +
+                               $"(epoch={string.Join(", ", bodyEpochs.Where(e => e != outcome.Epoch))}) — the two halves would mix builds. Retry the call.";
+                    return json ? JsonWire.RenderError(tear, outcome.Epoch) : "error: " + tear;
+                }
                 var bodyEpoch = bodyEpochs.FirstOrDefault() ?? outcome.Epoch;
                 envelope.Add(new("total", outcome.Total.ToString()));
                 headerLine += $"\n{outcome.Total} match(es); bodies for the {keys.Count}-row window below";

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -211,6 +211,19 @@ public static class RecordsTools
             return "error: formids= composes with the scan terms (types=/plugins=/where=/references=/conflicts_only=) in W2 PR 2 — " +
                    "not on this surface yet. Meanwhile: run the scan, spill/to_file the result, and re-enter it via where=[\"formid in @<file>\"]; " +
                    "or filter the formids list client-side.";
+        // dense is DEFINED as positional columnar cells 1:1 with the requested field paths (the tool description's
+        // own rule) — the forms with no fixed column set refuse by name rather than quietly switching transport
+        // (re-review: everything fell back to text, aggregate to the json table, neither saying so).
+        if (dense && form == "everything")
+            return "error: format='dense' renders positional columnar cells 1:1 with requested field paths, and the 'everything' form has no fixed column set — use format='text' or 'json', or name the paths via form='fields'.";
+        if (dense && form == "aggregate")
+            return "error: format='dense' is the per-row columnar transport, and the 'aggregate' form is a count table — its json render IS the compact form; use format='json'.";
+        // fields_source= is the SCAN lane's display pole in this wave (it retargets what a matched row DISPLAYS);
+        // the list lane's read is its display, so the request would be silently meaningless there — refuse by
+        // name (re-review: it was accepted and dropped). The generalized poles land with W2 PR 2's comparison forms.
+        if (winnerFields && formids is { Length: > 0 })
+            return "error: fields_source= is the scan lane's display pole in this wave — on a formids= read the version you want IS the source: name it via source= (source=\"winner\" is the default). The generalized display poles land with the W2 comparison forms.";
+
         if (offset < 0) return $"error: offset={offset} — offset must be >= 0.";
         var toFile = to_file?.Trim();
         bool wantFile = !string.IsNullOrEmpty(toFile);

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -64,7 +64,9 @@ public static class RecordsTools
          "SELECT: formids= | types= | plugins= (scope: which records are considered) | conflicts_only= | where= " +
          "(body predicates, ANDed: comparisons 'BasicStats.Damage >= 50', 'editorid contains Iron', 'editorid " +
          "startswith REQ_', flag tests 'BodyTemplate.FirstPersonFlags has Body', presence 'VirtualMachineAdapter " +
-         "exists', membership 'formid not in @<file>' / 'Race in [XXXXXX:A.esm, YYYYYY:B.esm]', ONE '->' link step " +
+         "exists', membership 'formid not in @<file>' / 'Race in [XXXXXX:A.esm, YYYYYY:B.esm]' (list entries " +
+         "separate on commas/newlines with brackets and quotes stripped — a value that itself contains a comma " +
+         "or bracket is not expressible in a list; test it with '='), ONE '->' link step " +
          "'Perks->editorid startswith REQ_NULL_', and the provenance term 'winner = X.esp' — which records does X " +
          "WIN; that term forces winner resolution over the scanned scope, the same declared cost as any winner " +
          "scan) | references= (reverse, one step — requires a bounding types=/plugins= scope; the reverse-reference " +
@@ -155,12 +157,28 @@ public static class RecordsTools
             return $"error: project.fields belongs to the 'fields' form only (got form='{form}'). Set project.form='fields', or drop fields.";
         if (form == "fields" && project?.fields is not { Length: > 0 })
             return "error: the 'fields' form names its field paths — pass project.fields=[\"<path>\", …] (or use form='everything' for the full body).";
-        if (project?.depth is { } dv && dv > 1 && form is not ("fields" or "everything"))
-            return $"error: project.depth expands field contents and belongs to the 'fields'/'everything' forms (got form='{form}').";
+        if (project?.depth is { } dv)
+        {
+            // ANY explicit depth is form-scoped (review round 3: `depth: 1` was accepted-and-dropped on other
+            // forms while `depth: 2` refused — the rule must not depend on the value), and 0/negative is refused
+            // rather than silently becoming 1.
+            if (form is not ("fields" or "everything"))
+                return $"error: project.depth expands field contents and belongs to the 'fields'/'everything' forms (got form='{form}').";
+            if (dv < 1)
+                return $"error: project.depth={dv} — depth must be >= 1 (1 shows a container as a collapsed summary; higher opens it).";
+        }
         if (project?.group_by is not null && form != "aggregate")
             return $"error: project.group_by belongs to the 'aggregate' form only (got form='{form}'). Set project.form='aggregate', or drop group_by.";
-        if (form == "aggregate" && string.IsNullOrWhiteSpace(project?.group_by))
-            return "error: the 'aggregate' form names its count key — pass project.group_by='winner' | 'type' | 'defined_in'.";
+        if (form == "aggregate")
+        {
+            // Validated HERE, before any read runs (review round 3: the list lane validated it only inside the
+            // render, after the batch had already been paid for).
+            var gbv = project?.group_by?.Trim().ToLowerInvariant();
+            if (string.IsNullOrEmpty(gbv))
+                return "error: the 'aggregate' form names its count key — pass project.group_by='winner' | 'type' | 'defined_in'.";
+            if (gbv is not ("winner" or "type" or "defined_in"))
+                return $"error: project.group_by='{project!.group_by}' is not a count key — use 'winner', 'type', or 'defined_in'.";
+        }
         if (project is { resolve_names: true } && form is not ("fields" or "everything"))
             return $"error: project.resolve_names annotates field values and belongs to the 'fields'/'everything' forms (got form='{form}').";
         int depth = project?.depth is { } d && d > 0 ? d : 1;
@@ -232,6 +250,7 @@ public static class RecordsTools
             if (Artifacts.ValidateToFile(toFile!) is { } verr) return verr;
             if (offset > 0) return "error: to_file= captures the COMPLETE result (the artifact is never a window), so offset= has nothing to page — drop offset=.";
             if (form == "aggregate") return "error: to_file= writes row artifacts, and the aggregate form is a count table with no record rows — drop one of the two.";
+            if (counts_only) return "error: counts_only= returns the census with no rows, and to_file= writes the rows — the two contradict; drop one (review: this pair used to return the census and silently write nothing).";
         }
         if (where_source is not null && where is not { Length: > 0 })
             return "error: where_source= retargets the where= predicates and needs where= — add predicates, or drop where_source=.";
@@ -241,6 +260,20 @@ public static class RecordsTools
         var envelope = new List<KeyValuePair<string, string>> { new("form", form) };
         string headerLine = $"records  form={form}";
         void Arm(string statement) { envelope.Add(new("source", statement)); headerLine += $"  source={statement}"; }
+
+        // limit=/offset= WINDOW the list lane's render (round-3 review: they were accepted-and-dropped there).
+        // The census, the aggregate, and every artifact write still cover the COMPLETE list; the window note
+        // rides the header + envelope so a windowed render can never read as the whole list.
+        int lim = limit <= 0 ? 500 : limit;
+        IReadOnlyList<T> Windowed<T>(IReadOnlyList<T> rows)
+        {
+            if (offset == 0 && rows.Count <= lim) return rows;
+            var w = rows.Skip(offset).Take(lim).ToList();
+            var note = $"window: rows {(w.Count == 0 ? 0 : offset + 1)}–{offset + w.Count} of {rows.Count} (limit={lim}, offset={offset})";
+            envelope.Add(new("window", note));
+            headerLine += "\n" + note;
+            return w;
+        }
 
         return hasFormids
             ? ListLane()
@@ -277,6 +310,14 @@ public static class RecordsTools
                 if (refusal is not null)
                     return json ? JsonWire.RenderError(refusal, epoch) : "error: " + refusal + $"\nepoch={epoch}";
                 Arm("winner");
+                if (counts_only)
+                {
+                    // The census honors counts_only on EVERY list form (round-3 review: identity rendered rows anyway).
+                    int okI = rows.Count(r => r.Error is null);
+                    return json ? JsonWire.RenderCounts(envelope, rows.Count, okI, rows.Count - okI, epoch)
+                                : $"{headerLine}\ncount={rows.Count} ok={okI} errors={rows.Count - okI}\nepoch={epoch}";
+                }
+                var winRows = Windowed(rows);
                 SpillState? spill = null;
                 if (wantFile)
                 {
@@ -285,8 +326,8 @@ public static class RecordsTools
                     spill = SpillState.Spilled(s!, manifestOnly: true);
                 }
                 string Render(SpillState? sp, out bool trunc) => json
-                    ? JsonWire.RenderResolve(rows, max_chars, epoch, sp, out trunc, envelope)
-                    : headerLine + "\n" + Wire.RenderResolve(rows, max_chars, epoch, sp, out trunc);
+                    ? JsonWire.RenderResolve(winRows, max_chars, epoch, sp, out trunc, envelope)
+                    : headerLine + "\n" + Wire.RenderResolve(winRows, max_chars, epoch, sp, out trunc);
                 var rendered = Render(spill, out var truncated);
                 if (spill is null && truncated)
                 {
@@ -344,6 +385,7 @@ public static class RecordsTools
                     : $"{headerLine}\ncount={outcomes.Count} ok={ok} errors={err}" + (epoch2 is not null ? $"\nepoch={epoch2}" : "");
             }
 
+            var winOutcomes = Windowed(outcomes);   // render window; census/aggregate/artifacts stay complete
             SpillState? spill2 = null;
             if (wantFile)
             {
@@ -352,9 +394,9 @@ public static class RecordsTools
                 spill2 = SpillState.Spilled(s!, manifestOnly: true);
             }
             string Render2(SpillState? sp, out bool trunc) => form == "summary"
-                ? RenderRecordsSummary(outcomes, json, headerLine, envelope, max_chars, sp, out trunc)
-                : json ? JsonWire.RenderBatch(outcomes, max_chars, sp, out trunc, envelope)
-                       : headerLine + "\n" + Wire.RenderBatch(svc, outcomes, projFields, false, max_chars, sp, out trunc);
+                ? RenderRecordsSummary(winOutcomes, json, headerLine, envelope, max_chars, sp, out trunc)
+                : json ? JsonWire.RenderBatch(winOutcomes, max_chars, sp, out trunc, envelope)
+                       : headerLine + "\n" + Wire.RenderBatch(svc, winOutcomes, projFields, false, max_chars, sp, out trunc);
             var rendered2 = Render2(spill2, out var truncated2);
             if (spill2 is null && truncated2)
             {
@@ -385,14 +427,18 @@ public static class RecordsTools
                 return "error: plugins.defined_in=true keeps records DEFINED in the scoped plugins, so plugins.names must name that scope.";
 
             // ---- OFF-ORDER source universe: the file's own records (absorbs read_plugin_file's enumeration).
+            string? probeEpoch = null;
             if (srcName is not null)
             {
-                // Resolve which arm ONCE via a cheap containment probe: the scan below re-captures, and the epoch
-                // stamp on its outcome is compared by the caller reading both — a mid-call order change surfaces
-                // as differing epochs, never a silently mixed answer.
+                // Resolve which arm ONCE via a cheap containment probe. The ACTIVE-arm scan below re-captures;
+                // its outcome stamp is compared against the probe's (a mid-call order change refuses loud, never
+                // an arm statement about a different world). The off-order lane reads the file directly and
+                // consults no further build.
                 var probe = svc.ProbeSourceArm(srcName, srcMod, out var probeErr);
                 if (probeErr is not null) return "error: " + probeErr;
-                if (!probe!.InOrder)
+                srcName = probe!.Plugin;   // a PATH pole resolves back to its plugin name — every consumer below uses the resolved name (round-3 F4)
+                probeEpoch = probe.Epoch;
+                if (!probe.InOrder)
                     return OffOrderScan(probe);
                 if (hasScope)
                     return "error: a plugins= scope combined with an ACTIVE named source= (scope-vs-pole streams) lands in W2 PR 2 — " +
@@ -433,6 +479,11 @@ public static class RecordsTools
             var outcome = svc.CrossQuery(types, refFks, null, conflicts_only, scanPlugins, where,
                                          effLimit, definedIn, groupBy, offset, where_source,
                                          refDemand is null ? null : new[] { refDemand });
+            // The probe→scan seam IS epoch-compared (round-3 F5): the arm statement must describe the same
+            // build the rows were scanned from.
+            if (probeEpoch is not null && outcome.Error is null && outcome.Epoch is not null && outcome.Epoch != probeEpoch)
+                return $"error: the load order changed between resolving the source arm (epoch={probeEpoch}) and the scan " +
+                       $"(epoch={outcome.Epoch}) — the arm statement would describe a different world. Retry the call.";
 
             List<KeyValuePair<string, string>> Echo()
             {
@@ -454,8 +505,9 @@ public static class RecordsTools
                 return e;
             }
 
-            // ---- form=everything on a scan: selection here, bodies via the batch lane (window-bounded). --
-            if (form == "everything" && outcome.Error is null && outcome.Groups is null)
+            // ---- form=everything on a scan: selection here, bodies via the batch lane (window-bounded).
+            // counts_only skips the body lane entirely — the census is the cross-query render below (round 3).
+            if (form == "everything" && !counts_only && outcome.Error is null && outcome.Groups is null)
             {
                 var keys = outcome.Keys.Select(k => k.ToString()).ToList();
                 IReadOnlyList<ReadOutcome> bodies;


### PR DESCRIPTION
## W2 PR 1 — `housecarl_records`: the 2.0 S1 read surface, core grammar (SPEC §2.2 / §4.2 / §6.1)

First of W2's two PRs (charter skeleton: *core grammar* here; *comparison/project forms* — delta/tree/chain/info_order, walk=, versus=, previous_provider, overlay source — in PR 2). Everything lands **additively behind the alias layer**: the 1.x read tools are byte-unchanged and stay registered through the build waves; they retire at 2.0.0's clean cut. Tool-NAME aliasing deliberately moves to PR 2, when the forms are complete enough to retire names.

### What ships

1. **`housecarl_records`** ([RecordsTools.cs](../blob/claude/w2-records-core/src/housecarl-mcp/RecordsTools.cs)) — SELECT × SOURCE × PROJECT × TRANSPORT over the existing proven engine lanes (`ResolveRefs` / `ResolveBatch` / the new `ResolveBatchFromPole` / `CrossQuery` / `ReadPluginFile`) — a consolidation of the surface, never a re-implementation of the engine.
   - PROJECT is the chartered **form-scoped structured object** (§2.2 F2): `project={form, fields, depth, group_by, resolve_names}`, each sub-parameter existing only inside its form; strays get the rule by name. Verified empirically: the MCP SDK publishes full nested object schemas with per-property descriptions for the POCO params, so the form-scoping is schema-carried as chartered.
   - SOURCE is the **§4.2 one-pole rule**: `source=` names a plugin *wherever it lives* — active, or on disk out of the order (absorbing `read_plugin_file`'s reach); the response **states which arm resolved**; a pole in neither place refuses naming both places searched; duplicate filenames refuse naming the mod folders + the `{file, mod}` disambiguator; an off-order file is declared **outside the epoch fingerprint** (the PR #305 coverage rule). The **§4.2 untouched contract** lands: a record the named pole doesn't touch is a per-item refusal **naming the actual touchers** (also upgraded on the shared `ResolveRead`, so 1.x `read_record plugin=` benefits).
   - Scan lane under a named source: the pole's records **are the scan universe** ("types alone enumerates every record of those types in whatever the SOURCE names").
   - `form=everything` on a scan composes selection (CrossQuery) with the batch body lane, **epoch-compared** so the two halves can never silently mix builds.

2. **The W2 `where=` grammar** ([FieldPredicate.cs](../blob/claude/w2-records-core/src/housecarl-core/FieldPredicate.cs)) — in the shared evaluator, so `cross_plugin_query` gains it too (strictly additive):
   - `startswith`;
   - the **`editorid` term** (dissolves `editorid_contains=` into grammar; EDID-header semantics — live even where the deep body can't parse; a no-EditorID record is a *definite* non-match, mirroring 1.x);
   - the **`winner` provenance term** (§2.2, Aaron-chartered): `where=["winner = X.esp"]` — reads *resolution*, not content; evaluated via a **resolution binding** the scan supplies off its own captured view (predicate and rows can never read different builds); unbound evaluation is a typed FatalError, never a silent non-match;
   - **`in`/`not in` generalized to any scalar leaf** (`=`-vocabulary equality per entry; pre-parsed FormKey set fast-path for FormLink-leaf × artifact-list; the formid identity form unchanged);
   - the **`->` link step** (§2.2's P3 term): exactly ONE hop; the left path's links (collected by the new `ReadEngine.CollectLinksAt` — NavigateValue + shape-dispatched link enumeration) resolve to winner bodies through the binding (per-scan target cache), the right side evaluates on each target through the same `EvalCore` as top-level terms (no drift by construction), ANY-match; a wrong left path fails loud in the Q3 accounting. Chains are refused — that's the walk construct's job (PR 2).

3. **Alias layer** ([AliasTable.cs](../blob/claude/w2-records-core/src/housecarl-mcp/AliasTable.cs)): the **chartered `conflict_tree` hint** (consumer-inventory obligation — the most-taught changing spelling) gated on the `project` carrier, naming the tree form *and* today's working 1.x spelling (PR 2 trims the interim clause); form-scoped hints for `fields`/`depth`/`group_by`/`resolve_names`; the pre-seeded rows go live on records (`plugin`/`mod`/`from_plugin` → `source`, `formid` → `formids`, `type` → `types`; `editorid_contains` and `winner_fields` hints now have their carriers). **CENSUS re-eyeballed and re-baked: 99 → 113**, all 14 new activations on `housecarl_records` (the `pluginname→plugins` rows are schema-level and kind-gated at runtime — a string can't bind the structured scope).

4. **`records-guard`** (new standing CI guard, in `ci-all`): grammar terms vs brute-force oracles; parse refusals; both lanes' dispatch; one-pole arms incl. neither-place/ambiguity; form-scoping + staging refusals by name; scan+everything epoch comparison; `to_file` + `@artifact` re-entry epoch-check (pass on same build, refuse naming both epochs after an order change).

### Decisions that need review eyes (the design record)

- **`where` stays `string[]`, with `where_source=` (SELECT pole) and `fields_source=` (PROJECT display pole) as flat parameters** — a deliberate deviation from the Phase-3 *instrument* schema's `{clauses, source}` object. Grounds: SPEC §2.2 says the two poles "survive as plain grammar" (two parameters explicitly blessed); the frozen §5.3 dictionary has no rename row for `where_source` and the `winner_fields` dissolution hint's own text names `fields_source=` — those are the canonical spellings; and the array shape keeps the live `editorid_contains` dissolution hint truthful on records. The Phase-3 schema pack is an eval instrument, deliberately not the freeze (§6.1).
- **`source=` is a polymorphic param (string | `{file, mod}`)** — its published schema is untyped; the description carries both forms. The structured form is required by §4.2 (the mod disambiguator), and the SDK has no anyOf lane for method params. Acceptable? (The probe covers both spellings.)
- **PR-1 staging refusals** (all named, each pointing at the 1.x tool that does the job today): the four comparison forms; `previous_provider`; the overlay source; `formids=` × scan-term composition; `plugins=` scope × active named source; off-order *scan* forms fields/everything, general where-grammar, references/conflicts_only/defined_in, multi-type, and `to_file`; `dense` on the list lane. Every one is PR-2 (or explicitly declared) content — nothing silently absent.
- **`identity` form contract**: winner-frame only (refuses `source=`), and formids-lane only (a scan's summary rows already carry identity).
- **List-lane `summary`** reads one cheap leaf (`EditorID`) to avoid the full dump; header facts come from the outcome. Artifact rows for a summary spill therefore carry that one field — acceptable?
- **Two-capture seams** (probe → dispatch; scan → body lane) are epoch-compared with a loud retry refusal on mismatch — the same-build discipline extended across lanes without threading a view through the tool layer.

### Description-harvest ledger (§6.1 rule, for the five partially-absorbed tools)

| Source | Teaching | Disposition |
|---|---|---|
| `read_record` | FormID format (`XXXXXX:Plugin.esp`), bracket indexing, depth semantics, `resolve_names` display-only | **Kept** (tool description + `project` property descriptions) |
| `read_record` | `conflict_tree` diff teaching | **PR 2** (tree form); the chartered hint bridges |
| `batch_record_detail` | per-item error honesty; one-epoch-per-batch; `to_file`/re-entry teaching | **Kept** |
| `cross_plugin_query` | the worked depth example (`fields=['Effects'], depth=4` → Magnitude/Area/Duration) — the E1.3/C1.3 discovered case | **Kept** (in `project.depth`'s description) |
| `cross_plugin_query` | UNION-ARM tip (`Configuration.Level.LevelMult >= 0`) | **Kept** (tool description) |
| `cross_plugin_query` | body-scan bounding rule + reverse-index future; pagination epoch-tiling; dense's depth-inexpressibility | **Kept** |
| `cross_plugin_query` | `where_source` #233 worked numbers (259 vs 82) | **Dropped** (rule kept, worked numbers cut for size — revisit at PR 2's harvest pass if wanted) |
| `resolve` | "deliberately minimal" labeling posture; engine-implicit forms (`PlayerRef`/`Player`) note | Posture **kept** (identity form); engine-implicit note **dropped from the description** (behavior unchanged — `ResolveRefs` renders it; the fact is response-carried) |
| `read_plugin_file` | OUT-OF-LOAD-ORDER labeling; "reads the file's OWN records, no master resolution" | **Kept** (the arm statement + off-order lane wording) |
| `read_plugin_file` | masters-declared-but-missing flag; standalone-copy flow pointer | **Dropped from the description** (the render still carries masters context on the reused lane; the copy flow is skill-lane teaching) |

### Verification

- `ci-all` green (114 probes incl. the new `records-guard`); CENSUS 113; binding-shim guard green.
- Live-instance verification of the new tool against ARR is **not** part of this PR (dev install predates W2; the tell for this PR is `housecarl_records` in tools/list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
