### PR TITLE
feat(w3): housecarl_apply — the 2.0 S1 field-write surface (LANE grammar, the §4.5 copy zip, in-place CopyFrom parity)

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -8,6 +8,35 @@ when it changes.
 
 *Accumulating notes for the next cut — not yet released; `plugin.json` still reads the last shipped version.*
 
+**New tool: `housecarl_apply` — the 2.0 field-write surface (W3 PR 1).** One write call composes *what changes*
+× *where it lands* × *how it reads back*, replacing `set_field` + `bulk_apply`. **Edits:** `ops=` is the edit
+list — one op is a set of one, so the old single-field call is the degenerate case — and it takes the inline
+array **or `"@<absolute path>"`**, the `@file` convention that retires `from_file=` along with its
+inline-vs-file mutual exclusion. Both lanes now read through the same strict parser, so an **undeclared op
+member is refused by name inline too** (the SDK's binder silently *drops* one, which in a large generated batch
+sends every downstream refusal chasing the wrong op); a 1.x spelling inside an op — `verb`, `from_plugin` —
+gets the new word in the refusal, because the alias layer only reaches top-level arguments.
+**Copying a field bundle between records** is `bundle=` (the paths, uniform across pairs) × `assignments=`
+(`[{target, from, from_source?}]`) — a **zip, never a product**: each target reads its own paired source, so N
+targets never fan out to N×N. Everything outside the bundle is untouched *by construction*, `from_source`
+defaults to the source record's load-order winner, and a cross-record pair must be the same record type
+(refused by name at pre-flight, with every bad pair reported at once). It composes with `ops=` in one call.
+**One lane spelling:** a new patch (`patch=`), `into=` an existing one, or **`in_place="X.esp"` — the string
+names the file being overwritten**, replacing the old `target=` + `in_place=true` pair. The three destinations
+are mutually exclusive and **naming two is refused by name**, as is `acknowledge=` without a lane (1.x silently
+ignored `patch_name=` under `into=`). `dry_run=`, the one-time in-place consent handshake, and the
+all-or-nothing pre-flight are unchanged. **Transport:** `readback=`, `max_chars=`, `format="json"` (the same
+data machine-readable — a refusal is a document too, and the consent prompt is its own flag rather than an
+error), and **every write response now carries `epoch=`**, the identity of the index build its winners were
+resolved from. `set_field` / `bulk_apply` are unchanged and stay registered through the build waves; from
+2.0.0's clean cut a call naming one answers with its successor `housecarl_apply` spelling.
+
+**Fixed: `CopyFrom` never worked on the in-place lane.** A legal `verb="CopyFrom"` edit with `in_place` resolved
+no source record and fell through to the verb engine, which has no CopyFrom branch — so it failed as *"pre-flight
+accepted it but the apply threw"*, reporting a missing capability as an internal fault. The in-place lane now
+resolves copy sources under the same contract as the patch lane (active-order and off-order alike), and copying a
+record's own field onto itself is refused as the no-op it is.
+
 **`housecarl_records` completed: the comparison and traversal forms, every SOURCE pole, and the full SELECT
 composition (W2 PR 2).** Every staging refusal from the core wave is now a capability. **Comparisons:**
 `project={"form": "delta"}` diffs the SUBJECT (`source=`) against a REFERENCE (`versus=`) and returns only what

--- a/plugin/codex/housecarl/SKILL.md
+++ b/plugin/codex/housecarl/SKILL.md
@@ -42,6 +42,7 @@ Beyond the core workflow, reach for the right group. Depth for the specialist ar
 - `housecarl_skse_inventory` — SKSE-plugin DLLs, configs, provider/metadata; `housecarl_skse_config_audit` — config references vs the load order; `housecarl_native_pairing_audit` — native Papyrus declarations vs the DLLs implementing them.
 
 **Write / author**
