### PR TITLE
W2 PR 2: housecarl_records — comparison/traversal forms, every pole, the SELECT compositions

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,38 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**`housecarl_records` completed: the comparison and traversal forms, every SOURCE pole, and the full SELECT
+composition (W2 PR 2).** Every staging refusal from the core wave is now a capability. **Comparisons:**
+`project={"form": "delta"}` diffs the SUBJECT (`source=`) against a REFERENCE (`versus=`) and returns only what
+differs — `versus="previous_provider"` answers *what did this plugin change relative to what sat beneath it*
+(measured FROM the subject, never from the winner; a mid-stack subject reports what outranks it as plain fact, a
+defining subject refuses rather than rendering an empty diff, and a subject that doesn't touch a record refuses
+naming its actual touchers); `project={"form": "tree"}` is the conflict view as a form — every provider of each
+record, winner last, each diffed against the reference pole — **now with a json render and a row form, so trees
+spill to artifacts like every other result**. **Traversal:** `walk=` follows record-to-record links from the
+call's own selection (seed paths, a named `follow=` chain or full closure, caller-supplied stop/refuse
+exclusions, recorded cycles, explicit caps); `project={"form": "chain"}` renders the paths with provenance —
+and an NPC `follow="Template"` walk adds the TemplateFlags report: per inheritance category, whether the NPC's
+own data is active or masked and WHICH record in the chain provides it. `walk={"direction": "reverse"}` over an
+MGEF traces every SPEL/ENCH/ALCH/SCRL/INGR applying it with the matching entry's magnitude/area/duration (the
+`effect_chain` job); any other reading form consumes what a walk reaches as its selection.
+**`project={"form": "info_order"}`** renders a dialogue topic's effective MERGED INFO sequence across every
+touching plugin — the order the game actually walks, MOVED lines annotated — with honest incompleteness
+reporting when a contributor can't be read (a quest fans out by composition: `types=["DIAL"]
+where=["Quest = <formid>"]`). **Poles:** `source={"overlay": "skypatcher", "state": "pre"|"post"}` reads records
+around the SkyPatcher INI layer (post-state bodies for any reading form; pre-vs-post is a delta of the two
+poles; INI content is declared outside the epoch fingerprint). **Composition:** `formids=` now composes with
+every scan term (the identity set intersects the scan, or alone IS the scan's bound); a `plugins=` scope
+combines with a named `source=` (the scope selects, the pole's version is read — untouched records counted and
+named, never silently absent); and the out-of-load-order scan lane carries the complete grammar (multi-type,
+the full `where=` predicate set over the file's own bodies, `references=`, windows, counts, artifacts,
+comparisons). Every two-capture seam (scan→compare, walk→read, probe→scan) is epoch-compared — a load-order
+change mid-call refuses loudly rather than mixing builds. The 8 absorbed 1.x read tools stay registered through
+the build waves; from 2.0.0's clean cut, a call naming one answers with its successor `housecarl_records`
+spelling instead of a generic unknown-tool error. Guarded by the extended `records-guard` (incl. the four
+`previous_provider` probe pins) in CI; alias CENSUS re-baked (113 → 119 — `versus=`/`walk=` activate the
+`plugin_a`/`plugin_b`/`mod_a`/`mod_b`/`mgef_formid`/`closure` hints).
+
 **New tool: `housecarl_records` — the 2.0 read surface, core forms (W2 PR 1).** One read call composes *which
 records* (SELECT: `formids=` incl. `@file`/artifact re-entry · set-valued `types=` · a structured `plugins=` scope
 with `defined_in` inside it · `conflicts_only=` · the `where=` grammar · `references=`) × *whose version* (SOURCE:

--- a/src/housecarl-core/DialogueValidate.cs
+++ b/src/housecarl-core/DialogueValidate.cs
@@ -169,6 +169,98 @@ public static class DialogueValidate
     /// the live resolvers, and opens ONE overlay session for the run. NEVER throws: a recoverable miss (not in the
     /// order, or none of the four input types) is a NAMED <see cref="DialogueValidationReport.Error"/>; a mid-run
     /// throw rides <see cref="DialogueValidationReport.CheckError"/> (Q3 — surfaced, never a silent empty pass).</summary>
+    /// <summary>The effective merged INFO order (#275) for a set of topics, off an ALREADY-CAPTURED view + open
+    /// session — one build for the whole batch. This is the engine entry the records info_order PROJECT form
+    /// consumes (the §6.1 F1 split: class 8 of validate_dialogue, an ordered sequence render, not a findings
+    /// list); Run's own per-topic order rides the same code. Per topic: every touching plugin's child list is
+    /// loaded in ONE typed DIAL pass per plugin (never a per-(topic,plugin) whole-overlay scan), unreadable
+    /// contributors are CARRIED as data (Complete/BaselineTrusted honesty gates — never a silent drop), and the
+    /// merge itself runs on plain data after the overlays are gone.</summary>
+    public static Dictionary<FormKey, InfoOrderView> InfoOrders(
+        LoadOrderResolver.IndexView view, LoadOrderResolver.OverlaySession session, IReadOnlyCollection<FormKey> topicFks)
+    {
+        // The fallback resolver serves a PNAM target that appears in none of the topic's own lists (rare);
+        // targets within the topic are served from the loaded lines, so this per-record lookup is almost
+        // never reached.
+        var loCache = new Dictionary<FormKey, IMajorRecordGetter?>();
+        (InfoLine Line, string Plugin)? ResolveInfo(FormKey k)
+        {
+            if (k.IsNull || view.ResolveWinner(k) is not { } w) return null;
+            if (!loCache.TryGetValue(k, out var g))
+                loCache[k] = g = view.GetRecord(session, w.WinnerPlugin, k);
+            return g is IDialogResponsesGetter r
+                ? (DialogueInfoOrder.LineOf(r), w.WinnerPlugin)      // the ONE projection, shared with LinesOf
+                : null;
+        }
+
+        var touchingOf = new Dictionary<FormKey, IReadOnlyList<string>>();
+        var wantedIn = new Dictionary<string, HashSet<FormKey>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var tfk in topicFks)
+        {
+            if (view.TouchingPlugins(tfk) is not { } touching) continue;
+            touchingOf[tfk] = touching;
+            foreach (var p in touching)
+            {
+                if (!wantedIn.TryGetValue(p, out var set)) wantedIn[p] = set = new HashSet<FormKey>();
+                set.Add(tfk);
+            }
+        }
+
+        // Keyed plugin-name -> topic -> lines, with the OUTER dictionary case-insensitive to match
+        // wantedIn and TouchingPlugins. A single flat (string, FormKey) tuple key compares its string
+        // ORDINALLY, so a plugin whose name reached the store and the lookup with different casing would
+        // miss — dropping that plugin from that topic's merge with no note (PR #293 re-review).
+        var lines = new Dictionary<string, Dictionary<FormKey, IReadOnlyList<InfoLine>>>(
+            StringComparer.OrdinalIgnoreCase);
+        foreach (var (plugin, wanted) in wantedIn)
+        {
+            var perTopic = new Dictionary<FormKey, IReadOnlyList<InfoLine>>();
+            foreach (var (rfk, _, body, _) in view.RecordsIn(new[] { plugin }, DialTypes))
+                if (wanted.Contains(rfk) && body is IDialogTopicGetter dt)
+                    perTopic[rfk] = DialogueInfoOrder.LinesOf(dt);
+            lines[plugin] = perTopic;
+        }
+
+        var built = new Dictionary<FormKey, InfoOrderView>();
+        foreach (var (tfk, touching) in touchingOf)
+        {
+            var groups = new List<(string, IReadOnlyList<InfoLine>)>(touching.Count);
+            var unread = new List<string>();
+            foreach (var p in touching)
+            {
+                if (lines.TryGetValue(p, out var perTopic) && perTopic.TryGetValue(tfk, out var l))
+                    groups.Add((p, l));
+                else
+                    unread.Add(p);                  // the index says it TOUCHES this topic — see below
+            }
+
+            // RecordsIn swallows an overlay it cannot open (catch/continue), where the GetRecord path this
+            // replaced would have thrown into Run's named CheckError. So a plugin moved or locked by
+            // MO2/xEdit mid-call now vanishes SILENTLY — and if the drop leaves one contributor the render
+            // would claim "single plugin, nothing merges here" for a genuinely contested topic, hiding the
+            // very reorder this exists to surface. Carry the absentees so the note states it (Q3).
+            // Built UNCONDITIONALLY — including when NOTHING read. Gating on groups.Count > 0 leaves
+            // InfoOrder null on a total drop, and the render then returns before it can say anything,
+            // which is the same silence one layer down. Safe: TouchingPlugins never yields an empty list,
+            // so no groups implies unread is non-empty implies Complete is false, and the incomplete
+            // render branch reads only counts — it never indexes ContributingPlugins.
+            //
+            // originIsDefiningPlugin — the move baseline is the first contributing group with a NON-EMPTY
+            // list, so it is trustworthy only if no unread plugin sits BEFORE that plugin in load order.
+            // Testing merely `touching[0] is unread` is too weak: a first plugin that read but carries an
+            // empty child list contributes no baseline, so an unread SECOND plugin still shifts it.
+            int firstWithLines = groups.FindIndex(g => g.Item2.Count > 0);
+            string? baselinePlugin = firstWithLines >= 0 ? groups[firstWithLines].Item1 : null;
+            bool baselineTrusted = unread.Count == 0
+                || (baselinePlugin is not null
+                    && !touching.TakeWhile(p => !p.Equals(baselinePlugin, StringComparison.OrdinalIgnoreCase))
+                                .Any(p => unread.Contains(p, StringComparer.OrdinalIgnoreCase)));
+
+            built[tfk] = DialogueInfoOrder.Compute(groups, ResolveInfo, unread, baselineTrusted);
+        }
+        return built;
+    }
+
     public static DialogueValidationReport Run(LoadOrderResolver resolver, AssetResolver assets, FormKey fk)
     {
         try
@@ -194,18 +286,6 @@ public static class DialogueValidate
             // ValidateTopic.BadRef.
             bool InOrder(FormKey k) => !k.IsNull && view.ResolveWinner(k) is not null;
 
-            // ---- effective INFO order (#275) --------------------------------------------------------------
-            // The order the game walks is the MERGE of every touching plugin's child list, not the winner's list
-            // alone — so this is the one view here that reads BEYOND the winner. The fallback resolver serves a PNAM
-            // target that appears in none of the topic's own lists (rare); targets within the topic are served from
-            // the loaded lines, so this per-record lookup is almost never reached.
-            (InfoLine Line, string Plugin)? ResolveInfo(FormKey k)
-            {
-                if (k.IsNull || view.ResolveWinner(k) is not { } w) return null;
-                return Resolve(k) is IDialogResponsesGetter r
-                    ? (DialogueInfoOrder.LineOf(r), w.WinnerPlugin)      // the ONE projection, shared with LinesOf
-                    : null;
-            }
 
             // Load every needed topic's per-plugin child lists in ONE typed DIAL pass per contributing plugin.
             // Deliberately NOT view.GetRecord per (topic, plugin): that is an UNINDEXED whole-overlay scan, so a
@@ -214,74 +294,8 @@ public static class DialogueValidate
             // Lines are PROJECTED inside the loop, while each body is still live (consume-before-advance), so the
             // merge itself runs on plain data after the overlays are gone.
             Dictionary<FormKey, InfoOrderView> OrdersFor(IReadOnlyCollection<FormKey> topicFks)
-            {
-                var touchingOf = new Dictionary<FormKey, IReadOnlyList<string>>();
-                var wantedIn = new Dictionary<string, HashSet<FormKey>>(StringComparer.OrdinalIgnoreCase);
-                foreach (var tfk in topicFks)
-                {
-                    if (view.TouchingPlugins(tfk) is not { } touching) continue;
-                    touchingOf[tfk] = touching;
-                    foreach (var p in touching)
-                    {
-                        if (!wantedIn.TryGetValue(p, out var set)) wantedIn[p] = set = new HashSet<FormKey>();
-                        set.Add(tfk);
-                    }
-                }
+                => InfoOrders(view, session, topicFks);
 
-                // Keyed plugin-name -> topic -> lines, with the OUTER dictionary case-insensitive to match
-                // wantedIn and TouchingPlugins. A single flat (string, FormKey) tuple key compares its string
-                // ORDINALLY, so a plugin whose name reached the store and the lookup with different casing would
-                // miss — dropping that plugin from that topic's merge with no note (PR #293 re-review).
-                var lines = new Dictionary<string, Dictionary<FormKey, IReadOnlyList<InfoLine>>>(
-                    StringComparer.OrdinalIgnoreCase);
-                foreach (var (plugin, wanted) in wantedIn)
-                {
-                    var perTopic = new Dictionary<FormKey, IReadOnlyList<InfoLine>>();
-                    foreach (var (rfk, _, body, _) in view.RecordsIn(new[] { plugin }, DialTypes))
-                        if (wanted.Contains(rfk) && body is IDialogTopicGetter dt)
-                            perTopic[rfk] = DialogueInfoOrder.LinesOf(dt);
-                    lines[plugin] = perTopic;
-                }
-
-                var built = new Dictionary<FormKey, InfoOrderView>();
-                foreach (var (tfk, touching) in touchingOf)
-                {
-                    var groups = new List<(string, IReadOnlyList<InfoLine>)>(touching.Count);
-                    var unread = new List<string>();
-                    foreach (var p in touching)
-                    {
-                        if (lines.TryGetValue(p, out var perTopic) && perTopic.TryGetValue(tfk, out var l))
-                            groups.Add((p, l));
-                        else
-                            unread.Add(p);                  // the index says it TOUCHES this topic — see below
-                    }
-
-                    // RecordsIn swallows an overlay it cannot open (catch/continue), where the GetRecord path this
-                    // replaced would have thrown into Run's named CheckError. So a plugin moved or locked by
-                    // MO2/xEdit mid-call now vanishes SILENTLY — and if the drop leaves one contributor the render
-                    // would claim "single plugin, nothing merges here" for a genuinely contested topic, hiding the
-                    // very reorder this exists to surface. Carry the absentees so the note states it (Q3).
-                    // Built UNCONDITIONALLY — including when NOTHING read. Gating on groups.Count > 0 leaves
-                    // InfoOrder null on a total drop, and the render then returns before it can say anything,
-                    // which is the same silence one layer down. Safe: TouchingPlugins never yields an empty list,
-                    // so no groups implies unread is non-empty implies Complete is false, and the incomplete
-                    // render branch reads only counts — it never indexes ContributingPlugins.
-                    //
-                    // originIsDefiningPlugin — the move baseline is the first contributing group with a NON-EMPTY
-                    // list, so it is trustworthy only if no unread plugin sits BEFORE that plugin in load order.
-                    // Testing merely `touching[0] is unread` is too weak: a first plugin that read but carries an
-                    // empty child list contributes no baseline, so an unread SECOND plugin still shifts it.
-                    int firstWithLines = groups.FindIndex(g => g.Item2.Count > 0);
-                    string? baselinePlugin = firstWithLines >= 0 ? groups[firstWithLines].Item1 : null;
-                    bool baselineTrusted = unread.Count == 0
-                        || (baselinePlugin is not null
-                            && !touching.TakeWhile(p => !p.Equals(baselinePlugin, StringComparison.OrdinalIgnoreCase))
-                                        .Any(p => unread.Contains(p, StringComparer.OrdinalIgnoreCase)));
-
-                    built[tfk] = DialogueInfoOrder.Compute(groups, ResolveInfo, unread, baselineTrusted);
-                }
-                return built;
-            }
 
             var win = view.ResolveWinner(fk);
             if (win is null)

--- a/src/housecarl-core/ReadEngine.cs
+++ b/src/housecarl-core/ReadEngine.cs
@@ -291,7 +291,7 @@ public static class ReadEngine
     /// link-bearing value — the note reuses the read walk's vocabulary ("(no field …", "(absent)", "(unreadable …")
     /// so callers classify it exactly like a leaf miss; a present-but-empty list returns an EMPTY list (a genuine
     /// "no links here", distinct from "not a link path").</summary>
-    internal static (List<FormKey>? Links, string? Note) CollectLinksAt(object record, string[] path)
+    public static (List<FormKey>? Links, string? Note) CollectLinksAt(object record, string[] path)
     {
         try
         {

--- a/src/housecarl-generator/BindingShimProbe.cs
+++ b/src/housecarl-generator/BindingShimProbe.cs
@@ -440,6 +440,16 @@ public static class BindingShimProbe
         "housecarl_records: resolvenames => hint",
         "housecarl_records: type -> types",
         "housecarl_records: winnerfields => hint",
+        // W2 PR 2 (re-eyeballed 2026-08-04): versus= and walk= land on housecarl_records, so their gated
+        // hints go LIVE — the diff_record pole spellings (plugin_a/b, mod_a/b -> the source=/versus= poles)
+        // and the walk-carried absorptions (effect_chain's mgef_formid; copy's closure). 113 -> 119, all six
+        // on housecarl_records.
+        "housecarl_records: closure => hint",
+        "housecarl_records: mgefformid => hint",
+        "housecarl_records: moda => hint",
+        "housecarl_records: modb => hint",
+        "housecarl_records: plugina => hint",
+        "housecarl_records: pluginb => hint",
         "housecarl_remove_record: archivename -> patch",
         "housecarl_remove_record: formids -> formid",
         "housecarl_remove_record: output -> patch",

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -78,6 +78,8 @@ internal static class RecordsGuardProbe
             var mgefB = master.MagicEffects.AddNew(); mgefB.EditorID = "OtherMgef";
             var spellA = master.Spells.AddNew(); spellA.EditorID = "HcRecSpellA";
             { var e = new Effect(); e.BaseEffect.SetTo(mgefA.FormKey); e.Data = new EffectData { Magnitude = 5 }; spellA.Effects.Add(e); }
+            var spellC = master.Spells.AddNew(); spellC.EditorID = "HcRecSpellC";
+            { var e = new Effect(); e.BaseEffect.SetTo(mgefA.FormKey); e.Data = new EffectData { Magnitude = 9 }; spellC.Effects.Add(e); }
             var spellB = master.Spells.AddNew(); spellB.EditorID = "HcRecSpellB";
             { var e = new Effect(); e.BaseEffect.SetTo(mgefB.FormKey); e.Data = new EffectData { Magnitude = 7 }; spellB.Effects.Add(e); }
 
@@ -154,7 +156,7 @@ internal static class RecordsGuardProbe
                   "membership: a numeric leaf 'in [10, 30]' keeps exactly the listed values");
             Check(Run(new[] { "BasicStats.Damage not in [10, 30]" }, weapBodies).SetEquals(new[] { weapons[1], noEidWeap.FormKey }),
                   "membership: 'not in' is its complement over value-bearing records");
-            Check(Run(new[] { $"Effects[0].BaseEffect in [{Fid(mgefA.FormKey)}]" }, spellBodies).SetEquals(new[] { spellA.FormKey }),
+            Check(Run(new[] { $"Effects[0].BaseEffect in [{Fid(mgefA.FormKey)}]" }, spellBodies).SetEquals(new[] { spellA.FormKey, spellC.FormKey }),
                   "membership: a FormLink leaf against a FormKey list uses identity-canonical equality");
 
             // the winner provenance term — bound resolver decides; unbound is a typed fatal.
@@ -176,7 +178,7 @@ internal static class RecordsGuardProbe
             // the -> link step — ANY-match over targets, resolved through the bound fetch.
             {
                 IMajorRecordGetter? Fetch(FormKey fk) => mgefByKey.GetValueOrDefault(fk);
-                Check(Run(new[] { "Effects->editorid startswith HcRec" }, spellBodies, null, Fetch).SetEquals(new[] { spellA.FormKey }),
+                Check(Run(new[] { "Effects->editorid startswith HcRec" }, spellBodies, null, Fetch).SetEquals(new[] { spellA.FormKey, spellC.FormKey }),
                       "link step: 'Effects->editorid startswith HcRec' selects the spell whose EFFECT TARGET matches");
                 Check(Run(new[] { $"Effects->formid in [{Fid(mgefB.FormKey)}]" }, spellBodies, null, Fetch).SetEquals(new[] { spellB.FormKey }),
                       "link step: '->formid in [list]' tests the TARGETS' identity");
@@ -677,6 +679,19 @@ internal static class RecordsGuardProbe
             var offEmptyIds = RecordsTools.Records(svc, formids: new[] { "" }, types: new[] { "WEAP" }, source: Je($"\"{oldName}\""));
             Check(offEmptyIds.StartsWith("error:") && offEmptyIds.Contains("empty"),
                   "fold F10: off-order formids= expanding to empty refuses (was a silent whole-file scan)");
+
+            // ---- PR #309 re-review folds ----
+            var offOvlCmp = RecordsTools.Records(svc, types: new[] { "WEAP" }, source: Je($"\"{oldName}\""),
+                                                 versus: Je("{\"overlay\": \"skypatcher\", \"state\": \"post\"}"),
+                                                 project: new RecordsTools.RecordsProject { form = "delta" });
+            Check(offOvlCmp.StartsWith("error:") && offOvlCmp.Contains("formids="),
+                  "re-review: an overlay versus= on the OFF-ORDER scan refuses too (the residual F5 gap)");
+            var revWin = RecordsTools.Records(svc, formids: new[] { Fid(mgefA.FormKey) },
+                                              walk: new RecordsTools.RecordsWalk { direction = "reverse" }, limit: 1,
+                                              project: new RecordsTools.RecordsProject { form = "chain" });
+            Check(!revWin.StartsWith("error:") && revWin.Contains("HcRecSpellA") && revWin.Contains("HcRecSpellC")
+                  && revWin.Contains("carrier_total=2") == false,
+                  "re-review: limit= windows the SEEDS only — both carriers of the one seed render (the cap is walk.max_nodes)");
 
             // ============================================================================================
             //  5 — TRANSPORT: to_file + @artifact re-entry, epoch-checked

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -311,9 +311,13 @@ internal static class RecordsGuardProbe
             var prevProv = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) }, source: Je("\"previous_provider\""));
             Check(prevProv.StartsWith("error:") && prevProv.Contains("subject", StringComparison.OrdinalIgnoreCase),
                   "source='previous_provider' refuses naming the subject-relative rule (it is a versus= value)");
-            var mixed = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) }, types: new[] { "WEAP" });
-            Check(mixed.StartsWith("error:") && mixed.Contains("W2 PR 2"),
-                  "staging: formids= x scan-terms composition refuses by name with the workaround");
+            var mixed = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]), Fid(armo.FormKey) }, types: new[] { "WEAP" });
+            Check(!mixed.StartsWith("error:") && mixed.Contains("HcRecW0") && !mixed.Contains("HcRecA0"),
+                  "formids x scan composition: the identity set intersects the type scan (the armor drops out)");
+            var setOnly = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]), Fid(weapons[1]) },
+                                               where: new[] { "BasicStats.Damage >= 90" });
+            Check(!setOnly.StartsWith("error:") && setOnly.Contains("HcRecW0") && !setOnly.Contains("HcRecW1"),
+                  "formids as the ONLY bound: a where= over the set needs no types=/plugins= (the set is the bound)");
             var idScan = RecordsTools.Records(svc, types: new[] { "WEAP" },
                                               project: new RecordsTools.RecordsProject { form = "identity" });
             Check(idScan.StartsWith("error:") && idScan.Contains("summary"),
@@ -338,10 +342,14 @@ internal static class RecordsGuardProbe
             var offScan = RecordsTools.Records(svc, types: new[] { "WEAP" }, source: Je($"\"{oldName}\""));
             Check(offScan.Contains("OUT-OF-LOAD-ORDER") && offScan.Contains("HcRecW1"),
                   "off-order scan: types= enumerates the FILE's own records, arm stated");
-            var offAgg = RecordsTools.Records(svc, source: Je($"\"{oldName}\""), types: new[] { "WEAP" },
-                                              project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "BasicStats.Damage" } });
-            Check(offAgg.StartsWith("error:") && offAgg.Contains("W2 PR 2"),
-                  "off-order scan: the fields form refuses by name (staged) with the formids= workaround");
+            var offFields = RecordsTools.Records(svc, source: Je($"\"{oldName}\""), types: new[] { "WEAP" },
+                                                 project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "BasicStats.Damage" } });
+            Check(!offFields.StartsWith("error:") && offFields.Contains("55") && offFields.Contains("OUT-OF-LOAD-ORDER"),
+                  "off-order scan: the fields form reads the FILE's bodies (the disabled patch's own damage)");
+            var offWhere = RecordsTools.Records(svc, source: Je($"\"{oldName}\""), types: new[] { "WEAP" },
+                                                where: new[] { "BasicStats.Damage >= 50" });
+            Check(!offWhere.StartsWith("error:") && offWhere.Contains("HcRecW1"),
+                  "off-order scan: the FULL where= grammar runs over the file's own bodies");
 
             // ============================================================================================
             //  4b — PR #307 review folds
@@ -388,11 +396,13 @@ internal static class RecordsGuardProbe
 
             // Off-order scan: offset= and counts_only= refuse by name (finding 5).
             var offOffset = RecordsTools.Records(svc, types: new[] { "WEAP" }, source: Je($"\"{oldName}\""), offset: 500);
-            Check(offOffset.StartsWith("error:") && offOffset.Contains("offset"),
-                  "off-order scan: offset= refuses by name (no silent same-window paging)");
+            Console.WriteLine("DBG-OFFSET: " + offOffset.Substring(0, Math.Min(400, offOffset.Length)).Replace("\n", " | "));
+            Check(!offOffset.StartsWith("error:") && offOffset.Contains("offset=500 skipped past"),
+                  "off-order scan: offset= pages in exact windows (past-the-end renders the true total, no rows)");
             var offCounts = RecordsTools.Records(svc, types: new[] { "WEAP" }, source: Je($"\"{oldName}\""), counts_only: true);
-            Check(offCounts.StartsWith("error:") && offCounts.Contains("counts_only"),
-                  "off-order scan: counts_only= refuses by name");
+            Console.WriteLine("DBG-COUNTS: " + offCounts.Substring(0, Math.Min(400, offCounts.Length)).Replace("\n", " | "));
+            Check(!offCounts.StartsWith("error:") && offCounts.Contains("1 match"),
+                  "off-order scan: counts_only= returns the census over the file's records");
 
             // List aggregate carries the source arm + coverage qualifier in BOTH formats (finding 6).
             var aggOld = RecordsTools.Records(svc, formids: new[] { Fid(weapons[1]) }, source: Je($"\"{oldName}\""),

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -707,7 +707,8 @@ internal static class RecordsGuardProbe
             Check(CountOf(dScanJson, "\"source\":") == 1,
                   "fold3 F1: a scan-lane delta's json envelope carries exactly ONE source property");
             var wScanSum = RecordsTools.Records(svc, types: new[] { "SPEL" }, walk: new RecordsTools.RecordsWalk());
-            Check(CountOf(wScanSum.Substring(0, Math.Max(0, wScanSum.IndexOf("epoch=", StringComparison.Ordinal))), "source=") == 1,
+            int wScanEp = wScanSum.IndexOf("epoch=", StringComparison.Ordinal);
+            Check(wScanEp > 0 && CountOf(wScanSum.Substring(0, wScanEp), "source=") == 1,
                   "fold3 F1: a scan-seeded walk's re-entered summary states ONE source arm");
             // F3: resolve_names is HONORED under the overlay post pole (link annotation resolves the effect).
             var ovlRn = RecordsTools.Records(svc, formids: new[] { Fid(spellA.FormKey) },
@@ -735,6 +736,25 @@ internal static class RecordsGuardProbe
                                                  walk: new RecordsTools.RecordsWalk());
             Check(denseWalk.StartsWith("error:") && denseWalk.Contains("dense"),
                   "fold3 F7: dense + walk refuses up front (was: the scan-lane walk ran, then rendered TEXT under dense)");
+
+            // ---- PR #309 round-4 folds (R3-1/R3-2/R3-3) ----
+            var treeOffSel = RecordsTools.Records(svc, types: new[] { "WEAP" }, source: Je($"\"{oldName}\""), format: "json",
+                                                  project: new RecordsTools.RecordsProject { form = "tree" });
+            Check(treeOffSel.Contains("OUT-OF-LOAD-ORDER") && treeOffSel.Contains("\"versus\": \"winner\"")
+                  && CountOf(treeOffSel, "\"source\":") == 1,
+                  "fold4 R3-1: an off-order tree's envelope keeps the SELECTION arm in source and the reference in versus");
+            var treeSrcList = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) }, source: Je($"\"{ovName}\""),
+                                                   project: new RecordsTools.RecordsProject { form = "tree" });
+            Check(treeSrcList.StartsWith("error:") && treeSrcList.Contains("no subject"),
+                  "fold4 R3-1: source= on the list-lane tree refuses by name (a tree has no subject)");
+            var fsNoop = RecordsTools.Records(svc, formids: new[] { Fid(spellA.FormKey) }, fields_source: "scoped",
+                                              walk: new RecordsTools.RecordsWalk());
+            Check(!fsNoop.StartsWith("error:"),
+                  "fold4 R3-3: fields_source='scoped' (the documented no-op default) stays accepted under a walk");
+            var fsBogusWalk = RecordsTools.Records(svc, formids: new[] { Fid(spellA.FormKey) }, fields_source: "winnner",
+                                                   walk: new RecordsTools.RecordsWalk());
+            Check(fsBogusWalk.StartsWith("error:") && fsBogusWalk.Contains("winnner"),
+                  "fold4 R3-3: an unknown fields_source under a walk gets the not-a-known-source refusal, by value");
 
             // ============================================================================================
             //  5 — TRANSPORT: to_file + @artifact re-entry, epoch-checked

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -633,6 +633,51 @@ internal static class RecordsGuardProbe
             Check(spSum.StartsWith("error:") && spSum.Contains("identity facts"),
                   "scope-vs-pole + summary refuses by name (the pole changes nothing there — never accepted-and-dropped)");
 
+            // ---- PR #309 review folds ----
+            // F1: conflicts_only + formids must still evaluate the body filters (was: index-only, filters dropped).
+            var coSet = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]), Fid(weapons[1]) }, conflicts_only: true,
+                                             where: new[] { "BasicStats.Damage >= 90" });
+            Check(!coSet.StartsWith("error:") && coSet.Contains("HcRecW0") && !coSet.Contains("HcRecW1"),
+                  "fold F1: conflicts_only + formids evaluates where= (the contested-but-non-matching key drops out)");
+            var coSetMiss = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) }, conflicts_only: true,
+                                                 where: new[] { "BasicStats.Damage >= 500" });
+            Check(!coSetMiss.StartsWith("error:") && !coSetMiss.Contains("HcRecW0"),
+                  "fold F1: …and a contested key FAILING the predicate is excluded, not returned as a match");
+            // F2: walk + aggregate on the scan lane aggregates the REACHED set, never the seeds relabeled.
+            var wAgg = RecordsTools.Records(svc, types: new[] { "SPEL" }, walk: new RecordsTools.RecordsWalk(),
+                                            project: new RecordsTools.RecordsProject { form = "aggregate", group_by = "type" });
+            Check(!wAgg.StartsWith("error:") && wAgg.Contains("MagicEffect") && wAgg.Contains("selection ="),
+                  "fold F2: scan + walk + aggregate counts the REACHED set (MGEFs appear) with the walk declared");
+            // F3: the reverse MGEF lane honors to_file= like every sibling lane.
+            var revArt = Path.Combine(root, "results", "carriers.jsonl");
+            var revFile = RecordsTools.Records(svc, formids: new[] { Fid(mgefA.FormKey) },
+                                               walk: new RecordsTools.RecordsWalk { direction = "reverse" },
+                                               to_file: revArt,
+                                               project: new RecordsTools.RecordsProject { form = "chain" });
+            Check(File.Exists(revArt) && revFile.Contains(revArt),
+                  "fold F3: reverse walk + to_file writes the carrier artifact (was accepted-and-dropped)");
+            // F5: an overlay pole on ANY scan form refuses (comparisons included — they compare every match).
+            var ovlScanCmp = RecordsTools.Records(svc, types: new[] { "WEAP" },
+                                                  source: Je("{\"overlay\": \"skypatcher\", \"state\": \"post\"}"),
+                                                  versus: Je("\"winner\""),
+                                                  project: new RecordsTools.RecordsProject { form = "delta" });
+            Check(ovlScanCmp.StartsWith("error:") && ovlScanCmp.Contains("formids="),
+                  "fold F5: an overlay pole on a scan COMPARISON refuses too, naming the bounded formids= lane");
+            // F8: the json census covers the COMPLETE list even when limit= windows the rows.
+            var dJsonWin = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]), Fid(weapons[1]), Fid(weapons[2]) },
+                                                versus: Je("\"winner\""), format: "json", limit: 1,
+                                                project: new RecordsTools.RecordsProject { form = "delta" });
+            Check(dJsonWin.Contains("\"count\": 3") && dJsonWin.Contains("\"rendered\": 1"),
+                  "fold F8: json delta census counts the COMPLETE list (3), rows windowed to 1");
+            // F9/F10: the off-order lane's narrowed validations restored.
+            var offWsBad = RecordsTools.Records(svc, types: new[] { "WEAP" }, source: Je($"\"{oldName}\""),
+                                                where: new[] { "BasicStats.Damage >= 1" }, where_source: "winnner");
+            Check(offWsBad.StartsWith("error:") && offWsBad.Contains("winnner"),
+                  "fold F9: off-order where_source with an unknown spelling refuses by name (was accepted-and-ignored)");
+            var offEmptyIds = RecordsTools.Records(svc, formids: new[] { "" }, types: new[] { "WEAP" }, source: Je($"\"{oldName}\""));
+            Check(offEmptyIds.StartsWith("error:") && offEmptyIds.Contains("empty"),
+                  "fold F10: off-order formids= expanding to empty refuses (was a silent whole-file scan)");
+
             // ============================================================================================
             //  5 — TRANSPORT: to_file + @artifact re-entry, epoch-checked
             // ============================================================================================

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -88,17 +88,32 @@ internal static class RecordsGuardProbe
             ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(ovMod, master.Weapons.First(w => w.FormKey == weapons[2])))
                 .IsDeleted = true;
 
+            // W2 PR 2 additions: a MID override (P2's mid-stack subject), and an NPC template pair for
+            // the TemplateFlags interpreter (child inherits Traits from parent; Stats stay local).
+            var midKey = new ModKey("HcRecMid", ModType.Plugin);
+            string midName = midKey.FileName.String;
+            var npcParent = master.Npcs.AddNew(); npcParent.EditorID = "HcRecNpcParent";
+            var npcChild = master.Npcs.AddNew(); npcChild.EditorID = "HcRecNpcChild";
+            npcChild.Template.SetTo(npcParent.FormKey);
+            npcChild.Configuration.TemplateFlags |= NpcConfiguration.TemplateFlag.Traits;
+
             var oldMod = new SkyrimMod(oldKey, SkyrimRelease.SkyrimSE);
             ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(oldMod, master.Weapons.First(w => w.FormKey == weapons[1])))
                 .BasicStats = new WeaponBasicStats { Damage = 55, Weight = 1 };
 
+            var midMod = new SkyrimMod(midKey, SkyrimRelease.SkyrimSE);
+            ((IWeapon)WriteEngine.GenericGetOrAddAsOverride(midMod, master.Weapons.First(w => w.FormKey == weapons[0])))
+                .BasicStats = new WeaponBasicStats { Damage = 50, Weight = 1 };
+
             var inst = Path.Combine(root, "inst");
             var mods = Path.Combine(inst, "mods");
-            foreach (var d in new[] { "MasterMod", "OverrideMod", "OldMod" }) Directory.CreateDirectory(Path.Combine(mods, d));
+            foreach (var d in new[] { "MasterMod", "MidMod", "OverrideMod", "OldMod" }) Directory.CreateDirectory(Path.Combine(mods, d));
             var masterFile = Path.Combine(mods, "MasterMod", masterName);
             var ovFile = Path.Combine(mods, "OverrideMod", ovName);
             var oldFile = Path.Combine(mods, "OldMod", oldName);
+            var midFile = Path.Combine(mods, "MidMod", midName);
             master.BeginWrite.ToPath(masterFile).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+            midMod.BeginWrite.ToPath(midFile).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
             ovMod.BeginWrite.ToPath(ovFile).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
             oldMod.BeginWrite.ToPath(oldFile).WithLoadOrder(new ISkyrimModGetter[] { master }).Write();
 
@@ -213,9 +228,9 @@ internal static class RecordsGuardProbe
                 + Path.Combine(root, "game").Replace(@"\", @"\\") + ")\r\n");
             var prof = Path.Combine(inst, "profiles", "Default");
             Directory.CreateDirectory(prof);
-            File.WriteAllText(Path.Combine(prof, "loadorder.txt"), "# header\r\n" + masterName + "\r\n" + ovName + "\r\n");
-            File.WriteAllText(Path.Combine(prof, "plugins.txt"), "*" + masterName + "\r\n*" + ovName + "\r\n");
-            File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n-OldMod\r\n+OverrideMod\r\n+MasterMod\r\n");
+            File.WriteAllText(Path.Combine(prof, "loadorder.txt"), "# header\r\n" + masterName + "\r\n" + midName + "\r\n" + ovName + "\r\n");
+            File.WriteAllText(Path.Combine(prof, "plugins.txt"), "*" + masterName + "\r\n*" + midName + "\r\n*" + ovName + "\r\n");
+            File.WriteAllText(Path.Combine(prof, "modlist.txt"), "# header\r\n-OldMod\r\n+OverrideMod\r\n+MidMod\r\n+MasterMod\r\n");
             var store = new UserConfigStore(Path.Combine(root, "user.json"));
             using var svc = LoadOrderService.WithInstance(inst, 0, store);
             var epoch0 = svc.Stats().epoch;
@@ -396,11 +411,9 @@ internal static class RecordsGuardProbe
 
             // Off-order scan: offset= and counts_only= refuse by name (finding 5).
             var offOffset = RecordsTools.Records(svc, types: new[] { "WEAP" }, source: Je($"\"{oldName}\""), offset: 500);
-            Console.WriteLine("DBG-OFFSET: " + offOffset.Substring(0, Math.Min(400, offOffset.Length)).Replace("\n", " | "));
             Check(!offOffset.StartsWith("error:") && offOffset.Contains("offset=500 skipped past"),
                   "off-order scan: offset= pages in exact windows (past-the-end renders the true total, no rows)");
             var offCounts = RecordsTools.Records(svc, types: new[] { "WEAP" }, source: Je($"\"{oldName}\""), counts_only: true);
-            Console.WriteLine("DBG-COUNTS: " + offCounts.Substring(0, Math.Min(400, offCounts.Length)).Replace("\n", " | "));
             Check(!offCounts.StartsWith("error:") && offCounts.Contains("1 match"),
                   "off-order scan: counts_only= returns the census over the file's records");
 
@@ -476,6 +489,149 @@ internal static class RecordsGuardProbe
             var pathScan = RecordsTools.Records(svc, types: new[] { "WEAP" }, source: Je(JsonSerializer.Serialize(ovFile)));
             Check(pathScan.Contains("active in the load order") && pathScan.Contains("HcRecW0") && !pathScan.StartsWith("error:"),
                   "a path-form source= on the scan lane resolves to its active plugin and the scan RUNS (was a refusal after a correct arm statement)");
+
+
+            // ============================================================================================
+            //  6 — W2 PR 2: the comparison/traversal forms, poles, and compositions
+            // ============================================================================================
+            Console.WriteLine();
+            Console.WriteLine("--- 6: W2 PR 2 — delta/tree/chain/info_order, poles, compositions ---");
+
+            // delta + previous_provider, the four §4.3 pins over the 3-deep stack on W0 (master < mid < override).
+            var d1 = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) }, source: Je($"\"{ovName}\""),
+                                          versus: Je("\"previous_provider\""),
+                                          project: new RecordsTools.RecordsProject { form = "delta" });
+            Check(!d1.StartsWith("error:") && d1.Contains("previous provider") && d1.Contains(midName) && d1.Contains("Damage"),
+                  "delta P1: subject wins — the reference is the plugin immediately below (the MID override)");
+            var d2 = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) }, source: Je($"\"{midName}\""),
+                                          versus: Je("\"previous_provider\""),
+                                          project: new RecordsTools.RecordsProject { form = "delta" });
+            Check(!d2.StartsWith("error:") && d2.Contains(masterName) && d2.Contains("stack above the subject") && d2.Contains(ovName)
+                  && !d2.Contains("consider") && !d2.Contains("should"),
+                  "delta P2: a mid-stack subject still measures BELOW ITSELF; what outranks it is stated as neutral FACT (§4.3)");
+            var d3 = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) }, source: Je($"\"{masterName}\""),
+                                          versus: Je("\"previous_provider\""),
+                                          project: new RecordsTools.RecordsProject { form = "delta" });
+            Check(d3.Contains("no previous provider") && d3.Contains("DEFINES"),
+                  "delta P3: the defining subject refuses loud — never an empty diff that reads as 'no changes'");
+            var d4 = RecordsTools.Records(svc, formids: new[] { Fid(weapons[1]) }, source: Je($"\"{ovName}\""),
+                                          versus: Je("\"previous_provider\""),
+                                          project: new RecordsTools.RecordsProject { form = "delta" });
+            Check(d4.Contains("does not define or override") && d4.Contains("Touched by") && d4.Contains(masterName),
+                  "delta P4: a subject that doesn't touch the record refuses naming the actual touchers");
+
+            var dNoV = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) },
+                                            project: new RecordsTools.RecordsProject { form = "delta" });
+            Check(dNoV.StartsWith("error:") && dNoV.Contains("versus"),
+                  "the delta form REQUIRES versus= (a delta has two poles)");
+            var vStray = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) }, versus: Je("\"winner\""));
+            Check(vStray.StartsWith("error:") && vStray.Contains("delta"),
+                  "versus= outside the comparison forms refuses naming them (form-scoping, never accepted-and-dropped)");
+            var srcPrev = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) }, source: Je("\"previous_provider\""),
+                                               versus: Je("\"winner\""),
+                                               project: new RecordsTools.RecordsProject { form = "delta" });
+            Check(srcPrev.StartsWith("error:") && srcPrev.Contains("SUBJECT"),
+                  "the inverted composition (source='previous_provider') refuses naming the subject rule");
+
+            // delta against an off-order reference: the coverage is declared, the file's own value shows.
+            var dOff = RecordsTools.Records(svc, formids: new[] { Fid(weapons[1]) }, versus: Je($"\"{oldName}\""),
+                                            project: new RecordsTools.RecordsProject { form = "delta" });
+            Check(!dOff.StartsWith("error:") && dOff.Contains("OUTSIDE the epoch fingerprint") && dOff.Contains("55"),
+                  "delta vs an OFF-ORDER reference: the one-pole rule serves the file's version, coverage declared");
+            var dSame = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) }, source: Je($"\"{ovName}\""),
+                                             versus: Je($"\"{ovName}\""),
+                                             project: new RecordsTools.RecordsProject { form = "delta" });
+            Check(dSame.Contains("SAME provider"),
+                  "both poles resolving to one provider is SAID (trivially empty by construction), never silent");
+
+            // tree: json render exists (committed) and the artifact row form makes trees spillable.
+            var tJson = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) }, format: "json",
+                                             project: new RecordsTools.RecordsProject { form = "tree" });
+            Check(tJson.Contains("\"nodes\"") && tJson.Contains("\"touchers\"") && tJson.Contains("\"is_winner\""),
+                  "tree in json: the committed render (the 1.x text-only refusal died by construction)");
+            var treeArt = Path.Combine(root, "results", "tree.jsonl");
+            var tFile = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) }, to_file: treeArt,
+                                             project: new RecordsTools.RecordsProject { form = "tree" });
+            Check(File.Exists(treeArt) && tFile.Contains(treeArt),
+                  "tree + to_file: trees SPILL (PR #306 fold-decision 1 — the row form exists now)");
+
+            // scan-lane delta: the scan SELECTS, the engine compares, totals stated.
+            var dScan = RecordsTools.Records(svc, types: new[] { "WEAP" }, where: new[] { $"winner = {ovName}" },
+                                             source: Je($"\"{ovName}\""), versus: Je("\"previous_provider\""),
+                                             project: new RecordsTools.RecordsProject { form = "delta" });
+            Check(!dScan.StartsWith("error:") && dScan.Contains("selected by the scan") && dScan.Contains(midName),
+                  "delta on the scan lane: scan selects (winner term), the comparison rides the selection");
+
+            // chain: forward named-follow and closure walks reach the spell's effect.
+            var chF = RecordsTools.Records(svc, formids: new[] { Fid(spellA.FormKey) },
+                                           walk: new RecordsTools.RecordsWalk { follow = "Effects" },
+                                           project: new RecordsTools.RecordsProject { form = "chain" });
+            Check(!chF.StartsWith("error:") && chF.Contains("HcRecMgefFire"),
+                  "chain forward, follow='Effects': the spell's effect link is reached with provenance");
+            var chAll = RecordsTools.Records(svc, formids: new[] { Fid(spellA.FormKey) },
+                                             walk: new RecordsTools.RecordsWalk(),
+                                             project: new RecordsTools.RecordsProject { form = "chain" });
+            Check(!chAll.StartsWith("error:") && chAll.Contains("HcRecMgefFire"),
+                  "chain forward closure (follow omitted): every link expands via the generic enumeration");
+            var walkSel = RecordsTools.Records(svc, formids: new[] { Fid(spellA.FormKey) },
+                                               walk: new RecordsTools.RecordsWalk());
+            Check(!walkSel.StartsWith("error:") && walkSel.Contains("HcRecSpellA") && walkSel.Contains("HcRecMgefFire")
+                  && walkSel.Contains("selection ="),
+                  "walk WITHOUT chain: the reached set (seeds included, declared) feeds the summary form");
+
+            // the NPC_ TemplateFlags interpreter (§3.3 registry entry #1).
+            var tpl = RecordsTools.Records(svc, formids: new[] { Fid(npcChild.FormKey) },
+                                           walk: new RecordsTools.RecordsWalk { follow = "Template" },
+                                           project: new RecordsTools.RecordsProject { form = "chain" });
+            Check(tpl.Contains("Traits: INHERITED from") && tpl.Contains("HcRecNpcParent") && tpl.Contains("Stats: local data ACTIVE"),
+                  "TemplateFlags interpreter: inherited categories name their PROVIDER; clear flags read local-active");
+
+            // the reverse MGEF lane (the effect_chain absorption): payload rows + the loud typed gate.
+            var rev = RecordsTools.Records(svc, formids: new[] { Fid(mgefA.FormKey) },
+                                           walk: new RecordsTools.RecordsWalk { direction = "reverse" },
+                                           project: new RecordsTools.RecordsProject { form = "chain" });
+            Check(!rev.StartsWith("error:") && rev.Contains("HcRecSpellA") && !rev.Contains("HcRecSpellB"),
+                  "reverse MGEF lane: the carriers of THIS effect, with the matching entry's payload");
+            var revBad = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) },
+                                              walk: new RecordsTools.RecordsWalk { direction = "reverse" },
+                                              project: new RecordsTools.RecordsProject { form = "chain" });
+            Check(revBad.Contains("error") && (revBad.Contains("MagicEffect") || revBad.Contains("MGEF")),
+                  "reverse with a non-MGEF seed fails LOUD naming the type (never a silent '0 carriers')");
+            var revDeep = RecordsTools.Records(svc, formids: new[] { Fid(mgefA.FormKey) },
+                                               walk: new RecordsTools.RecordsWalk { direction = "reverse", depth = 3 },
+                                               project: new RecordsTools.RecordsProject { form = "chain" });
+            Check(revDeep.StartsWith("error:") && revDeep.Contains("reverse-reference index"),
+                  "reverse depth>1 refuses naming the reverse-reference index as the future capability (§3.2)");
+
+            // info_order: a non-DIAL target refuses TYPED with the quest-composition teaching.
+            var io = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) },
+                                          project: new RecordsTools.RecordsProject { form = "info_order" });
+            Check(io.Contains("DIAL") && io.Contains("Quest ="),
+                  "info_order on a non-DIAL: a typed per-item refusal teaching the quest fan-out composition");
+
+            // the overlay source: post-state bodies read (no INI layer here, so post IS the winner), coverage declared.
+            var ovl = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) },
+                                           source: Je("{\"overlay\": \"skypatcher\", \"state\": \"post\"}"),
+                                           project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "BasicStats.Damage" } });
+            Check(!ovl.StartsWith("error:") && ovl.Contains("99") && ovl.Contains("OUTSIDE the epoch fingerprint"),
+                  "overlay post source: the replayed body is read; INI content declared outside the fingerprint");
+            var ovlD = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) },
+                                            source: Je("{\"overlay\": \"skypatcher\", \"state\": \"pre\"}"),
+                                            versus: Je("{\"overlay\": \"skypatcher\", \"state\": \"post\"}"),
+                                            project: new RecordsTools.RecordsProject { form = "delta" });
+            Check(!ovlD.StartsWith("error:") && ovlD.Contains("identical"),
+                  "pre-vs-post overlay delta: no INI layer here, so the two states agree (an honest identical)");
+
+            // scope-vs-pole streams: plugins= selects, source= is whose version the body forms read.
+            var sp = RecordsTools.Records(svc, types: null, plugins: new RecordsTools.RecordsScope { names = new[] { masterName } },
+                                          source: Je($"\"{ovName}\""),
+                                          project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "BasicStats.Damage" } });
+            Check(!sp.StartsWith("error:") && sp.Contains("99") && sp.Contains("not_touched"),
+                  "scope-vs-pole: the scope's matches read from the pole; untouched ones counted + named (§4.2)");
+            var spSum = RecordsTools.Records(svc, plugins: new RecordsTools.RecordsScope { names = new[] { masterName } },
+                                             source: Je($"\"{ovName}\""));
+            Check(spSum.StartsWith("error:") && spSum.Contains("identity facts"),
+                  "scope-vs-pole + summary refuses by name (the pole changes nothing there — never accepted-and-dropped)");
 
             // ============================================================================================
             //  5 — TRANSPORT: to_file + @artifact re-entry, epoch-checked

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -306,11 +306,11 @@ internal static class RecordsGuardProbe
                   "form-scoping: group_by outside the aggregate form refuses naming the rule");
             var tree = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) },
                                             project: new RecordsTools.RecordsProject { form = "tree" });
-            Check(tree.StartsWith("error:") && tree.Contains("conflict_tree"),
-                  "staging: form='tree' refuses by NAME pointing at today's working spelling");
+            Check(!tree.StartsWith("error:") && tree.Contains("winner last") && tree.Contains(ovName),
+                  "form='tree' renders the provider stack (winner last) with per-node deltas");
             var prevProv = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) }, source: Je("\"previous_provider\""));
-            Check(prevProv.StartsWith("error:") && prevProv.Contains("PR 2"),
-                  "staging: source='previous_provider' refuses by name");
+            Check(prevProv.StartsWith("error:") && prevProv.Contains("subject", StringComparison.OrdinalIgnoreCase),
+                  "source='previous_provider' refuses naming the subject-relative rule (it is a versus= value)");
             var mixed = RecordsTools.Records(svc, formids: new[] { Fid(weapons[0]) }, types: new[] { "WEAP" });
             Check(mixed.StartsWith("error:") && mixed.Contains("W2 PR 2"),
                   "staging: formids= x scan-terms composition refuses by name with the workaround");

--- a/src/housecarl-generator/RecordsGuardProbe.cs
+++ b/src/housecarl-generator/RecordsGuardProbe.cs
@@ -42,6 +42,13 @@ internal static class RecordsGuardProbe
 
     static JsonElement Je(string json) => JsonDocument.Parse(json).RootElement.Clone();
 
+    static int CountOf(string haystack, string needle)
+    {
+        int n = 0, i = 0;
+        while ((i = haystack.IndexOf(needle, i, StringComparison.Ordinal)) >= 0) { n++; i += needle.Length; }
+        return n;
+    }
+
     public static int RunGuard(string[] args)
     {
         Console.WriteLine("================================================================");
@@ -689,9 +696,45 @@ internal static class RecordsGuardProbe
             var revWin = RecordsTools.Records(svc, formids: new[] { Fid(mgefA.FormKey) },
                                               walk: new RecordsTools.RecordsWalk { direction = "reverse" }, limit: 1,
                                               project: new RecordsTools.RecordsProject { form = "chain" });
-            Check(!revWin.StartsWith("error:") && revWin.Contains("HcRecSpellA") && revWin.Contains("HcRecSpellC")
-                  && revWin.Contains("carrier_total=2") == false,
+            Check(!revWin.StartsWith("error:") && revWin.Contains("HcRecSpellA") && revWin.Contains("HcRecSpellC"),
                   "re-review: limit= windows the SEEDS only — both carriers of the one seed render (the cap is walk.max_nodes)");
+
+            // ---- PR #309 round-3 folds ----
+            // F1: exactly ONE source statement per response, scan-derived forms included.
+            var dScanJson = RecordsTools.Records(svc, types: new[] { "WEAP" }, where: new[] { $"winner = {ovName}" },
+                                                 source: Je($"\"{ovName}\""), versus: Je("\"previous_provider\""), format: "json",
+                                                 project: new RecordsTools.RecordsProject { form = "delta" });
+            Check(CountOf(dScanJson, "\"source\":") == 1,
+                  "fold3 F1: a scan-lane delta's json envelope carries exactly ONE source property");
+            var wScanSum = RecordsTools.Records(svc, types: new[] { "SPEL" }, walk: new RecordsTools.RecordsWalk());
+            Check(CountOf(wScanSum.Substring(0, Math.Max(0, wScanSum.IndexOf("epoch=", StringComparison.Ordinal))), "source=") == 1,
+                  "fold3 F1: a scan-seeded walk's re-entered summary states ONE source arm");
+            // F3: resolve_names is HONORED under the overlay post pole (link annotation resolves the effect).
+            var ovlRn = RecordsTools.Records(svc, formids: new[] { Fid(spellA.FormKey) },
+                                             source: Je("{\"overlay\": \"skypatcher\", \"state\": \"post\"}"),
+                                             project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "Effects" }, depth = 4, resolve_names = true });
+            Check(!ovlRn.StartsWith("error:") && ovlRn.Contains("HcRecMgefFire"),
+                  "fold3 F3: resolve_names under the overlay post pole annotates link targets (was accepted-and-dropped)");
+            // F4: fields_source refused by name on the lanes that cannot honor it.
+            var fsScope = RecordsTools.Records(svc, plugins: new RecordsTools.RecordsScope { names = new[] { masterName } },
+                                               source: Je($"\"{ovName}\""), fields_source: "winner",
+                                               project: new RecordsTools.RecordsProject { form = "fields", fields = new[] { "BasicStats.Damage" } });
+            Check(fsScope.StartsWith("error:") && fsScope.Contains("TWO display poles"),
+                  "fold3 F4: fields_source + scope-vs-pole refuses by name (two display poles on one call)");
+            var fsWalk = RecordsTools.Records(svc, formids: new[] { Fid(spellA.FormKey) }, fields_source: "winner",
+                                              walk: new RecordsTools.RecordsWalk());
+            Check(fsWalk.StartsWith("error:") && fsWalk.Contains("fields_source"),
+                  "fold3 F4: fields_source + walk refuses by name (the reading forms display the source= pole)");
+            var fsChain = RecordsTools.Records(svc, formids: new[] { Fid(spellA.FormKey) }, fields_source: "winner",
+                                               walk: new RecordsTools.RecordsWalk(),
+                                               project: new RecordsTools.RecordsProject { form = "chain" });
+            Check(fsChain.StartsWith("error:") && fsChain.Contains("fields_source"),
+                  "fold3 F4: fields_source + chain refuses by name (no field values to retarget)");
+            // F7: dense + walk refuses BEFORE any walk work, on both lanes.
+            var denseWalk = RecordsTools.Records(svc, types: new[] { "SPEL" }, format: "dense",
+                                                 walk: new RecordsTools.RecordsWalk());
+            Check(denseWalk.StartsWith("error:") && denseWalk.Contains("dense"),
+                  "fold3 F7: dense + walk refuses up front (was: the scan-lane walk ran, then rendered TEXT under dense)");
 
             // ============================================================================================
             //  5 — TRANSPORT: to_file + @artifact re-entry, epoch-checked

--- a/src/housecarl-mcp/AliasTable.cs
+++ b/src/housecarl-mcp/AliasTable.cs
@@ -213,4 +213,42 @@ internal static class AliasTable
             if (d.Old == normalizedKey && d.GateParams.All(declaredNormalized.Contains)) return d.Hint;
         return null;
     }
+
+    // ---- retired tool NAMES (W2 PR 2 — the tool-NAME lane, on top of the parameter layer) -----------
+
+    /// <summary>The 8 read tools `housecarl_records` absorbs, each mapped to its successor call shape.
+    /// The lane is DORMANT BY CONSTRUCTION while these tools stay registered (they do, through the build
+    /// waves — CHARTER_PHASE4 §3.4a): the SDK resolves a registered name before the shim's filter runs, so
+    /// this table answers only a call naming a tool the server does NOT have — which today is nothing, and
+    /// at retirement is exactly these. It turns the SDK's generic unknown-tool error into the successor
+    /// spelling, so a caller working from old docs lands on `records` in one hop instead of a dead end.</summary>
+    static readonly (string Old, string Successor)[] RetiredTools =
+    {
+        ("housecarl_read_record",
+         "absorbed into housecarl_records: formids=[\"XXXXXX:Plugin.esp\"] — project={\"form\": \"fields\", \"fields\": […]} for named fields, \"everything\" for the full body; plugin= is source=; conflict_tree=true is project={\"form\": \"tree\"}."),
+        ("housecarl_batch_record_detail",
+         "absorbed into housecarl_records: the same formids= list with a project= form (summary | fields | everything); plugin= is source=; to_file=/@file re-entry unchanged."),
+        ("housecarl_resolve",
+         "absorbed into housecarl_records: formids=[…] with project={\"form\": \"identity\"} — the labeling form."),
+        ("housecarl_cross_plugin_query",
+         "absorbed into housecarl_records: the same scan terms, set-valued — type= is types=, editorid_contains= is where=[\"editorid contains …\"], group_by= is project={\"form\": \"aggregate\", \"group_by\": …}, fields= lives inside project={\"form\": \"fields\"}."),
+        ("housecarl_read_plugin_file",
+         "absorbed into housecarl_records: source=\"X.esp\" reads that plugin WHEREVER it lives (active or on disk out of the order — the response states which); types=/where= scan the file's records; formids= reads specific ones."),
+        ("housecarl_diff_record",
+         "absorbed into housecarl_records: project={\"form\": \"delta\"} — source= is the subject (was plugin_a), versus= the reference (was plugin_b; structured poles carry the mod disambiguator), project.fields narrows the comparison."),
+        ("housecarl_effect_chain",
+         "absorbed into housecarl_records: project={\"form\": \"chain\"} with walk={\"direction\": \"reverse\"} and the MGEF in formids= (types= still narrows the carrier types)."),
+        ("housecarl_skypatcher_read",
+         "absorbed into housecarl_records: source={\"overlay\": \"skypatcher\", \"state\": \"post\"} reads the post-INI body; pre-vs-post is project={\"form\": \"delta\"} with the two overlay poles."),
+    };
+
+    /// <summary>The successor teaching for a retired tool name, or null. Case-insensitive on the full name.</summary>
+    internal static string? RetiredToolHint(string? toolName)
+    {
+        if (string.IsNullOrEmpty(toolName)) return null;
+        foreach (var (old, successor) in RetiredTools)
+            if (old.Equals(toolName.Trim(), StringComparison.OrdinalIgnoreCase))
+                return $"error: {old} is not on this surface — {successor}";
+        return null;
+    }
 }

--- a/src/housecarl-mcp/AliasTable.cs
+++ b/src/housecarl-mcp/AliasTable.cs
@@ -183,10 +183,9 @@ internal static class AliasTable
         // W2 PR 1 — the form-scoped PROJECT teachings (SPEC §2.2 F2): the flat 1.x spellings became sub-parameters
         // of the project= form object on `records`, so a stray flat one gets the form-scoping rule by name. All
         // gated on `project` — today that is exactly housecarl_records. conflict_tree is the CHARTERED W2 hint
-        // (the most-taught changing spelling — 9+ skills teach conflict_tree=true; consumer-inventory obligation):
-        // its PROJECT form (tree) ships in W2 PR 2, so the hint names both the destination and today's working
-        // spelling, and PR 2 trims the interim clause when the form lands.
-        new("conflicttree", new[] { "project" }, "not a parameter here — the provider tree is a PROJECT form: project={\"form\": \"tree\"} (lands with the W2 comparison forms; until then housecarl_read_record conflict_tree=true renders it)"),
+        // (the most-taught changing spelling — 9+ skills teach conflict_tree=true; consumer-inventory obligation);
+        // the tree form landed in W2 PR 2, so the interim "until then" clause is gone.
+        new("conflicttree", new[] { "project" }, "not a parameter here — the provider tree is a PROJECT form: project={\"form\": \"tree\"}"),
         new("fields",       new[] { "project" }, "not a parameter here — field paths live inside the form: project={\"form\": \"fields\", \"fields\": [\"<path>\", …]}"),
         new("depth",        new[] { "project" }, "not a parameter here — depth lives inside the fields/everything forms: project={\"form\": \"fields\", \"fields\": […], \"depth\": <n>}"),
         new("groupby",      new[] { "project" }, "not a parameter here — aggregation is a PROJECT form: project={\"form\": \"aggregate\", \"group_by\": \"winner\"}"),

--- a/src/housecarl-mcp/Artifacts.cs
+++ b/src/housecarl-mcp/Artifacts.cs
@@ -274,6 +274,49 @@ internal static class Artifacts
         return err is not null ? (null, err) : (new SpillInfo(path, manifest!, reason), null);
     }
 
+    /// <summary>Build + save the artifact for the reverse MGEF walk (records form=chain,
+    /// walk.direction='reverse') — one row per (seed, carrier) with the matching entry's payload; a failed
+    /// seed is an identity-less error row (errors are never identity-bearing).</summary>
+    public static (SpillInfo? Spill, string? Error) WriteEffectChains(
+        IReadOnlyList<(string Seed, EffectChainResult Result)> results, string? epoch, string path, string reason,
+        IReadOnlyList<KeyValuePair<string, string>> query)
+    {
+        using var writer = new ResultArtifact.Writer();
+        int total = 0;
+        foreach (var (seed, r) in results)
+        {
+            if (r.Error is not null)
+            {
+                writer.WriteRow((w, _) => { w.WriteStartObject(); w.WriteString("seed", seed); w.WriteString("error", r.Error); w.WriteEndObject(); });
+                total++;
+                continue;
+            }
+            foreach (var row in r.Rows)
+            {
+                writer.WriteRow((w, _) =>
+                {
+                    w.WriteStartObject();
+                    w.WriteString("seed", seed);
+                    w.WriteString("formid", row.Carrier.ToString());
+                    w.WriteString("type", row.Type);
+                    if (row.EditorId is not null) w.WriteString("editorid", row.EditorId);
+                    w.WriteString("winner", row.Winner);
+                    w.WriteNumber("effect_index", row.EffectIndex);
+                    w.WriteNumber("effect_count", row.EffectCount);
+                    w.WriteNumber("magnitude", row.Magnitude);
+                    w.WriteNumber("area", row.Area);
+                    w.WriteNumber("duration", row.Duration);
+                    w.WriteEndObject();
+                }, row.Type);
+                total++;
+            }
+        }
+        var (manifest, err) = writer.Save(path, "housecarl_records", query, "formid",
+                                          new[] { "seed", "formid", "type", "editorid", "winner", "effect_index", "effect_count", "magnitude", "area", "duration" },
+                                          "seed order, then carrier scan order", total, epoch ?? "");
+        return err is not null ? (null, err) : (new SpillInfo(path, manifest!, reason), null);
+    }
+
     /// <summary>Build + save the artifact for a records form=info_order result — one row per topic, in input
     /// order, exactly the json render's rows (honesty gates carried as data; per-item errors included).</summary>
     public static (SpillInfo? Spill, string? Error) WriteInfoOrder(

--- a/src/housecarl-mcp/Artifacts.cs
+++ b/src/housecarl-mcp/Artifacts.cs
@@ -258,6 +258,22 @@ internal static class Artifacts
         return err is not null ? (null, err) : (new SpillInfo(path, manifest!, reason), null);
     }
 
+    /// <summary>Build + save the artifact for a records form=chain result — one row per seed, in input order,
+    /// exactly the json render's rows (nodes with provenance; cycles; truncation notes; the template report).</summary>
+    public static (SpillInfo? Spill, string? Error) WriteChain(
+        IReadOnlyList<LoadOrderService.WalkSeedResult> rows, string? epoch, string path, string reason,
+        IReadOnlyList<KeyValuePair<string, string>> query)
+    {
+        using var writer = new ResultArtifact.Writer();
+        foreach (var row in rows)
+            writer.WriteRow((w, ms) => JsonWire.WriteChainRow(w, row, ms, int.MaxValue),
+                            row.Error is null ? row.Type : null);
+        var (manifest, err) = writer.Save(path, "housecarl_records", query, "formid",
+                                          new[] { "formid", "type", "editorid", "nodes", "cycles?", "truncation?", "template_inheritance?" },
+                                          "input order", rows.Count, epoch ?? "");
+        return err is not null ? (null, err) : (new SpillInfo(path, manifest!, reason), null);
+    }
+
     /// <summary>Build + save the artifact for a records form=info_order result — one row per topic, in input
     /// order, exactly the json render's rows (honesty gates carried as data; per-item errors included).</summary>
     public static (SpillInfo? Spill, string? Error) WriteInfoOrder(

--- a/src/housecarl-mcp/Artifacts.cs
+++ b/src/housecarl-mcp/Artifacts.cs
@@ -224,6 +224,40 @@ internal static class Artifacts
         return err is not null ? (null, err) : (new SpillInfo(path, manifest!, reason), null);
     }
 
+    /// <summary>Build + save the artifact for a records form=delta result — one row per input, in input order,
+    /// exactly the rows the json render emits (per-item refusals included: a dropped P3/P4/untouched row would
+    /// make the file claim a cleaner comparison than the call returned).</summary>
+    public static (SpillInfo? Spill, string? Error) WriteDelta(
+        IReadOnlyList<LoadOrderService.DeltaRow> rows, string? epoch, string path, string reason,
+        IReadOnlyList<KeyValuePair<string, string>> query)
+    {
+        using var writer = new ResultArtifact.Writer();
+        foreach (var row in rows)
+            writer.WriteRow((w, ms) => JsonWire.WriteDeltaRow(w, row, ms, int.MaxValue),
+                            row.Error is null ? row.Subject?.RecordType : null);
+        var (manifest, err) = writer.Save(path, "housecarl_records", query, "formid",
+                                          new[] { "formid", "type", "editorid", "subject", "reference", "stack_above?", "note?", "complete", "deltas", "delta_count", "agreed_count" },
+                                          "input order", rows.Count, epoch ?? "");
+        return err is not null ? (null, err) : (new SpillInfo(path, manifest!, reason), null);
+    }
+
+    /// <summary>Build + save the artifact for a records form=tree result — the row form that makes trees
+    /// SPILLABLE (PR #306 fold-decision 1): one row per record, the provider stack with per-node deltas, exactly
+    /// the json render's rows.</summary>
+    public static (SpillInfo? Spill, string? Error) WriteTree(
+        IReadOnlyList<LoadOrderService.TreeRow> rows, string? epoch, string path, string reason,
+        IReadOnlyList<KeyValuePair<string, string>> query)
+    {
+        using var writer = new ResultArtifact.Writer();
+        foreach (var row in rows)
+            writer.WriteRow((w, ms) => JsonWire.WriteTreeRow(w, row, ms, int.MaxValue),
+                            row.Error is null ? row.Type : null);
+        var (manifest, err) = writer.Save(path, "housecarl_records", query, "formid",
+                                          new[] { "formid", "type", "editorid", "reference", "touchers", "nodes" },
+                                          "input order", rows.Count, epoch ?? "");
+        return err is not null ? (null, err) : (new SpillInfo(path, manifest!, reason), null);
+    }
+
     /// <summary>Append the whole SpillState to a text response: the spilled block, or the failed-spill warning
     /// (a truncated response whose promised artifact could NOT be written must say so — the §2.1.1 "nothing is
     /// ever lost silently" promise would otherwise break exactly when the disk does).</summary>

--- a/src/housecarl-mcp/Artifacts.cs
+++ b/src/housecarl-mcp/Artifacts.cs
@@ -258,6 +258,22 @@ internal static class Artifacts
         return err is not null ? (null, err) : (new SpillInfo(path, manifest!, reason), null);
     }
 
+    /// <summary>Build + save the artifact for a records form=info_order result — one row per topic, in input
+    /// order, exactly the json render's rows (honesty gates carried as data; per-item errors included).</summary>
+    public static (SpillInfo? Spill, string? Error) WriteInfoOrder(
+        IReadOnlyList<LoadOrderService.InfoOrderRow> rows, string? epoch, string path, string reason,
+        IReadOnlyList<KeyValuePair<string, string>> query)
+    {
+        using var writer = new ResultArtifact.Writer();
+        foreach (var row in rows)
+            writer.WriteRow((w, ms) => JsonWire.WriteInfoOrderRow(w, row, ms, int.MaxValue),
+                            row.Error is null ? row.Type : null);
+        var (manifest, err) = writer.Save(path, "housecarl_records", query, "formid",
+                                          new[] { "formid", "type", "editorid", "winner", "contested", "complete", "moves_computed", "baseline_trusted", "contributing", "unread?", "note?", "moved_count", "order" },
+                                          "input order", rows.Count, epoch ?? "");
+        return err is not null ? (null, err) : (new SpillInfo(path, manifest!, reason), null);
+    }
+
     /// <summary>Append the whole SpillState to a text response: the spilled block, or the failed-spill warning
     /// (a truncated response whose promised artifact could NOT be written must say so — the §2.1.1 "nothing is
     /// ever lost silently" promise would otherwise break exactly when the disk does).</summary>

--- a/src/housecarl-mcp/DialogueTools.cs
+++ b/src/housecarl-mcp/DialogueTools.cs
@@ -204,11 +204,16 @@ static class DialogueWire
     /// identical, so it is invisible to a field diff. Budget-aware like <see cref="AppendIssues"/>: returns false at
     /// the cap so the caller stops (Q3 — an explicit notice, never a silent cut).</summary>
     static bool AppendInfoOrder(StringBuilder sb, TopicValidation t, string pad, int cap, bool indent)
+        => AppendInfoOrderView(sb, t.InfoOrder, pad, cap, indent);
+
+    /// <summary>The view-level body, shared with the records info_order PROJECT form (the §6.1 F1 split carried
+    /// this render's MOVED annotations and honesty gates across intact — one render, no drift).</summary>
+    internal static bool AppendInfoOrderView(StringBuilder sb, InfoOrderView? view, string pad, int cap, bool indent)
     {
         // An EMPTY order is normally nothing to say — unless it is empty because nothing could be READ, which is
         // the total-drop case and the one that must never render as silence (most topics are touched by exactly
         // one plugin, so for them any read failure IS a total failure).
-        if (t.InfoOrder is not { } io || (io.Order.Count == 0 && io.Complete)) return true;
+        if (view is not { } io || (io.Order.Count == 0 && io.Complete)) return true;
 
         // "Nothing merges here" is a CLAIM, and it holds only if EVERY touching plugin's list was actually read.
         // With one dropped, a genuinely contested topic presents as single-plugin — so the claim is gated on

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -344,6 +344,23 @@ static class JsonWire
         return Finish(ms);
     }
 
+    /// <summary>records counts_only for forms whose census has named counters (delta: differing/identical;
+    /// tree: contested) — the envelope plus the counters, no rows.</summary>
+    public static string RenderNamedCounts(IReadOnlyList<KeyValuePair<string, string>> envelope,
+                                           IReadOnlyList<KeyValuePair<string, int>> counts, string? epoch)
+    {
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            WriteEnvelope(w, envelope);
+            foreach (var (k, v) in counts.Select(c => (c.Key, c.Value))) w.WriteNumber(k, v);
+            WriteNullable(w, "epoch", epoch);
+            w.WriteEndObject();
+        }
+        return Finish(ms);
+    }
+
     /// <summary>records form=summary on the list lane: one identity+winner row per outcome (or its per-item
     /// error) — the json twin of the text summary lines, spill marker in-band.</summary>
     public static string RenderRecordsSummary(IReadOnlyList<ReadOutcome> outcomes, int maxChars,
@@ -415,6 +432,172 @@ static class JsonWire
                 w.WriteEndObject();
             }
             w.WriteEndArray();
+            w.WriteEndObject();
+        }
+        return Finish(ms);
+    }
+
+    // ---- housecarl_records (W2 PR 2): the delta / tree comparison forms -----------------------------
+
+    /// <summary>One §4.1 delta row — shared verbatim by the json render and the artifact writer (one shape, no
+    /// drift). A per-item refusal is <c>{formid, error, stack_above?}</c>; a compared row carries both poles, the
+    /// §4.3 stack-above FACT when the subject sits mid-stack, and the same delta strings the text render emits.</summary>
+    internal static void WriteDeltaRow(Utf8JsonWriter w, LoadOrderService.DeltaRow row, MemoryStream ms, int cap)
+    {
+        w.WriteStartObject();
+        w.WriteString("formid", row.Formid);
+        if (row.Error is not null)
+        {
+            w.WriteString("error", row.Error);
+            if (row.StackAbove is { Count: > 0 }) WriteStringArray(w, "stack_above", row.StackAbove);
+            w.WriteEndObject();
+            return;
+        }
+        var s = row.Subject!; var r = row.Reference!;
+        WriteNullable(w, "type", s.RecordType);
+        WriteNullable(w, "editorid", s.EditorId);
+        WriteDiffPole(w, "subject", s);
+        WriteDiffPole(w, "reference", r);
+        if (row.StackAbove is { Count: > 0 }) WriteStringArray(w, "stack_above", row.StackAbove);
+        if (row.Note is not null) w.WriteString("note", row.Note);
+        var d = row.Diff!;
+        w.WriteBoolean("complete", d.Complete);
+        w.WriteStartArray("deltas");
+        int rendered = 0; bool cut = false;
+        foreach (var delta in d.Deltas)
+        {
+            w.Flush();
+            if (ms.Length >= cap) { cut = true; break; }
+            w.WriteStringValue(delta);
+            rendered++;
+        }
+        w.WriteEndArray();
+        w.WriteNumber("delta_count", d.Deltas.Count);
+        if (cut) { w.WriteNumber("deltas_rendered", rendered); w.WriteBoolean("deltas_truncated", true); }
+        w.WriteNumber("agreed_count", d.AgreedCount);
+        w.WriteEndObject();
+    }
+
+    /// <summary>records form=delta: <c>{…envelope, count, differing, identical, errors, epoch, rows:[…]}</c>.
+    /// The identical count only counts COMPLETE comparisons — a truncated deep read is neither (its row says so
+    /// via <c>complete:false</c>, the §4.4 truncation-honesty rule).</summary>
+    public static string RenderDelta(IReadOnlyList<LoadOrderService.DeltaRow> rows, int maxChars, string? epoch,
+                                     IReadOnlyList<KeyValuePair<string, string>> envelope,
+                                     SpillState? spill, out bool truncated)
+    {
+        truncated = false;
+        int cap = Cap(maxChars);
+        bool manifestOnly = spill?.ManifestOnly ?? false;
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            WriteEnvelope(w, envelope);
+            w.WriteNumber("count", rows.Count);
+            w.WriteNumber("differing", rows.Count(x => x.Error is null && x.Diff!.Deltas.Count > 0));
+            w.WriteNumber("identical", rows.Count(x => x.Error is null && x.Diff!.Deltas.Count == 0 && x.Diff.Complete));
+            w.WriteNumber("errors", rows.Count(x => x.Error is not null));
+            WriteNullable(w, "epoch", epoch);
+            w.WriteStartArray("rows");
+            int rendered = 0; bool rowsTruncated = false;
+            foreach (var row in rows)
+            {
+                if (manifestOnly) break;
+                w.Flush();
+                if (ms.Length >= cap) { rowsTruncated = true; break; }
+                WriteDeltaRow(w, row, ms, cap);
+                rendered++;
+            }
+            w.WriteEndArray();
+            w.WriteNumber("rendered", rendered);
+            w.WriteBoolean("truncated", rowsTruncated);
+            truncated = rowsTruncated;
+            if (spill is not null) Artifacts.WriteSpillStateJson(w, spill);
+            w.WriteEndObject();
+        }
+        return Finish(ms);
+    }
+
+    /// <summary>One §4.1 tree row — the provider stack with per-node deltas against the row's reference pole.
+    /// Shared by the json render and the artifact writer: THIS is what makes trees spillable (PR #306
+    /// fold-decision 1 — the 1.x conflict_tree had no row form; the tree FORM does).</summary>
+    internal static void WriteTreeRow(Utf8JsonWriter w, LoadOrderService.TreeRow row, MemoryStream ms, int cap)
+    {
+        w.WriteStartObject();
+        w.WriteString("formid", row.Formid);
+        if (row.Error is not null)
+        {
+            w.WriteString("error", row.Error);
+            if (row.Touchers.Count > 0) WriteStringArray(w, "touchers", row.Touchers);
+            w.WriteEndObject();
+            return;
+        }
+        WriteNullable(w, "type", row.Type);
+        WriteNullable(w, "editorid", row.EditorId);
+        WriteNullable(w, "reference", row.ReferencePlugin);
+        WriteStringArray(w, "touchers", row.Touchers);   // priority order, winner LAST
+        w.WriteStartArray("nodes");
+        foreach (var n in row.Nodes)
+        {
+            w.Flush();
+            if (ms.Length >= cap)
+            {
+                w.WriteStartObject();
+                w.WriteString("note", "[nodes truncated at max_chars — raise max_chars or narrow with project.fields]");
+                w.WriteEndObject();
+                break;
+            }
+            w.WriteStartObject();
+            w.WriteString("plugin", n.Plugin);
+            w.WriteBoolean("is_winner", n.IsWinner);
+            w.WriteBoolean("is_reference", n.IsReference);
+            if (!n.IsReference)
+            {
+                w.WriteBoolean("complete", n.Complete);
+                WriteStringArray(w, "deltas", n.Deltas);
+                w.WriteNumber("delta_count", n.Deltas.Count);
+                w.WriteNumber("agreed_count", n.AgreedCount);
+            }
+            w.WriteEndObject();
+        }
+        w.WriteEndArray();
+        w.WriteEndObject();
+    }
+
+    /// <summary>records form=tree: <c>{…envelope, count, contested, errors, epoch, rows:[…]}</c> — the committed
+    /// json tree render (§6.1: "the tree/delta forms get a built json render"; the 1.x text-only refusal dies by
+    /// construction here).</summary>
+    public static string RenderTree(IReadOnlyList<LoadOrderService.TreeRow> rows, int maxChars, string? epoch,
+                                    IReadOnlyList<KeyValuePair<string, string>> envelope,
+                                    SpillState? spill, out bool truncated)
+    {
+        truncated = false;
+        int cap = Cap(maxChars);
+        bool manifestOnly = spill?.ManifestOnly ?? false;
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            WriteEnvelope(w, envelope);
+            w.WriteNumber("count", rows.Count);
+            w.WriteNumber("contested", rows.Count(x => x.Error is null && x.Touchers.Count > 1));
+            w.WriteNumber("errors", rows.Count(x => x.Error is not null));
+            WriteNullable(w, "epoch", epoch);
+            w.WriteStartArray("rows");
+            int rendered = 0; bool rowsTruncated = false;
+            foreach (var row in rows)
+            {
+                if (manifestOnly) break;
+                w.Flush();
+                if (ms.Length >= cap) { rowsTruncated = true; break; }
+                WriteTreeRow(w, row, ms, cap);
+                rendered++;
+            }
+            w.WriteEndArray();
+            w.WriteNumber("rendered", rendered);
+            w.WriteBoolean("truncated", rowsTruncated);
+            truncated = rowsTruncated;
+            if (spill is not null) Artifacts.WriteSpillStateJson(w, spill);
             w.WriteEndObject();
         }
         return Finish(ms);

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -483,6 +483,7 @@ static class JsonWire
     /// via <c>complete:false</c>, the §4.4 truncation-honesty rule).</summary>
     public static string RenderDelta(IReadOnlyList<LoadOrderService.DeltaRow> rows, int maxChars, string? epoch,
                                      IReadOnlyList<KeyValuePair<string, string>> envelope,
+                                     IReadOnlyList<KeyValuePair<string, int>> counts,
                                      SpillState? spill, out bool truncated)
     {
         truncated = false;
@@ -493,10 +494,9 @@ static class JsonWire
         {
             w.WriteStartObject();
             WriteEnvelope(w, envelope);
-            w.WriteNumber("count", rows.Count);
-            w.WriteNumber("differing", rows.Count(x => x.Error is null && x.Diff!.Deltas.Count > 0));
-            w.WriteNumber("identical", rows.Count(x => x.Error is null && x.Diff!.Deltas.Count == 0 && x.Diff.Complete));
-            w.WriteNumber("errors", rows.Count(x => x.Error is not null));
+            // The census covers the COMPLETE list (review F8): rows may be a WINDOW, so the caller computes the
+            // counters over everything and hands them in — recomputing here reported the window as the world.
+            foreach (var (k, v) in counts.Select(c => (c.Key, c.Value))) w.WriteNumber(k, v);
             WriteNullable(w, "epoch", epoch);
             w.WriteStartArray("rows");
             int rendered = 0; bool rowsTruncated = false;
@@ -569,6 +569,7 @@ static class JsonWire
     /// construction here).</summary>
     public static string RenderTree(IReadOnlyList<LoadOrderService.TreeRow> rows, int maxChars, string? epoch,
                                     IReadOnlyList<KeyValuePair<string, string>> envelope,
+                                    IReadOnlyList<KeyValuePair<string, int>> counts,
                                     SpillState? spill, out bool truncated)
     {
         truncated = false;
@@ -579,9 +580,7 @@ static class JsonWire
         {
             w.WriteStartObject();
             WriteEnvelope(w, envelope);
-            w.WriteNumber("count", rows.Count);
-            w.WriteNumber("contested", rows.Count(x => x.Error is null && x.Touchers.Count > 1));
-            w.WriteNumber("errors", rows.Count(x => x.Error is not null));
+            foreach (var (k, v) in counts.Select(c => (c.Key, c.Value))) w.WriteNumber(k, v);   // complete-list census (review F8)
             WriteNullable(w, "epoch", epoch);
             w.WriteStartArray("rows");
             int rendered = 0; bool rowsTruncated = false;
@@ -659,6 +658,7 @@ static class JsonWire
     /// <summary>records form=chain: <c>{…envelope, seeds, errors, epoch, rows:[…]}</c>.</summary>
     public static string RenderChain(IReadOnlyList<LoadOrderService.WalkSeedResult> rows, int maxChars, string? epoch,
                                      IReadOnlyList<KeyValuePair<string, string>> envelope,
+                                     IReadOnlyList<KeyValuePair<string, int>> counts,
                                      SpillState? spill, out bool truncated)
     {
         truncated = false;
@@ -669,8 +669,7 @@ static class JsonWire
         {
             w.WriteStartObject();
             WriteEnvelope(w, envelope);
-            w.WriteNumber("seeds", rows.Count);
-            w.WriteNumber("errors", rows.Count(x => x.Error is not null));
+            foreach (var (k, v) in counts.Select(c => (c.Key, c.Value))) w.WriteNumber(k, v);   // complete-list census (review F8)
             WriteNullable(w, "epoch", epoch);
             w.WriteStartArray("rows");
             int rendered = 0; bool rowsTruncated = false;
@@ -695,20 +694,25 @@ static class JsonWire
     /// <summary>records form=chain, walk=reverse (the typed MGEF carrier lane): per seed the carriers with the
     /// MATCHING entry's payload — magnitudes AS AUTHORED (conditions not evaluated), the effect_chain contract.</summary>
     public static string RenderEffectChains(IReadOnlyList<(string Seed, EffectChainResult Result)> results,
-                                            int maxChars, IReadOnlyList<KeyValuePair<string, string>> envelope)
+                                            int maxChars, IReadOnlyList<KeyValuePair<string, string>> envelope,
+                                            IReadOnlyList<KeyValuePair<string, int>> counts, string? epoch,
+                                            SpillState? spill, out bool outTruncated)
     {
+        outTruncated = false;
         int cap = Cap(maxChars);
+        bool manifestOnly = spill?.ManifestOnly ?? false;
         using var ms = new MemoryStream();
         using (var w = new Utf8JsonWriter(ms, Opts))
         {
             w.WriteStartObject();
             WriteEnvelope(w, envelope);
-            w.WriteNumber("seeds", results.Count);
-            WriteNullable(w, "epoch", results.Select(r => r.Result.Epoch).FirstOrDefault(e => e is not null));
+            foreach (var (k, v) in counts.Select(c => (c.Key, c.Value))) w.WriteNumber(k, v);   // complete-list census (review F8)
+            WriteNullable(w, "epoch", epoch);
             w.WriteStartArray("rows");
             bool truncated = false;
             foreach (var (seed, r) in results)
             {
+                if (manifestOnly) break;
                 w.Flush();
                 if (ms.Length >= cap) { truncated = true; break; }
                 w.WriteStartObject();
@@ -740,6 +744,8 @@ static class JsonWire
             }
             w.WriteEndArray();
             w.WriteBoolean("truncated", truncated);
+            outTruncated = truncated;
+            if (spill is not null) Artifacts.WriteSpillStateJson(w, spill);
             w.WriteEndObject();
         }
         return Finish(ms);
@@ -802,6 +808,7 @@ static class JsonWire
     /// <summary>records form=info_order: <c>{…envelope, count, contested, errors, epoch, rows:[…]}</c>.</summary>
     public static string RenderInfoOrder(IReadOnlyList<LoadOrderService.InfoOrderRow> rows, int maxChars, string? epoch,
                                          IReadOnlyList<KeyValuePair<string, string>> envelope,
+                                         IReadOnlyList<KeyValuePair<string, int>> counts,
                                          SpillState? spill, out bool truncated)
     {
         truncated = false;
@@ -812,9 +819,7 @@ static class JsonWire
         {
             w.WriteStartObject();
             WriteEnvelope(w, envelope);
-            w.WriteNumber("count", rows.Count);
-            w.WriteNumber("contested", rows.Count(x => x.Error is null && x.Order is { Contested: true }));
-            w.WriteNumber("errors", rows.Count(x => x.Error is not null));
+            foreach (var (k, v) in counts.Select(c => (c.Key, c.Value))) w.WriteNumber(k, v);   // complete-list census (review F8)
             WriteNullable(w, "epoch", epoch);
             w.WriteStartArray("rows");
             int rendered = 0; bool rowsTruncated = false;

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -354,7 +354,7 @@ static class JsonWire
         {
             w.WriteStartObject();
             WriteEnvelope(w, envelope);
-            foreach (var (k, v) in counts.Select(c => (c.Key, c.Value))) w.WriteNumber(k, v);
+            foreach (var c in counts) w.WriteNumber(c.Key, c.Value);
             WriteNullable(w, "epoch", epoch);
             w.WriteEndObject();
         }

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -603,6 +603,97 @@ static class JsonWire
         return Finish(ms);
     }
 
+    // ---- housecarl_records (W2 PR 2): the info_order form -------------------------------------------
+
+    /// <summary>One info_order row — shared by the json render and the artifact writer. Positions are 1-based
+    /// (matching the text render's #N). The honesty gates ride as data: <c>complete</c> (every touching plugin's
+    /// list read), <c>moves_computed</c> (the move analysis ran), <c>baseline_trusted</c> (origin positions
+    /// anchored on the true definer) — negative claims about moves hold only when the first two are both true.</summary>
+    internal static void WriteInfoOrderRow(Utf8JsonWriter w, LoadOrderService.InfoOrderRow row, MemoryStream ms, int cap)
+    {
+        w.WriteStartObject();
+        w.WriteString("formid", row.Formid);
+        if (row.Error is not null) { w.WriteString("error", row.Error); w.WriteEndObject(); return; }
+        WriteNullable(w, "type", row.Type);
+        WriteNullable(w, "editorid", row.EditorId);
+        WriteNullable(w, "winner", row.WinnerPlugin);
+        if (row.Order is not { } io)
+        {
+            w.WriteString("note", "the merge could not be computed for this topic (its key did not resolve in the touching index)");
+            w.WriteEndObject();
+            return;
+        }
+        w.WriteBoolean("contested", io.Contested);
+        w.WriteBoolean("complete", io.Complete);
+        w.WriteBoolean("moves_computed", io.MovesComputed);
+        w.WriteBoolean("baseline_trusted", io.BaselineTrusted);
+        WriteStringArray(w, "contributing", io.ContributingPlugins);
+        if (io.UnreadContributors.Count > 0) WriteStringArray(w, "unread", io.UnreadContributors);
+        WriteNullable(w, "note", io.Note);
+        w.WriteNumber("moved_count", io.Moved.Count);
+        w.WriteStartArray("order");
+        foreach (var e in io.Order)
+        {
+            w.Flush();
+            if (ms.Length >= cap)
+            {
+                w.WriteStartObject();
+                w.WriteString("note", "[order truncated at max_chars — raise max_chars]");
+                w.WriteEndObject();
+                break;
+            }
+            w.WriteStartObject();
+            w.WriteNumber("position", e.Index + 1);
+            w.WriteString("info", e.Info.ToString());
+            w.WriteString("placed_by", e.PlacedBy);
+            if (e.Deleted) w.WriteBoolean("deleted", true);
+            if (e.Moved) { w.WriteBoolean("moved", true); w.WriteNumber("origin_position", e.OriginIndex!.Value + 1); }
+            else if (e.OriginIndex is null && io.BaselineTrusted) w.WriteBoolean("added_by_later_plugin", true);
+            if (e.Placement == InfoPlacement.HeadFirstMarker) w.WriteString("placement", "pinned first by its own PNAM marker (deliberate)");
+            else if (e.Placement == InfoPlacement.HeadUnresolvable) w.WriteString("placement", "PNAM names no reachable line — forced to the top");
+            w.WriteEndObject();
+        }
+        w.WriteEndArray();
+        w.WriteEndObject();
+    }
+
+    /// <summary>records form=info_order: <c>{…envelope, count, contested, errors, epoch, rows:[…]}</c>.</summary>
+    public static string RenderInfoOrder(IReadOnlyList<LoadOrderService.InfoOrderRow> rows, int maxChars, string? epoch,
+                                         IReadOnlyList<KeyValuePair<string, string>> envelope,
+                                         SpillState? spill, out bool truncated)
+    {
+        truncated = false;
+        int cap = Cap(maxChars);
+        bool manifestOnly = spill?.ManifestOnly ?? false;
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            WriteEnvelope(w, envelope);
+            w.WriteNumber("count", rows.Count);
+            w.WriteNumber("contested", rows.Count(x => x.Error is null && x.Order is { Contested: true }));
+            w.WriteNumber("errors", rows.Count(x => x.Error is not null));
+            WriteNullable(w, "epoch", epoch);
+            w.WriteStartArray("rows");
+            int rendered = 0; bool rowsTruncated = false;
+            foreach (var row in rows)
+            {
+                if (manifestOnly) break;
+                w.Flush();
+                if (ms.Length >= cap) { rowsTruncated = true; break; }
+                WriteInfoOrderRow(w, row, ms, cap);
+                rendered++;
+            }
+            w.WriteEndArray();
+            w.WriteNumber("rendered", rendered);
+            w.WriteBoolean("truncated", rowsTruncated);
+            truncated = rowsTruncated;
+            if (spill is not null) Artifacts.WriteSpillStateJson(w, spill);
+            w.WriteEndObject();
+        }
+        return Finish(ms);
+    }
+
     // ---- housecarl_cross_plugin_query (P6) ----------------------------------------------------------
     /// <summary>cross_plugin_query as JSON — three shapes matching the text render: group_by count table
     /// (<c>{group_by, total, groups:[…]}</c>), detail rows (full record objects with fields), or summary rows

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -603,6 +603,148 @@ static class JsonWire
         return Finish(ms);
     }
 
+    // ---- housecarl_records (W2 PR 2): the chain form (walk=) ----------------------------------------
+
+    /// <summary>One chain row — shared by the json render and the artifact writer. Node status is 'expanded'
+    /// (entered) or 'kept' (a boundary: exclusion stop, depth cap, unresolved link — the note names which).</summary>
+    internal static void WriteChainRow(Utf8JsonWriter w, LoadOrderService.WalkSeedResult row, MemoryStream ms, int cap)
+    {
+        w.WriteStartObject();
+        w.WriteString("formid", row.Seed);
+        if (row.Error is not null) { w.WriteString("error", row.Error); w.WriteEndObject(); return; }
+        WriteNullable(w, "type", row.Type);
+        WriteNullable(w, "editorid", row.EditorId);
+        w.WriteStartArray("nodes");
+        foreach (var n in row.Nodes)
+        {
+            w.Flush();
+            if (ms.Length >= cap)
+            {
+                w.WriteStartObject();
+                w.WriteString("note", "[nodes truncated at max_chars — raise max_chars, or to_file= for the complete walk]");
+                w.WriteEndObject();
+                break;
+            }
+            w.WriteStartObject();
+            w.WriteString("key", n.Key);
+            WriteNullable(w, "type", n.Type);
+            WriteNullable(w, "editorid", n.EditorId);
+            w.WriteNumber("depth", n.Depth);
+            w.WriteString("pulled_by", n.PulledBy);
+            w.WriteString("status", n.Status);
+            WriteNullable(w, "note", n.Note);
+            w.WriteEndObject();
+        }
+        w.WriteEndArray();
+        if (row.Cycles.Count > 0) WriteStringArray(w, "cycles", row.Cycles);
+        WriteNullable(w, "truncation", row.TruncationNote);
+        if (row.TemplateReport is { } tr)
+        {
+            w.WriteStartArray("template_inheritance");
+            foreach (var c in tr)
+            {
+                w.WriteStartObject();
+                w.WriteString("category", c.Category);
+                w.WriteBoolean("inherited", c.InheritedAtSeed);
+                WriteNullable(w, "provider", c.ProviderKey);
+                WriteNullable(w, "provider_editorid", c.ProviderEditorId);
+                WriteNullable(w, "note", c.Note);
+                w.WriteEndObject();
+            }
+            w.WriteEndArray();
+        }
+        w.WriteEndObject();
+    }
+
+    /// <summary>records form=chain: <c>{…envelope, seeds, errors, epoch, rows:[…]}</c>.</summary>
+    public static string RenderChain(IReadOnlyList<LoadOrderService.WalkSeedResult> rows, int maxChars, string? epoch,
+                                     IReadOnlyList<KeyValuePair<string, string>> envelope,
+                                     SpillState? spill, out bool truncated)
+    {
+        truncated = false;
+        int cap = Cap(maxChars);
+        bool manifestOnly = spill?.ManifestOnly ?? false;
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            WriteEnvelope(w, envelope);
+            w.WriteNumber("seeds", rows.Count);
+            w.WriteNumber("errors", rows.Count(x => x.Error is not null));
+            WriteNullable(w, "epoch", epoch);
+            w.WriteStartArray("rows");
+            int rendered = 0; bool rowsTruncated = false;
+            foreach (var row in rows)
+            {
+                if (manifestOnly) break;
+                w.Flush();
+                if (ms.Length >= cap) { rowsTruncated = true; break; }
+                WriteChainRow(w, row, ms, cap);
+                rendered++;
+            }
+            w.WriteEndArray();
+            w.WriteNumber("rendered", rendered);
+            w.WriteBoolean("truncated", rowsTruncated);
+            truncated = rowsTruncated;
+            if (spill is not null) Artifacts.WriteSpillStateJson(w, spill);
+            w.WriteEndObject();
+        }
+        return Finish(ms);
+    }
+
+    /// <summary>records form=chain, walk=reverse (the typed MGEF carrier lane): per seed the carriers with the
+    /// MATCHING entry's payload — magnitudes AS AUTHORED (conditions not evaluated), the effect_chain contract.</summary>
+    public static string RenderEffectChains(IReadOnlyList<(string Seed, EffectChainResult Result)> results,
+                                            int maxChars, IReadOnlyList<KeyValuePair<string, string>> envelope)
+    {
+        int cap = Cap(maxChars);
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            WriteEnvelope(w, envelope);
+            w.WriteNumber("seeds", results.Count);
+            WriteNullable(w, "epoch", results.Select(r => r.Result.Epoch).FirstOrDefault(e => e is not null));
+            w.WriteStartArray("rows");
+            bool truncated = false;
+            foreach (var (seed, r) in results)
+            {
+                w.Flush();
+                if (ms.Length >= cap) { truncated = true; break; }
+                w.WriteStartObject();
+                w.WriteString("seed", seed);
+                if (r.Error is not null) { w.WriteString("error", r.Error); w.WriteEndObject(); continue; }
+                w.WriteString("mgef_editorid", r.MgefEditorId);
+                w.WriteNumber("total", r.Total);
+                w.WriteBoolean("capped", r.Capped);
+                WriteNullable(w, "scan_note", r.ScanNote);
+                w.WriteStartArray("carriers");
+                foreach (var row in r.Rows)
+                {
+                    w.Flush();
+                    if (ms.Length >= cap) { truncated = true; break; }
+                    w.WriteStartObject();
+                    w.WriteString("formid", row.Carrier.ToString());
+                    w.WriteString("type", row.Type);
+                    WriteNullable(w, "editorid", row.EditorId);
+                    w.WriteString("winner", row.Winner);
+                    w.WriteNumber("effect_index", row.EffectIndex);
+                    w.WriteNumber("effect_count", row.EffectCount);
+                    w.WriteNumber("magnitude", row.Magnitude);
+                    w.WriteNumber("area", row.Area);
+                    w.WriteNumber("duration", row.Duration);
+                    w.WriteEndObject();
+                }
+                w.WriteEndArray();
+                w.WriteEndObject();
+            }
+            w.WriteEndArray();
+            w.WriteBoolean("truncated", truncated);
+            w.WriteEndObject();
+        }
+        return Finish(ms);
+    }
+
     // ---- housecarl_records (W2 PR 2): the info_order form -------------------------------------------
 
     /// <summary>One info_order row — shared by the json render and the artifact writer. Positions are 1-based

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -1021,7 +1021,7 @@ public sealed class LoadOrderService : IDisposable
     /// no-op (true-ITM) scan: resolve the winner, materialize a mutable scratch copy, apply every
     /// type folder's ordered lines in field-map order. Error = the named reason the record can't be
     /// replayed (Q3 — the caller decides whether that's a Fail or a skip-with-count).</summary>
-    (string? TypeName, string? WinnerPlugin, string? EditorId, List<SkyPatcherFolderOutcome> Folders, string? Error)
+    (string? TypeName, string? WinnerPlugin, string? EditorId, List<SkyPatcherFolderOutcome> Folders, string? Error, IMajorRecord? Copy)
         ReplaySkyPatcher(
             LoadOrderResolver.IndexView view, LoadOrderResolver.OverlaySession session,
             SkyPatcherDiscovery.LayerScan scan, SkyPatcherCatalog catalog, SkyPatcherFieldMap fieldMap,
@@ -1031,17 +1031,17 @@ public sealed class LoadOrderService : IDisposable
         var none = new List<SkyPatcherFolderOutcome>();
         var winner = view.ResolveWinner(fk);
         if (winner is null)
-            return (null, null, null, none, $"FormID {fk} is not present in the load order ({view.PluginCount} plugins).");
+            return (null, null, null, none, $"FormID {fk} is not present in the load order ({view.PluginCount} plugins).", null);
 
         var body = view.GetRecord(session, winner.Value.WinnerPlugin, fk);
         if (body is null)
-            return (null, winner.Value.WinnerPlugin, null, none, $"Winner '{winner.Value.WinnerPlugin}' did not yield {fk} on fetch — a load-order inconsistency.");
+            return (null, winner.Value.WinnerPlugin, null, none, $"Winner '{winner.Value.WinnerPlugin}' did not yield {fk} on fetch — a load-order inconsistency.", null);
 
         var typeName = ReadEngine.ReadFields(body, new[] { "EditorID" }).Type;   // the same type naming every read tool reports
         var maps = fieldMap.ForRecordType(typeName);
         if (maps.Count == 0)
             return (typeName, winner.Value.WinnerPlugin, body.EditorID, none,
-                $"Record type '{typeName}' is not a SkyPatcher-patchable type (or has no field map) — the SkyPatcher layer cannot touch {fk}.");
+                $"Record type '{typeName}' is not a SkyPatcher-patchable type (or has no field map) — the SkyPatcher layer cannot touch {fk}.", null);
 
         // The running copy: the winner overridden into an in-memory scratch mod (never written to disk).
         // Nested-group types (CELL / REFR / INFO…) need the source link cache to rebuild their parent
@@ -1057,7 +1057,7 @@ public sealed class LoadOrderService : IDisposable
         catch (Exception ex)
         {
             return (typeName, winner.Value.WinnerPlugin, body.EditorID, none,
-                $"Could not materialize a mutable copy of {fk} ({typeName}) for the replay — {ex.GetType().Name}: {ex.Message}");
+                $"Could not materialize a mutable copy of {fk} ({typeName}) for the replay — {ex.GetType().Name}: {ex.Message}", null);
         }
 
         var folders = new List<SkyPatcherFolderOutcome>();
@@ -1082,7 +1082,7 @@ public sealed class LoadOrderService : IDisposable
                 folder.PatchingEnabled));
         }
 
-        return (typeName, winner.Value.WinnerPlugin, body.EditorID, folders, null);
+        return (typeName, winner.Value.WinnerPlugin, body.EditorID, folders, null, copy);
     }
 
     /// <summary>
@@ -2821,6 +2821,444 @@ public sealed class LoadOrderService : IDisposable
             return results.Select(r => r!).ToList();
         }
         finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    // ---- W2 PR 2: comparison poles + the delta/tree batches (SPEC §4.1–§4.4) ---------------------------
+
+    /// <summary>Which §4.2 pole a source=/versus= expression names. <see cref="Overlay"/> is the SkyPatcher
+    /// runtime replay (pre = the plain winner body; post = the winner body after the INI layer replays).</summary>
+    public enum PoleKind { Winner, Named, PreviousProvider, Overlay }
+
+    /// <summary>A parsed §4.2 pole expression — the tool layer parses the wire spelling ("winner" | a plugin
+    /// filename | {file, mod} | "previous_provider" | {overlay, state}) into this engine value.</summary>
+    public sealed record PoleSpec(PoleKind Kind, string? Plugin = null, string? Mod = null, string? OverlayState = null)
+    {
+        public static readonly PoleSpec Winner = new(PoleKind.Winner);
+        /// <summary>The arm statement a render leads with when the pole is uniform across the batch (Named/Winner/
+        /// Overlay). PreviousProvider is per-record; its statement is the rule, not an arm.</summary>
+        public string Label => Kind switch
+        {
+            PoleKind.Winner => "winner",
+            PoleKind.PreviousProvider => "previous_provider (the provider immediately below the subject, per record)",
+            PoleKind.Overlay => $"skypatcher overlay ({OverlayState})",
+            _ => Plugin ?? "?",
+        };
+    }
+
+    /// <summary>One record's §4.1 delta: subject pole vs reference pole, compared by <see cref="FieldsDiff"/>.
+    /// <see cref="StackAbove"/> — set only under a previous_provider reference when the subject sits mid-stack —
+    /// names what outranks the subject (winner last) as NEUTRAL FACT (§4.3: a non-winning subject is not an
+    /// anomaly; no advice, no warning tone). <see cref="Note"/> carries per-row facts like the two poles resolving
+    /// to the same provider. Error non-null ⇒ per-item refusal (P3/P4/untouched), the batch survives.</summary>
+    public sealed record DeltaRow(string Formid, DiffPole? Subject, DiffPole? Reference, FieldsDiff.Result? Diff,
+                                  IReadOnlyList<string>? StackAbove, string? Note, string? Error);
+
+    /// <summary>The §4.1 PROJECT=delta batch: every pole of every record resolves against ONE captured build
+    /// (§4.1 — a comparison can never span two builds). Subject defaults to winner; reference may be winner, a
+    /// named plugin (active or off-order — the §4.2 one-pole rule, off-order files declared outside the epoch
+    /// fingerprint), or previous_provider (§4.3, subject-relative, P1–P4 declared). A named pole that does not
+    /// touch a record is a per-item refusal naming the actual touchers (§4.2's untouched contract); the caller
+    /// counts those as not_touched accounting. Overlay poles resolve via the SkyPatcher replay.</summary>
+    public IReadOnlyList<DeltaRow> DeltaBatch(
+        IReadOnlyList<string> formids, PoleSpec subject, PoleSpec reference, IReadOnlyList<string>? fields,
+        ArtifactDemand? demand,
+        out string? subjectArm, out string? referenceArm, out bool epochCoversAll,
+        out string? refusal, out string? epoch)
+    {
+        subjectArm = null; referenceArm = null; epochCoversAll = true; refusal = null;
+        var resolver = Resolver;
+        var view = resolver.Capture();          // ONE build for every pole of every record (§4.1)
+        epoch = view.Epoch;
+        if (demand is not null && demand.Epoch != view.Epoch)
+        {
+            refusal = ArtifactEpochMismatch(demand, view.Epoch);
+            return Array.Empty<DeltaRow>();
+        }
+        using var session = resolver.OpenSession();
+
+        // Resolve the uniform arms once (named poles; winner/overlay are per-record but uniform in statement).
+        var sReader = MakePoleReader(view, session, subject, fields, out subjectArm, out var sCovers, out var sErr);
+        if (sErr is not null) { refusal = "source: " + sErr; return Array.Empty<DeltaRow>(); }
+        var rReader = MakePoleReader(view, session, reference, fields, out referenceArm, out var rCovers, out var rErr);
+        if (rErr is not null) { refusal = "versus: " + rErr; return Array.Empty<DeltaRow>(); }
+        epochCoversAll = sCovers && rCovers;
+
+        var rows = new List<DeltaRow>(formids.Count);
+        foreach (var raw in formids)
+        {
+            FormKey fk;
+            try { fk = FormKey.Factory(raw.Trim()); }
+            catch (Exception ex) { rows.Add(new DeltaRow(raw?.Trim() ?? "", null, null, null, null, null, $"bad FormID '{raw}': {ex.Message}")); continue; }
+
+            var s = sReader(fk, null);
+            if (s.Error is not null) { rows.Add(new DeltaRow(fk.ToString(), s.Pole, null, null, null, null, "subject: " + s.Error)); continue; }
+            // previous_provider is measured FROM THE SUBJECT (§4.3) — hand the reference reader the subject's
+            // resolved plugin for this record so P1–P4 anchor on the right stack position.
+            var r = rReader(fk, s.Pole!.Plugin);
+            if (r.Error is not null) { rows.Add(new DeltaRow(fk.ToString(), s.Pole, r.Pole, null, r.StackAbove, null, "versus: " + r.Error)); continue; }
+
+            string? note = string.Equals(s.Pole.Plugin, r.Pole!.Plugin, StringComparison.OrdinalIgnoreCase) && s.Pole.Where == r.Pole.Where
+                ? "the two poles resolved to the SAME provider — the diff is trivially empty by construction"
+                : null;
+            var diff = FieldsDiff.Compare(s.Fields!, r.Fields!, referenceLabel: r.Pole.Plugin);
+            rows.Add(new DeltaRow(fk.ToString(), s.Pole, r.Pole, diff, r.StackAbove, note, null));
+        }
+        return rows;
+    }
+
+    /// <summary>A pole reader's per-record result: the deep-read fields + the pole identity for the render, or a
+    /// per-item error. <see cref="StackAbove"/> is the previous_provider P2 fact (what outranks the subject).</summary>
+    internal sealed record PoleReading(RecordFields? Fields, DiffPole? Pole, IReadOnlyList<string>? StackAbove, string? Error);
+
+    internal delegate PoleReading PoleReader(FormKey fk, string? subjectPlugin);
+
+    /// <summary>Build the per-record reader for one §4.2 pole against the SHARED captured view/session. Uniform
+    /// arm resolution (a named plugin's active-vs-off-order arm; an off-order file opened and swept lazily on
+    /// first use) happens here ONCE; per-record work stays in the returned reader. <paramref name="covers"/> is
+    /// false when the pole reads content outside the epoch fingerprint (an off-order file; the overlay's INIs).</summary>
+    PoleReader MakePoleReader(LoadOrderResolver.IndexView view, LoadOrderResolver.OverlaySession session,
+                              PoleSpec spec, IReadOnlyList<string>? fields,
+                              out string? armStatement, out bool covers, out string? error)
+    {
+        error = null; covers = true;
+        switch (spec.Kind)
+        {
+            case PoleKind.Winner:
+                armStatement = "winner";
+                return (fk, _) =>
+                {
+                    var w = view.ResolveWinner(fk);
+                    if (w is null)
+                        return new PoleReading(null, null, null, $"{fk} is not present in the active order.");
+                    var body = view.GetRecord(session, w.Value.WinnerPlugin, fk);
+                    if (body is null)
+                        return new PoleReading(null, null, null, $"the winner body of {fk} could not be read from '{w.Value.WinnerPlugin}'.");
+                    return new PoleReading(ReadEngine.ReadFields(body, fields, ConflictDiffDepth),
+                                           new DiffPole(w.Value.WinnerPlugin, "winner (active order)", true,
+                                                        RecordNaming.StripOverlay(body.GetType().Name), body.EditorID), null, null);
+                };
+
+            case PoleKind.PreviousProvider:
+                // Subject-relative (§4.3): resolved per record against the touching list, anchored on the plugin
+                // the SUBJECT resolved to for that record. Always active-order (the touching list is the order's).
+                armStatement = spec.Label;
+                return (fk, subjectPlugin) =>
+                {
+                    var touchers = view.TouchingPlugins(fk) ?? Array.Empty<string>();
+                    if (touchers.Count == 0)
+                        return new PoleReading(null, null, null, $"no active plugin touches {fk} — there is no provider stack to measure previous_provider in.");
+                    int idx = -1;
+                    for (int i = 0; i < touchers.Count; i++)
+                        if (string.Equals(touchers[i], subjectPlugin, StringComparison.OrdinalIgnoreCase)) { idx = i; break; }
+                    if (idx < 0)   // P4 — the subject doesn't touch the record at all
+                        return new PoleReading(null, null, null,
+                            $"the subject '{subjectPlugin}' does not touch {fk}, so it has no position to measure previous_provider from. " +
+                            $"Touched by (active order, winner last): {string.Join(", ", touchers)}.");
+                    if (idx == 0)  // P3 — the subject IS the origin; never a silent empty diff
+                        return new PoleReading(null, null, null,
+                            $"no previous provider — '{subjectPlugin}' DEFINES {fk} (bottom of the touching list); there is nothing beneath it to compare against.");
+                    var refPlugin = touchers[idx - 1];
+                    var body = view.GetRecord(session, refPlugin, fk);
+                    if (body is null)
+                        return new PoleReading(null, null, null, $"the previous provider '{refPlugin}' of {fk} could not be read.");
+                    // P2 — mid-stack subject: what sits ABOVE is surfaced as neutral fact (§4.3), never advice.
+                    IReadOnlyList<string>? above = idx < touchers.Count - 1 ? touchers.Skip(idx + 1).ToList() : null;
+                    return new PoleReading(ReadEngine.ReadFields(body, fields, ConflictDiffDepth),
+                                           new DiffPole(refPlugin, $"previous provider (immediately below '{subjectPlugin}')", true,
+                                                        RecordNaming.StripOverlay(body.GetType().Name), body.EditorID), above, null);
+                };
+
+            case PoleKind.Overlay:
+                return MakeOverlayPoleReader(view, session, spec, fields, out armStatement, out covers, out error);
+
+            default:   // Named — the §4.2 one-pole rule: active in the order, else an on-disk file.
+                var (arm, armErr) = ResolvePoleArm(view, spec.Plugin!, spec.Mod);
+                if (armErr is not null) { armStatement = null; error = armErr; return (_, _) => new PoleReading(null, null, null, armErr); }
+                armStatement = $"{arm!.Plugin} — {arm.Where}";
+                if (arm.InOrder)
+                {
+                    if (view.ExcludedPlugins.TryGetValue(arm.Plugin, out var why))
+                    {
+                        var exclMsg = $"'{arm.Plugin}' was excluded from this session ({why}) — its records aren't resolvable.";
+                        error = exclMsg;
+                        return (_, _) => new PoleReading(null, null, null, exclMsg);
+                    }
+                    return (fk, _) =>
+                    {
+                        var body = view.GetRecord(session, arm.Plugin, fk);
+                        if (body is null)
+                        {
+                            // The §4.2 untouched contract: name the actual touchers, never a silent absence.
+                            var touchers = view.TouchingPlugins(fk) ?? Array.Empty<string>();
+                            return new PoleReading(null, null, null,
+                                $"'{arm.Plugin}' does not define or override {fk} — it has no version of this record. " +
+                                (touchers.Count > 0
+                                    ? $"Touched by (active order, winner last): {string.Join(", ", touchers)}."
+                                    : "No active plugin touches it either."));
+                        }
+                        return new PoleReading(ReadEngine.ReadFields(body, fields, ConflictDiffDepth),
+                                               new DiffPole(arm.Plugin, arm.Where, true,
+                                                            RecordNaming.StripOverlay(body.GetType().Name), body.EditorID), null, null);
+                    };
+                }
+                // OFF-ORDER arm: open the overlay lazily ONCE; per-record lookups sweep it on first use and
+                // memoise every record seen on the way (one enumeration pass serves the whole batch).
+                covers = false;   // the file's content sits outside the epoch fingerprint (PR #305 coverage rule)
+                var lazy = new OffOrderPoleCache(this, arm, fields);
+                return (fk, _) =>
+                {
+                    var (rec, oerr) = lazy.Find(fk);
+                    if (oerr is not null) return new PoleReading(null, null, null, oerr);
+                    if (rec is null)
+                    {
+                        var touchers = view.TouchingPlugins(fk) ?? Array.Empty<string>();
+                        return new PoleReading(null, null, null,
+                            $"file '{arm.Plugin}' ({arm.Where}) does not define or override {fk} — it has no version of this record. " +
+                            (touchers.Count > 0
+                                ? $"Touched by (active order, winner last): {string.Join(", ", touchers)}."
+                                : "No active plugin touches it either."));
+                    }
+                    return new PoleReading(rec, new DiffPole(arm.Plugin, arm.Where, false, rec.Type, rec.EditorId), null, null);
+                };
+        }
+    }
+
+    /// <summary>The SkyPatcher-overlay §4.2 pole (source={overlay:"skypatcher", state:"pre"|"post"}).
+    /// <c>pre</c> IS the plain load-order winner (the body the INI layer starts from) — labeled as the overlay's
+    /// pre state so a pre-vs-post delta's two arms read as a pair. <c>post</c> replays the discovered INI layer
+    /// onto a mutable copy of each record's winner via the SAME per-record core housecarl_skypatcher_read uses,
+    /// and reads the replayed body. INI content sits OUTSIDE the epoch fingerprint (the skypatcher_read posture),
+    /// so <paramref name="covers"/> is false on the post arm and the render declares it. A record whose type
+    /// SkyPatcher cannot patch reads as its winner with the fact stated on the pole line (the layer cannot touch
+    /// it — post IS pre there, an answer, not an error).</summary>
+    PoleReader MakeOverlayPoleReader(LoadOrderResolver.IndexView view, LoadOrderResolver.OverlaySession session,
+                                     PoleSpec spec, IReadOnlyList<string>? fields,
+                                     out string? armStatement, out bool covers, out string? error)
+    {
+        error = null;
+        var state = (spec.OverlayState ?? "post").Trim().ToLowerInvariant();
+        if (state is not ("pre" or "post"))
+        {
+            armStatement = null; covers = true;
+            error = $"overlay state '{spec.OverlayState}' is not recognized — use \"pre\" (the winner before the INI layer) or \"post\" (after it; the default).";
+            var msg = error;
+            return (_, _) => new PoleReading(null, null, null, msg);
+        }
+
+        if (state == "pre")
+        {
+            covers = true;
+            armStatement = "skypatcher overlay (pre) — the plain load-order winner, before the INI layer";
+            return (fk, _) =>
+            {
+                var w = view.ResolveWinner(fk);
+                if (w is null) return new PoleReading(null, null, null, $"{fk} is not present in the active order.");
+                var body = view.GetRecord(session, w.Value.WinnerPlugin, fk);
+                if (body is null) return new PoleReading(null, null, null, $"the winner body of {fk} could not be read from '{w.Value.WinnerPlugin}'.");
+                return new PoleReading(ReadEngine.ReadFields(body, fields, ConflictDiffDepth),
+                                       new DiffPole(w.Value.WinnerPlugin, "skypatcher overlay (pre) = winner", true,
+                                                    RecordNaming.StripOverlay(body.GetType().Name), body.EditorID), null, null);
+            };
+        }
+
+        covers = false;   // the INI layer's files are outside the index fingerprint (the skypatcher_read posture)
+        armStatement = "skypatcher overlay (post) — the winner after the SkyPatcher INI layer replays";
+        // The replay context is built lazily ONCE for the whole batch (discovery scan + catalogs + scratch mod +
+        // form resolver + per-folder line cache — the SkyPatcherLayer no-op scan's own idiom).
+        SkyPatcherFieldMap? fieldMap = null; SkyPatcherCatalog? catalog = null;
+        SkyPatcherDiscovery.LayerScan? scan = null; SkyrimMod? scratch = null;
+        SkyPatcherOverlay.IFormResolver? formResolver = null;
+        Dictionary<string, IReadOnlyList<SkyPatcherOverlay.OrderedLine>>? linesCache = null;
+        string? setupError = null;
+        return (fk, _) =>
+        {
+            if (setupError is not null) return new PoleReading(null, null, null, setupError);
+            if (scan is null)
+            {
+                try
+                {
+                    AssetResolver.AssetView assets;
+                    lock (_gate) { assets = Assets.Capture(); }
+                    fieldMap = SkyPatcherFieldMap.Load();
+                    catalog = SkyPatcherCatalog.Load();
+                    scan = SkyPatcherDiscovery.Scan(assets, catalog, view.ContainsPlugin, _skyPatcherParseCache);
+                    scratch = new SkyrimMod(SkyPatcherScratchKey, SkyrimRelease.SkyrimSE);
+                    formResolver = new SkyPatcherServiceResolver(this, view, session);
+                    linesCache = new Dictionary<string, IReadOnlyList<SkyPatcherOverlay.OrderedLine>>(StringComparer.OrdinalIgnoreCase);
+                }
+                catch (Exception ex)
+                {
+                    setupError = $"the SkyPatcher layer could not be discovered for the overlay pole: {ex.Message}";
+                    return new PoleReading(null, null, null, setupError);
+                }
+            }
+            var r = ReplaySkyPatcher(view, session, scan, catalog!, fieldMap!, scratch!, formResolver!, fk, linesCache);
+            if (r.Error is not null)
+            {
+                // An unpatchable TYPE is an answer, not a failure: the layer cannot touch it, so post IS pre.
+                if (r.TypeName is not null && r.Copy is null && r.Error.Contains("not a SkyPatcher-patchable type"))
+                {
+                    var w = view.ResolveWinner(fk);
+                    var body = w is null ? null : view.GetRecord(session, w.Value.WinnerPlugin, fk);
+                    if (body is not null)
+                        return new PoleReading(ReadEngine.ReadFields(body, fields, ConflictDiffDepth),
+                                               new DiffPole(w!.Value.WinnerPlugin,
+                                                            "skypatcher overlay (post) = winner — type not SkyPatcher-patchable, the layer cannot touch it",
+                                                            true, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID), null, null);
+                }
+                return new PoleReading(null, null, null, r.Error);
+            }
+            int applied = r.Folders.Where(f => f.Result is not null).Sum(f => f.Result!.Applied.Count);
+            var post = ReadEngine.ReadFields(r.Copy!, fields, ConflictDiffDepth);
+            return new PoleReading(post,
+                new DiffPole(r.WinnerPlugin!, $"skypatcher overlay (post) — {applied} op(s) applied onto the winner", true,
+                             post.Type, r.EditorId), null, null);
+        };
+    }
+
+    /// <summary>The off-order pole's lazy single-pass cache: opens the file's overlay on first lookup, sweeps it
+    /// ONCE materialising every record's deep fields as it passes (a value snapshot — the overlay is disposed at
+    /// the end of the sweep, no handle held at rest). Misses after the full sweep are definitive.</summary>
+    sealed class OffOrderPoleCache
+    {
+        readonly LoadOrderService _svc;
+        readonly PoleInfo _arm;
+        readonly IReadOnlyList<string>? _fields;
+        Dictionary<FormKey, RecordFields>? _all;
+        string? _error;
+
+        public OffOrderPoleCache(LoadOrderService svc, PoleInfo arm, IReadOnlyList<string>? fields)
+        { _svc = svc; _arm = arm; _fields = fields; }
+
+        public (RecordFields? Fields, string? Error) Find(FormKey fk)
+        {
+            if (_error is not null) return (null, _error);
+            if (_all is null && Sweep() is { } err) { _error = err; return (null, err); }
+            return (_all!.TryGetValue(fk, out var rec) ? rec : null, null);
+        }
+
+        string? Sweep()
+        {
+            string dataDir;
+            try { lock (_svc._gate) { _svc.EnsurePathsDerived(); dataDir = _svc._dataDir; } }
+            catch (Exception ex) { return $"the MO2 roots couldn't be derived to open '{_arm.Plugin}': {ex.Message}"; }
+            ISkyrimModGetter ov;
+            try { ov = LoadOrderResolver.OpenOverlay(_arm.Path!, string.IsNullOrEmpty(dataDir) ? null : dataDir); }
+            catch (Exception ex) { return $"could not open '{_arm.Path}' as a Skyrim plugin: {ex.Message}"; }
+            try
+            {
+                var all = new Dictionary<FormKey, RecordFields>();
+                foreach (var r in ov.EnumerateMajorRecords())
+                    if (!all.ContainsKey(r.FormKey))
+                        all[r.FormKey] = ReadEngine.ReadFields(r, _fields, ConflictDiffDepth);
+                _all = all;
+                return null;
+            }
+            catch (Exception ex) { return $"file '{_arm.Plugin}' could not be fully read — a record Mutagen cannot parse: {ex.Message}"; }
+            finally { (ov as IDisposable)?.Dispose(); }
+        }
+    }
+
+    /// <summary>One provider's node in a §4.1 PROJECT=tree row: its position in the touching list plus its delta
+    /// against the row's reference pole (empty deltas + Complete ⇒ genuinely identical to the reference).</summary>
+    public sealed record TreeNodeDelta(string Plugin, bool IsWinner, bool IsReference,
+                                       IReadOnlyList<string> Deltas, int AgreedCount, bool Complete, string? Error);
+
+    /// <summary>One record's §4.1 PROJECT=tree: every provider in priority order (winner LAST — the load order's
+    /// own reading direction), each diffed against the reference pole. Error non-null ⇒ per-item refusal.</summary>
+    public sealed record TreeRow(string Formid, string? Type, string? EditorId,
+                                 IReadOnlyList<string> Touchers, string? ReferencePlugin,
+                                 IReadOnlyList<TreeNodeDelta> Nodes, string? Error);
+
+    /// <summary>The §4.1 PROJECT=tree batch: per record, the full provider stack (touching list, winner last) with
+    /// each provider diffed against the reference pole — default winner (today's conflict_tree, now a PROJECT
+    /// form), or a named plugin (active or off-order under the one-pole rule; untouched records refuse naming the
+    /// touchers). One captured build for everything (§4.1).</summary>
+    public IReadOnlyList<TreeRow> TreeBatch(
+        IReadOnlyList<string> formids, PoleSpec reference, IReadOnlyList<string>? fields,
+        ArtifactDemand? demand,
+        out string? referenceArm, out bool epochCoversAll, out string? refusal, out string? epoch)
+    {
+        referenceArm = null; epochCoversAll = true; refusal = null;
+        var resolver = Resolver;
+        var view = resolver.Capture();
+        epoch = view.Epoch;
+        if (demand is not null && demand.Epoch != view.Epoch)
+        {
+            refusal = ArtifactEpochMismatch(demand, view.Epoch);
+            return Array.Empty<TreeRow>();
+        }
+        using var session = resolver.OpenSession();
+
+        // Winner reference reads each node off the tree itself; a named reference resolves through the same
+        // pole reader the delta form uses (one-pole rule + untouched contract, off-order cache included).
+        PoleReader? refReader = null;
+        if (reference.Kind is not PoleKind.Winner)
+        {
+            refReader = MakePoleReader(view, session, reference, fields, out referenceArm, out var rCovers, out var rErr);
+            if (rErr is not null) { refusal = "versus: " + rErr; return Array.Empty<TreeRow>(); }
+            epochCoversAll = rCovers;
+        }
+        else referenceArm = "winner";
+
+        var rows = new List<TreeRow>(formids.Count);
+        foreach (var raw in formids)
+        {
+            FormKey fk;
+            try { fk = FormKey.Factory(raw.Trim()); }
+            catch (Exception ex) { rows.Add(new TreeRow(raw?.Trim() ?? "", null, null, Array.Empty<string>(), null, Array.Empty<TreeNodeDelta>(), $"bad FormID '{raw}': {ex.Message}")); continue; }
+
+            var touchers = view.TouchingPlugins(fk) ?? Array.Empty<string>();
+            if (touchers.Count == 0)
+            {
+                rows.Add(new TreeRow(fk.ToString(), null, null, Array.Empty<string>(), null, Array.Empty<TreeNodeDelta>(),
+                                     $"{fk} is not present in the active order — no plugin touches it."));
+                continue;
+            }
+            var tree = ResolveTreePinned(new ViewPin(resolver, view), fk, fields);
+            if (tree is null || tree.Nodes.Count == 0)
+            {
+                rows.Add(new TreeRow(fk.ToString(), null, null, touchers, null, Array.Empty<TreeNodeDelta>(),
+                                     $"the provider bodies of {fk} could not be read."));
+                continue;
+            }
+
+            RecordFields? refFields; string refPlugin;
+            if (refReader is null)
+            {
+                var winnerNode = tree.Winner;
+                refFields = winnerNode.Record; refPlugin = winnerNode.Plugin;
+            }
+            else
+            {
+                var r = refReader(fk, null);
+                if (r.Error is not null)
+                {
+                    rows.Add(new TreeRow(fk.ToString(), tree.Winner.Record.Type, tree.Winner.Record.EditorId,
+                                         touchers, null, Array.Empty<TreeNodeDelta>(), "versus: " + r.Error));
+                    continue;
+                }
+                refFields = r.Fields; refPlugin = r.Pole!.Plugin;
+            }
+
+            var nodes = new List<TreeNodeDelta>(tree.Nodes.Count);
+            foreach (var node in tree.Nodes)
+            {
+                bool isWinner = ReferenceEquals(node, tree.Winner);
+                bool isRef = refReader is null ? isWinner
+                           : string.Equals(node.Plugin, refPlugin, StringComparison.OrdinalIgnoreCase);
+                if (isRef)
+                {
+                    nodes.Add(new TreeNodeDelta(node.Plugin, isWinner, true, Array.Empty<string>(), 0, true, null));
+                    continue;
+                }
+                var d = FieldsDiff.Compare(node.Record, refFields!, referenceLabel: refPlugin);
+                nodes.Add(new TreeNodeDelta(node.Plugin, isWinner, false, d.Deltas, d.AgreedCount, d.Complete, null));
+            }
+            rows.Add(new TreeRow(fk.ToString(), tree.Winner.Record.Type, tree.Winner.Record.EditorId,
+                                 touchers, refPlugin, nodes, null));
+        }
+        return rows;
     }
 
     // ---- cross-plugin query (Q4.9) ----------------------------------------------------------------------

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -2876,19 +2876,27 @@ public sealed class LoadOrderService : IDisposable
         }
         using var session = resolver.OpenSession();
 
+        // Pre-parse the keys so an off-order pole's cache materializes ONLY the requested records (round-3 F2).
+        var parsed = new List<(string Raw, FormKey? Fk, string? ParseError)>(formids.Count);
+        var wanted = new HashSet<FormKey>();
+        foreach (var raw in formids)
+        {
+            try { var fk0 = FormKey.Factory(raw.Trim()); parsed.Add((raw, fk0, null)); wanted.Add(fk0); }
+            catch (Exception ex) { parsed.Add((raw, null, $"bad FormID '{raw}': {ex.Message}")); }
+        }
+
         // Resolve the uniform arms once (named poles; winner/overlay are per-record but uniform in statement).
-        var sReader = MakePoleReader(view, session, subject, fields, out subjectArm, out var sCovers, out var sErr);
+        var sReader = MakePoleReader(view, session, subject, fields, wanted, out subjectArm, out var sCovers, out var sErr);
         if (sErr is not null) { refusal = "source: " + sErr; return Array.Empty<DeltaRow>(); }
-        var rReader = MakePoleReader(view, session, reference, fields, out referenceArm, out var rCovers, out var rErr);
+        var rReader = MakePoleReader(view, session, reference, fields, wanted, out referenceArm, out var rCovers, out var rErr);
         if (rErr is not null) { refusal = "versus: " + rErr; return Array.Empty<DeltaRow>(); }
         epochCoversAll = sCovers && rCovers;
 
         var rows = new List<DeltaRow>(formids.Count);
-        foreach (var raw in formids)
+        foreach (var (raw, fkOpt, parseError) in parsed)
         {
-            FormKey fk;
-            try { fk = FormKey.Factory(raw.Trim()); }
-            catch (Exception ex) { rows.Add(new DeltaRow(raw?.Trim() ?? "", null, null, null, null, null, $"bad FormID '{raw}': {ex.Message}")); continue; }
+            if (parseError is not null) { rows.Add(new DeltaRow(raw?.Trim() ?? "", null, null, null, null, null, parseError)); continue; }
+            var fk = fkOpt!.Value;
 
             var s = sReader(fk, null);
             if (s.Error is not null) { rows.Add(new DeltaRow(fk.ToString(), s.Pole, null, null, null, null, "subject: " + s.Error)); continue; }
@@ -2917,7 +2925,7 @@ public sealed class LoadOrderService : IDisposable
     /// first use) happens here ONCE; per-record work stays in the returned reader. <paramref name="covers"/> is
     /// false when the pole reads content outside the epoch fingerprint (an off-order file; the overlay's INIs).</summary>
     PoleReader MakePoleReader(LoadOrderResolver.IndexView view, LoadOrderResolver.OverlaySession session,
-                              PoleSpec spec, IReadOnlyList<string>? fields,
+                              PoleSpec spec, IReadOnlyList<string>? fields, IReadOnlyCollection<FormKey>? wanted,
                               out string? armStatement, out bool covers, out string? error)
     {
         error = null; covers = true;
@@ -3004,7 +3012,7 @@ public sealed class LoadOrderService : IDisposable
                 // OFF-ORDER arm: open the overlay lazily ONCE; per-record lookups sweep it on first use and
                 // memoise every record seen on the way (one enumeration pass serves the whole batch).
                 covers = false;   // the file's content sits outside the epoch fingerprint (PR #305 coverage rule)
-                var lazy = new OffOrderPoleCache(this, arm, fields);
+                var lazy = new OffOrderPoleCache(this, arm, fields, wanted);
                 return (fk, _) =>
                 {
                     var (rec, oerr) = lazy.Find(fk);
@@ -3128,11 +3136,13 @@ public sealed class LoadOrderService : IDisposable
         readonly LoadOrderService _svc;
         readonly PoleInfo _arm;
         readonly IReadOnlyList<string>? _fields;
+        readonly HashSet<FormKey>? _wanted;   // round-3 F2: materialize ONLY the requested keys, never the file
         Dictionary<FormKey, RecordFields>? _all;
         string? _error;
 
-        public OffOrderPoleCache(LoadOrderService svc, PoleInfo arm, IReadOnlyList<string>? fields)
-        { _svc = svc; _arm = arm; _fields = fields; }
+        public OffOrderPoleCache(LoadOrderService svc, PoleInfo arm, IReadOnlyList<string>? fields,
+                                 IReadOnlyCollection<FormKey>? wanted)
+        { _svc = svc; _arm = arm; _fields = fields; _wanted = wanted is null ? null : new HashSet<FormKey>(wanted); }
 
         public (RecordFields? Fields, string? Error) Find(FormKey fk)
         {
@@ -3153,8 +3163,12 @@ public sealed class LoadOrderService : IDisposable
             {
                 var all = new Dictionary<FormKey, RecordFields>();
                 foreach (var r in ov.EnumerateMajorRecords())
+                {
+                    if (_wanted is not null && !_wanted.Contains(r.FormKey)) continue;   // one pass, only what was asked (F2)
                     if (!all.ContainsKey(r.FormKey))
                         all[r.FormKey] = ReadEngine.ReadFields(r, _fields, ConflictDiffDepth);
+                    if (_wanted is not null && all.Count == _wanted.Count) break;
+                }
                 _all = all;
                 return null;
             }
@@ -3170,7 +3184,7 @@ public sealed class LoadOrderService : IDisposable
     /// cannot touch it, so post IS pre there. INI content sits outside the epoch fingerprint; the caller declares
     /// that on the envelope.</summary>
     public IReadOnlyList<ReadOutcome> OverlayPostBatch(
-        IReadOnlyList<string> formids, IReadOnlyList<string>? fields, int depth,
+        IReadOnlyList<string> formids, IReadOnlyList<string>? fields, int depth, bool resolveNames,
         ArtifactDemand? demand, out string? refusal, out string? refusalEpoch, out string? epoch)
     {
         refusal = null; refusalEpoch = null;
@@ -3210,6 +3224,7 @@ public sealed class LoadOrderService : IDisposable
         // second replay would run every INI line onto the already-mutated copy — unguarded AddEntry appends
         // twice, Mult/AddNumeric compound. One replay per key; duplicates reuse its outcome.
         var replayMemo = new Dictionary<FormKey, ReadOutcome>();
+        Dictionary<FormKey, ResolvedRef>? overlayLinkMemo = null;   // resolve_names cache, one per batch (F3)
         var outcomes = new List<ReadOutcome>(formids.Count);
         foreach (var raw in formids)
         {
@@ -3239,6 +3254,7 @@ public sealed class LoadOrderService : IDisposable
                 }
             }
             var record = ReadEngine.ReadFields(bodyToRead!, fields, depth);
+            if (resolveNames) record = AnnotateLinks(record, view, session, overlayLinkMemo ??= new Dictionary<FormKey, ResolvedRef>());
             var ok = new ReadOutcome(fk, record, winner.Value.WinnerPlugin, winner.Value.WinnerPlugin,
                                      winner.Value.OverrideDepth, null, null)
                      with { Epoch = view.Epoch, Pin = pin };
@@ -3280,21 +3296,29 @@ public sealed class LoadOrderService : IDisposable
 
         // Winner reference reads each node off the tree itself; a named reference resolves through the same
         // pole reader the delta form uses (one-pole rule + untouched contract, off-order cache included).
+        // Pre-parse for the same F2 reason as DeltaBatch: a named off-order reference materializes only these.
+        var parsedT = new List<(string Raw, FormKey? Fk, string? ParseError)>(formids.Count);
+        var wantedT = new HashSet<FormKey>();
+        foreach (var raw in formids)
+        {
+            try { var fk0 = FormKey.Factory(raw.Trim()); parsedT.Add((raw, fk0, null)); wantedT.Add(fk0); }
+            catch (Exception ex) { parsedT.Add((raw, null, $"bad FormID '{raw}': {ex.Message}")); }
+        }
+
         PoleReader? refReader = null;
         if (reference.Kind is not PoleKind.Winner)
         {
-            refReader = MakePoleReader(view, session, reference, fields, out referenceArm, out var rCovers, out var rErr);
+            refReader = MakePoleReader(view, session, reference, fields, wantedT, out referenceArm, out var rCovers, out var rErr);
             if (rErr is not null) { refusal = "versus: " + rErr; return Array.Empty<TreeRow>(); }
             epochCoversAll = rCovers;
         }
         else referenceArm = "winner";
 
         var rows = new List<TreeRow>(formids.Count);
-        foreach (var raw in formids)
+        foreach (var (raw, fkOpt, parseError) in parsedT)
         {
-            FormKey fk;
-            try { fk = FormKey.Factory(raw.Trim()); }
-            catch (Exception ex) { rows.Add(new TreeRow(raw?.Trim() ?? "", null, null, Array.Empty<string>(), null, Array.Empty<TreeNodeDelta>(), $"bad FormID '{raw}': {ex.Message}")); continue; }
+            if (parseError is not null) { rows.Add(new TreeRow(raw?.Trim() ?? "", null, null, Array.Empty<string>(), null, Array.Empty<TreeNodeDelta>(), parseError)); continue; }
+            var fk = fkOpt!.Value;
 
             var touchers = view.TouchingPlugins(fk) ?? Array.Empty<string>();
             if (touchers.Count == 0)
@@ -3549,7 +3573,6 @@ public sealed class LoadOrderService : IDisposable
             }
             // Walk down: the provider is the first node NOT forwarding this category.
             var cur = seed;
-            var curKey = seedFk;
             string? note = null; string? provKey = null; string? provEid = null;
             var hops = new HashSet<FormKey> { seedFk };
             while (true)
@@ -3566,7 +3589,7 @@ public sealed class LoadOrderService : IDisposable
                 { note = $"template target {nextKey} is a {RecordNaming.StripOverlay(body.GetType().Name)}, not an NPC or leveled actor"; break; }
                 if (!npc.Configuration.TemplateFlags.HasFlag(flag))
                 { provKey = nextKey.ToString(); provEid = npc.EditorID; break; }
-                cur = npc; curKey = nextKey;
+                cur = npc;
             }
             report.Add(new NpcTemplateCategory(name, true, provKey, provEid, note));
         }
@@ -3606,6 +3629,7 @@ public sealed class LoadOrderService : IDisposable
         // order to EVERY occurrence — a dictionary keyed on FormKey kept only the last row's index, and the
         // earlier duplicates rendered a fabricated "merge could not be computed" failure.
         var dialRows = new List<(int Index, FormKey Fk)>();
+        var dialSeen = new HashSet<FormKey>();
         foreach (var raw in formids)
         {
             FormKey fk;
@@ -3636,7 +3660,7 @@ public sealed class LoadOrderService : IDisposable
             dialRows.Add((rows.Count, fk));
             rows.Add(new InfoOrderRow(fk.ToString(), RecordNaming.StripOverlay(body.GetType().Name), body.EditorID,
                                       win.Value.WinnerPlugin, null, null));
-            if (!dialFks.Contains(fk)) dialFks.Add(fk);
+            if (dialSeen.Add(fk)) dialFks.Add(fk);
         }
         if (dialFks.Count > 0)
         {
@@ -3793,7 +3817,6 @@ public sealed class LoadOrderService : IDisposable
         }
         catch (ArgumentException ex) { return CrossQueryOutcome.Fail(ex.Message); }   // unknown type
 
-        IReadOnlyList<Type>? typesForSet = types;   // the set-alone branch type-checks bodies directly
         var keys = new List<FormKey>();
         var sources = new List<string?>();                                    // parallel to keys: the plugin whose body matched (null ⇒ winner), so the render displays the SAME body it filtered
         List<string?>? matched = multiTarget ? new() : null;                  // parallel to keys: which target(s) each hit referenced (multi-target references= un-merge); null when 0/1 target
@@ -3859,7 +3882,6 @@ public sealed class LoadOrderService : IDisposable
                             if (hitSet.Count == 0) continue;
                             if (multiTarget && groups is null) hitTargets = references!.Where(hitSet.Contains).Distinct().ToList();
                         }
-                        if (typesForSet is not null && !typesForSet.Any(t => t.IsInstanceOfType(body))) continue;
                         if (predicate is not null && !predicate.Matches(body))
                         {
                             if (predicate.FatalError is not null) break;

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -3159,6 +3159,82 @@ public sealed class LoadOrderService : IDisposable
         }
     }
 
+    /// <summary>The list-driven `records` read under the SkyPatcher-overlay POST source: each record's winner is
+    /// replayed through the discovered INI layer (the skypatcher_read core) and the REPLAYED body is what the
+    /// fields/everything/summary forms read, at the caller's own depth. Declared rule (envelope-carried, not
+    /// per-item silence): a record whose type SkyPatcher cannot patch reads as its plain winner — the layer
+    /// cannot touch it, so post IS pre there. INI content sits outside the epoch fingerprint; the caller declares
+    /// that on the envelope.</summary>
+    public IReadOnlyList<ReadOutcome> OverlayPostBatch(
+        IReadOnlyList<string> formids, IReadOnlyList<string>? fields, int depth,
+        ArtifactDemand? demand, out string? refusal, out string? refusalEpoch, out string? epoch)
+    {
+        refusal = null; refusalEpoch = null;
+        var resolver = Resolver;
+        var view = resolver.Capture();
+        epoch = view.Epoch;
+        if (demand is not null && demand.Epoch != view.Epoch)
+        {
+            refusal = ArtifactEpochMismatch(demand, view.Epoch);
+            refusalEpoch = view.Epoch;
+            return Array.Empty<ReadOutcome>();
+        }
+        var pin = new ViewPin(resolver, view);
+        using var session = resolver.OpenSession();
+
+        SkyPatcherFieldMap fieldMap; SkyPatcherCatalog catalog; SkyPatcherDiscovery.LayerScan scan;
+        SkyrimMod scratch; SkyPatcherOverlay.IFormResolver formResolver;
+        try
+        {
+            AssetResolver.AssetView assets;
+            lock (_gate) { assets = Assets.Capture(); }
+            fieldMap = SkyPatcherFieldMap.Load();
+            catalog = SkyPatcherCatalog.Load();
+            scan = SkyPatcherDiscovery.Scan(assets, catalog, view.ContainsPlugin, _skyPatcherParseCache);
+            scratch = new SkyrimMod(SkyPatcherScratchKey, SkyrimRelease.SkyrimSE);
+            formResolver = new SkyPatcherServiceResolver(this, view, session);
+        }
+        catch (Exception ex)
+        {
+            refusal = $"the SkyPatcher layer could not be discovered for the overlay source: {ex.Message}";
+            refusalEpoch = view.Epoch;
+            return Array.Empty<ReadOutcome>();
+        }
+        var linesCache = new Dictionary<string, IReadOnlyList<SkyPatcherOverlay.OrderedLine>>(StringComparer.OrdinalIgnoreCase);
+
+        var outcomes = new List<ReadOutcome>(formids.Count);
+        foreach (var raw in formids)
+        {
+            FormKey fk;
+            try { fk = FormKey.Factory(raw.Trim()); }
+            catch (Exception ex) { outcomes.Add(ReadOutcome.Fail(default, $"bad FormID '{raw}': {ex.Message}")); continue; }
+            var winner = view.ResolveWinner(fk);
+            if (winner is null)
+            {
+                outcomes.Add(ReadOutcome.Fail(fk, $"FormID {fk} is not present in the load order ({view.PluginCount} plugins).")
+                             with { Epoch = view.Epoch, Pin = pin });
+                continue;
+            }
+            var r = ReplaySkyPatcher(view, session, scan, catalog, fieldMap, scratch, formResolver, fk, linesCache);
+            IMajorRecordGetter? bodyToRead = r.Copy;
+            if (r.Error is not null)
+            {
+                if (r.Error.Contains("not a SkyPatcher-patchable type"))
+                    bodyToRead = view.GetRecord(session, winner.Value.WinnerPlugin, fk);   // post IS pre — the declared rule
+                if (bodyToRead is null)
+                {
+                    outcomes.Add(ReadOutcome.Fail(fk, r.Error) with { Epoch = view.Epoch, Pin = pin });
+                    continue;
+                }
+            }
+            var record = ReadEngine.ReadFields(bodyToRead!, fields, depth);
+            outcomes.Add(new ReadOutcome(fk, record, winner.Value.WinnerPlugin, winner.Value.WinnerPlugin,
+                                         winner.Value.OverrideDepth, null, null)
+                         with { Epoch = view.Epoch, Pin = pin });
+        }
+        return outcomes;
+    }
+
     /// <summary>One provider's node in a §4.1 PROJECT=tree row: its position in the touching list plus its delta
     /// against the row's reference pole (empty deltas + Complete ⇒ genuinely identical to the reference).</summary>
     public sealed record TreeNodeDelta(string Plugin, bool IsWinner, bool IsReference,

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -3337,6 +3337,230 @@ public sealed class LoadOrderService : IDisposable
         return rows;
     }
 
+    // ---- W2 PR 2: the §3 traversal construct (walk=) ----------------------------------------------------
+
+    /// <summary>One record the walk reached: identity + provenance (<see cref="PulledBy"/> — the parent node's
+    /// label, the ClosureItem posture) + whether the walk ENTERED it (expanded) or recorded it as a boundary
+    /// (kept: an exclusion stop, the depth cap, an unresolved link — the reason rides in <see cref="Note"/>).</summary>
+    public sealed record WalkNodeRow(string Key, string? Type, string? EditorId, int Depth,
+                                     string PulledBy, string Status, string? Note);
+
+    /// <summary>The NPC_ TemplateFlags typed interpreter (§3.3 — registry entry #1, and deliberately the ONLY
+    /// entry until a gap report demands a second): per inheritance category, whether the seed INHERITS it (its
+    /// own local data masked) and which record in the template chain actually provides it.</summary>
+    public sealed record NpcTemplateCategory(string Category, bool InheritedAtSeed,
+                                             string? ProviderKey, string? ProviderEditorId, string? Note);
+
+    /// <summary>One seed's walk: the reached nodes in BFS order with provenance, recorded cycles (named-follow
+    /// chains only — a closure walk dedupes on its visited set, the copy engine's own posture), the truncation
+    /// note when a cap cut the walk (the read posture: keep what was proved, say what wasn't), and — for an NPC_
+    /// seed under follow="Template" — the per-category inheritance report.</summary>
+    public sealed record WalkSeedResult(string Seed, string? Type, string? EditorId,
+                                        IReadOnlyList<WalkNodeRow> Nodes, IReadOnlyList<string> Cycles,
+                                        string? TruncationNote, IReadOnlyList<NpcTemplateCategory>? TemplateReport,
+                                        string? Error);
+
+    /// <summary>The §3 FORWARD walk over the winner link graph, per seed off ONE captured build. The edge unit is
+    /// the FORM LINK; within-record navigation stays PROJECT's path grammar (§3's declared seam). seed_paths
+    /// scope the FIRST hop (default: every link); follow scopes every LATER hop (default "*" = closure via the
+    /// generic EnumerateFormLinks — by construction, no per-type list; a named path = a restricted chain).
+    /// Exclusions are DATA handed in by the caller: stop prunes (recorded as a boundary), refuse fails the whole
+    /// call loud naming the seed and pull chain (the Race-refusal posture). Caps are the READ posture: an
+    /// explicit truncation note, never a silent cut.</summary>
+    public IReadOnlyList<WalkSeedResult> WalkForwardBatch(
+        IReadOnlyList<string> seeds, IReadOnlyList<string>? seedPaths, string? follow,
+        int depth, int maxNodes, IReadOnlyList<(string Match, bool Refuse)> exclusions,
+        ArtifactDemand? demand, out string? refusal, out string? epoch)
+    {
+        refusal = null;
+        var resolver = Resolver;
+        var view = resolver.Capture();
+        epoch = view.Epoch;
+        if (demand is not null && demand.Epoch != view.Epoch)
+        {
+            refusal = ArtifactEpochMismatch(demand, view.Epoch);
+            return Array.Empty<WalkSeedResult>();
+        }
+        using var session = resolver.OpenSession();
+
+        string[]? followSegs = null;
+        bool closure = string.IsNullOrWhiteSpace(follow) || follow!.Trim() == "*";
+        if (!closure)
+        {
+            followSegs = follow!.Trim().Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (followSegs.Length == 0) { refusal = $"walk.follow '{follow}' is not a usable field path."; return Array.Empty<WalkSeedResult>(); }
+        }
+
+        var bodyCache = new Dictionary<FormKey, IMajorRecordGetter?>();
+        IMajorRecordGetter? Fetch(FormKey k)
+        {
+            if (bodyCache.TryGetValue(k, out var c)) return c;
+            IMajorRecordGetter? g = view.ResolveWinner(k) is { } w ? view.GetRecord(session, w.WinnerPlugin, k) : null;
+            bodyCache[k] = g;
+            return g;
+        }
+        static string TypeOf(IMajorRecordGetter b) => RecordNaming.StripOverlay(b.GetType().Name);
+        List<FormKey> LinksOf(IMajorRecordGetter body, string[]? segs, out string? note)
+        {
+            note = null;
+            if (segs is null)
+            {
+                var seen = new HashSet<FormKey>();
+                var list = new List<FormKey>();
+                if (body is Mutagen.Bethesda.Plugins.Records.IFormLinkContainerGetter flc)
+                    foreach (var link in flc.EnumerateFormLinks())
+                        if (!link.FormKey.IsNull && seen.Add(link.FormKey)) list.Add(link.FormKey);
+                return list;
+            }
+            var (links, n) = ReadEngine.CollectLinksAt(body, segs);
+            note = n;
+            return links ?? new List<FormKey>();
+        }
+
+        var results = new List<WalkSeedResult>(seeds.Count);
+        foreach (var raw in seeds)
+        {
+            FormKey seedFk;
+            try { seedFk = FormKey.Factory(raw.Trim()); }
+            catch (Exception ex) { results.Add(new WalkSeedResult(raw?.Trim() ?? "", null, null, Array.Empty<WalkNodeRow>(), Array.Empty<string>(), null, null, $"bad FormID '{raw}': {ex.Message}")); continue; }
+            var seedBody = Fetch(seedFk);
+            if (seedBody is null)
+            {
+                results.Add(new WalkSeedResult(seedFk.ToString(), null, null, Array.Empty<WalkNodeRow>(), Array.Empty<string>(), null, null,
+                                               $"{seedFk} is not present in the active order — nothing to walk from."));
+                continue;
+            }
+            var seedType = TypeOf(seedBody);
+            var seedLabel = $"{seedType} {seedFk} ({seedBody.EditorID ?? "<no editorid>"})";
+
+            var nodes = new List<WalkNodeRow>();
+            var cycles = new List<string>();
+            string? truncation = null;
+            var visited = new HashSet<FormKey> { seedFk };
+            var queue = new Queue<(FormKey Key, int Depth, string PulledBy)>();
+
+            // First hop: seed_paths (each path's links) or every link on the seed.
+            if (seedPaths is { Count: > 0 })
+            {
+                foreach (var p in seedPaths)
+                {
+                    var segs = p.Trim().Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                    if (segs.Length == 0) continue;
+                    var links = LinksOf(seedBody, segs, out var note);
+                    if (links.Count == 0 && note is not null)
+                        nodes.Add(new WalkNodeRow($"(seed path '{p}')", null, null, 0, seedLabel, "no links", note));   // a wrong path fails LOUD in the rows (Q3)
+                    foreach (var l in links) queue.Enqueue((l, 1, $"{seedLabel}.{p}"));
+                }
+            }
+            else
+            {
+                foreach (var l in LinksOf(seedBody, null, out _)) queue.Enqueue((l, 1, seedLabel));
+            }
+
+            string? refuseError = null;
+            while (queue.Count > 0 && refuseError is null)
+            {
+                var (key, d, pulledBy) = queue.Dequeue();
+                if (key.IsNull) continue;
+                if (!visited.Add(key))
+                {
+                    // A named-follow walk is a linear chain per seed — a revisit IS a cycle, recorded and named
+                    // (never looped, never silently stopped — §3.1). Closure walks dedupe on the visited set.
+                    if (followSegs is not null) cycles.Add($"{pulledBy} -> {key} (already on this chain)");
+                    continue;
+                }
+                if (nodes.Count >= maxNodes)
+                {
+                    truncation = $"walk truncated: the {maxNodes}-node cap was reached — what is listed IS reached and proved; raise walk.max_nodes to walk further.";
+                    break;
+                }
+                var body = Fetch(key);
+                if (body is null)
+                {
+                    nodes.Add(new WalkNodeRow(key.ToString(), null, null, d, pulledBy, "kept",
+                                              "unresolved — no active plugin defines this target (a missing endpoint)"));
+                    continue;
+                }
+                var type = TypeOf(body);
+                var excl = exclusions.FirstOrDefault(x => x.Match.Equals(type, StringComparison.OrdinalIgnoreCase));
+                if (excl.Match is not null)
+                {
+                    if (excl.Refuse) { refuseError = $"the walk reached a {type} ({key}, via {pulledBy}) — a node class this call excludes with severity 'refuse'. Nothing is returned for this call."; break; }
+                    nodes.Add(new WalkNodeRow(key.ToString(), type, body.EditorID, d, pulledBy, "kept", $"excluded ({type}, severity stop) — recorded as a boundary, not entered"));
+                    continue;
+                }
+                bool atCap = d >= depth;
+                nodes.Add(new WalkNodeRow(key.ToString(), type, body.EditorID, d, pulledBy,
+                                          atCap ? "kept" : "expanded",
+                                          atCap ? $"at the walk.depth cap ({depth}) — not entered" : null));
+                if (atCap)
+                {
+                    truncation ??= $"walk reached its depth cap ({depth}) on at least one chain — nodes at the cap are recorded, not entered; raise walk.depth to walk deeper.";
+                    continue;
+                }
+                var label = $"{type} {key} ({body.EditorID ?? "<no editorid>"})";
+                foreach (var l in LinksOf(body, followSegs, out _))
+                    if (!l.IsNull) queue.Enqueue((l, d + 1, label));
+            }
+            if (refuseError is not null)
+            {
+                refusal = refuseError;
+                return Array.Empty<WalkSeedResult>();
+            }
+
+            IReadOnlyList<NpcTemplateCategory>? templateReport = null;
+            if (followSegs is { Length: 1 } && followSegs[0].Equals("Template", StringComparison.OrdinalIgnoreCase)
+                && seedBody is INpcGetter seedNpc)
+                templateReport = NpcTemplateReport(Fetch, seedNpc, seedFk);
+
+            results.Add(new WalkSeedResult(seedFk.ToString(), seedType, seedBody.EditorID, nodes, cycles, truncation, templateReport, null));
+        }
+        return results;
+    }
+
+    /// <summary>The NPC_ TemplateFlags interpreter (§3.3, registry entry #1): a SET flag means the category is
+    /// INHERITED — the seed's own local data for it is masked; the provider is the first record down the template
+    /// chain whose flag for that category is CLEAR (its own data is active). A chain ending in a leveled actor
+    /// resolves at runtime; a broken or missing link is reported, never guessed (Q3).</summary>
+    static IReadOnlyList<NpcTemplateCategory> NpcTemplateReport(Func<FormKey, IMajorRecordGetter?> fetch,
+                                                                INpcGetter seed, FormKey seedFk)
+    {
+        var report = new List<NpcTemplateCategory>();
+        foreach (NpcConfiguration.TemplateFlag flag in Enum.GetValues(typeof(NpcConfiguration.TemplateFlag)))
+        {
+            var name = flag.ToString();
+            if (!seed.Configuration.TemplateFlags.HasFlag(flag))
+            {
+                report.Add(new NpcTemplateCategory(name, false, seedFk.ToString(), seed.EditorID,
+                                                   "local data ACTIVE (flag clear)"));
+                continue;
+            }
+            // Walk down: the provider is the first node NOT forwarding this category.
+            var cur = seed;
+            var curKey = seedFk;
+            string? note = null; string? provKey = null; string? provEid = null;
+            var hops = new HashSet<FormKey> { seedFk };
+            while (true)
+            {
+                var t = cur.Template;
+                if (t is null || t.IsNull) { note = "flag SET but the template link is empty — the category inherits from nothing (worth a look)"; break; }
+                var nextKey = t.FormKey;
+                if (!hops.Add(nextKey)) { note = $"template chain CYCLES at {nextKey} — no provider is reachable"; break; }
+                var body = fetch(nextKey);
+                if (body is null) { note = $"template target {nextKey} is unresolved — the chain is broken here"; break; }
+                if (body is ILeveledNpcGetter lvln)
+                { provKey = nextKey.ToString(); provEid = lvln.EditorID; note = "a LEVELED actor — the concrete provider is rolled at runtime"; break; }
+                if (body is not INpcGetter npc)
+                { note = $"template target {nextKey} is a {RecordNaming.StripOverlay(body.GetType().Name)}, not an NPC or leveled actor"; break; }
+                if (!npc.Configuration.TemplateFlags.HasFlag(flag))
+                { provKey = nextKey.ToString(); provEid = npc.EditorID; break; }
+                cur = npc; curKey = nextKey;
+            }
+            report.Add(new NpcTemplateCategory(name, true, provKey, provEid, note));
+        }
+        return report;
+    }
+
     // ---- W2 PR 2: the info_order PROJECT form (§6.1 F1 split — validate_dialogue's class 8) --------------
 
     /// <summary>One topic's effective-INFO-order row: the merged sequence with its honesty gates

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -3069,10 +3069,14 @@ public sealed class LoadOrderService : IDisposable
         SkyPatcherDiscovery.LayerScan? scan = null; SkyrimMod? scratch = null;
         SkyPatcherOverlay.IFormResolver? formResolver = null;
         Dictionary<string, IReadOnlyList<SkyPatcherOverlay.OrderedLine>>? linesCache = null;
+        // Per-key memo (review F7): the scratch mod is shared across the reader's lifetime, so a repeated key's
+        // second replay would re-apply every INI line onto the already-mutated copy. One replay per key.
+        var postMemo = new Dictionary<FormKey, PoleReading>();
         string? setupError = null;
         return (fk, _) =>
         {
             if (setupError is not null) return new PoleReading(null, null, null, setupError);
+            if (postMemo.TryGetValue(fk, out var memoized)) return memoized;
             if (scan is null)
             {
                 try
@@ -3101,16 +3105,16 @@ public sealed class LoadOrderService : IDisposable
                     var w = view.ResolveWinner(fk);
                     var body = w is null ? null : view.GetRecord(session, w.Value.WinnerPlugin, fk);
                     if (body is not null)
-                        return new PoleReading(ReadEngine.ReadFields(body, fields, ConflictDiffDepth),
+                        return postMemo[fk] = new PoleReading(ReadEngine.ReadFields(body, fields, ConflictDiffDepth),
                                                new DiffPole(w!.Value.WinnerPlugin,
                                                             "skypatcher overlay (post) = winner — type not SkyPatcher-patchable, the layer cannot touch it",
                                                             true, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID), null, null);
                 }
-                return new PoleReading(null, null, null, r.Error);
+                return postMemo[fk] = new PoleReading(null, null, null, r.Error);
             }
             int applied = r.Folders.Where(f => f.Result is not null).Sum(f => f.Result!.Applied.Count);
             var post = ReadEngine.ReadFields(r.Copy!, fields, ConflictDiffDepth);
-            return new PoleReading(post,
+            return postMemo[fk] = new PoleReading(post,
                 new DiffPole(r.WinnerPlugin!, $"skypatcher overlay (post) — {applied} op(s) applied onto the winner", true,
                              post.Type, r.EditorId), null, null);
         };
@@ -3202,17 +3206,23 @@ public sealed class LoadOrderService : IDisposable
         }
         var linesCache = new Dictionary<string, IReadOnlyList<SkyPatcherOverlay.OrderedLine>>(StringComparer.OrdinalIgnoreCase);
 
+        // Per-batch replay memo (review F7): the scratch mod is shared across the batch, so a DUPLICATED key's
+        // second replay would run every INI line onto the already-mutated copy — unguarded AddEntry appends
+        // twice, Mult/AddNumeric compound. One replay per key; duplicates reuse its outcome.
+        var replayMemo = new Dictionary<FormKey, ReadOutcome>();
         var outcomes = new List<ReadOutcome>(formids.Count);
         foreach (var raw in formids)
         {
             FormKey fk;
             try { fk = FormKey.Factory(raw.Trim()); }
             catch (Exception ex) { outcomes.Add(ReadOutcome.Fail(default, $"bad FormID '{raw}': {ex.Message}")); continue; }
+            if (replayMemo.TryGetValue(fk, out var memoized)) { outcomes.Add(memoized); continue; }
             var winner = view.ResolveWinner(fk);
             if (winner is null)
             {
-                outcomes.Add(ReadOutcome.Fail(fk, $"FormID {fk} is not present in the load order ({view.PluginCount} plugins).")
-                             with { Epoch = view.Epoch, Pin = pin });
+                var miss = ReadOutcome.Fail(fk, $"FormID {fk} is not present in the load order ({view.PluginCount} plugins).")
+                           with { Epoch = view.Epoch, Pin = pin };
+                replayMemo[fk] = miss; outcomes.Add(miss);
                 continue;
             }
             var r = ReplaySkyPatcher(view, session, scan, catalog, fieldMap, scratch, formResolver, fk, linesCache);
@@ -3223,14 +3233,16 @@ public sealed class LoadOrderService : IDisposable
                     bodyToRead = view.GetRecord(session, winner.Value.WinnerPlugin, fk);   // post IS pre — the declared rule
                 if (bodyToRead is null)
                 {
-                    outcomes.Add(ReadOutcome.Fail(fk, r.Error) with { Epoch = view.Epoch, Pin = pin });
+                    var fail = ReadOutcome.Fail(fk, r.Error) with { Epoch = view.Epoch, Pin = pin };
+                    replayMemo[fk] = fail; outcomes.Add(fail);
                     continue;
                 }
             }
             var record = ReadEngine.ReadFields(bodyToRead!, fields, depth);
-            outcomes.Add(new ReadOutcome(fk, record, winner.Value.WinnerPlugin, winner.Value.WinnerPlugin,
-                                         winner.Value.OverrideDepth, null, null)
-                         with { Epoch = view.Epoch, Pin = pin });
+            var ok = new ReadOutcome(fk, record, winner.Value.WinnerPlugin, winner.Value.WinnerPlugin,
+                                     winner.Value.OverrideDepth, null, null)
+                     with { Epoch = view.Epoch, Pin = pin };
+            replayMemo[fk] = ok; outcomes.Add(ok);
         }
         return outcomes;
     }
@@ -3590,7 +3602,10 @@ public sealed class LoadOrderService : IDisposable
 
         var rows = new List<InfoOrderRow>(formids.Count);
         var dialFks = new List<FormKey>();
-        var rowIndexOf = new Dictionary<FormKey, int>();
+        // Per ROW, not per FormKey (review F6): a duplicated DIAL key in the input must attach the computed
+        // order to EVERY occurrence — a dictionary keyed on FormKey kept only the last row's index, and the
+        // earlier duplicates rendered a fabricated "merge could not be computed" failure.
+        var dialRows = new List<(int Index, FormKey Fk)>();
         foreach (var raw in formids)
         {
             FormKey fk;
@@ -3618,15 +3633,15 @@ public sealed class LoadOrderService : IDisposable
                     "For a quest's topics, select them by composition: types=[\"DIAL\"] where=[\"Quest = " + fk + "\"]."));
                 continue;
             }
-            rowIndexOf[fk] = rows.Count;
+            dialRows.Add((rows.Count, fk));
             rows.Add(new InfoOrderRow(fk.ToString(), RecordNaming.StripOverlay(body.GetType().Name), body.EditorID,
                                       win.Value.WinnerPlugin, null, null));
-            dialFks.Add(fk);
+            if (!dialFks.Contains(fk)) dialFks.Add(fk);
         }
         if (dialFks.Count > 0)
         {
             var orders = DialogueValidate.InfoOrders(view, session, dialFks);
-            foreach (var (fk, idx) in rowIndexOf.Select(kv => (kv.Key, kv.Value)))
+            foreach (var (idx, fk) in dialRows)
                 if (orders.TryGetValue(fk, out var io)) rows[idx] = rows[idx] with { Order = io };
         }
         return rows;
@@ -3794,7 +3809,10 @@ public sealed class LoadOrderService : IDisposable
         var unscannableSamples = new List<string>();
 
         HashSet<FormKey>? setFilter = hasFormidSet ? new HashSet<FormKey>(formidSet!) : null;
-        if (!hasType && !hasPlugins && hasFormidSet && !conflictsOnly)        // the formid set ALONE is the universe: per-key winner fetch
+        // The set-alone branch also owns conflicts_only + formidSet (its in-loop touching-count test): routing
+        // that pair to the index-only else-branch dropped every parsed body filter silently (review F1 — the
+        // predicate/references/editorid_contains were never evaluated, a Q3 silent wrong answer).
+        if (!hasType && !hasPlugins && hasFormidSet)                          // the formid set ALONE is the universe: per-key winner fetch
         {
             LoadOrderResolver.OverlaySession? setSession = null;
             try

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -3337,6 +3337,77 @@ public sealed class LoadOrderService : IDisposable
         return rows;
     }
 
+    // ---- W2 PR 2: the info_order PROJECT form (§6.1 F1 split — validate_dialogue's class 8) --------------
+
+    /// <summary>One topic's effective-INFO-order row: the merged sequence with its honesty gates
+    /// (Complete / MovesComputed / BaselineTrusted ride inside <see cref="Order"/>). Error non-null ⇒ per-item
+    /// refusal (bad FormID, absent record, or a non-DIAL target — typed, naming the actual type).</summary>
+    public sealed record InfoOrderRow(string Formid, string? Type, string? EditorId, string? WinnerPlugin,
+                                      InfoOrderView? Order, string? Error);
+
+    /// <summary>The records form='info_order' batch: per DIAL topic, the effective MERGED INFO order across every
+    /// touching plugin (the game's walk order — the "why does the wrong line play" diagnostic, #275), off ONE
+    /// captured build. Epoch-stamped honestly: this form reads plugin records through the index only (no VFS or
+    /// INI layer). A non-DIAL FormID is a per-item typed refusal — a quest's topics are selected by composition
+    /// (types=["DIAL"] where=["Quest = &lt;quest formid&gt;"]), not by silently fanning out here.</summary>
+    public IReadOnlyList<InfoOrderRow> InfoOrderBatch(IReadOnlyList<string> formids, ArtifactDemand? demand,
+                                                      out string? refusal, out string? epoch)
+    {
+        refusal = null;
+        var resolver = Resolver;
+        var view = resolver.Capture();
+        epoch = view.Epoch;
+        if (demand is not null && demand.Epoch != view.Epoch)
+        {
+            refusal = ArtifactEpochMismatch(demand, view.Epoch);
+            return Array.Empty<InfoOrderRow>();
+        }
+        using var session = resolver.OpenSession();
+
+        var rows = new List<InfoOrderRow>(formids.Count);
+        var dialFks = new List<FormKey>();
+        var rowIndexOf = new Dictionary<FormKey, int>();
+        foreach (var raw in formids)
+        {
+            FormKey fk;
+            try { fk = FormKey.Factory(raw.Trim()); }
+            catch (Exception ex) { rows.Add(new InfoOrderRow(raw?.Trim() ?? "", null, null, null, null, $"bad FormID '{raw}': {ex.Message}")); continue; }
+            var win = view.ResolveWinner(fk);
+            if (win is null)
+            {
+                rows.Add(new InfoOrderRow(fk.ToString(), null, null, null, null,
+                                          $"{fk} is not present in the active order."));
+                continue;
+            }
+            var body = view.GetRecord(session, win.Value.WinnerPlugin, fk);
+            if (body is null)
+            {
+                rows.Add(new InfoOrderRow(fk.ToString(), null, null, win.Value.WinnerPlugin, null,
+                                          $"the winner body of {fk} could not be read from '{win.Value.WinnerPlugin}'."));
+                continue;
+            }
+            if (body is not Mutagen.Bethesda.Skyrim.IDialogTopicGetter)
+            {
+                var typeName = RecordNaming.StripOverlay(body.GetType().Name);
+                rows.Add(new InfoOrderRow(fk.ToString(), typeName, body.EditorID, win.Value.WinnerPlugin, null,
+                    $"{fk} is a {typeName}, and the info_order form renders the merged INFO sequence of a DIALOGUE TOPIC (DIAL). " +
+                    "For a quest's topics, select them by composition: types=[\"DIAL\"] where=[\"Quest = " + fk + "\"]."));
+                continue;
+            }
+            rowIndexOf[fk] = rows.Count;
+            rows.Add(new InfoOrderRow(fk.ToString(), RecordNaming.StripOverlay(body.GetType().Name), body.EditorID,
+                                      win.Value.WinnerPlugin, null, null));
+            dialFks.Add(fk);
+        }
+        if (dialFks.Count > 0)
+        {
+            var orders = DialogueValidate.InfoOrders(view, session, dialFks);
+            foreach (var (fk, idx) in rowIndexOf.Select(kv => (kv.Key, kv.Value)))
+                if (orders.TryGetValue(fk, out var io)) rows[idx] = rows[idx] with { Order = io };
+        }
+        return rows;
+    }
+
     // ---- cross-plugin query (Q4.9) ----------------------------------------------------------------------
 
     /// <summary>Scan the order for records matching a filter (housecarl_cross_plugin_query). A SINGLE enumeration

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -3654,13 +3654,19 @@ public sealed class LoadOrderService : IDisposable
         => CrossQuery(type is null ? null : new[] { type }, references, editoridContains, conflictsOnly, plugins, where,
                       limit, definedIn, groupBy, offset, whereSource, artifactDemands);
 
+    /// <summary>W2 PR 2 — the formids×scan composition: <paramref name="formidSet"/> intersects the selection
+    /// with an explicit identity set (inline or artifact-fed). With a body-bearing scope it is a cheap pre-filter
+    /// on the stream; ALONE it IS the scan universe — each key's winner body is fetched and filtered, so a where=
+    /// over a formid set needs no types=/plugins= bound (the set is the bound).</summary>
+
     /// <summary>The W2 set-valued-types overload (`records` types= is a SET; one is a degenerate set — SPEC §2.2).
     /// Each entry resolves through the same <see cref="ResolveTypeFilter"/> the singular form used; the scan streams
     /// the UNION of the resolved type groups.</summary>
     public CrossQueryOutcome CrossQuery(IReadOnlyList<string>? typeSet, IReadOnlyList<FormKey>? references, string? editoridContains,
                                         bool conflictsOnly, IReadOnlyList<string>? plugins, IReadOnlyList<string>? where, int limit,
                                         bool definedIn = false, string? groupBy = null, int offset = 0, string? whereSource = null,
-                                        IReadOnlyList<ArtifactDemand>? artifactDemands = null)
+                                        IReadOnlyList<ArtifactDemand>? artifactDemands = null,
+                                        IReadOnlyList<FormKey>? formidSet = null)
     {
         var resolver = Resolver;
         var view = resolver.Capture();          // ONE build for the SCAN and every per-match fill it makes (HCBR-2026-06-11-02)
@@ -3669,10 +3675,13 @@ public sealed class LoadOrderService : IDisposable
         bool hasWhere = where is { Count: > 0 };
         bool hasReferences = references is { Count: > 0 };
         bool bodyFilter = hasReferences || !string.IsNullOrEmpty(editoridContains) || hasWhere;
+        bool hasFormidSet = formidSet is { Count: > 0 };
 
-        if (!hasType && !conflictsOnly && !hasPlugins && !bodyFilter)
+        if (!hasType && !conflictsOnly && !hasPlugins && !bodyFilter && !hasFormidSet)
             return CrossQueryOutcome.Fail("cross_plugin_query needs at least one of: type=, conflicts_only=true, editorid_contains=, references=, where=, or plugins=.");
-        if (bodyFilter && !hasType && !hasPlugins)
+        // A formid set is itself a bound: the scan touches at most those keys, so a body filter over one needs no
+        // types=/plugins= (the W2 formids×scan composition).
+        if (bodyFilter && !hasType && !hasPlugins && !hasFormidSet)
             return CrossQueryOutcome.Fail("editorid_contains/references/where is a body scan and must be combined with type= or plugins= to bound it (conflicts_only= alone is not enough — an unbounded body scan over the whole order is refused). A global reverse-reference index is a future capability.");
 
         // defined_in= keeps only records DEFINED in the scoped plugins (origin FormKey), the catalogue-scope semantics
@@ -3728,7 +3737,7 @@ public sealed class LoadOrderService : IDisposable
             groupBy = groupBy.Trim().ToLowerInvariant();
             if (groupBy is not ("winner" or "type" or "defined_in"))
                 return CrossQueryOutcome.Fail($"group_by='{groupBy}' is not a known aggregation key — use 'winner', 'type', or 'defined_in'.");
-            if (groupBy == "type" && !hasType && !hasPlugins)
+            if (groupBy == "type" && !hasType && !hasPlugins && !hasFormidSet)
                 return CrossQueryOutcome.Fail("group_by=type needs each match's type, which requires a body-bearing scope — add type= or plugins= (winner/defined_in group without a body).");
         }
         var refSet = hasReferences ? new HashSet<FormKey>(references!) : null;
@@ -3769,10 +3778,11 @@ public sealed class LoadOrderService : IDisposable
         }
         catch (ArgumentException ex) { return CrossQueryOutcome.Fail(ex.Message); }   // unknown type
 
+        IReadOnlyList<Type>? typesForSet = types;   // the set-alone branch type-checks bodies directly
         var keys = new List<FormKey>();
         var sources = new List<string?>();                                    // parallel to keys: the plugin whose body matched (null ⇒ winner), so the render displays the SAME body it filtered
         List<string?>? matched = multiTarget ? new() : null;                  // parallel to keys: which target(s) each hit referenced (multi-target references= un-merge); null when 0/1 target
-        List<RecordSummary>? prefilled = (hasType || hasPlugins) ? new() : null;   // parallel to keys; null = renderer fills lazily
+        List<RecordSummary>? prefilled = (hasType || hasPlugins || hasFormidSet) ? new() : null;   // parallel to keys; null = renderer fills lazily
         // OrdinalIgnoreCase so case-variant spellings of the SAME plugin — a master listed as `ccBGSSSE025-AdvDSGS.esm`
         // in one plugin's masters and `ccbgssse025-advdsgs.esm` in another's — merge into ONE group instead of splitting
         // the count (#248). Plugin filenames are case-insensitive identifiers everywhere else in houseCARL (and in the
@@ -3783,7 +3793,89 @@ public sealed class LoadOrderService : IDisposable
         int unscannable = 0;                                                  // records whose body tests THREW (Mutagen-unparseable content) — excluded + accounted, never silent (Q3)
         var unscannableSamples = new List<string>();
 
-        if (hasType || hasPlugins)                                            // a body-bearing scope: stream + filter in hand
+        HashSet<FormKey>? setFilter = hasFormidSet ? new HashSet<FormKey>(formidSet!) : null;
+        if (!hasType && !hasPlugins && hasFormidSet && !conflictsOnly)        // the formid set ALONE is the universe: per-key winner fetch
+        {
+            LoadOrderResolver.OverlaySession? setSession = null;
+            try
+            {
+                setSession = resolver.OpenSession();
+                var sess = setSession;
+                predicate?.BindResolution(
+                    fk => view.ResolveWinner(fk)?.WinnerPlugin,
+                    predicate.NeedsBodyResolution
+                        ? fk =>
+                        {
+                            var w = view.ResolveWinner(fk);
+                            return w is null ? null : view.GetRecord(sess, w.Value.WinnerPlugin, fk);
+                        }
+                        : null);
+                var seenSet = new HashSet<FormKey>();
+                foreach (var fk in formidSet!)
+                {
+                    if (!seenSet.Add(fk)) continue;
+                    var w = view.ResolveWinner(fk);
+                    if (w is null) continue;                                  // not in the order — a clean non-match for a SCAN (per-item errors are the formids= list lane's shape)
+                    try
+                    {
+                        var body = view.GetRecord(setSession, w.Value.WinnerPlugin, fk);
+                        if (body is null)
+                        {
+                            unscannable++;
+                            if (unscannableSamples.Count < 3)
+                                unscannableSamples.Add($"{fk} — winner '{w.Value.WinnerPlugin}' did not yield the record on fetch");
+                            continue;
+                        }
+                        if (conflictsOnly && (view.TouchingPlugins(fk)?.Count ?? 0) <= 1) continue;
+                        if (DeletedRecordRule.HasNoLiveBody(body)
+                            && (refSet is not null || predicate is { NeedsLiveBody: true })) continue;
+                        if (!string.IsNullOrEmpty(editoridContains)
+                            && (body.EditorID is null || body.EditorID.IndexOf(editoridContains, StringComparison.OrdinalIgnoreCase) < 0))
+                            continue;
+                        List<FormKey>? hitTargets = null;
+                        if (refSet is not null)
+                        {
+                            if (body is not IFormLinkContainerGetter flc) continue;
+                            var hitSet = new HashSet<FormKey>();
+                            foreach (var l in flc.EnumerateFormLinks()) if (refSet.Contains(l.FormKey)) hitSet.Add(l.FormKey);
+                            if (hitSet.Count == 0) continue;
+                            if (multiTarget && groups is null) hitTargets = references!.Where(hitSet.Contains).Distinct().ToList();
+                        }
+                        if (typesForSet is not null && !typesForSet.Any(t => t.IsInstanceOfType(body))) continue;
+                        if (predicate is not null && !predicate.Matches(body))
+                        {
+                            if (predicate.FatalError is not null) break;
+                            continue;
+                        }
+                        total++;
+                        if (groups is not null)
+                        {
+                            var gk = groupBy == "type" ? RecordNaming.StripOverlay(body.GetType().Name)
+                                   : groupBy == "defined_in" ? fk.ModKey.FileName.ToString()
+                                   : w.Value.WinnerPlugin;
+                            groups[gk] = groups.GetValueOrDefault(gk) + 1;
+                        }
+                        else if (total > offset && keys.Count < limit)
+                        {
+                            keys.Add(fk);
+                            sources.Add(null);                                // the winner body is what matched and displays
+                            matched?.Add(hitTargets is not null ? string.Join(", ", hitTargets) : null);
+                            prefilled?.Add(new RecordSummary(fk, RecordNaming.StripOverlay(body.GetType().Name), body.EditorID,
+                                                             w.Value.WinnerPlugin, w.Value.OverrideDepth, null));
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        unscannable++;
+                        if (unscannableSamples.Count < 3)
+                            unscannableSamples.Add($"{fk} — {ex.GetType().Name}: {ex.Message}");
+                    }
+                }
+            }
+            finally { setSession?.Dispose(); }
+            if (predicate?.FatalError is not null) return CrossQueryOutcome.Fail(predicate.FatalError);
+        }
+        else if (hasType || hasPlugins)                                       // a body-bearing scope: stream + filter in hand
         {
             // RecordsIn / WinnerRecordsOfType are LAZY iterators: ScopeIndices (a plugin not in the order) and
             // EnumerateMajorRecords(throwIfUnknown) throw on ENUMERATION, not on creation — so the try must wrap the
@@ -3817,6 +3909,7 @@ public sealed class LoadOrderService : IDisposable
                                : view.WinnerRecordsOfType(types!).Select(x => (fk: x.fk, depth: x.depth, body: x.body, source: (string?)null));    // the load-order winner's body
                 foreach (var (fk, depth, body, source) in stream)
                 {
+                    if (setFilter is not null && !setFilter.Contains(fk)) continue;   // formids×scan: the identity intersection, cheapest first
                     if (conflictsOnly && depth <= 1) continue;
                     // defined_in=: keep only records whose ORIGIN FormKey is a scoped plugin (a DEFINITION here, not
                     // an override this plugin merely touches). A FormKey test — no body needed, so it runs before the try.
@@ -3930,6 +4023,7 @@ public sealed class LoadOrderService : IDisposable
             // group_by= here can only be winner/defined_in (type was refused up front — no body to name the type).
             foreach (var fk in view.ConflictKeys())
             {
+                if (setFilter is not null && !setFilter.Contains(fk)) continue;   // formids×scan on the index-only branch
                 total++;
                 if (groups is not null)
                 {
@@ -3963,6 +4057,187 @@ public sealed class LoadOrderService : IDisposable
                                      predicate?.AccountingNote(), sources, scanNote,
                                      matched, groupRows, groupBy, definedIn ? string.Join(", ", plugins!) : null, offset,
                                      whereWinner, whereSourceNote)
+               { Epoch = view.Epoch, Pin = new ViewPin(resolver, view) };
+    }
+
+    // ---- W2 PR 2: the OFF-ORDER scan completed (the read_plugin_file reach, full grammar) ---------------
+
+    /// <summary>The off-order scan, completed (W2 PR 2): the FILE's own records are the universe, with the same
+    /// filter grammar the in-order scan runs — multi-type, the full where= predicate set (its `winner` and `-&gt;`
+    /// terms bound to the ACTIVE view's resolution — declared: provenance is an active-order question even when
+    /// the bodies come from the file), references=, a plugins= scope (keep file records those ACTIVE plugins also
+    /// touch), defined_in (records the file itself DEFINES), group_by, exact windows, artifact-fed identity sets.
+    /// Returns the same outcome shape the in-order scan renders, sources naming the file on every row; the
+    /// caller declares the file's content outside the epoch fingerprint (the standing coverage rule).</summary>
+    public CrossQueryOutcome OffOrderQuery(PoleInfo pole, IReadOnlyList<string>? typeSet,
+        IReadOnlyList<FormKey>? references, string? editoridContains, IReadOnlyList<string>? scopePlugins,
+        bool definedIn, IReadOnlyList<string>? where, int limit, string? groupBy, int offset,
+        IReadOnlyList<FormKey>? formidSet, IReadOnlyList<ArtifactDemand>? artifactDemands)
+    {
+        var resolver = Resolver;
+        var view = resolver.Capture();
+
+        if (groupBy is not null)
+        {
+            groupBy = groupBy.Trim().ToLowerInvariant();
+            if (groupBy is not ("winner" or "type" or "defined_in"))
+                return CrossQueryOutcome.Fail($"group_by='{groupBy}' is not a known aggregation key — use 'winner', 'type', or 'defined_in'.");
+        }
+        if (offset < 0)
+            return CrossQueryOutcome.Fail($"offset={offset} — offset must be >= 0.");
+        if (offset > 0 && groupBy is not null)
+            return CrossQueryOutcome.Fail("group_by= aggregates ALL matches into a count table, so offset= has nothing to page — drop one.");
+
+        FieldPredicateSet? predicate = null;
+        if (where is { Count: > 0 })
+        {
+            var (set, perr) = FieldPredicateSet.Parse(where);
+            if (perr is not null) return CrossQueryOutcome.Fail(perr);
+            predicate = set;
+        }
+        foreach (var demand in (artifactDemands ?? Array.Empty<ArtifactDemand>()).Concat(
+                     predicate?.ArtifactDemands ?? (IReadOnlyList<ArtifactDemand>)Array.Empty<ArtifactDemand>()))
+            if (demand.Epoch != view.Epoch)
+                return CrossQueryOutcome.Fail(ArtifactEpochMismatch(demand, view.Epoch)) with { Epoch = view.Epoch };
+
+        IReadOnlyList<Type>? types;
+        try
+        {
+            if (typeSet is { Count: > 0 })
+            {
+                var union = new List<Type>();
+                foreach (var ts in typeSet)
+                    foreach (var t in ResolveTypeFilter(ts.Trim()))
+                        if (!union.Contains(t)) union.Add(t);
+                types = union;
+            }
+            else types = null;
+        }
+        catch (ArgumentException ex) { return CrossQueryOutcome.Fail(ex.Message); }
+
+        var scopeSet = scopePlugins is { Count: > 0 }
+            ? new HashSet<string>(scopePlugins.Select(p => p.Trim()), StringComparer.OrdinalIgnoreCase)
+            : null;
+        if (scopeSet is not null)
+            foreach (var p in scopeSet)
+                if (!view.ContainsPlugin(p))
+                    return CrossQueryOutcome.Fail($"plugins= scope '{p}' is not in the active load order — over an out-of-load-order file the scope keeps the file's records that ACTIVE plugins also touch, so the scope names active plugins.") with { Epoch = view.Epoch };
+
+        ModKey fileKey;
+        try { fileKey = ModKey.FromFileName(pole.Plugin); }
+        catch (Exception ex) { return CrossQueryOutcome.Fail($"'{pole.Plugin}' is not a valid plugin filename: {ex.Message}"); }
+
+        string dataDir;
+        try { lock (_gate) { EnsurePathsDerived(); dataDir = _dataDir; } }
+        catch (Exception ex) { return CrossQueryOutcome.Fail($"the MO2 roots couldn't be derived to open '{pole.Plugin}': {ex.Message}") with { Epoch = view.Epoch }; }
+        ISkyrimModGetter ov;
+        try { ov = LoadOrderResolver.OpenOverlay(pole.Path!, string.IsNullOrEmpty(dataDir) ? null : dataDir); }
+        catch (Exception ex) { return CrossQueryOutcome.Fail($"could not open '{pole.Path}' as a Skyrim plugin: {ex.Message}") with { Epoch = view.Epoch }; }
+
+        var refSet = references is { Count: > 0 } ? new HashSet<FormKey>(references) : null;
+        bool multiTarget = references is { Count: >= 2 };
+        var setFilter = formidSet is { Count: > 0 } ? new HashSet<FormKey>(formidSet) : null;
+
+        var keys = new List<FormKey>();
+        var sources = new List<string?>();
+        List<string?>? matched = multiTarget ? new() : null;
+        var prefilled = new List<RecordSummary>();
+        Dictionary<string, int>? groups = groupBy is not null ? new(StringComparer.OrdinalIgnoreCase) : null;
+        int total = 0, unscannable = 0;
+        var unscannableSamples = new List<string>();
+        LoadOrderResolver.OverlaySession? session = null;
+        try
+        {
+            if (predicate is not null)
+            {
+                // The provenance/link terms read the ACTIVE order's resolution — a `winner` term over an
+                // off-order file asks "who wins this key in MY order", and a `->` target resolves to its live
+                // winner body. Declared semantics, same binding discipline as the in-order scan.
+                session = (predicate.NeedsBodyResolution ? resolver.OpenSession() : null);
+                var sess = session;
+                predicate.BindResolution(
+                    fk => view.ResolveWinner(fk)?.WinnerPlugin,
+                    predicate.NeedsBodyResolution
+                        ? fk =>
+                        {
+                            var w = view.ResolveWinner(fk);
+                            return w is null ? null : view.GetRecord(sess!, w.Value.WinnerPlugin, fk);
+                        }
+                        : null);
+            }
+            var seen = new HashSet<FormKey>();
+            foreach (var rec in ov.EnumerateMajorRecords())
+            {
+                var fk = rec.FormKey;
+                if (!seen.Add(fk)) continue;
+                try
+                {
+                    if (setFilter is not null && !setFilter.Contains(fk)) continue;
+                    if (definedIn && fk.ModKey != fileKey) continue;
+                    if (types is not null && !types.Any(t => t.IsInstanceOfType(rec))) continue;
+                    if (scopeSet is not null)
+                    {
+                        var touchers = view.TouchingPlugins(fk);
+                        if (touchers is null || !touchers.Any(scopeSet.Contains)) continue;
+                    }
+                    if (DeletedRecordRule.HasNoLiveBody(rec)
+                        && (refSet is not null || predicate is { NeedsLiveBody: true })) continue;
+                    if (!string.IsNullOrEmpty(editoridContains)
+                        && (rec.EditorID is null || rec.EditorID.IndexOf(editoridContains, StringComparison.OrdinalIgnoreCase) < 0))
+                        continue;
+                    List<FormKey>? hitTargets = null;
+                    if (refSet is not null)
+                    {
+                        if (rec is not IFormLinkContainerGetter flc) continue;
+                        var hitSet = new HashSet<FormKey>();
+                        foreach (var l in flc.EnumerateFormLinks()) if (refSet.Contains(l.FormKey)) hitSet.Add(l.FormKey);
+                        if (hitSet.Count == 0) continue;
+                        if (multiTarget && groups is null) hitTargets = references!.Where(hitSet.Contains).Distinct().ToList();
+                    }
+                    if (predicate is not null && !predicate.Matches(rec))
+                    {
+                        if (predicate.FatalError is not null) break;
+                        continue;
+                    }
+                    total++;
+                    if (groups is not null)
+                    {
+                        var gk = groupBy == "type" ? RecordNaming.StripOverlay(rec.GetType().Name)
+                               : groupBy == "defined_in" ? fk.ModKey.FileName.ToString()
+                               : view.ResolveWinner(fk)?.WinnerPlugin ?? "(not in the active order)";
+                        groups[gk] = groups.GetValueOrDefault(gk) + 1;
+                    }
+                    else if (total > offset && keys.Count < limit)
+                    {
+                        var w = view.ResolveWinner(fk);
+                        keys.Add(fk);
+                        sources.Add(pole.Plugin);
+                        matched?.Add(hitTargets is not null ? string.Join(", ", hitTargets) : null);
+                        prefilled.Add(new RecordSummary(fk, RecordNaming.StripOverlay(rec.GetType().Name), rec.EditorID,
+                                                        w?.WinnerPlugin ?? "(not in the active order)", w?.OverrideDepth ?? 0, null));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    unscannable++;
+                    if (unscannableSamples.Count < 3)
+                        unscannableSamples.Add($"{fk} in {pole.Plugin} — {ex.GetType().Name}: {ex.Message}");
+                }
+            }
+        }
+        catch (Exception ex) { return CrossQueryOutcome.Fail($"file '{pole.Plugin}' could not be fully read — {ex.GetType().Name}: {ex.Message}") with { Epoch = view.Epoch }; }
+        finally { session?.Dispose(); (ov as IDisposable)?.Dispose(); }
+        if (predicate?.FatalError is not null) return CrossQueryOutcome.Fail(predicate.FatalError) with { Epoch = view.Epoch };
+
+        string? scanNote = unscannable == 0 ? null
+            : $"note: {unscannable} record(s) in '{pole.Plugin}' could not be scanned and were skipped where the failure occurred: "
+              + string.Join("; ", unscannableSamples)
+              + (unscannable > unscannableSamples.Count ? $"; and {unscannable - unscannableSamples.Count} more" : "") + ".";
+        var groupRows = groups?.Select(kv => new GroupCount(kv.Key, kv.Value))
+                              .OrderByDescending(g => g.Count).ThenBy(g => g.Key, StringComparer.Ordinal).ToList();
+        return new CrossQueryOutcome(keys, prefilled, total, groups is null && total > offset + keys.Count, null,
+                                     predicate?.AccountingNote(), sources, scanNote, matched, groupRows, groupBy,
+                                     definedIn ? pole.Plugin : null, offset, false, null)
                { Epoch = view.Epoch, Pin = new ViewPin(resolver, view) };
     }
 

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -64,7 +64,7 @@ public static class RecordsTools
         [Description("The link path followed at every LATER hop. \"*\" (default) walks every link — full closure. A named path restricts to one chain, e.g. \"Template\" for NPC template inheritance.")]
         public string? follow { get; set; }
 
-        [Description("'forward' (default) — what the seeds point AT (cheap: each hop is one link resolve). 'reverse' — what points AT the seeds; depth 1 only (reverse is a bounded scan; transitive reverse is refused naming the reverse-reference index as the future capability). The general reverse spelling on this surface IS references= (same construct); walk.direction='reverse' serves the typed MGEF lane — magic-effect seeds get per-carrier magnitude/area/duration.")]
+        [Description("'forward' (default) — what the seeds point AT (cheap: each hop is one link resolve). 'reverse' — what points AT the seeds; depth 1 only (reverse is a bounded scan; transitive reverse is refused naming the reverse-reference index as the future capability). The general reverse spelling on this surface IS references= (same construct); walk.direction='reverse' serves the typed MGEF lane — magic-effect seeds get per-carrier magnitude/area/duration (types= narrows the carrier types; walk.max_nodes bounds each seed's carrier rows; limit=/offset= window the SEEDS).")]
         public string? direction { get; set; }
 
         [Description("Maximum hops from a seed (default 16). Nodes AT the cap are recorded, not entered, and the response says the cap cut the walk — never a silent stop.")]
@@ -600,7 +600,9 @@ public static class RecordsTools
                     FormKey fk;
                     try { fk = FormKey.Factory(raw.Trim()); }
                     catch (Exception ex) { results.Add((raw?.Trim() ?? "", EffectChainResult.Fail($"bad FormID '{raw}': {ex.Message}"))); continue; }
-                    results.Add((fk.ToString(), svc.ResolveEffectChain(fk, types, limit <= 0 ? 500 : limit)));
+                    // The per-seed carrier bound is the WALK's own reach budget (walk.max_nodes, default 2000) —
+                    // limit=/offset= stay the SEED window, never a second silent cut on the carrier axis (re-review).
+                    results.Add((fk.ToString(), svc.ResolveEffectChain(fk, types, walkMaxNodes)));
                 }
                 // ONE build for the whole batch (review F3): each seed's resolve captures its own view — the
                 // stamps must agree, and an @artifact seed list's epoch demand must match that build.
@@ -622,13 +624,19 @@ public static class RecordsTools
                 Arm("winner (carriers are the load-order-effective versions)");
                 envelope.Add(new("walk", "reverse, depth 1 — the typed MGEF carrier lane"));
                 headerLine += "\nwalk=reverse (per seed: every SPEL/ENCH/ALCH/SCRL/INGR applying it, with the MATCHING entry's magnitude/area/duration — reported AS AUTHORED; conditions are not evaluated, so a row means 'defines it at this strength', not 'it will fire')";
-                int carrierRows = results.Sum(r => r.Result.Error is null ? r.Result.Total : 0);
+                // The census separates WRITTEN rows from the true total, and names capped seeds — so the
+                // artifact and its census can never disagree, and a walk.max_nodes cut is declared (re-review).
+                int carrierRows = results.Sum(r => r.Result.Error is null ? r.Result.Rows.Count : 0);
+                int carrierTotal = results.Sum(r => r.Result.Error is null ? r.Result.Total : 0);
+                int cappedSeeds = results.Count(r => r.Result.Error is null && r.Result.Capped);
                 int seedErrs2 = results.Count(r => r.Result.Error is not null);
-                var revCounts = new[] { KvI("seeds", results.Count), KvI("carrier_rows", carrierRows), KvI("errors", seedErrs2) };
+                var revCounts = new[] { KvI("seeds", results.Count), KvI("carrier_rows", carrierRows), KvI("carrier_total", carrierTotal), KvI("capped_seeds", cappedSeeds), KvI("errors", seedErrs2) };
+                if (cappedSeeds > 0)
+                    headerLine += $"\n[!] {cappedSeeds} seed(s) hit the walk.max_nodes carrier bound ({walkMaxNodes}) — their rows are a prefix of carrier_total; raise walk.max_nodes.";
                 if (counts_only)
                     return json
                         ? JsonWire.RenderNamedCounts(envelope, revCounts, epochR)
-                        : $"{headerLine}\nseeds={results.Count} carrier_rows={carrierRows} errors={seedErrs2}" + (epochR is not null ? $"\nepoch={epochR}" : "");
+                        : $"{headerLine}\nseeds={results.Count} carrier_rows={carrierRows} carrier_total={carrierTotal} capped_seeds={cappedSeeds} errors={seedErrs2}" + (epochR is not null ? $"\nepoch={epochR}" : "");
                 var winResults = Windowed(results);
                 SpillState? revSpill = null;
                 if (wantFile)
@@ -639,7 +647,7 @@ public static class RecordsTools
                 }
                 string RenderRev(SpillState? sp, out bool trunc) => json
                     ? JsonWire.RenderEffectChains(winResults, max_chars, envelope, revCounts, epochR, sp, out trunc)
-                    : RenderRecordsEffectChains(winResults, results.Count, carrierRows, seedErrs2, headerLine, epochR, max_chars, sp, out trunc);
+                    : RenderRecordsEffectChains(winResults, results.Count, carrierRows, seedErrs2, headerLine, epochR, max_chars, sp, out trunc);   // header carries carrier_total/capped via headerLine
                 var revRendered = RenderRev(revSpill, out var revTrunc);
                 if (revSpill is null && revTrunc)
                 {
@@ -1224,6 +1232,10 @@ public static class RecordsTools
             if (walk is not null)
                 return "error: the walk expands the ACTIVE order's winner link graph — an out-of-load-order file's records are not in that graph. Enumerate the file with form='summary', then walk specific records via formids= (dropping source=).";
             if (dense) return "error: format='dense' is the in-order scan's columnar form — an off-order file scan renders text or json.";
+            if (versusSpec?.Kind == LoadOrderService.PoleKind.Overlay)
+                return "error: an overlay pole on a SCAN would replay the SkyPatcher INI layer over every match — a per-record replay at scan scale " +
+                       "(a scan comparison compares EVERY match, so it is not a bound). Name the records via formids= — the list lane reads and " +
+                       "compares their post-state bodies — or read the whole layer via housecarl_skypatcher_layer.";
             if (where_source is not null)
             {
                 // Full-vocabulary validation, mirroring the in-order engine (review F9): an unknown spelling must

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -37,7 +37,7 @@ public static class RecordsTools
     /// them (SPEC §2.2: form-scoped and structured — the flat spelling for an illegal pairing does not exist).</summary>
     public sealed class RecordsProject
     {
-        [Description("The form: 'identity' (FormID -> type/editorid/name/winner — the labeling form; needs formids=) | 'summary' (identity plus winner/override-depth header facts — the default) | 'fields' (named field values; takes fields= and depth=) | 'everything' (the full record body; takes depth=) | 'aggregate' (a counted table; takes group_by=) | 'delta' (subject vs reference, differences only — source= is the subject, versus= the reference; takes fields= to narrow) | 'tree' (every provider of each record in priority order, winner last, each diffed against the reference pole — default the winner; takes fields=). The traversal forms (chain | info_order) are refused by NAME until they land.")]
+        [Description("The form: 'identity' (FormID -> type/editorid/name/winner — the labeling form; needs formids=) | 'summary' (identity plus winner/override-depth header facts — the default) | 'fields' (named field values; takes fields= and depth=) | 'everything' (the full record body; takes depth=) | 'aggregate' (a counted table; takes group_by=) | 'delta' (subject vs reference, differences only — source= is the subject, versus= the reference; takes fields= to narrow) | 'tree' (every provider of each record in priority order, winner last, each diffed against the reference pole — default the winner; takes fields=) | 'info_order' (DIAL topics only: the effective MERGED INFO sequence across every touching plugin — the order the game walks, with MOVED annotations; the 'why does the wrong line play' diagnostic). The 'chain' traversal form is refused by NAME until it lands.")]
         public string? form { get; set; }
 
         [Description("fields form only: dotted field paths to read, e.g. [\"BasicStats.Damage\", \"Keywords\", \"Effects\"]. Index a list/dict element with BRACKETS ('Effects[0].Data.Magnitude').")]
@@ -92,7 +92,12 @@ public static class RecordsTools
          "it'. A tree lists EVERY plugin touching each record (load order, winner last) with each provider's " +
          "only-the-fields-that-differ against the reference (default the winner) — the conflict-resolution view. " +
          "Both compare by the content-keyed, truncation-honest engine (list reorders flagged; a truncated deep " +
-         "read is reported, never claimed 'identical').\n\n" +
+         "read is reported, never claimed 'identical'). form='info_order' (DIAL topics) renders the effective " +
+         "MERGED INFO sequence across every plugin touching each topic — the game walks it top to bottom and " +
+         "plays the FIRST passing line; re-listing a line appends it to the BOTTOM unless the plugin also carries " +
+         "its PNAM, so a reorder changes which line answers while every field stays identical (invisible to a " +
+         "diff — this form is how you see it). A quest's topics select by composition: types=[\"DIAL\"] " +
+         "where=[\"Quest = <quest formid>\"].\n\n" +
          "TRANSPORT: format= 'text' | 'json' | 'dense' (scan lane: positional columnar cells 1:1 with the requested " +
          "fields — by that definition depth expansion and the everything form are inexpressible in it); limit=/" +
          "offset= page a scan in exact windows WITHIN one epoch (different epochs across pages ⇒ the order changed " +
@@ -152,10 +157,10 @@ public static class RecordsTools
         var form = project?.form?.Trim().ToLowerInvariant() ?? "summary";
         switch (form)
         {
-            case "identity" or "summary" or "fields" or "everything" or "aggregate" or "delta" or "tree": break;
-            case "chain" or "info_order":
-                return $"error: project.form='{form}' is a W2 PR 2 form (traversal) and is not on this surface yet — " +
-                       "meanwhile: chain = housecarl_effect_chain / references=; info_order = housecarl_validate_dialogue.";
+            case "identity" or "summary" or "fields" or "everything" or "aggregate" or "delta" or "tree" or "info_order": break;
+            case "chain":
+                return "error: project.form='chain' is a W2 PR 2 form (traversal) and is not on this surface yet — " +
+                       "meanwhile: housecarl_effect_chain traces an MGEF's carriers; references= is the one-step reverse lookup.";
             default:
                 return $"error: project.form='{project?.form}' is not a form — use identity | summary | fields | everything | aggregate | delta | tree.";
         }
@@ -249,6 +254,10 @@ public static class RecordsTools
             return "error: format='dense' is the per-row columnar transport, and the 'aggregate' form is a count table — its json render IS the compact form; use format='json'.";
         if (dense && comparisonForm)
             return $"error: format='dense' renders positional columnar cells 1:1 with requested field paths, and the '{form}' form's rows are variable-length delta lists with no fixed column set — use format='text' or 'json'.";
+        if (dense && form == "info_order")
+            return "error: format='dense' renders positional columnar cells 1:1 with requested field paths, and the 'info_order' form is an ordered sequence render with no fixed column set — use format='text' or 'json'.";
+        if (form == "info_order" && srcSpec.Kind != LoadOrderService.PoleKind.Winner)
+            return "error: the info_order form merges EVERY plugin touching each topic — that merge is the answer, so a source= pole has no seat here (each line already names the plugin that placed it). Drop source=.";
         // fields_source= is the SCAN lane's display pole in this wave (it retargets what a matched row DISPLAYS);
         // the list lane's read is its display, so the request would be silently meaningless there — refuse by
         // name (re-review: it was accepted and dropped). The generalized poles land with W2 PR 2's comparison forms.
@@ -322,6 +331,20 @@ public static class RecordsTools
 
             // ---- delta / tree: the §4.1 comparison forms ride their own engine batches. ------------------
             if (form is "delta" or "tree") return ListCompare(ids, demand, echoSrc);
+
+            // ---- info_order: the merged effective INFO sequence (§6.1 F1 split). ------------------------
+            if (form == "info_order")
+            {
+                var ioRows = svc.InfoOrderBatch(ids, demand, out var ioRefusal, out var ioEpoch);
+                if (ioRefusal is not null)
+                    return json ? JsonWire.RenderError(ioRefusal, ioEpoch) : "error: " + ioRefusal + (ioEpoch is not null ? $"\nepoch={ioEpoch}" : "");
+                var e = new List<KeyValuePair<string, string>>
+                {
+                    new("formids", echoSrc ?? $"{ids.Length} inline formid(s)"),
+                    new("form", form),
+                };
+                return InfoOrderResponse(ioRows, ioEpoch, e);
+            }
 
             // ---- identity form: the labeling lane (absorbs housecarl_resolve). Winner frame by contract. --
             if (form == "identity")
@@ -555,6 +578,40 @@ public static class RecordsTools
             return rendered;
         }
 
+        // The shared info_order response pipeline (envelope, counts_only, window, to_file/ceiling spill, both
+        // renders) — one path for the list AND scan lanes.
+        string InfoOrderResponse(IReadOnlyList<LoadOrderService.InfoOrderRow> rows, string? epoch,
+                                 List<KeyValuePair<string, string>> echo)
+        {
+            Arm("the merge of every touching plugin (the effective order the game walks)");
+            int contested = rows.Count(x => x.Error is null && x.Order is { Contested: true });
+            int errs = rows.Count(x => x.Error is not null);
+            if (counts_only)
+                return json
+                    ? JsonWire.RenderNamedCounts(envelope, new[] { KvI("count", rows.Count), KvI("contested", contested), KvI("errors", errs) }, epoch)
+                    : $"{headerLine}\ncount={rows.Count} contested={contested} errors={errs}" + (epoch is not null ? $"\nepoch={epoch}" : "");
+            var winRows = Windowed(rows);
+            SpillState? spill = null;
+            if (wantFile)
+            {
+                var (s, aerr) = Artifacts.WriteInfoOrder(rows, epoch, toFile!, "to_file", echo);
+                if (aerr is not null) return json ? JsonWire.RenderError(aerr, epoch) : "error: " + aerr;
+                spill = SpillState.Spilled(s!, manifestOnly: true);
+            }
+            string Render(SpillState? sp, out bool trunc) => json
+                ? JsonWire.RenderInfoOrder(winRows, max_chars, epoch, envelope, sp, out trunc)
+                : RenderRecordsInfoOrder(winRows, rows.Count, contested, errs, headerLine, epoch, max_chars, sp, out trunc);
+            var rendered = Render(spill, out var truncated);
+            if (spill is null && truncated)
+            {
+                var path = ResultsStore.NextPath("housecarl_records", epoch ?? "none");
+                var (s, aerr) = Artifacts.WriteInfoOrder(rows, epoch, path, "ceiling", echo);
+                if (aerr is not null) ResultsStore.Release(path);
+                rendered = Render(aerr is null ? SpillState.Spilled(s!, manifestOnly: false) : SpillState.WriteFailed(aerr), out _);
+            }
+            return rendered;
+        }
+
         // A pole that reads content outside the epoch fingerprint (an off-order file; the overlay's INIs) is
         // DECLARED, envelope + header alike (the PR #305 coverage rule) — one helper so no form forgets.
         void CoverageNote(bool covers)
@@ -709,6 +766,25 @@ public static class RecordsTools
                 }
             }
 
+            // ---- info_order on a scan: the scan SELECTS the topics (types=["DIAL"] + where= is the quest
+            //      fan-out spelling), the merge engine renders — seam epoch-compared like every two-capture form.
+            if (form == "info_order" && outcome.Error is null && outcome.Groups is null)
+            {
+                var ioKeys = outcome.Keys.Select(k => k.ToString()).ToList();
+                envelope.Add(new("total", outcome.Total.ToString()));
+                headerLine += $"\n{outcome.Total} match(es) selected by the scan";
+                var ioRows = svc.InfoOrderBatch(ioKeys, null, out var ioRefusal, out var ioEpoch);
+                if (ioRefusal is not null)
+                    return json ? JsonWire.RenderError(ioRefusal, ioEpoch) : "error: " + ioRefusal + (ioEpoch is not null ? $"\nepoch={ioEpoch}" : "");
+                if (outcome.Epoch is not null && ioEpoch is not null && ioEpoch != outcome.Epoch)
+                {
+                    var tear = $"the load order changed between the scan (epoch={outcome.Epoch}) and the merge " +
+                               $"(epoch={ioEpoch}) — the two halves would mix builds. Retry the call.";
+                    return json ? JsonWire.RenderError(tear, ioEpoch) : "error: " + tear;
+                }
+                return InfoOrderResponse(ioRows, ioEpoch, Echo());
+            }
+
             // ---- form=everything on a scan: selection here, bodies via the batch lane (window-bounded).
             // counts_only skips the body lane entirely — the census is the cross-query render below (round 3).
             if (form == "everything" && !counts_only && outcome.Error is null && outcome.Groups is null)
@@ -831,6 +907,8 @@ public static class RecordsTools
                 return "error: conflicts_only= has no meaning on an out-of-load-order file — it is not in the conflict frame. Drop it, or read the winner (source=\"winner\").";
             if (comparisonForm)
                 return "error: the 'delta'/'tree' forms over an out-of-load-order file SCAN are not composed yet — enumerate the file with form='summary', then compare the specific records via formids= (the comparison poles read the off-order file under the one-pole rule).";
+            if (form == "info_order")
+                return "error: the info_order form merges the ACTIVE order's touching plugins — an out-of-load-order file is not in that frame. Read the winner's merge (drop source=), or enumerate the file's DIAL records with form='summary'.";
             if (references is { Length: > 0 } || plugins?.names is { Length: > 0 } || (plugins?.defined_in ?? false))
                 return "error: references=/plugins= over an out-of-load-order file land in W2 PR 2 — this wave reads the file by types= (and an 'editorid contains' where-clause).";
             if (form is "fields" or "everything")
@@ -1057,6 +1135,52 @@ public static class RecordsTools
                     sb.Append(fieldsNarrow
                         ? $"identical to {row.ReferencePlugin} across the fields read ({n.AgreedCount} leaf/leaves agree)\n"
                         : $"identical to {row.ReferencePlugin} (whole record; {n.AgreedCount} leaf/leaves agree)\n");
+            }
+            rendered++;
+        }
+        if (spill is not null) Artifacts.AppendSpillStateText(sb, spill);
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    /// <summary>The info_order form's text render: per topic its identity, then the SAME merged-order body
+    /// housecarl_validate_dialogue renders (shared via <see cref="DialogueWire.AppendInfoOrderView"/> — the §6.1
+    /// split carried the MOVED annotations and the MovesComputed×Complete / BaselineTrusted honesty gates across
+    /// intact, one render, no drift).</summary>
+    static string RenderRecordsInfoOrder(IReadOnlyList<LoadOrderService.InfoOrderRow> rows, int total, int contested,
+                                         int errors, string headerLine, string? epoch, int maxChars,
+                                         SpillState? spill, out bool truncated)
+    {
+        truncated = false;
+        int cap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        bool manifestOnly = spill?.ManifestOnly ?? false;
+        var sb = new StringBuilder();
+        sb.Append(headerLine).Append('\n');
+        sb.Append(total).Append(" topic(s): ").Append(contested).Append(" contested, ").Append(errors).Append(" error(s)");
+        if (epoch is not null) sb.Append("  epoch=").Append(epoch);
+        sb.Append('\n');
+        int rendered = 0;
+        foreach (var row in rows)
+        {
+            if (manifestOnly) break;
+            if (sb.Length >= cap)
+            {
+                truncated = true;
+                sb.Append("... [rendered ").Append(rendered).Append(" of ").Append(rows.Count)
+                  .Append(" rows at max_chars=").Append(cap).Append("]\n");
+                break;
+            }
+            sb.Append('\n').Append(row.Formid);
+            if (row.Error is not null) { sb.Append("  error=").Append(row.Error).Append('\n'); rendered++; continue; }
+            sb.Append("  ").Append(row.Type ?? "?").Append("  ").Append(row.EditorId ?? "<no editorid>")
+              .Append("  winner=").Append(row.WinnerPlugin ?? "?").Append('\n');
+            if (row.Order is null)
+                sb.Append("  [!] the merge could not be computed for this topic (its key did not resolve in the touching index).\n");
+            else if (row.Order.Order.Count == 0 && row.Order.Complete)
+                sb.Append("  no INFO lines — every touching plugin's child list is empty.\n");
+            else if (!DialogueWire.AppendInfoOrderView(sb, row.Order, "", cap, indent: false))
+            {
+                truncated = true;
+                break;
             }
             rendered++;
         }

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -37,7 +37,7 @@ public static class RecordsTools
     /// them (SPEC §2.2: form-scoped and structured — the flat spelling for an illegal pairing does not exist).</summary>
     public sealed class RecordsProject
     {
-        [Description("The form: 'identity' (FormID -> type/editorid/name/winner — the labeling form; needs formids=) | 'summary' (identity plus winner/override-depth header facts — the default) | 'fields' (named field values; takes fields= and depth=) | 'everything' (the full record body; takes depth=) | 'aggregate' (a counted table; takes group_by=). The comparison forms (delta | tree | chain | info_order) arrive with the W2 comparison wave and are refused by NAME until then.")]
+        [Description("The form: 'identity' (FormID -> type/editorid/name/winner — the labeling form; needs formids=) | 'summary' (identity plus winner/override-depth header facts — the default) | 'fields' (named field values; takes fields= and depth=) | 'everything' (the full record body; takes depth=) | 'aggregate' (a counted table; takes group_by=) | 'delta' (subject vs reference, differences only — source= is the subject, versus= the reference; takes fields= to narrow) | 'tree' (every provider of each record in priority order, winner last, each diffed against the reference pole — default the winner; takes fields=). The traversal forms (chain | info_order) are refused by NAME until they land.")]
         public string? form { get; set; }
 
         [Description("fields form only: dotted field paths to read, e.g. [\"BasicStats.Damage\", \"Keywords\", \"Effects\"]. Index a list/dict element with BRACKETS ('Effects[0].Data.Magnitude').")]
@@ -83,9 +83,16 @@ public static class RecordsTools
          "named plugin does not touch is refused naming the plugins that DO touch it — never silently absent. " +
          "An off-order file's content sits OUTSIDE the epoch fingerprint and the response says so. " +
          "('previous_provider' and the SkyPatcher overlay source arrive in W2 PR 2.)\n\n" +
-         "PROJECT is a single form (see project=): identity | summary (default) | fields | everything | aggregate. " +
-         "Sub-parameters live INSIDE the form that uses them (depth belongs to fields/everything, group_by to " +
-         "aggregate) — there is no flat spelling for an illegal pairing.\n\n" +
+         "PROJECT is a single form (see project=): identity | summary (default) | fields | everything | aggregate | " +
+         "delta | tree. Sub-parameters live INSIDE the form that uses them (depth belongs to fields/everything, " +
+         "group_by to aggregate, fields to fields/delta/tree) — there is no flat spelling for an illegal pairing. " +
+         "COMPARISONS (form='delta'/'tree'): a delta reads the SUBJECT (source=) and a REFERENCE (versus=) and " +
+         "returns only what differs — each delta line shows the subject's value with the reference's labeled by its " +
+         "plugin; versus=\"previous_provider\" answers 'what did this plugin change relative to what sat beneath " +
+         "it'. A tree lists EVERY plugin touching each record (load order, winner last) with each provider's " +
+         "only-the-fields-that-differ against the reference (default the winner) — the conflict-resolution view. " +
+         "Both compare by the content-keyed, truncation-honest engine (list reorders flagged; a truncated deep " +
+         "read is reported, never claimed 'identical').\n\n" +
          "TRANSPORT: format= 'text' | 'json' | 'dense' (scan lane: positional columnar cells 1:1 with the requested " +
          "fields — by that definition depth expansion and the everything form are inexpressible in it); limit=/" +
          "offset= page a scan in exact windows WITHIN one epoch (different epochs across pages ⇒ the order changed " +
@@ -112,8 +119,10 @@ public static class RecordsTools
             string? where_source = null,
         [Description("SELECT: find records that REFERENCE these FormIDs (reverse, one step; OR over the list, each match names which target(s) it hit). Requires a bounding types= or plugins= scope — see the cost declaration in the tool description. Accepts [\"@<path>\"] like formids=.")]
             string[]? references = null,
-        [Description("SOURCE: whose version to read. Omit or \"winner\" for the load-order winner; a plugin filename (e.g. \"OldPatch.esp\") for that plugin's version WHEREVER it lives — active or on disk out of the order (the response states which); {\"file\": \"X.esp\", \"mod\": \"<mod folder>\"} when two mods ship the same filename. \"previous_provider\" and the runtime overlay arrive in W2 PR 2.")]
+        [Description("SOURCE: whose version to read — the SUBJECT of the call. Omit or \"winner\" for the load-order winner; a plugin filename (e.g. \"OldPatch.esp\") for that plugin's version WHEREVER it lives — active or on disk out of the order (the response states which); {\"file\": \"X.esp\", \"mod\": \"<mod folder>\"} when two mods ship the same filename; {\"overlay\": \"skypatcher\", \"state\": \"pre\"|\"post\"} for the runtime view around the SkyPatcher INI layer (post = after it replays; INI content sits OUTSIDE the epoch fingerprint and the response says so). \"previous_provider\" is a versus= value only — it is measured FROM the subject this parameter names.")]
             JsonElement? source = null,
+        [Description("SOURCE (comparison forms): the REFERENCE pole a delta/tree compares against. Same forms as source= — \"winner\" | a plugin filename | {\"file\", \"mod\"} | {\"overlay\", \"state\"} — plus \"previous_provider\": the plugin immediately below the SUBJECT (whatever source= names) in the record's touching stack, measured FROM THE SUBJECT, never from the winner. Its four cases are all declared: subject=winner → next plugin down; subject mid-stack → still the one below the SUBJECT, with what sits above reported as plain fact (a mid-stack patch is ordinary practice, not judged); subject defines the record → refused naming it (never an empty diff that reads as 'no changes'); subject doesn't touch it → refused naming the actual touchers. REQUIRED when project.form='delta'; defaults to \"winner\" on 'tree'; refused on other forms.")]
+            JsonElement? versus = null,
         [Description("The pole field VALUES display from, when it differs from the matching pole: \"winner\" shows the live winner's values on a plugins=-scoped scan (the old winner_fields=true). Display only — where_source= governs matching.")]
             string? fields_source = null,
         [Description("PROJECT: the shape of the answer — a single form plus its own sub-parameters. Omit for summary rows.")]
@@ -143,18 +152,18 @@ public static class RecordsTools
         var form = project?.form?.Trim().ToLowerInvariant() ?? "summary";
         switch (form)
         {
-            case "identity" or "summary" or "fields" or "everything" or "aggregate": break;
-            case "delta" or "tree" or "chain" or "info_order":
-                return $"error: project.form='{form}' is a W2 PR 2 form (comparison/traversal) and is not on this surface yet — " +
-                       "meanwhile: delta = housecarl_diff_record; tree = housecarl_read_record conflict_tree=true; chain = " +
-                       "housecarl_effect_chain / references=; info_order = housecarl_validate_dialogue.";
+            case "identity" or "summary" or "fields" or "everything" or "aggregate" or "delta" or "tree": break;
+            case "chain" or "info_order":
+                return $"error: project.form='{form}' is a W2 PR 2 form (traversal) and is not on this surface yet — " +
+                       "meanwhile: chain = housecarl_effect_chain / references=; info_order = housecarl_validate_dialogue.";
             default:
-                return $"error: project.form='{project?.form}' is not a form — use identity | summary | fields | everything | aggregate.";
+                return $"error: project.form='{project?.form}' is not a form — use identity | summary | fields | everything | aggregate | delta | tree.";
         }
+        bool comparisonForm = form is "delta" or "tree";
         // Sub-parameters exist only inside their forms (SPEC §2.2) — a stray one is refused by name, so the caller
         // learns the form-scoping rule instead of getting a silently-ignored knob.
-        if (project?.fields is { Length: > 0 } && form != "fields")
-            return $"error: project.fields belongs to the 'fields' form only (got form='{form}'). Set project.form='fields', or drop fields.";
+        if (project?.fields is { Length: > 0 } && form != "fields" && !comparisonForm)
+            return $"error: project.fields belongs to the 'fields'/'delta'/'tree' forms (got form='{form}'). Set project.form, or drop fields.";
         if (form == "fields" && project?.fields is not { Length: > 0 })
             return "error: the 'fields' form names its field paths — pass project.fields=[\"<path>\", …] (or use form='everything' for the full body).";
         if (project?.depth is { } dv)
@@ -163,7 +172,9 @@ public static class RecordsTools
             // forms while `depth: 2` refused — the rule must not depend on the value), and 0/negative is refused
             // rather than silently becoming 1.
             if (form is not ("fields" or "everything"))
-                return $"error: project.depth expands field contents and belongs to the 'fields'/'everything' forms (got form='{form}').";
+                return comparisonForm
+                    ? $"error: project.depth belongs to the 'fields'/'everything' forms — the '{form}' comparison always deep-reads BOTH sides at the diff engine's fixed depth so line sets correspond (narrow with project.fields instead)."
+                    : $"error: project.depth expands field contents and belongs to the 'fields'/'everything' forms (got form='{form}').";
             if (dv < 1)
                 return $"error: project.depth={dv} — depth must be >= 1 (1 shows a container as a collapsed summary; higher opens it).";
         }
@@ -182,37 +193,37 @@ public static class RecordsTools
         if (project is { resolve_names: true } && form is not ("fields" or "everything"))
             return $"error: project.resolve_names annotates field values and belongs to the 'fields'/'everything' forms (got form='{form}').";
         int depth = project?.depth is { } d && d > 0 ? d : 1;
-        var projFields = form == "fields" ? project!.fields : null;
+        var projFields = form is "fields" or "delta" or "tree" ? project?.fields : null;
         bool resolveNames = project?.resolve_names ?? false;
 
-        // ---- SOURCE: the one-pole spelling --------------------------------------------------------------
-        string? srcName = null; string? srcMod = null;
-        if (source is { } se && se.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined)
+        // ---- SOURCE: the §4.2 pole grammar (source = the SUBJECT; versus = the comparison REFERENCE) ----
+        if (ParsePole(source, "source", subjectRole: true, out var srcSpec) is { } sperr) return sperr;
+        srcSpec ??= LoadOrderService.PoleSpec.Winner;
+        if (ParsePole(versus, "versus", subjectRole: false, out var versusSpec) is { } vperr) return vperr;
+
+        // versus= belongs to the comparison forms; the delta form REQUIRES it (§4.1 — a delta has two poles).
+        if (versusSpec is not null && !comparisonForm)
+            return $"error: versus= is the comparison REFERENCE pole and belongs to the 'delta'/'tree' forms (got form='{form}') — set project.form='delta' (subject vs reference) or 'tree' (every provider vs reference), or drop versus=.";
+        if (form == "delta" && versusSpec is null)
+            return "error: the 'delta' form compares the subject (source=, default the winner) against a REFERENCE — pass versus= (\"winner\" | a plugin filename | \"previous_provider\" | {\"overlay\": …}).";
+        if (form == "tree")
         {
-            if (se.ValueKind == JsonValueKind.String)
-            {
-                var s = se.GetString()!.Trim();
-                if (s.Equals("previous_provider", StringComparison.OrdinalIgnoreCase))
-                    return "error: source='previous_provider' is a W2 PR 2 pole (it pairs with the delta/tree comparison forms) — " +
-                           "meanwhile housecarl_read_record conflict_tree=true shows the full provider stack.";
-                if (s.Length > 0 && !s.Equals("winner", StringComparison.OrdinalIgnoreCase)) srcName = s;
-            }
-            else if (se.ValueKind == JsonValueKind.Object)
-            {
-                if (se.TryGetProperty("overlay", out _))
-                    return "error: the runtime-overlay source (SkyPatcher post-state) is a W2 PR 2 pole — meanwhile use housecarl_skypatcher_read.";
-                if (!se.TryGetProperty("file", out var fEl) || fEl.ValueKind != JsonValueKind.String)
-                    return "error: a structured source= names the plugin as {\"file\": \"X.esp\"[, \"mod\": \"<mod folder>\"]} — 'file' is required.";
-                srcName = fEl.GetString()!.Trim();
-                if (se.TryGetProperty("mod", out var mEl) && mEl.ValueKind == JsonValueKind.String) srcMod = mEl.GetString()!.Trim();
-            }
-            else return "error: source= is a string (\"winner\" | a plugin filename) or {\"file\": …, \"mod\": …}.";
+            versusSpec ??= LoadOrderService.PoleSpec.Winner;
+            if (versusSpec.Kind == LoadOrderService.PoleKind.PreviousProvider)
+                return "error: versus='previous_provider' is subject-relative and pairs with the 'delta' form (one subject, one reference below it) — a tree diffs EVERY provider against ONE reference pole. Use form='delta', or a named/winner versus= on the tree.";
         }
+        // The existing single-pole lanes below drive off the named-pole fields; the richer specs dispatch to the
+        // comparison/overlay lanes before reaching them.
+        string? srcName = srcSpec.Kind == LoadOrderService.PoleKind.Named ? srcSpec.Plugin : null;
+        string? srcMod = srcSpec.Kind == LoadOrderService.PoleKind.Named ? srcSpec.Mod : null;
+        bool srcOverlay = srcSpec.Kind == LoadOrderService.PoleKind.Overlay;
 
         // ---- fields_source (display pole) ---------------------------------------------------------------
         bool winnerFields = false;
         if (!string.IsNullOrWhiteSpace(fields_source))
         {
+            if (comparisonForm)
+                return $"error: fields_source= retargets what a matched row DISPLAYS, and the '{form}' form's display IS its two poles (source=/versus=) — name the version you want as a pole instead.";
             var fs = fields_source.Trim().ToLowerInvariant();
             if (fs == "winner") winnerFields = true;
             else if (fs is not ("scoped" or "scanned"))
@@ -236,6 +247,8 @@ public static class RecordsTools
             return "error: format='dense' renders positional columnar cells 1:1 with requested field paths, and the 'everything' form has no fixed column set — use format='text' or 'json', or name the paths via form='fields'.";
         if (dense && form == "aggregate")
             return "error: format='dense' is the per-row columnar transport, and the 'aggregate' form is a count table — its json render IS the compact form; use format='json'.";
+        if (dense && comparisonForm)
+            return $"error: format='dense' renders positional columnar cells 1:1 with requested field paths, and the '{form}' form's rows are variable-length delta lists with no fixed column set — use format='text' or 'json'.";
         // fields_source= is the SCAN lane's display pole in this wave (it retargets what a matched row DISPLAYS);
         // the list lane's read is its display, so the request would be silently meaningless there — refuse by
         // name (re-review: it was accepted and dropped). The generalized poles land with W2 PR 2's comparison forms.
@@ -307,10 +320,13 @@ public static class RecordsTools
                 return e;
             }
 
+            // ---- delta / tree: the §4.1 comparison forms ride their own engine batches. ------------------
+            if (form is "delta" or "tree") return ListCompare(ids, demand, echoSrc);
+
             // ---- identity form: the labeling lane (absorbs housecarl_resolve). Winner frame by contract. --
             if (form == "identity")
             {
-                if (srcName is not null)
+                if (srcName is not null || srcOverlay)
                     return "error: the identity form is the load-order labeling frame (type/editorid/name/WINNER per FormID) — " +
                            "it does not take a source= pole. Use form='summary' or 'fields' for a named version's view.";
                 var rows = svc.ResolveRefs(ids, demand, out var epoch, out var refusal);
@@ -357,13 +373,27 @@ public static class RecordsTools
             };
             IReadOnlyList<ReadOutcome> outcomes;
             LoadOrderService.PoleInfo? pole = null;
-            if (srcName is null)
+            if (srcOverlay && !string.Equals(srcSpec.OverlayState ?? "post", "pre", StringComparison.OrdinalIgnoreCase))
             {
+                // The overlay POST source: every record's winner replayed through the SkyPatcher INI layer, the
+                // replayed body read at the caller's own depth (absorbs skypatcher_read's post-state view).
+                outcomes = svc.OverlayPostBatch(ids, readFields, depth, demand, out var ovRefusal, out var ovEpoch, out _);
+                if (ovRefusal is not null)
+                    return json ? JsonWire.RenderError(ovRefusal, ovEpoch)
+                                : "error: " + ovRefusal + (ovEpoch is not null ? $"\nepoch={ovEpoch}" : "");
+                Arm("skypatcher overlay (post) — the winner after the SkyPatcher INI layer replays");
+                envelope.Add(new("epoch_covers_source", "false"));
+                headerLine += "\n(the SkyPatcher INI layer's files are OUTSIDE the epoch fingerprint — an INI edit changes answers " +
+                              "without changing the epoch; a record whose type SkyPatcher cannot patch reads as its plain winner)";
+            }
+            else if (srcName is null)
+            {
+                if (srcOverlay) Arm("skypatcher overlay (pre) = winner — the body the INI layer starts from");
                 outcomes = svc.ResolveBatch(ids, readFields, false, depth, resolveNames, null, demand, out var refusal, out var refusalEpoch);
                 if (refusal is not null)
                     return json ? JsonWire.RenderError(refusal, refusalEpoch)
                                 : "error: " + refusal + (refusalEpoch is not null ? $"\nepoch={refusalEpoch}" : "");
-                Arm("winner");
+                if (!srcOverlay) Arm("winner");
             }
             else
             {
@@ -416,6 +446,125 @@ public static class RecordsTools
         }
 
         // ================================================================================================
+        //  COMPARISON forms on the list lane — delta (subject vs reference) and tree (every provider vs
+        //  reference), riding the §4.1 engine batches (one captured build per call).
+        // ================================================================================================
+        string ListCompare(string[] ids, HousecarlCore.ArtifactDemand? demand, string? echoSrc)
+        {
+            List<KeyValuePair<string, string>> Echo()
+            {
+                var e = new List<KeyValuePair<string, string>>
+                {
+                    new("formids", echoSrc ?? $"{ids.Length} inline formid(s)"),
+                    new("form", form),
+                    new("source", srcSpec.Label),
+                };
+                if (versusSpec is not null) e.Add(new("versus", versusSpec.Label));
+                if (projFields is { Length: > 0 }) e.Add(new("fields", string.Join(", ", projFields)));
+                return e;
+            }
+
+            if (form == "delta")
+            {
+                var rows = svc.DeltaBatch(ids, srcSpec, versusSpec!, projFields, demand,
+                                          out var sArm, out var rArm, out var covers, out var refusal, out var epoch);
+                if (refusal is not null)
+                    return json ? JsonWire.RenderError(refusal, epoch) : "error: " + refusal + (epoch is not null ? $"\nepoch={epoch}" : "");
+                return DeltaResponse(rows, sArm, rArm, covers, epoch, Echo());
+            }
+            else   // tree
+            {
+                var rows = svc.TreeBatch(ids, versusSpec!, projFields, demand,
+                                         out var rArm, out var covers, out var refusal, out var epoch);
+                if (refusal is not null)
+                    return json ? JsonWire.RenderError(refusal, epoch) : "error: " + refusal + (epoch is not null ? $"\nepoch={epoch}" : "");
+                return TreeResponse(rows, rArm, covers, epoch, Echo());
+            }
+        }
+
+        // The shared delta response pipeline (envelope, counts_only, window, to_file/ceiling spill, both
+        // renders) — one path for the list AND scan lanes, so their behavior cannot drift.
+        string DeltaResponse(IReadOnlyList<LoadOrderService.DeltaRow> rows, string? sArm, string? rArm, bool covers,
+                             string? epoch, List<KeyValuePair<string, string>> echo)
+        {
+            Arm(sArm ?? srcSpec.Label);
+            envelope.Add(new("versus", rArm ?? versusSpec!.Label));
+            headerLine += $"  versus={rArm ?? versusSpec!.Label}";
+            CoverageNote(covers);
+            int differing = rows.Count(x => x.Error is null && x.Diff!.Deltas.Count > 0);
+            int identical = rows.Count(x => x.Error is null && x.Diff!.Deltas.Count == 0 && x.Diff.Complete);
+            int errs = rows.Count(x => x.Error is not null);
+            if (counts_only)
+                return json
+                    ? JsonWire.RenderNamedCounts(envelope, new[] { KvI("count", rows.Count), KvI("differing", differing), KvI("identical", identical), KvI("errors", errs) }, epoch)
+                    : $"{headerLine}\ncount={rows.Count} differing={differing} identical={identical} errors={errs}" + (epoch is not null ? $"\nepoch={epoch}" : "");
+            var winRows = Windowed(rows);
+            SpillState? spill = null;
+            if (wantFile)
+            {
+                var (s, aerr) = Artifacts.WriteDelta(rows, epoch, toFile!, "to_file", echo);
+                if (aerr is not null) return json ? JsonWire.RenderError(aerr, epoch) : "error: " + aerr;
+                spill = SpillState.Spilled(s!, manifestOnly: true);
+            }
+            string Render(SpillState? sp, out bool trunc) => json
+                ? JsonWire.RenderDelta(winRows, max_chars, epoch, envelope, sp, out trunc)
+                : RenderRecordsDelta(winRows, rows.Count, differing, identical, errs, headerLine, epoch, max_chars, sp, out trunc);
+            var rendered = Render(spill, out var truncated);
+            if (spill is null && truncated)
+            {
+                var path = ResultsStore.NextPath("housecarl_records", epoch ?? "none");
+                var (s, aerr) = Artifacts.WriteDelta(rows, epoch, path, "ceiling", echo);
+                if (aerr is not null) ResultsStore.Release(path);
+                rendered = Render(aerr is null ? SpillState.Spilled(s!, manifestOnly: false) : SpillState.WriteFailed(aerr), out _);
+            }
+            return rendered;
+        }
+
+        // The shared tree response pipeline — the tree form has no subject (every provider is on the bench);
+        // the envelope's source slot carries the reference statement instead.
+        string TreeResponse(IReadOnlyList<LoadOrderService.TreeRow> rows, string? rArm, bool covers,
+                            string? epoch, List<KeyValuePair<string, string>> echo)
+        {
+            Arm(versusSpec!.Kind == LoadOrderService.PoleKind.Winner ? "winner (every provider diffed against it)" : $"reference: {rArm}");
+            CoverageNote(covers);
+            int contested = rows.Count(x => x.Error is null && x.Touchers.Count > 1);
+            int errs = rows.Count(x => x.Error is not null);
+            if (counts_only)
+                return json
+                    ? JsonWire.RenderNamedCounts(envelope, new[] { KvI("count", rows.Count), KvI("contested", contested), KvI("errors", errs) }, epoch)
+                    : $"{headerLine}\ncount={rows.Count} contested={contested} errors={errs}" + (epoch is not null ? $"\nepoch={epoch}" : "");
+            var winRows = Windowed(rows);
+            SpillState? spill = null;
+            if (wantFile)
+            {
+                var (s, aerr) = Artifacts.WriteTree(rows, epoch, toFile!, "to_file", echo);
+                if (aerr is not null) return json ? JsonWire.RenderError(aerr, epoch) : "error: " + aerr;
+                spill = SpillState.Spilled(s!, manifestOnly: true);
+            }
+            string Render(SpillState? sp, out bool trunc) => json
+                ? JsonWire.RenderTree(winRows, max_chars, epoch, envelope, sp, out trunc)
+                : RenderRecordsTree(winRows, rows.Count, contested, errs, projFields is { Length: > 0 }, headerLine, epoch, max_chars, sp, out trunc);
+            var rendered = Render(spill, out var truncated);
+            if (spill is null && truncated)
+            {
+                var path = ResultsStore.NextPath("housecarl_records", epoch ?? "none");
+                var (s, aerr) = Artifacts.WriteTree(rows, epoch, path, "ceiling", echo);
+                if (aerr is not null) ResultsStore.Release(path);
+                rendered = Render(aerr is null ? SpillState.Spilled(s!, manifestOnly: false) : SpillState.WriteFailed(aerr), out _);
+            }
+            return rendered;
+        }
+
+        // A pole that reads content outside the epoch fingerprint (an off-order file; the overlay's INIs) is
+        // DECLARED, envelope + header alike (the PR #305 coverage rule) — one helper so no form forgets.
+        void CoverageNote(bool covers)
+        {
+            if (covers) return;
+            envelope.Add(new("epoch_covers_source", "false"));
+            headerLine += "\n(a pole reads content OUTSIDE the epoch fingerprint — an off-order file or the INI layer; an edit there changes answers without changing the epoch)";
+        }
+
+        // ================================================================================================
         //  SCAN lane — types/plugins/where/references/conflicts_only drive; SOURCE picks the universe.
         // ================================================================================================
         string ScanLane()
@@ -423,6 +572,9 @@ public static class RecordsTools
             if (form == "identity")
                 return "error: the identity form labels a formids= list; a scan's summary rows already carry each match's identity — use form='summary' (the default).";
 
+            if (srcOverlay && !comparisonForm)
+                return "error: the overlay source on a SCAN would replay the SkyPatcher INI layer over every match — a per-record replay at scan scale. " +
+                       "Name the records (formids= reads their post-state bodies), use form='delta'/'tree' for a bounded comparison, or read the whole layer via housecarl_skypatcher_layer.";
             bool hasBodyFilter = where is { Length: > 0 } || references is { Length: > 0 };
             bool hasTypes = types is { Length: > 0 };
             bool hasScope = plugins?.names is { Length: > 0 };
@@ -481,7 +633,9 @@ public static class RecordsTools
             var scanPlugins = srcName is not null ? new[] { srcName } : plugins?.names;
             bool definedIn = plugins?.defined_in ?? false;
             var groupBy = form == "aggregate" ? project!.group_by!.Trim().ToLowerInvariant() : null;
-            int effLimit = wantFile ? int.MaxValue : counts_only ? 0 : (limit <= 0 ? 500 : limit);
+            // Comparison forms compare EVERY match (the window applies to the comparison rows, and the counts /
+            // artifact must cover the full selection) — the scan itself is uncapped for them.
+            int effLimit = wantFile || comparisonForm ? int.MaxValue : counts_only ? 0 : (limit <= 0 ? 500 : limit);
 
             var outcome = svc.CrossQuery(types, refFks, null, conflicts_only, scanPlugins, where,
                                          effLimit, definedIn, groupBy, offset, where_source,
@@ -512,8 +666,47 @@ public static class RecordsTools
                 Add("fields", projFields is { Length: > 0 } ? string.Join(", ", projFields) : null);
                 if (depth > 1) Add("depth", depth.ToString());
                 if (winnerFields) Add("fields_source", "winner");
-                Add("source", srcName);
+                Add("source", srcName ?? (srcSpec.Kind != LoadOrderService.PoleKind.Winner ? srcSpec.Label : null));
+                if (versusSpec is not null) Add("versus", versusSpec.Label);
                 return e;
+            }
+
+            // ---- delta / tree on a scan: the scan SELECTS the records, the §4.1 engine batches compare
+            //      them. Two captures meet here, so the seam is epoch-compared — the halves can never
+            //      silently mix builds (the form=everything discipline).
+            if (comparisonForm && outcome.Error is null && outcome.Groups is null)
+            {
+                var cmpKeys = outcome.Keys.Select(k => k.ToString()).ToList();
+                envelope.Add(new("total", outcome.Total.ToString()));
+                headerLine += $"\n{outcome.Total} match(es) selected by the scan";
+                if (form == "delta")
+                {
+                    var rows = svc.DeltaBatch(cmpKeys, srcSpec, versusSpec!, projFields, null,
+                                              out var sArm, out var rArm, out var covers, out var refusal, out var depoch);
+                    if (refusal is not null)
+                        return json ? JsonWire.RenderError(refusal, depoch) : "error: " + refusal + (depoch is not null ? $"\nepoch={depoch}" : "");
+                    if (outcome.Epoch is not null && depoch is not null && depoch != outcome.Epoch)
+                    {
+                        var tear = $"the load order changed between the scan (epoch={outcome.Epoch}) and the comparison " +
+                                   $"(epoch={depoch}) — the two halves would mix builds. Retry the call.";
+                        return json ? JsonWire.RenderError(tear, depoch) : "error: " + tear;
+                    }
+                    return DeltaResponse(rows, sArm, rArm, covers, depoch, Echo());
+                }
+                else
+                {
+                    var rows = svc.TreeBatch(cmpKeys, versusSpec!, projFields, null,
+                                             out var rArm, out var covers, out var refusal, out var tepoch);
+                    if (refusal is not null)
+                        return json ? JsonWire.RenderError(refusal, tepoch) : "error: " + refusal + (tepoch is not null ? $"\nepoch={tepoch}" : "");
+                    if (outcome.Epoch is not null && tepoch is not null && tepoch != outcome.Epoch)
+                    {
+                        var tear = $"the load order changed between the scan (epoch={outcome.Epoch}) and the comparison " +
+                                   $"(epoch={tepoch}) — the two halves would mix builds. Retry the call.";
+                        return json ? JsonWire.RenderError(tear, tepoch) : "error: " + tear;
+                    }
+                    return TreeResponse(rows, rArm, covers, tepoch, Echo());
+                }
             }
 
             // ---- form=everything on a scan: selection here, bodies via the batch lane (window-bounded).
@@ -636,6 +829,8 @@ public static class RecordsTools
             envelope.Add(new("epoch_covers_source", "false"));
             if (conflicts_only)
                 return "error: conflicts_only= has no meaning on an out-of-load-order file — it is not in the conflict frame. Drop it, or read the winner (source=\"winner\").";
+            if (comparisonForm)
+                return "error: the 'delta'/'tree' forms over an out-of-load-order file SCAN are not composed yet — enumerate the file with form='summary', then compare the specific records via formids= (the comparison poles read the off-order file under the one-pole rule).";
             if (references is { Length: > 0 } || plugins?.names is { Length: > 0 } || (plugins?.defined_in ?? false))
                 return "error: references=/plugins= over an out-of-load-order file land in W2 PR 2 — this wave reads the file by types= (and an 'editorid contains' where-clause).";
             if (form is "fields" or "everything")
@@ -683,6 +878,190 @@ public static class RecordsTools
         if (t.Length == 0) return false;
         text = t;
         return true;
+    }
+
+    static KeyValuePair<string, int> KvI(string k, int v) => new(k, v);
+
+    /// <summary>Parse a §4.2 pole expression from its wire spelling. Null element ⇒ null spec (the caller applies
+    /// its default). Returns the named refusal, or null on success. <paramref name="subjectRole"/> marks source=
+    /// (the SUBJECT): previous_provider is measured FROM the subject and so cannot BE it (§4.3).</summary>
+    static string? ParsePole(JsonElement? el, string param, bool subjectRole, out LoadOrderService.PoleSpec? spec)
+    {
+        spec = null;
+        if (el is not { } e || e.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined) return null;
+        if (e.ValueKind == JsonValueKind.String)
+        {
+            var s = e.GetString()!.Trim();
+            if (s.Length == 0 || s.Equals("winner", StringComparison.OrdinalIgnoreCase))
+            { spec = LoadOrderService.PoleSpec.Winner; return null; }
+            if (s.Equals("previous_provider", StringComparison.OrdinalIgnoreCase))
+            {
+                if (subjectRole)
+                    return "error: source= is the SUBJECT of the call, and 'previous_provider' is measured FROM the subject " +
+                           "(it is the plugin immediately below whatever source= names, §4.3) — so it cannot BE the subject. " +
+                           "Name the subject via source= and pass versus=\"previous_provider\".";
+                spec = new LoadOrderService.PoleSpec(LoadOrderService.PoleKind.PreviousProvider);
+                return null;
+            }
+            spec = new LoadOrderService.PoleSpec(LoadOrderService.PoleKind.Named, s);
+            return null;
+        }
+        if (e.ValueKind == JsonValueKind.Object)
+        {
+            if (e.TryGetProperty("overlay", out var ov))
+            {
+                var kind = ov.ValueKind == JsonValueKind.String ? ov.GetString()!.Trim() : null;
+                if (!string.Equals(kind, "skypatcher", StringComparison.OrdinalIgnoreCase))
+                    return $"error: {param}= names overlay '{kind ?? "<non-string>"}', and the one runtime overlay on this surface is " +
+                           "{\"overlay\": \"skypatcher\", \"state\": \"pre\"|\"post\"} (post = after the INI layer replays; the default).";
+                string? st = e.TryGetProperty("state", out var stEl) && stEl.ValueKind == JsonValueKind.String ? stEl.GetString()!.Trim() : "post";
+                if (!st!.Equals("pre", StringComparison.OrdinalIgnoreCase) && !st.Equals("post", StringComparison.OrdinalIgnoreCase))
+                    return $"error: {param}= overlay state '{st}' — use \"pre\" (the winner before the INI layer) or \"post\" (after it; the default).";
+                spec = new LoadOrderService.PoleSpec(LoadOrderService.PoleKind.Overlay, OverlayState: st.ToLowerInvariant());
+                return null;
+            }
+            if (!e.TryGetProperty("file", out var fEl) || fEl.ValueKind != JsonValueKind.String)
+                return $"error: a structured {param}= names the plugin as {{\"file\": \"X.esp\"[, \"mod\": \"<mod folder>\"]}} or the runtime view as {{\"overlay\": \"skypatcher\", \"state\": \"pre\"|\"post\"}}.";
+            string? mod = e.TryGetProperty("mod", out var mEl) && mEl.ValueKind == JsonValueKind.String ? mEl.GetString()!.Trim() : null;
+            spec = new LoadOrderService.PoleSpec(LoadOrderService.PoleKind.Named, fEl.GetString()!.Trim(), mod);
+            return null;
+        }
+        return $"error: {param}= is a string (\"winner\" | a plugin filename{(subjectRole ? "" : " | \"previous_provider\"")}) or an object ({{\"file\", \"mod\"}} | {{\"overlay\", \"state\"}}).";
+    }
+
+    /// <summary>The delta form's text render: header counts, then per record the two pole lines, the §4.3
+    /// stack-above FACT (neutral — never advice), and diff_record's own delta-line grammar with its truncation
+    /// honesty (a truncated deep read is never rendered as 'identical').</summary>
+    static string RenderRecordsDelta(IReadOnlyList<LoadOrderService.DeltaRow> rows, int total, int differing, int identical, int errors,
+                                     string headerLine, string? epoch, int maxChars, SpillState? spill, out bool truncated)
+    {
+        truncated = false;
+        int cap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        bool manifestOnly = spill?.ManifestOnly ?? false;
+        var sb = new StringBuilder();
+        sb.Append(headerLine).Append('\n');
+        sb.Append(total).Append(" record(s): ").Append(differing).Append(" differing, ").Append(identical)
+          .Append(" identical, ").Append(errors).Append(" error(s)");
+        if (epoch is not null) sb.Append("  epoch=").Append(epoch);
+        sb.Append('\n');
+        int rendered = 0;
+        foreach (var row in rows)
+        {
+            if (manifestOnly) break;
+            if (sb.Length >= cap)
+            {
+                truncated = true;
+                sb.Append("... [rendered ").Append(rendered).Append(" of ").Append(rows.Count)
+                  .Append(" rows at max_chars=").Append(cap).Append("]\n");
+                break;
+            }
+            sb.Append('\n').Append(row.Formid);
+            if (row.Error is not null)
+            {
+                sb.Append("  error=").Append(row.Error).Append('\n');
+                if (row.StackAbove is { Count: > 0 })
+                    sb.Append("  stack above the subject (closer to winning, winner last): ").Append(string.Join(", ", row.StackAbove)).Append('\n');
+                rendered++;
+                continue;
+            }
+            var s = row.Subject!; var r = row.Reference!; var d = row.Diff!;
+            sb.Append("  ").Append(s.RecordType ?? "?").Append("  ").Append(s.EditorId ?? "<no editorid>").Append('\n');
+            sb.Append("  subject:   ").Append(s.Plugin).Append(" [").Append(s.Where).Append("]\n");
+            sb.Append("  reference: ").Append(r.Plugin).Append(" [").Append(r.Where).Append("]\n");
+            if (row.StackAbove is { Count: > 0 })
+                sb.Append("  stack above the subject (closer to winning, winner last): ").Append(string.Join(", ", row.StackAbove)).Append('\n');
+            if (row.Note is not null) sb.Append("  note: ").Append(row.Note).Append('\n');
+            if (d.Deltas.Count == 0)
+            {
+                if (!d.Complete)
+                    sb.Append("  no differing fields in what was read, but the deep read was TRUNCATED at the cap — NOT a clean 'identical' (Q3). Narrow with project.fields to compare in full.\n");
+                else if (d.AgreedCount > 0)
+                    sb.Append("  identical across the fields read (").Append(d.AgreedCount).Append(" value leaf/leaves agree).\n");
+                else
+                    sb.Append("  identical across the fields read (no differing fields).\n");
+            }
+            else
+            {
+                sb.Append("  ").Append(d.Deltas.Count).Append(d.Deltas.Count == 1 ? " difference" : " differences")
+                  .Append(" — each line: ").Append(s.Plugin).Append("'s value (reference = ").Append(r.Plugin).Append("):\n");
+                foreach (var delta in d.Deltas)
+                {
+                    if (sb.Length >= cap)
+                    {
+                        truncated = true;
+                        sb.Append("    ... [delta lines cut at max_chars=").Append(cap).Append(" — raise max_chars or narrow with project.fields]\n");
+                        break;
+                    }
+                    sb.Append("    - ").Append(delta).Append('\n');
+                }
+                if (!d.Complete)
+                    sb.Append("  note: the deep read was TRUNCATED — list-content and one-sided-presence deltas are SUPPRESSED; narrow with project.fields to compare those in full.\n");
+            }
+            rendered++;
+        }
+        if (spill is not null) Artifacts.AppendSpillStateText(sb, spill);
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    /// <summary>The tree form's text render: per record the touching list (load order, winner LAST) and each
+    /// provider's delta against the reference — the conflict_tree view as a PROJECT form, same wording rules
+    /// (identical-vs-truncated honesty; list contents compared by content, reorders flagged).</summary>
+    static string RenderRecordsTree(IReadOnlyList<LoadOrderService.TreeRow> rows, int total, int contested, int errors,
+                                    bool fieldsNarrow, string headerLine, string? epoch, int maxChars,
+                                    SpillState? spill, out bool truncated)
+    {
+        truncated = false;
+        int cap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        bool manifestOnly = spill?.ManifestOnly ?? false;
+        var sb = new StringBuilder();
+        sb.Append(headerLine).Append('\n');
+        sb.Append(total).Append(" record(s): ").Append(contested).Append(" contested, ").Append(errors).Append(" error(s)");
+        if (epoch is not null) sb.Append("  epoch=").Append(epoch);
+        sb.Append('\n');
+        int rendered = 0;
+        foreach (var row in rows)
+        {
+            if (manifestOnly) break;
+            if (sb.Length >= cap)
+            {
+                truncated = true;
+                sb.Append("... [rendered ").Append(rendered).Append(" of ").Append(rows.Count)
+                  .Append(" rows at max_chars=").Append(cap).Append("]\n");
+                break;
+            }
+            sb.Append('\n').Append(row.Formid);
+            if (row.Error is not null) { sb.Append("  error=").Append(row.Error).Append('\n'); rendered++; continue; }
+            sb.Append("  ").Append(row.Type ?? "?").Append("  ").Append(row.EditorId ?? "<no editorid>").Append('\n');
+            sb.Append("  ").Append(row.Touchers.Count).Append(" plugin(s) touch this record (load order, winner last):\n");
+            for (int i = 0; i < row.Touchers.Count; i++)
+                sb.Append("    ").Append(i + 1).Append(". ").Append(row.Touchers[i])
+                  .Append(i == row.Touchers.Count - 1 ? "  (winner)" : "").Append('\n');
+            if (row.Nodes.Count <= 1) { rendered++; continue; }   // a sole provider has nothing to diff against
+            sb.Append("  diff (field deltas vs ").Append(row.ReferencePlugin)
+              .Append("; identical fields omitted; list contents compared by content, element reorders flagged):\n");
+            foreach (var n in row.Nodes)
+            {
+                if (n.IsReference) continue;
+                if (sb.Length >= cap)
+                {
+                    truncated = true;
+                    sb.Append("    ... [nodes cut at max_chars=").Append(cap).Append(" — raise max_chars or narrow with project.fields]\n");
+                    break;
+                }
+                sb.Append("    ").Append(n.Plugin).Append(n.IsWinner ? " (winner)" : "").Append(": ");
+                if (n.Deltas.Count > 0)
+                    sb.Append(string.Join("; ", n.Deltas)).Append('\n');
+                else if (!n.Complete)
+                    sb.Append("no differing fields in what was read, but the deep read was TRUNCATED — not a clean 'identical'.\n");
+                else
+                    sb.Append(fieldsNarrow
+                        ? $"identical to {row.ReferencePlugin} across the fields read ({n.AgreedCount} leaf/leaves agree)\n"
+                        : $"identical to {row.ReferencePlugin} (whole record; {n.AgreedCount} leaf/leaves agree)\n");
+            }
+            rendered++;
+        }
+        if (spill is not null) Artifacts.AppendSpillStateText(sb, spill);
+        return sb.ToString().TrimEnd('\n');
     }
 
     /// <summary>The list-lane summary render: one identity+winner line per outcome (or its per-item error) — the

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -53,6 +53,39 @@ public static class RecordsTools
         public bool resolve_names { get; set; }
     }
 
+    /// <summary>The §3 traversal construct: follow record-to-record FORM LINKS and select what the walk reaches.
+    /// This traverses BETWEEN records; expanding nested fields WITHIN one record is project.depth (the declared
+    /// seam). Seeds are this call's own SELECT (formids=, or a scan's matches).</summary>
+    public sealed class RecordsWalk
+    {
+        [Description("Link-bearing field paths that start the walk from each seed, e.g. [\"HeadParts\", \"WornArmor\"]. Omit for every link on the seed.")]
+        public string[]? seed_paths { get; set; }
+
+        [Description("The link path followed at every LATER hop. \"*\" (default) walks every link — full closure. A named path restricts to one chain, e.g. \"Template\" for NPC template inheritance.")]
+        public string? follow { get; set; }
+
+        [Description("'forward' (default) — what the seeds point AT (cheap: each hop is one link resolve). 'reverse' — what points AT the seeds; depth 1 only (reverse is a bounded scan; transitive reverse is refused naming the reverse-reference index as the future capability). The general reverse spelling on this surface IS references= (same construct); walk.direction='reverse' serves the typed MGEF lane — magic-effect seeds get per-carrier magnitude/area/duration.")]
+        public string? direction { get; set; }
+
+        [Description("Maximum hops from a seed (default 16). Nodes AT the cap are recorded, not entered, and the response says the cap cut the walk — never a silent stop.")]
+        public int? depth { get; set; }
+
+        [Description("Maximum nodes reached per seed (default 2000, the read-expansion budget). A breach keeps what was proved and says so.")]
+        public int? max_nodes { get; set; }
+
+        [Description("Node classes the walk must not enter, as data: [{\"match\": \"Race\", \"severity\": \"stop\"|\"refuse\"}] — match is the record type name a read reports; stop prunes there (recorded as a boundary), refuse fails the whole call loud.")]
+        public RecordsWalkExclusion[]? exclusions { get; set; }
+    }
+
+    public sealed class RecordsWalkExclusion
+    {
+        [Description("The record type name to match (as reads report it, e.g. 'Race', 'Npc').")]
+        public string? match { get; set; }
+
+        [Description("'stop' (prune here, record the boundary) or 'refuse' (the whole walk fails loud).")]
+        public string? severity { get; set; }
+    }
+
     [McpServerTool(Name = "housecarl_records", ReadOnly = true, Title = "Read records (the 2.0 read surface)"),
      Description(
          "Read Bethesda records from the load order — ONE read surface: which records (SELECT) x whose version " +
@@ -132,6 +165,8 @@ public static class RecordsTools
             string? fields_source = null,
         [Description("PROJECT: the shape of the answer — a single form plus its own sub-parameters. Omit for summary rows.")]
             RecordsProject? project = null,
+        [Description("SELECT: the traversal construct — follow record-to-record links from this call's own SELECT (the seeds) and select what the walk reaches; project.form='chain' renders the paths/endpoints/cycles themselves (with, for NPC template chains, the per-category active-vs-masked inheritance report), while any other form reads the reached set like any selection. The walk expands on the WINNER's link graph; source= governs whose version the form then reads.")]
+            RecordsWalk? walk = null,
         [Description("TRANSPORT: 'text' (default) | 'json' (machine-readable document; same accounting in-band) | 'dense' (scan lane: columnar positional rows — the compact bulk-enumeration form).")]
             string? format = null,
         [Description("TRANSPORT: max rows to render (default 500). The TRUE total is always reported; page with offset=.")]
@@ -157,12 +192,9 @@ public static class RecordsTools
         var form = project?.form?.Trim().ToLowerInvariant() ?? "summary";
         switch (form)
         {
-            case "identity" or "summary" or "fields" or "everything" or "aggregate" or "delta" or "tree" or "info_order": break;
-            case "chain":
-                return "error: project.form='chain' is a W2 PR 2 form (traversal) and is not on this surface yet — " +
-                       "meanwhile: housecarl_effect_chain traces an MGEF's carriers; references= is the one-step reverse lookup.";
+            case "identity" or "summary" or "fields" or "everything" or "aggregate" or "delta" or "tree" or "info_order" or "chain": break;
             default:
-                return $"error: project.form='{project?.form}' is not a form — use identity | summary | fields | everything | aggregate | delta | tree.";
+                return $"error: project.form='{project?.form}' is not a form — use identity | summary | fields | everything | aggregate | delta | tree | chain | info_order.";
         }
         bool comparisonForm = form is "delta" or "tree";
         // Sub-parameters exist only inside their forms (SPEC §2.2) — a stray one is refused by name, so the caller
@@ -217,6 +249,54 @@ public static class RecordsTools
             if (versusSpec.Kind == LoadOrderService.PoleKind.PreviousProvider)
                 return "error: versus='previous_provider' is subject-relative and pairs with the 'delta' form (one subject, one reference below it) — a tree diffs EVERY provider against ONE reference pole. Use form='delta', or a named/winner versus= on the tree.";
         }
+        // ---- walk= (the §3 traversal construct) ---------------------------------------------------------
+        string walkDirection = "forward";
+        int walkDepth = 16, walkMaxNodes = 2000;
+        var walkExclusions = new List<(string Match, bool Refuse)>();
+        if (walk is not null)
+        {
+            var dir = walk.direction?.Trim().ToLowerInvariant();
+            if (dir is not (null or "" or "forward" or "reverse"))
+                return $"error: walk.direction='{walk.direction}' — use 'forward' (what the seeds point at) or 'reverse' (what points at them; depth 1).";
+            if (!string.IsNullOrEmpty(dir)) walkDirection = dir!;
+            if (walk.depth is { } wd)
+            {
+                if (wd < 1) return $"error: walk.depth={wd} — depth must be >= 1 (hops from the seed).";
+                walkDepth = wd;
+            }
+            if (walk.max_nodes is { } wn)
+            {
+                if (wn < 1) return $"error: walk.max_nodes={wn} — the node budget must be >= 1.";
+                walkMaxNodes = wn;
+            }
+            foreach (var x in walk.exclusions ?? Array.Empty<RecordsWalkExclusion>())
+            {
+                if (string.IsNullOrWhiteSpace(x.match))
+                    return "error: a walk.exclusions entry needs match= — the record type name a read reports (e.g. 'Race').";
+                var sev = x.severity?.Trim().ToLowerInvariant();
+                if (sev is not ("stop" or "refuse"))
+                    return $"error: walk.exclusions '{x.match}': severity='{x.severity}' — use 'stop' (prune, record the boundary) or 'refuse' (the whole walk fails loud).";
+                walkExclusions.Add((x.match!.Trim(), sev == "refuse"));
+            }
+            if (walkDirection == "reverse")
+            {
+                if (walk.depth is > 1)
+                    return "error: walk.direction='reverse' with depth>1 is a TRANSITIVE reverse lookup — no index exists for it today, so it is refused rather than run as an unbounded scan-of-scans (the reverse-reference index is the known future capability that lifts this). Depth-1 reverse: references= with a bounding types=/plugins=, or MGEF seeds under form='chain' for the typed carrier lane.";
+                if (walk.seed_paths is { Length: > 0 } || walk.exclusions is { Length: > 0 } || walk.follow is not null)
+                    return "error: walk.seed_paths/follow/exclusions shape a FORWARD expansion — a reverse walk scans TOWARD the seeds. Drop them.";
+                if (form != "chain")
+                    return "error: the reverse walk's general spelling on this surface IS references= (the same construct, depth 1, bounded by types=/plugins=) — walk.direction='reverse' serves form='chain' with MGEF seeds (per-carrier magnitude/area/duration).";
+            }
+            if (references is { Length: > 0 })
+                return "error: walk= and references= are the same construct (references= IS the reverse walk at depth 1) — use one spelling per call.";
+            if (comparisonForm || form is "info_order" or "identity")
+                return $"error: walk= derives a selection (the reached set), and the '{form}' form does not consume one — use form='chain' for the walk's own paths, or summary/fields/everything/aggregate over the reached set. To compare reached records, walk with to_file= and re-enter the artifact via formids=[\"@<file>\"] with form='{form}'.";
+            if (where is { Length: > 0 })
+                return "error: walk= composed with where= (filtering the reached set by predicate) — walk with to_file=, then re-enter the artifact on a bounded scan via where=[\"formid in @<file>\", …]; the reached set becomes the scan's identity list.";
+        }
+        if (form == "chain" && walk is null)
+            return "error: the 'chain' form renders a walk's paths — pass walk= (e.g. walk={\"follow\": \"Template\"} over NPC seeds; reverse MGEF carriers: walk={\"direction\": \"reverse\"} with MGEF formids=).";
+
         // The existing single-pole lanes below drive off the named-pole fields; the richer specs dispatch to the
         // comparison/overlay lanes before reaching them.
         string? srcName = srcSpec.Kind == LoadOrderService.PoleKind.Named ? srcSpec.Plugin : null;
@@ -241,10 +321,17 @@ public static class RecordsTools
                        || where is { Length: > 0 } || references is { Length: > 0 };
         if (!hasFormids && !hasScan)
             return "error: select something — formids= (a record list), or a scan scope: types=, plugins=, conflicts_only=true, where=, references=.";
-        if (hasFormids && hasScan)
+        // A reverse MGEF walk narrows its carrier set with types= — the one place formids (the seeds) and a scan
+        // term legitimately meet ahead of the general composition (the types entries bound the typed carrier scan).
+        bool reverseWalk = walk is not null && walkDirection == "reverse";
+        if (hasFormids && hasScan && !reverseWalk)
             return "error: formids= composes with the scan terms (types=/plugins=/where=/references=/conflicts_only=) in W2 PR 2 — " +
                    "not on this surface yet. Meanwhile: run the scan, spill/to_file the result, and re-enter it via where=[\"formid in @<file>\"]; " +
                    "or filter the formids list client-side.";
+        if (reverseWalk && (plugins?.names is { Length: > 0 } || conflicts_only || where is { Length: > 0 }))
+            return "error: the reverse MGEF walk takes formids= (the effects) and optionally types= (narrowing the carrier types) — the general bounded reverse over other scan terms is the references= spelling.";
+        if (reverseWalk && !hasFormids)
+            return "error: the reverse walk needs its seeds — pass formids= (the MGEF(s) whose carriers to trace).";
         // dense is DEFINED as positional columnar cells 1:1 with the requested field paths (the tool description's
         // own rule) — the forms with no fixed column set refuse by name rather than quietly switching transport
         // (re-review: everything fell back to text, aggregate to the json table, neither saying so).
@@ -284,6 +371,14 @@ public static class RecordsTools
         var envelope = new List<KeyValuePair<string, string>> { new("form", form) };
         string headerLine = $"records  form={form}";
         void Arm(string statement) { envelope.Add(new("source", statement)); headerLine += $"  source={statement}"; }
+        // When a walk (or a scan) derived the selection this call now reads, the two captures meet at a seam —
+        // every downstream form's epoch is compared against the deriving step's, and a divergence refuses loud
+        // (the mixed-builds rule every two-capture path on this surface follows).
+        string? expectEpoch = null;
+        string? SeamTear(string? epoch) =>
+            expectEpoch is not null && epoch is not null && epoch != expectEpoch
+                ? $"the load order changed between deriving the selection (epoch={expectEpoch}) and reading it (epoch={epoch}) — the two halves would mix builds. Retry the call."
+                : null;
 
         // limit=/offset= WINDOW the list lane's render (round-3 review: they were accepted-and-dropped there).
         // The census, the aggregate, and every artifact write still cover the COMPLETE list; the window note
@@ -328,6 +423,9 @@ public static class RecordsTools
                 if (depth > 1) e.Add(new("depth", depth.ToString()));
                 return e;
             }
+
+            // ---- walk=: the traversal construct derives the selection (or, form='chain', IS the render). --
+            if (walk is not null) return WalkLane(ids, demand, echoSrc);
 
             // ---- delta / tree: the §4.1 comparison forms ride their own engine batches. ------------------
             if (form is "delta" or "tree") return ListCompare(ids, demand, echoSrc);
@@ -433,6 +531,8 @@ public static class RecordsTools
                 }
             }
             var epoch2 = outcomes.FirstOrDefault(o => o.Epoch is not null)?.Epoch;
+            if (SeamTear(epoch2) is { } seamTear)
+                return json ? JsonWire.RenderError(seamTear, epoch2) : "error: " + seamTear;
 
             if (form == "aggregate")
                 return RenderListAggregate(outcomes, project!.group_by!, json, dense, epoch2, headerLine, envelope);
@@ -466,6 +566,123 @@ public static class RecordsTools
                 rendered2 = Render2(aerr is null ? SpillState.Spilled(s!, manifestOnly: false) : SpillState.WriteFailed(aerr), out _);
             }
             return rendered2;
+        }
+
+        // ================================================================================================
+        //  WALK lane — the §3 traversal construct: forward walks expand the winner link graph (chain form
+        //  renders the paths; any other form consumes the reached set as its selection); the reverse walk's
+        //  typed MGEF lane traces carriers with per-hit payload (the effect_chain absorption).
+        // ================================================================================================
+        string WalkLane(string[] ids, HousecarlCore.ArtifactDemand? demand, string? echoSrc)
+        {
+            List<KeyValuePair<string, string>> Echo()
+            {
+                var e = new List<KeyValuePair<string, string>>
+                {
+                    new("formids", echoSrc ?? $"{ids.Length} inline seed(s)"),
+                    new("form", form),
+                    new("walk", $"{walkDirection}{(walk!.follow is { } f ? $" follow={f}" : "")} depth={walkDepth}"),
+                };
+                if (walk.seed_paths is { Length: > 0 }) e.Add(new("seed_paths", string.Join(", ", walk.seed_paths)));
+                return e;
+            }
+
+            if (walkDirection == "reverse")
+            {
+                // The typed MGEF lane (the effect_chain absorption, §3.3): each seed MUST resolve to a
+                // MagicEffect — a non-MGEF seed fails LOUD per item, never a silent '0 carriers'.
+                var results = new List<(string Seed, EffectChainResult Result)>(ids.Length);
+                foreach (var raw in ids)
+                {
+                    FormKey fk;
+                    try { fk = FormKey.Factory(raw.Trim()); }
+                    catch (Exception ex) { results.Add((raw?.Trim() ?? "", EffectChainResult.Fail($"bad FormID '{raw}': {ex.Message}"))); continue; }
+                    results.Add((fk.ToString(), svc.ResolveEffectChain(fk, types, limit <= 0 ? 500 : limit)));
+                }
+                Arm("winner (carriers are the load-order-effective versions)");
+                envelope.Add(new("walk", "reverse, depth 1 — the typed MGEF carrier lane"));
+                headerLine += "\nwalk=reverse (per seed: every SPEL/ENCH/ALCH/SCRL/INGR applying it, with the MATCHING entry's magnitude/area/duration — reported AS AUTHORED; conditions are not evaluated, so a row means 'defines it at this strength', not 'it will fire')";
+                var epochR = results.Select(r => r.Result.Epoch).FirstOrDefault(e => e is not null);
+                if (counts_only)
+                    return json
+                        ? JsonWire.RenderNamedCounts(envelope, new[] { KvI("seeds", results.Count), KvI("carrier_rows", results.Sum(r => r.Result.Error is null ? r.Result.Total : 0)), KvI("errors", results.Count(r => r.Result.Error is not null)) }, epochR)
+                        : $"{headerLine}\nseeds={results.Count} carrier_rows={results.Sum(r => r.Result.Error is null ? r.Result.Total : 0)} errors={results.Count(r => r.Result.Error is not null)}" + (epochR is not null ? $"\nepoch={epochR}" : "");
+                if (json) return JsonWire.RenderEffectChains(results, max_chars, envelope);
+                var sbR = new StringBuilder();
+                sbR.Append(headerLine).Append('\n');
+                foreach (var (seed, result) in results)
+                {
+                    sbR.Append('\n').Append("seed ").Append(seed).Append('\n');
+                    sbR.Append(Wire.RenderEffectChain(result, max_chars));
+                    sbR.Append('\n');
+                    if (sbR.Length >= (max_chars > 0 ? max_chars : Wire.DefaultMaxChars))
+                    { sbR.Append("... [seeds cut at max_chars — raise max_chars or pass fewer seeds]\n"); break; }
+                }
+                return sbR.ToString().TrimEnd('\n');
+            }
+
+            // FORWARD: one engine batch, one captured build; the chain form renders it, every other form
+            // consumes the reached set (seeds ∪ reached — the render says so) through the normal lanes.
+            var rows = svc.WalkForwardBatch(ids, walk!.seed_paths, walk.follow, walkDepth, walkMaxNodes,
+                                            walkExclusions, demand, out var wRefusal, out var wEpoch);
+            if (wRefusal is not null)
+                return json ? JsonWire.RenderError(wRefusal, wEpoch) : "error: " + wRefusal + (wEpoch is not null ? $"\nepoch={wEpoch}" : "");
+            if (SeamTear(wEpoch) is { } wTear)
+                return json ? JsonWire.RenderError(wTear, wEpoch) : "error: " + wTear;
+
+            if (form == "chain")
+            {
+                Arm("winner (the walk expands the winner link graph)");
+                int reached = rows.Where(r => r.Error is null).Sum(r => r.Nodes.Count(n => !n.Status.StartsWith("no links")));
+                int errs = rows.Count(r => r.Error is not null);
+                envelope.Add(new("walk", $"forward{(walk.follow is { } f2 ? $" follow={f2}" : " (closure)")} depth={walkDepth}"));
+                if (counts_only)
+                    return json
+                        ? JsonWire.RenderNamedCounts(envelope, new[] { KvI("seeds", rows.Count), KvI("reached", reached), KvI("errors", errs) }, wEpoch)
+                        : $"{headerLine}\nseeds={rows.Count} reached={reached} errors={errs}" + (wEpoch is not null ? $"\nepoch={wEpoch}" : "");
+                var winRows = Windowed(rows);
+                SpillState? spill = null;
+                if (wantFile)
+                {
+                    var (s, aerr) = Artifacts.WriteChain(rows, wEpoch, toFile!, "to_file", Echo());
+                    if (aerr is not null) return json ? JsonWire.RenderError(aerr, wEpoch) : "error: " + aerr;
+                    spill = SpillState.Spilled(s!, manifestOnly: true);
+                }
+                string Render(SpillState? sp, out bool trunc) => json
+                    ? JsonWire.RenderChain(winRows, max_chars, wEpoch, envelope, sp, out trunc)
+                    : RenderRecordsChain(winRows, rows.Count, reached, errs, headerLine, wEpoch, max_chars, sp, out trunc);
+                var rendered = Render(spill, out var truncated);
+                if (spill is null && truncated)
+                {
+                    var path = ResultsStore.NextPath("housecarl_records", wEpoch ?? "none");
+                    var (s, aerr) = Artifacts.WriteChain(rows, wEpoch, path, "ceiling", Echo());
+                    if (aerr is not null) ResultsStore.Release(path);
+                    rendered = Render(aerr is null ? SpillState.Spilled(s!, manifestOnly: false) : SpillState.WriteFailed(aerr), out _);
+                }
+                return rendered;
+            }
+
+            // Selection consumption: seeds ∪ reached, in walk order, deduplicated — then the ordinary form
+            // pipelines read it (source= decides whose version), seam-checked against the walk's build.
+            var combined = new List<string>();
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var r in rows)
+            {
+                if (r.Error is not null) continue;
+                if (seen.Add(r.Seed)) combined.Add(r.Seed);
+                foreach (var n in r.Nodes)
+                    if (n.Type is not null && seen.Add(n.Key)) combined.Add(n.Key);
+            }
+            int seedErrs = rows.Count(r => r.Error is not null);
+            if (combined.Count == 0)
+                return json ? JsonWire.RenderError($"the walk reached nothing readable ({seedErrs} seed error(s) — run form='chain' to see each seed's outcome).", wEpoch)
+                            : $"error: the walk reached nothing readable ({seedErrs} seed error(s) — run form='chain' to see each seed's outcome)." + (wEpoch is not null ? $"\nepoch={wEpoch}" : "");
+            envelope.Add(new("walk", $"forward{(walk.follow is { } f3 ? $" follow={f3}" : " (closure)")} depth={walkDepth} — selection = the {combined.Count} record(s) the walk reached (seeds included{(seedErrs > 0 ? $"; {seedErrs} seed error(s), listed via form='chain'" : "")})"));
+            headerLine += $"\nwalk: selection = {combined.Count} reached record(s) (seeds included)";
+            expectEpoch = wEpoch;
+            formids = combined.ToArray();
+            walk = null;
+            return ListLane();
         }
 
         // ================================================================================================
@@ -690,9 +907,11 @@ public static class RecordsTools
             var scanPlugins = srcName is not null ? new[] { srcName } : plugins?.names;
             bool definedIn = plugins?.defined_in ?? false;
             var groupBy = form == "aggregate" ? project!.group_by!.Trim().ToLowerInvariant() : null;
-            // Comparison forms compare EVERY match (the window applies to the comparison rows, and the counts /
-            // artifact must cover the full selection) — the scan itself is uncapped for them.
-            int effLimit = wantFile || comparisonForm ? int.MaxValue : counts_only ? 0 : (limit <= 0 ? 500 : limit);
+            // The derived-selection forms (comparisons, info_order, a walk's seeds) consume EVERY match — the
+            // window applies to their rows, and the counts / artifact must cover the full selection — so the
+            // scan itself is uncapped for them.
+            bool derivedSelection = comparisonForm || form == "info_order" || walk is not null;
+            int effLimit = wantFile || derivedSelection ? int.MaxValue : counts_only ? 0 : (limit <= 0 ? 500 : limit);
 
             var outcome = svc.CrossQuery(types, refFks, null, conflicts_only, scanPlugins, where,
                                          effLimit, definedIn, groupBy, offset, where_source,
@@ -726,6 +945,17 @@ public static class RecordsTools
                 Add("source", srcName ?? (srcSpec.Kind != LoadOrderService.PoleKind.Winner ? srcSpec.Label : null));
                 if (versusSpec is not null) Add("versus", versusSpec.Label);
                 return e;
+            }
+
+            // ---- walk= on a scan: the scan's matches are the SEEDS; the walk lane takes it from there
+            //      (chain render, or the reached set through the form pipelines), seam-checked throughout.
+            if (walk is not null && outcome.Error is null && outcome.Groups is null)
+            {
+                var seedKeys = outcome.Keys.Select(k => k.ToString()).ToArray();
+                envelope.Add(new("total", outcome.Total.ToString()));
+                headerLine += $"\n{outcome.Total} match(es) selected by the scan as walk seeds";
+                expectEpoch = outcome.Epoch;
+                return WalkLane(seedKeys, null, null);
             }
 
             // ---- delta / tree on a scan: the scan SELECTS the records, the §4.1 engine batches compare
@@ -909,6 +1139,8 @@ public static class RecordsTools
                 return "error: the 'delta'/'tree' forms over an out-of-load-order file SCAN are not composed yet — enumerate the file with form='summary', then compare the specific records via formids= (the comparison poles read the off-order file under the one-pole rule).";
             if (form == "info_order")
                 return "error: the info_order form merges the ACTIVE order's touching plugins — an out-of-load-order file is not in that frame. Read the winner's merge (drop source=), or enumerate the file's DIAL records with form='summary'.";
+            if (walk is not null)
+                return "error: the walk expands the ACTIVE order's winner link graph — an out-of-load-order file's records are not in that graph. Enumerate the file with form='summary', then walk specific records via formids= (dropping source=).";
             if (references is { Length: > 0 } || plugins?.names is { Length: > 0 } || (plugins?.defined_in ?? false))
                 return "error: references=/plugins= over an out-of-load-order file land in W2 PR 2 — this wave reads the file by types= (and an 'editorid contains' where-clause).";
             if (form is "fields" or "everything")
@@ -1135,6 +1367,75 @@ public static class RecordsTools
                     sb.Append(fieldsNarrow
                         ? $"identical to {row.ReferencePlugin} across the fields read ({n.AgreedCount} leaf/leaves agree)\n"
                         : $"identical to {row.ReferencePlugin} (whole record; {n.AgreedCount} leaf/leaves agree)\n");
+            }
+            rendered++;
+        }
+        if (spill is not null) Artifacts.AppendSpillStateText(sb, spill);
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    /// <summary>The chain form's text render: per seed the reached nodes in BFS order with provenance (what
+    /// pulled each node in), recorded cycles, the cap-truncation note (read posture — what is listed IS proved),
+    /// and the NPC_ TemplateFlags inheritance report where the walk was a Template chain.</summary>
+    static string RenderRecordsChain(IReadOnlyList<LoadOrderService.WalkSeedResult> rows, int total, int reached,
+                                     int errors, string headerLine, string? epoch, int maxChars,
+                                     SpillState? spill, out bool truncated)
+    {
+        truncated = false;
+        int cap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        bool manifestOnly = spill?.ManifestOnly ?? false;
+        var sb = new StringBuilder();
+        sb.Append(headerLine).Append('\n');
+        sb.Append(total).Append(" seed(s), ").Append(reached).Append(" node(s) reached, ").Append(errors).Append(" error(s)");
+        if (epoch is not null) sb.Append("  epoch=").Append(epoch);
+        sb.Append('\n');
+        int rendered = 0;
+        foreach (var row in rows)
+        {
+            if (manifestOnly) break;
+            if (sb.Length >= cap)
+            {
+                truncated = true;
+                sb.Append("... [rendered ").Append(rendered).Append(" of ").Append(rows.Count)
+                  .Append(" seeds at max_chars=").Append(cap).Append("]\n");
+                break;
+            }
+            sb.Append('\n').Append(row.Seed);
+            if (row.Error is not null) { sb.Append("  error=").Append(row.Error).Append('\n'); rendered++; continue; }
+            sb.Append("  ").Append(row.Type ?? "?").Append("  ").Append(row.EditorId ?? "<no editorid>").Append('\n');
+            if (row.Nodes.Count == 0)
+                sb.Append("  no links to follow from this seed").Append(row.TruncationNote is null ? ".\n" : " before the cap.\n");
+            foreach (var n in row.Nodes)
+            {
+                if (sb.Length >= cap)
+                {
+                    truncated = true;
+                    sb.Append("    ... [nodes cut at max_chars=").Append(cap).Append(" — raise max_chars, or to_file= for the complete walk]\n");
+                    break;
+                }
+                sb.Append("    d").Append(n.Depth).Append("  ").Append(n.Key);
+                if (n.Type is not null) sb.Append("  ").Append(n.Type).Append("  ").Append(n.EditorId ?? "<no editorid>");
+                sb.Append("  [").Append(n.Status).Append(']');
+                if (n.Note is not null) sb.Append("  ").Append(n.Note);
+                sb.Append("  <- ").Append(n.PulledBy).Append('\n');
+            }
+            foreach (var c in row.Cycles)
+                sb.Append("  cycle: ").Append(c).Append('\n');
+            if (row.TruncationNote is not null)
+                sb.Append("  [!] ").Append(row.TruncationNote).Append('\n');
+            if (row.TemplateReport is { } tr)
+            {
+                sb.Append("  template inheritance (TemplateFlags — a SET flag means the category is INHERITED and the seed's own local data for it is MASKED):\n");
+                foreach (var c in tr)
+                {
+                    sb.Append("    ").Append(c.Category).Append(": ");
+                    if (!c.InheritedAtSeed) sb.Append("local data ACTIVE");
+                    else if (c.ProviderKey is not null)
+                        sb.Append("INHERITED from ").Append(c.ProviderKey).Append(" (").Append(c.ProviderEditorId ?? "<no editorid>").Append(')');
+                    else sb.Append("INHERITED");
+                    if (c.Note is not null && c.InheritedAtSeed) sb.Append("  — ").Append(c.Note);
+                    sb.Append('\n');
+                }
             }
             rendered++;
         }

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -106,8 +106,10 @@ public static class RecordsTools
          "index that would lift the bound is a known future capability). UNION-ARM tip: when a field is one of " +
          "several shapes (an NPC's Configuration.Level is a fixed level OR a PC-level multiplier), a scalar " +
          "predicate on one arm's sub-field doubles as an ARM-PRESENCE test: where=[\"Configuration.Level.LevelMult " +
-         ">= 0\"] returns exactly the NPCs on a multiplier. In this wave formids= composes with the OTHER select " +
-         "terms in W2 PR 2 — a combined call is refused by name until then.\n\n" +
+         ">= 0\"] returns exactly the NPCs on a multiplier. formids= COMPOSES with the scan terms: the identity set " +
+         "intersects the scan — or, alone, IS the scan universe (the set is the bound, so a where= over it needs " +
+         "no types=/plugins=). The walk= construct is a SELECT term too: what it reaches is a selection any " +
+         "reading form can consume.\n\n" +
          "SOURCE decides WHOSE version you read. Default: the load-order winner. Naming a plugin (source= " +
          "\"OldPatch.esp\", or {\"file\": \"X.esp\", \"mod\": \"<mod folder>\"} when two mods ship the filename) " +
          "reads THAT plugin's version wherever the plugin lives — active in your order, or sitting on disk unticked " +
@@ -115,9 +117,11 @@ public static class RecordsTools
          "and from where). A plugin found in neither place is refused naming both places searched. A record the " +
          "named plugin does not touch is refused naming the plugins that DO touch it — never silently absent. " +
          "An off-order file's content sits OUTSIDE the epoch fingerprint and the response says so. " +
-         "('previous_provider' and the SkyPatcher overlay source arrive in W2 PR 2.)\n\n" +
+         "versus= is the comparison REFERENCE pole (delta/tree); {\"overlay\": \"skypatcher\", \"state\": " +
+         "\"pre\"|\"post\"} reads around the SkyPatcher INI layer; \"previous_provider\" (a versus= value) is the " +
+         "plugin immediately below the SUBJECT in the record's touching stack.\n\n" +
          "PROJECT is a single form (see project=): identity | summary (default) | fields | everything | aggregate | " +
-         "delta | tree. Sub-parameters live INSIDE the form that uses them (depth belongs to fields/everything, " +
+         "delta | tree | chain | info_order. Sub-parameters live INSIDE the form that uses them (depth belongs to fields/everything, " +
          "group_by to aggregate, fields to fields/delta/tree) — there is no flat spelling for an illegal pairing. " +
          "COMPARISONS (form='delta'/'tree'): a delta reads the SUBJECT (source=) and a REFERENCE (versus=) and " +
          "returns only what differs — each delta line shows the subject's value with the reference's labeled by its " +
@@ -312,7 +316,7 @@ public static class RecordsTools
             var fs = fields_source.Trim().ToLowerInvariant();
             if (fs == "winner") winnerFields = true;
             else if (fs is not ("scoped" or "scanned"))
-                return $"error: fields_source='{fields_source}' — use 'winner' (display the live winner's values) or omit it (display the matched body). Further poles arrive with the W2 comparison wave.";
+                return $"error: fields_source='{fields_source}' — use 'winner' (display the live winner's values) or omit it (display the matched body). A NAMED display pole is the scope-vs-pole composition: plugins= selects, source= names whose version the body forms read.";
         }
 
         // ---- lane decision ------------------------------------------------------------------------------
@@ -342,11 +346,13 @@ public static class RecordsTools
             return "error: format='dense' renders positional columnar cells 1:1 with requested field paths, and the 'info_order' form is an ordered sequence render with no fixed column set — use format='text' or 'json'.";
         if (form == "info_order" && srcSpec.Kind != LoadOrderService.PoleKind.Winner)
             return "error: the info_order form merges EVERY plugin touching each topic — that merge is the answer, so a source= pole has no seat here (each line already names the plugin that placed it). Drop source=.";
-        // fields_source= is the SCAN lane's display pole in this wave (it retargets what a matched row DISPLAYS);
-        // the list lane's read is its display, so the request would be silently meaningless there — refuse by
-        // name (re-review: it was accepted and dropped). The generalized poles land with W2 PR 2's comparison forms.
-        if (winnerFields && formids is { Length: > 0 })
-            return "error: fields_source= is the scan lane's display pole in this wave — on a formids= read the version you want IS the source: name it via source= (source=\"winner\" is the default). The generalized display poles land with the W2 comparison forms.";
+        // fields_source= is the SCAN lane's display pole (it retargets what a matched row DISPLAYS); the list
+        // lane's read IS its display, so the request would be silently meaningless there — refuse by name
+        // (re-review: it was accepted and dropped). The GENERAL display pole is the composition itself:
+        // plugins= (scope) x source= (whose version) reads any pole's bodies; fields_source='winner' remains
+        // the winner shorthand on a scoped scan.
+        if (winnerFields && formids is { Length: > 0 } && !hasScan)
+            return "error: fields_source= is the scan lane's display pole — on a formids= read the version you want IS the source: name it via source= (source=\"winner\" is the default).";
 
         if (offset < 0) return $"error: offset={offset} — offset must be >= 0.";
         if (offset > 0 && form == "aggregate")
@@ -1101,7 +1107,7 @@ public static class RecordsTools
                 // impossible (the per-item wording below is ResolveBatchFromPole's own).
                 if (scopePlusPole)
                 {
-                    int notTouched = bodies.Count(o => o.Error is not null && o.Error.Contains("does not define or override"));
+                    int notTouched = bodies.Count(o => o.Error is not null && (o.Error.Contains("does not touch") || o.Error.Contains("does not define or override")));
                     if (notTouched > 0)
                     {
                         envelope.Add(new("not_touched", notTouched.ToString()));

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -293,8 +293,6 @@ public static class RecordsTools
             }
             if (references is { Length: > 0 })
                 return "error: walk= and references= are the same construct (references= IS the reverse walk at depth 1) — use one spelling per call.";
-            if (!string.IsNullOrWhiteSpace(fields_source))
-                return "error: fields_source= is the scan lane's display pole — a walk's reading forms display the source= pole's version of the reached set: name it via source= instead.";
             if (dense)
                 return "error: format='dense' renders positional columnar cells 1:1 with requested field paths, and a walk's outputs (chains; reached-set reads) have no fixed column set — use format='text' or 'json'.";
             if (comparisonForm || form is "info_order" or "identity")
@@ -312,17 +310,22 @@ public static class RecordsTools
         bool srcOverlay = srcSpec.Kind == LoadOrderService.PoleKind.Overlay;
 
         // ---- fields_source (display pole) ---------------------------------------------------------------
+        // Value first, THEN the lane rules (re-review R3-3): 'scoped'/'scanned' are the documented no-op
+        // defaults and stay accepted everywhere; only the actual RETARGET ('winner') is refused on the lanes
+        // that cannot honor it, and an unknown value always gets the not-a-known-source refusal.
         bool winnerFields = false;
         if (!string.IsNullOrWhiteSpace(fields_source))
         {
-            if (comparisonForm)
-                return $"error: fields_source= retargets what a matched row DISPLAYS, and the '{form}' form's display IS its two poles (source=/versus=) — name the version you want as a pole instead.";
-            if (form is "chain" or "info_order")
-                return $"error: fields_source= retargets FIELD display, and the '{form}' form renders no field values — drop it.";
             var fs = fields_source.Trim().ToLowerInvariant();
             if (fs == "winner") winnerFields = true;
             else if (fs is not ("scoped" or "scanned"))
                 return $"error: fields_source='{fields_source}' — use 'winner' (display the live winner's values) or omit it (display the matched body). A NAMED display pole is the scope-vs-pole composition: plugins= selects, source= names whose version the body forms read.";
+            if (winnerFields && comparisonForm)
+                return $"error: fields_source='winner' retargets what a matched row DISPLAYS, and the '{form}' form's display IS its two poles (source=/versus=) — name the version you want as a pole instead.";
+            if (winnerFields && form is "chain" or "info_order")
+                return $"error: fields_source='winner' retargets FIELD display, and the '{form}' form renders no field values — drop it.";
+            if (winnerFields && walk is not null)
+                return "error: fields_source='winner' — a walk's reading forms display the source= pole's version of the reached set: name the version via source= instead.";
         }
 
         // ---- lane decision ------------------------------------------------------------------------------
@@ -767,6 +770,8 @@ public static class RecordsTools
             }
             else   // tree
             {
+                if (srcSpec.Kind != LoadOrderService.PoleKind.Winner)
+                    return "error: the tree form has no subject — every provider of each record is on the bench, and the pole each is diffed against is versus=. Drop source= (or use form='delta' for a subject-vs-reference comparison).";
                 var rows = svc.TreeBatch(ids, versusSpec!, projFields, demand,
                                          out var rArm, out var covers, out var refusal, out var epoch);
                 if (refusal is not null)
@@ -819,7 +824,14 @@ public static class RecordsTools
         string TreeResponse(IReadOnlyList<LoadOrderService.TreeRow> rows, string? rArm, bool covers,
                             string? epoch, List<KeyValuePair<string, string>> echo)
         {
-            Arm(versusSpec!.Kind == LoadOrderService.PoleKind.Winner ? "winner (every provider diffed against it)" : $"reference: {rArm}");
+            // The tree has no subject: its REFERENCE rides the `versus` envelope key (delta's own convention),
+            // and `source` keeps the SELECTION arm — stated by the lane (scan/off-order), or the stack
+            // statement here on the list lane (first-wins; re-review R3-1: the reference in the source slot
+            // suppressed the selection arm that made epoch_covers_source intelligible).
+            var refStatement = versusSpec!.Kind == LoadOrderService.PoleKind.Winner ? "winner" : rArm ?? versusSpec.Label;
+            envelope.Add(new("versus", refStatement));
+            headerLine += $"  versus={refStatement}";
+            Arm("every provider of each record (the touching stack, winner last)");
             CoverageNote(covers);
             int contested = rows.Count(x => x.Error is null && x.Touchers.Count > 1);
             int errs = rows.Count(x => x.Error is not null);
@@ -910,9 +922,15 @@ public static class RecordsTools
             bool hasTypes = types is { Length: > 0 };
             bool hasScope = plugins?.names is { Length: > 0 };
             bool scopePlusPole = false;
-            // The derived-selection forms (comparisons, info_order, a walk's seeds) state their own source arm
-            // and consume EVERY match; known up front, used by the arm rule (F1) and the scan cap below.
+            // The derived-selection forms (comparisons, info_order, a walk's seeds) consume EVERY match;
+            // known up front, used by the scan cap below.
             bool derivedSelection = comparisonForm || form == "info_order" || walk is not null;
+            // The arm rule (F1, corrected in the round-4 fold): the scan pre-arm is skipped ONLY for forms
+            // whose pipeline states its own SOURCE arm (delta = the subject; info_order = the merge; a walk =
+            // the re-entered reading arm). The TREE has no subject — its reference lives in the `versus`
+            // envelope key — so the scan's own selection arm stays, which is exactly what discloses an
+            // off-order or scoped selection universe (re-review R3-1/R3-2).
+            bool pipelineArms = form == "delta" || form == "info_order" || walk is not null;
             if (hasBodyFilter && !hasTypes && !hasScope && !hasFormids)
                 return "error: where=/references= is a body scan and must be combined with types=, plugins=, or a formids= set to bound the work " +
                        "(conflicts_only= alone is not enough — an unbounded body scan over the whole order is refused; the " +
@@ -965,13 +983,17 @@ public static class RecordsTools
                     if (winnerFields)
                         return "error: fields_source='winner' and a named source= under a plugins= scope are TWO display poles on one call — the pole's version is what this composition reads. Drop fields_source= (or drop source= and keep fields_source='winner').";
                     scopePlusPole = true;
-                    Arm($"{probe.Plugin} — active in the load order (the plugins= scope selects; this pole's version is read)");
+                    // The scope statement is the truthful arm only for the forms that READ the pole's bodies;
+                    // delta's pipeline states its subject itself (R3-2). A scoped TREE reads every provider,
+                    // so the scope-selection arm (without the pole clause) is stated below like any scan.
+                    if (form == "tree") Arm($"{probe.Plugin} — scope-selected ({string.Join(", ", plugins!.names!)}); the tree reads every provider");
+                    else if (!pipelineArms) Arm($"{probe.Plugin} — active in the load order (the plugins= scope selects; this pole's version is read)");
                 }
-                else if (!derivedSelection)
+                else if (!pipelineArms)
                     // ACTIVE arm: the pole's records ARE the scan universe — the plugins= stream with the arm stated.
                     Arm($"{probe.Plugin} — active in the load order");
             }
-            else if (!derivedSelection) Arm("winner");   // the derived forms' pipelines state their own arm (F1)
+            else if (!pipelineArms) Arm("winner");   // delta/info_order/walk pipelines state their own arm (F1)
 
             // references= @file expansion + FormKey parse (mirrors cross_plugin_query).
             HousecarlCore.ArtifactDemand? refDemand = null; string? refEcho = null;
@@ -1240,10 +1262,9 @@ public static class RecordsTools
         // ================================================================================================
         string OffOrderScan(LoadOrderService.PoleInfo pole)
         {
-            // The comparison pipelines state their own subject arm (F1's one-statement rule; first-wins would
-            // otherwise pin the file arm on a delta whose subject is the file — same statement, so keep it for
-            // the reading forms and let the pipelines win on comparisons).
-            if (!comparisonForm) Arm($"{pole.Plugin} — {pole.Where}");
+            // The file arm is the SELECTION statement — stated for every form except delta, whose pipeline
+            // names the same file as its subject (R3-1: the tree needs this arm; its reference rides `versus`).
+            if (form != "delta") Arm($"{pole.Plugin} — {pole.Where}");
             envelope.Add(new("epoch_covers_source", "false"));
             headerLine += "\n(the off-order file's content is OUTSIDE the epoch fingerprint — an edit to it changes answers without changing the epoch)";
             if (conflicts_only)

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -321,13 +321,10 @@ public static class RecordsTools
                        || where is { Length: > 0 } || references is { Length: > 0 };
         if (!hasFormids && !hasScan)
             return "error: select something — formids= (a record list), or a scan scope: types=, plugins=, conflicts_only=true, where=, references=.";
-        // A reverse MGEF walk narrows its carrier set with types= — the one place formids (the seeds) and a scan
-        // term legitimately meet ahead of the general composition (the types entries bound the typed carrier scan).
+        // formids= composes with the scan terms (the W2 formids×scan composition): the identity set intersects
+        // the scan's selection — or IS the universe when it is the only bound. The reverse MGEF walk keeps its
+        // own lane (formids are the seeds; types= narrows the typed carrier scan).
         bool reverseWalk = walk is not null && walkDirection == "reverse";
-        if (hasFormids && hasScan && !reverseWalk)
-            return "error: formids= composes with the scan terms (types=/plugins=/where=/references=/conflicts_only=) in W2 PR 2 — " +
-                   "not on this surface yet. Meanwhile: run the scan, spill/to_file the result, and re-enter it via where=[\"formid in @<file>\"]; " +
-                   "or filter the formids list client-side.";
         if (reverseWalk && (plugins?.names is { Length: > 0 } || conflicts_only || where is { Length: > 0 }))
             return "error: the reverse MGEF walk takes formids= (the effects) and optionally types= (narrowing the carrier types) — the general bounded reverse over other scan terms is the references= spelling.";
         if (reverseWalk && !hasFormids)
@@ -399,9 +396,9 @@ public static class RecordsTools
             return w;
         }
 
-        return hasFormids
-            ? ListLane()
-            : ScanLane();
+        return hasScan && !reverseWalk
+            ? ScanLane()          // incl. formids×scan: the identity set rides the scan as an intersection
+            : ListLane();
 
         // ================================================================================================
         //  LIST lane — formids= drives; SOURCE picks the read lane.
@@ -852,12 +849,34 @@ public static class RecordsTools
             bool hasBodyFilter = where is { Length: > 0 } || references is { Length: > 0 };
             bool hasTypes = types is { Length: > 0 };
             bool hasScope = plugins?.names is { Length: > 0 };
-            if (hasBodyFilter && !hasTypes && !hasScope)
-                return "error: where=/references= is a body scan and must be combined with types= or plugins= to bound the work " +
+            bool scopePlusPole = false;
+            if (hasBodyFilter && !hasTypes && !hasScope && !hasFormids)
+                return "error: where=/references= is a body scan and must be combined with types=, plugins=, or a formids= set to bound the work " +
                        "(conflicts_only= alone is not enough — an unbounded body scan over the whole order is refused; the " +
                        "reverse-reference index that would lift this is a known future capability).";
             if (plugins is { defined_in: true } && !hasScope)
                 return "error: plugins.defined_in=true keeps records DEFINED in the scoped plugins, so plugins.names must name that scope.";
+
+            // formids×scan (W2 composition): the identity set intersects the scan — expanded here (@file /
+            // artifact demand honored inside the scan's own capture), parsed once, handed to the engine as the
+            // set filter (alone, it IS the scan universe — the set is the bound).
+            HousecarlCore.ArtifactDemand? fidDemand = null; string? fidEcho = null;
+            IReadOnlyList<FormKey>? formidSet = null;
+            if (hasFormids)
+            {
+                var (ftoks, fdemand, fecho, fxerr) = Artifacts.ExpandListInput(formids!, "formids");
+                if (fxerr is not null) return fxerr;
+                fidDemand = fdemand; fidEcho = fecho;
+                var fkList = new List<FormKey>();
+                foreach (var t in ftoks!)
+                {
+                    if (string.IsNullOrWhiteSpace(t)) continue;
+                    try { fkList.Add(FormKey.Factory(t.Trim())); }
+                    catch (Exception ex) { return $"error: bad formids entry '{t}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."; }
+                }
+                if (fkList.Count == 0) return "error: formids= expanded to an empty list — nothing to intersect the scan with.";
+                formidSet = fkList;
+            }
 
             // ---- OFF-ORDER source universe: the file's own records (absorbs read_plugin_file's enumeration).
             string? probeEpoch = null;
@@ -874,11 +893,18 @@ public static class RecordsTools
                 if (!probe.InOrder)
                     return OffOrderScan(probe);
                 if (hasScope)
-                    return "error: a plugins= scope combined with an ACTIVE named source= (scope-vs-pole streams) lands in W2 PR 2 — " +
-                           "meanwhile: scope to the source plugin itself (plugins.names=[source]) reads its records, or use " +
-                           "fields_source='winner' for winner-value display.";
-                // ACTIVE arm: the pole's records ARE the scan universe — the plugins= stream with the arm stated.
-                Arm($"{probe.Plugin} — active in the load order");
+                {
+                    // Scope-vs-pole streams (the W2 composition): the plugins= scope decides WHICH records are
+                    // considered; the named source= decides whose VERSION the body forms read. Identity-fact
+                    // forms have nothing for the pole to change — accepting-and-ignoring it is the sin.
+                    if (form is "summary" or "aggregate")
+                        return $"error: a plugins= scope with a named source= reads the POLE's version of each scoped match — and the '{form}' form's rows are identity facts the pole doesn't change. Drop source=, or use form='fields'/'everything' (the pole's bodies) or 'delta'/'tree' (comparisons).";
+                    scopePlusPole = true;
+                    Arm($"{probe.Plugin} — active in the load order (the plugins= scope selects; this pole's version is read)");
+                }
+                else
+                    // ACTIVE arm: the pole's records ARE the scan universe — the plugins= stream with the arm stated.
+                    Arm($"{probe.Plugin} — active in the load order");
             }
             else Arm("winner");
 
@@ -904,7 +930,7 @@ public static class RecordsTools
                 if (list.Count > 0) refFks = list.Distinct().ToList();
             }
 
-            var scanPlugins = srcName is not null ? new[] { srcName } : plugins?.names;
+            var scanPlugins = scopePlusPole ? plugins!.names : (srcName is not null ? new[] { srcName } : plugins?.names);
             bool definedIn = plugins?.defined_in ?? false;
             var groupBy = form == "aggregate" ? project!.group_by!.Trim().ToLowerInvariant() : null;
             // The derived-selection forms (comparisons, info_order, a walk's seeds) consume EVERY match — the
@@ -913,9 +939,12 @@ public static class RecordsTools
             bool derivedSelection = comparisonForm || form == "info_order" || walk is not null;
             int effLimit = wantFile || derivedSelection ? int.MaxValue : counts_only ? 0 : (limit <= 0 ? 500 : limit);
 
+            var demandsList = new List<HousecarlCore.ArtifactDemand>();
+            if (refDemand is not null) demandsList.Add(refDemand);
+            if (fidDemand is not null) demandsList.Add(fidDemand);
             var outcome = svc.CrossQuery(types, refFks, null, conflicts_only, scanPlugins, where,
                                          effLimit, definedIn, groupBy, offset, where_source,
-                                         refDemand is null ? null : new[] { refDemand });
+                                         demandsList.Count > 0 ? demandsList : null, formidSet);
             // The probe→scan seam IS epoch-compared (round-3 F5): the arm statement must describe the same
             // build the rows were scanned from.
             if (probeEpoch is not null && outcome.Error is null && outcome.Epoch is not null && outcome.Epoch != probeEpoch)
@@ -931,6 +960,7 @@ public static class RecordsTools
                 var e = new List<KeyValuePair<string, string>>();
                 void Add(string k, string? v) { if (!string.IsNullOrEmpty(v)) e.Add(new(k, v!)); }
                 Add("form", form);
+                Add("formids", fidEcho ?? (formidSet is not null ? $"{formidSet.Count} inline formid(s)" : null));
                 Add("types", types is { Length: > 0 } ? string.Join(", ", types) : null);
                 Add("references", refEcho ?? (refs is { Length: > 0 } ? string.Join(", ", refs) : null));
                 if (conflicts_only) Add("conflicts_only", "true");
@@ -1017,13 +1047,13 @@ public static class RecordsTools
 
             // ---- form=everything on a scan: selection here, bodies via the batch lane (window-bounded).
             // counts_only skips the body lane entirely — the census is the cross-query render below (round 3).
-            if (form == "everything" && !counts_only && outcome.Error is null && outcome.Groups is null)
+            if ((form == "everything" || (form == "fields" && scopePlusPole)) && !counts_only && outcome.Error is null && outcome.Groups is null)
             {
                 var keys = outcome.Keys.Select(k => k.ToString()).ToList();
                 IReadOnlyList<ReadOutcome> bodies;
                 if (srcName is not null)
                 {
-                    bodies = svc.ResolveBatchFromPole(keys, srcName, srcMod, null, depth, resolveNames, null,
+                    bodies = svc.ResolveBatchFromPole(keys, srcName, srcMod, form == "fields" ? projFields : null, depth, resolveNames, null,
                                                       out _, out var bref, out var brefEpoch);
                     // A refusal is judged on the NAMED cause, never on row count (review: a zero-match scan is an
                     // honest EMPTY result, and the pole lane's real refusals were being replaced by a generic one).
@@ -1064,6 +1094,18 @@ public static class RecordsTools
                             for (int i = 0; i < kv.Value.Count; i++) byIndex[kv.Value[i]] = res[i];
                         }
                         bodies = byIndex;
+                    }
+                }
+                // The §4.2 untouched contract, bulk shape: rows the pole does not touch come back as per-item
+                // refusals naming the touchers; the ACCOUNTING carries the explicit count so quiet omission is
+                // impossible (the per-item wording below is ResolveBatchFromPole's own).
+                if (scopePlusPole)
+                {
+                    int notTouched = bodies.Count(o => o.Error is not null && o.Error.Contains("does not define or override"));
+                    if (notTouched > 0)
+                    {
+                        envelope.Add(new("not_touched", notTouched.ToString()));
+                        headerLine += $"\nnot_touched={notTouched} — scoped match(es) the source pole has no version of (each row names its actual touchers)";
                     }
                 }
                 // The selection and every body read must agree on ONE build (grouped reads capture per batch) —
@@ -1133,47 +1175,164 @@ public static class RecordsTools
         {
             Arm($"{pole.Plugin} — {pole.Where}");
             envelope.Add(new("epoch_covers_source", "false"));
+            headerLine += "\n(the off-order file's content is OUTSIDE the epoch fingerprint — an edit to it changes answers without changing the epoch)";
             if (conflicts_only)
                 return "error: conflicts_only= has no meaning on an out-of-load-order file — it is not in the conflict frame. Drop it, or read the winner (source=\"winner\").";
-            if (comparisonForm)
-                return "error: the 'delta'/'tree' forms over an out-of-load-order file SCAN are not composed yet — enumerate the file with form='summary', then compare the specific records via formids= (the comparison poles read the off-order file under the one-pole rule).";
             if (form == "info_order")
                 return "error: the info_order form merges the ACTIVE order's touching plugins — an out-of-load-order file is not in that frame. Read the winner's merge (drop source=), or enumerate the file's DIAL records with form='summary'.";
             if (walk is not null)
                 return "error: the walk expands the ACTIVE order's winner link graph — an out-of-load-order file's records are not in that graph. Enumerate the file with form='summary', then walk specific records via formids= (dropping source=).";
-            if (references is { Length: > 0 } || plugins?.names is { Length: > 0 } || (plugins?.defined_in ?? false))
-                return "error: references=/plugins= over an out-of-load-order file land in W2 PR 2 — this wave reads the file by types= (and an 'editorid contains' where-clause).";
-            if (form is "fields" or "everything")
-                return "error: the fields/everything forms over an out-of-load-order file SCAN land in W2 PR 2 — meanwhile enumerate with form='summary', then read the specific records via formids= (the one-pole batch reads any of the file's records in full).";
             if (dense) return "error: format='dense' is the in-order scan's columnar form — an off-order file scan renders text or json.";
-            if (wantFile) return "error: to_file= over an out-of-load-order file scan lands in W2 PR 2 — enumerate inline, or batch-read via formids= with to_file=.";
-            if (offset > 0) return "error: offset= paging over an out-of-load-order file scan lands in W2 PR 2 — this wave renders the file's first limit= rows (narrow with types= or an 'editorid contains' clause).";
-            if (counts_only) return "error: counts_only= over an out-of-load-order file scan lands in W2 PR 2 — meanwhile form='aggregate' group_by='type' is the whole-file census.";
+            if (where_source is not null && where_source.Trim().ToLowerInvariant() == "winner")
+                return "error: where_source=winner matches on the live load-order winner — but this scan streams an out-of-load-order FILE's bodies, many of which have no winner. Match the winner by scanning the winner (drop source=), or drop where_source=.";
 
-            // The one where-clause this lane carries natively: a single 'editorid contains <text>'.
-            string? eidContains = null;
-            if (where is { Length: > 0 })
+            // The completed off-order lane (W2 PR 2): the same filter grammar as the in-order scan, run by the
+            // engine over the file's own records; provenance terms bind to the ACTIVE view (declared).
+            HousecarlCore.ArtifactDemand? refDemand = null; string? refEcho = null;
+            var refs = references;
+            if (refs is { Length: > 0 })
             {
-                if (where.Length == 1 && TryEditorIdContains(where[0], out eidContains)) { }
-                else return "error: over an out-of-load-order file this wave carries exactly one where-clause form: [\"editorid contains <text>\"] — " +
-                            "the full predicate grammar over off-order bodies lands in W2 PR 2.";
+                var (toks, demand, echoSrc2, xerr) = Artifacts.ExpandListInput(refs, "references");
+                if (xerr is not null) return xerr;
+                refs = toks!; refDemand = demand; refEcho = echoSrc2;
+            }
+            IReadOnlyList<FormKey>? refFks = null;
+            if (refs is { Length: > 0 })
+            {
+                var list = new List<FormKey>();
+                foreach (var r in refs)
+                {
+                    if (string.IsNullOrWhiteSpace(r)) continue;
+                    try { list.Add(FormKey.Factory(r.Trim())); }
+                    catch (Exception ex) { return $"error: bad references FormID '{r}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."; }
+                }
+                if (list.Count > 0) refFks = list.Distinct().ToList();
+            }
+            HousecarlCore.ArtifactDemand? fidDemand = null; string? fidEcho = null;
+            IReadOnlyList<FormKey>? formidSet = null;
+            if (formids is { Length: > 0 })
+            {
+                var (ftoks, fdemand, fecho, fxerr) = Artifacts.ExpandListInput(formids!, "formids");
+                if (fxerr is not null) return fxerr;
+                fidDemand = fdemand; fidEcho = fecho;
+                var fkList = new List<FormKey>();
+                foreach (var t in ftoks!)
+                {
+                    if (string.IsNullOrWhiteSpace(t)) continue;
+                    try { fkList.Add(FormKey.Factory(t.Trim())); }
+                    catch (Exception ex) { return $"error: bad formids entry '{t}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."; }
+                }
+                if (fkList.Count > 0) formidSet = fkList;
+            }
+            var offGroupBy = form == "aggregate" ? project!.group_by!.Trim().ToLowerInvariant() : null;
+            bool offDerived = comparisonForm;
+            int offLimit = wantFile || offDerived ? int.MaxValue : counts_only ? 0 : (limit <= 0 ? 500 : limit);
+            var offDemands = new List<HousecarlCore.ArtifactDemand>();
+            if (refDemand is not null) offDemands.Add(refDemand);
+            if (fidDemand is not null) offDemands.Add(fidDemand);
+
+            var outcome = svc.OffOrderQuery(pole, types, refFks, null, plugins?.names,
+                                            plugins?.defined_in ?? false, where, offLimit, offGroupBy, offset,
+                                            formidSet, offDemands.Count > 0 ? offDemands : null);
+
+            List<KeyValuePair<string, string>> Echo()
+            {
+                var e = new List<KeyValuePair<string, string>>();
+                void Add(string k, string? v) { if (!string.IsNullOrEmpty(v)) e.Add(new(k, v!)); }
+                Add("form", form);
+                Add("source", $"{pole.Plugin} (out-of-load-order)");
+                Add("formids", fidEcho ?? (formidSet is not null ? $"{formidSet.Count} inline formid(s)" : null));
+                Add("types", types is { Length: > 0 } ? string.Join(", ", types) : null);
+                Add("references", refEcho ?? (refs is { Length: > 0 } ? string.Join(", ", refs) : null));
+                Add("plugins", plugins?.names is { Length: > 0 } ? string.Join(", ", plugins.names) : null);
+                if (plugins?.defined_in ?? false) Add("defined_in", "true");
+                Add("where", where is { Length: > 0 } ? string.Join(" AND ", where) : null);
+                Add("group_by", offGroupBy);
+                if (versusSpec is not null) Add("versus", versusSpec.Label);
+                return e;
             }
 
-            string? typeArg = null;
-            if (types is { Length: > 1 })
-                return "error: an out-of-load-order file scan reads ONE types= entry at a time in this wave — call per type, or use form='aggregate' group_by='type' for the whole file's census.";
-            if (types is { Length: 1 }) typeArg = types[0];
-            if (form == "aggregate")
+            // Comparisons over the file's matches: the file IS the subject pole (its version of each match).
+            if (comparisonForm && outcome.Error is null && outcome.Groups is null)
             {
-                var gb = project!.group_by!.Trim().ToLowerInvariant();
-                if (gb != "type")
-                    return $"error: over an out-of-load-order file the aggregate form counts by 'type' (the file's own record census) — group_by='{gb}' has no frame there.";
-                typeArg = null;   // no type filter ⇒ the whole-file record-type summary
+                var cmpKeys = outcome.Keys.Select(k => k.ToString()).ToList();
+                envelope.Add(new("total", outcome.Total.ToString()));
+                headerLine += $"\n{outcome.Total} match(es) selected from the file";
+                if (form == "delta")
+                {
+                    var rows = svc.DeltaBatch(cmpKeys, srcSpec, versusSpec!, projFields, null,
+                                              out var sArm, out var rArm, out var covers, out var refusal, out var depoch);
+                    if (refusal is not null)
+                        return json ? JsonWire.RenderError(refusal, depoch) : "error: " + refusal + (depoch is not null ? $"\nepoch={depoch}" : "");
+                    return DeltaResponse(rows, sArm, rArm, covers, depoch, Echo());
+                }
+                else
+                {
+                    var rows = svc.TreeBatch(cmpKeys, versusSpec!, projFields, null,
+                                             out var rArm, out var covers, out var refusal, out var tepoch);
+                    if (refusal is not null)
+                        return json ? JsonWire.RenderError(refusal, tepoch) : "error: " + refusal + (tepoch is not null ? $"\nepoch={tepoch}" : "");
+                    return TreeResponse(rows, rArm, covers, tepoch, Echo());
+                }
             }
 
-            var o = svc.ReadPluginFile(pole.Plugin, null, typeArg, srcMod, null, 1, eidContains, limit <= 0 ? 500 : limit, false);
-            return json ? JsonWire.RenderPluginFile(o, max_chars, envelope)
-                        : headerLine + "\n" + Wire.RenderPluginFile(o, max_chars);
+            // fields/everything over the file's matches: bodies via the one-pole batch (it reads the FILE).
+            if (form is ("fields" or "everything") && !counts_only && outcome.Error is null && outcome.Groups is null)
+            {
+                var keys = outcome.Keys.Select(k => k.ToString()).ToList();
+                var bodies = svc.ResolveBatchFromPole(keys, pole.Plugin, srcMod, form == "fields" ? projFields : null,
+                                                      depth, resolveNames, null, out _, out var bref, out var brefEpoch);
+                if (bref is not null)
+                    return json ? JsonWire.RenderError(bref, brefEpoch)
+                                : "error: " + bref + (brefEpoch is not null ? $"\nepoch={brefEpoch}" : "");
+                envelope.Add(new("total", outcome.Total.ToString()));
+                headerLine += $"\n{outcome.Total} match(es); bodies for the {keys.Count}-row window below";
+                string RenderOff(SpillState? sp, out bool trunc) => json
+                    ? JsonWire.RenderBatch(bodies, max_chars, sp, out trunc, envelope)
+                    : headerLine + "\n" + Wire.RenderBatch(svc, bodies, form == "fields" ? projFields : null, false, max_chars, sp, out trunc);
+                SpillState? offSpill = null;
+                var offEpoch = bodies.FirstOrDefault(o => o.Epoch is not null)?.Epoch ?? outcome.Epoch;
+                if (wantFile)
+                {
+                    var (sp, aerr) = Artifacts.WriteBatch(bodies, toFile!, "to_file", Echo());
+                    if (aerr is not null) return json ? JsonWire.RenderError(aerr, offEpoch) : "error: " + aerr;
+                    offSpill = SpillState.Spilled(sp!, manifestOnly: true);
+                }
+                var offRendered = RenderOff(offSpill, out var offTrunc);
+                if (offSpill is null && offTrunc)
+                {
+                    var path = ResultsStore.NextPath("housecarl_records", offEpoch ?? "none");
+                    var (sp, aerr) = Artifacts.WriteBatch(bodies, path, "ceiling", Echo());
+                    if (aerr is not null) ResultsStore.Release(path);
+                    offRendered = RenderOff(aerr is null ? SpillState.Spilled(sp!, manifestOnly: false) : SpillState.WriteFailed(aerr), out _);
+                }
+                return offRendered;
+            }
+
+            // summary / aggregate: the shared cross-query renders (Prefilled rows carry the file's identities;
+            // winner context rides where a record also lives in the order).
+            SpillState? spill = null;
+            if (wantFile && outcome.Error is null)
+            {
+                var (sp, aerr) = Artifacts.WriteCrossQuery(svc, outcome, null, false, false, 1, toFile!, "to_file", Echo());
+                if (aerr is not null)
+                    return fmt is Wire.QueryFormat.Text ? "error: " + aerr : JsonWire.RenderError(aerr, outcome.Epoch);
+                spill = SpillState.Spilled(sp!, manifestOnly: true);
+            }
+            string Render(SpillState? sp, out bool trunc) => fmt switch
+            {
+                Wire.QueryFormat.Dense or Wire.QueryFormat.Json => JsonWire.RenderCrossQuery(svc, outcome, null, max_chars, false, false, 1, sp, out trunc, envelope),
+                _ => headerLine + "\n" + Wire.RenderCrossQuery(svc, outcome, null, false, max_chars, false, false, 1, sp, out trunc),
+            };
+            var rendered = Render(spill, out var truncated);
+            if (spill is null && truncated && outcome.Error is null)
+            {
+                var path = ResultsStore.NextPath("housecarl_records", outcome.Epoch ?? "none");
+                var (sp, aerr) = Artifacts.WriteCrossQuery(svc, outcome, null, false, false, 1, path, "ceiling", Echo());
+                if (aerr is not null) ResultsStore.Release(path);
+                rendered = Render(aerr is null ? SpillState.Spilled(sp!, manifestOnly: false) : SpillState.WriteFailed(aerr), out _);
+            }
+            return rendered;
         }
     });
 

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -602,26 +602,53 @@ public static class RecordsTools
                     catch (Exception ex) { results.Add((raw?.Trim() ?? "", EffectChainResult.Fail($"bad FormID '{raw}': {ex.Message}"))); continue; }
                     results.Add((fk.ToString(), svc.ResolveEffectChain(fk, types, limit <= 0 ? 500 : limit)));
                 }
+                // ONE build for the whole batch (review F3): each seed's resolve captures its own view — the
+                // stamps must agree, and an @artifact seed list's epoch demand must match that build.
+                var epochsR = results.Select(r => r.Result.Epoch).Where(e => e is not null).Distinct().ToList();
+                if (epochsR.Count > 1)
+                {
+                    var tear = $"the load order changed while the seeds resolved (epochs {string.Join(", ", epochsR)}) — " +
+                               "the carrier sets would mix builds. Retry the call.";
+                    return json ? JsonWire.RenderError(tear, epochsR[^1]) : "error: " + tear;
+                }
+                var epochR = epochsR.FirstOrDefault();
+                if (demand is not null && (epochR is null || demand.Epoch != epochR))
+                {
+                    var dref = epochR is null
+                        ? $"artifact '{demand.Path}' carries epoch={demand.Epoch}, but no seed consulted a build to verify it against (every seed failed pre-capture) — fix the seeds and retry."
+                        : LoadOrderService.ArtifactEpochMismatch(demand, epochR);
+                    return json ? JsonWire.RenderError(dref, epochR) : "error: " + dref + (epochR is not null ? $"\nepoch={epochR}" : "");
+                }
                 Arm("winner (carriers are the load-order-effective versions)");
                 envelope.Add(new("walk", "reverse, depth 1 — the typed MGEF carrier lane"));
                 headerLine += "\nwalk=reverse (per seed: every SPEL/ENCH/ALCH/SCRL/INGR applying it, with the MATCHING entry's magnitude/area/duration — reported AS AUTHORED; conditions are not evaluated, so a row means 'defines it at this strength', not 'it will fire')";
-                var epochR = results.Select(r => r.Result.Epoch).FirstOrDefault(e => e is not null);
+                int carrierRows = results.Sum(r => r.Result.Error is null ? r.Result.Total : 0);
+                int seedErrs2 = results.Count(r => r.Result.Error is not null);
+                var revCounts = new[] { KvI("seeds", results.Count), KvI("carrier_rows", carrierRows), KvI("errors", seedErrs2) };
                 if (counts_only)
                     return json
-                        ? JsonWire.RenderNamedCounts(envelope, new[] { KvI("seeds", results.Count), KvI("carrier_rows", results.Sum(r => r.Result.Error is null ? r.Result.Total : 0)), KvI("errors", results.Count(r => r.Result.Error is not null)) }, epochR)
-                        : $"{headerLine}\nseeds={results.Count} carrier_rows={results.Sum(r => r.Result.Error is null ? r.Result.Total : 0)} errors={results.Count(r => r.Result.Error is not null)}" + (epochR is not null ? $"\nepoch={epochR}" : "");
-                if (json) return JsonWire.RenderEffectChains(results, max_chars, envelope);
-                var sbR = new StringBuilder();
-                sbR.Append(headerLine).Append('\n');
-                foreach (var (seed, result) in results)
+                        ? JsonWire.RenderNamedCounts(envelope, revCounts, epochR)
+                        : $"{headerLine}\nseeds={results.Count} carrier_rows={carrierRows} errors={seedErrs2}" + (epochR is not null ? $"\nepoch={epochR}" : "");
+                var winResults = Windowed(results);
+                SpillState? revSpill = null;
+                if (wantFile)
                 {
-                    sbR.Append('\n').Append("seed ").Append(seed).Append('\n');
-                    sbR.Append(Wire.RenderEffectChain(result, max_chars));
-                    sbR.Append('\n');
-                    if (sbR.Length >= (max_chars > 0 ? max_chars : Wire.DefaultMaxChars))
-                    { sbR.Append("... [seeds cut at max_chars — raise max_chars or pass fewer seeds]\n"); break; }
+                    var (sp, aerr) = Artifacts.WriteEffectChains(results, epochR, toFile!, "to_file", Echo());
+                    if (aerr is not null) return json ? JsonWire.RenderError(aerr, epochR) : "error: " + aerr;
+                    revSpill = SpillState.Spilled(sp!, manifestOnly: true);
                 }
-                return sbR.ToString().TrimEnd('\n');
+                string RenderRev(SpillState? sp, out bool trunc) => json
+                    ? JsonWire.RenderEffectChains(winResults, max_chars, envelope, revCounts, epochR, sp, out trunc)
+                    : RenderRecordsEffectChains(winResults, results.Count, carrierRows, seedErrs2, headerLine, epochR, max_chars, sp, out trunc);
+                var revRendered = RenderRev(revSpill, out var revTrunc);
+                if (revSpill is null && revTrunc)
+                {
+                    var path = ResultsStore.NextPath("housecarl_records", epochR ?? "none");
+                    var (sp, aerr) = Artifacts.WriteEffectChains(results, epochR, path, "ceiling", Echo());
+                    if (aerr is not null) ResultsStore.Release(path);
+                    revRendered = RenderRev(aerr is null ? SpillState.Spilled(sp!, manifestOnly: false) : SpillState.WriteFailed(aerr), out _);
+                }
+                return revRendered;
             }
 
             // FORWARD: one engine batch, one captured build; the chain form renders it, every other form
@@ -651,8 +678,9 @@ public static class RecordsTools
                     if (aerr is not null) return json ? JsonWire.RenderError(aerr, wEpoch) : "error: " + aerr;
                     spill = SpillState.Spilled(s!, manifestOnly: true);
                 }
+                var chainCounts = new[] { KvI("seeds", rows.Count), KvI("reached", reached), KvI("errors", errs) };
                 string Render(SpillState? sp, out bool trunc) => json
-                    ? JsonWire.RenderChain(winRows, max_chars, wEpoch, envelope, sp, out trunc)
+                    ? JsonWire.RenderChain(winRows, max_chars, wEpoch, envelope, chainCounts, sp, out trunc)
                     : RenderRecordsChain(winRows, rows.Count, reached, errs, headerLine, wEpoch, max_chars, sp, out trunc);
                 var rendered = Render(spill, out var truncated);
                 if (spill is null && truncated)
@@ -749,8 +777,9 @@ public static class RecordsTools
                 if (aerr is not null) return json ? JsonWire.RenderError(aerr, epoch) : "error: " + aerr;
                 spill = SpillState.Spilled(s!, manifestOnly: true);
             }
+            var deltaCounts = new[] { KvI("count", rows.Count), KvI("differing", differing), KvI("identical", identical), KvI("errors", errs) };
             string Render(SpillState? sp, out bool trunc) => json
-                ? JsonWire.RenderDelta(winRows, max_chars, epoch, envelope, sp, out trunc)
+                ? JsonWire.RenderDelta(winRows, max_chars, epoch, envelope, deltaCounts, sp, out trunc)
                 : RenderRecordsDelta(winRows, rows.Count, differing, identical, errs, headerLine, epoch, max_chars, sp, out trunc);
             var rendered = Render(spill, out var truncated);
             if (spill is null && truncated)
@@ -784,8 +813,9 @@ public static class RecordsTools
                 if (aerr is not null) return json ? JsonWire.RenderError(aerr, epoch) : "error: " + aerr;
                 spill = SpillState.Spilled(s!, manifestOnly: true);
             }
+            var treeCounts = new[] { KvI("count", rows.Count), KvI("contested", contested), KvI("errors", errs) };
             string Render(SpillState? sp, out bool trunc) => json
-                ? JsonWire.RenderTree(winRows, max_chars, epoch, envelope, sp, out trunc)
+                ? JsonWire.RenderTree(winRows, max_chars, epoch, envelope, treeCounts, sp, out trunc)
                 : RenderRecordsTree(winRows, rows.Count, contested, errs, projFields is { Length: > 0 }, headerLine, epoch, max_chars, sp, out trunc);
             var rendered = Render(spill, out var truncated);
             if (spill is null && truncated)
@@ -818,8 +848,9 @@ public static class RecordsTools
                 if (aerr is not null) return json ? JsonWire.RenderError(aerr, epoch) : "error: " + aerr;
                 spill = SpillState.Spilled(s!, manifestOnly: true);
             }
+            var ioCounts = new[] { KvI("count", rows.Count), KvI("contested", contested), KvI("errors", errs) };
             string Render(SpillState? sp, out bool trunc) => json
-                ? JsonWire.RenderInfoOrder(winRows, max_chars, epoch, envelope, sp, out trunc)
+                ? JsonWire.RenderInfoOrder(winRows, max_chars, epoch, envelope, ioCounts, sp, out trunc)
                 : RenderRecordsInfoOrder(winRows, rows.Count, contested, errs, headerLine, epoch, max_chars, sp, out trunc);
             var rendered = Render(spill, out var truncated);
             if (spill is null && truncated)
@@ -849,9 +880,10 @@ public static class RecordsTools
             if (form == "identity")
                 return "error: the identity form labels a formids= list; a scan's summary rows already carry each match's identity — use form='summary' (the default).";
 
-            if (srcOverlay && !comparisonForm)
-                return "error: the overlay source on a SCAN would replay the SkyPatcher INI layer over every match — a per-record replay at scan scale. " +
-                       "Name the records (formids= reads their post-state bodies), use form='delta'/'tree' for a bounded comparison, or read the whole layer via housecarl_skypatcher_layer.";
+            if (srcOverlay || versusSpec?.Kind == LoadOrderService.PoleKind.Overlay)
+                return "error: an overlay pole on a SCAN would replay the SkyPatcher INI layer over every match — a per-record replay at scan scale " +
+                       "(a scan comparison compares EVERY match, so it is not a bound). Name the records via formids= — the list lane reads and " +
+                       "compares their post-state bodies — or read the whole layer via housecarl_skypatcher_layer.";
             bool hasBodyFilter = where is { Length: > 0 } || references is { Length: > 0 };
             bool hasTypes = types is { Length: > 0 };
             bool hasScope = plugins?.names is { Length: > 0 };
@@ -938,7 +970,10 @@ public static class RecordsTools
 
             var scanPlugins = scopePlusPole ? plugins!.names : (srcName is not null ? new[] { srcName } : plugins?.names);
             bool definedIn = plugins?.defined_in ?? false;
-            var groupBy = form == "aggregate" ? project!.group_by!.Trim().ToLowerInvariant() : null;
+            // Under walk= the scan only SELECTS the seeds — the aggregate (like every reading form) applies to
+            // the REACHED set via the walk lane's re-entry. Grouping the scan itself would return an aggregate
+            // of the seeds labeled as the walk's answer, with walk= silently dropped (review F2).
+            var groupBy = form == "aggregate" && walk is null ? project!.group_by!.Trim().ToLowerInvariant() : null;
             // The derived-selection forms (comparisons, info_order, a walk's seeds) consume EVERY match — the
             // window applies to their rows, and the counts / artifact must cover the full selection — so the
             // scan itself is uncapped for them.
@@ -1189,8 +1224,16 @@ public static class RecordsTools
             if (walk is not null)
                 return "error: the walk expands the ACTIVE order's winner link graph — an out-of-load-order file's records are not in that graph. Enumerate the file with form='summary', then walk specific records via formids= (dropping source=).";
             if (dense) return "error: format='dense' is the in-order scan's columnar form — an off-order file scan renders text or json.";
-            if (where_source is not null && where_source.Trim().ToLowerInvariant() == "winner")
-                return "error: where_source=winner matches on the live load-order winner — but this scan streams an out-of-load-order FILE's bodies, many of which have no winner. Match the winner by scanning the winner (drop source=), or drop where_source=.";
+            if (where_source is not null)
+            {
+                // Full-vocabulary validation, mirroring the in-order engine (review F9): an unknown spelling must
+                // refuse by name, never be accepted-and-ignored.
+                var ws = where_source.Trim().ToLowerInvariant();
+                if (ws == "winner")
+                    return "error: where_source=winner matches on the live load-order winner — but this scan streams an out-of-load-order FILE's bodies, many of which have no winner. Match the winner by scanning the winner (drop source=), or drop where_source=.";
+                if (ws is not ("scoped" or "scanned"))
+                    return $"error: where_source='{where_source}' is not a known source — over an out-of-load-order file the match reads the FILE's own bodies ('scoped', the default); drop where_source=, or use 'winner' on an in-order scan.";
+            }
 
             // The completed off-order lane (W2 PR 2): the same filter grammar as the in-order scan, run by the
             // engine over the file's own records; provenance terms bind to the ACTIVE view (declared).
@@ -1228,7 +1271,8 @@ public static class RecordsTools
                     try { fkList.Add(FormKey.Factory(t.Trim())); }
                     catch (Exception ex) { return $"error: bad formids entry '{t}': {ex.Message}. Expected 'XXXXXX:Plugin.esp'."; }
                 }
-                if (fkList.Count > 0) formidSet = fkList;
+                if (fkList.Count == 0) return "error: formids= expanded to an empty list — nothing to intersect the scan with.";
+                formidSet = fkList;
             }
             var offGroupBy = form == "aggregate" ? project!.group_by!.Trim().ToLowerInvariant() : null;
             bool offDerived = comparisonForm;
@@ -1253,6 +1297,7 @@ public static class RecordsTools
                 Add("plugins", plugins?.names is { Length: > 0 } ? string.Join(", ", plugins.names) : null);
                 if (plugins?.defined_in ?? false) Add("defined_in", "true");
                 Add("where", where is { Length: > 0 } ? string.Join(" AND ", where) : null);
+                Add("where_source", where_source);
                 Add("group_by", offGroupBy);
                 if (versusSpec is not null) Add("versus", versusSpec.Label);
                 return e;
@@ -1270,6 +1315,14 @@ public static class RecordsTools
                                               out var sArm, out var rArm, out var covers, out var refusal, out var depoch);
                     if (refusal is not null)
                         return json ? JsonWire.RenderError(refusal, depoch) : "error: " + refusal + (depoch is not null ? $"\nepoch={depoch}" : "");
+                    // The file selection's build and the comparison's build must agree (review F4) — the
+                    // selection filtered via the ACTIVE view (scope/provenance terms), same as the in-order seam.
+                    if (outcome.Epoch is not null && depoch is not null && depoch != outcome.Epoch)
+                    {
+                        var tear = $"the load order changed between the file scan (epoch={outcome.Epoch}) and the comparison " +
+                                   $"(epoch={depoch}) — the two halves would mix builds. Retry the call.";
+                        return json ? JsonWire.RenderError(tear, depoch) : "error: " + tear;
+                    }
                     return DeltaResponse(rows, sArm, rArm, covers, depoch, Echo());
                 }
                 else
@@ -1278,6 +1331,12 @@ public static class RecordsTools
                                              out var rArm, out var covers, out var refusal, out var tepoch);
                     if (refusal is not null)
                         return json ? JsonWire.RenderError(refusal, tepoch) : "error: " + refusal + (tepoch is not null ? $"\nepoch={tepoch}" : "");
+                    if (outcome.Epoch is not null && tepoch is not null && tepoch != outcome.Epoch)
+                    {
+                        var tear = $"the load order changed between the file scan (epoch={outcome.Epoch}) and the comparison " +
+                                   $"(epoch={tepoch}) — the two halves would mix builds. Retry the call.";
+                        return json ? JsonWire.RenderError(tear, tepoch) : "error: " + tear;
+                    }
                     return TreeResponse(rows, rArm, covers, tepoch, Echo());
                 }
             }
@@ -1291,6 +1350,15 @@ public static class RecordsTools
                 if (bref is not null)
                     return json ? JsonWire.RenderError(bref, brefEpoch)
                                 : "error: " + bref + (brefEpoch is not null ? $"\nepoch={brefEpoch}" : "");
+                // The selection's build and the body reads' build must agree (review F4) — same rule as the
+                // in-order body seam; the bodies re-open the file, but the SELECTION was made on the view.
+                var offBodyEpochs = bodies.Where(o => o.Epoch is not null).Select(o => o.Epoch!).Distinct().ToList();
+                if (outcome.Epoch is not null && offBodyEpochs.Any(e => e != outcome.Epoch))
+                {
+                    var tear = $"the load order changed between the file scan (epoch={outcome.Epoch}) and the body read " +
+                               $"(epoch={string.Join(", ", offBodyEpochs.Where(e => e != outcome.Epoch))}) — the two halves would mix builds. Retry the call.";
+                    return json ? JsonWire.RenderError(tear, outcome.Epoch) : "error: " + tear;
+                }
                 envelope.Add(new("total", outcome.Total.ToString()));
                 headerLine += $"\n{outcome.Total} match(es); bodies for the {keys.Count}-row window below";
                 string RenderOff(SpillState? sp, out bool trunc) => json
@@ -1602,6 +1670,39 @@ public static class RecordsTools
                     sb.Append('\n');
                 }
             }
+            rendered++;
+        }
+        if (spill is not null) Artifacts.AppendSpillStateText(sb, spill);
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    /// <summary>The reverse MGEF lane's text render: header census over the COMPLETE seed list, each windowed
+    /// seed's carriers via the shared effect-chain render, the standard explicit cut + in-band spill marker.</summary>
+    static string RenderRecordsEffectChains(IReadOnlyList<(string Seed, EffectChainResult Result)> results,
+                                            int totalSeeds, int carrierRows, int errors, string headerLine,
+                                            string? epoch, int maxChars, SpillState? spill, out bool truncated)
+    {
+        truncated = false;
+        int cap = maxChars > 0 ? maxChars : Wire.DefaultMaxChars;
+        bool manifestOnly = spill?.ManifestOnly ?? false;
+        var sb = new StringBuilder();
+        sb.Append(headerLine).Append('\n');
+        sb.Append(totalSeeds).Append(" seed(s), ").Append(carrierRows).Append(" carrier row(s), ").Append(errors).Append(" error(s)");
+        if (epoch is not null) sb.Append("  epoch=").Append(epoch);
+        sb.Append('\n');
+        int rendered = 0;
+        foreach (var (seed, result) in results)
+        {
+            if (manifestOnly) break;
+            if (sb.Length >= cap)
+            {
+                truncated = true;
+                sb.Append("... [rendered ").Append(rendered).Append(" of ").Append(results.Count)
+                  .Append(" seeds at max_chars=").Append(cap).Append("]\n");
+                break;
+            }
+            sb.Append('\n').Append("seed ").Append(seed).Append('\n');
+            sb.Append(Wire.RenderEffectChain(result, cap)).Append('\n');
             rendered++;
         }
         if (spill is not null) Artifacts.AppendSpillStateText(sb, spill);

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -173,7 +173,7 @@ public static class RecordsTools
             RecordsWalk? walk = null,
         [Description("TRANSPORT: 'text' (default) | 'json' (machine-readable document; same accounting in-band) | 'dense' (scan lane: columnar positional rows — the compact bulk-enumeration form).")]
             string? format = null,
-        [Description("TRANSPORT: max rows to render (default 500). The TRUE total is always reported; page with offset=.")]
+        [Description("TRANSPORT: max rows to render (default 500). The TRUE total is always reported; page with offset=. DECLARED COST: the derived-selection forms (delta/tree/chain/info_order, and any walk) consume EVERY scan match — their censuses and artifacts cover the full selection, and limit= windows only the rendered rows — so on a big order the SCAN TERMS (types=/plugins=/where=) are the cost bound: narrow them.")]
             int limit = 500,
         [Description("TRANSPORT: skip the first N matches (exact windows: offset=0/500/1000…). Windows tile only within one epoch — if two pages' epochs differ the load order changed mid-pagination; re-run from offset=0.")]
             int offset = 0,
@@ -293,6 +293,10 @@ public static class RecordsTools
             }
             if (references is { Length: > 0 })
                 return "error: walk= and references= are the same construct (references= IS the reverse walk at depth 1) — use one spelling per call.";
+            if (!string.IsNullOrWhiteSpace(fields_source))
+                return "error: fields_source= is the scan lane's display pole — a walk's reading forms display the source= pole's version of the reached set: name it via source= instead.";
+            if (dense)
+                return "error: format='dense' renders positional columnar cells 1:1 with requested field paths, and a walk's outputs (chains; reached-set reads) have no fixed column set — use format='text' or 'json'.";
             if (comparisonForm || form is "info_order" or "identity")
                 return $"error: walk= derives a selection (the reached set), and the '{form}' form does not consume one — use form='chain' for the walk's own paths, or summary/fields/everything/aggregate over the reached set. To compare reached records, walk with to_file= and re-enter the artifact via formids=[\"@<file>\"] with form='{form}'.";
             if (where is { Length: > 0 })
@@ -313,6 +317,8 @@ public static class RecordsTools
         {
             if (comparisonForm)
                 return $"error: fields_source= retargets what a matched row DISPLAYS, and the '{form}' form's display IS its two poles (source=/versus=) — name the version you want as a pole instead.";
+            if (form is "chain" or "info_order")
+                return $"error: fields_source= retargets FIELD display, and the '{form}' form renders no field values — drop it.";
             var fs = fields_source.Trim().ToLowerInvariant();
             if (fs == "winner") winnerFields = true;
             else if (fs is not ("scoped" or "scanned"))
@@ -373,7 +379,15 @@ public static class RecordsTools
         // Text renders get it as a header line; json renders carry the same pairs as top-level fields.
         var envelope = new List<KeyValuePair<string, string>> { new("form", form) };
         string headerLine = $"records  form={form}";
-        void Arm(string statement) { envelope.Add(new("source", statement)); headerLine += $"  source={statement}"; }
+        void Arm(string statement)
+        {
+            // ONE source statement per response (round-3 F1: the scan lane pre-armed and the derived forms'
+            // pipelines armed again — two "source" properties in one json object). The specific arm is always
+            // stated first now; first-wins is the backstop that keeps a future double-call from lying twice.
+            if (envelope.Any(kv => kv.Key == "source")) return;
+            envelope.Add(new("source", statement));
+            headerLine += $"  source={statement}";
+        }
         // When a walk (or a scan) derived the selection this call now reads, the two captures meet at a seam —
         // every downstream form's epoch is compared against the deriving step's, and a divergence refuses loud
         // (the mixed-builds rule every two-capture path on this surface follows).
@@ -501,7 +515,7 @@ public static class RecordsTools
             {
                 // The overlay POST source: every record's winner replayed through the SkyPatcher INI layer, the
                 // replayed body read at the caller's own depth (absorbs skypatcher_read's post-state view).
-                outcomes = svc.OverlayPostBatch(ids, readFields, depth, demand, out var ovRefusal, out var ovEpoch, out _);
+                outcomes = svc.OverlayPostBatch(ids, readFields, depth, resolveNames, demand, out var ovRefusal, out var ovEpoch, out _);
                 if (ovRefusal is not null)
                     return json ? JsonWire.RenderError(ovRefusal, ovEpoch)
                                 : "error: " + ovRefusal + (ovEpoch is not null ? $"\nepoch={ovEpoch}" : "");
@@ -647,7 +661,7 @@ public static class RecordsTools
                 }
                 string RenderRev(SpillState? sp, out bool trunc) => json
                     ? JsonWire.RenderEffectChains(winResults, max_chars, envelope, revCounts, epochR, sp, out trunc)
-                    : RenderRecordsEffectChains(winResults, results.Count, carrierRows, seedErrs2, headerLine, epochR, max_chars, sp, out trunc);   // header carries carrier_total/capped via headerLine
+                    : RenderRecordsEffectChains(winResults, results.Count, carrierRows, carrierTotal, seedErrs2, headerLine, epochR, max_chars, sp, out trunc);
                 var revRendered = RenderRev(revSpill, out var revTrunc);
                 if (revSpill is null && revTrunc)
                 {
@@ -896,6 +910,9 @@ public static class RecordsTools
             bool hasTypes = types is { Length: > 0 };
             bool hasScope = plugins?.names is { Length: > 0 };
             bool scopePlusPole = false;
+            // The derived-selection forms (comparisons, info_order, a walk's seeds) state their own source arm
+            // and consume EVERY match; known up front, used by the arm rule (F1) and the scan cap below.
+            bool derivedSelection = comparisonForm || form == "info_order" || walk is not null;
             if (hasBodyFilter && !hasTypes && !hasScope && !hasFormids)
                 return "error: where=/references= is a body scan and must be combined with types=, plugins=, or a formids= set to bound the work " +
                        "(conflicts_only= alone is not enough — an unbounded body scan over the whole order is refused; the " +
@@ -945,14 +962,16 @@ public static class RecordsTools
                     // forms have nothing for the pole to change — accepting-and-ignoring it is the sin.
                     if (form is "summary" or "aggregate")
                         return $"error: a plugins= scope with a named source= reads the POLE's version of each scoped match — and the '{form}' form's rows are identity facts the pole doesn't change. Drop source=, or use form='fields'/'everything' (the pole's bodies) or 'delta'/'tree' (comparisons).";
+                    if (winnerFields)
+                        return "error: fields_source='winner' and a named source= under a plugins= scope are TWO display poles on one call — the pole's version is what this composition reads. Drop fields_source= (or drop source= and keep fields_source='winner').";
                     scopePlusPole = true;
                     Arm($"{probe.Plugin} — active in the load order (the plugins= scope selects; this pole's version is read)");
                 }
-                else
+                else if (!derivedSelection)
                     // ACTIVE arm: the pole's records ARE the scan universe — the plugins= stream with the arm stated.
                     Arm($"{probe.Plugin} — active in the load order");
             }
-            else Arm("winner");
+            else if (!derivedSelection) Arm("winner");   // the derived forms' pipelines state their own arm (F1)
 
             // references= @file expansion + FormKey parse (mirrors cross_plugin_query).
             HousecarlCore.ArtifactDemand? refDemand = null; string? refEcho = null;
@@ -982,10 +1001,9 @@ public static class RecordsTools
             // the REACHED set via the walk lane's re-entry. Grouping the scan itself would return an aggregate
             // of the seeds labeled as the walk's answer, with walk= silently dropped (review F2).
             var groupBy = form == "aggregate" && walk is null ? project!.group_by!.Trim().ToLowerInvariant() : null;
-            // The derived-selection forms (comparisons, info_order, a walk's seeds) consume EVERY match — the
-            // window applies to their rows, and the counts / artifact must cover the full selection — so the
-            // scan itself is uncapped for them.
-            bool derivedSelection = comparisonForm || form == "info_order" || walk is not null;
+            // The derived-selection forms consume EVERY match — the window applies to their rows, and the
+            // counts / artifact must cover the full selection — so the scan itself is uncapped for them
+            // (a DECLARED cost, carried in the tool description: the scan terms are the bound).
             int effLimit = wantFile || derivedSelection ? int.MaxValue : counts_only ? 0 : (limit <= 0 ? 500 : limit);
 
             var demandsList = new List<HousecarlCore.ArtifactDemand>();
@@ -1222,7 +1240,10 @@ public static class RecordsTools
         // ================================================================================================
         string OffOrderScan(LoadOrderService.PoleInfo pole)
         {
-            Arm($"{pole.Plugin} — {pole.Where}");
+            // The comparison pipelines state their own subject arm (F1's one-statement rule; first-wins would
+            // otherwise pin the file arm on a delta whose subject is the file — same statement, so keep it for
+            // the reading forms and let the pipelines win on comparisons).
+            if (!comparisonForm) Arm($"{pole.Plugin} — {pole.Where}");
             envelope.Add(new("epoch_covers_source", "false"));
             headerLine += "\n(the off-order file's content is OUTSIDE the epoch fingerprint — an edit to it changes answers without changing the epoch)";
             if (conflicts_only)
@@ -1691,7 +1712,7 @@ public static class RecordsTools
     /// <summary>The reverse MGEF lane's text render: header census over the COMPLETE seed list, each windowed
     /// seed's carriers via the shared effect-chain render, the standard explicit cut + in-band spill marker.</summary>
     static string RenderRecordsEffectChains(IReadOnlyList<(string Seed, EffectChainResult Result)> results,
-                                            int totalSeeds, int carrierRows, int errors, string headerLine,
+                                            int totalSeeds, int carrierRows, int carrierTotal, int errors, string headerLine,
                                             string? epoch, int maxChars, SpillState? spill, out bool truncated)
     {
         truncated = false;
@@ -1699,7 +1720,9 @@ public static class RecordsTools
         bool manifestOnly = spill?.ManifestOnly ?? false;
         var sb = new StringBuilder();
         sb.Append(headerLine).Append('\n');
-        sb.Append(totalSeeds).Append(" seed(s), ").Append(carrierRows).Append(" carrier row(s), ").Append(errors).Append(" error(s)");
+        sb.Append(totalSeeds).Append(" seed(s), ").Append(carrierRows).Append(" carrier row(s)");
+        if (carrierTotal != carrierRows) sb.Append(" of ").Append(carrierTotal).Append(" total");
+        sb.Append(", ").Append(errors).Append(" error(s)");
         if (epoch is not null) sb.Append("  epoch=").Append(epoch);
         sb.Append('\n');
         int rendered = 0;

--- a/src/housecarl-mcp/ToolCallShim.cs
+++ b/src/housecarl-mcp/ToolCallShim.cs
@@ -50,9 +50,14 @@ internal static class ToolCallShim
     /// <summary>The filter. Registered on the server in Program.cs via WithRequestFilters → AddCallToolFilter.</summary>
     public static McpRequestFilter<CallToolRequestParams, CallToolResult> LenientArguments => next => async (request, cancellationToken) =>
     {
-        // MatchedPrimitive is resolved by the SDK BEFORE filters run; unknown tool names pass through untouched
-        // (the SDK's own unknown-tool error is already specific).
+        // MatchedPrimitive is resolved by the SDK BEFORE filters run. An unknown tool name normally passes
+        // through to the SDK's own specific unknown-tool error — EXCEPT a RETIRED name (W2 PR 2, the
+        // tool-NAME lane): the 8 reads housecarl_records absorbed answer with their successor call shape
+        // instead of a dead end. Dormant while those tools stay registered (a registered name resolves and
+        // never reaches this check); load-bearing the moment one is unregistered (2.0.0's clean cut).
         var p = request.Params;
+        if (request.MatchedPrimitive is not McpServerTool && AliasTable.RetiredToolHint(p?.Name) is { } retiredRedirect)
+            return NamedError(retiredRedirect);
         var received = DescribeArgs(p?.Arguments);   // what the caller ACTUALLY sent — captured before coercion rewrites
                                                      // the dictionary, so the failure message never shows a coerced shape
                                                      // as if the caller had sent it (review #1 finding 2)


### PR DESCRIPTION
## W2 PR 2 — `housecarl_records`: the comparison/traversal forms, every pole, the SELECT compositions (SPEC §3 / §4 / §6.1)

Second and final PR of W2 (charter skeleton: *core grammar* landed as PR #307; this is *comparison/project forms*). **The PR-1 staging refusals were the work list, verbatim — every one is now a capability, deleted only when the capability shipped.** Everything lands additively behind the alias layer; the 1.x read tools remain byte-unchanged and registered (clean cut at 2.0.0, CHARTER_PHASE4 §3.4a).

### What ships

1. **`delta` + `versus=`** (§4.1–§4.4): subject (`source=`) vs reference (`versus=`), deltas only, both poles resolved against ONE captured build via a shared pole-reader layer (winner | named active/off-order under the one-pole rule | previous_provider | overlay). `previous_provider` is **subject-relative** with all four §4.3 cases declared and probe-pinned (P1–P4 in `records-guard`); the P2 mid-stack fact renders **neutral** (what outranks the subject, by name — no advice, per the §4.3 neutrality rule). Both lanes (formids= and scan — the scan selects, the engine compares, the seam epoch-compared). Same `FieldsDiff` engine and truncation honesty as `diff_record`.
2. **`tree`**: the conflict view as a PROJECT form — every provider (winner last), each diffed against the reference pole (default winner; a named pole composes, `previous_provider` refused by name there — it has no single reference in a tree). **The committed json render + a row form: trees now SPILL** (PR #306 fold-decision 1 closed). The `conflict_tree` alias hint's interim clause is trimmed.
3. **`walk=` + `chain`** (§3): forward walks over the winner link graph (seed_paths → first hop; `follow=` named chain or `*` closure via generic `EnumerateFormLinks` — by construction; stop/refuse exclusions as caller data; depth/node caps with the read posture; cycles recorded on named-follow chains; provenance on every node). `chain` renders the walks; **any other reading form consumes the reached set as its selection** (seeds included, declared; seam epoch-checked). `follow="Template"` over NPC_ seeds adds the **TemplateFlags interpreter** (§3.3 registry entry #1 — and deliberately the only entry). `walk.direction="reverse"` depth 1 = the **typed MGEF carrier lane** (the `effect_chain` absorption: per-hit magnitude/area/duration, loud typed-match gate); depth>1 refused naming the reverse-reference index (§3.2).
4. **`info_order`** (§6.1 F1 split, class 8): the merged effective INFO sequence per DIAL topic — `DialogueValidate`'s merge extracted to a public `InfoOrders` entry (Run's own path now delegates to it: one merge, no drift), the render sharing `validate_dialogue`'s own body verbatim (MOVED annotations + the `MovesComputed`×`Complete` / `BaselineTrusted` honesty gates carried intact — the §6.1 "must not orphan them" check). Non-DIAL targets refuse typed, teaching the quest fan-out composition (`types=["DIAL"] where=["Quest = X"]`).
5. **The overlay pole** `{"overlay": "skypatcher", "state": "pre"|"post"}`: post-state bodies via the shared SkyPatcher replay core (which now hands back the mutated copy) for any reading form and for delta's poles (pre-vs-post = §4.2's "no new machinery"); INI content declared outside the epoch fingerprint; per-record scan replay refused as a declared cost.
6. **Compositions**: `formids=`×scan (a formid-set stream in `CrossQuery` — intersection under a scope, or the universe alone, where **the set is the bound** so `where=` needs no types/plugins); scope-vs-pole streams (`plugins=` selects, an active named `source=` is whose version the body forms read — untouched matches per-item-refused naming touchers **plus an explicit `not_touched` count**; summary/aggregate refuse by name since the pole changes nothing there); the **off-order scan completed** on a real engine query (`OffOrderQuery`: multi-type, the full `where=` grammar over the file's bodies, references=, plugins= scope, defined_in, group_by, windows, counts, artifacts, comparisons over the file's matches).
7. **The tool-NAME lane**: `AliasTable.RetiredTools` maps the 8 absorbed reads to their successor call shapes; `ToolCallShim` answers an UNRESOLVED tool name on that table with the successor spelling instead of the SDK generic. **Dormant by construction** while the 1.x tools stay registered (the SDK resolves a registered name before the filter's check runs); load-bearing at 2.0.0's clean cut.
8. **Guards**: `records-guard` gains section 6 (~25 checks over an extended fixture — a MID override for the mid-stack subject, an NPC template pair) incl. the four `previous_provider` pins; stale staging pins converted to capability pins; CENSUS re-eyeballed and re-baked **113 → 119** (`versus=`/`walk=` activate the six gated hints, all on `housecarl_records`). `ci-all` **ALL PASS**.

### Decisions that need review eyes (the design record)

- **Instrument-schema deviations, dictionary-grounded:** `walk.seeds` (the Phase-3 instrument's nested seeds object) is NOT a parameter — the walk's seeds ARE the call's own SELECT (the instrument itself said "defaults to this call's own SELECT"; one spelling, no duplicate seed grammar). The instrument is the frozen eval pack, not the build contract (§6.1's own rule).
- **The general reverse walk IS `references=`** (SPEC §3.3 says so verbatim: "references= is the same construct with follow=*") — `walk.direction="reverse"` therefore serves exactly the typed MGEF lane, and the general spelling is taught by name, not duplicated. Depth>1 refusal names the index (§3.2).
- **Walk expansion universe = the winner graph, declared in the schema.** The §3.1 universe parameterization's consumer is the ACT closure copy (W3's `copy`, with its donor-fetch delegate); for reads, `source=` governs whose version the FORMS render of the reached set. Nothing silently narrows: the schema states the rule.
- **`walk=` × `where=` composes through the artifact lane** (walk with `to_file=`, re-enter on a bounded scan) — the refusal teaches that spelling. An inline post-filter would be a second predicate seat on one call with two different bodies in scope; the artifact spelling keeps one grammar.
- **`fields_source` stays the `'winner'` shorthand**; the GENERAL display pole is the scope-vs-pole composition itself (`plugins=` × `source=`), which subsumes `fields_source=<plugin>` without a second pole vocabulary on the same call.
- **Overlay pre = the plain winner, labeled as the overlay's pre state** — so a pre-vs-post delta's arms read as a pair; a record whose type SkyPatcher cannot patch reads as its winner with the fact on the pole line (post IS pre there — an answer, not an error).
- **`info_order` is epoch-stamped** (unlike `validate_dialogue`, deliberately unstamped): this form reads plugin records through the index only — no VFS/INI layer — so the stamp is honest.
- **Retired-name redirects survive as an open 2.0.0 question:** CHARTER §3.4a removes "aliases" at 2.0.0; the retired-NAME table is arguably the changelog's §5.3 lookup in executable form and costs no schema/context. Flagging rather than deciding — the 2.0.0 release event owns it.
- **`delta`/`tree` read at the diff engine's fixed depth** (`ConflictDiffDepth`), `project.depth` refused by name on them — both sides must read the same paths at the same depth for line sets to correspond (`diff_record`'s own posture, now stated in the refusal).

### Description-harvest ledger (§6.1 rule — the four remaining absorbed tools)

| Source | Teaching | Disposition |
|---|---|---|
| `diff_record` | the classic use (a DISABLED old patch vs its successor); "unlike conflict_tree (winner pole), TWO explicit plugins"; truncated-read-is-not-identical | **Kept** (delta form teaching + the render's own honesty lines) |
| `diff_record` | `mod_a`/`mod_b` disambiguators | **Kept** (structured poles carry `mod`; the alias hints teach the spelling) |
| `effect_chain` | "magnitude AS AUTHORED — conditions not evaluated, a row means 'defines it at this strength', not 'it will fire'" | **Kept** (the reverse lane's header line, verbatim) |
| `effect_chain` | the typed-match gate (a non-MGEF fails loud, never a silent '0 carriers'); the five carrier types | **Kept** (engine unchanged; the walk description + refusals name them) |
| `skypatcher_read` | "the DLL reads INIs at runtime — this is what the record becomes AFTER"; folder-order assumption; per-op before/after | **Partially kept**: the overlay pole's description carries the post-state framing; the per-op ledger view stays `skypatcher_read`'s own render (the records form reads the BODY — the two views compose, neither absorbs the other's shape). Op-level detail teaching deliberately left with the 1.x tool until W5's S6 wave. |
| `validate_dialogue` (class 8) | re-list-appends-to-bottom; the merged-order framing ("the game walks top to bottom, FIRST passing line"); MOVED-is-invisible-to-a-diff | **Kept** (tool description + the shared render body itself) |
| `validate_dialogue` (class 8) | PNAM-absence-is-normal / placement markers | **Kept** (the shared render's placement brackets are the same code) |

### Verification

- `ci-all` **ALL PASS** (all probes incl. the extended `records-guard`, `alias-layer-guard`, `binding-shim-guard` with the re-baked CENSUS).
- Live-instance verification against ARR is not part of this PR (same posture as PR #307; the dev install predates W2).
- Not live-fixture-covered (declared): `info_order` over a real contested DIAL merge rides the existing dialogue-engine guards (the records lane is the same `InfoOrders` code `validate_dialogue` runs); the records-side pin is the typed-refusal + composition teaching. A retired-name redirect fires only for an unregistered name, so its guard is unit-level (`RetiredToolHint`), not e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