+- `housecarl_apply` — the consolidated 2.0 field-write surface (one or many edits × the lane × the read-back in one call): `ops=` for field edits, `bundle=`+`assignments=` to copy a field bundle from one record onto another, and one lane spelling — a new patch, `into=` an existing one, or `in_place="X.esp"` naming the file you intend to overwrite. The 1.x write tools below keep working through the 2.0 build.
 - `housecarl_set_field`, `housecarl_bulk_apply`, `housecarl_create_record`, `housecarl_bulk_create`, `housecarl_create_plugin` (header-only trigger plugin), `housecarl_remove_record`, `housecarl_forward_record` (copy-as-override, or revert to another plugin's version), `housecarl_validate_scripts` (unbound script properties).
 
 **Dialogue** — `housecarl_validate_dialogue`, `housecarl_write_seq` (the start-game-enabled quest `.seq`). Depth: `dialogue-authoring`.

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1862,6 +1862,14 @@ public static class WriteEngine
     /// (<c>SomethingMixIn.DeepCopy(this ISomethingGetter, TranslationMask? = null)</c>), not a parameterless instance
     /// method, so this finds and invokes it (or a same-shape instance overload where one exists). Returns null when the
     /// value has no DeepCopy (a plain scalar/value/string — the caller then assigns it directly). Per-type memoised.</summary>
+    /// <summary>A DETACHED deep copy of a whole record, or null if Mutagen models no DeepCopy for its type. Used by
+    /// the in-place lane to snapshot a copy source that lives in the file being rewritten: the source must not be
+    /// the live mutable record, or (a) later ops in the same call would be visible to it, and (b) the element-level
+    /// share in <see cref="CopyElement"/> — safe when a source is a read-only overlay, since an overlay element is
+    /// never the settable concrete type — would alias the two records' collection elements.</summary>
+    internal static IMajorRecordGetter? TryDeepCopyRecord(IMajorRecordGetter record)
+        => TryDeepCopy(record) as IMajorRecordGetter;
+
     static object? TryDeepCopy(object val)
     {
         var t = val.GetType();

--- a/src/housecarl-core/WriteEngine.cs
+++ b/src/housecarl-core/WriteEngine.cs
@@ -1858,18 +1858,19 @@ public static class WriteEngine
     // is done ONCE per type. A null entry means "no DeepCopy" (a plain scalar/value) — memoised too.
     static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, (MethodInfo? m, bool isExtension)> _deepCopyOf = new();
 
-    /// <summary>DeepCopy a Loqui getter to its settable concrete. Mutagen generates DeepCopy as an EXTENSION method
-    /// (<c>SomethingMixIn.DeepCopy(this ISomethingGetter, TranslationMask? = null)</c>), not a parameterless instance
-    /// method, so this finds and invokes it (or a same-shape instance overload where one exists). Returns null when the
-    /// value has no DeepCopy (a plain scalar/value/string — the caller then assigns it directly). Per-type memoised.</summary>
-    /// <summary>A DETACHED deep copy of a whole record, or null if Mutagen models no DeepCopy for its type. Used by
-    /// the in-place lane to snapshot a copy source that lives in the file being rewritten: the source must not be
-    /// the live mutable record, or (a) later ops in the same call would be visible to it, and (b) the element-level
+    /// <summary>A DETACHED deep copy of a whole record, or null if Mutagen models no DeepCopy for its type (the
+    /// caller then REFUSES — falling back to the live record is the bug this exists to prevent). Used by the
+    /// in-place lane to snapshot a copy source that lives in the file being rewritten: the source must not be the
+    /// live mutable record, or (a) later ops in the same call would be visible to it, and (b) the element-level
     /// share in <see cref="CopyElement"/> — safe when a source is a read-only overlay, since an overlay element is
     /// never the settable concrete type — would alias the two records' collection elements.</summary>
     internal static IMajorRecordGetter? TryDeepCopyRecord(IMajorRecordGetter record)
         => TryDeepCopy(record) as IMajorRecordGetter;
 
+    /// <summary>DeepCopy a Loqui getter to its settable concrete. Mutagen generates DeepCopy as an EXTENSION method
+    /// (<c>SomethingMixIn.DeepCopy(this ISomethingGetter, TranslationMask? = null)</c>), not a parameterless instance
+    /// method, so this finds and invokes it (or a same-shape instance overload where one exists). Returns null when the
+    /// value has no DeepCopy (a plain scalar/value/string — the caller then assigns it directly). Per-type memoised.</summary>
     static object? TryDeepCopy(object val)
     {
         var t = val.GetType();

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -87,12 +87,18 @@ public static class WritePatchBuilder
     {
         public IReadOnlyList<FullReadback>? ReadBack { get; init; }
 
-        /// <summary>SPEC §2.1.1 — the fingerprint of the index build this write resolved against (winners, master
-        /// membership, the in-place target's own body). Stamped on EVERY outcome decided after the capture: success,
+        /// <summary>SPEC §2.1.1 — the fingerprint of the index build THIS OUTCOME was decided from (winners, master
+        /// membership, the in-place target's own body). Stamped on EVERY outcome decided after a capture: success,
         /// refusal, dry run, and the consent prompt alike. Null only for the refusals taken BEFORE any build was
         /// consulted (a malformed op, an unopenable patch file) — they read no index, so they claim no build.
         /// Why a WRITE carries one: the readback proves what landed in the FILE, not what wins in the ORDER, and the
-        /// epoch is what lets a caller tell whether the winner it edited is the winner it read a moment earlier.</summary>
+        /// epoch is what lets a caller tell whether the winner it edited is the winner it read a moment earlier.
+        /// <para>HONESTY BOUND (round-4 review): a few call shapes consult more than one capture — an off-order
+        /// CopyFrom pre-locate takes its own, and the in-place lane captures once in the service to resolve the
+        /// target and again in the core. The field names the build the reported outcome came from, NOT a claim that
+        /// exactly one capture occurred. They can only differ if the load order changed mid-call (mtime freshness),
+        /// which would show as an epoch that does not match a read taken either side of it — detectable, which is
+        /// the point, rather than papered over.</para></summary>
         public string? Epoch { get; init; }
 
         /// <summary>True ⇒ this outcome came from the IN-PLACE lane (<see cref="Apply"/>'s sibling

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -707,10 +707,11 @@ public static class WritePatchBuilder
                 $"cannot edit '{targetName}' in place: it was EXCLUDED from this session ({excluded}) — houseCARL won't " +
                 "re-serialize a plugin it can't fully parse (that would risk dropping the record it couldn't read, Q3). The file is UNTOUCHED.");
 
-        var resolved = new List<(PatchEdit edit, IMajorRecordGetter body, WriteRequest req, string label, IMajorRecordGetter? srcBody)>(edits.Count);
+        var resolved = new List<(PatchEdit edit, IMajorRecordGetter body, WriteRequest req, string label, IMajorRecordGetter? srcBody, bool selfSource)>(edits.Count);
         var problems = new List<string>();
         foreach (var e in edits)
         {
+            bool selfSource = false;   // the copy source lives in the TARGET's own file — see the lifetime note below
             var body = view.GetRecord(session, targetName, e.Target);
             if (body is null)
             {
@@ -753,10 +754,19 @@ public static class WritePatchBuilder
                 {
                     srcBody = view.GetRecord(session, srcPlugin, e.CopySource);
                     if (srcBody is null) { problems.Add(CopySourceMissing(e, srcPlugin)); continue; }
+                    // LIFETIME (review [high]): a source resolved out of the TARGET's own file comes from a session
+                    // overlay that Phase 4 disposes (ReleaseOverlay, before WriteInPlace) — while CopyField's
+                    // contract is that the source overlay outlives the serialize, because TransplantValue shares
+                    // directly-assignable immutables (strings, MemorySlice) BY REFERENCE. Reading through the
+                    // disposed overlay at serialize time is garbage bytes over the user's original, on the one lane
+                    // that keeps no backup. Pre-flight (the type gate below) may use this body; the APPLY must not,
+                    // so it is re-resolved from the mutable targetMod in Phase 3, which lives through the write.
+                    // Deliberately not refused: copying between two records of the same file is a legitimate job.
+                    if (string.Equals(srcPlugin, targetName, StringComparison.OrdinalIgnoreCase)) selfSource = true;
                 }
                 if (CrossTypeRefusal(e, srcBody, body) is { } typeErr) { problems.Add(typeErr); continue; }
             }
-            resolved.Add((e, body, req, label, srcBody));
+            resolved.Add((e, body, req, label, srcBody, selfSource));
         }
         if (problems.Count > 0)
             return PatchOutcome.Fail(
@@ -785,7 +795,7 @@ public static class WritePatchBuilder
         //     never a foreign override's. A nested record gets the target overlay's link cache on demand (released in
         //     Phase 4). A throw after pre-flight passed is a real engine inconsistency — fail the WHOLE call (Q3). ---
         var ops = new List<OpResult>(resolved.Count);
-        foreach (var (e, body, req, label, srcBody) in resolved)
+        foreach (var (e, body, req, label, srcBody, selfSource) in resolved)
         {
             try
             {
@@ -794,7 +804,22 @@ public static class WritePatchBuilder
                 // CopyFrom transplants the field FROM the resolved source body into the target's own record; every
                 // other verb applies to it directly (the same two-branch shape Apply uses — one engine, two lanes).
                 if (string.Equals(req.Verb, "CopyFrom", StringComparison.Ordinal))
-                    WriteEngine.CopyField(srcBody!, ov, req.Path);
+                {
+                    // A source in the TARGET's own file is re-read from the MUTABLE targetMod, never the session
+                    // overlay Phase 4 releases — see the lifetime note in Phase 1. targetMod outlives the serialize,
+                    // so the by-reference immutables CopyField shares stay valid through it.
+                    var copyFrom = srcBody;
+                    if (selfSource)
+                    {
+                        copyFrom = targetMod.EnumerateMajorRecords().FirstOrDefault(r => r.FormKey == e.CopySource);
+                        if (copyFrom is null)
+                            return PatchOutcome.Fail(
+                                $"refused applying [{label}] to {req.RecordType} {e.Target} — the copy source {e.CopySource} " +
+                                $"resolved in '{fileName}' at pre-flight but is not present in the opened file (a real " +
+                                $"inconsistency, surfaced not swallowed — Q3). The file is untouched.");
+                    }
+                    WriteEngine.CopyField(copyFrom!, ov, req.Path);
+                }
                 else
                     WriteEngine.ApplyVerb(ov, req);
                 var (after, landed) = DescribeApplied(ov, req);

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -49,7 +49,19 @@ public static class WritePatchBuilder
         public Dictionary<string, string>? Entries { get; init; }
         public StructSpec? Struct { get; init; }
         public IReadOnlyList<StructSpec>? Structs { get; init; } // P8a batch struct-list ops (composes=): Add appends each, ReplaceAll clears+appends each.
-        public string? FromPlugin { get; init; } // P8b verb=CopyFrom: the plugin whose version of Target to deep-copy the field FROM (active, or off-order on disk).
+        public string? FromPlugin { get; init; } // P8b verb=CopyFrom: the plugin whose version of the SOURCE record to deep-copy the field FROM (active, or off-order on disk).
+
+        /// <summary>SPEC §4.5 (the <c>assignments=</c> zip) — the SOURCE RECORD a CopyFrom reads, when it is a
+        /// DIFFERENT record from <see cref="Target"/> (cross-record copy: "give this weapon that weapon's Keywords").
+        /// Null ⇒ same-FormKey copy, the P8b behaviour: <see cref="FromPlugin"/>'s version of <see cref="Target"/>
+        /// itself. The pair passes the same-runtime-record-type gate at pre-flight (§4.5: "legality does not
+        /// shrink") — a cross-TYPE pair is refused by name, never coerced.</summary>
+        public FormKey? FromTarget { get; init; }
+
+        /// <summary>The record a CopyFrom actually READS — the §4.5 zip's source record when one is named, else the
+        /// target itself. One accessor so every source-resolution site (pre-flight, the off-order pre-locate, the
+        /// in-place lane) can never disagree about which FormKey the copy reads.</summary>
+        public FormKey CopySource => FromTarget ?? Target;
     }
 
     /// <summary>Per-edit result. On a successful call every op has <see cref="Applied"/>=true (all-or-nothing);
@@ -74,6 +86,14 @@ public static class WritePatchBuilder
         IReadOnlyList<string> Masters, IReadOnlyList<OpResult> Ops, long Bytes)
     {
         public IReadOnlyList<FullReadback>? ReadBack { get; init; }
+
+        /// <summary>SPEC §2.1.1 — the fingerprint of the index build this write resolved against (winners, master
+        /// membership, the in-place target's own body). Stamped on EVERY outcome decided after the capture: success,
+        /// refusal, dry run, and the consent prompt alike. Null only for the refusals taken BEFORE any build was
+        /// consulted (a malformed op, an unopenable patch file) — they read no index, so they claim no build.
+        /// Why a WRITE carries one: the readback proves what landed in the FILE, not what wins in the ORDER, and the
+        /// epoch is what lets a caller tell whether the winner it edited is the winner it read a moment earlier.</summary>
+        public string? Epoch { get; init; }
 
         /// <summary>True ⇒ this outcome came from the IN-PLACE lane (<see cref="Apply"/>'s sibling
         /// <see cref="ApplyInPlace"/>) — the edits landed in the USER's own file at <see cref="OutputPath"/>, not a new
@@ -286,6 +306,20 @@ public static class WritePatchBuilder
         IReadOnlyList<PatchEdit> edits, string outPath, bool extend, bool fullReadback = false,
         IReadOnlyDictionary<PatchEdit, IMajorRecordGetter>? copyFromSources = null, bool dryRun = false)
     {
+        string? epoch = null;
+        var outcome = ApplyCore(resolver, rulebook, edits, outPath, extend, fullReadback, copyFromSources, dryRun, ref epoch);
+        return epoch is null ? outcome : outcome with { Epoch = epoch };
+    }
+
+    /// <summary>The body of <see cref="Apply"/>. Split only so the ONE captured build's fingerprint (SPEC §2.1.1)
+    /// stamps EVERY outcome — success, refusal, dry run, consent prompt — from a single place, instead of threading
+    /// it through the dozen return sites below. <paramref name="epoch"/> stays null for the refusals decided BEFORE
+    /// the capture (they consulted no build, so stamping them would claim evidence they never read).</summary>
+    static PatchOutcome ApplyCore(
+        LoadOrderResolver resolver, CorpusRulebook rulebook,
+        IReadOnlyList<PatchEdit> edits, string outPath, bool extend, bool fullReadback,
+        IReadOnlyDictionary<PatchEdit, IMajorRecordGetter>? copyFromSources, bool dryRun, ref string? epoch)
+    {
         if (edits.Count == 0) return PatchOutcome.Fail("no edits supplied.");
 
         // Per-call overlay session (Option B): every source plugin this write reads (winner bodies, the nested link
@@ -325,6 +359,7 @@ public static class WritePatchBuilder
         //     the current authoring session, never an arbitrary un-enabled plugin, so the Q3 winner-confusion hazard
         //     the declined read-un-enabled-plugins feature guards against doesn't arise. ---
         var view = resolver.Capture();
+        epoch = view.Epoch;                                               // SPEC §2.1.1 — stamped on every outcome from here down
         var resolved = new List<(PatchEdit edit, IMajorRecordGetter? body, string? winnerPlugin, IMajorRecord? patchLocal, WriteRequest req, string label, IMajorRecordGetter? srcBody)>(edits.Count);
         var problems = new List<string>();
         // Records the extended patch DEFINES (FormKey in the patch's own master space — created by a prior into=
@@ -366,9 +401,11 @@ public static class WritePatchBuilder
                 }
             }
 
-            // P8b CopyFrom source: from_plugin's version of e.Target — an OFF-ORDER file the SERVICE pre-located (passed in
-            // copyFromSources), ELSE resolved from the ACTIVE order via this same captured view (the forward_record contract:
-            // in the order, defines/overrides the record, and not the output patch itself). Refused loud, all-or-nothing (Q3).
+            // P8b CopyFrom source: from_plugin's version of the SOURCE record (e.CopySource — e.Target for a same-record
+            // copy, the §4.5 zip's `from` record for a cross-record one) — an OFF-ORDER file the SERVICE pre-located
+            // (passed in copyFromSources), ELSE resolved from the ACTIVE order via this same captured view (the
+            // forward_record contract: in the order, defines/overrides the record, and not the output patch itself).
+            // Refused loud, all-or-nothing (Q3).
             IMajorRecordGetter? srcBody = null;
             if (string.Equals(e.Verb, "CopyFrom", StringComparison.Ordinal))
             {
@@ -390,10 +427,16 @@ public static class WritePatchBuilder
                 { problems.Add($"{e.Target}: CopyFrom source '{e.FromPlugin}' was excluded from this session ({why}) — its records aren't resolvable."); continue; }
                 else
                 {
-                    srcBody = view.GetRecord(session, e.FromPlugin, e.Target);
+                    srcBody = view.GetRecord(session, e.FromPlugin, e.CopySource);
                     if (srcBody is null)
-                    { problems.Add($"{e.Target}: CopyFrom source '{e.FromPlugin}' is in the load order but does NOT define or override this record — there is no version of it there to copy."); continue; }
+                    { problems.Add(CopySourceMissing(e)); continue; }
                 }
+                // §4.5 — the same-runtime-record-type gate. A same-FormKey copy passes by construction (one record,
+                // one type); the zip's CROSS-record pair is the case that can disagree, and a cross-type transplant
+                // is refused BY NAME here rather than reaching CopyField, where the mismatch would surface as a
+                // property-shaped "no field X on Y" that points away from the real cause.
+                if (CrossTypeRefusal(e, srcBody, patchLocal ?? (object?)body) is { } typeErr)
+                { problems.Add(typeErr); continue; }
             }
 
             var recType = RecordNaming.StripOverlay((patchLocal ?? (object)body!).GetType().Name);
@@ -515,6 +558,31 @@ public static class WritePatchBuilder
         return new PatchOutcome(true, null, outPath, extend, masters, ops, bytes) { ReadBack = readBack };
     }
 
+    /// <summary>The "source plugin doesn't carry the record to copy" refusal, worded for the lane that hit it: a
+    /// SAME-record copy names the target (the P8b sentence, unchanged); a §4.5 cross-record copy names the SOURCE
+    /// record and the target it was being copied INTO, so the reader can tell WHICH of the two the source plugin is
+    /// missing (Q3 — the ambiguous "this record" would point at the wrong one half the time).</summary>
+    static string CopySourceMissing(PatchEdit e) =>
+        e.FromTarget is null
+            ? $"{e.Target}: CopyFrom source '{e.FromPlugin}' is in the load order but does NOT define or override this record — there is no version of it there to copy."
+            : $"{e.Target}: CopyFrom source '{e.FromPlugin}' is in the load order but does NOT define or override the SOURCE record {e.CopySource} — there is no version of it there to copy from.";
+
+    /// <summary>SPEC §4.5's same-runtime-record-type gate for a CROSS-record copy. Returns a named refusal when the
+    /// source and target records are different runtime types, else null. A same-FormKey copy (<see
+    /// cref="PatchEdit.FromTarget"/> null) is one record and always passes — the gate exists for the zip's pairs.
+    /// Compared on the OVERLAY-STRIPPED type name, the same identity every other surface reports, so a binary-overlay
+    /// source and a settable target of the same record type agree instead of tripping on their runtime classes.</summary>
+    static string? CrossTypeRefusal(PatchEdit e, IMajorRecordGetter srcBody, object? targetBody)
+    {
+        if (e.FromTarget is null || targetBody is null) return null;
+        var srcType = RecordNaming.StripOverlay(srcBody.GetType().Name);
+        var tgtType = RecordNaming.StripOverlay(targetBody.GetType().Name);
+        if (string.Equals(srcType, tgtType, StringComparison.Ordinal)) return null;
+        return $"{e.Target}: cannot copy from {e.CopySource} — the source is a {srcType} and the target is a {tgtType}. " +
+               "A field bundle copies between records of the SAME record type (a field path means different things on " +
+               "different types); pair each target with a source of its own type.";
+    }
+
     /// <summary>#131 F1 (edit-lane intent-following), shared by <see cref="Apply"/> and <see cref="ApplyInPlace"/>:
     /// after the edits are applied, for each DialogTopic this call edited where it SET <c>Subtype</c> but NOT
     /// <c>SubtypeName</c>, sync the SNAM marker to the new Subtype — otherwise the change is a silent in-game no-op
@@ -579,7 +647,19 @@ public static class WritePatchBuilder
     public static PatchOutcome ApplyInPlace(
         LoadOrderResolver resolver, CorpusRulebook rulebook,
         IReadOnlyList<PatchEdit> edits, string targetPath, string targetName, bool fullReadback = true,
-        bool dryRun = false)
+        bool dryRun = false, IReadOnlyDictionary<PatchEdit, IMajorRecordGetter>? copyFromSources = null)
+    {
+        string? epoch = null;
+        var outcome = ApplyInPlaceCore(resolver, rulebook, edits, targetPath, targetName, fullReadback, dryRun, copyFromSources, ref epoch);
+        return epoch is null ? outcome : outcome with { Epoch = epoch };
+    }
+
+    /// <summary>The body of <see cref="ApplyInPlace"/> — split for the same single-point epoch stamp as
+    /// <see cref="ApplyCore"/> (SPEC §2.1.1).</summary>
+    static PatchOutcome ApplyInPlaceCore(
+        LoadOrderResolver resolver, CorpusRulebook rulebook,
+        IReadOnlyList<PatchEdit> edits, string targetPath, string targetName, bool fullReadback,
+        bool dryRun, IReadOnlyDictionary<PatchEdit, IMajorRecordGetter>? copyFromSources, ref string? epoch)
     {
         if (edits.Count == 0) return PatchOutcome.Fail("no edits supplied.");
 
@@ -591,6 +671,7 @@ public static class WritePatchBuilder
         // --- Phase 1: resolve each edit's body FROM THE TARGET (not the winner) + derive type + pre-flight. The §4.1
         //     content-source guard. ONE captured view answers every edit (the hunt-F5 one-view discipline). ---
         var view = resolver.Capture();
+        epoch = view.Epoch;                                               // SPEC §2.1.1 — stamped on every outcome from here down
         if (!view.ContainsPlugin(targetName))
             return PatchOutcome.Fail($"in-place target '{targetName}' is not an active plugin in the load order.{view.AbsenceClause(targetName)}");
         if (view.ExcludedPlugins.TryGetValue(targetName, out var excluded))
@@ -598,7 +679,7 @@ public static class WritePatchBuilder
                 $"cannot edit '{targetName}' in place: it was EXCLUDED from this session ({excluded}) — houseCARL won't " +
                 "re-serialize a plugin it can't fully parse (that would risk dropping the record it couldn't read, Q3). The file is UNTOUCHED.");
 
-        var resolved = new List<(PatchEdit edit, IMajorRecordGetter body, WriteRequest req, string label)>(edits.Count);
+        var resolved = new List<(PatchEdit edit, IMajorRecordGetter body, WriteRequest req, string label, IMajorRecordGetter? srcBody)>(edits.Count);
         var problems = new List<string>();
         foreach (var e in edits)
         {
@@ -617,7 +698,34 @@ public static class WritePatchBuilder
             };
             var label = Label(req);
             if (rulebook.Validate(req) is { } reject) { problems.Add($"{recType} {e.Target} [{label}]: {reject}"); continue; }
-            resolved.Add((e, body, req, label));
+
+            // CopyFrom SOURCE resolution — the same contract Apply enforces, on this lane too (W3: the LANE axis is
+            // uniform, so every ACT verb must compose with in_place). Before this, a CopyFrom op reaching the in-place
+            // lane had NO source resolved and fell through to ApplyVerb, which has no CopyFrom branch — it surfaced as
+            // the "pre-flight ACCEPTED it but the apply threw" engine-inconsistency wrapper, i.e. a real capability gap
+            // reported as an internal fault (Q3). The source may be any plugin (the target itself is legitimate ONLY
+            // for a cross-record copy — copying a record's own field onto itself is a no-op, refused by name).
+            IMajorRecordGetter? srcBody = null;
+            if (string.Equals(e.Verb, "CopyFrom", StringComparison.Ordinal))
+            {
+                if (copyFromSources is not null && copyFromSources.TryGetValue(e, out var offSrc))
+                    srcBody = offSrc;
+                else if (string.IsNullOrWhiteSpace(e.FromPlugin))
+                { problems.Add($"{e.Target}: CopyFrom is missing from_plugin (internal — the mapper should have caught this)."); continue; }
+                else if (e.FromTarget is null && string.Equals(e.FromPlugin, targetName, StringComparison.OrdinalIgnoreCase))
+                { problems.Add($"{e.Target}: CopyFrom from_plugin '{e.FromPlugin}' is the in-place target itself — copying this record's own field onto itself is a no-op; name the OTHER plugin whose version to copy from."); continue; }
+                else if (!view.ContainsPlugin(e.FromPlugin))
+                { problems.Add($"{e.Target}: CopyFrom source '{e.FromPlugin}' is not in the load order (and no plugin file by that name was located on disk) — name an active plugin, or a plugin file present on disk."); continue; }
+                else if (view.ExcludedPlugins.TryGetValue(e.FromPlugin, out var cfWhy))
+                { problems.Add($"{e.Target}: CopyFrom source '{e.FromPlugin}' was excluded from this session ({cfWhy}) — its records aren't resolvable."); continue; }
+                else
+                {
+                    srcBody = view.GetRecord(session, e.FromPlugin, e.CopySource);
+                    if (srcBody is null) { problems.Add(CopySourceMissing(e)); continue; }
+                }
+                if (CrossTypeRefusal(e, srcBody, body) is { } typeErr) { problems.Add(typeErr); continue; }
+            }
+            resolved.Add((e, body, req, label, srcBody));
         }
         if (problems.Count > 0)
             return PatchOutcome.Fail(
@@ -646,13 +754,18 @@ public static class WritePatchBuilder
         //     never a foreign override's. A nested record gets the target overlay's link cache on demand (released in
         //     Phase 4). A throw after pre-flight passed is a real engine inconsistency — fail the WHOLE call (Q3). ---
         var ops = new List<OpResult>(resolved.Count);
-        foreach (var (e, body, req, label) in resolved)
+        foreach (var (e, body, req, label, srcBody) in resolved)
         {
             try
             {
                 ILinkCache? cache = WriteEngine.RecordNeedsSourceCache(body) ? session.LinkCacheFor(targetName) : null;
                 var ov = WriteEngine.GenericGetOrAddAsOverride(targetMod, body, cache);
-                WriteEngine.ApplyVerb(ov, req);
+                // CopyFrom transplants the field FROM the resolved source body into the target's own record; every
+                // other verb applies to it directly (the same two-branch shape Apply uses — one engine, two lanes).
+                if (string.Equals(req.Verb, "CopyFrom", StringComparison.Ordinal))
+                    WriteEngine.CopyField(srcBody!, ov, req.Path);
+                else
+                    WriteEngine.ApplyVerb(ov, req);
                 var (after, landed) = DescribeApplied(ov, req);
                 ops.Add(new OpResult(e.Target, req.RecordType, label, true, null, after, landed));
             }

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -409,27 +409,33 @@ public static class WritePatchBuilder
             IMajorRecordGetter? srcBody = null;
             if (string.Equals(e.Verb, "CopyFrom", StringComparison.Ordinal))
             {
+                // §4.5: with a source RECORD named, from_source is optional and DEFAULTS to that record's winner —
+                // resolved here, where the one captured view lives, so the default reads the same build every other
+                // decision in this call reads.
+                var srcPlugin = ResolveCopyPole(e, view, out var poleErr);
+                if (poleErr is not null) { problems.Add(poleErr); continue; }
+
                 if (copyFromSources is not null && copyFromSources.TryGetValue(e, out var offSrc))
                     srcBody = offSrc;
-                else if (string.IsNullOrWhiteSpace(e.FromPlugin))
+                else if (string.IsNullOrWhiteSpace(srcPlugin))
                 { problems.Add($"{e.Target}: CopyFrom is missing from_plugin (internal — the mapper should have caught this)."); continue; }
-                else if (string.Equals(e.FromPlugin, fileName, StringComparison.OrdinalIgnoreCase))
-                { problems.Add($"{e.Target}: CopyFrom from_plugin '{e.FromPlugin}' is the output patch itself — name the OTHER plugin whose version to copy from."); continue; }
-                else if (!view.ContainsPlugin(e.FromPlugin))
+                else if (string.Equals(srcPlugin, fileName, StringComparison.OrdinalIgnoreCase))
+                { problems.Add($"{e.Target}: CopyFrom from_plugin '{srcPlugin}' is the output patch itself — name the OTHER plugin whose version to copy from."); continue; }
+                else if (!view.ContainsPlugin(srcPlugin))
                 // Deliberately NO AbsenceClause here (review of PR #274): the service pre-resolves every off-order
                 // CopyFrom source before Apply — a source that is merely unticked / in a disabled mod / shadowed is
                 // LOCATED and supplied via copyFromSources above, and one that cannot be located aborts the whole call
                 // earlier. So the only name reaching this arm has no on-disk copy at all, which is exactly the case the
                 // explainer cannot explain — it would pay a profile parse plus a whole-install sweep, per edit, to
                 // return the did-you-mean the message would have got anyway. The sentence already says what is known.
-                { problems.Add($"{e.Target}: CopyFrom source '{e.FromPlugin}' is not in the load order (and no plugin file by that name was located on disk) — name an active plugin, or a plugin file present on disk."); continue; }
-                else if (view.ExcludedPlugins.TryGetValue(e.FromPlugin, out var why))
-                { problems.Add($"{e.Target}: CopyFrom source '{e.FromPlugin}' was excluded from this session ({why}) — its records aren't resolvable."); continue; }
+                { problems.Add($"{e.Target}: CopyFrom source '{srcPlugin}' is not in the load order (and no plugin file by that name was located on disk) — name an active plugin, or a plugin file present on disk."); continue; }
+                else if (view.ExcludedPlugins.TryGetValue(srcPlugin, out var why))
+                { problems.Add($"{e.Target}: CopyFrom source '{srcPlugin}' was excluded from this session ({why}) — its records aren't resolvable."); continue; }
                 else
                 {
-                    srcBody = view.GetRecord(session, e.FromPlugin, e.CopySource);
+                    srcBody = view.GetRecord(session, srcPlugin, e.CopySource);
                     if (srcBody is null)
-                    { problems.Add(CopySourceMissing(e)); continue; }
+                    { problems.Add(CopySourceMissing(e, srcPlugin)); continue; }
                 }
                 // §4.5 — the same-runtime-record-type gate. A same-FormKey copy passes by construction (one record,
                 // one type); the zip's CROSS-record pair is the case that can disagree, and a cross-type transplant
@@ -562,10 +568,32 @@ public static class WritePatchBuilder
     /// SAME-record copy names the target (the P8b sentence, unchanged); a §4.5 cross-record copy names the SOURCE
     /// record and the target it was being copied INTO, so the reader can tell WHICH of the two the source plugin is
     /// missing (Q3 — the ambiguous "this record" would point at the wrong one half the time).</summary>
-    static string CopySourceMissing(PatchEdit e) =>
+    static string CopySourceMissing(PatchEdit e, string srcPlugin) =>
         e.FromTarget is null
-            ? $"{e.Target}: CopyFrom source '{e.FromPlugin}' is in the load order but does NOT define or override this record — there is no version of it there to copy."
-            : $"{e.Target}: CopyFrom source '{e.FromPlugin}' is in the load order but does NOT define or override the SOURCE record {e.CopySource} — there is no version of it there to copy from.";
+            ? $"{e.Target}: CopyFrom source '{srcPlugin}' is in the load order but does NOT define or override this record — there is no version of it there to copy."
+            : $"{e.Target}: CopyFrom source '{srcPlugin}' is in the load order but does NOT define or override the SOURCE record {e.CopySource} — there is no version of it there to copy from.";
+
+    /// <summary>Resolve the PLUGIN a CopyFrom reads its source body from. Named <c>from_source</c> wins; when it is
+    /// absent AND a source RECORD is named (the §4.5 zip's <c>from</c>), it defaults to that record's load-order
+    /// WINNER — the §4.5 wording ("<c>from_source</c> … defaulting to winner"), resolved against the call's ONE
+    /// captured build so the default can't read a different order than the rest of the write. Returns null with a
+    /// null error when there is nothing to resolve (a non-CopyFrom op, or the off-order arm the service pre-located);
+    /// a source record absent from the whole order is a named refusal, never a silent skip.</summary>
+    static string? ResolveCopyPole(PatchEdit e, LoadOrderResolver.IndexView view, out string? error)
+    {
+        error = null;
+        if (!string.IsNullOrWhiteSpace(e.FromPlugin)) return e.FromPlugin;
+        if (e.FromTarget is null) return null;                     // same-record copy with no pole — the caller's mapper already refused it
+        var w = view.ResolveWinner(e.CopySource);
+        if (w is null)
+        {
+            error = $"{e.Target}: the source record {e.CopySource} is not present in the load order ({view.PluginCount} plugins), " +
+                    "so there is no winning version of it to copy from. Enable the plugin that defines it, or name a specific " +
+                    "plugin in from_source.";
+            return null;
+        }
+        return w.Value.WinnerPlugin;
+    }
 
     /// <summary>SPEC §4.5's same-runtime-record-type gate for a CROSS-record copy. Returns a named refusal when the
     /// source and target records are different runtime types, else null. A same-FormKey copy (<see
@@ -708,20 +736,23 @@ public static class WritePatchBuilder
             IMajorRecordGetter? srcBody = null;
             if (string.Equals(e.Verb, "CopyFrom", StringComparison.Ordinal))
             {
+                var srcPlugin = ResolveCopyPole(e, view, out var poleErr);
+                if (poleErr is not null) { problems.Add(poleErr); continue; }
+
                 if (copyFromSources is not null && copyFromSources.TryGetValue(e, out var offSrc))
                     srcBody = offSrc;
-                else if (string.IsNullOrWhiteSpace(e.FromPlugin))
+                else if (string.IsNullOrWhiteSpace(srcPlugin))
                 { problems.Add($"{e.Target}: CopyFrom is missing from_plugin (internal — the mapper should have caught this)."); continue; }
-                else if (e.FromTarget is null && string.Equals(e.FromPlugin, targetName, StringComparison.OrdinalIgnoreCase))
-                { problems.Add($"{e.Target}: CopyFrom from_plugin '{e.FromPlugin}' is the in-place target itself — copying this record's own field onto itself is a no-op; name the OTHER plugin whose version to copy from."); continue; }
-                else if (!view.ContainsPlugin(e.FromPlugin))
-                { problems.Add($"{e.Target}: CopyFrom source '{e.FromPlugin}' is not in the load order (and no plugin file by that name was located on disk) — name an active plugin, or a plugin file present on disk."); continue; }
-                else if (view.ExcludedPlugins.TryGetValue(e.FromPlugin, out var cfWhy))
-                { problems.Add($"{e.Target}: CopyFrom source '{e.FromPlugin}' was excluded from this session ({cfWhy}) — its records aren't resolvable."); continue; }
+                else if (e.FromTarget is null && string.Equals(srcPlugin, targetName, StringComparison.OrdinalIgnoreCase))
+                { problems.Add($"{e.Target}: CopyFrom from_plugin '{srcPlugin}' is the in-place target itself — copying this record's own field onto itself is a no-op; name the OTHER plugin whose version to copy from."); continue; }
+                else if (!view.ContainsPlugin(srcPlugin))
+                { problems.Add($"{e.Target}: CopyFrom source '{srcPlugin}' is not in the load order (and no plugin file by that name was located on disk) — name an active plugin, or a plugin file present on disk."); continue; }
+                else if (view.ExcludedPlugins.TryGetValue(srcPlugin, out var cfWhy))
+                { problems.Add($"{e.Target}: CopyFrom source '{srcPlugin}' was excluded from this session ({cfWhy}) — its records aren't resolvable."); continue; }
                 else
                 {
-                    srcBody = view.GetRecord(session, e.FromPlugin, e.CopySource);
-                    if (srcBody is null) { problems.Add(CopySourceMissing(e)); continue; }
+                    srcBody = view.GetRecord(session, srcPlugin, e.CopySource);
+                    if (srcBody is null) { problems.Add(CopySourceMissing(e, srcPlugin)); continue; }
                 }
                 if (CrossTypeRefusal(e, srcBody, body) is { } typeErr) { problems.Add(typeErr); continue; }
             }

--- a/src/housecarl-core/WritePatchBuilder.cs
+++ b/src/housecarl-core/WritePatchBuilder.cs
@@ -794,6 +794,41 @@ public static class WritePatchBuilder
         //     (already present in targetMod) returns THAT record (get-semantics) — the verb edits the file's own body,
         //     never a foreign override's. A nested record gets the target overlay's link cache on demand (released in
         //     Phase 4). A throw after pre-flight passed is a real engine inconsistency — fail the WHOLE call (Q3). ---
+        // --- Phase 2b: SNAPSHOT every same-file copy source, BEFORE any op mutates anything (re-review [high] +
+        //     [medium] + [low], one fix). A source living in the file being rewritten cannot be read from the live
+        //     mutable record for three reasons:
+        //       • ALIASING — CopyElement shares an element when the target's element type already accepts it. That
+        //         is safe for an overlay source (an EffectBinaryOverlay is not an Effect, so it deep-copies), but a
+        //         source out of targetMod IS the settable concrete type, so the two records would share the very
+        //         same element objects: editing the target's copy would silently edit the SOURCE too.
+        //       • ORDERING — targetMod is what the ops are mutating as they run, so a later op would read a source
+        //         an earlier op had already overwritten. Every other copy shape reads pre-call state; a swap
+        //         (A←B, B←A) must not depend on op order on one lane and not the other.
+        //       • COST — a per-op EnumerateMajorRecords() is O(records × ops) inside the write gate. One pass here.
+        //     ONE snapshot PER OP, not per FormKey: two ops copying one source onto two targets would otherwise
+        //     share that snapshot's elements and alias the two TARGETS to each other instead.
+        Dictionary<PatchEdit, IMajorRecordGetter>? selfSnapshots = null;
+        if (resolved.Any(r => r.selfSource))
+        {
+            var byKey = new Dictionary<FormKey, IMajorRecordGetter>();
+            foreach (var rec in targetMod.EnumerateMajorRecords()) byKey.TryAdd(rec.FormKey, rec);
+            selfSnapshots = new Dictionary<PatchEdit, IMajorRecordGetter>();
+            foreach (var r in resolved)
+            {
+                if (!r.selfSource) continue;
+                if (!byKey.TryGetValue(r.edit.CopySource, out var live))
+                    return PatchOutcome.Fail(
+                        $"refused: the copy source {r.edit.CopySource} resolved in '{fileName}' at pre-flight but is not " +
+                        "present in the opened file (a real inconsistency, surfaced not swallowed — Q3). The file is UNTOUCHED.");
+                if (WriteEngine.TryDeepCopyRecord(live) is not { } snap)
+                    return PatchOutcome.Fail(
+                        $"refused: cannot copy from {r.edit.CopySource} inside '{fileName}' — Mutagen models no deep copy for " +
+                        $"{RecordNaming.StripOverlay(live.GetType().Name)}, and copying from the live record would alias the two " +
+                        "records' data. Copy from another plugin's version instead. The file is UNTOUCHED.");
+                selfSnapshots[r.edit] = snap;
+            }
+        }
+
         var ops = new List<OpResult>(resolved.Count);
         foreach (var (e, body, req, label, srcBody, selfSource) in resolved)
         {
@@ -804,22 +839,9 @@ public static class WritePatchBuilder
                 // CopyFrom transplants the field FROM the resolved source body into the target's own record; every
                 // other verb applies to it directly (the same two-branch shape Apply uses — one engine, two lanes).
                 if (string.Equals(req.Verb, "CopyFrom", StringComparison.Ordinal))
-                {
-                    // A source in the TARGET's own file is re-read from the MUTABLE targetMod, never the session
-                    // overlay Phase 4 releases — see the lifetime note in Phase 1. targetMod outlives the serialize,
-                    // so the by-reference immutables CopyField shares stay valid through it.
-                    var copyFrom = srcBody;
-                    if (selfSource)
-                    {
-                        copyFrom = targetMod.EnumerateMajorRecords().FirstOrDefault(r => r.FormKey == e.CopySource);
-                        if (copyFrom is null)
-                            return PatchOutcome.Fail(
-                                $"refused applying [{label}] to {req.RecordType} {e.Target} — the copy source {e.CopySource} " +
-                                $"resolved in '{fileName}' at pre-flight but is not present in the opened file (a real " +
-                                $"inconsistency, surfaced not swallowed — Q3). The file is untouched.");
-                    }
-                    WriteEngine.CopyField(copyFrom!, ov, req.Path);
-                }
+                    WriteEngine.CopyField(
+                        selfSource ? selfSnapshots![e] : srcBody!,   // the pre-mutation private snapshot, never the live record
+                        ov, req.Path);
                 else
                     WriteEngine.ApplyVerb(ov, req);
                 var (after, landed) = DescribeApplied(ov, req);

--- a/src/housecarl-generator/ApplyGuardProbe.cs
+++ b/src/housecarl-generator/ApplyGuardProbe.cs
@@ -85,6 +85,11 @@ public static class ApplyGuardProbe
         public required string ArmorFid { get; init; }        // a different record TYPE — the cross-type refusal source
         public required string ModsDir { get; init; }
         public required string ReplacerPath { get; init; }   // the in-place target's real on-disk file
+        public required FormKey DonorKey { get; init; }
+        public required string PotionAFid { get; init; }     // same-file COPY SOURCE for the aliasing arm
+        public required string PotionBFid { get; init; }     // its target
+        public required FormKey PotionAKey { get; init; }
+        public required FormKey PotionBKey { get; init; }
         public required string MasterName { get; init; }
         public required string ReplacerName { get; init; }
         public required FormKey SubjectKey { get; init; }
@@ -125,6 +130,17 @@ public static class ApplyGuardProbe
             donor.Keywords = new Noggog.ExtendedList<IFormLinkGetter<IKeywordGetter>>
                 { new FormLink<IKeywordGetter>(k1.FormKey), new FormLink<IKeywordGetter>(k2.FormKey) };
 
+            // Two potions with modeled Effects lists — the aliasing arm copies A's Effects onto B, then edits B's
+            // copy; a shared element would show up as A changing too. Both are overridden by the replacer below so
+            // the in-place lane (which edits only what the file OWNS) can touch them.
+            var mg = m.MagicEffects.AddNew(); mg.EditorID = "ApMgef";
+            var potA = m.Ingestibles.AddNew(); potA.EditorID = "ApPotionA";
+            var eA = new Effect { Data = new EffectData { Magnitude = 5 } }; eA.BaseEffect.SetTo(mg.FormKey);
+            potA.Effects.Add(eA);
+            var potB = m.Ingestibles.AddNew(); potB.EditorID = "ApPotionB";
+            var eB = new Effect { Data = new EffectData { Magnitude = 1 } }; eB.BaseEffect.SetTo(mg.FormKey);
+            potB.Effects.Add(eB);
+
             var armor = m.Armors.AddNew();
             armor.EditorID = "ApArmor";
             armor.Name = "Some Cuirass";
@@ -144,6 +160,8 @@ public static class ApplyGuardProbe
             // named from_source, or defaulted to the wrong plugin, would leave both arms green. 7 vs 42 separates them.
             var rd = (IWeapon)WriteEngine.GenericGetOrAddAsOverride(r, donor);
             rd.BasicStats = new WeaponBasicStats { Damage = 7 };   // keywords carry over from the master (still 2)
+            WriteEngine.GenericGetOrAddAsOverride(r, potA);        // the replacer OWNS both potions, so in-place may edit them
+            WriteEngine.GenericGetOrAddAsOverride(r, potB);
             r.BeginWrite.ToPath(replPath).WithLoadOrder(new ISkyrimModGetter[] { m }).Write();
 
             File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + mKey.FileName + "\r\n" + rKey.FileName + "\r\n");
@@ -166,6 +184,11 @@ public static class ApplyGuardProbe
                 ArmorFid = $"{armor.FormKey.ID:X6}:{mKey.FileName}",
                 ModsDir = mods,
                 ReplacerPath = replPath,
+                DonorKey = donor.FormKey,
+                PotionAFid = $"{potA.FormKey.ID:X6}:{mKey.FileName}",
+                PotionBFid = $"{potB.FormKey.ID:X6}:{mKey.FileName}",
+                PotionAKey = potA.FormKey,
+                PotionBKey = potB.FormKey,
                 MasterName = mKey.FileName.String,
                 ReplacerName = rKey.FileName.String,
                 SubjectKey = subject.FormKey,
@@ -437,6 +460,52 @@ public static class ApplyGuardProbe
         var landed = ReadSubject(fx.ReplacerPath, fx.SubjectKey);
         Check($"...and the copied value actually landed intact in the rewritten file (Damage 7, got {landed.Dmg})",
             landed.Dmg == 7, sameFile);
+
+        // RE-REVIEW FOLD [high] — ALIASING. A same-file copy of a modeled LIST, then an edit to the target's copy.
+        // CopyElement shares an element the target's type already accepts; with a live source out of targetMod the
+        // two records would share the very same Effect object, so op 2 would silently mutate the SOURCE as well.
+        // The source is snapshotted, so it must be untouched. (Both potions are the replacer's own records.)
+        var alias = ApplyTools.Apply(fx.Svc,
+            ops: Json($$"""[{"formid":"{{fx.PotionBFid}}","field_path":"Effects","op":"CopyFrom","from":"{{fx.PotionAFid}}","from_source":"{{fx.ReplacerName}}"}, {"formid":"{{fx.PotionBFid}}","field_path":"Effects[0].Data.Magnitude","value":"99"}]"""),
+            in_place: fx.ReplacerName, acknowledge: true);
+        Check("a same-file LIST copy followed by an edit to the target's copy completes", alias.StartsWith("edited "), alias);
+        var (magA, magB) = ReadPotionMagnitudes(fx);
+        Check($"...the TARGET took the edit (B magnitude 99, got {magB})", magB == 99, alias);
+        Check($"...and the SOURCE record is UNTOUCHED — no shared element aliasing (A magnitude still 5, got {magA})",
+            magA == 5, alias);
+
+        // RE-REVIEW FOLD [medium] — ORDERING. A swap on one file: each op must read PRE-CALL state, exactly as the
+        // patch lane does. Reading the live mutable mod would leave both records holding the same value.
+        // Seed both sides to known, distinct values first so the exchange is unambiguous.
+        ApplyTools.Apply(fx.Svc,
+            ops: Json($$"""[{"formid":"{{fx.SubjectFid}}","field_path":"BasicStats.Damage","value":"111"}, {"formid":"{{fx.DonorWeaponFid}}","field_path":"BasicStats.Damage","value":"222"}]"""),
+            in_place: fx.ReplacerName, acknowledge: true);
+        var swap = ApplyTools.Apply(fx.Svc,
+            bundle: new[] { "BasicStats.Damage" },
+            assignments: Json($$"""[{"target":"{{fx.SubjectFid}}","from":"{{fx.DonorWeaponFid}}","from_source":"{{fx.ReplacerName}}"}, {"target":"{{fx.DonorWeaponFid}}","from":"{{fx.SubjectFid}}","from_source":"{{fx.ReplacerName}}"}]"""),
+            in_place: fx.ReplacerName, acknowledge: true);
+        Check("an A<->B swap on ONE file completes", swap.StartsWith("edited "), swap);
+        var subjAfter = ReadSubject(fx.ReplacerPath, fx.SubjectKey).Dmg;
+        var donorAfter = ReadSubject(fx.ReplacerPath, fx.DonorKey).Dmg;
+        // Seeded 111 / 222 → a correct swap yields 222 / 111. Reading mid-call state yields 222 / 222 (the first
+        // op overwrites the subject, the second then reads the already-overwritten value back onto the donor).
+        Check($"...and each record took the OTHER's PRE-CALL value, not a mid-call one (subject={subjAfter} expect 222, donor={donorAfter} expect 111)",
+            subjAfter == 222 && donorAfter == 111, swap);
+    }
+
+    /// <summary>The two potions' first-effect magnitudes, read off the rewritten in-place file.</summary>
+    static (ushort? A, ushort? B) ReadPotionMagnitudes(Fixture fx)
+    {
+        ISkyrimModGetter? ov = null;
+        try
+        {
+            ov = SkyrimMod.CreateFromBinaryOverlay(fx.ReplacerPath, SkyrimRelease.SkyrimSE);
+            ushort? Mag(FormKey fk) => (ushort?)ov.Ingestibles.FirstOrDefault(x => x.FormKey == fk)?
+                .Effects.FirstOrDefault()?.Data?.Magnitude;
+            return (Mag(fx.PotionAKey), Mag(fx.PotionBKey));
+        }
+        catch { return (null, null); }
+        finally { (ov as IDisposable)?.Dispose(); }
     }
 
     // ================= ARM 5 — TRANSPORT =================

--- a/src/housecarl-generator/ApplyGuardProbe.cs
+++ b/src/housecarl-generator/ApplyGuardProbe.cs
@@ -315,6 +315,21 @@ public static class ApplyGuardProbe
         Check("an undeclared member NESTED in compose.sets[0] is refused BY NAME (Disallow reaches the recursion)",
             deepStray.StartsWith("error:") && deepStray.Contains("nosuchmember"), deepStray);
 
+        // ROUND-5 FOLD [low] — the vocabulary hint is gated on the DECLARING TYPE, not the member name alone.
+        // The same word is a different mistake per shape, so a name-only match answers one caller with another
+        // caller's correction. `op` is the sharp case: legal on an op, wrong two different ways elsewhere.
+        var opInNested = ApplyTools.Apply(fx.Svc, ops: Json(
+            $$"""[{"formid":"{{fx.PotionAFid}}","field_path":"Effects","op":"Add","compose":""" +
+            """{"type":"Effect","sets":[{"path":"Data.Magnitude","op":"Set","value":"1"}]}}]"""));
+        Check("a stray `op` in a NESTED SET is corrected toward verb (the nested shape's own word)",
+            opInNested.StartsWith("error:") && opInNested.Contains("still spells its verb"), opInNested);
+
+        var opInAssignment = ApplyTools.Apply(fx.Svc, bundle: new[] { "Name" },
+            assignments: Json($$"""[{"target":"{{fx.SubjectFid}}","from":"{{fx.DonorWeaponFid}}","op":"CopyFrom"}]"""));
+        Check("...while the SAME stray in an ASSIGNMENT gets the assignment's own correction, not a compose= lecture",
+            opInAssignment.StartsWith("error:") && opInAssignment.Contains("carries no verb")
+                && !opInAssignment.Contains("compose="), opInAssignment);
+
         // values= / entries= — the other two payload members, likewise unexercised until now
         var valuesOp = ApplyTools.Apply(fx.Svc,
             ops: Json($$"""[{"formid":"{{fx.SubjectFid}}","field_path":"Keywords","op":"ReplaceAll","values":["{{fx.KeywordFid}}"]}]"""),
@@ -663,8 +678,13 @@ public static class ApplyGuardProbe
 
         // ...and the same emptiness rule governs a lane string, so the exclusivity check and what gets written
         // cannot disagree about whether patch= was named.
+        // Asserted POSITIVELY (round-5 nit): the earlier form only checked that the exclusivity refusal was
+        // ABSENT, which would stay green if the whole LANE block were deleted. A blank patch= must not merely
+        // fail to trip exclusivity — the call must actually TAKE the into= lane, which this proves by landing on
+        // into='s own "no such patch to extend" refusal.
         var blankPatch = ApplyTools.Apply(fx.Svc, ops: Json(OneOp("72")), patch: "   ", into: "NoSuchPatch.esp");
-        Check("a whitespace-only patch= counts as ABSENT for exclusivity, exactly as it does for the write",
-            !blankPatch.Contains("the two lanes are exclusive"), blankPatch);
+        Check("a whitespace-only patch= counts as ABSENT and the call TAKES the into= lane (its own refusal, not the exclusivity one)",
+            blankPatch.StartsWith("error:") && !blankPatch.Contains("the two lanes are exclusive")
+                && blankPatch.Contains("NoSuchPatch.esp"), blankPatch);
     }
 }

--- a/src/housecarl-generator/ApplyGuardProbe.cs
+++ b/src/housecarl-generator/ApplyGuardProbe.cs
@@ -52,13 +52,16 @@ public static class ApplyGuardProbe
         Directory.CreateDirectory(root);
         try
         {
-            var fx = Fixture.Build(Path.Combine(root, "fx"));
+            // `using`, not a trailing Dispose(): an arm that throws lands in the catch below, and a bare
+            // Dispose() call there would be skipped — leaving the LoadOrderService and its plugin overlays
+            // OPEN, which then makes the finally's Directory.Delete fail silently. Inside ci-all (one process,
+            // many probes) that is a leaked service plus file handles for every failing run.
+            using var fx = Fixture.Build(Path.Combine(root, "fx"));
             OpsGrammarArm(fx, root);
             LaneArm(fx);
             ZipArm(fx);
             InPlaceCopyArm(fx);
             TransportArm(fx);
-            fx.Dispose();
 
             Console.WriteLine();
             Console.WriteLine($"=== apply-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
@@ -86,6 +89,7 @@ public static class ApplyGuardProbe
         public required string ModsDir { get; init; }
         public required string ReplacerPath { get; init; }   // the in-place target's real on-disk file
         public required FormKey DonorKey { get; init; }
+        public required string KeywordFid { get; init; }     // a resolvable link value for values=/Add arms
         public required string PotionAFid { get; init; }     // same-file COPY SOURCE for the aliasing arm
         public required string PotionBFid { get; init; }     // its target
         public required FormKey PotionAKey { get; init; }
@@ -185,6 +189,7 @@ public static class ApplyGuardProbe
                 ModsDir = mods,
                 ReplacerPath = replPath,
                 DonorKey = donor.FormKey,
+                KeywordFid = $"{k1.FormKey.ID:X6}:{mKey.FileName}",
                 PotionAFid = $"{potA.FormKey.ID:X6}:{mKey.FileName}",
                 PotionBFid = $"{potB.FormKey.ID:X6}:{mKey.FileName}",
                 PotionAKey = potA.FormKey,
@@ -277,6 +282,59 @@ public static class ApplyGuardProbe
         var badPath = ApplyTools.Apply(fx.Svc, ops: Json($$"""[{"formid":"{{fx.SubjectFid}}","field_path":"NoSuchField","value":"1"}]"""), patch: "ApBad");
         Check("a bad field path refuses the whole call with nothing written (all-or-nothing preserved)",
             badPath.StartsWith("error:"), badPath);
+
+        // ROUND-4 FOLD [medium] — the COMPOSED payloads through the NEW strict reader. ReadListParam is a
+        // brand-new deserialization path replacing BOTH the SDK binder (1.x inline) and the old from_file=
+        // reader, and UnmappedMemberHandling.Disallow applies RECURSIVELY down StructInput -> NestedSet ->
+        // StructInput. Nothing above sends one, so the recursive shape was schema-pinned but never executed —
+        // and migrating a bulk_apply payload onto apply is exactly what the CHANGELOG instructs.
+        // composes= + ReplaceAll over a modeled list, with a NESTED compose arm inside sets[] (a Condition's
+        // polymorphic Data), inline:
+        string composeOps =
+            $$"""[{"formid":"{{fx.PotionAFid}}","field_path":"Effects","op":"ReplaceAll","composes":[""" +
+            """{"type":"Effect","sets":[{"path":"Data.Magnitude","value":"11"}]},""" +
+            """{"type":"Effect","sets":[{"path":"Data.Magnitude","value":"22"}]},""" +
+            """{"type":"Effect","sets":[{"path":"Data.Magnitude","value":"33"}]}]}]""";
+        var composed = ApplyTools.Apply(fx.Svc, ops: Json(composeOps), patch: "ApCompose");
+        var composedPath = PatchPathFrom(fx, composed);
+        Check("composes= + ReplaceAll builds a modeled list through the new strict reader (StructInput -> NestedSet recursion)",
+            composedPath is not null && CountEffects(composedPath, fx.PotionAKey) == 3, composed);
+
+        // the SAME payload via @file — the two lanes share one reader, so the file lane must accept it identically
+        var composeManifest = Path.Combine(root, "compose-ops.json");
+        File.WriteAllText(composeManifest, composeOps);
+        var composedFile = ApplyTools.Apply(fx.Svc, ops: Json($"\"@{composeManifest.Replace("\\", "\\\\")}\""), patch: "ApComposeFile");
+        var composedFilePath = PatchPathFrom(fx, composedFile);
+        Check("...and the IDENTICAL composed payload via ops=\"@<path>\" (ONE reader, both lanes)",
+            composedFilePath is not null && CountEffects(composedFilePath, fx.PotionAKey) == 3, composedFile);
+
+        // an undeclared member DEEP inside the recursion (compose.sets[0]) must refuse by name, not be dropped
+        var deepStray = ApplyTools.Apply(fx.Svc, ops: Json(
+            $$"""[{"formid":"{{fx.PotionAFid}}","field_path":"Effects","op":"Add","compose":""" +
+            """{"type":"Effect","sets":[{"path":"Data.Magnitude","value":"1","nosuchmember":"x"}]}}]"""));
+        Check("an undeclared member NESTED in compose.sets[0] is refused BY NAME (Disallow reaches the recursion)",
+            deepStray.StartsWith("error:") && deepStray.Contains("nosuchmember"), deepStray);
+
+        // values= / entries= — the other two payload members, likewise unexercised until now
+        var valuesOp = ApplyTools.Apply(fx.Svc,
+            ops: Json($$"""[{"formid":"{{fx.SubjectFid}}","field_path":"Keywords","op":"ReplaceAll","values":["{{fx.KeywordFid}}"]}]"""),
+            patch: "ApValues");
+        var valuesPath = PatchPathFrom(fx, valuesOp);
+        Check("values= drives a list ReplaceAll through the new reader",
+            valuesPath is not null && ReadSubject(valuesPath, fx.SubjectKey).Kw == 1, valuesOp);
+    }
+
+    /// <summary>Effect count on a potion, off a written patch.</summary>
+    static int? CountEffects(string espPath, FormKey fk)
+    {
+        ISkyrimModGetter? ov = null;
+        try
+        {
+            ov = SkyrimMod.CreateFromBinaryOverlay(espPath, SkyrimRelease.SkyrimSE);
+            return ov.Ingestibles.FirstOrDefault(x => x.FormKey == fk)?.Effects?.Count;
+        }
+        catch { return null; }
+        finally { (ov as IDisposable)?.Dispose(); }
     }
 
     // ================= ARM 2 — the LANE grammar =================
@@ -327,7 +385,7 @@ public static class ApplyGuardProbe
     // ================= ARM 3 — the §4.5 zip =================
     static void ZipArm(Fixture fx)
     {
-        Console.WriteLine("── ARM 4.5: the zip — bundle x assignments as a cross-RECORD copy ──");
+        Console.WriteLine("── ARM 3: the §4.5 zip — bundle x assignments as a cross-RECORD copy ──");
 
         // the load-bearing case: copy a DIFFERENT record's fields onto the subject. The subject's winner has
         // Damage 99 and no keywords; the donor's WINNER (the replacer's override) has Damage 7 and two keywords,
@@ -580,5 +638,33 @@ public static class ApplyGuardProbe
         var badFormat = ApplyTools.Apply(fx.Svc, ops: Json(OneOp("64")), format: "yaml");
         Check("an unrecognized format= is refused by name, never a silent fall-through to text",
             badFormat.StartsWith("error:") && badFormat.Contains("format="), badFormat);
+
+        // ROUND-4 FOLD [low] — a json caller must never parse "error: …" out of a string, and the sites hit most
+        // are the PRE-ENGINE ones (no outcome exists yet to render). Every refusal after format= is parsed now
+        // answers in the requested format; format= itself cannot, since its value is what failed to parse.
+        foreach (var (label, call) in new (string, string)[]
+        {
+            ("a LANE conflict", ApplyTools.Apply(fx.Svc, ops: Json(OneOp("70")), patch: "X", into: "Y.esp", format: "json")),
+            ("an undeclared op member", ApplyTools.Apply(fx.Svc, ops: Json($$"""[{"formid":"{{fx.SubjectFid}}","field_path":"Name","verb":"Set","value":"x"}]"""), format: "json")),
+            ("half a zip", ApplyTools.Apply(fx.Svc, bundle: new[] { "Name" }, format: "json")),
+            ("nothing to apply", ApplyTools.Apply(fx.Svc, format: "json")),
+        })
+        {
+            bool isDocument = false;
+            try { isDocument = Json(call).TryGetProperty("error", out _); } catch { }
+            Check($"a PRE-ENGINE refusal answers in json when asked — {label}", isDocument, call);
+        }
+
+        // ROUND-4 FOLD [low] — an explicitly EMPTY bundle= is a supplied parameter, not an absent one. Reading it
+        // as absent is the accepted-and-silently-dropped class; ops=[] already refused by name, so the two agree.
+        var emptyBundle = ApplyTools.Apply(fx.Svc, ops: Json(OneOp("71")), bundle: Array.Empty<string>(), patch: "ApEmptyBundle");
+        Check("an EMPTY bundle= is refused by name, not silently dropped (parity with ops=[])",
+            emptyBundle.StartsWith("error:") && emptyBundle.Contains("bundle="), emptyBundle);
+
+        // ...and the same emptiness rule governs a lane string, so the exclusivity check and what gets written
+        // cannot disagree about whether patch= was named.
+        var blankPatch = ApplyTools.Apply(fx.Svc, ops: Json(OneOp("72")), patch: "   ", into: "NoSuchPatch.esp");
+        Check("a whitespace-only patch= counts as ABSENT for exclusivity, exactly as it does for the write",
+            !blankPatch.Contains("the two lanes are exclusive"), blankPatch);
     }
 }

--- a/src/housecarl-generator/ApplyGuardProbe.cs
+++ b/src/housecarl-generator/ApplyGuardProbe.cs
@@ -1,0 +1,443 @@
+using System.Text.Json;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using HousecarlCore;
+using HousecarlMcp;
+
+namespace HousecarlGenerator;
+
+/// <summary>
+/// REGRESSION GUARD (standing CI instrument, self-contained) for <c>housecarl_apply</c> — the 2.0 S1 field-write
+/// surface (tool-surface-2.0 W3; SPEC §2.2 ACT, §4.5, §5.1/§5.2, §6.1).
+///
+/// Drives the REAL end-to-end tool path — a synthetic MO2 instance in temp + <see cref="LoadOrderService"/> +
+/// <see cref="ApplyTools.Apply"/> — so the wire reader, the LANE grammar, the alias-visible vocabulary, the corpus
+/// pre-flight and the apply engine are exercised exactly as a caller hits them. Five arms:
+/// <list type="number">
+/// <item><b>ops grammar</b> — the 2.0 vocabulary (op=, one op is a set of one), the @file spelling that retired
+/// from_file=, and the strict element reader's NAMED refusals (undeclared member, mixed inline/@file).</item>
+/// <item><b>LANE</b> — the three destinations are exclusive and a dropped one is refused BY NAME (the class 1.x
+/// silently ignored), in_place is the FILE'S NAME with its consent handshake, into= extends.</item>
+/// <item><b>the §4.5 zip</b> — bundle × assignments as a cross-RECORD copy: a real transplant, the winner default
+/// for from_source, composition with ops=, and every malformed-pair refusal (missing half, self-pair, cross-type).</item>
+/// <item><b>in-place CopyFrom</b> — the capability the lane never had (it died as an engine-inconsistency wrapper).</item>
+/// <item><b>TRANSPORT</b> — format=json is valid JSON carrying the same data, refusals are documents too, and every
+/// response (both renders) carries the §2.1.1 epoch.</item>
+/// </list>
+///
+/// Run: <c>dotnet run --project src/housecarl-generator apply-guard</c>
+/// </summary>
+public static class ApplyGuardProbe
+{
+    static int _pass, _fail;
+    static void Check(string label, bool ok, string? got = null)
+    {
+        Console.WriteLine($"   [{(ok ? "PASS" : "FAIL")}] {label}");
+        if (!ok && got is not null) Console.WriteLine($"          got: {Trim(got)}");
+        if (ok) _pass++; else _fail++;
+    }
+    static string Trim(string s) => s.Length <= 400 ? s.Replace("\n", " | ") : s[..400].Replace("\n", " | ") + " …";
+
+    static JsonElement Json(string raw) => JsonDocument.Parse(raw).RootElement.Clone();
+
+    public static int RunGuard(string[] args)
+    {
+        _pass = _fail = 0;
+        Console.WriteLine("################  REGRESSION GUARD — housecarl_apply (the 2.0 S1 write surface)  ################");
+        Console.WriteLine();
+
+        var root = Path.Combine(Path.GetTempPath(), "hc_apply_guard_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            var fx = Fixture.Build(Path.Combine(root, "fx"));
+            OpsGrammarArm(fx, root);
+            LaneArm(fx);
+            ZipArm(fx);
+            InPlaceCopyArm(fx);
+            TransportArm(fx);
+            fx.Dispose();
+
+            Console.WriteLine();
+            Console.WriteLine($"=== apply-guard: {_pass} passed, {_fail} failed -> {(_fail == 0 ? "PASS" : "FAIL")} ===");
+            return _fail == 0 ? 0 : 1;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"   FAIL (unexpected): {ex.GetType().Name}: {ex.Message}\n{ex.StackTrace}");
+            return 1;
+        }
+        finally { try { Directory.Delete(root, recursive: true); } catch { } }
+    }
+
+    // ================= the shared synthetic order =================
+
+    /// <summary>Master + replacer + an OFF-ORDER donor. The replacer WINS the subject weapon (so a copy from the
+    /// master genuinely changes a value, and a winner-default source is distinguishable from a named one); a second
+    /// weapon is the zip's cross-record SOURCE; an armor is the cross-TYPE refusal's source.</summary>
+    sealed class Fixture : IDisposable
+    {
+        public required LoadOrderService Svc { get; init; }
+        public required string SubjectFid { get; init; }      // the weapon the replacer wins (Damage 99, no keywords)
+        public required string DonorWeaponFid { get; init; }  // a DIFFERENT weapon (Damage 42, 2 keywords) — the zip source
+        public required string ArmorFid { get; init; }        // a different record TYPE — the cross-type refusal source
+        public required string ModsDir { get; init; }
+        public required string MasterName { get; init; }
+        public required string ReplacerName { get; init; }
+        public required FormKey SubjectKey { get; init; }
+
+        public void Dispose() => Svc.Dispose();
+
+        public static Fixture Build(string dir)
+        {
+            string instance = Path.Combine(dir, "instance");
+            string profiles = Path.Combine(instance, "profiles", "Default");
+            string mods = Path.Combine(instance, "mods");
+            Directory.CreateDirectory(profiles); Directory.CreateDirectory(mods);
+            Directory.CreateDirectory(Path.Combine(dir, "game", "Data"));
+            File.WriteAllText(Path.Combine(instance, "ModOrganizer.ini"),
+                "[General]\r\ngameName=Skyrim Special Edition\r\nselected_profile=@ByteArray(Default)\r\ngamePath=@ByteArray("
+                + Path.Combine(dir, "game").Replace(@"\", @"\\") + ")\r\n");
+
+            var mKey = new ModKey("HcApplyMaster", ModType.Master);
+            var rKey = new ModKey("HcApplyRepl", ModType.Plugin);
+            var masterPath = Path.Combine(mods, "ApplyMaster", mKey.FileName.String);
+            var replPath = Path.Combine(mods, "ApplyRepl", rKey.FileName.String);
+            Directory.CreateDirectory(Path.GetDirectoryName(masterPath)!);
+            Directory.CreateDirectory(Path.GetDirectoryName(replPath)!);
+
+            var m = new SkyrimMod(mKey, SkyrimRelease.SkyrimSE);
+            var k1 = m.Keywords.AddNew(); k1.EditorID = "ApKw1";
+            var k2 = m.Keywords.AddNew(); k2.EditorID = "ApKw2";
+
+            var subject = m.Weapons.AddNew();
+            subject.EditorID = "ApSubject";
+            subject.Name = "Master Sword";
+            subject.BasicStats = new WeaponBasicStats { Damage = 10 };
+
+            var donor = m.Weapons.AddNew();
+            donor.EditorID = "ApDonor";
+            donor.Name = "Donor Sword";
+            donor.BasicStats = new WeaponBasicStats { Damage = 42 };
+            donor.Keywords = new Noggog.ExtendedList<IFormLinkGetter<IKeywordGetter>>
+                { new FormLink<IKeywordGetter>(k1.FormKey), new FormLink<IKeywordGetter>(k2.FormKey) };
+
+            var armor = m.Armors.AddNew();
+            armor.EditorID = "ApArmor";
+            armor.Name = "Some Cuirass";
+
+            m.BeginWrite.ToPath(masterPath).WithLoadOrder(Array.Empty<ISkyrimModGetter>()).Write();
+
+            // the replacer WINS the subject: Damage 99, and no keywords at all
+            var r = new SkyrimMod(rKey, SkyrimRelease.SkyrimSE);
+            var rw = (IWeapon)WriteEngine.GenericGetOrAddAsOverride(r, subject);
+            rw.Name = "Winner Sword";
+            rw.BasicStats = new WeaponBasicStats { Damage = 99 };
+            rw.Keywords = new Noggog.ExtendedList<IFormLinkGetter<IKeywordGetter>>();
+            r.BeginWrite.ToPath(replPath).WithLoadOrder(new ISkyrimModGetter[] { m }).Write();
+
+            File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + mKey.FileName + "\r\n" + rKey.FileName + "\r\n");
+            File.WriteAllText(Path.Combine(profiles, "plugins.txt"), "*" + mKey.FileName + "\r\n*" + rKey.FileName + "\r\n");
+            File.WriteAllText(Path.Combine(profiles, "modlist.txt"), "# header\r\n+ApplyRepl\r\n+ApplyMaster\r\n");
+
+            var genDir = Path.Combine(dir, "corpus-gen");
+            try { _ = CorpusRulebook.LoadCorpus(); }
+            catch { CorpusGenerator.GenerateAll(genDir, Path.Combine(dir, "corpus-ref")); CorpusRulebook.CorpusPath = Path.Combine(genDir, "corpus.json"); }
+
+            var store = new UserConfigStore(Path.Combine(dir, "houseCARL.user.json"));
+            var svc = LoadOrderService.WithInstance(instance, 0, store);
+            svc.Stats();   // warm the lazy index once
+
+            return new Fixture
+            {
+                Svc = svc,
+                SubjectFid = $"{subject.FormKey.ID:X6}:{mKey.FileName}",
+                DonorWeaponFid = $"{donor.FormKey.ID:X6}:{mKey.FileName}",
+                ArmorFid = $"{armor.FormKey.ID:X6}:{mKey.FileName}",
+                ModsDir = mods,
+                MasterName = mKey.FileName.String,
+                ReplacerName = rKey.FileName.String,
+                SubjectKey = subject.FormKey,
+            };
+        }
+    }
+
+    /// <summary>Read the subject weapon back off a written patch: (damage, name, keyword count).</summary>
+    static (ushort? Dmg, string? Name, int? Kw) ReadSubject(string espPath, FormKey fk)
+    {
+        ISkyrimModGetter? ov = null;
+        try
+        {
+            ov = SkyrimMod.CreateFromBinaryOverlay(espPath, SkyrimRelease.SkyrimSE);
+            var w = ov.Weapons.FirstOrDefault(x => x.FormKey == fk);
+            return (w?.BasicStats?.Damage, w?.Name?.String, w?.Keywords?.Count);
+        }
+        catch { return (null, null, null); }
+        finally { (ov as IDisposable)?.Dispose(); }
+    }
+
+    /// <summary>The written patch's path, parsed out of the text render's first line ("wrote X.esp …"). The render is
+    /// what a caller actually gets, so reading the path from it keeps the guard honest about the reported artifact.</summary>
+    static string? PatchPathFrom(Fixture fx, string render)
+    {
+        if (!render.StartsWith("wrote ", StringComparison.Ordinal) && !render.StartsWith("extended ", StringComparison.Ordinal)) return null;
+        var file = render[(render.IndexOf(' ') + 1)..];
+        file = file[..file.IndexOf(' ')];
+        var mod = render.Contains("mod folder: ", StringComparison.Ordinal)
+            ? render[(render.IndexOf("mod folder: ", StringComparison.Ordinal) + 12)..].Split('\n')[0].Split("  ")[0].Trim()
+            : null;
+        return mod is null ? null : Path.Combine(fx.ModsDir, mod, file);
+    }
+
+    // ================= ARM 1 — the ops grammar =================
+    static void OpsGrammarArm(Fixture fx, string root)
+    {
+        Console.WriteLine("── ARM 1: the ops grammar — the 2.0 vocabulary, @file, and the strict element reader ──");
+
+        // one op is a set of one — the old set_field call, in the new spelling
+        var one = ApplyTools.Apply(fx.Svc, ops: Json($$"""[{"formid":"{{fx.SubjectFid}}","field_path":"BasicStats.Damage","value":"55"}]"""),
+            patch: "ApOne");
+        var onePath = PatchPathFrom(fx, one);
+        Check("one op is a set of one: BasicStats.Damage=55 lands in a new patch",
+            onePath is not null && ReadSubject(onePath, fx.SubjectKey).Dmg == 55, one);
+
+        // op= is the verb name (§5.1) — an Add on a list, on the winner that has NO keywords
+        var kwFid = $"{fx.DonorWeaponFid}";   // any FormID resolvable as a link value is enough for the Add to be legal
+        var add = ApplyTools.Apply(fx.Svc, ops: Json($$"""[{"formid":"{{fx.SubjectFid}}","field_path":"Keywords","op":"Add","value":"{{kwFid}}"}]"""),
+            patch: "ApAdd");
+        var addPath = PatchPathFrom(fx, add);
+        Check("op= carries the verb: Add on Keywords appends to the winner's empty list",
+            addPath is not null && ReadSubject(addPath, fx.SubjectKey).Kw == 1, add);
+
+        // the @file spelling that retired from_file=
+        var manifest = Path.Combine(root, "ops.json");
+        File.WriteAllText(manifest, $$"""[{"formid":"{{fx.SubjectFid}}","field_path":"BasicStats.Damage","value":"77"}]""");
+        var viaFile = ApplyTools.Apply(fx.Svc, ops: Json($"\"@{manifest.Replace("\\", "\\\\")}\""), patch: "ApFile");
+        var viaFilePath = PatchPathFrom(fx, viaFile);
+        Check("ops=\"@<path>\" reads the SAME array from disk (from_file= retired into the @file convention)",
+            viaFilePath is not null && ReadSubject(viaFilePath, fx.SubjectKey).Dmg == 77, viaFile);
+
+        // the one-element ["@path"] spelling, matching how formids= spells it
+        var viaFileArr = ApplyTools.Apply(fx.Svc, ops: Json($"[\"@{manifest.Replace("\\", "\\\\")}\"]"), patch: "ApFileArr");
+        Check("ops=[\"@<path>\"] — the same convention in the one-element array form formids= uses",
+            PatchPathFrom(fx, viaFileArr) is not null, viaFileArr);
+
+        // a mixed inline/@file array has no meaning — refused, not half-honored
+        var mixed = ApplyTools.Apply(fx.Svc, ops: Json($$"""["@{{manifest.Replace("\\", "\\\\")}}", {"formid":"{{fx.SubjectFid}}","field_path":"Name","value":"x"}]"""));
+        Check("a MIXED inline/@file ops array is refused by name, never half-honored",
+            mixed.StartsWith("error:") && mixed.Contains("cannot be mixed with inline elements"), mixed);
+
+        // an undeclared op member is refused BY NAME (the SDK binder would silently DROP it) and carries the §5.3 correction
+        var strayVerb = ApplyTools.Apply(fx.Svc, ops: Json($$"""[{"formid":"{{fx.SubjectFid}}","field_path":"BasicStats.Damage","verb":"Set","value":"1"}]"""));
+        Check("a 1.x 'verb' member inside an op is refused BY NAME (not silently dropped)",
+            strayVerb.StartsWith("error:") && strayVerb.Contains("verb"), strayVerb);
+        Check("...and the refusal carries the §5.3 correction — the alias layer cannot reach an op's members",
+            strayVerb.Contains("the verb member is now op"), strayVerb);
+
+        // nothing to apply at all
+        var empty = ApplyTools.Apply(fx.Svc);
+        Check("no ops and no zip: refused naming BOTH ways to give work",
+            empty.StartsWith("error:") && empty.Contains("ops=") && empty.Contains("bundle="), empty);
+
+        // a bad field path still refuses all-or-nothing with nothing written (the pre-flight contract, unchanged)
+        var badPath = ApplyTools.Apply(fx.Svc, ops: Json($$"""[{"formid":"{{fx.SubjectFid}}","field_path":"NoSuchField","value":"1"}]"""), patch: "ApBad");
+        Check("a bad field path refuses the whole call with nothing written (all-or-nothing preserved)",
+            badPath.StartsWith("error:"), badPath);
+    }
+
+    // ================= ARM 2 — the LANE grammar =================
+    static void LaneArm(Fixture fx)
+    {
+        Console.WriteLine("── ARM 2: LANE — three exclusive destinations, each dropped one refused BY NAME (§5.2) ──");
+
+        string OneOp(string v) => $$"""[{"formid":"{{fx.SubjectFid}}","field_path":"BasicStats.Damage","value":"{{v}}"}]""";
+
+        var bothPatchInto = ApplyTools.Apply(fx.Svc, ops: Json(OneOp("1")), patch: "X", into: "Y.esp");
+        Check("patch= + into= refused BY NAME (1.x silently IGNORED patch_name under into=)",
+            bothPatchInto.StartsWith("error:") && bothPatchInto.Contains("patch=") && bothPatchInto.Contains("into="), bothPatchInto);
+
+        var bothPatchInPlace = ApplyTools.Apply(fx.Svc, ops: Json(OneOp("1")), patch: "X", in_place: fx.ReplacerName);
+        Check("patch= + in_place= refused BY NAME",
+            bothPatchInPlace.StartsWith("error:") && bothPatchInPlace.Contains("exclusive"), bothPatchInPlace);
+
+        var bothLanes = ApplyTools.Apply(fx.Svc, ops: Json(OneOp("1")), into: "Y.esp", in_place: fx.ReplacerName);
+        Check("into= + in_place= refused BY NAME (different lanes, not a fallback)",
+            bothLanes.StartsWith("error:") && bothLanes.Contains("Name one"), bothLanes);
+
+        var strayAck = ApplyTools.Apply(fx.Svc, ops: Json(OneOp("1")), acknowledge: true);
+        Check("acknowledge= without in_place= refused BY NAME, not ignored",
+            strayAck.StartsWith("error:") && strayAck.Contains("meaningless without in_place"), strayAck);
+
+        // in_place is the FILE'S NAME (§5.2) — first touch returns the CONSENT prompt, not an error and not a write
+        var consent = ApplyTools.Apply(fx.Svc, ops: Json(OneOp("21")), in_place: fx.ReplacerName);
+        Check("in_place=\"X.esp\" enters the lane and the FIRST touch returns the consent prompt (a confirmation, not an error)",
+            !consent.StartsWith("error:") && consent.Contains("acknowledge", StringComparison.OrdinalIgnoreCase), consent);
+
+        var done = ApplyTools.Apply(fx.Svc, ops: Json(OneOp("21")), in_place: fx.ReplacerName, acknowledge: true);
+        Check("in_place + acknowledge writes the target's OWN file in place",
+            done.StartsWith("edited ") && done.Contains(fx.ReplacerName), done);
+
+        // into= extends an existing patch
+        var fresh = ApplyTools.Apply(fx.Svc, ops: Json(OneOp("31")), patch: "ApExtend");
+        var freshFile = fresh.StartsWith("wrote ") ? fresh[6..].Split(' ')[0] : null;
+        var extended = freshFile is null ? "" : ApplyTools.Apply(fx.Svc, ops: Json(OneOp("32")), into: freshFile);
+        Check("into= EXTENDS the existing patch rather than writing a fresh one",
+            extended.StartsWith("extended "), extended);
+
+        // dry_run on the default lane writes nothing and says so first
+        var dry = ApplyTools.Apply(fx.Svc, ops: Json(OneOp("41")), patch: "ApDry", dry_run: true);
+        Check("dry_run reports what WOULD change and writes nothing",
+            dry.StartsWith("DRY RUN") && dry.Contains("NOTHING was written"), dry);
+    }
+
+    // ================= ARM 3 — the §4.5 zip =================
+    static void ZipArm(Fixture fx)
+    {
+        Console.WriteLine("── ARM 4.5: the zip — bundle x assignments as a cross-RECORD copy ──");
+
+        // the load-bearing case: copy a DIFFERENT record's fields onto the subject. The subject's winner has
+        // Damage 99 and no keywords; the donor has Damage 42 and two keywords.
+        var zip = ApplyTools.Apply(fx.Svc,
+            bundle: new[] { "BasicStats.Damage", "Keywords" },
+            assignments: Json($$"""[{"target":"{{fx.SubjectFid}}","from":"{{fx.DonorWeaponFid}}"}]"""),
+            patch: "ApZip");
+        var zipPath = PatchPathFrom(fx, zip);
+        (ushort? Dmg, string? Name, int? Kw) after = zipPath is null ? (null, null, null) : ReadSubject(zipPath, fx.SubjectKey);
+        Check($"the zip copies a bundle BETWEEN records: Damage 99 -> 42 and 0 -> 2 keywords (got {after.Dmg}/{after.Kw})",
+            after.Dmg == 42 && after.Kw == 2, zip);
+        Check("...and leaves everything OUTSIDE the bundle untouched (Name is still the winner's)",
+            after.Name == "Winner Sword", zip);
+
+        // from_source defaults to the source record's WINNER (§4.5) — no pole named above, and it resolved
+        Check("from_source is optional: it defaulted to the source record's load-order winner",
+            zip.StartsWith("wrote "), zip);
+
+        // a named from_source reads THAT plugin's version instead
+        var poled = ApplyTools.Apply(fx.Svc,
+            bundle: new[] { "BasicStats.Damage" },
+            assignments: Json($$"""[{"target":"{{fx.SubjectFid}}","from":"{{fx.DonorWeaponFid}}","from_source":"{{fx.MasterName}}"}]"""),
+            patch: "ApZipPole");
+        var poledPath = PatchPathFrom(fx, poled);
+        Check("a named from_source reads that plugin's version of the source record",
+            poledPath is not null && ReadSubject(poledPath, fx.SubjectKey).Dmg == 42, poled);
+
+        // half a zip is not a zip
+        var bundleOnly = ApplyTools.Apply(fx.Svc, bundle: new[] { "BasicStats.Damage" });
+        Check("bundle= without assignments= refused BY NAME",
+            bundleOnly.StartsWith("error:") && bundleOnly.Contains("assignments="), bundleOnly);
+        var assignOnly = ApplyTools.Apply(fx.Svc, assignments: Json($$"""[{"target":"{{fx.SubjectFid}}","from":"{{fx.DonorWeaponFid}}"}]"""));
+        Check("assignments= without bundle= refused BY NAME",
+            assignOnly.StartsWith("error:") && assignOnly.Contains("bundle="), assignOnly);
+
+        // a self-pair is a no-op, and the refusal teaches the from_source form that DOES mean something
+        var selfPair = ApplyTools.Apply(fx.Svc, bundle: new[] { "BasicStats.Damage" },
+            assignments: Json($$"""[{"target":"{{fx.SubjectFid}}","from":"{{fx.SubjectFid}}"}]"""));
+        Check("target == from refused as a no-op, pointing at from_source= for the version case",
+            selfPair.StartsWith("error:") && selfPair.Contains("from_source"), selfPair);
+
+        // the §4.5 same-runtime-record-type gate
+        var crossType = ApplyTools.Apply(fx.Svc, bundle: new[] { "Name" },
+            assignments: Json($$"""[{"target":"{{fx.SubjectFid}}","from":"{{fx.ArmorFid}}"}]"""), patch: "ApCross");
+        Check("a CROSS-TYPE pair (Armor -> Weapon) is refused by name at pre-flight, naming both types",
+            crossType.StartsWith("error:") && crossType.Contains("Armor") && crossType.Contains("Weapon"), crossType);
+
+        // an incomplete assignment names its element
+        var noFrom = ApplyTools.Apply(fx.Svc, bundle: new[] { "Name" },
+            assignments: Json($$"""[{"target":"{{fx.SubjectFid}}"}]"""));
+        Check("an assignment missing from= is refused at its own index",
+            noFrom.StartsWith("error:") && noFrom.Contains("assignments[0]"), noFrom);
+
+        // the zip COMPOSES with ops= in one call — one patch, both edit sources
+        var composed = ApplyTools.Apply(fx.Svc,
+            ops: Json($$"""[{"formid":"{{fx.SubjectFid}}","field_path":"Name","value":"Renamed"}]"""),
+            bundle: new[] { "BasicStats.Damage" },
+            assignments: Json($$"""[{"target":"{{fx.SubjectFid}}","from":"{{fx.DonorWeaponFid}}"}]"""),
+            patch: "ApBoth");
+        var composedPath = PatchPathFrom(fx, composed);
+        (ushort? Dmg, string? Name, int? Kw) both = composedPath is null ? (null, null, null) : ReadSubject(composedPath, fx.SubjectKey);
+        Check($"ops= and the zip compose in ONE call (got name={both.Name}, dmg={both.Dmg})",
+            both.Name == "Renamed" && both.Dmg == 42, composed);
+    }
+
+    // ================= ARM 4 — in-place CopyFrom parity =================
+    static void InPlaceCopyArm(Fixture fx)
+    {
+        Console.WriteLine("── ARM 4: CopyFrom on the IN-PLACE lane — the capability the lane never had ──");
+
+        // The replacer OWNS the subject's override, so in-place may edit it. Copying the MASTER's Damage (10) onto
+        // the replacer's own record (99) proves the source resolved and the transplant ran. Before W3 this call
+        // died as "pre-flight ACCEPTED it but the apply threw" — a capability gap reported as an internal fault.
+        var copy = ApplyTools.Apply(fx.Svc,
+            ops: Json($$"""[{"formid":"{{fx.SubjectFid}}","field_path":"BasicStats.Damage","op":"CopyFrom","from_source":"{{fx.MasterName}}"}]"""),
+            in_place: fx.ReplacerName, acknowledge: true);
+        Check("CopyFrom composes with in_place= (it previously died as an engine-inconsistency wrapper)",
+            copy.StartsWith("edited "), copy);
+        Check("...and it is NOT the old internal-fault wording",
+            !copy.Contains("pre-flight ACCEPTED it but the apply threw"), copy);
+
+        // the target as its own copy source is a no-op, named as such
+        var selfSource = ApplyTools.Apply(fx.Svc,
+            ops: Json($$"""[{"formid":"{{fx.SubjectFid}}","field_path":"BasicStats.Damage","op":"CopyFrom","from_source":"{{fx.ReplacerName}}"}]"""),
+            in_place: fx.ReplacerName, acknowledge: true);
+        Check("copying the in-place target's own field onto itself is refused as a no-op",
+            selfSource.StartsWith("error:") && selfSource.Contains("no-op"), selfSource);
+    }
+
+    // ================= ARM 5 — TRANSPORT =================
+    static void TransportArm(Fixture fx)
+    {
+        Console.WriteLine("── ARM 5: TRANSPORT — json parity, refusals-as-documents, and the §2.1.1 epoch ──");
+
+        string OneOp(string v) => $$"""[{"formid":"{{fx.SubjectFid}}","field_path":"BasicStats.Damage","value":"{{v}}"}]""";
+
+        var text = ApplyTools.Apply(fx.Svc, ops: Json(OneOp("61")), patch: "ApEpoch");
+        Check("every TEXT write render carries epoch=<hex> — the build the winners resolved from (§2.1.1)",
+            text.Contains("\nepoch="), text);
+
+        var jsonOut = ApplyTools.Apply(fx.Svc, ops: Json(OneOp("62")), patch: "ApJson", format: "json");
+        JsonElement doc = default;
+        bool parsed = true;
+        try { doc = Json(jsonOut); } catch { parsed = false; }
+        Check("format=json emits VALID JSON", parsed, jsonOut);
+        if (parsed)
+        {
+            Check("...ok=true, lane=patch, and the epoch rides in-band (never a silently degraded mode)",
+                doc.TryGetProperty("ok", out var ok) && ok.GetBoolean() &&
+                doc.TryGetProperty("lane", out var lane) && lane.GetString() == "patch" &&
+                doc.TryGetProperty("epoch", out var ep) && ep.ValueKind == JsonValueKind.String, jsonOut);
+            Check("...and the read-back's provenance is DATA, not prose (the written file, not load-order truth)",
+                !doc.TryGetProperty("readback", out _) || doc.TryGetProperty("readback_source", out _), jsonOut);
+        }
+
+        // a REFUSAL is a document too — a json caller must never parse "error: …" out of a string
+        var jsonRefusal = ApplyTools.Apply(fx.Svc,
+            ops: Json($$"""[{"formid":"{{fx.SubjectFid}}","field_path":"NoSuchField","value":"1"}]"""),
+            patch: "ApJsonBad", format: "json");
+        bool refusalIsDoc = false;
+        try
+        {
+            var rd = Json(jsonRefusal);
+            refusalIsDoc = rd.TryGetProperty("ok", out var rok) && !rok.GetBoolean() && rd.TryGetProperty("error", out _);
+        }
+        catch { }
+        Check("a json REFUSAL is a document with ok:false + error, not a bare error string", refusalIsDoc, jsonRefusal);
+
+        // the consent prompt is its own flag — a required confirmation is not a failure (Q3)
+        var jsonConsent = ApplyTools.Apply(fx.Svc, ops: Json(OneOp("63")), in_place: fx.MasterName, format: "json");
+        bool consentFlagged = false;
+        try
+        {
+            var cd = Json(jsonConsent);
+            consentFlagged = cd.TryGetProperty("needs_acknowledge", out var na) && na.GetBoolean()
+                          && cd.TryGetProperty("confirmation", out _);
+        }
+        catch { }
+        Check("the in-place CONSENT prompt is its own json flag + 'confirmation' key, never an 'error'", consentFlagged, jsonConsent);
+
+        var badFormat = ApplyTools.Apply(fx.Svc, ops: Json(OneOp("64")), format: "yaml");
+        Check("an unrecognized format= is refused by name, never a silent fall-through to text",
+            badFormat.StartsWith("error:") && badFormat.Contains("format="), badFormat);
+    }
+}

--- a/src/housecarl-generator/ApplyGuardProbe.cs
+++ b/src/housecarl-generator/ApplyGuardProbe.cs
@@ -84,6 +84,7 @@ public static class ApplyGuardProbe
         public required string DonorWeaponFid { get; init; }  // a DIFFERENT weapon (Damage 42, 2 keywords) — the zip source
         public required string ArmorFid { get; init; }        // a different record TYPE — the cross-type refusal source
         public required string ModsDir { get; init; }
+        public required string ReplacerPath { get; init; }   // the in-place target's real on-disk file
         public required string MasterName { get; init; }
         public required string ReplacerName { get; init; }
         public required FormKey SubjectKey { get; init; }
@@ -136,6 +137,13 @@ public static class ApplyGuardProbe
             rw.Name = "Winner Sword";
             rw.BasicStats = new WeaponBasicStats { Damage = 99 };
             rw.Keywords = new Noggog.ExtendedList<IFormLinkGetter<IKeywordGetter>>();
+
+            // The replacer ALSO overrides the DONOR, at a distinct Damage. Without this the donor's winner IS the
+            // master, so "the pole defaulted to the source's winner" and "from_source named the master" would assert
+            // the SAME observable and neither would prove anything (review [medium]): a regression that ignored a
+            // named from_source, or defaulted to the wrong plugin, would leave both arms green. 7 vs 42 separates them.
+            var rd = (IWeapon)WriteEngine.GenericGetOrAddAsOverride(r, donor);
+            rd.BasicStats = new WeaponBasicStats { Damage = 7 };   // keywords carry over from the master (still 2)
             r.BeginWrite.ToPath(replPath).WithLoadOrder(new ISkyrimModGetter[] { m }).Write();
 
             File.WriteAllText(Path.Combine(profiles, "loadorder.txt"), "# header\r\n" + mKey.FileName + "\r\n" + rKey.FileName + "\r\n");
@@ -157,6 +165,7 @@ public static class ApplyGuardProbe
                 DonorWeaponFid = $"{donor.FormKey.ID:X6}:{mKey.FileName}",
                 ArmorFid = $"{armor.FormKey.ID:X6}:{mKey.FileName}",
                 ModsDir = mods,
+                ReplacerPath = replPath,
                 MasterName = mKey.FileName.String,
                 ReplacerName = rKey.FileName.String,
                 SubjectKey = subject.FormKey,
@@ -298,30 +307,33 @@ public static class ApplyGuardProbe
         Console.WriteLine("── ARM 4.5: the zip — bundle x assignments as a cross-RECORD copy ──");
 
         // the load-bearing case: copy a DIFFERENT record's fields onto the subject. The subject's winner has
-        // Damage 99 and no keywords; the donor has Damage 42 and two keywords.
+        // Damage 99 and no keywords; the donor's WINNER (the replacer's override) has Damage 7 and two keywords,
+        // while the MASTER's version of the donor has 42 — the two poles are observably different.
         var zip = ApplyTools.Apply(fx.Svc,
             bundle: new[] { "BasicStats.Damage", "Keywords" },
             assignments: Json($$"""[{"target":"{{fx.SubjectFid}}","from":"{{fx.DonorWeaponFid}}"}]"""),
             patch: "ApZip");
         var zipPath = PatchPathFrom(fx, zip);
         (ushort? Dmg, string? Name, int? Kw) after = zipPath is null ? (null, null, null) : ReadSubject(zipPath, fx.SubjectKey);
-        Check($"the zip copies a bundle BETWEEN records: Damage 99 -> 42 and 0 -> 2 keywords (got {after.Dmg}/{after.Kw})",
-            after.Dmg == 42 && after.Kw == 2, zip);
+        Check($"the zip copies a bundle BETWEEN records: Damage 99 -> 7 and 0 -> 2 keywords (got {after.Dmg}/{after.Kw})",
+            after.Dmg == 7 && after.Kw == 2, zip);
         Check("...and leaves everything OUTSIDE the bundle untouched (Name is still the winner's)",
             after.Name == "Winner Sword", zip);
 
-        // from_source defaults to the source record's WINNER (§4.5) — no pole named above, and it resolved
-        Check("from_source is optional: it defaulted to the source record's load-order winner",
-            zip.StartsWith("wrote "), zip);
+        // from_source omitted ⇒ the SOURCE RECORD's load-order winner (§4.5) — 7, the replacer's override, NOT the
+        // master's 42 and NOT the target's own plugin. This is the arm that pins the default's meaning.
+        Check($"from_source is optional and defaults to the SOURCE record's winner (7, the replacer's override — not the master's 42) (got {after.Dmg})",
+            after.Dmg == 7, zip);
 
-        // a named from_source reads THAT plugin's version instead
+        // a named from_source reads THAT plugin's version instead — 42, distinguishable from the default above
         var poled = ApplyTools.Apply(fx.Svc,
             bundle: new[] { "BasicStats.Damage" },
             assignments: Json($$"""[{"target":"{{fx.SubjectFid}}","from":"{{fx.DonorWeaponFid}}","from_source":"{{fx.MasterName}}"}]"""),
             patch: "ApZipPole");
         var poledPath = PatchPathFrom(fx, poled);
-        Check("a named from_source reads that plugin's version of the source record",
-            poledPath is not null && ReadSubject(poledPath, fx.SubjectKey).Dmg == 42, poled);
+        var poledDmg = poledPath is null ? null : ReadSubject(poledPath, fx.SubjectKey).Dmg;
+        Check($"a named from_source reads THAT plugin's version of the source record (42, the master's — not the winner's 7) (got {poledDmg})",
+            poledDmg == 42, poled);
 
         // half a zip is not a zip
         var bundleOnly = ApplyTools.Apply(fx.Svc, bundle: new[] { "BasicStats.Damage" });
@@ -349,6 +361,33 @@ public static class ApplyGuardProbe
         Check("an assignment missing from= is refused at its own index",
             noFrom.StartsWith("error:") && noFrom.Contains("assignments[0]"), noFrom);
 
+        // REVIEW FOLD [medium]: a zip-generated op must never be refused at an op[i] the caller never wrote.
+        // Two real ops here, so a naive index would say "op[2]" — a line that does not exist in the call.
+        var badPair = ApplyTools.Apply(fx.Svc,
+            ops: Json($$"""[{"formid":"{{fx.SubjectFid}}","field_path":"Name","value":"a"},{"formid":"{{fx.SubjectFid}}","field_path":"Value","value":"1"}]"""),
+            bundle: new[] { "Name" },
+            assignments: Json($$"""[{"target":"NOTAFORMID","from":"{{fx.DonorWeaponFid}}"}]"""));
+        Check("a bad FormID in an assignment is refused NAMING THE ASSIGNMENT, not a phantom op index",
+            badPair.StartsWith("error:") && badPair.Contains("assignments[0]") && !badPair.Contains("op[2]"), badPair);
+
+        // REVIEW FOLD [low]: a mixed inline/@file bundle is named like the other two list inputs, not silently
+        // treated as a literal field path.
+        var mixedBundle = ApplyTools.Apply(fx.Svc, bundle: new[] { "@C:\\jobs\\paths.json", "Keywords" },
+            assignments: Json($$"""[{"target":"{{fx.SubjectFid}}","from":"{{fx.DonorWeaponFid}}"}]"""));
+        Check("a MIXED inline/@file bundle= is refused by name (parity with ops=/assignments=)",
+            mixedBundle.StartsWith("error:") && mixedBundle.Contains("cannot be mixed with inline elements"), mixedBundle);
+
+        // REVIEW FOLD [high]: a copy carries no authored value — and that rule must not depend on whether the
+        // POLE was named. The from=-without-from_source= shape used to return early past this check and DISCARD
+        // the value silently; both spellings must refuse alike.
+        foreach (var (label, extra) in new[] { ("without from_source", ""), ("with from_source", $",\"from_source\":\"{fx.MasterName}\"") })
+        {
+            var valued = ApplyTools.Apply(fx.Svc,
+                ops: Json($$"""[{"formid":"{{fx.SubjectFid}}","field_path":"BasicStats.Damage","op":"CopyFrom","from":"{{fx.DonorWeaponFid}}"{{extra}},"value":"55"}]"""));
+            Check($"CopyFrom + value= is refused {label} (the value is never silently discarded)",
+                valued.StartsWith("error:") && valued.Contains("takes no value"), valued);
+        }
+
         // the zip COMPOSES with ops= in one call — one patch, both edit sources
         var composed = ApplyTools.Apply(fx.Svc,
             ops: Json($$"""[{"formid":"{{fx.SubjectFid}}","field_path":"Name","value":"Renamed"}]"""),
@@ -358,7 +397,7 @@ public static class ApplyGuardProbe
         var composedPath = PatchPathFrom(fx, composed);
         (ushort? Dmg, string? Name, int? Kw) both = composedPath is null ? (null, null, null) : ReadSubject(composedPath, fx.SubjectKey);
         Check($"ops= and the zip compose in ONE call (got name={both.Name}, dmg={both.Dmg})",
-            both.Name == "Renamed" && both.Dmg == 42, composed);
+            both.Name == "Renamed" && both.Dmg == 7, composed);
     }
 
     // ================= ARM 4 — in-place CopyFrom parity =================
@@ -383,6 +422,21 @@ public static class ApplyGuardProbe
             in_place: fx.ReplacerName, acknowledge: true);
         Check("copying the in-place target's own field onto itself is refused as a no-op",
             selfSource.StartsWith("error:") && selfSource.Contains("no-op"), selfSource);
+
+        // REVIEW FOLD [high] — the LIFETIME case. A CROSS-record copy whose source lives in the in-place target's
+        // OWN file: legitimate (not the self-record no-op above), and the source body must come from the mutable
+        // targetMod, never the session overlay Phase 4 releases before serialize. Both records are defined by the
+        // master but the REPLACER overrides both, so in-place on the replacer owns them: copy the donor's Damage
+        // (7, the replacer's own value) onto the subject, in place, and the write must complete AND land 7 —
+        // reading through a disposed overlay would yield garbage or throw at serialize.
+        var sameFile = ApplyTools.Apply(fx.Svc,
+            ops: Json($$"""[{"formid":"{{fx.SubjectFid}}","field_path":"BasicStats.Damage","op":"CopyFrom","from":"{{fx.DonorWeaponFid}}","from_source":"{{fx.ReplacerName}}"}]"""),
+            in_place: fx.ReplacerName, acknowledge: true);
+        Check("a CROSS-record copy sourced from the in-place target's OWN file completes (source read from the mutable mod, not the released overlay)",
+            sameFile.StartsWith("edited "), sameFile);
+        var landed = ReadSubject(fx.ReplacerPath, fx.SubjectKey);
+        Check($"...and the copied value actually landed intact in the rewritten file (Damage 7, got {landed.Dmg})",
+            landed.Dmg == 7, sameFile);
     }
 
     // ================= ARM 5 — TRANSPORT =================
@@ -435,6 +489,24 @@ public static class ApplyGuardProbe
         }
         catch { }
         Check("the in-place CONSENT prompt is its own json flag + 'confirmation' key, never an 'error'", consentFlagged, jsonConsent);
+
+        // REVIEW FOLD [medium] — the epoch contract says EVERY outcome decided after the capture carries one:
+        // success, refusal, dry run, AND the consent prompt. The prompt and the service-side in-place refusals are
+        // decided in LoadOrderService (before the core runs), and were the ones going out unstamped — while
+        // "first in_place call" is the single most common shape a caller meets. Both renders are pinned here,
+        // because checking only the success renders is exactly how this got through the first time.
+        bool consentEpoch = false;
+        try { consentEpoch = Json(jsonConsent).TryGetProperty("epoch", out var ce) && ce.ValueKind == JsonValueKind.String; }
+        catch { }
+        Check("the json CONSENT prompt carries the epoch (decided after a capture ⇒ stamped)", consentEpoch, jsonConsent);
+
+        var textConsent = ApplyTools.Apply(fx.Svc, ops: Json(OneOp("65")), in_place: fx.MasterName);
+        Check("the TEXT consent prompt carries the epoch too", textConsent.Contains("\nepoch="), textConsent);
+
+        // ...and the service-side "not an active plugin" refusal, decided off the same capture.
+        var notActive = ApplyTools.Apply(fx.Svc, ops: Json(OneOp("66")), in_place: "NotInTheOrder.esp");
+        Check("the service-side in-place 'not an active plugin' refusal carries the epoch",
+            notActive.StartsWith("error:") && notActive.Contains("\nepoch="), notActive);
 
         var badFormat = ApplyTools.Apply(fx.Svc, ops: Json(OneOp("64")), format: "yaml");
         Check("an unrecognized format= is refused by name, never a silent fall-through to text",

--- a/src/housecarl-generator/BindingShimProbe.cs
+++ b/src/housecarl-generator/BindingShimProbe.cs
@@ -308,6 +308,15 @@ public static class BindingShimProbe
             //    outside the census: activation here means "the row CAN fire on this tool for some value".
             //    On any schema or table change: eyeball the printed diff, then update CensusExpected.
             failures += CensusArm(tools);
+
+            // -- SCHEMA: the @file union ToolSchemas publishes, and the invariant that made it necessary.
+            //    ops=/assignments= are declared JsonElement (no C# type expresses "array OR '@path'"), so the
+            //    generator would publish {}; ToolSchemas republishes anyOf[<generated element array>, string].
+            //    The load-bearing check is the LAST one: the generator terminates a recursive type with a
+            //    POSITIONAL "#/..." back-reference relative to its own document, so nesting a generated
+            //    sub-schema silently produces a dangling $ref — a broken schema, strictly worse than the {}
+            //    it replaced. That check is generic over every tool, not just this one.
+            failures += SchemaArm(tools);
         }
         catch (Exception ex)
         {
@@ -502,6 +511,97 @@ public static class BindingShimProbe
     /// a tool when NO declared parameter normalizes to the old spelling (else the call is declared, or
     /// the bridge owns it) and the first non-excluded candidate IS declared; a hint is active when the
     /// old spelling is undeclared and every gate parameter is declared.</summary>
+    /// <summary>The published-schema arm (W3): the SPEC §5.1 <c>@file</c> union on the JsonElement-typed list
+    /// parameters, plus the same-document-pointer invariant every tool's schema must satisfy.</summary>
+    static int SchemaArm(JsonElement toolsList)
+    {
+        int failures = 0;
+        JsonElement apply = default;
+        bool found = false;
+        foreach (var t in toolsList.GetProperty("tools").EnumerateArray())
+            if (t.GetProperty("name").GetString() == "housecarl_apply") { apply = t; found = true; break; }
+
+        failures += Check("SCHEMA: housecarl_apply is published", found, "tool absent from tools/list");
+        if (found)
+        {
+            foreach (var (param, member) in new[] { ("ops", "field_path"), ("assignments", "target") })
+            {
+                JsonElement arms = default;
+                var ok = apply.GetProperty("inputSchema").GetProperty("properties").TryGetProperty(param, out var node)
+                      && node.TryGetProperty("anyOf", out arms)
+                      && arms.GetArrayLength() == 2
+                      && arms[0].TryGetProperty("type", out var t0) && t0.GetString() == "array"
+                      && arms[1].TryGetProperty("type", out var t1) && t1.GetString() == "string";
+                failures += Check($"SCHEMA: {param}= publishes anyOf[<generated array>, string] — not the bare {{}} the declared JsonElement would give",
+                    ok, ok ? "" : node.ValueKind == JsonValueKind.Undefined ? "parameter absent" : node.GetRawText());
+
+                // The array arm must be the GENERATED element schema, not an empty placeholder: a named member
+                // proves the generator ran over the real C# type (and so keeps tracking it as it changes).
+                bool typed = ok && arms[0].TryGetProperty("items", out var items)
+                                && items.TryGetProperty("properties", out var mprops)
+                                && mprops.TryGetProperty(member, out _);
+                failures += Check($"SCHEMA: {param}='s array arm carries the generated element members (e.g. {member})", typed, "");
+            }
+        }
+
+        // GENERIC: every same-document $ref in every published schema must resolve. This is what catches a
+        // generated sub-schema nested without rebasing its pointers.
+        var dangling = new List<string>();
+        foreach (var t in toolsList.GetProperty("tools").EnumerateArray())
+        {
+            if (!t.TryGetProperty("inputSchema", out var schema)) continue;
+            var name = t.GetProperty("name").GetString()!;
+            foreach (var r in CollectRefs(schema))
+                if (!PointerResolves(schema, r)) dangling.Add($"{name}: {r}");
+        }
+        failures += Check($"SCHEMA: every same-document $ref in every published tool schema resolves ({dangling.Count} dangling)",
+            dangling.Count == 0, string.Join(" | ", dangling.Take(5)));
+        return failures;
+    }
+
+    /// <summary>Every <c>$ref</c> string anywhere in a schema document.</summary>
+    static IEnumerable<string> CollectRefs(JsonElement node)
+    {
+        switch (node.ValueKind)
+        {
+            case JsonValueKind.Object:
+                foreach (var p in node.EnumerateObject())
+                {
+                    if (p.Name == "$ref" && p.Value.ValueKind == JsonValueKind.String) yield return p.Value.GetString()!;
+                    else foreach (var r in CollectRefs(p.Value)) yield return r;
+                }
+                break;
+            case JsonValueKind.Array:
+                foreach (var item in node.EnumerateArray())
+                    foreach (var r in CollectRefs(item)) yield return r;
+                break;
+        }
+    }
+
+    /// <summary>Walk a same-document JSON pointer ("#/a/b/0"). Anything not starting with '#' is external and
+    /// counts as resolvable — this arm polices the pointers we rebase, not the whole of JSON Schema.</summary>
+    static bool PointerResolves(JsonElement root, string reference)
+    {
+        if (!reference.StartsWith('#')) return true;
+        var cur = root;
+        foreach (var raw in reference[1..].Split('/', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var seg = raw.Replace("~1", "/").Replace("~0", "~");
+            if (cur.ValueKind == JsonValueKind.Object)
+            {
+                if (!cur.TryGetProperty(seg, out var next)) return false;
+                cur = next;
+            }
+            else if (cur.ValueKind == JsonValueKind.Array)
+            {
+                if (!int.TryParse(seg, out var i) || i < 0 || i >= cur.GetArrayLength()) return false;
+                cur = cur[i];
+            }
+            else return false;
+        }
+        return true;
+    }
+
     static int CensusArm(JsonElement toolsList)
     {
         var actual = new List<string>();

--- a/src/housecarl-generator/BindingShimProbe.cs
+++ b/src/housecarl-generator/BindingShimProbe.cs
@@ -346,6 +346,26 @@ public static class BindingShimProbe
         // nothing fires on S8 Nexus / S9 session tools, source-> only lands on the whose-version
         // plugin= tools and the two NIF mod= tools, and patch= lands on the §5.3 ARTIFACT per tool
         // (output on merge_plugins, archive_name on bsa_repack, patch_name elsewhere).
+        // W3 (eyeballed 2026-08-04): housecarl_apply joins the surface — the FIRST 2.0 write tool, so the
+        // write-side §5.3 rows go live. operations->ops and full_readback->readback are the pure renames;
+        // all four "the new artifact" spellings land on patch= (apply declares no other output name, so the
+        // clique's priority order is inert here); from_file's ⤳ hint activates on the `ops` gate — the @file
+        // convention that retired it now exists — and the four copy-zip hints activate on the `assignments`
+        // gate, exactly the wave §5.3 assigned them. 119 -> 130, all eleven on housecarl_apply.
+        // NOTE (deliberate negative): verb->op does NOT appear. `op` is a member of an ops ELEMENT, not a
+        // top-level parameter, and the shim rewrites top-level arguments only — a stray `verb` inside an op
+        // is refused by the strict element reader instead, which carries its own §5.3 correction.
+        "housecarl_apply: archivename -> patch",
+        "housecarl_apply: fromfile => hint",
+        "housecarl_apply: fullreadback -> readback",
+        "housecarl_apply: operations -> ops",
+        "housecarl_apply: output -> patch",
+        "housecarl_apply: patchname -> patch",
+        "housecarl_apply: pluginname -> patch",
+        "housecarl_apply: sourceformid => hint",
+        "housecarl_apply: sourcemod => hint",
+        "housecarl_apply: sourceplugin => hint",
+        "housecarl_apply: targetformid => hint",
         "housecarl_asset_status: paths -> asset_paths",
         "housecarl_batch_record_detail: formid -> formids",
         "housecarl_batch_record_detail: pluginname -> plugin",

--- a/src/housecarl-generator/BindingShimProbe.cs
+++ b/src/housecarl-generator/BindingShimProbe.cs
@@ -506,11 +506,6 @@ public static class BindingShimProbe
         "housecarl_write_seq: source -> plugin",
     };
 
-    /// <summary>Compute the activation census from the served tools/list and diff it against
-    /// <see cref="CensusExpected"/>. Mirrors ResolveAliases' value-independent gates: a row is active on
-    /// a tool when NO declared parameter normalizes to the old spelling (else the call is declared, or
-    /// the bridge owns it) and the first non-excluded candidate IS declared; a hint is active when the
-    /// old spelling is undeclared and every gate parameter is declared.</summary>
     /// <summary>The published-schema arm (W3): the SPEC §5.1 <c>@file</c> union on the JsonElement-typed list
     /// parameters, plus the same-document-pointer invariant every tool's schema must satisfy.</summary>
     static int SchemaArm(JsonElement toolsList)
@@ -602,6 +597,11 @@ public static class BindingShimProbe
         return true;
     }
 
+    /// <summary>Compute the activation census from the served tools/list and diff it against
+    /// <see cref="CensusExpected"/>. Mirrors ResolveAliases' value-independent gates: a row is active on
+    /// a tool when NO declared parameter normalizes to the old spelling (else the call is declared, or
+    /// the bridge owns it) and the first non-excluded candidate IS declared; a hint is active when the
+    /// old spelling is undeclared and every gate parameter is declared.</summary>
     static int CensusArm(JsonElement toolsList)
     {
         var actual = new List<string>();

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -85,6 +85,10 @@ public static class CiAll
         // for CopyFrom/diff); asserts append-vs-clear semantics, all-or-nothing per-element reasons, copy-then-readback
         // equality across field kinds + named non-transplantable refusals, and the two-pole diff incl. an off-order side.
         ("bulk-primitives-wave3-guard", BulkPrimitivesWave3Probe.RunGuard),
+        // W3 — housecarl_apply, the 2.0 S1 write surface: the ops grammar + @file, the LANE grammar (three
+        // exclusive destinations, in_place as the overwritten file's NAME, the consent handshake), the §4.5
+        // bundle x assignments cross-record copy zip, CopyFrom on the in-place lane, and json/epoch TRANSPORT.
+        ("apply-guard", ApplyGuardProbe.RunGuard),
         ("writelock-guard", WriteLockProbe.RunGuard),
         // #225 dry_run= on the write tools — the real pipeline HALTED before serialize, nothing written: refusal
         // parity with the real call, prediction parity (path/After/masters), the pre-empted missing-master failure,

--- a/src/housecarl-generator/CiAll.cs
+++ b/src/housecarl-generator/CiAll.cs
@@ -134,12 +134,13 @@ public static class CiAll
         // formats, and @file re-entry yields the identity column epoch-checked against the consuming call's own
         // capture — a stale artifact refuses loud naming both epochs, with no override switch by design.
         ("artifact-guard", ArtifactGuardProbe.RunGuard),
-        // The 2.0 S1 read surface, core forms (tool-surface 2.0 W2 PR 1, SPEC §2.2/§4.2/§6.1): the W2
+        // The 2.0 S1 read surface, COMPLETE (tool-surface 2.0 W2, SPEC §2.2/§3/§4/§6.1): the W2
         // where-grammar terms (startswith · editorid · winner provenance · generalized membership · the ->
-        // link step) against brute-force oracles, the housecarl_records dispatch (identity/summary/fields/
-        // everything/aggregate over the list + scan lanes), the §4.2 one-pole source (arm always stated,
-        // untouched refusals naming the touchers, neither-place refusals naming both places), form-scoping
-        // + staging refusals by name, and the to_file/@artifact re-entry epoch check.
+        // link step) against brute-force oracles, the housecarl_records dispatch over all nine PROJECT forms
+        // (identity/summary/fields/everything/aggregate on the list + scan lanes; delta/tree/chain/info_order
+        // in section 6), the §4.2 pole grammar (arm always stated, untouched refusals naming the touchers,
+        // neither-place refusals naming both places, previous_provider's four pins, the SkyPatcher overlay),
+        // the §3 walk construct, form-scoping refusals by name, and the to_file/@artifact re-entry epoch check.
         ("records-guard", RecordsGuardProbe.RunGuard),
         ("verify-loop-guard", VerifyLoopProbe.RunGuard),
         ("vmad-poly-guard", VmadPolyProbe.RunGuard),

--- a/src/housecarl-mcp/AliasTable.cs
+++ b/src/housecarl-mcp/AliasTable.cs
@@ -240,6 +240,14 @@ internal static class AliasTable
          "absorbed into housecarl_records: project={\"form\": \"chain\"} with walk={\"direction\": \"reverse\"} and the MGEF in formids= (types= still narrows the carrier types)."),
         ("housecarl_skypatcher_read",
          "absorbed into housecarl_records: source={\"overlay\": \"skypatcher\", \"state\": \"post\"} reads the post-INI body; pre-vs-post is project={\"form\": \"delta\"} with the two overlay poles."),
+
+        // W3 — the write side. Both field-edit tools became housecarl_apply; the LANE and vocabulary changes
+        // (§5.1/§5.2) are named here too, because a caller arriving from old docs has the old PARAMETER habits
+        // as well as the old tool name, and the one-hop redirect is worth more than a bare "use apply".
+        ("housecarl_set_field",
+         "absorbed into housecarl_apply: one op is a set of one — ops=[{formid, field_path, value}] (verb= is op=). patch_name= is patch=, full_readback= is readback=, and the target=+in_place=true pair is in_place=\"X.esp\" (the file being overwritten)."),
+        ("housecarl_bulk_apply",
+         "absorbed into housecarl_apply: operations= is ops= (verb= is op=), and from_file= is the @file convention — ops=\"@<absolute path>\". patch_name= is patch=, full_readback= is readback=, target=+in_place=true is in_place=\"X.esp\". Copying a field bundle BETWEEN records is bundle= + assignments=."),
     };
 
     /// <summary>The successor teaching for a retired tool name, or null. Case-insensitive on the full name.</summary>

--- a/src/housecarl-mcp/ApplyTools.cs
+++ b/src/housecarl-mcp/ApplyTools.cs
@@ -333,33 +333,52 @@ public static class ApplyTools
         return (text, null);
     }
 
-    /// <summary>The §5.3 vocabulary correction for a rejected OP-ELEMENT member. The alias layer rewrites TOP-LEVEL
-    /// arguments only (<see cref="ToolCallShim"/> works off the published schema, and an op's members are inside a
+    /// <summary>The §5.3 vocabulary correction for a rejected element member. The alias layer rewrites TOP-LEVEL
+    /// arguments only (<see cref="ToolCallShim"/> works off the published schema, and these members are inside a
     /// list value), so a caller carrying 1.x habits — <c>verb</c>, <c>from_plugin</c> — gets the strict reader's
     /// unmapped-member refusal with no way to learn the new word. That refusal is correct and stays; this appends
-    /// the one-hop correction to it. Deliberately narrow: only the spellings this tool actually renamed, matched off
-    /// the property name STJ already quoted, so it can never invent a member the shape doesn't declare.</summary>
+    /// the one-hop correction to it.
+    /// <para>Matched on the member name AND the DECLARING TYPE, both of which STJ already quotes. The type half is
+    /// load-bearing, not belt-and-braces: the same word means different things per shape — <c>verb</c> is a rename
+    /// on an op but a LEGAL member on a <see cref="NestedSet"/>, and <c>op</c> is legal on an op but a mistake in
+    /// two different ways on a nested set and on an <see cref="Assignment"/>. Matching the name alone would answer
+    /// a stray <c>op</c> inside an assignment by lecturing about `compose=`, a construct that caller never used
+    /// (round-5 review). Unmatched pairs simply get no hint — the refusal still names the member and its type.</para></summary>
     static string ElementVocabularyHint(string stjMessage)
     {
-        foreach (var (old, correction) in ElementRenames)
-            if (stjMessage.Contains($"'{old}'", StringComparison.Ordinal))
+        foreach (var (old, declaringType, correction) in ElementRenames)
+            if (stjMessage.Contains($"'{old}'", StringComparison.Ordinal) &&
+                stjMessage.Contains($".{declaringType}'", StringComparison.Ordinal))
                 return $" ('{old}' was the 1.x spelling — {correction})";
         return "";
     }
 
-    static readonly (string Old, string Correction)[] ElementRenames =
+    /// <summary>(old spelling, the type that REJECTED it, the correction). One row per (member, shape) pair,
+    /// because the same word is a different mistake — or no mistake — depending on which shape it landed in.</summary>
+    static readonly (string Old, string DeclaringType, string Correction)[] ElementRenames =
     {
-        // Scoped deliberately: the rename is AT THE OP LEVEL only. A nested set inside compose= is a NestedSet,
-        // shared verbatim with the 1.x wire shape, and still spells `verb` — so an unscoped "op everywhere"
-        // correction would send a caller straight into the opposite refusal one level down. The reverse row
-        // below catches exactly that caller.
-        ("verb", "at the OP level the verb member is now op — op=\"Add\". (A nested set inside compose= is unchanged and still takes verb.)"),
-        ("op", "a nested set inside compose= still spells its verb `verb` — only the top-level op member was renamed to op"),
-        ("from_plugin", "it split in two: from_source names the PLUGIN to copy from, from names a different source RECORD"),
-        ("fromplugin", "it split in two: from_source names the PLUGIN to copy from, from names a different source RECORD"),
-        ("target_formid", "a copy's destination record is the assignments= zip's target="),
-        ("source_formid", "a copy's source record is the assignments= zip's from= (or an op's from=)"),
-        ("source_plugin", "a copy's source pole is from_source="),
+        // AT THE OP LEVEL the rename is verb -> op. A nested set inside compose= is a NestedSet, shared verbatim
+        // with the 1.x wire shape, and legitimately still spells `verb` — hence the type gate, and the two
+        // opposite corrections below it.
+        ("verb", "ApplyOp", "at the OP level the verb member is now op — op=\"Add\". (A nested set inside compose= is unchanged and still takes verb.)"),
+        ("op", "NestedSet", "a nested set inside compose= still spells its verb `verb` — only the top-level op member was renamed to op"),
+        // An assignment names RECORDS, never a verb: the zip is a copy by construction. Answering this one with
+        // the NestedSet correction would lecture about compose=, which such a caller never used.
+        ("op", "Assignment", "an assignment pairs records and carries no verb — the zip is always a copy. Per-op verbs live in ops=[{…, op: \"…\"}]"),
+        ("verb", "Assignment", "an assignment pairs records and carries no verb — the zip is always a copy. Per-op verbs live in ops=[{…, op: \"…\"}]"),
+
+        ("from_plugin", "ApplyOp", "it split in two: from_source names the PLUGIN to copy from, from names a different source RECORD"),
+        ("fromplugin", "ApplyOp", "it split in two: from_source names the PLUGIN to copy from, from names a different source RECORD"),
+        ("from_plugin", "Assignment", "an assignment's source pole is from_source=, and its source RECORD is from="),
+
+        ("target_formid", "Assignment", "a copy's destination record is the assignments= zip's target="),
+        ("source_formid", "Assignment", "a copy's source record is the assignments= zip's from="),
+        ("source_plugin", "Assignment", "a copy's source pole is from_source="),
+        // The same three, typed into an OP instead — the zip's members do not exist there; an op copies with
+        // from=/from_source= and names its own record in formid=.
+        ("target_formid", "ApplyOp", "an op names its own record in formid=; a copy's DESTINATION only has a separate spelling inside the assignments= zip (target=)"),
+        ("source_formid", "ApplyOp", "an op's source record is from="),
+        ("source_plugin", "ApplyOp", "an op's source pole is from_source="),
     };
 
     /// <summary>STJ appends its own position block (" Path: $[0].x | LineNumber: 0 | BytePositionInLine: 89.") to a

--- a/src/housecarl-mcp/ApplyTools.cs
+++ b/src/housecarl-mcp/ApplyTools.cs
@@ -282,8 +282,9 @@ public static class ApplyTools
             // would contradict the 1-based position stated here — shear it; the element path is surfaced separately.
             string at = ex.LineNumber is { } ln ? $" at line {ln + 1}, byte {(ex.BytePositionInLine ?? 0) + 1} in the line" : "";
             string element = ex.Path is { Length: > 2 } p ? $" (element {p})" : "";
-            return (null, $"{origin} could not be parsed{at}{element}: {ShearStjPosition(Guard.Flatten(ex.Message))} " +
-                          $"Expected a JSON ARRAY of {shape} elements.");
+            var msg = ShearStjPosition(Guard.Flatten(ex.Message));
+            return (null, $"{origin} could not be parsed{at}{element}: {msg} " +
+                          $"Expected a JSON ARRAY of {shape} elements.{ElementVocabularyHint(msg)}");
         }
         if (items is null) return (null, $"{origin} parsed to JSON null — expected a JSON array of {shape} elements.");
         if (items.Length == 0) return (null, $"{param} is an empty array — give at least one {shape}.");
@@ -310,6 +311,30 @@ public static class ApplyTools
             return (null, $"{param}: '{path}' is empty. Expected a JSON array.");
         return (text, null);
     }
+
+    /// <summary>The §5.3 vocabulary correction for a rejected OP-ELEMENT member. The alias layer rewrites TOP-LEVEL
+    /// arguments only (<see cref="ToolCallShim"/> works off the published schema, and an op's members are inside a
+    /// list value), so a caller carrying 1.x habits — <c>verb</c>, <c>from_plugin</c> — gets the strict reader's
+    /// unmapped-member refusal with no way to learn the new word. That refusal is correct and stays; this appends
+    /// the one-hop correction to it. Deliberately narrow: only the spellings this tool actually renamed, matched off
+    /// the property name STJ already quoted, so it can never invent a member the shape doesn't declare.</summary>
+    static string ElementVocabularyHint(string stjMessage)
+    {
+        foreach (var (old, correction) in ElementRenames)
+            if (stjMessage.Contains($"'{old}'", StringComparison.Ordinal))
+                return $" ('{old}' was the 1.x spelling — {correction})";
+        return "";
+    }
+
+    static readonly (string Old, string Correction)[] ElementRenames =
+    {
+        ("verb", "the verb member is now op, one verb-name across the whole surface: op=\"Add\""),
+        ("from_plugin", "it split in two: from_source names the PLUGIN to copy from, from names a different source RECORD"),
+        ("fromplugin", "it split in two: from_source names the PLUGIN to copy from, from names a different source RECORD"),
+        ("target_formid", "a copy's destination record is the assignments= zip's target="),
+        ("source_formid", "a copy's source record is the assignments= zip's from= (or an op's from=)"),
+        ("source_plugin", "a copy's source pole is from_source="),
+    };
 
     /// <summary>STJ appends its own position block (" Path: $[0].x | LineNumber: 0 | BytePositionInLine: 89.") to a
     /// JsonException message — 0-based, contradicting the 1-based position the refusal already leads with. Shear it.</summary>

--- a/src/housecarl-mcp/ApplyTools.cs
+++ b/src/housecarl-mcp/ApplyTools.cs
@@ -1,0 +1,449 @@
+using System.ComponentModel;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ModelContextProtocol.Server;
+
+namespace HousecarlMcp;
+
+/// <summary>
+/// housecarl_apply — the 2.0 S1 field-write surface (tool-surface-2.0 W3; SPEC §2.2 ACT, §4.5, §5.1/§5.2, §6.1).
+///
+/// ONE field-edit tool: the ACT verbs (Set / Add / Remove / SetAtIndex / ReplaceAll / Merge / CopyFrom) × the LANE
+/// (new patch | <c>into</c> an existing one | <c>in_place</c> + consent | <c>dry_run</c>) × TRANSPORT, over the SAME
+/// proven write cleave the 1.x tools drive (<see cref="LoadOrderService.ApplyEdits"/> → WritePatchBuilder.Apply) —
+/// consolidation of the surface, not a re-implementation of the engine. Absorbs <c>housecarl_set_field</c> (the
+/// degenerate one-op call) and <c>housecarl_bulk_apply</c>.
+///
+/// Three things are new rather than renamed:
+/// <list type="bullet">
+/// <item><b>The §4.5 zip</b> — <c>bundle=</c> (field paths, uniform across pairs) × <c>assignments=</c>
+/// ([{target, from, from_source}]) is a cross-RECORD field-bundle copy, the generic core under
+/// "give this record that record's Keywords/stats/appearance frame". Which paths form a bundle is skill-carried
+/// data; the tool stays generic (CLAUDE.md §3, second cornerstone).</item>
+/// <item><b>One list spelling</b> — <c>ops=</c> takes the inline array OR <c>"@&lt;absolute path&gt;"</c>
+/// (SPEC §5.1's @file convention), retiring <c>from_file=</c> and its inline-vs-file mutual exclusion. Both lanes
+/// now parse through the SAME strict reader, so an unknown member is refused BY NAME inline too — the SDK binder
+/// silently DROPS one, which in a 700-op job points every downstream refusal away from the typo.</item>
+/// <item><b>in_place is the file's NAME</b> (§5.2) — the <c>target=</c>+<c>in_place=true</c> pair collapses into one
+/// string naming the file being overwritten. Restating it is deliberate consent-adjacent explicitness.</item>
+/// </list>
+/// The 1.x write tools stay registered and unchanged through the build waves; they retire at 2.0.0 (clean cut,
+/// CHARTER_PHASE4 §3.4a).
+/// </summary>
+[McpServerToolType]
+public static class ApplyTools
+{
+    [McpServerTool(Name = "housecarl_apply", Title = "Edit record fields (the 2.0 write surface)"),
+     Description(
+         "Edit fields on one or many records and write the result to a NEW patch plugin (originals untouched by " +
+         "default). ONE surface: what to change (ops=, or the bundle=/assignments= copy zip) x WHERE it lands (the " +
+         "LANE: a new patch | into= an existing one | in_place=\"X.esp\" | dry_run) x how it reads back (TRANSPORT).\n\n" +
+         "A FormID is 'XXXXXX:Plugin.esp' — 6 hex digits, a colon, the defining master's filename. Every edit " +
+         "resolves the record's load-order WINNER and overrides it into the patch; all edits land in ONE reviewable " +
+         ".esp, whose master header spans every plugin the edits reference (cross-master merge, derived not declared).\n\n" +
+         "OPS. ops= is the edit list — {formid, field_path, op?, value?, values?, key?, entries?, compose?, " +
+         "composes?, from?, from_source?} each; one op is a set of one (the old set_field call). field_path is " +
+         "dotted ('BasicStats.Damage', 'Name', 'Keywords'); step INTO a list/dict element MID-path with brackets " +
+         "('Effects[0].Data.Magnitude'), but at the LEAF use op + key instead of brackets. value is coerced to the " +
+         "field's real type — a number, an enum name ('OneHanded'), or a FormID for a reference.\n" +
+         "op is Set (default) | Add | Remove | SetAtIndex | ReplaceAll | Merge | CopyFrom. On a [Flags] enum (SPEL " +
+         "Flags, NPC Configuration.Flags, WEAP Data.Flags...) Add SETS a bit and Remove CLEARS one, leaving the " +
+         "OTHER bits untouched — the way to flip one flag WITHOUT a Set silently dropping every bit you didn't " +
+         "mention; to turn all bits off, Set the field to '0'. Omit value only for a Remove that whole-clears a " +
+         "NULLABLE field. values= is the whole new list for a list ReplaceAll; entries= (key->value) drives a dict " +
+         "Merge or dict ReplaceAll; key= is the dict key or list index at the leaf.\n" +
+         "compose= builds a MODELED struct for an Add or a polymorphic Set — a leveled-list entry, an effect, a " +
+         "condition row, or a polymorphic list element by its CONCRETE arm type (e.g. a VMAD script property: " +
+         "op=Add, field_path='VirtualMachineAdapter.Scripts[0].Properties', compose={type:'ScriptObjectProperty', " +
+         "fields:{Name:'MyProp', Flags:'Edited', Object:'XXXXXX:Plugin.esp', Alias:'-1'}}). Merging a weapon into a " +
+         "leveled list: op=Add, field_path='Entries', compose={type:'LeveledItemEntry', sets:[{path:'Data.Level'," +
+         "value:'1'},{path:'Data.Count',value:'1'},{path:'Data.Reference',value:'<weapon FormID>'}]}. composes= is " +
+         "the BATCH sibling — a LIST built in ONE op: with Add it APPENDS each in order (a whole block of condition " +
+         "rows at once), with ReplaceAll it CLEARS the list then appends each (the way to replace a whole modeled " +
+         "list); composes=[] with ReplaceAll clears the list to empty. compose and composes are mutually exclusive.\n" +
+         "COPYING A FIELD: op=CopyFrom takes no value — the source IS another record's version. from_source= names " +
+         "the plugin to copy from (an ACTIVE plugin, or a plugin FILE on disk that isn't in the load order — a " +
+         "disabled old patch you want to re-assert a field from). from= names a DIFFERENT source RECORD (defaulting " +
+         "to from_source's version of the record being edited); with from= and no from_source= the source is that " +
+         "record's load-order winner. Cross-record pairs must be the SAME record type — refused by name otherwise. " +
+         "CopyFrom copies a WHOLE field (scalar, formlink, modeled list, sub-struct); it cannot copy owned child " +
+         "records (forward the whole record with housecarl_forward_record instead).\n\n" +
+         "THE COPY ZIP (bundle= x assignments=). To copy the SAME set of fields from one record to another — many " +
+         "pairs in one call — name the paths once and pair them explicitly: bundle=[\"BasicStats.Damage\"," +
+         "\"Keywords\"], assignments=[{target:'AAA:Mod.esp', from:'BBB:Other.esp'}, {target:..., from:..., " +
+         "from_source:'OldPatch.esp'}]. It is a ZIP, never a product: each target takes its OWN source. Identity and " +
+         "everything outside the bundle are untouched BY CONSTRUCTION — a bundle only names what it copies. Which " +
+         "paths form an appearance set or a balance frame is knowledge a skill carries, not a verb this tool owns. " +
+         "The zip composes with ops= in one call.\n\n" +
+         "LANE — where the write lands. Default: a NEW patch named patch= (auto-suffixed if taken, so a prior patch " +
+         "is never overwritten). into='<an existing patch's filename>' EXTENDS that patch instead — the way to " +
+         "accumulate across calls and sessions. PRECEDENCE with into= (pinned): a FormKey the patch ALREADY CARRIES " +
+         "is edited AS-IS in the patch; only a FormKey it does NOT yet carry copies the load-order winner in first. " +
+         "So housecarl_forward_record from a source + apply into= the same patch is THE recipe to build on a " +
+         "specific plugin's version while a stale winner sits above it. in_place='<plugin filename>' is the opt-in " +
+         "THIRD lane: houseCARL rewrites your ORIGINAL file (incl. a mod it didn't author) — no new patch, and NO " +
+         "houseCARL backup or undo (keep your own). It re-lays-out the whole plugin the way xEdit/CK do on save, " +
+         "VERIFIES the records you edit, trusts Mutagen for the untouched rest, and refuses a file it can't parse or " +
+         "that holds engine-reserved (sub-0x800) records. The FIRST in-place edit of a given plugin returns a " +
+         "one-time confirmation prompt (re-call with acknowledge=true); that consent covers touching your original " +
+         "ONLY — it NEVER skips the record verify.\n" +
+         "dry_run=true runs the FULL pipeline — winner resolve, schema pre-flight, every op applied in memory, the " +
+         "reference-resolution check — and STOPS before anything touches disk. It returns what WOULD change and the " +
+         "expected masters, or EXACTLY the refusal the real call would give: catch a bad field path before the first " +
+         "write of a big batch, not after the last. Works on every lane (an in-place dry run needs no acknowledge " +
+         "and never records consent). Not a disk guarantee — a serialize/commit fault still surfaces only for real.\n\n" +
+         "ALL-OR-NOTHING (Q3): if ANY op is malformed or fails pre-flight, the whole call is refused with per-op " +
+         "reasons and NOTHING is written. No partial patches, ever.\n\n" +
+         "TRANSPORT: readback=true expands the read-back to the FULL deep field-by-field dump of every touched " +
+         "record (in place, the verify ALWAYS runs and shows compactly by default; readback widens it) — confirm " +
+         "composed structures landed and nothing else was disturbed WITHOUT enabling the patch in MO2. The read-back " +
+         "is the WRITTEN FILE's content, NOT load-order truth: the patch wins nothing until enabled + sorted in MO2. " +
+         "format='json' returns the same data machine-readable; max_chars caps the render with an explicit notice, " +
+         "never a silent cut. Every response carries epoch=<hex> — the identity of the index build the winners were " +
+         "resolved from.\n\n" +
+         "ops= (like every list-valued input) also accepts \"@<absolute path>\" in place of the inline array: the " +
+         "SAME array as a JSON manifest on disk. Write a big job's ops once, dry-run the file, then apply it — and " +
+         "re-run the same manifest to recover an interrupted write (overrides are idempotent). The path must be " +
+         "ABSOLUTE (the server resolves relative paths against its OWN working directory, not yours), and the file " +
+         "is read at CALL time, so re-dry-run it after editing.\n\n" +
+         "This tool edits EXISTING records' fields. New records are housecarl_create_record / housecarl_bulk_create; " +
+         "dropping a whole record is housecarl_remove_record; copying a whole record verbatim is " +
+         "housecarl_forward_record. Read first with housecarl_records.")]
+    public static string Apply(
+        LoadOrderService svc,
+        [Description("The edits, all into one artifact: [{formid, field_path, op?, value?, values?, key?, entries?, compose?, composes?, from?, from_source?}, …] — or \"@<absolute path>\" to read that SAME array from a JSON manifest file. One op is a set of one. An op member the shape does not declare is refused BY NAME at its element, never silently dropped.")]
+            JsonElement? ops = null,
+        [Description("THE COPY ZIP (with assignments=): the field paths copied for EVERY pair, e.g. [\"BasicStats.Damage\", \"Keywords\"]. Accepts [\"@<absolute path>\"] to read the path list from a file. Only what this names is copied — identity and every other field are untouched by construction.")]
+            string[]? bundle = null,
+        [Description("THE COPY ZIP (with bundle=): the per-target source mapping — [{target: 'XXXXXX:Plugin.esp', from: 'YYYYYY:Other.esp', from_source?: 'SomePlugin.esp'}, …], or \"@<absolute path>\". A ZIP, never a product: each target takes its OWN source record. from_source defaults to the source record's load-order winner; target and from must be the SAME record type.")]
+            JsonElement? assignments = null,
+        [Description("LANE: base filename for the NEW patch this call writes (default 'Patch'); auto-suffixed if taken, so a prior patch is never overwritten. Mutually exclusive with into= and in_place= — naming both lanes is refused, never silently ignored.")]
+            string? patch = null,
+        [Description("LANE: filename of an EXISTING houseCARL patch to EXTEND with these edits instead of writing a fresh one — the way to accumulate across calls and sessions. Found by the plugin's filename even if you've renamed its MO2 mod folder; for two patches sharing a filename, pass the mod-folder name here instead.")]
+            string? into = null,
+        [Description("LANE (opt-in): the FILENAME OF THE FILE BEING OVERWRITTEN, e.g. \"CoolWeapons.esp\" — edit that existing active plugin IN PLACE (incl. one houseCARL didn't author) instead of writing a patch. Your ORIGINAL file is rewritten; no houseCARL backup or undo. Naming the file is the point: it is what you are about to overwrite. OMIT for the default patch lane, which leaves every original untouched.")]
+            string? in_place = null,
+        [Description("Confirms the one-time in-place trade-off for the plugin named by in_place= — needed only on the FIRST in-place write to a given plugin, never again for it. Waives the consent to touch your original ONLY; it NEVER skips the record verify. Meaningless without in_place=, and refused there rather than ignored.")]
+            bool acknowledge = false,
+        [Description("DRY RUN: run the whole real pipeline and STOP before anything touches disk. Returns what WOULD change (the would-be values, the expected masters), or EXACTLY the refusal the real call would give. Works on every lane.")]
+            bool dry_run = false,
+        [Description("TRANSPORT: expand the read-back to the FULL deep field-by-field dump of every record this call touched (not just the edited leaves). The written file's content, not load-order truth.")]
+            bool readback = false,
+        [Description("TRANSPORT: 'text' (default) | 'json' (the same data, machine-readable, accounting in-band).")]
+            string? format = null,
+        [Description("TRANSPORT: character ceiling on the render; past it the read-back is cut with an explicit notice (never silent). 0 = a safe default kept under the host's per-response limit; raise it to widen a readback=true dump.")]
+            int max_chars = 0) => Guard.Tool("housecarl_apply", () =>
+    {
+        if (svc.ConfigPromptOrNull() is { } prompt) return prompt;
+
+        // ---- TRANSPORT: format --------------------------------------------------------------------------
+        bool json = Wire.WantsJson(format, out var ferr);
+        if (ferr is not null) return ferr;
+
+        // ---- LANE: the three destinations are mutually exclusive, and a dropped one is named ------------
+        // (SPEC §2.1 LANE; the W2 review's recurring theme carried to the write side — a parameter is honored
+        //  or refused BY NAME, never accepted-and-ignored. 1.x silently ignored patch_name= under into=.)
+        bool hasPatch = !string.IsNullOrWhiteSpace(patch);
+        bool hasInto = !string.IsNullOrWhiteSpace(into);
+        bool hasInPlace = !string.IsNullOrWhiteSpace(in_place);
+        if (hasInto && hasInPlace)
+            return "error: into= and in_place= are different lanes — into= EXTENDS a houseCARL patch, in_place= rewrites an existing plugin's own file. Name one.";
+        if (hasPatch && hasInto)
+            return $"error: patch='{patch}' names a NEW patch to write, but into='{into}' extends an existing one — the two lanes are exclusive. Drop patch= to extend, or drop into= to write fresh.";
+        if (hasPatch && hasInPlace)
+            return $"error: patch='{patch}' names a NEW patch to write, but in_place='{in_place}' rewrites that plugin's own file — the two lanes are exclusive. Drop patch= to edit in place, or drop in_place= to write a patch.";
+        if (acknowledge && !hasInPlace)
+            return "error: acknowledge= confirms the in-place trade-off and is meaningless without in_place=<plugin filename>. Drop it, or name the file to overwrite.";
+
+        // ---- The edit sources: ops= and/or the §4.5 zip -------------------------------------------------
+        var edits = new List<ApplyOp>();
+        if (ops is { } opsEl && opsEl.ValueKind is not JsonValueKind.Null)
+        {
+            var (parsed, err) = ReadOps(opsEl);
+            if (err is not null) return "error: " + err;
+            edits.AddRange(parsed!);
+        }
+
+        bool hasBundle = bundle is { Length: > 0 };
+        bool hasAssignments = assignments is { } aEl && aEl.ValueKind is not JsonValueKind.Null;
+        if (hasBundle != hasAssignments)
+            return hasBundle
+                ? "error: bundle= names the field paths to copy but assignments= names the target/source PAIRS — the zip needs both. Add assignments=[{target, from}, …], or use ops= for edits that aren't a copy."
+                : "error: assignments= names the target/source PAIRS but bundle= names the field paths to copy — the zip needs both. Add bundle=[\"<field path>\", …].";
+        if (hasBundle)
+        {
+            var (paths, perr) = ReadBundlePaths(bundle!);
+            if (perr is not null) return "error: " + perr;
+            var (zipped, zerr) = ExpandZip(paths!, assignments!.Value);
+            if (zerr is not null) return "error: " + zerr;
+            edits.AddRange(zipped!);
+        }
+
+        if (edits.Count == 0)
+            return "error: nothing to apply. Pass ops=[{formid, field_path, …}, …] (or ops=\"@<absolute path>\"), " +
+                   "and/or the copy zip bundle=[\"<field path>\", …] + assignments=[{target, from}, …].";
+
+        // ---- Map the 2.0 op shape onto the proven cleave ------------------------------------------------
+        // The 2.0 spellings are a RENAME over the same engine inputs: op -> verb, from_source -> the source
+        // plugin, from -> the source RECORD (§4.5's cross-record copy, carried alongside since it has no 1.x
+        // wire member). Mapping problems are collected per element, all at once, like every other refusal.
+        var wire = new List<BulkOp>(edits.Count);
+        var fromRecords = new List<string?>(edits.Count);
+        var problems = new List<string>();
+        for (int i = 0; i < edits.Count; i++)
+        {
+            var e = edits[i];
+            if (e.From is not null && !string.Equals(e.Op ?? "Set", "CopyFrom", StringComparison.OrdinalIgnoreCase))
+            {
+                problems.Add($"op[{i}]: from= names the SOURCE RECORD of a copy and is only valid with op='CopyFrom' (got op='{e.Op ?? "Set"}').");
+                continue;
+            }
+            wire.Add(new BulkOp
+            {
+                Formid = e.Formid, FieldPath = e.FieldPath, Verb = e.Op ?? "Set", Value = e.Value, Key = e.Key,
+                Values = e.Values, Entries = e.Entries, Compose = e.Compose, Composes = e.Composes,
+                FromPlugin = e.FromSource,
+            });
+            fromRecords.Add(e.From);
+        }
+        if (problems.Count > 0)
+            return $"error: refused — {problems.Count} of {edits.Count} operation(s) malformed; NOTHING written:\n  - "
+                 + string.Join("\n  - ", problems);
+
+        var outcome = svc.ApplyEdits(wire, patch ?? "Patch", into, readback, in_place, hasInPlace, acknowledge, dry_run, fromRecords);
+        return json
+            ? JsonWire.RenderPatchOutcome(outcome, max_chars, readback)
+            : WriteTools.Render(outcome, max_chars, readback);
+    });
+
+    // ---- input readers -------------------------------------------------------------------------------
+
+    /// <summary>Read <c>ops=</c>: either the inline JSON array of op objects, or the SPEC §5.1 <c>@file</c> spelling
+    /// — a bare <c>"@&lt;path&gt;"</c> string, or the one-element <c>["@&lt;path&gt;"]</c> form that matches how
+    /// <c>formids=</c> spells it (both accepted so the convention reads the same on a typed list and a string list).
+    /// BOTH lanes deserialize through the same strict options, so an unknown member is refused by name inline too —
+    /// the SDK's own binder silently drops one, and in a large generated batch a misspelled <c>field_path</c> would
+    /// then surface as a downstream refusal pointing away from the typo.</summary>
+    static (ApplyOp[]? Items, string? Error) ReadOps(JsonElement el)
+        => ReadListParam<ApplyOp>(el, "ops", "{formid, field_path, op?, value?, values?, key?, entries?, compose?, composes?, from?, from_source?}");
+
+    /// <summary>Read <c>assignments=</c> — the §4.5 zip's per-target source mapping. Same two spellings and the same
+    /// strict element contract as <see cref="ReadOps"/>.</summary>
+    static (Assignment[]? Items, string? Error) ReadAssignments(JsonElement el)
+        => ReadListParam<Assignment>(el, "assignments", "{target, from, from_source?}");
+
+    /// <summary>The shared list-parameter reader behind every 2.0 typed list input: inline array | "@path" |
+    /// ["@path"]. One implementation so the @file convention cannot drift between parameters, and so every failure
+    /// (unreadable, not JSON, not an array, empty, a null element, an undeclared member) names itself and its
+    /// element (Q3).</summary>
+    static (T[]? Items, string? Error) ReadListParam<T>(JsonElement el, string param, string shape)
+    {
+        string json;
+        string origin;
+        if (el.ValueKind is JsonValueKind.String)
+        {
+            var (text, err) = ReadAtFile(el.GetString(), param);
+            if (err is not null) return (null, err);
+            json = text!; origin = $"the file named by {param}";
+        }
+        else if (el.ValueKind is JsonValueKind.Array)
+        {
+            // The one-element ["@path"] spelling — the same shape formids= uses. An @-string anywhere else in the
+            // array is a mixed inline/file list, which has no meaning: refuse it by name rather than half-honor it.
+            var atIndexes = new List<int>();
+            int count = 0;
+            foreach (var item in el.EnumerateArray())
+            {
+                if (item.ValueKind is JsonValueKind.String && item.GetString()?.TrimStart().StartsWith('@') == true)
+                    atIndexes.Add(count);
+                count++;
+            }
+            if (atIndexes.Count > 0)
+            {
+                if (count != 1)
+                    return (null, $"{param}: \"@<path>\" reads the WHOLE list from a file, so it cannot be mixed with inline elements " +
+                                  $"(found {atIndexes.Count} @-element(s) among {count}). Pass either the inline array or a single \"@<absolute path>\".");
+                var (text, err) = ReadAtFile(el[0].GetString(), param);
+                if (err is not null) return (null, err);
+                json = text!; origin = $"the file named by {param}";
+            }
+            else { json = el.GetRawText(); origin = param; }
+        }
+        else
+            return (null, $"{param} must be an ARRAY of {shape} elements, or \"@<absolute path>\" naming a JSON file holding that array (got {el.ValueKind}).");
+
+        T[]? items;
+        try { items = JsonSerializer.Deserialize<T[]>(json, StrictList); }
+        catch (JsonException ex)
+        {
+            // "byte N in the line", not "column": BytePositionInLine is a UTF-8 byte offset, which skews from the
+            // visual column on a non-ASCII line. STJ appends its own 0-based position block to the message, which
+            // would contradict the 1-based position stated here — shear it; the element path is surfaced separately.
+            string at = ex.LineNumber is { } ln ? $" at line {ln + 1}, byte {(ex.BytePositionInLine ?? 0) + 1} in the line" : "";
+            string element = ex.Path is { Length: > 2 } p ? $" (element {p})" : "";
+            return (null, $"{origin} could not be parsed{at}{element}: {ShearStjPosition(Guard.Flatten(ex.Message))} " +
+                          $"Expected a JSON ARRAY of {shape} elements.");
+        }
+        if (items is null) return (null, $"{origin} parsed to JSON null — expected a JSON array of {shape} elements.");
+        if (items.Length == 0) return (null, $"{param} is an empty array — give at least one {shape}.");
+        for (int i = 0; i < items.Length; i++)
+            if (items[i] is null) return (null, $"{param}: element [{i}] is null — every element must be an object.");
+        return (items, null);
+    }
+
+    /// <summary>Read a list-input's <c>@&lt;path&gt;</c> target off disk. Absolute-path-only, for the reason the
+    /// message states: the server's working directory is not the caller's, so a relative path silently resolves
+    /// somewhere neither of them meant.</summary>
+    static (string? Text, string? Error) ReadAtFile(string? spelling, string param)
+    {
+        var raw = spelling?.Trim().Trim('"', '\'') ?? "";
+        var path = raw.StartsWith('@') ? raw[1..].Trim() : raw;
+        if (path.Length == 0)
+            return (null, $"{param}: \"@\" names no file — give the manifest's absolute path, e.g. \"@C:\\\\jobs\\\\ops.json\".");
+        if (!Path.IsPathRooted(path))
+            return (null, $"{param}: '{path}' must be an ABSOLUTE path — the server resolves relative paths against its OWN working directory, not yours.");
+        string text;
+        try { text = File.ReadAllText(path); }
+        catch (Exception ex) { return (null, $"{param}: could not read '{path}' — {ex.GetType().Name}: {ex.Message}"); }
+        if (string.IsNullOrWhiteSpace(text))
+            return (null, $"{param}: '{path}' is empty. Expected a JSON array.");
+        return (text, null);
+    }
+
+    /// <summary>STJ appends its own position block (" Path: $[0].x | LineNumber: 0 | BytePositionInLine: 89.") to a
+    /// JsonException message — 0-based, contradicting the 1-based position the refusal already leads with. Shear it.</summary>
+    static string ShearStjPosition(string msg)
+    {
+        int i = msg.IndexOf(" Path: ", StringComparison.Ordinal);
+        return i < 0 ? msg : msg[..i].TrimEnd();
+    }
+
+    /// <summary>Strict list-element options: property names case-insensitive like the SDK's inline binder, comments +
+    /// trailing commas tolerated (hand-generated files), and an undeclared member REFUSED by name.</summary>
+    static readonly JsonSerializerOptions StrictList = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+    };
+
+    // ---- the §4.5 zip --------------------------------------------------------------------------------
+
+    /// <summary>Resolve <c>bundle=</c> to its field-path list, honoring the <c>["@&lt;path&gt;"]</c> spelling (a
+    /// newline/comma-free JSON string array on disk) so a long, reused bundle can live in a file like any other
+    /// list input.</summary>
+    static (IReadOnlyList<string>? Paths, string? Error) ReadBundlePaths(string[] bundle)
+    {
+        if (bundle.Length == 1 && bundle[0]?.TrimStart().StartsWith('@') == true)
+        {
+            var (text, err) = ReadAtFile(bundle[0], "bundle");
+            if (err is not null) return (null, err);
+            string[]? paths;
+            try { paths = JsonSerializer.Deserialize<string[]>(text!, StrictList); }
+            catch (JsonException ex) { return (null, $"the file named by bundle could not be parsed: {ShearStjPosition(Guard.Flatten(ex.Message))} Expected a JSON array of field-path strings."); }
+            if (paths is null || paths.Length == 0) return (null, "the file named by bundle holds no field paths — expected a JSON array of dotted field paths.");
+            bundle = paths;
+        }
+        var clean = new List<string>(bundle.Length);
+        for (int i = 0; i < bundle.Length; i++)
+        {
+            var p = bundle[i]?.Trim();
+            if (string.IsNullOrEmpty(p))
+                return (null, $"bundle[{i}] is empty — every entry is a dotted field path to copy (e.g. \"BasicStats.Damage\").");
+            clean.Add(p);
+        }
+        return (clean, null);
+    }
+
+    /// <summary>Expand the §4.5 zip into ops: for each assignment, ONE CopyFrom op per bundle path. A zip, never a
+    /// product — each target reads its OWN paired source record, so N targets x M paths is N*M ops over N sources,
+    /// not N*N. Every pair is validated here (both FormIDs present and well-formed); the same-record-type gate and
+    /// the per-path legality rulebook run at the engine's pre-flight, which reports EVERY failure at once before
+    /// anything is written (§4.5: "legality does not shrink").</summary>
+    static (IReadOnlyList<ApplyOp>? Ops, string? Error) ExpandZip(IReadOnlyList<string> paths, JsonElement assignments)
+    {
+        var (pairs, err) = ReadAssignments(assignments);
+        if (err is not null) return (null, err);
+
+        var problems = new List<string>();
+        var ops = new List<ApplyOp>(pairs!.Length * paths.Count);
+        for (int i = 0; i < pairs.Length; i++)
+        {
+            var a = pairs[i];
+            if (string.IsNullOrWhiteSpace(a.Target))
+                { problems.Add($"assignments[{i}]: target is required — the FormID of the record being written."); continue; }
+            if (string.IsNullOrWhiteSpace(a.From))
+                { problems.Add($"assignments[{i}] ({a.Target}): from is required — the FormID of the record to copy the bundle FROM."); continue; }
+            if (string.Equals(a.Target!.Trim(), a.From!.Trim(), StringComparison.OrdinalIgnoreCase))
+                { problems.Add($"assignments[{i}]: target and from are the same record ({a.Target}) — copying a record's fields onto itself is a no-op. To re-assert an EARLIER PLUGIN's version of this record's fields, keep from= off and name that plugin in from_source=."); continue; }
+            foreach (var p in paths)
+                ops.Add(new ApplyOp
+                {
+                    Formid = a.Target, FieldPath = p, Op = "CopyFrom",
+                    From = a.From, FromSource = a.FromSource,
+                });
+        }
+        return problems.Count > 0
+            ? (null, $"refused — {problems.Count} of {pairs.Length} assignment(s) malformed; NOTHING written:\n  - " + string.Join("\n  - ", problems))
+            : (ops, null);
+    }
+}
+
+// ---- wire DTOs (the 2.0 op + zip shapes) ---------------------------------------------------------------
+
+/// <summary>One field edit off the 2.0 wire (housecarl_apply). The 1.x <see cref="BulkOp"/> with the SPEC §5.1
+/// vocabulary — <c>verb</c> is <c>op</c> (one verb-name across substrates), <c>from_plugin</c> splits into the
+/// §4.5 pair <c>from</c> (the source RECORD) + <c>from_source</c> (the pole it is read from). Its own record rather
+/// than a reshaped BulkOp so the 1.x tools' published schemas stay untouched through the build waves.</summary>
+public sealed record ApplyOp
+{
+    [JsonPropertyName("formid"), Description("The record to edit, as 'XXXXXX:Plugin.esp'.")]
+    public string? Formid { get; init; }
+
+    [JsonPropertyName("field_path"), Description("Dotted field path, e.g. 'BasicStats.Damage' or 'Entries'. Step into a list/dict element mid-path with brackets ('Effects[0].Data.Magnitude'); at the LEAF use op + key, not brackets.")]
+    public string? FieldPath { get; init; }
+
+    [JsonPropertyName("op"), Description("Set (default) | Add | Remove | SetAtIndex | ReplaceAll | Merge | CopyFrom. On a [Flags] enum, Add sets one bit and Remove clears one, leaving the others untouched.")]
+    public string? Op { get; init; }
+
+    [JsonPropertyName("value"), Description("The value, coerced to the field's type. Omit for Remove / ReplaceAll / Merge / compose / CopyFrom.")]
+    public string? Value { get; init; }
+
+    [JsonPropertyName("key"), Description("Dict key or list index at the leaf.")]
+    public string? Key { get; init; }
+
+    [JsonPropertyName("values"), Description("The whole new list for a list ReplaceAll.")]
+    public string[]? Values { get; init; }
+
+    [JsonPropertyName("entries"), Description("Key->value pairs for a dict Merge or dict ReplaceAll.")]
+    public Dictionary<string, string>? Entries { get; init; }
+
+    [JsonPropertyName("compose"), Description("Build a modeled struct: the arm for a polymorphic Set, or the element for a struct-element Add (e.g. 'LeveledItemEntry'; for a polymorphic list, the element's CONCRETE arm type such as 'ScriptObjectProperty').")]
+    public StructInput? Compose { get; init; }
+
+    [JsonPropertyName("composes"), Description("Build MANY modeled list elements in ONE op — the batch sibling of compose. With Add, appends each in order; with ReplaceAll, clears the list then appends each (composes=[] with ReplaceAll clears it to empty). Mutually exclusive with compose/value/values.")]
+    public StructInput[]? Composes { get; init; }
+
+    [JsonPropertyName("from"), Description("op='CopyFrom' only: the SOURCE RECORD to copy the field from, as 'XXXXXX:Plugin.esp' — a DIFFERENT record from formid (SPEC §4.5's cross-record copy). Omit to copy this same record's version from another plugin (name it in from_source). Source and target must be the same record type.")]
+    public string? From { get; init; }
+
+    [JsonPropertyName("from_source"), Description("op='CopyFrom' only: WHOSE version of the source record to copy — an ACTIVE plugin, or a plugin FILE on disk that isn't in the load order (a disabled old patch). With from= it defaults to the source record's load-order winner; without from= it is required (there is no other source to name).")]
+    public string? FromSource { get; init; }
+}
+
+/// <summary>One pair of the SPEC §4.5 <c>assignments=</c> zip: the record being written, the record its bundle is
+/// copied FROM, and optionally the pole that source is read at. Explicit pairing is the whole point — a join here
+/// is a ZIP, never a product, so N targets never silently fan out to N*N copies.</summary>
+public sealed record Assignment
+{
+    [JsonPropertyName("target"), Description("The record being WRITTEN, as 'XXXXXX:Plugin.esp' — the §5.2 meaning of the bare word 'target': a copy's destination record.")]
+    public string? Target { get; init; }
+
+    [JsonPropertyName("from"), Description("The record the bundle is copied FROM, as 'XXXXXX:Plugin.esp'. Must be the same record type as target.")]
+    public string? From { get; init; }
+
+    [JsonPropertyName("from_source"), Description("Optional. WHOSE version of the source record to read — a plugin filename (active, or a file on disk out of the load order). Defaults to the source record's load-order winner.")]
+    public string? FromSource { get; init; }
+}

--- a/src/housecarl-mcp/ApplyTools.cs
+++ b/src/housecarl-mcp/ApplyTools.cs
@@ -190,13 +190,18 @@ public static class ApplyTools
         // wire member). Mapping problems are collected per element, all at once, like every other refusal.
         var wire = new List<BulkOp>(edits.Count);
         var fromRecords = new List<string?>(edits.Count);
+        var origins = new List<string?>(edits.Count);
         var problems = new List<string>();
         for (int i = 0; i < edits.Count; i++)
         {
             var e = edits[i];
+            // Zip-generated edits carry the caller's OWN spelling (assignments[i] x bundle[j]); inline ops fall
+            // back to their real index. Both this loop and the service's mapper use it, so a refusal never points
+            // at an op index the caller did not write.
+            var where = e.Origin ?? $"op[{i}]";
             if (e.From is not null && !string.Equals(e.Op ?? "Set", "CopyFrom", StringComparison.OrdinalIgnoreCase))
             {
-                problems.Add($"op[{i}]: from= names the SOURCE RECORD of a copy and is only valid with op='CopyFrom' (got op='{e.Op ?? "Set"}').");
+                problems.Add($"{where}: from= names the SOURCE RECORD of a copy and is only valid with op='CopyFrom' (got op='{e.Op ?? "Set"}').");
                 continue;
             }
             wire.Add(new BulkOp
@@ -206,12 +211,13 @@ public static class ApplyTools
                 FromPlugin = e.FromSource,
             });
             fromRecords.Add(e.From);
+            origins.Add(e.Origin);
         }
         if (problems.Count > 0)
             return $"error: refused — {problems.Count} of {edits.Count} operation(s) malformed; NOTHING written:\n  - "
                  + string.Join("\n  - ", problems);
 
-        var outcome = svc.ApplyEdits(wire, patch ?? "Patch", into, readback, in_place, hasInPlace, acknowledge, dry_run, fromRecords);
+        var outcome = svc.ApplyEdits(wire, patch ?? "Patch", into, readback, in_place, hasInPlace, acknowledge, dry_run, fromRecords, origins);
         return json
             ? JsonWire.RenderPatchOutcome(outcome, max_chars, readback)
             : WriteTools.Render(outcome, max_chars, readback);
@@ -361,6 +367,14 @@ public static class ApplyTools
     /// list input.</summary>
     static (IReadOnlyList<string>? Paths, string? Error) ReadBundlePaths(string[] bundle)
     {
+        // A MIXED inline/@file list has no meaning here either — and it used to slip through, because the @file
+        // branch only fired at Length == 1: an "@path" sitting beside real paths became a literal dotted FIELD
+        // path, and the caller got an engine "no such field" refusal naming something they never meant as a field
+        // (review [low]). Named here with ReadListParam's wording, so all three list inputs answer alike.
+        int atCount = bundle.Count(b => b?.TrimStart().StartsWith('@') == true);
+        if (atCount > 0 && bundle.Length != 1)
+            return (null, $"bundle: \"@<path>\" reads the WHOLE list from a file, so it cannot be mixed with inline elements " +
+                          $"(found {atCount} @-element(s) among {bundle.Length}). Pass either the inline array of field paths or a single \"@<absolute path>\".");
         if (bundle.Length == 1 && bundle[0]?.TrimStart().StartsWith('@') == true)
         {
             var (text, err) = ReadAtFile(bundle[0], "bundle");
@@ -384,9 +398,11 @@ public static class ApplyTools
 
     /// <summary>Expand the §4.5 zip into ops: for each assignment, ONE CopyFrom op per bundle path. A zip, never a
     /// product — each target reads its OWN paired source record, so N targets x M paths is N*M ops over N sources,
-    /// not N*N. Every pair is validated here (both FormIDs present and well-formed); the same-record-type gate and
-    /// the per-path legality rulebook run at the engine's pre-flight, which reports EVERY failure at once before
-    /// anything is written (§4.5: "legality does not shrink").</summary>
+    /// not N*N. Pair-level shape is validated here (both halves present, and not the same record); FormID SYNTAX,
+    /// the same-record-type gate, and the per-path legality rulebook are the engine's pre-flight, which reports
+    /// EVERY failure at once before anything is written (§4.5: "legality does not shrink"). Each generated op
+    /// carries the caller's own spelling as its <see cref="ApplyOp.Origin"/>, so a downstream refusal names
+    /// <c>assignments[i] x bundle[j]</c> rather than an op index that exists only after this expansion.</summary>
     static (IReadOnlyList<ApplyOp>? Ops, string? Error) ExpandZip(IReadOnlyList<string> paths, JsonElement assignments)
     {
         var (pairs, err) = ReadAssignments(assignments);
@@ -403,11 +419,12 @@ public static class ApplyTools
                 { problems.Add($"assignments[{i}] ({a.Target}): from is required — the FormID of the record to copy the bundle FROM."); continue; }
             if (string.Equals(a.Target!.Trim(), a.From!.Trim(), StringComparison.OrdinalIgnoreCase))
                 { problems.Add($"assignments[{i}]: target and from are the same record ({a.Target}) — copying a record's fields onto itself is a no-op. To re-assert an EARLIER PLUGIN's version of this record's fields, keep from= off and name that plugin in from_source=."); continue; }
-            foreach (var p in paths)
+            for (int b = 0; b < paths.Count; b++)
                 ops.Add(new ApplyOp
                 {
-                    Formid = a.Target, FieldPath = p, Op = "CopyFrom",
+                    Formid = a.Target, FieldPath = paths[b], Op = "CopyFrom",
                     From = a.From, FromSource = a.FromSource,
+                    Origin = $"assignments[{i}] x bundle[{b}] ('{paths[b]}')",
                 });
         }
         return problems.Count > 0
@@ -456,6 +473,13 @@ public sealed record ApplyOp
 
     [JsonPropertyName("from_source"), Description("op='CopyFrom' only: WHOSE version of the source record to copy — an ACTIVE plugin, or a plugin FILE on disk that isn't in the load order (a disabled old patch). With from= it defaults to the source record's load-order winner; without from= it is required (there is no other source to name).")]
     public string? FromSource { get; init; }
+
+    /// <summary>NOT a wire member — never deserialized from a caller (<see cref="JsonIgnoreAttribute"/> keeps it out
+    /// of the published schema and out of the strict reader's member set). It is how an op the §4.5 zip GENERATED
+    /// remembers the caller's own spelling, so a refusal reads "assignments[0] x bundle[1]" instead of an op index
+    /// that only exists after expansion.</summary>
+    [JsonIgnore]
+    public string? Origin { get; init; }
 }
 
 /// <summary>One pair of the SPEC §4.5 <c>assignments=</c> zip: the record being written, the record its bundle is

--- a/src/housecarl-mcp/ApplyTools.cs
+++ b/src/housecarl-mcp/ApplyTools.cs
@@ -139,50 +139,65 @@ public static class ApplyTools
 
         // ---- TRANSPORT: format --------------------------------------------------------------------------
         bool json = Wire.WantsJson(format, out var ferr);
-        if (ferr is not null) return ferr;
+        if (ferr is not null) return ferr;   // the format value itself is unparsed — there is no known render to answer in
+
+        // EVERY refusal below this point answers in the caller's requested format. RenderPatchOutcome's contract
+        // says a json caller must never have to parse "error: …" out of a string, and the sites a caller hits most
+        // (a mixed inline/@file list, an undeclared op member, a LANE conflict, half a zip) are all decided HERE,
+        // before any engine outcome exists to render. Epoch is null on all of them: none has consulted a build yet.
+        string Refuse(string message) => json ? JsonWire.RenderError(message, null) : "error: " + message;
 
         // ---- LANE: the three destinations are mutually exclusive, and a dropped one is named ------------
         // (SPEC §2.1 LANE; the W2 review's recurring theme carried to the write side — a parameter is honored
         //  or refused BY NAME, never accepted-and-ignored. 1.x silently ignored patch_name= under into=.)
-        bool hasPatch = !string.IsNullOrWhiteSpace(patch);
+        // Emptiness is judged ONE way for a lane string: whitespace-only is absent, and the forwarded value uses
+        // the same rule (`patch` is normalized below), so the exclusivity checks and what actually gets written
+        // can never disagree about whether a lane was named.
+        var patchName = string.IsNullOrWhiteSpace(patch) ? null : patch.Trim();
+        bool hasPatch = patchName is not null;
         bool hasInto = !string.IsNullOrWhiteSpace(into);
         bool hasInPlace = !string.IsNullOrWhiteSpace(in_place);
         if (hasInto && hasInPlace)
-            return "error: into= and in_place= are different lanes — into= EXTENDS a houseCARL patch, in_place= rewrites an existing plugin's own file. Name one.";
+            return Refuse("into= and in_place= are different lanes — into= EXTENDS a houseCARL patch, in_place= rewrites an existing plugin's own file. Name one.");
         if (hasPatch && hasInto)
-            return $"error: patch='{patch}' names a NEW patch to write, but into='{into}' extends an existing one — the two lanes are exclusive. Drop patch= to extend, or drop into= to write fresh.";
+            return Refuse($"patch='{patch}' names a NEW patch to write, but into='{into}' extends an existing one — the two lanes are exclusive. Drop patch= to extend, or drop into= to write fresh.");
         if (hasPatch && hasInPlace)
-            return $"error: patch='{patch}' names a NEW patch to write, but in_place='{in_place}' rewrites that plugin's own file — the two lanes are exclusive. Drop patch= to edit in place, or drop in_place= to write a patch.";
+            return Refuse($"patch='{patch}' names a NEW patch to write, but in_place='{in_place}' rewrites that plugin's own file — the two lanes are exclusive. Drop patch= to edit in place, or drop in_place= to write a patch.");
         if (acknowledge && !hasInPlace)
-            return "error: acknowledge= confirms the in-place trade-off and is meaningless without in_place=<plugin filename>. Drop it, or name the file to overwrite.";
+            return Refuse("acknowledge= confirms the in-place trade-off and is meaningless without in_place=<plugin filename>. Drop it, or name the file to overwrite.");
 
         // ---- The edit sources: ops= and/or the §4.5 zip -------------------------------------------------
         var edits = new List<ApplyOp>();
         if (ops is { } opsEl && opsEl.ValueKind is not JsonValueKind.Null)
         {
             var (parsed, err) = ReadOps(opsEl);
-            if (err is not null) return "error: " + err;
+            if (err is not null) return Refuse(err);
             edits.AddRange(parsed!);
         }
 
-        bool hasBundle = bundle is { Length: > 0 };
+        // An explicitly EMPTY bundle= is a supplied parameter, not an absent one — reading it as absent is the
+        // accepted-and-silently-dropped class this tool exists to close, and it is exactly what `ops=[]` already
+        // refuses by name. Judge presence on the ARRAY, then refuse emptiness on its own terms.
+        bool hasBundle = bundle is not null;
         bool hasAssignments = assignments is { } aEl && aEl.ValueKind is not JsonValueKind.Null;
+        if (hasBundle && bundle!.Length == 0)
+            return Refuse("bundle= is an empty array — give at least one dotted field path to copy (e.g. bundle=[\"BasicStats.Damage\"]), or drop bundle= and assignments= entirely.");
         if (hasBundle != hasAssignments)
-            return hasBundle
-                ? "error: bundle= names the field paths to copy but assignments= names the target/source PAIRS — the zip needs both. Add assignments=[{target, from}, …], or use ops= for edits that aren't a copy."
-                : "error: assignments= names the target/source PAIRS but bundle= names the field paths to copy — the zip needs both. Add bundle=[\"<field path>\", …].";
+            return Refuse(hasBundle
+                ? "bundle= names the field paths to copy but assignments= names the target/source PAIRS — the zip needs both. Add assignments=[{target, from}, …], or use ops= for edits that aren't a copy."
+                : "assignments= names the target/source PAIRS but bundle= names the field paths to copy — the zip needs both. Add bundle=[\"<field path>\", …].");
         if (hasBundle)
         {
             var (paths, perr) = ReadBundlePaths(bundle!);
-            if (perr is not null) return "error: " + perr;
+            if (perr is not null) return Refuse(perr);
             var (zipped, zerr) = ExpandZip(paths!, assignments!.Value);
-            if (zerr is not null) return "error: " + zerr;
+            if (zerr is not null) return Refuse(zerr);
             edits.AddRange(zipped!);
         }
 
         if (edits.Count == 0)
-            return "error: nothing to apply. Pass ops=[{formid, field_path, …}, …] (or ops=\"@<absolute path>\"), " +
-                   "and/or the copy zip bundle=[\"<field path>\", …] + assignments=[{target, from}, …].";
+            return Refuse("nothing to apply. Pass ops=[{formid, field_path, …}, …] (or ops=\"@<absolute path>\"), " +
+                          "and/or the copy zip bundle=[\"<field path>\", …] + assignments=[{target, from}, …].");
 
         // ---- Map the 2.0 op shape onto the proven cleave ------------------------------------------------
         // The 2.0 spellings are a RENAME over the same engine inputs: op -> verb, from_source -> the source
@@ -214,10 +229,10 @@ public static class ApplyTools
             origins.Add(e.Origin);
         }
         if (problems.Count > 0)
-            return $"error: refused — {problems.Count} of {edits.Count} operation(s) malformed; NOTHING written:\n  - "
-                 + string.Join("\n  - ", problems);
+            return Refuse($"refused — {problems.Count} of {edits.Count} operation(s) malformed; NOTHING written:\n  - "
+                        + string.Join("\n  - ", problems));
 
-        var outcome = svc.ApplyEdits(wire, patch ?? "Patch", into, readback, in_place, hasInPlace, acknowledge, dry_run, fromRecords, origins);
+        var outcome = svc.ApplyEdits(wire, patchName ?? "Patch", into, readback, in_place, hasInPlace, acknowledge, dry_run, fromRecords, origins);
         return json
             ? JsonWire.RenderPatchOutcome(outcome, max_chars, readback)
             : WriteTools.Render(outcome, max_chars, readback);
@@ -334,7 +349,12 @@ public static class ApplyTools
 
     static readonly (string Old, string Correction)[] ElementRenames =
     {
-        ("verb", "the verb member is now op, one verb-name across the whole surface: op=\"Add\""),
+        // Scoped deliberately: the rename is AT THE OP LEVEL only. A nested set inside compose= is a NestedSet,
+        // shared verbatim with the 1.x wire shape, and still spells `verb` — so an unscoped "op everywhere"
+        // correction would send a caller straight into the opposite refusal one level down. The reverse row
+        // below catches exactly that caller.
+        ("verb", "at the OP level the verb member is now op — op=\"Add\". (A nested set inside compose= is unchanged and still takes verb.)"),
+        ("op", "a nested set inside compose= still spells its verb `verb` — only the top-level op member was renamed to op"),
         ("from_plugin", "it split in two: from_source names the PLUGIN to copy from, from names a different source RECORD"),
         ("fromplugin", "it split in two: from_source names the PLUGIN to copy from, from names a different source RECORD"),
         ("target_formid", "a copy's destination record is the assignments= zip's target="),
@@ -436,7 +456,9 @@ public static class ApplyTools
 // ---- wire DTOs (the 2.0 op + zip shapes) ---------------------------------------------------------------
 
 /// <summary>One field edit off the 2.0 wire (housecarl_apply). The 1.x <see cref="BulkOp"/> with the SPEC §5.1
-/// vocabulary — <c>verb</c> is <c>op</c> (one verb-name across substrates), <c>from_plugin</c> splits into the
+/// vocabulary — <c>verb</c> is <c>op</c> (§5.1's one verb-name, AT THE OP LEVEL: a nested set inside
+/// <c>compose=</c> is a <see cref="NestedSet"/>, shared verbatim with the 1.x wire shape, and still spells
+/// <c>verb</c>; the §5.3 row renames the op member, not every verb-shaped member beneath it), <c>from_plugin</c> splits into the
 /// §4.5 pair <c>from</c> (the source RECORD) + <c>from_source</c> (the pole it is read from). Its own record rather
 /// than a reshaped BulkOp so the 1.x tools' published schemas stay untouched through the build waves.</summary>
 public sealed record ApplyOp

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1486,4 +1486,105 @@ static class JsonWire
         }
         return Finish(ms);
     }
+
+    // ---- housecarl_apply (W3 — the 2.0 write surface) -----------------------------------------------
+    /// <summary>The machine-readable twin of <see cref="WriteTools.Render"/>: ONE write outcome, the SAME data the
+    /// text render states (decision D2 — one write path, two renders). Everything the text lane treats as prose is a
+    /// typed field here: the lane taken, whether it was a dry run, the epoch of the build the winners resolved from,
+    /// per-op results, and the read-back. A REFUSAL is a document too (<c>ok:false</c> with the reason), not an empty
+    /// body — a json caller must never have to parse "error: …" out of a string to learn the call failed. The
+    /// first-touch in-place CONSENT prompt is its own flag: it is a required confirmation, not a failure (Q3).
+    /// Budget handling matches every other json render — trailing ROWS drop and <c>truncated</c> says so, so the
+    /// document is always valid JSON rather than a string cut mid-token.</summary>
+    public static string RenderPatchOutcome(WritePatchBuilder.PatchOutcome o, int maxChars, bool readback)
+    {
+        int cap = Cap(maxChars);
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, Opts))
+        {
+            w.WriteStartObject();
+            w.WriteBoolean("ok", o.Success);
+            w.WriteBoolean("needs_acknowledge", o.NeedsAcknowledge);
+            w.WriteBoolean("dry_run", o.DryRun);
+            w.WriteString("lane", o.InPlace ? "in_place" : o.Extended ? "extend" : "patch");
+            WriteNullable(w, "epoch", o.Epoch);
+            if (!o.Success)
+            {
+                // NeedsAcknowledge carries its prompt in Error — labelled as a prompt, never as an error string.
+                WriteNullable(w, o.NeedsAcknowledge ? "confirmation" : "error", o.Error);
+                w.WriteEndObject();
+                return Finish(ms);
+            }
+
+            w.WriteString("path", o.OutputPath);
+            w.WriteString("file", Path.GetFileName(o.OutputPath));
+            w.WriteNumber("bytes", o.Bytes);
+            w.WriteStartArray("masters");
+            foreach (var m in o.Masters) w.WriteStringValue(m);
+            w.WriteEndArray();
+
+            w.WriteNumber("total_ops", o.Ops.Count);
+            w.WriteStartArray("ops");
+            int renderedOps = 0;
+            bool truncated = false;
+            foreach (var op in o.Ops)
+            {
+                if (ms.Length >= cap) { truncated = true; break; }
+                w.WriteStartObject();
+                w.WriteString("formid", op.Target.ToString());
+                w.WriteString("record_type", op.RecordType);
+                w.WriteString("label", op.Label);
+                w.WriteBoolean("applied", op.Applied);
+                WriteNullable(w, "error", op.Error);
+                WriteNullable(w, "after", op.After);
+                WriteNullable(w, "landed", op.Landed);
+                w.WriteEndObject();
+                renderedOps++;
+            }
+            w.WriteEndArray();
+            w.WriteNumber("rendered_ops", renderedOps);
+
+            if (o.ReadBack is { } rb)
+            {
+                // The read-back is the WRITTEN FILE's content, not load-order truth — stated as data (`source`) so a
+                // json consumer cannot lose the distinction the text render spells out in a sentence.
+                w.WriteString("readback_source", o.DryRun ? "in_memory_would_be_content" : "written_file");
+                w.WriteBoolean("readback_full", readback);
+                w.WriteStartArray("readback");
+                foreach (var r in rb)
+                {
+                    if (ms.Length >= cap) { truncated = true; break; }
+                    w.WriteStartObject();
+                    w.WriteString("formid", r.Target.ToString());
+                    if (r.Error is not null) w.WriteString("error", r.Error);
+                    else
+                    {
+                        var rec = r.Record!;
+                        w.WriteString("type", rec.Type);
+                        WriteNullable(w, "editorid", rec.EditorId);
+                        w.WriteNumber("field_count", rec.Fields.Count);
+                        w.WriteStartArray("fields");
+                        foreach (var f in rec.Fields)
+                        {
+                            if (ms.Length >= cap) { truncated = true; break; }
+                            w.WriteStartObject();
+                            w.WriteString("path", f.Path);
+                            if (f.HasValue) w.WriteString("value", f.Token); else w.WriteString("note", f.Note);
+                            w.WriteEndObject();
+                        }
+                        w.WriteEndArray();
+                    }
+                    w.WriteEndObject();
+                }
+                w.WriteEndArray();
+            }
+
+            WriteNullable(w, "note", o.Note);
+            w.WriteBoolean("truncated", truncated);
+            if (truncated)
+                w.WriteString("truncated_note", $"the render hit max_chars={cap} and dropped trailing rows — the WRITE is complete and unaffected; raise max_chars to see the rest.");
+            w.WriteEndObject();
+        }
+        return Finish(ms);
+    }
 }

--- a/src/housecarl-mcp/JsonWire.cs
+++ b/src/housecarl-mcp/JsonWire.cs
@@ -1513,6 +1513,11 @@ static class JsonWire
                 // NeedsAcknowledge carries its prompt in Error — labelled as a prompt, never as an error string.
                 WriteNullable(w, o.NeedsAcknowledge ? "confirmation" : "error", o.Error);
                 w.WriteEndObject();
+                // Flush BEFORE reading the stream: this return is INSIDE the writer's using-block, so without it
+                // the buffered document is still unwritten and the caller gets an EMPTY string — exactly the
+                // silent-degrade class PR #306 found on the json sweep refusals (a refusal that renders as nothing
+                // is worse than the failure it was reporting). The success path below returns after disposal.
+                w.Flush();
                 return Finish(ms);
             }
 

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4447,7 +4447,7 @@ public sealed class LoadOrderService : IDisposable
     /// (the pre-enable verify loop — wishlist #3 re-scoped / HCBR-2026-06-11-02 wave (b)).</summary>
     public WritePatchBuilder.PatchOutcome ApplyEdits(IReadOnlyList<BulkOp> ops, string? patchName, string? into,
         bool fullReadback = false, string? target = null, bool inPlace = false, bool acknowledge = false,
-        bool dryRun = false, IReadOnlyList<string?>? fromRecords = null)
+        bool dryRun = false, IReadOnlyList<string?>? fromRecords = null, IReadOnlyList<string?>? opOrigins = null)
     {
         if (ops.Count == 0)
             return WritePatchBuilder.PatchOutcome.Fail("no operations supplied.");
@@ -4474,7 +4474,9 @@ public sealed class LoadOrderService : IDisposable
         {
             // fromRecords[i] is the §4.5 zip's per-op SOURCE RECORD (housecarl_apply's from=), carried parallel to
             // the op list because BulkOp — the 1.x published wire shape — deliberately gains no new member.
-            var edit = MapEdit(ops[i], i, out var err, fromRecords is not null && i < fromRecords.Count ? fromRecords[i] : null);
+            var edit = MapEdit(ops[i], i, out var err,
+                fromRecords is not null && i < fromRecords.Count ? fromRecords[i] : null,
+                opOrigins is not null && i < opOrigins.Count ? opOrigins[i] : null);
             if (err is not null) problems.Add(err); else edits.Add(edit!);
         }
         if (problems.Count > 0)
@@ -4607,7 +4609,8 @@ public sealed class LoadOrderService : IDisposable
         if (targetPath is null)
             return WritePatchBuilder.PatchOutcome.Fail(
                 $"in-place target '{target}' is not an active plugin in the load order — name a plugin enabled in MO2, by its " +
-                "plugin filename (e.g. 'CoolWeapons.esp'). in-place edits the file the game actually loads. Nothing was written.");
+                "plugin filename (e.g. 'CoolWeapons.esp'). in-place edits the file the game actually loads. Nothing was written.")
+                with { Epoch = view.Epoch };
 
         // (2) CONSENT axis — the persistent, server-enforced first-touch handshake, keyed off the resolved path. NOT a
         //     sticky mode: each in-place write still names its own target=, so this only stops re-explaining the
@@ -4626,7 +4629,12 @@ public sealed class LoadOrderService : IDisposable
         else
         {
             if (!already && !acknowledge)
-                return WritePatchBuilder.PatchOutcome.NeedsAck(InPlaceHandshakeText(targetName, targetPath));
+                // Stamped like every other post-capture outcome (review [medium]): this branch is reached only
+                // after the view above resolved the target, and it is the MOST COMMON in-place response shape —
+                // an unstamped one would make the "every write response carries an epoch" contract false exactly
+                // where a caller most often meets it.
+                return WritePatchBuilder.PatchOutcome.NeedsAck(InPlaceHandshakeText(targetName, targetPath))
+                    with { Epoch = view.Epoch };
             if (!already && acknowledge)
             {
                 var (ok, err) = _store.RecordInPlaceAcknowledged(targetPath);
@@ -4639,7 +4647,7 @@ public sealed class LoadOrderService : IDisposable
         //     front with a clear message before any work). Kept in the dry run too: an unwritable parent is exactly
         //     what the real write would refuse on, and predicting that refusal is the dry run's job.
         if (InPlaceParentUnwritable(targetPath, out var why))
-            return WritePatchBuilder.PatchOutcome.Fail(why);
+            return WritePatchBuilder.PatchOutcome.Fail(why) with { Epoch = view.Epoch };
 
         // (4) The write — touched-record verify forced ON (the model-C substitute for the dropped whole-plugin floor).
         var outcome = WritePatchBuilder.ApplyInPlace(resolver, rulebook, edits, targetPath, targetName, fullReadback: true, dryRun, copyFromSources);
@@ -6193,10 +6201,13 @@ public sealed class LoadOrderService : IDisposable
     /// <summary>Map a wire op to a core <see cref="WritePatchBuilder.PatchEdit"/>: parse the FormID, split the dotted
     /// field path, and (if present) build the composition <see cref="StructSpec"/>. RecordType is NOT taken from the wire
     /// — the cleave derives it from the resolved winner. Returns null + a named error (Q3) on any malformed input.</summary>
-    WritePatchBuilder.PatchEdit? MapEdit(BulkOp op, int index, out string? error, string? fromRecord = null)
+    WritePatchBuilder.PatchEdit? MapEdit(BulkOp op, int index, out string? error, string? fromRecord = null, string? origin = null)
     {
         error = null;
-        var where = $"op[{index}]";
+        // The caller's OWN spelling for this edit. Ops written inline are op[i]; ops the §4.5 zip generated are
+        // named by the pair and path they came from — pointing a refusal at an op index the caller never wrote
+        // sends anyone fixing it to a line that does not exist (review [medium]).
+        var where = origin ?? $"op[{index}]";
         if (string.IsNullOrWhiteSpace(op.Formid)) { error = $"{where}: formid is required."; return null; }
         FormKey fk;
         try { fk = FormKey.Factory(op.Formid.Trim()); }
@@ -6253,6 +6264,17 @@ public sealed class LoadOrderService : IDisposable
                 error = $"{where}: from_plugin is only valid with verb=CopyFrom (got verb={verb}).";
             return null;
         }
+        // The "a copy carries no authored value" rule is independent of whether the POLE was named, so it is
+        // checked FIRST (review [high]): it used to sit below the from_plugin block, and the §4.5 cross-record
+        // shape (from= with no from_source=) returned early past it — so `op=CopyFrom, from=…, value="55"` was
+        // accepted and the value silently DISCARDED, while the same mistake WITH from_source= was refused by name.
+        // Nothing downstream catches it: the rulebook short-circuits CopyFrom to CopyFromLegality (which never
+        // sees Value), and the apply takes the CopyField branch. Two spellings of one mistake, one silent.
+        if (op.Value is not null || op.Values is not null || op.Entries is not null || spec is not null || specs is not null)
+        {
+            error = $"{where}: CopyFrom copies the field from the source record's version — it takes no value/values/entries/compose/composes.";
+            return null;
+        }
         if (string.IsNullOrWhiteSpace(op.FromPlugin))
         {
             // A named SOURCE RECORD (§4.5) identifies what to copy on its own, so the pole is optional and defaults
@@ -6260,11 +6282,6 @@ public sealed class LoadOrderService : IDisposable
             // from the target's own — required, or the op means nothing.
             if (hasSourceRecord) return null;
             error = $"{where}: CopyFrom requires from_plugin — the plugin whose version of this record to copy field_path from.";
-            return null;
-        }
-        if (op.Value is not null || op.Values is not null || op.Entries is not null || spec is not null || specs is not null)
-        {
-            error = $"{where}: CopyFrom copies the field from from_plugin's version — it takes no value/values/entries/compose/composes.";
             return null;
         }
         return op.FromPlugin.Trim();

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4485,7 +4485,22 @@ public sealed class LoadOrderService : IDisposable
             var rulebook = Rulebook;
 
             if (inPlace)
-                return ApplyEditsInPlace(resolver, rulebook, edits, target!.Trim(), acknowledge, dryRun);
+            {
+                // The in-place lane resolves off-order CopyFrom sources exactly as the patch lane does (W3: LANE is
+                // uniform — every ACT verb composes with in_place). The overlays must stay OPEN across the whole
+                // in-place write (CopyField deep-copies through them, and the re-serialize follows), so they are
+                // disposed only after ApplyEditsInPlace returns.
+                Dictionary<WritePatchBuilder.PatchEdit, IMajorRecordGetter>? ipSources = null;
+                List<IDisposable>? ipOverlays = null;
+                var ipError = ResolveOffOrderCopySources(resolver, edits, ref ipSources, ref ipOverlays);
+                if (ipError is not null)
+                {
+                    if (ipOverlays is not null) foreach (var d in ipOverlays) d.Dispose();
+                    return WritePatchBuilder.PatchOutcome.Fail(ipError);
+                }
+                try { return ApplyEditsInPlace(resolver, rulebook, edits, target!.Trim(), acknowledge, dryRun, ipSources); }
+                finally { if (ipOverlays is not null) foreach (var d in ipOverlays) d.Dispose(); }
+            }
 
             // #225: a dry run resolves the would-be output path WITHOUT creating the mod folder (create:false) — the
             // one disk side effect the pre-serialize pipeline otherwise has. The fresh-lane name is a preview: the
@@ -4549,9 +4564,18 @@ public sealed class LoadOrderService : IDisposable
             try { ov = LoadOrderResolver.OpenOverlay(loc.Path!, string.IsNullOrEmpty(dataDir) ? null : dataDir); }
             catch (Exception ex) { problems.Add($"{e.Target}: CopyFrom source file '{e.FromPlugin}' could not be opened as a Skyrim plugin ({ex.Message})."); continue; }
             IMajorRecordGetter? body;
-            try { body = ov.EnumerateMajorRecords().FirstOrDefault(r => r.FormKey == e.Target); }
+            try { body = ov.EnumerateMajorRecords().FirstOrDefault(r => r.FormKey == e.CopySource); }
             catch (Exception ex) { (ov as IDisposable)?.Dispose(); problems.Add($"{e.Target}: CopyFrom source file '{e.FromPlugin}' could not be read ({ex.Message})."); continue; }
-            if (body is null) { (ov as IDisposable)?.Dispose(); problems.Add($"{e.Target}: CopyFrom source file '{e.FromPlugin}' does not define or override this record — there is no version of it there to copy."); continue; }
+            if (body is null)
+            {
+                (ov as IDisposable)?.Dispose();
+                // Name WHICH record the file is missing: the target's own version (same-record copy) or the §4.5
+                // zip's SOURCE record (cross-record) — "this record" would point at the wrong one on the zip lane.
+                problems.Add(e.FromTarget is null
+                    ? $"{e.Target}: CopyFrom source file '{e.FromPlugin}' does not define or override this record — there is no version of it there to copy."
+                    : $"{e.Target}: CopyFrom source file '{e.FromPlugin}' does not define or override the SOURCE record {e.CopySource} — there is no version of it there to copy from.");
+                continue;
+            }
             (overlays ??= new()).Add((IDisposable)ov);
             (sources ??= new())[e] = body;   // distinct Path-array refs make each PatchEdit a distinct key (value equality); indexer is collision-safe regardless
         }
@@ -4571,7 +4595,8 @@ public sealed class LoadOrderService : IDisposable
     /// the CONSENT axis ONLY — the verify is a corruption-axis fact no acknowledgement overrides.</summary>
     WritePatchBuilder.PatchOutcome ApplyEditsInPlace(
         LoadOrderResolver resolver, CorpusRulebook rulebook, IReadOnlyList<WritePatchBuilder.PatchEdit> edits,
-        string target, bool acknowledge, bool dryRun = false)
+        string target, bool acknowledge, bool dryRun = false,
+        IReadOnlyDictionary<WritePatchBuilder.PatchEdit, IMajorRecordGetter>? copyFromSources = null)
     {
         // (1) Resolve target -> real on-disk path via the load order (by plugin FILENAME — unique in an order). Refuse
         //     loud if it isn't a real active plugin (closes the coincidental-folder collision the into= lane can hit).
@@ -4615,7 +4640,7 @@ public sealed class LoadOrderService : IDisposable
             return WritePatchBuilder.PatchOutcome.Fail(why);
 
         // (4) The write — touched-record verify forced ON (the model-C substitute for the dropped whole-plugin floor).
-        var outcome = WritePatchBuilder.ApplyInPlace(resolver, rulebook, edits, targetPath, targetName, fullReadback: true, dryRun);
+        var outcome = WritePatchBuilder.ApplyInPlace(resolver, rulebook, edits, targetPath, targetName, fullReadback: true, dryRun, copyFromSources);
 
         // (5-dry) #225: a successful dry run stamps NOTHING (no editedInPlace marker, no .seq note — those describe a
         //     write that happened); only the core's would-grow note + the pending-consent note ride along.

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4447,7 +4447,7 @@ public sealed class LoadOrderService : IDisposable
     /// (the pre-enable verify loop — wishlist #3 re-scoped / HCBR-2026-06-11-02 wave (b)).</summary>
     public WritePatchBuilder.PatchOutcome ApplyEdits(IReadOnlyList<BulkOp> ops, string? patchName, string? into,
         bool fullReadback = false, string? target = null, bool inPlace = false, bool acknowledge = false,
-        bool dryRun = false)
+        bool dryRun = false, IReadOnlyList<string?>? fromRecords = null)
     {
         if (ops.Count == 0)
             return WritePatchBuilder.PatchOutcome.Fail("no operations supplied.");
@@ -4472,7 +4472,9 @@ public sealed class LoadOrderService : IDisposable
         var problems = new List<string>();
         for (int i = 0; i < ops.Count; i++)
         {
-            var edit = MapEdit(ops[i], i, out var err);
+            // fromRecords[i] is the §4.5 zip's per-op SOURCE RECORD (housecarl_apply's from=), carried parallel to
+            // the op list because BulkOp — the 1.x published wire shape — deliberately gains no new member.
+            var edit = MapEdit(ops[i], i, out var err, fromRecords is not null && i < fromRecords.Count ? fromRecords[i] : null);
             if (err is not null) problems.Add(err); else edits.Add(edit!);
         }
         if (problems.Count > 0)
@@ -6191,7 +6193,7 @@ public sealed class LoadOrderService : IDisposable
     /// <summary>Map a wire op to a core <see cref="WritePatchBuilder.PatchEdit"/>: parse the FormID, split the dotted
     /// field path, and (if present) build the composition <see cref="StructSpec"/>. RecordType is NOT taken from the wire
     /// — the cleave derives it from the resolved winner. Returns null + a named error (Q3) on any malformed input.</summary>
-    WritePatchBuilder.PatchEdit? MapEdit(BulkOp op, int index, out string? error)
+    WritePatchBuilder.PatchEdit? MapEdit(BulkOp op, int index, out string? error, string? fromRecord = null)
     {
         error = null;
         var where = $"op[{index}]";
@@ -6213,21 +6215,36 @@ public sealed class LoadOrderService : IDisposable
         if (error is not null) return null;
 
         var verb = string.IsNullOrWhiteSpace(op.Verb) ? "Set" : op.Verb;
-        var fromPlugin = MapFromPlugin(op, verb, $"{where} ({op.Formid})", spec, specs, out error);
+
+        // SPEC §4.5 — the CROSS-RECORD copy source (housecarl_apply's from=). A named source record makes
+        // from_source OPTIONAL (it defaults to that record's load-order winner, resolved at pre-flight where the
+        // captured view lives); without one, the source plugin is the only thing that identifies a version to copy,
+        // so it stays required. A source equal to the target is a no-op, refused by name rather than written.
+        FormKey? fromKey = null;
+        if (!string.IsNullOrWhiteSpace(fromRecord))
+        {
+            try { fromKey = FormKey.Factory(fromRecord.Trim()); }
+            catch (Exception ex) { error = $"{where} ({op.Formid}): bad from '{fromRecord}' ({ex.Message}). Expected 'XXXXXX:Plugin.esp'."; return null; }
+            if (fromKey == fk)
+            { error = $"{where} ({op.Formid}): from names the SAME record as formid — copying a record's field onto itself is a no-op. Drop from=, and name the plugin whose version to copy in from_source=."; return null; }
+        }
+
+        var fromPlugin = MapFromPlugin(op, verb, $"{where} ({op.Formid})", spec, specs, fromKey is not null, out error);
         if (error is not null) return null;
 
         return new WritePatchBuilder.PatchEdit
         {
             Target = fk, Path = path, Verb = verb,
             Key = op.Key, Value = op.Value, Values = op.Values, Entries = op.Entries, Struct = spec, Structs = specs,
-            FromPlugin = fromPlugin,
+            FromPlugin = fromPlugin, FromTarget = fromKey,
         };
     }
 
     /// <summary>P8b — validate + extract from_plugin for a CopyFrom op. from_plugin is REQUIRED with (and ONLY with)
     /// verb=CopyFrom, which copies the field FROM that plugin's version and so takes no value/values/entries/compose/
     /// composes. Both rules refuse loud (Q3), never silently ignore. Returns null for a non-CopyFrom op.</summary>
-    static string? MapFromPlugin(BulkOp op, string verb, string where, StructSpec? spec, IReadOnlyList<StructSpec>? specs, out string? error)
+    static string? MapFromPlugin(BulkOp op, string verb, string where, StructSpec? spec, IReadOnlyList<StructSpec>? specs,
+        bool hasSourceRecord, out string? error)
     {
         error = null;
         if (!string.Equals(verb, "CopyFrom", StringComparison.Ordinal))   // match the engine's Ordinal verb compare — a mis-cased verb fails loud uniformly (Unknown verb … Legal: …CopyFrom)
@@ -6238,6 +6255,10 @@ public sealed class LoadOrderService : IDisposable
         }
         if (string.IsNullOrWhiteSpace(op.FromPlugin))
         {
+            // A named SOURCE RECORD (§4.5) identifies what to copy on its own, so the pole is optional and defaults
+            // to that record's winner. Without one, the plugin IS the only thing distinguishing a source version
+            // from the target's own — required, or the op means nothing.
+            if (hasSourceRecord) return null;
             error = $"{where}: CopyFrom requires from_plugin — the plugin whose version of this record to copy field_path from.";
             return null;
         }

--- a/src/housecarl-mcp/LoadOrderService.cs
+++ b/src/housecarl-mcp/LoadOrderService.cs
@@ -4496,11 +4496,11 @@ public sealed class LoadOrderService : IDisposable
                 // disposed only after ApplyEditsInPlace returns.
                 Dictionary<WritePatchBuilder.PatchEdit, IMajorRecordGetter>? ipSources = null;
                 List<IDisposable>? ipOverlays = null;
-                var ipError = ResolveOffOrderCopySources(resolver, edits, ref ipSources, ref ipOverlays);
+                var ipError = ResolveOffOrderCopySources(resolver, edits, ref ipSources, ref ipOverlays, out var ipEpoch);
                 if (ipError is not null)
                 {
                     if (ipOverlays is not null) foreach (var d in ipOverlays) d.Dispose();
-                    return WritePatchBuilder.PatchOutcome.Fail(ipError);
+                    return WritePatchBuilder.PatchOutcome.Fail(ipError) with { Epoch = ipEpoch };
                 }
                 try { return ApplyEditsInPlace(resolver, rulebook, edits, target!.Trim(), acknowledge, dryRun, ipSources); }
                 finally { if (ipOverlays is not null) foreach (var d in ipOverlays) d.Dispose(); }
@@ -4519,12 +4519,12 @@ public sealed class LoadOrderService : IDisposable
             // their overlays must stay OPEN through the serialize (CopyField deep-copies through them) — disposed after.
             Dictionary<WritePatchBuilder.PatchEdit, IMajorRecordGetter>? copyFromSources = null;
             List<IDisposable>? offOrderOverlays = null;
-            var cfError = ResolveOffOrderCopySources(resolver, edits, ref copyFromSources, ref offOrderOverlays);
+            var cfError = ResolveOffOrderCopySources(resolver, edits, ref copyFromSources, ref offOrderOverlays, out var cfEpoch);
             if (cfError is not null)
             {
                 if (offOrderOverlays is not null) foreach (var d in offOrderOverlays) d.Dispose();
                 if (created) RemoveFolderCreatedThisCall(outPath);   // a refused write leaves no orphan folder
-                return WritePatchBuilder.PatchOutcome.Fail(cfError);
+                return WritePatchBuilder.PatchOutcome.Fail(cfError) with { Epoch = cfEpoch };
             }
             try
             {
@@ -4544,10 +4544,16 @@ public sealed class LoadOrderService : IDisposable
     /// (all-or-nothing, before any write); null on success. Uses the SAME on-disk locate as read_plugin_file / the
     /// copy-npc-appearance donor lane, so the tools can never disagree on which file a filename names.</summary>
     string? ResolveOffOrderCopySources(LoadOrderResolver resolver, IReadOnlyList<WritePatchBuilder.PatchEdit> edits,
-        ref Dictionary<WritePatchBuilder.PatchEdit, IMajorRecordGetter>? sources, ref List<IDisposable>? overlays)
+        ref Dictionary<WritePatchBuilder.PatchEdit, IMajorRecordGetter>? sources, ref List<IDisposable>? overlays,
+        out string? epoch)
     {
+        // This helper takes its OWN capture, so its refusals are decided AFTER a build was consulted and must be
+        // stamped like every other post-capture outcome (re-review [low]: the first epoch fold missed this class).
+        // Null only when no CopyFrom op exists — then nothing here consults a build at all.
+        epoch = null;
         if (!edits.Any(e => string.Equals(e.Verb, "CopyFrom", StringComparison.Ordinal))) return null;   // no CopyFrom → no source work
         var view = resolver.Capture();
+        epoch = view.Epoch;
         string modsDir = "", dataDir = "", overwriteDir = "", profileDir = "";
         Mo2Composition? comp = null;
         var problems = new List<string>();

--- a/src/housecarl-mcp/Program.cs
+++ b/src/housecarl-mcp/Program.cs
@@ -164,6 +164,11 @@ static void AddMcp(IServiceCollection services, bool stdio)
     if (stdio) mcp.WithStdioServerTransport();
     else mcp.WithHttpTransport(o => o.Stateless = true);
     mcp.WithToolsFromAssembly();
+    // SPEC §5.1's @file convention forces a list parameter to accept an array OR a string, which C# cannot
+    // express as one type — so those parameters are declared JsonElement and the generator publishes "anything".
+    // This republishes them as anyOf[<the GENERATED element-array schema>, string]. Published shape only; what
+    // the tool ACCEPTS is unchanged (ApplyTools' strict reader). See ToolSchemas.
+    ToolSchemas.PublishFileListUnions(services);
     // The argument-binding shim (HCBR-2026-06-11-01): schema-driven coercion of obvious-intent argument shapes
     // (a bare string where an array is declared, quoted bools/numbers), named refusal of missing required
     // parameters, and a named rewrite of the SDK's generic binding-failure text. See ToolCallShim.

--- a/src/housecarl-mcp/RecordsTools.cs
+++ b/src/housecarl-mcp/RecordsTools.cs
@@ -7,16 +7,23 @@ using Mutagen.Bethesda.Plugins;
 namespace HousecarlMcp;
 
 /// <summary>
-/// housecarl_records — the 2.0 S1 read surface (tool-surface-2.0 W2 PR 1; SPEC §2.2/§4.2/§6.1).
+/// housecarl_records — the 2.0 S1 read surface, COMPLETE (tool-surface-2.0 W2; SPEC §2.2/§3/§4/§6.1).
 ///
 /// ONE read tool: SELECT (which records) × SOURCE (whose version) × PROJECT (what shape) × TRANSPORT compose in a
 /// single call, over the SAME proven engine lanes the 1.x read tools drive (CrossQuery / ResolveBatch /
 /// ResolveRefs / the one-pole batch / the plugin-file overlay) — consolidation of the surface, not a re-implementation
-/// of the engine. This PR ships the CORE forms (identity | summary | fields | everything | aggregate) and the
-/// one-pole named SOURCE; the comparison/traversal forms (delta | tree | chain | info_order, walk=, versus=,
-/// previous_provider, the SkyPatcher overlay source) arrive in W2 PR 2 — until then those spellings get a NAMED
-/// staging refusal pointing at the 1.x tool that does the job today (never a silent gap). The 1.x read tools stay
-/// registered and unchanged through the build waves; they retire at 2.0.0 (clean cut, CHARTER_PHASE4 §3.4a).
+/// of the engine.
+///
+/// All NINE PROJECT forms are live — identity | summary | fields | everything | aggregate | delta | tree | chain |
+/// info_order — each form-scoped, so a sub-parameter exists only inside the form that carries it (§2.2). SOURCE is
+/// the §4.2 pole grammar: the winner by default, a named plugin resolved wherever it lives (active or on disk
+/// out of the order, with the resolved arm always stated), the SkyPatcher overlay pre/post state, and — as the
+/// comparison REFERENCE, `versus=` — `previous_provider`. SELECT carries the full `where=` grammar (including the
+/// `winner` provenance term), `references=`, and the §3 `walk=` traversal construct, forward closure and the typed
+/// MGEF reverse lane alike.
+///
+/// The 1.x read tools stay registered and unchanged through the build waves; they retire at 2.0.0 (clean cut,
+/// CHARTER_PHASE4 §3.4a), at which point a call naming one is answered with its successor spelling here.
 /// </summary>
 [McpServerToolType]
 public static class RecordsTools

--- a/src/housecarl-mcp/ToolSchemas.cs
+++ b/src/housecarl-mcp/ToolSchemas.cs
@@ -1,0 +1,157 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Server;
+
+namespace HousecarlMcp;
+
+/// <summary>
+/// Publishes a REAL schema for the list parameters that carry SPEC §5.1's <c>@file</c> convention.
+///
+/// <para>The problem: a list-valued input accepts EITHER an inline array of objects OR the string
+/// <c>"@&lt;absolute path&gt;"</c>. C# has no type for that union, so the parameter is declared
+/// <see cref="JsonElement"/> and the SDK's schema generator — which works from the declared type — publishes
+/// "anything" (<c>{}</c>). The element shape then lives only in the tool description, where a client's schema
+/// rendering cannot use it.</para>
+///
+/// <para>The fix: after the assembly scan has built each tool, replace those property nodes with
+/// <c>anyOf[&lt;the generated array schema&gt;, string]</c>. The array arm is GENERATED from the C# element type
+/// by the same generator the SDK uses — adding a member to <see cref="ApplyOp"/> updates the published schema
+/// automatically, so this is not a hand-maintained copy. Only the union wrapper and the string arm are written
+/// here.</para>
+///
+/// <para>Route note: the SDK's <c>WithToolsFromAssembly</c> has no overload carrying
+/// <c>McpServerToolCreateOptions.SchemaCreateOptions</c>, so the per-node <c>TransformSchemaNode</c> hook cannot
+/// reach an assembly-scanned tool. <see cref="ModelContextProtocol.Protocol.Tool.InputSchema"/> is settable
+/// (and validates what it is given), so the schema is rewritten once at registration instead — which keeps
+/// every tool on the one registration path rather than special-casing one tool's wiring.</para>
+///
+/// <para><b>This changes only what is PUBLISHED, never what is ACCEPTED.</b> Binding still goes through
+/// <c>ApplyTools.ReadListParam</c>, whose strict reader is deliberately stricter than the SDK binder.</para>
+/// </summary>
+internal static class ToolSchemas
+{
+    /// <summary>One list parameter whose published schema becomes the @file union.</summary>
+    internal readonly record struct FileListParam(string Tool, string Parameter, Type ElementArrayType);
+
+    /// <summary>The parameters that carry the @file convention AND are typed <see cref="JsonElement"/> because of
+    /// it. A plain <c>string[]</c> list (<c>formids=</c>, <c>bundle=</c>) needs no entry: its generated schema is
+    /// already honest, since <c>["@&lt;path&gt;"]</c> IS a one-element string array.</summary>
+    static readonly FileListParam[] FileListParams =
+    {
+        new("housecarl_apply", "ops", typeof(ApplyOp[])),
+        new("housecarl_apply", "assignments", typeof(Assignment[])),
+    };
+
+    /// <summary>Register the rewrite. It runs as a POST-configure over <c>McpServerOptions</c>, which is the one
+    /// place the final tool collection exists regardless of how the tools got there: the assembly scan registers
+    /// each tool as a FACTORY, so the instances do not exist yet while the service collection is being built, and
+    /// both transports (stdio and http) build their host separately — a post-configure keeps this on ONE line
+    /// inside the shared registration instead of a call site per transport that could drift apart.
+    /// A tool or parameter not found is skipped here; <c>apply-guard</c> asserts the published shape end-to-end,
+    /// so a stale row fails there loudly rather than degrading the surface quietly.</summary>
+    internal static void PublishFileListUnions(IServiceCollection services) =>
+        services.PostConfigure<McpServerOptions>(options =>
+        {
+            if (options.ToolCollection is not { } tools) return;
+            foreach (var tool in tools)
+            {
+                var wanted = FileListParams.Where(p => p.Tool == tool.ProtocolTool.Name).ToList();
+                if (wanted.Count == 0) continue;
+                if (Rewrite(tool.ProtocolTool.InputSchema, wanted) is { } rebuilt)
+                    tool.ProtocolTool.InputSchema = rebuilt;
+            }
+        });
+
+    /// <summary>Build the rewritten schema, or null if the shape isn't what we expect (leave it alone rather than
+    /// publish something malformed).</summary>
+    static JsonElement? Rewrite(JsonElement schema, IReadOnlyList<FileListParam> parameters)
+    {
+        if (JsonNode.Parse(schema.GetRawText()) is not JsonObject root) return null;
+        if (root["properties"] is not JsonObject props) return null;
+
+        // $ref inside a generated sub-schema is written "#/$defs/X" — resolved against the ROOT document. So a
+        // generated schema's own $defs must be HOISTED to the tool schema's root, or every reference in it dangles.
+        var defs = root["$defs"] as JsonObject;
+
+        bool changed = false;
+        foreach (var p in parameters)
+        {
+            if (props[p.Parameter] is not JsonObject existing) continue;
+
+            var generated = JsonNode.Parse(
+                AIJsonUtilities.CreateJsonSchema(p.ElementArrayType, serializerOptions: SchemaJson).GetRawText()) as JsonObject;
+            if (generated is null) continue;
+
+            if (generated["$defs"] is JsonObject genDefs)
+            {
+                generated.Remove("$defs");
+                defs ??= new JsonObject();
+                foreach (var name in genDefs.Select(kv => kv.Key).ToList())
+                {
+                    if (defs.ContainsKey(name)) continue;          // same type, same generator ⇒ same schema; first wins
+                    var node = genDefs[name];
+                    genDefs.Remove(name);
+                    defs[name] = node;
+                }
+            }
+
+            // EVERY "#/..." pointer in the generated schema is relative to ITS OWN document root — the standalone
+            // array schema. Nesting that document under properties/<param>/anyOf/0 silently breaks all of them.
+            // This generator terminates a RECURSIVE type (StructInput → NestedSet.compose → StructInput, our
+            // compose/sets chain) with exactly such a positional back-reference, so this is not a hypothetical:
+            // without rebasing, the published schema carries a dangling $ref, which is worse than publishing
+            // nothing at all. Rebase to where the sub-document now lives.
+            RebaseRefs(generated, $"#/properties/{p.Parameter}/anyOf/0");
+
+            // The [Description] the SDK lifted off the parameter is the caller-facing teaching — it survives the
+            // rewrite verbatim, on the union node where a client will render it.
+            var description = existing["description"]?.GetValue<string>();
+
+            var union = new JsonObject
+            {
+                ["anyOf"] = new JsonArray(
+                    generated,
+                    new JsonObject
+                    {
+                        ["type"] = "string",
+                        ["description"] = $"\"@<absolute path>\" — read the same array from a JSON file on disk instead of inlining it.",
+                    }),
+            };
+            if (description is not null) union["description"] = description;
+
+            props[p.Parameter] = union;
+            changed = true;
+        }
+
+        if (!changed) return null;
+        if (defs is not null) root["$defs"] = defs;
+        return JsonSerializer.Deserialize<JsonElement>(root.ToJsonString());
+    }
+
+    /// <summary>Rewrite every same-document JSON pointer in a generated sub-schema so it resolves from the tool
+    /// schema's root once the sub-schema has been nested under <paramref name="basePointer"/>. A bare <c>"#"</c>
+    /// (the whole document) becomes the base itself; <c>"#/x/y"</c> becomes <c>"&lt;base&gt;/x/y"</c>. A pointer
+    /// into <c>$defs</c> is left alone — those definitions were hoisted to the root, which is exactly where
+    /// <c>#/$defs/…</c> already points. External refs (anything not starting with <c>#</c>) are untouched.</summary>
+    static void RebaseRefs(JsonNode? node, string basePointer)
+    {
+        switch (node)
+        {
+            case JsonObject obj:
+                if (obj["$ref"]?.GetValue<string>() is { } r && r.StartsWith('#') && !r.StartsWith("#/$defs/", StringComparison.Ordinal))
+                    obj["$ref"] = r.Length == 1 ? basePointer : basePointer + r[1..];
+                foreach (var key in obj.Select(kv => kv.Key).ToList())
+                    if (key != "$ref") RebaseRefs(obj[key], basePointer);
+                break;
+            case JsonArray arr:
+                foreach (var item in arr) RebaseRefs(item, basePointer);
+                break;
+        }
+    }
+
+    /// <summary>Match the SDK's own wire conventions so the generated arm reads like every other published schema
+    /// (camelCase member names come from each DTO's explicit <c>[JsonPropertyName]</c>, not from a policy).</summary>
+    static readonly JsonSerializerOptions SchemaJson = new(JsonSerializerDefaults.Web);
+}

--- a/src/housecarl-mcp/ToolSchemas.cs
+++ b/src/housecarl-mcp/ToolSchemas.cs
@@ -90,7 +90,12 @@ internal static class ToolSchemas
                 defs ??= new JsonObject();
                 foreach (var name in genDefs.Select(kv => kv.Key).ToList())
                 {
-                    if (defs.ContainsKey(name)) continue;          // same type, same generator ⇒ same schema; first wins
+                    // First-wins on the DEFINITION NAME. Sound for today's rows and for `create`'s records= in
+                    // W3 PR 2 — same generator, and the shared shapes (StructInput/NestedSet) are literally the
+                    // same C# types, so a duplicate name is a duplicate schema. It would bind the WRONG
+                    // definition only if two DISTINCT types ever produced the same short name here; if that day
+                    // comes, key the hoist by type rather than by name.
+                    if (defs.ContainsKey(name)) continue;
                     var node = genDefs[name];
                     genDefs.Remove(name);
                     defs[name] = node;

--- a/src/housecarl-mcp/WriteTools.cs
+++ b/src/housecarl-mcp/WriteTools.cs
@@ -527,8 +527,8 @@ public static class WriteTools
     /// On refusal, the full reason (every malformed/rejected op) so the caller can fix and retry.</summary>
     internal static string Render(WritePatchBuilder.PatchOutcome o, int maxChars = 0, bool fullDump = false)   // internal: the compact-readback guard renders one outcome three ways
     {
-        if (o.NeedsAcknowledge) return o.Error!;            // the first-touch in-place CONSENT prompt — a required confirmation, NOT an error (Q3)
-        if (!o.Success) return "error: " + o.Error;
+        if (o.NeedsAcknowledge) return o.Error! + Epoch(o);  // the first-touch in-place CONSENT prompt — a required confirmation, NOT an error (Q3)
+        if (!o.Success) return "error: " + o.Error + Epoch(o);
         if (o.DryRun) return RenderDryRun(o, maxChars, fullDump);
         var file = Path.GetFileName(o.OutputPath);
         var modFolder = Path.GetFileName(Path.GetDirectoryName(o.OutputPath) ?? "");
@@ -571,8 +571,15 @@ public static class WriteTools
         sb.Append(o.InPlace
             ? $"to make more in-place edits to this plugin, pass target=\"{file}\" in_place=true (no further confirmation needed for it)."
             : $"to add more edits to THIS patch, pass into=\"{file}\".");
+        sb.Append(Epoch(o));
         return sb.ToString();
     }
+
+    /// <summary>SPEC §2.1.1 — the index build this write resolved winners against, appended to EVERY write render
+    /// (success, refusal, dry run, consent prompt) exactly as the read surfaces stamp theirs. It is what lets a
+    /// caller tell whether the winner it edited is the winner a read reported a moment earlier: the read-back proves
+    /// what landed in the FILE, never what wins in the ORDER. Empty when the outcome consulted no build.</summary>
+    static string Epoch(WritePatchBuilder.PatchOutcome o) => o.Epoch is null ? "" : $"\nepoch={o.Epoch}";
 
     /// <summary>#225 — the dry_run=true confirmation: the SAME pipeline ran (winner resolve, pre-flight, every verb
     /// applied in memory, the reference-resolution check) and stopped AT the point of no return, so this reports what
@@ -600,7 +607,8 @@ public static class WriteTools
         if (fullDump && o.ReadBack is { } rb) AppendFullReadback(sb, rb, maxChars, dryRun: true);
         if (o.Note is { } note) sb.Append("note: ").Append(note).Append('\n');
         sb.Append("every op passed resolve + pre-flight; to apply for real, repeat the call without dry_run. ")
-          .Append("(A real write can still fail at serialize/commit — disk faults and data Mutagen refuses to serialize surface only there.)");
+          .Append("(A real write can still fail at serialize/commit — disk faults and data Mutagen refuses to serialize surface only there.)")
+          .Append(Epoch(o));
         return sb.ToString();
     }
 


### PR DESCRIPTION
**W3 PR 1 of 3** — the S1 write wave's first PR: the LANE grammar and `housecarl_apply`. Builds on W2's landed read surface (`housecarl_records`, PR #309). Refs #237 (the field-bundle copy gap the §4.5 zip closes as capability — deliberately **not** auto-closed; per CHARTER_PHASE4 §6 the milestone's issues close at 2.0.0's shipped surface, not on a construction proof).

## Ships

**`housecarl_apply` — the 2.0 S1 field-write surface** (SPEC §2.2 ACT · §4.5 · §5.1/§5.2 · §6.1). Absorbs `set_field` + `bulk_apply` over the unchanged write cleave.

- **Vocabulary (§5.1/§5.3):** `verb`→`op` · `operations`→`ops` · `patch_name`→`patch` · `full_readback`→`readback` · `from_plugin` splits into the §4.5 pair `from` (the source **record**) + `from_source` (the pole it is read at). `ApplyOp` is its own wire record so the 1.x tools' published schemas stay untouched.
- **LANE-as-name (§5.2):** the `target=` + `in_place=true` pair collapses into **`in_place="X.esp"`** — the string names the file being overwritten. The three destinations (`patch` / `into` / `in_place`) are mutually exclusive and **a dropped one is refused BY NAME** — 1.x silently ignored `patch_name=` under `into=`, the accepted-and-dropped class the W2 review closed on the read side. `acknowledge` without a lane likewise. W0's `LaneCorrections` machinery goes live here (it was written for exactly this and has been dormant since).
- **The §4.5 zip:** `bundle=` (field paths, uniform across pairs) × `assignments=` (`[{target, from, from_source?}]`) — a cross-**record** field-bundle copy. A zip, never a product: each target reads its own paired source. Identity and everything outside the bundle are untouched *by construction*; `from_source` defaults to the source record's winner (resolved against the call's one captured build); pairs pass the same-runtime-record-type gate with every failure reported at once. Composes with `ops=` in one call. **Which paths form a frame stays skill-carried data** (CLAUDE.md §3, second cornerstone) — this is the generic primitive under #237/#238, not a "copy the balance frame" verb.
- **One list spelling (§5.1 `@file`):** `ops=` / `assignments=` / `bundle=` each take the inline array **or** `"@<absolute path>"`, retiring `from_file=` and the inline-vs-file mutual exclusion it needed.
- **TRANSPORT:** `format=json` (`JsonWire.RenderPatchOutcome` — the D2 twin; a refusal is a document too, the consent prompt is its own flag), `readback=`, `max_chars=`, and `epoch=` on **every** write response.

**Engine seams** (`WritePatchBuilder` / `LoadOrderService`): `PatchEdit.FromTarget`/`CopySource` + the §4.5 type gate · `ResolveCopyPole` (the winner default) · **CopyFrom on the in-place lane** · `PatchOutcome.Epoch` stamped at one point via thin `Apply`/`ApplyInPlace` wrappers over `*Core`.

**Alias lane:** no new §5.3 rows were needed — every write-side row W0 baked was dormant waiting for this tool. Adding `apply` activates **eleven**, all where §5.3 assigned them. CENSUS **119 → 130**, re-eyeballed. `set_field`/`bulk_apply` join the retired-name redirect table (each naming its successor *call shape*, not just the tool).

**Published schema** (`ToolSchemas`, added after Aaron closed decision #1): `ops=` and `assignments=` publish `anyOf[<generated element array>, string]` instead of the bare `{}` their `JsonElement` declaration would give — one `PostConfigure` over `McpServerOptions.ToolCollection`, with same-document `$ref`s rebased so the nested generated sub-schemas resolve. Details in decision #1 below.

**Guards:** new `apply-guard`, **61 checks** after four review folds (37 at open), 5 arms, driving the real tool path on a synthetic order; `binding-shim-guard` gains the **SCHEMA arm**. **ci-all 114 → 115, ALL PASS.**

## Three defects found and fixed

1. **`CopyFrom` never worked on the in-place lane.** `ApplyInPlace` resolved no source body and fell through to `ApplyVerb`, which has no CopyFrom branch — so a legal call died as *"pre-flight ACCEPTED it but the apply threw"*: a missing capability reported as an internal fault (Q3). Pre-existing; `bulk_apply` benefits too.
2. **`JsonWire.RenderPatchOutcome`'s refusal path returned an EMPTY string** — the early return sits inside the writer's `using` block, so the buffered document never flushed. The exact silent-degrade class PR #306 fixed on the json sweep refusals. Caught by the guard on its first run; both arms now pinned.
3. **The published `@file` union carried dangling `$ref`s** until `RebaseRefs` — found by inspecting the real `tools/list` output during the decision-1 spike, which is exactly why it was spiked rather than just built. Now guarded generically for all 47 tools.

## Decisions — **1 and 2 are CLOSED by Aaron (2026-08-04)**; 3–8 are for the reviewer

1. **~~`ops=`/`assignments=` are `JsonElement?`, not published typed arrays~~ — RESOLVED; shipped in `ceaa1f4`.** A spike now publishes a real schema for both: **`anyOf[<the GENERATED element-array schema>, string]`**. The array arm comes from `AIJsonUtilities.CreateJsonSchema` over the real C# type, so adding a member to `ApplyOp` updates the published schema automatically — not a hand-maintained copy; only the union wrapper and the string arm are written, and each element member's `[Description]` (previously unpublished) now reaches the client.
   *Route:* `WithToolsFromAssembly` has no `SchemaCreateOptions` overload, so the per-node `TransformSchemaNode` hook can't reach an assembly-scanned tool — but `Tool.InputSchema` is settable and `McpServerOptions.ToolCollection` is the one place the final tools exist however they were registered, so it's a single `PostConfigure` inside the shared `AddMcp` (no per-transport call site to drift).
   *Binding is unchanged* — the parameters stay `JsonElement?` and `ApplyTools`' strict reader is untouched, so the spike needed no guard edits at all (`apply-guard` was 37/37 at the time; it is 61/61 now after four review folds).
   **The defect the spike existed to catch:** this generator terminates a *recursive* type with a **positional** back-reference relative to its own document root — our `compose` → `sets[].compose` chain emits `"$ref": "#/items/properties/compose/properties/sets"`. Nesting that document under `properties/ops/anyOf/0` left every such pointer **dangling** — a broken schema, strictly worse than the `{}` it replaced. `RebaseRefs` rewrites them (`#/$defs/…` excepted — those are hoisted to the root, which is where they already point).
   *Guard:* `binding-shim-guard` gains a **SCHEMA arm** beside CENSUS — the union shape, the generated members, and generically over all 47 tools: **every same-document `$ref` resolves**. Measured cost, accepted: `apply`'s `inputSchema` 3.7k → 10.2k chars. The same treatment is chartered for `create`'s `records=` in **W3 PR 2**.
2. **~~§4.5's per-path verbs on `bundle`~~ — CLOSED and deliberate: not built, not filed as a gap, not chartered. Please don't spend a finding on it.** Copied list fields **replace** rather than merge. The reason is *closure*, not scope: read + `Add` + `ReplaceAll` already reaches the identical end state, and CLAUDE.md §3's second cornerstone tests the **closure of the primitives**, not the presence of a verb — so merge-on-copy would be an ergonomic shortcut over an existing closure, not a missing primitive. It is also the safer surface to leave unbuilt: `bundle` can name any list field, and while `Keywords` is a **set** (a duplicate is meaningless), `LeveledItem.Entries` is a **bag** where listing an entry twice is *how you weight it* — a single "merge" verb taking duplicates-are-a-no-op as its rule would silently mis-patch leveled lists. Set-vs-bag is domain knowledge, which belongs in skills as data, not in a tool verb. The one real gap was **guidance**, recorded for the W6 write-side skill rewrite: *if you are merging, you are on the wrong verb* — `Add`/`Remove` need no read of the target and cannot destroy an unnamed entry, whereas a computed-union `ReplaceAll` must read every target and silently drops anything absent from the union.
3. **`from_source`'s winner default is asymmetric by design:** it applies only when a source *record* is named. A same-record `CopyFrom` still requires the pole, because "copy the winner onto the winner" is a no-op.
4. **The epoch line lands on the 1.x write renders too** (`WriteTools.Render` is shared). Judged correct — §2.1.1 is surface-wide and both tools resolve winners from the same build. No existing probe wording moved.
5. **`apply` gains no scan-driven SELECT** (`where=`/`types=`). §6.1's `apply` row is `ops` + the zip; scan→ops is the composition. Not silently added.
6. **LANE exclusivity is stricter than 1.x.** New tool only; 1.x behaviour untouched.
7. **Parameter-level refusals return plain strings even under `format="json"`** (a bad `format=`, a LANE conflict); only *outcome* refusals are documents. This is parity with `records`, which does the same — flagging it in case the reviewer wants it unified.
8. **The description still cross-references 1.x `create_record`/`remove_record`/`forward_record`** — they are what exists today. W3 PR 2 updates those pointers as it ships their successors.

## §6.1 description-harvest ledger

Diffed the merged description against **both** sources; everything present in exactly one is accounted for.

**Carried from `set_field` only:** the `[Flags]` Add/Remove one-bit semantics (and *why* — a `Set` silently drops unmentioned bits) · `Set '0'` to clear all bits · omit `value` only for a Remove that whole-clears a **nullable** field · mid-path brackets vs op+key at the leaf · "read first" (retargeted to `housecarl_records`).

**Carried from `bulk_apply` only:** the `compose`/`composes` worked examples verbatim in substance (leveled-list entry · the polymorphic VMAD `ScriptObjectProperty` arm · condition blocks · `composes=[]` + ReplaceAll clears) · `entries=` for dict Merge/ReplaceAll · cross-master merge is derived, not declared · the **pinned `into=` precedence rule** and the forward-then-edit stale-winner recipe · the manifest's recovery property (re-run the same file; overrides are idempotent) · dry-run's "catch it before the first write of a big batch, not after the last".

**Deliberately dropped:** set_field's "use `bulk_apply` for compose / many edits" and bulk_apply's "the batch form of `set_field`" — both are cross-references between two tools that are now one. set_field's "returns the patch path, its masters, and the value read back" is folded into the TRANSPORT paragraph rather than restated.

**New teaching (no source):** the zip's zip-not-product property · the same-type gate · `in_place` naming the file as consent-adjacent explicitness · the `@file` spelling · epoch.

## W3 PR 2 work list

`create` · `remove` · `forward` · `copy` (with `walk=` closure) · `write_seq`, then **PR 3: `check`** (the findings family incl. the dialogue classes 1–7 fold and its chartered **zero-capability-loss verification**, plus the W1 sweep-lane artifact fold). The `from_plugin`-vs-`from`/`from_source` consumer-inventory obligation is **resolved here** (§4.5's pair, as specified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



